### PR TITLE
docs: remove current accessbility api from java

### DIFF
--- a/docs/src/api/class-accessibility.md
+++ b/docs/src/api/class-accessibility.md
@@ -1,4 +1,5 @@
 # class: Accessibility
+* langs: csharp, js, python
 
 The Accessibility class provides methods for inspecting Chromium's accessibility tree. The accessibility tree is used by
 assistive technology such as [screen readers](https://en.wikipedia.org/wiki/Screen_reader) or

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -382,6 +382,7 @@ Emitted when a dedicated [WebWorker](https://developer.mozilla.org/en-US/docs/We
 page.
 
 ## property: Page.accessibility
+* langs: csharp, js, python
 - type: <[Accessibility]>
 
 ## async method: Page.addInitScript


### PR DESCRIPTION
The current API is close to unusable and we'll need to rethink it. As it hasn't been ship in java removing it now so that we don't have to deprecate it later.