### PR TITLE
test: remove hacky requires, use imports instead

### DIFF
--- a/test/css-parser.spec.ts
+++ b/test/css-parser.spec.ts
@@ -15,10 +15,7 @@
  */
 
 import { it, expect } from './fixtures';
-import * as path from 'path';
-
-const { parseCSS, serializeSelector: serialize } =
-    require(path.join(__dirname, '..', 'lib', 'server', 'common', 'cssParser'));
+import { parseCSS, serializeSelector as serialize } from '../src/server/common/cssParser';
 
 const parse = (selector: string) => {
   return parseCSS(selector, new Set(['text', 'not', 'has', 'react', 'scope', 'right-of', 'scope', 'is'])).selector;

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -18,6 +18,7 @@
 import { folio, RemoteServer } from './remoteServer.fixture';
 import { execSync } from 'child_process';
 import path from 'path';
+import * as stackTrace from '../src/utils/stackTrace';
 
 type FixturesFixtures = {
   connectedRemoteServer: RemoteServer;
@@ -129,7 +130,6 @@ describe('fixtures', (suite, { platform, headful }) => {
 });
 
 it('caller file path', async ({}) => {
-  const stackTrace = require(path.join(__dirname, '..', 'lib', 'utils', 'stackTrace'));
   const callme = require('./fixtures/callback');
   const filePath = callme(() => {
     return stackTrace.getCallerFilePath(path.join(__dirname, 'fixtures') + path.sep);

--- a/test/queryselector.spec.ts
+++ b/test/queryselector.spec.ts
@@ -16,9 +16,7 @@
  */
 
 import { it, expect } from './fixtures';
-import * as path from 'path';
-
-const { selectorsV2Enabled } = require(path.join(__dirname, '..', 'lib', 'server', 'common', 'selectorParser'));
+import { selectorsV2Enabled } from '../src/server/common/selectorParser';
 
 it('should throw for non-string selector', async ({page}) => {
   const error = await page.$(null).catch(e => e);

--- a/test/selector-generator.spec.ts
+++ b/test/selector-generator.spec.ts
@@ -15,10 +15,8 @@
  */
 
 import { folio } from './fixtures';
-import * as path from 'path';
 import type { Page, Frame } from '..';
-
-const { source } = require(path.join(__dirname, '..', 'lib', 'generated', 'consoleApiSource'));
+import { source } from '../src/generated/consoleApiSource';
 
 const fixtures = folio.extend();
 fixtures.context.override(async ({ context }, run) => {

--- a/test/selectors-css.spec.ts
+++ b/test/selectors-css.spec.ts
@@ -16,9 +16,7 @@
  */
 
 import { it, expect } from './fixtures';
-import * as path from 'path';
-
-const { selectorsV2Enabled } = require(path.join(__dirname, '..', 'lib', 'server', 'common', 'selectorParser'));
+import { selectorsV2Enabled } from '../src/server/common/selectorParser';
 
 it('should work with large DOM', async ({page, server}) => {
   await page.evaluate(() => {

--- a/test/selectors-misc.spec.ts
+++ b/test/selectors-misc.spec.ts
@@ -16,9 +16,7 @@
  */
 
 import { it, expect } from './fixtures';
-import * as path from 'path';
-
-const { selectorsV2Enabled } = require(path.join(__dirname, '..', 'lib', 'server', 'common', 'selectorParser'));
+import { selectorsV2Enabled } from '../src/server/common/selectorParser';
 
 it('should work for open shadow roots', async ({page, server}) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');

--- a/test/selectors-text.spec.ts
+++ b/test/selectors-text.spec.ts
@@ -16,9 +16,7 @@
  */
 
 import { it, expect } from './fixtures';
-import * as path from 'path';
-
-const { selectorsV2Enabled } = require(path.join(__dirname, '..', 'lib', 'server', 'common', 'selectorParser'));
+import { selectorsV2Enabled } from '../src/server/common/selectorParser';
 
 it('should work', async ({page}) => {
   await page.setContent(`<div>yo</div><div>ya</div><div>\nye  </div>`);


### PR DESCRIPTION
Since our client implements our types, we can now import
implementation in tests without type conflicts.