### PR TITLE
feat(snapshots): switch MutationObserver to only observer attributes

### DIFF
--- a/src/trace/snapshotter.ts
+++ b/src/trace/snapshotter.ts
@@ -62,6 +62,7 @@ export class Snapshotter {
     ];
     this._context.exposeBinding(kSnapshotBinding, false, (source, data: SnapshotData) => {
       const snapshot: FrameSnapshot = {
+        doctype: data.doctype,
         html: data.html,
         viewport: data.viewport,
         resourceOverrides: [],


### PR DESCRIPTION
Everything but attributes in the light dom is manually compared during
DOM traversal, for example child nodes or scroll offset.

This way we get a bullet-proof solution that works with input values,
scroll offsets, shadow dom and anything else web comes up with.

We also restore scroll only on the document scrolling element, for
performance reasons. We should figure out the story around scrolling.

Changes stationary snapshots from ~0.5ms to ~2.5ms due to DOM traversal.