### PR TITLE
chore: introduce Progress concept

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -57,21 +57,6 @@ export class RootLogger implements InnerLogger {
     if (this._logger.isEnabled(log.name, log.severity || 'info'))
       this._logger.log(log.name, log.severity || 'info', message, args, log.color ? { color: log.color } : {});
   }
-
-  startLaunchRecording() {
-    this._logger.add(`launch`, new RecordingLogger('browser'));
-  }
-
-  launchRecording(): string {
-    const logger = this._logger.get(`launch`) as RecordingLogger;
-    if (logger)
-      return logger.recording();
-    return '';
-  }
-
-  stopLaunchRecording() {
-    this._logger.remove(`launch`);
-  }
 }
 
 const colorMap = new Map<string, number>([
@@ -110,27 +95,6 @@ class MultiplexingLogger implements Logger {
   log(name: string, severity: LoggerSeverity, message: string | Error, args: any[], hints: { color?: string }) {
     for (const logger of this._loggers.values())
       logger.log(name, severity, message, args, hints);
-  }
-}
-
-export class RecordingLogger implements Logger {
-  private _prefix: string;
-  private _recording: string[] = [];
-
-  constructor(prefix: string) {
-    this._prefix = prefix;
-  }
-
-  isEnabled(name: string, severity: LoggerSeverity): boolean {
-    return name.startsWith(this._prefix);
-  }
-
-  log(name: string, severity: LoggerSeverity, message: string | Error, args: any[], hints: { color?: string }) {
-    this._recording.push(String(message));
-  }
-
-  recording(): string {
-    return this._recording.join('\n');
   }
 }
 

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InnerLogger, Log } from './logger';
+import { TimeoutError } from './errors';
+import { helper } from './helper';
+import * as types from './types';
+import { DEFAULT_TIMEOUT, TimeoutSettings } from './timeoutSettings';
+import { getCurrentApiCall, rewriteErrorMessage } from './debug/stackTrace';
+
+class AbortError extends Error {}
+
+export class Progress {
+  static async runCancelableTask<T>(task: (progress: Progress) => Promise<T>, timeoutOptions: types.TimeoutOptions, logger: InnerLogger, apiName?: string): Promise<T> {
+    let resolveCancelation = () => {};
+    const progress = new Progress(timeoutOptions, logger, new Promise(resolve => resolveCancelation = resolve), apiName);
+
+    const { timeout = DEFAULT_TIMEOUT } = timeoutOptions;
+    const timeoutError = new TimeoutError(`Timeout ${timeout}ms exceeded during ${progress.apiName}.`);
+    let rejectWithTimeout: (error: Error) => void;
+    const timeoutPromise = new Promise<T>((resolve, x) => rejectWithTimeout = x);
+    const timeoutTimer = setTimeout(() => rejectWithTimeout(timeoutError), helper.timeUntilDeadline(progress.deadline));
+
+    try {
+      const promise = task(progress);
+      const result = await Promise.race([promise, timeoutPromise]);
+      clearTimeout(timeoutTimer);
+      progress._running = false;
+      progress._logRecording = [];
+      return result;
+    } catch (e) {
+      resolveCancelation();
+      rewriteErrorMessage(e, e.message + formatLogRecording(progress._logRecording, progress.apiName));
+      clearTimeout(timeoutTimer);
+      progress._running = false;
+      progress._logRecording = [];
+      await Promise.all(progress._cleanups.splice(0).map(cleanup => runCleanup(cleanup)));
+      throw e;
+    }
+  }
+
+  readonly apiName: string;
+  readonly deadline: number;  // To be removed?
+  readonly _canceled: Promise<any>;
+
+  private _logger: InnerLogger;
+  private _logRecording: string[] = [];
+  private _cleanups: (() => any)[] = [];
+  private _running = true;
+
+  constructor(options: types.TimeoutOptions, logger: InnerLogger, canceled: Promise<any>, apiName?: string) {
+    this.apiName = apiName || getCurrentApiCall();
+    this.deadline = TimeoutSettings.computeDeadline(options.timeout);
+    this._canceled = canceled;
+    this._logger = logger;
+  }
+
+  cleanupWhenCanceled(cleanup: () => any) {
+    if (this._running)
+      this._cleanups.push(cleanup);
+    else
+      runCleanup(cleanup);
+  }
+
+  throwIfCanceled() {
+    if (!this._running)
+      throw new AbortError();
+  }
+
+  race<T>(promise: Promise<T>, cleanup?: () => any): Promise<T> {
+    const canceled = this._canceled.then(async error => {
+      if (cleanup)
+        await runCleanup(cleanup);
+      throw error;
+    });
+    const success = promise.then(result => {
+      cleanup = undefined;
+      return result;
+    });
+    return Promise.race<T>([success, canceled]);
+  }
+
+  log(log: Log, message: string | Error): void {
+    if (this._running)
+      this._logRecording.push(message.toString());
+    this._logger._log(log, message);
+  }
+}
+
+async function runCleanup(cleanup: () => any) {
+  try {
+    await cleanup();
+  } catch (e) {
+  }
+}
+
+function formatLogRecording(log: string[], name: string): string {
+  name = ` ${name} logs `;
+  const headerLength = 60;
+  const leftLength = (headerLength - name.length) / 2;
+  const rightLength = headerLength - name.length - leftLength;
+  return `\n${'='.repeat(leftLength)}${name}${'='.repeat(rightLength)}\n${log.join('\n')}\n${'='.repeat(headerLength)}`;
+}

--- a/src/server/browserServer.ts
+++ b/src/server/browserServer.ts
@@ -15,8 +15,8 @@
  */
 
 import { ChildProcess } from 'child_process';
-import { EventEmitter } from 'events';
 import { helper } from '../helper';
+import { EventEmitter } from 'events';
 
 export class WebSocketWrapper {
   readonly wsEndpoint: string;

--- a/src/server/processLauncher.ts
+++ b/src/server/processLauncher.ts
@@ -16,17 +16,17 @@
  */
 
 import * as childProcess from 'child_process';
-import { Log, RootLogger } from '../logger';
+import { Log } from '../logger';
 import * as readline from 'readline';
 import * as removeFolder from 'rimraf';
 import * as stream from 'stream';
 import * as util from 'util';
-import { TimeoutError } from '../errors';
 import { helper } from '../helper';
+import { Progress } from '../progress';
 
 const removeFolderAsync = util.promisify(removeFolder);
 
-const browserLog: Log = {
+export const browserLog: Log = {
   name: 'browser',
 };
 
@@ -57,7 +57,7 @@ export type LaunchProcessOptions = {
   // Note: attemptToGracefullyClose should reject if it does not close the browser.
   attemptToGracefullyClose: () => Promise<any>,
   onExit: (exitCode: number | null, signal: string | null) => void,
-  logger: RootLogger,
+  progress: Progress,
 };
 
 type LaunchResult = {
@@ -73,9 +73,9 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     }));
   };
 
