### PR TITLE
fix(input): send keypress event for enter key in chromium

### DIFF
--- a/src/server/chromium/crInput.ts
+++ b/src/server/chromium/crInput.ts
@@ -53,6 +53,8 @@ export class RawKeyboardImpl implements input.RawKeyboard {
     let commands = macEditingCommands[shortcut] || [];
     if (isString(commands))
       commands = [commands];
+    // Commands that insert text are not supported
+    commands = commands.filter(x => !x.startsWith('insert'));
     // remove the trailing : to match the Chromium command names.
     return commands.map(c => c.substring(0, c.length - 1));
   }

--- a/test/page-basic.spec.ts
+++ b/test/page-basic.spec.ts
@@ -237,9 +237,7 @@ it('page.press should work', async ({page, server}) => {
   expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('a');
 });
 
-it('page.press should work for Enter', test => {
-  test.fail(options.CHROMIUM && MAC, 'page.press() does not emit keypress event on Enter');
-}, async ({page, server}) => {
+it('page.press should work for Enter', async ({page, server}) => {
   await page.setContent(`<input onkeypress="console.log('press')"></input>`);
   const messages = [];
   page.on('console', message => messages.push(message));


### PR DESCRIPTION
This disables sending editing commands to Chromium that would insert text. I got a little bit lost trying to debug exactly why this behaves differently from the native keypresses in Chromium. But this seems to match what Chromium does.

#3781 