### PR TITLE
feat(tracing): trace actions

### DIFF
--- a/src/debug/debugController.ts
+++ b/src/debug/debugController.ts
@@ -17,8 +17,7 @@
 import { BrowserContext } from '../server/browserContext';
 import * as frames from '../server/frames';
 import { Page } from '../server/page';
-import { InstrumentingAgent } from '../server/instrumentation';
-import { Progress } from '../server/progress';
+import { ActionMetadata, ActionResult, InstrumentingAgent } from '../server/instrumentation';
 import { isDebugMode } from '../utils/utils';
 import * as debugScriptSource from '../generated/debugScriptSource';
 
@@ -43,6 +42,6 @@ export class DebugController implements InstrumentingAgent {
   async onContextDestroyed(context: BrowserContext): Promise<void> {
   }
 
-  async onBeforePageAction(page: Page, progress: Progress): Promise<void> {
+  async onAfterAction(result: ActionResult, metadata?: ActionMetadata): Promise<void> {
   }
 }

--- a/src/server/instrumentation.ts
+++ b/src/server/instrumentation.ts
@@ -14,14 +14,29 @@
  * limitations under the License.
  */
 
-import { BrowserContext } from './browserContext';
-import { Page } from './page';
-import { Progress } from './progress';
+import type { BrowserContext } from './browserContext';
+import type { ElementHandle } from './dom';
+import type { Page } from './page';
+
+export type ActionMetadata = {
+  type: 'click' | 'fill',
+  page: Page,
+  target: ElementHandle | string,
+  value?: string,
+  stack?: string,
+};
+
+export type ActionResult = {
+  logs: string[],
+  startTime: number,
+  endTime: number,
+  error?: Error,
+};
 
 export interface InstrumentingAgent {
   onContextCreated(context: BrowserContext): Promise<void>;
   onContextDestroyed(context: BrowserContext): Promise<void>;
-  onBeforePageAction(page: Page, progress: Progress): Promise<void>;
+  onAfterAction(result: ActionResult, metadata?: ActionMetadata): Promise<void>;
 }
 
 export const instrumentingAgents = new Set<InstrumentingAgent>();

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -32,7 +32,6 @@ import { Progress, runAbortableTask } from './progress';
 import { assert, isError } from '../utils/utils';
 import { debugLogger } from '../utils/debugLogger';
 import { Selectors } from './selectors';
-import { instrumentingAgents } from './instrumentation';
 
 export interface PageDelegate {
   readonly rawMouse: input.RawMouse;
@@ -200,11 +199,7 @@ export class Page extends EventEmitter {
   }
 
   async _runAbortableTask<T>(task: (progress: Progress) => Promise<T>, timeout: number): Promise<T> {
-    return runAbortableTask(async progress => {
-      for (const agent of instrumentingAgents)
-        await agent.onBeforePageAction(this, progress);
-      return task(progress);
-    }, timeout);
+    return runAbortableTask(task, timeout);
   }
 
   async _onFileChooserOpened(handle: dom.ElementHandle) {

--- a/src/trace/traceTypes.ts
+++ b/src/trace/traceTypes.ts
@@ -38,9 +38,20 @@ export type NetworkResourceTraceEvent = {
   sha1: string,
 };
 
-export type SnapshotTraceEvent = {
-  type: 'snapshot',
+export type ActionTraceEvent = {
+  type: 'action',
   contextId: string,
-  label: string,
-  sha1: string,
+  action: string,
+  target?: string,
+  label?: string,
+  value?: string,
+  startTime?: number,
+  endTime?: number,
+  logs?: string[],
+  snapshot?: {
+    sha1: string,
+    duration: number,
+  },
+  stack?: string,
+  error?: string,
 };


### PR DESCRIPTION
- Fill and click actions pass metadata to Progress.
- Progress reports success/failure through instrumentation.
- Tracer consumes ActionResult and ActionMetadata and records them.

Currently, only click and fill actions pass metadata to
contain the size of the change. Everything else should follow.
