### PR TITLE
fix: handle failures of adoptElementHandle

### DIFF
--- a/src/chromium/JSHandle.ts
+++ b/src/chromium/JSHandle.ts
@@ -202,11 +202,13 @@ export class DOMWorldDelegate implements dom.DOMWorldDelegate {
   }
 
   async adoptBackendNodeId(backendNodeId: Protocol.DOM.BackendNodeId, to: dom.DOMWorld): Promise<dom.ElementHandle> {
-    const {object} = await this._client.send('DOM.resolveNode', {
+    const result = await this._client.send('DOM.resolveNode', {
       backendNodeId,
       executionContextId: (to.context._delegate as ExecutionContextDelegate)._contextId,
-    });
-    return to.context._createHandle(object).asElement()!;
+    }).catch(debugError);
+    if (!result)
+      throw new Error('Unable to adopt element handle from a different document');
+    return to.context._createHandle(result.object).asElement()!;
   }
 }
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -344,9 +344,8 @@ export function waitForFunctionTask(pageFunction: Function | string, options: ty
   }, await domWorld.injected(), predicateBody, polling, options.timeout, ...args);
 }
 
-export function waitForSelectorTask(selector: string | ScopedSelector, timeout: number): Task {
+export function waitForSelectorTask(selector: string | types.Selector, timeout: number): Task {
   return async (domWorld: DOMWorld) => {
-    // TODO: we should not be able to adopt selector scope from a different document - handle this case.
     const resolved = await domWorld.resolveSelector(selector);
     return domWorld.context.evaluateHandle((injected: Injected, selector: string, scope: SelectorRoot | undefined, visible: boolean | undefined, timeout: number) => {
       if (visible !== undefined)


### PR DESCRIPTION
There is no way to trigger this issue through the api just yet, but there will be
once we support handles as selectors.