### PR TITLE
chore: make polling in page cancelable from node

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -167,5 +167,9 @@ export type ParsedSelector = {
 export type InjectedScriptResult<T = undefined> =
   (T extends undefined ? { status: 'success', value?: T} : { status: 'success', value: T }) |
   { status: 'notconnected' } |
-  { status: 'timeout' } |
   { status: 'error', error: string };
+
+export type CancelablePoll<T> = {
+  result: Promise<T>,
+  cancel: () => void,
+};


### PR DESCRIPTION
- unifies polling timeouts with everything else, based on the client time instead of the server time;
- prepares polling tasks for cancellation token behavior;
- improves type safety around polling.

Unfortunately, RerunnableTask had to be rewritten almost entirely.