### PR TITLE
fix(chromium): disable lazy loading iframes

### DIFF
--- a/src/server/chromium.ts
+++ b/src/server/chromium.ts
@@ -162,7 +162,7 @@ const DEFAULT_ARGS = [
   '--disable-dev-shm-usage',
   '--disable-extensions',
   // BlinkGenPropertyTrees disabled due to crbug.com/937609
-  '--disable-features=TranslateUI,BlinkGenPropertyTrees,ImprovedCookieControls,SameSiteByDefaultCookies',
+  '--disable-features=TranslateUI,BlinkGenPropertyTrees,ImprovedCookieControls,SameSiteByDefaultCookies,LazyFrameLoading',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',
   '--disable-popup-blocking',

--- a/test/assets/frames/lazy-frame.html
+++ b/test/assets/frames/lazy-frame.html
@@ -1,0 +1,6 @@
+<div style="height: 1000px; width: 1000px; background: red">One</div>
+<div style="height: 1000px; width: 1000px; background: blue">Two</div>
+<div style="height: 1000px; width: 1000px; background: red">Three</div>
+<div style="height: 1000px; width: 1000px; background: blue">Four</div>
+<div style="height: 1000px; width: 1000px; background: red">Five</div>
+<iframe loading="lazy" src='./frame.html'></iframe>

--- a/test/page-goto.spec.ts
+++ b/test/page-goto.spec.ts
@@ -491,3 +491,8 @@ it.skip(true)('extraHttpHeaders should be pushed to provisional page', async({pa
   expect(htmlReq.headers['foo']).toBe(undefined);
   expect(cssReq.headers['foo']).toBe('bar');
 });
+
+it('should work with lazy loading iframes', async({page, server}) => {
+  await page.goto(server.PREFIX + '/frames/lazy-frame.html');
+  expect(page.frames().length).toBe(2);
+});


### PR DESCRIPTION
These do not play nicely with our "page is loaded when all frames are loaded" logic.