### PR TITLE
chore(dotnet): add Get prefixes in Page and Frame

### DIFF
--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -744,6 +744,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.hover.timeout = %%-input-timeout-%%
 
 ## async method: Frame.innerHTML
+* langs:
+  - alias-csharp: GetInnerHTMLAsync
 - returns: <[string]>
 
 Returns `element.innerHTML`.
@@ -753,6 +755,8 @@ Returns `element.innerHTML`.
 ### option: Frame.innerHTML.timeout = %%-input-timeout-%%
 
 ## async method: Frame.innerText
+* langs:
+  - alias-csharp: GetInnerTextAsync
 - returns: <[string]>
 
 Returns `element.innerText`.
@@ -1019,6 +1023,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.tap.timeout = %%-input-timeout-%%
 
 ## async method: Frame.textContent
+* langs:
+  - alias-csharp: GetTextContentAsync
 - returns: <[null]|[string]>
 
 Returns `element.textContent`.

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1656,6 +1656,8 @@ Shortcut for main frame's [`method: Frame.hover`].
 ### option: Page.hover.timeout = %%-input-timeout-%%
 
 ## async method: Page.innerHTML
+* langs:
+  - alias-csharp: GetInnerHTMLAsync
 - returns: <[string]>
 
 Returns `element.innerHTML`.
@@ -1665,6 +1667,8 @@ Returns `element.innerHTML`.
 ### option: Page.innerHTML.timeout = %%-input-timeout-%%
 
 ## async method: Page.innerText
+* langs:
+  - alias-csharp: GetInnerTextAsync
 - returns: <[string]>
 
 Returns `element.innerText`.
@@ -2409,6 +2413,8 @@ Shortcut for main frame's [`method: Frame.tap`].
 ### option: Page.tap.timeout = %%-input-timeout-%%
 
 ## async method: Page.textContent
+* langs:
+  - alias-csharp: GetTextContentAsync
 - returns: <[null]|[string]>
 
 Returns `element.textContent`.


### PR DESCRIPTION
The generator is able to add the `Get` prefix in `IElementHandle` because those functions have no arguments there.
But it doesn't add the `Get` in Page and Frame. In order to be consistent, I'm adding these custom aliases.