### PR TITLE
feat: re-make global browser installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .local-browsers/
 /.dev_profile*
 .DS_Store
-.downloaded-browsers.json
 *.swp
 *.pyc
 .vscode

--- a/docs/api.md
+++ b/docs/api.md
@@ -3983,7 +3983,10 @@ If Playwright doesn't find them in the environment, a lowercased variant of thes
 - `PLAYWRIGHT_BROWSERS_PATH` - specify a shared folder that playwright will use to download browsers and to look for browsers when launching browser instances.
 
 ```sh
+# Install browsers to the shared location.
 $ PLAYWRIGHT_BROWSERS_PATH=$HOME/playwright-browsers npm install playwright
+# Use shared location to find browsers.
+$ PLAYWRIGHT_BROWSERS_PATH=$HOME/playwright-browsers node playwright-script.js
 ```
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -3980,10 +3980,11 @@ Playwright looks for certain [environment variables](https://en.wikipedia.org/wi
 If Playwright doesn't find them in the environment, a lowercased variant of these variables will be used from the [npm config](https://docs.npmjs.com/cli/config).
 
 - `PLAYWRIGHT_DOWNLOAD_HOST` - overwrite URL prefix that is used to download browsers. Note: this includes protocol and might even include path prefix. By default, Playwright uses `https://storage.googleapis.com` to download Chromium and `https://playwright.azureedge.net` to download Webkit & Firefox.
-- `PLAYWRIGHT_GLOBAL_INSTALL` - install Playwright browsers in a single global location. Locations are different on different platforms:
-  * MacOS: `$HOME/Library/Caches/playwright-nodejs`
-  * Linux: `$HOME/.cache/playwright-nodejs`
-  * Windows: `$HOME/AppData/Local/playwright-nodejs/Cache`
+- `PLAYWRIGHT_BROWSERS_PATH` - specify a shared folder that playwright will use to download browsers and to look for browsers when launching browser instances.
+
+```sh
+$ PLAYWRIGHT_BROWSERS_PATH=$HOME/playwright-browsers npm install playwright
+```
 
 
 ### Working with selectors

--- a/index.js
+++ b/index.js
@@ -13,18 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const fs = require('fs');
+const path = require('path');
 const {Playwright} = require('./lib/server/playwright.js');
+const {localDownloadOptions} = require('./download-browser.js');
 
 const playwright = new Playwright({
   browsers: ['webkit', 'chromium', 'firefox'],
 });
 
-try {
-  const downloadedBrowsers = require('./.downloaded-browsers.json');
-  playwright.chromium._executablePath = downloadedBrowsers.crExecutablePath;
-  playwright.firefox._executablePath = downloadedBrowsers.ffExecutablePath;
-  playwright.webkit._executablePath = downloadedBrowsers.wkExecutablePath;
-} catch (e) {
+if (fs.existsSync(path.join(__dirname, '.local-browsers'))) {
+  playwright.chromium._executablePath = localDownloadOptions('chromium').executablePath;
+  playwright.firefox._executablePath = localDownloadOptions('firefox').executablePath;
+  playwright.webkit._executablePath = localDownloadOptions('webkit').executablePath;
 }
 
 module.exports = playwright;

--- a/install-from-github.js
+++ b/install-from-github.js
@@ -41,15 +41,15 @@ const protocolGenerator = require('./utils/protocol-types-generator');
   const webkitOptions = localDownloadOptions('webkit');
   if (!(await existsAsync(chromiumOptions.downloadPath))) {
     await downloadBrowserWithProgressBar(chromiumOptions);
-    await protocolGenerator.generateChromiumProtocol(chromiumOptions.executablePath);
+    await protocolGenerator.generateChromiumProtocol(chromiumOptions.executablePath).catch(console.warn);
   }
   if (!(await existsAsync(firefoxOptions.downloadPath))) {
     await downloadBrowserWithProgressBar(firefoxOptions);
-    await protocolGenerator.generateFirefoxProtocol(firefoxOptions.executablePath);
+    await protocolGenerator.generateFirefoxProtocol(firefoxOptions.executablePath).catch(console.warn);
   }
   if (!(await existsAsync(webkitOptions.downloadPath))) {
     await downloadBrowserWithProgressBar(webkitOptions);
-    await protocolGenerator.generateWebKitProtocol(webkitOptions.downloadPath);
+    await protocolGenerator.generateWebKitProtocol(webkitOptions.downloadPath).catch(console.warn);
   }
 
   // Cleanup stale revisions.

--- a/install-from-github.js
+++ b/install-from-github.js
@@ -32,55 +32,31 @@ const fs = require('fs');
 const util = require('util');
 const rmAsync = util.promisify(require('rimraf'));
 const existsAsync = path => fs.promises.access(path).then(() => true, e => false);
-const {downloadBrowserWithProgressBar} = require('./download-browser');
+const {downloadBrowserWithProgressBar, localDownloadOptions} = require('./download-browser');
 const protocolGenerator = require('./utils/protocol-types-generator');
-const packageJSON = require('./package.json');
-
-const DOWNLOADED_BROWSERS_JSON_PATH = path.join(__dirname, '.downloaded-browsers.json');
-const DOWNLOAD_PATHS = {
-  chromium: path.join(__dirname, '.local-browsers', `chromium-${packageJSON.playwright.chromium_revision}`),
-  firefox: path.join(__dirname, '.local-browsers', `firefox-${packageJSON.playwright.firefox_revision}`),
-  webkit: path.join(__dirname, '.local-browsers', `webkit-${packageJSON.playwright.webkit_revision}`),
-};
 
 (async function() {
-  const downloadedBrowsersJSON = await fs.promises.readFile(DOWNLOADED_BROWSERS_JSON_PATH, 'utf8').then(json => JSON.parse(json)).catch(() => ({}));
-  try {
-    if (!(await existsAsync(DOWNLOAD_PATHS.chromium))) {
-      const crExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.chromium, 'chromium', false /* respectGlobalInstall */);
-      downloadedBrowsersJSON.crExecutablePath = crExecutablePath;
-      await protocolGenerator.generateChromiumProtocol(crExecutablePath);
-      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
-    }
-  } catch (e) {
-    console.warn(e.message);
+  const chromiumOptions = localDownloadOptions('chromium');
+  const firefoxOptions = localDownloadOptions('firefox');
+  const webkitOptions = localDownloadOptions('webkit');
+  if (!(await existsAsync(chromiumOptions.downloadPath))) {
+    await downloadBrowserWithProgressBar(chromiumOptions);
+    await protocolGenerator.generateChromiumProtocol(chromiumOptions.executablePath);
   }
-  try {
-    if (!(await existsAsync(DOWNLOAD_PATHS.firefox))) {
-      const ffExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.firefox, 'firefox', false /* respectGlobalInstall */);
-      downloadedBrowsersJSON.ffExecutablePath = ffExecutablePath;
-      await protocolGenerator.generateFirefoxProtocol(ffExecutablePath);
-      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
-    }
-  } catch (e) {
-    console.warn(e.message);
+  if (!(await existsAsync(firefoxOptions.downloadPath))) {
+    await downloadBrowserWithProgressBar(firefoxOptions);
+    await protocolGenerator.generateFirefoxProtocol(firefoxOptions.executablePath);
   }
-  try {
-    if (!(await existsAsync(DOWNLOAD_PATHS.webkit))) {
-      const wkExecutablePath = await downloadBrowserWithProgressBar(DOWNLOAD_PATHS.webkit, 'webkit', false /* respectGlobalInstall */);
-      downloadedBrowsersJSON.wkExecutablePath = wkExecutablePath;
-      await protocolGenerator.generateWebKitProtocol(path.dirname(wkExecutablePath));
-      await fs.promises.writeFile(DOWNLOADED_BROWSERS_JSON_PATH, JSON.stringify(downloadedBrowsersJSON));
-    }
-  } catch (e) {
-    console.warn(e.message);
+  if (!(await existsAsync(webkitOptions.downloadPath))) {
+    await downloadBrowserWithProgressBar(webkitOptions);
+    await protocolGenerator.generateWebKitProtocol(webkitOptions.downloadPath);
   }
 
   // Cleanup stale revisions.
   const directories = new Set(await readdirAsync(path.join(__dirname, '.local-browsers')));
-  directories.delete(DOWNLOAD_PATHS.chromium);
-  directories.delete(DOWNLOAD_PATHS.firefox);
-  directories.delete(DOWNLOAD_PATHS.webkit);
+  directories.delete(chromiumOptions.downloadPath);
+  directories.delete(firefoxOptions.downloadPath);
+  directories.delete(webkitOptions.downloadPath);
   // cleanup old browser directories.
   directories.add(path.join(__dirname, '.local-chromium'));
   directories.add(path.join(__dirname, '.local-firefox'));

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^4.1.0",
-    "env-paths": "^2.2.0",
     "extract-zip": "^1.6.6",
     "https-proxy-agent": "^3.0.0",
     "jpeg-js": "^0.3.6",

--- a/packages/playwright-chromium/index.js
+++ b/packages/playwright-chromium/index.js
@@ -15,15 +15,13 @@
  */
 const path = require('path');
 const {Playwright} = require('playwright-core/lib/server/playwright.js');
+const {downloadOptionsFromENV} = require('playwright-core/download-browser.js');
 
 const playwright = new Playwright({
   browsers: ['chromium'],
 });
+
+playwright.chromium._executablePath = downloadOptionsFromENV(__dirname, 'chromium').executablePath;
+
 module.exports = playwright;
 
-try {
-  const downloadedBrowsers = require('./.downloaded-browsers.json');
-  playwright.chromium._executablePath = downloadedBrowsers.crExecutablePath;
-} catch (e) {
-  throw new Error('playwright-chromium has not downloaded Chromium.');
-}

--- a/packages/playwright-chromium/install.js
+++ b/packages/playwright-chromium/install.js
@@ -15,8 +15,8 @@
  */
 const path = require('path');
 const fs = require('fs');
-const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
+const {downloadBrowserWithProgressBar, downloadOptionsFromEnv} = require('playwright-core/download-browser');
+
 (async function() {
-  const crExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'chromium'), 'chromium', true /* respectGlobalInstall */);
-  await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({crExecutablePath}));
+  await downloadBrowserWithProgressBar(downloadOptionsFromEnv(__dirname, 'chromium'));
 })();

--- a/packages/playwright-firefox/index.js
+++ b/packages/playwright-firefox/index.js
@@ -15,16 +15,13 @@
  */
 const path = require('path');
 const {Playwright} = require('playwright-core/lib/server/playwright.js');
+const {downloadOptionsFromENV} = require('playwright-core/download-browser.js');
 
 const playwright = new Playwright({
   browsers: ['firefox'],
 });
-module.exports = playwright;
 
-try {
-  const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
-  playwright.firefox._executablePath = downloadedBrowsers.ffExecutablePath;
-} catch (e) {
-  throw new Error('playwright-firefox has not downloaded Firefox.');
-}
+playwright.firefox._executablePath = downloadOptionsFromENV(__dirname, 'firefox').executablePath;
+
+module.exports = playwright;
 

--- a/packages/playwright-firefox/install.js
+++ b/packages/playwright-firefox/install.js
@@ -15,9 +15,8 @@
  */
 const path = require('path');
 const fs = require('fs');
-const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
+const {downloadBrowserWithProgressBar, downloadOptionsFromEnv} = require('playwright-core/download-browser');
 
 (async function() {
-  const ffExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'firefox'), 'firefox', true /* respectGlobalInstall */);
-  await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({ffExecutablePath, }));
+  await downloadBrowserWithProgressBar(downloadOptionsFromEnv(__dirname, 'firefox'));
 })();

--- a/packages/playwright-webkit/index.js
+++ b/packages/playwright-webkit/index.js
@@ -15,16 +15,13 @@
  */
 const path = require('path');
 const {Playwright} = require('playwright-core/lib/server/playwright.js');
+const {downloadOptionsFromENV} = require('playwright-core/download-browser.js');
 
 const playwright = new Playwright({
   browsers: ['webkit'],
 });
-module.exports = playwright;
 
-try {
-  const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
-  playwright.webkit._executablePath = downloadedBrowsers.wkExecutablePath;
-} catch (e) {
-  throw new Error('playwright-webkit has not downloaded WebKit.');
-}
+playwright.webkit._executablePath = downloadOptionsFromENV(__dirname, 'webkit').executablePath;
+
+module.exports = playwright;
 

--- a/packages/playwright-webkit/install.js
+++ b/packages/playwright-webkit/install.js
@@ -15,9 +15,8 @@
  */
 const path = require('path');
 const fs = require('fs');
-const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
+const {downloadBrowserWithProgressBar, downloadOptionsFromEnv} = require('playwright-core/download-browser');
 
 (async function() {
-  const wkExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'webkit'), 'webkit', true /* respectGlobalInstall */);
-  await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({wkExecutablePath, }));
+  await downloadBrowserWithProgressBar(downloadOptionsFromEnv(__dirname, 'webkit'));
 })();

--- a/packages/playwright/index.js
+++ b/packages/playwright/index.js
@@ -15,18 +15,15 @@
  */
 const path = require('path');
 const {Playwright} = require('playwright-core/lib/server/playwright.js');
+const {downloadOptionsFromENV} = require('playwright-core/download-browser.js');
 
 const playwright = new Playwright({
   browsers: ['webkit', 'chromium', 'firefox'],
 });
-module.exports = playwright;
 
-try {
-  const downloadedBrowsers = require(path.join(__dirname, '.downloaded-browsers.json'));
-  playwright.chromium._executablePath = downloadedBrowsers.crExecutablePath;
-  playwright.firefox._executablePath = downloadedBrowsers.ffExecutablePath;
-  playwright.webkit._executablePath = downloadedBrowsers.wkExecutablePath;
-} catch (e) {
-  throw new Error('ERROR: Playwright did not download browsers');
-}
+playwright.chromium._executablePath = downloadOptionsFromENV(__dirname, 'chromium').executablePath;
+playwright.webkit._executablePath = downloadOptionsFromENV(__dirname, 'webkit').executablePath;
+playwright.firefox._executablePath = downloadOptionsFromENV(__dirname, 'firefox').executablePath;
+
+module.exports = playwright;
 

--- a/packages/playwright/install.js
+++ b/packages/playwright/install.js
@@ -15,11 +15,10 @@
  */
 const path = require('path');
 const fs = require('fs');
