### PR TITLE
devops: rename docker image tag for tip-of-tree images

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -29,6 +29,6 @@ jobs:
         repository: public/playwright
         path: docs/docker/
         dockerfile: docs/docker/Dockerfile.bionic
-        tags: dev
+        tags: next
         tag_with_sha: true
 


### PR DESCRIPTION
We currently tag tip-of-tree docker images with `dev` tag. It'll
be much nicer to have consistent taggin with our `npm` which tags
with `next` tag.

This patch removes the `dev` tag and starts using the `next` tag instead
for docker images. Since we haven't announced `dev` tag support
anywhere, I think it's fine to remove it rather than have both `next`
and `dev`.