### PR TITLE
feat(slowmo): only slowmo once per user action

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -30,12 +30,11 @@ export interface BrowserProcess {
   close(): Promise<void>;
 }
 
-export type BrowserOptions = {
+export type BrowserOptions = types.UIOptions & {
   name: string,
   downloadsPath?: string,
   headful?: boolean,
   persistent?: types.BrowserContextOptions,  // Undefined means no persistent context.
-  slowMo?: number,
   browserProcess: BrowserProcess,
   proxy?: ProxySettings,
 };

--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -21,7 +21,7 @@ import { Events as CommonEvents } from '../events';
 import { assert } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding, Worker } from '../page';
-import { ConnectionTransport, SlowMoTransport } from '../transport';
+import { ConnectionTransport } from '../transport';
 import * as types from '../types';
 import { ConnectionEvents, CRConnection, CRSession } from './crConnection';
 import { CRPage } from './crPage';
@@ -48,7 +48,7 @@ export class CRBrowser extends BrowserBase {
   private _tracingClient: CRSession | undefined;
 
   static async connect(transport: ConnectionTransport, options: BrowserOptions, devtools?: CRDevTools): Promise<CRBrowser> {
-    const connection = new CRConnection(SlowMoTransport.wrap(transport, options.slowMo));
+    const connection = new CRConnection(transport);
     const browser = new CRBrowser(connection, options);
     browser._devtools = devtools;
     const session = connection.rootSession;

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -103,6 +103,10 @@ export class FrameExecutionContext extends js.ExecutionContext {
     }
     return this._debugScriptPromise;
   }
+
+  async doSlowMo() {
+    return this.frame._page._doSlowMo();
+  }
 }
 
 export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
@@ -490,9 +494,9 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async focus(): Promise<void> {
     await this._page._runAbortableTask(async progress => {
       const result = await this._focus(progress);
+      await this._page._doSlowMo();
       return assertDone(throwRetargetableDOMError(result));
     }, 0);
-    await this._page._doSlowMo();
   }
 
   async _focus(progress: Progress, resetSelectionIfNotFocused?: boolean): Promise<'error:notconnected' | 'done'> {
@@ -588,7 +592,6 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       throw new Error(`Error: failed to find element matching selector "${selector}"`);
     const result = await handle._evaluateExpression(expression, isFunction, true, arg);
     handle.dispose();
-    await this._page._doSlowMo();
     return result;
   }
 
@@ -596,7 +599,6 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const arrayHandle = await selectors._queryArray(this._context.frame, selector, this);
     const result = await arrayHandle._evaluateExpression(expression, isFunction, true, arg);
     arrayHandle.dispose();
-    await this._page._doSlowMo();
     return result;
   }
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -200,6 +200,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async dispatchEvent(type: string, eventInit: Object = {}) {
     await this._evaluateInMain(([injected, node, { type, eventInit }]) =>
       injected.dispatchEvent(node, type, eventInit), { type, eventInit });
+    await this._page._doSlowMo();
   }
 
   async _scrollRectIntoViewIfNeeded(rect?: types.Rect): Promise<'error:notvisible' | 'error:notconnected' | 'done'> {
@@ -407,7 +408,9 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const selectOptions = [...elements, ...values];
     return this._page._frameManager.waitForSignalsCreatedBy(progress, options.noWaitAfter, async () => {
       progress.throwIfAborted();  // Avoid action that has side-effects.
-      return throwFatalDOMError(await this._evaluateInUtility(([injected, node, selectOptions]) => injected.selectOptions(node, selectOptions), selectOptions));
+      const value = await this._evaluateInUtility(([injected, node, selectOptions]) => injected.selectOptions(node, selectOptions), selectOptions);
+      await this._page._doSlowMo();
+      return throwFatalDOMError(value);
     });
   }
 
@@ -480,14 +483,16 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       progress.throwIfAborted();  // Avoid action that has side-effects.
       await this._page._delegate.setInputFiles(this as any as ElementHandle<HTMLInputElement>, files);
     });
