### PR TITLE
chore(dotnet): avoid adding two prefixes

### DIFF
--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -438,7 +438,8 @@ function renderMethod(member, parent, output, name) {
   // set-only methods to settable properties
   if (member.args.size == 0
     && type !== 'void'
-    && !name.startsWith('Get')) {
+    && !name.startsWith('Get')
+    && !/Is[A-Z]/.test(name)) {
     if (!member.async) {
       if (member.spec)
         output(XmlDoc.renderXmlDoc(member.spec, maxDocumentationColumnWidth));


### PR DESCRIPTION
We are generating methods like `GetIsCheckedAsync`. Having `Get` and `Is` looks quite weird there.