### PR TITLE
fix(types): jsHandle.getProperty should never resolve to null

### DIFF
--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -67,14 +67,14 @@ export class JSHandle<T = any> {
     return this._context.evaluateHandle(pageFunction as any, this, ...args);
   }
 
-  async getProperty(propertyName: string): Promise<JSHandle | null> {
+  async getProperty(propertyName: string): Promise<JSHandle> {
     const objectHandle = await this.evaluateHandle((object: any, propertyName) => {
       const result: any = {__proto__: null};
       result[propertyName] = object[propertyName];
       return result;
     }, propertyName);
     const properties = await objectHandle.getProperties();
-    const result = properties.get(propertyName) || null;
+    const result = properties.get(propertyName)!;
     objectHandle.dispose();
     return result;
   }

--- a/test/jshandle.spec.js
+++ b/test/jshandle.spec.js
@@ -77,6 +77,18 @@ module.exports.describe = function({testRunner, expect, CHROMIUM, FFOX, WEBKIT})
       const twoHandle = await aHandle.getProperty('two');
       expect(await twoHandle.jsonValue()).toEqual(2);
     });
+    it('should work with undefined, null, and empty', async({page, server}) => {
+      const aHandle = await page.evaluateHandle(() => ({
+        undefined: undefined,
+        null: null,
+      }));
+      const undefinedHandle = await aHandle.getProperty('undefined');
+      expect(String(await undefinedHandle.jsonValue())).toEqual('undefined');
+      const nullHandle = await aHandle.getProperty('null');
+      expect(await nullHandle.jsonValue()).toEqual(null);
+      const emptyhandle = await aHandle.getProperty('empty');
+      expect(String(await emptyhandle.jsonValue())).toEqual('undefined');
+    })
   });
 
   describe('JSHandle.jsonValue', function() {


### PR DESCRIPTION
Added a test to confirm that this was dead code.