### PR TITLE
feat: upgrade node to 14.x in Docker image

### DIFF
--- a/docs/docker/Dockerfile.bionic
+++ b/docs/docker/Dockerfile.bionic
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 # 1. Install node12
 RUN apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs
 
 # 2. Install WebKit dependencies

--- a/docs/docker/Dockerfile.bionic
+++ b/docs/docker/Dockerfile.bionic
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic
 
-# 1. Install node12
+# 1. Install node14
 RUN apt-get update && apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs


### PR DESCRIPTION
Node 14 supports many new language features, like optional chaining, that are really convenient to use in tests