### PR TITLE
fix(webkit): do not swallow init errors

### DIFF
--- a/src/webkit/wkProvisionalPage.ts
+++ b/src/webkit/wkProvisionalPage.ts
@@ -48,7 +48,7 @@ export class WKProvisionalPage {
       helper.addEventListener(session, 'Network.loadingFailed', overrideFrameId(e => wkPage._onLoadingFailed(e))),
     ];
 
-    this.initializationPromise = this._wkPage._initializeSession(session, ({frameTree}) => this._handleFrameTree(frameTree));
+    this.initializationPromise = this._wkPage._initializeSession(session, true, ({frameTree}) => this._handleFrameTree(frameTree));
   }
 
   dispose() {


### PR DESCRIPTION
This is a speculative fix to the following issue from the bots:

NON-TEST ERROR #0: UNHANDLED ERROR
  TypeError: Cannot read property 'url' of undefined
      at WKPage._onTargetCreated (/Users/runner/runners/2.169.1/work/playwright/playwright/src/webkit/wkPage.ts:274:12)
      at process._tickCallback (internal/process/next_tick.js:68:7)

I assume that _initializeSession did swallow an error, so we erroneously
consider Page to be fully initialized (and having main frame).