### PR TITLE
fix: catch websocket error events

### DIFF
--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -18,7 +18,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { helper } from '../helper';
+import { debugError, helper } from '../helper';
 import { CRBrowser } from '../chromium/crBrowser';
 import * as platform from '../platform';
 import * as ws from 'ws';
@@ -268,6 +268,8 @@ function wrapTransportWithWebSocket(transport: ConnectionTransport, port: number
       // Pending session id, queue the message.
       session.queue!.push(parsedMessage);
     });
+
+    socket.on('error', error => debugError(error));
 
     socket.on('close', (socket as any).__closeListener = () => {
       const session = socketToBrowserSession.get(socket);

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -25,7 +25,7 @@ import { TimeoutError } from '../errors';
 import { Events } from '../events';
 import { FFBrowser } from '../firefox/ffBrowser';
 import { kBrowserCloseMessageId } from '../firefox/ffConnection';
-import { helper } from '../helper';
+import { debugError, helper } from '../helper';
 import * as platform from '../platform';
 import { BrowserServer } from './browserServer';
 import { BrowserArgOptions, BrowserType, LaunchOptions } from './browserType';
@@ -294,6 +294,8 @@ function wrapTransportWithWebSocket(transport: ConnectionTransport, port: number
       if (method === 'Browser.removeBrowserContext')
         pendingBrowserContextDeletions.set(seqNum, params.browserContextId);
     });
+
+    socket.on('error', error => debugError(error));
 
     socket.on('close', (socket as any).__closeListener = () => {
       for (const [browserContextId, s] of browserContextIds) {

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -22,7 +22,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as platform from '../platform';
 import * as os from 'os';
-import { helper } from '../helper';
+import { debugError, helper } from '../helper';
 import { kBrowserCloseMessageId } from '../webkit/wkConnection';
 import { LaunchOptions, BrowserArgOptions, BrowserType } from './browserType';
 import { ConnectionTransport, SequenceNumberMixer } from '../transport';
@@ -275,6 +275,8 @@ function wrapTransportWithWebSocket(transport: ConnectionTransport, port: number
       if (method === 'Playwright.deleteContext')
         pendingBrowserContextDeletions.set(seqNum, params.browserContextId);
     });
+
+    socket.on('error', error => debugError(error));
 
     socket.on('close', (socket as any).__closeListener = () => {
       for (const [pageProxyId, s] of pageProxyIds) {


### PR DESCRIPTION
WebSockets can throw an error event that has to be captured in
node to prevent application crashing.

This seems to be crashing WebKit Linux on some of the bots with the
`ECONNRESET` error:
- https://github.com/microsoft/playwright/runs/544357239

WS-related `ECONNRESET` error discussion:
- https://github.com/websockets/ws/issues/1256