### PR TITLE
chore(webkit): move target management to WKPageProxy

### DIFF
--- a/src/webkit/wkAccessibility.ts
+++ b/src/webkit/wkAccessibility.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import * as accessibility from '../accessibility';
-import { WKTargetSession } from './wkConnection';
+import { WKSession } from './wkConnection';
 import { Protocol } from './protocol';
 
-export async function getAccessibilityTree(session: WKTargetSession) {
+export async function getAccessibilityTree(session: WKSession) {
   const {axNode} = await session.send('Page.accessibilitySnapshot');
   return new WKAXNode(axNode);
 }

--- a/src/webkit/wkInput.ts
+++ b/src/webkit/wkInput.ts
@@ -18,7 +18,7 @@
 import * as input from '../input';
 import { helper } from '../helper';
 import { macEditingCommands } from '../usKeyboardLayout';
-import { WKPageProxySession, WKTargetSession } from './wkConnection';
+import { WKPageProxySession, WKSession } from './wkConnection';
 
 function toModifiersMask(modifiers: Set<input.Modifier>): number {
   // From Source/WebKit/Shared/WebEvent.h
@@ -36,13 +36,13 @@ function toModifiersMask(modifiers: Set<input.Modifier>): number {
 
 export class RawKeyboardImpl implements input.RawKeyboard {
   private readonly _pageProxySession: WKPageProxySession;
-  private _session: WKTargetSession;
+  private _session: WKSession;
 
   constructor(session: WKPageProxySession) {
     this._pageProxySession = session;
   }
 
-  setSession(session: WKTargetSession) {
+  setSession(session: WKSession) {
     this._session = session;
   }
 

--- a/src/webkit/wkNetworkManager.ts
+++ b/src/webkit/wkNetworkManager.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { WKTargetSession, WKPageProxySession } from './wkConnection';
+import { WKSession, WKPageProxySession } from './wkConnection';
 import { Page } from '../page';
 import { helper, RegisteredListener, assert } from '../helper';
 import { Protocol } from './protocol';
@@ -27,7 +27,7 @@ import * as platform from '../platform';
 export class WKNetworkManager {
   private readonly _page: Page;
   private readonly _pageProxySession: WKPageProxySession;
-  private _session: WKTargetSession;
+  private _session: WKSession;
   private readonly _requestIdToRequest = new Map<string, InterceptableRequest>();
   private _userCacheDisabled = false;
   private _sessionListeners: RegisteredListener[] = [];
@@ -41,7 +41,7 @@ export class WKNetworkManager {
     await this.authenticate(credentials);
   }
 
-  setSession(session: WKTargetSession) {
+  setSession(session: WKSession) {
     helper.removeEventListeners(this._sessionListeners);
     this._session = session;
     this._sessionListeners = [
@@ -53,7 +53,7 @@ export class WKNetworkManager {
     ];
   }
 
-  async initializeSession(session: WKTargetSession, interceptNetwork: boolean | null, offlineMode: boolean | null) {
+  async initializeSession(session: WKSession, interceptNetwork: boolean | null, offlineMode: boolean | null) {
     const promises = [];
     promises.push(session.send('Network.enable'));
     if (interceptNetwork)
@@ -188,14 +188,14 @@ const errorReasons: { [reason: string]: string } = {
 };
 
 class InterceptableRequest implements network.RequestDelegate {
-  private _session: WKTargetSession;
+  private _session: WKSession;
   readonly request: network.Request;
   _requestId: string;
   _documentId: string | undefined;
   _interceptedCallback: () => void;
   private _interceptedPromise: Promise<unknown>;
 
-  constructor(session: WKTargetSession, allowInterception: boolean, frame: frames.Frame | null, event: Protocol.Network.requestWillBeSentPayload, redirectChain: network.Request[], documentId: string | undefined) {
+  constructor(session: WKSession, allowInterception: boolean, frame: frames.Frame | null, event: Protocol.Network.requestWillBeSentPayload, redirectChain: network.Request[], documentId: string | undefined) {
     this._session = session;
     this._requestId = event.requestId;
     this._documentId = documentId;

--- a/src/webkit/wkPageProxy.ts
+++ b/src/webkit/wkPageProxy.ts
@@ -5,10 +5,15 @@
 import { BrowserContext } from '../browserContext';
 import { Page } from '../page';
 import { Protocol } from './protocol';
-import { WKPageProxySession, WKPageProxySessionEvents, WKTargetSession } from './wkConnection';
+import { WKPageProxySession, WKSession } from './wkConnection';
 import { WKPage } from './wkPage';
 import { RegisteredListener, helper, assert, debugError } from '../helper';
 import { Events } from '../events';
+
+// We keep provisional messages on the session instace until provisional
+// target is committed. Non-provisional target (there should be just one)
+// has undefined instead.
+const provisionalMessagesSymbol = Symbol('provisionalMessages');
 
 export class WKPageProxy {
   private readonly _pageProxySession: WKPageProxySession;
@@ -17,7 +22,7 @@ export class WKPageProxy {
   private _wkPage: WKPage | null = null;
   private readonly _firstTargetPromise: Promise<void>;
   private _firstTargetCallback: () => void;
-  private readonly _targetSessions = new Map<string, WKTargetSession>();
+  private readonly _sessions = new Map<string, WKSession>();
   private readonly _eventListeners: RegisteredListener[];
 
   constructor(session: WKPageProxySession, browserContext: BrowserContext) {
@@ -25,9 +30,10 @@ export class WKPageProxy {
     this._browserContext = browserContext;
     this._firstTargetPromise = new Promise(r => this._firstTargetCallback = r);
     this._eventListeners = [
-      helper.addEventListener(this._pageProxySession, WKPageProxySessionEvents.TargetCreated, this._onTargetCreated.bind(this)),
-      helper.addEventListener(this._pageProxySession, WKPageProxySessionEvents.TargetDestroyed, this._onTargetDestroyed.bind(this)),
-      helper.addEventListener(this._pageProxySession, WKPageProxySessionEvents.DidCommitProvisionalTarget, this._onProvisionalTargetCommitted.bind(this))
+      helper.addEventListener(this._pageProxySession, 'Target.targetCreated', this._onTargetCreated.bind(this)),
+      helper.addEventListener(this._pageProxySession, 'Target.targetDestroyed', this._onTargetDestroyed.bind(this)),
+      helper.addEventListener(this._pageProxySession, 'Target.dispatchMessageFromTarget', this._onDispatchMessageFromTarget.bind(this)),
+      helper.addEventListener(this._pageProxySession, 'Target.didCommitProvisionalTarget', this._onDidCommitProvisionalTarget.bind(this)),
     ];
 
     // Intercept provisional targets during cross-process navigation.
@@ -41,6 +47,9 @@ export class WKPageProxy {
 
   dispose() {
     helper.removeEventListeners(this._eventListeners);
+    for (const session of this._sessions.values())
+      session.dispose();
+    this._sessions.clear();
   }
 
   async page(): Promise<Page> {
@@ -59,10 +68,10 @@ export class WKPageProxy {
 
   private async _initializeWKPage(): Promise<Page> {
     await this._firstTargetPromise;
-    let session: WKTargetSession;
-    for (const targetSession of this._targetSessions.values()) {
-      if (!targetSession.isProvisional()) {
-        session = targetSession;
+    let session: WKSession;
+    for (const anySession of this._sessions.values()) {
+      if (!(anySession as any)[provisionalMessagesSymbol]) {
+        session = anySession;
         break;
       }
     }
@@ -71,35 +80,70 @@ export class WKPageProxy {
     this._wkPage.setSession(session);
     await Promise.all([
       this._wkPage._initializePageProxySession(),
-      this._wkPage._initializeSession(session)
+      this._wkPage._initializeSession(session, false),
     ]);
     return this._wkPage._page;
   }
 
-  private _onTargetCreated(session: WKTargetSession, targetInfo: Protocol.Target.TargetInfo) {
+  private _onTargetCreated(event: Protocol.Target.targetCreatedPayload) {
+    const { targetInfo } = event;
+    const session = new WKSession(this._pageProxySession._connection, targetInfo.targetId, `The ${targetInfo.type} has been closed.`, (message: any) => {
+      this._pageProxySession.send('Target.sendMessageToTarget', {
+        message: JSON.stringify(message), targetId: targetInfo.targetId
+      }).catch(e => {
+        session.dispatchMessage({ id: message.id, error: { message: e.message } });
+      });
+    });
     assert(targetInfo.type === 'page', 'Only page targets are expected in WebKit, received: ' + targetInfo.type);
-    this._targetSessions.set(targetInfo.targetId, session);
+    this._sessions.set(targetInfo.targetId, session);
     if (this._firstTargetCallback) {
       this._firstTargetCallback();
       this._firstTargetCallback = null;
     }
+    if (targetInfo.isProvisional)
+      (session as any)[provisionalMessagesSymbol] = [];
     if (targetInfo.isProvisional && this._wkPage)
-      this._wkPage._initializeSession(session);
+      this._wkPage._initializeSession(session, true);
     if (targetInfo.isPaused)
       this._pageProxySession.send('Target.resume', { targetId: targetInfo.targetId }).catch(debugError);
   }
 
-  private _onTargetDestroyed({targetId, crashed}) {
-    const targetSession = this._targetSessions.get(targetId);
-    this._targetSessions.delete(targetId);
+  private _onTargetDestroyed(event: Protocol.Target.targetDestroyedPayload) {
+    const { targetId, crashed } = event;
+    const session = this._sessions.get(targetId);
+    if (session)
+      session.dispose();
+    this._sessions.delete(targetId);
     if (!this._wkPage)
       return;
-    if (this._wkPage._session === targetSession)
+    if (this._wkPage._session === session)
       this._wkPage.didClose(crashed);
   }
 
-  private _onProvisionalTargetCommitted({oldTargetId, newTargetId}) {
-    const newTargetSession = this._targetSessions.get(newTargetId);
-    this._wkPage.setSession(newTargetSession);
+  private _onDispatchMessageFromTarget(event: Protocol.Target.dispatchMessageFromTargetPayload) {
+    const { targetId, message } = event;
+    const session = this._sessions.get(targetId);
+    assert(session, 'Unknown target: ' + targetId);
+    const provisionalMessages = (session as any)[provisionalMessagesSymbol];
+    if (provisionalMessages)
+      provisionalMessages.push(message);
+    else
+      session.dispatchMessage(JSON.parse(message));
+  }
+
+  private _onDidCommitProvisionalTarget(event: Protocol.Target.didCommitProvisionalTargetPayload) {
+    const { oldTargetId, newTargetId } = event;
+    const newSession = this._sessions.get(newTargetId);
+    assert(newSession, 'Unknown new target: ' + newTargetId);
+    const oldSession = this._sessions.get(oldTargetId);
+    assert(oldSession, 'Unknown old target: ' + oldTargetId);
+    // TODO: make some calls like screenshot catch swapped out error and retry.
+    oldSession.errorText = 'Target was swapped out.';
+    const provisionalMessages = (newSession as any)[provisionalMessagesSymbol];
+    assert(provisionalMessages, 'Committing target must be provisional');
+    (newSession as any)[provisionalMessagesSymbol] = undefined;
+    for (const message of provisionalMessages)
+      newSession.dispatchMessage(JSON.parse(message));
+    this._wkPage.setSession(newSession);
   }
 }

--- a/src/webkit/wkWorkers.ts
+++ b/src/webkit/wkWorkers.ts
@@ -17,7 +17,7 @@
 import { helper, RegisteredListener } from '../helper';
 import { Page, Worker } from '../page';
 import { Protocol } from './protocol';
-import { WKSession, WKTargetSession } from './wkConnection';
+import { WKSession } from './wkConnection';
 import { WKExecutionContext } from './wkExecutionContext';
 
 export class WKWorkers {
@@ -29,7 +29,7 @@ export class WKWorkers {
     this._page = page;
   }
 
-  setSession(session: WKTargetSession) {
+  setSession(session: WKSession) {
     helper.removeEventListeners(this._sessionListeners);
     this._page._clearWorkers();
     this._workerSessions.clear();
@@ -73,7 +73,7 @@ export class WKWorkers {
     ];
   }
 
-  async initializeSession(session: WKTargetSession) {
+  async initializeSession(session: WKSession) {
     await session.send('Worker.enable');
   }
 


### PR DESCRIPTION
This allows to remove WKTargetSession and use WKSession instead.