### PR TITLE
devops: move CircleCI to run against dev version of Docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: mcr.microsoft.com/playwright:bionic
+      - image: mcr.microsoft.com/playwright:dev
     steps:
       - checkout
 


### PR DESCRIPTION
Since we now auto-publish docker container, we can move CircleCI
to use the tip-of-tree docker images.