### PR TITLE
chore: allow skipping host requirements validation

### DIFF
--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -20,6 +20,7 @@ import * as os from 'os';
 import { spawn } from 'child_process';
 import { getUbuntuVersion } from '../utils/ubuntuVersion';
 import * as registry from '../utils/registry';
+import * as utils from '../utils/utils';
 import { printDepsWindowsExecutable } from '../utils/binaryPaths';
 
 const accessAsync = util.promisify(fs.access.bind(fs));
@@ -28,6 +29,10 @@ const statAsync = util.promisify(fs.stat.bind(fs));
 const readdirAsync = util.promisify(fs.readdir.bind(fs));
 
 export async function validateHostRequirements(registry: registry.Registry, browserName: registry.BrowserName) {
+  if (utils.getAsBooleanFromENV('PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS')) {
+    process.stdout.write('Skipping host requirements validation logic because `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS` env variable is set.\n');
+    return;
+  }
   const ubuntuVersion = await getUbuntuVersion();
   if (browserName === 'firefox' && ubuntuVersion === '16.04')
     throw new Error(`Cannot launch firefox on Ubuntu 16.04! Minimum required Ubuntu version for Firefox browser is 18.04`);


### PR DESCRIPTION
### Background

The `playwright` library uses patched browsers' binaries that are not working with [nix] because the host requirements might not be satisfied. 

A way to make them work with nix is to create a nix [derivation] that wraps provided binaries within their dependencies and provides them already available by a path to a folder, so it's easy to point to them by using the `PLAYWRIGHT_BROWSERS_PATH` env variable. That means nix cares about the browsers' dependencies on its own. Hence, it doesn't make sense to validate host requirements on the `playwright` library level in this case. 

However, the library [validates host's requirements](https://github.com/microsoft/playwright/blob/master/src/server/browserType.ts#L180-L181) in such cases, which leads to a failure even when the binaries are fully operational (since they wrapped with nix) but the host requirements defined in the library are not satisfied.

### In this PR

This PR adds a condition to allow skipping host requirements validation by providing boolean `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS` env variable. 

### Use case

In `shell.nix`

```nix
{ nixpkgs }:

with nixpkgs;

let
  playwright-browsers = callPackage ./playwright-browsers/default.nix { };
in stdenv.mkDerivation {
  name = "codeceptjs-testing-env";
  # ...
  PLAYWRIGHT_BROWSERS_PATH = playwright-browsers;
  PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = true;
}
```

and then

```
$ nix-shell --pure ./shell.nix
[nix-shell:/workdir/web]# $PLAYWRIGHT_BROWSERS_PATH/chromium-844399/chrome-linux/chrome --version
Chromium 90.0.4392.0
[nix-shell:/workdir/web]# node
Welcome to Node.js v12.16.1.
Type ".help" for more information.
> const playwright = require('playwright');
undefined
> const browser = playwright.chromium.launch();
undefined
> 
Skipping host requirements validation logic because `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS` env variable is set.
```

[nix]: https://nixos.org/manual/nix/unstable/introduction.html
[derivation]: https://nixos.org/manual/nix/unstable/expressions/derivations.html