### PR TITLE
test(iframes): Add cross-origin clicks (#3170)

### DIFF
--- a/test/assets/frames/link.html
+++ b/test/assets/frames/link.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Page with Link</title>
+    <style>
+      body {
+        background-color: red;
+      }
+    </style>
+  </head>
+  <body>
+    <a id="link-target" href="javascript:window.alert(47)">click me</a>
+  </body>
+</html>

--- a/test/click.jest.js
+++ b/test/click.jest.js
@@ -342,7 +342,7 @@ describe('Page.click', function() {
     const msg = await clickNotification;
     expect(msg).toBe("47");
   })
-  it.fail(CHROMIUM && !HEADLESS)('should click the visible link in an iframe (cross-origin)', async({page, server}) => {
+  it('should click the visible link in an iframe (cross-origin)', async({page, server}) => {
     const clickNotification = new Promise(fulfill => {
       page.on('dialog', dialog => {
         fulfill(dialog.message());
@@ -362,7 +362,7 @@ describe('Page.click', function() {
     const msg = await clickNotification;
     expect(msg).toBe("47");
   })
-  it.fail(CHROMIUM && !HEADLESS)('should click the visible link in an iframe (cross-origin) in fixed position div', async({page, server}) => {
+  it('should click the visible link in an iframe (cross-origin) in fixed position div', async({page, server}) => {
     const clickNotification = new Promise(fulfill => {
       page.on('dialog', dialog => {
         fulfill(dialog.message());
@@ -382,7 +382,7 @@ describe('Page.click', function() {
     const msg = await clickNotification;
     expect(msg).toBe("47");
   })
-  it.fail(CHROMIUM && !HEADLESS)('should click and navigate to a x-frame-options:DENY link in fixed position div', async({page, server}) => {
+  it('should click and navigate to a x-frame-options:DENY link in fixed position div', async({page, server}) => {
     server.setRoute('/login-with-x-frame-options-deny.html', async (req, res) => {
       res.setHeader('Content-Type', 'text/html');
       res.setHeader('X-Frame-Options', 'DENY');
@@ -438,7 +438,7 @@ describe('Page.click', function() {
       expect((await consoleMessaged).match(/^Refused to display.*login-with-x-frame-options-deny\.html' in a frame because it set 'X-Frame-Options' to 'DENY'\./i)).toBeTruthy();
     }
   })
-  it.fail(CHROMIUM && !HEADLESS)('should click and navigate to a x-frame-options:DENY link', async({page, server}) => {
+  it('should click and navigate to a x-frame-options:DENY link', async({page, server}) => {
     server.setRoute('/login-with-x-frame-options-deny.html', async (req, res) => {
       res.setHeader('Content-Type', 'text/html');
       res.setHeader('X-Frame-Options', 'DENY');

--- a/test/click.jest.js
+++ b/test/click.jest.js
@@ -362,7 +362,7 @@ describe('Page.click', function() {
     const msg = await clickNotification;
     expect(msg).toBe("47");
   })
-  it.only(FFOX)('should click and navigate to a x-frame-options:DENY link in fixed position div', async({page, server}) => {
+  it.fail(CHROMIUM || WEBKIT)('should click and navigate to a x-frame-options:DENY link in fixed position div', async({page, server}) => {
     server.setRoute('/login-with-x-frame-options-deny.html', async (req, res) => {
       res.setHeader('Content-Type', 'text/html');
       res.setHeader('X-Frame-Options', 'DENY');
@@ -406,7 +406,7 @@ describe('Page.click', function() {
     await button.click();
     expect(await loggedIn).toBeTruthy();
   })
-  it.only(FFOX)('should click and navigate to a x-frame-options:DENY link', async({page, server}) => {
+  it.fail(CHROMIUM || WEBKIT)('should click and navigate to a x-frame-options:DENY link', async({page, server}) => {
     server.setRoute('/login-with-x-frame-options-deny.html', async (req, res) => {
       res.setHeader('Content-Type', 'text/html');
       res.setHeader('X-Frame-Options', 'DENY');

--- a/test/click.jest.js
+++ b/test/click.jest.js
@@ -362,7 +362,7 @@ describe('Page.click', function() {
     const msg = await clickNotification;
     expect(msg).toBe("47");
   })
-  it.fail(CHROMIUM || WEBKIT)('should click and navigate to a x-frame-options:DENY link in fixed position div', async({page, server}) => {
+  it.fail(CHROMIUM && !HEADLESS)('should click and navigate to a x-frame-options:DENY link in fixed position div', async({page, server}) => {
     server.setRoute('/login-with-x-frame-options-deny.html', async (req, res) => {
       res.setHeader('Content-Type', 'text/html');
       res.setHeader('X-Frame-Options', 'DENY');
@@ -394,19 +394,31 @@ describe('Page.click', function() {
     })
 
     await page.goto(server.PREFIX + '/wrapper.html')
-    const loggedIn = new Promise(fulfull => {
+    const navigated = new Promise(fulfull => {
       page.on('framenavigated', (frame) => {
         if (frame.url().endsWith('/login-with-x-frame-options-deny.html')) {
           fulfull(frame.url());
         }
-      })
+      });
     });
+
+    const consoleMessaged = new Promise(fulfill => {
+      page.on('console', msg => {
+        fulfill(msg.text());
+      });
+    });
+
     const frame = page.frames()[1];
     const button = await frame.$('#pt-login');
     await button.click();
-    expect(await loggedIn).toBeTruthy();
+
+    if (FFOX) {
+      expect(await navigated).toBeTruthy();
+    } else if (WEBKIT || CHROMIUM) {
+      expect((await consoleMessaged).match(/^Refused to display.*login-with-x-frame-options-deny\.html' in a frame because it set 'X-Frame-Options' to 'DENY'\./i)).toBeTruthy();
+    }
   })
-  it.fail(CHROMIUM || WEBKIT)('should click and navigate to a x-frame-options:DENY link', async({page, server}) => {
+  it.fail(CHROMIUM && !HEADLESS)('should click and navigate to a x-frame-options:DENY link', async({page, server}) => {
     server.setRoute('/login-with-x-frame-options-deny.html', async (req, res) => {
       res.setHeader('Content-Type', 'text/html');
       res.setHeader('X-Frame-Options', 'DENY');
@@ -438,17 +450,29 @@ describe('Page.click', function() {
     })
 
     await page.goto(server.PREFIX + '/wrapper.html')
-    const loggedIn = new Promise(fulfull => {
+    const navigated = new Promise(fulfull => {
       page.on('framenavigated', (frame) => {
         if (frame.url().endsWith('/login-with-x-frame-options-deny.html')) {
           fulfull(frame.url());
         }
-      })
+      });
     });
+
+    const consoleMessaged = new Promise(fulfill => {
+      page.on('console', msg => {
+        fulfill(msg.text());
+      });
+    });
+
     const frame = page.frames()[1];
     const button = await frame.$('#pt-login');
     await button.click();
-    expect(await loggedIn).toBeTruthy();
+
+    if (FFOX) {
+      expect(await navigated).toBeTruthy();
+    } else if (WEBKIT || CHROMIUM) {
+      expect((await consoleMessaged).match(/^Refused to display.*login-with-x-frame-options-deny\.html' in a frame because it set 'X-Frame-Options' to 'DENY'\./i)).toBeTruthy();
+    }
   })
   it('should click the button with deviceScaleFactor set', async({browser, server}) => {
     const context = await browser.newContext({ viewport: { width: 400, height: 400 }, deviceScaleFactor: 5 });

--- a/test/click.jest.js
+++ b/test/click.jest.js
@@ -342,6 +342,26 @@ describe('Page.click', function() {
     const msg = await clickNotification;
     expect(msg).toBe("47");
   })
+  it.fail(CHROMIUM && !HEADLESS)('should click the visible link in an iframe (cross-origin)', async({page, server}) => {
+    const clickNotification = new Promise(fulfill => {
+      page.on('dialog', dialog => {
+        fulfill(dialog.message());
+        dialog.accept();
+      });
+    });
+    await page.goto(server.EMPTY_PAGE);
+    await page.setViewportSize({width:1920, height:1080});
+    await page.setContent(`
+    <div>
+        <iframe src="${server.CROSS_PROCESS_PREFIX + '/frames/link.html'}"  width="100%" height="100%" > </iframe>
+    </div>
+    `)
+    const frame = page.frames()[1];
+    const link = await frame.$("#link-target");
+    await link.click();
+    const msg = await clickNotification;
+    expect(msg).toBe("47");
+  })
   it.fail(CHROMIUM && !HEADLESS)('should click the visible link in an iframe (cross-origin) in fixed position div', async({page, server}) => {
     const clickNotification = new Promise(fulfill => {
       page.on('dialog', dialog => {


### PR DESCRIPTION
This PR adds a variety of tests regarding clicking on links in iframes. Based on the numerous edge cases surfaced by these tests, I think it would be good to add more iframe click tests in some form or another. (These tests were authored in real-time as I was discovering more edge cases, so I'm very open to suggestions for improvement. ❤️ )

EDIT: With #3201 by @dgozman, the Chrome Headfull tests are now passing! 🎉 

~~Many of the tests mark Chromium Head**full** as failing. In several of the failing Chromium Headfull failing cases, Playwright reports a click (i.e. we get past an `await button.click()`), but the click doesn't seem to actually happen (See `should click the visible link in an iframe (cross-origin)`.) In other cases, we timeout waiting for the click to complete and observe the following (repeated) log:~~

```
  pw:api retrying click action [] +0ms
  pw:api   waiting for element to be visible, enabled and not moving [] +0ms
  pw:api   element is visible, enabled and does not move [] +26ms
  pw:api   scrolling into view if needed [] +0ms
  pw:api   done scrolling [] +0ms
  pw:api   checking that element receives pointer events at (35.32,17) [] +1ms
  pw:api   element does not receive pointer events [] +6ms
```

~~See `should click the visible link in an iframe (cross-origin) in fixed position div` for an example of this happening.~~

Finally, we get to the set of tests that deal with [`X-Frame-Options`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) which is set to `DENY` to match the Wikipedia login link:

```
$ curl -v 'https://en.wikipedia.org/w/index.php?title=Special:UserLogin&returnto=Main+Page' 2>&1 | grep -i x-frame-options
< x-frame-options: DENY
```

In these tests—once we account for the clicking issues mentioned above—we see inconsistent behavior. Assuming you run the following script:

```javascript
const http = require("http");
const server = http.createServer((req, res) => {
  res.setHeader("Cache-Control", "no-store");
  console.log(req.url);
  res.end(`
    <body>
        <div>
            <iframe src="https://en.wikipedia.org/"  width="100%" height="100%" > </iframe>
        </div>
    </body>
  `);
});

server.listen(3000);
```
If you click _login_ in the iframe, the consumer-facing versions of Chrome, Firefox, and Webkit will all block the action and warn you in the console that `X-Frame-Options` is set to `'deny'`. However, in the Playwright versions of the browsers (as you'll see by the browser-specific passing criteria for the `should click and navigate to a x-frame-options:DENY link` test, Webkit and Chromium (Headless) give you the deny error, while Firefox navigates to the page against the policy set in the header. (Should Playwright-Firefox match the consumer Firefox behavior?) 
 