### PR TITLE
docs: added community example project

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -25,6 +25,7 @@
  
 * [e2e Boilerplates](https://github.com/e2e-boilerplates?utf8=%E2%9C%93&q=playwright): Project boilerplates for using Playwright with TypeScript, Cucumber, Jest, and other libraries
 * [react-app-playwright](https://github.com/KyleADay/react-app-playwright): Using Playwright with a create-react-app project
+* [playwright-react-typescript-jest-example](https://github.com/azemetre/playwright-react-typescript-jest-example): Using Playwright + Jest with a custom webpack configuration for React + Typescript project 
 * [playwright-mocha](https://github.com/roggerfe/playwright-mocha): Using Playwright with Mocha and Chai
 * [playwright-github-actions](https://github.com/arjun27/playwright-github-actions/actions): Playwright setup on GitHub Actions
 * [playwright-azure-functions](https://github.com/arjun27/playwright-azure-functions): Playwright setup on Azure Functions


### PR DESCRIPTION
Hello!

We love playwright where I work and are slowly starting to use it in a variety of ways.

I've created a community tutorial that shows users how to use playwright to do some user interactions and assertions for a TypeScript + React project:

https://github.com/azemetre/playwright-react-typescript-jest-example

I liked to it in the community section for the `docs/showcase.md`.