### PR TITLE
feat(selectors): add visible and index engines

### DIFF
--- a/src/server/selectors.ts
+++ b/src/server/selectors.ts
@@ -18,7 +18,7 @@ import * as dom from './dom';
 import * as frames from './frames';
 import * as js from './javascript';
 import * as types from './types';
-import { ParsedSelector, parseSelector } from './common/selectorParser';
+import { ParsedSelector, parseSelector, selectorsV2Enabled } from './common/selectorParser';
 
 export type SelectorInfo = {
   parsed: ParsedSelector,
@@ -40,9 +40,11 @@ export class Selectors {
       'data-testid', 'data-testid:light',
       'data-test-id', 'data-test-id:light',
       'data-test', 'data-test:light',
-      // v2 engines:
-      'not', 'is', 'where', 'has', 'scope', 'light', 'matches-text',
     ]);
+    if (selectorsV2Enabled()) {
+      for (const name of ['not', 'is', 'where', 'has', 'scope', 'light', 'index', 'visible', 'matches-text'])
+        this._builtinEngines.add(name);
+    }
     this._engines = new Map();
   }
 

--- a/test/selectors-misc.spec.ts
+++ b/test/selectors-misc.spec.ts
@@ -16,6 +16,9 @@
  */
 
 import { it, expect } from './fixtures';
+import * as path from 'path';
+
+const { selectorsV2Enabled } = require(path.join(__dirname, '..', 'lib', 'server', 'common', 'selectorParser'));
 
 it('should work for open shadow roots', async ({page, server}) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
@@ -25,4 +28,50 @@ it('should work for open shadow roots', async ({page, server}) => {
   expect(await page.$(`id:light=target`)).toBe(null);
   expect(await page.$(`data-testid:light=foo`)).toBe(null);
   expect(await page.$$(`data-testid:light=foo`)).toEqual([]);
+});
+
+it('should work with :index', async ({page}) => {
+  if (!selectorsV2Enabled())
+    return; // Selectors v1 do not support this.
+  await page.setContent(`
+    <section>
+      <div id=target1></div>
+      <div id=target2></div>
+      <span id=target3></span>
+      <div id=target4></div>
+    </section>
+  `);
+  expect(await page.$$eval(`:index(1, div, span)`, els => els.map(e => e.id).join(';'))).toBe('target1');
+  expect(await page.$$eval(`:index(2, div, span)`, els => els.map(e => e.id).join(';'))).toBe('target2');
+  expect(await page.$$eval(`:index(3, div, span)`, els => els.map(e => e.id).join(';'))).toBe('target3');
+
+  const error = await page.waitForSelector(`:index(5, div, span)`, { timeout: 100 }).catch(e => e);
+  expect(error.message).toContain('100ms');
+
+  const promise = page.waitForSelector(`:index(5, div, span)`, { state: 'attached' });
+  await page.$eval('section', section => section.appendChild(document.createElement('span')));
+  const element = await promise;
+  expect(await element.evaluate(e => e.tagName)).toBe('SPAN');
+});
+
+it('should work with :visible', async ({page}) => {
+  if (!selectorsV2Enabled())
+    return; // Selectors v1 do not support this.
+  await page.setContent(`
+    <section>
+      <div id=target1></div>
+      <div id=target2></div>
+    </section>
+  `);
+  expect(await page.$('div:visible')).toBe(null);
+
+  const error = await page.waitForSelector(`div:visible`, { timeout: 100 }).catch(e => e);
+  expect(error.message).toContain('100ms');
+
+  const promise = page.waitForSelector(`div:visible`, { state: 'attached' });
+  await page.$eval('#target2', div => div.textContent = 'Now visible');
+  const element = await promise;
+  expect(await element.evaluate(e => e.id)).toBe('target2');
+
+  expect(await page.$eval('div:visible', div => div.id)).toBe('target2');
 });


### PR DESCRIPTION
- `div:visible` matches only visible `div`s. Intended use is to specifically target the visible element, when it is otherwise indistinguishable from the similar invisible one.
```js
await page.$eval('a:text("read article", "i"):visible');
```

- `:index(2, div > span)` matches the second "span child of div". Index is one-based. Intended use is to target a specific item in the list.
```js
// Click the third item.
await page.click(':index(3, :text("Click me"))');
// Wait for at least 5 items to be visible in the list.
await page.waitForSelector(':index(5, .my-item:visible)');
```
