### PR TITLE
feat(click): retry when the element it outside of the viewport

### DIFF
--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -411,12 +411,12 @@ export class FFPage implements PageDelegate {
     return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
   }
 
-  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<void> {
-    await this._session.send('Page.scrollIntoViewIfNeeded', {
+  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'success' | 'invisible'> {
+    return await this._session.send('Page.scrollIntoViewIfNeeded', {
       frameId: handle._context.frame._id,
       objectId: handle._remoteObject.objectId!,
       rect,
-    }).catch(e => {
+    }).then(() => 'success' as const).catch(e => {
       if (e instanceof Error && e.message.includes('Node is detached from document'))
         throw new NotConnectedError();
       throw e;

--- a/src/page.ts
+++ b/src/page.ts
@@ -68,7 +68,7 @@ export interface PageDelegate {
   setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void>;
   getBoundingBox(handle: dom.ElementHandle): Promise<types.Rect | null>;
   getFrameElement(frame: frames.Frame): Promise<dom.ElementHandle>;
-  scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<void>;
+  scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'success' | 'invisible'>;
   setActivityPaused(paused: boolean): Promise<void>;
   rafCountForStablePosition(): number;
 

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -254,25 +254,25 @@ describe('ElementHandle.click', function() {
     await button.click().catch(err => error = err);
     expect(error.message).toContain('Element is not attached to the DOM');
   });
-  it('should throw for hidden nodes', async({page, server}) => {
+  it('should throw for hidden nodes with force', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/button.html');
     const button = await page.$('button');
     await page.evaluate(button => button.style.display = 'none', button);
     const error = await button.click({ force: true }).catch(err => err);
-    expect(error.message).toBe('Node is either not visible or not an HTMLElement');
+    expect(error.message).toBe('Element is not visible');
   });
-  it('should throw for recursively hidden nodes', async({page, server}) => {
+  it('should throw for recursively hidden nodes with force', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/button.html');
     const button = await page.$('button');
     await page.evaluate(button => button.parentElement.style.display = 'none', button);
     const error = await button.click({ force: true }).catch(err => err);
-    expect(error.message).toBe('Node is either not visible or not an HTMLElement');
+    expect(error.message).toBe('Element is not visible');
   });
-  it('should throw for <br> elements', async({page, server}) => {
+  it('should throw for <br> elements with force', async({page, server}) => {
     await page.setContent('hello<br>goodbye');
     const br = await page.$('br');
     const error = await br.click({ force: true }).catch(err => err);
-    expect(error.message).toBe('Node is either not visible or not an HTMLElement');
+    expect(error.message).toBe('Element is outside of the viewport');
   });
 });
 


### PR DESCRIPTION
The element might get animated into the viewport. Fixes #2276.