### PR TITLE
devops(docker): fix registry to be accessible by Azure Pipelines user

### DIFF
--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -79,15 +79,17 @@ RUN apt-get update && apt-get install -y python3.8 python3-pip && \
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
-RUN mkdir /ms-playwright && chmod 777 /ms-playwright
-
 # 1. Add tip-of-tree Playwright package to install its browsers.
 #    The package should be built beforehand from tip-of-tree Playwright.
 COPY ./playwright.tar.gz /tmp/playwright.tar.gz
 
 # 2. Install playwright and then delete the installation.
 #    Browsers will remain downloaded in `/ms-playwright`.
-RUN su pwuser -c "mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
-    npm i /tmp/playwright.tar.gz" && \
-    rm -rf /tmp/pw && rm /tmp/playwright.tar.gz
+#    Note: make sure to set 777 to the registry so that any user can access
+#    registry.
+RUN mdkir /ms-playwright && \
+    mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
+    npm i /tmp/playwright.tar.gz && \
+    rm -rf /tmp/pw && rm /tmp/playwright.tar.gz && \
+    chmod -R 777 /ms-playwright
 

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -78,15 +78,17 @@ RUN apt-get update && apt-get install -y python3.8 python3-pip && \
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
-RUN mkdir /ms-playwright && chmod 777 /ms-playwright
-
 # 1. Add tip-of-tree Playwright package to install its browsers.
 #    The package should be built beforehand from tip-of-tree Playwright.
 COPY ./playwright.tar.gz /tmp/playwright.tar.gz
 
 # 2. Install playwright and then delete the installation.
 #    Browsers will remain downloaded in `/ms-playwright`.
-RUN su pwuser -c "mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
-    npm i /tmp/playwright.tar.gz" && \
-    rm -rf /tmp/pw && rm /tmp/playwright.tar.gz
+#    Note: make sure to set 777 to the registry so that any user can access
+#    registry.
+RUN mdkir /ms-playwright && \
+    mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
+    npm i /tmp/playwright.tar.gz && \
+    rm -rf /tmp/pw && rm /tmp/playwright.tar.gz && \
+    chmod -R 777 /ms-playwright
 


### PR DESCRIPTION
Turns out Azure Pipelines is doing a few modifications to the base
container. One important modification is that they add a new
user to the container that has a passwordless sudo permissions. This
user is used later on to run all the pipeline steps.

This patch makes sure our shared registry inside the docker containers
is accessible to all the users.

Fixes #5635