### PR TITLE
feat: support atomic browser installation - attempt 2

### DIFF
--- a/src/install/browserPaths.ts
+++ b/src/install/browserPaths.ts
@@ -118,6 +118,10 @@ export function browserDirectory(browsersPath: string, browser: BrowserDescripto
   return path.join(browsersPath, `${browser.name}-${browser.revision}`);
 }
 
+export function markerFilePath(browsersPath: string, browser: BrowserDescriptor): string {
+  return path.join(browserDirectory(browsersPath, browser), 'INSTALLATION_COMPLETE');
+}
+
 export function isBrowserDirectory(browserPath: string): boolean {
   const baseName = path.basename(browserPath);
   return baseName.startsWith('chromium-') || baseName.startsWith('firefox-') || baseName.startsWith('webkit-');


### PR DESCRIPTION
Currently, Ctrl-C while extracting browser might yield users in
a bad place.

This patch adds a marker file inside browser directory to make
sure that browser extraction completed.

Note: this was already attempted in #2489, but was eventually
reverted in #2534.

References #2660