### PR TITLE
devops: do not create non-removable folders on windows

### DIFF
--- a/browser_patches/chromium/archive.sh
+++ b/browser_patches/chromium/archive.sh
@@ -127,7 +127,7 @@ function archive_compiled_chromium() {
 
   for ((i = 0; i < ${#CHROMIUM_FILES_TO_ARCHIVE[@]}; i++)) do
     file="${CHROMIUM_FILES_TO_ARCHIVE[$i]}"
-    mkdir -p "output/${CHROMIUM_FOLDER_NAME}/$(dirname $file)"
+    mkdir -p "output/${CHROMIUM_FOLDER_NAME}/$(dirname "${file}")"
     $COPY_COMMAND "${CR_CHECKOUT_PATH}/src/out/Default/${file}" "output/${CHROMIUM_FOLDER_NAME}/${file}"
   done
 


### PR DESCRIPTION
This fixes a bug where the script was creating a folder with a new line
symbol in its name. As a result, Windows was failing to remove  this
folder, and Chromium Windows BuildBot was failing to even initialize
checkout.