### PR TITLE
docs: use "Node.js" instead of "Node"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -10,7 +10,7 @@ assignees: ''
 **Context:**
 - Playwright Version: [what Playwright version do you use?]
 - Operating System: [e.g. Windows, Linux or Mac]
-- Node version: [e.g. 10.12, 10.14]
+- Node.js version: [e.g. 10.12, 10.14]
 - Browser: [e.g. All, Chromium, Firefox, WebKit]
 - Extra: [any specific details about your environment]
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ##### [Docs](docs/README.md) | [API reference](docs/api.md) | [Changelog](https://github.com/microsoft/playwright/releases)
 
-Playwright is a Node library to automate [Chromium](https://www.chromium.org/Home), [Firefox](https://www.mozilla.org/en-US/firefox/new/) and [WebKit](https://webkit.org/) with a single API. Playwright is built to enable cross-browser web automation that is **ever-green**, **capable**, **reliable** and **fast**.
+Playwright is a Node.js library to automate [Chromium](https://www.chromium.org/Home), [Firefox](https://www.mozilla.org/en-US/firefox/new/) and [WebKit](https://webkit.org/) with a single API. Playwright is built to enable cross-browser web automation that is **ever-green**, **capable**, **reliable** and **fast**.
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,7 @@
 - [WebKit](#webkit)
   * [WebKit headless doesn't launch on Linux/WSL](#webkit-headless-doesnt-launch-on-linuxwsl)
 - [Code transpilation issues](#code-transpilation-issues)
-- [Node.js requirements](#node-requirements)
+- [Node.js requirements](#nodejs-requirements)
   * [ReferenceError: URL is not defined](#referenceerror-url-is-not-defined)
 <!-- GEN:stop -->
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,7 @@
 - [WebKit](#webkit)
   * [WebKit headless doesn't launch on Linux/WSL](#webkit-headless-doesnt-launch-on-linuxwsl)
 - [Code transpilation issues](#code-transpilation-issues)
-- [Node requirements](#node-requirements)
+- [Node.js requirements](#node-requirements)
   * [ReferenceError: URL is not defined](#referenceerror-url-is-not-defined)
 <!-- GEN:stop -->
 
@@ -195,11 +195,11 @@ await page.evaluate(`(async() => {
 })()`);
 ```
 
-## Node requirements
+## Node.js requirements
 
 ### ReferenceError: URL is not defined
 
-Playwright requires Node 10 or higher. Node 8 is not supported, and will cause you to receive this error.
+Playwright requires Node.js 10 or higher. Node.js 8 is not supported, and will cause you to receive this error.
 
 # Please file an issue
 

--- a/src/common/README.md
+++ b/src/common/README.md
@@ -1,1 +1,1 @@
-Files in this folder are used both in Node and injected environments, they can't have dependencies.
+Files in this folder are used both in Node.js and injected environments, they can't have dependencies.


### PR DESCRIPTION
The Node.js project itself generally uses "Node.js" instead of "Node". It's likely best to follow the name the project itself uses rather than a different one to help ensure clear communication.

This PR updates all .md references from `Node` to `Node.js`.