### PR TITLE
browser(firefox): follow-up with assorted simplifications

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1182
-Changed: lushnikov@chromium.org Mon Oct  5 23:55:54 PDT 2020
+1183
+Changed: lushnikov@chromium.org Tue Oct  6 01:20:41 PDT 2020

--- a/browser_patches/firefox/juggler/SimpleChannel.js
+++ b/browser_patches/firefox/juggler/SimpleChannel.js
@@ -72,13 +72,11 @@ class SimpleChannel {
       throw new Error('ERROR: double-register for namespace ' + namespace);
     this._handlers.set(namespace, handler);
     // Try to re-deliver all pending messages.
-    Promise.resolve().then(() => {
-      const bufferedRequests = this._bufferedRequests;
-      this._bufferedRequests = [];
-      for (const data of bufferedRequests) {
-        this._onMessage(data);
-      }
-    });
+    const bufferedRequests = this._bufferedRequests;
+    this._bufferedRequests = [];
+    for (const data of bufferedRequests) {
+      this._onMessage(data);
+    }
     return () => this.unregister(namespace);
   }
 

--- a/browser_patches/firefox/juggler/content/main.js
+++ b/browser_patches/firefox/juggler/content/main.js
@@ -103,7 +103,6 @@ function initialize() {
     frameTree.addBinding(name, script);
 
   pageAgent = new PageAgent(messageManager, channel, frameTree);
-  pageAgent.enable();
 
   channel.register('', {
     addScriptToEvaluateOnNewDocument(script) {


### PR DESCRIPTION
This patch:
- moves `SimpleChannel` to synchronously dispatch buffered commands
  instead of a `await Promise.resolve()` hack
- moves dialog & screencast handling from `PageHandler` to
  `TargetManager`. This leaves `PageHandler` to be concerned solely about
  protocol.
- removes `attach` and `detach` methods for worker channels: since
  channels are buffering messages until the namespace registers, there's
  no chance to loose any events.
- slightly simplifies `PageNetwork` class: it's lifetime is now
  identical to the lifetime of the associated `PageTarget`, so a lot can
  be simplified later on.

References #3995