### PR TITLE
fix(inspector): skip stack trace playwright/src lines only under tests

### DIFF
--- a/src/utils/stackTrace.ts
+++ b/src/utils/stackTrace.ts
@@ -41,7 +41,7 @@ const PW_LIB_DIRS = [
   'playwright-chromium',
   'playwright-firefox',
   'playwright-webkit',
-].map(packageName => path.join(packageName, 'lib'));
+].map(packageName => path.join('node_modules', packageName, 'lib'));
 
 export function captureStackTrace(): { stack: string, frames: StackFrame[] } {
   const stack = new Error().stack!;
@@ -56,7 +56,7 @@ export function captureStackTrace(): { stack: string, frames: StackFrame[] } {
     if (PW_LIB_DIRS.some(libDir => fileName.includes(libDir)))
       continue;
     // for tests.
-    if (fileName.includes(path.join('playwright', 'src')))
+    if (isUnderTest() && fileName.includes(path.join('playwright', 'src')))
       continue;
     if (isUnderTest() && fileName.includes(path.join('playwright', 'test', 'coverage.js')))
       continue;

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -19,6 +19,7 @@ import { folio, RemoteServer } from './remoteServer.fixture';
 import { execSync } from 'child_process';
 import path from 'path';
 import * as stackTrace from '../src/utils/stackTrace';
+import { setUnderTest } from '../src/utils/utils';
 
 type FixturesFixtures = {
   connectedRemoteServer: RemoteServer;
@@ -129,6 +130,7 @@ describe('fixtures', (suite, { platform, headful }) => {
 });
 
 it('caller file path', async ({}) => {
+  setUnderTest();
   const callme = require('./fixtures/callback');
   const filePath = callme(() => {
     return stackTrace.getCallerFilePath(path.join(__dirname, 'fixtures') + path.sep);


### PR DESCRIPTION
Context: https://playwright.slack.com/archives/CSUHZPVLM/p1614183444018700?thread_ts=1614155581.011900&cid=CSUHZPVLM

The issue was that under his use-case, one of the lines was the following which resulted in an empty Inspector window:

 '/Users/abc/development/cucumber-**playwright/src**/support/common-hooks.ts'

so it matched previously. Now we match that only under pw tests.

Also as a drive-by enhanced the other check by adding `node_modules` to it, verified with the previous reported bug and its still working.