### PR TITLE
docs: rename Page.console to consoleMessage in java

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -125,6 +125,8 @@ page.remove_listener("request", log_request)
 Emitted when the page closes.
 
 ## event: Page.console
+* langs:
+  - alias-java: consoleMessage
 - argument: <[ConsoleMessage]>
 
 Emitted when JavaScript within the page calls one of console API methods, e.g. `console.log` or `console.dir`. Also


### PR DESCRIPTION
We already have `waitForConsoleMessage` and this change aligns `onConsoleMessage` name with it.