### PR TITLE
docs(languages): added Go reference

### DIFF
--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -99,7 +99,7 @@ $ docker run --rm -it playwright:localbuild /bin/bash
 
 ### Push
 
-Docker images are published automatically by Github Actions. We currently publish the following
+Docker images are published automatically by GitHub Actions. We currently publish the following
 images:
 - `mcr.microsoft.com/playwright:next` - tip-of-tree image version.
 - `mcr.microsoft.com/playwright:bionic` - last Playwright release docker image.

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -6,6 +6,7 @@ The Playwright API is available in multiple languages.
 - [JavaScript and TypeScript](#javascript-and-typescript)
 - [Python](#python)
 - [C#](#c)
+- [Go](#go)
 <!-- GEN:stop -->
 
 ## JavaScript and TypeScript
@@ -21,7 +22,7 @@ npm i -D playwright
 
 ## Python
 
-Playwright in Python is available in preview.
+Playwright for Python is available in preview.
 
 ```
 pip install playwright
@@ -33,7 +34,7 @@ pip install playwright
 
 ## C#
 
-Playwright in C# is available in preview.
+Playwright for C# is available in preview.
 
 ```
 dotnet add package PlaywrightSharp
@@ -41,3 +42,14 @@ dotnet add package PlaywrightSharp
 
 * [Playwright on NuGet](https://www.nuget.org/packages/PlaywrightSharp/)
 * [GitHub repo](https://github.com/hardkoded/playwright-sharp)
+
+## Go
+
+Playwright for Go is available in preview.
+
+```
+go get github.com/mxschmitt/playwright-go
+```
+
+* [GitHub repo](https://github.com/mxschmitt/playwright-go)
+* [Documentation](https://pkg.go.dev/github.com/mxschmitt/playwright-go?tab=doc)


### PR DESCRIPTION
Using the term "Playwright for X" instead of "in" since we use it for Python too. Also added the Go driver reference.