### PR TITLE
chore: do not run git fetch in export.sh

### DIFF
--- a/browser_patches/export.sh
+++ b/browser_patches/export.sh
@@ -100,8 +100,6 @@ else
   echo "-- checking $FRIENDLY_CHECKOUT_PATH is clean - OK"
 fi
 
-git fetch $REMOTE_BROWSER_UPSTREAM $BASE_BRANCH
-
 PATCH_NAME=$(ls -1 $EXPORT_PATH/patches)
 if [[ -z "$PATCH_NAME" ]]; then
   PATCH_NAME="bootstrap.diff"


### PR DESCRIPTION
The fetch slows down the process a lot and doesn't work on a slow connection. Local state should already be up-to-date after prepare_checkout.sh