### PR TITLE
devops(auto-roll): fix webkit build

### DIFF
--- a/.github/workflows/auto_roll.sh
+++ b/.github/workflows/auto_roll.sh
@@ -27,18 +27,6 @@ fi
 ./browser_patches/prepare_checkout.sh "$browser_name"
 
 if [[ "${browser_name}" == "webkit" ]]; then
-    ./browser_patches/webkit/checkout/Tools/gtk/install-dependencies
-    ./browser_patches/webkit/checkout/Tools/wpe/install-dependencies
-
-    ./browser_patches/webkit/checkout/Tools/Scripts/update-webkitwpe-libs
-    ./browser_patches/webkit/checkout/Tools/Scripts/update-webkitgtk-libs
-elif [[ "${browser_name}" == "firefox" ]]; then
-    cd browser_patches/firefox/checkout
-    SHELL=/bin/bash ./mach bootstrap --no-interactive --application-choice="Firefox for Desktop"
-    cd -
-fi
-
-if [[ "${browser_name}" == "webkit" ]]; then
   cd ./browser_patches/webkit/checkout
   # Rebase WebKit atop of master branch.
   git rebase browser_upstream/master
@@ -48,6 +36,15 @@ elif [[ "${browser_name}" == "firefox" ]]; then
   # We keep firefox atop of beta branch since it's much more stable.
   git rebase browser_upstream/beta
   cd -
+fi
+
+if [[ "${browser_name}" == "webkit" ]]; then
+    ./browser_patches/webkit/checkout/Tools/gtk/install-dependencies
+    ./browser_patches/webkit/checkout/Tools/wpe/install-dependencies
+elif [[ "${browser_name}" == "firefox" ]]; then
+    cd browser_patches/firefox/checkout
+    SHELL=/bin/bash ./mach bootstrap --no-interactive --application-choice="Firefox for Desktop"
+    cd -
 fi
 
 echo "Building $browser_name"


### PR DESCRIPTION
This should fix the current WebKit build if the patches could get applied. The change does rebase from the upstream first and then run the install scripts instead of doing it vise-versa. Also removes the update-*-libs calls since we do it in the build.sh.

How should we follow up with it? @aslushnikov