### PR TITLE
[DO NOT LAND] test: check what browsers do not close with contextmenu

### DIFF
--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -79,7 +79,7 @@ describe('Headful', function() {
     await page.click('button');
     await browser.close();
   });
-  it.fail(CHROMIUM || (WEBKIT && WIN))('should close browser after context menu was triggered', async({browserType, defaultBrowserOptions, server}) => {
+  it('should close browser after context menu was triggered', async({browserType, defaultBrowserOptions, server}) => {
     const browser = await browserType.launch({...defaultBrowserOptions, headless: false });
     const page = await browser.newPage();
     await page.goto(server.PREFIX + '/grid.html');


### PR DESCRIPTION
not for landing; this is to see which browsers do not actually close
when there's a context menu opened.