### PR TITLE
devops: automate Docker image publishing

### DIFF
--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -26,4 +26,14 @@ jobs:
     - run: utils/publish_all_packages.sh --tip-of-tree
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: playwright.azurecr.io
+        repository: microsoft/playwright
+        path: docs/docker/
+        dockerfile: docs/docker/Dockerfile.bionic
+        tags: dev
+        tag_with_sha: true
 

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -23,4 +23,13 @@ jobs:
     - run: utils/publish_all_packages.sh --release
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+    - uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: playwright.azurecr.io
+        repository: microsoft/playwright
+        path: docs/docker/
+        dockerfile: docs/docker/Dockerfile.bionic
+        tags: bionic,latest
+        tag_with_ref: true


### PR DESCRIPTION
This starts publishing our Docker images using Github Actions:
- on every commit, a new image will be pushed, tagged with a SHA of the
  commit, e.g.
  `mcr.microsoft.com/playwright:sha-fe997eca88d6de48378b05133dadfe032bd8b0ea`
- on every release, a new image will be pushed, tagged with the release
  version, e.g. `mcr.microsoft.com/playwright:v1.2.1`

**Note:** today we don't version our images and instead push them all as
`bionic`. This patch retains the tag - along with `latest`. Both
`bionic` and `latest` tags will point to the latest release.

References #2926