### PR TITLE
chore(webkit): build wpe and gtk to different folders

### DIFF
--- a/browser_patches/webkit/archive.sh
+++ b/browser_patches/webkit/archive.sh
@@ -57,24 +57,24 @@ createZipForLinux() {
 
   if [[ -n $USE_WPE ]]; then
     # copy all relevant binaries
-    cp -t $tmpdir ./WebKitBuild/Release/bin/MiniBrowser ./WebKitBuild/Release/bin/WPE*Process
+    cp -t $tmpdir ./WebKitBuild/WPE/Release/bin/MiniBrowser ./WebKitBuild/WPE/Release/bin/WPE*Process
     # copy all relevant shared objects
-    LD_LIBRARY_PATH="$PWD/WebKitBuild/DependenciesWPE/Root/lib" ldd WebKitBuild/Release/bin/MiniBrowser | grep -o '[^ ]*WebKitBuild/[^ ]*' | xargs cp -t $tmpdir
-    LD_LIBRARY_PATH="$PWD/WebKitBuild/DependenciesWPE/Root/lib" ldd WebKitBuild/Release/bin/WPENetworkProcess | grep -o '[^ ]*WebKitBuild/[^ ]*' | xargs cp -t $tmpdir
-    LD_LIBRARY_PATH="$PWD/WebKitBuild/DependenciesWPE/Root/lib" ldd WebKitBuild/Release/bin/WPEWebProcess | grep -o '[^ ]*WebKitBuild/[^ ]*' | xargs cp -t $tmpdir
+    LD_LIBRARY_PATH="$PWD/WebKitBuild/WPE/DependenciesWPE/Root/lib" ldd WebKitBuild/WPE/Release/bin/MiniBrowser | grep -o '[^ ]*WebKitBuild/WPE/[^ ]*' | xargs cp -t $tmpdir
+    LD_LIBRARY_PATH="$PWD/WebKitBuild/WPE/DependenciesWPE/Root/lib" ldd WebKitBuild/WPE/Release/bin/WPENetworkProcess | grep -o '[^ ]*WebKitBuild/WPE/[^ ]*' | xargs cp -t $tmpdir
+    LD_LIBRARY_PATH="$PWD/WebKitBuild/WPE/DependenciesWPE/Root/lib" ldd WebKitBuild/WPE/Release/bin/WPEWebProcess | grep -o '[^ ]*WebKitBuild/WPE/[^ ]*' | xargs cp -t $tmpdir
     mkdir -p $tmpdir/gio/modules
-    cp -t $tmpdir/gio/modules $PWD/WebKitBuild/DependenciesWPE/Root/lib/gio/modules/*
+    cp -t $tmpdir/gio/modules $PWD/WebKitBuild/WPE/DependenciesWPE/Root/lib/gio/modules/*
 
     cd $tmpdir
     ln -s libWPEBackend-fdo-1.0.so.1 libWPEBackend-fdo-1.0.so
     cd -
   else
     # copy all relevant binaries
-    cp -t $tmpdir ./WebKitBuild/Release/bin/MiniBrowser ./WebKitBuild/Release/bin/WebKit*Process
+    cp -t $tmpdir ./WebKitBuild/GTK/Release/bin/MiniBrowser ./WebKitBuild/GTK/Release/bin/WebKit*Process
     # copy all relevant shared objects
-    LD_LIBRARY_PATH="$PWD/WebKitBuild/DependenciesGTK/Root/lib" ldd WebKitBuild/Release/bin/MiniBrowser | grep -o '[^ ]*WebKitBuild/[^ ]*' | xargs cp -t $tmpdir
+    LD_LIBRARY_PATH="$PWD/WebKitBuild/GTK/DependenciesGTK/Root/lib" ldd WebKitBuild/GTK/Release/bin/MiniBrowser | grep -o '[^ ]*WebKitBuild/GTK/[^ ]*' | xargs cp -t $tmpdir
     mkdir -p $tmpdir/gio/modules
-    cp -t $tmpdir/gio/modules $PWD/WebKitBuild/DependenciesGTK/Root/lib/gio/modules/*
+    cp -t $tmpdir/gio/modules $PWD/WebKitBuild/GTK/DependenciesGTK/Root/lib/gio/modules/*
 
     # we failed to nicely build libgdk_pixbuf - expect it in the env
     rm $tmpdir/libgdk_pixbuf*

--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-set +x
+set -x
 
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname $0)"
@@ -11,15 +11,15 @@ if [[ "$(uname)" == "Darwin" ]]; then
 elif [[ "$(uname)" == "Linux" ]]; then
   cd "checkout"
   if [[ "$1" == "--wpe" ]]; then
-    if ! [[ -d ./WebKitBuild/DependenciesWPE ]]; then
-      yes | DEBIAN_FRONTEND=noninteractive ./Tools/Scripts/update-webkitwpe-libs
+    if ! [[ -d ./WebKitBuild/WPE/DependenciesWPE ]]; then
+      yes | WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/WPE DEBIAN_FRONTEND=noninteractive ./Tools/Scripts/update-webkitwpe-libs
     fi
-    ./Tools/Scripts/build-webkit --wpe --release --touch-events MiniBrowser
+    WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/WPE ./Tools/Scripts/build-webkit --wpe --release --touch-events MiniBrowser
   else
-    if ! [[ -d ./WebKitBuild/DependenciesGTK ]]; then
-      yes | DEBIAN_FRONTEND=noninteractive ./Tools/Scripts/update-webkitgtk-libs
+    if ! [[ -d ./WebKitBuild/GTK/DependenciesGTK ]]; then
+      yes | WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/GTK DEBIAN_FRONTEND=noninteractive ./Tools/Scripts/update-webkitgtk-libs
     fi
-    ./Tools/Scripts/build-webkit --gtk --release --touch-events MiniBrowser
+    WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/GTK ./Tools/Scripts/build-webkit --gtk --release --touch-events MiniBrowser
   fi
 elif [[ "$(uname)" == MINGW* ]]; then
   /c/Windows/System32/cmd.exe "/c buildwin.bat"

--- a/browser_patches/webkit/clean.sh
+++ b/browser_patches/webkit/clean.sh
@@ -9,3 +9,9 @@ cd "checkout"
 if [[ -d ./WebKitBuild ]]; then
   rm -rf ./WebKitBuild/Release
 fi
+if [[ -d ./WebKitBuild/GTK ]]; then
+  rm -rf ./WebKitBuild/GTK/Release
+fi
+if [[ -d ./WebKitBuild/WPE ]]; then
+  rm -rf ./WebKitBuild/WPE/Release
+fi

--- a/browser_patches/webkit/pw_run.sh
+++ b/browser_patches/webkit/pw_run.sh
@@ -18,29 +18,31 @@ function runOSX() {
 
 function runLinux() {
   # if script is run as-is
-  DEPENDENCIES_FOLDER="DependenciesGTK"
+  DEPENDENCIES_FOLDER="DependenciesGTK";
   MINIBROWSER_FOLDER="minibrowser-gtk";
-  GIO_DIR=""
+  BUILD_FOLDER="WebKitBuild/GTK";
+  GIO_DIR="";
   if [[ "$*" == *--headless* ]]; then
     DEPENDENCIES_FOLDER="DependenciesWPE";
     MINIBROWSER_FOLDER="minibrowser-wpe";
+    BUILD_FOLDER="WebKitBuild/WPE";
   fi
   if [[ -d $SCRIPT_PATH/$MINIBROWSER_FOLDER ]]; then
     LD_PATH="$SCRIPT_PATH/$MINIBROWSER_FOLDER"
     GIO_DIR="$SCRIPT_PATH/$MINIBROWSER_FOLDER/gio/modules"
     MINIBROWSER="$SCRIPT_PATH/$MINIBROWSER_FOLDER/MiniBrowser"
-  elif [[ -d $SCRIPT_PATH/checkout/WebKitBuild ]]; then
-    LD_PATH="$SCRIPT_PATH/checkout/WebKitBuild/$DEPENDENCIES_FOLDER/Root/lib:$SCRIPT_PATH/checkout/WebKitBuild/Release/bin"
-    GIO_DIR="$SCRIPT_PATH/checkout/WebKitBuild/$DEPENDENCIES_FOLDER/Root/lib/gio/modules"
-    MINIBROWSER="$SCRIPT_PATH/checkout/WebKitBuild/Release/bin/MiniBrowser"
+  elif [[ -d $SCRIPT_PATH/checkout/$BUILD_FOLDER ]]; then
+    LD_PATH="$SCRIPT_PATH/checkout/$BUILD_FOLDER/$DEPENDENCIES_FOLDER/Root/lib:$SCRIPT_PATH/checkout/$BUILD_FOLDER/Release/bin"
+    GIO_DIR="$SCRIPT_PATH/checkout/$BUILD_FOLDER/$DEPENDENCIES_FOLDER/Root/lib/gio/modules"
+    MINIBROWSER="$SCRIPT_PATH/checkout/$BUILD_FOLDER/Release/bin/MiniBrowser"
   elif [[ -f $SCRIPT_PATH/MiniBrowser ]]; then
     LD_PATH="$SCRIPT_PATH"
     GIO_DIR="$SCRIPT_PATH/gio/modules"
     MINIBROWSER="$SCRIPT_PATH/MiniBrowser"
-  elif [[ -d $SCRIPT_PATH/WebKitBuild ]]; then
-    LD_PATH="$SCRIPT_PATH/WebKitBuild/$DEPENDENCIES_FOLDER/Root/lib:$SCRIPT_PATH/WebKitBuild/Release/bin"
-    GIO_DIR="$SCRIPT_PATH/WebKitBuild/$DEPENDENCIES_FOLDER/Root/lib/gio/modules"
-    MINIBROWSER="$SCRIPT_PATH/WebKitBuild/Release/bin/MiniBrowser"
+  elif [[ -d $SCRIPT_PATH/$BUILD_FOLDER ]]; then
+    LD_PATH="$SCRIPT_PATH/$BUILD_FOLDER/$DEPENDENCIES_FOLDER/Root/lib:$SCRIPT_PATH/$BUILD_FOLDER/Release/bin"
+    GIO_DIR="$SCRIPT_PATH/$BUILD_FOLDER/$DEPENDENCIES_FOLDER/Root/lib/gio/modules"
+    MINIBROWSER="$SCRIPT_PATH/$BUILD_FOLDER/Release/bin/MiniBrowser"
   else
     echo "Cannot find a MiniBrowser.app in neither location" 1>&2
     exit 1

--- a/browser_patches/webkit/pw_run_debug.sh
+++ b/browser_patches/webkit/pw_run_debug.sh
@@ -18,15 +18,15 @@ function runOSX() {
 
 function runLinux() {
   # if script is run as-is
-  if [ -d $SCRIPT_PATH/checkout/WebKitBuild ]; then
-    LD_PATH="$SCRIPT_PATH/checkout/WebKitBuild/DependenciesGTK/Root/lib:$SCRIPT_PATH/checkout/WebKitBuild/Debug/bin"
-    MINIBROWSER="$SCRIPT_PATH/checkout/WebKitBuild/Debug/bin/MiniBrowser"
+  if [ -d $SCRIPT_PATH/checkout/WebKitBuild/GTK ]; then
+    LD_PATH="$SCRIPT_PATH/checkout/WebKitBuild/GTK/DependenciesGTK/Root/lib:$SCRIPT_PATH/checkout/WebKitBuild/GTK/Debug/bin"
+    MINIBROWSER="$SCRIPT_PATH/checkout/WebKitBuild/GTK/Debug/bin/MiniBrowser"
   elif [ -f $SCRIPT_PATH/MiniBrowser ]; then
     LD_PATH="$SCRIPT_PATH"
     MINIBROWSER="$SCRIPT_PATH/MiniBrowser"
-  elif [ -d $SCRIPT_PATH/WebKitBuild ]; then
-    LD_PATH="$SCRIPT_PATH/WebKitBuild/DependenciesGTK/Root/lib:$SCRIPT_PATH/WebKitBuild/Debug/bin"
-    MINIBROWSER="$SCRIPT_PATH/WebKitBuild/Debug/bin/MiniBrowser"
+  elif [ -d $SCRIPT_PATH/WebKitBuild/GTK ]; then
+    LD_PATH="$SCRIPT_PATH/WebKitBuild/GTK/DependenciesGTK/Root/lib:$SCRIPT_PATH/WebKitBuild/GTK/Debug/bin"
+    MINIBROWSER="$SCRIPT_PATH/WebKitBuild/GTK/Debug/bin/MiniBrowser"
   else
     echo "Cannot find a MiniBrowser.app in neither location" 1>&2
     exit 1


### PR DESCRIPTION
Second try at #556. Uses absolute paths for the environment variables so that WPEDependencies builds properly. Switches from `WebKitBuildWPE` to `WebKitBuild/WPE` to avoid the need to change the .gitignore.

My computer takes a long time to build, but it appears to be working.