### PR TITLE
devops: remove warnings when running under root without sandbox

### DIFF
--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -89,10 +89,8 @@ export class Chromium extends BrowserTypeBase {
     if (browserArguments.indexOf('--no-sandbox') !== -1)
       return browserArguments;
     const runningAsRoot = process.geteuid && process.geteuid() === 0;
-    if (runningAsRoot) {
-      console.warn('WARNING: Playwright is being run under "root" user - disabling Chromium sandbox! Run under regular user to get rid of this warning.');
+    if (runningAsRoot)
       return ['--no-sandbox', ...browserArguments];
-    }
     return browserArguments;
   }
 

--- a/src/server/electron/electron.ts
+++ b/src/server/electron/electron.ts
@@ -153,10 +153,8 @@ export class Electron  {
 
       if (os.platform() === 'linux') {
         const runningAsRoot = process.geteuid && process.geteuid() === 0;
-        if (runningAsRoot && electronArguments.indexOf('--no-sandbox') === -1) {
-          console.warn('WARNING: Playwright is being run under "root" user - disabling Electron sandbox! Run under regular user to get rid of this warning.');
+        if (runningAsRoot && electronArguments.indexOf('--no-sandbox') === -1)
           electronArguments.push('--no-sandbox');
-        }
       }
 
       const { launchedProcess, gracefullyClose, kill } = await launchProcess({


### PR DESCRIPTION
As discussed offline, our testing scenarios assume running trusted
web content - so this warning is just a noise for this usecases.

When it comes to dealing with untrusted web content though, automation
authors need to make sure to not launch browsers under root in the first
place.