### PR TITLE
browser(firefox): do not double-attach session to the same target

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1177
-Changed: lushnikov@chromium.org Wed Sep 30 03:11:29 MDT 2020
+1178
+Changed: lushnikov@chromium.org Wed Sep 30 23:36:27 PDT 2020

--- a/browser_patches/firefox/juggler/content/main.js
+++ b/browser_patches/firefox/juggler/content/main.js
@@ -90,10 +90,11 @@ const applySetting = {
 };
 
 function initialize() {
-  const loadContext = docShell.QueryInterface(Ci.nsILoadContext);
-  const userContextId = loadContext.originAttributes.userContextId;
-
-  const response = sendSyncMessage('juggler:content-ready', { userContextId })[0];
+  const response = sendSyncMessage('juggler:content-ready')[0];
+  // If we didn't get a response, then we don't want to do anything
+  // as a part of this frame script.
+  if (!response)
+    return;
   const {
     sessionIds = [],
     scriptsToEvaluateOnNewDocument = [],

--- a/browser_patches/firefox/juggler/protocol/BrowserHandler.js
+++ b/browser_patches/firefox/juggler/protocol/BrowserHandler.js
@@ -29,7 +29,7 @@ class BrowserHandler {
     this._enabled = true;
     this._attachToDefaultContext = attachToDefaultContext;
 
-    for (const target of this._targetRegistry.targets()) {
+    for (const target of this._targetRegistry.reportedTargets()) {
       if (!this._shouldAttachToTarget(target))
         continue;
       const session = this._dispatcher.createSession();


### PR DESCRIPTION
We currently might double-attach to the target in `BrowserHandler` since we iterate over all targets, and then subscribe to the additional event when target is getting initialized.

This patch fixes this race condition and should unblock the roll to r1177.

References #3995