### PR TITLE
fix(webkit): report event source

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "webkit",
-      "revision": "1246"
+      "revision": "1250"
     }
   ]
 }

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -260,7 +260,7 @@ describe('Response.statusText', function() {
 });
 
 describe('Request.resourceType', function() {
-  it.fail(WEBKIT)('should return event source', async ({page, server}) => {
+  it('should return event source', async ({page, server}) => {
     const SSE_MESSAGE = {foo: 'bar'};
     // 1. Setup server-sent events on server that immediately sends a message to the client.
     server.setRoute('/sse', (req, res) => {


### PR DESCRIPTION
This rolls webkit to r1250 where we report event source.

Fixes #2189