### PR TITLE
fix(textContent): make page.textContent(selector) atomic

### DIFF
--- a/src/common/selectorParser.ts
+++ b/src/common/selectorParser.ts
@@ -52,7 +52,6 @@ export function parseSelector(selector: string): ParsedSelector {
       name = 'css';
       body = part;
     }
-    name = name.toLowerCase();
     let capture = false;
     if (name[0] === '*') {
       capture = true;

--- a/test/utils.js
+++ b/test/utils.js
@@ -94,6 +94,15 @@ const utils = module.exports = {
     expect(await page.evaluate('window.innerHeight')).toBe(height);
   },
 
+  registerEngine: async (name, script, options) => {
+    try {
+      await playwright.selectors.register(name, script, options);
+    } catch (e) {
+      if (!e.message.includes('has been already registered'))
+        throw e;
+    }
+  },
+
   initializeFlakinessDashboardIfNeeded: async function(testRunner) {
     // Generate testIDs for all tests and verify they don't clash.
     // This will add |test.testId| for every test.


### PR DESCRIPTION
We now query selector and take textContent synchronously. This avoids any issues with async processing: node being recycled, detached, etc.

For this, some infrastructure has been moved to dom.ts. More methods will follow with the same atomic pattern and reuse it.

Drive-by: fixed selector engine names being sometimes case-sensitive and sometimes not.