### PR TITLE
devops: use chromium's FILES.cfg to compute archive files

### DIFF
--- a/browser_patches/chromium/archive.sh
+++ b/browser_patches/chromium/archive.sh
@@ -57,61 +57,14 @@ function archive_compiled_chromium() {
     CHROMIUM_FILES_TO_ARCHIVE=("Chromium.app")
   elif [[ $1 == "--compile-linux" ]]; then
     CHROMIUM_FOLDER_NAME="chrome-linux"
-    CHROMIUM_FILES_TO_ARCHIVE=(
-      "chrome"
-      "chrome_100_percent.pak"
-      "chrome_200_percent.pak"
-      "chrome_sandbox"
-      "chrome-wrapper"
-      "ClearKeyCdm"
-      "crashpad_handler"
-      "icudtl.dat"
-      "libEGL.so"
-      "libGLESv2.so"
-      "locales"
-      "MEIPreload"
-      "nacl_helper"
-      "nacl_helper_bootstrap"
-      "nacl_helper_nonsfi"
-      "nacl_irt_x86_64.nexe"
-      "product_logo_48.png"
-      "resources"
-      "resources.pak"
-      "swiftshader"
-      "v8_context_snapshot.bin"
-      "vk_swiftshader_icd.json"
-      "xdg-mime"
-      "xdg-settings"
-    )
-  elif [[ $1 == "--compile-win"* ]]; then
+    # Run python script and convert output to array.
+    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($("${SCRIPT_PATH}/compute_files_to_archive.py" 64bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/linux/FILES.cfg"))
+  elif [[ $1 == "--compile-win32" ]]; then
     CHROMIUM_FOLDER_NAME="chrome-win"
-    CHROMIUM_FILES_TO_ARCHIVE=(
-      "chrome.dll"
-      "chrome.exe"
-      "chrome_100_percent.pak"
-      "chrome_200_percent.pak"
-      "chrome_elf.dll"
-      "chrome_proxy.exe"
-      "chrome_pwa_launcher.exe"
-      "D3DCompiler_47.dll"
-      "elevation_service.exe"
-      "eventlog_provider.dll"
-      "First Run"
-      "icudtl.dat"
-      "libEGL.dll"
-      "libGLESv2.dll"
-      "locales"
-      "MEIPreload"
-      "mojo_core.dll"
-      "nacl_irt_x86_64.nexe"
-      "notification_helper.exe"
-      "resources.pak"
-      "swiftshader/libEGL.dll"
-      "swiftshader/libGLESv2.dll"
-      "v8_context_snapshot.bin"
-      "vk_swiftshader.dll"
-      "vk_swiftshader_icd.json"
-    )
+    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($("${SCRIPT_PATH}/compute_files_to_archive.py" 32bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/win/FILES.cfg"))
+  elif [[ $1 == "--compile-win64" ]]; then
+    CHROMIUM_FOLDER_NAME="chrome-win"
+    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($("${SCRIPT_PATH}/compute_files_to_archive.py" 64bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/win/FILES.cfg"))
   else
     echo "ERROR: unknown command, use --help for details"
     exit 1

--- a/browser_patches/chromium/compute_files_to_archive.py
+++ b/browser_patches/chromium/compute_files_to_archive.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+
+import sys
+import json
+
+if len(sys.argv) < 2:
+    print "ERROR: expected arch: 32bit or 64bit"
+    sys.exit(1)
+
+if str(sys.argv[1]) == "--help" or str(sys.argv[1]) == "-h":
+    print "Usage: read_files.py [32bit|64bit] <files.cfg path>"
+    sys.exit(1)
+
+if len(sys.argv) < 3:
+    print "ERROR: expected FILE.cfg path"
+    sys.exit(1)
+
+exclude_list = [
+    # Windows exclude list
+    "chrome_child.dll",
+    "gaia1_0.dll",
+    "gcp_setup.exe",
+    "icudt.dll",
+    "interactive_ui_tests.exe",
+    "*.manifest",
+    # Linux exclude list
+    "session",
+]
+
+target_arch = sys.argv[1]
+file_name = sys.argv[2]
+
+descriptors=[]
+if sys.version_info > (3, 0):
+    exec(open(file_name).read())
+    descriptors = FILES
+else:
+    variables = {}
+    execfile(file_name, variables)
+    descriptors = variables['FILES']
+
+def filter_descriptors(entry):
+    if 'archive' in entry:
+        return False
+    if not 'buildtype' in entry:
+        return False
+    if not 'dev' in entry['buildtype']:
+        return False
+    if ('arch' in entry) and (entry['arch'] != target_arch):
+        return False
+    if entry['filename'] in exclude_list:
+        return False
+    return True
+
+for entry in filter(filter_descriptors, descriptors):
+    print(entry['filename'])
+


### PR DESCRIPTION
Since the include list of files to pack with Chromium changes
eventually, we should use their list instead of hardcoded one
on our side.