### PR TITLE
devops: Separate base image from NodeJS image

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -33,8 +33,10 @@ jobs:
     - run: ./docs/docker/build.sh focal playwright:localbuild-focal
     - name: tag & publish
       run: |
-        ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:next
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:next-bionic
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:sha-${{ github.sha }}
+        ./docs/docker/tag_and_push.sh playwright:localbuild-bionic-base playwright.azurecr.io/public/playwright:next-bionic-base
+        ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:next
         ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:next-focal
+        ./docs/docker/tag_and_push.sh playwright:localbuild-focal-base playwright.azurecr.io/public/playwright:next-focal-base
 

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -38,19 +38,24 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 10.15
-    - run: npm ci
-    - run: npm run build
-    - run: ./docs/docker/build.sh bionic playwright:localbuild-bionic
-    - run: ./docs/docker/build.sh focal playwright:localbuild-focal
+    - run: |
+      npm ci
+      npm run build
+      ./docs/docker/build.sh bionic playwright:localbuild-bionic
+      ./docs/docker/build.sh focal playwright:localbuild-focal
     - name: tag & publish
       run: |
         # GITHUB_REF has a form of `refs/tags/v1.3.0`.
         # TAG_NAME would be `v1.3.0`
         TAG_NAME=${GITHUB_REF#refs/tags/}
-        ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:latest
+        ./docs/docker/tag_and_push.sh playwright:localbuild-bionic-base playwright.azurecr.io/public/playwright:bionic-base
+        ./docs/docker/tag_and_push.sh playwright:localbuild-focal-base playwright.azurecr.io/public/playwright:focal-base
+
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:bionic
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:${TAG_NAME}
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:${TAG_NAME}-bionic
 
+        ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:latest
         ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:focal
+        ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:${TAG_NAME}
         ./docs/docker/tag_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright:${TAG_NAME}-focal

--- a/docs/docker/Dockerfile.bionic
+++ b/docs/docker/Dockerfile.bionic
@@ -1,67 +1,11 @@
-FROM ubuntu:bionic
+FROM playwright:localbuild-bionic-base
 
-# 1. Install node14
+# Install node14
 RUN apt-get update && apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs
 
-# 2. Install WebKit dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libwoff1 \
-    libopus0 \
-    libwebp6 \
-    libwebpdemux2 \
-    libenchant1c2a \
-    libgudev-1.0-0 \
-    libsecret-1-0 \
-    libhyphen0 \
-    libgdk-pixbuf2.0-0 \
-    libegl1 \
-    libnotify4 \
-    libxslt1.1 \
-    libevent-2.1-6 \
-    libgles2 \
-    libvpx5 \
-    libxcomposite1 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libepoxy0 \
-    libgtk-3-0 \
-    libharfbuzz-icu0
-
-# 3. Install gstreamer and plugins to support video playback in WebKit.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgstreamer-gl1.0-0 \
-    libgstreamer-plugins-bad1.0-0 \
-    gstreamer1.0-plugins-good \
-    gstreamer1.0-libav
-
-# 4. Install Chromium dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libnss3 \
-    libxss1 \
-    libasound2 \
-    fonts-noto-color-emoji \
-    libxtst6
-
-# 5. Install Firefox dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libdbus-glib-1-2 \
-    libxt6
-
-# 6. Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg
-
-# 7. (Optional) Install XVFB if there's a need to run browsers in headful mode
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    xvfb
-
-# 8. Feature-parity with node.js base images.
-RUN apt-get update && apt-get install -y --no-install-recommends git ssh && \
-    npm install -g yarn
-
-# 9. Create the pwuser (we internally create a symlink for the pwuser and the root user)
+# Create the pwuser (we internally create a symlink for the pwuser and the root user)
 RUN adduser pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===

--- a/docs/docker/Dockerfile.bionic-base
+++ b/docs/docker/Dockerfile.bionic-base
@@ -1,0 +1,53 @@
+FROM ubuntu:bionic
+
+# 1. Install WebKit dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libwoff1 \
+    libopus0 \
+    libwebp6 \
+    libwebpdemux2 \
+    libenchant1c2a \
+    libgudev-1.0-0 \
+    libsecret-1-0 \
+    libhyphen0 \
+    libgdk-pixbuf2.0-0 \
+    libegl1 \
+    libnotify4 \
+    libxslt1.1 \
+    libevent-2.1-6 \
+    libgles2 \
+    libvpx5 \
+    libxcomposite1 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libepoxy0 \
+    libgtk-3-0 \
+    libharfbuzz-icu0
+
+# 2. Install gstreamer and plugins to support video playback in WebKit.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgstreamer-gl1.0-0 \
+    libgstreamer-plugins-bad1.0-0 \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-libav
+
+# 3. Install Chromium dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    fonts-noto-color-emoji \
+    libxtst6
+
+# 4. Install Firefox dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libdbus-glib-1-2 \
+    libxt6
+
+# 5. Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg
+
+# 6. (Optional) Install XVFB if there's a need to run browsers in headful mode
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xvfb

--- a/docs/docker/Dockerfile.focal
+++ b/docs/docker/Dockerfile.focal
@@ -1,66 +1,11 @@
-FROM ubuntu:focal
+FROM playwright:localbuild-focal-base
 
-# 1. Install node14
+# Install node14
 RUN apt-get update && apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs
 
-# 2. Install WebKit dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libwoff1 \
-    libopus0 \
-    libwebp6 \
-    libwebpdemux2 \
-    libenchant1c2a \
-    libgudev-1.0-0 \
-    libsecret-1-0 \
-    libhyphen0 \
-    libgdk-pixbuf2.0-0 \
-    libegl1 \
-    libnotify4 \
-    libxslt1.1 \
-    libevent-2.1-7 \
-    libgles2 \
-    libxcomposite1 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libepoxy0 \
-    libgtk-3-0 \
-    libharfbuzz-icu0
-
-# 3. Install gstreamer and plugins to support video playback in WebKit.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgstreamer-gl1.0-0 \
-    libgstreamer-plugins-bad1.0-0 \
-    gstreamer1.0-plugins-good \
-    gstreamer1.0-libav
-
-# 4. Install Chromium dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libnss3 \
-    libxss1 \
-    libasound2 \
-    fonts-noto-color-emoji \
-    libxtst6
-
-# 5. Install Firefox dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libdbus-glib-1-2 \
-    libxt6
-
-# 6. Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg
-
-# 7. (Optional) Install XVFB if there's a need to run browsers in headful mode
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    xvfb
-
-# 8. Feature-parity with node.js base images.
-RUN apt-get update && apt-get install -y --no-install-recommends git ssh && \
-    npm install -g yarn
-
-# 9. Create the pwuser (we internally create a symlink for the pwuser and the root user)
+# Create the pwuser (we internally create a symlink for the pwuser and the root user)
 RUN adduser pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===

--- a/docs/docker/Dockerfile.focal-base
+++ b/docs/docker/Dockerfile.focal-base
@@ -1,0 +1,52 @@
+FROM ubuntu:focal
+
+# 1. Install WebKit dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libwoff1 \
+    libopus0 \
+    libwebp6 \
+    libwebpdemux2 \
+    libenchant1c2a \
+    libgudev-1.0-0 \
+    libsecret-1-0 \
+    libhyphen0 \
+    libgdk-pixbuf2.0-0 \
+    libegl1 \
+    libnotify4 \
+    libxslt1.1 \
+    libevent-2.1-7 \
+    libgles2 \
+    libxcomposite1 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libepoxy0 \
+    libgtk-3-0 \
+    libharfbuzz-icu0
+
+# 2. Install gstreamer and plugins to support video playback in WebKit.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgstreamer-gl1.0-0 \
+    libgstreamer-plugins-bad1.0-0 \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-libav
+
+# 3. Install Chromium dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    fonts-noto-color-emoji \
+    libxtst6
+
+# 4. Install Firefox dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libdbus-glib-1-2 \
+    libxt6
+
+# 5. Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg
+
+# 6. (Optional) Install XVFB if there's a need to run browsers in headful mode
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xvfb

--- a/docs/docker/build.sh
+++ b/docs/docker/build.sh
@@ -26,5 +26,5 @@ cd "$(dirname "$0")"
 # We rely on `./playwright.tar.gz` to download browsers into the docker
 # image.
 node ../../packages/build_package.js playwright ./playwright.tar.gz
-
+docker build -t "$2-base" -f "Dockerfile.$1-base" .
 docker build -t "$2" -f "Dockerfile.$1" .


### PR DESCRIPTION
Details -
> - Discussion - https://github.com/microsoft/playwright-java/pull/91#discussion_r537801716 

Separating base image from NodeJS has following benefits-
- Central dependency management for browsers dependencies.
- Reduces code duplication
- Every related playwright project can build its image on top of it 
- Easier for users to build custom images .
@mxschmitt @pavelfeldman ^^