### PR TITLE
docs: fix nested union handling

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -734,7 +734,7 @@ to pass. This method throws when the element is detached while waiting, unless w
 If the element does not satisfy the condition for the [`option: timeout`] milliseconds, this method will throw.
 
 ### param: ElementHandle.waitForElementState.state
-- `state` <"visible"|"hidden"|"stable"|"enabled"|"disabled"|"editable">
+- `state` <[ElementStateEnum]<"visible"|"hidden"|"stable"|"enabled"|"disabled"|"editable">>
 
 A state to wait for, see below for more details.
 

--- a/utils/doclint/documentation.js
+++ b/utils/doclint/documentation.js
@@ -429,11 +429,14 @@ Documentation.Type = class {
    */
   static fromParsedType(parsedType, inUnion = false) {
     if (!inUnion && parsedType.union) {
-      const name = parsedType.unionName || '';
-      const type = new Documentation.Type(name);
+      const type = new Documentation.Type(parsedType.unionName || '');
       type.union = [];
-      for (let t = parsedType; t; t = t.union)
-        type.union.push(Documentation.Type.fromParsedType(t, true));
+      for (let t = parsedType; t; t = t.union) {
+        const nestedUnion = !!t.unionName && t !== parsedType;
+        type.union.push(Documentation.Type.fromParsedType(t, !nestedUnion));
+        if (nestedUnion)
+          break;
+      }
       return type;
     }
 


### PR DESCRIPTION
Types like `<null|[MediaEnum]<"screen"|"print">>` are now parsed as nested unions.