### PR TITLE
feat(types): make the template on BrowserType optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,8 +17,8 @@
 import * as types from './types/types';
 
 export * from './types/types';
-export const webkit: types.BrowserType<types.Browser>;
-export const chromium: types.BrowserType<types.Browser>;
-export const firefox: types.BrowserType<types.Browser>;
+export const webkit: types.BrowserType;
+export const chromium: types.BrowserType;
+export const firefox: types.BrowserType;
 export const _electron: types.Electron;
 export const _android: types.Android;

--- a/packages/common/index.d.ts
+++ b/packages/common/index.d.ts
@@ -17,8 +17,8 @@
 import * as types from './types/types';
 
 export * from './types/types';
-export const chromium: types.BrowserType<types.Browser>;
-export const firefox: types.BrowserType<types.Browser>;
-export const webkit: types.BrowserType<types.Browser>;
+export const chromium: types.BrowserType;
+export const firefox: types.BrowserType;
+export const webkit: types.BrowserType;
 export const _electron: types.Electron;
 export const _android: types.Android;

--- a/src/client/browserType.ts
+++ b/src/client/browserType.ts
@@ -46,7 +46,7 @@ export interface BrowserServer extends api.BrowserServer {
   kill(): Promise<void>;
 }
 
-export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, channels.BrowserTypeInitializer> implements api.BrowserType<api.Browser> {
+export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, channels.BrowserTypeInitializer> implements api.BrowserType {
   private _timeoutSettings = new TimeoutSettings();
   _serverLauncher?: BrowserServerLauncher;
 

--- a/tests/config/browserEnv.ts
+++ b/tests/config/browserEnv.ts
@@ -103,7 +103,7 @@ export class PlaywrightEnv implements Env<PlaywrightTestArgs> {
   protected _options: LaunchOptions & TestOptions;
   protected _browserOptions: LaunchOptions;
   private _playwright: typeof import('../../index');
-  protected _browserType: BrowserType<Browser>;
+  protected _browserType: BrowserType;
   private _coverage: ReturnType<typeof installCoverageHooks> | undefined;
   private _userDataDirs: string[] = [];
   private _persistentContext: BrowserContext | undefined;
@@ -142,7 +142,7 @@ export class PlaywrightEnv implements Env<PlaywrightTestArgs> {
     return dir;
   }
 
-  private async _launchPersistent(options?: Parameters<BrowserType<Browser>['launchPersistentContext']>[1]) {
+  private async _launchPersistent(options?: Parameters<BrowserType['launchPersistentContext']>[1]) {
     if (this._persistentContext)
       throw new Error('can only launch one persitent context');
     const userDataDir = await this._createUserDataDir();

--- a/tests/config/playwrightTest.ts
+++ b/tests/config/playwrightTest.ts
@@ -15,17 +15,17 @@
  */
 
 import { newTestType } from 'folio';
-import type { Browser, BrowserType, LaunchOptions, BrowserContext, Page } from '../../index';
+import type { BrowserType, LaunchOptions, BrowserContext, Page } from '../../index';
 import { CommonTestArgs } from './pageTest';
 import type { ServerTestArgs } from './serverTest';
 import { RemoteServer, RemoteServerOptions } from './remoteServer';
 export { expect } from 'folio';
 
 export type PlaywrightTestArgs = CommonTestArgs & {
-  browserType: BrowserType<Browser>;
+  browserType: BrowserType;
   browserOptions: LaunchOptions;
   createUserDataDir: () => Promise<string>;
-  launchPersistent: (options?: Parameters<BrowserType<Browser>['launchPersistentContext']>[1]) => Promise<{ context: BrowserContext, page: Page }>;
+  launchPersistent: (options?: Parameters<BrowserType['launchPersistentContext']>[1]) => Promise<{ context: BrowserContext, page: Page }>;
   startRemoteServer: (options?: RemoteServerOptions) => Promise<RemoteServer>;
 };
 

--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -29,7 +29,7 @@ export type RemoteServerOptions = {
 export class RemoteServer {
   _output: Map<any, any>;
   _outputCallback: Map<any, any>;
-  _browserType: BrowserType<Browser>;
+  _browserType: BrowserType;
   _child: import('child_process').ChildProcess;
   _exitPromise: Promise<unknown>;
   _exitAndDisconnectPromise: Promise<any>;
@@ -37,7 +37,7 @@ export class RemoteServer {
   _didExit: boolean;
   _wsEndpoint: string;
 
-  async _start(browserType: BrowserType<Browser>, browserOptions: LaunchOptions, remoteServerOptions: RemoteServerOptions = {}) {
+  async _start(browserType: BrowserType, browserOptions: LaunchOptions, remoteServerOptions: RemoteServerOptions = {}) {
     this._output = new Map();
     this._outputCallback = new Map();
     this._didExit = false;

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6459,7 +6459,7 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
  * ```
  * 
  */
-export interface BrowserType<Browser> {
+export interface BrowserType<Unused = {}> {
 
   /**
    * This methods attaches Playwright to an existing browser instance.

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -140,7 +140,7 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
   waitForSelector(selector: string, options: ElementHandleWaitForSelectorOptions): Promise<null|ElementHandle<SVGElement | HTMLElement>>;
 }
 
-export interface BrowserType<Browser> {
+export interface BrowserType<Unused = {}> {
 
 }
 

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -799,6 +799,15 @@ playwright.chromium.launch().then(async browser => {
   await browser.close();
 })();
 
+// for backwards compat, BrowserType is templated
+
+(async () => {
+  const browserType = {} as playwright.BrowserType<playwright.Browser & {foo: 'string'}>;
+  const browser = await browserType.launch();
+  // @ts-expect-error
+  browser.foo;
+})
+
 // exported types
 import {
   LaunchOptions,

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -804,8 +804,7 @@ playwright.chromium.launch().then(async browser => {
 (async () => {
   const browserType = {} as playwright.BrowserType<playwright.Browser & {foo: 'string'}>;
   const browser = await browserType.launch();
-  // @ts-expect-error
-  browser.foo;
+  await browser.close();
 })
 
 // exported types


### PR DESCRIPTION
This makes it much nicer to use `BrowserType` because it no longer has a template.

Technically a breaking change because of the rare edge case where someone used their own non-browser type inside the template, but I don't consider that intended behavior and think this is fine.