### PR TITLE
chore(test): move electron tests to typescript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,6 +11,7 @@ src/firefox/protocol.ts
 src/webkit/protocol.ts
 /types/*
 /index.d.ts
+/electron-types.d.ts
 utils/generate_types/overrides.d.ts
 utils/generate_types/test/test.ts
 test/

--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,7 @@ lib/injected/
 #types
 !types/*
 !index.d.ts
+!electron-types.d.ts
 
 !index.js
 !index.mjs

--- a/electron-types.d.ts
+++ b/electron-types.d.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Logger, Page, JSHandle, ChromiumBrowserContext } from './types/types';
+import { BrowserWindow, BrowserWindowConstructorOptions } from 'electron';
+
+export type ElectronLaunchOptions = {
+  args?: string[],
+  cwd?: string,
+  env?: {[key: string]: string|number|boolean},
+  handleSIGINT?: boolean,
+  handleSIGTERM?: boolean,
+  handleSIGHUP?: boolean,
+  timeout?: number,
+  logger?: Logger,
+};
+export interface ElectronLauncher {
+  launch(executablePath: string, options?: ElectronLaunchOptions): Promise<ElectronApplication>;
+}
+export interface ElectronApplication {
+  on(event: 'window', listener: (page : ElectronPage) => void): this;
+  addListener(event: 'window', listener: (page : ElectronPage) => void): this;
+  waitForEvent(event: 'window', optionsOrPredicate?: { predicate?: (page : ElectronPage) => boolean, timeout?: number }): Promise<ElectronPage>;
+
+  on(event: 'close', listener: (exitCode? : number) => void): this;
+  addListener(event: 'close', listener: (exitCode? : number) => void): this;
+  waitForEvent(event: 'close', optionsOrPredicate?: { predicate?: (exitCode? : number) => boolean, timeout?: number }): Promise<number|undefined>;
+
+  context(): ChromiumBrowserContext;
+  windows(): ElectronPage[];
+  firstWindow(): Promise<ElectronPage>;
+  newBrowserWindow(options?: BrowserWindowConstructorOptions): Promise<ElectronPage>;
+  close(): Promise<void>;
+  evaluate: JSHandle<typeof import('electron')>['evaluate'];
+  evaluateHandle: JSHandle<typeof import('electron')>['evaluateHandle'];
+}
+export interface ElectronPage extends Page {
+  browserWindow: JSHandle<BrowserWindow>;
+}

--- a/packages/playwright-electron/index.d.ts
+++ b/packages/playwright-electron/index.d.ts
@@ -14,41 +14,7 @@
  * limitations under the License.
  */
 
-import { Logger, Page, JSHandle, ChromiumBrowserContext } from 'playwright-core/types/types';
-import { BrowserWindow, BrowserWindowConstructorOptions } from 'electron';
-
+import { ElectronLauncher } from 'playwright-core/electron-types';
 export * from 'playwright-core/types/types';
-export type ElectronLaunchOptions = {
-  args?: string[],
-  cwd?: string,
-  env?: {[key: string]: string|number|boolean},
-  handleSIGINT?: boolean,
-  handleSIGTERM?: boolean,
-  handleSIGHUP?: boolean,
-  timeout?: number,
-  logger?: Logger,
-};
-export interface ElectronLauncher {
-  launch(executablePath: string, options?: ElectronLaunchOptions): Promise<ElectronApplication>;
-}
-export interface ElectronApplication {
-  on(event: 'window', listener: (page : ElectronPage) => void): this;
-  addListener(event: 'window', listener: (page : ElectronPage) => void): this;
-  waitForEvent(event: 'window', optionsOrPredicate?: { predicate?: (page : ElectronPage) => boolean, timeout?: number }): Promise<ElectronPage>;
-
-  on(event: 'close', listener: (exitCode? : number) => void): this;
-  addListener(event: 'close', listener: (exitCode? : number) => void): this;
-  waitForEvent(event: 'close', optionsOrPredicate?: { predicate?: (exitCode? : number) => boolean, timeout?: number }): Promise<number|undefined>;
-
-  context(): ChromiumBrowserContext;
-  windows(): ElectronPage[];
-  firstWindow(): Promise<ElectronPage>;
-  newBrowserWindow(options?: BrowserWindowConstructorOptions): Promise<ElectronPage>;
-  close(): Promise<void>;
-  evaluate: JSHandle<typeof import('electron')>['evaluate'];
-  evaluateHandle: JSHandle<typeof import('electron')>['evaluateHandle'];
-}
-export interface ElectronPage extends Page {
-  browserWindow: JSHandle<BrowserWindow>;
-}
+export * from 'playwright-core/electron-types';
 export const electron: ElectronLauncher;

--- a/test/electron/electron-app.spec.ts
+++ b/test/electron/electron-app.spec.ts
@@ -13,24 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require('../base.fixture');
+import './electron.fixture';
 
