### PR TITLE
devops: add yarn and git in the docker container

### DIFF
--- a/docs/docker/Dockerfile.bionic
+++ b/docs/docker/Dockerfile.bionic
@@ -62,7 +62,12 @@ RUN groupadd -r pwuser && useradd -r -g pwuser -G audio,video pwuser \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb
 
-# 9. Run everything after as non-privileged user.
+# 9. Install git & yarn. These are very helpful in a docker image.
+
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
+    npm install -g yarn
+
+# 10. Run everything after as non-privileged user.
 USER pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===


### PR DESCRIPTION
This will help consuming docker image as an env for test execution.

Fixes #3529.