### PR TITLE
chore: use HeadersArray instead of Headers object on the server side

### DIFF
--- a/src/chromium/crBrowser.ts
+++ b/src/chromium/crBrowser.ts
@@ -387,8 +387,8 @@ export class CRBrowserContext extends BrowserContextBase {
       await (page._delegate as CRPage).updateGeolocation();
   }
 
-  async setExtraHTTPHeaders(headers: types.Headers): Promise<void> {
-    this._options.extraHTTPHeaders = network.verifyHeaders(headers);
+  async setExtraHTTPHeaders(headers: types.HeadersArray): Promise<void> {
+    this._options.extraHTTPHeaders = headers;
     for (const page of this.pages())
       await (page._delegate as CRPage).updateExtraHTTPHeaders();
   }

--- a/src/chromium/crNetworkManager.ts
+++ b/src/chromium/crNetworkManager.ts
@@ -23,6 +23,7 @@ import * as network from '../network';
 import * as frames from '../frames';
 import * as types from '../types';
 import { CRPage } from './crPage';
+import { headersObjectToArray } from '../converters';
 
 export class CRNetworkManager {
   private _client: CRSession;
@@ -239,7 +240,7 @@ export class CRNetworkManager {
       const response = await this._client.send('Network.getResponseBody', { requestId: request._requestId });
       return Buffer.from(response.body, response.base64Encoded ? 'base64' : 'utf8');
     };
-    return new network.Response(request.request, responsePayload.status, responsePayload.statusText, headersObject(responsePayload.headers), getResponseBody);
+    return new network.Response(request.request, responsePayload.status, responsePayload.statusText, headersObjectToArray(responsePayload.headers), getResponseBody);
   }
 
   _handleRequestRedirect(request: InterceptableRequest, responsePayload: Protocol.Network.Response) {
@@ -350,7 +351,7 @@ class InterceptableRequest implements network.RouteDelegate {
     if (postDataEntries && postDataEntries.length && postDataEntries[0].bytes)
       postDataBuffer = Buffer.from(postDataEntries[0].bytes, 'base64');
 
-    this.request = new network.Request(allowInterception ? this : null, frame, redirectedFrom, documentId, url, type, method, postDataBuffer, headersObject(headers));
+    this.request = new network.Request(allowInterception ? this : null, frame, redirectedFrom, documentId, url, type, method, postDataBuffer, headersObjectToArray(headers));
   }
 
   async continue(overrides: types.NormalizedContinueOverrides) {
@@ -406,11 +407,3 @@ const errorReasons: { [reason: string]: Protocol.Network.ErrorReason } = {
   'timedout': 'TimedOut',
   'failed': 'Failed',
 };
-
-function headersObject(headers: Protocol.Network.Headers): types.Headers {
-  const result: types.Headers = {};
-  for (const key of Object.keys(headers))
-    result[key.toLowerCase()] = headers[key];
-  return result;
-}
-

--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -37,6 +37,7 @@ import * as types from '../types';
 import { ConsoleMessage } from '../console';
 import * as sourceMap from '../utils/sourceMap';
 import { rewriteErrorMessage } from '../utils/stackTrace';
+import { headersArrayToObject } from '../converters';
 
 
 const UTILITY_WORLD_NAME = '__playwright_utility_world__';
@@ -729,7 +730,7 @@ class FrameSession {
       this._crPage._browserContext._options.extraHTTPHeaders,
       this._page._state.extraHTTPHeaders
     ]);
-    await this._client.send('Network.setExtraHTTPHeaders', { headers });
+    await this._client.send('Network.setExtraHTTPHeaders', { headers: headersArrayToObject(headers, false /* lowerCase */) });
   }
 
   async _updateGeolocation(): Promise<void> {

--- a/src/firefox/ffNetworkManager.ts
+++ b/src/firefox/ffNetworkManager.ts
@@ -75,10 +75,7 @@ export class FFNetworkManager {
         throw new Error(`Response body for ${request.request.method()} ${request.request.url()} was evicted!`);
       return Buffer.from(response.base64body, 'base64');
     };
-    const headers: types.Headers = {};
-    for (const {name, value} of event.headers)
-      headers[name.toLowerCase()] = value;
-    const response = new network.Response(request.request, event.status, event.statusText, headers, getResponseBody);
+    const response = new network.Response(request.request, event.status, event.statusText, event.headers, getResponseBody);
     this._page._frameManager.requestReceivedResponse(response);
   }
 
@@ -150,14 +147,11 @@ class InterceptableRequest implements network.RouteDelegate {
     this._id = payload.requestId;
     this._session = session;
 
-    const headers: types.Headers = {};
-    for (const {name, value} of payload.headers)
-      headers[name.toLowerCase()] = value;
     let postDataBuffer = null;
     if (payload.postData)
       postDataBuffer = Buffer.from(payload.postData, 'base64');
     this.request = new network.Request(payload.isIntercepted ? this : null, frame, redirectedFrom ? redirectedFrom.request : null, payload.navigationId,
-        payload.url, internalCauseToResourceType[payload.internalCause] || causeToResourceType[payload.cause] || 'other', payload.method, postDataBuffer, headers);
+        payload.url, internalCauseToResourceType[payload.internalCause] || causeToResourceType[payload.cause] || 'other', payload.method, postDataBuffer, payload.headers);
   }
 
   async continue(overrides: types.NormalizedContinueOverrides) {
@@ -187,13 +181,4 @@ class InterceptableRequest implements network.RouteDelegate {
       errorCode,
     });
   }
