### PR TITLE
devops: fix webkit archiving

### DIFF
--- a/browser_patches/webkit/concat_protocol.js
+++ b/browser_patches/webkit/concat_protocol.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
-const protocolDir = path.join(__dirname, './checkout/Source/JavaScriptCore/inspector/protocol');
+const checkoutPath = process.env.WK_CHECKOUT_PATH || path.join(__dirname, 'checkout');
+const protocolDir = path.join(checkoutPath, './Source/JavaScriptCore/inspector/protocol');
 const files = fs.readdirSync(protocolDir).filter(f => f.endsWith('.json')).map(f => path.join(protocolDir, f));
 const json = files.map(file => JSON.parse(fs.readFileSync(file)));
 console.log(JSON.stringify(json));


### PR DESCRIPTION
Protocol concatenation script did not account for `WK_CHECKOUT_PATH`.