### PR TITLE
fix(debug): do not generate source urls for anonymous scripts

### DIFF
--- a/src/server/chromium/crCoverage.ts
+++ b/src/server/chromium/crCoverage.ts
@@ -102,9 +102,6 @@ class JSCoverage {
   }
 
   async _onScriptParsed(event: Protocol.Debugger.scriptParsedPayload) {
-    // Ignore playwright-injected scripts
-    if (sourceMap.isPlaywrightSourceUrl(event.url))
-      return;
     this._scriptIds.add(event.scriptId);
     // Ignore other anonymous scripts unless the reportAnonymousScripts option is true.
     if (!event.url && !this._reportAnonymousScripts)

--- a/src/server/chromium/crCoverage.ts
+++ b/src/server/chromium/crCoverage.ts
@@ -19,7 +19,6 @@ import { CRSession } from './crConnection';
 import { helper, RegisteredListener } from '../helper';
 import { Protocol } from './protocol';
 import * as types from '../types';
-import * as sourceMap from '../../utils/sourceMap';
 import { assert } from '../../utils/utils';
 
 export class CRCoverage {

--- a/src/utils/sourceMap.ts
+++ b/src/utils/sourceMap.ts
@@ -28,23 +28,19 @@ let sourceUrlCounter = 0;
 const playwrightSourceUrlPrefix = '__playwright_evaluation_script__';
 const sourceUrlRegex = /^[\040\t]*\/\/[@#] sourceURL=\s*(\S*?)\s*$/m;
 
-export function isPlaywrightSourceUrl(s: string): boolean {
-  return s.startsWith(playwrightSourceUrlPrefix);
-}
-
 export function ensureSourceUrl(expression: string): string {
   return sourceUrlRegex.test(expression) ? expression : expression + generateSourceUrl();
 }
 
 export async function generateSourceMapUrl(functionText: string, generatedText: string): Promise<string> {
   if (!isDebugMode())
-    return generateSourceUrl();
+    return '';
   const sourceMapUrl = await innerGenerateSourceMapUrl(functionText, generatedText);
   return sourceMapUrl || generateSourceUrl();
 }
 
 export function generateSourceUrl(): string {
-  return `\n//# sourceURL=${playwrightSourceUrlPrefix}${sourceUrlCounter++}\n`;
+  return isDebugMode() ? `\n//# sourceURL=${playwrightSourceUrlPrefix}${sourceUrlCounter++}\n` : '';
 }
 
 async function innerGenerateSourceMapUrl(functionText: string, generatedText: string): Promise<string | undefined> {

--- a/test/chromium-js-coverage.spec.ts
+++ b/test/chromium-js-coverage.spec.ts
@@ -57,15 +57,6 @@ describe('oopif', suite => {
     expect(coverage.length).toBe(2);
   });
 
-  it('should ignore playwright internal scripts if reportAnonymousScripts is true', async function({page, server}) {
-    await page.coverage.startJSCoverage({reportAnonymousScripts: true});
-    await page.goto(server.EMPTY_PAGE);
-    await page.evaluate('console.log("foo")');
-    await page.evaluate(() => console.log('bar'));
-    const coverage = await page.coverage.stopJSCoverage();
-    expect(coverage.length).toBe(0);
-  });
-
   it('should report multiple scripts', async function({page, server}) {
     await page.coverage.startJSCoverage();
     await page.goto(server.PREFIX + '/jscoverage/multiple.html');


### PR DESCRIPTION
DevTools hangs otherwise, we already recommend using PWDEBUG=true for actual source maps.