### PR TITLE
chore: bump version to 0.9.9-post

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright",
-  "version": "0.9.8-post",
+  "version": "0.9.9-post",
   "description": "A high-level API to control web browsers",
   "repository": "github:Microsoft/playwright",
   "engines": {


### PR DESCRIPTION
Creating a new release to try Studio changes after #353. I'll run `npm pub` after merge. Let me know if there's a better way to release a new version.