### PR TITLE
feat(actions): ensure we perform the action on the expected element

### DIFF
--- a/tests/page-click-timeout-4.spec.ts
+++ b/tests/page-click-timeout-4.spec.ts
@@ -29,3 +29,19 @@ it('should timeout waiting for stable position', async ({page, server}) => {
   expect(error.message).toContain('waiting for element to be visible, enabled and stable');
   expect(error.message).toContain('element is not stable - waiting');
 });
+
+it('should click for the second time after first timeout', async ({page, server, mode}) => {
+  it.skip(mode !== 'default');
+
+  await page.goto(server.PREFIX + '/input/button.html');
+  const __testHookBeforePointerAction = () => new Promise(f => setTimeout(f, 2000));
+  const error = await page.click('button', { timeout: 1000, __testHookBeforePointerAction } as any).catch(e => e);
+  expect(error.message).toContain('page.click: Timeout 1000ms exceeded.');
+
+  expect(await page.evaluate('result')).toBe('Was not clicked');
+  await page.waitForTimeout(2000);
+  expect(await page.evaluate('result')).toBe('Was not clicked');
+
+  await page.click('button');
+  expect(await page.evaluate('result')).toBe('Clicked');
+});

--- a/tests/page-click.spec.ts
+++ b/tests/page-click.spec.ts
@@ -780,3 +780,80 @@ it('should click zero-sized input by label', async ({page}) => {
   await page.click('text=Click me');
   expect(await page.evaluate('window.__clicked')).toBe(true);
 });
+
+it('should block all events when hit target is wrong', async ({page, server}) => {
+  await page.goto(server.PREFIX + '/input/button.html');
+  await page.evaluate(() => {
+    const blocker = document.createElement('div');
+    blocker.style.position = 'absolute';
+    blocker.style.width = '400px';
+    blocker.style.height = '400px';
+    blocker.style.left = '0';
+    blocker.style.top = '0';
+    document.body.appendChild(blocker);
+
+    const allEvents = [];
+    (window as any).allEvents = allEvents;
+    for (const name of ['mousedown', 'mouseup', 'click', 'dblclick', 'auxclick', 'contextmenu', 'pointerdown', 'pointerup']) {
+      window.addEventListener(name, e => allEvents.push(e.type));
+      blocker.addEventListener(name, e => allEvents.push(e.type));
+    }
+  });
+
+  const error = await page.click('button', { timeout: 1000 }).catch(e => e);
+  expect(error.message).toContain('page.click: Timeout 1000ms exceeded.');
+
+  // Give it some time, just in case.
+  await page.waitForTimeout(1000);
+  const allEvents = await page.evaluate(() => (window as any).allEvents);
+  expect(allEvents).toEqual([]);
+});
+
+it('should block click when mousedown succeeds but mouseup fails', async ({page, server}) => {
+  await page.goto(server.PREFIX + '/input/button.html');
+  await page.$eval('button', button => {
+    button.addEventListener('mousedown', () => {
+      button.style.marginLeft = '100px';
+    });
+
+    const allEvents = [];
+    (window as any).allEvents = allEvents;
+    for (const name of ['mousedown', 'mouseup', 'click', 'dblclick', 'auxclick', 'contextmenu', 'pointerdown', 'pointerup'])
+      button.addEventListener(name, e => allEvents.push(e.type));
+  });
+
+  await page.click('button');
+  expect(await page.evaluate('result')).toBe('Clicked');
+  const allEvents = await page.evaluate(() => (window as any).allEvents);
+  expect(allEvents).toEqual([
+    // First attempt failed.
+    'pointerdown', 'mousedown',
+    // Second attempt succeeded.
+    'pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click',
+  ]);
+});
+
+it('should not block programmatic events', async ({page, server}) => {
+  await page.goto(server.PREFIX + '/input/button.html');
+  await page.$eval('button', button => {
+    button.addEventListener('mousedown', () => {
+      button.style.marginLeft = '100px';
+      button.dispatchEvent(new MouseEvent('click'));
+    });
+
+    const allEvents = [];
+    (window as any).allEvents = allEvents;
+    button.addEventListener('click', e => {
+      if (!e.isTrusted)
+        allEvents.push(e.type);
+    });
+  });
+
+  await page.click('button');
+  expect(await page.evaluate('result')).toBe('Clicked');
+  const allEvents = await page.evaluate(() => (window as any).allEvents);
+  // We should get one programmatic click on each attempt.
+  expect(allEvents).toEqual([
+    'click', 'click',
+  ]);
+});

--- a/tests/page-mouse.spec.ts
+++ b/tests/page-mouse.spec.ts
@@ -111,7 +111,7 @@ it('should trigger hover state', async ({page, server}) => {
 it('should trigger hover state on disabled button', async ({page, server}) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
   await page.$eval('#button-6', (button: HTMLButtonElement) => button.disabled = true);
-  await page.hover('#button-6', { timeout: 5000 });
+  await page.hover('#button-6', { timeout: 2000 });
   expect(await page.evaluate(() => document.querySelector('button:hover').id)).toBe('button-6');
 });
 

--- a/tests/tap.spec.ts
+++ b/tests/tap.spec.ts
@@ -58,7 +58,7 @@ it('trial run should not tap', async ({}) => {
   await page.tap('#a');
   const eventsHandle = await trackEvents(await page.$('#b'));
   await page.tap('#b', { trial: true });
-  expect(await eventsHandle.jsonValue()).toEqual([]);
+  expect(await eventsHandle.jsonValue()).toEqual(['pointerover', 'pointerenter', 'pointerout', 'pointerleave']);
 });
 
 it('should not send mouse events touchstart is canceled', async ({}) => {


### PR DESCRIPTION
This changes previous `checkHitTarget` heurisitc that took place before the action, to `setupHitTargetInterceptor` that works during the action:
- Before the action we set up capturing listeners on the window.
- During the action we ensure that event target is the element we expect to interact with.
- After the action we clear the listeners.

This should catch the "layout shift" issues where things move between action point calculation and the actual action.

Possible issues:
- **Risk:** All events will be visible to the capturing listener on the `Window` object that was added before the click. The immediate mitigation with `addInitScript` and adding a listener once does not work because `document.open()` resets listeners on `window` object.
- **Risk:** `{ trial: true }` might dispatch move events like `mousemove` or `pointerout`, because we do actually move the mouse but prevent all other events.
- **Timing**: The timing of "hit target check" has moved, so this may affect different web pages in different ways, for example expose more races. In this case, we should retry the click as before.
- **No risk**: There is still a possibility of mistargeting with iframes shifting around, because we only intercept in the target frame. This behavior does not change.
