### PR TITLE
chore(trace): remove dependency on handle._previewPromise

### DIFF
--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -99,20 +99,18 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   readonly _context: FrameExecutionContext;
   readonly _page: Page;
   readonly _objectId: string;
-  readonly _previewPromise: Promise<string>;
 
   constructor(context: FrameExecutionContext, objectId: string) {
     super(context, 'node', objectId);
     this._objectId = objectId;
     this._context = context;
     this._page = context.frame._page;
-    this._previewPromise = this._initializePreview().catch(e => 'node');
-    this._previewPromise.then(preview => this._setPreview('JSHandle@' + preview));
+    this._initializePreview().catch(e => {});
   }
 
   async _initializePreview() {
     const utility = await this._context.injectedScript();
-    return utility.evaluate((injected, e) => injected.previewNode(e), this);
+    this._setPreview(await utility.evaluate((injected, e) => 'JSHandle@' + injected.previewNode(e), this));
   }
 
   asElement(): ElementHandle<T> | null {

--- a/src/trace/snapshotterInjected.ts
+++ b/src/trace/snapshotterInjected.ts
@@ -25,7 +25,7 @@ type SnapshotResult = {
   frameElements: Element[],
 };
 
-export function takeSnapshotInFrame(guid: string, removeNoScript: boolean): SnapshotResult {
+export function takeSnapshotInFrame(guid: string, removeNoScript: boolean, target: Node | undefined): SnapshotResult {
   const shadowAttribute = 'playwright-shadow-root';
   const win = window;
   const doc = win.document;
@@ -161,6 +161,8 @@ export function takeSnapshotInFrame(guid: string, removeNoScript: boolean): Snap
       const element = node as Element;
       builder.push('<');
       builder.push(nodeName);
+      if (node === target)
+        builder.push(' __playwright_target__="true"');
       for (let i = 0; i < element.attributes.length; i++) {
         const name = element.attributes[i].name;
         let value = element.attributes[i].value;

--- a/src/trace/traceTypes.ts
+++ b/src/trace/traceTypes.ts
@@ -56,7 +56,7 @@ export type ActionTraceEvent = {
   contextId: string,
   action: string,
   pageId?: string,
-  target?: string,
+  selector?: string,
   label?: string,
   value?: string,
   startTime?: number,


### PR DESCRIPTION
We now mark the target with '__playwright_target__' attribute and let the trace viewer do whatever it wants.