### PR TITLE
fix(route): validate headers

### DIFF
--- a/src/chromium/crNetworkManager.ts
+++ b/src/chromium/crNetworkManager.ts
@@ -342,6 +342,7 @@ class InterceptableRequest implements network.RouteDelegate {
 
     const responseHeaders: { [s: string]: string; } = {};
     if (response.headers) {
+      network.verifyHeaders(response.headers);
       for (const header of Object.keys(response.headers))
         responseHeaders[header.toLowerCase()] = response.headers[header];
     }


### PR DESCRIPTION
Our backends are inconsistent on whether they accept newlines in headers when fulfilling an intercepted request. Newlines are illegal in headers, and there is no standard way to escape them. So for consistency I filter them all on the frontend.

#2358