### PR TITLE
test: minor fixes

### DIFF
--- a/test/channels.spec.ts
+++ b/test/channels.spec.ts
@@ -163,7 +163,7 @@ it('should scope browser handles', async ({browserType, defaultBrowserOptions}) 
 });
 
 it('should work with the domain module', async ({ domain, browserType }) => {
-  const browser = await browserType.launch();
+  const browser = await browserType.launch(defaultBrowserOptions);
   const page = await browser.newPage();
   const result = await page.evaluate(() => 1 + 1);
   expect(result).toBe(2);

--- a/test/channels.spec.ts
+++ b/test/channels.spec.ts
@@ -162,7 +162,7 @@ it('should scope browser handles', async ({browserType, defaultBrowserOptions}) 
   await expectScopeState(browserType, GOLDEN_PRECONDITION);
 });
 
-it('should work with the domain module', async ({ domain, browserType }) => {
+it('should work with the domain module', async ({ domain, browserType, defaultBrowserOptions }) => {
   const browser = await browserType.launch(defaultBrowserOptions);
   const page = await browser.newPage();
   const result = await page.evaluate(() => 1 + 1);

--- a/test/downloads-path.spec.ts
+++ b/test/downloads-path.spec.ts
@@ -52,7 +52,7 @@ defineTestFixture('persistentDownloadsContext', async ({server, launchPersistent
         acceptDownloads: true
       }
   );
-  page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
+  await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
   await test(context);
   await context.close();
 });


### PR DESCRIPTION
- missing await
- missing `defaultBrowserOptions` that's important to respect `FFPATH` (and other custom browsers)