### PR TITLE
fix: do not recommend yarn

### DIFF
--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -248,7 +248,7 @@ export class Chromium implements BrowserType {
   _resolveExecutablePath(): { executablePath: string; missingText: string | null; } {
     const browserFetcher = this._createBrowserFetcher();
     const revisionInfo = browserFetcher.revisionInfo();
-    const missingText = !revisionInfo.local ? `Chromium revision is not downloaded. Run "npm install" or "yarn install"` : null;
+    const missingText = !revisionInfo.local ? `Chromium revision is not downloaded. Run "npm install"` : null;
     return { executablePath: revisionInfo.executablePath, missingText };
   }
 }

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -227,7 +227,7 @@ export class Firefox implements BrowserType {
   _resolveExecutablePath() {
     const browserFetcher = this._createBrowserFetcher();
     const revisionInfo = browserFetcher.revisionInfo();
-    const missingText = !revisionInfo.local ? `Firefox revision is not downloaded. Run "npm install" or "yarn install"` : null;
+    const missingText = !revisionInfo.local ? `Firefox revision is not downloaded. Run "npm install"` : null;
     return { executablePath: revisionInfo.executablePath, missingText };
   }
 }

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -218,7 +218,7 @@ export class WebKit implements BrowserType {
   _resolveExecutablePath(): { executablePath: string; missingText: string | null; } {
     const browserFetcher = this._createBrowserFetcher();
     const revisionInfo = browserFetcher.revisionInfo();
-    const missingText = !revisionInfo.local ? `WebKit revision is not downloaded. Run "npm install" or "yarn install"` : null;
+    const missingText = !revisionInfo.local ? `WebKit revision is not downloaded. Run "npm install"` : null;
     return { executablePath: revisionInfo.executablePath, missingText };
   }
 }


### PR DESCRIPTION
There's some confusion around Yarn vs Yarn 2 and their interop, which
apparently causes some [installation issues](https://stackoverflow.com/questions/59918776/playwright-error-firefox-revision-is-not-downloaded-run-npm-install-or-yarn).

Stop recommending "yarn install" if browser instances are not downloaded. 