### PR TITLE
test: fix service worker test

### DIFF
--- a/test/assets/serviceworkers/fetchdummy/sw.html
+++ b/test/assets/serviceworkers/fetchdummy/sw.html
@@ -1,5 +1,6 @@
 <script>
   window.registrationPromise = navigator.serviceWorker.register('sw.js');
+  window.activationPromise = new Promise(resolve => navigator.serviceWorker.oncontrollerchange = resolve);
 
   async function fetchDummy(name) {
     const response = await fetch(name);

--- a/test/assets/serviceworkers/fetchdummy/sw.js
+++ b/test/assets/serviceworkers/fetchdummy/sw.js
@@ -9,3 +9,7 @@ self.addEventListener('fetch', event => {
   const response = new Response(blob, { "status" : 200 , "statusText" : "OK" });
   event.respondWith(response);
 });
+
+self.addEventListener('activate', event => {
+  event.waitUntil(clients.claim());
+});

--- a/test/interception.spec.js
+++ b/test/interception.spec.js
@@ -570,8 +570,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   describe('service worker', function() {
     it('should intercept after a service worker', async({browser, page, server, context}) => {
       await page.goto(server.PREFIX + '/serviceworkers/fetchdummy/sw.html');
-      await page.evaluate(() => window.registrationPromise);
-      await page.reload();
+      await page.evaluate(() => window.activationPromise);
 
       // Sanity check.
       const swResponse = await page.evaluate(() => fetchDummy('foo'));


### PR DESCRIPTION
Do the following to ensure SW is active and serves requests:
- in ServiceWorker, claim all clients once activated
- in page, await activation promise instead of a registration