### PR TITLE
devops: normalize blob names on the CDN

### DIFF
--- a/browser_patches/buildbots/buildbot-mac-10.14.sh
+++ b/browser_patches/buildbots/buildbot-mac-10.14.sh
@@ -61,7 +61,7 @@ if [[ -n $(git status -s) ]]; then
 fi
 
 git pull origin master
-../checkout_build_archive_upload.sh firefox-mac >/tmp/$(basename $0)--firefox-mac.log || true
+../checkout_build_archive_upload.sh firefox-mac-10.14 >/tmp/$(basename $0)--firefox-mac.log || true
 
 git pull origin master
 ../checkout_build_archive_upload.sh webkit-mac-10.14 >/tmp/$(basename $0)--webkit-mac-10.14.log || true

--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -41,11 +41,11 @@ if [[ "$BUILD_FLAVOR" == "firefox-ubuntu-18.04" ]]; then
   EXPECTED_HOST_OS="Ubuntu"
   EXPECTED_HOST_OS_VERSION="18.04"
   BUILD_BLOB_NAME="firefox-ubuntu-18.04.zip"
-elif [[ "$BUILD_FLAVOR" == "firefox-mac" ]]; then
+elif [[ "$BUILD_FLAVOR" == "firefox-mac-10.14" ]]; then
   BROWSER_NAME="firefox"
   EXPECTED_HOST_OS="Darwin"
   EXPECTED_HOST_OS_VERSION="10.14"
-  BUILD_BLOB_NAME="firefox-mac.zip"
+  BUILD_BLOB_NAME="firefox-mac-10.14.zip"
 elif [[ "$BUILD_FLAVOR" == "firefox-win32" ]]; then
   BROWSER_NAME="firefox"
   EXPECTED_HOST_OS="MINGW"
@@ -59,26 +59,26 @@ elif [[ "$BUILD_FLAVOR" == "webkit-ubuntu-18.04" ]]; then
   BROWSER_NAME="webkit"
   EXPECTED_HOST_OS="Ubuntu"
   EXPECTED_HOST_OS_VERSION="18.04"
-  BUILD_BLOB_NAME="minibrowser-gtk-wpe-ubuntu-18.04.zip"
+  BUILD_BLOB_NAME="webkit-ubuntu-18.04.zip"
 elif [[ "$BUILD_FLAVOR" == "webkit-ubuntu-20.04" ]]; then
   BROWSER_NAME="webkit"
   EXPECTED_HOST_OS="Ubuntu"
   EXPECTED_HOST_OS_VERSION="20.04"
-  BUILD_BLOB_NAME="minibrowser-gtk-wpe-ubuntu-20.04.zip"
+  BUILD_BLOB_NAME="webkit-ubuntu-20.04.zip"
 elif [[ "$BUILD_FLAVOR" == "webkit-win64" ]]; then
   BROWSER_NAME="webkit"
   EXPECTED_HOST_OS="MINGW"
-  BUILD_BLOB_NAME="minibrowser-win64.zip"
+  BUILD_BLOB_NAME="webkit-win64.zip"
 elif [[ "$BUILD_FLAVOR" == "webkit-mac-10.14" ]]; then
   BROWSER_NAME="webkit"
   EXPECTED_HOST_OS="Darwin"
   EXPECTED_HOST_OS_VERSION="10.14"
-  BUILD_BLOB_NAME="minibrowser-mac-10.14.zip"
+  BUILD_BLOB_NAME="webkit-mac-10.14.zip"
 elif [[ "$BUILD_FLAVOR" == "webkit-mac-10.15" ]]; then
   BROWSER_NAME="webkit"
   EXPECTED_HOST_OS="Darwin"
   EXPECTED_HOST_OS_VERSION="10.15"
-  BUILD_BLOB_NAME="minibrowser-mac-10.15.zip"
+  BUILD_BLOB_NAME="webkit-mac-10.15.zip"
 else
   echo ERROR: unknown build flavor - "$BUILD_FLAVOR"
   exit 1

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1139
-Changed: lushnikov@chromium.org Thu Jul 23 09:56:07 PDT 2020
+1140
+Changed: lushnikov@chromium.org Thu Jul 23 17:44:30 PDT 2020