+    await this._page._doSlowMo();
     return 'done';
   }
 
   async focus(): Promise<void> {
-    return this._page._runAbortableTask(async progress => {
+    await this._page._runAbortableTask(async progress => {
       const result = await this._focus(progress);
       return assertDone(throwRetargetableDOMError(result));
     }, 0);
+    await this._page._doSlowMo();
   }
 
   async _focus(progress: Progress, resetSelectionIfNotFocused?: boolean): Promise<'error:notconnected' | 'done'> {
@@ -583,6 +588,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       throw new Error(`Error: failed to find element matching selector "${selector}"`);
     const result = await handle._evaluateExpression(expression, isFunction, true, arg);
     handle.dispose();
+    await this._page._doSlowMo();
     return result;
   }
 
@@ -590,6 +596,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const arrayHandle = await selectors._queryArray(this._context.frame, selector, this);
     const result = await arrayHandle._evaluateExpression(expression, isFunction, true, arg);
     arrayHandle.dispose();
+    await this._page._doSlowMo();
     return result;
   }
 

--- a/src/firefox/ffBrowser.ts
+++ b/src/firefox/ffBrowser.ts
@@ -21,7 +21,7 @@ import { Events } from '../events';
 import { assert, helper, RegisteredListener } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding } from '../page';
-import { ConnectionTransport, SlowMoTransport } from '../transport';
+import { ConnectionTransport } from '../transport';
 import * as types from '../types';
 import { ConnectionEvents, FFConnection } from './ffConnection';
 import { FFPage } from './ffPage';
