### PR TITLE
fix: do not return cookies with empty values

### DIFF
--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -23,6 +23,9 @@ export function filterCookies(cookies: types.NetworkCookie[], urls: string[]): t
   const parsedURLs = urls.map(s => new URL(s));
   // Chromiums's cookies are missing sameSite when it is 'None'
   return cookies.filter(c => {
+    // Firefox and WebKit can return cookies with empty values.
+    if (!c.value)
+      return false;
     if (!parsedURLs.length)
       return true;
     for (const parsedURL of parsedURLs) {

--- a/test/browsercontext-cookies.spec.ts
+++ b/test/browsercontext-cookies.spec.ts
@@ -199,3 +199,14 @@ it('should work with subdomain cookie', async ({context, page, server}) => {
     sameSite: 'None',
   }]);
 });
+
+it('should not return cookies with empty value', async ({context, page, server}) => {
+  server.setRoute('/empty.html', (req, res) => {
+    res.setHeader('Set-Cookie', 'name=;Path=/');
+    res.end();
+  });
+  await page.goto(server.EMPTY_PAGE);
+  const cookies = await context.cookies();
+  expect(cookies.length).toBe(0);
+});
+


### PR DESCRIPTION
Fixes: https://github.com/microsoft/playwright-python/issues/459, https://github.com/microsoft/playwright/issues/5127