### PR TITLE
fix: work-around electron's broken event loop

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -28,7 +28,7 @@ export function makeWaitForNextTask() {
   // using Node 14 internally, so we fallback to `setTimeout(0)` instead.
   // @see https://github.com/electron/electron/issues/28261
   if (process.versions.electron)
-    return callback => setTimeout(callback, 0);
+    return (callback: () => void) => setTimeout(callback, 0);
   if (parseInt(process.versions.node, 10) >= 11)
     return setImmediate;
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -24,6 +24,11 @@ const mkdirAsync = util.promisify(fs.mkdir.bind(fs));
 
 // See https://joel.tools/microtasks/
 export function makeWaitForNextTask() {
+  // As of Mar 2021, Electorn v12 doesn't create new task with `setImmediate` despite
+  // using Node 14 internally, so we fallback to `setTimeout(0)` instead.
+  // @see https://github.com/electron/electron/issues/28261
+  if (process.versions.electron)
+    return callback => setTimeout(callback, 0);
   if (parseInt(process.versions.node, 10) >= 11)
     return setImmediate;
 


### PR DESCRIPTION
Since `setImmediate` doesn't create a new task in Electron,
we have to fallback to `setTimeout` instead.

See https://github.com/electron/electron/issues/28261 for details.

Fixes #5228