### PR TITLE
[wip] feat(selectors): new experimental selectors backend

### DIFF
--- a/src/client/elementHandle.ts
+++ b/src/client/elementHandle.ts
@@ -241,10 +241,6 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> {
       return ElementHandle.fromNullable(result.element) as ElementHandle<Element> | null;
     });
   }
-
-  async _createSelectorForTest(name: string): Promise<string | undefined> {
-    return (await this._elementChannel.createSelectorForTest({ name })).value;
-  }
 }
 
 export function convertSelectOptionValues(values: string | ElementHandle | SelectOption | string[] | ElementHandle[] | SelectOption[] | null): { elements?: channels.ElementHandleChannel[], options?: SelectOption[] } {

--- a/src/debug/injected/consoleApi.ts
+++ b/src/debug/injected/consoleApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Selector, parseSelector, visitSelector } from '../../server/common/selectorParser';
+import { parseSelector } from '../../server/common/selectorParser';
 import type InjectedScript from '../../server/injected/injectedScript';
 
 export class ConsoleAPI {
@@ -29,34 +29,18 @@ export class ConsoleAPI {
     };
   }
 
-  private _checkSelector(parsed: Selector) {
-    const { engines, filters } = visitSelector(parsed);
-    for (const name of engines) {
-      if (!this._injectedScript.engines.has(name))
-        throw new Error(`Unknown engine "${name}"`);
-    }
-    for (const name of filters) {
-      if (!this._injectedScript.filters.has(name))
-        throw new Error(`Unknown filter "${name}"`);
-    }
-  }
-
   _querySelector(selector: string): (Element | undefined) {
     if (typeof selector !== 'string')
       throw new Error(`Usage: playwright.query('Playwright >> selector').`);
-    const parsed = parseSelector(selector);
-    this._checkSelector(parsed);
-    const elements = this._injectedScript.querySelector(parsed, document);
-    return elements[0];
+    const { parsed } = parseSelector(selector);
+    return this._injectedScript.querySelector(parsed, document);
   }
 
   _querySelectorAll(selector: string): Element[] {
     if (typeof selector !== 'string')
       throw new Error(`Usage: playwright.$$('Playwright >> selector').`);
-    const parsed = parseSelector(selector);
-    this._checkSelector(parsed);
-    const elements = this._injectedScript.querySelector(parsed, document);
-    return elements;
+    const { parsed } = parseSelector(selector);
+    return this._injectedScript.querySelectorAll(parsed, document);
   }
 
   _inspect(selector: string) {

--- a/src/debug/injected/consoleApi.ts
+++ b/src/debug/injected/consoleApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ParsedSelector, parseSelector } from '../../server/common/selectorParser';
+import { Selector, parseSelector, visitSelector } from '../../server/common/selectorParser';
 import type InjectedScript from '../../server/injected/injectedScript';
 
 export class ConsoleAPI {
@@ -29,10 +29,15 @@ export class ConsoleAPI {
     };
   }
 
