### PR TITLE
fix(redirects): make redirectedFrom/redirectedTo available at response time

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -171,7 +171,7 @@ export class Request {
     return JSON.parse(this._postData);
   }
 
-  headers(): {[key: string]: string} {
+  headers(): Headers {
     return { ...this._headers };
   }
 


### PR DESCRIPTION
Otherwise, we cannot determine whether a particular response is a redirect.
This makes it harder to work with redirects, for example because we always
throw when trying to get redirect body.