@@ -35,7 +35,7 @@ export class FFBrowser extends BrowserBase {
   private _version = '';
 
   static async connect(transport: ConnectionTransport, options: BrowserOptions): Promise<FFBrowser> {
-    const connection = new FFConnection(SlowMoTransport.wrap(transport, options.slowMo));
+    const connection = new FFConnection(transport);
     const browser = new FFBrowser(connection, options);
     const promises: Promise<any>[] = [
       connection.send('Browser.enable', { attachToDefaultContext: !!options.persistent }),

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -580,7 +580,6 @@ export class Frame {
       throw new Error(`Error: failed to find element matching selector "${selector}"`);
     const result = await handle._evaluateExpression(expression, isFunction, true, arg);
     handle.dispose();
-    await this._page._doSlowMo();
     return result;
   }
 
@@ -588,7 +587,6 @@ export class Frame {
     const arrayHandle = await selectors._queryArray(this, selector);
     const result = await arrayHandle._evaluateExpression(expression, isFunction, true, arg);
     arrayHandle.dispose();
-    await this._page._doSlowMo();
     return result;
   }
 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -355,6 +355,11 @@ export function getFromENV(name: string) {
   return value;
 }
 
+export async function doSlowMo(amount?: number) {
+  if (!amount)
+    return;
+  await new Promise(x => setTimeout(x, amount));
+}
 
 export async function mkdirIfNeeded(filePath: string) {
   // This will harmlessly throw on windows if the dirname is the root directory.

--- a/src/input.ts
+++ b/src/input.ts
@@ -42,11 +42,13 @@ export interface RawKeyboard {
 export class Keyboard {
   private _pressedModifiers = new Set<types.KeyboardModifier>();
   private _pressedKeys = new Set<string>();
+  private _raw: RawKeyboard;
+  private _page: Page;
 
-  constructor(
-    private _raw: RawKeyboard,
-    private _page: Page,
-  ) {}
+  constructor(raw: RawKeyboard, page: Page) {
+    this._raw = raw;
+    this._page = page;
+  }
 
   async down(key: string) {
     const description = this._keyDescriptionForString(key);
@@ -166,11 +168,12 @@ export class Mouse {
   private _y = 0;
   private _lastButton: 'none' | types.MouseButton = 'none';
   private _buttons = new Set<types.MouseButton>();
+  private _raw: RawMouse;
+  private _page: Page;
 
-  constructor(
-    private _raw: RawMouse,
-    private _page: Page,
-  ) {
+  constructor(raw: RawMouse, page: Page) {
+    this._raw = raw;
+    this._page = page;
     this._keyboard = this._page.keyboard;
   }
 

--- a/src/input.ts
+++ b/src/input.ts
@@ -17,6 +17,7 @@
 import { assert } from './helper';
 import * as keyboardLayout from './usKeyboardLayout';
 import * as types from './types';
+import type { Page } from './page';
 
 export const keypadLocation = keyboardLayout.keypadLocation;
 
@@ -39,13 +40,13 @@ export interface RawKeyboard {
 }
 
 export class Keyboard {
-  private _raw: RawKeyboard;
   private _pressedModifiers = new Set<types.KeyboardModifier>();
   private _pressedKeys = new Set<string>();
 
-  constructor(raw: RawKeyboard) {
-    this._raw = raw;
-  }
+  constructor(
+    private _raw: RawKeyboard,
+    private _page: Page,
+  ) {}
 
   async down(key: string) {
     const description = this._keyDescriptionForString(key);
@@ -55,6 +56,7 @@ export class Keyboard {
       this._pressedModifiers.add(description.key as types.KeyboardModifier);
     const text = description.text;
     await this._raw.keydown(this._pressedModifiers, description.code, description.keyCode, description.keyCodeWithoutLocation, description.key, description.location, autoRepeat, text);
+    await this._page._doSlowMo();
   }
 
   private _keyDescriptionForString(keyString: string): KeyDescription {
@@ -75,10 +77,12 @@ export class Keyboard {
       this._pressedModifiers.delete(description.key as types.KeyboardModifier);
     this._pressedKeys.delete(description.code);
     await this._raw.keyup(this._pressedModifiers, description.code, description.keyCode, description.keyCodeWithoutLocation, description.key, description.location);
+    await this._page._doSlowMo();
   }
 
   async insertText(text: string) {
     await this._raw.sendText(text);
+    await this._page._doSlowMo();
   }
 
   async type(text: string, options?: { delay?: number }) {
@@ -111,15 +115,19 @@ export class Keyboard {
     }
 
     const tokens = split(key);
+    const promises = [];
     key = tokens[tokens.length - 1];
     for (let i = 0; i < tokens.length - 1; ++i)
-      await this.down(tokens[i]);
-    await this.down(key);
-    if (options.delay)
+      promises.push(this.down(tokens[i]));
+    promises.push(this.down(key));
+    if (options.delay) {
+      await Promise.all(promises);
       await new Promise(f => setTimeout(f, options.delay));
-    await this.up(key);
+    }
+    promises.push(this.up(key));
     for (let i = tokens.length - 2; i >= 0; --i)
-      await this.up(tokens[i]);
+      promises.push(this.up(tokens[i]));
+    await Promise.all(promises);
   }
 
   async _ensureModifiers(modifiers: types.KeyboardModifier[]): Promise<types.KeyboardModifier[]> {
@@ -153,16 +161,17 @@ export interface RawMouse {
 }
 
 export class Mouse {
-  private _raw: RawMouse;
   private _keyboard: Keyboard;
   private _x = 0;
   private _y = 0;
   private _lastButton: 'none' | types.MouseButton = 'none';
   private _buttons = new Set<types.MouseButton>();
 
-  constructor(raw: RawMouse, keyboard: Keyboard) {
-    this._raw = raw;
-    this._keyboard = keyboard;
+  constructor(
+    private _raw: RawMouse,
+    private _page: Page,
+  ) {
+    this._keyboard = this._page.keyboard;
   }
 
   async move(x: number, y: number, options: { steps?: number } = {}) {
@@ -175,6 +184,7 @@ export class Mouse {
       const middleX = fromX + (x - fromX) * (i / steps);
       const middleY = fromY + (y - fromY) * (i / steps);
       await this._raw.move(middleX, middleY, this._lastButton, this._buttons, this._keyboard._modifiers());
+      await this._page._doSlowMo();
     }
   }
 
@@ -183,6 +193,7 @@ export class Mouse {
     this._lastButton = button;
     this._buttons.add(button);
     await this._raw.down(this._x, this._y, this._lastButton, this._buttons, this._keyboard._modifiers(), clickCount);
+    await this._page._doSlowMo();
   }
 
   async up(options: { button?: types.MouseButton, clickCount?: number } = {}) {
@@ -190,6 +201,7 @@ export class Mouse {
     this._lastButton = 'none';
     this._buttons.delete(button);
     await this._raw.up(this._x, this._y, button, this._buttons, this._keyboard._modifiers(), clickCount);
+    await this._page._doSlowMo();
   }
 
   async click(x: number, y: number, options: { delay?: number, button?: types.MouseButton, clickCount?: number } = {}) {

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -73,6 +73,10 @@ export class ExecutionContext {
   createHandle(remoteObject: RemoteObject): JSHandle {
     return this._delegate.createHandle(this, remoteObject);
   }
+
+  async doSlowMo() {
+    // overrided in FrameExecutionContext
+  }
 }
 
 export class JSHandle<T = any> {
@@ -106,8 +110,10 @@ export class JSHandle<T = any> {
     return evaluate(this._context, false /* returnByValue */, pageFunction, this, arg);
   }
 
-  _evaluateExpression(expression: string, isFunction: boolean, returnByValue: boolean, arg: any) {
-    return evaluateExpression(this._context, returnByValue, expression, isFunction, this, arg);
+  async _evaluateExpression(expression: string, isFunction: boolean, returnByValue: boolean, arg: any) {
+    const value = await evaluateExpression(this._context, returnByValue, expression, isFunction, this, arg);1;
+    await this._context.doSlowMo();
+    return value;
   }
 
   async getProperty(propertyName: string): Promise<JSHandle> {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -44,48 +44,6 @@ export interface ConnectionTransport {
   onclose?: () => void,
 }
 
-export class SlowMoTransport implements ConnectionTransport {
-  private readonly _delay: number;
-  private readonly _delegate: ConnectionTransport;
-
-  onmessage?: (message: ProtocolResponse) => void;
-  onclose?: () => void;
-
-  static wrap(transport: ConnectionTransport, delay?: number): ConnectionTransport {
-    return delay ? new SlowMoTransport(transport, delay) : transport;
-  }
-
-  constructor(transport: ConnectionTransport, delay: number) {
-    this._delay = delay;
-    this._delegate = transport;
-    this._delegate.onmessage = this._onmessage.bind(this);
-    this._delegate.onclose = this._onClose.bind(this);
-  }
-
-  private _onmessage(message: ProtocolResponse) {
-    if (this.onmessage)
-      this.onmessage(message);
-  }
-
-  private _onClose() {
-    if (this.onclose)
-      this.onclose();
-    this._delegate.onmessage = undefined;
-    this._delegate.onclose = undefined;
-  }
-
-  send(s: ProtocolRequest) {
-    setTimeout(() => {
-      if (this._delegate.onmessage)
-        this._delegate.send(s);
-    }, this._delay);
-  }
-
-  close() {
-    this._delegate.close();
-  }
-}
-
 export class WebSocketTransport implements ConnectionTransport {
   private _ws: WebSocket;
   private _progress: Progress;

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,7 +284,7 @@ type LaunchOptionsBase = {
   chromiumSandbox?: boolean,
   slowMo?: number,
 };
-export type LaunchOptions = LaunchOptionsBase & {
+export type LaunchOptions = LaunchOptionsBase & UIOptions & {
   firefoxUserPrefs?: { [key: string]: string | number | boolean },
 };
 export type LaunchPersistentOptions = LaunchOptionsBase & BrowserContextOptions;
@@ -334,4 +334,8 @@ export type Error = {
   message: string,
   name: string,
   stack?: string,
+};
+
+export type UIOptions = {
+  slowMo?: number;
 };

--- a/src/webkit/wkBrowser.ts
+++ b/src/webkit/wkBrowser.ts
@@ -21,7 +21,7 @@ import { Events } from '../events';
 import { helper, RegisteredListener, assert } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding } from '../page';
-import { ConnectionTransport, SlowMoTransport } from '../transport';
+import { ConnectionTransport } from '../transport';
 import * as types from '../types';
 import { Protocol } from './protocol';
 import { kPageProxyMessageReceived, PageProxyMessageReceivedPayload, WKConnection, WKSession } from './wkConnection';
@@ -38,7 +38,7 @@ export class WKBrowser extends BrowserBase {
   private readonly _eventListeners: RegisteredListener[];
 
   static async connect(transport: ConnectionTransport, options: BrowserOptions): Promise<WKBrowser> {
-    const browser = new WKBrowser(SlowMoTransport.wrap(transport, options.slowMo), options);
+    const browser = new WKBrowser(transport, options);
     const promises: Promise<any>[] = [
       browser._browserSession.send('Playwright.enable'),
     ];

--- a/test/slowmo.spec.ts
+++ b/test/slowmo.spec.ts
@@ -1,0 +1,221 @@
+import './base.fixture';
+import { attachFrame } from './utils';
+
+async function checkSlowMo(toImpl, page, task) {
+  let didSlowMo = false;
+  const orig = toImpl(page)._doSlowMo;
+  toImpl(page)._doSlowMo = async function (...args) {
+    if (didSlowMo)
+      throw new Error('already did slowmo');
+    await new Promise(x => setTimeout(x, 100));
+    didSlowMo = true;
+    return orig.call(this, ...args)
+  }
+  await task();
+  expect(!!didSlowMo).toBe(true);
+}
+
+async function checkPageSlowMo(toImpl, page, task) {
+  await page.setContent(`
+    <button>a</button>
+    <input type="checkbox" class="check">
+    <input type="checkbox" checked=true class="uncheck">
+    <input class="fill">
+    <select>
+      <option>foo</option>
+    </select>
+    <input type="file" class="file">
+  `)
+  await checkSlowMo(toImpl, page, task);
+}
+
+it('Page SlowMo $$eval', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.$$eval('button', () => void 0));
+});
+it('Page SlowMo $eval', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.$eval('button', () => void 0));
+});
+it('Page SlowMo check', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.check('.check'));
+});
+it('Page SlowMo click', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.click('button'));
+});
+it('Page SlowMo dblclick', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.dblclick('button'));
+});
+it('Page SlowMo dispatchEvent', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.dispatchEvent('button', 'click'));
+});
+it('Page SlowMo emulateMedia', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.emulateMedia({media: 'print'}));
+});
+it('Page SlowMo evaluate', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.evaluate(() => void 0));
+});
+it('Page SlowMo evaluateHandle', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.evaluateHandle(() => window));
+});
+it('Page SlowMo fill', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.fill('.fill', 'foo'));
+});
+it('Page SlowMo focus', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.focus('button'));
+});
+it('Page SlowMo goto', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.goto('about:blank'));
+});
+it('Page SlowMo hover', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.hover('button'));
+});
+it('Page SlowMo press', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.press('button', 'Enter'));
+});
+it('Page SlowMo reload', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.reload());
+});
+it('Page SlowMo setContent', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.setContent('hello world'));
+});
+it('Page SlowMo selectOption', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.selectOption('select', 'foo'));
+});
+it('Page SlowMo setInputFiles', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.setInputFiles('.file', []));
+});
+it('Page SlowMo setViewportSize', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.setViewportSize({height: 400, width: 400}));
+});
+it('Page SlowMo type', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.type('.fill', 'a'));
+});
+it('Page SlowMo uncheck', async ({page, toImpl}) => {
+  await checkPageSlowMo(toImpl, page, () => page.uncheck('.uncheck'));
+});
+
+async function checkFrameSlowMo(toImpl, page, server, task) {
+  const frame = await attachFrame(page, 'frame1', server.EMPTY_PAGE);
+  await frame.setContent(`
+    <button>a</button>
+    <input type="checkbox" class="check">
+    <input type="checkbox" checked=true class="uncheck">
+    <input class="fill">
+    <select>
+      <option>foo</option>
+    </select>
+    <input type="file" class="file">
+  `)
+  await checkSlowMo(toImpl, page, task.bind(null, frame));
+}
+
+it('Frame SlowMo $$eval', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.$$eval('button', () => void 0));
+});
+it('Frame SlowMo $eval', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.$eval('button', () => void 0));
+});
+it('Frame SlowMo check', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.check('.check'));
+});
+it('Frame SlowMo click', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.click('button'));
+});
+it('Frame SlowMo dblclick', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.dblclick('button'));
+});
+it('Frame SlowMo dispatchEvent', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.dispatchEvent('button', 'click'));
+});
+it('Frame SlowMo evaluate', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.evaluate(() => void 0));
+});
+it('Frame SlowMo evaluateHandle', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.evaluateHandle(() => window));
+});
+it('Frame SlowMo fill', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.fill('.fill', 'foo'));
+});
+it('Frame SlowMo focus', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.focus('button'));
+});
+it('Frame SlowMo goto', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.goto('about:blank'));
+});
+it('Frame SlowMo hover', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.hover('button'));
+});
+it('Frame SlowMo press', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.press('button', 'Enter'));
+});
+it('Frame SlowMo setContent', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.setContent('hello world'));
+});
+it('Frame SlowMo selectOption', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.selectOption('select', 'foo'));
+});
+it('Frame SlowMo setInputFiles', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.setInputFiles('.file', []));
+});
+it('Frame SlowMo type', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.type('.fill', 'a'));
+});
+it('Frame SlowMo uncheck', async({page, server, toImpl}) => {
+  await checkFrameSlowMo(toImpl, page, server, frame => frame.uncheck('.uncheck'));
+});
+
+async function checkElementSlowMo(toImpl, page, selector, task) {
+  await page.setContent(`
+    <button>a</button>
+    <input type="checkbox" class="check">
+    <input type="checkbox" checked=true class="uncheck">
+    <input class="fill">
+    <select>
+      <option>foo</option>
+    </select>
+    <input type="file" class="file">
+  `)
+  const element = await page.$(selector);
+  await checkSlowMo(toImpl, page, task.bind(null, element));
+}
+it('ElementHandle SlowMo $$', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, 'body', element => element.$$eval('button', () => void 0));
+});
+it('ElementHandle SlowMo $', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, 'body', element => element.$eval('button', () => void 0));
+});
+it('ElementHandle SlowMo check', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, '.check', element => element.check());
+});
+it('ElementHandle SlowMo click', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, 'button', element => element.click());
+});
+it('ElementHandle SlowMo dblclick', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, 'button', element => element.dblclick());
+});
+it('ElementHandle SlowMo dispatchEvent', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, 'button', element => element.dispatchEvent('click'));
+});
+it('ElementHandle SlowMo fill', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, '.fill', element => element.fill('foo'));
+});
+it('ElementHandle SlowMo focus', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, 'button', element => element.focus());
+});
+it('ElementHandle SlowMo hover', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, 'button', element => element.hover());
+});
+it('ElementHandle SlowMo press', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, 'button', element => element.press('Enter'));
+});
+it('ElementHandle SlowMo selectOption', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, 'select', element => element.selectOption('foo'));
+});
+it('ElementHandle SlowMo setInputFiles', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, '.file', element => element.setInputFiles([]));
+});
+it('ElementHandle SlowMo type', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, '.fill', element => element.type( 'a'));
+});
+it('ElementHandle SlowMo uncheck', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, '.uncheck', element => element.uncheck());
+});

