### PR TITLE
devops: fix firefox build on Windows

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1145
-Changed: lushnikov@chromium.org Wed 29 Jul 2020 17:27:10 PM PDT
+1146
+Changed: lushnikov@chromium.org Thu 30 Jul 2020 11:44:10 PM PDT

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -44,12 +44,18 @@ echo "mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/${OBJ_FOLDER}" >> .mozconfig
 if [[ $1 == "--juggler" ]]; then
   ./mach build faster
 else
-  # We manage Rust version ourselves.
-  echo "-- Using rust v${RUST_VERSION}"
-  rustup default "${RUST_VERSION}"
+  # TODO: rust is not in the PATH on Windows
+  if command -v rust >/dev/null; then
+    # We manage Rust version ourselves.
+    echo "-- Using rust v${RUST_VERSION}"
+    rustup default "${RUST_VERSION}"
+  fi
 
-  echo "-- Using cbindgen v${CBINDGEN_VERSION}"
-  cargo install cbindgen --version "${CBINDGEN_VERSION}"
+  # TODO: cargo is not in the PATH on Windows
+  if command -v cargo >/dev/null; then
+    echo "-- Using cbindgen v${CBINDGEN_VERSION}"
+    cargo install cbindgen --version "${CBINDGEN_VERSION}"
+  fi
   ./mach build
 fi
 


### PR DESCRIPTION
There's no RUST or CARGO on our windows bot. We'll need to figure it
out later.