### PR TITLE
test: always setUnderTest in index.js, rename to setDevMode

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+const { setDevMode } = require('./lib/utils/utils');
+setDevMode(); // Note: we must call setDevMode before initializing.
+
 const { Playwright } = require('./lib/server/playwright');
 const { Electron } = require('./lib/server/electron/electron');
 const { setupInProcess } = require('./lib/inprocess');
@@ -21,9 +24,4 @@ const path = require('path');
 
 const playwright = new Playwright(__dirname, require(path.join(__dirname, 'browsers.json'))['browsers']);
 playwright.electron = new Electron();
-if (process.env.PWCHANNEL === 'none') {
-  playwright._toImpl = x => x;
-  module.exports = playwright;
-} else {
-  module.exports = setupInProcess(playwright);
-}
+module.exports = setupInProcess(playwright);

--- a/src/client/browserContext.ts
+++ b/src/client/browserContext.ts
@@ -26,7 +26,7 @@ import { Events } from './events';
 import { TimeoutSettings } from '../utils/timeoutSettings';
 import { Waiter } from './waiter';
 import { URLMatch, Headers, WaitForEventOptions } from './types';
-import { isUnderTest, headersObjectToArray } from '../utils/utils';
+import { isDevMode, headersObjectToArray } from '../utils/utils';
 
 export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel, channels.BrowserContextInitializer> {
   _pages = new Set<Page>();
@@ -158,7 +158,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel,
   }
 
   async setHTTPCredentials(httpCredentials: { username: string, password: string } | null): Promise<void> {
-    if (!isUnderTest())
+    if (!isDevMode())
       deprecate(`context.setHTTPCredentials`, `warning: method |context.setHTTPCredentials()| is deprecated. Instead of changing credentials, create another browser context with new credentials.`);
     return this._wrapApiCall('browserContext.setHTTPCredentials', async () => {
       await this._channel.setHTTPCredentials({ httpCredentials: httpCredentials || undefined });

--- a/src/inprocess.ts
+++ b/src/inprocess.ts
@@ -20,7 +20,7 @@ import type { Playwright as PlaywrightAPI } from './client/playwright';
 import { PlaywrightDispatcher } from './dispatchers/playwrightDispatcher';
 import { Connection } from './client/connection';
 import { BrowserServerLauncherImpl } from './browserServerImpl';
-import { isUnderTest } from './utils/utils';
+import { isDevMode } from './utils/utils';
 
 export function setupInProcess(playwright: PlaywrightImpl): PlaywrightAPI {
   const clientConnection = new Connection();
@@ -41,7 +41,7 @@ export function setupInProcess(playwright: PlaywrightImpl): PlaywrightAPI {
   dispatcherConnection.onmessage = message => setImmediate(() => clientConnection.dispatch(message));
   clientConnection.onmessage = message => setImmediate(() => dispatcherConnection.dispatch(message));
 
-  if (isUnderTest())
+  if (isDevMode())
     (playwrightAPI as any)._toImpl = (x: any) => dispatcherConnection._dispatchers.get(x._guid)!._object;
   return playwrightAPI;
 }

--- a/src/protocol/validatorPrimitives.ts
+++ b/src/protocol/validatorPrimitives.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isUnderTest } from '../utils/utils';
+import { isDevMode } from '../utils/utils';
 
 export class ValidationError extends Error {}
 export type Validator = (arg: any, path: string) => any;
@@ -81,7 +81,7 @@ export const tObject = (s: { [key: string]: Validator }): Validator => {
       if (!Object.is(value, undefined))
         result[key] = value;
     }
-    if (isUnderTest()) {
+    if (isDevMode()) {
       for (const [key, value] of Object.entries(arg)) {
         if (key.startsWith('__testHook'))
           result[key] = value;

--- a/src/server/processLauncher.ts
+++ b/src/server/processLauncher.ts
@@ -22,7 +22,7 @@ import * as stream from 'stream';
 import { helper } from './helper';
 import { Progress } from './progress';
 import * as types from './types';
-import { isUnderTest } from '../utils/utils';
+import { isDevMode } from '../utils/utils';
 
 export type Env = {[key: string]: string | number | boolean | undefined};
 
@@ -117,7 +117,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     listeners.push(helper.addEventListener(process, 'SIGINT', () => {
       gracefullyClose().then(() => {
         // Give tests a chance to dispatch any async calls.
-        if (isUnderTest())
+        if (isDevMode())
           setTimeout(() => process.exit(130), 0);
         else
           process.exit(130);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -61,7 +61,7 @@ export function assert(value: any, message?: string): asserts value {
 }
 
 export function debugAssert(value: any, message?: string): asserts value {
-  if (isUnderTest() && !value)
+  if (isDevMode() && !value)
     throw new Error(message);
 }
 
@@ -86,12 +86,12 @@ export function isDebugMode(): boolean {
   return isInDebugMode;
 }
 
-let _isUnderTest = false;
-export function setUnderTest() {
-  _isUnderTest = true;
+let _isDevMode = false;
+export function setDevMode() {
+  _isDevMode = true;
 }
-export function isUnderTest(): boolean {
-  return _isUnderTest;
+export function isDevMode(): boolean {
+  return _isDevMode;
 }
 
 export function getFromENV(name: string) {

--- a/test/fixtures/closeme.js
+++ b/test/fixtures/closeme.js
@@ -7,10 +7,7 @@
     };
   }
 
-  const path = require('path');
-  const { setUnderTest } = require(path.join(playwrightPath, 'lib', 'utils', 'utils'));
-  setUnderTest();
-  const playwright = require(path.join(playwrightPath, 'index'));
+  const playwright = require(require('path').join(playwrightPath, 'index'));
 
   const browserServer = await playwright[browserTypeName].launchServer(launchOptions);
   browserServer.on('close', (exitCode, signal) => {

--- a/test/playwright.fixtures.ts
+++ b/test/playwright.fixtures.ts
@@ -22,10 +22,9 @@ import type { LaunchOptions, BrowserType, Browser, BrowserContext, Page, Browser
 import { TestServer } from '../utils/testserver';
 import { Connection } from '../lib/client/connection';
 import { Transport } from '../lib/protocol/transport';
-import { setUnderTest } from '../lib/utils/utils';
 import { installCoverageHooks } from './coverage';
 import { parameters, registerFixture, registerWorkerFixture } from '../test-runner';
-import {mkdtempAsync, removeFolderAsync} from './utils';
+import { mkdtempAsync, removeFolderAsync } from './utils';
 
 export const options = {
   CHROMIUM: parameters.browserName === 'chromium',
@@ -113,11 +112,6 @@ registerWorkerFixture('defaultBrowserOptions', async({browserName}, test) => {
 });
 
 registerWorkerFixture('playwright', async({browserName}, test) => {
-  const playwrightCacheEntry = require.cache[require.resolve('../index')];
-  if (playwrightCacheEntry)
-    throw new Error('Could not set playwright to test mode because it was required directly from ' + playwrightCacheEntry.parent.id);
-  setUnderTest(); // Note: we must call setUnderTest before requiring Playwright
-
   const {coverage, uninstall} = installCoverageHooks(browserName);
   if (options.WIRE) {
     const connection = new Connection();


### PR DESCRIPTION
Root index.js is only used for local development, so
assuming dev mode there is fine. This way we do not have
to worry about calling setUnderTest early enough.