### PR TITLE
fix(test): don't leave so many zombies on sigint

### DIFF
--- a/test/jest/playwrightEnvironment.js
+++ b/test/jest/playwrightEnvironment.js
@@ -51,6 +51,12 @@ class PlaywrightEnvironment extends NodeEnvironment {
       this.fixturePool.registerFixture(name, 'worker', fn);
     };
     registerFixtures(this.global);
+
+    process.on('SIGINT', async () => {
+      await this.fixturePool.teardownScope('test');
+      await this.fixturePool.teardownScope('worker');
+      process.exit(130);
+    });
   }
 
   async setup() {


### PR DESCRIPTION
This makes the jest runner leave the same few number of zombies as the old test runner. Most browsers will be cleaned up.