### PR TITLE
api: remove ExecutionContext from api

### DIFF
--- a/src/chromium/ExecutionContext.ts
+++ b/src/chromium/ExecutionContext.ts
@@ -125,7 +125,7 @@ export class ExecutionContextDelegate implements js.ExecutionContextDelegate {
       if (error.message.includes('Object couldn\'t be returned by value'))
         return {result: {type: 'undefined'}};
 
-      if (error.message.endsWith('Cannot find context with specified id') || error.message.endsWith('Inspected target navigated or closed'))
+      if (error.message.endsWith('Cannot find context with specified id') || error.message.endsWith('Inspected target navigated or closed') || error.message.endsWith('Execution context was destroyed.'))
         throw new Error('Execution context was destroyed, most likely because of a navigation.');
       throw error;
     }
@@ -140,7 +140,7 @@ export class ExecutionContextDelegate implements js.ExecutionContextDelegate {
     for (const property of response.result) {
       if (!property.enumerable)
         continue;
-      result.set(property.name, handle.executionContext()._createHandle(property.value));
+      result.set(property.name, handle._context._createHandle(property.value));
     }
     return result;
   }

--- a/src/chromium/api.ts
+++ b/src/chromium/api.ts
@@ -7,7 +7,7 @@ export { ElementHandle } from '../dom';
 export { TimeoutError } from '../errors';
 export { Frame } from '../frames';
 export { Keyboard, Mouse } from '../input';
-export { ExecutionContext, JSHandle } from '../javascript';
+export { JSHandle } from '../javascript';
 export { Request, Response } from '../network';
 export { Browser } from './Browser';
 export { BrowserContext } from '../browserContext';

--- a/src/chromium/features/workers.ts
+++ b/src/chromium/features/workers.ts
@@ -85,10 +85,6 @@ export class Worker extends EventEmitter {
     return this._url;
   }
 
-  async executionContext(): Promise<js.ExecutionContext> {
-    return this._executionContextPromise;
-  }
-
   evaluate: types.Evaluate = async (pageFunction, ...args) => {
     return (await this._executionContextPromise).evaluate(pageFunction, ...args as any);
   }

--- a/src/console.ts
+++ b/src/console.ts
@@ -28,7 +28,7 @@ export class ConsoleMessage {
 
   text(): string {
     if (this._text === undefined)
-      this._text = this._args.map(arg => arg.executionContext()._delegate.handleToString(arg, false /* includeType */)).join(' ');
+      this._text = this._args.map(arg => arg._context._delegate.handleToString(arg, false /* includeType */)).join(' ');
     return this._text;
   }
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -87,6 +87,10 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     this._page = context.frame()._page;
   }
 
+  frame(): frames.Frame {
+    return this._context.frame();
+  }
+
   asElement(): ElementHandle<T> | null {
     return this;
   }

--- a/src/firefox/ExecutionContext.ts
+++ b/src/firefox/ExecutionContext.ts
@@ -106,7 +106,7 @@ export class ExecutionContextDelegate implements js.ExecutionContextDelegate {
     return context._createHandle(payload.result);
 
     function rewriteError(error) : never {
-      if (error.message.includes('Failed to find execution context with id'))
+      if (error.message.includes('Failed to find execution context with id') || error.message.includes('Execution context was destroyed!'))
         throw new Error('Execution context was destroyed, most likely because of a navigation.');
       throw error;
     }
@@ -119,7 +119,7 @@ export class ExecutionContextDelegate implements js.ExecutionContextDelegate {
     });
     const result = new Map();
     for (const property of response.properties)
-      result.set(property.name, handle.executionContext()._createHandle(property.value));
+      result.set(property.name, handle._context._createHandle(property.value));
     return result;
   }
 

--- a/src/firefox/api.ts
+++ b/src/firefox/api.ts
@@ -7,7 +7,7 @@ export { Browser } from './Browser';
 export { BrowserContext } from '../browserContext';
 export { BrowserFetcher } from '../browserFetcher';
 export { Dialog } from '../dialog';
-export { ExecutionContext, JSHandle } from '../javascript';
+export { JSHandle } from '../javascript';
 export { ElementHandle } from '../dom';
 export { Accessibility } from './features/accessibility';
 export { Interception } from './features/interception';

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -354,10 +354,6 @@ export class Frame {
     return this._context('utility');
   }
 
