### PR TITLE
feat(api): wait for popups and downloads when performing actions

### DIFF
--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -134,6 +134,10 @@ export class CRBrowser extends BrowserBase {
       const opener = targetInfo.openerId ? this._crPages.get(targetInfo.openerId) || null : null;
       const crPage = new CRPage(session, targetInfo.targetId, context, opener);
       this._crPages.set(targetInfo.targetId, crPage);
+      if (opener && opener._initializedPage) {
+        for (const signalBarrier of opener._initializedPage._frameManager._signalBarriers)
+          signalBarrier.addPopup(crPage.pageOrError());
+      }
       crPage.pageOrError().then(() => {
         this._firstPageCallback();
         context.emit(CommonEvents.BrowserContext.Page, crPage._page);

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -55,7 +55,7 @@ export class FrameExecutionContext extends js.ExecutionContext {
   }
 
   async _doEvaluateInternal(returnByValue: boolean, waitForNavigations: boolean, pageFunction: string | Function, ...args: any[]): Promise<any> {
-    return await this.frame._page._frameManager.waitForNavigationsCreatedBy(async () => {
+    return await this.frame._page._frameManager.waitForSignalsCreatedBy(async () => {
       return this._delegate.evaluate(this, returnByValue, pageFunction, ...args);
     }, Number.MAX_SAFE_INTEGER, waitForNavigations ? undefined : { waitUntil: 'nowait' });
   }
@@ -227,7 +227,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     if (!force)
       await this._waitForHitTargetAt(point, deadline);
 
-    await this._page._frameManager.waitForNavigationsCreatedBy(async () => {
+    await this._page._frameManager.waitForSignalsCreatedBy(async () => {
       let restoreModifiers: input.Modifier[] | undefined;
       if (options && options.modifiers)
         restoreModifiers = await this._page.keyboard._ensureModifiers(options.modifiers);
@@ -269,7 +269,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       if (option.index !== undefined)
         assert(helper.isNumber(option.index), 'Indices must be numbers. Found index "' + option.index + '" of type "' + (typeof option.index) + '"');
     }
-    return await this._page._frameManager.waitForNavigationsCreatedBy<string[]>(async () => {
+    return await this._page._frameManager.waitForSignalsCreatedBy<string[]>(async () => {
       return this._evaluateInUtility(({ injected, node }, selectOptions) => injected.selectOptions(node, selectOptions), selectOptions);
     }, deadline, options);
   }
@@ -277,7 +277,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async fill(value: string, options?: types.NavigatingActionWaitOptions): Promise<void> {
     assert(helper.isString(value), 'Value must be string. Found value "' + value + '" of type "' + (typeof value) + '"');
     const deadline = this._page._timeoutSettings.computeDeadline(options);
-    await this._page._frameManager.waitForNavigationsCreatedBy(async () => {
+    await this._page._frameManager.waitForSignalsCreatedBy(async () => {
       const errorOrNeedsInput = await this._evaluateInUtility(({ injected, node }, value) => injected.fill(node, value), value);
       if (typeof errorOrNeedsInput === 'string')
         throw new Error(errorOrNeedsInput);
@@ -323,7 +323,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
         filePayloads.push(item);
       }
     }
-    await this._page._frameManager.waitForNavigationsCreatedBy(async () => {
+    await this._page._frameManager.waitForSignalsCreatedBy(async () => {
       await this._page._delegate.setInputFiles(this as any as ElementHandle<HTMLInputElement>, filePayloads);
     }, deadline, options);
   }
@@ -341,7 +341,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
   async type(text: string, options?: { delay?: number } & types.NavigatingActionWaitOptions) {
     const deadline = this._page._timeoutSettings.computeDeadline(options);
-    await this._page._frameManager.waitForNavigationsCreatedBy(async () => {
+    await this._page._frameManager.waitForSignalsCreatedBy(async () => {
       await this.focus();
       await this._page.keyboard.type(text, options);
     }, deadline, options, true);
@@ -349,7 +349,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
   async press(key: string, options?: { delay?: number } & types.NavigatingActionWaitOptions) {
     const deadline = this._page._timeoutSettings.computeDeadline(options);
-    await this._page._frameManager.waitForNavigationsCreatedBy(async () => {
+    await this._page._frameManager.waitForSignalsCreatedBy(async () => {
       await this.focus();
       await this._page.keyboard.press(key, options);
     }, deadline, options, true);

--- a/src/download.ts
+++ b/src/download.ts
@@ -39,6 +39,8 @@ export class Download {
     this._url = url;
     this._finishedCallback = () => {};
     this._finishedPromise = new Promise(f => this._finishedCallback = f);
+    for (const barrier of this._page._frameManager._signalBarriers)
+      barrier.addDownload();
     this._page.emit(Events.Page.Download, this);
     page._browserContext._downloads.add(this);
     this._acceptDownloads = !!this._page._browserContext._options.acceptDownloads;

--- a/src/firefox/ffBrowser.ts
+++ b/src/firefox/ffBrowser.ts
@@ -129,6 +129,10 @@ export class FFBrowser extends BrowserBase {
     const ffPage = new FFPage(session, context, opener);
     this._ffPages.set(targetId, ffPage);
 
+    if (opener && opener._initializedPage) {
+      for (const signalBarrier of opener._initializedPage._frameManager._signalBarriers)
+        signalBarrier.addPopup(ffPage.pageOrError());
+    }
     ffPage.pageOrError().then(async () => {
       this._firstPageCallback();
       const page = ffPage._page;
@@ -200,7 +204,7 @@ export class FFBrowserContext extends BrowserContextBase {
   }
 
   pages(): Page[] {
-    return this._ffPages().map(ffPage => ffPage._initializedPage()).filter(pageOrNull => !!pageOrNull) as Page[];
+    return this._ffPages().map(ffPage => ffPage._initializedPage).filter(pageOrNull => !!pageOrNull) as Page[];
   }
 
   async newPage(): Promise<Page> {

--- a/src/webkit/wkBrowser.ts
+++ b/src/webkit/wkBrowser.ts
@@ -128,6 +128,10 @@ export class WKBrowser extends BrowserBase {
     const wkPage = new WKPage(context, pageProxySession, opener || null);
     this._wkPages.set(pageProxyId, wkPage);
 
+    if (opener && opener._initializedPage) {
+      for (const signalBarrier of opener._initializedPage._frameManager._signalBarriers)
+        signalBarrier.addPopup(wkPage.pageOrError());
+    }
     wkPage.pageOrError().then(async () => {
       this._firstPageCallback();
       const page = wkPage._page;
@@ -216,7 +220,7 @@ export class WKBrowserContext extends BrowserContextBase {
   }
 
   pages(): Page[] {
-    return this._wkPages().map(wkPage => wkPage._initializedPage()).filter(pageOrNull => !!pageOrNull) as Page[];
+    return this._wkPages().map(wkPage => wkPage._initializedPage).filter(pageOrNull => !!pageOrNull) as Page[];
   }
 
   async newPage(): Promise<Page> {

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -630,7 +630,6 @@ describe('Events.BrowserContext.Page', function() {
       context.waitForEvent('page'),
       page.goto(server.PREFIX + '/popup/window-open.html')
     ]);
-    // The url is still about:blank in FF when 'page' event is fired.
     expect(popup.url()).toBe(server.PREFIX + '/popup/popup.html');
     expect(await popup.opener()).toBe(page);
     expect(await page.opener()).toBe(null);

--- a/test/popup.spec.js
+++ b/test/popup.spec.js
@@ -217,6 +217,20 @@ describe('Page.Events.Popup', function() {
     expect(popup).toBeTruthy();
     await context.close();
   });
+  it('should emit for immediately closed popups', async({browser, server}) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(server.EMPTY_PAGE);
+    const [popup] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.evaluate(() => {
+        const win = window.open(window.location.href);
+        win.close();
+      }),
+    ]);
+    expect(popup).toBeTruthy();
+    await context.close();
+  });
   it('should be able to capture alert', async({browser}) => {
     const context = await browser.newContext();
     const page = await context.newPage();


### PR DESCRIPTION
Possible follow up: wait for filechoosers, but it needs the `setInterceptFilechooser` rework.
