### PR TITLE
chore(docker): use root user in Docker image

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -68,8 +68,7 @@ Suggested configuration
 1. Using `--ipc=host` is also recommended when using Chromium—without it Chromium can run out of memory
    and crash. Learn more about this option in [Docker docs](https://docs.docker.com/engine/reference/run/#ipc-settings---ipc).
 1. Seeing other weird errors when launching Chromium? Try running your container
-   with `docker run --cap-add=SYS_ADMIN` when developing locally. Since the Dockerfile
-   adds a `pwuser` user as a non-privileged user, it may not have all the necessary privileges.
+   with `docker run --cap-add=SYS_ADMIN` when developing locally.
 1. [dumb-init](https://github.com/Yelp/dumb-init) is worth checking out if you're
    experiencing a lot of zombies Chromium processes sticking around. There's special
    treatment for processes with PID=1, which makes it hard to terminate Chromium
@@ -113,7 +112,7 @@ dist: bionic
 addons:
   apt:
     packages:
-    # These are required to run webkit	
+    # These are required to run webkit
     - libwoff1
     - libopus0
     - libwebp6
@@ -234,7 +233,7 @@ execute and download the browser binaries on every run.
 
 Most CI providers cache the [npm-cache](https://docs.npmjs.com/cli-commands/cache.html)
 directory (located at `$HOME/.npm`). If your CI pipelines caches the `node_modules`
-directory and you run `npm install` (instead of `npm ci`), the default configuration 
+directory and you run `npm install` (instead of `npm ci`), the default configuration
 **will not work**. This is because the `npm install` step will find the Playwright NPM
 package on disk and not execute the `postinstall` step.
 

--- a/docs/docker/Dockerfile.bionic
+++ b/docs/docker/Dockerfile.bionic
@@ -53,31 +53,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg
 
-# 7. Add user so we don't need --no-sandbox in Chromium
-RUN groupadd -r pwuser && useradd -r -g pwuser -G audio,video pwuser \
-    && mkdir -p /home/pwuser/Downloads \
-    && chown -R pwuser:pwuser /home/pwuser
-
-# 8. (Optional) Install XVFB if there's a need to run browsers in headful mode
+# 7. (Optional) Install XVFB if there's a need to run browsers in headful mode
 RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb
 
-# 9. Feature-parity with node.js base images.
+# 8. Feature-parity with node.js base images.
 RUN apt-get update && apt-get install -y --no-install-recommends git ssh && \
     npm install -g yarn
-
-# 10. Run everything after as non-privileged user.
-USER pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===
 
 # 1. Add tip-of-tree Playwright package to install its browsers.
 #    The package should be built beforehand from tip-of-tree Playwright.
-COPY --chown=pwuser ./playwright.tar.gz /home/pwuser/playwright.tar.gz
+COPY ./playwright.tar.gz /tmp/playwright.tar.gz
 
 # 2. Install playwright and then delete the installation.
-#    Browsers will remain downloaded in `/home/pwuser/.cache/ms-playwright`.
-RUN mkdir /home/pwuser/tmp && cd /home/pwuser/tmp && npm init -y && \
-    npm i ../playwright.tar.gz && \
-    cd ../ && rm -rf tmp && rm /home/pwuser/playwright.tar.gz
-
+#    Browsers will remain downloaded in `/root/.cache/ms-playwright`.
+RUN mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
+    npm i /tmp/playwright.tar.gz && \
+    rm -rf /tmp/pw && rm /tmp/playwright.tar.gz


### PR DESCRIPTION
As discussed offline other big images like Node.js or Nginx use root as the default user and the users in the end can base-off from our image to add their security features.

Not sure if follow up docs changes are required for that.

Fix #3703
Fix #3681