### PR TITLE
devops: fix docker publishing

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -1,0 +1,27 @@
+name: "devrelease"
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+    paths:
+      - docs/docker/**
+
+jobs:
+  publish-canary-docker:
+    name: "publish to DockerHub"
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/build-push-action@v1
+      with:
+        username: playwright
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: playwright.azurecr.io
+        repository: public/playwright
+        path: docs/docker/
+        dockerfile: docs/docker/Dockerfile.bionic
+        tags: dev
+        tag_with_sha: true
+

--- a/.github/workflows/publish_canary_npm.yml
+++ b/.github/workflows/publish_canary_npm.yml
@@ -1,4 +1,4 @@
-name: "canary"
+name: "devrelease"
 
 on:
   push:
@@ -10,8 +10,8 @@ env:
   CI: true
 
 jobs:
-  publish-canary:
-    name: "publish"
+  publish-canary-npm:
+    name: "publish to NPM"
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -26,14 +26,4 @@ jobs:
     - run: utils/publish_all_packages.sh --tip-of-tree
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - uses: docker/build-push-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        registry: playwright.azurecr.io
-        repository: microsoft/playwright
-        path: docs/docker/
-        dockerfile: docs/docker/Dockerfile.bionic
-        tags: dev
-        tag_with_sha: true
 

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -8,8 +8,8 @@ env:
   CI: true
 
 jobs:
-  publish-canary:
-    name: "publish"
+  publish-npm-release:
+    name: "publish to NPM"
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -23,12 +23,18 @@ jobs:
     - run: utils/publish_all_packages.sh --release
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-docker-release:
+    name: "publish to DockerHub"
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
     - uses: docker/build-push-action@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
+        username: playwright
         password: ${{ secrets.DOCKER_PASSWORD }}
         registry: playwright.azurecr.io
-        repository: microsoft/playwright
+        repository: public/playwright
         path: docs/docker/
         dockerfile: docs/docker/Dockerfile.bionic
         tags: bionic,latest


### PR DESCRIPTION
devops: fix docker publishing

- Repository name has to start with `public/` to be exported to dockerhub.
- Remove `DOCKER_USERNAME` to avoid unnecessary masking in our logs.
- Publish dev versions of Docker image only when changes to docker filehappen. (this is why NPM publishing and Docker publishing for dev releases are now separate).
- Release publishing in two separate jobs to make them independent.

References #2926