### PR TITLE
feat: support `PLAYWRIGHT_DOWNLOAD_HOST`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,7 @@
 - [class: ChromiumTarget](#class-chromiumtarget)
 - [class: FirefoxBrowser](#class-firefoxbrowser)
 - [class: WebKitBrowser](#class-webkitbrowser)
+- [Environment Variables](#environment-variables)
 - [Working with selectors](#working-with-selectors)
 - [Working with Chrome Extensions](#working-with-chrome-extensions)
 <!-- GEN:stop -->
@@ -3847,6 +3848,16 @@ WebKit browser instance does not expose WebKit-specific features.
 - [browser.newContext(options)](#browsernewcontextoptions)
 - [browser.newPage([options])](#browsernewpageoptions)
 <!-- GEN:stop -->
+
+### Environment Variables
+
+> **NOTE** [playwright-core](https://www.npmjs.com/package/playwright-core) **does not** respect environment variables.
+
+Playwright looks for certain [environment variables](https://en.wikipedia.org/wiki/Environment_variable) to aid its operations.
+If Playwright doesn't find them in the environment, a lowercased variant of these variables will be used from the [npm config](https://docs.npmjs.com/cli/config).
+
+- `PLAYWRIGHT_DOWNLOAD_HOST` - overwrite URL prefix that is used to download browsers. Note: this includes protocol and might even include path prefix. By default, Playwright uses `https://storage.googleapis.com` to download Chromium and `https://playwright.azureedge.net` to download Webkit & Firefox.
+
 
 ### Working with selectors
 

--- a/index.js
+++ b/index.js
@@ -18,5 +18,6 @@ const {Playwright} = require('./lib/server/playwright.js');
 module.exports = new Playwright({
   downloadPath: __dirname,
   browsers: ['webkit', 'chromium', 'firefox'],
+  respectEnvironmentVariables: false,
 });
 

--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -19,5 +19,6 @@ const {Playwright} = require('playwright-core/lib/server/playwright.js');
 module.exports = new Playwright({
   downloadPath: __dirname,
   browsers: ['chromium'],
+  respectEnvironmentVariables: true,
 });
 

--- a/packages/playwright-firefox/index.js
+++ b/packages/playwright-firefox/index.js
@@ -19,5 +19,6 @@ const {Playwright} = require('playwright-core/lib/server/playwright.js');
 module.exports = new Playwright({
   downloadPath: __dirname,
   browsers: ['firefox'],
+  respectEnvironmentVariables: true,
 });
 

--- a/packages/playwright-webkit/index.js
+++ b/packages/playwright-webkit/index.js
@@ -19,5 +19,6 @@ const {Playwright} = require('playwright-core/lib/server/playwright.js');
 module.exports = new Playwright({
   downloadPath: __dirname,
   browsers: ['webkit'],
+  respectEnvironmentVariables: true,
 });
 

--- a/packages/playwright/index.js
+++ b/packages/playwright/index.js
@@ -18,5 +18,6 @@ const {Playwright} = require('playwright-core/lib/server/playwright.js');
 module.exports = new Playwright({
   downloadPath: __dirname,
   browsers: ['webkit', 'chromium', 'firefox'],
+  respectEnvironmentVariables: true,
 });
 

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -38,10 +38,12 @@ import { BrowserContext } from '../browserContext';
 
 export class Chromium implements BrowserType {
   private _downloadPath: string;
+  private _downloadHost: string;
   readonly _revision: string;
 
-  constructor(downloadPath: string, preferredRevision: string) {
+  constructor(downloadPath: string, downloadHost: (string|undefined), preferredRevision: string) {
     this._downloadPath = downloadPath;
+    this._downloadHost = downloadHost || 'https://storage.googleapis.com';
     this._revision = preferredRevision;
   }
 
@@ -221,7 +223,7 @@ export class Chromium implements BrowserType {
 
     const defaultOptions = {
       path: path.join(this._downloadPath, '.local-chromium'),
-      host: 'https://storage.googleapis.com',
+      host: this._downloadHost,
       platform: (() => {
         const platform = os.platform();
         if (platform === 'darwin')

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -39,10 +39,12 @@ const mkdtempAsync = platform.promisify(fs.mkdtemp);
 
 export class Firefox implements BrowserType {
   private _downloadPath: string;
+  private _downloadHost: string;
   readonly _revision: string;
 
-  constructor(downloadPath: string, preferredRevision: string) {
+  constructor(downloadPath: string, downloadHost: (string|undefined), preferredRevision: string) {
     this._downloadPath = downloadPath;
+    this._downloadHost = downloadHost || 'https://playwright.azureedge.net';
     this._revision = preferredRevision;
   }
 
@@ -219,7 +221,7 @@ export class Firefox implements BrowserType {
 
     const defaultOptions = {
       path: path.join(this._downloadPath, '.local-firefox'),
-      host: 'https://playwright.azureedge.net',
+      host: this._downloadHost,
       platform: (() => {
         const platform = os.platform();
         if (platform === 'darwin')

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -41,10 +41,12 @@ import { BrowserContext } from '../browserContext';
 
 export class WebKit implements BrowserType {
   private _downloadPath: string;
+  private _downloadHost: string;
   readonly _revision: string;
 
-  constructor(downloadPath: string, preferredRevision: string) {
+  constructor(downloadPath: string, downloadHost: (string|undefined), preferredRevision: string) {
     this._downloadPath = downloadPath;
+    this._downloadHost = downloadHost || 'https://playwright.azureedge.net';
     this._revision = preferredRevision;
   }
 
@@ -203,7 +205,7 @@ export class WebKit implements BrowserType {
 
     const defaultOptions = {
       path: path.join(this._downloadPath, '.local-webkit'),
-      host: 'https://playwright.azureedge.net',
+      host: this._downloadHost,
       platform: (() => {
         const platform = os.platform();
         if (platform === 'darwin')


### PR DESCRIPTION
This patch starts respecting `PLAYWRIGHT_DOWNLOAD_HOST` env variable
in `playwright` package and it's vendored flavors (`playwright-firefox`,
`playwright-chromium` and `playwright-webkit`).

Fixes #1045