### PR TITLE
docs(dotnet): move options arguments last

### DIFF
--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -521,9 +521,8 @@ function renderMethod(member, parent, output, name) {
     pushArg(argType, argName, arg);
   };
 
-  Array.from(member.args)
-    .map(i => i[1])
-    .sort((a, b) =>  b.alias ==='options' ? -1 : 0) //move options to the back to the arguments list
+  member.argsArray
+    .sort((a, b) =>  b.alias === 'options' ? -1 : 0) //move options to the back to the arguments list
     .forEach(parseArg);
 
   output(XmlDoc.renderXmlDoc(member.spec, maxDocumentationColumnWidth));

--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -521,7 +521,10 @@ function renderMethod(member, parent, output, name) {
     pushArg(argType, argName, arg);
   };
 
-  member.args.forEach(parseArg);
+  Array.from(member.args)
+    .map(i => i[1])
+    .sort((a, b) =>  b.alias ==='options' ? -1 : 0) //move options to the back to the arguments list
+    .forEach(parseArg);
 
   output(XmlDoc.renderXmlDoc(member.spec, maxDocumentationColumnWidth));
   paramDocs.forEach((val, ind) => {


### PR DESCRIPTION
Language-specific arguments are being parsed after the options argument. We need options last.