### PR TITLE
fix: wait for the process to close when closing the browser

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -24,6 +24,7 @@ export interface Browser extends EventEmitter {
   newPage(options?: BrowserContextOptions): Promise<Page>;
   isConnected(): boolean;
   close(): Promise<void>;
+  _disconnect(): Promise<void>;
   _setDebugFunction(debugFunction: (message: string) => void): void;
 }
 

--- a/src/server/pipeTransport.ts
+++ b/src/server/pipeTransport.ts
@@ -23,14 +23,12 @@ export class PipeTransport implements ConnectionTransport {
   private _pendingMessage = '';
   private _eventListeners: RegisteredListener[];
   private _waitForNextTask = helper.makeWaitForNextTask();
-  private readonly _closeCallback: () => void;
 
   onmessage?: (message: ProtocolResponse) => void;
   onclose?: () => void;
 
-  constructor(pipeWrite: NodeJS.WritableStream, pipeRead: NodeJS.ReadableStream, closeCallback: () => void) {
+  constructor(pipeWrite: NodeJS.WritableStream, pipeRead: NodeJS.ReadableStream) {
     this._pipeWrite = pipeWrite;
-    this._closeCallback = closeCallback;
     this._eventListeners = [
       helper.addEventListener(pipeRead, 'data', buffer => this._dispatch(buffer)),
       helper.addEventListener(pipeRead, 'close', () => {
@@ -51,7 +49,7 @@ export class PipeTransport implements ConnectionTransport {
   }
 
   close() {
-    this._closeCallback();
+    throw new Error('unimplemented');
   }
 
   _dispatch(buffer: Buffer) {

--- a/src/server/processLauncher.ts
+++ b/src/server/processLauncher.ts
@@ -135,7 +135,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     }
     gracefullyClosing = true;
     debugBrowser(`<gracefully close start>`);
-    options.attemptToGracefullyClose().catch(() => killProcess());
+    await options.attemptToGracefullyClose().catch(() => killProcess());
     await waitForProcessToClose;
     debugBrowser(`<gracefully close end>`);
   }

--- a/test/playwright.spec.js
+++ b/test/playwright.spec.js
@@ -160,7 +160,7 @@ module.exports.addPlaywrightTests = ({testRunner, platform, products, playwright
       describe('', function() {
         beforeAll(async state => {
           state.browser = await browserType.launch(defaultBrowserOptions);
-          state.browserServer = state.browser.__server__;
+          state.browserServer = state.browser._ownedServer;
           state._stdout = readline.createInterface({ input: state.browserServer.process().stdout });
           state._stderr = readline.createInterface({ input: state.browserServer.process().stderr });
         });

--- a/utils/doclint/check_public_api/JSBuilder.js
+++ b/utils/doclint/check_public_api/JSBuilder.js
@@ -112,7 +112,7 @@ function checkSources(sources) {
       if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
         const module = node.moduleSpecifier.text;
         const isServerDependency = path.resolve(path.dirname(fileName), module).includes('src/server');
-        if (isServerDependency) {
+        if (isServerDependency && !node.importClause.isTypeOnly) {
           const lac = ts.getLineAndCharacterOfPosition(node.getSourceFile(), node.moduleSpecifier.pos);
           errors.push(`Disallowed import "${module}" at ${node.getSourceFile().fileName}:${lac.line + 1}`);
         }


### PR DESCRIPTION
I had a test, but it was chromium only (reading the cookies file). I'll work on a better one.