### PR TITLE
devops: upload flakiness dashboard for release branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         BROWSER: ${{ matrix.browser }}
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && github.ref == 'refs/heads/master'
+      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: always()
       with:
@@ -72,7 +72,7 @@ jobs:
         BROWSER: ${{ matrix.browser }}
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && github.ref == 'refs/heads/master'
+      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
@@ -103,7 +103,7 @@ jobs:
         BROWSER: ${{ matrix.browser }}
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && github.ref == 'refs/heads/master'
+      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
       shell: bash
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
@@ -158,7 +158,7 @@ jobs:
         HEADFUL: 1
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && github.ref == 'refs/heads/master'
+      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
@@ -192,7 +192,7 @@ jobs:
         PWMODE: "${{ matrix.mode }}"
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && github.ref == 'refs/heads/master'
+      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
@@ -225,7 +225,7 @@ jobs:
         BROWSER: ${{ matrix.browser }}
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && github.ref == 'refs/heads/master'
+      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
@@ -252,7 +252,7 @@ jobs:
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
         PW_ANDROID_TESTS: 1
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && github.ref == 'refs/heads/master'
+      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:


### PR DESCRIPTION
There are no reasons to not upload test results for release branches.