### PR TITLE
test: co-locate beforeunload tests

### DIFF
--- a/test/beforeunload.spec.ts
+++ b/test/beforeunload.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ * Modifications copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { it, expect } from './fixtures';
+
+it('should close browser with beforeunload page', (test, {browserName}) => {
+}, async ({server, browserType, browserOptions }) => {
+  const browser = await browserType.launch(browserOptions);
+  const page = await browser.newPage();
+  await page.goto(server.PREFIX + '/beforeunload.html');
+  // We have to interact with a page so that 'beforeunload' handlers
+  // fire.
+  await page.click('body');
+  await browser.close();
+});
+
+it('should close browsercontext with beforeunload page', (test, {browserName}) => {
+  test.fixme(browserName === 'firefox');
+}, async ({server, contextFactory }) => {
+  const browserContext = await contextFactory();
+  const page = await browserContext.newPage();
+  await page.goto(server.PREFIX + '/beforeunload.html');
+  // We have to interact with a page so that 'beforeunload' handlers
+  // fire.
+  await page.click('body');
+  await browserContext.close();
+});
+
+it('should close page with beforeunload listener', async ({context, server}) => {
+  const newPage = await context.newPage();
+  await newPage.goto(server.PREFIX + '/beforeunload.html');
+  // We have to interact with a page so that 'beforeunload' handlers
+  // fire.
+  await newPage.click('body');
+  await newPage.close();
+});
+
+it('should run beforeunload if asked for', async ({context, server, isChromium, isWebKit}) => {
+  const newPage = await context.newPage();
+  await newPage.goto(server.PREFIX + '/beforeunload.html');
+  // We have to interact with a page so that 'beforeunload' handlers
+  // fire.
+  await newPage.click('body');
+  const [dialog] = await Promise.all([
+    newPage.waitForEvent('dialog'),
+    newPage.close({ runBeforeUnload: true })
+  ]);
+  expect(dialog.type()).toBe('beforeunload');
+  expect(dialog.defaultValue()).toBe('');
+  if (isChromium)
+    expect(dialog.message()).toBe('');
+  else if (isWebKit)
+    expect(dialog.message()).toBe('Leave?');
+  else
+    expect(dialog.message()).toBe('This page is asking you to confirm that you want to leave - data you have entered may not be saved.');
+  await Promise.all([
+    dialog.accept(),
+    newPage.waitForEvent('close'),
+  ]);
+});
+
+it('should access page after beforeunload', (test, { browserName }) => {
+  test.fixme(browserName === 'chromium');
+  test.fixme(browserName === 'firefox');
+}, async ({contextFactory, server}) => {
+  const context = await contextFactory();
+  const page = await context.newPage();
+  await page.goto(server.PREFIX + '/beforeunload.html');
+  // We have to interact with a page so that 'beforeunload' handlers
+  // fire.
+  await page.click('body');
+  const [dialog] = await Promise.all([
+    page.waitForEvent('dialog'),
+    page.close({ runBeforeUnload: true }),
+  ]);
+  await dialog.dismiss();
+  await page.evaluate(() => document.title);
+});
+

--- a/test/page-basic.spec.ts
+++ b/test/page-basic.spec.ts
@@ -34,35 +34,6 @@ it('should not be visible in context.pages', async ({context}) => {
   expect(context.pages()).not.toContain(newPage);
 });
 
-it('should run beforeunload if asked for', async ({context, server, isChromium, isWebKit}) => {
-  const newPage = await context.newPage();
-  await newPage.goto(server.PREFIX + '/beforeunload.html');
-  // We have to interact with a page so that 'beforeunload' handlers
-  // fire.
-  await newPage.click('body');
-  const pageClosingPromise = newPage.close({ runBeforeUnload: true });
-  const dialog = await newPage.waitForEvent('dialog');
-  expect(dialog.type()).toBe('beforeunload');
-  expect(dialog.defaultValue()).toBe('');
-  if (isChromium)
-    expect(dialog.message()).toBe('');
-  else if (isWebKit)
-    expect(dialog.message()).toBe('Leave?');
-  else
-    expect(dialog.message()).toBe('This page is asking you to confirm that you want to leave - data you have entered may not be saved.');
-  await dialog.accept();
-  await pageClosingPromise;
-});
-
-it('should *not* run beforeunload by default', async ({context, server}) => {
-  const newPage = await context.newPage();
-  await newPage.goto(server.PREFIX + '/beforeunload.html');
-  // We have to interact with a page so that 'beforeunload' handlers
-  // fire.
-  await newPage.click('body');
-  await newPage.close();
-});
-
 it('should set the page close state', async ({context}) => {
   const newPage = await context.newPage();
   expect(newPage.isClosed()).toBe(false);

--- a/test/page-close.spec.ts
+++ b/test/page-close.spec.ts
@@ -27,23 +27,6 @@ it('should close page with active dialog', (test, { browserName, platform }) => 
   await page.close();
 });
 
-it('should access page after beforeunload', (test, { browserName }) => {
-  test.fixme(browserName === 'firefox', 'Only works on WebKit atm');
-  test.fixme(browserName === 'chromium');
-}, async ({context}) => {
-  const page = await context.newPage();
-  await page.evaluate(() => {
-    window.addEventListener('beforeunload', event => {
-      event.preventDefault();
-      event.returnValue = 'Do you want to close page?';
-    });
-  });
-  await page.close({ runBeforeUnload: true });
-  const dialog = await page.waitForEvent('dialog');
-  await dialog.dismiss();
-  await page.evaluate(() => document.title);
-});
-
 it('should not accept after close', (test, { browserName, platform }) => {
   test.fixme(browserName === 'webkit' && platform === 'darwin', 'WebKit hangs on a Mac');
 }, async ({page}) => {


### PR DESCRIPTION
This patch:
- co-locates beforeunload tests
- adds new tests to make sure browser and browsercontext can be closed if there's
  a page with beforeunload listener
- re-writes the `should access page after beforeunload` test to properly
  emit `beforeunload` event

References #4021