### PR TITLE
chore: fix emojis for CR and FF in Dockerfile

### DIFF
--- a/docs/docker/Dockerfile.bionic
+++ b/docs/docker/Dockerfile.bionic
@@ -35,7 +35,8 @@ RUN apt-get install -y libwoff1 \
 
 RUN apt-get install -y libnss3 \
                        libxss1 \
-                       libasound2
+                       libasound2 \
+                       fonts-noto-color-emoji
 
 # 4. Install Firefox dependencies
 


### PR DESCRIPTION
This change will fix that the emojis didn't render on Firefox and WebKit within the Docker container.

Fix #2521

Adds https://github.com/googlefonts/noto-emoji to the Docker dependencies.

Ref: https://packages.ubuntu.com/de/bionic/fonts-noto-color-emoji