### PR TITLE
feat(firefox): roll firefox to r1160

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎭 Playwright
 
-[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://join.slack.com/t/playwright/shared_invite/enQtOTEyMTUxMzgxMjIwLThjMDUxZmIyNTRiMTJjNjIyMzdmZDA3MTQxZWUwZTFjZjQwNGYxZGM5MzRmNzZlMWI5ZWUyOTkzMjE5Njg1NDg) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-86.0.4217.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-79.0a1-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> [![WebKit version](https://img.shields.io/badge/webkit-14.0-blue.svg?logo=safari)](https://webkit.org/)
+[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://join.slack.com/t/playwright/shared_invite/enQtOTEyMTUxMzgxMjIwLThjMDUxZmIyNTRiMTJjNjIyMzdmZDA3MTQxZWUwZTFjZjQwNGYxZGM5MzRmNzZlMWI5ZWUyOTkzMjE5Njg1NDg) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-86.0.4217.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-80.0b8-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> [![WebKit version](https://img.shields.io/badge/webkit-14.0-blue.svg?logo=safari)](https://webkit.org/)
 
 ## [Documentation](https://playwright.dev) | [API reference](https://playwright.dev/#?path=docs/api.md)
 
@@ -10,7 +10,7 @@ Playwright is a Node.js library to automate [Chromium](https://www.chromium.org/
 |   :---   | :---: | :---: | :---:   |
 | Chromium <!-- GEN:chromium-version -->86.0.4217.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | WebKit 14.0 | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Firefox <!-- GEN:firefox-version -->79.0a1<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Firefox <!-- GEN:firefox-version -->80.0b8<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 Headless execution is supported for all the browsers on all platforms. Check out [system requirements](https://playwright.dev/#?path=docs/intro.md&q=system-requirements) for details.
 

--- a/browsers.json
+++ b/browsers.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1157",
+      "revision": "1160",
       "download": true
     },
     {

--- a/test/browsercontext-add-cookies.spec.ts
+++ b/test/browsercontext-add-cookies.spec.ts
@@ -328,7 +328,7 @@ it('should(not) block third party cookies', async({context, page, server}) => {
   }, server.CROSS_PROCESS_PREFIX + '/grid.html');
   await page.frames()[1].evaluate(`document.cookie = 'username=John Doe'`);
   await page.waitForTimeout(2000);
-  const allowsThirdParty = CHROMIUM;
+  const allowsThirdParty = CHROMIUM || FFOX;
   const cookies = await context.cookies(server.CROSS_PROCESS_PREFIX + '/grid.html');
   if (allowsThirdParty) {
     expect(cookies).toEqual([

--- a/test/browsercontext-cookies.spec.ts
+++ b/test/browsercontext-cookies.spec.ts
@@ -38,7 +38,7 @@ it('should get a cookie', async({context, page, server}) => {
     expires: -1,
     httpOnly: false,
     secure: false,
-    sameSite: FFOX ? 'Lax' : 'None',
+    sameSite: 'None',
   }]);
 });
 
@@ -60,7 +60,7 @@ it('should get a non-session cookie', async({context, page, server}) => {
     expires: date / 1000,
     httpOnly: false,
     secure: false,
-    sameSite: FFOX ? 'Lax' : 'None',
+    sameSite: 'None',
   }]);
 });
 
@@ -116,7 +116,7 @@ it('should get multiple cookies', async({context, page, server}) => {
       expires: -1,
       httpOnly: false,
       secure: false,
-      sameSite: FFOX ? 'Lax' : 'None',
+      sameSite: 'None',
     },
     {
       name: 'username',
@@ -126,7 +126,7 @@ it('should get multiple cookies', async({context, page, server}) => {
       expires: -1,
       httpOnly: false,
       secure: false,
-      sameSite: FFOX ? 'Lax' : 'None',
+      sameSite: 'None',
     },
   ]);
 });

--- a/test/defaultbrowsercontext.spec.ts
+++ b/test/defaultbrowsercontext.spec.ts
@@ -67,7 +67,7 @@ it('context.cookies() should work', async ({server, launchPersistent}) => {
     expires: -1,
     httpOnly: false,
     secure: false,
-    sameSite: FFOX ? 'Lax' : 'None',
+    sameSite: 'None',
   }]);
 });
 
@@ -128,7 +128,7 @@ it('should(not) block third party cookies', async ({server, launchPersistent}) =
     return document.cookie;
   });
   await page.waitForTimeout(2000);
-  const allowsThirdParty = CHROMIUM;
+  const allowsThirdParty = CHROMIUM || FFOX;
   expect(documentCookie).toBe(allowsThirdParty ? 'username=John Doe' : '');
   const cookies = await context.cookies(server.CROSS_PROCESS_PREFIX + '/grid.html');
   if (allowsThirdParty) {

--- a/test/headful.spec.ts
+++ b/test/headful.spec.ts
@@ -110,7 +110,7 @@ it('should(not) block third party cookies', async({browserType, defaultBrowserOp
     return document.cookie;
   });
   await page.waitForTimeout(2000);
-  const allowsThirdParty = CHROMIUM;
+  const allowsThirdParty = CHROMIUM || FFOX;
   expect(documentCookie).toBe(allowsThirdParty ? 'username=John Doe' : '');
   const cookies = await page.context().cookies(server.CROSS_PROCESS_PREFIX + '/grid.html');
   if (allowsThirdParty) {


### PR DESCRIPTION
Since this is a beta build, cookie tests are restored to the
proper non-lax-by-default behavior.

Fixes #3215