### PR TITLE
feat(chromium): independent window size

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -742,7 +742,7 @@ page.removeListener('request', logRequest);
 - [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout)
 - [page.setExtraHTTPHeaders(headers)](#pagesetextrahttpheadersheaders)
 - [page.setInputFiles(selector, files[, options])](#pagesetinputfilesselector-files-options)
-- [page.setViewportSize(viewportSize)](#pagesetviewportsizeviewportsize)
+- [page.setViewportSize(viewportSize[, independentWindow])](#pagesetviewportsizeviewportsize-independentwindow)
 - [page.textContent(selector[, options])](#pagetextcontentselector-options)
 - [page.title()](#pagetitle)
 - [page.type(selector, text[, options])](#pagetypeselector-text-options)
@@ -1723,10 +1723,11 @@ This method expects `selector` to point to an [input element](https://developer.
 Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then they are resolved relative to the [current working directory](https://nodejs.org/api/process.html#process_process_cwd). For empty array, clears the selected files.
 
 
-#### page.setViewportSize(viewportSize)
+#### page.setViewportSize(viewportSize[, independentWindow])
 - `viewportSize` <[Object]>
   - `width` <[number]> page width in pixels. **required**
   - `height` <[number]> page height in pixels. **required**
+- `independentWindow` <[boolean]> Optional flag to keep window size separated from viewport size
 - returns: <[Promise]>
 
 In the case of multiple pages in a single browser, each page can have its own viewport size. However, [browser.newContext([options])](#browsernewcontextoptions) allows to set viewport size (and more) for all pages in the context at once.
@@ -1741,6 +1742,11 @@ await page.setViewportSize({
 });
 await page.goto('https://example.com');
 ```
+
+> Notice about the window size behvior when running `headless: false`:
+> - Chromium - window frame fit the new viewport size (can be independent when using the `independentWindow` flag)
+> - Firefox - window frame is independent of the viewport size
+> - WebKit - window frame always fit the viewport size
 
 #### page.textContent(selector[, options])
 - `selector` <[string]> A selector to search for an element. If there are multiple elements satisfying the selector, the first will be picked. See [working with selectors](#working-with-selectors) for more details.

--- a/docs/emulation.md
+++ b/docs/emulation.md
@@ -68,7 +68,7 @@ await page.emulateMedia({ colorScheme: 'dark' });
 
 - [`browser.newContext([options])`](./api.md#browsernewcontextoptions)
 - [`page.emulateMedia([options])`](./api.md#pageemulatemediaoptions)
-- [`page.setViewportSize(viewportSize)`](./api.md#pagesetviewportsizeviewportsize)
+- [`page.setViewportSize(viewportSize[, independentWindow])`](./api.md#pageviewportsize)
 
 <br/>
 

--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -138,9 +138,9 @@ export class CRPage implements PageDelegate {
     await this._forAllFrameSessions(frame => frame._updateHttpCredentials());
   }
 
-  async setViewportSize(viewportSize: types.Size): Promise<void> {
+  async setViewportSize(viewportSize: types.Size, independentWindow = false): Promise<void> {
     assert(this._page._state.viewportSize === viewportSize);
-    await this._mainFrameSession._updateViewport();
+    await this._mainFrameSession._updateViewport(independentWindow);
   }
 
   async updateEmulateMedia(): Promise<void> {
@@ -727,7 +727,7 @@ class FrameSession {
     await this._networkManager.authenticate(credentials);
   }
 
-  async _updateViewport(): Promise<void> {
+  async _updateViewport(independentWindow = false): Promise<void> {
     assert(this._isMainFrame());
     const options = this._crPage._browserContext._options;
     const viewportSize = this._page._state.viewportSize;
@@ -745,7 +745,7 @@ class FrameSession {
         screenOrientation: isLandscape ? { angle: 90, type: 'landscapePrimary' } : { angle: 0, type: 'portraitPrimary' },
       }),
     ];
-    if (this._windowId) {
+    if (this._windowId && independentWindow === false) {
       // TODO: popup windows have their own insets.
       let insets = { width: 24, height: 88 };
       if (process.platform === 'win32')

--- a/src/page.ts
+++ b/src/page.ts
@@ -49,7 +49,7 @@ export interface PageDelegate {
   navigateFrame(frame: frames.Frame, url: string, referrer: string | undefined): Promise<frames.GotoResult>;
 
   updateExtraHTTPHeaders(): Promise<void>;
-  setViewportSize(viewportSize: types.Size): Promise<void>;
+  setViewportSize(viewportSize: types.Size, independentWindow?: boolean): Promise<void>;
   updateEmulateMedia(): Promise<void>;
   updateRequestInterception(): Promise<void>;
   setFileChooserIntercepted(enabled: boolean): Promise<void>;
@@ -389,9 +389,9 @@ export class Page extends EventEmitter {
     await this._delegate.updateEmulateMedia();
   }
 
-  async setViewportSize(viewportSize: types.Size) {
+  async setViewportSize(viewportSize: types.Size, independentWindow = false) {
     this._state.viewportSize = { ...viewportSize };
-    await this._delegate.setViewportSize(this._state.viewportSize);
+    await this._delegate.setViewportSize(this._state.viewportSize, independentWindow);
   }
 
   viewportSize(): types.Size | null {

--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -126,7 +126,7 @@ export interface PageChannel extends Channel {
   screenshot(params: { options?: types.ScreenshotOptions }): Promise<Binary>;
   setExtraHTTPHeaders(params: { headers: types.Headers }): Promise<void>;
   setNetworkInterceptionEnabled(params: { enabled: boolean }): Promise<void>;
-  setViewportSize(params: { viewportSize: types.Size }): Promise<void>;
+  setViewportSize(params: { viewportSize: types.Size, independentWindow?: boolean }): Promise<void>;
 
   // Input
   keyboardDown(params: { key: string }): Promise<void>;

--- a/src/rpc/client/page.ts
+++ b/src/rpc/client/page.ts
@@ -353,9 +353,9 @@ export class Page extends ChannelOwner<PageChannel, PageInitializer> {
     await this._channel.emulateMedia({ options });
   }
 
-  async setViewportSize(viewportSize: types.Size) {
+  async setViewportSize(viewportSize: types.Size, independentWindow?: boolean) {
     this._viewportSize = viewportSize;
-    await this._channel.setViewportSize({ viewportSize });
+    await this._channel.setViewportSize({ viewportSize, independentWindow });
   }
 
   viewportSize(): types.Size | null {

--- a/src/rpc/server/pageDispatcher.ts
+++ b/src/rpc/server/pageDispatcher.ts
@@ -116,8 +116,8 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     await this._page.emulateMedia(params.options);
   }
 
-  async setViewportSize(params: { viewportSize: types.Size }): Promise<void> {
-    await this._page.setViewportSize(params.viewportSize);
+  async setViewportSize(params: { viewportSize: types.Size, independentWindow?: boolean }): Promise<void> {
+    await this._page.setViewportSize(params.viewportSize, params.independentWindow);
   }
 
   async addInitScript(params: { source: string }): Promise<void> {


### PR DESCRIPTION
This PR adds the ability to disable the size change of the window when changing the viewport size. The reason this is useful is to keep the window in place while debugging in the browser.

This behavior is unfortunately only possible in Chromium (and already is the only possibility with Firefox), because of differences between browsers:
- Chromium - window is independent by default and set to fit viewport by playwright (this behavior is disabled by this PR with a flag)
- Firefox - window is always independent of viewport; _there are WebDriver commands ([getWindowRect](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Commands/GetWindowRect)/[setWindowRect](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Commands/SetWindowRect)) or devTools protocol commands: [setWindowBounds](https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-setWindowBounds), [getWindowBounds](https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-getWindowBounds)) that might allow to align the behavior with Chromium, but I couldn't figure out how to call them (would be happy to contribute another PR with a little explanation of how to achieve that)_
- WebKit - window is always bound to viewport

Caveat about the tests - I wrote a test using `window.outerWidth/outerHeight`, however it seems that these properties only change when running chromium in `headless: false` mode. When running in headless these properties keep the original size and don't change to match the viewport size (even when calling `Browser.setWindowBounds`), so the new test is not checking anything and I didn't include it. Any suggestions on how to test would be great.

This PR resolves #2749 
