### PR TITLE
fix(protocol): rename websocket error event to socketerror

### DIFF
--- a/src/client/network.ts
+++ b/src/client/network.ts
@@ -336,7 +336,7 @@ export class WebSocket extends ChannelOwner<channels.WebSocketChannel, channels.
       const payload = event.opcode === 2 ? Buffer.from(event.data, 'base64') : event.data;
       this.emit(Events.WebSocket.FrameReceived, { payload });
     });
-    this._channel.on('error', ({ error }) => this.emit(Events.WebSocket.Error, error));
+    this._channel.on('socketError', ({ error }) => this.emit(Events.WebSocket.Error, error));
     this._channel.on('close', () => {
       this._isClosed = true;
       this.emit(Events.WebSocket.Close);

--- a/src/dispatchers/networkDispatchers.ts
+++ b/src/dispatchers/networkDispatchers.ts
@@ -107,7 +107,7 @@ export class WebSocketDispatcher extends Dispatcher<WebSocket, channels.WebSocke
     });
     webSocket.on(WebSocket.Events.FrameSent, (event: { opcode: number, data: string }) => this._dispatchEvent('frameSent', event));
     webSocket.on(WebSocket.Events.FrameReceived, (event: { opcode: number, data: string }) => this._dispatchEvent('frameReceived', event));
-    webSocket.on(WebSocket.Events.Error, (error: string) => this._dispatchEvent('error', { error }));
+    webSocket.on(WebSocket.Events.SocketError, (error: string) => this._dispatchEvent('socketError', { error }));
     webSocket.on(WebSocket.Events.Close, () => this._dispatchEvent('close', {}));
   }
 }

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -2215,7 +2215,7 @@ export interface WebSocketChannel extends Channel {
   on(event: 'open', callback: (params: WebSocketOpenEvent) => void): this;
   on(event: 'frameSent', callback: (params: WebSocketFrameSentEvent) => void): this;
   on(event: 'frameReceived', callback: (params: WebSocketFrameReceivedEvent) => void): this;
-  on(event: 'error', callback: (params: WebSocketErrorEvent) => void): this;
+  on(event: 'socketError', callback: (params: WebSocketSocketErrorEvent) => void): this;
   on(event: 'close', callback: (params: WebSocketCloseEvent) => void): this;
 }
 export type WebSocketOpenEvent = {};
@@ -2227,7 +2227,7 @@ export type WebSocketFrameReceivedEvent = {
   opcode: number,
   data: string,
 };
-export type WebSocketErrorEvent = {
+export type WebSocketSocketErrorEvent = {
   error: string,
 };
 export type WebSocketCloseEvent = {};

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -1895,7 +1895,7 @@ WebSocket:
         opcode: number
         data: string
 
-    error:
+    socketError:
       parameters:
         error: string
 

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -336,7 +336,7 @@ export class WebSocket extends EventEmitter {
 
   static Events = {
     Close: 'close',
-    Error: 'socketerror',
+    SocketError: 'socketerror',
     FrameReceived: 'framereceived',
     FrameSent: 'framesent',
   };
@@ -359,7 +359,7 @@ export class WebSocket extends EventEmitter {
   }
 
   error(errorMessage: string) {
-    this.emit(WebSocket.Events.Error, errorMessage);
+    this.emit(WebSocket.Events.SocketError, errorMessage);
   }
 
   closed() {


### PR DESCRIPTION
This is to avoid special handling of error events in node.

References #4445.