### PR TITLE
fix(launch): handle timeout and exceptions during launch

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -470,7 +470,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       return injected.waitForDisplayedAtStablePosition(node, rafCount, timeout);
     }, { rafCount, timeout: helper.timeUntilDeadline(deadline) });
     const timeoutMessage = 'element to be displayed and not moving';
-    const injectedResult = await helper.waitWithDeadline(stablePromise, timeoutMessage, deadline);
+    const injectedResult = await helper.waitWithDeadline(stablePromise, timeoutMessage, deadline, 'pw:input');
     handleInjectedResult(injectedResult, timeoutMessage);
     this._page._log(inputLog, '...element is displayed and does not move');
   }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -158,13 +158,9 @@ class Helper {
     });
   }
 
-  static async waitWithTimeout<T>(promise: Promise<T>, taskName: string, timeout: number): Promise<T> {
-    return this.waitWithDeadline(promise, taskName, helper.monotonicTime() + timeout);
-  }
-
-  static async waitWithDeadline<T>(promise: Promise<T>, taskName: string, deadline: number): Promise<T> {
+  static async waitWithDeadline<T>(promise: Promise<T>, taskName: string, deadline: number, debugName: string): Promise<T> {
     let reject: (error: Error) => void;
-    const timeoutError = new TimeoutError(`Waiting for ${taskName} failed: timeout exceeded. Re-run with the DEBUG=pw:input env variable to see the debug log.`);
+    const timeoutError = new TimeoutError(`Waiting for ${taskName} failed: timeout exceeded. Re-run with the DEBUG=${debugName} env variable to see the debug log.`);
     const timeoutPromise = new Promise<T>((resolve, x) => reject = x);
     const timeoutTimer = setTimeout(() => reject(timeoutError), helper.timeUntilDeadline(deadline));
     try {

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -42,11 +42,17 @@ export class Chromium extends AbstractBrowserType<CRBrowser> {
 
   async launch(options: LaunchOptions = {}): Promise<CRBrowser> {
     assert(!(options as any).userDataDir, 'userDataDir option is not supported in `browserType.launch`. Use `browserType.launchPersistentContext` instead');
+    const { timeout = 30000 } = options;
+    const deadline = TimeoutSettings.computeDeadline(timeout);
     const { browserServer, transport, downloadsPath, logger } = await this._launchServer(options, 'local');
-    const browser = await CRBrowser.connect(transport!, false, logger, options);
-    browser._ownedServer = browserServer;
-    browser._downloadsPath = downloadsPath;
-    return browser;
+    return await browserServer._initializeOrClose(deadline, async () => {
+      if ((options as any).__testHookBeforeCreateBrowser)
+        await (options as any).__testHookBeforeCreateBrowser();
+      const browser = await CRBrowser.connect(transport!, false, logger, options);
+      browser._ownedServer = browserServer;
+      browser._downloadsPath = downloadsPath;
+      return browser;
+    });
   }
 
   async launchServer(options: LaunchServerOptions = {}): Promise<BrowserServer> {
@@ -57,12 +63,16 @@ export class Chromium extends AbstractBrowserType<CRBrowser> {
     const { timeout = 30000 } = options;
     const deadline = TimeoutSettings.computeDeadline(timeout);
     const { transport, browserServer, logger } = await this._launchServer(options, 'persistent', userDataDir);
-    const browser = await CRBrowser.connect(transport!, true, logger, options);
-    browser._ownedServer = browserServer;
-    const context = browser._defaultContext!;
-    if (!options.ignoreDefaultArgs || Array.isArray(options.ignoreDefaultArgs))
-      await helper.waitWithTimeout(context._loadDefaultContext(), 'first page', helper.timeUntilDeadline(deadline));
-    return context;
+    return await browserServer._initializeOrClose(deadline, async () => {
+      if ((options as any).__testHookBeforeCreateBrowser)
+        await (options as any).__testHookBeforeCreateBrowser();
+      const browser = await CRBrowser.connect(transport!, true, logger, options);
+      browser._ownedServer = browserServer;
+      const context = browser._defaultContext!;
+      if (!options.ignoreDefaultArgs || Array.isArray(options.ignoreDefaultArgs))
+        await context._loadDefaultContext();
+      return context;
+    });
   }
 
   private async _launchServer(options: LaunchServerOptions, launchType: LaunchType, userDataDir?: string): Promise<{ browserServer: BrowserServer, transport?: ConnectionTransport, downloadsPath: string, logger: InnerLogger }> {

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -51,6 +51,17 @@ describe('Playwright', function() {
       await browserType.launch(options).catch(e => waitError = e);
       expect(waitError.message).toContain('Failed to launch');
     });
+    it('should handle timeout', async({browserType, defaultBrowserOptions}) => {
+      const options = { ...defaultBrowserOptions, timeout: 1000, __testHookBeforeCreateBrowser: () => new Promise(f => setTimeout(f, 2000)) };
+      const error = await browserType.launch(options).catch(e => e);
+      expect(error.message).toBe('Waiting for the browser to launch failed: timeout exceeded. Re-run with the DEBUG=pw:browser* env variable to see the debug log.');
+    });
+    it('should handle exception', async({browserType, defaultBrowserOptions}) => {
+      const e = new Error('Dummy');
+      const options = { ...defaultBrowserOptions, __testHookBeforeCreateBrowser: () => { throw e; } };
+      const error = await browserType.launch(options).catch(e => e);
+      expect(error).toBe(e);
+    });
   });
 
   describe('browserType.launchPersistentContext', function() {
@@ -85,6 +96,21 @@ describe('Playwright', function() {
       const gotUrls = browserContext.pages().map(page => page.url());
       expect(gotUrls).toEqual([server.EMPTY_PAGE]);
       await browserContext.close();
+      await removeUserDataDir(userDataDir);
+    });
+    it('should handle timeout', async({browserType, defaultBrowserOptions}) => {
+      const userDataDir = await makeUserDataDir();
+      const options = { ...defaultBrowserOptions, timeout: 1000, __testHookBeforeCreateBrowser: () => new Promise(f => setTimeout(f, 2000)) };
+      const error = await browserType.launchPersistentContext(userDataDir, options).catch(e => e);
+      expect(error.message).toBe('Waiting for the browser to launch failed: timeout exceeded. Re-run with the DEBUG=pw:browser* env variable to see the debug log.');
+      await removeUserDataDir(userDataDir);
+    });
+    it('should handle exception', async({browserType, defaultBrowserOptions}) => {
+      const userDataDir = await makeUserDataDir();
+      const e = new Error('Dummy');
+      const options = { ...defaultBrowserOptions, __testHookBeforeCreateBrowser: () => { throw e; } };
+      const error = await browserType.launchPersistentContext(userDataDir, options).catch(e => e);
+      expect(error).toBe(e);
       await removeUserDataDir(userDataDir);
     });
   });


### PR DESCRIPTION
This happened to me when I started throwing in `CRBrowser.connect` in a separate patch (see #2177). After catching the error, I noticed that we also leave the browser process running.