### PR TITLE
devops: use a helper script to tag and push docker images

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -32,7 +32,6 @@ jobs:
     - run: ./docs/docker/build.sh
     - name: tag & publish
       run: |
-        docker tag playwright:localbuild playwright.azurecr.io/public/playwright:next
-        docker tag playwright:localbuild playwright.azurecr.io/public/playwright:sha-${{ github.sha }}
-        docker push --all-tags playwright.azurecr.io/public/playwright
+        ./docs/docker/tag_and_push.sh playwright.azurecr.io/public/playwright:next
+        ./docs/docker/tag_and_push.sh playwright.azurecr.io/public/playwright:sha-${{ github.sha }}
 

--- a/docs/docker/tag_and_push.sh
+++ b/docs/docker/tag_and_push.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "-- tagging: $1"
+docker tag playwright:localbuild $1
+docker push $1


### PR DESCRIPTION
It turns out that the new `docker push --all-tags` is not yet available
in the latest docker distribution on Ubuntu 20.04.

This provides a helper script to tag and publish the docker image.