### PR TITLE
testrunner: make environment a simple class

### DIFF
--- a/test/environments.js
+++ b/test/environments.js
@@ -5,8 +5,6 @@ const rm = require('rimraf').sync;
 const {TestServer} = require('../utils/testserver/');
 
 class ServerEnvironment {
-  name() { return 'TestServer'; }
-
   async beforeAll(state) {
     const assetsPath = path.join(__dirname, 'assets');
     const cachedPath = path.join(__dirname, 'assets', 'cached');
@@ -69,8 +67,6 @@ class DefaultBrowserOptionsEnvironment {
 const hasBeenCleaned = new Set();
 
 class GoldenEnvironment {
-  name() { return 'Golden+CheckContexts'; }
-
   async beforeAll(state) {
     const { OUTPUT_DIR, GOLDEN_DIR } = utils.testOptions(state.browserType);
     if (!hasBeenCleaned.has(state.browserType)) {
@@ -104,8 +100,6 @@ class TraceTestEnvironment {
   constructor() {
     this._session = null;
   }
-
-  name() { return 'TraceTestEnvironment'; }
 
   async beforeEach() {
     const inspector = require('inspector');
@@ -151,8 +145,6 @@ class BrowserTypeEnvironment {
   constructor(browserType) {
     this._browserType = browserType;
   }
-
-  name() { return 'BrowserType'; }
 
   async beforeAll(state) {
     // Channel substitute
@@ -207,8 +199,6 @@ class BrowserEnvironment {
 }
 
 class PageEnvironment {
-  name() { return 'Page'; }
-
   async beforeEach(state) {
     state.context = await state.browser.newContext();
     state.page = await state.context.newPage();

--- a/test/environments.js
+++ b/test/environments.js
@@ -1,0 +1,233 @@
+const utils = require('./utils');
+const fs = require('fs');
+const path = require('path');
+const rm = require('rimraf').sync;
+const {TestServer} = require('../utils/testserver/');
+
+class ServerEnvironment {
+  name() { return 'TestServer'; }
+
+  async beforeAll(state) {
+    const assetsPath = path.join(__dirname, 'assets');
+    const cachedPath = path.join(__dirname, 'assets', 'cached');
+
+    const port = 8907 + state.parallelIndex * 2;
+    state.server = await TestServer.create(assetsPath, port);
+    state.server.enableHTTPCache(cachedPath);
+    state.server.PORT = port;
+    state.server.PREFIX = `http://localhost:${port}`;
+    state.server.CROSS_PROCESS_PREFIX = `http://127.0.0.1:${port}`;
+    state.server.EMPTY_PAGE = `http://localhost:${port}/empty.html`;
+
+    const httpsPort = port + 1;
+    state.httpsServer = await TestServer.createHTTPS(assetsPath, httpsPort);
+    state.httpsServer.enableHTTPCache(cachedPath);
+    state.httpsServer.PORT = httpsPort;
+    state.httpsServer.PREFIX = `https://localhost:${httpsPort}`;
+    state.httpsServer.CROSS_PROCESS_PREFIX = `https://127.0.0.1:${httpsPort}`;
+    state.httpsServer.EMPTY_PAGE = `https://localhost:${httpsPort}/empty.html`;
+  }
+
+  async afterAll({server, httpsServer}) {
+    await Promise.all([
+      server.stop(),
+      httpsServer.stop(),
+    ]);
+  }
+
+  async beforeEach(state) {
+    state.server.reset();
+    state.httpsServer.reset();
+  }
+}
+
+class DefaultBrowserOptionsEnvironment {
+  constructor(defaultBrowserOptions, logger, playwrightPath) {
+    this._defaultBrowserOptions = defaultBrowserOptions;
+    this._logger = logger;
+    this._playwrightPath = playwrightPath;
+  }
+
+  async beforeAll(state) {
+    state.defaultBrowserOptions = {
+      ...this._defaultBrowserOptions,
+      logger: this._logger,
+    };
+    state.playwrightPath = this._playwrightPath;
+  }
+
+  async beforeEach(state, testRun) {
+    this._logger.setTestRun(testRun);
+  }
+
+  async afterEach(state) {
+    this._logger.setTestRun(null);
+  }
+}
+
+// simulate globalSetup per browserType that happens only once regardless of TestWorker.
+const hasBeenCleaned = new Set();
+
+class GoldenEnvironment {
+  name() { return 'Golden+CheckContexts'; }
+
+  async beforeAll(state) {
+    const { OUTPUT_DIR, GOLDEN_DIR } = utils.testOptions(state.browserType);
+    if (!hasBeenCleaned.has(state.browserType)) {
+      hasBeenCleaned.add(state.browserType);
+      if (fs.existsSync(OUTPUT_DIR))
+        rm(OUTPUT_DIR);
+      fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+    }
+    state.golden = goldenName => ({ goldenPath: GOLDEN_DIR, outputPath: OUTPUT_DIR, goldenName });
+  }
+
+  async afterAll(state) {
+    delete state.golden;
+  }
+
+  async afterEach(state, testRun) {
+    if (state.browser && state.browser.contexts().length !== 0) {
+      if (testRun.ok())
+        console.warn(`\nWARNING: test "${testRun.test().fullName()}" (${testRun.test().location()}) did not close all created contexts!\n`);
+      await Promise.all(state.browser.contexts().map(context => context.close()));
+    }
+  }
+}
+
+class TraceTestEnvironment {
+  static enableForTest(test) {
+    test.setTimeout(100000000);
+    test.addEnvironment(new TraceTestEnvironment());
+  }
+
+  constructor() {
+    this._session = null;
+  }
+
+  name() { return 'TraceTestEnvironment'; }
+
+  async beforeEach() {
+    const inspector = require('inspector');
+    const fs = require('fs');
+    const util = require('util');
+    const url = require('url');
+    const readFileAsync = util.promisify(fs.readFile.bind(fs));
+    this._session = new inspector.Session();
+    this._session.connect();
+    const postAsync = util.promisify(this._session.post.bind(this._session));
+    await postAsync('Debugger.enable');
+    const setBreakpointCommands = [];
+    const N = t.body().toString().split('\n').length;
+    const location = t.location();
+    const lines = (await readFileAsync(location.filePath(), 'utf8')).split('\n');
+    for (let line = 0; line < N; ++line) {
+      const lineNumber = line + location.lineNumber();
+      setBreakpointCommands.push(postAsync('Debugger.setBreakpointByUrl', {
+        url: url.pathToFileURL(location.filePath()),
+        lineNumber,
+        condition: `console.log('${String(lineNumber + 1).padStart(6, ' ')} | ' + ${JSON.stringify(lines[lineNumber])})`,
+      }).catch(e => {}));
+    }
+    await Promise.all(setBreakpointCommands);
+  }
+
+  async afterEach() {
+    this._session.disconnect();
+  }
+}
+
+class PlaywrightEnvironment {
+  constructor(playwright) {
+    this._playwright = playwright;
+  }
+
+  name() { return 'Playwright'; };
+  beforeAll(state) { state.playwright = this._playwright; }
+  afterAll(state) { delete state.playwright; }
+}
+
+class BrowserTypeEnvironment {
+  constructor(browserType) {
+    this._browserType = browserType;
+  }
+
+  name() { return 'BrowserType'; }
+
+  async beforeAll(state) {
+    // Channel substitute
+    let overridenBrowserType = this._browserType;
+    if (process.env.PWCHANNEL) {
+      const dispatcherScope = new DispatcherScope();
+      const connection = new Connection();
+      dispatcherScope.onmessage = async message => {
+        setImmediate(() => connection.send(message));
+      };
+      connection.onmessage = async message => {
+        const result = await dispatcherScope.send(message);
+        await new Promise(f => setImmediate(f));
+        return result;
+      };
+      BrowserTypeDispatcher.from(dispatcherScope, this._browserType);
+      overridenBrowserType = await connection.waitForObjectWithKnownName(this._browserType.name());
+    }
+    state.browserType = overridenBrowserType;
+  }
+
+  async afterAll(state) {
+    delete state.browserType;
+  }
+}
+
+class BrowserEnvironment {
+  constructor(browserType, launchOptions, logger) {
+    this._browserType = browserType;
+    this._launchOptions = launchOptions;
+    this._logger = logger;
+  }
+
+  name() { return this._browserType.name(); }
+
+  async beforeAll(state) {
+    state.browser = await this._browserType.launch({...this._launchOptions, logger: this._logger});
+  }
+
+  async afterAll(state) {
+    await state.browser.close();
+    delete state.browser;
+  }
+
+  async beforeEach(state, testRun) {
+    this._logger.setTestRun(testRun);
+  }
+
+  async afterEach(state, testRun) {
+    this._logger.setTestRun(null);
+  }
+}
+
+class PageEnvironment {
+  name() { return 'Page'; }
+
+  async beforeEach(state) {
+    state.context = await state.browser.newContext();
+    state.page = await state.context.newPage();
+  }
+
+  async afterEach(state) {
+    await state.context.close();
+    state.context = null;
+    state.page = null;
+  }
+}
+
+module.exports = {
+  ServerEnvironment,
+  GoldenEnvironment,
+  TraceTestEnvironment,
+  DefaultBrowserOptionsEnvironment,
+  PlaywrightEnvironment,
+  BrowserTypeEnvironment,
+  BrowserEnvironment,
+  PageEnvironment,
+};

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -15,98 +15,20 @@
  * limitations under the License.
  */
 
-const fs = require('fs');
 const path = require('path');
-const rm = require('rimraf').sync;
 const utils = require('./utils');
-const {TestServer} = require('../utils/testserver/');
-const {Environment} = require('../utils/testrunner/Test');
+const {DefaultBrowserOptionsEnvironment, ServerEnvironment, GoldenEnvironment, TraceTestEnvironment} = require('./environments.js');
 
 const playwrightPath = path.join(__dirname, '..');
 
-class ServerEnvironment {
-  name() { return 'TestServer'; }
-
-  async beforeAll(state) {
-    const assetsPath = path.join(__dirname, 'assets');
-    const cachedPath = path.join(__dirname, 'assets', 'cached');
-
-    const port = 8907 + state.parallelIndex * 2;
-    state.server = await TestServer.create(assetsPath, port);
-    state.server.enableHTTPCache(cachedPath);
-    state.server.PORT = port;
-    state.server.PREFIX = `http://localhost:${port}`;
-    state.server.CROSS_PROCESS_PREFIX = `http://127.0.0.1:${port}`;
-    state.server.EMPTY_PAGE = `http://localhost:${port}/empty.html`;
-
-    const httpsPort = port + 1;
-    state.httpsServer = await TestServer.createHTTPS(assetsPath, httpsPort);
-    state.httpsServer.enableHTTPCache(cachedPath);
-    state.httpsServer.PORT = httpsPort;
-    state.httpsServer.PREFIX = `https://localhost:${httpsPort}`;
-    state.httpsServer.CROSS_PROCESS_PREFIX = `https://127.0.0.1:${httpsPort}`;
-    state.httpsServer.EMPTY_PAGE = `https://localhost:${httpsPort}/empty.html`;
-
-    state._extraLogger = utils.createTestLogger(valueFromEnv('DEBUGP', false), null, 'extra');
-    state.defaultBrowserOptions = {
-      handleSIGINT: false,
-      slowMo: valueFromEnv('SLOW_MO', 0),
-      headless: !!valueFromEnv('HEADLESS', true),
-      logger: state._extraLogger,
-    };
-    state.playwrightPath = playwrightPath;
-  }
-
-  async afterAll({server, httpsServer}) {
-    await Promise.all([
-      server.stop(),
-      httpsServer.stop(),
-    ]);
-  }
-
-  async beforeEach(state, testRun) {
-    state.server.reset();
-    state.httpsServer.reset();
-    state._extraLogger.setTestRun(testRun);
-  }
-
-  async afterEach(state) {
-    state._extraLogger.setTestRun(null);
-  }
-}
+const extraLogger = utils.createTestLogger(valueFromEnv('DEBUGP', false), null, 'extra');
+const defaultBrowserOptionsEnvironment = new DefaultBrowserOptionsEnvironment({
+  handleSIGINT: false,
+  slowMo: valueFromEnv('SLOW_MO', 0),
+  headless: !!valueFromEnv('HEADLESS', true),
+}, extraLogger, playwrightPath);
 
 const serverEnvironment = new ServerEnvironment();
-
-// simulate globalSetup per browserType that happens only once regardless of TestWorker.
-const hasBeenCleaned = new Set();
-
-class GoldenEnvironment {
-  name() { return 'Golden+CheckContexts'; }
-
-  async beforeAll(state) {
-    const { OUTPUT_DIR, GOLDEN_DIR } = require('./utils').testOptions(state.browserType);
-    if (!hasBeenCleaned.has(state.browserType)) {
-      hasBeenCleaned.add(state.browserType);
-      if (fs.existsSync(OUTPUT_DIR))
-        rm(OUTPUT_DIR);
-      fs.mkdirSync(OUTPUT_DIR, { recursive: true });
-    }
-    state.golden = goldenName => ({ goldenPath: GOLDEN_DIR, outputPath: OUTPUT_DIR, goldenName });
-  }
-
-  async afterAll(state) {
-    delete state.golden;
-  }
-
-  async afterEach(state, testRun) {
-    if (state.browser && state.browser.contexts().length !== 0) {
-      if (testRun.ok())
-        console.warn(`\nWARNING: test "${testRun.test().fullName()}" (${testRun.test().location()}) did not close all created contexts!\n`);
-      await Promise.all(state.browser.contexts().map(context => context.close()));
-    }
-  }
-}
-
 const customEnvironment = new GoldenEnvironment();
 
 function valueFromEnv(name, defaultValue) {
@@ -122,47 +44,7 @@ function setupTestRunner(testRunner) {
   collector.addTestModifier('fail', (t, condition) => condition && t.setExpectation(t.Expectations.Fail));
   collector.addSuiteModifier('fail', (s, condition) => condition && s.setExpectation(s.Expectations.Fail));
   collector.addTestModifier('slow', t => t.setTimeout(t.timeout() * 3));
-  collector.addTestAttribute('debug', t => {
-    class DebugEnvironment {
-      constructor() {
-        this._session = null;
-      }
-
-      name() { return 'DebugEnvironment'; }
-
-      async beforeEach() {
-        const inspector = require('inspector');
-        const fs = require('fs');
-        const util = require('util');
-        const url = require('url');
-        const readFileAsync = util.promisify(fs.readFile.bind(fs));
-        this._session = new inspector.Session();
-        this._session.connect();
-        const postAsync = util.promisify(this._session.post.bind(this._session));
-        await postAsync('Debugger.enable');
-        const setBreakpointCommands = [];
-        const N = t.body().toString().split('\n').length;
-        const location = t.location();
-        const lines = (await readFileAsync(location.filePath(), 'utf8')).split('\n');
-        for (let line = 0; line < N; ++line) {
-          const lineNumber = line + location.lineNumber();
-          setBreakpointCommands.push(postAsync('Debugger.setBreakpointByUrl', {
-            url: url.pathToFileURL(location.filePath()),
-            lineNumber,
-            condition: `console.log('${String(lineNumber + 1).padStart(6, ' ')} | ' + ${JSON.stringify(lines[lineNumber])})`,
-          }).catch(e => {}));
-        }
-        await Promise.all(setBreakpointCommands);
-      }
-
-      async afterEach() {
-        this._session.disconnect();
-      }
-    }
-
-    t.setTimeout(100000000);
-    t.addEnvironment(new DebugEnvironment());
-  });
+  collector.addTestAttribute('debug', t => TraceTestEnvironment.enableForTest(t));
   testRunner.api().fdescribe = testRunner.api().describe.only;
   testRunner.api().xdescribe = testRunner.api().describe.skip(true);
   testRunner.api().fit = testRunner.api().it.only;
@@ -183,7 +65,7 @@ module.exports = {
     headless: !!valueFromEnv('HEADLESS', true),
   },
 
-  globalEnvironments: [serverEnvironment],
+  globalEnvironments: [defaultBrowserOptionsEnvironment, serverEnvironment],
   setupTestRunner,
 
   specs: [

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -21,12 +21,12 @@ const {DefaultBrowserOptionsEnvironment, ServerEnvironment, GoldenEnvironment, T
 
 const playwrightPath = path.join(__dirname, '..');
 
-const extraLogger = utils.createTestLogger(valueFromEnv('DEBUGP', false), null, 'extra');
+const dumpLogOnFailure = valueFromEnv('DEBUGP', false);
 const defaultBrowserOptionsEnvironment = new DefaultBrowserOptionsEnvironment({
   handleSIGINT: false,
   slowMo: valueFromEnv('SLOW_MO', 0),
   headless: !!valueFromEnv('HEADLESS', true),
-}, extraLogger, playwrightPath);
+}, dumpLogOnFailure, playwrightPath);
 
 const serverEnvironment = new ServerEnvironment();
 const customEnvironment = new GoldenEnvironment();

--- a/test/test.js
+++ b/test/test.js
@@ -81,13 +81,11 @@ function collect(browserNames) {
   const { setUnderTest } = require(require('path').join(playwrightPath, 'lib/helper.js'));
   setUnderTest();
 
-  const playwrightEnvironment = new Environment('Playwright');
-  playwrightEnvironment.beforeAll(async state => {
-    state.playwright = playwright;
-  });
-  playwrightEnvironment.afterAll(async state => {
-    delete state.playwright;
-  });
+  const playwrightEnvironment = {
+    name() { return 'Playwright'; },
+    beforeAll(state) { state.playwright = playwright; },
+    afterAll(state) { delete state.playwright; },
+  };
 
   testRunner.collector().useEnvironment(playwrightEnvironment);
   for (const e of config.globalEnvironments || [])
@@ -98,29 +96,33 @@ function collect(browserNames) {
   for (const browserName of browserNames) {
     const browserType = playwright[browserName];
 
-    const browserTypeEnvironment = new Environment('BrowserType');
-    browserTypeEnvironment.beforeAll(async state => {
-      // Channel substitute
-      let overridenBrowserType = browserType;
-      if (process.env.PWCHANNEL) {
-        const dispatcherScope = new DispatcherScope();
-        const connection = new Connection();
-        dispatcherScope.onmessage = async message => {
-          setImmediate(() => connection.send(message));
-        };
-        connection.onmessage = async message => {
-          const result = await dispatcherScope.send(message);
-          await new Promise(f => setImmediate(f));
-          return result;
-        };
-        BrowserTypeDispatcher.from(dispatcherScope, browserType);
-        overridenBrowserType = await connection.waitForObjectWithKnownName(browserType.name());
-      }
-      state.browserType = overridenBrowserType;
-    });
-    browserTypeEnvironment.afterAll(async state => {
-      delete state.browserType;
-    });
+    const browserTypeEnvironment = {
+      name() { return 'BrowserType'; },
+
+      async beforeAll(state) {
+        // Channel substitute
+        let overridenBrowserType = browserType;
+        if (process.env.PWCHANNEL) {
+          const dispatcherScope = new DispatcherScope();
+          const connection = new Connection();
+          dispatcherScope.onmessage = async message => {
+            setImmediate(() => connection.send(message));
+          };
+          connection.onmessage = async message => {
+            const result = await dispatcherScope.send(message);
+            await new Promise(f => setImmediate(f));
+            return result;
+          };
+          BrowserTypeDispatcher.from(dispatcherScope, browserType);
+          overridenBrowserType = await connection.waitForObjectWithKnownName(browserType.name());
+        }
+        state.browserType = overridenBrowserType;
+      },
+
+      async afterAll(state) {
+        delete state.browserType;
+      },
+    };
 
     // TODO: maybe launch options per browser?
     const launchOptions = {
@@ -140,33 +142,42 @@ function collect(browserNames) {
         throw new Error(`Browser is not downloaded. Run 'npm install' and try to re-run tests`);
     }
 
-    const browserEnvironment = new Environment(browserName);
-    browserEnvironment.beforeAll(async state => {
-      state._logger = utils.createTestLogger(config.dumpLogOnFailure);
-      state.browser = await state.browserType.launch({...launchOptions, logger: state._logger});
-    });
-    browserEnvironment.afterAll(async state => {
-      await state.browser.close();
-      delete state.browser;
-      delete state._logger;
-    });
-    browserEnvironment.beforeEach(async(state, testRun) => {
-      state._logger.setTestRun(testRun);
-    });
-    browserEnvironment.afterEach(async (state, testRun) => {
-      state._logger.setTestRun(null);
-    });
+    const browserEnvironment = {
+      name() { return browserName; },
 
-    const pageEnvironment = new Environment('Page');
-    pageEnvironment.beforeEach(async state => {
-      state.context = await state.browser.newContext();
-      state.page = await state.context.newPage();
-    });
-    pageEnvironment.afterEach(async state => {
-      await state.context.close();
-      state.context = null;
-      state.page = null;
-    });
+      async beforeAll(state) {
+        state._logger = utils.createTestLogger(config.dumpLogOnFailure);
+        state.browser = await state.browserType.launch({...launchOptions, logger: state._logger});
+      },
+
+      async afterAll(state) {
+        await state.browser.close();
+        delete state.browser;
+        delete state._logger;
+      },
+
+      async beforeEach(state, testRun) {
+        state._logger.setTestRun(testRun);
+      },
+
+      async afterEach(state, testRun) {
+        state._logger.setTestRun(null);
+      },
+    };
+
+    const pageEnvironment = {
+      name() { return 'Page'; },
+      async beforeEach(state) {
+        state.context = await state.browser.newContext();
+        state.page = await state.context.newPage();
+      },
+
+      async afterEach(state) {
+        await state.context.close();
+        state.context = null;
+        state.page = null;
+      },
+    };
 
     const suiteName = { 'chromium': 'Chromium', 'firefox': 'Firefox', 'webkit': 'WebKit' }[browserName];
     describe(suiteName, () => {

--- a/test/test.js
+++ b/test/test.js
@@ -109,8 +109,7 @@ function collect(browserNames) {
         throw new Error(`Browser is not downloaded. Run 'npm install' and try to re-run tests`);
     }
 
-    const logger = utils.createTestLogger(config.dumpLogOnFailure);
-    const browserEnvironment = new BrowserEnvironment(browserType, launchOptions, logger);
+    const browserEnvironment = new BrowserEnvironment(browserType, launchOptions, config.dumpLogOnFailure);
     const pageEnvironment = new PageEnvironment();
 
     const suiteName = { 'chromium': 'Chromium', 'firefox': 'Firefox', 'webkit': 'WebKit' }[browserName];

--- a/utils/testrunner/Test.js
+++ b/utils/testrunner/Test.js
@@ -30,7 +30,7 @@ function createHook(callback, name) {
 class Environment {
   constructor(name) {
     this._name = name;
-    this._hooks = [];
+    this._hooks = new Map();
   }
 
   name() {
@@ -38,41 +38,41 @@ class Environment {
   }
 
   beforeEach(callback) {
-    this._hooks.push(createHook(callback, 'beforeEach'));
+    this._hooks.set('beforeEach', createHook(callback, 'beforeEach'));
     return this;
   }
 
   afterEach(callback) {
-    this._hooks.push(createHook(callback, 'afterEach'));
+    this._hooks.set('afterEach', createHook(callback, 'afterEach'));
     return this;
   }
 
   beforeAll(callback) {
-    this._hooks.push(createHook(callback, 'beforeAll'));
+    this._hooks.set('beforeAll', createHook(callback, 'beforeAll'));
     return this;
   }
 
   afterAll(callback) {
-    this._hooks.push(createHook(callback, 'afterAll'));
+    this._hooks.set('afterAll', createHook(callback, 'afterAll'));
     return this;
   }
 
   globalSetup(callback) {
-    this._hooks.push(createHook(callback, 'globalSetup'));
+    this._hooks.set('globalSetup', createHook(callback, 'globalSetup'));
     return this;
   }
 
   globalTeardown(callback) {
-    this._hooks.push(createHook(callback, 'globalTeardown'));
+    this._hooks.set('globalTeardown', createHook(callback, 'globalTeardown'));
     return this;
   }
 
-  hooks(name) {
-    return this._hooks.filter(hook => !name || hook.name === name);
+  hook(name) {
+    return this._hooks.get(name) || null;
   }
 
   isEmpty() {
-    return !this._hooks.length;
+    return !this._hooks.size;
   }
 }
 

--- a/utils/testrunner/Test.js
+++ b/utils/testrunner/Test.js
@@ -22,11 +22,6 @@ const TestExpectation = {
   Fail: 'fail',
 };
 
-function createHook(callback, name) {
-  const location = Location.getCallerLocation();
-  return { name, body: callback, location };
-}
-
 class Test {
   constructor(suite, name, callback, location) {
     this._suite = suite;
@@ -102,8 +97,6 @@ class Test {
   }
 }
 
-const hookLocationSymbol = Symbol('hookLocationSymbol');
-
 class Suite {
   constructor(parentSuite, name, location) {
     this._parentSuite = parentSuite;
@@ -125,7 +118,6 @@ class Suite {
     if (this._defaultEnvironment[name])
       throw new Error(`ERROR: cannot re-assign hook "${name}" for suite "${this._fullName}"`);
     this._defaultEnvironment[name] = callback;
-    callback[hookLocationSymbol] = Location.getCallerLocation();
   }
 
   beforeEach(callback) { this._addHook('beforeEach', callback); }

--- a/utils/testrunner/TestCollector.js
+++ b/utils/testrunner/TestCollector.js
@@ -195,12 +195,12 @@ class TestCollector {
         callback(test, ...args);
       this._tests.push(test);
     });
-    this._api.beforeAll = callback => this._currentSuite.environment().beforeAll(callback);
-    this._api.beforeEach = callback => this._currentSuite.environment().beforeEach(callback);
-    this._api.afterAll = callback => this._currentSuite.environment().afterAll(callback);
-    this._api.afterEach = callback => this._currentSuite.environment().afterEach(callback);
-    this._api.globalSetup = callback => this._currentSuite.environment().globalSetup(callback);
-    this._api.globalTeardown = callback => this._currentSuite.environment().globalTeardown(callback);
+    this._api.beforeAll = callback => this._currentSuite.beforeAll(callback);
+    this._api.beforeEach = callback => this._currentSuite.beforeEach(callback);
+    this._api.afterAll = callback => this._currentSuite.afterAll(callback);
+    this._api.afterEach = callback => this._currentSuite.afterEach(callback);
+    this._api.globalSetup = callback => this._currentSuite.globalSetup(callback);
+    this._api.globalTeardown = callback => this._currentSuite.globalTeardown(callback);
   }
 
   useEnvironment(environment) {

--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -367,7 +367,8 @@ class HookRunner {
     const hookBody = environment[hookName];
     if (!hookBody)
       return true;
-    return await this._runHookInternal(worker, testRun, {name: hookName, body: hookBody.bind(environment)}, environment.name(), hookArgs);
+    const envName = environment.name ? environment.name() : environment.constructor.name;
+    return await this._runHookInternal(worker, testRun, {name: hookName, body: hookBody.bind(environment)}, envName, hookArgs);
   }
 
   async maybeRunGlobalSetup(environment) {

--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -367,7 +367,7 @@ class HookRunner {
     const hookBody = environment[hookName];
     if (!hookBody)
       return true;
-    return await this._runHookInternal(worker, testRun, {name: hookName, body: hookBody}, environment.name(), hookArgs);
+    return await this._runHookInternal(worker, testRun, {name: hookName, body: hookBody.bind(environment)}, environment.name(), hookArgs);
   }
 
   async maybeRunGlobalSetup(environment) {

--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -359,34 +359,38 @@ class HookRunner {
   }
 
   async runAfterAll(environment, worker, testRun, hookArgs) {
-    for (const hook of environment.hooks('afterAll')) {
-      if (!await this._runHook(worker, testRun, hook, environment.name(), hookArgs))
-        return false;
-    }
+    const hook = environment.hook('afterAll');
+    if (!hook)
+      return true;
+    if (!await this._runHook(worker, testRun, hook, environment.name(), hookArgs))
+      return false;
     return true;
   }
 
   async runBeforeAll(environment, worker, testRun, hookArgs) {
-    for (const hook of environment.hooks('beforeAll')) {
-      if (!await this._runHook(worker, testRun, hook, environment.name(), hookArgs))
-        return false;
-    }
+    const hook = environment.hook('beforeAll');
+    if (!hook)
+      return true;
+    if (!await this._runHook(worker, testRun, hook, environment.name(), hookArgs))
+      return false;
     return true;
   }
 
   async runAfterEach(environment, worker, testRun, hookArgs) {
-    for (const hook of environment.hooks('afterEach')) {
-      if (!await this._runHook(worker, testRun, hook, environment.name(), hookArgs))
-        return false;
-    }
+    const hook = environment.hook('afterEach');
+    if (!hook)
+      return true;
+    if (!await this._runHook(worker, testRun, hook, environment.name(), hookArgs))
+      return false;
     return true;
   }
 
   async runBeforeEach(environment, worker, testRun, hookArgs) {
-    for (const hook of environment.hooks('beforeEach')) {
-      if (!await this._runHook(worker, testRun, hook, environment.name(), hookArgs))
-        return false;
-    }
+    const hook = environment.hook('beforeEach');
+    if (!hook)
+      return true;
+    if (!await this._runHook(worker, testRun, hook, environment.name(), hookArgs))
+      return false;
     return true;
   }
 
@@ -394,12 +398,12 @@ class HookRunner {
     const globalState = this._environmentToGlobalState.get(environment);
     if (!globalState.globalSetupPromise) {
       globalState.globalSetupPromise = (async () => {
-        let result = true;
-        for (const hook of environment.hooks('globalSetup')) {
-          if (!await this._runHook(null /* worker */, null /* testRun */, hook, environment.name(), []))
-            result = false;
-        }
-        return result;
+        const hook = environment.hook('globalSetup');
+        if (!hook)
+          return true;
+        if (!await this._runHook(null /* worker */, null /* testRun */, hook, environment.name(), []))
+          return false;
+        return true;
       })();
     }
     if (!await globalState.globalSetupPromise) {
@@ -414,12 +418,12 @@ class HookRunner {
     if (!globalState.globalTeardownPromise) {
       if (!globalState.pendingTestRuns.size || (this._testRunner._terminating && globalState.globalSetupPromise)) {
         globalState.globalTeardownPromise = (async () => {
-          let result = true;
-          for (const hook of environment.hooks('globalTeardown')) {
-            if (!await this._runHook(null /* worker */, null /* testRun */, hook, environment.name(), []))
-              result = false;
-          }
-          return result;
+          const hook = environment.hook('globalTeardown');
+          if (!hook)
+            return true;
+          if (!await this._runHook(null /* worker */, null /* testRun */, hook, environment.name(), []))
+            return false;
+          return true;
         })();
       }
     }

--- a/utils/testrunner/test/testrunner.spec.js
+++ b/utils/testrunner/test/testrunner.spec.js
@@ -290,25 +290,18 @@ module.exports.addTests = function({describe, fdescribe, xdescribe, it, xit, fit
       e2.beforeAll(() => log.push('env2:beforeAll'));
       e2.afterAll(() => log.push('env2:afterAll'));
       t.beforeAll(() => log.push('root:beforeAll'));
-      t.beforeEach(() => log.push('root:beforeEach1'));
-      t.beforeEach(() => log.push('root:beforeEach2'));
+      t.beforeEach(() => log.push('root:beforeEach'));
       t.it('uno', () => log.push('test #1'));
       t.describe('suite1', () => {
-        t.beforeAll(() => log.push('suite:beforeAll1'));
-        t.beforeAll(() => log.push('suite:beforeAll2'));
+        t.beforeAll(() => log.push('suite:beforeAll'));
         t.beforeEach(() => log.push('suite:beforeEach'));
         t.it('dos', () => log.push('test #2'));
-        t.tests()[t.tests().length - 1].environment().beforeEach(() => log.push('test:before1'));
-        t.tests()[t.tests().length - 1].environment().beforeEach(() => log.push('test:before2'));
-        t.tests()[t.tests().length - 1].environment().afterEach(() => log.push('test:after1'));
-        t.tests()[t.tests().length - 1].environment().afterEach(() => log.push('test:after2'));
+        t.tests()[t.tests().length - 1].environment().beforeEach(() => log.push('test:before'));
+        t.tests()[t.tests().length - 1].environment().afterEach(() => log.push('test:after'));
         t.it('tres', () => log.push('test #3'));
-        t.tests()[t.tests().length - 1].environment().beforeEach(() => log.push('test:before1'));
-        t.tests()[t.tests().length - 1].environment().beforeEach(() => log.push('test:before2'));
-        t.tests()[t.tests().length - 1].environment().afterEach(() => log.push('test:after1'));
-        t.tests()[t.tests().length - 1].environment().afterEach(() => log.push('test:after2'));
-        t.afterEach(() => log.push('suite:afterEach1'));
-        t.afterEach(() => log.push('suite:afterEach2'));
+        t.tests()[t.tests().length - 1].environment().beforeEach(() => log.push('test:before'));
+        t.tests()[t.tests().length - 1].environment().afterEach(() => log.push('test:after'));
+        t.afterEach(() => log.push('suite:afterEach'));
         t.afterAll(() => log.push('suite:afterAll'));
       });
       t.it('cuatro', () => log.push('test #4'));
@@ -326,41 +319,30 @@ module.exports.addTests = function({describe, fdescribe, xdescribe, it, xit, fit
       t.suites()[t.suites().length - 1].addEnvironment(e);
       t.suites()[t.suites().length - 1].addEnvironment(e2);
       t.afterEach(() => log.push('root:afterEach'));
-      t.afterAll(() => log.push('root:afterAll1'));
-      t.afterAll(() => log.push('root:afterAll2'));
+      t.afterAll(() => log.push('root:afterAll'));
       await t.run();
       expect(log).toEqual([
         'root:beforeAll',
-        'root:beforeEach1',
-        'root:beforeEach2',
+        'root:beforeEach',
         'test #1',
         'root:afterEach',
 
-        'suite:beforeAll1',
-        'suite:beforeAll2',
+        'suite:beforeAll',
 
-        'root:beforeEach1',
-        'root:beforeEach2',
+        'root:beforeEach',
         'suite:beforeEach',
-        'test:before1',
-        'test:before2',
+        'test:before',
         'test #2',
-        'test:after1',
-        'test:after2',
-        'suite:afterEach1',
-        'suite:afterEach2',
+        'test:after',
+        'suite:afterEach',
         'root:afterEach',
 
-        'root:beforeEach1',
-        'root:beforeEach2',
+        'root:beforeEach',
         'suite:beforeEach',
-        'test:before1',
-        'test:before2',
+        'test:before',
         'test #3',
-        'test:after1',
-        'test:after2',
-        'suite:afterEach1',
-        'suite:afterEach2',
+        'test:after',
+        'suite:afterEach',
         'root:afterEach',
 
         'suite:afterAll',
@@ -368,16 +350,14 @@ module.exports.addTests = function({describe, fdescribe, xdescribe, it, xit, fit
         'env:beforeAll',
         'env2:beforeAll',
 
-        'root:beforeEach1',
-        'root:beforeEach2',
+        'root:beforeEach',
         'env:beforeEach',
         'test #4',
         'env:afterEach',
         'root:afterEach',
 
         'suite2:beforeAll',
-        'root:beforeEach1',
-        'root:beforeEach2',
+        'root:beforeEach',
         'env:beforeEach',
         'test #5',
         'env:afterEach',
@@ -387,8 +367,7 @@ module.exports.addTests = function({describe, fdescribe, xdescribe, it, xit, fit
         'env2:afterAll',
         'env:afterAll',
 
-        'root:afterAll1',
-        'root:afterAll2',
+        'root:afterAll',
       ]);
     });
     it('should remove environment', async() => {

--- a/utils/testrunner/test/testrunner.spec.js
+++ b/utils/testrunner/test/testrunner.spec.js
@@ -281,14 +281,18 @@ module.exports.addTests = function({describe, fdescribe, xdescribe, it, xit, fit
     it('should run all hooks in proper order', async() => {
       const log = [];
       const t = new Runner();
-      const e = new Environment('env');
-      e.beforeAll(() => log.push('env:beforeAll'));
-      e.afterAll(() => log.push('env:afterAll'));
-      e.beforeEach(() => log.push('env:beforeEach'));
-      e.afterEach(() => log.push('env:afterEach'));
-      const e2 = new Environment('env2');
-      e2.beforeAll(() => log.push('env2:beforeAll'));
-      e2.afterAll(() => log.push('env2:afterAll'));
+      const e = {
+        name() { return 'env'; },
+        beforeAll() { log.push('env:beforeAll'); },
+        afterAll() { log.push('env:afterAll'); },
+        beforeEach() { log.push('env:beforeEach'); },
+        afterEach() { log.push('env:afterEach'); },
+      };
+      const e2 = {
+        name() { return 'env2'; },
+        beforeAll() { log.push('env2:beforeAll'); },
+        afterAll() { log.push('env2:afterAll'); },
+      };
       t.beforeAll(() => log.push('root:beforeAll'));
       t.beforeEach(() => log.push('root:beforeEach'));
       t.it('uno', () => log.push('test #1'));
@@ -296,11 +300,7 @@ module.exports.addTests = function({describe, fdescribe, xdescribe, it, xit, fit
         t.beforeAll(() => log.push('suite:beforeAll'));
         t.beforeEach(() => log.push('suite:beforeEach'));
         t.it('dos', () => log.push('test #2'));
-        t.tests()[t.tests().length - 1].environment().beforeEach(() => log.push('test:before'));
-        t.tests()[t.tests().length - 1].environment().afterEach(() => log.push('test:after'));
         t.it('tres', () => log.push('test #3'));
-        t.tests()[t.tests().length - 1].environment().beforeEach(() => log.push('test:before'));
-        t.tests()[t.tests().length - 1].environment().afterEach(() => log.push('test:after'));
         t.afterEach(() => log.push('suite:afterEach'));
         t.afterAll(() => log.push('suite:afterAll'));
       });
@@ -331,17 +331,13 @@ module.exports.addTests = function({describe, fdescribe, xdescribe, it, xit, fit
 
         'root:beforeEach',
         'suite:beforeEach',
-        'test:before',
         'test #2',
-        'test:after',
         'suite:afterEach',
         'root:afterEach',
 
         'root:beforeEach',
         'suite:beforeEach',
-        'test:before',
         'test #3',
-        'test:after',
         'suite:afterEach',
         'root:afterEach',
 
@@ -373,16 +369,20 @@ module.exports.addTests = function({describe, fdescribe, xdescribe, it, xit, fit
     it('should remove environment', async() => {
       const log = [];
       const t = new Runner();
-      const e = new Environment('env');
-      e.beforeAll(() => log.push('env:beforeAll'));
-      e.afterAll(() => log.push('env:afterAll'));
-      e.beforeEach(() => log.push('env:beforeEach'));
-      e.afterEach(() => log.push('env:afterEach'));
-      const e2 = new Environment('env2');
-      e2.beforeAll(() => log.push('env2:beforeAll'));
-      e2.afterAll(() => log.push('env2:afterAll'));
-      e2.beforeEach(() => log.push('env2:beforeEach'));
-      e2.afterEach(() => log.push('env2:afterEach'));
+      const e = {
+        name() { return 'env'; },
+        beforeAll() { log.push('env:beforeAll'); },
+        afterAll() { log.push('env:afterAll'); },
+        beforeEach() { log.push('env:beforeEach'); },
+        afterEach() { log.push('env:afterEach'); },
+      };
+      const e2 = {
+        name() { return 'env2'; },
+        beforeAll() { log.push('env2:beforeAll'); },
+        afterAll() { log.push('env2:afterAll'); },
+        beforeEach() { log.push('env2:beforeEach'); },
+        afterEach() { log.push('env2:afterEach'); },
+      };
       t.it('uno', () => log.push('test #1'));
       t.tests()[0].addEnvironment(e).addEnvironment(e2).removeEnvironment(e);
       await t.run();


### PR DESCRIPTION
This patch:
- makes environment a simple class with optional methods `beforeEach`, `afterEach`, `beforeAll`, `afterAll`, `globalSetup` and `globalTeardown`
- removes capability to have multiple hooks of the same name inside suite
- removes default environment for test. (`dit` now adds a `TraceTestEnvironment` to the test)
- extracts all environments that we use in our tests in `//test/environments.js`

Downsides:
- we no longer know hook locations for the environments. This, however, should not be a big deal since stack traces (if any) will still point into it.
- this also regresses hook locations for suites for simplicity. We can get them back, but it shouldn't be pressing since we now have only one hook of each kind in every suite.