### PR TITLE
devops: always get BUILD_NUMBER from upstream

### DIFF
--- a/browser_patches/export.sh
+++ b/browser_patches/export.sh
@@ -35,17 +35,20 @@ fi
 
 # FRIENDLY_CHECKOUT_PATH is used only for logging.
 FRIENDLY_CHECKOUT_PATH="";
+BUILD_NUMBER_UPSTREAM_URL=""
 CHECKOUT_PATH=""
 EXPORT_PATH=""
 if [[ ("$1" == "firefox") || ("$1" == "firefox/") || ("$1" == "ff") ]]; then
   FRIENDLY_CHECKOUT_PATH="//browser_patches/firefox/checkout";
   CHECKOUT_PATH="$PWD/firefox/checkout"
   EXPORT_PATH="$PWD/firefox/"
+  BUILD_NUMBER_UPSTREAM_URL="https://raw.githubusercontent.com/microsoft/playwright/master/browser_patches/firefox/BUILD_NUMBER"
   source "./firefox/UPSTREAM_CONFIG.sh"
 elif [[ ("$1" == "webkit") || ("$1" == "webkit/") || ("$1" == "wk") ]]; then
   FRIENDLY_CHECKOUT_PATH="//browser_patches/webkit/checkout";
   CHECKOUT_PATH="$PWD/webkit/checkout"
   EXPORT_PATH="$PWD/webkit/"
+  BUILD_NUMBER_UPSTREAM_URL="https://raw.githubusercontent.com/microsoft/playwright/master/browser_patches/webkit/BUILD_NUMBER"
   source "./webkit/UPSTREAM_CONFIG.sh"
 else
   echo ERROR: unknown browser to export - "$1"
@@ -111,7 +114,7 @@ CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 NEW_BASE_REVISION=$(git merge-base $REMOTE_BROWSER_UPSTREAM/$BASE_BRANCH $CURRENT_BRANCH)
 NEW_DIFF=$(git diff --diff-algorithm=myers --full-index $NEW_BASE_REVISION $CURRENT_BRANCH)
 # Increment BUILD_NUMBER
-BUILD_NUMBER=$(cat $EXPORT_PATH/BUILD_NUMBER)
+BUILD_NUMBER=$(curl ${BUILD_NUMBER_UPSTREAM_URL})
 BUILD_NUMBER=$((BUILD_NUMBER+1))
 if [[ "$NEW_BASE_REVISION" == "$BASE_REVISION" && "$OLD_DIFF" == "$NEW_DIFF" ]]; then
   echo "No changes"


### PR DESCRIPTION
This makes `export.sh` indepotent.