### PR TITLE
devops: introduce release publishing workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,25 @@
+name: "release"
+
+on:
+  release:
+    types: [created]
+
+env:
+  CI: true
+
+jobs:
+  publish-canary:
+    name: "publish"
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 10
+        registry-url: 'https://registry.npmjs.org'
+    - uses: microsoft/playwright-github-action@v1
+    - run: npm ci
+    - run: utils/publish_all_packages.sh --release
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+


### PR DESCRIPTION
This workflow is based on the Github Actions docs: [publishing node.js
packages](https://help.github.com/en/actions/language-and-framework-guides/publishing-nodejs-packages)

It should be triggered once we create a github release.
It's unclear how to test this workflow, so I tried to re-use as much
code from `publish_canary.yml` as possible.