### PR TITLE
fix(log): include log name in progress recording

### DIFF
--- a/src/progress.ts
+++ b/src/progress.ts
@@ -84,7 +84,7 @@ export class ProgressController {
       },
       log: (log: Log, message: string | Error) => {
         if (this._state === 'running') {
-          this._logRecording.push(message.toString());
+          this._logRecording.push(`[${log.name}] ${message.toString()}`);
           this._logger.log(log, '  ' + message);
         } else {
           this._logger.log(log, message);

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -54,6 +54,8 @@ describe('Playwright', function() {
       const options = { ...defaultBrowserOptions, timeout: 5000, __testHookBeforeCreateBrowser: () => new Promise(f => setTimeout(f, 6000)) };
       const error = await browserType.launch(options).catch(e => e);
       expect(error.message).toContain(`Timeout 5000ms exceeded during ${browserType.name()}.launch.`);
+      expect(error.message).toContain(`[browser] <launching>`);
+      expect(error.message).toContain(`[browser] <launched> pid=`);
     });
     it('should handle exception', async({browserType, defaultBrowserOptions}) => {
       const e = new Error('Dummy');


### PR DESCRIPTION
Otherwise, we are getting some confusing output from the browser stdout/stderr.