### PR TITLE
browser(firefox): ensure detachedFromTarget is always sent

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1212
-Changed: lushnikov@chromium.org Thu 19 Nov 2020 08:08:27 AM PST
+1213
+Changed: dgozman@gmail.com Fri Nov 20 07:01:37 PST 2020

--- a/browser_patches/firefox/juggler/TargetRegistry.js
+++ b/browser_patches/firefox/juggler/TargetRegistry.js
@@ -521,7 +521,12 @@ class PageTarget {
     this._browserContext.pages.delete(this);
     this._registry._browserToTarget.delete(this._linkedBrowser);
     this._registry._browserBrowsingContextToTarget.delete(this._linkedBrowser.browsingContext);
-    helper.removeListeners(this._eventListeners);
+    try {
+      helper.removeListeners(this._eventListeners);
+    } catch (e) {
+      // In some cases, removing listeners from this._linkedBrowser fails
+      // because it is already half-destroyed.
+    }
     this._registry.emit(TargetRegistry.Events.TargetDestroyed, this);
   }
 }

--- a/browser_patches/firefox/juggler/TargetRegistry.js
+++ b/browser_patches/firefox/juggler/TargetRegistry.js
@@ -526,6 +526,8 @@ class PageTarget {
     } catch (e) {
       // In some cases, removing listeners from this._linkedBrowser fails
       // because it is already half-destroyed.
+      if (e)
+        dump(e.message + '\n' + e.stack + '\n');
     }
     this._registry.emit(TargetRegistry.Events.TargetDestroyed, this);
   }


### PR DESCRIPTION
LinkedBrowser can throw when removing listeners in PageTarget.dispose,
and that prevents BrowserHandler from sending Browser.detachedFromTarget.

Using a try-catch seems good enough.