### PR TITLE
fix(testrunner): handle uncaught errors

### DIFF
--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -152,6 +152,7 @@ class TestPass {
       createTermination.call(this, 'SIGHUP', TestResult.Terminated, 'SIGHUP received'),
       createTermination.call(this, 'SIGTERM', TestResult.Terminated, 'SIGTERM received'),
       createTermination.call(this, 'unhandledRejection', TestResult.Crashed, 'UNHANDLED PROMISE REJECTION'),
+      createTermination.call(this, 'uncaughtException', TestResult.Crashed, 'UNHANDLED ERROR'),
     ];
     for (const termination of terminations)
       process.on(termination.event, termination.handler);


### PR DESCRIPTION
Follow-up is required with tests for unhandledPromiseRejection / uncaughtException - these aren't so easy since testrunner inside tests conflicts with testrunner that runs tests :man_shrugging: 