### PR TITLE
fix(webkit): make sure each message is dispatch in separate task

### DIFF
--- a/src/webkit/Target.ts
+++ b/src/webkit/Target.ts
@@ -57,7 +57,7 @@ export class Target {
     await (this._page._delegate as FrameManager)._initializeSession(session).catch(e => {
       // Swallow initialization errors due to newer target swap in,
       // since we will reinitialize again.
-      if (!isSwappedOutError(e))
+      if (this._page)
         throw e;
     });
   }


### PR DESCRIPTION
Dispatching each message in separate task is important to ensure that all microtasks for resolved promises run before next protocol message get dispatched. This fixes a bunch of test failures/timeouts.