### PR TITLE
tests(accessibility): Remove unused browser goldens

### DIFF
--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -234,18 +234,10 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, 
           this is the inner content
           <img alt="yo" src="fakeimg.png">
         </div>`);
-        const golden = FFOX ? {
-          role: 'textbox',
-          name: 'my favorite textbox',
-          value: 'this is the inner content yo'
-        } : CHROMIUM ? {
+        const golden = {
           role: 'textbox',
           name: 'my favorite textbox',
           value: 'this is the inner content '
-        } : {
-          role: 'textbox',
-          name: 'my favorite textbox',
-          value: 'this is the inner content  ',
         };
         const snapshot = await page.accessibility.snapshot();
         expect(snapshot.children[0]).toEqual(golden);
@@ -270,11 +262,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, 
           this is the inner content
           <img alt="yo" src="fakeimg.png">
         </div>`);
-        const golden = FFOX ? {
-          role: 'checkbox',
-          name: 'this is the inner content yo',
-          checked: true
-        } : {
+        const golden = {
           role: 'checkbox',
           name: 'this is the inner content yo',
           checked: true


### PR DESCRIPTION
Tell me if this makes sense.

Describe `plainttext contenteditable` [is not running on Firefox and Webkit](https://github.com/microsoft/playwright/blob/master/test/accessibility.spec.js#L201). Therefore we shouldn't need those specific node values. 