### PR TITLE
feat: validate Ubuntu version if launching firefox

### DIFF
--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -33,7 +33,7 @@ import * as types from '../types';
 import { TimeoutSettings } from '../timeoutSettings';
 import { WebSocketServer } from './webSocketServer';
 import { LoggerSink } from '../loggerSink';
-import { validateDependencies } from './validateDependencies';
+import { validateHostRequirements } from './validateDependencies';
 
 type FirefoxPrefsOptions = { firefoxUserPrefs?: { [key: string]: string | number | boolean } };
 type LaunchOptions = types.LaunchOptions & { logger?: LoggerSink };
@@ -193,7 +193,7 @@ export abstract class BrowserTypeBase implements BrowserType {
 
     if (!executablePath) {
       // We can only validate dependencies for bundled browsers.
-      await validateDependencies(this._browserPath, this._browserDescriptor);
+      await validateHostRequirements(this._browserPath, this._browserDescriptor);
     }
 
     // Note: it is important to define these variables before launchProcess, so that we don't get

--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -26,7 +26,14 @@ const checkExecutable = (filePath: string) => accessAsync(filePath, fs.constants
 const statAsync = util.promisify(fs.stat.bind(fs));
 const readdirAsync = util.promisify(fs.readdir.bind(fs));
 
-export async function validateDependencies(browserPath: string, browser: BrowserDescriptor) {
+export async function validateHostRequirements(browserPath: string, browser: BrowserDescriptor) {
+  const ubuntuVersion = await getUbuntuVersion();
+  if (browser.name === 'firefox' && ubuntuVersion === '16.04')
+    throw new Error(`Cannot launch firefox on Ubuntu 16.04! Minimum required Ubuntu version for Firefox browser is 18.04`);
+  await validateDependencies(browserPath, browser);
+}
+
+async function validateDependencies(browserPath: string, browser: BrowserDescriptor) {
   // We currently only support Linux.
   if (os.platform() !== 'linux')
     return;


### PR DESCRIPTION
The original plan was to rnu some checks against libc version the
binary is compiled with, but these turn out to be a little complicated:
parsing out libc version from both static binary and host system
requires text processing, and it's hard to make sure it works reliably
across distributions.

Instead, let's start with a very particular check against running
Firefox on Ubuntu 16.04.

References #2745