### PR TITLE
test(firefox): enable passing "userDataDir option should restore cookies"

### DIFF
--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -317,7 +317,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       await removeUserDataDir(userDataDir2);
     });
     // See https://github.com/microsoft/playwright/issues/717
-    it.slow().fail(FFOX || (WIN && CHROMIUM))('userDataDir option should restore cookies', async({server}) => {
+    it.slow().fail(WIN && CHROMIUM)('userDataDir option should restore cookies', async({server}) => {
       const userDataDir = await makeUserDataDir();
       const browserContext = await browserType.launchPersistentContext(userDataDir, defaultBrowserOptions);
       const page = await browserContext.newPage();


### PR DESCRIPTION
Ran this 100 times on Mac and Linux with no issues.