-  const logger = options.logger;
+  const progress = options.progress;
   const stdio: ('ignore' | 'pipe')[] = options.pipe ? ['ignore', 'pipe', 'pipe', 'pipe', 'pipe'] : ['ignore', 'pipe', 'pipe'];
-  logger._log(browserLog, `<launching> ${options.executablePath} ${options.args.join(' ')}`);
+  progress.log(browserLog, `<launching> ${options.executablePath} ${options.args.join(' ')}`);
   const spawnedProcess = childProcess.spawn(
       options.executablePath,
       options.args,
@@ -97,16 +97,16 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     });
     return cleanup().then(() => failedPromise).then(e => Promise.reject(e));
   }
-  logger._log(browserLog, `<launched> pid=${spawnedProcess.pid}`);
+  progress.log(browserLog, `<launched> pid=${spawnedProcess.pid}`);
 
   const stdout = readline.createInterface({ input: spawnedProcess.stdout });
   stdout.on('line', (data: string) => {
-    logger._log(browserStdOutLog, data);
+    progress.log(browserStdOutLog, data);
   });
 
   const stderr = readline.createInterface({ input: spawnedProcess.stderr });
   stderr.on('line', (data: string) => {
-    logger._log(browserStdErrLog, data);
+    progress.log(browserStdErrLog, data);
   });
 
   let processClosed = false;
