### PR TITLE
feat(selectors): switch to the new engine

### DIFF
--- a/src/debug/injected/consoleApi.ts
+++ b/src/debug/injected/consoleApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ParsedSelector, parseSelector } from '../../server/common/selectorParser';
+import { parseSelector } from '../../server/common/selectorParser';
 import type InjectedScript from '../../server/injected/injectedScript';
 
 export class ConsoleAPI {
@@ -29,29 +29,18 @@ export class ConsoleAPI {
     };
   }
 
-  private _checkSelector(parsed: ParsedSelector) {
-    for (const {name} of parsed.parts) {
-      if (!this._injectedScript.engines.has(name))
-        throw new Error(`Unknown engine "${name}"`);
-    }
-  }
-
   _querySelector(selector: string): (Element | undefined) {
     if (typeof selector !== 'string')
       throw new Error(`Usage: playwright.query('Playwright >> selector').`);
     const parsed = parseSelector(selector);
-    this._checkSelector(parsed);
-    const elements = this._injectedScript.querySelectorAll(parsed, document);
-    return elements[0];
+    return this._injectedScript.querySelector(parsed, document);
   }
 
   _querySelectorAll(selector: string): Element[] {
     if (typeof selector !== 'string')
       throw new Error(`Usage: playwright.$$('Playwright >> selector').`);
     const parsed = parseSelector(selector);
-    this._checkSelector(parsed);
-    const elements = this._injectedScript.querySelectorAll(parsed, document);
-    return elements;
+    return this._injectedScript.querySelectorAll(parsed, document);
   }
 
   _inspect(selector: string) {

--- a/src/server/injected/selectorEvaluator.ts
+++ b/src/server/injected/selectorEvaluator.ts
@@ -36,6 +36,7 @@ export class SelectorEvaluatorImpl implements SelectorEvaluator {
   private _cache = new Map<any, { rest: any[], result: any }[]>();
 
   constructor(extraEngines: Map<string, SelectorEngine>) {
+    // Note: keep predefined names in sync with Selectors class.
     for (const [name, engine] of extraEngines)
       this._engines.set(name, engine);
     this._engines.set('not', notEngine);
@@ -43,6 +44,7 @@ export class SelectorEvaluatorImpl implements SelectorEvaluator {
     this._engines.set('where', isEngine);
     this._engines.set('has', hasEngine);
     this._engines.set('scope', scopeEngine);
+    this._engines.set('light', lightEngine);
     this._engines.set('text', textEngine);
     this._engines.set('matches-text', matchesTextEngine);
     this._engines.set('xpath', xpathEngine);
@@ -319,6 +321,16 @@ const notEngine: SelectorEngine = {
       throw new Error(`"not" engine expects non-empty selector list`);
     return !evaluator.matches(element, args, context);
   },
+};
+
+const lightEngine: SelectorEngine = {
+  query(context: QueryContext, args: (string | number | Selector)[], evaluator: SelectorEvaluator): Element[] {
+    return evaluator.query({ ...context, pierceShadow: false }, args);
+  },
+
+  matches(element: Element, args: (string | number | Selector)[], context: QueryContext, evaluator: SelectorEvaluator): boolean {
+    return evaluator.matches(element, args, { ...context, pierceShadow: false });
+  }
 };
 
 const textEngine: SelectorEngine = {

--- a/src/server/selectors.ts
+++ b/src/server/selectors.ts
@@ -39,7 +39,9 @@ export class Selectors {
       'id', 'id:light',
       'data-testid', 'data-testid:light',
       'data-test-id', 'data-test-id:light',
-      'data-test', 'data-test:light'
+      'data-test', 'data-test:light',
+      // v2 engines:
+      'not', 'is', 'where', 'has', 'scope', 'light', 'matches-text',
     ]);
     this._engines = new Map();
   }
@@ -116,11 +118,11 @@ export class Selectors {
 
   _parseSelector(selector: string): SelectorInfo {
     const parsed = parseSelector(selector);
-    for (const {name} of parsed.parts) {
+    for (const name of parsed.names) {
       if (!this._builtinEngines.has(name) && !this._engines.has(name))
         throw new Error(`Unknown engine "${name}" while parsing selector ${selector}`);
     }
-    const needsMainWorld = parsed.parts.some(({name}) => {
+    const needsMainWorld = parsed.names.some(name => {
       const custom = this._engines.get(name);
       return custom ? !custom.contentScript : false;
     });

--- a/test/css-parser.spec.ts
+++ b/test/css-parser.spec.ts
@@ -21,50 +21,50 @@ const { parseCSS, serializeSelector: serialize } =
     require(path.join(__dirname, '..', 'lib', 'server', 'common', 'cssParser'));
 
 it('should parse css', async () => {
-  expect(serialize(parseCSS('div'))).toBe('div');
-  expect(serialize(parseCSS('div.class'))).toBe('div.class');
-  expect(serialize(parseCSS('.class'))).toBe('.class');
-  expect(serialize(parseCSS('#id'))).toBe('#id');
-  expect(serialize(parseCSS('.class#id'))).toBe('.class#id');
-  expect(serialize(parseCSS('div#id.class'))).toBe('div#id.class');
-  expect(serialize(parseCSS('*'))).toBe('*');
-  expect(serialize(parseCSS('*div'))).toBe('*div');
-  expect(serialize(parseCSS('div[attr *= foo i]'))).toBe('div[attr *= foo i]');
-  expect(serialize(parseCSS('div[attr~="Bar baz"  ]'))).toBe('div[attr~="Bar baz" ]');
-  expect(serialize(parseCSS(`div    [ foo = 'bar'  s]`))).toBe(`div [ foo = "bar" s]`);
+  expect(serialize(parseCSS('div').selector)).toBe('div');
+  expect(serialize(parseCSS('div.class').selector)).toBe('div.class');
+  expect(serialize(parseCSS('.class').selector)).toBe('.class');
+  expect(serialize(parseCSS('#id').selector)).toBe('#id');
+  expect(serialize(parseCSS('.class#id').selector)).toBe('.class#id');
+  expect(serialize(parseCSS('div#id.class').selector)).toBe('div#id.class');
+  expect(serialize(parseCSS('*').selector)).toBe('*');
+  expect(serialize(parseCSS('*div').selector)).toBe('*div');
+  expect(serialize(parseCSS('div[attr *= foo i]').selector)).toBe('div[attr *= foo i]');
+  expect(serialize(parseCSS('div[attr~="Bar baz"  ]').selector)).toBe('div[attr~="Bar baz" ]');
+  expect(serialize(parseCSS(`div    [ foo = 'bar'  s]`).selector)).toBe(`div [ foo = "bar" s]`);
 
-  expect(serialize(parseCSS(':hover'))).toBe(':hover');
-  expect(serialize(parseCSS('div:hover'))).toBe('div:hover');
-  expect(serialize(parseCSS('#id:active:hover'))).toBe('#id:active:hover');
-  expect(serialize(parseCSS(':dir(ltr)'))).toBe(':dir(ltr)');
-  expect(serialize(parseCSS('#foo-bar.cls:nth-child(3n + 10)'))).toBe('#foo-bar.cls:nth-child(3n + 10)');
-  expect(serialize(parseCSS(':lang(en)'))).toBe(':lang(en)');
-  expect(serialize(parseCSS('*:hover'))).toBe('*:hover');
+  expect(serialize(parseCSS(':hover').selector)).toBe(':hover');
+  expect(serialize(parseCSS('div:hover').selector)).toBe('div:hover');
+  expect(serialize(parseCSS('#id:active:hover').selector)).toBe('#id:active:hover');
+  expect(serialize(parseCSS(':dir(ltr)').selector)).toBe(':dir(ltr)');
+  expect(serialize(parseCSS('#foo-bar.cls:nth-child(3n + 10)').selector)).toBe('#foo-bar.cls:nth-child(3n + 10)');
+  expect(serialize(parseCSS(':lang(en)').selector)).toBe(':lang(en)');
+  expect(serialize(parseCSS('*:hover').selector)).toBe('*:hover');
 
-  expect(serialize(parseCSS('div span'))).toBe('div span');
-  expect(serialize(parseCSS('div>span'))).toBe('div > span');
-  expect(serialize(parseCSS('div +span'))).toBe('div + span');
-  expect(serialize(parseCSS('div~ span'))).toBe('div ~ span');
-  expect(serialize(parseCSS('div   >.class #id+ span'))).toBe('div > .class #id + span');
-  expect(serialize(parseCSS('div>span+.class'))).toBe('div > span + .class');
+  expect(serialize(parseCSS('div span').selector)).toBe('div span');
+  expect(serialize(parseCSS('div>span').selector)).toBe('div > span');
+  expect(serialize(parseCSS('div +span').selector)).toBe('div + span');
+  expect(serialize(parseCSS('div~ span').selector)).toBe('div ~ span');
+  expect(serialize(parseCSS('div   >.class #id+ span').selector)).toBe('div > .class #id + span');
+  expect(serialize(parseCSS('div>span+.class').selector)).toBe('div > span + .class');
 
-  expect(serialize(parseCSS('div:not(span)'))).toBe('div:not(span)');
-  expect(serialize(parseCSS(':not(span)#id'))).toBe('#id:not(span)');
-  expect(serialize(parseCSS('div:not(span):hover'))).toBe('div:hover:not(span)');
-  expect(serialize(parseCSS('div:has(span):hover'))).toBe('div:hover:has(span)');
-  expect(serialize(parseCSS('div:right-of(span):hover'))).toBe('div:hover:right-of(span)');
-  expect(serialize(parseCSS(':right-of(span):react(foobar)'))).toBe(':right-of(span):react(foobar)');
-  expect(serialize(parseCSS('div:is(span):hover'))).toBe('div:hover:is(span)');
-  expect(serialize(parseCSS('div:scope:hover'))).toBe('div:hover:scope()');
-  expect(serialize(parseCSS('div:sCOpe:HOVER'))).toBe('div:HOVER:scope()');
-  expect(serialize(parseCSS('div:NOT(span):hoVER'))).toBe('div:hoVER:not(span)');
+  expect(serialize(parseCSS('div:not(span)').selector)).toBe('div:not(span)');
+  expect(serialize(parseCSS(':not(span)#id').selector)).toBe('#id:not(span)');
+  expect(serialize(parseCSS('div:not(span):hover').selector)).toBe('div:hover:not(span)');
+  expect(serialize(parseCSS('div:has(span):hover').selector)).toBe('div:hover:has(span)');
+  expect(serialize(parseCSS('div:right-of(span):hover').selector)).toBe('div:hover:right-of(span)');
+  expect(serialize(parseCSS(':right-of(span):react(foobar)').selector)).toBe(':right-of(span):react(foobar)');
+  expect(serialize(parseCSS('div:is(span):hover').selector)).toBe('div:hover:is(span)');
+  expect(serialize(parseCSS('div:scope:hover').selector)).toBe('div:hover:scope()');
+  expect(serialize(parseCSS('div:sCOpe:HOVER').selector)).toBe('div:HOVER:scope()');
+  expect(serialize(parseCSS('div:NOT(span):hoVER').selector)).toBe('div:hoVER:not(span)');
 
-  expect(serialize(parseCSS(':text("foo")'))).toBe(':text("foo")');
-  expect(serialize(parseCSS(':text("*")'))).toBe(':text("*")');
-  expect(serialize(parseCSS(':text(*)'))).toBe(':text(*)');
-  expect(serialize(parseCSS(':text("foo", normalize-space)'))).toBe(':text("foo", normalize-space)');
-  expect(serialize(parseCSS(':index(3, div    span)'))).toBe(':index(3, div span)');
-  expect(serialize(parseCSS(':is(foo, bar>baz.cls+:not(qux))'))).toBe(':is(foo, bar > baz.cls + :not(qux))');
+  expect(serialize(parseCSS(':text("foo")').selector)).toBe(':text("foo")');
+  expect(serialize(parseCSS(':text("*")').selector)).toBe(':text("*")');
+  expect(serialize(parseCSS(':text(*)').selector)).toBe(':text(*)');
+  expect(serialize(parseCSS(':text("foo", normalize-space)').selector)).toBe(':text("foo", normalize-space)');
+  expect(serialize(parseCSS(':index(3, div    span)').selector)).toBe(':index(3, div span)');
+  expect(serialize(parseCSS(':is(foo, bar>baz.cls+:not(qux))').selector)).toBe(':is(foo, bar > baz.cls + :not(qux))');
 });
 
 it('should throw on malformed css', async () => {

--- a/test/queryselector.spec.ts
+++ b/test/queryselector.spec.ts
@@ -16,6 +16,9 @@
  */
 
 import { it, expect } from './fixtures';
+import * as path from 'path';
+
+const { selectorsV2Enabled } = require(path.join(__dirname, '..', 'lib', 'server', 'common', 'selectorParser'));
 
 it('should throw for non-string selector', async ({page}) => {
   const error = await page.$(null).catch(e => e);
@@ -58,6 +61,8 @@ it('should auto-detect xpath selector with starting parenthesis', async ({page, 
 });
 
 it('should auto-detect xpath selector starting with ..', async ({page, server}) => {
+  if (selectorsV2Enabled())
+    return; // Selectors v2 do not support this.
   await page.setContent('<div><section>test</section><span></span></div>');
   const span = await page.$('"test" >> ../span');
   expect(await span.evaluate(e => e.nodeName)).toBe('SPAN');

--- a/test/selectors-css.spec.ts
+++ b/test/selectors-css.spec.ts
@@ -16,6 +16,9 @@
  */
 
 import { it, expect } from './fixtures';
+import * as path from 'path';
+
+const { selectorsV2Enabled } = require(path.join(__dirname, '..', 'lib', 'server', 'common', 'selectorParser'));
 
 it('should work for open shadow roots', async ({page, server}) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
@@ -189,9 +192,9 @@ it('should work with +', async ({page}) => {
   expect(await page.$$eval(`css=#div3 + #div4 + #div5`, els => els.length)).toBe(1);
 });
 
-it('should work with spaces in :nth-child and :not', test => {
-  test.fixme('Our selector parser is broken');
-}, async ({page, server}) => {
+it('should work with spaces in :nth-child and :not', async ({page, server}) => {
+  if (!selectorsV2Enabled())
+    return; // Selectors v1 do not support this.
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$$eval(`css=span:nth-child(23n +2)`, els => els.length)).toBe(1);
   expect(await page.$$eval(`css=span:nth-child(23n+ 2)`, els => els.length)).toBe(1);
@@ -204,9 +207,9 @@ it('should work with spaces in :nth-child and :not', test => {
   expect(await page.$$eval(`css=span, section:not(span, div)`, els => els.length)).toBe(5);
 });
 
-it('should work with :is', test => {
-  test.skip('Needs a new selector evaluator');
-}, async ({page, server}) => {
+it('should work with :is', async ({page, server}) => {
+  if (!selectorsV2Enabled())
+    return; // Selectors v1 do not support this.
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$$eval(`css=div:is(#root1)`, els => els.length)).toBe(1);
   expect(await page.$$eval(`css=div:is(#root1, #target)`, els => els.length)).toBe(1);
@@ -218,18 +221,18 @@ it('should work with :is', test => {
   expect(await page.$$eval(`css=:is(div, span) > *`, els => els.length)).toBe(6);
 });
 
-it('should work with :has', test => {
-  test.skip('Needs a new selector evaluator');
-}, async ({page, server}) => {
+it('should work with :has', async ({page, server}) => {
+  if (!selectorsV2Enabled())
+    return; // Selectors v1 do not support this.
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$$eval(`css=div:has(#target)`, els => els.length)).toBe(2);
   expect(await page.$$eval(`css=div:has([data-testid=foo])`, els => els.length)).toBe(3);
   expect(await page.$$eval(`css=div:has([attr*=value])`, els => els.length)).toBe(2);
 });
 
-it('should work with :scope', test => {
-  test.skip('Needs a new selector evaluator');
-}, async ({page, server}) => {
+it('should work with :scope', async ({page, server}) => {
+  if (!selectorsV2Enabled())
+    return; // Selectors v1 do not support this.
   await page.goto(server.PREFIX + '/deep-shadow.html');
   // 'is' does not change the scope, so it remains 'html'.
   expect(await page.$$eval(`css=div:is(:scope#root1)`, els => els.length)).toBe(0);

--- a/test/selectors-register.spec.ts
+++ b/test/selectors-register.spec.ts
@@ -69,7 +69,7 @@ it('should work in main and isolated world', async ({playwright, page}) => {
       return window['__answer'];
     },
     queryAll(root, selector) {
-      return [document.body, document.documentElement, window['__answer']];
+      return window['__answer'] ? [window['__answer'], document.body, document.documentElement] : [];
     }
   });
   await playwright.selectors.register('main', createDummySelector);

--- a/test/selectors-text.spec.ts
+++ b/test/selectors-text.spec.ts
@@ -17,7 +17,7 @@
 
 import { it, expect } from './fixtures';
 
-it('query', async ({page, isWebKit}) => {
+it('query', async ({page}) => {
   await page.setContent(`<div>yo</div><div>ya</div><div>\nye  </div>`);
   expect(await page.$eval(`text=ya`, e => e.outerHTML)).toBe('<div>ya</div>');
   expect(await page.$eval(`text="ya"`, e => e.outerHTML)).toBe('<div>ya</div>');
@@ -59,9 +59,9 @@ it('query', async ({page, isWebKit}) => {
   expect(await page.$eval(`"x"`, e => e.outerHTML)).toBe('<div>x</div>');
   expect(await page.$eval(`'x'`, e => e.outerHTML)).toBe('<div>x</div>');
   let error = await page.$(`"`).catch(e => e);
-  expect(error.message).toContain(isWebKit ? 'SyntaxError' : 'querySelector');
+  expect(error).toBeInstanceOf(Error);
   error = await page.$(`'`).catch(e => e);
-  expect(error.message).toContain(isWebKit ? 'SyntaxError' : 'querySelector');
+  expect(error).toBeInstanceOf(Error);
 
   await page.setContent(`<div> ' </div><div> " </div>`);
   expect(await page.$eval(`text="`, e => e.outerHTML)).toBe('<div> " </div>');


### PR DESCRIPTION
We leave old implementation under the boolean flag, just in case we need a quick revert.