### PR TITLE
fix(types): don't export derived types

### DIFF
--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -174,4 +174,5 @@ class TimeoutError extends Error {}
 export const selectors: Selectors;
 export const devices: {[name: string]: DeviceDescriptor} & DeviceDescriptor[];
 
-export {}
+// This is required to not export everything by default. See https://github.com/Microsoft/TypeScript/issues/19545#issuecomment-340490459
+export {};

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -173,3 +173,5 @@ class TimeoutError extends Error {}
 
 export const selectors: Selectors;
 export const devices: {[name: string]: DeviceDescriptor} & DeviceDescriptor[];
+
+export {}


### PR DESCRIPTION
I was playing around today with different ways of changing the way we export types for #1439. I looked at only exporting 'Parameter' types, only exporting 'Return' types, only exporting a manual list of 'important' types. They all had different pros and cons, and it was very difficult to settle on a good answer.

For now, let's not export any parameter/return types. We can whitelist some types upon user request. I'm thinking `LaunchOptions` and `AccessibilitySnapshot` could be quite useful. We can always add new types after 1.0, but we can't remove them.

The patch looks funny because this was my original intent for the types, but I didn't know I had to `export {}` to tell typescript that my .d.ts shouldn't export everything.