### PR TITLE
test(webkit): disable flaky offline test

### DIFF
--- a/test/interception.spec.js
+++ b/test/interception.spec.js
@@ -545,7 +545,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   });
 
   describe.skip(FFOX)('Interception.setOfflineMode', function() {
-    it('should work', async({page, server}) => {
+    it.skip(WEBKIT)('should work', async({page, server}) => {
       await page.setOfflineMode(true);
       let error = null;
       await page.goto(server.EMPTY_PAGE).catch(e => error = e);


### PR DESCRIPTION
This test sometimes fails by returning `null` from `page.goto`. I've seen it flake on the bots, and I can replicate it locally by running it repeatedly in parallel. Suspecting some internal race with how we handle webkit navigations.