### PR TITLE
chore(test): fix tests when using browser path overwrites

### DIFF
--- a/test/base.fixture.ts
+++ b/test/base.fixture.ts
@@ -46,7 +46,7 @@ declare global {
     page: Page;
     httpsServer: TestServer;
     browserServer: BrowserServer;
-  }  
+  }
 }
 
 registerWorkerFixture('parallelIndex', async ({}, test) => {
@@ -73,14 +73,19 @@ registerWorkerFixture('http_server', async ({parallelIndex}, test) => {
   ]);
 });
 
-registerWorkerFixture('defaultBrowserOptions', async({}, test) => {
-  let executablePath = undefined;
+const getExecutablePath = () => {
   if (browserName === 'chromium' && process.env.CRPATH)
-    executablePath = process.env.CRPATH;
+    return process.env.CRPATH;
   if (browserName === 'firefox' && process.env.FFPATH)
-    executablePath = process.env.FFPATH;
+    return process.env.FFPATH;
   if (browserName === 'webkit' && process.env.WKPATH)
-    executablePath = process.env.WKPATH;
+    return process.env.WKPATH;
+  return
+}
+
+registerWorkerFixture('defaultBrowserOptions', async({}, test) => {
+  let executablePath = getExecutablePath();
+
   if (executablePath)
     console.error(`Using executable at ${executablePath}`);
   await test({
@@ -134,7 +139,11 @@ registerFixture('toImpl', async ({playwright}, test) => {
 });
 
 registerWorkerFixture('browserType', async ({playwright}, test) => {
-  await test(playwright[process.env.BROWSER || 'chromium']);
+  const browserType = playwright[process.env.BROWSER || 'chromium']
+  const executablePath = getExecutablePath()
+  if (executablePath)
+    browserType._executablePath = executablePath
+  await test(browserType);
 });
 
 registerWorkerFixture('browser', async ({browserType, defaultBrowserOptions}, test) => {


### PR DESCRIPTION
When using the environment variables for overwriting the executable paths (CRPATH, FFPATH, WKPATH) some tests are broken: `browserType.executablePath should work`. Also the fixture tests then lead to unexpected behaviour: https://github.com/mxschmitt/playwright/runs/981843408#step:10:28
