### PR TITLE
feat(snapshots): make cssom overrides efficient

### DIFF
--- a/src/cli/traceViewer/traceModel.ts
+++ b/src/cli/traceViewer/traceModel.ts
@@ -29,7 +29,6 @@ export type ContextEntry = {
   created: trace.ContextCreatedTraceEvent;
   destroyed: trace.ContextDestroyedTraceEvent;
   pages: PageEntry[];
-  resourcesByUrl: Map<string, trace.NetworkResourceTraceEvent[]>;
 }
 
 export type VideoEntry = {
@@ -79,7 +78,6 @@ export function readTraceFile(events: trace.TraceEvent[], traceModel: TraceModel
           created: event,
           destroyed: undefined as any,
           pages: [],
-          resourcesByUrl: new Map(),
         });
         break;
       }
@@ -123,19 +121,12 @@ export function readTraceFile(events: trace.TraceEvent[], traceModel: TraceModel
         break;
       }
       case 'resource': {
-        const contextEntry = contextEntries.get(event.contextId)!;
         const pageEntry = pageEntries.get(event.pageId!)!;
         const action = pageEntry.actions[pageEntry.actions.length - 1];
         if (action)
           action.resources.push(event);
         else
           pageEntry.resources.push(event);
-        let responseEvents = contextEntry.resourcesByUrl.get(event.url);
-        if (!responseEvents) {
-          responseEvents = [];
-          contextEntry.resourcesByUrl.set(event.url, responseEvents);
-        }
-        responseEvents.push(event);
         break;
       }
       case 'dialog-opened':

--- a/src/cli/traceViewer/traceViewer.ts
+++ b/src/cli/traceViewer/traceViewer.ts
@@ -54,7 +54,6 @@ const emptyModel: TraceModel = {
       name: '<empty>',
       filePath: '',
       pages: [],
-      resourcesByUrl: new Map()
     }
   ]
 };

--- a/src/trace/snapshotter.ts
+++ b/src/trace/snapshotter.ts
@@ -67,10 +67,14 @@ export class Snapshotter {
         resourceOverrides: [],
       };
       for (const { url, content } of data.resourceOverrides) {
-        const buffer = Buffer.from(content);
-        const sha1 = calculateSha1(buffer);
-        this._delegate.onBlob({ sha1, buffer });
-        snapshot.resourceOverrides.push({ url, sha1 });
+        if (typeof content === 'string') {
+          const buffer = Buffer.from(content);
+          const sha1 = calculateSha1(buffer);
+          this._delegate.onBlob({ sha1, buffer });
+          snapshot.resourceOverrides.push({ url, sha1 });
+        } else {
+          snapshot.resourceOverrides.push({ url, ref: content });
+        }
       }
       this._delegate.onFrameSnapshot(source.frame, data.url, snapshot, data.snapshotId);
     });

--- a/src/trace/traceTypes.ts
+++ b/src/trace/traceTypes.ts
@@ -152,6 +152,6 @@ export type TraceEvent =
 export type FrameSnapshot = {
   doctype?: string,
   html: NodeSnapshot,
-  resourceOverrides: { url: string, sha1: string }[],
+  resourceOverrides: { url: string, sha1?: string, ref?: number }[],
   viewport: { width: number, height: number },
 };

--- a/test/assets/snapshot/snapshot-with-css.html
+++ b/test/assets/snapshot/snapshot-with-css.html
@@ -7,14 +7,11 @@
   }
 </style>
 <div>hello, world!</div>
-<textarea>Before edit</textarea>
 <div class=root></div>
 <script>
   let shadow;
 
   window.addEventListener('DOMContentLoaded', () => {
-    document.querySelector('textarea').value = 'After edit';
-
     const root = document.querySelector('.root');
     shadow = root.attachShadow({ mode: 'open' });
 
@@ -27,6 +24,11 @@
     imaged.className = 'imaged';
     shadow.appendChild(imaged);
 
+    const textarea = document.createElement('textarea');
+    textarea.textContent = 'Before edit';
+    textarea.style.display = 'block';
+    shadow.appendChild(textarea);
+
     const iframe = document.createElement('iframe');
     iframe.width = '600px';
     iframe.height = '600px';
@@ -35,13 +37,22 @@
   });
 
   window.addEventListener('load', () => {
-    for (const rule of shadow.styleSheets[0].cssRules) {
-      if (rule.styleSheet) {
-        for (const rule2 of rule.styleSheet.cssRules) {
-          if (rule2.cssText.includes('width: 200px'))
-            rule2.style.width = '400px';
+    setTimeout(() => {
+      shadow.querySelector('textarea').value = 'After edit';
+
+      for (const rule of document.styleSheets[1].cssRules) {
+        if (rule.cssText.includes('background: cyan'))
+          rule.style.background = 'magenta';
+      }
+
+      for (const rule of shadow.styleSheets[0].cssRules) {
+        if (rule.styleSheet) {
+          for (const rule2 of rule.styleSheet.cssRules) {
+            if (rule2.cssText.includes('width: 200px'))
+              rule2.style.width = '400px';
+          }
         }
       }
-    }
+    }, 500);
   });
 </script>


### PR DESCRIPTION
- Intercept CSSOM modifications and recalculate overridden css text.
- When css text does not change, use "backwards reference" similar
  to node references.
- Set 'Cache-Control: no-cache' for resources that could be overridden.