### PR TITLE
feat: lower the engine requirement to node 10.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A high-level API to automate web browsers",
   "repository": "github:Microsoft/playwright",
   "engines": {
-    "node": ">=10.17.0"
+    "node": ">=10.15.0"
   },
   "main": "index.js",
   "playwright": {


### PR DESCRIPTION
Some people are still on 10.15, like the Google cloud. We can relax our supported node version a little bit to support them.