### PR TITLE
fix(types): add types for waitForEvent

### DIFF
--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -141,6 +141,7 @@ function createEventDescriptions(classDesc) {
     const argName = argNameForType(type);
     const params = argName ? `${argName} : ${type}` : '';
     descriptions.push({
+      type,
       params,
       eventName,
       comment: value.comment
@@ -167,6 +168,16 @@ function classBody(classDesc) {
   parts.push(members.map(member => {
     if (member.kind === 'event')
       return '';
+    if (member.name === 'waitForEvent') {
+      const parts = [];
+      for (const {eventName, params, comment, type} of eventDescriptions) {
+        if (comment)
+          parts.push(writeComment(comment, '  '));
+        parts.push(`  ${member.name}(event: '${eventName}', optionsOrPredicate?: { predicate?: (${params}) => boolean, timeout?: number }): Promise<${type}>;\n`);
+      }
+
+      return parts.join('\n');
+    }
     const jsdoc = memberJSDOC(member, '  ');
     const args = argsFromMember(member, classDesc.name);
     const type = typeToString(member.type, classDesc.name, member.name);

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -290,6 +290,31 @@ playwright.chromium.launch().then(async browser => {
   browser.close();
 })();
 
+// waitForEvent
+(async () => {
+  const browser = await playwright.webkit.launch();
+  const page = await browser.newPage();
+  {
+    const frame = await page.waitForEvent('frameattached');
+    const assertion: AssertType<playwright.Frame, typeof frame> = true;
+  }
+  {
+    const worker = await page.waitForEvent('worker', {
+      predicate: worker => {
+        const condition: AssertType<playwright.Worker, typeof worker> = true;
+        return true;
+      }
+    });
+    const assertion: AssertType<playwright.Worker, typeof worker> = true;
+  }
+  {
+    const newPage = await page.context().waitForEvent('page', {
+      timeout: 500
+    });
+    const assertion: AssertType<playwright.Page, typeof newPage> = true;
+  }
+})();
+
 // typed handles
 (async () => {
   const browser = await playwright.webkit.launch();
@@ -514,7 +539,6 @@ playwright.chromium.launch().then(async browser => {
       const canBeNull: AssertType<null, typeof handle> = true;
     }
   }
-
 
   await browser.close();
 })();


### PR DESCRIPTION
waitForEvent needs custom types that take into account the available events, similar to `on` and `addListener`.