### PR TITLE
chore: simplify conversions around setInputFiles

### DIFF
--- a/src/chromium/crPage.ts
+++ b/src/chromium/crPage.ts
@@ -270,7 +270,7 @@ export class CRPage implements PageDelegate {
 
   async setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void> {
     await handle._evaluateInUtility(([injected, node, files]) =>
-      injected.setInputFiles(node, files), dom.toFileTransferPayload(files));
+      injected.setInputFiles(node, files), files);
   }
 
   async adoptElementHandle<T extends Node>(handle: dom.ElementHandle<T>, to: dom.FrameExecutionContext): Promise<dom.ElementHandle<T>> {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -14,33 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as mime from 'mime';
-import * as path from 'path';
-import * as util from 'util';
 import * as types from './types';
-
-export async function normalizeFilePayloads(files: string | types.FilePayload | string[] | types.FilePayload[]): Promise<types.FilePayload[]> {
-  let ff: string[] | types.FilePayload[];
-  if (!Array.isArray(files))
-    ff = [ files ] as string[] | types.FilePayload[];
-  else
-    ff = files;
-  const filePayloads: types.FilePayload[] = [];
-  for (const item of ff) {
-    if (typeof item === 'string') {
-      const file: types.FilePayload = {
-        name: path.basename(item),
-        mimeType: mime.getType(item) || 'application/octet-stream',
-        buffer: await util.promisify(fs.readFile)(item)
-      };
-      filePayloads.push(file);
-    } else {
-      filePayloads.push(item);
-    }
-  }
-  return filePayloads;
-}
 
 export function headersObjectToArray(headers: { [key: string]: string }): types.HeadersArray {
   const result: types.HeadersArray = [];

--- a/src/firefox/ffPage.ts
+++ b/src/firefox/ffPage.ts
@@ -458,7 +458,7 @@ export class FFPage implements PageDelegate {
 
   async setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void> {
     await handle._evaluateInUtility(([injected, node, files]) =>
-      injected.setInputFiles(node, files), dom.toFileTransferPayload(files));
+      injected.setInputFiles(node, files), files);
   }
 
   async adoptElementHandle<T extends Node>(handle: dom.ElementHandle<T>, to: dom.FrameExecutionContext): Promise<dom.ElementHandle<T>> {

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -429,7 +429,7 @@ export class Frame {
       const waitUntil = verifyLifecycle('waitUntil', options.waitUntil === undefined ? 'load' : options.waitUntil);
       progress.log(`navigating to "${url}", waiting until "${waitUntil}"`);
       const headers = this._page._state.extraHTTPHeaders || [];
-      const refererHeader = headers.find(h => h.name === 'referer' || h.name === 'Referer');
+      const refererHeader = headers.find(h => h.name.toLowerCase() === 'referer');
       let referer = refererHeader ? refererHeader.value : undefined;
       if (options.referer !== undefined) {
         if (referer !== undefined && referer !== options.referer)
@@ -867,7 +867,7 @@ export class Frame {
     return this._retryWithSelectorIfNotConnected(selector, options, (progress, handle) => handle._selectOption(progress, elements, values, options));
   }
 
-  async setInputFiles(selector: string, files: string | types.FilePayload | string[] | types.FilePayload[], options: types.NavigatingActionWaitOptions = {}): Promise<void> {
+  async setInputFiles(selector: string, files: types.FilePayload[], options: types.NavigatingActionWaitOptions = {}): Promise<void> {
     await this._retryWithSelectorIfNotConnected(selector, options, (progress, handle) => handle._setInputFiles(progress, files, options));
   }
 

--- a/src/injected/injectedScript.ts
+++ b/src/injected/injectedScript.ts
@@ -425,7 +425,7 @@ export default class InjectedScript {
     throw new Error('Not a checkbox');
   }
 
-  async setInputFiles(node: Node, payloads: types.FileTransferPayload[]) {
+  async setInputFiles(node: Node, payloads: types.FilePayload[]) {
     if (node.nodeType !== Node.ELEMENT_NODE)
       return 'Node is not of type HTMLElement';
     const element: Element | undefined = node as Element;
@@ -437,8 +437,8 @@ export default class InjectedScript {
       return 'Not an input[type=file] element';
 
     const files = await Promise.all(payloads.map(async file => {
-      const result = await fetch(`data:${file.type};base64,${file.data}`);
-      return new File([await result.blob()], file.name, {type: file.type});
+      const result = await fetch(`data:${file.mimeType};base64,${file.buffer}`);
+      return new File([await result.blob()], file.name, {type: file.mimeType});
     }));
     const dt = new DataTransfer();
     for (const file of files)

--- a/src/rpc/server/elementHandlerDispatcher.ts
+++ b/src/rpc/server/elementHandlerDispatcher.ts
@@ -100,7 +100,7 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
   }
 
   async setInputFiles(params: { files: { name: string, mimeType: string, buffer: string }[] } & types.NavigatingActionWaitOptions) {
-    await this._elementHandle.setInputFiles(convertInputFiles(params.files), params);
+    await this._elementHandle.setInputFiles(params.files, params);
   }
 
   async focus() {
@@ -157,8 +157,4 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
   async waitForSelector(params: { selector: string } & types.WaitForElementOptions): Promise<{ element?: ElementHandleChannel }> {
     return { element: ElementHandleDispatcher.createNullable(this._scope, await this._elementHandle.waitForSelector(params.selector, params)) };
   }
-}
-
-export function convertInputFiles(files: { name: string, mimeType: string, buffer: string }[]): types.FilePayload[] {
-  return files.map(f => ({ name: f.name, mimeType: f.mimeType, buffer: Buffer.from(f.buffer, 'base64') }));
 }

--- a/src/rpc/server/frameDispatcher.ts
+++ b/src/rpc/server/frameDispatcher.ts
@@ -18,7 +18,7 @@ import { Frame, kAddLifecycleEvent, kRemoveLifecycleEvent, kNavigationEvent, Nav
 import * as types from '../../types';
 import { ElementHandleChannel, FrameChannel, FrameInitializer, JSHandleChannel, ResponseChannel, SerializedArgument, FrameWaitForFunctionParams, SerializedValue } from '../channels';
 import { Dispatcher, DispatcherScope, lookupNullableDispatcher, existingDispatcher } from './dispatcher';
-import { ElementHandleDispatcher, createHandle, convertInputFiles } from './elementHandlerDispatcher';
+import { ElementHandleDispatcher, createHandle } from './elementHandlerDispatcher';
 import { parseArgument, serializeResult } from './jsHandleDispatcher';
 import { ResponseDispatcher, RequestDispatcher } from './networkDispatchers';
 
@@ -157,7 +157,7 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
   }
 
   async setInputFiles(params: { selector: string, files: { name: string, mimeType: string, buffer: string }[] } & types.NavigatingActionWaitOptions): Promise<void> {
-    await this._frame.setInputFiles(params.selector, convertInputFiles(params.files), params);
+    await this._frame.setInputFiles(params.selector, params.files, params);
   }
 
   async type(params: { selector: string, text: string } & { delay?: number | undefined } & types.TimeoutOptions & { noWaitAfter?: boolean }): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,13 +90,7 @@ export type SelectOption = {
 export type FilePayload = {
   name: string,
   mimeType: string,
-  buffer: Buffer,
-};
-
-export type FileTransferPayload = {
-  name: string,
-  type: string,
-  data: string,
+  buffer: string,
 };
 
 export type MediaType = 'screen' | 'print';

--- a/src/webkit/wkPage.ts
+++ b/src/webkit/wkPage.ts
@@ -804,7 +804,12 @@ export class WKPage implements PageDelegate {
 
   async setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void> {
     const objectId = handle._objectId;
-    await this._session.send('DOM.setInputFiles', { objectId, files: dom.toFileTransferPayload(files) });
+    const protocolFiles = files.map(file => ({
+      name: file.name,
+      type: file.mimeType,
+      data: file.buffer,
+    }));
+    await this._session.send('DOM.setInputFiles', { objectId, files: protocolFiles });
   }
 
   async adoptElementHandle<T extends Node>(handle: dom.ElementHandle<T>, to: dom.FrameExecutionContext): Promise<dom.ElementHandle<T>> {


### PR DESCRIPTION
We do not need api types on the server side anymore.