### PR TITLE
docs: rename aggregate parameter objects to params

### DIFF
--- a/docs-src/api-body.md
+++ b/docs-src/api-body.md
@@ -919,8 +919,8 @@ fires or when the script content was injected into frame.
 
 Shortcut for main frame's [frame.addScriptTag()]().
 
-### param: Page.addScriptTag.script
-- `script` <[Object]>
+### param: Page.addScriptTag.params
+- `params` <[Object]>
   - `url` <[string]> URL of a script to be added.
   - `path` <[string]> Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
   - `content` <[string]> Raw JavaScript content to be injected into frame.
@@ -934,8 +934,8 @@ content. Returns the added tag when the stylesheet's onload fires or when the CS
 
 Shortcut for main frame's [frame.addStyleTag()]().
 
-### param: Page.addStyleTag.style
-- `style` <[Object]>
+### param: Page.addStyleTag.params
+- `params` <[Object]>
   - `url` <[string]> URL of the `<link>` tag.
   - `path` <[string]> Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
   - `content` <[string]> Raw CSS content to be injected into frame.
@@ -2473,8 +2473,8 @@ Returns the added tag when the script's onload fires or when the script content 
 
 Adds a `<script>` tag into the page with the desired url or content.
 
-### param: Frame.addScriptTag.script
-- `script` <[Object]>
+### param: Frame.addScriptTag.params
+- `params` <[Object]>
   - `url` <[string]> URL of a script to be added.
   - `path` <[string]> Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
   - `content` <[string]> Raw JavaScript content to be injected into frame.
@@ -2488,8 +2488,8 @@ Returns the added tag when the stylesheet's onload fires or when the CSS content
 Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<style type="text/css">` tag with the
 content.
 
-### param: Frame.addStyleTag.style
-- `style` <[Object]>
+### param: Frame.addStyleTag.params
+- `params` <[Object]>
   - `url` <[string]> URL of the `<link>` tag.
   - `path` <[string]> Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
   - `content` <[string]> Raw CSS content to be injected into frame.

--- a/docs/api.md
+++ b/docs/api.md
@@ -856,8 +856,8 @@ page.removeListener('request', logRequest);
 - [page.$$eval(selector, pageFunction[, arg])](#pageevalselector-pagefunction-arg-1)
 - [page.accessibility](#pageaccessibility)
 - [page.addInitScript(script[, arg])](#pageaddinitscriptscript-arg)
-- [page.addScriptTag(script)](#pageaddscripttagscript)
-- [page.addStyleTag(style)](#pageaddstyletagstyle)
+- [page.addScriptTag(params)](#pageaddscripttagparams)
+- [page.addStyleTag(params)](#pageaddstyletagparams)
 - [page.bringToFront()](#pagebringtofront)
 - [page.check(selector[, options])](#pagecheckselector-options)
 - [page.click(selector[, options])](#pageclickselector-options)
@@ -1176,8 +1176,8 @@ await page.addInitScript(preloadFile);
 > **NOTE** The order of evaluation of multiple scripts installed via [browserContext.addInitScript(script[, arg])](#browsercontextaddinitscriptscript-arg) and
 [page.addInitScript(script[, arg])](#pageaddinitscriptscript-arg) is not defined.
 
-#### page.addScriptTag(script)
-- `script` <[Object]>
+#### page.addScriptTag(params)
+- `params` <[Object]>
   - `url` <[string]> URL of a script to be added.
   - `path` <[string]> Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
   - `content` <[string]> Raw JavaScript content to be injected into frame.
@@ -1187,10 +1187,10 @@ await page.addInitScript(preloadFile);
 Adds a `<script>` tag into the page with the desired url or content. Returns the added tag when the script's onload
 fires or when the script content was injected into frame.
 
-Shortcut for main frame's [frame.addScriptTag(script)](#frameaddscripttagscript).
+Shortcut for main frame's [frame.addScriptTag(params)](#frameaddscripttagparams).
 
-#### page.addStyleTag(style)
-- `style` <[Object]>
+#### page.addStyleTag(params)
+- `params` <[Object]>
   - `url` <[string]> URL of the `<link>` tag.
   - `path` <[string]> Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
   - `content` <[string]> Raw CSS content to be injected into frame.
@@ -1199,7 +1199,7 @@ Shortcut for main frame's [frame.addScriptTag(script)](#frameaddscripttagscript)
 Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<style type="text/css">` tag with the
 content. Returns the added tag when the stylesheet's onload fires or when the CSS content was injected into frame.
 
-Shortcut for main frame's [frame.addStyleTag(style)](#frameaddstyletagstyle).
+Shortcut for main frame's [frame.addStyleTag(params)](#frameaddstyletagparams).
 
 #### page.bringToFront()
 - returns: <[Promise]>
