### PR TITLE
fix(prepare): Add --no-sandbox argument

### DIFF
--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -32,7 +32,7 @@ let documentation;
   if (!fs.existsSync(typesDir))
     fs.mkdirSync(typesDir)
   fs.writeFileSync(path.join(typesDir, 'protocol.d.ts'), fs.readFileSync(path.join(PROJECT_DIR, 'src', 'chromium', 'protocol.ts')), 'utf8');
-  const browser = await chromium.launch();
+  const browser = await chromium.launch({args: ["--no-sandbox"]});
   const page = await browser.newPage();
   const api = await Source.readFile(path.join(PROJECT_DIR, 'docs', 'api.md'));
   const {documentation: mdDocumentation} = await require('../doclint/check_public_api/MDBuilder')(page, [api]);

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -32,7 +32,7 @@ let documentation;
   if (!fs.existsSync(typesDir))
     fs.mkdirSync(typesDir)
   fs.writeFileSync(path.join(typesDir, 'protocol.d.ts'), fs.readFileSync(path.join(PROJECT_DIR, 'src', 'chromium', 'protocol.ts')), 'utf8');
-  const browser = await chromium.launch({args: ['--no-sandbox']});
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
   const page = await browser.newPage();
   const api = await Source.readFile(path.join(PROJECT_DIR, 'docs', 'api.md'));
   const {documentation: mdDocumentation} = await require('../doclint/check_public_api/MDBuilder')(page, [api]);

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -32,7 +32,7 @@ let documentation;
   if (!fs.existsSync(typesDir))
     fs.mkdirSync(typesDir)
   fs.writeFileSync(path.join(typesDir, 'protocol.d.ts'), fs.readFileSync(path.join(PROJECT_DIR, 'src', 'chromium', 'protocol.ts')), 'utf8');
-  const browser = await chromium.launch({args: ["--no-sandbox"]});
+  const browser = await chromium.launch({args: ['--no-sandbox']});
   const page = await browser.newPage();
   const api = await Source.readFile(path.join(PROJECT_DIR, 'docs', 'api.md'));
   const {documentation: mdDocumentation} = await require('../doclint/check_public_api/MDBuilder')(page, [api]);

--- a/utils/protocol-types-generator/index.js
+++ b/utils/protocol-types-generator/index.js
@@ -24,7 +24,7 @@ async function generateChromiumProtocol(executablePath) {
     result.push('--remote-debugging-port=9339');
     return result;
   };
-  const browser = await playwright.launch({ executablePath });
+  const browser = await playwright.launch({ executablePath, args: ['--no-sandbox'] });
   const page = await browser.newPage();
   await page.goto(`http://localhost:9339/json/protocol`);
   const json = JSON.parse(await page.evaluate(() => document.documentElement.innerText));


### PR DESCRIPTION
I don't know if this is the right thing to do. But I had to add this to run `sudo npm run prepare` and  `generate-types`