### PR TITLE
test(chromium): enable SelectAll test on mac

### DIFF
--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -290,7 +290,7 @@ describe('Keyboard', function() {
     await textarea.type('👹 Tokyo street Japan 🇯🇵');
     expect(await frame.$eval('textarea', textarea => textarea.value)).toBe('👹 Tokyo street Japan 🇯🇵');
   });
-  it.fail(CHROMIUM && MAC)('should handle selectAll', async({page, server}) => {
+  it('should handle selectAll', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/textarea.html');
     const textarea = await page.$('textarea');
     await textarea.type('some text');
@@ -301,7 +301,7 @@ describe('Keyboard', function() {
     await page.keyboard.press('Backspace');
     expect(await page.$eval('textarea', textarea => textarea.value)).toBe('');
   });
-  it.fail(CHROMIUM && MAC)('should be able to prevent selectAll', async({page, server}) => {
+  it('should be able to prevent selectAll', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/textarea.html');
     const textarea = await page.$('textarea');
     await textarea.type('some text');


### PR DESCRIPTION
closes #1067

I thought I would need to do a frontend patch with this, but it turns out the ChromeDriver team added support directly into Chromium in https://chromium.googlesource.com/chromium/src/+/3aea727ff4dce22542b1ec93818748fc970f3990. So everything just works with the roll.