### PR TITLE
chore: fix randomly crashing build-playwright-driver.sh

### DIFF
--- a/utils/build/build-playwright-driver.sh
+++ b/utils/build/build-playwright-driver.sh
@@ -31,7 +31,7 @@ function build {
   NPM_PATH=""
   if [[ "${ARCHIVE}" == "zip" ]]; then
     cd ./output
-    unzip ./${NODE_DIR}.zip
+    unzip -q ./${NODE_DIR}.zip
     cd ..
     cp ./output/${NODE_DIR}/node.exe ./output/playwright-${SUFFIX}/
     NPM_PATH="node_modules/npm/bin/npm-cli.js"
@@ -60,7 +60,7 @@ function build {
     echo "Unsupported RUN_DRIVER ${RUN_DRIVER}"
     exit 1
   fi
-  zip -r ../playwright-${PACKAGE_VERSION}-${SUFFIX}.zip .
+  zip -q -r ../playwright-${PACKAGE_VERSION}-${SUFFIX}.zip .
 }
 
 build "node-v12.20.1-darwin-x64" "mac" "tar.gz" "run-driver-posix.sh"

--- a/utils/build/build-playwright-driver.sh
+++ b/utils/build/build-playwright-driver.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-set +x
+set -x
 
 trap "cd $(pwd -P)" EXIT
 SCRIPT_PATH="$(cd "$(dirname "$0")" ; pwd -P)"
@@ -25,7 +25,7 @@ function build {
   cd ${SCRIPT_PATH}
 
   mkdir -p ./output/playwright-${SUFFIX}
-  tar -xzvf ./output/playwright.tgz -C ./output/playwright-${SUFFIX}/
+  tar -xzf ./output/playwright.tgz -C ./output/playwright-${SUFFIX}/
 
   curl ${NODE_URL} -o ./output/${NODE_DIR}.${ARCHIVE}
   NPM_PATH=""
@@ -36,7 +36,7 @@ function build {
     cp ./output/${NODE_DIR}/node.exe ./output/playwright-${SUFFIX}/
     NPM_PATH="node_modules/npm/bin/npm-cli.js"
   elif [[ "${ARCHIVE}" == "tar.gz" ]]; then
-    tar -xzvf ./output/${NODE_DIR}.tar.gz -C ./output/
+    tar -xzf ./output/${NODE_DIR}.tar.gz -C ./output/
     cp ./output/${NODE_DIR}/bin/node ./output/playwright-${SUFFIX}/
     NPM_PATH="lib/node_modules/npm/bin/npm-cli.js"
   else


### PR DESCRIPTION
Some googling showed that CI systems might not be capable of
handling too much STDOUT that `tar -v` produces.
([source](https://stackoverflow.com/questions/37540792/jenkins-script-tar-write-error)).

This patch:
- removes verbose flag from tar to reduce output
- sets `+x` to get some logging for the script
- silences zip output