### PR TITLE
chore(dotnet): fix properties with Is prefix

### DIFF
--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -443,15 +443,15 @@ function renderMethod(member, parent, output, name) {
   // set-only methods to settable properties
   if (member.args.size == 0
     && type !== 'void'
-    && !name.startsWith('Get')
-    && !/Is[A-Z]/.test(name)) {
+    && !name.startsWith('Get')) {
     if (!member.async) {
       if (member.spec)
         output(XmlDoc.renderXmlDoc(member.spec, maxDocumentationColumnWidth));
       output(`${type} ${name} { get; }`);
       return;
     }
-    name = `Get${name}`;
+    if (!/Is[A-Z]/.test(name))
+      name = `Get${name}`;
   } else if (member.args.size == 1
     && type === 'void'
     && name.startsWith('Set')


### PR DESCRIPTION
We turned the IsDetached property into a method with the previous change