### PR TITLE
chore: refactor actions part 1

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as dom from './dom';
+import * as frames from './frames';
+import * as types from './types';
+import { selectors } from './selectors';
+import { Progress } from './progress';
+import { ParsedSelector } from './common/selectorParser';
+import { assert, helper } from './helper';
+
+type ActionTarget = dom.ElementHandle | { frame: frames.Frame, selector: string };
+type ParsedActionTarget = { target: dom.ElementHandle | ParsedSelector, world: types.World, frame: frames.Frame };
+
+function parseActionTarget(target: ActionTarget): ParsedActionTarget {
+  if (target instanceof dom.ElementHandle)
+    return { target, world: 'utility', frame: target._context.frame };
+  const selectorInfo = selectors._parseSelector(target.selector);
+  return { target: selectorInfo.parsed, world: selectorInfo.world, frame: target.frame };
+}
+
+async function runTask<T>(progress: Progress, target: ParsedActionTarget, task: dom.SchedulableTask<T>): Promise<T> {
+  if (target.target instanceof dom.ElementHandle) {
+    const utility = await target.frame._context(target.world);
+    const injectedScript = await utility.injectedScript();
+    const poll = await task(injectedScript);
+    const pollHandler = new dom.InjectedScriptPollHandler(progress, poll);
+    return await pollHandler.finish();
+  }
+  return await target.frame._scheduleRerunnableTask(progress, target.world, task);
+}
+
+export async function fill(progress: Progress, target: ActionTarget, value: string, options: types.NavigatingActionWaitOptions): Promise<void> {
+  assert(helper.isString(value), 'Value must be string. Found value "' + value + '" of type "' + (typeof value) + '"');
+
+  if (target instanceof dom.ElementHandle)
+    progress.logger.info(`  fill("${value}")`);
+  else
+    progress.logger.info(`  fill("${target.selector}", "${value}")`);
+
+  const parsedTarget = parseActionTarget(target);
+  const result = await runTask(progress, parsedTarget, injectedScript => {
+    return injectedScript.evaluateHandle((injected, { target, value }) => {
+      return injected.waitForEnabledAndFill(target, value);
+    }, { target: parsedTarget.target, value });
+  });
+  const filled = dom.throwRetargetableDOMError(dom.throwFatalDOMError(result));
+
+  if (filled === 'needsinput') {
+    progress.throwIfAborted();  // Avoid action that has side-effects.
+    return await parsedTarget.frame._page._frameManager.waitForSignalsCreatedBy(progress, options.noWaitAfter, async () => {
+      if (value)
+        await parsedTarget.frame._page.keyboard.insertText(value);
+      else
+        await parsedTarget.frame._page.keyboard.press('Delete');
+    }, 'input');
+  } else {
+    dom.assertDone(filled);
+  }
+}
+
+export async function textContent(progress: Progress, target: ActionTarget): Promise<string | null> {
+  if (!(target instanceof dom.ElementHandle))
+    progress.logger.info(`  retrieving textContent from "${target.selector}"`);
+  const parsedTarget = parseActionTarget(target);
+  const result = await runTask(progress, parsedTarget, injectedScript => {
+    return injectedScript.evaluateHandle((injected, target) => {
+      return injected.waitForNodeAndReturnTextContent(target);
+    }, parsedTarget.target);
+  });
+  return result;
+}
+
+export async function innerText(progress: Progress, target: ActionTarget): Promise<string> {
+  if (!(target instanceof dom.ElementHandle))
+    progress.logger.info(`  retrieving innerText from "${target.selector}"`);
+  const parsedTarget = parseActionTarget(target);
+  const result = await runTask(progress, parsedTarget, injectedScript => {
+    return injectedScript.evaluateHandle((injected, target) => {
+      return injected.waitForNodeAndReturnInnerText(target);
+    }, parsedTarget.target);
+  });
+  return dom.throwFatalDOMError(result).innerText;
+}
+
+export async function innerHTML(progress: Progress, target: ActionTarget): Promise<string> {
+  if (!(target instanceof dom.ElementHandle))
+    progress.logger.info(`  retrieving innerHTML from "${target.selector}"`);
+  const parsedTarget = parseActionTarget(target);
+  const result = await runTask(progress, parsedTarget, injectedScript => {
+    return injectedScript.evaluateHandle((injected, target) => {
+      return injected.waitForNodeAndReturnInnerHTML(target);
+    }, parsedTarget.target);
+  });
+  return dom.throwFatalDOMError(result).innerHTML;
+}
+
+export async function getAttribute(progress: Progress, target: ActionTarget, name: string): Promise<string | null> {
+  if (!(target instanceof dom.ElementHandle))
+    progress.logger.info(`  retrieving attribute "${name}" from "${target.selector}"`);
+  else
+    progress.logger.info(`  retrieving attribute "${name}"`);
+  const parsedTarget = parseActionTarget(target);
+  const result = await runTask(progress, parsedTarget, injectedScript => {
+    return injectedScript.evaluateHandle((injected, { target, name }) => {
+      return injected.waitForNodeAndReturnAttribute(target, name);
+    }, { target: parsedTarget.target, name });
+  });
+  return dom.throwFatalDOMError(result).value;
+}
+
+export async function dispatchEvent(progress: Progress, target: ActionTarget, type: string, eventInit: Object): Promise<void> {
+  if (!(target instanceof dom.ElementHandle))
+    progress.logger.info(`  dispatching event "${type}" on "${target.selector}"`);
+  else
+    progress.logger.info(`  dispatching event "${type}"`);
+  const parsedTarget = parseActionTarget(target);
+  parsedTarget.world = 'main';  // We always dispatch events in the main world.
+  await runTask(progress, parsedTarget, injectedScript => {
+    return injectedScript.evaluateHandle((injected, { target, type, eventInit }) => {
+      return injected.waitForNodeAndDispatchEvent(target, type, eventInit);
+    }, { target: parsedTarget.target, type, eventInit });
+  });
+}

