### PR TITLE
devops: migrate `//utils/check_availability.js` off browser fetcher

### DIFF
--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -183,20 +183,6 @@ function toMegabytes(bytes: number) {
   return `${Math.round(mb * 10) / 10} Mb`;
 }
 
-export async function canDownload(browser: BrowserDescriptor, platform: BrowserPlatform): Promise<boolean> {
-  const url = revisionURL(browser, platform);
-  let resolve: (result: boolean) => void = () => {};
-  const promise = new Promise<boolean>(x => resolve = x);
-  const request = httpRequest(url, 'HEAD', response => {
-    resolve(response.statusCode === 200);
-  });
-  request.on('error', (error: any) => {
-    console.error(error);  // eslint-disable-line no-console
-    resolve(false);
-  });
-  return promise;
-}
-
 function downloadFile(url: string, destinationPath: string, progressCallback: OnProgressCallback | undefined): Promise<any> {
   let fulfill: () => void = () => {};
   let reject: (error: any) => void = () => {};


### PR DESCRIPTION
The script is used to check the state of chromium CDN, whereas
our browser fetcher now defaults to Playwright CDN.