### PR TITLE
docs(api.md) Fix USKeyboardLayout link

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3847,7 +3847,7 @@ const { chromium } = require('playwright');
 [TimeoutError]: #class-timeouterror "TimeoutError"
 [UIEvent.detail]: https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail "UIEvent.detail"
 [URL]: https://nodejs.org/api/url.html
-[USKeyboardLayout]: ../lib/USKeyboardLayout.js "USKeyboardLayout"
+[USKeyboardLayout]: ../src/usKeyboardLayout.ts "USKeyboardLayout"
 [UnixTime]: https://en.wikipedia.org/wiki/Unix_time "Unix Time"
 [WebKitBrowser]: #class-webkitbrowser "WebKitBrowser"
 [WebSocket]: #class-websocket "WebSocket"


### PR DESCRIPTION
I noticed that the link for `USKeyboardLayout` in the docs was broken - I've updated it to point towards `./src/usKeyboardLayout.ts` instead