### PR TITLE
test: unflake click-timeout-4

### DIFF
--- a/test/click-timeout-4.spec.ts
+++ b/test/click-timeout-4.spec.ts
@@ -24,8 +24,8 @@ it('should timeout waiting for stable position', async ({page, server}) => {
     button.style.transition = 'margin 5s linear 0s';
     button.style.marginLeft = '200px';
   });
-  const error = await button.click({ timeout: 5000 }).catch(e => e);
-  expect(error.message).toContain('elementHandle.click: Timeout 5000ms exceeded.');
+  const error = await button.click({ timeout: 3000 }).catch(e => e);
+  expect(error.message).toContain('elementHandle.click: Timeout 3000ms exceeded.');
   expect(error.message).toContain('waiting for element to be visible, enabled and not moving');
   expect(error.message).toContain('element is moving - waiting');
 });


### PR DESCRIPTION
We used to animate for 5 seconds, and also timeout after 5 seconds.
Presumably, this made the click work sometimes due to different timeout
schedulers in node vs browser.