### PR TITLE
feat: nicer error message for page.addScriptTag

### DIFF
--- a/src/firefox/ffExecutionContext.ts
+++ b/src/firefox/ffExecutionContext.ts
@@ -135,13 +135,13 @@ export class FFExecutionContext implements js.ExecutionContextDelegate {
   }
 }
 
-function checkException(exceptionDetails?: any) {
-  if (exceptionDetails) {
-    if (exceptionDetails.value)
-      throw new Error('Evaluation failed: ' + JSON.stringify(exceptionDetails.value));
-    else
-      throw new Error('Evaluation failed: ' + exceptionDetails.text + '\n' + exceptionDetails.stack);
-  }
+function checkException(exceptionDetails?: Protocol.Runtime.ExceptionDetails) {
+  if (!exceptionDetails)
+    return;
+  if (exceptionDetails.value)
+    throw new Error('Evaluation failed: ' + JSON.stringify(exceptionDetails.value));
+  else
+    throw new Error('Evaluation failed: ' + exceptionDetails.text + '\n' + exceptionDetails.stack);
 }
 
 export function deserializeValue({unserializableValue, value}: Protocol.Runtime.RemoteObject) {

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -580,7 +580,7 @@ export class Frame {
         script.type = options.type;
       const promise = new Promise((res, rej) => {
         script.onload = res;
-        script.onerror = rej;
+        script.onerror = e => rej(typeof e === 'string' ? new Error(e) : new Error(`Failed to load script at ${script.src}`));
       });
       document.head.appendChild(script);
       await promise;

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -654,6 +654,12 @@ describe('Page.addScriptTag', function() {
     await page.addScriptTag({ url: server.CROSS_PROCESS_PREFIX + '/injectedfile.js' }).catch(e => error = e);
     expect(error).toBeTruthy();
   });
+  it('should throw a nice error when the request fails', async({page, server}) => {
+    await page.goto(server.EMPTY_PAGE);
+    const url = server.PREFIX + '/this_does_not_exist.js';
+    const error = await page.addScriptTag({url}).catch(e => e);
+    expect(error.message).toContain(url);
+  });
 });
 
 describe('Page.addStyleTag', function() {


### PR DESCRIPTION
When `page.addScriptTag` failed it would just say "Evaluation Error: Event". This was unhelpful.