### PR TITLE
test: remove tests for SelectorEngine.create

### DIFF
--- a/src/client/elementHandle.ts
+++ b/src/client/elementHandle.ts
@@ -241,10 +241,6 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> {
       return ElementHandle.fromNullable(result.element) as ElementHandle<Element> | null;
     });
   }
-
-  async _createSelectorForTest(name: string): Promise<string | undefined> {
-    return (await this._elementChannel.createSelectorForTest({ name })).value;
-  }
 }
 
 export function convertSelectOptionValues(values: string | ElementHandle | SelectOption | string[] | ElementHandle[] | SelectOption[] | null): { elements?: channels.ElementHandleChannel[], options?: SelectOption[] } {

--- a/src/dispatchers/elementHandlerDispatcher.ts
+++ b/src/dispatchers/elementHandlerDispatcher.ts
@@ -183,8 +183,4 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements chann
   async waitForSelector(params: channels.ElementHandleWaitForSelectorParams): Promise<channels.ElementHandleWaitForSelectorResult> {
     return { element: ElementHandleDispatcher.createNullable(this._scope, await this._elementHandle.waitForSelector(params.selector, params)) };
   }
-
-  async createSelectorForTest(params: channels.ElementHandleCreateSelectorForTestParams): Promise<channels.ElementHandleCreateSelectorForTestResult> {
-    return { value: await this._elementHandle._page.selectors._createSelector(params.name, this._elementHandle as ElementHandle<Element>) };
-  }
 }

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -1756,7 +1756,6 @@ export interface ElementHandleChannel extends JSHandleChannel {
   uncheck(params: ElementHandleUncheckParams, metadata?: Metadata): Promise<ElementHandleUncheckResult>;
   waitForElementState(params: ElementHandleWaitForElementStateParams, metadata?: Metadata): Promise<ElementHandleWaitForElementStateResult>;
   waitForSelector(params: ElementHandleWaitForSelectorParams, metadata?: Metadata): Promise<ElementHandleWaitForSelectorResult>;
-  createSelectorForTest(params: ElementHandleCreateSelectorForTestParams, metadata?: Metadata): Promise<ElementHandleCreateSelectorForTestResult>;
 }
 export type ElementHandleEvalOnSelectorParams = {
   selector: string,
@@ -2088,15 +2087,6 @@ export type ElementHandleWaitForSelectorOptions = {
 };
 export type ElementHandleWaitForSelectorResult = {
   element?: ElementHandleChannel,
-};
-export type ElementHandleCreateSelectorForTestParams = {
-  name: string,
-};
-export type ElementHandleCreateSelectorForTestOptions = {
-
-};
-export type ElementHandleCreateSelectorForTestResult = {
-  value?: string,
 };
 
 // ----------- Request -----------

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -1762,12 +1762,6 @@ ElementHandle:
       returns:
         element: ElementHandle?
 
-    createSelectorForTest:
-      parameters:
-        name: string
-      returns:
-        value: string?
-
 
 Request:
   type: interface

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -837,9 +837,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     timeout: tOptional(tNumber),
     state: tOptional(tEnum(['attached', 'detached', 'visible', 'hidden'])),
   });
-  scheme.ElementHandleCreateSelectorForTestParams = tObject({
-    name: tString,
-  });
   scheme.RequestResponseParams = tOptional(tObject({}));
   scheme.RouteAbortParams = tObject({
     errorCode: tOptional(tString),

--- a/src/server/selectors.ts
+++ b/src/server/selectors.ts
@@ -114,14 +114,6 @@ export class Selectors {
     return adopted;
   }
 
-  async _createSelector(name: string, handle: dom.ElementHandle<Element>): Promise<string | undefined> {
-    const mainContext = await handle._page.mainFrame()._mainContext();
-    const injectedScript = await mainContext.injectedScript();
-    return injectedScript.evaluate((injected, { target, name }) => {
-      return injected.engines.get(name)!.create(document.documentElement, target);
-    }, { target: handle, name });
-  }
-
   _parseSelector(selector: string): SelectorInfo {
     const parsed = parseSelector(selector);
     for (const {name} of parsed.parts) {

--- a/test/selectors-register.spec.ts
+++ b/test/selectors-register.spec.ts
@@ -41,12 +41,10 @@ it('should work', async ({playwright, browser}) => {
   const page = await context.newPage();
   await page.setContent('<div><span></span></div><div></div>');
 
-  expect(await (await page.$('div') as any)._createSelectorForTest('tag')).toBe('DIV');
   expect(await page.$eval('tag=DIV', e => e.nodeName)).toBe('DIV');
   expect(await page.$eval('tag=SPAN', e => e.nodeName)).toBe('SPAN');
   expect(await page.$$eval('tag=DIV', es => es.length)).toBe(2);
 
-  expect(await (await page.$('div') as any)._createSelectorForTest('tag2')).toBe('DIV');
   expect(await page.$eval('tag2=DIV', e => e.nodeName)).toBe('DIV');
   expect(await page.$eval('tag2=SPAN', e => e.nodeName)).toBe('SPAN');
   expect(await page.$$eval('tag2=DIV', es => es.length)).toBe(2);

--- a/test/selectors-text.spec.ts
+++ b/test/selectors-text.spec.ts
@@ -106,22 +106,6 @@ it('query', async ({page, isWebKit}) => {
   expect((await page.$$(`text="lo wo"`)).length).toBe(0);
 });
 
-it('create', async ({page}) => {
-  await page.setContent(`<div>yo</div><div>"ya</div><div>ye ye</div>`);
-  expect(await (await page.$('div') as any)._createSelectorForTest('text')).toBe('yo');
-  expect(await (await page.$('div:nth-child(2)') as any)._createSelectorForTest('text')).toBe('"\\"ya"');
-  expect(await (await page.$('div:nth-child(3)') as any)._createSelectorForTest('text')).toBe('"ye ye"');
-
-  await page.setContent(`<div>yo</div><div>yo<div>ya</div>hey</div>`);
-  expect(await (await page.$('div:nth-child(2)') as any)._createSelectorForTest('text')).toBe('hey');
-
-  await page.setContent(`<div> yo <div></div>ya</div>`);
-  expect(await (await page.$('div') as any)._createSelectorForTest('text')).toBe('yo');
-
-  await page.setContent(`<div> "yo <div></div>ya</div>`);
-  expect(await (await page.$('div') as any)._createSelectorForTest('text')).toBe('" \\"yo "');
-});
-
 it('should be case sensitive if quotes are specified', async ({page}) => {
   await page.setContent(`<div>yo</div><div>ya</div><div>\nye  </div>`);
   expect(await page.$eval(`text=yA`, e => e.outerHTML)).toBe('<div>ya</div>');


### PR DESCRIPTION
We are not going to keep this functionality on arbitrary engines.