### PR TITLE
fix(bindings): unflake TestBrowserContextExposeFunction.shouldWork in java

### DIFF
--- a/src/server/browserContext.ts
+++ b/src/server/browserContext.ts
@@ -162,7 +162,7 @@ export abstract class BrowserContext extends SdkObject {
     }
     const binding = new PageBinding(name, playwrightBinding, needsHandle, 'main');
     this._pageBindings.set(identifier, binding);
-    this._doExposeBinding(binding);
+    await this._doExposeBinding(binding);
   }
 
   async grantPermissions(permissions: string[], origin?: string) {


### PR DESCRIPTION
This fixes following test failure in java:

```
Error:  Tests run: 5, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.073 s <<< FAILURE! - in com.microsoft.playwright.TestBrowserContextExposeFunction
Error:  com.microsoft.playwright.TestBrowserContextExposeFunction.shouldWork  Time elapsed: 0.224 s  <<< ERROR!
com.microsoft.playwright.PlaywrightException: 
Error {
  message='Evaluation failed: Invalid arguments: should be exactly one string.
  name='Error
  stack='Error: Evaluation failed: Invalid arguments: should be exactly one string.
    at CRExecutionContext.evaluateWithArguments (C:\Users\RUNNER~1\AppData\Local\Temp\playwright-java-9156795998977864695\package\lib\server\chromium\crExecutionContext.js:71:19)
    at async Object.evaluateExpression (C:\Users\RUNNER~1\AppData\Local\Temp\playwright-java-9156795998977864695\package\lib\server\javascript.js:171:16)
    at async FrameManager.waitForSignalsCreatedBy (C:\Users\RUNNER~1\AppData\Local\Temp\playwright-java-9156795998977864695\package\lib\server\frames.js:108:24)
    at async FrameExecutionContext.evaluateExpressionInternal (C:\Users\RUNNER~1\AppData\Local\Temp\playwright-java-9156795998977864695\package\lib\server\dom.js:59:16)
    at async Frame._evaluateExpression (C:\Users\RUNNER~1\AppData\Local\Temp\playwright-java-9156795998977864695\package\lib\server\frames.js:506:23)
    at async FrameDispatcher.evaluateExpression (C:\Users\RUNNER~1\AppData\Local\Temp\playwright-java-9156795998977864695\package\lib\dispatchers\frameDispatcher.js:57:62)
    at async DispatcherConnection.dispatch (C:\Users\RUNNER~1\AppData\Local\Temp\playwright-java-9156795998977864695\package\lib\dispatchers\dispatcher.js:178:28)
}
	at com.microsoft.playwright.TestBrowserContextExposeFunction.shouldWork(TestBrowserContextExposeFunction.java:53)
```