### PR TITLE
chore(dotnet): improve self-referenced events

### DIFF
--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -280,7 +280,7 @@ function renderMember(member, parent, out) {
         throw new Error(`No Event Type for ${name} in ${parent.name}`);
       if (member.spec)
         output(XmlDoc.renderXmlDoc(member.spec, maxDocumentationColumnWidth));
-      if (parent && (classNameMap.get(parent.name) === type))
+      if (parent && (classNameMap.get(parent.name) === type) && !['Popup'].includes(name))
         output(`event EventHandler ${name};`); // event sender will be the type, so we're fine to ignore
       else
         output(`event EventHandler<${type}> ${name};`);


### PR DESCRIPTION
Not all the events referencing the parent type are `EventHandler`.  The `Popup` even references the same type but that `IPage` is not `this` but the popup page.