### PR TITLE
fix(test): display correct error when golden files mismatch

### DIFF
--- a/test/jest/playwrightEnvironment.js
+++ b/test/jest/playwrightEnvironment.js
@@ -151,7 +151,7 @@ class PlaywrightEnvironment extends NodeEnvironment {
           snapshotState.matched++;
         else
           snapshotState.unmatched++;
-        return {pass, message};
+        return {pass, message: () => message};
       };
       this.global.expect.extend({ toBeGolden });
     }


### PR DESCRIPTION
Jest experts error messages to be functions that return strings, not strings.