### PR TITLE
fix(firefox): disable captive portal service

### DIFF
--- a/browser_patches/firefox/preferences/playwright.cfg
+++ b/browser_patches/firefox/preferences/playwright.cfg
@@ -10,6 +10,7 @@ pref("browser.library.activity-stream.enabled", false);
 pref("browser.search.geoSpecificDefaults", false);
 pref("browser.search.geoSpecificDefaults.url", "");
 pref("captivedetect.canonicalURL", "");
+pref("network.captive-portal-service.enabled", false);
 pref("network.connectivity-service.enabled", false);
 pref("browser.newtabpage.activity-stream.asrouter.providers.snippets", "");
 


### PR DESCRIPTION
The URL has already been set to an emtpy string, but the service kept complaining about it.