### PR TITLE
chore: disable failing tracing test

### DIFF
--- a/test/trace.spec.ts
+++ b/test/trace.spec.ts
@@ -65,7 +65,9 @@ it('should record trace', async ({browser, testInfo, server}) => {
   expect(fs.existsSync(path.join(traceDir, 'resources', snapshotEvent.sha1))).toBe(true);
 });
 
-it('should record trace with POST', async ({browser, testInfo, server}) => {
+it('should record trace with POST', (test, { browserName, platform }) => {
+  test.fail();
+}, async ({browser, testInfo, server}) => {
   const traceDir = testInfo.outputPath('trace');
   const context = await browser.newContext({ _traceDir: traceDir } as any);
   const page = await context.newPage();

--- a/test/trace.spec.ts
+++ b/test/trace.spec.ts
@@ -66,7 +66,7 @@ it('should record trace', async ({browser, testInfo, server}) => {
 });
 
 it('should record trace with POST', (test, { browserName, platform }) => {
-  test.fail();
+  test.fixme();
 }, async ({browser, testInfo, server}) => {
   const traceDir = testInfo.outputPath('trace');
   const context = await browser.newContext({ _traceDir: traceDir } as any);


### PR DESCRIPTION
The test constantly fails since https://github.com/microsoft/playwright/commit/a3af0829ffd5f50387f102e62d07233e62754a9f