### PR TITLE
docs(showcase.md): add Accessibilty Insights to community showcase

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -9,6 +9,7 @@
 * [Codex](https://github.com/codex-src/codex-app): Playwright is used to run functional and performance tests
 * [Instakittens React admin](https://github.com/fredericbonnet/instakittens-react-admin): Playwright is used to run end-to-end test scenarios written with Cucumber
 * [xterm.js](https://github.com/xtermjs/xterm.js): Playwright is used to run cross-browser integration tests
+* [Accessibility Insights for Web](https://github.com/microsoft/accessibility-insights-web): Playwright is used with Jest and axe-core to run end-to-end functional and accessibility tests of a WebExtension-based browser extension
 
 ## Tools
 


### PR DESCRIPTION
We just [migrated](https://github.com/microsoft/accessibility-insights-web/pull/3192) the end-to-end tests for [Accessibility Insights for Web](https://accessibilityinsights.io/) from Puppeteer to Playwright. This PR updates showcase.md accordingly.

Feedback on the migration: it was relatively straightforward overall. We were able to keep most existing tests unchanged and get rid of a significant chunk of helper code thanks to the actionability checks and automatic shadow DOM piercing. The work that was involved for us was:

* The default `waitForSelector` criteria being "visible" rather than "attached" required changes to a few test cases
* The actionability checks caused a previously-benign test bug to stop being benign. We have a "menu" button where the menu being opened has an overlay panel with its own second copy of the "menu" button; the test was trying to click the button to close the panel using a selector that matched the hidden, first copy of the button, which happened to work in Puppeteer because the click coordinates of the 2 buttons match, but failed in Playwright because the 2nd button was masking the click events from reaching the first button. We consider this a feature, not a bug.
* We had to rework our `Browser` wrapper to work in terms of a persisted BrowserContext, rather than a Playwright Browser
* We ripped out several test helpers related to shadow dom piercing and actionability checks
* We needed to rewrite some Options types for test helpers that we kept (in particular, we needed to repeat the definition of `EvaluateFn` to wrap `Page.evaluate`). See #2752
* We removed calls to `Page.bringToFront()`, since Playwright doesn't seem to support it. Our tests use this because we are testing a browser extension whose normal operation is to open an "assessment" window side-by-side with a "target page-under-test" window and run scans in the page under test, and since Chromium deprioritizes scripts running in non-focused pages, we see timing failures sometimes when a test needs to validate the coordination between the two pages if the test doesn't move focus between the pages.
* We rewrote the code that grabs a reference to our extension's background page in terms of the `backgroundPages()` and `on('background_page')` APIs. This was the same amount of code as the Puppeteer version that involved waiting for `target`s.