### PR TITLE
fix(doclint): support lists in comments

### DIFF
--- a/utils/doclint/check_public_api/test/md-builder-comments/doc.md
+++ b/utils/doclint/check_public_api/test/md-builder-comments/doc.md
@@ -1,0 +1,15 @@
+### class: Foo
+
+#### foo.method(arg1, arg2)
+- `arg1` <[string]> A single line argument comment
+- `arg2` <[string]> A multiline argument comment:
+  - it could be this
+  - or it could be that
+- returns: <[Promise]<[ElementHandle]>>
+
+The method does something.
+
+[string]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type "String"
+[Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
+[ElementHandle]: # "ElementHandle"
+[ElementHandle]: # "Frame"

--- a/utils/doclint/check_public_api/test/md-builder-comments/result.txt
+++ b/utils/doclint/check_public_api/test/md-builder-comments/result.txt
@@ -1,0 +1,35 @@
+{
+  "classes": [
+    {
+      "name": "Foo",
+      "members": [
+        {
+          "name": "method",
+          "type": {
+            "name": "Promise<ElementHandle>"
+          },
+          "kind": "method",
+          "comment": "The method does something.",
+          "args": [
+            {
+              "name": "arg1",
+              "type": {
+                "name": "string"
+              },
+              "kind": "property",
+              "comment": "A single line argument comment"
+            },
+            {
+              "name": "arg2",
+              "type": {
+                "name": "string"
+              },
+              "kind": "property",
+              "comment": "A multiline argument comment:\n - it could be this\n - or it could be that"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/utils/doclint/check_public_api/test/md-builder-common/result.txt
+++ b/utils/doclint/check_public_api/test/md-builder-common/result.txt
@@ -2,13 +2,15 @@
   "classes": [
     {
       "name": "Foo",
+      "comment": "This is a class.",
       "members": [
         {
           "name": "frame",
           "type": {
             "name": "[Frame]"
           },
-          "kind": "event"
+          "kind": "event",
+          "comment": "This event is dispatched."
         },
         {
           "name": "$",
@@ -16,13 +18,15 @@
             "name": "Promise<ElementHandle>"
           },
           "kind": "method",
+          "comment": "The method runs document.querySelector.",
           "args": [
             {
               "name": "selector",
               "type": {
                 "name": "string"
               },
-              "kind": "property"
+              "kind": "property",
+              "comment": "A selector to query page for"
             }
           ]
         },
@@ -31,7 +35,8 @@
           "type": {
             "name": "string"
           },
-          "kind": "property"
+          "kind": "property",
+          "comment": "Contains the URL of the request."
         }
       ]
     }

--- a/utils/doclint/check_public_api/test/test.js
+++ b/utils/doclint/check_public_api/test/test.js
@@ -55,6 +55,7 @@ describe('checkPublicAPI', function() {
   it('js-builder-common', testJSBuilder);
   it('js-builder-inheritance', testJSBuilder);
   it('md-builder-common', testMDBuilder);
+  it('md-builder-comments', testMDBuilder);
 });
 
 runner.run();
@@ -101,6 +102,7 @@ function serialize(doc) {
   const result = {
     classes: doc.classesArray.map(cls => ({
       name: cls.name,
+      comment: cls.comment || undefined,
       members: cls.membersArray.map(serializeMember)
     }))
   };
@@ -114,6 +116,7 @@ function serializeMember(member) {
     name: member.name,
     type: serializeType(member.type),
     kind: member.kind,
+    comment: member.comment || undefined,
     args: member.argsArray.length ? member.argsArray.map(serializeMember) : undefined
   }
 }


### PR DESCRIPTION
Adds logging comments to the doclint tests, and adds a new one with a bulleted list in a comment. Lists can only be used in comments where extra properties would be unexpected.