### PR TITLE
devops: make README.md to always reflect tip-of-tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # 🎭 Playwright
-[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) <!-- GEN:chromium-version-badge-if-release -->[![Chromium version](https://img.shields.io/badge/chromium-83.0.4101.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge-if-release -->[![Firefox version](https://img.shields.io/badge/firefox-75.0b8-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> [![WebKit version](https://img.shields.io/badge/webkit-13.0.4-blue.svg?logo=safari)](https://webkit.org/) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://join.slack.com/t/playwright/shared_invite/enQtOTEyMTUxMzgxMjIwLThjMDUxZmIyNTRiMTJjNjIyMzdmZDA3MTQxZWUwZTFjZjQwNGYxZGM5MzRmNzZlMWI5ZWUyOTkzMjE5Njg1NDg)
+[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-84.0.4117.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-76.0b5-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> [![WebKit version](https://img.shields.io/badge/webkit-13.0.4-blue.svg?logo=safari)](https://webkit.org/) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://join.slack.com/t/playwright/shared_invite/enQtOTEyMTUxMzgxMjIwLThjMDUxZmIyNTRiMTJjNjIyMzdmZDA3MTQxZWUwZTFjZjQwNGYxZGM5MzRmNzZlMWI5ZWUyOTkzMjE5Njg1NDg)
 
-###### [API](https://github.com/microsoft/playwright/blob/v0.13.0/docs/api.md) | [Changelog](https://github.com/microsoft/playwright/releases) | [FAQ](#faq) | [Contributing](#contributing)
+###### [API](https://github.com/microsoft/playwright/blob/master/docs/api.md) | [Changelog](https://github.com/microsoft/playwright/releases) | [FAQ](#faq) | [Contributing](#contributing)
 
 
 Playwright is a Node library to automate the [Chromium](https://www.chromium.org/Home), [WebKit](https://webkit.org/) and [Firefox](https://www.mozilla.org/en-US/firefox/new/) browsers with a single API. It enables **cross-browser** web automation that is **ever-green**, **capable**, **reliable** and **fast**.
 
 |          | ver | Linux | macOS | Win |
 |   ---:   | :---: | :---: | :---:  | :---: |
-| Chromium| <!-- GEN:chromium-version-if-release-->83.0.4101.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Chromium| <!-- GEN:chromium-version GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | WebKit | 13.0.4 | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Firefox | <!-- GEN:firefox-version-if-release -->75.0b8<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Firefox | <!-- GEN:firefox-version -->76.0b5<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 - Headless is supported for all the browsers on all platforms.
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,5 @@
 
 # Playwright API <!-- GEN:version -->Tip-Of-Tree<!-- GEN:stop-->
-<!-- GEN:empty-if-release --><!-- GEN:stop -->
 
 ##### Table of Contents
 

--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -54,7 +54,6 @@ async function run() {
       chromiumVersion: browserVersions.chromium,
       firefoxVersion: browserVersions.firefox,
     })));
-    messages.push(...await preprocessor.ensureReleasedAPILinks([readme], VERSION));
     messages.push(...preprocessor.ensureInternalLinksAreValid([api]));
 
     const browser = await playwright.chromium.launch();

--- a/utils/doclint/preprocessor/index.js
+++ b/utils/doclint/preprocessor/index.js
@@ -16,21 +16,6 @@
 
 const Message = require('../Message');
 
-function ensureReleasedAPILinks(sources, libversion) {
-  // Release version is everything that doesn't include "-".
-  const apiLinkRegex = /https:\/\/github.com\/microsoft\/playwright\/blob\/v[^/]*\/docs\/api.md/ig;
-  const lastReleasedAPI = `https://github.com/microsoft/playwright/blob/v${libversion.split('-')[0]}/docs/api.md`;
-
-  const messages = [];
-  for (const source of sources) {
-    const text = source.text();
-    const newText = text.replace(apiLinkRegex, lastReleasedAPI);
-    if (source.setText(newText))
-      messages.push(Message.warning(`GEN: updated ${source.projectPath()}`));
-  }
-  return messages;
-};
-
 function runCommands(sources, {libversion, chromiumVersion, firefoxVersion}) {
   // Release version is everything that doesn't include "-".
   const isReleaseVersion = !libversion.includes('-');
@@ -66,16 +51,14 @@ function runCommands(sources, {libversion, chromiumVersion, firefoxVersion}) {
     let newText = null;
     if (command.name === 'version')
       newText = isReleaseVersion ? 'v' + libversion : 'Tip-Of-Tree';
-    else if (command.name === 'empty-if-release')
-      newText = isReleaseVersion ? '' : command.originalText;
-    else if (command.name === 'chromium-version-if-release')
-      newText = isReleaseVersion ? chromiumVersion : command.originalText;
-    else if (command.name === 'firefox-version-if-release')
-      newText = isReleaseVersion ? firefoxVersion : command.originalText;
-    else if (command.name === 'chromium-version-badge-if-release')
-      newText = isReleaseVersion ? `[![Chromium version](https://img.shields.io/badge/chromium-${chromiumVersion}-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)` : command.originalText;
-    else if (command.name === 'firefox-version-badge-if-release')
-      newText = isReleaseVersion ? `[![Firefox version](https://img.shields.io/badge/firefox-${firefoxVersion}-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)` : command.originalText;
+    else if (command.name === 'chromium-version')
+      newText = chromiumVersion;
+    else if (command.name === 'firefox-version')
+      newText = firefoxVersion;
+    else if (command.name === 'chromium-version-badge')
+      newText = `[![Chromium version](https://img.shields.io/badge/chromium-${chromiumVersion}-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)`;
+    else if (command.name === 'firefox-version-badge')
+      newText = `[![Firefox version](https://img.shields.io/badge/firefox-${firefoxVersion}-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)`;
     else if (command.name === 'toc')
       newText = generateTableOfContents(command.source.text(), command.to, false /* topLevelOnly */);
     else if (command.name === 'toc-top-level')
@@ -194,4 +177,4 @@ function generateTableOfContentsForSuperclass(text, name) {
   return text;
 }
 
-module.exports = {ensureInternalLinksAreValid, runCommands, ensureReleasedAPILinks};
+module.exports = {ensureInternalLinksAreValid, runCommands};

--- a/utils/doclint/preprocessor/test.js
+++ b/utils/doclint/preprocessor/test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const {runCommands, ensureReleasedAPILinks} = require('.');
+const {runCommands, ensureTipOfTreeAPILinks} = require('.');
 const Source = require('../Source');
 const TestRunner  = require('../../testrunner/');
 const runner = new TestRunner();
@@ -23,43 +23,6 @@ const {describe, xdescribe, fdescribe} = runner.api();
 const {it, fit, xit} = runner.api();
 const {beforeAll, beforeEach, afterAll, afterEach} = runner.api();
 const {expect} = runner.api();
-
-describe('ensureReleasedAPILinks', function() {
-  it('should work with non-release version', function() {
-    const source = new Source('doc.md', `
-      [API](https://github.com/microsoft/playwright/blob/v1.1.0/docs/api.md#class-page)
-    `);
-    const messages = ensureReleasedAPILinks([source], '1.3.0-post');
-    expect(messages.length).toBe(1);
-    expect(messages[0].type).toBe('warning');
-    expect(messages[0].text).toContain('doc.md');
-    expect(source.text()).toBe(`
-      [API](https://github.com/microsoft/playwright/blob/v1.3.0/docs/api.md#class-page)
-    `);
-  });
-  it('should work with release version', function() {
-    const source = new Source('doc.md', `
-      [API](https://github.com/microsoft/playwright/blob/v1.1.0/docs/api.md#class-page)
-    `);
-    const messages = ensureReleasedAPILinks([source], '1.3.0');
-    expect(messages.length).toBe(1);
-    expect(messages[0].type).toBe('warning');
-    expect(messages[0].text).toContain('doc.md');
-    expect(source.text()).toBe(`
-      [API](https://github.com/microsoft/playwright/blob/v1.3.0/docs/api.md#class-page)
-    `);
-  });
-  it('should keep master links intact', function() {
-    const source = new Source('doc.md', `
-      [API](https://github.com/microsoft/playwright/blob/master/docs/api.md#class-page)
-    `);
-    const messages = ensureReleasedAPILinks([source], '1.3.0');
-    expect(messages.length).toBe(0);
-    expect(source.text()).toBe(`
-      [API](https://github.com/microsoft/playwright/blob/master/docs/api.md#class-page)
-    `);
-  });
-});
 
 describe('runCommands', function() {
   const OPTIONS_REL = {
@@ -95,7 +58,7 @@ describe('runCommands', function() {
         Playwright <!-- gen:version -->v1.3.0<!-- gen:stop -->
       `);
     });
-    it('should work for *-post versions', function() {
+    it('should work for pre-release versions', function() {
       const source = new Source('doc.md', `
         Playwright <!-- gen:version -->XXX<!-- gen:stop -->
       `);
@@ -120,30 +83,6 @@ describe('runCommands', function() {
       expect(messages.length).toBe(1);
       expect(messages[0].type).toBe('error');
       expect(messages[0].text).toContain(`Failed to find 'gen:stop'`);
-    });
-  });
-  describe('gen:empty-if-release', function() {
-    it('should clear text when release version', function() {
-      const source = new Source('doc.md', `
-        <!-- gen:empty-if-release -->XXX<!-- gen:stop -->
-      `);
-      const messages = runCommands([source], OPTIONS_REL);
-      expect(messages.length).toBe(1);
-      expect(messages[0].type).toBe('warning');
-      expect(messages[0].text).toContain('doc.md');
-      expect(source.text()).toBe(`
-        <!-- gen:empty-if-release --><!-- gen:stop -->
-      `);
-    });
-    it('should keep text when non-release version', function() {
-      const source = new Source('doc.md', `
-        <!-- gen:empty-if-release -->XXX<!-- gen:stop -->
-      `);
-      const messages = runCommands([source], OPTIONS_DEV);
-      expect(messages.length).toBe(0);
-      expect(source.text()).toBe(`
-        <!-- gen:empty-if-release -->XXX<!-- gen:stop -->
-      `);
     });
   });
   describe('gen:toc', function() {
@@ -231,7 +170,6 @@ describe('runCommands', function() {
   it('should work with multiple commands', function() {
     const source = new Source('doc.md', `
       <!-- gen:version -->xxx<!-- gen:stop -->
-      <!-- gen:empty-if-release -->yyy<!-- gen:stop -->
       <!-- gen:version -->zzz<!-- gen:stop -->
     `);
     const messages = runCommands([source], OPTIONS_REL);
@@ -240,55 +178,34 @@ describe('runCommands', function() {
     expect(messages[0].text).toContain('doc.md');
     expect(source.text()).toBe(`
       <!-- gen:version -->v1.3.0<!-- gen:stop -->
-      <!-- gen:empty-if-release --><!-- gen:stop -->
       <!-- gen:version -->v1.3.0<!-- gen:stop -->
     `);
   });
-  describe('gen:chromium-version-if-release', function() {
-    it('should work for release', function() {
+  describe('gen:chromium-version', function() {
+    it('should work', function() {
       const source = new Source('doc.md', `
-        Playwright <!-- gen:chromium-version-if-release -->XXX<!-- gen:stop -->
+        Playwright <!-- gen:chromium-version -->XXX<!-- gen:stop -->
       `);
       const messages = runCommands([source], OPTIONS_REL);
       expect(messages.length).toBe(1);
       expect(messages[0].type).toBe('warning');
       expect(messages[0].text).toContain('doc.md');
       expect(source.text()).toBe(`
-        Playwright <!-- gen:chromium-version-if-release -->80.0.4004.0<!-- gen:stop -->
-      `);
-    });
-    it('should be noop for dev', function() {
-      const source = new Source('doc.md', `
-        Playwright <!-- gen:chromium-version-if-release -->XXX<!-- gen:stop -->
-      `);
-      const messages = runCommands([source], OPTIONS_DEV);
-      expect(messages.length).toBe(0);
-      expect(source.text()).toBe(`
-        Playwright <!-- gen:chromium-version-if-release -->XXX<!-- gen:stop -->
+        Playwright <!-- gen:chromium-version -->80.0.4004.0<!-- gen:stop -->
       `);
     });
   });
   describe('gen:firefox-version', function() {
-    it('should work for release', function() {
+    it('should work', function() {
       const source = new Source('doc.md', `
-        Playwright <!-- gen:firefox-version-if-release -->XXX<!-- gen:stop -->
+        Playwright <!-- gen:firefox-version -->XXX<!-- gen:stop -->
       `);
       const messages = runCommands([source], OPTIONS_REL);
       expect(messages.length).toBe(1);
       expect(messages[0].type).toBe('warning');
       expect(messages[0].text).toContain('doc.md');
       expect(source.text()).toBe(`
-        Playwright <!-- gen:firefox-version-if-release -->73.0b3<!-- gen:stop -->
-      `);
-    });
-    it('should be noop for dev', function() {
-      const source = new Source('doc.md', `
-        Playwright <!-- gen:firefox-version-if-release -->XXX<!-- gen:stop -->
-      `);
-      const messages = runCommands([source], OPTIONS_DEV);
-      expect(messages.length).toBe(0);
-      expect(source.text()).toBe(`
-        Playwright <!-- gen:firefox-version-if-release -->XXX<!-- gen:stop -->
+        Playwright <!-- gen:firefox-version -->73.0b3<!-- gen:stop -->
       `);
     });
   });


### PR DESCRIPTION
As of today, we have tooling in place that makes sure that our
main README.md **roughly** represents the state of the last release:
- browser versions and browser badges are those that we released last
- links to our API point to the last-released API version

This tooling, however, relies on the fact that every release is a sequence
of two consecutive commits:
- one commit that sets `package.json` version to a released version
- the following that "bumps" version to `-post`.

This release process is very unfortunate, because:
- it made releasing from branch impossible
- it required "freezing" commits to the master branch

This patch removes all the tooling and transitions `README.md` to always
represent tip-of-tree state. We will fully rely on
`https://playwright.dev` to show versioned docs.