--- a/test/dispatchevent.spec.js
+++ b/test/dispatchevent.spec.js
@@ -98,22 +98,8 @@ describe('Page.dispatchEvent(click)', function() {
     expect(await page.evaluate(() => window.clicked)).toBe(true);
   });
   it('should be atomic', async({page}) => {
-    const createDummySelector = () => ({
-      create(root, target) {},
-      query(root, selector) {
-        const result = root.querySelector(selector);
-        if (result)
-          Promise.resolve().then(() => result.onclick = "");
-        return result;
-      },
-      queryAll(root, selector) {
-        const result = Array.from(root.querySelectorAll(selector));
-        for (const e of result)
-          Promise.resolve().then(() => result.onclick = "");
-        return result;
-      }
-    });
-    await utils.registerEngine('dispatchEvent', createDummySelector);
+    await utils.registerAtomicEngine('dispatchEvent');
+    await page.evaluate(() => window.__modify = e => e.onclick = '');
     await page.setContent(`<div onclick="window._clicked=true">Hello</div>`);
     await page.dispatchEvent('dispatchEvent=div', 'click');
     expect(await page.evaluate(() => window._clicked)).toBe(true);

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -485,91 +485,35 @@ describe('ElementHandle convenience API', function() {
     expect(await page.textContent('#inner')).toBe('Text,\nmore text');
   });
   it('textContent should be atomic', async({page}) => {
-    const createDummySelector = () => ({
-      create(root, target) {},
-      query(root, selector) {
-        const result = root.querySelector(selector);
-        if (result)
-          Promise.resolve().then(() => result.textContent = 'modified');
-        return result;
-      },
-      queryAll(root, selector) {
-        const result = Array.from(root.querySelectorAll(selector));
-        for (const e of result)
-          Promise.resolve().then(() => result.textContent = 'modified');
-        return result;
-      }
-    });
-    await utils.registerEngine('textContent', createDummySelector);
+    await utils.registerAtomicEngine('textContent');
+    await page.evaluate(() => window.__modify = e => e.textContent = 'modified');
     await page.setContent(`<div>Hello</div>`);
-    const tc = await page.textContent('textContent=div');
-    expect(tc).toBe('Hello');
+    const result = await page.textContent('textContent=div');
+    expect(result).toBe('Hello');
     expect(await page.evaluate(() => document.querySelector('div').textContent)).toBe('modified');
   });
   it('innerText should be atomic', async({page}) => {
-    const createDummySelector = () => ({
-      create(root, target) {},
-      query(root, selector) {
-        const result = root.querySelector(selector);
-        if (result)
-          Promise.resolve().then(() => result.textContent = 'modified');
-        return result;
-      },
-      queryAll(root, selector) {
-        const result = Array.from(root.querySelectorAll(selector));
-        for (const e of result)
-          Promise.resolve().then(() => result.textContent = 'modified');
-        return result;
-      }
-    });
-    await utils.registerEngine('innerText', createDummySelector);
+    await utils.registerAtomicEngine('innerText');
+    await page.evaluate(() => window.__modify = e => e.textContent = 'modified');
     await page.setContent(`<div>Hello</div>`);
-    const tc = await page.innerText('innerText=div');
-    expect(tc).toBe('Hello');
+    const result = await page.innerText('innerText=div');
+    expect(result).toBe('Hello');
     expect(await page.evaluate(() => document.querySelector('div').innerText)).toBe('modified');
   });
   it('innerHTML should be atomic', async({page}) => {
-    const createDummySelector = () => ({
-      create(root, target) {},
-      query(root, selector) {
-        const result = root.querySelector(selector);
-        if (result)
-          Promise.resolve().then(() => result.textContent = 'modified');
-        return result;
-      },
-      queryAll(root, selector) {
-        const result = Array.from(root.querySelectorAll(selector));
-        for (const e of result)
-          Promise.resolve().then(() => result.textContent = 'modified');
-        return result;
-      }
-    });
-    await utils.registerEngine('innerHTML', createDummySelector);
+    await utils.registerAtomicEngine('innerHTML');
+    await page.evaluate(() => window.__modify = e => e.textContent = 'modified');
     await page.setContent(`<div>Hello<span>world</span></div>`);
-    const tc = await page.innerHTML('innerHTML=div');
-    expect(tc).toBe('Hello<span>world</span>');
+    const result = await page.innerHTML('innerHTML=div');
+    expect(result).toBe('Hello<span>world</span>');
     expect(await page.evaluate(() => document.querySelector('div').innerHTML)).toBe('modified');
   });
   it('getAttribute should be atomic', async({page}) => {
-    const createDummySelector = () => ({
-      create(root, target) {},
-      query(root, selector) {
-        const result = root.querySelector(selector);
-        if (result)
-          Promise.resolve().then(() => result.setAttribute('foo', 'modified'));
-        return result;
-      },
-      queryAll(root, selector) {
-        const result = Array.from(root.querySelectorAll(selector));
-        for (const e of result)
-          Promise.resolve().then(() => result.setAttribute('foo', 'modified'));
-        return result;
-      }
-    });
-    await utils.registerEngine('getAttribute', createDummySelector);
+    await utils.registerAtomicEngine('getAttribute');
+    await page.evaluate(() => window.__modify = e => e.setAttribute('foo', 'modified'));
     await page.setContent(`<div foo=hello></div>`);
-    const tc = await page.getAttribute('getAttribute=div', 'foo');
-    expect(tc).toBe('hello');
+    const result = await page.getAttribute('getAttribute=div', 'foo');
+    expect(result).toBe('hello');
     expect(await page.evaluate(() => document.querySelector('div').getAttribute('foo'))).toBe('modified');
   });
 });

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -18,7 +18,8 @@
 const path = require('path');
 const util = require('util');
 const vm = require('vm');
