### PR TITLE
fix(tests): emit the test output again

### DIFF
--- a/utils/testrunner/Reporter.js
+++ b/utils/testrunner/Reporter.js
@@ -190,7 +190,7 @@ class Reporter {
       console.log(`${prefix} ${colors.yellow('[MARKED AS FAILING]')} ${test.fullName()} (${formatLocation(test.location())})`);
     } else if (testRun.result() === 'timedout') {
       console.log(`${prefix} ${colors.red(`[TIMEOUT ${test.timeout()}ms]`)} ${test.fullName()} (${formatLocation(test.location())})`);
-      if (testRun.output) {
+      if (testRun.output && testRun.output.length) {
         console.log('  Output:');
         for (const line of testRun.output)
           console.log('  ' + line);
@@ -238,7 +238,7 @@ class Reporter {
           console.log(padLines(stack, 4));
         }
       }
-      if (testRun.output) {
+      if (testRun.output && testRun.output.length) {
         console.log('  Output:');
         for (const line of testRun.output)
           console.log('  ' + line);

--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -321,6 +321,10 @@ class TestRun {
   workerId() {
     return this._workerId;
   }
+
+  name() {
+    return this._test.name();
+  }
 }
 
 class Result {
@@ -461,7 +465,7 @@ class TestWorker {
 
     if (!testRun._error && !this._markTerminated(testRun)) {
       await this._willStartTestBody(testRun);
-      const { promise, terminate } = runUserCallback(test.body(), test.timeout(), [this._state, test]);
+      const { promise, terminate } = runUserCallback(test.body(), test.timeout(), [this._state, testRun]);
       this._runningTestTerminate = terminate;
       testRun._error = await promise;
       this._runningTestTerminate = null;
@@ -490,7 +494,7 @@ class TestWorker {
   async _runHook(testRun, hook, fullName, passTest = false) {
     await this._willStartHook(hook, fullName);
     const timeout = this._testPass._runner._timeout;
-    const { promise, terminate } = runUserCallback(hook.body, timeout, passTest ? [this._state, testRun.test()] : [this._state]);
+    const { promise, terminate } = runUserCallback(hook.body, timeout, passTest ? [this._state, testRun] : [this._state]);
     this._runningHookTerminate = terminate;
     let error = await promise;
     this._runningHookTerminate = null;

--- a/utils/testrunner/test/testrunner.spec.js
+++ b/utils/testrunner/test/testrunner.spec.js
@@ -262,12 +262,12 @@ module.exports.addTests = function({testRunner, expect}) {
       t.describe('suite1', () => {
         t.beforeAll(() => log.push('suite:beforeAll1'));
         t.beforeAll(() => log.push('suite:beforeAll2'));
-        t.beforeEach((state, test) => {
+        t.beforeEach((state, run) => {
           log.push('suite:beforeEach');
-          test.before(() => log.push('test:before1'));
-          test.before(() => log.push('test:before2'));
-          test.after(() => log.push('test:after1'));
-          test.after(() => log.push('test:after2'));
+          run.test().before(() => log.push('test:before1'));
+          run.test().before(() => log.push('test:before2'));
+          run.test().after(() => log.push('test:after1'));
+          run.test().after(() => log.push('test:after2'));
         });
         t.it('dos', () => log.push('test #2'));
         t.it('tres', () => log.push('test #3'));


### PR DESCRIPTION
The output was broken when something switched from a Test to a TestRun. Now the TestRun is passed into tests, instead of the Test.