### PR TITLE
browser(firefox): support alertCheck and confirmCheck dialogs

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1216
-Changed: lushnikov@chromium.org Mon 30 Nov 2020 09:59:07 AM PST
+1217
+Changed: dgozman@gmail.com Mon Nov 30 18:45:31 PST 2020

--- a/browser_patches/firefox/juggler/TargetRegistry.js
+++ b/browser_patches/firefox/juggler/TargetRegistry.js
@@ -773,9 +773,13 @@ class Dialog {
     const type = prompt.args.promptType;
     switch (type) {
       case 'alert':
+      case 'alertCheck':
+        return new Dialog(prompt, 'alert');
       case 'prompt':
+        return new Dialog(prompt, 'prompt');
       case 'confirm':
-        return new Dialog(prompt, type);
+      case 'confirmCheck':
+        return new Dialog(prompt, 'confirm');
       case 'confirmEx':
         return new Dialog(prompt, 'beforeunload');
       default:


### PR DESCRIPTION
These are shown with "prevent this page from showing more dialogs" checkbox.

References #4546.