### PR TITLE
devops: do not check for logs existance when building browsers

### DIFF
--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -233,11 +233,7 @@ if ! [[ ($2 == '-f') || ($2 == '--force') ]]; then
   if ./upload.sh "${BUILD_BLOB_PATH}" --check; then
     echo "Build is already uploaded - no changes."
     exit 0
-  elif ./upload.sh "${LOG_BLOB_PATH}" --check; then
-    echo "This build has already been attempted - skip building."
-    exit 0
   fi
-  echo "Build is missing and has not been attempted - rebuilding"
 else
   echo "Force-rebuilding the build."
 fi


### PR DESCRIPTION
In our *old world*, browser buildbots were polling repo and were
trying to rebuild browsers every 5 minutes. They relied on the presence
of either build or build log on the CDN to avoid continiously
re-building.

In the new world, we trigger builds only when we change the
`BUILD_NUMBER` files, so there's no polling any more.

This patch removes the check for log presence so that those builds that
were failing due to misconfiguration (e.g. Visual Studio license
required updated) could be restarted just from the GitHub UI.