### PR TITLE
chore: generate README.md for playwright package on prepublish

### DIFF
--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -5,7 +5,8 @@
   "repository": "github:Microsoft/playwright",
   "main": "index.js",
   "scripts": {
-    "install": "node install.js"
+    "install": "node install.js",
+    "prepublishOnly": "cp ../../README.md ."
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -70,8 +70,6 @@ async function run() {
       await source.save();
       changedFiles = true;
     }
-
-    await readme.saveAs(path.join(PROJECT_DIR, 'packages', 'playwright', 'README.md'));
   }
 
   // Report results.


### PR DESCRIPTION
This will ensure that `playwright` package always has a readme.

Fix #1798