### PR TITLE
fix(docs): pick-up multiple links in a single markdown line

### DIFF
--- a/utils/doclint/documentation.js
+++ b/utils/doclint/documentation.js
@@ -612,7 +612,7 @@ function patchLinks(spec, classesMap, membersMap, linkRenderer) {
       if (p1 === 'option')
         return linkRenderer({ option: p2 }) || match;
     });
-    node.text = node.text.replace(/\[([\w]+)\]/, (match, p1) => {
+    node.text = node.text.replace(/\[([\w]+)\]/g, (match, p1) => {
       const clazz = classesMap.get(p1);
       if (clazz)
         return linkRenderer({ clazz }) || match;


### PR DESCRIPTION
The link patching only picked up the first link when there were multiples in a markdown line.