### PR TITLE
feat(webkit): bump to 1321

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -13,7 +13,7 @@
     },
     {
       "name": "webkit",
-      "revision": "1320",
+      "revision": "1321",
       "download": true
     }
   ]


### PR DESCRIPTION
The Windows browser archive is now 38Mb compared to 51Mb in 1320.