### PR TITLE
devops: skip flakiness upload for forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         BROWSER: ${{ matrix.browser }}
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
+      if: always() && github.repository == 'microsoft/playwright' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: always()
       with:
@@ -71,7 +71,7 @@ jobs:
         BROWSER: ${{ matrix.browser }}
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
+      if: always() && github.repository == 'microsoft/playwright' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
@@ -102,7 +102,7 @@ jobs:
         BROWSER: ${{ matrix.browser }}
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
+      if: always() && github.repository == 'microsoft/playwright' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
       shell: bash
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
@@ -157,7 +157,7 @@ jobs:
         HEADFUL: 1
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
+      if: always() && github.repository == 'microsoft/playwright' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
@@ -191,7 +191,7 @@ jobs:
         PWMODE: "${{ matrix.mode }}"
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
+      if: always() && github.repository == 'microsoft/playwright' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
@@ -224,7 +224,7 @@ jobs:
         BROWSER: ${{ matrix.browser }}
         FOLIO_JSON_OUTPUT_NAME: "test-results/report.json"
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
+      if: always() && github.repository == 'microsoft/playwright' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
@@ -254,7 +254,7 @@ jobs:
     - name: Run page tests
       run: npx folio test/page -p browserName=chromium --workers=1 --forbid-only --timeout=120000 --global-timeout=5400000 --retries=3 --reporter=dot,json
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
+      if: always() && github.repository == 'microsoft/playwright' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:


### PR DESCRIPTION
Before this change, forks face noise from pipeline
failures trying to upload to the flakiness dashboard.

Example: https://github.com/rwoll/playwright/runs/2199170557