### PR TITLE
fix(downloads): fix `acceptDownloads` complaint (#1777)

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -41,9 +41,9 @@ export class Download {
     this._finishedPromise = new Promise(f => this._finishedCallback = f);
     for (const barrier of this._page._frameManager._signalBarriers)
       barrier.addDownload();
-    this._page.emit(Events.Page.Download, this);
     page._browserContext._downloads.add(this);
     this._acceptDownloads = !!this._page._browserContext._options.acceptDownloads;
+    this._page.emit(Events.Page.Download, this);
   }
 
   url(): string {

--- a/test/download.spec.js
+++ b/test/download.spec.js
@@ -70,6 +70,20 @@ describe('Download', function() {
     expect(fs.readFileSync(path).toString()).toBe('Hello world');
     await page.close();
   });
+  fit(`should report download path within page.on('download', …) handler`, async({browser, server}) => {
+    const page = await browser.newPage({ acceptDownloads: true });
+    const onDownloadPathPath = new Promise((res, rej) => {
+      setTimeout(() => { rej('failed to find path quickly'); }, 1000);
+
+      page.on('download', dl => {
+        dl.path().then(res);
+      });
+    });
+    await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
+    await page.click('a');
+    const path = await onDownloadPathPath;
+    expect(fs.readFileSync(path).toString()).toBe('Hello world');
+  })
   it.skip(FFOX).fail(CHROMIUM || WEBKIT)('should report alt-click downloads', async({browser, server}) => {
     // Firefox does not download on alt-click by default.
     // Our WebKit embedder does not download on alt-click, although Safari does.

--- a/test/download.spec.js
+++ b/test/download.spec.js
@@ -72,9 +72,7 @@ describe('Download', function() {
   });
   it(`should report download path within page.on('download', …) handler`, async({browser, server}) => {
     const page = await browser.newPage({ acceptDownloads: true });
-    const onDownloadPathPath = new Promise((res, rej) => {
-      setTimeout(() => { rej('failed to find path quickly'); }, 1000);
-
+    const onDownloadPathPath = new Promise((res) => {
       page.on('download', dl => {
         dl.path().then(res);
       });

--- a/test/download.spec.js
+++ b/test/download.spec.js
@@ -70,7 +70,7 @@ describe('Download', function() {
     expect(fs.readFileSync(path).toString()).toBe('Hello world');
     await page.close();
   });
-  fit(`should report download path within page.on('download', …) handler`, async({browser, server}) => {
+  it(`should report download path within page.on('download', …) handler`, async({browser, server}) => {
     const page = await browser.newPage({ acceptDownloads: true });
     const onDownloadPathPath = new Promise((res, rej) => {
       setTimeout(() => { rej('failed to find path quickly'); }, 1000);
@@ -83,6 +83,7 @@ describe('Download', function() {
     await page.click('a');
     const path = await onDownloadPathPath;
     expect(fs.readFileSync(path).toString()).toBe('Hello world');
+    await page.close();
   })
   it.skip(FFOX).fail(CHROMIUM || WEBKIT)('should report alt-click downloads', async({browser, server}) => {
     // Firefox does not download on alt-click by default.


### PR DESCRIPTION
This patch fixes `download.path()` throwing an error that `acceptDownloads` is not set when using a download within a `page.on` handler even when `acceptDownloads` had been set to `true`.

See [this comment](https://github.com/microsoft/playwright/issues/1777#issuecomment-618011447) for an explanation of the issue.

If you checkout fbc52e74d1f0563a767e2eb3528d6b0c4685b259, you can run the newly added tests with the previous code and observe the failure.

Fixes #1777