### PR TITLE
browser(firefox): fix bootstrap on bots with --no-interactive

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1243
-Changed: lushnikov@chromium.org Thu 01 Apr 2021 03:39:34 PM PDT
+1244
+Changed: joel.einbinder@gmail.com Fri 02 Apr 2021 07:20:15 AM PDT

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -87,7 +87,7 @@ if [[ $1 == "--full" || $2 == "--full" ]]; then
     rm -rf "$HOME/.mozbuild/node"
     mv node "$HOME/.mozbuild/"
   elif [[ "$(uname)" == "Darwin" || "$(uname)" == "Linux" ]]; then
-    SHELL=/bin/sh ./mach bootstrap --application-choice=browser --no-interactive --no-system-changes
+    SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser --no-system-changes
   fi
   if [[ ! -z "${WIN32_REDIST_DIR}" ]]; then
     # Having this option in .mozconfig kills incremental compilation.


### PR DESCRIPTION
The command --no-interactive moved and broke our build. See https://bugzilla.mozilla.org/show_bug.cgi?id=1695272