### PR TITLE
feat(types): export ScreenshotOptions

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -2418,7 +2418,7 @@ export interface Page {
    * Returns the buffer with the captured screenshot.
    * @param options
    */
-  screenshot(options?: ScreenshotOptions): Promise<Buffer>;
+  screenshot(options?: PageScreenshotOptions): Promise<Buffer>;
 
   /**
    * This method waits for an element matching `selector`, waits for [actionability](https://playwright.dev/docs/actionability) checks, waits until
@@ -11319,7 +11319,7 @@ interface PageWaitForFunctionOptions {
   timeout?: number;
 }
 
-export interface ScreenshotOptions {
+export interface PageScreenshotOptions {
   /**
    * An object which specifies clipping of the resulting image. Should have the following fields:
    */

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -2418,69 +2418,7 @@ export interface Page {
    * Returns the buffer with the captured screenshot.
    * @param options
    */
-  screenshot(options?: {
-    /**
-     * An object which specifies clipping of the resulting image. Should have the following fields:
-     */
-    clip?: {
-      /**
-       * x-coordinate of top-left corner of clip area
-       */
-      x: number;
-
-      /**
-       * y-coordinate of top-left corner of clip area
-       */
-      y: number;
-
-      /**
-       * width of clipping area
-       */
-      width: number;
-
-      /**
-       * height of clipping area
-       */
-      height: number;
-    };
-
-    /**
-     * When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to
-     * `false`.
-     */
-    fullPage?: boolean;
-
-    /**
-     * Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
-     * Defaults to `false`.
-     */
-    omitBackground?: boolean;
-
-    /**
-     * The file path to save the image to. The screenshot type will be inferred from file extension. If `path` is a relative
-     * path, then it is resolved relative to the current working directory. If no path is provided, the image won't be saved to
-     * the disk.
-     */
-    path?: string;
-
-    /**
-     * The quality of the image, between 0-100. Not applicable to `png` images.
-     */
-    quality?: number;
-
-    /**
-     * Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by
-     * using the
-     * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browsercontextsetdefaulttimeouttimeout)
-     * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#pagesetdefaulttimeouttimeout) methods.
-     */
-    timeout?: number;
-
-    /**
-     * Specify screenshot type, defaults to `png`.
-     */
-    type?: "png"|"jpeg";
-  }): Promise<Buffer>;
+  screenshot(options?: ScreenshotOptions): Promise<Buffer>;
 
   /**
    * This method waits for an element matching `selector`, waits for [actionability](https://playwright.dev/docs/actionability) checks, waits until
@@ -11379,6 +11317,70 @@ interface PageWaitForFunctionOptions {
    * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browsercontextsetdefaulttimeouttimeout).
    */
   timeout?: number;
+}
+
+export interface ScreenshotOptions {
+  /**
+   * An object which specifies clipping of the resulting image. Should have the following fields:
+   */
+  clip?: {
+    /**
+     * x-coordinate of top-left corner of clip area
+     */
+    x: number;
+
+    /**
+     * y-coordinate of top-left corner of clip area
+     */
+    y: number;
+
+    /**
+     * width of clipping area
+     */
+    width: number;
+
+    /**
+     * height of clipping area
+     */
+    height: number;
+  };
+
+  /**
+   * When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to
+   * `false`.
+   */
+  fullPage?: boolean;
+
+  /**
+   * Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
+   * Defaults to `false`.
+   */
+  omitBackground?: boolean;
+
+  /**
+   * The file path to save the image to. The screenshot type will be inferred from file extension. If `path` is a relative
+   * path, then it is resolved relative to the current working directory. If no path is provided, the image won't be saved to
+   * the disk.
+   */
+  path?: string;
+
+  /**
+   * The quality of the image, between 0-100. Not applicable to `png` images.
+   */
+  quality?: number;
+
+  /**
+   * Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by
+   * using the
+   * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browsercontextsetdefaulttimeouttimeout)
+   * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#pagesetdefaulttimeouttimeout) methods.
+   */
+  timeout?: number;
+
+  /**
+   * Specify screenshot type, defaults to `png`.
+   */
+  type?: "png"|"jpeg";
 }
 
 type Devices = {

--- a/utils/generate_types/exported.json
+++ b/utils/generate_types/exported.json
@@ -6,5 +6,6 @@
   "BrowserNewContextOptions": "BrowserContextOptions",
   "BrowserNewContextOptionsViewport": "ViewportSize",
   "BrowserNewContextOptionsGeolocation": "Geolocation",
-  "BrowserNewContextOptionsHttpCredentials": "HTTPCredentials"
+  "BrowserNewContextOptionsHttpCredentials": "HTTPCredentials",
+  "PageScreenshotOptions": "ScreenshotOptions",
 }

--- a/utils/generate_types/exported.json
+++ b/utils/generate_types/exported.json
@@ -7,5 +7,5 @@
   "BrowserNewContextOptionsViewport": "ViewportSize",
   "BrowserNewContextOptionsGeolocation": "Geolocation",
   "BrowserNewContextOptionsHttpCredentials": "HTTPCredentials",
-  "PageScreenshotOptions": "ScreenshotOptions",
+  "PageScreenshotOptions": "PageScreenshotOptions"
 }


### PR DESCRIPTION
Exports `ScreenshotOptions` as a new type. Screenshots have a fairly complicated set of options, and they are likely to be exposed by libraries that wrap Playwright.

fixes #4752
