### PR TITLE
browser(firefox): pass drag action test

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1234
-Changed: lushnikov@chromium.org Fri 19 Feb 2021 21:20:12 PM PST
+1235
+Changed: joel.einbinder@gmail.com Mon 22 Feb 2021 09:28:46 PM PST

--- a/browser_patches/firefox/juggler/content/PageAgent.js
+++ b/browser_patches/firefox/juggler/content/PageAgent.js
@@ -819,10 +819,10 @@ class PageAgent {
       null /* relatedTarget */,
       dragService.getCurrentSession().dataTransfer.mozCloneForEvent(type)
     );
-
-    window.windowUtils.dispatchDOMEventViaPresShellForTesting(element, event);
+    if (type !== 'drop' || dragService.dragAction)
+      window.windowUtils.dispatchDOMEventViaPresShellForTesting(element, event);
     if (type === 'drop')
-      dragService.endDragSession(true);
+      this._cancelDragIfNeeded();
   }
 
   _cancelDragIfNeeded() {


### PR DESCRIPTION
fixes the test in #5559 for firefox. We were previously sending the drop event even if it was not an allowed effect. Dropping twice on the same page was also bugged.