### PR TITLE
browser(webkit): call build.sh twice on Windows

### DIFF
--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -71,6 +71,10 @@ elif [[ "$(uname)" == "Linux" ]]; then
   fi
 elif [[ "$(uname)" == MINGW* ]]; then
   /c/Windows/System32/cmd.exe "/c $(cygpath -w ${SCRIPT_FOLDER}/buildwin.bat)"
+  # Run build step twice on Windows to work around adjust-angle-include-paths.py not
+  # being called at right time. See
+  # https://github.com/WebKit/WebKit/commit/e9a19fe7e3c245252be6ed70c86639d09227a6dc
+  /c/Windows/System32/cmd.exe "/c $(cygpath -w ${SCRIPT_FOLDER}/buildwin.bat)"
 else
   echo "ERROR: cannot upload on this platform!" 1>&2
   exit 1;


### PR DESCRIPTION
This is a temporary fix until the ordering issue is resolved upstream.