### PR TITLE
browser(webkit): correctly report outerWidth/Height on Mac

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1315
-Changed: lushnikov@chromium.org Thu Jul 23 09:56:07 PDT 2020
+1316
+Changed: yurys@chromium.org Thu Jul 23 16:12:30 PDT 2020

--- a/browser_patches/webkit/embedder/Playwright/mac/AppDelegate.m
+++ b/browser_patches/webkit/embedder/Playwright/mac/AppDelegate.m
@@ -368,6 +368,11 @@ const NSActivityOptions ActivityOptions =
     }
 }
 
+- (void)_webView:(WKWebView *)webView getWindowFrameWithCompletionHandler:(void (^)(CGRect))completionHandler
+{
+    completionHandler([webView.window frame]);
+}
+
 - (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
 {
     WebViewDialog* dialog = [[WebViewDialog alloc] autorelease];

--- a/browser_patches/webkit/embedder/Playwright/mac/BrowserWindowController.m
+++ b/browser_patches/webkit/embedder/Playwright/mac/BrowserWindowController.m
@@ -421,6 +421,11 @@ static BOOL areEssentiallyEqual(double a, double b)
     [self.window close];
 }
 
+- (void)_webView:(WKWebView *)webView getWindowFrameWithCompletionHandler:(void (^)(CGRect))completionHandler
+{
+    completionHandler([self.window frame]);
+}
+
 #define DefaultMinimumZoomFactor (.5)
 #define DefaultMaximumZoomFactor (3.0)
 #define DefaultZoomFactorRatio (1.2)


### PR DESCRIPTION
https://github.com/yury-s/webkit/commit/282f02ed72648112a2a808d390a4e3d3d4d6f9ca

#3030