### PR TITLE
test: enable passing modifiers test

### DIFF
--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -349,7 +349,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       expect(await page.evaluate(() => offsetY)).toBe(1910);
     });
 
-    it.skip(WEBKIT)('should update modifiers correctly', async({page, server}) => {
+    it('should update modifiers correctly', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/button.html');
       await page.click('button', { modifiers: ['Shift'] });
       expect(await page.evaluate(() => shiftKey)).toBe(true);


### PR DESCRIPTION
This test passes. Maybe at some point it failed on mac, but that has been fixed for a long time.