### PR TITLE
fix(types): regenerate types for latest doc changes

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6274,20 +6274,19 @@ export interface BrowserType<Browser> {
    * });
    * ```
    * 
-   * > **Chromium-only** Playwright can also be used to control the Chrome browser, but it works best with the version of
-   * Chromium it is bundled with. There is no guarantee it will work with any other version. Use `executablePath` option with
-   * extreme caution.
+   * > **Chromium-only** Playwright can also be used to control the Google Chrome or Microsoft Edge browsers, but it works
+   * best with the version of Chromium it is bundled with. There is no guarantee it will work with any other version. Use
+   * `executablePath` option with extreme caution.
    * >
    * > If Google Chrome (rather than Chromium) is preferred, a
    * [Chrome Canary](https://www.google.com/chrome/browser/canary.html) or
    * [Dev Channel](https://www.chromium.org/getting-involved/dev-channel) build is suggested.
    * >
-   * > In [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browsertypelaunchoptions) above,
-   * any mention of Chromium also applies to Chrome.
-   * >
-   * > See [`this article`](https://www.howtogeek.com/202825/what%E2%80%99s-the-difference-between-chromium-and-chrome/) for
-   * a description of the differences between Chromium and Chrome.
-   * [`This article`](https://chromium.googlesource.com/chromium/src/+/lkgr/docs/chromium_browser_vs_google_chrome.md)
+   * > Stock browsers like Google Chrome and Microsoft Edge are suitable for tests that require proprietary media codecs for
+   * video playback. See
+   * [this article](https://www.howtogeek.com/202825/what%E2%80%99s-the-difference-between-chromium-and-chrome/) for other
+   * differences between Chromium and Chrome.
+   * [This article](https://chromium.googlesource.com/chromium/src/+/lkgr/docs/chromium_browser_vs_google_chrome.md)
    * describes some differences for Linux users.
    * @param options 
    */


### PR DESCRIPTION
48a295dcf74099cb8b1e0dee0599b0d19ed9a0c4 didn't regenerate the types.