### PR TITLE
fix: enable util world bindings in firefox

### DIFF
--- a/src/server/firefox/ffBrowser.ts
+++ b/src/server/firefox/ffBrowser.ts
@@ -23,7 +23,7 @@ import { Page, PageBinding, PageDelegate } from '../page';
 import { ConnectionTransport } from '../transport';
 import * as types from '../types';
 import { ConnectionEvents, FFConnection } from './ffConnection';
-import { FFPage } from './ffPage';
+import { FFPage, UTILITY_WORLD_NAME } from './ffPage';
 import { Protocol } from './protocol';
 
 export class FFBrowser extends Browser {
@@ -303,9 +303,8 @@ export class FFBrowserContext extends BrowserContext {
   }
 
   async _doExposeBinding(binding: PageBinding) {
-    if (binding.world !== 'main')
-      throw new Error('Only main context bindings are supported in Firefox.');
-    await this._browser._connection.send('Browser.addBinding', { browserContextId: this._browserContextId, name: binding.name, script: binding.source });
+    const worldName = binding.world === 'utility' ? UTILITY_WORLD_NAME : '';
+    await this._browser._connection.send('Browser.addBinding', { browserContextId: this._browserContextId, worldName, name: binding.name, script: binding.source });
   }
 
   async _doUpdateRequestInterception(): Promise<void> {

--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -33,7 +33,7 @@ import { Progress } from '../progress';
 import { splitErrorMessage } from '../../utils/stackTrace';
 import { debugLogger } from '../../utils/debugLogger';
 
-const UTILITY_WORLD_NAME = '__playwright_utility_world__';
+export const UTILITY_WORLD_NAME = '__playwright_utility_world__';
 
 export class FFPage implements PageDelegate {
   readonly cspErrorsAsynchronousForInlineScipts = true;
@@ -317,9 +317,8 @@ export class FFPage implements PageDelegate {
   }
 
   async exposeBinding(binding: PageBinding) {
-    if (binding.world !== 'main')
-      throw new Error('Only main context bindings are supported in Firefox.');
-    await this._session.send('Page.addBinding', { name: binding.name, script: binding.source });
+    const worldName = binding.world === 'utility' ? UTILITY_WORLD_NAME : '';
+    await this._session.send('Page.addBinding', { name: binding.name, script: binding.source, worldName });
   }
 
   didClose() {

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -581,36 +581,36 @@ export class PageBinding {
     }
 
     function takeHandle(arg: { name: string, seq: number }) {
-      const handle = (window as any)[arg.name]['handles'].get(arg.seq);
-      (window as any)[arg.name]['handles'].delete(arg.seq);
+      const handle = (globalThis as any)[arg.name]['handles'].get(arg.seq);
+      (globalThis as any)[arg.name]['handles'].delete(arg.seq);
       return handle;
     }
 
     function deliverResult(arg: { name: string, seq: number, result: any }) {
-      (window as any)[arg.name]['callbacks'].get(arg.seq).resolve(arg.result);
-      (window as any)[arg.name]['callbacks'].delete(arg.seq);
+      (globalThis as any)[arg.name]['callbacks'].get(arg.seq).resolve(arg.result);
+      (globalThis as any)[arg.name]['callbacks'].delete(arg.seq);
     }
 
     function deliverError(arg: { name: string, seq: number, message: string, stack: string | undefined }) {
       const error = new Error(arg.message);
       error.stack = arg.stack;
-      (window as any)[arg.name]['callbacks'].get(arg.seq).reject(error);
-      (window as any)[arg.name]['callbacks'].delete(arg.seq);
+      (globalThis as any)[arg.name]['callbacks'].get(arg.seq).reject(error);
+      (globalThis as any)[arg.name]['callbacks'].delete(arg.seq);
     }
 
     function deliverErrorValue(arg: { name: string, seq: number, error: any }) {
-      (window as any)[arg.name]['callbacks'].get(arg.seq).reject(arg.error);
-      (window as any)[arg.name]['callbacks'].delete(arg.seq);
+      (globalThis as any)[arg.name]['callbacks'].get(arg.seq).reject(arg.error);
+      (globalThis as any)[arg.name]['callbacks'].delete(arg.seq);
     }
   }
 }
 
 function addPageBinding(bindingName: string, needsHandle: boolean) {
-  const binding = (window as any)[bindingName];
+  const binding = (globalThis as any)[bindingName];
   if (binding.__installed)
     return;
-  (window as any)[bindingName] = (...args: any[]) => {
-    const me = (window as any)[bindingName];
+  (globalThis as any)[bindingName] = (...args: any[]) => {
+    const me = (globalThis as any)[bindingName];
     if (needsHandle && args.slice(1).some(arg => arg !== undefined))
       throw new Error(`exposeBindingHandle supports a single argument, ${args.length} received`);
     let callbacks = me['callbacks'];
@@ -634,5 +634,5 @@ function addPageBinding(bindingName: string, needsHandle: boolean) {
     }
     return promise;
   };
-  (window as any)[bindingName].__installed = true;
+  (globalThis as any)[bindingName].__installed = true;
 }

--- a/tests/inspector/cli-codegen-1.spec.ts
+++ b/tests/inspector/cli-codegen-1.spec.ts
@@ -29,7 +29,7 @@ test.describe('cli codegen', () => {
     expect(selector).toBe('text=Submit');
 
     const [message, sources] = await Promise.all([
-      page.waitForEvent('console'),
+      page.waitForEvent('console', msg => msg.type() !== 'error'),
       recorder.waitForOutput('<javascript>', 'click'),
       page.dispatchEvent('button', 'click', { detail: 1 })
     ]);
@@ -77,7 +77,7 @@ await page.ClickAsync("text=Submit");`);
     expect(selector).toBe('text=Submit');
 
     const [message, sources] = await Promise.all([
-      page.waitForEvent('console'),
+      page.waitForEvent('console', msg => msg.type() !== 'error'),
       recorder.waitForOutput('<javascript>', 'click'),
       page.dispatchEvent('button', 'click', { detail: 1 })
     ]);
@@ -103,7 +103,7 @@ await page.ClickAsync("text=Submit");`);
     expect(selector).toBe('text=Submit');
 
     const [message, sources] = await Promise.all([
-      page.waitForEvent('console'),
+      page.waitForEvent('console', msg => msg.type() !== 'error'),
       recorder.waitForOutput('<javascript>', 'click'),
       page.dispatchEvent('button', 'click', { detail: 1 })
     ]);
@@ -155,7 +155,7 @@ await page.ClickAsync("text=Submit");`);
     expect(divContents).toBe(`<div onclick="console.log('click')"> Some long text here </div>`);
 
     const [message, sources] = await Promise.all([
-      page.waitForEvent('console'),
+      page.waitForEvent('console', msg => msg.type() !== 'error'),
       recorder.waitForOutput('<javascript>', 'click'),
       page.dispatchEvent('div', 'click', { detail: 1 })
     ]);
@@ -173,7 +173,7 @@ await page.ClickAsync("text=Submit");`);
     expect(selector).toBe('input[name="name"]');
 
     const [message, sources] = await Promise.all([
-      page.waitForEvent('console'),
+      page.waitForEvent('console', msg => msg.type() !== 'error'),
       recorder.waitForOutput('<javascript>', 'fill'),
       page.fill('input', 'John')
     ]);
@@ -208,7 +208,7 @@ await page.FillAsync(\"input[name=\\\"name\\\"]\", \"John\");`);
     expect(selector).toBe('textarea[name="name"]');
 
     const [message, sources] = await Promise.all([
-      page.waitForEvent('console'),
+      page.waitForEvent('console', msg => msg.type() !== 'error'),
       recorder.waitForOutput('<javascript>', 'fill'),
       page.fill('textarea', 'John')
     ]);
@@ -322,7 +322,8 @@ await page.PressAsync(\"input[name=\\\"name\\\"]\", \"Shift+Enter\");`);
 
     const messages: any[] = [];
     page.on('console', message => {
-      messages.push(message);
+      if (message.type() !== 'error')
+        messages.push(message);
     });
     const [, sources] = await Promise.all([
       recorder.waitForActionPerformed(),
@@ -346,7 +347,7 @@ await page.PressAsync(\"input[name=\\\"name\\\"]\", \"Shift+Enter\");`);
     expect(selector).toBe('input[name="accept"]');
 
     const [message, sources] = await Promise.all([
-      page.waitForEvent('console'),
+      page.waitForEvent('console', msg => msg.type() !== 'error'),
       recorder.waitForOutput('<javascript>', 'check'),
       page.click('input')
     ]);
@@ -383,7 +384,7 @@ await page.CheckAsync(\"input[name=\\\"accept\\\"]\");`);
     expect(selector).toBe('input[name="accept"]');
 
     const [message, sources] = await Promise.all([
-      page.waitForEvent('console'),
+      page.waitForEvent('console', msg => msg.type() !== 'error'),
       recorder.waitForOutput('<javascript>', 'check'),
       page.keyboard.press('Space')
     ]);
@@ -403,7 +404,7 @@ await page.CheckAsync(\"input[name=\\\"accept\\\"]\");`);
     expect(selector).toBe('input[name="accept"]');
 
     const [message, sources] = await Promise.all([
-      page.waitForEvent('console'),
+      page.waitForEvent('console', msg => msg.type() !== 'error'),
       recorder.waitForOutput('<javascript>', 'uncheck'),
       page.click('input')
     ]);
@@ -440,7 +441,7 @@ await page.UncheckAsync(\"input[name=\\\"accept\\\"]\");`);
     expect(selector).toBe('select');
 
     const [message, sources] = await Promise.all([
-      page.waitForEvent('console'),
+      page.waitForEvent('console', msg => msg.type() !== 'error'),
       recorder.waitForOutput('<javascript>', 'select'),
       page.selectOption('select', '2')
     ]);

--- a/tests/inspector/cli-codegen-2.spec.ts
+++ b/tests/inspector/cli-codegen-2.spec.ts
@@ -442,7 +442,10 @@ await page1.GoToAsync("about:blank?foo");`);
     `);
 
     const messages: any[] = [];
-    page.on('console', message => messages.push(message.text()));
+    page.on('console', message => {
+      if (message.type() !== 'error')
+        messages.push(message.text());
+    });
     await Promise.all([
       page.click('button'),
       recorder.waitForOutput('<javascript>', 'page.click')

--- a/tests/inspector/pause.spec.ts
+++ b/tests/inspector/pause.spec.ts
@@ -166,7 +166,7 @@ it.describe('pause', () => {
     const scriptPromise = (async () => {
       await page.pause();
       await Promise.all([
-        page.waitForEvent('console'),
+        page.waitForEvent('console', msg => msg.type() === 'log' && msg.text() === '1'),
         page.click('button'),
       ]);
     })();


### PR DESCRIPTION
This PR is Firefox specific preparation for #6187.
* Support utility world in `addBinding` methods in Firefox
* Update recorder code to use `globalThis` instead of window in the code that is going to run in the utility context (in FF window is the main world's window while globalThis is the one from sandbox)
* Updated recorder tests to use console.error instead of private bindings (we don't expose non-main world bindings api to public).