### PR TITLE
fix(api): split waitForSelectorMissing from waitForSelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Puppeteer is a Node library which provides a high-level API to control Chrome or
 
 We are the same team that originally built Puppeteer at Google, but has since then moved on. Puppeteer proved that there is a lot of interest in the new generation of ever-green, capable and reliable automation drivers. With Playwright, we'd like to take it one step further and offer the same functionality for **all** the popular rendering engines. We'd like to see Playwright vendor-neutral and shared governed.
 
-With Playwright, we are making the APIs more testing-friendly as well. We are taking the lessons learned from Puppeteer and incorporate them into the API, for example, user agent / device emulation is set up consistently on the `BrowserContext` level to enable multi-page scenarios, `click` waits for the element to be available and visible by default, there is a way to wait for network and other events, etc.
+With Playwright, we are making the APIs more testing-friendly as well. We are taking the lessons learned from Puppeteer and incorporate them into the API, for example, user agent / device emulation is set up consistently on the `BrowserContext` level to enable multi-page scenarios, `click` waits for the element to be available and clickable by default, there is a way to wait for network and other events, etc.
 
 Playwright also aims at being cloud-native. Rather than a single page, `BrowserContext` abstraction is now central to the library operation. `BrowserContext`s are isolated, they can be either created locally or provided as a service.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -531,6 +531,7 @@ page.removeListener('request', logRequest);
 - [page.waitForRequest(urlOrPredicate[, options])](#pagewaitforrequesturlorpredicate-options)
 - [page.waitForResponse(urlOrPredicate[, options])](#pagewaitforresponseurlorpredicate-options)
 - [page.waitForSelector(selector[, options])](#pagewaitforselectorselector-options)
+- [page.waitForSelectorMissing(selector[, options])](#pagewaitforselectormissingselector-options)
 - [page.workers()](#pageworkers)
 <!-- GEN:stop -->
 
@@ -705,9 +706,8 @@ Shortcut for [page.mainFrame().$eval(selector, pageFunction)](#frameevalselector
 #### page.$wait(selector[, options])
 - `selector` <[string]> A selector of an element to wait for
 - `options` <[Object]>
-  - `visibility` <"visible"|"hidden"|"any"> Wait for element to become visible (`visible`), hidden (`hidden`), present in dom (`any`). Defaults to `any`.
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
-- returns: <[Promise]<?[ElementHandle]>> Promise which resolves when element specified by selector string is added to DOM. Resolves to `null` if waiting for `hidden: true` and selector is not found in DOM.
+- returns: <[Promise]<?[ElementHandle]>> Promise which resolves when element specified by selector string is added to DOM.
 
 Wait for the `selector` to appear in page. If at the moment of calling
 the method the `selector` already exists, the method will return
@@ -1447,7 +1447,6 @@ This is a shortcut for [page.mainFrame().url()](#frameurl)
 #### page.waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])
 - `selectorOrFunctionOrTimeout` <[string]|[number]|[function]> A [selector], predicate or timeout to wait for
 - `options` <[Object]> Optional waiting parameters
-  - `visibility` <"visible"|"hidden"|"any"> Wait for element to become visible (`visible`), hidden (`hidden`), present in dom (`any`). Defaults to `any`.
   - `polling` <[number]|"raf"|"mutation"> An interval at which the `pageFunction` is executed, defaults to `raf`. If `polling` is a number, then it is treated as an interval in milliseconds at which the function would be executed. If `polling` is a string, then it can be one of the following values:
     - `'raf'` - to constantly execute `pageFunction` in `requestAnimationFrame` callback. This is the tightest polling mode which is suitable to observe styling changes.
     - `'mutation'` - to execute `pageFunction` on every DOM mutation.
@@ -1456,8 +1455,7 @@ This is a shortcut for [page.mainFrame().url()](#frameurl)
 - returns: <[Promise]<[JSHandle]>> Promise which resolves to a JSHandle of the success value
 
 This method behaves differently with respect to the type of the first parameter:
-- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector] or [xpath], depending on whether or not it starts with '//', and the method is a shortcut for
-  [page.waitForSelector](#pagewaitforselectorselector-options)
+- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector], and the method is a shortcut for [page.waitForSelector](#pagewaitforselectorselector-options)
 - if `selectorOrFunctionOrTimeout` is a `function`, then the first argument is treated as a predicate to wait for and the method is a shortcut for [page.waitForFunction()](#pagewaitforfunctionpagefunction-options-args).
 - if `selectorOrFunctionOrTimeout` is a `number`, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
 - otherwise, an exception is thrown
@@ -1601,9 +1599,8 @@ return finalResponse.ok();
 #### page.waitForSelector(selector[, options])
 - `selector` <[string]> A selector of an element to wait for
 - `options` <[Object]>
-  - `visibility` <"visible"|"hidden"|"any"> Wait for element to become visible (`visible`), hidden (`hidden`), present in dom (`any`). Defaults to `any`.
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
-- returns: <[Promise]<?[ElementHandle]>> Promise which resolves when element specified by selector string is added to DOM. Resolves to `null` if waiting for `hidden: true` and selector is not found in DOM.
+- returns: <[Promise]<?[ElementHandle]>> Promise which resolves when element specified by selector string is added to DOM.
 
 Wait for the `selector` to appear in page. If at the moment of calling
 the method the `selector` already exists, the method will return
@@ -1627,6 +1624,19 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 })();
 ```
 Shortcut for [page.mainFrame().waitForSelector(selector[, options])](#framewaitforselectorselector-options).
+
+
+#### page.waitForSelectorMissing(selector[, options])
+- `selector` <[string]> A selector of an element to wait for missing.
+- `options` <[Object]>
+  - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
+- returns: <[Promise]<?[ElementHandle]>> Promise which resolves when element specified by selector string is removed from DOM.
+
+Wait for the `selector` to disappear from the page. If at the moment of calling
+the method the `selector` already does not exist, the method will return
+immediately. If the selector doesn't disappear after the `timeout` milliseconds of waiting, the function will throw. This method works across navigations.
+
+Shortcut for [page.mainFrame().waitForSelectorMissing(selector[, options])](#framewaitforselectormissingselector-options).
 
 #### page.workers()
 - returns: <[Array]<[Worker]>>
@@ -1708,6 +1718,7 @@ An example of getting text from an iframe element:
 - [frame.waitForLoadState([options])](#framewaitforloadstateoptions)
 - [frame.waitForNavigation([options])](#framewaitfornavigationoptions)
 - [frame.waitForSelector(selector[, options])](#framewaitforselectorselector-options)
+- [frame.waitForSelectorMissing(selector[, options])](#framewaitforselectormissingselector-options)
 <!-- GEN:stop -->
 
 #### frame.$(selector)
@@ -1757,9 +1768,8 @@ const html = await frame.$eval('.main-container', e => e.outerHTML);
 #### frame.$wait(selector[, options])
 - `selector` <[string]> A selector of an element to wait for
 - `options` <[Object]>
-  - `visibility` <"visible"|"hidden"|"any"> Wait for element to become visible (`visible`), hidden (`hidden`), present in dom (`any`). Defaults to `any`.
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
-- returns: <[Promise]<?[ElementHandle]>> Promise which resolves when element specified by selector string is added to DOM. Resolves to `null` if waiting for `hidden: true` and selector is not found in DOM.
+- returns: <[Promise]<?[ElementHandle]>> Promise which resolves when element specified by selector string is added to DOM.
 
 Wait for the `selector` to appear in page. If at the moment of calling
 the method the `selector` already exists, the method will return
@@ -2102,7 +2112,6 @@ Returns frame's url.
 #### frame.waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])
 - `selectorOrFunctionOrTimeout` <[string]|[number]|[function]> A [selector], predicate or timeout to wait for
 - `options` <[Object]> Optional waiting parameters
-  - `visibility` <"visible"|"hidden"|"any"> Wait for element to become visible (`visible`), hidden (`hidden`), present in dom (`any`). Defaults to `any`.
   - `polling` <[number]|"raf"|"mutation"> An interval at which the `pageFunction` is executed, defaults to `raf`. If `polling` is a number, then it is treated as an interval in milliseconds at which the function would be executed. If `polling` is a string, then it can be one of the following values:
     - `'raf'` - to constantly execute `pageFunction` in `requestAnimationFrame` callback. This is the tightest polling mode which is suitable to observe styling changes.
     - `'mutation'` - to execute `pageFunction` on every DOM mutation.
@@ -2111,8 +2120,7 @@ Returns frame's url.
 - returns: <[Promise]<[JSHandle]>> Promise which resolves to a JSHandle of the success value
 
 This method behaves differently with respect to the type of the first parameter:
-- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector] or [xpath], depending on whether or not it starts with '//', and the method is a shortcut for
-  [frame.waitForSelector](#framewaitforselectorselector-options)
+- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector], and the method is a shortcut for [frame.waitForSelector](#framewaitforselectorselector-options)
 - if `selectorOrFunctionOrTimeout` is a `function`, then the first argument is treated as a predicate to wait for and the method is a shortcut for [frame.waitForFunction()](#framewaitforfunctionpagefunction-options-args).
 - if `selectorOrFunctionOrTimeout` is a `number`, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
 - otherwise, an exception is thrown
@@ -2209,9 +2217,8 @@ const [response] = await Promise.all([
 #### frame.waitForSelector(selector[, options])
 - `selector` <[string]> A selector of an element to wait for
 - `options` <[Object]>
-  - `visibility` <"visible"|"hidden"|"any"> Wait for element to become visible (`visible`), hidden (`hidden`), present in dom (`any`). Defaults to `any`.
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
-- returns: <[Promise]<?[ElementHandle]>> Promise which resolves when element specified by selector string is added to DOM. Resolves to `null` if waiting for `hidden: true` and selector is not found in DOM.
+- returns: <[Promise]<?[ElementHandle]>> Promise which resolves when element specified by selector string is added to DOM.
 
 Wait for the `selector` to appear in page. If at the moment of calling
 the method the `selector` already exists, the method will return
@@ -2235,6 +2242,15 @@ const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
 })();
 ```
 
+#### frame.waitForSelectorMissing(selector[, options])
+- `selector` <[string]> A selector of an element to wait for missing.
+- `options` <[Object]>
+  - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
+- returns: <[Promise]<?[ElementHandle]>> Promise which resolves when element specified by selector string is removed from DOM.
+
+Wait for the `selector` to disappear from the page. If at the moment of calling
+the method the `selector` already does not exist, the method will return
+immediately. If the selector doesn't disappear after the `timeout` milliseconds of waiting, the function will throw. This method works across navigations.
 
 ### class: ElementHandle
 * extends: [JSHandle]

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -581,18 +581,13 @@ export function waitForFunctionTask(selector: string | undefined, pageFunction: 
   }, await context._injected(), selector, predicateBody, polling, options.timeout || 0, ...args);
 }
 
-export function waitForSelectorTask(selector: string, visibility: types.Visibility, timeout: number): Task {
+export function waitForSelectorTask(selector: string, present: boolean, timeout: number): Task {
   selector = normalizeSelector(selector);
-  return async (context: FrameExecutionContext) => context.evaluateHandle((injected: Injected, selector: string, visibility: types.Visibility, timeout: number) => {
-    const polling = visibility === 'any' ? 'mutation' : 'raf';
-    return injected.poll(polling, selector, timeout, (element: Element | undefined): Element | boolean => {
-      if (!element)
-        return visibility === 'hidden';
-      if (visibility === 'any')
-        return element;
-      return injected.isVisible(element) === (visibility === 'visible') ? element : false;
+  return async (context: FrameExecutionContext) => context.evaluateHandle((injected: Injected, selector: string, present: boolean, timeout: number) => {
+    return injected.poll('mutation', selector, timeout, (element: Element | undefined) => {
+      return present ? element : !element;
     });
-  }, await context._injected(), selector, visibility, timeout);
+  }, await context._injected(), selector, present, timeout);
 }
 
 export const setFileInputFunction = async (element: HTMLInputElement, payloads: types.FilePayload[]) => {

--- a/src/injected/injected.ts
+++ b/src/injected/injected.ts
@@ -135,16 +135,6 @@ class Injected {
     return result;
   }
 
-  isVisible(element: Element): boolean {
-    if (!element.ownerDocument || !element.ownerDocument.defaultView)
-      return true;
-    const style = element.ownerDocument.defaultView.getComputedStyle(element);
-    if (!style || style.visibility === 'hidden')
-      return false;
-    const rect = element.getBoundingClientRect();
-    return !!(rect.top || rect.bottom || rect.width || rect.height);
-  }
-
   private _pollMutation(selector: string | undefined, predicate: Predicate, timeout: number): Promise<any> {
     let timedOut = false;
     if (timeout)

--- a/src/page.ts
+++ b/src/page.ts
@@ -211,11 +211,15 @@ export class Page extends platform.EventEmitter {
     return this.mainFrame().$(selector);
   }
 
-  async waitForSelector(selector: string, options?: types.TimeoutOptions & { visibility?: types.Visibility }): Promise<dom.ElementHandle<Element> | null> {
+  async waitForSelector(selector: string, options?: types.TimeoutOptions): Promise<dom.ElementHandle<Element> | null> {
     return this.mainFrame().waitForSelector(selector, options);
   }
 
-  async $wait(selector: string, options?: types.TimeoutOptions & { visibility?: types.Visibility }): Promise<dom.ElementHandle<Element> | null> {
+  async waitForSelectorMissing(selector: string, options?: types.TimeoutOptions): Promise<void> {
+    return this.mainFrame().waitForSelectorMissing(selector, options);
+  }
+
+  async $wait(selector: string, options?: types.TimeoutOptions): Promise<dom.ElementHandle<Element> | null> {
     return this.mainFrame().$wait(selector, options);
   }
 
@@ -525,7 +529,7 @@ export class Page extends platform.EventEmitter {
     return this.mainFrame().uncheck(selector, options);
   }
 
-  async waitFor(selectorOrFunctionOrTimeout: (string | number | Function), options?: types.WaitForFunctionOptions & { visibility?: types.Visibility }, ...args: any[]): Promise<js.JSHandle | null> {
+  async waitFor(selectorOrFunctionOrTimeout: (string | number | Function), options?: types.WaitForFunctionOptions, ...args: any[]): Promise<js.JSHandle | null> {
     return this.mainFrame().waitFor(selectorOrFunctionOrTimeout, options, ...args);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,8 +38,6 @@ export type Quad = [ Point, Point, Point, Point ];
 export type TimeoutOptions = { timeout?: number };
 export type WaitForOptions = TimeoutOptions & { waitFor?: boolean };
 
-export type Visibility = 'visible' | 'hidden' | 'any';
-
 export type Polling = 'raf' | 'mutation' | number;
 export type WaitForFunctionOptions = TimeoutOptions & { polling?: Polling };
 

--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -158,7 +158,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       const error = await page.click('button', { waitFor: 'visible' }).catch(e => e);
       expect(error.message).toBe('waitFor option should be a boolean, got "string"');
     });
-    it('should waitFor visible', async({page, server}) => {
+    it('should waitFor display:none to be cleared', async({page, server}) => {
       let done = false;
       await page.goto(server.PREFIX + '/input/button.html');
       await page.$eval('button', b => b.style.display = 'none');

--- a/test/queryselector.spec.js
+++ b/test/queryselector.spec.js
@@ -200,17 +200,6 @@ module.exports.describe = function({testRunner, expect, selectors, FFOX, CHROMIU
       const element = await page.$('css=section >> css=div');
       expect(element).toBeTruthy();
     });
-    it('should respect waitFor visibility', async({page, server}) => {
-      await page.setContent('<section id="testAttribute">43543</section>');
-      expect(await page.waitForSelector('css=section', { waitFor: 'visible'})).toBeTruthy();
-      expect(await page.waitForSelector('css=section', { waitFor: 'any'})).toBeTruthy();
-      expect(await page.waitForSelector('css=section')).toBeTruthy();
-
-      await page.setContent('<section id="testAttribute" style="display: none">43543</section>');
-      expect(await page.waitForSelector('css=section', { waitFor: 'hidden'})).toBeTruthy();
-      expect(await page.waitForSelector('css=section', { waitFor: 'any'})).toBeTruthy();
-      expect(await page.waitForSelector('css=section')).toBeTruthy();
-    });
   });
 
   describe('Page.$$', function() {


### PR DESCRIPTION
This also drops the notion of visibility, which is pretty vague.