### PR TITLE
feat(webkit): pause and configure provisional pages on creation

### DIFF
--- a/src/page.ts
+++ b/src/page.ts
@@ -78,7 +78,7 @@ export class Page<Browser, BrowserContext extends BrowserContextInterface<Browse
   private _closedPromise: Promise<void>;
   private _disconnected = false;
   private _disconnectedCallback: (e: Error) => void;
-  private _disconnectedPromise: Promise<Error>;
+  readonly _disconnectedPromise: Promise<Error>;
   private _browserContext: BrowserContext;
   readonly keyboard: input.Keyboard;
   readonly mouse: input.Mouse;

--- a/src/webkit/NetworkManager.ts
+++ b/src/webkit/NetworkManager.ts
@@ -44,7 +44,7 @@ export class NetworkManager extends EventEmitter {
     this._frameManager = frameManager;
   }
 
-  async initialize(session: TargetSession) {
+  setSession(session: TargetSession) {
     helper.removeEventListeners(this._sessionListeners);
     this._session = session;
     this._sessionListeners = [
@@ -53,8 +53,13 @@ export class NetworkManager extends EventEmitter {
       helper.addEventListener(this._session, 'Network.loadingFinished', this._onLoadingFinished.bind(this)),
       helper.addEventListener(this._session, 'Network.loadingFailed', this._onLoadingFailed.bind(this)),
     ];
-    await this._session.send('Network.enable');
-    await this._session.send('Network.setExtraHTTPHeaders', { headers: this._extraHTTPHeaders });
+  }
+
+  async initializeSession(session: TargetSession) {
+    await Promise.all([
+      session.send('Network.enable'),
+      session.send('Network.setExtraHTTPHeaders', { headers: this._extraHTTPHeaders }),
+    ]);
   }
 
   async setExtraHTTPHeaders(extraHTTPHeaders: { [s: string]: string; }) {

--- a/src/webkit/Screenshotter.ts
+++ b/src/webkit/Screenshotter.ts
@@ -11,7 +11,7 @@ import { TargetSession } from './Connection';
 export class WKScreenshotDelegate implements ScreenshotterDelegate {
   private _session: TargetSession;
 
-  initialize(session: TargetSession) {
+  setSession(session: TargetSession) {
     this._session = session;
   }
 


### PR DESCRIPTION
* Provisional target is initialized and resumed when its created. All messages from it will be deferred until the target is committed.
* Added queue for incoming messages to guarantee execution order of protocol commands and their response handlers (chained promises)
* Split initialize(Session) into initializeSession(Session) which is called for committed and provisional sessions and setSession which is called when session is swapped (init still has to be called separately).
