### PR TITLE
chore: remove confusing logging from registry

### DIFF
--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -48,11 +48,14 @@ async function validateCache(packagePath: string, browsersPath: string, linksDir
   const allBrowsers: browserPaths.BrowserDescriptor[] = [];
   for (const fileName of await fsReaddirAsync(linksDir)) {
     const linkPath = path.join(linksDir, fileName);
+    let linkTarget = '';
     try {
-      const linkTarget = (await fsReadFileAsync(linkPath)).toString();
+      linkTarget = (await fsReadFileAsync(linkPath)).toString();
       const browsers = JSON.parse((await fsReadFileAsync(path.join(linkTarget, 'browsers.json'))).toString())['browsers'];
       allBrowsers.push(...browsers);
     } catch (e) {
+      if (linkTarget)
+        logPolitely('Failed to process descriptor at ' + linkTarget);
       await fsUnlinkAsync(linkPath).catch(e => {});
     }
   }

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -53,7 +53,6 @@ async function validateCache(packagePath: string, browsersPath: string, linksDir
       const browsers = JSON.parse((await fsReadFileAsync(path.join(linkTarget, 'browsers.json'))).toString())['browsers'];
       allBrowsers.push(...browsers);
     } catch (e) {
-      logPolitely('Failed to process descriptor at ' + fileName);
       await fsUnlinkAsync(linkPath).catch(e => {});
     }
   }


### PR DESCRIPTION
Since filenames are usually hashes of the paths, this log
yields something like:

```
Failed to process descriptor at 5c995f5d9d938b2c7a28e8d6dda598a2fdc7a6c5
```

This is not helpful and is scary to our users.