### PR TITLE
fix(types): fix type generation to make ts tests work

### DIFF
--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -177,7 +177,7 @@ function classBody(classDesc) {
       for (const {eventName, params, comment, type} of eventDescriptions) {
         if (comment)
           parts.push(writeComment(comment, '  '));
-        parts.push(`  ${member.name}(event: '${eventName}', optionsOrPredicate?: { predicate?: (${params}) => boolean, timeout?: number }): Promise<${type}>;\n`);
+        parts.push(`  ${member.name}(event: '${eventName}', optionsOrPredicate?: { predicate?: (${params}) => boolean, timeout?: number } | ((${params}) => boolean)): Promise<${type}>;\n`);
       }
 
       return parts.join('\n');
@@ -232,6 +232,9 @@ function writeComment(comment, indent = '') {
 function typeToString(type, ...namespace) {
   if (!type)
     return 'void';
+  // Accessibility.snapshot has a recursive data structure, so special case it here.
+  if (namespace[0] === 'AccessibilitySnapshot' && namespace[1] === 'children')
+    return 'Array<AccessibilitySnapshot>';
   let typeString = stringifyType(parseType(type.name));
   if (type.properties.length && typeString.indexOf('Object') !== -1) {
     const name = namespace.map(n => n[0].toUpperCase() + n.substring(1)).join('');

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -399,6 +399,10 @@ playwright.chromium.launch().then(async browser => {
     });
     const assertion: AssertType<playwright.Page, typeof newPage> = true;
   }
+  {
+    const response = await page.waitForEvent('response', response => response.url() === 'asdf');
+    const assertion: AssertType<playwright.Response, typeof response> = true;
+  }
 })();
 
 // typed handles


### PR DESCRIPTION
Extracted from #3384, this fixes type definitions for `AccessibilitySnapshot.children` and `waitForEvent(name, predicate)`.