### PR TITLE
docs(dotnet): rename getPayloadAsJson to PostDataJsonAsync

### DIFF
--- a/docs/src/api/csharp.md
+++ b/docs/src/api/csharp.md
@@ -1,10 +1,13 @@
-## method: Request.getPayloadAsJson
+## method: Request.PostDataJsonAsync
 * langs: csharp
 - returns: <[JsonDocument]>
 
-Returns a [JsonDocument] representation of [`method: Request.postDataBuffer`].
+Returns parsed request's body for `form-urlencoded` and JSON as a fallback if any.
 
-### option: Request.getPayloadAsJson.serializerOptions
+When the response is `application/x-www-form-urlencoded` then a key/value object of the values will be returned.
+Otherwise it will be parsed as JSON.
+
+### option: Request.PostDataJsonAsync.serializerOptions
 - `documentOptions` <[null]|[JsonDocumentOptions]>
 
 The options that control custom behaviour when parsing the JSON.

--- a/docs/src/api/csharp.md
+++ b/docs/src/api/csharp.md
@@ -1,4 +1,4 @@
-## method: Request.postDataJSON
+## method: Request.PostDataJSON
 * langs: csharp
 - returns: <[JsonDocument]>
 
@@ -7,7 +7,7 @@ Returns parsed request's body for `form-urlencoded` and JSON as a fallback if an
 When the response is `application/x-www-form-urlencoded` then a key/value object of the values will be returned.
 Otherwise it will be parsed as JSON.
 
-### param: Request.postDataJSON.serializerOptions
+### param: Request.PostDataJSON.serializerOptions
 * langs: csharp
 - `documentOptions` <[null]|[JsonDocumentOptions]>
 

--- a/docs/src/api/csharp.md
+++ b/docs/src/api/csharp.md
@@ -1,4 +1,4 @@
-## method: Request.PostDataJsonAsync
+## method: Request.postDataJSON
 * langs: csharp
 - returns: <[JsonDocument]>
 
@@ -7,10 +7,11 @@ Returns parsed request's body for `form-urlencoded` and JSON as a fallback if an
 When the response is `application/x-www-form-urlencoded` then a key/value object of the values will be returned.
 Otherwise it will be parsed as JSON.
 
-### option: Request.PostDataJsonAsync.serializerOptions
+### param: Request.postDataJSON.serializerOptions
+* langs: csharp
 - `documentOptions` <[null]|[JsonDocumentOptions]>
 
-The options that control custom behaviour when parsing the JSON.
+Optional Json options that control custom behaviour when parsing the JSON.
 
 ## method: Response.statusCode
 * langs: csharp

--- a/utils/doclint/api_parser.js
+++ b/utils/doclint/api_parser.js
@@ -118,20 +118,27 @@ class ApiParser {
    * @param {MarkdownNode} spec
    */
   parseArgument(spec) {
+    const langMatches =function (memberLangs, argumentLangs) {
+      if(!argumentLangs || !memberLangs || argumentLangs.every(arg => memberLangs.includes(arg)))
+        return true;
+
+      return false;
+    };
+
     const match = spec.text.match(/(param|option): ([^.]+)\.([^.]+)\.(.*)/);
     if(!match)
       throw `Something went wrong with matching ${spec.text}`;
     const clazz = this.classes.get(match[2]);
     if (!clazz)
       throw new Error('Invalid class ' + match[2]);
-    const method = clazz.membersArray.find(m => m.kind === 'method' && m.alias === match[3]);
-    if (!method)
-      throw new Error('Invalid method ' + match[2] + '.' + match[3]);
     const name = match[4];
     if (!name)
       throw new Error('Invalid member name ' + spec.text);
     if (match[1] === 'param') {
       const arg = this.parseProperty(spec);
+      const method = clazz.membersArray.find(m => m.kind === 'method' && m.alias === match[3] && langMatches(m.langs.only, arg.langs.only));
+      if (!method)
+        throw new Error('Invalid method ' + match[2] + '.' + match[3]);
       arg.name = name;
       const existingArg = method.argsArray.find(m => m.name === arg.name);
       if (existingArg && isTypeOverride(existingArg, arg)) {
@@ -145,6 +152,9 @@ class ApiParser {
         method.argsArray.push(arg);
       }
     } else {
+      const method = clazz.membersArray.find(m => m.kind === 'method' && m.alias === match[3]);
+      if (!method)
+        throw new Error('Invalid method ' + match[2] + '.' + match[3]);
       let options = method.argsArray.find(o => o.name === 'options');
       if (!options) {
         const type = new Documentation.Type('Object', []);


### PR DESCRIPTION
We should give it the same name as in upstream.

Related to https://github.com/microsoft/playwright-sharp/issues/1361