### PR TITLE
feature: update api around selectors

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -133,7 +133,7 @@ export class Keyboard {
     await this._raw.sendText(text);
   }
 
-  async type(text: string, options: { delay: (number | undefined); } | undefined) {
+  async type(text: string, options?: { delay?: number }) {
     const delay = (options && options.delay) || null;
     for (const char of text) {
       if (keyboardLayout.keyDefinitions[char]) {

--- a/src/page.ts
+++ b/src/page.ts
@@ -188,8 +188,8 @@ export class Page extends EventEmitter {
     this._timeoutSettings.setDefaultTimeout(timeout);
   }
 
-  async $(selector: string | types.Selector): Promise<dom.ElementHandle<Element> | null> {
-    return this.mainFrame().$(selector);
+  async $(selector: string, options?: frames.WaitForOptions): Promise<dom.ElementHandle<Element> | null> {
+    return this.mainFrame().$(selector, options);
   }
 
   async _createSelector(name: string, handle: dom.ElementHandle<Element>): Promise<string> {
@@ -212,7 +212,7 @@ export class Page extends EventEmitter {
     return this.mainFrame().$$eval(selector, pageFunction, ...args as any);
   }
 
-  async $$(selector: string | types.Selector): Promise<dom.ElementHandle<Element>[]> {
+  async $$(selector: string): Promise<dom.ElementHandle<Element>[]> {
     return this.mainFrame().$$(selector);
   }
 
@@ -461,48 +461,40 @@ export class Page extends EventEmitter {
     return this._closed;
   }
 
-  click(selector: string | types.Selector, options?: frames.WaitForOptions & input.ClickOptions) {
+  click(selector: string, options?: frames.WaitForOptions & input.ClickOptions) {
     return this.mainFrame().click(selector, options);
   }
 
-  dblclick(selector: string | types.Selector, options?: frames.WaitForOptions & input.MultiClickOptions) {
+  dblclick(selector: string, options?: frames.WaitForOptions & input.MultiClickOptions) {
     return this.mainFrame().dblclick(selector, options);
   }
 
-  tripleclick(selector: string | types.Selector, options?: frames.WaitForOptions & input.MultiClickOptions) {
+  tripleclick(selector: string, options?: frames.WaitForOptions & input.MultiClickOptions) {
     return this.mainFrame().tripleclick(selector, options);
   }
 
-  fill(selector: string | types.Selector, value: string, options?: frames.WaitForOptions) {
+  fill(selector: string, value: string, options?: frames.WaitForOptions) {
     return this.mainFrame().fill(selector, value, options);
   }
 
-  focus(selector: string | types.Selector, options?: frames.WaitForOptions) {
+  focus(selector: string, options?: frames.WaitForOptions) {
     return this.mainFrame().focus(selector, options);
   }
 
-  hover(selector: string | types.Selector, options?: frames.WaitForOptions & input.PointerActionOptions) {
+  hover(selector: string, options?: frames.WaitForOptions & input.PointerActionOptions) {
     return this.mainFrame().hover(selector, options);
   }
 
-  select(selector: string | types.Selector, value: string | dom.ElementHandle | input.SelectOption | string[] | dom.ElementHandle[] | input.SelectOption[] | undefined, options?: frames.WaitForOptions): Promise<string[]> {
+  select(selector: string, value: string | dom.ElementHandle | input.SelectOption | string[] | dom.ElementHandle[] | input.SelectOption[] | undefined, options?: frames.WaitForOptions): Promise<string[]> {
     return this.mainFrame().select(selector, value, options);
   }
 
-  type(selector: string | types.Selector, text: string, options: frames.WaitForOptions & { delay: (number | undefined); } | undefined) {
+  type(selector: string, text: string, options?: frames.WaitForOptions & { delay?: number }) {
     return this.mainFrame().type(selector, text, options);
   }
 
   waitFor(selectorOrFunctionOrTimeout: (string | number | Function), options: { visible?: boolean; hidden?: boolean; timeout?: number; polling?: string | number; } = {}, ...args: any[]): Promise<js.JSHandle> {
     return this.mainFrame().waitFor(selectorOrFunctionOrTimeout, options, ...args);
-  }
-
-  waitForSelector(selector: string | types.Selector, options: types.TimeoutOptions = {}): Promise<dom.ElementHandle | null> {
-    return this.mainFrame().waitForSelector(selector, options);
-  }
-
-  waitForXPath(xpath: string, options: types.TimeoutOptions = {}): Promise<dom.ElementHandle | null> {
-    return this.mainFrame().waitForXPath(xpath, options);
   }
 
   waitForFunction(pageFunction: Function | string, options: types.WaitForFunctionOptions, ...args: any[]): Promise<js.JSHandle> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import * as js from './javascript';
-import { helper } from './helper';
 import * as dom from './dom';
 
 type Boxed<Args extends any[]> = { [Index in keyof Args]: Args[Index] | js.JSHandle<Args[Index]> };
@@ -14,8 +13,8 @@ type ElementForSelector<T> = T extends keyof HTMLElementTagNameMap ? HTMLElement
 
 export type Evaluate = <Args extends any[], R>(pageFunction: PageFunction<Args, R>, ...args: Boxed<Args>) => Promise<R>;
 export type EvaluateHandle = <Args extends any[], R>(pageFunction: PageFunction<Args,  R>, ...args: Boxed<Args>) => Promise<Handle<R>>;
-export type $Eval<O = string | Selector> = <Args extends any[], R, S extends O>(selector: S, pageFunction: PageFunctionOn<ElementForSelector<S>, Args, R>, ...args: Boxed<Args>) => Promise<R>;
-export type $$Eval<O = string | Selector> = <Args extends any[], R, S extends O>(selector: S, pageFunction: PageFunctionOn<ElementForSelector<S>[], Args, R>, ...args: Boxed<Args>) => Promise<R>;
+export type $Eval = <Args extends any[], R, S extends string>(selector: S, pageFunction: PageFunctionOn<ElementForSelector<S>, Args, R>, ...args: Boxed<Args>) => Promise<R>;
+export type $$Eval = <Args extends any[], R, S extends string>(selector: S, pageFunction: PageFunctionOn<ElementForSelector<S>[], Args, R>, ...args: Boxed<Args>) => Promise<R>;
 export type EvaluateOn<T> = <Args extends any[], R>(pageFunction: PageFunctionOn<T, Args, R>, ...args: Boxed<Args>) => Promise<R>;
 export type EvaluateHandleOn<T> = <Args extends any[], R>(pageFunction: PageFunctionOn<T, Args, R>, ...args: Boxed<Args>) => Promise<Handle<R>>;
 
@@ -26,31 +25,9 @@ export type Quad = [ Point, Point, Point, Point ];
 
 export type TimeoutOptions = { timeout?: number };
 export type Visibility = 'visible' | 'hidden' | 'any';
-export type Selector = { selector: string, visibility?: Visibility };
 
 export type Polling = 'raf' | 'mutation' | number;
 export type WaitForFunctionOptions = TimeoutOptions & { polling?: Polling };
-
-export function selectorToString(selector: string | Selector): string {
-  if (typeof selector === 'string')
-    return selector;
-  let label;
-  switch (selector.visibility) {
-    case 'visible': label = '[visible] '; break;
-    case 'hidden': label = '[hidden] '; break;
-    case 'any':
-    case undefined:
-      label = ''; break;
-  }
-  return `${label}${selector.selector}`;
-}
-
-// Ensures that we don't use accidental properties in selector, e.g. scope.
-export function clearSelector(selector: string | Selector): string | Selector {
-  if (helper.isString(selector))
-    return selector;
-  return { selector: selector.selector, visibility: selector.visibility };
-}
 
 export type ElementScreenshotOptions = {
   type?: 'png' | 'jpeg',

--- a/test/chromium/connect.spec.js
+++ b/test/chromium/connect.spec.js
@@ -119,7 +119,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
       const browser = await playwright.launch(defaultBrowserOptions);
       const remote = await playwright.connect({...defaultBrowserOptions, browserWSEndpoint: browser.chromium.wsEndpoint()});
       const page = await remote.newPage();
-      const watchdog = page.waitForSelector('div', {timeout: 60000}).catch(e => e);
+      const watchdog = page.$('div', { waitFor: true, timeout: 60000 }).catch(e => e);
       remote.disconnect();
       const error = await watchdog;
       expect(error.message).toContain('Protocol error');

--- a/test/chromium/headful.spec.js
+++ b/test/chromium/headful.spec.js
@@ -99,7 +99,7 @@ module.exports.addTests = function({testRunner, expect, playwright, defaultBrows
         document.body.appendChild(frame);
         return new Promise(x => frame.onload = x);
       });
-      await page.waitForSelector('iframe[src="https://google.com/"]');
+      await page.$('iframe[src="https://google.com/"]', { waitFor: true });
       const urls = page.frames().map(frame => frame.url()).sort();
       expect(urls).toEqual([
         server.EMPTY_PAGE,

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1118,19 +1118,16 @@ module.exports.addTests = function({testRunner, expect, headless, playwright, FF
     });
     it('should respect selector visibilty', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/textarea.html');
-      await page.fill({selector: 'input', visibility: 'visible'}, 'some value');
+      await page.fill('input', 'some value', { waitFor: 'visible' });
       expect(await page.evaluate(() => result)).toBe('some value');
 
-      let error = null;
-      await page.goto(server.PREFIX + '/input/textarea.html');
-      await page.fill({selector: 'input', visibility: 'hidden'}, 'some value').catch(e => error = e);
-      expect(error.message).toBe('No node found for selector: [hidden] input');
-
-      error = null;
       await page.goto(server.PREFIX + '/input/textarea.html');
       await page.$eval('input', i => i.style.display = 'none');
-      await page.fill({selector: 'input', visibility: 'visible'}, 'some value').catch(e => error = e);
-      expect(error.message).toBe('No node found for selector: [visible] input');
+      await Promise.all([
+        page.fill('input', 'some value', { waitFor: 'visible' }),
+        page.$eval('input', i => i.style.display = 'block'),
+      ]);
+      expect(await page.evaluate(() => result)).toBe('some value');
     });
     it('should throw on disabled and readonly elements', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/textarea.html');


### PR DESCRIPTION
- Selector is again a string.
- Most methods taking selector also accept waitFor option.
- Available waitFor options are: 'visible', 'hidden', 'any' === true, false === undefined.
- waitForXPath is removed.
- waitForSelector is replaced by $(selector, { waitFor: true }).