### PR TITLE
cherry-pick(release-1.9): do not use import('electron') (#5572)

### DIFF
--- a/packages/common/index.d.ts
+++ b/packages/common/index.d.ts
@@ -20,3 +20,5 @@ export * from './types/types';
 export const chromium: types.BrowserType<types.ChromiumBrowser>;
 export const firefox: types.BrowserType<types.FirefoxBrowser>;
 export const webkit: types.BrowserType<types.WebKitBrowser>;
+export const _electron: types.Electron;
+export const _android: types.Android;

--- a/packages/installation-tests/installation-tests.sh
+++ b/packages/installation-tests/installation-tests.sh
@@ -108,7 +108,7 @@ function test_typescript_types {
                   "playwright-webkit"
   do
     echo "Checking types of ${PKG_NAME}"
-    echo "import { Page } from '${PKG_NAME}';" > "${PKG_NAME}.ts" && tsc "${PKG_NAME}.ts"
+    echo "import { Page } from '${PKG_NAME}';" > "${PKG_NAME}.ts" && npx -p typescript@3.7.5 tsc "${PKG_NAME}.ts"
   done;
 
   echo "${FUNCNAME[0]} success"
@@ -351,7 +351,7 @@ function test_electron_types {
   echo "import { Page, electron, ElectronApplication, Electron } from 'playwright-electron';" > "test.ts"
 
   echo "Running tsc"
-  npx tsc "test.ts"
+  npx -p typescript@3.7.5 tsc "test.ts"
 
   echo "${FUNCNAME[0]} success"
 }
@@ -365,7 +365,7 @@ function test_android_types {
   echo "import { AndroidDevice, android, AndroidWebView, Page } from 'playwright-android';" > "test.ts"
 
   echo "Running tsc"
-  npx tsc "test.ts"
+  npx -p typescript@3.7.5 tsc "test.ts"
 
   echo "${FUNCNAME[0]} success"
 }

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -7095,8 +7095,8 @@ export interface ElectronApplication {
    * @param pageFunction Function to be evaluated in the worker context.
    * @param arg Optional argument to pass to `pageFunction`.
    */
-  evaluate<R, Arg>(pageFunction: PageFunctionOn<typeof import('electron'), Arg, R>, arg: Arg): Promise<R>;
-  evaluate<R>(pageFunction: PageFunctionOn<typeof import('electron'), void, R>, arg?: any): Promise<R>;
+  evaluate<R, Arg>(pageFunction: PageFunctionOn<any, Arg, R>, arg: Arg): Promise<R>;
+  evaluate<R>(pageFunction: PageFunctionOn<any, void, R>, arg?: any): Promise<R>;
 
   /**
    * Returns the return value of `pageFunction` as a [JSHandle].
@@ -7117,8 +7117,8 @@ export interface ElectronApplication {
    * @param pageFunction Function to be evaluated in the worker context.
    * @param arg 
    */
-  evaluateHandle<R, Arg>(pageFunction: PageFunctionOn<typeof import('electron'), Arg, R>, arg: Arg): Promise<SmartHandle<R>>;
-  evaluateHandle<R>(pageFunction: PageFunctionOn<typeof import('electron'), void, R>, arg?: any): Promise<SmartHandle<R>>;
+  evaluateHandle<R, Arg>(pageFunction: PageFunctionOn<any, Arg, R>, arg: Arg): Promise<SmartHandle<R>>;
+  evaluateHandle<R>(pageFunction: PageFunctionOn<any, void, R>, arg?: any): Promise<SmartHandle<R>>;
   /**
    * This event is issued when the application closes.
    */

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -223,11 +223,11 @@ export const selectors: Selectors;
 export const devices: Devices & DeviceDescriptor[];
 
 export interface ElectronApplication {
-  evaluate<R, Arg>(pageFunction: PageFunctionOn<typeof import('electron'), Arg, R>, arg: Arg): Promise<R>;
-  evaluate<R>(pageFunction: PageFunctionOn<typeof import('electron'), void, R>, arg?: any): Promise<R>;
+  evaluate<R, Arg>(pageFunction: PageFunctionOn<any, Arg, R>, arg: Arg): Promise<R>;
+  evaluate<R>(pageFunction: PageFunctionOn<any, void, R>, arg?: any): Promise<R>;
 
-  evaluateHandle<R, Arg>(pageFunction: PageFunctionOn<typeof import('electron'), Arg, R>, arg: Arg): Promise<SmartHandle<R>>;
-  evaluateHandle<R>(pageFunction: PageFunctionOn<typeof import('electron'), void, R>, arg?: any): Promise<SmartHandle<R>>;
+  evaluateHandle<R, Arg>(pageFunction: PageFunctionOn<any, Arg, R>, arg: Arg): Promise<SmartHandle<R>>;
+  evaluateHandle<R>(pageFunction: PageFunctionOn<any, void, R>, arg?: any): Promise<SmartHandle<R>>;
 }
 
 export type AndroidElementInfo = {


### PR DESCRIPTION
Cherry-pick 5cb914b2feab098074232b6d64e6d5e5993f62d5