### PR TITLE
chore: generate browser versions when doing release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Playwright
-[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) [![Chromium version](https://img.shields.io/badge/chromium-81.0.4044-blue.svg)](https://www.chromium.org/Home) [![Firefox version](https://img.shields.io/badge/firefox-73.0b3-blue.svg)](https://www.mozilla.org/en-US/firefox/new/) [![WebKit version](https://img.shields.io/badge/webkit-13.0.4-blue.svg)](https://webkit.org/) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://join.slack.com/t/playwright/shared_invite/enQtOTEyMTUxMzgxMjIwLThjMDUxZmIyNTRiMTJjNjIyMzdmZDA3MTQxZWUwZTFjZjQwNGYxZGM5MzRmNzZlMWI5ZWUyOTkzMjE5Njg1NDg)
+[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) <!-- GEN:chromium-version-badge-if-release -->[![Chromium version](https://img.shields.io/badge/chromium-81.0.4044-blue.svg?logo=google-chrome)](https://www.chromium.org/Home) <!-- GEN:stop --> <!-- GEN:firefox-version-badge-if-release --> [![Firefox version](https://img.shields.io/badge/firefox-73.0b3-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/) <!-- GEN:stop --> [![WebKit version](https://img.shields.io/badge/webkit-13.0.4-blue.svg?logo=safari)](https://webkit.org/) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://join.slack.com/t/playwright/shared_invite/enQtOTEyMTUxMzgxMjIwLThjMDUxZmIyNTRiMTJjNjIyMzdmZDA3MTQxZWUwZTFjZjQwNGYxZGM5MzRmNzZlMWI5ZWUyOTkzMjE5Njg1NDg)
 
 ###### [API](https://github.com/microsoft/playwright/blob/v0.10.0/docs/api.md) | [FAQ](#faq) | [Contributing](#contributing)
 
@@ -8,9 +8,9 @@ Playwright is a Node library to automate the [Chromium](https://www.chromium.org
 
 |          | ver | Linux | macOS | Win |
 |   ---:   | :---: | :---: | :---:  | :---: |
-| Chromium| 81.0.4044 | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Chromium| <!-- GEN:chromium-version-if-release-->81.0.4044<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | WebKit | 13.0.4 | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Firefox |73.0b3 | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Firefox | <!-- GEN:firefox-version-if-release -->73.0b3<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 - Headless is supported for all the browsers on all platforms.
 
 

--- a/utils/doclint/preprocessor/index.js
+++ b/utils/doclint/preprocessor/index.js
@@ -15,11 +15,12 @@
  */
 
 const Message = require('../Message');
+const {firefox, webkit, chromium} = require('../../../');
 
-module.exports.ensureReleasedAPILinks = function(sources, version) {
+module.exports.ensureReleasedAPILinks = function(sources, libversion) {
   // Release version is everything that doesn't include "-".
   const apiLinkRegex = /https:\/\/github.com\/microsoft\/playwright\/blob\/v[^/]*\/docs\/api.md/ig;
-  const lastReleasedAPI = `https://github.com/microsoft/playwright/blob/v${version.split('-')[0]}/docs/api.md`;
+  const lastReleasedAPI = `https://github.com/microsoft/playwright/blob/v${libversion.split('-')[0]}/docs/api.md`;
 
   const messages = [];
   for (const source of sources) {
@@ -31,9 +32,9 @@ module.exports.ensureReleasedAPILinks = function(sources, version) {
   return messages;
 };
 
-module.exports.runCommands = function(sources, version) {
+module.exports.runCommands = function(sources, {libversion, chromiumVersion, firefoxVersion}) {
   // Release version is everything that doesn't include "-".
-  const isReleaseVersion = !version.includes('-');
+  const isReleaseVersion = !libversion.includes('-');
 
   const messages = [];
   const commands = [];
@@ -65,9 +66,17 @@ module.exports.runCommands = function(sources, version) {
   for (const command of commands) {
     let newText = null;
     if (command.name === 'version')
-      newText = isReleaseVersion ? 'v' + version : 'Tip-Of-Tree';
+      newText = isReleaseVersion ? 'v' + libversion : 'Tip-Of-Tree';
     else if (command.name === 'empty-if-release')
       newText = isReleaseVersion ? '' : command.originalText;
+    else if (command.name === 'chromium-version-if-release')
+      newText = isReleaseVersion ? chromiumVersion : command.originalText;
+    else if (command.name === 'firefox-version-if-release')
+      newText = isReleaseVersion ? firefoxVersion : command.originalText;
+    else if (command.name === 'chromium-version-badge-if-release')
+      newText = isReleaseVersion ? `[![Chromium version](https://img.shields.io/badge/chromium-${chromiumVersion}-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)` : command.originalText;
+    else if (command.name === 'firefox-version-badge-if-release')
+      newText = isReleaseVersion ? `[![Firefox version](https://img.shields.io/badge/firefox-${firefoxVersion}-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)` : command.originalText;
     else if (command.name === 'toc')
       newText = generateTableOfContents(command.source.text(), command.to, false /* topLevelOnly */);
     else if (command.name === 'toc-top-level')


### PR DESCRIPTION
This introduces a handful of new markdown preprocessor commands to
insert browser versions:
- `GEN:chromium-version-if-release` - inserts current Chromium version
  if we're doing release; noop otherwise.
- `GEN:firefox-version-if-release` - inserts current Firefox version
  if we're doing release; noop otherwise.

And to generate badge links:
- `GEN:chromium-version-badge-if-release` - inserts current Chromium version
  badge if we're doing release; noop otherwise.
- `GEN:firefox-version-badge-if-release` - inserts current Firefox version
  badge if we're doing release; noop otherwise.

This doesn't touch webkit at all - we're yet to figure what to do with
webkit version.

NOTE: versions will be updated only once we release. This way our
README.md always represents last released version.