### PR TITLE
chore(evaluate): explicitly annotate methods that wait for signals

### DIFF
--- a/src/dispatchers/electronDispatcher.ts
+++ b/src/dispatchers/electronDispatcher.ts
@@ -51,12 +51,12 @@ export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplicatio
 
   async evaluateExpression(params: channels.ElectronApplicationEvaluateExpressionParams): Promise<channels.ElectronApplicationEvaluateExpressionResult> {
     const handle = this._object._nodeElectronHandle!;
-    return { value: serializeResult(await handle._evaluateExpression(params.expression, params.isFunction, true /* returnByValue */, parseArgument(params.arg))) };
+    return { value: serializeResult(await handle.evaluateExpression(params.expression, params.isFunction, true /* returnByValue */, parseArgument(params.arg))) };
   }
 
   async evaluateExpressionHandle(params: channels.ElectronApplicationEvaluateExpressionHandleParams): Promise<channels.ElectronApplicationEvaluateExpressionHandleResult> {
     const handle = this._object._nodeElectronHandle!;
-    const result = await handle._evaluateExpression(params.expression, params.isFunction, false /* returnByValue */, parseArgument(params.arg));
+    const result = await handle.evaluateExpression(params.expression, params.isFunction, false /* returnByValue */, parseArgument(params.arg));
     return { handle: createHandle(this._scope, result) };
   }
 

