### PR TITLE
devops: install Media Pack on Windows bot

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,9 @@ jobs:
         browser: [chromium, firefox, webkit]
     runs-on: windows-latest
     steps:
+    - name: Install Media Pack
+      shell: powershell
+      run: Install-WindowsFeature Server-Media-Foundation
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
Instructions taken from [this page](https://help.manycam.com/knowledge-base/media-foundation-missing/#media-foundation-for-windows-server).

#2449