### PR TITLE
chore: don't hold sourcemap reference in prod build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ESNext",
     "module": "commonjs",
     "lib": ["esnext", "dom", "DOM.Iterable"],
-    "sourceMap": true,
     "rootDir": "./src",
     "outDir": "./lib",
     "strict": true,

--- a/utils/watch.js
+++ b/utils/watch.js
@@ -20,7 +20,7 @@ const fs = require('fs');
 
 const spawns = [
   child_process.spawn('node', [path.join(__dirname, 'runWebpack.js'), '--mode="development"', '--watch', '--silent'], { stdio: 'inherit', shell: true }),
-  child_process.spawn('npx', ['tsc', '-w', '--preserveWatchOutput', '-p', path.join(__dirname, '..')], { stdio: 'inherit', shell: true }),
+  child_process.spawn('npx', ['tsc', '-w', '--preserveWatchOutput', '--sourceMap', '-p', path.join(__dirname, '..')], { stdio: 'inherit', shell: true }),
 ];
 process.on('exit', () => spawns.forEach(s => s.kill()));
 


### PR DESCRIPTION
Relates #3957

It's no regression and not sure if its useful to have them persistent during development. Maybe if we debug through, so yep.

