### PR TITLE
chore(packages): copy readme from root folder into packages/playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "node utils/runWebpack.js --mode='development' && tsc -p .",
     "watch": "node utils/runWebpack.js --mode='development' --watch --silent | tsc -w -p .",
     "apply-next-version": "node utils/apply_next_version.js",
-    "version": "node utils/sync_package_versions.js"
+    "version": "node utils/sync_package_versions.js && npm run doc"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright/.gitignore
+++ b/packages/playwright/.gitignore
@@ -1,0 +1,2 @@
+# copied from the root readme
+README.md

--- a/packages/playwright/.npmignore
+++ b/packages/playwright/.npmignore
@@ -1,0 +1,1 @@
+# empty to not exclude things in gitignore

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -1,2 +1,0 @@
-# playwright
-This packagage contains the [Chromium](https://www.chromium.org/), [Firefox](https://www.mozilla.org/firefox/) and [WebKit](https://www.webkit.org/) flavors of [Playwright](http://github.com/microsoft/playwright).

--- a/utils/doclint/Source.js
+++ b/utils/doclint/Source.js
@@ -100,6 +100,11 @@ class Source {
   async save() {
     await writeFileAsync(this.filePath(), this.text());
   }
+  
+  async saveAs(path) {
+    console.log(path);
+    await writeFileAsync(path, this.text());
+  }
 
   /**
    * @param {string} filePath

--- a/utils/doclint/Source.js
+++ b/utils/doclint/Source.js
@@ -102,7 +102,6 @@ class Source {
   }
   
   async saveAs(path) {
-    console.log(path);
     await writeFileAsync(path, this.text());
   }
 

--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -59,6 +59,8 @@ async function run() {
       await source.save();
       changedFiles = true;
     }
+    
+    await readme.saveAs(path.join(PROJECT_DIR, 'packages', 'playwright', 'README.md'));
   }
 
   // Report results.


### PR DESCRIPTION
This is quick way to get a nicer readme for the playwright package. Later we should do something to distinguish playwright vs playwright-core in the READMEs.