### PR TITLE
fix(rpc): send messages in new lines

### DIFF
--- a/src/rpc/transport.ts
+++ b/src/rpc/transport.ts
@@ -54,7 +54,7 @@ export class Transport {
 
       const terminatorIndex = this._data.indexOf('\n');
       const message = this._data.slice(0, terminatorIndex);
-      this._data = this._data.slice(terminatorIndex +1);
+      this._data = this._data.slice(terminatorIndex + 1);
 
       this._waitForNextTask(() => {
         if (this.onmessage)


### PR DESCRIPTION
.NET Process objects read the Standard Output by line, so we would need to send a `\n` after each message.

As we know how messages are being sent, and now that we send a newline character after each message, I made the pipe message parsing simpler. 
I removed the message length info (and check), and replaced it with a new line check.

I tested things like this:

```
this._scope.sendMessageToClient(scope.guid, '__create__', { type : 'foo \n NEW LINE HERE', initializer, guid });
``` 

And it worked as expected.

I also got rid of the double serializing/deserializing. We were doing a `JSON.stringify` before calling the transport, and the transport was doing another `JSON.stringify` turning that into a serialized string. I removed the extra serialization/deserialization in the transport class.