-  executionContext(): Promise<dom.FrameExecutionContext> {
-    return this._mainContext();
-  }
-
   evaluateHandle: types.EvaluateHandle = async (pageFunction, ...args) => {
     const context = await this._mainContext();
     return context.evaluateHandle(pageFunction, ...args as any);
@@ -632,7 +628,7 @@ export class Frame {
     const values = value === undefined ? [] : Array.isArray(value) ? value : [value];
     const context = await this._utilityContext();
     const adoptedValues = await Promise.all(values.map(async value => {
-      if (value instanceof dom.ElementHandle && value.executionContext() !== context) {
+      if (value instanceof dom.ElementHandle && value._context !== context) {
         const adopted = this._page._delegate.adoptElementHandle(value, context);
         toDispose.push(adopted);
         return adopted;

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -47,10 +47,6 @@ export class JSHandle<T = any> {
     this._remoteObject = remoteObject;
   }
 
-  executionContext(): ExecutionContext {
-    return this._context;
-  }
-
   evaluate: types.EvaluateOn<T> = (pageFunction, ...args) => {
     return this._context.evaluate(pageFunction, this, ...args);
   }

--- a/src/page.ts
+++ b/src/page.ts
@@ -182,8 +182,7 @@ export class Page extends EventEmitter {
   }
 
   evaluateHandle: types.EvaluateHandle = async (pageFunction, ...args) => {
-    const context = await this.mainFrame().executionContext();
-    return context.evaluateHandle(pageFunction, ...args as any);
+    return this.mainFrame().evaluateHandle(pageFunction, ...args as any);
   }
 
   $eval: types.$Eval = (selector, pageFunction, ...args) => {

--- a/src/webkit/ExecutionContext.ts
+++ b/src/webkit/ExecutionContext.ts
@@ -261,7 +261,7 @@ export class ExecutionContextDelegate implements js.ExecutionContextDelegate {
     for (const property of response.properties) {
       if (!property.enumerable)
         continue;
-      result.set(property.name, handle.executionContext()._createHandle(property.value));
+      result.set(property.name, handle._context._createHandle(property.value));
     }
     return result;
   }

--- a/src/webkit/FrameManager.ts
+++ b/src/webkit/FrameManager.ts
@@ -212,7 +212,7 @@ export class FrameManager implements PageDelegate {
     else if (type === 'timing')
       derivedType = 'timeEnd';
 
-    const mainFrameContext = await this._page.mainFrame().executionContext();
+    const mainFrameContext = await this._page.mainFrame()._mainContext();
     const handles = (parameters || []).map(p => {
       let context: dom.FrameExecutionContext | null = null;
       if (p.objectId) {

--- a/src/webkit/api.ts
+++ b/src/webkit/api.ts
@@ -5,7 +5,7 @@ export { TimeoutError } from '../errors';
 export { Browser } from './Browser';
 export { BrowserContext } from '../browserContext';
 export { BrowserFetcher } from '../browserFetcher';
-export { ExecutionContext, JSHandle } from '../javascript';
+export { JSHandle } from '../javascript';
 export { ElementHandle } from '../dom';
 export { Frame } from '../frames';
 export { Mouse, Keyboard } from '../input';

--- a/test/chromium/workers.spec.js
+++ b/test/chromium/workers.spec.js
@@ -67,11 +67,11 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
       expect(log.args().length).toBe(4);
       expect(await (await log.args()[3].getProperty('origin')).jsonValue()).toBe('null');
     });
-    it('should have an execution context', async function({page}) {
+    it('should evaluate', async function({page}) {
       const workerCreatedPromise = new Promise(x => page.workers.once('workercreated', x));
       await page.evaluate(() => new Worker(`data:text/javascript,console.log(1)`));
       const worker = await workerCreatedPromise;
-      expect(await (await worker.executionContext()).evaluate('1+1')).toBe(2);
+      expect(await worker.evaluate('1+1')).toBe(2);
     });
     it('should report errors', async function({page}) {
       const errorPromise = new Promise(x => page.on('pageerror', x));

--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -252,7 +252,7 @@ module.exports.addTests = function({testRunner, expect, product, playwright, FFO
       await otherFrame.evaluate(addElement, 'div');
       await page.evaluate(addElement, 'div');
       const eHandle = await watchdog;
-      expect(eHandle.executionContext().frame()).toBe(page.mainFrame());
+      expect(eHandle.frame()).toBe(page.mainFrame());
     });
 
     it('should run in specified frame', async({page, server}) => {
@@ -264,7 +264,7 @@ module.exports.addTests = function({testRunner, expect, product, playwright, FFO
       await frame1.evaluate(addElement, 'div');
       await frame2.evaluate(addElement, 'div');
       const eHandle = await waitForSelectorPromise;
-      expect(eHandle.executionContext().frame()).toBe(frame2);
+      expect(eHandle.frame()).toBe(frame2);
     });
 
     it('should throw when frame is detached', async({page, server}) => {
@@ -415,7 +415,7 @@ module.exports.addTests = function({testRunner, expect, product, playwright, FFO
       await frame1.evaluate(addElement, 'div');
       await frame2.evaluate(addElement, 'div');
       const eHandle = await waitForXPathPromise;
-      expect(eHandle.executionContext().frame()).toBe(frame2);
+      expect(eHandle.frame()).toBe(frame2);
     });
     it('should throw when frame is detached', async({page, server}) => {
       await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);


### PR DESCRIPTION
In the current state, it is superseeded by Frame and JSHandle.