### PR TITLE
Revert "fix: increas recent logs buffer (#6330)"

### DIFF
--- a/src/utils/debugLogger.ts
+++ b/src/utils/debugLogger.ts
@@ -62,7 +62,7 @@ class DebugLogger {
 
 export const debugLogger = new DebugLogger();
 
-const kLogCount = 500;
+const kLogCount = 50;
 export class RecentLogsCollector {
   private _logs: string[] = [];
 


### PR DESCRIPTION
This reverts commit 3c126024ca88c09bfab9714e8290a4182797a336.

`pw:browser` logs should be fixed in #6331 and we can make recent log shorter again