### PR TITLE
browser(firefox): report pageerrors without stack properties

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1193
-Changed: joel.einbinder@gmail.com Fri 16 Oct 2020 01:22:55 AM PDT
+1194
+Changed: joel.einbinder@gmail.com Fri 16 Oct 2020 01:52:53 AM PDT

--- a/browser_patches/firefox/juggler/content/PageAgent.js
+++ b/browser_patches/firefox/juggler/content/PageAgent.js
@@ -375,7 +375,7 @@ class PageAgent {
     this._browserPage.emit('pageUncaughtError', {
       frameId: frame.id(),
       message: errorEvent.message,
-      stack: errorEvent.error ? errorEvent.error.stack : '',
+      stack: errorEvent.error && typeof errorEvent.error.stack === 'string' ? errorEvent.error.stack : '',
     });
   }
 


### PR DESCRIPTION
This makes sure we always send string stacks over the protocol. Fixes two tests in page-event-pageerror.spec.ts.