### PR TITLE
browser(firefox): fix screencast timescale precision

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1194
-Changed: joel.einbinder@gmail.com Fri 16 Oct 2020 01:52:53 AM PDT
+1195
+Changed: yurys@chromium.org Tue Oct 20 13:36:31 PDT 2020

--- a/browser_patches/firefox/juggler/screencast/ScreencastEncoder.h
+++ b/browser_patches/firefox/juggler/screencast/ScreencastEncoder.h
@@ -21,6 +21,7 @@ namespace mozilla {
 class ScreencastEncoder {
     NS_INLINE_DECL_THREADSAFE_REFCOUNTING(ScreencastEncoder)
 public:
+    static constexpr int fps = 25;
 
     static RefPtr<ScreencastEncoder> create(nsCString& errorString, const nsCString& filePath, int width, int height, Maybe<double> scale, const gfx::IntMargin& margin);
 

--- a/browser_patches/firefox/juggler/screencast/nsScreencastService.cpp
+++ b/browser_patches/firefox/juggler/screencast/nsScreencastService.cpp
@@ -92,7 +92,7 @@ class nsScreencastService::Session : public rtc::VideoSinkInterface<webrtc::Vide
     // The size is ignored in fact.
     capability.width = 1280;
     capability.height = 960;
-    capability.maxFPS = 24;
+    capability.maxFPS = ScreencastEncoder::fps;
     capability.videoType = webrtc::VideoType::kI420;
     int error = mCaptureModule->StartCapture(capability);
     if (error) {


### PR DESCRIPTION
* Set timebase unit to 1 / (1000 * fps) to more precisely encode frames with duration of up to 1.5s. Previously that would always add one more frame even if the frame duration was slightly above 1 which resulted in a skewed video timeline (each frame that was 1.03 * (1/25) seconds would become 2 / 25 seconds in the video
* Drive-by: switch from 24 to 25 fps.