### PR TITLE
chore: npm packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,9 +10,6 @@ lib/injected/
 !lib/**/*.d.ts
 !index.d.ts
 
-# Install
-!install.js
-
 # root for "playwright" package
 !index.js
 

--- a/.npmignore
+++ b/.npmignore
@@ -10,8 +10,11 @@ lib/injected/
 !lib/**/*.d.ts
 !index.d.ts
 
-# root for "playwright" package
+# used for npm install scripts
+!download-browser.js
+
+# root for "playwright-core" package
 !index.js
 
-# root for "playwright/web"
+# root for "playwright-core/web"
 !web.js

--- a/download-browser.js
+++ b/download-browser.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+async function downloadBrowser(browser) {
+  const playwright = require('.')[browser];
+  let progressBar = null;
+  let lastDownloadedBytes = 0;
+  function onProgress(downloadedBytes, totalBytes) {
+    if (!progressBar) {
+      const ProgressBar = require('progress');
+      progressBar = new ProgressBar(`Downloading ${browser} ${playwright._revision} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `, {
+        complete: '=',
+        incomplete: ' ',
+        width: 20,
+        total: totalBytes,
+      });
+    }
+    const delta = downloadedBytes - lastDownloadedBytes;
+    lastDownloadedBytes = downloadedBytes;
+    progressBar.tick(delta);
+  }
+
+  const fetcher = playwright._createBrowserFetcher();
+  const revisionInfo = fetcher.revisionInfo();
+  // Do nothing if the revision is already downloaded.
+  if (revisionInfo.local)
+    return revisionInfo;
+  await fetcher.download(revisionInfo.revision, onProgress);
+  logPolitely(`${browser} downloaded to ${revisionInfo.folderPath}`);
+  return revisionInfo;
+}
+
+
+function toMegabytes(bytes) {
+  const mb = bytes / 1024 / 1024;
+  return `${Math.round(mb * 10) / 10} Mb`;
+}
+
+function logPolitely(toBeLogged) {
+  const logLevel = process.env.npm_config_loglevel;
+  const logLevelDisplay = ['silent', 'error', 'warn'].indexOf(logLevel) > -1;
+
+  if (!logLevelDisplay)
+    console.log(toBeLogged);
+}
+
+module.exports = {downloadBrowser};

