### PR TITLE
fix(input): do not retarget from input/textarea/select to an ancestor button

### DIFF
--- a/src/server/injected/injectedScript.ts
+++ b/src/server/injected/injectedScript.ts
@@ -330,7 +330,8 @@ export class InjectedScript {
     let element = node.nodeType === Node.ELEMENT_NODE ? node as Element : node.parentElement;
     if (!element)
       return null;
-    element = element.closest('button, [role=button], [role=checkbox], [role=radio]') || element;
+    if (!element.matches('input, textarea, select'))
+      element = element.closest('button, [role=button], [role=checkbox], [role=radio]') || element;
     if (behavior === 'follow-label') {
       if (!element.matches('input, textarea, button, select, [role=button], [role=checkbox], [role=radio]') &&
           !(element as any).isContentEditable) {

--- a/test/page/page-check.spec.ts
+++ b/test/page/page-check.spec.ts
@@ -98,3 +98,11 @@ it('should throw when not a checkbox', async ({page}) => {
   const error = await page.check('div').catch(e => e);
   expect(error.message).toContain('Not a checkbox or radio button');
 });
+
+it('should check the box inside a button', async ({page}) => {
+  await page.setContent(`<div role='button'><input type='checkbox'></div>`);
+  await page.check('input');
+  expect(await page.$eval('input', input => input.checked)).toBe(true);
+  expect(await page.isChecked('input')).toBe(true);
+  expect(await (await page.$('input')).isChecked()).toBe(true);
+});


### PR DESCRIPTION
Although such markup is not expected, it happens in the wild. Retargeting
in this case in unexpected, so we check/click/etc the control itself.

Fixes #6032.