### PR TITLE
feat(tests): run navigation tests inside an iframe

### DIFF
--- a/test/assets/child-frame-environment.html
+++ b/test/assets/child-frame-environment.html
@@ -1,0 +1,19 @@
+<style>
+  body, html {
+    margin: 0;
+    position: relative;
+  }
+  iframe {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    width: 100%;
+    height: 100%;
+  }
+</style>
+<iframe></iframe>

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -81,6 +81,25 @@ customEnvironment.afterEach(async (state, testRun) => {
   }
 });
 
+const mainFrameEnvironment = new Environment('MainFrame');
+mainFrameEnvironment.beforeEach(async state => {
+  state.frame = state.page.mainFrame();
+});
+mainFrameEnvironment.afterEach(async state => {
+  delete state.frame;
+});
+
+const childFrameEnvironment = new Environment('ChildFrame');
+childFrameEnvironment.beforeEach(async state => {
+  await state.page.goto(state.server.PREFIX + '/child-frame-environment.html');
+  if (state.page.frames().length !== 2)
+    throw new Error('Failed to setup child frame environment');
+  state.frame = state.page.frames()[1];
+});
+childFrameEnvironment.afterEach(async state => {
+  delete state.frame;
+});
+
 function valueFromEnv(name, defaultValue) {
   if (!(name in process.env))
     return defaultValue;
@@ -168,7 +187,6 @@ module.exports = {
         './jshandle.spec.js',
         './keyboard.spec.js',
         './mouse.spec.js',
-        './navigation.spec.js',
         './network.spec.js',
         './page.spec.js',
         './queryselector.spec.js',
@@ -181,6 +199,24 @@ module.exports = {
         './permissions.spec.js',
       ],
       environments: [customEnvironment,  'page'],
+    },
+
+    {
+      files: [
+        './navigation.spec.js',
+      ],
+      environments: [customEnvironment,  'page', mainFrameEnvironment],
+    },
+
+    {
+      files: [
+        './navigation.spec.js',
+      ],
+      title: '[IFRAME]',
+      globals: {
+        IFRAME: true,
+      },
+      environments: [customEnvironment,  'page', childFrameEnvironment],
     },
 
     {

--- a/test/test.js
+++ b/test/test.js
@@ -162,6 +162,11 @@ function collect(browserNames) {
       testRunner.collector().useEnvironment(browserTypeEnvironment);
 
       for (const spec of config.specs || []) {
+        for (const [key, value] of Object.entries(spec.globals || {}))
+          global[key] = undefined;
+      }
+
+      for (const spec of config.specs || []) {
         const skip = spec.browsers && !spec.browsers.includes(browserName);
         (skip ? xdescribe : describe)(spec.title || '', () => {
           for (const e of spec.environments || ['page']) {
@@ -174,10 +179,14 @@ function collect(browserNames) {
               testRunner.collector().useEnvironment(e);
             }
           }
+          for (const [key, value] of Object.entries(spec.globals || {}))
+            global[key] = value;
           for (const file of spec.files || []) {
             require(file);
             delete require.cache[require.resolve(file)];
           }
+          for (const [key, value] of Object.entries(spec.globals || {}))
+            global[key] = undefined;
         });
       }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -38,13 +38,14 @@ const utils = module.exports = {
   },
 
   /**
-   * @param {!Page} page
+   * @param {!Page | !Frame} pageOrFrame
    * @param {string} frameId
    * @param {string} url
    * @return {!Playwright.Frame}
    */
-  attachFrame: async function(page, frameId, url) {
-    const handle = await page.evaluateHandle(async ({ frameId, url }) => {
+  attachFrame: async function(pageOrFrame, frameId, url) {
+    const frame = typeof pageOrFrame.mainFrame === 'function' ? pageOrFrame.mainFrame() : pageOrFrame;
+    const handle = await frame.evaluateHandle(async ({ frameId, url }) => {
       const frame = document.createElement('iframe');
       frame.src = url;
       frame.id = frameId;
@@ -56,11 +57,12 @@ const utils = module.exports = {
   },
 
   /**
-   * @param {!Page} page
+   * @param {!Page | !Frame} pageOrFrame
    * @param {string} frameId
    */
-  detachFrame: async function(page, frameId) {
-    await page.evaluate(frameId => {
+  detachFrame: async function(pageOrFrame, frameId) {
+    const frame = typeof pageOrFrame.mainFrame === 'function' ? pageOrFrame.mainFrame() : pageOrFrame;
+    await frame.evaluate(frameId => {
       document.getElementById(frameId).remove();
     }, frameId);
   },


### PR DESCRIPTION
- This only affects the `navigation.spec.js` for now, as it is the easiest to convert.
- All the tests are run with `state.frame` set to the main frame, and then once again with `state.frame` set to the child frame.
- There is a way to opt-out with `.skip(IFRAME)`.

References #1677.