### PR TITLE
fix: Fixing network request title in Trace Viewer.

### DIFF
--- a/src/cli/traceViewer/web/ui/networkTab.tsx
+++ b/src/cli/traceViewer/web/ui/networkTab.tsx
@@ -29,7 +29,7 @@ export const NetworkTab: React.FunctionComponent<{
         className={'network-request ' + (index === selected ? 'selected' : '')}
         onClick={() => setSelected(index)}>
         <Expandable style={{ width: '100%' }} title={
-          <div className='network-request-title'><div>resource.url</div></div>
+          <div className='network-request-title'><div>{resource.url}</div></div>
         } body={
           <div className='network-request-details'>{resource.responseHeaders.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
         }/>


### PR DESCRIPTION
This commit is fixing the way network request title is displayed in the Trace Viewer. Previously this value was hardcoded to string "resource.url". This commit is changing it to display the actual underlying value of the resource.url property.