### PR TITLE
feat(rpc): support more chromium-specific apis

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -26,6 +26,7 @@ import { ProxySettings } from './types';
 import { LoggerSink } from './loggerSink';
 
 export type BrowserOptions = {
+  name: string,
   loggers: Loggers,
   downloadsPath?: string,
   headful?: boolean,

--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -63,8 +63,7 @@ export interface BrowserChannel extends Channel {
   close(): Promise<void>;
   newContext(params: types.BrowserContextOptions): Promise<BrowserContextChannel>;
 
-  // Chromium-specific.
-  newBrowserCDPSession(): Promise<CDPSessionChannel>;
+  crNewBrowserCDPSession(): Promise<CDPSessionChannel>;
 }
 export type BrowserInitializer = {};
 
@@ -92,9 +91,15 @@ export interface BrowserContextChannel extends Channel {
   setNetworkInterceptionEnabled(params: { enabled: boolean }): Promise<void>;
   setOffline(params: { offline: boolean }): Promise<void>;
   waitForEvent(params: { event: string }): Promise<any>;
+
+  on(event: 'crBackgroundPage', callback: (params: PageChannel) => void): this;
+  on(event: 'crServiceWorker', callback: (params: WorkerChannel) => void): this;
+  crNewCDPSession(params: { page: PageChannel }): Promise<CDPSessionChannel>;
 }
 export type BrowserContextInitializer = {
-  pages: PageChannel[]
+  pages: PageChannel[],
+  crBackgroundPages: PageChannel[],
+  crServiceWorkers: WorkerChannel[],
 };
 
 

--- a/src/rpc/client/browser.ts
+++ b/src/rpc/client/browser.ts
@@ -79,8 +79,7 @@ export class Browser extends ChannelOwner<BrowserChannel, BrowserInitializer> {
     await this._channel.close();
   }
 
-  // Chromium-specific.
   async newBrowserCDPSession(): Promise<CDPSession> {
-    return CDPSession.from(await this._channel.newBrowserCDPSession());
+    return CDPSession.from(await this._channel.crNewBrowserCDPSession());
   }
 }

--- a/src/rpc/server/browserDispatcher.ts
+++ b/src/rpc/server/browserDispatcher.ts
@@ -41,8 +41,7 @@ export class BrowserDispatcher extends Dispatcher<Browser, BrowserInitializer> i
     await this._object.close();
   }
 
