### PR TITLE
feat(cli): small improvements

### DIFF
--- a/packages/installation-tests/installation-tests.sh
+++ b/packages/installation-tests/installation-tests.sh
@@ -361,14 +361,38 @@ function test_playwright_cli_install_should_work {
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_TGZ}
 
   local BROWSERS="$(pwd -P)/browsers"
-  echo "Running playwright install"
-  PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npx playwright install
-  if [[ ! -d "${BROWSERS}" ]]; then
-    echo "Directory for shared browsers was not created!"
+
+  echo "Running playwright install chromium"
+  OUTPUT=$(PLAYWRIGHT_BROWSERS_PATH=${BROWSERS} npx playwright install chromium)
+  if [[ "${OUTPUT}" != *"chromium"* ]]; then
+    echo "ERROR: should download chromium"
     exit 1
   fi
-  copy_test_scripts
+  if [[ "${OUTPUT}" == *"webkit"* ]]; then
+    echo "ERROR: should not download webkit"
+    exit 1
+  fi
+  if [[ "${OUTPUT}" == *"firefox"* ]]; then
+    echo "ERROR: should not download firefox"
+    exit 1
+  fi
 
+  echo "Running playwright install"
+  OUTPUT=$(PLAYWRIGHT_BROWSERS_PATH=${BROWSERS} npx playwright install)
+  if [[ "${OUTPUT}" == *"chromium"* ]]; then
+    echo "ERROR: should not download chromium"
+    exit 1
+  fi
+  if [[ "${OUTPUT}" != *"webkit"* ]]; then
+    echo "ERROR: should download webkit"
+    exit 1
+  fi
+  if [[ "${OUTPUT}" != *"firefox"* ]]; then
+    echo "ERROR: should download firefox"
+    exit 1
+  fi
+
+  copy_test_scripts
   echo "Running sanity.js"
   node sanity.js playwright none
   PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" node sanity.js playwright

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -36,6 +36,7 @@ import * as playwright from '../..';
 
 program
     .version('Version ' + require('../../package.json').version)
+    .name('npx playwright')
     .option('-b, --browser <browserType>', 'browser to use, one of cr, chromium, ff, firefox, wk, webkit', 'chromium')
     .option('--color-scheme <scheme>', 'emulate preferred color scheme, "light" or "dark"')
     .option('--device <deviceName>', 'emulate device, for example  "iPhone 11"')
@@ -128,10 +129,10 @@ program
     });
 
 program
-    .command('install')
+    .command('install [browserType...]')
     .description('Ensure browsers necessary for this version of Playwright are installed')
-    .action(function() {
-      installBrowsers().catch((e: any) => {
+    .action(function(browserType) {
+      installBrowsers(browserType.length ? browserType : undefined).catch((e: any) => {
         console.log(`Failed to install browsers\n${e}`);
         process.exit(1);
       });

--- a/src/cli/driver.ts
+++ b/src/cli/driver.ts
@@ -27,6 +27,7 @@ import { Playwright } from '../server/playwright';
 import { gracefullyCloseAll } from '../server/processLauncher';
 import { installHarTracer } from '../trace/harTracer';
 import { installTracer } from '../trace/tracer';
+import { BrowserName } from '../utils/browserPaths';
 
 export function printApiJson() {
   console.log(JSON.stringify(require('../../api.json')));
@@ -59,12 +60,12 @@ export function runServer() {
   new PlaywrightDispatcher(dispatcherConnection.rootDispatcher(), playwright);
 }
 
-export async function installBrowsers() {
+export async function installBrowsers(browserNames?: BrowserName[]) {
   let browsersJsonDir = path.dirname(process.execPath);
   if (!fs.existsSync(path.join(browsersJsonDir, 'browsers.json'))) {
     browsersJsonDir = path.join(__dirname, '..', '..');
     if (!fs.existsSync(path.join(browsersJsonDir, 'browsers.json')))
       throw new Error('Failed to find browsers.json in ' + browsersJsonDir);
   }
-  await installBrowsersWithProgressBar(browsersJsonDir);
+  await installBrowsersWithProgressBar(browsersJsonDir, browserNames);
 }

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -32,7 +32,7 @@ const fsUnlinkAsync = util.promisify(fs.unlink.bind(fs));
 const fsWriteFileAsync = util.promisify(fs.writeFile.bind(fs));
 const removeFolderAsync = util.promisify(removeFolder);
 
-export async function installBrowsersWithProgressBar(packagePath: string) {
+export async function installBrowsersWithProgressBar(packagePath: string, browserNames?: browserPaths.BrowserName[]) {
   // PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD should have a value of 0 or 1
   if (getAsBooleanFromENV('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD')) {
     browserFetcher.logPolitely('Skipping browsers download because `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` env variable is set');
@@ -59,11 +59,11 @@ export async function installBrowsersWithProgressBar(packagePath: string) {
 
   await fsMkdirAsync(linksDir,  { recursive: true });
   await fsWriteFileAsync(path.join(linksDir, sha1(packagePath)), packagePath);
-  await validateCache(packagePath, browsersPath, linksDir);
+  await validateCache(packagePath, browsersPath, linksDir, browserNames);
   await releaseLock();
 }
 
-async function validateCache(packagePath: string, browsersPath: string, linksDir: string) {
+async function validateCache(packagePath: string, browsersPath: string, linksDir: string, browserNames?: browserPaths.BrowserName[]) {
   // 1. Collect used downloads and package descriptors.
   const usedBrowserPaths: Set<string> = new Set();
   for (const fileName of await fsReaddirAsync(linksDir)) {
@@ -99,7 +99,7 @@ async function validateCache(packagePath: string, browsersPath: string, linksDir
   }
 
   // 3. Install missing browsers for this package.
-  const myBrowsersToDownload = await readBrowsersToDownload(packagePath);
+  const myBrowsersToDownload = await readBrowsersToDownload(packagePath, browserNames);
   for (const browser of myBrowsersToDownload) {
     await browserFetcher.downloadBrowserWithProgressBar(browsersPath, browser).catch(e => {
       throw new Error(`Failed to download ${browser.name}, caused by\n${e.stack}`);
@@ -108,11 +108,13 @@ async function validateCache(packagePath: string, browsersPath: string, linksDir
   }
 }
 
-async function readBrowsersToDownload(packagePath: string) {
+async function readBrowsersToDownload(packagePath: string, browserNames?: browserPaths.BrowserName[]) {
   const browsers = JSON.parse((await fsReadFileAsync(path.join(packagePath, 'browsers.json'))).toString())['browsers'] as browserPaths.BrowserDescriptor[];
   // Older versions do not have "download" field. We assume they need all browsers
   // from the list. So we want to skip all browsers that are explicitly marked as "download: false".
-  return browsers.filter(browser => browser.download !== false);
+  return browsers.filter(browser => {
+    return browserNames ? browserNames.includes(browser.name) : browser.download !== false;
+  });
 }
 
 function sha1(data: string): string {


### PR DESCRIPTION
- Allow specifying which browsers to install. This comes handy in playwright-cli.
- Print "npx playwright" as a tool name in help messages, instead of "cli".