### PR TITLE
feat: introduce `chromiumSandbox` launch option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3983,6 +3983,7 @@ This methods attaches Playwright to an existing browser instance.
     - `username` <[string]> Optional username to use if HTTP proxy requires authentication.
     - `password` <[string]> Optional password to use if HTTP proxy requires authentication.
   - `downloadsPath` <[string]> If specified, accepted downloads are downloaded into this folder. Otherwise, temporary folder is created and is deleted when browser is closed.
+  - `chromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `true`.
   - `firefoxUserPrefs` <[Object]> Firefox user preferences. Learn more about the Firefox user preferences at [`about:config`](https://support.mozilla.org/en-US/kb/about-config-editor-firefox).
   - `handleSIGINT` <[boolean]> Close the browser process on Ctrl-C. Defaults to `true`.
   - `handleSIGTERM` <[boolean]> Close the browser process on SIGTERM. Defaults to `true`.
@@ -4024,6 +4025,7 @@ const browser = await chromium.launch({  // Or 'firefox' or 'webkit'.
     - `password` <[string]> Optional password to use if HTTP proxy requires authentication.
   - `acceptDownloads` <[boolean]> Whether to automatically download all the attachments. Defaults to `false` where all the downloads are canceled.
   - `downloadsPath` <[string]> If specified, accepted downloads are downloaded into this folder. Otherwise, temporary folder is created and is deleted when browser is closed.
+  - `chromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `true`.
   - `handleSIGINT` <[boolean]> Close the browser process on Ctrl-C. Defaults to `true`.
   - `handleSIGTERM` <[boolean]> Close the browser process on SIGTERM. Defaults to `true`.
   - `handleSIGHUP` <[boolean]> Close the browser process on SIGHUP. Defaults to `true`.
@@ -4072,6 +4074,7 @@ Launches browser that uses persistent storage located at `userDataDir` and retur
     - `username` <[string]> Optional username to use if HTTP proxy requires authentication.
     - `password` <[string]> Optional password to use if HTTP proxy requires authentication.
   - `downloadsPath` <[string]> If specified, accepted downloads are downloaded into this folder. Otherwise, temporary folder is created and is deleted when browser is closed.
+  - `chromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `true`.
   - `firefoxUserPrefs` <[Object]> Firefox user preferences. Learn more about the Firefox user preferences at [`about:config`](https://support.mozilla.org/en-US/kb/about-config-editor-firefox).
   - `handleSIGINT` <[boolean]> Close the browser process on Ctrl-C. Defaults to `true`.
   - `handleSIGTERM` <[boolean]> Close the browser process on SIGTERM. Defaults to `true`.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -178,11 +178,11 @@ Bitbucket Pipelines can use public [Docker images as build environments](https:/
 image: mcr.microsoft.com/playwright:bionic
 ```
 
-While the Docker image supports sandboxing for Chromium, it does not work in the Bitbucket Pipelines environment. To launch Chromium on Bitbucket Pipelines, use the `--no-sandbox` launch argument.
+While the Docker image supports sandboxing for Chromium, it does not work in the Bitbucket Pipelines environment. To launch Chromium on Bitbucket Pipelines, use the `chromiumSandbox: false` launch argument.
 
 ```js
 const { chromium } = require('playwright');
-const browser = await chromium.launch({ args: ['--no-sandbox'] });
+const browser = await chromium.launch({ chromiumSandbox: false });
 ```
 
 ### GitLab CI

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -140,10 +140,10 @@ the host should be configured first. If there's no good sandbox for Chrome to us
 with the error `No usable sandbox!`.
 
 If you **absolutely trust** the content you open in Chrome, you can launch Chrome
-with the `--no-sandbox` argument:
+with the `chromiumSandbox: false` option:
 
 ```js
-const browser = await playwright.chromium.launch({args: ['--no-sandbox', '--disable-setuid-sandbox']});
+const browser = await playwright.chromium.launch({ chromiumSandbox: false });
 ```
 
 > **NOTE**: Running without a sandbox is **strongly discouraged**. Consider configuring a sandbox instead.

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -115,6 +115,8 @@ export class Chromium extends BrowserTypeBase {
           '--mute-audio'
       );
     }
+    if (options.chromiumSandbox === false)
+      chromeArguments.push('--no-sandbox');
     if (proxy) {
       const proxyURL = new URL(proxy.server);
       const isSocks = proxyURL.protocol === 'socks5:';

--- a/src/types.ts
+++ b/src/types.ts
@@ -295,6 +295,7 @@ export type LaunchOptionsBase = {
   devtools?: boolean,
   proxy?: ProxySettings,
   downloadsPath?: string,
+  chromiumSandbox?: boolean,
 };
 
 export type LaunchOptions = LaunchOptionsBase & { slowMo?: number };

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -194,10 +194,7 @@ playwright.chromium.launch().then(async browser => {
 // Example with launch options
 (async () => {
   const browser = await playwright.chromium.launch({
-    args: [
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
-    ],
+    chromiumSandbox: false,
     handleSIGINT: true,
     handleSIGHUP: true,
     handleSIGTERM: true,


### PR DESCRIPTION
The option is intended to be used instead of the `--no-sandbox`
argument that is accepted exclusively by Chromium and crashes
WebKit.

References #2745