### PR TITLE
feat(screencast): add start/stop events on context

### DIFF
--- a/src/browserContext.ts
+++ b/src/browserContext.ts
@@ -15,8 +15,10 @@
  * limitations under the License.
  */
 
+import * as fs from 'fs';
 import { helper } from './helper';
 import * as network from './network';
+import * as path from 'path';
 import { Page, PageBinding } from './page';
 import { TimeoutSettings } from './timeoutSettings';
 import * as frames from './frames';
@@ -28,10 +30,20 @@ import { EventEmitter } from 'events';
 import { Progress } from './progress';
 import { DebugController } from './debug/debugController';
 
+export class Screencast {
+  readonly path: string;
+  readonly page: Page;
+  constructor(path: string, page: Page) {
+    this.path = path;
+    this.page = page;
+  }
+}
+
 export abstract class BrowserContext extends EventEmitter {
   readonly _timeoutSettings = new TimeoutSettings();
   readonly _pageBindings = new Map<string, PageBinding>();
   readonly _options: types.BrowserContextOptions;
+  _screencastOptions: types.ContextScreencastOptions | null = null;
   _requestInterceptor?: network.RouteHandler;
   private _isPersistentContext: boolean;
   private _closedStatus: 'open' | 'closing' | 'closed' = 'open';
@@ -140,6 +152,15 @@ export abstract class BrowserContext extends EventEmitter {
 
   setDefaultTimeout(timeout: number) {
     this._timeoutSettings.setDefaultTimeout(timeout);
+  }
+
+  _enableScreencast(options: types.ContextScreencastOptions) {
+    this._screencastOptions = options;
+    fs.mkdirSync(path.dirname(options.dir), {recursive: true});
+  }
+
+  _disableScreencast() {
+    this._screencastOptions = null;
   }
 
   async _loadDefaultContext(progress: Progress) {

--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -209,11 +209,11 @@ export class CRPage implements PageDelegate {
     await this._mainFrameSession._client.send('Emulation.setDefaultBackgroundColorOverride', { color });
   }
 
-  async startVideoRecording(options: types.VideoRecordingOptions): Promise<void> {
+  async startScreencast(options: types.PageScreencastOptions): Promise<void> {
     throw new Error('Not implemented');
   }
 
-  async stopVideoRecording(): Promise<void> {
+  async stopScreencast(): Promise<void> {
     throw new Error('Not implemented');
   }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -23,6 +23,8 @@ export const Events = {
   BrowserContext: {
     Close: 'close',
     Page: 'page',
+    ScreencastStarted: 'screencaststarted',
+    ScreencastStopped: 'screencaststopped',
   },
 
   BrowserServer: {

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -346,7 +346,7 @@ export class FFPage implements PageDelegate {
       throw new Error('Not implemented');
   }
 
-  async startVideoRecording(options: types.VideoRecordingOptions): Promise<void> {
+  async startScreencast(options: types.PageScreencastOptions): Promise<void> {
     this._session.send('Page.startVideoRecording', {
       file: options.outputFile,
       width: options.width,
@@ -355,7 +355,7 @@ export class FFPage implements PageDelegate {
     });
   }
 
-  async stopVideoRecording(): Promise<void> {
+  async stopScreencast(): Promise<void> {
     await this._session.send('Page.stopVideoRecording');
   }
 

--- a/src/page.ts
+++ b/src/page.ts
@@ -57,8 +57,8 @@ export interface PageDelegate {
   canScreenshotOutsideViewport(): boolean;
   resetViewport(): Promise<void>; // Only called if canScreenshotOutsideViewport() returns false.
   setBackgroundColor(color?: { r: number; g: number; b: number; a: number; }): Promise<void>;
-  startVideoRecording(options: types.VideoRecordingOptions): Promise<void>;
-  stopVideoRecording(): Promise<void>;
+  startScreencast(options: types.PageScreencastOptions): Promise<void>;
+  stopScreencast(): Promise<void>;
   takeScreenshot(format: string, documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined): Promise<Buffer>;
 
   isElementHandle(remoteObject: any): boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,11 +60,18 @@ export type ScreenshotOptions = ElementScreenshotOptions & {
   clip?: Rect,
 };
 
-export type VideoRecordingOptions = {
-  outputFile: string,
+export type ScreencastOptions = {
   width: number,
   height: number,
   scale?: number,
+};
+
+export type PageScreencastOptions = ScreencastOptions & {
+  outputFile: string,
+};
+
+export type ContextScreencastOptions = ScreencastOptions & {
+  dir: string,
 };
 
 export type URLMatch = string | RegExp | ((url: URL) => boolean);

--- a/test/runner/checkCoverage.js
+++ b/test/runner/checkCoverage.js
@@ -38,6 +38,10 @@ if (browserName !== 'chromium') {
 if (browserName === 'webkit')
   api.delete('browserContext.clearPermissions');
 
+// Screencast APIs that are not publicly available.
+api.delete('browserContext.emit("screencaststarted")');
+api.delete('browserContext.emit("screencaststopped")');
+
 const coverageDir = path.join(__dirname, '..', 'coverage-report', 'coverage');
 
 const coveredMethods = new Set();

--- a/test/screencast.spec.ts
+++ b/test/screencast.spec.ts
@@ -179,13 +179,13 @@ it.fail(options.CHROMIUM)('should capture static page', async({page, tmpDir, vid
     return;
   const videoFile = path.join(tmpDir, 'v.webm');
   await page.evaluate(() => document.body.style.backgroundColor = 'red');
-  await toImpl(page)._delegate.startVideoRecording({outputFile: videoFile, width: 640, height: 480});
+  await toImpl(page)._delegate.startScreencast({outputFile: videoFile, width: 640, height: 480});
   // TODO: in WebKit figure out why video size is not reported correctly for
   // static pictures.
   if (HEADLESS && options.WEBKIT)
     await page.setViewportSize({width: 1270, height: 950});
   await new Promise(r => setTimeout(r, 300));
-  await toImpl(page)._delegate.stopVideoRecording();
+  await toImpl(page)._delegate.stopScreencast();
   expect(fs.existsSync(videoFile)).toBe(true);
 
   await videoPlayer.load(videoFile);
@@ -205,7 +205,7 @@ it.fail(options.CHROMIUM)('should capture navigation', async({page, tmpDir, serv
     return;
   const videoFile = path.join(tmpDir, 'v.webm');
   await page.goto(server.PREFIX + '/background-color.html#rgb(0,0,0)');
-  await toImpl(page)._delegate.startVideoRecording({outputFile: videoFile, width: 640, height: 480});
+  await toImpl(page)._delegate.startScreencast({outputFile: videoFile, width: 640, height: 480});
   // TODO: in WebKit figure out why video size is not reported correctly for
   // static pictures.
   if (HEADLESS && options.WEBKIT)
@@ -213,7 +213,7 @@ it.fail(options.CHROMIUM)('should capture navigation', async({page, tmpDir, serv
   await new Promise(r => setTimeout(r, 300));
   await page.goto(server.CROSS_PROCESS_PREFIX + '/background-color.html#rgb(100,100,100)');
   await new Promise(r => setTimeout(r, 300));
-  await toImpl(page)._delegate.stopVideoRecording();
+  await toImpl(page)._delegate.stopScreencast();
   expect(fs.existsSync(videoFile)).toBe(true);
 
   await videoPlayer.load(videoFile);
@@ -239,13 +239,13 @@ it.fail(options.CHROMIUM || (options.WEBKIT && WIN))('should capture css transfo
     return;
   const videoFile = path.join(tmpDir, 'v.webm');
   await page.goto(server.PREFIX + '/rotate-z.html');
-  await toImpl(page)._delegate.startVideoRecording({outputFile: videoFile, width: 640, height: 480});
+  await toImpl(page)._delegate.startScreencast({outputFile: videoFile, width: 640, height: 480});
   // TODO: in WebKit figure out why video size is not reported correctly for
   // static pictures.
   if (HEADLESS && options.WEBKIT)
     await page.setViewportSize({width: 1270, height: 950});
   await new Promise(r => setTimeout(r, 300));
-  await toImpl(page)._delegate.stopVideoRecording();
+  await toImpl(page)._delegate.stopScreencast();
   expect(fs.existsSync(videoFile)).toBe(true);
 
   await videoPlayer.load(videoFile);
@@ -257,4 +257,27 @@ it.fail(options.CHROMIUM || (options.WEBKIT && WIN))('should capture css transfo
     const pixels = await videoPlayer.pixels({x: 95, y: 45});
     expectAll(pixels, almostRed);
   }
+});
+
+it.fail(options.CHROMIUM || options.FFOX)('should fire start/stop events when page created/closed', async({browser, tmpDir, server, toImpl}) => {
+  if (!toImpl)
+   return;
+  // Use server side of the context. All the code below also uses server side APIs.
+  const context = toImpl(await browser.newContext());
+  context._enableScreencast({width: 640, height: 480, dir: tmpDir});
+  expect(context._screencastOptions).toBeTruthy();
+
+  const [startEvent, newPage] = await Promise.all([
+    new Promise(resolve => context.on('screencaststarted', resolve)) as Promise<any>,
+    context.newPage(),
+  ]);
+  expect(startEvent.page === newPage).toBe(true);
+  expect(startEvent.path).toBeTruthy();
+
+  const [stopEvent] = await Promise.all([
+    new Promise(resolve => context.on('screencaststopped', resolve)) as Promise<any>,
+    newPage.close(),
+  ]);
+  expect(stopEvent.page === newPage).toBe(true);
+  await context.close();
 });


### PR DESCRIPTION
Introduce start/stop events on the context. Partial implementation is provided for WebKit. After offline discussion we decided to generate events in the browser too and wait in the playwright for stop events for each known started screencast before reporting the context as closed. In FF we need to add start and stop events in the browser as we cannot throttle popups there.

#1158