### PR TITLE
chore: simplify remote connection protocol

### DIFF
--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -16,7 +16,7 @@
 
 import { Browser } from './browser';
 import { BrowserContext } from './browserContext';
-import { BrowserType, RemoteBrowser } from './browserType';
+import { BrowserType } from './browserType';
 import { ChannelOwner } from './channelOwner';
 import { ElementHandle } from './elementHandle';
 import { Frame } from './frame';
@@ -214,9 +214,6 @@ export class Connection {
         break;
       case 'Playwright':
         result = new Playwright(parent, type, guid, initializer);
-        break;
-      case 'RemoteBrowser':
-        result = new RemoteBrowser(parent, type, guid, initializer);
         break;
       case 'Request':
         result = new Request(parent, type, guid, initializer);

--- a/src/client/playwright.ts
+++ b/src/client/playwright.ts
@@ -42,6 +42,7 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel, channel
   readonly devices: Devices;
   readonly selectors: Selectors;
   readonly errors: { TimeoutError: typeof TimeoutError };
+  private _selectorsOwner: SelectorsOwner;
 
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.PlaywrightInitializer) {
     super(parent, type, guid, initializer);
@@ -55,6 +56,12 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel, channel
       this.devices[name] = descriptor;
     this.selectors = sharedSelectors;
     this.errors = { TimeoutError };
-    this.selectors._addChannel(SelectorsOwner.from(initializer.selectors));
+
+    this._selectorsOwner = SelectorsOwner.from(initializer.selectors);
+    this.selectors._addChannel(this._selectorsOwner);
+  }
+
+  _cleanup() {
+    this.selectors._removeChannel(this._selectorsOwner);
   }
 }

--- a/src/dispatchers/playwrightDispatcher.ts
+++ b/src/dispatchers/playwrightDispatcher.ts
@@ -22,9 +22,10 @@ import { Dispatcher, DispatcherScope } from './dispatcher';
 import { ElectronDispatcher } from './electronDispatcher';
 import { SelectorsDispatcher } from './selectorsDispatcher';
 import * as types from '../server/types';
+import type { BrowserDispatcher } from './browserDispatcher';
 
 export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.PlaywrightInitializer> implements channels.PlaywrightChannel {
-  constructor(scope: DispatcherScope, playwright: Playwright) {
+  constructor(scope: DispatcherScope, playwright: Playwright, customSelectors?: SelectorsDispatcher, preLaunchedBrowser?: BrowserDispatcher) {
     const descriptors = require('../server/deviceDescriptors') as types.Devices;
     const deviceDescriptors = Object.entries(descriptors)
         .map(([name, descriptor]) => ({ name, descriptor }));
@@ -35,7 +36,8 @@ export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.Playwr
       android: new AndroidDispatcher(scope, playwright.android),
       electron: new ElectronDispatcher(scope, playwright.electron),
       deviceDescriptors,
-      selectors: new SelectorsDispatcher(scope, playwright.selectors),
+      selectors: customSelectors || new SelectorsDispatcher(scope, playwright.selectors),
+      preLaunchedBrowser,
     }, false, 'Playwright');
   }
 }

--- a/src/inprocess.ts
+++ b/src/inprocess.ts
@@ -34,9 +34,9 @@ function setupInProcess(): PlaywrightAPI {
   // Initialize Playwright channel.
   new PlaywrightDispatcher(dispatcherConnection.rootDispatcher(), playwright);
   const playwrightAPI = clientConnection.getObjectWithKnownName('Playwright') as PlaywrightAPI;
-  playwrightAPI.chromium._serverLauncher = new BrowserServerLauncherImpl(playwright.chromium);
-  playwrightAPI.firefox._serverLauncher = new BrowserServerLauncherImpl(playwright.firefox);
-  playwrightAPI.webkit._serverLauncher = new BrowserServerLauncherImpl(playwright.webkit);
+  playwrightAPI.chromium._serverLauncher = new BrowserServerLauncherImpl(playwright, playwright.chromium);
+  playwrightAPI.firefox._serverLauncher = new BrowserServerLauncherImpl(playwright, playwright.firefox);
+  playwrightAPI.webkit._serverLauncher = new BrowserServerLauncherImpl(playwright, playwright.webkit);
 
   // Switch to async dispatch after we got Playwright object.
   dispatcherConnection.onmessage = message => setImmediate(() => clientConnection.dispatch(message));

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -173,23 +173,10 @@ export type PlaywrightInitializer = {
     },
   }[],
   selectors: SelectorsChannel,
