### PR TITLE
browser(webkit): stop building with --touch-enable

### DIFF
--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -7,13 +7,13 @@ cd "$(dirname $0)"
 cd "checkout"
 
 if [[ "$(uname)" == "Darwin" ]]; then
-  ./Tools/Scripts/build-webkit --release --touch-events
+  ./Tools/Scripts/build-webkit --release
 elif [[ "$(uname)" == "Linux" ]]; then
   # Check that WebKitBuild exists and is not empty.
   if ! [[ (-d ./WebKitBuild) && (-n $(ls -1 ./WebKitBuild/)) ]]; then
     yes | DEBIAN_FRONTEND=noninteractive ./Tools/Scripts/update-webkitgtk-libs
   fi
-  ./Tools/Scripts/build-webkit --gtk --release --touch-events MiniBrowser
+  ./Tools/Scripts/build-webkit --gtk --release MiniBrowser
 else
   echo "ERROR: cannot upload on this platform!" 1>&2
   exit 1;


### PR DESCRIPTION
Turns out we can't build with touch on Mac yet. Disable for now.

For the record: this was introduced in https://github.com/microsoft/playwright/pull/301