### PR TITLE
devops: remake downloading logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
-            - ./.local-chromium
-            - ./.local-firefox
-            - ./.local-webkit
+            - ./.local-browsers
 
       - run:
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,10 @@
 /test/output-firefox
 /test/output-webkit
 /test/test-user-data-dir*
-/.local-chromium/
-/.local-firefox/
-/.local-webkit/
+/.local-browsers/
 /.dev_profile*
 .DS_Store
+.downloaded-browsers.json
 *.swp
 *.pyc
 .vscode

--- a/docs/api.md
+++ b/docs/api.md
@@ -3602,12 +3602,12 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 
 <!-- GEN:toc -->
 - [browserType.connect(options)](#browsertypeconnectoptions)
-- [browserType.downloadBrowserIfNeeded([progress])](#browsertypedownloadbrowserifneededprogress)
 - [browserType.executablePath()](#browsertypeexecutablepath)
 - [browserType.launch([options])](#browsertypelaunchoptions)
 - [browserType.launchPersistentContext(userDataDir, [options])](#browsertypelaunchpersistentcontextuserdatadir-options)
 - [browserType.launchServer([options])](#browsertypelaunchserveroptions)
 - [browserType.name()](#browsertypename)
+- [browserType.setExecutablePath(executablePath)](#browsertypesetexecutablepathexecutablepath)
 <!-- GEN:stop -->
 
 #### browserType.connect(options)
@@ -3618,14 +3618,8 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 
 This methods attaches Playwright to an existing browser instance.
 
-#### browserType.downloadBrowserIfNeeded([progress])
-- `progress` <[function]> If download is initiated, this function is called with two parameters: `downloadedBytes` and `totalBytes`.
-- returns: <[Promise]> promise that resolves when browser is successfully downloaded.
-
-Download browser binary if it is missing.
-
 #### browserType.executablePath()
-- returns: <[string]> A path where Playwright expects to find a bundled browser.
+- returns: <[string]> A path where Playwright expects to find a bundled browser executable.
 
 #### browserType.launch([options])
 - `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:
@@ -3713,6 +3707,9 @@ const { chromium } = require('playwright');  // Or 'webkit' or 'firefox'.
 - returns: <[string]>
 
 Returns browser name. For example: `'chromium'`, `'webkit'` or `'firefox'`.
+
+#### browserType.setExecutablePath(executablePath)
+- `executablePath` <[string]> An executable path that Playwright will use to launch browser.
 
 ### class: ChromiumBrowser
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -3618,7 +3618,7 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 This methods attaches Playwright to an existing browser instance.
 
 #### browserType.executablePath()
-- returns: <[string|null]> A path where Playwright expects to find a bundled browser executable.
+- returns: <[string]> A path where Playwright expects to find a bundled browser executable.
 
 #### browserType.launch([options])
 - `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:

--- a/docs/api.md
+++ b/docs/api.md
@@ -3607,7 +3607,6 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 - [browserType.launchPersistentContext(userDataDir, [options])](#browsertypelaunchpersistentcontextuserdatadir-options)
 - [browserType.launchServer([options])](#browsertypelaunchserveroptions)
 - [browserType.name()](#browsertypename)
-- [browserType.setExecutablePath(executablePath)](#browsertypesetexecutablepathexecutablepath)
 <!-- GEN:stop -->
 
 #### browserType.connect(options)
@@ -3707,9 +3706,6 @@ const { chromium } = require('playwright');  // Or 'webkit' or 'firefox'.
 - returns: <[string]>
 
 Returns browser name. For example: `'chromium'`, `'webkit'` or `'firefox'`.
-
-#### browserType.setExecutablePath(executablePath)
-- `executablePath` <[string]> An executable path that Playwright will use to launch browser.
 
 ### class: ChromiumBrowser
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -3618,7 +3618,7 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 This methods attaches Playwright to an existing browser instance.
 
 #### browserType.executablePath()
-- returns: <[string]> A path where Playwright expects to find a bundled browser executable.
+- returns: <[string|null]> A path where Playwright expects to find a bundled browser executable.
 
 #### browserType.launch([options])
 - `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -164,7 +164,7 @@ done only once per host environment:
 
 ```bash
 # cd to the downloaded instance
-cd <project-dir-path>/node_modules/playwright/.local-chromium/linux-<revision>/chrome-linux/
+cd <project-dir-path>/node_modules/playwright/.local-browsers/chromium-<revision>/
 sudo chown root:root chrome_sandbox
 sudo chmod 4755 chrome_sandbox
 # copy sandbox executable to a shared location

--- a/index.js
+++ b/index.js
@@ -21,9 +21,9 @@ const playwright = new Playwright({
 
 try {
   const downloadedBrowsers = require('./.downloaded-browsers.json');
-  playwright.chromium.setExecutablePath(downloadedBrowsers.crExecutablePath);
-  playwright.firefox.setExecutablePath(downloadedBrowsers.ffExecutablePath);
-  playwright.webkit.setExecutablePath(downloadedBrowsers.wkExecutablePath);
+  playwright.chromium._executablePath = downloadedBrowsers.crExecutablePath;
+  playwright.firefox._executablePath = downloadedBrowsers.ffExecutablePath;
+  playwright.webkit._executablePath = downloadedBrowsers.wkExecutablePath;
 } catch (e) {
 }
 

--- a/index.js
+++ b/index.js
@@ -15,9 +15,17 @@
  */
 const {Playwright} = require('./lib/server/playwright.js');
 
-module.exports = new Playwright({
-  downloadPath: __dirname,
+const playwright = new Playwright({
   browsers: ['webkit', 'chromium', 'firefox'],
-  respectEnvironmentVariables: false,
 });
+
+try {
+  const downloadedBrowsers = require('./.downloaded-browsers.json');
+  playwright.chromium.setExecutablePath(downloadedBrowsers.crExecutablePath);
+  playwright.firefox.setExecutablePath(downloadedBrowsers.ffExecutablePath);
+  playwright.webkit.setExecutablePath(downloadedBrowsers.wkExecutablePath);
+} catch (e) {
+}
+
+module.exports = playwright;
 

--- a/install-from-github.js
+++ b/install-from-github.js
@@ -47,8 +47,8 @@ const DOWNLOAD_PATHS = {
     if (!(await existsAsync(DOWNLOAD_PATHS.chromium))) {
       const crExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.chromium, 'chromium');
       downloadedBrowsersJSON.crExecutablePath = crExecutablePath;
-      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
       await protocolGenerator.generateChromiumProtocol(crExecutablePath);
+      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
     }
   } catch (e) {
     console.warn(e.message);
@@ -57,8 +57,8 @@ const DOWNLOAD_PATHS = {
     if (!(await existsAsync(DOWNLOAD_PATHS.firefox))) {
       const ffExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.firefox, 'firefox');
       downloadedBrowsersJSON.ffExecutablePath = ffExecutablePath;
-      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
       await protocolGenerator.generateFirefoxProtocol(ffExecutablePath);
+      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
     }
   } catch (e) {
     console.warn(e.message);
@@ -67,8 +67,8 @@ const DOWNLOAD_PATHS = {
     if (!(await existsAsync(DOWNLOAD_PATHS.webkit))) {
       const wkExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.webkit, 'webkit');
       downloadedBrowsersJSON.wkExecutablePath = wkExecutablePath;
-      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
       await protocolGenerator.generateWebKitProtocol(path.dirname(wkExecutablePath));
+      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
     }
   } catch (e) {
     console.warn(e.message);

--- a/install-from-github.js
+++ b/install-from-github.js
@@ -24,41 +24,69 @@ try {
   });
 } catch (e) {
 }
-const {downloadBrowser} = require('./download-browser');
-const playwright = require('.');
+
+const path = require('path');
+const fs = require('fs');
+const util = require('util');
+const rmAsync = util.promisify(require('rimraf'));
+const existsAsync = path => fs.promises.access(path).then(() => true, e => false);
+const {downloadBrowserWithProgressBar} = require('./download-browser');
+const protocolGenerator = require('./utils/protocol-types-generator');
+const packageJSON = require('./package.json');
+
+const DOWNLOADED_BROWSERS_JSON_PATH = path.join(__dirname, '.downloaded-browsers.json');
+const DOWNLOAD_PATHS = {
+  chromium: path.join(__dirname, '.local-browsers', `chromium-${packageJSON.playwright.chromium_revision}`),
+  firefox: path.join(__dirname, '.local-browsers', `firefox-${packageJSON.playwright.firefox_revision}`),
+  webkit: path.join(__dirname, '.local-browsers', `webkit-${packageJSON.playwright.webkit_revision}`),
+};
 
 (async function() {
-  const protocolGenerator = require('./utils/protocol-types-generator');
+  const downloadedBrowsersJSON = await fs.promises.readFile(DOWNLOADED_BROWSERS_JSON_PATH, 'utf8').then(json => JSON.parse(json)).catch(() => ({}));
   try {
-    const chromeRevision = await downloadAndCleanup(playwright.chromium);
-    await protocolGenerator.generateChromiunProtocol(chromeRevision);
+    if (!(await existsAsync(DOWNLOAD_PATHS.chromium))) {
+      const crExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.chromium, 'chromium');
+      downloadedBrowsersJSON.crExecutablePath = crExecutablePath;
+      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
+      await protocolGenerator.generateChromiumProtocol(crExecutablePath);
+    }
+  } catch (e) {
+    console.warn(e.message);
+  }
+  try {
+    if (!(await existsAsync(DOWNLOAD_PATHS.firefox))) {
+      const ffExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.firefox, 'firefox');
+      downloadedBrowsersJSON.ffExecutablePath = ffExecutablePath;
+      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
+      await protocolGenerator.generateFirefoxProtocol(ffExecutablePath);
+    }
+  } catch (e) {
+    console.warn(e.message);
+  }
+  try {
+    if (!(await existsAsync(DOWNLOAD_PATHS.webkit))) {
+      const wkExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.webkit, 'webkit');
+      downloadedBrowsersJSON.wkExecutablePath = wkExecutablePath;
+      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
+      await protocolGenerator.generateWebKitProtocol(path.dirname(wkExecutablePath));
+    }
   } catch (e) {
     console.warn(e.message);
   }
 
-  try {
-    const firefoxRevision = await downloadAndCleanup(playwright.firefox);
-    await protocolGenerator.generateFirefoxProtocol(firefoxRevision);
-  } catch (e) {
-    console.warn(e.message);
-  }
+  // Cleanup stale revisions.
+  const directories = new Set(await readdirAsync(path.join(__dirname, '.local-browsers')));
+  directories.delete(DOWNLOAD_PATHS.chromium);
+  directories.delete(DOWNLOAD_PATHS.firefox);
+  directories.delete(DOWNLOAD_PATHS.webkit);
+  // cleanup old browser directories.
+  directories.add(path.join(__dirname, '.local-chromium'));
+  directories.add(path.join(__dirname, '.local-firefox'));
+  directories.add(path.join(__dirname, '.local-webkit'));
+  await Promise.all([...directories].map(directory => rmAsync(directory)));
 
-  try {
-    const webkitRevision = await downloadAndCleanup(playwright.webkit);
-    await protocolGenerator.generateWebKitProtocol(webkitRevision);
-  } catch (e) {
-    console.warn(e.message);
+  async function readdirAsync(dirpath) {
+    return fs.promises.readdir(dirpath).then(dirs => dirs.map(dir => path.join(dirpath, dir)));
   }
 })();
 
-async function downloadAndCleanup(browserType) {
-  const revisionInfo = await downloadBrowser(browserType);
-
-  // Remove previous revisions.
-  const fetcher = browserType._createBrowserFetcher();
-  const localRevisions = await fetcher.localRevisions();
-  const cleanupOldVersions = localRevisions.filter(revision => revision !== revisionInfo.revision).map(revision => fetcher.remove(revision));
-  await Promise.all([...cleanupOldVersions]);
-
-  return revisionInfo;
-}

--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -13,12 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+const path = require('path');
 const {Playwright} = require('playwright-core/lib/server/playwright.js');
 
-module.exports = new Playwright({
-  downloadPath: __dirname,
+const playwright = new Playwright({
   browsers: ['chromium'],
-  respectEnvironmentVariables: true,
 });
+module.exports = playwright;
+
+try {
+  const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
+  playwright.chromium.setExecutablePath(downloadedBrowsers.crExecutablePath);
+} catch (e) {
+  throw new Error('ERROR: Playwright-Chromium did not download browser');
+}
+
 

--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -22,10 +22,9 @@ const playwright = new Playwright({
 module.exports = playwright;
 
 try {
-  const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
+  const downloadedBrowsers = require('./.downloaded-browsers.json');
   playwright.chromium.setExecutablePath(downloadedBrowsers.crExecutablePath);
 } catch (e) {
   throw new Error('ERROR: Playwright-Chromium did not download browser');
 }
-
 

--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -23,7 +23,7 @@ module.exports = playwright;
 
 try {
   const downloadedBrowsers = require('./.downloaded-browsers.json');
-  playwright.chromium.setExecutablePath(downloadedBrowsers.crExecutablePath);
+  playwright.chromium._executablePath = downloadedBrowsers.crExecutablePath;
 } catch (e) {
   throw new Error('playwright-chromium has not downloaded Chromium.');
 }

--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -25,6 +25,5 @@ try {
   const downloadedBrowsers = require('./.downloaded-browsers.json');
   playwright.chromium.setExecutablePath(downloadedBrowsers.crExecutablePath);
 } catch (e) {
-  throw new Error('ERROR: Playwright-Chromium did not download browser');
+  throw new Error('playwright-chromium has not downloaded Chromium.');
 }
-

--- a/packages/playwright-chromium/install.js
+++ b/packages/playwright-chromium/install.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const {downloadBrowser} = require('playwright-core/download-browser');
-const playwright = require('.');
-downloadBrowser(playwright.chromium);
+const path = require('path');
+const fs = require('fs');
+const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
+(async function() {
+  const crExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'chromium'), 'chromium');
+  await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({crExecutablePath}));
+})();

--- a/packages/playwright-firefox/index.js
+++ b/packages/playwright-firefox/index.js
@@ -13,12 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+const path = require('path');
 const {Playwright} = require('playwright-core/lib/server/playwright.js');
 
-module.exports = new Playwright({
-  downloadPath: __dirname,
+const playwright = new Playwright({
   browsers: ['firefox'],
-  respectEnvironmentVariables: true,
 });
+module.exports = playwright;
+
+try {
+  const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
+  playwright.firefox.setExecutablePath(downloadedBrowsers.ffExecutablePath);
+} catch (e) {
+  throw new Error('ERROR: Playwright-Firefox did not download browser');
+}
+
 

--- a/packages/playwright-firefox/index.js
+++ b/packages/playwright-firefox/index.js
@@ -25,7 +25,6 @@ try {
   const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
   playwright.firefox.setExecutablePath(downloadedBrowsers.ffExecutablePath);
 } catch (e) {
-  throw new Error('ERROR: Playwright-Firefox did not download browser');
+  throw new Error('playwright-firefox has not downloaded Firefox.');
 }
-
 

--- a/packages/playwright-firefox/index.js
+++ b/packages/playwright-firefox/index.js
@@ -23,7 +23,7 @@ module.exports = playwright;
 
 try {
   const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
-  playwright.firefox.setExecutablePath(downloadedBrowsers.ffExecutablePath);
+  playwright.firefox._executablePath = downloadedBrowsers.ffExecutablePath;
 } catch (e) {
   throw new Error('playwright-firefox has not downloaded Firefox.');
 }

--- a/packages/playwright-firefox/install.js
+++ b/packages/playwright-firefox/install.js
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const {downloadBrowser} = require('playwright-core/download-browser');
-const playwright = require('.');
-downloadBrowser(playwright.firefox);
+const path = require('path');
+const fs = require('fs');
+const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
+
+(async function() {
+  const ffExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'firefox'), 'firefox');
+  await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({ffExecutablePath, }));
+})();

--- a/packages/playwright-webkit/index.js
+++ b/packages/playwright-webkit/index.js
@@ -23,7 +23,7 @@ module.exports = playwright;
 
 try {
   const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
-  playwright.webkit.setExecutablePath(downloadedBrowsers.wkExecutablePath);
+  playwright.webkit._executablePath = downloadedBrowsers.wkExecutablePath;
 } catch (e) {
   throw new Error('playwright-webkit has not downloaded WebKit.');
 }

--- a/packages/playwright-webkit/index.js
+++ b/packages/playwright-webkit/index.js
@@ -25,7 +25,6 @@ try {
   const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
   playwright.webkit.setExecutablePath(downloadedBrowsers.wkExecutablePath);
 } catch (e) {
-  throw new Error('ERROR: Playwright-Webkit did not download browser');
+  throw new Error('playwright-webkit has not downloaded WebKit.');
 }
-
 

--- a/packages/playwright-webkit/index.js
+++ b/packages/playwright-webkit/index.js
@@ -13,12 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+const path = require('path');
 const {Playwright} = require('playwright-core/lib/server/playwright.js');
 
-module.exports = new Playwright({
-  downloadPath: __dirname,
+const playwright = new Playwright({
   browsers: ['webkit'],
-  respectEnvironmentVariables: true,
 });
+module.exports = playwright;
+
+try {
+  const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
+  playwright.webkit.setExecutablePath(downloadedBrowsers.wkExecutablePath);
+} catch (e) {
+  throw new Error('ERROR: Playwright-Webkit did not download browser');
+}
+
 

--- a/packages/playwright-webkit/install.js
+++ b/packages/playwright-webkit/install.js
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const {downloadBrowser} = require('playwright-core/download-browser');
-const playwright = require('.');
-downloadBrowser(playwright.webkit);
+const path = require('path');
+const fs = require('fs');
+const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
+
+(async function() {
+  const wkExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'webkit'), 'webkit');
+  await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({wkExecutablePath, }));
+})();

--- a/packages/playwright/index.js
+++ b/packages/playwright/index.js
@@ -23,9 +23,9 @@ module.exports = playwright;
 
 try {
   const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
-  playwright.chromium.setExecutablePath(downloadedBrowsers.crExecutablePath);
-  playwright.firefox.setExecutablePath(downloadedBrowsers.ffExecutablePath);
-  playwright.webkit.setExecutablePath(downloadedBrowsers.wkExecutablePath);
+  playwright.chromium._executablePath = downloadedBrowsers.crExecutablePath;
+  playwright.firefox._executablePath = downloadedBrowsers.ffExecutablePath;
+  playwright.webkit._executablePath = downloadedBrowsers.wkExecutablePath;
 } catch (e) {
   throw new Error('ERROR: Playwright did not download browsers');
 }

--- a/packages/playwright/index.js
+++ b/packages/playwright/index.js
@@ -13,11 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const path = require('path');
 const {Playwright} = require('playwright-core/lib/server/playwright.js');
 
-module.exports = new Playwright({
-  downloadPath: __dirname,
+const playwright = new Playwright({
   browsers: ['webkit', 'chromium', 'firefox'],
-  respectEnvironmentVariables: true,
 });
+module.exports = playwright;
+
+try {
+  const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
+  playwright.chromium.setExecutablePath(downloadedBrowsers.crExecutablePath);
+  playwright.firefox.setExecutablePath(downloadedBrowsers.ffExecutablePath);
+  playwright.webkit.setExecutablePath(downloadedBrowsers.wkExecutablePath);
+} catch (e) {
+  throw new Error('ERROR: Playwright did not download browsers');
+}
+
 

--- a/packages/playwright/install.js
+++ b/packages/playwright/install.js
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const {downloadBrowser} = require('playwright-core/download-browser');
-const playwright = require('.');
+const path = require('path');
+const fs = require('fs');
+const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
+
 (async function() {
-  await downloadBrowser(playwright.chromium);
-  await downloadBrowser(playwright.firefox);
-  await downloadBrowser(playwright.webkit);
+  const crExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'chromium'), 'chromium');
+  const ffExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'firefox'), 'firefox');
+  const wkExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'webkit'), 'webkit');
+  await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({crExecutablePath, ffExecutablePath, wkExecutablePath, }));
 })();

--- a/src/server/browserFetcher.ts
+++ b/src/server/browserFetcher.ts
@@ -101,7 +101,7 @@ export type DownloadOptions = {
 const CURRENT_HOST_PLATFORM = ((): string => {
   const platform = os.platform();
   if (platform === 'darwin') {
-    const macVersion = execSync('sw_vers -productVersion').toString('utf8').trim();
+    const macVersion = execSync('sw_vers -productVersion').toString('utf8').trim().split('.').slice(0, 2).join('.');
     return `mac${macVersion}`;
   }
   if (platform === 'linux')

--- a/src/server/browserFetcher.ts
+++ b/src/server/browserFetcher.ts
@@ -17,110 +17,152 @@
 
 import * as extract from 'extract-zip';
 import * as fs from 'fs';
+import * as os from 'os';
+import * as util from 'util';
+import { execSync } from 'child_process';
 import * as ProxyAgent from 'https-proxy-agent';
 import * as path from 'path';
-import * as platform from '../platform';
 import { getProxyForUrl } from 'proxy-from-env';
-import * as removeRecursive from 'rimraf';
 import * as URL from 'url';
 import { assert } from '../helper';
+import * as platform from '../platform';
 
-const readdirAsync = platform.promisify(fs.readdir.bind(fs));
-const mkdirAsync = platform.promisify(fs.mkdir.bind(fs));
 const unlinkAsync = platform.promisify(fs.unlink.bind(fs));
 const chmodAsync = platform.promisify(fs.chmod.bind(fs));
+const existsAsync = (path: string): Promise<boolean> => new Promise(resolve => fs.stat(path, err => resolve(!err)));
 
-function existsAsync(filePath: string): Promise<boolean> {
-  let fulfill: (exists: boolean) => void;
-  const promise = new Promise<boolean>(x => fulfill = x);
-  fs.access(filePath, err => fulfill(!err));
-  return promise;
-}
+const DEFAULT_DOWNLOAD_HOSTS = {
+  chromium: 'https://storage.googleapis.com',
+  firefox: 'https://playwright.azureedge.net',
+  webkit: 'https://playwright.azureedge.net',
+};
 
-type ParamsGetter = (platform: string, revision: string) => { downloadUrl: string, executablePath: string };
+const DOWNLOAD_URLS = {
+  chromium: {
+    'linux': '%s/chromium-browser-snapshots/Linux_x64/%d/chrome-linux.zip',
+    'mac10.14': '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip',
+    'mac10.15': '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip',
+    'win32': '%s/chromium-browser-snapshots/Win/%d/chrome-win.zip',
+    'win64': '%s/chromium-browser-snapshots/Win_x64/%d/chrome-win.zip',
+  },
+  firefox: {
+    'linux': '%s/builds/firefox/%s/firefox-linux.zip',
+    'mac10.14': '%s/builds/firefox/%s/firefox-mac.zip',
+    'mac10.15': '%s/builds/firefox/%s/firefox-mac.zip',
+    'win32': '%s/builds/firefox/%s/firefox-win32.zip',
+    'win64': '%s/builds/firefox/%s/firefox-win64.zip',
+  },
+  webkit: {
+    'linux': '%s/builds/webkit/%s/minibrowser-gtk-wpe.zip',
+    'mac10.14': '%s/builds/webkit/%s/minibrowser-mac-10.14.zip',
+    'mac10.15': '%s/builds/webkit/%s/minibrowser-mac-10.15.zip',
+    'win32': '%s/builds/webkit/%s/minibrowser-win64.zip',
+    'win64': '%s/builds/webkit/%s/minibrowser-win64.zip',
+  },
+};
+
+const RELATIVE_EXECUTABLE_PATHS = {
+  chromium: {
+    'linux': ['chrome-linux', 'chrome'],
+    'mac10.14': ['chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium'],
+    'mac10.15': ['chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium'],
+    'win32': ['chrome-win', 'chrome.exe'],
+    'win64': ['chrome-win', 'chrome.exe'],
+  },
+  firefox: {
+    'linux': ['firefox', 'firefox'],
+    'mac10.14': ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox'],
+    'mac10.15': ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox'],
+    'win32': ['firefox', 'firefox.exe'],
+    'win64': ['firefox', 'firefox.exe'],
+  },
+  webkit: {
+    'linux': ['pw_run.sh'],
+    'mac10.14': ['pw_run.sh'],
+    'mac10.15': ['pw_run.sh'],
+    'win32': ['MiniBrowser.exe'],
+    'win64': ['MiniBrowser.exe'],
+  },
+};
 
 export type OnProgressCallback = (downloadedBytes: number, totalBytes: number) => void;
+export type BrowserName = ('chromium'|'webkit'|'firefox');
+export type BrowserPlatform = ('win32'|'win64'|'mac10.14'|'mac10.15'|'linux');
 
-export class BrowserFetcher {
-  private _downloadsFolder: string;
-  private _platform: string;
-  private _preferredRevision: string;
-  private _params: ParamsGetter;
+export type DownloadOptions = {
+  browser: BrowserName,
+  revision: string,
+  downloadPath: string,
+  platform?: BrowserPlatform,
+  host?: string,
+  progress?: OnProgressCallback,
+};
 
-  constructor(downloadsFolder: string, platform: string, preferredRevision: string, params: ParamsGetter) {
-    this._downloadsFolder = downloadsFolder;
-    this._platform = platform;
-    this._preferredRevision = preferredRevision;
-    this._params = params;
+const CURRENT_HOST_PLATFORM = ((): string => {
+  const platform = os.platform();
+  if (platform === 'darwin') {
+    const macVersion = execSync('sw_vers -productVersion').toString('utf8').trim();
+    return `mac${macVersion}`;
   }
+  if (platform === 'linux')
+    return 'linux';
+  if (platform === 'win32')
+    return os.arch() === 'x64' ? 'win64' : 'win32';
+  return platform;
+})();
 
-  canDownload(revision: string = this._preferredRevision): Promise<boolean> {
-    const url = this._params(this._platform, revision).downloadUrl;
-    let resolve: (result: boolean) => void = () => {};
-    const promise = new Promise<boolean>(x => resolve = x);
-    const request = httpRequest(url, 'HEAD', response => {
-      resolve(response.statusCode === 200);
-    });
-    request.on('error', (error: any) => {
-      console.error(error);
-      resolve(false);
-    });
-    return promise;
-  }
-
-  async download(revision: string = this._preferredRevision, progressCallback?: OnProgressCallback): Promise<BrowserFetcherRevisionInfo> {
-    const url = this._params(this._platform, revision).downloadUrl;
-    const zipPath = path.join(this._downloadsFolder, `download-${this._platform}-${revision}.zip`);
-    const folderPath = this._getFolderPath(revision);
-    if (await existsAsync(folderPath))
-      return this.revisionInfo(revision);
-    if (!(await existsAsync(this._downloadsFolder)))
-      await mkdirAsync(this._downloadsFolder);
-    try {
-      await downloadFile(url, zipPath, progressCallback);
-      await extractZip(zipPath, folderPath);
-    } finally {
-      if (await existsAsync(zipPath))
-        await unlinkAsync(zipPath);
-    }
-    const revisionInfo = this.revisionInfo(revision);
-    if (revisionInfo)
-      await chmodAsync(revisionInfo.executablePath, 0o755);
-    return revisionInfo;
-  }
-
-  async localRevisions(): Promise<string[]> {
-    if (!await existsAsync(this._downloadsFolder))
-      return [];
-    const fileNames: string[] = await readdirAsync(this._downloadsFolder);
-    return fileNames.map(fileName => parseFolderPath(fileName)).filter(entry => entry && entry.platform === this._platform).map(entry => entry!.revision);
-  }
-
-  async remove(revision: string = this._preferredRevision) {
-    const folderPath = this._getFolderPath(revision);
-    assert(await existsAsync(folderPath), `Failed to remove: revision ${revision} is not downloaded`);
-    await new Promise(fulfill => removeRecursive(folderPath, fulfill));
-  }
-
-  revisionInfo(revision: string = this._preferredRevision): BrowserFetcherRevisionInfo {
-    const folderPath = this._getFolderPath(revision);
-    const params = this._params(this._platform, revision);
-    const local = fs.existsSync(folderPath);
-    return {revision, executablePath: path.join(folderPath, params.executablePath), folderPath, local, url: params.downloadUrl};
-  }
-
-  _getFolderPath(revision: string): string {
-    return path.join(this._downloadsFolder, this._platform + '-' + revision);
-  }
+function revisionURL(options: DownloadOptions): string {
+  const {
+    browser,
+    revision,
+    platform = CURRENT_HOST_PLATFORM,
+    host = DEFAULT_DOWNLOAD_HOSTS[browser],
+  } = options;
+  assert(revision, `'revision' must be specified`);
+  assert(DOWNLOAD_URLS[browser], 'Unsupported browser: ' + browser);
+  const urlTemplate = (DOWNLOAD_URLS[browser] as any)[platform];
+  assert(urlTemplate, `ERROR: Playwright does not support ${browser} on ${platform}`);
+  return util.format(urlTemplate, host, revision);
 }
 
-function parseFolderPath(folderPath: string): { platform: string; revision: string; } | null {
-  const name = path.basename(folderPath);
-  const splits = name.split('-');
-  if (splits.length !== 2)
-    return null;
-  const [platform, revision] = splits;
-  return {platform, revision};
+export async function downloadBrowser(options: DownloadOptions): Promise<string> {
+  const {
+    browser,
+    revision,
+    downloadPath,
+    platform = CURRENT_HOST_PLATFORM,
+    progress,
+  } = options;
+  assert(downloadPath, '`downloadPath` must be provided');
+  const url = revisionURL(options);
+  const zipPath = path.join(os.tmpdir(), `playwright-download-${browser}-${platform}-${revision}.zip`);
+  if (await existsAsync(downloadPath))
+    throw new Error('ERROR: downloadPath folder already exists!');
+  try {
+    await downloadFile(url, zipPath, progress);
+    // await mkdirAsync(downloadPath, {recursive: true});
+    await extractZip(zipPath, downloadPath);
+  } finally {
+    if (await existsAsync(zipPath))
+      await unlinkAsync(zipPath);
+  }
+  const executablePath = path.join(downloadPath, ...RELATIVE_EXECUTABLE_PATHS[browser][platform as BrowserPlatform]);
+  await chmodAsync(executablePath, 0o755);
+  return executablePath;
+}
+
+export async function canDownload(options: DownloadOptions): Promise<boolean> {
+  const url = revisionURL(options);
+  let resolve: (result: boolean) => void = () => {};
+  const promise = new Promise<boolean>(x => resolve = x);
+  const request = httpRequest(url, 'HEAD', response => {
+    resolve(response.statusCode === 200);
+  });
+  request.on('error', (error: any) => {
+    console.error(error);
+    resolve(false);
+  });
+  return promise;
 }
 
 function downloadFile(url: string, destinationPath: string, progressCallback: OnProgressCallback | undefined): Promise<any> {
@@ -199,17 +241,3 @@ function httpRequest(url: string, method: string, response: (r: any) => void) {
   request.end();
   return request;
 }
-
-export type BrowserFetcherOptions = {
-  platform?: string,
-  path?: string,
-  host?: string,
-};
-
-export type BrowserFetcherRevisionInfo = {
-  folderPath: string,
-  executablePath: string,
-  url: string,
-  local: boolean,
-  revision: string,
-};

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -17,7 +17,6 @@
 import { Browser, ConnectOptions } from '../browser';
 import { BrowserContext } from '../browserContext';
 import { BrowserServer } from './browserServer';
-import { OnProgressCallback } from './browserFetcher';
 
 export type BrowserArgOptions = {
   headless?: boolean,
@@ -41,11 +40,11 @@ export type LaunchOptions = BrowserArgOptions & {
 };
 
 export interface BrowserType {
-  executablePath(): string;
+  executablePath(): (string|null);
+  setExecutablePath(executablePath: string): void;
   name(): string;
   launch(options?: LaunchOptions & { slowMo?: number }): Promise<Browser>;
   launchServer(options?: LaunchOptions & { port?: number }): Promise<BrowserServer>;
   launchPersistentContext(userDataDir: string, options?: LaunchOptions): Promise<BrowserContext>;
   connect(options: ConnectOptions): Promise<Browser>;
-  downloadBrowserIfNeeded(progress?: OnProgressCallback): Promise<void>;
 }

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -41,7 +41,6 @@ export type LaunchOptions = BrowserArgOptions & {
 
 export interface BrowserType {
   executablePath(): (string|null);
-  setExecutablePath(executablePath: string): void;
   name(): string;
   launch(options?: LaunchOptions & { slowMo?: number }): Promise<Browser>;
   launchServer(options?: LaunchOptions & { port?: number }): Promise<BrowserServer>;

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -40,7 +40,7 @@ export type LaunchOptions = BrowserArgOptions & {
 };
 
 export interface BrowserType {
-  executablePath(): (string|null);
+  executablePath(): string;
   name(): string;
   launch(options?: LaunchOptions & { slowMo?: number }): Promise<Browser>;
   launchServer(options?: LaunchOptions & { port?: number }): Promise<BrowserServer>;

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -36,7 +36,9 @@ export class Chromium implements BrowserType {
   private _executablePath: (string|undefined);
 
   executablePath(): (string|null) {
-    return this._executablePath || null;
+    if (!this._executablePath)
+      throw new Error('No executable path!');
+    return this._executablePath;
   }
 
   name() {

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -35,7 +35,7 @@ import { BrowserContext } from '../browserContext';
 export class Chromium implements BrowserType {
   private _executablePath: (string|undefined);
 
-  executablePath(): (string|null) {
+  executablePath(): string {
     if (!this._executablePath)
       throw new Error('No executable path!');
     return this._executablePath;

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -18,9 +18,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import * as util from 'util';
-import { BrowserFetcher, OnProgressCallback, BrowserFetcherOptions } from '../server/browserFetcher';
-import { assert, helper } from '../helper';
+import { helper } from '../helper';
 import { CRBrowser } from '../chromium/crBrowser';
 import * as platform from '../platform';
 import { TimeoutError } from '../errors';
@@ -35,14 +33,17 @@ import { ConnectionTransport } from '../transport';
 import { BrowserContext } from '../browserContext';
 
 export class Chromium implements BrowserType {
-  private _downloadPath: string;
-  private _downloadHost: string;
-  readonly _revision: string;
+  private _executablePath: (string|undefined);
 
-  constructor(downloadPath: string, downloadHost: (string|undefined), preferredRevision: string) {
-    this._downloadPath = downloadPath;
-    this._downloadHost = downloadHost || 'https://storage.googleapis.com';
-    this._revision = preferredRevision;
+  constructor() {
+  }
+
+  executablePath(): (string|null) {
+    return this._executablePath || null;
+  }
+
+  setExecutablePath(executablePath: string) {
+    this._executablePath = executablePath;
   }
 
   name() {
@@ -97,16 +98,12 @@ export class Chromium implements BrowserType {
     else
       chromeArguments.push(...args);
 
-    let chromeExecutable = executablePath;
-    if (!executablePath) {
-      const {missingText, executablePath} = this._resolveExecutablePath();
-      if (missingText)
-        throw new Error(missingText);
-      chromeExecutable = executablePath;
-    }
+    const chromeExecutable = executablePath || this._executablePath;
+    if (!chromeExecutable)
+      throw new Error(`No executable path is specified. Either use "chromium.setExecutablePath()" to set one, or pass "executablePath" option directly.`);
     let browserServer: BrowserServer | undefined = undefined;
     const { launchedProcess, gracefullyClose } = await launchProcess({
-      executablePath: chromeExecutable!,
+      executablePath: chromeExecutable,
       args: chromeArguments,
       env,
       handleSIGINT,
@@ -134,7 +131,7 @@ export class Chromium implements BrowserType {
     let transport: PipeTransport | undefined;
     let browserWSEndpoint: string | undefined;
     if (launchType === 'server') {
-      const timeoutError = new TimeoutError(`Timed out after ${timeout} ms while trying to connect to Chromium! The only Chromium revision guaranteed to work is r${this._revision}`);
+      const timeoutError = new TimeoutError(`Timed out after ${timeout} ms while trying to connect to Chromium!`);
       const match = await waitForLine(launchedProcess, launchedProcess.stderr, /^DevTools listening on (ws:\/\/.*)$/, timeout, timeoutError);
       browserWSEndpoint = match[1];
       browserServer = new BrowserServer(launchedProcess, gracefullyClose, browserWSEndpoint);
@@ -151,10 +148,6 @@ export class Chromium implements BrowserType {
     return await platform.connectToWebsocket(options.wsEndpoint, transport => {
       return CRBrowser.connect(transport, false, options.slowMo);
     });
-  }
-
-  executablePath(): string {
-    return this._resolveExecutablePath().executablePath;
   }
 
   private _defaultArgs(options: BrowserArgOptions = {}, launchType: LaunchType, userDataDir: string, port: number): string[] {
@@ -192,71 +185,6 @@ export class Chromium implements BrowserType {
     }
 
     return chromeArguments;
-  }
-
-  async downloadBrowserIfNeeded(onProgress?: OnProgressCallback) {
-    const fetcher = this._createBrowserFetcher();
-    const revisionInfo = fetcher.revisionInfo();
-    // Do nothing if the revision is already downloaded.
-    if (revisionInfo.local)
-      return;
-    await fetcher.download(revisionInfo.revision, onProgress);
-  }
-
-  _createBrowserFetcher(options: BrowserFetcherOptions = {}): BrowserFetcher {
-    const downloadURLs = {
-      linux: '%s/chromium-browser-snapshots/Linux_x64/%d/%s.zip',
-      mac: '%s/chromium-browser-snapshots/Mac/%d/%s.zip',
-      win32: '%s/chromium-browser-snapshots/Win/%d/%s.zip',
-      win64: '%s/chromium-browser-snapshots/Win_x64/%d/%s.zip',
-    };
-
-    const defaultOptions = {
-      path: path.join(this._downloadPath, '.local-chromium'),
-      host: this._downloadHost,
-      platform: (() => {
-        const platform = os.platform();
-        if (platform === 'darwin')
-          return 'mac';
-        if (platform === 'linux')
-          return 'linux';
-        if (platform === 'win32')
-          return os.arch() === 'x64' ? 'win64' : 'win32';
-        return platform;
-      })()
-    };
-    options = {
-      ...defaultOptions,
-      ...options,
-    };
-    assert(!!(downloadURLs as any)[options.platform!], 'Unsupported platform: ' + options.platform);
-
-    return new BrowserFetcher(options.path!, options.platform!, this._revision, (platform: string, revision: string) => {
-      let archiveName = '';
-      let executablePath = '';
-      if (platform === 'linux') {
-        archiveName = 'chrome-linux';
-        executablePath = path.join(archiveName, 'chrome');
-      } else if (platform === 'mac') {
-        archiveName = 'chrome-mac';
-        executablePath = path.join(archiveName, 'Chromium.app', 'Contents', 'MacOS', 'Chromium');
-      } else if (platform === 'win32' || platform === 'win64') {
-        // Windows archive name changed at r591479.
-        archiveName = parseInt(revision, 10) > 591479 ? 'chrome-win' : 'chrome-win32';
-        executablePath = path.join(archiveName, 'chrome.exe');
-      }
-      return {
-        downloadUrl: util.format((downloadURLs as any)[platform], options.host, revision, archiveName),
-        executablePath
-      };
-    });
-  }
-
-  _resolveExecutablePath(): { executablePath: string; missingText: string | null; } {
-    const browserFetcher = this._createBrowserFetcher();
-    const revisionInfo = browserFetcher.revisionInfo();
-    const missingText = !revisionInfo.local ? `Chromium revision is not downloaded. Run "npm install"` : null;
-    return { executablePath: revisionInfo.executablePath, missingText };
   }
 }
 

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -35,15 +35,8 @@ import { BrowserContext } from '../browserContext';
 export class Chromium implements BrowserType {
   private _executablePath: (string|undefined);
 
-  constructor() {
-  }
-
   executablePath(): (string|null) {
     return this._executablePath || null;
-  }
-
-  setExecutablePath(executablePath: string) {
-    this._executablePath = executablePath;
   }
 
   name() {
@@ -100,7 +93,7 @@ export class Chromium implements BrowserType {
 
     const chromeExecutable = executablePath || this._executablePath;
     if (!chromeExecutable)
-      throw new Error(`No executable path is specified. Either use "chromium.setExecutablePath()" to set one, or pass "executablePath" option directly.`);
+      throw new Error(`No executable path is specified. Pass "executablePath" option directly.`);
     let browserServer: BrowserServer | undefined = undefined;
     const { launchedProcess, gracefullyClose } = await launchProcess({
       executablePath: chromeExecutable,

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -35,8 +35,10 @@ const mkdtempAsync = platform.promisify(fs.mkdtemp);
 export class Firefox implements BrowserType {
   private _executablePath: (string|undefined);
 
-  executablePath(): (string|null) {
-    return this._executablePath || null;
+  executablePath(): string {
+    if (!this._executablePath)
+      throw new Error('No executable path!');
+    return this._executablePath;
   }
 
   name() {

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -35,15 +35,8 @@ const mkdtempAsync = platform.promisify(fs.mkdtemp);
 export class Firefox implements BrowserType {
   private _executablePath: (string|undefined);
 
-  constructor() {
-  }
-
   executablePath(): (string|null) {
     return this._executablePath || null;
-  }
-
-  setExecutablePath(executablePath: string) {
-    this._executablePath = executablePath;
   }
 
   name() {
@@ -110,7 +103,7 @@ export class Firefox implements BrowserType {
 
     const firefoxExecutable = executablePath || this._executablePath;
     if (!firefoxExecutable)
-      throw new Error(`No executable path is specified. Either use "firefox.setExecutablePath()" to set one, or pass "executablePath" option directly.`);
+      throw new Error(`No executable path is specified. Pass "executablePath" option directly.`);
 
     let browserServer: BrowserServer | undefined = undefined;
     const { launchedProcess, gracefullyClose } = await launchProcess({

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -18,16 +18,14 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import * as util from 'util';
 import { ConnectOptions, LaunchType } from '../browser';
 import { BrowserContext } from '../browserContext';
 import { TimeoutError } from '../errors';
 import { Events } from '../events';
 import { FFBrowser } from '../firefox/ffBrowser';
 import { kBrowserCloseMessageId } from '../firefox/ffConnection';
-import { assert, helper } from '../helper';
+import { helper } from '../helper';
 import * as platform from '../platform';
-import { BrowserFetcher, BrowserFetcherOptions, OnProgressCallback } from './browserFetcher';
 import { BrowserServer } from './browserServer';
 import { BrowserArgOptions, BrowserType, LaunchOptions } from './browserType';
 import { launchProcess, waitForLine } from './processLauncher';
@@ -35,23 +33,17 @@ import { launchProcess, waitForLine } from './processLauncher';
 const mkdtempAsync = platform.promisify(fs.mkdtemp);
 
 export class Firefox implements BrowserType {
-  private _downloadPath: string;
-  private _downloadHost: string;
-  readonly _revision: string;
+  private _executablePath: (string|undefined);
 
-  constructor(downloadPath: string, downloadHost: (string|undefined), preferredRevision: string) {
-    this._downloadPath = downloadPath;
-    this._downloadHost = downloadHost || 'https://playwright.azureedge.net';
-    this._revision = preferredRevision;
+  constructor() {
   }
 
-  async downloadBrowserIfNeeded(onProgress?: OnProgressCallback) {
-    const fetcher = this._createBrowserFetcher();
-    const revisionInfo = fetcher.revisionInfo();
-    // Do nothing if the revision is already downloaded.
-    if (revisionInfo.local)
-      return;
-    await fetcher.download(revisionInfo.revision, onProgress);
+  executablePath(): (string|null) {
+    return this._executablePath || null;
+  }
+
+  setExecutablePath(executablePath: string) {
+    this._executablePath = executablePath;
   }
 
   name() {
@@ -116,13 +108,9 @@ export class Firefox implements BrowserType {
     else
       firefoxArguments.push(...args);
 
-    let firefoxExecutable = executablePath;
-    if (!firefoxExecutable) {
-      const {missingText, executablePath} = this._resolveExecutablePath();
-      if (missingText)
-        throw new Error(missingText);
-      firefoxExecutable = executablePath;
-    }
+    const firefoxExecutable = executablePath || this._executablePath;
+    if (!firefoxExecutable)
+      throw new Error(`No executable path is specified. Either use "firefox.setExecutablePath()" to set one, or pass "executablePath" option directly.`);
 
     let browserServer: BrowserServer | undefined = undefined;
     const { launchedProcess, gracefullyClose } = await launchProcess({
@@ -168,10 +156,6 @@ export class Firefox implements BrowserType {
     });
   }
 
-  executablePath(): string {
-    return this._resolveExecutablePath().executablePath;
-  }
-
   private _defaultArgs(options: BrowserArgOptions = {}, launchType: LaunchType, userDataDir: string, port: number): string[] {
     const {
       devtools = false,
@@ -203,56 +187,6 @@ export class Firefox implements BrowserType {
     if (args.every(arg => arg.startsWith('-')))
       firefoxArguments.push('about:blank');
     return firefoxArguments;
-  }
-
-  _createBrowserFetcher(options: BrowserFetcherOptions = {}): BrowserFetcher {
-    const downloadURLs = {
-      linux: '%s/builds/firefox/%s/firefox-linux.zip',
-      mac: '%s/builds/firefox/%s/firefox-mac.zip',
-      win32: '%s/builds/firefox/%s/firefox-win32.zip',
-      win64: '%s/builds/firefox/%s/firefox-win64.zip',
-    };
-
-    const defaultOptions = {
-      path: path.join(this._downloadPath, '.local-firefox'),
-      host: this._downloadHost,
-      platform: (() => {
-        const platform = os.platform();
-        if (platform === 'darwin')
-          return 'mac';
-        if (platform === 'linux')
-          return 'linux';
-        if (platform === 'win32')
-          return os.arch() === 'x64' ? 'win64' : 'win32';
-        return platform;
-      })()
-    };
-    options = {
-      ...defaultOptions,
-      ...options,
-    };
-    assert(!!(downloadURLs as any)[options.platform!], 'Unsupported platform: ' + options.platform);
-
-    return new BrowserFetcher(options.path!, options.platform!, this._revision, (platform: string, revision: string) => {
-      let executablePath = '';
-      if (platform === 'linux')
-        executablePath = path.join('firefox', 'firefox');
-      else if (platform === 'mac')
-        executablePath = path.join('firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox');
-      else if (platform === 'win32' || platform === 'win64')
-        executablePath = path.join('firefox', 'firefox.exe');
-      return {
-        downloadUrl: util.format((downloadURLs as any)[platform], options.host, revision),
-        executablePath
-      };
-    });
-  }
-
-  _resolveExecutablePath() {
-    const browserFetcher = this._createBrowserFetcher();
-    const revisionInfo = browserFetcher.revisionInfo();
-    const missingText = !revisionInfo.local ? `Firefox revision is not downloaded. Run "npm install"` : null;
-    return { executablePath: revisionInfo.executablePath, missingText };
   }
 }
 

--- a/src/server/playwright.ts
+++ b/src/server/playwright.ts
@@ -23,17 +23,13 @@ import { Chromium } from './chromium';
 import { WebKit } from './webkit';
 import { Firefox } from './firefox';
 
-const packageJSON = require('../../package.json');
-
 for (const className in api) {
   if (typeof (api as any)[className] === 'function')
     helper.installApiHooks(className[0].toLowerCase() + className.substring(1), (api as any)[className]);
 }
 
 type PlaywrightOptions = {
-  downloadPath: string,
   browsers: Array<('firefox'|'webkit'|'chromium')>,
-  respectEnvironmentVariables: boolean,
 };
 
 export class Playwright {
@@ -46,25 +42,15 @@ export class Playwright {
 
   constructor(options: PlaywrightOptions) {
     const {
-      downloadPath,
       browsers,
-      respectEnvironmentVariables,
     } = options;
     this.devices = DeviceDescriptors;
     this.errors = { TimeoutError };
-    const downloadHost = respectEnvironmentVariables ? getFromENV('PLAYWRIGHT_DOWNLOAD_HOST') : undefined;
     if (browsers.includes('chromium'))
-      this.chromium = new Chromium(downloadPath, downloadHost, packageJSON.playwright.chromium_revision);
+      this.chromium = new Chromium();
     if (browsers.includes('webkit'))
-      this.webkit = new WebKit(downloadPath, downloadHost, packageJSON.playwright.webkit_revision);
+      this.webkit = new WebKit();
     if (browsers.includes('firefox'))
-      this.firefox = new Firefox(downloadPath, downloadHost, packageJSON.playwright.firefox_revision);
+      this.firefox = new Firefox();
   }
-}
-
-function getFromENV(name: string): (string|undefined) {
-  let value = process.env[name];
-  value = value || process.env[`npm_config_${name.toLowerCase()}`];
-  value = value || process.env[`npm_package_config_${name.toLowerCase()}`];
-  return value;
 }

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -36,15 +36,8 @@ import { BrowserContext } from '../browserContext';
 export class WebKit implements BrowserType {
   private _executablePath: (string|undefined);
 
-  constructor() {
-  }
-
   executablePath(): (string|null) {
     return this._executablePath || null;
-  }
-
-  setExecutablePath(executablePath: string) {
-    this._executablePath = executablePath;
   }
 
   name() {
@@ -100,7 +93,7 @@ export class WebKit implements BrowserType {
 
     const webkitExecutable = executablePath || this._executablePath;
     if (!webkitExecutable)
-      throw new Error(`No executable path is specified. Either use "webkit.setExecutablePath()" to set one, or pass "executablePath" option directly.`);
+      throw new Error(`No executable path is specified.`);
 
     let transport: ConnectionTransport | undefined = undefined;
     let browserServer: BrowserServer | undefined = undefined;

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -36,8 +36,10 @@ import { BrowserContext } from '../browserContext';
 export class WebKit implements BrowserType {
   private _executablePath: (string|undefined);
 
-  executablePath(): (string|null) {
-    return this._executablePath || null;
+  executablePath(): string {
+    if (!this._executablePath)
+      throw new Error('No executable path!');
+    return this._executablePath;
   }
 
   name() {

--- a/test/chromium/launcher.spec.js
+++ b/test/chromium/launcher.spec.js
@@ -91,36 +91,6 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
     });
   });
 
-  describe('BrowserFetcher', function() {
-    it('should download and extract linux binary', async({server}) => {
-      const downloadsFolder = await mkdtempAsync(TMP_FOLDER);
-      const browserFetcher = browserType._createBrowserFetcher({
-        platform: 'linux',
-        path: downloadsFolder,
-        host: server.PREFIX
-      });
-      let revisionInfo = browserFetcher.revisionInfo('123456');
-      server.setRoute(revisionInfo.url.substring(server.PREFIX.length), (req, res) => {
-        server.serveFile(req, res, '/chromium-linux.zip');
-      });
-
-      expect(revisionInfo.local).toBe(false);
-      expect(browserFetcher._platform).toBe('linux');
-      expect(await browserFetcher.canDownload('100000')).toBe(false);
-      expect(await browserFetcher.canDownload('123456')).toBe(true);
-
-      revisionInfo = await browserFetcher.download('123456');
-      expect(revisionInfo.local).toBe(true);
-      expect(await readFileAsync(revisionInfo.executablePath, 'utf8')).toBe('LINUX BINARY\n');
-      const expectedPermissions = WIN ? 0666 : 0755;
-      expect((await statAsync(revisionInfo.executablePath)).mode & 0777).toBe(expectedPermissions);
-      expect(await browserFetcher.localRevisions()).toEqual(['123456']);
-      await browserFetcher.remove('123456');
-      expect(await browserFetcher.localRevisions()).toEqual([]);
-      await rmAsync(downloadsFolder);
-    });
-  });
-
   describe('BrowserContext', function() {
     it('should not create pages automatically', async function() {
       const browser = await browserType.launch();

--- a/test/utils.js
+++ b/test/utils.js
@@ -285,9 +285,8 @@ const utils = module.exports = {
   makeUserDataDir: async function() {
     return await mkdtempAsync(path.join(os.tmpdir(), 'playwright_dev_profile-'));
   },
-  
+
   removeUserDataDir: async function(dir) {
     await removeFolderAsync(dir).catch(e => {});
   }
-  
 };

--- a/utils/check_availability.js
+++ b/utils/check_availability.js
@@ -16,11 +16,11 @@
  */
 
 const assert = require('assert');
-const playwright = require('..').chromium;
+const browserFetcher = require('../lib/server/browserFetcher.js');
 const https = require('https');
 const SUPPORTER_PLATFORMS = ['linux', 'mac', 'win32', 'win64'];
 
-const fetchers = SUPPORTER_PLATFORMS.map(platform => playwright._createBrowserFetcher(platform === 'mac' ? 'mac10.15' : platform));
+const fetcherOptions = SUPPORTER_PLATFORMS.map(platform => ({platform: platform === 'mac' ? 'mac10.15' : platform, browser: 'chromium'}));
 
 const colors = {
   reset: '\x1b[0m',
@@ -100,7 +100,7 @@ async function checkRangeAvailability(fromRevision, toRevision, stopWhenAllAvail
  * @return {boolean}
  */
 async function checkAndDrawRevisionAvailability(table, name, revision) {
-  const promises = fetchers.map(fetcher => fetcher.canDownload(revision));
+  const promises = fetcherOptions.map(options => browserFetcher.canDownload({...options, revision}));
   const availability = await Promise.all(promises);
   const allAvailable = availability.every(e => !!e);
   const values = [name + ' ' + (allAvailable ? colors.green + revision + colors.reset : revision)];

--- a/utils/check_availability.js
+++ b/utils/check_availability.js
@@ -20,7 +20,7 @@ const playwright = require('..').chromium;
 const https = require('https');
 const SUPPORTER_PLATFORMS = ['linux', 'mac', 'win32', 'win64'];
 
-const fetchers = SUPPORTER_PLATFORMS.map(platform => playwright._createBrowserFetcher({platform}));
+const fetchers = SUPPORTER_PLATFORMS.map(platform => playwright._createBrowserFetcher(platform === 'mac' ? 'mac10.15' : platform));
 
 const colors = {
   reset: '\x1b[0m',

--- a/utils/protocol-types-generator/index.js
+++ b/utils/protocol-types-generator/index.js
@@ -4,29 +4,26 @@ const fs = require('fs');
 const StreamZip = require('node-stream-zip');
 const vm = require('vm');
 const os = require('os');
+const util = require('util');
 
-async function generateChromiunProtocol(revision) {
+async function generateChromiumProtocol(executablePath) {
   const outputPath = path.join(__dirname, '..', '..', 'src', 'chromium', 'protocol.ts');
-  if (revision.local && fs.existsSync(outputPath))
-    return;
   const playwright = await require('../../index').chromium;
-  const browserServer = await playwright.launchServer({ executablePath: revision.executablePath, args: ['--no-sandbox'] });
+  const browserServer = await playwright.launchServer({ executablePath, args: ['--no-sandbox'] });
   const origin = browserServer.wsEndpoint().match(/ws:\/\/([0-9A-Za-z:\.]*)\//)[1];
   const browser = await playwright.connect({ wsEndpoint: browserServer.wsEndpoint() });
   const page = await browser.newPage();
   await page.goto(`http://${origin}/json/protocol`);
   const json = JSON.parse(await page.evaluate(() => document.documentElement.innerText));
   await browserServer.close();
-  fs.writeFileSync(outputPath, jsonToTS(json));
+  await fs.promises.writeFile(outputPath, jsonToTS(json));
   console.log(`Wrote protocol.ts to ${path.relative(process.cwd(), outputPath)}`);
 }
 
-async function generateWebKitProtocol(revision) {
+async function generateWebKitProtocol(folderPath) {
   const outputPath = path.join(__dirname, '..', '..', 'src', 'webkit', 'protocol.ts');
-  if (revision.local && fs.existsSync(outputPath))
-    return;
-  const json = JSON.parse(fs.readFileSync(path.join(revision.folderPath, 'protocol.json'), 'utf8'));
-  fs.writeFileSync(outputPath, jsonToTS({domains: json}));
+  const json = JSON.parse(await fs.promises.readFile(path.join(folderPath, 'protocol.json'), 'utf8'));
+  await fs.promises.writeFile(outputPath, jsonToTS({domains: json}));
   console.log(`Wrote protocol.ts for WebKit to ${path.relative(process.cwd(), outputPath)}`);
 }
 
@@ -118,13 +115,11 @@ function typeOfProperty(property, domain) {
   return property.type;
 }
 
-async function generateFirefoxProtocol(revision) {
+async function generateFirefoxProtocol(executablePath) {
   const outputPath = path.join(__dirname, '..', '..', 'src', 'firefox', 'protocol.ts');
-  if (revision.local && fs.existsSync(outputPath))
-    return;
   const omnija = os.platform() === 'darwin' ?
-    path.join(revision.executablePath, '..', '..', 'Resources', 'omni.ja') :
-    path.join(revision.executablePath, '..', 'omni.ja');
+    path.join(executablePath, '..', '..', 'Resources', 'omni.ja') :
+    path.join(executablePath, '..', 'omni.ja');
   const zip = new StreamZip({file: omnija, storeEntries: true});
   // @ts-ignore
   await new Promise(x => zip.on('ready', x));
@@ -164,7 +159,7 @@ async function generateFirefoxProtocol(revision) {
     }
   }
   const json = vm.runInContext(`(${inject})();${protocolJSCode}; this.protocol;`, ctx);
-  fs.writeFileSync(outputPath, firefoxJSONToTS(json));
+  await fs.promises.writeFile(outputPath, firefoxJSONToTS(json));
   console.log(`Wrote protocol.ts for Firefox to ${path.relative(process.cwd(), outputPath)}`);
 }
 
@@ -216,4 +211,4 @@ function firefoxTypeToString(type, indent='    ') {
   return type['$type'];
 }
 
-module.exports = {generateChromiunProtocol, generateFirefoxProtocol, generateWebKitProtocol};
+module.exports = {generateChromiumProtocol, generateFirefoxProtocol, generateWebKitProtocol};


### PR DESCRIPTION
This patch:
- removes `browserType.downloadBrowserIfNeeded()` method. The method
  turned out to be ill-behaving and cannot not be used as we'd like to (see #1085)
- adds a `browserType.setExecutablePath` method to set a browser
  exectuable.

With this patch, we take the following approach towards managing browser downloads:
- `playwright-core` doesn't download any browsers. In `playwright-core`, `playwright.chromium.executablePath()` returns `null` (same for firefox and webkit).
- clients of `playwright-core` (e.g. `playwright` and others) download browsers one way or another.
They can then configure `playwright` with executable paths and re-export the `playwright` object to their clients.
- `playwright`, `playwright-firefox`, `playwright-chromium` and `playwright-webkit` download 
browsers. Once browsers are downloaded, their executable paths are saved to a `.downloaded-browsers.json` file. This file is read in `playwright/index.js` to configure browser executable paths and re-export the API.
- special case is `install-from-github.js` that also cleans up old browsers.
