### PR TITLE
docs: some js syntax fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,23 +157,23 @@ npm run ftest -- --break-on-failure
 - To run a specific test, substitute the `it` with `fit` (mnemonic rule: '*focus it*'):
 
 ```js
-  ...
-  // Using "fit" to run specific test
-  fit('should work', async ({server, page}) => {
-    const response = await page.goto(server.EMPTY_PAGE);
-    expect(response.ok).toBe(true);
-  });
+...
+// Using "fit" to run specific test
+fit('should work', async ({server, page}) => {
+  const response = await page.goto(server.EMPTY_PAGE);
+  expect(response.ok).toBe(true);
+});
 ```
 
 - To disable a specific test, substitute the `it` with `xit` (mnemonic rule: '*cross it*'):
 
 ```js
-  ...
-  // Using "xit" to skip specific test
-  xit('should work', async ({server, page}) => {
-    const response = await page.goto(server.EMPTY_PAGE);
-    expect(response.ok).toBe(true);
-  });
+...
+// Using "xit" to skip specific test
+xit('should work', async ({server, page}) => {
+  const response = await page.goto(server.EMPTY_PAGE);
+  expect(response.ok).toBe(true);
+});
 ```
 
 - To run tests in non-headless (headful) mode:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🎭 Playwright 
+# 🎭 Playwright
 
 [![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://join.slack.com/t/playwright/shared_invite/enQtOTEyMTUxMzgxMjIwLThjMDUxZmIyNTRiMTJjNjIyMzdmZDA3MTQxZWUwZTFjZjQwNGYxZGM5MzRmNzZlMWI5ZWUyOTkzMjE5Njg1NDg) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-84.0.4135.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-76.0b5-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> [![WebKit version](https://img.shields.io/badge/webkit-13.0.4-blue.svg?logo=safari)](https://webkit.org/)
 
@@ -100,7 +100,7 @@ const { firefox } = require('playwright');
       height: document.documentElement.clientHeight,
       deviceScaleFactor: window.devicePixelRatio
     }
-  })
+  });
   console.log(dimensions);
 
   await browser.close();

--- a/browser_patches/README.md
+++ b/browser_patches/README.md
@@ -52,7 +52,7 @@ This script will:
 
 If you omit the path to your checkout, the script will assume one is located at `./browser_patches/firefox/checkout`
 
