### PR TITLE
chore(installer): remove stale backlinks silently

### DIFF
--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -83,8 +83,6 @@ async function validateCache(packagePath: string, browsersPath: string, linksDir
           usedBrowserPaths.add(usedBrowserPath);
       }
     } catch (e) {
-      if (linkTarget)
-        browserFetcher.logPolitely('Failed to process descriptor at ' + linkTarget);
       await fsUnlinkAsync(linkPath).catch(e => {});
     }
   }


### PR DESCRIPTION
Messages like "Failed to process descriptor at /tmp/playwright-java-8478102099289711652" are not actionable for the user and being a part of normal workflow just confuse the users.

Fixes #4283