### PR TITLE
Add RobotFramework Browser library to showcase.md

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -34,6 +34,7 @@
 * [query-selector-shadow-dom](https://github.com/Georgegriff/query-selector-shadow-dom): Custom selector engine to pierce shadow DOM roots
 * [Playwright Sharp](https://github.com/kblok/playwright-sharp): Work in progress port of Playwright to .NET
 * [playwright-fluent](https://github.com/hdorgeval/playwright-fluent): Fluent API around Playwright
+* [robotframework-browser](https://robotframework-browser.org/) Robotframework library that uses Playwright to achieve good development ergonomics.
 
 ## Examples
  


### PR DESCRIPTION
We have a RobotFramework library that heavily used playwright, and we would like to add it to the showcase.md