### PR TITLE
add type for selector engine

### DIFF
--- a/src/client/selectors.ts
+++ b/src/client/selectors.ts
@@ -17,12 +17,13 @@
 import { evaluationScript } from './clientHelper';
 import * as channels from '../protocol/channels';
 import { ChannelOwner } from './channelOwner';
+import { SelectorEngine } from './types';
 
 export class Selectors {
   private _channels = new Set<SelectorsOwner>();
   private _registrations: channels.SelectorsRegisterParams[] = [];
 
-  async register(name: string, script: string | Function | { path?: string, content?: string }, options: { contentScript?: boolean } = {}): Promise<void> {
+  async register(name: string, script: string | (() => SelectorEngine) | { path?: string, content?: string }, options: { contentScript?: boolean } = {}): Promise<void> {
     const source = await evaluationScript(script, undefined, false);
     const params = { ...options, name, source };
     for (const channel of this._channels)

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -86,3 +86,19 @@ export type LaunchServerOptions = {
   port?: number,
   logger?: Logger,
 } & FirefoxUserPrefs;
+
+export type SelectorEngine = {
+  /**
+   * Creates a selector that matches given target when queried at the root.
+   * Can return undefined if unable to create one.
+   */
+  create(root: HTMLElement, target: HTMLElement): string | undefined;
+  /**
+   * Returns the first element matching given selector in the root's subtree.
+   */
+  query(root: HTMLElement, selector: string): HTMLElement | null;
+  /**
+   * Returns all elements matching given selector in the root's subtree.
+   */
+  queryAll(root: HTMLElement, selector: string): HTMLElement[];
+};


### PR DESCRIPTION
The [docs show how you can register a custom selector engine](https://playwright.dev/#version=v1.5.1&path=docs%2Fapi.md)

This adds a type for it (`SelectorEngine`). Currently it's just `Function`.

