### PR TITLE
test: add a failing test for Page.waitForLoadState

### DIFF
--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -764,6 +764,16 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       response.end('Not found');
       await navigationPromise;
     });
+    it.skip(WEBKIT || FFOX)('should work with pages that have loaded before being connected to', async({page, context, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(async () => {
+        const child = window.open(document.location.href);
+        while(child.document.readyState !== 'complete' || child.document.location.href === 'about:blank')
+          await new Promise(setTimeout);
+      });
+      const [, childPage] = await context.pages();
+      await childPage.waitForLoadState();
+    });
   });
 
   describe('Page.goBack', function() {

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -172,8 +172,7 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
       expect(await page.evaluate(() => !!window.opener)).toBe(false);
       expect(await popup.evaluate(() => !!window.opener)).toBe(false);
     });
-    // Crashes with Target closed on WebKit / Linux.
-    it('should not treat navigations as new popups', async({page, server}) => {
+    it.skip(WEBKIT || FFOX)('should not treat navigations as new popups', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       await page.setContent('<a target=_blank rel=noopener href="/one-style.html">yo</a>');
       const [popup] = await Promise.all([


### PR DESCRIPTION
Firefox and WebKit are not reporting lifecycle events if we connect late, causing a test to timeout sometimes. I added a failing test to consistently reproduce the problem.