### PR TITLE
fix(firefox): be able to launch on headful+windows

### DIFF
--- a/src/server/ffPlaywright.ts
+++ b/src/server/ffPlaywright.ts
@@ -203,6 +203,8 @@ export class FFPlaywright implements Playwright {
       firefoxArguments.push('-profile', userDataDir);
     if (headless)
       firefoxArguments.push('-headless');
+    else
+      firefoxArguments.push('-wait-for-browser');
     firefoxArguments.push(...args);
     if (args.every(arg => arg.startsWith('-')))
       firefoxArguments.push('about:blank');


### PR DESCRIPTION
Without the `-wait-for-browser` flag, the launcher process immediately exits on windows. Because we listen to 'exit', we think the browser has closed.

We still can't close the Firefox process very well.