### PR TITLE
docs: enable BowserType.connect in java

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -96,7 +96,9 @@ can see what is going on. Defaults to 0.
 
 ### option: BrowserType.connect.timeout
 * langs: java
-- `timeout` <[float]> Maximum time in milliseconds to wait for the connection to be established. Defaults to
+- `timeout` <[float]>
+
+Maximum time in milliseconds to wait for the connection to be established. Defaults to
 `30000` (30 seconds). Pass `0` to disable timeout.
 
 ## async method: BrowserType.connectOverCDP

--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -66,12 +66,13 @@ with sync_playwright() as playwright:
 ```
 
 ## async method: BrowserType.connect
-* langs: js
+* langs: js, java
 - returns: <[Browser]>
 
 This methods attaches Playwright to an existing browser instance.
 
 ### param: BrowserType.connect.params
+* langs: js
 - `params` <[Object]>
   - `wsEndpoint` <[string]> A browser websocket endpoint to connect to.
   - `slowMo` <[float]> Slows down Playwright operations by the specified amount of milliseconds. Useful so that you
@@ -79,6 +80,24 @@ This methods attaches Playwright to an existing browser instance.
   - `logger` <[Logger]> Logger sink for Playwright logging. Optional.
   - `timeout` <[float]> Maximum time in milliseconds to wait for the connection to be established. Defaults to
     `30000` (30 seconds). Pass `0` to disable timeout.
+
+### param: BrowserType.connect.wsEndpoint
+* langs: java
+- `wsEndpoint` <[string]>
+
+A browser websocket endpoint to connect to.
+
+### option: BrowserType.connect.slowMo
+* langs: java
+- `slowMo` <[float]>
+
+Slows down Playwright operations by the specified amount of milliseconds. Useful so that you
+can see what is going on. Defaults to 0.
+
+### option: BrowserType.connect.timeout
+* langs: java
+- `timeout` <[float]> Maximum time in milliseconds to wait for the connection to be established. Defaults to
+`30000` (30 seconds). Pass `0` to disable timeout.
 
 ## async method: BrowserType.connectOverCDP
 * langs: js


### PR DESCRIPTION
While we are debating long-term solution for client/server connections adding this method to java to enable using it with existing playwright node servers. `BrowserType.launchServer` is available only in js as before.