### PR TITLE
fix(network): disallow intercepting redirects

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1112"
+      "revision": "1113"
     },
     {
       "name": "webkit",

--- a/src/chromium/crNetworkManager.ts
+++ b/src/chromium/crNetworkManager.ts
@@ -191,6 +191,13 @@ export class CRNetworkManager {
         this._client._sendMayFail('Fetch.continueRequest', { requestId: requestPausedEvent.requestId });
       return;
     }
+    let allowInterception = this._userRequestInterceptionEnabled;
+    if (redirectedFrom) {
+      allowInterception = false;
+      // We do not support intercepting redirects.
+      if (requestPausedEvent)
+        this._client._sendMayFail('Fetch.continueRequest', { requestId: requestPausedEvent.requestId });
+    }
     const isNavigationRequest = requestWillBeSentEvent.requestId === requestWillBeSentEvent.loaderId && requestWillBeSentEvent.type === 'Document';
     const documentId = isNavigationRequest ? requestWillBeSentEvent.loaderId : undefined;
     if (isNavigationRequest)
@@ -199,7 +206,7 @@ export class CRNetworkManager {
       client: this._client,
       frame,
       documentId,
-      allowInterception: this._userRequestInterceptionEnabled,
+      allowInterception,
       requestWillBeSentEvent,
       requestPausedEvent,
       redirectedFrom

--- a/src/network.ts
+++ b/src/network.ts
@@ -115,6 +115,7 @@ export class Request {
   constructor(routeDelegate: RouteDelegate | null, frame: frames.Frame, redirectedFrom: Request | null, documentId: string | undefined,
     url: string, resourceType: string, method: string, postData: string | null, headers: Headers) {
     assert(!url.startsWith('data:'), 'Data urls should not fire requests');
+    assert(!(routeDelegate && redirectedFrom), 'Should not be able to intercept redirects');
     this._routeDelegate = routeDelegate;
     this._frame = frame;
     this._redirectedFrom = redirectedFrom;

--- a/src/webkit/wkInterceptableRequest.ts
+++ b/src/webkit/wkInterceptableRequest.ts
@@ -44,10 +44,12 @@ export class WKInterceptableRequest implements network.RouteDelegate {
   readonly _requestId: string;
   _interceptedCallback: () => void = () => {};
   private _interceptedPromise: Promise<unknown>;
+  readonly _allowInterception: boolean;
 
   constructor(session: WKSession, allowInterception: boolean, frame: frames.Frame, event: Protocol.Network.requestWillBeSentPayload, redirectedFrom: network.Request | null, documentId: string | undefined) {
     this._session = session;
     this._requestId = event.requestId;
+    this._allowInterception = allowInterception;
     const resourceType = event.type ? event.type.toLowerCase() : (redirectedFrom ? redirectedFrom.resourceType() : 'other');
     this.request = new network.Request(allowInterception ? this : null, frame, redirectedFrom, documentId, event.request.url,
         resourceType, event.request.method, event.request.postData || null, headersObject(event.request.headers));


### PR DESCRIPTION
WebKit and Firefox are only able to continue redirects.
Firefox is faking it on the backend, so you can't even stall it.

Instead, we just do not fire routes for redirects on all browsers and avoid surprises.