### PR TITLE
chore: deprecate method `context.setHTTPCredentials()`

### DIFF
--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -18,7 +18,7 @@
 import { BrowserBase, BrowserOptions, BrowserContextOptions } from '../browser';
 import { assertBrowserContextIsNotOwned, BrowserContext, BrowserContextBase, validateBrowserContextOptions, verifyGeolocation } from '../browserContext';
 import { Events as CommonEvents } from '../events';
-import { assert } from '../helper';
+import { assert, deprecate } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding, Worker } from '../page';
 import { ConnectionTransport, SlowMoTransport } from '../transport';
@@ -397,6 +397,7 @@ export class CRBrowserContext extends BrowserContextBase {
   }
 
   async setHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void> {
+    deprecate(`context.setHTTPCredentials`, `warning: method |context.setHTTPCredentials()| is deprecated. Instead of changing credentials, create another browser context with new credentials.`);
     this._options.httpCredentials = httpCredentials || undefined;
     for (const page of this.pages())
       await (page._delegate as CRPage).updateHttpCredentials();

--- a/src/firefox/ffBrowser.ts
+++ b/src/firefox/ffBrowser.ts
@@ -18,7 +18,7 @@
 import { BrowserBase, BrowserOptions, BrowserContextOptions } from '../browser';
 import { assertBrowserContextIsNotOwned, BrowserContext, BrowserContextBase, validateBrowserContextOptions, verifyGeolocation } from '../browserContext';
 import { Events } from '../events';
-import { assert, helper, RegisteredListener } from '../helper';
+import { assert, deprecate, helper, RegisteredListener } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding } from '../page';
 import { ConnectionTransport, SlowMoTransport } from '../transport';
@@ -296,6 +296,7 @@ export class FFBrowserContext extends BrowserContextBase {
   }
 
   async setHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void> {
+    deprecate(`context.setHTTPCredentials`, `warning: method |context.setHTTPCredentials()| is deprecated. Instead of changing credentials, create another browser context with new credentials.`);
     this._options.httpCredentials = httpCredentials || undefined;
     await this._browser._connection.send('Browser.setHTTPCredentials', { browserContextId: this._browserContextId || undefined, credentials: httpCredentials });
   }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -36,7 +36,16 @@ export type Listener = (...args: any[]) => void;
 let isInDebugMode = !!getFromENV('PWDEBUG');
 let isInRecordMode = false;
 
+const deprecatedHits = new Set();
+export function deprecate(methodName: string, message: string) {
+  if (deprecatedHits.has(methodName))
+    return;
+  deprecatedHits.add(methodName);
+  console.warn(message);
+}
+
 class Helper {
+
   static evaluationString(fun: Function | string, ...args: any[]): string {
     if (Helper.isString(fun)) {
       assert(args.length === 0 || (args.length === 1 && args[0] === undefined), 'Cannot evaluate a string with arguments');

--- a/src/webkit/wkBrowser.ts
+++ b/src/webkit/wkBrowser.ts
@@ -18,7 +18,7 @@
 import { BrowserBase, BrowserOptions, BrowserContextOptions } from '../browser';
 import { assertBrowserContextIsNotOwned, BrowserContext, BrowserContextBase, validateBrowserContextOptions, verifyGeolocation } from '../browserContext';
 import { Events } from '../events';
-import { helper, RegisteredListener, assert } from '../helper';
+import { helper, deprecate, RegisteredListener, assert } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding } from '../page';
 import { ConnectionTransport, SlowMoTransport } from '../transport';
@@ -309,6 +309,7 @@ export class WKBrowserContext extends BrowserContextBase {
   }
 
   async setHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void> {
+    deprecate(`context.setHTTPCredentials`, `warning: method |context.setHTTPCredentials()| is deprecated. Instead of changing credentials, create another browser context with new credentials.`);
     this._options.httpCredentials = httpCredentials || undefined;
     for (const page of this.pages())
       await (page._delegate as WKPage).updateHttpCredentials();


### PR DESCRIPTION
This will start emitting deprecation warning once
`context.setHTTPCredentials` is called.

Fixes #2196