-const {FFOX, CHROMIUM, WEBKIT, WIN, CHANNEL} = require('./utils').testOptions(browserType);
+const utils = require('./utils');
+const {FFOX, CHROMIUM, WEBKIT, WIN, CHANNEL} = utils.testOptions(browserType);
 
 describe('Page.close', function() {
   it('should reject all promises when page is closed', async({context}) => {
@@ -1079,7 +1080,7 @@ describe('Page.fill', function() {
       await page.$eval('input', (input, type) => input.setAttribute('type', type), type);
       let error = null;
       await page.fill('input', '').catch(e => error = e);
-      expect(error.message).toContain(`input of type "${type}" cannot be filled`);
+      expect(error.message).toContain(`has input type "${type}" and cannot be filled`);
     }
   });
   it('should fill different input types', async({page, server}) => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -103,6 +103,25 @@ const utils = module.exports = {
     }
   },
 
+  registerAtomicEngine: async (name) => {
+    const createAtomicEngine = () => ({
+      create(root, target) {},
+      query(root, selector) {
+        const result = root.querySelector(selector);
+        if (result)
+          Promise.resolve().then(() => window.__modify && window.__modify(result));
+        return result;
+      },
+      queryAll(root, selector) {
+        const result = Array.from(root.querySelectorAll(selector));
+        for (const e of result)
+          Promise.resolve().then(() => window.__modify && window.__modify(result));
+        return result;
+      }
+    });
+    await utils.registerEngine(name, createAtomicEngine, { contentScript: false });
+  },
+
   initializeFlakinessDashboardIfNeeded: async function(testRunner) {
     // Generate testIDs for all tests and verify they don't clash.
     // This will add |test.testId| for every test.


### PR DESCRIPTION
This separates actions from `frames.ts` and `dom.ts` and unifies selector-based and handle-based versions. The unification allows selector-based actions to ensure that target element actually matches selector when action is performed, to avoid issues with element being detached or recycled.

This change covers innerText, textContent, getAttribute, innerHTML, fill and dispatchEvent actions.