### PR TITLE
feat(cdp): replace wsEndpoint with protocol neutral endpointURL

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -116,7 +116,7 @@ Connecting over the Chrome DevTools Protocol is only supported for Chromium-base
 ### param: BrowserType.connectOverCDP.params
 * langs: js
 - `params` <[Object]>
-  - `wsEndpoint` <[string]> A CDP websocket endpoint to connect to.
+  - `endpointURL` <[string]> A CDP websocket endpoint or http url to connect to. For example `http://localhost:9222/` or `ws://127.0.0.1:9222/devtools/browser/387adf4c-243f-4051-a181-46798f4a46f4`.
   - `slowMo` <[float]> Slows down Playwright operations by the specified amount of milliseconds. Useful so that you
     can see what is going on. Defaults to 0.
   - `logger` <[Logger]> Logger sink for Playwright logging. Optional.

--- a/docs/src/api/java.md
+++ b/docs/src/api/java.md
@@ -58,11 +58,11 @@ page.navigate("https://www.w3.org/");
 playwright.close();
 ```
 
-### param: BrowserType.connectOverCDP.wsEndpoint
+### param: BrowserType.connectOverCDP.endpointURL
 * langs: java
-- `wsEndpoint` <[string]>
+- `endpointURL` <[string]>
 
-A CDP websocket endpoint to connect to.
+A CDP websocket endpoint or http url to connect to. For example `http://localhost:9222/` or `ws://127.0.0.1:9222/devtools/browser/387adf4c-243f-4051-a181-46798f4a46f4`.
 
 ### param: BrowserContext.waitForPage.callback = %%-java-wait-for-event-callback-%%
 

--- a/src/client/browserType.ts
+++ b/src/client/browserType.ts
@@ -187,14 +187,16 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, chann
     }, logger);
   }
 
