### PR TITLE
fix: allow email type in input for fill action

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -339,7 +339,7 @@ export const fillFunction = (node: Node) => {
   if (element.nodeName.toLowerCase() === 'input') {
     const input = element as HTMLInputElement;
     const type = input.getAttribute('type') || '';
-    const kTextInputTypes = new Set(['', 'password', 'search', 'tel', 'text', 'url']);
+    const kTextInputTypes = new Set(['', 'email', 'password', 'search', 'tel', 'text', 'url']);
     if (!kTextInputTypes.has(type.toLowerCase()))
       return 'Cannot fill input of type "' + type + '".';
     if (input.disabled)

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -977,7 +977,7 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
     });
     it('should throw on non-text inputs', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/textarea.html');
-      for (const type of ['email', 'number', 'date']) {
+      for (const type of ['color', 'number', 'date']) {
         await page.$eval('input', (input, type) => input.setAttribute('type', type), type);
         let error = null;
         await page.fill('input', '').catch(e => error = e);


### PR DESCRIPTION
I was trying out Studio after https://github.com/microsoft/playwright-studio/pull/309 and found an issue where the VSO login fails. Studio is not able to `fill` on inputs with type `email` - see screenshot below.

![Screen Shot 2020-01-02 at 1 07 38 PM](https://user-images.githubusercontent.com/284612/71693635-cf3a3f00-2d61-11ea-8de7-c9093c7f47a4.png)

Since email is a text-like input, I added it to the set of valid input types. Also updated the corresponding test. I'm not sure why it was there in the first place, and I might be missing something in understanding this.