### PR TITLE
feat(persistent context): ensure initial about:blank

### DIFF
--- a/src/browserContext.ts
+++ b/src/browserContext.ts
@@ -164,6 +164,17 @@ export abstract class BrowserContextBase extends ExtendedEventEmitter implements
   _log(log: Log, message: string | Error, ...args: any[]) {
     return this._logger._log(log, message, ...args);
   }
+
+  async _loadDefaultContext() {
+    if (!this.pages().length)
+      await this.waitForEvent('page');
+    const pages = this.pages();
+    await pages[0].waitForLoadState();
+    if (pages.length !== 1 || pages[0].url() !== 'about:blank') {
+      await this.close().catch(e => null);
+      throw new Error('Arguments can not specify page to be opened');
+    }
+  }
 }
 
 export function assertBrowserContextIsNotOwned(context: BrowserContextBase) {

--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -40,8 +40,6 @@ export class CRBrowser extends BrowserBase {
   _crPages = new Map<string, CRPage>();
   _backgroundPages = new Map<string, CRPage>();
   _serviceWorkers = new Map<string, CRServiceWorker>();
-  readonly _firstPagePromise: Promise<void>;
-  private _firstPageCallback = () => {};
 
   private _tracingRecording = false;
   private _tracingPath: string | null = '';
@@ -100,7 +98,6 @@ export class CRBrowser extends BrowserBase {
     });
     this._session.on('Target.attachedToTarget', this._onAttachedToTarget.bind(this));
     this._session.on('Target.detachedFromTarget', this._onDetachedFromTarget.bind(this));
-    this._firstPagePromise = new Promise(f => this._firstPageCallback = f);
   }
 
   async newContext(options: BrowserContextOptions = {}): Promise<BrowserContext> {
@@ -160,7 +157,6 @@ export class CRBrowser extends BrowserBase {
           signalBarrier.addPopup(crPage.pageOrError());
       }
       crPage.pageOrError().then(() => {
-        this._firstPageCallback();
         context!.emit(CommonEvents.BrowserContext.Page, crPage._page);
         if (opener) {
           opener.pageOrError().then(openerPage => {

--- a/src/firefox/ffBrowser.ts
+++ b/src/firefox/ffBrowser.ts
@@ -35,8 +35,6 @@ export class FFBrowser extends BrowserBase {
   readonly _defaultContext: FFBrowserContext | null = null;
   readonly _contexts: Map<string, FFBrowserContext>;
   private _eventListeners: RegisteredListener[];
-  readonly _firstPagePromise: Promise<void>;
-  private _firstPageCallback = () => {};
 
   static async connect(transport: ConnectionTransport, logger: InnerLogger, attachToDefaultContext: boolean, slowMo?: number): Promise<FFBrowser> {
     const connection = new FFConnection(SlowMoTransport.wrap(transport, slowMo), logger);
@@ -64,7 +62,6 @@ export class FFBrowser extends BrowserBase {
       helper.addEventListener(this._connection, 'Browser.downloadCreated', this._onDownloadCreated.bind(this)),
       helper.addEventListener(this._connection, 'Browser.downloadFinished', this._onDownloadFinished.bind(this)),
     ];
-    this._firstPagePromise = new Promise(f => this._firstPageCallback = f);
   }
 
   isConnected(): boolean {
@@ -137,7 +134,6 @@ export class FFBrowser extends BrowserBase {
         signalBarrier.addPopup(ffPage.pageOrError());
     }
     ffPage.pageOrError().then(async () => {
-      this._firstPageCallback();
       const page = ffPage._page;
       context.emit(Events.BrowserContext.Page, page);
       if (!opener)

--- a/src/timeoutSettings.ts
+++ b/src/timeoutSettings.ts
@@ -57,10 +57,13 @@ export class TimeoutSettings {
 
   computeDeadline(options?: TimeoutOptions) {
     const { timeout } = options || {};
+    return TimeoutSettings.computeDeadline(typeof timeout === 'number' ? timeout : this._timeout());
+  }
+
+  static computeDeadline(timeout: number): number {
     if (timeout === 0)
       return Number.MAX_SAFE_INTEGER;
-    else if (typeof timeout === 'number')
+    else
       return helper.monotonicTime() + timeout;
-    return helper.monotonicTime() + this._timeout();
   }
 }


### PR DESCRIPTION
We declare only the initial about:blank to be a supported usecase, so that we can support options for the default context in the future.