### PR TITLE
feat: add ElementHandle.hasFocus() method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2509,6 +2509,7 @@ ElementHandle instances can be used as an argument in [`page.$eval()`](#pageeval
 - [elementHandle.fill(value[, options])](#elementhandlefillvalue-options)
 - [elementHandle.focus()](#elementhandlefocus)
 - [elementHandle.getAttribute(name)](#elementhandlegetattributename)
+- [elementHandle.hasFocus()](#elementhandlehasfocus)
 - [elementHandle.hover([options])](#elementhandlehoveroptions)
 - [elementHandle.innerHTML()](#elementhandleinnerhtml)
 - [elementHandle.innerText()](#elementhandleinnertext)
@@ -2705,6 +2706,11 @@ Calls [focus](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
 - returns: <[Promise]<null|[string]>> Resolves to the attribute value.
 
 Returns element attribute value.
+
+#### elementHandle.hasFocus()
+- returns: <[Promise]<[boolean]>>
+
+Returns `true` is this element is equal to [`document.activeElement`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/activeElement).
 
 #### elementHandle.hover([options])
 - `options` <[Object]>

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -157,6 +157,15 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     }, {});
   }
 
+  async hasFocus(): Promise<boolean> {
+    return this._evaluateInUtility(({node}) => {
+      if (node.nodeType !== Node.ELEMENT_NODE)
+        throw new Error('Not an element');
+      const element = node as unknown as Element;
+      return element === document.activeElement;
+    }, {});
+  }
+
   async dispatchEvent(type: string, eventInit: Object = {}) {
     await this._evaluateInMain(({ injected, node }, { type, eventInit }) =>
       injected.dispatchEvent(node, type, eventInit), { type, eventInit });

--- a/test/focus.spec.js
+++ b/test/focus.spec.js
@@ -60,3 +60,14 @@ describe('Page.focus', function() {
     expect(await page.$eval('#i2', e => e.value)).toBe('Last');
   });
 });
+
+describe('ElementHandle.hasFocus', function() {
+  it('should work', async({page, server}) => {
+    await page.setContent(`<div id=d1 tabIndex=0></div>`);
+    expect(await page.$('body').then(body => body.hasFocus())).toBe(true);
+    expect(await page.$('#d1').then(div => div.hasFocus())).toBe(false);
+    await page.focus('#d1');
+    expect(await page.$('body').then(body => body.hasFocus())).toBe(false);
+    expect(await page.$('#d1').then(div => div.hasFocus())).toBe(true);
+  });
+});


### PR DESCRIPTION
Note: `page.hasFocus()` would look weird since it clashes with Web's
`document.hasFocus()`.

Fixes #2159