### PR TITLE
fix(launchdoctor): disable launch doctor on Win7

### DIFF
--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -30,7 +30,10 @@ export async function validateHostRequirements(browserPath: string, browser: Bro
   const ubuntuVersion = await getUbuntuVersion();
   if (browser.name === 'firefox' && ubuntuVersion === '16.04')
     throw new Error(`Cannot launch firefox on Ubuntu 16.04! Minimum required Ubuntu version for Firefox browser is 18.04`);
-  await validateDependencies(browserPath, browser);
+  if (os.platform() === 'linux')
+    return await validateDependenciesLinux(browserPath, browser);
+  if (isSupportedWindowsVersion())
+    return await validateDependenciesWindows(browserPath, browser);
 }
 
 const DL_OPEN_LIBRARIES = {
@@ -39,12 +42,14 @@ const DL_OPEN_LIBRARIES = {
   firefox: [],
 };
 
-async function validateDependencies(browserPath: string, browser: BrowserDescriptor) {
-  // We currently only support Linux.
-  if (os.platform() === 'linux')
-    return await validateDependenciesLinux(browserPath, browser);
-  if (os.platform() === 'win32' && os.arch() === 'x64')
-    return await validateDependenciesWindows(browserPath, browser);
+function isSupportedWindowsVersion(): boolean {
+  if (os.platform() !== 'win32' || os.arch() !== 'x64')
+    return false;
+  const [major, minor] = os.release().split('.').map(token => parseInt(token, 10));
+  // This is based on: https://stackoverflow.com/questions/42524606/how-to-get-windows-version-using-node-js/44916050#44916050
+  // The table with versions is taken from: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexw#remarks
+  // We support launch doctor on windows 7 and above, which is encoded as `6.1`.
+  return major > 6 || (major === 6 && minor > 1);
 }
 
 async function validateDependenciesWindows(browserPath: string, browser: BrowserDescriptor) {


### PR DESCRIPTION
Windows 7 was end-of-lifed on January 14, 2020. Instead of maintaining
list of libraries on win7, let's disable launch doctor there so that
folks have chances of running there.

References #3435