### PR TITLE
browser(webkit): fix web process startup crash on macos 11

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1380
-Changed: yurys@chromium.org Fri Nov  6 01:49:33 GMTST 2020
+1381
+Changed: einbinder@chromium.org Fri 06 Nov 2020 10:35:03 AM PST

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -7650,23 +7650,6 @@ index e40a6e172bfd2b75076fd4053da643ebab9eb81f..2516655bbc9e5bc863537a554c5faac0
  
 -#endif // ENABLE(TOUCH_EVENTS)
 +#endif // ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
-diff --git a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
-index 22c0b189aafc69405083c36004b4d4de4f3bbfd1..1d883c903018a2bb33db8f1458adda8b04a089bc 100644
---- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
-+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
-@@ -63,7 +63,11 @@
- #endif
- 
- #if PLATFORM(MAC)
--#define USE_CACHE_COMPILED_SANDBOX 1
-+// Playwright begin
-+// Disable compiled sandbox since it doesn't work on BigSUr.
-+// #define USE_CACHE_COMPILED_SANDBOX 1
-+#define USE_CACHE_COMPILED_SANDBOX 0
-+// Playwright end
- #else
- #define USE_CACHE_COMPILED_SANDBOX 0
- #endif
 diff --git a/Source/WebKit/Shared/win/WebEventFactory.cpp b/Source/WebKit/Shared/win/WebEventFactory.cpp
 index 88d53d236cd6d62735f03678a04ca9c198dddacb..b8f8efc57ab00dc5725660c5a8ad56a3e6384de5 100644
 --- a/Source/WebKit/Shared/win/WebEventFactory.cpp
@@ -16559,6 +16542,38 @@ index dfa57c655ada7cf97189b757c59aa901950aa9e8..56832e0190d11e0894a4c537b3ff3806
  }
  
  void WebProcess::initializeConnection(IPC::Connection* connection)
+diff --git a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+index 3c3fbaab081e5775e9c6e40e571e56521c8de843..25ca899fc5fb6be42aceec515fcabbec7753a586 100644
+--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
++++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+@@ -1218,14 +1218,19 @@
+ #include <WebKitAdditions/WebContentSandboxAdditionsMac.sb>
+ #endif
+ 
+-(when (defined? 'mach-bootstrap)
+-    (allow mach-bootstrap
+-        (apply-message-filter
+-            (allow xpc-message-send (with telemetry))
+-            (allow xpc-message-send (with telemetry) (message-number 206))
+-        )
+-    )
+-)
++;;; Playwright: This requires an entitlement
++;;; that only exists in builds signed by Apple.
++;;; It looks like we can disable it for now
++;;; without side effects
++;;;
++;;; (when (defined? 'mach-bootstrap)
++;;;     (allow mach-bootstrap
++;;;         (apply-message-filter
++;;;             (allow xpc-message-send (with telemetry))
++;;;             (allow xpc-message-send (with telemetry) (message-number 206))
++;;;         )
++;;;     )
++;;; )
+ 
+ (when (defined? 'mach-kernel-endpoint)
+     (allow mach-kernel-endpoint
 diff --git a/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp b/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp
 index 89bc159df35910abe133c68d71057cdfe1995cbb..aba8e9110a3ec4c59e9888b148e1e908d477cbe4 100644
 --- a/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp


### PR DESCRIPTION
reverts #4357 and provides the real fix. Apple accidentally landed some code that will crash the web process if it is not signed by them. I'm sure they will figure it out once they get test bots for macos 11. But until then, we can just revert.

https://bugs.webkit.org/show_bug.cgi?id=218342