### PR TITLE
devops(firefox): fixate rust and cbindgen version

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1144
-Changed: joel.einbinder@gmail.com Tue 28 Jul 2020 01:41:10 PM PDT
+1145
+Changed: lushnikov@chromium.org Wed 29 Jul 2020 17:27:10 PM PDT

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -2,6 +2,9 @@
 set -e
 set +x
 
+RUST_VERSION="1.42.0"
+CBINDGEN_VERSION="0.14.1"
+
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname $0)"
 cd "checkout"
@@ -41,6 +44,12 @@ echo "mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/${OBJ_FOLDER}" >> .mozconfig
 if [[ $1 == "--juggler" ]]; then
   ./mach build faster
 else
+  # We manage Rust version ourselves.
+  echo "-- Using rust v${RUST_VERSION}"
+  rustup default "${RUST_VERSION}"
+
+  echo "-- Using cbindgen v${CBINDGEN_VERSION}"
+  cargo install cbindgen --version "${CBINDGEN_VERSION}"
   ./mach build
 fi
 


### PR DESCRIPTION
Firefox buildchain does not fixate `rust` and `cbindgen` versions,
so we want to fixate them on our end.

A table with matching rust version for every firefox version can
be found at [Rust Update Policy for Firefox](https://wiki.mozilla.org/Rust_Update_Policy_for_Firefox).

Additionally, there are checks in `mozbuild` for the minimum
rust version and minimum `cbindgen` version.