### PR TITLE
docs: update langs fields to include java

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -737,7 +737,7 @@ A glob pattern, regex pattern or predicate receiving [URL] used to register a ro
 Optional handler function used to register a routing with [`method: BrowserContext.route`].
 
 ## async method: BrowserContext.waitForEvent
-* langs:
+* langs: js,python
   - alias-python: expect_event
 - returns: <[any]>
 

--- a/docs/src/api/class-cdpsession.md
+++ b/docs/src/api/class-cdpsession.md
@@ -1,5 +1,5 @@
 # class: CDPSession
-* langs: js, python
+* langs: js,python
 * extends: [EventEmitter]
 
 The `CDPSession` instances are used to talk raw Chrome Devtools Protocol:

--- a/docs/src/api/class-download.md
+++ b/docs/src/api/class-download.md
@@ -39,7 +39,7 @@ not performed and user has no access to the downloaded files.
 :::
 
 ## async method: Download.createReadStream
-* langs: js
+* langs: js,java
 - returns: <[null]|[Readable]>
 
 Returns readable stream for current download or `null` if download failed.

--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -58,6 +58,7 @@ ElementHandle instances can be used as an argument in [`method: Page.$eval`] and
 
 ## async method: ElementHandle.$
 * langs:
+  - alias-java: querySelector
   - alias-python: query_selector
 - returns: <[null]|[ElementHandle]>
 
@@ -69,6 +70,7 @@ returns `null`.
 
 ## async method: ElementHandle.$$
 * langs:
+  - alias-java: querySelectorAll
   - alias-python: query_selector_all
 - returns: <[Array]<[ElementHandle]>>
 
@@ -80,6 +82,7 @@ returns empty array.
 
 ## async method: ElementHandle.$eval
 * langs:
+  - alias-java: evalOnSelector
   - alias-python: eval_on_selector
 - returns: <[Serializable]>
 
@@ -115,7 +118,9 @@ assert tweet_handle.eval_on_selector(".retweets", "node => node.innerText") = "1
 ### param: ElementHandle.$eval.selector = %%-query-selector-%%
 
 ### param: ElementHandle.$eval.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]\([Element]\)>
 
 Function to be evaluated in browser context
@@ -127,6 +132,7 @@ Optional argument to pass to [`param: pageFunction`]
 
 ## async method: ElementHandle.$$eval
 * langs:
+  - alias-java: evalOnSelectorAll
   - alias-python: eval_on_selector_all
 - returns: <[Serializable]>
 
