### PR TITLE
devops: attempt to fix chromium-mac-arm64 build

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -84,8 +84,8 @@ EOF
     echo 'target_cpu = "arm64"' >> ./out/Default/args.gn
   fi
 
-  # Compile Chromium.
-  gn gen out/Default
+  # Compile Chromium with correct Xcode version.
+  DEVELOPER_DIR=/Applications/Xcode12.2.app/Contents/Developer gn gen out/Default
   DEVELOPER_DIR=/Applications/Xcode12.2.app/Contents/Developer autoninja -C out/Default chrome
 
   # Prepare resulting archive similarly to how we do it in mirror_chromium.


### PR DESCRIPTION
It looks like gn generation should use correct xcode version as well.