### PR TITLE
devops: fix checking if branch is tip-of-tree when publishing @next

### DIFF
--- a/utils/publish_all_packages.sh
+++ b/utils/publish_all_packages.sh
@@ -54,7 +54,7 @@ elif [[ $1 == "--tip-of-tree" ]]; then
   fi
 
   # Ensure this is actually tip-of-tree.
-  UPSTREAM_SHA=$(git ls-remote https://github.com/microsoft/playwright --tags master | cut -f1)
+  UPSTREAM_SHA=$(git ls-remote https://github.com/microsoft/playwright --tags $(git rev-parse --abbrev-ref HEAD) | cut -f1)
   CURRENT_SHA=$(git rev-parse HEAD)
   if [[ "${UPSTREAM_SHA}" != "${CURRENT_SHA}" ]]; then
     echo "REFUSING TO PUBLISH: this is not tip-of-tree"


### PR DESCRIPTION
This should fix publishing @next from release branches.