### PR TITLE
feat: actually bundle FFMPEG binaries with NPM packages

### DIFF
--- a/packages/common/.npmignore
+++ b/packages/common/.npmignore
@@ -11,8 +11,8 @@
 # Exclude injected files. A preprocessed version of these is included via lib/generated.
 # See src/server/injected/README.md.
 lib/server/injected/
-# Include Windows dependency checker executable.
-!bin/PrintDeps.exe
+# Include all binaries that we ship with the package.
+!bin/*
 # Include generated types and entrypoint.
 !types/*
 !index.d.ts

--- a/packages/installation-tests/installation-tests.sh
+++ b/packages/installation-tests/installation-tests.sh
@@ -29,6 +29,7 @@ NODE_VERSION="$(node --version)"
 
 function copy_test_scripts {
   cp "${SCRIPTS_PATH}/sanity.js" .
+  cp "${SCRIPTS_PATH}/screencast.js" .
   cp "${SCRIPTS_PATH}/esm.mjs" .
   cp "${SCRIPTS_PATH}/esm-playwright.mjs" .
   cp "${SCRIPTS_PATH}/esm-playwright-chromium.mjs" .
@@ -39,6 +40,7 @@ function copy_test_scripts {
 }
 
 function run_tests {
+  test_screencast
   test_typescript_types
   test_skip_browser_download
   test_playwright_global_installation_subsequent_installs
@@ -50,6 +52,22 @@ function run_tests {
   test_playwright_global_installation_cross_package
   test_playwright_electron_should_work
   test_electron_types
+}
+
+function test_screencast {
+  initialize_test "${FUNCNAME[0]}"
+  copy_test_scripts
+
+  local BROWSERS="$(pwd -P)/browsers"
+  PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm install ${PLAYWRIGHT_TGZ}
+  PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm install ${PLAYWRIGHT_FIREFOX_TGZ}
+  PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm install ${PLAYWRIGHT_WEBKIT_TGZ}
+  PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm install ${PLAYWRIGHT_CHROMIUM_TGZ}
+
+  PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" node screencast.js playwright
+  PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" node screencast.js playwright-chromium
+  PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" node screencast.js playwright-webkit
+  PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" node screencast.js playwright-firefox
 }
 
 function test_typescript_types {

--- a/packages/installation-tests/screencast.js
+++ b/packages/installation-tests/screencast.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const requireName = process.argv[2];
+let success = {
+  'playwright': ['chromium', 'firefox', 'webkit'],
+  'playwright-chromium': ['chromium'],
+  'playwright-firefox': ['firefox'],
+  'playwright-webkit': ['webkit'],
+}[requireName];
+if (process.argv[3] === 'none')
+  success = [];
+if (process.argv[3] === 'all')
+  success = ['chromium', 'firefox', 'webkit'];
+
+const playwright = require(requireName);
+const path = require('path');
+const fs = require('fs');
+
+(async () => {
+  for (const browserType of success) {
+    try {
+      const browser = await playwright[browserType].launch({
+        _videosPath: __dirname,
+      });
+      const context = await browser.newContext({
+        _recordVideos: {width: 320, height: 240},
+      });
+      const page = await context.newPage();
+      const video = await page.waitForEvent('_videostarted');
+      const [videoFile] = await Promise.all([
+        video.path(),
+        context.close(),
+      ]);
+      await browser.close();
+      if (!fs.existsSync(videoFile)) {
+        console.error(`Package "${requireName}", browser "${browserType}" should have created screencast!`);
+        process.exit(1);
+      }
+    } catch (err) {
+      console.error(`Should be able to launch ${browserType} from ${requireName}`);
+      console.error(err);
+      process.exit(1);
+    }
+  }
+})();

--- a/packages/installation-tests/screencast.js
+++ b/packages/installation-tests/screencast.js
@@ -41,17 +41,19 @@ const fs = require('fs');
       });
       const page = await context.newPage();
       const video = await page.waitForEvent('_videostarted');
+      // Wait fo 1 second to actually record something.
+      await new Promise(x => setTimeout(x, 1000));
       const [videoFile] = await Promise.all([
         video.path(),
         context.close(),
       ]);
       await browser.close();
       if (!fs.existsSync(videoFile)) {
-        console.error(`Package "${requireName}", browser "${browserType}" should have created screencast!`);
+        console.error(`ERROR: Package "${requireName}", browser "${browserType}" should have created screencast!`);
         process.exit(1);
       }
     } catch (err) {
-      console.error(`Should be able to launch ${browserType} from ${requireName}`);
+      console.error(`ERROR: Should be able to launch ${browserType} from ${requireName}`);
       console.error(err);
       process.exit(1);
     }


### PR DESCRIPTION
This patch:
- adds FFMPEG binaries to the NPM packages
- adds a screencast test to make sure that screencast works. This currently relies on private screencast APIs.

NOTE: with this patch playwright package size grows from `650KB` to `4.2MB`. 