### PR TITLE
docs: brush up selector docs

### DIFF
--- a/docs/src/api/class-chromiumbrowser.md
+++ b/docs/src/api/class-chromiumbrowser.md
@@ -11,6 +11,30 @@ await page.goto('https://www.google.com');
 await browser.stopTracing();
 ```
 
+[ChromiumBrowser] can also be used for testing Chrome Extensions.
+
+> **NOTE** Extensions in Chrome / Chromium currently only work in non-headless mode.
+
+The following is code for getting a handle to the [background page](https://developer.chrome.com/extensions/background_pages) of an extension whose source is located in `./my-extension`:
+```js
+const { chromium } = require('playwright');
+
+(async () => {
+  const pathToExtension = require('path').join(__dirname, 'my-extension');
+  const userDataDir = '/tmp/test-user-data-dir';
+  const browserContext = await chromium.launchPersistentContext(userDataDir,{
+    headless: false,
+    args: [
+      `--disable-extensions-except=${pathToExtension}`,
+      `--load-extension=${pathToExtension}`
+    ]
+  });
+  const backgroundPage = browserContext.backgroundPages()[0];
+  // Test the background page as you would any other page.
+  await browserContext.close();
+})();
+```
+
 ## async method: ChromiumBrowser.newBrowserCDPSession
 - returns: <[CDPSession]>
 

--- a/docs/src/selectors.md
+++ b/docs/src/selectors.md
@@ -13,7 +13,7 @@ Selector describes an element in the page. It can be used to obtain `ElementHand
 
 Selector has the following format: `engine=body [>> engine=body]*`. Here `engine` is one of the supported [selector engines](./selectors.md) (e.g. `css` or `xpath`), and `body` is a selector body in the format of the particular engine. When multiple `engine=body` clauses are present (separated by `>>`), next one is queried relative to the previous one's result.
 
-Playwright supports various engines:
+Playwright supports various selector engines:
   * [Text] selectors, for example `text="Log in"`
   * [CSS] selectors, including the following extensions:
     - [Shadow piercing](#shadow-piercing) by default and [`:light`](#css-extension-light) pseudo-class

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6651,6 +6651,33 @@ export interface BrowserType<Browser> {
  * await browser.stopTracing();
  * ```
  * 
+ * [ChromiumBrowser] can also be used for testing Chrome Extensions.
+ * 
+ * > **NOTE** Extensions in Chrome / Chromium currently only work in non-headless mode.
+ * 
+ * The following is code for getting a handle to the
+ * [background page](https://developer.chrome.com/extensions/background_pages) of an extension whose source is located in
+ * `./my-extension`:
+ * 
+ * ```js
+ * const { chromium } = require('playwright');
+ * 
+ * (async () => {
+ *   const pathToExtension = require('path').join(__dirname, 'my-extension');
+ *   const userDataDir = '/tmp/test-user-data-dir';
+ *   const browserContext = await chromium.launchPersistentContext(userDataDir,{
+ *     headless: false,
+ *     args: [
+ *       `--disable-extensions-except=${pathToExtension}`,
+ *       `--load-extension=${pathToExtension}`
+ *     ]
+ *   });
+ *   const backgroundPage = browserContext.backgroundPages()[0];
+ *   // Test the background page as you would any other page.
+ *   await browserContext.close();
+ * })();
+ * ```
+ * 
  */
 export interface ChromiumBrowser extends Browser {
   /**


### PR DESCRIPTION
- Remove duplication
- Move extensions block to ChromiumBrowser
- Remove accidental ":xpath" extension from css selectors
- Document :has and :is extensions