### PR TITLE
devops: push all tags to docker registry

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -27,13 +27,10 @@ jobs:
         node-version: 10.15
     - run: npm ci
     - run: npm run build
-    - name: docker - build & publish
+    - run: ./docs/docker/build.sh
+    - name: tag & publish
       run: |
-        # build docker image
-        ./docs/docker/build.sh
-        # tag image accordingly
         docker tag playwright:localbuild playwright.azurecr.io/public/playwright:next
         docker tag playwright:localbuild playwright.azurecr.io/public/playwright:sha-${{ github.sha }}
-        # push image to registry
-        docker push playwright.azurecr.io/public/playwright
+        docker push --all-tags playwright.azurecr.io/public/playwright
 

--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -34,7 +34,6 @@ jobs:
         # tag image accordingly
         docker tag playwright:localbuild playwright.azurecr.io/public/playwright:next
         docker tag playwright:localbuild playwright.azurecr.io/public/playwright:sha-${{ github.sha }}
-        docker rmi playwright:localbuild
         # push image to registry
-        docker push playwright.azurecr.io/public/playwright:next
+        docker push playwright.azurecr.io/public/playwright
 


### PR DESCRIPTION
Instead of pushing one specific tag, push repository itself.
This should push all the associated tags.