### PR TITLE
devops: verify clean tree on bots after build

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -23,6 +23,13 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: npm run lint
+    - name: Verify clean tree
+      run: |
+        if [[ -n $(git status -s) ]]; then
+          echo "ERROR: tree is dirty after npm run build:"
+          git diff
+          exit 1
+        fi
 
   build-playwright-driver:
     name: "build-playwright-driver"


### PR DESCRIPTION
Prevents #5353 in the future and does allow existing changes after running npm run build.

(Credits to Yury, originally stolen from playwright-java)