### PR TITLE
docs(ci): list sample configurations for ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,4 +181,5 @@ Playwright is being actively developed as we get to the feature parity across Ch
 ## Resources
 
 * [API documentation](docs/api.md)
+* [Getting started on CI](docs/ci.md)
 * [Community showcase](docs/showcase.md)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,38 @@
+# Getting started on CI
+
+Playwright tests can be executed to run on your CI environments. To simplify this, we have created sample configurations for common CI providers that can be used to bootstrap your setup.
+
+- [Docker](#docker)
+- [GitHub](#github-actions)
+- [Azure Pipelines](#azure-pipelines)
+- [Travis CI](#travis-ci)
+- [CircleCI](#circleci)
+- [AppVeyor](#appveyor)
+
+Broadly, configuration on CI involves **ensuring system dependencies** are in place, **installing Playwright and browsers** (typically with `npm install`), and **running tests** (typically with `npm test`). Windows and macOS build agents do not require any additional system dependencies. Linux build agents can require additional dependencies, depending on the Linux distribution.
+
+## Docker
+
+We have a [pre-built Docker image](docker/README.md) which can either be used directly, or as a reference to update your existing Docker definitions.
+
+## GitHub Actions
+
+We run our tests on GitHub Actions, across a matrix of 3 platforms (Windows, Linux, macOS) and 3 browsers (Chromium, Firefox, WebKit). Use our [Actions configuration](/.github/workflows/tests.yml) to bootstrap your own.
+
+## Azure Pipelines
+
+For Windows or macOS agents, no additional configuration required, just install Playwright and run your tests.
+
+For Linux agents, refer to [our Docker setup](docker/README.md) to see additional dependencies that need to be installed.
+
+## Travis CI
+
+We run our tests on Travis CI over a Linux agent (Ubuntu 18.04). Use our [Travis configuration](/.travis.yml) to see list of additional dependencies to be installed.
+
+## CircleCI
+
+We run our tests on CircleCI, with our [pre-built Docker image](docker/README.md). Use our [CircleCI configuration](/.circleci/config.yml) to create your own.
+
+## AppVeyor
+
+We run our tests on Windows agents in AppVeyor. Use our [AppVeyor configuration](/.appveyor.yml) to create your own.

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -1,6 +1,6 @@
 # Running Playwright in Docker
 
-`Dockerfile.bionic` is a playwright-ready image of playwright.
+[Dockerfile.bionic](Dockerfile.bionic) is a playwright-ready image of playwright.
 This image includes all the dependencies needed to run browsers in a Docker
 container.
 


### PR DESCRIPTION
Has some overlaps with the troubleshooting doc, which I plan to clean up in a subsequent PR. This first version of the doc has a feel of "build-your-own" with our sample configurations. Over time we can tweak the level of hand-holding for the best user experience to get started with CI.

Closes #1103 