### PR TITLE
feat: don't scare users with browser downloads

### DIFF
--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -100,12 +100,11 @@ async function validateCache(packagePath: string, browsersPath: string, linksDir
 
   // 3. Install missing browsers for this package.
   const myBrowsersToDownload = await readBrowsersToDownload(packagePath);
-  for (const browser of myBrowsersToDownload) {
-    await browserFetcher.downloadBrowserWithProgressBar(browsersPath, browser).catch(e => {
-      throw new Error(`Failed to download ${browser.name}, caused by\n${e.stack}`);
-    });
+  await browserFetcher.downloadBrowsersWithProgressBar(browsersPath, ...myBrowsersToDownload).catch(e => {
+    throw new Error(`Failed to download browser, caused by\n${e.stack}`);
+  });
+  for (const browser of myBrowsersToDownload)
     await fsWriteFileAsync(browserPaths.markerFilePath(browsersPath, browser), '');
-  }
 }
 
 async function readBrowsersToDownload(packagePath: string) {


### PR DESCRIPTION
We get a lot of requests to install playwright and only download one of the browsers. But its unclear whether users actually need to save disk space/bandwidth or just get annoyed seeing the three loading bars. I combine them into one bar and make it a little bit less intense when we download browsers.

This patch also downloads the browsers in parallel, which might speed things up significantly.