### PR TITLE
chore: explicitly type SerializedArgument, fix rpc dispatchEvent

### DIFF
--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -196,7 +196,7 @@ export async function evaluateExpression(context: ExecutionContext, returnByValu
     return handles.length - 1;
   };
 
-  args = args.map(arg => serializeAsCallArgument(arg, (handle: any): { h?: number, fallThrough?: any } => {
+  args = args.map(arg => serializeAsCallArgument(arg, handle => {
     if (handle instanceof JSHandle) {
       if (!handle._objectId)
         return { fallThrough: handle._value };

--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -16,8 +16,11 @@
 
 import { EventEmitter } from 'events';
 import * as types from '../types';
+import { SerializedValue } from '../common/utilityScriptSerializers';
 
 export type Binary = string;
+export type SerializedArgument = { value: SerializedValue, handles: Channel[] };
+
 export type BrowserContextOptions = {
   viewport?: types.Size | null,
   ignoreHTTPSErrors?: boolean,
@@ -198,17 +201,17 @@ export interface FrameChannel extends Channel {
   on(event: 'loadstate', callback: (params: { add?: types.LifecycleEvent, remove?: types.LifecycleEvent }) => void): this;
   on(event: 'navigated', callback: (params: FrameNavigatedEvent) => void): this;
 
-  evalOnSelector(params: { selector: string; expression: string, isFunction: boolean, arg: any}): Promise<{ value: any }>;
-  evalOnSelectorAll(params: { selector: string; expression: string, isFunction: boolean, arg: any}): Promise<{ value: any }>;
+  evalOnSelector(params: { selector: string; expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }>;
+  evalOnSelectorAll(params: { selector: string; expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }>;
   addScriptTag(params: { url?: string, content?: string, type?: string }): Promise<{ element: ElementHandleChannel }>;
   addStyleTag(params: { url?: string, content?: string }): Promise<{ element: ElementHandleChannel }>;
   check(params: { selector: string, force?: boolean, noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
   click(params: { selector: string, force?: boolean, noWaitAfter?: boolean } & types.PointerActionOptions & types.MouseClickOptions & types.TimeoutOptions): Promise<void>;
   content(): Promise<{ value: string }>;
   dblclick(params: { selector: string, force?: boolean } & types.PointerActionOptions & types.MouseMultiClickOptions & types.TimeoutOptions): Promise<void>;
-  dispatchEvent(params: { selector: string, type: string, eventInit: any } & types.TimeoutOptions): Promise<void>;
-  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any}): Promise<{ value: any }>;
-  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any}): Promise<{ handle: JSHandleChannel }>;
+  dispatchEvent(params: { selector: string, type: string, eventInit: SerializedArgument } & types.TimeoutOptions): Promise<void>;
+  evaluateExpression(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }>;
+  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ handle: JSHandleChannel }>;
   fill(params: { selector: string, value: string } & types.NavigatingActionWaitOptions): Promise<void>;
   focus(params: { selector: string } & types.TimeoutOptions): Promise<void>;
   frameElement(): Promise<{ element: ElementHandleChannel }>;
@@ -227,7 +230,7 @@ export interface FrameChannel extends Channel {
   title(): Promise<{ value: string }>;
   type(params: { selector: string, text: string, delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
   uncheck(params: { selector: string, force?: boolean, noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
-  waitForFunction(params: { expression: string, isFunction: boolean, arg: any } & types.WaitForFunctionOptions): Promise<{ handle: JSHandleChannel }>;
+  waitForFunction(params: { expression: string, isFunction: boolean, arg: SerializedArgument } & types.WaitForFunctionOptions): Promise<{ handle: JSHandleChannel }>;
   waitForSelector(params: { selector: string } & types.WaitForElementOptions): Promise<{ element: ElementHandleChannel | null }>;
 }
 export type FrameInitializer = {
@@ -239,8 +242,8 @@ export type FrameInitializer = {
 
 
 export interface WorkerChannel extends Channel {
-  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
-  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ handle: JSHandleChannel }>;
+  evaluateExpression(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }>;
+  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ handle: JSHandleChannel }>;
 }
 export type WorkerInitializer = {
   url: string,
@@ -251,11 +254,11 @@ export interface JSHandleChannel extends Channel {
   on(event: 'previewUpdated', callback: (params: { preview: string }) => void): this;
 
   dispose(): Promise<void>;
-  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
-  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any}): Promise<{ handle: JSHandleChannel }>;
+  evaluateExpression(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }>;
+  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ handle: JSHandleChannel }>;
   getPropertyList(): Promise<{ properties: { name: string, value: JSHandleChannel}[] }>;
   getProperty(params: { name: string }): Promise<{ handle: JSHandleChannel }>;
-  jsonValue(): Promise<{ value: any }>;
+  jsonValue(): Promise<{ value: SerializedValue }>;
 }
 export type JSHandleInitializer = {
   preview: string,
@@ -263,14 +266,14 @@ export type JSHandleInitializer = {
 
 
 export interface ElementHandleChannel extends JSHandleChannel {
-  evalOnSelector(params: { selector: string; expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
-  evalOnSelectorAll(params: { selector: string; expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
+  evalOnSelector(params: { selector: string; expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }>;
+  evalOnSelectorAll(params: { selector: string; expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }>;
   boundingBox(): Promise<{ value: types.Rect | null }>;
   check(params: { force?: boolean } & { noWaitAfter?: boolean } & types.TimeoutOptions): Promise<void>;
   click(params: { force?: boolean, noWaitAfter?: boolean } & types.PointerActionOptions & types.MouseClickOptions & types.TimeoutOptions): Promise<void>;
   contentFrame(): Promise<{ frame: FrameChannel | null }>;
   dblclick(params: { force?: boolean, noWaitAfter?: boolean } & types.PointerActionOptions & types.MouseMultiClickOptions & types.TimeoutOptions): Promise<void>;
-  dispatchEvent(params: { type: string, eventInit: any }): Promise<void>;
+  dispatchEvent(params: { type: string, eventInit: SerializedArgument }): Promise<void>;
   fill(params: { value: string } & types.NavigatingActionWaitOptions): Promise<void>;
   focus(): Promise<void>;
   getAttribute(params: { name: string }): Promise<{ value: string | null }>;
@@ -342,11 +345,12 @@ export type ConsoleMessageInitializer = {
 
 export interface BindingCallChannel extends Channel {
   reject(params: { error: types.Error }): void;
-  resolve(params: { result: any }): void;
+  resolve(params: { result: SerializedArgument }): void;
 }
 export type BindingCallInitializer = {
   frame: FrameChannel,
   name: string,
+  // TODO: migrate this to SerializedArgument.
   args: any[]
 };
 
@@ -426,9 +430,9 @@ export interface ElectronApplicationChannel extends Channel {
   on(event: 'close', callback: () => void): this;
   on(event: 'window', callback: (params: { page: PageChannel, browserWindow: JSHandleChannel }) => void): this;
 
-  newBrowserWindow(params: { arg: any }): Promise<{ page: PageChannel }>;
-  evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }>;
-  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ handle: JSHandleChannel }>;
+  newBrowserWindow(params: { arg: SerializedArgument }): Promise<{ page: PageChannel }>;
+  evaluateExpression(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }>;
+  evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ handle: JSHandleChannel }>;
   close(): Promise<void>;
 }
 export type ElectronApplicationInitializer = {

--- a/src/rpc/client/elementHandle.ts
+++ b/src/rpc/client/elementHandle.ts
@@ -80,7 +80,7 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> {
 
   async dispatchEvent(type: string, eventInit: Object = {}) {
     return this._wrapApiCall('elementHandle.dispatchEvent', async () => {
-      await this._elementChannel.dispatchEvent({ type, eventInit });
+      await this._elementChannel.dispatchEvent({ type, eventInit: serializeArgument(eventInit) });
     });
   }
 

--- a/src/rpc/server/electronDispatcher.ts
+++ b/src/rpc/server/electronDispatcher.ts
@@ -16,12 +16,13 @@
 
 import { Dispatcher, DispatcherScope, lookupDispatcher } from './dispatcher';
 import { Electron, ElectronApplication, ElectronEvents, ElectronPage } from '../../server/electron';
-import { ElectronApplicationChannel, ElectronApplicationInitializer, PageChannel, JSHandleChannel, ElectronInitializer, ElectronChannel, ElectronLaunchOptions } from '../channels';
+import { ElectronApplicationChannel, ElectronApplicationInitializer, PageChannel, JSHandleChannel, ElectronInitializer, ElectronChannel, ElectronLaunchOptions, SerializedArgument } from '../channels';
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 import { BrowserContextBase } from '../../browserContext';
 import { PageDispatcher } from './pageDispatcher';
 import { parseArgument } from './jsHandleDispatcher';
 import { createHandle } from './elementHandlerDispatcher';
+import { SerializedValue } from '../../common/utilityScriptSerializers';
 
 export class ElectronDispatcher extends Dispatcher<Electron, ElectronInitializer> implements ElectronChannel {
   constructor(scope: DispatcherScope, electron: Electron) {
@@ -49,17 +50,17 @@ export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplicatio
     });
   }
 
-  async newBrowserWindow(params: { arg: any }): Promise<{ page: PageChannel }> {
+  async newBrowserWindow(params: { arg: SerializedArgument }): Promise<{ page: PageChannel }> {
     const page = await this._object.newBrowserWindow(parseArgument(params.arg));
     return { page: lookupDispatcher<PageChannel>(page) };
   }
 
-  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }> {
+  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }> {
     const handle = this._object._nodeElectronHandle!;
     return { value: await handle._evaluateExpression(params.expression, params.isFunction, true /* returnByValue */, parseArgument(params.arg)) };
   }
 
-  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any}): Promise<{ handle: JSHandleChannel }> {
+  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ handle: JSHandleChannel }> {
     const handle = this._object._nodeElectronHandle!;
     const result = await handle._evaluateExpression(params.expression, params.isFunction, false /* returnByValue */, parseArgument(params.arg));
     return { handle: createHandle(this._scope, result) };

--- a/src/rpc/server/elementHandlerDispatcher.ts
+++ b/src/rpc/server/elementHandlerDispatcher.ts
@@ -17,10 +17,11 @@
 import { ElementHandle } from '../../dom';
 import * as js from '../../javascript';
 import * as types from '../../types';
-import { ElementHandleChannel, FrameChannel, Binary } from '../channels';
+import { ElementHandleChannel, FrameChannel, Binary, SerializedArgument } from '../channels';
 import { DispatcherScope, lookupNullableDispatcher } from './dispatcher';
 import { JSHandleDispatcher, serializeResult, parseArgument } from './jsHandleDispatcher';
 import { FrameDispatcher } from './frameDispatcher';
+import { SerializedValue } from '../../common/utilityScriptSerializers';
 
 export function createHandle(scope: DispatcherScope, handle: js.JSHandle): JSHandleDispatcher {
   return handle.asElement() ? new ElementHandleDispatcher(scope, handle.asElement()!) : new JSHandleDispatcher(scope, handle);
@@ -64,8 +65,8 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
     return { value: await this._elementHandle.innerHTML() };
   }
 
-  async dispatchEvent(params: { type: string, eventInit: Object }) {
-    await this._elementHandle.dispatchEvent(params.type, params.eventInit);
+  async dispatchEvent(params: { type: string, eventInit: SerializedArgument }) {
+    await this._elementHandle.dispatchEvent(params.type, parseArgument(params.eventInit));
   }
 
   async scrollIntoViewIfNeeded(params: types.TimeoutOptions) {
@@ -138,11 +139,11 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
     return { elements: elements.map(e => new ElementHandleDispatcher(this._scope, e)) };
   }
 
-  async evalOnSelector(params: { selector: string, expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }> {
+  async evalOnSelector(params: { selector: string, expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }> {
     return { value: serializeResult(await this._elementHandle._$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
-  async evalOnSelectorAll(params: { selector: string, expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }> {
+  async evalOnSelectorAll(params: { selector: string, expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }> {
     return { value: serializeResult(await this._elementHandle._$$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 }

--- a/src/rpc/server/frameDispatcher.ts
+++ b/src/rpc/server/frameDispatcher.ts
@@ -16,11 +16,12 @@
 
 import { Frame, kAddLifecycleEvent, kRemoveLifecycleEvent, kNavigationEvent, NavigationEvent } from '../../frames';
 import * as types from '../../types';
-import { ElementHandleChannel, FrameChannel, FrameInitializer, JSHandleChannel, ResponseChannel } from '../channels';
+import { ElementHandleChannel, FrameChannel, FrameInitializer, JSHandleChannel, ResponseChannel, SerializedArgument } from '../channels';
 import { Dispatcher, DispatcherScope, lookupNullableDispatcher, existingDispatcher } from './dispatcher';
 import { convertSelectOptionValues, ElementHandleDispatcher, createHandle, convertInputFiles } from './elementHandlerDispatcher';
 import { parseArgument, serializeResult } from './jsHandleDispatcher';
 import { ResponseDispatcher, RequestDispatcher } from './networkDispatchers';
+import { SerializedValue } from '../../common/utilityScriptSerializers';
 
 export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> implements FrameChannel {
   private _frame: Frame;
@@ -64,11 +65,11 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     return { element: new ElementHandleDispatcher(this._scope, await this._frame.frameElement()) };
   }
 
-  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }> {
+  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }> {
     return { value: serializeResult(await this._frame._evaluateExpression(params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
-  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any }): Promise<{ handle: JSHandleChannel }> {
+  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ handle: JSHandleChannel }> {
     return { handle: createHandle(this._scope, await this._frame._evaluateExpressionHandle(params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
@@ -76,15 +77,15 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     return { element: ElementHandleDispatcher.createNullable(this._scope, await this._frame.waitForSelector(params.selector, params)) };
   }
 
-  async dispatchEvent(params: { selector: string, type: string, eventInit: any } & types.TimeoutOptions): Promise<void> {
+  async dispatchEvent(params: { selector: string, type: string, eventInit: SerializedArgument } & types.TimeoutOptions): Promise<void> {
     return this._frame.dispatchEvent(params.selector, params.type, parseArgument(params.eventInit), params);
   }
 
-  async evalOnSelector(params: { selector: string, expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }> {
+  async evalOnSelector(params: { selector: string, expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }> {
     return { value: serializeResult(await this._frame._$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
-  async evalOnSelectorAll(params: { selector: string, expression: string, isFunction: boolean, arg: any }): Promise<{ value: any }> {
+  async evalOnSelectorAll(params: { selector: string, expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }> {
     return { value: serializeResult(await this._frame._$$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
@@ -173,7 +174,7 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
     await this._frame.uncheck(params.selector, params);
   }
 
-  async waitForFunction(params: { expression: string, isFunction: boolean, arg: any } & types.WaitForFunctionOptions): Promise<{ handle: JSHandleChannel }> {
+  async waitForFunction(params: { expression: string, isFunction: boolean, arg: SerializedArgument } & types.WaitForFunctionOptions): Promise<{ handle: JSHandleChannel }> {
     return { handle: createHandle(this._scope, await this._frame._waitForFunctionExpression(params.expression, params.isFunction, parseArgument(params.arg), params)) };
   }
 

--- a/src/rpc/server/pageDispatcher.ts
+++ b/src/rpc/server/pageDispatcher.ts
@@ -20,7 +20,7 @@ import { Frame } from '../../frames';
 import { Request } from '../../network';
 import { Page, Worker } from '../../page';
 import * as types from '../../types';
-import { BindingCallChannel, BindingCallInitializer, ElementHandleChannel, PageChannel, PageInitializer, ResponseChannel, WorkerInitializer, WorkerChannel, JSHandleChannel, Binary, PDFOptions } from '../channels';
+import { BindingCallChannel, BindingCallInitializer, ElementHandleChannel, PageChannel, PageInitializer, ResponseChannel, WorkerInitializer, WorkerChannel, JSHandleChannel, Binary, PDFOptions, SerializedArgument } from '../channels';
 import { Dispatcher, DispatcherScope, lookupDispatcher, lookupNullableDispatcher } from './dispatcher';
 import { parseError, serializeError, headersArrayToObject } from '../serializers';
 import { ConsoleMessageDispatcher } from './consoleMessageDispatcher';
@@ -32,6 +32,7 @@ import { serializeResult, parseArgument } from './jsHandleDispatcher';
 import { ElementHandleDispatcher, createHandle } from './elementHandlerDispatcher';
 import { FileChooser } from '../../fileChooser';
 import { CRCoverage } from '../../chromium/crCoverage';
+import { SerializedValue } from '../../common/utilityScriptSerializers';
 
 export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements PageChannel {
   private _page: Page;
@@ -232,11 +233,11 @@ export class WorkerDispatcher extends Dispatcher<Worker, WorkerInitializer> impl
     worker.on(Events.Worker.Close, () => this._dispatchEvent('close'));
   }
 
-  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: any, isPage?: boolean }): Promise<{ value: any }> {
+  async evaluateExpression(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ value: SerializedValue }> {
     return { value: serializeResult(await this._object._evaluateExpression(params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
-  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: any, isPage?: boolean }): Promise<{ handle: JSHandleChannel }> {
+  async evaluateExpressionHandle(params: { expression: string, isFunction: boolean, arg: SerializedArgument }): Promise<{ handle: JSHandleChannel }> {
     return { handle: createHandle(this._scope, await this._object._evaluateExpressionHandle(params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 }
@@ -262,7 +263,7 @@ export class BindingCallDispatcher extends Dispatcher<{}, BindingCallInitializer
     return this._promise;
   }
 
-  resolve(params: { result: any }) {
+  resolve(params: { result: SerializedArgument }) {
     this._resolve!(parseArgument(params.result));
   }
 

--- a/test/dispatchevent.jest.js
+++ b/test/dispatchevent.jest.js
@@ -132,6 +132,20 @@ describe('Page.dispatchEvent(drag)', function() {
   });
 });
 
+describe('ElementHandle.dispatchEvent(drag)', function() {
+  it.fail(WEBKIT)('should dispatch drag drop events', async({page, server}) => {
+    await page.goto(server.PREFIX + '/drag-n-drop.html');
+    const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
+    const source = await page.$('#source');
+    await source.dispatchEvent('dragstart', { dataTransfer });
+    const target = await page.$('#target');
+    await target.dispatchEvent('drop', { dataTransfer });
+    expect(await page.evaluate(() => {
+      return source.parentElement === target;
+    })).toBeTruthy();
+  });
+});
+
 describe('ElementHandle.dispatchEvent(click)', function() {
   it('should dispatch click event', async({page, server}) => {
     await page.goto(server.PREFIX + '/input/button.html');


### PR DESCRIPTION
We now have types for SerializedValue/SerializedArgument. This will
allow us to avoid double parse/serialize for evaluation arguments/results.

Drive-by: typing exposed a bug in ElementHandle.dispatchEvent().