### PR TITLE
fix: start downloading firefox build for ubuntu 20.04

### DIFF
--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -108,7 +108,7 @@ const DOWNLOAD_URLS = {
   },
   'firefox': {
     'ubuntu18.04': '%s/builds/firefox/%s/firefox-ubuntu-18.04.zip',
-    'ubuntu20.04': '%s/builds/firefox/%s/firefox-ubuntu-18.04.zip',
+    'ubuntu20.04': '%s/builds/firefox/%s/firefox-ubuntu-20.04.zip',
     'mac10.13': '%s/builds/firefox/%s/firefox-mac-10.14.zip',
     'mac10.14': '%s/builds/firefox/%s/firefox-mac-10.14.zip',
     'mac10.15': '%s/builds/firefox/%s/firefox-mac-10.14.zip',


### PR DESCRIPTION
Custom firefox build for Ubuntu 20.04 fixes WebGL on headful.