### PR TITLE
devops: extract base docker image

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -29,8 +29,12 @@ jobs:
         node-version: 10.15
     - run: npm ci
     - run: npm run build
-    - run: ./docs/docker/build.sh bionic playwright:localbuild-bionic
-    - run: ./docs/docker/build.sh focal playwright:localbuild-focal
+    - run: ./docs/docker/build.sh bionic playwright.azurecr.io/public/playwright-base:next-bionic playwright:localbuild-bionic
+    - run: ./docs/docker/build.sh focal playwright.azurecr.io/public/playwright-base:next-focal playwright:localbuild-focal
+    - name: publish base image
+      run: |
+        docker push playwright.azurecr.io/public/playwright-base:next-bionic
+        docker push playwright.azurecr.io/public/playwright-base:next-focal
     - name: tag & publish
       run: |
         ./docs/docker/tag_and_push.sh playwright:localbuild-bionic playwright.azurecr.io/public/playwright:next

--- a/docs/docker/Dockerfile.bionic
+++ b/docs/docker/Dockerfile.bionic
@@ -1,67 +1,16 @@
-FROM ubuntu:bionic
+ARG BASE_IMAGE=playwright:bionic-base
+FROM ${BASE_IMAGE}
 
 # 1. Install node14
 RUN apt-get update && apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs
 
-# 2. Install WebKit dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libwoff1 \
-    libopus0 \
-    libwebp6 \
-    libwebpdemux2 \
-    libenchant1c2a \
-    libgudev-1.0-0 \
-    libsecret-1-0 \
-    libhyphen0 \
-    libgdk-pixbuf2.0-0 \
-    libegl1 \
-    libnotify4 \
-    libxslt1.1 \
-    libevent-2.1-6 \
-    libgles2 \
-    libvpx5 \
-    libxcomposite1 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libepoxy0 \
-    libgtk-3-0 \
-    libharfbuzz-icu0
-
-# 3. Install gstreamer and plugins to support video playback in WebKit.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgstreamer-gl1.0-0 \
-    libgstreamer-plugins-bad1.0-0 \
-    gstreamer1.0-plugins-good \
-    gstreamer1.0-libav
-
-# 4. Install Chromium dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libnss3 \
-    libxss1 \
-    libasound2 \
-    fonts-noto-color-emoji \
-    libxtst6
-
-# 5. Install Firefox dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libdbus-glib-1-2 \
-    libxt6
-
-# 6. Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg
-
-# 7. (Optional) Install XVFB if there's a need to run browsers in headful mode
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    xvfb
-
-# 8. Feature-parity with node.js base images.
+# 2. Feature-parity with node.js base images.
 RUN apt-get update && apt-get install -y --no-install-recommends git ssh && \
     npm install -g yarn
 
-# 9. Create the pwuser (we internally create a symlink for the pwuser and the root user)
+# 3. Create the pwuser (we internally create a symlink for the pwuser and the root user)
 RUN adduser pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===

--- a/docs/docker/Dockerfile.bionic-base
+++ b/docs/docker/Dockerfile.bionic-base
@@ -1,0 +1,53 @@
+FROM ubuntu:bionic
+
+# 1. Install WebKit dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libwoff1 \
+    libopus0 \
+    libwebp6 \
+    libwebpdemux2 \
+    libenchant1c2a \
+    libgudev-1.0-0 \
+    libsecret-1-0 \
+    libhyphen0 \
+    libgdk-pixbuf2.0-0 \
+    libegl1 \
+    libnotify4 \
+    libxslt1.1 \
+    libevent-2.1-6 \
+    libgles2 \
+    libvpx5 \
+    libxcomposite1 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libepoxy0 \
+    libgtk-3-0 \
+    libharfbuzz-icu0
+
+# 2. Install gstreamer and plugins to support video playback in WebKit.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgstreamer-gl1.0-0 \
+    libgstreamer-plugins-bad1.0-0 \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-libav
+
+# 3. Install Chromium dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    fonts-noto-color-emoji \
+    libxtst6
+
+# 4. Install Firefox dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libdbus-glib-1-2 \
+    libxt6
+
+# 5. Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg
+
+# 6. (Optional) Install XVFB if there's a need to run browsers in headful mode
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xvfb

--- a/docs/docker/Dockerfile.focal
+++ b/docs/docker/Dockerfile.focal
@@ -1,66 +1,16 @@
-FROM ubuntu:focal
+ARG BASE_IMAGE=playwright:focal-base
+FROM ${BASE_IMAGE}
 
 # 1. Install node14
 RUN apt-get update && apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs
 
