### PR TITLE
make page.goto work with URL objects

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1192,7 +1192,7 @@ can not go forward, resolves to `null`.
 Navigate to the next page in history.
 
 #### page.goto(url[, options])
-- `url` <[string]> URL to navigate page to. The url should include scheme, e.g. `https://`.
+- `url` <[string]|[URL]> URL to navigate page to. The url should include scheme, e.g. `https://`.
 - `options` <[Object]> Navigation parameters which might have the following properties:
   - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultNavigationTimeout(timeout)](#browsercontextsetdefaultnavigationtimeouttimeout), [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout), [page.setDefaultNavigationTimeout(timeout)](#pagesetdefaultnavigationtimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
   - `waitUntil` <"load"|"domcontentloaded"|"networkidle0"|"networkidle2"|[Array]<"load"|"domcontentloaded"|"networkidle0"|"networkidle2">> When to consider navigation succeeded, defaults to `load`. Given an array of event strings, navigation is considered to be successful after all events have been fired. Events can be either:
@@ -2060,7 +2060,7 @@ console.log(frame === contentFrame);  // -> true
 ```
 
 #### frame.goto(url[, options])
-- `url` <[string]> URL to navigate frame to. The url should include scheme, e.g. `https://`.
+- `url` <[string]|[URL]> URL to navigate frame to. The url should include scheme, e.g. `https://`.
 - `options` <[Object]> Navigation parameters which might have the following properties:
   - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultNavigationTimeout(timeout)](#browsercontextsetdefaultnavigationtimeouttimeout), [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout), [page.setDefaultNavigationTimeout(timeout)](#pagesetdefaultnavigationtimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
   - `waitUntil` <"load"|"domcontentloaded"|"networkidle0"|"networkidle2"|[Array]<"load"|"domcontentloaded"|"networkidle0"|"networkidle2">>  When to consider navigation succeeded, defaults to `load`. Given an array of event strings, navigation is considered to be successful after all events have been fired. Events can be either:

--- a/src/page.ts
+++ b/src/page.ts
@@ -293,8 +293,7 @@ export class Page extends platform.EventEmitter {
   async setContent(html: string, options?: frames.NavigateOptions): Promise<void> {
     return this.mainFrame().setContent(html, options);
   }
-
-  async goto(url: string, options?: frames.GotoOptions): Promise<network.Response | null> {
+  async goto(url: string | URL, options?: frames.GotoOptions): Promise<network.Response | null> {
     return this.mainFrame().goto(url, options);
   }
 


### PR DESCRIPTION
Resolves #1006

Attempt to allow [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) objects as an accepted parameter type for Page and Frames `goto` function.

I had different approaches in mind as suggested in the issue, open for make changes based on feedback!
