### PR TITLE
chore(xmldocs): resolve MD links to XmlDocs tags

### DIFF
--- a/utils/doclint/xmlDocumentation.js
+++ b/utils/doclint/xmlDocumentation.js
@@ -122,6 +122,7 @@ function _wrapAndEscape(node, maxColumns = 0) {
   text = text.replace(/\[(.*?)\]\((.*?\))/g, (match, linkName, linkUrl) => {
     return `<a href="${linkUrl}">${linkName}</a>`;
   });
+  text = text.replace(/\[(.*?)\]/g, (match, link) => `<see cref="${link}" />`);
   const words = text.split(' ');
   let line = '';
   for (let i = 0; i < words.length; i++) {


### PR DESCRIPTION
For items that don't resolve otherwise (i.e. to a class, method, etc.), we can assume they're a .NET reference and resolve to a `<see>` tag.