### PR TITLE
fix: properly download browsers

### DIFF
--- a/download-browser.js
+++ b/download-browser.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-async function downloadBrowser(browser) {
-  const browserType = require('.')[browser];
+async function downloadBrowser(browserType) {
+  const browser = browserType.name();
   let progressBar = null;
   let lastDownloadedBytes = 0;
   function onProgress(downloadedBytes, totalBytes) {

--- a/install-from-github.js
+++ b/install-from-github.js
@@ -25,36 +25,37 @@ try {
 } catch (e) {
 }
 const {downloadBrowser} = require('./download-browser');
+const playwright = require('.');
 
 (async function() {
   const protocolGenerator = require('./utils/protocol-types-generator');
   try {
-    const chromeRevision = await downloadAndCleanup('chromium');
+    const chromeRevision = await downloadAndCleanup(playwright.chromium);
     await protocolGenerator.generateChromiunProtocol(chromeRevision);
   } catch (e) {
     console.warn(e.message);
   }
 
   try {
-    const firefoxRevision = await downloadAndCleanup('firefox');
+    const firefoxRevision = await downloadAndCleanup(playwright.firefox);
     await protocolGenerator.generateFirefoxProtocol(firefoxRevision);
   } catch (e) {
     console.warn(e.message);
   }
 
   try {
-    const webkitRevision = await downloadAndCleanup('webkit');
+    const webkitRevision = await downloadAndCleanup(playwright.webkit);
     await protocolGenerator.generateWebKitProtocol(webkitRevision);
   } catch (e) {
     console.warn(e.message);
   }
 })();
 
-async function downloadAndCleanup(browser) {
-  const revisionInfo = await downloadBrowser(browser);
+async function downloadAndCleanup(browserType) {
+  const revisionInfo = await downloadBrowser(browserType);
 
   // Remove previous revisions.
-  const fetcher = require('.')[browser]._createBrowserFetcher();
+  const fetcher = browserType._createBrowserFetcher();
   const localRevisions = await fetcher.localRevisions();
   const cleanupOldVersions = localRevisions.filter(revision => revision !== revisionInfo.revision).map(revision => fetcher.remove(revision));
   await Promise.all([...cleanupOldVersions]);

--- a/packages/playwright-chromium/install.js
+++ b/packages/playwright-chromium/install.js
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 const {downloadBrowser} = require('playwright-core/download-browser');
-downloadBrowser('chromium');
+const playwright = require('.');
+downloadBrowser(playwright.chromium);

--- a/packages/playwright-firefox/install.js
+++ b/packages/playwright-firefox/install.js
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 const {downloadBrowser} = require('playwright-core/download-browser');
-downloadBrowser('firefox');
+const playwright = require('.');
+downloadBrowser(playwright.firefox);

--- a/packages/playwright-webkit/install.js
+++ b/packages/playwright-webkit/install.js
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 const {downloadBrowser} = require('playwright-core/download-browser');
-downloadBrowser('webkit');
+const playwright = require('.');
+downloadBrowser(playwright.webkit);

--- a/packages/playwright/install.js
+++ b/packages/playwright/install.js
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 const {downloadBrowser} = require('playwright-core/download-browser');
+const playwright = require('.');
 (async function() {
-  await downloadBrowser('chromium');
-  await downloadBrowser('firefox');
-  await downloadBrowser('webkit');
+  await downloadBrowser(playwright.chromium);
+  await downloadBrowser(playwright.firefox);
+  await downloadBrowser(playwright.webkit);
 })();


### PR DESCRIPTION
Playwright API is parametrized with a `downloadPath` - a path that
is used to download browsers and to look for downloaded browsers.

This patch starts respecting `downloadPath` as part of
`download-browser.js` utility.