### PR TITLE
chore: remove apiName plumbing and some unused methods from server side

### DIFF
--- a/src/browserContext.ts
+++ b/src/browserContext.ts
@@ -86,7 +86,7 @@ export abstract class BrowserContextBase extends EventEmitter implements Browser
 
   async waitForEvent(event: string, optionsOrPredicate: types.WaitForEventOptions = {}): Promise<any> {
     const options = typeof optionsOrPredicate === 'function' ? { predicate: optionsOrPredicate } : optionsOrPredicate;
-    const progressController = new ProgressController(this._apiLogger, this._timeoutSettings.timeout(options), 'browserContext.waitForEvent');
+    const progressController = new ProgressController(this._apiLogger, this._timeoutSettings.timeout(options));
     if (event !== Events.BrowserContext.Close)
       this._closePromise.then(error => progressController.abort(error));
     return progressController.run(progress => helper.waitForEvent(progress, this, event, options.predicate).promise);
@@ -191,9 +191,9 @@ export abstract class BrowserContextBase extends EventEmitter implements Browser
     if (!this.pages().length)
       await this.waitForEvent('page');
     const pages = this.pages();
-    await pages[0].waitForLoadState();
-    if (pages.length !== 1 || pages[0].url() !== 'about:blank')
-      throw new Error(`Arguments can not specify page to be opened (first url is ${pages[0].url()})`);
+    await pages[0].mainFrame().waitForLoadState();
+    if (pages.length !== 1 || pages[0].mainFrame().url() !== 'about:blank')
+      throw new Error(`Arguments can not specify page to be opened (first url is ${pages[0].mainFrame().url()})`);
     if (this._options.isMobile || this._options.locale) {
       // Workaround for:
       // - chromium fails to change isMobile for existing page;

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -223,7 +223,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async scrollIntoViewIfNeeded(options: types.TimeoutOptions = {}) {
     return this._page._runAbortableTask(
         progress => this._waitAndScrollIntoViewIfNeeded(progress),
-        this._page._timeoutSettings.timeout(options), 'elementHandle.scrollIntoViewIfNeeded');
+        this._page._timeoutSettings.timeout(options));
   }
 
   private async _waitForVisible(progress: Progress): Promise<'error:notconnected' | 'done'> {
@@ -376,7 +376,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._hover(progress, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.hover');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   _hover(progress: Progress, options: types.PointerActionOptions & types.PointerActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -387,7 +387,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._click(progress, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.click');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   _click(progress: Progress, options: types.MouseClickOptions & types.PointerActionWaitOptions & types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -398,7 +398,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._dblclick(progress, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.dblclick');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   _dblclick(progress: Progress, options: types.MouseMultiClickOptions & types.PointerActionWaitOptions & types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -409,7 +409,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._selectOption(progress, values, options);
       return throwRetargetableDOMError(result);
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.selectOption');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   async _selectOption(progress: Progress, values: string | ElementHandle | types.SelectOption | string[] | ElementHandle[] | types.SelectOption[] | null, options: types.NavigatingActionWaitOptions): Promise<string[] | 'error:notconnected'> {
@@ -444,7 +444,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._fill(progress, value, options);
       assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.fill');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   async _fill(progress: Progress, value: string, options: types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -483,14 +483,14 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       const pollHandler = new InjectedScriptPollHandler(progress, poll);
       const result = throwFatalDOMError(await pollHandler.finish());
       assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.selectText');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   async setInputFiles(files: string | types.FilePayload | string[] | types.FilePayload[], options: types.NavigatingActionWaitOptions = {}) {
     return this._page._runAbortableTask(async progress => {
       const result = await this._setInputFiles(progress, files, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.setInputFiles');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   async _setInputFiles(progress: Progress, files: string | types.FilePayload | string[] | types.FilePayload[], options: types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -517,7 +517,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._focus(progress);
       return assertDone(throwRetargetableDOMError(result));
-    }, 0, 'elementHandle.focus');
+    }, 0);
   }
 
   async _focus(progress: Progress, resetSelectionIfNotFocused?: boolean): Promise<'error:notconnected' | 'done'> {
@@ -530,7 +530,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._type(progress, text, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.type');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   async _type(progress: Progress, text: string, options: { delay?: number } & types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -549,7 +549,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._press(progress, key, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.press');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   async _press(progress: Progress, key: string, options: { delay?: number } & types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -568,14 +568,14 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._runAbortableTask(async progress => {
       const result = await this._setChecked(progress, true, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.check');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   async uncheck(options: types.PointerActionWaitOptions & types.NavigatingActionWaitOptions = {}) {
     return this._page._runAbortableTask(async progress => {
       const result = await this._setChecked(progress, false, options);
       return assertDone(throwRetargetableDOMError(result));
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.uncheck');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   async _setChecked(progress: Progress, state: boolean, options: types.PointerActionWaitOptions & types.NavigatingActionWaitOptions): Promise<'error:notconnected' | 'done'> {
@@ -596,7 +596,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async screenshot(options: types.ElementScreenshotOptions = {}): Promise<Buffer> {
     return this._page._runAbortableTask(
         progress => this._page._screenshotter.screenshotElement(progress, this, options),
-        this._page._timeoutSettings.timeout(options), 'elementHandle.screenshot');
+        this._page._timeoutSettings.timeout(options));
   }
 
   async $(selector: string): Promise<ElementHandle | null> {
@@ -655,7 +655,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       }
       const handle = result.asElement() as ElementHandle<Element>;
       return handle._adoptTo(await this._context.frame._mainContext());
-    }, this._page._timeoutSettings.timeout(options), 'elementHandle.waitForSelector');
+    }, this._page._timeoutSettings.timeout(options));
   }
 
   async _adoptTo(context: FrameExecutionContext): Promise<ElementHandle<T>> {

--- a/src/rpc/inprocess.ts
+++ b/src/rpc/inprocess.ts
@@ -18,14 +18,11 @@ import { DispatcherConnection } from './server/dispatcher';
 import type { Playwright as PlaywrightImpl } from '../server/playwright';
 import type { Playwright as PlaywrightAPI } from './client/playwright';
 import { PlaywrightDispatcher } from './server/playwrightDispatcher';
-import { setUseApiName } from '../progress';
 import { Connection } from './client/connection';
 import { isUnderTest } from '../helper';
 import { BrowserServerLauncherImpl } from './browserServerImpl';
 
 export function setupInProcess(playwright: PlaywrightImpl): PlaywrightAPI {
-  setUseApiName(false);
-
   const clientConnection = new Connection();
   const dispatcherConnection = new DispatcherConnection();
 

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -19,10 +19,7 @@ import { DispatcherConnection } from './server/dispatcher';
 import { Playwright } from '../server/playwright';
 import { PlaywrightDispatcher } from './server/playwrightDispatcher';
 import { Electron } from '../server/electron';
-import { setUseApiName } from '../progress';
 import { gracefullyCloseAll } from '../server/processLauncher';
-
-setUseApiName(false);
 
 const dispatcherConnection = new DispatcherConnection();
 const transport = new Transport(process.stdout, process.stdin);

--- a/src/rpc/server/pageDispatcher.ts
+++ b/src/rpc/server/pageDispatcher.ts
@@ -143,10 +143,6 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
   async setFileChooserInterceptedNoReply(params: { intercepted: boolean }) {
   }
 
-  async title() {
-    return await this._page.title();
-  }
-
   async keyboardDown(params: { key: string }): Promise<void> {
     await this._page.keyboard.down(params.key);
   }

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -85,8 +85,7 @@ export abstract class BrowserTypeBase implements BrowserType {
     assert(!(options as any).port, 'Cannot specify a port without launching as a server.');
     options = validateLaunchOptions(options);
     const loggers = new Loggers(options.logger);
-    const label = 'browserType.launch';
-    const browser = await runAbortableTask(progress => this._innerLaunch(progress, options, loggers, undefined), loggers.browser, TimeoutSettings.timeout(options), label).catch(e => { throw this._rewriteStartupError(e, label); });
+    const browser = await runAbortableTask(progress => this._innerLaunch(progress, options, loggers, undefined), loggers.browser, TimeoutSettings.timeout(options)).catch(e => { throw this._rewriteStartupError(e); });
     return browser;
   }
 
@@ -95,8 +94,7 @@ export abstract class BrowserTypeBase implements BrowserType {
     options = validateLaunchOptions(options);
     const persistent = validateBrowserContextOptions(options);
     const loggers = new Loggers(options.logger);
-    const label = 'browserType.launchPersistentContext';
-    const browser = await runAbortableTask(progress => this._innerLaunch(progress, options, loggers, persistent, userDataDir), loggers.browser, TimeoutSettings.timeout(options), label).catch(e => { throw this._rewriteStartupError(e, label); });
+    const browser = await runAbortableTask(progress => this._innerLaunch(progress, options, loggers, persistent, userDataDir), loggers.browser, TimeoutSettings.timeout(options)).catch(e => { throw this._rewriteStartupError(e); });
     return browser._defaultContext!;
   }
 
@@ -224,7 +222,7 @@ export abstract class BrowserTypeBase implements BrowserType {
   abstract _connectToTransport(transport: ConnectionTransport, options: BrowserOptions): Promise<BrowserBase>;
   abstract _amendEnvironment(env: Env, userDataDir: string, executable: string, browserArguments: string[]): Env;
   abstract _amendArguments(browserArguments: string[]): string[];
-  abstract _rewriteStartupError(error: Error, prefix: string): Error;
+  abstract _rewriteStartupError(error: Error): Error;
   abstract _attemptToGracefullyCloseBrowser(transport: ConnectionTransport): void;
 }
 

--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -61,13 +61,13 @@ export class Chromium extends BrowserTypeBase {
     return CRBrowser.connect(transport, options, devtools);
   }
 
-  _rewriteStartupError(error: Error, prefix: string): Error {
+  _rewriteStartupError(error: Error): Error {
     // These error messages are taken from Chromium source code as of July, 2020:
     // https://github.com/chromium/chromium/blob/70565f67e79f79e17663ad1337dc6e63ee207ce9/content/browser/zygote_host/zygote_host_impl_linux.cc
     if (!error.message.includes('crbug.com/357670') && !error.message.includes('No usable sandbox!') && !error.message.includes('crbug.com/638180'))
       return error;
     return rewriteErrorMessage(error, [
-      `${prefix}: Chromium sandboxing failed!`,
+      `Chromium sandboxing failed!`,
       `================================`,
       `To workaround sandboxing issues, do either of the following:`,
       `  - (preferred): Configure environment to support sandboxing: https://github.com/microsoft/playwright/blob/master/docs/troubleshooting.md`,

--- a/src/server/electron.ts
+++ b/src/server/electron.ts
@@ -94,7 +94,7 @@ export class ElectronApplication extends EventEmitter {
       this._windows.delete(page);
     });
     this._windows.add(page);
-    await page.waitForLoadState('domcontentloaded').catch(e => {}); // can happen after detach
+    await page.mainFrame().waitForLoadState('domcontentloaded').catch(e => {}); // can happen after detach
     this.emit(ElectronEvents.ElectronApplication.Window, page);
   }
 
@@ -136,7 +136,7 @@ export class ElectronApplication extends EventEmitter {
 
   async waitForEvent(event: string, optionsOrPredicate: types.WaitForEventOptions = {}): Promise<any> {
     const options = typeof optionsOrPredicate === 'function' ? { predicate: optionsOrPredicate } : optionsOrPredicate;
-    const progressController = new ProgressController(this._apiLogger, this._timeoutSettings.timeout(options), 'electron.waitForEvent');
+    const progressController = new ProgressController(this._apiLogger, this._timeoutSettings.timeout(options));
     if (event !== ElectronEvents.ElectronApplication.Close)
       this._browserContext._closePromise.then(error => progressController.abort(error));
     return progressController.run(progress => helper.waitForEvent(progress, this, event, options.predicate).promise);
@@ -212,6 +212,6 @@ export class Electron  {
       app = new ElectronApplication(loggers, browser, nodeConnection);
       await app._init();
       return app;
-    }, loggers.browser, TimeoutSettings.timeout(options), 'electron.launch');
+    }, loggers.browser, TimeoutSettings.timeout(options));
   }
 }

--- a/src/server/firefox.ts
+++ b/src/server/firefox.ts
@@ -36,7 +36,7 @@ export class Firefox extends BrowserTypeBase {
     return FFBrowser.connect(transport, options);
   }
 
-  _rewriteStartupError(error: Error, prefix: string): Error {
+  _rewriteStartupError(error: Error): Error {
     return error;
   }
 

--- a/src/server/webkit.ts
+++ b/src/server/webkit.ts
@@ -42,7 +42,7 @@ export class WebKit extends BrowserTypeBase {
     return browserArguments;
   }
 
-  _rewriteStartupError(error: Error, prefix: string): Error {
+  _rewriteStartupError(error: Error): Error {
     return error;
   }
 

--- a/test/page-event-crash.spec.ts
+++ b/test/page-event-crash.spec.ts
@@ -22,7 +22,7 @@ const CRASH_FAIL = (FFOX && WIN) || WIRE;
 // Firefox Win: it just doesn't crash sometimes.
 function crash(pageImpl) {
   if (CHROMIUM)
-    pageImpl.goto('chrome://crash').catch(e => {});
+    pageImpl.mainFrame().goto('chrome://crash').catch(e => {});
   else if (WEBKIT)
     pageImpl._delegate._session.send('Page.crash', {}).catch(e => {});
   else if (FFOX)


### PR DESCRIPTION
We append apiName where needed on the client instead.