### PR TITLE
fix: fix method elementHandle.frameElement() for framesets

### DIFF
--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -520,7 +520,7 @@ export class FFPage implements PageDelegate {
     const parent = frame.parentFrame();
     if (!parent)
       throw new Error('Frame has been detached.');
-    const handles = await this._page.selectors._queryAll(parent, 'iframe', undefined);
+    const handles = await this._page.selectors._queryAll(parent, 'frame,iframe', undefined);
     const items = await Promise.all(handles.map(async handle => {
       const frame = await handle.contentFrame().catch(e => null);
       return { handle, frame };

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -877,7 +877,7 @@ export class WKPage implements PageDelegate {
     const parent = frame.parentFrame();
     if (!parent)
       throw new Error('Frame has been detached.');
-    const handles = await this._page.selectors._queryAll(parent, 'iframe', undefined);
+    const handles = await this._page.selectors._queryAll(parent, 'frame,iframe', undefined);
     const items = await Promise.all(handles.map(async handle => {
       const frame = await handle.contentFrame().catch(e => null);
       return { handle, frame };

--- a/tests/page/frame-frame-element.spec.ts
+++ b/tests/page/frame-frame-element.spec.ts
@@ -40,6 +40,14 @@ it('should work with contentFrame', async ({page, server}) => {
   expect(contentFrame).toBe(frame);
 });
 
+it('should work with frameset', async ({page, server}) => {
+  await page.goto(server.PREFIX + '/frames/frameset.html');
+  const frameElement1 = await page.$('frame');
+  const frame = await frameElement1.contentFrame();
+  const frameElement2 = await frame.frameElement();
+  expect(await frameElement1.evaluate((a, b) => a === b, frameElement2)).toBe(true);
+});
+
 it('should throw when detached', async ({page, server}) => {
   await page.goto(server.EMPTY_PAGE);
   const frame1 = await attachFrame(page, 'frame1', server.EMPTY_PAGE);

--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -29,6 +29,16 @@ it('should click the button', async ({page, server}) => {
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
+it('should click button inside frameset', async ({page, server}) => {
+  await page.goto(server.PREFIX + '/frames/frameset.html');
+  const frameElement = await page.$('frame');
+  await frameElement.evaluate(frame => frame.src = '/input/button.html');
+  const frame = await frameElement.contentFrame();
+  await frame.click('button');
+  expect(await frame.evaluate('result')).toBe('Clicked');
+});
+
+
 it('should click svg', async ({page}) => {
   await page.setContent(`
     <svg height="100" width="100">


### PR DESCRIPTION
Playwright clicks did not work in regular frames due to a bug
in `frameElement` method.

Fixes #6453