### PR TITLE
docs: filter out devices section in java

### DIFF
--- a/docs/src/downloads.md
+++ b/docs/src/downloads.md
@@ -74,4 +74,3 @@ are downloading a file since your main control flow is not awaiting for this ope
 ### API reference
 - [Download]
 - [`event: Page.download`]
-- [`method: Page.waitForEvent`]

--- a/docs/src/emulation.md
+++ b/docs/src/emulation.md
@@ -17,6 +17,7 @@ can be changed for individual pages.
 <br/>
 
 ## Devices
+* langs: js, python
 
 Playwright comes with a registry of device parameters for selected mobile devices. It can be used to simulate browser
 behavior on a mobile device:


### PR DESCRIPTION
* Page.waitForEvent is not available in java, removed it from the downloads docs.