### PR TITLE
fix(scripts): do not depend on env in pw_run.sh for debug builds

### DIFF
--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -6,19 +6,14 @@ trap "cd $(pwd -P)" EXIT
 cd "$(dirname $0)"
 cd "checkout"
 
-BUILD_TYPE=--release
-if [[ -v WKDEBUG ]]; then
-  BUILD_TYPE=--debug
-fi
-
 if [[ "$(uname)" == "Darwin" ]]; then
-  ./Tools/Scripts/build-webkit $BUILD_TYPE --touch-events
+  ./Tools/Scripts/build-webkit --release --touch-events
 elif [[ "$(uname)" == "Linux" ]]; then
   # Check that WebKitBuild exists and is not empty.
   if ! [[ (-d ./WebKitBuild) && (-n $(ls -1 ./WebKitBuild/)) ]]; then
     yes | DEBIAN_FRONTEND=noninteractive ./Tools/Scripts/update-webkitgtk-libs
   fi
-  ./Tools/Scripts/build-webkit --gtk $BUILD_TYPE --touch-events MiniBrowser
+  ./Tools/Scripts/build-webkit --gtk --release --touch-events MiniBrowser
 else
   echo "ERROR: cannot upload on this platform!" 1>&2
   exit 1;

--- a/browser_patches/webkit/pw_run_debug.sh
+++ b/browser_patches/webkit/pw_run_debug.sh
@@ -2,12 +2,12 @@
 
 function runOSX() {
   # if script is run as-is
-  if [ -d $SCRIPT_PATH/checkout/WebKitBuild/Release/MiniBrowser.app ]; then
-    DYLIB_PATH="$SCRIPT_PATH/checkout/WebKitBuild/Release"
+  if [ -d $SCRIPT_PATH/checkout/WebKitBuild/Debug/MiniBrowser.app ]; then
+    DYLIB_PATH="$SCRIPT_PATH/checkout/WebKitBuild/Debug"
   elif [ -d $SCRIPT_PATH/MiniBrowser.app ]; then
     DYLIB_PATH="$SCRIPT_PATH"
-  elif [ -d $SCRIPT_PATH/WebKitBuild/Release/MiniBrowser.app ]; then
-    DYLIB_PATH="$SCRIPT_PATH/WebKitBuild/Release"
+  elif [ -d $SCRIPT_PATH/WebKitBuild/Debug/MiniBrowser.app ]; then
+    DYLIB_PATH="$SCRIPT_PATH/WebKitBuild/Debug"
   else
     echo "Cannot find a MiniBrowser.app in neither location" 1>&2
     exit 1
@@ -19,14 +19,14 @@ function runOSX() {
 function runLinux() {
   # if script is run as-is
   if [ -d $SCRIPT_PATH/checkout/WebKitBuild ]; then
-    LD_PATH="$SCRIPT_PATH/checkout/WebKitBuild/DependenciesGTK/Root/lib:$SCRIPT_PATH/checkout/WebKitBuild/Release/bin"
-    MINIBROWSER="$SCRIPT_PATH/checkout/WebKitBuild/Release/bin/MiniBrowser"
+    LD_PATH="$SCRIPT_PATH/checkout/WebKitBuild/DependenciesGTK/Root/lib:$SCRIPT_PATH/checkout/WebKitBuild/Debug/bin"
+    MINIBROWSER="$SCRIPT_PATH/checkout/WebKitBuild/Debug/bin/MiniBrowser"
   elif [ -f $SCRIPT_PATH/MiniBrowser ]; then
     LD_PATH="$SCRIPT_PATH"
     MINIBROWSER="$SCRIPT_PATH/MiniBrowser"
   elif [ -d $SCRIPT_PATH/WebKitBuild ]; then
-    LD_PATH="$SCRIPT_PATH/WebKitBuild/DependenciesGTK/Root/lib:$SCRIPT_PATH/WebKitBuild/Release/bin"
-    MINIBROWSER="$SCRIPT_PATH/WebKitBuild/Release/bin/MiniBrowser"
+    LD_PATH="$SCRIPT_PATH/WebKitBuild/DependenciesGTK/Root/lib:$SCRIPT_PATH/WebKitBuild/Debug/bin"
+    MINIBROWSER="$SCRIPT_PATH/WebKitBuild/Debug/bin/MiniBrowser"
   else
     echo "Cannot find a MiniBrowser.app in neither location" 1>&2
     exit 1


### PR DESCRIPTION
Clients may have WKDEBUG in their environment and we don't want to break because of that. Since Debug builds are only used for development we can have a separate pw_run_debug.sh which is configured with WKPATH in development environment. 