### PR TITLE
docs(csharp): events convention based naming fix for csharp

### DIFF
--- a/docs/src/api/class-chromiumbrowsercontext.md
+++ b/docs/src/api/class-chromiumbrowsercontext.md
@@ -16,7 +16,7 @@ background_page = await context.wait_for_event("backgroundpage")
 background_page = context.wait_for_event("backgroundpage")
 ```
 
-## event: ChromiumBrowserContext.backgroundpage
+## event: ChromiumBrowserContext.backgroundPage
 - type: <[Page]>
 
 Emitted when new background page is created in the context.
@@ -25,7 +25,7 @@ Emitted when new background page is created in the context.
 Only works with persistent context.
 :::
 
-## event: ChromiumBrowserContext.serviceworker
+## event: ChromiumBrowserContext.serviceWorker
 - type: <[Worker]>
 
 Emitted when new service worker is created in the context.

--- a/docs/src/api/class-filechooser.md
+++ b/docs/src/api/class-filechooser.md
@@ -1,6 +1,6 @@
 # class: FileChooser
 
-[FileChooser] objects are dispatched by the page in the [`event: Page.filechooser`] event.
+[FileChooser] objects are dispatched by the page in the [`event: Page.fileChooser`] event.
 
 ```js
 const [fileChooser] = await Promise.all([

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -4,10 +4,10 @@ At every point of time, page exposes its current frame tree via the [`method: Pa
 [`method: Frame.childFrames`] methods.
 
 [Frame] object's lifecycle is controlled by three events, dispatched on the page object:
-* [`event: Page.frameattached`] - fired when the frame gets attached to the page. A Frame can be attached to the page
+* [`event: Page.frameAttached`] - fired when the frame gets attached to the page. A Frame can be attached to the page
   only once.
-* [`event: Page.framenavigated`] - fired when the frame commits navigation to a different URL.
-* [`event: Page.framedetached`] - fired when the frame gets detached from the page.  A Frame can be detached from the
+* [`event: Page.frameNavigated`] - fired when the frame commits navigation to a different URL.
+* [`event: Page.frameDetached`] - fired when the frame gets detached from the page.  A Frame can be detached from the
   page only once.
 
 An example of dumping frame tree:

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -236,7 +236,7 @@ Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/We
 
 Emitted when an uncaught exception happens within the page.
 
-## event: Page.popUp
+## event: Page.popup
 - type: <[Page]>
 
 Emitted when the page opens a new tab or window. This event is emitted in addition to the
@@ -286,7 +286,7 @@ Emitted when a request fails, for example by timing out.
 
 :::note
 HTTP Error responses, such as 404 or 503, are still successful responses from HTTP standpoint, so request will complete
-with [`event: Page.requestfinished`] event and not with [`event: Page.requestfailed`].
+with [`event: Page.requestFinished`] event and not with [`event: Page.requestFailed`].
 :::
 
 ## event: Page.requestFinished

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -177,7 +177,7 @@ Emitted when a JavaScript dialog appears, such as `alert`, `prompt`, `confirm` o
 When no [`event: Page.dialog`] listeners are present, all dialogs are automatically dismissed.
 :::
 
-## event: Page.domcontentloaded
+## event: Page.DOMContentLoaded
 - type: <[Page]>
 
 Emitted when the JavaScript [`DOMContentLoaded`](https://developer.mozilla.org/en-US/docs/Web/Events/DOMContentLoaded)
@@ -195,7 +195,7 @@ downloaded content. If [`option: acceptDownloads`] is not set, download events a
 not performed and user has no access to the downloaded files.
 :::
 
-## event: Page.filechooser
+## event: Page.fileChooser
 - type: <[FileChooser]>
 
 Emitted when a file chooser is supposed to appear, such as after clicking the  `<input type=file>`. Playwright can
@@ -211,17 +211,17 @@ page.on('filechooser', async (fileChooser) => {
 page.on("filechooser", lambda file_chooser: file_chooser.set_files("/tmp/myfile.pdf"))
 ```
 
-## event: Page.frameattached
+## event: Page.frameAttached
 - type: <[Frame]>
 
 Emitted when a frame is attached.
 
-## event: Page.framedetached
+## event: Page.frameDetached
 - type: <[Frame]>
 
 Emitted when a frame is detached.
 
-## event: Page.framenavigated
+## event: Page.frameNavigated
 - type: <[Frame]>
 
 Emitted when a frame is navigated to a new url.
@@ -231,12 +231,12 @@ Emitted when a frame is navigated to a new url.
 
 Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched.
 
-## event: Page.pageerror
+## event: Page.pageError
 - type: <[Error]>
 
 Emitted when an uncaught exception happens within the page.
 
-## event: Page.popup
+## event: Page.popUp
 - type: <[Page]>
 
 Emitted when the page opens a new tab or window. This event is emitted in addition to the
@@ -279,7 +279,7 @@ cases).
 Emitted when a page issues a request. The [request] object is read-only. In order to intercept and mutate requests, see
 [`method: Page.route`] or [`method: BrowserContext.route`].
 
-## event: Page.requestfailed
+## event: Page.requestFailed
 - type: <[Request]>
 
 Emitted when a request fails, for example by timing out.
@@ -289,7 +289,7 @@ HTTP Error responses, such as 404 or 503, are still successful responses from HT
 with [`event: Page.requestfinished`] event and not with [`event: Page.requestfailed`].
 :::
 
-## event: Page.requestfinished
+## event: Page.requestFinished
 - type: <[Request]>
 
 Emitted when a request finishes successfully after downloading the response body. For a successful response, the
@@ -301,7 +301,7 @@ sequence of events is `request`, `response` and `requestfinished`.
 Emitted when [response] status and headers are received for a request. For a successful response, the sequence of events
 is `request`, `response` and `requestfinished`.
 
-## event: Page.websocket
+## event: Page.webSocket
 - type: <[WebSocket]>
 
 Emitted when <[WebSocket]> request is sent.

--- a/docs/src/api/class-request.md
+++ b/docs/src/api/class-request.md
@@ -3,10 +3,10 @@
 Whenever the page sends a request for a network resource the following sequence of events are emitted by [Page]:
 * [`event: Page.request`] emitted when the request is issued by the page.
 * [`event: Page.response`] emitted when/if the response status and headers are received for the request.
-* [`event: Page.requestfinished`] emitted when the response body is downloaded and the request is complete.
+* [`event: Page.requestFinished`] emitted when the response body is downloaded and the request is complete.
 
 If request fails at some point, then instead of `'requestfinished'` event (and possibly instead of 'response' event),
-the  [`event: Page.requestfailed`] event is emitted.
+the  [`event: Page.requestFailed`] event is emitted.
 
 :::note
 HTTP Error responses, such as 404 or 503, are still successful responses from HTTP standpoint, so request will complete

--- a/docs/src/api/class-websocket.md
+++ b/docs/src/api/class-websocket.md
@@ -19,7 +19,7 @@ Fired when the websocket recieves a frame.
 
 Fired when the websocket sends a frame.
 
-## event: WebSocket.sockEterror
+## event: WebSocket.socketError
 - type: <[String]>
 
 Fired when the websocket has an error.

--- a/docs/src/api/class-websocket.md
+++ b/docs/src/api/class-websocket.md
@@ -7,19 +7,19 @@ The [WebSocket] class represents websocket connections in the page.
 
 Fired when the websocket closes.
 
-## event: WebSocket.framereceived
+## event: WebSocket.frameReceived
 - type: <[Object]>
   - `payload` <[string]|[Buffer]> frame payload
 
 Fired when the websocket recieves a frame.
 
-## event: WebSocket.framesent
+## event: WebSocket.frameSent
 - type: <[Object]>
   - `payload` <[string]|[Buffer]> frame payload
 
 Fired when the websocket sends a frame.
 
-## event: WebSocket.socketerror
+## event: WebSocket.sockEterror
 - type: <[String]>
 
 Fired when the websocket has an error.

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -487,7 +487,7 @@ page.set_input_files(
 )
 ```
 
-If you don't have input element in hand (it is created dynamically), you can handle the [`event: Page.filechooser`] event
+If you don't have input element in hand (it is created dynamically), you can handle the [`event: Page.fileChooser`] event
 or use a corresponding waiting method upon your action:
 
 ```js

--- a/docs/src/navigations.md
+++ b/docs/src/navigations.md
@@ -21,7 +21,7 @@ navigation succeeds, page starts **loading** the document.
 events:
 - [`method: Page.url`] is set to the new url
 - document content is loaded over network and parsed
-- [`event: Page.domcontentloaded`] event is fired
+- [`event: Page.DOMContentLoaded`] event is fired
 - page executes some scripts and loads resources like stylesheets and images
 - [`event: Page.load`] event is fired
 - page executes dynamically loaded scripts

--- a/docs/src/verification.md
+++ b/docs/src/verification.md
@@ -108,7 +108,7 @@ page.goto("data:text/html,<script>throw new Error('test')</script>")
 
 ### API reference
 - [Page]
-- [`event: Page.pageerror`]
+- [`event: Page.pageError`]
 
 <br/>
 
@@ -161,6 +161,6 @@ popup = popup_info.value
 
 ### API reference
 - [Page]
-- [`event: Page.requestfailed`]
+- [`event: Page.requestFailed`]
 - [`event: Page.dialog`]
 - [`event: Page.popup`]

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -54,7 +54,7 @@ let hadChanges = false;
     if (member.kind === 'method')
       return createMemberLink(member.clazz, `${member.clazz.varName}.${member.alias}(${renderJSSignature(member.argsArray)})`);
     if (member.kind === 'event')
-      return createMemberLink(member.clazz, `${member.clazz.varName}.on('${member.alias}')`);
+      return createMemberLink(member.clazz, `${member.clazz.varName}.on('${member.alias.toLowerCase()}')`);
     if (member.kind === 'property')
       return createMemberLink(member.clazz, `${member.clazz.varName}.${member.alias}`);
     throw new Error('Unknown member kind ' + member.kind);
@@ -184,7 +184,8 @@ function createEventDescriptions(classDesc) {
   if (!hasUniqueEvents(classDesc))
     return [];
   const descriptions = [];
-  for (const [eventName, value] of classDesc.events) {
+  for (let [eventName, value] of classDesc.events) {
+    eventName = eventName.toLowerCase();
     const type = stringifyComplexType(value && value.type, '', classDesc.name, eventName, 'payload');
     const argName = argNameForType(type);
     const params = argName ? `${argName}: ${type}` : '';


### PR DESCRIPTION
Updating some event names to match the expected convention in dotnet land.