### PR TITLE
browser(firefox): don't send messages to content too quickly

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1198
-Changed: lushnikov@chromium.org Thu 29 Oct 2020 04:23:02 PM PDT
+1199
+Changed: joel.einbinder@gmail.com Fri 30 Oct 2020 08:46:32 AM PDT

--- a/browser_patches/firefox/juggler/TargetRegistry.js
+++ b/browser_patches/firefox/juggler/TargetRegistry.js
@@ -94,6 +94,7 @@ class TargetRegistry {
 
     this._browserContextIdToBrowserContext = new Map();
     this._userContextIdToBrowserContext = new Map();
+    /** @type {Map<any, PageTarget>} */
     this._browserToTarget = new Map();
     this._browserBrowsingContextToTarget = new Map();
 
@@ -128,7 +129,7 @@ class TargetRegistry {
         const target = this._browserToTarget.get(linkedBrowser);
         if (!target)
           return;
-
+        target.contentIsReadyCallback();
         return {
           scriptsToEvaluateOnNewDocument: target.browserContext().scriptsToEvaluateOnNewDocument,
           bindings: target.browserContext().bindings,
@@ -329,7 +330,9 @@ class PageTarget {
     this._viewportSize = undefined;
     this._url = 'about:blank';
     this._openerId = opener ? opener.id() : undefined;
-    this._channel = SimpleChannel.createForMessageManager(`browser::page[${this._targetId}]`, this._linkedBrowser.messageManager);
+    this._channel = SimpleChannel.createForMessageManager(`browser::page[${this._targetId}]`, this._linkedBrowser.messageManager, new Promise(x => {
+      this.contentIsReadyCallback = x;
+    }));
     this._screencastInfo = undefined;
     this._dialogs = new Map();
 


### PR DESCRIPTION
Sending messages too quickly to the content process could have them reach there before the channel is set up. Then they would be silently discarded.