### PR TITLE
fix(launchDoctor): add sudo to install missing packages hint

### DIFF
--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -138,7 +138,7 @@ async function validateDependenciesLinux(browserPath: string, browser: BrowserDe
   if (missingPackages.size) {
     missingPackagesMessage = [
       `  Install missing packages with:`,
-      `      apt-get install ${[...missingPackages].join('\\\n          ')}`,
+      `      sudo apt-get install ${[...missingPackages].join('\\\n          ')}`,
       ``,
       ``,
     ].join('\n');


### PR DESCRIPTION
More often that not sudo is required to install packages. Adding it to the hint lets me copy and paste it into my terminal.