### PR TITLE
test: disable Firefox Linux and WebKit Linux failing tests

### DIFF
--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -283,14 +283,14 @@ module.exports.addTests = function({testRunner, expect, playwright, FFOX, CHROME
       expect(await frame.evaluate(() => window.result)).toBe('Clicked');
     });
 
-    it('should click the button with relative point', async({page, server}) => {
+    it.skip(WEBKIT)('should click the button with relative point', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/button.html');
       await page.click('button', { relativePoint: { x: 20, y: 10 } });
       expect(await page.evaluate(() => result)).toBe('Clicked');
       expect(await page.evaluate(() => offsetX)).toBe(20);
       expect(await page.evaluate(() => offsetY)).toBe(10);
     });
-    it('should click the button with px border with relative point', async({page, server}) => {
+    it.skip(WEBKIT)('should click the button with px border with relative point', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/button.html');
       await page.$eval('button', button => button.style.borderWidth = '2px');
       await page.click('button', { relativePoint: { x: 20, y: 10 } });
@@ -298,7 +298,7 @@ module.exports.addTests = function({testRunner, expect, playwright, FFOX, CHROME
       expect(await page.evaluate(() => offsetX)).toBe(20);
       expect(await page.evaluate(() => offsetY)).toBe(10);
     });
-    it('should click the button with em border with relative point', async({page, server}) => {
+    it.skip(WEBKIT)('should click the button with em border with relative point', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/button.html');
       await page.$eval('button', button => button.style.borderWidth = '2em');
       await page.click('button', { relativePoint: { x: 20, y: 10 } });
@@ -306,7 +306,7 @@ module.exports.addTests = function({testRunner, expect, playwright, FFOX, CHROME
       expect(await page.evaluate(() => offsetX)).toBe(20);
       expect(await page.evaluate(() => offsetY)).toBe(10);
     });
-    it('should click a very large button with relative point', async({page, server}) => {
+    it.skip(WEBKIT)('should click a very large button with relative point', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/button.html');
       await page.$eval('button', button => button.style.height = button.style.width = '2000px');
       await page.click('button', { relativePoint: { x: 1900, y: 1910 } });

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -29,7 +29,7 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
       const box = await elementHandle.boundingBox();
       expect(box).toEqual({ x: 100, y: 50, width: 50, height: 50 });
     });
-    it('should handle nested frames', async({page, server}) => {
+    it.skip(FFOX)('should handle nested frames', async({page, server}) => {
       await page.setViewport({width: 500, height: 500});
       await page.goto(server.PREFIX + '/frames/nested-frames.html');
       const nestedFrame = page.frames().find(frame => frame.name() === 'dos');

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -49,7 +49,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
       else
         expect(dumpioData).toContain('Juggler listening on ws://');
     });
-    it('should close the browser when the node process closes', async({ server }) => {
+    it.skip(FFOX)('should close the browser when the node process closes', async({ server }) => {
       const {spawn, execSync} = require('child_process');
       const options = Object.assign({}, defaultBrowserOptions, {
         // Disable DUMPIO to cleanly read stdout.

--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -33,7 +33,7 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
       await page.keyboard.type(text);
       expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe(text);
     });
-    it('should press the metaKey', async({page, server}) => {
+    it.skip(WEBKIT)('should press the metaKey', async({page, server}) => {
       await page.goto(server.PREFIX + '/empty.html');
       await page.evaluate(() => {
         window.keyPromise = new Promise(resolve => document.addEventListener('keydown', event => resolve(event.key)));
@@ -82,7 +82,7 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
       await page.keyboard.sendCharacters('a');
       expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('嗨a');
     });
-    it.skip(FFOX)('should report shiftKey', async({page, server}) => {
+    it.skip(FFOX || WEBKIT)('should report shiftKey', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/keyboard.html');
       const keyboard = page.keyboard;
       const codeForKey = {'Shift': 16, 'Alt': 18, 'Control': 17};
@@ -102,7 +102,7 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
         expect(await page.evaluate(() => getResult())).toBe('Keyup: ' + modifierKey + ' ' + modifierKey + 'Left ' + codeForKey[modifierKey] + ' []');
       }
     });
-    it('should report multiple modifiers', async({page, server}) => {
+    it.skip(WEBKIT)('should report multiple modifiers', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/keyboard.html');
       const keyboard = page.keyboard;
       await keyboard.down('Control');
@@ -118,7 +118,7 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
       await keyboard.up('Alt');
       expect(await page.evaluate(() => getResult())).toBe('Keyup: Alt AltLeft 18 []');
     });
-    it('should send proper codes while typing', async({page, server}) => {
+    it.skip(WEBKIT)('should send proper codes while typing', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/keyboard.html');
       await page.keyboard.type('!');
       expect(await page.evaluate(() => getResult())).toBe(
@@ -131,7 +131,7 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
             'Keypress: ^ Digit6 94 94 []',
             'Keyup: ^ Digit6 54 []'].join('\n'));
     });
-    it('should send proper codes while typing with shift', async({page, server}) => {
+    it.skip(WEBKIT)('should send proper codes while typing with shift', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/keyboard.html');
       const keyboard = page.keyboard;
       await keyboard.down('Shift');
@@ -143,7 +143,7 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
             'Keyup: ~ Backquote 192 [Shift]'].join('\n'));
       await keyboard.up('Shift');
     });
-    it('should not type canceled events', async({page, server}) => {
+    it.skip(WEBKIT)('should not type canceled events', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/textarea.html');
       await page.focus('textarea');
       await page.evaluate(() => {
@@ -184,7 +184,7 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
       await page.keyboard.type(text);
       expect(await page.evaluate('result')).toBe(text);
     });
-    it('should specify location', async({page, server}) => {
+    it.skip(WEBKIT)('should specify location', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/textarea.html');
       await page.evaluate(() => {
         window.addEventListener('keydown', event => window.keyLocation = event.location, true);
@@ -226,7 +226,7 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
       await textarea.type('👹 Tokyo street Japan 🇯🇵');
       expect(await frame.$eval('textarea', textarea => textarea.value)).toBe('👹 Tokyo street Japan 🇯🇵');
     });
-    it('should press the meta key', async({page}) => {
+    it.skip(WEBKIT)('should press the meta key', async({page}) => {
       await page.evaluate(() => {
         window.result = null;
         document.addEventListener('keydown', event => {

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -31,7 +31,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
 
   describe('Playwright', function() {
     describe('BrowserFetcher', function() {
-      it.skip(WEBKIT)('should download and extract linux binary', async({server}) => {
+      it.skip(WEBKIT || FFOX)('should download and extract linux binary', async({server}) => {
         const downloadsFolder = await mkdtempAsync(TMP_FOLDER);
         const browserFetcher = playwright.createBrowserFetcher({
           platform: 'linux',

--- a/test/screenshot.spec.js
+++ b/test/screenshot.spec.js
@@ -151,7 +151,7 @@ module.exports.addTests = function({testRunner, expect, product, FFOX, CHROME, W
       const screenshot = await elementHandle.screenshot();
       expect(screenshot).toBeGolden('screenshot-element-padding-border.png');
     });
-    it('should capture full element when larger than viewport in parallel', async({page, server}) => {
+    it.skip(WEBKIT)('should capture full element when larger than viewport in parallel', async({page, server}) => {
       await page.setViewport({width: 500, height: 500});
 
       await page.setContent(`


### PR DESCRIPTION
This patch disables all tests that fail on WebKit Linux and
FireFox Linux.

The plan is to have a Linux CI that will run against playwright
and avoid future regressions.