### PR TITLE
devops: switch docker publishing to a bash script

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -21,15 +21,16 @@ jobs:
         node-version: 10.15
     - run: npm ci
     - run: npm run build
-    - run: ./docs/docker/build.sh --prepare-context
-    - uses: docker/build-push-action@v1
-      with:
-        username: playwright
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        registry: playwright.azurecr.io
-        repository: public/playwright
-        path: docs/docker/
-        dockerfile: docs/docker/Dockerfile.bionic
-        tags: next
-        tag_with_sha: true
+    - name: login & publish to docker
+      run: |
+        # login to docker
+        docker login --username playwright --password ${{ secrets.DOCKER_PASSWORD }} playwright.azurecr.io
+        # build docker image
+        ./docs/docker/build.sh
+        # tag image accordingly
+        docker tag playwright:localbuild public/playwright:next
+        docker tag playwright:localbuild public/playwright:sha-$(git rev-parse HEAD)
+        docker rmi playwright:localbuild
+        # push image to registry
+        docker push public/playwright:next
 

--- a/docs/docker/build.sh
+++ b/docs/docker/build.sh
@@ -3,7 +3,7 @@ set -e
 set +x
 
 if [[ ($1 == '--help') || ($1 == '-h') ]]; then
-  echo "usage: $(basename $0) [--prepare-only]"
+  echo "usage: $(basename $0)"
   echo
   echo "Build Playwright docker image and tag it as 'playwright:localbuild'."
   echo "Once image is built, you can run it with"
@@ -12,22 +12,12 @@ if [[ ($1 == '--help') || ($1 == '-h') ]]; then
   echo ""
   echo "NOTE: this requires on Playwright dependencies to be installed with 'npm install'"
   echo "      and Playwright itself being built with 'npm run build'"
-  echo
-  echo "  --prepare-context    prepare docker context and skip building."
-  echo "                       This is to defer building & publishing to Docker Github Action."
   echo ""
   exit 0
 fi
 
-PREPARE_CONTEXT_ONLY=""
-if [[ $1 == "--prepare-context" ]]; then
-  PREPARE_CONTEXT_ONLY="1"
-fi
-
 function cleanup() {
-  if [[ -z "${PREPARE_CONTEXT_ONLY}" ]]; then
-    rm -f "playwright.tar.gz"
-  fi
+  rm -f "playwright.tar.gz"
 }
 
 trap "cleanup; cd $(pwd -P)" EXIT
@@ -36,9 +26,5 @@ cd "$(dirname "$0")"
 # We rely on `./playwright.tar.gz` to download browsers into the docker
 # image.
 node ../../packages/build_package.js playwright ./playwright.tar.gz
-
-if [[ -n "${PREPARE_CONTEXT_ONLY}" ]]; then
-  exit 0
-fi
 
 docker build -t "playwright:localbuild" -f Dockerfile.bionic .


### PR DESCRIPTION
It turns out Github Actions have docker pre-installed.

This patch unifies the codepaths that we use to build docker image
locally and to publish it from CI.

As a result, there's no extra `--prepare-context` argument in
`//docs/docker/build.sh` that was used solely on CI.

References #2926