### PR TITLE
browser(firefox): disable proton UI for now

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1247
-Changed: dgozman@gmail.com Fri Apr 23 15:46:40 PDT 2021
+1248
+Changed: aslushnikov@gmail.com Mon Apr 26 12:48:04 -05 2021

--- a/browser_patches/firefox/preferences/playwright.cfg
+++ b/browser_patches/firefox/preferences/playwright.cfg
@@ -11,6 +11,11 @@ pref("browser.tabs.remote.useCrossOriginOpenerPolicy", false);
 // support for the new modal UI (see Bug 1686743).
 pref("prompts.contentPromptSubDialog", false);
 
+
+// The new "proton" UI breaks our screencast tests.
+// Disable the UI until we figure what is going on.
+pref("browser.proton.enabled", false);
+
 // Increase max number of child web processes so that new pages
 // get a new process by default and we have a process isolation
 // between pages from different contexts. If this becomes a performance


### PR DESCRIPTION
The new Proton UI breaks certain screencast tests. Disable
this for now.

I bisected the regression in tests to the following revision: https://phabricator.services.mozilla.com/D110156
