### PR TITLE
chore: migrate to Folio 0.3.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7699,9 +7699,9 @@
       }
     },
     "folio": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/folio/-/folio-0.3.16.tgz",
-      "integrity": "sha512-V/eKkMh88VTd6gL8SCN+++Y6UbjFvGvp3EfipbYzKIY1BS07L0uVh3CXZJGaaTT0/7gZqrnwYbfHpK7XPzrbvA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/folio/-/folio-0.3.17.tgz",
+      "integrity": "sha512-aYbhifQ/A0E6ZwEUdBGU900+aW2R243pxkWF0GhYceQxFTbkoCLIEHegTOpo4VtNsNHyM3sI/Xz3DkmITiwRcg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-notice": "^0.9.10",
     "eslint-plugin-react-hooks": "^4.2.0",
     "file-loader": "^6.1.0",
-    "folio": "=0.3.16",
+    "folio": "=0.3.17",
     "formidable": "^1.2.2",
     "html-webpack-plugin": "^4.4.1",
     "ncp": "^2.0.0",

--- a/test/browsercontext-proxy.spec.ts
+++ b/test/browsercontext-proxy.spec.ts
@@ -125,9 +125,7 @@ it('should authenticate', async ({contextFactory, contextOptions, server}) => {
   await browser.close();
 });
 
