### PR TITLE
browser(firefox): a different way to emit 'load' event

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1184
-Changed: lushnikov@chromium.org Tue Oct  6 12:04:41 PDT 2020
+1185
+Changed: lushnikov@chromium.org Wed Oct  7 08:45:05 PDT 2020

--- a/browser_patches/firefox/juggler/content/FrameTree.js
+++ b/browser_patches/firefox/juggler/content/FrameTree.js
@@ -196,6 +196,7 @@ class FrameTree {
     const isStart = flag & Ci.nsIWebProgressListener.STATE_START;
     const isTransferring = flag & Ci.nsIWebProgressListener.STATE_TRANSFERRING;
     const isStop = flag & Ci.nsIWebProgressListener.STATE_STOP;
+    const isDocument = flag & Ci.nsIWebProgressListener.STATE_IS_DOCUMENT;
 
     if (isStart) {
       // Starting a new navigation.
@@ -225,6 +226,9 @@ class FrameTree {
       if (frame === this._mainFrame && status !== Cr.NS_BINDING_ABORTED)
         this.forcePageReady();
     }
+
+    if (isStop && isDocument)
+      this.emit(FrameTree.Events.Load, frame);
   }
 
   onFrameLocationChange(progress, request, location, flags) {
@@ -303,6 +307,7 @@ FrameTree.Events = {
   NavigationAborted: 'navigationaborted',
   SameDocumentNavigation: 'samedocumentnavigation',
   PageReady: 'pageready',
+  Load: 'load',
 };
 
 class Frame {

--- a/browser_patches/firefox/juggler/content/PageAgent.js
+++ b/browser_patches/firefox/juggler/content/PageAgent.js
@@ -163,9 +163,9 @@ class PageAgent {
       helper.addObserver(this._onWindowOpenInNewContext.bind(this), 'juggler-window-open-in-new-context'),
       helper.addObserver(this._filePickerShown.bind(this), 'juggler-file-picker-shown'),
       helper.addEventListener(this._messageManager, 'DOMContentLoaded', this._onDOMContentLoaded.bind(this)),
-      helper.addEventListener(this._messageManager, 'pageshow', this._onLoad.bind(this)),
       helper.addObserver(this._onDocumentOpenLoad.bind(this), 'juggler-document-open-loaded'),
       helper.addEventListener(this._messageManager, 'error', this._onError.bind(this)),
+      helper.on(this._frameTree, 'load', this._onLoad.bind(this)),
       helper.on(this._frameTree, 'bindingcalled', this._onBindingCalled.bind(this)),
       helper.on(this._frameTree, 'frameattached', this._onFrameAttached.bind(this)),
       helper.on(this._frameTree, 'framedetached', this._onFrameDetached.bind(this)),
@@ -389,11 +389,7 @@ class PageAgent {
     });
   }
 
-  _onLoad(event) {
-    const docShell = event.target.ownerGlobal.docShell;
-    const frame = this._frameTree.frameForDocShell(docShell);
-    if (!frame)
-      return;
+  _onLoad(frame) {
     this._browserPage.emit('pageEventFired', {
       frameId: frame.id(),
       name: 'load'


### PR DESCRIPTION
Using WebProgressListener events works in all cases. Currently
used `pageshow` event will stop being emitted in future when loading
was stopped with `window.stop()` api.

References #3995