### PR TITLE
docs: replace headful with headed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ it.skip('should work', async ({server, page}) => {
 });
 ```
 
-- To run tests in non-headless (headful) mode:
+- To run tests in non-headless (headed) mode:
 
 ```bash
 HEADFUL=1 npm run ctest

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -169,10 +169,10 @@ addons:
     - gstreamer1.0-plugins-bad
     # This is required to run chromium
     - libgbm1
-    # this is needed for running headful tests
+    # this is needed for running headed tests
     - xvfb
 
-# allow headful tests
+# allow headed tests
 before_install:
   # Enable user namespace cloning
   - "sysctl kernel.unprivileged_userns_clone=1"
@@ -327,7 +327,7 @@ DEBUG=pw:browser* npm run test
 DEBUG=pw:browser* pytest
 ```
 
-## Running headful
+## Running headed
 
 By default, Playwright launches browsers in headless mode. This can be changed by passing a flag when the browser is launched.
 
@@ -371,7 +371,7 @@ with sync_playwright() as p:
    browser = p.chromium.launch(headless=False)
 ```
 
-On Linux agents, headful execution requires [Xvfb](https://en.wikipedia.org/wiki/Xvfb) to be installed. Our [Docker image](./docker.md) and GitHub Action have Xvfb pre-installed. To run browsers in headful mode with Xvfb, add `xvfb-run` before the Node.js command.
+On Linux agents, headed execution requires [Xvfb](https://en.wikipedia.org/wiki/Xvfb) to be installed. Our [Docker image](./docker.md) and GitHub Action have Xvfb pre-installed. To run browsers in headed mode with Xvfb, add `xvfb-run` before the Node.js command.
 
 ```sh js
 xvfb-run node index.js

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -20,7 +20,7 @@ the following primitives.
 A [Browser] refers to an instance of Chromium, Firefox
 or WebKit. Playwright scripts generally start with launching a browser instance
 and end with closing the browser. Browser instances can be launched in headless
-(without a GUI) or headful mode.
+(without a GUI) or headed mode.
 
 ```js
 const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.

--- a/docs/src/debug.md
+++ b/docs/src/debug.md
@@ -16,7 +16,7 @@ for browser automation.
 <img width="712" alt="Playwright Inspector" src="https://user-images.githubusercontent.com/883973/108614092-8c478a80-73ac-11eb-9597-67dfce110e00.png"></img>
 
 
-## Run in headful mode
+## Run in headed mode
 
 Playwright runs browsers in headless mode by default. To change this behavior,
 use `headless: false` as a launch option. You can also use the [`option: slowMo`] option
@@ -130,7 +130,7 @@ $ pytest -s
 
 With PWDEBUG, the following defaults are configured for you:
 
-* **Run in headful**: With PWDEBUG, browsers always launch in headful mode
+* **Run in headed**: With PWDEBUG, browsers always launch in headed mode
 * **Disables timeout**: PWDEBUG sets timeout to 0 (= no timeout)
 
 ### Debugging Selectors

--- a/docs/src/test-runners-python.md
+++ b/docs/src/test-runners-python.md
@@ -29,8 +29,8 @@ To run your tests, use pytest CLI.
 # Run tests (Chromium and headless by default)
 $ pytest
 
-# Run tests in headful mode
-$ pytest --headful
+# Run tests in headed mode
+$ pytest --headed
 
 # Run tests in a different browser (chromium, firefox, webkit)
 $ pytest --browser firefox
@@ -45,7 +45,7 @@ If you want to add the CLI arguments automatically without specifying them, you 
 # content of pytest.ini
 [pytest]
 # Run firefox with UI
-addopts = --headful --browser firefox
+addopts = --headed --browser firefox
 
 ```
 

--- a/docs/src/why-playwright.md
+++ b/docs/src/why-playwright.md
@@ -15,7 +15,7 @@ Playwright enables fast, reliable and capable automation across all modern brows
 
 * **Test for mobile**. Use [device emulation](./emulation.md) to test your responsive web apps in mobile web browsers.
 
-* **Headless and headful**. Playwright supports headless (without browser UI) and headful (with browser UI) modes for all browsers and all platforms. Headful is great for debugging, and headless is faster and suited for CI/cloud executions.
+* **Headless and headed**. Playwright supports headless (without browser UI) and headed (with browser UI) modes for all browsers and all platforms. Headed is great for debugging, and headless is faster and suited for CI/cloud executions.
 
 ## Fast and reliable execution
 * **Auto-wait APIs**. Playwright interactions [auto-wait for elements](./actionability.md) to be ready. This improves reliability and simplifies test authoring.


### PR DESCRIPTION
There are far more occurrences of headful than for headed, so let's stick with headful and be consistent?