### PR TITLE
fix(visibility): unify visibilty checks

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -947,7 +947,7 @@ Shortcut for [page.mainFrame().addStyleTag(options)](#frameaddstyletagoptions).
 - `selector` <[string]> A selector to search for checkbox or radio button to check. If there are multiple elements satisfying the selector, the first will be checked.
 - `options` <[Object]>
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -971,7 +971,7 @@ Shortcut for [page.mainFrame().check(selector[, options])](#framecheckselector-o
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -1024,7 +1024,7 @@ Browser-specific Coverage implementation, only available for Chromium atm. See [
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the double click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -1333,7 +1333,7 @@ Shortcut for [page.mainFrame().goto(url[, options])](#framegotourl-options)
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the hover, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -1658,7 +1658,7 @@ Shortcut for [page.mainFrame().type(selector, text[, options])](#frametypeselect
 - `selector` <[string]> A selector to search for uncheckbox to check. If there are multiple elements satisfying the selector, the first will be checked.
 - `options` <[Object]>
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -1854,6 +1854,8 @@ return finalResponse.ok();
 
 Wait for the `selector` to satisfy `waitFor` option (either appear/disappear from dom, or become visible/hidden). If at the moment of calling the method `selector` already satisfies the condition, the method will return immediately. If the selector doesn't satisfy the condition for the `timeout` milliseconds, the function will throw.
 
+Element is considered `visible` when it has non-empty bounding box (for example, it has some content and no `display:none`) and no `visibility:hidden`. Element is considired `hidden` when it is not `visible` as defined above.
+
 This method works across navigations:
 ```js
 const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
@@ -2022,7 +2024,7 @@ Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<s
 - `selector` <[string]> A selector to search for checkbox to check. If there are multiple elements satisfying the selector, the first will be checked.
 - `options` <[Object]>
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -2047,7 +2049,7 @@ If there's no element matching `selector`, the method throws an error.
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -2073,7 +2075,7 @@ Gets the full HTML contents of the frame, including the doctype.
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the double click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -2246,7 +2248,7 @@ console.log(frame === contentFrame);  // -> true
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the hover, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -2369,7 +2371,7 @@ await frame.type('#mytextarea', 'World', {delay: 100}); // Types slower, like a 
 - `selector` <[string]> A selector to search for uncheckbox to check. If there are multiple elements satisfying the selector, the first will be checked.
 - `options` <[Object]>
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -2638,7 +2640,7 @@ This method returns the bounding box of the element (relative to the main frame)
 #### elementHandle.check([options])
 - `options` <[Object]>
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -2658,7 +2660,7 @@ If element is not already checked, it scrolls it into view if needed, and then u
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -2681,7 +2683,7 @@ If the element is detached from DOM, the method throws an error.
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the double click, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -2754,7 +2756,7 @@ Returns element attribute value.
     - y <[number]>
   - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the hover, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.
@@ -2893,7 +2895,7 @@ await elementHandle.press('Enter');
 #### elementHandle.uncheck([options])
 - `options` <[Object]>
   - `force` <[boolean]> Whether to bypass the actionability checks. By default actions wait until the element is:
-    - displayed (for example, no `display:none`),
+    - displayed (for example, not empty, no `display:none`, no `visibility:hidden`),
     - is not moving (for example, waits until css transition finishes),
     - receives pointer events at the action point (for example, waits until element becomes non-obscured by other elements).
     Even if the action is forced, it will wait for the element matching selector to be in DOM. Defaults to `false`.

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -183,10 +183,11 @@ const sectionText = await page.$eval('*css=section >> text=Selectors', e => e.te
 
 Actions like `click` and `fill` auto-wait for the element to be visible and actionable. For example, click will:
 - wait for element with given selector to be in DOM
-- wait for it to become displayed, i.e. not `display:none`,
+- wait for it to become displayed, i.e. not empty, no `display:none`, no `visibility:hidden`
 - wait for it to stop moving, for example, until css transition finishes
 - scroll the element into view
 - wait for it to receive pointer events at the action point, for example, waits until element becomes non-obscured by other elements
+- retry if the element is detached during any of the above checks
 
 
 ```js

--- a/docs/input.md
+++ b/docs/input.md
@@ -115,10 +115,11 @@ await page.click('button#submit');
 Performs a simple human click. Under the hood, this and other pointer-related methods:
 
 - wait for element with given selector to be in DOM
-- wait for it to become displayed, i.e. not `display:none`,
+- wait for it to become displayed, i.e. not empty, no `display:none`, no `visibility:hidden`
 - wait for it to stop moving, for example, until css transition finishes
 - scroll the element into view
 - wait for it to receive pointer events at the action point, for example, waits until element becomes non-obscured by other elements
+- retry if the element is detached during any of the above checks
 
 #### Variations
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -5,7 +5,7 @@
 - [Usage](#usage)
 - [Writing your first script](#writing-your-first-script)
 - [Debugging scripts](#debugging-scripts)
-- [Deploying to CI](#deploying-to-ci)
+- [Continuous Integration](#continuous-integration)
 <!-- GEN:stop -->
 
 ## Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-core",
-  "version": "1.0.0-post",
+  "version": "0.15.0-post",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -287,6 +287,16 @@ describe('Frame.waitForSelector', function() {
     expect(await waitForSelector).toBe(true);
     expect(divFound).toBe(true);
   });
+  it('should not consider visible when zero-sized', async({page, server}) => {
+    await page.setContent(`<div style='width: 0; height: 0;'>1</div>`);
+    let error = await page.waitForSelector('div', { waitFor: 'visible', timeout: 1000 }).catch(e => e);
+    expect(error.message).toContain('timeout exceeded');
+    await page.evaluate(() => document.querySelector('div').style.width = '10px');
+    error = await page.waitForSelector('div', { waitFor: 'visible', timeout: 1000 }).catch(e => e);
+    expect(error.message).toContain('timeout exceeded');
+    await page.evaluate(() => document.querySelector('div').style.height = '10px');
+    expect(await page.waitForSelector('div', { waitFor: 'visible', timeout: 1000 })).toBeTruthy();
+  });
   it('should wait for visible recursively', async({page, server}) => {
     let divVisible = false;
     const waitForSelector = page.waitForSelector('div#inner', { waitFor: 'visible' }).then(() => divVisible = true);
@@ -300,7 +310,7 @@ describe('Frame.waitForSelector', function() {
   });
   it('hidden should wait for hidden', async({page, server}) => {
     let divHidden = false;
-    await page.setContent(`<div style='display: block;'></div>`);
+    await page.setContent(`<div style='display: block;'>content</div>`);
     const waitForSelector = page.waitForSelector('div', { waitFor: 'hidden' }).then(() => divHidden = true);
     await page.waitForSelector('div'); // do a round trip
     expect(divHidden).toBe(false);
@@ -310,7 +320,7 @@ describe('Frame.waitForSelector', function() {
   });
   it('hidden should wait for display: none', async({page, server}) => {
     let divHidden = false;
-    await page.setContent(`<div style='display: block;'></div>`);
+    await page.setContent(`<div style='display: block;'>content</div>`);
     const waitForSelector = page.waitForSelector('div', { waitFor: 'hidden' }).then(() => divHidden = true);
     await page.waitForSelector('div'); // do a round trip
     expect(divHidden).toBe(false);
@@ -319,7 +329,7 @@ describe('Frame.waitForSelector', function() {
     expect(divHidden).toBe(true);
   });
   it('hidden should wait for removal', async({page, server}) => {
-    await page.setContent(`<div></div>`);
+    await page.setContent(`<div>content</div>`);
     let divRemoved = false;
     const waitForSelector = page.waitForSelector('div', { waitFor: 'hidden' }).then(() => divRemoved = true);
     await page.waitForSelector('div'); // do a round trip
@@ -340,9 +350,9 @@ describe('Frame.waitForSelector', function() {
     expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
   });
   it('should have an error message specifically for awaiting an element to be hidden', async({page, server}) => {
-    await page.setContent(`<div></div>`);
+    await page.setContent(`<div>content</div>`);
     let error = null;
-    await page.waitForSelector('div', { waitFor: 'hidden', timeout: 10 }).catch(e => error = e);
+    await page.waitForSelector('div', { waitFor: 'hidden', timeout: 1000 }).catch(e => error = e);
     expect(error).toBeTruthy();
     expect(error.message).toContain('waiting for selector "[hidden] div" failed: timeout');
   });


### PR DESCRIPTION
This applies a common definition of visibility to clicks and waitfors:
- non-empty bounding box - implies non-empty content and no `display:none`;
- no `visibility:hidden`.

References #1981.