### PR TITLE
feat(firefox,webkit): roll both Firefox and WebKit

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -7,11 +7,11 @@
     },
     {
       "name": "firefox",
-      "revision": "1138"
+      "revision": "1140"
     },
     {
       "name": "webkit",
-      "revision": "1313"
+      "revision": "1317"
     }
   ]
 }


### PR DESCRIPTION
This rolls Firefox and WebKit to the builds generated by newly
provisioned ubuntu buildbots.