### PR TITLE
feat: introduce `mouse.currentState()` api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3624,6 +3624,7 @@ await page.mouse.up();
 
 <!-- GEN:toc -->
 - [mouse.click(x, y[, options])](#mouseclickx-y-options)
+- [mouse.currentState()](#mousecurrentstate)
 - [mouse.dblclick(x, y[, options])](#mousedblclickx-y-options)
 - [mouse.down([options])](#mousedownoptions)
 - [mouse.move(x, y[, options])](#mousemovex-y-options)
@@ -3640,6 +3641,13 @@ await page.mouse.up();
 - returns: <[Promise]>
 
 Shortcut for [`mouse.move`](#mousemovex-y-options), [`mouse.down`](#mousedownoptions) and [`mouse.up`](#mouseupoptions).
+
+#### mouse.currentState()
+- returns: <[Object]>
+  - `x` <[number]> Current mouse `x` position
+  - `y` <[number]> Current mouse `y` position
+
+Returns current mouse state.
 
 #### mouse.dblclick(x, y[, options])
 - `x` <[number]>

--- a/src/client/input.ts
+++ b/src/client/input.ts
@@ -47,12 +47,23 @@ export class Keyboard {
 
 export class Mouse {
   private _channel: channels.PageChannel;
+  private _x = 0;
+  private _y = 0;
 
   constructor(channel: channels.PageChannel) {
     this._channel = channel;
   }
 
+  currentState(): {x: number, y: number} {
+    return {
+      x: this._x,
+      y: this._y,
+    };
+  }
+
   async move(x: number, y: number, options: { steps?: number } = {}) {
+    this._x = x;
+    this._y = y;
     await this._channel.mouseMove({ x, y, ...options });
   }
 
@@ -65,10 +76,14 @@ export class Mouse {
   }
 
   async click(x: number, y: number, options: channels.PageMouseClickOptions = {}) {
+    this._x = x;
+    this._y = y;
     await this._channel.mouseClick({ x, y, ...options });
   }
 
   async dblclick(x: number, y: number, options: Omit<channels.PageMouseClickOptions, 'clickCount'> = {}) {
+    this._x = x;
+    this._y = y;
     await this.click(x, y, { ...options, clickCount: 2 });
   }
 }

--- a/src/server/input.ts
+++ b/src/server/input.ts
@@ -177,6 +177,13 @@ export class Mouse {
     this._keyboard = this._page.keyboard;
   }
 
+  currentState(): {x: number, y: number} {
+    return {
+      x: this._x,
+      y: this._y,
+    };
+  }
+
   async move(x: number, y: number, options: { steps?: number } = {}) {
     const { steps = 1 } = options;
     const fromX = this._x;

--- a/test/mouse.spec.ts
+++ b/test/mouse.spec.ts
@@ -195,3 +195,19 @@ xdescribe('Drag and Drop', function() {
     expect(await page.$eval('#target', target => target.contains(document.querySelector('#source')))).toBe(true); // could not find source in target
   });
 });
+
+describe('Mouse.currentState', () => {
+  it('should work', async({server, page}) => {
+    await page.mouse.click(30, 40);
+    expect(page.mouse.currentState()).toEqual({
+      x: 30,
+      y: 40,
+    });
+    await page.mouse.move(33, 43);
+    expect(page.mouse.currentState()).toEqual({
+      x: 33,
+      y: 43,
+    });
+  });
+});
+

--- a/test/mouse.spec.ts
+++ b/test/mouse.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { it, expect, xdescribe } from './fixtures';
+import { it, expect, describe, xdescribe } from './fixtures';
 
 function dimensions() {
   const rect = document.querySelector('textarea').getBoundingClientRect();
@@ -197,7 +197,7 @@ xdescribe('Drag and Drop', function() {
 });
 
 describe('Mouse.currentState', () => {
-  it('should work', async({server, page}) => {
+  it('should work', async ({server, page}) => {
     await page.mouse.click(30, 40);
     expect(page.mouse.currentState()).toEqual({
       x: 30,


### PR DESCRIPTION
This adds a new `mouse.currentState()` method that will return
current mouse state. For now, this has only the `x` and `y`
coordinates.