-Send a PR to the Playwright repo to be reviewed. 
+Send a PR to the Playwright repo to be reviewed.
 
 ## 4. Rolling Playwright to the new browser build
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1559,7 +1559,7 @@ Shortcut for [page.mainFrame().selectOption()](#frameselectoptionselector-values
 - `html` <[string]> HTML markup to assign to the page.
 - `options` <[Object]> Parameters which might have the following properties:
   - `timeout` <[number]> Maximum time in milliseconds for resources to load, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultNavigationTimeout(timeout)](#browsercontextsetdefaultnavigationtimeouttimeout), [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout), [page.setDefaultNavigationTimeout(timeout)](#pagesetdefaultnavigationtimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
-  - `waitUntil` <"load"|"domcontentloaded"|"networkidle">  When to consider setting markup succeeded, defaults to `load`. Given an array of event strings, setting content is considered to be successful after all events have been fired. Events can be either:
+  - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider setting markup succeeded, defaults to `load`. Given an array of event strings, setting content is considered to be successful after all events have been fired. Events can be either:
     - `'load'` - consider setting content to be finished when the `load` event is fired.
     - `'domcontentloaded'` - consider setting content to be finished when the `DOMContentLoaded` event is fired.
     - `'networkidle'` - consider setting content to be finished when there are no network connections for at least `500` ms.
@@ -1760,7 +1760,7 @@ Shortcut for [page.mainFrame().waitForLoadState([options])](#framewaitforloadsta
 - `options` <[Object]> Navigation parameters which might have the following properties:
   - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultNavigationTimeout(timeout)](#browsercontextsetdefaultnavigationtimeouttimeout), [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout), [page.setDefaultNavigationTimeout(timeout)](#pagesetdefaultnavigationtimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
   - `url` <[string]|[RegExp]|[Function]> A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation.
-  - `waitUntil` <"load"|"domcontentloaded"|"networkidle">  When to consider navigation succeeded, defaults to `load`. Events can be either:
+  - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider navigation succeeded, defaults to `load`. Events can be either:
     - `'domcontentloaded'` - consider navigation to be finished when the `DOMContentLoaded` event is fired.
     - `'load'` - consider navigation to be finished when the `load` event is fired.
     - `'networkidle'` - consider navigation to be finished when there are no network connections for at least `500` ms.
@@ -1892,9 +1892,9 @@ const { firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
 An example of getting text from an iframe element:
 
 ```js
-  const frame = page.frames().find(frame => frame.name() === 'myframe');
-  const text = await frame.$eval('.selector', element => element.textContent);
-  console.log(text);
+const frame = page.frames().find(frame => frame.name() === 'myframe');
+const text = await frame.$eval('.selector', element => element.textContent);
+console.log(text);
 ```
 
 <!-- GEN:toc -->
@@ -2197,7 +2197,7 @@ console.log(frame === contentFrame);  // -> true
 - `url` <[string]> URL to navigate frame to. The url should include scheme, e.g. `https://`.
 - `options` <[Object]> Navigation parameters which might have the following properties:
   - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultNavigationTimeout(timeout)](#browsercontextsetdefaultnavigationtimeouttimeout), [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout), [page.setDefaultNavigationTimeout(timeout)](#pagesetdefaultnavigationtimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
-  - `waitUntil` <"load"|"domcontentloaded"|"networkidle">  When to consider navigation succeeded, defaults to `load`. Events can be either:
+  - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider navigation succeeded, defaults to `load`. Events can be either:
     - `'domcontentloaded'` - consider navigation to be finished when the `DOMContentLoaded` event is fired.
     - `'load'` - consider navigation to be finished when the `load` event is fired.
     - `'networkidle'` - consider navigation to be finished when there are no network connections for at least `500` ms.
@@ -2303,7 +2303,7 @@ frame.selectOption('select#colors', 'red', 'green', 'blue');
 - `html` <[string]> HTML markup to assign to the page.
 - `options` <[Object]> Parameters which might have the following properties:
   - `timeout` <[number]> Maximum time in milliseconds for resources to load, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultNavigationTimeout(timeout)](#browsercontextsetdefaultnavigationtimeouttimeout), [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout), [page.setDefaultNavigationTimeout(timeout)](#pagesetdefaultnavigationtimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
-  - `waitUntil` <"load"|"domcontentloaded"|"networkidle">  When to consider navigation succeeded, defaults to `load`. Events can be either:
+  - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider navigation succeeded, defaults to `load`. Events can be either:
     - `'domcontentloaded'` - consider setting content to be finished when the `DOMContentLoaded` event is fired.
     - `'load'` - consider setting content to be finished when the `load` event is fired.
     - `'networkidle'` - consider setting content to be finished when there are no network connections for at least `500` ms.
@@ -2414,7 +2414,7 @@ await frame.waitForLoadState(); // The promise resolves after 'load' event.
 - `options` <[Object]> Navigation parameters which might have the following properties:
   - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultNavigationTimeout(timeout)](#browsercontextsetdefaultnavigationtimeouttimeout), [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout), [page.setDefaultNavigationTimeout(timeout)](#pagesetdefaultnavigationtimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
   - `url` <[string]|[RegExp]|[Function]> URL string, URL regex pattern or predicate receiving [URL] to match while waiting for the navigation.
-  - `waitUntil` <"load"|"domcontentloaded"|"networkidle">  When to consider navigation succeeded, defaults to `load`. Events can be either:
+  - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider navigation succeeded, defaults to `load`. Events can be either:
     - `'domcontentloaded'` - consider navigation to be finished when the `DOMContentLoaded` event is fired.
     - `'load'` - consider navigation to be finished when the `load` event is fired.
     - `'networkidle'` - consider navigation to be finished when there are no network connections for at least `500` ms.
@@ -3822,7 +3822,7 @@ This methods attaches Playwright to an existing browser instance.
 - returns: <[string]> A path where Playwright expects to find a bundled browser executable.
 
 #### browserType.launch([options])
-- `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:
+- `options` <[Object]> Set of configurable options to set on the browser. Can have the following fields:
   - `headless` <[boolean]> Whether to run browser in headless mode. More details for [Chromium](https://developers.google.com/web/updates/2017/04/headless-chrome) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode). Defaults to `true` unless the `devtools` option is `true`.
   - `executablePath` <[string]> Path to a browser executable to run instead of the bundled one. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). Note that Playwright only works with the bundled Chromium, Firefox or WebKit, use at your own risk.
   - `args` <[Array]<[string]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
@@ -3855,7 +3855,7 @@ const browser = await chromium.launch({  // Or 'firefox' or 'webkit'.
 
 #### browserType.launchPersistentContext(userDataDir, [options])
  - `userDataDir` <[string]> Path to a User Data Directory, which stores browser session data like cookies and local storage. More details for [Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options#User_Profile).
-- `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:
+- `options` <[Object]> Set of configurable options to set on the browser. Can have the following fields:
   - `headless` <[boolean]> Whether to run browser in headless mode. More details for [Chromium](https://developers.google.com/web/updates/2017/04/headless-chrome) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode). Defaults to `true` unless the `devtools` option is `true`.
   - `executablePath` <[string]> Path to a browser executable to run instead of the bundled one. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). **BEWARE**: Playwright is only guaranteed to work with the bundled Chromium, Firefox or WebKit, use at your own risk.
   - `args` <[Array]<[string]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
@@ -3873,7 +3873,7 @@ const browser = await chromium.launch({  // Or 'firefox' or 'webkit'.
 Launches browser instance that uses persistent storage located at `userDataDir`.
 
 #### browserType.launchServer([options])
-- `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:
+- `options` <[Object]> Set of configurable options to set on the browser. Can have the following fields:
   - `headless` <[boolean]> Whether to run browser in headless mode. More details for [Chromium](https://developers.google.com/web/updates/2017/04/headless-chrome) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode). Defaults to `true` unless the `devtools` option is `true`.
   - `port` <[number]> Port to use for the web socket. Defaults to 0 that picks any available port.
   - `executablePath` <[string]> Path to a browser executable to run instead of the bundled one. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). **BEWARE**: Playwright is only guaranteed to work with the bundled Chromium, Firefox or WebKit, use at your own risk.
@@ -4088,12 +4088,12 @@ const v8toIstanbul = require('v8-to-istanbul');
 <!-- GEN:stop -->
 
 #### chromiumCoverage.startCSSCoverage([options])
-- `options` <[Object]>  Set of configurable options for coverage
+- `options` <[Object]> Set of configurable options for coverage
   - `resetOnNavigation` <[boolean]> Whether to reset coverage on every navigation. Defaults to `true`.
 - returns: <[Promise]> Promise that resolves when coverage is started
 
 #### chromiumCoverage.startJSCoverage([options])
-- `options` <[Object]>  Set of configurable options for coverage
+- `options` <[Object]> Set of configurable options for coverage
   - `resetOnNavigation` <[boolean]> Whether to reset coverage on every navigation. Defaults to `true`.
   - `reportAnonymousScripts` <[boolean]> Whether anonymous scripts generated by the page should be reported. Defaults to `false`.
 - returns: <[Promise]> Promise that resolves when coverage is started

--- a/docs/emulation.md
+++ b/docs/emulation.md
@@ -46,8 +46,7 @@ const context = await browser.newContext({
 });
 
 // Resize viewport for individual page
-await page.setViewportSize(
-    { 'width': 1600, 'height': 1200 });
+await page.setViewportSize({ width: 1600, height: 1200 });
 
 // Emulate high-DPI
 const context = await browser.newContext({
@@ -155,7 +154,7 @@ const context = await browser.newContext({
 Change the location later:
 
 ```js
-await context.setGeolocation({ longitude: 29.979097, latitude: 31.134256 };
+await context.setGeolocation({ longitude: 29.979097, latitude: 31.134256 });
 ```
 
 **Note** you can only change geolocation for all pages in the context.

--- a/docs/input.md
+++ b/docs/input.md
@@ -91,7 +91,7 @@ await page.selectOption('select#colors', option);
 
 ## Mouse click
 
-Performs a simple human click. 
+Performs a simple human click.
 
 ```js
 // Generic click
@@ -138,7 +138,7 @@ Under the hood, this and other pointer-related methods:
 
 ## Type characters
 
-Type into the field character by character, as if it was a user with a real keyboard. 
+Type into the field character by character, as if it was a user with a real keyboard.
 
 ```js
 // Type characted by character
@@ -187,10 +187,10 @@ Simple version produces a single character. This character is case-sensitive, so
 
 
 ```js
-// <input id=name></input>
+// <input id=name>
 await page.press('#name', 'Shift+A');
 
-// <input id=name></input>
+// <input id=name>
 await page.press('#name', 'Shift+ArrowLeft');
 ```
 
@@ -222,9 +222,9 @@ await page.setInputFiles('input#upload', []);
 
 // Upload buffer from memory
 await page.setInputFiles('input#upload', {
-	name: 'file.txt',
-	mimeType: 'text/plain',
-	buffer: Buffer.from('this is test')
+  name: 'file.txt',
+  mimeType: 'text/plain',
+  buffer: Buffer.from('this is test')
 });
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,8 +26,8 @@ These browsers will take few hundreds of megabytes of the disk space when instal
 ```sh
 du -hs ./Library/Caches/ms-playwright/*
 281M  chromium-XXXXXX
-187M	firefox-XXXX
-180M	webkit-XXXX
+187M  firefox-XXXX
+180M  webkit-XXXX
 ```
 
 You can override default behavior using environment variables. When installing Playwright, ask it to download browsers into a specific location:

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,7 +14,7 @@
 
 Use npm or Yarn to install Playwright in your Node.js project. Playwright requires Node.js 10 or higher.
 
-```
+```sh
 npm i playwright
 ```
 

--- a/docs/network.md
+++ b/docs/network.md
@@ -40,8 +40,8 @@ You can also use [`browserContext.setHTTPCredentials`](./api.md#browsercontextse
 
 ```js
 const [ download ] = await Promise.all([
-	page.waitForEvent('download'), // <-- start waiting for the download
-	page.click('button#delayed-download') // <-- perform the action that directly or indirectly initiates it.
+  page.waitForEvent('download'), // <-- start waiting for the download
+  page.click('button#delayed-download') // <-- perform the action that directly or indirectly initiates it.
 ]);
 const path = await download.path();
 ```

--- a/utils/testserver/README.md
+++ b/utils/testserver/README.md
@@ -7,9 +7,9 @@ This test server is used internally by Playwright to test Playwright itself.
 ```js
 const {TestServer} = require('.');
 
-(async(() => {
-  const httpServer = await TestServer.create(__dirname, 8000),
-  const httpsServer = await TestServer.createHTTPS(__dirname, 8001)
+(async () => {
+  const httpServer = await TestServer.create(__dirname, 8000);
+  const httpsServer = await TestServer.createHTTPS(__dirname, 8001);
   httpServer.setRoute('/hello', (req, res) => {
     res.end('Hello, world!');
   });


### PR DESCRIPTION
1. Some JS syntax fixes. I used `eslint-plugin-markdown`.
1. Change tabs to spaces.