### PR TITLE
fix(lint): update check_deps for src/remote

### DIFF
--- a/utils/check_deps.js
+++ b/utils/check_deps.js
@@ -124,9 +124,8 @@ DEPS['src/trace/'] = ['src/utils/', 'src/client/**', 'src/server/**'];
 DEPS['src/debug/'] = ['src/utils/', 'src/generated/', 'src/server/**', 'src/debug/**'];
 
 // The service is a cross-cutting feature, and so it depends on a bunch of things.
-DEPS['src/remote/playwrightClient.ts'] = ['src/client/'];
-DEPS['src/remote/playwrightServer.ts'] = ['src/debug/', 'src/dispatchers/', 'src/server/', 'src/server/electron/', 'src/trace/'];
-DEPS['src/service.ts'] = ['src/remote/playwrightServer.ts'];
+DEPS['src/remote/'] = ['src/client/', 'src/debug/', 'src/dispatchers/', 'src/server/', 'src/server/electron/', 'src/trace/'];
+DEPS['src/service.ts'] = ['src/remote/'];
 
 checkDeps().catch(e => {
   console.error(e && e.stack ? e.stack : e);

--- a/utils/check_deps.js
+++ b/utils/check_deps.js
@@ -66,7 +66,6 @@ async function checkDeps() {
     while (!DEPS[from]) {
       if (from.endsWith('/'))
         from = from.substring(0, from.length - 1);
-      console.log(from, to);
       if (from.lastIndexOf('/') === -1)
         throw new Error(`Cannot find DEPS for ${fromDirectory}`);
       from = from.substring(0, from.lastIndexOf('/') + 1);

--- a/utils/check_deps.js
+++ b/utils/check_deps.js
@@ -66,6 +66,7 @@ async function checkDeps() {
     while (!DEPS[from]) {
       if (from.endsWith('/'))
         from = from.substring(0, from.length - 1);
+      console.log(from, to);
       if (from.lastIndexOf('/') === -1)
         throw new Error(`Cannot find DEPS for ${fromDirectory}`);
       from = from.substring(0, from.lastIndexOf('/') + 1);
@@ -123,4 +124,12 @@ DEPS['src/trace/'] = ['src/utils/', 'src/client/**', 'src/server/**'];
 // Debug is a server plugin, nothing should depend on it.
 DEPS['src/debug/'] = ['src/utils/', 'src/generated/', 'src/server/**', 'src/debug/**'];
 
-checkDeps();
+// The service is a cross-cutting feature, and so it depends on a bunch of things.
+DEPS['src/remote/playwrightClient.ts'] = ['src/client/'];
+DEPS['src/remote/playwrightServer.ts'] = ['src/debug/', 'src/dispatchers/', 'src/server/', 'src/server/electron/', 'src/trace/'];
+DEPS['src/service.ts'] = ['src/remote/playwrightServer.ts'];
+
+checkDeps().catch(e => {
+  console.error(e && e.stack ? e.stack : e);
+  process.exit(1);
+});


### PR DESCRIPTION
check_deps was throwing an error, but nobody was catching it and it still returned an exit code 0. I fixed that, and also fixed the error by adding deps for src/remote.