### PR TITLE
fix(elementhandle): contentFrame and ownerFrame work in various scenarios

### DIFF
--- a/src/firefox/FrameManager.ts
+++ b/src/firefox/FrameManager.ts
@@ -94,7 +94,7 @@ export class FrameManager implements PageDelegate {
     if (!context)
       return;
     this._contextIdToContext.delete(executionContextId);
-    context.frame()._contextDestroyed(context as dom.FrameExecutionContext);
+    context.frame._contextDestroyed(context as dom.FrameExecutionContext);
   }
 
   _onNavigationStarted() {
@@ -237,7 +237,7 @@ export class FrameManager implements PageDelegate {
   }
 
   getBoundingBoxForScreenshot(handle: dom.ElementHandle<Node>): Promise<types.Rect | null> {
-    const frameId = handle._context.frame()._id;
+    const frameId = handle._context.frame._id;
     return this._session.send('Page.getBoundingBox', {
       frameId,
       objectId: handle._remoteObject.objectId,
@@ -268,12 +268,16 @@ export class FrameManager implements PageDelegate {
 
   async getContentFrame(handle: dom.ElementHandle): Promise<frames.Frame | null> {
     const { frameId } = await this._session.send('Page.contentFrame', {
-      frameId: handle._context.frame()._id,
+      frameId: handle._context.frame._id,
       objectId: toRemoteObject(handle).objectId,
     });
     if (!frameId)
       return null;
     return this._page._frameManager.frame(frameId);
+  }
+
+  async getOwnerFrame(handle: dom.ElementHandle): Promise<frames.Frame | null> {
+    return handle._context.frame;
   }
 
   isElementHandle(remoteObject: any): boolean {
@@ -301,7 +305,7 @@ export class FrameManager implements PageDelegate {
 
   async getContentQuads(handle: dom.ElementHandle): Promise<types.Quad[] | null> {
     const result = await this._session.send('Page.getContentQuads', {
-      frameId: handle._context.frame()._id,
+      frameId: handle._context.frame._id,
       objectId: toRemoteObject(handle).objectId,
     }).catch(debugError);
     if (!result)

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as frames from './frames';
 import * as types from './types';
 import * as dom from './dom';
 
@@ -18,10 +17,6 @@ export class ExecutionContext {
 
   constructor(delegate: ExecutionContextDelegate) {
     this._delegate = delegate;
-  }
-
-  frame(): frames.Frame | null {
-    return null;
   }
 
   _evaluate(returnByValue: boolean, pageFunction: string | Function, ...args: any[]): Promise<any> {

--- a/src/page.ts
+++ b/src/page.ts
@@ -57,7 +57,8 @@ export interface PageDelegate {
 
   isElementHandle(remoteObject: any): boolean;
   adoptElementHandle<T extends Node>(handle: dom.ElementHandle<T>, to: dom.FrameExecutionContext): Promise<dom.ElementHandle<T>>;
-  getContentFrame(handle: dom.ElementHandle): Promise<frames.Frame | null>;
+  getContentFrame(handle: dom.ElementHandle): Promise<frames.Frame | null>;  // Only called for frame owner elements.
+  getOwnerFrame(handle: dom.ElementHandle): Promise<frames.Frame | null>;
   getContentQuads(handle: dom.ElementHandle): Promise<types.Quad[] | null>;
   layoutViewport(): Promise<{ width: number, height: number }>;
   setInputFiles(handle: dom.ElementHandle, files: input.FilePayload[]): Promise<void>;

--- a/src/webkit/FrameManager.ts
+++ b/src/webkit/FrameManager.ts
@@ -130,7 +130,7 @@ export class FrameManager implements PageDelegate {
   disconnectFromTarget() {
     for (const context of this._contextIdToContext.values()) {
       (context._delegate as ExecutionContextDelegate)._dispose();
-      context.frame()._contextDestroyed(context);
+      context.frame._contextDestroyed(context);
     }
     this._contextIdToContext.clear();
   }
@@ -160,7 +160,7 @@ export class FrameManager implements PageDelegate {
   _onFrameNavigated(framePayload: Protocol.Page.Frame, initial: boolean) {
     const frame = this._page._frameManager.frame(framePayload.id);
     for (const [contextId, context] of this._contextIdToContext) {
-      if (context.frame() === frame) {
+      if (context.frame === frame) {
         (context._delegate as ExecutionContextDelegate)._dispose();
         this._contextIdToContext.delete(contextId);
         frame._contextDestroyed(context);
@@ -372,6 +372,10 @@ export class FrameManager implements PageDelegate {
     if (!nodeInfo.contentFrameId)
       return null;
     return this._page._frameManager.frame(nodeInfo.contentFrameId);
+  }
+
+  async getOwnerFrame(handle: dom.ElementHandle): Promise<frames.Frame | null> {
+    return handle._context.frame;
   }
 
   isElementHandle(remoteObject: any): boolean {

--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -282,7 +282,7 @@ module.exports.describe = function({testRunner, expect, product, playwright, FFO
       await otherFrame.evaluate(addElement, 'div');
       await page.evaluate(addElement, 'div');
       const eHandle = await watchdog;
-      expect(eHandle.frame()).toBe(page.mainFrame());
+      expect(await eHandle.ownerFrame()).toBe(page.mainFrame());
     });
 
     it('should run in specified frame', async({page, server}) => {
@@ -294,7 +294,7 @@ module.exports.describe = function({testRunner, expect, product, playwright, FFO
       await frame1.evaluate(addElement, 'div');
       await frame2.evaluate(addElement, 'div');
       const eHandle = await waitForSelectorPromise;
-      expect(eHandle.frame()).toBe(frame2);
+      expect(await eHandle.ownerFrame()).toBe(frame2);
     });
 
     it('should throw when frame is detached', async({page, server}) => {
@@ -473,7 +473,7 @@ module.exports.describe = function({testRunner, expect, product, playwright, FFO
       await frame1.evaluate(addElement, 'div');
       await frame2.evaluate(addElement, 'div');
       const eHandle = await waitForXPathPromise;
-      expect(eHandle.frame()).toBe(frame2);
+      expect(await eHandle.ownerFrame()).toBe(frame2);
     });
     it('should throw when frame is detached', async({page, server}) => {
       await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);


### PR DESCRIPTION
Drive-by: use evaluateInUtility for various utility evals.