### PR TITLE
docs(CONTRIBUTING.md): Add build step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ cd playwright
 npm install
 ```
 
-3. Build via Webpack
+3. Build Playwright
 
 ```bash
 npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,13 @@ cd playwright
 npm install
 ```
 
-3. Run all Playwright tests locally. For more information about tests, read [Running & Writing Tests](#running--writing-tests).
+3. Build via Webpack
+
+```bash
+npm run build
+```
+
+4. Run all Playwright tests locally. For more information about tests, read [Running & Writing Tests](#running--writing-tests).
 
 ```bash
 npm test


### PR DESCRIPTION
Without the build step, a fresh install without any previous
builds would get:

```
$ npm test

> playwright-internal@1.2.0-post test /Users/pw/code/playwright
> cross-env BROWSER=all node --unhandled-rejections=strict test/test.js

internal/modules/cjs/loader.js:1033
  throw err;
  ^

Error: Cannot find module '../lib/rpc/server/dispatcher'
Require stack:
- /Users/pw/code/playwright/test/environments.js
- /Users/pw/code/playwright/test/test.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:1030:15)
    at Function.Module._load (internal/modules/cjs/loader.js:899:27)
    at Module.require (internal/modules/cjs/loader.js:1090:19)
    at require (internal/modules/cjs/helpers.js:75:18)
    at Object.<anonymous> (/Users/pw/code/playwright/test/environments.js:23:34)
    at Module._compile (internal/modules/cjs/loader.js:1201:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1221:10)
    at Module.load (internal/modules/cjs/loader.js:1050:32)
    at Function.Module._load (internal/modules/cjs/loader.js:938:14)
    at Module.require (internal/modules/cjs/loader.js:1090:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/pw/code/playwright/test/environments.js',
    '/Users/pw/code/playwright/test/test.js'
  ]
}
npm ERR! Test failed.  See above for more details.
```

Fixes #2868.