### PR TITLE
fix(install): generate new protocol.d.ts when browsers are downloaded

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -446,8 +446,6 @@ const iPhone = playwright.devices['iPhone 6'];
 
 Downloads the default browser that Playwright controls. The browser is usually around 100mb.
 
-> **NOTE** Depending on your terminal, the progress bar might not appear.
-
 #### playwright.errors
 - returns: <[Object]>
   - `TimeoutError` <[function]> A class of [TimeoutError].

--- a/src/download.ts
+++ b/src/download.ts
@@ -8,7 +8,9 @@ export async function download(
   revision: string,
   browserName: string,
   {onProgress}: {onProgress?: (downloadedBytes: number, totalBytes: number) => void} = {}) : Promise<RevisionInfo> {
-  return await browserFetcher.download(revision, onProgress);
+  const revisionInfo = browserFetcher.revisionInfo(revision);
+  await browserFetcher.download(revision, onProgress);
+  return revisionInfo;
 }
 
 export type RevisionInfo = {


### PR DESCRIPTION
`playwright.download` now returns the revision info from *before* the revision was downloaded. Otherwise `.local` was always true, which was unhelpful.