### PR TITLE
browser(firefox): follow-up with crash reporter disabling

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1233
-Changed: lushnikov@chromium.org Fri 19 Feb 2021 12:48:12 PM PST
+1234
+Changed: lushnikov@chromium.org Fri 19 Feb 2021 21:20:12 PM PST

--- a/browser_patches/firefox/preferences/playwright.cfg
+++ b/browser_patches/firefox/preferences/playwright.cfg
@@ -273,5 +273,3 @@ pref("extensions.blocklist.enabled", false);
 // Force Firefox Devtools to open in a separate window.
 pref("devtools.toolbox.host", "window");
 
-// Disable crash reporter.
-Components.classes["@mozilla.org/toolkit/crash-reporter;1"].getService(Components.interfaces.nsICrashReporter).submitReports = false;


### PR DESCRIPTION
Since we now disable crash reporter compilation and don't ship it
with Firefox anymore, we should not attempt to disable it
with preferences.