### PR TITLE
chore(testrunner): enable eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,5 @@
 test/assets/modernizr.js
-third_party/*
-utils/browser/playwright-web.js
 utils/doclint/check_public_api/test/
-utils/testrunner/examples/
 lib/
 *.js
 src/generated/*
@@ -13,6 +10,8 @@ src/server/webkit/protocol.ts
 /index.d.ts
 /electron-types.d.ts
 utils/generate_types/overrides.d.ts
-utils/generate_types/test/test.ts
-test/
-test-runner/
+utils/generate_types/test/test.ts 
+/test/
+node_modules/
+browser_patches/*/checkout/
+packages/**/*.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
     parser: '@typescript-eslint/parser',
     plugins: ['@typescript-eslint', 'notice'],
     parserOptions: {
-      project: ['./tsconfig.json', './test/tsconfig.json'],
       ecmaVersion: 9,
       sourceType: 'module',
     },
@@ -113,8 +112,5 @@ module.exports = {
             "mustMatch": "Copyright",
             "templateFile": "./utils/copyright.js",
         }],
-
-        // type-aware rules
-        "@typescript-eslint/no-unnecessary-type-assertion": 2,
     }
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ftest": "cross-env BROWSER=firefox node test-runner/cli test/",
     "wtest": "cross-env BROWSER=webkit node test-runner/cli test/",
     "test": "node test-runner/cli test/",
-    "eslint": "[ \"$CI\" = true ] && eslint --quiet -f codeframe --ext js,ts ./src || eslint --ext js,ts ./src",
+    "eslint": "[ \"$CI\" = true ] && eslint --quiet -f codeframe --ext js,ts . || eslint --ext js,ts .",
     "tsc": "tsc -p .",
     "tsc-installer": "tsc -p ./src/install/tsconfig.json",
     "doc": "node utils/doclint/cli.js",

--- a/test-runner/src/cli.ts
+++ b/test-runner/src/cli.ts
@@ -33,67 +33,67 @@ export const reporters = {
 };
 
 program
