### PR TITLE
devops: add utility to count compressed docker image size

### DIFF
--- a/docs/docker/CURRENT_DOCKER_IMAGE_SIZE
+++ b/docs/docker/CURRENT_DOCKER_IMAGE_SIZE
@@ -1,0 +1,2 @@
+(generated with docker-image-size.sh)
+224M

--- a/docs/docker/docker-image-size.sh
+++ b/docs/docker/docker-image-size.sh
@@ -7,15 +7,6 @@ set +x
 
 DOCKER_IMAGE_NAME="docker-image-to-count-compressed-size"
 FILE_NAME="docker-image-to-count-compressed-size"
-RUN_AS=""
-if [[ "$(uname)" == "Darwin" ]]; then
-  RUN_AS=""
-elif [[ "$(uname)" == "Linux" ]]; then
-  RUN_AS="sudo"
-else
-  echo "ERROR: cannot run script on platform $(uname)"
-  exit 1;
-fi
 
 function cleanup() {
   echo "-- Removing .tar if any"
@@ -23,16 +14,16 @@ function cleanup() {
   echo "-- Removing .tar.gz if any"
   rm -f "${FILE_NAME}.tar.gz"
   echo "-- Removing docker image if any"
-  $RUN_AS docker rmi "${DOCKER_IMAGE_NAME}:bionic" >/dev/null
+  docker rmi "${DOCKER_IMAGE_NAME}:bionic" >/dev/null
 }
 
 trap "cleanup; cd $(pwd -P)" EXIT
 cd "$(dirname "$0")"
 
 echo "-- Building image..."
-$RUN_AS docker build -t "${DOCKER_IMAGE_NAME}:bionic" -f Dockerfile.bionic . >/dev/null
+docker build -t "${DOCKER_IMAGE_NAME}:bionic" -f Dockerfile.bionic . >/dev/null
 echo "-- Saving .tar of the image..."
-$RUN_AS docker save "${DOCKER_IMAGE_NAME}:bionic" > "${FILE_NAME}.tar"
+docker save "${DOCKER_IMAGE_NAME}:bionic" > "${FILE_NAME}.tar"
 echo "-- Compressing image..."
 gzip "${FILE_NAME}.tar" >/dev/null
 du -sh ${FILE_NAME}.tar.gz

--- a/docs/docker/docker-image-size.sh
+++ b/docs/docker/docker-image-size.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+set +x
+
+# This script computes **compressed image size with all its layers**.
+# This solution is based on https://stackoverflow.com/a/55156181/314883
+
+DOCKER_IMAGE_NAME="docker-image-to-count-compressed-size"
+FILE_NAME="docker-image-to-count-compressed-size"
+RUN_AS=""
+if [[ "$(uname)" == "Darwin" ]]; then
+  RUN_AS=""
+elif [[ "$(uname)" == "Linux" ]]; then
+  RUN_AS="sudo"
+else
+  echo "ERROR: cannot run script on platform $(uname)"
+  exit 1;
+fi
+
+function cleanup() {
+  echo "-- Removing .tar if any"
+  rm -f "${FILE_NAME}.tar"
+  echo "-- Removing .tar.gz if any"
+  rm -f "${FILE_NAME}.tar.gz"
+  echo "-- Removing docker image if any"
+  $RUN_AS docker rmi "${DOCKER_IMAGE_NAME}:bionic" >/dev/null
+}
+
+trap "cleanup; cd $(pwd -P)" EXIT
+cd "$(dirname "$0")"
+
+echo "-- Building image..."
+$RUN_AS docker build -t "${DOCKER_IMAGE_NAME}:bionic" -f Dockerfile.bionic . >/dev/null
+echo "-- Saving .tar of the image..."
+$RUN_AS docker save "${DOCKER_IMAGE_NAME}:bionic" > "${FILE_NAME}.tar"
+echo "-- Compressing image..."
+gzip "${FILE_NAME}.tar" >/dev/null
+du -sh ${FILE_NAME}.tar.gz

--- a/docs/docker/docker-image-size.sh
+++ b/docs/docker/docker-image-size.sh
@@ -26,4 +26,7 @@ echo "-- Saving .tar of the image..."
 docker save "${DOCKER_IMAGE_NAME}:bionic" > "${FILE_NAME}.tar"
 echo "-- Compressing image..."
 gzip "${FILE_NAME}.tar" >/dev/null
-du -sh ${FILE_NAME}.tar.gz
+
+echo "(generated with docker-image-size.sh)" > CURRENT_DOCKER_IMAGE_SIZE
+du -sh ${FILE_NAME}.tar.gz | cut -f1 | xargs >> CURRENT_DOCKER_IMAGE_SIZE
+


### PR DESCRIPTION
This adds a new script to calculate docker image size with
all parent layers.

Note: take this metrics with a grain of salt, since in reality
docker compresses and reuses layers.

Some historic stats obtained with this script:
- **`208MB`** (-33MB) chore(docker): skip "recommended" dependencies (#2917) (1cebf8757c35cebb91c27d16e6b0aa1fcae42fcb)
- **`241MB`** (-29MB) chore(docker): trim some of the gstreamer dependencies (#2897) (bce4b1aea95790ebc1f592c44acdea1a1e709fac)
- **`272MB`** (-1MB) devops: do cache busting for APT (#2656) (bb3441809541cc6609c5444063973c4ab922981b)
- **`273MB`** (+49MB) fix(webkit): update Docker file to include gstreamer (#2636) (5c6c65915c47b8d2f71f5fa75821460183530414)
- **`224MB`** (+0MB) chore: fix emojis for CR and FF in Dockerfile (#2522) (24316ad261ca081b6d77dd2f655a42b4836a622b)
- **`224MB`** (-1MB) fix: Dockerfile for Firefox (#1937) (b516ac4fb233d30964930d830dea7832a9aae031)
- **`225MB`** (+49MB) devops(docker): Install ffmpeg dependency, adding codecs necessary for video playback in Firefox (#1627) (222d01caaadad7419c4e54b4f36a6e9d41d8dc65)
-  **`176MB`** (+32MB) chore(docs): optionally install XVFB in docker(ec3ee660430336d47a309553981eb960e49c2ede)
-  **`144MB`** (+144MB)  feat: add a playwright-ready docker image (#1161)(1781ae7006554eb77ed42bf90be70ef637fd1aae)