### PR TITLE
feat: support `PLAYWRIGHT_GLOBAL_INSTALL=1` env variable

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3972,6 +3972,10 @@ Playwright looks for certain [environment variables](https://en.wikipedia.org/wi
 If Playwright doesn't find them in the environment, a lowercased variant of these variables will be used from the [npm config](https://docs.npmjs.com/cli/config).
 
 - `PLAYWRIGHT_DOWNLOAD_HOST` - overwrite URL prefix that is used to download browsers. Note: this includes protocol and might even include path prefix. By default, Playwright uses `https://storage.googleapis.com` to download Chromium and `https://playwright.azureedge.net` to download Webkit & Firefox.
+- `PLAYWRIGHT_GLOBAL_INSTALL` - install Playwright browsers in a single global location. Locations are different on different platforms:
+  * MacOS: `$HOME/Library/Caches/playwright-nodejs`
+  * Linux: `$HOME/.cache/playwright-nodejs`
+  * Windows: `$HOME/AppData/Local/playwright-nodejs/Cache`
 
 
 ### Working with selectors

--- a/download-browser.js
+++ b/download-browser.js
@@ -17,13 +17,16 @@ const fs = require('fs');
 const path = require('path');
 const browserFetcher = require('./lib/server/browserFetcher.js');
 const packageJSON = require('./package.json');
-const envPaths = require('env-paths');
-const appPaths = envPaths('playwright');
+
+const FALSY_VALUES = ['0', 'false'];
 
 async function downloadBrowserWithProgressBar(downloadPath, browser, respectGlobalInstall = false) {
   const PLAYWRIGHT_GLOBAL_INSTALL = respectGlobalInstall ? getFromENV('PLAYWRIGHT_GLOBAL_INSTALL') : false;
-  if (!!PLAYWRIGHT_GLOBAL_INSTALL && PLAYWRIGHT_GLOBAL_INSTALL.toLowerCase().trim() !== 'false')
+  if (!!PLAYWRIGHT_GLOBAL_INSTALL && !FALSY_VALUES.includes(PLAYWRIGHT_GLOBAL_INSTALL.toLowerCase().trim())) {
+    const envPaths = require('env-paths');
+    const appPaths = envPaths('playwright');
     downloadPath = path.join(appPaths.cache, `playwright-${packageJSON.version}-${browser}`);
+  }
   let progressBar = null;
   let lastDownloadedBytes = 0;
   const revision = packageJSON.playwright[`${browser}_revision`];

--- a/download-browser.js
+++ b/download-browser.js
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 const fs = require('fs');
+const path = require('path');
 const browserFetcher = require('./lib/server/browserFetcher.js');
 const packageJSON = require('./package.json');
+const envPaths = require('env-paths');
+const appPaths = envPaths('playwright');
 
-async function downloadBrowserWithProgressBar(downloadPath, browser, version = '') {
+async function downloadBrowserWithProgressBar(downloadPath, browser, respectGlobalInstall = false) {
+  const PLAYWRIGHT_GLOBAL_INSTALL = respectGlobalInstall ? getFromENV('PLAYWRIGHT_GLOBAL_INSTALL') : false;
+  if (!!PLAYWRIGHT_GLOBAL_INSTALL && PLAYWRIGHT_GLOBAL_INSTALL.toLowerCase().trim() !== 'false')
+    downloadPath = path.join(appPaths.cache, `playwright-${packageJSON.version}-${browser}`);
   let progressBar = null;
   let lastDownloadedBytes = 0;
   const revision = packageJSON.playwright[`${browser}_revision`];
@@ -29,7 +35,6 @@ async function downloadBrowserWithProgressBar(downloadPath, browser, version = '
         incomplete: ' ',
         width: 20,
         total: totalBytes,
-        host: getFromENV('PLAYWRIGHT_DOWNLOAD_HOST'),
       });
     }
     const delta = downloadedBytes - lastDownloadedBytes;
@@ -41,6 +46,7 @@ async function downloadBrowserWithProgressBar(downloadPath, browser, version = '
     browser,
     revision,
     progress,
+    host: getFromENV('PLAYWRIGHT_DOWNLOAD_HOST'),
   });
   logPolitely(`${browser} downloaded to ${downloadPath}`);
   return executablePath;

--- a/install-from-github.js
+++ b/install-from-github.js
@@ -47,7 +47,7 @@ const DOWNLOAD_PATHS = {
   const downloadedBrowsersJSON = await fs.promises.readFile(DOWNLOADED_BROWSERS_JSON_PATH, 'utf8').then(json => JSON.parse(json)).catch(() => ({}));
   try {
     if (!(await existsAsync(DOWNLOAD_PATHS.chromium))) {
-      const crExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.chromium, 'chromium');
+      const crExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.chromium, 'chromium', false /* respectGlobalInstall */);
       downloadedBrowsersJSON.crExecutablePath = crExecutablePath;
       await protocolGenerator.generateChromiumProtocol(crExecutablePath);
       await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
@@ -57,7 +57,7 @@ const DOWNLOAD_PATHS = {
   }
   try {
     if (!(await existsAsync(DOWNLOAD_PATHS.firefox))) {
-      const ffExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.firefox, 'firefox');
+      const ffExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.firefox, 'firefox', false /* respectGlobalInstall */);
       downloadedBrowsersJSON.ffExecutablePath = ffExecutablePath;
       await protocolGenerator.generateFirefoxProtocol(ffExecutablePath);
       await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
@@ -67,7 +67,7 @@ const DOWNLOAD_PATHS = {
   }
   try {
     if (!(await existsAsync(DOWNLOAD_PATHS.webkit))) {
-      const wkExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.webkit, 'webkit');
+      const wkExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.webkit, 'webkit', false /* respectGlobalInstall */);
       downloadedBrowsersJSON.wkExecutablePath = wkExecutablePath;
       await protocolGenerator.generateWebKitProtocol(path.dirname(wkExecutablePath));
       await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^4.1.0",
+    "env-paths": "^2.2.0",
     "extract-zip": "^1.6.6",
     "https-proxy-agent": "^3.0.0",
     "jpeg-js": "^0.3.6",

--- a/packages/playwright-chromium/install.js
+++ b/packages/playwright-chromium/install.js
@@ -17,6 +17,6 @@ const path = require('path');
 const fs = require('fs');
 const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
 (async function() {
-  const crExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'chromium'), 'chromium');
+  const crExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'chromium'), 'chromium', true /* respectGlobalInstall */);
   await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({crExecutablePath}));
 })();

