### PR TITLE
feat(snapshot): page.snapshot prototype with tests

### DIFF
--- a/src/cli/traceViewer/snapshotServer.ts
+++ b/src/cli/traceViewer/snapshotServer.ts
@@ -19,8 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { TraceModel, trace, ContextEntry } from './traceModel';
 import { TraceServer } from './traceServer';
-import { NodeSnapshot } from '../../trace/traceTypes';
-
+import {serializeSnapshot} from '../../trace/serializeSnapshot';
 export class SnapshotServer {
   private _resourcesDir: string | undefined;
   private _server: TraceServer;
@@ -202,75 +201,6 @@ export class SnapshotServer {
         }
       }
 
-      const autoClosing = new Set(['AREA', 'BASE', 'BR', 'COL', 'COMMAND', 'EMBED', 'HR', 'IMG', 'INPUT', 'KEYGEN', 'LINK', 'MENUITEM', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR']);
-      const escaped = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', '\'': '&#39;' };
-      function escapeAttribute(s: string): string {
-        return s.replace(/[&<>"']/ug, char => (escaped as any)[char]);
-      }
-      function escapeText(s: string): string {
-        return s.replace(/[&<]/ug, char => (escaped as any)[char]);
-      }
-
-      function snapshotNodes(snapshot: trace.FrameSnapshot): NodeSnapshot[] {
-        if (!(snapshot as any)._nodes) {
-          const nodes: NodeSnapshot[] = [];
-          const visit = (n: trace.NodeSnapshot) => {
-            if (typeof n === 'string') {
-              nodes.push(n);
-            } else if (typeof n[0] === 'string') {
-              for (let i = 2; i < n.length; i++)
-                visit(n[i]);
-              nodes.push(n);
-            }
-          };
-          visit(snapshot.html);
-          (snapshot as any)._nodes = nodes;
-        }
-        return (snapshot as any)._nodes;
-      }
-
-      function serializeSnapshot(snapshots: trace.FrameSnapshotTraceEvent[], initialSnapshotIndex: number): string {
-        const visit = (n: trace.NodeSnapshot, snapshotIndex: number): string => {
-          // Text node.
-          if (typeof n === 'string')
-            return escapeText(n);
-
-          if (!(n as any)._string) {
-            if (Array.isArray(n[0])) {
-              // Node reference.
-              const referenceIndex = snapshotIndex - n[0][0];
-              if (referenceIndex >= 0 && referenceIndex < snapshotIndex) {
-                const nodes = snapshotNodes(snapshots[referenceIndex].snapshot);
-                const nodeIndex = n[0][1];
-                if (nodeIndex >= 0 && nodeIndex < nodes.length)
-                  (n as any)._string = visit(nodes[nodeIndex], referenceIndex);
-              }
-            } else if (typeof n[0] === 'string') {
-              // Element node.
-              const builder: string[] = [];
-              builder.push('<', n[0]);
-              for (const [attr, value] of Object.entries(n[1] || {}))
-                builder.push(' ', attr, '="', escapeAttribute(value), '"');
-              builder.push('>');
-              for (let i = 2; i < n.length; i++)
-                builder.push(visit(n[i], snapshotIndex));
-              if (!autoClosing.has(n[0]))
-                builder.push('</', n[0], '>');
-              (n as any)._string = builder.join('');
-            } else {
-              // Why are we here? Let's not throw, just in case.
-              (n as any)._string = '';
-            }
-          }
-          return (n as any)._string;
-        };
-
-        const snapshot = snapshots[initialSnapshotIndex].snapshot;
-        let html = visit(snapshot.html, initialSnapshotIndex);
-        if (snapshot.doctype)
-          html = `<!DOCTYPE ${snapshot.doctype}>` + html;
-        return html;
-      }
 
       function findResourceOverride(snapshots: trace.FrameSnapshotTraceEvent[], snapshotIndex: number, url: string): string | undefined {
         while (true) {

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -32,6 +32,7 @@ import { ProgressController, runAbortableTask } from './progress';
 import { assert, isError } from '../utils/utils';
 import { debugLogger } from '../utils/debugLogger';
 import { Selectors } from './selectors';
+import { takeSnapshot } from '../trace/snapshotter';
 
 export interface PageDelegate {
   readonly rawMouse: input.RawMouse;
@@ -413,6 +414,15 @@ export class Page extends EventEmitter {
       return;
     }
     route.continue();
+  }
+
+  async snapshot() {
+    return takeSnapshot(this);
+  }
+
+  async loadSnapshot(snapshot: string) {
+    const controller = new ProgressController();
+    await this.mainFrame().setContent(controller, snapshot);
   }
 
   async screenshot(options: types.ScreenshotOptions = {}): Promise<Buffer> {

--- a/src/trace/serializeSnapshot.ts
+++ b/src/trace/serializeSnapshot.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FrameSnapshot, NodeSnapshot, FrameSnapshotTraceEvent } from './traceTypes';
+
+const autoClosing = new Set(['AREA', 'BASE', 'BR', 'COL', 'COMMAND', 'EMBED', 'HR', 'IMG', 'INPUT', 'KEYGEN', 'LINK', 'MENUITEM', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR']);
+const escaped = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', '\'': '&#39;' };
+function escapeAttribute(s: string): string {
+  return s.replace(/[&<>"']/ug, char => (escaped as any)[char]);
+}
+function escapeText(s: string): string {
+  return s.replace(/[&<]/ug, char => (escaped as any)[char]);
+}
+
+function snapshotNodes(snapshot: FrameSnapshot): NodeSnapshot[] {
+  if (!(snapshot as any)._nodes) {
+    const nodes: NodeSnapshot[] = [];
+    const visit = (n: NodeSnapshot) => {
+      if (typeof n === 'string') {
+        nodes.push(n);
+      } else if (typeof n[0] === 'string') {
+        for (let i = 2; i < n.length; i++)
+          visit(n[i] as NodeSnapshot);
+        nodes.push(n);
+      }
+    };
+    visit(snapshot.html);
+    (snapshot as any)._nodes = nodes;
+  }
+  return (snapshot as any)._nodes;
+}
+export function serializeSnapshot(snapshots: FrameSnapshotTraceEvent[], initialSnapshotIndex: number): string {
+  const visit = (n: NodeSnapshot, snapshotIndex: number): string => {
+    // Text node.
+    if (typeof n === 'string')
+      return escapeText(n);
+
+    if (!(n as any)._string) {
+      if (Array.isArray(n[0])) {
+        // Node reference.
+        const referenceIndex = snapshotIndex - n[0][0];
+        if (referenceIndex >= 0 && referenceIndex < snapshotIndex) {
+          const nodes = snapshotNodes(snapshots[referenceIndex].snapshot);
+          const nodeIndex = n[0][1];
+          if (nodeIndex >= 0 && nodeIndex < nodes.length)
+            (n as any)._string = visit(nodes[nodeIndex], referenceIndex);
+        }
+      } else if (typeof n[0] === 'string') {
+        // Element node.
+        const builder: string[] = [];
+        builder.push('<', n[0]);
+        for (const [attr, value] of Object.entries(n[1] || {}))
+          builder.push(' ', attr, '="', escapeAttribute(value), '"');
+        builder.push('>');
+        for (let i = 2; i < n.length; i++)
+          builder.push(visit(n[i] as NodeSnapshot, snapshotIndex));
+        if (!autoClosing.has(n[0]))
+          builder.push('</', n[0], '>');
+        (n as any)._string = builder.join('');
+      } else {
+        // Why are we here? Let's not throw, just in case.
+        (n as any)._string = '';
+      }
+    }
+    return (n as any)._string;
+  };
+
+  const snapshot = snapshots[initialSnapshotIndex].snapshot;
+  let html = visit(snapshot.html, initialSnapshotIndex);
+  if (snapshot.doctype)
+    html = `<!DOCTYPE ${snapshot.doctype}>` + html;
+  return html;
+}

--- a/test/snapshots.spec.ts
+++ b/test/snapshots.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { it, describe } from './fixtures';
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+import type {Page} from '../src/server/page';
+import fs from 'fs';
+import path from 'path';
+
+describe('screenshot', (suite, { mode }) => {
+  suite.skip(mode !== 'default');
+}, () => {
+  it('button', async ({page, server, toImpl, testInfo}) => {
+    await page.goto(server.PREFIX + '/input/button.html');
+    await testPage(toImpl(page), testInfo.outputPath('snapshot.png'));
+  });
+
+  // fails because of the focus ring
+  // fails because of the text caret
+  // fails because of textarea selection
+  it.skip('textarea', async ({page, server, toImpl, testInfo}) => {
+    await page.goto(server.PREFIX + '/input/textarea.html');
+    await page.fill('textarea', 'hello world');
+    await page.$eval('textarea', t => t.setSelectionRange(5, 10));
+    await testPage(toImpl(page), testInfo.outputPath('snapshot.png'));
+  });
+
+  it('scrollable', async ({page, server, toImpl, testInfo}) => {
+    await page.goto(server.PREFIX + '/input/scrollable.html');
+    await testPage(toImpl(page), testInfo.outputPath('snapshot.png'));
+  });
+
+  // the snapshot renderer doesn't yet integrate network files
+  it.skip('image', async ({page, server, toImpl, testInfo}) => {
+    await page.goto(server.EMPTY_PAGE);
+    server.setRoute('/fakeimage.png', (request, response) => {
+      server.serveFile(request, response, path.join(__dirname, 'assets', 'digits', '1.png'));
+    });
+    await page.setContent(`<img style="zoom: 5" src="/fakeimage.png">`);
+    server.reset();
+    await testPage(toImpl(page), testInfo.outputPath('snapshot.png'));
+  });
+});
+
+async function testPage(page: Page, filePath: string) {
+  const expectedBuffer = await page.screenshot();
+  const snapshot = await page.snapshot();
+  await page.loadSnapshot(snapshot);
+  const actualBuffer = await page.screenshot();
+
+  const actual = PNG.sync.read(actualBuffer);
+  const expected = PNG.sync.read(expectedBuffer);
+  if (expected.width !== actual.width || expected.height !== actual.height)
+    throw new Error(`Sizes differ; expected image ${expected.width}px X ${expected.height}px, but got ${actual.width}px X ${actual.height}px. `);
+
+  const diff = new PNG({width: expected.width, height: expected.height});
+  const count = pixelmatch(expected.data, actual.data, diff.data, expected.width, expected.height, { threshold: 0 });
+  if (count !== 0) {
+    await fs.promises.writeFile(filePath, PNG.sync.write(diff));
+    throw new Error(`diff saved to ${filePath}`);
+  }
+}


### PR DESCRIPTION
I started adding `page.snapshot` and `page.loadSnapshot` to enable some tests of our snapshotting engine.

Some thoughts:
- `loadSnapshot` should probably be on the browser instead of the page. Because the snapshots will eventually contain isMobile. Or we could put `compareToSnapshot` on the page.
- It takes a lot of refactoring to display a snapshot outside of the trace viewer. I rolled back my changes to that made resources to work so that this patch is more approachable.
- The important edge cases that are needed for pixel perfect screenshots are not easy to add into the current snapshot format. I started to add focused node into the document, but doing so requires identifying nodes inside the serialized html. It's certainly doable, but its a lot of code so I left it out of this patch. We also need selection, `:hover`, `:active`, etc.

