### PR TITLE
docs: Use green check marks in browser compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Playwright is a Node.js library to automate [Chromium](https://www.chromium.org/
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->88.0.4287.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| WebKit 14.0 | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Firefox <!-- GEN:firefox-version -->82.0b9<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Chromium <!-- GEN:chromium-version -->88.0.4287.0<!-- GEN:stop --> | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| WebKit 14.0 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Firefox <!-- GEN:firefox-version -->82.0b9<!-- GEN:stop --> | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 
 Headless execution is supported for all the browsers on all platforms. Check out [system requirements](https://playwright.dev/#?path=docs/intro.md&q=system-requirements) for details.
 


### PR DESCRIPTION
Because green check marks look so much better than white check marks, and is better for accessibility!

![2020-10-16_17-34](https://user-images.githubusercontent.com/1504756/96324381-6feaaa00-0fd6-11eb-9482-289f256362d2.png)
