### PR TITLE
feat: validate browser dependencies before launching on Linux

### DIFF
--- a/src/install/browserPaths.ts
+++ b/src/install/browserPaths.ts
@@ -47,8 +47,8 @@ export function linuxLddDirectories(browserPath: string, browser: BrowserDescrip
     return [path.join(browserPath, 'firefox')];
   if (browser.name === 'webkit') {
     return [
-      path.join(browserPath, 'linux', 'minibrowser-gtk'),
-      path.join(browserPath, 'linux', 'minibrowser-wpe'),
+      path.join(browserPath, 'minibrowser-gtk'),
+      path.join(browserPath, 'minibrowser-wpe'),
     ];
   }
   return [];

--- a/src/install/browserPaths.ts
+++ b/src/install/browserPaths.ts
@@ -40,6 +40,20 @@ export const hostPlatform = ((): BrowserPlatform => {
   return platform as BrowserPlatform;
 })();
 
+export function linuxLddDirectories(browserPath: string, browser: BrowserDescriptor): string[] {
+  if (browser.name === 'chromium')
+    return [path.join(browserPath, 'chrome-linux')];
+  if (browser.name === 'firefox')
+    return [path.join(browserPath, 'firefox')];
+  if (browser.name === 'webkit') {
+    return [
+      path.join(browserPath, 'linux', 'minibrowser-gtk'),
+      path.join(browserPath, 'linux', 'minibrowser-wpe'),
+    ];
+  }
+  return [];
+}
+
 export function executablePath(browserPath: string, browser: BrowserDescriptor): string | undefined {
   let tokens: string[] | undefined;
   if (browser.name === 'chromium') {

--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -42,6 +42,7 @@ export async function validateDependencies(browserPath: string, browser: Browser
   if (!missingDeps.size)
     return;
   const deps = [...missingDeps].sort().map(dep => '   ' + dep).join('\n');
+  console.log(deps);
   throw new Error('Host system is missing dependencies to run browser:\n' + deps);
 }
 

--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import * as fs from 'fs';
 import * as util from 'util';
 import * as path from 'path';
@@ -63,13 +78,11 @@ function lddAsync(filePath: string): Promise<{stdout: string, stderr: string, co
     },
   });
 
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     let stdout = '';
     let stderr = '';
     ldd.stdout.on('data', data => stdout += data);
     ldd.stderr.on('data', data => stderr += data);
-    ldd.on('close', (code) => {
-      resolve({stdout, stderr, code});
-    });
+    ldd.on('close', code => resolve({stdout, stderr, code}));
   });
 }

--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs';
+import * as util from 'util';
+import * as path from 'path';
+import * as os from 'os';
+import {spawn} from 'child_process';
+import {linuxLddDirectories, BrowserDescriptor} from '../install/browserPaths.js';
+
+const accessAsync = util.promisify(fs.access.bind(fs));
+const checkExecutable = (filePath: string) => accessAsync(filePath, fs.constants.X_OK).then(() => true).catch(e => false);
+const statAsync = util.promisify(fs.stat.bind(fs));
+const readdirAsync = util.promisify(fs.readdir.bind(fs));
+
+export async function validateDependencies(browserPath: string, browser: BrowserDescriptor) {
+  // We currently only support Linux.
+  if (os.platform() !== 'linux')
+    return;
+  const directoryPaths = linuxLddDirectories(browserPath, browser);
+  const lddPaths: string[] = [];
+  for (const directoryPath of directoryPaths)
+    lddPaths.push(...(await executablesOrSharedLibraries(directoryPath)));
+  const allMissingDeps = await Promise.all(lddPaths.map(lddPath => missingFileDependencies(lddPath)));
+  const missingDeps = new Set();
+  for (const deps of allMissingDeps) {
+    for (const dep of deps)
+      missingDeps.add(dep);
+  }
+  if (!missingDeps.size)
+    return;
+  const deps = [...missingDeps].sort().map(dep => '   ' + dep).join('\n');
+  throw new Error('Host system is missing dependencies to run browser:\n' + deps);
+}
+
+async function executablesOrSharedLibraries(directoryPath: string): Promise<string[]> {
+  const allPaths = (await readdirAsync(directoryPath)).map(file => path.resolve(directoryPath, file));
+  const allStats = await Promise.all(allPaths.map(aPath => statAsync(aPath)));
+  const filePaths = allPaths.filter((aPath, index) => allStats[index].isFile());
+
+  const executablersOrLibraries = (await Promise.all(filePaths.map(async filePath => {
+    const basename = path.basename(filePath).toLowerCase();
+    if (basename.endsWith('.so') || basename.includes('.so.'))
+      return filePath;
+    if (await checkExecutable(filePath))
+      return filePath;
+    return false;
+  }))).filter(Boolean);
+
+  return executablersOrLibraries as string[];
+}
+
+async function missingFileDependencies(filePath: string): Promise<Array<string>> {
+  const {stdout} = await lddAsync(filePath);
+  const missingDeps = stdout.split('\n').map(line => line.trim()).filter(line => line.endsWith('not found') && line.includes('=>')).map(line => line.split('=>')[0].trim());
+  return missingDeps;
+}
+
+function lddAsync(filePath: string): Promise<{stdout: string, stderr: string, code: number}> {
+  const dirname = path.dirname(filePath);
+  const ldd = spawn('ldd', [filePath], {
+    cwd: dirname,
+    env: {
+      ...process.env,
+      LD_LIBRARY_PATH: dirname,
+    },
+  });
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    ldd.stdout.on('data', data => stdout += data);
+    ldd.stderr.on('data', data => stderr += data);
+    ldd.on('close', (code) => {
+      resolve({stdout, stderr, code});
+    });
+  });
+}

--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -42,8 +42,7 @@ export async function validateDependencies(browserPath: string, browser: Browser
   if (!missingDeps.size)
     return;
   const deps = [...missingDeps].sort().map(dep => '   ' + dep).join('\n');
-  console.log(deps);
-  throw new Error('Host system is missing dependencies to run browser:\n' + deps);
+  throw new Error('Host system is missing the following dependencies to run browser\n' + deps);
 }
 
 async function executablesOrSharedLibraries(directoryPath: string): Promise<string[]> {


### PR DESCRIPTION
Missing dependencies is a number 1 problem with launching on Linux.

This patch starts validating browser dependencies before launching
browser on Linux. In case of a missing dependency, we will abandon
launching with an error that lists all missing libs.

References #2745