### PR TITLE
docs: fix playwright.dev generation error

### DIFF
--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -102,7 +102,7 @@ async def main():
 
         # Setup context however you like.
         context = await browser.new_context() # Pass any options
-        await context.route('**/*', lambda route: route.continue_())
+        await context.route('**/*', lambda route: route.resume())
 
         # Pause the page, and start recording manually.
         page = await context.new_page()
@@ -111,7 +111,7 @@ async def main():
 asyncio.run(main())
 ```
 
-```python async
+```python sync
 from playwright.sync_api import sync_playwright
 
 with sync_playwright() as p:
@@ -120,7 +120,7 @@ with sync_playwright() as p:
 
     # Setup context however you like.
     context = browser.new_context() # Pass any options
-    context.route('**/*', lambda route: route.continue_())
+    context.route('**/*', lambda route: route.resume())
 
     # Pause the page, and start recording manually.
     page = context.new_page()

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -102,7 +102,7 @@ async def main():
 
         # Setup context however you like.
         context = await browser.new_context() # Pass any options
-        await context.route('**/*', lambda route: route.resume())
+        await context.route('**/*', lambda route: route.continue_())
 
         # Pause the page, and start recording manually.
         page = await context.new_page()
@@ -120,7 +120,7 @@ with sync_playwright() as p:
 
     # Setup context however you like.
     context = browser.new_context() # Pass any options
-    context.route('**/*', lambda route: route.resume())
+    context.route('**/*', lambda route: route.continue_())
 
     # Pause the page, and start recording manually.
     page = context.new_page()


### PR DESCRIPTION
Fixes following error:
```
  type: 'code',
  lines: [
    'import asyncio',
    'from playwright.async_api import async_playwright',
    '',
    'async def main():',
    '    async with async_playwright() as p:',
    '        # Make sure to run headed.',
    '        browser = await p.chromium.launch(headless=False)',
    '',
    '        # Setup context however you like.',
    '        context = await browser.new_context() # Pass any options',
    "        await context.route('**/*', lambda route: route.continue_())",
    '',
    '        # Pause the page, and start recording manually.',
    '        page = await context.new_page()',
    '        await page.pause()',
    '',
    'asyncio.run(main())'
  ],
  codeLang: 'python async'
}
/home/yurys/playwright.dev/src/generator.js:169
            throw new Error('Bad Python snippet pair');
            ^

Error: Bad Python snippet pair
    at Generator.formatComment (/home/yurys/playwright.dev/src/generator.js:169:19)
    at /home/yurys/playwright.dev/src/generator.js:245:30
    at visit (/home/yurys/playwright.dev/src/markdown.js:364:3)
    at visit (/home/yurys/playwright.dev/src/markdown.js:366:5)
    at Object.visitAll (/home/yurys/playwright.dev/src/markdown.js:356:5)
    at Generator.generateDoc (/home/yurys/playwright.dev/src/generator.js:243:8)
    at new Generator (/home/yurys/playwright.dev/src/generator.js:83:12)
    at Object.<anonymous> (/home/yurys/playwright.dev/src/generator.js:448:1)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
```