### PR TITLE
chore(docs): add support for language specific notes

### DIFF
--- a/utils/doclint/documentation.js
+++ b/utils/doclint/documentation.js
@@ -207,6 +207,7 @@ Documentation.Class = class {
       member.filterForLanguage(lang);
       membersArray.push(member);
     }
+    this.spec = filterSpecs(this.spec, lang);
     this.membersArray = membersArray;
   }
 
@@ -340,6 +341,7 @@ Documentation.Member = class {
       argsArray.push(overriddenArg);
     }
     this.argsArray = argsArray;
+    this.spec = filterSpecs(this.spec, lang);
   }
 
   clone() {
@@ -685,6 +687,18 @@ function generateSourceCodeComment(spec) {
     }
   });
   return md.render(comments, 120);
+}
+
+/**
+ * 
+ * @param {MarkdownNode[]} spec 
+ * @param {string} lang 
+ * @returns {MarkdownNode[]}
+ */
+function filterSpecs(spec, lang) {
+  if(!spec)
+    return;
+  return spec.filter(n => n.type !== 'note' || (n.type === 'note' && (!n.codeLang || n.codeLang === lang)));
 }
 
 module.exports = Documentation;

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -141,10 +141,12 @@ function buildTree(lines) {
     }
 
     if (content.startsWith(':::')) {
+      let noteType = content.substring(3).split(' ');
       /** @type {MarkdownNode} */
       const node = {
         type: 'note',
-        noteType: content.substring(3)
+        noteType: noteType[0],
+        codeLang: noteType[1]
       };
       line = lines[++i];
       const tokens = [];


### PR DESCRIPTION
This PR lets us define notes in markdown, that are language specific, for example:

```markdown
Contains the request's resource type as it was perceived by the rendering engine. ResourceType will be one of the
following: `document`, `stylesheet`, `image`, `media`, `font`, `script`, `texttrack`, `xhr`, `fetch`, `eventsource`,
`websocket`, `manifest`, `other`.

:::note csharp
The resource types are available as constants in [ResourceTypes].
:::
```

which would mean we can include small information nuggets like [here](https://github.com/microsoft/playwright/pull/5785) more easily without having to override the entire comment.