### PR TITLE
docs: add ffmpeg to roll_browser.js usage output

### DIFF
--- a/utils/roll_browser.js
+++ b/utils/roll_browser.js
@@ -30,7 +30,7 @@ function usage() {
 usage: ${SCRIPT_NAME} <browser> <revision>
 
 Roll the <browser> to a specific <revision> and generate new protocol.
-Supported browsers: chromium, firefox, webkit.
+Supported browsers: chromium, firefox, webkit, ffmpeg.
 
 Example:
   ${SCRIPT_NAME} chromium 123456


### PR DESCRIPTION
This is a small change to show that ffmpeg is a supported browser parameter
value in the script usage. Although, the whole file should probably be
refactored now to something more generic like roll_download.js since ffmpeg
is just reusing the logic and isn't a browser.