### PR TITLE
fix(docker): avoid symlink hack in Docker images

### DIFF
--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -77,16 +77,17 @@ RUN apt-get update && apt-get install -y python3.8 python3-pip && \
 
 # === BAKE BROWSERS INTO IMAGE ===
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+RUN mkdir /ms-playwright && chmod 777 /ms-playwright
+
 # 1. Add tip-of-tree Playwright package to install its browsers.
 #    The package should be built beforehand from tip-of-tree Playwright.
 COPY ./playwright.tar.gz /tmp/playwright.tar.gz
 
 # 2. Install playwright and then delete the installation.
-#    Browsers will remain downloaded in `/home/pwuser/.cache/ms-playwright`.
+#    Browsers will remain downloaded in `/ms-playwright`.
 RUN su pwuser -c "mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
     npm i /tmp/playwright.tar.gz" && \
     rm -rf /tmp/pw && rm /tmp/playwright.tar.gz
 
-# 3. Symlink downloaded browsers for root user
-RUN mkdir /root/.cache/ && \
-    ln -s /home/pwuser/.cache/ms-playwright/ /root/.cache/ms-playwright

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -76,16 +76,17 @@ RUN apt-get update && apt-get install -y python3.8 python3-pip && \
 
 # === BAKE BROWSERS INTO IMAGE ===
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+RUN mkdir /ms-playwright && chmod 777 /ms-playwright
+
 # 1. Add tip-of-tree Playwright package to install its browsers.
 #    The package should be built beforehand from tip-of-tree Playwright.
 COPY ./playwright.tar.gz /tmp/playwright.tar.gz
 
 # 2. Install playwright and then delete the installation.
-#    Browsers will remain downloaded in `/home/pwuser/.cache/ms-playwright`.
+#    Browsers will remain downloaded in `/ms-playwright`.
 RUN su pwuser -c "mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
     npm i /tmp/playwright.tar.gz" && \
     rm -rf /tmp/pw && rm /tmp/playwright.tar.gz
 
-# 3. Symlink downloaded browsers for root user
-RUN mkdir /root/.cache/ && \
-    ln -s /home/pwuser/.cache/ms-playwright/ /root/.cache/ms-playwright


### PR DESCRIPTION
Instead of symlinking pwuser's registry to root's registry, we now
use the `PLAYWRIGHT_BROWSERS_PATH` variable to define a single
browser registry across the docker image, accessible for all
users.

Fixes #4485