### PR TITLE
Add failing test for exposeFunction with elements

### DIFF
--- a/test/page-expose-function.spec.ts
+++ b/test/page-expose-function.spec.ts
@@ -61,6 +61,26 @@ it('should work with handles and complex objects', async ({page, server}) => {
   expect(equals).toBe(true);
 });
 
+
+it.only('should work with elements from page', async ({page, server}) => {
+  await page.exposeFunction('element', element => {
+    return [{ id: element.id }];
+  });
+
+  const equals = await page.evaluate(async () => {
+    const div = document.createElement('div');
+    div.innerText = 'test';
+    div.id = 'test';
+    document.body.appendChild(div);
+
+    const value = await window['element'](div);
+    const [{ id }] = value;
+    return id === div.id;
+  });
+
+  expect(equals).toBe(true);
+});
+
 it('should throw exception in page context', async ({page, server}) => {
   await page.exposeFunction('woof', function() {
     throw new Error('WOOF WOOF');


### PR DESCRIPTION
This PR is adds a failing test as a repro for the following issue: https://github.com/microsoft/playwright/issues/3695

I also have a [separate repo](https://github.com/lewisl9029/playwright-expose-function-repro/blob/master/index.js#L7) with a repro script that more closely represents what I'm actually trying to do in my project: Expose a function that accepts an element and then takes a screenshot of it using playwright.

Currently when an element is passed to an exposed function, it appears to get serialized into an empty object, instead of getting wrapped in an ElementHandle that can be referenced by playwright as @pavelfeldman suggested in this comment: https://github.com/microsoft/playwright/issues/3695#issuecomment-684187877

Would appreciate any guidance on how to make this work if I'm missing something here.

If it is an actual bug, I'd be happy to try to make a fix if folks can offer some ideas on what a good fix could look like.

Thanks!