### PR TITLE
fix(actions): wait for some time before retrying the action

### DIFF
--- a/test/click-timeout-3.spec.ts
+++ b/test/click-timeout-3.spec.ts
@@ -54,6 +54,7 @@ it('should timeout waiting for hit target', async ({page, server}) => {
   expect(error.message).toContain('elementHandle.click: Timeout 5000ms exceeded.');
   expect(error.message).toContain('<div id="blocker"></div> intercepts pointer events');
   expect(error.message).toContain('retrying click action');
+  expect(error.message).toContain('waiting 500ms');
 });
 
 it('should report wrong hit target subtree', async ({page, server}) => {


### PR DESCRIPTION
This saves some CPU cycles while waiting for the page to
change the state, e.g. for animations to complete.

Note that retrying logic is only applicable in rare
circumstances like unexpected scroll in the middle of an
action, or some overlay blocking the click. Usually,
action times out in this cases while retrying.

References #3897.