### PR TITLE
feat(firefox): roll to r1182

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1180",
+      "revision": "1182",
       "download": true
     },
     {


### PR DESCRIPTION
This revision enables `documentchannel` feature by default.

References #3995