### PR TITLE
feat(testrunner): catch delegate errors

### DIFF
--- a/utils/testrunner/Location.js
+++ b/utils/testrunner/Location.js
@@ -15,7 +15,10 @@
  * limitations under the License.
  */
 
- const path = require('path');
+const path = require('path');
+
+// Hack for our own tests.
+const testRunnerTestFile = path.join(__dirname, 'test', 'testrunner.spec.js');
 
 class Location {
   constructor() {
@@ -69,7 +72,7 @@ class Location {
       if (!match)
         return null;
       const filePath = match[1];
-      if (filePath === __filename || filePath.startsWith(ignorePrefix))
+      if (filePath === __filename || (filePath.startsWith(ignorePrefix) && filePath !== testRunnerTestFile))
         continue;
 
       location._filePath = filePath;

--- a/utils/testrunner/Matchers.js
+++ b/utils/testrunner/Matchers.js
@@ -102,8 +102,6 @@ function stringFormatter(received, expected) {
 }
 
 function objectFormatter(received, expected) {
-  const receivedLines = received.split('\n');
-  const expectedLines = expected.split('\n');
   const encodingMap = new Map();
   const decodingMap = new Map();
 
@@ -142,8 +140,12 @@ function objectFormatter(received, expected) {
     if (type === 1)
       return lines.map(line => '+   ' + colors.bgGreen.black(line));
     return lines.map(line => '    ' + line);
-  }).flat().join('\n');
-  return `Received:\n${highlighted}`;
+  });
+
+  const flattened = [];
+  for (const list of highlighted)
+    flattened.push(...list);
+  return `Received:\n${flattened.join('\n')}`;
 }
 
 function toBeFormatter(received, expected) {

--- a/utils/testrunner/test/testrunner.spec.js
+++ b/utils/testrunner/test/testrunner.spec.js
@@ -822,6 +822,23 @@ module.exports.addTests = function({describe, fdescribe, xdescribe, it, xit, fit
       ]);
       expect(result.result).toBe('ok');
     });
+    it('should crash when onStarted throws', async() => {
+      const t = new Runner({
+        onStarted: () => { throw 42; },
+      });
+      const result = await t.run();
+      expect(result.ok()).toBe(false);
+      expect(result.message).toBe('INTERNAL ERROR: 42');
+    });
+    it('should crash when onFinished throws', async() => {
+      const t = new Runner({
+        onFinished: () => { throw new Error('42'); },
+      });
+      const result = await t.run();
+      expect(result.ok()).toBe(false);
+      expect(result.message).toBe('INTERNAL ERROR');
+      expect(result.result).toBe('crashed');
+    });
   });
 };
 


### PR DESCRIPTION
This ensures we get a proper error when something goes wrong. Should also help with producing the right error code in the case of internal error.

Drive-by: fix location issue which manifests on the bots.
Drive-by: remove the use of Array.prototype.flat to make it work on bots.