### PR TITLE
fix(snapshot): do not let a single frame fail the whole snapshot

### DIFF
--- a/src/utils/timeoutSettings.ts
+++ b/src/utils/timeoutSettings.ts
@@ -17,7 +17,8 @@
 
 import { isDebugMode } from './utils';
 
-const DEFAULT_TIMEOUT = isDebugMode() ? 0 : 30000;
+export const DEFAULT_TIMEOUT = 30000;
+const TIMEOUT = isDebugMode() ? 0 : DEFAULT_TIMEOUT;
 
 export class TimeoutSettings {
   private _parent: TimeoutSettings | undefined;
@@ -45,7 +46,7 @@ export class TimeoutSettings {
       return this._defaultTimeout;
     if (this._parent)
       return this._parent.navigationTimeout(options);
-    return DEFAULT_TIMEOUT;
+    return TIMEOUT;
   }
 
   timeout(options: { timeout?: number }): number {
@@ -55,12 +56,12 @@ export class TimeoutSettings {
       return this._defaultTimeout;
     if (this._parent)
       return this._parent.timeout(options);
-    return DEFAULT_TIMEOUT;
+    return TIMEOUT;
   }
 
   static timeout(options: { timeout?: number }): number {
     if (typeof options.timeout === 'number')
       return options.timeout;
-    return DEFAULT_TIMEOUT;
+    return TIMEOUT;
   }
 }

--- a/test/snapshot.spec.ts
+++ b/test/snapshot.spec.ts
@@ -20,5 +20,5 @@ it('should not throw', (test, parameters) => {
   test.skip(!options.TRACING);
 }, async ({page, server, playwright, toImpl}) => {
   await page.goto(server.PREFIX + '/snapshot/snapshot-with-css.html');
-  await (playwright as any).__tracer.captureSnapshot(toImpl(page), { timeout: 5000, label: 'snapshot' });
+  await (playwright as any).__tracer.captureSnapshot(toImpl(page), { label: 'snapshot' });
 });


### PR DESCRIPTION
Sometimes, we are unable to take a frame snapshot. The most common
example would be "frame is stuck during the navigation in Chromium",
where we cannot evaluate until the frame is done navigating.

In this case, use all other frames and just stub the failing ones
with "Snapshot is not available". Chances are, noone will even see
this frame because it's an invisible tracking iframe.