### PR TITLE
browser(firefox): don't record video outside the viewport

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1251
-Changed: lushnikov@chromium.org Mon 03 May 2021 05:04:07 PM PDT
+1252
+Changed: joel.einbinder@gmail.com Tue 04 May 2021 02:47:58 AM PDT

--- a/browser_patches/firefox/juggler/TargetRegistry.js
+++ b/browser_patches/firefox/juggler/TargetRegistry.js
@@ -504,7 +504,8 @@ class PageTarget {
     // Exclude address bar and navigation control from the video.
     const rect = this.linkedBrowser().getBoundingClientRect();
     const devicePixelRatio = this._window.devicePixelRatio;
-    const videoSessionId = screencast.startVideoRecording(docShell, file, width, height, scale || 0, devicePixelRatio * rect.top);
+    const viewport = this._viewportSize || this._browserContext.defaultViewportSize || {width: 0, height: 0};
+    const videoSessionId = screencast.startVideoRecording(docShell, file, width, height, viewport.width, viewport.height, scale || 0, devicePixelRatio * rect.top);
     this._screencastInfo = { videoSessionId, file };
     this.emit(PageTarget.Events.ScreencastStarted);
   }

--- a/browser_patches/firefox/juggler/screencast/nsIScreencastService.idl
+++ b/browser_patches/firefox/juggler/screencast/nsIScreencastService.idl
@@ -12,7 +12,7 @@ interface nsIDocShell;
 [scriptable, uuid(d8c4d9e0-9462-445e-9e43-68d3872ad1de)]
 interface nsIScreencastService : nsISupports
 {
-  AString startVideoRecording(in nsIDocShell docShell, in ACString fileName, in uint32_t width, in uint32_t height, in double scale, in int32_t offset_top);
+  AString startVideoRecording(in nsIDocShell docShell, in ACString fileName, in uint32_t width, in uint32_t height, in uint32_t viewportWidth, in uint32_t viewportHeight, in double scale, in int32_t offset_top);
 
   /**
    * Will emit 'juggler-screencast-stopped' when the video file is saved.

--- a/browser_patches/firefox/juggler/screencast/nsScreencastService.cpp
+++ b/browser_patches/firefox/juggler/screencast/nsScreencastService.cpp
@@ -140,7 +140,7 @@ nsScreencastService::nsScreencastService() = default;
 nsScreencastService::~nsScreencastService() {
 }
 
-nsresult nsScreencastService::StartVideoRecording(nsIDocShell* aDocShell, const nsACString& aFileName, uint32_t width, uint32_t height, double scale, int32_t offsetTop, nsAString& sessionId) {
+nsresult nsScreencastService::StartVideoRecording(nsIDocShell* aDocShell, const nsACString& aFileName, uint32_t width, uint32_t height, uint32_t viewportWidth, uint32_t viewportHeight, double scale, int32_t offsetTop, nsAString& sessionId) {
   MOZ_RELEASE_ASSERT(NS_IsMainThread(), "Screencast service must be started on the Main thread.");
 
   PresShell* presShell = aDocShell->GetPresShell();
@@ -164,15 +164,13 @@ nsresult nsScreencastService::StartVideoRecording(nsIDocShell* aDocShell, const 
     maybeScale = Some(scale);
 
   gfx::IntMargin margin;
-  // On GTK the bottom of the client rect is below the bounds and
-  // client size is actually equal to the size of the bounds so
-  // we don't need an adjustment.
-#ifndef MOZ_WIDGET_GTK
   auto bounds = widget->GetScreenBounds().ToUnknownRect();
   auto clientBounds = widget->GetClientBounds().ToUnknownRect();
+  // The browser window has a minimum size, so it might be larger than the viewport size.
+  clientBounds.width = std::min((int)viewportWidth, clientBounds.width);
+  clientBounds.height = std::min((int)viewportHeight, clientBounds.height);
   // Crop the image to exclude frame (if any).
   margin = bounds - clientBounds;
-#endif
   // Crop the image to exclude controls.
   margin.top += offsetTop;
 


### PR DESCRIPTION
The browser window has a min width of 450px. If the viewport was smaller than that, the video would try to capture outside the viewport. Passes the test in #6346 on linux. I have not tested on other operating systems yet.