--- a/packages/playwright-firefox/install.js
+++ b/packages/playwright-firefox/install.js
@@ -18,6 +18,6 @@ const fs = require('fs');
 const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
 
 (async function() {
-  const ffExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'firefox'), 'firefox');
+  const ffExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'firefox'), 'firefox', true /* respectGlobalInstall */);
   await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({ffExecutablePath, }));
 })();

--- a/packages/playwright-webkit/install.js
+++ b/packages/playwright-webkit/install.js
@@ -18,6 +18,6 @@ const fs = require('fs');
 const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
 
 (async function() {
-  const wkExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'webkit'), 'webkit');
+  const wkExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'webkit'), 'webkit', true /* respectGlobalInstall */);
   await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({wkExecutablePath, }));
 })();

--- a/packages/playwright/install.js
+++ b/packages/playwright/install.js
@@ -18,8 +18,8 @@ const fs = require('fs');
 const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
 
 (async function() {
-  const crExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'chromium'), 'chromium');
-  const ffExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'firefox'), 'firefox');
-  const wkExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'webkit'), 'webkit');
+  const crExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'chromium'), 'chromium', true /* respectGlobalInstall */);
+  const ffExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'firefox'), 'firefox', true /* respectGlobalInstall */);
+  const wkExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'webkit'), 'webkit', true /* respectGlobalInstall */);
   await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({crExecutablePath, ffExecutablePath, wkExecutablePath, }));
 })();


### PR DESCRIPTION
You can install playwright with

```
PLAYWRIGHT_GLOBAL_INSTALL=1 npm i playwright
```

to make it use a single shared location for all browser
downloads.

Fixes #1102