### PR TITLE
chore: explicitly plumb various errors through the retries

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -23,10 +23,4 @@ class CustomError extends Error {
   }
 }
 
-export class NotConnectedError extends CustomError {
-  constructor() {
-    super('Element is not attached to the DOM');
-  }
-}
-
 export class TimeoutError extends CustomError {}

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -31,7 +31,6 @@ import { RawKeyboardImpl, RawMouseImpl } from './ffInput';
 import { FFNetworkManager, headersArray } from './ffNetworkManager';
 import { Protocol } from './protocol';
 import { selectors } from '../selectors';
-import { NotConnectedError } from '../errors';
 import { rewriteErrorMessage } from '../utils/stackTrace';
 
 const UTILITY_WORLD_NAME = '__playwright_utility_world__';
@@ -411,14 +410,14 @@ export class FFPage implements PageDelegate {
     return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
   }
 
-  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'success' | 'invisible'> {
+  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'notvisible' | 'notconnected' | 'done'> {
     return await this._session.send('Page.scrollIntoViewIfNeeded', {
       frameId: handle._context.frame._id,
       objectId: handle._objectId,
       rect,
-    }).then(() => 'success' as const).catch(e => {
+    }).then(() => 'done' as const).catch(e => {
       if (e instanceof Error && e.message.includes('Node is detached from document'))
-        throw new NotConnectedError();
+        return 'notconnected';
       throw e;
     });
   }

--- a/src/page.ts
+++ b/src/page.ts
@@ -69,7 +69,7 @@ export interface PageDelegate {
   setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void>;
   getBoundingBox(handle: dom.ElementHandle): Promise<types.Rect | null>;
   getFrameElement(frame: frames.Frame): Promise<dom.ElementHandle>;
-  scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'success' | 'invisible'>;
+  scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'notvisible' | 'notconnected' | 'done'>;
   rafCountForStablePosition(): number;
 
   getAccessibilityTree(needle?: dom.ElementHandle): Promise<{tree: accessibility.AXNode, needle: accessibility.AXNode | null}>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,10 +154,7 @@ export type JSCoverageOptions = {
   reportAnonymousScripts?: boolean,
 };
 
-export type InjectedScriptResult<T = undefined> =
-  (T extends undefined ? { status: 'success', value?: T} : { status: 'success', value: T }) |
-  { status: 'notconnected' } |
-  { status: 'error', error: string };
+export type InjectedScriptResult<T> = { error?: string, value?: T };
 
 export type InjectedScriptProgress = {
   canceled: boolean,

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -36,7 +36,6 @@ import { WKBrowserContext } from './wkBrowser';
 import { selectors } from '../selectors';
 import * as jpeg from 'jpeg-js';
 import * as png from 'pngjs';
-import { NotConnectedError } from '../errors';
 import { ConsoleMessageLocation } from '../console';
 import { JSHandle } from '../javascript';
 
@@ -746,15 +745,15 @@ export class WKPage implements PageDelegate {
     return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
   }
 
-  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'success' | 'invisible'> {
+  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'notvisible' | 'notconnected' | 'done'> {
     return await this._session.send('DOM.scrollIntoViewIfNeeded', {
       objectId: handle._objectId,
       rect,
-    }).then(() => 'success' as const).catch(e => {
+    }).then(() => 'done' as const).catch(e => {
       if (e instanceof Error && e.message.includes('Node does not have a layout object'))
-        return 'invisible';
+        return 'notvisible';
       if (e instanceof Error && e.message.includes('Node is detached from document'))
-        throw new NotConnectedError();
+        return 'notconnected';
       throw e;
     });
   }

--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -621,7 +621,6 @@ describe('Page.click', function() {
     const error = await promise;
     expect(await page.evaluate(() => window.clicked)).toBe(undefined);
     expect(error.message).toContain('Element is not attached to the DOM');
-    expect(error.name).toContain('NotConnectedError');
   });
   it('should fail when element detaches after animation', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/animating-button.html');
@@ -632,7 +631,6 @@ describe('Page.click', function() {
     const error = await promise;
     expect(await page.evaluate(() => window.clicked)).toBe(undefined);
     expect(error.message).toContain('Element is not attached to the DOM');
-    expect(error.name).toContain('NotConnectedError');
   });
   it('should retry when element detaches after animation', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/animating-button.html');

--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -463,25 +463,25 @@ describe('Frame.waitForSelector', function() {
     await page.waitForSelector('.zombo', { timeout: 10 }).catch(e => error = e);
     expect(error.stack).toContain('waittask.spec.js');
   });
-  it('should throw for unknown waitFor option', async({page, server}) => {
+  it('should throw for unknown state option', async({page, server}) => {
     await page.setContent('<section>test</section>');
     const error = await page.waitForSelector('section', { state: 'foo' }).catch(e => e);
-    expect(error.message).toContain('Unsupported waitFor option');
+    expect(error.message).toContain('Unsupported state option "foo"');
   });
   it('should throw for visibility option', async({page, server}) => {
     await page.setContent('<section>test</section>');
     const error = await page.waitForSelector('section', { visibility: 'hidden' }).catch(e => e);
     expect(error.message).toBe('options.visibility is not supported, did you mean options.state?');
   });
-  it('should throw for true waitFor option', async({page, server}) => {
+  it('should throw for true state option', async({page, server}) => {
     await page.setContent('<section>test</section>');
     const error = await page.waitForSelector('section', { state: true }).catch(e => e);
-    expect(error.message).toContain('Unsupported waitFor option');
+    expect(error.message).toContain('Unsupported state option "true"');
   });
-  it('should throw for false waitFor option', async({page, server}) => {
+  it('should throw for false state option', async({page, server}) => {
     await page.setContent('<section>test</section>');
     const error = await page.waitForSelector('section', { state: false }).catch(e => e);
-    expect(error.message).toContain('Unsupported waitFor option');
+    expect(error.message).toContain('Unsupported state option "false"');
   });
   it('should support >> selector syntax', async({page, server}) => {
     await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
We are about to have more errors like 'not matching selector anymore', so explicit plumbing helps with visibility.