### PR TITLE
browser(firefox): fix videoSessionId

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1203
-Changed: lushnikov@chromium.org Thu Nov  5 17:39:41 PST 2020
+1204
+Changed: dgozman@gmail.com Fri Nov  6 14:37:05 PST 2020

--- a/browser_patches/firefox/juggler/screencast/nsScreencastService.cpp
+++ b/browser_patches/firefox/juggler/screencast/nsScreencastService.cpp
@@ -73,7 +73,7 @@ nsresult generateUid(nsString& uid) {
   NS_ENSURE_SUCCESS(rv, rv);
 
   for (int i = 0; i < kLen; i++) {
-    uid.AppendPrintf("%" PRIx8, buffer[i]);
+    uid.AppendPrintf("%02x", buffer[i]);
   }
   free(buffer);
   return rv;


### PR DESCRIPTION
PRIx8 produced "%hx%hx%hx%hx%hx%hx%hx%hx%hx%hx%hx%hx%hx%hx%hx%hx",
so video session ids were clashing between pages, and popup videos
did not work.