### PR TITLE
chore: add devcontainer.json for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "name": "Playwright",
+    "image": "mcr.microsoft.com/playwright:next",
+    "postCreateCommand": "npm install && npm run build",
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    }
+}


### PR DESCRIPTION
Since more and more people are getting access to GitHub Codespaces and we want to make it for new contributors as easy as possible to contribute to the project I've added a GitHub Codespaces configuration.

This makes it possible for users per one click to get a new instance of the repo, which is based on our "tip of tree" Docker image, installs all our NPM packages, built it and make it ready for running e.g. `yarn ctest`.
