### PR TITLE
api(popups): emit PageEvent immediately, and resolve page() once initialized

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -304,7 +304,15 @@ Emitted when Browser context gets closed. This might happen because of one of th
 - <[PageEvent]>
 
 Emitted when a new Page is created in the BrowserContext. The event will also fire for popup
-pages.
+pages. See also [`Page.on('popup')`](#event-popup) to receive events about popups relevant to a specific page.
+
+```js
+const [event] = await Promise.all([
+  context.waitForEvent('page'),
+  page.click('a[target=_blank]'),
+]);
+const newPage = await event.page();
+```
 
 #### browserContext.addInitScript(script[, ...args])
 - `script` <[function]|[string]|[Object]> Script to be evaluated in all pages in the browser context.
@@ -726,22 +734,24 @@ Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/We
 Emitted when an uncaught exception happens within the page.
 
 #### event: 'popup'
-- <[Page]> Page corresponding to "popup" window
+- <[PageEvent]> Page event corresponding to "popup" window
 
-Emitted when the page opens a new tab or window.
+Emitted when the page opens a new tab or window. This event is emitted in addition to the [`browserContext.on('page')`](#event-page), but only for popups relevant to this page.
 
 ```js
-const [popup] = await Promise.all([
-  new Promise(resolve => page.once('popup', resolve)),
+const [event] = await Promise.all([
+  page.waitForEvent('popup'),
   page.click('a[target=_blank]'),
 ]);
+const popup = await event.page();
 ```
 
 ```js
-const [popup] = await Promise.all([
-  new Promise(resolve => page.once('popup', resolve)),
+const [event] = await Promise.all([
+  page.waitForEvent('popup'),
   page.evaluate(() => window.open('https://example.com')),
 ]);
+const popup = await event.page();
 ```
 
 #### event: 'request'
@@ -1753,8 +1763,7 @@ This method returns all of the dedicated [WebWorkers](https://developer.mozilla.
 
 ### class: PageEvent
 
-Event object passed to the listeners of ['page'](#event-page) on [`BrowserContext`](#class-browsercontext). Provides access
-to the newly created page.
+Event object passed to the listeners of [`browserContext.on('page')`](#event-page) and [`page.on('popup')`](#event-popup) events. Provides access to the newly created page.
 
 #### pageEvent.page()
 - returns: <[Promise]<[Page]>> Promise which resolves to the created page.

--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -388,7 +388,10 @@ export class CRPage implements PageDelegate {
     const openerTarget = CRTarget.fromPage(this._page).opener();
     if (!openerTarget)
       return null;
-    return await openerTarget.page();
+    const openerPage = await openerTarget.pageOrError();
+    if (openerPage instanceof Page && !openerPage.isClosed())
+      return openerPage;
+    return null;
   }
 
   async reload(): Promise<void> {

--- a/src/page.ts
+++ b/src/page.ts
@@ -89,14 +89,20 @@ export type FileChooser = {
 };
 
 export class PageEvent {
-  private readonly _page: Page;
+  private readonly _pageOrError: Promise<Page | Error>;
 
-  constructor(page: Page) {
-    this._page = page;
+  constructor(pageOrErrorPromise: Promise<Page | Error>) {
+    this._pageOrError = pageOrErrorPromise;
   }
 
   async page(/* options?: frames.NavigateOptions */): Promise<Page> {
-    return this._page;
+    const result = await this._pageOrError;
+    if (result instanceof Page) {
+      if (result.isClosed())
+        throw new Error('Page has been closed.');
+      return result;
+    }
+    throw result;
   }
 }
 

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -70,10 +70,16 @@ export class Chromium implements BrowserType {
     const { timeout = 30000 } = options || {};
     const { browserServer, transport } = await this._launchServer(options, 'persistent', userDataDir);
     const browser = await CRBrowser.connect(transport!, true);
-    const firstPage = new Promise(r => browser._defaultContext.once(Events.BrowserContext.Page, r));
-    await helper.waitWithTimeout(firstPage, 'first page', timeout);
-    // Hack: for typical launch scenario, ensure that close waits for actual process termination.
     const browserContext = browser._defaultContext;
+
+    function targets() {
+      return browser._allTargets().filter(target => target.context() === browserContext && target.type() === 'page');
+    }
+    const firstTarget = targets().length ? Promise.resolve() : new Promise(f => browserContext.once('page', f));
+    const firstPage = firstTarget.then(() => targets()[0].pageOrError());
+    await helper.waitWithTimeout(firstPage, 'first page', timeout);
+
+    // Hack: for typical launch scenario, ensure that close waits for actual process termination.
     browserContext.close = () => browserServer.close();
     return browserContext;
   }

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -437,8 +437,12 @@ export class WKPage implements PageDelegate {
   }
 
   async opener(): Promise<Page | null> {
-    const openerPage = this._opener ? await this._opener.page() : null;
-    return openerPage && !openerPage.isClosed() ? openerPage : null;
+    if (!this._opener)
+      return null;
+    const openerPage = await this._opener.pageOrError();
+    if (openerPage instanceof Page && !openerPage.isClosed())
+      return openerPage;
+    return null;
   }
 
   async reload(): Promise<void> {

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -39,7 +39,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
       const [popup] = await Promise.all([
-        utils.waitEvent(page, 'popup'),
+        utils.waitEvent(page, 'popup').then(e => e.page()),
         page.evaluate(url => window.open(url), server.EMPTY_PAGE)
       ]);
       expect(popup.context()).toBe(context);

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -209,7 +209,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT})
     it('should work for adopted elements', async({page,server}) => {
       await page.goto(server.EMPTY_PAGE);
       const [popup] = await Promise.all([
-        page.waitForEvent('popup').then(async popup => { await popup.waitForLoadState(); return popup; }),
+        page.waitForEvent('popup').then(async e => { const popup = await e.page(); await popup.waitForLoadState(); return popup; }),
         page.evaluate(url => window.__popup = window.open(url), server.EMPTY_PAGE),
       ]);
       const divHandle = await page.evaluateHandle(() => {

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -132,7 +132,7 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
   describe('Page.opener', function() {
     it('should provide access to the opener page', async({page}) => {
       const [popup] = await Promise.all([
-        new Promise(x => page.once('popup', x)),
+        page.waitForEvent('popup').then(e => e.page()),
         page.evaluate(() => window.open('about:blank')),
       ]);
       const opener = await popup.opener();
@@ -140,7 +140,7 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
     });
     it('should return null if parent page has been closed', async({page}) => {
       const [popup] = await Promise.all([
-        new Promise(x => page.once('popup', x)),
+        page.waitForEvent('popup').then(e => e.page()),
         page.evaluate(() => window.open('about:blank')),
       ]);
       await page.close();
@@ -1077,7 +1077,7 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
 
   describe('Page.Events.Close', function() {
     it('should work with window.close', async function({ page, context, server }) {
-      const newPagePromise = new Promise(f => page.once('popup', f));
+      const newPagePromise = page.waitForEvent('popup').then(e => e.page());
       await page.evaluate(() => window['newPage'] = window.open('about:blank'));
       const newPage = await newPagePromise;
       const closedPromise = new Promise(x => newPage.on('close', x));

--- a/test/popup.spec.js
+++ b/test/popup.spec.js
@@ -139,18 +139,31 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       const context = await browser.newContext();
       const page = await context.newPage();
       const [popup] = await Promise.all([
-        new Promise(x => page.once('popup', x)),
+        page.waitForEvent('popup').then(e => e.page()),
         page.evaluate(() => window.__popup = window.open('about:blank')),
       ]);
       expect(await page.evaluate(() => !!window.opener)).toBe(false);
       expect(await popup.evaluate(() => !!window.opener)).toBe(true);
       await context.close();
     });
+    it('should emit for immediately closed popups', async({browser}) => {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      const [popupEvent] = await Promise.all([
+        page.waitForEvent('popup'),
+        page.evaluate(() => {
+          const win = window.open('about:blank');
+          win.close();
+        }),
+      ]);
+      expect(popupEvent).toBeTruthy();
+      await context.close();
+    });
     it('should work with empty url', async({browser}) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       const [popup] = await Promise.all([
-        new Promise(x => page.once('popup', x)),
+        page.waitForEvent('popup').then(e => e.page()),
         page.evaluate(() => window.__popup = window.open('')),
       ]);
       expect(await page.evaluate(() => !!window.opener)).toBe(false);
@@ -161,7 +174,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       const context = await browser.newContext();
       const page = await context.newPage();
       const [popup] = await Promise.all([
-        new Promise(x => page.once('popup', x)),
+        page.waitForEvent('popup').then(e => e.page()),
         page.evaluate(() => window.__popup = window.open('about:blank', null, 'noopener')),
       ]);
       expect(await page.evaluate(() => !!window.opener)).toBe(false);
@@ -174,7 +187,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       await page.goto(server.EMPTY_PAGE);
       await page.setContent('<a target=_blank rel="opener" href="/one-style.html">yo</a>');
       const [popup] = await Promise.all([
-        page.waitForEvent('popup').then(async popup => { await popup.waitForLoadState(); return popup; }),
+        page.waitForEvent('popup').then(async e => { const popup = await e.page(); await popup.waitForLoadState(); return popup; }),
         page.click('a'),
       ]);
       expect(await page.evaluate(() => !!window.opener)).toBe(false);
@@ -188,7 +201,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       await page.goto(server.EMPTY_PAGE);
       await page.setContent('<a target=_blank rel=noopener href="/one-style.html">yo</a>');
       const [popup] = await Promise.all([
-        page.waitForEvent('popup').then(async popup => { await popup.waitForLoadState(); return popup; }),
+        page.waitForEvent('popup').then(async e => { const popup = await e.page(); await popup.waitForLoadState(); return popup; }),
         page.$eval('a', a => a.click()),
       ]);
       expect(await page.evaluate(() => !!window.opener)).toBe(false);
@@ -203,7 +216,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       await page.goto(server.EMPTY_PAGE);
       await page.setContent('<a target=_blank rel=noopener href="/one-style.html">yo</a>');
       const [popup] = await Promise.all([
-        page.waitForEvent('popup').then(async popup => { await popup.waitForLoadState(); return popup; }),
+        page.waitForEvent('popup').then(async e => { const popup = await e.page(); await popup.waitForLoadState(); return popup; }),
         page.click('a'),
       ]);
       expect(await page.evaluate(() => !!window.opener)).toBe(false);
@@ -216,7 +229,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       await page.goto(server.EMPTY_PAGE);
       await page.setContent('<a target=_blank rel=noopener href="/one-style.html">yo</a>');
       const [popup] = await Promise.all([
-        page.waitForEvent('popup').then(async popup => { await popup.waitForLoadState(); return popup; }),
+        page.waitForEvent('popup').then(async e => { const popup = await e.page(); await popup.waitForLoadState(); return popup; }),
         page.click('a'),
       ]);
       let badSecondPopup = false;


### PR DESCRIPTION
This way we do not miss any popups, even immediately closed ones.