### PR TITLE
docs: support method overrides

### DIFF
--- a/utils/doclint/api_parser.js
+++ b/utils/doclint/api_parser.js
@@ -104,7 +104,7 @@ class ApiParser {
     }
     const clazz = this.classes.get(match[2]);
     const existingMember = clazz.membersArray.find(m => m.name === name && m.kind === member.kind);
-    if (existingMember) {
+    if (existingMember && !existingMember.langs.only) {
       for (const lang of member.langs.only) {
         existingMember.langs.types = existingMember.langs.types || {};
         existingMember.langs.types[lang] = returnType;


### PR DESCRIPTION
Allow to override entire method, not only its return type

It's a follow-up to #5402