### PR TITLE
tests for request event and interception with redirects

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1656,9 +1656,9 @@ await browser.close();
 
 Routing provides the capability to modify network requests that are made by a page.
 
-Once routing is enabled, every request* matching the url pattern will stall unless it's continued, fulfilled or aborted.
+Once routing is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
 
-_* The handler will only be called for the first url if the response is a redirect._
+> **NOTE** The handler will only be called for the first url if the response is a redirect.
 
 An example of a naïve handler that aborts all image requests:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1656,7 +1656,9 @@ await browser.close();
 
 Routing provides the capability to modify network requests that are made by a page.
 
-Once routing is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
+Once routing is enabled, every request* matching the url pattern will stall unless it's continued, fulfilled or aborted.
+
+_* The handler will only be called for the first URL if the response is a redirect._
 
 An example of a naïve handler that aborts all image requests:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1658,7 +1658,7 @@ Routing provides the capability to modify network requests that are made by a pa
 
 Once routing is enabled, every request* matching the url pattern will stall unless it's continued, fulfilled or aborted.
 
-_* The handler will only be called for the first URL if the response is a redirect._
+_* The handler will only be called for the first url if the response is a redirect._
 
 An example of a naïve handler that aborts all image requests:
 

--- a/test/network-request.spec.ts
+++ b/test/network-request.spec.ts
@@ -45,6 +45,18 @@ it('should work for fetch requests', async ({page, server}) => {
   expect(requests[0].frame()).toBe(page.mainFrame());
 });
 
+it('should work for a redirect', async ({page, server}) => {
+  server.setRedirect('/foo.html', '/empty.html');
+  let requests = [];
+  page.on('request', request => requests.push(request));
+  requests = requests.filter(request => !request.url().includes('favicon'));
+  await page.goto(server.PREFIX + '/foo.html');
+
+  expect(requests.length).toBe(2);
+  expect(requests[0].url()).toBe(server.PREFIX + '/foo.html');
+  expect(requests[1].url()).toBe(server.PREFIX + '/empty.html');
+});
+
 it('should return headers', async ({page, server, isChromium, isFirefox, isWebKit}) => {
   const response = await page.goto(server.EMPTY_PAGE);
   if (isChromium)

--- a/test/network-request.spec.ts
+++ b/test/network-request.spec.ts
@@ -58,6 +58,8 @@ it('should work for a redirect', async ({page, server}) => {
 });
 
 it('should work for a redirect and interception', async ({page, server}) => {
+// https://github.com/microsoft/playwright/issues/3993
+it('should not work for a redirect and interception', async ({page, server}) => {
   server.setRedirect('/foo.html', '/empty.html');
   let requests = [];
   await page.route('**', route => {
@@ -69,9 +71,8 @@ it('should work for a redirect and interception', async ({page, server}) => {
 
   expect(page.url()).toBe(server.PREFIX + '/empty.html');
 
-  expect(requests.length).toBe(2);
+  expect(requests.length).toBe(1);
   expect(requests[0].url()).toBe(server.PREFIX + '/foo.html');
-  expect(requests[1].url()).toBe(server.PREFIX + '/empty.html');
 });
 
 it('should return headers', async ({page, server, isChromium, isFirefox, isWebKit}) => {

--- a/test/network-request.spec.ts
+++ b/test/network-request.spec.ts
@@ -57,6 +57,23 @@ it('should work for a redirect', async ({page, server}) => {
   expect(requests[1].url()).toBe(server.PREFIX + '/empty.html');
 });
 
+it('should work for a redirect and interception', async ({page, server}) => {
+  server.setRedirect('/foo.html', '/empty.html');
+  let requests = [];
+  await page.route('**', route => {
+    requests.push(route.request());
+    route.continue();
+  });
+  requests = requests.filter(request => !request.url().includes('favicon'));
+  await page.goto(server.PREFIX + '/foo.html');
+
+  expect(page.url()).toBe(server.PREFIX + '/empty.html');
+
+  expect(requests.length).toBe(2);
+  expect(requests[0].url()).toBe(server.PREFIX + '/foo.html');
+  expect(requests[1].url()).toBe(server.PREFIX + '/empty.html');
+});
+
 it('should return headers', async ({page, server, isChromium, isFirefox, isWebKit}) => {
   const response = await page.goto(server.EMPTY_PAGE);
   if (isChromium)

--- a/test/network-request.spec.ts
+++ b/test/network-request.spec.ts
@@ -37,19 +37,17 @@ it('should work for subframe navigation request', async ({page, server}) => {
 
 it('should work for fetch requests', async ({page, server}) => {
   await page.goto(server.EMPTY_PAGE);
-  let requests = [];
+  const requests = [];
   page.on('request', request => requests.push(request));
   await page.evaluate(() => fetch('/digits/1.png'));
-  requests = requests.filter(request => !request.url().includes('favicon'));
   expect(requests.length).toBe(1);
   expect(requests[0].frame()).toBe(page.mainFrame());
 });
 
 it('should work for a redirect', async ({page, server}) => {
   server.setRedirect('/foo.html', '/empty.html');
-  let requests = [];
+  const requests = [];
   page.on('request', request => requests.push(request));
-  requests = requests.filter(request => !request.url().includes('favicon'));
   await page.goto(server.PREFIX + '/foo.html');
 
   expect(requests.length).toBe(2);
@@ -57,16 +55,14 @@ it('should work for a redirect', async ({page, server}) => {
   expect(requests[1].url()).toBe(server.PREFIX + '/empty.html');
 });
 
-it('should work for a redirect and interception', async ({page, server}) => {
 // https://github.com/microsoft/playwright/issues/3993
 it('should not work for a redirect and interception', async ({page, server}) => {
   server.setRedirect('/foo.html', '/empty.html');
-  let requests = [];
+  const requests = [];
   await page.route('**', route => {
     requests.push(route.request());
     route.continue();
   });
-  requests = requests.filter(request => !request.url().includes('favicon'));
   await page.goto(server.PREFIX + '/foo.html');
 
   expect(page.url()).toBe(server.PREFIX + '/empty.html');


### PR DESCRIPTION
See https://github.com/microsoft/playwright/issues/3993

This adds a ~~currently failing~~ test for intercepting a request that redirects. The interceptor is not called for the redirect.