### PR TITLE
fix(require): allow requiring internals

### DIFF
--- a/packages/build_package.js
+++ b/packages/build_package.js
@@ -124,8 +124,15 @@ if (!package) {
     homepage: pwInternalJSON.homepage,
     main: 'index.js',
     exports: {
-      import: './index.mjs',
-      require: './index.js',
+      // Root import: we have a wrapper ES Module to support the following syntax.
+      // const { chromium } = require('playwright');
+      // import { chromium } from 'playwright';
+      '.': {
+        import: './index.mjs',
+        require: './index.js',
+      },
+      // Anything else can be required/imported by providing a relative path.
+      './': './',
     },
     scripts: {
       install: 'node install.js',

--- a/packages/installation-tests/esm-playwright-chromium.mjs
+++ b/packages/installation-tests/esm-playwright-chromium.mjs
@@ -16,8 +16,14 @@
 
 import { chromium, selectors, devices, errors } from 'playwright-chromium';
 import playwright from 'playwright-chromium';
+import errorsFile from 'playwright-chromium/lib/errors.js';
 
 if (playwright.chromium !== chromium)
+  process.exit(1);
+
+if (playwright.errors !== errors)
+  process.exit(1);
+if (errors.TimeoutError !== errorsFile.TimeoutError)
   process.exit(1);
 
 (async () => {

--- a/packages/installation-tests/esm-playwright-firefox.mjs
+++ b/packages/installation-tests/esm-playwright-firefox.mjs
@@ -16,8 +16,14 @@
 
 import { firefox, selectors, devices, errors } from 'playwright-firefox';
 import playwright from 'playwright-firefox';
+import errorsFile from 'playwright-firefox/lib/errors.js';
 
 if (playwright.firefox !== firefox)
+  process.exit(1);
+
+if (playwright.errors !== errors)
+  process.exit(1);
+if (errors.TimeoutError !== errorsFile.TimeoutError)
   process.exit(1);
 
 (async () => {

--- a/packages/installation-tests/esm-playwright-webkit.mjs
+++ b/packages/installation-tests/esm-playwright-webkit.mjs
@@ -16,8 +16,14 @@
 
 import { webkit, selectors, devices, errors } from 'playwright-webkit';
 import playwright from 'playwright-webkit';
+import errorsFile from 'playwright-webkit/lib/errors.js';
 
 if (playwright.webkit !== webkit)
+  process.exit(1);
+
+if (playwright.errors !== errors)
+  process.exit(1);
+if (errors.TimeoutError !== errorsFile.TimeoutError)
   process.exit(1);
 
 (async () => {

--- a/packages/installation-tests/esm-playwright.mjs
+++ b/packages/installation-tests/esm-playwright.mjs
@@ -16,12 +16,18 @@
 
 import { chromium, firefox, webkit, selectors, devices, errors } from 'playwright';
 import playwright from 'playwright';
+import errorsFile from 'playwright/lib/errors.js';
 
 if (playwright.chromium !== chromium)
   process.exit(1);
 if (playwright.firefox !== firefox)
   process.exit(1);
 if (playwright.webkit !== webkit)
+  process.exit(1);
+
+if (playwright.errors !== errors)
+  process.exit(1);
+if (errors.TimeoutError !== errorsFile.TimeoutError)
   process.exit(1);
 
 (async () => {

--- a/packages/installation-tests/sanity.js
+++ b/packages/installation-tests/sanity.js
@@ -19,6 +19,10 @@ const browsers = process.argv.slice(3);
 
 const playwright = require(requireName);
 
+// Requiring internals should work.
+const errors = require(requireName + '/lib/errors');
+const installer = require(requireName + '/lib/install/installer');
+
 (async () => {
   for (const browserType of browsers) {
     const browser = await playwright[browserType].launch();


### PR DESCRIPTION
This is what we used to do:

```js
const errors = require('playwright/lib/errors');
```