### PR TITLE
test(types): use @ts-expect-error in tests where we check for errors

### DIFF
--- a/test/browsertype-launch-server.spec.ts
+++ b/test/browsertype-launch-server.spec.ts
@@ -49,7 +49,8 @@ describe('lauch server', suite => {
   it('should fire close event', async ({browserType, defaultBrowserOptions}) => {
     const browserServer = await browserType.launchServer(defaultBrowserOptions);
     const [result] = await Promise.all([
-      new Promise(f => (browserServer as any).on('close', (exitCode, signal) => f({ exitCode, signal }))),
+      // @ts-expect-error The signal parameter is not documented.
+      new Promise(f => browserServer.on('close', (exitCode, signal) => f({ exitCode, signal }))),
       browserServer.close(),
     ]);
     expect(result['exitCode']).toBe(0);

--- a/test/browsertype-launch.spec.ts
+++ b/test/browsertype-launch.spec.ts
@@ -92,7 +92,8 @@ it('should report launch log', test => {
 it('should accept objects as options', test => {
   test.slow();
 }, async ({browserType, defaultBrowserOptions}) => {
-  const browser = await browserType.launch({ ...defaultBrowserOptions, process } as any);
+  // @ts-expect-error process is not a real option.
+  const browser = await browserType.launch({ ...defaultBrowserOptions, process });
   await browser.close();
 });
 

--- a/test/chromium/session.spec.ts
+++ b/test/chromium/session.spec.ts
@@ -40,7 +40,8 @@ describe('session', suite => {
   });
 
   it('should only accept a page', async function({page}) {
-    const error = await (page.context() as ChromiumBrowserContext).newCDPSession(page.context() as any).catch(e => e);
+    // @ts-expect-error newCDPSession expects a Page
+    const error = await (page.context() as ChromiumBrowserContext).newCDPSession(page.context()).catch(e => e);
     expect(error.message).toContain('page: expected Page');
   });
 
@@ -84,7 +85,8 @@ describe('session', suite => {
     expect(error.message).toContain('ThisCommand.DoesNotExist');
 
     async function theSourceOfTheProblems() {
-      await client.send('ThisCommand.DoesNotExist' as any);
+      // @ts-expect-error invalid command
+      await client.send('ThisCommand.DoesNotExist');
     }
   });
 

--- a/test/geolocation.spec.ts
+++ b/test/geolocation.spec.ts
@@ -74,7 +74,8 @@ it('should isolate contexts', async ({page, server, context, browser}) => {
 it('should throw with missing latitude', async ({context}) => {
   let error = null;
   try {
-    await context.setGeolocation({longitude: 10} as any);
+    // @ts-expect-error setGeolocation must have latitude
+    await context.setGeolocation({longitude: 10});
   } catch (e) {
     error = e;
   }
@@ -93,7 +94,8 @@ it('should not modify passed default options object', async ({browser}) => {
 it('should throw with missing longitude in default options', async ({browser}) => {
   let error = null;
   try {
-    const context = await browser.newContext({ geolocation: {latitude: 10} as any });
+    // @ts-expect-error geolocation must have longitude
+    const context = await browser.newContext({ geolocation: {latitude: 10} });
     await context.close();
   } catch (e) {
     error = e;

--- a/test/page-add-init-script.spec.ts
+++ b/test/page-add-init-script.spec.ts
@@ -39,7 +39,8 @@ it('should work with content', async ({ page, server }) => {
 });
 
 it('should throw without path and content', async ({ page, server }) => {
-  const error = await page.addInitScript({ foo: 'bar' } as any).catch(e => e);
+  // @ts-expect-error foo is not a real option of addInitScript
+  const error = await page.addInitScript({ foo: 'bar' }).catch(e => e);
   expect(error.message).toContain('Either path or content property must be present');
 });
 

--- a/test/page-emulate-media.spec.ts
+++ b/test/page-emulate-media.spec.ts
@@ -34,7 +34,8 @@ it('should emulate type', async ({page, server}) => {
 
 it('should throw in case of bad type argument', async ({page, server}) => {
   let error = null;
-  await page.emulateMedia({ media: 'bad' as any}).catch(e => error = e);
+  // @ts-expect-error 'bad' is not a valid media type
+  await page.emulateMedia({ media: 'bad'}).catch(e => error = e);
   expect(error.message).toContain('media: expected one of (screen|print|null)');
 });
 
@@ -62,7 +63,8 @@ it('should default to light', async ({page, server}) => {
 
 it('should throw in case of bad argument', async ({page, server}) => {
   let error = null;
-  await page.emulateMedia({ colorScheme: 'bad' as any}).catch(e => error = e);
+  // @ts-expect-error 'bad' is not a valid media type
+  await page.emulateMedia({ colorScheme: 'bad' }).catch(e => error = e);
   expect(error.message).toContain('colorScheme: expected one of (dark|light|no-preference|null)');
 });
 

--- a/test/page-fill.spec.ts
+++ b/test/page-fill.spec.ts
@@ -138,7 +138,8 @@ it('should throw when element is not an <input>, <textarea> or [contenteditable]
 it('should throw if passed a non-string value', async ({page, server}) => {
   let error = null;
   await page.goto(server.PREFIX + '/input/textarea.html');
-  await page.fill('textarea', 123 as any).catch(e => error = e);
+  // @ts-expect-error fill only accepts string values
+  await page.fill('textarea', 123).catch(e => error = e);
   expect(error.message).toContain('value: expected string, got number');
 });
 

--- a/test/page-goto.spec.ts
+++ b/test/page-goto.spec.ts
@@ -199,12 +199,14 @@ it('should not crash when navigating to bad SSL after a cross origin navigation'
 });
 
 it('should not throw if networkidle0 is passed as an option', async ({page, server}) => {
-  await page.goto(server.EMPTY_PAGE, {waitUntil: 'networkidle0' as any});
+  // @ts-expect-error networkidle0 is undocumented
+  await page.goto(server.EMPTY_PAGE, {waitUntil: 'networkidle0'});
 });
 
 it('should throw if networkidle2 is passed as an option', async ({page, server}) => {
   let error = null;
-  await page.goto(server.EMPTY_PAGE, {waitUntil: 'networkidle2' as any}).catch(err => error = err);
+  // @ts-expect-error networkidle2 is not allowed
+  await page.goto(server.EMPTY_PAGE, {waitUntil: 'networkidle2'}).catch(err => error = err);
   expect(error.message).toContain(`waitUntil: expected one of (load|domcontentloaded|networkidle)`);
 });
 

--- a/test/page-select-option.spec.ts
+++ b/test/page-select-option.spec.ts
@@ -175,7 +175,8 @@ it('should throw if passed wrong types', async ({page, server}) => {
 
   error = null;
   try {
-    await page.selectOption('select', 12 as any);
+    // @ts-expect-error cannot select numbers
+    await page.selectOption('select', 12);
   } catch (e) {
     error = e;
   }
@@ -183,7 +184,8 @@ it('should throw if passed wrong types', async ({page, server}) => {
 
   error = null;
   try {
-    await page.selectOption('select', { value: 12 } as any);
+    // @ts-expect-error cannot select numbers
+    await page.selectOption('select', { value: 12 });
   } catch (e) {
     error = e;
   }
@@ -191,7 +193,8 @@ it('should throw if passed wrong types', async ({page, server}) => {
 
   error = null;
   try {
-    await page.selectOption('select', { label: 12 } as any);
+    // @ts-expect-error cannot select numbers
+    await page.selectOption('select', { label: 12 });
   } catch (e) {
     error = e;
   }
@@ -199,7 +202,8 @@ it('should throw if passed wrong types', async ({page, server}) => {
 
   error = null;
   try {
-    await page.selectOption('select', { index: '12' } as any);
+    // @ts-expect-error cannot select string indices
+    await page.selectOption('select', { index: '12' });
   } catch (e) {
     error = e;
   }

--- a/test/page-set-extra-http-headers.spec.ts
+++ b/test/page-set-extra-http-headers.spec.ts
@@ -74,10 +74,12 @@ it('should override extra headers from browser context', async ({browser, server
 });
 
 it('should throw for non-string header values', async ({browser, page}) => {
-  const error1 = await page.setExtraHTTPHeaders({ 'foo': 1 as any }).catch(e => e);
+  // @ts-expect-error headers must be strings
+  const error1 = await page.setExtraHTTPHeaders({ 'foo': 1 }).catch(e => e);
   expect(error1.message).toContain('Expected value of header "foo" to be String, but "number" is found.');
-  const error2 = await page.context().setExtraHTTPHeaders({ 'foo': true as any }).catch(e => e);
+  // @ts-expect-error headers must be strings
+  const error2 = await page.context().setExtraHTTPHeaders({ 'foo': true }).catch(e => e);
   expect(error2.message).toContain('Expected value of header "foo" to be String, but "boolean" is found.');
-  const error3 = await browser.newContext({ extraHTTPHeaders: { 'foo': null as any } }).catch(e => e);
+  const error3 = await browser.newContext({ extraHTTPHeaders: { 'foo': null } }).catch(e => e);
   expect(error3.message).toContain('Expected value of header "foo" to be String, but "object" is found.');
 });

--- a/test/page-wait-for-load-state.spec.ts
+++ b/test/page-wait-for-load-state.spec.ts
@@ -45,7 +45,8 @@ it('should resolve immediately if loaded', async ({page, server}) => {
 
 it('should throw for bad state', async ({page, server}) => {
   await page.goto(server.PREFIX + '/one-style.html');
-  const error = await page.waitForLoadState('bad' as any).catch(e => e);
+  // @ts-expect-error 'bad' is not a valid load state
+  const error = await page.waitForLoadState('bad').catch(e => e);
   expect(error.message).toContain(`state: expected one of (load|domcontentloaded|networkidle)`);
 });
 

--- a/test/proxy.spec.ts
+++ b/test/proxy.spec.ts
@@ -22,7 +22,8 @@ import socks from 'socksv5';
 it('should throw for bad server value', async ({browserType, defaultBrowserOptions}) => {
   const error = await browserType.launch({
     ...defaultBrowserOptions,
-    proxy: { server: 123 as any }
+    // @ts-expect-error server must be a string
+    proxy: { server: 123 }
   }).catch(e => e);
   expect(error.message).toContain('proxy.server: expected string, got number');
 });

--- a/test/wait-for-function.spec.ts
+++ b/test/wait-for-function.spec.ts
@@ -68,7 +68,8 @@ it('should avoid side effects after timeout', async ({page}) => {
 });
 
 it('should throw on polling:mutation', async ({page}) => {
-  const error = await page.waitForFunction(() => true, {}, {polling: 'mutation' as any}).catch(e => e);
+  // @ts-expect-error mutation is not a valid polling strategy
+  const error = await page.waitForFunction(() => true, {}, {polling: 'mutation'}).catch(e => e);
   expect(error.message).toContain('Unknown polling option: mutation');
 });
 
@@ -113,7 +114,8 @@ it('should work with strict CSP policy', async ({page, server}) => {
 it('should throw on bad polling value', async ({page}) => {
   let error = null;
   try {
-    await page.waitForFunction(() => !!document.body, {}, {polling: 'unknown' as any});
+    // @ts-expect-error 'unknown' is not a valid polling strategy
+    await page.waitForFunction(() => !!document.body, {}, {polling: 'unknown'});
   } catch (e) {
     error = e;
   }

--- a/test/wait-for-selector-1.spec.ts
+++ b/test/wait-for-selector-1.spec.ts
@@ -28,14 +28,16 @@ const addElement = tag => document.body.appendChild(document.createElement(tag))
 it('should throw on waitFor', async ({page, server}) => {
   await page.goto(server.EMPTY_PAGE);
   let error;
-  await page.waitForSelector('*', { waitFor: 'attached' } as any).catch(e => error = e);
+  // @ts-expect-error waitFor is undocumented
+  await page.waitForSelector('*', { waitFor: 'attached' }).catch(e => error = e);
   expect(error.message).toContain('options.waitFor is not supported, did you mean options.state?');
 });
 
 it('should tolerate waitFor=visible', async ({page, server}) => {
   await page.goto(server.EMPTY_PAGE);
   let error = false;
-  await page.waitForSelector('*', { waitFor: 'visible' } as any).catch(() => error = true);
+  // @ts-expect-error waitFor is undocumented
+  await page.waitForSelector('*', { waitFor: 'visible' }).catch(() => error = true);
   expect(error).toBe(false);
 });
 

--- a/test/wait-for-selector-2.spec.ts
+++ b/test/wait-for-selector-2.spec.ts
@@ -146,25 +146,29 @@ it('should have correct stack trace for timeout', async ({page, server}) => {
 
 it('should throw for unknown state option', async ({page, server}) => {
   await page.setContent('<section>test</section>');
-  const error = await page.waitForSelector('section', { state: 'foo' as any}).catch(e => e);
+  // @ts-expect-error state is not an option of waitForSelector
+  const error = await page.waitForSelector('section', { state: 'foo'}).catch(e => e);
   expect(error.message).toContain('state: expected one of (attached|detached|visible|hidden)');
 });
 
 it('should throw for visibility option', async ({page, server}) => {
   await page.setContent('<section>test</section>');
-  const error = await page.waitForSelector('section', { visibility: 'hidden' } as any).catch(e => e);
+  // @ts-expect-error visibility is not an option of waitForSelector
+  const error = await page.waitForSelector('section', { visibility: 'hidden' }).catch(e => e);
   expect(error.message).toContain('options.visibility is not supported, did you mean options.state?');
 });
 
 it('should throw for true state option', async ({page, server}) => {
   await page.setContent('<section>test</section>');
-  const error = await page.waitForSelector('section', { state: true as any }).catch(e => e);
+  // @ts-expect-error state is not an option of waitForSelector
+  const error = await page.waitForSelector('section', { state: true }).catch(e => e);
   expect(error.message).toContain('state: expected one of (attached|detached|visible|hidden)');
 });
 
 it('should throw for false state option', async ({page, server}) => {
   await page.setContent('<section>test</section>');
-  const error = await page.waitForSelector('section', { state: false as any }).catch(e => e);
+  // @ts-expect-error state is not an option of waitForSelector
+  const error = await page.waitForSelector('section', { state: false }).catch(e => e);
   expect(error.message).toContain('state: expected one of (attached|detached|visible|hidden)');
 });
 


### PR DESCRIPTION
A bunch of our tests purposely call functions with the wrong parameters in order to check that they fail properly. We were casting the parameters to `any` to avoid typescript complaining. But we actually want typescript to complain, to ensure that our types are working. `@ts-expect-error` checks that a typescript error occurs on the following line.