### PR TITLE
Fix getExceptionMessage to prevent undefined message

### DIFF
--- a/src/chromium/crProtocolHelper.ts
+++ b/src/chromium/crProtocolHelper.ts
@@ -22,7 +22,7 @@ import * as util from 'util';
 
 export function getExceptionMessage(exceptionDetails: Protocol.Runtime.ExceptionDetails): string {
   if (exceptionDetails.exception)
-    return exceptionDetails.exception.description || String(exceptionDetails.exception.value);
+    return exceptionDetails.exception.description || String(exceptionDetails.exception.value) || exceptionDetails.exception.type;
   let message = exceptionDetails.text;
   if (exceptionDetails.stackTrace) {
     for (const callframe of exceptionDetails.stackTrace.callFrames) {


### PR DESCRIPTION
fix: Prevent undefined exception message

exceptionDetails.exception.value is optional and thus can return undefined, in Javascript, which throws further down in exceptionToError(...) when we try to split('\n') the exception message with stack.