@@ -115,7 +115,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
   let fulfillCleanup = () => {};
   const waitForCleanup = new Promise<void>(f => fulfillCleanup = f);
   spawnedProcess.once('exit', (exitCode, signal) => {
-    logger._log(browserLog, `<process did exit ${exitCode}, ${signal}>`);
+    progress.log(browserLog, `<process did exit: exitCode=${exitCode}, signal=${signal}>`);
     processClosed = true;
     helper.removeEventListeners(listeners);
     options.onExit(exitCode, signal);
@@ -142,21 +142,21 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     // reentrancy to this function, for example user sends SIGINT second time.
     // In this case, let's forcefully kill the process.
     if (gracefullyClosing) {
-      logger._log(browserLog, `<forecefully close>`);
+      progress.log(browserLog, `<forecefully close>`);
       killProcess();
       await waitForClose;  // Ensure the process is dead and we called options.onkill.
       return;
     }
     gracefullyClosing = true;
-    logger._log(browserLog, `<gracefully close start>`);
+    progress.log(browserLog, `<gracefully close start>`);
     await options.attemptToGracefullyClose().catch(() => killProcess());
     await waitForCleanup;  // Ensure the process is dead and we have cleaned up.
-    logger._log(browserLog, `<gracefully close end>`);
+    progress.log(browserLog, `<gracefully close end>`);
   }
 
   // This method has to be sync to be used as 'exit' event handler.
   function killProcess() {
-    logger._log(browserLog, `<kill>`);
+    progress.log(browserLog, `<kill>`);
     helper.removeEventListeners(listeners);
     if (spawnedProcess.pid && !spawnedProcess.killed && !processClosed) {
       // Force kill the browser.
@@ -184,36 +184,19 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
   return { launchedProcess: spawnedProcess, gracefullyClose, kill: killAndWait };
 }
 
-export function waitForLine(process: childProcess.ChildProcess, inputStream: stream.Readable, regex: RegExp, timeout: number, timeoutError: TimeoutError): Promise<RegExpMatchArray> {
+export function waitForLine(progress: Progress, process: childProcess.ChildProcess, inputStream: stream.Readable, regex: RegExp): Promise<RegExpMatchArray> {
   return new Promise((resolve, reject) => {
     const rl = readline.createInterface({ input: inputStream });
-    let stderr = '';
     const listeners = [
       helper.addEventListener(rl, 'line', onLine),
-      helper.addEventListener(rl, 'close', () => onClose()),
-      helper.addEventListener(process, 'exit', () => onClose()),
-      helper.addEventListener(process, 'error', error => onClose(error))
+      helper.addEventListener(rl, 'close', reject),
+      helper.addEventListener(process, 'exit', reject),
+      helper.addEventListener(process, 'error', reject)
     ];
-    const timeoutId = timeout ? setTimeout(onTimeout, timeout) : 0;
 
-    function onClose(error?: Error) {
-      cleanup();
-      reject(new Error([
-        'Failed to launch browser!' + (error ? ' ' + error.message : ''),
-        stderr,
-        '',
-        'TROUBLESHOOTING: https://github.com/Microsoft/playwright/blob/master/docs/troubleshooting.md',
-        '',
-      ].join('\n')));
-    }
-
-    function onTimeout() {
-      cleanup();
-      reject(timeoutError);
-    }
+    progress.cleanupWhenCanceled(cleanup);
 
     function onLine(line: string) {
-      stderr += line + '\n';
       const match = line.match(regex);
       if (!match)
         return;
@@ -222,8 +205,6 @@ export function waitForLine(process: childProcess.ChildProcess, inputStream: str
     }
 
     function cleanup() {
-      if (timeoutId)
-        clearTimeout(timeoutId);
       helper.removeEventListeners(listeners);
     }
   });

--- a/src/timeoutSettings.ts
+++ b/src/timeoutSettings.ts
@@ -19,7 +19,7 @@ import { TimeoutOptions } from './types';
 import { helper } from './helper';
 import * as debugSupport from './debug/debugSupport';
 
-const DEFAULT_TIMEOUT = debugSupport.isDebugMode() ? 0 : 30000;
+export const DEFAULT_TIMEOUT = debugSupport.isDebugMode() ? 0 : 30000;
 
 export class TimeoutSettings {
   private _parent: TimeoutSettings | undefined;

--- a/test/defaultbrowsercontext.spec.js
+++ b/test/defaultbrowsercontext.spec.js
@@ -363,7 +363,7 @@ describe('launchPersistentContext()', function() {
     const userDataDir = await makeUserDataDir();
     const options = { ...defaultBrowserOptions, timeout: 5000, __testHookBeforeCreateBrowser: () => new Promise(f => setTimeout(f, 6000)) };
     const error = await browserType.launchPersistentContext(userDataDir, options).catch(e => e);
-    expect(error.message).toContain('Waiting for the browser to launch failed: timeout exceeded. Re-run with the DEBUG=pw:browser* env variable to see the debug log.');
+    expect(error.message).toContain(`Timeout 5000ms exceeded during ${browserType.name()}.launchPersistentContext.`);
     await removeUserDataDir(userDataDir);
   });
   it('should handle exception', async({browserType, defaultBrowserOptions}) => {

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -53,7 +53,7 @@ describe('Playwright', function() {
     it('should handle timeout', async({browserType, defaultBrowserOptions}) => {
       const options = { ...defaultBrowserOptions, timeout: 5000, __testHookBeforeCreateBrowser: () => new Promise(f => setTimeout(f, 6000)) };
       const error = await browserType.launch(options).catch(e => e);
-      expect(error.message).toContain('Waiting for the browser to launch failed: timeout exceeded. Re-run with the DEBUG=pw:browser* env variable to see the debug log.');
+      expect(error.message).toContain(`Timeout 5000ms exceeded during ${browserType.name()}.launch.`);
     });
     it('should handle exception', async({browserType, defaultBrowserOptions}) => {
       const e = new Error('Dummy');
@@ -285,11 +285,10 @@ describe('browserType.connect', function() {
   });
   it.slow()('should handle exceptions during connect', async({browserType, defaultBrowserOptions, server}) => {
     const browserServer = await browserType.launchServer(defaultBrowserOptions);
-    const e = new Error('Dummy');
-    const __testHookBeforeCreateBrowser = () => { throw e };
+    const __testHookBeforeCreateBrowser = () => { throw new Error('Dummy') };
     const error = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint(), __testHookBeforeCreateBrowser }).catch(e => e);
     await browserServer._checkLeaks();
     await browserServer.close();
-    expect(error).toBe(e);
+    expect(error.message).toContain('Dummy');
   });
 });


### PR DESCRIPTION
A progress roughly corresponds to an api call. It is used:
- to collect logs related to the call;
- to handle timeout;
- to provide "cancellation token" behavior so that cancelable process can either early-exit with `progress.throwIfCanceled()` or race against it with `progress.race()`;
- to ensure resources are disposed in the case of a failure with `progress.cleanupWhenCanceled()`;
- (possibly) to log api calls if needed;
- (in the future) to augment async stacks.