### PR TITLE
Removing "Codex" as it isn't using Playwright

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -6,7 +6,6 @@
 * [TypeScript](https://github.com/microsoft/TypeScript): Playwright is used test typescript.js across browsers
 * [Elastic APM JS agent](https://github.com/elastic/apm-agent-rum-js): Playwright is used to run benchmark tests across browsers
 * [Blockstack](https://github.com/blockstack/ux): Playwright is used to run cross-browser UI tests
-* [Codex](https://github.com/codex-src/codex-app): Playwright is used to run functional and performance tests
 * [Instakittens React admin](https://github.com/fredericbonnet/instakittens-react-admin): Playwright is used to run end-to-end test scenarios written with Cucumber
 * [xterm.js](https://github.com/xtermjs/xterm.js): Playwright is used to run cross-browser integration tests
 * [Accessibility Insights for Web](https://github.com/microsoft/accessibility-insights-web): Playwright is used with Jest and axe-core to run end-to-end functional and accessibility tests of a WebExtension-based browser extension


### PR DESCRIPTION
I looked at that repo and could not find anywhere where Playwright was being used. I think it would be good to remove to prevent confusion.