### PR TITLE
test: fixed Node.js deprecation warning

### DIFF
--- a/test/channels.spec.ts
+++ b/test/channels.spec.ts
@@ -24,7 +24,6 @@ playwrightFixtures.defineWorkerFixture('domain', async ({ }, test) => {
   local.run(() => { });
   let err;
   local.on('error', e => err = e);
-  local.enter();
   await test(null);
   if (err)
     throw err;


### PR DESCRIPTION
Today is the day of small Pull Requests!

Fixes the following deprecation warning. Checked locally if the test will also fail/pass without the enter method and it works without as expected.

```
(node:41018) [DEP0097] DeprecationWarning: Using a domain property in MakeCallback is deprecated. Use the async_context variant of MakeCallback or the AsyncResource class instead.
```

See on bots: https://github.com/microsoft/playwright/runs/1105154274#step:9:8