### PR TITLE
docs(dotnet): mark waitForClose as async

### DIFF
--- a/docs/src/api/class-worker.md
+++ b/docs/src/api/class-worker.md
@@ -96,7 +96,7 @@ Optional argument to pass to [`param: expression`].
 ## method: Worker.url
 - returns: <[string]>
 
-## method: Worker.waitForClose
+## async method: Worker.waitForClose
 * langs: csharp, java
 - returns: <[Worker]>
 


### PR DESCRIPTION
@yury-s this method looks like it's only useful when it's `async`. Does this mess with Java at all?