### PR TITLE
docs: split RecordVideo object into dir and size options in java

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -370,12 +370,12 @@ Optional setting to control whether to omit request content from the HAR. Defaul
 Path on the filesystem to write the HAR file to.
 
 ## context-option-recordvideo
-* langs: java, js
+* langs: js
 - `recordVideo` <[Object]>
   - `dir` <[path]> Path to the directory to put videos into.
-  - `size` <[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`.
-    If `viewport` is not configured explicitly the video size defaults to 1280x720. Actual picture of each page will be
-    scaled down if necessary to fit the specified size.
+  - `size` <[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`
+    scaled down to fit into 800x800. If `viewport` is not configured explicitly it defaults to 1280x720 and video size
+    will be 800x450. Actual picture of each page will be scaled down if necessary to fit the specified size.
     - `width` <[int]> Video frame width.
     - `height` <[int]> Video frame height.
 
@@ -383,20 +383,24 @@ Enables video recording for all pages into `recordVideo.dir` directory. If not s
 sure to await [`method: BrowserContext.close`] for videos to be saved.
 
 ## python-context-option-recordvideo-dir
-* langs: python
-- `record_video_dir` <[path]>
+* langs: csharp, java, python
+  - alias-python: record_video_dir
+- `recordVideoDir` <[path]>
 
 Path to the directory to put videos into.
 
 ## python-context-option-recordvideo-size
-* langs: python
-- `record_video_size` <[Object]>
+* langs: csharp, java, python
+  - alias-python: record_video_size
+- `recordVideoSize` <[Object]>
   If `viewport` is not configured explicitly the video size defaults to 1280x720. Actual picture of each page will be
   scaled down if necessary to fit the specified size.
   - `width` <[int]> Video frame width.
   - `height` <[int]> Video frame height.
 
-Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`.
+Dimensions of the recorded videos. If not specified the size will be equal to `viewport`
+scaled down to fit into 800x800. If `viewport` is not configured explicitly it defaults to 1280x720 and video size
+will be 800x450. Actual picture of each page will be scaled down if necessary to fit the specified size.
 
 ## context-option-proxy
 - `proxy` <[Object]>

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -374,8 +374,8 @@ Path on the filesystem to write the HAR file to.
 - `recordVideo` <[Object]>
   - `dir` <[path]> Path to the directory to put videos into.
   - `size` <[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`
-    scaled down to fit into 800x800. If `viewport` is not configured explicitly it defaults to 1280x720 and video size
-    will be 800x450. Actual picture of each page will be scaled down if necessary to fit the specified size.
+    scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450.
+    Actual picture of each page will be scaled down if necessary to fit the specified size.
     - `width` <[int]> Video frame width.
     - `height` <[int]> Video frame height.
 
@@ -393,14 +393,14 @@ Path to the directory to put videos into.
 * langs: csharp, java, python
   - alias-python: record_video_size
 - `recordVideoSize` <[Object]>
-  If `viewport` is not configured explicitly the video size defaults to 1280x720. Actual picture of each page will be
+  If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of each page will be
   scaled down if necessary to fit the specified size.
   - `width` <[int]> Video frame width.
   - `height` <[int]> Video frame height.
 
 Dimensions of the recorded videos. If not specified the size will be equal to `viewport`
-scaled down to fit into 800x800. If `viewport` is not configured explicitly it defaults to 1280x720 and video size
-will be 800x450. Actual picture of each page will be scaled down if necessary to fit the specified size.
+scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450.
+Actual picture of each page will be scaled down if necessary to fit the specified size.
 
 ## context-option-proxy
 - `proxy` <[Object]>

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6520,9 +6520,9 @@ export interface BrowserType<Browser> {
       dir: string;
 
       /**
-       * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`. If `viewport` is not
-       * configured explicitly the video size defaults to 1280x720. Actual picture of each page will be scaled down if necessary
-       * to fit the specified size.
+       * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit
+       * into 800x800. If `viewport` is not configured explicitly it defaults to 1280x720 and video size will be 800x450. Actual
+       * picture of each page will be scaled down if necessary to fit the specified size.
        */
       size?: {
         /**
@@ -7454,9 +7454,9 @@ export interface Browser extends EventEmitter {
       dir: string;
 
       /**
-       * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`. If `viewport` is not
-       * configured explicitly the video size defaults to 1280x720. Actual picture of each page will be scaled down if necessary
-       * to fit the specified size.
+       * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit
+       * into 800x800. If `viewport` is not configured explicitly it defaults to 1280x720 and video size will be 800x450. Actual
+       * picture of each page will be scaled down if necessary to fit the specified size.
        */
       size?: {
         /**
@@ -9535,9 +9535,9 @@ export interface BrowserContextOptions {
     dir: string;
 
     /**
-     * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`. If `viewport` is not
-     * configured explicitly the video size defaults to 1280x720. Actual picture of each page will be scaled down if necessary
-     * to fit the specified size.
+     * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit
+     * into 800x800. If `viewport` is not configured explicitly it defaults to 1280x720 and video size will be 800x450. Actual
+     * picture of each page will be scaled down if necessary to fit the specified size.
      */
     size?: {
       /**

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6521,8 +6521,8 @@ export interface BrowserType<Browser> {
 
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit
-       * into 800x800. If `viewport` is not configured explicitly it defaults to 1280x720 and video size will be 800x450. Actual
-       * picture of each page will be scaled down if necessary to fit the specified size.
+       * into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of each page
+       * will be scaled down if necessary to fit the specified size.
        */
       size?: {
         /**
@@ -7455,8 +7455,8 @@ export interface Browser extends EventEmitter {
 
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit
-       * into 800x800. If `viewport` is not configured explicitly it defaults to 1280x720 and video size will be 800x450. Actual
-       * picture of each page will be scaled down if necessary to fit the specified size.
+       * into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of each page
+       * will be scaled down if necessary to fit the specified size.
        */
       size?: {
         /**
@@ -9536,8 +9536,8 @@ export interface BrowserContextOptions {
 
     /**
      * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit
-     * into 800x800. If `viewport` is not configured explicitly it defaults to 1280x720 and video size will be 800x450. Actual
-     * picture of each page will be scaled down if necessary to fit the specified size.
+     * into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of each page
+     * will be scaled down if necessary to fit the specified size.
      */
     size?: {
       /**


### PR DESCRIPTION
Drive-by: update video size comment.