### PR TITLE
fix(websocket): race between the first frame, and enabling frame reporting

### DIFF
--- a/src/dispatchers/networkDispatchers.ts
+++ b/src/dispatchers/networkDispatchers.ts
@@ -109,4 +109,8 @@ export class WebSocketDispatcher extends Dispatcher<WebSocket, channels.WebSocke
     webSocket.on(WebSocket.Events.Error, (error: string) => this._dispatchEvent('error', { error }));
     webSocket.on(WebSocket.Events.Close, () => this._dispatchEvent('close', {}));
   }
+
+  async setFramesReportingEnabledNoReply(params: channels.WebSocketSetFramesReportingEnabledNoReplyParams): Promise<void> {
+    this._object.setFramesReportingEnabled(params.enabled);
+  }
 }

--- a/src/dispatchers/pageDispatcher.ts
+++ b/src/dispatchers/pageDispatcher.ts
@@ -158,10 +158,6 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageInitializer> i
     await this._page._setFileChooserIntercepted(params.intercepted);
   }
 
-  async setWebSocketFramesReportingEnabledNoReply(params: channels.PageSetWebSocketFramesReportingEnabledNoReplyParams): Promise<void> {
-    this._page._setWebSocketFramesReportingEnabled(params.enabled);
-  }
-
   async keyboardDown(params: channels.PageKeyboardDownParams): Promise<void> {
     await this._page.keyboard.down(params.key);
   }

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -728,7 +728,6 @@ export interface PageChannel extends Channel {
   setDefaultNavigationTimeoutNoReply(params: PageSetDefaultNavigationTimeoutNoReplyParams, metadata?: Metadata): Promise<PageSetDefaultNavigationTimeoutNoReplyResult>;
   setDefaultTimeoutNoReply(params: PageSetDefaultTimeoutNoReplyParams, metadata?: Metadata): Promise<PageSetDefaultTimeoutNoReplyResult>;
   setFileChooserInterceptedNoReply(params: PageSetFileChooserInterceptedNoReplyParams, metadata?: Metadata): Promise<PageSetFileChooserInterceptedNoReplyResult>;
-  setWebSocketFramesReportingEnabledNoReply(params: PageSetWebSocketFramesReportingEnabledNoReplyParams, metadata?: Metadata): Promise<PageSetWebSocketFramesReportingEnabledNoReplyResult>;
   addInitScript(params: PageAddInitScriptParams, metadata?: Metadata): Promise<PageAddInitScriptResult>;
   close(params: PageCloseParams, metadata?: Metadata): Promise<PageCloseResult>;
   emulateMedia(params: PageEmulateMediaParams, metadata?: Metadata): Promise<PageEmulateMediaResult>;
@@ -840,13 +839,6 @@ export type PageSetFileChooserInterceptedNoReplyOptions = {
 
 };
 export type PageSetFileChooserInterceptedNoReplyResult = void;
-export type PageSetWebSocketFramesReportingEnabledNoReplyParams = {
-  enabled: boolean,
-};
-export type PageSetWebSocketFramesReportingEnabledNoReplyOptions = {
-
-};
-export type PageSetWebSocketFramesReportingEnabledNoReplyResult = void;
 export type PageAddInitScriptParams = {
   source: string,
 };
@@ -2236,6 +2228,7 @@ export interface WebSocketChannel extends Channel {
   on(event: 'frameReceived', callback: (params: WebSocketFrameReceivedEvent) => void): this;
   on(event: 'error', callback: (params: WebSocketErrorEvent) => void): this;
   on(event: 'close', callback: (params: WebSocketCloseEvent) => void): this;
+  setFramesReportingEnabledNoReply(params: WebSocketSetFramesReportingEnabledNoReplyParams, metadata?: Metadata): Promise<WebSocketSetFramesReportingEnabledNoReplyResult>;
 }
 export type WebSocketOpenEvent = {};
 export type WebSocketFrameSentEvent = {
@@ -2250,6 +2243,13 @@ export type WebSocketErrorEvent = {
   error: string,
 };
 export type WebSocketCloseEvent = {};
+export type WebSocketSetFramesReportingEnabledNoReplyParams = {
+  enabled: boolean,
+};
+export type WebSocketSetFramesReportingEnabledNoReplyOptions = {
+
+};
+export type WebSocketSetFramesReportingEnabledNoReplyResult = void;
 
 // ----------- ConsoleMessage -----------
 export type ConsoleMessageInitializer = {

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -625,10 +625,6 @@ Page:
       parameters:
         intercepted: boolean
 
-    setWebSocketFramesReportingEnabledNoReply:
-      parameters:
-        enabled: boolean
-
     addInitScript:
       parameters:
         source: string
@@ -1876,6 +1872,13 @@ WebSocket:
 
   initializer:
     url: string
+
+  commands:
+
+    # Frames reporting is enabled by default.
+    setFramesReportingEnabledNoReply:
+      parameters:
+        enabled: boolean
 
   events:
     open:

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -330,9 +330,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   scheme.PageSetFileChooserInterceptedNoReplyParams = tObject({
     intercepted: tBoolean,
   });
-  scheme.PageSetWebSocketFramesReportingEnabledNoReplyParams = tObject({
-    enabled: tBoolean,
-  });
   scheme.PageAddInitScriptParams = tObject({
     source: tString,
   });
@@ -870,6 +867,9 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   });
   scheme.ResponseBodyParams = tOptional(tObject({}));
   scheme.ResponseFinishedParams = tOptional(tObject({}));
+  scheme.WebSocketSetFramesReportingEnabledNoReplyParams = tObject({
+    enabled: tBoolean,
+  });
   scheme.BindingCallRejectParams = tObject({
     error: tType('SerializedError'),
   });

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -359,16 +359,12 @@ export class FrameManager {
   }
 
   onWebSocketFrameSent(requestId: string, opcode: number, data: string) {
-    if (!this._page._webSocketFramesReportingEnabled)
-      return;
     const ws = this._webSockets.get(requestId);
     if (ws)
       ws.frameSent(opcode, data);
   }
 
   webSocketFrameReceived(requestId: string, opcode: number, data: string) {
-    if (!this._page._webSocketFramesReportingEnabled)
-      return;
     const ws = this._webSockets.get(requestId);
     if (ws)
       ws.frameReceived(opcode, data);

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -327,6 +327,7 @@ export class Response {
 
 export class WebSocket extends EventEmitter {
   private _url: string;
+  private _framesReportingEnabled = true;
 
   static Events = {
     Close: 'close',
@@ -345,11 +346,13 @@ export class WebSocket extends EventEmitter {
   }
 
   frameSent(opcode: number, data: string) {
-    this.emit(WebSocket.Events.FrameSent, { opcode, data });
+    if (this._framesReportingEnabled)
+      this.emit(WebSocket.Events.FrameSent, { opcode, data });
   }
 
   frameReceived(opcode: number, data: string) {
-    this.emit(WebSocket.Events.FrameReceived, { opcode, data });
+    if (this._framesReportingEnabled)
+      this.emit(WebSocket.Events.FrameReceived, { opcode, data });
   }
 
   error(errorMessage: string) {
@@ -358,6 +361,10 @@ export class WebSocket extends EventEmitter {
 
   closed() {
     this.emit(WebSocket.Events.Close);
+  }
+
+  setFramesReportingEnabled(enabled: boolean) {
+    this._framesReportingEnabled = enabled;
   }
 }
 

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -147,7 +147,6 @@ export class Page extends EventEmitter {
   _ownedContext: BrowserContext | undefined;
   readonly selectors: Selectors;
   _video: Video | null = null;
-  _webSocketFramesReportingEnabled = false;
 
   constructor(delegate: PageDelegate, browserContext: BrowserContext) {
     super();
@@ -439,10 +438,6 @@ export class Page extends EventEmitter {
 
   async _setFileChooserIntercepted(enabled: boolean): Promise<void> {
     await this._delegate.setFileChooserIntercepted(enabled);
-  }
-
-  _setWebSocketFramesReportingEnabled(enabled: boolean) {
-    this._webSocketFramesReportingEnabled = enabled;
   }
 
   videoStarted(video: Video) {


### PR DESCRIPTION
Instead of enabling frame reporting when needed, we disable
frame reporting if nobody is listening for this particular
websocket. This way we can still report a few initial frames,
but we'll block excessive protocol traffic afterwards.