### PR TITLE
fix: disable chromium sandbox by default

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4206,7 +4206,7 @@ This methods attaches Playwright to an existing browser instance.
     - `username` <[string]> Optional username to use if HTTP proxy requires authentication.
     - `password` <[string]> Optional password to use if HTTP proxy requires authentication.
   - `downloadsPath` <[string]> If specified, accepted downloads are downloaded into this folder. Otherwise, temporary folder is created and is deleted when browser is closed.
-  - `chromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `true`.
+  - `chromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `false`.
   - `firefoxUserPrefs` <[Object]<[string], [string]|[number]|[boolean]>> Firefox user preferences. Learn more about the Firefox user preferences at [`about:config`](https://support.mozilla.org/en-US/kb/about-config-editor-firefox).
   - `handleSIGINT` <[boolean]> Close the browser process on Ctrl-C. Defaults to `true`.
   - `handleSIGTERM` <[boolean]> Close the browser process on SIGTERM. Defaults to `true`.

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -169,7 +169,7 @@ export abstract class BrowserType {
     let browserProcess: BrowserProcess | undefined = undefined;
     const { launchedProcess, gracefullyClose, kill } = await launchProcess({
       executablePath: executable,
-      args: this._amendArguments(browserArguments),
+      args: browserArguments,
       env: this._amendEnvironment(env, userDataDir, executable, browserArguments),
       handleSIGINT,
       handleSIGTERM,
@@ -212,7 +212,6 @@ export abstract class BrowserType {
   abstract _defaultArgs(options: types.LaunchOptions, isPersistent: boolean, userDataDir: string): string[];
   abstract _connectToTransport(transport: ConnectionTransport, options: BrowserOptions): Promise<Browser>;
   abstract _amendEnvironment(env: Env, userDataDir: string, executable: string, browserArguments: string[]): Env;
-  abstract _amendArguments(browserArguments: string[]): string[];
   abstract _rewriteStartupError(error: Error): Error;
   abstract _attemptToGracefullyCloseBrowser(transport: ConnectionTransport): void;
 }

--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -16,7 +16,6 @@
  */
 
 import * as path from 'path';
-import * as os from 'os';
 import { CRBrowser } from './crBrowser';
 import { Env } from '../processLauncher';
 import { kBrowserCloseMessageId } from './crConnection';

--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -80,20 +80,6 @@ export class Chromium extends BrowserType {
     return env;
   }
 
-  _amendArguments(browserArguments: string[]): string[] {
-    // We currently only support Linux.
-    if (os.platform() !== 'linux')
-      return browserArguments;
-
-    // If there's already --no-sandbox passed in, do nothing.
-    if (browserArguments.indexOf('--no-sandbox') !== -1)
-      return browserArguments;
-    const runningAsRoot = process.geteuid && process.geteuid() === 0;
-    if (runningAsRoot)
-      return ['--no-sandbox', ...browserArguments];
-    return browserArguments;
-  }
-
   _attemptToGracefullyCloseBrowser(transport: ConnectionTransport): void {
     const message: ProtocolRequest = { method: 'Browser.close', id: kBrowserCloseMessageId, params: {} };
     transport.send(message);

--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -124,7 +124,7 @@ export class Chromium extends BrowserType {
           '--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4',
       );
     }
-    if (options.chromiumSandbox === false)
+    if (options.chromiumSandbox !== true)
       chromeArguments.push('--no-sandbox');
     if (proxy) {
       const proxyURL = new URL(proxy.server);

--- a/src/server/firefox/firefox.ts
+++ b/src/server/firefox/firefox.ts
@@ -49,10 +49,6 @@ export class Firefox extends BrowserType {
     } : env;
   }
 
-  _amendArguments(browserArguments: string[]): string[] {
-    return browserArguments;
-  }
-
   _attemptToGracefullyCloseBrowser(transport: ConnectionTransport): void {
     const message = { method: 'Browser.close', params: {}, id: kBrowserCloseMessageId };
     transport.send(message);

--- a/src/server/webkit/webkit.ts
+++ b/src/server/webkit/webkit.ts
@@ -38,10 +38,6 @@ export class WebKit extends BrowserType {
     return { ...env, CURL_COOKIE_JAR_PATH: path.join(userDataDir, 'cookiejar.db') };
   }
 
-  _amendArguments(browserArguments: string[]): string[] {
-    return browserArguments;
-  }
-
   _rewriteStartupError(error: Error): Error {
     return error;
   }


### PR DESCRIPTION
Certain environments, e.g. Azure Pipelines, override default user
inside container with a custom one, whereas fail to pass proper
seccomp profile for the docker image.

As a result, chromium sandboxing fails.

To ease life of devops deploying tests in various CI's, this patch
disables Chromium sandbox by default.

References #4084