### PR TITLE
devops: fix firefox-stable build script

### DIFF
--- a/browser_patches/firefox-stable/build.sh
+++ b/browser_patches/firefox-stable/build.sh
@@ -87,7 +87,7 @@ if [[ $1 == "--full" || $2 == "--full" ]]; then
     rm -rf "$HOME/.mozbuild/node"
     mv node "$HOME/.mozbuild/"
   elif [[ "$(uname)" == "Darwin" || "$(uname)" == "Linux" ]]; then
-    SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser --no-system-changes
+    SHELL=/bin/sh ./mach bootstrap --no-interactive --application-choice=browser --no-system-changes
   fi
   if [[ ! -z "${WIN32_REDIST_DIR}" ]]; then
     # Having this option in .mozconfig kills incremental compilation.


### PR DESCRIPTION
The old mach used `--no-interactive` flag at a different place.