### PR TITLE
fix(close): fix a race during context.close and page.close

### DIFF
--- a/src/client/browser.ts
+++ b/src/client/browser.ts
@@ -22,6 +22,7 @@ import { Events } from './events';
 import { BrowserContextOptions } from './types';
 import { validateHeaders } from './network';
 import { headersObjectToArray } from '../utils/utils';
+import { isSafeCloseError } from '../utils/errors';
 
 export class Browser extends ChannelOwner<channels.BrowserChannel, channels.BrowserInitializer> {
   readonly _contexts = new Set<BrowserContext>();
@@ -88,9 +89,7 @@ export class Browser extends ChannelOwner<channels.BrowserChannel, channels.Brow
         await this._closedPromise;
       });
     } catch (e) {
-      if (e.message === 'browser.close: Browser has been closed')
-        return;
-      if (e.message === 'browser.close: Target browser or context has been closed')
+      if (isSafeCloseError(e))
         return;
       throw e;
     }

--- a/src/client/browserType.ts
+++ b/src/client/browserType.ts
@@ -29,6 +29,7 @@ import { envObjectToArray } from './clientHelper';
 import { validateHeaders } from './network';
 import { assert, makeWaitForNextTask, headersObjectToArray } from '../utils/utils';
 import { SelectorsOwner, sharedSelectors } from './selectors';
+import { kBrowserClosedError } from '../utils/errors';
 
 export interface BrowserServerLauncher {
   launchServer(options?: LaunchServerOptions): Promise<BrowserServer>;
@@ -127,7 +128,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, chann
       connection.onmessage = message => {
         if (ws.readyState !== WebSocket.OPEN) {
           setTimeout(() => {
-            connection.dispatch({ id: (message as any).id, error: serializeError(new Error('Browser has been closed')) });
+            connection.dispatch({ id: (message as any).id, error: serializeError(new Error(kBrowserClosedError)) });
           }, 0);
           return;
         }

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -20,6 +20,7 @@ import { serializeError } from '../protocol/serializers';
 import { createScheme, Validator, ValidationError } from '../protocol/validator';
 import { assert, createGuid, debugAssert, isUnderTest } from '../utils/utils';
 import { tOptional } from '../protocol/validatorPrimitives';
+import { kBrowserOrContextClosedError } from '../utils/errors';
 
 export const dispatcherSymbol = Symbol('dispatcher');
 
@@ -167,7 +168,7 @@ export class DispatcherConnection {
     const { id, guid, method, params, metadata } = message as any;
     const dispatcher = this._dispatchers.get(guid);
     if (!dispatcher) {
-      this.onmessage({ id, error: serializeError(new Error('Target browser or context has been closed')) });
+      this.onmessage({ id, error: serializeError(new Error(kBrowserOrContextClosedError)) });
       return;
     }
     if (method === 'debugScopeState') {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -24,3 +24,10 @@ class CustomError extends Error {
 }
 
 export class TimeoutError extends CustomError {}
+
+export const kBrowserClosedError = 'Browser has been closed';
+export const kBrowserOrContextClosedError = 'Target browser or context has been closed';
+
+export function isSafeCloseError(error: Error) {
+  return error.message.endsWith(kBrowserClosedError) || error.message.endsWith(kBrowserOrContextClosedError);
+}

--- a/test/browsertype-connect.spec.ts
+++ b/test/browsertype-connect.spec.ts
@@ -211,4 +211,25 @@ describe('connect', (suite, { wire }) => {
     ]);
     await remote.close();
   });
+
+  it('should not throw on context.close after disconnect', async ({browserType, remoteServer, server}) => {
+    const remote = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
+    const context = await remote.newContext();
+    await context.newPage();
+    await Promise.all([
+      new Promise(f => remote.on('disconnected', f)),
+      remoteServer.close()
+    ]);
+    await context.close();
+  });
+
+  it('should not throw on page.close after disconnect', async ({browserType, remoteServer, server}) => {
+    const remote = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
+    const page = await remote.newPage();
+    await Promise.all([
+      new Promise(f => remote.on('disconnected', f)),
+      remoteServer.close()
+    ]);
+    await page.close();
+  });
 });


### PR DESCRIPTION
There is a race between "close" event coming from the server and
"close" command issued from the client.

This is similar to calling close after disconnect, so added tests.