### PR TITLE
fix(popups): do not override popup size from window features

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -346,6 +346,16 @@ class Helper {
       }
     }
   }
+
+  static getViewportSizeFromWindowFeatures(features: string[]): types.Size | null {
+    const widthString = features.find(f => f.startsWith('width='));
+    const heightString = features.find(f => f.startsWith('height='));
+    const width = widthString ? parseInt(widthString.substring(6), 10) : NaN;
+    const height = heightString ? parseInt(heightString.substring(7), 10) : NaN;
+    if (!Number.isNaN(width) && !Number.isNaN(height))
+      return { width, height };
+    return null;
+  }
 }
 
 export function assert(value: any, message?: string): asserts value {

--- a/src/webkit/wkBrowser.ts
+++ b/src/webkit/wkBrowser.ts
@@ -57,6 +57,7 @@ export class WKBrowser extends BrowserBase {
       helper.addEventListener(this._browserSession, 'Playwright.pageProxyCreated', this._onPageProxyCreated.bind(this)),
       helper.addEventListener(this._browserSession, 'Playwright.pageProxyDestroyed', this._onPageProxyDestroyed.bind(this)),
       helper.addEventListener(this._browserSession, 'Playwright.provisionalLoadFailed', event => this._onProvisionalLoadFailed(event)),
+      helper.addEventListener(this._browserSession, 'Playwright.windowOpen', event => this._onWindowOpen(event)),
       helper.addEventListener(this._browserSession, 'Playwright.downloadCreated', this._onDownloadCreated.bind(this)),
       helper.addEventListener(this._browserSession, 'Playwright.downloadFilenameSuggested', this._onDownloadFilenameSuggested.bind(this)),
       helper.addEventListener(this._browserSession, 'Playwright.downloadFinished', this._onDownloadFinished.bind(this)),
@@ -178,6 +179,13 @@ export class WKBrowser extends BrowserBase {
     if (!wkPage)
       return;
     wkPage.handleProvisionalLoadFailed(event);
+  }
+
+  _onWindowOpen(event: Protocol.Playwright.windowOpenPayload) {
+    const wkPage = this._wkPages.get(event.pageProxyId);
+    if (!wkPage)
+      return;
+    wkPage.handleWindowOpen(event);
   }
 
   isConnected(): boolean {


### PR DESCRIPTION
We usually force window size from the browser context. However, popups that have window features insist on a specific window size, so we respect that.