### PR TITLE
browser(webkit): keep browser process running when all windows closed

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1460
-Changed: yurys@chromium.org Tue 06 Apr 2021 10:21:52 PM PDT
+1461
+Changed: yurys@chromium.org Thu, Apr  8, 2021  2:02:23 AM

--- a/browser_patches/webkit/embedder/Playwright/win/MainWindow.cpp
+++ b/browser_patches/webkit/embedder/Playwright/win/MainWindow.cpp
@@ -48,11 +48,11 @@ std::wstring MainWindow::s_windowClass;
 size_t MainWindow::s_numInstances;
 
 bool MainWindow::s_headless = false;
-bool MainWindow::s_noStartupWindow = false;
+bool MainWindow::s_controlledRemotely = false;
 
-void MainWindow::configure(bool headless, bool noStartupWindow) {
+void MainWindow::configure(bool headless, bool controlledRemotely) {
     s_headless = headless;
-    s_noStartupWindow = noStartupWindow;
+    s_controlledRemotely = controlledRemotely;
 }
 
 static std::wstring loadString(int id)
@@ -324,7 +324,7 @@ LRESULT CALLBACK MainWindow::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPA
     case WM_NCDESTROY:
         SetWindowLongPtr(hWnd, GWLP_USERDATA, 0);
         delete thisWindow;
-        if (s_noStartupWindow || s_numInstances > 0)
+        if (s_controlledRemotely || s_numInstances > 0)
             return 0;
         PostQuitMessage(0);
         break;

--- a/browser_patches/webkit/embedder/Playwright/win/MainWindow.h
+++ b/browser_patches/webkit/embedder/Playwright/win/MainWindow.h
@@ -35,7 +35,7 @@
 
 class MainWindow : public BrowserWindowClient {
 public:
-    static void configure(bool headless, bool noStartupWindow);
+    static void configure(bool headless, bool controlledRemotely);
 
     MainWindow();
 
@@ -56,7 +56,7 @@ private:
     static std::wstring s_windowClass;
     static size_t s_numInstances;
     static bool s_headless;
-    static bool s_noStartupWindow;
+    static bool s_controlledRemotely;
 
     bool toggleMenuItem(UINT menuID);
     void onURLBarEnter();

--- a/browser_patches/webkit/embedder/Playwright/win/WinMain.cpp
+++ b/browser_patches/webkit/embedder/Playwright/win/WinMain.cpp
@@ -101,7 +101,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
     if (SetProcessDpiAwarenessContextPtr())
         SetProcessDpiAwarenessContextPtr()(DPI_AWARENESS_CONTEXT_UNAWARE);
 
-    MainWindow::configure(g_options.headless, g_options.noStartupWindow);
+    MainWindow::configure(g_options.headless, g_options.inspectorPipe);
 
     if (!g_options.noStartupWindow) {
         auto configuration = adoptWK(WKWebsiteDataStoreConfigurationCreate());

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -13057,10 +13057,10 @@ index 0000000000000000000000000000000000000000..d0e11ed81a6257c011df23d5870da740
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..4463301d7cbe4831ee35f91664fe0ec2e8288fe6
+index 0000000000000000000000000000000000000000..f55fb6443a7478fb8532c73e3ec7ae8f0f3e8380
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
-@@ -0,0 +1,894 @@
+@@ -0,0 +1,888 @@
 +/*
 + * Copyright (C) 2019 Microsoft Corporation.
 + *
@@ -13558,12 +13558,6 @@ index 0000000000000000000000000000000000000000..4463301d7cbe4831ee35f91664fe0ec2
 +    }
 +    for (auto* page : pages)
 +        page->closePage();
-+
-+    if (!WebProcessPool::allProcessPools().size()) {
-+        m_client->closeBrowser();
-+        callback(String());
-+        return;
-+    }
 +
 +    if (!m_defaultContext) {
 +        m_client->closeBrowser();


### PR DESCRIPTION
* Browser process should stay even if all pages have been closed. It will only exit when Playwright tells it to.
* In InspectorPlaywrightAgent.closeImpl always call syncLocalStorage even if all pages and their web processes are gone (network process is still alive).

~https://github.com/yury-s/webkit/commit/0b2cc62e8f39dc5cb8b80760f909f99de1e852e6~
https://github.com/yury-s/webkit/commit/8b15a43e30ef6c56ec69fde993779b4896d22ad3