### PR TITLE
chore: simplify conversions around selectOption

### DIFF
--- a/src/frames.ts
+++ b/src/frames.ts
@@ -863,8 +863,8 @@ export class Frame {
     await this._retryWithSelectorIfNotConnected(selector, options, (progress, handle) => handle._hover(progress, options));
   }
 
-  async selectOption(selector: string, values: string | dom.ElementHandle | types.SelectOption | string[] | dom.ElementHandle[] | types.SelectOption[] | null, options: types.NavigatingActionWaitOptions = {}): Promise<string[]> {
-    return this._retryWithSelectorIfNotConnected(selector, options, (progress, handle) => handle._selectOption(progress, values, options));
+  async selectOption(selector: string, elements: dom.ElementHandle[], values: types.SelectOption[], options: types.NavigatingActionWaitOptions = {}): Promise<string[]> {
+    return this._retryWithSelectorIfNotConnected(selector, options, (progress, handle) => handle._selectOption(progress, elements, values, options));
   }
 
   async setInputFiles(selector: string, files: string | types.FilePayload | string[] | types.FilePayload[], options: types.NavigatingActionWaitOptions = {}): Promise<void> {

--- a/src/rpc/client/elementHandle.ts
+++ b/src/rpc/client/elementHandle.ts
@@ -224,7 +224,7 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> {
 }
 
 export function convertSelectOptionValues(values: string | ElementHandle | SelectOption | string[] | ElementHandle[] | SelectOption[] | null): { elements?: ElementHandleChannel[], options?: SelectOption[] } {
-  if (!values)
+  if (values === null)
     return {};
   if (!Array.isArray(values))
     values = [ values as any ];
@@ -232,7 +232,6 @@ export function convertSelectOptionValues(values: string | ElementHandle | Selec
     return {};
   for (let i = 0; i < values.length; i++)
     assert(values[i] !== null, `options[${i}]: expected object, got null`);
-
   if (values[0] instanceof ElementHandle)
     return { elements: (values as ElementHandle[]).map((v: ElementHandle) => v._elementChannel) };
   if (helper.isString(values[0]))

--- a/src/rpc/server/elementHandlerDispatcher.ts
+++ b/src/rpc/server/elementHandlerDispatcher.ts
@@ -87,7 +87,8 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
   }
 
   async selectOption(params: { elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions): Promise<{ values: string[] }> {
-    return { values: await this._elementHandle.selectOption(convertSelectOptionValues(params.elements, params.options), params) };
+    const elements = (params.elements || []).map(e => (e as ElementHandleDispatcher)._elementHandle);
+    return { values: await this._elementHandle.selectOption(elements, params.options || [], params) };
   }
 
   async fill(params: { value: string } & types.NavigatingActionWaitOptions) {
@@ -156,14 +157,6 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements Eleme
   async waitForSelector(params: { selector: string } & types.WaitForElementOptions): Promise<{ element?: ElementHandleChannel }> {
     return { element: ElementHandleDispatcher.createNullable(this._scope, await this._elementHandle.waitForSelector(params.selector, params)) };
   }
-}
-
-export function convertSelectOptionValues(elements?: ElementHandleChannel[], options?: types.SelectOption[]): string | ElementHandle | types.SelectOption | string[] | ElementHandle[] | types.SelectOption[] | null {
-  if (elements)
-    return elements.map(v => (v as ElementHandleDispatcher)._elementHandle);
-  if (options)
-    return options;
-  return null;
 }
 
 export function convertInputFiles(files: { name: string, mimeType: string, buffer: string }[]): types.FilePayload[] {

--- a/src/rpc/server/frameDispatcher.ts
+++ b/src/rpc/server/frameDispatcher.ts
@@ -18,7 +18,7 @@ import { Frame, kAddLifecycleEvent, kRemoveLifecycleEvent, kNavigationEvent, Nav
 import * as types from '../../types';
 import { ElementHandleChannel, FrameChannel, FrameInitializer, JSHandleChannel, ResponseChannel, SerializedArgument, FrameWaitForFunctionParams, SerializedValue } from '../channels';
 import { Dispatcher, DispatcherScope, lookupNullableDispatcher, existingDispatcher } from './dispatcher';
-import { convertSelectOptionValues, ElementHandleDispatcher, createHandle, convertInputFiles } from './elementHandlerDispatcher';
+import { ElementHandleDispatcher, createHandle, convertInputFiles } from './elementHandlerDispatcher';
 import { parseArgument, serializeResult } from './jsHandleDispatcher';
 import { ResponseDispatcher, RequestDispatcher } from './networkDispatchers';
 
@@ -152,7 +152,8 @@ export class FrameDispatcher extends Dispatcher<Frame, FrameInitializer> impleme
   }
 
   async selectOption(params: { selector: string, elements?: ElementHandleChannel[], options?: types.SelectOption[] } & types.NavigatingActionWaitOptions): Promise<{ values: string[] }> {
-    return { values: await this._frame.selectOption(params.selector, convertSelectOptionValues(params.elements, params.options), params) };
+    const elements = (params.elements || []).map(e => (e as ElementHandleDispatcher)._elementHandle);
+    return { values: await this._frame.selectOption(params.selector, elements, params.options || [], params) };
   }
 
   async setInputFiles(params: { selector: string, files: { name: string, mimeType: string, buffer: string }[] } & types.NavigatingActionWaitOptions): Promise<void> {


### PR DESCRIPTION
We do not need to support api types on the server side.