### PR TITLE
fix(dom): make selectOption wait for options

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -545,6 +545,8 @@ Returns the array of option values that have been successfully selected.
 Triggers a `change` and `input` event once all the provided options have been selected. If element is not a `<select>`
 element, the method throws an error.
 
+Will wait until all specified options are present in the `<select>` element.
+
 ```js
 // single selection matching the value
 handle.selectOption('blue');

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -842,6 +842,8 @@ Returns the array of option values that have been successfully selected.
 Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element
 matching [`param: selector`], the method throws an error.
 
+Will wait until all specified options are present in the `<select>` element.
+
 ```js
 // single selection matching the value
 frame.selectOption('select#colors', 'blue');

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1869,6 +1869,8 @@ Returns the array of option values that have been successfully selected.
 Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element
 matching [`param: selector`], the method throws an error.
 
+Will wait until all specified options are present in the `<select>` element.
+
 ```js
 // single selection matching the value
 page.selectOption('select#colors', 'blue');

--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -446,7 +446,8 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const selectOptions = [...elements, ...values];
     return this._page._frameManager.waitForSignalsCreatedBy(progress, options.noWaitAfter, async () => {
       progress.throwIfAborted();  // Avoid action that has side-effects.
-      const value = await this._evaluateInUtility(([injected, node, selectOptions]) => injected.selectOptions(node, selectOptions), selectOptions);
+      progress.log('  selecting specified option(s)');
+      const value = await this._evaluateInUtility(([injected, node, selectOptions]) => injected.waitForOptionsAndSelect(node, selectOptions), selectOptions);
       await this._page._doSlowMo();
       return throwFatalDOMError(value);
     });

--- a/src/server/injected/injectedScript.ts
+++ b/src/server/injected/injectedScript.ts
@@ -312,7 +312,7 @@ export class InjectedScript {
       }
       select.value = undefined as any;
       selectedOptions.forEach(option => option.selected = true);
-      progress.log('    selected soecified option(s)');
+      progress.log('    selected specified option(s)');
       select.dispatchEvent(new Event('input', { 'bubbles': true }));
       select.dispatchEvent(new Event('change', { 'bubbles': true }));
       return selectedOptions.map(option => option.value);

--- a/src/server/injected/injectedScript.ts
+++ b/src/server/injected/injectedScript.ts
@@ -267,35 +267,52 @@ export class InjectedScript {
     return { left: parseInt(style.borderLeftWidth || '', 10), top: parseInt(style.borderTopWidth || '', 10) };
   }
 
-  selectOptions(node: Node, optionsToSelect: (Node | { value?: string, label?: string, index?: number })[]): string[] | 'error:notconnected' | FatalDOMError {
-    const element = this.findLabelTarget(node as Element);
-    if (!element || !element.isConnected)
-      return 'error:notconnected';
-    if (element.nodeName.toLowerCase() !== 'select')
-      return 'error:notselect';
-    const select = element as HTMLSelectElement;
-    const options = Array.from(select.options);
-    select.value = undefined as any;
-    for (let index = 0; index < options.length; index++) {
-      const option = options[index];
-      option.selected = optionsToSelect.some(optionToSelect => {
-        if (optionToSelect instanceof Node)
-          return option === optionToSelect;
-        let matches = true;
-        if (optionToSelect.value !== undefined)
-          matches = matches && optionToSelect.value === option.value;
-        if (optionToSelect.label !== undefined)
-          matches = matches && optionToSelect.label === option.label;
-        if (optionToSelect.index !== undefined)
-          matches = matches && optionToSelect.index === index;
-        return matches;
-      });
-      if (option.selected && !select.multiple)
-        break;
-    }
-    select.dispatchEvent(new Event('input', { 'bubbles': true }));
-    select.dispatchEvent(new Event('change', { 'bubbles': true }));
-    return options.filter(option => option.selected).map(option => option.value);
+  waitForOptionsAndSelect(node: Node, optionsToSelect: (Node | { value?: string, label?: string, index?: number })[]): Promise<string[] | 'error:notconnected' | FatalDOMError> {
+    return this.pollRaf((progress, continuePolling) => {
+      const element = this.findLabelTarget(node as Element);
+      if (!element || !element.isConnected)
+        return 'error:notconnected';
+      if (element.nodeName.toLowerCase() !== 'select')
+        return 'error:notselect';
+      const select = element as HTMLSelectElement;
+      const options = Array.from(select.options);
+      const selectedOptions = [];
+      let remainingOptionsToSelect = optionsToSelect.slice();
+      for (let index = 0; index < options.length; index++) {
+        const option = options[index];
+        const filter = (optionToSelect: Node | { value?: string, label?: string, index?: number }) => {
+          if (optionToSelect instanceof Node)
+            return option === optionToSelect;
+          let matches = true;
+          if (optionToSelect.value !== undefined)
+            matches = matches && optionToSelect.value === option.value;
+          if (optionToSelect.label !== undefined)
+            matches = matches && optionToSelect.label === option.label;
+          if (optionToSelect.index !== undefined)
+            matches = matches && optionToSelect.index === index;
+          return matches;
+        };
+        if (!remainingOptionsToSelect.some(filter))
+          continue;
+        selectedOptions.push(option);
+        if (select.multiple) {
+          remainingOptionsToSelect = remainingOptionsToSelect.filter(o => !filter(o));
+        } else {
+          remainingOptionsToSelect = [];
+          break;
+        }
+      }
+      if (remainingOptionsToSelect.length) {
+        progress.logRepeating('    did not find some options - waiting... ');
+        return continuePolling;
+      }
+      select.value = undefined as any;
+      selectedOptions.forEach(option => option.selected = true);
+      progress.log('    selected soecified option(s)');
+      select.dispatchEvent(new Event('input', { 'bubbles': true }));
+      select.dispatchEvent(new Event('change', { 'bubbles': true }));
+      return selectedOptions.map(option => option.value);
+    }).result;
   }
 
   waitForEnabledAndFill(node: Node, value: string): InjectedScriptPoll<FatalDOMError | 'error:notconnected' | 'needsinput' | 'done'> {

--- a/test/page-fill.spec.ts
+++ b/test/page-fill.spec.ts
@@ -288,3 +288,14 @@ it('should be able to clear', async ({page, server}) => {
   await page.fill('input', '');
   expect(await page.evaluate(() => window['result'])).toBe('');
 });
+
+it('should not throw when fill causes navigation', async ({page, server}) => {
+  await page.goto(server.PREFIX + '/input/textarea.html');
+  await page.$eval('input', select => select.addEventListener('input', () => window.location.href = '/empty.html'));
+  await Promise.all([
+    page.fill('input', 'some value'),
+    page.waitForNavigation(),
+  ]);
+  expect(page.url()).toContain('empty.html');
+});
+

--- a/test/page-fill.spec.ts
+++ b/test/page-fill.spec.ts
@@ -291,11 +291,11 @@ it('should be able to clear', async ({page, server}) => {
 
 it('should not throw when fill causes navigation', async ({page, server}) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
+  await page.setContent('<input type=date>');
   await page.$eval('input', select => select.addEventListener('input', () => window.location.href = '/empty.html'));
   await Promise.all([
-    page.fill('input', 'some value'),
+    page.fill('input', '2020-03-02'),
     page.waitForNavigation(),
   ]);
   expect(page.url()).toContain('empty.html');
 });
-

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -2417,6 +2417,8 @@ export interface Page {
    * Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element
    * matching `selector`, the method throws an error.
    * 
+   * Will wait until all specified options are present in the `<select>` element.
+   * 
    * ```js
    * // single selection matching the value
    * page.selectOption('select#colors', 'blue');
@@ -4089,6 +4091,8 @@ export interface Frame {
    * 
    * Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element
    * matching `selector`, the method throws an error.
+   * 
+   * Will wait until all specified options are present in the `<select>` element.
    * 
    * ```js
    * // single selection matching the value
@@ -5939,6 +5943,8 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
    * 
    * Triggers a `change` and `input` event once all the provided options have been selected. If element is not a `<select>`
    * element, the method throws an error.
+   * 
+   * Will wait until all specified options are present in the `<select>` element.
    * 
    * ```js
    * // single selection matching the value


### PR DESCRIPTION
Ideally we'd use `InjectedScriptPollHandler` for polling options but that may result in an exception if selecting an option triggers navigation.

Fixes #4921