### PR TITLE
feat(emulation): emulate a mouse pointer in headless chrome

### DIFF
--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -120,7 +120,8 @@ export class Chromium extends BrowserType {
       chromeArguments.push(
           '--headless',
           '--hide-scrollbars',
-          '--mute-audio'
+          '--mute-audio',
+          '--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4',
       );
     }
     if (options.chromiumSandbox === false)
@@ -173,5 +174,4 @@ const DEFAULT_ARGS = [
   '--enable-automation',
   '--password-store=basic',
   '--use-mock-keychain',
-  '--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4'
 ];

--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -173,5 +173,5 @@ const DEFAULT_ARGS = [
   '--enable-automation',
   '--password-store=basic',
   '--use-mock-keychain',
-  '--blink-settings=primaryHoverType=2'
+  '--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4'
 ];

--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -173,4 +173,5 @@ const DEFAULT_ARGS = [
   '--enable-automation',
   '--password-store=basic',
   '--use-mock-keychain',
+  '--blink-settings=primaryHoverType=2'
 ];

--- a/test/browsercontext-viewport-mobile.spec.ts
+++ b/test/browsercontext-viewport-mobile.spec.ts
@@ -130,4 +130,19 @@ describe('mobile viewport', (suite, parameters) => {
     expect(await page.evaluate(() => window.innerWidth)).toBe(320);
     await context.close();
   });
+
+  it('should emulate the hover media feature', (test, parameters) => {
+    test.fail(options.WEBKIT(parameters));
+  }, async ({playwright, browser}) => {
+    const iPhone = playwright.devices['iPhone 6'];
+    const mobilepage = await browser.newPage({ ...iPhone });
+    expect(await mobilepage.evaluate(() => matchMedia('(hover: hover)').matches)).toBe(false);
+    expect(await mobilepage.evaluate(() => matchMedia('(hover: none)').matches)).toBe(true);
+    await mobilepage.close();
+
+    const desktopPage = await browser.newPage();
+    expect(await desktopPage.evaluate(() => matchMedia('(hover: none)').matches)).toBe(false);
+    expect(await desktopPage.evaluate(() => matchMedia('(hover: hover)').matches)).toBe(true);
+    await desktopPage.close();
+  });
 });

--- a/test/browsercontext-viewport-mobile.spec.ts
+++ b/test/browsercontext-viewport-mobile.spec.ts
@@ -138,11 +138,23 @@ describe('mobile viewport', (suite, parameters) => {
     const mobilepage = await browser.newPage({ ...iPhone });
     expect(await mobilepage.evaluate(() => matchMedia('(hover: hover)').matches)).toBe(false);
     expect(await mobilepage.evaluate(() => matchMedia('(hover: none)').matches)).toBe(true);
+    expect(await mobilepage.evaluate(() => matchMedia('(any-hover: hover)').matches)).toBe(false);
+    expect(await mobilepage.evaluate(() => matchMedia('(any-hover: none)').matches)).toBe(true);
+    expect(await mobilepage.evaluate(() => matchMedia('(pointer: coarse)').matches)).toBe(true);
+    expect(await mobilepage.evaluate(() => matchMedia('(pointer: fine)').matches)).toBe(false);
+    expect(await mobilepage.evaluate(() => matchMedia('(any-pointer: coarse)').matches)).toBe(true);
+    expect(await mobilepage.evaluate(() => matchMedia('(any-pointer: fine)').matches)).toBe(false);
     await mobilepage.close();
 
     const desktopPage = await browser.newPage();
     expect(await desktopPage.evaluate(() => matchMedia('(hover: none)').matches)).toBe(false);
     expect(await desktopPage.evaluate(() => matchMedia('(hover: hover)').matches)).toBe(true);
+    expect(await desktopPage.evaluate(() => matchMedia('(any-hover: none)').matches)).toBe(false);
+    expect(await desktopPage.evaluate(() => matchMedia('(any-hover: hover)').matches)).toBe(true);
+    expect(await desktopPage.evaluate(() => matchMedia('(pointer: coarse)').matches)).toBe(false);
+    expect(await desktopPage.evaluate(() => matchMedia('(pointer: fine)').matches)).toBe(true);
+    expect(await desktopPage.evaluate(() => matchMedia('(any-pointer: coarse)').matches)).toBe(false);
+    expect(await desktopPage.evaluate(() => matchMedia('(any-pointer: fine)').matches)).toBe(true);
     await desktopPage.close();
   });
 });


### PR DESCRIPTION
I added a test for the `hover` media query, which is unimplemented for us in webkit. This value was wrong for headless chrome, but it was easily fixed with a new command line flag.