### PR TITLE
fix(permissions): browserContext.grantPermissions to respect the origin

### DIFF
--- a/src/browserContext.ts
+++ b/src/browserContext.ts
@@ -123,17 +123,17 @@ export abstract class BrowserContext extends EventEmitter {
     this._doExposeBinding(binding);
   }
 
-  async grantPermissions(permissions: string[], options?: { origin?: string }) {
-    let origin = '*';
-    if (options && options.origin) {
-      const url = new URL(options.origin);
-      origin = url.origin;
+  async grantPermissions(permissions: string[], origin?: string) {
+    let resolvedOrigin = '*';
+    if (origin) {
+      const url = new URL(origin);
+      resolvedOrigin = url.origin;
     }
-    const existing = new Set(this._permissions.get(origin) || []);
+    const existing = new Set(this._permissions.get(resolvedOrigin) || []);
     permissions.forEach(p => existing.add(p));
     const list = [...existing.values()];
-    this._permissions.set(origin, list);
-    await this._doGrantPermissions(origin, list);
+    this._permissions.set(resolvedOrigin, list);
+    await this._doGrantPermissions(resolvedOrigin, list);
   }
 
   async clearPermissions() {

--- a/test/permissions.spec.ts
+++ b/test/permissions.spec.ts
@@ -40,10 +40,17 @@ describe.skip(options.WEBKIT())('permissions', () => {
     expect(error.message).toContain('Unknown permission: foo');
   });
 
-  it('should grant geolocation permission when listed', async({page, server, context}) => {
+  it('should grant geolocation permission when origin is listed', async({page, server, context}) => {
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions(['geolocation'], { origin: server.EMPTY_PAGE });
     expect(await getPermission(page, 'geolocation')).toBe('granted');
+  });
+
+  it('should prompt for geolocation permission when origin is not listed', async({page, server, context}) => {
+    await page.goto(server.EMPTY_PAGE);
+    await context.grantPermissions(['geolocation'], { origin: server.EMPTY_PAGE });
+    await page.goto(server.EMPTY_PAGE.replace('localhost', '127.0.0.1'));
+    expect(await getPermission(page, 'geolocation')).toBe('prompt');
   });
 
   it('should grant notifications permission when listed', async({page, server, context}) => {


### PR DESCRIPTION
Due to wrong type usage, we ignored the origin while granting permissions.
Switching to generated types revealed this issue. We should follow up
with switching all dispatchers to the generated types.