### PR TITLE
devops: strictly configure build folder for Firefox builds

### DIFF
--- a/browser_patches/firefox/archive.sh
+++ b/browser_patches/firefox/archive.sh
@@ -32,11 +32,7 @@ trap "cd $(pwd -P)" EXIT
 cd "$(dirname $0)"
 cd checkout
 
-OBJ_FOLDER=$(ls -1 | grep obj-)
-if [[ $OBJ_FOLDER == "" ]]; then
-  echo "ERROR: cannot find obj-* folder in the checkout/. Did you build?"
-  exit 1;
-fi
+OBJ_FOLDER="obj-build-playwright"
 
 ./mach package
 node ../install-preferences.js $PWD/$OBJ_FOLDER/dist/firefox

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -36,12 +36,14 @@ else
   exit 1;
 fi
 
+OBJ_FOLDER="obj-build-playwright"
+echo "mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/${OBJ_FOLDER}" >> .mozconfig
+
 ./mach build
 
-OBJ_FOLDER=$(ls -1 | grep obj-)
 if [[ "$(uname)" == "Darwin" ]]; then
-  node ../install-preferences.js $PWD/$OBJ_FOLDER/dist
+  node ../install-preferences.js $PWD/${OBJ_FOLDER}/dist
 else
-  node ../install-preferences.js $PWD/$OBJ_FOLDER/dist/bin
+  node ../install-preferences.js $PWD/${OBJ_FOLDER}/dist/bin
 fi
 

--- a/browser_patches/firefox/clean.sh
+++ b/browser_patches/firefox/clean.sh
@@ -6,7 +6,7 @@ trap "cd $(pwd -P)" EXIT
 cd "$(dirname $0)"
 cd "checkout"
 
-OBJ_FOLDER=$(ls -1 | grep obj- || true)
+OBJ_FOLDER="obj-build-playwright"
 if [[ -d $OBJ_FOLDER ]]; then
   rm -rf $OBJ_FOLDER
 fi


### PR DESCRIPTION
This strictly defines Firefox build folder as `obj-build-playwright`.

Currently, Firefox build folder encodes current Mac OS version including
patch versions, and thus we might end up with multiple different build
folders.