### PR TITLE
browser(firefox): make dpr emulation optional, take screenshots at 1x

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1241
-Changed: joel.einbinder@gmail.com Thu Apr  1 11:26:01 PDT 2021
+1242
+Changed: dgozman@gmail.com Thu Apr  1 13:10:41 PDT 2021

--- a/browser_patches/firefox/juggler/protocol/PageHandler.js
+++ b/browser_patches/firefox/juggler/protocol/PageHandler.js
@@ -299,10 +299,6 @@ class PageHandler {
     return await this._contentPage.send('screenshot', options);
   }
 
-  async ['Page.getBoundingBox'](options) {
-    return await this._contentPage.send('getBoundingBox', options);
-  }
-
   async ['Page.getContentQuads'](options) {
     return await this._contentPage.send('getContentQuads', options);
   }

--- a/browser_patches/firefox/juggler/protocol/Protocol.js
+++ b/browser_patches/firefox/juggler/protocol/Protocol.js
@@ -71,7 +71,7 @@ pageTypes.Size = {
 
 pageTypes.Viewport = {
   viewportSize: pageTypes.Size,
-  deviceScaleFactor: t.Number,
+  deviceScaleFactor: t.Optional(t.Number),
 };
 
 pageTypes.DOMQuad = {
@@ -801,15 +801,6 @@ const Page = {
         frameId: t.String,
       },
     },
-    'getBoundingBox': {
-      params: {
-        frameId: t.String,
-        objectId: t.String,
-      },
-      returns: {
-        boundingBox: t.Nullable(pageTypes.Rect),
-      },
-    },
     'adoptNode': {
       params: {
         frameId: t.String,
@@ -823,8 +814,8 @@ const Page = {
     'screenshot': {
       params: {
         mimeType: t.Enum(['image/png', 'image/jpeg']),
-        fullPage: t.Optional(t.Boolean),
         clip: t.Optional(pageTypes.Clip),
+        omitDeviceScaleFactor: t.Optional(t.Boolean),
       },
       returns: {
         data: t.String,


### PR DESCRIPTION
- deviceScaleFactor is now optional, so we can use host machine's dpr.
- Screenshots are not scaled up by dpr.
- Removed unused methods.