### PR TITLE
chore(dotnet): generate generic WaitForEvents

### DIFF
--- a/docs/src/api/csharp.md
+++ b/docs/src/api/csharp.md
@@ -23,3 +23,39 @@ Gets the [System.Net.HttpStatusCode] code of the response.
 
 ### param: Page.selectOption.values = %%-csharp-select-options-values-%%
 ### param: Page.setInputFiles.files = %%-csharp-input-files-%%
+
+## async method: Page.waitForEvent
+* langs: csharp
+- returns: <[T]>
+
+### param: Page.waitForEvent.event
+* langs: csharp
+- `event` <[PlaywrightEvent<T>]>
+
+Page event.
+
+### option: Page.waitForEvent.predicate = %%-csharp-wait-for-event-predicate-%%
+
+## async method: BrowserContext.waitForEvent
+* langs: csharp
+- returns: <[T]>
+
+### param: BrowserContext.waitForEvent.event
+* langs: csharp
+- `event` <[PlaywrightEvent<T>]>
+
+Browser context event.
+
+### option: BrowserContext.waitForEvent.predicate = %%-csharp-wait-for-event-predicate-%%
+
+## async method: WebSocket.waitForEvent
+* langs: csharp
+- returns: <[T]>
+
+### param: WebSocket.waitForEvent.event
+* langs: csharp
+- `event` <[PlaywrightEvent<T>]>
+
+WebSocket context event.
+
+### option: WebSocket.waitForEvent.predicate = %%-csharp-wait-for-event-predicate-%%

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -536,6 +536,12 @@ only the first option matching one of the passed options is selected. Optional.
 
 Receives the event data and resolves to truthy value when the waiting should resolve.
 
+## csharp-wait-for-event-predicate
+* langs: csharp
+- `predicate` <[Func<T, bool>]>
+
+Receives the event data and resolves to truthy value when the waiting should resolve.
+
 ## wait-for-event-timeout
 * langs: csharp, java, python
 - `timeout` <[float]>


### PR DESCRIPTION
This will generate the `WaitForEventAsync` we had before (and were adding through overloads).