### PR TITLE
fix(video): close all contexts before closing the browser

### DIFF
--- a/src/server/browser.ts
+++ b/src/server/browser.ts
@@ -113,6 +113,7 @@ export abstract class Browser extends EventEmitter {
   async close() {
     if (!this._startedClosing) {
       this._startedClosing = true;
+      await Promise.all(this.contexts().map(c => c.close()));
       await this._options.browserProcess.close();
     }
     if (this.isConnected())

--- a/test/screencast.spec.ts
+++ b/test/screencast.spec.ts
@@ -365,4 +365,32 @@ describe('screencast', suite => {
       expectAll(pixels, almostRed);
     }
   });
+
+  it('should capture static page when closing the browser', async ({browserType, defaultBrowserOptions, testInfo}) => {
+    const videosPath = testInfo.outputPath('');
+    const size = { width: 320, height: 240 };
+    const browser = await browserType.launch(defaultBrowserOptions);
+    const page = await browser.newPage({
+      videosPath,
+      viewport: size,
+      videoSize: size
+    });
+
+    await page.evaluate(() => document.body.style.backgroundColor = 'red');
+    await new Promise(r => setTimeout(r, 1000));
+    await browser.close();
+
+    const videoFile = findVideo(videosPath);
+    const videoPlayer = new VideoPlayer(videoFile);
+    const duration = videoPlayer.duration;
+    expect(duration).toBeGreaterThan(0);
+
+    expect(videoPlayer.videoWidth).toBe(320);
+    expect(videoPlayer.videoHeight).toBe(240);
+
+    {
+      const pixels = videoPlayer.seekLastFrame().data;
+      expectAll(pixels, almostRed);
+    }
+  });
 });


### PR DESCRIPTION
To ensure that all videos have been processed, we should first
close all contexts (and pages), and only then close the browser.

This change affects non-video contexts as well, and may result
in slowing down of `Browser.close()` call.