### PR TITLE
feat(postData): roll firefox to r1137, support binary post data

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1134"
+      "revision": "1137"
     },
     {
       "name": "webkit",

--- a/docs/api.md
+++ b/docs/api.md
@@ -3486,6 +3486,7 @@ If request gets a 'redirect' response, the request is successfully finished with
 - [request.isNavigationRequest()](#requestisnavigationrequest)
 - [request.method()](#requestmethod)
 - [request.postData()](#requestpostdata)
+- [request.postDataBuffer()](#requestpostdatabuffer)
 - [request.postDataJSON()](#requestpostdatajson)
 - [request.redirectedFrom()](#requestredirectedfrom)
 - [request.redirectedTo()](#requestredirectedto)
@@ -3525,6 +3526,9 @@ Whether this request is driving frame's navigation.
 
 #### request.postData()
 - returns: <?[string]> Request's post body, if any.
+
+#### request.postDataBuffer()
+- returns: <?[Buffer]> Request's post body in a binary form, if any.
 
 #### request.postDataJSON()
 - returns: <?[Object]> Parsed request's body for `form-urlencoded` and JSON as a fallback if any.

--- a/src/chromium/crNetworkManager.ts
+++ b/src/chromium/crNetworkManager.ts
@@ -342,10 +342,14 @@ class InterceptableRequest implements network.RouteDelegate {
       headers,
       method,
       url,
-      postData = null,
+      postDataEntries = null,
     } = requestPausedEvent ? requestPausedEvent.request : requestWillBeSentEvent.request;
     const type = (requestWillBeSentEvent.type || '').toLowerCase();
-    this.request = new network.Request(allowInterception ? this : null, frame, redirectedFrom, documentId, url, type, method, postData, headersObject(headers));
+    let postDataBuffer = null;
+    if (postDataEntries && postDataEntries.length && postDataEntries[0].bytes)
+      postDataBuffer = Buffer.from(postDataEntries[0].bytes, 'base64');
+
+    this.request = new network.Request(allowInterception ? this : null, frame, redirectedFrom, documentId, url, type, method, postDataBuffer, headersObject(headers));
   }
 
   async continue(overrides: types.NormalizedContinueOverrides) {

--- a/src/firefox/ffNetworkManager.ts
+++ b/src/firefox/ffNetworkManager.ts
@@ -153,9 +153,11 @@ class InterceptableRequest implements network.RouteDelegate {
     const headers: types.Headers = {};
     for (const {name, value} of payload.headers)
       headers[name.toLowerCase()] = value;
-
+    let postDataBuffer = null;
+    if (payload.postData)
+      postDataBuffer = Buffer.from(payload.postData, 'base64');
     this.request = new network.Request(payload.isIntercepted ? this : null, frame, redirectedFrom ? redirectedFrom.request : null, payload.navigationId,
-        payload.url, internalCauseToResourceType[payload.internalCause] || causeToResourceType[payload.cause] || 'other', payload.method, payload.postData || null, headers);
+        payload.url, internalCauseToResourceType[payload.internalCause] || causeToResourceType[payload.cause] || 'other', payload.method, postDataBuffer, headers);
   }
 
   async continue(overrides: types.NormalizedContinueOverrides) {

--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -1400,7 +1400,7 @@ export type RequestInitializer = {
   url: string,
   resourceType: string,
   method: string,
-  postData?: string,
+  postData?: Binary,
   headers: {
     name: string,
     value: string,

--- a/src/rpc/protocol.pdl
+++ b/src/rpc/protocol.pdl
@@ -1291,7 +1291,7 @@ interface Request
     url: string
     resourceType: string
     method: string
-    postData?: string
+    postData?: binary
     headers: object[]
       name: string
       value: string

--- a/src/rpc/server/networkDispatchers.ts
+++ b/src/rpc/server/networkDispatchers.ts
@@ -33,13 +33,13 @@ export class RequestDispatcher extends Dispatcher<Request, RequestInitializer> i
   }
 
   private constructor(scope: DispatcherScope, request: Request) {
-    const postData = request.postData();
+    const postData = request.postDataBuffer();
     super(scope, request, 'Request', {
       frame: FrameDispatcher.from(scope, request.frame()),
       url: request.url(),
       resourceType: request.resourceType(),
       method: request.method(),
-      postData: postData === null ? undefined : postData,
+      postData: postData === null ? undefined : postData.toString('base64'),
       headers: headersObjectToArray(request.headers()),
       isNavigationRequest: request.isNavigationRequest(),
       redirectedFrom: RequestDispatcher.fromNullable(scope, request.redirectedFrom()),

--- a/src/webkit/wkInterceptableRequest.ts
+++ b/src/webkit/wkInterceptableRequest.ts
@@ -53,8 +53,11 @@ export class WKInterceptableRequest implements network.RouteDelegate {
     this._requestId = event.requestId;
     this._allowInterception = allowInterception;
     const resourceType = event.type ? event.type.toLowerCase() : (redirectedFrom ? redirectedFrom.resourceType() : 'other');
+    let postDataBuffer = null;
+    if (event.request.postData)
+      postDataBuffer = Buffer.from(event.request.postData, 'binary');
     this.request = new network.Request(allowInterception ? this : null, frame, redirectedFrom, documentId, event.request.url,
-        resourceType, event.request.method, event.request.postData || null, headersObject(event.request.headers));
+        resourceType, event.request.method, postDataBuffer, headersObject(event.request.headers));
     this._interceptedPromise = new Promise(f => this._interceptedCallback = f);
   }
 


### PR DESCRIPTION
This has a partial fix for https://github.com/microsoft/playwright/issues/2588