### PR TITLE
fix: increase recent logs buffer

### DIFF
--- a/src/utils/debugLogger.ts
+++ b/src/utils/debugLogger.ts
@@ -62,7 +62,7 @@ class DebugLogger {
 
 export const debugLogger = new DebugLogger();
 
-const kLogCount = 50;
+const kLogCount = 500;
 export class RecentLogsCollector {
   private _logs: string[] = [];
 


### PR DESCRIPTION
Otherwise we may miss important information, like to frames in this chrome crash: https://gist.github.com/yury-s/334134dbf68748dbbadc55aa4908de04