### PR TITLE
fix: throw if quality=0 is passed for png screenshot

### DIFF
--- a/src/server/screenshotter.ts
+++ b/src/server/screenshotter.ts
@@ -205,7 +205,7 @@ function validateScreenshotOptions(options: types.ScreenshotOptions): 'png' | 'j
   if (!format)
     format = 'png';
 
-  if (options.quality) {
+  if (options.quality !== undefined) {
     assert(format === 'jpeg', 'options.quality is unsupported for the ' + format + ' screenshots');
     assert(typeof options.quality === 'number', 'Expected options.quality to be a number but found ' + (typeof options.quality));
     assert(Number.isInteger(options.quality), 'Expected options.quality to be an integer');

--- a/test/page-screenshot.spec.ts
+++ b/test/page-screenshot.spec.ts
@@ -292,6 +292,16 @@ describe('page screenshot', (suite, { browserName, headful }) => {
     expect(error.message).toContain('path: unsupported mime type "text/plain"');
   });
 
+  it.only('quality option should throw for png', async ({page}) => {
+    const error = await page.screenshot({ quality: 10 }).catch(e => e);
+    expect(error.message).toContain('options.quality is unsupported for the png');
+  });
+
+  it.only('zero quality option should throw for png', async ({page}) => {
+    const error = await page.screenshot({ quality: 0, type: 'png' }).catch(e => e);
+    expect(error.message).toContain('options.quality is unsupported for the png');
+  });
+
   it('should prefer type over extension', async ({page, testInfo}) => {
     const outputPath = testInfo.outputPath('file.png');
     const buffer = await page.screenshot({ path: outputPath, type: 'jpeg' });

--- a/test/page-screenshot.spec.ts
+++ b/test/page-screenshot.spec.ts
@@ -297,7 +297,7 @@ describe('page screenshot', (suite, { browserName, headful }) => {
     expect(error.message).toContain('options.quality is unsupported for the png');
   });
 
-  it.only('zero quality option should throw for png', async ({page}) => {
+  it('zero quality option should throw for png', async ({page}) => {
     const error = await page.screenshot({ quality: 0, type: 'png' }).catch(e => e);
     expect(error.message).toContain('options.quality is unsupported for the png');
   });

--- a/test/page-screenshot.spec.ts
+++ b/test/page-screenshot.spec.ts
@@ -292,7 +292,7 @@ describe('page screenshot', (suite, { browserName, headful }) => {
     expect(error.message).toContain('path: unsupported mime type "text/plain"');
   });
 
-  it.only('quality option should throw for png', async ({page}) => {
+  it('quality option should throw for png', async ({page}) => {
     const error = await page.screenshot({ quality: 10 }).catch(e => e);
     expect(error.message).toContain('options.quality is unsupported for the png');
   });


### PR DESCRIPTION
#4811