### PR TITLE
fix(build): only ever run webpack in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "doc": "node utils/doclint/cli.js",
     "coverage": "cross-env COVERAGE=true npm run unit",
     "tsc": "tsc -p .",
-    "build": "node utils/runWebpack.js --mode='production' && tsc -p .",
+    "build": "node utils/runWebpack.js --mode='development' && tsc -p .",
     "watch": "node utils/runWebpack.js --mode='development' --watch --silent | tsc -w -p .",
     "apply-next-version": "node utils/apply_next_version.js",
     "bundle": "npx browserify -r ./index.js:playwright -o utils/browser/playwright-web.js",


### PR DESCRIPTION
production mode doesn't work for some reason. We shouldn't be running two different versions of our code if we can help it anyway.