### PR TITLE
chore(dotnet): fix goto casing

### DIFF
--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -686,7 +686,6 @@ Attribute name to get the value for.
 ## async method: Frame.goto
 * langs:
   - alias-java: navigate
-  - alias-csharp: GoToAsync
 - returns: <[null]|[Response]>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1599,7 +1599,6 @@ Navigate to the next page in history.
 ## async method: Page.goto
 * langs:
   - alias-java: navigate
-  - alias-csharp: GoToAsync
 - returns: <[null]|[Response]>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the


### PR DESCRIPTION
The dotnet team is using this casing https://github.com/dotnet/runtime/blob/01b7e73cd378145264a7cb7a09365b41ed42b240/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs#L12

@pavelfeldman keep in mind that this will slightly change the code being shown in the upcoming demo.

Output code: https://github.com/microsoft/playwright-sharp/pull/1363