### PR TITLE
fix(webkit): support 'eventsource' resource type

### DIFF
--- a/src/webkit/wkInterceptableRequest.ts
+++ b/src/webkit/wkInterceptableRequest.ts
@@ -50,13 +50,13 @@ export class WKInterceptableRequest implements network.RouteDelegate {
     this._session = session;
     this._requestId = event.requestId;
     const headers = headersObject(event.request.headers);
-    let resourceType = event.type;
-    if (!resourceType && redirectedFrom && redirectedFrom.resourceType())
+    let resourceType = 'other';
+    if (event.type)
+      resourceType = event.type.toLowerCase();
+    if (redirectedFrom && redirectedFrom.resourceType())
       resourceType = redirectedFrom.resourceType();
     else if (headers['accept'] === 'text/event-stream')
       resourceType = 'eventsource';
-    else
-      resourceType = 'other';
     this.request = new network.Request(allowInterception ? this : null, frame, redirectedFrom, documentId, event.request.url,
         resourceType, event.request.method, event.request.postData || null, headers);
     this._interceptedPromise = new Promise(f => this._interceptedCallback = f);

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -260,7 +260,7 @@ describe('Response.statusText', function() {
 });
 
 describe('Request.resourceType', function() {
-  it.fail(FFOX || WEBKIT)('should return event source', async ({page, server}) => {
+  it.fail(FFOX)('should return event source', async ({page, server}) => {
     const SSE_MESSAGE = {foo: 'bar'};
     // 1. Setup server-sent events on server that immediately sends a message to the client.
     server.setRoute('/sse', (req, res) => {


### PR DESCRIPTION
The resource type for `eventsource` events in webkit seems to be hard to
reach from our instrumentation points.

This suggests an alternative approach for webkit to treat all requests
with 'accept' header of server-sent events as server-sent events.

References #2189