### PR TITLE
docs: add enum aliases

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -504,10 +504,7 @@ The file path to save the image to. The screenshot type will be inferred from fi
 relative path, then it is resolved relative to the current working directory. If no path is provided, the image won't be
 saved to the disk.
 
-### option: ElementHandle.screenshot.type
-- `type` <"png"|"jpeg">
-
-Specify screenshot type, defaults to `png`.
+### option: ElementHandle.screenshot.type = %%-screenshot-type-%%
 
 ### option: ElementHandle.screenshot.quality
 - `quality` <[int]>

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -712,15 +712,13 @@ page.evaluate("matchMedia('(prefers-color-scheme: no-preference)').matches")
 ```
 
 ### option: Page.emulateMedia.media
-* langs:
-  - alias-enum: MediaEnum
-- `media` <[null]|"screen"|"print">
+- `media` <null|[MediaEnum]<"screen"|"print">>
 
 Changes the CSS media type of the page. The only allowed values are `'screen'`, `'print'` and `null`.
 Passing `null` disables CSS media emulation.
 
 ### option: Page.emulateMedia.colorScheme
-- `colorScheme` <[null]|"light"|"dark"|"no-preference">
+- `colorScheme` <null|[ColorSchemeEnum]<"light"|"dark"|"no-preference">>
 
 Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. Passing
 `null` disables color scheme emulation.

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -712,6 +712,8 @@ page.evaluate("matchMedia('(prefers-color-scheme: no-preference)').matches")
 ```
 
 ### option: Page.emulateMedia.media
+* langs:
+  - alias-enum: MediaEnum
 - `media` <[null]|"screen"|"print">
 
 Changes the CSS media type of the page. The only allowed values are `'screen'`, `'print'` and `null`.
@@ -1844,10 +1846,7 @@ The file path to save the image to. The screenshot type will be inferred from fi
 relative path, then it is resolved relative to the current working directory. If no path is provided, the image won't be
 saved to the disk.
 
-### option: Page.screenshot.type
-- `type` <"png"|"jpeg">
-
-Specify screenshot type, defaults to `png`.
+### option: Page.screenshot.type = %%-screenshot-type-%%
 
 ### option: Page.screenshot.quality
 - `quality` <[int]>

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -1,4 +1,6 @@
 ## navigation-wait-until
+* langs:
+  - alias-enum: WaitUntilEnum
 - `waitUntil` <"load"|"domcontentloaded"|"networkidle">
 
 When to consider operation succeeded, defaults to `load`. Events can be either:
@@ -56,12 +58,16 @@ A point to use relative to the top-left corner of element padding box. If not sp
 element.
 
 ## input-modifiers
+* langs:
+  - alias-enum: ModifierEnum
 - `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">>
 
 Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
 modifiers back. If not specified, currently pressed modifiers are used.
 
 ## input-button
+* langs:
+  - alias-enum: ButtonEnum
 - `button` <"left"|"right"|"middle">
 
 Defaults to `left`.
@@ -88,6 +94,8 @@ defaults to 1. See [UIEvent.detail].
 A selector to query for. See [working with selectors](./selectors.md) for more details.
 
 ## wait-for-selector-state
+* langs:
+  - alias-enum: ElementStateEnum
 - `state` <"attached"|"detached"|"visible"|"hidden">
 
 Defaults to `'visible'`. Can be either:
@@ -321,6 +329,8 @@ Whether to emulate network being offline. Defaults to `false`.
 Credentials for [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
 
 ## context-option-colorscheme
+* langs:
+  - alias-enum: ColorSchemeEnum
 - `colorScheme` <"light"|"dark"|"no-preference">
 
 Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. See
@@ -432,6 +442,8 @@ A glob pattern, regex pattern or predicate receiving [URL] to match while waitin
 Event name, same one typically passed into `*.on(event)`.
 
 ## wait-for-load-state-state
+* langs:
+  - alias-enum: LoadStateEnum
 - `state` <"load"|"domcontentloaded"|"networkidle">
 
 Optional load state to wait for, defaults to `load`. If the state has been already reached while loading current document, the
@@ -439,6 +451,13 @@ method resolves immediately. Can be one of:
   * `'load'` - wait for the `load` event to be fired.
   * `'domcontentloaded'` - wait for the `DOMContentLoaded` event to be fired.
   * `'networkidle'` - wait until there are no network connections for at least `500` ms.
+
+## screenshot-type
+* langs:
+  - alias-enum: ScreenshotTypeEnum
+- `type` <"png"|"jpeg">
+
+Specify screenshot type, defaults to `png`.
 
 ## java-wait-for-event-callback
 * langs: java

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -1,7 +1,5 @@
 ## navigation-wait-until
-* langs:
-  - alias-enum: WaitUntilEnum
-- `waitUntil` <"load"|"domcontentloaded"|"networkidle">
+- `waitUntil` <[WaitUntilEnum]<"load"|"domcontentloaded"|"networkidle">>
 
 When to consider operation succeeded, defaults to `load`. Events can be either:
 * `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
