### PR TITLE
devops: fix chromium archiving with FILES.cfg

### DIFF
--- a/browser_patches/chromium/archive.sh
+++ b/browser_patches/chromium/archive.sh
@@ -58,13 +58,16 @@ function archive_compiled_chromium() {
   elif [[ $1 == "--compile-linux" ]]; then
     CHROMIUM_FOLDER_NAME="chrome-linux"
     # Run python script and convert output to array.
-    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($(python "${SCRIPT_PATH}/compute_files_to_archive.py" 64bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/linux/FILES.cfg"))
+    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($("${SCRIPT_PATH}/compute_files_to_archive.py" 64bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/linux/FILES.cfg"))
+    unset IFS
   elif [[ $1 == "--compile-win32" ]]; then
     CHROMIUM_FOLDER_NAME="chrome-win"
-    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($(python "${SCRIPT_PATH}/compute_files_to_archive.py" 32bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/win/FILES.cfg"))
+    IFS=$'\n\r' CHROMIUM_FILES_TO_ARCHIVE=($("${SCRIPT_PATH}/compute_files_to_archive.py" 32bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/win/FILES.cfg"))
+    unset IFS
   elif [[ $1 == "--compile-win64" ]]; then
     CHROMIUM_FOLDER_NAME="chrome-win"
-    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($(python "${SCRIPT_PATH}/compute_files_to_archive.py" 64bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/win/FILES.cfg"))
+    IFS=$'\n\r' CHROMIUM_FILES_TO_ARCHIVE=($("${SCRIPT_PATH}/compute_files_to_archive.py" 64bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/win/FILES.cfg"))
+    unset IFS
   else
     echo "ERROR: unknown command, use --help for details"
     exit 1

--- a/browser_patches/chromium/archive.sh
+++ b/browser_patches/chromium/archive.sh
@@ -58,13 +58,13 @@ function archive_compiled_chromium() {
   elif [[ $1 == "--compile-linux" ]]; then
     CHROMIUM_FOLDER_NAME="chrome-linux"
     # Run python script and convert output to array.
-    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($("${SCRIPT_PATH}/compute_files_to_archive.py" 64bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/linux/FILES.cfg"))
+    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($(python "${SCRIPT_PATH}/compute_files_to_archive.py" 64bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/linux/FILES.cfg"))
   elif [[ $1 == "--compile-win32" ]]; then
     CHROMIUM_FOLDER_NAME="chrome-win"
-    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($("${SCRIPT_PATH}/compute_files_to_archive.py" 32bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/win/FILES.cfg"))
+    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($(python "${SCRIPT_PATH}/compute_files_to_archive.py" 32bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/win/FILES.cfg"))
   elif [[ $1 == "--compile-win64" ]]; then
     CHROMIUM_FOLDER_NAME="chrome-win"
-    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($("${SCRIPT_PATH}/compute_files_to_archive.py" 64bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/win/FILES.cfg"))
+    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($(python "${SCRIPT_PATH}/compute_files_to_archive.py" 64bit "${CR_CHECKOUT_PATH}/src/chrome/tools/build/win/FILES.cfg"))
   else
     echo "ERROR: unknown command, use --help for details"
     exit 1

--- a/browser_patches/chromium/compute_files_to_archive.py
+++ b/browser_patches/chromium/compute_files_to_archive.py
@@ -4,15 +4,15 @@ import sys
 import json
 
 if len(sys.argv) < 2:
-    print "ERROR: expected arch: 32bit or 64bit"
+    print("ERROR: expected arch: 32bit or 64bit")
     sys.exit(1)
 
 if str(sys.argv[1]) == "--help" or str(sys.argv[1]) == "-h":
-    print "Usage: read_files.py [32bit|64bit] <files.cfg path>"
+    print("Usage: read_files.py [32bit|64bit] <files.cfg path>")
     sys.exit(1)
 
 if len(sys.argv) < 3:
-    print "ERROR: expected FILE.cfg path"
+    print("ERROR: expected FILE.cfg path")
     sys.exit(1)
 
 exclude_list = [


### PR DESCRIPTION
- unset `IFS` variable so that it doesn't affect future script execution
- use `\n\r` separator on windows
- fix script to be Python2/Python3 compliant