### PR TITLE
feat: avoid side effects after progress aborts

### DIFF
--- a/src/progress.ts
+++ b/src/progress.ts
@@ -26,6 +26,7 @@ export interface Progress {
   isRunning(): boolean;
   cleanupWhenAborted(cleanup: () => any): void;
   log(log: Log, message: string | Error): void;
+  throwIfAborted(): void;
 }
 
 export async function runAbortableTask<T>(task: (progress: Progress) => Promise<T>, logger: InnerLogger, timeout: number, apiName?: string): Promise<T> {
@@ -89,6 +90,10 @@ export class ProgressController {
           this._logger.log(log, message);
         }
       },
+      throwIfAborted: () => {
+        if (this._state === 'aborted')
+          throw new AbortedError();
+      },
     };
     this._logger.log(apiLog, `=> ${this._apiName} started`);
 
@@ -142,3 +147,5 @@ function monotonicTime(): number {
   const [seconds, nanoseconds] = process.hrtime();
   return seconds * 1000 + (nanoseconds / 1000000 | 0);
 }
+
+class AbortedError extends Error {}

--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -66,6 +66,13 @@ describe('Page.click', function() {
     ]).catch(e => {});
     await context.close();
   });
+  it('should avoid side effects after timeout', async({page, server}) => {
+    await page.goto(server.PREFIX + '/input/button.html');
+    const error = await page.click('button', { timeout: 2000, __testHookBeforePointerAction: () => new Promise(f => setTimeout(f, 2500))}).catch(e => e);
+    await page.waitForTimeout(5000);  // Give it some time to click after the test hook is done waiting.
+    expect(await page.evaluate(() => result)).toBe('Was not clicked');
+    expect(error.message).toContain('Timeout 2000ms exceeded during page.click.');
+  });
   it('should click the button after navigation ', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/button.html');
     await page.click('button');


### PR DESCRIPTION
Actions like click, focus or polling now avoid doing any work with side-effects after their progress has been aborted.