### PR TITLE
feat(debug): improve api logs

### DIFF
--- a/src/progress.ts
+++ b/src/progress.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { InnerLogger, Log } from './logger';
+import { InnerLogger, Log, apiLog } from './logger';
 import { TimeoutError } from './errors';
 import { assert } from './helper';
 import { getCurrentApiCall, rewriteErrorMessage } from './debug/stackTrace';
@@ -82,11 +82,15 @@ export class ProgressController {
           runCleanup(cleanup);
       },
       log: (log: Log, message: string | Error) => {
-        if (this._state === 'running')
+        if (this._state === 'running') {
           this._logRecording.push(message.toString());
-        this._logger._log(log, message);
+          this._logger._log(log, '  ' + message);
+        } else {
+          this._logger._log(log, message);
+        }
       },
     };
+    this._logger._log(apiLog, `=> ${this._apiName} started`);
 
     const timeoutError = new TimeoutError(`Timeout ${this._timeout}ms exceeded during ${this._apiName}.`);
     const timer = setTimeout(() => this._forceAbort(timeoutError), progress.timeUntilDeadline());
@@ -96,6 +100,7 @@ export class ProgressController {
       clearTimeout(timer);
       this._state = 'finished';
       this._logRecording = [];
+      this._logger._log(apiLog, `<= ${this._apiName} succeeded`);
       return result;
     } catch (e) {
       this._aborted();
@@ -103,6 +108,7 @@ export class ProgressController {
       clearTimeout(timer);
       this._state = 'aborted';
       this._logRecording = [];
+      this._logger._log(apiLog, `<= ${this._apiName} failed`);
       await Promise.all(this._cleanups.splice(0).map(cleanup => runCleanup(cleanup)));
       throw e;
     }

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -120,38 +120,25 @@ export class Selectors {
 
         return injected.poll('raf', (progress: types.InjectedScriptProgress) => {
           const element = injected.querySelector(parsed, document);
+          const visible = element ? injected.isVisible(element) : false;
 
-          const log = (suffix: string) => {
-            if (lastElement === element)
-              return;
+          if (lastElement !== element) {
             lastElement = element;
             if (!element)
-              progress.log(`selector did not resolve to any element`);
+              progress.log(`  selector did not resolve to any element`);
             else
-              progress.log(`selector resolved to "${injected.previewElement(element)}"${suffix ? ' ' + suffix : ''}`);
-          };
+              progress.log(`  selector resolved to ${visible ? 'visible' : 'hidden'} ${injected.previewElement(element)}`);
+          }
 
           switch (state) {
-            case 'attached': {
+            case 'attached':
               return element || false;
-            }
-            case 'detached': {
-              if (element)
-                log('');
+            case 'detached':
               return !element;
-            }
-            case 'visible': {
-              const result = element && injected.isVisible(element) ? element : false;
-              if (!result)
-                log('that is not visible');
-              return result;
-            }
-            case 'hidden': {
-              const result = !element || !injected.isVisible(element);
-              if (!result)
-                log('that is still visible');
-              return result;
-            }
+            case 'visible':
+              return visible ? element : false;
+            case 'hidden':
+              return !visible;
           }
         });
       }, { parsed, state });

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,6 +176,7 @@ export type InjectedScriptLogs = { current: string[], next: Promise<InjectedScri
 export type InjectedScriptPoll<T> = {
   result: Promise<T>,
   logs: Promise<InjectedScriptLogs>,
+  takeLastLogs: () => string[],
   cancel: () => void,
 };
 

--- a/test/autowaiting.spec.js
+++ b/test/autowaiting.spec.js
@@ -192,7 +192,7 @@ describe('Auto waiting', () => {
     const __testHookAfterPointerAction = () => new Promise(f => setTimeout(f, 6000));
     const error = await page.click('a', { timeout: 5000, __testHookAfterPointerAction }).catch(e => e);
     expect(error.message).toContain('Timeout 5000ms exceeded during page.click.');
-    expect(error.message).toContain('waiting for scheduled navigations to finish...');
+    expect(error.message).toContain('waiting for scheduled navigations to finish');
     expect(error.message).toContain(`navigated to "${server.PREFIX + '/frames/one-frame.html'}"`);
   });
 });

