### PR TITLE
cherry-pick(release-1.8): do not rely on $PATH when resolving sysctl

### DIFF
--- a/src/utils/browserPaths.ts
+++ b/src/utils/browserPaths.ts
@@ -38,7 +38,7 @@ export const hostPlatform = ((): BrowserPlatform => {
     let arm64 = false;
     // BigSur is the first version that might run on Apple Silicon.
     if (major >= 11) {
-      arm64 = execSync('sysctl -in hw.optional.arm64', {
+      arm64 = execSync('/usr/sbin/sysctl -in hw.optional.arm64', {
         stdio: ['ignore', 'pipe', 'ignore']
       }).toString().trim() === '1';
     }


### PR DESCRIPTION
Cherry-pick f2b25fe6bd9be62bd7672a721deebcfc508b6ab9 PR #5475

References #5469