### PR TITLE
chore: migrate node types to 10.17.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/debug": "0.0.31",
     "@types/extract-zip": "^1.6.2",
     "@types/mime": "^2.0.1",
-    "@types/node": "^8.10.34",
+    "@types/node": "^10.17.17",
     "@types/pngjs": "^3.4.0",
     "@types/proxy-from-env": "^1.0.0",
     "@types/rimraf": "^2.0.2",

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -128,7 +128,8 @@ export class Chromium implements BrowserType<CRBrowser> {
 
     let transport: PipeTransport | undefined = undefined;
     let browserServer: BrowserServer | undefined = undefined;
-    transport = new PipeTransport(launchedProcess.stdio[3] as NodeJS.WritableStream, launchedProcess.stdio[4] as NodeJS.ReadableStream);
+    const stdio = launchedProcess.stdio as unknown as [NodeJS.ReadableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.ReadableStream];
+    transport = new PipeTransport(stdio[3], stdio[4]);
     browserServer = new BrowserServer(launchedProcess, gracefullyClose, launchType === 'server' ? wrapTransportWithWebSocket(transport, port) : null);
     return { browserServer, transport, downloadsPath };
   }

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -128,7 +128,8 @@ export class WebKit implements BrowserType<WKBrowser> {
     // For local launch scenario close will terminate the browser process.
     let transport: ConnectionTransport | undefined = undefined;
     let browserServer: BrowserServer | undefined = undefined;
-    transport = new PipeTransport(launchedProcess.stdio[3] as NodeJS.WritableStream, launchedProcess.stdio[4] as NodeJS.ReadableStream);
+    const stdio = launchedProcess.stdio as unknown as [NodeJS.ReadableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.ReadableStream];
+    transport = new PipeTransport(stdio[3], stdio[4]);
     browserServer = new BrowserServer(launchedProcess, gracefullyClose, launchType === 'server' ? wrapTransportWithWebSocket(transport, port || 0) : null);
     return { browserServer, transport, downloadsPath };
   }


### PR DESCRIPTION
We actually require minimum node version 10, and we want to compile
against types for v10.

This patch migrates node type definitions to v10.