### PR TITLE
fix(close): actually mark the page as closing

### DIFF
--- a/src/page.ts
+++ b/src/page.ts
@@ -480,6 +480,7 @@ export class Page extends EventEmitter {
       return;
     const runBeforeUnload = !!options && !!options.runBeforeUnload;
     if (this._closedState !== 'closing') {
+      this._closedState = 'closing';
       assert(!this._disconnected, 'Protocol error: Connection closed. Most likely the page has been closed.');
       await this._delegate.closePage(runBeforeUnload);
     }


### PR DESCRIPTION
Currently double-closing flakiness is seen on Firefox bots.