### PR TITLE
chore: replace FrameTask with internal events on Frame

### DIFF
--- a/src/browserContext.ts
+++ b/src/browserContext.ts
@@ -99,7 +99,7 @@ export abstract class BrowserContextBase extends EventEmitter implements Browser
     const progressController = new ProgressController(this._apiLogger, this._timeoutSettings.timeout(options), 'browserContext.waitForEvent');
     if (event !== Events.BrowserContext.Close)
       this._closePromise.then(error => progressController.abort(error));
-    return progressController.run(progress => helper.waitForEvent(progress, this, event, options.predicate));
+    return progressController.run(progress => helper.waitForEvent(progress, this, event, options.predicate).promise);
   }
 
   _browserClosed() {

--- a/src/page.ts
+++ b/src/page.ts
@@ -356,7 +356,7 @@ export class Page extends EventEmitter {
     this._disconnectedPromise.then(error => progressController.abort(error));
     if (event !== Events.Page.Crash)
       this._crashedPromise.then(error => progressController.abort(error));
-    return progressController.run(progress => helper.waitForEvent(progress, this, event, options.predicate));
+    return progressController.run(progress => helper.waitForEvent(progress, this, event, options.predicate).promise);
   }
 
   async goBack(options?: types.NavigateOptions): Promise<network.Response | null> {

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -29,12 +29,6 @@ export interface Progress {
   throwIfAborted(): void;
 }
 
-let runningTaskCount = 0;
-
-export function isRunningTask(): boolean {
-  return !!runningTaskCount;
-}
-
 export async function runAbortableTask<T>(task: (progress: Progress) => Promise<T>, logger: Logger, timeout: number, apiName: string): Promise<T> {
   const controller = new ProgressController(logger, timeout, apiName);
   return controller.run(task);
@@ -75,7 +69,6 @@ export class ProgressController {
   async run<T>(task: (progress: Progress) => Promise<T>): Promise<T> {
     assert(this._state === 'before');
     this._state = 'running';
-    ++runningTaskCount;
 
     const loggerScope = this._logger.createScope(this._apiName, true);
 
@@ -114,8 +107,6 @@ export class ProgressController {
       loggerScope.endScope(`failed`);
       await Promise.all(this._cleanups.splice(0).map(cleanup => runCleanup(cleanup)));
       throw e;
-    } finally {
-      --runningTaskCount;
     }
   }
 

--- a/src/server/electron.ts
+++ b/src/server/electron.ts
@@ -135,7 +135,7 @@ export class ElectronApplication extends EventEmitter {
     const progressController = new ProgressController(this._apiLogger, this._timeoutSettings.timeout(options), 'electron.waitForEvent');
     if (event !== ElectronEvents.ElectronApplication.Close)
       this._browserContext._closePromise.then(error => progressController.abort(error));
-    return progressController.run(progress => helper.waitForEvent(progress, this, event, options.predicate));
+    return progressController.run(progress => helper.waitForEvent(progress, this, event, options.predicate).promise);
   }
 
   async _init()  {


### PR DESCRIPTION
We now use a few helper.waitForEvent calls to wait for internal
events kNavigationEvent and kLifecycleEvent. With these events,
we should be able to replicate logic over rpc.