### PR TITLE
chore(test): require playwright fixtures from userland

### DIFF
--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;
 

--- a/test/autowaiting-basic.spec.ts
+++ b/test/autowaiting-basic.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 

--- a/test/autowaiting-no-hang.spec.ts
+++ b/test/autowaiting-no-hang.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 

--- a/test/base.fixture.ts
+++ b/test/base.fixture.ts
@@ -23,6 +23,7 @@ import { Connection } from '../lib/rpc/client/connection';
 import { Transport } from '../lib/rpc/transport';
 import { setUnderTest } from '../lib/helper';
 import { installCoverageHooks } from './harness/coverage';
+import { valueFromEnv } from './harness/utils';
 
 setUnderTest(); // Note: we must call setUnderTest before requiring Playwright
 
@@ -178,9 +179,3 @@ registerFixture('httpsServer', async ({http_server}, test) => {
   http_server.httpsServer.reset();
   await test(http_server.httpsServer);
 });
-
-function valueFromEnv(name, defaultValue) {
-  if (!(name in process.env))
-    return defaultValue;
-  return JSON.parse(process.env[name]);
-}

--- a/test/base.fixture.ts
+++ b/test/base.fixture.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from 'path';
+import childProcess from 'child_process';
+import { LaunchOptions, BrowserType, Browser, BrowserContext, Page, BrowserServer } from '../index';
+import { TestServer } from '../utils/testserver/';
+import { Connection } from '../lib/rpc/client/connection';
+import { Transport } from '../lib/rpc/transport';
+import { setupInProcess } from '../lib/rpc/inprocess';
+import { setUnderTest } from '../lib/helper';
+
+setUnderTest(); // Note: we must call setUnderTest before requiring Playwright
+
+const browserName = process.env.BROWSER || 'chromium';
+
+declare global {
+  interface WorkerState {
+    parallelIndex: number;
+    http_server: {server: TestServer, httpsServer: TestServer};
+    defaultBrowserOptions: LaunchOptions;
+    playwright: typeof import('../index');
+    browserType: BrowserType<Browser>;
+    browser: Browser;
+  }
+  interface FixtureState {
+    toImpl: (rpcObject: any) => any;
+    context: BrowserContext;
+    server: TestServer;
+    page: Page;
+    httpsServer: TestServer;
+    browserServer: BrowserServer;
+  }  
+}
+
+registerWorkerFixture('parallelIndex', async ({}, test) => {
+  await test(parseInt(process.env.JEST_WORKER_ID, 10) - 1);
+});
+
+registerWorkerFixture('http_server', async ({parallelIndex}, test) => {
+  const assetsPath = path.join(__dirname, 'assets');
+  const cachedPath = path.join(__dirname, 'assets', 'cached');
+
+  const port = 8907 + parallelIndex * 2;
+  const server = await TestServer.create(assetsPath, port);
+  server.enableHTTPCache(cachedPath);
+
+  const httpsPort = port + 1;
+  const httpsServer = await TestServer.createHTTPS(assetsPath, httpsPort);
+  httpsServer.enableHTTPCache(cachedPath);
+
+  await test({server, httpsServer});
+
+  await Promise.all([
+    server.stop(),
+    httpsServer.stop(),
+  ]);
+});
+
+registerWorkerFixture('defaultBrowserOptions', async({}, test) => {
+  let executablePath = undefined;
+  if (browserName === 'chromium' && process.env.CRPATH)
+    executablePath = process.env.CRPATH;
+  if (browserName === 'firefox' && process.env.FFPATH)
+    executablePath = process.env.FFPATH;
+  if (browserName === 'webkit' && process.env.WKPATH)
+    executablePath = process.env.WKPATH;
+  if (executablePath)
+    console.error(`Using executable at ${executablePath}`);
+  await test({
+    handleSIGINT: false,
+    slowMo: valueFromEnv('SLOW_MO', 0),
+    headless: !!valueFromEnv('HEADLESS', true),
+    executablePath
+  });
+});
+
+registerWorkerFixture('playwright', async({}, test) => {
+  if (process.env.PWCHANNEL === 'wire') {
+    const connection = new Connection();
+    const spawnedProcess = childProcess.fork(path.join(__dirname, '..', 'lib', 'rpc', 'server'), [], {
+      stdio: 'pipe',
+      detached: true,
+    });
+    spawnedProcess.unref();
+    const onExit = (exitCode, signal) => {
+      throw new Error(`Server closed with exitCode=${exitCode} signal=${signal}`);
+    };
+    spawnedProcess.on('exit', onExit);
+    const transport = new Transport(spawnedProcess.stdin, spawnedProcess.stdout);
+    connection.onmessage = message => transport.send(JSON.stringify(message));
+    transport.onmessage = message => connection.dispatch(JSON.parse(message));
+    const playwrightObject = await connection.waitForObjectWithKnownName('Playwright');
+    await test(playwrightObject);
+    spawnedProcess.removeListener('exit', onExit);
+    spawnedProcess.stdin.destroy();
+    spawnedProcess.stdout.destroy();
+    spawnedProcess.stderr.destroy();
+  } else {
+    await test(require('../index'))
+  }
+});
+
+registerFixture('toImpl', async ({playwright}, test) => {
+  await test((playwright as any)._toImpl);
+});
+
+registerWorkerFixture('browserType', async ({playwright}, test) => {
+  await test(playwright[process.env.BROWSER || 'chromium']);
+});
+
+registerWorkerFixture('browser', async ({browserType, defaultBrowserOptions}, test) => {
+  const browser = await browserType.launch(defaultBrowserOptions);
+  try {
+    await test(browser);
+    if (browser.contexts().length !== 0) {
+      console.warn(`\nWARNING: test did not close all created contexts! ${new Error().stack}\n`);
+      await Promise.all(browser.contexts().map(context => context.close()));
+    }
+  } finally {
+    await browser.close();
+  }
+});
+
+registerFixture('context', async ({browser}, test) => {
+  const context = await browser.newContext();
+  try {
+    await test(context);
+  } finally {
+    await context.close();
+  }
+});
+
+registerFixture('page', async ({context}, test) => {
+  const page = await context.newPage();
+  await test(page);
+});
+
+registerFixture('server', async ({http_server}, test) => {
+  http_server.server.reset();
+  await test(http_server.server);
+});
+
+registerFixture('httpsServer', async ({http_server}, test) => {
+  http_server.httpsServer.reset();
+  await test(http_server.httpsServer);
+});
+
+function valueFromEnv(name, defaultValue) {
+  if (!(name in process.env))
+    return defaultValue;
+  return JSON.parse(process.env[name]);
+}

