### PR TITLE
devops: fix typo in rustup detection

### DIFF
--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -44,8 +44,8 @@ echo "mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/${OBJ_FOLDER}" >> .mozconfig
 if [[ $1 == "--juggler" ]]; then
   ./mach build faster
 else
-  # TODO: rust is not in the PATH on Windows
-  if command -v rust >/dev/null; then
+  # TODO: rustup is not in the PATH on Windows
+  if command -v rustup >/dev/null; then
     # We manage Rust version ourselves.
     echo "-- Using rust v${RUST_VERSION}"
     rustup default "${RUST_VERSION}"


### PR DESCRIPTION
This should bring back docker build.