### PR TITLE
feat: change vendor package exports

### DIFF
--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 module.exports = {
-  chromium: require('playwright-core').chromium;
-};
+  ...require('playwright-core'),
+  // Keep exporting Chromium and nullify other browsers.
+  webkit: undefined,
+  firefox: undefined,
+}

--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -13,4 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module.exports = require('playwright-core').chromium;
+module.exports = {
+  chromiuM: require('playwright-core').chromium;
+};

--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 module.exports = {
-  chromiuM: require('playwright-core').chromium;
+  chromium: require('playwright-core').chromium;
 };

--- a/packages/playwright-firefox/index.js
+++ b/packages/playwright-firefox/index.js
@@ -13,4 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module.exports = require('playwright-core').firefox;
+module.exports = {
+  firefox: require('playwright-core').firefox,
+};

--- a/packages/playwright-firefox/index.js
+++ b/packages/playwright-firefox/index.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 module.exports = {
-  firefox: require('playwright-core').firefox,
-};
+  ...require('playwright-core'),
+  // Keep exporting firefox and nullify other browsers.
+  chromium: undefined,
+  webkit: undefined,
+}

--- a/packages/playwright-webkit/index.js
+++ b/packages/playwright-webkit/index.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 module.exports = {
-  webkit: require('playwright-core').webkit,
-};
+  ...require('playwright-core'),
+  // Keep exporting webkit and nullify other browsers.
+  chromium: undefined,
+  firefox: undefined,
+}

--- a/packages/playwright-webkit/index.js
+++ b/packages/playwright-webkit/index.js
@@ -13,4 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module.exports = require('playwright-core').webkit;
+module.exports = {
+  webkit: require('playwright-core').webkit,
+};


### PR DESCRIPTION
This patch changes top-level exports for the vendor-specific
packages:
- `playwright-chromium`: now exports an object with a single `chromium`
field
- `playwright-wekbit`: now exports an object with a single `webkit`
- `playwright-firefox`: now exports an object with a single `firefox`

Fixes #814