### PR TITLE
chore: remove ProgressController.abort

### DIFF
--- a/src/server/electron/electron.ts
+++ b/src/server/electron/electron.ts
@@ -100,17 +100,11 @@ export class ElectronApplication extends SdkObject {
   }
 
   async close() {
-    const closed = this._waitForEvent(ElectronApplication.Events.Close);
+    const progressController = new ProgressController(internalCallMetadata(), this);
+    const closed = progressController.run(progress => helper.waitForEvent(progress, this, ElectronApplication.Events.Close).promise, this._timeoutSettings.timeout({}));
     await this._nodeElectronHandle!.evaluate(({ app }) => app.quit());
     this._nodeConnection.close();
     await closed;
-  }
-
-  private async _waitForEvent(event: string, predicate?: Function): Promise<any> {
-    const progressController = new ProgressController(internalCallMetadata(), this);
-    if (event !== ElectronApplication.Events.Close)
-      this._browserContext._closePromise.then(error => progressController.abort(error));
-    return progressController.run(progress => helper.waitForEvent(progress, this, event, predicate).promise, this._timeoutSettings.timeout({}));
   }
 
   async _init()  {

--- a/src/server/progress.ts
+++ b/src/server/progress.ts
@@ -111,10 +111,6 @@ export class ProgressController {
       clearTimeout(timer);
     }
   }
-
-  abort(error: Error) {
-    this._forceAbort(error);
-  }
 }
 
 async function runCleanup(cleanup: () => any) {


### PR DESCRIPTION
It is used in a few places, but we can do a Promise.race. This change will allow us to pass existing progress to multi-step operations.