### PR TITLE
chore: add Python to docker images

### DIFF
--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -68,6 +68,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends git ssh && \
 # Create the pwuser (we internally create a symlink for the pwuser and the root user)
 RUN adduser pwuser
 
+# Install Python 3.8
+
+RUN apt-get update && apt-get install -y python3.8 python3-pip && \
+    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
 # === BAKE BROWSERS INTO IMAGE ===
 
 # 1. Add tip-of-tree Playwright package to install its browsers.

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -67,6 +67,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends git ssh && \
 # Create the pwuser (we internally create a symlink for the pwuser and the root user)
 RUN adduser pwuser
 
+# Install Python 3.8
+
+RUN apt-get update && apt-get install -y python3.8 python3-pip && \
+    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
 # === BAKE BROWSERS INTO IMAGE ===
 
 # 1. Add tip-of-tree Playwright package to install its browsers.


### PR DESCRIPTION
This adds +100MB to network transfer size but enables our
users to use playwright-python from-inside docker container.