### PR TITLE
fix(testrunner): do not override debug.log

### DIFF
--- a/test/runner/runner.js
+++ b/test/runner/runner.js
@@ -219,9 +219,6 @@ class OopWorker extends EventEmitter {
         process.stderr.write(chunk);
       this.stderr.push(chunk);
     });
-    this.on('debug', data => {
-      process.stderr.write(data + '\n');
-    });
   }
 
   async init() {

--- a/test/runner/worker.js
+++ b/test/runner/worker.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-const debug = require('debug');
 const { fixturePool } = require('./fixturesUI');
 const { gracefullyCloseAll } = require('../../lib/server/processLauncher');
 const { TestRunner, initializeImageMatcher } = require('./testRunner');
@@ -40,10 +39,6 @@ process.stdout.write = chunk => {
 
 process.stderr.write = chunk => {
   sendMessageToParent('stderr', chunkToParams(chunk));
-};
-
-debug.log = data => {
-  sendMessageToParent('debug', data);
 };
 
 process.on('disconnect', gracefullyCloseAndExit);


### PR DESCRIPTION
Otherwise, our DEBUG_FILE is ignored and we dump all DEBUG on the bots.