### PR TITLE
chore(types): add return type to advancePosition

### DIFF
--- a/src/utils/sourceMap.ts
+++ b/src/utils/sourceMap.ts
@@ -133,7 +133,7 @@ function findPosition(source: string, offset: number): Position {
   return result;
 }
 
-function advancePosition(position: Position, delta: Position) {
+function advancePosition(position: Position, delta: Position): Position {
   return {
     line: position.line + delta.line,
     column: delta.column + (delta.line ? 0 : position.column),


### PR DESCRIPTION
This commit adds a return type to the function `advancePosition` found in `/src/utils/sourceMap.ts`