### PR TITLE
docs(dotnet): fix link regex on xmldocs

### DIFF
--- a/utils/doclint/xmlDocumentation.js
+++ b/utils/doclint/xmlDocumentation.js
@@ -118,7 +118,7 @@ function _wrapAndEscape(node, maxColumns = 0) {
 
 
   let text = node.text;
-  text = text.replace(/\[(.*?)\]\((.*?)\)/g, (match, linkName, linkUrl) => {
+  text = text.replace(/\[([^\]]*)\]\((.*?)\)/g, (match, linkName, linkUrl) => {
     return `<a href="${linkUrl}">${linkName}</a>`;
   });
   text = text.replace(/(?<!`)\[(.*?)\]/g, (match, link) => `<see cref="${link}"/>`);


### PR DESCRIPTION
That regex was generating invalid XML when it found text in brackets with no links. For instance: `[contenteditable]`  in ElementHandle fill.

Output code: https://github.com/microsoft/playwright-sharp/pull/1363