### PR TITLE
feat(rpc): migrate DeviceDescriptors payload to an array

### DIFF
--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -29,7 +29,7 @@ export type PlaywrightInitializer = {
   firefox: BrowserTypeChannel,
   webkit: BrowserTypeChannel,
   electron?: ElectronChannel,
-  deviceDescriptors: types.Devices,
+  deviceDescriptors: { name: string, descriptor: types.DeviceDescriptor }[],
   selectors: SelectorsChannel,
 };
 

--- a/src/rpc/client/playwright.ts
+++ b/src/rpc/client/playwright.ts
@@ -35,7 +35,9 @@ export class Playwright extends ChannelOwner<PlaywrightChannel, PlaywrightInitia
     this.webkit = BrowserType.from(initializer.webkit);
     if (initializer.electron)
       (this as any).electron = Electron.from(initializer.electron);
-    this.devices = initializer.deviceDescriptors;
+    this.devices = {};
+    for (const { name, descriptor } of initializer.deviceDescriptors)
+      this.devices[name] = descriptor;
     this.selectors = Selectors.from(initializer.selectors);
   }
 }

--- a/src/rpc/server/playwrightDispatcher.ts
+++ b/src/rpc/server/playwrightDispatcher.ts
@@ -25,12 +25,14 @@ import { ElectronDispatcher } from './electronDispatcher';
 export class PlaywrightDispatcher extends Dispatcher<Playwright, PlaywrightInitializer> implements PlaywrightChannel {
   constructor(scope: DispatcherScope, playwright: Playwright) {
     const electron = (playwright as any).electron as (Electron | undefined);
+    const deviceDescriptors = Object.entries(playwright.devices)
+        .map(([name, descriptor]) => ({ name, descriptor }));
     super(scope, playwright, 'playwright', {
       chromium: new BrowserTypeDispatcher(scope, playwright.chromium!),
       firefox: new BrowserTypeDispatcher(scope, playwright.firefox!),
       webkit: new BrowserTypeDispatcher(scope, playwright.webkit!),
       electron: electron ? new ElectronDispatcher(scope, electron) : undefined,
-      deviceDescriptors: playwright.devices,
+      deviceDescriptors,
       selectors: new SelectorsDispatcher(scope, playwright.selectors),
     }, false, 'playwright');
   }


### PR DESCRIPTION
Currently it is an object with arbitrary keys - that makes it hard to have a protocol definition.