### PR TITLE
feat(rpc): make sure filechooser is only intercepted when needed

### DIFF
--- a/src/rpc/client/page.ts
+++ b/src/rpc/client/page.ts
@@ -536,6 +536,22 @@ export class Page extends ChannelOwner<PageChannel, PageInitializer> {
     return this;
   }
 
+  addListener(event: string | symbol, listener: Listener): this {
+    if (event === Events.Page.FileChooser) {
+      if (!this.listenerCount(event))
+        this._channel.setFileChooserInterceptedNoReply({ intercepted: true });
+    }
+    super.addListener(event, listener);
+    return this;
+  }
+
+  off(event: string | symbol, listener: Listener): this {
+    super.off(event, listener);
+    if (event === Events.Page.FileChooser && !this.listenerCount(event))
+      this._channel.setFileChooserInterceptedNoReply({ intercepted: false });
+    return this;
+  }
+
   removeListener(event: string | symbol, listener: Listener): this {
     super.removeListener(event, listener);
     if (event === Events.Page.FileChooser && !this.listenerCount(event))

--- a/test/page-set-input-files.spec.ts
+++ b/test/page-set-input-files.spec.ts
@@ -54,10 +54,40 @@ it('should set from memory', async({page}) => {
   expect(await page.$eval('input', input => input.files[0].name)).toBe('test.txt');
 });
 
-it('should emit event', async({page, server}) => {
+it('should emit event once', async({page, server}) => {
   await page.setContent(`<input type=file>`);
   const [chooser] = await Promise.all([
     new Promise(f => page.once('filechooser', f)),
+    page.click('input'),
+  ]);
+  expect(chooser).toBeTruthy();
+});
+
+it('should emit event on/off', async({page, server}) => {
+  await page.setContent(`<input type=file>`);
+  const [chooser] = await Promise.all([
+    new Promise(f => {
+      const listener = chooser => {
+        page.off('filechooser', listener);
+        f(chooser);
+      }
+      page.on('filechooser', listener);
+    }),
+    page.click('input'),
+  ]);
+  expect(chooser).toBeTruthy();
+});
+
+it('should emit event addListener/removeListener', async({page, server}) => {
+  await page.setContent(`<input type=file>`);
+  const [chooser] = await Promise.all([
+    new Promise(f => {
+      const listener = chooser => {
+        page.removeListener('filechooser', listener);
+        f(chooser);
+      }
+      page.addListener('filechooser', listener);
+    }),
     page.click('input'),
   ]);
   expect(chooser).toBeTruthy();


### PR DESCRIPTION
So that user can choose a file manually in headful mode.

Unfortunately, I don't see how to write a test for this.