### PR TITLE
test(focus): add passing test for focusing more than one page

### DIFF
--- a/test/emulation-focus.spec.ts
+++ b/test/emulation-focus.spec.ts
@@ -173,9 +173,9 @@ it('should change focused iframe', async ({page, server}) => {
 });
 
 // @see https://github.com/microsoft/playwright/issues/3476
-it('should focus with more than one page/context', async ({browser}) => {
-  const page1 = await (await browser.newContext()).newPage();
-  const page2 = await (await browser.newContext()).newPage();
+it('should focus with more than one page/context', async ({contextFactory}) => {
+  const page1 = await (await contextFactory()).newPage();
+  const page2 = await (await contextFactory()).newPage();
   await page1.setContent(`<button id="foo" onfocus="window.gotFocus=true">foo</button>`);
   await page2.setContent(`<button id="foo" onfocus="window.gotFocus=true">foo</button>`);
   await page1.focus('#foo');

--- a/test/emulation-focus.spec.ts
+++ b/test/emulation-focus.spec.ts
@@ -171,3 +171,15 @@ it('should change focused iframe', async ({page, server}) => {
     expect(focused).toEqual([false, true]);
   }
 });
+
+// @see https://github.com/microsoft/playwright/issues/3476
+it('should focus with more than one page/context', async ({browser}) => {
+  const page1 = await (await browser.newContext()).newPage();
+  const page2 = await (await browser.newContext()).newPage();
+  await page1.setContent(`<button id="foo" onfocus="window.gotFocus=true">foo</button>`);
+  await page2.setContent(`<button id="foo" onfocus="window.gotFocus=true">foo</button>`);
+  await page1.focus('#foo');
+  await page2.focus('#foo');
+  expect(await page1.evaluate(() => !!window['gotFocus'])).toBe(true);
+  expect(await page2.evaluate(() => !!window['gotFocus'])).toBe(true);
+});


### PR DESCRIPTION
closes #3476

This was already fixed by #4150, but I'm adding the test from the bug report just for completeness.
