### PR TITLE
Add more detail to waitForNavigation API method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1935,12 +1935,12 @@ Shortcut for [page.mainFrame().waitForLoadState([options])](#framewaitforloadsta
 - returns: <[Promise]<[null]|[Response]>> Promise which resolves to the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. In case of navigation to a different anchor or navigation due to History API usage, the navigation will resolve with `null`.
 
 This resolves when the page navigates to a new URL or reloads. It is useful for when you run code
-which will indirectly cause the page to navigate. Consider this example:
+which will indirectly cause the page to navigate. e.g. The click target has an `onclick` handler that triggers navigation from a `setTimeout`. Consider this example:
 
 ```js
 const [response] = await Promise.all([
   page.waitForNavigation(), // The promise resolves after navigation has finished
-  page.click('a.my-link'), // Clicking the link will indirectly cause a navigation
+  page.click('a.delayed-navigation'), // Clicking the link will indirectly cause a navigation
 ]);
 ```
 


### PR DESCRIPTION
This adds more detail to the `waitForNavigation` API to help clarify
that `waitForNavigation` is only necessary for special cases when used
with `.click`.

Related to https://github.com/microsoft/playwright/issues/1190#issuecomment-608580429