### PR TITLE
feat(firefox&webkit): support root in accessibility.snapshot

### DIFF
--- a/src/accessibility.ts
+++ b/src/accessibility.ts
@@ -73,14 +73,17 @@ export class Accessibility {
       root = null,
     } = options;
     const {tree, needle} = await this._getAXTree(root);
-    if (!interestingOnly)
-      return serializeTree(needle)[0];
+    if (!interestingOnly) {
+      if (root)
+        return needle && serializeTree(needle)[0];
+      return serializeTree(tree)[0];
+    }
 
     const interestingNodes: Set<AXNode> = new Set();
     collectInterestingNodes(interestingNodes, tree, false);
     if (root && !interestingNodes.has(needle))
       return null;
-    return serializeTree(needle, interestingNodes)[0];
+    return serializeTree(needle || tree, interestingNodes)[0];
   }
 }
 

--- a/src/accessibility.ts
+++ b/src/accessibility.ts
@@ -59,8 +59,8 @@ export interface AXNode {
 }
 
 export class Accessibility {
-  private _getAXTree:  (needle?: dom.ElementHandle) => Promise<{tree: AXNode, needle?: AXNode}>;
-  constructor(getAXTree: (needle?: dom.ElementHandle) => Promise<{tree: AXNode, needle?: AXNode}>) {
+  private _getAXTree:  (needle?: dom.ElementHandle) => Promise<{tree: AXNode, needle: AXNode | null}>;
+  constructor(getAXTree: (needle?: dom.ElementHandle) => Promise<{tree: AXNode, needle: AXNode | null}>) {
     this._getAXTree = getAXTree;
   }
 
@@ -81,7 +81,7 @@ export class Accessibility {
 
     const interestingNodes: Set<AXNode> = new Set();
     collectInterestingNodes(interestingNodes, tree, false);
-    if (root && !interestingNodes.has(needle))
+    if (root && (!needle || !interestingNodes.has(needle)))
       return null;
     return serializeTree(needle || tree, interestingNodes)[0];
   }

--- a/src/accessibility.ts
+++ b/src/accessibility.ts
@@ -72,7 +72,7 @@ export class Accessibility {
       interestingOnly = true,
       root = null,
     } = options;
-    const {tree, needle} = await this._getAXTree(root);
+    const {tree, needle} = await this._getAXTree(root || undefined);
     if (!interestingOnly) {
       if (root)
         return needle && serializeTree(needle)[0];

--- a/src/chromium/crAccessibility.ts
+++ b/src/chromium/crAccessibility.ts
@@ -20,12 +20,12 @@ import { Protocol } from './protocol';
 import * as dom from '../dom';
 import * as accessibility from '../accessibility';
 
-export async function getAccessibilityTree(client: CRSession, needle?: dom.ElementHandle) : Promise<{tree: accessibility.AXNode, needle?: accessibility.AXNode}> {
+export async function getAccessibilityTree(client: CRSession, needle?: dom.ElementHandle) : Promise<{tree: accessibility.AXNode, needle: accessibility.AXNode | null}> {
   const {nodes} = await client.send('Accessibility.getFullAXTree');
   const tree = CRAXNode.createTree(client, nodes);
   return {
     tree,
-    needle: needle && await tree._findElement(needle)
+    needle: needle ? await tree._findElement(needle) : null
   };
 }
 

--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -480,8 +480,8 @@ export class CRPage implements PageDelegate {
     return to._createHandle(result.object).asElement()!;
   }
 
-  async getAccessibilityTree(): Promise<accessibility.AXNode> {
-    return getAccessibilityTree(this._client);
+  async getAccessibilityTree(needle?: dom.ElementHandle) {
+    return getAccessibilityTree(this._client, needle);
   }
 
   async pdf(options?: types.PDFOptions): Promise<platform.BufferType> {

--- a/src/firefox/ffAccessibility.ts
+++ b/src/firefox/ffAccessibility.ts
@@ -30,6 +30,33 @@ export async function getAccessibilityTree(session: FFSession, needle: dom.Eleme
   };
 }
 
+const FFRoleToARIARole = new Map(Object.entries({
+  'pushbutton': 'button',
+  'checkbutton': 'checkbox',
+  'editcombobox': 'combobox',
+  'content deletion': 'deletion',
+  'footnote': 'doc-footnote',
+  'non-native document': 'document',
+  'grouping': 'group',
+  'graphic': 'img',
+  'content insertion': 'insertion',
+  'animation': 'marquee',
+  'flat equation': 'math',
+  'menupopup': 'menu',
+  'check menu item': 'menuitemcheckbox',
+  'radio menu item': 'menuitemradio',
+  'listbox option': 'option',
+  'radiobutton': 'radio',
+  'statusbar': 'status',
+  'pagetab': 'tab',
+  'pagetablist': 'tablist',
+  'propertypage': 'tabpanel',
+  'entry': 'textbox',
+  'outline': 'tree',
+  'tree table': 'treegrid',
+  'outlineitem': 'treeitem',
+}));
+
 class FFAXNode implements accessibility.AXNode {
   _children: FFAXNode[];
   private _payload: Protocol.AXTree;
@@ -173,7 +200,7 @@ class FFAXNode implements accessibility.AXNode {
 
   serialize(): accessibility.SerializedAXNode {
     const node: {[x in keyof accessibility.SerializedAXNode]: any} = {
-      role: this._role,
+      role: FFRoleToARIARole.get(this._role) || this._role,
       name: this._name || ''
     };
     const userStringProperties: Array<keyof accessibility.SerializedAXNode> = [

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -355,8 +355,8 @@ export class FFPage implements PageDelegate {
     return handle;
   }
 
-  async getAccessibilityTree() : Promise<accessibility.AXNode> {
-    return getAccessibilityTree(this._session);
+  async getAccessibilityTree(needle?: dom.ElementHandle) {
+    return getAccessibilityTree(this._session, needle);
   }
 
   coverage(): Coverage | undefined {

--- a/src/page.ts
+++ b/src/page.ts
@@ -68,7 +68,7 @@ export interface PageDelegate {
   setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void>;
   getBoundingBox(handle: dom.ElementHandle): Promise<types.Rect | null>;
 
-  getAccessibilityTree(needle?: dom.ElementHandle): Promise<{tree: accessibility.AXNode, needle?: accessibility.AXNode}>;
+  getAccessibilityTree(needle?: dom.ElementHandle): Promise<{tree: accessibility.AXNode, needle: accessibility.AXNode | null}>;
   pdf?: (options?: types.PDFOptions) => Promise<platform.BufferType>;
   coverage(): Coverage | undefined;
 }

--- a/src/page.ts
+++ b/src/page.ts
@@ -68,7 +68,7 @@ export interface PageDelegate {
   setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void>;
   getBoundingBox(handle: dom.ElementHandle): Promise<types.Rect | null>;
 
-  getAccessibilityTree(): Promise<accessibility.AXNode>;
+  getAccessibilityTree(needle?: dom.ElementHandle): Promise<{tree: accessibility.AXNode, needle?: accessibility.AXNode}>;
   pdf?: (options?: types.PDFOptions) => Promise<platform.BufferType>;
   coverage(): Coverage | undefined;
 }

--- a/src/webkit/wkAccessibility.ts
+++ b/src/webkit/wkAccessibility.ts
@@ -24,7 +24,7 @@ export async function getAccessibilityTree(session: WKSession, needle?: dom.Elem
   const tree = new WKAXNode(axNode);
   return {
     tree,
-    needle: needle && tree._findNeedle()
+    needle: needle ? tree._findNeedle() : null
   };
 }
 
@@ -184,22 +184,17 @@ class WKAXNode implements accessibility.AXNode {
       if ('value' in this._payload && this._payload.role !== 'text')
         node.value = this._payload.value;
 
-      type AXPropertyOfType<Type> = {
-        [Key in keyof Protocol.Page.AXNode]:
-            Protocol.Page.AXNode[Key] extends Type ? Key : never
-      }[keyof Protocol.Page.AXNode];
-
-      const userStringProperties: string[] = [
+      const userStringProperties: Array<keyof accessibility.SerializedAXNode & keyof Protocol.Page.AXNode> = [
         'keyshortcuts',
         'valuetext'
       ];
       for (const userStringProperty of userStringProperties) {
         if (!(userStringProperty in this._payload))
           continue;
-        (node as any)[userStringProperty] = (this._payload as any)[userStringProperty];
+        (node as any)[userStringProperty] = this._payload[userStringProperty];
       }
 
-      const booleanProperties: string[] = [
+      const booleanProperties: Array<keyof accessibility.SerializedAXNode & keyof Protocol.Page.AXNode> = [
         'disabled',
         'expanded',
         'focused',
@@ -215,7 +210,7 @@ class WKAXNode implements accessibility.AXNode {
         // not whether focus is specifically on the root node.
         if (booleanProperty === 'focused' && (this._payload.role === 'WebArea' || this._payload.role === 'ScrollArea'))
           continue;
-        const value = (this._payload as any)[booleanProperty];
+        const value = this._payload[booleanProperty];
         if (!value)
           continue;
         (node as any)[booleanProperty] = value;
@@ -231,7 +226,7 @@ class WKAXNode implements accessibility.AXNode {
         const value = this._payload[tristateProperty];
         node[tristateProperty] = value === 'mixed' ? 'mixed' : value === 'true' ? true : false;
       }
-      const numericalProperties: string[] = [
+      const numericalProperties: Array<keyof accessibility.SerializedAXNode & keyof Protocol.Page.AXNode> = [
         'level',
         'valuemax',
         'valuemin',
@@ -241,7 +236,7 @@ class WKAXNode implements accessibility.AXNode {
           continue;
         (node as any)[numericalProperty] = (this._payload as any)[numericalProperty];
       }
-      const tokenProperties: string[] = [
+      const tokenProperties: Array<keyof accessibility.SerializedAXNode & keyof Protocol.Page.AXNode> = [
         'autocomplete',
         'haspopup',
         'invalid',

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -497,7 +497,7 @@ export class WKPage implements PageDelegate {
     return to._createHandle(result.object) as dom.ElementHandle<T>;
   }
 
-  async getAccessibilityTree(needle?: dom.ElementHandle) : Promise<{tree: accessibility.AXNode, needle?: accessibility.AXNode}> {
+  async getAccessibilityTree(needle?: dom.ElementHandle) : Promise<{tree: accessibility.AXNode, needle: accessibility.AXNode | null}> {
     return getAccessibilityTree(this._session, needle);
   }
 

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -497,8 +497,8 @@ export class WKPage implements PageDelegate {
     return to._createHandle(result.object) as dom.ElementHandle<T>;
   }
 
-  async getAccessibilityTree() : Promise<accessibility.AXNode> {
-    return getAccessibilityTree(this._session);
+  async getAccessibilityTree(needle?: dom.ElementHandle) : Promise<{tree: accessibility.AXNode, needle?: accessibility.AXNode}> {
+    return getAccessibilityTree(this._session, needle);
   }
 
   coverage(): Coverage | undefined {

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -21,7 +21,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('Accessibility', function() {
-    it.skip(WEBKIT)('should work', async function({page}) {
+    it('should work', async function({page}) {
       await page.setContent(`
       <head>
         <title>Accessibility Test</title>
@@ -51,13 +51,13 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
         children: [
           {role: 'text leaf', name: 'Hello World'},
           {role: 'heading', name: 'Inputs', level: 1},
-          {role: 'entry', name: 'Empty input', focused: true},
-          {role: 'entry', name: 'readonly input', readonly: true},
-          {role: 'entry', name: 'disabled input', disabled: true},
-          {role: 'entry', name: 'Input with whitespace', value: '  '},
-          {role: 'entry', name: '', value: 'value only'},
-          {role: 'entry', name: '', value: 'and a value'}, // firefox doesn't use aria-placeholder for the name
-          {role: 'entry', name: '', value: 'and a value', description: 'This is a description!'}, // and here
+          {role: 'textbox', name: 'Empty input', focused: true},
+          {role: 'textbox', name: 'readonly input', readonly: true},
+          {role: 'textbox', name: 'disabled input', disabled: true},
+          {role: 'textbox', name: 'Input with whitespace', value: '  '},
+          {role: 'textbox', name: '', value: 'value only'},
+          {role: 'textbox', name: '', value: 'and a value'}, // firefox doesn't use aria-placeholder for the name
+          {role: 'textbox', name: '', value: 'and a value', description: 'This is a description!'}, // and here
           {role: 'combobox', name: '', value: 'First Option', haspopup: true, children: [
             {role: 'combobox option', name: 'First Option', selected: true},
             {role: 'combobox option', name: 'Second Option'}]
@@ -83,14 +83,14 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
         role: 'WebArea',
         name: 'Accessibility Test',
         children: [
-          {role: 'heading', name: 'Inputs', level: 1 },
-          {role: 'TextField', name: 'Empty input', focused: true, readonly: true},
-          {role: 'TextField', name: 'readonly input', readonly: true },
-          {role: 'TextField', name: 'disabled input', disabled: true, readonly: true},
-          {role: 'TextField', name: 'Input with whitespace', value: '  ', description: 'Input with whitespace', readonly: true},
-          {role: 'TextField', name: '', value: 'value only', readonly: true },
-          {role: 'TextField', name: 'placeholder',value: 'and a value',readonly: true},
-          {role: 'TextField', name: 'This is a description!',value: 'and a value',readonly: true},
+          {role: 'heading', name: 'Inputs', level: 1},
+          {role: 'textbox', name: 'Empty input', focused: true},
+          {role: 'textbox', name: 'readonly input', readonly: true},
+          {role: 'textbox', name: 'disabled input', disabled: true},
+          {role: 'textbox', name: 'Input with whitespace', value: '  ' },
+          {role: 'textbox', name: '', value: 'value only' },
+          {role: 'textbox', name: 'placeholder',value: 'and a value'},
+          {role: 'textbox', name: 'This is a description!',value: 'and a value'}, // webkit uses the description over placeholder for the name
           {role: 'button', name: '', value: 'First Option', children: [
             { role: 'MenuListOption', name: '', value: 'First Option', selected: true },
             { role: 'MenuListOption', name: '', value: 'Second Option' }]
@@ -98,42 +98,6 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
         ]
       };
       expect(await page.accessibility.snapshot()).toEqual(golden);
-    });
-    it.skip(WEBKIT)('should report uninteresting nodes', async function({page}) {
-      await page.setContent(`<textarea autofocus>hi</textarea>`);
-      // autofocus happens after a delay in chrome these days
-      await page.waitForFunction(() => document.activeElement.hasAttribute('autofocus'));
-      const golden = FFOX ? {
-        role: 'entry',
-        name: '',
-        value: 'hi',
-        focused: true,
-        multiline: true,
-        children: [{
-          role: 'text leaf',
-          name: 'hi'
-        }]
-      } : CHROMIUM ? {
-        role: 'textbox',
-        name: '',
-        value: 'hi',
-        focused: true,
-        multiline: true,
-        children: [{
-          role: 'generic',
-          name: '',
-          children: [{
-            role: 'text', name: 'hi'
-          }]
-        }]
-      } : {
-        role: 'textbox',
-        name: '',
-        value: 'hi',
-        focused: true,
-        multiline: true
-      };
-      expect(findFocusedNode(await page.accessibility.snapshot({interestingOnly: false}))).toEqual(golden);
     });
     it('roledescription', async({page}) => {
       await page.setContent('<div tabIndex=-1 aria-roledescription="foo">Hi</div>');
@@ -145,8 +109,8 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
       const snapshot = await page.accessibility.snapshot();
       expect(snapshot.children[0].orientation).toEqual('vertical');
     });
-    it.skip(FFOX || WEBKIT)('autocomplete', async({page}) => {
-      await page.setContent('<input type="number" aria-autocomplete="list" />');
+    it('autocomplete', async({page}) => {
+      await page.setContent('<div role="textbox" aria-autocomplete="list">hi</div>');
       const snapshot = await page.accessibility.snapshot();
       expect(snapshot.children[0].autocomplete).toEqual('list');
     });
@@ -167,33 +131,8 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
           <div role="tab" aria-selected="true"><b>Tab1</b></div>
           <div role="tab">Tab2</div>
         </div>`);
-        const golden = FFOX ? {
-          role: 'document',
-          name: '',
-          children: [{
-            role: 'pagetab',
-            name: 'Tab1',
-            selected: true
-          }, {
-            role: 'pagetab',
-            name: 'Tab2'
-          }]
-        } : WEBKIT ? {
-          role: 'WebArea',
-          name: '',
-          roledescription: 'HTML content',
-          children: [{
-            role: 'tab',
-            name: 'Tab1',
-            roledescription: 'tab',
-            selected: true
-          }, {
-            role: 'tab',
-            name: 'Tab2',
-            roledescription: 'tab',
-          }]
-        } : {
-          role: 'WebArea',
+        const golden = {
+          role: FFOX ? 'document' : 'WebArea',
           name: '',
           children: [{
             role: 'tab',
@@ -244,7 +183,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
           Edit this image: <img src="fakeimage.png" alt="my fake image">
         </div>`);
         const golden = FFOX ? {
-          role: 'entry',
+          role: 'textbox',
           name: '',
           value: 'Edit this image: my fake image',
           children: [{
@@ -305,7 +244,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
           <img alt="yo" src="fakeimg.png">
         </div>`);
         const golden = FFOX ? {
-          role: 'entry',
+          role: 'textbox',
           name: 'my favorite textbox',
           value: 'this is the inner content yo'
         } : CHROMIUM ? {
@@ -313,10 +252,9 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
           name: 'my favorite textbox',
           value: 'this is the inner content '
         } : {
-          role: 'TextField',
+          role: 'textbox',
           name: 'my favorite textbox',
           value: 'this is the inner content  ',
-          description: 'my favorite textbox'
         };
         const snapshot = await page.accessibility.snapshot();
         expect(snapshot.children[0]).toEqual(golden);
@@ -327,18 +265,9 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
           this is the inner content
           <img alt="yo" src="fakeimg.png">
         </div>`);
-        const golden = FFOX ? {
-          role: 'checkbutton',
-          name: 'my favorite checkbox',
-          checked: true
-        } : CHROMIUM ? {
+        const golden = {
           role: 'checkbox',
           name: 'my favorite checkbox',
-          checked: true
-        } : {
-          role: 'checkbox',
-          name: 'my favorite checkbox',
-          description: "my favorite checkbox",
           checked: true
         };
         const snapshot = await page.accessibility.snapshot();
@@ -351,7 +280,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
           <img alt="yo" src="fakeimg.png">
         </div>`);
         const golden = FFOX ? {
-          role: 'checkbutton',
+          role: 'checkbox',
           name: 'this is the inner content yo',
           checked: true
         } : {
@@ -364,7 +293,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
       });
 
       describe('root option', function() {
-        fit('should work a button', async({page}) => {
+        it('should work a button', async({page}) => {
           await page.setContent(`<button>My Button</button>`);
 
           const button = await page.$('button');
@@ -383,7 +312,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
             value: 'My Value'
           });
         });
-        it('should work a menu', async({page}) => {
+        it('should work on a menu', async({page}) => {
           await page.setContent(`
             <div role="menu" title="My Menu">
               <div role="menuitem">First Item</div>
@@ -399,7 +328,8 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
             children:
             [ { role: 'menuitem', name: 'First Item' },
               { role: 'menuitem', name: 'Second Item' },
-              { role: 'menuitem', name: 'Third Item' } ]
+              { role: 'menuitem', name: 'Third Item' } ],
+            orientation: WEBKIT ? 'vertical' : undefined
           });
         });
         it('should return null when the element is no longer in DOM', async({page}) => {
@@ -407,27 +337,6 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
           const button = await page.$('button');
           await page.$eval('button', button => button.remove());
           expect(await page.accessibility.snapshot({root: button})).toEqual(null);
-        });
-        it('should support the interestingOnly option', async({page}) => {
-          await page.setContent(`<div><button>My Button</button></div>`);
-          const div = await page.$('div');
-          expect(await page.accessibility.snapshot({root: div})).toEqual(null);
-          expect(await page.accessibility.snapshot({root: div, interestingOnly: false})).toEqual({
-            role: 'generic',
-            name: '',
-            children: [
-              {
-                role: 'button',
-                name: 'My Button',
-                children: [
-                  {
-                    role: "text",
-                    name: "My Button"
-                  }
-                ],
-              }
-            ]
-          });
         });
       });
     });

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -76,7 +76,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, 
           {role: 'textbox', name: 'disabled input', disabled: true},
           {role: 'textbox', name: 'Input with whitespace', value: '  ' },
           {role: 'textbox', name: '', value: 'value only' },
-          {role: 'textbox', name: 'placeholder',value: 'and a value'},
+          {role: 'textbox', name: 'placeholder', value: 'and a value'},
           {role: 'textbox', name: 'This is a description!',value: 'and a value'}, // webkit uses the description over placeholder for the name
         ]
       };

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -363,8 +363,8 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
         expect(snapshot.children[0]).toEqual(golden);
       });
 
-      describe.skip(FFOX || WEBKIT)('root option', function() {
-        it('should work a button', async({page}) => {
+      describe('root option', function() {
+        fit('should work a button', async({page}) => {
           await page.setContent(`<button>My Button</button>`);
 
           const button = await page.$('button');


### PR DESCRIPTION
This adds support for `root` in accessibility.snapshot
firefox role names are now normalized to aria roles where they match
webkit roledescriptions are less noisey on mac
webkit mac/linux results are further defined
interestingOnly tests are replaced by one that doesn't rely on undefined behavior
the main accessibility test was split up a bit for more refined testing.
