### PR TITLE
chore: support esm imports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       if: ${{ always() }}
       with:
         name: ${{ matrix.browser }}-linux-jest-report
-        path: jest-report.json  
+        path: jest-report.json
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
@@ -82,7 +82,7 @@ jobs:
       if: ${{ always() }}
       with:
         name: ${{ matrix.browser }}-mac-jest-report
-        path: jest-report.json  
+        path: jest-report.json
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
@@ -134,6 +134,7 @@ jobs:
   test-package-installations:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node_version:
         - "^10.17.0" # pre 10.17, --unhandled-rejections=strict was not an option (https://github.com/nodejs/node/pull/26599) which we need in our tests

--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,7 @@ lib/injected/
 !index.d.ts
 
 !index.js
+!index.mjs
 !install.js
 !README.md
 !LICENSE

--- a/packages/build_package.js
+++ b/packages/build_package.js
@@ -83,7 +83,7 @@ if (args.some(arg => arg === '--help')) {
 
 // 2. Setup cleanup if needed
 if (!args.some(arg => arg === '--no-cleanup')) {
-  process.on('exit', () => { 
+  process.on('exit', () => {
     cleanupPaths.forEach(cleanupPath => rmSync(cleanupPath, {}));
   });
   process.on('SIGINT', () => process.exit(2));
@@ -123,6 +123,10 @@ if (!package) {
     engines: pwInternalJSON.engines,
     homepage: pwInternalJSON.homepage,
     main: 'index.js',
+    exports: {
+      import: './index.mjs',
+      require: './index.js',
+    },
     scripts: {
       install: 'node install.js',
     },

--- a/packages/installation-tests/esm-playwright-chromium.mjs
+++ b/packages/installation-tests/esm-playwright-chromium.mjs
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-const requireName = process.argv[2];
-const browsers = process.argv.slice(3);
+import { chromium, selectors, devices, errors } from 'playwright-chromium';
+import playwright from 'playwright-chromium';
 
-const playwright = require(requireName);
+if (playwright.chromium !== chromium)
+  process.exit(1);
 
 (async () => {
-  for (const browserType of browsers) {
-    const browser = await playwright[browserType].launch();
+  for (const browserType of [chromium]) {
+    const browser = await browserType.launch();
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.evaluate(() => navigator.userAgent);
     await browser.close();
   }
-  console.log(`require SUCCESS`);
+  console.log(`esm SUCCESS`);
 })().catch(err => {
   console.error(err);
   process.exit(1);

--- a/packages/installation-tests/esm-playwright-firefox.mjs
+++ b/packages/installation-tests/esm-playwright-firefox.mjs
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-const requireName = process.argv[2];
-const browsers = process.argv.slice(3);
+import { firefox, selectors, devices, errors } from 'playwright-firefox';
+import playwright from 'playwright-firefox';
 
-const playwright = require(requireName);
+if (playwright.firefox !== firefox)
+  process.exit(1);
 
 (async () => {
-  for (const browserType of browsers) {
-    const browser = await playwright[browserType].launch();
+  for (const browserType of [firefox]) {
+    const browser = await browserType.launch();
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.evaluate(() => navigator.userAgent);
     await browser.close();
   }
-  console.log(`require SUCCESS`);
+  console.log(`esm SUCCESS`);
 })().catch(err => {
   console.error(err);
   process.exit(1);

--- a/packages/installation-tests/esm-playwright-webkit.mjs
+++ b/packages/installation-tests/esm-playwright-webkit.mjs
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-const requireName = process.argv[2];
-const browsers = process.argv.slice(3);
+import { webkit, selectors, devices, errors } from 'playwright-webkit';
+import playwright from 'playwright-webkit';
 
-const playwright = require(requireName);
+if (playwright.webkit !== webkit)
+  process.exit(1);
 
 (async () => {
-  for (const browserType of browsers) {
-    const browser = await playwright[browserType].launch();
+  for (const browserType of [webkit]) {
+    const browser = await browserType.launch();
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.evaluate(() => navigator.userAgent);
     await browser.close();
   }
-  console.log(`require SUCCESS`);
+  console.log(`esm SUCCESS`);
 })().catch(err => {
   console.error(err);
   process.exit(1);

--- a/packages/installation-tests/esm-playwright.mjs
+++ b/packages/installation-tests/esm-playwright.mjs
@@ -14,20 +14,25 @@
  * limitations under the License.
  */
 
-const requireName = process.argv[2];
-const browsers = process.argv.slice(3);
+import { chromium, firefox, webkit, selectors, devices, errors } from 'playwright';
+import playwright from 'playwright';
 
-const playwright = require(requireName);
+if (playwright.chromium !== chromium)
+  process.exit(1);
+if (playwright.firefox !== firefox)
+  process.exit(1);
+if (playwright.webkit !== webkit)
+  process.exit(1);
 
 (async () => {
-  for (const browserType of browsers) {
-    const browser = await playwright[browserType].launch();
+  for (const browserType of [chromium, firefox, webkit]) {
+    const browser = await browserType.launch();
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.evaluate(() => navigator.userAgent);
     await browser.close();
   }
-  console.log(`require SUCCESS`);
+  console.log(`esm SUCCESS`);
 })().catch(err => {
   console.error(err);
   process.exit(1);

--- a/packages/installation-tests/installation-tests.sh
+++ b/packages/installation-tests/installation-tests.sh
@@ -22,8 +22,17 @@ PLAYWRIGHT_CHROMIUM_TGZ="$(node ${PACKAGE_BUILDER} playwright-chromium ./playwri
 PLAYWRIGHT_WEBKIT_TGZ="$(node ${PACKAGE_BUILDER} playwright-webkit ./playwright-webkit.tgz)"
 PLAYWRIGHT_FIREFOX_TGZ="$(node ${PACKAGE_BUILDER} playwright-firefox ./playwright-firefox.tgz)"
 
-SANITY_JS="$(pwd -P)/../sanity.js"
+SCRIPTS_PATH="$(pwd -P)/.."
 TEST_ROOT="$(pwd -P)"
+NODE_VERSION="$(node --version)"
+
+function copy_test_scripts {
+  cp "${SCRIPTS_PATH}/sanity.js" .
+  cp "${SCRIPTS_PATH}/esm-playwright.mjs" .
+  cp "${SCRIPTS_PATH}/esm-playwright-chromium.mjs" .
+  cp "${SCRIPTS_PATH}/esm-playwright-firefox.mjs" .
+  cp "${SCRIPTS_PATH}/esm-playwright-webkit.mjs" .
+}
 
 function run_tests {
   test_typescript_types
@@ -67,7 +76,7 @@ function test_playwright_global_installation {
     echo "Directory for shared browsers was not created!"
     exit 1
   fi
-  cp ${SANITY_JS} .
+  copy_test_scripts
   if node sanity.js playwright chromium 2>/dev/null; then
     echo "Should not be able to launch chromium without PLAYWRIGHT_BROWSERS_PATH variable!"
     exit 1
@@ -111,28 +120,44 @@ function test_playwright_should_work {
   initialize_test "${FUNCNAME[0]}"
 
   npm install ${PLAYWRIGHT_TGZ}
-  cp ${SANITY_JS} . && node sanity.js playwright chromium firefox webkit
+  copy_test_scripts
+  node sanity.js playwright chromium firefox webkit
+  if [[ "${NODE_VERSION}" == *"v14."* ]]; then
+    node esm-playwright.mjs
+  fi
 }
 
 function test_playwright_chromium_should_work {
   initialize_test "${FUNCNAME[0]}"
 
   npm install ${PLAYWRIGHT_CHROMIUM_TGZ}
-  cp ${SANITY_JS} . && node sanity.js playwright-chromium chromium
+  copy_test_scripts
+  node sanity.js playwright-chromium chromium
+  if [[ "${NODE_VERSION}" == *"v14."* ]]; then
+    node esm-playwright-chromium.mjs
+  fi
 }
 
 function test_playwright_webkit_should_work {
   initialize_test "${FUNCNAME[0]}"
 
   npm install ${PLAYWRIGHT_WEBKIT_TGZ}
-  cp ${SANITY_JS} . && node sanity.js playwright-webkit webkit
+  copy_test_scripts
+  node sanity.js playwright-webkit webkit
+  if [[ "${NODE_VERSION}" == *"v14."* ]]; then
+    node esm-playwright-webkit.mjs
+  fi
 }
 
 function test_playwright_firefox_should_work {
   initialize_test "${FUNCNAME[0]}"
 
   npm install ${PLAYWRIGHT_FIREFOX_TGZ}
-  cp ${SANITY_JS} . && node sanity.js playwright-firefox firefox
+  copy_test_scripts
+  node sanity.js playwright-firefox firefox
+  if [[ "${NODE_VERSION}" == *"v14."* ]]; then
+    node esm-playwright-firefox.mjs
+  fi
 }
 
 function initialize_test {

--- a/packages/playwright-chromium/index.mjs
+++ b/packages/playwright-chromium/index.mjs
@@ -14,21 +14,10 @@
  * limitations under the License.
  */
 
-const requireName = process.argv[2];
-const browsers = process.argv.slice(3);
+import playwright from './index.js';
 
-const playwright = require(requireName);
-
-(async () => {
-  for (const browserType of browsers) {
-    const browser = await playwright[browserType].launch();
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await page.evaluate(() => navigator.userAgent);
-    await browser.close();
-  }
-  console.log(`require SUCCESS`);
-})().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+export const chromium = playwright.chromium;
+export const selectors = playwright.selectors;
+export const devices = playwright.devices;
+export const errors = playwright.errors;
+export default playwright;

--- a/packages/playwright-core/index.mjs
+++ b/packages/playwright-core/index.mjs
@@ -14,21 +14,12 @@
  * limitations under the License.
  */
 
-const requireName = process.argv[2];
-const browsers = process.argv.slice(3);
+import playwright from './index.js';
 
-const playwright = require(requireName);
-
-(async () => {
-  for (const browserType of browsers) {
-    const browser = await playwright[browserType].launch();
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await page.evaluate(() => navigator.userAgent);
-    await browser.close();
-  }
-  console.log(`require SUCCESS`);
-})().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+export const chromium = playwright.chromium;
+export const firefox = playwright.firefox;
+export const webkit = playwright.webkit;
+export const selectors = playwright.selectors;
+export const devices = playwright.devices;
+export const errors = playwright.errors;
+export default playwright;

--- a/packages/playwright-electron/index.mjs
+++ b/packages/playwright-electron/index.mjs
@@ -14,21 +14,10 @@
  * limitations under the License.
  */
 
-const requireName = process.argv[2];
-const browsers = process.argv.slice(3);
+import playwright from './index.js';
 
-const playwright = require(requireName);
-
-(async () => {
-  for (const browserType of browsers) {
-    const browser = await playwright[browserType].launch();
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await page.evaluate(() => navigator.userAgent);
-    await browser.close();
-  }
-  console.log(`require SUCCESS`);
-})().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+export const electron = playwright.electron;
+export const selectors = playwright.selectors;
+export const devices = playwright.devices;
+export const errors = playwright.errors;
+export default playwright;

--- a/packages/playwright-firefox/index.mjs
+++ b/packages/playwright-firefox/index.mjs
@@ -14,21 +14,10 @@
  * limitations under the License.
  */
 
-const requireName = process.argv[2];
-const browsers = process.argv.slice(3);
+import playwright from './index.js';
 
-const playwright = require(requireName);
-
-(async () => {
-  for (const browserType of browsers) {
-    const browser = await playwright[browserType].launch();
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await page.evaluate(() => navigator.userAgent);
-    await browser.close();
-  }
-  console.log(`require SUCCESS`);
-})().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+export const firefox = playwright.firefox;
+export const selectors = playwright.selectors;
+export const devices = playwright.devices;
+export const errors = playwright.errors;
+export default playwright;

--- a/packages/playwright-webkit/index.mjs
+++ b/packages/playwright-webkit/index.mjs
@@ -14,21 +14,10 @@
  * limitations under the License.
  */
 
-const requireName = process.argv[2];
-const browsers = process.argv.slice(3);
+import playwright from './index.js';
 
-const playwright = require(requireName);
-
-(async () => {
-  for (const browserType of browsers) {
-    const browser = await playwright[browserType].launch();
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await page.evaluate(() => navigator.userAgent);
-    await browser.close();
-  }
-  console.log(`require SUCCESS`);
-})().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+export const webkit = playwright.webkit;
+export const selectors = playwright.selectors;
+export const devices = playwright.devices;
+export const errors = playwright.errors;
+export default playwright;

--- a/packages/playwright/index.mjs
+++ b/packages/playwright/index.mjs
@@ -14,21 +14,12 @@
  * limitations under the License.
  */
 
-const requireName = process.argv[2];
-const browsers = process.argv.slice(3);
+import playwright from './index.js';
 
-const playwright = require(requireName);
-
-(async () => {
-  for (const browserType of browsers) {
-    const browser = await playwright[browserType].launch();
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await page.evaluate(() => navigator.userAgent);
-    await browser.close();
-  }
-  console.log(`require SUCCESS`);
-})().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+export const chromium = playwright.chromium;
+export const firefox = playwright.firefox;
+export const webkit = playwright.webkit;
+export const selectors = playwright.selectors;
+export const devices = playwright.devices;
+export const errors = playwright.errors;
+export default playwright;


### PR DESCRIPTION
We provide an `index.mjs` wrapper that exports all fields from playwright, so that `import { chromium } from 'playwright'` syntax continues to work.

Fixes #2269.