### PR TITLE
fix: do not auto wait for downloads

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -39,8 +39,6 @@ export class Download {
     this._url = url;
     this._finishedCallback = () => {};
     this._finishedPromise = new Promise(f => this._finishedCallback = f);
-    for (const barrier of this._page._frameManager._signalBarriers)
-      barrier.addDownload();
     this._page.emit(Events.Page.Download, this);
     page._browserContext._downloads.add(this);
     this._acceptDownloads = !!this._page._browserContext._options.acceptDownloads;

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -147,10 +147,6 @@ export class FFPage implements PageDelegate {
 
   _onNavigationAborted(params: Protocol.Page.navigationAbortedPayload) {
     const frame = this._page._frameManager.frame(params.frameId)!;
-    if (params.errorText === 'Will download to file') {
-      for (const barrier of this._page._frameManager._signalBarriers)
-        barrier.expectDownload();
-    }
     for (const task of frame._frameTasks)
       task.onNewDocument(params.navigationId, new Error(params.errorText));
   }

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -948,7 +948,6 @@ export class SignalBarrier {
   private _options: types.NavigatingActionWaitOptions;
   private _protectCount = 0;
   private _expectedPopups = 0;
-  private _expectedDownloads = 0;
   private _promise: Promise<void>;
   private _promiseCallback = () => {};
   private _deadline: number;
@@ -989,16 +988,6 @@ export class SignalBarrier {
     this.release();
   }
 
-  async expectDownload() {
-    ++this._expectedDownloads;
-  }
-
-  async addDownload() {
-    if (this._expectedDownloads)
-      --this._expectedDownloads;
-    this._maybeResolve();
-  }
-
   retain() {
     ++this._protectCount;
   }
@@ -1009,7 +998,7 @@ export class SignalBarrier {
   }
 
   private async _maybeResolve() {
-    if (!this._protectCount && !this._expectedPopups && !this._expectedDownloads && !this._frameIds.size)
+    if (!this._protectCount && !this._expectedPopups && !this._frameIds.size)
       this._promiseCallback();
   }
 }

--- a/test/autowaiting.spec.js
+++ b/test/autowaiting.spec.js
@@ -54,20 +54,6 @@ describe('Auto waiting', () => {
     ]);
     expect(messages.join('|')).toBe('popup|click');
   });
-  it.fail(CHROMIUM)('should await download when clicking anchor', async function({page, server}) {
-    server.setRoute('/download', (req, res) => {
-      res.setHeader('Content-Type', 'application/octet-stream');
-      res.setHeader('Content-Disposition', 'attachment');
-      res.end(`Hello world`);
-    });
-    await page.setContent(`<a download=true href="${server.PREFIX}/download">download</a>`);
-    const messages = [];
-    await Promise.all([
-      page.waitForEvent('download').then(() => messages.push('download')),
-      page.click('a').then(() => messages.push('click')),
-    ]);
-    expect(messages.join('|')).toBe('download|click');
-  });
   it('should await cross-process navigation when clicking anchor', async({page, server}) => {
     const messages = [];
     server.setRoute('/empty.html', async (req, res) => {


### PR DESCRIPTION
Remove the test and corresponding logic while we don't have reliable support for that across all browsers.