### PR TITLE
devops: use ubuntu 20.04 to build & publish docker images

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -13,7 +13,8 @@ on:
 jobs:
   publish-canary-docker:
     name: "publish to DockerHub"
-    runs-on: ubuntu-18.04
+    # We use `docker push --all-tags` to push all tags which is a newly addition to docker
+    runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -24,7 +24,8 @@ jobs:
 
   publish-docker-release:
     name: "publish to DockerHub"
-    runs-on: ubuntu-18.04
+    # We use `docker push --all-tags` to push all tags which is a newly addition to docker
+    runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We rely on `docker push --all-tags` flag that exists only in the
new version of docker.

The PR to docker with the flag: https://github.com/docker/cli/pull/2220