### PR TITLE
devops(docker): upgrade to node 16

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -113,6 +113,7 @@ jobs:
         node_version:
         - "^12.0.0"
         - "^14.1.0"  # pre 14.1, zip extraction was broken (https://github.com/microsoft/playwright/issues/1988)
+        - "^16.0.0"
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2

--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -2,9 +2,9 @@ FROM ubuntu:bionic
 
 # === INSTALL Node.js ===
 
-# Install node14
+# Install node16
 RUN apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -y nodejs
 
 # Feature-parity with node.js base images.
@@ -40,4 +40,3 @@ RUN mkdir /ms-playwright && \
     DEBIAN_FRONTEND=noninteractive npx playwright install-deps && \
     rm -rf /tmp/pw && rm /tmp/playwright.tar.gz && \
     chmod -R 777 /ms-playwright
-

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -2,9 +2,9 @@ FROM ubuntu:focal
 
 # === INSTALL Node.js ===
 
-# Install node14
+# Install node16
 RUN apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -y nodejs
 
 # Feature-parity with node.js base images.
@@ -39,4 +39,3 @@ RUN mkdir /ms-playwright && \
     DEBIAN_FRONTEND=noninteractive npx playwright install-deps && \
     rm -rf /tmp/pw && rm /tmp/playwright.tar.gz && \
     chmod -R 777 /ms-playwright
-


### PR DESCRIPTION
Hello 👋 

Now that node@16 is out 

I haven't seen a node@14 requirement, so I've overwritten the current image, but I could decline the image in flavors if you prefer (`bionic-node14`, `bionic-node16`, ...)