### PR TITLE
docs: move Go port to showcase

### DIFF
--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -40,14 +40,3 @@ dotnet add package PlaywrightSharp
 
 * [Playwright on NuGet](https://www.nuget.org/packages/PlaywrightSharp/)
 * [GitHub repo](https://github.com/microsoft/playwright-sharp)
-
-## Go
-
-Playwright for Go is available in preview.
-
-```
-go get github.com/mxschmitt/playwright-go
-```
-
-* [GitHub repo](https://github.com/mxschmitt/playwright-go)
-* [Documentation](https://pkg.go.dev/github.com/mxschmitt/playwright-go?tab=doc)

--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -13,6 +13,12 @@ title: "Community Showcase"
 * [xterm.js](https://github.com/xtermjs/xterm.js): Playwright is used to run cross-browser integration tests
 * [Accessibility Insights for Web](https://github.com/microsoft/accessibility-insights-web): Playwright is used with Jest and axe-core to run end-to-end functional and accessibility tests of a WebExtension-based browser extension
 
+## Unofficial language ports
+
+* Playwright for Go
+  * [GitHub repo](https://github.com/mxschmitt/playwright-go)
+  * [Documentation](https://pkg.go.dev/github.com/mxschmitt/playwright-go?tab=doc)
+
 ## Tools
 
 * [CodeceptJS](https://github.com/Codeception/CodeceptJS): Write scenario-driven Playwright tests with synchronous code
@@ -35,15 +41,14 @@ title: "Community Showcase"
 
 * [jest-playwright](https://github.com/mmarkelov/jest-playwright): Jest preset to run Playwright tests with Jest
 * [query-selector-shadow-dom](https://github.com/Georgegriff/query-selector-shadow-dom): Custom selector engine to pierce shadow DOM roots
-* [Playwright Sharp](https://github.com/kblok/playwright-sharp): Work in progress port of Playwright to .NET
 * [playwright-fluent](https://github.com/hdorgeval/playwright-fluent): Fluent API around Playwright
 * [robotframework-browser](https://robotframework-browser.org/) Robotframework library that uses Playwright to achieve good development ergonomics.
 
 ## Examples
- 
+
 * [e2e Boilerplates](https://github.com/e2e-boilerplate?utf8=%E2%9C%93&q=playwright): Project boilerplates for using Playwright with TypeScript, Cucumber, Jest, and other libraries
 * [react-app-playwright](https://github.com/KyleADay/react-app-playwright): Using Playwright with a create-react-app project
-* [playwright-react-typescript-jest-example](https://github.com/azemetre/playwright-react-typescript-jest-example): Using Playwright + Jest with a custom webpack configuration for React + Typescript project 
+* [playwright-react-typescript-jest-example](https://github.com/azemetre/playwright-react-typescript-jest-example): Using Playwright + Jest with a custom webpack configuration for React + Typescript project
 * [playwright-mocha](https://github.com/roggerfe/playwright-mocha): Using Playwright with Mocha and Chai
 * [playwright-cljs](https://github.com/apeckham/playwright-cljs): Playwright examples in ClojureScript
 * [playwright-azure-functions](https://github.com/arjun27/playwright-azure-functions): Playwright setup on Azure Functions


### PR DESCRIPTION
playwright-go is an unofficial port, so we put it to a new section in showcase.