-  // Chromium-specific.
-  async newBrowserCDPSession(): Promise<CDPSessionChannel> {
+  async crNewBrowserCDPSession(): Promise<CDPSessionChannel> {
     const crBrowser = this._object as CRBrowser;
     return new CDPSessionDispatcher(this._scope, await crBrowser.newBrowserCDPSession());
   }

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -106,6 +106,7 @@ export abstract class BrowserTypeBase implements BrowserType {
     if ((options as any).__testHookBeforeCreateBrowser)
       await (options as any).__testHookBeforeCreateBrowser();
     const browserOptions: BrowserOptions = {
+      name: this._name,
       slowMo: options.slowMo,
       persistent,
       headful: !options.headless,
@@ -142,7 +143,7 @@ export abstract class BrowserTypeBase implements BrowserType {
       progress.cleanupWhenAborted(() => transport.closeAndWait());
       if ((options as any).__testHookBeforeCreateBrowser)
         await (options as any).__testHookBeforeCreateBrowser();
-      const browser = await this._connectToTransport(transport, { slowMo: options.slowMo, loggers });
+      const browser = await this._connectToTransport(transport, { name: this._name, slowMo: options.slowMo, loggers });
       return browser;
     }, loggers.browser, TimeoutSettings.timeout(options), 'browserType.connect');
   }

--- a/src/server/electron.ts
+++ b/src/server/electron.ts
@@ -202,7 +202,7 @@ export class Electron  {
       const chromeMatch = await waitForLine(progress, launchedProcess, launchedProcess.stderr, /^DevTools listening on (ws:\/\/.*)$/);
       const chromeTransport = await WebSocketTransport.connect(progress, chromeMatch[1]);
       const browserServer = new BrowserServer(launchedProcess, gracefullyClose, kill);
-      const browser = await CRBrowser.connect(chromeTransport, { headful: true, loggers, persistent: { viewport: null }, ownedServer: browserServer });
+      const browser = await CRBrowser.connect(chromeTransport, { name: 'electron', headful: true, loggers, persistent: { viewport: null }, ownedServer: browserServer });
       app = new ElectronApplication(loggers, browser, nodeConnection);
       await app._init();
       return app;

--- a/test/chromium/chromium.spec.js
+++ b/test/chromium/chromium.spec.js
@@ -16,7 +16,7 @@
 
 const {FFOX, CHROMIUM, WEBKIT, CHANNEL} = require('../utils').testOptions(browserType);
 
-describe.skip(CHANNEL)('ChromiumBrowserContext', function() {
+describe('ChromiumBrowserContext', function() {
   it('should create a worker from a service worker', async({browser, page, server, context}) => {
     const [worker] = await Promise.all([
       context.waitForEvent('serviceworker'),
@@ -49,6 +49,19 @@ describe.skip(CHANNEL)('ChromiumBrowserContext', function() {
       new SharedWorker('data:text/javascript,console.log("hi")');
     });
     expect(serviceWorkerCreated).not.toBeTruthy();
+  });
+  it('should close service worker together with the context', async({browser, server}) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const [worker] = await Promise.all([
+      context.waitForEvent('serviceworker'),
+      page.goto(server.PREFIX + '/serviceworkers/empty/sw.html')
+    ]);
+    const messages = [];
+    context.on('close', () => messages.push('context'));
+    worker.on('close', () => messages.push('worker'));
+    await context.close();
+    expect(messages.join('|')).toBe('worker|context');
   });
 });
 

--- a/test/chromium/launcher.spec.js
+++ b/test/chromium/launcher.spec.js
@@ -19,7 +19,7 @@ const utils = require('../utils');
 const {makeUserDataDir, removeUserDataDir} = utils;
 const {FFOX, CHROMIUM, WEBKIT, WIN, CHANNEL} = utils.testOptions(browserType);
 
-describe.skip(CHANNEL)('launcher', function() {
+describe('launcher', function() {
   it('should throw with remote-debugging-pipe argument', async({browserType, defaultBrowserOptions}) => {
     const options = Object.assign({}, defaultBrowserOptions);
     options.args = ['--remote-debugging-pipe'].concat(options.args || []);
@@ -49,7 +49,7 @@ describe.skip(CHANNEL)('launcher', function() {
   });
 });
 
-describe.skip(CHANNEL)('extensions', () => {
+describe('extensions', () => {
   it('should return background pages', async({browserType, defaultBrowserOptions}) => {
     const userDataDir = await makeUserDataDir();
     const extensionPath = path.join(__dirname, '..', 'assets', 'simple-extension');
@@ -73,7 +73,7 @@ describe.skip(CHANNEL)('extensions', () => {
   });
 });
 
-describe.skip(CHANNEL)('BrowserContext', function() {
+describe('BrowserContext', function() {
   it('should not create pages automatically', async ({browserType, defaultBrowserOptions}) => {
     const browser = await browserType.launch(defaultBrowserOptions);
     const browserSession = await browser.newBrowserCDPSession();

--- a/test/chromium/oopif.spec.js
+++ b/test/chromium/oopif.spec.js
@@ -16,7 +16,7 @@
 
 const {FFOX, CHROMIUM, WEBKIT, CHANNEL} = require('../utils').testOptions(browserType);
 
-describe.skip(CHANNEL)('OOPIF', function() {
+describe('OOPIF', function() {
   beforeAll(async function(state) {
     state.browser = await state.browserType.launch(Object.assign({}, state.defaultBrowserOptions, {
       args: (state.defaultBrowserOptions.args || []).concat(['--site-per-process']),

--- a/test/chromium/session.spec.js
+++ b/test/chromium/session.spec.js
@@ -16,7 +16,7 @@
 
 const {FFOX, CHROMIUM, WEBKIT, CHANNEL} = require('../utils').testOptions(browserType);
 
-describe.skip(CHANNEL)('ChromiumBrowserContext.createSession', function() {
+describe('ChromiumBrowserContext.createSession', function() {
   it('should work', async function({page, browser, server}) {
     const client = await page.context().newCDPSession(page);
 
@@ -35,7 +35,7 @@ describe.skip(CHANNEL)('ChromiumBrowserContext.createSession', function() {
     await page.goto(server.EMPTY_PAGE);
     expect(events.length).toBe(1);
   });
-  it('should enable and disable domains independently', async function({page, browser, server}) {
+  it.skip(CHANNEL)('should enable and disable domains independently', async function({page, browser, server}) {
     const client = await page.context().newCDPSession(page);
     await client.send('Runtime.enable');
     await client.send('Debugger.enable');
@@ -64,7 +64,7 @@ describe.skip(CHANNEL)('ChromiumBrowserContext.createSession', function() {
     } catch (e) {
       error = e;
     }
-    expect(error.message).toContain('Session closed.');
+    expect(error.message).toContain(CHANNEL ? 'Target browser or context has been closed' : 'Session closed.');
   });
   it('should throw nice errors', async function({page, browser}) {
     const client = await page.context().newCDPSession(page);


### PR DESCRIPTION
This includes page CDPSession, backgroundPages() and serviceWorkers().

This has also revealed an issue with closing order between the context and the service worker.