### PR TITLE
fix(types): fix waitForSelector typing to not union null when appropriate

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -21,10 +21,10 @@ import { Readable } from 'stream';
 import { Serializable, EvaluationArgument, PageFunction, PageFunctionOn, SmartHandle, ElementHandleForTag, BindingSource } from './structs';
 
 type PageWaitForSelectorOptionsNotHidden = PageWaitForSelectorOptions & {
-  state: 'visible'|'attached';
+  state?: 'visible'|'attached';
 };
 type ElementHandleWaitForSelectorOptionsNotHidden = ElementHandleWaitForSelectorOptions & {
-  state: 'visible'|'attached';
+  state?: 'visible'|'attached';
 };
 
 /**

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -20,10 +20,10 @@ import { Readable } from 'stream';
 import { Serializable, EvaluationArgument, PageFunction, PageFunctionOn, SmartHandle, ElementHandleForTag, BindingSource } from './structs';
 
 type PageWaitForSelectorOptionsNotHidden = PageWaitForSelectorOptions & {
-  state: 'visible'|'attached';
+  state?: 'visible'|'attached';
 };
 type ElementHandleWaitForSelectorOptionsNotHidden = ElementHandleWaitForSelectorOptions & {
-  state: 'visible'|'attached';
+  state?: 'visible'|'attached';
 };
 
 export interface Page {

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -675,47 +675,58 @@ playwright.chromium.launch().then(async browser => {
     }
   }
 
+  type AssertCanBeNull<T> = null extends T ? true : false
+
   const frameLikes = [page, frame];
   for (const frameLike of frameLikes) {
     {
       const handle = await frameLike.waitForSelector('body');
+      const bodyAssertion: AssertType<playwright.ElementHandle<HTMLBodyElement>, typeof handle> = true;      
+      const canBeNull: AssertCanBeNull<typeof handle> = false     
+    }
+    {
+      const handle = await frameLike.waitForSelector('body', {timeout: 0});
       const bodyAssertion: AssertType<playwright.ElementHandle<HTMLBodyElement>, typeof handle> = true;
-      const canBeNull: AssertType<null, typeof handle> = false;
+      const canBeNull: AssertCanBeNull<typeof handle> = false;
     }
     {
       const state = Math.random() > .5 ? 'attached' : 'visible';
       const handle = await frameLike.waitForSelector('body', {state});
       const bodyAssertion: AssertType<playwright.ElementHandle<HTMLBodyElement>, typeof handle> = true;
-      const canBeNull: AssertType<null, typeof handle> = false;
+      const canBeNull: AssertCanBeNull<typeof handle> = false;
     }
     {
       const handle = await frameLike.waitForSelector('body', {state: 'hidden'});
       const bodyAssertion: AssertType<playwright.ElementHandle<HTMLBodyElement>, typeof handle> = true;
-      const canBeNull: AssertType<null, typeof handle> = true;
+      const canBeNull: AssertCanBeNull<typeof handle> = true;
     }
     {
       const state = Math.random() > .5 ? 'hidden' : 'visible';
       const handle = await frameLike.waitForSelector('body', {state});
       const bodyAssertion: AssertType<playwright.ElementHandle<HTMLBodyElement>, typeof handle> = true;
-      const canBeNull: AssertType<null, typeof handle> = true;
+      const canBeNull: AssertCanBeNull<typeof handle> = true;
     }
-
     {
       const handle = await frameLike.waitForSelector('something-strange');
       const elementAssertion: AssertType<playwright.ElementHandle<HTMLElement|SVGElement>, typeof handle> = true;
-      const canBeNull: AssertType<null, typeof handle> = false;
+      const canBeNull: AssertCanBeNull<typeof handle> = false;
     }
+    {
+      const handle = await frameLike.waitForSelector('something-strange', {timeout: 0});
+      const elementAssertion: AssertType<playwright.ElementHandle<HTMLElement|SVGElement>, typeof handle> = true;
+      const canBeNull: AssertCanBeNull<typeof handle> = false;      
+    }    
     {
       const state = Math.random() > .5 ? 'attached' : 'visible';
       const handle = await frameLike.waitForSelector('something-strange', {state});
       const elementAssertion: AssertType<playwright.ElementHandle<HTMLElement|SVGElement>, typeof handle> = true;
-      const canBeNull: AssertType<null, typeof handle> = false;
+      const canBeNull: AssertCanBeNull<typeof handle> = false;
     }
     {
       const state = Math.random() > .5 ? 'hidden' : 'visible';
       const handle = await frameLike.waitForSelector('something-strange', {state});
       const elementAssertion: AssertType<playwright.ElementHandle<HTMLElement|SVGElement>, typeof handle> = true;
-      const canBeNull: AssertType<null, typeof handle> = true;
+      const canBeNull: AssertCanBeNull<typeof handle> = true;
     }
   }
 


### PR DESCRIPTION
I found an issue with the `types.d.ts` file regarding `waitForSelector` when passing some options, but no state. When no `state` key is provided, the return type would include null. This is despite the default state value is `visible` and shouldn't allow `null`.

I discovered when doing something like below. The example shows passing no options gives the correct return type, but not when options are passed.
<img width="751" alt="Screen Shot 2021-04-27 at 7 08 06 PM" src="https://user-images.githubusercontent.com/7098/116327235-f2c19e00-a78b-11eb-9e85-a4662de6c23b.png">
<details>
  <summary>Source Code</summary>

```ts
  const el = await page.waitForSelector(tid('document-viewer'), {
    timeout: docLoadTimeout, // no state passed, should default to visible
  })
  await el.click() // Object is possible 'null'

  const elNoOptions = await page.waitForSelector(tid('document-viewer'))
  await elNoOptions.click()
```
</details>

I found the solution, added some tests, but I also fixed the `canBeNull` assertion because my new test case wouldn't fail the tests as they were (even though the types clearly included null, but the assertion was missing it.) Looking at some [code review comments this might have been the case for a while](https://github.com/microsoft/playwright/pull/1166#discussion_r391294546). If anyone has some insight, I'd love to hear it.

