### PR TITLE
feat(firefox): roll Firefox to r1186

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1182",
+      "revision": "1186",
       "download": true
     },
     {


### PR DESCRIPTION
This roll includes two important fixes:
- await search service startup when launching browser
- report `"load"` event differently to support `window.stop()` in future

References #3995
