### PR TITLE
browser(firefox): start screencast in existing pages upon setScreencastOptions

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1179
-Changed: lushnikov@chromium.org Fri Oct  2 03:14:15 PDT 2020
+1180
+Changed: dgozman@gmail.com Fri Oct  2 09:36:06 PDT 2020


### PR DESCRIPTION
This makes it work in persistent context.

To achieve this, we have to move screencast logic into PageTarget and
make PageHandler listen to an event.

References #3996.