### PR TITLE
fix(close): allow errors when closing all pages of a context

### DIFF
--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -400,7 +400,9 @@ export class Page extends EventEmitter {
     if (this._closedState !== 'closing') {
       this._closedState = 'closing';
       assert(!this._disconnected, 'Protocol error: Connection closed. Most likely the page has been closed.');
-      await this._delegate.closePage(runBeforeUnload);
+      // This might throw if the browser context containing the page closes
+      // while we are trying to close the page.
+      await this._delegate.closePage(runBeforeUnload).catch(e => {});
     }
     if (!runBeforeUnload)
       await this._closedPromise;

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -402,7 +402,7 @@ export class Page extends EventEmitter {
       assert(!this._disconnected, 'Protocol error: Connection closed. Most likely the page has been closed.');
       // This might throw if the browser context containing the page closes
       // while we are trying to close the page.
-      await this._delegate.closePage(runBeforeUnload).catch(e => {});
+      await this._delegate.closePage(runBeforeUnload).catch(e => debugLogger.log('error', e));
     }
     if (!runBeforeUnload)
       await this._closedPromise;


### PR DESCRIPTION
When closing a persistent browser context, we first close all of the pages, and then the browser itself. On windows (and Linux?) headful Chromium will close once all of its pages are closed. That is usually fine, because the subsequent `browser.close()` will be a no-op. However If one of the pages closes on its own while we are closing all pages, the browser will close prematurely. Then our attempts to close the page can be rejected with `Protocol error (Target.closeTarget): Target closed` because the browser will have closed.

This patch just adds a catch. I wasn't able to make a test to repro this with any consistency.

Alternatively I think we can pass `--keep-alive-for-test` when launching chromium. Is this a breaking change though?

There are a few other cases where we throw errors when closing the page. See
https://github.com/microsoft/playwright/blob/924cc9894a89a75f89f9de20679c904a397d212f/src/server/page.ts#L380
It seems bad to throw an error because the page was already closed. Maybe we should never throw inside page.close?

relevant log segment from a user:

```
pw:api => browserContext.close started
pw:channel:command {
  id: 26,
  guid: 'BrowserContext@535a297eccac3daa9d73971c6ceb5b48',
  method: 'close',
  params: undefined
}
pw:protocol SEND ► {"id":239,"method":"Target.closeTarget","params":{"targetId":"A856BA5DE458B03F247620FFADDDE2B9"}}
pw:protocol SEND ► {"id":240,"method":"Target.closeTarget","params":{"targetId":"D6723437446390F4BEA7C52BB2B25E67"}}
pw:protocol SEND ► {"id":241,"method":"Target.closeTarget","params":{"targetId":"BA75F9197F1455A0A0CD44E0649AB701"}}
pw:protocol SEND ► {"id":242,"method":"Target.closeTarget","params":{"targetId":"FF25F50631E7B5931C152FCDE2CBFF69"}}
pw:channel:event {
  guid: 'Page@3eb2879dc7a6900e3c27cbf569035970',
  method: 'close',
  params: {}
}
pw:channel:event {
  guid: 'Page@f6fae01f39d1f2cf297b6f6a845980b5',
  method: 'close',
  params: {}
}
pw:channel:event {
  guid: 'Page@e50baaa8925b1a3bf9a0682ca6e2f975',
  method: 'close',
  params: {}
}
pw:channel:event {
  guid: 'Page@62956092cc994829e19e7297c4313edf',
  method: 'close',
  params: {}
}
pw:channel:event {
  guid: 'BrowserContext@535a297eccac3daa9d73971c6ceb5b48',
  method: 'close',
  params: {}
}
pw:channel:event {
  guid: 'BrowserContext@535a297eccac3daa9d73971c6ceb5b48',
  method: '__dispose__',
  params: {}
}
pw:channel:response {
  id: 26,
  error: {
    error: {
      message: 'Protocol error (Target.closeTarget): Target closed.',
      stack: 'Protocol error (Target.closeTarget): Target closed.Error: \n' +
        '    at D:\\a\\1\\s\\node_modules\\playwright\\lib\\server\\chromium\\crConnection.js:131:63\n' +
        '    at new Promise (<anonymous>)\n' +
        '    at CRSession.send (D:\\a\\1\\s\\node_modules\\playwright\\lib\\server\\chromium\\crConnection.js:130:16)\n' +
        '    at CRBrowser._closePage (D:\\a\\1\\s\\node_modules\\playwright\\lib\\server\\chromium\\crBrowser.js:183:29)\n' +
        '    at CRPage.closePage (D:\\a\\1\\s\\node_modules\\playwright\\lib\\server\\chromium\\crPage.js:162:49)\n' +
        '    at Page.close (D:\\a\\1\\s\\node_modules\\playwright\\lib\\server\\page.js:240:34)\n' +
        '    at D:\\a\\1\\s\\node_modules\\playwright\\lib\\server\\browserContext.js:202:65\n' +
        '    at Array.map (<anonymous>)\n' +
        '    at CRBrowserContext.close (D:\\a\\1\\s\\node_modules\\playwright\\lib\\server\\browserContext.js:202:48)\n' +
        '    at BrowserContextDispatcher.close (D:\\a\\1\\s\\node_modules\\playwright\\lib\\dispatchers\\browserContextDispatcher.js:101:29)\n' +
        '    at DispatcherConnection.dispatch (D:\\a\\1\\s\\node_modules\\playwright\\lib\\dispatchers\\dispatcher.js:148:52)\n' +
        '    at Immediate.<anonymous> (D:\\a\\1\\s\\node_modules\\playwright\\lib\\inprocess.js:41:85)\n' +
        '    at processImmediate (internal/timers.js:456:21)',
      name: 'Error'
    }
  }
}
```