### PR TITLE
enh: bake browser revisions into driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "roll-browser": "node utils/roll_browser.js",
     "coverage": "node test/checkCoverage.js",
     "check-deps": "node utils/check_deps.js",
-    "build-driver": "pkg --public --targets node12-linux-x64,node12-macos-x64,node12-win-x64 --out-path=drivers packages/playwright-driver/main.js",
     "build-testrunner": "tsc -p test-runner",
     "test-testrunner": "node test-runner/cli test-runner/test"
   },

--- a/packages/playwright-driver/.gitignore
+++ b/packages/playwright-driver/.gitignore
@@ -1,0 +1,1 @@
+api.json

--- a/packages/playwright-driver/main.js
+++ b/packages/playwright-driver/main.js
@@ -19,21 +19,53 @@ const fs = require('fs');
 const os = require('os');
 const util = require('util');
 
+const readFileAsync = util.promisify(fs.readFile);
+const writeFileAsync = util.promisify(fs.writeFile);
+
 (async () => {
+  if (process.argv.length === 2 || process.argv.some(arg => arg.includes('--help'))) {
+    console.log(`Usage:
+      './driver --print-api' - Prints the Playwright API to the stdout
+      './driver --print-readme'    - Prints the upstream Playwright README
+      './driver --install'   - Downloads the Playwright browsers
+      './driver --run'       - Executes the Playwright RPC server
+    `);
+    return;
+  }
+  // Playwright needs to launch the PrintDeps.exe which is embedded into the NPM package.
+  // Since it's packed with PKG, we have to move it out and set the new path as an environment
+  // variable so Playwright can use it.
   if (os.platform() === 'win32') {
-    const checkDbPath = path.join(__dirname, 'node_modules', 'playwright', 'bin', 'PrintDeps.exe')
+    const printDepsPath = path.join(__dirname, '..', '..', 'bin', 'PrintDeps.exe');
 
-    const content = await util.promisify(fs.readFile)(checkDbPath);
-    const output = path.join(os.tmpdir(), 'ms-playwright-print-deps.exe')
-    await util.promisify(fs.writeFile)(output, content)
+    const printDepsFile = await readFileAsync(printDepsPath);
+    const pwPrintDepsPath = path.join(os.tmpdir(), 'ms-playwright-print-deps.exe');
+    await writeFileAsync(pwPrintDepsPath, printDepsFile);
 
-    process.env.PW_PRINT_DEPS_WINDOWS_EXECUTABLE = output
+    process.env.PW_PRINT_DEPS_WINDOWS_EXECUTABLE = pwPrintDepsPath;
   }
 
-  if (process.argv.includes('install')) {
-    await require('../../lib/install/installer').installBrowsersWithProgressBar(path.dirname(process.argv[0]));
+  if (process.argv[2] === '--print-api') {
+    console.log((await readFileAsync(path.join(__dirname, 'api.json'))).toString());
     return;
   }
 
-  require('../../lib/server');
+  if (process.argv[2] === '--print-readme') {
+    console.log((await readFileAsync(path.join(__dirname, '..', '..', 'README.md'))).toString());
+    return;
+  }
+
+  if (process.argv[2] === '--install') {
+    // Place the browsers.json file into the current working directory.
+    const browsersJSON = await readFileAsync(path.join(__dirname, '..', '..', 'browsers.json'));
+    const driverDir = path.dirname(process.argv[0]);
+    await writeFileAsync(path.join(driverDir, 'browsers.json'), browsersJSON);
+
+    await require('../../lib/install/installer').installBrowsersWithProgressBar(driverDir);
+    return;
+  }
+
+  if (process.argv[2] === '--run') {
+    require('../../lib/server');
+  }
 })();

--- a/utils/build_driver.sh
+++ b/utils/build_driver.sh
@@ -1,0 +1,11 @@
+#/bin/bash
+
+set -e
+
+echo "Generating API"
+node utils/doclint/dumpTypes.js > packages/playwright-driver/api.json
+echo "Generated API successfully"
+
+echo "Building RPC drivers"
+node_modules/.bin/pkg --public --targets node12-linux-x64,node12-macos-x64,node12-win-x64 --out-path=drivers -c packages/playwright-driver/package.json packages/playwright-driver/main.js
+echo "Built RPC drivers successfully"


### PR DESCRIPTION
Changes: Bake browsers.json into the RPC driver and added API.json too.

It's breaking since the `--run` is now required but should not be a big deal.

cc @pavelfeldman