### PR TITLE
fix(rpc): ensure better error messages when rpc misbehaves

### DIFF
--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -133,7 +133,9 @@ export class Connection {
   }
 
   private _createRemoteObject(parentGuid: string, type: string, guid: string, initializer: any): any {
-    const parent = this._objects.get(parentGuid)!;
+    const parent = this._objects.get(parentGuid);
+    if (!parent)
+      throw new Error(`Cannot find parent object ${parentGuid} to create ${guid}`);
     let result: ChannelOwner<any, any>;
     initializer = this._replaceGuidsWithChannels(initializer);
     switch (type) {


### PR DESCRIPTION
- Print parentGuid when it is not available for __create__.
  Some bots show generic "something is undefined" error - let's
  get better information about the failure.

- Ignore events on disposed objects outside of tests.
  Some bots show this happening for "previewUpdated" - let's see
  whether there are more important events that misbehave.