### PR TITLE
feat: introduce `mouse.currentState()` api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3397,6 +3397,7 @@ await page.mouse.up();
 
 <!-- GEN:toc -->
 - [mouse.click(x, y[, options])](#mouseclickx-y-options)
+- [mouse.currentState()](#mousecurrentstate)
 - [mouse.dblclick(x, y[, options])](#mousedblclickx-y-options)
 - [mouse.down([options])](#mousedownoptions)
 - [mouse.move(x, y[, options])](#mousemovex-y-options)
@@ -3413,6 +3414,13 @@ await page.mouse.up();
 - returns: <[Promise]>
 
 Shortcut for [`mouse.move`](#mousemovex-y-options), [`mouse.down`](#mousedownoptions) and [`mouse.up`](#mouseupoptions).
+
+#### mouse.currentState()
+- returns: <[Object]>
+  - `x` <[number]> Current mouse `x` position
+  - `y` <[number]> Current mouse `y` position
+
+Returns current mouse state.
 
 #### mouse.dblclick(x, y[, options])
 - `x` <[number]>

--- a/src/input.ts
+++ b/src/input.ts
@@ -165,6 +165,13 @@ export class Mouse {
     this._keyboard = keyboard;
   }
 
+  currentState(): {x: number, y: number} {
+    return {
+      x: this._x,
+      y: this._y,
+    };
+  }
+
   async move(x: number, y: number, options: { steps?: number } = {}) {
     const { steps = 1 } = options;
     const fromX = this._x;

--- a/test/mouse.jest.js
+++ b/test/mouse.jest.js
@@ -154,3 +154,18 @@ describe('Mouse', function() {
     })
   });
 });
+
+describe('Mouse.currentState', () => {
+  it('should work', async({server, page}) => {
+    await page.mouse.click(30, 40);
+    expect(page.mouse.currentState()).toEqual({
+      x: 30,
+      y: 40,
+    });
+    await page.mouse.move(33, 43);
+    expect(page.mouse.currentState()).toEqual({
+      x: 33,
+      y: 43,
+    });
+  });
+});


### PR DESCRIPTION
This adds a new `mouse.currentState()` method that will return
current mouse state. For now, this has only the `x` and `y`
coordinates.

Fixes #3032