### PR TITLE
browser(firefox): remove the hack around setting viewport size

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1174
-Changed: lushnikov@chromium.org Tue Sep 29 02:02:37 MDT 2020
+1175
+Changed: lushnikov@chromium.org Wed Sep 30 00:14:19 MDT 2020

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
 1175
-Changed: lushnikov@chromium.org Wed Sep 30 00:14:19 MDT 2020
+Changed: lushnikov@chromium.org Wed Sep 30 00:44:40 MDT 2020

--- a/browser_patches/firefox/juggler/Helper.js
+++ b/browser_patches/firefox/juggler/Helper.js
@@ -22,6 +22,15 @@ class Helper {
     return () => receiver.removeEventListener(eventName, handler);
   }
 
+  awaitEvent(receiver, eventName) {
+    return new Promise(resolve => {
+      receiver.addEventListener(eventName, function listener(...args) {
+        receiver.removeEventListener(eventName, listener);
+        resolve(args);
+      });
+    });
+  }
+
   on(receiver, eventName, handler) {
     // The toolkit/modules/EventEmitter.jsm dispatches event name as a first argument.
     // Fire event listeners without it for convenience.

--- a/browser_patches/firefox/juggler/Helper.js
+++ b/browser_patches/firefox/juggler/Helper.js
@@ -24,9 +24,9 @@ class Helper {
 
   awaitEvent(receiver, eventName) {
     return new Promise(resolve => {
-      receiver.addEventListener(eventName, function listener(...args) {
+      receiver.addEventListener(eventName, function listener() {
         receiver.removeEventListener(eventName, listener);
-        resolve(args);
+        resolve();
       });
     });
   }

--- a/browser_patches/firefox/juggler/TargetRegistry.js
+++ b/browser_patches/firefox/juggler/TargetRegistry.js
@@ -194,8 +194,8 @@ class TargetRegistry {
       const tab = event.target;
       const userContextId = tab.userContextId;
       const browserContext = this._userContextIdToBrowserContext.get(userContextId);
-      const hasSpecifiedSize = (appWindow.chromeFlags & Ci.nsIWebBrowserChrome.CHROME_WITH_SIZE) !== 0;
-      if (!hasSpecifiedSize && browserContext && browserContext.defaultViewportSize)
+      const hasExplicitSize = (appWindow.chromeFlags & Ci.nsIWebBrowserChrome.JUGGLER_WINDOW_EXPLICIT_SIZE) !== 0;
+      if (!hasExplicitSize && browserContext && browserContext.defaultViewportSize)
         setViewportSizeForBrowser(browserContext.defaultViewportSize, tab.linkedBrowser, window);
     };
 

--- a/browser_patches/firefox/patches/bootstrap.diff
+++ b/browser_patches/firefox/patches/bootstrap.diff
@@ -1583,6 +1583,23 @@ index 318037b12e9ea7b8bad92498950ac48ff936fb3c..44db941025a5253da38572600cd0fc57
                                          int32_t aCurSelfProgress,
                                          int32_t aMaxSelfProgress,
                                          int32_t aCurTotalProgress,
+diff --git a/toolkit/components/windowwatcher/nsWindowWatcher.cpp b/toolkit/components/windowwatcher/nsWindowWatcher.cpp
+index 876b1ae05bbc2bdf725b749687b1c86e63b1f225..eb1bca3ca991e075a5d28253356b37a6bf8129b6 100644
+--- a/toolkit/components/windowwatcher/nsWindowWatcher.cpp
++++ b/toolkit/components/windowwatcher/nsWindowWatcher.cpp
+@@ -1796,6 +1796,12 @@ uint32_t nsWindowWatcher::CalculateChromeFlagsForContent(
+   uint32_t chromeFlags = CalculateChromeFlagsHelper(
+       nsIWebBrowserChrome::CHROME_WINDOW_BORDERS, aFeatures, aSizeSpec);
+ 
++  if (aFeatures.Exists("width") || aFeatures.Exists("height")) {
++    // Noone reads this flag in Firefox, so we are free to use it for
++    // Juggler needs.
++    chromeFlags |= nsIWebBrowserChrome::CHROME_WITH_SIZE;
++  }
++
+   return EnsureFlagsSafeForContent(chromeFlags);
+ }
+ 
 diff --git a/toolkit/mozapps/update/UpdateService.jsm b/toolkit/mozapps/update/UpdateService.jsm
 index 32a9ac1478a20ecfcf5c5fa1cefe8468b122b895..3aaa78c4558019c9d1d76b3c4204beae45f7b70c 100644
 --- a/toolkit/mozapps/update/UpdateService.jsm

--- a/browser_patches/firefox/patches/bootstrap.diff
+++ b/browser_patches/firefox/patches/bootstrap.diff
@@ -1547,6 +1547,20 @@ index 66df8509044600a0d71eb36bb838f96087a53ef1..e4558874434e3aa57bc26344f0ca89b3
        ? "https://firefox.settings.services.mozilla.com/v1"
        : gServerURL;
    },
+diff --git a/toolkit/components/browser/nsIWebBrowserChrome.idl b/toolkit/components/browser/nsIWebBrowserChrome.idl
+index 1e9bea1655af731fc003f8d0cab3ad4d2ad29f5d..5081c0e1ee0c41c6a79bd2ed358a57442e3baa6b 100644
+--- a/toolkit/components/browser/nsIWebBrowserChrome.idl
++++ b/toolkit/components/browser/nsIWebBrowserChrome.idl
+@@ -70,6 +70,9 @@ interface nsIWebBrowserChrome : nsISupports
+     // Whether this window should use out-of-process cross-origin subframes.
+     const unsigned long CHROME_FISSION_WINDOW         = 0x00200000;
+ 
++    // Whether this window has "width" or "height" defined in features
++    const unsigned long JUGGLER_WINDOW_EXPLICIT_SIZE  = 0x00400000;
++
+     // Prevents new window animations on MacOS and Windows. Currently
+     // ignored for Linux.
+     const unsigned long CHROME_SUPPRESS_ANIMATION     = 0x01000000;
 diff --git a/toolkit/components/startup/nsAppStartup.cpp b/toolkit/components/startup/nsAppStartup.cpp
 index 4eebb0e55ab3622e8f1f55655ef096d919e0ecb1..fb0e29281393f9c68d14a6549d3a9988569b0366 100644
 --- a/toolkit/components/startup/nsAppStartup.cpp
@@ -1584,17 +1598,15 @@ index 318037b12e9ea7b8bad92498950ac48ff936fb3c..44db941025a5253da38572600cd0fc57
                                          int32_t aMaxSelfProgress,
                                          int32_t aCurTotalProgress,
 diff --git a/toolkit/components/windowwatcher/nsWindowWatcher.cpp b/toolkit/components/windowwatcher/nsWindowWatcher.cpp
-index 876b1ae05bbc2bdf725b749687b1c86e63b1f225..eb1bca3ca991e075a5d28253356b37a6bf8129b6 100644
+index 876b1ae05bbc2bdf725b749687b1c86e63b1f225..be0aee2bcc5cf0a0576d953b31e85d1d84bfd245 100644
 --- a/toolkit/components/windowwatcher/nsWindowWatcher.cpp
 +++ b/toolkit/components/windowwatcher/nsWindowWatcher.cpp
-@@ -1796,6 +1796,12 @@ uint32_t nsWindowWatcher::CalculateChromeFlagsForContent(
+@@ -1796,6 +1796,10 @@ uint32_t nsWindowWatcher::CalculateChromeFlagsForContent(
    uint32_t chromeFlags = CalculateChromeFlagsHelper(
        nsIWebBrowserChrome::CHROME_WINDOW_BORDERS, aFeatures, aSizeSpec);
  
 +  if (aFeatures.Exists("width") || aFeatures.Exists("height")) {
-+    // Noone reads this flag in Firefox, so we are free to use it for
-+    // Juggler needs.
-+    chromeFlags |= nsIWebBrowserChrome::CHROME_WITH_SIZE;
++    chromeFlags |= nsIWebBrowserChrome::JUGGLER_WINDOW_EXPLICIT_SIZE;
 +  }
 +
    return EnsureFlagsSafeForContent(chromeFlags);


### PR DESCRIPTION
Juggler code had a bug where we subscribed to window and tab
events, but did not iterate collections of current windows and tabs.

As a result, we were sometimes failing to set viewport size for the
initial window, and implemented an artificial promise to workaround
the problem.

This patch:
- starts calling `onOpenWindow` and `onOpenTabListener` callbacks
  for *all* windows and tabs - current and future, eliminating the
  race condition.

This worked too well and we started overriding window sizes that
were set by users with `window.open(url, 'width=300;height=400')` (we
have a test for this). To fix this, we now plumb `CHROME_WITH_SIZE`
flag from appWindow and override viewport iff this flag is not set.

After this patch, we will use the `onTabOpened` event to move user
agent emulation to the browser-side.

References #3995