### PR TITLE
browser(webkit): install patchelf (required by generate-bundle)

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1405
-Changed: yurys@chromium.org Wed 16 Dec 2020 09:16:58 AM PST
+1406
+Changed: yurys@chromium.org Wed 16 Dec 2020 11:32:50 AM PST

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -17474,6 +17474,18 @@ index bacc141154331b79d1a3ced681c7f948988b9066..2510aeebae530265918f7bd08e114faa
 +
 +
  } // namespace WTR
+diff --git a/Tools/gtk/install-dependencies b/Tools/gtk/install-dependencies
+index 3d428cc63cc396f82e05b8794a7a1f33facd4e80..6f92d7643acbe7b347ccf15918fb2e9527509e8e 100755
+--- a/Tools/gtk/install-dependencies
++++ b/Tools/gtk/install-dependencies
+@@ -149,6 +149,7 @@ function installDependenciesWithApt {
+         libwayland-dev \
+         ninja-build \
+         patch \
++        patchelf \
+         ruby \
+         xfonts-utils"
+ 
 diff --git a/Tools/win/DLLLauncher/DLLLauncherMain.cpp b/Tools/win/DLLLauncher/DLLLauncherMain.cpp
 index 39238ac08dbcab92fb1d053928938a96f154c9b1..64bc9f1458254322dca9005b5e2d2b19bb901386 100644
 --- a/Tools/win/DLLLauncher/DLLLauncherMain.cpp
@@ -17547,3 +17559,15 @@ index c09b6f39f894943f11b7a453428fab7d6f6e68fb..bc21acb648562ee0380811599b08f7d2
  
      static cairo_user_data_key_t bufferKey;
      cairo_surface_set_user_data(m_snapshot, &bufferKey, buffer,
+diff --git a/Tools/wpe/install-dependencies b/Tools/wpe/install-dependencies
+index 4d51f0d0f9a9105ec5f9f50f6a2a86f879e41a85..d84068e9e89b6dd66e47872633b0467b68685139 100755
+--- a/Tools/wpe/install-dependencies
++++ b/Tools/wpe/install-dependencies
+@@ -90,6 +90,7 @@ function installDependenciesWithApt {
+         libxslt1-dev \
+         ninja-build \
+         patch \
++        patchelf \
+         pkg-config \
+         ruby \
+         zlib1g-dev"


### PR DESCRIPTION
https://github.com/yury-s/webkit/commit/5d405a924bbff7b5ad0c175761bf9256da406ec0

It should fix the following failure:

```bash
+ Tools/Scripts/generate-bundle --bundle=MiniBrowser --release --platform=gtk --destination=/tmp/webkit-deploy-HvDLg0YIBx
Add to bundle [bin]: <RUNNER_WORKSPACE>/playwright-internal/browser_patches/webkit/checkout/WebKitBuild/GTK/Release/bin/MiniBrowser
WARNING: patchelf not found. Not modifying rpath
Downloading setuptools-44.1.1...
Installing setuptools-44.1.1...
Installed setuptools-44.1.1!
Downloading wheel-0.35.1...
Installing wheel-0.35.1...
Installed wheel-0.35.1!
Downloading toml-0.10.1...
Installing toml-0.10.1...
Installed toml-0.10.1!
Traceback (most recent call last):
  File "Tools/Scripts/generate-bundle", line 710, in <module>
    sys.exit(main())
  File "Tools/Scripts/generate-bundle", line 700, in main
    bundle_file_path = bundle_creator.create()
  File "Tools/Scripts/generate-bundle", line 358, in create
    self._create_bundle(bundle_binary)
  File "Tools/Scripts/generate-bundle", line 517, in _create_bundle
    libraries, interpreter = self._ldd_recursive_get_libs_and_interpreter(object)
  File "Tools/Scripts/generate-bundle", line 218, in _ldd_recursive_get_libs_and_interpreter
    sub_libs, sub_interpreter = self._ldd_recursive_get_libs_and_interpreter(lib, already_checked_libs)
  File "Tools/Scripts/generate-bundle", line 218, in _ldd_recursive_get_libs_and_interpreter
    sub_libs, sub_interpreter = self._ldd_recursive_get_libs_and_interpreter(lib, already_checked_libs)
  File "Tools/Scripts/generate-bundle", line 218, in _ldd_recursive_get_libs_and_interpreter
    sub_libs, sub_interpreter = self._ldd_recursive_get_libs_and_interpreter(lib, already_checked_libs)
  [Previous line repeated 1 more time]
  File "Tools/Scripts/generate-bundle", line 211, in _ldd_recursive_get_libs_and_interpreter
    libs, interpreter = self._get_libs_and_interpreter(object)
  File "Tools/Scripts/generate-bundle", line 200, in _get_libs_and_interpreter
    interpreter_objname = self._get_interpreter_objname(object)
  File "Tools/Scripts/generate-bundle", line 164, in _get_interpreter_objname
    retcode, stdout, stderr = self._run_cmd_and_get_output(['patchelf', '--print-interpreter', object])
  File "Tools/Scripts/generate-bundle", line 155, in _run_cmd_and_get_output
    command_process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
  File "/usr/lib/python3.6/subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1364, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'patchelf': 'patchelf'
```