### PR TITLE
fix(types): export playwright-core types from playwright

### DIFF
--- a/packages/playwright/index.d.ts
+++ b/packages/playwright/index.d.ts
@@ -1,0 +1,1 @@
+export * from "playwright-core";


### PR DESCRIPTION
Resolves #627

I tested this works locally with `npm link`.