### PR TITLE
test: fixed flaky connectOverCDP tests

### DIFF
--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -186,7 +186,8 @@ export abstract class BrowserType extends SdkObject {
       await validateHostRequirements(this._registry, options.channel as registry.BrowserName);
 
     let wsEndpointCallback: ((wsEndpoint: string) => void) | undefined;
-    const wsEndpoint = options.useWebSocket ? new Promise<string>(f => wsEndpointCallback = f) : undefined;
+    const shouldWaitForWSListening = options.useWebSocket || options.args?.some(a => a.startsWith('--remote-debugging-port'));
+    const waitForWSEndpoint = shouldWaitForWSListening ? new Promise<string>(f => wsEndpointCallback = f) : undefined;
     // Note: it is important to define these variables before launchProcess, so that we don't get
     // "Cannot access 'browserServer' before initialization" if something went wrong.
     let transport: ConnectionTransport | undefined = undefined;
@@ -242,8 +243,11 @@ export abstract class BrowserType extends SdkObject {
       kill
     };
     progress.cleanupWhenAborted(() => closeOrKill(progress.timeUntilDeadline()));
+    let wsEndpoint: string | undefined;
+    if (shouldWaitForWSListening)
+      wsEndpoint = await waitForWSEndpoint;
     if (options.useWebSocket) {
-      transport = await WebSocketTransport.connect(progress, await wsEndpoint!);
+      transport = await WebSocketTransport.connect(progress, wsEndpoint!);
     } else {
       const stdio = launchedProcess.stdio as unknown as [NodeJS.ReadableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.ReadableStream];
       transport = new PipeTransport(stdio[3], stdio[4]);


### PR DESCRIPTION
Currently in some places we are using `BrowserType.launch` to launch a Chromium browser with the `--remote-debugging-port=` argument. Chromium internally takes a bit to expose the WebSocket server. This resulted on Windows to flaky tests.

~q: I thought about when `remote-debugging-port` is passed as an argument, should we use actually this WebSocket connection for Playwright or stick with the pipe transport?~
~q: We could also probably fix it in the tests by passing in the few places `useWebSocket: true` but I think its better to auto-wait internally.~

See: https://devops.aslushnikov.com/flakiness2.html#filter_spec=should+connect+to&commits=50&browser=chromium&platform=Windows