### PR TITLE
test: try to unflake network idle tests

### DIFF
--- a/test/assets/networkidle.js
+++ b/test/assets/networkidle.js
@@ -1,18 +1,12 @@
-async function sleep(delay) {
-  return new Promise(resolve => setTimeout(resolve, delay));
-}
-
 async function main() {
   window.ws = new WebSocket('ws://localhost:' + window.location.port + '/ws');
   window.ws.addEventListener('message', message => {});
 
-  const roundOne = Promise.all([
-    fetch('fetch-request-a.js'),
-  ]);
-
-  await roundOne;
-  await sleep(50);
-  await fetch('fetch-request-d.js');
+  fetch('fetch-request-a.js');
+  window.top.fetchSecond = () => {
+    // Do not return the promise here.
+    fetch('fetch-request-b.js');
+  };
 }
 
 main();


### PR DESCRIPTION
I think that we are too slow to fire the second fetch during 500ms,
and so network idle happens prematurely.

The fix is to manually trigger the second fetch early enough.