### PR TITLE
feat(webkit): roll to r1011

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "playwright": {
     "chromium_revision": "733125",
     "firefox_revision": "1018",
-    "webkit_revision": "1112"
+    "webkit_revision": "1113"
   },
   "scripts": {
     "unit": "node test/test.js",


### PR DESCRIPTION
This roll fixes flakiness for the `Interception.setOfflineMode should
work` test. Follow-up to #656.