### PR TITLE
chore: introduce InstallOptions

### DIFF
--- a/utils/roll_browser.js
+++ b/utils/roll_browser.js
@@ -69,7 +69,7 @@ Example:
   // 3. Download new browser.
   console.log('\nDownloading new browser...');
   const { installBrowsersWithProgressBar } = require('../lib/install/installer');
-  await installBrowsersWithProgressBar(ROOT_PATH);
+  await installBrowsersWithProgressBar(ROOT_PATH, { skipCollection: true, onlyBrowsers: [browserName] });
 
   // 4. Generate types.
   console.log('\nGenerating protocol types...');


### PR DESCRIPTION
We use these options for roll_browser script to avoid removing browsers.

The browser name filter will be used by other languages to only install
the required browser on demand.