### PR TITLE
fix(click): force any hover effects before waiting for hit target

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -220,6 +220,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const point = position ? await this._offsetPoint(position) : await this._clickablePoint();
     point.x = (point.x * 100 | 0) / 100;
     point.y = (point.y * 100 | 0) / 100;
+    await this._page.mouse.move(point.x, point.y);  // Force any hover effects before waiting for hit target.
     if (!force)
       await this._waitForHitTargetAt(point, deadline);
 


### PR DESCRIPTION
This way, any on-hover animations or click blockers will be accounted for.

References #1808.