### PR TITLE
fix(firefox): imply default ports for http/s

### DIFF
--- a/src/server/firefox/ffBrowser.ts
+++ b/src/server/firefox/ffBrowser.ts
@@ -47,6 +47,7 @@ export class FFBrowser extends Browser {
     }
     if (options.proxy) {
       const proxyServer = new URL(options.proxy.server);
+      let proxyPort = parseInt(proxyServer.port, 10);
       let aType: 'http'|'https'|'socks'|'socks4' = 'http';
       if (proxyServer.protocol === 'socks5:')
         aType = 'socks';
@@ -54,11 +55,17 @@ export class FFBrowser extends Browser {
         aType = 'socks4';
       else if (proxyServer.protocol === 'https:')
         aType = 'https';
+      if (proxyServer.port === '') {
+        if (proxyServer.protocol === 'http:')
+          proxyPort = 80;
+        else if (proxyServer.protocol === 'https:')
+          proxyPort = 443;
+      }
       promises.push(browser._connection.send('Browser.setBrowserProxy', {
         type: aType,
         bypass: options.proxy.bypass ? options.proxy.bypass.split(',').map(domain => domain.trim()) : [],
         host: proxyServer.hostname,
-        port: parseInt(proxyServer.port, 10),
+        port: proxyPort,
         username: options.proxy.username,
         password: options.proxy.password,
       }));

--- a/test/proxy.spec.ts
+++ b/test/proxy.spec.ts
@@ -152,3 +152,11 @@ it('should use socks proxy', test => {
   await browser.close();
   server.close();
 });
+
+it('does launch without a port', async ({ browserType, defaultBrowserOptions }) => {
+  const browser = await browserType.launch({
+    ...defaultBrowserOptions,
+    proxy: { server: 'http://localhost' }
+  });
+  await browser.close();
+});


### PR DESCRIPTION
```js
const playwright = require('.');

/** Only for Firefox
 * (node:65025) UnhandledPromiseRejectionWarning: browserType.launch: Protocol error (Browser.setBrowserProxy): ERROR: failed to call method 'Browser.setBrowserProxy' with parameters {
  "type": "http",
  "bypass": [],
  "host": "1.0.0.1",
  "port": null
}
Expected "<root>.port" to be |number|; found |object| `null` instead. _dispatch@chrome://juggler/content/protocol/Dispatcher.js:67:15
 */

(async () => {
  const browser = await playwright.firefox.launch({
    proxy: {
      server: "1.0.0.1"
    }
  });
  const context = await browser.newContext();
  const page = await context.newPage();
  await page.goto('http://api.ipify.org');
  await page.screenshot({ path: `example-$.png` });
  await browser.close();
})();
```

We could fix it also in Juggler but its probably better when we do it on the Playwright layer end to ensure by that, that our proxy URLs are fine.