### PR TITLE
fix(test): unflake waitForSelector when browser closes test

### DIFF
--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -172,6 +172,10 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       const remote = await playwright.connect(browserApp.connectOptions());
       const page = await remote.defaultContext().newPage();
       const watchdog = page.waitForSelector('div', { timeout: 60000 }).catch(e => e);
+      
+      // Make sure the previous waitForSelector has time to make it to the browser before we disconnect.
+      await page.waitForSelector('body');
+
       await remote.disconnect();
       const error = await watchdog;
       expect(error.message).toContain('Protocol error');


### PR DESCRIPTION
The waitForSelector call might not have made it into the browser by the time we disconnect, resulting in a websocket error instead of a protocol error.