### PR TITLE
devops: scheduled daily runs with latest browser revisions

### DIFF
--- a/.github/workflows/auto_roll.sh
+++ b/.github/workflows/auto_roll.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -ex
+
+browser_name="$1"
+playwright_dir="$(pwd)"
+
+function set_github_action_output_parameter {
+    echo "::set-output name=$1::$2"
+}
+
+git config --global user.email "devops@playwright.dev"
+git config --global user.name "playwright-devops"
+
+# Ensure the compiled browser will be used
+rm -rf ~/.cache/ms-playwright/
+
+set_github_action_output_parameter "FFPATH" "$(pwd)/browser_patches/firefox/checkout/obj-build-playwright/dist/bin/firefox"
+set_github_action_output_parameter "WKPATH" "$(pwd)/browser_patches/webkit/pw_run.sh"
+
+if [[ "${browser_name}" == "webkit" ]]; then
+    sudo apt install -y libharfbuzz-dev libepoxy-dev libgcrypt-dev libsoup2.4-dev libwebp-dev flatpak
+elif [[ "${browser_name}" == "firefox" ]]; then
+    sudo apt install -y autoconf2.13 libclang-dev clang
+fi
+
+./browser_patches/prepare_checkout.sh "$browser_name"
+
+if [[ "${browser_name}" == "webkit" ]]; then
+    ./browser_patches/webkit/checkout/Tools/gtk/install-dependencies
+    ./browser_patches/webkit/checkout/Tools/wpe/install-dependencies
+
+    ./browser_patches/webkit/checkout/Tools/Scripts/update-webkitwpe-libs
+    ./browser_patches/webkit/checkout/Tools/Scripts/update-webkitgtk-libs
+elif [[ "${browser_name}" == "firefox" ]]; then
+    cd browser_patches/firefox/checkout
+    SHELL=/bin/bash ./mach bootstrap --no-interactive --application-choice="Firefox for Desktop"
+    cd -
+fi
+
+if [[ "${browser_name}" == "webkit" ]]; then
+  cd ./browser_patches/webkit/checkout
+  # Rebase WebKit atop of master branch.
+  git rebase browser_upstream/master
+  cd -
+elif [[ "${browser_name}" == "firefox" ]]; then
+  cd ./browser_patches/firefox/checkout
+  # We keep firefox atop of beta branch since it's much more stable.
+  git rebase browser_upstream/beta
+  cd -
+fi
+
+echo "Building $browser_name"
+SHELL=/bin/bash "./browser_patches/$browser_name/build.sh"
+
+./browser_patches/export.sh "${browser_name}"
+
+git commit -am "feat($browser_name): roll $browser_name"

--- a/.github/workflows/auto_roll.yml
+++ b/.github/workflows/auto_roll.yml
@@ -1,0 +1,47 @@
+name: Auto browser roll
+on:
+  schedule:
+    - cron:  '0 1 * * *'
+jobs:
+  roll:
+    strategy:
+      fail-fast: false
+      matrix:
+       browser: [firefox, webkit]
+    runs-on: ubuntu-18.04
+    name: ${{ matrix.browser }}
+    steps:
+    - uses: microsoft/playwright-github-action@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 10
+    - run: npm ci
+    - run: npm run build
+    - name: Build ${{ matrix.browser }}
+      id: build-browser
+      run: bash .github/workflows/auto_roll.sh ${{ matrix.browser }}
+    - run: mkdir -p coredumps
+    # Set core dump file name pattern
+    - run: sudo bash -c 'echo "$(pwd -P)/coredumps/core-pid_%p.dump" > /proc/sys/kernel/core_pattern'
+    # XVFB-RUN merges both STDOUT and STDERR, whereas we need only STDERR
+    # Wrap `npm run` in a subshell to redirect STDERR to file.
+    # Enable core dumps in the subshell.
+    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && node test/runner test/ --jobs=1 --forbid-only --timeout=30000 && npm run coverage"
+      env:
+        BROWSER: ${{ matrix.browser }}
+        DEBUG: "pw:*,-pw:wrapped*,-pw:test*"
+        DEBUG_FILE: "testrun.log"
+        PWCHANNEL: none
+        FFPATH: ${{ steps.build-browser.outputs.FFPATH }}
+        WKPATH: ${{ steps.build-browser.outputs.WKPATH }}
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: ${{ matrix.browser }}-output
+        path: test/output-${{ matrix.browser }}
+    - uses: actions/upload-artifact@v1
+      if: ${{ always() }}
+      with:
+        name: ${{ matrix.browser }}-testrun.log
+        path: testrun.log

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -10,9 +10,6 @@ on:
       - master
       - release-*
 
