### PR TITLE
browser(firefox): pass null for the data transfer

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1236
-Changed: lushnikov@chromium.org Tue 02 Mar 2021 06:38:43 PM PST
+1237
+Changed: joel.einbinder@gmail.com Thu 04 Mar 2021 05:16:38 PM PST

--- a/browser_patches/firefox/juggler/content/PageAgent.js
+++ b/browser_patches/firefox/juggler/content/PageAgent.js
@@ -790,8 +790,6 @@ class PageAgent {
     const element = window.windowUtils.elementFromPoint(x, y, false, false);
     const event = window.document.createEvent('DragEvent');
 
-    const dataTransfer = dragService.getCurrentSession().dataTransfer.mozCloneForEvent(type);
-    dataTransfer.dropEffect = 'move';
     event.initDragEvent(
       type,
       true /* bubble */,
@@ -808,7 +806,7 @@ class PageAgent {
       modifiers & 8 /* metaKey */,
       0 /* button */, // firefox always has the button as 0 on drops, regardless of which was pressed
       null /* relatedTarget */,
-      dataTransfer,
+      null,
     );
     if (type !== 'drop' || dragService.dragAction)
       window.windowUtils.dispatchDOMEventViaPresShellForTesting(element, event);


### PR DESCRIPTION
for some reason we don't need this and everything works great.