### PR TITLE
fix(JSCoverageEntry): added scriptId and isBlockCoverage

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4299,9 +4299,11 @@ const v8toIstanbul = require('v8-to-istanbul');
 #### chromiumCoverage.stopJSCoverage()
 - returns: <[Promise]<[Array]<[Object]>>> Promise that resolves to the array of coverage reports for all scripts
   - `url` <[string]> Script URL
+  - `scriptId` <[string]> Script ID
   - `source` <[string]> Script content, if applicable.
   - `functions` <[Array]<[Object]>> V8-specific coverage format.
     - `functionName` <[string]>
+    - `isBlockCoverage` <[boolean]>
     - `ranges` <[Array]<[Object]>>
       - `count` <[number]>
       - `startOffset` <[number]>

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,9 +149,11 @@ export type CSSCoverageEntry = {
 
 export type JSCoverageEntry = {
   url: string,
+  scriptId: string,
   source?: string,
   functions: {
     functionName: string,
+    isBlockCoverage: boolean,
     ranges: JSRange[]
   }[]
 };


### PR DESCRIPTION
Added scriptId and isBlockCoverage fields to [JSCoverageEntry](https://github.com/microsoft/playwright/blob/a91ec9a15d3ed5dccf61e1128dfb8d503a47b6c5/src/types.ts#L150)

fixes: #2906