### PR TITLE
chore: merge BrowserType and BrowserTypeBase, remove logName

### DIFF
--- a/src/browserServerImpl.ts
+++ b/src/browserServerImpl.ts
@@ -15,7 +15,7 @@
  */
 
 import { LaunchServerOptions } from './client/types';
-import { BrowserTypeBase } from './server/browserType';
+import { BrowserType } from './server/browserType';
 import * as ws from 'ws';
 import { Browser } from './server/browser';
 import { ChildProcess } from 'child_process';
@@ -31,9 +31,9 @@ import { SelectorsDispatcher } from './dispatchers/selectorsDispatcher';
 import { Selectors } from './server/selectors';
 
 export class BrowserServerLauncherImpl implements BrowserServerLauncher {
-  private _browserType: BrowserTypeBase;
+  private _browserType: BrowserType;
 
-  constructor(browserType: BrowserTypeBase) {
+  constructor(browserType: BrowserType) {
     this._browserType = browserType;
   }
 
@@ -50,12 +50,12 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
 
 export class BrowserServerImpl extends EventEmitter implements BrowserServer {
   private _server: ws.Server;
-  private _browserType: BrowserTypeBase;
+  private _browserType: BrowserType;
   private _browser: Browser;
   private _wsEndpoint: string;
   private _process: ChildProcess;
 
-  constructor(browserType: BrowserTypeBase, browser: Browser, port: number = 0) {
+  constructor(browserType: BrowserType, browser: Browser, port: number = 0) {
     super();
 
     this._browserType = browserType;

--- a/src/dispatchers/browserTypeDispatcher.ts
+++ b/src/dispatchers/browserTypeDispatcher.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { BrowserTypeBase, BrowserType } from '../server/browserType';
+import { BrowserType } from '../server/browserType';
 import { BrowserDispatcher } from './browserDispatcher';
 import * as channels from '../protocol/channels';
 import { Dispatcher, DispatcherScope } from './dispatcher';
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 
 export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.BrowserTypeInitializer> implements channels.BrowserTypeChannel {
-  constructor(scope: DispatcherScope, browserType: BrowserTypeBase) {
+  constructor(scope: DispatcherScope, browserType: BrowserType) {
     super(scope, browserType, 'BrowserType', {
       executablePath: browserType.executablePath(),
       name: browserType.name()

--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -21,7 +21,7 @@ import { CRBrowser } from './crBrowser';
 import { Env } from '../processLauncher';
 import { kBrowserCloseMessageId } from './crConnection';
 import { rewriteErrorMessage } from '../../utils/stackTrace';
-import { BrowserTypeBase } from '../browserType';
+import { BrowserType } from '../browserType';
 import { ConnectionTransport, ProtocolRequest } from '../transport';
 import type { BrowserDescriptor } from '../../utils/browserPaths';
 import { CRDevTools } from './crDevTools';
@@ -29,7 +29,7 @@ import { BrowserOptions } from '../browser';
 import * as types from '../types';
 import { isDebugMode, getFromENV } from '../../utils/utils';
 
-export class Chromium extends BrowserTypeBase {
+export class Chromium extends BrowserType {
   private _devtools: CRDevTools | undefined;
   private _debugPort: number | undefined;
 

--- a/src/server/chromium/videoRecorder.ts
+++ b/src/server/chromium/videoRecorder.ts
@@ -16,7 +16,7 @@
 
 import { launchProcess } from '../processLauncher';
 import { ChildProcess } from 'child_process';
-import { Progress, runAbortableTask } from '../progress';
+import { Progress, ProgressController } from '../progress';
 import * as types from '../types';
 import * as path from 'path';
 import * as os from 'os';
@@ -37,11 +37,13 @@ export class VideoRecorder {
     if (!options.outputFile.endsWith('.webm'))
       throw new Error('File must have .webm extension');
 
-    return await runAbortableTask(async progress => {
+    const controller = new ProgressController(0);
+    controller.setLogName('browser');
+    return await controller.run(async progress => {
       const recorder = new VideoRecorder(progress);
       await recorder._launch(options);
       return recorder;
-    }, 0, 'browser');
+    });
   }
 
   private constructor(progress: Progress) {

--- a/src/server/electron/electron.ts
+++ b/src/server/electron/electron.ts
@@ -27,7 +27,7 @@ import * as types from '../types';
 import { launchProcess, waitForLine, envArrayToObject } from '../processLauncher';
 import { BrowserContext } from '../browserContext';
 import type {BrowserWindow} from 'electron';
-import { runAbortableTask, ProgressController } from '../progress';
+import { ProgressController } from '../progress';
 import { EventEmitter } from 'events';
 import { helper } from '../helper';
 import { BrowserProcess } from '../browser';
@@ -147,7 +147,9 @@ export class Electron  {
       handleSIGTERM = true,
       handleSIGHUP = true,
     } = options;
-    return runAbortableTask(async progress => {
+    const controller = new ProgressController(TimeoutSettings.timeout(options));
+    controller.setLogName('browser');
+    return controller.run(async progress => {
       let app: ElectronApplication | undefined = undefined;
       const electronArguments = ['--inspect=0', '--remote-debugging-port=0', '--require', path.join(__dirname, 'electronLoader.js'), ...args];
 
@@ -188,6 +190,6 @@ export class Electron  {
       app = new ElectronApplication(browser, nodeConnection);
       await app._init();
       return app;
-    }, TimeoutSettings.timeout(options), 'browser');
+    });
   }
 }

--- a/src/server/firefox/firefox.ts
+++ b/src/server/firefox/firefox.ts
@@ -20,14 +20,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { FFBrowser } from './ffBrowser';
 import { kBrowserCloseMessageId } from './ffConnection';
-import { BrowserTypeBase } from '../browserType';
+import { BrowserType } from '../browserType';
 import { Env } from '../processLauncher';
 import { ConnectionTransport } from '../transport';
 import { BrowserOptions } from '../browser';
 import { BrowserDescriptor } from '../../utils/browserPaths';
 import * as types from '../types';
 
-export class Firefox extends BrowserTypeBase {
+export class Firefox extends BrowserType {
   constructor(packagePath: string, browser: BrowserDescriptor) {
     const webSocketRegex = /^Juggler listening on (ws:\/\/.*)$/;
     super(packagePath, browser, { webSocketRegex, stream: 'stdout' });

--- a/src/server/webkit/webkit.ts
+++ b/src/server/webkit/webkit.ts
@@ -19,13 +19,13 @@ import { WKBrowser } from '../webkit/wkBrowser';
 import { Env } from '../processLauncher';
 import * as path from 'path';
 import { kBrowserCloseMessageId } from './wkConnection';
-import { BrowserTypeBase } from '../browserType';
+import { BrowserType } from '../browserType';
 import { ConnectionTransport } from '../transport';
 import { BrowserOptions } from '../browser';
 import { BrowserDescriptor } from '../../utils/browserPaths';
 import * as types from '../types';
 
-export class WebKit extends BrowserTypeBase {
+export class WebKit extends BrowserType {
   constructor(packagePath: string, browser: BrowserDescriptor) {
     super(packagePath, browser, null /* use pipe not websocket */);
   }


### PR DESCRIPTION
- We do not need the public BrowserType different from BrowserTypeBase anymore.
- Removing 'logName' parameter from runAbortableTask - it will
be used for metadata instead.