### PR TITLE
fix(accessibility): don't filter everything when the page has a title

### DIFF
--- a/src/chromium/crAccessibility.ts
+++ b/src/chromium/crAccessibility.ts
@@ -145,7 +145,7 @@ class CRAXNode implements accessibility.AXNode {
     // Here and below: Android heuristics
     if (this._hasFocusableChild())
       return false;
-    if (this._focusable && this._name)
+    if (this._focusable && this._role !== 'WebArea' && this._name)
       return true;
     if (this._role === 'heading' && this._name)
       return true;

--- a/src/firefox/ffAccessibility.ts
+++ b/src/firefox/ffAccessibility.ts
@@ -148,7 +148,7 @@ class FFAXNode implements accessibility.AXNode {
     // Here and below: Android heuristics
     if (this._hasFocusableChild())
       return false;
-    if (this._focusable && this._name)
+    if (this._focusable && this._role !== 'document' && this._name)
       return true;
     if (this._role === 'heading' && this._name)
       return true;

--- a/test/accessibility.jest.js
+++ b/test/accessibility.jest.js
@@ -347,4 +347,13 @@ describe('Accessibility', function() {
       });
     });
   });
+  it('should work when there is a title ', async ({page}) => {
+    await page.setContent(`
+      <title>This is the title</title>
+      <div>This is the content</div>
+    `);
+    const snapshot = await page.accessibility.snapshot();
+    expect(snapshot.name).toBe('This is the title');
+    expect(snapshot.children[0].name).toBe('This is the content');
+  });
 });


### PR DESCRIPTION
When the page had a title, but it had no focusable descendants, we incorrectly considered it an atomic control and filtered all of its descendants.