### PR TITLE
tests(downloads): add a test for Blob downloads (#1936)

### DIFF
--- a/test/assets/download-blob.html
+++ b/test/assets/download-blob.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Blob Download Example</title>
+  </head>
+  <body>
+    <script>
+      const download = (data, filename) => {
+      const a = document.createElement("a");
+      a.style = "display: none";
+      document.body.appendChild(a);
+      a.style = "display: none";
+
+      const blob = new Blob([data], { type: "octet/stream" });
+      const url = window.URL.createObjectURL(blob);
+      a.href = url;
+      a.download = filename;
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    };
+
+    const downloadIt = () => {
+      download("Hello world", "example.txt");
+    }
+    </script>
+    <a onclick="javascipt:downloadIt();">Download</a>
+  </body>
+</html>

--- a/test/download.spec.js
+++ b/test/download.spec.js
@@ -70,7 +70,7 @@ describe('Download', function() {
     expect(fs.readFileSync(path).toString()).toBe('Hello world');
     await page.close();
   });
-  it(`should report download path within page.on('download', …) handler`, async({browser, server}) => {
+  it(`should report download path within page.on('download', …) handler for Files`, async({browser, server}) => {
     const page = await browser.newPage({ acceptDownloads: true });
     const onDownloadPathPath = new Promise((res) => {
       page.on('download', dl => {
@@ -78,6 +78,19 @@ describe('Download', function() {
       });
     });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
+    await page.click('a');
+    const path = await onDownloadPathPath;
+    expect(fs.readFileSync(path).toString()).toBe('Hello world');
+    await page.close();
+  })
+  it(`should report download path within page.on('download', …) handler for Blobs`, async({browser, server}) => {
+    const page = await browser.newPage({ acceptDownloads: true });
+    const onDownloadPathPath = new Promise((res) => {
+      page.on('download', dl => {
+        dl.path().then(res);
+      });
+    });
+    await page.goto(server.PREFIX + '/download-blob.html');
     await page.click('a');
     const path = await onDownloadPathPath;
     expect(fs.readFileSync(path).toString()).toBe('Hello world');

--- a/test/download.spec.js
+++ b/test/download.spec.js
@@ -83,7 +83,7 @@ describe('Download', function() {
     expect(fs.readFileSync(path).toString()).toBe('Hello world');
     await page.close();
   })
-  it(`should report download path within page.on('download', …) handler for Blobs`, async({browser, server}) => {
+  it.fail(FFOX || WEBKIT)(`should report download path within page.on('download', …) handler for Blobs`, async({browser, server}) => {
     const page = await browser.newPage({ acceptDownloads: true });
     const onDownloadPath = new Promise((res) => {
       page.on('download', dl => {

--- a/test/download.spec.js
+++ b/test/download.spec.js
@@ -72,27 +72,27 @@ describe('Download', function() {
   });
   it(`should report download path within page.on('download', …) handler for Files`, async({browser, server}) => {
     const page = await browser.newPage({ acceptDownloads: true });
-    const onDownloadPathPath = new Promise((res) => {
+    const onDownloadPath = new Promise((res) => {
       page.on('download', dl => {
         dl.path().then(res);
       });
     });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     await page.click('a');
-    const path = await onDownloadPathPath;
+    const path = await onDownloadPath;
     expect(fs.readFileSync(path).toString()).toBe('Hello world');
     await page.close();
   })
   it(`should report download path within page.on('download', …) handler for Blobs`, async({browser, server}) => {
     const page = await browser.newPage({ acceptDownloads: true });
-    const onDownloadPathPath = new Promise((res) => {
+    const onDownloadPath = new Promise((res) => {
       page.on('download', dl => {
         dl.path().then(res);
       });
     });
     await page.goto(server.PREFIX + '/download-blob.html');
     await page.click('a');
-    const path = await onDownloadPathPath;
+    const path = await onDownloadPath;
     expect(fs.readFileSync(path).toString()).toBe('Hello world');
     await page.close();
   })


### PR DESCRIPTION
This patch adds test cases for Blob downloads which appear to have
differing behavior on the different browsers.

NB: For each of the browsers, I manually tried going to a page that
looked like the newly added test asset page (`download-blob.html`)
and performing the steps that the test does. In each of the cases
I ended up with the target file; however, Firefox and Safari both had an
additional prompt. (I'm not sure if that prompt was a default prompt
that should be disabled when running via Playwright or if additional
handling logic is needed.)

For Chrome, this test passes (and manual replication yields a file
download).

For Firefox, this test crashes the browser (but manual replication
yields a file but requires dealing with one extra download prompt in
Firefox).

For Webkit, this test will timeout (but manual replication yields a file
but requires dealing with one extra download prompt in Webkit.)

Test Output:

```
Failures:
1) [CRASHED] Firefox Download should report download path within page.on('download', …) handler for Blobs (download.spec.js:86:3)

2) [TIMEOUT 10000ms] WebKit Download should report download path within page.on('download', …) handler for Blobs (download.spec.js:86:3)
```

References: #1936