### PR TITLE
feature: make directory in the path before screenshot

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -189,6 +189,7 @@ export async function readFileAsync(file: string, encoding: string): Promise<str
 
 export async function writeFileAsync(file: string, data: any) {
   assertFileAccess();
+  await nodeFS.mkdirSync(nodePath.dirname(file), {recursive: true});
   return await promisify(nodeFS.writeFile)(file, data);
 }
 


### PR DESCRIPTION
i had an issue about `page.screenshot()` like below
```shell
Error: ENOENT: no such file or directory,
```
i think this error is generated when the 'fs' module attempt to write the screenshot result file. 
so, i had modified it to `mkdir` before write file

thank you!