### PR TITLE
devops: introduce goma infrastructure for Chromium builds

### DIFF
--- a/browser_patches/chromium/.gitignore
+++ b/browser_patches/chromium/.gitignore
@@ -1,2 +1,3 @@
 /output
 /depot_tools
+/electron-build-tools

--- a/browser_patches/chromium/buildwingoma.bat
+++ b/browser_patches/chromium/buildwingoma.bat
@@ -1,0 +1,2 @@
+CALL gn gen out/Default
+CALL ninja -j 200 -C out/Default chrome

--- a/browser_patches/chromium/goma.sh
+++ b/browser_patches/chromium/goma.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+set +x
+
+trap "cd $(pwd -P)" EXIT
+cd "$(dirname $0)"
+
+if [[ ! -d ./electron-build-tools ]]; then
+  git clone --single-branch --branch msft-goma  https://github.com/electron/build-tools/ electron-build-tools
+  cd electron-build-tools
+  npm install
+  mkdir -p third_party
+  ./src/e update-goma msftGoma
+  cd ..
+fi
+
+cd electron-build-tools
+
+if [[ $1 == "--help" ]]; then
+  echo "$(basename $0) [login|start|stop|--help]"
+  exit 0
+elif [[ $1 == "login" ]]; then
+  python ./third_party/goma/goma_auth.py login
+elif [[ $1 == "start" ]]; then
+  if [[ ! -z "$GOMA_LOGIN_COOKIE" ]]; then
+    echo "$GOMA_LOGIN_COOKIE" > "$HOME/.goma_oauth2_config"
+  fi
+  if [[ ! -f "$HOME/.goma_oauth2_config" ]]; then
+    echo "ERROR: goma is not logged in!"
+    echo "run '$(basename $0) login'"
+    exit 1
+  fi
+  python ./third_party/goma/goma_ctl.py ensure_start
+elif [[ $1 == "stop" ]]; then
+  python ./third_party/goma/goma_ctl.py stop
+else
+  echo "ERROR: unknown command - $1"
+  echo "Use --help to list all available commands"
+  exit 1
+fi
+


### PR DESCRIPTION
This patch adds `//browser_patches/chromium/goma.sh` script that
manages goma to build chromium.