--- a/test/browser.spec.ts
+++ b/test/browser.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {CHROMIUM} = testOptions;

--- a/test/browsercontext-add-cookies.spec.ts
+++ b/test/browsercontext-add-cookies.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {FFOX, CHROMIUM} = testOptions;

--- a/test/browsercontext-basic.spec.ts
+++ b/test/browsercontext-basic.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 

--- a/test/browsercontext-clearcookies.spec.ts
+++ b/test/browsercontext-clearcookies.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 

--- a/test/browsercontext-cookies.spec.ts
+++ b/test/browsercontext-cookies.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {FFOX, WEBKIT, WIN} = testOptions;

--- a/test/browsercontext-credentials.spec.ts
+++ b/test/browsercontext-credentials.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {CHROMIUM, HEADLESS} = testOptions;

--- a/test/browsercontext-csp.spec.ts
+++ b/test/browsercontext-csp.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import * as utils from './utils';
 

--- a/test/browsercontext-device.spec.ts
+++ b/test/browsercontext-device.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {FFOX} = testOptions;

--- a/test/browsercontext-expose-function.spec.ts
+++ b/test/browsercontext-expose-function.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {FFOX, CHROMIUM, WEBKIT, MAC, CHANNEL, HEADLESS} = testOptions;

--- a/test/browsercontext-locale.spec.ts
+++ b/test/browsercontext-locale.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {CHROMIUM, FFOX, MAC, HEADLESS} = testOptions;

--- a/test/browsercontext-page-event.spec.ts
+++ b/test/browsercontext-page-event.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 import utils from './utils';
 const {FFOX, CHROMIUM, WEBKIT, MAC, CHANNEL, HEADLESS} = testOptions;
 const {devices} = require('..');

--- a/test/browsercontext-route.spec.ts
+++ b/test/browsercontext-route.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {FFOX, CHROMIUM, WEBKIT, MAC, CHANNEL, HEADLESS} = testOptions;

