### PR TITLE
chore: disable v1 flakiness dashboard

### DIFF
--- a/utils/flakiness-dashboard/processing/index.js
+++ b/utils/flakiness-dashboard/processing/index.js
@@ -29,7 +29,8 @@ module.exports = async function(context) {
 
   // Process dashboards one-by-one to limit max heap utilization.
   await processDashboardRaw(context, report);
-  await processDashboardV1(context, report);
+  // Disable V1 dashboard since it's crazy expensive to compute.
+  // await processDashboardV1(context, report);
   // Disable V2 dashboard in favor of raw data.
   // await processDashboardV2(context, report);
 }


### PR DESCRIPTION
Computing V1 flakiness dashboard was very expensive (>1 minute for AZ
function to run).

Disable it now in favor of V2 flakiness dashboard that proves to be very
reliable.