### PR TITLE
docs(api): fix cdp session creation example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3578,7 +3578,7 @@ Useful links:
 - Getting Started with DevTools Protocol: https://github.com/aslushnikov/getting-started-with-cdp/blob/master/README.md
 
 ```js
-const client = await browser.pageTarget(page).createCDPSession();
+const client = await chromium.pageTarget(page).createCDPSession();
 await client.send('Animation.enable');
 client.on('Animation.animationCreated', () => console.log('Animation created!'));
 const response = await client.send('Animation.getPlaybackRate');

--- a/docs/api.md
+++ b/docs/api.md
@@ -3578,7 +3578,7 @@ Useful links:
 - Getting Started with DevTools Protocol: https://github.com/aslushnikov/getting-started-with-cdp/blob/master/README.md
 
 ```js
-const client = await page.chromium.pageTarget(page).createCDPSession();
+const client = await browser.pageTarget(page).createCDPSession();
 await client.send('Animation.enable');
 client.on('Animation.animationCreated', () => console.log('Animation created!'));
 const response = await client.send('Animation.getPlaybackRate');


### PR DESCRIPTION
+ requires browser object instead of page to launch the cdp session. 