### PR TITLE
chore: encapsulate target business in Browser class

### DIFF
--- a/src/chromium/BrowserContext.ts
+++ b/src/chromium/BrowserContext.ts
@@ -21,7 +21,6 @@ import { Browser } from './Browser';
 import { CDPSession } from './Connection';
 import { Permissions } from './features/permissions';
 import { Page } from './Page';
-import { Target } from './Target';
 
 export class BrowserContext {
   readonly permissions: Permissions;
@@ -35,17 +34,8 @@ export class BrowserContext {
     this.permissions = new Permissions(client, contextId);
   }
 
-  _targets(): Target[] {
-    return this._browser._allTargets().filter(target => target.browserContext() === this);
-  }
-
-  async pages(): Promise<Page[]> {
-    const pages = await Promise.all(
-        this._targets()
-            .filter(target => target.type() === 'page')
-            .map(target => target.page())
-    );
-    return pages.filter(page => !!page);
+  pages(): Promise<Page[]> {
+    return this._browser._pages(this);
   }
 
   isIncognito(): boolean {

--- a/src/chromium/Screenshotter.ts
+++ b/src/chromium/Screenshotter.ts
@@ -85,7 +85,7 @@ export class Screenshotter {
   }
 
   private async _screenshot(page: Page, format: 'png' | 'jpeg', options: ScreenshotOptions): Promise<Buffer | string> {
-    await page._client.send('Target.activateTarget', {targetId: page._target._targetId});
+    await page.browser()._activatePage(page);
     let clip = options.clip ? processClip(options.clip) : undefined;
     const viewport = page.viewport();
 

--- a/src/chromium/features/chromium.ts
+++ b/src/chromium/features/chromium.ts
@@ -92,7 +92,7 @@ export class Chromium extends EventEmitter {
   }
 
   pageTarget(page: Page): Target {
-    return page._target;
+    return Target.fromPage(page);
   }
 
   waitForTarget(predicate: (arg0: Target) => boolean, options: { timeout?: number; } | undefined = {}): Promise<Target> {

--- a/src/webkit/FrameManager.ts
+++ b/src/webkit/FrameManager.ts
@@ -91,7 +91,7 @@ export class FrameManager extends EventEmitter implements frames.FrameDelegate {
     ];
   }
 
-  async _swapTargetOnNavigation(newSession) {
+  async _swapSessionOnNavigation(newSession) {
     helper.removeEventListeners(this._sessionListeners);
     this.disconnectFromTarget();
     this._session = newSession;


### PR DESCRIPTION
Page and BrowserContext are now closer to be reused between browsers.