### PR TITLE
browser(firefox): fix uploads of large files in Firefox

### DIFF
--- a/browser_patches/firefox-stable/BUILD_NUMBER
+++ b/browser_patches/firefox-stable/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1250
-Changed: yurys@chromium.org Wed 12 May 2021 08:53:32 AM PDT
+1251
+Changed: lushnikov@chromium.org Wed 12 May 2021 04:13:18 PM PDT

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1260
-Changed: yurys@chromium.org Wed 12 May 2021 08:49:17 AM PDT
+1261
+Changed: lushnikov@chromium.org Wed 12 May 2021 04:12:52 PM PDT


### PR DESCRIPTION
- to read post data of requests, we have to read stream
- to restore the stream later on, we have to rewind it back
- however, if the stream is large enough, it cannot be rewound back

This patch starts cloning post data streams if possible to avoid
back-rewinding them later on.

References #4704