### PR TITLE
fix(firefox): don't crash when messages come after close

### DIFF
--- a/src/server/firefox/ffConnection.ts
+++ b/src/server/firefox/ffConnection.ts
@@ -188,6 +188,8 @@ export class FFSession extends EventEmitter {
   }
 
   dispatchMessage(object: ProtocolResponse) {
+    if (this._disposed)
+      return;
     if (object.id && this._callbacks.has(object.id)) {
       const callback = this._callbacks.get(object.id)!;
       this._callbacks.delete(object.id);


### PR DESCRIPTION
In [this test run](https://github.com/microsoft/playwright/runs/1323672300), we get an unexpected protocol response. This can only happen if the session receives a message after it has been closed. There is a comment in ffConnection.ts that implies as much:
```typescript
      const callback = this._callbacks.get(message.id);
      // Callbacks could be all rejected if someone has called `.dispose()`.
      if (callback) {
```
I haven't been able to repro it locally, but I am confident that this patch is neutral or beneficial.