-  private _checkSelector(parsed: ParsedSelector) {
-    for (const {name} of parsed.parts) {
+  private _checkSelector(parsed: Selector) {
+    const { engines, filters } = visitSelector(parsed);
+    for (const name of engines) {
       if (!this._injectedScript.engines.has(name))
         throw new Error(`Unknown engine "${name}"`);
+    }
+    for (const name of filters) {
+      if (!this._injectedScript.filters.has(name))
+        throw new Error(`Unknown filter "${name}"`);
     }
   }
 
@@ -41,7 +46,7 @@ export class ConsoleAPI {
       throw new Error(`Usage: playwright.query('Playwright >> selector').`);
     const parsed = parseSelector(selector);
     this._checkSelector(parsed);
-    const elements = this._injectedScript.querySelectorAll(parsed, document);
+    const elements = this._injectedScript.querySelector(parsed, document);
     return elements[0];
   }
 
@@ -50,7 +55,7 @@ export class ConsoleAPI {
       throw new Error(`Usage: playwright.$$('Playwright >> selector').`);
     const parsed = parseSelector(selector);
     this._checkSelector(parsed);
-    const elements = this._injectedScript.querySelectorAll(parsed, document);
+    const elements = this._injectedScript.querySelector(parsed, document);
     return elements;
   }
 

--- a/src/dispatchers/elementHandlerDispatcher.ts
+++ b/src/dispatchers/elementHandlerDispatcher.ts
@@ -183,8 +183,4 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements chann
   async waitForSelector(params: channels.ElementHandleWaitForSelectorParams): Promise<channels.ElementHandleWaitForSelectorResult> {
     return { element: ElementHandleDispatcher.createNullable(this._scope, await this._elementHandle.waitForSelector(params.selector, params)) };
   }
-
-  async createSelectorForTest(params: channels.ElementHandleCreateSelectorForTestParams): Promise<channels.ElementHandleCreateSelectorForTestResult> {
-    return { value: await this._elementHandle._page.selectors._createSelector(params.name, this._elementHandle as ElementHandle<Element>) };
-  }
 }

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -1765,7 +1765,6 @@ export interface ElementHandleChannel extends JSHandleChannel {
   uncheck(params: ElementHandleUncheckParams, metadata?: Metadata): Promise<ElementHandleUncheckResult>;
   waitForElementState(params: ElementHandleWaitForElementStateParams, metadata?: Metadata): Promise<ElementHandleWaitForElementStateResult>;
   waitForSelector(params: ElementHandleWaitForSelectorParams, metadata?: Metadata): Promise<ElementHandleWaitForSelectorResult>;
-  createSelectorForTest(params: ElementHandleCreateSelectorForTestParams, metadata?: Metadata): Promise<ElementHandleCreateSelectorForTestResult>;
 }
 export type ElementHandleEvalOnSelectorParams = {
   selector: string,
@@ -2097,15 +2096,6 @@ export type ElementHandleWaitForSelectorOptions = {
 };
 export type ElementHandleWaitForSelectorResult = {
   element?: ElementHandleChannel,
-};
-export type ElementHandleCreateSelectorForTestParams = {
-  name: string,
-};
-export type ElementHandleCreateSelectorForTestOptions = {
-
-};
-export type ElementHandleCreateSelectorForTestResult = {
-  value?: string,
 };
 
 // ----------- Request -----------

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -1750,12 +1750,6 @@ ElementHandle:
       returns:
         element: ElementHandle?
 
-    createSelectorForTest:
-      parameters:
-        name: string
-      returns:
-        value: string?
-
 
 Request:
   type: interface

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -834,9 +834,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     timeout: tOptional(tNumber),
     state: tOptional(tEnum(['attached', 'detached', 'visible', 'hidden'])),
   });
