### PR TITLE
devops: introduce Google Chrome Beta testers

### DIFF
--- a/.github/workflows/tests_chrome_beta.yml
+++ b/.github/workflows/tests_chrome_beta.yml
@@ -1,0 +1,103 @@
+name: tests Chrome Beta
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request:
+    branches:
+      - master
+      - release-*
+
+env:
+  # Force terminal colors. @see https://www.npmjs.com/package/colors
+  FORCE_COLOR: 1
+  FLAKINESS_CONNECTION_STRING: ${{ secrets.FLAKINESS_CONNECTION_STRING }}
+
+jobs:
+  chrome_beta_linux:
+    name: "Chrome Beta (Linux)"
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - run: ./utils/install-chrome-beta/reinstall_linux.sh
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 12
+    - run: npm ci
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+    - run: npm run build
+    - run: node lib/cli/cli install-deps chromium
+    - run: node lib/cli/cli install ffmpeg
+    # XVFB-RUN merges both STDOUT and STDERR, whereas we need only STDERR
+    # Wrap `npm run` in a subshell to redirect STDERR to file.
+    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash -c "npm run ctest"
+      env:
+        PWTEST_CHANNEL: "chrome-beta"
+    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+      if: always()
+    - uses: actions/upload-artifact@v1
+      if: ${{ always() }}
+      with:
+        name: chrome-beta-linux-test-results
+        path: test-results
+
+  chrome_beta_win:
+    name: "Chrome Beta (Win)"
+    runs-on: windows-latest
+    steps:
+    - name: Install Media Pack
+      shell: powershell
+      run: Install-WindowsFeature Server-Media-Foundation
+    - name: Install Chrome Beta
+      shell: powershell
+      run: choco install -y googlechromebeta --pre --force
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 12
+    - run: npm ci
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+    - run: npm run build
+    - run: node lib/cli/cli install ffmpeg
+    - run: npm run ctest
+      shell: bash
+      env:
+        PWTEST_CHANNEL: "chrome-beta"
+    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+      if: always()
+      shell: bash
+    - uses: actions/upload-artifact@v1
+      if: ${{ always() }}
+      with:
+        name: chrome-beta-win-test-results
+        path: test-results
+
+  chrome_beta_mac:
+    name: "Chrome Beta (Mac)"
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v2
+    - run: ./utils/install-chrome-beta/reinstall_mac.sh
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 12
+    - run: npm ci
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+    - run: npm run build
+    - run: node lib/cli/cli install ffmpeg
+    - run: npm run ctest
+      env:
+        PWTEST_CHANNEL: "chrome-beta"
+    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+      if: always()
+    - uses: actions/upload-artifact@v1
+      if: ${{ always() }}
+      with:
+        name: chrome-beta-mac-test-results
+        path: test-results
+

--- a/utils/install-chrome-beta/reinstall_linux.sh
+++ b/utils/install-chrome-beta/reinstall_linux.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+set -x
+
+# 1. make sure to remove old beta if any.
+if sudo dpkg -S google-chrome-beta &>/dev/null; then
+  sudo apt-get remove -y google-chrome-beta
+fi
+
+# 2. download chrome beta from dl.google.com and install it.
+cd /tmp
+wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
+sudo apt-get install -y ./google-chrome-beta_current_amd64.deb
+rm -rf ./google-chrome-beta_current_amd64.deb
+cd -

--- a/utils/install-chrome-beta/reinstall_mac.sh
+++ b/utils/install-chrome-beta/reinstall_mac.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+set -x
+
+rm -rf "/Applications/Google Chrome Beta.app"
+cd /tmp
+curl -o ./googlechromebeta.dmg -k https://dl.google.com/chrome/mac/beta/googlechromebeta.dmg
+hdiutil attach -nobrowse -quiet -noautofsck -noautoopen -mountpoint /Volumes/googlechromebeta.dmg ./googlechromebeta.dmg
+cp -rf "/Volumes/googlechromebeta.dmg/Google Chrome Beta.app" /Applications
+hdiutil detach /Volumes/googlechromebeta.dmg


### PR DESCRIPTION
- Mac & Linux: manually downloading Chrome installer
- WIndows: using Chocolatey to install `googlechromebeta`
