### PR TITLE
fix: do not ship broken symlinks in webkit for mac

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1437
-Changed: dgozman@gmail.com Fri Feb 19 16:12:07 PST 2021
+1438
+Changed: lushnikov@chromium.com Fri Feb 19 21:08:07 PST 2021

--- a/browser_patches/webkit/archive.sh
+++ b/browser_patches/webkit/archive.sh
@@ -131,6 +131,9 @@ createZipForMac() {
   # copy protocol
   node $SCRIPTS_DIR/concat_protocol.js > $tmpdir/protocol.json
 
+  # Remove all broken symlinks. @see https://github.com/microsoft/playwright/issues/5472
+  find "${tmpdir}" -type l ! -exec test -e {} \; -print | xargs rm
+
   # zip resulting directory and cleanup TMP.
   ditto -c -k $tmpdir $ZIP_PATH
   rm -rf $tmpdir


### PR DESCRIPTION
Since we don't ship things like WebKitPluginAgent, we can
safely remove all the symlinks that point to the missing targets.

Fixes #5472