### PR TITLE
feat: surface javascript dialogs in `pw:input`

### DIFF
--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -626,6 +626,7 @@ class FrameSession {
 
   _onDialog(event: Protocol.Page.javascriptDialogOpeningPayload) {
     this._page.emit(Events.Page.Dialog, new dialog.Dialog(
+        this._page,
         event.type,
         event.message,
         async (accept: boolean, promptText?: string) => {

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -16,23 +16,28 @@
  */
 
 import { assert } from './helper';
+import { inputLog } from './logger';
+import { Page } from './page';
 
 type OnHandle = (accept: boolean, promptText?: string) => Promise<void>;
 
 export type DialogType = 'alert' | 'beforeunload' | 'confirm' | 'prompt';
 
 export class Dialog {
+  private _page: Page;
   private _type: string;
   private _message: string;
   private _onHandle: OnHandle;
   private _handled = false;
   private _defaultValue: string;
 
-  constructor(type: string, message: string, onHandle: OnHandle, defaultValue?: string) {
+  constructor(page: Page, type: string, message: string, onHandle: OnHandle, defaultValue?: string) {
+    this._page = page;
     this._type = type;
     this._message = message;
     this._onHandle = onHandle;
     this._defaultValue = defaultValue || '';
+    this._page._log(inputLog, `dialog opened: "${this._type}"`);
   }
 
   type(): string {
@@ -51,11 +56,13 @@ export class Dialog {
     assert(!this._handled, 'Cannot accept dialog which is already handled!');
     this._handled = true;
     await this._onHandle(true, promptText);
+    this._page._log(inputLog, `dialog accepted: "${this._type}"`);
   }
 
   async dismiss() {
     assert(!this._handled, 'Cannot dismiss dialog which is already handled!');
     this._handled = true;
     await this._onHandle(false);
+    this._page._log(inputLog, `dialog dismissed: "${this._type}"`);
   }
 }

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -27,7 +27,7 @@ import { Page } from './page';
 import { selectors } from './selectors';
 import * as types from './types';
 import { NotConnectedError, TimeoutError } from './errors';
-import { Log, logError } from './logger';
+import { Log, logError, inputLog } from './logger';
 
 export type PointerActionOptions = {
   modifiers?: input.Modifier[];
@@ -37,11 +37,6 @@ export type PointerActionOptions = {
 export type ClickOptions = PointerActionOptions & input.MouseClickOptions;
 
 export type MultiClickOptions = PointerActionOptions & input.MouseMultiClickOptions;
-
-export const inputLog: Log = {
-  name: 'input',
-  color: 'cyan'
-};
 
 export class FrameExecutionContext extends js.ExecutionContext {
   readonly frame: frames.Frame;

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -27,7 +27,7 @@ import { Page } from './page';
 import { selectors } from './selectors';
 import * as types from './types';
 import { NotConnectedError, TimeoutError } from './errors';
-import { Log, logError, inputLog } from './logger';
+import { logError, inputLog } from './logger';
 
 export type PointerActionOptions = {
   modifiers?: input.Modifier[];

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -194,6 +194,7 @@ export class FFPage implements PageDelegate {
 
   _onDialogOpened(params: Protocol.Page.dialogOpenedPayload) {
     this._page.emit(Events.Page.Dialog, new dialog.Dialog(
+        this._page,
         params.type,
         params.message,
         async (accept: boolean, promptText?: string) => {

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -28,6 +28,7 @@ import { Page } from './page';
 import { selectors } from './selectors';
 import * as types from './types';
 import { waitForTimeoutWasUsed } from './hints';
+import { inputLog } from './logger';
 
 type ContextType = 'main' | 'utility';
 type ContextData = {
@@ -688,13 +689,13 @@ export class Frame {
     selector: string, options: types.TimeoutOptions,
     action: (handle: dom.ElementHandle<Element>, deadline: number) => Promise<R>): Promise<R> {
     const deadline = this._page._timeoutSettings.computeDeadline(options);
-    this._page._log(dom.inputLog, `(page|frame).${actionName}("${selector}")`);
+    this._page._log(inputLog, `(page|frame).${actionName}("${selector}")`);
     while (!helper.isPastDeadline(deadline)) {
       try {
         const { world, task } = selectors._waitForSelectorTask(selector, 'attached', deadline);
-        this._page._log(dom.inputLog, `waiting for the selector "${selector}"`);
+        this._page._log(inputLog, `waiting for the selector "${selector}"`);
         const handle = await this._scheduleRerunnableTask(task, world, deadline, `selector "${selector}"`);
-        this._page._log(dom.inputLog, `...got element for the selector`);
+        this._page._log(inputLog, `...got element for the selector`);
         const element = handle.asElement() as dom.ElementHandle<Element>;
         try {
           return await action(element, deadline);
@@ -704,7 +705,7 @@ export class Frame {
       } catch (e) {
         if (!(e instanceof NotConnectedError))
           throw e;
-        this._page._log(dom.inputLog, 'Element was detached from the DOM, retrying');
+        this._page._log(inputLog, 'Element was detached from the DOM, retrying');
       }
     }
     throw new TimeoutError(`waiting for selector "${selector}" failed: timeout exceeded. Re-run with the DEBUG=pw:input env variable to see the debug log.`);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -35,6 +35,10 @@ export interface InnerLogger {
 }
 
 export const errorLog: Log = { name: 'generic', severity: 'error' };
+export const inputLog: Log = {
+  name: 'input',
+  color: 'cyan'
+};
 
 export function logError(logger: InnerLogger): (error: Error) => void {
   return error => logger._log(errorLog, error, []);

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -518,13 +518,14 @@ export class WKPage implements PageDelegate {
 
   _onDialog(event: Protocol.Dialog.javascriptDialogOpeningPayload) {
     this._page.emit(Events.Page.Dialog, new dialog.Dialog(
-      this._page,
-      event.type as dialog.DialogType,
-      event.message,
-      async (accept: boolean, promptText?: string) => {
-        await this._pageProxySession.send('Dialog.handleJavaScriptDialog', { accept, promptText });
-      },
-      event.defaultPrompt));
+        this._page,
+        event.type as dialog.DialogType,
+        event.message,
+        async (accept: boolean, promptText?: string) => {
+          await this._pageProxySession.send('Dialog.handleJavaScriptDialog', { accept, promptText });
+        },
+        event.defaultPrompt,
+    ));
   }
 
   private async _onFileChooserOpened(event: {frameId: Protocol.Network.FrameId, element: Protocol.Runtime.RemoteObject}) {

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -518,6 +518,7 @@ export class WKPage implements PageDelegate {
 
   _onDialog(event: Protocol.Dialog.javascriptDialogOpeningPayload) {
     this._page.emit(Events.Page.Dialog, new dialog.Dialog(
+      this._page,
       event.type as dialog.DialogType,
       event.message,
       async (accept: boolean, promptText?: string) => {


### PR DESCRIPTION
JS dialogs can stall all playwright scripts; surfacing
them in the `pw:input` logs should help debugging such issues.

Fixes #2200