### PR TITLE
fix(chromium): force --use-gl=swiftshader on Windows

### DIFF
--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -134,6 +134,9 @@ export class Chromium extends BrowserType {
     if (options.devtools)
       chromeArguments.push('--auto-open-devtools-for-tabs');
     if (options.headless) {
+      // See http://crbug.com/1200964
+      if (process.platform === 'win32')
+        chromeArguments.push('--use-gl=swiftshader');
       chromeArguments.push(
           '--headless',
           '--hide-scrollbars',


### PR DESCRIPTION
Hadless has always been using swiftshader but it recently broke upstream (see http://crbug.com/1200964) to avoid that we force it on our end.