### PR TITLE
fix(test): fix flaky interception test

### DIFF
--- a/test/interception.spec.js
+++ b/test/interception.spec.js
@@ -566,13 +566,17 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       await page.setRequestInterception(true);
       expect(await page.evaluate(() => navigator.onLine)).toBe(true);
       let intercepted;
-      page.on('request', async request => {
-        intercepted = true;
-        await page.setRequestInterception(false);
-      });
+      const finished = new Promise(callback => {
+        page.on('request', async request => {
+          intercepted = true;
+          await page.setRequestInterception(false);
+          callback();
+        });
+      })
       const response = await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
       expect(intercepted).toBe(true);
       expect(response.status()).toBe(200);
+      await finished;
     });
   });
 

--- a/test/interception.spec.js
+++ b/test/interception.spec.js
@@ -572,7 +572,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
           await page.setRequestInterception(false);
           callback();
         });
-      })
+      });
       const response = await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
       expect(intercepted).toBe(true);
       expect(response.status()).toBe(200);


### PR DESCRIPTION
This test was not awaiting turning off interception, and sometimes throwing unhandled promise rejections in later tests.