### PR TITLE
fix(trace viewer): updating default traceStorageDir value

### DIFF
--- a/src/cli/traceViewer/traceViewer.ts
+++ b/src/cli/traceViewer/traceViewer.ts
@@ -142,6 +142,10 @@ export async function showTraceViewer(traceStorageDir: string | undefined, trace
     files = [tracePath];
     if (!traceStorageDir)
       traceStorageDir = path.dirname(tracePath);
+
+      if(fs.existsSync(traceStorageDir + '/trace-resources')) {
+        traceStorageDir = traceStorageDir + '/trace-resources';
+      }
   } else {
     files = collectFiles(tracePath);
     if (!traceStorageDir)

--- a/src/cli/traceViewer/traceViewer.ts
+++ b/src/cli/traceViewer/traceViewer.ts
@@ -140,12 +140,12 @@ export async function showTraceViewer(traceStorageDir: string | undefined, trace
   let files: string[];
   if (fs.statSync(tracePath).isFile()) {
     files = [tracePath];
-    if (!traceStorageDir)
+    if (!traceStorageDir) {
       traceStorageDir = path.dirname(tracePath);
 
-      if(fs.existsSync(traceStorageDir + '/trace-resources')) {
+      if (fs.existsSync(traceStorageDir + '/trace-resources'))
         traceStorageDir = traceStorageDir + '/trace-resources';
-      }
+    }
   } else {
     files = collectFiles(tracePath);
     if (!traceStorageDir)

--- a/src/cli/traceViewer/traceViewer.ts
+++ b/src/cli/traceViewer/traceViewer.ts
@@ -137,19 +137,13 @@ export async function showTraceViewer(traceStorageDir: string | undefined, trace
   if (!fs.existsSync(tracePath))
     throw new Error(`${tracePath} does not exist`);
 
-  let files: string[];
-  if (fs.statSync(tracePath).isFile()) {
-    files = [tracePath];
-    if (!traceStorageDir) {
-      traceStorageDir = path.dirname(tracePath);
+  const files: string[] = fs.statSync(tracePath).isFile() ? [tracePath] : collectFiles(tracePath);
 
-      if (fs.existsSync(traceStorageDir + '/trace-resources'))
-        traceStorageDir = traceStorageDir + '/trace-resources';
-    }
-  } else {
-    files = collectFiles(tracePath);
-    if (!traceStorageDir)
-      traceStorageDir = tracePath;
+  if (!traceStorageDir) {
+    traceStorageDir = fs.statSync(tracePath).isFile() ? path.dirname(tracePath) : tracePath;
+
+    if (fs.existsSync(traceStorageDir + '/trace-resources'))
+      traceStorageDir = traceStorageDir + '/trace-resources';
   }
 
   const traceViewer = new TraceViewer(traceStorageDir);


### PR DESCRIPTION
When `npx playwright show-trace <tracePath>` command is executed, without providing the `resources` optional parameter, the function expects the `traceStorageDir` default value to be the same directory in which the `tracePath` resides. This change updates it to the `dirname(tracePath)/trace-resources` if it exists. Such directory hierarchy is created by Tracer by default.