### PR TITLE
fix(BrowserContext): race between continue and close

### DIFF
--- a/src/client/browserContext.ts
+++ b/src/client/browserContext.ts
@@ -79,7 +79,8 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel,
         return;
       }
     }
-    route.continue();
+    // it can race with BrowserContext.close() which then throws since its closed
+    route.continue().catch(() => {});
   }
 
   async _onBinding(bindingCall: BindingCall) {


### PR DESCRIPTION
Debug logs:

```
2021-03-05T11:30:01.796Z pw:api => browserContext.close started
2021-03-05T11:30:01.808Z pw:api <= route.fulfill succeeded
2021-03-05T11:30:01.809Z pw:api => route.continue started <-- wants to continue
2021-03-05T11:30:01.813Z pw:api <= browserContext.close succeeded <-- closed
2021-03-05T11:30:01.814Z pw:api => browser.newContext started
2021-03-05T11:30:01.815Z pw:api <= route.continue failed <-- closed
```

Error:
```
route.continue: Target page, context or browser has been closed

Error: 
    at Object.captureStackTrace (/home/runner/work/node_modules/playwright/lib/utils/stackTrace.js:48:19)
    at Connection.sendMessageToServer (/home/runner/work/node_modules/playwright/lib/client/connection.js:69:48)
    at Proxy.<anonymous> (/home/runner/work/node_modules/playwright/lib/client/channelOwner.js:64:61)
    at /home/runner/work/node_modules/playwright/lib/client/network.js:201:35
    at Route._wrapApiCall (/home/runner/work/node_modules/playwright/lib/client/channelOwner.js:77:34)
    at Route.continue (/home/runner/work/node_modules/playwright/lib/client/network.js:199:21)
    at BrowserContext._onRoute (/home/runner/work/node_modules/playwright/lib/client/browserContext.js:92:23)
    at Page._onRoute (/home/runner/work/node_modules/playwright/lib/client/page.js:162:30)
    at Proxy.<anonymous> (/home/runner/work/node_modules/playwright/lib/client/page.js:112:64)
    at Proxy.emit (events.js:314:20)
    at Connection.dispatch (/home/runner/work/node_modules/playwright/lib/client/connection.js:116:25)
    at Immediate._onImmediate (/home/runner/work/node_modules/playwright/lib/inprocess.js:37:85)
    at processImmediate (internal/timers.js:458:21)
```