### PR TITLE
feat: show warning on ff & wk if devtools was given

### DIFF
--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -158,7 +158,7 @@ export class Firefox implements BrowserType<FFBrowser> {
       args = [],
     } = options;
     if (devtools)
-      throw new Error('Option "devtools" is not supported by Firefox');
+      console.warn('devtools parameter is not supported as a launch argument in Firefox. You can launch the devtools window manually.');
     const userDataDirArg = args.find(arg => arg.startsWith('-profile') || arg.startsWith('--profile'));
     if (userDataDirArg)
       throw new Error('Pass userDataDir parameter instead of specifying -profile argument');

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -144,7 +144,7 @@ export class WebKit implements BrowserType<WKBrowser> {
       args = [],
     } = options;
     if (devtools)
-      console.warn('devtools parameter as a launch argument and launching DevTools manually in WebKit is not supported.');
+      console.warn('devtools parameter as a launch argument in WebKit is not supported. Also starting Web Inspector manually will terminate the execution in WebKit.');
     const userDataDirArg = args.find(arg => arg.startsWith('--user-data-dir='));
     if (userDataDirArg)
       throw new Error('Pass userDataDir parameter instead of specifying --user-data-dir argument');

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -144,7 +144,7 @@ export class WebKit implements BrowserType<WKBrowser> {
       args = [],
     } = options;
     if (devtools)
-      throw new Error('Option "devtools" is not supported by WebKit');
+      console.warn('devtools parameter is not supported as a launch argument in WebKit. You can launch the devtools window manually.');
     const userDataDirArg = args.find(arg => arg.startsWith('--user-data-dir='));
     if (userDataDirArg)
       throw new Error('Pass userDataDir parameter instead of specifying --user-data-dir argument');

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -144,7 +144,7 @@ export class WebKit implements BrowserType<WKBrowser> {
       args = [],
     } = options;
     if (devtools)
-      console.warn('devtools parameter is not supported as a launch argument in WebKit. You can launch the devtools window manually.');
+      console.warn('devtools parameter as a launch argument and launching DevTools manually in WebKit is not supported.');
     const userDataDirArg = args.find(arg => arg.startsWith('--user-data-dir='));
     if (userDataDirArg)
       throw new Error('Pass userDataDir parameter instead of specifying --user-data-dir argument');


### PR DESCRIPTION
Show just a warning instead of preventing the launch on Firefox and WebKit to minimize the error rate / entry barrier.

Not fully sure if `console.warn` is okay for that.

Closes #1440