### PR TITLE
test: update http credentials tests

### DIFF
--- a/src/firefox/ffBrowser.ts
+++ b/src/firefox/ffBrowser.ts
@@ -202,14 +202,6 @@ export class FFBrowserContext extends BrowserContextBase {
     return Array.from(this._browser._ffPages.values()).filter(ffPage => ffPage._browserContext === this);
   }
 
-  setDefaultNavigationTimeout(timeout: number) {
-    this._timeoutSettings.setDefaultNavigationTimeout(timeout);
-  }
-
-  setDefaultTimeout(timeout: number) {
-    this._timeoutSettings.setDefaultTimeout(timeout);
-  }
-
   pages(): Page[] {
     return this._ffPages().map(ffPage => ffPage._initializedPage).filter(pageOrNull => !!pageOrNull) as Page[];
   }

--- a/test/apicoverage.spec.js
+++ b/test/apicoverage.spec.js
@@ -55,7 +55,7 @@ describe.skip(!process.env.COVERAGE)('**API COVERAGE**', () => {
     {
       name: 'Firefox',
       events: require('../lib/events').Events,
-      missingCoverage: ['browserContext.setGeolocation', 'browserContext.setOffline', 'cDPSession.send', 'cDPSession.detach'],
+      missingCoverage: ['cDPSession.send', 'cDPSession.detach'],
     },
     {
       name: 'WebKit',
@@ -73,7 +73,12 @@ describe.skip(!process.env.COVERAGE)('**API COVERAGE**', () => {
   ];
   const browserConfig = BROWSER_CONFIGS.find(config => config.name.toLowerCase() === browserType.name());
   const events = browserConfig.events;
-  const api = require('../lib/api');
+  // TODO: we should rethink our api.ts approach to ensure coverage and async stacks.
+  const api = {
+    ...require('../lib/api'),
+    Browser: require('../lib/browser').BrowserBase,
+    BrowserContext: require('../lib/browserContext').BrowserContextBase,
+  };
 
   const coverage = new Map();
   Object.keys(api).forEach(apiName => {


### PR DESCRIPTION
We have tests that will never pass, currently marked as `fail(true)` - remove them.
Update all the rest to use non-deprecated `{httpCredentials}` option instead of `setHTTPCredentials()`, leaving just one to test the latter.