### PR TITLE
chore: simplify doclint

### DIFF
--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -145,7 +145,7 @@ export class CRBrowser extends BrowserBase {
       const backgroundPage = new CRPage(session, targetInfo.targetId, context, null, false);
       this._backgroundPages.set(targetInfo.targetId, backgroundPage);
       backgroundPage.pageOrError().then(() => {
-        context!.emit(Events.CRBrowserContext.BackgroundPage, backgroundPage._page);
+        context!.emit(Events.ChromiumBrowserContext.BackgroundPage, backgroundPage._page);
       });
       return;
     }
@@ -172,7 +172,7 @@ export class CRBrowser extends BrowserBase {
     if (targetInfo.type === 'service_worker') {
       const serviceWorker = new CRServiceWorker(context, session, targetInfo.url);
       this._serviceWorkers.set(targetInfo.targetId, serviceWorker);
-      context.emit(Events.CRBrowserContext.ServiceWorker, serviceWorker);
+      context.emit(Events.ChromiumBrowserContext.ServiceWorker, serviceWorker);
       return;
     }
 

--- a/src/chromium/events.ts
+++ b/src/chromium/events.ts
@@ -16,7 +16,7 @@
  */
 
 export const Events = {
-  CRBrowserContext: {
+  ChromiumBrowserContext: {
     BackgroundPage: 'backgroundpage',
     ServiceWorker: 'serviceworker',
   }

--- a/src/rpc/client/chromiumBrowserContext.ts
+++ b/src/rpc/client/chromiumBrowserContext.ts
@@ -32,13 +32,13 @@ export class ChromiumBrowserContext extends BrowserContext {
     this._channel.on('crBackgroundPage', ({ page }) => {
       const backgroundPage = Page.from(page);
       this._backgroundPages.add(backgroundPage);
-      this.emit(ChromiumEvents.CRBrowserContext.BackgroundPage, backgroundPage);
+      this.emit(ChromiumEvents.ChromiumBrowserContext.BackgroundPage, backgroundPage);
     });
     this._channel.on('crServiceWorker', ({worker}) => {
       const serviceWorker = Worker.from(worker);
       serviceWorker._context = this;
       this._serviceWorkers.add(serviceWorker);
-      this.emit(ChromiumEvents.CRBrowserContext.ServiceWorker, serviceWorker);
+      this.emit(ChromiumEvents.ChromiumBrowserContext.ServiceWorker, serviceWorker);
     });
   }
 

--- a/src/rpc/server/browserContextDispatcher.ts
+++ b/src/rpc/server/browserContextDispatcher.ts
@@ -44,10 +44,10 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, Browser
     if (context._browserBase._options.name === 'chromium') {
       for (const page of (context as CRBrowserContext).backgroundPages())
         this._dispatchEvent('crBackgroundPage', { page: new PageDispatcher(this._scope, page) });
-      context.on(ChromiumEvents.CRBrowserContext.BackgroundPage, page => this._dispatchEvent('crBackgroundPage', { page: new PageDispatcher(this._scope, page) }));
+      context.on(ChromiumEvents.ChromiumBrowserContext.BackgroundPage, page => this._dispatchEvent('crBackgroundPage', { page: new PageDispatcher(this._scope, page) }));
       for (const serviceWorker of (context as CRBrowserContext).serviceWorkers())
         this._dispatchEvent('crServiceWorker', new WorkerDispatcher(this._scope, serviceWorker));
-      context.on(ChromiumEvents.CRBrowserContext.ServiceWorker, serviceWorker => this._dispatchEvent('crServiceWorker', { worker: new WorkerDispatcher(this._scope, serviceWorker) }));
+      context.on(ChromiumEvents.ChromiumBrowserContext.ServiceWorker, serviceWorker => this._dispatchEvent('crServiceWorker', { worker: new WorkerDispatcher(this._scope, serviceWorker) }));
     }
   }
 

--- a/test/jest/coverage.js
+++ b/test/jest/coverage.js
@@ -73,7 +73,7 @@ function apiForBrowser(browserName) {
       name: 'Chromium',
       events: {
         ...require('../../lib/events').Events,
-        ChromiumBrowserContext: require('../../lib/chromium/events').Events.CRBrowserContext,
+        ...require('../../lib/chromium/events').Events,
       }
     },
   ];


### PR DESCRIPTION
This renames CRBrowserContext events into ChromiumBrowserContext and
simplifies some doclint/coverage logic.