### PR TITLE
feat: browser.newContext({device})

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -200,6 +200,13 @@ Indicates that the browser is connected.
     - `deviceScaleFactor` <[number]> Specify device scale factor (can be thought of as dpr). Defaults to `1`.
     - `isMobile` <[boolean]> Whether the `meta viewport` tag is taken into account and touch events are enabled. Defaults to `false`. Not supported in Firefox.
   - `userAgent` <?[string]> Specific user agent to use in this context.
+  - `device` <[string]|[Object]> Pass a device name or object from [playwright.devices](#playwrightdevices) to set the viewport and user agent.
+    - `viewport` <?[Object]> Sets a consistent viewport for each page. Defaults to an 1280x720 viewport. `null` disables the default viewport.
+      - `width` <[number]>
+      - `height` <[number]>
+      - `deviceScaleFactor` <[number]>
+      - `isMobile` <[boolean]>
+    - `userAgent` <[string]>
   - `javaScriptEnabled` <?[boolean]> Whether or not to enable or disable JavaScript in the context. Defaults to true.
   - `timezoneId` <?[string]> Changes the timezone of the context. See [ICU’s `metaZones.txt`](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs.
   - `geolocation` <[Object]>
@@ -238,6 +245,13 @@ Creates a new browser context. It won't share cookies/cache with other browser c
     - `deviceScaleFactor` <[number]> Specify device scale factor (can be thought of as dpr). Defaults to `1`.
     - `isMobile` <[boolean]> Whether the `meta viewport` tag is taken into account and touch events are enabled. Defaults to `false`. Not supported in Firefox.
   - `userAgent` <?[string]> Specific user agent to use in this context.
+  - `device` <[string]|[Object]> Pass a device name or object from [playwright.devices](#playwrightdevices) to set the viewport and user agent.
+    - `viewport` <?[Object]> Sets a consistent viewport for each page. Defaults to an 1280x720 viewport. `null` disables the default viewport.
+      - `width` <[number]>
+      - `height` <[number]>
+      - `deviceScaleFactor` <[number]>
+      - `isMobile` <[boolean]>
+    - `userAgent` <[string]>
   - `javaScriptEnabled` <?[boolean]> Whether or not to enable or disable JavaScript in the context. Defaults to true.
   - `timezoneId` <?[string]> Changes the timezone of the context. See [ICU’s `metaZones.txt`](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs.
   - `geolocation` <[Object]>
@@ -3821,8 +3835,7 @@ const iPhone = webkit.devices['iPhone 6'];
 (async () => {
   const browser = await webkit.launch();
   const context = await browser.newContext({
-    viewport: iPhone.viewport,
-    userAgent: iPhone.userAgent
+    device: iPhone
   });
   const page = await context.newPage();
   await page.goto('https://example.com');

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -303,6 +303,24 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       await context.close();
     });
   });
+  describe('BrowserContext({device})', function() {
+    it('should work with a device descriptor', async({browser}) => {
+      const context = await browser.newContext({ device: playwright.devices['iPhone 6'] });
+      const page = await context.newPage();
+      expect(page.viewportSize().width).toBe(375);
+      expect(page.viewportSize().height).toBe(667);
+      expect(await page.evaluate(() => navigator.userAgent)).toContain('iPhone');
+      await context.close();
+    });
+    it('should work with a string', async({browser, server}) => {
+      const context = await browser.newContext({ device: 'iPhone 6' });
+      const page = await context.newPage();
+      expect(page.viewportSize().width).toBe(375);
+      expect(page.viewportSize().height).toBe(667);
+      expect(await page.evaluate(() => navigator.userAgent)).toContain('iPhone');
+      await context.close();
+    });
+  });
 
   describe('BrowserContext.pages()', function() {
     it('should return all of the pages', async({browser, server}) => {


### PR DESCRIPTION
Adds `device` as an option to `browser.newContext` and `browser.newPage` that allows for directly passing in a string like `'iPhone 6'` or a descriptor from `playwright.devices`.