+  preLaunchedBrowser?: BrowserChannel,
 };
 export interface PlaywrightChannel extends Channel {
 }
-
-// ----------- RemoteBrowser -----------
-export type RemoteBrowserInitializer = {
-  browser: BrowserChannel,
-  selectors: SelectorsChannel,
-};
-export interface RemoteBrowserChannel extends Channel {
-  on(event: 'video', callback: (params: RemoteBrowserVideoEvent) => void): this;
-}
-export type RemoteBrowserVideoEvent = {
-  context: BrowserContextChannel,
-  stream: StreamChannel,
-  relativePath: string,
-};
 
 // ----------- Selectors -----------
 export type SelectorsInitializer = {};
@@ -575,6 +562,7 @@ export interface BrowserContextChannel extends Channel {
   on(event: 'close', callback: (params: BrowserContextCloseEvent) => void): this;
   on(event: 'page', callback: (params: BrowserContextPageEvent) => void): this;
   on(event: 'route', callback: (params: BrowserContextRouteEvent) => void): this;
+  on(event: 'video', callback: (params: BrowserContextVideoEvent) => void): this;
   on(event: 'crBackgroundPage', callback: (params: BrowserContextCrBackgroundPageEvent) => void): this;
   on(event: 'crServiceWorker', callback: (params: BrowserContextCrServiceWorkerEvent) => void): this;
   addCookies(params: BrowserContextAddCookiesParams, metadata?: Metadata): Promise<BrowserContextAddCookiesResult>;
@@ -608,6 +596,10 @@ export type BrowserContextPageEvent = {
 export type BrowserContextRouteEvent = {
   route: RouteChannel,
   request: RequestChannel,
+};
+export type BrowserContextVideoEvent = {
+  stream: StreamChannel,
+  relativePath: string,
 };
 export type BrowserContextCrBackgroundPageEvent = {
   page: PageChannel,

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -257,24 +257,8 @@ Playwright:
                 - firefox
                 - webkit
     selectors: Selectors
-
-
-RemoteBrowser:
-  type: interface
-
-  initializer:
-    browser: Browser
-    selectors: Selectors
-
-  events:
-
-    # Video stream blocks owner context from closing until the stream is closed.
-    # Make sure to close the stream!
-    video:
-      parameters:
-        context: BrowserContext
-        stream: Stream
-        relativePath: string
+    # Only present when connecting remotely via BrowserType.connect() method.
+    preLaunchedBrowser: Browser?
 
 
 Selectors:
@@ -700,6 +684,14 @@ BrowserContext:
       parameters:
         route: Route
         request: Request
+
+    # This event is only sent for remotely connected contexts.
+    # Video stream blocks the context from closing until the stream is closed.
+    # Make sure to close the stream!
+    video:
+      parameters:
+        stream: Stream
+        relativePath: string
 
     crBackgroundPage:
       parameters:


### PR DESCRIPTION
This changes the root object from RemoteBrowser to Playwright,
similar to local driver connection.

Previous structure:
```
RemoteBrowser
  - browser (using ConnectedBrowser for remote-specific behavior)
  - selectors (special instance for this remote connection)
```

New structure:
```
Playwright
  - ...
  - selectors (special instance for this remote connection)
  - preLaunchedBrowser (using ConnectedBrowser for remote-specific behavior)
```