### PR TITLE
fix(evaluate): awaitPromise when Promise is overwritten

### DIFF
--- a/src/common/utilityScriptSerializers.ts
+++ b/src/common/utilityScriptSerializers.ts
@@ -52,9 +52,6 @@ export function serializeAsCallArgument(value: any, jsHandleSerializer: (value: 
 }
 
 function serialize(value: any, jsHandleSerializer: (value: any) => { fallThrough?: any }, visited: Set<any>): any {
-  if (value && typeof value === 'object' && typeof value.then === 'function')
-    return value;
-
   const result = jsHandleSerializer(value);
   if ('fallThrough' in result)
     value = result.fallThrough;

--- a/src/injected/utilityScript.ts
+++ b/src/injected/utilityScript.ts
@@ -47,8 +47,16 @@ export default class UtilityScript {
       }
     };
 
-    if (value && typeof value === 'object' && typeof value.then === 'function')
-      return value.then(safeJson);
+    if (value && typeof value === 'object' && typeof value.then === 'function') {
+      return (async () => {
+        // By using async function we ensure that return value is a native Promise,
+        // and not some overriden Promise in the page.
+        // This makes Firefox and WebKit debugging protocols recognize it as a Promise,
+        // properly await and return the value.
+        const promiseValue = await value;
+        return safeJson(promiseValue);
+      })();
+    }
     return safeJson(value);
   }
 }

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -115,7 +115,7 @@ describe('Frame.evaluate', function() {
       iframe.contentDocument.close();
     });
     // Main world should work.
-    expect(await page.frames()[1].evaluate(() => window.top.location.href)).toBe('http://localhost:8907/empty.html');
+    expect(await page.frames()[1].evaluate(() => window.top.location.href)).toBe(server.EMPTY_PAGE);
     // Utility world should work.
     expect(await page.frames()[1].$('div')).toBeTruthy(null);
   });


### PR DESCRIPTION
Firefox and WebKit require native promises to provide awaitPromise functionality. When the Promise is overwritten, all evaluations in the main world produce wrong Promise, so we wrap with async function to get a native promise instead.

Fixes #2732.