### PR TITLE
test: run tests by ordinals, not ranges

### DIFF
--- a/test/focus.spec.ts
+++ b/test/focus.spec.ts
@@ -74,6 +74,7 @@ it('should traverse focus in all directions', async function({page}) {
   await page.keyboard.press('Shift+Tab');
   expect(await page.evaluate(() => (document.activeElement as HTMLInputElement).value)).toBe('1');
 });
+
 // Chromium and WebKit both have settings for tab traversing all links, but 
 // it is only on by default in WebKit.
 it.skip(!MAC || !WEBKIT)('should traverse only form elements', async function({page}) {

--- a/test/page-goto.spec.ts
+++ b/test/page-goto.spec.ts
@@ -173,7 +173,7 @@ it('should fail when navigating to bad url', async({page, server}) => {
     expect(error.message).toContain('Invalid url');
 });
 
-it('should fail when navigating to bad SSL', async({page, httpsServer}) => {
+it('should fail when navigating to bad SSL', async({page, httpsServer, browserName}) => {
   // Make sure that network events do not emit 'undefined'.
   // @see https://crbug.com/750469
   page.on('request', request => expect(request).toBeTruthy());
@@ -181,15 +181,15 @@ it('should fail when navigating to bad SSL', async({page, httpsServer}) => {
   page.on('requestfailed', request => expect(request).toBeTruthy());
   let error = null;
   await page.goto(httpsServer.EMPTY_PAGE).catch(e => error = e);
-  utils.expectSSLError(error.message, );
+  utils.expectSSLError(browserName, error.message, );
 });
 
-it('should fail when navigating to bad SSL after redirects', async({page, server, httpsServer}) => {
+it('should fail when navigating to bad SSL after redirects', async({page, server, httpsServer, browserName}) => {
   server.setRedirect('/redirect/1.html', '/redirect/2.html');
   server.setRedirect('/redirect/2.html', '/empty.html');
   let error = null;
   await page.goto(httpsServer.PREFIX + '/redirect/1.html').catch(e => error = e);
-  utils.expectSSLError(error.message);
+  utils.expectSSLError(browserName, error.message);
 });
 
 it('should not crash when navigating to bad SSL after a cross origin navigation', async({page, server, httpsServer}) => {

--- a/test/page-wait-for-navigation.spec.ts
+++ b/test/page-wait-for-navigation.spec.ts
@@ -71,14 +71,14 @@ it('should work with clicking on anchor links', async({page, server}) => {
   expect(page.url()).toBe(server.EMPTY_PAGE + '#foobar');
 });
 
-it('should work with clicking on links which do not commit navigation', async({page, server, httpsServer}) => {
+it('should work with clicking on links which do not commit navigation', async({page, server, httpsServer, browserName}) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<a href='${httpsServer.EMPTY_PAGE}'>foobar</a>`);
   const [error] = await Promise.all([
     page.waitForNavigation().catch(e => e),
     page.click('a'),
   ]);
-  utils.expectSSLError(error.message);
+  utils.expectSSLError(browserName, error.message);
 });
 
 it('should work with history.pushState()', async({page, server}) => {

--- a/test/runner/fixtures.js
+++ b/test/runner/fixtures.js
@@ -120,6 +120,21 @@ class FixturePool {
       }
     };
   }
+
+  fixtures(callback) {
+    const result = new Set();
+    const visit  = (callback) => {
+      for (const name of fixtureParameterNames(callback)) {
+        if (name in result)
+          continue;
+        result.add(name);
+        const { fn } = registrations.get(name)
+        visit(fn);
+      }
+    };
+    visit(callback);
+    return result;
+  }
 }
 
 function fixtureParameterNames(fn) {
@@ -146,7 +161,7 @@ function registerFixture(name, fn) {
   innerRegisterFixture(name, 'test', fn);
 };
 
-function registerWorkerFixture (name, fn) {
+function registerWorkerFixture(name, fn) {
   innerRegisterFixture(name, 'worker', fn);
 };
 

--- a/test/runner/fixturesUI.js
+++ b/test/runner/fixturesUI.js
@@ -81,6 +81,7 @@ function fixturesUI(testRunner, suite) {
         wrapper.__original = fn;
       }
       const test = new Test(title, wrapper);
+      test.__fixtures = fixturePool.fixtures(fn);
       test.file = file;
       suite.addTest(test);
       const only = specs.only && specs.only[0];

--- a/test/runner/index.js
+++ b/test/runner/index.js
@@ -43,7 +43,7 @@ program
     let total = 0;
     // Build the test model, suite per file.
     for (const file of files) {
-      const testRunner = new TestRunner(file, 0, {
+      const testRunner = new TestRunner(file, [], {
         forbidOnly: command.forbidOnly || undefined,
         grep: command.grep,
         reporter: NullReporter,

--- a/test/runner/worker.js
+++ b/test/runner/worker.js
@@ -62,7 +62,7 @@ process.on('message', async message => {
     return;
   }
   if (message.method === 'run') {
-    const testRunner = new TestRunner(message.params.file, message.params.startOrdinal, message.params.options);
+    const testRunner = new TestRunner(message.params.file, message.params.ordinals, message.params.options);
     for (const event of ['test', 'pending', 'pass', 'fail', 'done'])
       testRunner.on(event, sendMessageToParent.bind(null, event));
     await testRunner.run();

--- a/test/utils.js
+++ b/test/utils.js
@@ -23,7 +23,6 @@ const removeFolder = require('rimraf');
 
 const {FlakinessDashboard} = require('../utils/flakiness-dashboard');
 const PROJECT_ROOT = fs.existsSync(path.join(__dirname, '..', 'package.json')) ? path.join(__dirname, '..') : path.join(__dirname, '..', '..');
-const browserName = process.env.BROWSER || 'chromium';
 
 let platform = os.platform();
 
@@ -227,7 +226,7 @@ const utils = module.exports = {
     return logger;
   },
 
-  expectSSLError(errorMessage) {
+  expectSSLError(browserName, errorMessage) {
     if (browserName === 'chromium') {
       expect(errorMessage).toContain('net::ERR_CERT_AUTHORITY_INVALID');
     } else if (browserName === 'webkit') {


### PR DESCRIPTION
This is required for the test generator - if we'd like to generate tests for each `browserName` fixture value, we would need to cherry-pick the tests that we run in the matrix mode. This would require updating the worker hash logic to be per test, not per file.