### PR TITLE
feat: make browserServer.kill() wait for the process to exit

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3935,8 +3935,9 @@ Emitted when the browser server closes.
 Closes the browser gracefully and makes sure the process is terminated.
 
 #### browserServer.kill()
+- returns: <[Promise]>
 
-Kills the browser process.
+Kills the browser process and waits for the process to exit.
 
 #### browserServer.process()
 - returns: <[ChildProcess]> Spawned browser application process.

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -230,7 +230,7 @@ export abstract class BrowserTypeBase implements BrowserType {
     // "Cannot access 'browserServer' before initialization" if something went wrong.
     let transport: ConnectionTransport | undefined = undefined;
     let browserServer: BrowserServer | undefined = undefined;
-    const { launchedProcess, gracefullyClose } = await launchProcess({
+    const { launchedProcess, gracefullyClose, kill } = await launchProcess({
       executablePath: executable,
       args: browserArguments,
       env: this._amendEnvironment(env, userDataDir, executable, browserArguments),
@@ -248,7 +248,7 @@ export abstract class BrowserTypeBase implements BrowserType {
         // our connection ignores kBrowserCloseMessageId.
         this._attemptToGracefullyCloseBrowser(transport!);
       },
-      onkill: (exitCode, signal) => {
+      onExit: (exitCode, signal) => {
         if (browserServer)
           browserServer.emit(Events.BrowserServer.Close, exitCode, signal);
       },
@@ -269,7 +269,7 @@ export abstract class BrowserTypeBase implements BrowserType {
       helper.killProcess(launchedProcess);
       throw e;
     }
-    browserServer = new BrowserServer(launchedProcess, gracefullyClose);
+    browserServer = new BrowserServer(launchedProcess, gracefullyClose, kill);
     return { browserServer, downloadsPath, transport };
   }
 


### PR DESCRIPTION
This ensures we cleaned everything up.