### PR TITLE
fix: drop support for webkit on macos 10.14

### DIFF
--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -107,7 +107,7 @@ const DOWNLOAD_URLS = {
     'ubuntu18.04': '%s/builds/webkit/%s/webkit-ubuntu-18.04.zip',
     'ubuntu20.04': '%s/builds/webkit/%s/webkit-ubuntu-20.04.zip',
     'mac10.13': undefined,
-    'mac10.14': '%s/builds/webkit/%s/webkit-mac-10.14.zip',
+    'mac10.14': undefined,
     'mac10.15': '%s/builds/webkit/%s/webkit-mac-10.15.zip',
     'mac11': '%s/builds/webkit/%s/webkit-mac-10.15.zip',
     'mac11-arm64': '%s/builds/webkit/%s/webkit-mac-11.0-arm64.zip',


### PR DESCRIPTION
Mojave support was dropped from WebKit ToT (https://bugs.webkit.org/show_bug.cgi?id=221211) and latest webkit roll doesn't compile on macos 10.14. So we are going to remove support for 10.14 starting with v1.10