### PR TITLE
feat(api): rename browserContext() to context() in the apis, remove url from newPage

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -44,7 +44,8 @@ const { chromium, firefox, webkit } = require('playwright');
 
 (async () => {
   const browser = await chromium.launch();  // Or 'firefox' or 'webkit'.
-  const page = await browser.newPage('http://example.com');
+  const page = await browser.newPage();
+  await page.goto('http://example.com');
   // other actions...
   await browser.close();
 })();
@@ -81,7 +82,8 @@ const iPhone = devices['iPhone 6'];
     viewport: iPhone.viewport,
     userAgent: iPhone.userAgent
   });
-  const page = await context.newPage('http://example.com');
+  const page = await context.newPage();
+  await page.goto('http://example.com');
   // other actions...
   await browser.close();
 })();
@@ -136,7 +138,8 @@ const { firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
 
 (async () => {
   const browser = await firefox.launch();
-  const page = await browser.newPage('https://example.com');
+  const page = await browser.newPage();
+  await page.goto('https://example.com');
   await browser.close();
 })();
 ```
@@ -145,11 +148,11 @@ See [ChromiumBrowser], [FirefoxBrowser] and [WebKitBrowser] for browser-specific
 
 <!-- GEN:toc -->
 - [event: 'disconnected'](#event-disconnected)
-- [browser.browserContexts()](#browserbrowsercontexts)
 - [browser.close()](#browserclose)
+- [browser.contexts()](#browsercontexts)
 - [browser.isConnected()](#browserisconnected)
 - [browser.newContext(options)](#browsernewcontextoptions)
-- [browser.newPage(url, [options])](#browsernewpageurl-options)
+- [browser.newPage([options])](#browsernewpageoptions)
 - [browser.pages()](#browserpages)
 <!-- GEN:stop -->
 
@@ -157,12 +160,6 @@ See [ChromiumBrowser], [FirefoxBrowser] and [WebKitBrowser] for browser-specific
 Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
 - Browser application is closed or crashed.
 - The [`browser.disconnect`](#browserdisconnect) method was called.
-
-#### browser.browserContexts()
-- returns: <[Array]<[BrowserContext]>>
-
-Returns an array of all open browser contexts. In a newly created browser, this will return
-a single instance of [BrowserContext].
 
 #### browser.close()
 - returns: <[Promise]>
@@ -172,6 +169,12 @@ In case this browser is obtained using [browserType.launch](#browsertypelaunchop
 In case this browser is obtained using [browserType.connect](#browsertypeconnectoptions), clears all created contexts belonging to this browser and disconnects from the browser server.
 
 The [Browser] object itself is considered to be disposed and cannot be used anymore.
+
+#### browser.contexts()
+- returns: <[Array]<[BrowserContext]>>
+
+Returns an array of all open browser contexts. In a newly created browser, this will return
+a single instance of [BrowserContext].
 
 #### browser.isConnected()
 
@@ -206,12 +209,12 @@ Creates a new browser context. It won't share cookies/cache with other browser c
   // Create a new incognito browser context.
   const context = await browser.newContext();
   // Create a new page in a pristine context.
-  const page = await context.newPage('https://example.com');
+  const page = await context.newPage();
+  await page.goto('https://example.com');
 })();
 ```
 
-#### browser.newPage(url, [options])
-- `url` <?[string]> Optional url to navigate the page to.
+#### browser.newPage([options])
 - `options` <[Object]>
   - `ignoreHTTPSErrors` <?[boolean]> Whether to ignore HTTPS errors during navigation. Defaults to `false`.
   - `bypassCSP` <?[boolean]> Toggles bypassing page's Content-Security-Policy.
@@ -230,7 +233,7 @@ Creates a new browser context. It won't share cookies/cache with other browser c
   - `permissions` <[Object]> A map from origin keys to permissions values. See [browserContext.setPermissions](#browsercontextsetpermissionsorigin-permissions) for more details.
 - returns: <[Promise]<[Page]>>
 
-Creates a new page in a new browser context and optionally navigates it to the specified URL.
+Creates a new page in a new browser context.
 
 #### browser.pages()
 - returns: <[Promise]<[Array]<[Page]>>> Promise which resolves to an array of all open pages.
@@ -253,7 +256,8 @@ Playwright allows creation of "incognito" browser contexts with `browser.newCont
 // Create a new incognito browser context
 const context = await browser.newContext();
 // Create a new page inside context.
-const page = await context.newPage('https://example.com');
+const page = await context.newPage();
+await page.goto('https://example.com');
 // Dispose context once it's no longer needed.
 await context.close();
 ```
@@ -263,7 +267,7 @@ await context.close();
 - [browserContext.clearPermissions()](#browsercontextclearpermissions)
 - [browserContext.close()](#browsercontextclose)
 - [browserContext.cookies([...urls])](#browsercontextcookiesurls)
-- [browserContext.newPage(url)](#browsercontextnewpageurl)
+- [browserContext.newPage()](#browsercontextnewpage)
 - [browserContext.pages()](#browsercontextpages)
 - [browserContext.setCookies(cookies)](#browsercontextsetcookiescookies)
 - [browserContext.setGeolocation(geolocation)](#browsercontextsetgeolocationgeolocation)
@@ -314,11 +318,10 @@ If URLs are specified, only cookies that affect those URLs are returned.
 
 > **NOTE** the default browser context cannot be closed.
 
-#### browserContext.newPage(url)
-- `url` <?[string]> Optional url to navigate the page to.
+#### browserContext.newPage()
 - returns: <[Promise]<[Page]>>
 
-Creates a new page in the browser context and optionally navigates it to the specified URL.
+Creates a new page in the browser context.
 
 #### browserContext.pages()
 - returns: <[Promise]<[Array]<[Page]>>> Promise which resolves to an array of all open pages. Non visible pages, such as `"background_page"`, will not be listed here. You can find them using [target.page()](#targetpage).
@@ -397,7 +400,8 @@ const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
 (async () => {
   const browser = await webkit.launch();
   const context = await browser.newContext();
-  const page = await context.newPage('https://example.com');
+  const page = await context.newPage();
+  await page.goto('https://example.com');
   await page.screenshot({path: 'screenshot.png'});
   await browser.close();
 })();
@@ -449,11 +453,11 @@ page.removeListener('request', logRequest);
 - [page.addScriptTag(options)](#pageaddscripttagoptions)
 - [page.addStyleTag(options)](#pageaddstyletagoptions)
 - [page.authenticate(credentials)](#pageauthenticatecredentials)
-- [page.browserContext()](#pagebrowsercontext)
 - [page.check(selector, [options])](#pagecheckselector-options)
 - [page.click(selector[, options])](#pageclickselector-options)
 - [page.close([options])](#pagecloseoptions)
 - [page.content()](#pagecontent)
+- [page.context()](#pagecontext)
 - [page.coverage](#pagecoverage)
 - [page.dblclick(selector[, options])](#pagedblclickselector-options)
 - [page.emulateMedia(options)](#pageemulatemediaoptions)
@@ -729,12 +733,6 @@ Provide credentials for [HTTP authentication](https://developer.mozilla.org/en-U
 
 To disable authentication, pass `null`.
 
-#### page.browserContext()
-
-- returns: <[BrowserContext]>
-
-Get the browser context that the page belongs to.
-
 #### page.check(selector, [options])
 - `selector` <[string]> A selector to search for checkbox or radio button to check. If there are multiple elements satisfying the selector, the first will be checked.
 - `options` <[Object]>
@@ -791,6 +789,12 @@ By default, `page.close()` **does not** run beforeunload handlers.
 - returns: <[Promise]<[string]>>
 
 Gets the full HTML contents of the page, including the doctype.
+
+#### page.context()
+
+- returns: <[BrowserContext]>
+
+Get the browser context that the page belongs to.
 
 #### page.coverage
 
@@ -1633,7 +1637,8 @@ const { firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
 
 (async () => {
   const browser = await firefox.launch();
-  const page = await browser.newPage('https://www.google.com/chrome/browser/canary.html');
+  const page = await browser.newPage();
+  await page.goto('https://www.google.com/chrome/browser/canary.html');
   dumpFrameTree(page.mainFrame(), '');
   await browser.close();
 
@@ -2224,7 +2229,8 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch();
-  const page = await browser.newPage('https://example.com');
+  const page = await browser.newPage();
+  await page.goto('https://example.com');
   const hrefElement = await page.$('a');
   await hrefElement.click();
   // ...
@@ -3143,7 +3149,8 @@ const { selectors, firefox } = require('playwright');  // Or 'chromium' or 'webk
   await selectors.register(createTagNameEngine);
 
   const browser = await firefox.launch();
-  const page = await browser.newPage('http://example.com');
+  const page = await browser.newPage();
+  await page.goto('https://example.com');
 
   // Use the selector prefixed with its name.
   const button = await page.$('tag=button');
@@ -3453,7 +3460,8 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch();
-  const page = await browser.newPage('http://example.com');
+  const page = await browser.newPage();
+  await page.goto('https://example.com');
   // other actions...
   await browser.close();
 })();
@@ -3493,7 +3501,8 @@ const iPhone = webkit.devices['iPhone 6'];
     viewport: iPhone.viewport,
     userAgent: iPhone.userAgent
   });
-  const page = await context.newPage('http://example.com');
+  const page = await context.newPage();
+  await page.goto('https://example.com');
   // other actions...
   await browser.close();
 })();
@@ -3638,11 +3647,11 @@ await browser.stopTracing();
 <!-- GEN:stop -->
 <!-- GEN:toc-extends-Browser -->
 - [event: 'disconnected'](#event-disconnected)
-- [browser.browserContexts()](#browserbrowsercontexts)
 - [browser.close()](#browserclose)
+- [browser.contexts()](#browsercontexts)
 - [browser.isConnected()](#browserisconnected)
 - [browser.newContext(options)](#browsernewcontextoptions)
-- [browser.newPage(url, [options])](#browsernewpageurl-options)
+- [browser.newPage([options])](#browsernewpageoptions)
 - [browser.pages()](#browserpages)
 <!-- GEN:stop -->
 
@@ -3760,7 +3769,7 @@ to send messages.
 
 
 <!-- GEN:toc -->
-- [chromiumTarget.browserContext()](#chromiumtargetbrowsercontext)
+- [chromiumTarget.context()](#chromiumtargetcontext)
 - [chromiumTarget.createCDPSession()](#chromiumtargetcreatecdpsession)
 - [chromiumTarget.opener()](#chromiumtargetopener)
 - [chromiumTarget.page()](#chromiumtargetpage)
@@ -3768,7 +3777,7 @@ to send messages.
 - [chromiumTarget.url()](#chromiumtargeturl)
 <!-- GEN:stop -->
 
-#### chromiumTarget.browserContext()
+#### chromiumTarget.context()
 
 - returns: <[BrowserContext]>
 
@@ -3805,11 +3814,11 @@ Firefox browser instance does not expose Firefox-specific features.
 
 <!-- GEN:toc-extends-Browser -->
 - [event: 'disconnected'](#event-disconnected)
-- [browser.browserContexts()](#browserbrowsercontexts)
 - [browser.close()](#browserclose)
+- [browser.contexts()](#browsercontexts)
 - [browser.isConnected()](#browserisconnected)
 - [browser.newContext(options)](#browsernewcontextoptions)
-- [browser.newPage(url, [options])](#browsernewpageurl-options)
+- [browser.newPage([options])](#browsernewpageoptions)
 - [browser.pages()](#browserpages)
 <!-- GEN:stop -->
 
@@ -3821,11 +3830,11 @@ WebKit browser instance does not expose WebKit-specific features.
 
 <!-- GEN:toc-extends-Browser -->
 - [event: 'disconnected'](#event-disconnected)
-- [browser.browserContexts()](#browserbrowsercontexts)
 - [browser.close()](#browserclose)
+- [browser.contexts()](#browsercontexts)
 - [browser.isConnected()](#browserisconnected)
 - [browser.newContext(options)](#browsernewcontextoptions)
-- [browser.newPage(url, [options])](#browsernewpageurl-options)
+- [browser.newPage([options])](#browsernewpageoptions)
 - [browser.pages()](#browserpages)
 <!-- GEN:stop -->
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -20,11 +20,12 @@ import { Page } from './page';
 
 export interface Browser extends platform.EventEmitterType {
   newContext(options?: BrowserContextOptions): Promise<BrowserContext>;
-  browserContexts(): BrowserContext[];
+  contexts(): BrowserContext[];
   pages(): Promise<Page[]>;
-  newPage(url?: string, options?: BrowserContextOptions): Promise<Page>;
+  newPage(options?: BrowserContextOptions): Promise<Page>;
   isConnected(): boolean;
   close(): Promise<void>;
+  _defaultContext: BrowserContext | undefined;
 }
 
 export type ConnectOptions = {
@@ -34,7 +35,7 @@ export type ConnectOptions = {
 
 export async function collectPages(browser: Browser): Promise<Page[]> {
   const result: Promise<Page[]>[] = [];
-  for (const browserContext of browser.browserContexts())
+  for (const browserContext of browser.contexts())
     result.push(browserContext.pages());
   const pages: Page[] = [];
   for (const group of await Promise.all(result))

--- a/src/browserContext.ts
+++ b/src/browserContext.ts
@@ -78,11 +78,8 @@ export class BrowserContext {
     return this._delegate.pages();
   }
 
-  async newPage(url?: string): Promise<Page> {
-    const page = await this._delegate.newPage();
-    if (url)
-      await page.goto(url);
-    return page;
+  async newPage(): Promise<Page> {
+    return this._delegate.newPage();
   }
 
   async cookies(...urls: string[]): Promise<network.NetworkCookie[]> {

--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -61,10 +61,11 @@ export class CRBrowser extends platform.EventEmitter implements Browser {
     this._client.on('Target.targetDestroyed', this._targetDestroyed.bind(this));
     this._client.on('Target.targetInfoChanged', this._targetInfoChanged.bind(this));
   }
+
   _createBrowserContext(contextId: string | null, options: BrowserContextOptions): BrowserContext {
     const context = new BrowserContext({
       pages: async (): Promise<Page[]> => {
-        const targets = this._allTargets().filter(target => target.browserContext() === context && target.type() === 'page');
+        const targets = this._allTargets().filter(target => target.context() === context && target.type() === 'page');
         const pages = await Promise.all(targets.map(target => target.page()));
         return pages.filter(page => !!page) as Page[];
       },
@@ -72,7 +73,7 @@ export class CRBrowser extends platform.EventEmitter implements Browser {
       existingPages: (): Page[] => {
         const pages: Page[] = [];
         for (const target of this._allTargets()) {
-          if (target.browserContext() === context && target._crPage)
+          if (target.context() === context && target._crPage)
             pages.push(target._crPage.page());
         }
         return pages;
@@ -159,7 +160,7 @@ export class CRBrowser extends platform.EventEmitter implements Browser {
     return context;
   }
 
-  browserContexts(): BrowserContext[] {
+  contexts(): BrowserContext[] {
     return Array.from(this._contexts.values());
   }
 
@@ -167,9 +168,9 @@ export class CRBrowser extends platform.EventEmitter implements Browser {
     return collectPages(this);
   }
 
-  async newPage(url?: string, options?: BrowserContextOptions): Promise<Page> {
-    const browserContext = await this.newContext(options);
-    return browserContext.newPage(url);
+  async newPage(options?: BrowserContextOptions): Promise<Page> {
+    const context = await this.newContext(options);
+    return context.newPage();
   }
 
   async _targetCreated(event: Protocol.Target.targetCreatedPayload) {
@@ -240,7 +241,7 @@ export class CRBrowser extends platform.EventEmitter implements Browser {
 
   async close() {
     const disconnected = new Promise(f => this._connection.once(ConnectionEvents.Disconnected, f));
-    await Promise.all(this.browserContexts().map(context => context.close()));
+    await Promise.all(this.contexts().map(context => context.close()));
     this._connection.close();
     await disconnected;
   }
@@ -294,7 +295,7 @@ export class CRBrowser extends platform.EventEmitter implements Browser {
 
   targets(context?: BrowserContext): CRTarget[] {
     const targets = this._allTargets();
-    return context ? targets.filter(t => t.browserContext() === context) : targets;
+    return context ? targets.filter(t => t.context() === context) : targets;
   }
 
   pageTarget(page: Page): CRTarget {

--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -100,7 +100,7 @@ export class CRPage implements PageDelegate {
       this._networkManager.initialize(),
       this._client.send('Target.setAutoAttach', { autoAttach: true, waitForDebuggerOnStart: true, flatten: true }),
     ];
-    const options = this._page.browserContext()._options;
+    const options = this._page.context()._options;
     if (options.bypassCSP)
       promises.push(this._client.send('Page.setBypassCSP', { enabled: true }));
     if (options.ignoreHTTPSErrors)
@@ -323,7 +323,7 @@ export class CRPage implements PageDelegate {
   }
 
   async _updateViewport(updateTouch: boolean): Promise<void> {
-    let viewport = this._page.browserContext()._options.viewport || { width: 0, height: 0 };
+    let viewport = this._page.context()._options.viewport || { width: 0, height: 0 };
     const viewportSize = this._page._state.viewportSize;
     if (viewportSize)
       viewport = { ...viewport, ...viewportSize };

--- a/src/chromium/crTarget.ts
+++ b/src/chromium/crTarget.ts
@@ -120,7 +120,7 @@ export class CRTarget {
     return 'other';
   }
 
-  browserContext(): BrowserContext {
+  context(): BrowserContext {
     return this._browserContext;
   }
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -144,7 +144,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const frameId = await this._page._delegate.getOwnerFrame(this);
     if (!frameId)
       return null;
-    const pages = this._page.browserContext()._existingPages();
+    const pages = this._page.context()._existingPages();
     for (const page of pages) {
       const frame = page._frameManager.frame(frameId);
       if (frame)
@@ -188,7 +188,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
         element.scrollIntoView({block: 'center', inline: 'center', behavior: 'instant'});
       }
       return false;
-    }, !!this._page.browserContext()._options.javaScriptEnabled);
+    }, !!this._page.context()._options.javaScriptEnabled);
     if (error)
       throw new Error(error);
   }

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -82,7 +82,7 @@ export class FFPage implements PageDelegate {
       this._session.send('Network.enable'),
       this._session.send('Page.enable'),
     ];
-    const options = this._page.browserContext()._options;
+    const options = this._page.context()._options;
     if (options.viewport)
       promises.push(this._updateViewport());
     if (options.bypassCSP)
@@ -272,7 +272,7 @@ export class FFPage implements PageDelegate {
   }
 
   async _updateViewport() {
-    let viewport = this._page.browserContext()._options.viewport || { width: 0, height: 0 };
+    let viewport = this._page.context()._options.viewport || { width: 0, height: 0 };
     const viewportSize = this._page._state.viewportSize;
     if (viewportSize)
       viewport = { ...viewport, ...viewportSize };

--- a/src/page.ts
+++ b/src/page.ts
@@ -181,7 +181,7 @@ export class Page extends platform.EventEmitter {
     this.emit(Events.Page.FileChooser, fileChooser);
   }
 
-  browserContext(): BrowserContext {
+  context(): BrowserContext {
     return this._browserContext;
   }
 

--- a/src/screenshotter.ts
+++ b/src/screenshotter.ts
@@ -28,7 +28,7 @@ export class Screenshotter {
   constructor(page: Page) {
     this._page = page;
 
-    const browserContext = page.browserContext();
+    const browserContext = page.context();
     this._queue = (browserContext as any)[taskQueueSymbol];
     if (!this._queue) {
       this._queue = new TaskQueue();

--- a/src/webkit/wkBrowser.ts
+++ b/src/webkit/wkBrowser.ts
@@ -83,7 +83,7 @@ export class WKBrowser extends platform.EventEmitter implements Browser {
     return context;
   }
 
-  browserContexts(): BrowserContext[] {
+  contexts(): BrowserContext[] {
     return Array.from(this._contexts.values());
   }
 
@@ -91,9 +91,9 @@ export class WKBrowser extends platform.EventEmitter implements Browser {
     return collectPages(this);
   }
 
-  async newPage(url?: string, options?: BrowserContextOptions): Promise<Page> {
-    const browserContext = await this.newContext(options);
-    return browserContext.newPage(url);
+  async newPage(options?: BrowserContextOptions): Promise<Page> {
+    const context = await this.newContext(options);
+    return context.newPage();
   }
 
   async _waitForFirstPageTarget(timeout: number): Promise<void> {
@@ -164,7 +164,7 @@ export class WKBrowser extends platform.EventEmitter implements Browser {
   async close() {
     helper.removeEventListeners(this._eventListeners);
     const disconnected = new Promise(f => this.once(Events.Browser.Disconnected, f));
-    await Promise.all(this.browserContexts().map(context => context.close()));
+    await Promise.all(this.contexts().map(context => context.close()));
     this._connection.close();
     await disconnected;
   }

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -70,7 +70,7 @@ export class WKPage implements PageDelegate {
       this._pageProxySession.send('Dialog.enable'),
       this.authenticate(this._page._state.credentials)
     ];
-    const contextOptions = this._page.browserContext()._options;
+    const contextOptions = this._page.context()._options;
     if (contextOptions.javaScriptEnabled === false)
       promises.push(this._pageProxySession.send('Emulation.setJavaScriptEnabled', { enabled: false }));
     if (this._page._state.viewportSize || contextOptions.viewport)
@@ -130,7 +130,7 @@ export class WKPage implements PageDelegate {
     if (this._page._state.cacheEnabled === false)
       promises.push(session.send('Network.setResourceCachingDisabled', { disabled: true }));
 
-    const contextOptions = this._page.browserContext()._options;
+    const contextOptions = this._page.context()._options;
     if (contextOptions.userAgent)
       promises.push(session.send('Page.overrideUserAgent', { value: contextOptions.userAgent }));
     if (this._page._state.mediaType || this._page._state.colorScheme)
@@ -390,7 +390,7 @@ export class WKPage implements PageDelegate {
   }
 
   async _updateViewport(updateTouch: boolean): Promise<void> {
-    let viewport = this._page.browserContext()._options.viewport || { width: 0, height: 0 };
+    let viewport = this._page.context()._options.viewport || { width: 0, height: 0 };
     const viewportSize = this._page._state.viewportSize;
     if (viewportSize)
       viewport = { ...viewport, ...viewportSize };

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -22,25 +22,23 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('Browser', function() {
-    it('should create new page', async function({browser, newPage}) {
+    it('should create new page', async function({browser}) {
       expect((await browser.pages()).length).toBe(0);
-      const page1 = await newPage();
+      const page1 = await browser.newPage();
       expect((await browser.pages()).length).toBe(1);
-      expect(browser.browserContexts().length).toBe(1);
+      expect(browser.contexts().length).toBe(1);
 
-      const page2 = await newPage();
+      const page2 = await browser.newPage();
       expect((await browser.pages()).length).toBe(2);
-      expect(browser.browserContexts().length).toBe(2);
+      expect(browser.contexts().length).toBe(2);
 
-      await page1.close();
+      await page1.context().close();
       expect((await browser.pages()).length).toBe(1);
-      expect(browser.browserContexts().length).toBe(2);
+      expect(browser.contexts().length).toBe(1);
 
-      await page2.browserContext().close();
+      await page2.context().close();
       expect((await browser.pages()).length).toBe(0);
-      expect(browser.browserContexts().length).toBe(1);
-      await page1.browserContext().close();
-      expect(browser.browserContexts().length).toBe(0);
+      expect(browser.contexts().length).toBe(0);
     });
   });
 };

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -24,12 +24,12 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
 
   describe('BrowserContext', function() {
     it('should create new context', async function({browser, newContext}) {
-      expect(browser.browserContexts().length).toBe(0);
+      expect(browser.contexts().length).toBe(0);
       const context = await newContext();
-      expect(browser.browserContexts().length).toBe(1);
-      expect(browser.browserContexts().indexOf(context) !== -1).toBe(true);
+      expect(browser.contexts().length).toBe(1);
+      expect(browser.contexts().indexOf(context) !== -1).toBe(true);
       await context.close();
-      expect(browser.browserContexts().length).toBe(0);
+      expect(browser.contexts().length).toBe(0);
     });
     it.skip(CHROMIUM)('popup should inherit user agent', async function({newContext, server}) {
       const context = await newContext({
@@ -52,7 +52,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
         utils.waitEvent(page, 'popup'),
         page.evaluate(url => window.open(url), server.EMPTY_PAGE)
       ]);
-      expect(popupTarget.browserContext()).toBe(context);
+      expect(popupTarget.context()).toBe(context);
     });
     it('should isolate localStorage and cookies', async function({browser, newContext, server}) {
       // Create two incognito contexts.
@@ -96,7 +96,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
         context1.close(),
         context2.close()
       ]);
-      expect(browser.browserContexts().length).toBe(0);
+      expect(browser.contexts().length).toBe(0);
     });
     it('should propagate default viewport to the page', async({ newPage }) => {
       const page = await newPage({ viewport: { width: 456, height: 789 } });

--- a/test/chromium/chromium.spec.js
+++ b/test/chromium/chromium.spec.js
@@ -168,7 +168,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
     it('should wait for a target', async function({browser, server, newContext}) {
       const context = await newContext();
       let resolved = false;
-      const targetPromise = browser.waitForTarget(target => target.browserContext() === context && target.url() === server.EMPTY_PAGE);
+      const targetPromise = browser.waitForTarget(target => target.context() === context && target.url() === server.EMPTY_PAGE);
       targetPromise.then(() => resolved = true);
       const page = await context.newPage();
       expect(resolved).toBe(false);
@@ -177,7 +177,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       expect(await target.page()).toBe(page);
     });
     it('should timeout waiting for a non-existent target', async function({browser, context, server}) {
-      const error = await browser.waitForTarget(target => target.browserContext() === context && target.url() === server.EMPTY_PAGE, {timeout: 1}).catch(e => e);
+      const error = await browser.waitForTarget(target => target.context() === context && target.url() === server.EMPTY_PAGE, {timeout: 1}).catch(e => e);
       expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
     });
     it('should wait for a target', async function({browser, server}) {
@@ -189,7 +189,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       await page.goto(server.EMPTY_PAGE);
       const target = await targetPromise;
       expect(await target.page()).toBe(page);
-      await page.browserContext().close();
+      await page.close();
     });
     it('should fire target events', async function({browser, newContext, server}) {
       const context = await newContext();

--- a/test/chromium/headful.spec.js
+++ b/test/chromium/headful.spec.js
@@ -88,7 +88,7 @@ module.exports.describe = function({testRunner, expect, playwright, defaultBrows
       const context = await browser.newContext();
       await Promise.all([
         context.newPage(),
-        browser.waitForTarget(target => target.browserContext() === context && target.url().includes('devtools://')),
+        browser.waitForTarget(target => target.context() === context && target.url().includes('devtools://')),
       ]);
       await browser.close();
     });

--- a/test/chromium/tracing.spec.js
+++ b/test/chromium/tracing.spec.js
@@ -55,7 +55,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       const newPage = await browser.newPage();
       let error = null;
       await browser.startTracing(newPage, {path: outputFile}).catch(e => error = e);
-      await newPage.browserContext().close();
+      await newPage.context().close();
       expect(error).toBeTruthy();
       await browser.stopTracing();
     });

--- a/test/defaultbrowsercontext.spec.js
+++ b/test/defaultbrowsercontext.spec.js
@@ -39,7 +39,7 @@ module.exports.describe = function ({ testRunner, expect, defaultBrowserOptions,
       await page.evaluate(() => {
         document.cookie = 'username=John Doe';
       });
-      expect(await page.browserContext().cookies()).toEqual([{
+      expect(await page.context().cookies()).toEqual([{
         name: 'username',
         value: 'John Doe',
         domain: 'localhost',
@@ -53,13 +53,13 @@ module.exports.describe = function ({ testRunner, expect, defaultBrowserOptions,
     });
     it('context.setCookies() should work', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
-      await page.browserContext().setCookies([{
+      await page.context().setCookies([{
         url: server.EMPTY_PAGE,
         name: 'username',
         value: 'John Doe'
       }]);
       expect(await page.evaluate(() => document.cookie)).toBe('username=John Doe');
-      expect(await page.browserContext().cookies()).toEqual([{
+      expect(await page.context().cookies()).toEqual([{
         name: 'username',
         value: 'John Doe',
         domain: 'localhost',
@@ -73,7 +73,7 @@ module.exports.describe = function ({ testRunner, expect, defaultBrowserOptions,
     });
     it('context.clearCookies() should work', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
-      await page.browserContext().setCookies([{
+      await page.context().setCookies([{
         url: server.EMPTY_PAGE,
         name: 'cookie1',
         value: '1'
@@ -83,7 +83,7 @@ module.exports.describe = function ({ testRunner, expect, defaultBrowserOptions,
         value: '2'
       }]);
       expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie2=2');
-      await page.browserContext().clearCookies();
+      await page.context().clearCookies();
       expect(await page.evaluate('document.cookie')).toBe('');
     });
   });

--- a/test/multiclient.spec.js
+++ b/test/multiclient.spec.js
@@ -26,16 +26,16 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
     it('should work across sessions', async () => {
       const browserServer = await playwright.launchServer(defaultBrowserOptions);
       const browser1 = await playwright.connect({ wsEndpoint: browserServer.wsEndpoint() });
-      expect(browser1.browserContexts().length).toBe(0);
+      expect(browser1.contexts().length).toBe(0);
       await browser1.newContext();
-      expect(browser1.browserContexts().length).toBe(1);
+      expect(browser1.contexts().length).toBe(1);
 
       const browser2 = await playwright.connect({ wsEndpoint: browserServer.wsEndpoint() });
-      expect(browser2.browserContexts().length).toBe(0);
+      expect(browser2.contexts().length).toBe(0);
       await browser2.newContext();
-      expect(browser2.browserContexts().length).toBe(1);
+      expect(browser2.contexts().length).toBe(1);
 
-      expect(browser1.browserContexts().length).toBe(1);
+      expect(browser1.contexts().length).toBe(1);
       await browserServer.close();
     });
   });

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -297,7 +297,7 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
         frame.remove();
       });
       // 4. Connect to the popup and make sure it doesn't throw.
-      await page.browserContext().pages();
+      await page.context().pages();
     });
   });
 
@@ -1160,7 +1160,7 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
 
   describe('Page.browserContext', function() {
     it('should return the correct browser instance', async function({page, context}) {
-      expect(page.browserContext()).toBe(context);
+      expect(page.context()).toBe(context);
     });
   });
 };

--- a/test/web.spec.js
+++ b/test/web.spec.js
@@ -43,7 +43,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
 
     afterEach(async state => {
       await state.page.evaluate(() => teardown());
-      await state.page.browserContext().close();
+      await state.page.context().close();
       state.page = null;
     });
 


### PR DESCRIPTION
- rename `.browserContext(s)` to `.context(s)`
- remove `url` from `newPage`
- make `browser.newPage` own created context