### PR TITLE
docs: document PlaywrightException in java

### DIFF
--- a/docs/src/api/class-playwrightexception.md
+++ b/docs/src/api/class-playwrightexception.md
@@ -1,0 +1,7 @@
+# class: PlaywrightException
+* langs: java
+* extends: [RuntimeException]
+
+PlaywrightException is thrown whenever certain operations are terminated abnormally, e.g.
+browser closes while [`method: Page.evaluate`] is running. All Playwright exceptions
+inherit from this class.

--- a/utils/doclint/documentation.js
+++ b/utils/doclint/documentation.js
@@ -68,7 +68,7 @@ class Documentation {
     for (const [name, clazz] of this.classes.entries()) {
       clazz.validateOrder(errors, clazz);
 
-      if (!clazz.extends || clazz.extends === 'EventEmitter' || clazz.extends === 'Error')
+      if (!clazz.extends || clazz.extends === 'EventEmitter' || clazz.extends === 'Error' || clazz.extends === 'RuntimeException')
         continue;
       const superClass = this.classes.get(clazz.extends);
       if (!superClass) {


### PR DESCRIPTION
This is the base class for all exceptions thrown in playwright java, adding this so that playwright.dev has it.