### PR TITLE
devops: make sure rust toolchain is installed

### DIFF
--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -48,6 +48,7 @@ else
   if command -v rustup >/dev/null; then
     # We manage Rust version ourselves.
     echo "-- Using rust v${RUST_VERSION}"
+    rustup install "${RUST_VERSION}"
     rustup default "${RUST_VERSION}"
   fi
 


### PR DESCRIPTION
Otherwise if required version is not installed the build fails with a cryptic message like
`error: toolchain '1.45.0-x86_64-unknown-linux-gnu' does not support components`