### PR TITLE
docs: improve enum naming

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -111,7 +111,7 @@ browser_context.add_cookies([cookie_object1, cookie_object2])
   - `expires` <[float]> Unix time in seconds. Optional.
   - `httpOnly` <[boolean]> Optional.
   - `secure` <[boolean]> Optional.
-  - `sameSite` <[SameSiteEnum]<"Strict"|"Lax"|"None">> Optional.
+  - `sameSite` <[SameSiteAttribute]<"Strict"|"Lax"|"None">> Optional.
 
 ## async method: BrowserContext.addInitScript
 
@@ -217,7 +217,7 @@ The default browser context cannot be closed.
   - `expires` <[float]> Unix time in seconds.
   - `httpOnly` <[boolean]>
   - `secure` <[boolean]>
-  - `sameSite` <[SameSiteEnum]<"Strict"|"Lax"|"None">>
+  - `sameSite` <[SameSiteAttribute]<"Strict"|"Lax"|"None">>
 
 If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those URLs
 are returned.
@@ -710,7 +710,7 @@ Whether to emulate network being offline for the browser context.
     - `expires` <[float]> Unix time in seconds.
     - `httpOnly` <[boolean]>
     - `secure` <[boolean]>
-    - `sameSite` <[SameSiteEnum]<"Strict"|"Lax"|"None">>
+    - `sameSite` <[SameSiteAttribute]<"Strict"|"Lax"|"None">>
   - `origins` <[Array]<[Object]>>
     - `origin` <[string]>
     - `localStorage` <[Array]<[Object]>>

--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -734,7 +734,7 @@ to pass. This method throws when the element is detached while waiting, unless w
 If the element does not satisfy the condition for the [`option: timeout`] milliseconds, this method will throw.
 
 ### param: ElementHandle.waitForElementState.state
-- `state` <[ElementStateEnum]<"visible"|"hidden"|"stable"|"enabled"|"disabled"|"editable">>
+- `state` <[ElementState]<"visible"|"hidden"|"stable"|"enabled"|"disabled"|"editable">>
 
 A state to wait for, see below for more details.
 

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -712,13 +712,13 @@ page.evaluate("matchMedia('(prefers-color-scheme: no-preference)').matches")
 ```
 
 ### option: Page.emulateMedia.media
-- `media` <null|[MediaEnum]<"screen"|"print">>
+- `media` <null|[Media]<"screen"|"print">>
 
 Changes the CSS media type of the page. The only allowed values are `'screen'`, `'print'` and `null`.
 Passing `null` disables CSS media emulation.
 
 ### option: Page.emulateMedia.colorScheme
-- `colorScheme` <null|[ColorSchemeEnum]<"light"|"dark"|"no-preference">>
+- `colorScheme` <null|[ColorScheme]<"light"|"dark"|"no-preference">>
 
 Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. Passing
 `null` disables color scheme emulation.

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -1,5 +1,5 @@
 ## navigation-wait-until
-- `waitUntil` <[WaitUntilEnum]<"load"|"domcontentloaded"|"networkidle">>
+- `waitUntil` <[WaitUntilState]<"load"|"domcontentloaded"|"networkidle">>
 
 When to consider operation succeeded, defaults to `load`. Events can be either:
 * `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
@@ -56,13 +56,13 @@ A point to use relative to the top-left corner of element padding box. If not sp
 element.
 
 ## input-modifiers
-- `modifiers` <[Array]<[ModifierEnum]<"Alt"|"Control"|"Meta"|"Shift">>>
+- `modifiers` <[Array]<[KeyboardModifier]<"Alt"|"Control"|"Meta"|"Shift">>>
 
 Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
 modifiers back. If not specified, currently pressed modifiers are used.
 
 ## input-button
-- `button` <[ButtonEnum]<"left"|"right"|"middle">>
+- `button` <[MouseButton]<"left"|"right"|"middle">>
 
 Defaults to `left`.
 
@@ -88,7 +88,7 @@ defaults to 1. See [UIEvent.detail].
 A selector to query for. See [working with selectors](./selectors.md) for more details.
 
 ## wait-for-selector-state
-- `state` <[ElementStateEnum]<"attached"|"detached"|"visible"|"hidden">>
+- `state` <[WaitForSelectorState]<"attached"|"detached"|"visible"|"hidden">>
 
 Defaults to `'visible'`. Can be either:
 * `'attached'` - wait for element to be present in DOM.
@@ -155,7 +155,7 @@ Specify environment variables that will be visible to the browser. Defaults to `
     - `expires` <[float]> Optional Unix time in seconds.
     - `httpOnly` <[boolean]> Optional httpOnly flag
     - `secure` <[boolean]> Optional secure flag
-    - `sameSite` <["SameSiteEnum"]<"Strict"|"Lax"|"None">> Optional sameSite flag
+    - `sameSite` <["SameSiteAttribute"]<"Strict"|"Lax"|"None">> Optional sameSite flag
   - `origins` <[Array]<[Object]>> Optional localStorage to set for context
     - `origin` <[string]>
     - `localStorage` <[Array]<[Object]>>
@@ -321,7 +321,7 @@ Whether to emulate network being offline. Defaults to `false`.
 Credentials for [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
 
 ## context-option-colorscheme
-- `colorScheme` <[ColorSchemeEnum]<"light"|"dark"|"no-preference">>
+- `colorScheme` <[ColorScheme]<"light"|"dark"|"no-preference">>
 
 Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. See
 [`method: Page.emulateMedia`] for more details. Defaults to '`light`'.
@@ -432,7 +432,7 @@ A glob pattern, regex pattern or predicate receiving [URL] to match while waitin
 Event name, same one typically passed into `*.on(event)`.
 
 ## wait-for-load-state-state
-- `state` <[LoadStateEnum]<"load"|"domcontentloaded"|"networkidle">>
+- `state` <[LoadState]<"load"|"domcontentloaded"|"networkidle">>
 
 Optional load state to wait for, defaults to `load`. If the state has been already reached while loading current document, the
 method resolves immediately. Can be one of:
@@ -441,7 +441,7 @@ method resolves immediately. Can be one of:
   * `'networkidle'` - wait until there are no network connections for at least `500` ms.
 
 ## screenshot-type
-- `type` <[ScreenshotTypeEnum]<"png"|"jpeg">>
+- `type` <[ScreenshotType]<"png"|"jpeg">>
 
 Specify screenshot type, defaults to `png`.
 


### PR DESCRIPTION
* drop `Enum` suffix
* Use more specific names for keyboard modifiers and mouse button
* Split ElementState and WaitForSelectorState