### PR TITLE
fix: properly nullify error stacks

### DIFF
--- a/src/chromium/crProtocolHelper.ts
+++ b/src/chromium/crProtocolHelper.ts
@@ -101,6 +101,7 @@ export function toConsoleMessageLocation(stackTrace: Protocol.Runtime.StackTrace
 export function exceptionToError(exceptionDetails: Protocol.Runtime.ExceptionDetails): Error {
   const message = getExceptionMessage(exceptionDetails);
   const err = new Error(message);
-  err.stack = ''; // Don't report clientside error with a node stack attached
+  // Don't report clientside error with a node stack attached
+  err.stack = 'Error: ' + err.message; // Stack is supposed to contain error message as the first line.
   return err;
 }

--- a/src/page.ts
+++ b/src/page.ts
@@ -152,7 +152,8 @@ export class Page extends platform.EventEmitter {
 
   _didCrash() {
     const error = new Error('Page crashed!');
-    error.stack = '';
+    // Do not report node.js stack.
+    error.stack = 'Error: ' + error.message; // Stack is supposed to contain error message as the first line.
     this.emit('error', error);
   }
 

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -322,7 +322,7 @@ export class WKPage implements PageDelegate {
     }
     if (level === 'error' && source === 'javascript') {
       const error = new Error(text);
-      error.stack = '';
+      error.stack = 'Error: ' + error.message; // Nullify stack. Stack is supposed to contain error message as the first line.
       this._page.emit(Events.Page.PageError, error);
       return;
     }


### PR DESCRIPTION
`error.stack` is supposed to have error message as the first line.