### PR TITLE
browser(webkit): duplicate each frame duration times

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1343
-Changed: yurys@chromium.org Tue Sep  8 22:36:26 GMTST 2020
+1344
+Changed: yurys@chromium.org Fri Sep 11 13:34:58 PDT 2020

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -8669,10 +8669,10 @@ index 0000000000000000000000000000000000000000..31a922667462de1a1edc24a10f25c064
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..6cc90fc6576eeba03d9c6438b79ce4ca2af19db7
+index 0000000000000000000000000000000000000000..3e9eb9575bb19486ff9d1cefa3dec19a4f804673
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp
-@@ -0,0 +1,387 @@
+@@ -0,0 +1,389 @@
 +/*
 + * Copyright (c) 2010, The WebM Project authors. All rights reserved.
 + * Copyright (c) 2013 The Chromium Authors. All rights reserved.
@@ -8856,7 +8856,9 @@ index 0000000000000000000000000000000000000000..6cc90fc6576eeba03d9c6438b79ce4ca
 +    {
 +        m_encoderQueue->dispatch([this, frame = WTFMove(frame)] {
 +            frame->convertToVpxImage(m_image.get());
-+            encodeFrame(m_image.get(), frame->duration());
++            // TODO: figure out why simply passing duration doesn't work well.
++            for (int i = 0; i < frame->duration(); i++)
++                encodeFrame(m_image.get(), 1);
 +        });
 +    }
 +


### PR DESCRIPTION
https://github.com/yury-s/webkit/commit/e31220581486e5f20bbdd547c455d6bc1e2ef8e0

Otherwise duration encoding doesn't work well for still frame and results in  skewed timelines in the videos with few frames. E.g. in a blank page that changes it's background color in the very beginning and then recorded for 1s there are 2 frames. When replaying it the first one may take almost entire video and the last one will just blink while in practice it was opposite.

#1158