### PR TITLE
fix(errors): strict error handling around element operations

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1302,10 +1302,11 @@ const fs = require('fs');
 - `options` <[Object]>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
-- returns: <[Promise]> Promise which resolves when the element matching `selector` is successfully filled. The promise will be rejected if there is no element matching `selector`.
+- returns: <[Promise]>
 
-This method focuses the element and triggers an `input` event after filling.
-If there's no text `<input>`, `<textarea>` or `[contenteditable]` element matching `selector`, the method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for an element matching `selector`, waits for [actionability](./actionability.md) checks, focuses the element, fills it and triggers an `input` event after filling.
+If the element matching `selector` is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error.
+Note that you can pass an empty string to clear the input field.
 
 To send fine-grained keyboard events, use [`page.type`](#pagetypeselector-text-options).
 
@@ -2253,10 +2254,11 @@ await resultHandle.dispose();
 - `options` <[Object]>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
-- returns: <[Promise]> Promise which resolves when the element matching `selector` is successfully filled. The promise will be rejected if there is no element matching `selector`.
+- returns: <[Promise]>
 
-This method focuses the element and triggers an `input` event after filling.
-If there's no text `<input>`, `<textarea>` or `[contenteditable]` element matching `selector`, the method throws an error.
+This method waits for an element matching `selector`, waits for [actionability](./actionability.md) checks, focuses the element, fills it and triggers an `input` event after filling.
+If the element matching `selector` is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error.
+Note that you can pass an empty string to clear the input field.
 
 To send fine-grained keyboard events, use [`frame.type`](#frametypeselector-text-options).
 
@@ -2791,10 +2793,11 @@ await elementHandle.dispatchEvent('dragstart', { dataTransfer });
 - `options` <[Object]>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) methods.
-- returns: <[Promise]> Promise which resolves when the element is successfully filled.
+- returns: <[Promise]>
 
-This method focuses the element and triggers an `input` event after filling.
-If element is not a text `<input>`, `<textarea>` or `[contenteditable]` element, the method throws an error.
+This method waits for [actionability](./actionability.md) checks, focuses the element, fills it and triggers an `input` event after filling.
+If the element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error.
+Note that you can pass an empty string to clear the input field.
 
 #### elementHandle.focus()
 - returns: <[Promise]>

--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -243,7 +243,7 @@ export class CRPage implements PageDelegate {
     return this._sessionForHandle(handle)._getBoundingBox(handle);
   }
 
-  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'notvisible' | 'notconnected' | 'done'> {
+  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'error:notvisible' | 'error:notconnected' | 'done'> {
     return this._sessionForHandle(handle)._scrollRectIntoViewIfNeeded(handle, rect);
   }
 
@@ -825,15 +825,15 @@ class FrameSession {
     return {x, y, width, height};
   }
 
-  async _scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'notvisible' | 'notconnected' | 'done'> {
+  async _scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'error:notvisible' | 'error:notconnected' | 'done'> {
     return await this._client.send('DOM.scrollIntoViewIfNeeded', {
       objectId: handle._objectId,
       rect,
     }).then(() => 'done' as const).catch(e => {
       if (e instanceof Error && e.message.includes('Node does not have a layout object'))
-        return 'notvisible';
+        return 'error:notvisible';
       if (e instanceof Error && e.message.includes('Node is detached from document'))
-        return 'notconnected';
+        return 'error:notconnected';
       throw e;
     });
   }

--- a/src/common/domErrors.ts
+++ b/src/common/domErrors.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type FatalDOMError =
+  'error:notelement' |
+  'error:nothtmlelement' |
+  'error:notfillableelement' |
+  'error:notfillableinputtype' |
+  'error:notfillablenumberinput' |
+  'error:notvaliddate' |
+  'error:notinput' |
+  'error:notselect';
+
+export type RetargetableDOMError = 'error:notconnected';

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -410,16 +410,16 @@ export class FFPage implements PageDelegate {
     return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
   }
 
-  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'notvisible' | 'notconnected' | 'done'> {
+  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'error:notvisible' | 'error:notconnected' | 'done'> {
     return await this._session.send('Page.scrollIntoViewIfNeeded', {
       frameId: handle._context.frame._id,
       objectId: handle._objectId,
       rect,
     }).then(() => 'done' as const).catch(e => {
       if (e instanceof Error && e.message.includes('Node is detached from document'))
-        return 'notconnected';
+        return 'error:notconnected';
       if (e instanceof Error && e.message.includes('Node does not have a layout object'))
-        return 'notvisible';
+        return 'error:notvisible';
       throw e;
     });
   }

--- a/src/page.ts
+++ b/src/page.ts
@@ -67,7 +67,7 @@ export interface PageDelegate {
   setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void>;
   getBoundingBox(handle: dom.ElementHandle): Promise<types.Rect | null>;
   getFrameElement(frame: frames.Frame): Promise<dom.ElementHandle>;
-  scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'notvisible' | 'notconnected' | 'done'>;
+  scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'error:notvisible' | 'error:notconnected' | 'done'>;
   rafCountForStablePosition(): number;
 
   getAccessibilityTree(needle?: dom.ElementHandle): Promise<{tree: accessibility.AXNode, needle: accessibility.AXNode | null}>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,10 +137,8 @@ export type JSCoverageOptions = {
   reportAnonymousScripts?: boolean,
 };
 
-export type InjectedScriptResult<T> = { error?: string, value?: T };
-
 export type InjectedScriptProgress = {
-  canceled: boolean,
+  aborted: boolean,
   log: (message: string) => void,
   logRepeating: (message: string) => void,
 };

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -750,15 +750,15 @@ export class WKPage implements PageDelegate {
     return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
   }
 
-  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'notvisible' | 'notconnected' | 'done'> {
+  async scrollRectIntoViewIfNeeded(handle: dom.ElementHandle, rect?: types.Rect): Promise<'error:notvisible' | 'error:notconnected' | 'done'> {
     return await this._session.send('DOM.scrollIntoViewIfNeeded', {
       objectId: handle._objectId,
       rect,
     }).then(() => 'done' as const).catch(e => {
       if (e instanceof Error && e.message.includes('Node does not have a layout object'))
-        return 'notvisible';
+        return 'error:notvisible';
       if (e instanceof Error && e.message.includes('Node is detached from document'))
-        return 'notconnected';
+        return 'error:notconnected';
       throw e;
     });
   }

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1049,7 +1049,7 @@ describe('Page.fill', function() {
       await page.$eval('input', (input, type) => input.setAttribute('type', type), type);
       let error = null;
       await page.fill('input', '').catch(e => error = e);
-      expect(error.message).toContain('Cannot fill input of type');
+      expect(error.message).toContain(`input of type "${type}" cannot be filled`);
     }
   });
   it('should fill different input types', async({page, server}) => {
@@ -1069,7 +1069,7 @@ describe('Page.fill', function() {
   it.skip(WEBKIT)('should throw on incorrect date', async({page, server}) => {
     await page.setContent('<input type=date>');
     const error = await page.fill('input', '2020-13-05').catch(e => e);
-    expect(error.message).toContain('Malformed date "2020-13-05"');
+    expect(error.message).toContain('Malformed value');
   });
   it('should fill time input', async({page, server}) => {
     await page.setContent('<input type=time>');
@@ -1079,7 +1079,7 @@ describe('Page.fill', function() {
   it.skip(WEBKIT)('should throw on incorrect time', async({page, server}) => {
     await page.setContent('<input type=time>');
     const error = await page.fill('input', '25:05').catch(e => e);
-    expect(error.message).toContain('Malformed time "25:05"');
+    expect(error.message).toContain('Malformed value');
   });
   it('should fill datetime-local input', async({page, server}) => {
     await page.setContent('<input type=datetime-local>');
@@ -1089,7 +1089,7 @@ describe('Page.fill', function() {
   it.skip(WEBKIT || FFOX)('should throw on incorrect datetime-local', async({page, server}) => {
     await page.setContent('<input type=datetime-local>');
     const error = await page.fill('input', 'abc').catch(e => e);
-    expect(error.message).toContain('Malformed datetime-local "abc"');
+    expect(error.message).toContain('Malformed value');
   });
   it('should fill contenteditable', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/textarea.html');
@@ -1213,7 +1213,7 @@ describe('Page.fill', function() {
     await page.setContent(`<input id="input" type="number"></input>`);
     let error = null;
     await page.fill('input', 'abc').catch(e => error = e);
-    expect(error.message).toContain('Cannot type text into input[type=number].');
+    expect(error.message).toContain('Cannot type text into input[type=number]');
   });
   it('should be able to clear', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/textarea.html');


### PR DESCRIPTION
- Gave all possible dom errors distinct names, and throw them on the node side.
- Separated errors into FatalDOMError and RetargetableDOMError. Fatal errors are unrecoverable. Retargetable errors could be resolved by requerying the selector.
- This exposed a number of unhandled 'notconnected' cases.
- Added helper functions to handle errors and ensure TypeScript catches unhandled ones.