### PR TITLE
chore: add dummy package.json's for GH dependents analysis

### DIFF
--- a/.github/dummy-package-files-for-dependents-analytics/playwright-chromium/package.json
+++ b/.github/dummy-package-files-for-dependents-analytics/playwright-chromium/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "playwright-chromium",
+    "version": "1.0.0",
+    "description": "A high-level API to automate web browsers",
+    "repository": "github:Microsoft/playwright",
+    "license": "Apache-2.0"
+}

--- a/.github/dummy-package-files-for-dependents-analytics/playwright-core/package.json
+++ b/.github/dummy-package-files-for-dependents-analytics/playwright-core/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "playwright-core",
+    "version": "1.0.0",
+    "description": "A high-level API to automate web browsers",
+    "repository": "github:Microsoft/playwright",
+    "license": "Apache-2.0"
+}

--- a/.github/dummy-package-files-for-dependents-analytics/playwright-firefox/package.json
+++ b/.github/dummy-package-files-for-dependents-analytics/playwright-firefox/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "playwright-firefox",
+    "version": "1.0.0",
+    "description": "A high-level API to automate web browsers",
+    "repository": "github:Microsoft/playwright",
+    "license": "Apache-2.0"
+}

--- a/.github/dummy-package-files-for-dependents-analytics/playwright-webkit/package.json
+++ b/.github/dummy-package-files-for-dependents-analytics/playwright-webkit/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "playwright-webkit",
+    "version": "1.0.0",
+    "description": "A high-level API to automate web browsers",
+    "repository": "github:Microsoft/playwright",
+    "license": "Apache-2.0"
+}

--- a/.github/dummy-package-files-for-dependents-analytics/playwright/package.json
+++ b/.github/dummy-package-files-for-dependents-analytics/playwright/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "playwright",
+    "version": "1.0.0",
+    "description": "A high-level API to automate web browsers",
+    "repository": "github:Microsoft/playwright",
+    "license": "Apache-2.0"
+}


### PR DESCRIPTION
Relates #4320

The support suggest something like that.

(does not close because we want to verify it works before)