### PR TITLE
devops: suppport WK_CHECKOUT_PATH variable

### DIFF
--- a/browser_patches/export.sh
+++ b/browser_patches/export.sh
@@ -61,6 +61,11 @@ elif [[ ("$1" == "webkit") || ("$1" == "webkit/") || ("$1" == "wk") ]]; then
   EXPORT_PATH="$PWD/webkit"
   BUILD_NUMBER_UPSTREAM_URL="https://raw.githubusercontent.com/microsoft/playwright/master/browser_patches/webkit/BUILD_NUMBER"
   source "./webkit/UPSTREAM_CONFIG.sh"
+  if [[ ! -z "${WK_CHECKOUT_PATH}" ]]; then
+    echo "WARNING: using checkout path from WK_CHECKOUT_PATH env: ${WK_CHECKOUT_PATH}"
+    CHECKOUT_PATH="${WK_CHECKOUT_PATH}"
+    FRIENDLY_CHECKOUT_PATH="<WK_CHECKOUT_PATH>"
+  fi
 else
   echo ERROR: unknown browser to export - "$1"
   exit 1

--- a/browser_patches/prepare_checkout.sh
+++ b/browser_patches/prepare_checkout.sh
@@ -61,6 +61,11 @@ elif [[ ("$1" == "webkit") || ("$1" == "webkit/") || ("$1" == "wk") ]]; then
   WEBKIT_EXTRA_FOLDER_PATH="$PWD/webkit/embedder/Playwright"
   BUILD_NUMBER=$(head -1 "$PWD/webkit/BUILD_NUMBER")
   source "./webkit/UPSTREAM_CONFIG.sh"
+  if [[ ! -z "${WK_CHECKOUT_PATH}" ]]; then
+    echo "WARNING: using checkout path from WK_CHECKOUT_PATH env: ${WK_CHECKOUT_PATH}"
+    CHECKOUT_PATH="${WK_CHECKOUT_PATH}"
+    FRIENDLY_CHECKOUT_PATH="<WK_CHECKOUT_PATH>"
+  fi
 else
   echo ERROR: unknown browser - "$1"
   exit 1

--- a/browser_patches/webkit/archive.sh
+++ b/browser_patches/webkit/archive.sh
@@ -29,7 +29,12 @@ if ! [[ -d $(dirname $ZIP_PATH) ]]; then
 fi
 
 main() {
-  cd checkout
+  if [[ ! -z "${WK_CHECKOUT_PATH}" ]]; then
+    cd "${WK_CHECKOUT_PATH}"
+    echo "WARNING: checkout path from WK_CHECKOUT_PATH env: ${WK_CHECKOUT_PATH}"
+  else
+    cd "checkout"
+  fi
 
   set -x
   if [[ "$(uname)" == "Darwin" ]]; then

--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -34,11 +34,16 @@ ensure_linux_deps() {
   yes | DEBIAN_FRONTEND=noninteractive WEBKIT_JHBUILD=1 WEBKIT_JHBUILD_MODULESET=minimal WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/GTK ./Tools/Scripts/update-webkitgtk-libs
 }
 
-if [[ "$(uname)" == "Darwin" ]]; then
+if [[ ! -z "${WK_CHECKOUT_PATH}" ]]; then
+  cd "${WK_CHECKOUT_PATH}"
+  echo "WARNING: checkout path from WK_CHECKOUT_PATH env: ${WK_CHECKOUT_PATH}"
+else
   cd "checkout"
+fi
+
+if [[ "$(uname)" == "Darwin" ]]; then
   ./Tools/Scripts/build-webkit --release --touch-events --orientation-events
 elif [[ "$(uname)" == "Linux" ]]; then
-  cd "checkout"
   if [[ $# == 0 || (-z "$1") ]]; then
     echo
     echo BUILDING: GTK and WPE

--- a/browser_patches/webkit/buildwin.bat
+++ b/browser_patches/webkit/buildwin.bat
@@ -1,5 +1,5 @@
 set PATH=%WEBKIT_BUILD_PATH%
-set WEBKIT_LIBRARIES=%~dp0checkout\WebKitLibraries\win
-set WEBKIT_OUTPUTDIR=%~dp0checkout\WebKitBuild
-perl %~dp0checkout\Tools\Scripts\build-webkit --wincairo --release --no-ninja --touch-events --orientation-events --dark-mode-css --generate-project-only --cmakeargs="-DLIBVPX_PACKAGE_PATH=C:\vcpkg\packages\libvpx_x64-windows"
-%DEVENV% %~dp0checkout\WebKitBuild\Release\WebKit.sln /build "Release|x64"
+set WEBKIT_LIBRARIES=%~dp0WebKitLibraries\win
+set WEBKIT_OUTPUTDIR=%~dp0WebKitBuild
+perl %~dp0Tools\Scripts\build-webkit --wincairo --release --no-ninja --touch-events --orientation-events --dark-mode-css --generate-project-only --cmakeargs="-DLIBVPX_PACKAGE_PATH=C:\vcpkg\packages\libvpx_x64-windows"
+%DEVENV% %~dp0WebKitBuild\Release\WebKit.sln /build "Release|x64"

--- a/browser_patches/webkit/clean.sh
+++ b/browser_patches/webkit/clean.sh
@@ -4,7 +4,13 @@ set +x
 
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname $0)"
-cd "checkout"
+
+if [[ ! -z "${WK_CHECKOUT_PATH}" ]]; then
+  cd "${WK_CHECKOUT_PATH}"
+  echo "WARNING: checkout path from WK_CHECKOUT_PATH env: ${WK_CHECKOUT_PATH}"
+else
+  cd "checkout"
+fi
 
 if [[ -d ./WebKitBuild ]]; then
   rm -rf ./WebKitBuild/Release


### PR DESCRIPTION
`WK_CHECKOUT_PATH` defines location of webkit checkout on the
file system. All browser-related scripts, like `prepare_checkout.sh` and
`export.sh` respect this environment variable on all platforms.