### PR TITLE
browser(firefox): make tab close listener sync again

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1161
-Changed: yurys@chromium.org Wed Aug 19 11:51:52 PDT 2020
+1162
+Changed: yurys@chromium.org Wed Aug 19 12:50:44 PDT 2020

--- a/browser_patches/firefox/juggler/TargetRegistry.js
+++ b/browser_patches/firefox/juggler/TargetRegistry.js
@@ -198,7 +198,7 @@ class TargetRegistry {
         setViewportSizeForBrowser(browserContext.defaultViewportSize, tab.linkedBrowser, window);
     };
 
-    const onTabCloseListener = async event => {
+    const onTabCloseListener = event => {
       const tab = event.target;
       const linkedBrowser = tab.linkedBrowser;
       const target = this._browserToTarget.get(linkedBrowser);


### PR DESCRIPTION
This is a follow-up to #3530