### PR TITLE
browser(firefox): enable webgl on headless

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1201
-Changed: lushnikov@chromium.org Tue 03 Nov 2020 02:16:18 PM PST
+1202
+Changed: joel.einbinder@gmail.com Thu 05 Nov 2020 09:21:15 AM PST

--- a/browser_patches/firefox/patches/bootstrap.diff
+++ b/browser_patches/firefox/patches/bootstrap.diff
@@ -983,6 +983,38 @@ index dd1bc7262365f55531c22200c2bb359abebf18e1..552e1ec925c3eb2eb863ec0e99f5bbba
    static void ResetTimeZone();
  
    static bool DumpEnabled();
+diff --git a/dom/canvas/WebGLContext.cpp b/dom/canvas/WebGLContext.cpp
+index a505c44829b7c871cdf1ab4a5128989075467b60..da81d8820709eb34db176be8454ee5b6b93b0627 100644
+--- a/dom/canvas/WebGLContext.cpp
++++ b/dom/canvas/WebGLContext.cpp
+@@ -247,15 +247,18 @@ bool WebGLContext::CreateAndInitGL(
+     bool forceEnabled, std::vector<FailureReason>* const out_failReasons) {
+   const FuncScope funcScope(*this, "<Create>");
+ 
+-  // Can't use WebGL in headless mode.
+-  if (gfxPlatform::IsHeadless()) {
+-    FailureReason reason;
+-    reason.info =
+-        "Can't use WebGL in headless mode (https://bugzil.la/1375585).";
+-    out_failReasons->push_back(reason);
+-    GenerateWarning("%s", reason.info.BeginReading());
+-    return false;
+-  }
++  // Playwright: It looks like we can comment this out
++  // with minimal side effects. See https://bugzilla.mozilla.org/show_bug.cgi?id=1375585#c30
++  //
++  // // Can't use WebGL in headless mode.
++  // if (gfxPlatform::IsHeadless()) {
++  //   FailureReason reason;
++  //   reason.info =
++  //       "Can't use WebGL in headless mode (https://bugzil.la/1375585).";
++  //   out_failReasons->push_back(reason);
++  //   GenerateWarning("%s", reason.info.BeginReading());
++  //   return false;
++  // }
+ 
+   // WebGL2 is separately blocked:
+   if (IsWebGL2() && !forceEnabled) {
 diff --git a/dom/geolocation/Geolocation.cpp b/dom/geolocation/Geolocation.cpp
 index e1b1075e6318d63c7b7d6d60b419d5fe6b630652..c02ae426052f22997fa8513f20bc3dc05b14726a 100644
 --- a/dom/geolocation/Geolocation.cpp


### PR DESCRIPTION
This patch just comments out the code that disables webgl on headless. It seems to work?! The [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1375585) referenced says that it might cause a crash when running without a display. I haven't been able to repro that. There is also a [patch in review](https://phabricator.services.mozilla.com/D88945) that we maybe should just wait for.

#1032