### PR TITLE
feat(select): don't accept undefined as a value

### DIFF
--- a/src/frames.ts
+++ b/src/frames.ts
@@ -815,9 +815,9 @@ export class Frame {
     await handle.dispose();
   }
 
-  async select(selector: string, value: string | dom.ElementHandle | types.SelectOption | string[] | dom.ElementHandle[] | types.SelectOption[] | undefined, options?: types.WaitForOptions): Promise<string[]> {
+  async select(selector: string, value: string | dom.ElementHandle | types.SelectOption | string[] | dom.ElementHandle[] | types.SelectOption[], options?: types.WaitForOptions): Promise<string[]> {
     const handle = await this._optionallyWaitForSelectorInUtilityContext(selector, options);
-    const values = value === undefined ? [] : Array.isArray(value) ? value : [value];
+    const values = Array.isArray(value) ? value : [value];
     const result = await handle.select(...values);
     await handle.dispose();
     return result;

--- a/src/page.ts
+++ b/src/page.ts
@@ -514,7 +514,7 @@ export class Page extends platform.EventEmitter {
     return this.mainFrame().hover(selector, options);
   }
 
-  async select(selector: string, value: string | dom.ElementHandle | types.SelectOption | string[] | dom.ElementHandle[] | types.SelectOption[] | undefined, options?: types.WaitForOptions): Promise<string[]> {
+  async select(selector: string, value: string | dom.ElementHandle | types.SelectOption | string[] | dom.ElementHandle[] | types.SelectOption[], options?: types.WaitForOptions): Promise<string[]> {
     return this.mainFrame().select(selector, value, options);
   }
 

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -886,20 +886,20 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
     });
     it('should return [] on no values',async({page, server}) => {
       await page.goto(server.PREFIX + '/input/select.html');
-      const result = await page.select('select');
+      const result = await page.select('select', []);
       expect(result).toEqual([]);
     });
     it('should deselect all options when passed no values for a multiple select',async({page, server}) => {
       await page.goto(server.PREFIX + '/input/select.html');
       await page.evaluate(() => makeMultiple());
       await page.select('select', ['blue','black','magenta']);
-      await page.select('select');
+      await page.select('select', []);
       expect(await page.$eval('select', select => Array.from(select.options).every(option => !option.selected))).toEqual(true);
     });
     it('should deselect all options when passed no values for a select without multiple',async({page, server}) => {
       await page.goto(server.PREFIX + '/input/select.html');
       await page.select('select', ['blue','black','magenta']);
-      await page.select('select');
+      await page.select('select', []);
       expect(await page.$eval('select', select => Array.from(select.options).every(option => !option.selected))).toEqual(true);
     });
     it('should throw if passed wrong types', async({page, server}) => {


### PR DESCRIPTION
`page.select` accepting an `undefined` value is a legacy of when `page.select` took `...values`. This matches the way the method is documented in the API.