### PR TITLE
roll(firefox): roll Firefox to r1174

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1173",
+      "revision": "1174",
       "download": true
     },
     {

--- a/test/workers.spec.ts
+++ b/test/workers.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import { it, expect } from './fixtures';
+import { attachFrame, detachFrame } from './utils';
 import type { ConsoleMessage } from '..';
 
 it('Page.workers', async function({page, server}) {
@@ -104,6 +105,23 @@ it('should clear upon cross-process navigation', async function({server, page}) 
   await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
   expect(destroyed).toBe(true);
   expect(page.workers().length).toBe(0);
+});
+
+it('should attribute network activity for worker inside iframe to the iframe', (test, {browserName}) => {
+  test.fixme(browserName === 'firefox' || browserName === 'chromium');
+}, async function({page, server}) {
+  await page.goto(server.PREFIX + '/empty.html');
+  const [worker, frame] = await Promise.all([
+    page.waitForEvent('worker'),
+    attachFrame(page, 'frame1', server.PREFIX + '/worker/worker.html'),
+  ]);
+  const url = server.PREFIX + '/one-style.css';
+  const [request] = await Promise.all([
+    page.waitForRequest(url),
+    worker.evaluate(url => fetch(url).then(response => response.text()).then(console.log), url),
+  ]);
+  expect(request.url()).toBe(url);
+  expect(request.frame()).toBe(frame)
 });
 
 it('should report network activity', async function({page, server}) {

--- a/test/workers.spec.ts
+++ b/test/workers.spec.ts
@@ -121,7 +121,7 @@ it('should attribute network activity for worker inside iframe to the iframe', (
     worker.evaluate(url => fetch(url).then(response => response.text()).then(console.log), url),
   ]);
   expect(request.url()).toBe(url);
-  expect(request.frame()).toBe(frame)
+  expect(request.frame()).toBe(frame);
 });
 
 it('should report network activity', async function({page, server}) {

--- a/test/workers.spec.ts
+++ b/test/workers.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { it, expect } from './fixtures';
-import { attachFrame, detachFrame } from './utils';
+import { attachFrame } from './utils';
 import type { ConsoleMessage } from '..';
 
 it('Page.workers', async function({page, server}) {


### PR DESCRIPTION
The r1174 starts using cross-process frameIds. This
simplifies Juggler a lot, but regresses a rare usecase:
network requests from workers from subframes are attributed
to main frame.

This adds a test to annotate this regression. Note that this
doesn't also work in Chromium.

References #3995