### PR TITLE
fix: do not rely on $PATH when resolving executables

### DIFF
--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -136,7 +136,7 @@ export const hostPlatform = ((): BrowserPlatform => {
     let arm64 = false;
     // BigSur is the first version that might run on Apple Silicon.
     if (major >= 11) {
-      arm64 = execSync('sysctl -in hw.optional.arm64', {
+      arm64 = execSync('/usr/sbin/sysctl -in hw.optional.arm64', {
         stdio: ['ignore', 'pipe', 'ignore']
       }).toString().trim() === '1';
     }


### PR DESCRIPTION
Since CRON jobs reset $PATH to a very basic one, we should
use only direct paths to system executables.

Fixes #5469