### PR TITLE
fix(firefox): roll firefox to 1021

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "index.js",
   "playwright": {
     "chromium_revision": "737027",
-    "firefox_revision": "1020",
+    "firefox_revision": "1021",
     "webkit_revision": "1124"
   },
   "scripts": {


### PR DESCRIPTION
This should make firefox accessibility tests more reliable, especially on mac.