### PR TITLE
devops: use proper tags for self-hosted runner

### DIFF
--- a/.github/workflows/build_firefox.yml
+++ b/.github/workflows/build_firefox.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   ubuntu_18_04:
     name: Ubuntu 18.04
-    runs-on: [self-hosted, ubuntu-18.04]
+    runs-on: [self-hosted, fast-ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1

--- a/.github/workflows/build_webkit.yml
+++ b/.github/workflows/build_webkit.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   ubuntu_18_04:
     name: Ubuntu 18.04
-    runs-on: [self-hosted, ubuntu-18.04]
+    runs-on: [self-hosted, fast-ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1


### PR DESCRIPTION
Turns out github already has a reserved bot label called `ubuntu-18.04`,
so marking our self-hosted bot this way was adding it to the pool of
machines that are used for general tasks.
