### PR TITLE
fix(connect): handle disconnect in various situations

### DIFF
--- a/src/client/browser.ts
+++ b/src/client/browser.ts
@@ -28,7 +28,7 @@ export class Browser extends ChannelOwner<channels.BrowserChannel, channels.Brow
   readonly _contexts = new Set<BrowserContext>();
   private _isConnected = true;
   private _closedPromise: Promise<void>;
-  _isRemote = false;
+  _remoteType: 'owns-connection' | 'uses-connection' | null = null;
   readonly _name: string;
 
   static from(browser: channels.BrowserChannel): Browser {
@@ -98,7 +98,10 @@ export class Browser extends ChannelOwner<channels.BrowserChannel, channels.Brow
   async close(): Promise<void> {
     try {
       await this._wrapApiCall('browser.close', async (channel: channels.BrowserChannel) => {
-        await channel.close();
+        if (this._remoteType === 'owns-connection')
+          this._connection.close();
+        else
+          await channel.close();
         await this._closedPromise;
       });
     } catch (e) {

--- a/src/client/channelOwner.ts
+++ b/src/client/channelOwner.ts
@@ -23,7 +23,7 @@ import type { Connection } from './connection';
 import type { Logger } from './types';
 
 export abstract class ChannelOwner<T extends channels.Channel = channels.Channel, Initializer = {}> extends EventEmitter {
-  private _connection: Connection;
+  protected _connection: Connection;
   private _parent: ChannelOwner | undefined;
   private _objects = new Map<string, ChannelOwner>();
 

--- a/src/client/frame.ts
+++ b/src/client/frame.ts
@@ -102,6 +102,8 @@ export class Frame extends ChannelOwner<channels.FrameChannel, channels.FrameIni
 
   private _setupNavigationWaiter(name: string, options: { timeout?: number }): Waiter {
     const waiter = new Waiter(this, name);
+    if (this._page!.isClosed())
+      waiter.rejectImmediately(new Error('Navigation failed because page was closed!'));
     waiter.rejectOnEvent(this._page!, Events.Page.Close, new Error('Navigation failed because page was closed!'));
     waiter.rejectOnEvent(this._page!, Events.Page.Crash, new Error('Navigation failed because page crashed!'));
     waiter.rejectOnEvent<Frame>(this._page!, Events.Page.FrameDetached, new Error('Navigating frame was detached!'), frame => frame === this);

--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -124,7 +124,7 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     this._channel.on('domcontentloaded', () => this.emit(Events.Page.DOMContentLoaded, this));
     this._channel.on('download', ({ url, suggestedFilename, artifact }) => {
       const artifactObject = Artifact.from(artifact);
-      artifactObject._isRemote = !!this._browserContext._browser && this._browserContext._browser._isRemote;
+      artifactObject._isRemote = !!this._browserContext._browser && !!this._browserContext._browser._remoteType;
       this.emit(Events.Page.Download, new Download(url, suggestedFilename, artifactObject));
     });
     this._channel.on('fileChooser', ({ element, isMultiple }) => this.emit(Events.Page.FileChooser, new FileChooser(this, ElementHandle.from(element), isMultiple)));

--- a/src/client/tracing.ts
+++ b/src/client/tracing.ts
@@ -42,7 +42,7 @@ export class Tracing {
       return await channel.tracingExport();
     });
     const artifact = Artifact.from(result.artifact);
-    if (this._context.browser()?._isRemote)
+    if (this._context.browser()?._remoteType)
       artifact._isRemote = true;
     await artifact.saveAs(path);
     await artifact.delete();

--- a/src/client/video.ts
+++ b/src/client/video.ts
@@ -25,7 +25,7 @@ export class Video implements api.Video {
 
   constructor(page: Page) {
     const browser = page.context()._browser;
-    this._isRemote = !!browser && browser._isRemote;
+    this._isRemote = !!browser && !!browser._remoteType;
     this._artifact = Promise.race([
       new Promise<Artifact>(f => this._artifactCallback = f),
       page._closedOrCrashedPromise.then(() => null),

--- a/src/dispatchers/playwrightDispatcher.ts
+++ b/src/dispatchers/playwrightDispatcher.ts
@@ -21,11 +21,10 @@ import { BrowserTypeDispatcher } from './browserTypeDispatcher';
 import { Dispatcher, DispatcherScope } from './dispatcher';
 import { ElectronDispatcher } from './electronDispatcher';
 import { SelectorsDispatcher } from './selectorsDispatcher';
-import type { BrowserDispatcher } from './browserDispatcher';
 import * as types from '../server/types';
 
 export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.PlaywrightInitializer> implements channels.PlaywrightChannel {
-  constructor(scope: DispatcherScope, playwright: Playwright, customSelectors?: SelectorsDispatcher, preLaunchedBrowser?: BrowserDispatcher) {
+  constructor(scope: DispatcherScope, playwright: Playwright, customSelectors?: channels.SelectorsChannel, preLaunchedBrowser?: channels.BrowserChannel) {
     const descriptors = require('../server/deviceDescriptors') as types.Devices;
     const deviceDescriptors = Object.entries(descriptors)
         .map(([name, descriptor]) => ({ name, descriptor }));

--- a/tests/browsertype-connect.spec.ts
+++ b/tests/browsertype-connect.spec.ts
@@ -79,7 +79,10 @@ test('disconnected event should be emitted when browser is closed or server is c
   const remoteServer = await startRemoteServer();
 
   const browser1 = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
+  await browser1.newPage();
+
   const browser2 = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
+  await browser2.newPage();
 
   let disconnected1 = 0;
   let disconnected2 = 0;
@@ -141,6 +144,19 @@ test('should throw when used after isConnected returns false', async ({browserTy
   expect(error.message).toContain('has been closed');
 });
 
+test('should throw when calling waitForNavigation after disconnect', async ({browserType, startRemoteServer}) => {
+  const remoteServer = await startRemoteServer();
+  const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
+  const page = await browser.newPage();
+  await Promise.all([
+    remoteServer.close(),
+    new Promise(f => browser.once('disconnected', f)),
+  ]);
+  expect(browser.isConnected()).toBe(false);
+  const error = await page.waitForNavigation().catch(e => e);
+  expect(error.message).toContain('Navigation failed because page was closed');
+});
+
 test('should reject navigation when browser closes', async ({browserType, startRemoteServer, server}) => {
   const remoteServer = await startRemoteServer();
   server.setRoute('/one-style.css', () => {});
@@ -150,7 +166,7 @@ test('should reject navigation when browser closes', async ({browserType, startR
   await server.waitForRequest('/one-style.css');
   await browser.close();
   const error = await navigationPromise;
-  expect(error.message).toContain('Navigation failed because page was closed!');
+  expect(error.message).toContain('has been closed');
 });
 
 test('should reject waitForSelector when browser closes', async ({browserType, startRemoteServer, server}) => {
@@ -165,7 +181,7 @@ test('should reject waitForSelector when browser closes', async ({browserType, s
 
   await browser.close();
   const error = await watchdog;
-  expect(error.message).toContain('Protocol error');
+  expect(error.message).toContain('has been closed');
 });
 
 test('should emit close events on pages and contexts', async ({browserType, startRemoteServer}) => {
@@ -359,4 +375,46 @@ test('should work with cluster', async ({browserType, startRemoteServer}) => {
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const page = await browser.newPage();
   expect(await page.evaluate('1 + 2')).toBe(3);
+});
+
+test('should properly disconnect when connection closes from the client side', async ({browserType, startRemoteServer, server}) => {
+  server.setRoute('/one-style.css', () => {});
+  const remoteServer = await startRemoteServer();
+  const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
+  const page = await browser.newPage();
+  const navigationPromise = page.goto(server.PREFIX + '/one-style.html', {timeout: 60000}).catch(e => e);
+  const waitForNavigationPromise = page.waitForNavigation().catch(e => e);
+
+  const disconnectedPromise = new Promise(f => browser.once('disconnected', f));
+  // This closes the websocket.
+  (browser as any)._connection.close();
+  await disconnectedPromise;
+  expect(browser.isConnected()).toBe(false);
+
+  expect((await navigationPromise).message).toContain('has been closed');
+  expect((await waitForNavigationPromise).message).toContain('Navigation failed because page was closed');
+  expect((await page.goto(server.EMPTY_PAGE).catch(e => e)).message).toContain('has been closed');
+  expect((await page.waitForNavigation().catch(e => e)).message).toContain('Navigation failed because page was closed');
+});
+
+test('should properly disconnect when connection closes from the server side', async ({browserType, startRemoteServer, server, platform}) => {
+  test.skip(platform === 'win32', 'Cannot send signals');
+
+  server.setRoute('/one-style.css', () => {});
+  const remoteServer = await startRemoteServer({ disconnectOnSIGHUP: true });
+  const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
+  const page = await browser.newPage();
+  const navigationPromise = page.goto(server.PREFIX + '/one-style.html', {timeout: 60000}).catch(e => e);
+  const waitForNavigationPromise = page.waitForNavigation().catch(e => e);
+
+  const disconnectedPromise = new Promise(f => browser.once('disconnected', f));
+  // This closes the websocket server.
+  process.kill(remoteServer.child().pid, 'SIGHUP');
+  await disconnectedPromise;
+  expect(browser.isConnected()).toBe(false);
+
+  expect((await navigationPromise).message).toContain('has been closed');
+  expect((await waitForNavigationPromise).message).toContain('Navigation failed because page was closed');
+  expect((await page.goto(server.EMPTY_PAGE).catch(e => e)).message).toContain('has been closed');
+  expect((await page.waitForNavigation().catch(e => e)).message).toContain('Navigation failed because page was closed');
 });

--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -22,6 +22,7 @@ const playwrightPath = path.join(__dirname, '..', '..');
 
 export type RemoteServerOptions = {
   stallOnClose?: boolean;
+  disconnectOnSIGHUP?: boolean;
   inCluster?: boolean;
   url?: string;
 };

--- a/tests/page/page-wait-for-url.spec.ts
+++ b/tests/page/page-wait-for-url.spec.ts
@@ -24,9 +24,9 @@ it('should work', async ({page, server}) => {
 });
 
 it('should respect timeout', async ({page, server}) => {
-  const promise = page.waitForURL('**/frame.html', { timeout: 2500 });
+  const promise = page.waitForURL('**/frame.html', { timeout: 2500 }).catch(e => e);
   await page.goto(server.EMPTY_PAGE);
-  const error = await promise.catch(e => e);
+  const error = await promise;
   expect(error.message).toContain('page.waitForNavigation: Timeout 2500ms exceeded.');
 });
 


### PR DESCRIPTION
There are a few ways for `connect()` to finish:
- `Browser.close()` from the client side.
- Browser on the server side did exit (e.g. crashed).
- Connection was dropped by either of the sides.

We reduce all the cases to the last one by dropping the
connection when client wants calls `Browser.close()` or
server-side browser exits.

In all these cases we should properly cleanup on the server side,
and ensure that all promises reject on the client side.