### PR TITLE
chore(types): upgrade to typescript 3.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "pixelmatch": "^4.0.2",
     "text-diff": "^1.0.1",
     "ts-loader": "^6.1.2",
-    "typescript": "3.6.3",
+    "typescript": "^3.7.5",
     "webpack": "^4.41.0",
     "webpack-cli": "^3.3.9"
   },

--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -93,8 +93,8 @@ export class CRBrowser extends platform.EventEmitter implements Browser {
 
       close: async (): Promise<void> => {
         assert(contextId, 'Non-incognito profiles cannot be closed!');
-        await this._client.send('Target.disposeBrowserContext', { browserContextId: contextId! });
-        this._contexts.delete(contextId!);
+        await this._client.send('Target.disposeBrowserContext', { browserContextId: contextId });
+        this._contexts.delete(contextId);
       },
 
       cookies: async (): Promise<network.NetworkCookie[]> => {
@@ -288,7 +288,7 @@ export class CRBrowser extends platform.EventEmitter implements Browser {
     assert(this._tracingClient, 'Tracing was not started.');
     let fulfill: (buffer: platform.BufferType) => void;
     const contentPromise = new Promise<platform.BufferType>(x => fulfill = x);
-    this._tracingClient!.once('Tracing.tracingComplete', event => {
+    this._tracingClient.once('Tracing.tracingComplete', event => {
       readProtocolStream(this._tracingClient!, event.stream!, this._tracingPath).then(fulfill);
     });
     await this._tracingClient!.send('Tracing.end');

--- a/src/chromium/crCoverage.ts
+++ b/src/chromium/crCoverage.ts
@@ -129,7 +129,7 @@ class JSCoverage {
       this._client.send('Profiler.stopPreciseCoverage'),
       this._client.send('Profiler.disable'),
       this._client.send('Debugger.disable'),
-    ]);
+    ] as const);
     helper.removeEventListeners(this._eventListeners);
 
     const coverage = [];

--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -91,7 +91,7 @@ export class CRPage implements PageDelegate {
     const [,{frameTree}] = await Promise.all([
       this._client.send('Page.enable'),
       this._client.send('Page.getFrameTree'),
-    ]);
+    ] as const);
     this._handleFrameTree(frameTree);
     const promises: Promise<any>[] = [
       this._client.send('Log.enable', {}),

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -237,7 +237,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const [quads, metrics] = await Promise.all([
       this._page._delegate.getContentQuads(this),
       this._page._delegate.layoutViewport(),
-    ]);
+    ] as const);
     if (!quads || !quads.length)
       throw new Error('Node is either not visible or not an HTMLElement');
 

--- a/src/firefox/ffBrowser.ts
+++ b/src/firefox/ffBrowser.ts
@@ -188,8 +188,8 @@ export class FFBrowser extends platform.EventEmitter implements Browser {
 
       close: async (): Promise<void> => {
         assert(browserContextId, 'Non-incognito profiles cannot be closed!');
-        await this._connection.send('Target.removeBrowserContext', { browserContextId: browserContextId! });
-        this._contexts.delete(browserContextId!);
+        await this._connection.send('Target.removeBrowserContext', { browserContextId });
+        this._contexts.delete(browserContextId);
       },
 
       cookies: async (): Promise<network.NetworkCookie[]> => {

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -783,7 +783,7 @@ export class Frame {
       const context = await this._context('utility');
       const maybeHandle = await context._$(selector);
       assert(maybeHandle, 'No node found for selector: ' + selector);
-      handle = maybeHandle!;
+      handle = maybeHandle;
     }
     return handle;
   }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -219,7 +219,7 @@ class Helper {
   }
 }
 
-export function assert(value: any, message?: string) {
+export function assert(value: any, message?: string): asserts value {
   if (!value)
     throw new Error(message);
 }

--- a/src/network.ts
+++ b/src/network.ts
@@ -201,20 +201,20 @@ export class Request {
     assert(this._delegate, 'Request Interception is not enabled!');
     assert(!this._interceptionHandled, 'Request is already handled!');
     this._interceptionHandled = true;
-    await this._delegate!.abort(errorCode);
+    await this._delegate.abort(errorCode);
   }
 
   async fulfill(response: { status: number; headers: Headers; contentType: string; body: (string | platform.BufferType); }) {    // Mocking responses for dataURL requests is not currently supported.
     assert(this._delegate, 'Request Interception is not enabled!');
     assert(!this._interceptionHandled, 'Request is already handled!');
     this._interceptionHandled = true;
-    await this._delegate!.fulfill(response);
+    await this._delegate.fulfill(response);
   }
 
   async continue(overrides: { method?: string; headers?: Headers; postData?: string } = {}) {
     assert(this._delegate, 'Request Interception is not enabled!');
     assert(!this._interceptionHandled, 'Request is already handled!');
-    await this._delegate!.continue(overrides);
+    await this._delegate.continue(overrides);
   }
 
   _isIntercepted(): boolean {

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -53,7 +53,7 @@ export class WebKit implements BrowserType {
   }
 
   async launch(options?: LaunchOptions & { slowMo?: number }): Promise<WKBrowser> {
-    const { browserServer, transport } = await this._launchServer(options, 'local', null);
+    const { browserServer, transport } = await this._launchServer(options, 'local');
     const browser = await WKBrowser.connect(transport!, options && options.slowMo);
     // Hack: for typical launch scenario, ensure that close waits for actual process termination.
     browser.close = () => browserServer.close();

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -112,7 +112,7 @@ export class WKPage implements PageDelegate {
       // Page agent must be enabled before Runtime.
       session.send('Page.enable'),
       session.send('Page.getResourceTree'),
-    ]);
+    ] as const);
     resourceTreeHandler(frameTree);
     const promises : Promise<any>[] = [
       // Resource tree should be received before first execution context.


### PR DESCRIPTION
Due to Microsoft/typescript#35626, we had to add `const` into all of our `Promise.all` patterns.

But with the new  `asserts condition` feature, we can remove a bunch of trailing `!`. I think its healthy to be on the latest version typescript, but I don't feel super strongly about landing this.