### PR TITLE
browser(firefox): browser.version() to return full version

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1211
-Changed: lushnikov@chromium.org Wed 18 Nov 2020 08:00:56 AM PST
+1212
+Changed: lushnikov@chromium.org Thu 19 Nov 2020 08:08:27 AM PST

--- a/browser_patches/firefox/juggler/protocol/BrowserHandler.js
+++ b/browser_patches/firefox/juggler/protocol/BrowserHandler.js
@@ -9,6 +9,7 @@ const {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
 const {TargetRegistry} = ChromeUtils.import("chrome://juggler/content/TargetRegistry.js");
 const {Helper} = ChromeUtils.import('chrome://juggler/content/Helper.js');
 const {PageHandler} = ChromeUtils.import("chrome://juggler/content/protocol/PageHandler.js");
+const {AppConstants} = ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
 
 const helper = new Helper();
 
@@ -252,9 +253,7 @@ class BrowserHandler {
   }
 
   async ['Browser.getInfo']() {
-    const version = Components.classes["@mozilla.org/xre/app-info;1"]
-                              .getService(Components.interfaces.nsIXULAppInfo)
-                              .version;
+    const version = AppConstants.MOZ_APP_VERSION_DISPLAY;
     const userAgent = Components.classes["@mozilla.org/network/protocol;1?name=http"]
                                 .getService(Components.interfaces.nsIHttpProtocolHandler)
                                 .userAgent;


### PR DESCRIPTION
Currently, browser.version() returns `83.0`, whereas launching firefox
with `--version` flag returns `83.0b3`. This patch alings protocol's
`Browser.version()` with flag output.