### PR TITLE
fix(lint): fix doclint and preprocessor tests

### DIFF
--- a/utils/doclint/check_public_api/test/test.js
+++ b/utils/doclint/check_public_api/test/test.js
@@ -20,7 +20,7 @@ const checkPublicAPI = require('..');
 const Source = require('../../Source');
 const mdBuilder = require('../MDBuilder');
 const jsBuilder = require('../JSBuilder');
-const { registerWorkerFixture } = require('@playwright/test-runner');
+const { registerWorkerFixture, describe, it, expect } = require('@playwright/test-runner');
 
 registerWorkerFixture('page', async({}, test) => {
   const browser = await playwright.chromium.launch();

--- a/utils/doclint/preprocessor/test.js
+++ b/utils/doclint/preprocessor/test.js
@@ -16,6 +16,7 @@
 
 const {runCommands} = require('.');
 const Source = require('../Source');
+const { describe, it, expect } = require('@playwright/test-runner');
 
 describe('runCommands', function() {
   const OPTIONS_REL = {


### PR DESCRIPTION
These tests were failing successfully by throwing unhandled promise rejections. I'll fix the root cause in the playwright-runner repo.