### PR TITLE
chore: make generate_types not depend on the built playwright

### DIFF
--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -95,7 +95,7 @@ $ python -m playwright wk example.com
 ```
 
 ### Emulate devices
-`open` can emulate mobile and tablet devices ([see all devices](https://github.com/microsoft/playwright/blob/master/src/server/deviceDescriptors.ts)).
+`open` can emulate mobile and tablet devices from the [`playwright.devices`](https://playwright.dev/docs/api/class-playwright#playwrightdevices) list.
 
 ```sh js
 # Emulate iPhone 11.

--- a/src/dispatchers/playwrightDispatcher.ts
+++ b/src/dispatchers/playwrightDispatcher.ts
@@ -15,17 +15,18 @@
  */
 
 import * as channels from '../protocol/channels';
-import { DeviceDescriptors } from '../server/deviceDescriptors';
 import { Playwright } from '../server/playwright';
 import { AndroidDispatcher } from './androidDispatcher';
 import { BrowserTypeDispatcher } from './browserTypeDispatcher';
 import { Dispatcher, DispatcherScope } from './dispatcher';
 import { ElectronDispatcher } from './electronDispatcher';
 import { SelectorsDispatcher } from './selectorsDispatcher';
+import * as types from '../server/types';
 
 export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.PlaywrightInitializer> implements channels.PlaywrightChannel {
   constructor(scope: DispatcherScope, playwright: Playwright) {
-    const deviceDescriptors = Object.entries(DeviceDescriptors)
+    const descriptors = require('../server/deviceDescriptors') as types.Devices;
+    const deviceDescriptors = Object.entries(descriptors)
         .map(([name, descriptor]) => ({ name, descriptor }));
     super(scope, playwright, 'Playwright', {
       chromium: new BrowserTypeDispatcher(scope, playwright.chromium),

--- a/src/server/deviceDescriptors.js
+++ b/src/server/deviceDescriptors.js
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-import * as types from './types';
-
-export const DeviceDescriptors: types.Devices = {
+/**
+ * @type {import('./types').Devices}
+ */
+module.exports = {
   'Blackberry PlayBook': {
     'userAgent': 'Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/7.2.1.0 Safari/536.2+',
     'viewport': {

--- a/test/launcher.spec.ts
+++ b/test/launcher.spec.ts
@@ -23,7 +23,7 @@ it('should require top-level Errors', async ({}) => {
 });
 
 it('should require top-level DeviceDescriptors', async ({playwright}) => {
-  const Devices = require('../lib/server/deviceDescriptors.js').DeviceDescriptors;
+  const Devices = require('../lib/server/deviceDescriptors.js');
   expect(Devices['iPhone 6']).toBeTruthy();
   expect(Devices['iPhone 6']).toEqual(playwright.devices['iPhone 6']);
 });

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -17,7 +17,7 @@
 //@ts-check
 const path = require('path');
 const os = require('os');
-const {devices} = require('../..');
+const devices = require('../../src/server/deviceDescriptors');
 const Documentation = require('../doclint/documentation');
 const PROJECT_DIR = path.join(__dirname, '..', '..');
 const fs = require('fs');


### PR DESCRIPTION
The only dependency is a list of devices that we can turn into a js file.