### PR TITLE
fix(logs): streaming logs from InjectedScriptPoll without exception

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -143,10 +143,11 @@ export type InjectedScriptProgress = {
   logRepeating: (message: string) => void,
 };
 
-export type InjectedScriptLogs = { current: string[], next: Promise<InjectedScriptLogs> };
 export type InjectedScriptPoll<T> = {
   result: Promise<T>,
-  logs: Promise<InjectedScriptLogs>,
+  // Takes more logs, waiting until at least one message is available.
+  takeNextLogs: () => Promise<string[]>,
+  // Takes all current logs without waiting.
   takeLastLogs: () => string[],
   cancel: () => void,
 };


### PR DESCRIPTION
We used to get undefined messages, because we were mistakenly fulfilling the logs promise multiple times.