### PR TITLE
fix(webkit): do not poll readyState if target is paused before first navigation

### DIFF
--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -122,7 +122,7 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
     });
   });
 
-  describe('Page.Events.Popup', function() {
+  fdescribe('Page.Events.Popup', function() {
     it('should work', async({page}) => {
       const [popup] = await Promise.all([
         new Promise(x => page.once('popup', x)),

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -122,7 +122,7 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
     });
   });
 
-  fdescribe('Page.Events.Popup', function() {
+  describe('Page.Events.Popup', function() {
     it('should work', async({page}) => {
       const [popup] = await Promise.all([
         new Promise(x => page.once('popup', x)),


### PR DESCRIPTION
Follow-up fix for #690