### PR TITLE
devops: do cache busting for APT

### DIFF
--- a/docs/docker/Dockerfile.bionic
+++ b/docs/docker/Dockerfile.bionic
@@ -15,43 +15,43 @@ RUN apt-get update && apt-get install -y curl && \
     apt-get install -y nodejs
 
 # 2. Install WebKit dependencies
-RUN apt-get install -y libwoff1 \
-                       libopus0 \
-                       libwebp6 \
-                       libwebpdemux2 \
-                       libenchant1c2a \
-                       libgudev-1.0-0 \
-                       libsecret-1-0 \
-                       libhyphen0 \
-                       libgdk-pixbuf2.0-0 \
-                       libegl1 \
-                       libnotify4 \
-                       libxslt1.1 \
-                       libevent-2.1-6 \
-                       libgles2 \
-                       libvpx5
+RUN apt-get update && apt-get install -y libwoff1 \
+                                         libopus0 \
+                                         libwebp6 \
+                                         libwebpdemux2 \
+                                         libenchant1c2a \
+                                         libgudev-1.0-0 \
+                                         libsecret-1-0 \
+                                         libhyphen0 \
+                                         libgdk-pixbuf2.0-0 \
+                                         libegl1 \
+                                         libnotify4 \
+                                         libxslt1.1 \
+                                         libevent-2.1-6 \
+                                         libgles2 \
+                                         libvpx5
 
 # 3. Install gstreamer and plugins to support video playback in WebKit.
-RUN apt-get install -y gstreamer1.0-gl \
-                       gstreamer1.0-plugins-base \
-                       gstreamer1.0-plugins-good \
-                       gstreamer1.0-plugins-bad
+RUN apt-get update && apt-get install -y gstreamer1.0-gl \
+                                         gstreamer1.0-plugins-base \
+                                         gstreamer1.0-plugins-good \
+                                         gstreamer1.0-plugins-bad
 
 # 4. Install Chromium dependencies
 
-RUN apt-get install -y libnss3 \
-                       libxss1 \
-                       libasound2 \
-                       fonts-noto-color-emoji
+RUN apt-get update && apt-get install -y libnss3 \
+                                         libxss1 \
+                                         libasound2 \
+                                         fonts-noto-color-emoji
 
 # 5. Install Firefox dependencies
 
-RUN apt-get install -y libdbus-glib-1-2 \
-                       libxt6
+RUN apt-get update && apt-get install -y libdbus-glib-1-2 \
+                                         libxt6
 
 # 6. Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
 
-RUN apt-get install -y ffmpeg
+RUN apt-get update && apt-get install -y ffmpeg
 
 # 7. Add user so we don't need --no-sandbox in Chromium
 RUN groupadd -r pwuser && useradd -r -g pwuser -G audio,video pwuser \
@@ -59,7 +59,7 @@ RUN groupadd -r pwuser && useradd -r -g pwuser -G audio,video pwuser \
     && chown -R pwuser:pwuser /home/pwuser
 
 # 8. (Optional) Install XVFB if there's a need to run browsers in headful mode
-RUN apt-get install -y xvfb
+RUN apt-get update && apt-get install -y xvfb
 
 # Run everything after as non-privileged user.
 USER pwuser


### PR DESCRIPTION
To avoid caching old package lists, every `apt-get install`
should be prefixed with `apt-get update`.

More info on the matter:
- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
- https://github.com/moby/moby/issues/3313