### PR TITLE
fix: break require cycle

### DIFF
--- a/src/server/supplements/recorder/recorderApp.ts
+++ b/src/server/supplements/recorder/recorderApp.ts
@@ -20,7 +20,6 @@ import * as util from 'util';
 import { CRPage } from '../../chromium/crPage';
 import { Page } from '../../page';
 import { ProgressController } from '../../progress';
-import { createPlaywright } from '../../playwright';
 import { EventEmitter } from 'events';
 import { internalCallMetadata } from '../../instrumentation';
 import type { CallLog, EventData, Mode, Source } from './recorderTypes';
@@ -95,7 +94,7 @@ export class RecorderApp extends EventEmitter {
   }
 
   static async open(inspectedContext: BrowserContext): Promise<RecorderApp> {
-    const recorderPlaywright = createPlaywright(true);
+    const recorderPlaywright = require('../../playwright').createPlaywright() as import('../../playwright').Playwright;
     const args = [
       '--app=data:text/html,',
       '--window-size=600,600',


### PR DESCRIPTION
We have `CRBrowserContext` that extends `BrowserContext`, and
it sometimes fails beacause `BrowserContext` is undefined, depending
on the require order. Below is the require cycle.

```log
server/browserContext.ts
server/supplements/recorderSupplement.ts
server/supplements/recorder/recorderApp.ts
server/playwright.ts
server/android/android.ts
server/chromium/crBrowser.ts
server/browserContext.ts
```

Fixing this by using `require`.