### PR TITLE
devops: prepare buildbots to the introduction of Ubuntu 20.04 builder

### DIFF
--- a/browser_patches/buildbots/buildbot-ubuntu-18.04.sh
+++ b/browser_patches/buildbots/buildbot-ubuntu-18.04.sh
@@ -7,6 +7,14 @@ if [[ $(uname) != "Linux" ]]; then
   exit 1
 fi
 
+CURRENT_HOST_OS="$(bash -c 'source /etc/os-release && echo $NAME')"
+CURRENT_HOST_OS_VERSION="$(bash -c 'source /etc/os-release && echo $VERSION_ID')"
+
+if [[ "$CURRENT_HOST_OS" != "Ubuntu" || "$CURRENT_HOST_OS_VERSION" != "18.04" ]]; then
+  echo "ERROR: this script is designed to be run on Ubuntu 18.04. Can't run on $CURRENT_HOST_OS $CURRENT_HOST_OS_VERSION"
+  exit 1
+fi
+
 if [[ ($1 == '--help') || ($1 == '-h') ]]; then
   echo "usage: $(basename $0)"
   echo
@@ -55,9 +63,9 @@ if [[ -n $(git status -s) ]]; then
 fi
 
 git pull origin master
-../checkout_build_archive_upload.sh firefox-linux >/tmp/$(basename $0)--firefox-linux.log || true
+../checkout_build_archive_upload.sh firefox-ubuntu-18.04 >/tmp/$(basename $0)--firefox.log || true
 
 git pull origin master
-../checkout_build_archive_upload.sh webkit-gtk >/tmp/$(basename $0)--webkit-gtk.log || true
-../checkout_build_archive_upload.sh webkit-wpe >/tmp/$(basename $0)--webkit-wpe.log || true
-../checkout_build_archive_upload.sh webkit-gtk-wpe >/tmp/$(basename $0)--webkit-gtk-wpe.log || true
+../checkout_build_archive_upload.sh webkit-gtk-ubuntu-18.04 >/tmp/$(basename $0)--webkit-gtk.log || true
+../checkout_build_archive_upload.sh webkit-wpe-ubuntu-18.04 >/tmp/$(basename $0)--webkit-wpe.log || true
+../checkout_build_archive_upload.sh webkit-gtk-wpe-ubuntu-18.04 >/tmp/$(basename $0)--webkit-gtk-wpe.log || true

--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -25,6 +25,9 @@ CURRENT_HOST_OS="$(uname)"
 CURRENT_HOST_OS_VERSION=""
 if [[ "$CURRENT_HOST_OS" == "Darwin" ]]; then
   CURRENT_HOST_OS_VERSION=$(sw_vers -productVersion | grep -o '^\d\+.\d\+')
+elif [[ "$CURRENT_HOST_OS" == "Linux" ]]; then
+  CURRENT_HOST_OS="$(bash -c 'source /etc/os-release && echo $NAME')"
+  CURRENT_HOST_OS_VERSION="$(bash -c 'source /etc/os-release && echo $VERSION_ID')"
 fi
 
 BROWSER_NAME=""
@@ -34,10 +37,11 @@ BUILD_FLAVOR="$1"
 BUILD_BLOB_NAME=""
 EXPECTED_HOST_OS=""
 EXPECTED_HOST_OS_VERSION=""
-if [[ "$BUILD_FLAVOR" == "firefox-linux" ]]; then
+if [[ "$BUILD_FLAVOR" == "firefox-ubuntu-18.04" ]]; then
   BROWSER_NAME="firefox"
-  EXPECTED_HOST_OS="Linux"
-  BUILD_BLOB_NAME="firefox-linux.zip"
+  EXPECTED_HOST_OS="Ubuntu"
+  EXPECTED_HOST_OS_VERSION="18.04"
+  BUILD_BLOB_NAME="firefox-ubuntu-18.04.zip"
 elif [[ "$BUILD_FLAVOR" == "firefox-mac" ]]; then
   BROWSER_NAME="firefox"
   EXPECTED_HOST_OS="Darwin"
@@ -52,22 +56,25 @@ elif [[ "$BUILD_FLAVOR" == "firefox-win64" ]]; then
   EXTRA_BUILD_ARGS="--win64"
   EXPECTED_HOST_OS="MINGW"
   BUILD_BLOB_NAME="firefox-win64.zip"
-elif [[ "$BUILD_FLAVOR" == "webkit-gtk" ]]; then
+elif [[ "$BUILD_FLAVOR" == "webkit-gtk-ubuntu-18.04" ]]; then
   BROWSER_NAME="webkit"
   EXTRA_BUILD_ARGS="--gtk"
   EXTRA_ARCHIVE_ARGS="--gtk"
