### PR TITLE
devops: try using another Github Actions event to trigger releases

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -2,7 +2,7 @@ name: "release"
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 env:
   CI: true


### PR DESCRIPTION
The [official documentation](https://help.github.com/en/actions/language-and-framework-guides/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) suggests using `created` event, but it didn't work for us.

As someone mentioned on [github community](https://github.community/t5/GitHub-Actions/Workflow-set-for-on-release-not-triggering-not-showing-up/m-p/53236#M8758), it looks like the `created` event is actually issued when release draft is first created.

Try using [`published`](https://help.github.com/en/actions/reference/events-that-trigger-workflows#release-event-release) event instead.