### PR TITLE
browser(firefox): send dragend after drop and survive navigations

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1214
-Changed: lushnikov@chromium.org Mon 23 Nov 2020 04:14:36 PM PST
+1215
+Changed: joel.einbinder@gmail.com Wed 25 Nov 2020 03:31:22 AM PST


### PR DESCRIPTION
Storing the data transfer was unnecessary for drag and drops. The active data transfer is already stored on the drag session. And it was causing a bug where navigating the page would invalidate the data transfer and break an ongoing drag.

Also fixes dragend events not being fired on drop: `dragService.endDragSession(true);`