### PR TITLE
browser(firefox): fix SimpleChannel to await initialization

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1198
-Changed: lushnikov@chromium.org Thu 29 Oct 2020 04:23:02 PM PDT
+1199
+Changed: lushnikov@chromium.org Mon 02 Nov 2020 04:10:47 PM PST

--- a/browser_patches/firefox/juggler/content/FrameTree.js
+++ b/browser_patches/firefox/juggler/content/FrameTree.js
@@ -527,10 +527,10 @@ class Worker {
     workerDebugger.initialize('chrome://juggler/content/content/WorkerMain.js');
 
     this._channel = new SimpleChannel(`content::worker[${this._workerId}]`);
-    this._channel.transport = {
+    this._channel.setTransport({
       sendMessage: obj => workerDebugger.postMessage(JSON.stringify(obj)),
       dispose: () => {},
-    };
+    });
     this._workerDebuggerListener = {
       QueryInterface: ChromeUtils.generateQI([Ci.nsIWorkerDebuggerListener]),
       onMessage: msg => void this._channel._onMessage(JSON.parse(msg)),

--- a/browser_patches/firefox/juggler/content/WorkerMain.js
+++ b/browser_patches/firefox/juggler/content/WorkerMain.js
@@ -9,10 +9,10 @@ loadSubScript('chrome://juggler/content/SimpleChannel.js');
 const channel = new SimpleChannel('worker::worker');
 const eventListener = event => channel._onMessage(JSON.parse(event.data));
 this.addEventListener('message', eventListener);
-channel.transport = {
+channel.setTransport({
   sendMessage: msg => postMessage(JSON.stringify(msg)),
   dispose: () => this.removeEventListener('message', eventListener),
-};
+});
 
 const runtime = new Runtime(true /* isWorker */);
 


### PR DESCRIPTION
As Joel noticed recently, MessageManager in firefox doesn't guarantee
message delivery if the opposite end hasn't been initialized yet. In
this case, message will be silently dropped on the ground.

To fix this, we establish a handshake in SimpleChannel to make sure that
both ends are initialized, end buffer outgoing messages until this
happens.

Drive-by: serialize dialog events to only deliver *after* the
`Page.ready` protocol event. Otherwise, we deliver dialog events to the
unreported page.