--- a/test/slowmo.spec.ts
+++ b/test/slowmo.spec.ts
@@ -17,6 +17,8 @@ import './base.fixture';
 
 import { attachFrame } from './utils';
 
+const {WIRE} = testOptions;
+
 async function checkSlowMo(toImpl, page, task) {
   let didSlowMo = false;
   const orig = toImpl(page)._doSlowMo;
@@ -45,67 +47,67 @@ async function checkPageSlowMo(toImpl, page, task) {
   await checkSlowMo(toImpl, page, task);
 }
 
-it('Page SlowMo $$eval', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo $$eval', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.$$eval('button', () => void 0));
 });
-it('Page SlowMo $eval', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo $eval', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.$eval('button', () => void 0));
 });
-it('Page SlowMo check', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo check', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.check('.check'));
 });
-it('Page SlowMo click', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo click', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.click('button'));
 });
-it('Page SlowMo dblclick', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo dblclick', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.dblclick('button'));
 });
-it('Page SlowMo dispatchEvent', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo dispatchEvent', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.dispatchEvent('button', 'click'));
 });
-it('Page SlowMo emulateMedia', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo emulateMedia', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.emulateMedia({media: 'print'}));
 });
-it('Page SlowMo evaluate', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo evaluate', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.evaluate(() => void 0));
 });
