### PR TITLE
test(chromium): disable large screenshot test

### DIFF
--- a/test/page-screenshot.spec.ts
+++ b/test/page-screenshot.spec.ts
@@ -298,8 +298,9 @@ describe('page screenshot', (suite, { browserName, headful }) => {
     expect([buffer[0], buffer[1], buffer[2]]).toEqual([0xFF, 0xD8, 0xFF]);
   });
 
-  it('should work with large size', test => {
+  it('should work with large size', (test, {browserName, headful, platform}) => {
     test.slow('Large screenshot is slow');
+    test.fixme(browserName === 'chromium' && headful === true && platform === 'linux', 'Chromium has gpu problems on linux with large screnshots');
   }, async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.evaluate(() => {


### PR DESCRIPTION
This is flaky on the bots, but it fails every time on my computer. I get a variety of gpu error messages in the logs. Sometimes the protocol will return a definitive screenshot failed message. Sometimes it will hang while continouslly spitting out messages about the gpu. I also saw a crash in there, so something is definitely broken.

```
  pw:browser [err] Received signal 11 SEGV_MAPERR 000000000000 +5ms
  pw:browser [err] #0 0x56254b26bd89 base::debug::CollectStackTrace() +4ms
  pw:browser [err] #1 0x56254b1dd533 base::debug::StackTrace::StackTrace() +2ms
  pw:browser [err] #2 0x56254b26b92b base::debug::(anonymous namespace)::StackDumpSignalHandler() +3ms
  pw:browser [err] #3 0x7fa4de2df3c0 (/lib/x86_64-linux-gnu/libpthread-2.31.so+0x153bf) +0ms
  pw:browser [err] #4 0x56254d5605a2 gpu::SharedImageInterfaceInProcess::DestroyOnGpu() +4ms
  pw:browser [err] #5 0x56254c780373 gpu::Scheduler::RunNextTask() +4ms
  pw:browser [err] #6 0x5625487c2d64 base::internal::Invoker<>::RunOnce() +0ms
  pw:browser [err] #7 0x56254b22d0d6 base::TaskAnnotator::RunTask() +2ms
  pw:browser [err] #8 0x56254b23e035 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl() +2ms
  pw:browser [err] #9 0x56254b23dd38 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() +2ms
  pw:browser [err] #10 0x56254b1f3ff7 base::(anonymous namespace)::WorkSourceDispatch() +3ms
  pw:browser [err] #11 0x7fa4de187fbd g_main_context_dispatch +0ms
  pw:browser [err] #12 0x7fa4de188240 (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.6400.3+0x5223f) +0ms
  pw:browser [err] #13 0x7fa4de1882e3 g_main_context_iteration +0ms
  pw:browser [err] #14 0x56254b1f3dc2 base::MessagePumpGlib::Run() +2ms
  pw:browser [err] #15 0x56254b23e7dd base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run() +2ms
  pw:browser [err] #16 0x56254b214ebe base::RunLoop::Run() +3ms
  pw:browser [err] #17 0x56254f9e44e7 content::GpuMain() +6ms
  pw:browser [err] #18 0x56254b1874ff content::RunZygote() +2ms
  pw:browser [err] #19 0x56254b1887c1 content::ContentMainRunnerImpl::Run() +3ms
  pw:browser [err] #20 0x56254b185be4 content::RunContentProcess() +2ms
  pw:browser [err] #21 0x56254b1865cc content::ContentMain() +2ms
  pw:browser [err] #22 0x5625487bfc4c ChromeMain +7ms
  pw:browser [err] #23 0x7fa4dcb250b3 __libc_start_main +0ms
  pw:browser [err] #24 0x5625487bfa6a _start +7ms
  pw:browser [err]   r8: 0000000000000000  r9: 00007ffd774efd28 r10: 00007ffd774efd20 r11: 0000000000013325 +0ms
  pw:browser [err]  r12: 000000000000001d r13: 000006c53d94fa00 r14: 00007fa4c08ec9a0 r15: 000006c53d8d7000 +0ms
  pw:browser [err]   di: 0000000000000000  si: 00007fa4c08ec9a0  bp: 00007ffd774efd60  bx: 000006c53e488510 +0ms
  pw:browser [err]   dx: 0000000000000000  ax: 000006c53d959000  cx: 000056254d5604f0  sp: 00007ffd774efd40 +0ms
  pw:browser [err]   ip: 000056254d5605a2 efl: 0000000000010246 cgf: 002b000000000033 erf: 0000000000000004 +0ms
  pw:browser [err]  trp: 000000000000000e msk: 0000000000000000 cr2: 0000000000000000 +0ms
  pw:browser [err] [end of stack trace] +0ms
```

This only happens on headful with the gpu enabled. So if a user is seeing this, pass `--disable-gpu` in your launch args to bypass this problem.