### PR TITLE
docs(test-runners.md): add WebStorm comment

### DIFF
--- a/docs/test-runners.md
+++ b/docs/test-runners.md
@@ -105,9 +105,9 @@ If using TypeScript, add types to your variables like:
 let page: import('playwright').Page;
 ```
 
-If using JavaScript, you can still get nice autocompletions in VSCode by using JSDOC
+If using JavaScript, you can still get nice autocompletions in VSCode or WebStorm by using JSDoc.
 ```js
-/** @type {import('playwright').Page} **/
+/** @type {import('playwright').Page} */
 let page;
 ```
 


### PR DESCRIPTION
This works in WebStorm too.

Also, I changed the end of the comment to `*/` - this is [standard](https://jsdoc.app/about-getting-started.html) and the double-star is an ESLint error with the [spaced-comment](https://eslint.org/docs/rules/spaced-comment) rule.

I made this edit in GitHub and it's done something with a newline at the end. Hope that's OK.