### PR TITLE
fix(chromium): select all on macos should work again

### DIFF
--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -40,6 +40,7 @@ export class CRBrowser extends BrowserBase {
   _backgroundPages = new Map<string, CRPage>();
   _serviceWorkers = new Map<string, CRServiceWorker>();
   _devtools?: CRDevTools;
+  _isMac = false;
 
   private _tracingRecording = false;
   private _tracingPath: string | null = '';
@@ -50,6 +51,8 @@ export class CRBrowser extends BrowserBase {
     const browser = new CRBrowser(connection, options);
     browser._devtools = devtools;
     const session = connection.rootSession;
+    const version = await session.send('Browser.getVersion');
+    browser._isMac = version.userAgent.includes('Macintosh');
     if (!options.persistent) {
       await session.send('Target.setAutoAttach', { autoAttach: true, waitForDebuggerOnStart: true, flatten: true });
       return browser;

--- a/src/chromium/crInput.ts
+++ b/src/chromium/crInput.ts
@@ -50,7 +50,7 @@ export class RawKeyboardImpl implements input.RawKeyboard {
     }
     parts.push(code);
     const shortcut = parts.join('+');
-    let commands = (this._isMac && macEditingCommands[shortcut]) || [];
+    let commands = macEditingCommands[shortcut] || [];
     if (helper.isString(commands))
       commands = [commands];
     // remove the trailing : to match the Chromium command names.

--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -65,7 +65,7 @@ export class CRPage implements PageDelegate {
   constructor(client: CRSession, targetId: string, browserContext: CRBrowserContext, opener: CRPage | null, hasUIWindow: boolean) {
     this._targetId = targetId;
     this._opener = opener;
-    this.rawKeyboard = new RawKeyboardImpl(client);
+    this.rawKeyboard = new RawKeyboardImpl(client, browserContext._browser._isMac);
     this.rawMouse = new RawMouseImpl(client);
     this._pdf = new CRPDF(client);
     this._coverage = new CRCoverage(client);

--- a/test/keyboard.jest.js
+++ b/test/keyboard.jest.js
@@ -290,7 +290,7 @@ describe('Keyboard', function() {
     await textarea.type('👹 Tokyo street Japan 🇯🇵');
     expect(await frame.$eval('textarea', textarea => textarea.value)).toBe('👹 Tokyo street Japan 🇯🇵');
   });
-  it.skip(CHROMIUM && MAC)('should handle selectAll', async ({page, server}) => {
+  it('should handle selectAll', async ({page, server}) => {
     await page.goto(server.PREFIX + '/input/textarea.html');
     const textarea = await page.$('textarea');
     await textarea.type('some text');
@@ -317,6 +317,15 @@ describe('Keyboard', function() {
     await page.keyboard.up(modifier);
     await page.keyboard.press('Backspace');
     expect(await page.$eval('textarea', textarea => textarea.value)).toBe('some tex');
+  });
+  it.skip(!MAC)('should support MacOS shortcuts', async ({page, server}) => {
+    await page.goto(server.PREFIX + '/input/textarea.html');
+    const textarea = await page.$('textarea');
+    await textarea.type('some text');
+    // select one word backwards
+    await page.keyboard.press('Shift+Control+Alt+KeyB');
+    await page.keyboard.press('Backspace');
+    expect(await page.$eval('textarea', textarea => textarea.value)).toBe('some ');
   });
   it('should press the meta key', async ({page}) => {
     const lastEvent = await captureLastKeydown(page);


### PR DESCRIPTION
The patch that enabled this upstream for us got reverted. So we do it ourselves using our own list of macOS editing commands.