### PR TITLE
chore: run recorder app without sandbox

### DIFF
--- a/src/server/supplements/recorder/recorderApp.ts
+++ b/src/server/supplements/recorder/recorderApp.ts
@@ -99,7 +99,8 @@ export class RecorderApp extends EventEmitter {
         `--user-data-dir=${path.join(os.homedir(),'.playwright-app')}`,
         '--remote-debugging-pipe',
         '--app=data:text/html,',
-        `--window-size=300,800`,
+        '--window-size=300,800',
+        '--no-sandbox',
       ],
       noDefaultViewport: true
     });


### PR DESCRIPTION
In the DevOps repo the tests are running inside Docker to verify that the Docker image's are working as intended. The CLI tests currently spawn a Chromium browser without `--no-sandbox`, thats why they are failing there since its under root. With this change the sandbox is disabled in the recorder app.

Blocks: https://github.com/aslushnikov/devops.aslushnikov.com/pull/9