### PR TITLE
feat: make JSHandle generic

### DIFF
--- a/src/chromium/ExecutionContext.ts
+++ b/src/chromium/ExecutionContext.ts
@@ -149,7 +149,7 @@ export class ExecutionContextDelegate implements js.ExecutionContextDelegate {
     await releaseObject(this._client, toRemoteObject(handle));
   }
 
-  async handleJSONValue(handle: js.JSHandle): Promise<any> {
+  async handleJSONValue<T>(handle: js.JSHandle<T>): Promise<T> {
     const remoteObject = toRemoteObject(handle);
     if (remoteObject.objectId) {
       const response = await this._client.send('Runtime.callFunctionOn', {

--- a/src/chromium/JSHandle.ts
+++ b/src/chromium/JSHandle.ts
@@ -194,11 +194,11 @@ export class DOMWorldDelegate implements dom.DOMWorldDelegate {
     await handle.evaluate(input.setFileInputFunction, files);
   }
 
-  async adoptElementHandle(handle: dom.ElementHandle, to: dom.DOMWorld): Promise<dom.ElementHandle> {
+  async adoptElementHandle<T extends Node>(handle: dom.ElementHandle<T>, to: dom.DOMWorld): Promise<dom.ElementHandle<T>> {
     const nodeInfo = await this._client.send('DOM.describeNode', {
       objectId: toRemoteObject(handle).objectId,
     });
-    return this.adoptBackendNodeId(nodeInfo.node.backendNodeId, to);
+    return this.adoptBackendNodeId(nodeInfo.node.backendNodeId, to) as Promise<dom.ElementHandle<T>>;
   }
 
   async adoptBackendNodeId(backendNodeId: Protocol.DOM.BackendNodeId, to: dom.DOMWorld): Promise<dom.ElementHandle> {

--- a/src/chromium/Page.ts
+++ b/src/chromium/Page.ts
@@ -222,7 +222,7 @@ export class Page extends EventEmitter {
     this._timeoutSettings.setDefaultTimeout(timeout);
   }
 
-  async $(selector: string | types.Selector): Promise<dom.ElementHandle | null> {
+  async $(selector: string | types.Selector): Promise<dom.ElementHandle<Element> | null> {
     return this.mainFrame().$(selector);
   }
 
@@ -239,11 +239,11 @@ export class Page extends EventEmitter {
     return this.mainFrame().$$eval(selector, pageFunction, ...args as any);
   }
 
-  async $$(selector: string | types.Selector): Promise<dom.ElementHandle[]> {
+  async $$(selector: string | types.Selector): Promise<dom.ElementHandle<Element>[]> {
     return this.mainFrame().$$(selector);
   }
 
-  async $x(expression: string): Promise<dom.ElementHandle[]> {
+  async $x(expression: string): Promise<dom.ElementHandle<Element>[]> {
     return this.mainFrame().$x(expression);
   }
 

--- a/src/chromium/Playwright.ts
+++ b/src/chromium/Playwright.ts
@@ -30,7 +30,7 @@ export class Playwright {
     this._launcher = new Launcher(projectRoot, preferredRevision);
   }
 
-  launch(options: (LauncherLaunchOptions & LauncherChromeArgOptions & LauncherBrowserOptions) | undefined): Promise<Browser> {
+  launch(options?: (LauncherLaunchOptions & LauncherChromeArgOptions & LauncherBrowserOptions) | undefined): Promise<Browser> {
     return this._launcher.launch(options);
   }
 

--- a/src/firefox/ExecutionContext.ts
+++ b/src/firefox/ExecutionContext.ts
@@ -134,7 +134,7 @@ export class ExecutionContextDelegate implements js.ExecutionContextDelegate {
     });
   }
 
-  async handleJSONValue(handle: js.JSHandle): Promise<any> {
+  async handleJSONValue<T>(handle: js.JSHandle<T>): Promise<T> {
     const payload = handle._remoteObject;
     if (!payload.objectId)
       return deserializeValue(payload);

--- a/src/firefox/JSHandle.ts
+++ b/src/firefox/JSHandle.ts
@@ -22,6 +22,7 @@ import * as types from '../types';
 import * as frames from '../frames';
 import { JugglerSession } from './Connection';
 import { FrameManager } from './FrameManager';
+import { Protocol } from './protocol';
 
 export class DOMWorldDelegate implements dom.DOMWorldDelegate {
   readonly keyboard: input.Keyboard;
@@ -138,13 +139,13 @@ export class DOMWorldDelegate implements dom.DOMWorldDelegate {
     await handle.evaluate(input.setFileInputFunction, files);
   }
 
-  async adoptElementHandle(handle: dom.ElementHandle, to: dom.DOMWorld): Promise<dom.ElementHandle> {
+  async adoptElementHandle<T extends Node>(handle: dom.ElementHandle<T>, to: dom.DOMWorld): Promise<dom.ElementHandle<T>> {
     assert(false, 'Multiple isolated worlds are not implemented');
     return handle;
   }
 }
 
-function toRemoteObject(handle: dom.ElementHandle): any {
+function toRemoteObject(handle: dom.ElementHandle): Protocol.RemoteObject {
   return handle._remoteObject;
 }
 

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -122,12 +122,12 @@ export class Frame {
     return context.evaluate(pageFunction, ...args as any);
   }
 
-  async $(selector: string | types.Selector): Promise<dom.ElementHandle | null> {
+  async $(selector: string | types.Selector): Promise<dom.ElementHandle<Element> | null> {
     const domWorld = await this._mainDOMWorld();
     return domWorld.$(types.clearSelector(selector));
   }
 
-  async $x(expression: string): Promise<dom.ElementHandle[]> {
+  async $x(expression: string): Promise<dom.ElementHandle<Element>[]> {
     const domWorld = await this._mainDOMWorld();
     return domWorld.$$('xpath=' + expression);
   }
@@ -142,7 +142,7 @@ export class Frame {
     return domWorld.$$eval(selector, pageFunction, ...args as any);
   }
 
-  async $$(selector: string | types.Selector): Promise<dom.ElementHandle[]> {
+  async $$(selector: string | types.Selector): Promise<dom.ElementHandle<Element>[]> {
     const domWorld = await this._mainDOMWorld();
     return domWorld.$$(types.clearSelector(selector));
   }

--- a/src/injected/injected.ts
+++ b/src/injected/injected.ts
@@ -31,9 +31,11 @@ class Injected {
     return element as Element;
   }
 
-  querySelectorAll(selector: string, root: SelectorRoot): Element[] {
+  querySelectorAll(selector: string, root: Node): Element[] {
     const parsed = this._parseSelector(selector);
-    let set = new Set<SelectorRoot>([ root ]);
+    if (!root["querySelectorAll"])
+      throw new Error('Node is not queryable.');
+    let set = new Set<SelectorRoot>([ root as SelectorRoot ]);
     for (const { engine, selector } of parsed) {
       const newSet = new Set<Element>();
       for (const prev of set) {

--- a/src/injected/injected.ts
+++ b/src/injected/injected.ts
@@ -17,9 +17,11 @@ class Injected {
       this.engines.set(engine.name, engine);
   }
 
-  querySelector(selector: string, root: SelectorRoot): Element | undefined {
+  querySelector(selector: string, root: Node): Element | undefined {
     const parsed = this._parseSelector(selector);
-    let element = root;
+    if (!root["querySelector"])
+      throw new Error('Node is not queryable.');
+    let element = root as SelectorRoot;
     for (const { engine, selector } of parsed) {
       const next = engine.query((element as Element).shadowRoot || element, selector);
       if (!next)

--- a/src/input.ts
+++ b/src/input.ts
@@ -287,9 +287,10 @@ export class Mouse {
   }
 }
 
-export const selectFunction = (element: HTMLSelectElement, ...optionsToSelect: (Node | SelectOption)[]) => {
-  if (element.nodeName.toLowerCase() !== 'select')
+export const selectFunction = (node: Node, ...optionsToSelect: (Node | SelectOption)[]) => {
+  if (node.nodeName.toLowerCase() !== 'select')
     throw new Error('Element is not a <select> element.');
+  const element = node as HTMLSelectElement;
 
   const options = Array.from(element.options);
   element.value = undefined;
@@ -315,9 +316,10 @@ export const selectFunction = (element: HTMLSelectElement, ...optionsToSelect: (
   return options.filter(option => option.selected).map(option => option.value);
 };
 
-export const fillFunction = (element: HTMLElement) => {
-  if (element.nodeType !== Node.ELEMENT_NODE)
+export const fillFunction = (node: Node) => {
+  if (node.nodeType !== Node.ELEMENT_NODE)
     return 'Node is not of type HTMLElement';
+  const element = node as HTMLElement;
   if (element.nodeName.toLowerCase() === 'input') {
     const input = element as HTMLInputElement;
     const type = input.getAttribute('type') || '';

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -38,7 +38,7 @@ export class ExecutionContext {
   }
 }
 
-export class JSHandle {
+export class JSHandle<T = any> {
   readonly _context: ExecutionContext;
   readonly _remoteObject: any;
   _disposed = false;
@@ -52,11 +52,11 @@ export class JSHandle {
     return this._context;
   }
 
-  evaluate: types.EvaluateOn = (pageFunction, ...args) => {
+  evaluate: types.EvaluateOn<T> = (pageFunction, ...args) => {
     return this._context.evaluate(pageFunction, this, ...args);
   }
 
-  evaluateHandle: types.EvaluateHandleOn = (pageFunction, ...args) => {
+  evaluateHandle: types.EvaluateHandleOn<T> = (pageFunction, ...args) => {
     return this._context.evaluateHandle(pageFunction, this, ...args);
   }
 
@@ -76,7 +76,7 @@ export class JSHandle {
     return this._context._delegate.getProperties(this);
   }
 
-  jsonValue(): Promise<any> {
+  jsonValue(): Promise<T> {
     return this._context._delegate.handleJSONValue(this);
   }
 

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -10,7 +10,7 @@ export interface ExecutionContextDelegate {
   getProperties(handle: JSHandle): Promise<Map<string, JSHandle>>;
   releaseHandle(handle: JSHandle): Promise<void>;
   handleToString(handle: JSHandle, includeType: boolean): string;
-  handleJSONValue(handle: JSHandle): Promise<any>;
+  handleJSONValue<T>(handle: JSHandle<T>): Promise<T>;
 }
 
 export class ExecutionContext {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,17 +3,21 @@
 
 import * as js from './javascript';
 import { helper } from './helper';
+import * as dom from './dom';
 
-type Boxed<Args extends any[]> = { [Index in keyof Args]: Args[Index] | js.JSHandle };
+type Boxed<Args extends any[]> = { [Index in keyof Args]: Args[Index] | js.JSHandle<Args[Index]> };
 type PageFunction<Args extends any[], R = any> = string | ((...args: Args) => R | Promise<R>);
 type PageFunctionOn<On, Args extends any[], R = any> = string | ((on: On, ...args: Args) => R | Promise<R>);
 
+type Handle<T> = T extends Node ? dom.ElementHandle<T> : js.JSHandle<T>;
+type ElementForSelector<T> = T extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[T] : Element; 
+
 export type Evaluate = <Args extends any[], R>(pageFunction: PageFunction<Args, R>, ...args: Boxed<Args>) => Promise<R>;
-export type EvaluateHandle = <Args extends any[]>(pageFunction: PageFunction<Args>, ...args: Boxed<Args>) => Promise<js.JSHandle>;
-export type $Eval<S = string | Selector> = <Args extends any[], R>(selector: S, pageFunction: PageFunctionOn<Element, Args, R>, ...args: Boxed<Args>) => Promise<R>;
-export type $$Eval<S = string | Selector> = <Args extends any[], R>(selector: S, pageFunction: PageFunctionOn<Element[], Args, R>, ...args: Boxed<Args>) => Promise<R>;
-export type EvaluateOn = <Args extends any[], R>(pageFunction: PageFunctionOn<any, Args, R>, ...args: Boxed<Args>) => Promise<R>;
-export type EvaluateHandleOn = <Args extends any[]>(pageFunction: PageFunctionOn<any, Args>, ...args: Boxed<Args>) => Promise<js.JSHandle>;
+export type EvaluateHandle = <Args extends any[], R>(pageFunction: PageFunction<Args,  R>, ...args: Boxed<Args>) => Promise<Handle<R>>;
+export type $Eval<O = string | Selector> = <Args extends any[], R, S extends O>(selector: S, pageFunction: PageFunctionOn<ElementForSelector<S>, Args, R>, ...args: Boxed<Args>) => Promise<R>;
+export type $$Eval<O = string | Selector> = <Args extends any[], R, S extends O>(selector: S, pageFunction: PageFunctionOn<ElementForSelector<S>[], Args, R>, ...args: Boxed<Args>) => Promise<R>;
+export type EvaluateOn<T> = <Args extends any[], R>(pageFunction: PageFunctionOn<T, Args, R>, ...args: Boxed<Args>) => Promise<R>;
+export type EvaluateHandleOn<T> = <Args extends any[], R>(pageFunction: PageFunctionOn<T, Args, R>, ...args: Boxed<Args>) => Promise<Handle<R>>;
 
 export type Rect = { x: number, y: number, width: number, height: number };
 export type Point = { x: number, y: number };

--- a/src/webkit/ExecutionContext.ts
+++ b/src/webkit/ExecutionContext.ts
@@ -289,7 +289,7 @@ export class ExecutionContextDelegate implements js.ExecutionContextDelegate {
     await releaseObject(this._session, toRemoteObject(handle));
   }
 
-  async handleJSONValue(handle: js.JSHandle): Promise<any> {
+  async handleJSONValue<T>(handle: js.JSHandle<T>): Promise<T> {
     const remoteObject = toRemoteObject(handle);
     if (remoteObject.objectId) {
       const response = await this._session.send('Runtime.callFunctionOn', {

--- a/src/webkit/JSHandle.ts
+++ b/src/webkit/JSHandle.ts
@@ -141,7 +141,7 @@ export class DOMWorldDelegate implements dom.DOMWorldDelegate {
     await this._client.send('DOM.setInputFiles', { objectId, files });
   }
 
-  async adoptElementHandle(handle: dom.ElementHandle, to: dom.DOMWorld): Promise<dom.ElementHandle> {
+  async adoptElementHandle<T extends Node>(handle: dom.ElementHandle<T>, to: dom.DOMWorld): Promise<dom.ElementHandle<T>> {
     assert(false, 'Multiple isolated worlds are not implemented');
     return handle;
   }


### PR DESCRIPTION
This makes it so that JSHandles and ElementHandles are aware of what types they point to. As a fun bonus, `$eval('input')` knows its going to get an HTMLInputElement.

Most of this patch is casting things where previously we just assumed ElementHandles held the right kind of node. This gets us closer to being able to turn on `noImplicityAny` as well.

#6