### PR TITLE
fix: fix har entry time calculation

### DIFF
--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -251,3 +251,10 @@ it('should include content', async ({ contextFactory, server }, testInfo) => {
   expect(content2.mimeType).toBe('text/css; charset=utf-8');
   expect(Buffer.from(content2.text, 'base64').toString()).toContain('pink');
 });
+
+it('should calculate time', async ({ contextFactory, server }, testInfo) => {
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo);
+  await page.goto(server.PREFIX + '/har.html');
+  const log = await getLog();
+  expect(log.entries[0].time).toBeGreaterThan(0);
+});


### PR DESCRIPTION
According to [HAR 1.2 Spec](http://www.softwareishard.com/blog/har-12-spec/#entries):
>time [number] - Total elapsed time of the request in milliseconds. This is the sum of all timings available in the timings object (i.e. not including -1 values) .