-  EXPECTED_HOST_OS="Linux"
-  BUILD_BLOB_NAME="minibrowser-gtk.zip"
-elif [[ "$BUILD_FLAVOR" == "webkit-wpe" ]]; then
+  EXPECTED_HOST_OS="Ubuntu"
+  EXPECTED_HOST_OS_VERSION="18.04"
+  BUILD_BLOB_NAME="minibrowser-gtk-ubuntu-18.04.zip"
+elif [[ "$BUILD_FLAVOR" == "webkit-wpe-ubuntu-18.04" ]]; then
   BROWSER_NAME="webkit"
   EXTRA_BUILD_ARGS="--wpe"
   EXTRA_ARCHIVE_ARGS="--wpe"
-  EXPECTED_HOST_OS="Linux"
-  BUILD_BLOB_NAME="minibrowser-wpe.zip"
-elif [[ "$BUILD_FLAVOR" == "webkit-gtk-wpe" ]]; then
+  EXPECTED_HOST_OS="Ubuntu"
+  EXPECTED_HOST_OS_VERSION="18.04"
+  BUILD_BLOB_NAME="minibrowser-wpe-ubuntu-18.04.zip"
+elif [[ "$BUILD_FLAVOR" == "webkit-gtk-wpe-ubuntu-18.04" ]]; then
   BROWSER_NAME="webkit"
-  EXPECTED_HOST_OS="Linux"
-  BUILD_BLOB_NAME="minibrowser-gtk-wpe.zip"
+  EXPECTED_HOST_OS="Ubuntu"
+  EXPECTED_HOST_OS_VERSION="18.04"
+  BUILD_BLOB_NAME="minibrowser-gtk-wpe-ubuntu-18.04.zip"
 elif [[ "$BUILD_FLAVOR" == "webkit-win64" ]]; then
   BROWSER_NAME="webkit"
   EXPECTED_HOST_OS="MINGW"