-}
-
-export function headersArray(headers: types.Headers): Protocol.Network.HTTPHeader[] {
-  const result: Protocol.Network.HTTPHeader[] = [];
-  for (const name in headers) {
-    if (!Object.is(headers[name], undefined))
-      result.push({name, value: headers[name] + ''});
-  }
-  return result;
 }

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -28,7 +28,7 @@ import { FFBrowserContext } from './ffBrowser';
 import { FFSession, FFSessionEvents } from './ffConnection';
 import { FFExecutionContext } from './ffExecutionContext';
 import { RawKeyboardImpl, RawMouseImpl } from './ffInput';
-import { FFNetworkManager, headersArray } from './ffNetworkManager';
+import { FFNetworkManager } from './ffNetworkManager';
 import { Protocol } from './protocol';
 import { selectors } from '../selectors';
 import { rewriteErrorMessage } from '../utils/stackTrace';
@@ -272,7 +272,7 @@ export class FFPage implements PageDelegate {
   }
 
   async updateExtraHTTPHeaders(): Promise<void> {
-    await this._session.send('Network.setExtraHTTPHeaders', { headers: headersArray(this._page._state.extraHTTPHeaders || {}) });
+    await this._session.send('Network.setExtraHTTPHeaders', { headers: this._page._state.extraHTTPHeaders || [] });
   }
 
   async setViewportSize(viewportSize: types.Size): Promise<void> {

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -428,8 +428,9 @@ export class Frame {
     return runNavigationTask(this, options, async progress => {
       const waitUntil = verifyLifecycle('waitUntil', options.waitUntil === undefined ? 'load' : options.waitUntil);
       progress.log(`navigating to "${url}", waiting until "${waitUntil}"`);
-      const headers = (this._page._state.extraHTTPHeaders || {});
-      let referer = headers['referer'] || headers['Referer'];
+      const headers = this._page._state.extraHTTPHeaders || [];
+      const refererHeader = headers.find(h => h.name === 'referer' || h.name === 'Referer');
+      let referer = refererHeader ? refererHeader.value : undefined;
       if (options.referer !== undefined) {
         if (referer !== undefined && referer !== options.referer)
           throw new Error('"referer" is already specified as extra HTTP header');

--- a/src/page.ts
+++ b/src/page.ts
@@ -87,7 +87,7 @@ type PageState = {
   viewportSize: types.Size | null;
   mediaType: types.MediaType | null;
   colorScheme: types.ColorScheme | null;
-  extraHTTPHeaders: types.Headers | null;
+  extraHTTPHeaders: types.HeadersArray | null;
 };
 
 export class Page extends EventEmitter {
@@ -214,8 +214,8 @@ export class Page extends EventEmitter {
     await this._delegate.exposeBinding(binding);
   }
 
-  setExtraHTTPHeaders(headers: types.Headers) {
-    this._state.extraHTTPHeaders = network.verifyHeaders(headers);
+  setExtraHTTPHeaders(headers: types.HeadersArray) {
+    this._state.extraHTTPHeaders = headers;
     return this._delegate.updateExtraHTTPHeaders();
   }
 

--- a/src/rpc/client/browser.ts
+++ b/src/rpc/client/browser.ts
@@ -22,6 +22,7 @@ import { Events } from './events';
 import { BrowserType } from './browserType';
 import { headersObjectToArray } from '../../converters';
 import { BrowserContextOptions } from './types';
+import { validateHeaders } from './network';
 
 export class Browser extends ChannelOwner<BrowserChannel, BrowserInitializer> {
   readonly _contexts = new Set<BrowserContext>();
@@ -47,8 +48,9 @@ export class Browser extends ChannelOwner<BrowserChannel, BrowserInitializer> {
 
   async newContext(options: BrowserContextOptions = {}): Promise<BrowserContext> {
     const logger = options.logger;
-    options = { ...options, logger: undefined };
     return this._wrapApiCall('browser.newContext', async () => {
+      if (options.extraHTTPHeaders)
+        validateHeaders(options.extraHTTPHeaders);
       const contextOptions: BrowserNewContextParams = {
         ...options,
         viewport: options.viewport === null ? undefined : options.viewport,

--- a/src/rpc/client/browserContext.ts
+++ b/src/rpc/client/browserContext.ts
@@ -147,6 +147,7 @@ export class BrowserContext extends ChannelOwner<BrowserContextChannel, BrowserC
 
   async setExtraHTTPHeaders(headers: Headers): Promise<void> {
     return this._wrapApiCall('browserContext.setExtraHTTPHeaders', async () => {
+      network.validateHeaders(headers);
       await this._channel.setExtraHTTPHeaders({ headers: headersObjectToArray(headers) });
     });
   }

--- a/src/rpc/client/browserType.ts
+++ b/src/rpc/client/browserType.ts
@@ -28,6 +28,7 @@ import { Events } from './events';
 import { TimeoutSettings } from '../../timeoutSettings';
 import { ChildProcess } from 'child_process';
 import { envObjectToArray } from './clientHelper';
+import { validateHeaders } from './network';
 
 export interface BrowserServerLauncher {
   launchServer(options?: LaunchServerOptions): Promise<BrowserServer>;
@@ -88,6 +89,8 @@ export class BrowserType extends ChannelOwner<BrowserTypeChannel, BrowserTypeIni
     const logger = options.logger;
     options = { ...options, logger: undefined };
     return this._wrapApiCall('browserType.launchPersistentContext', async () => {
+      if (options.extraHTTPHeaders)
+        validateHeaders(options.extraHTTPHeaders);
       const persistentOptions: BrowserTypeLaunchPersistentContextParams = {
         ...options,
         viewport: options.viewport === null ? undefined : options.viewport,

--- a/src/rpc/client/page.ts
+++ b/src/rpc/client/page.ts
@@ -32,7 +32,7 @@ import { Worker } from './worker';
 import { Frame, FunctionWithSource, verifyLoadState, WaitForNavigationOptions } from './frame';
 import { Keyboard, Mouse } from './input';
 import { assertMaxArguments, Func1, FuncOn, SmartHandle, serializeArgument, parseResult } from './jsHandle';
-import { Request, Response, Route, RouteHandler } from './network';
+import { Request, Response, Route, RouteHandler, validateHeaders } from './network';
 import { FileChooser } from './fileChooser';
 import { Buffer } from 'buffer';
 import { ChromiumCoverage } from './chromiumCoverage';
@@ -291,6 +291,7 @@ export class Page extends ChannelOwner<PageChannel, PageInitializer> {
 
   async setExtraHTTPHeaders(headers: Headers) {
     return this._wrapApiCall('page.setExtraHTTPHeaders', async () => {
+      validateHeaders(headers);
       await this._channel.setExtraHTTPHeaders({ headers: headersObjectToArray(headers) });
     });
   }

--- a/src/rpc/server/browserContextDispatcher.ts
+++ b/src/rpc/server/browserContextDispatcher.ts
@@ -24,7 +24,6 @@ import { RouteDispatcher, RequestDispatcher } from './networkDispatchers';
 import { CRBrowserContext } from '../../chromium/crBrowser';
 import { CDPSessionDispatcher } from './cdpSessionDispatcher';
 import { Events as ChromiumEvents } from '../../chromium/events';
-import { headersArrayToObject } from '../../converters';
 
 export class BrowserContextDispatcher extends Dispatcher<BrowserContext, BrowserContextInitializer> implements BrowserContextChannel {
   private _context: BrowserContextBase;
@@ -96,7 +95,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, Browser
   }
 
   async setExtraHTTPHeaders(params: { headers: types.HeadersArray }): Promise<void> {
-    await this._context.setExtraHTTPHeaders(headersArrayToObject(params.headers));
+    await this._context.setExtraHTTPHeaders(params.headers);
   }
 
   async setOffline(params: { offline: boolean }): Promise<void> {

--- a/src/rpc/server/browserDispatcher.ts
+++ b/src/rpc/server/browserDispatcher.ts
@@ -23,7 +23,6 @@ import { CDPSessionDispatcher } from './cdpSessionDispatcher';
 import { Dispatcher, DispatcherScope } from './dispatcher';
 import { CRBrowser } from '../../chromium/crBrowser';
 import { PageDispatcher } from './pageDispatcher';
-import { headersArrayToObject } from '../../converters';
 
 export class BrowserDispatcher extends Dispatcher<Browser, BrowserInitializer> implements BrowserChannel {
   constructor(scope: DispatcherScope, browser: BrowserBase, guid?: string) {
@@ -37,11 +36,7 @@ export class BrowserDispatcher extends Dispatcher<Browser, BrowserInitializer> i
   }
 
   async newContext(params: BrowserNewContextParams): Promise<{ context: BrowserContextChannel }> {
-    const options = {
-      ...params,
-      extraHTTPHeaders: params.extraHTTPHeaders ? headersArrayToObject(params.extraHTTPHeaders) : undefined,
-    };
-    return { context: new BrowserContextDispatcher(this._scope, await this._object.newContext(options) as BrowserContextBase) };
+    return { context: new BrowserContextDispatcher(this._scope, await this._object.newContext(params) as BrowserContextBase) };
   }
 
   async close(): Promise<void> {

--- a/src/rpc/server/browserTypeDispatcher.ts
+++ b/src/rpc/server/browserTypeDispatcher.ts
@@ -21,7 +21,6 @@ import { BrowserChannel, BrowserTypeChannel, BrowserContextChannel, BrowserTypeI
 import { Dispatcher, DispatcherScope } from './dispatcher';
 import { BrowserContextBase } from '../../browserContext';
 import { BrowserContextDispatcher } from './browserContextDispatcher';
-import { headersArrayToObject } from '../../converters';
 
 export class BrowserTypeDispatcher extends Dispatcher<BrowserType, BrowserTypeInitializer> implements BrowserTypeChannel {
   constructor(scope: DispatcherScope, browserType: BrowserTypeBase) {
@@ -37,11 +36,7 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, BrowserTypeIn
   }
 
   async launchPersistentContext(params: BrowserTypeLaunchPersistentContextParams): Promise<{ context: BrowserContextChannel }> {
-    const options = {
-      ...params,
-      extraHTTPHeaders: params.extraHTTPHeaders ? headersArrayToObject(params.extraHTTPHeaders) : undefined,
-    };
-    const browserContext = await this._object.launchPersistentContext(params.userDataDir, options);
+    const browserContext = await this._object.launchPersistentContext(params.userDataDir, params);
     return { context: new BrowserContextDispatcher(this._scope, browserContext as BrowserContextBase) };
   }
 }

--- a/src/rpc/server/pageDispatcher.ts
+++ b/src/rpc/server/pageDispatcher.ts
@@ -23,7 +23,6 @@ import * as types from '../../types';
 import { BindingCallChannel, BindingCallInitializer, ElementHandleChannel, PageChannel, PageInitializer, ResponseChannel, WorkerInitializer, WorkerChannel, JSHandleChannel, Binary, SerializedArgument, PagePdfParams, SerializedError, PageAccessibilitySnapshotResult, SerializedValue, PageEmulateMediaParams, AXNode } from '../channels';
 import { Dispatcher, DispatcherScope, lookupDispatcher, lookupNullableDispatcher } from './dispatcher';
 import { parseError, serializeError } from '../serializers';
-import { headersArrayToObject } from '../../converters';
 import { ConsoleMessageDispatcher } from './consoleMessageDispatcher';
 import { DialogDispatcher } from './dialogDispatcher';
 import { DownloadDispatcher } from './downloadDispatcher';
@@ -92,7 +91,7 @@ export class PageDispatcher extends Dispatcher<Page, PageInitializer> implements
   }
 
   async setExtraHTTPHeaders(params: { headers: types.HeadersArray }): Promise<void> {
-    await this._page.setExtraHTTPHeaders(headersArrayToObject(params.headers));
+    await this._page.setExtraHTTPHeaders(params.headers);
   }
 
   async reload(params: types.NavigateOptions): Promise<{ response?: ResponseChannel }> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,18 +208,10 @@ export type MouseMultiClickOptions = PointerActionOptions & {
 
 export type World = 'main' | 'utility';
 
-export type Headers = { [key: string]: string };
 export type HeadersArray = { name: string, value: string }[];
 
 export type GotoOptions = NavigateOptions & {
   referer?: string,
-};
-
-export type FulfillResponse = {
-  status?: number,
-  headers?: Headers,
-  contentType?: string,
-  body?: string | Buffer,
 };
 
 export type NormalizedFulfillResponse = {
@@ -227,12 +219,6 @@ export type NormalizedFulfillResponse = {
   headers: HeadersArray,
   body: string,
   isBase64: boolean,
-};
-
-export type ContinueOverrides = {
-  method?: string,
-  headers?: Headers,
-  postData?: string | Buffer,
 };
 
 export type NormalizedContinueOverrides = {
@@ -275,7 +261,7 @@ export type BrowserContextOptions = {
   timezoneId?: string,
   geolocation?: Geolocation,
   permissions?: string[],
-  extraHTTPHeaders?: Headers,
+  extraHTTPHeaders?: HeadersArray,
   offline?: boolean,
   httpCredentials?: Credentials,
   deviceScaleFactor?: number,

--- a/src/webkit/wkBrowser.ts
+++ b/src/webkit/wkBrowser.ts
@@ -293,8 +293,8 @@ export class WKBrowserContext extends BrowserContextBase {
     await this._browser._browserSession.send('Playwright.setGeolocationOverride', { browserContextId: this._browserContextId, geolocation: payload });
   }
 
-  async setExtraHTTPHeaders(headers: types.Headers): Promise<void> {
-    this._options.extraHTTPHeaders = network.verifyHeaders(headers);
+  async setExtraHTTPHeaders(headers: types.HeadersArray): Promise<void> {
+    this._options.extraHTTPHeaders = headers;
     for (const page of this.pages())
       await (page._delegate as WKPage).updateExtraHTTPHeaders();
   }

--- a/test/network-response.spec.ts
+++ b/test/network-response.spec.ts
@@ -22,10 +22,13 @@ import path from 'path';
 it('should work', async({page, server}) => {
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('foo', 'bar');
+    res.setHeader('BaZ', 'bAz');
     res.end();
   });
   const response = await page.goto(server.EMPTY_PAGE);
   expect(response.headers()['foo']).toBe('bar');
+  expect(response.headers()['baz']).toBe('bAz');
+  expect(response.headers()['BaZ']).toBe(undefined);
 });
 
 


### PR DESCRIPTION
This simplifies implementation and avoids multiple conversions.
Also adding some tests around lowercase and wrong types.