### PR TITLE
fix(rpc): protocol Route.fulfill

### DIFF
--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -1446,13 +1446,13 @@ export type RouteContinueParams = {
 };
 export type RouteContinueResult = void;
 export type RouteFulfillParams = {
-  status: number,
-  headers: {
+  status?: number,
+  headers?: {
     name: string,
     value: string,
   }[],
-  body: string,
-  isBase64: boolean,
+  body?: string,
+  isBase64?: boolean,
 };
 export type RouteFulfillResult = void;
 

--- a/src/rpc/protocol.yml
+++ b/src/rpc/protocol.yml
@@ -1693,16 +1693,17 @@ Route:
 
     fulfill:
       parameters:
-        status: number
+        # default is 200
+        status: number?
         headers:
-          type: array
+          type: array?
           items:
             type: object
             properties:
               name: string
               value: string
-        body: string
-        isBase64: boolean
+        body: string?
+        isBase64: boolean?
 
 
 

--- a/src/rpc/validator.ts
+++ b/src/rpc/validator.ts
@@ -802,13 +802,13 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     postData: tOptional(tBinary),
   });
   scheme.RouteFulfillParams = tObject({
-    status: tNumber,
-    headers: tArray(tObject({
+    status: tOptional(tNumber),
+    headers: tOptional(tArray(tObject({
       name: tString,
       value: tString,
-    })),
-    body: tString,
-    isBase64: tBoolean,
+    }))),
+    body: tOptional(tString),
+    isBase64: tOptional(tBoolean),
   });
   scheme.ResponseBodyParams = tOptional(tObject({}));
   scheme.ResponseFinishedParams = tOptional(tObject({}));


### PR DESCRIPTION
Not sure about `isBase64`. We faced into that by rolling the new version into Playwright Python.