### PR TITLE
fix(chromium): abort fetch requests that lack networkId

### DIFF
--- a/src/frames.ts
+++ b/src/frames.ts
@@ -215,8 +215,13 @@ export class FrameManager {
     this._inflightRequestStarted(request);
     for (const task of request.frame()._frameTasks)
       task.onRequest(request);
-    if (!request._isFavicon)
-      this._page._requestStarted(request);
+    if (request._isFavicon) {
+      const route = request._route();
+      if (route)
+        route.continue();
+      return;
+    }
+    this._page._requestStarted(request);
   }
 
   requestReceivedResponse(response: network.Response) {


### PR DESCRIPTION
These requests are usually internal ones, and we can safely abort them.
An example would be DevTools loading cached resources to show the content.
There will never be a matching Network.requestWillBeSent event, so we do not
report them to the user.