### PR TITLE
feat(debug): stream logs from waitForSelector

### DIFF
--- a/src/progress.ts
+++ b/src/progress.ts
@@ -74,6 +74,10 @@ export class Progress {
     this._logger = logger;
   }
 
+  isCanceled(): boolean {
+    return !this._running;
+  }
+
   cleanupWhenCanceled(cleanup: () => any) {
     if (this._running)
       this._cleanups.push(cleanup);

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,7 +169,14 @@ export type InjectedScriptResult<T = undefined> =
   { status: 'notconnected' } |
   { status: 'error', error: string };
 
-export type CancelablePoll<T> = {
+export type InjectedScriptProgress = {
+  canceled: boolean,
+  log: (message: string) => void,
+};
+
+export type InjectedScriptLogs = { current: string[], next: Promise<InjectedScriptLogs> };
+export type InjectedScriptPoll<T> = {
   result: Promise<T>,
+  logs: Promise<InjectedScriptLogs>,
   cancel: () => void,
 };


### PR DESCRIPTION
- we can now stream logs from InjectedScriptProgress to Progress;
- waitForSelector task uses it to report intermediate elements.