### PR TITLE
feat: add common mac editing  commands.

### DIFF
--- a/src/server/macEditingCommands.ts
+++ b/src/server/macEditingCommands.ts
@@ -126,4 +126,9 @@ export const macEditingCommands: {[key: string]: string|string[]} = {
   'Shift+Meta+ArrowRight': 'moveToRightEndOfLineAndModifySelection:',
 
   'Meta+KeyA': 'selectAll:',
+  'Meta+KeyC': 'copy:',
+  'Meta+KeyX': 'cut:',
+  'Meta+KeyV': 'paste:',
+  'Meta+KeyZ': 'undo:',
+  'Shift+Meta+KeyZ': 'redo:',
 };

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -344,8 +344,8 @@ it('should be able to prevent selectAll', async ({page, server, isMac}) => {
   expect(await page.$eval('textarea', textarea => textarea.value)).toBe('some tex');
 });
 
-it('should handle copy & paste text', async ({ page, server, isMac, browserName }) => {
-  it.fail(browserName === 'webkit');
+it('should handle copy & paste text', async ({page, server, isMac, browserName, platform}) => {
+  it.skip(browserName === 'webkit' && platform !== 'win32');
 
   await page.goto(server.PREFIX + '/input/textarea.html');
   const textarea = await page.$('textarea');
@@ -359,8 +359,8 @@ it('should handle copy & paste text', async ({ page, server, isMac, browserName 
   expect(await page.$eval('textarea', textarea => textarea.value)).toBe('copy text');
 });
 
-it('should handle cut text', async ({ page, server, isMac, browserName }) => {
-  it.fail(browserName === 'webkit');
+it('should handle cut text', async ({page, server, isMac, browserName, platform}) => {
+  it.skip(browserName === 'webkit' && platform !== 'win32');
 
   await page.goto(server.PREFIX + '/input/textarea.html');
   const textarea = await page.$('textarea');
@@ -373,8 +373,8 @@ it('should handle cut text', async ({ page, server, isMac, browserName }) => {
   expect(await page.$eval('textarea', textarea => textarea.value)).toBe('cut text');
 });
 
-it('should handle undo & redo', async ({ page, server, isMac, browserName }) => {
-  it.fail(browserName === 'webkit');
+it('should handle undo & redo', async ({page, server, isMac, browserName, platform}) => {
+  it.skip(browserName === 'webkit' && platform !== 'win32');
 
   await page.goto(server.PREFIX + '/input/textarea.html');
   const textarea = await page.$('textarea');

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -344,6 +344,51 @@ it('should be able to prevent selectAll', async ({page, server, isMac}) => {
   expect(await page.$eval('textarea', textarea => textarea.value)).toBe('some tex');
 });
 
+it('should handle copy & paste text', async ({ page, server, isMac, browserName }) => {
+  it.fail(browserName === 'webkit');
+
+  await page.goto(server.PREFIX + '/input/textarea.html');
+  const textarea = await page.$('textarea');
+  await textarea.type('copy text');
+  const modifier = isMac ? 'Meta' : 'Control';
+  await textarea.selectText();
+  await page.keyboard.press(`${modifier}+c`);
+  await textarea.fill('');
+  expect(await page.$eval('textarea', textarea => textarea.value)).toBe('');
+  await page.keyboard.press(`${modifier}+v`);
+  expect(await page.$eval('textarea', textarea => textarea.value)).toBe('copy text');
+});
+
+it('should handle cut text', async ({ page, server, isMac, browserName }) => {
+  it.fail(browserName === 'webkit');
+
+  await page.goto(server.PREFIX + '/input/textarea.html');
+  const textarea = await page.$('textarea');
+  await textarea.type('cut text');
+  const modifier = isMac ? 'Meta' : 'Control';
+  await textarea.selectText();
+  await page.keyboard.press(`${modifier}+x`);
+  expect(await page.$eval('textarea', textarea => textarea.value)).toBe('');
+  await page.keyboard.press(`${modifier}+v`);
+  expect(await page.$eval('textarea', textarea => textarea.value)).toBe('cut text');
+});
+
+it('should handle undo & redo', async ({ page, server, isMac, browserName }) => {
+  it.fail(browserName === 'webkit');
+
+  await page.goto(server.PREFIX + '/input/textarea.html');
+  const textarea = await page.$('textarea');
+  await textarea.type('example text');
+  const modifier = isMac ? 'Meta' : 'Control';
+  await textarea.selectText();
+  await page.keyboard.press('Backspace');
+  expect(await page.$eval('textarea', textarea => textarea.value)).toBe('');
+  await page.keyboard.press(`${modifier}+z`);
+  expect(await page.$eval('textarea', textarea => textarea.value)).toBe('example text');
+  await page.keyboard.press(`Shift+${modifier}+z`);
+  expect(await page.$eval('textarea', textarea => textarea.value)).toBe('');
+});
+
 it('should support MacOS shortcuts', async ({page, server, platform, browserName}) => {
   it.skip(platform !== 'darwin');
   // @see https://github.com/microsoft/playwright/issues/5721


### PR DESCRIPTION
Editing commands works fine on Chrome now, while still fails on non-win32 Webkit.
|Browser(macOS)|Before|After|
|---|---|---|
|Chrome|❌|✅|
|Firefox|✅|✅|
|Webkit|❌|❌|