-  .version('Version ' + /** @type {any} */ (require)('../package.json').version)
-  .option('--forbid-only', 'Fail if exclusive test(s) encountered', false)
-  .option('-g, --grep <grep>', 'Only run tests matching this string or regexp', '.*')
-  .option('-j, --jobs <jobs>', 'Number of concurrent jobs for --parallel; use 1 to run in serial, default: (number of CPU cores / 2)', Math.ceil(require('os').cpus().length / 2) as any)
-  .option('--reporter <reporter>', 'Specify reporter to use, comma-separated, can be "dot", "list", "json"', 'dot')
-  .option('--trial-run', 'Only collect the matching tests and report them as passing')
-  .option('--quiet', 'Suppress stdio', false)
-  .option('--debug', 'Run tests in-process for debugging', false)
-  .option('--output <outputDir>', 'Folder for output artifacts, default: test-results', path.join(process.cwd(), 'test-results'))
-  .option('--timeout <timeout>', 'Specify test timeout threshold (in milliseconds), default: 10000', '10000')
-  .option('-u, --update-snapshots', 'Use this flag to re-record every snapshot that fails during this test run')
-  .action(async (command) => {
-    const testDir = path.resolve(process.cwd(), command.args[0]);
-    const config: RunnerConfig = {
-      debug: command.debug,
-      quiet: command.quiet,
-      grep: command.grep,
-      jobs: command.jobs,
-      outputDir: command.output,
-      snapshotDir: path.join(testDir, '__snapshots__'),
-      testDir,
-      timeout: command.timeout,
-      trialRun: command.trialRun,
-      updateSnapshots: command.updateSnapshots
-    };
-    const files = collectFiles(testDir, '', command.args.slice(1));
-    const suite = collectTests(config, files);
-    if (command.forbidOnly) {
-      const hasOnly = suite.eachTest(t => t.only) || suite.eachSuite(s => s.only);
-      if (hasOnly) {
-        console.error('=====================================');
-        console.error(' --forbid-only found a focused test.');
-        console.error('=====================================');
+    .version('Version ' + /** @type {any} */ (require)('../package.json').version)
+    .option('--forbid-only', 'Fail if exclusive test(s) encountered', false)
+    .option('-g, --grep <grep>', 'Only run tests matching this string or regexp', '.*')
+    .option('-j, --jobs <jobs>', 'Number of concurrent jobs for --parallel; use 1 to run in serial, default: (number of CPU cores / 2)', Math.ceil(require('os').cpus().length / 2) as any)
+    .option('--reporter <reporter>', 'Specify reporter to use, comma-separated, can be "dot", "list", "json"', 'dot')
+    .option('--trial-run', 'Only collect the matching tests and report them as passing')
+    .option('--quiet', 'Suppress stdio', false)
+    .option('--debug', 'Run tests in-process for debugging', false)
+    .option('--output <outputDir>', 'Folder for output artifacts, default: test-results', path.join(process.cwd(), 'test-results'))
+    .option('--timeout <timeout>', 'Specify test timeout threshold (in milliseconds), default: 10000', '10000')
+    .option('-u, --update-snapshots', 'Use this flag to re-record every snapshot that fails during this test run')
+    .action(async command => {
+      const testDir = path.resolve(process.cwd(), command.args[0]);
+      const config: RunnerConfig = {
+        debug: command.debug,
+        quiet: command.quiet,
+        grep: command.grep,
+        jobs: command.jobs,
+        outputDir: command.output,
+        snapshotDir: path.join(testDir, '__snapshots__'),
+        testDir,
+        timeout: command.timeout,
+        trialRun: command.trialRun,
+        updateSnapshots: command.updateSnapshots
+      };
+      const files = collectFiles(testDir, '', command.args.slice(1));
+      const suite = collectTests(config, files);
+      if (command.forbidOnly) {
+        const hasOnly = suite.eachTest(t => t.only) || suite.eachSuite(s => s.only);
+        if (hasOnly) {
+          console.error('=====================================');
+          console.error(' --forbid-only found a focused test.');
+          console.error('=====================================');
+          process.exit(1);
+        }
+      }
+
+      const total = suite.total();
+      if (!total) {
+        console.error('=================');
+        console.error(' no tests found.');
+        console.error('=================');
         process.exit(1);
       }
-    }
 
-    const total = suite.total();
-    if (!total) {
-      console.error('=================');
-      console.error(' no tests found.');
-      console.error('=================');
-      process.exit(1);
-    }
-
-    const reporterList = command.reporter.split(',');
-    const reporterObjects: Reporter[] = reporterList.map(c => {
-      if (reporters[c])
-        return new reporters[c]();
-      try {
-        const p = path.resolve(process.cwd(), c);
-        return new (require(p).default);
-      } catch (e) {
-        console.error('Invalid reporter ' + c, e);
-        process.exit(1);
-      }
+      const reporterList = command.reporter.split(',');
+      const reporterObjects: Reporter[] = reporterList.map(c => {
+        if (reporters[c])
+          return new reporters[c]();
+        try {
+          const p = path.resolve(process.cwd(), c);
+          return new (require(p).default)();
+        } catch (e) {
+          console.error('Invalid reporter ' + c, e);
+          process.exit(1);
+        }
+      });
+      await runTests(config, suite, new Multiplexer(reporterObjects));
+      const hasFailures = suite.eachTest(t => t.error);
+      process.exit(hasFailures ? 1 : 0);
     });
-    await runTests(config, suite, new Multiplexer(reporterObjects));
-    const hasFailures = suite.eachTest(t => t.error);
-    process.exit(hasFailures ? 1 : 0);
-  });
 
 program.parse(process.argv);
 

--- a/test-runner/src/expect.ts
+++ b/test-runner/src/expect.ts
@@ -35,7 +35,7 @@ export function initializeImageMatcher(config: RunnerConfig) {
   function toMatchImage(received: Buffer, name: string, options?: { threshold?: number }) {
     const { pass, message } = compare(received, name, config, testFile, options);
     return { pass, message: () => message };
-  };
+  }
   expect.extend({ toMatchImage });
 }
 

--- a/test-runner/src/golden.ts
+++ b/test-runner/src/golden.ts
@@ -70,7 +70,7 @@ function compareText(actual: Buffer, expectedBuffer: Buffer): { diff?: object; e
   };
 }
 
-export function compare(actual: Buffer, name: string, config: RunnerConfig, testFile: string, options?: { threshold?: number } ): { pass: boolean; message?: string; } {
+export function compare(actual: Buffer, name: string, config: RunnerConfig, testFile: string, options?: { threshold?: number }): { pass: boolean; message?: string; } {
   let expectedPath: string;
   const relativeTestFile = path.relative(config.testDir, testFile);
   const testAssetsDir = relativeTestFile.replace(/\.spec\.[jt]s/, '');
@@ -125,8 +125,8 @@ export function compare(actual: Buffer, name: string, config: RunnerConfig, test
   }
   fs.writeFileSync(actualPath, actual);
   if (result.diff)
-    fs.writeFileSync(diffPath, result.diff);  
-  
+    fs.writeFileSync(diffPath, result.diff);
+
   const output = [
     c.red(`Image comparison failed:`),
   ];

--- a/test-runner/src/index.ts
+++ b/test-runner/src/index.ts
@@ -42,8 +42,8 @@ declare global {
   }
 }
 
-let beforeFunctions: Function[] = [];
-let afterFunctions: Function[] = [];
+const beforeFunctions: Function[] = [];
+const afterFunctions: Function[] = [];
 let matrix: Matrix = {};
 
 global['before'] = (fn: Function) => beforeFunctions.push(fn);
@@ -52,11 +52,11 @@ global['matrix'] = (m: Matrix) => matrix = m;
 
 export function registerFixture<T extends keyof TestState>(name: T, fn: (params: FixtureParameters & WorkerState & TestState, runTest: (arg: TestState[T]) => Promise<void>, config: RunnerConfig, test: Test) => Promise<void>) {
   registerFixtureT<RunnerConfig>(name, fn);
-};
+}
 
-export function registerWorkerFixture<T extends keyof (WorkerState & FixtureParameters)>(name: T, fn: (params: FixtureParameters & WorkerState, runTest: (arg: (WorkerState & FixtureParameters)[T]) => Promise<void>, config: RunnerConfig) => Promise<void>) {
+export function registerWorkerFixture<T extends keyof(WorkerState & FixtureParameters)>(name: T, fn: (params: FixtureParameters & WorkerState, runTest: (arg: (WorkerState & FixtureParameters)[T]) => Promise<void>, config: RunnerConfig) => Promise<void>) {
   registerWorkerFixtureT<RunnerConfig>(name, fn);
-};
+}
 
 export function collectTests(config: RunnerConfig, files: string[]): Suite {
   const revertBabelRequire = installTransform();

--- a/test-runner/src/reporters/base.ts
+++ b/test-runner/src/reporters/base.ts
@@ -26,7 +26,7 @@ import { Reporter } from '../reporter';
 import { RunnerConfig } from '../runnerConfig';
 import { Suite, Test } from '../test';
 
-const stackUtils = new StackUtils()
+const stackUtils = new StackUtils();
 
 export class BaseReporter implements Reporter  {
   pending: Test[] = [];
@@ -86,7 +86,7 @@ export class BaseReporter implements Reporter  {
   epilogue() {
     console.log('');
 
-    console.log(colors.green(`  ${this.passes.length} passed`) + colors.dim(` (${milliseconds(this.duration)})`));  
+    console.log(colors.green(`  ${this.passes.length} passed`) + colors.dim(` (${milliseconds(this.duration)})`));
 
     if (this.pending.length)
       console.log(colors.yellow(`  ${this.pending.length} skipped`));
@@ -126,9 +126,9 @@ export class BaseReporter implements Reporter  {
         const source = fs.readFileSync(failure.file, 'utf8');
         tokens.push('');
         tokens.push(indent(codeFrameColumns(source, {
-            start: position,
-          },
-          { highlightCode: true}
+          start: position,
+        },
+        { highlightCode: true}
         ), '    '));
       }
       tokens.push('');

--- a/test-runner/src/reporters/dot.ts
+++ b/test-runner/src/reporters/dot.ts
@@ -21,22 +21,22 @@ import { Test } from '../test';
 class DotReporter extends BaseReporter {
   onPending(test: Test) {
     super.onPending(test);
-    process.stdout.write(colors.yellow('∘'))
+    process.stdout.write(colors.yellow('∘'));
   }
-  
+
   onPass(test: Test) {
     super.onPass(test);
     process.stdout.write(colors.green('·'));
   }
-  
+
   onFail(test: Test) {
     super.onFail(test);
     if (test.duration >= test.timeout)
       process.stdout.write(colors.red('T'));
     else
       process.stdout.write(colors.red('F'));
-  } 
- 
+  }
+
   onEnd() {
     super.onEnd();
     process.stdout.write('\n');

--- a/test-runner/src/reporters/json.ts
+++ b/test-runner/src/reporters/json.ts
@@ -65,7 +65,7 @@ class JSONReporter extends BaseReporter {
 function stdioEntry(s: string | Buffer): any {
   if (typeof s === 'string')
     return { text: s };
-  return { buffer: s.toString('base64') }
+  return { buffer: s.toString('base64') };
 }
 
 export default JSONReporter;

--- a/test-runner/src/reporters/multiplexer.ts
+++ b/test-runner/src/reporters/multiplexer.ts
@@ -42,12 +42,12 @@ export class Multiplexer implements Reporter {
 
   onStdOut(test: Test, chunk: string | Buffer) {
     for (const reporter of this._reporters)
-      reporter.onStdOut(test, chunk);    
+      reporter.onStdOut(test, chunk);
   }
 
   onStdErr(test: Test, chunk: string | Buffer) {
     for (const reporter of this._reporters)
-      reporter.onStdErr(test, chunk);    
+      reporter.onStdErr(test, chunk);
   }
 
   onPass(test: Test) {

--- a/test-runner/src/reporters/pytest.ts
+++ b/test-runner/src/reporters/pytest.ts
@@ -22,7 +22,7 @@ import { BaseReporter } from './base';
 import { RunnerConfig } from '../runnerConfig';
 
 const cursorPrevLine = '\u001B[F';
-const eraseLine = '\u001B[2K'
+const eraseLine = '\u001B[2K';
 
 type Row = {
   id: string;
@@ -214,7 +214,7 @@ const yellowBar = colors.yellow('▇');
 function serializeConfiguration(configuration: Configuration): string {
   const tokens = [];
   for (const { name, value } of configuration)
-      tokens.push(`${name}=${value}`);
+    tokens.push(`${name}=${value}`);
   return tokens.join(', ');
 }
 

--- a/test-runner/src/runner.ts
+++ b/test-runner/src/runner.ts
@@ -59,7 +59,7 @@ export class Runner {
       const total = suite.total();
       console.log();
       const jobs = Math.min(config.jobs, suite.suites.length);
-      console.log(`Running ${total} test${ total > 1 ? 's' : '' } using ${jobs} worker${ jobs > 1 ? 's' : ''}`);
+      console.log(`Running ${total} test${total > 1 ? 's' : ''} using ${jobs} worker${jobs > 1 ? 's' : ''}`);
     }
   }
 
@@ -240,7 +240,7 @@ class OopWorker extends Worker {
       stdio: ['ignore', 'ignore', 'ignore', 'ipc']
     });
     this.process.on('exit', () => this.emit('exit'));
-    this.process.on('error', (e) => {});  // do not yell at a send to dead process.
+    this.process.on('error', e => {});  // do not yell at a send to dead process.
     this.process.on('message', message => {
       const { method, params } = message;
       this.emit(method, params);

--- a/test-runner/src/test.ts
+++ b/test-runner/src/test.ts
@@ -164,7 +164,7 @@ export class Suite {
 export function serializeConfiguration(configuration: Configuration): string {
   const tokens = [];
   for (const { name, value } of configuration)
-      tokens.push(`${name}=${value}`);
+    tokens.push(`${name}=${value}`);
   return tokens.join(', ');
 }
 
@@ -173,7 +173,7 @@ export function serializeError(error: Error | any): any {
     return {
       message: error.message,
       stack: error.stack
-    }
+    };
   }
   return trimCycles(error);
 }
@@ -181,13 +181,13 @@ export function serializeError(error: Error | any): any {
 function trimCycles(obj: any): any {
   const cache = new Set();
   return JSON.parse(
-    JSON.stringify(obj, function(key, value) {
-      if (typeof value === 'object' && value !== null) {
-        if (cache.has(value))
-          return '' + value;
-        cache.add(value);
-      }
-      return value;
-    })
+      JSON.stringify(obj, function(key, value) {
+        if (typeof value === 'object' && value !== null) {
+          if (cache.has(value))
+            return '' + value;
+          cache.add(value);
+        }
+        return value;
+      })
   );
 }

--- a/test-runner/src/testCollector.ts
+++ b/test-runner/src/testCollector.ts
@@ -71,7 +71,7 @@ export class TestCollector {
         const values = this._matrix[name];
         if (!values)
           continue;
-        let state = generatorConfigurations.length ? generatorConfigurations.slice() : [[]];
+        const state = generatorConfigurations.length ? generatorConfigurations.slice() : [[]];
         generatorConfigurations.length = 0;
         for (const gen of state) {
           for (const value of values)

--- a/test-runner/src/testRunner.ts
+++ b/test-runner/src/testRunner.ts
@@ -92,11 +92,11 @@ export class TestRunner extends EventEmitter {
   }
 
   stdout(chunk: string | Buffer) {
-    this.emit('stdout', { testId: this._testId(), ...chunkToParams(chunk) })
+    this.emit('stdout', { testId: this._testId(), ...chunkToParams(chunk) });
   }
 
   stderr(chunk: string | Buffer) {
-    this.emit('stderr', { testId: this._testId(), ...chunkToParams(chunk) })
+    this.emit('stderr', { testId: this._testId(), ...chunkToParams(chunk) });
   }
 
   async run() {
@@ -121,11 +121,11 @@ export class TestRunner extends EventEmitter {
       this._reportDone();
     }
     for (const entry of suite._entries) {
-      if (entry instanceof Suite) {
+      if (entry instanceof Suite)
         await this._runSuite(entry);
-      } else {
+      else
         await this._runTest(entry);
-      }
+
     }
     try {
       await this._runHooks(suite, 'afterAll', 'after');

--- a/test-runner/src/transform.ts
+++ b/test-runner/src/transform.ts
@@ -56,7 +56,7 @@ export function installTransform(): () => void {
     sourceMaps.set(filename, sourceMapPath);
     if (fs.existsSync(codePath))
       return fs.readFileSync(codePath, 'utf8');
-    
+
     const result = babel.transformFileSync(filename, {
       presets: [
         ['@babel/preset-env', {targets: {node: 'current'}}],
@@ -66,7 +66,7 @@ export function installTransform(): () => void {
     if (result.code) {
       fs.mkdirSync(path.dirname(cachePath), {recursive: true});
       if (result.map)
-        fs.writeFileSync(sourceMapPath, JSON.stringify(result.map), 'utf8');  
+        fs.writeFileSync(sourceMapPath, JSON.stringify(result.map), 'utf8');
       fs.writeFileSync(codePath, result.code, 'utf8');
     }
     return result.code;

--- a/test-runner/test/exit-code.spec.ts
+++ b/test-runner/test/exit-code.spec.ts
@@ -23,28 +23,28 @@ import '../lib';
 
 const removeFolderAsync = promisify(rimraf);
 
-it('should fail', async() => {
+it('should fail', async () => {
   const result = await runTest('one-failure.js');
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);
 });
 
-it('should succeed', async() => {
+it('should succeed', async () => {
   const result = await runTest('one-success.js');
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
   expect(result.failed).toBe(0);
 });
 
-it('should access error in fixture', async() => {
+it('should access error in fixture', async () => {
   const result = await runTest('test-error-visible-in-fixture.js');
   expect(result.exitCode).toBe(1);
   const data = JSON.parse(fs.readFileSync(path.join(__dirname, 'test-results', 'test-error-visible-in-fixture.txt')).toString());
   expect(data.message).toContain('Object.is equality');
 });
 
-it('should access data in fixture', async() => {
+it('should access data in fixture', async () => {
   const result = await runTest('test-data-visible-in-fixture.js');
   expect(result.exitCode).toBe(1);
   const data = JSON.parse(fs.readFileSync(path.join(__dirname, 'test-results', 'results.json')).toString());
@@ -54,19 +54,19 @@ it('should access data in fixture', async() => {
   expect(test.stderr).toEqual([{ text: 'console.error\n' }]);
 });
 
-it('should handle worker fixture timeout', async() => {
+it('should handle worker fixture timeout', async () => {
   const result = await runTest('worker-fixture-timeout.js', 1000);
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('Timeout of 1000ms');
 });
 
-it('should handle worker fixture error', async() => {
+it('should handle worker fixture error', async () => {
   const result = await runTest('worker-fixture-error.js');
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('Worker failed');
 });
 
-it('should collect stdio', async() => {
+it('should collect stdio', async () => {
   const result = await runTest('stdio.js');
   expect(result.exitCode).toBe(0);
   const data = JSON.parse(fs.readFileSync(path.join(__dirname, 'test-results', 'results.json')).toString());
@@ -77,7 +77,7 @@ it('should collect stdio', async() => {
 });
 
 async function runTest(filePath: string, timeout = 10000) {
-  const outputDir = path.join(__dirname, 'test-results')
+  const outputDir = path.join(__dirname, 'test-results');
   await removeFolderAsync(outputDir).catch(e => {});
 
   const { output, status } = spawnSync('node', [
@@ -97,7 +97,7 @@ async function runTest(filePath: string, timeout = 10000) {
   return {
     exitCode: status,
     output: output.toString(),
-    passed: parseInt(passed),
-    failed: parseInt(failed || '0')
-  }
+    passed: parseInt(passed, 10),
+    failed: parseInt(failed || '0', 10)
+  };
 }


### PR DESCRIPTION
Runs eslint over the testrunner source and tests.

Because the testrunner tests do not have a tsconfig, I was struggling to get our type-aware eslint rules to run. However, I noticed that we only have one type-aware rule: '@typescript-eslint/no-unnecessary-type-assertion'. I was previously fighting this rule because it doesn't actually work very well. Sometimes it removes an assertion as unnecessary when it is in fact necessary. So I decided to just remove this rule. This also made our eslint command twice as fast.

I'll revisit '@typescript-eslint/no-unnecessary-type-assertion' in a month to see if it was actually catching things.

Sibling patch of #3638