### PR TITLE
devops: stop bundling FFMPEG with Chromium

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -9,18 +9,11 @@ rm -rf output
 mkdir -p output
 cd output
 
-BUILD_NUMBER=$(head -1 ../BUILD_NUMBER)
-# Support BUILD_NUMBER in the form of <CRREV>.<GENERATION>
-# This will allow us to bump generation to produce new builds.
-CRREV="${BUILD_NUMBER%.*}"
+CRREV=$(head -1 ../BUILD_NUMBER)
 
 CHROMIUM_URL=""
 CHROMIUM_FOLDER_NAME=""
 CHROMIUM_FILES_TO_REMOVE=()
-
-FFMPEG_VERSION="4.3.1"
-FFMPEG_URL=""
-FFMPEG_BIN_PATH=""
 
 PLATFORM="$1"
 if [[ -z "${PLATFORM}" ]]; then
@@ -41,24 +34,16 @@ if [[ "${PLATFORM}" == "--win32" ]]; then
   CHROMIUM_URL="https://storage.googleapis.com/chromium-browser-snapshots/Win/${CRREV}/chrome-win.zip"
   CHROMIUM_FOLDER_NAME="chrome-win"
   CHROMIUM_FILES_TO_REMOVE+=("chrome-win/interactive_ui_tests.exe")
-  FFMPEG_URL="https://playwright2.blob.core.windows.net/builds/ffmpeg/${FFMPEG_VERSION}/ffmpeg-win32.zip"
-  FFMPEG_BIN_PATH="ffmpeg.exe"
 elif [[ "${PLATFORM}" == "--win64" ]]; then
   CHROMIUM_URL="https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/${CRREV}/chrome-win.zip"
   CHROMIUM_FOLDER_NAME="chrome-win"
   CHROMIUM_FILES_TO_REMOVE+=("chrome-win/interactive_ui_tests.exe")
-  FFMPEG_URL="https://playwright2.blob.core.windows.net/builds/ffmpeg/${FFMPEG_VERSION}/ffmpeg-win64.zip"
-  FFMPEG_BIN_PATH="ffmpeg.exe"
 elif [[ "${PLATFORM}" == "--mac" ]]; then
   CHROMIUM_URL="https://storage.googleapis.com/chromium-browser-snapshots/Mac/${CRREV}/chrome-mac.zip"
   CHROMIUM_FOLDER_NAME="chrome-mac"
-  FFMPEG_URL="https://playwright2.blob.core.windows.net/builds/ffmpeg/${FFMPEG_VERSION}/ffmpeg-mac.zip"
-  FFMPEG_BIN_PATH="ffmpeg"
 elif [[ "${PLATFORM}" == "--linux" ]]; then
   CHROMIUM_URL="https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/${CRREV}/chrome-linux.zip"
   CHROMIUM_FOLDER_NAME="chrome-linux"
-  # Even though we could bundle ffmpeg on Linux (2.5MB zipped), we
-  # prefer rely on system-installed ffmpeg instead.
 else
   echo "ERROR: unknown platform to build: $1"
   exit 1
@@ -71,11 +56,5 @@ unzip chromium-upstream.zip
 for file in ${CHROMIUM_FILES_TO_REMOVE[@]}; do
   rm -f "${file}"
 done
-
-if [[ -n "${FFMPEG_URL}" ]]; then
-  curl --output ffmpeg-upstream.zip "${FFMPEG_URL}"
-  unzip ffmpeg-upstream.zip
-  cp "$FFMPEG_BIN_PATH" "${CHROMIUM_FOLDER_NAME}"
-fi
 
 zip --symlinks -r build.zip "${CHROMIUM_FOLDER_NAME}"

--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -129,7 +129,7 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
 }
 
 function revisionURL(browser: BrowserDescriptor, platform = browserPaths.hostPlatform): string {
-  const revision = parseFloat(browser.revision);
+  const revision = parseInt(browser.revision, 10);
   const serverHost = getDownloadHost(browser.name, revision);
   const urlTemplate = getDownloadUrl(browser.name, revision, platform);
   assert(urlTemplate, `ERROR: Playwright does not support ${browser.name} on ${platform}`);

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -55,7 +55,7 @@ async function validateCache(packagePath: string, browsersPath: string, linksDir
       const browsersToDownload = await readBrowsersToDownload(linkTarget);
       for (const browser of browsersToDownload) {
         const usedBrowserPath = browserPaths.browserDirectory(browsersPath, browser);
-        const browserRevision = parseFloat(browser.revision);
+        const browserRevision = parseInt(browser.revision, 10);
         // Old browser installations don't have marker file.
         const shouldHaveMarkerFile = (browser.name === 'chromium' && browserRevision >= 786218) ||
             (browser.name === 'firefox' && browserRevision >= 1128) ||


### PR DESCRIPTION
- This stops bundling FFMPEG with Chromium
- Stop supporting build numbers as fractional parts for Chromium
revisions