### PR TITLE
browser(firefox): fix automatic http->https redirect

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1169
-Changed: yurys@chromium.org Tue Sep  1 17:07:52 PDT 2020
+1170
+Changed: dgozman@gmail.com Tue Sep  8 21:12:30 PDT 2020

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
 1170
-Changed: dgozman@gmail.com Tue Sep  8 21:12:30 PDT 2020
+Changed: dgozman@gmail.com Tue Sep  8 22:17:56 PDT 2020

--- a/browser_patches/firefox/juggler/protocol/NetworkHandler.js
+++ b/browser_patches/firefox/juggler/protocol/NetworkHandler.js
@@ -23,7 +23,6 @@ class NetworkHandler {
     this._requestInterception = false;
     this._eventListeners = [];
     this._pendingRequstWillBeSentEvents = new Set();
-    this._requestIdToFrameId = new Map();
   }
 
   async enable() {
@@ -126,9 +125,7 @@ class NetworkHandler {
       this._pendingRequstWillBeSentEvents.delete(pendingRequestPromise);
       return;
     }
-    // Inherit frameId for redirects when details are not available.
-    const frameId = details ? details.frameId : (eventDetails.redirectedFrom ? this._requestIdToFrameId.get(eventDetails.redirectedFrom) : undefined);
-    this._requestIdToFrameId.set(eventDetails.requestId, frameId);
+    const frameId = details ? details.frameId : undefined;
     const activity = this._ensureHTTPActivity(eventDetails.requestId);
     activity.request = {
       frameId,


### PR DESCRIPTION
Sometimes, Firefox does an automatic http->https redirect without hitting
the network (e.g. for http://wikipedia.org). In this case, the http request
is very strange:
- it does not actually hit the network;
- it is never intercepted;
- we cannot access its response because there was no actual response.

So, we had a bug where:
- redirects inherited the original request's listener;
- that listener was throwing an error.
This lead to the error in the listeners onDataAvailable call chain,
and original listener that renders the response was never called,
resulting in an empty page.

This change:
- ignores the original request that did not hit the network;
- does not inherit the listener;
- adds try/catch around problematic calls.


Fixes #3776