### PR TITLE
chore(test): support typescript in jest files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,3 +13,4 @@ src/webkit/protocol.ts
 /index.d.ts
 utils/generate_types/overrides.d.ts
 utils/generate_types/test/test.ts
+test/

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,18 @@ module.exports = /** @type {import('@jest/types').Config.InitialOptions} */ ({
   testTimeout: 10000,
   globalSetup: './jest/setup.js',
   globalTeardown: './jest/teardown.js',
+  transform: {
+    '^.+\\.ts$': ['babel-jest', {
+      presets: [
+        ['@babel/preset-env', {
+          targets: {
+            node: 'current'
+          }
+        }],
+        ['@babel/preset-typescript']
+      ],
+    }],
+  },
   reporters: [
     'default',
     './jest/reporter'


### PR DESCRIPTION
This doesn't add any typescript test files, but just sets up the config so that .ts files can be consumed.