### PR TITLE
api(websocket): require captureWebSocketFrames for framesent/framereceived

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -240,6 +240,7 @@ Indicates that the browser is connected.
     - `size` <[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`. If `viewport` is not configured explicitly the video size defaults to 1280x720. Actual picture of each page will be scaled down if necessary to fit the specified size.
       - `width` <[number]> Video frame width.
       - `height` <[number]> Video frame height.
+  - `captureWebSocketFrames` <[boolean]> Whether to capture [`WebSocket`](#class-websocket) frames and emit [`framereceived`](#event-framereceived) and [`framesent`](#event-framesent) events. Capturing WebSocket frames incurs significant overhead, use with caution.
 - returns: <[Promise]<[BrowserContext]>>
 
 Creates a new browser context. It won't share cookies/cache with other browser contexts.
@@ -299,6 +300,7 @@ Creates a new browser context. It won't share cookies/cache with other browser c
     - `size` <[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`. If `viewport` is not configured explicitly the video size defaults to 1280x720. Actual picture of each page will be scaled down if necessary to fit the specified size.
       - `width` <[number]> Video frame width.
       - `height` <[number]> Video frame height.
+  - `captureWebSocketFrames` <[boolean]> Whether to capture [`WebSocket`](#class-websocket) frames and emit [`framereceived`](#event-framereceived) and [`framesent`](#event-framesent) events. Capturing WebSocket frames incurs significant overhead, use with caution.
 - returns: <[Promise]<[Page]>>
 
 Creates a new page in a new browser context. Closing this page will close the context as well.
@@ -4181,13 +4183,13 @@ Fired when the websocket closes.
 - <[Object]> web socket frame data
   - `payload` <[string]|[Buffer]> frame payload
 
-Fired when the websocket recieves a frame.
+Fired when the websocket recieves a frame. Requires [`captureWebSocketFrames`] option of the browser context be set to true. See [`browser.newContext([options])`](#browsernewcontextoptions).
 
 #### event: 'framesent'
 - <[Object]> web socket frame data
   - `payload` <[string]|[Buffer]> frame payload
 
-Fired when the websocket sends a frame.
+Fired when the websocket sends a frame. Requires [`captureWebSocketFrames`] option of the browser context be set to true. See [`browser.newContext([options])`](#browsernewcontextoptions).
 
 #### event: 'socketerror'
 - <[String]> the error message
@@ -4515,6 +4517,7 @@ const browser = await chromium.launch({  // Or 'firefox' or 'webkit'.
     - `size` <[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`. If `viewport` is not configured explicitly the video size defaults to 1280x720. Actual picture of each page will be scaled down if necessary to fit the specified size.
       - `width` <[number]> Video frame width.
       - `height` <[number]> Video frame height.
+  - `captureWebSocketFrames` <[boolean]> Whether to capture [`WebSocket`](#class-websocket) frames and emit [`framereceived`](#event-framereceived) and [`framesent`](#event-framesent) events. Capturing WebSocket frames incurs significant overhead, use with caution.
 - returns: <[Promise]<[BrowserContext]>> Promise that resolves to the persistent browser context instance.
 
 Launches browser that uses persistent storage located at `userDataDir` and returns the only context. Closing this context will automatically close the browser.

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -272,6 +272,7 @@ export type BrowserTypeLaunchPersistentContextParams = {
       height: number,
     },
   },
+  captureWebSocketFrames?: boolean,
   recordHar?: {
     omitContent?: boolean,
     path: string,
@@ -341,6 +342,7 @@ export type BrowserTypeLaunchPersistentContextOptions = {
       height: number,
     },
   },
+  captureWebSocketFrames?: boolean,
   recordHar?: {
     omitContent?: boolean,
     path: string,
@@ -408,6 +410,7 @@ export type BrowserNewContextParams = {
       height: number,
     },
   },
+  captureWebSocketFrames?: boolean,
   recordHar?: {
     omitContent?: boolean,
     path: string,
@@ -460,6 +463,7 @@ export type BrowserNewContextOptions = {
       height: number,
     },
   },
+  captureWebSocketFrames?: boolean,
   recordHar?: {
     omitContent?: boolean,
     path: string,

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -325,6 +325,7 @@ BrowserType:
               properties:
                 width: number
                 height: number
+        captureWebSocketFrames: boolean?
         recordHar:
           type: object?
           properties:
@@ -402,6 +403,7 @@ Browser:
               properties:
                 width: number
                 height: number
+        captureWebSocketFrames: boolean?
         recordHar:
           type: object?
           properties:

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -190,6 +190,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
         height: tNumber,
       })),
     })),
+    captureWebSocketFrames: tOptional(tBoolean),
     recordHar: tOptional(tObject({
       omitContent: tOptional(tBoolean),
       path: tString,
@@ -237,6 +238,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
         height: tNumber,
       })),
     })),
+    captureWebSocketFrames: tOptional(tBoolean),
     recordHar: tOptional(tObject({
       omitContent: tOptional(tBoolean),
       path: tString,

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -359,12 +359,16 @@ export class FrameManager {
   }
 
   onWebSocketFrameSent(requestId: string, opcode: number, data: string) {
+    if (!this._page._browserContext._options.captureWebSocketFrames)
+      return;
     const ws = this._webSockets.get(requestId);
     if (ws)
       ws.frameSent(opcode, data);
   }
 
   webSocketFrameReceived(requestId: string, opcode: number, data: string) {
+    if (!this._page._browserContext._options.captureWebSocketFrames)
+      return;
     const ws = this._webSockets.get(requestId);
     if (ws)
       ws.frameReceived(opcode, data);

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -246,6 +246,7 @@ export type BrowserContextOptions = {
     omitContent?: boolean,
     path: string
   },
+  captureWebSocketFrames?: boolean,
   proxy?: ProxySettings,
   _tracePath?: string,
   _traceResourcesPath?: string,


### PR DESCRIPTION
These events incur significant overhead, so we make them opt-in.