### PR TITLE
fix: follow-up with offline comments on implementation of deprecation

### DIFF
--- a/src/browserContext.ts
+++ b/src/browserContext.ts
@@ -16,7 +16,7 @@
  */
 
 import { Writable } from 'stream';
-import { helper } from './helper';
+import { isUnderTest, helper, deprecate} from './helper';
 import * as network from './network';
 import { Page, PageBinding } from './page';
 import { TimeoutSettings } from './timeoutSettings';
@@ -123,7 +123,7 @@ export abstract class BrowserContextBase extends EventEmitter implements Browser
   abstract _doGrantPermissions(origin: string, permissions: string[]): Promise<void>;
   abstract _doClearPermissions(): Promise<void>;
   abstract setGeolocation(geolocation: types.Geolocation | null): Promise<void>;
-  abstract setHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void>;
+  abstract _doSetHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void>;
   abstract setExtraHTTPHeaders(headers: types.Headers): Promise<void>;
   abstract setOffline(offline: boolean): Promise<void>;
   abstract _doAddInitScript(expression: string): Promise<void>;
@@ -140,6 +140,12 @@ export abstract class BrowserContextBase extends EventEmitter implements Browser
 
   async exposeFunction(name: string, playwrightFunction: Function): Promise<void> {
     await this.exposeBinding(name, (options, ...args: any) => playwrightFunction(...args));
+  }
+
+  setHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void> {
+    if (!isUnderTest())
+      deprecate(`context.setHTTPCredentials`, `warning: method |context.setHTTPCredentials()| is deprecated. Instead of changing credentials, create another browser context with new credentials.`);
+    return this._doSetHTTPCredentials(httpCredentials);
   }
 
   async exposeBinding(name: string, playwrightBinding: frames.FunctionWithSource): Promise<void> {

--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -18,7 +18,7 @@
 import { BrowserBase, BrowserOptions, BrowserContextOptions } from '../browser';
 import { assertBrowserContextIsNotOwned, BrowserContext, BrowserContextBase, validateBrowserContextOptions, verifyGeolocation } from '../browserContext';
 import { Events as CommonEvents } from '../events';
-import { assert, deprecate } from '../helper';
+import { assert } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding, Worker } from '../page';
 import { ConnectionTransport, SlowMoTransport } from '../transport';
@@ -392,8 +392,7 @@ export class CRBrowserContext extends BrowserContextBase {
       await (page._delegate as CRPage).updateOffline();
   }
 
-  async setHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void> {
-    deprecate(`context.setHTTPCredentials`, `warning: method |context.setHTTPCredentials()| is deprecated. Instead of changing credentials, create another browser context with new credentials.`);
+  async _doSetHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void> {
     this._options.httpCredentials = httpCredentials || undefined;
     for (const page of this.pages())
       await (page._delegate as CRPage).updateHttpCredentials();

--- a/src/firefox/ffBrowser.ts
+++ b/src/firefox/ffBrowser.ts
@@ -18,7 +18,7 @@
 import { BrowserBase, BrowserOptions, BrowserContextOptions } from '../browser';
 import { assertBrowserContextIsNotOwned, BrowserContext, BrowserContextBase, validateBrowserContextOptions, verifyGeolocation } from '../browserContext';
 import { Events } from '../events';
-import { assert, deprecate, helper, RegisteredListener } from '../helper';
+import { assert, helper, RegisteredListener } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding } from '../page';
 import { ConnectionTransport, SlowMoTransport } from '../transport';
@@ -291,8 +291,7 @@ export class FFBrowserContext extends BrowserContextBase {
     await this._browser._connection.send('Browser.setOnlineOverride', { browserContextId: this._browserContextId || undefined, override: offline ? 'offline' : 'online' });
   }
 
-  async setHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void> {
-    deprecate(`context.setHTTPCredentials`, `warning: method |context.setHTTPCredentials()| is deprecated. Instead of changing credentials, create another browser context with new credentials.`);
+  async _doSetHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void> {
     this._options.httpCredentials = httpCredentials || undefined;
     await this._browser._connection.send('Browser.setHTTPCredentials', { browserContextId: this._browserContextId || undefined, credentials: httpCredentials });
   }

--- a/src/webkit/wkBrowser.ts
+++ b/src/webkit/wkBrowser.ts
@@ -18,7 +18,7 @@
 import { BrowserBase, BrowserOptions, BrowserContextOptions } from '../browser';
 import { assertBrowserContextIsNotOwned, BrowserContext, BrowserContextBase, validateBrowserContextOptions, verifyGeolocation } from '../browserContext';
 import { Events } from '../events';
-import { helper, deprecate, RegisteredListener, assert } from '../helper';
+import { helper, RegisteredListener, assert } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding } from '../page';
 import { ConnectionTransport, SlowMoTransport } from '../transport';
@@ -304,8 +304,7 @@ export class WKBrowserContext extends BrowserContextBase {
       await (page._delegate as WKPage).updateOffline();
   }
 
-  async setHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void> {
-    deprecate(`context.setHTTPCredentials`, `warning: method |context.setHTTPCredentials()| is deprecated. Instead of changing credentials, create another browser context with new credentials.`);
+  async _doSetHTTPCredentials(httpCredentials: types.Credentials | null): Promise<void> {
     this._options.httpCredentials = httpCredentials || undefined;
     for (const page of this.pages())
       await (page._delegate as WKPage).updateHttpCredentials();


### PR DESCRIPTION
This moves all extra deprecation messages from vendor implementations
into a single vendor-neutral land.