### PR TITLE
 docs(core-concepts.md): fix typos

### DIFF
--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -278,7 +278,7 @@ Playwright's [`ElementHandle`](./api.md#class-elementhandle) extends
 [`JSHandle`](./api.md#class-jshandle).
 
 Handles Lifetime:
-- Handles can be acquired using the page methods [`page.evaluteHandle`](./api.md#pageevaluatehandlepagefunction-arg), [`page.$`](./api.md#pageselector) or [`page.$$`](./api.md#pageselector-1) or
+- Handles can be acquired using the page methods [`page.evaluateHandle`](./api.md#pageevaluatehandlepagefunction-arg), [`page.$`](./api.md#pageselector) or [`page.$$`](./api.md#pageselector-1) or
   their frame counterparts [`frame.evaluateHandle`](./api.md#frameevaluatehandlepagefunction-arg), [`frame.$`](./api.md#frameselector) or [`frame.$$`](./api.md#frameselector-1).
 - Once created, handles will retain object from [garbage collection](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Memory_Management)
 - Handles will be **automatically disposed** once the page or frame they belong to navigates or closes.
@@ -303,7 +303,7 @@ await page.evaluate(uiElement => getComputedStyle(uiElement).getPropertyValue('d
 #### API reference
 - [class `JSHandle`](./api.md#class-jshandle)
 - [class `ElementHandle`](./api.md#class-elementhandle)
-- [`page.evaluteHandle`](./api.md#pageevaluatehandlepagefunction-arg)
+- [`page.evaluateHandle`](./api.md#pageevaluatehandlepagefunction-arg)
 - [`page.$`](./api.md#pageselector)
 - [`page.$$`](./api.md#pageselector-1)
 - [`jsHandle.evaluate`](./api.md#jshandleevaluatepagefunction-arg)


### PR DESCRIPTION
Realized that the `evaluateHandle` method wasn't spelled properly in these two instances. 