### PR TITLE
fix: Dockerfile for Firefox

### DIFF
--- a/docs/docker/Dockerfile.bionic
+++ b/docs/docker/Dockerfile.bionic
@@ -39,7 +39,8 @@ RUN apt-get install -y libnss3 \
 
 # 4. Install Firefox dependencies
 
-RUN apt-get install -y libdbus-glib-1-2
+RUN apt-get install -y libdbus-glib-1-2 \
+                       libxt6
 
 # 5. Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
 


### PR DESCRIPTION
Tested with:

```js
const playwright = require("playwright");

(async () => {
  for (const browserType of ['chromium', 'webkit', 'firefox']) {
    const browser = await playwright[browserType].launch({
      logger: {
        isEnabled: (name, severity) => true,
        log: (name, severity, message, args) => console.log(`${name} ${message}`)
      }
    });
    const context = await browser.newContext();
    const page = await context.newPage();
    await page.goto('http://whatsmyuseragent.org/');
    await page.screenshot({ path: `example-${browserType}.png` });
    await browser.close();
  }
})();
```

Logs:

```
ackend_1   | browser <launching> /backend/node_modules/playwright/.local-browsers/firefox/firefox/firefox -no-remote -headless -profile /tmp/playwright_dev_firefox_profile-5vUzFi -juggler 0 -silent
backend_1   | browser <launched> pid=18
backend_1   | browser:err XPCOMGlueLoad error for file /backend/node_modules/playwright/.local-browsers/firefox/firefox/libxul.so:
backend_1   | browser:err libXt.so.6: cannot open shared object file: No such file or directory
backend_1   | browser:err Couldn't load XPCOM.
backend_1   | browser <process did exit 255, null>
backend_1   | /backend/node_modules/playwright-core/lib/server/firefox.js:109
backend_1   |                 if (browserServer)
backend_1   |                 ^
backend_1   | 
backend_1   | ReferenceError: Cannot access 'browserServer' before initialization
backend_1   |     at Object.onkill (/backend/node_modules/playwright-core/lib/server/firefox.js:109:17)
backend_1   |     at ChildProcess.<anonymous> (/backend/node_modules/playwright-core/lib/server/processLauncher.js:76:21)
backend_1   |     at Object.onceWrapper (events.js:417:26)
backend_1   |     at ChildProcess.emit (events.js:310:20)
backend_1   |     at ChildProcess.EventEmitter.emit (domain.js:482:12)
backend_1   |     at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)
```

Before that change Firefox was not working. By installing this new dependency, it works.

Maybe we should setup a build bot for it to guarantee, that the Dockerfile can start all the browsers? 

Side note: @arjun27 had it also in [his Dockerfile](https://github.com/arjun27/playwright-github-actions/blob/master/Dockerfile#L30).

Closes #1622