### PR TITLE
devops: fix firefox build

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1187
-Changed: lushnikov@chromium.org Wed Oct  7 13:30:11 PDT 2020
+1188
+Changed: lushnikov@chromium.org Wed Oct  7 14:29:11 PDT 2020

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -41,6 +41,10 @@ fi
 OBJ_FOLDER="obj-build-playwright"
 echo "mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/${OBJ_FOLDER}" >> .mozconfig
 
+if ! [[ -f "$HOME/.mozbuild/_virtualenvs/mach/bin/python" ]]; then
+  ./mach create-mach-environment
+fi
+
 if [[ $1 == "--juggler" ]]; then
   ./mach build faster
 else


### PR DESCRIPTION
New firefox build requires a pre-created python virtual environment.
We should detect it and create if necessary.

References #3995