### PR TITLE
chore: remove stack from WaitForEventInfo

### DIFF
--- a/src/client/channelOwner.ts
+++ b/src/client/channelOwner.ts
@@ -103,8 +103,8 @@ export abstract class ChannelOwner<T extends channels.Channel = channels.Channel
     }
   }
 
-  _waitForEventInfoBefore(waitId: string, apiName: string, stack: StackFrame[]) {
-    this._connection.sendMessageToServer(this._guid, 'waitForEventInfo', { info: { apiName, waitId, phase: 'before', stack } }, undefined).catch(() => {});
+  _waitForEventInfoBefore(waitId: string, apiName: string) {
+    this._connection.sendMessageToServer(this._guid, 'waitForEventInfo', { info: { apiName, waitId, phase: 'before' } }, undefined).catch(() => {});
   }
 
   _waitForEventInfoAfter(waitId: string, error?: string) {

--- a/src/client/channelOwner.ts
+++ b/src/client/channelOwner.ts
@@ -16,12 +16,11 @@
 
 import { EventEmitter } from 'events';
 import * as channels from '../protocol/channels';
-import type { Connection } from './connection';
-import type { Logger } from './types';
+import { createScheme, ValidationError, Validator } from '../protocol/validator';
 import { debugLogger } from '../utils/debugLogger';
 import { rewriteErrorMessage } from '../utils/stackTrace';
-import { createScheme, Validator, ValidationError } from '../protocol/validator';
-import { StackFrame } from '../common/types';
+import type { Connection } from './connection';
+import type { Logger } from './types';
 
 export abstract class ChannelOwner<T extends channels.Channel = channels.Channel, Initializer = {}> extends EventEmitter {
   private _connection: Connection;

--- a/src/client/waiter.ts
+++ b/src/client/waiter.ts
@@ -15,7 +15,7 @@
  */
 
 import { EventEmitter } from 'events';
-import { captureStackTrace, rewriteErrorMessage } from '../utils/stackTrace';
+import { rewriteErrorMessage } from '../utils/stackTrace';
 import { TimeoutError } from '../utils/errors';
 import { createGuid } from '../utils/utils';
 import { ChannelOwner } from './channelOwner';
@@ -32,7 +32,7 @@ export class Waiter {
   constructor(channelOwner: ChannelOwner, apiName: string) {
     this._waitId = createGuid();
     this._channelOwner = channelOwner;
-    this._channelOwner._waitForEventInfoBefore(this._waitId, apiName, captureStackTrace().frames);
+    this._channelOwner._waitForEventInfoBefore(this._waitId, apiName);
     this._dispose = [
       () => this._channelOwner._waitForEventInfoAfter(this._waitId, this._error)
     ];

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -220,7 +220,6 @@ export class DispatcherConnection {
           switch (info.phase) {
             case 'before':
               callMetadata.apiName = info.apiName;
-              callMetadata.stack = info.stack;
               this._waitOperations.set(info.waitId, callMetadata);
               break;
             case 'log':

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -39,7 +39,6 @@ export type WaitForEventInfo = {
   waitId: string,
   phase: 'before' | 'after' | 'log',
   apiName?: string,
-  stack?: StackFrame[],
   message?: string,
   error?: string,
 };

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -42,9 +42,6 @@ WaitForEventInfo:
       - after
       - log
     apiName: string?
-    stack:
-      type: array?
-      items: StackFrame
     message: string?
     error: string?
 

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -47,7 +47,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     waitId: tString,
     phase: tEnum(['before', 'after', 'log']),
     apiName: tOptional(tString),
-    stack: tOptional(tArray(tType('StackFrame'))),
     message: tOptional(tString),
     error: tOptional(tString),
   });


### PR DESCRIPTION
It was only passed in phase 'before' and was done synchronously so the stack is identical to the one in request metadata.