### PR TITLE
fix(registry): handle relative registry path

### DIFF
--- a/packages/installation-tests/installation-tests.sh
+++ b/packages/installation-tests/installation-tests.sh
@@ -15,14 +15,22 @@ unset PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD
 export PLAYWRIGHT_BROWSERS_PATH=0
 
 # Pack all packages and put them in our output folder.
+echo "Building packages..."
 PACKAGE_BUILDER="../../../packages/build_package.js"
 PLAYWRIGHT_CORE_TGZ="$(node ${PACKAGE_BUILDER} playwright-core ./playwright-core.tgz)"
+echo "playwright-core built"
 PLAYWRIGHT_TGZ="$(node ${PACKAGE_BUILDER} playwright ./playwright.tgz)"
+echo "playwright built"
 PLAYWRIGHT_CHROMIUM_TGZ="$(node ${PACKAGE_BUILDER} playwright-chromium ./playwright-chromium.tgz)"
+echo "playwright-chromium built"
 PLAYWRIGHT_WEBKIT_TGZ="$(node ${PACKAGE_BUILDER} playwright-webkit ./playwright-webkit.tgz)"
+echo "playwright-webkit built"
 PLAYWRIGHT_FIREFOX_TGZ="$(node ${PACKAGE_BUILDER} playwright-firefox ./playwright-firefox.tgz)"
+echo "playwright-firefox built"
 PLAYWRIGHT_ELECTRON_TGZ="$(node ${PACKAGE_BUILDER} playwright-electron ./playwright-electron.tgz)"
+echo "playwright-electron built"
 PLAYWRIGHT_ANDROID_TGZ="$(node ${PACKAGE_BUILDER} playwright-android ./playwright-android.tgz)"
+echo "playwright-android built"
 
 SCRIPTS_PATH="$(pwd -P)/.."
 TEST_ROOT="$(pwd -P)"
@@ -46,6 +54,8 @@ function run_tests {
   test_skip_browser_download
   test_playwright_global_installation_subsequent_installs
   test_playwright_should_work
+  test_playwright_should_work_with_relative_home_path
+  test_playwright_should_work_with_relative_browsers_path
   test_playwright_chromium_should_work
   test_playwright_webkit_should_work
   test_playwright_firefox_should_work
@@ -205,6 +215,31 @@ function test_playwright_should_work {
     node esm-playwright.mjs
   fi
 
+  echo "${FUNCNAME[0]} success"
+}
+
+function test_playwright_should_work_with_relative_home_path {
+  initialize_test "${FUNCNAME[0]}"
+  PLAYWRIGHT_BROWSERS_PATH="" HOME=. npm install ${PLAYWRIGHT_TGZ}
+  copy_test_scripts
+  echo "Running sanity.js"
+  # Firefox does not work with relative HOME.
+  PLAYWRIGHT_BROWSERS_PATH="" HOME=. node sanity.js playwright chromium webkit
+  echo "${FUNCNAME[0]} success"
+}
+
+function test_playwright_should_work_with_relative_browsers_path {
+  initialize_test "${FUNCNAME[0]}"
+
+  # Make sure that browsers path is resolved relative to the `npm install` call location.
+  mkdir foo
+  cd foo
+  PLAYWRIGHT_BROWSERS_PATH="../relative" npm install ${PLAYWRIGHT_TGZ}
+  cd ..
+
+  copy_test_scripts
+  echo "Running sanity.js"
+  PLAYWRIGHT_BROWSERS_PATH="./relative" node sanity.js playwright
   echo "${FUNCNAME[0]} success"
 }
 

--- a/packages/installation-tests/sanity.js
+++ b/packages/installation-tests/sanity.js
@@ -23,8 +23,10 @@ let success = {
 }[requireName];
 if (process.argv[3] === 'none')
   success = [];
-if (process.argv[3] === 'all')
+else if (process.argv[3] === 'all')
   success = ['chromium', 'firefox', 'webkit'];
+else if (process.argv[3])
+  success = process.argv.slice(3)
 
 const playwright = require(requireName);
 
@@ -54,6 +56,7 @@ const installer = require(requireName + '/lib/install/installer');
       process.exit(1);
     } catch (e) {
       // All good.
+      console.log(`Expected error while launching ${browserType}: ${e}`);
     }
   }
   console.log(`require SUCCESS`);

--- a/src/server/firefox/firefox.ts
+++ b/src/server/firefox/firefox.ts
@@ -40,6 +40,8 @@ export class Firefox extends BrowserType {
   }
 
   _amendEnvironment(env: Env, userDataDir: string, executable: string, browserArguments: string[]): Env {
+    if (!path.isAbsolute(os.homedir()))
+      throw new Error(`Cannot launch Firefox with relative home directory. Did you set ${os.platform() === 'win32' ? 'USERPROFILE' : 'HOME'} to a relative path?`);
     return os.platform() === 'linux' ? {
       ...env,
       // On linux Juggler ships the libstdc++ it was linked against.


### PR DESCRIPTION
We get relative registry path when `PLAYWRIGHT_BROWSERS_PATH` or `HOME` is relative.
In this case, it would be good to resolve to the same absolute path
during installation and execution, and we can usually do that using `INIT_CWD`.

References #4867.