### PR TITLE
fix(webkit): allow fufilling requests to redirects

### DIFF
--- a/src/webkit/wkInterceptableRequest.ts
+++ b/src/webkit/wkInterceptableRequest.ts
@@ -69,7 +69,7 @@ export class WKInterceptableRequest implements network.RouteDelegate {
     await this._interceptedPromise;
 
     const base64Encoded = !!response.body && !helper.isString(response.body);
-    const responseBody = response.body ? (base64Encoded ? response.body.toString('base64') : response.body as string) : undefined;
+    const responseBody = response.body ? (base64Encoded ? response.body.toString('base64') : response.body as string) : '';
 
     const responseHeaders: { [s: string]: string; } = {};
     if (response.headers) {

--- a/test/interception.spec.js
+++ b/test/interception.spec.js
@@ -368,8 +368,7 @@ describe('Page.route', function() {
     expect(response.ok()).toBe(true);
     expect(intercepted).toBe(true);
   });
-  // WebKit crashes. Firefox succeeds, but then fails to close.
-  it.fail(FFOX || WEBKIT)('should create a redirect', async({page, server}) => {
+  it('should create a redirect', async({page, server}) => {
     await page.goto(server.PREFIX + '/empty.html');
     await page.route('**/*', async(route, request) => {
       if (request.url() !== server.PREFIX + '/redirect_this')


### PR DESCRIPTION
I enabled it for firefox as well. It looks like the failure there is unrelated.