### PR TITLE
chore: read browsers.json with require

### DIFF
--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -16,7 +16,6 @@
  */
 
 import { execSync } from 'child_process';
-import fs from 'fs';
 import * as os from 'os';
 import path from 'path';
 import * as util from 'util';
@@ -235,7 +234,9 @@ export class Registry {
   }
 
   constructor(packagePath: string) {
-    const browsersJSON = JSON.parse(fs.readFileSync(path.join(packagePath, 'browsers.json'), 'utf8'));
+    // require() needs to be used there otherwise it breaks on Vercel serverless
+    // functions. See https://github.com/microsoft/playwright/pull/6186
+    const browsersJSON = require(path.join(packagePath, 'browsers.json'));
     this._descriptors = browsersJSON['browsers'].map((obj: any) => {
       const name = obj.name;
       const revisionOverride = (obj.revisionOverrides || {})[hostPlatform];


### PR DESCRIPTION
This fixes the compatibility on Vercel with Next.js when it's used in
a serverless function.
Next.js uses https://github.com/vercel/nft to trace down the
dependencies which a serverless function is using which
is currently not capable of detecting the browsers.json in our current
setup. Previously we used `require` to load the browers.json which was
replaced by `readFileSync` in #5318. Since then it was broken.

`require` has not much down-sides except its caching which in our-case
should not have any side-effects.

Without that it caused a `Error: ENOENT: no such file or directory, open '/var/task/node_modules/playwright-core/browsers.json'`.

Fixes #5862