### PR TITLE
chore: update error message when using userDataDir arg

### DIFF
--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -112,7 +112,7 @@ export class Chromium extends BrowserType {
     const { args = [], proxy } = options;
     const userDataDirArg = args.find(arg => arg.startsWith('--user-data-dir'));
     if (userDataDirArg)
-      throw new Error('Pass userDataDir parameter instead of specifying --user-data-dir argument');
+      throw new Error('Pass userDataDir parameter to `browserType.launchPersistentContext(userDataDir, ...)` instead of specifying --user-data-dir argument');
     if (args.find(arg => arg.startsWith('--remote-debugging-pipe')))
       throw new Error('Playwright manages remote debugging connection itself.');
     if (args.find(arg => !arg.startsWith('-')))

--- a/src/server/firefox/firefox.ts
+++ b/src/server/firefox/firefox.ts
@@ -60,7 +60,7 @@ export class Firefox extends BrowserType {
       console.warn('devtools parameter is not supported as a launch argument in Firefox. You can launch the devtools window manually.');
     const userDataDirArg = args.find(arg => arg.startsWith('-profile') || arg.startsWith('--profile'));
     if (userDataDirArg)
-      throw new Error('Pass userDataDir parameter instead of specifying -profile argument');
+      throw new Error('Pass userDataDir parameter to `browserType.launchPersistentContext(userDataDir, ...)` instead of specifying --profile argument');
     if (args.find(arg => arg.startsWith('-juggler')))
       throw new Error('Use the port parameter instead of -juggler argument');
     const firefoxUserPrefs = isPersistent ? undefined : options.firefoxUserPrefs;

--- a/src/server/webkit/webkit.ts
+++ b/src/server/webkit/webkit.ts
@@ -49,9 +49,9 @@ export class WebKit extends BrowserType {
     const { args = [], proxy, devtools, headless } = options;
     if (devtools)
       console.warn('devtools parameter as a launch argument in WebKit is not supported. Also starting Web Inspector manually will terminate the execution in WebKit.');
-    const userDataDirArg = args.find(arg => arg.startsWith('--user-data-dir='));
+    const userDataDirArg = args.find(arg => arg.startsWith('--user-data-dir'));
     if (userDataDirArg)
-      throw new Error('Pass userDataDir parameter instead of specifying --user-data-dir argument');
+      throw new Error('Pass userDataDir parameter to `browserType.launchPersistentContext(userDataDir, ...)` instead of specifying --user-data-dir argument');
     if (args.find(arg => !arg.startsWith('-')))
       throw new Error('Arguments can not specify page to be opened');
     const webkitArguments = ['--inspector-pipe'];

--- a/test/browsertype-launch.spec.ts
+++ b/test/browsertype-launch.spec.ts
@@ -36,6 +36,13 @@ it('should throw if userDataDir option is passed', async ({browserType, browserO
   expect(waitError.message).toContain('userDataDir option is not supported in `browserType.launch`. Use `browserType.launchPersistentContext` instead');
 });
 
+it('should throw if userDataDir is passed as an argument', async ({browserType, browserOptions}) => {
+  let waitError = null;
+  const options = Object.assign({}, browserOptions, {args: ['--user-data-dir=random-path', '--profile=random-path']});
+  await browserType.launch(options).catch(e => waitError = e);
+  expect(waitError.message).toContain('Pass userDataDir parameter to `browserType.launchPersistentContext');
+});
+
 it('should throw if port option is passed', async ({browserType, browserOptions}) => {
   const options = Object.assign({}, browserOptions, {port: 1234});
   const error = await browserType.launch(options).catch(e => e);


### PR DESCRIPTION
New Playwright users may unaware of the proper way to set the browser's
`userDataDir`. Currently, calling `launch({args: ['--userDataDir=...']})`
throws shows users an error message, leading some to try
`launch({userDataDir})`, which also throws and shows a different error
message, leading users to the proper invocation,
`launchPersistentContext(userDataDir, ...)`.

This change updates the first error message's text to hopefully hint users to
the proper invocation more quickly.