### PR TITLE
fix(testrunner): attribute unhandle promise reject to a single worker

### DIFF
--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -411,7 +411,7 @@ class TestPass {
     if (error) {
       if (error.stack)
         await this._runner._sourceMapSupport.rewriteStackTraceWithSourceMaps(error);
-      this._result.addError(message, error);
+      this._result.addError(message, error, this._workers.length === 1 ? this._workers[0] : null);
     }
   }
 


### PR DESCRIPTION
When there is a single worker, we are almost sure the error originated in that worker. Attributing it helps with context by showing last run tests.