### PR TITLE
cherry-pick(release-1.10): do not run video tests with Chrome Stable on Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -263,7 +263,7 @@ jobs:
         path: test-results
 
   chrome_stable_linux:
-    name: "Chrome Stable"
+    name: "Chrome Stable (Linux)"
     strategy:
       fail-fast: false
     runs-on: ubuntu-18.04
@@ -287,7 +287,7 @@ jobs:
     # XVFB-RUN merges both STDOUT and STDERR, whereas we need only STDERR
     # Wrap `npm run` in a subshell to redirect STDERR to file.
     # Enable core dumps in the subshell.
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && npx folio test/ --workers=1 --forbid-only --timeout=60000 --global-timeout=5400000 --retries=3 --reporter=dot,json -p video"
+    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && npx folio test/ --workers=1 --forbid-only --timeout=60000 --global-timeout=5400000 --retries=3 --reporter=dot,json"
       env:
         BROWSER: "chromium"
         PW_CHROMIUM_CHANNEL: "chrome"


### PR DESCRIPTION
This cherry-picks PR #5931, commit 76781122422334da6bbb7f3bd6788a3a1713375d