### PR TITLE
docs: added initial Python reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Playwright is a library to automate [Chromium](https://www.chromium.org/Home), [
     - [First script](./intro.md#first-script)
     - [Core concepts](./core-concepts.md)
     - [Debugging](./debug.md)
+    - [Playwright for Python](./python.md)
     - [Getting help](./getting-help.md)
 1. Guides
     - [Selectors](./selectors.md)

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,0 +1,50 @@
+# Playwright for Python
+
+[Plawright Python](https://github.com/microsoft/playwright-python) is an official Python version of Playwright, it provides the full feature set of Playwright in an async (async/await) and sync version.
+
+## Installation
+
+To install the library via [pip](https://pypi.org/project/playwright/) and the browsers, you need to execute the following:
+
+```
+pip install playwright
+python -m playwright install
+```
+
+## Usage
+
+For most use cases its more convenient to use the sync variant of Playwright because then inline REPLs like pdb/ipython or the Visual Studio Code debugger automatically returns the correct value. A basic example to make a screenshot with all the browser engines would look like as follows:
+
+```py
+from playwright import sync_playwright
+
+with sync_playwright() as p:
+    for browser_type in [p.chromium, p.firefox, p.webkit]:
+        browser = browser_type.launch()
+        page = browser.newPage()
+        page.goto('http://whatsmyuseragent.org/')
+        page.screenshot(path=f'example-{browser_type.name}.png')
+        browser.close()
+```
+
+The async alternative would look like that:
+
+```py
+import asyncio
+from playwright import async_playwright
+
+async def main():
+    async with async_playwright() as p:
+        for browser_type in [p.chromium, p.firefox, p.webkit]:
+            browser = await browser_type.launch()
+            page = await browser.newPage()
+            await page.goto('http://whatsmyuseragent.org/')
+            await page.screenshot(path=f'example-{browser_type.name}.png')
+            await browser.close()
+
+asyncio.get_event_loop().run_until_complete(main())
+```
+
+## Further reference
+
+For more information about it especially about how to use the methods, evaluating JavaScript, or waiting for events you'll find a full reference in the [GitHub](https://github.com/microsoft/playwright-python#readme) repository.

--- a/docs/python.md
+++ b/docs/python.md
@@ -13,7 +13,13 @@ python -m playwright install
 
 ## Usage
 
-For most use cases its more convenient to use the sync variant of Playwright because then inline REPLs like pdb/ipython or the Visual Studio Code debugger automatically returns the correct value. A basic example to make a screenshot with all the browser engines would look like as follows:
+### Pytest
+
+Playwright can be used as a library in your application or as a part of the testing solution. We recommend using our [Pytest](https://github.com/microsoft/playwright-pytest#readme) plugin for testing.
+
+As a library, Playwright offers both blocking (synchronous) API and asyncio API (async/await). For most use cases its more convenient to use the sync variant of Playwright because then inline REPLs like pdb/ipython or the Visual Studio Code debugger automatically returns the value. You can pick the one that works best for you. They are identical in terms of capabilities and only differ in a way one consumes the API. A basic example to make a screenshot with all the browser engines would look like as follows:
+
+### Sync variant
 
 ```py
 from playwright import sync_playwright
@@ -27,7 +33,7 @@ with sync_playwright() as p:
         browser.close()
 ```
 
-The async alternative would look like that:
+### Async variant
 
 ```py
 import asyncio
@@ -44,6 +50,8 @@ async def main():
 
 asyncio.get_event_loop().run_until_complete(main())
 ```
+
+#
 
 ## Further reference
 


### PR DESCRIPTION
Until we don't mirror the entire Playwright Python readme a reference to it with a basic example seems to be fine.