### PR TITLE
browser(firefox): wait for search and addon manager initialization

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1185
-Changed: lushnikov@chromium.org Wed Oct  7 08:45:05 PDT 2020
+1186
+Changed: lushnikov@chromium.org Wed Oct  7 09:26:45 PDT 2020


### PR DESCRIPTION
It looks like terminating browser when search service or addon manager is
not fully initialized results in a broken shutdown sequence. As of
today, this results in multiple errors in the browser STDERR. In future,
this might also result in browser stalling instead of terminating.

This starts awaiting search and addon manager termination.

References #3995