### PR TITLE
test: fixed executable path test if ran in Docker

### DIFF
--- a/test/browsertype-basic.spec.ts
+++ b/test/browsertype-basic.spec.ts
@@ -23,7 +23,7 @@ it('browserType.executablePath should work', test => {
 }, async ({browserType}) => {
   const executablePath = browserType.executablePath();
   expect(fs.existsSync(executablePath)).toBe(true);
-  expect(fs.realpathSync(executablePath)).toBe(executablePath);
+  expect(fs.realpathSync(executablePath)).toBe(fs.realpathSync(executablePath));
 });
 
 it('browserType.name should work', async ({browserType, isChromium, isFirefox, isWebKit}) => {

--- a/test/browsertype-basic.spec.ts
+++ b/test/browsertype-basic.spec.ts
@@ -23,7 +23,6 @@ it('browserType.executablePath should work', test => {
 }, async ({browserType}) => {
   const executablePath = browserType.executablePath();
   expect(fs.existsSync(executablePath)).toBe(true);
-  expect(fs.realpathSync(executablePath)).toBe(fs.realpathSync(executablePath));
 });
 
 it('browserType.name should work', async ({browserType, isChromium, isFirefox, isWebKit}) => {


### PR DESCRIPTION
In the DevOps repo we run the test inside our Docker container. Inside of that we are using symlinks for the browser executable paths, that leads to [an error](https://github.com/aslushnikov/devops.aslushnikov.com/runs/1295791310?check_suite_focus=true#step:8:324) with the current implementation.

We applied the same fix to the Python tests [here](https://github.com/microsoft/playwright-python/pull/207/files#diff-3b0de63633fe072c2546a28cc4ac9d527e7826b18103c776f4a3da0fe9b30d5aL91).

