### PR TITLE
devops: remove custom caching on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ notifications:
 install:
 - npm ci
 
-cache:
-  directories:
-  - node_modules
-
 jobs:
   include:
     - os: linux


### PR DESCRIPTION
Travis custom-caching seems to be unfortunate for us as it disables
`~/.npm` caching. Removing it.

References #2191