### PR TITLE
docs: fix inline code quoting

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -437,7 +437,7 @@ Defaults to `false`.
 
 This method waits for [actionability](./actionability.md) checks, then tries to scroll element into view, unless it is
 completely visible as defined by
-[IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)'s ```ratio```.
+[IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)'s `ratio`.
 
 Throws when `elementHandle` does not point to an element
 [connected](https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected) to a Document or a ShadowRoot.

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6009,7 +6009,7 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
   /**
    * This method waits for [actionability](https://github.com/microsoft/playwright/blob/master/docs/actionability.md) checks, then tries to scroll element into view, unless it is
    * completely visible as defined by
-   * [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)'s ```ratio```.
+   * [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)'s `ratio`.
    * 
    * Throws when `elementHandle` does not point to an element
    * [connected](https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected) to a Document or a ShadowRoot.


### PR DESCRIPTION
This is the only place in code where we use triple ticks to mark inline code snippet and it breaks javadoc gen.