### PR TITLE
chore: refactor goBack/goForward/reload

### DIFF
--- a/src/server/browserContext.ts
+++ b/src/server/browserContext.ts
@@ -175,7 +175,7 @@ export abstract class BrowserContext extends EventEmitter {
       await waitForEvent.promise;
     }
     const pages = this.pages();
-    await pages[0].mainFrame().waitForLoadState();
+    await pages[0].mainFrame()._waitForLoadState(progress, 'load');
     if (pages.length !== 1 || pages[0].mainFrame().url() !== 'about:blank')
       throw new Error(`Arguments can not specify page to be opened (first url is ${pages[0].mainFrame().url()})`);
     if (this._options.isMobile || this._options.locale) {

--- a/src/server/electron/electron.ts
+++ b/src/server/electron/electron.ts
@@ -27,7 +27,7 @@ import * as types from '../types';
 import { launchProcess, waitForLine, envArrayToObject } from '../processLauncher';
 import { BrowserContext } from '../browserContext';
 import type {BrowserWindow} from 'electron';
-import { ProgressController } from '../progress';
+import { ProgressController, runAbortableTask } from '../progress';
 import { EventEmitter } from 'events';
 import { helper } from '../helper';
 import { BrowserProcess } from '../browser';
@@ -88,7 +88,7 @@ export class ElectronApplication extends EventEmitter {
       this._windows.delete(page);
     });
     this._windows.add(page);
-    await page.mainFrame().waitForLoadState('domcontentloaded').catch(e => {}); // can happen after detach
+    await runAbortableTask(progress => page.mainFrame()._waitForLoadState(progress, 'domcontentloaded'), page._timeoutSettings.navigationTimeout({})).catch(e => {}); // can happen after detach
     this.emit(ElectronApplication.Events.Window, page);
   }
 


### PR DESCRIPTION
These methods are the only users of waitForNavigation and
waitForLoadState on the server side. This refactor lifts the
Progress wrapper to the top-most goBack/goForward/reload call
and leaves waitForNavigation/waitForLoadState as internal helpers.
This way we get a single Progress for the actual api call.