### PR TITLE
fix(devops): auto roll tests

### DIFF
--- a/.github/workflows/auto_roll.yml
+++ b/.github/workflows/auto_roll.yml
@@ -27,12 +27,11 @@ jobs:
     # XVFB-RUN merges both STDOUT and STDERR, whereas we need only STDERR
     # Wrap `npm run` in a subshell to redirect STDERR to file.
     # Enable core dumps in the subshell.
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && node test/runner test/ --jobs=1 --forbid-only --timeout=30000 && npm run coverage"
+    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && node test/runner test/ --jobs=1 --forbid-only --timeout=30000"
       env:
         BROWSER: ${{ matrix.browser }}
         DEBUG: "pw:*,-pw:wrapped*,-pw:test*"
         DEBUG_FILE: "testrun.log"
-        PWCHANNEL: none
         FFPATH: ${{ steps.build-browser.outputs.FFPATH }}
         WKPATH: ${{ steps.build-browser.outputs.WKPATH }}
     - uses: actions/upload-artifact@v1

--- a/test/base.fixture.ts
+++ b/test/base.fixture.ts
@@ -152,9 +152,6 @@ registerFixture('toImpl', async ({playwright}, test) => {
 
 registerWorkerFixture('browserType', async ({playwright, browserName}, test) => {
   const browserType = playwright[browserName];
-  const executablePath = getExecutablePath(browserName)
-  if (executablePath)
-    browserType._executablePath = executablePath
   await test(browserType);
 });
 

--- a/test/browsertype-basic.spec.ts
+++ b/test/browsertype-basic.spec.ts
@@ -18,7 +18,7 @@
 import fs from 'fs';
 import './base.fixture';
 
-it('browserType.executablePath should work', async({browserType}) => {
+it.skip(Boolean(process.env.CRPATH || process.env.FFPATH || process.env.WKPATH))('browserType.executablePath should work', async({browserType}) => {
   const executablePath = browserType.executablePath();
   expect(fs.existsSync(executablePath)).toBe(true);
   expect(fs.realpathSync(executablePath)).toBe(executablePath);


### PR DESCRIPTION
Changes:
- disabled coverage checking on browser roll bots (fixes [that](https://github.com/mxschmitt/playwright/runs/1002194040?check_suite_focus=true#step:10:19))
- reverted change to overwrite executable path since we skip the test now and it was not working without `PWCHANNEL=none` (fixes [that](https://github.com/microsoft/playwright/runs/1000959327?check_suite_focus=true#step:10:12))
- skipping `browserType.executablePath()` test when using manual executable path overwrite