### PR TITLE
chore: Replace extract-zip with yauzl-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/yauzl": "^2.9.1",
     "debug": "^4.1.0",
     "https-proxy-agent": "^3.0.0",
     "jpeg-js": "^0.3.6",
@@ -63,6 +62,7 @@
     "@types/proxy-from-env": "^1.0.0",
     "@types/rimraf": "^2.0.2",
     "@types/ws": "^6.0.1",
+    "@types/yauzl": "^2.9.1",
     "@typescript-eslint/eslint-plugin": "^2.6.1",
     "@typescript-eslint/parser": "^2.6.1",
     "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@types/yauzl": "^2.9.1",
     "debug": "^4.1.0",
     "https-proxy-agent": "^3.0.0",
     "jpeg-js": "^0.3.6",
@@ -52,7 +53,7 @@
     "proxy-from-env": "^1.1.0",
     "rimraf": "^3.0.2",
     "ws": "^6.1.0",
-    "yauzl-promise": "^2.1.3"
+    "yauzl": "^2.10.0"
   },
   "devDependencies": {
     "@types/debug": "0.0.31",
@@ -62,7 +63,6 @@
     "@types/proxy-from-env": "^1.0.0",
     "@types/rimraf": "^2.0.2",
     "@types/ws": "^6.0.1",
-    "@types/yauzl-promise": "^2.1.0",
     "@typescript-eslint/eslint-plugin": "^2.6.1",
     "@typescript-eslint/parser": "^2.6.1",
     "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^4.1.0",
-    "extract-zip": "^1.6.6",
     "https-proxy-agent": "^3.0.0",
     "jpeg-js": "^0.3.6",
     "mime": "^2.4.4",
@@ -52,17 +51,18 @@
     "progress": "^2.0.3",
     "proxy-from-env": "^1.1.0",
     "rimraf": "^3.0.2",
-    "ws": "^6.1.0"
+    "ws": "^6.1.0",
+    "yauzl-promise": "^2.1.3"
   },
   "devDependencies": {
     "@types/debug": "0.0.31",
-    "@types/extract-zip": "^1.6.2",
     "@types/mime": "^2.0.1",
     "@types/node": "^10.17.17",
     "@types/pngjs": "^3.4.0",
     "@types/proxy-from-env": "^1.0.0",
     "@types/rimraf": "^2.0.2",
     "@types/ws": "^6.0.1",
+    "@types/yauzl-promise": "^2.1.0",
     "@typescript-eslint/eslint-plugin": "^2.6.1",
     "@typescript-eslint/parser": "^2.6.1",
     "colors": "^1.4.0",

--- a/src/server/browserFetcher.ts
+++ b/src/server/browserFetcher.ts
@@ -227,7 +227,7 @@ function extractZip(zipPath: string, folderPath: string) {
         resolve();
       });
 
-      zipfile.on('entry', async (entry) => {
+      zipfile.on('entry', async entry => {
         if (entry.fileName.endsWith('/')) {
           await fsPromises.mkdir(path.resolve(folderPath, entry.fileName), { recursive: true });
           zipfile.readEntry();
@@ -249,7 +249,7 @@ function extractZip(zipPath: string, folderPath: string) {
         }
       });
       zipfile.readEntry();
-    })
+    });
   });
 }
 

--- a/src/server/browserFetcher.ts
+++ b/src/server/browserFetcher.ts
@@ -29,7 +29,7 @@ import { assert } from '../helper';
 
 const unlinkAsync = util.promisify(fs.unlink.bind(fs));
 const chmodAsync = util.promisify(fs.chmod.bind(fs));
-const mkdirAsync = fs.promises.mkdir;
+const mkdirAsync = util.promisify(fs.mkdir.bind(fs));
 
 const existsAsync = (path: string): Promise<boolean> => new Promise(resolve => fs.stat(path, err => resolve(!err)));
 
@@ -238,6 +238,8 @@ function extractZip(zipPath: string, folderPath: string) {
           zipfile.openReadStream(entry, (err, rs) => {
             if (err) reject(err);
             const readStream = rs as Readable;
+
+            readStream.on('error', reject);
 
             readStream.on('end', () => {
               zipfile.readEntry();

--- a/src/server/browserFetcher.ts
+++ b/src/server/browserFetcher.ts
@@ -29,7 +29,7 @@ import { assert } from '../helper';
 
 const unlinkAsync = util.promisify(fs.unlink.bind(fs));
 const chmodAsync = util.promisify(fs.chmod.bind(fs));
-const fsPromises = fs.promises;
+const mkdirAsync = fs.promises.mkdir;
 
 const existsAsync = (path: string): Promise<boolean> => new Promise(resolve => fs.stat(path, err => resolve(!err)));
 
@@ -229,11 +229,11 @@ function extractZip(zipPath: string, folderPath: string) {
 
       zipfile.on('entry', async entry => {
         if (entry.fileName.endsWith('/')) {
-          await fsPromises.mkdir(path.resolve(folderPath, entry.fileName), { recursive: true });
+          await mkdirAsync(path.resolve(folderPath, entry.fileName), { recursive: true });
           zipfile.readEntry();
         } else {
           const filepath = path.resolve(folderPath, entry.fileName);
-          await fsPromises.mkdir(path.parse(filepath).dir, { recursive: true });
+          await mkdirAsync(path.parse(filepath).dir, { recursive: true });
 
           zipfile.openReadStream(entry, (err, rs) => {
             if (err) reject(err);


### PR DESCRIPTION
Since extract-zip is abandonware, remove it and just work with
yauzl directly.

In order to make TypeScript happy with recursive `mkdir`, I updated `@types/node` to v10 (since the min version for playwright is v10 anyway). However, this broke some other typings throughout the code. 

Fixes #1510