### PR TITLE
feat: add browser type to device descriptors

### DIFF
--- a/src/client/playwright.ts
+++ b/src/client/playwright.ts
@@ -27,7 +27,8 @@ type DeviceDescriptor = {
   viewport: Size,
   deviceScaleFactor: number,
   isMobile: boolean,
-  hasTouch: boolean
+  hasTouch: boolean,
+  defaultBrowserType: 'chromium' | 'firefox' | 'webkit'
 };
 type Devices = { [name: string]: DeviceDescriptor };
 

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -102,6 +102,7 @@ export type PlaywrightInitializer = {
       deviceScaleFactor: number,
       isMobile: boolean,
       hasTouch: boolean,
+      defaultBrowserType: 'chromium' | 'firefox' | 'webkit',
     },
   }[],
   selectors: SelectorsChannel,

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -143,6 +143,12 @@ Playwright:
               deviceScaleFactor: number
               isMobile: boolean
               hasTouch: boolean
+              defaultBrowserType:
+                type: enum
+                literals:
+                - chromium
+                - firefox
+                - webkit
     selectors: Selectors
 
 

--- a/src/server/deviceDescriptors.ts
+++ b/src/server/deviceDescriptors.ts
@@ -26,7 +26,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 1,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'Blackberry PlayBook landscape': {
     'userAgent': 'Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/7.2.1.0 Safari/536.2+',
@@ -36,7 +37,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 1,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'BlackBerry Z30': {
     'userAgent': 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.0.9.2372 Mobile Safari/537.10+',
@@ -46,7 +48,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'BlackBerry Z30 landscape': {
     'userAgent': 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.0.9.2372 Mobile Safari/537.10+',
@@ -56,7 +59,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'Galaxy Note 3': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
@@ -66,7 +70,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'Galaxy Note 3 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
@@ -76,7 +81,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'Galaxy Note II': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
@@ -86,7 +92,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'Galaxy Note II landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
@@ -96,7 +103,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'Galaxy S III': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
@@ -106,7 +114,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'Galaxy S III landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
@@ -116,7 +125,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'Galaxy S5': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -126,7 +136,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Galaxy S5 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -136,7 +147,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'iPad (gen 6)': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -146,7 +158,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPad (gen 6) landscape': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -156,7 +169,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPad (gen 7)': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -166,7 +180,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPad (gen 7) landscape': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -176,7 +191,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPad Mini': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -186,7 +202,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPad Mini landscape': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -196,7 +213,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPad Pro 11': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -206,7 +224,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPad Pro 11 landscape': {
     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -216,7 +235,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 6': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -226,7 +246,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 6 landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -236,7 +257,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 6 Plus': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -246,7 +268,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 6 Plus landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -256,7 +279,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 7': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -266,7 +290,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 7 landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -276,7 +301,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 7 Plus': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -286,7 +312,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 7 Plus landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -296,7 +323,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 8': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -306,7 +334,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 8 landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -316,7 +345,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 8 Plus': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -326,7 +356,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 8 Plus landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -336,7 +367,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone SE': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
@@ -346,7 +378,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone SE landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
@@ -356,7 +389,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone X': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -366,7 +400,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone X landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
@@ -376,7 +411,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone XR': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
@@ -386,7 +422,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone XR landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
@@ -396,7 +433,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 11': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -406,7 +444,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 11 landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -416,7 +455,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 11 Pro': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -426,7 +466,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 11 Pro landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -436,7 +477,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 11 Pro Max': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -446,7 +488,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'iPhone 11 Pro Max landscape': {
     'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
@@ -456,7 +499,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'JioPhone 2': {
     'userAgent': 'Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-15-130718-i;Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5',
@@ -466,7 +510,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 1,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'firefox'
   },
   'JioPhone 2 landscape': {
     'userAgent': 'Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-15-130718-i;Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5',
@@ -476,7 +521,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 1,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'firefox'
   },
   'Kindle Fire HDX': {
     'userAgent': 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true',
@@ -486,7 +532,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'Kindle Fire HDX landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true',
@@ -496,7 +543,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'LG Optimus L70': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -506,7 +554,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 1.25,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'LG Optimus L70 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -516,7 +565,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 1.25,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Microsoft Lumia 550': {
     'userAgent': 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
@@ -526,7 +576,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Microsoft Lumia 550 landscape': {
     'userAgent': 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
@@ -536,7 +587,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Microsoft Lumia 950': {
     'userAgent': 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
@@ -546,7 +598,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 4,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Microsoft Lumia 950 landscape': {
     'userAgent': 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
@@ -556,7 +609,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 4,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 10': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 10 Build/MOB31T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
@@ -566,7 +620,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 10 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 10 Build/MOB31T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
@@ -576,7 +631,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 4': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -586,7 +642,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 4 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -596,7 +653,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 5': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -606,7 +664,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 5 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -616,7 +675,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 5X': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR4.170623.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -626,7 +686,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2.625,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 5X landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR4.170623.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -636,7 +697,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2.625,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 6': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -646,7 +708,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3.5,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 6 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -656,7 +719,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3.5,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 6P': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -666,7 +730,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3.5,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 6P landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -676,7 +741,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3.5,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 7': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
@@ -686,7 +752,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nexus 7 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Safari/537.36',
@@ -696,7 +763,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nokia Lumia 520': {
     'userAgent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 520)',
@@ -706,7 +774,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 1.5,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nokia Lumia 520 landscape': {
     'userAgent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 520)',
@@ -716,7 +785,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 1.5,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Nokia N9': {
     'userAgent': 'Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13',
@@ -726,7 +796,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 1,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'Nokia N9 landscape': {
     'userAgent': 'Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13',
@@ -736,7 +807,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 1,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'webkit'
   },
   'Pixel 2': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -746,7 +818,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2.625,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Pixel 2 landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -756,7 +829,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 2.625,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Pixel 2 XL': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -766,7 +840,8 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3.5,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   },
   'Pixel 2 XL landscape': {
     'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36',
@@ -776,6 +851,7 @@ export const DeviceDescriptors: types.Devices = {
     },
     'deviceScaleFactor': 3.5,
     'isMobile': true,
-    'hasTouch': true
+    'hasTouch': true,
+    'defaultBrowserType': 'chromium'
   }
 };

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -101,7 +101,8 @@ export type DeviceDescriptor = {
   viewport: Size,
   deviceScaleFactor: number,
   isMobile: boolean,
-  hasTouch: boolean
+  hasTouch: boolean,
+  defaultBrowserType: 'chromium' | 'firefox' | 'webkit'
 };
 export type Devices = { [name: string]: DeviceDescriptor };
 

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -184,6 +184,7 @@ type DeviceDescriptor = {
   deviceScaleFactor: number;
   isMobile: boolean;
   hasTouch: boolean;
+  defaultBrowserType: 'chromium' | 'firefox' | 'webkit';
 };
 
 export namespace errors {

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -728,6 +728,7 @@ playwright.chromium.launch().then(async browser => {
       deviceScaleFactor: 1,
       hasTouch: false,
       isMobile: true,
+      defaultBrowserType: 'chromium'
     };
     const iPhone = playwright.devices['iPhone 11'];
     const assertion: AssertType<string, typeof iPhone.userAgent> = true;


### PR DESCRIPTION
Found two cases which were not directly clear to me:
- Samsung Galaxy S3 Android Browser 4: Already Chromium or still WebKit?
- Nokia Lumia 520: In Theory IE10. I would drop it since its a device from April 2013

Also not sure if we want to keep it directly associated in the device descriptors, because that would maybe lead to breaking the backwards compatibility since `preferredBrowserType` is not directly related to the BrowserContextOptions.

Fixes #3728