### PR TITLE
docs: change the position argument location in check functions

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -130,11 +130,11 @@ If the element is detached from the DOM at any moment during the action, this me
 When all steps combined have not finished during the specified [`option: timeout`], this method throws a
 [TimeoutError]. Passing zero timeout disables this.
 
+### option: ElementHandle.check.position = %%-input-position-%%
+
 ### option: ElementHandle.check.force = %%-input-force-%%
 
 ### option: ElementHandle.check.noWaitAfter = %%-input-no-wait-after-%%
-
-### option: ElementHandle.check.position = %%-input-position-%%
 
 ### option: ElementHandle.check.timeout = %%-input-timeout-%%
 
@@ -780,11 +780,11 @@ If the element is detached from the DOM at any moment during the action, this me
 When all steps combined have not finished during the specified [`option: timeout`], this method throws a
 [TimeoutError]. Passing zero timeout disables this.
 
+### option: ElementHandle.uncheck.position = %%-input-position-%%
+
 ### option: ElementHandle.uncheck.force = %%-input-force-%%
 
 ### option: ElementHandle.uncheck.noWaitAfter = %%-input-no-wait-after-%%
-
-### option: ElementHandle.uncheck.position = %%-input-position-%%
 
 ### option: ElementHandle.uncheck.timeout = %%-input-timeout-%%
 

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -169,11 +169,11 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### param: Frame.check.selector = %%-input-selector-%%
 
+### option: Frame.check.position = %%-input-position-%%
+
 ### option: Frame.check.force = %%-input-force-%%
 
 ### option: Frame.check.noWaitAfter = %%-input-no-wait-after-%%
-
-### option: Frame.check.position = %%-input-position-%%
 
 ### option: Frame.check.timeout = %%-input-timeout-%%
 
@@ -1100,11 +1100,11 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### param: Frame.uncheck.selector = %%-input-selector-%%
 
+### option: Frame.uncheck.position = %%-input-position-%%
+
 ### option: Frame.uncheck.force = %%-input-force-%%
 
 ### option: Frame.uncheck.noWaitAfter = %%-input-no-wait-after-%%
-
-### option: Frame.uncheck.position = %%-input-position-%%
 
 ### option: Frame.uncheck.timeout = %%-input-timeout-%%
 

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -527,11 +527,11 @@ Shortcut for main frame's [`method: Frame.check`].
 
 ### param: Page.check.selector = %%-input-selector-%%
 
+### option: Page.check.position = %%-input-position-%%
+
 ### option: Page.check.force = %%-input-force-%%
 
 ### option: Page.check.noWaitAfter = %%-input-no-wait-after-%%
-
-### option: Page.check.position = %%-input-position-%%
 
 ### option: Page.check.timeout = %%-input-timeout-%%
 
@@ -2503,11 +2503,11 @@ Shortcut for main frame's [`method: Frame.uncheck`].
 
 ### param: Page.uncheck.selector = %%-input-selector-%%
 
+### option: Page.uncheck.position = %%-input-position-%%
+
 ### option: Page.uncheck.force = %%-input-force-%%
 
 ### option: Page.uncheck.noWaitAfter = %%-input-no-wait-after-%%
-
-### option: Page.uncheck.position = %%-input-position-%%
 
 ### option: Page.uncheck.timeout = %%-input-timeout-%%
 


### PR DESCRIPTION
I think `position` is more relevant to the user than the "noWaitAfter, force, timeout" pack