-it('Page SlowMo evaluateHandle', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo evaluateHandle', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.evaluateHandle(() => window));
 });
-it('Page SlowMo fill', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo fill', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.fill('.fill', 'foo'));
 });
-it('Page SlowMo focus', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo focus', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.focus('button'));
 });
-it('Page SlowMo goto', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo goto', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.goto('about:blank'));
 });
-it('Page SlowMo hover', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo hover', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.hover('button'));
 });
-it('Page SlowMo press', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo press', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.press('button', 'Enter'));
 });
-it('Page SlowMo reload', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo reload', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.reload());
 });
-it('Page SlowMo setContent', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo setContent', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.setContent('hello world'));
 });
-it('Page SlowMo selectOption', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo selectOption', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.selectOption('select', 'foo'));
 });
-it('Page SlowMo setInputFiles', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo setInputFiles', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.setInputFiles('.file', []));
 });
-it('Page SlowMo setViewportSize', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo setViewportSize', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.setViewportSize({height: 400, width: 400}));
 });
-it('Page SlowMo type', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo type', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.type('.fill', 'a'));
 });
-it('Page SlowMo uncheck', async ({page, toImpl}) => {
+it.skip(WIRE)('Page SlowMo uncheck', async ({page, toImpl}) => {
   await checkPageSlowMo(toImpl, page, () => page.uncheck('.uncheck'));
 });
 
@@ -124,58 +126,58 @@ async function checkFrameSlowMo(toImpl, page, server, task) {
   await checkSlowMo(toImpl, page, task.bind(null, frame));
 }
 
-it('Frame SlowMo $$eval', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo $$eval', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.$$eval('button', () => void 0));
 });
-it('Frame SlowMo $eval', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo $eval', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.$eval('button', () => void 0));
 });
