### PR TITLE
fix(webkit): make go back/forard return null on error

### DIFF
--- a/src/webkit/Page.ts
+++ b/src/webkit/Page.ts
@@ -266,12 +266,14 @@ export class Page extends EventEmitter {
   }
 
   async _go<T extends keyof Protocol.CommandParameters>(command: T): Promise<network.Response | null> {
-    const [response, error] = await Promise.all([
+    const [response] = await Promise.all([
       this.waitForNavigation(),
-      this._session.send(command).then(() => null).catch(e => e),
-    ]);
-    if (error)
-      return null;
+      this._session.send(command).then(() => null),
+    ]).catch(error => {
+      if (error instanceof Error && error.message.includes(`Protocol error (${command}): Failed to go`))
+        return [null];
+      throw error;
+    });
     return response;
   }
 

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -451,7 +451,7 @@ module.exports.addTests = function({testRunner, expect, playwright, FFOX, CHROME
   });
 
   describe('Page.goBack', function() {
-    it.skip(WEBKIT)('should work', async({page, server}) => {
+    it('should work', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       await page.goto(server.PREFIX + '/grid.html');
 


### PR DESCRIPTION
Depends on backend changes in WebKit: https://github.com/microsoft/playwright/commit/6294f0248af1fe23509b6b20fe2d805fe2e4da24