### PR TITLE
devops: start publishing canary at midnight every day

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -35,5 +35,5 @@ jobs:
     - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
-    - run: node utils/build/update_canary_version.js
+    - run: node utils/build/update_canary_version.js --today-date
     - run: utils/build/build-playwright-driver.sh

--- a/.github/workflows/publish_canary_driver.yml
+++ b/.github/workflows/publish_canary_driver.yml
@@ -1,10 +1,9 @@
 name: "devrelease:driver"
 
 on:
-  schedule:
-    - cron: "10 0 * * *"
   push:
     branches:
+      - master
       - release-*
 
 jobs:
@@ -21,10 +20,7 @@ jobs:
     - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
-    - run: node utils/build/update_canary_version.js --today-date
-      if: contains(github.ref, "master")
     - run: node utils/build/update_canary_version.js --commit-timestamp
-      if: contains(github.ref, "release")
     - run: utils/build/build-playwright-driver.sh
     - run: utils/build/upload-playwright-driver.sh
       env:

--- a/.github/workflows/publish_canary_driver.yml
+++ b/.github/workflows/publish_canary_driver.yml
@@ -1,9 +1,10 @@
 name: "devrelease:driver"
 
 on:
+  schedule:
+    - cron: "10 0 * * *"
   push:
     branches:
-      - master
       - release-*
 
 jobs:
@@ -20,7 +21,10 @@ jobs:
     - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
-    - run: node utils/build/update_canary_version.js
+    - run: node utils/build/update_canary_version.js --today-date
+      if: contains(github.ref, "master")
+    - run: node utils/build/update_canary_version.js --commit-timestamp
+      if: contains(github.ref, "release")
     - run: utils/build/build-playwright-driver.sh
     - run: utils/build/upload-playwright-driver.sh
       env:

--- a/.github/workflows/publish_canary_npm.yml
+++ b/.github/workflows/publish_canary_npm.yml
@@ -1,9 +1,10 @@
 name: "devrelease:npm"
 
 on:
+  schedule:
+    - cron: "10 0 * * *"
   push:
     branches:
-      - master
       - release-*
 
 jobs:
@@ -20,7 +21,10 @@ jobs:
     - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
-    # publish_all_packages.sh updates the version automatically
+    - run: node utils/build/update_canary_version.js --today-date
+      if: contains(github.ref, "master")
+    - run: node utils/build/update_canary_version.js --commit-timestamp
+      if: contains(github.ref, "release")
     - run: utils/publish_all_packages.sh --tip-of-tree
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/utils/build/update_canary_version.js
+++ b/utils/build/update_canary_version.js
@@ -19,10 +19,20 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
-const timestamp = execSync('git show -s --format=%ct HEAD', {
-  stdio: ['ignore', 'pipe', 'ignore']
-}).toString('utf8').trim() + '000';
 const packageJSON = require('../../package.json');
-packageJSON.version = packageJSON.version + '-' + timestamp;
+if (process.argv[2] === '--today-date') {
+  const date = new Date();
+  const month = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'][date.getMonth()];
+  const day = date.getDate();
+  const year = date.getFullYear();
+  packageJSON.version = `${packageJSON.version}-alpha-${month}-${day}-${year}`;
+} else if (prcess.argv[2] === '--commit-timestamp') {
+  const timestamp = execSync('git show -s --format=%ct HEAD', {
+    stdio: ['ignore', 'pipe', 'ignore']
+  }).toString('utf8').trim();
+  packageJSON.version = `${packageJSON.version}-${timestamp}000`;
+} else {
+  throw new Error('This script must be run with either --timestamp or --current-date parameter');
+}
 console.log('Setting version to ' + packageJSON.version);
 fs.writeFileSync(path.join(__dirname, '..', '..', 'package.json'), JSON.stringify(packageJSON, undefined, 2) + '\n');

--- a/utils/build/update_canary_version.js
+++ b/utils/build/update_canary_version.js
@@ -32,7 +32,7 @@ if (process.argv[2] === '--today-date') {
   }).toString('utf8').trim();
   packageJSON.version = `${packageJSON.version}-${timestamp}000`;
 } else {
-  throw new Error('This script must be run with either --timestamp or --current-date parameter');
+  throw new Error('This script must be run with either --timestamp or --today-date parameter');
 }
 console.log('Setting version to ' + packageJSON.version);
 fs.writeFileSync(path.join(__dirname, '..', '..', 'package.json'), JSON.stringify(packageJSON, undefined, 2) + '\n');

--- a/utils/publish_all_packages.sh
+++ b/utils/publish_all_packages.sh
@@ -48,9 +48,6 @@ fi
 
 NPM_PUBLISH_TAG="next"
 
-if [[ $1 == "--tip-of-tree" ]]; then
-  node utils/build/update_canary_version.js
-fi
 VERSION=$(node -e 'console.log(require("./package.json").version)')
 
 if [[ $1 == "--release" ]]; then

--- a/utils/publish_all_packages.sh
+++ b/utils/publish_all_packages.sh
@@ -41,16 +41,15 @@ fi
 
 cd ..
 
-if [[ -n $(git status -s) ]]; then
-  echo "ERROR: git status is dirty; some uncommitted changes or untracked files"
-  exit 1
-fi
-
 NPM_PUBLISH_TAG="next"
 
 VERSION=$(node -e 'console.log(require("./package.json").version)')
 
 if [[ $1 == "--release" ]]; then
+  if [[ -n $(git status -s) ]]; then
+    echo "ERROR: git status is dirty; some uncommitted changes or untracked files"
+    exit 1
+  fi
   # Ensure package version does not contain dash.
   if [[ "${VERSION}" == *-* ]]; then
     echo "ERROR: cannot publish pre-release version with --release flag"
@@ -58,6 +57,10 @@ if [[ $1 == "--release" ]]; then
   fi
   NPM_PUBLISH_TAG="latest"
 elif [[ $1 == "--tip-of-tree" ]]; then
+  if [[ $(git status -s) != " M package.json" ]]; then
+    echo "ERROR: git status is unexpected; some uncommitted changes or untracked files"
+    exit 1
+  fi
   # Ensure package version contains dash.
   if [[ "${VERSION}" != *-* ]]; then
     echo "ERROR: cannot publish release version with --tip-of-tree flag"


### PR DESCRIPTION
This patch:
- starts publishing canary NPM package at 00:10AM UTC
- canary version is published from default (`master`) branch and is 
  named with a date. E.g. for a version published on Feb 5, 2021, the
  version would be `1.8.0-alpha-feb-5-2021`
- versions from release branches are still published on every commit and have the 
  regular commit timestamp suffix