@@ -58,17 +56,13 @@ A point to use relative to the top-left corner of element padding box. If not sp
 element.
 
 ## input-modifiers
-* langs:
-  - alias-enum: ModifierEnum
-- `modifiers` <[Array]<"Alt"|"Control"|"Meta"|"Shift">>
+- `modifiers` <[Array]<[ModifierEnum]<"Alt"|"Control"|"Meta"|"Shift">>>
 
 Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
 modifiers back. If not specified, currently pressed modifiers are used.
 
 ## input-button
-* langs:
-  - alias-enum: ButtonEnum
-- `button` <"left"|"right"|"middle">
+- `button` <[ButtonEnum]<"left"|"right"|"middle">>
 
 Defaults to `left`.
 
@@ -94,9 +88,7 @@ defaults to 1. See [UIEvent.detail].
 A selector to query for. See [working with selectors](./selectors.md) for more details.
 
 ## wait-for-selector-state
-* langs:
-  - alias-enum: ElementStateEnum
-- `state` <"attached"|"detached"|"visible"|"hidden">
+- `state` <[ElementStateEnum]<"attached"|"detached"|"visible"|"hidden">>
 
 Defaults to `'visible'`. Can be either:
 * `'attached'` - wait for element to be present in DOM.
@@ -329,9 +321,7 @@ Whether to emulate network being offline. Defaults to `false`.
 Credentials for [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
 
 ## context-option-colorscheme
-* langs:
-  - alias-enum: ColorSchemeEnum
-- `colorScheme` <"light"|"dark"|"no-preference">
+- `colorScheme` <[ColorSchemeEnum]<"light"|"dark"|"no-preference">>
 
 Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. See
 [`method: Page.emulateMedia`] for more details. Defaults to '`light`'.
@@ -442,9 +432,7 @@ A glob pattern, regex pattern or predicate receiving [URL] to match while waitin
 Event name, same one typically passed into `*.on(event)`.
 
 ## wait-for-load-state-state
-* langs:
-  - alias-enum: LoadStateEnum
-- `state` <"load"|"domcontentloaded"|"networkidle">
+- `state` <[LoadStateEnum]<"load"|"domcontentloaded"|"networkidle">>
 
 Optional load state to wait for, defaults to `load`. If the state has been already reached while loading current document, the
 method resolves immediately. Can be one of:
@@ -453,9 +441,7 @@ method resolves immediately. Can be one of:
   * `'networkidle'` - wait until there are no network connections for at least `500` ms.
 
 ## screenshot-type
-* langs:
-  - alias-enum: ScreenshotTypeEnum
-- `type` <"png"|"jpeg">
+- `type` <[ScreenshotTypeEnum]<"png"|"jpeg">>
 
 Specify screenshot type, defaults to `png`.
 

--- a/utils/doclint/documentation.js
+++ b/utils/doclint/documentation.js
@@ -16,8 +16,6 @@
 
 // @ts-check
 
-const { triggerAsyncId } = require('async_hooks');
-const { isEnumDeclaration } = require('typescript');
 const md = require('../markdown');
 
 /** @typedef {import('../markdown').MarkdownNode} MarkdownNode */

--- a/utils/doclint/generateApiJson.js
+++ b/utils/doclint/generateApiJson.js
@@ -35,7 +35,7 @@ const PROJECT_DIR = path.join(__dirname, '..', '..');
   });
   documentation.generateSourceCodeComments();
   const result = serialize(documentation);
-  fs.writeFileSync(path.join(PROJECT_DIR, 'api.json'), JSON.stringify(result));
+  fs.writeFileSync(path.join(PROJECT_DIR, 'api.json'), JSON.stringify(result, null, 2));
 }
 
 /**

--- a/utils/doclint/generateApiJson.js
+++ b/utils/doclint/generateApiJson.js
@@ -35,7 +35,7 @@ const PROJECT_DIR = path.join(__dirname, '..', '..');
   });
   documentation.generateSourceCodeComments();
   const result = serialize(documentation);
-  fs.writeFileSync(path.join(PROJECT_DIR, 'api.json'), JSON.stringify(result, null, 2));
+  fs.writeFileSync(path.join(PROJECT_DIR, 'api.json'), JSON.stringify(result));
 }
 
 /**


### PR DESCRIPTION
Added enum aliases so that they can be used for generating named types in Java and C#.