### PR TITLE
docs(dotnet): adding missing methods from dotnet port

### DIFF
--- a/docs/src/api/csharp.md
+++ b/docs/src/api/csharp.md
@@ -1,0 +1,16 @@
+## method: Request.getPayloadAsJson
+* langs: csharp
+- returns: <[JsonDocument]>
+
+Returns a [JsonDocument] representation of [`method: Request.postDataBuffer`].
+
+### option: Request.getPayloadAsJson.serializerOptions
+- `documentOptions` <[null]|[JsonDocumentOptions]>
+
+The options that control custom behaviour when parsing the JSON.
+
+## method: Response.statusCode
+* langs: csharp
+- returns: <[System.Net.HttpStatusCode]>
+
+Gets the [System.Net.HttpStatusCode] code of the response.


### PR DESCRIPTION
This adds some methods from the dotnet port that should be a part of the documented API.