### PR TITLE
devops: use microsoft/playwright-github-action@v1 everywhere

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -19,12 +19,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 10.15
-    - name: install required packages
-      run: |
-        sudo apt-get update
-        sudo apt-get install libgbm-dev
-        sudo apt-get install xvfb
-        sudo apt-get install ffmpeg
+    - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
     - run: npm run lint

--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -22,6 +22,7 @@ jobs:
         login-server: playwright.azurecr.io
         username: playwright
         password: ${{ secrets.DOCKER_PASSWORD }}
+    - uses: microsoft/playwright-github-action@v1
     - uses: actions/setup-node@v1
       with:
         node-version: 10.15


### PR DESCRIPTION
Since we launch browsers as part of the `npm run build`, we need
to prepare environment.