### PR TITLE
fix(video): wait for videos when closing persistent context

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1179",
+      "revision": "1180",
       "download": true
     },
     {

--- a/test/downloads-path.spec.ts
+++ b/test/downloads-path.spec.ts
@@ -83,7 +83,6 @@ it('should delete downloads when context closes', async ({downloadsBrowser, serv
   expect(fs.existsSync(path)).toBeTruthy();
   await page.close();
   expect(fs.existsSync(path)).toBeFalsy();
-
 });
 
 it('should report downloads in downloadsPath folder', async ({downloadsBrowser, testOutputPath, server}) => {
@@ -98,7 +97,7 @@ it('should report downloads in downloadsPath folder', async ({downloadsBrowser, 
   await page.close();
 });
 
-it('should accept downloads', async ({persistentDownloadsContext, testOutputPath, server})  => {
+it('should accept downloads in persistent context', async ({persistentDownloadsContext, testOutputPath, server})  => {
   const page = persistentDownloadsContext.pages()[0];
   const [ download ] = await Promise.all([
     page.waitForEvent('download'),
@@ -110,13 +109,14 @@ it('should accept downloads', async ({persistentDownloadsContext, testOutputPath
   expect(path.startsWith(testOutputPath(''))).toBeTruthy();
 });
 
-it('should not delete downloads when the context closes', async ({persistentDownloadsContext}) => {
+it('should delete downloads when persistent context closes', async ({persistentDownloadsContext}) => {
   const page = persistentDownloadsContext.pages()[0];
   const [ download ] = await Promise.all([
     page.waitForEvent('download'),
     page.click('a')
   ]);
   const path = await download.path();
-  await persistentDownloadsContext.close();
   expect(fs.existsSync(path)).toBeTruthy();
+  await persistentDownloadsContext.close();
+  expect(fs.existsSync(path)).toBeFalsy();
 });

--- a/test/screencast.spec.ts
+++ b/test/screencast.spec.ts
@@ -341,9 +341,7 @@ describe('screencast', suite => {
     expect(await videoPlayer.videoHeight).toBe(720);
   });
 
-  it('should capture static page in persistent context', test => {
-    test.fixme('We do not wait for the video finish when closing persistent context.');
-  }, async ({launchPersistent, testOutputPath}) => {
+  it('should capture static page in persistent context', async ({launchPersistent, testOutputPath}) => {
     const videosPath = testOutputPath('');
     const size = { width: 320, height: 240 };
     const { context, page } = await launchPersistent({


### PR DESCRIPTION
To achieve this, we close all the pages one by one, then wait for the videos to finish processing, and then close the browser.

Drive-by: fixes a bug where we did not delete downloads from persistent context.

References #3996.