### PR TITLE
Revert "chore: ensure we emit Page event before resoliving pageOrErro…

### DIFF
--- a/src/server/chromium/crBrowser.ts
+++ b/src/server/chromium/crBrowser.ts
@@ -136,15 +136,20 @@ export class CRBrowser extends Browser {
     assert(!this._serviceWorkers.has(targetInfo.targetId), 'Duplicate target ' + targetInfo.targetId);
 
     if (targetInfo.type === 'background_page') {
-      const backgroundPage = new CRPage(session, targetInfo.targetId, context, null, false, true);
+      const backgroundPage = new CRPage(session, targetInfo.targetId, context, null, false);
       this._backgroundPages.set(targetInfo.targetId, backgroundPage);
+      backgroundPage.pageOrError().then(pageOrError => {
+        if (pageOrError instanceof Page)
+          context!.emit(CRBrowserContext.CREvents.BackgroundPage, backgroundPage._page);
+      });
       return;
     }
 
     if (targetInfo.type === 'page') {
       const opener = targetInfo.openerId ? this._crPages.get(targetInfo.openerId) || null : null;
-      const crPage = new CRPage(session, targetInfo.targetId, context, opener, true, false);
+      const crPage = new CRPage(session, targetInfo.targetId, context, opener, true);
       this._crPages.set(targetInfo.targetId, crPage);
+      crPage._page.reportAsNew();
       return;
     }
 

--- a/src/server/chromium/crPage.ts
+++ b/src/server/chromium/crPage.ts
@@ -57,7 +57,6 @@ export class CRPage implements PageDelegate {
   readonly _browserContext: CRBrowserContext;
   private readonly _pagePromise: Promise<Page | Error>;
   _initializedPage: Page | null = null;
-  private _isBackgroundPage: boolean;
 
   // Holds window features for the next popup being opened via window.open,
   // until the popup target arrives. This could be racy if two oopifs
@@ -71,10 +70,9 @@ export class CRPage implements PageDelegate {
     return crPage._mainFrameSession;
   }
 
-  constructor(client: CRSession, targetId: string, browserContext: CRBrowserContext, opener: CRPage | null, hasUIWindow: boolean, isBackgroundPage: boolean) {
+  constructor(client: CRSession, targetId: string, browserContext: CRBrowserContext, opener: CRPage | null, hasUIWindow: boolean) {
     this._targetId = targetId;
     this._opener = opener;
-    this._isBackgroundPage = isBackgroundPage;
     this.rawKeyboard = new RawKeyboardImpl(client, browserContext._browser._isMac);
     this.rawMouse = new RawMouseImpl(client);
     this.rawTouchscreen = new RawTouchscreenImpl(client);
@@ -91,25 +89,7 @@ export class CRPage implements PageDelegate {
       if (viewportSize)
         this._page._state.emulatedSize = { viewport: viewportSize, screen: viewportSize };
     }
-    // Note: it is important to call |reportAsNew| before resolving pageOrError promise,
-    // so that anyone who awaits pageOrError got a ready and reported page.
-    this._pagePromise = this._mainFrameSession._initialize(hasUIWindow).then(() => {
-      this._initializedPage = this._page;
-      this._reportAsNew();
-      return this._page;
-    }).catch(e => {
-      this._reportAsNew(e);
-      return e;
-    });
-  }
-
-  private _reportAsNew(error?: Error) {
-    if (this._isBackgroundPage) {
-      if (!error)
-        this._browserContext.emit(CRBrowserContext.CREvents.BackgroundPage, this._page);
-    } else {
-      this._page.reportAsNew(error);
-    }
+    this._pagePromise = this._mainFrameSession._initialize(hasUIWindow).then(() => this._initializedPage = this._page).catch(e => e);
   }
 
   private async _forAllFrameSessions(cb: (frame: FrameSession) => Promise<any>) {

--- a/src/server/firefox/ffBrowser.ts
+++ b/src/server/firefox/ffBrowser.ts
@@ -107,6 +107,7 @@ export class FFBrowser extends Browser {
     const opener = openerId ? this._ffPages.get(openerId)! : null;
     const ffPage = new FFPage(session, context, opener);
     this._ffPages.set(targetId, ffPage);
+    ffPage._page.reportAsNew();
   }
 
   _onDownloadCreated(payload: Protocol.Browser.downloadCreatedPayload) {
@@ -119,7 +120,7 @@ export class FFBrowser extends Browser {
     if (!originPage) {
       // Resume the page creation with an error. The page will automatically close right
       // after the download begins.
-      ffPage._markAsError(new Error('Starting new page download'));
+      ffPage._pageCallback(new Error('Starting new page download'));
       if (ffPage._opener)
         originPage = ffPage._opener._initializedPage;
     }

--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -44,7 +44,7 @@ export class FFPage implements PageDelegate {
   readonly _networkManager: FFNetworkManager;
   readonly _browserContext: FFBrowserContext;
   private _pagePromise: Promise<Page | Error>;
-  private _pageCallback: (pageOrError: Page | Error) => void = () => {};
+  _pageCallback: (pageOrError: Page | Error) => void = () => {};
   _initializedPage: Page | null = null;
   readonly _opener: FFPage | null;
   private readonly _contextIdToContext: Map<string, dom.FrameExecutionContext>;
@@ -93,22 +93,12 @@ export class FFPage implements PageDelegate {
     this._pagePromise = new Promise(f => this._pageCallback = f);
     session.once(FFSessionEvents.Disconnected, () => this._page._didDisconnect());
     this._session.once('Page.ready', () => {
-      // Note: it is important to call |reportAsNew| before resolving pageOrError promise,
-      // so that anyone who awaits pageOrError got a ready and reported page.
-      this._initializedPage = this._page;
-      this._page.reportAsNew();
       this._pageCallback(this._page);
+      this._initializedPage = this._page;
     });
     // Ideally, we somehow ensure that utility world is created before Page.ready arrives, but currently it is racy.
     // Therefore, we can end up with an initialized page without utility world, although very unlikely.
-    this._session.send('Page.addScriptToEvaluateOnNewDocument', { script: '', worldName: UTILITY_WORLD_NAME }).catch(e => this._markAsError(e));
-  }
-
-  _markAsError(error: Error) {
-    if (!this._initializedPage) {
-      this._page.reportAsNew(error);
-      this._pageCallback(error);
-    }
+    this._session.send('Page.addScriptToEvaluateOnNewDocument', { script: '', worldName: UTILITY_WORLD_NAME }).catch(this._pageCallback);
   }
 
   async pageOrError(): Promise<Page | Error> {

--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -301,7 +301,7 @@ export class FFPage implements PageDelegate {
 
   didClose() {
     if (!this._initializedPage)
-      this._markAsError(new Error('Page has been closed'));
+      this._pageCallback(new Error('Page has been closed'));
     this._session.dispose();
     helper.removeEventListeners(this._eventListeners);
     this._networkManager.dispose();

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -182,13 +182,14 @@ export class Page extends SdkObject {
     this.selectors = browserContext.selectors();
   }
 
-  reportAsNew(error?: Error) {
-    if (error) {
+  async reportAsNew() {
+    const pageOrError = await this._delegate.pageOrError();
+    if (pageOrError instanceof Error) {
       // Initialization error could have happened because of
       // context/browser closure. Just ignore the page.
       if (this._browserContext.isClosingOrClosed())
         return;
-      this._setIsError(error);
+      this._setIsError(pageOrError);
     }
     this._browserContext.emit(BrowserContext.Events.Page, this);
     const openerDelegate = this._delegate.openerDelegate();

--- a/src/server/webkit/wkBrowser.ts
+++ b/src/server/webkit/wkBrowser.ts
@@ -155,6 +155,7 @@ export class WKBrowser extends Browser {
     const opener = event.openerId ? this._wkPages.get(event.openerId) : undefined;
     const wkPage = new WKPage(context, pageProxySession, opener || null);
     this._wkPages.set(pageProxyId, wkPage);
+    wkPage._page.reportAsNew();
   }
 
   _onPageProxyDestroyed(event: Protocol.Playwright.pageProxyDestroyedPayload) {

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -316,10 +316,7 @@ export class WKPage implements PageDelegate {
         // Avoid rejection on disconnect.
         this._firstNonInitialNavigationCommittedPromise.catch(() => {});
       }
-      // Note: it is important to call |reportAsNew| before resolving pageOrError promise,
-      // so that anyone who awaits pageOrError got a ready and reported page.
       this._initializedPage = pageOrError instanceof Page ? pageOrError : null;
-      this._page.reportAsNew(pageOrError instanceof Page ? undefined : pageOrError);
       this._pagePromiseCallback(pageOrError);
     } else {
       assert(targetInfo.isProvisional);


### PR DESCRIPTION
…r (#6012)"

This reverts commit 98f1f715c5e3acab87f75d0fe78bb7cc7cffc481.


This broke popup behavior in firefox, caught in java:

```java
    Page page = context.newPage();
    Page popup = context.waitForPage(() -> {
      page.evaluate("() => {\n" +
        "  const win = window.open('about:blank');\n" +
        "  win.close();\n" +
        "}");
    });
    page.close();
```

RPC messages look like this:
```
SND: {"id":7,"guid":"Page@c47944e71ee35cf0ce7cb14bf71ed3f4","method":"close","params":{}}
RECV: {"guid":"Page@7fe9de979b457e137b1d8005fb22a07f","method":"close","params":{}}
RECV: {"guid":"Page@7fe9de979b457e137b1d8005fb22a07f","method":"__dispose__","params":{}}
RECV: {"guid":"Page@c47944e71ee35cf0ce7cb14bf71ed3f4","method":"popup","params":{"page":{"guid":"Page@7fe9de979b457e137b1d8005fb22a07f"}}}
```