### PR TITLE
fix(launchdoctor): fix launch doctor

### DIFF
--- a/src/utils/browserPaths.ts
+++ b/src/utils/browserPaths.ts
@@ -56,7 +56,11 @@ export function linuxLddDirectories(browserPath: string, browser: BrowserDescrip
   if (browser.name === 'webkit') {
     return [
       path.join(browserPath, 'minibrowser-gtk'),
+      path.join(browserPath, 'minibrowser-gtk', 'bin'),
+      path.join(browserPath, 'minibrowser-gtk', 'lib'),
       path.join(browserPath, 'minibrowser-wpe'),
+      path.join(browserPath, 'minibrowser-wpe', 'bin'),
+      path.join(browserPath, 'minibrowser-wpe', 'lib'),
     ];
   }
   return [];


### PR DESCRIPTION
New webkit build, generated by 19f21b1bdee3e26aa22b344f1275ee3acf80749a, changed webkit build
layout: now there are subfolders that contain libraries and executables, and some of the dependencies are no longer bundled.

This patch:
- teaches launch doctor new directories structure: subfolders are now inspected for missing dependencies, and they are also used in the `LD_LIBRARY_PATH`.
- adds `libevent` and `libicudata` libs to the mapping for ubuntu 18.04
