### PR TITLE
test(keyboard): Remove duplicated test

### DIFF
--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -37,14 +37,6 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, 
       await page.keyboard.type(text);
       expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe(text);
     });
-    it('should press the metaKey', async({page, server}) => {
-      await page.goto(server.PREFIX + '/empty.html');
-      await page.evaluate(() => {
-        window.keyPromise = new Promise(resolve => document.addEventListener('keydown', event => resolve(event.key)));
-      });
-      await page.keyboard.press('Meta');
-      expect(await page.evaluate('keyPromise')).toBe(FFOX && !MAC ? 'OS' : 'Meta');
-    });
     it('should move with the arrow keys', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/textarea.html');
       await page.type('textarea', 'Hello World!');


### PR DESCRIPTION
[This test](https://github.com/microsoft/playwright/blob/v0.11.1/test/keyboard.spec.js#L280) is better than the test being removed here and tests the same functionality.

This is quite a selfish change. I would need to have unique `describe-it` names so I can track changes and progress in PlaywrightSharp 🤓 