### PR TITLE
fix(launchDoctor): support existing LD_LIBRARY_PATH

### DIFF
--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -121,7 +121,7 @@ function lddAsync(filePath: string): Promise<{stdout: string, stderr: string, co
     cwd: dirname,
     env: {
       ...process.env,
-      LD_LIBRARY_PATH: dirname,
+      LD_LIBRARY_PATH: process.env.LD_LIBRARY_PATH ? `${process.env.LD_LIBRARY_PATH}:${dirname}` : dirname,
     },
   });
 


### PR DESCRIPTION
On especially Heroku and other environments where `LD_LIBRARY_PATH` is used which is typically the case if you compile a dependency yourself, the library path gets added to the `LD_LIBRARY_PATH` environment variable. Since its currently overwritten, it does not reflect the way how browsers will run.

https://github.com/microsoft/playwright/blob/cb8b1bca9796dd0397bd39b851f889044d68633a/browser_patches/webkit/pw_run.sh#L59 
