### PR TITLE
fix(rpc): add a custom toJSON to help jest's expect library

### DIFF
--- a/src/rpc/client/channelOwner.ts
+++ b/src/rpc/client/channelOwner.ts
@@ -106,6 +106,17 @@ export abstract class ChannelOwner<T extends Channel = Channel, Initializer = {}
       throw e;
     }
   }
+
+  private toJSON() {
+    // Jest's expect library tries to print objects sometimes.
+    // RPC objects can contain links to lots of other objects,
+    // which can cause jest to crash. Let's help it out
+    // by just returning the important values.
+    return {
+      _type: this._type,
+      _guid: this._guid,
+    };
+  }
 }
 
 const debugLogger = new DebugLoggerSink();

--- a/utils/doclint/check_public_api/JSBuilder.js
+++ b/utils/doclint/check_public_api/JSBuilder.js
@@ -234,6 +234,8 @@ function checkSources(sources) {
         continue;
       if (name.startsWith('_'))
         continue;
+      if (member.valueDeclaration && ts.getCombinedModifierFlags(member.valueDeclaration) & ts.ModifierFlags.Private)
+        continue;
       if (EventEmitter.prototype.hasOwnProperty(name))
         continue;
       const memberType = checker.getTypeOfSymbolAtLocation(member, member.valueDeclaration);


### PR DESCRIPTION
```js
    // Jest's expect library tries to print objects sometimes.
    // RPC objects can contain links to lots of other objects,
    // which can cause jest to crash. Let's help it out
    // by just returning the important values.
```

I looked into fixing this upstream in expect, but its not a trivial fix. Considering that they already have a special case for the JSDOM window object, I think its better that we just don't send massive objects to our users without toJSON. This should fix the crashes @yury-s was having today.