### PR TITLE
docs(page): opener is not async anymore

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1759,7 +1759,7 @@ The page's main frame. Page is guaranteed to have a main frame which persists du
 ## property: Page.mouse
 - type: <[Mouse]>
 
-## async method: Page.opener
+## method: Page.opener
 - returns: <[null]|[Page]>
 
 Returns the opener for popup pages and `null` for others. If the opener has been closed already the returns `null`.

--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -220,7 +220,7 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     return this._browserContext;
   }
 
-  async opener(): Promise<Page | null> {
+  opener(): Page | null {
     if (!this._opener || this._opener.isClosed())
       return null;
     return this._opener;

--- a/tests/browsercontext-page-event.spec.ts
+++ b/tests/browsercontext-page-event.spec.ts
@@ -135,8 +135,8 @@ it('should have an opener', async ({browser, server}) => {
     page.goto(server.PREFIX + '/popup/window-open.html')
   ]);
   expect(popup.url()).toBe(server.PREFIX + '/popup/popup.html');
-  expect(await popup.opener()).toBe(page);
-  expect(await page.opener()).toBe(null);
+  expect(popup.opener()).toBe(page);
+  expect(page.opener()).toBe(null);
   await context.close();
 });
 
@@ -168,7 +168,7 @@ it('should work with Shift-clicking', async ({browser, server, browserName}) => 
     context.waitForEvent('page'),
     page.click('a', { modifiers: ['Shift'] }),
   ]);
-  expect(await popup.opener()).toBe(null);
+  expect(popup.opener()).toBe(null);
   await context.close();
 });
 
@@ -184,6 +184,6 @@ it('should work with Ctrl-clicking', async ({browser, server, isMac, browserName
     context.waitForEvent('page'),
     page.click('a', { modifiers: [ isMac ? 'Meta' : 'Control'] }),
   ]);
-  expect(await popup.opener()).toBe(null);
+  expect(popup.opener()).toBe(null);
   await context.close();
 });

--- a/tests/page-basic.spec.ts
+++ b/tests/page-basic.spec.ts
@@ -85,7 +85,7 @@ it('should provide access to the opener page', async ({page}) => {
     page.waitForEvent('popup'),
     page.evaluate(() => window.open('about:blank')),
   ]);
-  const opener = await popup.opener();
+  const opener = popup.opener();
   expect(opener).toBe(page);
 });
 
@@ -95,7 +95,7 @@ it('should return null if parent page has been closed', async ({page}) => {
     page.evaluate(() => window.open('about:blank')),
   ]);
   await page.close();
-  const opener = await popup.opener();
+  const opener = popup.opener();
   expect(opener).toBe(null);
 });
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -2121,7 +2121,7 @@ export interface Page {
   /**
    * Returns the opener for popup pages and `null` for others. If the opener has been closed already the returns `null`.
    */
-  opener(): Promise<null|Page>;
+  opener(): null|Page;
 
   /**
    * Pauses script execution. Playwright will stop executing the script and wait for the user to either press 'Resume' button


### PR DESCRIPTION
I know you might consider this a breaking change. But `opener` is not `async` anymore.
I don't know if we want to make this change now, or leave it as it is and, create async wrappers in the .NET binding.