### PR TITLE
docs(showcase): rename playwright-controller to playwright-fluent

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -23,7 +23,7 @@
 * [jest-playwright](https://github.com/mmarkelov/jest-playwright): Jest present to run Playwright tests with Jest
 * [query-selector-shadow-dom](https://github.com/Georgegriff/query-selector-shadow-dom): Custom selector engine to pierce shadow DOM roots
 * [Playwright Sharp](https://github.com/kblok/playwright-sharp): Work in progress port of Playwright to .NET
-* [playwright-controller](https://github.com/hdorgeval/playwright-controller): Fluent API around Playwright
+* [playwright-fluent](https://github.com/hdorgeval/playwright-fluent): Fluent API around Playwright
 
 ## Examples
  


### PR DESCRIPTION
The goal of this PR is to reflect recent changes to the name of the project as suggested by [arjun27](https://github.com/hdorgeval/playwright-fluent/issues/1)