### PR TITLE
feat(devices): remove name from device objects

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -81,8 +81,7 @@ const iPhone = devices['iPhone 6'];
 (async () => {
   const browser = await webkit.launch();
   const context = await browser.newContext({
-    viewport: iPhone.viewport,
-    userAgent: iPhone.userAgent
+    ...iPhone
   });
   const page = await context.newPage();
   await page.goto('http://example.com');

--- a/src/deviceDescriptors.ts
+++ b/src/deviceDescriptors.ts
@@ -17,9 +17,8 @@
 
 import * as types from './types';
 
-const descriptors: types.DeviceDescriptor[] = [
-  {
-    'name': 'Blackberry PlayBook',
+export const DeviceDescriptors: types.Devices = {
+  'Blackberry PlayBook': {
     'userAgent': 'Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/7.2.1.0 Safari/536.2+',
     'viewport': {
       'width': 600,
@@ -28,8 +27,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Blackberry PlayBook landscape',
+  'Blackberry PlayBook landscape': {
     'userAgent': 'Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/7.2.1.0 Safari/536.2+',
     'viewport': {
       'width': 1024,
@@ -38,8 +36,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'BlackBerry Z30',
+  'BlackBerry Z30': {
     'userAgent': 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.0.9.2372 Mobile Safari/537.10+',
     'viewport': {
       'width': 360,
@@ -48,8 +45,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'BlackBerry Z30 landscape',
+  'BlackBerry Z30 landscape': {
     'userAgent': 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.0.9.2372 Mobile Safari/537.10+',
     'viewport': {
       'width': 640,
@@ -58,8 +54,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Galaxy Note 3',
+  'Galaxy Note 3': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
     'viewport': {
       'width': 360,
@@ -68,8 +63,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Galaxy Note 3 landscape',
+  'Galaxy Note 3 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
     'viewport': {
       'width': 640,
@@ -78,8 +72,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Galaxy Note II',
+  'Galaxy Note II': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
     'viewport': {
       'width': 360,
@@ -88,8 +81,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Galaxy Note II landscape',
+  'Galaxy Note II landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
     'viewport': {
       'width': 640,
@@ -98,8 +90,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Galaxy S III',
+  'Galaxy S III': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
     'viewport': {
       'width': 360,
@@ -108,8 +99,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Galaxy S III landscape',
+  'Galaxy S III landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
     'viewport': {
       'width': 640,
@@ -118,8 +108,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Galaxy S5',
+  'Galaxy S5': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 360,
@@ -128,8 +117,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Galaxy S5 landscape',
+  'Galaxy S5 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 640,
@@ -138,8 +126,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPad (gen 6)',
+  'iPad (gen 6)': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 768,
@@ -148,8 +135,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPad (gen 6) landscape',
+  'iPad (gen 6) landscape': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 1024,
@@ -158,8 +144,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPad (gen 7)',
+  'iPad (gen 7)': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 810,
@@ -168,8 +153,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPad (gen 7) landscape',
+  'iPad (gen 7) landscape': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 1080,
@@ -178,8 +162,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPad Mini',
+  'iPad Mini': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 768,
@@ -188,8 +171,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPad Mini landscape',
+  'iPad Mini landscape': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 1024,
@@ -198,8 +180,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPad Pro 11',
+  'iPad Pro 11': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 834,
@@ -208,8 +189,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPad Pro 11 landscape',
+  'iPad Pro 11 landscape': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 1194,
@@ -218,8 +198,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 6',
+  'iPhone 6': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 375,
@@ -228,8 +207,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 6 landscape',
+  'iPhone 6 landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 667,
@@ -238,8 +216,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 6 Plus',
+  'iPhone 6 Plus': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 414,
@@ -248,8 +225,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 6 Plus landscape',
+  'iPhone 6 Plus landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 736,
@@ -258,8 +234,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 7',
+  'iPhone 7': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 375,
@@ -268,8 +243,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 7 landscape',
+  'iPhone 7 landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 667,
@@ -278,8 +252,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 7 Plus',
+  'iPhone 7 Plus': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 414,
@@ -288,8 +261,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 7 Plus landscape',
+  'iPhone 7 Plus landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 736,
@@ -298,8 +270,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 8',
+  'iPhone 8': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 375,
@@ -308,8 +279,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 8 landscape',
+  'iPhone 8 landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 667,
@@ -318,8 +288,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 8 Plus',
+  'iPhone 8 Plus': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 414,
@@ -328,8 +297,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 8 Plus landscape',
+  'iPhone 8 Plus landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 736,
@@ -338,8 +306,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone SE',
+  'iPhone SE': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
     'viewport': {
       'width': 320,
@@ -348,8 +315,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone SE landscape',
+  'iPhone SE landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
     'viewport': {
       'width': 568,
@@ -358,8 +324,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone X',
+  'iPhone X': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 375,
@@ -368,8 +333,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone X landscape',
+  'iPhone X landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
     'viewport': {
       'width': 812,
@@ -378,8 +342,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone XR',
+  'iPhone XR': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 414,
@@ -388,8 +351,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone XR landscape',
+  'iPhone XR landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 896,
@@ -398,8 +360,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 11',
+  'iPhone 11': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 414,
@@ -408,8 +369,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 11 landscape',
+  'iPhone 11 landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 896,
@@ -418,8 +378,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 11 Pro',
+  'iPhone 11 Pro': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 375,
@@ -428,8 +387,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 11 Pro landscape',
+  'iPhone 11 Pro landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 812,
@@ -438,8 +396,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 11 Pro Max',
+  'iPhone 11 Pro Max': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 414,
@@ -448,8 +405,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'iPhone 11 Pro Max landscape',
+  'iPhone 11 Pro Max landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
     'viewport': {
       'width': 896,
@@ -458,8 +414,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'JioPhone 2',
+  'JioPhone 2': {
     'userAgent': 'Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-15-130718-i;Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5',
     'viewport': {
       'width': 240,
@@ -468,8 +423,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'JioPhone 2 landscape',
+  'JioPhone 2 landscape': {
     'userAgent': 'Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-15-130718-i;Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5',
     'viewport': {
       'width': 320,
@@ -478,8 +432,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Kindle Fire HDX',
+  'Kindle Fire HDX': {
     'userAgent': 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true',
     'viewport': {
       'width': 800,
@@ -488,8 +441,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Kindle Fire HDX landscape',
+  'Kindle Fire HDX landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true',
     'viewport': {
       'width': 1280,
@@ -498,8 +450,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'LG Optimus L70',
+  'LG Optimus L70': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 384,
@@ -508,8 +459,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'LG Optimus L70 landscape',
+  'LG Optimus L70 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 640,
@@ -518,8 +468,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Microsoft Lumia 550',
+  'Microsoft Lumia 550': {
     'userAgent': 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
     'viewport': {
       'width': 640,
@@ -528,8 +477,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Microsoft Lumia 550 landscape',
+  'Microsoft Lumia 550 landscape': {
     'userAgent': 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
     'viewport': {
       'width': 360,
@@ -538,8 +486,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Microsoft Lumia 950',
+  'Microsoft Lumia 950': {
     'userAgent': 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
     'viewport': {
       'width': 360,
@@ -548,8 +495,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Microsoft Lumia 950 landscape',
+  'Microsoft Lumia 950 landscape': {
     'userAgent': 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
     'viewport': {
       'width': 640,
@@ -558,8 +504,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 10',
+  'Nexus 10': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 10 Build/MOB31T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
     'viewport': {
       'width': 800,
@@ -568,8 +513,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 10 landscape',
+  'Nexus 10 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 10 Build/MOB31T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
     'viewport': {
       'width': 1280,
@@ -578,8 +522,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 4',
+  'Nexus 4': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 384,
@@ -588,8 +531,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 4 landscape',
+  'Nexus 4 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 640,
@@ -598,8 +540,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 5',
+  'Nexus 5': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 360,
@@ -608,8 +549,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 5 landscape',
+  'Nexus 5 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 640,
@@ -618,8 +558,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 5X',
+  'Nexus 5X': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR4.170623.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 412,
@@ -628,8 +567,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 5X landscape',
+  'Nexus 5X landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR4.170623.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 732,
@@ -638,8 +576,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 6',
+  'Nexus 6': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 412,
@@ -648,8 +585,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 6 landscape',
+  'Nexus 6 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 732,
@@ -658,8 +594,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 6P',
+  'Nexus 6P': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 412,
@@ -668,8 +603,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 6P landscape',
+  'Nexus 6P landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 732,
@@ -678,8 +612,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 7',
+  'Nexus 7': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
     'viewport': {
       'width': 600,
@@ -688,8 +621,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nexus 7 landscape',
+  'Nexus 7 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
     'viewport': {
       'width': 960,
@@ -698,8 +630,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nokia Lumia 520',
+  'Nokia Lumia 520': {
     'userAgent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 520)',
     'viewport': {
       'width': 320,
@@ -708,8 +639,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nokia Lumia 520 landscape',
+  'Nokia Lumia 520 landscape': {
     'userAgent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 520)',
     'viewport': {
       'width': 533,
@@ -718,8 +648,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nokia N9',
+  'Nokia N9': {
     'userAgent': 'Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13',
     'viewport': {
       'width': 480,
@@ -728,8 +657,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Nokia N9 landscape',
+  'Nokia N9 landscape': {
     'userAgent': 'Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13',
     'viewport': {
       'width': 854,
@@ -738,8 +666,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Pixel 2',
+  'Pixel 2': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 411,
@@ -748,8 +675,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Pixel 2 landscape',
+  'Pixel 2 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 731,
@@ -758,8 +684,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Pixel 2 XL',
+  'Pixel 2 XL': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 411,
@@ -768,8 +693,7 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   },
-  {
-    'name': 'Pixel 2 XL landscape',
+  'Pixel 2 XL landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
     'viewport': {
       'width': 823,
@@ -778,8 +702,4 @@ const descriptors: types.DeviceDescriptor[] = [
       'isMobile': true
     }
   }
-];
-
-export const DeviceDescriptors = descriptors as types.Devices;
-for (const device of descriptors)
-  DeviceDescriptors[device.name] = device;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,11 +116,10 @@ export type ColorScheme = 'dark' | 'light' | 'no-preference';
 export const colorSchemes: Set<ColorScheme> = new Set(['dark', 'light', 'no-preference']);
 
 export type DeviceDescriptor = {
-  name: string,
   userAgent: string,
   viewport: Viewport,
 };
-export type Devices = { [name: string]: DeviceDescriptor } & DeviceDescriptor[];
+export type Devices = { [name: string]: DeviceDescriptor };
 
 export type PDFOptions = {
   scale?: number,

--- a/test/emulation.spec.js
+++ b/test/emulation.spec.js
@@ -83,7 +83,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
   describe.skip(FFOX)('viewport.isMobile', () => {
     // Firefox does not support isMobile.
     it('should support mobile emulation', async({browser, server}) => {
-      const context = await browser.newContext({ viewport: iPhone.viewport });
+      const context = await browser.newContext({ ...iPhone });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
       expect(await page.evaluate(() => window.innerWidth)).toBe(375);
@@ -92,7 +92,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       await context.close();
     });
     it('should support touch emulation', async({browser, server}) => {
-      const context = await browser.newContext({ viewport: iPhone.viewport });
+      const context = await browser.newContext({ ...iPhone });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
       expect(await page.evaluate(() => 'ontouchstart' in window)).toBe(true);
@@ -113,7 +113,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       }
     });
     it('should be detectable by Modernizr', async({browser, server}) => {
-      const context = await browser.newContext({ viewport: iPhone.viewport });
+      const context = await browser.newContext({ ...iPhone });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/detect-touch.html');
       expect(await page.evaluate(() => document.body.textContent.trim())).toBe('YES');
@@ -128,11 +128,11 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       await context.close();
     });
     it('should support landscape emulation', async({browser, server}) => {
-      const context1 = await browser.newContext({ viewport: iPhone.viewport });
+      const context1 = await browser.newContext({ ...iPhone });
       const page1 = await context1.newPage();
       await page1.goto(server.PREFIX + '/mobile.html');
       expect(await page1.evaluate(() => matchMedia('(orientation: landscape)').matches)).toBe(false);
-      const context2 = await browser.newContext({ viewport: iPhoneLandscape.viewport });
+      const context2 = await browser.newContext({ ...iPhoneLandscape });
       const page2 = await context2.newPage();
       expect(await page2.evaluate(() => matchMedia('(orientation: landscape)').matches)).toBe(true);
       await context1.close();
@@ -174,7 +174,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
 
   describe.skip(FFOX)('Page.emulate', function() {
     it('should work', async({browser, server}) => {
-      const context = await browser.newContext({viewport: iPhone.viewport, userAgent: iPhone.userAgent});
+      const context = await browser.newContext({ ...iPhone });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
       expect(await page.evaluate(() => window.innerWidth)).toBe(375);
@@ -182,7 +182,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       await context.close();
     });
     it('should support clicking', async({browser, server}) => {
-      const context = await browser.newContext({ viewport: iPhone.viewport, userAgent: iPhone.userAgent });
+      const context = await browser.newContext({ ...iPhone });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/input/button.html');
       const button = await page.$('button');


### PR DESCRIPTION
This allows device objects to be destructured directly into `newContext` or `newPage`. I also remove the array form of the DeviceDescriptors object, as it becomes rather useless without names.