### PR TITLE
chore: fix compatibility to the domain module

### DIFF
--- a/src/client/channelOwner.ts
+++ b/src/client/channelOwner.ts
@@ -62,6 +62,8 @@ export abstract class ChannelOwner<T extends channels.Channel = channels.Channel
           return obj.addListener;
         if (prop === 'removeEventListener')
           return obj.removeListener;
+        if (prop === 'domain') // https://github.com/microsoft/playwright/issues/3848
+          return obj.domain;
         return (params: any) => this._connection.sendMessageToServer(this._type, guid, String(prop), params);
       },
     });

--- a/test/channels.spec.ts
+++ b/test/channels.spec.ts
@@ -15,8 +15,20 @@
  * limitations under the License.
  */
 
-import { it, expect, options } from './playwright.fixtures';
+import domain from 'domain';
+import { it, expect, options, playwrightFixtures } from './playwright.fixtures';
 import type { ChromiumBrowser } from '..';
+
+playwrightFixtures.defineWorkerFixture('domain', async ({ }, test) => {
+  const local = domain.create();
+  local.run(() => { });
+  let err;
+  local.on('error', e => err = e);
+  local.enter();
+  await test(null);
+  if (err)
+    throw err;
+});
 
 it('should work', async ({browser}) => {
   expect(!!browser['_connection']).toBeTruthy();
@@ -142,6 +154,14 @@ it('should scope browser handles', async ({browserType, defaultBrowserOptions}) 
 
   await browser.close();
   await expectScopeState(browserType, GOLDEN_PRECONDITION);
+});
+
+it('should work with the domain module', async ({ domain, browserType }) => {
+  const browser = await browserType.launch();
+  const page = await browser.newPage();
+  const result = await page.evaluate(() => 1 + 1);
+  expect(result).toBe(2);
+  await browser.close();
 });
 
 async function expectScopeState(object, golden) {

--- a/test/playwright.fixtures.ts
+++ b/test/playwright.fixtures.ts
@@ -38,6 +38,7 @@ type PlaywrightWorkerFixtures = {
   browserType: BrowserType<Browser>;
   browser: Browser;
   httpService: {server: TestServer, httpsServer: TestServer}
+  domain: void;
   toImpl: (rpcObject: any) => any;
   isChromium: boolean;
   isFirefox: boolean;


### PR DESCRIPTION
Fixes #3848

When using the domain module (deprecated but still used widely) it's not allowed to use a property called `domain` in a class which inherits from the EventEmitter. Before the tests timeout out.