### PR TITLE
test(webkit): add tests for after cross origin navigations

### DIFF
--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -70,6 +70,13 @@ module.exports.addTests = function({testRunner, expect, playwright, FFOX, CHROME
       await page.click('button');
       expect(await page.evaluate(() => result)).toBe('Clicked');
     });
+    it.skip(WEBKIT)('should click the button after a cross origin navigation ', async({page, server}) => {
+      await page.goto(server.PREFIX + '/input/button.html');
+      await page.click('button');
+      await page.goto(server.CROSS_PROCESS_PREFIX + '/input/button.html');
+      await page.click('button');
+      expect(await page.evaluate(() => result)).toBe('Clicked');
+    });
     it.skip(FFOX)('should click with disabled javascript', async({newPage, server}) => {
       const page = await newPage({ javaScriptEnabled: false });
       await page.goto(server.PREFIX + '/wrappedlink.html');

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -97,6 +97,15 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
       await page.goto(server.EMPTY_PAGE);
       expect(await frameEvaluation).toBe(42);
     });
+    it.skip(WEBKIT)('should work right after a cross-origin navigation', async({page, server}) => {
+        await page.goto(server.EMPTY_PAGE);
+        let frameEvaluation = null;
+        page.on('framenavigated', async frame => {
+          frameEvaluation = frame.evaluate(() => 6 * 7);
+        });
+        await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
+        expect(await frameEvaluation).toBe(42);
+    });
     it('should work from-inside an exposed function', async({page, server}) => {
       // Setup inpage callback, which calls Page.evaluate
       await page.exposeFunction('callController', async function(a, b) {
@@ -290,6 +299,14 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
       // Make sure CSP works.
       await page.addScriptTag({content: 'window.e = 10;'}).catch(e => void e);
       expect(await page.evaluate(() => window.e)).toBe(undefined);
+    });
+    it.skip(WEBKIT)('should work after a cross origin navigation', async({page, server}) => {
+      await page.goto(server.CROSS_PROCESS_PREFIX);
+      await page.evaluateOnNewDocument(function(){
+        window.injected = 123;
+      });
+      await page.goto(server.PREFIX + '/tamperable.html');
+      expect(await page.evaluate(() => window.result)).toBe(123);
     });
   });
 

--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -280,5 +280,14 @@ module.exports.addTests = function({testRunner, expect, FFOX, CHROME, WEBKIT, MA
         expect(metaKey).toBe(true);
 
     });
+    it.skip(WEBKIT)('should work after a cross origin navigation', async({page, server}) => {
+      await page.goto(server.PREFIX + '/empty.html');
+      await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
+      await page.evaluate(() => {
+        document.addEventListener('keydown', event => window.lastKey = event);
+      })
+      await page.keyboard.press('a');
+      expect(await page.evaluate('lastKey.key')).toBe('a');
+    })
   });
 };

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -167,6 +167,10 @@ module.exports.addTests = function({testRunner, expect, playwright, FFOX, CHROME
       await page.goto(httpsServer.PREFIX + '/redirect/1.html').catch(e => error = e);
       expectSSLError(error.message);
     });
+    it.skip(WEBKIT)('should not crash when navigating to bad SSL after a cross origin navigation', async({page, server, httpsServer}) => {
+      await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
+      await page.goto(httpsServer.EMPTY_PAGE).catch(e => void 0);
+    });
     it('should throw if networkidle is passed as an option', async({page, server}) => {
       let error = null;
       await page.goto(server.EMPTY_PAGE, {waitUntil: 'networkidle'}).catch(err => error = err);

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -567,6 +567,18 @@ module.exports.addTests = function({testRunner, expect, headless, playwright, FF
       });
       expect(result).toBe(15);
     });
+    it.skip(WEBKIT)('should work after cross origin navigation', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.exposeFunction('compute', function(a, b) {
+        return a * b;
+      });
+
+      await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
+      const result = await page.evaluate(async function() {
+        return await compute(9, 4);
+      });
+      expect(result).toBe(36);
+    });
     it('should work with complex objects', async({page, server}) => {
       await page.exposeFunction('complexObject', function(a, b) {
         return {x: a.x + b.x};


### PR DESCRIPTION
Mouse, Keyboard, and others are broken in WebKit after the first cross-process navigation.