### PR TITLE
chore(dotnet): don't generate set only properties

### DIFF
--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -459,7 +459,7 @@ function renderMethod(member, parent, output, name) {
     name = name.substring(3); // remove the 'Set'
     if (member.spec)
       output(XmlDoc.renderXmlDoc(member.spec, maxDocumentationColumnWidth));
-    output(`${translateType(member.argsArray[0].type, parent)} ${name} { set; }`);
+    output(`${translateType(member.argsArray[0].type, parent)} ${name} { get; set; }`);
     return;
   }
 


### PR DESCRIPTION
It doesn't make any sense to have set only properties. This affects only the DefaultTimeout properties in IPage