### PR TITLE
fix(xmldocs): over-greedy regex for Markdown links

### DIFF
--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -364,7 +364,7 @@ function generateEnumNameIfApplicable(member, name, type, parent) {
 function renderMethod(member, parent, output, name) {
   const typeResolve = (type) => translateType(type, parent, (t) => {
     let newName = `${parent.name}${translateMemberName(member.kind, member.name, null)}Result`;
-    documentedResults.set(newName, `Result of calling <see cref="${translateMemberName("interface", parent.name)}.${translateMemberName(member.kind, member.name, member)}" />.`);
+    documentedResults.set(newName, `Result of calling <see cref="${translateMemberName("interface", parent.name)}.${translateMemberName(member.kind, member.name, member)}"/>.`);
     return newName;
   });
 

--- a/utils/doclint/templates/interface.cs
+++ b/utils/doclint/templates/interface.cs
@@ -39,6 +39,7 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;

--- a/utils/doclint/xmlDocumentation.js
+++ b/utils/doclint/xmlDocumentation.js
@@ -118,11 +118,11 @@ function _wrapAndEscape(node, maxColumns = 0) {
 
 
   let text = node.text;
-  text = text.replace(/`([^`]*)`/g, (match, code) => `<c>${code.replace('<', '&lt;').replace('>', '&gt;')}</c>`);
   text = text.replace(/\[(.*?)\]\((.*?)\)/g, (match, linkName, linkUrl) => {
     return `<a href="${linkUrl}">${linkName}</a>`;
   });
-  text = text.replace(/\[(.*?)\]/g, (match, link) => `<see cref="${link}" />`);
+  text = text.replace(/(?<!`)\[(.*?)\]/g, (match, link) => `<see cref="${link}"/>`);
+  text = text.replace(/`([^`]*)`/g, (match, code) => `<c>${code.replace('<', '&lt;').replace('>', '&gt;')}</c>`);
   const words = text.split(' ');
   let line = '';
   for (let i = 0; i < words.length; i++) {

--- a/utils/doclint/xmlDocumentation.js
+++ b/utils/doclint/xmlDocumentation.js
@@ -119,7 +119,7 @@ function _wrapAndEscape(node, maxColumns = 0) {
 
   let text = node.text;
   text = text.replace(/`([^`]*)`/g, (match, code) => `<c>${code.replace('<', '&lt;').replace('>', '&gt;')}</c>`);
-  text = text.replace(/\[(.*?)\]\((.*?\))/g, (match, linkName, linkUrl) => {
+  text = text.replace(/\[(.*?)\]\((.*?)\)/g, (match, linkName, linkUrl) => {
     return `<a href="${linkUrl}">${linkName}</a>`;
   });
   text = text.replace(/\[(.*?)\]/g, (match, link) => `<see cref="${link}" />`);


### PR DESCRIPTION
Turns out my regex was over-greedy, and it matched:

```markdown
Find more information at
[Resource Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming).
```

as 

```

[Resource Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming)
--
Group 1 |  Resource Timing API
Group 2 |  https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming)

```