### PR TITLE
cherrypick(release-1.7): fix(webkit): properly detect arm64 on apple silicon

### DIFF
--- a/src/utils/browserPaths.ts
+++ b/src/utils/browserPaths.ts
@@ -35,7 +35,13 @@ export const hostPlatform = ((): BrowserPlatform => {
     const macVersion = execSync('sw_vers -productVersion', {
       stdio: ['ignore', 'pipe', 'ignore']
     }).toString('utf8').trim().split('.').slice(0, 2).join('.');
-    const archSuffix = os.arch() === 'arm64' ? '-arm64' : '';
+    let arm64 = false;
+    if (!macVersion.startsWith('10.')) {
+      arm64 = execSync('sysctl -in hw.optional.arm64', {
+        stdio: ['ignore', 'pipe', 'ignore']
+      }).toString().trim() === '1';
+    }
+    const archSuffix = arm64 ? '-arm64' : '';
     return `mac${macVersion}${archSuffix}` as BrowserPlatform;
   }
   if (platform === 'linux') {


### PR DESCRIPTION
PR #4783
SHA ff2a1f1bd0a6014bca5c52c8382c58ea2ffaacb1