### PR TITLE
browser(firefox): always create new process rather than reuse one

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1152
-Changed: yurys@chromium.org Tue Aug  4 17:40:33 PDT 2020
+1153
+Changed: yurys@chromium.org Wed Aug  5 13:40:00 PDT 2020

--- a/browser_patches/firefox/preferences/playwright.cfg
+++ b/browser_patches/firefox/preferences/playwright.cfg
@@ -10,6 +10,10 @@ pref("ui.systemUsesDarkTheme", 0);
 //
 pref("dom.ipc.processCount", 60000);
 
+// Never reuse processes as they may keep previously overridden values
+// (locale, timezone etc.).
+pref("dom.ipc.processPrelaunch.enabled", false);
+
 // Do not use system colors - they are affected by themes.
 pref("ui.use_standins_for_native_colors", true);
 


### PR DESCRIPTION
Reusing processes would require resetting its global state to the default values which Firefox doesn't do for locale and timezone. So we ensure that new process is launched every time.