### PR TITLE
browser(webkit): do not crash when opening web inspector

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1333
-Changed: yurys@chromium.org Tue Aug 25 15:39:47 PDT 2020
+1334
+Changed: yurys@chromium.org Tue Aug 25 18:01:13 PDT 2020

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -9999,10 +9999,10 @@ index 0000000000000000000000000000000000000000..f356c613945fd263889bc74166bef2b2
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..2c5e2bc04b51b39ae4f3128c86afb29e0042b968
+index 0000000000000000000000000000000000000000..8e3989ef7f9947c685dcbe30d58561dab7f5ea5b
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
-@@ -0,0 +1,848 @@
+@@ -0,0 +1,855 @@
 +/*
 + * Copyright (C) 2019 Microsoft Corporation.
 + *
@@ -10043,6 +10043,7 @@ index 0000000000000000000000000000000000000000..2c5e2bc04b51b39ae4f3128c86afb29e
 +#include "WebAutomationSession.h"
 +#include "WebGeolocationManagerProxy.h"
 +#include "WebGeolocationPosition.h"
++#include "WebInspectorUtilities.h"
 +#include "WebPageInspectorController.h"
 +#include "WebPageInspectorTarget.h"
 +#include "WebPageProxy.h"
@@ -10327,6 +10328,9 @@ index 0000000000000000000000000000000000000000..2c5e2bc04b51b39ae4f3128c86afb29e
 +    if (!m_isEnabled)
 +        return;
 +
++    if (isInspectorProcessPool(page.process().processPool()))
++        return;
++
 +    ASSERT(m_frontendChannel);
 +
 +    String browserContextID = toBrowserContextIDProtocolString(page.sessionID());
@@ -10352,6 +10356,9 @@ index 0000000000000000000000000000000000000000..2c5e2bc04b51b39ae4f3128c86afb29e
 +void InspectorPlaywrightAgent::willDestroyInspectorController(WebPageProxy& page)
 +{
 +    if (!m_isEnabled)
++        return;
++
++    if (isInspectorProcessPool(page.process().processPool()))
 +        return;
 +
 +    String browserContextID = toBrowserContextIDProtocolString(page.sessionID());


### PR DESCRIPTION
https://github.com/yury-s/webkit/commit/ec7f25ba6f6581cac385bad08aaadb068e566d6a

Inspector frontend page is always loaded in the default context. If mini browser started without user data dir Playwright doesn't track persistent context and would crash when web inspector opens. To avoid that we simply ignore all web inspector front-end pages.

  pw:browser [err] 1   0x7fa95a7f8869 WTFCrash +9s
  pw:browser [err] 2   0x7fa95ccb9094 /home/yurys/.cache/ms-playwright/webkit-1332/minibrowser-gtk/libwebkit2gtk-4.0.so.37(+0x2100094) [0x7fa95ccb9094] +0ms
  pw:browser [err] 3   0x7fa95ccbaaeb WebKit::InspectorPlaywrightAgent::didCreateInspectorController(WebKit::WebPageProxy&) +2ms
  pw:browser [err] 4   0x7fa95ce5a22a WebKit::WebPageInspectorController::init() +1ms
  pw:browser [err] 5   0x7fa95cd19ddd WebKit::WebPageProxy::WebPageProxy(WebKit::PageClient&, WebKit::WebProcessProxy&, WTF::Ref<API::PageConfiguration, WTF::DumbPtrTraits<API::PageConfiguration> >&&) +1ms
  pw:browser [err] 6   0x7fa95cd19fd2 WebKit::WebPageProxy::create(WebKit::PageClient&, WebKit::WebProcessProxy&, WTF::Ref<API::PageConfiguration, WTF::DumbPtrTraits<API::PageConfiguration> >&&) +1ms
  pw:browser [err] 7   0x7fa95cd61467 WebKit::WebProcessProxy::createWebPage(WebKit::PageClient&, WTF::Ref<API::PageConfiguration, WTF::DumbPtrTraits<API::PageConfiguration> >&&) +2ms
  pw:browser [err] 8   0x7fa95cd68013 WebKit::WebProcessPool::createWebPage(WebKit::PageClient&, WTF::Ref<API::PageConfiguration, WTF::DumbPtrTraits<API::PageConfiguration> >&&) +1ms
  pw:browser [err] 9   0x7fa95ce21491 webkitWebViewBaseCreateWebPage(_WebKitWebViewBase*, WTF::Ref<API::PageConfiguration, WTF::DumbPtrTraits<API::PageConfiguration> >&&) +1ms
  pw:browser [err] 10  0x7fa95ce2161b webkitWebViewBaseCreate(API::PageConfiguration const&) +2ms
  pw:browser [err] 11  0x7fa95ce64376 WebKit::WebInspectorProxy::platformCreateFrontendPage() +1ms
  pw:browser [err] 12  0x7fa95ce58a48 WebKit::WebInspectorProxy::createFrontendPage() +1ms
  pw:browser [err] 13  0x7fa95ce58b58 WebKit::WebInspectorProxy::connect() +2ms
  pw:browser [err] 14  0x7fa95ce58e21 WebKit::WebInspectorProxy::show() +1ms
