### PR TITLE
devops: put .local-browsers into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ playwright-*.tgz
 /web.js
 /web.js.map
 /types/*
+.local-browsers

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /test/output-firefox
 /test/output-webkit
 /test/test-user-data-dir*
-/.local-browsers/
+.local-browsers/
 /.dev_profile*
 .DS_Store
 .downloaded-browsers.json
@@ -22,4 +22,3 @@ playwright-*.tgz
 /web.js
 /web.js.map
 /types/*
-.local-browsers


### PR DESCRIPTION
Yep I feel bad for these small PRs. But from my point of view it's good to have it in the `.gitignore` e.g. if you test something with Playwright directly from source.