### PR TITLE
Fix typos across playwright repo

### DIFF
--- a/browser_patches/buildbots/buildbot-linux.sh
+++ b/browser_patches/buildbots/buildbot-linux.sh
@@ -3,7 +3,7 @@ set -e
 set +x
 
 if [[ $(uname) != "Linux" ]]; then
-  echo "ERROR: this script is desgined to be run on Linux. Can't run on $(uname)"
+  echo "ERROR: this script is designed to be run on Linux. Can't run on $(uname)"
   exit 1
 fi
 

--- a/browser_patches/buildbots/buildbot-mac-10.14.sh
+++ b/browser_patches/buildbots/buildbot-mac-10.14.sh
@@ -3,13 +3,13 @@ set -e
 set +x
 
 if [[ "$(uname)" != "Darwin" ]]; then
-  echo "ERROR: this script is desgined to be run on OSX. Can't run on $(uname)"
+  echo "ERROR: this script is designed to be run on OSX. Can't run on $(uname)"
   exit 1
 fi
 
 MAC_MAJOR_MINOR_VERSION=$(sw_vers -productVersion | grep -o '^\d\+.\d\+')
 if [[ $MAC_MAJOR_MINOR_VERSION != "10.14" ]]; then
-  echo "ERROR: this script is desgined to be run on OSX 10.14. Can't run on OSX $MAC_MAJOR_MINOR_VERSION"
+  echo "ERROR: this script is designed to be run on OSX 10.14. Can't run on OSX $MAC_MAJOR_MINOR_VERSION"
   exit 1
 fi
 

--- a/browser_patches/buildbots/buildbot-mac-10.15.sh
+++ b/browser_patches/buildbots/buildbot-mac-10.15.sh
@@ -3,13 +3,13 @@ set -e
 set +x
 
 if [[ "$(uname)" != "Darwin" ]]; then
-  echo "ERROR: this script is desgined to be run on OSX. Can't run on $(uname)"
+  echo "ERROR: this script is designed to be run on OSX. Can't run on $(uname)"
   exit 1
 fi
 
 MAC_MAJOR_MINOR_VERSION=$(sw_vers -productVersion | grep -o '^\d\+.\d\+')
 if [[ $MAC_MAJOR_MINOR_VERSION != "10.15" ]]; then
-  echo "ERROR: this script is desgined to be run on OSX 10.15. Can't run on OSX $MAC_MAJOR_MINOR_VERSION"
+  echo "ERROR: this script is designed to be run on OSX 10.15. Can't run on OSX $MAC_MAJOR_MINOR_VERSION"
   exit 1
 fi
 

--- a/browser_patches/buildbots/buildbot-windows.sh
+++ b/browser_patches/buildbots/buildbot-windows.sh
@@ -3,7 +3,7 @@ set -e
 set +x
 
 if [[ $(uname) != MINGW* ]]; then
-  echo "ERROR: this script is desgined to be run on MINGW. Can't run on $(uname)"
+  echo "ERROR: this script is designed to be run on MINGW. Can't run on $(uname)"
   exit 1
 fi
 

--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -5,7 +5,7 @@ set +x
 if [[ ($1 == '--help') || ($1 == '-h') ]]; then
   echo "usage: $(basename $0) [firefox-linux|firefox-win32|firefox-win64|webkit-gtk|webkit-wpe|webkit-gtk-wpe|webkit-win64|webkit-mac-10.14|webkit-mac-10.15] [-f|--force]"
   echo
