### PR TITLE
docs(js) fix a typo in page.on('console') example

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -137,7 +137,7 @@ The arguments passed into `console.log` appear as arguments on the event handler
 An example of handling `console` event:
 
 ```js
-page.on('console', msg => {
+page.on('console', async (msg) => {
   for (let i = 0; i < msg.args().length; ++i)
     console.log(`${i}: ${await msg.args()[i].jsonValue()}`);
 });

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -380,7 +380,7 @@ export interface Page {
    * An example of handling `console` event:
    * 
    * ```js
-   * page.on('console', msg => {
+   * page.on('console', async (msg) => {
    *   for (let i = 0; i < msg.args().length; ++i)
    *     console.log(`${i}: ${await msg.args()[i].jsonValue()}`);
    * });


### PR DESCRIPTION
Add missing "async".