### PR TITLE
chore: simplify WebSocketTransport.connect

### DIFF
--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -114,11 +114,10 @@ export abstract class BrowserTypeBase implements BrowserType {
 
   async connect(options: ConnectOptions): Promise<Browser> {
     const logger = new RootLogger(options.logger);
-    return await WebSocketTransport.connect(options.wsEndpoint, async transport => {
-      if ((options as any).__testHookBeforeCreateBrowser)
-        await (options as any).__testHookBeforeCreateBrowser();
-      return this._connectToTransport(transport, { slowMo: options.slowMo, logger, downloadsPath: '' });
-    }, logger);
+    const transport = await WebSocketTransport.connect(options.wsEndpoint, logger);
+    if ((options as any).__testHookBeforeCreateBrowser)
+      await (options as any).__testHookBeforeCreateBrowser();
+    return this._connectToTransport(transport, { slowMo: options.slowMo, logger, downloadsPath: '' });
   }
 
   abstract _launchServer(options: LaunchServerOptions, launchType: LaunchType, browserServer: BrowserServer, userDataDir?: string): Promise<{ transport?: ConnectionTransport, downloadsPath: string }>;

--- a/src/server/electron.ts
+++ b/src/server/electron.ts
@@ -195,14 +195,11 @@ export class Electron  {
     const deadline = browserServer._launchDeadline;
     const timeoutError = new TimeoutError(`Timed out while trying to connect to Electron!`);
     const nodeMatch = await waitForLine(launchedProcess, launchedProcess.stderr, /^Debugger listening on (ws:\/\/.*)$/, helper.timeUntilDeadline(deadline), timeoutError);
-    const nodeConnection = await WebSocketTransport.connect(nodeMatch[1], transport => {
-      return new CRConnection(transport, logger);
-    });
+    const transport = await WebSocketTransport.connect(nodeMatch[1]);
+    const nodeConnection = new CRConnection(transport, logger);
 
     const chromeMatch = await waitForLine(launchedProcess, launchedProcess.stderr, /^DevTools listening on (ws:\/\/.*)$/, helper.timeUntilDeadline(deadline), timeoutError);
-    const chromeTransport = await WebSocketTransport.connect(chromeMatch[1], transport => {
-      return transport;
-    }, logger);
+    const chromeTransport = await WebSocketTransport.connect(chromeMatch[1], logger);
     browserServer._initialize(launchedProcess, gracefullyClose, null);
     const browser = await CRBrowser.connect(chromeTransport, { headful: true, logger, persistent: true, viewport: null, ownedServer: browserServer, downloadsPath: '' });
     app = new ElectronApplication(logger, browser, nodeConnection);

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -125,21 +125,13 @@ export class WebSocketTransport implements ConnectionTransport {
   onmessage?: (message: ProtocolResponse) => void;
   onclose?: () => void;
 
-  // 'onmessage' handler must be installed synchronously when 'onopen' callback is invoked to
-  // avoid missing incoming messages.
-  static connect<T>(url: string, onopen: (transport: ConnectionTransport) => Promise<T> | T, logger?: InnerLogger): Promise<T> {
+  static connect(url: string, logger?: InnerLogger): Promise<ConnectionTransport> {
     logger && logger._log({ name: 'browser' }, `<ws connecting> ${url}`);
     const transport = new WebSocketTransport(url, logger);
-    return new Promise<T>((fulfill, reject) => {
+    return new Promise((fulfill, reject) => {
       transport._ws.addEventListener('open', async () => {
         logger && logger._log({ name: 'browser' }, `<ws connected> ${url}`);
-        try {
-          fulfill(await onopen(transport));
-        } catch (e) {
-          logger && logger._log({ name: 'browser' }, `<ws disconnecting> ${url}`);
-          try { transport._ws.close(); } catch (ignored) {}
-          reject(e);
-        }
+        fulfill(transport);
       });
       transport._ws.addEventListener('error', event => {
         logger && logger._log({ name: 'browser' }, `<ws connect error> ${url} ${event.message}`);


### PR DESCRIPTION
Now that all browsers support radio silence it's ok to add message listeners asynchronously after web socket is connected as we won't miss any messages.