### PR TITLE
feat(rpc): return objects for every protocol command

### DIFF
--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -36,7 +36,7 @@ export type PlaywrightInitializer = {
 
 export interface SelectorsChannel extends Channel {
   register(params: { name: string, source: string, options: { contentScript?: boolean } }): Promise<void>;
-  createSelector(params: { name: string, handle: ElementHandleChannel }): Promise<{ selector?: string }>;
+  createSelector(params: { name: string, handle: ElementHandleChannel }): Promise<{ value?: string }>;
 }
 export type SelectorsInitializer = {};
 
@@ -73,7 +73,7 @@ export interface BrowserChannel extends Channel {
 
   crNewBrowserCDPSession(): Promise<{ session: CDPSessionChannel }>;
   crStartTracing(params: { page?: PageChannel, path?: string, screenshots?: boolean, categories?: string[] }): Promise<void>;
-  crStopTracing(): Promise<{ trace: Binary }>;
+  crStopTracing(): Promise<{ binary: Binary }>;
 }
 export type BrowserInitializer = {};
 
@@ -142,7 +142,7 @@ export interface PageChannel extends Channel {
   goForward(params: types.NavigateOptions): Promise<{ response: ResponseChannel | null }>;
   opener(): Promise<{ page: PageChannel | null }>;
   reload(params: types.NavigateOptions): Promise<{ response: ResponseChannel | null }>;
-  screenshot(params: types.ScreenshotOptions): Promise<{ screenshot: Binary }>;
+  screenshot(params: types.ScreenshotOptions): Promise<{ binary: Binary }>;
   setExtraHTTPHeaders(params: { headers: types.Headers }): Promise<void>;
   setNetworkInterceptionEnabled(params: { enabled: boolean }): Promise<void>;
   setViewportSize(params: { viewportSize: types.Size }): Promise<void>;
@@ -158,7 +158,7 @@ export interface PageChannel extends Channel {
   mouseUp(params: { button?: types.MouseButton, clickCount?: number }): Promise<void>;
   mouseClick(params: { x: number, y: number, delay?: number, button?: types.MouseButton, clickCount?: number }): Promise<void>;
 
-  accessibilitySnapshot(params: { interestingOnly?: boolean, root?: ElementHandleChannel }): Promise<{ axNode: types.SerializedAXNode | null }>;
+  accessibilitySnapshot(params: { interestingOnly?: boolean, root?: ElementHandleChannel }): Promise<{ rootAXNode: types.SerializedAXNode | null }>;
   pdf: (params: PDFOptions) => Promise<{ pdf: Binary }>;
 
   crStartJSCoverage(params: types.JSCoverageOptions): Promise<void>;
@@ -184,7 +184,7 @@ export interface FrameChannel extends Channel {
   addStyleTag(params: { url?: string, content?: string } & PageAttribution): Promise<{ element: ElementHandleChannel }>;
   check(params: { selector: string, force?: boolean, noWaitAfter?: boolean } & types.TimeoutOptions & PageAttribution): Promise<void>;
   click(params: { selector: string, force?: boolean, noWaitAfter?: boolean } & types.PointerActionOptions & types.MouseClickOptions & types.TimeoutOptions & PageAttribution): Promise<void>;
-  content(): Promise<{ content: string }>;
+  content(): Promise<{ value: string }>;
   dblclick(params: { selector: string, force?: boolean } & types.PointerActionOptions & types.MouseMultiClickOptions & types.TimeoutOptions & PageAttribution): Promise<void>;
   dispatchEvent(params: { selector: string, type: string, eventInit: any } & types.TimeoutOptions & PageAttribution): Promise<void>;
   evaluateExpression(params: { expression: string, isFunction: boolean, arg: any} & PageAttribution): Promise<{ value: any }>;
@@ -192,19 +192,19 @@ export interface FrameChannel extends Channel {
   fill(params: { selector: string, value: string } & types.NavigatingActionWaitOptions & PageAttribution): Promise<void>;
   focus(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<void>;
   frameElement(): Promise<{ element: ElementHandleChannel }>;
-  getAttribute(params: { selector: string, name: string } & types.TimeoutOptions & PageAttribution): Promise<{ attribute: string | null }>;
+  getAttribute(params: { selector: string, name: string } & types.TimeoutOptions & PageAttribution): Promise<{ value: string | null }>;
   goto(params: { url: string } & types.GotoOptions & PageAttribution): Promise<{ response: ResponseChannel | null }>;
   hover(params: { selector: string, force?: boolean } & types.PointerActionOptions & types.TimeoutOptions & PageAttribution): Promise<void>;
-  innerHTML(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ innerHTML: string }>;
-  innerText(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ innerText: string }>;
+  innerHTML(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ value: string }>;
+  innerText(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ value: string }>;
   press(params: { selector: string, key: string, delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions & PageAttribution): Promise<void>;
   querySelector(params: { selector: string} & PageAttribution): Promise<{ element: ElementHandleChannel | null }>;
   querySelectorAll(params: { selector: string} & PageAttribution): Promise<{ elements: ElementHandleChannel[] }>;
-  selectOption(params: { selector: string, elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<{ selectedValues: string[] }>;
+  selectOption(params: { selector: string, elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<{ values: string[] }>;
   setContent(params: { html: string } & types.NavigateOptions & PageAttribution): Promise<void>;
   setInputFiles(params: { selector: string, files: { name: string, mimeType: string, buffer: Binary }[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<void>;
-  textContent(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ textContent: string | null }>;
-  title(): Promise<{ title: string }>;
+  textContent(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ value: string | null }>;
+  title(): Promise<{ value: string }>;
   type(params: { selector: string, text: string, delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions & PageAttribution): Promise<void>;
   uncheck(params: { selector: string, force?: boolean, noWaitAfter?: boolean } & types.TimeoutOptions & PageAttribution): Promise<void>;
   waitForFunction(params: { expression: string, isFunction: boolean, arg: any } & types.WaitForFunctionOptions & PageAttribution): Promise<{ handle: JSHandleChannel }>;
@@ -246,7 +246,7 @@ export type JSHandleInitializer = {
 export interface ElementHandleChannel extends JSHandleChannel {
   evalOnSelector(params: { selector: string; expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
   evalOnSelectorAll(params: { selector: string; expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
-  boundingBox(): Promise<{ box: types.Rect | null }>;
+  boundingBox(): Promise<{ value: types.Rect | null }>;
   check(params: { force?: boolean } & { noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
   click(params: { force?: boolean, noWaitAfter?: boolean } & types.PointerActionOptions & types.MouseClickOptions & types.TimeoutOptions): Promise<void>;
   contentFrame(): Promise<{ frame: FrameChannel | null }>;
@@ -254,20 +254,20 @@ export interface ElementHandleChannel extends JSHandleChannel {
   dispatchEvent(params: { type: string, eventInit: any }): Promise<void>;
   fill(params: { value: string } & types.NavigatingActionWaitOptions): Promise<void>;
   focus(): Promise<void>;
-  getAttribute(params: { name: string }): Promise<{ attribute: string | null }>;
+  getAttribute(params: { name: string }): Promise<{ value: string | null }>;
   hover(params: { force?: boolean } & types.PointerActionOptions & types.TimeoutOptions): Promise<void>;
-  innerHTML(): Promise<{ innerHTML: string }>;
-  innerText(): Promise<{ innerText: string }>;
+  innerHTML(): Promise<{ value: string }>;
+  innerText(): Promise<{ value: string }>;
   ownerFrame(): Promise<{ frame: FrameChannel | null }>;
   press(params: { key: string, delay?: number } & types.TimeoutOptions & { noWaitAfter?: boolean }): Promise<void>;
   querySelector(params: { selector: string }): Promise<{ element: ElementHandleChannel | null }>;
   querySelectorAll(params: { selector: string }): Promise<{ elements: ElementHandleChannel[] }>;
-  screenshot(params: types.ElementScreenshotOptions): Promise<{ screenshot: Binary }>;
+  screenshot(params: types.ElementScreenshotOptions): Promise<{ binary: Binary }>;
   scrollIntoViewIfNeeded(params: types.TimeoutOptions): Promise<void>;
-  selectOption(params: { elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions): Promise<{ selectedValues: string[] }>;
+  selectOption(params: { elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions): Promise<{ values: string[] }>;
   selectText(params: types.TimeoutOptions): Promise<void>;
   setInputFiles(params: { files: { name: string, mimeType: string, buffer: Binary }[] } & types.NavigatingActionWaitOptions): Promise<void>;
-  textContent(): Promise<{ textContent: string | null }>;
+  textContent(): Promise<{ value: string | null }>;
   type(params: { text: string, delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
   uncheck(params: { force?: boolean, noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
 }
@@ -304,7 +304,7 @@ export type RouteInitializer = {
 
 
 export interface ResponseChannel extends Channel {
-  body(): Promise<{ body: Binary }>;
+  body(): Promise<{ binary: Binary }>;
   finished(): Promise<{ error: Error | null }>;
 }
 export type ResponseInitializer = {
@@ -349,7 +349,7 @@ export type DialogInitializer = {
 
 
 export interface DownloadChannel extends Channel {
-  path(): Promise<{ path: string | null }>;
+  path(): Promise<{ value: string | null }>;
   failure(): Promise<{ error: string | null }>;
   stream(): Promise<{ stream: StreamChannel | null }>;
   delete(): Promise<void>;
@@ -361,7 +361,7 @@ export type DownloadInitializer = {
 
 
 export interface StreamChannel extends Channel {
-  read(params: { size?: number }): Promise<{ data: Binary }>;
+  read(params: { size?: number }): Promise<{ binary: Binary }>;
 }
 export type StreamInitializer = {
 }
@@ -403,7 +403,7 @@ export type ElectronLaunchOptions = {
   timeout?: number,
 };
 export interface ElectronChannel extends Channel {
-  launch(params: { executablePath: string } & ElectronLaunchOptions): Promise<{ application: ElectronApplicationChannel }>;
+  launch(params: { executablePath: string } & ElectronLaunchOptions): Promise<{ electronApplication: ElectronApplicationChannel }>;
 }
 export type ElectronInitializer = {};
 

--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -36,16 +36,16 @@ export type PlaywrightInitializer = {
 
 export interface SelectorsChannel extends Channel {
   register(params: { name: string, source: string, options: { contentScript?: boolean } }): Promise<void>;
-  createSelector(params: { name: string, handle: ElementHandleChannel }): Promise<string | undefined>;
+  createSelector(params: { name: string, handle: ElementHandleChannel }): Promise<{ selector?: string }>;
 }
 export type SelectorsInitializer = {};
 
 
 export interface BrowserTypeChannel extends Channel {
-  connect(params: types.ConnectOptions): Promise<BrowserChannel>;
-  launch(params: types.LaunchOptions): Promise<BrowserChannel>;
-  launchServer(params: types.LaunchServerOptions): Promise<BrowserServerChannel>;
-  launchPersistentContext(params: { userDataDir: string } & types.LaunchOptions & types.BrowserContextOptions): Promise<BrowserContextChannel>;
+  connect(params: types.ConnectOptions): Promise<{ browser: BrowserChannel }>;
+  launch(params: types.LaunchOptions): Promise<{ browser: BrowserChannel }>;
+  launchServer(params: types.LaunchServerOptions): Promise<{ server: BrowserServerChannel }>;
+  launchPersistentContext(params: { userDataDir: string } & types.LaunchOptions & types.BrowserContextOptions): Promise<{ context: BrowserContextChannel }>;
 }
 export type BrowserTypeInitializer = {
   executablePath: string,
@@ -69,19 +69,19 @@ export interface BrowserChannel extends Channel {
   on(event: 'close', callback: () => void): this;
 
   close(): Promise<void>;
-  newContext(params: types.BrowserContextOptions): Promise<BrowserContextChannel>;
+  newContext(params: types.BrowserContextOptions): Promise<{ context: BrowserContextChannel }>;
 
-  crNewBrowserCDPSession(): Promise<CDPSessionChannel>;
+  crNewBrowserCDPSession(): Promise<{ session: CDPSessionChannel }>;
   crStartTracing(params: { page?: PageChannel, path?: string, screenshots?: boolean, categories?: string[] }): Promise<void>;
-  crStopTracing(): Promise<Binary>;
+  crStopTracing(): Promise<{ trace: Binary }>;
 }
 export type BrowserInitializer = {};
 
 
 export interface BrowserContextChannel extends Channel {
-  on(event: 'bindingCall', callback: (params: BindingCallChannel) => void): this;
+  on(event: 'bindingCall', callback: (params: { binding: BindingCallChannel }) => void): this;
   on(event: 'close', callback: () => void): this;
-  on(event: 'page', callback: (params: PageChannel) => void): this;
+  on(event: 'page', callback: (params: { page: PageChannel }) => void): this;
   on(event: 'route', callback: (params: { route: RouteChannel, request: RequestChannel }) => void): this;
 
   addCookies(params: { cookies: types.SetNetworkCookieParam[] }): Promise<void>;
@@ -89,10 +89,10 @@ export interface BrowserContextChannel extends Channel {
   clearCookies(): Promise<void>;
   clearPermissions(): Promise<void>;
   close(): Promise<void>;
-  cookies(params: { urls: string[] }): Promise<types.NetworkCookie[]>;
+  cookies(params: { urls: string[] }): Promise<{ cookies: types.NetworkCookie[] }>;
   exposeBinding(params: { name: string }): Promise<void>;
   grantPermissions(params: { permissions: string[], origin?: string }): Promise<void>;
-  newPage(): Promise<PageChannel>;
+  newPage(): Promise<{ page: PageChannel }>;
   setDefaultNavigationTimeoutNoReply(params: { timeout: number }): void;
   setDefaultTimeoutNoReply(params: { timeout: number }): void;
   setExtraHTTPHeaders(params: { headers: types.Headers }): Promise<void>;
@@ -101,34 +101,34 @@ export interface BrowserContextChannel extends Channel {
   setNetworkInterceptionEnabled(params: { enabled: boolean }): Promise<void>;
   setOffline(params: { offline: boolean }): Promise<void>;
 
-  on(event: 'crBackgroundPage', callback: (params: PageChannel) => void): this;
-  on(event: 'crServiceWorker', callback: (params: WorkerChannel) => void): this;
-  crNewCDPSession(params: { page: PageChannel }): Promise<CDPSessionChannel>;
+  on(event: 'crBackgroundPage', callback: (params: { page: PageChannel }) => void): this;
+  on(event: 'crServiceWorker', callback: (params: { worker: WorkerChannel }) => void): this;
+  crNewCDPSession(params: { page: PageChannel }): Promise<{ session: CDPSessionChannel }>;
 }
 export type BrowserContextInitializer = {};
 
 
 export interface PageChannel extends Channel {
-  on(event: 'bindingCall', callback: (params: BindingCallChannel) => void): this;
+  on(event: 'bindingCall', callback: (params: { binding: BindingCallChannel }) => void): this;
   on(event: 'close', callback: () => void): this;
-  on(event: 'console', callback: (params: ConsoleMessageChannel) => void): this;
+  on(event: 'console', callback: (params: { message: ConsoleMessageChannel }) => void): this;
   on(event: 'crash', callback: () => void): this;
-  on(event: 'dialog', callback: (params: DialogChannel) => void): this;
-  on(event: 'download', callback: (params: DownloadChannel) => void): this;
+  on(event: 'dialog', callback: (params: { dialog: DialogChannel }) => void): this;
+  on(event: 'download', callback: (params: { download: DownloadChannel }) => void): this;
   on(event: 'domcontentloaded', callback: () => void): this;
   on(event: 'fileChooser', callback: (params: { element: ElementHandleChannel, isMultiple: boolean }) => void): this;
-  on(event: 'frameAttached', callback: (params: FrameChannel) => void): this;
-  on(event: 'frameDetached', callback: (params: FrameChannel) => void): this;
+  on(event: 'frameAttached', callback: (params: { frame: FrameChannel }) => void): this;
+  on(event: 'frameDetached', callback: (params: { frame: FrameChannel }) => void): this;
   on(event: 'frameNavigated', callback: (params: { frame: FrameChannel, url: string, name: string }) => void): this;
   on(event: 'load', callback: () => void): this;
   on(event: 'pageError', callback: (params: { error: types.Error }) => void): this;
-  on(event: 'popup', callback: (params: PageChannel) => void): this;
-  on(event: 'request', callback: (params: RequestChannel) => void): this;
+  on(event: 'popup', callback: (params: { page: PageChannel }) => void): this;
+  on(event: 'request', callback: (params: { request: RequestChannel }) => void): this;
   on(event: 'requestFailed', callback: (params: { request: RequestChannel, failureText: string | null }) => void): this;
-  on(event: 'requestFinished', callback: (params: RequestChannel) => void): this;
-  on(event: 'response', callback: (params: ResponseChannel) => void): this;
+  on(event: 'requestFinished', callback: (params: { request: RequestChannel }) => void): this;
+  on(event: 'response', callback: (params: { response: ResponseChannel }) => void): this;
   on(event: 'route', callback: (params: { route: RouteChannel, request: RequestChannel }) => void): this;
-  on(event: 'worker', callback: (params: WorkerChannel) => void): this;
+  on(event: 'worker', callback: (params: { worker: WorkerChannel }) => void): this;
 
   setDefaultNavigationTimeoutNoReply(params: { timeout: number }): void;
   setDefaultTimeoutNoReply(params: { timeout: number }): Promise<void>;
@@ -138,11 +138,11 @@ export interface PageChannel extends Channel {
   close(params: { runBeforeUnload?: boolean }): Promise<void>;
   emulateMedia(params: { media?: 'screen' | 'print', colorScheme?: 'dark' | 'light' | 'no-preference' }): Promise<void>;
   exposeBinding(params: { name: string }): Promise<void>;
-  goBack(params: types.NavigateOptions): Promise<ResponseChannel | null>;
-  goForward(params: types.NavigateOptions): Promise<ResponseChannel | null>;
-  opener(): Promise<PageChannel | null>;
-  reload(params: types.NavigateOptions): Promise<ResponseChannel | null>;
-  screenshot(params: types.ScreenshotOptions): Promise<Binary>;
+  goBack(params: types.NavigateOptions): Promise<{ response: ResponseChannel | null }>;
+  goForward(params: types.NavigateOptions): Promise<{ response: ResponseChannel | null }>;
+  opener(): Promise<{ page: PageChannel | null }>;
+  reload(params: types.NavigateOptions): Promise<{ response: ResponseChannel | null }>;
+  screenshot(params: types.ScreenshotOptions): Promise<{ screenshot: Binary }>;
   setExtraHTTPHeaders(params: { headers: types.Headers }): Promise<void>;
   setNetworkInterceptionEnabled(params: { enabled: boolean }): Promise<void>;
   setViewportSize(params: { viewportSize: types.Size }): Promise<void>;
@@ -158,13 +158,13 @@ export interface PageChannel extends Channel {
   mouseUp(params: { button?: types.MouseButton, clickCount?: number }): Promise<void>;
   mouseClick(params: { x: number, y: number, delay?: number, button?: types.MouseButton, clickCount?: number }): Promise<void>;
 
-  accessibilitySnapshot(params: { interestingOnly?: boolean, root?: ElementHandleChannel }): Promise<types.SerializedAXNode | null>;
-  pdf: (params: PDFOptions) => Promise<Binary>;
+  accessibilitySnapshot(params: { interestingOnly?: boolean, root?: ElementHandleChannel }): Promise<{ axNode: types.SerializedAXNode | null }>;
+  pdf: (params: PDFOptions) => Promise<{ pdf: Binary }>;
 
   crStartJSCoverage(params: types.JSCoverageOptions): Promise<void>;
-  crStopJSCoverage(): Promise<types.JSCoverageEntry[]>;
+  crStopJSCoverage(): Promise<{ entries: types.JSCoverageEntry[] }>;
   crStartCSSCoverage(params: types.CSSCoverageOptions): Promise<void>;
-  crStopCSSCoverage(): Promise<types.CSSCoverageEntry[]>;
+  crStopCSSCoverage(): Promise<{ entries: types.CSSCoverageEntry[] }>;
 }
 
 export type PageInitializer = {
@@ -178,38 +178,38 @@ export type PageAttribution = { isPage?: boolean };
 export interface FrameChannel extends Channel {
   on(event: 'loadstate', callback: (params: { add?: types.LifecycleEvent, remove?: types.LifecycleEvent }) => void): this;
 
-  evalOnSelector(params: { selector: string; expression: string, isFunction: boolean, arg: any} & PageAttribution): Promise<any>;
-  evalOnSelectorAll(params: { selector: string; expression: string, isFunction: boolean, arg: any} & PageAttribution): Promise<any>;
-  addScriptTag(params: { url?: string, content?: string, type?: string } & PageAttribution): Promise<ElementHandleChannel>;
-  addStyleTag(params: { url?: string, content?: string } & PageAttribution): Promise<ElementHandleChannel>;
+  evalOnSelector(params: { selector: string; expression: string, isFunction: boolean, arg: any} & PageAttribution): Promise<{ value: any }>;
+  evalOnSelectorAll(params: { selector: string; expression: string, isFunction: boolean, arg: any} & PageAttribution): Promise<{ value: any }>;
+  addScriptTag(params: { url?: string, content?: string, type?: string } & PageAttribution): Promise<{ element: ElementHandleChannel }>;
+  addStyleTag(params: { url?: string, content?: string } & PageAttribution): Promise<{ element: ElementHandleChannel }>;
   check(params: { selector: string, force?: boolean, noWaitAfter?: boolean } & types.TimeoutOptions & PageAttribution): Promise<void>;
   click(params: { selector: string, force?: boolean, noWaitAfter?: boolean } & types.PointerActionOptions & types.MouseClickOptions & types.TimeoutOptions & PageAttribution): Promise<void>;
-  content(): Promise<string>;
+  content(): Promise<{ content: string }>;
   dblclick(params: { selector: string, force?: boolean } & types.PointerActionOptions & types.MouseMultiClickOptions & types.TimeoutOptions & PageAttribution): Promise<void>;
   dispatchEvent(params: { selector: string, type: string, eventInit: any } & types.TimeoutOptions & PageAttribution): Promise<void>;
-  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any} & PageAttribution): Promise<any>;
-  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any} & PageAttribution): Promise<JSHandleChannel>;
+  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any} & PageAttribution): Promise<{ value: any }>;
+  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any} & PageAttribution): Promise<{ handle: JSHandleChannel }>;
   fill(params: { selector: string, value: string } & types.NavigatingActionWaitOptions & PageAttribution): Promise<void>;
   focus(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<void>;
-  frameElement(): Promise<ElementHandleChannel>;
-  getAttribute(params: { selector: string, name: string } & types.TimeoutOptions & PageAttribution): Promise<string | null>;
-  goto(params: { url: string } & types.GotoOptions & PageAttribution): Promise<ResponseChannel | null>;
+  frameElement(): Promise<{ element: ElementHandleChannel }>;
+  getAttribute(params: { selector: string, name: string } & types.TimeoutOptions & PageAttribution): Promise<{ attribute: string | null }>;
+  goto(params: { url: string } & types.GotoOptions & PageAttribution): Promise<{ response: ResponseChannel | null }>;
   hover(params: { selector: string, force?: boolean } & types.PointerActionOptions & types.TimeoutOptions & PageAttribution): Promise<void>;
-  innerHTML(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<string>;
-  innerText(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<string>;
+  innerHTML(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ innerHTML: string }>;
+  innerText(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ innerText: string }>;
   press(params: { selector: string, key: string, delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions & PageAttribution): Promise<void>;
-  querySelector(params: { selector: string} & PageAttribution): Promise<ElementHandleChannel | null>;
-  querySelectorAll(params: { selector: string} & PageAttribution): Promise<ElementHandleChannel[]>;
-  selectOption(params: { selector: string, elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<string[]>;
+  querySelector(params: { selector: string} & PageAttribution): Promise<{ element: ElementHandleChannel | null }>;
+  querySelectorAll(params: { selector: string} & PageAttribution): Promise<{ elements: ElementHandleChannel[] }>;
+  selectOption(params: { selector: string, elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<{ selectedValues: string[] }>;
   setContent(params: { html: string } & types.NavigateOptions & PageAttribution): Promise<void>;
   setInputFiles(params: { selector: string, files: { name: string, mimeType: string, buffer: Binary }[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<void>;
-  textContent(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<string | null>;
-  title(): Promise<string>;
+  textContent(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ textContent: string | null }>;
+  title(): Promise<{ title: string }>;
   type(params: { selector: string, text: string, delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions & PageAttribution): Promise<void>;
   uncheck(params: { selector: string, force?: boolean, noWaitAfter?: boolean } & types.TimeoutOptions & PageAttribution): Promise<void>;
-  waitForFunction(params: { expression: string, isFunction: boolean, arg: any } & types.WaitForFunctionOptions & PageAttribution): Promise<JSHandleChannel>;
-  waitForNavigation(params: types.WaitForNavigationOptions & PageAttribution): Promise<ResponseChannel | null>;
-  waitForSelector(params: { selector: string } & types.WaitForElementOptions & PageAttribution): Promise<ElementHandleChannel | null>;
+  waitForFunction(params: { expression: string, isFunction: boolean, arg: any } & types.WaitForFunctionOptions & PageAttribution): Promise<{ handle: JSHandleChannel }>;
+  waitForNavigation(params: types.WaitForNavigationOptions & PageAttribution): Promise<{ response: ResponseChannel | null }>;
+  waitForSelector(params: { selector: string } & types.WaitForElementOptions & PageAttribution): Promise<{ element: ElementHandleChannel | null }>;
 }
 export type FrameInitializer = {
   url: string,
@@ -220,8 +220,8 @@ export type FrameInitializer = {
 
 
 export interface WorkerChannel extends Channel {
-  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<any>;
-  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any }): Promise<JSHandleChannel>;
+  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
+  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ handle: JSHandleChannel }>;
 }
 export type WorkerInitializer = {
   url: string,
@@ -229,14 +229,14 @@ export type WorkerInitializer = {
 
 
 export interface JSHandleChannel extends Channel {
-  on(event: 'previewUpdated', callback: (preview: string) => void): this;
+  on(event: 'previewUpdated', callback: (params: { preview: string }) => void): this;
 
   dispose(): Promise<void>;
-  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<any>;
-  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any}): Promise<JSHandleChannel>;
-  getPropertyList(): Promise<{ name: string, value: JSHandleChannel}[]>;
-  getProperty(params: { name: string }): Promise<JSHandleChannel>;
-  jsonValue(): Promise<any>;
+  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
+  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any}): Promise<{ handle: JSHandleChannel }>;
+  getPropertyList(): Promise<{ properties: { name: string, value: JSHandleChannel}[] }>;
+  getProperty(params: { name: string }): Promise<{ handle: JSHandleChannel }>;
+  jsonValue(): Promise<{ value: any }>;
 }
 export type JSHandleInitializer = {
   preview: string,
@@ -244,37 +244,37 @@ export type JSHandleInitializer = {
 
 
 export interface ElementHandleChannel extends JSHandleChannel {
-  evalOnSelector(params: { selector: string; expression: string, isFunction: boolean, arg: any }): Promise<any>;
-  evalOnSelectorAll(params: { selector: string; expression: string, isFunction: boolean, arg: any }): Promise<any>;
-  boundingBox(): Promise<types.Rect | null>;
+  evalOnSelector(params: { selector: string; expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
+  evalOnSelectorAll(params: { selector: string; expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
+  boundingBox(): Promise<{ box: types.Rect | null }>;
   check(params: { force?: boolean } & { noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
   click(params: { force?: boolean, noWaitAfter?: boolean } & types.PointerActionOptions & types.MouseClickOptions & types.TimeoutOptions): Promise<void>;
-  contentFrame(): Promise<FrameChannel | null>;
+  contentFrame(): Promise<{ frame: FrameChannel | null }>;
   dblclick(params: { force?: boolean, noWaitAfter?: boolean } & types.PointerActionOptions & types.MouseMultiClickOptions & types.TimeoutOptions): Promise<void>;
   dispatchEvent(params: { type: string, eventInit: any }): Promise<void>;
   fill(params: { value: string } & types.NavigatingActionWaitOptions): Promise<void>;
   focus(): Promise<void>;
-  getAttribute(params: { name: string }): Promise<string | null>;
+  getAttribute(params: { name: string }): Promise<{ attribute: string | null }>;
   hover(params: { force?: boolean } & types.PointerActionOptions & types.TimeoutOptions): Promise<void>;
-  innerHTML(): Promise<string>;
-  innerText(): Promise<string>;
-  ownerFrame(): Promise<FrameChannel | null>;
+  innerHTML(): Promise<{ innerHTML: string }>;
+  innerText(): Promise<{ innerText: string }>;
+  ownerFrame(): Promise<{ frame: FrameChannel | null }>;
   press(params: { key: string, delay?: number } & types.TimeoutOptions & { noWaitAfter?: boolean }): Promise<void>;
-  querySelector(params: { selector: string }): Promise<ElementHandleChannel | null>;
-  querySelectorAll(params: { selector: string }): Promise<ElementHandleChannel[]>;
-  screenshot(params: types.ElementScreenshotOptions): Promise<Binary>;
+  querySelector(params: { selector: string }): Promise<{ element: ElementHandleChannel | null }>;
+  querySelectorAll(params: { selector: string }): Promise<{ elements: ElementHandleChannel[] }>;
+  screenshot(params: types.ElementScreenshotOptions): Promise<{ screenshot: Binary }>;
   scrollIntoViewIfNeeded(params: types.TimeoutOptions): Promise<void>;
-  selectOption(params: { elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions): string[] | Promise<string[]>;
+  selectOption(params: { elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions): Promise<{ selectedValues: string[] }>;
   selectText(params: types.TimeoutOptions): Promise<void>;
   setInputFiles(params: { files: { name: string, mimeType: string, buffer: Binary }[] } & types.NavigatingActionWaitOptions): Promise<void>;
-  textContent(): Promise<string | null>;
+  textContent(): Promise<{ textContent: string | null }>;
   type(params: { text: string, delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
   uncheck(params: { force?: boolean, noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
 }
 
 
 export interface RequestChannel extends Channel {
-  response(): Promise<ResponseChannel | null>;
+  response(): Promise<{ response: ResponseChannel | null }>;
 }
 export type RequestInitializer = {
   frame: FrameChannel,
@@ -304,8 +304,8 @@ export type RouteInitializer = {
 
 
 export interface ResponseChannel extends Channel {
-  body(): Promise<Binary>;
-  finished(): Promise<Error | null>;
+  body(): Promise<{ body: Binary }>;
+  finished(): Promise<{ error: Error | null }>;
 }
 export type ResponseInitializer = {
   request: RequestChannel,
@@ -349,9 +349,9 @@ export type DialogInitializer = {
 
 
 export interface DownloadChannel extends Channel {
-  path(): Promise<string | null>;
-  failure(): Promise<string | null>;
-  stream(): Promise<StreamChannel | null>;
+  path(): Promise<{ path: string | null }>;
+  failure(): Promise<{ error: string | null }>;
+  stream(): Promise<{ stream: StreamChannel | null }>;
   delete(): Promise<void>;
 }
 export type DownloadInitializer = {
@@ -361,7 +361,7 @@ export type DownloadInitializer = {
 
 
 export interface StreamChannel extends Channel {
-  read(params: { size?: number }): Promise<Binary>;
+  read(params: { size?: number }): Promise<{ data: Binary }>;
 }
 export type StreamInitializer = {
 }
@@ -372,7 +372,7 @@ export interface CDPSessionChannel extends Channel {
   on(event: 'event', callback: (params: { method: string, params?: Object }) => void): this;
   on(event: 'disconnected', callback: () => void): this;
 
-  send(params: { method: string, params?: Object }): Promise<Object>;
+  send(params: { method: string, params?: Object }): Promise<{ result: Object }>;
   detach(): Promise<void>;
 }
 export type CDPSessionInitializer = {};
@@ -403,18 +403,18 @@ export type ElectronLaunchOptions = {
   timeout?: number,
 };
 export interface ElectronChannel extends Channel {
-  launch(params: { executablePath: string } & ElectronLaunchOptions): Promise<ElectronApplicationChannel>;
+  launch(params: { executablePath: string } & ElectronLaunchOptions): Promise<{ application: ElectronApplicationChannel }>;
 }
 export type ElectronInitializer = {};
 
 
 export interface ElectronApplicationChannel extends Channel {
   on(event: 'close', callback: () => void): this;
-  on(event: 'window', callback: (params: PageChannel) => void): this;
+  on(event: 'window', callback: (params: { page: PageChannel }) => void): this;
 
-  newBrowserWindow(params: { arg: any }): Promise<PageChannel>;
-  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<any>;
-  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any }): Promise<JSHandleChannel>;
+  newBrowserWindow(params: { arg: any }): Promise<{ page: PageChannel }>;
+  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
+  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ handle: JSHandleChannel }>;
   close(): Promise<void>;
 }
 export type ElectronApplicationInitializer = {

--- a/src/rpc/client/accessibility.ts
+++ b/src/rpc/client/accessibility.ts
@@ -29,6 +29,6 @@ export class Accessibility {
   async snapshot(options: { interestingOnly?: boolean; root?: ElementHandle } = {}): Promise<types.SerializedAXNode | null> {
     const root = options.root ? options.root._elementChannel : undefined;
     const result = await this._channel.accessibilitySnapshot({ interestingOnly: options.interestingOnly, root });
-    return result.axNode;
+    return result.rootAXNode;
   }
 }

--- a/src/rpc/client/accessibility.ts
+++ b/src/rpc/client/accessibility.ts
@@ -26,8 +26,9 @@ export class Accessibility {
     this._channel = channel;
   }
 
-  snapshot(options: { interestingOnly?: boolean; root?: ElementHandle } = {}): Promise<types.SerializedAXNode | null> {
+  async snapshot(options: { interestingOnly?: boolean; root?: ElementHandle } = {}): Promise<types.SerializedAXNode | null> {
     const root = options.root ? options.root._elementChannel : undefined;
-    return this._channel.accessibilitySnapshot({ interestingOnly: options.interestingOnly, root });
+    const result = await this._channel.accessibilitySnapshot({ interestingOnly: options.interestingOnly, root });
+    return result.axNode;
   }
 }

--- a/src/rpc/client/browser.ts
+++ b/src/rpc/client/browser.ts
@@ -53,7 +53,7 @@ export class Browser extends ChannelOwner<BrowserChannel, BrowserInitializer> {
   async newContext(options: types.BrowserContextOptions & { logger?: LoggerSink } = {}): Promise<BrowserContext> {
     const logger = options.logger;
     options = { ...options, logger: undefined };
-    const context = BrowserContext.from(await this._channel.newContext(options));
+    const context = BrowserContext.from((await this._channel.newContext(options)).context);
     this._contexts.add(context);
     context._logger = logger || this._logger;
     return context;

--- a/src/rpc/client/browserContext.ts
+++ b/src/rpc/client/browserContext.ts
@@ -53,9 +53,9 @@ export class BrowserContext extends ChannelOwner<BrowserContextChannel, BrowserC
       this._browser = parent;
     this._browserName = browserName;
 
-    this._channel.on('bindingCall', bindingCall => this._onBinding(BindingCall.from(bindingCall)));
+    this._channel.on('bindingCall', ({binding}) => this._onBinding(BindingCall.from(binding)));
     this._channel.on('close', () => this._onClose());
-    this._channel.on('page', page => this._onPage(Page.from(page)));
+    this._channel.on('page', ({page}) => this._onPage(Page.from(page)));
     this._channel.on('route', ({ route, request }) => this._onRoute(network.Route.from(route), network.Request.from(request)));
     this._closedPromise = new Promise(f => this.once(Events.BrowserContext.Close, f));
   }
@@ -99,7 +99,7 @@ export class BrowserContext extends ChannelOwner<BrowserContextChannel, BrowserC
   async newPage(): Promise<Page> {
     if (this._ownerPage)
       throw new Error('Please use browser.newContext()');
-    return Page.from(await this._channel.newPage());
+    return Page.from((await this._channel.newPage()).page);
   }
 
   async cookies(urls?: string | string[]): Promise<network.NetworkCookie[]> {
@@ -107,7 +107,7 @@ export class BrowserContext extends ChannelOwner<BrowserContextChannel, BrowserC
       urls = [];
     if (urls && typeof urls === 'string')
       urls = [ urls ];
-    return this._channel.cookies({ urls: urls as string[] });
+    return (await this._channel.cookies({ urls: urls as string[] })).cookies;
   }
 
   async addCookies(cookies: network.SetNetworkCookieParam[]): Promise<void> {

--- a/src/rpc/client/browserType.ts
+++ b/src/rpc/client/browserType.ts
@@ -43,20 +43,21 @@ export class BrowserType extends ChannelOwner<BrowserTypeChannel, BrowserTypeIni
   async launch(options: types.LaunchOptions & { logger?: LoggerSink } = {}): Promise<Browser> {
     const logger = options.logger;
     options = { ...options, logger: undefined };
-    const browser = Browser.from(await this._channel.launch(options));
+    const browser = Browser.from((await this._channel.launch(options)).browser);
     browser._logger = logger;
     return browser;
   }
 
   async launchServer(options: types.LaunchServerOptions & { logger?: LoggerSink } = {}): Promise<BrowserServer> {
     options = { ...options, logger: undefined };
-    return BrowserServer.from(await this._channel.launchServer(options));
+    return BrowserServer.from((await this._channel.launchServer(options)).server);
   }
 
   async launchPersistentContext(userDataDir: string, options: types.LaunchOptions & types.BrowserContextOptions & { logger?: LoggerSink } = {}): Promise<BrowserContext> {
     const logger = options.logger;
     options = { ...options, logger: undefined };
-    const context = BrowserContext.from(await this._channel.launchPersistentContext({ userDataDir, ...options }));
+    const result = await this._channel.launchPersistentContext({ userDataDir, ...options });
+    const context = BrowserContext.from(result.context);
     context._logger = logger;
     return context;
   }
@@ -64,7 +65,7 @@ export class BrowserType extends ChannelOwner<BrowserTypeChannel, BrowserTypeIni
   async connect(options: types.ConnectOptions & { logger?: LoggerSink }): Promise<Browser> {
     const logger = options.logger;
     options = { ...options, logger: undefined };
-    const browser = Browser.from(await this._channel.connect(options));
+    const browser = Browser.from((await this._channel.connect(options)).browser);
     browser._logger = logger;
     return browser;
   }

--- a/src/rpc/client/cdpSession.ts
+++ b/src/rpc/client/cdpSession.ts
@@ -47,7 +47,7 @@ export class CDPSession extends ChannelOwner<CDPSessionChannel, CDPSessionInitia
     params?: Protocol.CommandParameters[T]
   ): Promise<Protocol.CommandReturnValues[T]> {
     const result = await this._channel.send({ method, params });
-    return result as Protocol.CommandReturnValues[T];
+    return result.result as Protocol.CommandReturnValues[T];
   }
 
   async detach() {

--- a/src/rpc/client/chromiumBrowser.ts
+++ b/src/rpc/client/chromiumBrowser.ts
@@ -28,6 +28,6 @@ export class ChromiumBrowser extends Browser {
   }
 
   async stopTracing(): Promise<Buffer> {
-    return Buffer.from((await this._channel.crStopTracing()).trace, 'base64');
+    return Buffer.from((await this._channel.crStopTracing()).binary, 'base64');
   }
 }

--- a/src/rpc/client/chromiumBrowser.ts
+++ b/src/rpc/client/chromiumBrowser.ts
@@ -20,7 +20,7 @@ import { Browser } from './browser';
 
 export class ChromiumBrowser extends Browser {
   async newBrowserCDPSession(): Promise<CDPSession> {
-    return CDPSession.from(await this._channel.crNewBrowserCDPSession());
+    return CDPSession.from((await this._channel.crNewBrowserCDPSession()).session);
   }
 
   async startTracing(page?: Page, options: { path?: string; screenshots?: boolean; categories?: string[]; } = {}) {
@@ -28,6 +28,6 @@ export class ChromiumBrowser extends Browser {
   }
 
   async stopTracing(): Promise<Buffer> {
-    return Buffer.from(await this._channel.crStopTracing(), 'base64');
+    return Buffer.from((await this._channel.crStopTracing()).trace, 'base64');
   }
 }

--- a/src/rpc/client/chromiumBrowserContext.ts
+++ b/src/rpc/client/chromiumBrowserContext.ts
@@ -29,16 +29,16 @@ export class ChromiumBrowserContext extends BrowserContext {
 
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: BrowserContextInitializer) {
     super(parent, type, guid, initializer, 'chromium');
-    this._channel.on('crBackgroundPage', pageChannel => {
-      const page = Page.from(pageChannel);
-      this._backgroundPages.add(page);
-      this.emit(ChromiumEvents.CRBrowserContext.BackgroundPage, page);
+    this._channel.on('crBackgroundPage', ({ page }) => {
+      const backgroundPage = Page.from(page);
+      this._backgroundPages.add(backgroundPage);
+      this.emit(ChromiumEvents.CRBrowserContext.BackgroundPage, backgroundPage);
     });
-    this._channel.on('crServiceWorker', serviceWorkerChannel => {
-      const worker = Worker.from(serviceWorkerChannel);
-      worker._context = this;
-      this._serviceWorkers.add(worker);
-      this.emit(ChromiumEvents.CRBrowserContext.ServiceWorker, worker);
+    this._channel.on('crServiceWorker', ({worker}) => {
+      const serviceWorker = Worker.from(worker);
+      serviceWorker._context = this;
+      this._serviceWorkers.add(serviceWorker);
+      this.emit(ChromiumEvents.CRBrowserContext.ServiceWorker, serviceWorker);
     });
   }
 
@@ -51,6 +51,7 @@ export class ChromiumBrowserContext extends BrowserContext {
   }
 
   async newCDPSession(page: Page): Promise<CDPSession> {
-    return CDPSession.from(await this._channel.crNewCDPSession({ page: page._channel }));
+    const result = await this._channel.crNewCDPSession({ page: page._channel });
+    return CDPSession.from(result.session);
   }
 }

--- a/src/rpc/client/coverage.ts
+++ b/src/rpc/client/coverage.ts
@@ -29,7 +29,7 @@ export class Coverage {
   }
 
   async stopJSCoverage(): Promise<types.JSCoverageEntry[]> {
-    return await this._channel.crStopJSCoverage();
+    return (await this._channel.crStopJSCoverage()).entries;
   }
 
   async startCSSCoverage(options: types.CSSCoverageOptions = {}) {
@@ -37,6 +37,6 @@ export class Coverage {
   }
 
   async stopCSSCoverage(): Promise<types.CSSCoverageEntry[]> {
-    return await this._channel.crStopCSSCoverage();
+    return (await this._channel.crStopCSSCoverage()).entries;
   }
 }

--- a/src/rpc/client/download.ts
+++ b/src/rpc/client/download.ts
@@ -37,18 +37,18 @@ export class Download extends ChannelOwner<DownloadChannel, DownloadInitializer>
   }
 
   async path(): Promise<string | null> {
-    return this._channel.path();
+    return (await this._channel.path()).path;
   }
 
   async failure(): Promise<string | null> {
-    return this._channel.failure();
+    return (await this._channel.failure()).error;
   }
 
   async createReadStream(): Promise<Readable | null> {
-    const s = await this._channel.stream();
-    if (!s)
+    const result = await this._channel.stream();
+    if (!result.stream)
       return null;
-    const stream = Stream.from(s);
+    const stream = Stream.from(result.stream);
     return stream.stream();
   }
 

--- a/src/rpc/client/download.ts
+++ b/src/rpc/client/download.ts
@@ -37,7 +37,7 @@ export class Download extends ChannelOwner<DownloadChannel, DownloadInitializer>
   }
 
   async path(): Promise<string | null> {
-    return (await this._channel.path()).path;
+    return (await this._channel.path()).value;
   }
 
   async failure(): Promise<string | null> {

--- a/src/rpc/client/electron.ts
+++ b/src/rpc/client/electron.ts
@@ -37,7 +37,7 @@ export class Electron extends ChannelOwner<ElectronChannel, ElectronInitializer>
   async launch(executablePath: string, options: ElectronLaunchOptions = {}): Promise<ElectronApplication> {
     options = { ...options };
     delete (options as any).logger;
-    return ElectronApplication.from((await this._channel.launch({ executablePath, ...options })).application);
+    return ElectronApplication.from((await this._channel.launch({ executablePath, ...options })).electronApplication);
   }
 }
 

--- a/src/rpc/client/electron.ts
+++ b/src/rpc/client/electron.ts
@@ -37,7 +37,7 @@ export class Electron extends ChannelOwner<ElectronChannel, ElectronInitializer>
   async launch(executablePath: string, options: ElectronLaunchOptions = {}): Promise<ElectronApplication> {
     options = { ...options };
     delete (options as any).logger;
-    return ElectronApplication.from(await this._channel.launch({ executablePath, ...options }));
+    return ElectronApplication.from((await this._channel.launch({ executablePath, ...options })).application);
   }
 }
 
@@ -53,10 +53,10 @@ export class ElectronApplication extends ChannelOwner<ElectronApplicationChannel
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: ElectronApplicationInitializer) {
     super(parent, type, guid, initializer);
     this._context = BrowserContext.from(initializer.context);
-    this._channel.on('window', pageChannel => {
-      const page = Page.from(pageChannel);
-      this._windows.add(page);
-      this.emit(ElectronEvents.ElectronApplication.Window, page);
+    this._channel.on('window', ({page}) => {
+      const window = Page.from(page);
+      this._windows.add(window);
+      this.emit(ElectronEvents.ElectronApplication.Window, window);
     });
     this._channel.on('close', () => {
       this.emit(ElectronEvents.ElectronApplication.Close);
@@ -74,7 +74,8 @@ export class ElectronApplication extends ChannelOwner<ElectronApplicationChannel
   }
 
   async newBrowserWindow(options: any): Promise<Page> {
-    return Page.from(await this._channel.newBrowserWindow({ arg: serializeArgument(options) }));
+    const result = await this._channel.newBrowserWindow({ arg: serializeArgument(options) });
+    return Page.from(result.page);
   }
 
   context(): BrowserContext {
@@ -100,13 +101,14 @@ export class ElectronApplication extends ChannelOwner<ElectronApplicationChannel
   async evaluate<R, Arg>(pageFunction: FuncOn<any, Arg, R>, arg: Arg): Promise<R>;
   async evaluate<R>(pageFunction: FuncOn<any, void, R>, arg?: any): Promise<R>;
   async evaluate<R, Arg>(pageFunction: FuncOn<any, Arg, R>, arg: Arg): Promise<R> {
-    return parseResult(await this._channel.evaluateExpression({ expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) }));
+    const result = await this._channel.evaluateExpression({ expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) });
+    return parseResult(result.value);
   }
 
   async evaluateHandle<R, Arg>(pageFunction: FuncOn<any, Arg, R>, arg: Arg): Promise<SmartHandle<R>>;
   async evaluateHandle<R>(pageFunction: FuncOn<any, void, R>, arg?: any): Promise<SmartHandle<R>>;
   async evaluateHandle<R, Arg>(pageFunction: FuncOn<any, Arg, R>, arg: Arg): Promise<SmartHandle<R>> {
-    const handleChannel = await this._channel.evaluateExpressionHandle({ expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) });
-    return JSHandle.from(handleChannel) as SmartHandle<R>;
+    const result = await this._channel.evaluateExpressionHandle({ expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) });
+    return JSHandle.from(result.handle) as SmartHandle<R>;
   }
 }

--- a/src/rpc/client/elementHandle.ts
+++ b/src/rpc/client/elementHandle.ts
@@ -51,19 +51,19 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> {
   }
 
   async getAttribute(name: string): Promise<string | null> {
-    return (await this._elementChannel.getAttribute({ name })).attribute;
+    return (await this._elementChannel.getAttribute({ name })).value;
   }
 
   async textContent(): Promise<string | null> {
-    return (await this._elementChannel.textContent()).textContent;
+    return (await this._elementChannel.textContent()).value;
   }
 
   async innerText(): Promise<string> {
-    return (await this._elementChannel.innerText()).innerText;
+    return (await this._elementChannel.innerText()).value;
   }
 
   async innerHTML(): Promise<string> {
-    return (await this._elementChannel.innerHTML()).innerHTML;
+    return (await this._elementChannel.innerHTML()).value;
   }
 
   async dispatchEvent(type: string, eventInit: Object = {}) {
@@ -88,7 +88,7 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> {
 
   async selectOption(values: string | ElementHandle | types.SelectOption | string[] | ElementHandle[] | types.SelectOption[] | null, options: types.NavigatingActionWaitOptions = {}): Promise<string[]> {
     const result = await this._elementChannel.selectOption({ ...convertSelectOptionValues(values), ...options });
-    return result.selectedValues;
+    return result.values;
   }
 
   async fill(value: string, options: types.NavigatingActionWaitOptions = {}): Promise<void> {
@@ -124,11 +124,11 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> {
   }
 
   async boundingBox(): Promise<types.Rect | null> {
-    return (await this._elementChannel.boundingBox()).box;
+    return (await this._elementChannel.boundingBox()).value;
   }
 
   async screenshot(options: types.ElementScreenshotOptions = {}): Promise<Buffer> {
-    return Buffer.from((await this._elementChannel.screenshot(options)).screenshot, 'base64');
+    return Buffer.from((await this._elementChannel.screenshot(options)).binary, 'base64');
   }
 
   async $(selector: string): Promise<ElementHandle<Element> | null> {

--- a/src/rpc/client/elementHandle.ts
+++ b/src/rpc/client/elementHandle.ts
@@ -43,27 +43,27 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> {
   }
 
   async ownerFrame(): Promise<Frame | null> {
-    return Frame.fromNullable(await this._elementChannel.ownerFrame());
+    return Frame.fromNullable((await this._elementChannel.ownerFrame()).frame);
   }
 
   async contentFrame(): Promise<Frame | null> {
-    return Frame.fromNullable(await this._elementChannel.contentFrame());
+    return Frame.fromNullable((await this._elementChannel.contentFrame()).frame);
   }
 
   async getAttribute(name: string): Promise<string | null> {
-    return await this._elementChannel.getAttribute({ name });
+    return (await this._elementChannel.getAttribute({ name })).attribute;
   }
 
   async textContent(): Promise<string | null> {
-    return await this._elementChannel.textContent();
+    return (await this._elementChannel.textContent()).textContent;
   }
 
   async innerText(): Promise<string> {
-    return await this._elementChannel.innerText();
+    return (await this._elementChannel.innerText()).innerText;
   }
 
   async innerHTML(): Promise<string> {
-    return await this._elementChannel.innerHTML();
+    return (await this._elementChannel.innerHTML()).innerHTML;
   }
 
   async dispatchEvent(type: string, eventInit: Object = {}) {
@@ -87,7 +87,8 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> {
   }
 
   async selectOption(values: string | ElementHandle | types.SelectOption | string[] | ElementHandle[] | types.SelectOption[] | null, options: types.NavigatingActionWaitOptions = {}): Promise<string[]> {
-    return await this._elementChannel.selectOption({ ...convertSelectOptionValues(values), ...options });
+    const result = await this._elementChannel.selectOption({ ...convertSelectOptionValues(values), ...options });
+    return result.selectedValues;
   }
 
   async fill(value: string, options: types.NavigatingActionWaitOptions = {}): Promise<void> {
@@ -123,31 +124,34 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> {
   }
 
   async boundingBox(): Promise<types.Rect | null> {
-    return await this._elementChannel.boundingBox();
+    return (await this._elementChannel.boundingBox()).box;
   }
 
   async screenshot(options: types.ElementScreenshotOptions = {}): Promise<Buffer> {
-    return Buffer.from(await this._elementChannel.screenshot(options), 'base64');
+    return Buffer.from((await this._elementChannel.screenshot(options)).screenshot, 'base64');
   }
 
   async $(selector: string): Promise<ElementHandle<Element> | null> {
-    return ElementHandle.fromNullable(await this._elementChannel.querySelector({ selector })) as ElementHandle<Element> | null;
+    return ElementHandle.fromNullable((await this._elementChannel.querySelector({ selector })).element) as ElementHandle<Element> | null;
   }
 
   async $$(selector: string): Promise<ElementHandle<Element>[]> {
-    return (await this._elementChannel.querySelectorAll({ selector })).map(h => ElementHandle.from(h) as ElementHandle<Element>);
+    const result = await this._elementChannel.querySelectorAll({ selector });
+    return result.elements.map(h => ElementHandle.from(h) as ElementHandle<Element>);
   }
 
   async $eval<R, Arg>(selector: string, pageFunction: FuncOn<Element, Arg, R>, arg: Arg): Promise<R>;
   async $eval<R>(selector: string, pageFunction: FuncOn<Element, void, R>, arg?: any): Promise<R>;
   async $eval<R, Arg>(selector: string, pageFunction: FuncOn<Element, Arg, R>, arg: Arg): Promise<R> {
-    return parseResult(await this._elementChannel.evalOnSelector({ selector, expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) }));
+    const result = await this._elementChannel.evalOnSelector({ selector, expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) });
+    return parseResult(result.value);
   }
 
   async $$eval<R, Arg>(selector: string, pageFunction: FuncOn<Element[], Arg, R>, arg: Arg): Promise<R>;
   async $$eval<R>(selector: string, pageFunction: FuncOn<Element[], void, R>, arg?: any): Promise<R>;
   async $$eval<R, Arg>(selector: string, pageFunction: FuncOn<Element[], Arg, R>, arg: Arg): Promise<R> {
-    return parseResult(await this._elementChannel.evalOnSelectorAll({ selector, expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) }));
+    const result = await this._elementChannel.evalOnSelectorAll({ selector, expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) });
+    return parseResult(result.value);
   }
 }
 

--- a/src/rpc/client/frame.ts
+++ b/src/rpc/client/frame.ts
@@ -156,7 +156,7 @@ export class Frame extends ChannelOwner<FrameChannel, FrameInitializer> {
   }
 
   async content(): Promise<string> {
-    return (await this._channel.content()).content;
+    return (await this._channel.content()).value;
   }
 
   async setContent(html: string, options: types.NavigateOptions = {}): Promise<void> {
@@ -216,19 +216,19 @@ export class Frame extends ChannelOwner<FrameChannel, FrameInitializer> {
   }
 
   async textContent(selector: string, options: types.TimeoutOptions = {}): Promise<null|string> {
-    return (await this._channel.textContent({ selector, ...options, isPage: this._page!._isPageCall })).textContent;
+    return (await this._channel.textContent({ selector, ...options, isPage: this._page!._isPageCall })).value;
   }
 
   async innerText(selector: string, options: types.TimeoutOptions = {}): Promise<string> {
-    return (await this._channel.innerText({ selector, ...options, isPage: this._page!._isPageCall })).innerText;
+    return (await this._channel.innerText({ selector, ...options, isPage: this._page!._isPageCall })).value;
   }
 
   async innerHTML(selector: string, options: types.TimeoutOptions = {}): Promise<string> {
-    return (await this._channel.innerHTML({ selector, ...options, isPage: this._page!._isPageCall })).innerHTML;
+    return (await this._channel.innerHTML({ selector, ...options, isPage: this._page!._isPageCall })).value;
   }
 
   async getAttribute(selector: string, name: string, options: types.TimeoutOptions = {}): Promise<string | null> {
-    return (await this._channel.getAttribute({ selector, name, ...options, isPage: this._page!._isPageCall })).attribute;
+    return (await this._channel.getAttribute({ selector, name, ...options, isPage: this._page!._isPageCall })).value;
   }
 
   async hover(selector: string, options: types.PointerActionOptions & types.PointerActionWaitOptions = {}) {
@@ -236,7 +236,7 @@ export class Frame extends ChannelOwner<FrameChannel, FrameInitializer> {
   }
 
   async selectOption(selector: string, values: string | ElementHandle | types.SelectOption | string[] | ElementHandle[] | types.SelectOption[] | null, options: types.NavigatingActionWaitOptions = {}): Promise<string[]> {
-    return (await this._channel.selectOption({ selector, ...convertSelectOptionValues(values), ...options, isPage: this._page!._isPageCall })).selectedValues;
+    return (await this._channel.selectOption({ selector, ...convertSelectOptionValues(values), ...options, isPage: this._page!._isPageCall })).values;
   }
 
   async setInputFiles(selector: string, files: string | types.FilePayload | string[] | types.FilePayload[], options: types.NavigatingActionWaitOptions = {}): Promise<void> {
@@ -271,7 +271,7 @@ export class Frame extends ChannelOwner<FrameChannel, FrameInitializer> {
   }
 
   async title(): Promise<string> {
-    return (await this._channel.title()).title;
+    return (await this._channel.title()).value;
   }
 }
 

--- a/src/rpc/client/network.ts
+++ b/src/rpc/client/network.ts
@@ -199,7 +199,7 @@ export class Response extends ChannelOwner<ResponseChannel, ResponseInitializer>
   }
 
   async body(): Promise<Buffer> {
-    return Buffer.from((await this._channel.body()).body, 'base64');
+    return Buffer.from((await this._channel.body()).binary, 'base64');
   }
 
   async text(): Promise<string> {

--- a/src/rpc/client/network.ts
+++ b/src/rpc/client/network.ts
@@ -104,7 +104,7 @@ export class Request extends ChannelOwner<RequestChannel, RequestInitializer> {
   }
 
   async response(): Promise<Response | null> {
-    return Response.fromNullable(await this._channel.response());
+    return Response.fromNullable((await this._channel.response()).response);
   }
 
   frame(): Frame {
@@ -195,11 +195,11 @@ export class Response extends ChannelOwner<ResponseChannel, ResponseInitializer>
   }
 
   async finished(): Promise<Error | null> {
-    return await this._channel.finished();
+    return (await this._channel.finished()).error;
   }
 
   async body(): Promise<Buffer> {
-    return Buffer.from(await this._channel.body(), 'base64');
+    return Buffer.from((await this._channel.body()).body, 'base64');
   }
 
   async text(): Promise<string> {

--- a/src/rpc/client/page.ts
+++ b/src/rpc/client/page.ts
@@ -391,7 +391,7 @@ export class Page extends ChannelOwner<PageChannel, PageInitializer> {
   }
 
   async screenshot(options: types.ScreenshotOptions = {}): Promise<Buffer> {
-    return Buffer.from((await this._channel.screenshot(options)).screenshot, 'base64');
+    return Buffer.from((await this._channel.screenshot(options)).binary, 'base64');
   }
 
   async title(): Promise<string> {

--- a/src/rpc/client/selectors.ts
+++ b/src/rpc/client/selectors.ts
@@ -34,6 +34,6 @@ export class Selectors extends ChannelOwner<SelectorsChannel, SelectorsInitializ
   }
 
   async _createSelector(name: string, handle: ElementHandle<Element>): Promise<string | undefined> {
-    return this._channel.createSelector({ name, handle: handle._elementChannel });
+    return (await this._channel.createSelector({ name, handle: handle._elementChannel })).selector;
   }
 }

--- a/src/rpc/client/selectors.ts
+++ b/src/rpc/client/selectors.ts
@@ -34,6 +34,6 @@ export class Selectors extends ChannelOwner<SelectorsChannel, SelectorsInitializ
   }
 
   async _createSelector(name: string, handle: ElementHandle<Element>): Promise<string | undefined> {
-    return (await this._channel.createSelector({ name, handle: handle._elementChannel })).selector;
+    return (await this._channel.createSelector({ name, handle: handle._elementChannel })).value;
   }
 }

--- a/src/rpc/client/stream.ts
+++ b/src/rpc/client/stream.ts
@@ -41,9 +41,9 @@ class StreamImpl extends Readable {
   }
 
   async _read(size: number) {
-    const data = await this._channel.read({ size });
-    if (data)
-      this.push(Buffer.from(data, 'base64'));
+    const result = await this._channel.read({ size });
+    if (result.data)
+      this.push(Buffer.from(result.data, 'base64'));
     else
       this.push(null);
   }

--- a/src/rpc/client/stream.ts
+++ b/src/rpc/client/stream.ts
@@ -42,8 +42,8 @@ class StreamImpl extends Readable {
 
   async _read(size: number) {
     const result = await this._channel.read({ size });
-    if (result.data)
-      this.push(Buffer.from(result.data, 'base64'));
+    if (result.binary)
+      this.push(Buffer.from(result.binary, 'base64'));
     else
       this.push(null);
   }

--- a/src/rpc/client/worker.ts
+++ b/src/rpc/client/worker.ts
@@ -50,13 +50,15 @@ export class Worker extends ChannelOwner<WorkerChannel, WorkerInitializer> {
   async evaluate<R>(pageFunction: Func1<void, R>, arg?: any): Promise<R>;
   async evaluate<R, Arg>(pageFunction: Func1<Arg, R>, arg: Arg): Promise<R> {
     assertMaxArguments(arguments.length, 2);
-    return parseResult(await this._channel.evaluateExpression({ expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) }));
+    const result = await this._channel.evaluateExpression({ expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) });
+    return parseResult(result.value);
   }
 
   async evaluateHandle<R, Arg>(pageFunction: Func1<Arg, R>, arg: Arg): Promise<SmartHandle<R>>;
   async evaluateHandle<R>(pageFunction: Func1<void, R>, arg?: any): Promise<SmartHandle<R>>;
   async evaluateHandle<R, Arg>(pageFunction: Func1<Arg, R>, arg: Arg): Promise<SmartHandle<R>> {
     assertMaxArguments(arguments.length, 2);
-    return JSHandle.from(await this._channel.evaluateExpressionHandle({ expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) })) as SmartHandle<R>;
+    const result = await this._channel.evaluateExpressionHandle({ expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) });
+    return JSHandle.from(result.handle) as SmartHandle<R>;
   }
 }

--- a/src/rpc/server/browserDispatcher.ts
+++ b/src/rpc/server/browserDispatcher.ts
@@ -52,9 +52,9 @@ export class BrowserDispatcher extends Dispatcher<Browser, BrowserInitializer> i
     await crBrowser.startTracing(params.page ? params.page._object : undefined, params);
   }
 
-  async crStopTracing(): Promise<{ trace: Binary }> {
+  async crStopTracing(): Promise<{ binary: Binary }> {
     const crBrowser = this._object as CRBrowser;
     const buffer = await crBrowser.stopTracing();
-    return { trace: buffer.toString('base64') };
+    return { binary: buffer.toString('base64') };
   }
 }

--- a/src/rpc/server/browserDispatcher.ts
+++ b/src/rpc/server/browserDispatcher.ts
@@ -34,17 +34,17 @@ export class BrowserDispatcher extends Dispatcher<Browser, BrowserInitializer> i
     });
   }
 
-  async newContext(params: types.BrowserContextOptions): Promise<BrowserContextChannel> {
-    return new BrowserContextDispatcher(this._scope, await this._object.newContext(params) as BrowserContextBase);
+  async newContext(params: types.BrowserContextOptions): Promise<{ context: BrowserContextChannel }> {
+    return { context: new BrowserContextDispatcher(this._scope, await this._object.newContext(params) as BrowserContextBase) };
   }
 
   async close(): Promise<void> {
     await this._object.close();
   }
 
-  async crNewBrowserCDPSession(): Promise<CDPSessionChannel> {
+  async crNewBrowserCDPSession(): Promise<{ session: CDPSessionChannel }> {
     const crBrowser = this._object as CRBrowser;
-    return new CDPSessionDispatcher(this._scope, await crBrowser.newBrowserCDPSession());
+    return { session: new CDPSessionDispatcher(this._scope, await crBrowser.newBrowserCDPSession()) };
   }
 
   async crStartTracing(params: { page?: PageDispatcher, path?: string, screenshots?: boolean, categories?: string[] }): Promise<void> {
@@ -52,9 +52,9 @@ export class BrowserDispatcher extends Dispatcher<Browser, BrowserInitializer> i
     await crBrowser.startTracing(params.page ? params.page._object : undefined, params);
   }
 
-  async crStopTracing(): Promise<Binary> {
+  async crStopTracing(): Promise<{ trace: Binary }> {
     const crBrowser = this._object as CRBrowser;
     const buffer = await crBrowser.stopTracing();
-    return buffer.toString('base64');
+    return { trace: buffer.toString('base64') };
   }
 }

--- a/src/rpc/server/browserTypeDispatcher.ts
+++ b/src/rpc/server/browserTypeDispatcher.ts
@@ -32,22 +32,22 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, BrowserTypeIn
     }, true, browserType.name());
   }
 
-  async launch(params: types.LaunchOptions): Promise<BrowserChannel> {
+  async launch(params: types.LaunchOptions): Promise<{ browser: BrowserChannel }> {
     const browser = await this._object.launch(params);
-    return new BrowserDispatcher(this._scope, browser as BrowserBase);
+    return { browser: new BrowserDispatcher(this._scope, browser as BrowserBase) };
   }
 
-  async launchPersistentContext(params: { userDataDir: string } & types.LaunchOptions & types.BrowserContextOptions): Promise<BrowserContextChannel> {
+  async launchPersistentContext(params: { userDataDir: string } & types.LaunchOptions & types.BrowserContextOptions): Promise<{ context: BrowserContextChannel }> {
     const browserContext = await this._object.launchPersistentContext(params.userDataDir, params);
-    return new BrowserContextDispatcher(this._scope, browserContext as BrowserContextBase);
+    return { context: new BrowserContextDispatcher(this._scope, browserContext as BrowserContextBase) };
   }
 
-  async launchServer(params: types.LaunchServerOptions): Promise<BrowserServerChannel> {
-    return new BrowserServerDispatcher(this._scope, await this._object.launchServer(params));
+  async launchServer(params: types.LaunchServerOptions): Promise<{ server: BrowserServerChannel }> {
+    return { server: new BrowserServerDispatcher(this._scope, await this._object.launchServer(params)) };
   }
 
-  async connect(params: types.ConnectOptions): Promise<BrowserChannel> {
+  async connect(params: types.ConnectOptions): Promise<{ browser: BrowserChannel }> {
     const browser = await this._object.connect(params);
-    return new BrowserDispatcher(this._scope, browser as BrowserBase);
+    return { browser: new BrowserDispatcher(this._scope, browser as BrowserBase) };
   }
 }

--- a/src/rpc/server/cdpSessionDispatcher.ts
+++ b/src/rpc/server/cdpSessionDispatcher.ts
@@ -28,8 +28,8 @@ export class CDPSessionDispatcher extends Dispatcher<CRSession, CDPSessionInitia
     });
   }
 
-  async send(params: { method: string, params?: Object }): Promise<Object> {
-    return this._object.send(params.method as any, params.params);
+  async send(params: { method: string, params?: Object }): Promise<{ result: Object }> {
+    return { result: await this._object.send(params.method as any, params.params) };
   }
 
   async detach(): Promise<void> {

--- a/src/rpc/server/downloadDispatcher.ts
+++ b/src/rpc/server/downloadDispatcher.ts
@@ -27,8 +27,8 @@ export class DownloadDispatcher extends Dispatcher<Download, DownloadInitializer
     });
   }
 
-  async path(): Promise<{ path: string | null }> {
-    return { path: await this._object.path() };
+  async path(): Promise<{ value: string | null }> {
+    return { value: await this._object.path() };
   }
 
   async stream(): Promise<{ stream: StreamChannel | null }> {

--- a/src/rpc/server/downloadDispatcher.ts
+++ b/src/rpc/server/downloadDispatcher.ts
@@ -27,20 +27,20 @@ export class DownloadDispatcher extends Dispatcher<Download, DownloadInitializer
     });
   }
 
-  async path(): Promise<string | null> {
-    return this._object.path();
+  async path(): Promise<{ path: string | null }> {
+    return { path: await this._object.path() };
   }
 
-  async stream(): Promise<StreamChannel | null> {
+  async stream(): Promise<{ stream: StreamChannel | null }> {
     const stream = await this._object.createReadStream();
     if (!stream)
-      return null;
+      return { stream: null };
     await new Promise(f => stream.on('readable', f));
-    return new StreamDispatcher(this._scope, stream);
+    return { stream: new StreamDispatcher(this._scope, stream) };
   }
 
-  async failure(): Promise<string | null> {
-    return this._object.failure();
+  async failure(): Promise<{ error: string | null }> {
+    return { error: await this._object.failure() };
   }
 
   async delete(): Promise<void> {

--- a/src/rpc/server/electronDispatcher.ts
+++ b/src/rpc/server/electronDispatcher.ts
@@ -29,9 +29,9 @@ export class ElectronDispatcher extends Dispatcher<Electron, ElectronInitializer
     super(scope, electron, 'electron', {}, true);
   }
 
-  async launch(params: { executablePath: string } & ElectronLaunchOptions): Promise<{ application: ElectronApplicationChannel }> {
+  async launch(params: { executablePath: string } & ElectronLaunchOptions): Promise<{ electronApplication: ElectronApplicationChannel }> {
     const electronApplication = await this._object.launch(params.executablePath, params);
-    return { application: new ElectronApplicationDispatcher(this._scope, electronApplication) };
+    return { electronApplication: new ElectronApplicationDispatcher(this._scope, electronApplication) };
   }
 }
 

--- a/src/rpc/server/elementHandlerDispatcher.ts
+++ b/src/rpc/server/elementHandlerDispatcher.ts
@@ -48,20 +48,20 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
     return { frame: lookupNullableDispatcher<FrameDispatcher>(await this._elementHandle.contentFrame()) };
   }
 
-  async getAttribute(params: { name: string }): Promise<{ attribute: string | null }> {
-    return { attribute: await this._elementHandle.getAttribute(params.name) };
+  async getAttribute(params: { name: string }): Promise<{ value: string | null }> {
+    return { value: await this._elementHandle.getAttribute(params.name) };
   }
 
-  async textContent(): Promise<{ textContent: string | null }> {
-    return { textContent: await this._elementHandle.textContent() };
+  async textContent(): Promise<{ value: string | null }> {
+    return { value: await this._elementHandle.textContent() };
   }
 
-  async innerText(): Promise<{ innerText: string }> {
-    return { innerText: await this._elementHandle.innerText() };
+  async innerText(): Promise<{ value: string }> {
+    return { value: await this._elementHandle.innerText() };
   }
 
-  async innerHTML(): Promise<{ innerHTML: string }> {
-    return { innerHTML: await this._elementHandle.innerHTML() };
+  async innerHTML(): Promise<{ value: string }> {
+    return { value: await this._elementHandle.innerHTML() };
   }
 
   async dispatchEvent(params: { type: string, eventInit: Object }) {
@@ -84,8 +84,8 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
     await this._elementHandle.dblclick(params);
   }
 
-  async selectOption(params: { elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions): Promise<{ selectedValues: string[] }> {
-    return { selectedValues: await this._elementHandle.selectOption(convertSelectOptionValues(params.elements, params.options), params) };
+  async selectOption(params: { elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions): Promise<{ values: string[] }> {
+    return { values: await this._elementHandle.selectOption(convertSelectOptionValues(params.elements, params.options), params) };
   }
 
   async fill(params: { value: string } & types.NavigatingActionWaitOptions) {
@@ -120,12 +120,12 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
     await this._elementHandle.uncheck(params);
   }
 
-  async boundingBox(): Promise<{ box: types.Rect | null }> {
-    return { box: await this._elementHandle.boundingBox() };
+  async boundingBox(): Promise<{ value: types.Rect | null }> {
+    return { value: await this._elementHandle.boundingBox() };
   }
 
-  async screenshot(params: types.ElementScreenshotOptions): Promise<{ screenshot: Binary }> {
-    return { screenshot: (await this._elementHandle.screenshot(params)).toString('base64') };
+  async screenshot(params: types.ElementScreenshotOptions): Promise<{ binary: Binary }> {
+    return { binary: (await this._elementHandle.screenshot(params)).toString('base64') };
   }
 
   async querySelector(params: { selector: string }): Promise<{ element: ElementHandleChannel | null }> {

--- a/src/rpc/server/elementHandlerDispatcher.ts
+++ b/src/rpc/server/elementHandlerDispatcher.ts
@@ -17,7 +17,7 @@
 import { ElementHandle } from '../../dom';
 import * as js from '../../javascript';
 import * as types from '../../types';
-import { ElementHandleChannel, FrameChannel } from '../channels';
+import { ElementHandleChannel, FrameChannel, Binary } from '../channels';
 import { DispatcherScope, lookupNullableDispatcher } from './dispatcher';
 import { JSHandleDispatcher, serializeResult, parseArgument } from './jsHandleDispatcher';
 import { FrameDispatcher } from './frameDispatcher';
@@ -40,28 +40,28 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
     this._elementHandle = elementHandle;
   }
 
-  async ownerFrame(): Promise<FrameChannel | null> {
-    return lookupNullableDispatcher<FrameDispatcher>(await this._elementHandle.ownerFrame());
+  async ownerFrame(): Promise<{ frame: FrameChannel | null }> {
+    return { frame: lookupNullableDispatcher<FrameDispatcher>(await this._elementHandle.ownerFrame()) };
   }
 
-  async contentFrame(): Promise<FrameChannel | null> {
-    return lookupNullableDispatcher<FrameDispatcher>(await this._elementHandle.contentFrame());
+  async contentFrame(): Promise<{ frame: FrameChannel | null }> {
+    return { frame: lookupNullableDispatcher<FrameDispatcher>(await this._elementHandle.contentFrame()) };
   }
 
-  async getAttribute(params: { name: string }): Promise<string | null> {
-    return this._elementHandle.getAttribute(params.name);
+  async getAttribute(params: { name: string }): Promise<{ attribute: string | null }> {
+    return { attribute: await this._elementHandle.getAttribute(params.name) };
   }
 
-  async textContent(): Promise<string | null> {
-    return this._elementHandle.textContent();
+  async textContent(): Promise<{ textContent: string | null }> {
+    return { textContent: await this._elementHandle.textContent() };
   }
 
-  async innerText(): Promise<string> {
-    return this._elementHandle.innerText();
+  async innerText(): Promise<{ innerText: string }> {
+    return { innerText: await this._elementHandle.innerText() };
   }
 
-  async innerHTML(): Promise<string> {
-    return this._elementHandle.innerHTML();
+  async innerHTML(): Promise<{ innerHTML: string }> {
+    return { innerHTML: await this._elementHandle.innerHTML() };
   }
 
   async dispatchEvent(params: { type: string, eventInit: Object }) {
@@ -84,8 +84,8 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
     await this._elementHandle.dblclick(params);
   }
 
-  async selectOption(params: { elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions): Promise<string[]> {
-    return this._elementHandle.selectOption(convertSelectOptionValues(params.elements, params.options), params);
+  async selectOption(params: { elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions): Promise<{ selectedValues: string[] }> {
+    return { selectedValues: await this._elementHandle.selectOption(convertSelectOptionValues(params.elements, params.options), params) };
   }
 
   async fill(params: { value: string } & types.NavigatingActionWaitOptions) {
@@ -120,30 +120,30 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
     await this._elementHandle.uncheck(params);
   }
 
-  async boundingBox(): Promise<types.Rect | null> {
-    return await this._elementHandle.boundingBox();
+  async boundingBox(): Promise<{ box: types.Rect | null }> {
+    return { box: await this._elementHandle.boundingBox() };
   }
 
-  async screenshot(params: types.ElementScreenshotOptions): Promise<string> {
-    return (await this._elementHandle.screenshot(params)).toString('base64');
+  async screenshot(params: types.ElementScreenshotOptions): Promise<{ screenshot: Binary }> {
+    return { screenshot: (await this._elementHandle.screenshot(params)).toString('base64') };
   }
 
-  async querySelector(params: { selector: string }): Promise<ElementHandleChannel | null> {
+  async querySelector(params: { selector: string }): Promise<{ element: ElementHandleChannel | null }> {
     const handle = await this._elementHandle.$(params.selector);
-    return handle ? new ElementHandleDispatcher(this._scope, handle) : null;
+    return { element: handle ? new ElementHandleDispatcher(this._scope, handle) : null };
   }
 
-  async querySelectorAll(params: { selector: string }): Promise<ElementHandleChannel[]> {
+  async querySelectorAll(params: { selector: string }): Promise<{ elements: ElementHandleChannel[] }> {
     const elements = await this._elementHandle.$$(params.selector);
-    return elements.map(e => new ElementHandleDispatcher(this._scope, e));
+    return { elements: elements.map(e => new ElementHandleDispatcher(this._scope, e)) };
   }
 
-  async evalOnSelector(params: { selector: string, expression: string, isFunction: boolean, arg: any }): Promise<any> {
-    return serializeResult(await this._elementHandle._$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg)));
+  async evalOnSelector(params: { selector: string, expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }> {
+    return { value: serializeResult(await this._elementHandle._$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
-  async evalOnSelectorAll(params: { selector: string, expression: string, isFunction: boolean, arg: any }): Promise<any> {
-    return serializeResult(await this._elementHandle._$$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg)));
+  async evalOnSelectorAll(params: { selector: string, expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }> {
+    return { value: serializeResult(await this._elementHandle._$$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 }
 

--- a/src/rpc/server/frameDispatcher.ts
+++ b/src/rpc/server/frameDispatcher.ts
@@ -46,33 +46,33 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     });
   }
 
-  async goto(params: { url: string } & types.GotoOptions & PageAttribution): Promise<ResponseChannel | null> {
+  async goto(params: { url: string } & types.GotoOptions & PageAttribution): Promise<{ response: ResponseChannel | null }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return lookupNullableDispatcher<ResponseDispatcher>(await target.goto(params.url, params));
+    return { response: lookupNullableDispatcher<ResponseDispatcher>(await target.goto(params.url, params)) };
   }
 
-  async waitForNavigation(params: types.WaitForNavigationOptions & PageAttribution): Promise<ResponseChannel | null> {
+  async waitForNavigation(params: types.WaitForNavigationOptions & PageAttribution): Promise<{ response: ResponseChannel | null }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return lookupNullableDispatcher<ResponseDispatcher>(await target.waitForNavigation(params));
+    return { response: lookupNullableDispatcher<ResponseDispatcher>(await target.waitForNavigation(params)) };
   }
 
-  async frameElement(): Promise<ElementHandleChannel> {
-    return new ElementHandleDispatcher(this._scope, await this._frame.frameElement());
+  async frameElement(): Promise<{ element: ElementHandleChannel }> {
+    return { element: new ElementHandleDispatcher(this._scope, await this._frame.frameElement()) };
   }
 
-  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: any } & PageAttribution): Promise<any> {
+  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: any } & PageAttribution): Promise<{ value: any }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return serializeResult(await target._evaluateExpression(params.expression, params.isFunction, parseArgument(params.arg)));
+    return { value: serializeResult(await target._evaluateExpression(params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
-  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any } & PageAttribution): Promise<JSHandleChannel> {
+  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any } & PageAttribution): Promise<{ handle: JSHandleChannel }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return createHandle(this._scope, await target._evaluateExpressionHandle(params.expression, params.isFunction, parseArgument(params.arg)));
+    return { handle: createHandle(this._scope, await target._evaluateExpressionHandle(params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
-  async waitForSelector(params: { selector: string } & types.WaitForElementOptions & PageAttribution): Promise<ElementHandleChannel | null> {
+  async waitForSelector(params: { selector: string } & types.WaitForElementOptions & PageAttribution): Promise<{ element: ElementHandleChannel | null }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return ElementHandleDispatcher.createNullable(this._scope, await target.waitForSelector(params.selector, params));
+    return { element: ElementHandleDispatcher.createNullable(this._scope, await target.waitForSelector(params.selector, params)) };
   }
 
   async dispatchEvent(params: { selector: string, type: string, eventInit: any } & types.TimeoutOptions & PageAttribution): Promise<void> {
@@ -80,29 +80,29 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     return target.dispatchEvent(params.selector, params.type, parseArgument(params.eventInit), params);
   }
 
-  async evalOnSelector(params: { selector: string, expression: string, isFunction: boolean, arg: any } & PageAttribution): Promise<any> {
+  async evalOnSelector(params: { selector: string, expression: string, isFunction: boolean, arg: any } & PageAttribution): Promise<{ value: any }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return serializeResult(await target._$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg)));
+    return { value: serializeResult(await target._$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
-  async evalOnSelectorAll(params: { selector: string, expression: string, isFunction: boolean, arg: any } & PageAttribution): Promise<any> {
+  async evalOnSelectorAll(params: { selector: string, expression: string, isFunction: boolean, arg: any } & PageAttribution): Promise<{ value: any }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return serializeResult(await target._$$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg)));
+    return { value: serializeResult(await target._$$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
-  async querySelector(params: { selector: string } & PageAttribution): Promise<ElementHandleChannel | null> {
+  async querySelector(params: { selector: string } & PageAttribution): Promise<{ element: ElementHandleChannel | null }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return ElementHandleDispatcher.createNullable(this._scope, await target.$(params.selector));
+    return { element: ElementHandleDispatcher.createNullable(this._scope, await target.$(params.selector)) };
   }
 
-  async querySelectorAll(params: { selector: string } & PageAttribution): Promise<ElementHandleChannel[]> {
+  async querySelectorAll(params: { selector: string } & PageAttribution): Promise<{ elements: ElementHandleChannel[] }> {
     const target = params.isPage ? this._frame._page : this._frame;
     const elements = await target.$$(params.selector);
-    return elements.map(e => new ElementHandleDispatcher(this._scope, e));
+    return { elements: elements.map(e => new ElementHandleDispatcher(this._scope, e)) };
   }
 
-  async content(): Promise<string> {
-    return await this._frame.content();
+  async content(): Promise<{ content: string }> {
+    return { content: await this._frame.content() };
   }
 
   async setContent(params: { html: string } & types.NavigateOptions & PageAttribution): Promise<void> {
@@ -110,14 +110,14 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     await target.setContent(params.html, params);
   }
 
-  async addScriptTag(params: { url?: string, content?: string, type?: string } & PageAttribution): Promise<ElementHandleChannel> {
+  async addScriptTag(params: { url?: string, content?: string, type?: string } & PageAttribution): Promise<{ element: ElementHandleChannel }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return new ElementHandleDispatcher(this._scope, await target.addScriptTag(params));
+    return { element: new ElementHandleDispatcher(this._scope, await target.addScriptTag(params)) };
   }
 
-  async addStyleTag(params: { url?: string, content?: string } & PageAttribution): Promise<ElementHandleChannel> {
+  async addStyleTag(params: { url?: string, content?: string } & PageAttribution): Promise<{ element: ElementHandleChannel }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return new ElementHandleDispatcher(this._scope, await target.addStyleTag(params));
+    return { element: new ElementHandleDispatcher(this._scope, await target.addStyleTag(params)) };
   }
 
   async click(params: { selector: string } & types.PointerActionOptions & types.MouseClickOptions & types.TimeoutOptions & { force?: boolean } & { noWaitAfter?: boolean } & PageAttribution): Promise<void> {
@@ -140,24 +140,24 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     await target.focus(params.selector, params);
   }
 
-  async textContent(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<string | null> {
+  async textContent(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ textContent: string | null }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return await target.textContent(params.selector, params);
+    return { textContent: await target.textContent(params.selector, params) };
   }
 
-  async innerText(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<string> {
+  async innerText(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ innerText: string }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return await target.innerText(params.selector, params);
+    return { innerText: await target.innerText(params.selector, params) };
   }
 
-  async innerHTML(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<string> {
+  async innerHTML(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ innerHTML: string }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return await target.innerHTML(params.selector, params);
+    return { innerHTML: await target.innerHTML(params.selector, params) };
   }
 
-  async getAttribute(params: { selector: string, name: string } & types.TimeoutOptions & PageAttribution): Promise<string | null> {
+  async getAttribute(params: { selector: string, name: string } & types.TimeoutOptions & PageAttribution): Promise<{ attribute: string | null }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return await target.getAttribute(params.selector, params.name, params);
+    return { attribute: await target.getAttribute(params.selector, params.name, params) };
   }
 
   async hover(params: { selector: string } & types.PointerActionOptions & types.TimeoutOptions & { force?: boolean } & PageAttribution): Promise<void> {
@@ -165,9 +165,9 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     await target.hover(params.selector, params);
   }
 
-  async selectOption(params: { selector: string, elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<string[]> {
+  async selectOption(params: { selector: string, elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<{ selectedValues: string[] }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return target.selectOption(params.selector, convertSelectOptionValues(params.elements, params.options), params);
+    return { selectedValues: await target.selectOption(params.selector, convertSelectOptionValues(params.elements, params.options), params) };
   }
 
   async setInputFiles(params: { selector: string, files: { name: string, mimeType: string, buffer: string }[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<void> {
@@ -195,12 +195,12 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     await target.uncheck(params.selector, params);
   }
 
-  async waitForFunction(params: { expression: string, isFunction: boolean, arg: any } & types.WaitForFunctionOptions & PageAttribution): Promise<JSHandleChannel> {
+  async waitForFunction(params: { expression: string, isFunction: boolean, arg: any } & types.WaitForFunctionOptions & PageAttribution): Promise<{ handle: JSHandleChannel }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return createHandle(this._scope, await target._waitForFunctionExpression(params.expression, params.isFunction, parseArgument(params.arg), params));
+    return { handle: createHandle(this._scope, await target._waitForFunctionExpression(params.expression, params.isFunction, parseArgument(params.arg), params)) };
   }
 
-  async title(): Promise<string> {
-    return await this._frame.title();
+  async title(): Promise<{ title: string }> {
+    return { title: await this._frame.title() };
   }
 }

--- a/src/rpc/server/frameDispatcher.ts
+++ b/src/rpc/server/frameDispatcher.ts
@@ -101,8 +101,8 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     return { elements: elements.map(e => new ElementHandleDispatcher(this._scope, e)) };
   }
 
-  async content(): Promise<{ content: string }> {
-    return { content: await this._frame.content() };
+  async content(): Promise<{ value: string }> {
+    return { value: await this._frame.content() };
   }
 
   async setContent(params: { html: string } & types.NavigateOptions & PageAttribution): Promise<void> {
@@ -140,24 +140,24 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     await target.focus(params.selector, params);
   }
 
-  async textContent(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ textContent: string | null }> {
+  async textContent(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ value: string | null }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return { textContent: await target.textContent(params.selector, params) };
+    return { value: await target.textContent(params.selector, params) };
   }
 
-  async innerText(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ innerText: string }> {
+  async innerText(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ value: string }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return { innerText: await target.innerText(params.selector, params) };
+    return { value: await target.innerText(params.selector, params) };
   }
 
-  async innerHTML(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ innerHTML: string }> {
+  async innerHTML(params: { selector: string } & types.TimeoutOptions & PageAttribution): Promise<{ value: string }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return { innerHTML: await target.innerHTML(params.selector, params) };
+    return { value: await target.innerHTML(params.selector, params) };
   }
 
-  async getAttribute(params: { selector: string, name: string } & types.TimeoutOptions & PageAttribution): Promise<{ attribute: string | null }> {
+  async getAttribute(params: { selector: string, name: string } & types.TimeoutOptions & PageAttribution): Promise<{ value: string | null }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return { attribute: await target.getAttribute(params.selector, params.name, params) };
+    return { value: await target.getAttribute(params.selector, params.name, params) };
   }
 
   async hover(params: { selector: string } & types.PointerActionOptions & types.TimeoutOptions & { force?: boolean } & PageAttribution): Promise<void> {
@@ -165,9 +165,9 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     await target.hover(params.selector, params);
   }
 
-  async selectOption(params: { selector: string, elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<{ selectedValues: string[] }> {
+  async selectOption(params: { selector: string, elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<{ values: string[] }> {
     const target = params.isPage ? this._frame._page : this._frame;
-    return { selectedValues: await target.selectOption(params.selector, convertSelectOptionValues(params.elements, params.options), params) };
+    return { values: await target.selectOption(params.selector, convertSelectOptionValues(params.elements, params.options), params) };
   }
 
   async setInputFiles(params: { selector: string, files: { name: string, mimeType: string, buffer: string }[] } & types.NavigatingActionWaitOptions & PageAttribution): Promise<void> {
@@ -200,7 +200,7 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     return { handle: createHandle(this._scope, await target._waitForFunctionExpression(params.expression, params.isFunction, parseArgument(params.arg), params)) };
   }
 
-  async title(): Promise<{ title: string }> {
-    return { title: await this._frame.title() };
+  async title(): Promise<{ value: string }> {
+    return { value: await this._frame.title() };
   }
 }

--- a/src/rpc/server/jsHandleDispatcher.ts
+++ b/src/rpc/server/jsHandleDispatcher.ts
@@ -26,33 +26,33 @@ export class JSHandleDispatcher extends Dispatcher<js.JSHandle, JSHandleInitiali
     super(scope, jsHandle, jsHandle.asElement() ? 'elementHandle' : 'jsHandle', {
       preview: jsHandle.toString(),
     });
-    jsHandle._setPreviewCallback(preview => this._dispatchEvent('previewUpdated', preview));
+    jsHandle._setPreviewCallback(preview => this._dispatchEvent('previewUpdated', { preview }));
   }
 
-  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<any> {
-    return this._object._evaluateExpression(params.expression, params.isFunction, true /* returnByValue */, parseArgument(params.arg));
+  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }> {
+    return { value: serializeResult(await this._object._evaluateExpression(params.expression, params.isFunction, true /* returnByValue */, parseArgument(params.arg))) };
   }
 
-  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any}): Promise<JSHandleChannel> {
+  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any}): Promise<{ handle: JSHandleChannel }> {
     const jsHandle = await this._object._evaluateExpression(params.expression, params.isFunction, false /* returnByValue */, parseArgument(params.arg));
-    return createHandle(this._scope, jsHandle);
+    return { handle: createHandle(this._scope, jsHandle) };
   }
 
-  async getProperty(params: { name: string }): Promise<JSHandleChannel> {
+  async getProperty(params: { name: string }): Promise<{ handle: JSHandleChannel }> {
     const jsHandle = await this._object.getProperty(params.name);
-    return createHandle(this._scope, jsHandle);
+    return { handle: createHandle(this._scope, jsHandle) };
   }
 
-  async getPropertyList(): Promise<{ name: string, value: JSHandleChannel }[]> {
+  async getPropertyList(): Promise<{ properties: { name: string, value: JSHandleChannel }[] }> {
     const map = await this._object.getProperties();
-    const result = [];
+    const properties = [];
     for (const [name, value] of map)
-      result.push({ name, value: new JSHandleDispatcher(this._scope, value) });
-    return result;
+      properties.push({ name, value: new JSHandleDispatcher(this._scope, value) });
+    return { properties };
   }
 
-  async jsonValue(): Promise<any> {
-    return serializeResult(await this._object.jsonValue());
+  async jsonValue(): Promise<{ value: any }> {
+    return { value: serializeResult(await this._object.jsonValue()) };
   }
 
   async dispose() {

--- a/src/rpc/server/networkDispatchers.ts
+++ b/src/rpc/server/networkDispatchers.ts
@@ -66,8 +66,8 @@ export class ResponseDispatcher extends Dispatcher<Response, ResponseInitializer
     return { error: await this._object.finished() };
   }
 
-  async body(): Promise<{ body: Binary }> {
-    return { body: (await this._object.body()).toString('base64') };
+  async body(): Promise<{ binary: Binary }> {
+    return { binary: (await this._object.body()).toString('base64') };
   }
 }
 

--- a/src/rpc/server/networkDispatchers.ts
+++ b/src/rpc/server/networkDispatchers.ts
@@ -44,8 +44,8 @@ export class RequestDispatcher extends Dispatcher<Request, RequestInitializer> i
     });
   }
 
-  async response(): Promise<ResponseChannel | null> {
-    return lookupNullableDispatcher<ResponseDispatcher>(await this._object.response());
+  async response(): Promise<{ response: ResponseChannel | null }> {
+    return { response: lookupNullableDispatcher<ResponseDispatcher>(await this._object.response()) };
   }
 }
 
@@ -62,12 +62,12 @@ export class ResponseDispatcher extends Dispatcher<Response, ResponseInitializer
     });
   }
 
-  async finished(): Promise<Error | null> {
-    return await this._object.finished();
+  async finished(): Promise<{ error: Error | null }> {
+    return { error: await this._object.finished() };
   }
 
-  async body(): Promise<Binary> {
-    return (await this._object.body()).toString('base64');
+  async body(): Promise<{ body: Binary }> {
+    return { body: (await this._object.body()).toString('base64') };
   }
 }
 

--- a/src/rpc/server/pageDispatcher.ts
+++ b/src/rpc/server/pageDispatcher.ts
@@ -46,11 +46,11 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     });
     this._page = page;
     page.on(Events.Page.Close, () => this._dispatchEvent('close'));
-    page.on(Events.Page.Console, message => this._dispatchEvent('console', new ConsoleMessageDispatcher(this._scope, message)));
+    page.on(Events.Page.Console, message => this._dispatchEvent('console', { message: new ConsoleMessageDispatcher(this._scope, message) }));
     page.on(Events.Page.Crash, () => this._dispatchEvent('crash'));
     page.on(Events.Page.DOMContentLoaded, () => this._dispatchEvent('domcontentloaded'));
-    page.on(Events.Page.Dialog, dialog => this._dispatchEvent('dialog', new DialogDispatcher(this._scope, dialog)));
-    page.on(Events.Page.Download, dialog => this._dispatchEvent('download', new DownloadDispatcher(this._scope, dialog)));
+    page.on(Events.Page.Dialog, dialog => this._dispatchEvent('dialog', { dialog: new DialogDispatcher(this._scope, dialog) }));
+    page.on(Events.Page.Download, dialog => this._dispatchEvent('download', { download: new DownloadDispatcher(this._scope, dialog) }));
     page.on(Events.Page.FileChooser, (fileChooser: FileChooser) => this._dispatchEvent('fileChooser', {
       element: new ElementHandleDispatcher(this._scope, fileChooser.element()),
       isMultiple: fileChooser.isMultiple()
@@ -60,15 +60,15 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     page.on(Events.Page.FrameNavigated, frame => this._onFrameNavigated(frame));
     page.on(Events.Page.Load, () => this._dispatchEvent('load'));
     page.on(Events.Page.PageError, error => this._dispatchEvent('pageError', { error: serializeError(error) }));
-    page.on(Events.Page.Popup, page => this._dispatchEvent('popup', lookupDispatcher<PageDispatcher>(page)));
-    page.on(Events.Page.Request, request => this._dispatchEvent('request', RequestDispatcher.from(this._scope, request)));
+    page.on(Events.Page.Popup, page => this._dispatchEvent('popup', { page: lookupDispatcher<PageDispatcher>(page) }));
+    page.on(Events.Page.Request, request => this._dispatchEvent('request', { request: RequestDispatcher.from(this._scope, request) }));
     page.on(Events.Page.RequestFailed, (request: Request) => this._dispatchEvent('requestFailed', {
       request: RequestDispatcher.from(this._scope, request),
       failureText: request._failureText
     }));
-    page.on(Events.Page.RequestFinished, request => this._dispatchEvent('requestFinished', RequestDispatcher.from(scope, request)));
-    page.on(Events.Page.Response, response => this._dispatchEvent('response', new ResponseDispatcher(this._scope, response)));
-    page.on(Events.Page.Worker, worker => this._dispatchEvent('worker', new WorkerDispatcher(this._scope, worker)));
+    page.on(Events.Page.RequestFinished, request => this._dispatchEvent('requestFinished', { request: RequestDispatcher.from(scope, request) }));
+    page.on(Events.Page.Response, response => this._dispatchEvent('response', { response: new ResponseDispatcher(this._scope, response) }));
+    page.on(Events.Page.Worker, worker => this._dispatchEvent('worker', { worker: new WorkerDispatcher(this._scope, worker) }));
   }
 
   async setDefaultNavigationTimeoutNoReply(params: { timeout: number }) {
@@ -79,15 +79,15 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     this._page.setDefaultTimeout(params.timeout);
   }
 
-  async opener(): Promise<PageChannel | null> {
-    return lookupNullableDispatcher<PageDispatcher>(await this._page.opener());
+  async opener(): Promise<{ page: PageChannel | null }> {
+    return { page: lookupNullableDispatcher<PageDispatcher>(await this._page.opener()) };
   }
 
   async exposeBinding(params: { name: string }): Promise<void> {
     await this._page.exposeBinding(params.name, (source, ...args) => {
-      const bindingCall = new BindingCallDispatcher(this._scope, params.name, source, args);
-      this._dispatchEvent('bindingCall', bindingCall);
-      return bindingCall.promise();
+      const binding = new BindingCallDispatcher(this._scope, params.name, source, args);
+      this._dispatchEvent('bindingCall', { binding });
+      return binding.promise();
     });
   }
 
@@ -95,16 +95,16 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     await this._page.setExtraHTTPHeaders(params.headers);
   }
 
-  async reload(params: types.NavigateOptions): Promise<ResponseChannel | null> {
-    return lookupNullableDispatcher<ResponseDispatcher>(await this._page.reload(params));
+  async reload(params: types.NavigateOptions): Promise<{ response: ResponseChannel | null }> {
+    return { response: lookupNullableDispatcher<ResponseDispatcher>(await this._page.reload(params)) };
   }
 
-  async goBack(params: types.NavigateOptions): Promise<ResponseChannel | null> {
-    return lookupNullableDispatcher<ResponseDispatcher>(await this._page.goBack(params));
+  async goBack(params: types.NavigateOptions): Promise<{ response: ResponseChannel | null }> {
+    return { response: lookupNullableDispatcher<ResponseDispatcher>(await this._page.goBack(params)) };
   }
 
-  async goForward(params: types.NavigateOptions): Promise<ResponseChannel | null> {
-    return lookupNullableDispatcher<ResponseDispatcher>(await this._page.goForward(params));
+  async goForward(params: types.NavigateOptions): Promise<{ response: ResponseChannel | null }> {
+    return { response: lookupNullableDispatcher<ResponseDispatcher>(await this._page.goForward(params)) };
   }
 
   async emulateMedia(params: { media?: 'screen' | 'print', colorScheme?: 'dark' | 'light' | 'no-preference' }): Promise<void> {
@@ -129,8 +129,8 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     });
   }
 
-  async screenshot(params: types.ScreenshotOptions): Promise<Binary> {
-    return (await this._page.screenshot(params)).toString('base64');
+  async screenshot(params: types.ScreenshotOptions): Promise<{ screenshot: Binary }> {
+    return { screenshot: (await this._page.screenshot(params)).toString('base64') };
   }
 
   async close(params: { runBeforeUnload?: boolean }): Promise<void> {
@@ -180,18 +180,19 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     await this._page.mouse.click(params.x, params.y, params);
   }
 
-  async accessibilitySnapshot(params: { interestingOnly?: boolean, root?: ElementHandleChannel }): Promise<types.SerializedAXNode | null> {
-    return await this._page.accessibility.snapshot({
+  async accessibilitySnapshot(params: { interestingOnly?: boolean, root?: ElementHandleChannel }): Promise<{ axNode: types.SerializedAXNode | null }> {
+    const axNode = await this._page.accessibility.snapshot({
       interestingOnly: params.interestingOnly,
       root: params.root ? (params.root as ElementHandleDispatcher)._elementHandle : undefined
     });
+    return { axNode };
   }
 
-  async pdf(params: PDFOptions): Promise<Binary> {
+  async pdf(params: PDFOptions): Promise<{ pdf: Binary }> {
     if (!this._page.pdf)
       throw new Error('PDF generation is only supported for Headless Chromium');
-    const binary = await this._page.pdf(params);
-    return binary.toString('base64');
+    const buffer = await this._page.pdf(params);
+    return { pdf: buffer.toString('base64') };
   }
 
   async crStartJSCoverage(params: types.JSCoverageOptions): Promise<void> {
@@ -199,9 +200,9 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     await coverage.startJSCoverage(params);
   }
 
-  async crStopJSCoverage(): Promise<types.JSCoverageEntry[]> {
+  async crStopJSCoverage(): Promise<{ entries: types.JSCoverageEntry[] }> {
     const coverage = this._page.coverage as CRCoverage;
-    return await coverage.stopJSCoverage();
+    return { entries: await coverage.stopJSCoverage() };
   }
 
   async crStartCSSCoverage(params: types.CSSCoverageOptions): Promise<void> {
@@ -209,13 +210,13 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     await coverage.startCSSCoverage(params);
   }
 
-  async crStopCSSCoverage(): Promise<types.CSSCoverageEntry[]> {
+  async crStopCSSCoverage(): Promise<{ entries: types.CSSCoverageEntry[] }> {
     const coverage = this._page.coverage as CRCoverage;
-    return await coverage.stopCSSCoverage();
+    return { entries: await coverage.stopCSSCoverage() };
   }
 
   _onFrameAttached(frame: Frame) {
-    this._dispatchEvent('frameAttached', FrameDispatcher.from(this._scope, frame));
+    this._dispatchEvent('frameAttached', { frame: FrameDispatcher.from(this._scope, frame) });
   }
 
   _onFrameNavigated(frame: Frame) {
@@ -223,7 +224,7 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
   }
 
   _onFrameDetached(frame: Frame) {
-    this._dispatchEvent('frameDetached', lookupDispatcher<FrameDispatcher>(frame));
+    this._dispatchEvent('frameDetached', { frame: lookupDispatcher<FrameDispatcher>(frame) });
   }
 }
 
@@ -236,12 +237,12 @@ export class WorkerDispatcher extends Dispatcher<Worker, WorkerInitializer> impl
     worker.on(Events.Worker.Close, () => this._dispatchEvent('close'));
   }
 
-  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: any, isPage?: boolean }): Promise<any> {
-    return serializeResult(await this._object._evaluateExpression(params.expression, params.isFunction, parseArgument(params.arg)));
+  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: any, isPage?: boolean }): Promise<{ value: any }> {
+    return { value: serializeResult(await this._object._evaluateExpression(params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
-  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any, isPage?: boolean }): Promise<JSHandleChannel> {
-    return createHandle(this._scope, await this._object._evaluateExpressionHandle(params.expression, params.isFunction, parseArgument(params.arg)));
+  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any, isPage?: boolean }): Promise<{ handle: JSHandleChannel }> {
+    return { handle: createHandle(this._scope, await this._object._evaluateExpressionHandle(params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 }
 

--- a/src/rpc/server/pageDispatcher.ts
+++ b/src/rpc/server/pageDispatcher.ts
@@ -129,8 +129,8 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     });
   }
 
-  async screenshot(params: types.ScreenshotOptions): Promise<{ screenshot: Binary }> {
-    return { screenshot: (await this._page.screenshot(params)).toString('base64') };
+  async screenshot(params: types.ScreenshotOptions): Promise<{ binary: Binary }> {
+    return { binary: (await this._page.screenshot(params)).toString('base64') };
   }
 
   async close(params: { runBeforeUnload?: boolean }): Promise<void> {
@@ -180,12 +180,12 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
     await this._page.mouse.click(params.x, params.y, params);
   }
 
-  async accessibilitySnapshot(params: { interestingOnly?: boolean, root?: ElementHandleChannel }): Promise<{ axNode: types.SerializedAXNode | null }> {
-    const axNode = await this._page.accessibility.snapshot({
+  async accessibilitySnapshot(params: { interestingOnly?: boolean, root?: ElementHandleChannel }): Promise<{ rootAXNode: types.SerializedAXNode | null }> {
+    const rootAXNode = await this._page.accessibility.snapshot({
       interestingOnly: params.interestingOnly,
       root: params.root ? (params.root as ElementHandleDispatcher)._elementHandle : undefined
     });
-    return { axNode };
+    return { rootAXNode };
   }
 
   async pdf(params: PDFOptions): Promise<{ pdf: Binary }> {

--- a/src/rpc/server/selectorsDispatcher.ts
+++ b/src/rpc/server/selectorsDispatcher.ts
@@ -29,7 +29,7 @@ export class SelectorsDispatcher extends Dispatcher<Selectors, SelectorsInitiali
     await this._object.register(params.name, params.source, params.options);
   }
 
-  async createSelector(params: { name: string, handle: ElementHandleDispatcher }): Promise<string | undefined> {
-    return this._object._createSelector(params.name, params.handle._object as dom.ElementHandle<Element>);
+  async createSelector(params: { name: string, handle: ElementHandleDispatcher }): Promise<{ selector?: string }> {
+    return { selector: await this._object._createSelector(params.name, params.handle._object as dom.ElementHandle<Element>) };
   }
 }

--- a/src/rpc/server/selectorsDispatcher.ts
+++ b/src/rpc/server/selectorsDispatcher.ts
@@ -29,7 +29,7 @@ export class SelectorsDispatcher extends Dispatcher<Selectors, SelectorsInitiali
     await this._object.register(params.name, params.source, params.options);
   }
 
-  async createSelector(params: { name: string, handle: ElementHandleDispatcher }): Promise<{ selector?: string }> {
-    return { selector: await this._object._createSelector(params.name, params.handle._object as dom.ElementHandle<Element>) };
+  async createSelector(params: { name: string, handle: ElementHandleDispatcher }): Promise<{ value?: string }> {
+    return { value: await this._object._createSelector(params.name, params.handle._object as dom.ElementHandle<Element>) };
   }
 }

--- a/src/rpc/server/streamDispatcher.ts
+++ b/src/rpc/server/streamDispatcher.ts
@@ -23,8 +23,8 @@ export class StreamDispatcher extends Dispatcher<stream.Readable, StreamInitiali
     super(scope, stream, 'stream', {});
   }
 
-  async read(params: { size?: number }): Promise<{ data: Binary }> {
+  async read(params: { size?: number }): Promise<{ binary: Binary }> {
     const buffer = this._object.read(Math.min(this._object.readableLength, params.size || this._object.readableLength));
-    return { data: buffer ? buffer.toString('base64') : '' };
+    return { binary: buffer ? buffer.toString('base64') : '' };
   }
 }

--- a/src/rpc/server/streamDispatcher.ts
+++ b/src/rpc/server/streamDispatcher.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { StreamChannel, StreamInitializer } from '../channels';
+import { StreamChannel, StreamInitializer, Binary } from '../channels';
 import { Dispatcher, DispatcherScope } from './dispatcher';
 import * as stream from 'stream';
 
@@ -23,8 +23,8 @@ export class StreamDispatcher extends Dispatcher<stream.Readable, StreamInitiali
     super(scope, stream, 'stream', {});
   }
 
-  async read(params: { size?: number }): Promise<string> {
+  async read(params: { size?: number }): Promise<{ data: Binary }> {
     const buffer = this._object.read(Math.min(this._object.readableLength, params.size || this._object.readableLength));
-    return buffer ? buffer.toString('base64') : '';
+    return { data: buffer ? buffer.toString('base64') : '' };
   }
 }

--- a/test/jshandle.spec.js
+++ b/test/jshandle.spec.js
@@ -99,6 +99,23 @@ describe('Page.evaluateHandle', function() {
   });
 });
 
+describe('JSHandle.evaluate', function() {
+  it('should work with function', async({page, server}) => {
+    const windowHandle = await page.evaluateHandle(() => {
+      window.foo = [1, 2];
+      return window;
+    });
+    expect(await windowHandle.evaluate(w => w.foo)).toEqual([1, 2]);
+  });
+  it('should work with expression', async({page, server}) => {
+    const windowHandle = await page.evaluateHandle(() => {
+      window.foo = [1, 2];
+      return window;
+    });
+    expect(await windowHandle.evaluate('window.foo')).toEqual([1, 2]);
+  });
+});
+
 describe('JSHandle.getProperty', function() {
   it('should work', async({page, server}) => {
     const aHandle = await page.evaluateHandle(() => ({

--- a/test/queryselector.spec.js
+++ b/test/queryselector.spec.js
@@ -173,6 +173,11 @@ describe('Page.$eval', function() {
     await page.setContent('<div><input placeholder="Select&quot;date"></div>');
     await inputPromise;
   });
+  it('should return complex values', async({page, server}) => {
+    await page.setContent('<section id="testAttribute">43543</section>');
+    const idAttribute = await page.$eval('css=section', e => [{ id: e.id }]);
+    expect(idAttribute).toEqual([{ id: 'testAttribute' }]);
+  });
 });
 
 describe('Page.$$eval', function() {
@@ -220,6 +225,11 @@ describe('Page.$$eval', function() {
     expect(await page.$$eval('*css=div >> span', els => els.length)).toBe(2);
     await page.setContent('<div><div><span></span></div><span></span><span></span></div><div></div>');
     expect(await page.$$eval('*css=div >> span', els => els.length)).toBe(2);
+  });
+  it('should return complex values', async({page, server}) => {
+    await page.setContent('<div>hello</div><div>beautiful</div><div>world!</div>');
+    const texts = await page.$$eval('css=div', divs => divs.map(div => div.textContent));
+    expect(texts).toEqual(['hello', 'beautiful', 'world!']);
   });
 });
 


### PR DESCRIPTION
For future extensibility, returning objects with fields instead of plain strings or channels.

This exposed a few evaluation bugs, added tests for those.