### PR TITLE
devops(chromium): missing depot tools in prepare_checkout.sh script

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -13,7 +13,6 @@ EOF
 )
 
 SCRIPT_PATH=$(pwd -P)
-CRREV=$(head -1 ./BUILD_NUMBER)
 
 main() {
   if [[ $1 == "--help" || $1 == "-h" ]]; then
@@ -41,15 +40,7 @@ compile_chromium() {
     exit 1
   fi
 
-  # install depot_tools if they are not in system
-  # NOTE: as of Feb 8, 2021, windows requires manual and separate
-  # installation of depot_tools.
-  if ! command -v autoninja >/dev/null; then
-    if [[ ! -d "${SCRIPT_PATH}/depot_tools" ]]; then
-      git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "${SCRIPT_PATH}/depot_tools"
-    fi
-    export PATH="${SCRIPT_PATH}/depot_tools:$PATH"
-  fi
+  source "${SCRIPT_PATH}/ensure_depot_tools.sh"
 
   if [[ $1 == "--compile-mac"* ]]; then
     # As of Jan, 2021 Chromium mac compilation requires Xcode12.2
@@ -135,6 +126,7 @@ mirror_chromium() {
     fi
   fi
 
+  CRREV=$(head -1 "${SCRIPT_PATH}/BUILD_NUMBER")
   if [[ "${PLATFORM}" == "--mirror-win32" ]]; then
     CHROMIUM_URL="https://storage.googleapis.com/chromium-browser-snapshots/Win/${CRREV}/chrome-win.zip"
   elif [[ "${PLATFORM}" == "--mirror-win64" ]]; then

--- a/browser_patches/chromium/ensure_depot_tools.sh
+++ b/browser_patches/chromium/ensure_depot_tools.sh
@@ -1,0 +1,28 @@
+# Since this script modifies PATH, it cannot be run in a subshell
+# and must be sourced.
+# Make sure it is sourced.
+sourced=0
+(return 0 2>/dev/null) && sourced=1 || sourced=0
+
+if [[ $sourced == 0 ]]; then
+  echo 'ERROR: cannot run this script in a subshell'
+  echo 'This file modifies $PATH of the current shell, so it must be sourced instead'
+  echo 'Use `source ensure_depot_tool.sh` instead'
+  exit 1
+fi
+
+# Install depot_tools if they are not in system, and modify $PATH
+# to include depot_tools
+if ! command -v autoninja >/dev/null; then
+  if [[ $(uname) == "MINGW"* ]]; then
+    # NOTE: as of Feb 8, 2021, windows requires manual and separate
+    # installation of depot_tools.
+    echo "ERROR: cannot automatically install depot_tools on windows. Please, install manually"
+    exit 1
+  fi
+  SCRIPT_PATH=$(cd "$(dirname "$BASH_SOURCE")"; pwd -P)
+  if [[ ! -d "${SCRIPT_PATH}/depot_tools" ]]; then
+    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "${SCRIPT_PATH}/depot_tools"
+  fi
+  export PATH="${SCRIPT_PATH}/depot_tools:$PATH"
+fi

--- a/browser_patches/chromium/goma.sh
+++ b/browser_patches/chromium/goma.sh
@@ -16,6 +16,8 @@ fi
 
 cd electron-build-tools/third_party/goma
 
+export GOMA_START_COMPILER_PROXY=true
+
 if [[ $1 == "--help" ]]; then
   echo "$(basename $0) [login|start|stop|--help]"
   exit 0

--- a/browser_patches/prepare_checkout.sh
+++ b/browser_patches/prepare_checkout.sh
@@ -29,6 +29,9 @@ fi
 
 function prepare_chromium_checkout {
   cd "${SCRIPT_PATH}"
+
+  source "${SCRIPT_PATH}/chromium/ensure_depot_tools.sh"
+
   if [[ -z "${CR_CHECKOUT_PATH}" ]]; then
     echo "ERROR: chromium compilation requires CR_CHECKOUT_PATH to be set to reuse checkout."
     echo "NOTE: we expect '\$CR_CHECKOUT_PATH/src' to exist to be a valid chromium checkout."


### PR DESCRIPTION
Make sure `prepare_checkout.sh` has depot_tools in its PATH.

Drive-by: enable goma compiler proxy auto-restart.