### PR TITLE
test: disable flaky redirect loop test

### DIFF
--- a/test/screenshot.spec.js
+++ b/test/screenshot.spec.js
@@ -181,7 +181,8 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       const screenshot = await page.screenshot();
       expect(screenshot).toBeGolden('screenshot-webgl.png');
     });
-    it('should work while navigating', async({page, server}) => {
+    // firefox and webkit are flaky
+    it.skip(FFOX || WEBKIT)('should work while navigating', async({page, server}) => {
       await page.setViewport({width: 500, height: 500});
       await page.goto(server.PREFIX + '/redirectloop1.html');
       for (let i = 0; i < 10; i++) {


### PR DESCRIPTION
These flake on the bots in firefox. Running 100 times and in parallel to replicate locally. Fails with either `Missing injected script for given executionContextId` in webkit or `Navigation to http://localhost:8907/redirectloop1.html was canceled by another one` in firefox.