### PR TITLE
fix(navigation): do not count random failures as navigation cancel

### DIFF
--- a/src/frames.ts
+++ b/src/frames.ts
@@ -428,9 +428,10 @@ export class Frame {
     let resolve: (error: Error|void) => void;
     const promise = new Promise<Error|void>(x => resolve = x);
     const watch = (documentId: string, error?: Error) => {
-      if (documentId !== expectedDocumentId)
-        return resolve(new Error('Navigation interrupted by another one'));
-      resolve(error);
+      if (documentId === expectedDocumentId)
+        resolve(error);
+      else if (!error)
+        resolve(new Error('Navigation interrupted by another one'));
     };
     const dispose = () => this._documentWatchers.delete(watch);
     this._documentWatchers.add(watch);


### PR DESCRIPTION
In WebKit, we sometimes get the following:
- page starts a navigation in some frame;
- we issue page.goto();
- new navigation commits;
- old page is still alive and cancels the frame navigation;
- while waiting for 'Page.frameNavigated' on the frontend from the new target, we receive 'Browser.provisionalLoadFailed' for the frame navigation from the old target;
- this counts as cancel for the new navigation, although it was clearly a cancellation of some other navigation.

Wasn't able to write a reliable test. Any ideas are welcome! Fixes #1044.