### PR TITLE
Revert "test: screenshot on failure (#3053)"

### DIFF
--- a/test/jest/fixtures.js
+++ b/test/jest/fixtures.js
@@ -26,8 +26,6 @@ const { PlaywrightDispatcher } = require('../../lib/rpc/server/playwrightDispatc
 const { setUseApiName } = require('../../lib/progress');
 
 const browserName = process.env.BROWSER || 'chromium';
-const activeBrowsers = new Set();
-global.__activeBrowsers__ = activeBrowsers;
 
 module.exports = function registerFixtures(global) {
   global.registerWorkerFixture('parallelIndex', async ({}, test) => {
@@ -139,7 +137,6 @@ module.exports = function registerFixtures(global) {
 
   global.registerWorkerFixture('browser', async ({browserType, defaultBrowserOptions}, test) => {
     const browser = await browserType.launch(defaultBrowserOptions);
-    activeBrowsers.add(browser);
     try {
       await test(browser);
       if (browser.contexts().length !== 0) {
@@ -147,7 +144,6 @@ module.exports = function registerFixtures(global) {
         await Promise.all(browser.contexts().map(context => context.close()));
       }
     } finally {
-      activeBrowsers.delete(browser);
       await browser.close();
     }
   });


### PR DESCRIPTION
It should be opt-in and configurable. The folder we collect information
into should be consistent with the rest of the artifacts we collect.
Lets revisit it later.