### PR TITLE
api(click): rename offset to position

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -311,7 +311,7 @@ Emitted when Browser context gets closed. This might happen because of one of th
 - The [`browser.close`](#browserclose) method was called.
 
 #### event: 'page'
-- <[Page]> 
+- <[Page]>
 
 The event is emitted when a new Page is created in the BrowserContext. The page may still be loading. The event will also fire for popup pages. See also [`Page.on('popup')`](#event-popup) to receive events about popups relevant to a specific page.
 
@@ -940,7 +940,7 @@ Shortcut for [page.mainFrame().check(selector[, options])](#framecheckselector-o
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `clickCount` <[number]> defaults to 1. See [UIEvent.detail].
   - `delay` <[number]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
-  - `offset` <[Object]> A point to click relative to the top-left corner of element padding box. If not specified, clicks to some visible point of the element.
+  - `position` <[Object]> A point to click relative to the top-left corner of element padding box. If not specified, clicks to some visible point of the element.
     - x <[number]>
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
@@ -998,7 +998,7 @@ Browser-specific Coverage implementation, only available for Chromium atm. See [
 - `options` <[Object]>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `delay` <[number]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
-  - `offset` <[Object]> A point to double click relative to the top-left corner of element padding box. If not specified, double clicks to some visible point of the element.
+  - `position` <[Object]> A point to double click relative to the top-left corner of element padding box. If not specified, double clicks to some visible point of the element.
     - x <[number]>
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the double click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
@@ -1286,7 +1286,7 @@ Shortcut for [page.mainFrame().goto(url[, options])](#framegotourl-options)
 #### page.hover(selector[, options])
 - `selector` <[string]> A selector to search for element to hover. If there are multiple elements satisfying the selector, the first will be hovered.
 - `options` <[Object]>
-  - `offset` <[Object]> A point to hover relative to the top-left corner of element padding box. If not specified, hovers over some visible point of the element.
+  - `position` <[Object]> A point to hover relative to the top-left corner of element padding box. If not specified, hovers over some visible point of the element.
     - x <[number]>
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the hover, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
@@ -1978,7 +1978,7 @@ If there's no element matching `selector`, the method throws an error.
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `clickCount` <[number]> defaults to 1. See [UIEvent.detail].
   - `delay` <[number]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
-  - `offset` <[Object]> A point to click relative to the top-left corner of element padding box. If not specified, clicks to some visible point of the element.
+  - `position` <[Object]> A point to click relative to the top-left corner of element padding box. If not specified, clicks to some visible point of the element.
     - x <[number]>
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
@@ -2009,7 +2009,7 @@ Gets the full HTML contents of the frame, including the doctype.
 - `options` <[Object]>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `delay` <[number]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
-  - `offset` <[Object]> A point to double click relative to the top-left corner of element padding box. If not specified, double clicks to some visible point of the element.
+  - `position` <[Object]> A point to double click relative to the top-left corner of element padding box. If not specified, double clicks to some visible point of the element.
     - x <[number]>
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the double click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
@@ -2158,7 +2158,7 @@ console.log(frame === contentFrame);  // -> true
 #### frame.hover(selector[, options])
 - `selector` <[string]> A selector to search for element to hover. If there are multiple elements satisfying the selector, the first will be hovered.
 - `options` <[Object]>
-  - `offset` <[Object]> A point to hover relative to the top-left corner of element padding box. If not specified, hovers over some visible point of the element.
+  - `position` <[Object]> A point to hover relative to the top-left corner of element padding box. If not specified, hovers over some visible point of the element.
     - x <[number]>
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the hover, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
@@ -2575,7 +2575,7 @@ If element is not already checked, it scrolls it into view if needed, and then u
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `clickCount` <[number]> defaults to 1. See [UIEvent.detail].
   - `delay` <[number]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
-  - `offset` <[Object]> A point to click relative to the top-left corner of element padding box. If not specified, clicks to some visible point of the element.
+  - `position` <[Object]> A point to click relative to the top-left corner of element padding box. If not specified, clicks to some visible point of the element.
     - x <[number]>
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
@@ -2603,7 +2603,7 @@ If the element is detached from DOM, the method throws an error.
 - `options` <[Object]>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `delay` <[number]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
-  - `offset` <[Object]> A point to double click relative to the top-left corner of element padding box. If not specified, double clicks to some visible point of the element.
+  - `position` <[Object]> A point to double click relative to the top-left corner of element padding box. If not specified, double clicks to some visible point of the element.
     - x <[number]>
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the double click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
@@ -2650,7 +2650,7 @@ Calls [focus](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
 
 #### elementHandle.hover([options])
 - `options` <[Object]>
-  - `offset` <[Object]> A point to hover relative to the top-left corner of element padding box. If not specified, hovers over some visible point of the element.
+  - `position` <[Object]> A point to hover relative to the top-left corner of element padding box. If not specified, hovers over some visible point of the element.
     - x <[number]>
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the hover, and then restores current modifiers back. If not specified, currently pressed modifiers are used.

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -27,7 +27,7 @@ import { Selectors } from './selectors';
 
 export type PointerActionOptions = {
   modifiers?: input.Modifier[];
-  offset?: types.Point;
+  position?: types.Point;
 };
 
 export type ClickOptions = PointerActionOptions & input.MouseClickOptions;
@@ -225,9 +225,9 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const { force = false } = (options || {});
     if (!force)
       await this._waitForDisplayedAtStablePosition(options);
-    const offset = options ? options.offset : undefined;
-    await this._scrollRectIntoViewIfNeeded(offset ? { x: offset.x, y: offset.y, width: 0, height: 0 } : undefined);
-    const point = offset ? await this._offsetPoint(offset) : await this._clickablePoint();
+    const position = options ? options.position : undefined;
+    await this._scrollRectIntoViewIfNeeded(position ? { x: position.x, y: position.y, width: 0, height: 0 } : undefined);
+    const point = position ? await this._offsetPoint(position) : await this._clickablePoint();
     if (!force)
       await this._waitForHitTargetAt(point, options);
 

--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -322,7 +322,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
     it('should click the button with px border with offset', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/button.html');
       await page.$eval('button', button => button.style.borderWidth = '8px');
-      await page.click('button', { offset: { x: 20, y: 10 } });
+      await page.click('button', { position: { x: 20, y: 10 } });
       expect(await page.evaluate(() => result)).toBe('Clicked');
       // Safari reports border-relative offsetX/offsetY.
       expect(await page.evaluate(() => offsetX)).toBe(WEBKIT ? 20 + 8 : 20);
@@ -332,7 +332,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       await page.goto(server.PREFIX + '/input/button.html');
       await page.$eval('button', button => button.style.borderWidth = '2em');
       await page.$eval('button', button => button.style.fontSize = '12px');
-      await page.click('button', { offset: { x: 20, y: 10 } });
+      await page.click('button', { position: { x: 20, y: 10 } });
       expect(await page.evaluate(() => result)).toBe('Clicked');
       // Safari reports border-relative offsetX/offsetY.
       expect(await page.evaluate(() => offsetX)).toBe(WEBKIT ? 12 * 2 + 20 : 20);
@@ -342,7 +342,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
       await page.goto(server.PREFIX + '/input/button.html');
       await page.$eval('button', button => button.style.borderWidth = '8px');
       await page.$eval('button', button => button.style.height = button.style.width = '2000px');
-      await page.click('button', { offset: { x: 1900, y: 1910 } });
+      await page.click('button', { position: { x: 1900, y: 1910 } });
       expect(await page.evaluate(() => window.result)).toBe('Clicked');
       // Safari reports border-relative offsetX/offsetY.
       expect(await page.evaluate(() => offsetX)).toBe(WEBKIT ? 1900 + 8 : 1900);
@@ -361,7 +361,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
         button.style.width = '2000px';
         button.style.borderWidth = '8px';
       });
-      await page.click('button', { offset: { x: 1900, y: 1910 } });
+      await page.click('button', { position: { x: 1900, y: 1910 } });
       expect(await page.evaluate(() => window.result)).toBe('Clicked');
       // Safari reports border-relative offsetX/offsetY.
       expect(await page.evaluate(() => offsetX)).toBe(WEBKIT ? 1900 + 8 : 1900);
@@ -375,7 +375,7 @@ module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMI
         button.style.borderWidth = '8px';
         document.body.style.margin = '0';
       });
-      await page.click('button', { offset: { x: 20, y: 10 } });
+      await page.click('button', { position: { x: 20, y: 10 } });
       expect(await page.evaluate(() => result)).toBe('Clicked');
       let expected = { x: 28, y: 18 };  // 20;10 + 8px of border in each direction
       if (WEBKIT) {


### PR DESCRIPTION
To allow for features like position: 'center' or similar.