### PR TITLE
docs: Recommend using --ipc=host in docker

### DIFF
--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -13,9 +13,10 @@ $ sudo docker build -t microsoft/playwright:bionic -f Dockerfile.bionic .
 Running image:
 
 ```
-$ sudo docker container run -it --rm --security-opt seccomp=chrome.json microsoft/playwright:bionic /bin/bash
+$ sudo docker container run -it --rm --ipc=host --security-opt seccomp=chrome.json microsoft/playwright:bionic /bin/bash
 ```
 
 > **NOTE**: The seccomp profile is coming from Jessie Frazelle. It's needed
-> to run Chrome without sandbox.
-
+> to run Chrome without sandbox.  
+> Using `--ipc=host` is also recommended when using Chrome. Without it Chrome can run out of memory and crash.  
+> [See the docker documentation for this option here.](https://docs.docker.com/engine/reference/run/#ipc-settings---ipc)


### PR DESCRIPTION
Using `--ipc=host` is the most consistent fix I've found the the various crashes I was seeing using Chrome inside of Docker.

Related to https://github.com/microsoft/playwright/issues/1968.