### PR TITLE
chore(eslint): lint for copyrights on files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
     parser: '@typescript-eslint/parser',
-    plugins: ['@typescript-eslint'],
+    plugins: ['@typescript-eslint', 'notice'],
     parserOptions: {
       project: './tsconfig.json',
       ecmaVersion: 9,
@@ -106,6 +106,12 @@ module.exports = {
         "indent": [2, 2, { "SwitchCase": 1, "CallExpression": {"arguments": 2}, "MemberExpression": 2 }],
         "key-spacing": [2, {
             "beforeColon": false
+        }],
+
+        // copyright
+        "notice/notice": [2, {
+            "mustMatch": "Copyright",
+            "templateFile": "./utils/copyright.js",
         }],
 
         // type-aware rules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1794,6 +1794,17 @@
         }
       }
     },
+    "eslint-plugin-notice": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-notice/-/eslint-plugin-notice-0.9.10.tgz",
+      "integrity": "sha512-rF79EuqdJKu9hhTmwUkNeSvLmmq03m/NXq/NHwUENHbdJ0wtoyOjxZBhW4QCug8v5xYE6cGe3AWkGqSIe9KUbQ==",
+      "dev": true,
+      "requires": {
+        "find-root": "^1.1.0",
+        "lodash": "^4.17.15",
+        "metric-lcs": "^0.1.2"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
@@ -2173,6 +2184,12 @@
         "make-dir": "^2.0.0",
         "pkg-dir": "^3.0.0"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
     },
     "find-up": {
       "version": "3.0.0",
@@ -3297,6 +3314,12 @@
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
       }
+    },
+    "metric-lcs": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/metric-lcs/-/metric-lcs-0.1.2.tgz",
+      "integrity": "sha512-+TZ5dUDPKPJaU/rscTzxyN8ZkX7eAVLAiQU/e+YINleXPv03SCmJShaMT1If1liTH8OcmWXZs0CmzCBRBLcMpA==",
+      "dev": true
     },
     "micromatch": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "cross-env": "^5.0.5",
     "electron": "^9.0.0-beta.24",
     "eslint": "^6.6.0",
+    "eslint-plugin-notice": "^0.9.10",
     "esprima": "^4.0.0",
     "formidable": "^1.2.1",
     "ncp": "^2.0.0",

--- a/utils/copyright.js
+++ b/utils/copyright.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */


### PR DESCRIPTION
I got tired of forgetting to put the copyright on things. This checks that every file begins with a comment containing the word copyright. It also will automatically add copyright on `eslint --fix`.

New dev dependency is [`eslint-plugin-notice`](https://www.npmjs.com/package/eslint-plugin-notice)