### PR TITLE
test(firefox): support loading of file URLs

### DIFF
--- a/test/interception.spec.js
+++ b/test/interception.spec.js
@@ -642,15 +642,3 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
     });
   });
 };
-
-/**
- * @param {string} path
- * @return {string}
- */
-function pathToFileURL(path) {
-  let pathName = path.replace(/\\/g, '/');
-  // Windows drive letter must be prefixed with a slash.
-  if (!pathName.startsWith('/'))
-    pathName = '/' + pathName;
-  return 'file://' + pathName;
-}

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -16,6 +16,8 @@
  */
 
 const utils = require('./utils');
+const path = require('path');
+const url = require('url');
 
 /**
  * @type {PageTestSuite}
@@ -29,6 +31,12 @@ module.exports.describe = function({testRunner, expect, playwright, MAC, WIN, FF
     it('should work', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       expect(page.url()).toBe(server.EMPTY_PAGE);
+    });
+    it('should work with file URL', async({page, server}) => {
+      const fileurl = url.pathToFileURL(path.join(__dirname, 'assets', 'frames', 'two-frames.html')).href;
+      await page.goto(fileurl);
+      expect(page.url()).toBe(fileurl);
+      expect(page.frames().length).toBe(3);
     });
     it('should use http for no protocol', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE.substring('http://'.length));
@@ -978,3 +986,4 @@ module.exports.describe = function({testRunner, expect, playwright, MAC, WIN, FF
     }
   }
 };
+

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -35,7 +35,7 @@ module.exports.describe = function({testRunner, expect, playwright, MAC, WIN, FF
     it('should work with file URL', async({page, server}) => {
       const fileurl = url.pathToFileURL(path.join(__dirname, 'assets', 'frames', 'two-frames.html')).href;
       await page.goto(fileurl);
-      expect(page.url()).toBe(fileurl);
+      expect(page.url().toLowerCase()).toBe(fileurl.toLowerCase());
       expect(page.frames().length).toBe(3);
     });
     it('should use http for no protocol', async({page, server}) => {


### PR DESCRIPTION
The actual support was done with #1110; this adds a test.

Fixes #822