### PR TITLE
fix(webkit): handle Page.frame{Will,Did}RequestNavigation

### DIFF
--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -651,10 +651,9 @@ describe('Events.BrowserContext.Page', function() {
     ]);
     await context.close();
   });
-  it.fail(CHROMIUM || WEBKIT)('should work with Shift-clicking', async({browser, server}) => {
+  it.fail(CHROMIUM)('should work with Shift-clicking', async({browser, server}) => {
     // Chromium: Shift+Click fires frameRequestedNavigation that never materializes
     // because it actually opens a new window.
-    // WebKit: Shift+Click does not open a new window.
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
@@ -665,12 +664,13 @@ describe('Events.BrowserContext.Page', function() {
     ]);
     expect(await page.evaluate(() => !!window.opener)).toBe(false);
     expect(await popup.evaluate(() => !!window.opener)).toBe(false);
+    expect(await popup.opener()).toBe(null);
     await context.close();
   });
-  it.fail(CHROMIUM || WEBKIT)('should work with Ctrl-clicking', async({browser, server}) => {
+  it.fail(CHROMIUM || FFOX)('should work with Ctrl-clicking', async({browser, server}) => {
     // Chromium: Ctrl+Click fires frameRequestedNavigation that never materializes
     // because it actually opens a new tab.
-    // WebKit: Ctrl+Click does not open a new tab.
+    // Firefox: reports an opener.
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
@@ -681,6 +681,7 @@ describe('Events.BrowserContext.Page', function() {
     ]);
     expect(await page.evaluate(() => !!window.opener)).toBe(false);
     expect(await popup.evaluate(() => !!window.opener)).toBe(false);
+    expect(await popup.opener()).toBe(null);
     await context.close();
   });
 });

--- a/test/download.spec.js
+++ b/test/download.spec.js
@@ -51,8 +51,7 @@ describe('Download', function() {
     expect(fs.readFileSync(path).toString()).toBe('Hello world');
     await page.close();
   });
-  it.fail(WEBKIT)('should report non-navigation downloads', async({browser, server}) => {
-    // Our WebKit embedder does not download in this case, although Safari does.
+  it('should report non-navigation downloads', async({browser, server}) => {
     server.setRoute('/download', (req, res) => {
       res.setHeader('Content-Type', 'application/octet-stream');
       res.end(`Hello world`);
@@ -96,9 +95,8 @@ describe('Download', function() {
     expect(fs.readFileSync(path).toString()).toBe('Hello world');
     await page.close();
   })
-  it.skip(FFOX).fail(CHROMIUM || WEBKIT)('should report alt-click downloads', async({browser, server}) => {
+  it.skip(FFOX).fail(CHROMIUM)('should report alt-click downloads', async({browser, server}) => {
     // Firefox does not download on alt-click by default.
-    // Our WebKit embedder does not download on alt-click, although Safari does.
     // Chromium hangs waiting for navigation because of Page.frameRequestedNavigation.
     server.setRoute('/download', (req, res) => {
       res.setHeader('Content-Type', 'application/octet-stream');

--- a/test/popup.spec.js
+++ b/test/popup.spec.js
@@ -304,43 +304,6 @@ describe('Page.Events.Popup', function() {
     expect(await popup.evaluate(() => !!window.opener)).toBe(true);
     await context.close();
   });
-  it.fail(true)('should work with Shift-clicking', async({browser, server}) => {
-    // Chromium:
-    // - Shift+Click fires frameRequestedNavigation that never materializes
-    //   because it actually opens a new window.
-    // - New window does not report an opener.
-    // WebKit: Shift+Click does not open a new window.
-    // Firefox: new window does not report an opener.
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await page.goto(server.EMPTY_PAGE);
-    await page.setContent('<a href="/one-style.html">yo</a>');
-    const [popup] = await Promise.all([
-      page.waitForEvent('popup'),
-      page.click('a', { modifiers: ['Shift'] }),
-    ]);
-    expect(await page.evaluate(() => !!window.opener)).toBe(false);
-    expect(await popup.evaluate(() => !!window.opener)).toBe(true);
-    await context.close();
-  });
-  it.fail(CHROMIUM || WEBKIT)('should work with Control-clicking', async({browser, server}) => {
-    // Chromium:
-    // - Shift+Click fires frameRequestedNavigation that never materializes
-    //   because it actually opens a new tab.
-    // - New tab does not report an opener.
-    // WebKit: Shift+Click does not open a new tab.
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await page.goto(server.EMPTY_PAGE);
-    await page.setContent('<a href="/one-style.html">yo</a>');
-    const [popup] = await Promise.all([
-      page.waitForEvent('popup'),
-      page.click('a', { modifiers: [MAC ? 'Meta' : 'Control'] }),
-    ]);
-    expect(await page.evaluate(() => !!window.opener)).toBe(false);
-    expect(await popup.evaluate(() => !!window.opener)).toBe(false);
-    await context.close();
-  });
   it('should work with fake-clicking target=_blank and rel=noopener', async({browser, server}) => {
     const context = await browser.newContext();
     const page = await context.newPage();


### PR DESCRIPTION
This should make following navigations bullet-proof, as we now instrument both async points - navigation scheduling and navigation policy decision. As a side effect, we also capture new pages opened as a result of navigation action.

Requires #2004.