### PR TITLE
browser(webkit): fix mac build after latest roll

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1386
-Changed: yurys@chromium.org Mon 16 Nov 2020 12:23:50 PM PST
+1387
+Changed: yurys@chromium.org Mon 16 Nov 2020 02:24:23 PM PST

--- a/browser_patches/webkit/archive.sh
+++ b/browser_patches/webkit/archive.sh
@@ -118,7 +118,6 @@ createZipForMac() {
   ditto {./WebKitBuild/Release,$tmpdir}/libwebrtc.dylib
   ditto {./WebKitBuild/Release,$tmpdir}/Playwright.app
   ditto {./WebKitBuild/Release,$tmpdir}/PluginProcessShim.dylib
-  ditto {./WebKitBuild/Release,$tmpdir}/SecItemShim.dylib
   ditto {./WebKitBuild/Release,$tmpdir}/WebCore.framework
   ditto {./WebKitBuild/Release,$tmpdir}/WebInspectorUI.framework
   ditto {./WebKitBuild/Release,$tmpdir}/WebKit.framework


### PR DESCRIPTION
The file was removed from the build in https://bugs.webkit.org/show_bug.cgi?id=218919