### PR TITLE
feat(selectors): support various kinds of selectors

### DIFF
--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -34,7 +34,7 @@ export class ExecutionContext {
   }
 
   _createHandle(remoteObject: any): JSHandle {
-    return (this._domWorld && this._domWorld._createHandle(remoteObject)) || new JSHandle(this, remoteObject);
+    return (this._domWorld && this._domWorld.createHandle(remoteObject)) || new JSHandle(this, remoteObject);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,8 +9,8 @@ type PageFunctionOn<On, Args extends any[], R = any> = string | ((on: On, ...arg
 
 export type Evaluate = <Args extends any[], R>(pageFunction: PageFunction<Args, R>, ...args: Boxed<Args>) => Promise<R>;
 export type EvaluateHandle = <Args extends any[]>(pageFunction: PageFunction<Args>, ...args: Boxed<Args>) => Promise<js.JSHandle>;
-export type $Eval = <Args extends any[], R>(selector: string, pageFunction: PageFunctionOn<Element, Args, R>, ...args: Boxed<Args>) => Promise<R>;
-export type $$Eval = <Args extends any[], R>(selector: string, pageFunction: PageFunctionOn<Element[], Args, R>, ...args: Boxed<Args>) => Promise<R>;
+export type $Eval<S = string> = <Args extends any[], R>(selector: S, pageFunction: PageFunctionOn<Element, Args, R>, ...args: Boxed<Args>) => Promise<R>;
+export type $$Eval<S = string> = <Args extends any[], R>(selector: S, pageFunction: PageFunctionOn<Element[], Args, R>, ...args: Boxed<Args>) => Promise<R>;
 export type EvaluateOn = <Args extends any[], R>(pageFunction: PageFunctionOn<any, Args, R>, ...args: Boxed<Args>) => Promise<R>;
 export type EvaluateHandleOn = <Args extends any[]>(pageFunction: PageFunctionOn<any, Args>, ...args: Boxed<Args>) => Promise<js.JSHandle>;
 

--- a/test/assets/deep-shadow.html
+++ b/test/assets/deep-shadow.html
@@ -1,0 +1,27 @@
+<script>
+window.addEventListener('DOMContentLoaded', () => {
+  const outer = document.createElement('section');
+  document.body.appendChild(outer);
+
+  const root1 = document.createElement('div');
+  outer.appendChild(root1);
+  const shadowRoot1 = root1.attachShadow({mode: 'open'});
+  const span1 = document.createElement('span');
+  span1.textContent = 'Hello from root1';
+  shadowRoot1.appendChild(span1);
+
+  const root2 = document.createElement('div');
+  shadowRoot1.appendChild(root2);
+  const shadowRoot2 = root2.attachShadow({mode: 'open'});
+  const span2 = document.createElement('span');
+  span2.textContent = 'Hello from root2';
+  shadowRoot2.appendChild(span2);
+
+  const root3 = document.createElement('div');
+  shadowRoot1.appendChild(root3);
+  const shadowRoot3 = root3.attachShadow({mode: 'open'});
+  const span3 = document.createElement('span');
+  span3.textContent = 'Hello from root3';
+  shadowRoot3.appendChild(span3);
+});
+</script>


### PR DESCRIPTION
This adds support for generic `engine=body [>> engine=body]*` selector syntax and auto-detects simple css or xpath.