### PR TITLE
test: throw if 'browserName' param is not specified

### DIFF
--- a/test/playwright.fixtures.ts
+++ b/test/playwright.fixtures.ts
@@ -161,7 +161,7 @@ registerWorkerFixture('browserType', async ({playwright, browserName}, test) => 
 });
 
 registerWorkerFixture('browserName', async ({}, test) => {
-  await test('chromium');
+  throw new Error(`Parameter 'browserName' is not specified`);
 });
 
 registerWorkerFixture('browser', async ({browserType, defaultBrowserOptions}, test) => {

--- a/test/screencast.spec.ts
+++ b/test/screencast.spec.ts
@@ -163,6 +163,7 @@ class VideoPlayer {
 
 describe('screencast', suite => {
   suite.slow();
+  suite.flaky();
   suite.skip(options.WIRE);
 }, () => {
   it('should capture static page', test => {


### PR DESCRIPTION
drive-by: mark screencast as flaky