### PR TITLE
feat(testrunner): support `--repeat` CLI flag to repeat tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -197,6 +197,13 @@ function collect(browserNames) {
     testRunner.focusMatchingTests(new RegExp(filter, 'i'));
   }
 
+  const repeatArgIndex = process.argv.indexOf('--repeat');
+  if (repeatArgIndex !== -1) {
+    const repeat = parseInt(process.argv[repeatArgIndex + 1], 10);
+    if (!isNaN(repeat))
+      testRunner.repeatAll(repeat);
+  }
+
   return testRunner;
 }
 

--- a/utils/testrunner/TestCollector.js
+++ b/utils/testrunner/TestCollector.js
@@ -167,6 +167,7 @@ class TestCollector {
     this._api = {};
 
     this._currentSuite = new Suite(null, '', new Location());
+    this._rootSuite = this._currentSuite;
 
     this._api.describe = specBuilder(this._suiteModifiers, this._suiteAttributes, (specs, name, suiteCallback, ...suiteArgs) => {
       const location = Location.getCallerLocation();
@@ -222,6 +223,10 @@ class TestCollector {
 
   suites() {
     return this._suites;
+  }
+
+  rootSuite() {
+    return this._rootSuite;
   }
 }
 

--- a/utils/testrunner/index.js
+++ b/utils/testrunner/index.js
@@ -89,6 +89,10 @@ class DefaultTestRunner {
     }
   }
 
+  repeatAll(repeatCount) {
+    this._repeater.repeat(this._collector.rootSuite(), repeatCount);
+  }
+
   async run() {
     let reporter = null;
 


### PR DESCRIPTION
This allows you to run `npm run cunit -- --repeat 10` to run
tests multiple times.