### PR TITLE
browser(webkit): postpone creation of the first page

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1409
-Changed: einbinder@chromium.org Wed 23 Dec 2020 08:04:33 AM PST
+1410
+Changed: dgozman@gmail.com Tue Dec 22 18:36:56 PST 2020

--- a/browser_patches/webkit/embedder/Playwright/mac/AppDelegate.m
+++ b/browser_patches/webkit/embedder/Playwright/mac/AppDelegate.m
@@ -250,8 +250,18 @@ const NSActivityOptions ActivityOptions =
     if (_noStartupWindow)
         return;
 
-    [self createNewPage:0];
-    _initialURL = nil;
+    // Force creation of the default browser context.
+    [self defaultConfiguration];
+    // Creating the first NSWindow immediately makes it invisible in headless mode,
+    // so we postpone it for 50ms. Experiments show that 10ms is not enough, and 20ms is enough.
+    // We give it 50ms just in case.
+    [NSTimer scheduledTimerWithTimeInterval: 0.05
+                                    repeats: NO
+                                      block:(void *)^(NSTimer* timer)
+    {
+        [self createNewPage:0 withURL:_initialURL ? _initialURL : @"about:blank"];
+        _initialURL = nil;
+    }];
 }
 
 - (void)_updateNewWindowKeyEquivalents
@@ -278,7 +288,11 @@ const NSActivityOptions ActivityOptions =
 
 - (WKWebView *)createNewPage:(uint64_t)sessionID
 {
-    NSString* urlString = _initialURL ? _initialURL : @"about:blank";
+    return [self createNewPage:sessionID withURL:@"about:blank"];
+}
+
+- (WKWebView *)createNewPage:(uint64_t)sessionID withURL:(NSString*)urlString
+{
     WKWebViewConfiguration *configuration = [self sessionConfiguration:sessionID];
     if (_headless)
         return [self createHeadlessPage:configuration withURL:urlString];


### PR DESCRIPTION
When we create the first page in the default context in headless mode on mac,
it gets `NSWindow` that is "not visible". Although we call `[window setIsVisible:YES]`,
later on `window.isVisible` still returns `NO`.

We create our offscreen "headless" `NSWindow` directly from `applicationDidFinishLaunching:`.
Experiments show that delaying this by 100ms makes everything work. As a symptom,
we get `applicationDidUnhide:` notification that does not happen when we create the window
immediately.

Perhaps, we create the window too early, and there is some essential initialization
that happens after `applicationDidFinishLaunching:`. However, if we call
`[NSApp activateIgnoringOtherApps:YES]` like we do in headful mode, everything works.

The only solution that worked so far is creating the first page after a timeout.