### PR TITLE
Recommend a dev install of Playwright in the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Headless execution is supported for all the browsers on all platforms.
 ## Usage
 
 ```
-npm i playwright
+npm i -D playwright
 ```
 
 This installs Playwright and browser binaries for Chromium, Firefox and WebKit. Once installed, you can `require` Playwright in a Node.js script and automate web browser interactions.

--- a/docs/api.md
+++ b/docs/api.md
@@ -4393,7 +4393,7 @@ If Playwright doesn't find them in the environment, a lowercased variant of thes
 
 ```sh
 # Install browsers to the shared location.
-$ PLAYWRIGHT_BROWSERS_PATH=$HOME/playwright-browsers npm install playwright
+$ PLAYWRIGHT_BROWSERS_PATH=$HOME/playwright-browsers npm install --save-dev playwright
 # Use shared location to find browsers.
 $ PLAYWRIGHT_BROWSERS_PATH=$HOME/playwright-browsers node playwright-script.js
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ Each version of Playwright needs specific versions of browser binaries to operat
 - `~/.cache/ms-playwright` on Linux
 
 ```sh
-npm i playwright
+npm i -D playwright
 ```
 
 These browsers will take few hundreds of megabytes of the disk space when installed:
@@ -33,7 +33,7 @@ du -hs ./Library/Caches/ms-playwright/*
 You can override default behavior using environment variables. When installing Playwright, ask it to download browsers into a specific location:
 
 ```sh
-$ PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers npm i playwright
+$ PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers npm i -D playwright
 ```
 
 When running Playwright scripts, ask it to search for browsers in a shared location:
@@ -65,7 +65,7 @@ binaries. In this case, Playwright can be configured to download from a custom
 location using the `PLAYWRIGHT_DOWNLOAD_HOST` env variable.
 
 ```sh
-$ PLAYWRIGHT_DOWNLOAD_HOST=192.168.1.78 npm i playwright
+$ PLAYWRIGHT_DOWNLOAD_HOST=192.168.1.78 npm i -D playwright
 ```
 
 <br>
@@ -78,7 +78,7 @@ browser binaries are managed separately.
 This can be done by setting `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` variable before installation.
 
 ```sh
-$ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i playwright
+$ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i -D playwright
 ```
 
 <br>
@@ -97,7 +97,7 @@ Using these packages is as easy as using a regular Playwright:
 Install a specific package
 
 ```sh
-$ npm i playwright-webkit
+$ npm i -D playwright-webkit
 ```
 
 Require package

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -15,7 +15,7 @@
 Use npm or Yarn to install Playwright in your Node.js project. Playwright requires Node.js 10 or higher.
 
 ```sh
-npm i playwright
+npm i -D playwright
 ```
 
 During installation, Playwright downloads browser binaries for Chromium, Firefox and WebKit. This sets up your environment for browser automation with just one command. It is possible to modify this default behavior for monorepos and other scenarios. See [installation parameters](installation.md) for mode details.


### PR DESCRIPTION
Seems like most usage of Playwright needs it as a dev dependency. Probably best to give users the easiest thing they can copy/paste.