### PR TITLE
test(chromium): disable webgl2 on headful

### DIFF
--- a/test/capabilities.spec.ts
+++ b/test/capabilities.spec.ts
@@ -72,16 +72,17 @@ it('should play video', (test, { browserName, platform }) => {
 it('should support webgl', (test, {browserName, headful}) => {
   test.fixme(browserName === 'firefox' && !headful);
 }, async ({page}) => {
-  const hasWebGL2 = await page.evaluate(() => {
+  const hasWebGL = await page.evaluate(() => {
     const canvas = document.createElement('canvas');
     return !!canvas.getContext('webgl');
   });
-  expect(hasWebGL2).toBe(true);
+  expect(hasWebGL).toBe(true);
 });
 
 it('should support webgl 2', (test, {browserName, headful}) => {
   test.skip(browserName === 'webkit', 'Webkit doesn\'t have webgl2 enabled yet upstream.');
   test.fixme(browserName === 'firefox' && !headful);
+  test.fixme(browserName === 'chromium' && headful, 'chromium doesn\'t like webgl2 when running under xvfb');
 }, async ({page}) => {
   const hasWebGL2 = await page.evaluate(() => {
     const canvas = document.createElement('canvas');


### PR DESCRIPTION
This started failing after d20e56e197dd5e64d8d4503db8c83e76cdb78930, but that looks unrelated. The test fails locally if I run it under xvfb. The commit that added this test also fails locally if I run it under xvfb, so this is a non-regression. Maybe something changed on our bots?

drive-by: fix `hasWebGL` variable name.