### PR TITLE
devops: support FF_CHECKOUT_PATH to customize browser checkout

### DIFF
--- a/browser_patches/export.sh
+++ b/browser_patches/export.sh
@@ -48,6 +48,11 @@ if [[ ("$1" == "firefox") || ("$1" == "firefox/") || ("$1" == "ff") ]]; then
   EXPORT_PATH="$PWD/firefox"
   BUILD_NUMBER_UPSTREAM_URL="https://raw.githubusercontent.com/microsoft/playwright/master/browser_patches/firefox/BUILD_NUMBER"
   source "./firefox/UPSTREAM_CONFIG.sh"
+  if [[ ! -z "${FF_CHECKOUT_PATH}" ]]; then
+    echo "WARNING: using checkout path from FF_CHECKOUT_PATH env: ${FF_CHECKOUT_PATH}"
+    CHECKOUT_PATH="${FF_CHECKOUT_PATH}"
+    FRIENDLY_CHECKOUT_PATH="<FF_CHECKOUT_PATH>"
+  fi
 elif [[ ("$1" == "webkit") || ("$1" == "webkit/") || ("$1" == "wk") ]]; then
   FRIENDLY_CHECKOUT_PATH="//browser_patches/webkit/checkout";
   CHECKOUT_PATH="$PWD/webkit/checkout"

--- a/browser_patches/firefox/archive.sh
+++ b/browser_patches/firefox/archive.sh
@@ -30,12 +30,19 @@ fi
 
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname $0)"
-cd checkout
+SCRIPT_FOLDER="$(pwd -P)"
+
+if [[ ! -z "${FF_CHECKOUT_PATH}" ]]; then
+  cd "${FF_CHECKOUT_PATH}"
+  echo "WARNING: checkout path from FF_CHECKOUT_PATH env: ${FF_CHECKOUT_PATH}"
+else
+  cd "checkout"
+fi
 
 OBJ_FOLDER="obj-build-playwright"
 
 ./mach package
-node ../install-preferences.js $PWD/$OBJ_FOLDER/dist/firefox
+node "${SCRIPT_FOLDER}"/install-preferences.js $PWD/$OBJ_FOLDER/dist/firefox
 
 if ! [[ -d $OBJ_FOLDER/dist/firefox ]]; then
   echo "ERROR: cannot find $OBJ_FOLDER/dist/firefox folder in the checkout/. Did you build?"

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -6,8 +6,17 @@ RUST_VERSION="1.45.0"
 CBINDGEN_VERSION="0.15.0"
 
 trap "cd $(pwd -P)" EXIT
+
 cd "$(dirname $0)"
-cd "checkout"
+SCRIPT_FOLDER="$(pwd -P)"
+
+if [[ ! -z "${FF_CHECKOUT_PATH}" ]]; then
+  cd "${FF_CHECKOUT_PATH}"
+  echo "WARNING: checkout path from FF_CHECKOUT_PATH env: ${FF_CHECKOUT_PATH}"
+else
+  cd "checkout"
+fi
+
 
 if [[ "$(uname)" == "Darwin" ]]; then
   # Firefox currently does not build on 10.15 out of the box - it requires SDK for 10.11.
@@ -74,8 +83,8 @@ else
 fi
 
 if [[ "$(uname)" == "Darwin" ]]; then
-  node ../install-preferences.js $PWD/${OBJ_FOLDER}/dist
+  node "${SCRIPT_FOLDER}"/install-preferences.js $PWD/${OBJ_FOLDER}/dist
 else
-  node ../install-preferences.js $PWD/${OBJ_FOLDER}/dist/bin
+  node "${SCRIPT_FOLDER}"/install-preferences.js $PWD/${OBJ_FOLDER}/dist/bin
 fi
 

--- a/browser_patches/firefox/clean.sh
+++ b/browser_patches/firefox/clean.sh
@@ -3,8 +3,13 @@ set -e
 set +x
 
 trap "cd $(pwd -P)" EXIT
-cd "$(dirname $0)"
-cd "checkout"
+if [[ ! -z "${FF_CHECKOUT_PATH}" ]]; then
+  cd "${FF_CHECKOUT_PATH}"
+  echo "WARNING: checkout path from FF_CHECKOUT_PATH env: ${FF_CHECKOUT_PATH}"
+else
+  cd "$(dirname $0)"
+  cd "checkout"
+fi
 
 OBJ_FOLDER="obj-build-playwright"
 if [[ -d $OBJ_FOLDER ]]; then

--- a/browser_patches/prepare_checkout.sh
+++ b/browser_patches/prepare_checkout.sh
@@ -49,6 +49,11 @@ elif [[ ("$1" == "firefox") || ("$1" == "firefox/") || ("$1" == "ff") ]]; then
   FIREFOX_EXTRA_FOLDER_PATH="$PWD/firefox/juggler"
   BUILD_NUMBER=$(head -1 "$PWD/firefox/BUILD_NUMBER")
   source "./firefox/UPSTREAM_CONFIG.sh"
+  if [[ ! -z "${FF_CHECKOUT_PATH}" ]]; then
+    echo "WARNING: using checkout path from FF_CHECKOUT_PATH env: ${FF_CHECKOUT_PATH}"
+    CHECKOUT_PATH="${FF_CHECKOUT_PATH}"
+    FRIENDLY_CHECKOUT_PATH="<FF_CHECKOUT_PATH>"
+  fi
 elif [[ ("$1" == "webkit") || ("$1" == "webkit/") || ("$1" == "wk") ]]; then
   FRIENDLY_CHECKOUT_PATH="//browser_patches/webkit/checkout";
   CHECKOUT_PATH="$PWD/webkit/checkout"


### PR DESCRIPTION
**TL;DR:**

Firefox build fails since checkout is deeply nested and hits max arg
size on windows.

**Problem**

1. We're trying to setup a windows-based github self-hosted runner in the
  playwright-internal repo.
1. Commands on Windows are mandated to have total arguments length
  less then 32767 characters.
1. On windows, github self-hosted runner framework puts repository
checkout at `c:\w\playwright-internal\playwright-internal`
1. Our scripts create a checkout at
`c:\w\playwright-internal\playwright-internal\browser_patches\firefox\checkout`
1. One of the scripts in Firefox buildsystem tries to execute a command,
passing lots of absolute paths to various webidl's
1. The command fails due to restriction in (2)

**Solution**

This patch introduces a new variable `FF_CHECKOUT_PATH` that is
respected by all browser-related scripts. This way we'll be able
to checkout firefox to `c:\firefox` and avoid hitting long arguments
limit.