### PR TITLE
refactor: migrate installation flow to use public APIs only

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3604,6 +3604,7 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 - [browserType.connect(options)](#browsertypeconnectoptions)
 - [browserType.downloadBrowserIfNeeded([progress])](#browsertypedownloadbrowserifneededprogress)
 - [browserType.executablePath()](#browsertypeexecutablepath)
+- [browserType.folderPath()](#browsertypefolderpath)
 - [browserType.launch([options])](#browsertypelaunchoptions)
 - [browserType.launchPersistentContext(userDataDir, [options])](#browsertypelaunchpersistentcontextuserdatadir-options)
 - [browserType.launchServer([options])](#browsertypelaunchserveroptions)
@@ -3625,7 +3626,10 @@ This methods attaches Playwright to an existing browser instance.
 Download browser binary if it is missing.
 
 #### browserType.executablePath()
-- returns: <[string]> A path where Playwright expects to find a bundled browser.
+- returns: <[string]> A path where Playwright expects to find a bundled browser executable.
+
+#### browserType.folderPath()
+- returns: <[string]> A path where Playwright expects to find a bundled browser with all its resources.
 
 #### browserType.launch([options])
 - `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:

--- a/download-browser.js
+++ b/download-browser.js
@@ -13,8 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const fs = require('fs');
+
+const existsAsync = path => fs.promises.access(path).then(() => true, e => false);
 
 async function downloadBrowser(browserType) {
+  if (await existsAsync(browserType.executablePath()))
+    return false;
+
   const browser = browserType.name();
   let progressBar = null;
   let lastDownloadedBytes = 0;
@@ -32,17 +38,10 @@ async function downloadBrowser(browserType) {
     lastDownloadedBytes = downloadedBytes;
     progressBar.tick(delta);
   }
-
-  const fetcher = browserType._createBrowserFetcher();
-  const revisionInfo = fetcher.revisionInfo();
-  // Do nothing if the revision is already downloaded.
-  if (revisionInfo.local)
-    return revisionInfo;
   await browserType.downloadBrowserIfNeeded(onProgress);
-  logPolitely(`${browser} downloaded to ${revisionInfo.folderPath}`);
-  return revisionInfo;
+  logPolitely(`${browser} downloaded to ${browserType.folderPath()}`);
+  return true;
 }
-
 
 function toMegabytes(bytes) {
   const mb = bytes / 1024 / 1024;

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -42,6 +42,7 @@ export type LaunchOptions = BrowserArgOptions & {
 
 export interface BrowserType {
   executablePath(): string;
+  folderPath(): string;
   name(): string;
   launch(options?: LaunchOptions & { slowMo?: number }): Promise<Browser>;
   launchServer(options?: LaunchOptions & { port?: number }): Promise<BrowserServer>;

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -99,7 +99,7 @@ export class Chromium implements BrowserType {
 
     let chromeExecutable = executablePath;
     if (!executablePath) {
-      const {missingText, executablePath} = this._resolveExecutablePath();
+      const {missingText, executablePath} = this._resolvePaths();
       if (missingText)
         throw new Error(missingText);
       chromeExecutable = executablePath;
@@ -154,7 +154,11 @@ export class Chromium implements BrowserType {
   }
 
   executablePath(): string {
-    return this._resolveExecutablePath().executablePath;
+    return this._resolvePaths().executablePath;
+  }
+
+  folderPath(): string {
+    return this._resolvePaths().folderPath;
   }
 
   private _defaultArgs(options: BrowserArgOptions = {}, launchType: LaunchType, userDataDir: string, port: number): string[] {
@@ -252,11 +256,11 @@ export class Chromium implements BrowserType {
     });
   }
 
-  _resolveExecutablePath(): { executablePath: string; missingText: string | null; } {
+  _resolvePaths(): { folderPath: string; executablePath: string; missingText: string | null; } {
     const browserFetcher = this._createBrowserFetcher();
     const revisionInfo = browserFetcher.revisionInfo();
     const missingText = !revisionInfo.local ? `Chromium revision is not downloaded. Run "npm install"` : null;
-    return { executablePath: revisionInfo.executablePath, missingText };
+    return { executablePath: revisionInfo.executablePath, folderPath: revisionInfo.folderPath, missingText };
   }
 }
 

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -118,7 +118,7 @@ export class Firefox implements BrowserType {
 
     let firefoxExecutable = executablePath;
     if (!firefoxExecutable) {
-      const {missingText, executablePath} = this._resolveExecutablePath();
+      const {missingText, executablePath} = this._resolvePaths();
       if (missingText)
         throw new Error(missingText);
       firefoxExecutable = executablePath;
@@ -169,7 +169,11 @@ export class Firefox implements BrowserType {
   }
 
   executablePath(): string {
-    return this._resolveExecutablePath().executablePath;
+    return this._resolvePaths().executablePath;
+  }
+
+  folderPath(): string {
+    return this._resolvePaths().folderPath;
   }
 
   private _defaultArgs(options: BrowserArgOptions = {}, launchType: LaunchType, userDataDir: string, port: number): string[] {
@@ -248,11 +252,11 @@ export class Firefox implements BrowserType {
     });
   }
 
-  _resolveExecutablePath() {
+  _resolvePaths(): {executablePath: string, folderPath: string, missingText: (string|null)} {
     const browserFetcher = this._createBrowserFetcher();
     const revisionInfo = browserFetcher.revisionInfo();
     const missingText = !revisionInfo.local ? `Firefox revision is not downloaded. Run "npm install"` : null;
-    return { executablePath: revisionInfo.executablePath, missingText };
+    return { executablePath: revisionInfo.executablePath, folderPath: revisionInfo.folderPath, missingText };
   }
 }
 

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -109,7 +109,7 @@ export class WebKit implements BrowserType {
 
     let webkitExecutable = executablePath;
     if (!executablePath) {
-      const {missingText, executablePath} = this._resolveExecutablePath();
+      const {missingText, executablePath} = this._resolvePaths();
       if (missingText)
         throw new Error(missingText);
       webkitExecutable = executablePath;
@@ -157,7 +157,11 @@ export class WebKit implements BrowserType {
   }
 
   executablePath(): string {
-    return this._resolveExecutablePath().executablePath;
+    return this._resolvePaths().executablePath;
+  }
+
+  folderPath(): string {
+    return this._resolvePaths().folderPath;
   }
 
   _defaultArgs(options: BrowserArgOptions = {}, launchType: LaunchType, userDataDir: string, port: number): string[] {
@@ -221,11 +225,11 @@ export class WebKit implements BrowserType {
     });
   }
 
-  _resolveExecutablePath(): { executablePath: string; missingText: string | null; } {
+  _resolvePaths(): { folderPath: string; executablePath: string; missingText: string | null; } {
     const browserFetcher = this._createBrowserFetcher();
     const revisionInfo = browserFetcher.revisionInfo();
     const missingText = !revisionInfo.local ? `WebKit revision is not downloaded. Run "npm install"` : null;
-    return { executablePath: revisionInfo.executablePath, missingText };
+    return { executablePath: revisionInfo.executablePath, folderPath: revisionInfo.folderPath, missingText };
   }
 }
 

--- a/test/chromium/launcher.spec.js
+++ b/test/chromium/launcher.spec.js
@@ -91,36 +91,6 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
     });
   });
 
-  describe('BrowserFetcher', function() {
-    it('should download and extract linux binary', async({server}) => {
-      const downloadsFolder = await mkdtempAsync(TMP_FOLDER);
-      const browserFetcher = browserType._createBrowserFetcher({
-        platform: 'linux',
-        path: downloadsFolder,
-        host: server.PREFIX
-      });
-      let revisionInfo = browserFetcher.revisionInfo('123456');
-      server.setRoute(revisionInfo.url.substring(server.PREFIX.length), (req, res) => {
-        server.serveFile(req, res, '/chromium-linux.zip');
-      });
-
-      expect(revisionInfo.local).toBe(false);
-      expect(browserFetcher._platform).toBe('linux');
-      expect(await browserFetcher.canDownload('100000')).toBe(false);
-      expect(await browserFetcher.canDownload('123456')).toBe(true);
-
-      revisionInfo = await browserFetcher.download('123456');
-      expect(revisionInfo.local).toBe(true);
-      expect(await readFileAsync(revisionInfo.executablePath, 'utf8')).toBe('LINUX BINARY\n');
-      const expectedPermissions = WIN ? 0666 : 0755;
-      expect((await statAsync(revisionInfo.executablePath)).mode & 0777).toBe(expectedPermissions);
-      expect(await browserFetcher.localRevisions()).toEqual(['123456']);
-      await browserFetcher.remove('123456');
-      expect(await browserFetcher.localRevisions()).toEqual([]);
-      await rmAsync(downloadsFolder);
-    });
-  });
-
   describe('BrowserContext', function() {
     it('should not create pages automatically', async function() {
       const browser = await browserType.launch();

--- a/utils/protocol-types-generator/index.js
+++ b/utils/protocol-types-generator/index.js
@@ -4,29 +4,26 @@ const fs = require('fs');
 const StreamZip = require('node-stream-zip');
 const vm = require('vm');
 const os = require('os');
+const util = require('util');
 
-async function generateChromiunProtocol(revision) {
+async function generateChromiumProtocol(executablePath) {
   const outputPath = path.join(__dirname, '..', '..', 'src', 'chromium', 'protocol.ts');
-  if (revision.local && fs.existsSync(outputPath))
-    return;
   const playwright = await require('../../index').chromium;
-  const browserServer = await playwright.launchServer({ executablePath: revision.executablePath, args: ['--no-sandbox'] });
+  const browserServer = await playwright.launchServer({ executablePath, args: ['--no-sandbox'] });
   const origin = browserServer.wsEndpoint().match(/ws:\/\/([0-9A-Za-z:\.]*)\//)[1];
   const browser = await playwright.connect({ wsEndpoint: browserServer.wsEndpoint() });
   const page = await browser.newPage();
   await page.goto(`http://${origin}/json/protocol`);
   const json = JSON.parse(await page.evaluate(() => document.documentElement.innerText));
   await browserServer.close();
-  fs.writeFileSync(outputPath, jsonToTS(json));
+  await fs.promises.writeFile(outputPath, jsonToTS(json));
   console.log(`Wrote protocol.ts to ${path.relative(process.cwd(), outputPath)}`);
 }
 
-async function generateWebKitProtocol(revision) {
+async function generateWebKitProtocol(folderPath) {
   const outputPath = path.join(__dirname, '..', '..', 'src', 'webkit', 'protocol.ts');
-  if (revision.local && fs.existsSync(outputPath))
-    return;
-  const json = JSON.parse(fs.readFileSync(path.join(revision.folderPath, 'protocol.json'), 'utf8'));
-  fs.writeFileSync(outputPath, jsonToTS({domains: json}));
+  const json = JSON.parse(await fs.promises.readFile(path.join(folderPath, 'protocol.json'), 'utf8'));
+  await fs.promises.writeFile(outputPath, jsonToTS({domains: json}));
   console.log(`Wrote protocol.ts for WebKit to ${path.relative(process.cwd(), outputPath)}`);
 }
 
@@ -118,13 +115,11 @@ function typeOfProperty(property, domain) {
   return property.type;
 }
 
-async function generateFirefoxProtocol(revision) {
+async function generateFirefoxProtocol(executablePath) {
   const outputPath = path.join(__dirname, '..', '..', 'src', 'firefox', 'protocol.ts');
-  if (revision.local && fs.existsSync(outputPath))
-    return;
   const omnija = os.platform() === 'darwin' ?
-    path.join(revision.executablePath, '..', '..', 'Resources', 'omni.ja') :
-    path.join(revision.executablePath, '..', 'omni.ja');
+    path.join(executablePath, '..', '..', 'Resources', 'omni.ja') :
+    path.join(executablePath, '..', 'omni.ja');
   const zip = new StreamZip({file: omnija, storeEntries: true});
   // @ts-ignore
   await new Promise(x => zip.on('ready', x));
@@ -164,7 +159,7 @@ async function generateFirefoxProtocol(revision) {
     }
   }
   const json = vm.runInContext(`(${inject})();${protocolJSCode}; this.protocol;`, ctx);
-  fs.writeFileSync(outputPath, firefoxJSONToTS(json));
+  await fs.promises.writeFile(outputPath, firefoxJSONToTS(json));
   console.log(`Wrote protocol.ts for Firefox to ${path.relative(process.cwd(), outputPath)}`);
 }
 
@@ -216,4 +211,4 @@ function firefoxTypeToString(type, indent='    ') {
   return type['$type'];
 }
 
-module.exports = {generateChromiunProtocol, generateFirefoxProtocol, generateWebKitProtocol};
+module.exports = {generateChromiumProtocol, generateFirefoxProtocol, generateWebKitProtocol};


### PR DESCRIPTION
This patch moves installation flow to use solely Playwright
public APIs.

This ensures that Playwright APIs exposed for browser downloads
and management are capable enough for real-world usecases.

This adds a `browserType.folderPath()` method that
points to the folder that contains downloaded browser.