### PR TITLE
chore: simplify server screencast code

### DIFF
--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -380,18 +380,6 @@ export class FFPage implements PageDelegate {
       throw new Error('Not implemented');
   }
 
-  async startScreencast(options: types.PageScreencastOptions): Promise<void> {
-    this._session.send('Page.startVideoRecording', {
-      file: options.outputFile,
-      width: options.width,
-      height: options.height,
-    });
-  }
-
-  async stopScreencast(): Promise<void> {
-    await this._session.send('Page.stopVideoRecording');
-  }
-
   async takeScreenshot(format: 'png' | 'jpeg', documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined): Promise<Buffer> {
     if (!documentRect) {
       const context = await this._page.mainFrame()._utilityContext();

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -61,8 +61,6 @@ export interface PageDelegate {
   canScreenshotOutsideViewport(): boolean;
   resetViewport(): Promise<void>; // Only called if canScreenshotOutsideViewport() returns false.
   setBackgroundColor(color?: { r: number; g: number; b: number; a: number; }): Promise<void>;
-  startScreencast(options: types.PageScreencastOptions): Promise<void>;
-  stopScreencast(): Promise<void>;
   takeScreenshot(format: string, documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined): Promise<Buffer>;
 
   isElementHandle(remoteObject: any): boolean;


### PR DESCRIPTION
Currently, we always throw from FrameSession._stopScreencast
when not running with video, and immediately catch it in
CRPage.didClose (thanks to debugger to point that).

Overall, we have code prepared for start/stop API, which
we never did, so it makes sense to simplify code a bit,
and throw if something goes wrong.