### PR TITLE
fix(yarn): download browsers to package directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,26 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const {Playwright} = require('./lib/server/playwright.js');
 
-const { helper } = require('./lib/helper');
-const api = require('./lib/api');
-const packageJson = require('./package.json');
-const { DeviceDescriptors } = require('./lib/deviceDescriptors');
-const { TimeoutError } = require('./lib/errors');
-const { Chromium } = require('./lib/server/chromium');
-const { Firefox } = require('./lib/server/firefox');
-const { WebKit } = require('./lib/server/webkit');
+module.exports = new Playwright({
+  downloadPath: __dirname,
+  browsers: ['webkit', 'chromium', 'firefox'],
+});
 
-for (const className in api) {
-  if (typeof api[className] === 'function')
-    helper.installApiHooks(className[0].toLowerCase() + className.substring(1), api[className]);
-}
-
-module.exports = {
-  devices: DeviceDescriptors,
-  errors: { TimeoutError },
-  selectors: api.Selectors._instance(),
-  chromium: new Chromium(__dirname, packageJson.playwright.chromium_revision),
-  firefox: new Firefox(__dirname, packageJson.playwright.firefox_revision),
-  webkit: new WebKit(__dirname, packageJson.playwright.webkit_revision),
-}

--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-module.exports = {
-  ...require('playwright-core'),
-  // Keep exporting Chromium and nullify other browsers.
-  webkit: undefined,
-  firefox: undefined,
-}
+const {Playwright} = require('playwright-core/lib/server/playwright.js');
+
+module.exports = new Playwright({
+  downloadPath: __dirname,
+  browsers: ['chromium'],
+});
+

--- a/packages/playwright-firefox/index.js
+++ b/packages/playwright-firefox/index.js
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-module.exports = {
-  ...require('playwright-core'),
-  // Keep exporting firefox and nullify other browsers.
-  chromium: undefined,
-  webkit: undefined,
-}
+const {Playwright} = require('playwright-core/lib/server/playwright.js');
+
+module.exports = new Playwright({
+  downloadPath: __dirname,
+  browsers: ['firefox'],
+});
+

--- a/packages/playwright-webkit/index.js
+++ b/packages/playwright-webkit/index.js
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-module.exports = {
-  ...require('playwright-core'),
-  // Keep exporting webkit and nullify other browsers.
-  chromium: undefined,
-  firefox: undefined,
-}
+const {Playwright} = require('playwright-core/lib/server/playwright.js');
+
+module.exports = new Playwright({
+  downloadPath: __dirname,
+  browsers: ['webkit'],
+});
+

