### PR TITLE
devops: re-use firefox checkout for firefox-stable

### DIFF
--- a/browser_patches/export.sh
+++ b/browser_patches/export.sh
@@ -53,9 +53,11 @@ if [[ ("$1" == "firefox") || ("$1" == "firefox/") || ("$1" == "ff") ]]; then
     CHECKOUT_PATH="${FF_CHECKOUT_PATH}"
     FRIENDLY_CHECKOUT_PATH="<FF_CHECKOUT_PATH>"
   fi
-elif [[ ("$1" == "firefox-stable") ]]; then
-  FRIENDLY_CHECKOUT_PATH="//browser_patches/firefox-stable/checkout";
-  CHECKOUT_PATH="$PWD/firefox-stable/checkout"
+elif [[ ("$1" == "firefox-stable") || ("$1" == "ff-stable") ]]; then
+  # NOTE: firefox-stable re-uses firefox checkout.
+  FRIENDLY_CHECKOUT_PATH="//browser_patches/firefox/checkout";
+  CHECKOUT_PATH="$PWD/firefox/checkout"
+
   EXTRA_FOLDER_PW_PATH="$PWD/firefox-stable/juggler"
   EXTRA_FOLDER_CHECKOUT_RELPATH="juggler"
   EXPORT_PATH="$PWD/firefox-stable"

--- a/browser_patches/firefox-stable/archive.sh
+++ b/browser_patches/firefox-stable/archive.sh
@@ -36,7 +36,7 @@ if [[ ! -z "${FF_CHECKOUT_PATH}" ]]; then
   cd "${FF_CHECKOUT_PATH}"
   echo "WARNING: checkout path from FF_CHECKOUT_PATH env: ${FF_CHECKOUT_PATH}"
 else
-  cd "checkout"
+  cd "../firefox/checkout"
 fi
 
 OBJ_FOLDER="obj-build-playwright"

--- a/browser_patches/firefox-stable/build.sh
+++ b/browser_patches/firefox-stable/build.sh
@@ -18,7 +18,7 @@ if [[ ! -z "${FF_CHECKOUT_PATH}" ]]; then
   cd "${FF_CHECKOUT_PATH}"
   echo "WARNING: checkout path from FF_CHECKOUT_PATH env: ${FF_CHECKOUT_PATH}"
 else
-  cd "checkout"
+  cd "../firefox/checkout"
 fi
 
 rm -rf .mozconfig

--- a/browser_patches/firefox-stable/clean.sh
+++ b/browser_patches/firefox-stable/clean.sh
@@ -8,7 +8,7 @@ if [[ ! -z "${FF_CHECKOUT_PATH}" ]]; then
   echo "WARNING: checkout path from FF_CHECKOUT_PATH env: ${FF_CHECKOUT_PATH}"
 else
   cd "$(dirname $0)"
-  cd "checkout"
+  cd "../firefox/checkout"
 fi
 
 OBJ_FOLDER="obj-build-playwright"

--- a/browser_patches/prepare_checkout.sh
+++ b/browser_patches/prepare_checkout.sh
@@ -93,9 +93,11 @@ elif [[ ("$1" == "firefox") || ("$1" == "firefox/") || ("$1" == "ff") ]]; then
     CHECKOUT_PATH="${FF_CHECKOUT_PATH}"
     FRIENDLY_CHECKOUT_PATH="<FF_CHECKOUT_PATH>"
   fi
-elif [[ ("$1" == "firefox-stable") ]]; then
-  FRIENDLY_CHECKOUT_PATH="//browser_patches/firefox-stable/checkout";
-  CHECKOUT_PATH="$PWD/firefox-stable/checkout"
+elif [[ ("$1" == "firefox-stable") || ("$1" == "ff-stable") ]]; then
+  # NOTE: firefox-stable re-uses firefox checkout.
+  FRIENDLY_CHECKOUT_PATH="//browser_patches/firefox/checkout";
+  CHECKOUT_PATH="$PWD/firefox/checkout"
+
   PATCHES_PATH="$PWD/firefox-stable/patches"
   FIREFOX_EXTRA_FOLDER_PATH="$PWD/firefox-stable/juggler"
   BUILD_NUMBER=$(head -1 "$PWD/firefox-stable/BUILD_NUMBER")
@@ -236,7 +238,7 @@ elif [[ ! -z "${FIREFOX_EXTRA_FOLDER_PATH}" ]]; then
   git add $EMBEDDER_DIR
 fi
 
-git commit -a --author="playwright-devops <devops@playwright.dev>" -m "chore: bootstrap build #$BUILD_NUMBER"
+git commit -a --author="playwright-devops <devops@playwright.dev>" -m "chore($1): bootstrap build #$BUILD_NUMBER"
 
 echo
 echo


### PR DESCRIPTION
Every patch to Firefox should also go to firefox-stable. This patch
starts re-using Firefox-beta checkout for firefox-stable, making
possible to easily rebaseline work atop of firefox-stable.

With this patch, working on a patch in Firefox is a 2-step
process:
1. work on a patch against Firefox-Beta
2. rebaseline your work atop of Firefox-Stable

Working on Firefox-Beta is as usual:
- setup an up-to-date firefox checkout:
  ```sh
  $ ./browser_patches/prepare_checkout.sh firefox
  ```
- create a new branch for your firefox work off `playwright-build`:
  ```sh
  $ cd ./browser_patches/firefox/checkout
  $ git checkout -b my-feature
  ```
- once work is done, export your branch:
  ```sh
  $ ./browser_patches/export.sh firefox
  ```

Rebaselining your work for Firefox-Stable takes advantage of a single
checkout:
- prepare a firefox-stable checkout:
  ```sh
  $ ./browser_patches/prepare_checkout.sh ff-stable
  ```
- rebaseline your feature branch atop of stable:
  ```sh
  $ cd ./browser_patches/firefox/checkout
  $ git checkout my-feature
  $ git rebase -i playwright-build
  ```
- make sure firefox-stable compiles:
  ```sh
  $ ./browser_patches/firefox-stable/build.sh
  ```
- export firefox-stable:
  ```sh
  $ ./browser_patches/export.sh ff-stable
  ```