### PR TITLE
docs(dotnet): reference the available constants for csharp

### DIFF
--- a/docs/src/api/class-request.md
+++ b/docs/src/api/class-request.md
@@ -157,6 +157,10 @@ Contains the request's resource type as it was perceived by the rendering engine
 following: `document`, `stylesheet`, `image`, `media`, `font`, `script`, `texttrack`, `xhr`, `fetch`, `eventsource`,
 `websocket`, `manifest`, `other`.
 
+:::note csharp
+The resource types are available as constants in [ResourceTypes].
+:::
+
 ## async method: Request.response
 - returns: <[null]|[Response]>
 


### PR DESCRIPTION
Since the `resourceType` returned is strings, C# introduces some constants for this, to make comparison easier. This change makes them discoverable for the user.