-const path = require('path');
+import path from 'path';
 const electronName = process.platform === 'win32' ? 'electron.cmd' : 'electron';
 
 const { CHROMIUM } = testOptions;
 
-registerFixture('application', async ({playwright}, test) => {
-  const electronPath = path.join(__dirname, '..', '..', 'node_modules', '.bin', electronName);
-  const application = await playwright.electron.launch(electronPath, {
-    args: [path.join(__dirname, 'testApp.js')],
-  });
-  try {
-    await test(application);
-  } finally {
-    await application.close();
-  }
-});
 
 it.skip(!CHROMIUM)('should fire close event', async ({ playwright }) => {
   const electronPath = path.join(__dirname, '..', '..', 'node_modules', '.bin', electronName);
@@ -108,16 +97,15 @@ it.skip(!CHROMIUM)('should support init script', async ({ application }) => {
   await application.context().addInitScript('window.magic = 42;')
   const page = await application.newBrowserWindow({ width: 800, height: 600 });
   await page.goto('data:text/html,<script>window.copy = magic</script>');
-  expect(await page.evaluate(() => copy)).toBe(42);
+  expect(await page.evaluate(() => window['copy'])).toBe(42);
 });
 
 it.skip(!CHROMIUM)('should expose function', async ({ application }) => {
-  const result = new Promise(f => callback = f);
   const t = Date.now();
   await application.context().exposeFunction('add', (a, b) => a + b);
   const page = await application.newBrowserWindow({ width: 800, height: 600 });
   await page.goto('data:text/html,<script>window.result = add(20, 22);</script>');
-  expect(await page.evaluate(() => result)).toBe(42);
+  expect(await page.evaluate(() => window['result'])).toBe(42);
 });
 
 it.skip(!CHROMIUM)('should wait for first window', async ({ application }) => {

--- a/test/electron/electron-window.spec.ts
+++ b/test/electron/electron-window.spec.ts
@@ -13,50 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require('../base.fixture');
-
-const path = require('path');
-const electronName = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+import './electron.fixture';
 
 const { CHROMIUM } = testOptions;
-
-registerFixture('application', async ({playwright}, test) => {
-  const electronPath = path.join(__dirname, '..', '..', 'node_modules', '.bin', electronName);
-  const application = await playwright.electron.launch(electronPath, {
-    args: [path.join(__dirname, 'testApp.js')],
-  });
-  try {
-    await test(application);
-  } finally {
-    await application.close();
-  }
-});
-
-registerFixture('window', async ({application}, test) => {
-  const page = await application.newBrowserWindow({ width: 800, height: 600 });
-  try {
-    await test(page);
-  } finally {
-    await page.close();
-  }
-});
 
 it.skip(!CHROMIUM)('should click the button', async({window, server}) => {
   await window.goto(server.PREFIX + '/input/button.html');
   await window.click('button');
-  expect(await window.evaluate(() => result)).toBe('Clicked');
+  expect(await window.evaluate('result')).toBe('Clicked');
 });
 
 it.skip(!CHROMIUM)('should check the box', async({window}) => {
   await window.setContent(`<input id='checkbox' type='checkbox'></input>`);
   await window.check('input');
-  expect(await window.evaluate(() => checkbox.checked)).toBe(true);
+  expect(await window.evaluate('checkbox.checked')).toBe(true);
 });
 
 it.skip(!CHROMIUM)('should not check the checked box', async({window}) => {
   await window.setContent(`<input id='checkbox' type='checkbox' checked></input>`);
   await window.check('input');
-  expect(await window.evaluate(() => checkbox.checked)).toBe(true);
+  expect(await window.evaluate('checkbox.checked')).toBe(true);
 });
 
 it.skip(!CHROMIUM)('should type into a textarea', async({window, server}) => {

--- a/test/electron/electron.fixture.ts
+++ b/test/electron/electron.fixture.ts
@@ -1,0 +1,37 @@
+import '../base.fixture';
+import {ElectronApplication, ElectronLauncher, ElectronPage} from '../../electron-types';
+import path from 'path';
+
+const electronName = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+
+declare global {
+  interface FixtureState {
+    application: ElectronApplication;
+    window: ElectronPage;
+  }
+}
+
+declare module '../../index' {
+  const electron: ElectronLauncher
+}
+
+registerFixture('application', async ({playwright}, test) => {
+  const electronPath = path.join(__dirname, '..', '..', 'node_modules', '.bin', electronName);
+  const application = await playwright.electron.launch(electronPath, {
+    args: [path.join(__dirname, 'testApp.js')],
+  });
+  try {
+    await test(application);
+  } finally {
+    await application.close();
+  }
+});
+
+registerFixture('window', async ({application}, test) => {
+  const page = await application.newBrowserWindow({ width: 800, height: 600 });
+  try {
+    await test(page);
+  } finally {
+    await page.close();
+  }
+});


### PR DESCRIPTION
This also moves around our electron types. Instead of living in `playwright-electron`, they live in `playwright-core` and are linked to via `playwright-electron`.