### PR TITLE
feat(scopes): make page a scope

### DIFF
--- a/src/dispatchers/pageDispatcher.ts
+++ b/src/dispatchers/pageDispatcher.ts
@@ -43,14 +43,17 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageInitializer> i
       videoRelativePath: page._video ? page._video._relativePath : undefined,
       viewportSize: page.viewportSize() || undefined,
       isClosed: page.isClosed()
-    });
+    }, true);
     this._page = page;
-    page.on(Page.Events.Close, () => this._dispatchEvent('close'));
+    page.on(Page.Events.Close, () => {
+      this._dispatchEvent('close');
+      this._dispose();
+    });
     page.on(Page.Events.Console, message => this._dispatchEvent('console', { message: new ConsoleMessageDispatcher(this._scope, message) }));
     page.on(Page.Events.Crash, () => this._dispatchEvent('crash'));
     page.on(Page.Events.DOMContentLoaded, () => this._dispatchEvent('domcontentloaded'));
     page.on(Page.Events.Dialog, dialog => this._dispatchEvent('dialog', { dialog: new DialogDispatcher(this._scope, dialog) }));
-    page.on(Page.Events.Download, download => this._dispatchEvent('download', { download: new DownloadDispatcher(this._scope, download) }));
+    page.on(Page.Events.Download, download => this._dispatchEvent('download', { download: new DownloadDispatcher(scope, download) }));
     this._page.on(Page.Events.FileChooser, (fileChooser: FileChooser) => this._dispatchEvent('fileChooser', {
       element: new ElementHandleDispatcher(this._scope, fileChooser.element()),
       isMultiple: fileChooser.isMultiple()

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -296,7 +296,8 @@ export class FrameManager {
     this.removeChildFramesRecursively(frame);
     frame._onDetached();
     this._frames.delete(frame._id);
-    this._page.emit(Page.Events.FrameDetached, frame);
+    if (!this._page.isClosed())
+      this._page.emit(Page.Events.FrameDetached, frame);
   }
 
   private _inflightRequestFinished(request: network.Request) {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -26,7 +26,7 @@ class CustomError extends Error {
 export class TimeoutError extends CustomError {}
 
 export const kBrowserClosedError = 'Browser has been closed';
-export const kBrowserOrContextClosedError = 'Target browser or context has been closed';
+export const kBrowserOrContextClosedError = 'Target page, context or browser has been closed';
 
 export function isSafeCloseError(error: Error) {
   return error.message.endsWith(kBrowserClosedError) || error.message.endsWith(kBrowserOrContextClosedError);

--- a/test/channels.spec.ts
+++ b/test/channels.spec.ts
@@ -63,9 +63,10 @@ it('should scope context handles', async ({browser, server}) => {
         { _guid: 'Browser', objects: [
           { _guid: 'BrowserContext', objects: [
             { _guid: 'Frame', objects: [] },
-            { _guid: 'Page', objects: [] },
-            { _guid: 'Request', objects: [] },
-            { _guid: 'Response', objects: [] },
+            { _guid: 'Page', objects: [
+              { _guid: 'Request', objects: [] },
+              { _guid: 'Response', objects: [] },
+            ]},
           ]},
         ] },
       ] },

--- a/test/chromium/session.spec.ts
+++ b/test/chromium/session.spec.ts
@@ -75,7 +75,7 @@ describe('session', (suite, { browserName }) => {
     } catch (e) {
       error = e;
     }
-    expect(error.message).toContain('Target browser or context has been closed');
+    expect(error.message).toContain('Target page, context or browser has been closed');
   });
 
   it('should throw nice errors', async function({page}) {

--- a/test/page-close.spec.ts
+++ b/test/page-close.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { it } from './fixtures';
+import { it, expect } from './fixtures';
 
 it('should close page with active dialog', (test, { browserName, platform }) => {
   test.fixme(browserName === 'webkit' && platform === 'darwin', 'WebKit hangs on a Mac');
@@ -42,4 +42,14 @@ it('should access page after beforeunload', (test, { browserName }) => {
   const dialog = await page.waitForEvent('dialog');
   await dialog.dismiss();
   await page.evaluate(() => document.title);
+});
+
+it('should not accept after close', (test, { browserName, platform }) => {
+  test.fixme(browserName === 'webkit' && platform === 'darwin', 'WebKit hangs on a Mac');
+}, async ({page}) => {
+  page.evaluate(() => alert()).catch(() => {});
+  const dialog = await page.waitForEvent('dialog');
+  await page.close();
+  const e = await dialog.dismiss().catch(e => e);
+  expect(e.message).toContain('Target page, context or browser has been closed');
 });


### PR DESCRIPTION
Although we end up with a structure where Frame is on the same level as the page, it is very convenient to attribute console messages, dialogs, web sockets to the page rather than the browser context. We get a lot of `page()` methods for free on those.