### PR TITLE
fix(install): improve browser download

### DIFF
--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -174,8 +174,8 @@ export async function downloadBrowserWithProgressBar(browsersPath: string, brows
   const zipPath = path.join(os.tmpdir(), `playwright-download-${browser.name}-${browserPaths.hostPlatform}-${browser.revision}.zip`);
   try {
     for (let i = 1; i <= 10; ++i) {
-      await downloadFile(url, zipPath, progress).catch(error => {
-        if (!/ECONNRESET/.test(err.message))
+      await downloadFile(url, zipPath, progress).catch(async error => {
+        if (!/ECONNRESET/.test(error.message))
           throw error;
 
         // maximum delay is 10th retry: ~3 seconds

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -57,10 +57,13 @@ export async function installBrowsersWithProgressBar(packagePath: string, browse
   });
   const linksDir = path.join(browsersPath, '.links');
 
-  await fsMkdirAsync(linksDir,  { recursive: true });
-  await fsWriteFileAsync(path.join(linksDir, sha1(packagePath)), packagePath);
-  await validateCache(packagePath, browsersPath, linksDir, browserNames);
-  await releaseLock();
+  try {
+    await fsMkdirAsync(linksDir,  { recursive: true });
+    await fsWriteFileAsync(path.join(linksDir, sha1(packagePath)), packagePath);
+    await validateCache(packagePath, browsersPath, linksDir, browserNames);
+  } finally {
+    await releaseLock();
+  }
 }
 
 async function validateCache(packagePath: string, browsersPath: string, linksDir: string, browserNames?: browserPaths.BrowserName[]) {


### PR DESCRIPTION
- release lock if an exception happens during install
- retry downloading to support intermittent network

Unfortunately, writing tests for ECONNRESET is pretty hard - so relying
heavily on review here.

Fixes #5110