### PR TITLE
chore: cleanup some har code

### DIFF
--- a/test/elementhandle-screenshot.spec.ts
+++ b/test/elementhandle-screenshot.spec.ts
@@ -394,12 +394,13 @@ describe('element screenshot', (suite, parameters) => {
     expect(await fs.promises.readFile(outputPath)).toMatchSnapshot('screenshot-element-bounding-box.png');
   });
 
-  it('should prefer type over extension', async ({page, server}) => {
+  it('should prefer type over extension', async ({page, server, testInfo}) => {
     await page.setViewportSize({width: 500, height: 500});
     await page.goto(server.PREFIX + '/grid.html');
     await page.evaluate(() => window.scrollBy(50, 100));
     const elementHandle = await page.$('.box:nth-of-type(3)');
-    const buffer = await elementHandle.screenshot({ path: 'file.png', type: 'jpeg' });
+    const outputPath = testInfo.outputPath('file.png');
+    const buffer = await elementHandle.screenshot({ path: outputPath, type: 'jpeg' });
     expect([buffer[0], buffer[1], buffer[2]]).toEqual([0xFF, 0xD8, 0xFF]);
   });
 });

--- a/test/page-screenshot.spec.ts
+++ b/test/page-screenshot.spec.ts
@@ -292,8 +292,9 @@ describe('page screenshot', (suite, { browserName, headful }) => {
     expect(error.message).toContain('path: unsupported mime type "text/plain"');
   });
 
-  it('should prefer type over extension', async ({page}) => {
-    const buffer = await page.screenshot({ path: 'file.png', type: 'jpeg' });
+  it('should prefer type over extension', async ({page, testInfo}) => {
+    const outputPath = testInfo.outputPath('file.png');
+    const buffer = await page.screenshot({ path: outputPath, type: 'jpeg' });
     expect([buffer[0], buffer[1], buffer[2]]).toEqual([0xFF, 0xD8, 0xFF]);
   });
 


### PR DESCRIPTION
Drive-by: do not create <root>/file.png in the tests.