### PR TITLE
devops: test install over more node versions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,10 @@
 environment:
   matrix:
     - nodejs_version: "10"
+    - nodejs_version: "11"
+    - nodejs_version: "12"
+    - nodejs_version: "13"
+    - nodejs_version: "14"
 
 build: off
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,8 @@ script:
 - xvfb-run --auto-servernum npm run wtest
 jobs:
   include:
+  - node_js: '10'
+  - node_js: '11'
   - node_js: '12'
-
+  - node_js: '13'
+  - node_js: '14'


### PR DESCRIPTION
This relates to https://github.com/microsoft/playwright/issues/1988. It would be helpful to run tests in more Node environments to ensure compatibility with the most popular versions of node that are currently out.