### PR TITLE
devops: auto-detect platform in `//browser_patches/chromium/build.sh`

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -22,24 +22,39 @@ FFMPEG_VERSION="4.3.1"
 FFMPEG_URL=""
 FFMPEG_BIN_PATH=""
 
-if [[ $1 == "--win32" ]]; then
+PLATFORM="$1"
+if [[ -z "${PLATFORM}" ]]; then
+  CURRENT_HOST_OS="$(uname)"
+  if [[ "${CURRENT_HOST_OS}" == "Darwin" ]]; then
+    PLATFORM="--mac"
+  elif [[ "${CURRENT_HOST_OS}" == "Linux" ]]; then
+    PLATFORM="--linux"
+  elif [[ "${CURRENT_HOST_OS}" == MINGW* ]]; then
+    PLATFORM="--win64"
+  else
+    echo "ERROR: unsupported host platform - ${CURRENT_HOST_OS}"
+    exit 1
+  fi
+fi
+
+if [[ "${PLATFORM}" == "--win32" ]]; then
   CHROMIUM_URL="https://storage.googleapis.com/chromium-browser-snapshots/Win/${CRREV}/chrome-win.zip"
   CHROMIUM_FOLDER_NAME="chrome-win"
   CHROMIUM_FILES_TO_REMOVE+=("chrome-win/interactive_ui_tests.exe")
   FFMPEG_URL="https://playwright2.blob.core.windows.net/builds/ffmpeg/${FFMPEG_VERSION}/ffmpeg-win32.zip"
   FFMPEG_BIN_PATH="ffmpeg.exe"
-elif [[ $1 == "--win64" ]]; then
+elif [[ "${PLATFORM}" == "--win64" ]]; then
   CHROMIUM_URL="https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/${CRREV}/chrome-win.zip"
   CHROMIUM_FOLDER_NAME="chrome-win"
   CHROMIUM_FILES_TO_REMOVE+=("chrome-win/interactive_ui_tests.exe")
   FFMPEG_URL="https://playwright2.blob.core.windows.net/builds/ffmpeg/${FFMPEG_VERSION}/ffmpeg-win64.zip"
   FFMPEG_BIN_PATH="ffmpeg.exe"
-elif [[ $1 == "--mac" ]]; then
+elif [[ "${PLATFORM}" == "--mac" ]]; then
   CHROMIUM_URL="https://storage.googleapis.com/chromium-browser-snapshots/Mac/${CRREV}/chrome-mac.zip"
   CHROMIUM_FOLDER_NAME="chrome-mac"
   FFMPEG_URL="https://playwright2.blob.core.windows.net/builds/ffmpeg/${FFMPEG_VERSION}/ffmpeg-mac.zip"
   FFMPEG_BIN_PATH="ffmpeg"
-elif [[ $1 == "--linux" ]]; then
+elif [[ "${PLATFORM}" == "--linux" ]]; then
   CHROMIUM_URL="https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/${CRREV}/chrome-linux.zip"
   CHROMIUM_FOLDER_NAME="chrome-linux"
   # Even though we could bundle ffmpeg on Linux (2.5MB zipped), we
@@ -48,6 +63,8 @@ else
   echo "ERROR: unknown platform to build: $1"
   exit 1
 fi
+
+echo "--> Pulling Chromium ${CRREV} for ${PLATFORM#--}"
 
 curl --output chromium-upstream.zip "${CHROMIUM_URL}"
 unzip chromium-upstream.zip


### PR DESCRIPTION
If there's no platform specified for the chromium build, we should
detect the host platform.

This will make it pleasant to verify Chromium rolls locally.
Assuming there's a `CR` env variable pointing to the local chromium,
rolling would look like this:

- bump a revision in `//browser_patches/chromium/BUILD_NUMBER`
- run `//browser_patches/chromium/build.sh`
- run tests with pulled chromium: `CRPATH=$CR npm run ctest`