-it('Frame SlowMo check', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo check', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.check('.check'));
 });
-it('Frame SlowMo click', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo click', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.click('button'));
 });
-it('Frame SlowMo dblclick', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo dblclick', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.dblclick('button'));
 });
-it('Frame SlowMo dispatchEvent', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo dispatchEvent', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.dispatchEvent('button', 'click'));
 });
-it('Frame SlowMo evaluate', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo evaluate', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.evaluate(() => void 0));
 });
-it('Frame SlowMo evaluateHandle', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo evaluateHandle', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.evaluateHandle(() => window));
 });
-it('Frame SlowMo fill', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo fill', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.fill('.fill', 'foo'));
 });
-it('Frame SlowMo focus', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo focus', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.focus('button'));
 });
-it('Frame SlowMo goto', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo goto', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.goto('about:blank'));
 });
-it('Frame SlowMo hover', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo hover', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.hover('button'));
 });
-it('Frame SlowMo press', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo press', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.press('button', 'Enter'));
 });
-it('Frame SlowMo setContent', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo setContent', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.setContent('hello world'));
 });
-it('Frame SlowMo selectOption', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo selectOption', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.selectOption('select', 'foo'));
 });
-it('Frame SlowMo setInputFiles', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo setInputFiles', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.setInputFiles('.file', []));
 });
