### PR TITLE
test: mark couple tests as failing on Windows

### DIFF
--- a/test/cookies.spec.js
+++ b/test/cookies.spec.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const {FFOX, CHROMIUM, WEBKIT, MAC} = require('./utils').testOptions(browserType);
+const {FFOX, CHROMIUM, WEBKIT, MAC, WIN} = require('./utils').testOptions(browserType);
 
 describe('BrowserContext.cookies', function() {
   it('should return no cookies in pristine browser context', async({context, page, server}) => {
@@ -37,7 +37,7 @@ describe('BrowserContext.cookies', function() {
       sameSite: 'None',
     }]);
   });
-  it('should get a non-session cookie', async({context, page, server}) => {
+  it.fail(WEBKIT && WIN)('should get a non-session cookie', async({context, page, server}) => {
     await page.goto(server.EMPTY_PAGE);
     // @see https://en.wikipedia.org/wiki/Year_2038_problem
     const date = +(new Date('1/1/2038'));

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -17,7 +17,7 @@
 
 const path = require('path');
 const vm = require('vm');
-const {FFOX, CHROMIUM, WEBKIT} = require('./utils').testOptions(browserType);
+const {FFOX, CHROMIUM, WEBKIT, WIN} = require('./utils').testOptions(browserType);
 
 describe('Page.close', function() {
   it('should reject all promises when page is closed', async({context}) => {
@@ -119,7 +119,7 @@ describe('Page.Events.Crash', function() {
     crash(page);
     await new Promise(f => page.on('crash', f));
   });
-  it('should throw on any action after page crashes', async({page}) => {
+  it.fail(FFOX && WIN)('should throw on any action after page crashes', async({page}) => {
     await page.setContent(`<div>This page should crash</div>`);
     crash(page);
     await page.waitForEvent('crash');


### PR DESCRIPTION
From this run: https://github.com/microsoft/playwright/pull/2019/checks?check_run_id=630877434
I've already seen both of these a few times before.

```
Failures:
1) [TIMEOUT 30000ms] Firefox Page.Events.Crash should throw on any action after page crashes (page.spec.js:122:3)

Failures:
1) [FAIL] WebKit BrowserContext.cookies should get a non-session cookie (cookies.spec.js:40:3)

    44 |     await page.evaluate(timestamp => {
    45 |       const date = new Date(timestamp);
    46 |       document.cookie = `username=John Doe;expires=${date.toUTCString()}`;
    47 |     }, date);
    48 |     expect(await context.cookies()).toEqual([{
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

    Received:
    -   [
    -     {
    -       "domain": "localhost",
    -       "expires": 2145916800,
    -       "httpOnly": false,
    -       "name": "username",
    -       "path": "/",
    -       "sameSite": "None",
    -       "secure": false,
    -       "value": "John Doe"
    -     }
    -   ]
    +   []
```