@@ -136,7 +143,7 @@ fi
 
 function generate_and_upload_browser_build {
   # webkit-gtk-wpe is a special build doesn't need to be built.
-  if [[ "$BUILD_FLAVOR" == "webkit-gtk-wpe" ]]; then
+  if [[ "$BUILD_FLAVOR" == webkit-gtk-wpe-* ]]; then
     echo "-- combining binaries together"
     if ! ./webkit/download_gtk_and_wpe_and_zip_together.sh $ZIP_PATH; then
       return 10

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1138
-Changed: yurys@chromium.org Wed Jul 22 18:07:07 PDT 2020
+1139
+Changed: lushnikov@chromium.org Thu Jul 23 09:56:07 PDT 2020

--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1314
-Changed: yurys@chromium.org Thu Jul 23 09:31:18 PDT 2020
+1315
+Changed: lushnikov@chromium.org Thu Jul 23 09:56:07 PDT 2020

--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -55,7 +55,7 @@ const ENV_DOWNLOAD_HOSTS: { [key: string]: string } = {
   webkit: 'PLAYWRIGHT_WEBKIT_DOWNLOAD_HOST',
 };
 
-function getDownloadUrl(browserName: BrowserName, platform: BrowserPlatform): string | undefined {
+function getDownloadUrl(browserName: BrowserName, revision: number, platform: BrowserPlatform): string | undefined {
   if (browserName === 'chromium') {
     return new Map<BrowserPlatform, string>([
       ['linux', '%s/chromium-browser-snapshots/Linux_x64/%d/chrome-linux.zip'],
@@ -68,31 +68,51 @@ function getDownloadUrl(browserName: BrowserName, platform: BrowserPlatform): st
   }
 
   if (browserName === 'firefox') {
-    return new Map<BrowserPlatform, string>([
-      ['linux', '%s/builds/firefox/%s/firefox-linux.zip'],
-      ['mac10.13', '%s/builds/firefox/%s/firefox-mac.zip'],
-      ['mac10.14', '%s/builds/firefox/%s/firefox-mac.zip'],
-      ['mac10.15', '%s/builds/firefox/%s/firefox-mac.zip'],
-      ['win32', '%s/builds/firefox/%s/firefox-win32.zip'],
-      ['win64', '%s/builds/firefox/%s/firefox-win64.zip'],
-    ]).get(platform);
+    const FIREFOX_RENAME_LINUX_TO_UBUNTU_REVISION = 1139;
+    return revision < FIREFOX_RENAME_LINUX_TO_UBUNTU_REVISION ?
+      new Map<BrowserPlatform, string>([
+        ['linux', '%s/builds/firefox/%s/firefox-linux.zip'],
+        ['mac10.13', '%s/builds/firefox/%s/firefox-mac.zip'],
+        ['mac10.14', '%s/builds/firefox/%s/firefox-mac.zip'],
+        ['mac10.15', '%s/builds/firefox/%s/firefox-mac.zip'],
+        ['win32', '%s/builds/firefox/%s/firefox-win32.zip'],
+        ['win64', '%s/builds/firefox/%s/firefox-win64.zip'],
+      ]).get(platform) :
+      new Map<BrowserPlatform, string>([
+        ['linux', '%s/builds/firefox/%s/firefox-ubuntu-18.04.zip'],
+        ['mac10.13', '%s/builds/firefox/%s/firefox-mac.zip'],
+        ['mac10.14', '%s/builds/firefox/%s/firefox-mac.zip'],
+        ['mac10.15', '%s/builds/firefox/%s/firefox-mac.zip'],
+        ['win32', '%s/builds/firefox/%s/firefox-win32.zip'],
+        ['win64', '%s/builds/firefox/%s/firefox-win64.zip'],
+      ]).get(platform);
   }
 
   if (browserName === 'webkit') {
-    return new Map<BrowserPlatform, string | undefined>([
-      ['linux', '%s/builds/webkit/%s/minibrowser-gtk-wpe.zip'],
-      ['mac10.13', undefined],
-      ['mac10.14', '%s/builds/webkit/%s/minibrowser-mac-10.14.zip'],
-      ['mac10.15', '%s/builds/webkit/%s/minibrowser-mac-10.15.zip'],
-      ['win32', '%s/builds/webkit/%s/minibrowser-win64.zip'],
-      ['win64', '%s/builds/webkit/%s/minibrowser-win64.zip'],
-    ]).get(platform);
+    const WEBKIT_RENAME_LINUX_TO_UBUNTU_REVISION = 1315;
+    return revision < WEBKIT_RENAME_LINUX_TO_UBUNTU_REVISION ?
+      new Map<BrowserPlatform, string | undefined>([
+        ['linux', '%s/builds/webkit/%s/minibrowser-gtk-wpe.zip'],
+        ['mac10.13', undefined],
+        ['mac10.14', '%s/builds/webkit/%s/minibrowser-mac-10.14.zip'],
+        ['mac10.15', '%s/builds/webkit/%s/minibrowser-mac-10.15.zip'],
+        ['win32', '%s/builds/webkit/%s/minibrowser-win64.zip'],
+        ['win64', '%s/builds/webkit/%s/minibrowser-win64.zip'],
+      ]).get(platform) :
+      new Map<BrowserPlatform, string | undefined>([
+        ['linux', '%s/builds/webkit/%s/minibrowser-gtk-wpe-ubuntu-18.04.zip'],
+        ['mac10.13', undefined],
+        ['mac10.14', '%s/builds/webkit/%s/minibrowser-mac-10.14.zip'],
+        ['mac10.15', '%s/builds/webkit/%s/minibrowser-mac-10.15.zip'],
+        ['win32', '%s/builds/webkit/%s/minibrowser-win64.zip'],
+        ['win64', '%s/builds/webkit/%s/minibrowser-win64.zip'],
+      ]).get(platform);
   }
 }
 
 function revisionURL(browser: BrowserDescriptor, platform = browserPaths.hostPlatform): string {
   const serverHost = getFromENV(ENV_DOWNLOAD_HOSTS[browser.name]) || getFromENV(ENV_DOWNLOAD_HOSTS.default) || DEFAULT_DOWNLOAD_HOSTS[browser.name];
-  const urlTemplate = getDownloadUrl(browser.name, platform);
+  const urlTemplate = getDownloadUrl(browser.name, parseInt(browser.revision, 10), platform);
   assert(urlTemplate, `ERROR: Playwright does not support ${browser.name} on ${platform}`);
   return util.format(urlTemplate, serverHost, browser.revision);
 }


### PR DESCRIPTION
This patch:
- specializes "linux" scripts into "Ubuntu 18.04" scripts
- renames all future linux blobs on CDN:
    * `firefox-linux.zip => firefox-ubuntu-18.04.zip`
    * `minibrowser-gtk.zip => minibrowser-gtk-ubuntu-18.04.zip`
    * `minibrowser-wpe.zip => minibrowser-wpe-ubuntu-18.04.zip`
    * `minibrowser-gtk-wpe.zip => minibrowser-gtk-wpe-ubuntu-18.04.zip`
- updates downloader to deal with the new names

References #2745