### PR TITLE
fix(all): ensure a exception catch when async send call to a dead object;

### DIFF
--- a/src/dispatchers/browserContextDispatcher.ts
+++ b/src/dispatchers/browserContextDispatcher.ts
@@ -114,7 +114,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
       await this._context._setRequestInterceptor(undefined);
       return;
     }
-    this._context._setRequestInterceptor((route, request) => {
+    await this._context._setRequestInterceptor((route, request) => {
       this._dispatchEvent('route', { route: new RouteDispatcher(this._scope, route), request: RequestDispatcher.from(this._scope, request) });
     });
   }

--- a/src/dispatchers/pageDispatcher.ts
+++ b/src/dispatchers/pageDispatcher.ts
@@ -136,7 +136,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageInitializer> i
       await this._page._setClientRequestInterceptor(undefined);
       return;
     }
-    this._page._setClientRequestInterceptor((route, request) => {
+    await this._page._setClientRequestInterceptor((route, request) => {
       this._dispatchEvent('route', { route: new RouteDispatcher(this._scope, route), request: RequestDispatcher.from(this._scope, request) });
     });
   }


### PR DESCRIPTION
**Hello devs,**

_Please accept this fix to mitigate a problem with a scenario of intense concurrency headless use;_

Recently I migrate from puppeteer to this project targeting a better performance, and so it is, but in the path I found a async function been called without a await. Resulting, in a high performance application, a case of send to a dead object on the Dispatch(s):
```
<gracefully close start>
Error
at /home/ubuntu/project_name/node_modules/playwright-firefox/lib/server/firefox/ffConnection.js:147:63
at new Promise ()
at FFSession.send (/home/ubuntu/project_name/node_modules/playwright-firefox/lib/server/firefox/ffConnection.js:146:16)
at FFNetworkManager.setRequestInterception (/home/ubuntu/project_name/node_modules/playwright-firefox/lib/server/firefox/ffNetworkManager.js:39:29)
at FFPage.updateRequestInterception (/home/ubuntu/project_name/node_modules/playwright-firefox/lib/server/firefox/ffPage.js:285:36)
at Page._setClientRequestInterceptor (/home/ubuntu/project_name/node_modules/playwright-firefox/lib/server/page.js:254:30)
at PageDispatcher.setNetworkInterceptionEnabled (/home/ubuntu/project_name/node_modules/playwright-firefox/lib/dispatchers/pageDispatcher.js:125:20)
at DispatcherConnection.dispatch (/home/ubuntu/project_name/node_modules/playwright-firefox/lib/dispatchers/dispatcher.js:149:52)
at Immediate. (/home/ubuntu/project_name/node_modules/playwright-firefox/lib/inprocess.js:45:85)
at processImmediate (node:internal/timers:463:21)
at process.topLevelDomainCallback (node:domain:147:15)
at process.callbackTrampoline (node:internal/async_hooks:130:14)
```

Current example was on `playwright-firefox` package, but the fix reflects on all Browser Types.

Thanks, att
Gilberto

