### PR TITLE
feat(download): add Page in Download

### DIFF
--- a/docs/src/api/class-download.md
+++ b/docs/src/api/class-download.md
@@ -69,6 +69,11 @@ Deletes the downloaded file. Will wait for the download to finish if necessary.
 
 Returns download error if any. Will wait for the download to finish if necessary.
 
+## method: Download.page
+- returns: <[Page]>
+
+Get the page that the download belongs to.
+
 ## async method: Download.path
 - returns: <[null]|[path]>
 

--- a/src/client/download.ts
+++ b/src/client/download.ts
@@ -17,16 +17,23 @@
 import { Readable } from 'stream';
 import * as api from '../../types/types';
 import { Artifact } from './artifact';
+import { Page } from './page';
 
 export class Download implements api.Download {
+  private _page: Page;
   private _url: string;
   private _suggestedFilename: string;
   private _artifact: Artifact;
 
-  constructor(url: string, suggestedFilename: string, artifact: Artifact) {
+  constructor(page: Page, url: string, suggestedFilename: string, artifact: Artifact) {
+    this._page = page;
     this._url = url;
     this._suggestedFilename = suggestedFilename;
     this._artifact = artifact;
+  }
+
+  page(): Page {
+    return this._page;
   }
 
   url(): string {

--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -125,7 +125,7 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     this._channel.on('download', ({ url, suggestedFilename, artifact }) => {
       const artifactObject = Artifact.from(artifact);
       artifactObject._isRemote = !!this._browserContext._browser && !!this._browserContext._browser._remoteType;
-      this.emit(Events.Page.Download, new Download(url, suggestedFilename, artifactObject));
+      this.emit(Events.Page.Download, new Download(this, url, suggestedFilename, artifactObject));
     });
     this._channel.on('fileChooser', ({ element, isMultiple }) => this.emit(Events.Page.FileChooser, new FileChooser(this, ElementHandle.from(element), isMultiple)));
     this._channel.on('frameAttached', ({ frame }) => this._onFrameAttached(Frame.from(frame)));

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -43,6 +43,7 @@ it.describe('download event', () => {
       page.click('a')
     ]);
     let error;
+    expect(download.page()).toBe(page);
     expect(download.url()).toBe(`${server.PREFIX}/downloadWithFilename`);
     expect(download.suggestedFilename()).toBe(`file.txt`);
     await download.path().catch(e => error = e);

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -9299,6 +9299,11 @@ export interface Download {
   failure(): Promise<null|string>;
 
   /**
+   * Get the page that the download belongs to.
+   */
+  page(): Page;
+
+  /**
    * Returns path to the downloaded file in case of successful download. The method will wait for the download to finish if
    * necessary. The method throws when connected remotely.
    */


### PR DESCRIPTION
The `Page` class provides a [method](https://playwright.dev/docs/api/class-page/#pagecontext) to retrieve its `BrowserContext`. The `BrowserContext` has a [method](https://playwright.dev/docs/api/class-browsercontext#browsercontextbrowser) for its `Browser`. This pull request adds a method to retrieve the `Page` of a `Download`.