### PR TITLE
feat(unit): add click test on animated target

### DIFF
--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -374,5 +374,35 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       await page.click('button');
       expect(await page.evaluate('window.clicked')).toBe(true);
     });
+    it('should click on an animated button', async({page}) => {
+      const buttonSize = 50;
+      const containerWidth = 500;
+      const transition = 500;
+      await page.setContent(`
+      <html>
+      <body>
+      <div style="border: 1px solid black; height: 50px; overflow: auto; width: ${containerWidth}px;">
+      <button id="button" style="height: ${buttonSize}px; width: ${buttonSize}px; transition: left ${transition}ms linear 0s; left: 0; position: relative" onClick="window.clicked++">hi</button>
+      </div>
+      </body>
+      <script>
+      const animateLeft = () => {
+        const button = document.querySelector('#button');
+        document.querySelector('#button').style.left = button.style.left === '0px' ? '${containerWidth - buttonSize}px' : '0px';
+      };
+      window.clicked = 0;
+      window.setTimeout(animateLeft, 0);
+      window.setInterval(animateLeft, ${transition});
+      </script>
+      </html>
+      `);
+      await page.click('button');
+      expect(await page.evaluate('window.clicked')).toBe(1);
+      expect(await page.evaluate('document.querySelector("#button").style.left')).toBe(`${containerWidth - buttonSize}px`);
+      await new Promise(resolve => setTimeout(resolve, 500));
+      await page.click('button');
+      expect(await page.evaluate('window.clicked')).toBe(2);
+      expect(await page.evaluate('document.querySelector("#button").style.left')).toBe('0px');
+    });
   });
 };

--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -374,7 +374,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       await page.click('button');
       expect(await page.evaluate('window.clicked')).toBe(true);
     });
-    it('should click on an animated button', async({page}) => {
+    it.skip(true)('should click on an animated button', async({page}) => {
       const buttonSize = 50;
       const containerWidth = 500;
       const transition = 500;


### PR DESCRIPTION
Hi ✋,

First of all, thanks a ton for all the work done on this awesome project!

I was looking at this issue https://github.com/microsoft/playwright/issues/13 and immediately thought about giving the project a try and see how clicking on an CSS-animated element will behave. I have some solid experience with other e2e frameworks and clicking on an animated element is one of the most annoying thing to tackle.

It happens that this is already handled out of the box by playwright! I made a quick proof test to validate it, hence I created this small PR.

N.B.: I'd really love to contribute on fixing the aforementioned issue. Not sure though to fully get how the project wants to scope it. What I see as an issue is having e.g. a target you want to click on, hidden by some other animated `div` and then finally clickable.