### PR TITLE
chore(generators): use the same definition for viewPortSize

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2531,10 +2531,7 @@ Shortcut for main frame's [`method: Frame.url`].
 
 Video object associated with this page.
 
-## method: Page.viewportSize
-- returns: <[null]|[Object]>
-  - `width` <[int]> page width in pixels.
-  - `height` <[int]> page height in pixels.
+## method: Page.viewportSize = %%-option-viewport-%%
 
 ## method: Page.waitForClose
 * langs: csharp, java

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -208,8 +208,8 @@ Whether to ignore HTTPS errors during navigation. Defaults to `false`.
 
 Toggles bypassing page's Content-Security-Policy.
 
-## context-option-viewport
-* langs: js, java
+## option-viewport
+* langs: js, java, csharp
   - alias-java: viewportSize
   - alias-csharp: viewportSize
 - `viewport` <[null]|[Object]>
@@ -544,7 +544,7 @@ is considered matching if all specified properties match.
 - %%-context-option-acceptdownloads-%%
 - %%-context-option-ignorehttpserrors-%%
 - %%-context-option-bypasscsp-%%
-- %%-context-option-viewport-%%
+- %%-option-viewport-%%
 - %%-python-context-option-viewport-%%
 - %%-python-context-option-no-viewport-%%
 - %%-context-option-useragent-%%


### PR DESCRIPTION
The page viewportSize should use the same definition as the viewport used to create the context. They should reference the same type in code