### PR TITLE
browser(firefox): ignore WebProgress events coming from workers

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1204
-Changed: dgozman@gmail.com Fri Nov  6 14:37:05 PST 2020
+1205
+Changed: dgozman@gmail.com Sun Nov  8 07:09:21 PST 2020

--- a/browser_patches/firefox/juggler/content/FrameTree.js
+++ b/browser_patches/firefox/juggler/content/FrameTree.js
@@ -197,6 +197,12 @@ class FrameTree {
       return;
     }
 
+    if (!channel.isDocument) {
+      // Somehow, we can get worker requests here,
+      // while we are only interested in frame documents.
+      return;
+    }
+
     const isStart = flag & Ci.nsIWebProgressListener.STATE_START;
     const isTransferring = flag & Ci.nsIWebProgressListener.STATE_TRANSFERRING;
     const isStop = flag & Ci.nsIWebProgressListener.STATE_STOP;


### PR DESCRIPTION
Somehow, we get WebProgress state changes when worker is loaded
with a blob url. This messes up frame navigation detection.

Luckily, it's easy to filter out non-document state changes.