### PR TITLE
devops: fix protocol generation with root on Linux

### DIFF
--- a/utils/protocol-types-generator/index.js
+++ b/utils/protocol-types-generator/index.js
@@ -10,7 +10,7 @@ async function generateChromiunProtocol(revision) {
   if (revision.local && fs.existsSync(outputPath))
     return;
   const playwright = await require('../../index').chromium;
-  const browserServer = await playwright.launchServer({ executablePath: revision.executablePath });
+  const browserServer = await playwright.launchServer({ executablePath: revision.executablePath, args: ['--no-sandbox'] });
   const origin = browserServer.wsEndpoint().match(/ws:\/\/([0-9A-Za-z:\.]*)\//)[1];
   const browser = await playwright.connect({ wsEndpoint: browserServer.wsEndpoint() });
   const page = await browser.newPage();


### PR DESCRIPTION
Currently it was leading to an error if I tried to build it with a root user on a Linux environment. So in the end the type generation was just skipped:

```
22:51:55.757 $ node install-from-github.js
22:51:55.813 Building playwright...
22:52:14.094 chromium downloaded to /11994741/playwright/.local-chromium/linux-747023 22:52:14.123 Failed to launch browser!
22:52:14.123 [0310/215214.121201:ERROR:zygote_host_impl_linux.cc(89)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
22:52:14.123 TROUBLESHOOTING: https://github.com/Microsoft/playwright/blob/master/docs/troubleshooting.md
```

Maybe we should also exit the script with an error code if the protocol generation was not successful.