### PR TITLE
devops: fix goma path on windows

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -168,8 +168,12 @@ EOF
   fi
 
   if [[ ! -z "$USE_GOMA" ]]; then
+    PLAYWRIGHT_GOMA_PATH="${SCRIPT_PATH}/electron-build-tools/third_party/goma"
+    if [[ $1 == "--compile-win"* ]]; then
+      PLAYWRIGHT_GOMA_PATH=$(cygpath -w "${PLAYWRIGHT_GOMA_PATH}")
+    fi
     echo 'use_goma = true' >> ./out/Default/args.gn
-    echo "goma_dir = '${SCRIPT_PATH}/electron-build-tools/third_party/goma'" >> ./out/Default/args.gn
+    echo "goma_dir = '${PLAYWRIGHT_GOMA_PATH}'" >> ./out/Default/args.gn
   fi
 
   if [[ $1 == "--compile-win"* ]]; then


### PR DESCRIPTION
Convert unix path to win path when running GOMA on windows.