### PR TITLE
docs(page): remove note that screenshot takes 1/6+s

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2158,10 +2158,6 @@ handler function to route the request.
 
 Returns the buffer with the captured screenshot.
 
-:::note
-Screenshots take at least 1/6 second on Chromium OS X and Chromium Windows. See https://crbug.com/741689 for discussion.
-:::
-
 ### option: Page.screenshot.path
 - `path` <[path]>
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -2359,9 +2359,6 @@ export interface Page {
 
   /**
    * Returns the buffer with the captured screenshot.
-   * 
-   * > NOTE: Screenshots take at least 1/6 second on Chromium OS X and Chromium Windows. See https://crbug.com/741689 for
-   * discussion.
    * @param options 
    */
   screenshot(options?: {


### PR DESCRIPTION
This was fixed upstream: https://chromium-review.googlesource.com/c/chromium/src/+/2713827