### PR TITLE
feat(rpc): use SerializedValue for CDPSession

### DIFF
--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -1571,21 +1571,15 @@ export interface CDPSessionChannel extends Channel {
 }
 export type CDPSessionEventEvent = {
   method: string,
-  params?: {
-
-  },
+  params?: SerializedValue,
 };
 export type CDPSessionDisconnectedEvent = {};
 export type CDPSessionSendParams = {
   method: string,
-  params?: {
-
-  },
+  params?: SerializedValue,
 };
 export type CDPSessionSendResult = {
-  result: {
-
-  },
+  result: SerializedValue,
 };
 export type CDPSessionDetachParams = {};
 export type CDPSessionDetachResult = void;

--- a/src/rpc/protocol.pdl
+++ b/src/rpc/protocol.pdl
@@ -1407,16 +1407,16 @@ interface CDPSession
   event event
     parameters
       method: string
-      params?: object
+      params?: SerializedValue
 
   event disconnected
 
   command send
     parameters
       method: string
-      params?: object
+      params?: SerializedValue
     returns
-      result: object
+      result: SerializedValue
 
   command detach
 


### PR DESCRIPTION
This is our way to define a schema for arbitrary values.