### PR TITLE
fix(docker): update native deps and docker files for chromium

### DIFF
--- a/src/nativeDeps.ts
+++ b/src/nativeDeps.ts
@@ -34,6 +34,7 @@ export const deps = {
       'libcups2',
       'libdbus-1-3',
       'libdrm2',
+      'libegl1',
       'libgbm1',
       'libglib2.0-0',
       'libgtk-3-0',
@@ -47,6 +48,7 @@ export const deps = {
       'libxext6',
       'libxfixes3',
       'libxrandr2',
+      'libxshmfence1',
     ],
     firefox: [
       'ffmpeg',
@@ -138,6 +140,7 @@ export const deps = {
       'libcups2',
       'libdbus-1-3',
       'libdrm2',
+      'libegl1',
       'libgbm1',
       'libglib2.0-0',
       'libgtk-3-0',

--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcups2\
     libdbus-1-3\
     libdrm2\
+    libegl1\
     libgbm1\
     libglib2.0-0\
     libgtk-3-0\
@@ -31,7 +32,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxdamage1\
     libxext6\
     libxfixes3\
-    libxrandr2
+    libxrandr2\
+    libxshmfence1
 
 # firefox
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcups2\
     libdbus-1-3\
     libdrm2\
+    libegl1\
     libgbm1\
     libglib2.0-0\
     libgtk-3-0\
@@ -31,7 +32,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxdamage1\
     libxext6\
     libxfixes3\
-    libxrandr2
+    libxrandr2\
+    libxshmfence1
 
 # firefox
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
* libxshmfence1 is required to start Chromium as was already [reported and fixed](https://github.com/microsoft/playwright/pull/5988) on Ubuntu 20.04
* Without libegl1 Chromium will crash with the following trace:

```sh
  pw:browser [pid=6752][err] Received signal 6 +0ms
  pw:browser [pid=6752][err] #0 0x55f6e1452c49 base::debug::CollectStackTrace() +5ms
  pw:browser [pid=6752][err] #1 0x55f6e13c0ab3 base::debug::StackTrace::StackTrace() +8ms
  pw:browser [pid=6752][err] #2 0x55f6e14527f0 base::debug::(anonymous namespace)::StackDumpSignalHandler() +7ms
  pw:browser [pid=6752][err] #3 0x7f691a3d33c0 (/usr/lib/x86_64-linux-gnu/libpthread-2.31.so+0x153bf) +0ms
  pw:browser [pid=6752][err] #4 0x7f6918a6818b gsignal +0ms
  pw:browser [pid=6752][err] #5 0x7f6918a47859 abort +0ms
  pw:browser [pid=6752][err] #6 0x55f6e1451e15 base::debug::BreakDebugger() +7ms
  pw:browser [pid=6752][err] #7 0x55f6e13d1998 logging::LogMessage::~LogMessage() +7ms
  pw:browser [pid=6752][err] #8 0x55f6e13d204e logging::LogMessage::~LogMessage() +7ms
  pw:browser [pid=6752][err] #9 0x55f6de9739f8 x11::InitXlib() +1ms
  pw:browser [pid=6752][err] #10 0x55f6de973bb9 x11::XlibDisplay::XlibDisplay() +0ms
  pw:browser [pid=6752][err] #11 0x55f6de96cd90 x11::Connection::GetXlibDisplay() +1ms
  pw:browser [pid=6752][err] #12 0x55f6e27c3137 gl::init::InitializeGLOneOffPlatformX11() +10ms
  pw:browser [pid=6752][err] #13 0x55f6e27c113b gl::init::InitializeGLOneOffPlatformImplementation() +10ms
  pw:browser [pid=6752][err] #14 0x55f6e27c0ec1 gl::init::(anonymous namespace)::InitializeGLOneOffPlatformHelper() +10ms
  pw:browser [pid=6752][err] #15 0x55f6e27c0fbc gl::init::InitializeGLNoExtensionsOneOff() +9ms
  pw:browser [pid=6752][err] #16 0x55f6e31d5254 gpu::GpuInit::InitializeAndStartSandbox() +12ms
  pw:browser [pid=6752][err] #17 0x55f6e5a95f04 content::GpuMain() +18ms
  pw:browser [pid=6752][err] #18 0x55f6e135df83 content::RunZygote() +7ms
  pw:browser [pid=6752][err] #19 0x55f6e135f262 content::ContentMainRunnerImpl::Run() +7ms
  pw:browser [pid=6752][err] #20 0x55f6e135c83d content::RunContentProcess() +7ms
  pw:browser [pid=6752][err] #21 0x55f6e135d1dd content::ContentMain() +7ms
  pw:browser [pid=6752][err] #22 0x55f6e13bae25 headless::(anonymous namespace)::RunContentMain() +7ms
  pw:browser [pid=6752][err] #23 0x55f6e13babce headless::RunChildProcessIfNeeded() +7ms
  pw:browser [pid=6752][err] #24 0x55f6e13b9445 headless::HeadlessShellMain() +7ms
  pw:browser [pid=6752][err] #25 0x55f6de429765 ChromeMain +21ms
  pw:browser [pid=6752][err] #26 0x7f6918a490b3 __libc_start_main +0ms
  pw:browser [pid=6752][err] #27 0x55f6de4295aa _start +21ms
  pw:browser [pid=6752][err]   r8: 0000000000000000  r9: 00007ffc083715e0 r10: 0000000000000008 r11: 0000000000000246 +0ms
  pw:browser [pid=6752][err]  r12: 00003e8800304280 r13: 00007ffc08371840 r14: 00003e8800304290 r15: aaaaaaaaaaaaaaaa +0ms
  pw:browser [pid=6752][err]   di: 0000000000000002  si: 00007ffc083715e0  bp: 00007ffc08371830  bx: 00007f69176a8d80 +0ms
  pw:browser [pid=6752][err]   dx: 0000000000000000  ax: 0000000000000000  cx: 00007f6918a6818b  sp: 00007ffc083715e0 +0ms
  pw:browser [pid=6752][err]   ip: 00007f6918a6818b efl: 0000000000000246 cgf: 002b000000000033 erf: 0000000000000000 +0ms
  pw:browser [pid=6752][err]  trp: 0000000000000000 msk: 0000000000000000 cr2: 0000000000000000 +0ms
  pw:browser [pid=6752][err] [end of stack trace] +0ms
  pw:browser [pid=6752][err] Calling _exit(1). Core file will not be generated. +0ms
  pw:browser [pid=6752][err] [0329/192525.903997:WARNING:gpu_process_host.cc(1296)] The GPU process has crashed 6 time(s) +2ms
  pw:browser [pid=6752][err] [0329/192525.908656:ERROR:gpu_init.cc(426)] Passthrough is not supported, GL is disabled +5ms
  pw:browser [pid=6752][err] [0329/192525.911687:WARNING:gpu_process_host.cc(1016)] Reinitialized the GPU process after a crash. The reported initialization time was 0 ms +3ms
```

Note that our docker files already installed libegl1 but only in webkit section, so if one copied just chromium deps it wouldn't be sufficient to run chromium.