### PR TITLE
feat(rpc): move per-operation logging to the client

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -23,7 +23,7 @@ import * as js from './javascript';
 import { Page } from './page';
 import { selectors, SelectorInfo } from './selectors';
 import * as types from './types';
-import { Progress } from './progress';
+import { Progress, kProgressLoggerSink } from './progress';
 import DebugScript from './debug/injected/debugScript';
 import { FatalDOMError, RetargetableDOMError } from './common/domErrors';
 import { normalizeFilePayloads } from './rpc/serializers';
@@ -223,7 +223,8 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async scrollIntoViewIfNeeded(options: types.TimeoutOptions = {}) {
     return this._page._runAbortableTask(
         progress => this._waitAndScrollIntoViewIfNeeded(progress),
-        this._page._timeoutSettings.timeout(options), 'elementHandle.scrollIntoViewIfNeeded');
+        this._page._timeoutSettings.timeout(options), 'elementHandle.scrollIntoViewIfNeeded',
+        (options as any)[kProgressLoggerSink]);
   }
 
   private async _waitForVisible(progress: Progress): Promise<'error:notconnected' | 'done'> {
@@ -375,7 +376,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._hover(progress, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.hover');
+    }, this._page._timeoutSettings.timeout(options), 'elementHandle.hover', (options as any)[kProgressLoggerSink]);
   }
 
   _hover(progress: Progress, options: types.PointerActionOptions & types.PointerActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -386,7 +387,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._click(progress, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.click');
+    }, this._page._timeoutSettings.timeout(options), 'elementHandle.click', (options as any)[kProgressLoggerSink]);
   }
 
   _click(progress: Progress, options: types.MouseClickOptions & types.PointerActionWaitOptions & types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -397,7 +398,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._dblclick(progress, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.dblclick');
+    }, this._page._timeoutSettings.timeout(options), 'elementHandle.dblclick', (options as any)[kProgressLoggerSink]);
   }
 
   _dblclick(progress: Progress, options: types.MouseMultiClickOptions & types.PointerActionWaitOptions & types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -408,7 +409,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._selectOption(progress, values, options);
       return throwRetargetableDOMError(result);
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.selectOption');
+    }, this._page._timeoutSettings.timeout(options), 'elementHandle.selectOption', (options as any)[kProgressLoggerSink]);
   }
 
   async _selectOption(progress: Progress, values: string | ElementHandle | types.SelectOption | string[] | ElementHandle[] | types.SelectOption[] | null, options: types.NavigatingActionWaitOptions): Promise<string[] | 'error:notconnected'> {
@@ -441,7 +442,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._fill(progress, value, options);
       assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.fill');
+    }, this._page._timeoutSettings.timeout(options), 'elementHandle.fill', (options as any)[kProgressLoggerSink]);
   }
 
   async _fill(progress: Progress, value: string, options: types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -480,14 +481,14 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       const pollHandler = new InjectedScriptPollHandler(progress, poll);
       const result = throwFatalDOMError(await pollHandler.finish());
       assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.selectText');
+    }, this._page._timeoutSettings.timeout(options), 'elementHandle.selectText', (options as any)[kProgressLoggerSink]);
   }
 
   async setInputFiles(files: string | types.FilePayload | string[] | types.FilePayload[], options: types.NavigatingActionWaitOptions = {}) {
     return this._page._runAbortableTask(async progress => {
       const result = await this._setInputFiles(progress, files, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.setInputFiles');
+    }, this._page._timeoutSettings.timeout(options), 'elementHandle.setInputFiles', (options as any)[kProgressLoggerSink]);
   }
 
   async _setInputFiles(progress: Progress, files: string | types.FilePayload | string[] | types.FilePayload[], options: types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -527,7 +528,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._type(progress, text, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.type');
+    }, this._page._timeoutSettings.timeout(options), 'elementHandle.type', (options as any)[kProgressLoggerSink]);
   }
 
   async _type(progress: Progress, text: string, options: { delay?: number } & types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -546,7 +547,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._press(progress, key, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.press');
+    }, this._page._timeoutSettings.timeout(options), 'elementHandle.press', (options as any)[kProgressLoggerSink]);
   }
 
   async _press(progress: Progress, key: string, options: { delay?: number } & types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -565,14 +566,14 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._setChecked(progress, true, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.check');
+    }, this._page._timeoutSettings.timeout(options), 'elementHandle.check', (options as any)[kProgressLoggerSink]);
   }
 
   async uncheck(options: types.PointerActionWaitOptions & types.NavigatingActionWaitOptions = {}) {
     return this._page._runAbortableTask(async progress => {
       const result = await this._setChecked(progress, false, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.uncheck');
+    }, this._page._timeoutSettings.timeout(options), 'elementHandle.uncheck', (options as any)[kProgressLoggerSink]);
   }
 
   async _setChecked(progress: Progress, state: boolean, options: types.PointerActionWaitOptions & types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -593,7 +594,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async screenshot(options: types.ElementScreenshotOptions = {}): Promise<Buffer> {
     return this._page._runAbortableTask(
         progress => this._page._screenshotter.screenshotElement(progress, this, options),
-        this._page._timeoutSettings.timeout(options), 'elementHandle.screenshot');
+        this._page._timeoutSettings.timeout(options), 'elementHandle.screenshot', (options as any)[kProgressLoggerSink]);
   }
 
   async $(selector: string): Promise<ElementHandle | null> {

--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -23,6 +23,16 @@ export interface Channel extends EventEmitter {
 }
 
 
+export type LogMessage = {
+  commandId: number,
+  name: string,
+  severity: string,
+  message: string | types.Error,
+  args: any[],
+  hints: { color?: string },
+};
+
+
 export interface PlaywrightChannel extends Channel {
 }
 export type PlaywrightInitializer = {

--- a/src/rpc/client/channelOwner.ts
+++ b/src/rpc/client/channelOwner.ts
@@ -41,9 +41,9 @@ export abstract class ChannelOwner<T extends Channel, Initializer> extends Event
           return obj.on;
         if (prop === 'once')
           return obj.once;
-        if (prop === 'addEventListener')
+        if (prop === 'addListener')
           return obj.addListener;
-        if (prop === 'removeEventListener')
+        if (prop === 'removeListener')
           return obj.removeListener;
         return (params: any) => scope.sendMessageToServer({ guid, method: String(prop), params });
       },

--- a/src/rpc/serializers.ts
+++ b/src/rpc/serializers.ts
@@ -42,6 +42,10 @@ export function parseError(error: types.Error): any {
   return e;
 }
 
+export function parseErrorToString(error: types.Error): string {
+  return (error.message || '') + (error.stack || '');
+}
+
 export async function normalizeFilePayloads(files: string | types.FilePayload | string[] | types.FilePayload[]): Promise<types.FilePayload[]> {
   let ff: string[] | types.FilePayload[];
   if (!Array.isArray(files))

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -28,7 +28,7 @@ import { assert, helper } from '../helper';
 import { launchProcess, Env, waitForLine } from './processLauncher';
 import { Events } from '../events';
 import { PipeTransport } from './pipeTransport';
-import { Progress, runAbortableTask } from '../progress';
+import { Progress, runAbortableTask, kProgressLoggerSink } from '../progress';
 import * as types from '../types';
 import { TimeoutSettings } from '../timeoutSettings';
 import { WebSocketServer } from './webSocketServer';
@@ -87,7 +87,7 @@ export abstract class BrowserTypeBase implements BrowserType {
     assert(!(options as any).port, 'Cannot specify a port without launching as a server.');
     options = validateLaunchOptions(options);
     const loggers = new Loggers(options.logger);
-    const browser = await runAbortableTask(progress => this._innerLaunch(progress, options, loggers, undefined), loggers.browser, TimeoutSettings.timeout(options), `browserType.launch`);
+    const browser = await runAbortableTask(progress => this._innerLaunch(progress, options, loggers, undefined), loggers.browser, TimeoutSettings.timeout(options), `browserType.launch`, (options as any)[kProgressLoggerSink]);
     return browser;
   }
 
@@ -96,7 +96,7 @@ export abstract class BrowserTypeBase implements BrowserType {
     options = validateLaunchOptions(options);
     const persistent = validateBrowserContextOptions(options);
     const loggers = new Loggers(options.logger);
-    const browser = await runAbortableTask(progress => this._innerLaunch(progress, options, loggers, persistent, userDataDir), loggers.browser, TimeoutSettings.timeout(options), 'browserType.launchPersistentContext');
+    const browser = await runAbortableTask(progress => this._innerLaunch(progress, options, loggers, persistent, userDataDir), loggers.browser, TimeoutSettings.timeout(options), 'browserType.launchPersistentContext', (options as any)[kProgressLoggerSink]);
     return browser._defaultContext!;
   }
 
@@ -132,7 +132,7 @@ export abstract class BrowserTypeBase implements BrowserType {
       const { browserServer, transport } = await this._launchServer(progress, options, false, loggers);
       browserServer._webSocketServer = this._startWebSocketServer(transport, loggers.browser, port);
       return browserServer;
-    }, loggers.browser, TimeoutSettings.timeout(options), 'browserType.launchServer');
+    }, loggers.browser, TimeoutSettings.timeout(options), 'browserType.launchServer', (options as any)[kProgressLoggerSink]);
   }
 
   async connect(options: ConnectOptions): Promise<Browser> {
@@ -144,7 +144,7 @@ export abstract class BrowserTypeBase implements BrowserType {
         await (options as any).__testHookBeforeCreateBrowser();
       const browser = await this._connectToTransport(transport, { slowMo: options.slowMo, loggers });
       return browser;
-    }, loggers.browser, TimeoutSettings.timeout(options), 'browserType.connect');
+    }, loggers.browser, TimeoutSettings.timeout(options), 'browserType.connect', (options as any)[kProgressLoggerSink]);
   }
 
   private async _launchServer(progress: Progress, options: LaunchServerOptions, isPersistent: boolean, loggers: Loggers, userDataDir?: string): Promise<{ browserServer: BrowserServer, downloadsPath: string, transport: ConnectionTransport }> {

--- a/src/server/electron.ts
+++ b/src/server/electron.ts
@@ -29,7 +29,7 @@ import { BrowserServer } from './browserServer';
 import { launchProcess, waitForLine } from './processLauncher';
 import { BrowserContext } from '../browserContext';
 import type {BrowserWindow} from 'electron';
-import { runAbortableTask, ProgressController } from '../progress';
+import { runAbortableTask, ProgressController, kProgressLoggerSink } from '../progress';
 import { EventEmitter } from 'events';
 import { helper } from '../helper';
 import { LoggerSink } from '../loggerSink';
@@ -206,6 +206,6 @@ export class Electron  {
       app = new ElectronApplication(loggers, browser, nodeConnection);
       await app._init();
       return app;
-    }, loggers.browser, TimeoutSettings.timeout(options), 'electron.launch');
+    }, loggers.browser, TimeoutSettings.timeout(options), 'electron.launch', (options as any)[kProgressLoggerSink]);
   }
 }

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -104,11 +104,11 @@ describe('BrowserContext', function() {
   });
   it('should not allow deviceScaleFactor with null viewport', async({ browser }) => {
     const error = await browser.newContext({ viewport: null, deviceScaleFactor: 1 }).catch(e => e);
-    expect(error.message).toBe('"deviceScaleFactor" option is not supported with null "viewport"');
+    expect(error.message).toContain('"deviceScaleFactor" option is not supported with null "viewport"');
   });
   it('should not allow isMobile with null viewport', async({ browser }) => {
     const error = await browser.newContext({ viewport: null, isMobile: true }).catch(e => e);
-    expect(error.message).toBe('"isMobile" option is not supported with null "viewport"');
+    expect(error.message).toContain('"isMobile" option is not supported with null "viewport"');
   });
   it('close() should work for empty context', async({ browser }) => {
     const context = await browser.newContext();

--- a/test/cookies.spec.js
+++ b/test/cookies.spec.js
@@ -369,7 +369,7 @@ describe('BrowserContext.addCookies', function() {
     } catch (e) {
       error = e;
     }
-    expect(error.message).toEqual(
+    expect(error.message).toContain(
         `Blank page can not have cookie "example-cookie-blank"`
     );
   });

--- a/test/emulation.spec.js
+++ b/test/emulation.spec.js
@@ -237,7 +237,7 @@ describe('Page.emulateMedia type', function() {
   it('should throw in case of bad type argument', async({page, server}) => {
     let error = null;
     await page.emulateMedia({ media: 'bad' }).catch(e => error = e);
-    expect(error.message).toBe('Unsupported media: bad');
+    expect(error.message).toContain('Unsupported media: bad');
   });
 });
 
@@ -265,7 +265,7 @@ describe('Page.emulateMedia colorScheme', function() {
   it('should throw in case of bad argument', async({page, server}) => {
     let error = null;
     await page.emulateMedia({ colorScheme: 'bad' }).catch(e => error = e);
-    expect(error.message).toBe('Unsupported color scheme: bad');
+    expect(error.message).toContain('Unsupported color scheme: bad');
   });
   it('should work during navigation', async({page, server}) => {
     await page.emulateMedia({ colorScheme: 'light' });
@@ -348,7 +348,7 @@ describe('BrowserContext({timezoneId})', function() {
       let error = null;
       const context = await browser.newContext({ timezoneId });
       const page = await context.newPage().catch(e => error = e);
-      expect(error.message).toBe(`Invalid timezone ID: ${timezoneId}`);
+      expect(error.message).toContain(`Invalid timezone ID: ${timezoneId}`);
       await context.close();
     }
   });

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -611,7 +611,7 @@ describe('Frame.evaluate', function() {
     const childResult = await childFrame.evaluate(() => window.__foo);
     expect(childResult).toEqual({ bar: 'baz' });
     const error = await childFrame.evaluate(foo => foo.bar, handle).catch(e => e);
-    expect(error.message).toBe('JSHandles can be evaluated only in the context they were created!');
+    expect(error.message).toContain('JSHandles can be evaluated only in the context they were created!');
   });
   it('should allow cross-frame element handles', async({page, server}) => {
     await page.goto(server.PREFIX + '/frames/one-frame.html');

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -53,7 +53,7 @@ describe('Frame.frameElement', function() {
     const frame1 = await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
     await page.$eval('#frame1', e => e.remove());
     const error = await frame1.frameElement().catch(e => e);
-    expect(error.message).toBe('Frame has been detached.');
+    expect(error.message).toContain('Frame has been detached.');
   });
 });
 

--- a/test/keyboard.spec.ts
+++ b/test/keyboard.spec.ts
@@ -268,13 +268,13 @@ describe('Keyboard', function() {
   });
   it('should throw on unknown keys', async ({page, server}) => {
     let error = await page.keyboard.press('NotARealKey').catch(e => e);
-    expect(error.message).toBe('Unknown key: "NotARealKey"');
+    expect(error.message).toContain('Unknown key: "NotARealKey"');
 
     error = await page.keyboard.press('ё').catch(e => e);
-    expect(error && error.message).toBe('Unknown key: "ё"');
+    expect(error && error.message).toContain('Unknown key: "ё"');
 
     error = await page.keyboard.press('😊').catch(e => e);
-    expect(error && error.message).toBe('Unknown key: "😊"');
+    expect(error && error.message).toContain('Unknown key: "😊"');
   });
   it('should type emoji', async ({page, server}) => {
     await page.goto(server.PREFIX + '/input/textarea.html');

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -458,6 +458,6 @@ describe('Page.setExtraHTTPHeaders', function() {
     } catch (e) {
       error = e;
     }
-    expect(error.message).toBe('Expected value of header "foo" to be String, but "number" is found.');
+    expect(error.message).toContain('Expected value of header "foo" to be String, but "number" is found.');
   });
 });

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -707,7 +707,7 @@ describe('Page.addScriptTag', function() {
     } catch (e) {
       error = e;
     }
-    expect(error.message).toBe('Provide an object with a `url`, `path` or `content` property');
+    expect(error.message).toContain('Provide an object with a `url`, `path` or `content` property');
   });
 
   it('should work with a url', async({page, server}) => {
@@ -799,7 +799,7 @@ describe('Page.addStyleTag', function() {
     } catch (e) {
       error = e;
     }
-    expect(error.message).toBe('Provide an object with a `url`, `path` or `content` property');
+    expect(error.message).toContain('Provide an object with a `url`, `path` or `content` property');
   });
 
   it('should work with a url', async({page, server}) => {

--- a/test/permissions.spec.js
+++ b/test/permissions.spec.js
@@ -36,7 +36,7 @@ describe.skip(WEBKIT)('Permissions', function() {
     await page.goto(server.EMPTY_PAGE);
     let error = {};
     await context.grantPermissions(['foo'], { origin: server.EMPTY_PAGE }).catch(e => error = e);
-    expect(error.message).toBe('Unknown permission: foo');
+    expect(error.message).toContain('Unknown permission: foo');
   });
   it('should grant geolocation permission when listed', async({page, server, context}) => {
     await page.goto(server.EMPTY_PAGE);

--- a/test/queryselector.spec.js
+++ b/test/queryselector.spec.js
@@ -120,11 +120,11 @@ describe('Page.$eval', function() {
   });
   it('should throw on multiple * captures', async({page, server}) => {
     const error = await page.$eval('*css=div >> *css=span', e => e.outerHTML).catch(e => e);
-    expect(error.message).toBe('Only one of the selectors can capture using * modifier');
+    expect(error.message).toContain('Only one of the selectors can capture using * modifier');
   });
   it('should throw on malformed * capture', async({page, server}) => {
     const error = await page.$eval('*=div', e => e.outerHTML).catch(e => e);
-    expect(error.message).toBe('Unknown engine "" while parsing selector *=div');
+    expect(error.message).toContain('Unknown engine "" while parsing selector *=div');
   });
   it('should work with spaces in css attributes', async({page, server}) => {
     await page.setContent('<div><input placeholder="Select date"></div>');
@@ -368,7 +368,7 @@ describe('ElementHandle.$eval', function() {
     await page.setContent(htmlContent);
     const elementHandle = await page.$('#myId');
     const errorMessage = await elementHandle.$eval('.a', node => node.innerText).catch(error => error.message);
-    expect(errorMessage).toBe(`Error: failed to find element matching selector ".a"`);
+    expect(errorMessage).toContain(`Error: failed to find element matching selector ".a"`);
   });
 });
 describe('ElementHandle.$$eval', function() {
@@ -805,7 +805,7 @@ describe('selectors.register', () => {
   });
   it('should handle errors', async ({page}) => {
     let error = await page.$('neverregister=ignored').catch(e => e);
-    expect(error.message).toBe('Unknown engine "neverregister" while parsing selector neverregister=ignored');
+    expect(error.message).toContain('Unknown engine "neverregister" while parsing selector neverregister=ignored');
 
     const createDummySelector = () => ({
       create(root, target) {
@@ -820,16 +820,16 @@ describe('selectors.register', () => {
     });
 
     error = await playwright.selectors.register('$', createDummySelector).catch(e => e);
-    expect(error.message).toBe('Selector engine name may only contain [a-zA-Z0-9_] characters');
+    expect(error.message).toContain('Selector engine name may only contain [a-zA-Z0-9_] characters');
 
     // Selector names are case-sensitive.
     await utils.registerEngine('dummy', createDummySelector);
     await utils.registerEngine('duMMy', createDummySelector);
 
     error = await playwright.selectors.register('dummy', createDummySelector).catch(e => e);
-    expect(error.message).toBe('"dummy" selector engine has been already registered');
+    expect(error.message).toContain('"dummy" selector engine has been already registered');
 
     error = await playwright.selectors.register('css', createDummySelector).catch(e => e);
-    expect(error.message).toBe('"css" is a predefined selector engine');
+    expect(error.message).toContain('"css" is a predefined selector engine');
   });
 });

--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -74,7 +74,7 @@ describe('Frame.waitForFunction', function() {
   });
   it('should throw on polling:mutation', async({page, server}) => {
     const error = await page.waitForFunction(() => true, {}, {polling: 'mutation'}).catch(e => e);
-    expect(error.message).toBe('Unknown polling option: mutation');
+    expect(error.message).toContain('Unknown polling option: mutation');
   });
   it('should poll on raf', async({page, server}) => {
     const watchdog = page.waitForFunction(() => window.__FOO === 'hit', {}, {polling: 'raf'});
@@ -203,7 +203,7 @@ describe('Frame.waitForSelector', function() {
     await page.goto(server.EMPTY_PAGE);
     let error;
     await page.waitForSelector('*', { waitFor: 'attached' }).catch(e => error = e);
-    expect(error.message).toBe('options.waitFor is not supported, did you mean options.state?');
+    expect(error.message).toContain('options.waitFor is not supported, did you mean options.state?');
   });
   it('should tolerate waitFor=visible', async({page, server}) => {
     await page.goto(server.EMPTY_PAGE);
@@ -471,7 +471,7 @@ describe('Frame.waitForSelector', function() {
   it('should throw for visibility option', async({page, server}) => {
     await page.setContent('<section>test</section>');
     const error = await page.waitForSelector('section', { visibility: 'hidden' }).catch(e => e);
-    expect(error.message).toBe('options.visibility is not supported, did you mean options.state?');
+    expect(error.message).toContain('options.visibility is not supported, did you mean options.state?');
   });
   it('should throw for true state option', async({page, server}) => {
     await page.setContent('<section>test</section>');


### PR DESCRIPTION
This introduces additional protocol message "log" that references
a command id, and delivers a log message related to the command.
Client now collects these logs to produce a nice error message.

Next change will also stream logs that are unrelated to any command,
most likely attributing them to page/browserContent/browser/browserType
if possible.

Many tests switched from `toBe` to `toContain` because we now add the
notice about using `pw:api` to any error.