### PR TITLE
devops: bake commit SHA inside npm package

### DIFF
--- a/packages/build_package.js
+++ b/packages/build_package.js
@@ -157,7 +157,12 @@ if (!args.some(arg => arg === '--no-cleanup')) {
     browser.download = package.browsers.includes(browser.name);
   await writeToPackage('browsers.json', JSON.stringify(browsersJSON, null, 2));
 
-  // 6. Run npm pack
+  // 6. Bake commit SHA into the package
+  const commitSHA = spawnSync('git', ['rev-parse', 'HEAD'], {cwd: __dirname, encoding: 'utf8'});
+  console.log(commitSHA.stdout.trim());
+  await writeToPackage('commitinfo', commitSHA.stdout.trim());
+
+  // 7. Run npm pack
   const shell = os.platform() === 'win32';
   const {stdout, stderr, status} = spawnSync('npm', ['pack'], {cwd: packagePath, encoding: 'utf8', shell});
   if (status !== 0) {

--- a/packages/common/.npmignore
+++ b/packages/common/.npmignore
@@ -33,3 +33,5 @@ lib/server/injected/
 !protocol.yml
 # Include browser descriptors.
 !browsers.json
+# Include commit info
+!commitinfo


### PR DESCRIPTION
This bakes in `//commitinfo` file with the SHA of the commit that
produced given NPM package.

Fixes #3743