### PR TITLE
fix(chromium): fix race with Chromium lifecycle events

### DIFF
--- a/src/server/chromium/crPage.ts
+++ b/src/server/chromium/crPage.ts
@@ -436,7 +436,7 @@ class FrameSession {
         } else {
           this._firstNonInitialNavigationCommittedFulfill();
           this._eventListeners.push(helper.addEventListener(this._client, 'Page.lifecycleEvent', event => this._onLifecycleEvent(event)));
-        };
+        }
         return lifecycleEventsEnabled;
       }),
       this._client.send('Log.enable', {}),


### PR DESCRIPTION
We should subscribe to lifecycle events not later than we send the
`Page.setLifecycleEventsEnabled` event.

Currently, we subscribe to the lifecycle events only after the frame
tree is returned. However, this way we might miss some of the lifecycle
events, which results in Chromium hanging.

Fixes #5228