### PR TITLE
fix(removeFrameSession): Prevent errors when frame does not exist

### DIFF
--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -104,8 +104,8 @@ export class CRPage implements PageDelegate {
       return;
     // Frame id equals target id.
     const frame = this._page._frameManager.frame(targetId);
-    assert(frame);
-    this._page._frameManager.removeChildFramesRecursively(frame);
+    if (frame)
+      this._page._frameManager.removeChildFramesRecursively(frame);
     frameSession.dispose();
     this._sessions.delete(targetId);
   }


### PR DESCRIPTION
When navigating away from the page loaded in `goto`, the frame no longer
exists. Page.removeFrameSession is called and throws an error. Instead
of calling the helper.assert method, moved removeChildFramesRecursively
into a conditional.

closes #1762