### PR TITLE
fix(docker): Update nativeDeps.ts

### DIFF
--- a/src/nativeDeps.ts
+++ b/src/nativeDeps.ts
@@ -151,6 +151,7 @@ export const deps = {
       'libxext6',
       'libxfixes3',
       'libxrandr2',
+      'libxshmfence1',
     ],
     firefox: [
       'ffmpeg',


### PR DESCRIPTION
add chromium dependencies on ubuntu:focal, it show error when using chromium.
not sure Bionic works fine or not.