### PR TITLE
docs(dotnet): use framework objects instead of arbitrary strings

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -287,6 +287,12 @@ Whether or not to enable JavaScript in the context. Defaults to `true`.
 Changes the timezone of the context. See [ICU's metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1)
 for a list of supported timezone IDs.
 
+## context-option-timezoneid
+* langs: csharp
+- `timezoneId` <[TimeZoneInfo]>
+
+Changes the timezone of the context.
+
 ## context-option-geolocation
 - `geolocation` <[Object]>
   - `latitude` <[float]> Latitude between -90 and 90.

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -299,6 +299,13 @@ for a list of supported timezone IDs.
 Specify user locale, for example `en-GB`, `de-DE`, etc. Locale will affect `navigator.language` value, `Accept-Language`
 request header value as well as number and date formatting rules.
 
+## context-option-locale
+* langs: csharp
+- `locale` <[CultureInfo]>
+
+Specify user locale, for example using `CultureInfo.CurrentUICulture`. Locale will affect `navigator.language` value, `Accept-Language`
+request header value as well as number and date formatting rules.
+
 ## context-option-permissions
 - `permissions` <[Array]<[string]>>
 


### PR DESCRIPTION
This was one of the suggestions from the Azure SDK team - to switch to a more .NET friendly object for describing the locale. While this is a fairly cosmetic change, it does improve the look & feel of the API.