### PR TITLE
feat(testrunner): improvements to testrunner

### DIFF
--- a/utils/testrunner/Reporter.js
+++ b/utils/testrunner/Reporter.js
@@ -15,6 +15,7 @@
  */
 
 const fs = require('fs');
+const path = require('path');
 const colors = require('colors/safe');
 const {MatchError} = require('./Matchers.js');
 
@@ -38,15 +39,23 @@ class Reporter {
   onStarted(testRuns) {
     this._testCounter = 0;
     this._timestamp = Date.now();
-    if (!this._delegate.hasFocusedTestsOrSuites()) {
+    if (!this._delegate.hasFocusedTestsOrSuitesOrFiles()) {
       console.log(`Running all ${colors.yellow(testRuns.length)} tests on ${colors.yellow(this._delegate.parallel())} worker${this._delegate.parallel() > 1 ? 's' : ''}:\n`);
     } else {
       console.log(`Running ${colors.yellow(testRuns.length)} focused tests out of total ${colors.yellow(this._delegate.testCount())} on ${colors.yellow(this._delegate.parallel())} worker${this._delegate.parallel() > 1 ? 's' : ''}`);
       console.log('');
+      const focusedFilePaths = this._delegate.focusedFilePaths();
+      if (focusedFilePaths.length) {
+        console.log('Focused Files:');
+        for (let i = 0; i < focusedFilePaths.length; ++i)
+          console.log(`  ${i + 1}) ${colors.yellow(path.basename(focusedFilePaths[i]))}`);
+        console.log('');
+      }
       const focusedEntities = [
         ...this._delegate.focusedSuites(),
         ...this._delegate.focusedTests(),
       ];
+
       if (focusedEntities.length) {
         console.log('Focused Suites and Tests:');
         for (let i = 0; i < focusedEntities.length; ++i)

--- a/utils/testrunner/test/testrunner.spec.js
+++ b/utils/testrunner/test/testrunner.spec.js
@@ -8,8 +8,8 @@ class Runner {
     this._filter = new FocusedFilter();
     this._repeater = new Repeater();
     this._collector = new TestCollector(options);
-    this._collector.addSuiteAttribute('only', s => this._filter.markFocused(s));
-    this._collector.addTestAttribute('only', t => this._filter.markFocused(t));
+    this._collector.addSuiteAttribute('only', s => this._filter.focusSuite(s));
+    this._collector.addTestAttribute('only', t => this._filter.focusTest(t));
     this._collector.addSuiteAttribute('skip', s => s.setSkipped(true));
     this._collector.addTestAttribute('skip', t => t.setSkipped(true));
     this._collector.addTestAttribute('fail', t => t.setExpectation(t.Expectations.Fail));
@@ -712,16 +712,16 @@ module.exports.addTests = function({describe, fdescribe, xdescribe, it, xit, fit
     });
   });
 
-  describe('TestRunner.hasFocusedTestsOrSuites', () => {
+  describe('TestRunner.hasFocusedTestsOrSuitesOrFiles', () => {
     it('should work', () => {
       const t = new Runner();
       t.it('uno', () => {});
-      expect(t._filter.hasFocusedTestsOrSuites()).toBe(false);
+      expect(t._filter.hasFocusedTestsOrSuitesOrFiles()).toBe(false);
     });
     it('should work #2', () => {
       const t = new Runner();
       t.fit('uno', () => {});
-      expect(t._filter.hasFocusedTestsOrSuites()).toBe(true);
+      expect(t._filter.hasFocusedTestsOrSuitesOrFiles()).toBe(true);
     });
     it('should work #3', () => {
       const t = new Runner();
@@ -732,7 +732,7 @@ module.exports.addTests = function({describe, fdescribe, xdescribe, it, xit, fit
           });
         });
       });
-      expect(t._filter.hasFocusedTestsOrSuites()).toBe(true);
+      expect(t._filter.hasFocusedTestsOrSuitesOrFiles()).toBe(true);
     });
   });
 


### PR DESCRIPTION
This patch:
- teaches test runner to understand custom argument spelling, e.g. `--file=evalu` and `-j10`
- fixes `--file` filter to actually focus file paths instead of focusing
all tests with given path