### PR TITLE
test: failing test for setting JSON equal to null

### DIFF
--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -259,6 +259,11 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROME, WEBKIT}) {
       })).catch(e => error = e);
       expect(error.message).toContain('Error in promise');
     });
+    it.skip(FFOX || WEBKIT)('should work even when JSON is set to null', async({page, server}) => {
+      await page.evaluate(() => window.JSON = null);
+      const result = await page.evaluate(() => ({abc: 123}));
+      expect(result).toEqual({abc: 123}); 
+    })
   });
 
   describe('Page.evaluateOnNewDocument', function() {


### PR DESCRIPTION
Firefox and WebKit are both using the globally available `JSON` object to serialize all values. Tampering with this results in a bad time.