### PR TITLE
chore(test): remove try/finally pattern from fixtures

### DIFF
--- a/test/chromium/oopif.spec.ts
+++ b/test/chromium/oopif.spec.ts
@@ -30,20 +30,14 @@ registerFixture('sppBrowser', async ({browserType, defaultBrowserOptions}, test)
     ...defaultBrowserOptions,
     args: (defaultBrowserOptions.args || []).concat(['--site-per-process'])
   });
-  try {
-    await test(browser);
-  } finally {
-    await browser.close();
-  }
+  await test(browser);
+  await browser.close();
 });
 
 registerFixture('sppContext', async ({sppBrowser}, test) => {
   const context = await sppBrowser.newContext();
-  try {
-    await test(context);
-  } finally {
-    await context.close();
-  }
+  await test(context);
+  await context.close();
 });
 
 registerFixture('sppPage', async ({sppContext}, test) => {

--- a/test/defaultbrowsercontext.spec.ts
+++ b/test/defaultbrowsercontext.spec.ts
@@ -32,11 +32,8 @@ declare global {
 }
 registerFixture('userDataDir', async ({}, test) => {
   const userDataDir = await mkdtempAsync(path.join(os.tmpdir(), 'playwright_dev_profile-'));
-  try {
-    await test(userDataDir);
-  } finally {
-    removeFolderAsync(userDataDir).catch(e => {});
-  }
+  await test(userDataDir);
+  removeFolderAsync(userDataDir).catch(e => {});
 });
 
 registerFixture('launchPersistent', async ({userDataDir, defaultBrowserOptions, browserType}, test) => {
@@ -48,12 +45,9 @@ registerFixture('launchPersistent', async ({userDataDir, defaultBrowserOptions, 
     const page = context.pages()[0];
     return {context, page};
   }
-  try {
-    await test(launchPersistent);
-  } finally {
-    if (context)
-      await context.close();
-  }
+  await test(launchPersistent);
+  if (context)
+    await context.close();
 });
 
 it('context.cookies() should work', async ({server, launchPersistent}) => {

--- a/test/download.spec.ts
+++ b/test/download.spec.ts
@@ -30,11 +30,8 @@ declare global {
 }
 registerFixture('persistentDirectory', async ({}, test) => {
   const persistentDirectory = await mkdtempAsync(path.join(os.tmpdir(), 'playwright-test-'));
-  try {
-    await test(persistentDirectory);
-  } finally {
-    await removeFolderAsync(persistentDirectory);
-  }
+  await test(persistentDirectory);
+  await removeFolderAsync(persistentDirectory);
 });
 
 beforeEach(async ({server}) => {

--- a/test/downloads-path.spec.ts
+++ b/test/downloads-path.spec.ts
@@ -30,11 +30,8 @@ declare global {
 }
 registerFixture('downloadsPath', async ({}, test) => {
   const downloadsPath = await mkdtempAsync(path.join(os.tmpdir(), 'playwright-test-'));
-  try {
-    await test(downloadsPath);
-  } finally {
-    await removeFolderAsync(downloadsPath);
-  }
+  await test(downloadsPath);
+  await removeFolderAsync(downloadsPath);
 });
 
 registerFixture('downloadsBrowser', async ({server, browserType, defaultBrowserOptions, downloadsPath}, test) => {
@@ -47,11 +44,8 @@ registerFixture('downloadsBrowser', async ({server, browserType, defaultBrowserO
     ...defaultBrowserOptions,
     downloadsPath: downloadsPath,
   });
-  try {
-    await test(browser);
-  } finally {
-    await browser.close();
-  }
+  await test(browser);
+  await browser.close();
 });
 
 registerFixture('persistentDownloadsContext', async ({server, browserType, defaultBrowserOptions, downloadsPath}, test) => {
@@ -71,12 +65,9 @@ registerFixture('persistentDownloadsContext', async ({server, browserType, defau
   );
   const page = context.pages()[0];
   page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
-  try {
-    await test(context);
-  } finally {
-    await context.close();
-    await removeFolderAsync(userDataDir);
-  }
+  await test(context);
+  await context.close();
+  await removeFolderAsync(userDataDir);
 });
 
 it('should keep downloadsPath folder', async({downloadsBrowser, downloadsPath, server})  => {

--- a/test/electron/electron.fixture.ts
+++ b/test/electron/electron.fixture.ts
@@ -20,18 +20,12 @@ registerFixture('application', async ({playwright}, test) => {
   const application = await playwright.electron.launch(electronPath, {
     args: [path.join(__dirname, 'testApp.js')],
   });
-  try {
-    await test(application);
-  } finally {
-    await application.close();
-  }
+  await test(application);
+  await application.close();
 });
 
 registerFixture('window', async ({application}, test) => {
   const page = await application.newBrowserWindow({ width: 800, height: 600 });
-  try {
-    await test(page);
-  } finally {
-    await page.close();
-  }
+  await test(page);
+  await page.close();
 });

--- a/test/screencast.spec.ts
+++ b/test/screencast.spec.ts
@@ -33,11 +33,8 @@ declare global {
 
 registerFixture('persistentDirectory', async ({}, test) => {
   const persistentDirectory = await mkdtempAsync(path.join(os.tmpdir(), 'playwright-test-'));
-  try {
-    await test(persistentDirectory);
-  } finally {
-    await removeFolderAsync(persistentDirectory);
-  }
+  await test(persistentDirectory);
+  await removeFolderAsync(persistentDirectory);
 });
 
 registerFixture('videoPlayer', async ({playwright, context}, test) => {
@@ -48,17 +45,13 @@ registerFixture('videoPlayer', async ({playwright, context}, test) => {
     context = await firefox.newContext();
   }
 
-  let page;
-  try {
-    page = await context.newPage();
-    const player = new VideoPlayer(page);
-    await test(player);
-  } finally {
-    if (firefox)
-      await firefox.close();
-    else
-      await page.close();
-  }
+  const page = await context.newPage();
+  const player = new VideoPlayer(page);
+  await test(player);
+  if (firefox)
+    await firefox.close();
+  else
+    await page.close();
 });
 
 function almostRed(r, g, b, alpha) {


### PR DESCRIPTION
I went to remove the code that was throwing from the `test` function in fixtures, but it turns out there was none. As `test` can never throw, I removed the `try/finally` patterns wrapping it in our fixtures. Also I noticed we had a stale `harness/fixtures.js` file so I removed it.