### PR TITLE
test: migrate tests to use environments

### DIFF
--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, MAC}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/autowaiting.spec.js
+++ b/test/autowaiting.spec.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, playwright, MAC, WIN, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -17,7 +17,7 @@
 const utils = require('./utils');
 
 /**
- * @type {BrowserTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;
@@ -25,7 +25,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('Browser.newPage', function() {
-    it('should create new page', async function({browser}) {
+    it.browser('should create new page', async function({browser}) {
       const page1 = await browser.newPage();
       expect(browser.contexts().length).toBe(1);
 
@@ -38,7 +38,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, WE
       await page2.close();
       expect(browser.contexts().length).toBe(0);
     });
-    it('should throw upon second create new page', async function({browser}) {
+    it.browser('should throw upon second create new page', async function({browser}) {
       const page = await browser.newPage();
       let error;
       await page.context().newPage().catch(e => error = e);

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -18,7 +18,7 @@
 const utils = require('./utils');
 
 /**
- * @type {BrowserTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FFOX, WEBKIT, LINUX}) {
   const {describe, xdescribe, fdescribe} = testRunner;
@@ -26,7 +26,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('BrowserContext', function() {
-    it('should create new context', async function({browser}) {
+    it.browser('should create new context', async function({browser}) {
       expect(browser.contexts().length).toBe(0);
       const context = await browser.newContext();
       expect(browser.contexts().length).toBe(1);
@@ -34,7 +34,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       await context.close();
       expect(browser.contexts().length).toBe(0);
     });
-    it('window.open should use parent tab context', async function({browser, server}) {
+    it.browser('window.open should use parent tab context', async function({browser, server}) {
       const context = await browser.newContext();
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
@@ -45,7 +45,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(popup.context()).toBe(context);
       await context.close();
     });
-    it('should isolate localStorage and cookies', async function({browser, server}) {
+    it.browser('should isolate localStorage and cookies', async function({browser, server}) {
       // Create two incognito contexts.
       const context1 = await browser.newContext();
       const context2 = await browser.newContext();
@@ -89,7 +89,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       ]);
       expect(browser.contexts().length).toBe(0);
     });
-    it('should propagate default viewport to the page', async({ browser }) => {
+    it.browser('should propagate default viewport to the page', async({ browser }) => {
       const context = await browser.newContext({ viewport: { width: 456, height: 789 } });
       const page = await context.newPage();
       expect(page.viewportSize().width).toBe(456);
@@ -98,7 +98,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(await page.evaluate('window.innerHeight')).toBe(789);
       await context.close();
     });
-    it('should make a copy of default viewport', async({ browser }) => {
+    it.browser('should make a copy of default viewport', async({ browser }) => {
       const viewport = { width: 456, height: 789 };
       const context = await browser.newContext({ viewport });
       viewport.width = 567;
@@ -109,11 +109,11 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(await page.evaluate('window.innerHeight')).toBe(789);
       await context.close();
     });
-    it('close() should work for empty context', async({ browser }) => {
+    it.browser('close() should work for empty context', async({ browser }) => {
       const context = await browser.newContext();
       await context.close();
     });
-    it('close() should abort waitForEvent', async({ browser }) => {
+    it.browser('close() should abort waitForEvent', async({ browser }) => {
       const context = await browser.newContext();
       const promise = context.waitForEvent('page').catch(e => e);
       await context.close();
@@ -123,7 +123,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
   });
 
   describe('BrowserContext({userAgent})', function() {
-    it('should work', async({browser, server}) => {
+    it.browser('should work', async({browser, server}) => {
       {
         const context = await browser.newContext();
         const page = await context.newPage();
@@ -141,7 +141,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
         await context.close();
       }
     });
-    it('should work for subframes', async({browser, server}) => {
+    it.browser('should work for subframes', async({browser, server}) => {
       {
         const context = await browser.newContext();
         const page = await context.newPage();
@@ -159,7 +159,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
         await context.close();
       }
     });
-    it('should emulate device user-agent', async({browser, server}) => {
+    it.browser('should emulate device user-agent', async({browser, server}) => {
       {
         const context = await browser.newContext();
         const page = await context.newPage();
@@ -175,7 +175,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
         await context.close();
       }
     });
-    it('should make a copy of default options', async({browser, server}) => {
+    it.browser('should make a copy of default options', async({browser, server}) => {
       const options = { userAgent: 'foobar' };
       const context = await browser.newContext(options);
       options.userAgent = 'wrong';
@@ -190,7 +190,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
   });
 
   describe('BrowserContext({bypassCSP})', function() {
-    it('should bypass CSP meta tag', async({browser, server}) => {
+    it.browser('should bypass CSP meta tag', async({browser, server}) => {
       // Make sure CSP prohibits addScriptTag.
       {
         const context = await browser.newContext();
@@ -212,7 +212,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       }
     });
 
-    it('should bypass CSP header', async({browser, server}) => {
+    it.browser('should bypass CSP header', async({browser, server}) => {
       // Make sure CSP prohibits addScriptTag.
       server.setCSP('/empty.html', 'default-src "self"');
 
@@ -236,7 +236,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       }
     });
 
-    it('should bypass after cross-process navigation', async({browser, server}) => {
+    it.browser('should bypass after cross-process navigation', async({browser, server}) => {
       const context = await browser.newContext({ bypassCSP: true });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/csp.html');
@@ -248,7 +248,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(await page.evaluate(() => window.__injected)).toBe(42);
       await context.close();
     });
-    it('should bypass CSP in iframes as well', async({browser, server}) => {
+    it.browser('should bypass CSP in iframes as well', async({browser, server}) => {
       // Make sure CSP prohibits addScriptTag in an iframe.
       {
         const context = await browser.newContext();
@@ -274,7 +274,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
   });
 
   describe('BrowserContext({javaScriptEnabled})', function() {
-    it('should work', async({browser}) => {
+    it.browser('should work', async({browser}) => {
       {
         const context = await browser.newContext({ javaScriptEnabled: false });
         const page = await context.newPage();
@@ -296,7 +296,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
         await context.close();
       }
     });
-    it('should be able to navigate after disabling javascript', async({browser, server}) => {
+    it.browser('should be able to navigate after disabling javascript', async({browser, server}) => {
       const context = await browser.newContext({ javaScriptEnabled: false });
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
@@ -305,7 +305,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
   });
 
   describe('BrowserContext.pages()', function() {
-    it('should return all of the pages', async({browser, server}) => {
+    it.browser('should return all of the pages', async({browser, server}) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       const second = await context.newPage();
@@ -315,7 +315,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(allPages).toContain(second);
       await context.close();
     });
-    it('should close all belonging pages once closing context', async function({browser}) {
+    it.browser('should close all belonging pages once closing context', async function({browser}) {
       const context = await browser.newContext();
       await context.newPage();
       expect(context.pages().length).toBe(1);
@@ -326,7 +326,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
   });
 
   describe('BrowserContext.exposeFunction', () => {
-    it('should work', async({browser, server}) => {
+    it.browser('should work', async({browser, server}) => {
       const context = await browser.newContext();
       await context.exposeFunction('add', (a, b) => a + b);
       const page = await context.newPage();
@@ -337,7 +337,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(result).toEqual({ mul: 36, add: 13 });
       await context.close();
     });
-    it('should throw for duplicate registrations', async({browser, server}) => {
+    it.browser('should throw for duplicate registrations', async({browser, server}) => {
       const context = await browser.newContext();
       await context.exposeFunction('foo', () => {});
       await context.exposeFunction('bar', () => {});
@@ -351,7 +351,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(error.message).toBe('Function "baz" has been already registered in one of the pages');
       await context.close();
     });
-    it('should be callable from-inside addInitScript', async({browser, server}) => {
+    it.browser('should be callable from-inside addInitScript', async({browser, server}) => {
       const context = await browser.newContext();
       let args = [];
       await context.exposeFunction('woof', function(arg) {
@@ -368,7 +368,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
   });
 
   describe('BrowserContext.route', () => {
-    it('should intercept', async({browser, server}) => {
+    it.browser('should intercept', async({browser, server}) => {
       const context = await browser.newContext();
       let intercepted = false;
       await context.route('**/empty.html', route => {
