### PR TITLE
fix(firefox): fix launching firefox without dependencies

### DIFF
--- a/src/server/processLauncher.ts
+++ b/src/server/processLauncher.ts
@@ -166,11 +166,12 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
 export function waitForLine(progress: Progress, process: childProcess.ChildProcess, inputStream: stream.Readable, regex: RegExp): Promise<RegExpMatchArray> {
   return new Promise((resolve, reject) => {
     const rl = readline.createInterface({ input: inputStream });
+    const failError = new Error('Process failed to launch!');
     const listeners = [
       helper.addEventListener(rl, 'line', onLine),
-      helper.addEventListener(rl, 'close', reject),
-      helper.addEventListener(process, 'exit', reject),
-      helper.addEventListener(process, 'error', reject)
+      helper.addEventListener(rl, 'close', reject.bind(null, failError)),
+      helper.addEventListener(process, 'exit', reject.bind(null, failError)),
+      helper.addEventListener(process, 'error', reject.bind(null, failError))
     ];
 
     progress.cleanupWhenAborted(cleanup);

--- a/test/assets/dummy_bad_browser_executable.js
+++ b/test/assets/dummy_bad_browser_executable.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+process.exit(1);

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -44,6 +44,12 @@ describe('Playwright', function() {
       await browserType.launch(options).catch(e => waitError = e);
       expect(waitError.message).toContain('can not specify page');
     });
+    it('should reject if launched browser fails immediately', async({browserType, defaultBrowserOptions}) => {
+      const options = Object.assign({}, defaultBrowserOptions, {executablePath: path.join(__dirname, 'assets', 'dummy_bad_browser_executable.js')});
+      let waitError = null;
+      await browserType.launch(options).catch(e => waitError = e);
+      expect(waitError.message).toContain('browserType.launch logs');
+    });
     it('should reject if executable path is invalid', async({browserType, defaultBrowserOptions}) => {
       let waitError = null;
       const options = Object.assign({}, defaultBrowserOptions, {executablePath: 'random-invalid-path'});


### PR DESCRIPTION
We always have to reject promises with some error. Otherwise,
our error-rewriting logic in try-catch miserably fails.

With this patch, attempt to launch Firefox when it's missing
dependencies will actually result in a thrown exception with
pretty logs. Without this patch, Playwright throws internal error.