### PR TITLE
test: unflake launcher test

### DIFF
--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -58,7 +58,7 @@ describe('Playwright', function() {
     });
     it('should handle exception', async({browserType, defaultBrowserOptions}) => {
       const e = new Error('Dummy');
-      const options = { ...defaultBrowserOptions, __testHookBeforeCreateBrowser: () => { throw e; } };
+      const options = { ...defaultBrowserOptions, __testHookBeforeCreateBrowser: () => { throw e; }, timeout: 9000 };
       const error = await browserType.launch(options).catch(e => e);
       expect(error).toBe(e);
     });


### PR DESCRIPTION
We throw an exception and then gracefully close the browser. If something went wrong, we should timeout before the test times out, kill the process and report the original exception.