### PR TITLE
fix(oopifs): do not emulate focus in oopifs

### DIFF
--- a/src/server/chromium/crPage.ts
+++ b/src/server/chromium/crPage.ts
@@ -445,8 +445,9 @@ class FrameSession {
       }),
       this._networkManager.initialize(),
       this._client.send('Target.setAutoAttach', { autoAttach: true, waitForDebuggerOnStart: true, flatten: true }),
-      this._client.send('Emulation.setFocusEmulationEnabled', { enabled: true }),
     ];
+    if (this._isMainFrame())
+      promises.push(this._client.send('Emulation.setFocusEmulationEnabled', { enabled: true }));
     const options = this._crPage._browserContext._options;
     if (options.bypassCSP)
       promises.push(this._client.send('Page.setBypassCSP', { enabled: true }));


### PR DESCRIPTION
- We don't need this, since it should propagate from the main frame.
- Forcing focus in oopif immediately focuses it and blurs currently focused frame. This leads to undesired side effects, e.g. selects being closed.

Fixes #5226.