### PR TITLE
devops: re-package chromium on windows without `interactive_ui_tests.exe`

### DIFF
--- a/browser_patches/chromium/archive.sh
+++ b/browser_patches/chromium/archive.sh
@@ -31,4 +31,4 @@ fi
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname $0)"
 
-cp output/archive.zip $ZIP_PATH
+cp output/build.zip $ZIP_PATH

--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -11,12 +11,16 @@ cd output
 BUILD_NUMBER=$(head -1 ../BUILD_NUMBER)
 FOLDER_NAME=""
 ZIP_NAME=""
+FILES_TO_REMOVE=()
+
 if [[ $1 == "--win32" ]]; then
   FOLDER_NAME="Win"
   ZIP_NAME="chrome-win.zip"
+  FILES_TO_REMOVE+=("chrome-win/interactive_ui_tests.exe")
 elif [[ $1 == "--win64" ]]; then
   FOLDER_NAME="Win_x64"
   ZIP_NAME="chrome-win.zip"
+  FILES_TO_REMOVE+=("chrome-win/interactive_ui_tests.exe")
 elif [[ $1 == "--mac" ]]; then
   FOLDER_NAME="Mac"
   ZIP_NAME="chrome-mac.zip"
@@ -29,5 +33,12 @@ else
 fi
 
 URL="https://storage.googleapis.com/chromium-browser-snapshots/${FOLDER_NAME}/${BUILD_NUMBER}/${ZIP_NAME}"
-curl --output archive.zip "${URL}"
+curl --output upstream.zip "${URL}"
 
+unzip upstream.zip
+
+for file in ${FILES_TO_REMOVE[@]}; do
+  rm -f "${file}"
+done
+
+zip -r build.zip ${ZIP_NAME%.zip}


### PR DESCRIPTION
This reduces archive size from 145MB to 97MB.

Fixes #3259