### PR TITLE
feat(rpc): implement waitForNavigation on the client

### DIFF
--- a/src/frames.ts
+++ b/src/frames.ts
@@ -53,8 +53,16 @@ type ConsoleTagHandler = () => void;
 export type FunctionWithSource = (source: { context: BrowserContext, page: Page, frame: Frame}, ...args: any) => any;
 
 export const kNavigationEvent = Symbol('navigation');
-type NavigationEvent = {
-  documentInfo?: DocumentInfo,  // Undefined for same-document navigations.
+export type NavigationEvent = {
+  // New frame url after navigation.
+  url: string,
+  // New frame name after navigation.
+  name: string,
+  // Information about the new document for cross-document navigations.
+  // Undefined for same-document navigations.
+  newDocument?: DocumentInfo,
+  // Error for cross-document navigations if any. When error is present,
+  // the navigation did not commit.
   error?: Error,
 };
 export const kAddLifecycleEvent = Symbol('addLifecycle');
@@ -172,9 +180,9 @@ export class FrameManager {
     else
       frame._currentDocument = { documentId, request: undefined };
     frame._pendingDocument = undefined;
-    const navigationEvent: NavigationEvent = { documentInfo: frame._currentDocument };
-    frame._eventEmitter.emit(kNavigationEvent, navigationEvent);
     frame._onClearLifecycle();
+    const navigationEvent: NavigationEvent = { url, name, newDocument: frame._currentDocument };
+    frame._eventEmitter.emit(kNavigationEvent, navigationEvent);
     if (!initial) {
       this._page._logger.info(`  navigated to "${url}"`);
       this._page.emit(Events.Page.FrameNavigated, frame);
@@ -186,7 +194,7 @@ export class FrameManager {
     if (!frame)
       return;
     frame._url = url;
-    const navigationEvent: NavigationEvent = {};
+    const navigationEvent: NavigationEvent = { url, name: frame._name };
     frame._eventEmitter.emit(kNavigationEvent, navigationEvent);
     this._page._logger.info(`  navigated to "${url}"`);
     this._page.emit(Events.Page.FrameNavigated, frame);
@@ -198,7 +206,12 @@ export class FrameManager {
       return;
     if (documentId !== undefined && frame._pendingDocument.documentId !== documentId)
       return;
-    const navigationEvent: NavigationEvent = { documentInfo: frame._pendingDocument, error: new Error(errorText) };
+    const navigationEvent: NavigationEvent = {
+      url: frame._url,
+      name: frame._name,
+      newDocument: frame._pendingDocument,
+      error: new Error(errorText),
+    };
     frame._pendingDocument = undefined;
     frame._eventEmitter.emit(kNavigationEvent, navigationEvent);
   }
@@ -410,7 +423,7 @@ export class Frame {
       }
       url = helper.completeUserURL(url);
 
-      const sameDocument = helper.waitForEvent(progress, this._eventEmitter, kNavigationEvent, (e: NavigationEvent) => !e.documentInfo);
+      const sameDocument = helper.waitForEvent(progress, this._eventEmitter, kNavigationEvent, (e: NavigationEvent) => !e.newDocument);
       const navigateResult = await this._page._delegate.navigateFrame(this, url, referer);
 
       let event: NavigationEvent;
@@ -419,10 +432,10 @@ export class Frame {
         event = await helper.waitForEvent(progress, this._eventEmitter, kNavigationEvent, (event: NavigationEvent) => {
           // We are interested either in this specific document, or any other document that
           // did commit and replaced the expected document.
-          return event.documentInfo && (event.documentInfo.documentId === navigateResult.newDocumentId || !event.error);
+          return event.newDocument && (event.newDocument.documentId === navigateResult.newDocumentId || !event.error);
         }).promise;
 
-        if (event.documentInfo!.documentId !== navigateResult.newDocumentId) {
+        if (event.newDocument!.documentId !== navigateResult.newDocumentId) {
           // This is just a sanity check. In practice, new navigation should
           // cancel the previous one and report "request cancelled"-like error.
           throw new Error('Navigation interrupted by another one');
@@ -436,7 +449,7 @@ export class Frame {
       if (!this._subtreeLifecycleEvents.has(waitUntil))
         await helper.waitForEvent(progress, this._eventEmitter, kAddLifecycleEvent, (e: types.LifecycleEvent) => e === waitUntil).promise;
 
-      const request = event.documentInfo ? event.documentInfo.request : undefined;
+      const request = event.newDocument ? event.newDocument.request : undefined;
       return request ? request._finalRequest().response() : null;
     });
   }
@@ -460,7 +473,7 @@ export class Frame {
       if (!this._subtreeLifecycleEvents.has(waitUntil))
         await helper.waitForEvent(progress, this._eventEmitter, kAddLifecycleEvent, (e: types.LifecycleEvent) => e === waitUntil).promise;
 
-      const request = navigationEvent.documentInfo ? navigationEvent.documentInfo.request : undefined;
+      const request = navigationEvent.newDocument ? navigationEvent.newDocument.request : undefined;
       return request ? request._finalRequest().response() : null;
     });
   }

--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -119,7 +119,6 @@ export interface PageChannel extends Channel {
   on(event: 'fileChooser', callback: (params: { element: ElementHandleChannel, isMultiple: boolean }) => void): this;
   on(event: 'frameAttached', callback: (params: { frame: FrameChannel }) => void): this;
   on(event: 'frameDetached', callback: (params: { frame: FrameChannel }) => void): this;
-  on(event: 'frameNavigated', callback: (params: { frame: FrameChannel, url: string, name: string }) => void): this;
   on(event: 'load', callback: () => void): this;
   on(event: 'pageError', callback: (params: { error: types.Error }) => void): this;
   on(event: 'popup', callback: (params: { page: PageChannel }) => void): this;
@@ -173,8 +172,11 @@ export type PageInitializer = {
   isClosed: boolean
 };
 
+export type FrameNavigatedEvent = { url: string, name: string, newDocument?: { request?: RequestChannel }, error?: string };
+
 export interface FrameChannel extends Channel {
   on(event: 'loadstate', callback: (params: { add?: types.LifecycleEvent, remove?: types.LifecycleEvent }) => void): this;
+  on(event: 'navigated', callback: (params: FrameNavigatedEvent) => void): this;
 
   evalOnSelector(params: { selector: string; expression: string, isFunction: boolean, arg: any}): Promise<{ value: any }>;
   evalOnSelectorAll(params: { selector: string; expression: string, isFunction: boolean, arg: any}): Promise<{ value: any }>;
@@ -206,7 +208,6 @@ export interface FrameChannel extends Channel {
   type(params: { selector: string, text: string, delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
   uncheck(params: { selector: string, force?: boolean, noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
   waitForFunction(params: { expression: string, isFunction: boolean, arg: any } & types.WaitForFunctionOptions): Promise<{ handle: JSHandleChannel }>;
-  waitForNavigation(params: types.WaitForNavigationOptions): Promise<{ response: ResponseChannel | null }>;
   waitForSelector(params: { selector: string } & types.WaitForElementOptions): Promise<{ element: ElementHandleChannel | null }>;
 }
 export type FrameInitializer = {
@@ -403,7 +404,7 @@ export type ElectronInitializer = {};
 
 export interface ElectronApplicationChannel extends Channel {
   on(event: 'close', callback: () => void): this;
-  on(event: 'window', callback: (params: { page: PageChannel }) => void): this;
+  on(event: 'window', callback: (params: { page: PageChannel, browserWindow: JSHandleChannel }) => void): this;
 
   newBrowserWindow(params: { arg: any }): Promise<{ page: PageChannel }>;
   evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;

--- a/src/rpc/client/network.ts
+++ b/src/rpc/client/network.ts
@@ -132,6 +132,10 @@ export class Request extends ChannelOwner<RequestChannel, RequestInitializer> {
       errorText: this._failureText
     };
   }
+
+  _finalRequest(): Request {
+    return this._redirectedTo ? this._redirectedTo._finalRequest() : this;
+  }
 }
 
 export class Route extends ChannelOwner<RouteChannel, RouteInitializer> {

--- a/src/rpc/client/page.ts
+++ b/src/rpc/client/page.ts
@@ -75,6 +75,7 @@ export class Page extends ChannelOwner<PageChannel, PageInitializer> {
 
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: PageInitializer) {
     super(parent, type, guid, initializer);
+    this.setMaxListeners(0);
     this._browserContext = parent as BrowserContext;
     this._timeoutSettings = new TimeoutSettings(this._browserContext._timeoutSettings);
 
@@ -98,7 +99,6 @@ export class Page extends ChannelOwner<PageChannel, PageInitializer> {
     this._channel.on('fileChooser', ({ element, isMultiple }) => this.emit(Events.Page.FileChooser, new FileChooser(this, ElementHandle.from(element), isMultiple)));
     this._channel.on('frameAttached', ({ frame }) => this._onFrameAttached(Frame.from(frame)));
     this._channel.on('frameDetached', ({ frame }) => this._onFrameDetached(Frame.from(frame)));
-    this._channel.on('frameNavigated', ({ frame, url, name }) => this._onFrameNavigated(Frame.from(frame), url, name));
     this._channel.on('load', () => this.emit(Events.Page.Load));
     this._channel.on('pageError', ({ error }) => this.emit(Events.Page.PageError, parseError(error)));
     this._channel.on('popup', ({ page }) => this.emit(Events.Page.Popup, Page.from(page)));
@@ -134,12 +134,6 @@ export class Page extends ChannelOwner<PageChannel, PageInitializer> {
     if (frame._parentFrame)
       frame._parentFrame._childFrames.delete(frame);
     this.emit(Events.Page.FrameDetached, frame);
-  }
-
-  private _onFrameNavigated(frame: Frame, url: string, name: string) {
-    frame._url = url;
-    frame._name = name;
-    this.emit(Events.Page.FrameNavigated, frame);
   }
 
   private _onRoute(route: Route, request: Request) {

--- a/src/rpc/server/electronDispatcher.ts
+++ b/src/rpc/server/electronDispatcher.ts
@@ -15,11 +15,10 @@
  */
 
 import { Dispatcher, DispatcherScope, lookupDispatcher } from './dispatcher';
-import { Electron, ElectronApplication, ElectronEvents } from '../../server/electron';
+import { Electron, ElectronApplication, ElectronEvents, ElectronPage } from '../../server/electron';
 import { ElectronApplicationChannel, ElectronApplicationInitializer, PageChannel, JSHandleChannel, ElectronInitializer, ElectronChannel, ElectronLaunchOptions } from '../channels';
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 import { BrowserContextBase } from '../../browserContext';
-import { Page } from '../../page';
 import { PageDispatcher } from './pageDispatcher';
 import { parseArgument } from './jsHandleDispatcher';
 import { createHandle } from './elementHandlerDispatcher';
@@ -42,8 +41,11 @@ export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplicatio
     });
 
     electronApplication.on(ElectronEvents.ElectronApplication.Close, () => this._dispatchEvent('close'));
-    electronApplication.on(ElectronEvents.ElectronApplication.Window, (page: Page) => {
-      this._dispatchEvent('window', { page: lookupDispatcher<PageDispatcher>(page) });
+    electronApplication.on(ElectronEvents.ElectronApplication.Window, (page: ElectronPage) => {
+      this._dispatchEvent('window', {
+        page: lookupDispatcher<PageDispatcher>(page),
+        browserWindow: createHandle(this._scope, page.browserWindow),
+      });
     });
   }
 

--- a/src/rpc/server/pageDispatcher.ts
+++ b/src/rpc/server/pageDispatcher.ts
@@ -57,7 +57,6 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     }));
     page.on(Events.Page.FrameAttached, frame => this._onFrameAttached(frame));
     page.on(Events.Page.FrameDetached, frame => this._onFrameDetached(frame));
-    page.on(Events.Page.FrameNavigated, frame => this._onFrameNavigated(frame));
     page.on(Events.Page.Load, () => this._dispatchEvent('load'));
     page.on(Events.Page.PageError, error => this._dispatchEvent('pageError', { error: serializeError(error) }));
     page.on(Events.Page.Popup, page => this._dispatchEvent('popup', { page: lookupDispatcher<PageDispatcher>(page) }));
@@ -217,10 +216,6 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
 
   _onFrameAttached(frame: Frame) {
     this._dispatchEvent('frameAttached', { frame: FrameDispatcher.from(this._scope, frame) });
-  }
-
-  _onFrameNavigated(frame: Frame) {
-    this._dispatchEvent('frameNavigated', { frame: lookupDispatcher<FrameDispatcher>(frame), url: frame.url(), name: frame.name() });
   }
 
   _onFrameDetached(frame: Frame) {

--- a/src/server/electron.ts
+++ b/src/server/electron.ts
@@ -52,7 +52,7 @@ export const ElectronEvents = {
   }
 };
 
-interface ElectronPage extends Page {
+export interface ElectronPage extends Page {
   browserWindow: js.JSHandle<BrowserWindow>;
   _browserWindowId: number;
 }

--- a/test/autowaiting.spec.js
+++ b/test/autowaiting.spec.js
@@ -166,7 +166,7 @@ describe('Auto waiting', () => {
     await page.setContent(`<a href="${server.EMPTY_PAGE}">empty.html</a>`);
     await Promise.all([
       page.click('a').then(() => page.waitForLoadState('load')).then(() => messages.push('clickload')),
-      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).then(() => messages.push('domcontentloaded')),
+      page.waitForEvent('framenavigated').then(() => page.waitForLoadState('domcontentloaded')).then(() => messages.push('domcontentloaded')),
     ]);
     expect(messages.join('|')).toBe('route|domcontentloaded|clickload');
   });

--- a/test/chromium/session.spec.js
+++ b/test/chromium/session.spec.js
@@ -66,7 +66,7 @@ describe('ChromiumBrowserContext.createSession', function() {
     }
     expect(error.message).toContain(CHANNEL ? 'Target browser or context has been closed' : 'Session closed.');
   });
-  it.skip(USES_HOOKS)('should throw nice errors', async function({page, browser}) {
+  it.skip(CHANNEL)('should throw nice errors', async function({page, browser}) {
     const client = await page.context().newCDPSession(page);
     const error = await theSourceOfTheProblems().catch(error => error);
     expect(error.stack).toContain('theSourceOfTheProblems');

--- a/test/electron/electron.spec.js
+++ b/test/electron/electron.spec.js
@@ -55,7 +55,7 @@ describe('Electron', function() {
     await page.goto('data:text/html,<title>Hello World 2</title>');
     expect(await page.title()).toBe('Hello World 2');
   });
-  it.skip(CHANNEL)('should create multiple windows', async ({ application }) => {
+  it('should create multiple windows', async ({ application }) => {
     const createPage = async ordinal => {
       const page = await application.newBrowserWindow({ width: 800, height: 600 });
       await Promise.all([

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -17,7 +17,7 @@
 
 const utils = require('./utils');
 const path = require('path');
-const {FFOX, CHROMIUM, WEBKIT, USES_HOOKS} = utils.testOptions(browserType);
+const {FFOX, CHROMIUM, WEBKIT, USES_HOOKS, CHANNEL} = utils.testOptions(browserType);
 
 describe('Page.evaluate', function() {
   it('should work', async({page, server}) => {
@@ -373,7 +373,7 @@ describe('Page.evaluate', function() {
     });
     expect(result).toBe(undefined);
   });
-  it.slow().skip(USES_HOOKS)('should transfer 100Mb of data from page to node.js', async({page, server}) => {
+  it.slow().skip(CHANNEL)('should transfer 100Mb of data from page to node.js', async({page, server}) => {
     const a = await page.evaluate(() => Array(100 * 1024 * 1024 + 1).join('a'));
     expect(a.length).toBe(100 * 1024 * 1024);
   });

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -460,18 +460,14 @@ describe('Page.goto', function() {
         return Promise.all([
           server.waitForRequest(suffix),
           frame._page.waitForRequest(server.PREFIX + suffix),
-        ])
+        ]);
       }
       let responses = {};
       // Hold on to a bunch of requests without answering.
       server.setRoute('/fetch-request-a.js', (req, res) => responses.a = res);
-      const initialFetchResourcesRequested = Promise.all([
-        waitForRequest('/fetch-request-a.js'),
-      ]);
-
-      let secondFetchResourceRequested;
+      const firstFetchResourceRequested = waitForRequest('/fetch-request-a.js');
       server.setRoute('/fetch-request-d.js', (req, res) => responses.d = res);
-      secondFetchResourceRequested = waitForRequest('/fetch-request-d.js');
+      const secondFetchResourceRequested = waitForRequest('/fetch-request-d.js');
 
       const waitForLoadPromise = isSetContent ? Promise.resolve() : frame.waitForNavigation({ waitUntil: 'load' });
 
@@ -487,8 +483,8 @@ describe('Page.goto', function() {
       await waitForLoadPromise;
       expect(actionFinished).toBe(false);
 
-      // Wait for the initial three resources to be requested.
-      await initialFetchResourcesRequested;
+      // Wait for the initial resource to be requested.
+      await firstFetchResourceRequested;
       expect(actionFinished).toBe(false);
 
       expect(responses.a).toBeTruthy();
@@ -564,7 +560,7 @@ describe('Page.goto', function() {
   });
 });
 
-describe.skip(CHANNEL)('Page.waitForNavigation', function() {
+describe('Page.waitForNavigation', function() {
   it('should work', async({page, server}) => {
     await page.goto(server.EMPTY_PAGE);
     const [response] = await Promise.all([

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -18,7 +18,7 @@
 const path = require('path');
 const util = require('util');
 const vm = require('vm');
-const {FFOX, CHROMIUM, WEBKIT, WIN, USES_HOOKS} = require('./utils').testOptions(browserType);
+const {FFOX, CHROMIUM, WEBKIT, WIN, USES_HOOKS, CHANNEL} = require('./utils').testOptions(browserType);
 
 describe('Page.close', function() {
   it('should reject all promises when page is closed', async({context}) => {
@@ -101,7 +101,7 @@ describe('Page.Events.Load', function() {
   });
 });
 
-describe.skip(USES_HOOKS)('Async stacks', () => {
+describe.skip(CHANNEL)('Async stacks', () => {
   it('should work', async({page, server}) => {
     server.setRoute('/empty.html', (req, res) => {
       req.socket.end();

--- a/test/queryselector.spec.js
+++ b/test/queryselector.spec.js
@@ -525,7 +525,7 @@ describe('text selector', () => {
     expect(await page.$$eval(`text=lowo`, els => els.map(e => e.outerHTML).join(''))).toBe('<div>helloworld</div><span>helloworld</span>');
   });
 
-  it.skip(CHANNEL)('create', async ({page}) => {
+  it('create', async ({playwright, page}) => {
     await page.setContent(`<div>yo</div><div>"ya</div><div>ye ye</div>`);
     expect(await playwright.selectors._createSelector('text', await page.$('div'))).toBe('yo');
     expect(await playwright.selectors._createSelector('text', await page.$('div:nth-child(2)'))).toBe('"\\"ya"');

--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -16,7 +16,7 @@
  */
 
 const utils = require('./utils');
-const {FFOX, CHROMIUM, WEBKIT, USES_HOOKS} = utils.testOptions(browserType);
+const {FFOX, CHROMIUM, WEBKIT, CHANNEL} = utils.testOptions(browserType);
 
 async function giveItTimeToLog(frame) {
   await frame.evaluate(() => new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f))));
@@ -458,7 +458,7 @@ describe('Frame.waitForSelector', function() {
     await page.setContent(`<div class='zombo'>anything</div>`);
     expect(await page.evaluate(x => x.textContent, await waitForSelector)).toBe('anything');
   });
-  it.skip(USES_HOOKS)('should have correct stack trace for timeout', async({page, server}) => {
+  it.skip(CHANNEL)('should have correct stack trace for timeout', async({page, server}) => {
     let error;
     await page.waitForSelector('.zombo', { timeout: 10 }).catch(e => error = e);
     expect(error.stack).toContain('waittask.spec.js');


### PR DESCRIPTION
Drive-by: fix electron issues, exposed by the test using waitForNavigation.

Drive-by: mark some tests skip(CHANNEL) that were mistakenly marked skip(USES_HOOKS).