-# 2. Install WebKit dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libwoff1 \
-    libopus0 \
-    libwebp6 \
-    libwebpdemux2 \
-    libenchant1c2a \
-    libgudev-1.0-0 \
-    libsecret-1-0 \
-    libhyphen0 \
-    libgdk-pixbuf2.0-0 \
-    libegl1 \
-    libnotify4 \
-    libxslt1.1 \
-    libevent-2.1-7 \
-    libgles2 \
-    libxcomposite1 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libepoxy0 \
-    libgtk-3-0 \
-    libharfbuzz-icu0
-
-# 3. Install gstreamer and plugins to support video playback in WebKit.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgstreamer-gl1.0-0 \
-    libgstreamer-plugins-bad1.0-0 \
-    gstreamer1.0-plugins-good \
-    gstreamer1.0-libav
-
-# 4. Install Chromium dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libnss3 \
-    libxss1 \
-    libasound2 \
-    fonts-noto-color-emoji \
-    libxtst6
-
-# 5. Install Firefox dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libdbus-glib-1-2 \
-    libxt6
-
-# 6. Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg
-
-# 7. (Optional) Install XVFB if there's a need to run browsers in headful mode
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    xvfb
-
-# 8. Feature-parity with node.js base images.
+# 2. Feature-parity with node.js base images.
 RUN apt-get update && apt-get install -y --no-install-recommends git ssh && \
     npm install -g yarn
 
-# 9. Create the pwuser (we internally create a symlink for the pwuser and the root user)
+# 3. Create the pwuser (we internally create a symlink for the pwuser and the root user)
 RUN adduser pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===

--- a/docs/docker/Dockerfile.focal-base
+++ b/docs/docker/Dockerfile.focal-base
@@ -1,0 +1,52 @@
+FROM ubuntu:focal
+
+# 1. Install WebKit dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libwoff1 \
+    libopus0 \
+    libwebp6 \
+    libwebpdemux2 \
+    libenchant1c2a \
+    libgudev-1.0-0 \
+    libsecret-1-0 \
+    libhyphen0 \
+    libgdk-pixbuf2.0-0 \
+    libegl1 \
+    libnotify4 \
+    libxslt1.1 \
+    libevent-2.1-7 \
+    libgles2 \
+    libxcomposite1 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libepoxy0 \
+    libgtk-3-0 \
+    libharfbuzz-icu0
+
+# 2. Install gstreamer and plugins to support video playback in WebKit.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgstreamer-gl1.0-0 \
+    libgstreamer-plugins-bad1.0-0 \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-libav
+
+# 3. Install Chromium dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    fonts-noto-color-emoji \
+    libxtst6
+
+# 4. Install Firefox dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libdbus-glib-1-2 \
+    libxt6
+
+# 5. Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg
+
+# 6. (Optional) Install XVFB if there's a need to run browsers in headful mode
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xvfb

--- a/docs/docker/build.sh
+++ b/docs/docker/build.sh
@@ -2,19 +2,25 @@
 set -e
 set +x
 
-if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
-  echo "usage: $(basename $0) {bionic,focal} playwright:localbuild-bionic"
+if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') || ($3 == '') ]]; then
+  echo "usage: $(basename $0) {bionic,focal} playwright-base:localbuild-bionic playwright:localbuild-bionic"
   echo
-  echo "Build Playwright docker image and tag it as 'playwright:localbuild-bionic'."
+  echo "Build Playwright base nad npm docker images and tag them as "
+  echo "'playwright-base:localbuild-bionic' and 'playwright:localbuild-bionic'."
   echo "Once image is built, you can run it with"
   echo ""
-  echo "  docker run --rm -it playwright:localbuildbionic /bin/bash"
+  echo "  docker run --rm -it playwright:localbuild-bionic /bin/bash"
   echo ""
   echo "NOTE: this requires on Playwright dependencies to be installed with 'npm install'"
   echo "      and Playwright itself being built with 'npm run build'"
   echo ""
   exit 0
 fi
+
+BASE_IMAGE_LABEL=$2
+# First build the base image with browser dependencies. It is reused across
+# playwright language bindings (Java, Python etc.).
+docker build -t "$BASE_IMAGE_LABEL" -f "Dockerfile.$1-base" .
 
 function cleanup() {
   rm -f "playwright.tar.gz"
@@ -27,4 +33,4 @@ cd "$(dirname "$0")"
 # image.
 node ../../packages/build_package.js playwright ./playwright.tar.gz
 
-docker build -t "$2" -f "Dockerfile.$1" .
+docker build -t "$3" -f "Dockerfile.$1" --build-arg BASE_IMAGE="$BASE_IMAGE_LABEL" .


### PR DESCRIPTION
This was base image with browser dependencies could be reused in Dockerfiles for different language bindings without repeating the deps installation steps in each of them.