### PR TITLE
fix(driver): stop sending protocol messages after disconnect

### DIFF
--- a/src/protocol/transport.ts
+++ b/src/protocol/transport.ts
@@ -47,7 +47,11 @@ export class Transport {
     this._endian = endian;
     this._closeableStream = closeable;
     pipeRead.on('data', buffer => this._dispatch(buffer));
-    pipeRead.on('close', () => this.onclose && this.onclose());
+    pipeRead.on('close', () => {
+      this._closed = true;
+      if (this.onclose)
+        this.onclose();
+    });
     this.onmessage = undefined;
     this.onclose = undefined;
   }


### PR DESCRIPTION
When the client only closes the input pipe, we are still
sending protocol messages over the output pipe. This could
probably lead to some errors, e.g. write buffer being full.