### PR TITLE
[DRAFT] feat(page): add pagecreated event to allow listening for new pages

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -41,6 +41,7 @@ export const Events = {
     FrameDetached: 'framedetached',
     FrameNavigated: 'framenavigated',
     Load: 'load',
+    PageCreated: 'pagecreated',
     Popup: 'popup',
     WebSocket: 'websocket',
     WorkerCreated: 'workercreated',

--- a/src/page.ts
+++ b/src/page.ts
@@ -139,6 +139,7 @@ export class Page extends platform.EventEmitter {
     if (delegate.pdf)
       this.pdf = delegate.pdf.bind(delegate);
     this.coverage = delegate.coverage();
+    this.emit(Events.Page.PageCreated);
   }
 
   _didClose() {


### PR DESCRIPTION
It would be nice to know when a page is created on a browser context.

I noticed BrowserContext is not an event emitter, so I am emitting just on Page right now. Happy to make those changes and add tests. 

But I wanted to open this PR first for discussion purposes, to see if that API change would be ok?