### PR TITLE
fix(test): Disable spellcheck in our textarea tests

### DIFF
--- a/test/assets/input/textarea.html
+++ b/test/assets/input/textarea.html
@@ -4,7 +4,7 @@
     <title>Textarea test</title>
   </head>
   <body>
-    <textarea></textarea>
+    <textarea spellcheck="false"></textarea>
     <input></input>
     <div contenteditable="true"></div>
     <script src='mouse-helper.js'></script>

--- a/test/mouse.spec.js
+++ b/test/mouse.spec.js
@@ -70,7 +70,7 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
       expect(newDimensions.width).toBe(Math.round(width + 104));
       expect(newDimensions.height).toBe(Math.round(height + 104));
     });
-    it.skip(WEBKIT)('should select the text with mouse', async({page, server}) => {
+    it('should select the text with mouse', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/textarea.html');
       await page.focus('textarea');
       const text = 'This is the text that we are going to try to select. Let\'s see how it goes.';


### PR DESCRIPTION
Our keyboard emulation is so good on Mac that we trigger the infamous Apple autocorrect. It turns `'` into a fancy `’`. Disabling spellcheck on the textarea keeps things consistent cross platform.