### PR TITLE
chore: prepare parsed selectors to more tasks

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -178,3 +178,5 @@ export type MouseMultiClickOptions = PointerActionOptions & {
   delay?: number;
   button?: MouseButton;
 };
+
+export type World = 'main' | 'utility';


### PR DESCRIPTION
We currently have dispatchEventTask and waitForSelectorTask.
However, most selector-based operations make sense as tasks, to ensure
atomic execution, e.g. textContent(selector) or focus(selector).
This will fight hydration, elements recycling and other async issues.

In preparation, decouple tasks from selectors parsing so that
we can have common infrastructure for tasks.