### PR TITLE
devops(docker): push focal images to CR

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -34,6 +34,7 @@ jobs:
     - name: tag & publish
       run: |
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:next
+        ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:next-bionic
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:sha-${{ github.sha }}
         ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:next-focal
 

--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -30,8 +30,10 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: ./docs/docker/build.sh bionic playwright:localbuild-bionic
+    - run: ./docs/docker/build.sh focal playwright:localbuild-focal
     - name: tag & publish
       run: |
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:next
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:sha-${{ github.sha }}
+        ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:next-focal
 

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -41,6 +41,7 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: ./docs/docker/build.sh bionic playwright:localbuild-bionic
+    - run: ./docs/docker/build.sh focal playwright:localbuild-focal
     - name: tag & publish
       run: |
         # GITHUB_REF has a form of `refs/tags/v1.3.0`.
@@ -49,3 +50,6 @@ jobs:
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:latest
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:bionic
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:${TAG_NAME}
+
+        ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:focal
+        ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:${TAG_NAME}-focal

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -50,6 +50,7 @@ jobs:
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:latest
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:bionic
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:${TAG_NAME}
+        ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:${TAG_NAME}-bionic
 
         ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:focal
         ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:${TAG_NAME}-focal

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -14,6 +14,8 @@
   * [Build the image](#build-the-image)
   * [Push](#push)
 - [Base images](#base-images)
+  * [Ubuntu 20](#ubuntu-20)
+  * [Ubuntu 18](#ubuntu-18)
   * [Alpine](#alpine)
 <!-- GEN:stop -->
 
@@ -110,7 +112,13 @@ Status of push to MCR can be [verified here](https://mcrflow-status-ui.azurewebs
 
 ## Base images
 
-`playwright:bionic` is based on Ubuntu 18.04 LTS (Bionic Beaver).
+### Ubuntu 20
+
+`mcr.microsoft.com/playwright:focal` is based on Ubuntu 20.04 LTS (Focal Fossa).
+
+### Ubuntu 18
+
+`mcr.microsoft.com/playwright:bionic` is based on Ubuntu 18.04 LTS (Bionic Beaver).
 
 ### Alpine
 


### PR DESCRIPTION
This will end up in the following Docker tags:
- focal <- new
- bionic < old as before
- latest <- old as before, keep bionic for now until EOL is reached
- v1.4 <- old as before, is bionic
- v1.4-focal <- new, is focal

Depends on https://github.com/aslushnikov/devops.aslushnikov.com/pull/3 to ensure it works.
Relates to https://github.com/microsoft/playwright/issues/3791.