### PR TITLE
fix(chromium): install libgbm

### DIFF
--- a/.github/workflows/chromium-linux.yml
+++ b/.github/workflows/chromium-linux.yml
@@ -25,6 +25,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: install required packages
       run: |
+        sudo apt-get install libgbm1
         sudo apt-get install xvfb
 
     - name: npm install, build, and test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ addons:
       - libevent-2.1-6
       - libnotify4
       - libxslt1.1
+    # This is required to run chromium
+      - libgbm1
+    # this is needed for running headful tests
       - xvfb
 notifications:
   email: false

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -81,6 +81,7 @@ libnss3
 lsb-release
 xdg-utils
 wget
+libgbm1
 ```
 </details>
 


### PR DESCRIPTION
The new Chromium (#771) requires [`libgbm1`](https://packages.debian.org/sid/libgbm1) to be installed. Install it manually on the bots, and add it to troubleshooting.md.