### PR TITLE
fix(api): page.viewport -> page.viewportSize

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -484,13 +484,13 @@ page.removeListener('request', logRequest);
 - [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout)
 - [page.setExtraHTTPHeaders(headers)](#pagesetextrahttpheadersheaders)
 - [page.setOfflineMode(enabled)](#pagesetofflinemodeenabled)
-- [page.setViewport(viewport)](#pagesetviewportviewport)
+- [page.setViewportSize(viewportSize)](#pagesetviewportsizeviewportsize)
 - [page.title()](#pagetitle)
 - [page.tripleclick(selector[, options])](#pagetripleclickselector-options)
 - [page.type(selector, text[, options])](#pagetypeselector-text-options)
 - [page.uncheck(selector, [options])](#pageuncheckselector-options)
 - [page.url()](#pageurl)
-- [page.viewport()](#pageviewport)
+- [page.viewportSize()](#pageviewportsize)
 - [page.waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])](#pagewaitforselectororfunctionortimeout-options-args)
 - [page.waitForEvent(event[, optionsOrPredicate])](#pagewaitforeventevent-optionsorpredicate)
 - [page.waitForFunction(pageFunction[, options[, ...args]])](#pagewaitforfunctionpagefunction-options-args)
@@ -1338,26 +1338,21 @@ The extra HTTP headers will be sent with every request the page initiates.
 - `enabled` <[boolean]> When `true`, enables offline mode for the page.
 - returns: <[Promise]>
 
-#### page.setViewport(viewport)
-- `viewport` <[Object]>
+#### page.setViewportSize(viewportSize)
+- `viewportSize` <[Object]>
   - `width` <[number]> page width in pixels. **required**
   - `height` <[number]> page height in pixels. **required**
-  - `deviceScaleFactor` <[number]> Specify device scale factor (can be thought of as dpr). Defaults to `1`.
-  - `isMobile` <[boolean]> Whether the `meta viewport` tag is taken into account. Defaults to `false`.
 - returns: <[Promise]>
 
-> **NOTE** in certain cases, setting viewport will reload the page in order to set the `isMobile` property.
+In the case of multiple pages in a single browser, each page can have its own viewport size. However, [browser.newContext(options)](#browsernewcontextoptions) allows to set viewport size (and more) for all pages in the context at once.
 
-In the case of multiple pages in a single browser, each page can have its own viewport size.
-
-`page.setViewport` will resize the page. A lot of websites don't expect phones to change size, so you should set the viewport before navigating to the page.
+`page.setViewportSize` will resize the page. A lot of websites don't expect phones to change size, so you should set the viewport size before navigating to the page.
 
 ```js
 const page = await browser.newPage();
-await page.setViewport({
+await page.setViewportSize({
   width: 640,
   height: 480,
-  deviceScaleFactor: 1,
 });
 await page.goto('https://example.com');
 ```
@@ -1426,12 +1421,10 @@ Shortcut for [page.mainFrame().uncheck(selector[, options])](#frameuncheckselect
 
 This is a shortcut for [page.mainFrame().url()](#frameurl)
 
-#### page.viewport()
+#### page.viewportSize()
 - returns: <?[Object]>
   - `width` <[number]> page width in pixels.
   - `height` <[number]> page height in pixels.
-  - `deviceScaleFactor` <[number]> Specify device scale factor (can be though of as dpr). Defaults to `1`.
-  - `isMobile` <[boolean]> Whether the `meta viewport` tag is taken into account. Defaults to `false`.
 
 #### page.waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])
 - `selectorOrFunctionOrTimeout` <[string]|[number]|[function]> A [selector], predicate or timeout to wait for
@@ -1499,7 +1492,7 @@ const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
   const browser = await webkit.launch();
   const page = await browser.newPage();
   const watchDog = page.waitForFunction('window.innerWidth < 100');
-  await page.setViewport({width: 50, height: 50});
+  await page.setViewportSize({width: 50, height: 50});
   await watchDog;
   await browser.close();
 })();
@@ -2136,7 +2129,7 @@ const { firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
   const browser = await firefox.launch();
   const page = await browser.newPage();
   const watchDog = page.mainFrame().waitForFunction('window.innerWidth < 100');
-  page.setViewport({width: 50, height: 50});
+  page.setViewportSize({width: 50, height: 50});
   await watchDog;
   await browser.close();
 })();

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -87,8 +87,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
     });
     it('should propagate default viewport to the page', async({ newPage }) => {
       const page = await newPage({ viewport: { width: 456, height: 789 } });
-      expect(page.viewport().width).toBe(456);
-      expect(page.viewport().height).toBe(789);
+      expect(page.viewportSize().width).toBe(456);
+      expect(page.viewportSize().height).toBe(789);
       expect(await page.evaluate('window.innerWidth')).toBe(456);
       expect(await page.evaluate('window.innerHeight')).toBe(789);
     });
@@ -107,14 +107,14 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
     });
     it('should restore default viewport after fullPage screenshot', async({ newPage }) => {
       const page = await newPage({ viewport: { width: 456, height: 789 } });
-      expect(page.viewport().width).toBe(456);
-      expect(page.viewport().height).toBe(789);
+      expect(page.viewportSize().width).toBe(456);
+      expect(page.viewportSize().height).toBe(789);
       expect(await page.evaluate('window.innerWidth')).toBe(456);
       expect(await page.evaluate('window.innerHeight')).toBe(789);
       const screenshot = await page.screenshot({ fullPage: true });
       expect(screenshot).toBeInstanceOf(Buffer);
-      expect(page.viewport().width).toBe(456);
-      expect(page.viewport().height).toBe(789);
+      expect(page.viewportSize().width).toBe(456);
+      expect(page.viewportSize().height).toBe(789);
       expect(await page.evaluate('window.innerWidth')).toBe(456);
       expect(await page.evaluate('window.innerHeight')).toBe(789);
     });
@@ -123,8 +123,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       const context = await newContext({ viewport });
       viewport.width = 567;
       const page = await context.newPage();
-      expect(page.viewport().width).toBe(456);
-      expect(page.viewport().height).toBe(789);
+      expect(page.viewportSize().width).toBe(456);
+      expect(page.viewportSize().height).toBe(789);
       expect(await page.evaluate('window.innerWidth')).toBe(456);
       expect(await page.evaluate('window.innerHeight')).toBe(789);
     });

--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -219,8 +219,9 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       expect(error.message).toBe('No node found for selector: button.does-not-exist');
     });
     // @see https://github.com/GoogleChrome/puppeteer/issues/161
-    it('should not hang with touch-enabled viewports', async({page, server}) => {
-      await page.setViewport(playwright.devices['iPhone 6'].viewport);
+    it('should not hang with touch-enabled viewports', async({server, newContext}) => {
+      const context = await newContext({ viewport: playwright.devices['iPhone 6'].viewport });
+      const page = await context.newPage();
       await page.mouse.down();
       await page.mouse.move(100, 10);
       await page.mouse.up();
@@ -284,7 +285,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
     // @see https://github.com/GoogleChrome/puppeteer/issues/4110
     xit('should click the button with fixed position inside an iframe', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.setContent('<div style="width:100px;height:2000px">spacer</div>');
       await utils.attachFrame(page, 'button-test', server.CROSS_PROCESS_PREFIX + '/input/button.html');
       const frame = page.frames()[1];
@@ -292,8 +293,9 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       await frame.click('button');
       expect(await frame.evaluate(() => window.result)).toBe('Clicked');
     });
-    it('should click the button with deviceScaleFactor set', async({page, server}) => {
-      await page.setViewport({width: 400, height: 400, deviceScaleFactor: 5});
+    it('should click the button with deviceScaleFactor set', async({newContext, server}) => {
+      const context = await newContext({ viewport: {width: 400, height: 400, deviceScaleFactor: 5} });
+      const page = await context.newPage();
       expect(await page.evaluate(() => window.devicePixelRatio)).toBe(5);
       await page.setContent('<div style="width:100px;height:100px">spacer</div>');
       await utils.attachFrame(page, 'button-test', server.PREFIX + '/input/button.html');

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -24,14 +24,14 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
 
   describe('ElementHandle.boundingBox', function() {
     it('should work', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
       const elementHandle = await page.$('.box:nth-of-type(13)');
       const box = await elementHandle.boundingBox();
       expect(box).toEqual({ x: 100, y: 50, width: 50, height: 50 });
     });
     it('should handle nested frames', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/frames/nested-frames.html');
       const nestedFrame = page.frames().find(frame => frame.name() === 'dos');
       const elementHandle = await nestedFrame.$('div');
@@ -44,7 +44,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
       expect(await element.boundingBox()).toBe(null);
     });
     it('should force a layout', async({page, server}) => {
-      await page.setViewport({ width: 500, height: 500 });
+      await page.setViewportSize({ width: 500, height: 500 });
       await page.setContent('<div style="width: 100px; height: 100px">hello</div>');
       const elementHandle = await page.$('div');
       await page.evaluate(element => element.style.height = '200px', elementHandle);

--- a/test/mouse.spec.js
+++ b/test/mouse.spec.js
@@ -130,9 +130,10 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, 
       ]);
     });
     // @see https://crbug.com/929806
-    it('should work with mobile viewports and cross process navigations', async({page, server}) => {
+    it('should work with mobile viewports and cross process navigations', async({newContext, server}) => {
+      const context = await newContext({ viewport: {width: 360, height: 640, isMobile: true} });
+      const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
-      await page.setViewport({width: 360, height: 640, isMobile: true});
       await page.goto(server.CROSS_PROCESS_PREFIX + '/mobile.html');
       await page.evaluate(() => {
         document.addEventListener('click', event => {

--- a/test/screenshot.spec.js
+++ b/test/screenshot.spec.js
@@ -22,13 +22,13 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
 
   describe('Page.screenshot', function() {
     it('should work', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
       const screenshot = await page.screenshot();
       expect(screenshot).toBeGolden('screenshot-sanity.png');
     });
     it('should clip rect', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
       const screenshot = await page.screenshot({
         clip: {
@@ -41,7 +41,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshot).toBeGolden('screenshot-clip-rect.png');
     });
     it('should clip elements to the viewport', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
       const screenshot = await page.screenshot({
         clip: {
@@ -54,7 +54,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshot).toBeGolden('screenshot-offscreen-clip.png');
     });
     it('should throw on clip outside the viewport', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
       const screenshotError = await page.screenshot({
         clip: {
@@ -67,7 +67,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshotError.message).toBe('Clipped area is either empty or outside the viewport');
     });
     it('should run in parallel', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
       const promises = [];
       for (let i = 0; i < 3; ++i) {
@@ -84,7 +84,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshots[1]).toBeGolden('grid-cell-1.png');
     });
     it('should take fullPage screenshots', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
       const screenshot = await page.screenshot({
         fullPage: true
@@ -92,12 +92,12 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshot).toBeGolden('screenshot-grid-fullpage.png');
     });
     it('should restore viewport after fullPage screenshot', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
       const screenshot = await page.screenshot({ fullPage: true });
       expect(screenshot).toBeInstanceOf(Buffer);
-      expect(page.viewport().width).toBe(500);
-      expect(page.viewport().height).toBe(500);
+      expect(page.viewportSize().width).toBe(500);
+      expect(page.viewportSize().height).toBe(500);
     });
     it('should run in parallel in multiple pages', async({page, server, context}) => {
       const N = 2;
@@ -115,7 +115,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       await Promise.all(pages.map(page => page.close()));
     });
     it.skip(FFOX)('should allow transparency', async({page, server}) => {
-      await page.setViewport({ width: 50, height: 150 });
+      await page.setViewportSize({ width: 50, height: 150 });
       await page.setContent(`
         <style>
           body { margin: 0 }
@@ -129,7 +129,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshot).toBeGolden('transparent.png');
     });
     it('should render white background on jpeg file', async({page, server}) => {
-      await page.setViewport({ width: 100, height: 100 });
+      await page.setViewportSize({ width: 100, height: 100 });
       await page.goto(server.EMPTY_PAGE);
       const screenshot = await page.screenshot({omitBackground: true, type: 'jpeg'});
       expect(screenshot).toBeGolden('white.jpg');
@@ -146,44 +146,41 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshot).toBeGolden('screenshot-clip-odd-size.png');
     });
     it('should return base64', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
       const screenshot = await page.screenshot({
         encoding: 'base64'
       });
       expect(Buffer.from(screenshot, 'base64')).toBeGolden('screenshot-sanity.png');
     });
-    it.skip(FFOX)('should work with a mobile viewport', async({page, server}) => {
-      await page.setViewport({
-        width: 320,
-        height: 480,
-        isMobile: true
-      });
+    it.skip(FFOX)('should work with a mobile viewport', async({newContext, server}) => {
+      const context = await newContext({viewport: { width: 320, height: 480, isMobile: true }});
+      const page = await context.newPage();
       await page.goto(server.PREFIX + '/overflow.html');
       const screenshot = await page.screenshot();
       expect(screenshot).toBeGolden('screenshot-mobile.png');
     });
     it('should work for canvas', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/screenshots/canvas.html');
       const screenshot = await page.screenshot();
       expect(screenshot).toBeGolden('screenshot-canvas.png');
     });
     it('should work for translateZ', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/screenshots/translateZ.html');
       const screenshot = await page.screenshot();
       expect(screenshot).toBeGolden('screenshot-translateZ.png');
     });
     it.skip(FFOX || WEBKIT)('should work for webgl', async({page, server}) => {
-      await page.setViewport({width: 640, height: 480});
+      await page.setViewportSize({width: 640, height: 480});
       await page.goto(server.PREFIX + '/screenshots/webgl.html');
       const screenshot = await page.screenshot();
       expect(screenshot).toBeGolden('screenshot-webgl.png');
     });
     // firefox is flaky
     it.skip(FFOX)('should work while navigating', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/redirectloop1.html');
       for (let i = 0; i < 10; i++) {
         const screenshot = await page.screenshot({ fullPage: true }).catch(e => {
@@ -198,7 +195,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
 
   describe('ElementHandle.screenshot', function() {
     it('should work', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
       await page.evaluate(() => window.scrollBy(50, 100));
       const elementHandle = await page.$('.box:nth-of-type(3)');
@@ -206,7 +203,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshot).toBeGolden('screenshot-element-bounding-box.png');
     });
     it('should take into account padding and border', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.setContent(`
         <div style="height: 14px">oooo</div>
         <style>div {
@@ -223,7 +220,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshot).toBeGolden('screenshot-element-padding-border.png');
     });
     it('should capture full element when larger than viewport in parallel', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
 
       await page.setContent(`
         <div style="height: 14px">oooo</div>
@@ -249,9 +246,8 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
 
       expect(await page.evaluate(() => ({ w: window.innerWidth, h: window.innerHeight }))).toEqual({ w: 500, h: 500 });
     });
-    // Fails on GTK due to async setViewport.
     it('should capture full element when larger than viewport', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
 
       await page.setContent(`
         <div style="height: 14px">oooo</div>
@@ -277,7 +273,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(await page.evaluate(() => ({ w: window.innerWidth, h: window.innerHeight }))).toEqual({ w: 500, h: 500 });
     });
     it('should scroll element into view', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.setContent(`
         <div style="height: 14px">oooo</div>
         <style>div.above {
@@ -300,7 +296,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshot).toBeGolden('screenshot-element-scrolled-into-view.png');
     });
     it('should work with a rotated element', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
+      await page.setViewportSize({width: 500, height: 500});
       await page.setContent(`<div style="position:absolute;
                                         top: 100px;
                                         left: 100px;

--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -62,7 +62,7 @@ module.exports.describe = function({testRunner, expect, product, playwright, FFO
     it('should wait for predicate', async({page, server}) => {
       await Promise.all([
         page.waitFor(() => window.innerWidth < 130), // Windows doesn't like windows below 120px wide
-        page.setViewport({width: 10, height: 10}),
+        page.setViewportSize({width: 10, height: 10}),
       ]);
     });
     it('should throw when unknown type', async({page, server}) => {

--- a/test/web.spec.js
+++ b/test/web.spec.js
@@ -68,7 +68,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
 
     it('should take screenshot', async({page, server}) => {
       const { base64, bufferClassName } = await page.evaluate(async url => {
-        await page.setViewport({width: 500, height: 500});
+        await page.setViewportSize({width: 500, height: 500});
         await page.goto(url);
         const screenshot = await page.screenshot();
         return { base64: screenshot.toString('base64'), bufferClassName: screenshot.constructor.name };


### PR DESCRIPTION
We now only allow to resize the page, leaving isMobile and deviceScaleFactor as browser context options.