### PR TITLE
feat(chromium): roll chromium to r740847

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index.js",
   "playwright": {
-    "chromium_revision": "740289",
+    "chromium_revision": "740847",
     "firefox_revision": "1028",
     "webkit_revision": "1145"
   },


### PR DESCRIPTION
Notable patch:
- DevTools: Don't interrupt for Runtime.callFunctionOn, Runtime.runScript - https://chromium-review.googlesource.com/c/chromium/src/+/2050850 

This roll should unflake Chromium workers.