### PR TITLE
feat(firefox): roll firefox to r1012

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "index.js",
   "playwright": {
     "chromium_revision": "724623",
-    "firefox_revision": "1011",
+    "firefox_revision": "1012",
     "webkit_revision": "1087"
   },
   "scripts": {

--- a/src/firefox/ffAccessibility.ts
+++ b/src/firefox/ffAccessibility.ts
@@ -35,7 +35,7 @@ class FFAXNode implements accessibility.AXNode {
   private _role: string;
   private _cachedHasFocusableChild: boolean|undefined;
 
-  constructor(payload: Protocol.AXTree) {
+  constructor(payload: Protocol.Accessibility.AXTree) {
     this._payload = payload;
     this._children = (payload.children || []).map(x => new FFAXNode(x));
     this._editable = !!payload.editable;

--- a/src/firefox/ffExecutionContext.ts
+++ b/src/firefox/ffExecutionContext.ts
@@ -173,7 +173,7 @@ function checkException(exceptionDetails?: any) {
   }
 }
 
-export function deserializeValue({unserializableValue, value}: Protocol.RemoteObject) {
+export function deserializeValue({unserializableValue, value}: Protocol.Runtime.RemoteObject) {
   if (unserializableValue === 'Infinity')
     return Infinity;
   if (unserializableValue === '-Infinity')

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -260,12 +260,13 @@ export class FFPage implements PageDelegate {
     await this._session.send('Page.close', { runBeforeUnload });
   }
 
-  getBoundingBoxForScreenshot(handle: dom.ElementHandle<Node>): Promise<types.Rect | null> {
+  async getBoundingBoxForScreenshot(handle: dom.ElementHandle<Node>): Promise<types.Rect | null> {
     const frameId = handle._context.frame._id;
-    return this._session.send('Page.getBoundingBox', {
+    const response = await this._session.send('Page.getBoundingBox', {
       frameId,
       objectId: handle._remoteObject.objectId,
     });
+    return response.boundingBox;
   }
 
   canScreenshotOutsideViewport(): boolean {
@@ -373,6 +374,6 @@ export function normalizeWaitUntil(waitUntil: frames.LifecycleEvent | frames.Lif
   return waitUntil;
 }
 
-function toRemoteObject(handle: dom.ElementHandle): Protocol.RemoteObject {
+function toRemoteObject(handle: dom.ElementHandle): Protocol.Runtime.RemoteObject {
   return handle._remoteObject;
 }

--- a/utils/protocol-types-generator/index.js
+++ b/utils/protocol-types-generator/index.js
@@ -162,7 +162,7 @@ async function generateFirefoxProtocol(revision) {
       return {"$type": "ref", "$ref": schemeName };
     }
   }
-  const json = vm.runInContext(`(${inject})();${protocolJSCode}; this.protocol.types = types; this.protocol;`, ctx);
+  const json = vm.runInContext(`(${inject})();${protocolJSCode}; this.protocol;`, ctx);
   fs.writeFileSync(outputPath, firefoxJSONToTS(json));
   console.log(`Wrote protocol.ts for Firefox to ${path.relative(process.cwd(), outputPath)}`);
 }
@@ -170,10 +170,10 @@ async function generateFirefoxProtocol(revision) {
 function firefoxJSONToTS(json) {
   const domains = Object.entries(json.domains);
   return `// This is generated from /utils/protocol-types-generator/index.js
-export module Protocol {${Object.entries(json.types).map(([typeName, type]) => `
-  export type ${typeName} = ${firefoxTypeToString(type, '  ')};`).join('')}
+export module Protocol {
 ${domains.map(([domainName, domain]) => `
-  export module ${domainName} {${(Object.entries(domain.events)).map(([eventName, event]) => `
+  export module ${domainName} {${Object.entries(domain.types).map(([typeName, type]) => `
+    export type ${typeName} = ${firefoxTypeToString(type, '    ')};`).join('')}${(Object.entries(domain.events)).map(([eventName, event]) => `
     export type ${eventName}Payload = ${firefoxTypeToString(event)}`).join('')}${(Object.entries(domain.methods)).map(([commandName, command]) => `
     export type ${commandName}Parameters = ${firefoxTypeToString(command.params)};
     export type ${commandName}ReturnValue = ${firefoxTypeToString(command.returns)};`).join('')}


### PR DESCRIPTION
This roll puts Firefox protocol types under related protocol domains,
so protocol type generator had to be updated as well.