### PR TITLE
feat: playwright.downloadBrowser

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,7 @@
   * [playwright.createBrowserFetcher([options])](#playwrightcreatebrowserfetcheroptions)
   * [playwright.defaultArgs([options])](#playwrightdefaultargsoptions)
   * [playwright.devices](#playwrightdevices)
+  * [playwright.downloadBrowser([options])](#playwrightdownloadbrowseroptions)
   * [playwright.errors](#playwrighterrors)
   * [playwright.executablePath()](#playwrightexecutablepath)
   * [playwright.launch([options])](#playwrightlaunchoptions)
@@ -430,6 +431,22 @@ const iPhone = playwright.devices['iPhone 6'];
 ```
 
 > **NOTE** The old way (Playwright versions <= v1.14.0) devices can be obtained with `require('playwright/DeviceDescriptors')`.
+
+#### playwright.downloadBrowser([options])
+- `options` <[Object]>
+  - `onProgress` <[function]([number], [number])> A function that will be called with two arguments:
+    - `downloadedBytes` <[number]> how many bytes have been downloaded
+    - `totalBytes` <[number]> how large is the total download.
+- returns: <[Promise]<[Object]>> Resolves with revision information when the revision is downloaded and extracted
+  - `revision` <[string]> the revision the info was created from
+  - `folderPath` <[string]> path to the extracted revision folder
+  - `executablePath` <[string]> path to the revision executable
+  - `url` <[string]> URL this revision can be downloaded from
+  - `local` <[boolean]> whether the revision is locally available on disk
+
+Downloads the default browser that Playwright controls. The browser is usually around 100mb.
+
+> **NOTE** Depending on your terminal, the progress bar might not appear.
 
 #### playwright.errors
 - returns: <[Object]>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "extract-zip": "^1.6.6",
     "https-proxy-agent": "^3.0.0",
     "mime": "^2.0.3",
-    "progress": "^2.0.1",
     "proxy-from-env": "^1.0.0",
     "rimraf": "^2.6.1",
     "ws": "^6.1.0"
@@ -61,6 +60,7 @@
     "node-stream-zip": "^1.8.2",
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
+    "progress": "^2.0.1",
     "text-diff": "^1.0.1",
     "ts-loader": "^6.1.2",
     "typescript": "3.6.3",

--- a/src/chromium/LifecycleWatcher.ts
+++ b/src/chromium/LifecycleWatcher.ts
@@ -39,7 +39,7 @@ export class LifecycleWatcher {
   private _newDocumentNavigationCompleteCallback: () => void;
   private _timeoutPromise: Promise<Error>;
   private _terminationPromise: Promise<Error | null>;
-  private _terminationCallback: () => void;
+  private _terminationCallback: (err: Error | null) => void;
   private _maximumTimer: NodeJS.Timer;
   private _hasSameDocumentNavigation: boolean;
 

--- a/src/chromium/Playwright.ts
+++ b/src/chromium/Playwright.ts
@@ -20,14 +20,17 @@ import { ConnectionTransport } from '../ConnectionTransport';
 import { DeviceDescriptors } from '../DeviceDescriptors';
 import * as Errors from '../Errors';
 import { Launcher, LauncherBrowserOptions, LauncherChromeArgOptions, LauncherLaunchOptions } from './Launcher';
+import {download, RevisionInfo} from '../download';
 
 export class Playwright {
   private _projectRoot: string;
   private _launcher: Launcher;
+  downloadBrowser: (options?: { onProgress?: (downloadedBytes: number, totalBytes: number) => void; }) => Promise<RevisionInfo>;
 
   constructor(projectRoot: string, preferredRevision: string) {
     this._projectRoot = projectRoot;
     this._launcher = new Launcher(projectRoot, preferredRevision);
+    this.downloadBrowser = download.bind(null, this.createBrowserFetcher(), preferredRevision, 'Chromium');
   }
 
   launch(options: (LauncherLaunchOptions & LauncherChromeArgOptions & LauncherBrowserOptions) | undefined): Promise<Browser> {
@@ -60,7 +63,7 @@ export class Playwright {
     return this._launcher.defaultArgs(options);
   }
 
-  createBrowserFetcher(options: BrowserFetcherOptions | undefined): BrowserFetcher {
+  createBrowserFetcher(options?: BrowserFetcherOptions | undefined): BrowserFetcher {
     return new BrowserFetcher(this._projectRoot, options);
   }
 }

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+export async function download(
+  browserFetcher:
+    import('./chromium/BrowserFetcher').BrowserFetcher |
+    import('./firefox/BrowserFetcher').BrowserFetcher |
+    import('./webkit/BrowserFetcher').BrowserFetcher,
+  revision: string,
+  browserName: string,
+  {onProgress}: {onProgress?: (downloadedBytes: number, totalBytes: number) => void} = {}) : Promise<RevisionInfo> {
+  return await browserFetcher.download(revision, onProgress);
+}
+
+export type RevisionInfo = {
+  folderPath: string,
+  executablePath: string,
+  url: string,
+  local: boolean,
+  revision: string,
+};

--- a/src/firefox/Playwright.ts
+++ b/src/firefox/Playwright.ts
@@ -20,14 +20,17 @@ import { ConnectionTransport } from '../ConnectionTransport';
 import { DeviceDescriptors } from '../DeviceDescriptors';
 import * as Errors from '../Errors';
 import { Launcher } from './Launcher';
+import {download, RevisionInfo} from '../download';
 
 export class Playwright {
   private _projectRoot: string;
   private _launcher: Launcher;
+  downloadBrowser: (options?: { onProgress?: (downloadedBytes: number, totalBytes: number) => void; }) => Promise<RevisionInfo>;
 
   constructor(projectRoot: string, preferredRevision: string) {
     this._projectRoot = projectRoot;
     this._launcher = new Launcher(projectRoot, preferredRevision);
+    this.downloadBrowser = download.bind(null, this.createBrowserFetcher(), preferredRevision, 'Chromium');
   }
 
   launch(options: any): Promise<Browser> {
@@ -60,7 +63,7 @@ export class Playwright {
     return this._launcher.defaultArgs(options);
   }
 
-  createBrowserFetcher(options: any | undefined): BrowserFetcher {
+  createBrowserFetcher(options?: any | undefined): BrowserFetcher {
     return new BrowserFetcher(this._projectRoot, { browser: 'firefox', ...options });
   }
 }

--- a/src/webkit/Browser.ts
+++ b/src/webkit/Browser.ts
@@ -20,7 +20,6 @@ import { EventEmitter } from 'events';
 import { assert, helper, RegisteredListener } from '../helper';
 import { filterCookies, NetworkCookie, rewriteCookies, SetNetworkCookieParam } from '../network';
 import { Connection } from './Connection';
-import { Events } from './events';
 import { Page, Viewport } from './Page';
 import { Target } from './Target';
 import { TaskQueue } from './TaskQueue';

--- a/src/webkit/NetworkManager.ts
+++ b/src/webkit/NetworkManager.ts
@@ -90,7 +90,7 @@ export class NetworkManager extends EventEmitter {
     });
   }
 
-  _onRequestWillBeSent(event: Protocol.Network.requestWillBeSentPayload, interceptionId: string | null) {
+  _onRequestWillBeSent(event: Protocol.Network.requestWillBeSentPayload) {
     let redirectChain: network.Request[] = [];
     if (event.redirectResponse) {
       const request = this._requestIdToRequest.get(event.requestId);
@@ -101,7 +101,7 @@ export class NetworkManager extends EventEmitter {
       }
     }
     const frame = event.frameId && this._frameManager ? this._frameManager.frame(event.frameId) : null;
-    const request = new InterceptableRequest(frame, interceptionId, event, redirectChain);
+    const request = new InterceptableRequest(frame, undefined, event, redirectChain);
     this._requestIdToRequest.set(event.requestId, request);
     this.emit(NetworkManagerEvents.Request, request.request);
   }

--- a/src/webkit/Playwright.ts
+++ b/src/webkit/Playwright.ts
@@ -19,14 +19,17 @@ import { BrowserFetcher, BrowserFetcherOptions } from './BrowserFetcher';
 import { DeviceDescriptors } from '../DeviceDescriptors';
 import * as Errors from '../Errors';
 import { Launcher, LauncherLaunchOptions } from './Launcher';
+import { download, RevisionInfo } from '../download';
 
 export class Playwright {
   private _projectRoot: string;
   private _launcher: Launcher;
+  downloadBrowser: (options?: { onProgress?: (downloadedBytes: number, totalBytes: number) => void; }) => Promise<RevisionInfo>;
 
   constructor(projectRoot: string, preferredRevision: string) {
     this._projectRoot = projectRoot;
     this._launcher = new Launcher(projectRoot, preferredRevision);
+    this.downloadBrowser = download.bind(null, this.createBrowserFetcher(), preferredRevision, 'WebKit');
   }
 
   launch(options: (LauncherLaunchOptions) | undefined): Promise<Browser> {
@@ -52,7 +55,7 @@ export class Playwright {
     return this._launcher.defaultArgs(options);
   }
 
-  createBrowserFetcher(options: BrowserFetcherOptions | undefined): BrowserFetcher {
+  createBrowserFetcher(options?: BrowserFetcherOptions | undefined): BrowserFetcher {
     return new BrowserFetcher(this._projectRoot, options);
   }
 }

--- a/src/webkit/Target.ts
+++ b/src/webkit/Target.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { helper, RegisteredListener } from '../helper';
+import { RegisteredListener } from '../helper';
 import { Browser, BrowserContext } from './Browser';
 import { Page } from './Page';
 import { Protocol } from './protocol';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "lib": ["esnext", "dom"],
     "sourceMap": true,
     "rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "strictBindCallApply": true
   },
   "compileOnSave": true,
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
```js
await playwright.downloadBrowser()
```
Easy one liner to download a browser, optionally showing the progress bar.

No test at the moment. Need to add some environment variables back for that, in order to mock the host

#48