--- a/packages/playwright/index.js
+++ b/packages/playwright/index.js
@@ -13,4 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module.exports = require('playwright-core');
+const {Playwright} = require('playwright-core/lib/server/playwright.js');
+
+module.exports = new Playwright({
+  downloadPath: __dirname,
+  browsers: ['webkit', 'chromium', 'firefox'],
+});
+

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -37,11 +37,11 @@ import { ConnectionTransport } from '../transport';
 import { BrowserContext } from '../browserContext';
 
 export class Chromium implements BrowserType {
-  private _projectRoot: string;
+  private _downloadPath: string;
   readonly _revision: string;
 
-  constructor(projectRoot: string, preferredRevision: string) {
-    this._projectRoot = projectRoot;
+  constructor(downloadPath: string, preferredRevision: string) {
+    this._downloadPath = downloadPath;
     this._revision = preferredRevision;
   }
 
@@ -218,7 +218,7 @@ export class Chromium implements BrowserType {
     };
 
     const defaultOptions = {
-      path: path.join(this._projectRoot, '.local-chromium'),
+      path: path.join(this._downloadPath, '.local-chromium'),
       host: 'https://storage.googleapis.com',
       platform: (() => {
         const platform = os.platform();

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -38,11 +38,11 @@ import { BrowserContext } from '../browserContext';
 const mkdtempAsync = platform.promisify(fs.mkdtemp);
 
 export class Firefox implements BrowserType {
-  private _projectRoot: string;
+  private _downloadPath: string;
   readonly _revision: string;
 
-  constructor(projectRoot: string, preferredRevision: string) {
-    this._projectRoot = projectRoot;
+  constructor(downloadPath: string, preferredRevision: string) {
+    this._downloadPath = downloadPath;
     this._revision = preferredRevision;
   }
 
@@ -216,7 +216,7 @@ export class Firefox implements BrowserType {
     };
 
     const defaultOptions = {
-      path: path.join(this._projectRoot, '.local-firefox'),
+      path: path.join(this._downloadPath, '.local-firefox'),
       host: 'https://playwright.azureedge.net',
       platform: (() => {
         const platform = os.platform();

--- a/src/server/playwright.ts
+++ b/src/server/playwright.ts
@@ -15,24 +15,41 @@
  */
 
 import * as types from '../types';
+import * as api from '../api';
+import { helper } from '../helper';
 import { TimeoutError } from '../errors';
 import { DeviceDescriptors } from '../deviceDescriptors';
 import { Chromium } from './chromium';
 import { WebKit } from './webkit';
 import { Firefox } from './firefox';
 
+const packageJSON = require('../../package.json');
+
+for (const className in api) {
+  if (typeof (api as any)[className] === 'function')
+    helper.installApiHooks(className[0].toLowerCase() + className.substring(1), (api as any)[className]);
+}
+
 export class Playwright {
+  readonly selectors = api.Selectors;
   readonly devices: types.Devices;
   readonly errors: { TimeoutError: typeof TimeoutError };
-  readonly chromium: Chromium;
-  readonly firefox: Firefox;
-  readonly webkit: WebKit;
+  readonly chromium: (Chromium|undefined);
+  readonly firefox: (Firefox|undefined);
+  readonly webkit: (WebKit|undefined);
 
-  constructor(projectRoot: string, revisions: { chromium_revision: string, firefox_revision: string, webkit_revision: string }) {
+  constructor(options: {downloadPath: string, browsers: Array<('firefox'|'webkit'|'chromium')>}) {
+    const {
+      downloadPath,
+      browsers,
+    } = options;
     this.devices = DeviceDescriptors;
     this.errors = { TimeoutError };
-    this.chromium = new Chromium(projectRoot, revisions.chromium_revision);
-    this.firefox = new Firefox(projectRoot, revisions.firefox_revision);
-    this.webkit = new WebKit(projectRoot, revisions.webkit_revision);
+    if (browsers.includes('chromium'))
+      this.chromium = new Chromium(downloadPath, packageJSON.playwright.chromium_revision);
+    if (browsers.includes('webkit'))
+      this.webkit = new WebKit(downloadPath, packageJSON.playwright.webkit_revision);
+    if (browsers.includes('firefox'))
+      this.firefox = new Firefox(downloadPath, packageJSON.playwright.firefox_revision);
   }
 }

--- a/src/server/playwright.ts
+++ b/src/server/playwright.ts
@@ -31,7 +31,7 @@ for (const className in api) {
 }
 
 export class Playwright {
-  readonly selectors = api.Selectors;
+  readonly selectors = api.Selectors._instance();
   readonly devices: types.Devices;
   readonly errors: { TimeoutError: typeof TimeoutError };
   readonly chromium: (Chromium|undefined);

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -40,11 +40,11 @@ import { Events } from '../events';
 import { BrowserContext } from '../browserContext';
 
 export class WebKit implements BrowserType {
-  private _projectRoot: string;
+  private _downloadPath: string;
   readonly _revision: string;
 
-  constructor(projectRoot: string, preferredRevision: string) {
-    this._projectRoot = projectRoot;
+  constructor(downloadPath: string, preferredRevision: string) {
+    this._downloadPath = downloadPath;
     this._revision = preferredRevision;
   }
 
@@ -200,7 +200,7 @@ export class WebKit implements BrowserType {
     };
 
     const defaultOptions = {
-      path: path.join(this._projectRoot, '.local-webkit'),
+      path: path.join(this._downloadPath, '.local-webkit'),
       host: 'https://playwright.azureedge.net',
       platform: (() => {
         const platform = os.platform();


### PR DESCRIPTION
This patch makes it so all our packages, like `playwright` and
browser-specific flavors, download browsers to their
directories rather then using directory of `playwright-core`.

This way yarn@1 caches are not busted: they didn't expect that directory
content might change after packages's explicit install step
is failed, there's that was what we were doing.

Fixes #1085