### PR TITLE
fix(tests): fix test that was leaking a context

### DIFF
--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -42,6 +42,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       const page = await browser.newPage();
       let error;
       await page.context().newPage().catch(e => error = e);
+      await page.close();
       expect(error.message).toContain('Please use browser.newContext()');
     });
   });

--- a/test/playwright.spec.js
+++ b/test/playwright.spec.js
@@ -118,6 +118,7 @@ module.exports.describe = ({testRunner, product, playwrightPath}) => {
 
       state.tearDown = async () => {
         await Promise.all(contexts.map(c => c.close()));
+        expect((await state.browser.contexts()).length).toBe(0, `"${test.fullName}" leaked a context`);
         if (rl) {
           rl.removeListener('line', onLine);
           rl.close();


### PR DESCRIPTION
Added a check for tests that leak contexts, and caught one. This hopefully will start greening up our tree.