### PR TITLE
chore(dotnet): split unions into multiple overloads

### DIFF
--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -548,7 +548,8 @@ function renderMethod(member, parent, output, name) {
 
       let argDocumentation = XmlDoc.renderTextOnly(arg.spec, maxDocumentationColumnWidth);
       for (const newArg of translatedArguments) {
-        const sanitizedArgName = newArg.match(/(?<=^[\s"']*)(\w+)/g, '')[0] || newArg;
+        let nonGenericType = newArg.replace(/\IEnumerable<(.*)\>/g, (m, v) => 'Enumerable' + v[0].toUpperCase() + v.substring(1))
+        const sanitizedArgName = nonGenericType.match(/(?<=^[\s"']*)(\w+)/g, '')[0] || nonGenericType;
         const newArgName = `${argName}${sanitizedArgName[0].toUpperCase() + sanitizedArgName.substring(1)}`;
         pushArg(newArg, newArgName, arg, true); // push the exploded arg
         addParamsDoc(newArgName, argDocumentation);
@@ -709,9 +710,7 @@ function translateType(type, parent, generateNameCallback = t => t.name) {
     } else if (type.union.length == 2 && type.union[1].name === 'Array' && type.union[1].templates[0].name === type.union[0].name)
       return `IEnumerable<${type.union[0].name}>`; // an example of this is [string]|[Array]<[string]>
     else if (type.union[0].name === 'path')
-      // we don't support path, but we know it's usually an object on the other end, and we expect
-      // the dotnet folks to use [NameOfTheObject].LoadFromPath(); method which we can provide separately
-      return translateType(type.union[1], parent, generateNameCallback);
+      return null;
     else if (type.expression === '[float]|"raf"')
       return `Polling`; // hardcoded because there's no other way to denote this
 


### PR DESCRIPTION
Splits union arguments into overloads and hides the main function. It keeps the "renamed" argument and also adds the relevant documentation;

Here's an example of `RouteAsync`:

```csharp
/// <summary>
/// <para>
/// Routing provides the capability to modify network requests that are made by any
/// page in the browser context. Once route is enabled, every request matching the url
/// pattern will stall unless it's continued, fulfilled or aborted.
/// </para>
/// <para>An example of a naive handler that aborts all image requests:</para>
/// <para>or the same snippet using a regex pattern instead:</para>
/// <para>
/// It is possible to examine the request to decide the route action. For example, mocking
/// all requests that contain some post data, and leaving all other requests as is:
/// </para>
/// <para>
/// Page routes (set up with <see cref="IPage.RouteAsync"/>) take precedence over browser
/// context routes when request matches both handlers.
/// </para>
/// <para>To remove a route with its handler you can use <see cref="IBrowserContext.UnrouteAsync"/>.</para>
/// </summary>
/// <remarks><para>Enabling routing disables http cache.</para></remarks>
/// <param name="urlString">
/// A glob pattern, regex pattern or predicate receiving <see cref="URL"/> to match
/// while routing.
/// </param>
/// <param name="handler">handler function to route the request.</param>
Task RouteAsync(string urlString, Action<IRoute> handler);

/// <summary>
/// <para>
/// Routing provides the capability to modify network requests that are made by any
/// page in the browser context. Once route is enabled, every request matching the url
/// pattern will stall unless it's continued, fulfilled or aborted.
/// </para>
/// <para>An example of a naive handler that aborts all image requests:</para>
/// <para>or the same snippet using a regex pattern instead:</para>
/// <para>
/// It is possible to examine the request to decide the route action. For example, mocking
/// all requests that contain some post data, and leaving all other requests as is:
/// </para>
/// <para>
/// Page routes (set up with <see cref="IPage.RouteAsync"/>) take precedence over browser
/// context routes when request matches both handlers.
/// </para>
/// <para>To remove a route with its handler you can use <see cref="IBrowserContext.UnrouteAsync"/>.</para>
/// </summary>
/// <remarks><para>Enabling routing disables http cache.</para></remarks>
/// <param name="urlRegex">
/// A glob pattern, regex pattern or predicate receiving <see cref="URL"/> to match
/// while routing.
/// </param>
/// <param name="handler">handler function to route the request.</param>
Task RouteAsync(Regex urlRegex, Action<IRoute> handler);

/// <summary>
/// <para>
/// Routing provides the capability to modify network requests that are made by any
/// page in the browser context. Once route is enabled, every request matching the url
/// pattern will stall unless it's continued, fulfilled or aborted.
/// </para>
/// <para>An example of a naive handler that aborts all image requests:</para>
/// <para>or the same snippet using a regex pattern instead:</para>
/// <para>
/// It is possible to examine the request to decide the route action. For example, mocking
/// all requests that contain some post data, and leaving all other requests as is:
/// </para>
/// <para>
/// Page routes (set up with <see cref="IPage.RouteAsync"/>) take precedence over browser
/// context routes when request matches both handlers.
/// </para>
/// <para>To remove a route with its handler you can use <see cref="IBrowserContext.UnrouteAsync"/>.</para>
/// </summary>
/// <remarks><para>Enabling routing disables http cache.</para></remarks>
/// <param name="urlFunc">
/// A glob pattern, regex pattern or predicate receiving <see cref="URL"/> to match
/// while routing.
/// </param>
/// <param name="handler">handler function to route the request.</param>
Task RouteAsync(Func<string, bool> urlFunc, Action<IRoute> handler);
```