### PR TITLE
feat(testrunner): provide TestInfo before running the test

### DIFF
--- a/test-runner/src/cli.js
+++ b/test-runner/src/cli.js
@@ -94,18 +94,18 @@ program
       retries: command.retries,
       snapshotDir: path.join(testDir, '__snapshots__'),
       testDir,
-      timeout: command.timeout,
+      timeout: +command.timeout,
       trialRun: command.trialRun,
       updateSnapshots: command.updateSnapshots
     });
     try {
       if (beforeFunction)
-        await beforeFunction();
+        await beforeFunction({ outputDir: command.output });
       await runner.run();
       await runner.stop();
     } finally {
       if (afterFunction)
-        await afterFunction();
+        await afterFunction({ outputDir: command.output });
     }
     process.exit(runner.stats.failures ? 1 : 0);
   });

--- a/test-runner/src/fixturesUI.js
+++ b/test-runner/src/fixturesUI.js
@@ -63,13 +63,16 @@ function fixturesUI(wrappers, suite) {
 
       if (suite.isPending())
         fn = null;
-      const wrapper = fn ? wrappers.testWrapper(fn, title, file, specs.slow && specs.slow[0]) : undefined;
+      const isSlow = specs.slow && specs.slow[0];
+      const wrapper = fn ? wrappers.testWrapper(fn, title, file, isSlow) : undefined;
       if (wrapper) {
         wrapper.toString = () => fn.toString();
         wrapper.__original = fn;
       }
       const test = new Test(title, wrapper);
+      // HACK: save isSlow on the test object to use in hookWrapper.
       test.file = file;
+      test._isSlow = isSlow;
       suite.addTest(test);
       const only = wrappers.ignoreOnly ? false : specs.only && specs.only[0];
       if (only)

--- a/test/playwright.fixtures.ts
+++ b/test/playwright.fixtures.ts
@@ -184,9 +184,9 @@ registerFixture('context', async ({browser}, test) => {
   await context.close();
 });
 
-registerFixture('page', async ({context}, test) => {
+registerFixture('page', async ({context}, test, info) => {
   const page = await context.newPage();
-  const { success, info } = await test(page);
+  const { success } = await test(page);
   if (!success) {
     const relativePath = path.relative(info.testDir, info.file).replace(/\.spec\.[jt]s/, '');
     const sanitizedTitle = info.title.replace(/[^\w\d]+/g, '_');

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-declare const before: (f: () => Promise<any>) => void;
-declare const after: (f: () => Promise<any>) => void;
+type GlobalInfo = { outputDir: string };
+declare const before: (f: (info: GlobalInfo) => Promise<any>) => void;
+declare const after: (f: (info: GlobalInfo) => Promise<any>) => void;
 declare const matrix: (m: any) => void;
 
 matrix({
@@ -28,7 +29,7 @@ matrix({
 before(async () => {
 });
 
-after(async () => {  
+after(async () => {
 });
 
 function valueFromEnv(name, defaultValue) {

--- a/test/test-runner.spec.ts
+++ b/test/test-runner.spec.ts
@@ -17,6 +17,13 @@
 import './test-runner-helper';
 import { registerFixture } from '../test-runner';
 
+type TestInfo = {
+  file: string;
+  title: string;
+  timeout: number;
+  outputDir: string;
+  testDir: string;
+};
 declare global {
   interface TestState {
     a: string;
@@ -24,6 +31,8 @@ declare global {
     ab: string;
     zero: number;
     tear: string;
+    info1: TestInfo;
+    info2: TestInfo;
   }
 }
 
@@ -46,4 +55,31 @@ registerFixture('ab', async ({a, b}, test) => {
 
 it('should eval fixture once', async ({ab}) => {
   expect(ab).toBe('a0b0');
+});
+
+let beforeEachInfo1;
+beforeEach(async ({info1}) => {
+  beforeEachInfo1 = info1;
+});
+
+registerFixture('info1', async ({}, test, info) => {
+  await test(info);
+});
+registerFixture('info2', async ({}, test, info) => {
+  await test(info);
+});
+
+it('should get info', async ({info2}) => {
+  function expectInfo(info) {
+    expect(info.file).toContain('test-runner.spec');
+    expect(typeof info.timeout).toBe('number');
+    expect(typeof info.outputDir).toBe('string');
+    expect(info.title).toBe('should get info');
+  }
+
+  // Info passed directly to the fixture.
+  expectInfo(info2);
+
+  // Info passed to fixture invoked from beforeEach.
+  expectInfo(beforeEachInfo1);
 });


### PR DESCRIPTION
- We now provide TestInfo to the fixture immediately instead of after test run.
- Fix timeout being a string instead of a number.
- Provide outputDir to global before/after.
- Fix incorrect beforeEach/afterEach hooks skipping.