### PR TITLE
refactor: remove revisions from generate-protocol-types

### DIFF
--- a/install-from-github.js
+++ b/install-from-github.js
@@ -31,21 +31,21 @@ const playwright = require('.');
   const protocolGenerator = require('./utils/protocol-types-generator');
   try {
     const chromeRevision = await downloadAndCleanup(playwright.chromium);
-    await protocolGenerator.generateChromiunProtocol(chromeRevision);
+    await protocolGenerator.generateChromiumProtocol(chromeRevision.executablePath);
   } catch (e) {
     console.warn(e.message);
   }
 
   try {
     const firefoxRevision = await downloadAndCleanup(playwright.firefox);
-    await protocolGenerator.generateFirefoxProtocol(firefoxRevision);
+    await protocolGenerator.generateFirefoxProtocol(firefoxRevision.executablePath);
   } catch (e) {
     console.warn(e.message);
   }
 
   try {
     const webkitRevision = await downloadAndCleanup(playwright.webkit);
-    await protocolGenerator.generateWebKitProtocol(webkitRevision);
+    await protocolGenerator.generateWebKitProtocol(webkitRevision.executablePath);
   } catch (e) {
     console.warn(e.message);
   }

--- a/utils/protocol-types-generator/index.js
+++ b/utils/protocol-types-generator/index.js
@@ -4,29 +4,37 @@ const fs = require('fs');
 const StreamZip = require('node-stream-zip');
 const vm = require('vm');
 const os = require('os');
+const util = require('util');
 
-async function generateChromiunProtocol(revision) {
+const existsAsync = path => fs.promises.access(path).then(() => true).catch(e => false);
+
+async function generateChromiumProtocol(executablePath) {
   const outputPath = path.join(__dirname, '..', '..', 'src', 'chromium', 'protocol.ts');
-  if (revision.local && fs.existsSync(outputPath))
+  if (!await existsAsync(executablePath))
+    return;
+  if (await existsAsync(outputPath))
     return;
   const playwright = await require('../../index').chromium;
-  const browserServer = await playwright.launchServer({ executablePath: revision.executablePath, args: ['--no-sandbox'] });
+  const browserServer = await playwright.launchServer({ executablePath, args: ['--no-sandbox'] });
   const origin = browserServer.wsEndpoint().match(/ws:\/\/([0-9A-Za-z:\.]*)\//)[1];
   const browser = await playwright.connect({ wsEndpoint: browserServer.wsEndpoint() });
   const page = await browser.newPage();
   await page.goto(`http://${origin}/json/protocol`);
   const json = JSON.parse(await page.evaluate(() => document.documentElement.innerText));
   await browserServer.close();
-  fs.writeFileSync(outputPath, jsonToTS(json));
+  await fs.promises.writeFile(outputPath, jsonToTS(json));
   console.log(`Wrote protocol.ts to ${path.relative(process.cwd(), outputPath)}`);
 }
 
-async function generateWebKitProtocol(revision) {
+async function generateWebKitProtocol(executablePath) {
   const outputPath = path.join(__dirname, '..', '..', 'src', 'webkit', 'protocol.ts');
-  if (revision.local && fs.existsSync(outputPath))
+  if (!await existsAsync(executablePath))
     return;
-  const json = JSON.parse(fs.readFileSync(path.join(revision.folderPath, 'protocol.json'), 'utf8'));
-  fs.writeFileSync(outputPath, jsonToTS({domains: json}));
+  if (await existsAsync(outputPath))
+    return;
+  const folderPath = path.dirname(executablePath);
+  const json = JSON.parse(await fs.promises.readFile(path.join(folderPath, 'protocol.json'), 'utf8'));
+  await fs.promises.writeFile(outputPath, jsonToTS({domains: json}));
   console.log(`Wrote protocol.ts for WebKit to ${path.relative(process.cwd(), outputPath)}`);
 }
 
@@ -118,13 +126,15 @@ function typeOfProperty(property, domain) {
   return property.type;
 }
 
-async function generateFirefoxProtocol(revision) {
+async function generateFirefoxProtocol(executablePath) {
   const outputPath = path.join(__dirname, '..', '..', 'src', 'firefox', 'protocol.ts');
-  if (revision.local && fs.existsSync(outputPath))
+  if (!await existsAsync(executablePath))
+    return;
+  if (await existsAsync(outputPath))
     return;
   const omnija = os.platform() === 'darwin' ?
-    path.join(revision.executablePath, '..', '..', 'Resources', 'omni.ja') :
-    path.join(revision.executablePath, '..', 'omni.ja');
+    path.join(executablePath, '..', '..', 'Resources', 'omni.ja') :
+    path.join(executablePath, '..', 'omni.ja');
   const zip = new StreamZip({file: omnija, storeEntries: true});
   // @ts-ignore
   await new Promise(x => zip.on('ready', x));
@@ -164,7 +174,7 @@ async function generateFirefoxProtocol(revision) {
     }
   }
   const json = vm.runInContext(`(${inject})();${protocolJSCode}; this.protocol;`, ctx);
-  fs.writeFileSync(outputPath, firefoxJSONToTS(json));
+  await fs.promises.writeFile(outputPath, firefoxJSONToTS(json));
   console.log(`Wrote protocol.ts for Firefox to ${path.relative(process.cwd(), outputPath)}`);
 }
 
@@ -216,4 +226,4 @@ function firefoxTypeToString(type, indent='    ') {
   return type['$type'];
 }
 
-module.exports = {generateChromiunProtocol, generateFirefoxProtocol, generateWebKitProtocol};
+module.exports = {generateChromiumProtocol, generateFirefoxProtocol, generateWebKitProtocol};


### PR DESCRIPTION
BrowserFetcher's revisions are getting quite deep into our infrastructure. I'd like to remove them so that I can ultimately re-work the way BrowserFetcher manages downloads.

References #1102 