### PR TITLE
chore(types): add channel to launchServer

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -295,7 +295,7 @@ Whether to run browser in headless mode. More details for
 ### option: BrowserType.launchPersistentContext.channel
 - `channel` <[BrowserChannel]<"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary">>
 
-Browser distribution channel.
+Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.md#google-chrome--microsoft-edge).
 
 ### option: BrowserType.launchPersistentContext.executablePath
 - `executablePath` <[path]>
@@ -398,6 +398,11 @@ Whether to run browser in headless mode. More details for
 - `port` <[int]>
 
 Port to use for the web socket. Defaults to 0 that picks any available port.
+
+### option: BrowserType.launchServer.channel
+- `channel` <[BrowserChannel]<"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary">>
+
+Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.md#google-chrome--microsoft-edge).
 
 ### option: BrowserType.launchServer.executablePath
 - `executablePath` <[path]>

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -75,6 +75,7 @@ export type ConnectOptions = {
   logger?: Logger,
 };
 export type LaunchServerOptions = {
+  channel?: channels.BrowserTypeLaunchOptions['channel'],
   executablePath?: string,
   args?: string[],
   ignoreDefaultArgs?: boolean | string[],

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6603,7 +6603,8 @@ export interface BrowserType<Unused = {}> {
     bypassCSP?: boolean;
 
     /**
-     * Browser distribution channel.
+     * Browser distribution channel. Read more about using
+     * [Google Chrome and Microsoft Edge](https://playwright.dev/docs/browsers#google-chrome--microsoft-edge).
      */
     channel?: "chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary";
 
@@ -6930,6 +6931,12 @@ export interface BrowserType<Unused = {}> {
      * [here](http://peter.sh/experiments/chromium-command-line-switches/).
      */
     args?: Array<string>;
+
+    /**
+     * Browser distribution channel. Read more about using
+     * [Google Chrome and Microsoft Edge](https://playwright.dev/docs/browsers#google-chrome--microsoft-edge).
+     */
+    channel?: "chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary";
 
     /**
      * Enable Chromium sandboxing. Defaults to `true`.


### PR DESCRIPTION
Before this change the channel was not included in the server options as well as not in the docs.