--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -182,14 +182,14 @@ describe('Page.click', function() {
     await page.$eval('button', b => b.style.display = 'none');
     const error = await page.click('button', { timeout: 5000 }).catch(e => e);
     expect(error.message).toContain('Timeout 5000ms exceeded during page.click.');
-    expect(error.message).toContain('waiting for element to be displayed, enabled and not moving...');
+    expect(error.message).toContain('waiting for element to be displayed, enabled and not moving');
   });
   it('should timeout waiting for visbility:hidden to be gone', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/button.html');
     await page.$eval('button', b => b.style.visibility = 'hidden');
     const error = await page.click('button', { timeout: 5000 }).catch(e => e);
     expect(error.message).toContain('Timeout 5000ms exceeded during page.click.');
-    expect(error.message).toContain('waiting for element to be displayed, enabled and not moving...');
+    expect(error.message).toContain('waiting for element to be displayed, enabled and not moving');
   });
   it('should waitFor visible when parent is hidden', async({page, server}) => {
     let done = false;
@@ -431,7 +431,7 @@ describe('Page.click', function() {
     });
     const error = await button.click({ timeout: 5000 }).catch(e => e);
     expect(error.message).toContain('Timeout 5000ms exceeded during elementHandle.click.');
-    expect(error.message).toContain('waiting for element to be displayed, enabled and not moving...');
+    expect(error.message).toContain('waiting for element to be displayed, enabled and not moving');
   });
   it('should wait for becoming hit target', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/button.html');
@@ -479,7 +479,8 @@ describe('Page.click', function() {
     });
     const error = await button.click({ timeout: 5000 }).catch(e => e);
     expect(error.message).toContain('Timeout 5000ms exceeded during elementHandle.click.');
-    expect(error.message).toContain('...element does not receive pointer events, retrying input action');
+    expect(error.message).toContain('element does not receive pointer events');
+    expect(error.message).toContain('retrying elementHandle.click action');
   });
   it('should fail when obscured and not waiting for hit target', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/button.html');
@@ -704,7 +705,8 @@ describe('Page.click', function() {
     expect(clicked).toBe(false);
     expect(await page.evaluate(() => window.clicked)).toBe(undefined);
     expect(error.message).toContain('Timeout 5000ms exceeded during elementHandle.click.');
-    expect(error.message).toContain('...element does not receive pointer events, retrying input action');
+    expect(error.message).toContain('element does not receive pointer events');
+    expect(error.message).toContain('retrying elementHandle.click action');
   });
   it('should dispatch microtasks in order', async({page, server}) => {
     await page.setContent(`

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -919,7 +919,7 @@ describe('Frame.goto', function() {
     const url = server.PREFIX + '/frames/child-redirect.html';
     const error = await page.goto(url, { timeout: 5000, waitUntil: 'networkidle' }).catch(e => e);
     expect(error.message).toContain('Timeout 5000ms exceeded during page.goto.');
-    expect(error.message).toContain(`page.goto("${url}"), waiting until "networkidle"`);
+    expect(error.message).toContain(`navigating to "${url}", waiting until "networkidle"`);
     expect(error.message).toContain(`navigated to "${url}"`);
     expect(error.message).toContain(`navigated to "${server.PREFIX + '/frames/one-frame.html'}"`);
     expect(error.message).toContain(`"domcontentloaded" event fired`);

--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -211,7 +211,9 @@ describe('Frame.waitForSelector', function() {
       const div = document.createElement('div');
       div.className = 'foo bar';
       div.id = 'mydiv';
-      div.style.display = 'none';
+      div.setAttribute('style', 'display: none');
+      div.setAttribute('foo', '123456789012345678901234567890123456789012345678901234567890');
+      div.textContent = 'abcdefghijklmnopqrstuvwyxzabcdefghijklmnopqrstuvwyxzabcdefghijklmnopqrstuvwyxz';
       document.body.appendChild(div);
     });
     await giveItTimeToLog(frame);
@@ -229,10 +231,10 @@ describe('Frame.waitForSelector', function() {
 
     const error = await watchdog.catch(e => e);
     expect(error.message).toContain(`Timeout 5000ms exceeded during frame.waitForSelector.`);
-    expect(error.message).toContain(`Waiting for selector "div" to be visible...`);
-    expect(error.message).toContain(`selector resolved to "div#mydiv.foo.bar" that is not visible`);
+    expect(error.message).toContain(`waiting for selector "div" to be visible`);
+    expect(error.message).toContain(`selector resolved to hidden <div id="mydiv" class="foo bar" foo="1234567890123456…>abcdefghijklmnopqrstuvwyxzabcdefghijklmnopqrstuvw…</div>`);
     expect(error.message).toContain(`selector did not resolve to any element`);
-    expect(error.message).toContain(`selector resolved to "div.another" that is not visible`);
+    expect(error.message).toContain(`selector resolved to hidden <div class="another"></div>`);
   });
   it('should report logs while waiting for hidden', async({page, server}) => {
     await page.goto(server.EMPTY_PAGE);
@@ -259,9 +261,9 @@ describe('Frame.waitForSelector', function() {
 
     const error = await watchdog.catch(e => e);
     expect(error.message).toContain(`Timeout 5000ms exceeded during frame.waitForSelector.`);
-    expect(error.message).toContain(`Waiting for selector "div" to be hidden...`);
-    expect(error.message).toContain(`selector resolved to "div#mydiv.foo.bar" that is still visible`);
-    expect(error.message).toContain(`selector resolved to "div.another" that is still visible`);
+    expect(error.message).toContain(`waiting for selector "div" to be hidden`);
+    expect(error.message).toContain(`selector resolved to visible <div id="mydiv" class="foo bar">hello</div>`);
+    expect(error.message).toContain(`selector resolved to visible <div class="another">hello</div>`);
   });
   it('should resolve promise when node is added in shadow dom', async({page, server}) => {
     await page.goto(server.EMPTY_PAGE);
@@ -400,7 +402,7 @@ describe('Frame.waitForSelector', function() {
     await page.waitForSelector('div', { timeout: 10, state: 'attached' }).catch(e => error = e);
     expect(error).toBeTruthy();
     expect(error.message).toContain('Timeout 10ms exceeded during page.waitForSelector');
-    expect(error.message).toContain('Waiting for selector "div"...');
+    expect(error.message).toContain('waiting for selector "div"');
     expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
   });
   it('should have an error message specifically for awaiting an element to be hidden', async({page, server}) => {
@@ -409,7 +411,7 @@ describe('Frame.waitForSelector', function() {
     await page.waitForSelector('div', { state: 'hidden', timeout: 1000 }).catch(e => error = e);
     expect(error).toBeTruthy();
     expect(error.message).toContain('Timeout 1000ms exceeded during page.waitForSelector');
-    expect(error.message).toContain('Waiting for selector "div" to be hidden...');
+    expect(error.message).toContain('waiting for selector "div" to be hidden');
   });
   it('should respond to node attribute mutation', async({page, server}) => {
     let divFound = false;
@@ -490,7 +492,7 @@ describe('Frame.waitForSelector xpath', function() {
     await page.waitForSelector('//div', { state: 'attached', timeout: 10 }).catch(e => error = e);
     expect(error).toBeTruthy();
     expect(error.message).toContain('Timeout 10ms exceeded during page.waitForSelector');
-    expect(error.message).toContain('Waiting for selector "//div"...');
+    expect(error.message).toContain('waiting for selector "//div"');
     expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
   });
   it('should run in specified frame', async({page, server}) => {


### PR DESCRIPTION
Any suggestions are welcome!

This is a typical log now:

```log
  pw:api => chromium.launch started +0ms
  pw:api <= chromium.launch succeeded +130ms
  pw:api => page.goto started +247ms
  pw:api   navigating to "http://localhost:8907/input/button.html", waiting until "load" +1ms
  pw:api   navigated to "http://localhost:8907/input/button.html" +17ms
  pw:api   "domcontentloaded" event fired +5ms
  pw:api   "load" event fired +1ms
  pw:api <= page.goto succeeded +0ms
  pw:api => page.click started +50ms
  pw:api   waiting for selector "button" +1ms
  pw:api     selector resolved to visible <button>Click target</button> +6ms
  pw:api   attempting page.click action +0ms
  pw:api     waiting for element to be displayed, enabled and not moving +1ms
  pw:api     element is displayed and does not move +30ms
  pw:api     scrolling into view if needed +0ms
  pw:api     done scrolling +1ms
  pw:api     checking that element receives pointer events at (100,10) +1ms
  pw:api     element does not receive pointer events +3ms
  pw:api   retrying page.click action +0ms
  pw:api     waiting for element to be displayed, enabled and not moving +0ms
  pw:api     element is displayed and does not move +29ms
  pw:api     scrolling into view if needed +0ms
  pw:api     done scrolling +0ms
  pw:api     checking that element receives pointer events at (100,10) +1ms
  pw:api     element does not receive pointer events +2ms
  pw:api   retrying page.click action +0ms
  pw:api     waiting for element to be displayed, enabled and not moving +0ms
  pw:api     element is displayed and does not move +30ms
  pw:api     scrolling into view if needed +0ms
  pw:api     done scrolling +1ms
  pw:api     checking that element receives pointer events at (100,10) +0ms
  pw:api     element does not receive pointer events +3ms
  pw:api   retrying page.click action +0ms
  pw:api     waiting for element to be displayed, enabled and not moving +0ms
  pw:api     element is displayed and does not move +29ms
  pw:api     scrolling into view if needed +1ms
  pw:api     done scrolling +0ms
  pw:api     checking that element receives pointer events at (100,10) +2ms
  pw:api     element does not receive pointer events +3ms
  pw:api   retrying page.click action +0ms
  pw:api     waiting for element to be displayed, enabled and not moving +0ms
  pw:api     element is displayed and does not move +28ms
  pw:api     scrolling into view if needed +0ms
  pw:api     done scrolling +1ms
  pw:api     checking that element receives pointer events at (100,10) +0ms
  pw:api     element does receive pointer events, continuing input action +3ms
  pw:api     performing page.click action +1ms
  pw:api     page.click action done +21ms
  pw:api     waiting for scheduled navigations to finish +1ms
  pw:api     navigations have finished +0ms
  pw:api <= page.click succeeded +1ms
```

And this is an error message:
```log
TimeoutError: Timeout 5000ms exceeded during elementHandle.click.
================= elementHandle.click logs =================
attempting elementHandle.click action
  waiting for element to be displayed, enabled and not moving
  element is displayed and does not move
  scrolling into view if needed
  done scrolling
  checking that element receives pointer events at (49.33,18.5)
  element does not receive pointer events
retrying elementHandle.click action
  waiting for element to be displayed, enabled and not moving
============================================================
```
