### PR TITLE
devops: fix azure function bugs

### DIFF
--- a/utils/flakiness-dashboard/processing/dashboard_raw.js
+++ b/utils/flakiness-dashboard/processing/dashboard_raw.js
@@ -28,7 +28,6 @@ async function processDashboardRaw(context, report) {
     SHA: ${report.metadata.commitSHA}
     URL: ${report.metadata.runURL}
     timestamp: ${report.metadata.commitTimestamp}
-    added specs: ${addedSpecs}
   ===== complete in ${Date.now() - timestamp}ms =====
   `);
 }

--- a/utils/flakiness-dashboard/processing/index.js
+++ b/utils/flakiness-dashboard/processing/index.js
@@ -27,10 +27,9 @@ module.exports = async function(context) {
   const data = await gunzipAsync(context.bindings.newBlob);
   const report = JSON.parse(data.toString('utf8'));
 
-  // Upload report to both dashboards.
-  await Promise.all([
-    processDashboardV1(context, report),
-    processDashboardV2(context, report),
-    processDashboardRaw(context, report),
-  ]);
+  // Process dashboards one-by-one to limit max heap utilization.
+  await processDashboardRaw(context, report);
+  await processDashboardV1(context, report);
+  // Disable V2 dashboard in favor of raw data.
+  // await processDashboardV2(context, report);
 }


### PR DESCRIPTION
This patch:
- starts processing dashboards serially to avoid hitting node.js azure
  function heap limit
- fixes typo in the new `dashboards_raw` processor