### PR TITLE
feat: Request.postDataJSON

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3499,6 +3499,7 @@ If request gets a 'redirect' response, the request is successfully finished with
 - [request.isNavigationRequest()](#requestisnavigationrequest)
 - [request.method()](#requestmethod)
 - [request.postData()](#requestpostdata)
+- [request.postDataJSON()](#requestpostdatajson)
 - [request.redirectedFrom()](#requestredirectedfrom)
 - [request.redirectedTo()](#requestredirectedto)
 - [request.resourceType()](#requestresourcetype)
@@ -3537,6 +3538,9 @@ Whether this request is driving frame's navigation.
 
 #### request.postData()
 - returns: <?[string]> Request's post body, if any.
+
+#### request.postDataJSON()
+- returns: <?[Object]> Parsed request's body if the request is JSON or form-urlencoded if any.
 
 #### request.redirectedFrom()
 - returns: <?[Request]> Request that was redirected by the server to this one, if any.

--- a/docs/api.md
+++ b/docs/api.md
@@ -3540,7 +3540,9 @@ Whether this request is driving frame's navigation.
 - returns: <?[string]> Request's post body, if any.
 
 #### request.postDataJSON()
-- returns: <?[Object]> Parsed request's body if the request is JSON or form-urlencoded if any.
+- returns: <?[Object]> Parsed request's body for `form-urlencoded` and JSON as a fallback if any.
+
+When the response is `application/x-www-form-urlencoded` then a key/value object of the values will be returned. Otherwise it will be parsed as JSON.
 
 #### request.redirectedFrom()
 - returns: <?[Request]> Request that was redirected by the server to this one, if any.

--- a/src/network.ts
+++ b/src/network.ts
@@ -170,13 +170,10 @@ export class Request {
       return entries;
     }
 
-    if (contentType.startsWith('application/json'))
-      return JSON.parse(this._postData);
-
-    return null;
+    return JSON.parse(this._postData);
   }
 
-  headers(): { [key: string]: string } {
+  headers(): {[key: string]: string} {
     return { ...this._headers };
   }
 

--- a/src/network.ts
+++ b/src/network.ts
@@ -20,6 +20,7 @@ import * as util from 'util';
 import * as frames from './frames';
 import { assert, helper } from './helper';
 import { Page } from './page';
+import { URLSearchParams } from 'url';
 
 export type NetworkCookie = {
   name: string,
@@ -153,7 +154,29 @@ export class Request {
     return this._postData;
   }
 
-  headers(): {[key: string]: string} {
+  postDataJSON(): Object | null {
+    if (!this._postData)
+      return null;
+
+    const contentType = this.headers()['content-type'];
+    if (!contentType)
+      return null;
+
+    if (contentType === 'application/x-www-form-urlencoded') {
+      const entries: Record<string, string> = {};
+      const parsed = new URLSearchParams(this._postData);
+      for (const [k, v] of parsed.entries())
+        entries[k] = v;
+      return entries;
+    }
+
+    if (contentType.startsWith('application/json'))
+      return JSON.parse(this._postData);
+
+    return null;
+  }
+
+  headers(): { [key: string]: string } {
     return { ...this._headers };
   }
 

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -157,7 +157,6 @@ describe('Request.postDataJSON', function () {
     page.on('request', r => request = r);
     await page.evaluate(() => fetch('./post', { method: 'POST', body: JSON.stringify({ foo: 'bar' }) }));
     expect(request).toBeTruthy();
-    console.log(request.headers())
     expect(request.postDataJSON()).toEqual(null);
   });
 

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -140,6 +140,44 @@ describe('Request.postData', function() {
   });
 });
 
+describe('Request.postDataJSON', function () {
+  it('should work with application/json content-type', async ({ page, server }) => {
+    await page.goto(server.EMPTY_PAGE);
+    server.setRoute('/post', (req, res) => res.end());
+    let request = null;
+    page.on('request', r => request = r);
+    await page.evaluate(() => fetch('./post', { method: 'POST', body: JSON.stringify({ foo: 'bar' }), headers: new Headers({ 'Content-Type': 'application/json' }) }));
+    expect(request).toBeTruthy();
+    expect(request.postDataJSON()).toEqual({ "foo": "bar" });
+  });
+  it('should be |undefined| when it is has no application/json content-type', async ({ page, server }) => {
+    await page.goto(server.EMPTY_PAGE);
+    server.setRoute('/post', (req, res) => res.end());
+    let request = null;
+    page.on('request', r => request = r);
+    await page.evaluate(() => fetch('./post', { method: 'POST', body: JSON.stringify({ foo: 'bar' }) }));
+    expect(request).toBeTruthy();
+    console.log(request.headers())
+    expect(request.postDataJSON()).toEqual(null);
+  });
+
+  it("should parse the data if content-type is application/x-www-form-urlencoded", async({page, server}) => {
+    await page.goto(server.EMPTY_PAGE);
+    server.setRoute('/post', (req, res) => res.end());
+    let request = null;
+    page.on('request', r => request = r);
+    await page.setContent(`<form method='POST' action='/post'><input type='text' name='foo' value='bar'><input type='number' name='baz' value='123'><input type='submit'></form>`);
+    await page.click('input[type=submit]');
+    expect(request).toBeTruthy();
+    expect(request.postDataJSON()).toEqual({"foo":"bar","baz":"123"});
+  })
+
+  it('should be |undefined| when there is no post data', async ({ page, server }) => {
+    const response = await page.goto(server.EMPTY_PAGE);
+    expect(response.request().postDataJSON()).toBe(null);
+  });
+});
+
 describe('Response.text', function() {
   it('should work', async({page, server}) => {
     const response = await page.goto(server.PREFIX + '/simple.json');

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -141,26 +141,17 @@ describe('Request.postData', function() {
 });
 
 describe('Request.postDataJSON', function () {
-  it('should work with application/json content-type', async ({ page, server }) => {
-    await page.goto(server.EMPTY_PAGE);
-    server.setRoute('/post', (req, res) => res.end());
-    let request = null;
-    page.on('request', r => request = r);
-    await page.evaluate(() => fetch('./post', { method: 'POST', body: JSON.stringify({ foo: 'bar' }), headers: new Headers({ 'Content-Type': 'application/json' }) }));
-    expect(request).toBeTruthy();
-    expect(request.postDataJSON()).toEqual({ "foo": "bar" });
-  });
-  it('should be |undefined| when it is has no application/json content-type', async ({ page, server }) => {
+  it('should parse the JSON payload', async ({ page, server }) => {
     await page.goto(server.EMPTY_PAGE);
     server.setRoute('/post', (req, res) => res.end());
     let request = null;
     page.on('request', r => request = r);
     await page.evaluate(() => fetch('./post', { method: 'POST', body: JSON.stringify({ foo: 'bar' }) }));
     expect(request).toBeTruthy();
-    expect(request.postDataJSON()).toEqual(null);
+    expect(request.postDataJSON()).toEqual({ "foo": "bar" });
   });
 
-  it("should parse the data if content-type is application/x-www-form-urlencoded", async({page, server}) => {
+  it('should parse the data if content-type is application/x-www-form-urlencoded', async({page, server}) => {
     await page.goto(server.EMPTY_PAGE);
     server.setRoute('/post', (req, res) => res.end());
     let request = null;
@@ -168,7 +159,7 @@ describe('Request.postDataJSON', function () {
     await page.setContent(`<form method='POST' action='/post'><input type='text' name='foo' value='bar'><input type='number' name='baz' value='123'><input type='submit'></form>`);
     await page.click('input[type=submit]');
     expect(request).toBeTruthy();
-    expect(request.postDataJSON()).toEqual({"foo":"bar","baz":"123"});
+    expect(request.postDataJSON()).toEqual({'foo':'bar','baz':'123'});
   })
 
   it('should be |undefined| when there is no post data', async ({ page, server }) => {


### PR DESCRIPTION
This PR implements the `Request.postDataJSON` method as proposed in #1686.

Currently it handles `JSON` and `form-urlencoded` values which is probably enough for most use cases. Also thought about renaming it to e.g. `parsedPostData`.