### PR TITLE
browser(firefox): remove multisession logic

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
 1179
-Changed: lushnikov@chromium.org Fri Oct  2 00:35:19 MDT 2020
+Changed: lushnikov@chromium.org Fri Oct  2 03:14:15 PDT 2020

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1178
-Changed: lushnikov@chromium.org Wed Sep 30 23:36:27 PDT 2020
+1179
+Changed: lushnikov@chromium.org Thu Oct  1 16:38:45 PDT 2020

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
 1179
-Changed: lushnikov@chromium.org Thu Oct  1 16:38:45 PDT 2020
+Changed: lushnikov@chromium.org Fri Oct  2 00:35:19 MDT 2020

--- a/browser_patches/firefox/juggler/TargetRegistry.js
+++ b/browser_patches/firefox/juggler/TargetRegistry.js
@@ -308,7 +308,7 @@ class TargetRegistry {
       if (await target.hasFailedToOverrideTimezone())
         throw new Error('Failed to override timezone');
     }
-    return target;
+    return target.id();
   }
 
   targets() {
@@ -343,7 +343,6 @@ class PageTarget {
     this._viewportSize = undefined;
     this._url = 'about:blank';
     this._openerId = opener ? opener.id() : undefined;
-
     this._channel = SimpleChannel.createForMessageManager(`browser::page[${this._targetId}]`, this._linkedBrowser.messageManager);
     this._channelIds = new Set();
 
@@ -400,12 +399,6 @@ class PageTarget {
   async setViewportSize(viewportSize) {
     this._viewportSize = viewportSize;
     await this.updateViewportSize();
-  }
-
-  async disconnectSession(session) {
-    if (this._disposed)
-      return;
-    this._channel.connect('').emit('detach', { sessionId: session.sessionId() });
   }
 
   async close(runBeforeUnload = false) {

--- a/browser_patches/firefox/juggler/content/main.js
+++ b/browser_patches/firefox/juggler/content/main.js
@@ -106,10 +106,6 @@ function initialize() {
   pageAgent.enable();
 
   channel.register('', {
-    detach() {
-      pageAgent.dispose();
-    },
-
     addScriptToEvaluateOnNewDocument(script) {
       frameTree.addScriptToEvaluateOnNewDocument(script);
     },

--- a/browser_patches/firefox/juggler/protocol/AccessibilityHandler.js
+++ b/browser_patches/firefox/juggler/protocol/AccessibilityHandler.js
@@ -4,7 +4,7 @@
 
 class AccessibilityHandler {
   constructor(session, contentChannel) {
-    this._contentPage = contentChannel.connect(session.sessionId() + 'page');
+    this._contentPage = contentChannel.connect('page');
   }
 
   async getFullAXTree(params) {

--- a/browser_patches/firefox/juggler/protocol/BrowserHandler.js
+++ b/browser_patches/firefox/juggler/protocol/BrowserHandler.js
@@ -7,6 +7,10 @@
 const {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
 const {TargetRegistry} = ChromeUtils.import("chrome://juggler/content/TargetRegistry.js");
 const {Helper} = ChromeUtils.import('chrome://juggler/content/Helper.js');
+const {PageHandler} = ChromeUtils.import("chrome://juggler/content/protocol/PageHandler.js");
+const {NetworkHandler} = ChromeUtils.import("chrome://juggler/content/protocol/NetworkHandler.js");
+const {RuntimeHandler} = ChromeUtils.import("chrome://juggler/content/protocol/RuntimeHandler.js");
+const {AccessibilityHandler} = ChromeUtils.import("chrome://juggler/content/protocol/AccessibilityHandler.js");
 
 const helper = new Helper();
 
@@ -29,19 +33,6 @@ class BrowserHandler {
     this._enabled = true;
     this._attachToDefaultContext = attachToDefaultContext;
 
-    for (const target of this._targetRegistry.reportedTargets()) {
-      if (!this._shouldAttachToTarget(target))
-        continue;
-      const session = this._dispatcher.createSession();
-      this._attachedSessions.set(target, session);
-      this._session.emitEvent('Browser.attachedToTarget', {
-        sessionId: session.sessionId(),
-        targetInfo: target.info()
-      });
-      target.initSession(session);
-      target.connectSession(session);
-    }
-
     this._eventListeners = [
       helper.on(this._targetRegistry, TargetRegistry.Events.TargetCreated, this._onTargetCreated.bind(this)),
       helper.on(this._targetRegistry, TargetRegistry.Events.TargetDestroyed, this._onTargetDestroyed.bind(this)),
@@ -54,6 +45,9 @@ class BrowserHandler {
     };
     Services.obs.addObserver(onScreencastStopped, 'juggler-screencast-stopped');
     this._eventListeners.push(() => Services.obs.removeObserver(onScreencastStopped, 'juggler-screencast-stopped'));
+
+    for (const target of this._targetRegistry.targets())
+      this._onTargetCreated(target);
   }
 
   async createBrowserContext({removeOnDetach}) {
@@ -87,24 +81,29 @@ class BrowserHandler {
   }
 
   _shouldAttachToTarget(target) {
-    if (!target._browserContext)
-      return false;
     if (this._createdBrowserContextIds.has(target._browserContext.browserContextId))
       return true;
     return this._attachToDefaultContext && target._browserContext === this._targetRegistry.defaultContext();
   }
 
-  _onTargetCreated({sessions, target}) {
+  _onTargetCreated(target) {
     if (!this._shouldAttachToTarget(target))
       return;
+    const channel = target.channel();
     const session = this._dispatcher.createSession();
     this._attachedSessions.set(target, session);
+    const pageHandler = new PageHandler(target, session, channel);
+    const networkHandler = new NetworkHandler(target, session, channel);
+    session.registerHandler('Page', pageHandler);
+    session.registerHandler('Network', networkHandler);
+    session.registerHandler('Runtime', new RuntimeHandler(session, channel));
+    session.registerHandler('Accessibility', new AccessibilityHandler(session, channel));
+    pageHandler.enable();
+    networkHandler.enable();
     this._session.emitEvent('Browser.attachedToTarget', {
       sessionId: session.sessionId(),
       targetInfo: target.info()
     });
-    target.initSession(session);
-    sessions.push(session);
   }
 
   _onTargetDestroyed(target) {
@@ -128,8 +127,10 @@ class BrowserHandler {
   }
 
   async newPage({browserContextId}) {
-    const targetId = await this._targetRegistry.newPage({browserContextId});
-    return {targetId};
+    const target = await this._targetRegistry.newPage({browserContextId});
+    if (!target)
+      throw new Error(`Failed to create target in browserContextId = ${browserContextId}!`);
+    return {targetId: target.id()};
   }
 
   async close() {

--- a/browser_patches/firefox/juggler/protocol/BrowserHandler.js
+++ b/browser_patches/firefox/juggler/protocol/BrowserHandler.js
@@ -67,10 +67,8 @@ class BrowserHandler {
 
   dispose() {
     helper.removeListeners(this._eventListeners);
-    for (const [target, session] of this._attachedSessions) {
-      target.disconnectSession(session);
+    for (const [target, session] of this._attachedSessions)
       this._dispatcher.destroySession(session);
-    }
     this._attachedSessions.clear();
     for (const browserContextId of this._createdBrowserContextIds) {
       const browserContext = this._targetRegistry.browserContextForId(browserContextId);
@@ -127,10 +125,8 @@ class BrowserHandler {
   }
 
   async newPage({browserContextId}) {
-    const target = await this._targetRegistry.newPage({browserContextId});
-    if (!target)
-      throw new Error(`Failed to create target in browserContextId = ${browserContextId}!`);
-    return {targetId: target.id()};
+    const targetId = await this._targetRegistry.newPage({browserContextId});
+    return {targetId};
   }
 
   async close() {

--- a/browser_patches/firefox/juggler/protocol/PageHandler.js
+++ b/browser_patches/firefox/juggler/protocol/PageHandler.js
@@ -17,7 +17,7 @@ const helper = new Helper();
 class WorkerHandler {
   constructor(session, contentChannel, workerId) {
     this._session = session;
-    this._contentWorker = contentChannel.connect(session.sessionId() + workerId);
+    this._contentWorker = contentChannel.connect(workerId);
     this._workerId = workerId;
 
     const emitWrappedProtocolEvent = eventName => {
@@ -30,7 +30,7 @@ class WorkerHandler {
     }
 
     this._eventListeners = [
-      contentChannel.register(session.sessionId() + workerId, {
+      contentChannel.register(workerId, {
         runtimeConsole: emitWrappedProtocolEvent('Runtime.console'),
         runtimeExecutionContextCreated: emitWrappedProtocolEvent('Runtime.executionContextCreated'),
         runtimeExecutionContextDestroyed: emitWrappedProtocolEvent('Runtime.executionContextDestroyed'),
@@ -59,7 +59,7 @@ class PageHandler {
   constructor(target, session, contentChannel) {
     this._session = session;
     this._contentChannel = contentChannel;
-    this._contentPage = contentChannel.connect(session.sessionId() + 'page');
+    this._contentPage = contentChannel.connect('page');
     this._workers = new Map();
 
     const emitProtocolEvent = eventName => {
@@ -67,7 +67,7 @@ class PageHandler {
     }
 
     this._eventListeners = [
-      contentChannel.register(session.sessionId() + 'page', {
+      contentChannel.register('page', {
         pageBindingCalled: emitProtocolEvent('Page.bindingCalled'),
         pageDispatchMessageFromWorker: emitProtocolEvent('Page.dispatchMessageFromWorker'),
         pageEventFired: emitProtocolEvent('Page.eventFired'),

--- a/browser_patches/firefox/juggler/protocol/RuntimeHandler.js
+++ b/browser_patches/firefox/juggler/protocol/RuntimeHandler.js
@@ -14,15 +14,14 @@ const helper = new Helper();
 
 class RuntimeHandler {
   constructor(session, contentChannel) {
-    const sessionId = session.sessionId();
-    this._contentRuntime = contentChannel.connect(sessionId + 'runtime');
+    this._contentRuntime = contentChannel.connect('runtime');
 
     const emitProtocolEvent = eventName => {
       return (...args) => session.emitEvent(eventName, ...args);
     }
 
     this._eventListeners = [
-      contentChannel.register(sessionId + 'runtime', {
+      contentChannel.register('runtime', {
         runtimeConsole: emitProtocolEvent('Runtime.console'),
         runtimeExecutionContextCreated: emitProtocolEvent('Runtime.executionContextCreated'),
         runtimeExecutionContextDestroyed: emitProtocolEvent('Runtime.executionContextDestroyed'),


### PR DESCRIPTION
This patch:
1. Changes `SimpleChannel` to buffer messages to the namespace that
   hasn't been registered yet. This allows us to create `SimpleChannel`
   per target on the browser side right away.
2. Removes multisession support. Now there's only one `PageAgent` in the
   content process, which talks to a single `PageHandler` on the browser
   side. Both ends can be created as-soon-as-needed; thanks to
   `SimpleChannel` bufferring, no messages will be lost and all messages
   will be delivered in proper order. (This is currently the reason why
   build 1178 flakes on windows).
3. Straightens up the target reporting. Targets are reported as soon
   as they appear on the browser side.

**NOTE:** this doesn't yet remove sessions from protocol.

References #3995