### PR TITLE
fix(test): import playwright types with import type

### DIFF
--- a/test/browsercontext-user-agent.spec.ts
+++ b/test/browsercontext-user-agent.spec.ts
@@ -17,7 +17,6 @@
 import './playwright.fixtures';
 
 import utils from './utils';
-const {devices} = require('..');
 
 it('should work', async({browser, server}) => {
   {
@@ -57,7 +56,7 @@ it('should work for subframes', async({browser, server}) => {
   }
 });
 
-it('should emulate device user-agent', async({browser, server}) => {
+it('should emulate device user-agent', async({browser, server, playwright}) => {
   {
     const context = await browser.newContext();
     const page = await context.newPage();
@@ -66,7 +65,7 @@ it('should emulate device user-agent', async({browser, server}) => {
     await context.close();
   }
   {
-    const context = await browser.newContext({ userAgent: devices['iPhone 6'].userAgent });
+    const context = await browser.newContext({ userAgent: playwright.devices['iPhone 6'].userAgent });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/mobile.html');
     expect(await page.evaluate(() => navigator.userAgent)).toContain('iPhone');

--- a/test/channels.spec.ts
+++ b/test/channels.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import { options } from './playwright.fixtures';
-import { ChromiumBrowser } from '..';
+import type { ChromiumBrowser } from '..';
 
 it('should work', async({browser}) => {
   expect(!!browser['_connection']).toBeTruthy();

--- a/test/chromium/chromium.spec.ts
+++ b/test/chromium/chromium.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { options } from '../playwright.fixtures';
-import { ChromiumBrowserContext } from '../..';
+import type { ChromiumBrowserContext } from '../..';
 
 it.skip(!options.CHROMIUM)('should create a worker from a service worker', async({page, server, context}) => {
   const [worker] = await Promise.all([

--- a/test/chromium/launcher.spec.ts
+++ b/test/chromium/launcher.spec.ts
@@ -17,7 +17,7 @@ import { options } from '../playwright.fixtures';
 
 import path from 'path';
 import utils from '../utils';
-import { ChromiumBrowser, ChromiumBrowserContext } from '../..';
+import type { ChromiumBrowser, ChromiumBrowserContext } from '../..';
 const { makeUserDataDir, removeUserDataDir } = utils;
 
 it.skip(options.WIRE || !options.CHROMIUM)('should throw with remote-debugging-pipe argument', async({browserType, defaultBrowserOptions}) => {

--- a/test/chromium/tracing.spec.ts
+++ b/test/chromium/tracing.spec.ts
@@ -19,7 +19,7 @@ import { registerFixture } from '../../test-runner';
 
 import fs from 'fs';
 import path from 'path';
-import { ChromiumBrowser } from '../..';
+import type { ChromiumBrowser } from '../..';
 
 declare global {
   interface TestState {

--- a/test/downloads-path.spec.ts
+++ b/test/downloads-path.spec.ts
@@ -23,7 +23,7 @@ import path from 'path';
 import fs from 'fs';
 import os from 'os';
 import {mkdtempAsync, removeFolderAsync} from './utils';
-import { Browser, BrowserContext } from '..';
+import type { Browser, BrowserContext } from '..';
 
 declare global {
   interface TestState {

--- a/test/page-network-idle.spec.ts
+++ b/test/page-network-idle.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import './playwright.fixtures';
-import { Frame, Page } from '..';
+import type { Frame, Page } from '..';
 import { TestServer } from '../utils/testserver';
 
 it('should navigate to empty page with networkidle', async({page, server}) => {

--- a/test/page-wait-for-load-state.spec.ts
+++ b/test/page-wait-for-load-state.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { options } from './playwright.fixtures';
-import { Route } from '..';
+import type { Route } from '..';
 
 it('should pick up ongoing navigation', async({page, server}) => {
   let response = null;

--- a/test/page-wait-for-navigation.spec.ts
+++ b/test/page-wait-for-navigation.spec.ts
@@ -18,7 +18,7 @@
 import { options } from './playwright.fixtures';
 
 import utils from './utils';
-import { Frame } from '..';
+import type { Frame } from '..';
 
 it('should work', async({page, server}) => {
   await page.goto(server.EMPTY_PAGE);

--- a/test/playwright.fixtures.ts
+++ b/test/playwright.fixtures.ts
@@ -113,6 +113,9 @@ registerWorkerFixture('defaultBrowserOptions', async({browserName}, test) => {
 });
 
 registerWorkerFixture('playwright', async({browserName}, test) => {
+  const playwrightCacheEntry = require.cache[require.resolve('../index')];
+  if (playwrightCacheEntry)
+    throw new Error('Could not set playwright to test mode because it was required directly from ' + playwrightCacheEntry.parent.id);
   setUnderTest(); // Note: we must call setUnderTest before requiring Playwright
 
   const {coverage, uninstall} = installCoverageHooks(browserName);

--- a/test/remoteServer.fixture.ts
+++ b/test/remoteServer.fixture.ts
@@ -18,7 +18,7 @@ import { registerFixture } from '../test-runner/lib';
 
 import path from 'path';
 import { spawn } from 'child_process';
-import { BrowserType, Browser, LaunchOptions } from '..';
+import type { BrowserType, Browser, LaunchOptions } from '..';
 
 declare global {
   interface TestState {

--- a/test/screencast.spec.ts
+++ b/test/screencast.spec.ts
@@ -16,7 +16,7 @@
 
 import { options } from './playwright.fixtures';
 import { registerFixture } from '../test-runner';
-import { Page } from '..';
+import type { Page } from '..';
 
 import fs from 'fs';
 import path from 'path';

--- a/test/workers.spec.ts
+++ b/test/workers.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import './playwright.fixtures';
-import { ConsoleMessage } from '..';
+import type { ConsoleMessage } from '..';
 
 it('Page.workers', async function({page, server}) {
   await Promise.all([


### PR DESCRIPTION
Because we don't strip unused types, our playwright imports became real. Because of the way we inject toImpl, it is important that playwright has not been loaded by the time the fixture setup runs. This changes imports of playwright to `import type` in order to fix this. 