### PR TITLE
devops: playwwright-core installation should not touch browser registry

### DIFF
--- a/packages/playwright-core/install.js
+++ b/packages/playwright-core/install.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Explicitly empty install.js to avoid touching browser registry at all.
+// See https://github.com/microsoft/playwright/issues/4083


### PR DESCRIPTION
Currently, `playwright-core` installation would check browser registry
and remove any unused browsers. This, however, might be unexpected
since `playwright-core` shouldn't touch browser registry at all.

Fixes #4083