### PR TITLE
docs(keyboard): clarify how page.type works for non-US characters

### DIFF
--- a/docs/src/api/class-keyboard.md
+++ b/docs/src/api/class-keyboard.md
@@ -286,6 +286,10 @@ page.keyboard.type("World", delay=100) # types slower, like a user
 Modifier keys DO NOT effect `keyboard.type`. Holding down `Shift` will not type the text in upper case.
 :::
 
+:::note
+For characters that are not on a US keyboard, only an `input` event will be sent.
+:::
+
 ### param: Keyboard.type.text
 - `text` <[string]>
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -9417,6 +9417,7 @@ export interface Keyboard {
    * ```
    * 
    * > NOTE: Modifier keys DO NOT effect `keyboard.type`. Holding down `Shift` will not type the text in upper case.
+   * > NOTE: For characters that are not on a US keyboard, only an `input` event will be sent.
    * @param text A text to type into a focused element.
    * @param options 
    */


### PR DESCRIPTION
#6267