### PR TITLE
Update error message to point to existing docs

### DIFF
--- a/src/server/processLauncher.ts
+++ b/src/server/processLauncher.ts
@@ -166,7 +166,7 @@ export function waitForLine(process: childProcess.ChildProcess, inputStream: str
         'Failed to launch browser!' + (error ? ' ' + error.message : ''),
         stderr,
         '',
-        'TROUBLESHOOTING: https://github.com/Microsoft/playwright/blob/master/docs/troubleshooting.md',
+        'DOCUMENTATION: https://github.com/Microsoft/playwright/blob/master/docs/api.md',
         '',
       ].join('\n')));
     }


### PR DESCRIPTION
This change edits the suggested documentation message so that it points to a valid URL.

It makes sense that eventually we should write a troubleshooting doc. In the meantime, I think this is a reasonable alternative. Happy to point it somewhere else if it's desired.