### PR TITLE
chore(devops): restructured / added Dockerfiles for Debian and Ubuntu 20

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -85,7 +85,7 @@ For Linux agents, you can use [our Docker container](docker/README.md) with Azur
 pool:
   vmImage: 'ubuntu-18.04'
 
-container: aslushnikov/playwright:bionic
+container: mcr.microsoft.com/playwright:bionic
 
 steps:
 - script: npm install
@@ -151,7 +151,7 @@ We run our tests on CircleCI, with our [pre-built Docker image](docker/README.md
 
    ```yaml
    docker:
-     - image: aslushnikov/playwright:bionic
+     - image: mcr.microsoft.com/playwright:bionic
        environment:
          NODE_ENV: development # Needed if playwright is in `devDependencies`
    ```
@@ -175,7 +175,7 @@ We run our tests on Windows agents in AppVeyor. Use our [AppVeyor configuration]
 Bitbucket Pipelines can use public [Docker images as build environments](https://confluence.atlassian.com/bitbucket/use-docker-images-as-build-environments-792298897.html). To run Playwright tests on Bitbucket, use our public Docker image ([see Dockerfile](docker/README.md)).
 
 ```yml
-image: aslushnikov/playwright:bionic
+image: mcr.microsoft.com/playwright:bionic
 ```
 
 While the Docker image supports sandboxing for Chromium, it does not work in the Bitbucket Pipelines environment. To launch Chromium on Bitbucket Pipelines, use the `--no-sandbox` launch argument.
@@ -195,7 +195,7 @@ stages:
 
 tests:
   stage: test
-  image: aslushnikov/playwright:bionic
+  image: mcr.microsoft.com/playwright:bionic
   script:
     - npm install # This should install playwright
     - npm run test
@@ -214,7 +214,7 @@ execute and download the browser binaries on every run.
 
 Most CI providers cache the [npm-cache](https://docs.npmjs.com/cli-commands/cache.html)
 directory (located at `$HOME/.npm`). If your CI pipelines caches the `node_modules`
-directory and you run `npm install` (instead of `npm ci`), the default configuration 
+directory and you run `npm install` (instead of `npm ci`), the default configuration
 **will not work**. This is because the `npm install` step will find the Playwright NPM
 package on disk and not execute the `postinstall` step.
 

--- a/docs/docker/Dockerfile.buster
+++ b/docs/docker/Dockerfile.buster
@@ -1,18 +1,13 @@
 ################################################
 # Compile with:
-#     docker build -t mcr.microsoft.com/playwright:bionic -f Dockerfile.bionic .
+#     docker build -t mcr.microsoft.com/playwright:buster -f Dockerfile.buster .
 #
 # Run with:
-#     docker run -d -p --rm --name playwright mcr.microsoft.com/playwright:bionic
+#     docker run -d -p --rm --name playwright mcr.microsoft.com/playwright:buster
 #
 #################################################
 
-FROM ubuntu:bionic
-
-# Install Node.js (LTS)
-RUN apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y nodejs
+FROM node:12-buster-slim
 
 # Install dependencies
 RUN apt-get update && \
@@ -28,11 +23,8 @@ RUN apt-get update && \
     libhyphen0 \
     libgdk-pixbuf2.0-0 \
     libegl1 \
-    libnotify4 \
     libxslt1.1 \
-    libevent-2.1-6 \
     libgles2 \
-    libvpx5 \
     # gstreamer and plugins to support video playback in WebKit
     gstreamer1.0-gl \
     gstreamer1.0-plugins-base \
@@ -43,13 +35,33 @@ RUN apt-get update && \
     libxss1 \
     libasound2 \
     fonts-noto-color-emoji \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libxcomposite1 \
+    libcups2 \
+    libgtk-3-0 \
     # Firefox dependencies
     libdbus-glib-1-2 \
     libxt6 \
     # FFmpeg to bring in audio and video codecs necessary for playing videos in Firefox
     ffmpeg \
     # (Optional) XVFB if there's a need to run browsers in headful mode
-    xvfb
+    xvfb \
+    # For compiling libjpeg for WebKit
+    curl \
+    gcc \
+    make
+
+# Compiling libjpeg for WebKit
+RUN cd /tmp && \
+    curl -s http://www.ijg.org/files/jpegsrc.v8d.tar.gz | tar zx && \
+    cd jpeg-8d && \
+    ./configure && \
+    make && \
+    make install
+
+# Add directory in which libjpeg was built to the search path
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # Add user so we don't need --no-sandbox in Chromium
 RUN groupadd -r pwuser && useradd -r -g pwuser -G audio,video pwuser \

--- a/docs/docker/Dockerfile.focal
+++ b/docs/docker/Dockerfile.focal
@@ -1,13 +1,13 @@
 ################################################
 # Compile with:
-#     docker build -t mcr.microsoft.com/playwright:bionic -f Dockerfile.bionic .
+#     docker build -t mcr.microsoft.com/playwright:focal -f Dockerfile.focal .
 #
 # Run with:
-#     docker run -d -p --rm --name playwright mcr.microsoft.com/playwright:bionic
+#     docker run -d -p --rm --name playwright mcr.microsoft.com/playwright:focal
 #
 #################################################
 
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 # Install Node.js (LTS)
 RUN apt-get update && apt-get install -y curl && \
@@ -28,11 +28,11 @@ RUN apt-get update && \
     libhyphen0 \
     libgdk-pixbuf2.0-0 \
     libegl1 \
-    libnotify4 \
+    #libnotify4 \ will install whole xserver
     libxslt1.1 \
-    libevent-2.1-6 \
+    libevent-2.1-7 \
     libgles2 \
-    libvpx5 \
+    libvpx6 \
     # gstreamer and plugins to support video playback in WebKit
     gstreamer1.0-gl \
     gstreamer1.0-plugins-base \

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -1,25 +1,41 @@
 # Running Playwright in Docker
 
-[Dockerfile.bionic](Dockerfile.bionic) is a playwright-ready image of playwright.
-This image includes all the dependencies needed to run browsers in a Docker
-container.
+## General
 
-Building image:
+We provide official Docker images which include all the need dependencies for the recent **Ubuntu** and **Debian** versions to run browsers in a Docker container.
 
+### Building image
+
+```bash
+docker build -t mcr.microsoft.com/playwright:focal -f Dockerfile.focal .
 ```
-$ sudo docker build -t microsoft/playwright:bionic -f Dockerfile.bionic .
-```
 
-Running image:
+### Running image
 
-```
-$ sudo docker container run -it --rm --ipc=host --security-opt seccomp=chrome.json microsoft/playwright:bionic /bin/bash
+```bash
+docker container run -it --rm --ipc=host --security-opt seccomp=chrome.json mcr.microsoft.com/playwright:focal /bin/bash
 ```
 
 > **NOTE**: The seccomp profile is coming from Jessie Frazelle. It's needed
-> to run Chrome without sandbox.  
-> Using `--ipc=host` is also recommended when using Chrome. Without it Chrome can run out of memory and crash.  
+> to run Chrome without sandbox.
+> Using `--ipc=host` is also recommended when using Chrome. Without it Chrome can run out of memory and crash.
 > [See the docker documentation for this option here.](https://docs.docker.com/engine/reference/run/#ipc-settings---ipc)
+
+## Playwright on Ubuntu
+
+### Ubuntu 20 - Focal
+
+[Dockerfile.focal](Dockerfile.focal) is based on [Ubuntu 20](https://hub.docker.com/_/ubuntu).
+
+### Ubuntu 18 - Bionic
+
+[Dockerfile.bionic](Dockerfile.bionic) is based on [Ubuntu 18](https://hub.docker.com/_/ubuntu).
+
+## Playwright on Debian
+
+### Debian 10 - Buster
+
+[Dockerfile.buster](Dockerfile.buster) is based on a [slim version](https://hub.docker.com/_/node/) of Debian buster.
 
 ## Playwright on Alpine
 

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -9,10 +9,13 @@ We provide official Docker images which include all the need dependencies for th
   * [Using on CI](#using-on-ci)
 - [Development](#development)
   * [Build the image](#build-the-image)
-  * [Push](#push-the-image)
+  * [Push the image](#push-the-image)
 - [Available images](#available-images)
   * [Ubuntu](#ubuntu)
+    - [Ubuntu 20 - Focal](#ubuntu-20---focal)
+    - [Ubuntu 18 - Bionic](#ubuntu-18---bionic)
   * [Debian](#debian)
+    - [Debian 10 - Buster](#debian-10---buster)
   * [Alpine](#alpine)
 <!-- GEN:stop -->
 


### PR DESCRIPTION
I had some modified Dockerfiles lying around on my disk, probably they are useful for others. Changes:
- Grouped APT calls into a single APT call as discussed here: https://github.com/microsoft/playwright/pull/2656#issuecomment-647003569
- Added Ubuntu (20 - focal) - latest LTS release of Ubuntu
- Added Debian (10 - buster) - based on `node:12-buster-slim` a bit more lightweight, different and also common as a Docker base image. Needed also the custom `libjpeg` build, as proposed here: https://github.com/microsoft/playwright/issues/2437#issuecomment-642860416.

With these the users, should be have more official Dockerfiles to get started with Playwright and see easier which dependencies are required in which Linux distribution (rather than just a list of deps in the docs).

Tested all of these three with Try Playwright locally, all of the browsers are working, making screenshots and interaction works.

Follow up questions:
- Maybe replace the `bionic` (Ubuntu 18) build to the `focal` (Ubuntu 20) build everywhere?
- @arjun27 can we push them also to the Docker registry as soon as its merged?

Relates to #3338