### PR TITLE
fix(page): add name property to pageerror event

### DIFF
--- a/src/protocol/serializers.ts
+++ b/src/protocol/serializers.ts
@@ -36,6 +36,7 @@ export function parseError(error: SerializedError): Error {
   }
   const e = new Error(error.error.message);
   e.stack = error.error.stack || '';
+  e.name = error.error.name;
   return e;
 }
 

--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -30,6 +30,7 @@ import { RawKeyboardImpl, RawMouseImpl, RawTouchscreenImpl } from './ffInput';
 import { FFNetworkManager } from './ffNetworkManager';
 import { Protocol } from './protocol';
 import { Progress } from '../progress';
+import { splitErrorMessage } from '../../utils/stackTrace';
 
 const UTILITY_WORLD_NAME = '__playwright_utility_world__';
 
@@ -221,9 +222,11 @@ export class FFPage implements PageDelegate {
   }
 
   _onUncaughtError(params: Protocol.Page.uncaughtErrorPayload) {
-    const message = params.message.startsWith('Error: ') ? params.message.substring(7) : params.message;
+    const {name, message} = splitErrorMessage(params.message);
+
     const error = new Error(message);
     error.stack = params.stack;
+    error.name = name;
     this._page.emit(Page.Events.PageError, error);
   }
 

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -18,6 +18,7 @@
 import * as jpeg from 'jpeg-js';
 import path from 'path';
 import * as png from 'pngjs';
+import { splitErrorMessage } from '../../utils/stackTrace';
 import { assert, createGuid, debugAssert, headersArrayToObject, headersObjectToArray } from '../../utils/utils';
 import * as accessibility from '../accessibility';
 import * as dialog from '../dialog';
@@ -490,7 +491,7 @@ export class WKPage implements PageDelegate {
       return;
     }
     if (level === 'error' && source === 'javascript') {
-      const message = text.startsWith('Error: ') ? text.substring(7) : text;
+      const {name, message} = splitErrorMessage(text);
       const error = new Error(message);
       if (event.message.stackTrace) {
         error.stack = event.message.stackTrace.map(callFrame => {
@@ -499,6 +500,7 @@ export class WKPage implements PageDelegate {
       } else {
         error.stack = '';
       }
+      error.name = name;
       this._page.emit(Page.Events.PageError, error);
       return;
     }

--- a/src/utils/stackTrace.ts
+++ b/src/utils/stackTrace.ts
@@ -69,3 +69,11 @@ export function captureStackTrace(): { stack: string, frames: StackFrame[] } {
   }
   return { stack, frames };
 }
+
+export function splitErrorMessage(message: string): { name: string, message: string } {
+  const separationIdx = message.indexOf(':');
+  return {
+    name: separationIdx !== -1 ? message.slice(0, separationIdx) : '',
+    message: separationIdx !== -1 && separationIdx + 2 <= message.length ? message.substring(separationIdx + 2) : message,
+  };
+}


### PR DESCRIPTION
Before that change the `name` property of an Error was not correctly passed over to the `pageerror` event and it was always `Error`.

```js
const error = new Error('foo bar message');
error.name = 'FooBarError';
```

this PR fixes it.