### PR TITLE
chore(test): disable flaky proxy test on Chromium

### DIFF
--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -54,7 +54,8 @@ it('should authenticate', async ({browserType, defaultBrowserOptions, server}) =
   await browser.close();
 });
 
-it('should exclude patterns', async ({browserType, defaultBrowserOptions, server}) => {
+// This test is flaky in Chromium.
+it.fail(CHROMIUM)('should exclude patterns', async ({browserType, defaultBrowserOptions, server}) => {
   server.setRoute('/target.html', async (req, res) => {
     res.end('<html><title>Served by the proxy</title></html>');
   });


### PR DESCRIPTION
This test flakes on our bots. Maybe we have trouble showing the DNS error page?