### PR TITLE
feat(firefox): migrate to protocol-based proxy implementation

### DIFF
--- a/src/firefox/protocol.ts
+++ b/src/firefox/protocol.ts
@@ -100,14 +100,25 @@ export module Protocol {
       }[];
     };
     export type setExtraHTTPHeadersReturnValue = void;
-    export type setProxyParameters = {
+    export type setBrowserProxyParameters = {
+      type: ("http"|"https"|"socks"|"socks4");
+      bypass: string[];
+      host: string;
+      port: number;
+      username?: string;
+      password?: string;
+    };
+    export type setBrowserProxyReturnValue = void;
+    export type setContextProxyParameters = {
       browserContextId?: string;
       type: ("http"|"https"|"socks"|"socks4");
       bypass: string[];
       host: string;
       port: number;
+      username?: string;
+      password?: string;
     };
-    export type setProxyReturnValue = void;
+    export type setContextProxyReturnValue = void;
     export type setHTTPCredentialsParameters = {
       browserContextId?: string;
       credentials: {
@@ -940,7 +951,8 @@ export module Protocol {
     "Browser.close": Browser.closeParameters;
     "Browser.getInfo": Browser.getInfoParameters;
     "Browser.setExtraHTTPHeaders": Browser.setExtraHTTPHeadersParameters;
-    "Browser.setProxy": Browser.setProxyParameters;
+    "Browser.setBrowserProxy": Browser.setBrowserProxyParameters;
+    "Browser.setContextProxy": Browser.setContextProxyParameters;
     "Browser.setHTTPCredentials": Browser.setHTTPCredentialsParameters;
     "Browser.setRequestInterception": Browser.setRequestInterceptionParameters;
     "Browser.setGeolocationOverride": Browser.setGeolocationOverrideParameters;
@@ -1011,7 +1023,8 @@ export module Protocol {
     "Browser.close": Browser.closeReturnValue;
     "Browser.getInfo": Browser.getInfoReturnValue;
     "Browser.setExtraHTTPHeaders": Browser.setExtraHTTPHeadersReturnValue;
-    "Browser.setProxy": Browser.setProxyReturnValue;
+    "Browser.setBrowserProxy": Browser.setBrowserProxyReturnValue;
+    "Browser.setContextProxy": Browser.setContextProxyReturnValue;
     "Browser.setHTTPCredentials": Browser.setHTTPCredentialsReturnValue;
     "Browser.setRequestInterception": Browser.setRequestInterceptionReturnValue;
     "Browser.setGeolocationOverride": Browser.setGeolocationOverrideReturnValue;

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -65,7 +65,7 @@ export class Firefox extends BrowserTypeBase {
   }
 
   _defaultArgs(options: LaunchNonPersistentOptions, isPersistent: boolean, userDataDir: string): string[] {
-    const { args = [], proxy, devtools, headless } = options;
+    const { args = [], devtools, headless } = options;
     if (devtools)
       console.warn('devtools parameter is not supported as a launch argument in Firefox. You can launch the devtools window manually.');
     const userDataDirArg = args.find(arg => arg.startsWith('-profile') || arg.startsWith('--profile'));
@@ -73,25 +73,7 @@ export class Firefox extends BrowserTypeBase {
       throw new Error('Pass userDataDir parameter instead of specifying -profile argument');
     if (args.find(arg => arg.startsWith('-juggler')))
       throw new Error('Use the port parameter instead of -juggler argument');
-    let firefoxUserPrefs = isPersistent ? undefined : options.firefoxUserPrefs;
-    if (proxy) {
-      // TODO: we should support proxy in persistent context without overriding user prefs.
-      firefoxUserPrefs = firefoxUserPrefs || {};
-      firefoxUserPrefs['network.proxy.type'] = 1;
-      const proxyServer = new URL(proxy.server);
-      const isSocks = proxyServer.protocol === 'socks5:';
-      if (isSocks) {
-        firefoxUserPrefs['network.proxy.socks'] = proxyServer.hostname;
-        firefoxUserPrefs['network.proxy.socks_port'] = parseInt(proxyServer.port, 10);
-      } else {
-        firefoxUserPrefs['network.proxy.http'] = proxyServer.hostname;
-        firefoxUserPrefs['network.proxy.http_port'] = parseInt(proxyServer.port, 10);
-        firefoxUserPrefs['network.proxy.ssl'] = proxyServer.hostname;
-        firefoxUserPrefs['network.proxy.ssl_port'] = parseInt(proxyServer.port, 10);
-      }
-      if (proxy.bypass)
-        firefoxUserPrefs['network.proxy.no_proxies_on'] = proxy.bypass;
-    }
+    const firefoxUserPrefs = isPersistent ? undefined : options.firefoxUserPrefs;
     if (firefoxUserPrefs) {
       const lines: string[] = [];
       for (const [name, value] of Object.entries(firefoxUserPrefs))


### PR DESCRIPTION
Migrate Firefox to the protocol-based proxy implementation. 

This enables secure web proxies in firefox that are already supported by Chromium.