--- a/test/browsercontext-timezone-id.spec.ts
+++ b/test/browsercontext-timezone-id.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {CHROMIUM, FFOX, MAC, HEADLESS} = testOptions;

--- a/test/browsercontext-user-agent.spec.ts
+++ b/test/browsercontext-user-agent.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {FFOX, CHROMIUM, WEBKIT, MAC, CHANNEL, HEADLESS} = testOptions;

--- a/test/browsercontext-viewport-mobile.spec.ts
+++ b/test/browsercontext-viewport-mobile.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {CHROMIUM, FFOX, MAC, HEADLESS} = testOptions;

--- a/test/browsercontext-viewport.spec.ts
+++ b/test/browsercontext-viewport.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {CHROMIUM, FFOX, MAC, HEADLESS} = testOptions;

--- a/test/browsertype-basic.spec.ts
+++ b/test/browsertype-basic.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import path from 'path';
 import fs from 'fs';

--- a/test/browsertype-connect.spec.ts
+++ b/test/browsertype-connect.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {FFOX, CHROMIUM, WEBKIT, WIN, USES_HOOKS, CHANNEL} = testOptions;

--- a/test/browsertype-launch-server.spec.js
+++ b/test/browsertype-launch-server.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const fs = require('fs');

--- a/test/browsertype-launch.spec.ts
+++ b/test/browsertype-launch.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import path from 'path';
 import fs from 'fs';

--- a/test/capabilities.spec.ts
+++ b/test/capabilities.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import path from 'path';
 import url from 'url';

--- a/test/channels.spec.ts
+++ b/test/channels.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 import { ChromiumBrowser } from '../types/types';

