### PR TITLE
chore: add support for macOS Big Sur 11.1

### DIFF
--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -68,6 +68,7 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
         ['mac10.14', '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip'],
         ['mac10.15', '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip'],
         ['mac11.0', '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip'],
+        ['mac11.1', '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip'],
         ['win32', '%s/chromium-browser-snapshots/Win/%d/chrome-win.zip'],
         ['win64', '%s/chromium-browser-snapshots/Win_x64/%d/chrome-win.zip'],
       ]).get(platform) :
@@ -79,6 +80,8 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
         ['mac10.15', '%s/builds/chromium/%s/chromium-mac.zip'],
         ['mac11.0', '%s/builds/chromium/%s/chromium-mac.zip'],
         ['mac11.0-arm64', '%s/builds/chromium/%s/chromium-mac-arm64.zip'],
+        ['mac11.1', '%s/builds/chromium/%s/chromium-mac.zip'],
+        ['mac11.1-arm64', '%s/builds/chromium/%s/chromium-mac-arm64.zip'],
         ['win32', '%s/builds/chromium/%s/chromium-win32.zip'],
         ['win64', '%s/builds/chromium/%s/chromium-win64.zip'],
       ]).get(platform);
@@ -94,6 +97,7 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
         ['mac10.14', '%s/builds/firefox/%s/firefox-mac.zip'],
         ['mac10.15', '%s/builds/firefox/%s/firefox-mac.zip'],
         ['mac11.0', '%s/builds/firefox/%s/firefox-mac.zip'],
+        ['mac11.1', '%s/builds/firefox/%s/firefox-mac.zip'],
         ['win32', '%s/builds/firefox/%s/firefox-win32.zip'],
         ['win64', '%s/builds/firefox/%s/firefox-win64.zip'],
       ]).get(platform) :
@@ -105,6 +109,8 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
         ['mac10.15', '%s/builds/firefox/%s/firefox-mac-10.14.zip'],
         ['mac11.0', '%s/builds/firefox/%s/firefox-mac-10.14.zip'],
         ['mac11.0-arm64', '%s/builds/firefox/%s/firefox-mac-10.14.zip'],
+        ['mac11.1', '%s/builds/firefox/%s/firefox-mac-10.14.zip'],
+        ['mac11.1-arm64', '%s/builds/firefox/%s/firefox-mac-10.14.zip'],
         ['win32', '%s/builds/firefox/%s/firefox-win32.zip'],
         ['win64', '%s/builds/firefox/%s/firefox-win64.zip'],
       ]).get(platform);
@@ -120,6 +126,7 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
         ['mac10.14', '%s/builds/webkit/%s/minibrowser-mac-10.14.zip'],
         ['mac10.15', '%s/builds/webkit/%s/minibrowser-mac-10.15.zip'],
         ['mac11.0', '%s/builds/webkit/%s/minibrowser-mac-10.15.zip'],
+        ['mac11.1', '%s/builds/webkit/%s/minibrowser-mac-10.15.zip'],
         ['win32', '%s/builds/webkit/%s/minibrowser-win64.zip'],
         ['win64', '%s/builds/webkit/%s/minibrowser-win64.zip'],
       ]).get(platform) :
@@ -131,6 +138,8 @@ function getDownloadUrl(browserName: BrowserName, revision: number, platform: Br
         ['mac10.15', '%s/builds/webkit/%s/webkit-mac-10.15.zip'],
         ['mac11.0', '%s/builds/webkit/%s/webkit-mac-10.15.zip'],
         ['mac11.0-arm64', '%s/builds/webkit/%s/webkit-mac-11.0-arm64.zip'],
+        ['mac11.1', '%s/builds/webkit/%s/webkit-mac-10.15.zip'],
+        ['mac11.1-arm64', '%s/builds/webkit/%s/webkit-mac-11.0-arm64.zip'],
         ['win32', '%s/builds/webkit/%s/webkit-win64.zip'],
         ['win64', '%s/builds/webkit/%s/webkit-win64.zip'],
       ]).get(platform);

--- a/src/utils/browserPaths.ts
+++ b/src/utils/browserPaths.ts
@@ -22,7 +22,7 @@ import { getUbuntuVersionSync } from './ubuntuVersion';
 import { getFromENV } from './utils';
 
 export type BrowserName = 'chromium'|'webkit'|'firefox'|'clank';
-export type BrowserPlatform = 'win32'|'win64'|'mac10.13'|'mac10.14'|'mac10.15'|'mac11.0'|'mac11.0-arm64'|'ubuntu18.04'|'ubuntu20.04';
+export type BrowserPlatform = 'win32'|'win64'|'mac10.13'|'mac10.14'|'mac10.15'|'mac11.0'|'mac11.0-arm64'|'mac11.1'|'mac11.1-arm64'|'ubuntu18.04'|'ubuntu20.04';
 export type BrowserDescriptor = {
   name: BrowserName,
   revision: string,
@@ -88,6 +88,8 @@ export function executablePath(browserPath: string, browser: BrowserDescriptor):
       ['mac10.15', ['chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium']],
       ['mac11.0', ['chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium']],
       ['mac11.0-arm64', ['chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium']],
+      ['mac11.1', ['chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium']],
+      ['mac11.1-arm64', ['chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium']],
       ['win32', ['chrome-win', 'chrome.exe']],
       ['win64', ['chrome-win', 'chrome.exe']],
     ]).get(hostPlatform);
@@ -102,6 +104,8 @@ export function executablePath(browserPath: string, browser: BrowserDescriptor):
       ['mac10.15', ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox']],
       ['mac11.0', ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox']],
       ['mac11.0-arm64', ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox']],
+      ['mac11.1', ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox']],
+      ['mac11.1-arm64', ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox']],
       ['win32', ['firefox', 'firefox.exe']],
       ['win64', ['firefox', 'firefox.exe']],
     ]).get(hostPlatform);
@@ -116,6 +120,8 @@ export function executablePath(browserPath: string, browser: BrowserDescriptor):
       ['mac10.15', ['pw_run.sh']],
       ['mac11.0', ['pw_run.sh']],
       ['mac11.0-arm64', ['pw_run.sh']],
+      ['mac11.1', ['pw_run.sh']],
+      ['mac11.1-arm64', ['pw_run.sh']],
       ['win32', ['Playwright.exe']],
       ['win64', ['Playwright.exe']],
     ]).get(hostPlatform);


### PR DESCRIPTION
11.1 is an official update for macOS Big Sur. We should maybe add a custom macOS version parser which falls back if minor version changes so we don't have to maintain all the versions manually.

Fixes #4722

Probably also something which should get cherry-picked into the 1.7 release.