### PR TITLE
fix(docker): add again pwuser

### DIFF
--- a/docs/docker/Dockerfile.bionic
+++ b/docs/docker/Dockerfile.bionic
@@ -61,6 +61,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get install -y --no-install-recommends git ssh && \
     npm install -g yarn
 
+# 9. Create the pwuser (we internally create a symlink for the pwuser and the root user)
+RUN adduser pwuser
+
 # === BAKE BROWSERS INTO IMAGE ===
 
 # 1. Add tip-of-tree Playwright package to install its browsers.
@@ -69,6 +72,9 @@ COPY ./playwright.tar.gz /tmp/playwright.tar.gz
 
 # 2. Install playwright and then delete the installation.
 #    Browsers will remain downloaded in `/root/.cache/ms-playwright`.
-RUN mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
-    npm i /tmp/playwright.tar.gz && \
+RUN su pwuser -c "mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
+    npm i /tmp/playwright.tar.gz" && \
     rm -rf /tmp/pw && rm /tmp/playwright.tar.gz
+
+RUN mkdir /root/.cache/ && \
+    ln -s /home/pwuser/.cache/ms-playwright/ /root/.cache/

--- a/docs/docker/Dockerfile.bionic
+++ b/docs/docker/Dockerfile.bionic
@@ -71,10 +71,11 @@ RUN adduser pwuser
 COPY ./playwright.tar.gz /tmp/playwright.tar.gz
 
 # 2. Install playwright and then delete the installation.
-#    Browsers will remain downloaded in `/root/.cache/ms-playwright`.
+#    Browsers will remain downloaded in `/home/pwuser/.cache/ms-playwright`.
 RUN su pwuser -c "mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
     npm i /tmp/playwright.tar.gz" && \
     rm -rf /tmp/pw && rm /tmp/playwright.tar.gz
 
+# 3. Symlink downloaded browsers for root user
 RUN mkdir /root/.cache/ && \
-    ln -s /home/pwuser/.cache/ms-playwright/ /root/.cache/
+    ln -s /home/pwuser/.cache/ms-playwright/ /root/.cache/ms-playwright

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -46,7 +46,7 @@ docker run -it --rm --ipc=host mcr.microsoft.com/playwright:bionic /bin/bash
 On untrusted websites, it's recommended to use a separate user for launching the browsers in combination with the seccomp profile. Inside the container or if you are using the Docker image as a base image you have to use `adduser` for it.
 
 ```
-$ docker run -it --rm --ipc=host --security-opt seccomp=seccomp_profile.json mcr.microsoft.com/playwright:bionic /bin/bash
+$ docker run -it --rm --ipc=host --user pwuser --security-opt seccomp=seccomp_profile.json mcr.microsoft.com/playwright:bionic /bin/bash
 ```
 
 [`seccomp_profile.json`](seccomp_profile.json) is needed to run Chromium with sandbox. This is
@@ -71,7 +71,6 @@ a [default Docker seccomp profile](https://github.com/docker/engine/blob/d0d99b0
 
 > **NOTE**: Using `--ipc=host` is recommended when using Chrome ([Docker docs](https://docs.docker.com/engine/reference/run/#ipc-settings---ipc)). Chrome can run out of memory without this flag.
 
-Since the seccomp profile is now in use, you have to create a separate user with `adduser pwuser` which you use to run your browsers with Playwright.
 
 ### Using on CI
 


### PR DESCRIPTION
In version 1.4 we introduced a breaking change for the Docker behaviour since we removed the pwuser completely. In this PR I add this user again and create a symlink so that root uses the browser of the pwuser. This has also the benefit, that the users who wants to use the seccomp profile that they don't have to create this user.

Reference: https://playwright.slack.com/archives/CSUHZPVLM/p1600240776120400

Tested on root and on pwuser. Works.