### PR TITLE
devops: fix chromium-win build

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -118,7 +118,8 @@ compile_chromium() {
       "nacl_irt_x86_64.nexe"
       "notification_helper.exe"
       "resources.pak"
-      "swiftshader"
+      "swiftshader/libEGL.dll"
+      "swiftshader/libGLESv2.dll"
       "v8_context_snapshot.bin"
     )
   else
@@ -202,6 +203,7 @@ EOF
     COPY_COMMAND="ditto"
   fi
   for file in ${CHROMIUM_FILES_TO_ARCHIVE[@]}; do
+    mkdir -p "output/${CHROMIUM_FOLDER_NAME}/$(dirname $file)"
     $COPY_COMMAND "${CR_CHECKOUT_PATH}/src/out/Default/${file}" "output/${CHROMIUM_FOLDER_NAME}/${file}"
   done
   if [[ $1 == "--compile-win"* ]]; then

--- a/browser_patches/chromium/buildwin.bat
+++ b/browser_patches/chromium/buildwin.bat
@@ -1,2 +1,2 @@
 CALL gn gen out/Default
-CALL autoninja -C out/Default chrome
+CALL autoninja -C out/Default chrome eventlog_provider

--- a/browser_patches/chromium/buildwingoma.bat
+++ b/browser_patches/chromium/buildwingoma.bat
@@ -1,2 +1,2 @@
 CALL gn gen out/Default
-CALL ninja -j 200 -C out/Default chrome
+CALL ninja -j 200 -C out/Default chrome eventlog_provider


### PR DESCRIPTION
- add missing build targets
- do not copy *.pdb files in folders