### PR TITLE
docs: note that user data dir is a parent of profile path

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -216,8 +216,9 @@ this context will automatically close the browser.
 - `userDataDir` <[path]>
 
 Path to a User Data Directory, which stores browser session data like cookies and local storage. More details for
-[Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md) and
+[Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md#introduction) and
 [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options#User_Profile).
+Note that Chromium's user data directory is the **parent** directory of the "Profile Path" seen at `chrome://version`.
 
 ### option: BrowserType.launchPersistentContext.headless
 - `headless` <[boolean]>

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6256,8 +6256,9 @@ export interface BrowserType<Browser> {
    * 
    * Launches browser that uses persistent storage located at `userDataDir` and returns the only context. Closing this
    * context will automatically close the browser.
-   * @param userDataDir Path to a User Data Directory, which stores browser session data like cookies and local storage. More details for [Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md) and
-   * [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options#User_Profile).
+   * @param userDataDir Path to a User Data Directory, which stores browser session data like cookies and local storage. More details for [Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md#introduction) and
+   * [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options#User_Profile). Note that Chromium's user
+   * data directory is the **parent** directory of the "Profile Path" seen at `chrome://version`.
    * @param options 
    */
   launchPersistentContext(userDataDir: string, options?: {


### PR DESCRIPTION
Copied from https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md#current-location
to help users that copy "Profile Path" to be used as user data dir.

Fixes #5258.