-  echo "Prepares checkout under browser folder, applies patches, builds, archives, and uploades if build is missing."
+  echo "Prepares checkout under browser folder, applies patches, builds, archives, and uploads if build is missing."
   echo "Script will bail out early if the build for the browser version is already present."
   echo
   echo "Pass -f to upload anyway."

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -292,7 +292,7 @@ await page.evaluate(`(async() => {
 
 ## ReferenceError: URL is not defined
 
-Playwright requires node 10 or higher. Node 8 is not supported, and will cause you to recieve this error.
+Playwright requires node 10 or higher. Node 8 is not supported, and will cause you to receive this error.
 
 # Please file an issue
 

--- a/src/chromium/crTarget.ts
+++ b/src/chromium/crTarget.ts
@@ -92,7 +92,7 @@ export class CRTarget {
         session.once('Runtime.executionContextCreated', async event => {
           worker._createExecutionContext(new CRExecutionContext(session, event.context));
         });
-        // This might fail if the target is closed before we recieve all execution contexts.
+        // This might fail if the target is closed before we receive all execution contexts.
         session.send('Runtime.enable', {}).catch(debugError);
         return worker;
       });

--- a/test/test.js
+++ b/test/test.js
@@ -117,7 +117,7 @@ describe(product, () => {
 });
 
 if (process.env.CI && testRunner.hasFocusedTestsOrSuites()) {
-  console.error('ERROR: "focused" tests/suites are prohibitted on bots. Remove any "fit"/"fdescribe" declarations.');
+  console.error('ERROR: "focused" tests/suites are prohibited on bots. Remove any "fit"/"fdescribe" declarations.');
   process.exit(1);
 }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -222,7 +222,7 @@ const utils = module.exports = {
     //   from someone who has WRITE ACCESS to the repo.
     //
     // Since we don't want to run flakiness dashboard for PRs on all CIs, we
-    // check existance of FLAKINESS_DASHBOARD_PASSWORD and absense of
+    // check existence of FLAKINESS_DASHBOARD_PASSWORD and absence of
     // CIRRUS_BASE_SHA env variables.
     if (!process.env.FLAKINESS_DASHBOARD_PASSWORD || process.env.CIRRUS_BASE_SHA)
       return;

--- a/utils/flakiness-dashboard/FlakinessDashboard.js
+++ b/utils/flakiness-dashboard/FlakinessDashboard.js
@@ -150,7 +150,7 @@ class Git {
     schemeIndex += '://'.length;
     url = url.substring(0, schemeIndex) + username + ':' + password + '@' + url.substring(schemeIndex);
     const repoPath = await mkdtempAsync(TMP_FOLDER);
-    // Check existance of a remote branch for this bot.
+    // Check existence of a remote branch for this bot.
     const {stdout} = await spawnAsync('git', 'ls-remote', '--heads', url, branch);
     // If there is no remote branch for this bot - create one.
     if (!stdout.includes(branch)) {


### PR DESCRIPTION
:writing_hand: **Fix typos across playwright repo**

**Files that have typos**

```
playwright/browser_patches/buildbots/buildbot-linux.sh:6:30: "desgined" is a misspelling of "designed"
playwright/browser_patches/buildbots/buildbot-mac-10.14.sh:6:30: "desgined" is a misspelling of "designed"
playwright/browser_patches/buildbots/buildbot-mac-10.14.sh:12:30: "desgined" is a misspelling of "designed"
playwright/browser_patches/buildbots/buildbot-mac-10.15.sh:6:30: "desgined" is a misspelling of "designed"
playwright/browser_patches/buildbots/buildbot-mac-10.15.sh:12:30: "desgined" is a misspelling of "designed"
playwright/browser_patches/buildbots/buildbot-windows.sh:6:30: "desgined" is a misspelling of "designed"
playwright/browser_patches/checkout_build_archive_upload.sh:8:87: "uploades" is a misspelling of "uploads"
playwright/docs/troubleshooting.md:295:86: "recieve" is a misspelling of "receive"
playwright/src/chromium/crTarget.ts:95:61: "recieve" is a misspelling of "receive"
playwright/test/test.js:120:51: "prohibitted" is a misspelling of "prohibited"
playwright/test/utils.js:225:13: "existance" is a misspelling of "existence"
playwright/test/utils.js:225:59: "absense" is a misspelling of "absence"
playwright/utils/flakiness-dashboard/FlakinessDashboard.js:153:13: "existance" is a misspelling of "existence"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos :heart: