### PR TITLE
devops: support browser aliases in `export.sh` and `prepare_checkout.sh`

### DIFF
--- a/browser_patches/export.sh
+++ b/browser_patches/export.sh
@@ -37,12 +37,12 @@ fi
 FRIENDLY_CHECKOUT_PATH="";
 CHECKOUT_PATH=""
 EXPORT_PATH=""
-if [[ ("$1" == "firefox") || ("$1" == "firefox/") ]]; then
+if [[ ("$1" == "firefox") || ("$1" == "firefox/") || ("$1" == "ff") ]]; then
   FRIENDLY_CHECKOUT_PATH="//browser_patches/firefox/checkout";
   CHECKOUT_PATH="$PWD/firefox/checkout"
   EXPORT_PATH="$PWD/firefox/"
   source "./firefox/UPSTREAM_CONFIG.sh"
-elif [[ ("$1" == "webkit") || ("$1" == "webkit/") ]]; then
+elif [[ ("$1" == "webkit") || ("$1" == "webkit/") || ("$1" == "wk") ]]; then
   FRIENDLY_CHECKOUT_PATH="//browser_patches/webkit/checkout";
   CHECKOUT_PATH="$PWD/webkit/checkout"
   EXPORT_PATH="$PWD/webkit/"

--- a/browser_patches/prepare_checkout.sh
+++ b/browser_patches/prepare_checkout.sh
@@ -31,13 +31,13 @@ FRIENDLY_CHECKOUT_PATH="";
 CHECKOUT_PATH=""
 PATCHES_PATH=""
 BUILD_NUMBER=""
-if [[ ("$1" == "firefox") || ("$1" == "firefox/") ]]; then
+if [[ ("$1" == "firefox") || ("$1" == "firefox/") || ("$1" == "ff") ]]; then
   FRIENDLY_CHECKOUT_PATH="//browser_patches/firefox/checkout";
   CHECKOUT_PATH="$PWD/firefox/checkout"
   PATCHES_PATH="$PWD/firefox/patches"
   BUILD_NUMBER=$(cat "$PWD/firefox/BUILD_NUMBER")
   source "./firefox/UPSTREAM_CONFIG.sh"
-elif [[ ("$1" == "webkit") || ("$1" == "webkit/") ]]; then
+elif [[ ("$1" == "webkit") || ("$1" == "webkit/") || ("$1" == "wk") ]]; then
   FRIENDLY_CHECKOUT_PATH="//browser_patches/webkit/checkout";
   CHECKOUT_PATH="$PWD/webkit/checkout"
   PATCHES_PATH="$PWD/webkit/patches"


### PR DESCRIPTION
This lets you use `ff` for `firefox` and `wk` for `webkit`

```sh
$ ./browser_patches/prepare_checkout.sh ff
```