### PR TITLE
fix(test): remove defaultBrowserOptions, fix zombies on sigint

### DIFF
--- a/test/channels.jest.js
+++ b/test/channels.jest.js
@@ -103,7 +103,7 @@ describe.skip(!CHANNEL)('Channels', function() {
     await expectScopeState(browserType, GOLDEN_PRECONDITION);
   });
 
-  it('should scope browser handles', async({browserType, defaultBrowserOptions}) => {
+  it('should scope browser handles', async({browserType}) => {
     const GOLDEN_PRECONDITION = {
       _guid: '',
       objects: [
@@ -119,7 +119,7 @@ describe.skip(!CHANNEL)('Channels', function() {
     };
     await expectScopeState(browserType, GOLDEN_PRECONDITION);
 
-    const browser = await browserType.launch(defaultBrowserOptions);
+    const browser = await browserType.launch();
     await browser.newContext();
     await expectScopeState(browserType, {
       _guid: '',

--- a/test/chromium/launcher.jest.js
+++ b/test/chromium/launcher.jest.js
@@ -20,26 +20,26 @@ const {makeUserDataDir, removeUserDataDir} = utils;
 const {FFOX, CHROMIUM, WEBKIT, WIN, USES_HOOKS} = testOptions;
 
 describe.skip(!CHROMIUM)('launcher', function() {
-  it('should throw with remote-debugging-pipe argument', async({browserType, defaultBrowserOptions}) => {
-    const options = Object.assign({}, defaultBrowserOptions);
-    options.args = ['--remote-debugging-pipe'].concat(options.args || []);
-    const error = await browserType.launchServer(options).catch(e => e);
+  it('should throw with remote-debugging-pipe argument', async({browserType}) => {
+    const error = await browserType.launchServer({
+      args: ['--remote-debugging-pipe']
+    }).catch(e => e);
     expect(error.message).toContain('Playwright manages remote debugging connection itself');
   });
-  it('should not throw with remote-debugging-port argument', async({browserType, defaultBrowserOptions}) => {
-    const options = Object.assign({}, defaultBrowserOptions);
-    options.args = ['--remote-debugging-port=0'].concat(options.args || []);
-    const browser = await browserType.launchServer(options);
+  it('should not throw with remote-debugging-port argument', async({browserType}) => {
+    const browser = await browserType.launchServer({
+      args: ['--remote-debugging-port=0']
+    });
     await browser.close();
   });
-  it.fail(USES_HOOKS || WIN)('should open devtools when "devtools: true" option is given', async({browserType, defaultBrowserOptions}) => {
+  it.fail(USES_HOOKS || WIN)('should open devtools when "devtools: true" option is given', async({browserType}) => {
     let devtoolsCallback;
     const devtoolsPromise = new Promise(f => devtoolsCallback = f);
     const __testHookForDevTools = devtools => devtools.__testHookOnBinding = parsed => {
       if (parsed.method === 'getPreferences')
         devtoolsCallback();
     };
-    const browser = await browserType.launch({...defaultBrowserOptions, headless: false, devtools: true, __testHookForDevTools});
+    const browser = await browserType.launch({ headless: false, devtools: true, __testHookForDevTools});
     const context = await browser.newContext();
     await Promise.all([
       devtoolsPromise,
@@ -50,10 +50,10 @@ describe.skip(!CHROMIUM)('launcher', function() {
 });
 
 describe.skip(!CHROMIUM)('extensions', () => {
-  it('should return background pages', async({browserType, defaultBrowserOptions}) => {
+  it('should return background pages', async({browserType}) => {
     const userDataDir = await makeUserDataDir();
     const extensionPath = path.join(__dirname, '..', 'assets', 'simple-extension');
-    const extensionOptions = {...defaultBrowserOptions,
+    const extensionOptions = {
       headless: false,
       args: [
         `--disable-extensions-except=${extensionPath}`,
@@ -74,8 +74,8 @@ describe.skip(!CHROMIUM)('extensions', () => {
 });
 
 describe.skip(!CHROMIUM)('BrowserContext', function() {
-  it('should not create pages automatically', async ({browserType, defaultBrowserOptions}) => {
-    const browser = await browserType.launch(defaultBrowserOptions);
+  it('should not create pages automatically', async ({browserType}) => {
+    const browser = await browserType.launch();
     const browserSession = await browser.newBrowserCDPSession();
     const targets = [];
     browserSession.on('Target.targetCreated', async ({targetInfo}) => {

--- a/test/chromium/oopif.jest.js
+++ b/test/chromium/oopif.jest.js
@@ -16,10 +16,9 @@
 
 const {FFOX, CHROMIUM, WEBKIT, CHANNEL} = testOptions;
 
-registerFixture('sppBrowser', async ({browserType, defaultBrowserOptions}, test) => {
+registerFixture('sppBrowser', async ({browserType}, test) => {
   const browser = await browserType.launch({
-    ...defaultBrowserOptions,
-    args: (defaultBrowserOptions.args || []).concat(['--site-per-process'])
+    args: ['--site-per-process']
   });
   try {
     await test(browser);
@@ -269,10 +268,10 @@ describe.skip(!CHROMIUM)('OOPIF', function() {
     await page.click('button');
     expect(await page.evaluate(() => window.BUTTON_CLICKED)).toBe(true);
   });
-  it('should report google.com frame with headful', async({browserType, defaultBrowserOptions, server}) => {
+  it('should report google.com frame with headful', async({browserType, server}) => {
     // @see https://github.com/GoogleChrome/puppeteer/issues/2548
     // https://google.com is isolated by default in Chromium embedder.
-    const browser = await browserType.launch({...defaultBrowserOptions, headless: false});
+    const browser = await browserType.launch({headless: false});
     const page = await browser.newPage();
     await page.goto(server.EMPTY_PAGE);
     await page.route('**/*', route => {

--- a/test/cookies.jest.js
+++ b/test/cookies.jest.js
@@ -277,13 +277,13 @@ describe('BrowserContext.addCookies', function() {
       await context.close();
     }
   });
-  it.slow()('should isolate cookies between launches', async({browserType, server, defaultBrowserOptions}) => {
-    const browser1 = await browserType.launch(defaultBrowserOptions);
+  it.slow()('should isolate cookies between launches', async({browserType, server,}) => {
+    const browser1 = await browserType.launch();
     const context1 = await browser1.newContext();
     await context1.addCookies([{url: server.EMPTY_PAGE, name: 'cookie-in-context-1', value: 'value', expires: Date.now() / 1000 + 10000}]);
     await browser1.close();
 
-    const browser2 = await browserType.launch(defaultBrowserOptions);
+    const browser2 = await browserType.launch();
     const context2 = await browser2.newContext();
     const cookies = await context2.cookies();
     expect(cookies.length).toBe(0);

--- a/test/download.jest.js
+++ b/test/download.jest.js
@@ -183,8 +183,8 @@ describe('Download', function() {
     expect(fs.existsSync(path1)).toBeFalsy();
     expect(fs.existsSync(path2)).toBeFalsy();
   });
-  it('should delete downloads on browser gone', async ({ server, browserType, defaultBrowserOptions }) => {
-    const browser = await browserType.launch(defaultBrowserOptions);
+  it('should delete downloads on browser gone', async ({ server, browserType }) => {
+    const browser = await browserType.launch();
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download1 ] = await Promise.all([

--- a/test/downloadsPath.jest.js
+++ b/test/downloadsPath.jest.js
@@ -34,14 +34,13 @@ registerFixture('downloadsPath', async ({}, test) => {
   }
 });
 
-registerFixture('downloadsBrowser', async ({server, browserType, defaultBrowserOptions, downloadsPath}, test) => {
+registerFixture('downloadsBrowser', async ({server, browserType, downloadsPath}, test) => {
   server.setRoute('/download', (req, res) => {
     res.setHeader('Content-Type', 'application/octet-stream');
     res.setHeader('Content-Disposition', 'attachment; filename=file.txt');
     res.end(`Hello world`);
   });
   const browser = await browserType.launch({
-    ...defaultBrowserOptions,
     downloadsPath: downloadsPath,
   });
   try {
@@ -51,7 +50,7 @@ registerFixture('downloadsBrowser', async ({server, browserType, defaultBrowserO
   }
 });
 
-registerFixture('persistentDownloadsContext', async ({server, browserType, defaultBrowserOptions, downloadsPath}, test) => {
+registerFixture('persistentDownloadsContext', async ({server, browserType, downloadsPath}, test) => {
   const userDataDir = await mkdtempAsync(path.join(os.tmpdir(), 'playwright-test-'));
   server.setRoute('/download', (req, res) => {
     res.setHeader('Content-Type', 'application/octet-stream');
@@ -61,7 +60,6 @@ registerFixture('persistentDownloadsContext', async ({server, browserType, defau
   const context = await browserType.launchPersistentContext(
     userDataDir,
     {
-      ...defaultBrowserOptions,
       downloadsPath,
       acceptDownloads: true
     }

--- a/test/firefox/launcher.jest.js
+++ b/test/firefox/launcher.jest.js
@@ -17,9 +17,8 @@
 const { FFOX } = testOptions;
 
 describe.skip(!FFOX)('launcher', function() {
-  it('should pass firefox user preferences', async({browserType, defaultBrowserOptions}) => {
+  it('should pass firefox user preferences', async({browserType}) => {
     const browser = await browserType.launch({
-      ...defaultBrowserOptions,
       firefoxUserPrefs: {
         'network.proxy.type': 1,
         'network.proxy.http': '127.0.0.1',

--- a/test/fixtures.jest.js
+++ b/test/fixtures.jest.js
@@ -22,12 +22,12 @@ const {FFOX, CHROMIUM, WEBKIT, WIN, LINUX, HEADLESS} = testOptions;
 const playwrightPath = path.join(__dirname, '..');
 
 class Wrapper {
-  constructor(browserType, defaultBrowserOptions, extraOptions) {
+  constructor(browserType, extraOptions) {
     this._output = new Map();
     this._outputCallback = new Map();
 
     this._browserType = browserType;
-    const launchOptions = {...defaultBrowserOptions,
+    const launchOptions = {
       handleSIGINT: true,
       handleSIGTERM: true,
       handleSIGHUP: true,
@@ -91,14 +91,14 @@ class Wrapper {
   }
 }
 
-registerFixture('wrapper', async ({browserType, defaultBrowserOptions}, test) => {
-  const wrapper = new Wrapper(browserType, defaultBrowserOptions);
+registerFixture('wrapper', async ({browserType}, test) => {
+  const wrapper = new Wrapper(browserType);
   await wrapper.connect();
   await test(wrapper);
 });
 
-registerFixture('stallingWrapper', async ({browserType, defaultBrowserOptions}, test) => {
-  const wrapper = new Wrapper(browserType, defaultBrowserOptions, { stallOnClose: true });
+registerFixture('stallingWrapper', async ({browserType}, test) => {
+  const wrapper = new Wrapper(browserType, { stallOnClose: true });
   await wrapper.connect();
   await test(wrapper);
 });

--- a/test/headful.jest.js
+++ b/test/headful.jest.js
@@ -19,25 +19,25 @@ const { makeUserDataDir, removeUserDataDir } = utils;
 const {FFOX, CHROMIUM, WEBKIT, WIN, MAC} = testOptions;
 
 describe('Headful', function() {
-  it('should have default url when launching browser', async ({browserType, defaultBrowserOptions}) => {
+  it('should have default url when launching browser', async ({browserType}) => {
     const userDataDir = await makeUserDataDir();
-    const browserContext = await browserType.launchPersistentContext(userDataDir, {...defaultBrowserOptions, headless: false });
+    const browserContext = await browserType.launchPersistentContext(userDataDir, { headless: false });
     const urls = browserContext.pages().map(page => page.url());
     expect(urls).toEqual(['about:blank']);
     await browserContext.close();
     await removeUserDataDir(userDataDir);
   });
-  it.fail(WIN && CHROMIUM).slow()('headless should be able to read cookies written by headful', async({browserType, defaultBrowserOptions, server}) => {
+  it.fail(WIN && CHROMIUM).slow()('headless should be able to read cookies written by headful', async({browserType, server}) => {
     // see https://github.com/microsoft/playwright/issues/717
     const userDataDir = await makeUserDataDir();
     // Write a cookie in headful chrome
-    const headfulContext = await browserType.launchPersistentContext(userDataDir, {...defaultBrowserOptions, headless: false});
+    const headfulContext = await browserType.launchPersistentContext(userDataDir, { headless: false});
     const headfulPage = await headfulContext.newPage();
     await headfulPage.goto(server.EMPTY_PAGE);
     await headfulPage.evaluate(() => document.cookie = 'foo=true; expires=Fri, 31 Dec 9999 23:59:59 GMT');
     await headfulContext.close();
     // Read the cookie from headless chrome
-    const headlessContext = await browserType.launchPersistentContext(userDataDir, {...defaultBrowserOptions, headless: true});
+    const headlessContext = await browserType.launchPersistentContext(userDataDir, { headless: true});
     const headlessPage = await headlessContext.newPage();
     await headlessPage.goto(server.EMPTY_PAGE);
     const cookie = await headlessPage.evaluate(() => document.cookie);
@@ -46,9 +46,9 @@ describe('Headful', function() {
     await removeUserDataDir(userDataDir);
     expect(cookie).toBe('foo=true');
   });
-  it.slow()('should close browser with beforeunload page', async({browserType, defaultBrowserOptions, server}) => {
+  it.slow()('should close browser with beforeunload page', async({browserType, server}) => {
     const userDataDir = await makeUserDataDir();
-    const browserContext = await browserType.launchPersistentContext(userDataDir, {...defaultBrowserOptions, headless: false});
+    const browserContext = await browserType.launchPersistentContext(userDataDir, { headless: false});
     const page = await browserContext.newPage();
     await page.goto(server.PREFIX + '/beforeunload.html');
     // We have to interact with a page so that 'beforeunload' handlers
@@ -57,8 +57,8 @@ describe('Headful', function() {
     await browserContext.close();
     await removeUserDataDir(userDataDir);
   });
-  it('should not crash when creating second context', async ({browserType, defaultBrowserOptions, server}) => {
-    const browser = await browserType.launch({...defaultBrowserOptions, headless: false });
+  it('should not crash when creating second context', async ({browserType, server}) => {
+    const browser = await browserType.launch({ headless: false });
     {
       const browserContext = await browser.newContext();
       const page = await browserContext.newPage();
@@ -71,23 +71,23 @@ describe('Headful', function() {
     }
     await browser.close();
   });
-  it('should click background tab', async({browserType, defaultBrowserOptions, server}) => {
-    const browser = await browserType.launch({...defaultBrowserOptions, headless: false });
+  it('should click background tab', async({browserType, server}) => {
+    const browser = await browserType.launch({ headless: false });
     const page = await browser.newPage();
     await page.setContent(`<button>Hello</button><a target=_blank href="${server.EMPTY_PAGE}">empty.html</a>`);
     await page.click('a');
     await page.click('button');
     await browser.close();
   });
-  it('should close browser after context menu was triggered', async({browserType, defaultBrowserOptions, server}) => {
-    const browser = await browserType.launch({...defaultBrowserOptions, headless: false });
+  it('should close browser after context menu was triggered', async({browserType, server}) => {
+    const browser = await browserType.launch({ headless: false });
     const page = await browser.newPage();
     await page.goto(server.PREFIX + '/grid.html');
     await page.click('body', {button: 'right'});
     await browser.close();
   });
-  it('should(not) block third party cookies', async({browserType, defaultBrowserOptions, server}) => {
-    const browser = await browserType.launch({...defaultBrowserOptions, headless: false });
+  it('should(not) block third party cookies', async({browserType, server}) => {
+    const browser = await browserType.launch({ headless: false });
     const page = await browser.newPage();
     await page.goto(server.EMPTY_PAGE);
     await page.evaluate(src => {
@@ -125,9 +125,9 @@ describe('Headful', function() {
     }
     await browser.close();
   });
-  it.fail(WEBKIT)('should not override viewport size when passed null', async function({browserType, defaultBrowserOptions, server}) {
+  it.fail(WEBKIT)('should not override viewport size when passed null', async function({browserType, server}) {
     // Our WebKit embedder does not respect window features.
-    const browser = await browserType.launch({...defaultBrowserOptions, headless: false });
+    const browser = await browserType.launch({ headless: false });
     const context = await browser.newContext({ viewport: null });
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);

--- a/test/jest/fixtures.js
+++ b/test/jest/fixtures.js
@@ -156,6 +156,7 @@ module.exports = function registerFixtures(global) {
     const closables = new Set();
     /** @type {BrowserType} */
     const wrapper = {
+      ...browserType,
       async connect(options) {
         const browser = await browserType.connect(options);
         closables.add(browser);

--- a/test/launcher.jest.js
+++ b/test/launcher.jest.js
@@ -22,8 +22,8 @@ const {FFOX, CHROMIUM, WEBKIT, WIN, USES_HOOKS, CHANNEL} = testOptions;
 
 describe('Playwright', function() {
   describe('browserType.launch', function() {
-    it('should reject all promises when browser is closed', async({browserType, defaultBrowserOptions}) => {
-      const browser = await browserType.launch(defaultBrowserOptions);
+    it('should reject all promises when browser is closed', async({browserType}) => {
+      const browser = await browserType.launch();
       const page = await (await browser.newContext()).newPage();
       let error = null;
       const neverResolves = page.evaluate(() => new Promise(r => {})).catch(e => error = e);
@@ -32,52 +32,52 @@ describe('Playwright', function() {
       await neverResolves;
       expect(error.message).toContain('Protocol error');
     });
-    it('should throw if userDataDir option is passed', async({browserType, defaultBrowserOptions}) => {
+    it('should throw if userDataDir option is passed', async({browserType}) => {
       let waitError = null;
-      const options = Object.assign({}, defaultBrowserOptions, {userDataDir: 'random-path'});
+      const options = Object.assign({}, {userDataDir: 'random-path'});
       await browserType.launch(options).catch(e => waitError = e);
       expect(waitError.message).toContain('launchPersistentContext');
     });
-    it.skip(FFOX)('should throw if page argument is passed', async({browserType, defaultBrowserOptions}) => {
+    it.skip(FFOX)('should throw if page argument is passed', async({browserType}) => {
       let waitError = null;
-      const options = Object.assign({}, defaultBrowserOptions, { args: ['http://example.com'] });
+      const options = Object.assign({}, { args: ['http://example.com'] });
       await browserType.launch(options).catch(e => waitError = e);
       expect(waitError.message).toContain('can not specify page');
     });
-    it.fail(true)('should reject if launched browser fails immediately', async({browserType, defaultBrowserOptions}) => {
+    it.fail(true)('should reject if launched browser fails immediately', async({browserType}) => {
       // I'm getting ENCONRESET on this one.
-      const options = Object.assign({}, defaultBrowserOptions, {executablePath: path.join(__dirname, 'assets', 'dummy_bad_browser_executable.js')});
+      const options = Object.assign({}, {executablePath: path.join(__dirname, 'assets', 'dummy_bad_browser_executable.js')});
       let waitError = null;
       await browserType.launch(options).catch(e => waitError = e);
       expect(waitError.message).toContain('== logs ==');
     });
-    it('should reject if executable path is invalid', async({browserType, defaultBrowserOptions}) => {
+    it('should reject if executable path is invalid', async({browserType}) => {
       let waitError = null;
-      const options = Object.assign({}, defaultBrowserOptions, {executablePath: 'random-invalid-path'});
+      const options = Object.assign({}, {executablePath: 'random-invalid-path'});
       await browserType.launch(options).catch(e => waitError = e);
       expect(waitError.message).toContain('Failed to launch');
     });
-    it.skip(USES_HOOKS)('should handle timeout', async({browserType, defaultBrowserOptions}) => {
-      const options = { ...defaultBrowserOptions, timeout: 5000, __testHookBeforeCreateBrowser: () => new Promise(f => setTimeout(f, 6000)) };
+    it.skip(USES_HOOKS)('should handle timeout', async({browserType}) => {
+      const options = { timeout: 5000, __testHookBeforeCreateBrowser: () => new Promise(f => setTimeout(f, 6000)) };
       const error = await browserType.launch(options).catch(e => e);
       expect(error.message).toContain(`browserType.launch: Timeout 5000ms exceeded.`);
       expect(error.message).toContain(`[browser] <launching>`);
       expect(error.message).toContain(`[browser] <launched> pid=`);
     });
-    it.skip(USES_HOOKS)('should handle exception', async({browserType, defaultBrowserOptions}) => {
+    it.skip(USES_HOOKS)('should handle exception', async({browserType}) => {
       const e = new Error('Dummy');
-      const options = { ...defaultBrowserOptions, __testHookBeforeCreateBrowser: () => { throw e; }, timeout: 9000 };
+      const options = { __testHookBeforeCreateBrowser: () => { throw e; }, timeout: 9000 };
       const error = await browserType.launch(options).catch(e => e);
       expect(error.message).toContain('Dummy');
     });
-    it.skip(USES_HOOKS)('should report launch log', async({browserType, defaultBrowserOptions}) => {
+    it.skip(USES_HOOKS)('should report launch log', async({browserType}) => {
       const e = new Error('Dummy');
-      const options = { ...defaultBrowserOptions, __testHookBeforeCreateBrowser: () => { throw e; }, timeout: 9000 };
+      const options = { __testHookBeforeCreateBrowser: () => { throw e; }, timeout: 9000 };
       const error = await browserType.launch(options).catch(e => e);
       expect(error.message).toContain('<launching>');
     });
-    it.skip(CHANNEL).slow()('should accept objects as options', async({browserType, defaultBrowserOptions}) => {
-      const browser = await browserType.launch({ ...defaultBrowserOptions, process });
+    it.skip(CHANNEL).slow()('should accept objects as options', async({browserType}) => {
+      const browser = await browserType.launch({ process });
       await browser.close();
     });
   });
@@ -117,8 +117,8 @@ describe('Top-level requires', function() {
 });
 
 describe('Browser.isConnected', () => {
-  it('should set the browser connected state', async ({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should set the browser connected state', async ({browserType}) => {
+    const browserServer = await browserType.launchServer();
     const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     expect(remote.isConnected()).toBe(true);
     await remote.close();
@@ -126,8 +126,8 @@ describe('Browser.isConnected', () => {
     await browserServer._checkLeaks();
     await browserServer.close();
   });
-  it('should throw when used after isConnected returns false', async({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should throw when used after isConnected returns false', async({browserType}) => {
+    const browserServer = await browserType.launchServer();
     const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     const page = await remote.newPage();
     await Promise.all([
@@ -141,9 +141,9 @@ describe('Browser.isConnected', () => {
 });
 
 describe('Browser.disconnect', function() {
-  it('should reject navigation when browser closes', async({browserType, defaultBrowserOptions, server}) => {
+  it('should reject navigation when browser closes', async({browserType, server}) => {
     server.setRoute('/one-style.css', () => {});
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+    const browserServer = await browserType.launchServer();
     const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     const page = await remote.newPage();
     const navigationPromise = page.goto(server.PREFIX + '/one-style.html', {timeout: 60000}).catch(e => e);
@@ -154,9 +154,9 @@ describe('Browser.disconnect', function() {
     await browserServer._checkLeaks();
     await browserServer.close();
   });
-  it('should reject waitForSelector when browser closes', async({browserType, defaultBrowserOptions, server}) => {
+  it('should reject waitForSelector when browser closes', async({browserType, server}) => {
     server.setRoute('/empty.html', () => {});
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+    const browserServer = await browserType.launchServer();
     const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     const page = await remote.newPage();
     const watchdog = page.waitForSelector('div', { state: 'attached', timeout: 60000 }).catch(e => e);
@@ -170,8 +170,8 @@ describe('Browser.disconnect', function() {
     await browserServer._checkLeaks();
     await browserServer.close();
   });
-  it('should throw if used after disconnect', async({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should throw if used after disconnect', async({browserType}) => {
+    const browserServer = await browserType.launchServer();
     const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     const page = await remote.newPage();
     await remote.close();
@@ -180,8 +180,8 @@ describe('Browser.disconnect', function() {
     await browserServer._checkLeaks();
     await browserServer.close();
   });
-  it('should emit close events on pages and contexts', async({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should emit close events on pages and contexts', async({browserType}) => {
+    const browserServer = await browserType.launchServer();
     const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     const context = await remote.newContext();
     const page = await context.newPage();
@@ -196,8 +196,8 @@ describe('Browser.disconnect', function() {
 });
 
 describe('Browser.close', function() {
-  it('should terminate network waiters', async({browserType, defaultBrowserOptions, server}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should terminate network waiters', async({browserType, server}) => {
+    const browserServer = await browserType.launchServer();
     const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     const newPage = await remote.newPage();
     const results = await Promise.all([
@@ -211,16 +211,16 @@ describe('Browser.close', function() {
       expect(message).not.toContain('Timeout');
     }
   });
-  it('should fire close event for all contexts', async({browserType, defaultBrowserOptions}) => {
-    const browser = await browserType.launch(defaultBrowserOptions);
+  it('should fire close event for all contexts', async({browserType}) => {
+    const browser = await browserType.launch();
     const context = await browser.newContext();
     let closed = false;
     context.on('close', () => closed = true);
     await browser.close();
     expect(closed).toBe(true);
   });
-  it('should be callable twice', async({browserType, defaultBrowserOptions}) => {
-    const browser = await browserType.launch(defaultBrowserOptions);
+  it('should be callable twice', async({browserType}) => {
+    const browser = await browserType.launch();
     await Promise.all([
       browser.close(),
       browser.close(),
@@ -230,8 +230,8 @@ describe('Browser.close', function() {
 });
 
 describe('browserType.launchServer', function() {
-  it('should work', async({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should work', async({browserType}) => {
+    const browserServer = await browserType.launchServer();
     const browser = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     const browserContext = await browser.newContext();
     expect(browserContext.pages().length).toBe(0);
@@ -243,8 +243,8 @@ describe('browserType.launchServer', function() {
     await browserServer._checkLeaks();
     await browserServer.close();
   });
-  it('should fire "disconnected" when closing the server', async({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should fire "disconnected" when closing the server', async({browserType}) => {
+    const browserServer = await browserType.launchServer();
     const browser = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     const disconnectedEventPromise = new Promise(resolve => browser.once('disconnected', resolve));
     const closedPromise = new Promise(f => browserServer.on('close', f));
@@ -254,9 +254,9 @@ describe('browserType.launchServer', function() {
       closedPromise,
     ]);
   });
-  it('should fire "close" event during kill', async({browserType, defaultBrowserOptions}) => {
+  it('should fire "close" event during kill', async({browserType}) => {
     const order = [];
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+    const browserServer = await browserType.launchServer();
     const closedPromise = new Promise(f => browserServer.on('close', () => {
       order.push('closed');
       f();
@@ -267,13 +267,13 @@ describe('browserType.launchServer', function() {
     ]);
     expect(order).toEqual(['closed', 'killed']);
   });
-  it('should return child_process instance', async ({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should return child_process instance', async ({browserType}) => {
+    const browserServer = await browserType.launchServer();
     expect(browserServer.process().pid).toBeGreaterThan(0);
     await browserServer.close();
   });
-  it('should fire close event', async ({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should fire close event', async ({browserType}) => {
+    const browserServer = await browserType.launchServer();
     await Promise.all([
       new Promise(f => browserServer.on('close', f)),
       browserServer.close(),
@@ -282,8 +282,8 @@ describe('browserType.launchServer', function() {
 });
 
 describe('browserType.connect', function() {
-  it.slow()('should be able to reconnect to a browser', async({browserType, defaultBrowserOptions, server}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it.slow()('should be able to reconnect to a browser', async({browserType, server}) => {
+    const browserServer = await browserType.launchServer();
     {
       const browser = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       const browserContext = await browser.newContext();
@@ -301,8 +301,8 @@ describe('browserType.connect', function() {
     await browserServer._checkLeaks();
     await browserServer.close();
   });
-  it.fail(USES_HOOKS || (CHROMIUM && WIN)).slow()('should handle exceptions during connect', async({browserType, defaultBrowserOptions, server}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it.fail(USES_HOOKS || (CHROMIUM && WIN)).slow()('should handle exceptions during connect', async({browserType, server}) => {
+    const browserServer = await browserType.launchServer();
     const __testHookBeforeCreateBrowser = () => { throw new Error('Dummy') };
     const error = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint(), __testHookBeforeCreateBrowser }).catch(e => e);
     await browserServer._checkLeaks();

--- a/test/logger.jest.js
+++ b/test/logger.jest.js
@@ -19,9 +19,9 @@ const path = require('path');
 const {FFOX, CHROMIUM, WEBKIT, CHANNEL} = testOptions;
 
 describe('Logger', function() {
-  it('should log', async({browserType, defaultBrowserOptions}) => {
+  it('should log', async({browserType}) => {
     const log = [];
-    const browser = await browserType.launch({...defaultBrowserOptions, logger: {
+    const browser = await browserType.launch({ logger: {
       log: (name, severity, message) => log.push({name, severity, message}),
       isEnabled: (name, severity) => severity !== 'verbose'
     }});
@@ -32,9 +32,9 @@ describe('Logger', function() {
     expect(log.filter(item => item.message.includes('browserType.launch started')).length > 0).toBeTruthy();
     expect(log.filter(item => item.message.includes('browserType.launch succeeded')).length > 0).toBeTruthy();
   });
-  it('should log context-level', async({browserType, defaultBrowserOptions}) => {
+  it('should log context-level', async({browserType}) => {
     const log = [];
-    const browser = await browserType.launch(defaultBrowserOptions);
+    const browser = await browserType.launch();
     const context = await browser.newContext({
       logger: {
         log: (name, severity, message) => log.push({name, severity, message}),

--- a/test/multiclient.jest.js
+++ b/test/multiclient.jest.js
@@ -18,8 +18,8 @@
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;
 
 describe('BrowserContext', function() {
-  it('should work across sessions', async ({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should work across sessions', async ({browserType}) => {
+    const browserServer = await browserType.launchServer();
     const browser1 = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     expect(browser1.contexts().length).toBe(0);
     await browser1.newContext();
@@ -41,8 +41,8 @@ describe('BrowserContext', function() {
 });
 
 describe('Browser.Events.disconnected', function() {
-  it.slow()('should be emitted when: browser gets closed, disconnected or underlying websocket gets closed', async ({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it.slow()('should be emitted when: browser gets closed, disconnected or underlying websocket gets closed', async ({browserType}) => {
+    const browserServer = await browserType.launchServer();
     const originalBrowser = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     const wsEndpoint = browserServer.wsEndpoint();
     const remoteBrowser1 = await browserType.connect({ wsEndpoint });
@@ -77,8 +77,8 @@ describe('Browser.Events.disconnected', function() {
 });
 
 describe('browserType.connect', function() {
-  it('should be able to connect multiple times to the same browser', async({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should be able to connect multiple times to the same browser', async({browserType}) => {
+    const browserServer = await browserType.launchServer();
     const browser1 = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     const browser2 = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
     const page1 = await browser1.newPage();
@@ -91,8 +91,8 @@ describe('browserType.connect', function() {
     await browserServer._checkLeaks();
     await browserServer.close();
   });
-  it('should not be able to close remote browser', async({browserType, defaultBrowserOptions}) => {
-    const browserServer = await browserType.launchServer(defaultBrowserOptions);
+  it('should not be able to close remote browser', async({browserType}) => {
+    const browserServer = await browserType.launchServer();
     {
       const remote = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() });
       await remote.newContext();

--- a/test/proxy.jest.js
+++ b/test/proxy.jest.js
@@ -19,12 +19,11 @@ const utils = require('./utils');
 const {FFOX, CHROMIUM, WEBKIT, MAC} = testOptions;
 
 describe('HTTP Proxy', () => {
-  it('should use proxy', async ({browserType, defaultBrowserOptions, server}) => {
+  it('should use proxy', async ({browserType, server}) => {
     server.setRoute('/target.html', async (req, res) => {
       res.end('<html><title>Served by the proxy</title></html>');
     });
     const browser = await browserType.launch({
-      ...defaultBrowserOptions,
       proxy: { server: `localhost:${server.PORT}` }
     });
     const page = await browser.newPage();
@@ -33,7 +32,7 @@ describe('HTTP Proxy', () => {
     await browser.close();
   });
 
-  it('should authenticate', async ({browserType, defaultBrowserOptions, server}) => {
+  it('should authenticate', async ({browserType, server}) => {
     server.setRoute('/target.html', async (req, res) => {
       const auth = req.headers['proxy-authorization'];
       if (!auth) {
@@ -41,11 +40,11 @@ describe('HTTP Proxy', () => {
           'Proxy-Authenticate': 'Basic realm="Access to internal site"'
         });
         res.end();  
+      } else {
+        res.end(`<html><title>${auth}</title></html>`);
       }
-      res.end(`<html><title>${auth}</title></html>`);
     });
     const browser = await browserType.launch({
-      ...defaultBrowserOptions,
       proxy: { server: `localhost:${server.PORT}`, username: 'user', password: 'secret' }
     });
     const page = await browser.newPage();
@@ -54,12 +53,11 @@ describe('HTTP Proxy', () => {
     await browser.close();
   });
 
-  it('should exclude patterns', async ({browserType, defaultBrowserOptions, server}) => {
+  it('should exclude patterns', async ({browserType, server}) => {
     server.setRoute('/target.html', async (req, res) => {
       res.end('<html><title>Served by the proxy</title></html>');
     });
     const browser = await browserType.launch({
-      ...defaultBrowserOptions,
       proxy: { server: `localhost:${server.PORT}`, bypass: 'non-existent1.com, .non-existent2.com, .zone' }
     });
 
@@ -87,7 +85,7 @@ describe('HTTP Proxy', () => {
 });
 
 describe('SOCKS Proxy', () => {
-  it('should use proxy', async ({ browserType, defaultBrowserOptions, parallelIndex }) => {
+  it('should use proxy', async ({ browserType, parallelIndex }) => {
     const server = socks.createServer((info, accept, deny) => {
       if (socket = accept(true)) {
         const body = '<html><title>Served by the SOCKS proxy</title></html>';
@@ -106,7 +104,6 @@ describe('SOCKS Proxy', () => {
     server.useAuth(socks.auth.None());
 
     const browser = await browserType.launch({
-      ...defaultBrowserOptions,
       proxy: { server: `socks5://localhost:${socksPort}` }
     });
     const page = await browser.newPage();


### PR DESCRIPTION
This patch wraps `browserType` with an object that tracks browsers and cleans them up on sigint. It also removes `defaultBrowserOptions`, as this is handled by the wrapper.

This shouild fix all zombies in our jest test runner, except for the fixtures test, which isn't a regression. I'll fix fixturesin a follow up. 