--- a/install-development.js
+++ b/install-development.js
@@ -25,31 +25,24 @@ try {
 }
 
 (async function() {
-  let protocolGenerator;
-  try {
-    protocolGenerator = require('./utils/protocol-types-generator');
-  } catch (e) {
-    // Release mode
-  }
+  const protocolGenerator = require('./utils/protocol-types-generator');
   try {
     const chromeRevision = await downloadBrowser('chromium', require('./index').chromium);
-    if (protocolGenerator)
-      await protocolGenerator.generateChromiunProtocol(chromeRevision);
+    await protocolGenerator.generateChromiunProtocol(chromeRevision);
   } catch (e) {
     console.warn(e.message);
   }
 
   try {
     const firefoxRevision = await downloadBrowser('firefox', require('./index').firefox);
-    if (protocolGenerator)
-      await protocolGenerator.generateFirefoxProtocol(firefoxRevision);
+    await protocolGenerator.generateFirefoxProtocol(firefoxRevision);
   } catch (e) {
     console.warn(e.message);
   }
+
   try {
     const webkitRevision = await downloadBrowser('webkit', require('./index').webkit);
-    if (protocolGenerator)
-      await protocolGenerator.generateWebKitProtocol(webkitRevision);
+    await protocolGenerator.generateWebKitProtocol(webkitRevision);
   } catch (e) {
     console.warn(e.message);
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "debug-unit": "node --inspect-brk test/test.js",
     "test-doclint": "node utils/doclint/check_public_api/test/test.js && node utils/doclint/preprocessor/test.js",
     "test": "npm run lint --silent && npm run coverage && npm run test-doclint && node utils/testrunner/test/test.js",
-    "install": "node -e \"try { require('./install-development.js'); } catch(e) { }\"",
+    "prepare": "node prepare.js",
     "lint": "([ \"$CI\" = true ] && eslint --quiet -f codeframe --ext js,ts ./src || eslint --ext js,ts ./src) && npm run tsc && npm run doc",
     "doc": "node utils/doclint/cli.js",
     "coverage": "cross-env COVERAGE=true npm run unit",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "node utils/runWebpack.js --mode='development' && tsc -p .",
     "watch": "node utils/runWebpack.js --mode='development' --watch --silent | tsc -w -p .",
     "apply-next-version": "node utils/apply_next_version.js",
-    "sync-versions": "node utils/sync_package_versions.js"
+    "version": "node utils/sync_package_versions.js"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "debug-unit": "node --inspect-brk test/test.js",
     "test-doclint": "node utils/doclint/check_public_api/test/test.js && node utils/doclint/preprocessor/test.js",
     "test": "npm run lint --silent && npm run coverage && npm run test-doclint && node utils/testrunner/test/test.js",
-    "install": "node install.js",
+    "install": "node -e \"try { require('./install-development.js'); } catch(e) { }\"",
     "lint": "([ \"$CI\" = true ] && eslint --quiet -f codeframe --ext js,ts ./src || eslint --ext js,ts ./src) && npm run tsc && npm run doc",
     "doc": "node utils/doclint/cli.js",
     "coverage": "cross-env COVERAGE=true npm run unit",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "playwright",
+  "name": "playwright-core",
   "version": "0.9.17-post",
   "description": "A high-level API to automate web browsers",
   "repository": "github:Microsoft/playwright",
@@ -28,7 +28,8 @@
     "tsc": "tsc -p .",
     "build": "node utils/runWebpack.js --mode='development' && tsc -p .",
     "watch": "node utils/runWebpack.js --mode='development' --watch --silent | tsc -w -p .",
-    "apply-next-version": "node utils/apply_next_version.js"
+    "apply-next-version": "node utils/apply_next_version.js",
+    "sync-versions": "node utils/sync_package_versions.js"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-chromium/README.md
+++ b/packages/playwright-chromium/README.md
@@ -1,0 +1,2 @@
+# playwright-chromium
+This packagage contains the [Chromium](https://www.chromium.org/) flavor of [Playwright](http://github.com/microsoft/playwright).

--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -1,0 +1,1 @@
+module.exports = require('playwright-core').chromium;

--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -1,1 +1,16 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module.exports = require('playwright-core').chromium;

--- a/packages/playwright-chromium/install.js
+++ b/packages/playwright-chromium/install.js
@@ -1,0 +1,39 @@
+downloadBrowser('chromium', require('./index').chromium);
+
+async function downloadBrowser(browser, playwright) {
+  let progressBar = null;
+  let lastDownloadedBytes = 0;
+  function onProgress(downloadedBytes, totalBytes) {
+    if (!progressBar) {
+      const ProgressBar = require('progress');
+      progressBar = new ProgressBar(`Downloading ${browser} ${playwright._revision} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `, {
+        complete: '=',
+        incomplete: ' ',
+        width: 20,
+        total: totalBytes,
+      });
+    }
+    const delta = downloadedBytes - lastDownloadedBytes;
+    lastDownloadedBytes = downloadedBytes;
+    progressBar.tick(delta);
+  }
+
+  const fetcher = playwright._createBrowserFetcher();
+  const revisionInfo = fetcher.revisionInfo();
+  await fetcher.download(revisionInfo.revision, onProgress);
+  logPolitely(`${browser} downloaded to ${revisionInfo.folderPath}`);
+}
+
+function toMegabytes(bytes) {
+  const mb = bytes / 1024 / 1024;
+  return `${Math.round(mb * 10) / 10} Mb`;
+}
+
+function logPolitely(toBeLogged) {
+  const logLevel = process.env.npm_config_loglevel;
+  const logLevelDisplay = ['silent', 'error', 'warn'].indexOf(logLevel) > -1;
+
+  if (!logLevelDisplay)
+    console.log(toBeLogged);
+}
+

--- a/packages/playwright-chromium/install.js
+++ b/packages/playwright-chromium/install.js
@@ -1,39 +1,17 @@
-downloadBrowser('chromium', require('./index').chromium);
-
-async function downloadBrowser(browser, playwright) {
-  let progressBar = null;
-  let lastDownloadedBytes = 0;
-  function onProgress(downloadedBytes, totalBytes) {
-    if (!progressBar) {
-      const ProgressBar = require('progress');
-      progressBar = new ProgressBar(`Downloading ${browser} ${playwright._revision} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `, {
-        complete: '=',
-        incomplete: ' ',
-        width: 20,
-        total: totalBytes,
-      });
-    }
-    const delta = downloadedBytes - lastDownloadedBytes;
-    lastDownloadedBytes = downloadedBytes;
-    progressBar.tick(delta);
-  }
-
-  const fetcher = playwright._createBrowserFetcher();
-  const revisionInfo = fetcher.revisionInfo();
-  await fetcher.download(revisionInfo.revision, onProgress);
-  logPolitely(`${browser} downloaded to ${revisionInfo.folderPath}`);
-}
-
-function toMegabytes(bytes) {
-  const mb = bytes / 1024 / 1024;
-  return `${Math.round(mb * 10) / 10} Mb`;
-}
-
-function logPolitely(toBeLogged) {
-  const logLevel = process.env.npm_config_loglevel;
-  const logLevelDisplay = ['silent', 'error', 'warn'].indexOf(logLevel) > -1;
-
-  if (!logLevelDisplay)
-    console.log(toBeLogged);
-}
-
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const {downloadBrowser} = require('playwright-core/download-browser');
+downloadBrowser('chromium');

--- a/packages/playwright-chromium/package.json
+++ b/packages/playwright-chromium/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-chromium",
   "version": "0.9.17-post",
-  "description": "A high-level API to automate web browsers",
+  "description": "A high-level API to automate Chromium",
   "repository": "github:Microsoft/playwright",
   "main": "index.js",
   "scripts": {

--- a/packages/playwright-chromium/package.json
+++ b/packages/playwright-chromium/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "playwright-chromium",
+  "version": "0.9.17-post",
+  "description": "A high-level API to automate web browsers",
+  "repository": "github:Microsoft/playwright",
+  "main": "index.js",
+  "scripts": {
+    "install": "node install.js"
+  },
+  "author": {
+    "name": "Microsoft Corporation"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "playwright-core": "=0.9.17-post"
+  }
+}

--- a/packages/playwright-firefox/README.md
+++ b/packages/playwright-firefox/README.md
@@ -1,0 +1,2 @@
+# playwright-firefox
+This packagage contains the [Firefox](https://www.mozilla.org/firefox/) flavor of [Playwright](http://github.com/microsoft/playwright).

--- a/packages/playwright-firefox/index.js
+++ b/packages/playwright-firefox/index.js
@@ -1,1 +1,16 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module.exports = require('playwright-core').firefox;

--- a/packages/playwright-firefox/index.js
+++ b/packages/playwright-firefox/index.js
@@ -1,0 +1,1 @@
+module.exports = require('playwright-core').firefox;

--- a/packages/playwright-firefox/install.js
+++ b/packages/playwright-firefox/install.js
@@ -1,39 +1,17 @@
-downloadBrowser('firefox', require('./index').firefox);
-
-async function downloadBrowser(browser, playwright) {
-  let progressBar = null;
-  let lastDownloadedBytes = 0;
-  function onProgress(downloadedBytes, totalBytes) {
-    if (!progressBar) {
-      const ProgressBar = require('progress');
-      progressBar = new ProgressBar(`Downloading ${browser} ${playwright._revision} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `, {
-        complete: '=',
-        incomplete: ' ',
-        width: 20,
-        total: totalBytes,
-      });
-    }
-    const delta = downloadedBytes - lastDownloadedBytes;
-    lastDownloadedBytes = downloadedBytes;
-    progressBar.tick(delta);
-  }
-
-  const fetcher = playwright._createBrowserFetcher();
-  const revisionInfo = fetcher.revisionInfo();
-  await fetcher.download(revisionInfo.revision, onProgress);
-  logPolitely(`${browser} downloaded to ${revisionInfo.folderPath}`);
-}
-
-function toMegabytes(bytes) {
-  const mb = bytes / 1024 / 1024;
-  return `${Math.round(mb * 10) / 10} Mb`;
-}
-
-function logPolitely(toBeLogged) {
-  const logLevel = process.env.npm_config_loglevel;
-  const logLevelDisplay = ['silent', 'error', 'warn'].indexOf(logLevel) > -1;
-
-  if (!logLevelDisplay)
-    console.log(toBeLogged);
-}
-
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const {downloadBrowser} = require('playwright-core/download-browser');
+downloadBrowser('firefox');

--- a/packages/playwright-firefox/install.js
+++ b/packages/playwright-firefox/install.js
@@ -1,0 +1,39 @@
+downloadBrowser('firefox', require('./index').firefox);
+
+async function downloadBrowser(browser, playwright) {
+  let progressBar = null;
+  let lastDownloadedBytes = 0;
+  function onProgress(downloadedBytes, totalBytes) {
+    if (!progressBar) {
+      const ProgressBar = require('progress');
+      progressBar = new ProgressBar(`Downloading ${browser} ${playwright._revision} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `, {
+        complete: '=',
+        incomplete: ' ',
+        width: 20,
+        total: totalBytes,
+      });
+    }
+    const delta = downloadedBytes - lastDownloadedBytes;
+    lastDownloadedBytes = downloadedBytes;
+    progressBar.tick(delta);
+  }
+
+  const fetcher = playwright._createBrowserFetcher();
+  const revisionInfo = fetcher.revisionInfo();
+  await fetcher.download(revisionInfo.revision, onProgress);
+  logPolitely(`${browser} downloaded to ${revisionInfo.folderPath}`);
+}
+
+function toMegabytes(bytes) {
+  const mb = bytes / 1024 / 1024;
+  return `${Math.round(mb * 10) / 10} Mb`;
+}
+
+function logPolitely(toBeLogged) {
+  const logLevel = process.env.npm_config_loglevel;
+  const logLevelDisplay = ['silent', 'error', 'warn'].indexOf(logLevel) > -1;
+
+  if (!logLevelDisplay)
+    console.log(toBeLogged);
+}
+

--- a/packages/playwright-firefox/package.json
+++ b/packages/playwright-firefox/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "playwright-firefox",
+  "version": "0.9.17-post",
+  "description": "A high-level API to automate web browsers",
+  "repository": "github:Microsoft/playwright",
+  "main": "index.js",
+  "scripts": {
+    "install": "node install.js"
+  },
+  "author": {
+    "name": "Microsoft Corporation"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "playwright-core": "=0.9.17-post"
+  }
+}

--- a/packages/playwright-firefox/package.json
+++ b/packages/playwright-firefox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-firefox",
   "version": "0.9.17-post",
-  "description": "A high-level API to automate web browsers",
+  "description": "A high-level API to automate Firefox",
   "repository": "github:Microsoft/playwright",
   "main": "index.js",
   "scripts": {

--- a/packages/playwright-webkit/README.md
+++ b/packages/playwright-webkit/README.md
@@ -1,0 +1,2 @@
+# playwright-webkit
+This packagage contains the [WebKit](https://www.webkit.org/) flavor of [Playwright](http://github.com/microsoft/playwright).

--- a/packages/playwright-webkit/index.js
+++ b/packages/playwright-webkit/index.js
@@ -1,0 +1,1 @@
+module.exports = require('playwright-core').webkit;

--- a/packages/playwright-webkit/index.js
+++ b/packages/playwright-webkit/index.js
@@ -1,1 +1,16 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module.exports = require('playwright-core').webkit;

--- a/packages/playwright-webkit/install.js
+++ b/packages/playwright-webkit/install.js
@@ -1,39 +1,17 @@
-downloadBrowser('webkit', require('./index').webkit);
-
-async function downloadBrowser(browser, playwright) {
-  let progressBar = null;
-  let lastDownloadedBytes = 0;
-  function onProgress(downloadedBytes, totalBytes) {
-    if (!progressBar) {
-      const ProgressBar = require('progress');
-      progressBar = new ProgressBar(`Downloading ${browser} ${playwright._revision} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `, {
-        complete: '=',
-        incomplete: ' ',
-        width: 20,
-        total: totalBytes,
-      });
-    }
-    const delta = downloadedBytes - lastDownloadedBytes;
-    lastDownloadedBytes = downloadedBytes;
-    progressBar.tick(delta);
-  }
-
-  const fetcher = playwright._createBrowserFetcher();
-  const revisionInfo = fetcher.revisionInfo();
-  await fetcher.download(revisionInfo.revision, onProgress);
-  logPolitely(`${browser} downloaded to ${revisionInfo.folderPath}`);
-}
-
-function toMegabytes(bytes) {
-  const mb = bytes / 1024 / 1024;
-  return `${Math.round(mb * 10) / 10} Mb`;
-}
-
-function logPolitely(toBeLogged) {
-  const logLevel = process.env.npm_config_loglevel;
-  const logLevelDisplay = ['silent', 'error', 'warn'].indexOf(logLevel) > -1;
-
-  if (!logLevelDisplay)
-    console.log(toBeLogged);
-}
-
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const {downloadBrowser} = require('playwright-core/download-browser');
+downloadBrowser('webkit');

--- a/packages/playwright-webkit/install.js
+++ b/packages/playwright-webkit/install.js
@@ -1,0 +1,39 @@
+downloadBrowser('webkit', require('./index').webkit);
+
+async function downloadBrowser(browser, playwright) {
+  let progressBar = null;
+  let lastDownloadedBytes = 0;
+  function onProgress(downloadedBytes, totalBytes) {
+    if (!progressBar) {
+      const ProgressBar = require('progress');
+      progressBar = new ProgressBar(`Downloading ${browser} ${playwright._revision} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `, {
+        complete: '=',
+        incomplete: ' ',
+        width: 20,
+        total: totalBytes,
+      });
+    }
+    const delta = downloadedBytes - lastDownloadedBytes;
+    lastDownloadedBytes = downloadedBytes;
+    progressBar.tick(delta);
+  }
+
+  const fetcher = playwright._createBrowserFetcher();
+  const revisionInfo = fetcher.revisionInfo();
+  await fetcher.download(revisionInfo.revision, onProgress);
+  logPolitely(`${browser} downloaded to ${revisionInfo.folderPath}`);
+}
+
+function toMegabytes(bytes) {
+  const mb = bytes / 1024 / 1024;
+  return `${Math.round(mb * 10) / 10} Mb`;
+}
+
+function logPolitely(toBeLogged) {
+  const logLevel = process.env.npm_config_loglevel;
+  const logLevelDisplay = ['silent', 'error', 'warn'].indexOf(logLevel) > -1;
+
+  if (!logLevelDisplay)
+    console.log(toBeLogged);
+}
+

--- a/packages/playwright-webkit/package.json
+++ b/packages/playwright-webkit/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "playwright-webkit",
+  "version": "0.9.17-post",
+  "description": "A high-level API to automate web browsers",
+  "repository": "github:Microsoft/playwright",
+  "main": "index.js",
+  "scripts": {
+    "install": "node install.js"
+  },
+  "author": {
+    "name": "Microsoft Corporation"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "playwright-core": "=0.9.17-post"
+  }
+}

--- a/packages/playwright-webkit/package.json
+++ b/packages/playwright-webkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-webkit",
   "version": "0.9.17-post",
-  "description": "A high-level API to automate web browsers",
+  "description": "A high-level API to automate WebKit",
   "repository": "github:Microsoft/playwright",
   "main": "index.js",
   "scripts": {

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -1,0 +1,2 @@
+# playwright
+This is a placeholder package for [Playwright](http://github.com/microsoft/playwright). Install one of `playwright-chromium`, `playwright-webkit`, or `playwright-firefox` to use playwright.

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -1,2 +1,2 @@
 # playwright
-This is a placeholder package for [Playwright](http://github.com/microsoft/playwright). Install one of `playwright-chromium`, `playwright-webkit`, or `playwright-firefox` to use playwright.
+This packagage contains the [Chromium](https://www.chromium.org/), [Firefox](https://www.mozilla.org/firefox/) and [WebKit](https://www.webkit.org/) flavors of [Playwright](http://github.com/microsoft/playwright).

--- a/packages/playwright/index.js
+++ b/packages/playwright/index.js
@@ -13,9 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const {downloadBrowser} = require('playwright-core/download-browser');
-(async function() {
-  await downloadBrowser('chromium');
-  await downloadBrowser('firefox');
-  await downloadBrowser('webkit');
-})();
+module.exports = require('playwright-core');

--- a/packages/playwright/install.js
+++ b/packages/playwright/install.js
@@ -1,2 +1,17 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 console.error('This package, "playwright", is a placeholder. Please install "playwright-chromium", "playwright-firefox", or "playwright-webkit" to use playwright.');
 process.exit(1);

--- a/packages/playwright/install.js
+++ b/packages/playwright/install.js
@@ -1,0 +1,2 @@
+console.error('This package, "playwright", is a placeholder. Please install "playwright-chromium", "playwright-firefox", or "playwright-webkit" to use playwright.');
+process.exit(1);

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -10,5 +10,8 @@
   "author": {
     "name": "Microsoft Corporation"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "playwright-core": "=0.9.13-post"
+  }
 }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "playwright",
+  "version": "0.9.17-post",
+  "description": "A high-level API to automate web browsers",
+  "repository": "github:Microsoft/playwright",
+  "main": "index.js",
+  "scripts": {
+    "install": "node install.js"
+  },
+  "author": {
+    "name": "Microsoft Corporation"
+  },
+  "license": "Apache-2.0"
+}

--- a/prepare.js
+++ b/prepare.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
- // This file is only run when someone clones the github repo for development
+ // This file is only run when someone installs via the github repo
 
 try {
   console.log('Building playwright...');
@@ -56,6 +56,7 @@ async function downloadAndCleanup(browser) {
   // Remove previous revisions.
   const playwright = require('.')[browser];
   const fetcher = playwright._createBrowserFetcher();
+  const localRevisions = await fetcher.localRevisions();
   const cleanupOldVersions = localRevisions.filter(revision => revision !== revisionInfo.revision).map(revision => fetcher.remove(revision));
   await Promise.all([...cleanupOldVersions]);
 

--- a/utils/sync_package_versions.js
+++ b/utils/sync_package_versions.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const fs = require('fs');
+const path = require('path');
+const {version} = require('../package.json');
+updatePackage('playwright', packageJSON => {
+  packageJSON.version = version;
+});
+
+for (const packageName of ['playwright-chromium', 'playwright-firefox', 'playwright-webkit']) {
+  updatePackage(packageName, packageJSON => {
+    packageJSON.version = version;
+    packageJSON.dependencies['playwright-core'] = `=${version}`;
+  });
+}
+
+function updatePackage(packageName, transform) {
+  const packageJSONPath = path.join(__dirname, '..', 'packages', packageName, 'package.json');
+  console.log(`Updating ${packageJSONPath} to ${version}.`);
+  const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));
+  transform(packageJSON);
+  fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, undefined, 2) + '\n');
+}

--- a/utils/sync_package_versions.js
+++ b/utils/sync_package_versions.js
@@ -16,11 +16,8 @@
 const fs = require('fs');
 const path = require('path');
 const {version} = require('../package.json');
-updatePackage('playwright', packageJSON => {
-  packageJSON.version = version;
-});
 
-for (const packageName of ['playwright-chromium', 'playwright-firefox', 'playwright-webkit']) {
+for (const packageName of ['playwright-chromium', 'playwright-firefox', 'playwright-webkit', 'playwright']) {
   updatePackage(packageName, packageJSON => {
     packageJSON.version = version;
     packageJSON.dependencies['playwright-core'] = `=${version}`;


### PR DESCRIPTION
# Npm Packages

## playwright-chromium
- installs chromium
- exposes chromium api from playwright-core

## playwright-firefox
- installs firefox
- exposes firefox api from playwright-core

## playwright-webkit
- installs webkit
- exposes webkit api from playwright-core

## playwright-core
- downloads no browsers
- contains all of the js code
- designed for internal use

## playwright
- downloads all browsers
- exposes the entire api from playwright-core

## github
- downloads all browsers, generates protocol definitions, builds typescript
- exposes "playwright-core" api
