### PR TITLE
test: disable test on all bigsur

### DIFF
--- a/test/capabilities.spec.ts
+++ b/test/capabilities.spec.ts
@@ -53,7 +53,8 @@ it('should respect CSP', async ({page, server}) => {
 
 it('should play video', (test, { browserName, platform }) => {
   test.fixme(browserName === 'webkit' && platform !== 'darwin');
-  test.fixme(browserName === 'webkit' && platform === 'darwin' && os.release() === '20.1.0');
+  // Doesnt' work on BigSur
+  test.fixme(browserName === 'webkit' && platform === 'darwin' && parseInt(os.release(), 10) >= 20);
 }, async ({page, asset, isWebKit}) => {
   // TODO: the test passes on Windows locally but fails on GitHub Action bot,
   // apparently due to a Media Pack issue in the Windows Server.


### PR DESCRIPTION
Certain GitHub Macs got accidentally updated from 11.0 to 11.2,
which broke this test check.