### PR TITLE
test: fix should poll on interval test

### DIFF
--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -50,7 +50,7 @@ describe('Frame.waitForFunction', function() {
       }
       return Date.now() - window.__startTime;
     }, {}, {polling});
-    expect(timeDelta).not.toBeLessThan(polling);
+    expect(await timeDelta.jsonValue()).not.toBeLessThan(polling);
   });
   it('should throw on polling:mutation', async({page, server}) => {
     const error = await page.waitForFunction(() => true, {}, {polling: 'mutation'}).catch(e => e);


### PR DESCRIPTION
This was an invalid check because we were comparing a `JSHandle` to a number. 

>expect(timeDelta).not.toBeLessThan(polling);

`timeDelta < polling` is always false. We need to grab the value from the `JSHandle` and use that.
 

