### PR TITLE
fix(codegen): add timeout to our actions, catch errors

### DIFF
--- a/src/server/supplements/injected/recorder.ts
+++ b/src/server/supplements/injected/recorder.ts
@@ -608,7 +608,7 @@ export class Recorder {
 
   private async _performAction(action: actions.Action) {
     this._performingAction = true;
-    await window.playwrightRecorderPerformAction(action);
+    await window.playwrightRecorderPerformAction(action).catch(e => {});
     this._performingAction = false;
 
     // Action could have changed DOM, update hovered model selectors.

--- a/src/server/supplements/recorder/codeGenerator.ts
+++ b/src/server/supplements/recorder/codeGenerator.ts
@@ -64,6 +64,11 @@ export class CodeGenerator {
     this._currentAction = action;
   }
 
+  performedActionFailed(action: ActionInContext) {
+    if (this._currentAction === action)
+      this._currentAction = undefined;
+  }
+
   didPerformAction(actionInContext: ActionInContext) {
     const { action, pageAlias } = actionInContext;
     let eraseLastAction = false;


### PR DESCRIPTION
Actions we perform during recording may fail for various reasons:
interrupted by the user, element selector changes, etc.

We should not wait for 30 seconds for the action to fail,
and should never have `this._performingAction` stuck as `true`
due to exception.

Fixes #5185, #5186.