### PR TITLE
fix: deal with delayed _nodeElectronHandle

### DIFF
--- a/src/dispatchers/electronDispatcher.ts
+++ b/src/dispatchers/electronDispatcher.ts
@@ -50,12 +50,12 @@ export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplicatio
   }
 
   async evaluateExpression(params: channels.ElectronApplicationEvaluateExpressionParams): Promise<channels.ElectronApplicationEvaluateExpressionResult> {
-    const handle = this._object._nodeElectronHandle!;
+    const handle = await this._object._nodeElectronHandlePromised;
     return { value: serializeResult(await handle.evaluateExpressionAndWaitForSignals(params.expression, params.isFunction, true /* returnByValue */, parseArgument(params.arg))) };
   }
 
   async evaluateExpressionHandle(params: channels.ElectronApplicationEvaluateExpressionHandleParams): Promise<channels.ElectronApplicationEvaluateExpressionHandleResult> {
-    const handle = this._object._nodeElectronHandle!;
+    const handle = await this._object._nodeElectronHandlePromised;
     const result = await handle.evaluateExpressionAndWaitForSignals(params.expression, params.isFunction, false /* returnByValue */, parseArgument(params.arg));
     return { handle: ElementHandleDispatcher.fromJSHandle(this._scope, result) };
   }


### PR DESCRIPTION
Since `process.mainModule.require('electron')` maybe be slow, we could possibly get undefined `_nodeElectronHandle`, so just treat it as a Promise.
![image](https://user-images.githubusercontent.com/7849435/116395126-4a2c4080-a856-11eb-964d-8cbdc1861f48.png)