-  async connectOverCDP(params: ConnectOptions): Promise<Browser> {
+  async connectOverCDP(params: api.ConnectOverCDPOptions): Promise<Browser>
+  async connectOverCDP(params: api.ConnectOptions): Promise<Browser>
+  async connectOverCDP(params: api.ConnectOverCDPOptions | api.ConnectOptions): Promise<Browser> {
     if (this.name() !== 'chromium')
       throw new Error('Connecting over CDP is only supported in Chromium.');
     const logger = params.logger;
     return this._wrapApiCall('browserType.connectOverCDP', async (channel: channels.BrowserTypeChannel) => {
       const result = await channel.connectOverCDP({
         sdkLanguage: 'javascript',
-        wsEndpoint: params.wsEndpoint,
+        endpointURL: 'endpointURL' in params ? params.endpointURL : params.wsEndpoint,
         slowMo: params.slowMo,
         timeout: params.timeout
       });

--- a/src/dispatchers/browserTypeDispatcher.ts
+++ b/src/dispatchers/browserTypeDispatcher.ts
@@ -40,7 +40,7 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.Brow
   }
 
   async connectOverCDP(params: channels.BrowserTypeConnectOverCDPParams, metadata: CallMetadata): Promise<channels.BrowserTypeConnectOverCDPResult> {
-    const browser = await this._object.connectOverCDP(metadata, params.wsEndpoint, params, params.timeout);
+    const browser = await this._object.connectOverCDP(metadata, params.endpointURL, params, params.timeout);
     return {
       browser: new BrowserDispatcher(this._scope, browser),
       defaultContext: browser._defaultContext ? new BrowserContextDispatcher(this._scope, browser._defaultContext) : undefined,

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -408,7 +408,7 @@ export type BrowserTypeLaunchPersistentContextResult = {
 };
 export type BrowserTypeConnectOverCDPParams = {
   sdkLanguage: string,
-  wsEndpoint: string,
+  endpointURL: string,
   slowMo?: number,
   timeout?: number,
 };

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -422,7 +422,7 @@ BrowserType:
     connectOverCDP:
       parameters:
         sdkLanguage: string
-        wsEndpoint: string
+        endpointURL: string
         slowMo: number?
         timeout: number?
       returns:

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -249,7 +249,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   });
   scheme.BrowserTypeConnectOverCDPParams = tObject({
     sdkLanguage: tString,
-    wsEndpoint: tString,
+    endpointURL: tString,
     slowMo: tOptional(tNumber),
     timeout: tOptional(tNumber),
   });

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -248,7 +248,7 @@ export abstract class BrowserType extends SdkObject {
     return { browserProcess, downloadsPath, transport };
   }
 
-  async connectOverCDP(metadata: CallMetadata, wsEndpoint: string, options: { slowMo?: number, sdkLanguage: string }, timeout?: number): Promise<Browser> {
+  async connectOverCDP(metadata: CallMetadata, endpointURL: string, options: { slowMo?: number, sdkLanguage: string }, timeout?: number): Promise<Browser> {
     throw new Error('CDP connections are only supported by Chromium');
   }
 

--- a/tests/browsertype-basic.spec.ts
+++ b/tests/browsertype-basic.spec.ts
@@ -33,6 +33,6 @@ test('browserType.name should work', async ({browserType, browserName}) => {
 test('should throw when trying to connect with not-chromium', async ({ browserType, browserName }) => {
   test.skip(browserName === 'chromium');
 
-  const error = await browserType.connectOverCDP({wsEndpoint: 'foo'}).catch(e => e);
+  const error = await browserType.connectOverCDP({endpointURL: 'ws://foo'}).catch(e => e);
   expect(error.message).toBe('Connecting over CDP is only supported in Chromium.');
 });

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6460,13 +6460,6 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
  * 
  */
 export interface BrowserType<Unused = {}> {
-
-  /**
-   * This methods attaches Playwright to an existing browser instance.
-   * @param params 
-   */
-  connect(params: ConnectOptions): Promise<Browser>;
-
   /**
    * This methods attaches Playwright to an existing browser instance using the Chrome DevTools Protocol.
    * 
@@ -6476,29 +6469,17 @@ export interface BrowserType<Unused = {}> {
    * > NOTE: Connecting over the Chrome DevTools Protocol is only supported for Chromium-based browsers.
    * @param params 
    */
-  connectOverCDP(params: {
-    /**
-     * A CDP websocket endpoint to connect to.
-     */
-    wsEndpoint: string;
-
-    /**
-     * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going on.
-     * Defaults to 0.
-     */
-    slowMo?: number;
-
-    /**
-     * Logger sink for Playwright logging. Optional.
-     */
-    logger?: Logger;
-
-    /**
-     * Maximum time in milliseconds to wait for the connection to be established. Defaults to `30000` (30 seconds). Pass `0` to
-     * disable timeout.
-     */
-    timeout?: number;
-  }): Promise<Browser>;
+  connectOverCDP(options: ConnectOverCDPOptions): Promise<Browser>;
+  /**
+   * Option `wsEndpoint` is deprecated. Instead use `endpointURL`.
+   * @deprecated
+   */
+  connectOverCDP(options: ConnectOptions): Promise<Browser>;
+  /**
+   * This methods attaches Playwright to an existing browser instance.
+   * @param params 
+   */
+  connect(params: ConnectOptions): Promise<Browser>;
 
   /**
    * A path where Playwright expects to find a bundled browser executable.
@@ -10682,6 +10663,31 @@ export interface LaunchOptions {
 
   /**
    * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `30000` (30 seconds). Pass `0` to
+   * disable timeout.
+   */
+  timeout?: number;
+}
+
+export interface ConnectOverCDPOptions {
+  /**
+   * A CDP websocket endpoint or http url to connect to. For example `http://localhost:9222/` or
+   * `ws://127.0.0.1:9222/devtools/browser/387adf4c-243f-4051-a181-46798f4a46f4`.
+   */
+  endpointURL: string;
+
+  /**
+   * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going on.
+   * Defaults to 0.
+   */
+  slowMo?: number;
+
+  /**
+   * Logger sink for Playwright logging. Optional.
+   */
+  logger?: Logger;
+
+  /**
+   * Maximum time in milliseconds to wait for the connection to be established. Defaults to `30000` (30 seconds). Pass `0` to
    * disable timeout.
    */
   timeout?: number;

--- a/utils/generate_types/exported.json
+++ b/utils/generate_types/exported.json
@@ -1,6 +1,7 @@
 {
   "BrowserTypeLaunchOptions": "LaunchOptions",
   "BrowserTypeConnectParams": "ConnectOptions",
+  "BrowserTypeConnectOverCDPParams": "ConnectOverCDPOptions",
   "BrowserContextCookies": "Cookie",
   "BrowserNewContextOptions": "BrowserContextOptions",
   "BrowserNewContextOptionsViewport": "ViewportSize",

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -141,7 +141,12 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 }
 
 export interface BrowserType<Unused = {}> {
-
+  connectOverCDP(options: ConnectOverCDPOptions): Promise<Browser>;
+  /**
+   * Option `wsEndpoint` is deprecated. Instead use `endpointURL`.
+   * @deprecated
+   */
+  connectOverCDP(options: ConnectOptions): Promise<Browser>;
 }
 
 export interface CDPSession {


### PR DESCRIPTION
fixes #6084

The wsEndpoint option is removed from the docs and deprecated in typescript. It was renamed to `endpointURL`. A new type `ConnectOverCDPOptions` is exported, next to `ConnectOptions`. `endpointURL` looks closely at the URL and if its http goes to `/json/version` to find the websocket url. This should make connecting over cdp much easier.

@dgozman for types review
@pavelfeldman for api review
@yury-s for how this affects the api in java