### PR TITLE
devops(windows): fix vswhere location

### DIFF
--- a/browser_patches/webkit/archive.sh
+++ b/browser_patches/webkit/archive.sh
@@ -78,7 +78,7 @@ createZipForLinux() {
 
 # see https://docs.microsoft.com/en-us/visualstudio/install/tools-for-managing-visual-studio-instances?view=vs-2019
 printMSVCRedistDir() {
-  local dll_file=$("$PROGRAMFILES\Microsoft Visual Studio\Installer\vswhere.exe" -latest -find '**\Redist\MSVC\*\x64\**\vcruntime140.dll')
+  local dll_file=$("C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -find '**\Redist\MSVC\*\x64\**\vcruntime140.dll')
   local redist_dir=$(dirname "$dll_file")
   if ! [[ -d $redist_dir ]]; then
     echo "ERROR: cannot find MS VS C++ redistributable $redist_dir"


### PR DESCRIPTION
%PROGRAMFILES% locations depends on shell bitness; we're migrating from
mingw32 to mingw64.