### PR TITLE
feat(trace): streaming snapshots

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -202,6 +202,8 @@ async function launchContext(options: Options, headless: boolean): Promise<{ bro
   if (contextOptions.isMobile && browserType.name() === 'firefox')
     contextOptions.isMobile = undefined;
 
+  if (process.env.PWTRACE)
+    (contextOptions as any)._traceDir = path.join(process.cwd(), '.trace');
 
   // Proxy
 

--- a/src/cli/traceViewer/snapshotRouter.ts
+++ b/src/cli/traceViewer/snapshotRouter.ts
@@ -17,55 +17,117 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as util from 'util';
-import type { Route } from '../../..';
+import type { Frame, Route } from '../../..';
 import { parsedURL } from '../../client/clientHelper';
-import type { FrameSnapshot, NetworkResourceTraceEvent, PageSnapshot } from '../../trace/traceTypes';
-import { ContextEntry } from './traceModel';
+import { ContextEntry, PageEntry, trace } from './traceModel';
 
 const fsReadFileAsync = util.promisify(fs.readFile.bind(fs));
 
 export class SnapshotRouter {
   private _contextEntry: ContextEntry | undefined;
   private _unknownUrls = new Set<string>();
-  private _traceStorageDir: string;
-  private _frameBySrc = new Map<string, FrameSnapshot>();
+  private _resourcesDir: string;
+  private _snapshotFrameIdToSnapshot = new Map<string, trace.FrameSnapshot>();
+  private _pageUrl = '';
+  private _frameToSnapshotFrameId = new Map<Frame, string>();
 
-  constructor(traceStorageDir: string) {
-    this._traceStorageDir = traceStorageDir;
+  constructor(resourcesDir: string) {
+    this._resourcesDir = resourcesDir;
   }
 
-  selectSnapshot(snapshot: PageSnapshot, contextEntry: ContextEntry) {
-    this._frameBySrc.clear();
+  // Returns the url to navigate to.
+  async selectSnapshot(contextEntry: ContextEntry, pageEntry: PageEntry, snapshotId?: string, timestamp?: number): Promise<string> {
     this._contextEntry = contextEntry;
-    for (const frameSnapshot of snapshot.frames)
-      this._frameBySrc.set(frameSnapshot.url, frameSnapshot);
+    if (!snapshotId && !timestamp)
+      return 'data:text/html,Snapshot is not available';
+
+    const lastSnapshotEvent = new Map<string, trace.FrameSnapshotTraceEvent>();
+    for (const [frameId, snapshots] of pageEntry.snapshotsByFrameId) {
+      for (const snapshot of snapshots) {
+        const current = lastSnapshotEvent.get(frameId);
+        // Prefer snapshot with exact id.
+        const exactMatch = snapshotId && snapshot.snapshotId === snapshotId;
+        const currentExactMatch = current && snapshotId && current.snapshotId === snapshotId;
+        // If not available, prefer the latest snapshot before the timestamp.
+        const timestampMatch = timestamp && snapshot.timestamp <= timestamp;
+        if (exactMatch || (timestampMatch && !currentExactMatch))
+          lastSnapshotEvent.set(frameId, snapshot);
+      }
+    }
+
+    this._snapshotFrameIdToSnapshot.clear();
+    for (const [frameId, event] of lastSnapshotEvent) {
+      const buffer = await this._readSha1(event.sha1);
+      if (!buffer)
+        continue;
+      try {
+        const snapshot = JSON.parse(buffer.toString('utf8')) as trace.FrameSnapshot;
+        // Request url could come lower case, so we always normalize to lower case.
+        this._snapshotFrameIdToSnapshot.set(frameId.toLowerCase(), snapshot);
+      } catch (e) {
+      }
+    }
+
+    const mainFrameSnapshot = lastSnapshotEvent.get('');
+    if (!mainFrameSnapshot)
+      return 'data:text/html,Snapshot is not available';
+
+    if (!mainFrameSnapshot.frameUrl.startsWith('http'))
+      this._pageUrl = 'http://playwright.snapshot/';
+    else
+      this._pageUrl = mainFrameSnapshot.frameUrl;
+    return this._pageUrl;
   }
 
   async route(route: Route) {
     const url = route.request().url();
-    if (this._frameBySrc.has(url)) {
-      const frameSnapshot = this._frameBySrc.get(url)!;
+    const frame = route.request().frame();
+
+    if (route.request().isNavigationRequest()) {
+      let snapshotFrameId: string | undefined;
+      if (url === this._pageUrl) {
+        snapshotFrameId = '';
+      } else {
+        snapshotFrameId = url.substring(url.indexOf('://') + 3);
+        if (snapshotFrameId.endsWith('/'))
+          snapshotFrameId = snapshotFrameId.substring(0, snapshotFrameId.length - 1);
+        // Request url could come lower case, so we always normalize to lower case.
+        snapshotFrameId = snapshotFrameId.toLowerCase();
+      }
+
+      const snapshot = this._snapshotFrameIdToSnapshot.get(snapshotFrameId);
+      if (!snapshot) {
+        route.fulfill({
+          contentType: 'text/html',
+          body: 'data:text/html,Snapshot is not available',
+        });
+        return;
+      }
+
+      this._frameToSnapshotFrameId.set(frame, snapshotFrameId);
       route.fulfill({
         contentType: 'text/html',
-        body: Buffer.from(frameSnapshot.html),
+        body: snapshot.html,
       });
       return;
     }
 
-    const frameSrc = route.request().frame().url();
-    const frameSnapshot = this._frameBySrc.get(frameSrc);
-    if (!frameSnapshot)
+    const snapshotFrameId = this._frameToSnapshotFrameId.get(frame);
+    if (snapshotFrameId === undefined)
+      return this._routeUnknown(route);
+    const snapshot = this._snapshotFrameIdToSnapshot.get(snapshotFrameId);
+    if (!snapshot)
       return this._routeUnknown(route);
 
     // Find a matching resource from the same context, preferrably from the same frame.
     // Note: resources are stored without hash, but page may reference them with hash.
-    let resource: NetworkResourceTraceEvent | null = null;
+    let resource: trace.NetworkResourceTraceEvent | null = null;
     const resourcesWithUrl = this._contextEntry!.resourcesByUrl.get(removeHash(url)) || [];
     for (const resourceEvent of resourcesWithUrl) {
-      if (resource && resourceEvent.frameId !== frameSnapshot.frameId)
+      if (resource && resourceEvent.frameId !== snapshotFrameId)
         continue;
       resource = resourceEvent;
-      if (resourceEvent.frameId === frameSnapshot.frameId)
+      if (resourceEvent.frameId === snapshotFrameId)
         break;
     }
     if (!resource)
@@ -73,7 +135,7 @@ export class SnapshotRouter {
 
     // This particular frame might have a resource content override, for example when
     // stylesheet is modified using CSSOM.
-    const resourceOverride = frameSnapshot.resourceOverrides.find(o => o.url === url);
+    const resourceOverride = snapshot.resourceOverrides.find(o => o.url === url);
     const overrideSha1 = resourceOverride ? resourceOverride.sha1 : undefined;
     const resourceData = await this._readResource(resource, overrideSha1);
     if (!resourceData)
@@ -98,17 +160,23 @@ export class SnapshotRouter {
     route.abort();
   }
 
-  private async _readResource(event: NetworkResourceTraceEvent, overrideSha1: string | undefined) {
+  private async _readSha1(sha1: string) {
     try {
-      const body = await fsReadFileAsync(path.join(this._traceStorageDir, overrideSha1 || event.sha1));
-      return {
-        contentType: event.contentType,
-        body,
-        headers: event.responseHeaders,
-      };
+      return await fsReadFileAsync(path.join(this._resourcesDir, sha1));
     } catch (e) {
       return undefined;
     }
+  }
+
+  private async _readResource(event: trace.NetworkResourceTraceEvent, overrideSha1: string | undefined) {
+    const body = await this._readSha1(overrideSha1 || event.sha1);
+    if (!body)
+      return;
+    return {
+      contentType: event.contentType,
+      body,
+      headers: event.responseHeaders,
+    };
   }
 }
 

--- a/src/cli/traceViewer/traceModel.ts
+++ b/src/cli/traceViewer/traceModel.ts
@@ -46,6 +46,7 @@ export type PageEntry = {
   actions: ActionEntry[];
   interestingEvents: InterestingPageEvent[];
   resources: trace.NetworkResourceTraceEvent[];
+  snapshotsByFrameId: Map<string, trace.FrameSnapshotTraceEvent[]>;
 }
 
 export type ActionEntry = {
@@ -93,6 +94,7 @@ export function readTraceFile(events: trace.TraceEvent[], traceModel: TraceModel
           actions: [],
           resources: [],
           interestingEvents: [],
+          snapshotsByFrameId: new Map(),
         };
         pageEntries.set(event.pageId, pageEntry);
         contextEntries.get(event.contextId)!.pages.push(pageEntry);
@@ -142,6 +144,13 @@ export function readTraceFile(events: trace.TraceEvent[], traceModel: TraceModel
       case 'load': {
         const pageEntry = pageEntries.get(event.pageId)!;
         pageEntry.interestingEvents.push(event);
+        break;
+      }
+      case 'snapshot': {
+        const pageEntry = pageEntries.get(event.pageId!)!;
+        if (!pageEntry.snapshotsByFrameId.has(event.frameId))
+          pageEntry.snapshotsByFrameId.set(event.frameId, []);
+        pageEntry.snapshotsByFrameId.get(event.frameId)!.push(event);
         break;
       }
     }

--- a/src/cli/traceViewer/traceViewer.ts
+++ b/src/cli/traceViewer/traceViewer.ts
@@ -21,7 +21,7 @@ import * as util from 'util';
 import { ScreenshotGenerator } from './screenshotGenerator';
 import { SnapshotRouter } from './snapshotRouter';
 import { readTraceFile, TraceModel } from './traceModel';
-import type { ActionTraceEvent, PageSnapshot, TraceEvent } from '../../trace/traceTypes';
+import type { ActionTraceEvent, TraceEvent } from '../../trace/traceTypes';
 
 const fsReadFileAsync = util.promisify(fs.readFile.bind(fs));
 
@@ -92,25 +92,20 @@ class TraceViewer {
     await uiPage.exposeBinding('readFile', async (_, path: string) => {
       return fs.readFileSync(path).toString();
     });
-    await uiPage.exposeBinding('renderSnapshot', async (_, action: ActionTraceEvent) => {
+    await uiPage.exposeBinding('renderSnapshot', async (_, arg: { action: ActionTraceEvent, snapshot: { name: string, snapshotId?: string } }) => {
+      const { action, snapshot } = arg;
       if (!this._document)
         return;
       try {
-        if (!action.snapshot) {
-          const snapshotFrame = uiPage.frames()[1];
-          await snapshotFrame.goto('data:text/html,No snapshot available');
-          return;
-        }
-
-        const snapshot = await fsReadFileAsync(path.join(this._document.resourcesDir, action.snapshot!.sha1), 'utf8');
-        const snapshotObject = JSON.parse(snapshot) as PageSnapshot;
         const contextEntry = this._document.model.contexts.find(entry => entry.created.contextId === action.contextId)!;
-        this._document.snapshotRouter.selectSnapshot(snapshotObject, contextEntry);
+        const pageEntry = contextEntry.pages.find(entry => entry.created.pageId === action.pageId)!;
+        const snapshotTime = snapshot.name === 'before' ? action.startTime : (snapshot.name === 'after' ? action.endTime : undefined);
+        const pageUrl = await this._document.snapshotRouter.selectSnapshot(contextEntry, pageEntry, snapshot.snapshotId, snapshotTime);
 
         // TODO: fix Playwright bug where frame.name is lost (empty).
         const snapshotFrame = uiPage.frames()[1];
         try {
-          await snapshotFrame.goto(snapshotObject.frames[0].url);
+          await snapshotFrame.goto(pageUrl);
         } catch (e) {
           if (!e.message.includes('frame was detached'))
             console.error(e);

--- a/src/cli/traceViewer/web/index.tsx
+++ b/src/cli/traceViewer/web/index.tsx
@@ -25,7 +25,7 @@ declare global {
   interface Window {
     getTraceModel(): Promise<TraceModel>;
     readFile(filePath: string): Promise<string>;
-    renderSnapshot(action: trace.ActionTraceEvent): void;
+    renderSnapshot(arg: { action: trace.ActionTraceEvent, snapshot: { name: string, snapshotId?: string } }): void;
   }
 }
 

--- a/src/cli/traceViewer/web/ui/propertiesTabbedPane.css
+++ b/src/cli/traceViewer/web/ui/propertiesTabbedPane.css
@@ -68,6 +68,28 @@
   font-weight: 600;
 }
 
+.snapshot-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.snapshot-controls {
+  flex: 0 0 24px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.snapshot-toggle {
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+.snapshot-toggle.toggled {
+  background: var(--inactive-focus-ring);
+}
+
 .snapshot-wrapper {
   flex: auto;
   margin: 1px;

--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -378,6 +378,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       if (options && options.modifiers)
         restoreModifiers = await this._page.keyboard._ensureModifiers(options.modifiers);
       progress.log(`  performing ${actionName} action`);
+      await progress.checkpoint('before');
       await action(point);
       progress.log(`  ${actionName} action done`);
       progress.log('  waiting for scheduled navigations to finish');
@@ -447,6 +448,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._frameManager.waitForSignalsCreatedBy(progress, options.noWaitAfter, async () => {
       progress.throwIfAborted();  // Avoid action that has side-effects.
       progress.log('  selecting specified option(s)');
+      await progress.checkpoint('before');
       const poll = await this._evaluateHandleInUtility(([injected, node, selectOptions]) => injected.waitForOptionsAndSelect(node, selectOptions), selectOptions);
       const pollHandler = new InjectedScriptPollHandler(progress, poll);
       const result = throwFatalDOMError(await pollHandler.finish());
@@ -475,6 +477,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       if (filled === 'error:notconnected')
         return filled;
       progress.log('  element is visible, enabled and editable');
+      await progress.checkpoint('before');
       if (filled === 'needsinput') {
         progress.throwIfAborted();  // Avoid action that has side-effects.
         if (value)
@@ -521,6 +524,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     assert(multiple || files.length <= 1, 'Non-multiple file input can only accept single file!');
     await this._page._frameManager.waitForSignalsCreatedBy(progress, options.noWaitAfter, async () => {
       progress.throwIfAborted();  // Avoid action that has side-effects.
+      await progress.checkpoint('before');
       await this._page._delegate.setInputFiles(this as any as ElementHandle<HTMLInputElement>, files);
     });
     await this._page._doSlowMo();
@@ -555,6 +559,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       if (result !== 'done')
         return result;
       progress.throwIfAborted();  // Avoid action that has side-effects.
+      await progress.checkpoint('before');
       await this._page.keyboard.type(text, options);
       return 'done';
     }, 'input');
@@ -574,6 +579,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       if (result !== 'done')
         return result;
       progress.throwIfAborted();  // Avoid action that has side-effects.
+      await progress.checkpoint('before');
       await this._page.keyboard.press(key, options);
       return 'done';
     }, 'input');

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -131,8 +131,11 @@ export class FrameManager {
     if (progress)
       progress.cleanupWhenAborted(() => this._signalBarriers.delete(barrier));
     const result = await action();
-    if (source === 'input')
+    if (source === 'input') {
       await this._page._delegate.inputActionEpilogue();
+      if (progress)
+        await progress.checkpoint('after');
+    }
     await barrier.waitFor();
     this._signalBarriers.delete(barrier);
     // Resolve in the next task, after all waitForNavigations.

--- a/src/trace/traceTypes.ts
+++ b/src/trace/traceTypes.ts
@@ -76,12 +76,9 @@ export type ActionTraceEvent = {
   startTime: number,
   endTime: number,
   logs?: string[],
-  snapshot?: {
-    sha1: string,
-    duration: number,
-  },
   stack?: string,
   error?: string,
+  snapshots?: { name: string, snapshotId: string }[],
 };
 
 export type DialogOpenedEvent = {
@@ -117,6 +114,17 @@ export type LoadEvent = {
   pageId: string,
 };
 
+export type FrameSnapshotTraceEvent = {
+  timestamp: number,
+  type: 'snapshot',
+  contextId: string,
+  pageId: string,
+  frameId: string,  // Empty means main frame.
+  sha1: string,
+  frameUrl: string,
+  snapshotId?: string,
+};
+
 export type TraceEvent =
     ContextCreatedTraceEvent |
     ContextDestroyedTraceEvent |
@@ -128,18 +136,13 @@ export type TraceEvent =
     DialogOpenedEvent |
     DialogClosedEvent |
     NavigationEvent |
-    LoadEvent;
+    LoadEvent |
+    FrameSnapshotTraceEvent;
 
 
 export type FrameSnapshot = {
-  frameId: string,
-  url: string,
   html: string,
   resourceOverrides: { url: string, sha1: string }[],
-};
-
-export type PageSnapshot = {
-  viewportSize?: { width: number, height: number },
-  // First frame is the main frame.
-  frames: FrameSnapshot[],
+  viewport: { width: number, height: number },
+  url: string,
 };

--- a/src/trace/tracer.ts
+++ b/src/trace/tracer.ts
@@ -23,9 +23,7 @@ import * as fs from 'fs';
 import { calculateSha1, createGuid, getFromENV, mkdirIfNeeded, monotonicTime } from '../utils/utils';
 import { Page } from '../server/page';
 import { Snapshotter } from './snapshotter';
-import { ElementHandle } from '../server/dom';
 import { helper, RegisteredListener } from '../server/helper';
-import { DEFAULT_TIMEOUT } from '../utils/timeoutSettings';
 import { ProgressResult } from '../server/progress';
 import { Dialog } from '../server/dialog';
 import { Frame, NavigationEvent } from '../server/frames';
@@ -64,6 +62,14 @@ class Tracer implements ContextListener {
 }
 
 const pageIdSymbol = Symbol('pageId');
+const snapshotsSymbol = Symbol('snapshots');
+
+// TODO: this is a hacky way to pass snapshots between onActionCheckpoint and onAfterAction.
+function snapshotsForMetadata(metadata: ActionMetadata): { name: string, snapshotId: string }[] {
+  if (!(metadata as any)[snapshotsSymbol])
+    (metadata as any)[snapshotsSymbol] = [];
+  return (metadata as any)[snapshotsSymbol];
+}
 
 class ContextTracer implements SnapshotterDelegate, ActionListener {
   private _context: BrowserContext;
@@ -119,31 +125,50 @@ class ContextTracer implements SnapshotterDelegate, ActionListener {
     this._appendTraceEvent(event);
   }
 
+  onFrameSnapshot(frame: Frame, snapshot: trace.FrameSnapshot, snapshotId?: string): void {
+    const buffer = Buffer.from(JSON.stringify(snapshot));
+    const sha1 = calculateSha1(buffer);
+    this._writeArtifact(sha1, buffer);
+    const event: trace.FrameSnapshotTraceEvent = {
+      timestamp: monotonicTime(),
+      type: 'snapshot',
+      contextId: this._contextId,
+      pageId: this.pageId(frame._page),
+      frameId: frame._page.mainFrame() === frame ? '' : frame._id,
+      sha1,
+      frameUrl: snapshot.url,
+      snapshotId,
+    };
+    this._appendTraceEvent(event);
+  }
+
   pageId(page: Page): string {
     return (page as any)[pageIdSymbol];
   }
 
+  async onActionCheckpoint(name: string, metadata: ActionMetadata): Promise<void> {
+    const snapshotId = createGuid();
+    snapshotsForMetadata(metadata).push({ name, snapshotId });
+    await this._snapshotter.forceSnapshot(metadata.page, snapshotId);
+  }
+
   async onAfterAction(result: ProgressResult, metadata: ActionMetadata): Promise<void> {
-    try {
-      const snapshot = await this._takeSnapshot(metadata.page, typeof metadata.target === 'string' ? undefined : metadata.target);
-      const event: trace.ActionTraceEvent = {
-        timestamp: monotonicTime(),
-        type: 'action',
-        contextId: this._contextId,
-        pageId: this.pageId(metadata.page),
-        action: metadata.type,
-        selector: typeof metadata.target === 'string' ? metadata.target : undefined,
-        value: metadata.value,
-        snapshot,
-        startTime: result.startTime,
-        endTime: result.endTime,
-        stack: metadata.stack,
-        logs: result.logs.slice(),
-        error: result.error ? result.error.stack : undefined,
-      };
-      this._appendTraceEvent(event);
-    } catch (e) {
-    }
+    const event: trace.ActionTraceEvent = {
+      timestamp: monotonicTime(),
+      type: 'action',
+      contextId: this._contextId,
+      pageId: this.pageId(metadata.page),
+      action: metadata.type,
+      selector: typeof metadata.target === 'string' ? metadata.target : undefined,
+      value: metadata.value,
+      startTime: result.startTime,
+      endTime: result.endTime,
+      stack: metadata.stack,
+      logs: result.logs.slice(),
+      error: result.error ? result.error.stack : undefined,
+      snapshots: snapshotsForMetadata(metadata),
+    };
+    this._appendTraceEvent(event);
   }
 
   private _onPage(page: Page) {
@@ -235,22 +260,6 @@ class ContextTracer implements SnapshotterDelegate, ActionListener {
       };
       this._appendTraceEvent(event);
     });
-  }
-
-  private async _takeSnapshot(page: Page, target: ElementHandle | undefined, timeout: number = 0): Promise<{ sha1: string, duration: number } | undefined> {
-    if (!timeout) {
-      // Never use zero timeout to avoid stalling because of snapshot.
-      // Use 20% of the default timeout.
-      timeout = (page._timeoutSettings.timeout({}) || DEFAULT_TIMEOUT) / 5;
-    }
-    const startTime = monotonicTime();
-    const snapshot = await this._snapshotter.takeSnapshot(page, target, timeout);
-    if (!snapshot)
-      return;
-    const buffer = Buffer.from(JSON.stringify(snapshot));
-    const sha1 = calculateSha1(buffer);
-    this._writeArtifact(sha1, buffer);
-    return { sha1, duration: monotonicTime() - startTime };
   }
 
   async dispose() {


### PR DESCRIPTION
- Instead of capturing snapshots on demand, we now stream them
  from each frame every 100ms.
- Certain actions can also force snapshots at particular moment using
  "checkpoints".
- Trace viewer is able to show the page snapshot at a particular
  timestamp, or using a "checkpoint" snapshot.
- Small optimization to not process stylesheets if CSSOM was not used.
  There still is a lot of room for improvement.