### PR TITLE
fix(windows): show details about missing dependencies

### DIFF
--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -88,6 +88,9 @@ async function validateDependenciesWindows(browserPath: string, browser: Browser
         `as Administrator:`,
         ``,
         `    Install-WindowsFeature Server-Media-Foundation`,
+        ``,
+        `For Windows N editions visit:`,
+        `https://support.microsoft.com/en-us/help/3145500/media-feature-pack-list-for-windows-n-editions`,
         ``);
   }
 
@@ -200,7 +203,7 @@ async function missingFileDependenciesWindows(filePath: string): Promise<Array<s
   });
   if (code !== 0)
     return [];
-  const missingDeps = stdout.split('\n').map(line => line.trim()).filter(line => line.endsWith('not found') && line.includes('=>')).map(line => line.split('=>')[0].trim());
+  const missingDeps = stdout.split('\n').map(line => line.trim()).filter(line => line.endsWith('not found') && line.includes('=>')).map(line => line.split('=>')[0].trim().toLowerCase());
   return missingDeps;
 }
 


### PR DESCRIPTION
Convert file names of missing windows dependencies to lower case.
This enables the detailed error message about missing media feature pack.
Also provide a link to the official support page on how to optain the media features for Windows N releases.

When I tried to launch webkit I got this error message:
```
    browserType.launch: Host system is missing dependencies!

    Full list of missing libraries:
        EVR.dll

    Note: use DEBUG=pw:api environment variable and rerun to capture Playwright logs.
```

With with fix I am now getting the much more useful message:
```
    browserType.launchPersistentContext: Host system is missing dependencies!

    Some of the Media Foundation files cannot be found on the system. If you are
    on Windows Server try fixing this by running the following command in PowerShell
    as Administrator:

        Install-WindowsFeature Server-Media-Foundation

    For Windows N editions visit:
    https://support.microsoft.com/en-us/help/3145500/media-feature-pack-list-for-windows-n-editions

    Full list of missing libraries:
        evr.dll

    Note: use DEBUG=pw:api environment variable and rerun to capture Playwright logs.
```