### PR TITLE
fix(handles): always use the proper handle dispatcher type

### DIFF
--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -176,6 +176,8 @@ export class DispatcherConnection {
     }
     try {
       const validated = this._validateParams(dispatcher._type, method, params);
+      if (typeof (dispatcher as any)[method] !== 'function')
+        throw new Error(`Mismatching dispatcher: "${dispatcher._type}" does not implement "${method}"`);
       const result = await (dispatcher as any)[method](validated, this._validateMetadata(metadata));
       this.onmessage({ id, result: this._replaceDispatchersWithGuids(result) });
     } catch (e) {

--- a/src/dispatchers/jsHandleDispatcher.ts
+++ b/src/dispatchers/jsHandleDispatcher.ts
@@ -23,6 +23,7 @@ import { parseSerializedValue, serializeValue } from '../protocol/serializers';
 export class JSHandleDispatcher extends Dispatcher<js.JSHandle, channels.JSHandleInitializer> implements channels.JSHandleChannel {
 
   constructor(scope: DispatcherScope, jsHandle: js.JSHandle) {
+    // Do not call this directly, use createHandle() instead.
     super(scope, jsHandle, jsHandle.asElement() ? 'ElementHandle' : 'JSHandle', {
       preview: jsHandle.toString(),
     });
@@ -47,7 +48,7 @@ export class JSHandleDispatcher extends Dispatcher<js.JSHandle, channels.JSHandl
     const map = await this._object.getProperties();
     const properties = [];
     for (const [name, value] of map)
-      properties.push({ name, value: new JSHandleDispatcher(this._scope, value) });
+      properties.push({ name, value: createHandle(this._scope, value) });
     return { properties };
   }
 

--- a/src/dispatchers/pageDispatcher.ts
+++ b/src/dispatchers/pageDispatcher.ts
@@ -26,7 +26,7 @@ import { DialogDispatcher } from './dialogDispatcher';
 import { DownloadDispatcher } from './downloadDispatcher';
 import { FrameDispatcher } from './frameDispatcher';
 import { RequestDispatcher, ResponseDispatcher, RouteDispatcher, WebSocketDispatcher } from './networkDispatchers';
-import { serializeResult, parseArgument, JSHandleDispatcher } from './jsHandleDispatcher';
+import { serializeResult, parseArgument } from './jsHandleDispatcher';
 import { ElementHandleDispatcher, createHandle } from './elementHandlerDispatcher';
 import { FileChooser } from '../server/fileChooser';
 import { CRCoverage } from '../server/chromium/crCoverage';
@@ -274,7 +274,7 @@ export class BindingCallDispatcher extends Dispatcher<{}, channels.BindingCallIn
       frame: lookupDispatcher<FrameDispatcher>(source.frame),
       name,
       args: needsHandle ? undefined : args.map(serializeResult),
-      handle: needsHandle ? new JSHandleDispatcher(scope, args[0] as JSHandle) : undefined,
+      handle: needsHandle ? createHandle(scope, args[0] as JSHandle) : undefined,
     });
     this._promise = new Promise((resolve, reject) => {
       this._resolve = resolve;

--- a/test/jshandle-properties.spec.ts
+++ b/test/jshandle-properties.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import { it, expect } from './fixtures';
+import type { ElementHandle } from '..';
 
 it('should work', async ({page}) => {
   const aHandle = await page.evaluateHandle(() => ({
@@ -93,4 +94,13 @@ it('getProperties should return even non-own properties', async ({page}) => {
   const properties = await aHandle.getProperties();
   expect(await properties.get('a').jsonValue()).toBe('1');
   expect(await properties.get('b').jsonValue()).toBe('2');
+});
+
+it('getProperties should work with elements', async ({page}) => {
+  await page.setContent(`<div>Hello</div>`);
+  const handle = await page.evaluateHandle(() => ({ body: document.body }));
+  const properties = await handle.getProperties();
+  const body = properties.get('body') as ElementHandle;
+  expect(body).toBeTruthy();
+  expect(await body.textContent()).toBe('Hello');
 });


### PR DESCRIPTION
Sometimes we used `JSHandleDispatcher` for `ElementHandle`s, while we should use `createHandle` to choose the proper one.

Fixes #4872.