### PR TITLE
fix(selectors): text engine after capture matches scope

### DIFF
--- a/src/server/injected/selectorEvaluator.ts
+++ b/src/server/injected/selectorEvaluator.ts
@@ -120,8 +120,8 @@ export class SelectorEvaluatorImpl implements SelectorEvaluator {
 
   private _matchesSimple(element: Element, simple: CSSSimpleSelector, context: QueryContext): boolean {
     return this._cached<boolean>(this._cacheMatchesSimple, element, [simple, context], () => {
-      const isScopeClause = simple.functions.some(f => f.name === 'scope');
-      if (!isScopeClause && element === context.scope)
+      const isPossiblyScopeClause = simple.functions.some(f => f.name === 'scope' || f.name === 'is');
+      if (!isPossiblyScopeClause && element === context.scope)
         return false;
       if (simple.css && !this._matchesCSS(element, simple.css))
         return false;

--- a/test/selectors-css.spec.ts
+++ b/test/selectors-css.spec.ts
@@ -348,6 +348,8 @@ it('should work with :is', async ({page, server}) => {
   expect(await page.$$eval(`css=:is(div, span)`, els => els.length)).toBe(7);
   expect(await page.$$eval(`css=section:is(section) div:is(section div)`, els => els.length)).toBe(3);
   expect(await page.$$eval(`css=:is(div, span) > *`, els => els.length)).toBe(6);
+  expect(await page.$$eval(`css=#root1:has(:is(#root1))`, els => els.length)).toBe(0);
+  expect(await page.$$eval(`css=#root1:has(:is(:scope, #root1))`, els => els.length)).toBe(1);
 });
 
 it('should work with :has', async ({page, server}) => {

--- a/test/selectors-text.spec.ts
+++ b/test/selectors-text.spec.ts
@@ -227,3 +227,8 @@ it('should match root after >>', async ({page, server}) => {
   const element2 = await page.$('text=test >> text=test');
   expect(element2).toBeTruthy();
 });
+
+it('should match root after >> with *', async ({ page }) => {
+  await page.setContent(`<button> hello world </button> <button> hellow <span> world </span> </button>`);
+  expect(await page.$$eval('*css=button >> text=hello >> text=world', els => els.length)).toBe(2);
+});


### PR DESCRIPTION
This fixes a regression, where `*css=div >> "foo"` matches `<div>foo</div>`.