### PR TITLE
chore: move slowMo implementation to the client side

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -38,7 +38,6 @@ export type BrowserOptions = {
   downloadsPath?: string,
   headful?: boolean,
   persistent?: types.BrowserContextOptions,  // Undefined means no persistent context.
-  slowMo?: number,
   browserProcess: BrowserProcess,
   proxy?: ProxySettings,
 };

--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -21,7 +21,7 @@ import { Events as CommonEvents } from '../events';
 import { assert } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding, Worker } from '../page';
-import { ConnectionTransport, SlowMoTransport } from '../transport';
+import { ConnectionTransport } from '../transport';
 import * as types from '../types';
 import { ConnectionEvents, CRConnection, CRSession } from './crConnection';
 import { CRPage } from './crPage';
@@ -48,7 +48,7 @@ export class CRBrowser extends BrowserBase {
   private _tracingClient: CRSession | undefined;
 
   static async connect(transport: ConnectionTransport, options: BrowserOptions, devtools?: CRDevTools): Promise<CRBrowser> {
-    const connection = new CRConnection(SlowMoTransport.wrap(transport, options.slowMo), options.loggers);
+    const connection = new CRConnection(transport, options.loggers);
     const browser = new CRBrowser(connection, options);
     browser._devtools = devtools;
     const session = connection.rootSession;

--- a/src/firefox/ffBrowser.ts
+++ b/src/firefox/ffBrowser.ts
@@ -21,7 +21,7 @@ import { Events } from '../events';
 import { assert, helper, RegisteredListener } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding } from '../page';
-import { ConnectionTransport, SlowMoTransport } from '../transport';
+import { ConnectionTransport } from '../transport';
 import * as types from '../types';
 import { ConnectionEvents, FFConnection } from './ffConnection';
 import { headersArray } from './ffNetworkManager';
@@ -36,7 +36,7 @@ export class FFBrowser extends BrowserBase {
   private _version = '';
 
   static async connect(transport: ConnectionTransport, options: BrowserOptions): Promise<FFBrowser> {
-    const connection = new FFConnection(SlowMoTransport.wrap(transport, options.slowMo), options.loggers);
+    const connection = new FFConnection(transport, options.loggers);
     const browser = new FFBrowser(connection, options);
     const promises: Promise<any>[] = [
       connection.send('Browser.enable', { attachToDefaultContext: !!options.persistent }),

--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -168,7 +168,6 @@ export type BrowserTypeLaunchParams = {
   downloadsPath?: string,
   firefoxUserPrefs?: any,
   chromiumSandbox?: boolean,
-  slowMo?: number,
 };
 export type BrowserTypeLaunchOptions = {
   executablePath?: string,
@@ -194,7 +193,6 @@ export type BrowserTypeLaunchOptions = {
   downloadsPath?: string,
   firefoxUserPrefs?: any,
   chromiumSandbox?: boolean,
-  slowMo?: number,
 };
 export type BrowserTypeLaunchResult = {
   browser: BrowserChannel,
@@ -223,7 +221,6 @@ export type BrowserTypeLaunchPersistentContextParams = {
   },
   downloadsPath?: string,
   chromiumSandbox?: boolean,
-  slowMo?: number,
   noDefaultViewport?: boolean,
   viewport?: {
     width: number,
@@ -279,7 +276,6 @@ export type BrowserTypeLaunchPersistentContextOptions = {
   },
   downloadsPath?: string,
   chromiumSandbox?: boolean,
-  slowMo?: number,
   noDefaultViewport?: boolean,
   viewport?: {
     width: number,

--- a/src/rpc/client/types.ts
+++ b/src/rpc/client/types.ts
@@ -52,6 +52,7 @@ type LaunchOverrides = {
   ignoreDefaultArgs?: boolean | string[],
   env?: Env,
   logger?: LoggerSink,
+  slowMo?: number,
 };
 type FirefoxUserPrefs = {
   firefoxUserPrefs?: { [key: string]: string | number | boolean },

--- a/src/rpc/protocol.yml
+++ b/src/rpc/protocol.yml
@@ -209,7 +209,6 @@ BrowserType:
         downloadsPath: string?
         firefoxUserPrefs: json?
         chromiumSandbox: boolean?
-        slowMo: number?
       returns:
         browser: Browser
 
@@ -246,7 +245,6 @@ BrowserType:
             password: string?
         downloadsPath: string?
         chromiumSandbox: boolean?
-        slowMo: number?
         noDefaultViewport: boolean?
         viewport:
           type: object?

--- a/src/rpc/validator.ts
+++ b/src/rpc/validator.ts
@@ -124,7 +124,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     downloadsPath: tOptional(tString),
     firefoxUserPrefs: tOptional(tAny),
     chromiumSandbox: tOptional(tBoolean),
-    slowMo: tOptional(tNumber),
   });
   scheme.BrowserTypeLaunchPersistentContextParams = tObject({
     userDataDir: tString,
@@ -150,7 +149,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     })),
     downloadsPath: tOptional(tString),
     chromiumSandbox: tOptional(tBoolean),
-    slowMo: tOptional(tNumber),
     noDefaultViewport: tOptional(tBoolean),
     viewport: tOptional(tObject({
       width: tNumber,

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -107,7 +107,6 @@ export abstract class BrowserTypeBase implements BrowserType {
       await (options as any).__testHookBeforeCreateBrowser();
     const browserOptions: BrowserOptions = {
       name: this._name,
-      slowMo: options.slowMo,
       persistent,
       headful: !options.headless,
       loggers: logger,

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -44,48 +44,6 @@ export interface ConnectionTransport {
   onclose?: () => void,
 }
 
-export class SlowMoTransport implements ConnectionTransport {
-  private readonly _delay: number;
-  private readonly _delegate: ConnectionTransport;
-
-  onmessage?: (message: ProtocolResponse) => void;
-  onclose?: () => void;
-
-  static wrap(transport: ConnectionTransport, delay?: number): ConnectionTransport {
-    return delay ? new SlowMoTransport(transport, delay) : transport;
-  }
-
-  constructor(transport: ConnectionTransport, delay: number) {
-    this._delay = delay;
-    this._delegate = transport;
-    this._delegate.onmessage = this._onmessage.bind(this);
-    this._delegate.onclose = this._onClose.bind(this);
-  }
-
-  private _onmessage(message: ProtocolResponse) {
-    if (this.onmessage)
-      this.onmessage(message);
-  }
-
-  private _onClose() {
-    if (this.onclose)
-      this.onclose();
-    this._delegate.onmessage = undefined;
-    this._delegate.onclose = undefined;
-  }
-
-  send(s: ProtocolRequest) {
-    setTimeout(() => {
-      if (this._delegate.onmessage)
-        this._delegate.send(s);
-    }, this._delay);
-  }
-
-  close() {
-    this._delegate.close();
-  }
-}
-
 export class DeferWriteTransport implements ConnectionTransport {
   private _delegate: ConnectionTransport;
   private _readPromise: Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -305,7 +305,7 @@ export type LaunchOptionsBase = {
   chromiumSandbox?: boolean,
 };
 
-export type LaunchOptions = LaunchOptionsBase & { slowMo?: number };
+export type LaunchOptions = LaunchOptionsBase;
 export type LaunchServerOptions = LaunchOptionsBase & { port?: number };
 
 export type SerializedAXNode = {

--- a/src/webkit/wkBrowser.ts
+++ b/src/webkit/wkBrowser.ts
@@ -21,7 +21,7 @@ import { Events } from '../events';
 import { helper, RegisteredListener, assert } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding } from '../page';
-import { ConnectionTransport, SlowMoTransport } from '../transport';
+import { ConnectionTransport } from '../transport';
 import * as types from '../types';
 import { Protocol } from './protocol';
 import { kPageProxyMessageReceived, PageProxyMessageReceivedPayload, WKConnection, WKSession } from './wkConnection';
@@ -38,7 +38,7 @@ export class WKBrowser extends BrowserBase {
   private readonly _eventListeners: RegisteredListener[];
 
   static async connect(transport: ConnectionTransport, options: BrowserOptions): Promise<WKBrowser> {
-    const browser = new WKBrowser(SlowMoTransport.wrap(transport, options.slowMo), options);
+    const browser = new WKBrowser(transport, options);
     const promises: Promise<any>[] = [
       browser._browserSession.send('Playwright.enable'),
     ];


### PR DESCRIPTION
We now slow down sending rpc messages by slowMo on the client side.
This roughly corresponds to "every api call is slowed down".