### PR TITLE
browser(firefox): clear AuthCache when setting context proxy

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1223
-Changed: lushnikov@chromium.org Thu Dec 17 21:58:44 MST 2020
+1224
+Changed: yurys@chromium.org Mon 21 Dec 2020 03:43:57 PM PST

--- a/browser_patches/firefox/juggler/TargetRegistry.js
+++ b/browser_patches/firefox/juggler/TargetRegistry.js
@@ -593,6 +593,8 @@ class BrowserContext {
   }
 
   setProxy(proxy) {
+    // Clear AuthCache.
+    Services.obs.notifyObservers(null, "net:clear-active-logins");
     this._proxy = proxy;
   }
 


### PR DESCRIPTION
This solution is not ideal as there is still a race - credentials will be picked up from the context which is used next. If there are several contexts setting proxy to the same host but with different username/password they will mess up but if the contexts are used sequentially most recently set credentials will be picked up.

#4789