### PR TITLE
fix(installer): create tmp directory inside `browserPath`

### DIFF
--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -18,8 +18,6 @@
 import * as extract from 'extract-zip';
 import * as fs from 'fs';
 import * as ProxyAgent from 'https-proxy-agent';
-import * as os from 'os';
-import * as path from 'path';
 import * as ProgressBar from 'progress';
 import { getProxyForUrl } from 'proxy-from-env';
 import * as URL from 'url';

--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -30,7 +30,6 @@ import { BrowserName, BrowserPlatform, BrowserDescriptor } from './browserPaths'
 
 const unlinkAsync = util.promisify(fs.unlink.bind(fs));
 const chmodAsync = util.promisify(fs.chmod.bind(fs));
-const mkdtempAsync = util.promisify(fs.mkdtemp.bind(fs));
 const renameAsync = util.promisify(fs.rename.bind(fs));
 const existsAsync = (path: string): Promise<boolean> => new Promise(resolve => fs.stat(path, err => resolve(!err)));
 
@@ -109,10 +108,10 @@ export async function downloadBrowserWithProgressBar(browserPath: string, browse
   }
 
   const url = revisionURL(browser);
-  const zipPath = path.join(os.tmpdir(), `playwright-download-${browser.name}-${browserPaths.hostPlatform}-${browser.revision}.zip`);
+  const zipPath = browserPaths.browserZipFile(browserPath, browser);
   try {
     await downloadFile(url, zipPath, progress);
-    const extractPath = await mkdtempAsync(path.join(path.dirname(browserPath), `playwright-extract-${browser.name}-${browserPaths.hostPlatform}-${browser.revision}-`));
+    const extractPath = browserPaths.browserExtractDirectory(browserPath, browser);
     await extract(zipPath, { dir: extractPath});
     await chmodAsync(browserPaths.executablePath(extractPath, browser)!, 0o755);
     await renameAsync(extractPath, browserPath);

--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -112,7 +112,7 @@ export async function downloadBrowserWithProgressBar(browserPath: string, browse
   const zipPath = path.join(os.tmpdir(), `playwright-download-${browser.name}-${browserPaths.hostPlatform}-${browser.revision}.zip`);
   try {
     await downloadFile(url, zipPath, progress);
-    const extractPath = await mkdtempAsync(path.join(os.tmpdir(), `playwright-extract-${browser.name}-${browserPaths.hostPlatform}-${browser.revision}-`));
+    const extractPath = await mkdtempAsync(path.join(path.dirname(browserPath), `playwright-extract-${browser.name}-${browserPaths.hostPlatform}-${browser.revision}-`));
     await extract(zipPath, { dir: extractPath});
     await chmodAsync(browserPaths.executablePath(extractPath, browser)!, 0o755);
     await renameAsync(extractPath, browserPath);

--- a/src/install/browserPaths.ts
+++ b/src/install/browserPaths.ts
@@ -104,13 +104,13 @@ export function browserDirectory(browsersPath: string, browser: BrowserDescripto
   return path.join(browsersPath, `${browser.name}-${browser.revision}`);
 }
 
-export function isBrowserDirectory(browserPath: string): boolean {
-  const baseName = path.basename(browserPath);
+export function isBrowserDirectory(aPath: string): boolean {
+  const baseName = path.basename(aPath);
   return baseName.startsWith('chromium-') || baseName.startsWith('firefox-') || baseName.startsWith('webkit-');
 }
 
-export function isBrowserExtractDirectory(browserPath: string): boolean {
-  const baseName = path.basename(browserPath);
+export function isBrowserExtractDirectory(aPath: string): boolean {
+  const baseName = path.basename(aPath);
   return baseName.startsWith('playwright-extract-');
 }
 
@@ -118,8 +118,8 @@ export function browserExtractDirectory(browserPath: string, browser: BrowserDes
   return (path.join(path.dirname(browserPath), `playwright-extract-${browser.name}-${hostPlatform}-${browser.revision}`));
 }
 
-export function isBrowserZipFile(browserPath: string): boolean {
-  const baseName = path.basename(browserPath);
+export function isBrowserZipFile(aPath: string): boolean {
+  const baseName = path.basename(aPath);
   return baseName.startsWith('playwright-download-') && baseName.endsWith('.zip');
 }
 

--- a/src/install/browserPaths.ts
+++ b/src/install/browserPaths.ts
@@ -109,20 +109,24 @@ export function isBrowserDirectory(aPath: string): boolean {
   return baseName.startsWith('chromium-') || baseName.startsWith('firefox-') || baseName.startsWith('webkit-');
 }
 
+const BROWSER_EXTRACT_DIRECTORY_PREFIX = 'playwright-extract-';
+
 export function isBrowserExtractDirectory(aPath: string): boolean {
   const baseName = path.basename(aPath);
-  return baseName.startsWith('playwright-extract-');
+  return baseName.startsWith(BROWSER_EXTRACT_DIRECTORY_PREFIX);
 }
 
 export function browserExtractDirectory(browserPath: string, browser: BrowserDescriptor): string {
-  return (path.join(path.dirname(browserPath), `playwright-extract-${browser.name}-${hostPlatform}-${browser.revision}`));
+  return (path.join(path.dirname(browserPath), `${BROWSER_EXTRACT_DIRECTORY_PREFIX}${browser.name}-${hostPlatform}-${browser.revision}`));
 }
+
+const BROWSER_ZIP_FILE_PREFIX = 'playwright-download-';
 
 export function isBrowserZipFile(aPath: string): boolean {
   const baseName = path.basename(aPath);
-  return baseName.startsWith('playwright-download-') && baseName.endsWith('.zip');
+  return baseName.startsWith(BROWSER_ZIP_FILE_PREFIX) && baseName.endsWith('.zip');
 }
 
 export function browserZipFile(browserPath: string, browser: BrowserDescriptor): string {
-  return path.join(path.dirname(browserPath), `playwright-download-${browser.name}-${hostPlatform}-${browser.revision}.zip`);
+  return path.join(path.dirname(browserPath), `${BROWSER_ZIP_FILE_PREFIX}${browser.name}-${hostPlatform}-${browser.revision}.zip`);
 }

--- a/src/install/browserPaths.ts
+++ b/src/install/browserPaths.ts
@@ -108,3 +108,21 @@ export function isBrowserDirectory(browserPath: string): boolean {
   const baseName = path.basename(browserPath);
   return baseName.startsWith('chromium-') || baseName.startsWith('firefox-') || baseName.startsWith('webkit-');
 }
+
+export function isBrowserExtractDirectory(browserPath: string): boolean {
+  const baseName = path.basename(browserPath);
+  return baseName.startsWith('playwright-extract-');
+}
+
+export function browserExtractDirectory(browserPath: string, browser: BrowserDescriptor): string {
+  return (path.join(path.dirname(browserPath), `playwright-extract-${browser.name}-${hostPlatform}-${browser.revision}`));
+}
+
+export function isBrowserZipFile(browserPath: string): boolean {
+  const baseName = path.basename(browserPath);
+  return baseName.startsWith('playwright-download-') && baseName.endsWith('.zip');
+}
+
+export function browserZipFile(browserPath: string, browser: BrowserDescriptor): string {
+  return path.join(path.dirname(browserPath), `playwright-download-${browser.name}-${hostPlatform}-${browser.revision}.zip`);
+}

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -64,8 +64,10 @@ async function validateCache(packagePath: string, browsersPath: string, linksDir
   // NOTE: this must not run concurrently with other installations.
   let staleFiles = (await fsReaddirAsync(browsersPath)).map(file => path.join(browsersPath, file));
   staleFiles = staleFiles.filter(file => browserPaths.isBrowserZipFile(file) || browserPaths.isBrowserExtractDirectory(file));
-  for (const staleFile of staleFiles)
+  for (const staleFile of staleFiles) {
+    logPolitely('Removing leftover from interrupted installation ' + staleFile);
     await rmAsync(staleFile).catch(e => {});
+  }
 
   // 3. Delete all unused browsers.
   let downloadedBrowsers = (await fsReaddirAsync(browsersPath)).map(file => path.join(browsersPath, file));


### PR DESCRIPTION
`fs.rename` doesn't work across partitions, so we have to have
tmp folder next to our final destination.

Fixes #2494