### PR TITLE
feat: introduce BrowserType.name()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3402,6 +3402,7 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 - [browserType.executablePath()](#browsertypeexecutablepath)
 - [browserType.launch([options])](#browsertypelaunchoptions)
 - [browserType.launchBrowserApp([options])](#browsertypelaunchbrowserappoptions)
+- [browserType.name()](#browsertypename)
 <!-- GEN:stop -->
 
 #### browserType.connect(options)
@@ -3522,6 +3523,11 @@ const browser = await chromium.launch({  // Or 'firefox' or 'webkit'.
   - `webSocket` <[boolean]> Connects to the browser over a WebSocket instead of a pipe. Defaults to `false`.
   - `devtools` <[boolean]> **Chromium-only** Whether to auto-open a Developer Tools panel for each tab. If this option is `true`, the `headless` option will be set `false`.
 - returns: <[Promise]<[BrowserApp]>> Promise which resolves to the browser app instance.
+
+#### browserType.name()
+- returns: <[string]>
+
+Returns browser name. For example: `'chromium'`, `'webkit'` or `'firefox'`.
 
 ### class: ChromiumBrowser
 

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -41,6 +41,7 @@ export type LaunchOptions = BrowserArgOptions & {
 
 export interface BrowserType {
   executablePath(): string;
+  name(): string;
   launchBrowserApp(options?: LaunchOptions): Promise<BrowserApp>;
   launch(options?: LaunchOptions): Promise<Browser>;
   defaultArgs(options?: BrowserArgOptions): string[];

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -43,6 +43,10 @@ export class Chromium implements BrowserType {
     this._revision = preferredRevision;
   }
 
+  name() {
+    return 'chromium';
+  }
+
   async launch(options?: LaunchOptions): Promise<CRBrowser> {
     const app = await this.launchBrowserApp(options);
     const browser = await CRBrowser.connect(app.connectOptions());

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -42,6 +42,10 @@ export class Firefox implements BrowserType {
     this._revision = preferredRevision;
   }
 
+  name() {
+    return 'firefox';
+  }
+
   async launch(options?: LaunchOptions): Promise<FFBrowser> {
     const app = await this.launchBrowserApp(options);
     const browser = await FFBrowser.connect(app.connectOptions());

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -47,6 +47,10 @@ export class WebKit implements BrowserType {
     this._revision = preferredRevision;
   }
 
+  name() {
+    return 'webkit';
+  }
+
   async launch(options?: LaunchOptions): Promise<WKBrowser> {
     const app = await this.launchBrowserApp(options);
     const browser = await WKBrowser.connect(app.connectOptions());

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -81,6 +81,19 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       });
     });
 
+    describe('Playwright.name', function() {
+      it('should work', async({server}) => {
+        if (WEBKIT)
+          expect(playwright.name()).toBe('webkit');
+        else if (FFOX)
+          expect(playwright.name()).toBe('firefox');
+        else if (CHROMIUM)
+          expect(playwright.name()).toBe('chromium');
+        else
+          throw new Error('Unknown browser');
+      });
+    });
+
     describe('Playwright.defaultArguments', () => {
       it('should return the default arguments', async() => {
         if (CHROMIUM)


### PR DESCRIPTION
This helps a lot to produce nice logging:

```js
const { chromium, webkit } = require('playwright');

(async () => {
  for (const launcher of [chromium, webkit]) {
    console.log(`Testing on ${launcher.name()}`);
    const browser = await launcher.launch();
    // ...
    await browser.close();
  }
})();
```