### PR TITLE
fix(webkit): properly detect arm64 on apple silicon

### DIFF
--- a/src/utils/browserPaths.ts
+++ b/src/utils/browserPaths.ts
@@ -35,7 +35,13 @@ export const hostPlatform = ((): BrowserPlatform => {
     const macVersion = execSync('sw_vers -productVersion', {
       stdio: ['ignore', 'pipe', 'ignore']
     }).toString('utf8').trim().split('.').slice(0, 2).join('.');
-    const archSuffix = os.arch() === 'arm64' ? '-arm64' : '';
+    let arm64 = false;
+    if (!macVersion.startsWith('10.')) {
+      arm64 = execSync('sysctl -in hw.optional.arm64', {
+        stdio: ['ignore', 'pipe', 'ignore']
+      }).toString().trim() === '1';  
+    }
+    const archSuffix = arm64 ? '-arm64' : '';
     return `mac${macVersion}${archSuffix}` as BrowserPlatform;
   }
   if (platform === 'linux') {

--- a/src/utils/browserPaths.ts
+++ b/src/utils/browserPaths.ts
@@ -39,7 +39,7 @@ export const hostPlatform = ((): BrowserPlatform => {
     if (!macVersion.startsWith('10.')) {
       arm64 = execSync('sysctl -in hw.optional.arm64', {
         stdio: ['ignore', 'pipe', 'ignore']
-      }).toString().trim() === '1';  
+      }).toString().trim() === '1';
     }
     const archSuffix = arm64 ? '-arm64' : '';
     return `mac${macVersion}${archSuffix}` as BrowserPlatform;


### PR DESCRIPTION
`os.arch()` returns `"x64"` on all platforms. `uname -u` returns `i386` when called from node. However `sysctl` tells us the real architecture, even if we are running under Rosetta.

Depending on how we merge this into a release, we should also bump the browser number.