-it('Frame SlowMo type', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo type', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.type('.fill', 'a'));
 });
-it('Frame SlowMo uncheck', async({page, server, toImpl}) => {
+it.skip(WIRE)('Frame SlowMo uncheck', async({page, server, toImpl}) => {
   await checkFrameSlowMo(toImpl, page, server, frame => frame.uncheck('.uncheck'));
 });
 
@@ -193,51 +195,51 @@ async function checkElementSlowMo(toImpl, page, selector, task) {
   const element = await page.$(selector);
   await checkSlowMo(toImpl, page, task.bind(null, element));
 }
-it('ElementHandle SlowMo $$eval', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo $$eval', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'body', element => element.$$eval('button', () => void 0));
 });
-it('ElementHandle SlowMo $eval', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo $eval', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'body', element => element.$eval('button', () => void 0));
 });
-it('ElementHandle SlowMo check', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo check', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, '.check', element => element.check());
 });
-it('ElementHandle SlowMo click', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo click', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'button', element => element.click());
 });
-it('ElementHandle SlowMo dblclick', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo dblclick', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'button', element => element.dblclick());
 });
-it('ElementHandle SlowMo dispatchEvent', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo dispatchEvent', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'button', element => element.dispatchEvent('click'));
 });
-it('ElementHandle SlowMo evaluate', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo evaluate', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'button', element => element.evaluate(() => void 0));
 });
