### PR TITLE
feat(firefox): bump to 1257 and 1247 (stable)

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -8,12 +8,12 @@
     },
     {
       "name": "firefox",
-      "revision": "1256",
+      "revision": "1257",
       "installByDefault": true
     },
     {
       "name": "firefox-stable",
-      "revision": "1246",
+      "revision": "1247",
       "installByDefault": false
     },
     {

--- a/tests/browsercontext-expose-function.spec.ts
+++ b/tests/browsercontext-expose-function.spec.ts
@@ -85,3 +85,12 @@ it('exposeBindingHandle should work', async ({context}) => {
   expect(await target.evaluate(x => x.foo)).toBe(42);
   expect(result).toEqual(17);
 });
+
+it('should work with CSP', async ({ page, context, server }) => {
+  server.setCSP('/empty.html', 'default-src "self"');
+  await page.goto(server.EMPTY_PAGE);
+  let called = false;
+  await context.exposeBinding('hi', () => called = true);
+  await page.evaluate(() => (window as any).hi());
+  expect(called).toBe(true);
+});


### PR DESCRIPTION
This fixes addBinding on pages with CSP.

Fixes #5189.