-env:
-  CI: true
-
 jobs:
   doc-and-lint:
     name: "docs & lint"

--- a/.github/workflows/publish_canary_npm.yml
+++ b/.github/workflows/publish_canary_npm.yml
@@ -6,9 +6,6 @@ on:
       - master
       - release-*
 
-env:
-  CI: true
-
 jobs:
   publish-canary-npm:
     name: "publish to NPM"

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
 
-env:
-  CI: true
-
 jobs:
   publish-npm-release:
     name: "publish to NPM"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ on:
       - release-*
 
 env:
-  CI: true
   # Force terminal colors. @see https://www.npmjs.com/package/colors
   FORCE_COLOR: 1
 
@@ -38,7 +37,7 @@ jobs:
     # XVFB-RUN merges both STDOUT and STDERR, whereas we need only STDERR
     # Wrap `npm run` in a subshell to redirect STDERR to file.
     # Enable core dumps in the subshell.
-    - run: xvfb-run --auto-servernum  --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && node test/runner test/ --jobs=1 --forbid-only --timeout=30000 && npm run coverage"
+    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && node test/runner test/ --jobs=1 --forbid-only --timeout=30000 && npm run coverage"
       env:
         BROWSER: ${{ matrix.browser }}
         DEBUG: "pw:*,-pw:wrapped*,-pw:test*"
@@ -160,7 +159,7 @@ jobs:
     # XVFB-RUN merges both STDOUT and STDERR, whereas we need only STDERR
     # Wrap `npm run` in a subshell to redirect STDERR to file.
     # Enable core dumps in the subshell.
-    - run: xvfb-run --auto-servernum  --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && node test/runner test/ --jobs=1 --forbid-only --timeout=30000"
+    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && node test/runner test/ --jobs=1 --forbid-only --timeout=30000"
       if: ${{ always() }}
       env:
         BROWSER: ${{ matrix.browser }}
@@ -198,7 +197,7 @@ jobs:
     # XVFB-RUN merges both STDOUT and STDERR, whereas we need only STDERR
     # Wrap `npm run` in a subshell to redirect STDERR to file.
     # Enable core dumps in the subshell.
-    - run: xvfb-run --auto-servernum  --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && node test/runner test/ --jobs=1 --forbid-only --timeout=30000"
+    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && node test/runner test/ --jobs=1 --forbid-only --timeout=30000"
       env:
         BROWSER: ${{ matrix.browser }}
         DEBUG: "pw:*,-pw:wrapped*,-pw:test*"

--- a/browser_patches/prepare_checkout.sh
+++ b/browser_patches/prepare_checkout.sh
@@ -126,7 +126,7 @@ elif [[ ! -z "${FIREFOX_EXTRA_FOLDER_PATH}" ]]; then
   git add juggler
 fi
 
-git commit -a --author="playwright-devops <devops@playwright.com>" -m "chore: bootstrap build #$BUILD_NUMBER"
+git commit -a --author="playwright-devops <devops@playwright.dev>" -m "chore: bootstrap build #$BUILD_NUMBER"
 
 echo
 echo


### PR DESCRIPTION
Relates #3258

After a chat with @aslushnikov we add this in two iterations. The first one (this PR) is about scheduled runs for testing the latest tip-of-tree version of the browsers daily and the next PR is about opening an automated PRs once its passing (not sure if its worth to add for failing too) or sending Telegram/Slack notifications.

Current status is that Firefox (around 2 hours) and WebKit (around 3-4 hours) works.

Known issues which I fix before we merge:
- ~~Changes in `test/base.fixture.ts` will get extracted in #3453~~

Feel free to review, current blockers are before we can merge:
- ~~#3453~~
- potential git clone optimisation by aslushnikov