--- a/test/check.spec.ts
+++ b/test/check.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 it('should check the box', async({page}) => {
   await page.setContent(`<input id='checkbox' type='checkbox'></input>`);

--- a/test/chromium-css-coverage.spec.ts
+++ b/test/chromium-css-coverage.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;

--- a/test/chromium-js-coverage.spec.ts
+++ b/test/chromium-js-coverage.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;

--- a/test/chromium/chromium.spec.js
+++ b/test/chromium/chromium.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('../base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT, CHANNEL} = testOptions;
 

--- a/test/chromium/launcher.spec.js
+++ b/test/chromium/launcher.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('../base.fixture');
 
 const path = require('path');
 const utils = require('../utils');

--- a/test/chromium/oopif.spec.ts
+++ b/test/chromium/oopif.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import '../base.fixture';
 import { Page, Browser, BrowserContext } from '../../types/types';
 
 const {FFOX, CHROMIUM, WEBKIT, CHANNEL} = testOptions;

--- a/test/chromium/session.spec.js
+++ b/test/chromium/session.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('../base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT, CHANNEL, USES_HOOKS} = testOptions;
 

--- a/test/chromium/tracing.spec.ts
+++ b/test/chromium/tracing.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import '../base.fixture';
 
 import fs from 'fs';
 import path from 'path';

--- a/test/click-react.spec.ts
+++ b/test/click-react.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 import utils from './utils';
 
 declare const renderComponent;

--- a/test/click-timeout-1.spec.ts
+++ b/test/click-timeout-1.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {USES_HOOKS} = testOptions;

--- a/test/click-timeout-2.spec.ts
+++ b/test/click-timeout-2.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {USES_HOOKS} = testOptions;

--- a/test/click-timeout-3.spec.ts
+++ b/test/click-timeout-3.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {USES_HOOKS} = testOptions;

--- a/test/click-timeout-4.spec.ts
+++ b/test/click-timeout-4.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 import utils from './utils';
 
 it('should timeout waiting for stable position', async({page, server}) => {

--- a/test/click.spec.ts
+++ b/test/click.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import utils from './utils';
 const {FFOX, CHROMIUM, WEBKIT, HEADLESS, USES_HOOKS} = testOptions;

--- a/test/defaultbrowsercontext.spec.ts
+++ b/test/defaultbrowsercontext.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import fs from 'fs';
 import path from 'path';

--- a/test/dialog.spec.js
+++ b/test/dialog.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT, CHANNEL} = testOptions;
 

--- a/test/dispatchevent.spec.js
+++ b/test/dispatchevent.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const {FFOX, CHROMIUM, WEBKIT, WIN, USES_HOOKS} = testOptions;

--- a/test/download.spec.ts
+++ b/test/download.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import fs from 'fs';
 import path from 'path';

--- a/test/downloads-path.spec.ts
+++ b/test/downloads-path.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import path from 'path';
 import fs from 'fs';

--- a/test/electron/electron-app.spec.js
+++ b/test/electron/electron-app.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('../base.fixture');
 
 const path = require('path');
 const electronName = process.platform === 'win32' ? 'electron.cmd' : 'electron';

--- a/test/electron/electron-window.spec.js
+++ b/test/electron/electron-window.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('../base.fixture');
 
 const path = require('path');
 const electronName = process.platform === 'win32' ? 'electron.cmd' : 'electron';

--- a/test/elementhandle-bounding-box.spec.js
+++ b/test/elementhandle-bounding-box.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const { FFOX, HEADLESS } = testOptions;

--- a/test/elementhandle-click.spec.js
+++ b/test/elementhandle-click.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const { FFOX, HEADLESS } = testOptions;

--- a/test/elementhandle-content-frame.spec.js
+++ b/test/elementhandle-content-frame.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const { FFOX, HEADLESS } = testOptions;

--- a/test/elementhandle-convenience.spec.js
+++ b/test/elementhandle-convenience.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const { FFOX, HEADLESS } = testOptions;

--- a/test/elementhandle-eval-on-selector.spec.js
+++ b/test/elementhandle-eval-on-selector.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const utils = require('./utils');

--- a/test/elementhandle-misc.spec.js
+++ b/test/elementhandle-misc.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const { FFOX, HEADLESS } = testOptions;

--- a/test/elementhandle-owner-frame.spec.js
+++ b/test/elementhandle-owner-frame.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const { FFOX, HEADLESS } = testOptions;

--- a/test/elementhandle-press.spec.js
+++ b/test/elementhandle-press.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const { FFOX, HEADLESS } = testOptions;

--- a/test/elementhandle-query-selector.spec.js
+++ b/test/elementhandle-query-selector.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const utils = require('./utils');

--- a/test/elementhandle-screenshot.spec.js
+++ b/test/elementhandle-screenshot.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const {FFOX, CHROMIUM, WEBKIT, USES_HOOKS, HEADLESS} = testOptions;

--- a/test/elementhandle-scroll-into-view.spec.js
+++ b/test/elementhandle-scroll-into-view.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const { FFOX, HEADLESS } = testOptions;

--- a/test/elementhandle-select-text.spec.js
+++ b/test/elementhandle-select-text.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const { FFOX, HEADLESS } = testOptions;

--- a/test/elementhandle-type.spec.js
+++ b/test/elementhandle-type.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const { FFOX, HEADLESS } = testOptions;

--- a/test/emulation-focus.spec.js
+++ b/test/emulation-focus.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const {CHROMIUM, FFOX, MAC, HEADLESS} = testOptions;

--- a/test/eval-on-selector-all.spec.js
+++ b/test/eval-on-selector-all.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const utils = require('./utils');

--- a/test/eval-on-selector.spec.js
+++ b/test/eval-on-selector.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const utils = require('./utils');

--- a/test/firefox/launcher.spec.js
+++ b/test/firefox/launcher.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('../base.fixture');
 
 const { FFOX } = testOptions;
 

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import path from 'path';
 import {spawn, execSync} from 'child_process';

--- a/test/focus.spec.js
+++ b/test/focus.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, LINUX, WEBKIT, MAC} = testOptions;
 

--- a/test/frame-evaluate.spec.js
+++ b/test/frame-evaluate.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const path = require('path');

--- a/test/frame-frame-element.spec.js
+++ b/test/frame-frame-element.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;

--- a/test/frame-goto.spec.js
+++ b/test/frame-goto.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const path = require('path');

--- a/test/frame-hierarcy.spec.js
+++ b/test/frame-hierarcy.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;

--- a/test/geolocation.spec.js
+++ b/test/geolocation.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;
 

--- a/test/harness/coverage.js
+++ b/test/harness/coverage.js
@@ -24,6 +24,7 @@
 function traceAPICoverage(apiCoverage, api, events) {
   const uninstalls = [];
   for (const [name, classType] of Object.entries(api)) {
+    // console.log('trace', name);
     const className = name.substring(0, 1).toLowerCase() + name.substring(1);
     for (const methodName of Reflect.ownKeys(classType.prototype)) {
       const method = Reflect.get(classType.prototype, methodName);

--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const { makeUserDataDir, removeUserDataDir } = utils;

--- a/test/ignorehttpserrors.spec.js
+++ b/test/ignorehttpserrors.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT, MAC} = testOptions;
 

--- a/test/interception.spec.js
+++ b/test/interception.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const fs = require('fs');
 const path = require('path');

--- a/test/jest/checkCoverage.js
+++ b/test/jest/checkCoverage.js
@@ -15,7 +15,7 @@
  */
 const path = require('path');
 const fs = require('fs');
-const {installCoverageHooks} = require('./coverage');
+const {installCoverageHooks} = require('../harness/coverage');
 
 const browserName = process.env.BROWSER || 'chromium';
 

--- a/test/jest/playwrightEnvironment.js
+++ b/test/jest/playwrightEnvironment.js
@@ -21,13 +21,13 @@ const fs = require('fs');
 const debug = require('debug');
 const util = require('util');
 const GoldenUtils = require('../../utils/testrunner/GoldenUtils');
-const {installCoverageHooks} = require('./coverage');
 const reportOnly = !!process.env.REPORT_ONLY_PLATFORM;
 const { ModuleMocker } = require('jest-mock');
 
 global.testOptions = require('../harness/testOptions');
 global.registerFixture = registerFixture;
 global.registerWorkerFixture = registerWorkerFixture;
+global.testPath = null;
 
 const browserName = process.env.BROWSER || 'chromium';
 
@@ -50,32 +50,16 @@ class PlaywrightEnvironment {
     this.fixturePool = new FixturePool();
     this.global = global;
     this.global.testOptions = testOptions;
-    this.testPath = context.testPath;
+    this.global.testPath = context.testPath;
   }
 
   async setup() {
-    const {coverage, uninstall} = installCoverageHooks(browserName);
-    this.coverage = coverage;
-    this.uninstallCoverage = uninstall;
     currentFixturePool = this.fixturePool;
   }
 
   async teardown() {
     currentFixturePool = null;
     await this.fixturePool.teardownScope('worker');
-    // If the setup throws an error, we don't want to override it
-    // with a useless error about this.coverage not existing.
-    if (!this.coverage)
-      return;
-    this.uninstallCoverage();
-    const testRoot = path.join(__dirname, '..');
-    const relativeTestPath = path.relative(testRoot, this.testPath);
-    const coveragePath = path.join(outputPath, 'coverage', relativeTestPath + '.json');
-    const coverageJSON = [...this.coverage.keys()].filter(key => this.coverage.get(key));
-    await fs.promises.mkdir(path.dirname(coveragePath), { recursive: true });
-    await fs.promises.writeFile(coveragePath, JSON.stringify(coverageJSON, undefined, 2), 'utf8');
-    delete this.coverage;
-    delete this.uninstallCoverage;
   }
 
   runScript(script) {

--- a/test/jest/playwrightEnvironment.js
+++ b/test/jest/playwrightEnvironment.js
@@ -15,7 +15,6 @@
  */
 
 const { FixturePool, registerFixture, registerWorkerFixture } = require('../harness/fixturePool');
-const registerFixtures = require('../harness/fixtures');
 const os = require('os');
 const path = require('path');
 const fs = require('fs');
@@ -29,8 +28,6 @@ const { ModuleMocker } = require('jest-mock');
 global.testOptions = require('../harness/testOptions');
 global.registerFixture = registerFixture;
 global.registerWorkerFixture = registerWorkerFixture;
-
-registerFixtures(global);
 
 const browserName = process.env.BROWSER || 'chromium';
 

--- a/test/jshandle-as-element.spec.js
+++ b/test/jshandle-as-element.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;
 

--- a/test/jshandle-evaluate.spec.js
+++ b/test/jshandle-evaluate.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;
 

--- a/test/jshandle-json-value.spec.js
+++ b/test/jshandle-json-value.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;
 

--- a/test/jshandle-properties.spec.js
+++ b/test/jshandle-properties.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;
 

--- a/test/jshandle-to-string.spec.js
+++ b/test/jshandle-to-string.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;
 

--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const fs = require('fs');

--- a/test/logger.spec.js
+++ b/test/logger.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const fs = require('fs');
 const path = require('path');

--- a/test/mouse.spec.js
+++ b/test/mouse.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT, MAC, WIN} = testOptions;
 

--- a/test/multiclient.spec.js
+++ b/test/multiclient.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;
 

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 it('should work with _blank target', async({page, server}) => {
   server.setRoute('/empty.html', (req, res) => {

--- a/test/network-request.spec.js
+++ b/test/network-request.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const fs = require('fs');
 const path = require('path');

--- a/test/network-response.spec.js
+++ b/test/network-response.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const fs = require('fs');
 const path = require('path');

--- a/test/nojest/nojest.js
+++ b/test/nojest/nojest.js
@@ -22,14 +22,12 @@ const pirates = require('pirates');
 const babel = require('@babel/core');
 const TestRunner = require('../../utils/testrunner');
 const { FixturePool, registerFixture, registerWorkerFixture } = require('../harness/fixturePool');
-const registerFixtures = require('../harness/fixtures');
 const testOptions = require('../harness/testOptions');
 
 Error.stackTraceLimit = 15;
 global.testOptions = require('../harness/testOptions');
 global.registerFixture = registerFixture;
 global.registerWorkerFixture = registerWorkerFixture;
-registerFixtures(global);
 process.env.JEST_WORKER_ID = 1;
 const browserName = process.env.BROWSER || 'chromium';
 const goldenPath = path.join(__dirname, '..', 'golden-' + browserName);

--- a/test/page-add-init-script.spec.js
+++ b/test/page-add-init-script.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const path = require('path');

--- a/test/page-add-script-tag.spec.js
+++ b/test/page-add-script-tag.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const util = require('util');

--- a/test/page-add-style-tag.spec.js
+++ b/test/page-add-style-tag.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const util = require('util');

--- a/test/page-basic.spec.js
+++ b/test/page-basic.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const util = require('util');

--- a/test/page-emulate-media.spec.js
+++ b/test/page-emulate-media.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const {CHROMIUM, FFOX, MAC, HEADLESS} = testOptions;

--- a/test/page-evaluate-handle.spec.js
+++ b/test/page-evaluate-handle.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;
 

--- a/test/page-evaluate.spec.js
+++ b/test/page-evaluate.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const path = require('path');

--- a/test/page-event-console.spec.js
+++ b/test/page-event-console.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const util = require('util');

--- a/test/page-event-crash.spec.js
+++ b/test/page-event-crash.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const util = require('util');

--- a/test/page-event-network.spec.js
+++ b/test/page-event-network.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const fs = require('fs');
 const path = require('path');

--- a/test/page-event-pageerror.spec.js
+++ b/test/page-event-pageerror.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const {FFOX, CHROMIUM, WEBKIT, WIN, USES_HOOKS, CHANNEL} = testOptions;

--- a/test/page-event-popup.spec.js
+++ b/test/page-event-popup.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT, MAC} = testOptions;
 

--- a/test/page-event-request.spec.js
+++ b/test/page-event-request.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const fs = require('fs');
 const path = require('path');

--- a/test/page-expose-function.spec.js
+++ b/test/page-expose-function.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const util = require('util');

--- a/test/page-fill.spec.js
+++ b/test/page-fill.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const util = require('util');

--- a/test/page-goto.spec.js
+++ b/test/page-goto.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const path = require('path');

--- a/test/page-history.spec.js
+++ b/test/page-history.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const url = require('url');

--- a/test/page-network-idle.spec.js
+++ b/test/page-network-idle.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const path = require('path');

--- a/test/page-route.spec.js
+++ b/test/page-route.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const fs = require('fs');
 const path = require('path');

--- a/test/page-screenshot.spec.js
+++ b/test/page-screenshot.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const {FFOX, CHROMIUM, WEBKIT, USES_HOOKS, HEADLESS} = testOptions;

--- a/test/page-select-option.spec.js
+++ b/test/page-select-option.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const util = require('util');

--- a/test/page-set-content.spec.js
+++ b/test/page-set-content.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const util = require('util');

--- a/test/page-set-extra-http-headers.spec.js
+++ b/test/page-set-extra-http-headers.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const fs = require('fs');
 const path = require('path');

--- a/test/page-set-input-files.spec.js
+++ b/test/page-set-input-files.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const fs = require('fs');

--- a/test/page-wait-for-load-state.spec.js
+++ b/test/page-wait-for-load-state.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const path = require('path');

--- a/test/page-wait-for-navigation.spec.js
+++ b/test/page-wait-for-navigation.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const path = require('path');

--- a/test/page-wait-for-request.spec.js
+++ b/test/page-wait-for-request.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const util = require('util');

--- a/test/page-wait-for-response.spec.js
+++ b/test/page-wait-for-response.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const util = require('util');

--- a/test/pdf.spec.ts
+++ b/test/pdf.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './base.fixture';
 
 import fs from 'fs'
 import path from 'path'

--- a/test/permissions.spec.js
+++ b/test/permissions.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT, LINUX, HEADLESS} = testOptions;
 

--- a/test/popup.spec.js
+++ b/test/popup.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT, MAC} = testOptions;
 

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const socks = require('socksv5');
 const utils = require('./utils');

--- a/test/queryselector.spec.js
+++ b/test/queryselector.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const utils = require('./utils');

--- a/test/request-continue.spec.js
+++ b/test/request-continue.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const fs = require('fs');
 const path = require('path');

--- a/test/request-fulfill.spec.js
+++ b/test/request-fulfill.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const fs = require('fs');
 const path = require('path');

--- a/test/selectors-css.spec.js
+++ b/test/selectors-css.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const utils = require('./utils');

--- a/test/selectors-misc.spec.js
+++ b/test/selectors-misc.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const utils = require('./utils');

--- a/test/selectors-register.spec.js
+++ b/test/selectors-register.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const utils = require('./utils');

--- a/test/selectors-text.spec.js
+++ b/test/selectors-text.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const path = require('path');
 const utils = require('./utils');

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -8,5 +8,5 @@
         "strictNullChecks": false,
         "allowSyntheticDefaultImports": true,
     },
-    "include": ["**/*.spec.js", "types.d.ts", "**/*.spec.ts"]
+    "include": ["**/*.spec.js", "types.d.ts", "**/*.ts"]
   }

--- a/test/types.d.ts
+++ b/test/types.d.ts
@@ -61,5 +61,7 @@ declare const testOptions: {
     ASSETS_DIR: string;
 };
 
+declare const testPath : string;
+
 // keyboard.html
 declare function getResult(): string;

--- a/test/types.d.ts
+++ b/test/types.d.ts
@@ -10,13 +10,10 @@ type ItFunction<STATE> = ((name: string, inner: (state: STATE) => Promise<void>)
     repeat(n: number): ItFunction<STATE>;
 };
 
+interface WorkerState {
+}
+
 interface FixtureState {
-    parallelIndex: number;
-    http_server: {server: TestServer, httpsServer: TestServer};
-    defaultBrowserOptions: import('../index').LaunchOptions;
-    playwright: typeof import('../index');
-    browserType: import('../index').BrowserType<import('../index').Browser>;
-    browser: import('../index').Browser;
     toImpl: (rpcObject: any) => any;
     context: import('../index').BrowserContext;
     server: TestServer;
@@ -24,6 +21,7 @@ interface FixtureState {
     httpsServer: TestServer;
     browserServer: import('../index').BrowserServer;
 }
+
 
 interface TestServer {
     enableHTTPCache(pathPrefix: string);
@@ -57,18 +55,19 @@ declare const expect: typeof import('expect');
 declare const describe: DescribeFunction;
 declare const fdescribe: DescribeFunction;
 declare const xdescribe: DescribeFunction;
-declare const it: ItFunction<FixtureState>;
-declare const fit: ItFunction<FixtureState>;
-declare const dit: ItFunction<FixtureState>;
-declare const xit: ItFunction<FixtureState>;
+declare const it: ItFunction<FixtureState & WorkerState>;
+declare const fit: ItFunction<FixtureState & WorkerState>;
+declare const dit: ItFunction<FixtureState & WorkerState>;
+declare const xit: ItFunction<FixtureState & WorkerState>;
 
-declare const beforeEach: (inner: (state: FixtureState) => Promise<void>) => void;
-declare const afterEach: (inner: (state: FixtureState) => Promise<void>) => void;
-declare const beforeAll: (inner: (state: FixtureState) => Promise<void>) => void;
-declare const afterAll: (inner: (state: FixtureState) => Promise<void>) => void;
+declare const beforeEach: (inner: (state: FixtureState & WorkerState) => Promise<void>) => void;
+declare const afterEach: (inner: (state: FixtureState & WorkerState) => Promise<void>) => void;
+declare const beforeAll: (inner: (state: WorkerState) => Promise<void>) => void;
+declare const afterAll: (inner: (state: WorkerState) => Promise<void>) => void;
 
-declare const registerFixture: <T extends keyof FixtureState>(name: T, inner: (state: FixtureState, test: (arg: FixtureState[T]) => Promise<void>) => Promise<void>) => void;
-  
+declare const registerFixture: <T extends keyof FixtureState>(name: T, inner: (state: FixtureState & WorkerState, test: (arg: FixtureState[T]) => Promise<void>) => Promise<void>) => void;
+declare const registerWorkerFixture: <T extends keyof WorkerState>(name: T, inner: (state: WorkerState, test: (arg: WorkerState[T]) => Promise<void>) => Promise<void>) => void;
+
 declare const browserType: import('../index').BrowserType<import('../index').Browser>;
 
 // global variables in assets

--- a/test/types.d.ts
+++ b/test/types.d.ts
@@ -14,32 +14,8 @@ interface WorkerState {
 }
 
 interface FixtureState {
-    toImpl: (rpcObject: any) => any;
-    context: import('../index').BrowserContext;
-    server: TestServer;
-    page: import('../index').Page;
-    httpsServer: TestServer;
-    browserServer: import('../index').BrowserServer;
 }
 
-
-interface TestServer {
-    enableHTTPCache(pathPrefix: string);
-    setAuth(path: string, username: string, password: string);
-    enableGzip(path: string);
-    setCSP(path: string, csp: string);
-    stop(): Promise<void>;
-    setRoute(path: string, handler: (message: IncomingMessage, response: ServerResponse) => void);
-    setRedirect(from: string, to: string);
-    waitForRequest(path: string): Promise<IncomingMessage>;
-    reset();
-    serveFile(request: IncomingMessage, response: ServerResponse, pathName: string);
-
-    PORT: number;
-    PREFIX: string;
-    CROSS_PROCESS_PREFIX: string;
-    EMPTY_PAGE: string;
-}
 declare module '' {
     module 'expect/build/types' {
         interface Matchers<R> {

--- a/test/wait-for-function.spec.js
+++ b/test/wait-for-function.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const {FFOX, CHROMIUM, WEBKIT, CHANNEL} = testOptions;

--- a/test/wait-for-selector.spec.js
+++ b/test/wait-for-selector.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const utils = require('./utils');
 const {FFOX, CHROMIUM, WEBKIT, CHANNEL} = testOptions;

--- a/test/workers.spec.js
+++ b/test/workers.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+require('./base.fixture');
 
 const {FFOX, CHROMIUM, WEBKIT} = testOptions;
 

--- a/utils/testserver/index.d.ts
+++ b/utils/testserver/index.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export class TestServer {
+  static create(dirPath: string, port: number): Promise<TestServer>;
+  static createHTTPS(dirPath: string, port: number): Promise<TestServer>;
+  enableHTTPCache(pathPrefix: string);
+  setAuth(path: string, username: string, password: string);
+  enableGzip(path: string);
+  setCSP(path: string, csp: string);
+  stop(): Promise<void>;
+  setRoute(path: string, handler: (message: IncomingMessage, response: ServerResponse) => void);
+  setRedirect(from: string, to: string);
+  waitForRequest(path: string): Promise<IncomingMessage>;
+  reset();
+  serveFile(request: IncomingMessage, response: ServerResponse, pathName: string);
+
+  PORT: number;
+  PREFIX: string;
+  CROSS_PROCESS_PREFIX: string;
+  EMPTY_PAGE: string;
+}

--- a/utils/testserver/index.js
+++ b/utils/testserver/index.js
@@ -83,6 +83,13 @@ class TestServer {
     this._gzipRoutes = new Set();
     /** @type {!Map<string, !Promise>} */
     this._requestSubscribers = new Map();
+
+    const protocol = sslOptions ? 'https' : 'http';
+    this.PORT = port;
+    this.PREFIX = `${protocol}://localhost:${port}`;
+    this.CROSS_PROCESS_PREFIX = `${protocol}://127.0.0.1:${port}`;
+    this.EMPTY_PAGE = `${protocol}://localhost:${port}/empty.html`;
+  
   }
 
   _onSocket(socket) {


### PR DESCRIPTION
This patch moves fixtures.js to base.fixtures.ts that sits next to tests. All tests get an extra import to get the base fixtures (both types and implementations).