### PR TITLE
feat(rpc): make ElectronApplication a scope

### DIFF
--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -1617,10 +1617,9 @@ export type ElectronLaunchResult = {
 };
 
 // ----------- ElectronApplication -----------
-export type ElectronApplicationInitializer = {
-  context: BrowserContextChannel,
-};
+export type ElectronApplicationInitializer = {};
 export interface ElectronApplicationChannel extends Channel {
+  on(event: 'context', callback: (params: ElectronApplicationContextEvent) => void): this;
   on(event: 'close', callback: (params: ElectronApplicationCloseEvent) => void): this;
   on(event: 'window', callback: (params: ElectronApplicationWindowEvent) => void): this;
   newBrowserWindow(params: ElectronApplicationNewBrowserWindowParams): Promise<ElectronApplicationNewBrowserWindowResult>;
@@ -1628,6 +1627,9 @@ export interface ElectronApplicationChannel extends Channel {
   evaluateExpressionHandle(params: ElectronApplicationEvaluateExpressionHandleParams): Promise<ElectronApplicationEvaluateExpressionHandleResult>;
   close(params?: ElectronApplicationCloseParams): Promise<ElectronApplicationCloseResult>;
 }
+export type ElectronApplicationContextEvent = {
+  context: BrowserContextChannel,
+};
 export type ElectronApplicationCloseEvent = {};
 export type ElectronApplicationWindowEvent = {
   page: PageChannel,

--- a/src/rpc/client/channelOwner.ts
+++ b/src/rpc/client/channelOwner.ts
@@ -15,10 +15,10 @@
  */
 
 import { EventEmitter } from 'events';
-import { Channel } from '../channels';
-import { Connection } from './connection';
+import type { Channel } from '../channels';
+import type { Connection } from './connection';
 import { assert } from '../../helper';
-import { LoggerSink } from '../../loggerSink';
+import type { LoggerSink } from '../../loggerSink';
 import { DebugLoggerSink } from '../../logger';
 
 export abstract class ChannelOwner<T extends Channel = Channel, Initializer = {}> extends EventEmitter {
@@ -37,11 +37,11 @@ export abstract class ChannelOwner<T extends Channel = Channel, Initializer = {}
 
   constructor(parent: ChannelOwner | Connection, type: string, guid: string, initializer: Initializer, isScope?: boolean) {
     super();
-    this._connection = parent instanceof Connection ? parent : parent._connection;
+    this._connection = parent instanceof ChannelOwner ? parent._connection : parent;
     this._type = type;
     this._guid = guid;
     this._isScope = !!isScope;
-    this._parent = parent instanceof Connection ? undefined : parent;
+    this._parent = parent instanceof ChannelOwner ? parent : undefined;
 
     this._connection._objects.set(guid, this);
     if (this._parent) {

--- a/src/rpc/client/connection.ts
+++ b/src/rpc/client/connection.ts
@@ -131,8 +131,8 @@ export class Connection {
         break;
       case 'BrowserContext':
         let browserName = '';
-        if (parent instanceof Electron) {
-          // Launching electron produces Electron parent for BrowserContext.
+        if (parent instanceof ElectronApplication) {
+          // Launching electron produces ElectronApplication parent for BrowserContext.
           browserName = 'electron';
         } else if (parent instanceof Browser) {
           // Launching a browser produces Browser parent for BrowserContext.

--- a/src/rpc/protocol.yml
+++ b/src/rpc/protocol.yml
@@ -1887,9 +1887,6 @@ Electron:
 ElectronApplication:
   type: interface
 
-  initializer:
-    context: BrowserContext
-
   commands:
 
     newBrowserWindow:
@@ -1917,6 +1914,11 @@ ElectronApplication:
     close:
 
   events:
+
+    # This event happens once immediately after creation.
+    context:
+      parameters:
+        context: BrowserContext
 
     close:
 

--- a/src/rpc/server/electronDispatcher.ts
+++ b/src/rpc/server/electronDispatcher.ts
@@ -41,11 +41,12 @@ export class ElectronDispatcher extends Dispatcher<Electron, ElectronInitializer
 
 export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplication, ElectronApplicationInitializer> implements ElectronApplicationChannel {
   constructor(scope: DispatcherScope, electronApplication: ElectronApplication) {
-    super(scope, electronApplication, 'ElectronApplication', {
-      context: new BrowserContextDispatcher(scope, electronApplication.context() as BrowserContextBase),
+    super(scope, electronApplication, 'ElectronApplication', {}, true);
+    this._dispatchEvent('context', { context: new BrowserContextDispatcher(this._scope, electronApplication.context() as BrowserContextBase) });
+    electronApplication.on(ElectronEvents.ElectronApplication.Close, () => {
+      this._dispatchEvent('close');
+      this._dispose();
     });
-
-    electronApplication.on(ElectronEvents.ElectronApplication.Close, () => this._dispatchEvent('close'));
     electronApplication.on(ElectronEvents.ElectronApplication.Window, (page: ElectronPage) => {
       this._dispatchEvent('window', {
         page: lookupDispatcher<PageDispatcher>(page),


### PR DESCRIPTION
For this, we must move BrowserContext out of initializer, so that it is created later, in the scope of parent ElectronApplication.