### PR TITLE
fix(firefox): roll Firefox to 1239

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1238",
+      "revision": "1239",
       "installByDefault": true
     },
     {

--- a/test/favicon.spec.ts
+++ b/test/favicon.spec.ts
@@ -19,7 +19,6 @@ import path from 'path';
 import { it } from './fixtures';
 
 it('should load svg favicon with prefer-color-scheme', (test, {browserName, browserChannel, headful}) => {
-  test.fixme(browserName === 'firefox', 'firefox hard crashes in both headless and headful');
   test.skip(!headful && browserName !== 'firefox', 'headless browsers, except firefox, do not request favicons');
   test.skip(headful && browserName === 'webkit' && !browserChannel, 'playwright headful webkit does not have a favicon feature');
 }, async ({page, server}) => {


### PR DESCRIPTION
Re-enable now passing SVG Favicon prefers-color-scheme
test.

Fixes #5977