### PR TITLE
test: rework testrunner workers

### DIFF
--- a/utils/testrunner/test/testrunner.spec.js
+++ b/utils/testrunner/test/testrunner.spec.js
@@ -225,6 +225,20 @@ module.exports.addTests = function({testRunner, expect}) {
         'afterAll',
       ]);
     });
+    it('should report as terminated even when hook crashes', async() => {
+      const t = new TestRunner({timeout: 10000});
+      t.afterEach(() => { throw new Error('crash!'); });
+      t.it('uno', () => { t.terminate(); });
+      await t.run();
+      expect(t.tests()[0].result).toBe('terminated');
+    });
+    it('should report as terminated when terminated during hook', async() => {
+      const t = new TestRunner({timeout: 10000});
+      t.afterEach(() => { t.terminate(); });
+      t.it('uno', () => { });
+      await t.run();
+      expect(t.tests()[0].result).toBe('terminated');
+    });
     it('should unwind hooks properly when crashed', async() => {
       const log = [];
       const t = new TestRunner({timeout: 10000});


### PR DESCRIPTION
This change introduces a TestWorker that can be in a certain state,
meaning it has run some beforeAll hooks of a certain test suite stack.

TestWorker can be created at any time, which allows for a number of features:
- don't run hooks for suites with no runnable tests;
- smarter test distribution (and possibility for variuos strategies);
- recovering from hook failures and test failure by creating a new worker;
- possible isolation between workers by running them in separate environments.