### PR TITLE
test: remove `newContext` and `newPage` test helpers

### DIFF
--- a/test/chromium/chromium.spec.js
+++ b/test/chromium/chromium.spec.js
@@ -152,10 +152,10 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       expect(createdTarget.opener()).toBe(browser.pageTarget(page));
       expect(browser.pageTarget(page).opener()).toBe(null);
     });
-    it('should close all belonging targets once closing context', async function({browser, newContext}) {
+    it('should close all belonging targets once closing context', async function({browser}) {
       const targets = async (context) => (await browser.targets()).filter(t => t.type() === 'page' && t.context() === context);
 
-      const context = await newContext();
+      const context = await browser.newContext();
       await context.newPage();
       expect((await targets(context)).length).toBe(1);
       expect((await context.pages()).length).toBe(1);
@@ -166,8 +166,8 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
   });
 
   describe('Chromium.waitForTarget', () => {
-    it('should wait for a target', async function({browser, server, newContext}) {
-      const context = await newContext();
+    it('should wait for a target', async function({server, browser}) {
+      const context = await browser.newContext();
       let resolved = false;
       const targetPromise = browser.waitForTarget(target => target.context() === context && target.url() === server.EMPTY_PAGE);
       targetPromise.then(() => resolved = true);
@@ -176,6 +176,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       await page.goto(server.EMPTY_PAGE);
       const target = await targetPromise;
       expect(await target.page()).toBe(page);
+      await context.close();
     });
     it('should timeout waiting for a non-existent target', async function({browser, context, server}) {
       const error = await browser.waitForTarget(target => target.context() === context && target.url() === server.EMPTY_PAGE, {timeout: 1}).catch(e => e);
@@ -192,8 +193,8 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       expect(await target.page()).toBe(page);
       await page.context().close();
     });
-    it('should fire target events', async function({browser, newContext, server}) {
-      const context = await newContext();
+    it('should fire target events', async function({browser, server}) {
+      const context = await browser.newContext();
       const events = [];
       browser.on('targetcreated', target => events.push('CREATED: ' + target.url()));
       browser.on('targetchanged', target => events.push('CHANGED: ' + target.url()));
@@ -206,6 +207,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
         `CHANGED: ${server.EMPTY_PAGE}`,
         `DESTROYED: ${server.EMPTY_PAGE}`
       ]);
+      await context.close();
     });
   });
 

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -68,8 +68,9 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
       }, element);
       expect(pwBoundingBox).toEqual(webBoundingBox);
     });
-    it('should work with page scale', async({newPage, server}) => {
-      const page = await newPage({ viewport: { width: 400, height: 400, isMobile: true} });
+    it('should work with page scale', async({browser, server}) => {
+      const context = await browser.newContext({ viewport: { width: 400, height: 400, isMobile: true} });
+      const page = await context.newPage();
       await page.goto(server.PREFIX + '/input/button.html');
       const button = await page.$('button');
       await button.evaluate(button => {
@@ -85,6 +86,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
       expect(Math.round(box.y * 100)).toBe(23 * 100);
       expect(Math.round(box.width * 100)).toBe(200 * 100);
       expect(Math.round(box.height * 100)).toBe(20 * 100);
+      await context.close();
     });
     it('should work when inline box child is outside of viewport', async({page, server}) => {
       await page.setContent(`

--- a/test/emulation.spec.js
+++ b/test/emulation.spec.js
@@ -38,13 +38,14 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       expect(await page.evaluate(() => window.innerWidth)).toBe(123);
       expect(await page.evaluate(() => window.innerHeight)).toBe(456);
     });
-    it('should support mobile emulation', async({newContext, server}) => {
-      const context = await newContext({ viewport: iPhone.viewport });
+    it('should support mobile emulation', async({browser, server}) => {
+      const context = await browser.newContext({ viewport: iPhone.viewport });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
       expect(await page.evaluate(() => window.innerWidth)).toBe(375);
       await page.setViewportSize({width: 400, height: 300});
       expect(await page.evaluate(() => window.innerWidth)).toBe(400);
+      await context.close();
     });
     it('should not have touch by default', async({page, server}) => {
       await page.goto(server.PREFIX + '/mobile.html');
@@ -52,12 +53,13 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       await page.goto(server.PREFIX + '/detect-touch.html');
       expect(await page.evaluate(() => document.body.textContent.trim())).toBe('NO');
     });
-    it('should support touch emulation', async({newContext, server}) => {
-      const context = await newContext({ viewport: iPhone.viewport });
+    it('should support touch emulation', async({browser, server}) => {
+      const context = await browser.newContext({ viewport: iPhone.viewport });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
       expect(await page.evaluate(() => 'ontouchstart' in window)).toBe(true);
       expect(await page.evaluate(dispatchTouch)).toBe('Received touch');
+      await context.close();
 
       function dispatchTouch() {
         let fulfill;
@@ -72,30 +74,34 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
         return promise;
       }
     });
-    it('should be detectable by Modernizr', async({newContext, server}) => {
-      const context = await newContext({ viewport: iPhone.viewport });
+    it('should be detectable by Modernizr', async({browser, server}) => {
+      const context = await browser.newContext({ viewport: iPhone.viewport });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/detect-touch.html');
       expect(await page.evaluate(() => document.body.textContent.trim())).toBe('YES');
+      await context.close();
     });
-    it('should detect touch when applying viewport with touches', async({newContext, server}) => {
-      const context = await newContext({ viewport: { width: 800, height: 600, isMobile: true } });
+    it('should detect touch when applying viewport with touches', async({browser, server}) => {
+      const context = await browser.newContext({ viewport: { width: 800, height: 600, isMobile: true } });
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
       await page.addScriptTag({url: server.PREFIX + '/modernizr.js'});
       expect(await page.evaluate(() => Modernizr.touchevents)).toBe(true);
+      await context.close();
     });
-    it.skip(FFOX)('should support landscape emulation', async({newContext, server}) => {
-      const context1 = await newContext({ viewport: iPhone.viewport });
+    it.skip(FFOX)('should support landscape emulation', async({browser, server}) => {
+      const context1 = await browser.newContext({ viewport: iPhone.viewport });
       const page1 = await context1.newPage();
       await page1.goto(server.PREFIX + '/mobile.html');
       expect(await page1.evaluate(() => matchMedia('(orientation: landscape)').matches)).toBe(false);
-      const context2 = await newContext({ viewport: iPhoneLandscape.viewport });
+      const context2 = await browser.newContext({ viewport: iPhoneLandscape.viewport });
       const page2 = await context2.newPage();
       expect(await page2.evaluate(() => matchMedia('(orientation: landscape)').matches)).toBe(true);
+      await context1.close();
+      await context2.close();
     });
-    it.skip(FFOX || WEBKIT)('should fire orientationchange event', async({newContext, server}) => {
-      const context = await newContext({ viewport: { width: 300, height: 400, isMobile: true } });
+    it.skip(FFOX || WEBKIT)('should fire orientationchange event', async({browser, server}) => {
+      const context = await browser.newContext({ viewport: { width: 300, height: 400, isMobile: true } });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
       await page.evaluate(() => {
@@ -110,35 +116,42 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       const event2 = page.waitForEvent('console');
       await page.setViewportSize({width: 300, height: 400});
       expect((await event2).text()).toBe('2');
+      await context.close();
     });
-    it.skip(FFOX)('default mobile viewports to 980 width', async({newContext, server}) => {
-      const context = await newContext({ viewport: {width: 320, height: 480, isMobile: true} });
+    it.skip(FFOX)('default mobile viewports to 980 width', async({browser, server}) => {
+      const context = await browser.newContext({ viewport: {width: 320, height: 480, isMobile: true} });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/empty.html');
       expect(await page.evaluate(() => window.innerWidth)).toBe(980);
+      await context.close();
     });
-    it.skip(FFOX)('respect meta viewport tag', async({newContext, server}) => {
-      const context = await newContext({ viewport: {width: 320, height: 480, isMobile: true} });
+    it.skip(FFOX)('respect meta viewport tag', async({browser, server}) => {
+      const context = await browser.newContext({ viewport: {width: 320, height: 480, isMobile: true} });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
       expect(await page.evaluate(() => window.innerWidth)).toBe(320);
+      await context.close();
     });
   });
 
   describe('Page.emulate', function() {
-    it('should work', async({newPage, server}) => {
-      const page = await newPage({ viewport: iPhone.viewport, userAgent: iPhone.userAgent });
+    it('should work', async({browser, server}) => {
+      const context = await browser.newContext({viewport: iPhone.viewport, userAgent: iPhone.userAgent});
+      const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
       expect(await page.evaluate(() => window.innerWidth)).toBe(375);
       expect(await page.evaluate(() => navigator.userAgent)).toContain('iPhone');
+      await context.close();
     });
-    it('should support clicking', async({newPage, server}) => {
-      const page = await newPage({ viewport: iPhone.viewport, userAgent: iPhone.userAgent });
+    it('should support clicking', async({browser, server}) => {
+      const context = await browser.newContext({ viewport: iPhone.viewport, userAgent: iPhone.userAgent });
+      const page = await context.newPage();
       await page.goto(server.PREFIX + '/input/button.html');
       const button = await page.$('button');
       await page.evaluate(button => button.style.marginTop = '200px', button);
       await button.click();
       expect(await page.evaluate(() => result)).toBe('Clicked');
+      await context.close();
     });
   });
 
@@ -201,72 +214,94 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
   });
 
   describe.skip(FFOX)('BrowserContext({timezoneId})', function() {
-    it('should work', async ({ newPage }) => {
+    it('should work', async ({ browser }) => {
       const func = () => new Date(1479579154987).toString();
       {
-        const page = await newPage({ timezoneId: 'America/Jamaica' });
+        const context = await browser.newContext({ timezoneId: 'America/Jamaica' });
+        const page = await context.newPage();
         expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 13:12:34 GMT-0500 (Eastern Standard Time)');
+        await context.close();
       }
       {
-        const page = await newPage({ timezoneId: 'Pacific/Honolulu' });
+        const context = await browser.newContext({ timezoneId: 'Pacific/Honolulu' });
+        const page = await context.newPage();
         expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 08:12:34 GMT-1000 (Hawaii-Aleutian Standard Time)');
+        await context.close();
       }
       {
-        const page = await newPage({ timezoneId: 'America/Buenos_Aires' });
+        const context = await browser.newContext({ timezoneId: 'America/Buenos_Aires' });
+        const page = await context.newPage();
         expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 15:12:34 GMT-0300 (Argentina Standard Time)');
+        await context.close();
       }
       {
-        const page = await newPage({ timezoneId: 'Europe/Berlin' });
+        const context = await browser.newContext({ timezoneId: 'Europe/Berlin' });
+        const page = await context.newPage();
         expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 19:12:34 GMT+0100 (Central European Standard Time)');
+        await context.close();
       }
     });
 
-    it('should throw for invalid timezone IDs', async({newPage}) => {
-      let error = null;
-      await newPage({ timezoneId: 'Foo/Bar' }).catch(e => error = e);
-      expect(error.message).toBe('Invalid timezone ID: Foo/Bar');
-      await newPage({ timezoneId: 'Baz/Qux' }).catch(e => error = e);
-      expect(error.message).toBe('Invalid timezone ID: Baz/Qux');
+    it('should throw for invalid timezone IDs when creating pages', async({browser}) => {
+      for (const timezoneId of ['Foo/Bar', 'Baz/Qux']) {
+        let error = null;
+        const context = await browser.newContext({ timezoneId });
+        const page = await context.newPage().catch(e => error = e);
+        expect(error.message).toBe(`Invalid timezone ID: ${timezoneId}`);
+        await context.close();
+      }
     });
   });
 
   describe.skip(CHROMIUM || FFOX)('BrowserContext({locale})', function() {
-    it('should affect accept-language header', async({newPage, server}) => {
-      const page = await newPage({ locale: 'fr-CH' });
+    it('should affect accept-language header', async({browser, server}) => {
+      const context = await browser.newContext({ locale: 'fr-CH' });
+      const page = await browser.newPage();
       const [request] = await Promise.all([
         server.waitForRequest('/empty.html'),
         page.goto(server.EMPTY_PAGE),
       ]);
       expect(request.headers['accept-language'].substr(0, 5)).toBe('fr-CH');
+      await context.close();
     });
-    it('should affect navigator.language', async({newPage, server}) => {
-      const page = await newPage({ locale: 'fr-CH' });
+    it('should affect navigator.language', async({browser, server}) => {
+      const context = await browser.newContext({ locale: 'fr-CH' });
+      const page = await context.newPage();
       expect(await page.evaluate(() => navigator.language)).toBe('fr-CH');
+      await context.close();
     });
-    it('should format number', async({newPage, server}) => {
+    it('should format number', async({browser, server}) => {
       {
-        const page = await newPage({ locale: 'en-US' });
+        const context = await browser.newContext({ locale: 'en-US' });
+        const page = await context.newPage();
         await page.goto(server.EMPTY_PAGE);
         expect(await page.evaluate(() => (1000000.50).toLocaleString())).toBe('1,000,000.5');
+        await context.close();
       }
       {
-        const page = await newPage({ locale: 'fr-CH' });
+        const context = await browser.newContext({ locale: 'fr-CH' });
+        const page = await context.newPage();
         await page.goto(server.EMPTY_PAGE);
         expect(await page.evaluate(() => (1000000.50).toLocaleString().replace(/\s/g, ' '))).toBe('1 000 000,5');
+        await context.close();
       }
     });
-    it('should format date', async({newPage, server}) => {
+    it('should format date', async({browser, server}) => {
       {
-        const page = await newPage({ locale: 'en-US', timezoneId: 'America/Los_Angeles' });
+        const context = await browser.newContext({ locale: 'en-US', timezoneId: 'America/Los_Angeles' });
+        const page = await context.newPage();
         await page.goto(server.EMPTY_PAGE);
         const formatted = 'Sat Nov 19 2016 10:12:34 GMT-0800 (Pacific Standard Time)';
         expect(await page.evaluate(() => new Date(1479579154987).toString())).toBe(formatted);
+        await context.close();
       }
       {
-        const page = await newPage({ locale: 'de-DE', timezoneId: 'Europe/Berlin' });
+        const context = await browser.newContext({ locale: 'de-DE', timezoneId: 'Europe/Berlin' });
+        const page = await context.newPage();
         await page.goto(server.EMPTY_PAGE);
         expect(await page.evaluate(() => new Date(1479579154987).toString())).toBe(
             'Sat Nov 19 2016 19:12:34 GMT+0100 (Mitteleuropäische Normalzeit)');
+        await context.close();
       }
     });
   });

--- a/test/emulation.spec.js
+++ b/test/emulation.spec.js
@@ -256,7 +256,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
   describe.skip(CHROMIUM || FFOX)('BrowserContext({locale})', function() {
     it('should affect accept-language header', async({browser, server}) => {
       const context = await browser.newContext({ locale: 'fr-CH' });
-      const page = await browser.newPage();
+      const page = await context.newPage();
       const [request] = await Promise.all([
         server.waitForRequest('/empty.html'),
         page.goto(server.EMPTY_PAGE),

--- a/test/features/permissions.spec.js
+++ b/test/features/permissions.spec.js
@@ -78,9 +78,9 @@ module.exports.describe = function({testRunner, expect, WEBKIT}) {
       await context.clearPermissions();
       expect(await page.evaluate(() => window['events'])).toEqual(['prompt', 'denied', 'granted', 'prompt']);
     });
-    it('should isolate permissions between browser contexs', async({page, server, context, newContext}) => {
+    it('should isolate permissions between browser contexs', async({page, server, context, browser}) => {
       await page.goto(server.EMPTY_PAGE);
-      const otherContext = await newContext();
+      const otherContext = await browser.newContext();
       const otherPage = await otherContext.newPage();
       await otherPage.goto(server.EMPTY_PAGE);
       expect(await getPermission(page, 'geolocation')).toBe('prompt');
@@ -94,6 +94,7 @@ module.exports.describe = function({testRunner, expect, WEBKIT}) {
       await context.clearPermissions();
       expect(await getPermission(page, 'geolocation')).toBe('prompt');
       expect(await getPermission(otherPage, 'geolocation')).toBe('granted');
+      await otherContext.close();
     });
   });
 };

--- a/test/geolocation.spec.js
+++ b/test/geolocation.spec.js
@@ -54,27 +54,28 @@ module.exports.describe = function ({ testRunner, expect, FFOX, WEBKIT }) {
       }
       expect(error.message).toContain('Invalid latitude "undefined"');
     });
-    it('should not modify passed default options object', async({newContext}) => {
+    it('should not modify passed default options object', async({browser}) => {
       const geolocation = { longitude: 10, latitude: 10 };
       const options = { geolocation };
-      const context = await newContext(options);
+      const context = await browser.newContext(options);
       await context.setGeolocation({ longitude: 20, latitude: 20 });
       expect(options.geolocation).toBe(geolocation);
+      await context.close();
     });
-    it('should throw with missing longitude in default options', async({newContext}) => {
+    it('should throw with missing longitude in default options', async({browser}) => {
       let error = null;
       try {
-        const context = await newContext({ geolocation: {latitude: 10} });
+        const context = await browser.newContext({ geolocation: {latitude: 10} });
         await context.close();
       } catch (e) {
         error = e;
       }
       expect(error.message).toContain('Invalid longitude "undefined"');
     });
-    it('should use context options', async({newContext, server}) => {
+    it('should use context options', async({browser, server}) => {
       const options = { geolocation: { longitude: 10, latitude: 10 }, permissions: {} };
       options.permissions[server.PREFIX] = ['geolocation'];
-      const context = await newContext(options);
+      const context = await browser.newContext(options);
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
 
@@ -85,6 +86,7 @@ module.exports.describe = function ({ testRunner, expect, FFOX, WEBKIT }) {
         latitude: 10,
         longitude: 10
       });
+      await context.close();
     });
   });
 };

--- a/test/ignorehttpserrors.spec.js
+++ b/test/ignorehttpserrors.spec.js
@@ -23,24 +23,28 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   const {it, fit, xit, dit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
   describe('ignoreHTTPSErrors', function() {
-    it('should work', async({newPage, httpsServer}) => {
+    it('should work', async({browser, httpsServer}) => {
       let error = null;
-      const page = await newPage({ ignoreHTTPSErrors: true });
+      const context = await browser.newContext({ ignoreHTTPSErrors: true });
+      const page = await context.newPage();
       const response = await page.goto(httpsServer.EMPTY_PAGE).catch(e => error = e);
       expect(error).toBe(null);
       expect(response.ok()).toBe(true);
+      await context.close();
     });
-    it('should work with mixed content', async({newPage, server, httpsServer}) => {
+    it('should work with mixed content', async({browser, server, httpsServer}) => {
       httpsServer.setRoute('/mixedcontent.html', (req, res) => {
         res.end(`<iframe src=${server.EMPTY_PAGE}></iframe>`);
       });
-      const page = await newPage({ ignoreHTTPSErrors: true });
+      const context = await browser.newContext({ ignoreHTTPSErrors: true });
+      const page = await context.newPage();
       await page.goto(httpsServer.PREFIX + '/mixedcontent.html', {waitUntil: 'load'});
       expect(page.frames().length).toBe(2);
       // Make sure blocked iframe has functional execution context
       // @see https://github.com/GoogleChrome/puppeteer/issues/2709
       expect(await page.frames()[0].evaluate('1 + 2')).toBe(3);
       expect(await page.frames()[1].evaluate('2 + 3')).toBe(5);
+      await context.close();
     });
   });
 };

--- a/test/interception.spec.js
+++ b/test/interception.spec.js
@@ -325,9 +325,10 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       await request.continue().catch(e => error = e);
       expect(error).toBe(null);
     });
-    it('should throw if interception is not enabled', async({newPage, server}) => {
+    it('should throw if interception is not enabled', async({browser, server}) => {
       let error = null;
-      const page = await newPage();
+      const context = await browser.newContext();
+      const page = await context.newPage();
       page.on('request', async request => {
         try {
           await request.continue();
@@ -337,6 +338,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       });
       await page.goto(server.EMPTY_PAGE);
       expect(error.message).toContain('Request Interception is not enabled');
+      await context.close();
     });
     it('should intercept main resource during cross-process navigation', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
@@ -558,12 +560,14 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   });
 
   describe('ignoreHTTPSErrors', function() {
-    it('should work with request interception', async({newPage, httpsServer}) => {
-      const page = await newPage({ ignoreHTTPSErrors: true, interceptNetwork: true });
+    it('should work with request interception', async({browser, httpsServer}) => {
+      const context = await browser.newContext({ ignoreHTTPSErrors: true, interceptNetwork: true });
+      const page = await context.newPage();
 
       await page.route('**/*', request => request.continue());
       const response = await page.goto(httpsServer.EMPTY_PAGE);
       expect(response.status()).toBe(200);
+      await context.close();
     });
   });
 

--- a/test/mouse.spec.js
+++ b/test/mouse.spec.js
@@ -133,8 +133,8 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, 
       ]);
     });
     // @see https://crbug.com/929806
-    it('should work with mobile viewports and cross process navigations', async({newContext, server}) => {
-      const context = await newContext({ viewport: {width: 360, height: 640, isMobile: true} });
+    it('should work with mobile viewports and cross process navigations', async({browser, server}) => {
+      const context = await browser.newContext({ viewport: {width: 360, height: 640, isMobile: true} });
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
       await page.goto(server.CROSS_PROCESS_PREFIX + '/mobile.html');
@@ -147,6 +147,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, 
       await page.mouse.click(30, 40);
 
       expect(await page.evaluate('result')).toEqual({x: 30, y: 40});
+      await context.close();
     });
   });
 };

--- a/test/playwright.spec.js
+++ b/test/playwright.spec.js
@@ -112,7 +112,6 @@ module.exports.describe = ({testRunner, product, playwrightPath}) => {
     });
 
     beforeEach(async(state, test) => {
-      const contexts = [];
       const onLine = (line) => test.output += line + '\n';
       if (dumpProtocolOnFailure)
         state.browser._setDebugFunction(onLine);
@@ -125,7 +124,6 @@ module.exports.describe = ({testRunner, product, playwrightPath}) => {
       }
 
       state.tearDown = async () => {
-        await Promise.all(contexts.map(c => c.close()));
         if (rl) {
           rl.removeListener('line', onLine);
           rl.close();
@@ -133,30 +131,22 @@ module.exports.describe = ({testRunner, product, playwrightPath}) => {
         if (dumpProtocolOnFailure)
           state.browser._setDebugFunction(() => void 0);
       };
-
-      state.newContext = async (options) => {
-        const context = await state.browser.newContext(options);
-        contexts.push(context);
-        return context;
-      };
-
-      state.newPage = async (options) => {
-        const context = await state.newContext(options);
-        return await context.newPage();
-      };
     });
 
-    afterEach(async state => {
+    afterEach(async (state, test) => {
+      if (state.browser.contexts().length !== 0)
+        console.warn(`\nWARNING: test "${test.fullName}" (${test.location.fileName}:${test.location.lineNumber}) did not close all created contexts!\n`);
       await state.tearDown();
     });
 
     describe('Page', function() {
       beforeEach(async state => {
-        state.context = await state.newContext();
+        state.context = await state.browser.newContext();
         state.page = await state.context.newPage();
       });
 
       afterEach(async state => {
+        await state.context.close();
         state.context = null;
         state.page = null;
       });

--- a/test/playwright.spec.js
+++ b/test/playwright.spec.js
@@ -134,8 +134,11 @@ module.exports.describe = ({testRunner, product, playwrightPath}) => {
     });
 
     afterEach(async (state, test) => {
-      if (state.browser.contexts().length !== 0)
-        console.warn(`\nWARNING: test "${test.fullName}" (${test.location.fileName}:${test.location.lineNumber}) did not close all created contexts!\n`);
+      if (state.browser.contexts().length !== 0) {
+        if (test.result === 'ok')
+          console.warn(`\nWARNING: test "${test.fullName}" (${test.location.fileName}:${test.location.lineNumber}) did not close all created contexts!\n`);
+        await Promise.all(state.browser.contexts().map(context => context.close()));
+      }
       await state.tearDown();
     });
 

--- a/test/popup.spec.js
+++ b/test/popup.spec.js
@@ -20,8 +20,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('window.open', function() {
-    it.skip(CHROMIUM || WEBKIT)('should inherit user agent from browser context', async function({newContext, server}) {
-      const context = await newContext({
+    it.skip(CHROMIUM || WEBKIT)('should inherit user agent from browser context', async function({browser, server}) {
+      const context = await browser.newContext({
         userAgent: 'hey'
       });
       const page = await context.newPage();
@@ -36,8 +36,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       expect(userAgent).toBe('hey');
       expect(request.headers['user-agent']).toBe('hey');
     });
-    it.skip(CHROMIUM)('should inherit touch support from browser context', async function({newContext, server}) {
-      const context = await newContext({
+    it.skip(CHROMIUM)('should inherit touch support from browser context', async function({browser, server}) {
+      const context = await browser.newContext({
         viewport: { width: 400, height: 500, isMobile: true }
       });
       const page = await context.newPage();
@@ -49,8 +49,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       await context.close();
       expect(hasTouch).toBe(true);
     });
-    it.skip(CHROMIUM || WEBKIT)('should inherit viewport size from browser context', async function({newContext, server}) {
-      const context = await newContext({
+    it.skip(CHROMIUM || WEBKIT)('should inherit viewport size from browser context', async function({browser, server}) {
+      const context = await browser.newContext({
         viewport: { width: 400, height: 500, isMobile: true }
       });
       const page = await context.newPage();
@@ -65,8 +65,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
   });
 
   describe('Page.Events.Popup', function() {
-    it('should work', async({newContext}) => {
-      const context = await newContext();
+    it('should work', async({browser}) => {
+      const context = await browser.newContext();
       const page = await context.newPage();
       const [popup] = await Promise.all([
         new Promise(x => page.once('popup', x)),
@@ -76,8 +76,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       expect(await popup.evaluate(() => !!window.opener)).toBe(true);
       await context.close();
     });
-    it.skip(CHROMIUM)('should work with empty url', async({newContext}) => {
-      const context = await newContext();
+    it.skip(CHROMIUM)('should work with empty url', async({browser}) => {
+      const context = await browser.newContext();
       const page = await context.newPage();
       const [popup] = await Promise.all([
         new Promise(x => page.once('popup', x)),
@@ -87,8 +87,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       expect(await popup.evaluate(() => !!window.opener)).toBe(true);
       await context.close();
     });
-    it('should work with noopener', async({newContext}) => {
-      const context = await newContext();
+    it('should work with noopener', async({browser}) => {
+      const context = await browser.newContext();
       const page = await context.newPage();
       const [popup] = await Promise.all([
         new Promise(x => page.once('popup', x)),
@@ -98,8 +98,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       expect(await popup.evaluate(() => !!window.opener)).toBe(false);
       await context.close();
     });
-    it('should work with clicking target=_blank', async({newContext, server}) => {
-      const context = await newContext();
+    it('should work with clicking target=_blank', async({browser, server}) => {
+      const context = await browser.newContext();
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
       await page.setContent('<a target=_blank rel="opener" href="/one-style.html">yo</a>');
@@ -111,8 +111,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       expect(await popup.evaluate(() => !!window.opener)).toBe(true);
       await context.close();
     });
-    it('should work with fake-clicking target=_blank and rel=noopener', async({newContext, server}) => {
-      const context = await newContext();
+    it('should work with fake-clicking target=_blank and rel=noopener', async({browser, server}) => {
+      const context = await browser.newContext();
       const page = await context.newPage();
       // TODO: FFOX sends events for "one-style.html" request to both pages.
       await page.goto(server.EMPTY_PAGE);
@@ -127,8 +127,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       expect(await popup.evaluate(() => !!window.opener)).toBe(false);
       await context.close();
     });
-    it('should work with clicking target=_blank and rel=noopener', async({newContext, server}) => {
-      const context = await newContext();
+    it('should work with clicking target=_blank and rel=noopener', async({browser, server}) => {
+      const context = await browser.newContext();
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
       await page.setContent('<a target=_blank rel=noopener href="/one-style.html">yo</a>');
@@ -140,8 +140,8 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       expect(await popup.evaluate(() => !!window.opener)).toBe(false);
       await context.close();
     });
-    it('should not treat navigations as new popups', async({newContext, server}) => {
-      const context = await newContext();
+    it('should not treat navigations as new popups', async({browser, server}) => {
+      const context = await browser.newContext();
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
       await page.setContent('<a target=_blank rel=noopener href="/one-style.html">yo</a>');

--- a/test/screenshot.spec.js
+++ b/test/screenshot.spec.js
@@ -156,12 +156,13 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       });
       expect(Buffer.from(screenshot, 'base64')).toBeGolden('screenshot-sanity.png');
     });
-    it.skip(FFOX)('should work with a mobile viewport', async({newContext, server}) => {
-      const context = await newContext({viewport: { width: 320, height: 480, isMobile: true }});
+    it.skip(FFOX)('should work with a mobile viewport', async({browser, server}) => {
+      const context = await browser.newContext({viewport: { width: 320, height: 480, isMobile: true }});
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/overflow.html');
       const screenshot = await page.screenshot();
       expect(screenshot).toBeGolden('screenshot-mobile.png');
+      await context.close();
     });
     it('should work for canvas', async({page, server}) => {
       await page.setViewportSize({width: 500, height: 500});
@@ -358,8 +359,9 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       const screenshot = await elementHandle.screenshot();
       expect(screenshot).toBeGolden('screenshot-element-fractional-offset.png');
     });
-    it('should take screenshots when default viewport is null', async({server, newPage}) => {
-      const page = await newPage({ viewport: null });
+    it('should take screenshots when default viewport is null', async({server, browser}) => {
+      const context = await browser.newContext({ viewport: null });
+      const page = await context.newPage();
       await page.goto(server.PREFIX + '/grid.html');
       const sizeBefore = await page.evaluate(() => ({ width: document.body.offsetWidth, height: document.body.offsetHeight }));
       const screenshot = await page.screenshot();
@@ -368,9 +370,11 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       const sizeAfter = await page.evaluate(() => ({ width: document.body.offsetWidth, height: document.body.offsetHeight }));
       expect(sizeBefore.width).toBe(sizeAfter.width);
       expect(sizeBefore.height).toBe(sizeAfter.height);
+      await context.close();
     });
-    it('should take fullPage screenshots when default viewport is null', async({server, newPage}) => {
-      const page = await newPage({ viewport: null });
+    it('should take fullPage screenshots when default viewport is null', async({server, browser}) => {
+      const context = await browser.newContext({ viewport: null });
+      const page = await context.newPage();
       await page.goto(server.PREFIX + '/grid.html');
       const sizeBefore = await page.evaluate(() => ({ width: document.body.offsetWidth, height: document.body.offsetHeight }));
       const screenshot = await page.screenshot({
@@ -381,9 +385,11 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       const sizeAfter = await page.evaluate(() => ({ width: document.body.offsetWidth, height: document.body.offsetHeight }));
       expect(sizeBefore.width).toBe(sizeAfter.width);
       expect(sizeBefore.height).toBe(sizeAfter.height);
+      await context.close();
     });
-    it('should restore default viewport after fullPage screenshot', async({ newPage }) => {
-      const page = await newPage({ viewport: { width: 456, height: 789 } });
+    it('should restore default viewport after fullPage screenshot', async({ browser }) => {
+      const context = await browser.newContext({ viewport: { width: 456, height: 789 } });
+      const page = await context.newPage();
       expect(page.viewportSize().width).toBe(456);
       expect(page.viewportSize().height).toBe(789);
       expect(await page.evaluate('window.innerWidth')).toBe(456);
@@ -394,9 +400,11 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(page.viewportSize().height).toBe(789);
       expect(await page.evaluate('window.innerWidth')).toBe(456);
       expect(await page.evaluate('window.innerHeight')).toBe(789);
+      await context.close();
     });
-    it('should take element screenshot when default viewport is null and restore back', async({server, newPage}) => {
-      const page = await newPage({ viewport: null });
+    it('should take element screenshot when default viewport is null and restore back', async({server, browser}) => {
+      const context = await browser.newContext({viewport: null});
+      const page = await context.newPage({ viewport: null });
       await page.setContent(`
         <div style="height: 14px">oooo</div>
         <style>
@@ -421,8 +429,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       const sizeAfter = await page.evaluate(() => ({ width: document.body.offsetWidth, height: document.body.offsetHeight }));
       expect(sizeBefore.width).toBe(sizeAfter.width);
       expect(sizeBefore.height).toBe(sizeAfter.height);
+      await context.close();
     });
   });
-
-
 };

--- a/test/types.d.ts
+++ b/test/types.d.ts
@@ -66,8 +66,6 @@ type TestState = {
 type BrowserState = TestState & {
     browser: import('../src/browser').Browser;
     browserServer: import('../src/server/browserServer').BrowserServer;
-    newPage: (options?: import('../src/browserContext').BrowserContextOptions) => Promise<import('../src/page').Page>;
-    newContext: (options?: import('../src/browserContext').BrowserContextOptions) => Promise<import('../src/browserContext').BrowserContext>;
 };
 
 type PageState = BrowserState & {


### PR DESCRIPTION
All tests should clean up their contexts themselves.