### PR TITLE
fix: installer compilation

### DIFF
--- a/install-from-github.js
+++ b/install-from-github.js
@@ -21,8 +21,11 @@ const {execSync} = require('child_process');
 
 console.log(`Rebuilding installer...`);
 try {
-  execSync('npm run tsc-installer');
+  execSync('npm run tsc-installer', {
+    stdio: ['inherit', 'inherit', 'inherit'],
+  });
 } catch (e) {
+  process.exit(1);
 }
 
 console.log(`Downloading browsers...`);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -27,7 +27,7 @@ export function makeWaitForNextTask() {
   // As of Mar 2021, Electorn v12 doesn't create new task with `setImmediate` despite
   // using Node 14 internally, so we fallback to `setTimeout(0)` instead.
   // @see https://github.com/electron/electron/issues/28261
-  if (process.versions.electron)
+  if ('electron' in process.versions)
     return (callback: () => void) => setTimeout(callback, 0);
   if (parseInt(process.versions.node, 10) >= 11)
     return setImmediate;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -27,7 +27,7 @@ export function makeWaitForNextTask() {
   // As of Mar 2021, Electorn v12 doesn't create new task with `setImmediate` despite
   // using Node 14 internally, so we fallback to `setTimeout(0)` instead.
   // @see https://github.com/electron/electron/issues/28261
-  if ('electron' in process.versions)
+  if ((process.versions as any).electron)
     return (callback: () => void) => setTimeout(callback, 0);
   if (parseInt(process.versions.node, 10) >= 11)
     return setImmediate;


### PR DESCRIPTION
For some reason typescript can't find electron types when using
nested tsconfig - workaround the bug.

Drive-by: surface installer compilation problems.