### PR TITLE
chore(trace viewer): split SnapshotServer

### DIFF
--- a/src/cli/traceViewer/traceServer.ts
+++ b/src/cli/traceViewer/traceServer.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as http from 'http';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { TraceModel } from './traceModel';
+
+export type ServerRouteHandler = (request: http.IncomingMessage, response: http.ServerResponse) => boolean;
+
+export class TraceServer {
+  private _traceModel: TraceModel;
+  private _server: http.Server | undefined;
+  private _urlPrefix: string;
+  private _routes: { prefix?: string, exact?: string, needsReferrer: boolean, handler: ServerRouteHandler }[] = [];
+
+  constructor(traceModel: TraceModel) {
+    this._traceModel = traceModel;
+    this._urlPrefix = '';
+
+    const traceModelHandler: ServerRouteHandler = (request, response) => {
+      response.statusCode = 200;
+      response.setHeader('Content-Type', 'application/json');
+      response.end(JSON.stringify(this._traceModel));
+      return true;
+    };
+    this.routePath('/tracemodel', traceModelHandler);
+  }
+
+  routePrefix(prefix: string, handler: ServerRouteHandler, skipReferrerCheck?: boolean) {
+    this._routes.push({ prefix, handler, needsReferrer: !skipReferrerCheck });
+  }
+
+  routePath(path: string, handler: ServerRouteHandler, skipReferrerCheck?: boolean) {
+    this._routes.push({ exact: path, handler, needsReferrer: !skipReferrerCheck });
+  }
+
+  async start(): Promise<string> {
+    this._server = http.createServer(this._onRequest.bind(this));
+    this._server.listen();
+    await new Promise(cb => this._server!.once('listening', cb));
+    const address = this._server.address();
+    this._urlPrefix = typeof address === 'string' ? address : `http://127.0.0.1:${address.port}`;
+    return this._urlPrefix;
+  }
+
+  async stop() {
+    await new Promise(cb => this._server!.close(cb));
+  }
+
+  urlPrefix() {
+    return this._urlPrefix;
+  }
+
+  serveFile(response: http.ServerResponse, absoluteFilePath: string, headers?: { [name: string]: string }): boolean {
+    try {
+      const content = fs.readFileSync(absoluteFilePath);
+      response.statusCode = 200;
+      const contentType = extensionToMime[path.extname(absoluteFilePath).substring(1)] || 'application/octet-stream';
+      response.setHeader('Content-Type', contentType);
+      response.setHeader('Content-Length', content.byteLength);
+      for (const [name, value] of Object.entries(headers || {}))
+        response.setHeader(name, value);
+      response.end(content);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  private _onRequest(request: http.IncomingMessage, response: http.ServerResponse) {
+    request.on('error', () => response.end());
+    try {
+      if (!request.url) {
+        response.end();
+        return;
+      }
+      const url = new URL('http://localhost' + request.url);
+      const hasReferrer = request.headers['referer'] && request.headers['referer'].startsWith(this._urlPrefix);
+      for (const route of this._routes) {
+        if (route.needsReferrer && !hasReferrer)
+          continue;
+        if (route.exact && url.pathname === route.exact && route.handler(request, response))
+          return;
+        if (route.prefix && url.pathname.startsWith(route.prefix) && route.handler(request, response))
+          return;
+      }
+      response.statusCode = 404;
+      response.end();
+    } catch (e) {
+      response.end();
+    }
+  }
+}
+
+const extensionToMime: { [key: string]: string } = {
+  'css': 'text/css',
+  'html': 'text/html',
+  'jpeg': 'image/jpeg',
+  'jpg': 'image/jpeg',
+  'js': 'application/javascript',
+  'png': 'image/png',
+  'ttf': 'font/ttf',
+  'svg': 'image/svg+xml',
+  'webp': 'image/webp',
+  'woff': 'font/woff',
+  'woff2': 'font/woff2',
+};

--- a/src/cli/traceViewer/traceViewer.ts
+++ b/src/cli/traceViewer/traceViewer.ts
@@ -22,6 +22,7 @@ import { ScreenshotGenerator } from './screenshotGenerator';
 import { readTraceFile, TraceModel } from './traceModel';
 import type { TraceEvent } from '../../trace/traceTypes';
 import { SnapshotServer } from './snapshotServer';
+import { ServerRouteHandler, TraceServer } from './traceServer';
 
 const fsReadFileAsync = util.promisify(fs.readFile.bind(fs));
 
@@ -80,14 +81,81 @@ class TraceViewer {
 
   async show() {
     const browser = await playwright.chromium.launch({ headless: false });
-    const server = await SnapshotServer.create(
-        path.join(__dirname, '..', '..', 'web'),
-        this._document ? this._document.resourcesDir : undefined,
-        this._document ? this._document.model : emptyModel,
-        this._document ? new ScreenshotGenerator(this._document.resourcesDir, this._document.model) : undefined);
+
+    // Served by TraceServer
+    // - "/tracemodel" - json with trace model.
+    //
+    // Served by TraceViewer
+    // - "/traceviewer/..." - our frontend.
+    // - "/file?filePath" - local files, used by sources tab.
+    // - "/action-preview/..." - lazily generated action previews.
+    // - "/sha1/<sha1>" - trace resource bodies, used by network previews.
+    //
+    // Served by SnapshotServer
+    // - "/resources/<resourceId>" - network resources from the trace.
+    // - "/snapshot/" - root for snapshot frame.
+    // - "/snapshot/pageId/..." - actual snapshot html.
+    // - "/snapshot/service-worker.js" - service worker that intercepts snapshot resources
+    //   and translates them into "/resources/<resourceId>".
+
+    const server = new TraceServer(this._document ? this._document.model : emptyModel);
+    const snapshotServer = new SnapshotServer(server, this._document ? this._document.model : emptyModel, this._document ? this._document.resourcesDir : undefined);
+    const screenshotGenerator = this._document ? new ScreenshotGenerator(snapshotServer, this._document.resourcesDir, this._document.model) : undefined;
+
+    const traceViewerHandler: ServerRouteHandler = (request, response) => {
+      const relativePath = request.url!.substring('/traceviewer/'.length);
+      const absolutePath = path.join(__dirname, '..', '..', 'web', ...relativePath.split('/'));
+      return server.serveFile(response, absolutePath);
+    };
+    server.routePrefix('/traceviewer/', traceViewerHandler, true);
+
+    const actionPreviewHandler: ServerRouteHandler = (request, response) => {
+      if (!screenshotGenerator)
+        return false;
+      const fullPath = request.url!.substring('/action-preview/'.length);
+      const actionId = fullPath.substring(0, fullPath.indexOf('.png'));
+      screenshotGenerator.generateScreenshot(actionId).then(body => {
+        if (!body) {
+          response.statusCode = 404;
+          response.end();
+        } else {
+          response.statusCode = 200;
+          response.setHeader('Content-Type', 'image/png');
+          response.setHeader('Content-Length', body.byteLength);
+          response.end(body);
+        }
+      });
+      return true;
+    };
+    server.routePrefix('/action-preview/', actionPreviewHandler);
+
+    const fileHandler: ServerRouteHandler = (request, response) => {
+      try {
+        const url = new URL('http://localhost' + request.url!);
+        const search = url.search;
+        if (search[0] !== '?')
+          return false;
+        return server.serveFile(response, search.substring(1));
+      } catch (e) {
+        return false;
+      }
+    };
+    server.routePath('/file', fileHandler);
+
+    const sha1Handler: ServerRouteHandler = (request, response) => {
+      if (!this._document)
+        return false;
+      const sha1 = request.url!.substring('/sha1/'.length);
+      if (sha1.includes('/'))
+        return false;
+      return server.serveFile(response, path.join(this._document.resourcesDir, sha1));
+    };
+    server.routePrefix('/sha1/', sha1Handler);
+
+    const urlPrefix = await server.start();
     const uiPage = await browser.newPage({ viewport: null });
     uiPage.on('close', () => process.exit(0));
-    await uiPage.goto(server.traceViewerUrl('traceViewer/index.html'));
+    await uiPage.goto(urlPrefix + '/traceviewer/traceViewer/index.html');
   }
 }
 

--- a/src/web/traceViewer/index.tsx
+++ b/src/web/traceViewer/index.tsx
@@ -22,9 +22,6 @@ import { applyTheme } from '../theme';
 import '../common.css';
 
 (async () => {
-  navigator.serviceWorker.register('/service-worker.js');
-  if (!navigator.serviceWorker.controller)
-    await new Promise(resolve => navigator.serviceWorker.oncontrollerchange = resolve);
   applyTheme();
   const traceModel = await fetch('/tracemodel').then(response => response.json());
   ReactDOM.render(<Workbench traceModel={traceModel} />, document.querySelector('#root'));

--- a/src/web/traceViewer/ui/propertiesTabbedPane.tsx
+++ b/src/web/traceViewer/ui/propertiesTabbedPane.tsx
@@ -76,8 +76,6 @@ const SnapshotTab: React.FunctionComponent<{
 }> = ({ actionEntry, snapshotSize, selectedTime, boundaries }) => {
   const [measure, ref] = useMeasure<HTMLDivElement>();
   const [snapshotIndex, setSnapshotIndex] = React.useState(0);
-  const origin = location.href.substring(0, location.href.indexOf(location.pathname));
-  const snapshotIframeUrl = origin + '/snapshot/';
 
   let snapshots: { name: string, snapshotId?: string, snapshotTime?: number }[] = [];
   snapshots = (actionEntry ? (actionEntry.action.snapshots || []) : []).slice();
@@ -91,15 +89,16 @@ const SnapshotTab: React.FunctionComponent<{
     if (!actionEntry || !iframeRef.current)
       return;
 
+    // TODO: this logic is copied from SnapshotServer. Find a way to share.
     let snapshotUrl = 'data:text/html,Snapshot is not available';
     if (selectedTime) {
-      snapshotUrl = origin + `/snapshot/pageId/${actionEntry.action.pageId!}/timestamp/${selectedTime}/main`;
+      snapshotUrl = `/snapshot/pageId/${actionEntry.action.pageId!}/timestamp/${selectedTime}/main`;
     } else {
       const snapshot = snapshots[snapshotIndex];
       if (snapshot && snapshot.snapshotTime)
-        snapshotUrl = origin + `/snapshot/pageId/${actionEntry.action.pageId!}/timestamp/${snapshot.snapshotTime}/main`;
+        snapshotUrl = `/snapshot/pageId/${actionEntry.action.pageId!}/timestamp/${snapshot.snapshotTime}/main`;
       else if (snapshot && snapshot.snapshotId)
-        snapshotUrl = origin + `/snapshot/pageId/${actionEntry.action.pageId!}/snapshotId/${snapshot.snapshotId}/main`;
+        snapshotUrl = `/snapshot/pageId/${actionEntry.action.pageId!}/snapshotId/${snapshot.snapshotId}/main`;
     }
 
     try {
@@ -129,7 +128,7 @@ const SnapshotTab: React.FunctionComponent<{
         height: snapshotSize.height + 'px',
         transform: `translate(${-snapshotSize.width * (1 - scale) / 2}px, ${-snapshotSize.height * (1 - scale) / 2}px) scale(${scale})`,
       }}>
-        <iframe ref={iframeRef} id='snapshot' name='snapshot' src={snapshotIframeUrl}></iframe>
+        <iframe ref={iframeRef} id='snapshot' name='snapshot' src='/snapshot/'></iframe>
       </div>
     </div>
   </div>;


### PR DESCRIPTION
- Move service worker under /snapshot/ instead of /.
- Fix stylesheet base uri bug, where we inherited the wrong base url.
- Introduce TraceServer and routes there, split the actual routes
  between snapshot, ui and action previews.