### PR TITLE
Update jpeg-js dependency to patch vulnerability CVE-2020-8175

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7438,9 +7438,9 @@
       }
     },
     "jpeg-js": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
-      "integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.1.tgz",
+      "integrity": "sha512-jA55yJiB5tCXEddos8JBbvW+IMrqY0y1tjjx9KNVtA+QPmu7ND5j0zkKopClpUTsaETL135uOM2XfcYG4XRjmw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debug": "^4.1.1",
     "extract-zip": "^2.0.0",
     "https-proxy-agent": "^5.0.0",
-    "jpeg-js": "^0.3.7",
+    "jpeg-js": "^0.4.0",
     "mime": "^2.4.4",
     "pngjs": "^5.0.0",
     "progress": "^2.0.3",


### PR DESCRIPTION
https://github.com/advisories/GHSA-w7q9-p3jq-fmhm