### PR TITLE
chore: revert atomic install

### DIFF
--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -18,6 +18,8 @@
 import * as extract from 'extract-zip';
 import * as fs from 'fs';
 import * as ProxyAgent from 'https-proxy-agent';
+import * as os from 'os';
+import * as path from 'path';
 import * as ProgressBar from 'progress';
 import { getProxyForUrl } from 'proxy-from-env';
 import * as URL from 'url';
@@ -28,7 +30,6 @@ import { BrowserName, BrowserPlatform, BrowserDescriptor } from './browserPaths'
 
 const unlinkAsync = util.promisify(fs.unlink.bind(fs));
 const chmodAsync = util.promisify(fs.chmod.bind(fs));
-const renameAsync = util.promisify(fs.rename.bind(fs));
 const existsAsync = (path: string): Promise<boolean> => new Promise(resolve => fs.stat(path, err => resolve(!err)));
 
 export type OnProgressCallback = (downloadedBytes: number, totalBytes: number) => void;
@@ -106,13 +107,11 @@ export async function downloadBrowserWithProgressBar(browserPath: string, browse
   }
 
   const url = revisionURL(browser);
-  const zipPath = browserPaths.browserZipFile(browserPath, browser);
+  const zipPath = path.join(os.tmpdir(), `playwright-download-${browser.name}-${browserPaths.hostPlatform}-${browser.revision}.zip`);
   try {
     await downloadFile(url, zipPath, progress);
-    const extractPath = browserPaths.browserExtractDirectory(browserPath, browser);
-    await extract(zipPath, { dir: extractPath});
-    await chmodAsync(browserPaths.executablePath(extractPath, browser)!, 0o755);
-    await renameAsync(extractPath, browserPath);
+    await extract(zipPath, { dir: browserPath});
+    await chmodAsync(browserPaths.executablePath(browserPath, browser)!, 0o755);
   } catch (e) {
     process.exitCode = 1;
     throw e;

--- a/src/install/browserPaths.ts
+++ b/src/install/browserPaths.ts
@@ -104,29 +104,7 @@ export function browserDirectory(browsersPath: string, browser: BrowserDescripto
   return path.join(browsersPath, `${browser.name}-${browser.revision}`);
 }
 
-export function isBrowserDirectory(aPath: string): boolean {
-  const baseName = path.basename(aPath);
+export function isBrowserDirectory(browserPath: string): boolean {
+  const baseName = path.basename(browserPath);
   return baseName.startsWith('chromium-') || baseName.startsWith('firefox-') || baseName.startsWith('webkit-');
-}
-
-const BROWSER_EXTRACT_DIRECTORY_PREFIX = 'playwright-extract-';
-
-export function isBrowserExtractDirectory(aPath: string): boolean {
-  const baseName = path.basename(aPath);
-  return baseName.startsWith(BROWSER_EXTRACT_DIRECTORY_PREFIX);
-}
-
-export function browserExtractDirectory(browserPath: string, browser: BrowserDescriptor): string {
-  return (path.join(path.dirname(browserPath), `${BROWSER_EXTRACT_DIRECTORY_PREFIX}${browser.name}-${hostPlatform}-${browser.revision}`));
-}
-
-const BROWSER_ZIP_FILE_PREFIX = 'playwright-download-';
-
-export function isBrowserZipFile(aPath: string): boolean {
-  const baseName = path.basename(aPath);
-  return baseName.startsWith(BROWSER_ZIP_FILE_PREFIX) && baseName.endsWith('.zip');
-}
-
-export function browserZipFile(browserPath: string, browser: BrowserDescriptor): string {
-  return path.join(path.dirname(browserPath), `${BROWSER_ZIP_FILE_PREFIX}${browser.name}-${hostPlatform}-${browser.revision}.zip`);
 }

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -28,7 +28,7 @@ const fsReaddirAsync = util.promisify(fs.readdir.bind(fs));
 const fsReadFileAsync = util.promisify(fs.readFile.bind(fs));
 const fsUnlinkAsync = util.promisify(fs.unlink.bind(fs));
 const fsWriteFileAsync = util.promisify(fs.writeFile.bind(fs));
-const rmAsync = util.promisify(removeFolder);
+const removeFolderAsync = util.promisify(removeFolder);
 
 export async function installBrowsersWithProgressBar(packagePath: string) {
   const browsersPath = browserPaths.browsersPath(packagePath);
@@ -60,16 +60,7 @@ async function validateCache(packagePath: string, browsersPath: string, linksDir
     }
   }
 
-  // 2. Delete all stale browser extract directories and .zip files.
-  // NOTE: this must not run concurrently with other installations.
-  let staleFiles = (await fsReaddirAsync(browsersPath)).map(file => path.join(browsersPath, file));
-  staleFiles = staleFiles.filter(file => browserPaths.isBrowserZipFile(file) || browserPaths.isBrowserExtractDirectory(file));
-  for (const staleFile of staleFiles) {
-    logPolitely('Removing leftover from interrupted installation ' + staleFile);
-    await rmAsync(staleFile).catch(e => {});
-  }
-
-  // 3. Delete all unused browsers.
+  // 2. Delete all unused browsers.
   let downloadedBrowsers = (await fsReaddirAsync(browsersPath)).map(file => path.join(browsersPath, file));
   downloadedBrowsers = downloadedBrowsers.filter(file => browserPaths.isBrowserDirectory(file));
   const directories = new Set<string>(downloadedBrowsers);
@@ -77,10 +68,10 @@ async function validateCache(packagePath: string, browsersPath: string, linksDir
     directories.delete(browserPaths.browserDirectory(browsersPath, browser));
   for (const directory of directories) {
     logPolitely('Removing unused browser at ' + directory);
-    await rmAsync(directory).catch(e => {});
+    await removeFolderAsync(directory).catch(e => {});
   }
 
-  // 4. Install missing browsers for this package.
+  // 3. Install missing browsers for this package.
   const myBrowsers = JSON.parse((await fsReadFileAsync(path.join(packagePath, 'browsers.json'))).toString())['browsers'] as browserPaths.BrowserDescriptor[];
   for (const browser of myBrowsers) {
     const browserPath = browserPaths.browserDirectory(browsersPath, browser);


### PR DESCRIPTION
This reverts 2 commits:

- "fix(installer): create tmp directory inside `browserPath` (#2498)"
  commit 946b4efa3b55dd96396b1c34f1f159735beaaaea.

- "feat: support atomic installation of browsers (#2489)"
  commit 3de0c087bcc2592ae9fa65a79a29129e2b153e06.

This addresses installation issues we see in some CI environments.