-const {downloadBrowserWithProgressBar} = require('playwright-core/download-browser');
+const {downloadBrowserWithProgressBar, downloadOptionsFromEnv} = require('playwright-core/download-browser');
 
 (async function() {
-  const crExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'chromium'), 'chromium', true /* respectGlobalInstall */);
-  const ffExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'firefox'), 'firefox', true /* respectGlobalInstall */);
-  const wkExecutablePath = await downloadBrowserWithProgressBar(path.join(__dirname, '.local-browsers', 'webkit'), 'webkit', true /* respectGlobalInstall */);
-  await fs.promises.writeFile(path.join(__dirname, '.downloaded-browsers.json'), JSON.stringify({crExecutablePath, ffExecutablePath, wkExecutablePath, }));
+  await downloadBrowserWithProgressBar(downloadOptionsFromEnv(__dirname, 'chromium'));
+  await downloadBrowserWithProgressBar(downloadOptionsFromEnv(__dirname, 'firefox'));
+  await downloadBrowserWithProgressBar(downloadOptionsFromEnv(__dirname, 'webkit'));
 })();

--- a/src/server/browserFetcher.ts
+++ b/src/server/browserFetcher.ts
@@ -125,7 +125,7 @@ function revisionURL(options: DownloadOptions): string {
   return util.format(urlTemplate, host, revision);
 }
 
-export async function downloadBrowser(options: DownloadOptions): Promise<string> {
+export async function downloadBrowser(options: DownloadOptions): Promise<void> {
   const {
     browser,
     revision,
@@ -146,9 +146,16 @@ export async function downloadBrowser(options: DownloadOptions): Promise<string>
     if (await existsAsync(zipPath))
       await unlinkAsync(zipPath);
   }
-  const executablePath = path.join(downloadPath, ...RELATIVE_EXECUTABLE_PATHS[browser][platform as BrowserPlatform]);
-  await chmodAsync(executablePath, 0o755);
-  return executablePath;
+  await chmodAsync(executablePath(options), 0o755);
+}
+
+export function executablePath(options: DownloadOptions): string {
+  const {
+    browser,
+    downloadPath,
+    platform = CURRENT_HOST_PLATFORM,
+  } = options;
+  return path.join(downloadPath, ...RELATIVE_EXECUTABLE_PATHS[browser][platform as BrowserPlatform]);
 }
 
 export async function canDownload(options: DownloadOptions): Promise<boolean> {


### PR DESCRIPTION
This patch removes the `PLAYWRIGHT_GLOBAL_INSTALL=1` variable
and instead introduces a new var - `PLAYWRIGHT_BROWSERS_PATH`.

You can specify `PLAYWRIGHT_BROWSERS_PATH` to affect where playwright
installs browsers and where it looks for browsers.

Fixes #1102 