### PR TITLE
devops: start releasing from Github Actions

### DIFF
--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -1,0 +1,27 @@
+name: "canary"
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  CI: true
+
+jobs:
+  publish-canary:
+    name: "publish"
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 10
+        registry-url: 'https://registry.npmjs.org'
+    - uses: microsoft/playwright-github-action@v1
+    - run: npm ci
+    - run: node utils/update_version.js --next
+    - run: utils/publish_all_packages.sh --tip-of-tree
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,3 @@ jobs:
   include:
   - node_js: '12'
 
-before_deploy:
-  - node utils/update_version.js --next
-
-deploy:
-  skip_cleanup: true
-  provider: script
-  script: utils/publish_all_packages.sh --tip-of-tree
-  on:
-    branch: master


### PR DESCRIPTION
This patch:
- removes releasing from Travis CI
- sets up a new GH Action that releases @next version from tip-of-tree

Once this GH Action proves to be working, we'll setup a `publish_release.yml`
workflow that will be triggered only by **release** github events
and that will publish released version with `LATEST` tag.

NOTE: this workflow does not actually run publishing - we're doing
`--dry-run` for now to see how it works in
`//utils/publish_all_packages.sh`.