### PR TITLE
feat(element state): support aria-disabled attribute

### DIFF
--- a/src/server/injected/injectedScript.ts
+++ b/src/server/injected/injectedScript.ts
@@ -662,7 +662,7 @@ export class InjectedScript {
 
   isElementDisabled(element: Element): boolean {
     const elementOrButton = element.closest('button, [role=button]') || element;
-    return ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'].includes(elementOrButton.nodeName) && elementOrButton.hasAttribute('disabled');
+    return ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'].includes(elementOrButton.nodeName) && elementOrButton.hasAttribute('disabled') || elementOrButton.getAttribute('aria-disabled') === 'true';
   }
 
   isElementReadOnly(element: Element): boolean {

--- a/src/server/injected/injectedScript.ts
+++ b/src/server/injected/injectedScript.ts
@@ -662,7 +662,9 @@ export class InjectedScript {
 
   isElementDisabled(element: Element): boolean {
     const elementOrButton = element.closest('button, [role=button]') || element;
-    return ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'].includes(elementOrButton.nodeName) && elementOrButton.hasAttribute('disabled') || elementOrButton.getAttribute('aria-disabled') === 'true';
+    const ariaDisabled = elementOrButton.getAttribute('aria-disabled')
+    return ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'].includes(elementOrButton.nodeName) && elementOrButton.hasAttribute('disabled') ||
+      ariaDisabled != null && ariaDisabled.toLowerCase() !== 'false';
   }
 
   isElementReadOnly(element: Element): boolean {

--- a/src/server/injected/injectedScript.ts
+++ b/src/server/injected/injectedScript.ts
@@ -662,9 +662,12 @@ export class InjectedScript {
 
   isElementDisabled(element: Element): boolean {
     const elementOrButton = element.closest('button, [role=button]') || element;
-    const ariaDisabled = elementOrButton.getAttribute('aria-disabled')
-    return ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'].includes(elementOrButton.nodeName) && elementOrButton.hasAttribute('disabled') ||
-      ariaDisabled != null && ariaDisabled.toLowerCase() !== 'false';
+    if (['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'].includes(elementOrButton.nodeName)) {
+      return elementOrButton.hasAttribute('disabled');
+    } else {
+      const ariaDisabled = elementOrButton.getAttribute('aria-disabled');
+      return ariaDisabled !== null && ariaDisabled.toLowerCase() !== 'false';
+    }
   }
 
   isElementReadOnly(element: Element): boolean {

--- a/test/elementhandle-convenience.spec.ts
+++ b/test/elementhandle-convenience.spec.ts
@@ -175,6 +175,7 @@ it('isEnabled and isDisabled should work', async ({ page }) => {
   await page.setContent(`
     <button disabled>button1</button>
     <button>button2</button>
+    <button aria-disabled="true">button3</button>
     <div>div</div>
     <div role="button" aria-disabled="true">role=button1</div>
     <div role="button" aria-disabled="faLSE">role=button2</div>
@@ -195,6 +196,11 @@ it('isEnabled and isDisabled should work', async ({ page }) => {
   expect(await button2.isDisabled()).toBe(false);
   expect(await page.isEnabled(':text("button2")')).toBe(true);
   expect(await page.isDisabled(':text("button2")')).toBe(false);
+  const button3 = await page.$(':text("button3")');
+  expect(await button3.isEnabled()).toBe(true);
+  expect(await button3.isDisabled()).toBe(false);
+  expect(await page.isEnabled(':text("button3")')).toBe(true);
+  expect(await page.isDisabled(':text("button3")')).toBe(false);
   const roleButton1 = await page.$(':text("role=button1")');
   expect(await roleButton1.isEnabled()).toBe(false);
   expect(await roleButton1.isDisabled()).toBe(true);

--- a/test/elementhandle-convenience.spec.ts
+++ b/test/elementhandle-convenience.spec.ts
@@ -176,6 +176,8 @@ it('isEnabled and isDisabled should work', async ({ page }) => {
     <button disabled>button1</button>
     <button>button2</button>
     <div>div</div>
+    <div role="button" aria-disabled="true">role=button1</div>
+    <div role="button" aria-disabled="false">role=button2</div>
   `);
   const div = await page.$('div');
   expect(await div.isEnabled()).toBe(true);
@@ -192,6 +194,16 @@ it('isEnabled and isDisabled should work', async ({ page }) => {
   expect(await button2.isDisabled()).toBe(false);
   expect(await page.isEnabled(':text("button2")')).toBe(true);
   expect(await page.isDisabled(':text("button2")')).toBe(false);
+  const roleButton1 = await page.$(':text("role=button1")');
+  expect(await roleButton1.isEnabled()).toBe(false);
+  expect(await roleButton1.isDisabled()).toBe(true);
+  expect(await page.isEnabled(':text("role=button1")')).toBe(false);
+  expect(await page.isDisabled(':text("role=button1")')).toBe(true);
+  const roleButton2 = await page.$(':text("role=button2")');
+  expect(await roleButton2.isEnabled()).toBe(true);
+  expect(await roleButton2.isDisabled()).toBe(false);
+  expect(await page.isEnabled(':text("role=button2")')).toBe(true);
+  expect(await page.isDisabled(':text("role=button2")')).toBe(false);
 });
 
 it('isEditable should work', async ({ page }) => {

--- a/test/elementhandle-convenience.spec.ts
+++ b/test/elementhandle-convenience.spec.ts
@@ -177,7 +177,8 @@ it('isEnabled and isDisabled should work', async ({ page }) => {
     <button>button2</button>
     <div>div</div>
     <div role="button" aria-disabled="true">role=button1</div>
-    <div role="button" aria-disabled="false">role=button2</div>
+    <div role="button" aria-disabled="faLSE">role=button2</div>
+    <div role="button" aria-disabled="foo">role=button3</div>
   `);
   const div = await page.$('div');
   expect(await div.isEnabled()).toBe(true);
@@ -204,6 +205,11 @@ it('isEnabled and isDisabled should work', async ({ page }) => {
   expect(await roleButton2.isDisabled()).toBe(false);
   expect(await page.isEnabled(':text("role=button2")')).toBe(true);
   expect(await page.isDisabled(':text("role=button2")')).toBe(false);
+  const roleButton3 = await page.$(':text("role=button3")');
+  expect(await roleButton3.isEnabled()).toBe(false);
+  expect(await roleButton3.isDisabled()).toBe(true);
+  expect(await page.isEnabled(':text("role=button3")')).toBe(false);
+  expect(await page.isDisabled(':text("role=button3")')).toBe(true);
 });
 
 it('isEditable should work', async ({ page }) => {

--- a/test/page-click.spec.ts
+++ b/test/page-click.spec.ts
@@ -570,6 +570,18 @@ it('should wait for select to be enabled', async ({page, server}) => {
   expect(await page.evaluate('__CLICKED')).toBe(true);
 });
 
+it('should wait for div with aria-disabled to be enabled', async ({page, server}) => {
+  await page.setContent('<div onclick="javascript:window.__CLICKED=true;" role="button" aria-disabled="true"><span>Click target</span></div>');
+  let done = false;
+  const clickPromise = page.click('text=Click target').then(() => done = true);
+  await giveItAChanceToClick(page);
+  expect(await page.evaluate('window.__CLICKED')).toBe(undefined);
+  expect(done).toBe(false);
+  await page.evaluate(() => document.querySelector('[role=button]').removeAttribute('aria-disabled'));
+  await clickPromise;
+  expect(await page.evaluate('__CLICKED')).toBe(true);
+});
+
 it('should click disabled div', async ({page, server}) => {
   await page.setContent('<div onclick="javascript:window.__CLICKED=true;" disabled>Click target</div>');
   await page.click('text=Click target');


### PR DESCRIPTION
Click must be blocked if aria-disabled="true" is specified.
isEnabled() and isDisabled() should consider aria-disabled
when computing value.

This will enable better support for custom accessible buttons.