### PR TITLE
fix(keyboard): correctly press enter on firefox

### DIFF
--- a/src/firefox/ffInput.ts
+++ b/src/firefox/ffInput.ts
@@ -64,6 +64,9 @@ export class RawKeyboardImpl implements input.RawKeyboard {
       code = 'OSLeft';
     if (code === 'MetaRight')
       code = 'OSRight';
+    // Firefox will figure out Enter by itself
+    if (text === '\r')
+      text = '';
     await this._client.send('Page.dispatchKeyEvent', {
       type: 'keydown',
       keyCode: keyCodeWithoutLocation,


### PR DESCRIPTION
@dgozman I'm not sure why firefox is using `text` in dispatchKeyEvent now. Maybe we could just revert it. But for now this is an easy fix for Enter. 
#1009 #1019 