-  scheme.ElementHandleCreateSelectorForTestParams = tObject({
-    name: tString,
-  });
   scheme.RequestResponseParams = tOptional(tObject({}));
   scheme.RouteAbortParams = tObject({
     errorCode: tOptional(tString),

--- a/src/server/common/selectorParser.ts
+++ b/src/server/common/selectorParser.ts
@@ -16,73 +16,31 @@
 
 // This file can't have dependencies, it is a part of the utility script.
 
-export type SelectorArgument = { selector: Selector } | { value: any };
-type QuerySelector = { name: string, arguments: SelectorArgument[] };
-type FilterSelector = { selector: Selector, name: string, arguments: SelectorArgument[] };
-type RelativeSelector = { parent: Selector, child: Selector, kind: 'descendant' | 'child' | 'hasDescendant' | 'hasChild' };
-export type Selector = { query: QuerySelector } | { filter: FilterSelector } | { relative: RelativeSelector };
+export type ParsedSelector = any;
 
-export function visitSelector(selector: Selector): { engines: Set<string>, filters: Set<string> } {
-  const engines = new Set<string>();
-  const filters = new Set<string>();
-  const visit = (selector: Selector) => {
-    if ('query' in selector) {
-      engines.add(selector.query.name);
-    } else if ('relative' in selector) {
-      visit(selector.relative.parent);
-      visit(selector.relative.child);
-    } else {
-      filters.add(selector.filter.name);
-      visit(selector.filter.selector);
-    }
-  };
-  visit(selector);
-  return { engines, filters };
-}
-
-export function parseSelector(selector: string): Selector {
+export function parseSelector(selector: string): { parsed: ParsedSelector, names: string[] } {
   let index = 0;
   let quote: string | undefined;
   let start = 0;
 
-  const parts: Selector[] = [];
+  const parts: string[] = [];
   let captureIndex: number | undefined;
+  const names = new Set<string>();
 
   const append = () => {
-    const part = selector.substring(start, index).trim();
-    const eqIndex = part.indexOf('=');
-    let name: string;
-    let body: string;
+    let part = selector.substring(start, index).trim();
+    let eqIndex = part.indexOf('=');
     if (eqIndex !== -1 && part.substring(0, eqIndex).trim().match(/^[a-zA-Z_0-9-+:*]+$/)) {
-      name = part.substring(0, eqIndex).trim();
-      body = part.substring(eqIndex + 1);
-    } else if (part.length > 1 && part[0] === '"' && part[part.length - 1] === '"') {
-      name = 'text';
-      body = part;
-    } else if (part.length > 1 && part[0] === "'" && part[part.length - 1] === "'") {
-      name = 'text';
-      body = part;
-    } else if (/^\(*\/\//.test(part) || part.startsWith('..')) {
-      // If selector starts with '//' or '//' prefixed with multiple opening
-      // parenthesis, consider xpath. @see https://github.com/microsoft/playwright/issues/817
-      // If selector starts with '..', consider xpath as well.
-      name = 'xpath';
-      body = part;
-    } else {
-      name = 'css';
-      body = part;
+      if (part[0] === '*' && part.substring(0, eqIndex).trim() !== '*') {
+        if (captureIndex !== undefined)
+          throw new Error(`Only one of the selectors can capture using * modifier`);
+        captureIndex = parts.length;
+        part = part.substring(1);
+        eqIndex--;
+      }
+      names.add(part.substring(0, eqIndex).trim());
     }
-    let capture = false;
-    if (name[0] === '*') {
-      capture = true;
-      name = name.substring(1);
-    }
-    parts.push({ query: { name, arguments: [{ value: body }] } });
-    if (capture) {
-      if (captureIndex !== undefined)
-        throw new Error(`Only one of the selectors can capture using * modifier`);
-      captureIndex = parts.length - 1;
-    }
+    parts.push(part);
   };
 
   while (index < selector.length) {
@@ -105,15 +63,15 @@ export function parseSelector(selector: string): Selector {
   }
   append();
 
-  let result: Selector = parts[0];
+  let result: ParsedSelector = parts[0];
   const actualCaptureIndex = captureIndex === undefined ? parts.length - 1 : captureIndex;
   for (let i = 1; i <= actualCaptureIndex; i++)
-    result = { relative: { parent: result, child: parts[i], kind: 'descendant' }};
+    result = ['$', result, parts[i]];
   if (actualCaptureIndex + 1 < parts.length) {
-    let has: Selector = parts[actualCaptureIndex + 1];
+    let has: ParsedSelector = parts[actualCaptureIndex + 1];
     for (let i = actualCaptureIndex + 2; i < parts.length; i++)
-      has = { relative: { parent: has, child: parts[i], kind: 'descendant' }};
-    result = { relative: { parent: result, child: has, kind: 'hasDescendant' }};
+      has = ['$', has, parts[i]];
+    result = ['has', result, has];
   }
-  return result;
+  return { parsed: result, names: Array.from(names) };
 }

--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -83,7 +83,7 @@ export class FrameExecutionContext extends js.ExecutionContext {
       const source = `
         new (${injectedScriptSource.source})([
           ${custom.join(',\n')}
-        ], [], [])
+        ])
       `;
       this._injectedScriptPromise = this._delegate.rawEvaluate(source).then(objectId => new js.JSHandle(this, 'object', objectId));
     }
@@ -851,7 +851,7 @@ export function waitForSelectorTask(selector: SelectorInfo, state: 'attached' | 
     let lastElement: Element | undefined;
 
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, root || document)[0];
+      const element = injected.querySelector(parsed, root || document);
       const visible = element ? injected.isVisible(element) : false;
 
       if (lastElement !== element) {
@@ -879,7 +879,7 @@ export function waitForSelectorTask(selector: SelectorInfo, state: 'attached' | 
 export function dispatchEventTask(selector: SelectorInfo, type: string, eventInit: Object): SchedulableTask<undefined> {
   return injectedScript => injectedScript.evaluateHandle((injected, { parsed, type, eventInit }) => {
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, document)[0];
+      const element = injected.querySelector(parsed, document);
       if (!element)
         return continuePolling;
       progress.log(`  selector resolved to ${injected.previewNode(element)}`);
@@ -891,7 +891,7 @@ export function dispatchEventTask(selector: SelectorInfo, type: string, eventIni
 export function textContentTask(selector: SelectorInfo): SchedulableTask<string | null> {
   return injectedScript => injectedScript.evaluateHandle((injected, parsed) => {
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, document)[0];
+      const element = injected.querySelector(parsed, document);
       if (!element)
         return continuePolling;
       progress.log(`  selector resolved to ${injected.previewNode(element)}`);
@@ -903,7 +903,7 @@ export function textContentTask(selector: SelectorInfo): SchedulableTask<string 
 export function innerTextTask(selector: SelectorInfo): SchedulableTask<'error:nothtmlelement' | { innerText: string }> {
   return injectedScript => injectedScript.evaluateHandle((injected, parsed) => {
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, document)[0];
+      const element = injected.querySelector(parsed, document);
       if (!element)
         return continuePolling;
       progress.log(`  selector resolved to ${injected.previewNode(element)}`);
@@ -917,7 +917,7 @@ export function innerTextTask(selector: SelectorInfo): SchedulableTask<'error:no
 export function innerHTMLTask(selector: SelectorInfo): SchedulableTask<string> {
   return injectedScript => injectedScript.evaluateHandle((injected, parsed) => {
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, document)[0];
+      const element = injected.querySelector(parsed, document);
       if (!element)
         return continuePolling;
       progress.log(`  selector resolved to ${injected.previewNode(element)}`);
@@ -929,7 +929,7 @@ export function innerHTMLTask(selector: SelectorInfo): SchedulableTask<string> {
 export function getAttributeTask(selector: SelectorInfo, name: string): SchedulableTask<string | null> {
   return injectedScript => injectedScript.evaluateHandle((injected, { parsed, name }) => {
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, document)[0];
+      const element = injected.querySelector(parsed, document);
       if (!element)
         return continuePolling;
       progress.log(`  selector resolved to ${injected.previewNode(element)}`);

--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -83,7 +83,7 @@ export class FrameExecutionContext extends js.ExecutionContext {
       const source = `
         new (${injectedScriptSource.source})([
           ${custom.join(',\n')}
-        ])
+        ], [], [])
       `;
       this._injectedScriptPromise = this._delegate.rawEvaluate(source).then(objectId => new js.JSHandle(this, 'object', objectId));
     }
@@ -851,7 +851,7 @@ export function waitForSelectorTask(selector: SelectorInfo, state: 'attached' | 
     let lastElement: Element | undefined;
 
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, root || document);
+      const element = injected.querySelector(parsed, root || document)[0];
       const visible = element ? injected.isVisible(element) : false;
 
       if (lastElement !== element) {
@@ -879,7 +879,7 @@ export function waitForSelectorTask(selector: SelectorInfo, state: 'attached' | 
 export function dispatchEventTask(selector: SelectorInfo, type: string, eventInit: Object): SchedulableTask<undefined> {
   return injectedScript => injectedScript.evaluateHandle((injected, { parsed, type, eventInit }) => {
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, document);
+      const element = injected.querySelector(parsed, document)[0];
       if (!element)
         return continuePolling;
       progress.log(`  selector resolved to ${injected.previewNode(element)}`);
@@ -891,7 +891,7 @@ export function dispatchEventTask(selector: SelectorInfo, type: string, eventIni
 export function textContentTask(selector: SelectorInfo): SchedulableTask<string | null> {
   return injectedScript => injectedScript.evaluateHandle((injected, parsed) => {
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, document);
+      const element = injected.querySelector(parsed, document)[0];
       if (!element)
         return continuePolling;
       progress.log(`  selector resolved to ${injected.previewNode(element)}`);
@@ -903,7 +903,7 @@ export function textContentTask(selector: SelectorInfo): SchedulableTask<string 
 export function innerTextTask(selector: SelectorInfo): SchedulableTask<'error:nothtmlelement' | { innerText: string }> {
   return injectedScript => injectedScript.evaluateHandle((injected, parsed) => {
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, document);
+      const element = injected.querySelector(parsed, document)[0];
       if (!element)
         return continuePolling;
       progress.log(`  selector resolved to ${injected.previewNode(element)}`);
@@ -917,7 +917,7 @@ export function innerTextTask(selector: SelectorInfo): SchedulableTask<'error:no
 export function innerHTMLTask(selector: SelectorInfo): SchedulableTask<string> {
   return injectedScript => injectedScript.evaluateHandle((injected, parsed) => {
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, document);
+      const element = injected.querySelector(parsed, document)[0];
       if (!element)
         return continuePolling;
       progress.log(`  selector resolved to ${injected.previewNode(element)}`);
@@ -929,7 +929,7 @@ export function innerHTMLTask(selector: SelectorInfo): SchedulableTask<string> {
 export function getAttributeTask(selector: SelectorInfo, name: string): SchedulableTask<string | null> {
   return injectedScript => injectedScript.evaluateHandle((injected, { parsed, name }) => {
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, document);
+      const element = injected.querySelector(parsed, document)[0];
       if (!element)
         return continuePolling;
       progress.log(`  selector resolved to ${injected.previewNode(element)}`);

--- a/src/server/injected/attributeSelectorEngine.ts
+++ b/src/server/injected/attributeSelectorEngine.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { SelectorEngine, SelectorRoot } from './selectorEngine';
+import { LegacySelectorEngine, SelectorRoot } from './selectorEngine';
 
-export function createAttributeEngine(attribute: string, shadow: boolean): SelectorEngine {
-  const engine: SelectorEngine = {
+export function createAttributeEngine(attribute: string, shadow: boolean): LegacySelectorEngine {
+  const engine: LegacySelectorEngine = {
     create(root: SelectorRoot, target: Element): string | undefined {
       const value = target.getAttribute(attribute);
       if (!value)

--- a/src/server/injected/cssSelectorEngine.ts
+++ b/src/server/injected/cssSelectorEngine.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { SelectorEngine, SelectorRoot } from './selectorEngine';
+import { LegacySelectorEngine, SelectorRoot } from './selectorEngine';
 
-export function createCSSEngine(shadow: boolean): SelectorEngine {
-  const engine: SelectorEngine = {
+export function createCSSEngine(shadow: boolean): LegacySelectorEngine {
+  const engine: LegacySelectorEngine = {
     create(root: SelectorRoot, targetElement: Element): string | undefined {
       if (shadow)
         return;
@@ -177,8 +177,10 @@ function queryShadowAllInternal(boundary: SelectorRoot, root: SelectorRoot, sele
         if (!element.matches(parts[0]))
           continue;
         // If there is a single part, there are no ancestors to match.
-        if (parts.length === 1 || ancestorsMatch(element, parts, boundary))
+        if (parts.length === 1 || ancestorsMatch(element, parts, boundary)) {
           result.push(element);
+          break;
+        }
       }
     }
   }
@@ -277,7 +279,7 @@ function split(selector: string): string[][] {
   return result.filter(parts => !!parts.length).map(parts => parts.reverse());
 }
 
-function test(engine: SelectorEngine) {
+function test(engine: LegacySelectorEngine) {
   let id = 0;
 
   function createShadow(level: number): Element {

--- a/src/server/injected/selectorEngine.ts
+++ b/src/server/injected/selectorEngine.ts
@@ -23,10 +23,10 @@ export interface LegacySelectorEngine {
   queryAll(root: SelectorRoot, selector: string): Element[];
 }
 
-export interface SelectorEngine {
-  evaluate(root: SelectorRoot, ...args: any[]): Element[];
+export interface SelectorEvaluator {
+  evaluate(root: SelectorRoot, selector: any): Element[];
 }
 
-export interface SelectorFilter {
-  filter(elements: Element[], ...args: any[]): Element[];
+export interface SelectorEngine {
+  query(evaluator: SelectorEvaluator, root: SelectorRoot, ...args: any[]): Element[];
 }

--- a/src/server/injected/selectorEngine.ts
+++ b/src/server/injected/selectorEngine.ts
@@ -17,8 +17,16 @@
 export type SelectorType = 'default' | 'notext';
 export type SelectorRoot = Element | ShadowRoot | Document;
 
-export interface SelectorEngine {
+export interface LegacySelectorEngine {
   create(root: SelectorRoot, target: Element, type?: SelectorType): string | undefined;
   query(root: SelectorRoot, selector: string): Element | undefined;
   queryAll(root: SelectorRoot, selector: string): Element[];
+}
+
+export interface SelectorEngine {
+  evaluate(root: SelectorRoot, ...args: any[]): Element[];
+}
+
+export interface SelectorFilter {
+  filter(elements: Element[], ...args: any[]): Element[];
 }

--- a/src/server/injected/textSelectorEngine.ts
+++ b/src/server/injected/textSelectorEngine.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { SelectorEngine, SelectorType, SelectorRoot } from './selectorEngine';
+import { LegacySelectorEngine, SelectorType, SelectorRoot } from './selectorEngine';
 
-export function createTextSelector(shadow: boolean): SelectorEngine {
-  const engine: SelectorEngine = {
+export function createTextSelector(shadow: boolean): LegacySelectorEngine {
+  const engine: LegacySelectorEngine = {
     create(root: SelectorRoot, targetElement: Element, type: SelectorType): string | undefined {
       const document = root instanceof Document ? root : root.ownerDocument;
       if (!document)

--- a/src/server/injected/xpathSelectorEngine.ts
+++ b/src/server/injected/xpathSelectorEngine.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { SelectorEngine, SelectorType, SelectorRoot } from './selectorEngine';
+import { LegacySelectorEngine, SelectorType, SelectorRoot } from './selectorEngine';
 
 const maxTextLength = 80;
 const minMeaningfulSelectorLegth = 100;
 
-export const XPathEngine: SelectorEngine = {
+export const XPathEngine: LegacySelectorEngine = {
   create(root: SelectorRoot, targetElement: Element, type: SelectorType): string | undefined {
     const maybeDocument = root instanceof Document ? root : root.ownerDocument;
     if (!maybeDocument)

--- a/test/eval-on-selector.spec.ts
+++ b/test/eval-on-selector.spec.ts
@@ -141,7 +141,7 @@ it('should throw on multiple * captures', async ({page, server}) => {
 
 it('should throw on malformed * capture', async ({page, server}) => {
   const error = await page.$eval('*=div', e => e.outerHTML).catch(e => e);
-  expect(error.message).toContain('Unknown engine "" while parsing selector *=div');
+  expect(error.message).toContain('Unknown engine "*" while parsing selector "*=div"');
 });
 
 it('should work with spaces in css attributes', async ({page, server}) => {

--- a/test/selectors-register.spec.ts
+++ b/test/selectors-register.spec.ts
@@ -51,7 +51,7 @@ it('should work', async ({playwright, browser}) => {
 
   // Selector names are case-sensitive.
   const error = await page.$('tAG=DIV').catch(e => e);
-  expect(error.message).toContain('Unknown engine "tAG" while parsing selector tAG=DIV');
+  expect(error.message).toContain('Unknown engine "tAG" while parsing selector "tAG=DIV"');
 
   await context.close();
 });
@@ -96,7 +96,7 @@ it('should work in main and isolated world', async ({playwright, page}) => {
 
 it('should handle errors', async ({playwright, page}) => {
   let error = await page.$('neverregister=ignored').catch(e => e);
-  expect(error.message).toContain('Unknown engine "neverregister" while parsing selector neverregister=ignored');
+  expect(error.message).toContain('Unknown engine "neverregister" while parsing selector "neverregister=ignored"');
 
   const createDummySelector = () => ({
     create(root, target) {

--- a/test/selectors-register.spec.ts
+++ b/test/selectors-register.spec.ts
@@ -41,12 +41,10 @@ it('should work', async ({playwright, browser}) => {
   const page = await context.newPage();
   await page.setContent('<div><span></span></div><div></div>');
 
-  expect(await (await page.$('div') as any)._createSelectorForTest('tag')).toBe('DIV');
   expect(await page.$eval('tag=DIV', e => e.nodeName)).toBe('DIV');
   expect(await page.$eval('tag=SPAN', e => e.nodeName)).toBe('SPAN');
   expect(await page.$$eval('tag=DIV', es => es.length)).toBe(2);
 
-  expect(await (await page.$('div') as any)._createSelectorForTest('tag2')).toBe('DIV');
   expect(await page.$eval('tag2=DIV', e => e.nodeName)).toBe('DIV');
   expect(await page.$eval('tag2=SPAN', e => e.nodeName)).toBe('SPAN');
   expect(await page.$$eval('tag2=DIV', es => es.length)).toBe(2);
@@ -71,7 +69,7 @@ it('should work in main and isolated world', async ({playwright, page}) => {
       return window['__answer'];
     },
     queryAll(root, selector) {
-      return [document.body, document.documentElement, window['__answer']];
+      return [window['__answer'], window['__answer']];
     }
   });
   await playwright.selectors.register('main', createDummySelector);
@@ -81,14 +79,14 @@ it('should work in main and isolated world', async ({playwright, page}) => {
   // Works in main if asked.
   expect(await page.$eval('main=ignored', e => e.nodeName)).toBe('SPAN');
   expect(await page.$eval('css=div >> main=ignored', e => e.nodeName)).toBe('SPAN');
-  expect(await page.$$eval('main=ignored', es => window['__answer'] !== undefined)).toBe(true);
-  expect(await page.$$eval('main=ignored', es => es.filter(e => e).length)).toBe(3);
+  expect(await page.$$eval('main=ignored', es => es[0] === es[1])).toBe(true);
+  expect(await page.$$eval('main=ignored', es => es.filter(e => e).length)).toBe(2);
   // Works in isolated by default.
   expect(await page.$('isolated=ignored')).toBe(null);
   expect(await page.$('css=div >> isolated=ignored')).toBe(null);
   // $$eval always works in main, to avoid adopting nodes one by one.
-  expect(await page.$$eval('isolated=ignored', es => window['__answer'] !== undefined)).toBe(true);
-  expect(await page.$$eval('isolated=ignored', es => es.filter(e => e).length)).toBe(3);
+  expect(await page.$$eval('isolated=ignored', es => es[0] === es[1])).toBe(true);
+  expect(await page.$$eval('isolated=ignored', es => es.filter(e => e).length)).toBe(2);
   // At least one engine in main forces all to be in main.
   expect(await page.$eval('main=ignored >> isolated=ignored', e => e.nodeName)).toBe('SPAN');
   expect(await page.$eval('isolated=ignored >> main=ignored', e => e.nodeName)).toBe('SPAN');

--- a/test/selectors-text.spec.ts
+++ b/test/selectors-text.spec.ts
@@ -106,22 +106,6 @@ it('query', async ({page, isWebKit}) => {
   expect((await page.$$(`text="lo wo"`)).length).toBe(0);
 });
 
-it('create', async ({page}) => {
-  await page.setContent(`<div>yo</div><div>"ya</div><div>ye ye</div>`);
-  expect(await (await page.$('div') as any)._createSelectorForTest('text')).toBe('yo');
-  expect(await (await page.$('div:nth-child(2)') as any)._createSelectorForTest('text')).toBe('"\\"ya"');
-  expect(await (await page.$('div:nth-child(3)') as any)._createSelectorForTest('text')).toBe('"ye ye"');
-
-  await page.setContent(`<div>yo</div><div>yo<div>ya</div>hey</div>`);
-  expect(await (await page.$('div:nth-child(2)') as any)._createSelectorForTest('text')).toBe('hey');
-
-  await page.setContent(`<div> yo <div></div>ya</div>`);
-  expect(await (await page.$('div') as any)._createSelectorForTest('text')).toBe('yo');
-
-  await page.setContent(`<div> "yo <div></div>ya</div>`);
-  expect(await (await page.$('div') as any)._createSelectorForTest('text')).toBe('" \\"yo "');
-});
-
 it('should be case sensitive if quotes are specified', async ({page}) => {
   await page.setContent(`<div>yo</div><div>ya</div><div>\nye  </div>`);
   expect(await page.$eval(`text=yA`, e => e.outerHTML)).toBe('<div>ya</div>');


### PR DESCRIPTION
The new backend is designed to allow more features. It is centered around "custom functions" that are given the current `root` node and arguments, and can call back into main `evaluator` at any moment.

An example of trivial `visible` filter would be:
```ts
const visibleEngine = {
  query(evaluator, root, elements) {
    return elements.filter(e => isVisible(e));
  }
};
```

An example of less trivial `and` filter would be:
```ts
const andEngine = {
  query(evaluator, root, selector1, selector2) {
    const elements1 = evaluator.evaluate(root, selector1);
    const elements2 = new Set(evaluator.evaluate(root, selector2));
    return elements1.filter(e => elements2.has(e));
  }
};
```

Currently, this implements `$` and `has` engines that are used for `>>` and `*capture` respectively, and parses existing selectors syntax into `$` and `has` combinations. We also wrap existing selector engines, including custom ones, to adhere to the new interface.

Note: with functions operating on `Element[]` lists we lose the performance optimization of querying just one element instead of all. Added a special case for simple css selectors, as a premature optimization.
