### PR TITLE
installer: start downloading Chromium archives from our CDN

### DIFF
--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -78,7 +78,7 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
         ['mac10.15', '%s/builds/chromium/%s/chromium-mac.zip'],
         ['win32', '%s/builds/chromium/%s/chromium-win32.zip'],
         ['win64', '%s/builds/chromium/%s/chromium-win64.zip'],
-      ]).get(platform)
+      ]).get(platform);
   }
 
   if (browserName === 'firefox') {

--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -42,30 +42,43 @@ const existsAsync = (path: string): Promise<boolean> => new Promise(resolve => f
 
 export type OnProgressCallback = (downloadedBytes: number, totalBytes: number) => void;
 
-const DEFAULT_DOWNLOAD_HOSTS: { [key: string]: string } = {
-  chromium: 'https://storage.googleapis.com',
-  firefox: 'https://playwright.azureedge.net',
-  webkit: 'https://playwright.azureedge.net',
-};
+const CHROMIUM_MOVE_TO_AZURE_CDN_REVISION = 792639;
 
-const ENV_DOWNLOAD_HOSTS: { [key: string]: string } = {
-  default: 'PLAYWRIGHT_DOWNLOAD_HOST',
-  chromium: 'PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST',
-  firefox: 'PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST',
-  webkit: 'PLAYWRIGHT_WEBKIT_DOWNLOAD_HOST',
-};
+function getDownloadHost(browserName: BrowserName, revision: number): string {
+  // Only old chromium revisions are downloaded from gbucket.
+  const defaultDownloadHost = browserName === 'chromium' && revision < CHROMIUM_MOVE_TO_AZURE_CDN_REVISION ?  'https://storage.googleapis.com' : 'https://playwright.azureedge.net';
+
+  const envDownloadHost: { [key: string]: string } = {
+    chromium: 'PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST',
+    firefox: 'PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST',
+    webkit: 'PLAYWRIGHT_WEBKIT_DOWNLOAD_HOST',
+  };
+  return getFromENV(envDownloadHost[browserName]) ||
+         getFromENV('PLAYWRIGHT_DOWNLOAD_HOST') ||
+         defaultDownloadHost;
+}
 
 function getDownloadUrl(browserName: BrowserName, revision: number, platform: BrowserPlatform): string | undefined {
   if (browserName === 'chromium') {
-    return new Map<BrowserPlatform, string>([
-      ['ubuntu18.04', '%s/chromium-browser-snapshots/Linux_x64/%d/chrome-linux.zip'],
-      ['ubuntu20.04', '%s/chromium-browser-snapshots/Linux_x64/%d/chrome-linux.zip'],
-      ['mac10.13', '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip'],
-      ['mac10.14', '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip'],
-      ['mac10.15', '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip'],
-      ['win32', '%s/chromium-browser-snapshots/Win/%d/chrome-win.zip'],
-      ['win64', '%s/chromium-browser-snapshots/Win_x64/%d/chrome-win.zip'],
-    ]).get(platform);
+    return revision < CHROMIUM_MOVE_TO_AZURE_CDN_REVISION ?
+      new Map<BrowserPlatform, string>([
+        ['ubuntu18.04', '%s/chromium-browser-snapshots/Linux_x64/%d/chrome-linux.zip'],
+        ['ubuntu20.04', '%s/chromium-browser-snapshots/Linux_x64/%d/chrome-linux.zip'],
+        ['mac10.13', '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip'],
+        ['mac10.14', '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip'],
+        ['mac10.15', '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip'],
+        ['win32', '%s/chromium-browser-snapshots/Win/%d/chrome-win.zip'],
+        ['win64', '%s/chromium-browser-snapshots/Win_x64/%d/chrome-win.zip'],
+      ]).get(platform) :
+      new Map<BrowserPlatform, string>([
+        ['ubuntu18.04', '%s/builds/chromium/%s/chromium-linux.zip'],
+        ['ubuntu20.04', '%s/builds/chromium/%s/chromium-linux.zip'],
+        ['mac10.13', '%s/builds/chromium/%s/chromium-mac.zip'],
+        ['mac10.14', '%s/builds/chromium/%s/chromium-mac.zip'],
+        ['mac10.15', '%s/builds/chromium/%s/chromium-mac.zip'],
+        ['win32', '%s/builds/chromium/%s/chromium-win32.zip'],
+        ['win64', '%s/builds/chromium/%s/chromium-win64.zip'],
+      ]).get(platform)
   }
 
   if (browserName === 'firefox') {
@@ -116,8 +129,9 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
 }
 
 function revisionURL(browser: BrowserDescriptor, platform = browserPaths.hostPlatform): string {
-  const serverHost = getFromENV(ENV_DOWNLOAD_HOSTS[browser.name]) || getFromENV(ENV_DOWNLOAD_HOSTS.default) || DEFAULT_DOWNLOAD_HOSTS[browser.name];
-  const urlTemplate = getDownloadUrl(browser.name, parseInt(browser.revision, 10), platform);
+  const revision = parseInt(browser.revision, 10);
+  const serverHost = getDownloadHost(browser.name, revision);
+  const urlTemplate = getDownloadUrl(browser.name, revision, platform);
   assert(urlTemplate, `ERROR: Playwright does not support ${browser.name} on ${platform}`);
   return util.format(urlTemplate, serverHost, browser.revision);
 }


### PR DESCRIPTION
This starts downloading newer Chromium archives from our CDN, but
retains old endpoint for older Chromium revisions.

This backwards compatibility might help later on to implement
a browser bisecting tool.

References #3259