### PR TITLE
docs: add getting help section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Playwright is a library to automate [Chromium](https://www.chromium.org/Home), [
     - [First script](./intro.md#first-script)
     - [Core concepts](./core-concepts.md)
     - [Debugging](./debug.md)
+    - [Getting help](./getting-help.md)
 1. Guides
     - [Selectors](./selectors.md)
     - [Input](./input.md)

--- a/docs/getting-help.md
+++ b/docs/getting-help.md
@@ -1,0 +1,15 @@
+# Getting help
+
+The Playwright community is active and ready to hear from you! If you get stuck,
+please use one of the following channels to ask your question:
+
+* [GitHub Issue in the Playwright Repo][gh]
+* [Playwright Slack][slack]
+* [Playwright Stack Overflow][so]
+
+If you have a **feature request**, please open a [GitHub Issue][gh] or talk to
+the community in [Slack][slack].
+
+[gh]: https://github.com/microsoft/playwright/issues/new/choose
+[slack]: https://join.slack.com/t/playwright/shared_invite/enQtOTEyMTUxMzgxMjIwLThjMDUxZmIyNTRiMTJjNjIyMzdmZDA3MTQxZWUwZTFjZjQwNGYxZGM5MzRmNzZlMWI5ZWUyOTkzMjE5Njg1NDg
+[so]: https://stackoverflow.com/tags/playwright


### PR DESCRIPTION
The Playwright Community is awesome and responsive! <3 Let's make the
community as a resource more prominent in the docs. (Currently they just
appear in a footer, but this change calls it out explicitly.)

/cc @arjun27 