### PR TITLE
chore: remove test dependency on pw itself

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1159,16 +1159,6 @@
         }
       }
     },
-    "@playwright/test": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-0.9.10.tgz",
-      "integrity": "sha512-jH/cqTnhiufgOUMuoTaK7bRnzKy7/FmJwmIHmFc/V9Cc4m//ETJJwavHog+GCVW7rOmsGtsBzhu/XoiZ3t3aWg==",
-      "dev": true,
-      "requires": {
-        "playwright": "1.4.0-next.1601161680085",
-        "rimraf": "^3.0.2"
-      }
-    },
     "@playwright/test-runner": {
       "version": "0.9.22",
       "resolved": "https://registry.npmjs.org/@playwright/test-runner/-/test-runner-0.9.22.tgz",
@@ -5403,25 +5393,6 @@
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
       "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
       "dev": true
-    },
-    "playwright": {
-      "version": "1.4.0-next.1601161680085",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.4.0-next.1601161680085.tgz",
-      "integrity": "sha512-IpBNNG8vPVjm5SeGzzwCrz2aMv1K8KMyUvEsAYJnkDOwgOIVECtdJkM6WZmvIjw2bxS+QxHsX7mA9y42C1B+Qg==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "extract-zip": "^2.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "jpeg-js": "^0.4.2",
-        "mime": "^2.4.6",
-        "pngjs": "^5.0.0",
-        "progress": "^2.0.3",
-        "proper-lockfile": "^4.1.1",
-        "proxy-from-env": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "ws": "^7.3.1"
-      }
     },
     "pngjs": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "ws": "^7.3.1"
   },
   "devDependencies": {
-    "@playwright/test": "0.9.10",
     "@playwright/test-runner": "0.9.22",
     "@types/debug": "^4.1.5",
     "@types/extract-zip": "^1.6.2",


### PR DESCRIPTION
Playwright had Playwright as a peer dependency. This resulted if the browser revisions were different that the upstream revision (first browser version) got removed. By that the tests were failing because the browser was not installed anymore.

Example: https://github.com/aslushnikov/devops.aslushnikov.com/runs/1212393441?check_suite_focus=true