### PR TITLE
fix(driver): use ncc to reduce the number of files

### DIFF
--- a/packages/common/.npmignore
+++ b/packages/common/.npmignore
@@ -8,6 +8,8 @@
 
 # Include sources from lib, but not map files.
 !lib/**/*.js
+!lib/**/*.html
+!lib/**/*.ttf
 # Exclude injected files. A preprocessed version of these is included via lib/generated.
 # See src/server/injected/README.md.
 lib/server/injected/

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -11,6 +11,16 @@ module.exports = {
      */
     "rules": {
         "no-console": [2, { "allow": ["warn", "error", "assert", "timeStamp", "time", "timeEnd"] }],
-        "no-debugger": 0
-    }
+        "no-debugger": 0,
+        "no-undef": 2,
+    },
+    "env": {
+      "browser": true,
+      "node": true,
+      "es2021": true,
+    },
+    "globals": {
+      "__filename": "off",
+      "__dirname": "off",
+    },
 };

--- a/src/cli/driver.ts
+++ b/src/cli/driver.ts
@@ -28,13 +28,14 @@ import { gracefullyCloseAll } from '../server/processLauncher';
 import { installHarTracer } from '../trace/harTracer';
 import { installTracer } from '../trace/tracer';
 import { BrowserName } from '../utils/browserPaths';
+import { packageRoot } from '../utils/utils';
 
 export function printApiJson() {
-  console.log(JSON.stringify(require('../../api.json')));
+  console.log(fs.readFileSync(path.join(packageRoot(), 'api.json'), 'utf8'));
 }
 
 export function printProtocol() {
-  console.log(fs.readFileSync(path.join(__dirname, '..', '..', 'protocol.yml'), 'utf8'));
+  console.log(fs.readFileSync(path.join(packageRoot(), 'protocol.yml'), 'utf8'));
 }
 
 export function runServer() {
@@ -56,14 +57,14 @@ export function runServer() {
     process.exit(0);
   };
 
-  const playwright = new Playwright(__dirname, require('../../browsers.json')['browsers']);
+  const playwright = new Playwright();
   new PlaywrightDispatcher(dispatcherConnection.rootDispatcher(), playwright);
 }
 
 export async function installBrowsers(browserNames?: BrowserName[]) {
   let browsersJsonDir = path.dirname(process.execPath);
   if (!fs.existsSync(path.join(browsersJsonDir, 'browsers.json'))) {
-    browsersJsonDir = path.join(__dirname, '..', '..');
+    browsersJsonDir = packageRoot();
     if (!fs.existsSync(path.join(browsersJsonDir, 'browsers.json')))
       throw new Error('Failed to find browsers.json in ' + browsersJsonDir);
   }

--- a/src/cli/traceViewer/traceViewer.ts
+++ b/src/cli/traceViewer/traceViewer.ts
@@ -23,6 +23,7 @@ import { SnapshotRouter } from './snapshotRouter';
 import { readTraceFile, TraceModel } from './traceModel';
 import type { ActionTraceEvent, PageSnapshot, TraceEvent } from '../../trace/traceTypes';
 import { VideoTileGenerator } from './videoTileGenerator';
+import { packageRoot } from '../../utils/utils';
 
 const fsReadFileAsync = util.promisify(fs.readFile.bind(fs));
 
@@ -110,14 +111,13 @@ class TraceViewer {
           });
           return;
         }
-        let filePath: string;
+        let body: Buffer;
         if (request.url().includes('video-tile')) {
           const fullPath = url.pathname.substring('/video-tile/'.length);
-          filePath = this._videoTileGenerator.tilePath(fullPath);
+          body = fs.readFileSync(this._videoTileGenerator.tilePath(fullPath));
         } else {
-          filePath = path.join(__dirname, 'web', url.pathname.substring(1));
+          body = fs.readFileSync(path.join(packageRoot(), 'lib', 'cli', 'traceViewer', 'web', url.pathname.substring(1)));
         }
-        const body = fs.readFileSync(filePath);
         route.fulfill({
           contentType: extensionToMime[path.extname(url.pathname).substring(1)] || 'text/plain',
           body,

--- a/src/inprocess.ts
+++ b/src/inprocess.ts
@@ -23,10 +23,9 @@ import { BrowserServerLauncherImpl } from './browserServerImpl';
 import { installDebugController } from './debug/debugController';
 import { installTracer } from './trace/tracer';
 import { installHarTracer } from './trace/harTracer';
-import * as path from 'path';
 
 function setupInProcess(): PlaywrightAPI {
-  const playwright = new PlaywrightImpl(path.join(__dirname, '..'), require('../browsers.json')['browsers']);
+  const playwright = new PlaywrightImpl();
 
   installDebugController();
   installTracer();

--- a/src/remote/playwrightServer.ts
+++ b/src/remote/playwrightServer.ts
@@ -62,7 +62,7 @@ export class PlaywrightServer {
         this._onDisconnect();
       });
       dispatcherConnection.onmessage = message => ws.send(JSON.stringify(message));
-      const playwright = new Playwright(__dirname, require('../../browsers.json')['browsers']);
+      const playwright = new Playwright();
       new PlaywrightDispatcher(dispatcherConnection.rootDispatcher(), playwright);
     });
   }