@@ -2390,8 +2390,8 @@ console.log(text);
 - [frame.$$(selector)](#frameselector-1)
 - [frame.$eval(selector, pageFunction[, arg])](#frameevalselector-pagefunction-arg)
 - [frame.$$eval(selector, pageFunction[, arg])](#frameevalselector-pagefunction-arg-1)
-- [frame.addScriptTag(script)](#frameaddscripttagscript)
-- [frame.addStyleTag(style)](#frameaddstyletagstyle)
+- [frame.addScriptTag(params)](#frameaddscripttagparams)
+- [frame.addStyleTag(params)](#frameaddstyletagparams)
 - [frame.check(selector[, options])](#framecheckselector-options)
 - [frame.childFrames()](#framechildframes)
 - [frame.click(selector[, options])](#frameclickselector-options)
@@ -2490,8 +2490,8 @@ Examples:
 const divsCounts = await frame.$$eval('div', (divs, min) => divs.length >= min, 10);
 ```
 
-#### frame.addScriptTag(script)
-- `script` <[Object]>
+#### frame.addScriptTag(params)
+- `params` <[Object]>
   - `url` <[string]> URL of a script to be added.
   - `path` <[string]> Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
   - `content` <[string]> Raw JavaScript content to be injected into frame.
@@ -2502,8 +2502,8 @@ Returns the added tag when the script's onload fires or when the script content 
 
 Adds a `<script>` tag into the page with the desired url or content.
 
-#### frame.addStyleTag(style)
-- `style` <[Object]>
+#### frame.addStyleTag(params)
+- `params` <[Object]>
   - `url` <[string]> URL of the `<link>` tag.
   - `path` <[string]> Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
   - `content` <[string]> Raw CSS content to be injected into frame.

--- a/src/client/frame.ts
+++ b/src/client/frame.ts
@@ -288,9 +288,9 @@ export class Frame extends ChannelOwner<channels.FrameChannel, channels.FrameIni
     return this._detached;
   }
 
-  async addScriptTag(script: { url?: string, path?: string, content?: string, type?: string }): Promise<ElementHandle> {
+  async addScriptTag(params: { url?: string, path?: string, content?: string, type?: string }): Promise<ElementHandle> {
     return this._wrapApiCall(this._apiName('addScriptTag'), async () => {
-      const copy = { ...script };
+      const copy = { ...params };
       if (copy.path) {
         copy.content = (await fsReadFileAsync(copy.path)).toString();
         copy.content += '//# sourceURL=' + copy.path.replace(/\n/g, '');
@@ -299,9 +299,9 @@ export class Frame extends ChannelOwner<channels.FrameChannel, channels.FrameIni
     });
   }
 
-  async addStyleTag(style: { url?: string; path?: string; content?: string; }): Promise<ElementHandle> {
+  async addStyleTag(params: { url?: string; path?: string; content?: string; }): Promise<ElementHandle> {
     return this._wrapApiCall(this._apiName('addStyleTag'), async () => {
-      const copy = { ...style };
+      const copy = { ...params };
       if (copy.path) {
         copy.content = (await fsReadFileAsync(copy.path)).toString();
         copy.content += '/*# sourceURL=' + copy.path.replace(/\n/g, '') + '*/';

--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -298,12 +298,12 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     return this._attributeToPage(() => this._mainFrame.$$(selector));
   }
 
-  async addScriptTag(script: { url?: string; path?: string; content?: string; type?: string; }): Promise<ElementHandle> {
-    return this._attributeToPage(() => this._mainFrame.addScriptTag(script));
+  async addScriptTag(params: { url?: string; path?: string; content?: string; type?: string; }): Promise<ElementHandle> {
+    return this._attributeToPage(() => this._mainFrame.addScriptTag(params));
   }
 
-  async addStyleTag(style: { url?: string; path?: string; content?: string; }): Promise<ElementHandle> {
-    return this._attributeToPage(() => this._mainFrame.addStyleTag(style));
+  async addStyleTag(params: { url?: string; path?: string; content?: string; }): Promise<ElementHandle> {
+    return this._attributeToPage(() => this._mainFrame.addStyleTag(params));
   }
 
   async exposeFunction(name: string, playwrightFunction: Function) {

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -704,7 +704,7 @@ export class Frame extends EventEmitter {
     return Array.from(this._childFrames);
   }
 
-  async addScriptTag(options: {
+  async addScriptTag(params: {
       url?: string,
       content?: string,
       type?: string,
@@ -713,7 +713,7 @@ export class Frame extends EventEmitter {
       url = null,
       content = null,
       type = ''
-    } = options;
+    } = params;
     if (!url && !content)
       throw new Error('Provide an object with a `url`, `path` or `content` property');
 
@@ -729,11 +729,11 @@ export class Frame extends EventEmitter {
       return result;
     });
 
-    async function addScriptUrl(options: { url: string, type: string }): Promise<HTMLElement> {
+    async function addScriptUrl(params: { url: string, type: string }): Promise<HTMLElement> {
       const script = document.createElement('script');
-      script.src = options.url;
-      if (options.type)
-        script.type = options.type;
+      script.src = params.url;
+      if (params.type)
+        script.type = params.type;
       const promise = new Promise((res, rej) => {
         script.onload = res;
         script.onerror = e => rej(typeof e === 'string' ? new Error(e) : new Error(`Failed to load script at ${script.src}`));
@@ -743,10 +743,10 @@ export class Frame extends EventEmitter {
       return script;
     }
 
-    function addScriptContent(options: { content: string, type: string }): HTMLElement {
+    function addScriptContent(params: { content: string, type: string }): HTMLElement {
       const script = document.createElement('script');
-      script.type = options.type || 'text/javascript';
-      script.text = options.content;
+      script.type = params.type || 'text/javascript';
+      script.text = params.content;
       let error = null;
       script.onerror = e => error = e;
       document.head.appendChild(script);
@@ -756,11 +756,11 @@ export class Frame extends EventEmitter {
     }
   }
 
-  async addStyleTag(options: { url?: string, content?: string }): Promise<dom.ElementHandle> {
+  async addStyleTag(params: { url?: string, content?: string }): Promise<dom.ElementHandle> {
     const {
       url = null,
       content = null
-    } = options;
+    } = params;
     if (!url && !content)
       throw new Error('Provide an object with a `url`, `path` or `content` property');
 


### PR DESCRIPTION
This way `addStyleTag.params` type in e.g. java will be generated as `AddStyleTagParams` rather than odd `AddStyleTagStyle`.