### PR TITLE
fix(text selector): make quoted text selector match by a single text node

### DIFF
--- a/docs/src/selectors.md
+++ b/docs/src/selectors.md
@@ -148,7 +148,7 @@ Text selector has a few variations:
   page.click("text=Log in")
   ```
 
-- `text="Log in"` - text body can be escaped with single or double quotes for full-string case-sensitive match. For example `text="Log"` does not match `<button>Log in</button>` but instead matches `<span>Log</span>`.
+- `text="Log in"` - text body can be escaped with single or double quotes for stricter case-sensitive match. For example `text="Log"` does not match `<button>log in</button>` but instead matches `<span>Log</span>`.
 
   Quoted body follows the usual escaping rules, e.g. use `\"` to escape double quote in a double-quoted string: `text="foo\"bar"`.
 

--- a/src/server/supplements/injected/selectorGenerator.ts
+++ b/src/server/supplements/injected/selectorGenerator.ts
@@ -180,7 +180,7 @@ function buildCandidates(injectedScript: InjectedScript, element: Element): Sele
 function buildTextCandidates(injectedScript: InjectedScript, element: Element, allowHasText: boolean): SelectorToken[] {
   if (element.nodeName === 'SELECT')
     return [];
-  const text = elementText(injectedScript._evaluator, element).trim().replace(/\s+/g, ' ').substring(0, 80);
+  const text = elementText(injectedScript._evaluator, element).trimmed.substring(0, 80);
   if (!text)
     return [];
   const candidates: SelectorToken[] = [];

--- a/test/selectors-text.spec.ts
+++ b/test/selectors-text.spec.ts
@@ -115,7 +115,7 @@ it('should work with :text', async ({page}) => {
   expect(await page.$eval(`:text("y")`, e => e.outerHTML)).toBe('<div>yo</div>');
   expect(await page.$(`:text-is("y")`)).toBe(null);
   expect(await page.$eval(`:text("hello world")`, e => e.outerHTML)).toBe('<div>\nHELLO   \n world  </div>');
-  expect(await page.$eval(`:text-is("hello world")`, e => e.outerHTML)).toBe('<div>\nHELLO   \n world  </div>');
+  expect(await page.$eval(`:text-is("HELLO world")`, e => e.outerHTML)).toBe('<div>\nHELLO   \n world  </div>');
   expect(await page.$eval(`:text("lo wo")`, e => e.outerHTML)).toBe('<div>\nHELLO   \n world  </div>');
   expect(await page.$(`:text-is("lo wo")`)).toBe(null);
   expect(await page.$eval(`:text-matches("^[ay]+$")`, e => e.outerHTML)).toBe('<div>ya</div>');
@@ -145,11 +145,11 @@ it('should work across nodes', async ({page}) => {
   expect(await page.$(`text=hello world`)).toBe(null);
 
   expect(await page.$eval(`:text-is("Hello, world!")`, e => e.id)).toBe('target1');
-  expect(await page.$(`:text-is("Hello")`)).toBe(null);
+  expect(await page.$eval(`:text-is("Hello")`, e => e.id)).toBe('target1');
   expect(await page.$eval(`:text-is("world")`, e => e.id)).toBe('target2');
   expect(await page.$$eval(`:text-is("world")`, els => els.length)).toBe(1);
   expect(await page.$eval(`text="Hello, world!"`, e => e.id)).toBe('target1');
-  expect(await page.$(`text="Hello"`)).toBe(null);
+  expect(await page.$eval(`text="Hello"`, e => e.id)).toBe('target1');
   expect(await page.$eval(`text="world"`, e => e.id)).toBe('target2');
   expect(await page.$$eval(`text="world"`, els => els.length)).toBe(1);
 
@@ -160,6 +160,21 @@ it('should work across nodes', async ({page}) => {
   expect(await page.$eval(`text=/.*/`, e => e.nodeName)).toBe('I');
   expect(await page.$eval(`text=/world?/`, e => e.id)).toBe('target2');
   expect(await page.$$eval(`text=/world/`, els => els.length)).toBe(1);
+});
+
+it('should work with text nodes in strict match mode', async ({page}) => {
+  await page.setContent(`<div id=target1>Hello<span id=target2>wo  rld  </span>  Hi again  </div>`);
+  expect(await page.$eval(`text="Hello"`, e => e.id)).toBe('target1');
+  expect(await page.$eval(`text="Hi again"`, e => e.id)).toBe('target1');
+  expect(await page.$eval(`text="wo rld"`, e => e.id)).toBe('target2');
+  expect(await page.$eval(`text="Hellowo rld Hi again"`, e => e.id)).toBe('target1');
+  expect(await page.$(`text="Hellowo"`)).toBe(null);
+  expect(await page.$(`text="Hellowo rld"`)).toBe(null);
+  expect(await page.$(`text="wo rld Hi ag"`)).toBe(null);
+  expect(await page.$(`text="again"`)).toBe(null);
+  expect(await page.$eval(`text=Hellowo`, e => e.id)).toBe('target1');
+  expect(await page.$eval(`text=wo rld Hi ag`, e => e.id)).toBe('target1');
+  expect(await page.$eval(`text=Hellowo rld`, e => e.id)).toBe('target1');
 });
 
 it('should clear caches', async ({page}) => {
@@ -249,6 +264,7 @@ it('should work with large DOM', async ({page}) => {
     'text=id18',
     'text=id12345',
     'text=id',
+    'text="id12345"',
     '#id18',
     '#id12345',
     '*',


### PR DESCRIPTION
This is a fix for a case where element contains text nodes and child elements
```html
<div>text1<span>child node</span>text2</div>
```

We now match this div by `text="text1"` and `text="text2"`.