### PR TITLE
browser(webkit): properly disconnect signal handlers when closing browser

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1301
-Changed: lushnikov@chromium.org Thu Jul  2 15:14:04 PDT 2020
+1302
+Changed: yurys@chromium.org Mon Jul  6 13:55:53 PDT 2020

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -15030,6 +15030,18 @@ index 113170ce21145fc53a3c804822ef20fa9d89de8b..855ff101965bf1dd652d58903db0c143
  # TODO: Add a check for HAVE_RSA_PSS for support of CryptoAlgorithmRSA_PSS
  # https://bugs.webkit.org/show_bug.cgi?id=206635
  
+diff --git a/Tools/MiniBrowser/gtk/BrowserDownloadsBar.c b/Tools/MiniBrowser/gtk/BrowserDownloadsBar.c
+index b9feb8e7d97716ff505c3ce0d3bea830ff0a9d62..91d83beeb8b6350f1a03551f638df65af838c2aa 100644
+--- a/Tools/MiniBrowser/gtk/BrowserDownloadsBar.c
++++ b/Tools/MiniBrowser/gtk/BrowserDownloadsBar.c
+@@ -127,6 +127,7 @@ static void browserDownloadFinalize(GObject *object)
+     BrowserDownload *browserDownload = BROWSER_DOWNLOAD(object);
+ 
+     if (browserDownload->download) {
++        g_signal_handlers_disconnect_by_data(browserDownload->download, browserDownload);
+         g_object_unref(browserDownload->download);
+         browserDownload->download = NULL;
+     }
 diff --git a/Tools/MiniBrowser/gtk/BrowserTab.c b/Tools/MiniBrowser/gtk/BrowserTab.c
 index 3845eabba3e964f9e11bb0ffcb8726fd4ea96fc4..630a6e395298bd9c03c1b131f984b0a8444d2051 100644
 --- a/Tools/MiniBrowser/gtk/BrowserTab.c


### PR DESCRIPTION
https://github.com/yury-s/webkit/commit/0c258cd33bfb7d96249a23c9ec6dedee0288221c

This fixes following crash in 
"WebKit browserType.launch({downloadsPath}) should keep downloadsPath folder (downloadsPath.spec.js:46:3)":


#0  0x00007f4072b28e4d in g_type_check_instance () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libgobject-2.0.so.0
#1  0x00007f4072b1ca34 in g_signal_handlers_disconnect_matched () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libgobject-2.0.so.0
#2  0x000056033590193b in ?? ()
#3  0x00007f4072b01c2d in g_closure_invoke () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libgobject-2.0.so.0
#4  0x00007f4072b1562e in ?? () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libgobject-2.0.so.0
#5  0x00007f4072b1dfe5 in g_signal_emit_valist () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libgobject-2.0.so.0
#6  0x00007f4072b1e9ff in g_signal_emit () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libgobject-2.0.so.0
#7  0x00007f4076edaafb in webkitDownloadFailed(_WebKitDownload*, WebCore::ResourceError const&) () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libwebkit2gtk-4.0.so.37
#8  0x00007f4076edb9fe in webkitDownloadCancelled(_WebKitDownload*) () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libwebkit2gtk-4.0.so.37
#9  0x00007f4076edc1e9 in DownloadClient::didCancel(WebKit::DownloadProxy&) () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libwebkit2gtk-4.0.so.37
#10 0x00007f4076f614b5 in WebKit::DownloadProxy::didCancel(IPC::DataReference const&) () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libwebkit2gtk-4.0.so.37
#11 0x00007f4076b014e1 in WebKit::DownloadProxy::didReceiveMessage(IPC::Connection&, IPC::Decoder&) () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libwebkit2gtk-4.0.so.37
#12 0x00007f4076d0b5f8 in IPC::MessageReceiverMap::dispatchMessage(IPC::Connection&, IPC::Decoder&) () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libwebkit2gtk-4.0.so.37
#13 0x00007f4076f74fbf in non-virtual thunk to WebKit::NetworkProcessProxy::didReceiveMessage(IPC::Connection&, IPC::Decoder&) () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libwebkit2gtk-4.0.so.37
#14 0x00007f4076d03f90 in IPC::Connection::dispatchMessage(IPC::Decoder&) () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libwebkit2gtk-4.0.so.37
#15 0x00007f4076d05d25 in IPC::Connection::dispatchMessage(std::unique_ptr<IPC::Decoder, std::default_delete<IPC::Decoder> >) () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libwebkit2gtk-4.0.so.37
#16 0x00007f4076d064cf in IPC::Connection::dispatchOneIncomingMessage() () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libwebkit2gtk-4.0.so.37
#17 0x00007f4074940df5 in WTF::RunLoop::performWork() () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libjavascriptcoregtk-4.0.so.18
#18 0x00007f40749a9b09 in ?? () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libjavascriptcoregtk-4.0.so.18
#19 0x00007f407ab639e5 in g_main_context_dispatch () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libglib-2.0.so.0
#20 0x00007f407ab63db0 in ?? () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libglib-2.0.so.0
#21 0x00007f407ab63e3c in g_main_context_iteration () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libglib-2.0.so.0
#22 0x00007f4072e1069d in g_application_run () from /home/yurys/.cache/ms-playwright/webkit-1301/minibrowser-gtk/libgio-2.0.so.0
#23 0x00005603358ff76f in ?? ()
#24 0x00007f4071b30b97 in __libc_start_main (main=0x5603358ff320, argc=3, argv=0x7ffd6d806508, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7ffd6d8064f8) at ../csu/libc-start.c:310
#25 0x00005603358ff81a in ?? ()
