### PR TITLE
chore: unify evaluations across browsers even more

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -64,7 +64,7 @@ export class FrameExecutionContext extends js.ExecutionContext {
   async evaluateInternal<Arg, R>(pageFunction: types.Func1<Arg, R>, arg: Arg): Promise<R>;
   async evaluateInternal(pageFunction: never, ...args: never[]): Promise<any> {
     return await this.frame._page._frameManager.waitForSignalsCreatedBy(null, false /* noWaitFor */, async () => {
-      return this._delegate.evaluate(this, true /* returnByValue */, pageFunction, ...args);
+      return js.evaluate(this, true /* returnByValue */, pageFunction, ...args);
     });
   }
 
@@ -72,7 +72,7 @@ export class FrameExecutionContext extends js.ExecutionContext {
   async evaluateHandleInternal<Arg, R>(pageFunction: types.Func1<Arg, R>, arg: Arg): Promise<types.SmartHandle<R>>;
   async evaluateHandleInternal(pageFunction: never, ...args: never[]): Promise<any> {
     return await this.frame._page._frameManager.waitForSignalsCreatedBy(null, false /* noWaitFor */, async () => {
-      return this._delegate.evaluate(this, false /* returnByValue */, pageFunction, ...args);
+      return js.evaluate(this, false /* returnByValue */, pageFunction, ...args);
     });
   }
 

--- a/src/page.ts
+++ b/src/page.ts
@@ -586,16 +586,14 @@ export class Worker extends EventEmitter {
   async evaluate<R>(pageFunction: types.Func1<void, R>, arg?: any): Promise<R>;
   async evaluate<R, Arg>(pageFunction: types.Func1<Arg, R>, arg: Arg): Promise<R> {
     assertMaxArguments(arguments.length, 2);
-    const context = await this._executionContextPromise;
-    return context._delegate.evaluate(context, true /* returnByValue */, pageFunction, arg);
+    return js.evaluate(await this._executionContextPromise, true /* returnByValue */, pageFunction, arg);
   }
 
   async evaluateHandle<R, Arg>(pageFunction: types.Func1<Arg, R>, arg: Arg): Promise<types.SmartHandle<R>>;
   async evaluateHandle<R>(pageFunction: types.Func1<void, R>, arg?: any): Promise<types.SmartHandle<R>>;
   async evaluateHandle<R, Arg>(pageFunction: types.Func1<Arg, R>, arg: Arg): Promise<types.SmartHandle<R>> {
     assertMaxArguments(arguments.length, 2);
-    const context = await this._executionContextPromise;
-    return context._delegate.evaluate(context, false /* returnByValue */, pageFunction, arg);
+    return js.evaluate(await this._executionContextPromise, false /* returnByValue */, pageFunction, arg);
   }
 }
 

--- a/src/server/electron.ts
+++ b/src/server/electron.ts
@@ -133,7 +133,7 @@ export class ElectronApplication extends ExtendedEventEmitter {
       this._nodeExecutionContext = new js.ExecutionContext(new CRExecutionContext(this._nodeSession, event.context), this._logger);
     });
     await this._nodeSession.send('Runtime.enable', {}).catch(e => {});
-    this._nodeElectronHandle = await this._nodeExecutionContext!._delegate.evaluate(this._nodeExecutionContext!, false /* returnByValue */, () => {
+    this._nodeElectronHandle = await js.evaluate(this._nodeExecutionContext!, false /* returnByValue */, () => {
       // Resolving the race between the debugger and the boot-time script.
       if ((global as any)._playwrightRun)
         return (global as any)._playwrightRun();

--- a/src/webkit/wkExecutionContext.ts
+++ b/src/webkit/wkExecutionContext.ts
@@ -16,7 +16,6 @@
  */
 
 import { WKSession, isSwappedOutError } from './wkConnection';
-import { helper } from '../helper';
 import { Protocol } from './protocol';
 import * as js from '../javascript';
 import * as debugSupport from '../debug/debugSupport';
@@ -41,20 +40,33 @@ export class WKExecutionContext implements js.ExecutionContextDelegate {
   }
 
   async rawEvaluate(expression: string): Promise<string> {
-    const contextId = this._contextId;
-    const response = await this._session.send('Runtime.evaluate', {
-      expression: debugSupport.ensureSourceUrl(expression),
-      contextId,
-      returnByValue: false
-    });
-    if (response.wasThrown)
-      throw new Error('Evaluation failed: ' + response.result.description);
-    return response.result.objectId!;
+    try {
+      const response = await this._session.send('Runtime.evaluate', {
+        expression: debugSupport.ensureSourceUrl(expression),
+        contextId: this._contextId,
+        returnByValue: false
+      });
+      if (response.wasThrown)
+        throw new Error('Evaluation failed: ' + response.result.description);
+      return response.result.objectId!;
+    } catch (error) {
+      throw rewriteError(error);
+    }
   }
 
-  async evaluate(context: js.ExecutionContext, returnByValue: boolean, pageFunction: Function | string, ...args: any[]): Promise<any> {
+  async evaluateWithArguments(expression: string, returnByValue: boolean, utilityScript: js.JSHandle<any>, values: any[], objectIds: string[]): Promise<any> {
     try {
-      let response = await this._evaluateRemoteObject(context, pageFunction, args, returnByValue);
+      let response = await this._session.send('Runtime.callFunctionOn', {
+        functionDeclaration: expression,
+        objectId: utilityScript._objectId!,
+        arguments: [
+          { objectId: utilityScript._objectId },
+          ...values.map(value => ({ value })),
+          ...objectIds.map(objectId => ({ objectId })),
+        ],
+        returnByValue: false, // We need to return real Promise if that is a promise.
+        emulateUserGesture: true
+      });
       if (response.result.objectId && response.result.className === 'Promise') {
         response = await Promise.race([
           this._executionContextDestroyedPromise.then(() => contextDestroyedResult),
@@ -67,53 +79,12 @@ export class WKExecutionContext implements js.ExecutionContextDelegate {
       if (response.wasThrown)
         throw new Error('Evaluation failed: ' + response.result.description);
       if (!returnByValue)
-        return context.createHandle(response.result);
+        return utilityScript._context.createHandle(response.result);
       if (response.result.objectId)
-        return await this._returnObjectByValue(context, response.result.objectId);
+        return await this._returnObjectByValue(utilityScript._context, response.result.objectId);
       return parseEvaluationResultValue(response.result.value);
     } catch (error) {
-      if (isSwappedOutError(error) || error.message.includes('Missing injected script for given'))
-        throw new Error('Execution context was destroyed, most likely because of a navigation.');
-      throw error;
-    }
-  }
-
-  private async _evaluateRemoteObject(context: js.ExecutionContext, pageFunction: Function | string, args: any[], returnByValue: boolean): Promise<Protocol.Runtime.callFunctionOnReturnValue> {
-    if (helper.isString(pageFunction)) {
-      const utilityScript = await context.utilityScript();
-      const functionDeclaration = `function (returnByValue, pageFunction) { return this.evaluate(returnByValue, pageFunction); }` + debugSupport.generateSourceUrl();
-      return await this._session.send('Runtime.callFunctionOn', {
-        functionDeclaration,
-        objectId: utilityScript._objectId!,
-        arguments: [
-          { value: returnByValue },
-          { value: debugSupport.ensureSourceUrl(pageFunction) } ],
-        returnByValue: false, // We need to return real Promise if that is a promise.
-        emulateUserGesture: true
-      });
-    }
-
-    if (typeof pageFunction !== 'function')
-      throw new Error(`Expected to get |string| or |function| as the first argument, but got "${pageFunction}" instead.`);
-
-    const { functionText, values, handles, dispose } = await js.prepareFunctionCall(pageFunction, context, args);
-
-    try {
-      const utilityScript = await context.utilityScript();
-      return await this._session.send('Runtime.callFunctionOn', {
-        functionDeclaration: `function (...args) { return this.callFunction(...args) }` + debugSupport.generateSourceUrl(),
-        objectId: utilityScript._objectId!,
-        arguments: [
-          { value: returnByValue },
-          { value: functionText },
-          ...values.map(value => ({ value })),
-          ...handles,
-        ],
-        returnByValue: false, // We need to return real Promise if that is a promise.
-        emulateUserGesture: true
-      });
-    } finally {
-      dispose();
+      throw rewriteError(error);
     }
   }
 
@@ -130,10 +101,11 @@ export class WKExecutionContext implements js.ExecutionContextDelegate {
       if (serializeResponse.wasThrown)
         return undefined;
       return parseEvaluationResultValue(serializeResponse.result.value);
-    } catch (e) {
-      if (isSwappedOutError(e))
-        return contextDestroyedResult;
+    } catch (error) {
       return undefined;
+      // TODO: we should actually throw an error, but that breaks the common case of undefined
+      // that is for some reason reported as an object and cannot be accessed after navigation.
+      // throw rewriteError(error);
     }
   }
 
@@ -164,22 +136,6 @@ export class WKExecutionContext implements js.ExecutionContextDelegate {
       return;
     await this._session.send('Runtime.releaseObject', {objectId: handle._objectId}).catch(error => {});
   }
-
-  async handleJSONValue<T>(handle: js.JSHandle<T>): Promise<T> {
-    if (handle._objectId) {
-      const utilityScript = await handle._context.utilityScript();
-      const response = await this._session.send('Runtime.callFunctionOn', {
-        functionDeclaration: 'function (object) { return this.jsonValue(true, object); }' + debugSupport.generateSourceUrl(),
-        objectId: utilityScript._objectId!,
-        arguments: [ { objectId: handle._objectId } ],
-        returnByValue: true
-      });
-      if (response.wasThrown)
-        throw new Error('Evaluation failed: ' + response.result.description);
-      return parseEvaluationResultValue(response.result.value);
-    }
-    return handle._value;
-  }
 }
 
 const contextDestroyedResult = {
@@ -193,4 +149,10 @@ function potentiallyUnserializableValue(remoteObject: Protocol.Runtime.RemoteObj
   const value = remoteObject.value;
   const unserializableValue = remoteObject.type === 'number' && value === null ? remoteObject.description : undefined;
   return unserializableValue ? js.parseUnserializableValue(unserializableValue) : value;
+}
+
+function rewriteError(error: Error): Error {
+  if (isSwappedOutError(error) || error.message.includes('Missing injected script for given'))
+    return new Error('Execution context was destroyed, most likely because of a navigation.');
+  return error;
 }

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -309,6 +309,22 @@ describe('Page.evaluate', function() {
     });
     expect(result).toEqual([42]);
   });
+  it.fail(WEBKIT)('should not throw an error when evaluation does a synchronous navigation and returns an object', async({page, server}) => {
+    // It is imporant to be on about:blank for sync reload.
+    const result = await page.evaluate(() => {
+      window.location.reload();
+      return {a: 42};
+    });
+    expect(result).toEqual({a: 42});
+  });
+  it('should not throw an error when evaluation does a synchronous navigation and returns undefined', async({page, server}) => {
+    // It is imporant to be on about:blank for sync reload.
+    const result = await page.evaluate(() => {
+      window.location.reload();
+      return undefined;
+    });
+    expect(result).toBe(undefined);
+  });
   it.slow()('should transfer 100Mb of data from page to node.js', async({page, server}) => {
     const a = await page.evaluate(() => Array(100 * 1024 * 1024 + 1).join('a'));
     expect(a.length).toBe(100 * 1024 * 1024);


### PR DESCRIPTION
This moves all the logic around UtilityScript to javascript.ts.
Also uncovers a bug in WebKit where we cannot returnByValue after navigation.