--- a/src/server/playwright.ts
+++ b/src/server/playwright.ts
@@ -15,6 +15,9 @@
  */
 
 import * as browserPaths from '../utils/browserPaths';
+import * as fs from 'fs';
+import * as path from 'path';
+import { packageRoot } from '../utils/utils';
 import { Android } from './android/android';
 import { AdbBackend } from './android/backendAdb';
 import { Chromium } from './chromium/chromium';
@@ -31,7 +34,10 @@ export class Playwright {
   readonly firefox: Firefox;
   readonly webkit: WebKit;
 
-  constructor(packagePath: string, browsers: browserPaths.BrowserDescriptor[]) {
+  constructor() {
+    const packagePath = packageRoot();
+    const browsers = JSON.parse(fs.readFileSync(path.join(packageRoot(), 'browsers.json'), 'utf8')).browsers as browserPaths.BrowserDescriptor[];
+
     const chromium = browsers.find(browser => browser.name === 'chromium');
     this.chromium = new Chromium(packagePath, chromium!);
 

--- a/src/utils/binaryPaths.ts
+++ b/src/utils/binaryPaths.ts
@@ -17,6 +17,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { packageRoot } from './utils';
 
 export function printDepsWindowsExecutable(): string | undefined {
   return pathToExecutable(['bin', 'PrintDeps.exe']);
@@ -34,17 +35,10 @@ export function ffmpegExecutable(): string | undefined {
 }
 
 function pathToExecutable(relative: string[]): string | undefined {
-  const defaultPath = path.join(__dirname, '..', '..', ...relative);
-  const localPath = path.join(path.dirname(process.argv[0]), relative[relative.length - 1]);
   try {
-    if (fs.existsSync(defaultPath))
-      return defaultPath;
-  } catch (e) {
-  }
-
-  try {
-    if (fs.existsSync(localPath))
-      return localPath;
+    const executbalePath = path.join(packageRoot(), ...relative);
+    if (fs.existsSync(executbalePath))
+      return executbalePath;
   } catch (e) {
   }
 }

--- a/src/utils/stackTrace.ts
+++ b/src/utils/stackTrace.ts
@@ -15,9 +15,7 @@
  */
 
 import * as path from 'path';
-
-// NOTE: update this to point to playwright/lib when moving this file.
-const PLAYWRIGHT_LIB_PATH = path.normalize(path.join(__dirname, '..'));
+import { packageRoot } from './utils';
 
 type ParsedStackFrame = { filePath: string, functionName: string };
 
@@ -45,7 +43,7 @@ function parseStackFrame(frame: string): ParsedStackFrame | null {
   return { filePath, functionName };
 }
 
-export function getCallerFilePath(ignorePrefix = PLAYWRIGHT_LIB_PATH): string | null {
+export function getCallerFilePath(ignorePrefix = path.join(packageRoot(), 'lib')): string | null {
   const error = new Error();
   const stackFrames = (error.stack || '').split('\n').slice(2);
   // Find first stackframe that doesn't point to ignorePrefix.

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -145,3 +145,10 @@ export function calculateSha1(buffer: Buffer): string {
 export function createGuid(): string {
   return crypto.randomBytes(16).toString('hex');
 }
+
+// This is set by minified driver that messes up with directory structure.
+const packageRootEnv = getFromENV('_PW_PACKAGE_ROOT');
+export function packageRoot(): string {
+  // Note: this should be the only place referencing __dirname. Do not add similar exceptions.
+  return packageRootEnv || path.join(__dirname, '..', '..');  // eslint-disable-line no-undef
+}

--- a/utils/build/run-driver-posix.sh
+++ b/utils/build/run-driver-posix.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 SCRIPT_PATH="$(cd "$(dirname "$0")" ; pwd -P)"
-$SCRIPT_PATH/node $SCRIPT_PATH/package/lib/cli/cli.js "$@"
+_PW_PACKAGE_ROOT=$SCRIPT_PATH/package $SCRIPT_PATH/node $SCRIPT_PATH/package/lib/cli/cli.js "$@"

--- a/utils/build/run-driver-win.cmd
+++ b/utils/build/run-driver-win.cmd
@@ -1,3 +1,4 @@
 @ECHO OFF
 SETLOCAL
+SET _PW_PACKAGE_ROOT="%~dp0\package"
 "%~dp0\node.exe" "%~dp0\package\lib\cli\cli.js" %*


### PR DESCRIPTION
Instead of zipping the whole node_modules directory, use `ncc`
(uses `webpack` internally) to produce a single bundle that is
put to `lib/cli/cli.js`.

For `__dirname`-based file resolution to work:
- introduce `packageRoot()` utility function;
- disallow `__dirname` usage across the `src`.