### PR TITLE
fix(selectors): fix selector parsing for css attributes and quotes

### DIFF
--- a/src/injected/cssSelectorEngine.ts
+++ b/src/injected/cssSelectorEngine.ts
@@ -219,6 +219,7 @@ function parentElementOrShadowHost(element: Element): Element | undefined {
 function split(selector: string): string[][] {
   let index = 0;
   let quote: string | undefined;
+  let insideAttr = false;
   let start = 0;
   let space: 'none' | 'before' | 'after' = 'none';
   const result: string[][] = [];
@@ -235,7 +236,7 @@ function split(selector: string): string[][] {
   };
   while (index < selector.length) {
     const c = selector[index];
-    if (!quote && c === ' ') {
+    if (!quote && !insideAttr && c === ' ') {
       if (space === 'none' || space === 'before')
         space = 'before';
       index++;
@@ -256,10 +257,16 @@ function split(selector: string): string[][] {
       } else if (c === quote) {
         quote = undefined;
         index++;
-      } else if (c === '\'' || c === '"') {
+      } else if (!quote && (c === '\'' || c === '"')) {
         quote = c;
         index++;
-      } else if (!quote && c === ',') {
+      } else if (!quote && c === '[') {
+        insideAttr = true;
+        index++;
+      } else if (!quote && insideAttr && c === ']') {
+        insideAttr = false;
+        index++;
+      } else if (!quote && !insideAttr && c === ',') {
         appendToResult();
         index++;
         start = index;

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -219,6 +219,9 @@ export function parseSelector(selector: string): types.ParsedSelector {
     } else if (c === quote) {
       quote = undefined;
       index++;
+    } else if (!quote && (c === '"' || c === '\'' || c === '`')) {
+      quote = c;
+      index++;
     } else if (!quote && c === '>' && selector[index + 1] === '>') {
       append();
       index += 2;


### PR DESCRIPTION
- css attribute selector may contain spaces;
- `>>` escaping inside strings was sometimes incorrect.

See added test cases for more details. Fixes #2372.