### PR TITLE
fix($$): use utility context when possible

### DIFF
--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -552,7 +552,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async $$(selector: string): Promise<ElementHandle<Element>[]> {
-    return this._page.selectors._queryAll(this._context.frame, selector, this);
+    return this._page.selectors._queryAll(this._context.frame, selector, this, true /* adoptToMain */);
   }
 
   async _$evalExpression(selector: string, expression: string, isFunction: boolean, arg: any): Promise<any> {

--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -488,7 +488,7 @@ export class FFPage implements PageDelegate {
     const parent = frame.parentFrame();
     if (!parent)
       throw new Error('Frame has been detached.');
-    const handles = await this._page.selectors._queryAll(parent, 'iframe', undefined, true /* allowUtilityContext */);
+    const handles = await this._page.selectors._queryAll(parent, 'iframe', undefined);
     const items = await Promise.all(handles.map(async handle => {
       const frame = await handle.contentFrame().catch(e => null);
       return { handle, frame };

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -590,7 +590,7 @@ export class Frame extends EventEmitter {
   }
 
   async $$(selector: string): Promise<dom.ElementHandle<Element>[]> {
-    return this._page.selectors._queryAll(this, selector);
+    return this._page.selectors._queryAll(this, selector, undefined, true /* adoptToMain */);
   }
 
   async content(): Promise<string> {

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -854,7 +854,7 @@ export class WKPage implements PageDelegate {
     const parent = frame.parentFrame();
     if (!parent)
       throw new Error('Frame has been detached.');
-    const handles = await this._page.selectors._queryAll(parent, 'iframe', undefined, true /* allowUtilityContext */);
+    const handles = await this._page.selectors._queryAll(parent, 'iframe', undefined);
     const items = await Promise.all(handles.map(async handle => {
       const frame = await handle.contentFrame().catch(e => null);
       return { handle, frame };

--- a/test/queryselector.spec.ts
+++ b/test/queryselector.spec.ts
@@ -114,3 +114,15 @@ it('xpath should return multiple elements', async ({page, server}) => {
   const elements = await page.$$('xpath=/html/body/div');
   expect(elements.length).toBe(2);
 });
+
+it('$$ should work with bogus Array.from', async ({page, server}) => {
+  await page.setContent('<div>hello</div><div></div>');
+  const div1 = await page.evaluateHandle(() => {
+    Array.from = () => [];
+    return document.querySelector('div');
+  });
+  const elements = await page.$$('div');
+  expect(elements.length).toBe(2);
+  // Check that element handle is functional and belongs to the main world.
+  expect(await elements[0].evaluate((div, div1) => div === div1, div1)).toBe(true);
+});


### PR DESCRIPTION
This avoids the typical issue of overridden builtins, trading it for performance of one by one node adoptions.

Fixes #3865.