### PR TITLE
fix(oopif): make Page.addInitScript and Page.exposeBinding work for oopifs

### DIFF
--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -440,7 +440,11 @@ class FrameSession {
     promises.push(this._updateEmulateMedia());
     for (const binding of this._crPage._browserContext._pageBindings.values())
       promises.push(this._initBinding(binding));
+    for (const binding of this._crPage._page._pageBindings.values())
+      promises.push(this._initBinding(binding));
     for (const source of this._crPage._browserContext._evaluateOnNewDocumentSources)
+      promises.push(this._evaluateOnNewDocument(source));
+    for (const source of this._crPage._page._evaluateOnNewDocumentSources)
       promises.push(this._evaluateOnNewDocument(source));
     promises.push(this._client.send('Runtime.runIfWaitingForDebugger'));
     promises.push(this._firstNonInitialNavigationCommittedPromise);

--- a/src/page.ts
+++ b/src/page.ts
@@ -103,6 +103,7 @@ export class Page extends EventEmitter {
   readonly _logger: InnerLogger;
   readonly _state: PageState;
   readonly _pageBindings = new Map<string, PageBinding>();
+  readonly _evaluateOnNewDocumentSources: string[] = [];
   readonly _screenshotter: Screenshotter;
   readonly _frameManager: frames.FrameManager;
   readonly accessibility: accessibility.Accessibility;
@@ -379,7 +380,9 @@ export class Page extends EventEmitter {
   }
 
   async addInitScript(script: Function | string | { path?: string, content?: string }, arg?: any) {
-    await this._delegate.evaluateOnNewDocument(await helper.evaluationScript(script, arg));
+    const source = await helper.evaluationScript(script, arg);
+    this._evaluateOnNewDocumentSources.push(source);
+    await this._delegate.evaluateOnNewDocument(source);
   }
 
   _needsRequestInterception(): boolean {

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -59,7 +59,6 @@ export class WKPage implements PageDelegate {
   private _mainFrameContextId?: number;
   private _sessionListeners: RegisteredListener[] = [];
   private _eventListeners: RegisteredListener[];
-  private readonly _evaluateOnNewDocumentSources: string[] = [];
   readonly _browserContext: WKBrowserContext;
   _initializedPage: Page | null = null;
   private _firstNonInitialNavigationCommittedPromise: Promise<void>;
@@ -655,7 +654,6 @@ export class WKPage implements PageDelegate {
   }
 
   async evaluateOnNewDocument(script: string): Promise<void> {
-    this._evaluateOnNewDocumentSources.push(script);
     await this._updateBootstrapScript();
   }
 
@@ -670,7 +668,7 @@ export class WKPage implements PageDelegate {
     for (const binding of this._page._pageBindings.values())
       scripts.push(this._bindingToScript(binding));
     scripts.push(...this._browserContext._evaluateOnNewDocumentSources);
-    scripts.push(...this._evaluateOnNewDocumentSources);
+    scripts.push(...this._page._evaluateOnNewDocumentSources);
     return scripts.join(';');
   }
 

--- a/test/chromium/oopif.spec.js
+++ b/test/chromium/oopif.spec.js
@@ -199,6 +199,28 @@ describe('OOPIF', function() {
     expect(requestFrames[2]).toBe(grandChild);
     expect(finishedFrames[2]).toBe(grandChild);
   });
+  it('should support exposeFunction', async function({browser, page, server, context}) {
+    await context.exposeFunction('dec', a => a - 1);
+    await page.exposeFunction('inc', a => a + 1);
+    await page.goto(server.PREFIX + '/dynamic-oopif.html');
+    expect(await countOOPIFs(browser)).toBe(1);
+    expect(page.frames().length).toBe(2);
+    expect(await page.frames()[0].evaluate(() => inc(3))).toBe(4);
+    expect(await page.frames()[1].evaluate(() => inc(4))).toBe(5);
+    expect(await page.frames()[0].evaluate(() => dec(3))).toBe(2);
+    expect(await page.frames()[1].evaluate(() => dec(4))).toBe(3);
+  });
+  it('should support addInitScript', async function({browser, page, server, context}) {
+    await context.addInitScript(() => window.bar = 17);
+    await page.addInitScript(() => window.foo = 42);
+    await page.goto(server.PREFIX + '/dynamic-oopif.html');
+    expect(await countOOPIFs(browser)).toBe(1);
+    expect(page.frames().length).toBe(2);
+    expect(await page.frames()[0].evaluate(() => window.foo)).toBe(42);
+    expect(await page.frames()[1].evaluate(() => window.foo)).toBe(42);
+    expect(await page.frames()[0].evaluate(() => window.bar)).toBe(17);
+    expect(await page.frames()[1].evaluate(() => window.bar)).toBe(17);
+  });
   // @see https://github.com/microsoft/playwright/issues/1240
   it('should click a button when it overlays oopif', async function({browser, page, server, context}) {
     await page.goto(server.PREFIX + '/button-overlay-oopif.html');


### PR DESCRIPTION
Fixes #2537.