@@ -166,7 +172,9 @@ assert feed_handle.eval_on_selector_all(".tweet", "nodes => nodes.map(n => n.inn
 ### param: ElementHandle.$$eval.selector = %%-query-selector-%%
 
 ### param: ElementHandle.$$eval.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]\([Array]<[Element]>\)>
 
 Function to be evaluated in browser context

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -77,6 +77,7 @@ with sync_playwright() as playwright:
 ## async method: Frame.$
 * langs:
   - alias-python: query_selector
+  - alias-java: querySelector
 - returns: <[null]|[ElementHandle]>
 
 Returns the ElementHandle pointing to the frame element.
@@ -90,6 +91,7 @@ returns `null`.
 ## async method: Frame.$$
 * langs:
   - alias-python: query_selector_all
+  - alias-java: querySelectorAll
 - returns: <[Array]<[ElementHandle]>>
 
 Returns the ElementHandles pointing to the frame elements.
@@ -103,6 +105,7 @@ returns empty array.
 ## async method: Frame.$eval
 * langs:
   - alias-python: eval_on_selector
+  - alias-java: evalOnSelector
 - returns: <[Serializable]>
 
 Returns the return value of [`param: pageFunction`]
@@ -137,7 +140,9 @@ html = frame.eval_on_selector(".main-container", "(e, suffix) => e.outerHTML + s
 ### param: Frame.$eval.selector = %%-query-selector-%%
 
 ### param: Frame.$eval.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]\([Element]\)>
 
 Function to be evaluated in browser context
@@ -150,6 +155,7 @@ Optional argument to pass to [`param: pageFunction`]
 ## async method: Frame.$$eval
 * langs:
   - alias-python: eval_on_selector_all
+  - alias-java: evalOnSelectorAll
 - returns: <[Serializable]>
 
 Returns the return value of [`param: pageFunction`]
@@ -178,7 +184,9 @@ divs_counts = frame.eval_on_selector_all("div", "(divs, min) => divs.length >= m
 ### param: Frame.$$eval.selector = %%-query-selector-%%
 
 ### param: Frame.$$eval.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]\([Array]<[Element]>\)>
 
 Function to be evaluated in browser context
@@ -478,7 +486,9 @@ body_handle.dispose()
 ```
 
 ### param: Frame.evaluate.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]|[string]>
 
 Function to be evaluated in browser context
@@ -552,7 +562,9 @@ result_handle.dispose()
 ```
 
 ### param: Frame.evaluateHandle.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]|[string]>
 
 Function to be evaluated in the page context
@@ -634,6 +646,8 @@ Attribute name to get the value for.
 ### option: Frame.getAttribute.timeout = %%-input-timeout-%%
 
 ## async method: Frame.goto
+* langs:
+  - alias-java: navigate
 - returns: <[null]|[Response]>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
@@ -1090,7 +1104,9 @@ frame.wait_for_function("selector => !!document.querySelector(selector)", select
 ```
 
 ### param: Frame.waitForFunction.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]|[string]>
 
 Function to be evaluated in browser context

--- a/docs/src/api/class-jshandle.md
+++ b/docs/src/api/class-jshandle.md
@@ -62,7 +62,9 @@ assert tweet_handle.evaluate("node => node.innerText") == "10 retweets"
 ```
 
 ### param: JSHandle.evaluate.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]>
 
 Function to be evaluated in browser context
@@ -88,7 +90,9 @@ for the promise to resolve and return its value.
 See [`method: Page.evaluateHandle`] for more details.
 
 ### param: JSHandle.evaluateHandle.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]|[string]>
 
 Function to be evaluated

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -311,6 +311,7 @@ page.
 
 ## async method: Page.$
 * langs:
+  - alias-java: querySelector
   - alias-python: query_selector
 - returns: <[null]|[ElementHandle]>
 
@@ -323,6 +324,7 @@ Shortcut for main frame's [`method: Frame.$`].
 
 ## async method: Page.$$
 * langs:
+  - alias-java: querySelectorAll
   - alias-python: query_selector_all
 - returns: <[Array]<[ElementHandle]>>
 
@@ -335,6 +337,7 @@ Shortcut for main frame's [`method: Frame.$$`].
 
 ## async method: Page.$eval
 * langs:
+  - alias-java: evalOnSelector
   - alias-python: eval_on_selector
 - returns: <[Serializable]>
 
@@ -370,7 +373,9 @@ Shortcut for main frame's [`method: Frame.$eval`].
 ### param: Page.$eval.selector = %%-query-selector-%%
 
 ### param: Page.$eval.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]\([Element]\)>
 
 Function to be evaluated in browser context
@@ -382,6 +387,7 @@ Optional argument to pass to [`param: pageFunction`]
 
 ## async method: Page.$$eval
 * langs:
+  - alias-java: evalOnSelectorAll
   - alias-python: eval_on_selector_all
 - returns: <[Serializable]>
 
@@ -408,7 +414,9 @@ div_counts = page.eval_on_selector_all("div", "(divs, min) => divs.length >= min
 ### param: Page.$$eval.selector = %%-query-selector-%%
 
 ### param: Page.$$eval.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]\([Array]<[Element]>\)>
 
 Function to be evaluated in browser context
@@ -819,7 +827,7 @@ page.evaluate("matchMedia('(prefers-color-scheme: no-preference)').matches")
 ```
 
 ### param: Page.emulateMedia.params
-* langs: js
+* langs: js,java
 - `params` <[Object]>
   - `media` <[null]|"screen"|"print"> Changes the CSS media type of the page. The only allowed values are
     `'screen'`, `'print'` and `null`. Passing `null` disables CSS media emulation. Omitting `media` or passing
@@ -902,7 +910,9 @@ body_handle.dispose()
 Shortcut for main frame's [`method: Frame.evaluate`].
 
 ### param: Page.evaluate.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]|[string]>
 
 Function to be evaluated in the page context
@@ -976,7 +986,9 @@ result_handle.dispose()
 ```
 
 ### param: Page.evaluateHandle.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]|[string]>
 
 Function to be evaluated in the page context
@@ -1298,7 +1310,7 @@ frame = page.frame(url=r".*domain.*")
 ```
 
 ### param: Page.frame.frameSelector
-* langs: js
+* langs: js,java
 - `frameSelector` <[string]|[Object]>
   - `name` <[string]> Frame name specified in the `iframe`'s `name` attribute. Optional.
   - `url` <[string]|[RegExp]|[function]\([URL]\):[boolean]> A glob pattern, regex pattern or predicate receiving
@@ -1350,6 +1362,8 @@ Navigate to the next page in history.
 ### option: Page.goForward.waitUntil = %%-navigation-wait-until-%%
 
 ## async method: Page.goto
+* langs:
+  - alias-java: navigate
 - returns: <[null]|[Response]>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
@@ -2168,7 +2182,7 @@ Video object associated with this page.
   - `height` <[int]> page height in pixels.
 
 ## async method: Page.waitForEvent
-* langs:
+* langs: js,python
   - alias-python: expect_event
 - returns: <[any]>
 
@@ -2278,7 +2292,9 @@ page.wait_for_function("selector => !!document.querySelector(selector)", selecto
 Shortcut for main frame's [`method: Frame.waitForFunction`].
 
 ### param: Page.waitForFunction.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]|[string]>
 
 Function to be evaluated in browser context

--- a/docs/src/api/class-route.md
+++ b/docs/src/api/class-route.md
@@ -30,6 +30,7 @@ Optional error code. Defaults to `failed`, could be one of the following:
 
 ## async method: Route.continue
 * langs:
+  - alias-java: continue_
   - alias-python: continue_
 
 Continues route's request with optional overrides.

--- a/docs/src/api/class-selectors.md
+++ b/docs/src/api/class-selectors.md
@@ -57,7 +57,7 @@ Name that is used in selectors as a prefix, e.g. `{name: 'foo'}` enables `foo=my
 contain `[a-zA-Z0-9_]` characters.
 
 ### param: Selectors.register.script
-* langs: js
+* langs: js,java
 - `script` <[function]|[string]|[Object]>
   - `path` <[path]> Path to the JavaScript file. If `path` is a relative path, then it is resolved relative to the
     current working directory. Optional.

--- a/docs/src/api/class-websocket.md
+++ b/docs/src/api/class-websocket.md
@@ -35,7 +35,7 @@ Indicates that the web socket has been closed.
 Contains the URL of the WebSocket.
 
 ## async method: WebSocket.waitForEvent
-* langs:
+* langs: js,python
   - alias-python: expect_event
 - returns: <[any]>
 

--- a/docs/src/api/class-worker.md
+++ b/docs/src/api/class-worker.md
@@ -45,7 +45,9 @@ If the function passed to the `worker.evaluate` returns a non-[Serializable] val
 `-0`, `NaN`, `Infinity`, `-Infinity`, and bigint literals.
 
 ### param: Worker.evaluate.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]|[string]>
 
 Function to be evaluated in the worker context
@@ -67,7 +69,9 @@ If the function passed to the `worker.evaluateHandle` returns a [Promise], then 
 the promise to resolve and return its value.
 
 ### param: Worker.evaluateHandle.pageFunction
-* langs: js
+* langs:
+  - alias-java: expression
+  - alias-python: expression
 - `pageFunction` <[function]|[string]>
 
 Function to be evaluated in the page context

--- a/docs/src/api/java.md
+++ b/docs/src/api/java.md
@@ -1,0 +1,27 @@
+## method: Playwright.stop
+* langs: java
+
+Terminates this instance of Playwright.
+
+### param: BrowserContext.addInitScript.script
+* langs: java
+- `script` <[string]>
+
+Script to be evaluated in all pages in the browser context.
+
+### param: ElementHandle.$eval.expression = %%-java-evaluate-expression-%%
+### param: ElementHandle.$$eval.expression = %%-java-evaluate-expression-%%
+### param: Frame.$eval.expression = %%-java-evaluate-expression-%%
+### param: Frame.$$eval.expression = %%-java-evaluate-expression-%%
+### param: Frame.evaluate.expression = %%-java-evaluate-expression-%%
+### param: Frame.evaluateHandle.expression = %%-java-evaluate-expression-%%
+### param: Frame.waitForFunction.expression = %%-java-evaluate-expression-%%
+### param: JSHandle.evaluate.expression = %%-java-evaluate-expression-%%
+### param: JSHandle.evaluateHandle.expression = %%-java-evaluate-expression-%%
+### param: Page.$eval.expression = %%-java-evaluate-expression-%%
+### param: Page.$$eval.expression = %%-java-evaluate-expression-%%
+### param: Page.evaluate.expression = %%-java-evaluate-expression-%%
+### param: Page.evaluateHandle.expression = %%-java-evaluate-expression-%%
+### param: Page.waitForFunction.expression = %%-java-evaluate-expression-%%
+### param: Worker.evaluate.expression = %%-java-evaluate-expression-%%
+### param: Worker.evaluateHandle.expression = %%-java-evaluate-expression-%%

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -147,7 +147,7 @@ Whether to ignore HTTPS errors during navigation. Defaults to `false`.
 Toggles bypassing page's Content-Security-Policy.
 
 ## context-option-viewport
-* langs: js
+* langs: js,java
 - `viewport` <[null]|[Object]>
   - `width` <[int]> page width in pixels.
   - `height` <[int]> page height in pixels.
@@ -262,7 +262,7 @@ Logger sink for Playwright logging.
 **DEPRECATED** Use [`option: recordVideo`] instead.
 
 ## context-option-recordhar
-* langs: js
+* langs: js,java
 - `recordHar` <[Object]>
   - `omitContent` <[boolean]> Optional setting to control whether to omit request content from the HAR. Defaults to
     `false`.
@@ -285,7 +285,7 @@ Optional setting to control whether to omit request content from the HAR. Defaul
 Path on the filesystem to write the HAR file to.
 
 ## context-option-recordvideo
-* langs: js
+* langs: js,java
 - `recordVideo` <[Object]>
   - `dir` <[path]> Path to the directory to put videos into.
   - `size` <[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`.
@@ -326,7 +326,7 @@ option to work. If all contexts override the proxy, global proxy will be never u
 `launch({ proxy: { server: 'per-context' } })`.
 
 ## select-options-values
-* langs: js
+* langs: js,java
 - `values` <[null]|[string]|[ElementHandle]|[Array]<[string]>|[Object]|[Array]<[ElementHandle]>|[Array]<[Object]>>
   - `value` <[string]> Matches by `option.value`. Optional.
   - `label` <[string]> Matches by `option.label`. Optional.
@@ -354,6 +354,13 @@ method resolves immediately. Can be one of:
   * `'load'` - wait for the `load` event to be fired.
   * `'domcontentloaded'` - wait for the `DOMContentLoaded` event to be fired.
   * `'networkidle'` - wait until there are no network connections for at least `500` ms.
+
+## java-evaluate-expression
+* langs: java
+- `expression` <[string]>
+
+JavaScript expression to be evaluated in the browser context. If it looks like a function declaration,
+it is interpreted as a function. Otherwise, evaluated as an expression.
 
 ## python-select-options-element
 * langs: python


### PR DESCRIPTION
* Use -alias-java for parameters like `ElementHandle.$$eval.pageFunction` to preserve their order in the original method signature while renaming and changing type in language ports.