### PR TITLE
fix(frames): do not start network idle timer after detach

### DIFF
--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -122,7 +122,7 @@ export class Connection {
     }
     const object = this._objects.get(guid);
     if (!object)
-      throw new Error(`Cannot find object to call "${method}": ${guid}`);
+      throw new Error(`Cannot find object to emit "${method}": ${guid}`);
     object._channel.emit(method, this._replaceGuidsWithChannels(params));
   }
 

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -1056,7 +1056,10 @@ export class Frame extends EventEmitter {
 
   _startNetworkIdleTimer() {
     assert(!this._networkIdleTimer);
-    if (this._firedLifecycleEvents.has('networkidle'))
+    // We should not start a timer and report networkidle in detached frames.
+    // This happens at least in Firefox for child frames, where we may get requestFinished
+    // after the frame was detached - probably a race in the Firefox itself.
+    if (this._firedLifecycleEvents.has('networkidle') || this._detached)
       return;
     this._networkIdleTimer = setTimeout(() => this._onLifecycleEvent('networkidle'), 500);
   }


### PR DESCRIPTION
This fixes a common flaky error on the bots:
```
Error: Cannot find object to emit "loadstate": Frame@f5b80c8c318c5471a1e6af552866e981
```