### PR TITLE
chore: reduce the number of evaluate methods, improve types

### DIFF
--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -264,7 +264,7 @@ export class CRPage implements PageDelegate {
   }
 
   async setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void> {
-    await handle._evaluateInUtility(({ injected, node }, files) =>
+    await handle._evaluateInUtility(([injected, node, files]) =>
       injected.setInputFiles(node, files), dom.toFileTransferPayload(files));
   }
 

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -443,7 +443,7 @@ export class FFPage implements PageDelegate {
   }
 
   async setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void> {
-    await handle._evaluateInUtility(({ injected, node }, files) =>
+    await handle._evaluateInUtility(([injected, node, files]) =>
       injected.setInputFiles(node, files), dom.toFileTransferPayload(files));
   }
 

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -45,24 +45,8 @@ export class ExecutionContext {
     this._logger = logger;
   }
 
-  doEvaluateInternal(returnByValue: boolean, waitForNavigations: boolean, pageFunction: string | Function, ...args: any[]): Promise<any> {
-    return this._delegate.evaluate(this, returnByValue, pageFunction, ...args);
-  }
-
   adoptIfNeeded(handle: JSHandle): Promise<JSHandle> | null {
     return null;
-  }
-
-  async evaluateInternal<R>(pageFunction: types.Func0<R>): Promise<R>;
-  async evaluateInternal<Arg, R>(pageFunction: types.Func1<Arg, R>, arg: Arg): Promise<R>;
-  async evaluateInternal(pageFunction: never, ...args: never[]): Promise<any> {
-    return this.doEvaluateInternal(true /* returnByValue */, true /* waitForNavigations */, pageFunction, ...args);
-  }
-
-  async evaluateHandleInternal<R>(pageFunction: types.Func0<R>): Promise<types.SmartHandle<R>>;
-  async evaluateHandleInternal<Arg, R>(pageFunction: types.Func1<Arg, R>, arg: Arg): Promise<types.SmartHandle<R>>;
-  async evaluateHandleInternal(pageFunction: never, ...args: never[]): Promise<any> {
-    return this.doEvaluateInternal(false /* returnByValue */, true /* waitForNavigations */, pageFunction, ...args);
   }
 
   utilityScript(): Promise<JSHandle> {
@@ -95,13 +79,13 @@ export class JSHandle<T = any> {
   async evaluate<R, Arg>(pageFunction: types.FuncOn<T, Arg, R>, arg: Arg): Promise<R>;
   async evaluate<R>(pageFunction: types.FuncOn<T, void, R>, arg?: any): Promise<R>;
   async evaluate<R, Arg>(pageFunction: types.FuncOn<T, Arg, R>, arg: Arg): Promise<R> {
-    return this._context.doEvaluateInternal(true /* returnByValue */, true /* waitForNavigations */, pageFunction, this, arg);
+    return this._context._delegate.evaluate(this._context, true /* returnByValue */, pageFunction, this, arg);
   }
 
   async evaluateHandle<R, Arg>(pageFunction: types.FuncOn<T, Arg, R>, arg: Arg): Promise<types.SmartHandle<R>>;
   async evaluateHandle<R>(pageFunction: types.FuncOn<T, void, R>, arg?: any): Promise<types.SmartHandle<R>>;
   async evaluateHandle<R, Arg>(pageFunction: types.FuncOn<T, Arg, R>, arg: Arg): Promise<types.SmartHandle<R>> {
-    return this._context.doEvaluateInternal(false /* returnByValue */, true /* waitForNavigations */, pageFunction, this, arg);
+    return this._context._delegate.evaluate(this._context, false /* returnByValue */, pageFunction, this, arg);
   }
 
   async getProperty(propertyName: string): Promise<JSHandle> {

--- a/src/page.ts
+++ b/src/page.ts
@@ -586,14 +586,16 @@ export class Worker extends EventEmitter {
   async evaluate<R>(pageFunction: types.Func1<void, R>, arg?: any): Promise<R>;
   async evaluate<R, Arg>(pageFunction: types.Func1<Arg, R>, arg: Arg): Promise<R> {
     assertMaxArguments(arguments.length, 2);
-    return (await this._executionContextPromise).evaluateInternal(pageFunction, arg);
+    const context = await this._executionContextPromise;
+    return context._delegate.evaluate(context, true /* returnByValue */, pageFunction, arg);
   }
 
   async evaluateHandle<R, Arg>(pageFunction: types.Func1<Arg, R>, arg: Arg): Promise<types.SmartHandle<R>>;
   async evaluateHandle<R>(pageFunction: types.Func1<void, R>, arg?: any): Promise<types.SmartHandle<R>>;
   async evaluateHandle<R, Arg>(pageFunction: types.Func1<Arg, R>, arg: Arg): Promise<types.SmartHandle<R>> {
     assertMaxArguments(arguments.length, 2);
-    return (await this._executionContextPromise).evaluateHandleInternal(pageFunction, arg);
+    const context = await this._executionContextPromise;
+    return context._delegate.evaluate(context, false /* returnByValue */, pageFunction, arg);
   }
 }
 

--- a/src/server/electron.ts
+++ b/src/server/electron.ts
@@ -133,7 +133,7 @@ export class ElectronApplication extends ExtendedEventEmitter {
       this._nodeExecutionContext = new js.ExecutionContext(new CRExecutionContext(this._nodeSession, event.context), this._logger);
     });
     await this._nodeSession.send('Runtime.enable', {}).catch(e => {});
-    this._nodeElectronHandle = await this._nodeExecutionContext!.evaluateHandleInternal(() => {
+    this._nodeElectronHandle = await this._nodeExecutionContext!._delegate.evaluate(this._nodeExecutionContext!, false /* returnByValue */, () => {
       // Resolving the race between the debugger and the boot-time script.
       if ((global as any)._playwrightRun)
         return (global as any)._playwrightRun();

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,9 @@ type Unboxed<Arg> =
   Arg extends dom.ElementHandle<infer T> ? T :
   Arg extends js.JSHandle<infer T> ? T :
   Arg extends NoHandles<Arg> ? Arg :
+  Arg extends [infer A0] ? [Unboxed<A0>] :
+  Arg extends [infer A0, infer A1] ? [Unboxed<A0>, Unboxed<A1>] :
+  Arg extends [infer A0, infer A1, infer A2] ? [Unboxed<A0>, Unboxed<A1>, Unboxed<A2>] :
   Arg extends Array<infer T> ? Array<Unboxed<T>> :
   Arg extends object ? { [Key in keyof Arg]: Unboxed<Arg[Key]> } :
   Arg;

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -28,6 +28,10 @@ type Unboxed<Arg> =
   Arg extends ElementHandle<infer T> ? T :
   Arg extends JSHandle<infer T> ? T :
   Arg extends NoHandles<Arg> ? Arg :
+  Arg extends [infer A0] ? [Unboxed<A0>] :
+  Arg extends [infer A0, infer A1] ? [Unboxed<A0>, Unboxed<A1>] :
+  Arg extends [infer A0, infer A1, infer A2] ? [Unboxed<A0>, Unboxed<A1>, Unboxed<A2>] :
+  Arg extends [infer A0, infer A1, infer A2, infer A3] ? [Unboxed<A0>, Unboxed<A1>, Unboxed<A2>, Unboxed<A3>] :
   Arg extends Array<infer T> ? Array<Unboxed<T>> :
   Arg extends object ? { [Key in keyof Arg]: Unboxed<Arg[Key]> } :
   Arg;

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -409,6 +409,11 @@ playwright.chromium.launch().then(async browser => {
   const browser = await playwright.webkit.launch();
   const page = await browser.newPage();
   const windowHandle = await page.evaluateHandle(() => window);
+
+  function wrap<T>(t: T): [T, string, boolean, number] {
+    return [t, '1', true, 1];
+  }
+
   {
     const value = await page.evaluate(() => 1);
     const assertion: AssertType<number, typeof value> = true;
@@ -436,6 +441,17 @@ playwright.chromium.launch().then(async browser => {
   {
     const value = await page.evaluate(([a, b, c]) => ({a, b, c}), [3, '123', true] as const);
     const assertion: AssertType<{a: 3, b: '123', c: true}, typeof value> = true;
+  }
+  {
+    const handle = await page.evaluateHandle(() => 3);
+    const value = await page.evaluate(([a, b, c, d]) => ({a, b, c, d}), wrap(handle));
+    const assertion: AssertType<{a: number, b: string, c: boolean, d: number}, typeof value> = true;
+  }
+  {
+    const handle = await page.evaluateHandle(() => 3);
+    const h = await page.evaluateHandle(([a, b, c, d]) => ({a, b, c, d}), wrap(handle));
+    const value = await h.evaluate(h => h);
+    const assertion: AssertType<{a: number, b: string, c: boolean, d: number}, typeof value> = true;
   }
 
   {


### PR DESCRIPTION
Types can now handle non-trivial tuples with handles inside.