### PR TITLE
chore(firefox): remove FFPage._initialize to ensure early initialization

### DIFF
--- a/test/emulation.spec.js
+++ b/test/emulation.spec.js
@@ -399,9 +399,15 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
     });
   });
 
-  describe('focus', function() {
-    it.fail(!headless)('should think that it is focused by default', async({page}) => {
+  describe.fail(!headless)('focus', function() {
+    it('should think that it is focused by default', async({page}) => {
       expect(await page.evaluate('document.hasFocus()')).toBe(true);
+    });
+    it.fail(FFOX)('should think that all pages are focused', async({page}) => {
+      const page2 = await page.context().newPage();
+      expect(await page.evaluate('document.hasFocus()')).toBe(true);
+      expect(await page2.evaluate('document.hasFocus()')).toBe(true);
+      await page2.close();
     });
   });
 };

--- a/test/popup.spec.js
+++ b/test/popup.spec.js
@@ -217,14 +217,11 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       expect(popup).toBeTruthy();
       await context.close();
     });
-    it.fail(FFOX)('should be able to capture alert', async({browser}) => {
-      // Firefox:
-      // - immediately closes dialog by itself, without protocol call;
-      // - waits for Page.addScriptToEvaluateOnNewDocument before resolving page(), which is too late.
+    it('should be able to capture alert', async({browser}) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       const evaluatePromise = page.evaluate(() => {
-        const win = window.open('about:blank');
+        const win = window.open('');
         win.alert('hello');
       });
       const popup = await page.waitForEvent('popup');


### PR DESCRIPTION
This makes one test pass for Firefox. However, I discovered a focus issue with Firefox, so one more test is now failing.