--- a/browser_patches/tools/check_cdn.sh
+++ b/browser_patches/tools/check_cdn.sh
@@ -23,7 +23,7 @@ HOST="https://playwright2.blob.core.windows.net/builds"
 
 FFOX_REVISION=$(head -1 ../firefox/BUILD_NUMBER)
 FFOX_ARCHIVES=(
-  "$HOST/firefox/%s/firefox-mac.zip"
+  "$HOST/firefox/%s/firefox-mac-10.14.zip"
   "$HOST/firefox/%s/firefox-ubuntu-18.04.zip"
   "$HOST/firefox/%s/firefox-win32.zip"
   "$HOST/firefox/%s/firefox-win64.zip"
@@ -37,11 +37,11 @@ FFOX_ALIASES=(
 
 WK_REVISION=$(head -1 ../webkit/BUILD_NUMBER)
 WK_ARCHIVES=(
-  "$HOST/webkit/%s/minibrowser-gtk-wpe-ubuntu-18.04.zip"
-  "$HOST/webkit/%s/minibrowser-gtk-wpe-ubuntu-20.04.zip"
-  "$HOST/webkit/%s/minibrowser-mac-10.14.zip"
-  "$HOST/webkit/%s/minibrowser-mac-10.15.zip"
-  "$HOST/webkit/%s/minibrowser-win64.zip"
+  "$HOST/webkit/%s/webkit-ubuntu-18.04.zip"
+  "$HOST/webkit/%s/webkit-ubuntu-20.04.zip"
+  "$HOST/webkit/%s/webkit-mac-10.14.zip"
+  "$HOST/webkit/%s/webkit-mac-10.15.zip"
+  "$HOST/webkit/%s/webkit-win64.zip"
 )
 WK_ALIASES=(
   "WK-UBUNTU-18.04"

--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1316
-Changed: yurys@chromium.org Thu Jul 23 16:12:30 PDT 2020
+1317
+Changed: lushnikov@chromium.org Thu Jul 23 17:44:30 PDT 2020

--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -69,8 +69,8 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
   }
 
   if (browserName === 'firefox') {
-    const FIREFOX_RENAME_LINUX_TO_UBUNTU_REVISION = 1139;
-    return revision < FIREFOX_RENAME_LINUX_TO_UBUNTU_REVISION ?
+    const FIREFOX_NORMALIZE_CDN_NAMES_REVISION = 1140;
+    return revision < FIREFOX_NORMALIZE_CDN_NAMES_REVISION ?
       new Map<BrowserPlatform, string>([
         ['ubuntu18.04', '%s/builds/firefox/%s/firefox-linux.zip'],
         ['ubuntu20.04', '%s/builds/firefox/%s/firefox-linux.zip'],
@@ -83,17 +83,17 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
       new Map<BrowserPlatform, string>([
         ['ubuntu18.04', '%s/builds/firefox/%s/firefox-ubuntu-18.04.zip'],
         ['ubuntu20.04', '%s/builds/firefox/%s/firefox-ubuntu-18.04.zip'],
-        ['mac10.13', '%s/builds/firefox/%s/firefox-mac.zip'],
-        ['mac10.14', '%s/builds/firefox/%s/firefox-mac.zip'],
-        ['mac10.15', '%s/builds/firefox/%s/firefox-mac.zip'],
+        ['mac10.13', '%s/builds/firefox/%s/firefox-mac-10.14.zip'],
+        ['mac10.14', '%s/builds/firefox/%s/firefox-mac-10.14.zip'],
+        ['mac10.15', '%s/builds/firefox/%s/firefox-mac-10.14.zip'],
         ['win32', '%s/builds/firefox/%s/firefox-win32.zip'],
         ['win64', '%s/builds/firefox/%s/firefox-win64.zip'],
       ]).get(platform);
   }
 
   if (browserName === 'webkit') {
-    const WEBKIT_RENAME_LINUX_TO_UBUNTU_REVISION = 1315;
-    return revision < WEBKIT_RENAME_LINUX_TO_UBUNTU_REVISION ?
+    const WEBKIT_NORMALIZE_CDN_NAMES_REVISION = 1317;
+    return revision < WEBKIT_NORMALIZE_CDN_NAMES_REVISION ?
       new Map<BrowserPlatform, string | undefined>([
         ['ubuntu18.04', '%s/builds/webkit/%s/minibrowser-gtk-wpe.zip'],
         ['ubuntu20.04', '%s/builds/webkit/%s/minibrowser-gtk-wpe.zip'],
@@ -104,13 +104,13 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
         ['win64', '%s/builds/webkit/%s/minibrowser-win64.zip'],
       ]).get(platform) :
       new Map<BrowserPlatform, string | undefined>([
-        ['ubuntu18.04', '%s/builds/webkit/%s/minibrowser-gtk-wpe-ubuntu-18.04.zip'],
-        ['ubuntu20.04', '%s/builds/webkit/%s/minibrowser-gtk-wpe-ubuntu-20.04.zip'],
+        ['ubuntu18.04', '%s/builds/webkit/%s/webkit-ubuntu-18.04.zip'],
+        ['ubuntu20.04', '%s/builds/webkit/%s/webkit-ubuntu-20.04.zip'],
         ['mac10.13', undefined],
-        ['mac10.14', '%s/builds/webkit/%s/minibrowser-mac-10.14.zip'],
-        ['mac10.15', '%s/builds/webkit/%s/minibrowser-mac-10.15.zip'],
-        ['win32', '%s/builds/webkit/%s/minibrowser-win64.zip'],
-        ['win64', '%s/builds/webkit/%s/minibrowser-win64.zip'],
+        ['mac10.14', '%s/builds/webkit/%s/webkit-mac-10.14.zip'],
+        ['mac10.15', '%s/builds/webkit/%s/webkit-mac-10.15.zip'],
+        ['win32', '%s/builds/webkit/%s/webkit-win64.zip'],
+        ['win64', '%s/builds/webkit/%s/webkit-win64.zip'],
       ]).get(platform);
   }
 }


### PR DESCRIPTION
This establishes a single naming for all our blobs with browser
builds that we upload to CDN: `<browser-name>-<os-version>`

- `<browser-name>` is either `firefox` or `webkit`.
- `os-version` is the OS that was used to produce the build.

References #2745