### PR TITLE
Update `getFromEnv` logic to validate that value is undefined (instead of falsey) before redefining it

### DIFF
--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -33,7 +33,8 @@ const fsWriteFileAsync = util.promisify(fs.writeFile.bind(fs));
 const removeFolderAsync = util.promisify(removeFolder);
 
 export async function installBrowsersWithProgressBar(packagePath: string) {
-  if (getFromENV('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD')) {
+  // PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD should have a value of 0 or 1
+  if (!!Number(getFromENV('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD'))) {
     browserFetcher.logPolitely('Skipping browsers download because `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` env variable is set');
     return false;
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -97,8 +97,8 @@ export function isUnderTest(): boolean {
 
 export function getFromENV(name: string) {
   let value = process.env[name];
-  value = value || process.env[`npm_config_${name.toLowerCase()}`];
-  value = value || process.env[`npm_package_config_${name.toLowerCase()}`];
+  value = typeof value === 'undefined' ? process.env[`npm_config_${name.toLowerCase()}`] : value;
+  value = typeof value === 'undefined' ?  process.env[`npm_package_config_${name.toLowerCase()}`] : value;
   return value;
 }
 


### PR DESCRIPTION
Additionally, cast the `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` check to a number to allow for values of 0 or 1

Fix for https://github.com/microsoft/playwright/issues/4225