### PR TITLE
fix(frame): check if the frame was removed before committing navigation

### DIFF
--- a/src/frames.ts
+++ b/src/frames.ts
@@ -168,7 +168,9 @@ export class FrameManager {
   }
 
   frameCommittedNewDocumentNavigation(frameId: string, url: string, name: string, documentId: string, initial: boolean) {
-    const frame = this._frames.get(frameId)!;
+    const frame = this._frames.get(frameId);
+    if (!frame)
+      return;
     this.removeChildFramesRecursively(frame);
     frame._url = url;
     frame._name = name;


### PR DESCRIPTION
We got a report form a user with this stack trace:

```
TypeError: Cannot read property 'childFrames' of undefined
 
      at FrameManager.removeChildFramesRecursively (node_modules/playwright/lib/frames.js:214:35)
      at FrameManager.frameCommittedNewDocumentNavigation (node_modules/playwright/lib/frames.js:115:14)
      at FrameSession._onFrameNavigated (node_modules/playwright/lib/chromium/crPage.js:417:34)
      at CRSession._eventListeners.helper_1.helper.addEventListener.event (node_modules/playwright/lib/chromium/crPage.js:273:97)
      at Promise.resolve.then (node_modules/playwright/lib/chromium/crConnection.js:151:47)
```

I wasn't able to reproduce this locally, but looking at their website it has a lot of iframes constantly being added and removed. Sometimes in process, sometimes out of process. Sometimes nested frames. I suspect that somehow we get a `Page.frameNavigated` message for a frame that has already detached.

Whatever the race is, it seems highly likely that the fix will be to just return if the frame was already detached. There is suspicious code that already do this for `frameCommittedSameDocumentNavigation`.