### PR TITLE
devops: use playwright-github-action@v1

### DIFF
--- a/.github/workflows/publish_canary_npm.yml
+++ b/.github/workflows/publish_canary_npm.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         node-version: 10
         registry-url: 'https://registry.npmjs.org'
-    - uses: microsoft/playwright-github-action@v1.4.2
+    - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
     - run: node utils/update_version.js --next

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         node-version: 10
         registry-url: 'https://registry.npmjs.org'
-    - uses: microsoft/playwright-github-action@v1.4.2
+    - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
     - run: utils/publish_all_packages.sh --release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 10
-    - uses: microsoft/playwright-github-action@v1.4.2
+    - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
     - run: mkdir -p coredumps
@@ -71,7 +71,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 10
-    - uses: microsoft/playwright-github-action@v1.4.2
+    - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
     - run: npm run jest -- --testTimeout=30000
@@ -110,7 +110,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 10
-    - uses: microsoft/playwright-github-action@v1.4.2
+    - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
     - run: npm run jest -- --testTimeout=30000
@@ -149,7 +149,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node_version }}
-    - uses: microsoft/playwright-github-action@v1.4.2
+    - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
     - run: bash packages/installation-tests/installation-tests.sh
@@ -166,7 +166,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 10
-    - uses: microsoft/playwright-github-action@v1.4.2
+    - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
     - run: mkdir -p coredumps
@@ -205,7 +205,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 10
-    - uses: microsoft/playwright-github-action@v1.4.2
+    - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
     - run: mkdir -p coredumps


### PR DESCRIPTION
The playwright-github-action@v1 now points to v1.4.2, so we can
switch to it once again.