### PR TITLE
devops: add ability to skip architecture enforcement

### DIFF
--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -151,7 +151,9 @@ else
   exit 1
 fi
 
-if [[ "$CURRENT_ARCH" != "$EXPECTED_ARCH" ]]; then
+# Ability to skip arch checks since as of Dec 8, 2020 github self-hosted runner runs
+# under rosetta on Apple Silicon: https://github.com/actions/runner/issues/805
+if [[ (-n "${DO_NOT_ENFORCE_ARCH}") || ("$CURRENT_ARCH" != "$EXPECTED_ARCH") ]]; then
   echo "ERROR: cannot build $BUILD_FLAVOR"
   echo "  -- expected arch: $EXPECTED_ARCH"
   echo "  --  current arch: $CURRENT_ARCH"


### PR DESCRIPTION
Github self-hosted runners currently run under rosetta:
https://github.com/actions/runner/issues/805

This patch is an attempt to build arm webkit from-inside rosetta
shell on arm hardware.