### PR TITLE
chore(dotnet): generate generic EventHandlers

### DIFF
--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -280,10 +280,7 @@ function renderMember(member, parent, out) {
         throw new Error(`No Event Type for ${name} in ${parent.name}`);
       if (member.spec)
         output(XmlDoc.renderXmlDoc(member.spec, maxDocumentationColumnWidth));
-      if (parent && (classNameMap.get(parent.name) === type))
-        output(`event EventHandler ${name};`); // event sender will be the type, so we're fine to ignore
-      else
-        output(`event EventHandler<${type}> ${name};`);
+      output(`event EventHandler<${type}> ${name};`);
     } else if (member.kind === 'property') {
       if (member.spec)
         output(XmlDoc.renderXmlDoc(member.spec, maxDocumentationColumnWidth));


### PR DESCRIPTION
We are going to generate the generic `EventHandler` even if the generic type references the sender.

With this change, we are going to have, for instance, `event EventHandler<IPage> Close;` where the event args will be the same as `object sender` and `event EventHandler<IPage> Popup;`, where the event args will reference the popup page.
