### PR TITLE
feat: support webkit technology preview

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -20,6 +20,11 @@
       }
     },
     {
+      "name": "webkit-technology-preview",
+      "revision": "1443",
+      "installByDefault": false
+    },
+    {
       "name": "ffmpeg",
       "revision": "1005",
       "installByDefault": true

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -32,6 +32,7 @@ import { BrowserType } from '../client/browserType';
 import { BrowserContextOptions, LaunchOptions } from '../client/types';
 import { spawn } from 'child_process';
 import { installDeps } from '../install/installDeps';
+import { allBrowserNames } from '../utils/registry';
 
 program
     .version('Version ' + require('../../package.json').version)
@@ -85,10 +86,10 @@ program
     .description('ensure browsers necessary for this version of Playwright are installed')
     .action(async function(browserType) {
       try {
-        const allBrowsers = new Set(['chromium', 'firefox', 'webkit', 'ffmpeg']);
+        const allBrowsers = new Set(allBrowserNames);
         for (const type of browserType) {
           if (!allBrowsers.has(type)) {
-            console.log(`Invalid browser name: '${type}'. Expecting 'chromium', 'firefox' or 'webkit'.`);
+            console.log(`Invalid browser name: '${type}'. Expecting one of: ${allBrowserNames.map(name => `'${name}'`).join(', ')}`);
             process.exit(1);
           }
         }

--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -43,11 +43,12 @@ export async function validateHostRequirements(registry: registry.Registry, brow
 }
 
 const DL_OPEN_LIBRARIES = {
-  chromium: [],
-  webkit: ['libGLESv2.so.2', 'libx264.so'],
-  firefox: [],
-  clank: [],
-  ffmpeg: [],
+  'chromium': [],
+  'webkit': ['libGLESv2.so.2', 'libx264.so'],
+  'webkit-technology-preview': ['libGLESv2.so.2', 'libx264.so'],
+  'firefox': [],
+  'clank': [],
+  'ffmpeg': [],
 };
 
 function isSupportedWindowsVersion(): boolean {

--- a/src/server/webkit/webkit.ts
+++ b/src/server/webkit/webkit.ts
@@ -34,7 +34,7 @@ export class WebKit extends BrowserType {
   executablePath(options?: types.LaunchOptions): string {
     if (options?.channel) {
       let executablePath = undefined;
-      if (options.channel === 'technology-preview')
+      if ((options.channel as any) === 'technology-preview')
         executablePath = this._registry.executablePath('webkit-technology-preview');
       assert(executablePath, `unsupported webkit channel "${options.channel}"`);
       assert(fs.existsSync(executablePath), `webkit channel "${options.channel}" is not installed. Try running 'npx playwright install webkit-technology-preview'`);

--- a/src/server/webkit/webkit.ts
+++ b/src/server/webkit/webkit.ts
@@ -23,10 +23,24 @@ import { BrowserType } from '../browserType';
 import { ConnectionTransport } from '../transport';
 import { BrowserOptions, PlaywrightOptions } from '../browser';
 import * as types from '../types';
+import * as fs from 'fs';
+import { assert } from '../../utils/utils';
 
 export class WebKit extends BrowserType {
   constructor(playwrightOptions: PlaywrightOptions) {
     super('webkit', playwrightOptions);
+  }
+
+  executablePath(options?: types.LaunchOptions): string {
+    if (options?.channel) {
+      let executablePath = undefined;
+      if (options.channel === 'technology-preview')
+        executablePath = this._registry.executablePath('webkit-technology-preview');
+      assert(executablePath, `unsupported webkit channel "${options.channel}"`);
+      assert(fs.existsSync(executablePath), `webkit channel "${options.channel}" is not installed. Try running 'npx playwright install webkit-technology-preview'`);
+      return executablePath;
+    }
+    return super.executablePath(options);
   }
 
   _connectToTransport(transport: ConnectionTransport, options: BrowserOptions): Promise<WKBrowser> {


### PR DESCRIPTION
This patch adds support for `technology preview` webkit channel, which
we will keep close to the actual Safari Technology Preview releases.

This channel does not install by default. It is supposed to be installed
with the following CLI command:

```sh
$ npx playwright install webkit-technology-preview
```

Once the channel is installed, it can be used the following way:

```js
const browser = await playwright.webkit.launch({
  channel: 'technology-preview',
});
```

**NOTE:** if clients attempt using the channel without installing it,
it'll throw an error with a copyable instructions to install via CLI.

References #5884