### PR TITLE
test: fixed OS-locale specific failing test

### DIFF
--- a/test/browsercontext-timezone-id.spec.ts
+++ b/test/browsercontext-timezone-id.spec.ts
@@ -19,25 +19,25 @@ import { it, expect } from './playwright.fixtures';
 it('should work', async ({ browser }) => {
   const func = () => new Date(1479579154987).toString();
   {
-    const context = await browser.newContext({ timezoneId: 'America/Jamaica' });
+    const context = await browser.newContext({ locale: 'en-US', timezoneId: 'America/Jamaica' });
     const page = await context.newPage();
     expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 13:12:34 GMT-0500 (Eastern Standard Time)');
     await context.close();
   }
   {
-    const context = await browser.newContext({ timezoneId: 'Pacific/Honolulu' });
+    const context = await browser.newContext({ locale: 'en-US', timezoneId: 'Pacific/Honolulu' });
     const page = await context.newPage();
     expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 08:12:34 GMT-1000 (Hawaii-Aleutian Standard Time)');
     await context.close();
   }
   {
-    const context = await browser.newContext({ timezoneId: 'America/Buenos_Aires' });
+    const context = await browser.newContext({ locale: 'en-US', timezoneId: 'America/Buenos_Aires' });
     const page = await context.newPage();
     expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 15:12:34 GMT-0300 (Argentina Standard Time)');
     await context.close();
   }
   {
-    const context = await browser.newContext({ timezoneId: 'Europe/Berlin' });
+    const context = await browser.newContext({ locale: 'en-US', timezoneId: 'Europe/Berlin' });
     const page = await context.newPage();
     expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 19:12:34 GMT+0100 (Central European Standard Time)');
     await context.close();

--- a/test/defaultbrowsercontext-2.spec.ts
+++ b/test/defaultbrowsercontext-2.spec.ts
@@ -42,7 +42,7 @@ it('should support colorScheme option', async ({launchPersistent}) => {
 });
 
 it('should support timezoneId option', async ({launchPersistent}) => {
-  const {page} = await launchPersistent({timezoneId: 'America/Jamaica'});
+  const {page} = await launchPersistent({locale: 'en-US', timezoneId: 'America/Jamaica'});
   expect(await page.evaluate(() => new Date(1479579154987).toString())).toBe('Sat Nov 19 2016 13:12:34 GMT-0500 (Eastern Standard Time)');
 });
 


### PR DESCRIPTION
Was broken on `LANG=de_DE.UTF-8`. The rest works. (GitHub Codespaces uses by default the browser language on the OS. Thats how I found that.)