### PR TITLE
fix(launchdoctor): make launch doctor to warn on Win7

### DIFF
--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -50,7 +50,7 @@ function isSupportedWindowsVersion(): boolean {
   const [major, minor] = os.release().split('.').map(token => parseInt(token, 10));
   // This is based on: https://stackoverflow.com/questions/42524606/how-to-get-windows-version-using-node-js/44916050#44916050
   // The table with versions is taken from: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexw#remarks
-  // We support launch doctor on windows 7 and above, which is encoded as `6.1`.
+  // Windows 7 is not supported and is encoded as `6.1`.
   return major > 6 || (major === 6 && minor > 1);
 }
 


### PR DESCRIPTION
Windows 7 was end-of-lifed on January 14, 2020. We don't support this
system, but we'd like to have a best-effort to work there.

It does look like Chromium is missing some libraries on Win 7, however
it still manages to work there. To support this usecase, this patch
starts printing console warning about missing libraries on Win 7 only
instead of refusing to launch.

Fixes #3496