@@ -390,7 +390,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(intercepted).toBe(true);
       await context.close();
     });
-    it('should yield to page.route', async({browser, server}) => {
+    it.browser('should yield to page.route', async({browser, server}) => {
       const context = await browser.newContext();
       await context.route('**/empty.html', route => {
         route.fulfill({ status: 200, body: 'context' });
@@ -407,7 +407,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
   });
 
   describe('BrowserContext.setHTTPCredentials', function() {
-    it('should work', async({browser, server}) => {
+    it.browser('should work', async({browser, server}) => {
       server.setAuth('/empty.html', 'user', 'pass');
       const context = await browser.newContext();
       const page = await context.newPage();
@@ -421,7 +421,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(response.status()).toBe(200);
       await context.close();
     });
-    it('should fail if wrong credentials', async({browser, server}) => {
+    it.browser('should fail if wrong credentials', async({browser, server}) => {
       server.setAuth('/empty.html', 'user', 'pass');
       const context = await browser.newContext({
         httpCredentials: { username: 'foo', password: 'bar' }
@@ -437,7 +437,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(response.status()).toBe(200);
       await context.close();
     });
-    it('should allow disable authentication', async({browser, server}) => {
+    it.browser('should allow disable authentication', async({browser, server}) => {
       server.setAuth('/empty.html', 'user', 'pass');
       const context = await browser.newContext({
         httpCredentials: { username: 'user', password: 'pass' }
@@ -451,7 +451,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(response.status()).toBe(401);
       await context.close();
     });
-    it('should return resource body', async({browser, server}) => {
+    it.browser('should return resource body', async({browser, server}) => {
       server.setAuth('/playground.html', 'user', 'pass');
       const context = await browser.newContext({
         httpCredentials: { username: 'user', password: 'pass' }
@@ -466,7 +466,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
   });
 
   describe('BrowserContext.setOffline', function() {
-    it('should work with initial option', async({browser, server}) => {
+    it.browser('should work with initial option', async({browser, server}) => {
       const context = await browser.newContext({offline: true});
       const page = await context.newPage();
       let error = null;
@@ -477,7 +477,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(response.status()).toBe(200);
       await context.close();
     });
-    it('should emulate navigator.onLine', async({browser, server}) => {
+    it.browser('should emulate navigator.onLine', async({browser, server}) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       expect(await page.evaluate(() => window.navigator.onLine)).toBe(true);
@@ -490,7 +490,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
   });
 
   describe('Events.BrowserContext.Page', function() {
-    it('should have url', async({browser, server}) => {
+    it.browser('should have url', async({browser, server}) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       const [otherPage] = await Promise.all([
@@ -500,7 +500,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(otherPage.url()).toBe(server.EMPTY_PAGE);
       await context.close();
     });
-    it('should have url after domcontentloaded', async({browser, server}) => {
+    it.browser('should have url after domcontentloaded', async({browser, server}) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       const [otherPage] = await Promise.all([
@@ -511,7 +511,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(otherPage.url()).toBe(server.EMPTY_PAGE);
       await context.close();
     });
-    it('should have about:blank url with domcontentloaded', async({browser, server}) => {
+    it.browser('should have about:blank url with domcontentloaded', async({browser, server}) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       const [otherPage] = await Promise.all([
@@ -522,7 +522,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(otherPage.url()).toBe('about:blank');
       await context.close();
     });
-    it('should have about:blank for empty url with domcontentloaded', async({browser, server}) => {
+    it.browser('should have about:blank for empty url with domcontentloaded', async({browser, server}) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       const [otherPage] = await Promise.all([
@@ -533,7 +533,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(otherPage.url()).toBe('about:blank');
       await context.close();
     });
-    it('should report when a new page is created and closed', async({browser, server}) => {
+    it.browser('should report when a new page is created and closed', async({browser, server}) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       const [otherPage] = await Promise.all([
@@ -559,7 +559,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(allPages).not.toContain(otherPage);
       await context.close();
     });
-    it('should report initialized pages', async({browser, server}) => {
+    it.browser('should report initialized pages', async({browser, server}) => {
       const context = await browser.newContext();
       const pagePromise = context.waitForEvent('page');
       context.newPage();
@@ -573,7 +573,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       await evaluatePromise;
       await context.close();
     });
-    it('should not crash while redirecting of original request was missed', async({browser, server}) => {
+    it.browser('should not crash while redirecting of original request was missed', async({browser, server}) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       let serverResponse = null;
@@ -592,7 +592,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       // Cleanup.
       await context.close();
     });
-    it('should have an opener', async({browser, server}) => {
+    it.browser('should have an opener', async({browser, server}) => {
       const context = await browser.newContext();
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
@@ -606,7 +606,7 @@ module.exports.describe = function({testRunner, expect, playwright, CHROMIUM, FF
       expect(await page.opener()).toBe(null);
       await context.close();
     });
-    it('should fire page lifecycle events', async function({browser, server}) {
+    it.browser('should fire page lifecycle events', async function({browser, server}) {
       const context = await browser.newContext();
       const events = [];
       context.on('page', async page => {

--- a/test/capabilities.spec.js
+++ b/test/capabilities.spec.js
@@ -18,7 +18,7 @@ const utils = require('./utils');
 const { waitEvent } = utils;
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, WIN, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/chromium/chromium.spec.js
+++ b/test/chromium/chromium.spec.js
@@ -17,7 +17,7 @@
 const { waitEvent } = require('../utils');
 
 /**
- * @type {ChromiumTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/chromium/coverage.spec.js
+++ b/test/chromium/coverage.spec.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * @type {ChromiumTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/chromium/launcher.spec.js
+++ b/test/chromium/launcher.spec.js
@@ -47,19 +47,19 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
   });
 
   describe('launcher', function() {
-    it('should throw with remote-debugging-pipe argument', async() => {
+    it.pw('should throw with remote-debugging-pipe argument', async() => {
       const options = Object.assign({}, defaultBrowserOptions);
       options.args = ['--remote-debugging-pipe'].concat(options.args || []);
       const error = await browserType.launchServer(options).catch(e => e);
       expect(error.message).toContain('Playwright manages remote debugging connection itself');
     });
-    it('should throw with remote-debugging-port argument', async() => {
+    it.pw('should throw with remote-debugging-port argument', async() => {
       const options = Object.assign({}, defaultBrowserOptions);
       options.args = ['--remote-debugging-port=9222'].concat(options.args || []);
       const error = await browserType.launchServer(options).catch(e => e);
       expect(error.message).toContain('Playwright manages remote debugging connection itself');
     });
-    it('should open devtools when "devtools: true" option is given', async({server}) => {
+    it.pw('should open devtools when "devtools: true" option is given', async({server}) => {
       const browser = await browserType.launch(Object.assign({devtools: true}, headfulOptions));
       const context = await browser.newContext();
       const browserSession = await browser.newBrowserCDPSession();
@@ -77,7 +77,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
   });
 
   describe('extensions', () => {
-    it('should return background pages', async() => {
+    it.pw('should return background pages', async() => {
       const userDataDir = await makeUserDataDir();
       const context = await browserType.launchPersistentContext(userDataDir, extensionOptions);
       const backgroundPages = context.backgroundPages();
@@ -92,7 +92,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
   });
 
   describe('BrowserContext', function() {
-    it('should not create pages automatically', async function() {
+    it.pw('should not create pages automatically', async function() {
       const browser = await browserType.launch();
       const browserSession = await browser.newBrowserCDPSession();
       const targets = [];

--- a/test/chromium/oopif.spec.js
+++ b/test/chromium/oopif.spec.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * @type {ChromiumTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, defaultBrowserOptions, browserType, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;
@@ -45,24 +45,24 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
       await state.browser.close();
       state.browser = null;
     });
-    it.fail(true)('should report oopif frames', async function({browser, page, server, context}) {
+    it.pw.fail(true)('should report oopif frames', async function({browser, page, server, context}) {
       await page.goto(server.PREFIX + '/dynamic-oopif.html');
       expect(await countOOPIFs(browser)).toBe(1);
       expect(page.frames().length).toBe(2);
     });
-    it('should load oopif iframes with subresources and request interception', async function({browser, page, server, context}) {
+    it.pw('should load oopif iframes with subresources and request interception', async function({browser, page, server, context}) {
       await page.route('**/*', route => route.continue());
       await page.goto(server.PREFIX + '/dynamic-oopif.html');
       expect(await countOOPIFs(browser)).toBe(1);
     });
     // @see https://github.com/microsoft/playwright/issues/1240
-    xit('should click a button when it overlays oopif', async function({browser, page, server, context}) {
+    xit.pw('should click a button when it overlays oopif', async function({browser, page, server, context}) {
       await page.goto(server.PREFIX + '/button-overlay-oopif.html');
       expect(await countOOPIFs(browser)).toBe(1);
       await page.click('button');
       expect(await page.evaluate(() => window.BUTTON_CLICKED)).toBe(true);
     });
-    it.fail(true)('should report google.com frame with headful', async({server}) => {
+    it.pw.fail(true)('should report google.com frame with headful', async({server}) => {
       // TODO: Support OOOPIF. @see https://github.com/GoogleChrome/puppeteer/issues/2548
       // https://google.com is isolated by default in Chromium embedder.
       const browser = await browserType.launch(headfulOptions);

--- a/test/chromium/pdf.spec.js
+++ b/test/chromium/pdf.spec.js
@@ -18,7 +18,7 @@ const fs = require('fs');
 const path = require('path');
 
 /**
- * @type {ChromiumTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, headless, ASSETS_DIR}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/chromium/session.spec.js
+++ b/test/chromium/session.spec.js
@@ -17,7 +17,7 @@
 const { waitEvent } = require('../utils');
 
 /**
- * @type {ChromiumTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/chromium/tracing.spec.js
+++ b/test/chromium/tracing.spec.js
@@ -18,7 +18,7 @@ const fs = require('fs');
 const path = require('path');
 
 /**
- * @type {ChromiumTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, defaultBrowserOptions, browserType, ASSETS_DIR}) {
   const {describe, xdescribe, fdescribe} = testRunner;
@@ -40,20 +40,20 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
         state.outputFile = null;
       }
     });
-    it('should output a trace', async({browser, page, server, outputFile}) => {
+    it.pw('should output a trace', async({browser, page, server, outputFile}) => {
       await browser.startTracing(page, {screenshots: true, path: outputFile});
       await page.goto(server.PREFIX + '/grid.html');
       await browser.stopTracing();
       expect(fs.existsSync(outputFile)).toBe(true);
     });
-    it('should run with custom categories if provided', async({browser, page, outputFile}) => {
+    it.pw('should run with custom categories if provided', async({browser, page, outputFile}) => {
       await browser.startTracing(page, {path: outputFile, categories: ['disabled-by-default-v8.cpu_profiler.hires']});
       await browser.stopTracing();
 
       const traceJson = JSON.parse(fs.readFileSync(outputFile).toString());
       expect(traceJson.metadata['trace-config']).toContain('disabled-by-default-v8.cpu_profiler.hires', 'Does not contain expected category');
     });
-    it('should throw if tracing on two pages', async({browser, page, server, outputFile}) => {
+    it.pw('should throw if tracing on two pages', async({browser, page, server, outputFile}) => {
       await browser.startTracing(page, {path: outputFile});
       const newPage = await browser.newPage();
       let error = null;
@@ -62,20 +62,20 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
       expect(error).toBeTruthy();
       await browser.stopTracing();
     });
-    it('should return a buffer', async({browser, page, server, outputFile}) => {
+    it.pw('should return a buffer', async({browser, page, server, outputFile}) => {
       await browser.startTracing(page, {screenshots: true, path: outputFile});
       await page.goto(server.PREFIX + '/grid.html');
       const trace = await browser.stopTracing();
       const buf = fs.readFileSync(outputFile);
       expect(trace.toString()).toEqual(buf.toString(), 'Tracing buffer mismatch');
     });
-    it('should work without options', async({browser, page, server, outputFile}) => {
+    it.pw('should work without options', async({browser, page, server, outputFile}) => {
       await browser.startTracing(page);
       await page.goto(server.PREFIX + '/grid.html');
       const trace = await browser.stopTracing();
       expect(trace).toBeTruthy();
     });
-    it('should support a buffer without a path', async({browser, page, server}) => {
+    it.pw('should support a buffer without a path', async({browser, page, server}) => {
       await browser.startTracing(page, {screenshots: true});
       await page.goto(server.PREFIX + '/grid.html');
       const trace = await browser.stopTracing();

--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -18,7 +18,7 @@
 const utils = require('./utils');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/cookies.spec.js
+++ b/test/cookies.spec.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, browserType, defaultBrowserOptions, MAC, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/defaultbrowsercontext.spec.js
+++ b/test/defaultbrowsercontext.spec.js
@@ -18,7 +18,7 @@
 const { makeUserDataDir, removeUserDataDir } = require('./utils');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function ({ testRunner, expect, defaultBrowserOptions, browserType, WEBKIT }) {
   const {describe, xdescribe, fdescribe} = testRunner;
@@ -37,7 +37,7 @@ module.exports.describe = function ({ testRunner, expect, defaultBrowserOptions,
       delete state.page;
       await removeUserDataDir(state.userDataDir);
     });
-    it('context.cookies() should work', async({page, server}) => {
+    it.pw('context.cookies() should work', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       await page.evaluate(() => {
         document.cookie = 'username=John Doe';
@@ -53,7 +53,7 @@ module.exports.describe = function ({ testRunner, expect, defaultBrowserOptions,
         sameSite: 'None',
       }]);
     });
-    it('context.addCookies() should work', async({page, server}) => {
+    it.pw('context.addCookies() should work', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       await page.context().addCookies([{
         url: server.EMPTY_PAGE,
@@ -72,7 +72,7 @@ module.exports.describe = function ({ testRunner, expect, defaultBrowserOptions,
         sameSite: 'None',
       }]);
     });
-    it('context.clearCookies() should work', async({page, server}) => {
+    it.pw('context.clearCookies() should work', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       await page.context().addCookies([{
         url: server.EMPTY_PAGE,

--- a/test/dialog.spec.js
+++ b/test/dialog.spec.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/download.spec.js
+++ b/test/download.spec.js
@@ -43,7 +43,7 @@ module.exports.describe = function({testRunner, expect, browserType, CHROMIUM, W
       expect(await download.failure()).toContain('acceptDownloads');
       expect(error.message).toContain('acceptDownloads: true');
     });
-    it('should report downloads with acceptDownloads: true', async({browser, server}) => {
+    it.browser('should report downloads with acceptDownloads: true', async({browser, server}) => {
       const page = await browser.newPage({ acceptDownloads: true });
       await page.setContent(`<a download=true href="${server.PREFIX}/download">download</a>`);
       const [ download ] = await Promise.all([
@@ -55,7 +55,7 @@ module.exports.describe = function({testRunner, expect, browserType, CHROMIUM, W
       expect(fs.readFileSync(path).toString()).toBe('Hello world');
       await page.close();
     });
-    it('should delete file', async({browser, server}) => {
+    it.browser('should delete file', async({browser, server}) => {
       const page = await browser.newPage({ acceptDownloads: true });
       await page.setContent(`<a download=true href="${server.PREFIX}/download">download</a>`);
       const [ download ] = await Promise.all([
@@ -67,7 +67,7 @@ module.exports.describe = function({testRunner, expect, browserType, CHROMIUM, W
       await download.delete();
       expect(fs.existsSync(path)).toBeFalsy();
     });
-    it('should expose stream', async({browser, server}) => {
+    it.browser('should expose stream', async({browser, server}) => {
       const page = await browser.newPage({ acceptDownloads: true });
       await page.setContent(`<a download=true href="${server.PREFIX}/download">download</a>`);
       const [ download ] = await Promise.all([
@@ -81,7 +81,7 @@ module.exports.describe = function({testRunner, expect, browserType, CHROMIUM, W
       expect(content).toBe('Hello world');
       stream.close();
     });
-    it('should delete downloads on context destruction', async({browser, server}) => {
+    it.browser('should delete downloads on context destruction', async({browser, server}) => {
       const page = await browser.newPage({ acceptDownloads: true });
       await page.setContent(`<a download=true href="${server.PREFIX}/download">download</a>`);
       const [ download1 ] = await Promise.all([
@@ -100,7 +100,7 @@ module.exports.describe = function({testRunner, expect, browserType, CHROMIUM, W
       expect(fs.existsSync(path1)).toBeFalsy();
       expect(fs.existsSync(path2)).toBeFalsy();
     });
-    it('should delete downloads on browser gone', async ({ server, defaultBrowserOptions }) => {
+    it.pw('should delete downloads on browser gone', async ({ server, defaultBrowserOptions }) => {
       const browser = await browserType.launch(defaultBrowserOptions);
       const page = await browser.newPage({ acceptDownloads: true });
       await page.setContent(`<a download=true href="${server.PREFIX}/download">download</a>`);

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -18,7 +18,7 @@
 const utils = require('./utils');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/emulation.spec.js
+++ b/test/emulation.spec.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, playwright, headless, FFOX, CHROMIUM, WEBKIT, MAC, WIN}) {
   const {describe, xdescribe, fdescribe} = testRunner;
@@ -25,7 +25,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
   const iPhone = playwright.devices['iPhone 6'];
   const iPhoneLandscape = playwright.devices['iPhone 6 landscape'];
 
-  describe('BrowserContext({viewport})', function() {
+  describe('Page.setViewportSize', function() {
     it('should get the proper viewport size', async({page, server}) => {
       expect(page.viewportSize()).toEqual({width: 1280, height: 720});
       expect(await page.evaluate(() => window.innerWidth)).toBe(1280);
@@ -84,9 +84,9 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
     });
   });
 
-  describe.skip(FFOX)('viewport.isMobile', () => {
+  describe.skip(FFOX)('BrowserContext({isMobile})', () => {
     // Firefox does not support isMobile.
-    it('should support mobile emulation', async({browser, server}) => {
+    it.browser('should support mobile emulation', async({browser, server}) => {
       const context = await browser.newContext({ ...iPhone });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
@@ -95,7 +95,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       expect(await page.evaluate(() => window.innerWidth)).toBe(400);
       await context.close();
     });
-    it('should support touch emulation', async({browser, server}) => {
+    it.browser('should support touch emulation', async({browser, server}) => {
       const context = await browser.newContext({ ...iPhone });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
@@ -116,14 +116,14 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
         return promise;
       }
     });
-    it('should be detectable by Modernizr', async({browser, server}) => {
+    it.browser('should be detectable by Modernizr', async({browser, server}) => {
       const context = await browser.newContext({ ...iPhone });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/detect-touch.html');
       expect(await page.evaluate(() => document.body.textContent.trim())).toBe('YES');
       await context.close();
     });
-    it('should detect touch when applying viewport with touches', async({browser, server}) => {
+    it.browser('should detect touch when applying viewport with touches', async({browser, server}) => {
       const context = await browser.newContext({ viewport: { width: 800, height: 600 }, hasTouch: true });
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
@@ -131,7 +131,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       expect(await page.evaluate(() => Modernizr.touchevents)).toBe(true);
       await context.close();
     });
-    it('should support landscape emulation', async({browser, server}) => {
+    it.browser('should support landscape emulation', async({browser, server}) => {
       const context1 = await browser.newContext({ ...iPhone });
       const page1 = await context1.newPage();
       await page1.goto(server.PREFIX + '/mobile.html');
@@ -142,7 +142,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       await context1.close();
       await context2.close();
     });
-    it.fail(WEBKIT)('should fire orientationchange event', async({browser, server}) => {
+    it.browser.fail(WEBKIT)('should fire orientationchange event', async({browser, server}) => {
       const context = await browser.newContext({ viewport: { width: 300, height: 400 }, isMobile: true });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
@@ -160,14 +160,14 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       expect((await event2).text()).toBe('2');
       await context.close();
     });
-    it('default mobile viewports to 980 width', async({browser, server}) => {
+    it.browser('default mobile viewports to 980 width', async({browser, server}) => {
       const context = await browser.newContext({ viewport: {width: 320, height: 480 }, isMobile: true });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/empty.html');
       expect(await page.evaluate(() => window.innerWidth)).toBe(980);
       await context.close();
     });
-    it('respect meta viewport tag', async({browser, server}) => {
+    it.browser('respect meta viewport tag', async({browser, server}) => {
       const context = await browser.newContext({ viewport: {width: 320, height: 480 }, isMobile: true });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
@@ -176,8 +176,8 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
     });
   });
 
-  describe.skip(FFOX)('Page.emulate', function() {
-    it('should work', async({browser, server}) => {
+  describe.skip(FFOX)('BrowserContext(device)', function() {
+    it.browser('should work', async({browser, server}) => {
       const context = await browser.newContext({ ...iPhone });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/mobile.html');
@@ -185,7 +185,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       expect(await page.evaluate(() => navigator.userAgent)).toContain('iPhone');
       await context.close();
     });
-    it('should support clicking', async({browser, server}) => {
+    it.browser('should support clicking', async({browser, server}) => {
       const context = await browser.newContext({ ...iPhone });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/input/button.html');
@@ -256,7 +256,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
   });
 
   describe('BrowserContext({timezoneId})', function() {
-    it('should work', async ({ browser }) => {
+    it.browser('should work', async ({ browser }) => {
       const func = () => new Date(1479579154987).toString();
       {
         const context = await browser.newContext({ timezoneId: 'America/Jamaica' });
@@ -284,7 +284,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       }
     });
 
-    it('should throw for invalid timezone IDs when creating pages', async({browser}) => {
+    it.browser('should throw for invalid timezone IDs when creating pages', async({browser}) => {
       for (const timezoneId of ['Foo/Bar', 'Baz/Qux']) {
         let error = null;
         const context = await browser.newContext({ timezoneId });
@@ -293,7 +293,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
         await context.close();
       }
     });
-    it('should work for multiple pages sharing same process', async({browser, server}) => {
+    it.browser('should work for multiple pages sharing same process', async({browser, server}) => {
       const context = await browser.newContext({ timezoneId: 'Europe/Moscow' });
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
@@ -310,7 +310,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
   });
 
   describe('BrowserContext({locale})', function() {
-    it('should affect accept-language header', async({browser, server}) => {
+    it.browser('should affect accept-language header', async({browser, server}) => {
       const context = await browser.newContext({ locale: 'fr-CH' });
       const page = await context.newPage();
       const [request] = await Promise.all([
@@ -320,13 +320,13 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       expect(request.headers['accept-language'].substr(0, 5)).toBe('fr-CH');
       await context.close();
     });
-    it('should affect navigator.language', async({browser, server}) => {
+    it.browser('should affect navigator.language', async({browser, server}) => {
       const context = await browser.newContext({ locale: 'fr-CH' });
       const page = await context.newPage();
       expect(await page.evaluate(() => navigator.language)).toBe('fr-CH');
       await context.close();
     });
-    it('should format number', async({browser, server}) => {
+    it.browser('should format number', async({browser, server}) => {
       {
         const context = await browser.newContext({ locale: 'en-US' });
         const page = await context.newPage();
@@ -342,7 +342,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
         await context.close();
       }
     });
-    it('should format date', async({browser, server}) => {
+    it.browser('should format date', async({browser, server}) => {
       {
         const context = await browser.newContext({ locale: 'en-US', timezoneId: 'America/Los_Angeles' });
         const page = await context.newPage();
@@ -360,7 +360,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
         await context.close();
       }
     });
-    it('should format number in popups', async({browser, server}) => {
+    it.browser('should format number in popups', async({browser, server}) => {
       const context = await browser.newContext({ locale: 'fr-CH' });
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
@@ -374,7 +374,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       expect(result).toBe('1 000 000,5');
       await context.close();
     });
-    it('should affect navigator.language in popups', async({browser, server}) => {
+    it.browser('should affect navigator.language in popups', async({browser, server}) => {
       const context = await browser.newContext({ locale: 'fr-CH' });
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
@@ -387,7 +387,7 @@ module.exports.describe = function({testRunner, expect, playwright, headless, FF
       expect(result).toBe('fr-CH');
       await context.close();
     });
-    it('should work for multiple pages sharing same process', async({browser, server}) => {
+    it.browser('should work for multiple pages sharing same process', async({browser, server}) => {
       const context = await browser.newContext({ locale: 'ru-RU' });
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -20,7 +20,7 @@ const path = require('path');
 const bigint = typeof BigInt !== 'undefined';
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, LINUX}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -69,21 +69,21 @@ module.exports.describe = function({testRunner, expect, product, browserType, pl
   }
 
   describe('Fixtures', function() {
-    it.slow()('should dump browser process stderr', async({server}) => {
+    it.pw.slow()('should dump browser process stderr', async({server}) => {
       let dumpioData = '';
       const res = spawn('node', [path.join(__dirname, 'fixtures', 'dumpio.js'), playwrightPath, product, 'usewebsocket']);
       res.stdout.on('data', data => dumpioData += data.toString('utf8'));
       await new Promise(resolve => res.on('close', resolve));
       expect(dumpioData).toContain('message from dumpio');
     });
-    it.slow()('should dump browser process stderr', async({server}) => {
+    it.pw.slow()('should dump browser process stderr', async({server}) => {
       let dumpioData = '';
       const res = spawn('node', [path.join(__dirname, 'fixtures', 'dumpio.js'), playwrightPath, product]);
       res.stdout.on('data', data => dumpioData += data.toString('utf8'));
       await new Promise(resolve => res.on('close', resolve));
       expect(dumpioData).toContain('message from dumpio');
     });
-    it.slow()('should close the browser when the node process closes', async () => {
+    it.pw.slow()('should close the browser when the node process closes', async () => {
       const result = await testSignal(child => {
         if (WIN)
           execSync(`taskkill /pid ${child.pid} /T /F`);
@@ -97,37 +97,37 @@ module.exports.describe = function({testRunner, expect, product, browserType, pl
 
     describe.skip(WIN)('signals', () => {
       // Cannot reliably send signals on Windows.
-      it.slow()('should report browser close signal', async () => {
+      it.pw.slow()('should report browser close signal', async () => {
         const result = await testSignal((child, browserPid) => process.kill(browserPid), true);
         expect(result.exitCode).toBe(0);
         expect(result.browserExitCode).toBe('null');
         expect(result.browserSignal).toBe('SIGTERM');
       });
-      it.slow()('should report browser close signal 2', async (state, test) => {
+      it.pw.slow()('should report browser close signal 2', async (state, test) => {
         const result = await testSignal((child, browserPid) => process.kill(browserPid, 'SIGKILL'), true);
         expect(result.exitCode).toBe(0);
         expect(result.browserExitCode).toBe('null');
         expect(result.browserSignal).toBe('SIGKILL');
       });
-      it.slow()('should close the browser on SIGINT', async () => {
+      it.pw.slow()('should close the browser on SIGINT', async () => {
         const result = await testSignal(child => process.kill(child.pid, 'SIGINT'));
         expect(result.exitCode).toBe(130);
         expect(result.browserExitCode).toBe('0');
         expect(result.browserSignal).toBe('null');
       });
-      it.slow()('should close the browser on SIGTERM', async () => {
+      it.pw.slow()('should close the browser on SIGTERM', async () => {
         const result = await testSignal(child => process.kill(child.pid, 'SIGTERM'));
         expect(result.exitCode).toBe(0);
         expect(result.browserExitCode).toBe('0');
         expect(result.browserSignal).toBe('null');
       });
-      it.slow()('should close the browser on SIGHUP', async () => {
+      it.pw.slow()('should close the browser on SIGHUP', async () => {
         const result = await testSignal(child => process.kill(child.pid, 'SIGHUP'));
         expect(result.exitCode).toBe(0);
         expect(result.browserExitCode).toBe('0');
         expect(result.browserSignal).toBe('null');
       });
-      it.slow()('should kill the browser on double SIGINT', async () => {
+      it.pw.slow()('should kill the browser on double SIGINT', async () => {
         const result = await testSignal(child => {
           process.kill(child.pid, 'SIGINT');
           process.kill(child.pid, 'SIGINT');
@@ -136,7 +136,7 @@ module.exports.describe = function({testRunner, expect, product, browserType, pl
         // TODO: ideally, we would expect the SIGKILL on the browser from
         // force kill, but that's racy with sending two signals.
       });
-      it.slow()('should kill the browser on SIGINT + SIGTERM', async () => {
+      it.pw.slow()('should kill the browser on SIGINT + SIGTERM', async () => {
         const result = await testSignal(child => {
           process.kill(child.pid, 'SIGINT');
           process.kill(child.pid, 'SIGTERM');
@@ -145,7 +145,7 @@ module.exports.describe = function({testRunner, expect, product, browserType, pl
         // TODO: ideally, we would expect the SIGKILL on the browser from
         // force kill, but that's racy with sending two signals.
       });
-      it.slow()('should kill the browser on SIGTERM + SIGINT', async () => {
+      it.pw.slow()('should kill the browser on SIGTERM + SIGINT', async () => {
         const result = await testSignal(child => {
           process.kill(child.pid, 'SIGTERM');
           process.kill(child.pid, 'SIGINT');

--- a/test/focus.spec.js
+++ b/test/focus.spec.js
@@ -18,7 +18,7 @@ const utils = require('./utils');
 const { waitEvent } = utils;
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -18,7 +18,7 @@
 const utils = require('./utils');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/geolocation.spec.js
+++ b/test/geolocation.spec.js
@@ -16,15 +16,16 @@
  */
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function ({ testRunner, expect, FFOX, WEBKIT }) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit, dit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
-  describe('Overrides.setGeolocation', function() {
-    it('should work', async({page, server, context}) => {
+  describe('BrowserContext.setGeolocation', function() {
+    it.context('should work', async({server, context}) => {
+      const page = await context.newPage();
       await context.grantPermissions(['geolocation']);
       await page.goto(server.EMPTY_PAGE);
       await context.setGeolocation({longitude: 10, latitude: 10});
@@ -36,7 +37,7 @@ module.exports.describe = function ({ testRunner, expect, FFOX, WEBKIT }) {
         longitude: 10
       });
     });
-    it('should throw when invalid longitude', async({context}) => {
+    it.context('should throw when invalid longitude', async({context}) => {
       let error = null;
       try {
         await context.setGeolocation({longitude: 200, latitude: 10});
@@ -45,7 +46,7 @@ module.exports.describe = function ({ testRunner, expect, FFOX, WEBKIT }) {
       }
       expect(error.message).toContain('Invalid longitude "200"');
     });
-    it('should throw with missing latitude', async({context}) => {
+    it.context('should throw with missing latitude', async({context}) => {
       let error = null;
       try {
         await context.setGeolocation({longitude: 10});
@@ -54,7 +55,7 @@ module.exports.describe = function ({ testRunner, expect, FFOX, WEBKIT }) {
       }
       expect(error.message).toContain('Invalid latitude "undefined"');
     });
-    it('should not modify passed default options object', async({browser}) => {
+    it.browser('should not modify passed default options object', async({browser}) => {
       const geolocation = { longitude: 10, latitude: 10 };
       const options = { geolocation };
       const context = await browser.newContext(options);
@@ -62,7 +63,7 @@ module.exports.describe = function ({ testRunner, expect, FFOX, WEBKIT }) {
       expect(options.geolocation).toBe(geolocation);
       await context.close();
     });
-    it('should throw with missing longitude in default options', async({browser}) => {
+    it.browser('should throw with missing longitude in default options', async({browser}) => {
       let error = null;
       try {
         const context = await browser.newContext({ geolocation: {latitude: 10} });
@@ -72,7 +73,7 @@ module.exports.describe = function ({ testRunner, expect, FFOX, WEBKIT }) {
       }
       expect(error.message).toContain('Invalid longitude "undefined"');
     });
-    it('should use context options', async({browser, server}) => {
+    it.browser('should use context options', async({browser, server}) => {
       const options = { geolocation: { longitude: 10, latitude: 10 }, permissions: ['geolocation'] };
       const context = await browser.newContext(options);
       const page = await context.newPage();
@@ -87,7 +88,8 @@ module.exports.describe = function ({ testRunner, expect, FFOX, WEBKIT }) {
       });
       await context.close();
     });
-    it('watchPosition should be notified', async({page, server, context}) => {
+    it.context('watchPosition should be notified', async({server, context}) => {
+      const page = await context.newPage();
       await context.grantPermissions(['geolocation']);
       await page.goto(server.EMPTY_PAGE);
       const messages = [];
@@ -112,7 +114,8 @@ module.exports.describe = function ({ testRunner, expect, FFOX, WEBKIT }) {
       expect(allMessages).toContain('lat=20 lng=30');
       expect(allMessages).toContain('lat=40 lng=50');
     });
-    it('should use context options for popup', async({page, context, server}) => {
+    it.context('should use context options for popup', async({context, server}) => {
+      const page = await context.newPage();
       await context.grantPermissions(['geolocation']);
       await context.setGeolocation({ longitude: 10, latitude: 10 });
       const [popup] = await Promise.all([

--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -32,7 +32,7 @@ module.exports.describe = function({testRunner, expect, browserType, defaultBrow
   });
 
   describe('Headful', function() {
-    it('should have default url when launching browser', async function() {
+    it.pw('should have default url when launching browser', async function() {
       const userDataDir = await makeUserDataDir();
       const browserContext = await browserType.launchPersistentContext(userDataDir, headfulOptions);
       const urls = browserContext.pages().map(page => page.url());
@@ -40,7 +40,7 @@ module.exports.describe = function({testRunner, expect, browserType, defaultBrow
       await browserContext.close();
       await removeUserDataDir(userDataDir);
     });
-    it.slow().fail(WIN && CHROMIUM)('headless should be able to read cookies written by headful', async({server}) => {
+    it.pw.slow().fail(WIN && CHROMIUM)('headless should be able to read cookies written by headful', async({server}) => {
       // see https://github.com/microsoft/playwright/issues/717
       const userDataDir = await makeUserDataDir();
       // Write a cookie in headful chrome
@@ -59,7 +59,7 @@ module.exports.describe = function({testRunner, expect, browserType, defaultBrow
       await removeUserDataDir(userDataDir);
       expect(cookie).toBe('foo=true');
     });
-    it('should close browser with beforeunload page', async({server}) => {
+    it.pw('should close browser with beforeunload page', async({server}) => {
       const userDataDir = await makeUserDataDir();
       const browserContext = await browserType.launchPersistentContext(userDataDir, headfulOptions);
       const page = await browserContext.newPage();

--- a/test/ignorehttpserrors.spec.js
+++ b/test/ignorehttpserrors.spec.js
@@ -16,14 +16,14 @@
  */
 
 /**
- * @type {BrowserTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, defaultBrowserOptions, playwright, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit, dit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
   describe('ignoreHTTPSErrors', function() {
-    it('should work', async({browser, httpsServer}) => {
+    it.browser('should work', async({browser, httpsServer}) => {
       let error = null;
       const context = await browser.newContext({ ignoreHTTPSErrors: true });
       const page = await context.newPage();
@@ -32,7 +32,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       expect(response.ok()).toBe(true);
       await context.close();
     });
-    it('should isolate contexts', async({browser, httpsServer}) => {
+    it.browser('should isolate contexts', async({browser, httpsServer}) => {
       {
         let error = null;
         const context = await browser.newContext({ ignoreHTTPSErrors: true });
@@ -40,7 +40,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
         const response = await page.goto(httpsServer.EMPTY_PAGE).catch(e => error = e);
         expect(error).toBe(null);
         expect(response.ok()).toBe(true);
-        await context.close();  
+        await context.close();
       }
       {
         let error = null;
@@ -48,10 +48,10 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
         const page = await context.newPage();
         await page.goto(httpsServer.EMPTY_PAGE).catch(e => error = e);
         expect(error).not.toBe(null);
-        await context.close();  
+        await context.close();
       }
     });
-    it('should work with mixed content', async({browser, server, httpsServer}) => {
+    it.browser('should work with mixed content', async({browser, server, httpsServer}) => {
       httpsServer.setRoute('/mixedcontent.html', (req, res) => {
         res.end(`<iframe src=${server.EMPTY_PAGE}></iframe>`);
       });

--- a/test/input.spec.js
+++ b/test/input.spec.js
@@ -22,7 +22,7 @@ const formidable = require('formidable');
 const FILE_TO_UPLOAD = path.join(__dirname, '/assets/file-to-upload.txt');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/interception.spec.js
+++ b/test/interception.spec.js
@@ -22,7 +22,7 @@ const utils = require('./utils');
 const vm = require('vm');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, defaultBrowserOptions, playwright, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;
@@ -487,7 +487,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   });
 
   describe('ignoreHTTPSErrors', function() {
-    it('should work with request interception', async({browser, httpsServer}) => {
+    it.browser('should work with request interception', async({browser, httpsServer}) => {
       const context = await browser.newContext({ ignoreHTTPSErrors: true });
       const page = await context.newPage();
 
@@ -528,7 +528,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   });
 
   describe('glob', function() {
-    it('should work with glob', async({newPage, httpsServer}) => {
+    it.pw('should work with glob', async() => {
       expect(helper.globToRegex('**/*.js').test('https://localhost:8080/foo.js')).toBeTruthy();
       expect(helper.globToRegex('**/*.css').test('https://localhost:8080/foo.js')).toBeFalsy();
       expect(helper.globToRegex('*.js').test('https://localhost:8080/foo.js')).toBeFalsy();

--- a/test/jshandle.spec.js
+++ b/test/jshandle.spec.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, CHROMIUM, FFOX, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -19,7 +19,7 @@ const utils = require('./utils');
 const os = require('os');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, MAC}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -30,7 +30,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
 
   describe('Playwright', function() {
     describe('browserType.launch', function() {
-      it('should reject all promises when browser is closed', async() => {
+      it.pw('should reject all promises when browser is closed', async() => {
         const browser = await browserType.launch(defaultBrowserOptions);
         const page = await (await browser.newContext()).newPage();
         let error = null;
@@ -39,19 +39,19 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
         await neverResolves;
         expect(error.message).toContain('Protocol error');
       });
-      it('should throw if userDataDir option is passed', async() => {
+      it.pw('should throw if userDataDir option is passed', async() => {
         let waitError = null;
         const options = Object.assign({}, defaultBrowserOptions, {userDataDir: 'random-path'});
         await browserType.launch(options).catch(e => waitError = e);
         expect(waitError.message).toContain('launchPersistentContext');
       });
-      it('should throw if page argument is passed', async() => {
+      it.pw('should throw if page argument is passed', async() => {
         let waitError = null;
         const options = Object.assign({}, defaultBrowserOptions, { args: ['http://example.com'] });
         await browserType.launch(options).catch(e => waitError = e);
         expect(waitError.message).toContain('can not specify page');
       });
-      it('should reject if executable path is invalid', async({server}) => {
+      it.pw('should reject if executable path is invalid', async({server}) => {
         let waitError = null;
         const options = Object.assign({}, defaultBrowserOptions, {executablePath: 'random-invalid-path'});
         await browserType.launch(options).catch(e => waitError = e);
@@ -60,7 +60,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
     });
 
     describe('browserType.launchPersistentContext', function() {
-      it('should have default URL when launching browser', async function() {
+      it.pw('should have default URL when launching browser', async function() {
         const userDataDir = await makeUserDataDir();
         const browserContext = await browserType.launchPersistentContext(userDataDir, defaultBrowserOptions);
         const urls = browserContext.pages().map(page => page.url());
@@ -68,7 +68,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
         await browserContext.close();
         await removeUserDataDir(userDataDir);
       });
-      it('should have custom URL when launching browser', async function({server}) {
+      it.pw('should have custom URL when launching browser', async function({server}) {
         const userDataDir = await makeUserDataDir();
         const options = Object.assign({}, defaultBrowserOptions);
         options.args = [server.EMPTY_PAGE].concat(options.args || []);
@@ -86,12 +86,12 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
     });
 
     describe('browserType.launchServer', function() {
-      it('should return child_process instance', async () => {
+      it.pw('should return child_process instance', async () => {
         const browserServer = await browserType.launchServer(defaultBrowserOptions);
         expect(browserServer.process().pid).toBeGreaterThan(0);
         await browserServer.close();
       });
-      it('should fire close event', async () => {
+      it.pw('should fire close event', async () => {
         const browserServer = await browserType.launchServer(defaultBrowserOptions);
         await Promise.all([
           utils.waitEvent(browserServer, 'close'),
@@ -101,7 +101,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
     });
 
     describe('browserType.executablePath', function() {
-      it('should work', async({server}) => {
+      it.pw('should work', async({server}) => {
         const executablePath = browserType.executablePath();
         expect(fs.existsSync(executablePath)).toBe(true);
         expect(fs.realpathSync(executablePath)).toBe(executablePath);
@@ -109,7 +109,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
     });
 
     describe('browserType.name', function() {
-      it('should work', async({server}) => {
+      it.pw('should work', async({server}) => {
         if (WEBKIT)
           expect(browserType.name()).toBe('webkit');
         else if (FFOX)
@@ -123,11 +123,11 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   });
 
   describe('Top-level requires', function() {
-    it('should require top-level Errors', async() => {
+    it.pw('should require top-level Errors', async() => {
       const Errors = require(path.join(utils.projectRoot(), '/lib/errors.js'));
       expect(Errors.TimeoutError).toBe(playwright.errors.TimeoutError);
     });
-    it('should require top-level DeviceDescriptors', async() => {
+    it.pw('should require top-level DeviceDescriptors', async() => {
       const Devices = require(path.join(utils.projectRoot(), '/lib/deviceDescriptors.js')).DeviceDescriptors;
       expect(Devices['iPhone 6']).toBeTruthy();
       expect(Devices['iPhone 6']).toBe(playwright.devices['iPhone 6']);
@@ -136,7 +136,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   });
 
   describe('Browser.isConnected', () => {
-    it('should set the browser connected state', async () => {
+    it.pw('should set the browser connected state', async () => {
       const browserServer = await browserType.launchServer({...defaultBrowserOptions });
       const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       expect(remote.isConnected()).toBe(true);
@@ -145,7 +145,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       await browserServer._checkLeaks();
       await browserServer.close();
     });
-    it('should throw when used after isConnected returns false', async({server}) => {
+    it.pw('should throw when used after isConnected returns false', async({server}) => {
       const browserServer = await browserType.launchServer({...defaultBrowserOptions });
       const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       const page = await remote.newPage();
@@ -160,7 +160,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   });
 
   describe('Browser.disconnect', function() {
-    it('should reject navigation when browser closes', async({server}) => {
+    it.pw('should reject navigation when browser closes', async({server}) => {
       server.setRoute('/one-style.css', () => {});
       const browserServer = await browserType.launchServer({...defaultBrowserOptions });
       const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
@@ -173,7 +173,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       await browserServer._checkLeaks();
       await browserServer.close();
     });
-    it('should reject waitForSelector when browser closes', async({server}) => {
+    it.pw('should reject waitForSelector when browser closes', async({server}) => {
       server.setRoute('/empty.html', () => {});
       const browserServer = await browserType.launchServer({...defaultBrowserOptions });
       const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
@@ -189,7 +189,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       await browserServer._checkLeaks();
       await browserServer.close();
     });
-    it('should throw if used after disconnect', async({server}) => {
+    it.pw('should throw if used after disconnect', async({server}) => {
       const browserServer = await browserType.launchServer({...defaultBrowserOptions });
       const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       const page = await remote.newPage();
@@ -199,7 +199,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       await browserServer._checkLeaks();
       await browserServer.close();
     });
-    it('should emit close events on pages and contexts', async({server}) => {
+    it.pw('should emit close events on pages and contexts', async({server}) => {
       const browserServer = await browserType.launchServer({...defaultBrowserOptions });
       const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       const context = await remote.newContext();
@@ -215,7 +215,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   });
 
   describe('Browser.close', function() {
-    it('should terminate network waiters', async({server}) => {
+    it.pw('should terminate network waiters', async({server}) => {
       const browserServer = await browserType.launchServer({...defaultBrowserOptions });
       const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       const newPage = await remote.newPage();
@@ -230,7 +230,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
         expect(message).not.toContain('Timeout');
       }
     });
-    it('should fire close event for all contexts', async(state, test) => {
+    it.pw('should fire close event for all contexts', async(state, test) => {
       const browser = await browserType.launch(defaultBrowserOptions);
       const context = await browser.newContext();
       let closed = false;
@@ -241,7 +241,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   });
 
   describe('browserType.launch |webSocket| option', function() {
-    it('should support the webSocket option', async() => {
+    it.pw('should support the webSocket option', async() => {
       const browserServer = await browserType.launchServer(defaultBrowserOptions);
       const browser = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       const browserContext = await browser.newContext();
@@ -254,7 +254,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       await browserServer._checkLeaks();
       await browserServer.close();
     });
-    it('should fire "disconnected" when closing with webSocket', async() => {
+    it.pw('should fire "disconnected" when closing with webSocket', async() => {
       const browserServer = await browserType.launchServer(defaultBrowserOptions);
       const browser = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       const disconnectedEventPromise = new Promise(resolve => browser.once('disconnected', resolve));
@@ -264,7 +264,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   });
 
   describe('browserType.connect', function() {
-    it.slow()('should be able to reconnect to a browser', async({server}) => {
+    it.pw.slow()('should be able to reconnect to a browser', async({server}) => {
       const browserServer = await browserType.launchServer(defaultBrowserOptions);
       {
         const browser = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
@@ -286,7 +286,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
   });
 
   describe('browserType.launchPersistentContext', function() {
-    it('userDataDir option', async({server}) => {
+    it.pw('userDataDir option', async({server}) => {
       const userDataDir = await makeUserDataDir();
       const options = Object.assign(defaultBrowserOptions);
       const browserContext = await browserType.launchPersistentContext(userDataDir, options);
@@ -298,7 +298,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       // This might throw. See https://github.com/GoogleChrome/puppeteer/issues/2778
       await removeUserDataDir(userDataDir);
     });
-    it.slow()('userDataDir option should restore state', async({server}) => {
+    it.pw.slow()('userDataDir option should restore state', async({server}) => {
       const userDataDir = await makeUserDataDir();
       const browserContext = await browserType.launchPersistentContext(userDataDir, defaultBrowserOptions);
       const page = await browserContext.newPage();
@@ -324,7 +324,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, p
       await removeUserDataDir(userDataDir2);
     });
     // See https://github.com/microsoft/playwright/issues/717
-    it.slow().fail(WIN && CHROMIUM)('userDataDir option should restore cookies', async({server}) => {
+    it.pw.slow().fail(WIN && CHROMIUM)('userDataDir option should restore cookies', async({server}) => {
       const userDataDir = await makeUserDataDir();
       const browserContext = await browserType.launchPersistentContext(userDataDir, defaultBrowserOptions);
       const page = await browserContext.newPage();

--- a/test/mouse.spec.js
+++ b/test/mouse.spec.js
@@ -27,7 +27,7 @@ function dimensions() {
 }
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, MAC}) {
   const {describe, xdescribe, fdescribe} = testRunner;
@@ -132,7 +132,7 @@ module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, 
         [200, 300]
       ]);
     });
-    it.skip(FFOX)('should work with mobile viewports and cross process navigations', async({browser, server}) => {
+    it.browser.skip(FFOX)('should work with mobile viewports and cross process navigations', async({browser, server}) => {
       // @see https://crbug.com/929806
       const context = await browser.newContext({ viewport: {width: 360, height: 640, isMobile: true} });
       const page = await context.newPage();

--- a/test/multiclient.spec.js
+++ b/test/multiclient.spec.js
@@ -26,7 +26,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('BrowserContext', function() {
-    it('should work across sessions', async () => {
+    it.pw('should work across sessions', async () => {
       const browserServer = await browserType.launchServer(defaultBrowserOptions);
       const browser1 = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       expect(browser1.contexts().length).toBe(0);
@@ -49,7 +49,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
   });
 
   describe('Browser.Events.disconnected', function() {
-    it.slow()('should be emitted when: browser gets closed, disconnected or underlying websocket gets closed', async () => {
+    it.pw.slow()('should be emitted when: browser gets closed, disconnected or underlying websocket gets closed', async () => {
       const browserServer = await browserType.launchServer(defaultBrowserOptions);
       const originalBrowser = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       const wsEndpoint = browserServer.wsEndpoint();
@@ -85,7 +85,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
   });
 
   describe('browserType.connect', function() {
-    it('should be able to connect multiple times to the same browser', async({server}) => {
+    it.pw('should be able to connect multiple times to the same browser', async({server}) => {
       const browserServer = await browserType.launchServer(defaultBrowserOptions);
       const browser1 = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       const browser2 = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
@@ -99,7 +99,7 @@ module.exports.describe = function({testRunner, expect, defaultBrowserOptions, b
       await browserServer._checkLeaks();
       await browserServer.close();
     });
-    it('should not be able to close remote browser', async() => {
+    it.pw('should not be able to close remote browser', async() => {
       const browserServer = await browserType.launchServer(defaultBrowserOptions);
       {
         const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -20,7 +20,7 @@ const path = require('path');
 const url = require('url');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, playwright, MAC, WIN, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -20,7 +20,7 @@ const path = require('path');
 const utils = require('./utils');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, MAC, WIN, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -21,7 +21,7 @@ const {waitEvent} = utils;
 const vm = require('vm');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, headless, playwright, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/permissions.spec.js
+++ b/test/permissions.spec.js
@@ -19,7 +19,7 @@ const fs = require('fs');
 const path = require('path');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, WEBKIT, FFOX}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/queryselector.spec.js
+++ b/test/queryselector.spec.js
@@ -19,7 +19,7 @@ const path = require('path');
 const zsSelectorEngineSource = require('../lib/generated/zsSelectorEngineSource');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, playwright, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/screenshot.spec.js
+++ b/test/screenshot.spec.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;
@@ -163,7 +163,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       });
       expect(screenshot).toBeGolden('screenshot-clip-odd-size.png');
     });
-    it.skip(FFOX)('should work with a mobile viewport', async({browser, server}) => {
+    it.browser.skip(FFOX)('should work with a mobile viewport', async({browser, server}) => {
       const context = await browser.newContext({ viewport: { width: 320, height: 480 }, isMobile: true });
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/overflow.html');
@@ -171,7 +171,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshot).toBeGolden('screenshot-mobile.png');
       await context.close();
     });
-    it.skip(FFOX)('should work with a mobile viewport and clip', async({browser, server}) => {
+    it.browser.skip(FFOX)('should work with a mobile viewport and clip', async({browser, server}) => {
       const context = await browser.newContext({viewport: { width: 320, height: 480 }, isMobile: true});
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/overflow.html');
@@ -179,7 +179,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       expect(screenshot).toBeGolden('screenshot-mobile-clip.png');
       await context.close();
     });
-    it.skip(FFOX)('should work with a mobile viewport and fullPage', async({browser, server}) => {
+    it.browser.skip(FFOX)('should work with a mobile viewport and fullPage', async({browser, server}) => {
       const context = await browser.newContext({viewport: { width: 320, height: 480 }, isMobile: true});
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/overflow-large.html');
@@ -376,7 +376,7 @@ module.exports.describe = function({testRunner, expect, product, FFOX, CHROMIUM,
       const screenshot = await elementHandle.screenshot();
       expect(screenshot).toBeGolden('screenshot-element-fractional.png');
     });
-    it.skip(FFOX)('should work with a mobile viewport', async({browser, server}) => {
+    it.browser.skip(FFOX)('should work with a mobile viewport', async({browser, server}) => {
       const context = await browser.newContext({viewport: { width: 320, height: 480, isMobile: true }});
       const page = await context.newPage();
       await page.goto(server.PREFIX + '/grid.html');

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -7,5 +7,5 @@
         "target": "ESNext",
         "strictNullChecks": false,
     },
-    "include": ["*.spec.js", "types.d.ts"]
+    "include": ["*.spec.js"]
   }

--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -18,7 +18,7 @@
 const utils = require('./utils');
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, product, playwright, FFOX, CHROMIUM, WEBKIT}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/test/workers.spec.js
+++ b/test/workers.spec.js
@@ -19,7 +19,7 @@ const utils = require('./utils');
 const { waitEvent } = utils;
 
 /**
- * @type {PageTestSuite}
+ * @type {TestSuite}
  */
 module.exports.describe = function({testRunner, expect, FFOX, CHROMIUM, WEBKIT, LINUX}) {
   const {describe, xdescribe, fdescribe} = testRunner;

--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -178,7 +178,7 @@ class Test {
   removeEnvironment(environment) {
     const index = this._environments.indexOf(environment);
     if (index === -1)
-      throw new Error(`Environment "${environment.name()}" cannot be removed because it was not added to the test "${test.fullName()}"`);
+      throw new Error(`Environment "${environment.name()}" cannot be removed because it was not added to the test "${this.fullName()}"`);
     this._environments.splice(index, 1);
     return this;
   }


### PR DESCRIPTION
All tests are now declared as:
- it - needs a page in a fresh context;
- it.context - needs a fresh context;
- it.browser - needs a launched browser;
- it.pw - does not need anything.

These can be mixed inside a test suite which allows to group tests by their semantic instead of environment setup. Some suites immediately make use of this.