### PR TITLE
devops: include protocol and api.md in NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -19,6 +19,8 @@ lib/injected/
 !README.md
 !LICENSE
 !NOTICE
+!api.md
+!protocol.yml
 
 # browser descriptor
 !browsers.json

--- a/packages/build_package.js
+++ b/packages/build_package.js
@@ -118,6 +118,9 @@ if (!args.some(arg => arg === '--no-cleanup')) {
   for (const file of package.files)
     await copyToPackage(path.join(ROOT_PATH, file), path.join(packagePath, file));
 
+  await copyToPackage(path.join(ROOT_PATH, 'docs/api.md'), path.join(packagePath, 'api.md'));
+  await copyToPackage(path.join(ROOT_PATH, 'src/rpc/protocol.yml'), path.join(packagePath, 'protocol.yml'));
+
   // 4. Generate package.json
   const pwInternalJSON = require(path.join(ROOT_PATH, 'package.json'));
   await writeToPackage('package.json', JSON.stringify({


### PR DESCRIPTION
The reason for this change is that in Playwright Python we would need the related `protocol.yml` and `api.md` for the installed NPM package. For that we could either add the Git hash to the released package e.g. as a file (and go over the GitHub repo to get the file content) but Pavel proposed that it might be better to include the two files in the NPM package.

Tested locally by adding to the `utils/publish_all_packages.sh` script `--dry` to the NPM publish commands.

cc @aslushnikov @pavelfeldman 

Related issues: https://github.com/microsoft/playwright-python/pull/101 and https://github.com/microsoft/playwright-python/pull/96