### PR TITLE
browser(firefox): force a layout before dispatching a tap

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1208
-Changed: yurys@chromium.org Fri 13 Nov 2020 02:55:31 PM PST
+1209
+Changed: joel.einbinder@gmail.com Mon 16 Nov 2020 10:52:59 AM PST

--- a/browser_patches/firefox/juggler/content/PageAgent.js
+++ b/browser_patches/firefox/juggler/content/PageAgent.js
@@ -715,6 +715,14 @@ class PageAgent {
   }
 
   async _dispatchTapEvent({x, y, modifiers}) {
+    // Force a layout at the point in question, because touch events
+    // do not seem to trigger one like mouse events.
+    this._frameTree.mainFrame().domWindow().windowUtils.elementFromPoint(
+      x,
+      y,
+      false /* aIgnoreRootScrollFrame */,
+      true /* aFlushLayout */);
+
     const {defaultPrevented: startPrevented} = await this._dispatchTouchEvent({
       type: 'touchstart',
       modifiers,


### PR DESCRIPTION
Sometimes tap tests would fail in firefox. The touch events would miss, but the generated mouse events would still hit their target. This fixes it.