-it('ElementHandle SlowMo evaluateHandle', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo evaluateHandle', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'button', element => element.evaluateHandle(() => void 0));
 });
-it('ElementHandle SlowMo fill', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo fill', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, '.fill', element => element.fill('foo'));
 });
-it('ElementHandle SlowMo focus', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo focus', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'button', element => element.focus());
 });
-it('ElementHandle SlowMo hover', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo hover', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'button', element => element.hover());
 });
-it('ElementHandle SlowMo press', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo press', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'button', element => element.press('Enter'));
 });
-it('ElementHandle SlowMo selectOption', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo selectOption', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'select', element => element.selectOption('foo'));
 });
-it('ElementHandle SlowMo setInputFiles', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo setInputFiles', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, '.file', element => element.setInputFiles([]));
 });
-it('ElementHandle SlowMo type', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo type', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, '.fill', element => element.type( 'a'));
 });
-it('ElementHandle SlowMo uncheck', async ({page, toImpl}) => {
+it.skip(WIRE)('ElementHandle SlowMo uncheck', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, '.uncheck', element => element.uncheck());
 });

--- a/test/slowmo.spec.ts
+++ b/test/slowmo.spec.ts
@@ -193,10 +193,10 @@ async function checkElementSlowMo(toImpl, page, selector, task) {
   const element = await page.$(selector);
   await checkSlowMo(toImpl, page, task.bind(null, element));
 }
-it('ElementHandle SlowMo $$', async ({page, toImpl}) => {
+it('ElementHandle SlowMo $$eval', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'body', element => element.$$eval('button', () => void 0));
 });
-it('ElementHandle SlowMo $', async ({page, toImpl}) => {
+it('ElementHandle SlowMo $eval', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'body', element => element.$eval('button', () => void 0));
 });
 it('ElementHandle SlowMo check', async ({page, toImpl}) => {
@@ -210,6 +210,12 @@ it('ElementHandle SlowMo dblclick', async ({page, toImpl}) => {
 });
 it('ElementHandle SlowMo dispatchEvent', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, 'button', element => element.dispatchEvent('click'));
+});
+it('ElementHandle SlowMo evaluate', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, 'button', element => element.evaluate(() => void 0));
+});
+it('ElementHandle SlowMo evaluateHandle', async ({page, toImpl}) => {
+  await checkElementSlowMo(toImpl, page, 'button', element => element.evaluateHandle(() => void 0));
 });
 it('ElementHandle SlowMo fill', async ({page, toImpl}) => {
   await checkElementSlowMo(toImpl, page, '.fill', element => element.fill('foo'));

--- a/test/slowmo.spec.ts
+++ b/test/slowmo.spec.ts
@@ -1,4 +1,20 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import './base.fixture';
+
 import { attachFrame } from './utils';
 
 async function checkSlowMo(toImpl, page, task) {


### PR DESCRIPTION
This changes the behavior of slowmo to slow down user actions instead of every protocol command. This makes slowmo a lot more predictable. Without this, there is no way to set slowmo to a good value without incurring a huge delay at the start of your test when it sets things up.