### PR TITLE
Fix minimum node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=10.15.0"
+    "node": ">=10.17.0"
   },
   "scripts": {
     "ctest": "cross-env BROWSER=chromium test-runner test/",


### PR DESCRIPTION
playwright@1.3.0 uses extract-zip@^2.0.1 which [enforces node >= 10.17.0](https://github.com/maxogden/extract-zip/blob/d64157132e8d9841054f72bb5d76b87a8d9f246d/package.json#L32). Therefore playwright enforces node >= 10.17.0