### PR TITLE
devops: cancel prevous GitHub Action runs

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -11,6 +11,13 @@ on:
       - release-*
 
 jobs:
+  cancel-previous-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
   doc-and-lint:
     name: "docs & lint"
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -11,6 +11,13 @@ on:
       - .github/workflows/publish_canary_docker.yml
 
 jobs:
+  cancel-previous-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
   publish-canary-docker:
     name: "publish to DockerHub"
     runs-on: ubuntu-20.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,13 @@ env:
   FLAKINESS_CONNECTION_STRING: ${{ secrets.FLAKINESS_CONNECTION_STRING }}
 
 jobs:
+  cancel-previous-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
   test_linux:
     name: ${{ matrix.os }} (${{ matrix.browser }})
     strategy:


### PR DESCRIPTION
This GitHub Action seems quite trustworthy: https://github.com/styfle/cancel-workflow-action/blob/main/src/index.ts

The main issue is `Starting workflow run` which is caused because we have too many concurrent builds. When you cancel them manually, the new one get scheduled. This added GitHub Action will cancel them automatically if it will detect that a new one was triggered.

With cancellation in scope are not jobs of a file, they cancel a whole file, thats why I added it to our long-running workflow files for now.

Let's use it as an experiment for a few days / hours, if it does not help, we can revert it.