### PR TITLE
chore: ensure we emit Page event before resoliving pageOrError

### DIFF
--- a/src/server/chromium/crBrowser.ts
+++ b/src/server/chromium/crBrowser.ts
@@ -136,20 +136,15 @@ export class CRBrowser extends Browser {
     assert(!this._serviceWorkers.has(targetInfo.targetId), 'Duplicate target ' + targetInfo.targetId);
 
     if (targetInfo.type === 'background_page') {
-      const backgroundPage = new CRPage(session, targetInfo.targetId, context, null, false);
+      const backgroundPage = new CRPage(session, targetInfo.targetId, context, null, false, true);
       this._backgroundPages.set(targetInfo.targetId, backgroundPage);
-      backgroundPage.pageOrError().then(pageOrError => {
-        if (pageOrError instanceof Page)
-          context!.emit(CRBrowserContext.CREvents.BackgroundPage, backgroundPage._page);
-      });
       return;
     }
 
     if (targetInfo.type === 'page') {
       const opener = targetInfo.openerId ? this._crPages.get(targetInfo.openerId) || null : null;
-      const crPage = new CRPage(session, targetInfo.targetId, context, opener, true);
+      const crPage = new CRPage(session, targetInfo.targetId, context, opener, true, false);
       this._crPages.set(targetInfo.targetId, crPage);
-      crPage._page.reportAsNew();
       return;
     }
 

--- a/src/server/firefox/ffBrowser.ts
+++ b/src/server/firefox/ffBrowser.ts
@@ -107,7 +107,6 @@ export class FFBrowser extends Browser {
     const opener = openerId ? this._ffPages.get(openerId)! : null;
     const ffPage = new FFPage(session, context, opener);
     this._ffPages.set(targetId, ffPage);
-    ffPage._page.reportAsNew();
   }
 
   _onDownloadCreated(payload: Protocol.Browser.downloadCreatedPayload) {
@@ -120,7 +119,7 @@ export class FFBrowser extends Browser {
     if (!originPage) {
       // Resume the page creation with an error. The page will automatically close right
       // after the download begins.
-      ffPage._pageCallback(new Error('Starting new page download'));
+      ffPage._markAsError(new Error('Starting new page download'));
       if (ffPage._opener)
         originPage = ffPage._opener._initializedPage;
     }

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -181,14 +181,13 @@ export class Page extends SdkObject {
     this.selectors = browserContext.selectors();
   }
 
-  async reportAsNew() {
-    const pageOrError = await this._delegate.pageOrError();
-    if (pageOrError instanceof Error) {
+  async reportAsNew(error?: Error) {
+    if (error) {
       // Initialization error could have happened because of
       // context/browser closure. Just ignore the page.
       if (this._browserContext.isClosingOrClosed())
         return;
-      this._setIsError(pageOrError);
+      this._setIsError(error);
     }
     this._browserContext.emit(BrowserContext.Events.Page, this);
     const openerDelegate = this._delegate.openerDelegate();

--- a/src/server/webkit/wkBrowser.ts
+++ b/src/server/webkit/wkBrowser.ts
@@ -155,7 +155,6 @@ export class WKBrowser extends Browser {
     const opener = event.openerId ? this._wkPages.get(event.openerId) : undefined;
     const wkPage = new WKPage(context, pageProxySession, opener || null);
     this._wkPages.set(pageProxyId, wkPage);
-    wkPage._page.reportAsNew();
   }
 
   _onPageProxyDestroyed(event: Protocol.Playwright.pageProxyDestroyedPayload) {

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -316,7 +316,10 @@ export class WKPage implements PageDelegate {
         // Avoid rejection on disconnect.
         this._firstNonInitialNavigationCommittedPromise.catch(() => {});
       }
+      // Note: it is important to call |reportAsNew| before resolving pageOrError promise,
+      // so that anyone who awaits pageOrError got a ready and reported page.
       this._initializedPage = pageOrError instanceof Page ? pageOrError : null;
+      this._page.reportAsNew(pageOrError instanceof Page ? undefined : pageOrError);
       this._pagePromiseCallback(pageOrError);
     } else {
       assert(targetInfo.isProvisional);


### PR DESCRIPTION
Internal callers of pageOrError should be able to rely on the
Page being already reported.