### PR TITLE
fix(hover): do not require the element to be enabled before hovering

### DIFF
--- a/docs/actionability.md
+++ b/docs/actionability.md
@@ -8,7 +8,8 @@ Some actions like `page.click()` support `{force: true}` option that disable non
 
 | Actions | Performed checks |
 | ------ | ------- |
-| `check()`<br>`click()`<br>`dblclick()`<br>`hover()`<br>`uncheck()` | [Visible]<br>[Stable]<br>[Enabled]<br>[Receiving Events]<br>[Attached] |
+| `check()`<br>`click()`<br>`dblclick()`<br>`uncheck()` | [Visible]<br>[Stable]<br>[Enabled]<br>[Receiving Events]<br>[Attached] |
+| `hover()` | [Visible]<br>[Stable]<br>[Receiving Events]<br>[Attached] |
 | `fill()` | [Visible]<br>[Enabled]<br>[Editable]<br>[Attached] |
 | `dispatchEvent()`<br>`focus()`<br>`press()`<br>`setInputFiles()`<br>`selectOption()`<br>`type()` | [Attached] |
 | `scrollIntoViewIfNeeded()`<br>`screenshot()` | [Visible]<br>[Stable]<br>[Attached] |

--- a/test/mouse.spec.ts
+++ b/test/mouse.spec.ts
@@ -107,6 +107,13 @@ it('should trigger hover state', async({page, server}) => {
   expect(await page.evaluate(() => document.querySelector('button:hover').id)).toBe('button-91');
 });
 
+it('should trigger hover state on disabled button', async({page, server}) => {
+  await page.goto(server.PREFIX + '/input/scrollable.html');
+  await page.$eval('#button-6', (button: HTMLButtonElement) => button.disabled = true);
+  await page.hover('#button-6', { timeout: 5000 });
+  expect(await page.evaluate(() => document.querySelector('button:hover').id)).toBe('button-6');
+});
+
 it('should trigger hover state with removed window.Node', async({page, server}) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
   await page.evaluate(() => delete window.Node);


### PR DESCRIPTION
Fixes #3437.