### PR TITLE
fix(eslint): ignore output dir

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,4 +14,5 @@ utils/generate_types/test/test.ts
 /test/
 node_modules/
 browser_patches/*/checkout/
-packages/**/*.d.ts
+output
+


### PR DESCRIPTION
packages/test-installation/output/ was being checked by eslint, but these are generated files we should ignore. Doclint also seems to use an output folder, so i added a generic online `output`.

packages/**/*.d.ts was incorrectly ignored. We actually do want to lint these.