-it('should authenticate with empty password', (test, { browserName }) => {
-  test.flaky(browserName === 'firefox', 'Fails when runs afer previous test, see https://github.com/microsoft/playwright/issues/4789');
-}, async ({contextFactory, contextOptions, server}) => {
+it('should authenticate with empty password', async ({contextFactory, contextOptions, server}) => {
   server.setRoute('/target.html', async (req, res) => {
     const auth = req.headers['proxy-authorization'];
     if (!auth) {
@@ -228,9 +226,7 @@ it('should exclude patterns', (test, { browserName, headful }) => {
   await browser.close();
 });
 
-it('should use socks proxy', (test, { browserName, platform }) => {
-  test.flaky(platform === 'darwin' && browserName === 'webkit', 'Intermittent page.goto: The network connection was lost error on bots');
-}, async ({ contextFactory, contextOptions, socksPort }) => {
+it('should use socks proxy', async ({ contextFactory, contextOptions, socksPort }) => {
   const browser = await contextFactory({
     ...contextOptions,
     proxy: { server: `socks5://localhost:${socksPort}` }
@@ -241,9 +237,7 @@ it('should use socks proxy', (test, { browserName, platform }) => {
   await browser.close();
 });
 
-it('should use socks proxy in second page', (test, { browserName, platform }) => {
-  test.flaky(platform === 'darwin' && browserName === 'webkit', 'Intermittent page.goto: The network connection was lost error on bots');
-}, async ({ contextFactory, contextOptions, socksPort }) => {
+it('should use socks proxy in second page', async ({ contextFactory, contextOptions, socksPort }) => {
   const browser = await contextFactory({
     ...contextOptions,
     proxy: { server: `socks5://localhost:${socksPort}` }

--- a/test/browsertype-connect.spec.ts
+++ b/test/browsertype-connect.spec.ts
@@ -233,9 +233,7 @@ describe('connect', (suite, { mode }) => {
     await page.close();
   });
 
-  it('should save videos from remote browser', (test, {browserName, platform}) => {
-    test.flaky(browserName === 'firefox' && platform === 'win32');
-  }, async ({browserType, remoteServer, testInfo}) => {
+  it('should save videos from remote browser', async ({browserType, remoteServer, testInfo}) => {
     const remote = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
     const videosPath = testInfo.outputPath();
     const context = await remote.newContext({

--- a/test/defaultbrowsercontext-2.spec.ts
+++ b/test/defaultbrowsercontext-2.spec.ts
@@ -66,9 +66,7 @@ it('should support ignoreHTTPSErrors option', async ({httpsServer, launchPersist
   expect(response.ok()).toBe(true);
 });
 
-it('should support extraHTTPHeaders option', (test, { browserName, platform, headful }) => {
-  test.flaky(browserName === 'firefox' && headful && platform === 'linux', 'Intermittent timeout on bots');
-}, async ({server, launchPersistent}) => {
+it('should support extraHTTPHeaders option', async ({server, launchPersistent}) => {
   const {page} = await launchPersistent({extraHTTPHeaders: { foo: 'bar' }});
   const [request] = await Promise.all([
     server.waitForRequest('/empty.html'),
@@ -111,7 +109,6 @@ it('should restore state from userDataDir', (test, { browserName }) => {
 
 it('should restore cookies from userDataDir', (test, { browserName }) => {
   test.slow();
-  test.flaky(browserName === 'chromium');
 }, async ({browserType, browserOptions,  server, createUserDataDir}) => {
   const userDataDir = await createUserDataDir();
   const browserContext = await browserType.launchPersistentContext(userDataDir, browserOptions);

--- a/test/elementhandle-owner-frame.spec.ts
+++ b/test/elementhandle-owner-frame.spec.ts
@@ -34,9 +34,7 @@ it('should work for cross-process iframes', async ({ page, server }) => {
   expect(await elementHandle.ownerFrame()).toBe(frame);
 });
 
-it('should work for document', (test, { browserName, platform }) => {
-  test.flaky(platform === 'win32' && browserName === 'webkit');
-}, async ({ page, server }) => {
+it('should work for document', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   const frame = page.frames()[1];

--- a/test/elementhandle-screenshot.spec.ts
+++ b/test/elementhandle-screenshot.spec.ts
@@ -362,9 +362,7 @@ describe('element screenshot', (suite, parameters) => {
     await context.close();
   });
 
-  it('should wait for element to stop moving', (test, { browserName, headful, platform }) => {
-    test.flaky(browserName === 'webkit' && headful && platform === 'linux');
-  }, async ({ page, server }) => {
+  it('should wait for element to stop moving', async ({ page, server }) => {
     await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const elementHandle = await page.$('.box:nth-of-type(3)');

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -46,7 +46,6 @@ const { it, describe, expect } = fixtures.build();
 
 it('should close the browser when the node process closes', test => {
   test.slow();
-  test.flaky('Flakes at least on WebKit Linux');
 }, async ({connectedRemoteServer, isWindows}) => {
   if (isWindows)
     execSync(`taskkill /pid ${connectedRemoteServer.child().pid} /T /F`);

--- a/test/headful.spec.ts
+++ b/test/headful.spec.ts
@@ -24,8 +24,6 @@ it('should have default url when launching browser', async ({browserType, browse
 });
 
 it('headless should be able to read cookies written by headful', (test, { browserName, platform }) => {
-  test.flaky(platform === 'win32' && browserName === 'chromium');
-  test.flaky(browserName === 'firefox');
   test.slow();
 }, async ({browserType, browserOptions, server, createUserDataDir}) => {
   // see https://github.com/microsoft/playwright/issues/717

--- a/test/page-event-crash.spec.ts
+++ b/test/page-event-crash.spec.ts
@@ -29,7 +29,6 @@ function crash(page, toImpl, browserName) {
 
 describe('', (suite, { browserName, platform, mode }) => {
   suite.skip(mode !== 'default' && browserName !== 'chromium');
-  suite.flaky(browserName === 'firefox' && platform === 'win32');
   const isBigSur = platform === 'darwin' && parseInt(os.release(), 10) >= 20;
   suite.fixme(isBigSur && browserName === 'webkit', 'Timing out after roll');
 }, () => {

--- a/test/page-mouse.spec.ts
+++ b/test/page-mouse.spec.ts
@@ -27,9 +27,7 @@ function dimensions() {
   };
 }
 
-it('should click the document', (test, { browserName, platform }) => {
-  test.flaky(browserName === 'firefox' && platform === 'win32', 'Occasionally times out on options.FIREFOX on Windows: https://github.com/microsoft/playwright/pull/1911/checks?check_run_id=607149016');
-}, async ({page, server}) => {
+it('should click the document', async ({page, server}) => {
   await page.evaluate(() => {
     window['clickPromise'] = new Promise(resolve => {
       document.addEventListener('click', event => {

--- a/test/page-request-continue.spec.ts
+++ b/test/page-request-continue.spec.ts
@@ -16,7 +16,6 @@
  */
 
 import { it, expect, describe } from './fixtures';
-import * as os from 'os';
 
 it('should work', async ({page, server}) => {
   await page.route('**/*', route => route.continue());
@@ -97,10 +96,7 @@ it('should amend method on main request', async ({page, server}) => {
   expect((await request).method).toBe('POST');
 });
 
-describe('', (suite, { browserName, platform }) => {
-  const isBigSur = platform === 'darwin' && parseInt(os.release(), 10) >= 20;
-  suite.flaky(isBigSur && browserName === 'webkit', 'Flaky after roll');
-}, () => {
+describe('', () => {
   it('should amend post data', async ({page, server}) => {
     await page.goto(server.EMPTY_PAGE);
     await page.route('**/*', route => {

--- a/test/permissions.spec.ts
+++ b/test/permissions.spec.ts
@@ -104,7 +104,6 @@ describe('permissions', (suite, { browserName }) => {
   it('should trigger permission onchange', (test, { browserName, headful, platform }) => {
     test.fail(browserName === 'webkit');
     test.fail(browserName === 'chromium' && headful);
-    test.flaky(browserName === 'firefox' && platform === 'linux');
   }, async ({page, server, context}) => {
     // TODO: flaky
     // - Linux: https://github.com/microsoft/playwright/pull/1790/checks?check_run_id=587327883

--- a/test/proxy.spec.ts
+++ b/test/proxy.spec.ts
@@ -137,9 +137,7 @@ it('should exclude patterns', (test, { browserName, headful }) => {
   await browser.close();
 });
 
-it('should use socks proxy', (test, { browserName, platform }) => {
-  test.flaky(platform === 'darwin' && browserName === 'webkit', 'Intermittent page.goto: The network connection was lost error on bots');
-}, async ({ browserType, browserOptions, socksPort }) => {
+it('should use socks proxy', async ({ browserType, browserOptions, socksPort }) => {
   const browser = await browserType.launch({
     ...browserOptions,
     proxy: { server: `socks5://localhost:${socksPort}` }
@@ -150,9 +148,7 @@ it('should use socks proxy', (test, { browserName, platform }) => {
   await browser.close();
 });
 
-it('should use socks proxy in second page', (test, { browserName, platform }) => {
-  test.flaky(platform === 'darwin' && browserName === 'webkit', 'Intermittent page.goto: The network connection was lost error on bots');
-}, async ({ browserType, browserOptions, socksPort }) => {
+it('should use socks proxy in second page', async ({ browserType, browserOptions, socksPort }) => {
   const browser = await browserType.launch({
     ...browserOptions,
     proxy: { server: `socks5://localhost:${socksPort}` }


### PR DESCRIPTION
Folio 0.3.17 doesn't differentiate between expected and unexpected
flakiness, thus no longer supporting the "flaky" annotation.

Flaky specs are reported after run, but flaky specs do not render
test run as failed. We'll track flakiness separately via a dashboard.