### PR TITLE
fix(fill): make fill work with date/time inputs

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -233,13 +233,15 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async fill(value: string, options?: types.NavigatingActionWaitOptions): Promise<void> {
     assert(helper.isString(value), 'Value must be string. Found value "' + value + '" of type "' + (typeof value) + '"');
     await this._page._frameManager.waitForNavigationsCreatedBy(async () => {
-      const error = await this._evaluateInUtility(({ injected, node }, value) => injected.fill(node, value), value);
-      if (error)
-        throw new Error(error);
-      if (value)
-        await this._page.keyboard.insertText(value);
-      else
-        await this._page.keyboard.press('Delete');
+      const errorOrNeedsInput = await this._evaluateInUtility(({ injected, node }, value) => injected.fill(node, value), value);
+      if (typeof errorOrNeedsInput === 'string')
+        throw new Error(errorOrNeedsInput);
+      if (errorOrNeedsInput) {
+        if (value)
+          await this._page.keyboard.insertText(value);
+        else
+          await this._page.keyboard.press('Delete');
+      }
     }, options, true);
   }
 

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -921,7 +921,7 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
     });
     it('should throw on unsupported inputs', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/textarea.html');
-      for (const type of ['color', 'date']) {
+      for (const type of ['color', 'file']) {
         await page.$eval('input', (input, type) => input.setAttribute('type', type), type);
         let error = null;
         await page.fill('input', '').catch(e => error = e);
@@ -935,6 +935,37 @@ module.exports.describe = function({testRunner, expect, headless, playwright, FF
         await page.fill('input', 'text ' + type);
         expect(await page.evaluate(() => result)).toBe('text ' + type);
       }
+    });
+    it('should fill date input after clicking', async({page, server}) => {
+      await page.setContent('<input type=date>');
+      await page.click('input');
+      await page.fill('input', '2020-03-02');
+      expect(await page.$eval('input', input => input.value)).toBe('2020-03-02');
+    });
+    it.skip(WEBKIT)('should throw on incorrect date', async({page, server}) => {
+      await page.setContent('<input type=date>');
+      const error = await page.fill('input', '2020-13-05').catch(e => e);
+      expect(error.message).toBe('Malformed date "2020-13-05"');
+    });
+    it('should fill time input', async({page, server}) => {
+      await page.setContent('<input type=time>');
+      await page.fill('input', '13:15');
+      expect(await page.$eval('input', input => input.value)).toBe('13:15');
+    });
+    it.skip(WEBKIT)('should throw on incorrect time', async({page, server}) => {
+      await page.setContent('<input type=time>');
+      const error = await page.fill('input', '25:05').catch(e => e);
+      expect(error.message).toBe('Malformed time "25:05"');
+    });
+    it('should fill datetime-local input', async({page, server}) => {
+      await page.setContent('<input type=datetime-local>');
+      await page.fill('input', '2020-03-02T05:15');
+      expect(await page.$eval('input', input => input.value)).toBe('2020-03-02T05:15');
+    });
+    it.skip(WEBKIT || FFOX)('should throw on incorrect datetime-local', async({page, server}) => {
+      await page.setContent('<input type=datetime-local>');
+      const error = await page.fill('input', 'abc').catch(e => e);
+      expect(error.message).toBe('Malformed datetime-local "abc"');
     });
     it('should fill contenteditable', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/textarea.html');


### PR DESCRIPTION
fix(fill): make fill work with date/time inputs

Date/time inputs are locale-specific, and also do not work with insertText. We just set the value on them and emulate input/change events. Note that some browsers do not support these input types just yet.

References #1331.