### PR TITLE
fix(webkit): do not swallow errors when returning by value

### DIFF
--- a/src/common/utilityScriptSerializers.ts
+++ b/src/common/utilityScriptSerializers.ts
@@ -15,8 +15,7 @@
  */
 
 export function parseEvaluationResultValue(value: any, handles: any[] = []): any {
-  // { type: 'undefined' } does not even have value.
-  if (value === 'undefined')
+  if (value === undefined)
     return undefined;
   if (typeof value === 'object') {
     if (value.v === 'undefined')

--- a/src/injected/utilityScript.ts
+++ b/src/injected/utilityScript.ts
@@ -32,6 +32,9 @@ export default class UtilityScript {
   }
 
   jsonValue(returnByValue: true, value: any) {
+    // Special handling of undefined to work-around multi-step returnByValue handling in WebKit.
+    if (Object.is(value, undefined))
+      return undefined;
     return serializeAsCallArgument(value, (value: any) => ({ fallThrough: value }));
   }
 

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -228,6 +228,10 @@ describe('Page.evaluate', function() {
   it('should properly serialize undefined fields', async({page}) => {
     expect(await page.evaluate(() => ({a: undefined}))).toEqual({});
   });
+  it('should return undefined properties', async({page}) => {
+    const value = await page.evaluate(() => ({a: undefined}));
+    expect('a' in value).toBe(true);
+  });
   it('should properly serialize null arguments', async({page}) => {
     expect(await page.evaluate(x => x, null)).toEqual(null);
   });


### PR DESCRIPTION
We currently return undefined whenever we had an error trying
return the evaluation result by error. The most common error
is "execution context destroyed".

This produces very unexpected undefined from methods that do not
ever expect undefined. Instead, we should throw because we were
not able to return the result.