--- a/src/dispatchers/elementHandlerDispatcher.ts
+++ b/src/dispatchers/elementHandlerDispatcher.ts
@@ -171,11 +171,11 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements chann
   }
 
   async evalOnSelector(params: channels.ElementHandleEvalOnSelectorParams, metadata: CallMetadata): Promise<channels.ElementHandleEvalOnSelectorResult> {
-    return { value: serializeResult(await this._elementHandle._$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
+    return { value: serializeResult(await this._elementHandle.$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
   async evalOnSelectorAll(params: channels.ElementHandleEvalOnSelectorAllParams, metadata: CallMetadata): Promise<channels.ElementHandleEvalOnSelectorAllResult> {
-    return { value: serializeResult(await this._elementHandle._$$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
+    return { value: serializeResult(await this._elementHandle.$$evalExpression(params.selector, params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 
   async waitForElementState(params: channels.ElementHandleWaitForElementStateParams, metadata: CallMetadata): Promise<void> {

--- a/src/dispatchers/frameDispatcher.ts
+++ b/src/dispatchers/frameDispatcher.ts
@@ -61,11 +61,11 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameInitializer
   }
 
   async evaluateExpression(params: channels.FrameEvaluateExpressionParams, metadata: CallMetadata): Promise<channels.FrameEvaluateExpressionResult> {
-    return { value: serializeResult(await this._frame._evaluateExpression(params.expression, params.isFunction, parseArgument(params.arg), params.world)) };
+    return { value: serializeResult(await this._frame.evaluateExpressionAndWaitForSignals(params.expression, params.isFunction, parseArgument(params.arg), params.world)) };
   }
 
   async evaluateExpressionHandle(params: channels.FrameEvaluateExpressionHandleParams, metadata: CallMetadata): Promise<channels.FrameEvaluateExpressionHandleResult> {
-    return { handle: createHandle(this._scope, await this._frame._evaluateExpressionHandle(params.expression, params.isFunction, parseArgument(params.arg), params.world)) };
+    return { handle: createHandle(this._scope, await this._frame.evaluateExpressionHandleAndWaitForSignals(params.expression, params.isFunction, parseArgument(params.arg), params.world)) };
   }
 
   async waitForSelector(params: channels.FrameWaitForSelectorParams, metadata: CallMetadata): Promise<channels.FrameWaitForSelectorResult> {

--- a/src/dispatchers/jsHandleDispatcher.ts
+++ b/src/dispatchers/jsHandleDispatcher.ts
@@ -31,11 +31,11 @@ export class JSHandleDispatcher extends Dispatcher<js.JSHandle, channels.JSHandl
   }
 
   async evaluateExpression(params: channels.JSHandleEvaluateExpressionParams): Promise<channels.JSHandleEvaluateExpressionResult> {
-    return { value: serializeResult(await this._object._evaluateExpression(params.expression, params.isFunction, true /* returnByValue */, parseArgument(params.arg))) };
+    return { value: serializeResult(await this._object.evaluateExpression(params.expression, params.isFunction, true /* returnByValue */, parseArgument(params.arg))) };
   }
 
   async evaluateExpressionHandle(params: channels.JSHandleEvaluateExpressionHandleParams): Promise<channels.JSHandleEvaluateExpressionHandleResult> {
-    const jsHandle = await this._object._evaluateExpression(params.expression, params.isFunction, false /* returnByValue */, parseArgument(params.arg));
+    const jsHandle = await this._object.evaluateExpression(params.expression, params.isFunction, false /* returnByValue */, parseArgument(params.arg));
     return { handle: createHandle(this._scope, jsHandle) };
   }
 

--- a/src/server/browserContext.ts
+++ b/src/server/browserContext.ts
@@ -316,7 +316,7 @@ export abstract class BrowserContext extends SdkObject {
         const originStorage: types.OriginStorage = { origin, localStorage: [] };
         const frame = page.mainFrame();
         await frame.goto(internalMetadata, origin);
-        const storage = await frame._evaluateExpression(`({
+        const storage = await frame.evaluateExpression(`({
           localStorage: Object.keys(localStorage).map(name => ({ name, value: localStorage.getItem(name) })),
         })`, false, undefined, 'utility');
         originStorage.localStorage = storage.localStorage;
@@ -340,7 +340,7 @@ export abstract class BrowserContext extends SdkObject {
       for (const originState of state.origins) {
         const frame = page.mainFrame();
         await frame.goto(metadata, originState.origin);
-        await frame._evaluateExpression(`
+        await frame.evaluateExpression(`
           originState => {
             for (const { name, value } of (originState.localStorage || []))
               localStorage.setItem(name, value);

--- a/src/server/chromium/crPage.ts
+++ b/src/server/chromium/crPage.ts
@@ -143,7 +143,7 @@ export class CRPage implements PageDelegate {
 
   async exposeBinding(binding: PageBinding) {
     await this._forAllFrameSessions(frame => frame._initBinding(binding));
-    await Promise.all(this._page.frames().map(frame => frame._evaluateExpression(binding.source, false, {}, binding.world).catch(e => {})));
+    await Promise.all(this._page.frames().map(frame => frame.evaluateExpression(binding.source, false, {}, binding.world).catch(e => {})));
   }
 
   async updateExtraHTTPHeaders(): Promise<void> {
@@ -284,7 +284,7 @@ export class CRPage implements PageDelegate {
   }
 
   async setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void> {
-    await handle._evaluateInUtility(([injected, node, files]) =>
+    await handle.evaluateInUtility(([injected, node, files]) =>
       injected.setInputFiles(node, files), files);
   }
 
@@ -421,9 +421,9 @@ class FrameSession {
             worldName: UTILITY_WORLD_NAME,
           });
           for (const binding of this._crPage._browserContext._pageBindings.values())
-            frame._evaluateExpression(binding.source, false, undefined, binding.world).catch(e => {});
+            frame.evaluateExpression(binding.source, false, undefined, binding.world).catch(e => {});
           for (const source of this._crPage._browserContext._evaluateOnNewDocumentSources)
-            frame._evaluateExpression(source, false, undefined, 'main').catch(e => {});
+            frame.evaluateExpression(source, false, undefined, 'main').catch(e => {});
         }
         const isInitialEmptyPage = this._isMainFrame() && this._page.mainFrame().url() === ':';
         if (isInitialEmptyPage) {

--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -389,7 +389,7 @@ export class FFPage implements PageDelegate {
   async takeScreenshot(format: 'png' | 'jpeg', documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined): Promise<Buffer> {
     if (!documentRect) {
       const context = await this._page.mainFrame()._utilityContext();
-      const scrollOffset = await context.evaluateInternal(() => ({ x: window.scrollX, y: window.scrollY }));
+      const scrollOffset = await context.evaluate(() => ({ x: window.scrollX, y: window.scrollY }));
       documentRect = {
         x: viewportRect!.x + scrollOffset.x,
         y: viewportRect!.y + scrollOffset.y,
@@ -484,7 +484,7 @@ export class FFPage implements PageDelegate {
   }
 
   async setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void> {
-    await handle._evaluateInUtility(([injected, node, files]) =>
+    await handle.evaluateInUtility(([injected, node, files]) =>
       injected.setInputFiles(node, files), files);
   }
 

--- a/src/server/javascript.ts
+++ b/src/server/javascript.ts
@@ -114,19 +114,15 @@ export class JSHandle<T = any> extends SdkObject {
     this._context._delegate.rawCallFunctionNoReply(func, this, arg);
   }
 
-  async evaluate<R, Arg>(pageFunction: FuncOn<T, Arg, R>, arg: Arg): Promise<R>;
-  async evaluate<R>(pageFunction: FuncOn<T, void, R>, arg?: any): Promise<R>;
-  async evaluate<R, Arg>(pageFunction: FuncOn<T, Arg, R>, arg: Arg): Promise<R> {
+  async evaluate<R, Arg>(pageFunction: FuncOn<T, Arg, R>, arg?: Arg): Promise<R> {
     return evaluate(this._context, true /* returnByValue */, pageFunction, this, arg);
   }
 
-  async evaluateHandle<R, Arg>(pageFunction: FuncOn<T, Arg, R>, arg: Arg): Promise<SmartHandle<R>>;
-  async evaluateHandle<R>(pageFunction: FuncOn<T, void, R>, arg?: any): Promise<SmartHandle<R>>;
-  async evaluateHandle<R, Arg>(pageFunction: FuncOn<T, Arg, R>, arg: Arg): Promise<SmartHandle<R>> {
+  async evaluateHandle<R, Arg>(pageFunction: FuncOn<T, Arg, R>, arg?: Arg): Promise<SmartHandle<R>> {
     return evaluate(this._context, false /* returnByValue */, pageFunction, this, arg);
   }
 
-  async _evaluateExpression(expression: string, isFunction: boolean | undefined, returnByValue: boolean, arg: any) {
+  async evaluateExpression(expression: string, isFunction: boolean | undefined, returnByValue: boolean, arg: any) {
     const value = await evaluateExpression(this._context, returnByValue, expression, isFunction, this, arg);
     await this._context.doSlowMo();
     return value;

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -563,17 +563,17 @@ export class PageBinding {
       const binding = page.getBinding(name, context.world)!;
       let result: any;
       if (binding.needsHandle) {
-        const handle = await context.evaluateHandleInternal(takeHandle, { name, seq }).catch(e => null);
+        const handle = await context.evaluateHandle(takeHandle, { name, seq }).catch(e => null);
         result = await binding.playwrightFunction({ frame: context.frame, page, context: page._browserContext }, handle);
       } else {
         result = await binding.playwrightFunction({ frame: context.frame, page, context: page._browserContext }, ...args);
       }
-      context.evaluateInternal(deliverResult, { name, seq, result }).catch(e => debugLogger.log('error', e));
+      context.evaluate(deliverResult, { name, seq, result }).catch(e => debugLogger.log('error', e));
     } catch (error) {
       if (isError(error))
-        context.evaluateInternal(deliverError, { name, seq, message: error.message, stack: error.stack }).catch(e => debugLogger.log('error', e));
+        context.evaluate(deliverError, { name, seq, message: error.message, stack: error.stack }).catch(e => debugLogger.log('error', e));
       else
-        context.evaluateInternal(deliverErrorValue, { name, seq, error }).catch(e => debugLogger.log('error', e));
+        context.evaluate(deliverErrorValue, { name, seq, error }).catch(e => debugLogger.log('error', e));
     }
 
     function takeHandle(arg: { name: string, seq: number }) {

--- a/src/server/screenshotter.ts
+++ b/src/server/screenshotter.ts
@@ -37,14 +37,14 @@ export class Screenshotter {
     let viewportSize = originalViewportSize;
     if (!viewportSize) {
       const context = await this._page.mainFrame()._utilityContext();
-      viewportSize = await context.evaluateInternal(() => ({ width: window.innerWidth, height: window.innerHeight }));
+      viewportSize = await context.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
     }
     return { viewportSize, originalViewportSize };
   }
 
   private async _fullPageSize(): Promise<types.Size> {
     const context = await this._page.mainFrame()._utilityContext();
-    const fullPageSize = await context.evaluateInternal(() => {
+    const fullPageSize = await context.evaluate(() => {
       if (!document.body || !document.documentElement)
         return null;
       return {
@@ -125,7 +125,7 @@ export class Screenshotter {
       }
 
       const context = await this._page.mainFrame()._utilityContext();
-      const scrollOffset = await context.evaluateInternal(() => ({ x: window.scrollX, y: window.scrollY }));
+      const scrollOffset = await context.evaluate(() => ({ x: window.scrollX, y: window.scrollY }));
       const documentRect = { ...boundingBox };
       documentRect.x += scrollOffset.x;
       documentRect.y += scrollOffset.y;

--- a/src/server/snapshot/snapshotter.ts
+++ b/src/server/snapshot/snapshotter.ts
@@ -185,7 +185,7 @@ export class Snapshotter {
 
 async function setIntervalInFrame(frame: Frame, interval: number) {
   const context = frame._existingMainContext();
-  await context?.evaluateInternal(({ kSnapshotStreamer, interval }) => {
+  await context?.evaluate(({ kSnapshotStreamer, interval }) => {
     (window as any)[kSnapshotStreamer].setSnapshotInterval(interval);
   }, { kSnapshotStreamer, interval }).catch(debugExceptionHandler);
 }
@@ -197,7 +197,7 @@ async function annotateFrameHierarchy(frame: Frame) {
     if (!parent)
       return;
     const context = await parent._mainContext();
-    await context?.evaluateInternal(({ kSnapshotStreamer, frameElement, frameId }) => {
+    await context?.evaluate(({ kSnapshotStreamer, frameElement, frameId }) => {
       (window as any)[kSnapshotStreamer].markIframe(frameElement, frameId);
     }, { kSnapshotStreamer, frameElement, frameId: frame.uniqueId });
     frameElement.dispose();

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -91,7 +91,7 @@ class HarContextTracer {
     page.on(Page.Events.Response, (response: network.Response) => this._onResponse(page, response));
 
     page.on(Page.Events.DOMContentLoaded, () => {
-      const promise = page.mainFrame()._evaluateExpression(String(() => {
+      const promise = page.mainFrame().evaluateExpression(String(() => {
         return {
           title: document.title,
           domContentLoaded: performance.timing.domContentLoadedEventStart,
@@ -103,7 +103,7 @@ class HarContextTracer {
       this._addBarrier(page, promise);
     });
     page.on(Page.Events.Load, () => {
-      const promise = page.mainFrame()._evaluateExpression(String(() => {
+      const promise = page.mainFrame().evaluateExpression(String(() => {
         return {
           title: document.title,
           loaded: performance.timing.loadEventStart,
@@ -118,7 +118,7 @@ class HarContextTracer {
 
   private _addBarrier(page: Page, promise: Promise<void>) {
     const race = Promise.race([
-      new Promise(f => page.on('close', () => {
+      new Promise<void>(f => page.on('close', () => {
         this._barrierPromises.delete(race);
         f();
       })),

--- a/src/server/supplements/recorder/recorderApp.ts
+++ b/src/server/supplements/recorder/recorderApp.ts
@@ -121,25 +121,25 @@ export class RecorderApp extends EventEmitter {
   }
 
   async setMode(mode: 'none' | 'recording' | 'inspecting'): Promise<void> {
-    await this._page.mainFrame()._evaluateExpression(((mode: Mode) => {
+    await this._page.mainFrame().evaluateExpression(((mode: Mode) => {
       window.playwrightSetMode(mode);
     }).toString(), true, mode, 'main').catch(() => {});
   }
 
   async setFile(file: string): Promise<void> {
-    await this._page.mainFrame()._evaluateExpression(((file: string) => {
+    await this._page.mainFrame().evaluateExpression(((file: string) => {
       window.playwrightSetFile(file);
     }).toString(), true, file, 'main').catch(() => {});
   }
 
   async setPaused(paused: boolean): Promise<void> {
-    await this._page.mainFrame()._evaluateExpression(((paused: boolean) => {
+    await this._page.mainFrame().evaluateExpression(((paused: boolean) => {
       window.playwrightSetPaused(paused);
     }).toString(), true, paused, 'main').catch(() => {});
   }
 
   async setSources(sources: Source[]): Promise<void> {
-    await this._page.mainFrame()._evaluateExpression(((sources: Source[]) => {
+    await this._page.mainFrame().evaluateExpression(((sources: Source[]) => {
       window.playwrightSetSources(sources);
     }).toString(), true, sources, 'main').catch(() => {});
 
@@ -154,13 +154,13 @@ export class RecorderApp extends EventEmitter {
   }
 
   async setSelector(selector: string, focus?: boolean): Promise<void> {
-    await this._page.mainFrame()._evaluateExpression(((arg: any) => {
+    await this._page.mainFrame().evaluateExpression(((arg: any) => {
       window.playwrightSetSelector(arg.selector, arg.focus);
     }).toString(), true, { selector, focus }, 'main').catch(() => {});
   }
 
   async updateCallLogs(callLogs: CallLog[]): Promise<void> {
-    await this._page.mainFrame()._evaluateExpression(((callLogs: CallLog[]) => {
+    await this._page.mainFrame().evaluateExpression(((callLogs: CallLog[]) => {
       window.playwrightUpdateLogs(callLogs);
     }).toString(), true, callLogs, 'main').catch(() => {});
   }

--- a/src/server/supplements/recorderSupplement.ts
+++ b/src/server/supplements/recorderSupplement.ts
@@ -284,7 +284,7 @@ export class RecorderSupplement {
 
   private _refreshOverlay() {
     for (const page of this._context.pages())
-      page.mainFrame()._evaluateExpression('window._playwrightRefreshOverlay()', false, undefined, 'main').catch(() => {});
+      page.mainFrame().evaluateExpression('window._playwrightRefreshOverlay()', false, undefined, 'main').catch(() => {});
   }
 
   private async _onPage(page: Page) {

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -178,7 +178,7 @@ export class WKPage implements PageDelegate {
       promises.push(WKPage._setEmulateMedia(session, this._page._state.mediaType, this._page._state.colorScheme));
     const bootstrapScript = this._calculateBootstrapScript();
     promises.push(session.send('Page.setBootstrapScript', { source: bootstrapScript }));
-    this._page.frames().map(frame => frame._evaluateExpression(bootstrapScript, false, undefined, 'main').catch(e => {}));
+    this._page.frames().map(frame => frame.evaluateExpression(bootstrapScript, false, undefined, 'main').catch(e => {}));
     if (contextOptions.bypassCSP)
       promises.push(session.send('Page.setBypassCSP', { enabled: true }));
     if (this._page._state.viewportSize) {
@@ -699,7 +699,7 @@ export class WKPage implements PageDelegate {
     if (binding.world !== 'main')
       throw new Error('Only main context bindings are supported in WebKit.');
     const script = this._bindingToScript(binding);
-    await Promise.all(this._page.frames().map(frame => frame._evaluateExpression(script, false, {}).catch(e => {})));
+    await Promise.all(this._page.frames().map(frame => frame.evaluateExpression(script, false, {}).catch(e => {})));
   }
 
   async evaluateOnNewDocument(script: string): Promise<void> {

--- a/test/page-expose-function.spec.ts
+++ b/test/page-expose-function.spec.ts
@@ -246,22 +246,22 @@ it('should work with internal bindings', (test, { mode, browserName }) => {
     foo = arg;
   }, 'utility');
   expect(await page.evaluate('!!window.foo')).toBe(false);
-  expect(await implPage.mainFrame()._evaluateExpression('!!window.foo', false, {}, 'utility')).toBe(true);
+  expect(await implPage.mainFrame().evaluateExpression('!!window.foo', false, {}, 'utility')).toBe(true);
   expect(foo).toBe(undefined);
-  await implPage.mainFrame()._evaluateExpression('window.foo(123)', false, {}, 'utility');
+  await implPage.mainFrame().evaluateExpression('window.foo(123)', false, {}, 'utility');
   expect(foo).toBe(123);
 
   // should work after reload
   await page.goto(server.EMPTY_PAGE);
   expect(await page.evaluate('!!window.foo')).toBe(false);
-  await implPage.mainFrame()._evaluateExpression('window.foo(456)', false, {}, 'utility');
+  await implPage.mainFrame().evaluateExpression('window.foo(456)', false, {}, 'utility');
   expect(foo).toBe(456);
 
   // should work inside frames
   const frame = await attachFrame(page, 'myframe', server.CROSS_PROCESS_PREFIX + '/empty.html');
   expect(await frame.evaluate('!!window.foo')).toBe(false);
   const implFrame: import('../src/server/frames').Frame = toImpl(frame);
-  await implFrame._evaluateExpression('window.foo(789)', false, {}, 'utility');
+  await implFrame.evaluateExpression('window.foo(789)', false, {}, 'utility');
   expect(foo).toBe(789);
 });
 


### PR DESCRIPTION
This change forks `Frame._evaluateExpression` into `Frame.evaluateExpression` and `Frame.evaluateExpressionAndWaitForSignals` and uses appropriate version. Drive-by names `Handle._evaluateExpression` as public w/o prefix.