### PR TITLE
fix: include parsed .md spec into api.json

### DIFF
--- a/utils/doclint/generateApiJson.js
+++ b/utils/doclint/generateApiJson.js
@@ -49,7 +49,7 @@ function serialize(documentation) {
  * @param {Documentation.Class} clazz
  */
 function serializeClass(clazz) {
-  const result = { name: clazz.name };
+  const result = { name: clazz.name, spec: clazz.spec };
   if (clazz.extends)
     result.extends = clazz.extends;
   result.langs = clazz.langs;
@@ -88,7 +88,6 @@ function sanitize(result) {
   delete result.argsArray;
   delete result.clazz;
   delete result.enclosingMethod;
-  delete result.spec;
 }
 
 /**


### PR DESCRIPTION
* Add .spec to all classes/members to simplify generation of language-specific docs (such as javadoc).
* Keeping .comment fields too to minimize changes on the python end for now.

Raw `api.json` size differs by 0.5Mb but zipped one grows by just 31Kb so should not be a problem.

```
-rw-rw-r-- 1 yurys yurys 681K Mar  1 12:16 api.json
-rw-rw-r-- 1 yurys yurys 1.1M Mar  1 12:15 api.json-both
```

```
-rw-rw-r-- 1 yurys yurys 121K Mar  1 12:17 b.zip
-rw-rw-r-- 1 yurys yurys  90K Mar  1 12:17 c.zip
```