### PR TITLE
test: do not retain large artifacts in test-results

### DIFF
--- a/tests/chromium/tracing.spec.ts
+++ b/tests/chromium/tracing.spec.ts
@@ -21,9 +21,9 @@ import path from 'path';
 it.describe('tracing', () => {
   it.skip(({ browserName }) => browserName !== 'chromium');
 
-  it('should output a trace', async ({browser, server}, testInfo) => {
+  it('should output a trace', async ({browser, server, createTempDir}, testInfo) => {
     const page = await browser.newPage();
-    const outputTraceFile = testInfo.outputPath(path.join(`trace.json`));
+    const outputTraceFile = path.join(createTempDir(), `trace.json`);
     await browser.startTracing(page, {screenshots: true, path: outputTraceFile});
     await page.goto(server.PREFIX + '/grid.html');
     await browser.stopTracing();
@@ -31,9 +31,9 @@ it.describe('tracing', () => {
     await page.close();
   });
 
-  it('should create directories as needed', async ({browser, server}, testInfo) => {
+  it('should create directories as needed', async ({browser, server, createTempDir}, testInfo) => {
     const page = await browser.newPage();
-    const filePath = testInfo.outputPath(path.join('these', 'are', 'directories', 'trace.json'));
+    const filePath = path.join(createTempDir(), 'these', 'are', 'directories', 'trace.json');
     await browser.startTracing(page, {screenshots: true, path: filePath});
     await page.goto(server.PREFIX + '/grid.html');
     await browser.stopTracing();
@@ -41,9 +41,9 @@ it.describe('tracing', () => {
     await page.close();
   });
 
-  it('should run with custom categories if provided', async ({browser}, testInfo) => {
+  it('should run with custom categories if provided', async ({browser, createTempDir}, testInfo) => {
     const page = await browser.newPage();
-    const outputTraceFile = testInfo.outputPath(path.join(`trace.json`));
+    const outputTraceFile = path.join(createTempDir(), `trace.json`);
     await browser.startTracing(page, {path: outputTraceFile, categories: ['disabled-by-default-v8.cpu_profiler.hires']});
     await browser.stopTracing();
 
@@ -52,9 +52,9 @@ it.describe('tracing', () => {
     await page.close();
   });
 
-  it('should throw if tracing on two pages', async ({browser}, testInfo) => {
+  it('should throw if tracing on two pages', async ({browser, createTempDir}, testInfo) => {
     const page = await browser.newPage();
-    const outputTraceFile = testInfo.outputPath(path.join(`trace.json`));
+    const outputTraceFile = path.join(createTempDir(), `trace.json`);
     await browser.startTracing(page, {path: outputTraceFile});
     const newPage = await browser.newPage();
     let error = null;
@@ -65,9 +65,9 @@ it.describe('tracing', () => {
     await page.close();
   });
 
-  it('should return a buffer', async ({browser, server}, testInfo) => {
+  it('should return a buffer', async ({browser, server, createTempDir}, testInfo) => {
     const page = await browser.newPage();
-    const outputTraceFile = testInfo.outputPath(path.join(`trace.json`));
+    const outputTraceFile = path.join(createTempDir(), `trace.json`);
     await browser.startTracing(page, {screenshots: true, path: outputTraceFile});
     await page.goto(server.PREFIX + '/grid.html');
     const trace = await browser.stopTracing();

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -439,8 +439,8 @@ it.describe('download event', () => {
     expect(saveError.message).toContain('File deleted upon browser context closure.');
   });
 
-  it('should download large binary.zip', async ({browser, server, browserName}, testInfo) => {
-    const zipFile = testInfo.outputPath('binary.zip');
+  it('should download large binary.zip', async ({browser, server, createTempDir}, testInfo) => {
+    const zipFile = path.join(createTempDir(), 'binary.zip');
     const content = crypto.randomBytes(1 << 20);
     fs.writeFileSync(zipFile, content);
     server.setRoute('/binary.zip', (req, res) => server.serveFile(req, res, zipFile));


### PR DESCRIPTION
This reduces zipped test-results from 3MB to 250KB.