### PR TITLE
devops: fix publishing of @next packages to NPM

### DIFF
--- a/packages/build_package.js
+++ b/packages/build_package.js
@@ -159,7 +159,6 @@ if (!args.some(arg => arg === '--no-cleanup')) {
 
   // 6. Bake commit SHA into the package
   const commitSHA = spawnSync('git', ['rev-parse', 'HEAD'], {cwd: __dirname, encoding: 'utf8'});
-  console.log(commitSHA.stdout.trim());
   await writeToPackage('commitinfo', commitSHA.stdout.trim());
 
   // 7. Run npm pack

--- a/utils/publish_all_packages.sh
+++ b/utils/publish_all_packages.sh
@@ -75,11 +75,16 @@ else
   exit 1
 fi
 
-PLAYWRIGHT_TGZ="$(node ./packages/build_package.js playwright ./playwright.tgz)"
-PLAYWRIGHT_CORE_TGZ="$(node ./packages/build_package.js playwright-core ./playwright-core.tgz)"
-PLAYWRIGHT_WEBKIT_TGZ="$(node ./packages/build_package.js playwright-webkit ./playwright-webkit.tgz)"
-PLAYWRIGHT_FIREFOX_TGZ="$(node ./packages/build_package.js playwright-firefox ./playwright-firefox.tgz)"
-PLAYWRIGHT_CHROMIUM_TGZ="$(node ./packages/build_package.js playwright-chromium ./playwright-chromium.tgz)"
+PLAYWRIGHT_TGZ="$PWD/playwright.tgz"
+PLAYWRIGHT_CORE_TGZ="$PWD/playwright-core.tgz"
+PLAYWRIGHT_WEBKIT_TGZ="$PWD/playwright-webkit.tgz"
+PLAYWRIGHT_FIREFOX_TGZ="$PWD/playwright-firefox.tgz"
+PLAYWRIGHT_CHROMIUM_TGZ="$PWD/playwright-chromium.tgz"
+node ./packages/build_package.js playwright "${PLAYWRIGHT_TGZ}"
+node ./packages/build_package.js playwright-core "${PLAYWRIGHT_CORE_TGZ}"
+node ./packages/build_package.js playwright-webkit "${PLAYWRIGHT_WEBKIT_TGZ}"
+node ./packages/build_package.js playwright-firefox "${PLAYWRIGHT_FIREFOX_TGZ}"
+node ./packages/build_package.js playwright-chromium "${PLAYWRIGHT_CHROMIUM_TGZ}"
 
 npm publish ${PLAYWRIGHT_TGZ}           --tag="${NPM_PUBLISH_TAG}"
 npm publish ${PLAYWRIGHT_CORE_TGZ}      --tag="${NPM_PUBLISH_TAG}"


### PR DESCRIPTION
This patch:
- stop relying on stdout from `//packages/build_package.js` to get
output paths. This was a legacy code that's not needed anymore
- remove stray output from `//packages/build_package.js`