### PR TITLE
fix(types): cast nodes to elements in _viewportPointAndScroll

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -258,8 +258,8 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   private async _viewportPointAndScroll(relativePoint: types.Point): Promise<{point: types.Point, scrollX: number, scrollY: number}> {
     const [box, border] = await Promise.all([
       this.boundingBox(),
-      this.evaluate((e: Element) => {
-        const style = e.ownerDocument.defaultView.getComputedStyle(e);
+      this.evaluate((e: Node) => {
+        const style = e.ownerDocument.defaultView.getComputedStyle(e as Element);
         return { x: parseInt(style.borderLeftWidth, 10), y: parseInt(style.borderTopWidth, 10) };
       }).catch(debugError),
     ]);


### PR DESCRIPTION
Everywhere this gets used, we've already checked that the node is an element, so this is fine.