### PR TITLE
chore: add internal method for utility context bindings

### DIFF
--- a/src/server/browserContext.ts
+++ b/src/server/browserContext.ts
@@ -184,7 +184,7 @@ export abstract class BrowserContext extends EventEmitter {
   }
 
   async exposeBinding(name: string, needsHandle: boolean, playwrightBinding: frames.FunctionWithSource): Promise<void> {
-    const identifier = 'main:' + name;
+    const identifier = PageBinding.identifier(name, 'main');
     if (this._pageBindings.has(identifier))
       throw new Error(`Function "${name}" has been already registered`);
     for (const page of this.pages()) {

--- a/src/server/browserContext.ts
+++ b/src/server/browserContext.ts
@@ -184,14 +184,15 @@ export abstract class BrowserContext extends EventEmitter {
   }
 
   async exposeBinding(name: string, needsHandle: boolean, playwrightBinding: frames.FunctionWithSource): Promise<void> {
+    const identifier = 'main:' + name;
+    if (this._pageBindings.has(identifier))
+      throw new Error(`Function "${name}" has been already registered`);
     for (const page of this.pages()) {
-      if (page._pageBindings.has(name))
+      if (page.getBinding(name, 'main'))
         throw new Error(`Function "${name}" has been already registered in one of the pages`);
     }
-    if (this._pageBindings.has(name))
-      throw new Error(`Function "${name}" has been already registered`);
-    const binding = new PageBinding(name, playwrightBinding, needsHandle);
-    this._pageBindings.set(name, binding);
+    const binding = new PageBinding(name, playwrightBinding, needsHandle, 'main');
+    this._pageBindings.set(identifier, binding);
     this._doExposeBinding(binding);
   }
 

--- a/src/server/chromium/crPage.ts
+++ b/src/server/chromium/crPage.ts
@@ -693,7 +693,9 @@ class FrameSession {
 
   async _onBindingCalled(event: Protocol.Runtime.bindingCalledPayload) {
     const context = this._contextIdToContext.get(event.executionContextId)!;
-    await this._page._onBindingCalled(event.payload, context);
+    const pageOrError = await this._crPage.pageOrError();
+    if (!(pageOrError instanceof Error))
+      await this._page._onBindingCalled(event.payload, context);
   }
 
   _onDialog(event: Protocol.Page.javascriptDialogOpeningPayload) {

--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -28,11 +28,12 @@ import { FatalDOMError, RetargetableDOMError } from './common/domErrors';
 export class FrameExecutionContext extends js.ExecutionContext {
   readonly frame: frames.Frame;
   private _injectedScriptPromise?: Promise<js.JSHandle>;
-  private _debugScriptPromise?: Promise<js.JSHandle | undefined>;
+  readonly world: types.World|null;
 
-  constructor(delegate: js.ExecutionContextDelegate, frame: frames.Frame) {
+  constructor(delegate: js.ExecutionContextDelegate, frame: frames.Frame, world: types.World|null) {
     super(delegate);
     this.frame = frame;
+    this.world = world;
   }
 
   adoptIfNeeded(handle: js.JSHandle): Promise<js.JSHandle> | null {

--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -28,7 +28,7 @@ import { FatalDOMError, RetargetableDOMError } from './common/domErrors';
 export class FrameExecutionContext extends js.ExecutionContext {
   readonly frame: frames.Frame;
   private _injectedScriptPromise?: Promise<js.JSHandle>;
-  readonly world: types.World|null;
+  readonly world: types.World | null;
 
   constructor(delegate: js.ExecutionContextDelegate, frame: frames.Frame, world: types.World|null) {
     super(delegate);

--- a/src/server/firefox/ffBrowser.ts
+++ b/src/server/firefox/ffBrowser.ts
@@ -298,6 +298,8 @@ export class FFBrowserContext extends BrowserContext {
   }
 
   async _doExposeBinding(binding: PageBinding) {
+    if (binding.world !== 'main')
+      throw new Error('Only main context bindings are supported in Firefox.');
     await this._browser._connection.send('Browser.addBinding', { browserContextId: this._browserContextId, name: binding.name, script: binding.source });
   }
 

--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -134,11 +134,14 @@ export class FFPage implements PageDelegate {
     if (!frame)
       return;
     const delegate = new FFExecutionContext(this._session, executionContextId);
-    const context = new dom.FrameExecutionContext(delegate, frame);
+    let worldName: types.World|null = null;
     if (auxData.name === UTILITY_WORLD_NAME)
-      frame._contextCreated('utility', context);
-    else if (!auxData.name)
-      frame._contextCreated('main', context);
+      worldName = 'utility';
+    else if (!auxData)
+      worldName = 'main';
+    const context = new dom.FrameExecutionContext(delegate, frame, worldName);
+    if (worldName)
+      frame._contextCreated(worldName, context);
     this._contextIdToContext.set(executionContextId, context);
   }
 
@@ -290,6 +293,8 @@ export class FFPage implements PageDelegate {
   }
 
   async exposeBinding(binding: PageBinding) {
+    if (binding.world !== 'main')
+      throw new Error('Only main context bindings are supported in Firefox.');
     await this._session.send('Page.addBinding', { name: binding.name, script: binding.source });
   }
 

--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -137,7 +137,7 @@ export class FFPage implements PageDelegate {
     let worldName: types.World|null = null;
     if (auxData.name === UTILITY_WORLD_NAME)
       worldName = 'utility';
-    else if (!auxData)
+    else if (!auxData.name)
       worldName = 'main';
     const context = new dom.FrameExecutionContext(delegate, frame, worldName);
     if (worldName)

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -258,7 +258,7 @@ export class Page extends EventEmitter {
   }
 
   async exposeBinding(name: string, needsHandle: boolean, playwrightBinding: frames.FunctionWithSource) {
-    const identifier = 'main:' + name;
+    const identifier = PageBinding.identifier(name, 'main');
     if (this._pageBindings.has(identifier))
       throw new Error(`Function "${name}" has been already registered`);
     if (this._browserContext._pageBindings.has(identifier))
@@ -469,7 +469,8 @@ export class Page extends EventEmitter {
   }
 
   getBinding(name: string, world: types.World) {
-    return this._pageBindings.get(world + ':' + name) || this._browserContext._pageBindings.get(world + ':' + name);
+    const identifier = PageBinding.identifier(name, world);
+    return this._pageBindings.get(identifier) || this._browserContext._pageBindings.get(identifier);
   }
 }
 
@@ -521,6 +522,10 @@ export class PageBinding {
     this.source = `(${addPageBinding.toString()})(${JSON.stringify(name)}, ${needsHandle})`;
     this.needsHandle = needsHandle;
     this.world = world;
+  }
+
+  static identifier(name: string, world: types.World) {
+    return world + ':' + name;
   }
 
   static async dispatch(page: Page, payload: string, context: dom.FrameExecutionContext) {


### PR DESCRIPTION
This only works in chromium, throws for other browsers. Split from #4519.