### PR TITLE
fix(download): do not stall BrowserContext.close waiting for downloads

### DIFF
--- a/src/dispatchers/downloadDispatcher.ts
+++ b/src/dispatchers/downloadDispatcher.ts
@@ -39,7 +39,7 @@ export class DownloadDispatcher extends Dispatcher<Download, channels.DownloadIn
     return await new Promise((resolve, reject) => {
       this._object.saveAs(async (localPath, error) => {
         if (error !== undefined) {
-          reject(error);
+          reject(new Error(error));
           return;
         }
 
@@ -58,7 +58,7 @@ export class DownloadDispatcher extends Dispatcher<Download, channels.DownloadIn
     return await new Promise((resolve, reject) => {
       this._object.saveAs(async (localPath, error) => {
         if (error !== undefined) {
-          reject(error);
+          reject(new Error(error));
           return;
         }
 

--- a/src/server/download.ts
+++ b/src/server/download.ts
@@ -107,7 +107,22 @@ export class Download {
       await util.promisify(fs.unlink)(fileName).catch(e => {});
   }
 
+  async deleteOnContextClose(): Promise<void> {
+    // Compared to "delete", this method does not wait for the download to finish.
+    // We use it when closing the context to avoid stalling.
+    if (this._deleted)
+      return;
+    this._deleted = true;
+    if (this._acceptDownloads) {
+      const fileName = path.join(this._downloadsPath, this._uuid);
+      await util.promisify(fs.unlink)(fileName).catch(e => {});
+    }
+    this._reportFinished('Download deleted upon browser context closure.');
+  }
+
   async _reportFinished(error?: string) {
+    if (this._finished)
+      return;
     this._finished = true;
     this._failure = error || null;
 


### PR DESCRIPTION
We might not ever get the "download finished" event when closing the context:
- in Chromium, for any ongoing download;
- in all browsers, for failed downloads.

This should not prevent closing the context. Instead of waiting for the
download and then deleting it, we force delete it immediately and reject
any promises waiting for the download completion.

References #5273.