### PR TITLE
chore: remove screenshot path from the server side

### DIFF
--- a/src/rpc/channels.ts
+++ b/src/rpc/channels.ts
@@ -1822,14 +1822,12 @@ export type ElementHandleQuerySelectorAllResult = {
 export type ElementHandleScreenshotParams = {
   timeout?: number,
   type?: 'png' | 'jpeg',
-  path?: string,
   quality?: number,
   omitBackground?: boolean,
 };
 export type ElementHandleScreenshotOptions = {
   timeout?: number,
   type?: 'png' | 'jpeg',
-  path?: string,
   quality?: number,
   omitBackground?: boolean,
 };

--- a/src/rpc/client/page.ts
+++ b/src/rpc/client/page.ts
@@ -27,7 +27,7 @@ import { ChannelOwner } from './channelOwner';
 import { ConsoleMessage } from './consoleMessage';
 import { Dialog } from './dialog';
 import { Download } from './download';
-import { ElementHandle } from './elementHandle';
+import { ElementHandle, determineScreenshotType } from './elementHandle';
 import { Worker } from './worker';
 import { Frame, FunctionWithSource, verifyLoadState, WaitForNavigationOptions } from './frame';
 import { Keyboard, Mouse } from './input';
@@ -425,7 +425,9 @@ export class Page extends ChannelOwner<PageChannel, PageInitializer> {
 
   async screenshot(options: PageScreenshotOptions & { path?: string } = {}): Promise<Buffer> {
     return this._wrapApiCall('page.screenshot', async () => {
-      const buffer = Buffer.from((await this._channel.screenshot(options)).binary, 'base64');
+      const type = determineScreenshotType(options);
+      const result = await this._channel.screenshot({ ...options, type });
+      const buffer = Buffer.from(result.binary, 'base64');
       if (options.path) {
         await mkdirIfNeeded(options.path);
         await fsWriteFileAsync(options.path, buffer);

--- a/src/rpc/protocol.yml
+++ b/src/rpc/protocol.yml
@@ -1513,7 +1513,6 @@ ElementHandle:
           literals:
           - png
           - jpeg
-        path: string?
         quality: number?
         omitBackground: boolean?
       returns:

--- a/src/rpc/validator.ts
+++ b/src/rpc/validator.ts
@@ -718,7 +718,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   scheme.ElementHandleScreenshotParams = tObject({
     timeout: tOptional(tNumber),
     type: tOptional(tEnum(['png', 'jpeg'])),
-    path: tOptional(tString),
     quality: tOptional(tNumber),
     omitBackground: tOptional(tBoolean),
   });

--- a/src/screenshotter.ts
+++ b/src/screenshotter.ts
@@ -15,11 +15,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as mime from 'mime';
-import * as util from 'util';
 import * as dom from './dom';
-import { assert, helper, mkdirIfNeeded } from './helper';
+import { assert, helper } from './helper';
 import { Page } from './page';
 import * as types from './types';
 import { rewriteErrorMessage } from './utils/stackTrace';
@@ -153,10 +150,6 @@ export class Screenshotter {
     if (shouldSetDefaultBackground)
       await this._page._delegate.setBackgroundColor();
     progress.throwIfAborted(); // Avoid side effects.
-    if (options.path) {
-      await mkdirIfNeeded(options.path);
-      await util.promisify(fs.writeFile)(options.path, buffer);
-    }
     if ((options as any).__testHookAfterScreenshot)
       await (options as any).__testHookAfterScreenshot();
     return buffer;
@@ -206,13 +199,6 @@ function validateScreenshotOptions(options: types.ScreenshotOptions): 'png' | 'j
   if (options.type) {
     assert(options.type === 'png' || options.type === 'jpeg', 'Unknown options.type value: ' + options.type);
     format = options.type;
-  } else if (options.path) {
-    const mimeType = mime.getType(options.path);
-    if (mimeType === 'image/png')
-      format = 'png';
-    else if (mimeType === 'image/jpeg')
-      format = 'jpeg';
-    assert(format, 'Unsupported screenshot mime type: ' + mimeType);
   }
 
   if (!format)

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,6 @@ export type WaitForNavigationOptions = TimeoutOptions & {
 
 export type ElementScreenshotOptions = TimeoutOptions & {
   type?: 'png' | 'jpeg',
-  path?: string,
   quality?: number,
   omitBackground?: boolean,
 };

--- a/test/elementhandle-screenshot.spec.ts
+++ b/test/elementhandle-screenshot.spec.ts
@@ -19,6 +19,8 @@ import './base.fixture';
 import utils from './utils';
 const {WIRE, HEADLESS} = testOptions;
 import {PNG} from 'pngjs';
+import path from 'path';
+import fs from 'fs';
 
 // Firefox headful produces a different image.
 const ffheadful = FFOX && !HEADLESS;
@@ -368,4 +370,14 @@ it.skip(ffheadful)('should take screenshot of disabled button', async({page}) =>
   const button = await page.$('button');
   const screenshot = await button.screenshot();
   expect(screenshot).toBeInstanceOf(Buffer);
+});
+
+it.skip(ffheadful)('path option should create subdirectories', async({page, server, golden, tmpDir}) => {
+  await page.setViewportSize({width: 500, height: 500});
+  await page.goto(server.PREFIX + '/grid.html');
+  await page.evaluate(() => window.scrollBy(50, 100));
+  const elementHandle = await page.$('.box:nth-of-type(3)');
+  const outputPath = path.join(tmpDir, 'these', 'are', 'directories', 'screenshot.png');
+  await elementHandle.screenshot({path: outputPath});
+  expect(await fs.promises.readFile(outputPath)).toMatchImage(golden('screenshot-element-bounding-box.png'));
 });

--- a/test/page-screenshot.spec.ts
+++ b/test/page-screenshot.spec.ts
@@ -265,3 +265,17 @@ it.skip(ffheadful)('path option should create subdirectories', async({page, serv
   await page.screenshot({path: outputPath});
   expect(await fs.promises.readFile(outputPath)).toMatchImage(golden('screenshot-sanity.png'));
 });
+
+it.skip(ffheadful)('path option should detect jpeg', async({page, server, golden, tmpDir}) => {
+  await page.setViewportSize({ width: 100, height: 100 });
+  await page.goto(server.EMPTY_PAGE);
+  const outputPath = path.join(tmpDir, 'screenshot.jpg');
+  const screenshot = await page.screenshot({omitBackground: true, path: outputPath});
+  expect(await fs.promises.readFile(outputPath)).toMatchImage(golden('white.jpg'));
+  expect(screenshot).toMatchImage(golden('white.jpg'));
+});
+
+it.skip(ffheadful)('path option should throw for unsupported mime type', async({page, server, golden, tmpDir}) => {
+  const error = await page.screenshot({ path: 'file.txt' }).catch(e => e);
+  expect(error.message).toContain('path: unsupported mime type "text/plain"');
+});


### PR DESCRIPTION
Also fixes auto-detection of mime type based on path and adds tests.
Drive-by: also remove paths from addScriptTag/addStyleTag.