### PR TITLE
chore(waitForEvent): refactor waitForEvent into a single implementation

### DIFF
--- a/src/browserContext.ts
+++ b/src/browserContext.ts
@@ -73,12 +73,17 @@ export abstract class BrowserContextBase extends ExtendedEventEmitter implements
   readonly _permissions = new Map<string, string[]>();
 
   constructor(options: BrowserContextOptions) {
-    super({
-      timeoutGetter: event => this._timeoutSettings.timeout(),
-      abortGetter: event => event === Events.BrowserContext.Close ? new Promise<Error>(() => void 0) : this._closePromise,
-    });
+    super();
     this._options = options;
     this._closePromise = new Promise(fulfill => this._closePromiseFulfill = fulfill);
+  }
+
+  protected _abortPromiseForEvent(event: string) {
+    return event === Events.BrowserContext.Close ? super._abortPromiseForEvent(event) : this._closePromise;
+  }
+
+  protected _timeoutForEvent(event: string): number {
+    return this._timeoutSettings.timeout();
   }
 
   _browserClosed() {

--- a/src/extendedEventEmitter.ts
+++ b/src/extendedEventEmitter.ts
@@ -1,24 +1,36 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { EventEmitter } from './platform';
 import { helper } from './helper';
 
 export class ExtendedEventEmitter extends EventEmitter {
-  private _timeoutGetter: (event: string) => number;
-  private _abortGetter: (event: string) => Promise<Error>;
-  constructor(options: {timeoutGetter: (event: string) => number, abortGetter?: (event: string) => Promise<Error>}) {
-    super();
-    const {
-      timeoutGetter,
-      abortGetter = () => new Promise<Error>(() => void 0)
-    } = options;
-    this._timeoutGetter = timeoutGetter;
-    this._abortGetter = abortGetter;
+  protected _abortPromiseForEvent(event: string) {
+    return new Promise<Error>(() => void 0);
+  }
+
+  protected _timeoutForEvent(event: string): number {
+    throw new Error('unimplemented');
   }
 
   async waitForEvent(event: string, optionsOrPredicate: Function|{ predicate?: Function, timeout?: number } = {}): Promise<any> {
     const {
       predicate = () => true,
-      timeout = this._timeoutGetter(event)
+      timeout = this._timeoutForEvent(event)
     } = typeof optionsOrPredicate === 'function' ? {predicate: optionsOrPredicate} : optionsOrPredicate;
-    return helper.waitForEvent(this, event, predicate, timeout, this._abortGetter(event));
+    return helper.waitForEvent(this, event, predicate, timeout, this._abortPromiseForEvent(event));
   }
 }

--- a/src/extendedEventEmitter.ts
+++ b/src/extendedEventEmitter.ts
@@ -1,0 +1,24 @@
+import { EventEmitter } from './platform';
+import { helper } from './helper';
+
+export class ExtendedEventEmitter extends EventEmitter {
+  private _timeoutGetter: (event: string) => number;
+  private _abortGetter: (event: string) => Promise<Error>;
+  constructor(options: {timeoutGetter: (event: string) => number, abortGetter?: (event: string) => Promise<Error>}) {
+    super();
+    const {
+      timeoutGetter,
+      abortGetter = () => new Promise<Error>(() => void 0)
+    } = options;
+    this._timeoutGetter = timeoutGetter;
+    this._abortGetter = abortGetter;
+  }
+
+  async waitForEvent(event: string, optionsOrPredicate: Function|{ predicate?: Function, timeout?: number } = {}): Promise<any> {
+    const {
+      predicate = () => true,
+      timeout = this._timeoutGetter(event)
+    } = typeof optionsOrPredicate === 'function' ? {predicate: optionsOrPredicate} : optionsOrPredicate;
+    return helper.waitForEvent(this, event, predicate, timeout, this._abortGetter(event));
+  }
+}

--- a/src/page.ts
+++ b/src/page.ts
@@ -112,10 +112,7 @@ export class Page extends ExtendedEventEmitter {
   _ownedContext: BrowserContext | undefined;
 
   constructor(delegate: PageDelegate, browserContext: BrowserContextBase) {
-    super({
-      timeoutGetter: event => this._timeoutSettings.timeout(),
-      abortGetter: event => this._disconnectedPromise,
-    });
+    super();
     this._delegate = delegate;
     this._closedCallback = () => {};
     this._closedPromise = new Promise(f => this._closedCallback = f);
@@ -144,6 +141,14 @@ export class Page extends ExtendedEventEmitter {
     if (delegate.pdf)
       this.pdf = delegate.pdf.bind(delegate);
     this.coverage = delegate.coverage ? delegate.coverage() : null;
+  }
+
+  protected _abortPromiseForEvent(event: string) {
+    return this._disconnectedPromise;
+  }
+
+  protected _timeoutForEvent(event: string): number {
+    return this._timeoutSettings.timeout();
   }
 
   _didClose() {


### PR DESCRIPTION
Moves the `waitForEvent` implementation into an `ExtendedEventEmitter` class.

This is step one if we want to add `waitForEvent` to `Worker`, `Browser`, and `BrowserServer` objects. All of these only have a 'close' event, but I still feel we should be consistent with our event emitters.