### PR TITLE
feat: introduce `page.on('crash')` event

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -632,6 +632,7 @@ page.removeListener('request', logRequest);
 <!-- GEN:toc -->
 - [event: 'close'](#event-close-1)
 - [event: 'console'](#event-console)
+- [event: 'crash'](#event-crash)
 - [event: 'dialog'](#event-dialog)
 - [event: 'domcontentloaded'](#event-domcontentloaded)
 - [event: 'download'](#event-download)
@@ -725,6 +726,10 @@ page.on('console', msg => {
 });
 page.evaluate(() => console.log('hello', 5, {foo: 'bar'}));
 ```
+
+#### event: 'crash'
+
+Emitted when the page crashes. Browser pages might crash if they try to allocate too much memory.
 
 #### event: 'dialog'
 - <[Dialog]>

--- a/src/chromium/crConnection.ts
+++ b/src/chromium/crConnection.ts
@@ -142,7 +142,7 @@ export class CRSession extends EventEmitter {
     this.once = super.once;
   }
 
-  markAsCrashed() {
+  _markAsCrashed() {
     this._crashed = true;
   }
 

--- a/src/chromium/crConnection.ts
+++ b/src/chromium/crConnection.ts
@@ -121,6 +121,7 @@ export class CRSession extends EventEmitter {
   private readonly _targetType: string;
   private readonly _sessionId: string;
   private readonly _rootSessionId: string;
+  private _crashed: boolean = false;
   on: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
   addListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
   off: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
@@ -141,10 +142,16 @@ export class CRSession extends EventEmitter {
     this.once = super.once;
   }
 
+  markAsCrashed() {
+    this._crashed = true;
+  }
+
   async send<T extends keyof Protocol.CommandParameters>(
     method: T,
     params?: Protocol.CommandParameters[T]
   ): Promise<Protocol.CommandReturnValues[T]> {
+    if (this._crashed)
+      throw new Error('Target crashed');
     if (!this._connection)
       throw new Error(`Protocol error (${method}): Session closed. Most likely the ${this._targetType} has been closed.`);
     const id = this._connection._rawSend(this._sessionId, method, params);

--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -613,7 +613,8 @@ class FrameSession {
     this._page.emit(Events.Page.PageError, exceptionToError(exceptionDetails));
   }
 
-  _onTargetCrashed() {
+  async _onTargetCrashed() {
+    this._client.markAsCrashed();
     this._page._didCrash();
   }
 

--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -614,7 +614,7 @@ class FrameSession {
   }
 
   async _onTargetCrashed() {
-    this._client.markAsCrashed();
+    this._client._markAsCrashed();
     this._page._didCrash();
   }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -31,6 +31,7 @@ export const Events = {
 
   Page: {
     Close: 'close',
+    Crash: 'crash',
     Console: 'console',
     Dialog: 'dialog',
     Download: 'download',

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -251,6 +251,7 @@ export class FFPage implements PageDelegate {
   }
 
   async _onCrashed(event: Protocol.Page.crashedPayload) {
+    this._session.markAsCrashed();
     this._page._didCrash();
   }
 

--- a/src/page.ts
+++ b/src/page.ts
@@ -159,10 +159,7 @@ export class Page extends ExtendedEventEmitter {
   }
 
   _didCrash() {
-    const error = new Error('Page crashed!');
-    // Do not report node.js stack.
-    error.stack = 'Error: ' + error.message; // Stack is supposed to contain error message as the first line.
-    this.emit('error', error);
+    this.emit(Events.Page.Crash);
   }
 
   _didDisconnect() {

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -194,8 +194,10 @@ export class WKPage implements PageDelegate {
     } else if (this._session.sessionId === targetId) {
       this._session.dispose();
       helper.removeEventListeners(this._sessionListeners);
-      if (crashed)
+      if (crashed) {
+        this._session.markAsCrashed();
         this._page._didCrash();
+      }
     }
   }
 


### PR DESCRIPTION
Currently, whenever the page crashes, it emits an `'error'` event.
Error event is a special type of event in node.js; if unhandled,
it crashes the process.

Instead of emitting `'error'` event, this patch switches to emitting
`'crash'` event. Playwright users are free to handle the event
however they like, or just to ignore it.