### PR TITLE
feat: do not let users pass `userDataDir` to `browserType.launch()`

### DIFF
--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -50,7 +50,7 @@ export class Chromium implements BrowserType {
   }
 
   async launch(options?: LaunchOptions & { slowMo?: number }): Promise<CRBrowser> {
-    if (options && options.userDataDir)
+    if (options && (options as any).userDataDir)
       throw new Error('userDataDir option is not supported in `browserType.launch`. Use `browserType.launchPersistent` instead');
     const { browserServer, transport } = await this._launchServer(options, 'local');
     const browser = await CRBrowser.connect(transport!, options && options.slowMo);

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -50,6 +50,8 @@ export class Chromium implements BrowserType {
   }
 
   async launch(options?: LaunchOptions & { slowMo?: number }): Promise<CRBrowser> {
+    if (options && options.userDataDir)
+      throw new Error('userDataDir option is not supported in `browserType.launch`. Use `browserType.launchPersistent` instead');
     const { browserServer, transport } = await this._launchServer(options, 'local');
     const browser = await CRBrowser.connect(transport!, options && options.slowMo);
     // Hack: for typical launch scenario, ensure that close waits for actual process termination.

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -60,6 +60,8 @@ export class Firefox implements BrowserType {
   }
 
   async launch(options?: LaunchOptions & { slowMo?: number }): Promise<FFBrowser> {
+    if (options && options.userDataDir)
+      throw new Error('userDataDir option is not supported in `browserType.launch`. Use `browserType.launchPersistent` instead');
     const { browserServer, transport } = await this._launchServer(options, 'local');
     const browser = await FFBrowser.connect(transport!, options && options.slowMo);
     // Hack: for typical launch scenario, ensure that close waits for actual process termination.

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -60,7 +60,7 @@ export class Firefox implements BrowserType {
   }
 
   async launch(options?: LaunchOptions & { slowMo?: number }): Promise<FFBrowser> {
-    if (options && options.userDataDir)
+    if (options && (options as any).userDataDir)
       throw new Error('userDataDir option is not supported in `browserType.launch`. Use `browserType.launchPersistent` instead');
     const { browserServer, transport } = await this._launchServer(options, 'local');
     const browser = await FFBrowser.connect(transport!, options && options.slowMo);

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -62,6 +62,8 @@ export class WebKit implements BrowserType {
   }
 
   async launch(options?: LaunchOptions & { slowMo?: number }): Promise<WKBrowser> {
+    if (options && options.userDataDir)
+      throw new Error('userDataDir option is not supported in `browserType.launch`. Use `browserType.launchPersistent` instead');
     const { browserServer, transport } = await this._launchServer(options, 'local');
     const browser = await WKBrowser.connect(transport!, options && options.slowMo);
     // Hack: for typical launch scenario, ensure that close waits for actual process termination.

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -62,7 +62,7 @@ export class WebKit implements BrowserType {
   }
 
   async launch(options?: LaunchOptions & { slowMo?: number }): Promise<WKBrowser> {
-    if (options && options.userDataDir)
+    if (options && (options as any).userDataDir)
       throw new Error('userDataDir option is not supported in `browserType.launch`. Use `browserType.launchPersistent` instead');
     const { browserServer, transport } = await this._launchServer(options, 'local');
     const browser = await WKBrowser.connect(transport!, options && options.slowMo);

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -39,6 +39,12 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
         await neverResolves;
         expect(error.message).toContain('Protocol error');
       });
+      it('should throw if userDataDir option is passed', async() => {
+        let waitError = null;
+        const options = Object.assign({}, defaultBrowserOptions, {userDataDir: 'random-path'});
+        await playwright.launch(options).catch(e => waitError = e);
+        expect(waitError.message).toContain('launchPersistent');
+      });
       it('should reject if executable path is invalid', async({server}) => {
         let waitError = null;
         const options = Object.assign({}, defaultBrowserOptions, {executablePath: 'random-invalid-path'});


### PR DESCRIPTION
We now have a separate method for this - `browserType.launchPersistent`.
This will probably save our users quite some time.