### PR TITLE
Example of broken types

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@
 const { helper } = require('./lib/helper');
 const api = require('./lib/api');
 const packageJson = require('./package.json');
-const DeviceDescriptors = require('./lib/deviceDescriptors');
+const { DeviceDescriptors } = require('./lib/deviceDescriptors');
 const { TimeoutError } = require('./lib/errors');
 const { Chromium } = require('./lib/server/chromium');
 const { Firefox } = require('./lib/server/firefox');

--- a/packages/playwright-test-types/.gitignore
+++ b/packages/playwright-test-types/.gitignore
@@ -1,0 +1,1 @@
+node_modules/**

--- a/packages/playwright-test-types/package.json
+++ b/packages/playwright-test-types/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "playwright-test-types",
+  "version": "0.0.0",
+  "description": "Check types",
+  "main": "index.js",
+  "scripts": {
+    "tsc": "tsc -p ."
+  },
+  "dependencies": {
+    "playwright-core": "^0.9.23"
+  }
+}

--- a/packages/playwright-test-types/src/index.ts
+++ b/packages/playwright-test-types/src/index.ts
@@ -1,0 +1,4 @@
+import assert from "assert";
+import playwright from "playwright-core";
+
+assert(playwright.devices["iPhone 7"]);

--- a/packages/playwright-test-types/tsconfig.json
+++ b/packages/playwright-test-types/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "commonjs",
+    "lib": ["esnext", "dom"],
+    "sourceMap": true,
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "strict": true,
+    "declaration": true
+  },
+  "compileOnSave": true,
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR is not intended to be merged, just an example of a top level export issue and types issue with `playwright-core@0.9.23` and typescript.

If you try to run `npm run build` in the `playwright-test-types` package you will see the types error

<img width="1471" alt="Screen Shot 2020-01-27 at 6 02 31 PM" src="https://user-images.githubusercontent.com/1136652/73227004-454a7f80-412f-11ea-86d1-4eb2d084bdba.png">

I think it would be useful to have a test that `playwright` can be imported by a typescript package and built, and to test top level exports like playwright.devices work.

I would be happy to add this test, if you could point me in the right direction of how you would like it to work with the test runner.