### PR TITLE
fix(docs): ava example, missing the context object

### DIFF
--- a/docs/test-runners.md
+++ b/docs/test-runners.md
@@ -54,7 +54,9 @@ const browserPromise = chromium.launch();
 
 async function pageMacro(t, callback) {
   const browser = await browserPromise;
-  const page = await browser.newPage();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
   try {
     await callback(t, page);
   } finally {


### PR DESCRIPTION
the previous example doesnt work out. Maybe other examples for the remaining test runners have also to be updated