### PR TITLE
chore: fix deprecation warning with Node.js 16 imports

### DIFF
--- a/packages/build_package.js
+++ b/packages/build_package.js
@@ -150,7 +150,7 @@ if (!args.some(arg => arg === '--no-cleanup')) {
         require: './index.js',
       },
       // Anything else can be required/imported by providing a relative path.
-      './': './',
+      './*': './*',
     },
     scripts: {
       install: 'node install.js',


### PR DESCRIPTION
This isn't a quick-one, with a change we probably break previous Node.js versions. For reference 
- https://github.com/microsoft/tslib/pull/135#issuecomment-754876173
- https://github.com/postcss/postcss/issues/1455 (they made the change and then reverted. Its still persistent for them)

Fixes #6026

See here https://github.com/microsoft/playwright/issues/6026#issuecomment-823491247 for reproducible steps.