### PR TITLE
browser(firefox): disable cross-process navigation

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1217
-Changed: dgozman@gmail.com Mon Nov 30 18:45:31 PST 2020
+1218
+Changed: lushnikov@chromium.org Fri 04 Dec 2020 10:13:12 AM PST

--- a/browser_patches/firefox/preferences/playwright.cfg
+++ b/browser_patches/firefox/preferences/playwright.cfg
@@ -3,6 +3,10 @@
 // Use light theme by default.
 pref("ui.systemUsesDarkTheme", 0);
 
+// @see https://github.com/microsoft/playwright/issues/4297
+pref("browser.tabs.remote.useCrossOriginEmbedderPolicy", false);
+pref("browser.tabs.remote.useCrossOriginOpenerPolicy", false);
+
 // Increase max number of child web processes so that new pages
 // get a new process by default and we have a process isolation
 // between pages from different contexts. If this becomes a performance


### PR DESCRIPTION
This disable cross-process navigation until we properly support it.

References #4297