### PR TITLE
browser(firefox): await browser initialization when closing browser

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1188
-Changed: lushnikov@chromium.org Wed Oct  7 14:29:11 PDT 2020
+1189
+Changed: lushnikov@chromium.org Mon Oct 12 22:21:30 PDT 2020

--- a/browser_patches/firefox/juggler/protocol/BrowserHandler.js
+++ b/browser_patches/firefox/juggler/protocol/BrowserHandler.js
@@ -51,7 +51,7 @@ class BrowserHandler {
     // service before returning from this method. Failing to do so will result
     // in a broken shutdown sequence and multiple errors in browser STDERR log.
     //
-    // NOTE: we have to put this here instead of in the `Browser.close` handler
+    // NOTE: we have to put this here as well as in the `Browser.close` handler
     // since browser shutdown can be initiated when the last tab is closed, e.g.
     // with persistent context.
     await Promise.all([
@@ -139,6 +139,12 @@ class BrowserHandler {
     if (browserWindow && browserWindow.gBrowserInit) {
       await browserWindow.gBrowserInit.idleTasksFinishedPromise;
     }
+    // Try to fully initialize browser before closing.
+    // See comment in `Browser.enable`.
+    await Promise.all([
+      waitForAddonManager(),
+      waitForSearchService(),
+    ]);
     this._onclose();
     Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
   }


### PR DESCRIPTION
We try to avoid closing firefox too early, fearing that this
might terminate clean shutdown sequence.

Usually we assume that `Browser.enable` is called before `Browser.close`
- however, this is not the case in certain tests. So we have to
ensure browser initialization in `Browser.close` as well.

In my local tests, this fixes the Firefox Pipe problem: it looks like
we were closing browser too quickly.