### PR TITLE
fix(webkit): correctly report outerWidth/Height on Mac

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -13,7 +13,7 @@
     },
     {
       "name": "webkit",
-      "revision": "1317",
+      "revision": "1319",
       "download": true
     }
   ]

--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -158,7 +158,7 @@ export class CRBrowser extends BrowserBase {
 
     if (targetInfo.type === 'page') {
       const opener = targetInfo.openerId ? this._crPages.get(targetInfo.openerId) || null : null;
-      const crPage = new CRPage(session, targetInfo.targetId, context, opener, !!this._options.headful);
+      const crPage = new CRPage(session, targetInfo.targetId, context, opener, true);
       this._crPages.set(targetInfo.targetId, crPage);
       crPage.pageOrError().then(pageOrError => {
         const page = crPage._page;

--- a/test/emulation.jest.js
+++ b/test/emulation.jest.js
@@ -16,7 +16,7 @@
  */
 
 const utils = require('./utils');
-const {FFOX, HEADLESS} = testOptions;
+const {CHROMIUM, FFOX, MAC, HEADLESS} = testOptions;
 
 describe('BrowserContext({viewport})', function() {
   it('should get the proper default viewport size', async({page, server}) => {
@@ -26,6 +26,21 @@ describe('BrowserContext({viewport})', function() {
     await utils.verifyViewport(page, 1280, 720);
     await page.setViewportSize({width: 123, height: 456});
     await utils.verifyViewport(page, 123, 456);
+  });
+  // TODO: enable in Chromium after http://crrev.com/c/2321409 is landed and rolled.
+  it.fail(CHROMIUM && HEADLESS && MAC)('should return correct outerWidth and outerHeight', async({page}) => {
+    const size = await page.evaluate(() => {
+      return {
+        innerWidth: window.innerWidth,
+        innerHeight: window.innerHeight,
+        outerWidth: window.outerWidth,
+        outerHeight: window.outerHeight,
+      };
+    });
+    expect(size.innerWidth).toBe(1280);
+    expect(size.innerHeight).toBe(720);
+    expect(size.outerWidth >= size.innerWidth).toBeTruthy();
+    expect(size.outerHeight >= size.innerHeight).toBeTruthy();
   });
   it('should emulate device width', async({page, server}) => {
     expect(page.viewportSize()).toEqual({width: 1280, height: 720});


### PR DESCRIPTION
Fixes #3030