### PR TITLE
test: prepare test to use options as passed

### DIFF
--- a/tests/beforeunload.spec.ts
+++ b/tests/beforeunload.spec.ts
@@ -44,7 +44,7 @@ it('should close page with beforeunload listener', async ({context, server}) => 
   await newPage.close();
 });
 
-it('should run beforeunload if asked for', async ({context, server, isChromium, isWebKit}) => {
+it('should run beforeunload if asked for', async ({context, server, browserName}) => {
   const newPage = await context.newPage();
   await newPage.goto(server.PREFIX + '/beforeunload.html');
   // We have to interact with a page so that 'beforeunload' handlers
@@ -56,9 +56,9 @@ it('should run beforeunload if asked for', async ({context, server, isChromium, 
   ]);
   expect(dialog.type()).toBe('beforeunload');
   expect(dialog.defaultValue()).toBe('');
-  if (isChromium)
+  if (browserName === 'chromium')
     expect(dialog.message()).toBe('');
-  else if (isWebKit)
+  else if (browserName === 'webkit')
     expect(dialog.message()).toBe('Leave?');
   else
     expect(dialog.message()).toContain('This page is asking you to confirm that you want to leave');

--- a/tests/browser.spec.ts
+++ b/tests/browser.spec.ts
@@ -38,9 +38,9 @@ test('should throw upon second create new page', async function({browser}) {
   expect(error.message).toContain('Please use browser.newContext()');
 });
 
-test('version should work', async function({browser, isChromium}) {
+test('version should work', async function({browser, browserName}) {
   const version = browser.version();
-  if (isChromium)
+  if (browserName === 'chromium')
     expect(version.match(/^\d+\.\d+\.\d+\.\d+$/)).toBeTruthy();
   else
     expect(version.match(/^\d+\.\d+/)).toBeTruthy();

--- a/tests/browsercontext-add-cookies.spec.ts
+++ b/tests/browsercontext-add-cookies.spec.ts
@@ -333,7 +333,7 @@ it('should set cookies for a frame', async ({context, page, server}) => {
   expect(await page.frames()[1].evaluate('document.cookie')).toBe('frame-cookie=value');
 });
 
-it('should(not) block third party cookies', async ({context, page, server, isChromium, isFirefox}) => {
+it('should(not) block third party cookies', async ({context, page, server, browserName}) => {
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(src => {
     let fulfill;
@@ -346,7 +346,7 @@ it('should(not) block third party cookies', async ({context, page, server, isChr
   }, server.CROSS_PROCESS_PREFIX + '/grid.html');
   await page.frames()[1].evaluate(`document.cookie = 'username=John Doe'`);
   await page.waitForTimeout(2000);
-  const allowsThirdParty = isChromium || isFirefox;
+  const allowsThirdParty = browserName === 'chromium' || browserName === 'firefox';
   const cookies = await context.cookies(server.CROSS_PROCESS_PREFIX + '/grid.html');
   if (allowsThirdParty) {
     expect(cookies).toEqual([

--- a/tests/browsercontext-basic.spec.ts
+++ b/tests/browsercontext-basic.spec.ts
@@ -188,14 +188,14 @@ it('should close all belonging pages once closing context', async function({brow
   expect(context.pages().length).toBe(0);
 });
 
-it('should disable javascript', async ({browser, isWebKit}) => {
+it('should disable javascript', async ({browser, browserName}) => {
   {
     const context = await browser.newContext({ javaScriptEnabled: false });
     const page = await context.newPage();
     await page.goto('data:text/html, <script>var something = "forbidden"</script>');
     let error = null;
     await page.evaluate('something').catch(e => error = e);
-    if (isWebKit)
+    if (browserName === 'webkit')
       expect(error.message).toContain('Can\'t find variable: something');
     else
       expect(error.message).toContain('something is not defined');

--- a/tests/browsercontext-credentials.spec.ts
+++ b/tests/browsercontext-credentials.spec.ts
@@ -17,8 +17,8 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should fail without credentials', async ({browser, server, browserName, headful}) => {
-  it.fail(browserName === 'chromium' && headful);
+it('should fail without credentials', async ({browser, server, browserName, headless}) => {
+  it.fail(browserName === 'chromium' && !headless);
 
   server.setAuth('/empty.html', 'user', 'pass');
   const context = await browser.newContext();
@@ -28,8 +28,8 @@ it('should fail without credentials', async ({browser, server, browserName, head
   await context.close();
 });
 
-it('should work with setHTTPCredentials', async ({browser, server, browserName, headful}) => {
-  it.fail(browserName === 'chromium' && headful);
+it('should work with setHTTPCredentials', async ({browser, server, browserName, headless}) => {
+  it.fail(browserName === 'chromium' && !headless);
 
   server.setAuth('/empty.html', 'user', 'pass');
   const context = await browser.newContext();

--- a/tests/browsercontext-pages.spec.ts
+++ b/tests/browsercontext-pages.spec.ts
@@ -79,7 +79,7 @@ it('should click the button with deviceScaleFactor set', async ({browser, server
   await context.close();
 });
 
-it('should click the button with offset with page scale', async ({browser, server, isWebKit, isChromium, headful, browserName, browserVersion}) => {
+it('should click the button with offset with page scale', async ({browser, server, headless, browserName, browserVersion}) => {
   it.skip(browserName === 'firefox');
 
   const context = await browser.newContext({ viewport: { width: 400, height: 400 }, isMobile: true });
@@ -93,13 +93,13 @@ it('should click the button with offset with page scale', async ({browser, serve
   expect(await page.evaluate('result')).toBe('Clicked');
   const round = x => Math.round(x + 0.01);
   let expected = { x: 28, y: 18 };  // 20;10 + 8px of border in each direction
-  if (isWebKit) {
+  if (browserName === 'webkit') {
     // WebKit rounds up during css -> dip -> css conversion.
     expected = { x: 29, y: 19 };
-  } else if (isChromium && !headful) {
+  } else if (browserName === 'chromium' && headless) {
     // Headless Chromium rounds down during css -> dip -> css conversion.
     expected = { x: 27, y: 18 };
-  } else if (isChromium && headful && !chromiumVersionLessThan(browserVersion, '92.0.4498.0')) {
+  } else if (browserName === 'chromium' && !headless && !chromiumVersionLessThan(browserVersion, '92.0.4498.0')) {
     // New headed Chromium rounds down during css -> dip -> css conversion as well.
     expected = { x: 27, y: 18 };
   }

--- a/tests/browsercontext-proxy.spec.ts
+++ b/tests/browsercontext-proxy.spec.ts
@@ -206,8 +206,8 @@ it('should isolate proxy credentials between contexts', async ({contextFactory, 
   }
 });
 
-it('should exclude patterns', async ({contextFactory, server, browserName, headful}) => {
-  it.fixme(browserName === 'chromium' && headful, 'Chromium headful crashes with CHECK(!in_frame_tree_) in RenderFrameImpl::OnDeleteFrame.');
+it('should exclude patterns', async ({contextFactory, server, browserName, headless}) => {
+  it.fixme(browserName === 'chromium' && !headless, 'Chromium headed crashes with CHECK(!in_frame_tree_) in RenderFrameImpl::OnDeleteFrame.');
 
   server.setRoute('/target.html', async (req, res) => {
     res.end('<html><title>Served by the proxy</title></html>');

--- a/tests/browsertype-basic.spec.ts
+++ b/tests/browsertype-basic.spec.ts
@@ -18,8 +18,8 @@
 import fs from 'fs';
 import { playwrightTest as test, expect } from './config/browserTest';
 
-test('browserType.executablePath should work', async ({ browserType, browserChannel, browserOptions }) => {
-  test.skip(!!browserChannel, 'We skip browser download when testing a channel');
+test('browserType.executablePath should work', async ({ browserType, channel, browserOptions }) => {
+  test.skip(!!channel, 'We skip browser download when testing a channel');
   test.skip(!!browserOptions.executablePath, 'Skip with custom executable path');
 
   const executablePath = browserType.executablePath();

--- a/tests/browsertype-launch-server.spec.ts
+++ b/tests/browsertype-launch-server.spec.ts
@@ -60,8 +60,8 @@ it.describe('launch server', () => {
     await browserServer.close();
   });
 
-  it('should fire close event', async ({browserType, browserOptions, browserChannel}) => {
-    it.fixme(!!browserChannel, 'Uncomment on roll');
+  it('should fire close event', async ({browserType, browserOptions, channel}) => {
+    it.fixme(!!channel, 'Uncomment on roll');
 
     const browserServer = await browserType.launchServer(browserOptions);
     const [result] = await Promise.all([

--- a/tests/capabilities.spec.ts
+++ b/tests/capabilities.spec.ts
@@ -51,7 +51,7 @@ it('should respect CSP', async ({page, server}) => {
   expect(await page.evaluate(() => window['testStatus'])).toBe('SUCCESS');
 });
 
-it('should play video', async ({page, asset, isWebKit, browserName, platform}) => {
+it('should play video', async ({page, asset, browserName, platform}) => {
   // TODO: the test passes on Windows locally but fails on GitHub Action bot,
   // apparently due to a Media Pack issue in the Windows Server.
   // Also the test is very flaky on Linux WebKit.
@@ -59,7 +59,7 @@ it('should play video', async ({page, asset, isWebKit, browserName, platform}) =
   it.fixme(browserName === 'webkit' && platform === 'darwin' && parseInt(os.release(), 10) >= 20, 'Does not work on BigSur');
 
   // Safari only plays mp4 so we test WebKit with an .mp4 clip.
-  const fileName = isWebKit ? 'video_mp4.html' : 'video.html';
+  const fileName = browserName === 'webkit' ? 'video_mp4.html' : 'video.html';
   const absolutePath = asset(fileName);
   // Our test server doesn't support range requests required to play on Mac,
   // so we load the page using a file url.
@@ -68,8 +68,8 @@ it('should play video', async ({page, asset, isWebKit, browserName, platform}) =
   await page.$eval('video', v => v.pause());
 });
 
-it('should support webgl', async ({page, browserName, headful}) => {
-  it.fixme(browserName === 'firefox' && !headful);
+it('should support webgl', async ({page, browserName, headless}) => {
+  it.fixme(browserName === 'firefox' && headless);
 
   const hasWebGL = await page.evaluate(() => {
     const canvas = document.createElement('canvas');
@@ -78,10 +78,10 @@ it('should support webgl', async ({page, browserName, headful}) => {
   expect(hasWebGL).toBe(true);
 });
 
-it('should support webgl 2', async ({page, browserName, headful}) => {
+it('should support webgl 2', async ({page, browserName, headless}) => {
   it.skip(browserName === 'webkit', 'WebKit doesn\'t have webgl2 enabled yet upstream.');
-  it.fixme(browserName === 'firefox' && !headful);
-  it.fixme(browserName === 'chromium' && headful, 'chromium doesn\'t like webgl2 when running under xvfb');
+  it.fixme(browserName === 'firefox' && headless);
+  it.fixme(browserName === 'chromium' && !headless, 'chromium doesn\'t like webgl2 when running under xvfb');
 
   const hasWebGL2 = await page.evaluate(() => {
     const canvas = document.createElement('canvas');

--- a/tests/channels.spec.ts
+++ b/tests/channels.spec.ts
@@ -152,7 +152,7 @@ it('should scope browser handles', async ({browserType, browserOptions}) => {
   await expectScopeState(browserType, GOLDEN_PRECONDITION);
 });
 
-it('should work with the domain module', async ({ browserType, browserOptions, server, isFirefox }) => {
+it('should work with the domain module', async ({ browserType, browserOptions, server, browserName }) => {
   const local = domain.create();
   local.run(() => { });
   let err;
@@ -172,7 +172,7 @@ it('should work with the domain module', async ({ browserType, browserOptions, s
     new WebSocket('ws://localhost:' + port + '/bogus-ws');
   }, server.PORT);
   const message = await result;
-  if (isFirefox)
+  if (browserName === 'firefox')
     expect(message).toBe('CLOSE_ABNORMAL');
   else
     expect(message).toContain(': 400');

--- a/tests/chromium/launcher.spec.ts
+++ b/tests/chromium/launcher.spec.ts
@@ -52,8 +52,8 @@ it('should open devtools when "devtools: true" option is given', async ({browser
   await browser.close();
 });
 
-it('should return background pages', async ({browserType, browserOptions, createUserDataDir, asset, browserChannel}) => {
-  it.fixme(browserChannel);
+it('should return background pages', async ({browserType, browserOptions, createUserDataDir, asset, channel}) => {
+  it.fixme(channel);
   const userDataDir = await createUserDataDir();
   const extensionPath = asset('simple-extension');
   const extensionOptions = {...browserOptions,

--- a/tests/chromium/oopif.spec.ts
+++ b/tests/chromium/oopif.spec.ts
@@ -227,7 +227,7 @@ it('should click a button when it overlays oopif', async function({page, browser
   expect(await page.evaluate(() => window['BUTTON_CLICKED'])).toBe(true);
 });
 
-it('should report google.com frame with headful', async ({browserType, browserOptions, server}) => {
+it('should report google.com frame with headed', async ({browserType, browserOptions, server}) => {
   // @see https://github.com/GoogleChrome/puppeteer/issues/2548
   // https://google.com is isolated by default in Chromium embedder.
   const browser = await browserType.launch({...browserOptions, headless: false});

--- a/tests/config/android.config.ts
+++ b/tests/config/android.config.ts
@@ -66,6 +66,7 @@ config.projects.push({
   name: 'android',
   options: {
     loopback: '10.0.2.2',
+    browserName: 'chromium',
   },
   testDir: path.join(testDir, 'android'),
 });
@@ -74,6 +75,7 @@ config.projects.push({
   name: 'android',
   options: {
     loopback: '10.0.2.2',
+    browserName: 'chromium',
   },
   testDir: path.join(testDir, 'page'),
   define: { test: pageTest, env: new AndroidPageEnv() },

--- a/tests/config/baseTest.ts
+++ b/tests/config/baseTest.ts
@@ -29,17 +29,14 @@ type Mode = 'default' | 'driver' | 'service';
 type BaseWorkerArgs = {
   mode: Mode;
   platform: 'win32' | 'darwin' | 'linux';
-  video: boolean;
-  headful: boolean;
+  video: boolean | undefined;
+  headless: boolean | undefined;
 
   playwright: typeof import('../../index');
   toImpl: (rpcObject: any) => any;
   browserName: BrowserName;
-  browserChannel: string | undefined;
+  channel: string | undefined;
 
-  isChromium: boolean;
-  isFirefox: boolean;
-  isWebKit: boolean;
   isWindows: boolean;
   isMac: boolean;
   isLinux: boolean;
@@ -108,7 +105,7 @@ type BaseOptions = {
   browserName?: BrowserName;
   channel?: string;
   video?: boolean;
-  headful?: boolean;
+  headless?: boolean;
 };
 
 class BaseEnv {
@@ -118,7 +115,7 @@ class BaseEnv {
   private _playwright: typeof import('../../index');
 
   hasBeforeAllOptions(options: BaseOptions) {
-    return 'mode' in options || 'browserName' in options || 'channel' in options || 'video' in options || 'headful' in options;
+    return 'mode' in options || 'browserName' in options || 'channel' in options || 'video' in options || 'headless' in options;
   }
 
   async beforeAll(options: BaseOptions, workerInfo: folio.WorkerInfo): Promise<BaseWorkerArgs> {
@@ -134,15 +131,12 @@ class BaseEnv {
     return {
       playwright: this._playwright,
       browserName: this._browserName,
-      browserChannel: this._options.channel,
-      isChromium: this._browserName === 'chromium',
-      isFirefox: this._browserName === 'firefox',
-      isWebKit: this._browserName === 'webkit',
+      channel: this._options.channel,
       isWindows: process.platform === 'win32',
       isMac: process.platform === 'darwin',
       isLinux: process.platform === 'linux',
-      headful: !!this._options.headful,
-      video: !!this._options.video,
+      headless: this._options.headless,
+      video: this._options.video,
       mode: this._options.mode || 'default',
       platform: process.platform as ('win32' | 'darwin' | 'linux'),
       toImpl: (this._playwright as any)._toImpl,
@@ -152,7 +146,7 @@ class BaseEnv {
   async beforeEach({}, testInfo: folio.TestInfo) {
     testInfo.snapshotPathSegment = this._browserName;
     testInfo.data = { browserName: this._browserName };
-    if (this._options.headful)
+    if (!this._options.headless)
       testInfo.data.headful = true;
     if ((this._options.mode || 'default') !== 'default')
       testInfo.data.mode = this._options.mode || 'default';

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -57,8 +57,8 @@ class PlaywrightEnv {
     this._browserType = args.playwright[args.browserName];
     this._browserOptions = {
       traceDir: args.traceDir,
-      channel: args.browserChannel,
-      headless: !args.headful,
+      channel: args.channel,
+      headless: args.headless,
       handleSIGINT: false,
       ...args.launchOptions,
     } as any;

--- a/tests/config/default.config.ts
+++ b/tests/config/default.config.ts
@@ -42,8 +42,8 @@ class PageEnv {
     this._browser = await args.playwright[args.browserName].launch({
       ...args.launchOptions,
       traceDir: args.traceDir,
-      channel: args.browserChannel,
-      headless: !args.headful,
+      channel: args.channel,
+      headless: args.headless,
       handleSIGINT: false,
     } as any);
     this._browserVersion = this._browser.version();
@@ -79,7 +79,7 @@ class PageEnv {
 }
 
 const mode = folio.registerCLIOption('mode', 'Transport mode: default, driver or service').value as ('default' | 'driver' | 'service' | undefined);
-const headful = folio.registerCLIOption('headed', 'Run tests in headed mode (default: headless)', { type: 'boolean' }).value || !!process.env.HEADFUL;
+const headed = folio.registerCLIOption('headed', 'Run tests in headed mode (default: headless)', { type: 'boolean' }).value || !!process.env.HEADFUL;
 const channel = folio.registerCLIOption('channel', 'Browser channel (default: no channel)').value;
 const video = !!folio.registerCLIOption('video', 'Record videos for all tests', { type: 'boolean' }).value;
 
@@ -115,7 +115,7 @@ for (const browserName of browserNames) {
     options: {
       mode,
       browserName,
-      headful,
+      headless: !headed,
       channel,
       video,
       traceDir: process.env.PWTRACE ? path.join(outputDir, 'trace') : undefined,

--- a/tests/config/electron.config.ts
+++ b/tests/config/electron.config.ts
@@ -59,7 +59,8 @@ const config: folio.Config<AllOptions> = {
 config.projects.push({
   name: 'electron',
   options: {
-    coverageName: 'electron'
+    browserName: 'chromium',
+    coverageName: 'electron',
   },
   testDir: path.join(testDir, 'electron'),
 });
@@ -67,7 +68,8 @@ config.projects.push({
 config.projects.push({
   name: 'electron',
   options: {
-    coverageName: 'electron'
+    browserName: 'chromium',
+    coverageName: 'electron',
   },
   testDir: path.join(testDir, 'page'),
   define: { test: pageTest, env: new ElectronPageEnv() },

--- a/tests/defaultbrowsercontext-1.spec.ts
+++ b/tests/defaultbrowsercontext-1.spec.ts
@@ -79,7 +79,7 @@ it('context.clearCookies() should work', async ({server, launchPersistent}) => {
   expect(await page.evaluate('document.cookie')).toBe('');
 });
 
-it('should(not) block third party cookies', async ({server, launchPersistent, isChromium, isFirefox}) => {
+it('should(not) block third party cookies', async ({server, launchPersistent, browserName}) => {
   const {page, context} = await launchPersistent();
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(src => {
@@ -96,7 +96,7 @@ it('should(not) block third party cookies', async ({server, launchPersistent, is
     return document.cookie;
   });
   await page.waitForTimeout(2000);
-  const allowsThirdParty = isChromium || isFirefox;
+  const allowsThirdParty = browserName === 'chromium' || browserName === 'firefox';
   expect(documentCookie).toBe(allowsThirdParty ? 'username=John Doe' : '');
   const cookies = await context.cookies(server.CROSS_PROCESS_PREFIX + '/grid.html');
   if (allowsThirdParty) {
@@ -146,12 +146,12 @@ it('should support bypassCSP option', async ({server, launchPersistent}) => {
   expect(await page.evaluate('__injected')).toBe(42);
 });
 
-it('should support javascriptEnabled option', async ({launchPersistent, isWebKit}) => {
+it('should support javascriptEnabled option', async ({launchPersistent, browserName}) => {
   const {page} = await launchPersistent({javaScriptEnabled: false});
   await page.goto('data:text/html, <script>var something = "forbidden"</script>');
   let error = null;
   await page.evaluate('something').catch(e => error = e);
-  if (isWebKit)
+  if (browserName === 'webkit')
     expect(error.message).toContain('Can\'t find variable: something');
   else
     expect(error.message).toContain('something is not defined');

--- a/tests/defaultbrowsercontext-2.spec.ts
+++ b/tests/defaultbrowsercontext-2.spec.ts
@@ -106,8 +106,8 @@ it('should restore state from userDataDir', async ({browserType, browserOptions,
   await browserContext3.close();
 });
 
-it('should restore cookies from userDataDir', async ({browserType, browserOptions,  server, createUserDataDir, platform, browserChannel}) => {
-  it.fixme(platform === 'win32' && browserChannel === 'chrome');
+it('should restore cookies from userDataDir', async ({browserType, browserOptions,  server, createUserDataDir, platform, channel}) => {
+  it.fixme(platform === 'win32' && channel === 'chrome');
   it.slow();
 
   const userDataDir = await createUserDataDir();
@@ -149,14 +149,14 @@ it('should throw if page argument is passed', async ({browserType, browserOption
   expect(error.message).toContain('can not specify page');
 });
 
-it('should have passed URL when launching with ignoreDefaultArgs: true', async ({browserType, browserOptions, server, createUserDataDir, toImpl, mode, isFirefox}) => {
+it('should have passed URL when launching with ignoreDefaultArgs: true', async ({browserType, browserOptions, server, createUserDataDir, toImpl, mode, browserName}) => {
   it.skip(mode !== 'default');
 
   const userDataDir = await createUserDataDir();
   const args = toImpl(browserType)._defaultArgs(browserOptions, 'persistent', userDataDir, 0).filter(a => a !== 'about:blank');
   const options = {
     ...browserOptions,
-    args: isFirefox ? [...args, '-new-tab', server.EMPTY_PAGE] : [...args, server.EMPTY_PAGE],
+    args: browserName === 'firefox' ? [...args, '-new-tab', server.EMPTY_PAGE] : [...args, server.EMPTY_PAGE],
     ignoreDefaultArgs: true,
   };
   const browserContext = await browserType.launchPersistentContext(userDataDir, options);

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -274,10 +274,10 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should report new window downloads', async ({browser, server, browserName, headful}) => {
-    it.fixme(browserName === 'chromium' && headful);
+  it('should report new window downloads', async ({browser, server, browserName, headless}) => {
+    it.fixme(browserName === 'chromium' && !headless);
 
-    // TODO: - the test fails in headful Chromium as the popup page gets closed along
+    // TODO: - the test fails in headed Chromium as the popup page gets closed along
     // with the session before download completed event arrives.
     // - WebKit doesn't close the popup page
     const page = await browser.newPage({ acceptDownloads: true });

--- a/tests/emulation-focus.spec.ts
+++ b/tests/emulation-focus.spec.ts
@@ -101,10 +101,9 @@ it('should change document.activeElement', async ({page, server}) => {
   expect(active).toEqual(['INPUT', 'TEXTAREA']);
 });
 
-it('should not affect screenshots', async ({page, server, browserName, headful}) => {
-  it.skip(browserName === 'firefox' && headful);
+it('should not affect screenshots', async ({page, server, browserName, headless}) => {
+  it.skip(browserName === 'firefox' && !headless, 'Firefox headede produces a different image');
 
-  // Firefox headful produces a different image.
   const page2 = await page.context().newPage();
   await Promise.all([
     page.setViewportSize({width: 500, height: 500}),

--- a/tests/favicon.spec.ts
+++ b/tests/favicon.spec.ts
@@ -17,9 +17,9 @@
 
 import { contextTest as it } from './config/browserTest';
 
-it('should load svg favicon with prefer-color-scheme', async ({page, server, browserName, browserChannel, headful, asset}) => {
-  it.skip(!headful && browserName !== 'firefox', 'headless browsers, except firefox, do not request favicons');
-  it.skip(headful && browserName === 'webkit' && !browserChannel, 'playwright headful webkit does not have a favicon feature');
+it('should load svg favicon with prefer-color-scheme', async ({page, server, browserName, channel, headless, asset}) => {
+  it.skip(headless && browserName !== 'firefox', 'headless browsers, except firefox, do not request favicons');
+  it.skip(!headless && browserName === 'webkit' && !channel, 'headed webkit does not have a favicon feature');
 
   // Browsers aggresively cache favicons, so force bust with the
   // `d` parameter to make iterating on this test more predictable and isolated.

--- a/tests/headful.spec.ts
+++ b/tests/headful.spec.ts
@@ -67,7 +67,7 @@ it('should close browser after context menu was triggered', async ({browserType,
   await browser.close();
 });
 
-it('should(not) block third party cookies', async ({browserType, browserOptions, server, isChromium, isFirefox}) => {
+it('should(not) block third party cookies', async ({browserType, browserOptions, server, browserName}) => {
   const browser = await browserType.launch({...browserOptions, headless: false });
   const page = await browser.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -85,7 +85,7 @@ it('should(not) block third party cookies', async ({browserType, browserOptions,
     return document.cookie;
   });
   await page.waitForTimeout(2000);
-  const allowsThirdParty = isChromium || isFirefox;
+  const allowsThirdParty = browserName === 'chromium' || browserName === 'firefox';
   expect(documentCookie).toBe(allowsThirdParty ? 'username=John Doe' : '');
   const cookies = await page.context().cookies(server.CROSS_PROCESS_PREFIX + '/grid.html');
   if (allowsThirdParty) {
@@ -147,13 +147,13 @@ it('Page.bringToFront should work', async ({browserType, browserOptions}) => {
   await browser.close();
 });
 
-it('focused input should produce the same screenshot', async ({browserType, browserOptions, browserName, platform, browserChannel}, testInfo) => {
+it('focused input should produce the same screenshot', async ({browserType, browserOptions, browserName, platform, channel}, testInfo) => {
   it.fail(browserName === 'firefox' && platform === 'darwin', 'headless has thinner outline');
   it.fail(browserName === 'firefox' && platform === 'linux', 'headless has no outline');
   it.fail(browserName === 'firefox' && platform === 'win32', 'headless has outline since new version');
   it.skip(browserName === 'webkit' && platform === 'linux', 'gtk vs wpe');
   it.skip(!!process.env.CRPATH);
-  it.skip(!!browserChannel, 'Uncomment on roll');
+  it.skip(!!channel, 'Uncomment on roll');
 
   testInfo.snapshotPathSegment = browserName + '-' + platform;
 

--- a/tests/inspector/cli-codegen-1.spec.ts
+++ b/tests/inspector/cli-codegen-1.spec.ts
@@ -18,7 +18,7 @@ import { test, expect } from './inspectorTest';
 
 test.describe('cli codegen', () => {
   test.skip(({ mode }) => mode !== 'default');
-  test.fixme(({ browserName, headful }) => browserName === 'firefox' && headful, 'Focus is off');
+  test.fixme(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Focus is off');
 
   test('should click', async ({ page, openRecorder }) => {
     const recorder = await openRecorder();
@@ -469,8 +469,8 @@ await page.SelectOptionAsync(\"select\", \"2\");`);
     expect(message.text()).toBe('2');
   });
 
-  test('should await popup', async ({ page, openRecorder, browserName, headful }) => {
-    test.fixme(browserName === 'webkit' && headful, 'Middle click does not open a popup in our webkit embedder');
+  test('should await popup', async ({ page, openRecorder, browserName, headless }) => {
+    test.fixme(browserName === 'webkit' && !headless, 'Middle click does not open a popup in our webkit embedder');
 
     const recorder = await openRecorder();
     await recorder.setContentAndWait('<a target=_blank rel=noopener href="about:blank">link</a>');
@@ -609,8 +609,8 @@ await Task.WhenAll(
     expect(page.url()).toContain('about:blank#foo');
   });
 
-  test('should ignore AltGraph', async ({ openRecorder, isFirefox }, testInfo) => {
-    testInfo.skip(isFirefox, 'The TextInputProcessor in Firefox does not work with AltGraph.');
+  test('should ignore AltGraph', async ({ openRecorder, browserName }) => {
+    test.skip(browserName === 'firefox', 'The TextInputProcessor in Firefox does not work with AltGraph.');
     const recorder = await openRecorder();
     await recorder.setContentAndWait(`<input></input>`);
 

--- a/tests/inspector/cli-codegen-2.spec.ts
+++ b/tests/inspector/cli-codegen-2.spec.ts
@@ -464,9 +464,9 @@ await page1.GoToAsync("about:blank?foo");`);
     expect(models.hovered).toBe('input[name="updated"]');
   });
 
-  test('should update active model on action', async ({ page, openRecorder, browserName, headful }) => {
-    test.fixme(browserName === 'webkit' && !headful);
-    test.fixme(browserName === 'firefox' && !headful);
+  test('should update active model on action', async ({ page, openRecorder, browserName, headless }) => {
+    test.fixme(browserName === 'webkit' && headless);
+    test.fixme(browserName === 'firefox' && headless);
 
     const recorder = await openRecorder();
     await recorder.setContentAndWait(`<input id="checkbox" type="checkbox" name="accept" onchange="checkbox.name='updated'"></input>`);

--- a/tests/inspector/cli-codegen-csharp.spec.ts
+++ b/tests/inspector/cli-codegen-csharp.spec.ts
@@ -27,19 +27,19 @@ function capitalize(browserName: string): string {
   return browserName[0].toUpperCase() + browserName.slice(1);
 }
 
-test('should print the correct imports and context options', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct imports and context options', async ({ browserName, channel, runCLI }) => {
   const cli = runCLI(['--target=csharp', emptyHTML]);
   const expectedResult = `await Playwright.InstallAsync();
 using var playwright = await Playwright.CreateAsync();
 await using var browser = await playwright.${capitalize(browserName)}.LaunchAsync(
-    ${launchOptions(browserChannel)}
+    ${launchOptions(channel)}
 );
 var context = await browser.NewContextAsync();`;
   await cli.waitFor(expectedResult).catch(e => e);
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print the correct context options for custom settings', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct context options for custom settings', async ({ browserName, channel, runCLI }) => {
   const cli = runCLI([
     '--color-scheme=dark',
     '--geolocation=37.819722,-122.478611',
@@ -53,7 +53,7 @@ test('should print the correct context options for custom settings', async ({ br
   const expectedResult = `await Playwright.InstallAsync();
 using var playwright = await Playwright.CreateAsync();
 await using var browser = await playwright.${capitalize(browserName)}.LaunchAsync(
-    ${launchOptions(browserChannel)},
+    ${launchOptions(channel)},
     proxy: new ProxySettings
     {
         Server = "http://myproxy:3128",
@@ -79,21 +79,21 @@ var context = await browser.NewContextAsync(
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print the correct context options when using a device', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct context options when using a device', async ({ browserName, channel, runCLI }) => {
   test.skip(browserName !== 'chromium');
 
   const cli = runCLI(['--device=Pixel 2', '--target=csharp', emptyHTML]);
   const expectedResult = `await Playwright.InstallAsync();
 using var playwright = await Playwright.CreateAsync();
 await using var browser = await playwright.Chromium.LaunchAsync(
-    ${launchOptions(browserChannel)}
+    ${launchOptions(channel)}
 );
 var context = await browser.NewContextAsync(playwright.Devices["Pixel 2"]);`;
   await cli.waitFor(expectedResult);
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print the correct context options when using a device and additional options', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct context options when using a device and additional options', async ({ browserName, channel, runCLI }) => {
   test.skip(browserName !== 'webkit');
 
   const cli = runCLI([
@@ -110,7 +110,7 @@ test('should print the correct context options when using a device and additiona
   const expectedResult = `await Playwright.InstallAsync();
 using var playwright = await Playwright.CreateAsync();
 await using var browser = await playwright.Webkit.LaunchAsync(
-    ${launchOptions(browserChannel)},
+    ${launchOptions(channel)},
     proxy: new ProxySettings
     {
         Server = "http://myproxy:3128",
@@ -139,7 +139,7 @@ var context = await browser.NewContextAsync(new BrowserContextOptions(playwright
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print load/save storageState', async ({ browserName, browserChannel, runCLI }, testInfo) => {
+test('should print load/save storageState', async ({ browserName, channel, runCLI }, testInfo) => {
   const loadFileName = testInfo.outputPath('load.json');
   const saveFileName = testInfo.outputPath('save.json');
   await fs.promises.writeFile(loadFileName, JSON.stringify({ cookies: [], origins: [] }), 'utf8');
@@ -147,7 +147,7 @@ test('should print load/save storageState', async ({ browserName, browserChannel
   const expectedResult1 = `await Playwright.InstallAsync();
 using var playwright = await Playwright.CreateAsync();
 await using var browser = await playwright.${capitalize(browserName)}.LaunchAsync(
-    ${launchOptions(browserChannel)}
+    ${launchOptions(channel)}
 );
 var context = await browser.NewContextAsync(
     storageState: "${loadFileName}");`;

--- a/tests/inspector/cli-codegen-java.spec.ts
+++ b/tests/inspector/cli-codegen-java.spec.ts
@@ -23,7 +23,7 @@ const launchOptions = (channel: string) => {
   return channel ? `.setHeadless(false)\n        .setChannel("${channel}")` : '.setHeadless(false)';
 };
 
-test('should print the correct imports and context options', async ({ runCLI, browserChannel, browserName }) => {
+test('should print the correct imports and context options', async ({ runCLI, channel, browserName }) => {
   const cli = runCLI(['--target=java', emptyHTML]);
   const expectedResult = `import com.microsoft.playwright.*;
 import com.microsoft.playwright.options.*;
@@ -32,7 +32,7 @@ public class Example {
   public static void main(String[] args) {
     try (Playwright playwright = Playwright.create()) {
       Browser browser = playwright.${browserName}().launch(new BrowserType.LaunchOptions()
-        ${launchOptions(browserChannel)});
+        ${launchOptions(channel)});
       BrowserContext context = browser.newContext();`;
   await cli.waitFor(expectedResult);
   expect(cli.text()).toContain(expectedResult);

--- a/tests/inspector/cli-codegen-javascript.spec.ts
+++ b/tests/inspector/cli-codegen-javascript.spec.ts
@@ -24,26 +24,26 @@ const launchOptions = (channel: string) => {
   return channel ? `headless: false,\n    channel: '${channel}'` : 'headless: false';
 };
 
-test('should print the correct imports and context options', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct imports and context options', async ({ browserName, channel, runCLI }) => {
   const cli = runCLI([emptyHTML]);
   const expectedResult = `const { ${browserName} } = require('playwright');
 
 (async () => {
   const browser = await ${browserName}.launch({
-    ${launchOptions(browserChannel)}
+    ${launchOptions(channel)}
   });
   const context = await browser.newContext();`;
   await cli.waitFor(expectedResult);
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print the correct context options for custom settings', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct context options for custom settings', async ({ browserName, channel, runCLI }) => {
   const cli = runCLI(['--color-scheme=light', emptyHTML]);
   const expectedResult = `const { ${browserName} } = require('playwright');
 
 (async () => {
   const browser = await ${browserName}.launch({
-    ${launchOptions(browserChannel)}
+    ${launchOptions(channel)}
   });
   const context = await browser.newContext({
     colorScheme: 'light'
@@ -53,7 +53,7 @@ test('should print the correct context options for custom settings', async ({ br
 });
 
 
-test('should print the correct context options when using a device', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct context options when using a device', async ({ browserName, channel, runCLI }) => {
   test.skip(browserName !== 'chromium');
 
   const cli = runCLI(['--device=Pixel 2', emptyHTML]);
@@ -61,7 +61,7 @@ test('should print the correct context options when using a device', async ({ br
 
 (async () => {
   const browser = await chromium.launch({
-    ${launchOptions(browserChannel)}
+    ${launchOptions(channel)}
   });
   const context = await browser.newContext({
     ...devices['Pixel 2'],
@@ -70,7 +70,7 @@ test('should print the correct context options when using a device', async ({ br
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print the correct context options when using a device and additional options', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct context options when using a device and additional options', async ({ browserName, channel, runCLI }) => {
   test.skip(browserName !== 'webkit');
 
   const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', emptyHTML]);
@@ -78,7 +78,7 @@ test('should print the correct context options when using a device and additiona
 
 (async () => {
   const browser = await webkit.launch({
-    ${launchOptions(browserChannel)}
+    ${launchOptions(channel)}
   });
   const context = await browser.newContext({
     ...devices['iPhone 11'],
@@ -88,7 +88,7 @@ test('should print the correct context options when using a device and additiona
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should save the codegen output to a file if specified', async ({ browserName, browserChannel, runCLI }, testInfo) => {
+test('should save the codegen output to a file if specified', async ({ browserName, channel, runCLI }, testInfo) => {
   const tmpFile = testInfo.outputPath('script.js');
   const cli = runCLI(['--output', tmpFile, emptyHTML]);
   await cli.exited;
@@ -97,7 +97,7 @@ test('should save the codegen output to a file if specified', async ({ browserNa
 
 (async () => {
   const browser = await ${browserName}.launch({
-    ${launchOptions(browserChannel)}
+    ${launchOptions(channel)}
   });
   const context = await browser.newContext();
 
@@ -116,7 +116,7 @@ test('should save the codegen output to a file if specified', async ({ browserNa
 })();`);
 });
 
-test('should print load/save storageState', async ({ browserName, browserChannel, runCLI }, testInfo) => {
+test('should print load/save storageState', async ({ browserName, channel, runCLI }, testInfo) => {
   const loadFileName = testInfo.outputPath('load.json');
   const saveFileName = testInfo.outputPath('save.json');
   await fs.promises.writeFile(loadFileName, JSON.stringify({ cookies: [], origins: [] }), 'utf8');
@@ -125,7 +125,7 @@ test('should print load/save storageState', async ({ browserName, browserChannel
 
 (async () => {
   const browser = await ${browserName}.launch({
-    ${launchOptions(browserChannel)}
+    ${launchOptions(channel)}
   });
   const context = await browser.newContext({
     storageState: '${loadFileName}'

--- a/tests/inspector/cli-codegen-python-async.spec.ts
+++ b/tests/inspector/cli-codegen-python-async.spec.ts
@@ -23,31 +23,31 @@ const launchOptions = (channel: string) => {
   return channel ? `headless=False, channel="${channel}"` : 'headless=False';
 };
 
-test('should print the correct imports and context options', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct imports and context options', async ({ browserName, channel, runCLI }) => {
   const cli = runCLI(['--target=python-async', emptyHTML]);
   const expectedResult = `import asyncio
 from playwright.async_api import async_playwright
 
 async def run(playwright):
-    browser = await playwright.${browserName}.launch(${launchOptions(browserChannel)})
+    browser = await playwright.${browserName}.launch(${launchOptions(channel)})
     context = await browser.new_context()`;
   await cli.waitFor(expectedResult);
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print the correct context options for custom settings', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct context options for custom settings', async ({ browserName, channel, runCLI }) => {
   const cli = runCLI(['--color-scheme=light', '--target=python-async', emptyHTML]);
   const expectedResult = `import asyncio
 from playwright.async_api import async_playwright
 
 async def run(playwright):
-    browser = await playwright.${browserName}.launch(${launchOptions(browserChannel)})
+    browser = await playwright.${browserName}.launch(${launchOptions(channel)})
     context = await browser.new_context(color_scheme="light")`;
   await cli.waitFor(expectedResult);
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print the correct context options when using a device', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct context options when using a device', async ({ browserName, channel, runCLI }) => {
   test.skip(browserName !== 'chromium');
 
   const cli = runCLI(['--device=Pixel 2', '--target=python-async', emptyHTML]);
@@ -55,13 +55,13 @@ test('should print the correct context options when using a device', async ({ br
 from playwright.async_api import async_playwright
 
 async def run(playwright):
-    browser = await playwright.chromium.launch(${launchOptions(browserChannel)})
+    browser = await playwright.chromium.launch(${launchOptions(channel)})
     context = await browser.new_context(**playwright.devices["Pixel 2"])`;
   await cli.waitFor(expectedResult);
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print the correct context options when using a device and additional options', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct context options when using a device and additional options', async ({ browserName, channel, runCLI }) => {
   test.skip(browserName !== 'webkit');
 
   const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', '--target=python-async', emptyHTML]);
@@ -69,13 +69,13 @@ test('should print the correct context options when using a device and additiona
 from playwright.async_api import async_playwright
 
 async def run(playwright):
-    browser = await playwright.webkit.launch(${launchOptions(browserChannel)})
+    browser = await playwright.webkit.launch(${launchOptions(channel)})
     context = await browser.new_context(**playwright.devices["iPhone 11"], color_scheme="light")`;
   await cli.waitFor(expectedResult);
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should save the codegen output to a file if specified', async ({ browserName, browserChannel, runCLI }, testInfo) => {
+test('should save the codegen output to a file if specified', async ({ browserName, channel, runCLI }, testInfo) => {
   const tmpFile = testInfo.outputPath('script.js');
   const cli = runCLI(['--target=python-async', '--output', tmpFile, emptyHTML]);
   await cli.exited;
@@ -84,7 +84,7 @@ test('should save the codegen output to a file if specified', async ({ browserNa
 from playwright.async_api import async_playwright
 
 async def run(playwright):
-    browser = await playwright.${browserName}.launch(${launchOptions(browserChannel)})
+    browser = await playwright.${browserName}.launch(${launchOptions(channel)})
     context = await browser.new_context()
 
     # Open new page
@@ -106,7 +106,7 @@ async def main():
 asyncio.run(main())`);
 });
 
-test('should print load/save storage_state', async ({ browserName, browserChannel, runCLI }, testInfo) => {
+test('should print load/save storage_state', async ({ browserName, channel, runCLI }, testInfo) => {
   const loadFileName = testInfo.outputPath('load.json');
   const saveFileName = testInfo.outputPath('save.json');
   await fs.promises.writeFile(loadFileName, JSON.stringify({ cookies: [], origins: [] }), 'utf8');
@@ -115,7 +115,7 @@ test('should print load/save storage_state', async ({ browserName, browserChanne
 from playwright.async_api import async_playwright
 
 async def run(playwright):
-    browser = await playwright.${browserName}.launch(${launchOptions(browserChannel)})
+    browser = await playwright.${browserName}.launch(${launchOptions(channel)})
     context = await browser.new_context(storage_state="${loadFileName}")`;
   await cli.waitFor(expectedResult1);
 

--- a/tests/inspector/cli-codegen-python.spec.ts
+++ b/tests/inspector/cli-codegen-python.spec.ts
@@ -23,55 +23,55 @@ const launchOptions = (channel: string) => {
   return channel ? `headless=False, channel="${channel}"` : 'headless=False';
 };
 
-test('should print the correct imports and context options', async ({ runCLI, browserChannel, browserName }) => {
+test('should print the correct imports and context options', async ({ runCLI, channel, browserName }) => {
   const cli = runCLI(['--target=python', emptyHTML]);
   const expectedResult = `from playwright.sync_api import sync_playwright
 
 def run(playwright):
-    browser = playwright.${browserName}.launch(${launchOptions(browserChannel)})
+    browser = playwright.${browserName}.launch(${launchOptions(channel)})
     context = browser.new_context()`;
   await cli.waitFor(expectedResult);
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print the correct context options for custom settings', async ({ runCLI, browserChannel, browserName }) => {
+test('should print the correct context options for custom settings', async ({ runCLI, channel, browserName }) => {
   const cli = runCLI(['--color-scheme=light', '--target=python', emptyHTML]);
   const expectedResult = `from playwright.sync_api import sync_playwright
 
 def run(playwright):
-    browser = playwright.${browserName}.launch(${launchOptions(browserChannel)})
+    browser = playwright.${browserName}.launch(${launchOptions(channel)})
     context = browser.new_context(color_scheme="light")`;
   await cli.waitFor(expectedResult);
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print the correct context options when using a device', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct context options when using a device', async ({ browserName, channel, runCLI }) => {
   test.skip(browserName !== 'chromium');
 
   const cli = runCLI(['--device=Pixel 2', '--target=python', emptyHTML]);
   const expectedResult = `from playwright.sync_api import sync_playwright
 
 def run(playwright):
-    browser = playwright.chromium.launch(${launchOptions(browserChannel)})
+    browser = playwright.chromium.launch(${launchOptions(channel)})
     context = browser.new_context(**playwright.devices["Pixel 2"])`;
   await cli.waitFor(expectedResult);
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should print the correct context options when using a device and additional options', async ({ browserName, browserChannel, runCLI }) => {
+test('should print the correct context options when using a device and additional options', async ({ browserName, channel, runCLI }) => {
   test.skip(browserName !== 'webkit');
 
   const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', '--target=python', emptyHTML]);
   const expectedResult = `from playwright.sync_api import sync_playwright
 
 def run(playwright):
-    browser = playwright.webkit.launch(${launchOptions(browserChannel)})
+    browser = playwright.webkit.launch(${launchOptions(channel)})
     context = browser.new_context(**playwright.devices["iPhone 11"], color_scheme="light")`;
   await cli.waitFor(expectedResult);
   expect(cli.text()).toContain(expectedResult);
 });
 
-test('should save the codegen output to a file if specified', async ({ runCLI, browserChannel, browserName }, testInfo) => {
+test('should save the codegen output to a file if specified', async ({ runCLI, channel, browserName }, testInfo) => {
   const tmpFile = testInfo.outputPath('script.js');
   const cli = runCLI(['--target=python', '--output', tmpFile, emptyHTML]);
   await cli.exited;
@@ -79,7 +79,7 @@ test('should save the codegen output to a file if specified', async ({ runCLI, b
   expect(content.toString()).toBe(`from playwright.sync_api import sync_playwright
 
 def run(playwright):
-    browser = playwright.${browserName}.launch(${launchOptions(browserChannel)})
+    browser = playwright.${browserName}.launch(${launchOptions(channel)})
     context = browser.new_context()
 
     # Open new page
@@ -99,7 +99,7 @@ with sync_playwright() as playwright:
     run(playwright)`);
 });
 
-test('should print load/save storage_state', async ({ runCLI, browserChannel, browserName }, testInfo) => {
+test('should print load/save storage_state', async ({ runCLI, channel, browserName }, testInfo) => {
   const loadFileName = testInfo.outputPath('load.json');
   const saveFileName = testInfo.outputPath('save.json');
   await fs.promises.writeFile(loadFileName, JSON.stringify({ cookies: [], origins: [] }), 'utf8');
@@ -107,7 +107,7 @@ test('should print load/save storage_state', async ({ runCLI, browserChannel, br
   const expectedResult1 = `from playwright.sync_api import sync_playwright
 
 def run(playwright):
-    browser = playwright.${browserName}.launch(${launchOptions(browserChannel)})
+    browser = playwright.${browserName}.launch(${launchOptions(channel)})
     context = browser.new_context(storage_state="${loadFileName}")`;
   await cli.waitFor(expectedResult1);
 

--- a/tests/inspector/inspectorTest.ts
+++ b/tests/inspector/inspectorTest.ts
@@ -35,7 +35,7 @@ export const test = contextTest.extend({
     process.env.PWTEST_RECORDER_PORT = String(10907 + workerInfo.workerIndex);
   },
 
-  async beforeEach({ page, context, toImpl, browserName, browserChannel, headful, mode, launchOptions: { executablePath } }, testInfo: folio.TestInfo): Promise<CLITestArgs> {
+  async beforeEach({ page, context, toImpl, browserName, channel, headless, mode, launchOptions: { executablePath } }, testInfo: folio.TestInfo): Promise<CLITestArgs> {
     testInfo.skip(mode === 'service');
     const recorderPageGetter = async () => {
       while (!toImpl(context).recorderAppForTest)
@@ -47,7 +47,7 @@ export const test = contextTest.extend({
     };
     return {
       runCLI: (cliArgs: string[]) => {
-        this._cli = new CLIMock(browserName, browserChannel, !headful, cliArgs, executablePath);
+        this._cli = new CLIMock(browserName, channel, headless, cliArgs, executablePath);
         return this._cli;
       },
       openRecorder: async () => {
@@ -180,7 +180,7 @@ class CLIMock {
   private waitForCallback: () => void;
   exited: Promise<void>;
 
-  constructor(browserName: string, browserChannel: string, headless: boolean, args: string[], executablePath?: string) {
+  constructor(browserName: string, channel: string | undefined, headless: boolean | undefined, args: string[], executablePath?: string) {
     this.data = '';
     const nodeArgs = [
       path.join(__dirname, '..', '..', 'lib', 'cli', 'cli.js'),
@@ -188,8 +188,8 @@ class CLIMock {
       ...args,
       `--browser=${browserName}`,
     ];
-    if (browserChannel)
-      nodeArgs.push(`--channel=${browserChannel}`);
+    if (channel)
+      nodeArgs.push(`--channel=${channel}`);
     this.process = spawn('node', nodeArgs, {
       env: {
         ...process.env,

--- a/tests/page/elementhandle-bounding-box.spec.ts
+++ b/tests/page/elementhandle-bounding-box.spec.ts
@@ -19,8 +19,8 @@ import { test as it, expect } from './pageTest';
 
 it.skip(({ isAndroid }) => isAndroid);
 
-it('should work', async ({ page, server, browserName, headful }) => {
-  it.fail(browserName === 'firefox' && headful);
+it('should work', async ({ page, server, browserName, headless }) => {
+  it.fail(browserName === 'firefox' && !headless);
 
   await page.setViewportSize({ width: 500, height: 500 });
   await page.goto(server.PREFIX + '/grid.html');

--- a/tests/page/elementhandle-screenshot.spec.ts
+++ b/tests/page/elementhandle-screenshot.spec.ts
@@ -21,7 +21,7 @@ import path from 'path';
 import fs from 'fs';
 
 it.describe('element screenshot', () => {
-  it.skip(({ browserName, headful }) => browserName === 'firefox' && headful);
+  it.skip(({ browserName, headless }) => browserName === 'firefox' && !headless);
   it.skip(({ isAndroid }) => isAndroid, 'Different dpr. Remove after using 1x scale for screenshots.');
 
   it('should work', async ({page, server}) => {

--- a/tests/page/elementhandle-select-text.spec.ts
+++ b/tests/page/elementhandle-select-text.spec.ts
@@ -17,12 +17,12 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should select textarea', async ({ page, server, isFirefox }) => {
+it('should select textarea', async ({ page, server, browserName }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   const textarea = await page.$('textarea');
   await textarea.evaluate(textarea => textarea.value = 'some value');
   await textarea.selectText();
-  if (isFirefox) {
+  if (browserName === 'firefox') {
     expect(await textarea.evaluate(el => el.selectionStart)).toBe(0);
     expect(await textarea.evaluate(el => el.selectionEnd)).toBe(10);
   } else {
@@ -30,12 +30,12 @@ it('should select textarea', async ({ page, server, isFirefox }) => {
   }
 });
 
-it('should select input', async ({ page, server, isFirefox }) => {
+it('should select input', async ({ page, server, browserName }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   const input = await page.$('input');
   await input.evaluate(input => input.value = 'some value');
   await input.selectText();
-  if (isFirefox) {
+  if (browserName === 'firefox') {
     expect(await input.evaluate(el => el.selectionStart)).toBe(0);
     expect(await input.evaluate(el => el.selectionEnd)).toBe(10);
   } else {

--- a/tests/page/elementhandle-wait-for-element-state.spec.ts
+++ b/tests/page/elementhandle-wait-for-element-state.spec.ts
@@ -114,8 +114,8 @@ it('should wait for disabled button', async ({page}) => {
   await promise;
 });
 
-it('should wait for stable position', async ({page, server, isFirefox, platform}) => {
-  it.fixme(isFirefox && platform === 'linux');
+it('should wait for stable position', async ({page, server, browserName, platform}) => {
+  it.fixme(browserName === 'firefox' && platform === 'linux');
 
   await page.goto(server.PREFIX + '/input/button.html');
   const button = await page.$('button');

--- a/tests/page/frame-evaluate.spec.ts
+++ b/tests/page/frame-evaluate.spec.ts
@@ -36,31 +36,31 @@ it('should have correct execution contexts', async ({ page, server }) => {
   expect(await page.frames()[1].evaluate(() => document.body.textContent.trim())).toBe(`Hi, I'm frame`);
 });
 
-function expectContexts(pageImpl, count, isChromium) {
-  if (isChromium)
+function expectContexts(pageImpl, count, browserName) {
+  if (browserName === 'chromium')
     expect(pageImpl._delegate._mainFrameSession._contextIdToContext.size).toBe(count);
   else
     expect(pageImpl._delegate._contextIdToContext.size).toBe(count);
 }
 
-it('should dispose context on navigation', async ({ page, server, toImpl, isChromium, mode }) => {
+it('should dispose context on navigation', async ({ page, server, toImpl, browserName, mode }) => {
   it.skip(mode !== 'default');
 
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(page.frames().length).toBe(2);
-  expectContexts(toImpl(page), 4, isChromium);
+  expectContexts(toImpl(page), 4, browserName);
   await page.goto(server.EMPTY_PAGE);
-  expectContexts(toImpl(page), 2, isChromium);
+  expectContexts(toImpl(page), 2, browserName);
 });
 
-it('should dispose context on cross-origin navigation', async ({ page, server, toImpl, isChromium, mode }) => {
+it('should dispose context on cross-origin navigation', async ({ page, server, toImpl, browserName, mode }) => {
   it.skip(mode !== 'default');
 
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(page.frames().length).toBe(2);
-  expectContexts(toImpl(page), 4, isChromium);
+  expectContexts(toImpl(page), 4, browserName);
   await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
-  expectContexts(toImpl(page), 2, isChromium);
+  expectContexts(toImpl(page), 2, browserName);
 });
 
 it('should execute after cross-site navigation', async ({ page, server }) => {

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -145,8 +145,8 @@ it('should work with regular expression passed from a different context', async 
   expect(intercepted).toBe(true);
 });
 
-it('should not break remote worker importScripts', async ({ page, server, isChromium, browserMajorVersion }) => {
-  it.fixme(isChromium && browserMajorVersion < 91);
+it('should not break remote worker importScripts', async ({ page, server, browserName, browserMajorVersion }) => {
+  it.fixme(browserName && browserMajorVersion < 91);
 
   await page.route('**', async route => {
     await route.continue();

--- a/tests/page/jshandle-to-string.spec.ts
+++ b/tests/page/jshandle-to-string.spec.ts
@@ -36,7 +36,7 @@ it('should work for promises', async ({page}) => {
   expect(bHandle.toString()).toBe('JSHandle@promise');
 });
 
-it('should work with different subtypes', async ({page, isWebKit}) => {
+it('should work with different subtypes', async ({page, browserName}) => {
   expect((await page.evaluateHandle('(function(){})')).toString()).toBe('JSHandle@function');
   expect((await page.evaluateHandle('12')).toString()).toBe('JSHandle@12');
   expect((await page.evaluateHandle('true')).toString()).toBe('JSHandle@true');
@@ -54,6 +54,6 @@ it('should work with different subtypes', async ({page, isWebKit}) => {
   expect((await page.evaluateHandle('new WeakSet()')).toString()).toBe('JSHandle@weakset');
   expect((await page.evaluateHandle('new Error()')).toString()).toBe('JSHandle@error');
   // TODO(yurys): change subtype from array to typedarray in WebKit.
-  expect((await page.evaluateHandle('new Int32Array()')).toString()).toBe(isWebKit ? 'JSHandle@array' : 'JSHandle@typedarray');
+  expect((await page.evaluateHandle('new Int32Array()')).toString()).toBe(browserName === 'webkit' ? 'JSHandle@array' : 'JSHandle@typedarray');
   expect((await page.evaluateHandle('new Proxy({}, {})')).toString()).toBe('JSHandle@proxy');
 });

--- a/tests/page/network-post-data.spec.ts
+++ b/tests/page/network-post-data.spec.ts
@@ -88,8 +88,8 @@ it('should return post data for PUT requests', async ({page, server}) => {
   expect(request.postDataJSON()).toEqual({ value: 42 });
 });
 
-it('should get post data for file/blob', async ({page, server, isWebKit, isChromium}) => {
-  it.fail(isWebKit || isChromium);
+it('should get post data for file/blob', async ({page, server, browserName}) => {
+  it.fail(browserName === 'webkit' || browserName === 'chromium');
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     page.waitForRequest('**/*'),

--- a/tests/page/page-add-script-tag.spec.ts
+++ b/tests/page/page-add-script-tag.spec.ts
@@ -74,8 +74,8 @@ it('should work with a path', async ({page, server, asset}) => {
   expect(await page.evaluate(() => window['__injected'])).toBe(42);
 });
 
-it('should include sourceURL when path is provided', async ({page, server, isWebKit, asset}) => {
-  it.skip(isWebKit);
+it('should include sourceURL when path is provided', async ({page, server, browserName, asset}) => {
+  it.skip(browserName === 'webkit');
 
   await page.goto(server.EMPTY_PAGE);
   await page.addScriptTag({ path: asset('injectedfile.js') });

--- a/tests/page/page-basic.spec.ts
+++ b/tests/page/page-basic.spec.ts
@@ -182,7 +182,7 @@ it('page.frame should respect url', async function({page, server}) {
   expect(page.frame({ url: /empty/ }).url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should have sane user agent', async ({page, isChromium, isFirefox, isElectron, isAndroid}) => {
+it('should have sane user agent', async ({page, browserName, isElectron, isAndroid}) => {
   it.skip(isAndroid);
   it.skip(isElectron);
 
@@ -199,7 +199,7 @@ it('should have sane user agent', async ({page, isChromium, isFirefox, isElectro
   // Second part in parenthesis is platform - ignore it.
 
   // Third part for Firefox is the last one and encodes engine and browser versions.
-  if (isFirefox) {
+  if (browserName === 'firefox') {
     const [engine, browser] = part3.split(' ');
     expect(engine.startsWith('Gecko')).toBe(true);
     expect(browser.startsWith('Firefox')).toBe(true);
@@ -213,7 +213,7 @@ it('should have sane user agent', async ({page, isChromium, isFirefox, isElectro
   // 5th part encodes real browser name and engine version.
   const [engine, browser] = part5.split(' ');
   expect(browser.startsWith('Safari/')).toBe(true);
-  if (isChromium)
+  if (browserName === 'chromium')
     expect(engine.includes('Chrome/')).toBe(true);
   else
     expect(engine.startsWith('Version/')).toBe(true);

--- a/tests/page/page-click-scroll.spec.ts
+++ b/tests/page/page-click-scroll.spec.ts
@@ -16,8 +16,8 @@
 
 import { test as it } from './pageTest';
 
-it('should not hit scroll bar', async ({page, isAndroid, isWebKit, platform}) => {
-  it.fixme(isWebKit && platform === 'darwin');
+it('should not hit scroll bar', async ({page, isAndroid, browserName, platform}) => {
+  it.fixme(browserName === 'webkit' && platform === 'darwin');
   it.skip(isAndroid);
 
   await page.setContent(`

--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -306,8 +306,8 @@ it('should click the button inside an iframe', async ({page, server}) => {
   expect(await frame.evaluate(() => window['result'])).toBe('Clicked');
 });
 
-it('should click the button with fixed position inside an iframe', async ({page, server, isChromium, isWebKit}) => {
-  it.fixme(isChromium || isWebKit);
+it('should click the button with fixed position inside an iframe', async ({page, server, browserName}) => {
+  it.fixme(browserName === 'chromium' || browserName === 'webkit');
 
   // @see https://github.com/GoogleChrome/puppeteer/issues/4110
   // @see https://bugs.chromium.org/p/chromium/issues/detail?id=986390
@@ -359,28 +359,28 @@ it('should click the button behind sticky header', async ({page}) => {
   expect(await page.evaluate(() => window['__clicked'])).toBe(true);
 });
 
-it('should click the button with px border with offset', async ({page, server, isWebKit}) => {
+it('should click the button with px border with offset', async ({page, server, browserName}) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', button => button.style.borderWidth = '8px');
   await page.click('button', { position: { x: 20, y: 10 } });
   expect(await page.evaluate('result')).toBe('Clicked');
   // Safari reports border-relative offsetX/offsetY.
-  expect(await page.evaluate('offsetX')).toBe(isWebKit ? 20 + 8 : 20);
-  expect(await page.evaluate('offsetY')).toBe(isWebKit ? 10 + 8 : 10);
+  expect(await page.evaluate('offsetX')).toBe(browserName === 'webkit' ? 20 + 8 : 20);
+  expect(await page.evaluate('offsetY')).toBe(browserName === 'webkit' ? 10 + 8 : 10);
 });
 
-it('should click the button with em border with offset', async ({page, server, isWebKit}) => {
+it('should click the button with em border with offset', async ({page, server, browserName}) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', button => button.style.borderWidth = '2em');
   await page.$eval('button', button => button.style.fontSize = '12px');
   await page.click('button', { position: { x: 20, y: 10 } });
   expect(await page.evaluate('result')).toBe('Clicked');
   // Safari reports border-relative offsetX/offsetY.
-  expect(await page.evaluate('offsetX')).toBe(isWebKit ? 12 * 2 + 20 : 20);
-  expect(await page.evaluate('offsetY')).toBe(isWebKit ? 12 * 2 + 10 : 10);
+  expect(await page.evaluate('offsetX')).toBe(browserName === 'webkit' ? 12 * 2 + 20 : 20);
+  expect(await page.evaluate('offsetY')).toBe(browserName === 'webkit' ? 12 * 2 + 10 : 10);
 });
 
-it('should click a very large button with offset', async ({page, server, isWebKit, isAndroid}) => {
+it('should click a very large button with offset', async ({page, server, browserName, isAndroid}) => {
   it.fixme(isAndroid);
 
   await page.goto(server.PREFIX + '/input/button.html');
@@ -389,11 +389,11 @@ it('should click a very large button with offset', async ({page, server, isWebKi
   await page.click('button', { position: { x: 1900, y: 1910 } });
   expect(await page.evaluate(() => window['result'])).toBe('Clicked');
   // Safari reports border-relative offsetX/offsetY.
-  expect(await page.evaluate('offsetX')).toBe(isWebKit ? 1900 + 8 : 1900);
-  expect(await page.evaluate('offsetY')).toBe(isWebKit ? 1910 + 8 : 1910);
+  expect(await page.evaluate('offsetX')).toBe(browserName === 'webkit' ? 1900 + 8 : 1900);
+  expect(await page.evaluate('offsetY')).toBe(browserName === 'webkit' ? 1910 + 8 : 1910);
 });
 
-it('should click a button in scrolling container with offset', async ({page, server, isWebKit, isAndroid}) => {
+it('should click a button in scrolling container with offset', async ({page, server, browserName, isAndroid}) => {
   it.fixme(isAndroid);
 
   await page.goto(server.PREFIX + '/input/button.html');
@@ -411,8 +411,8 @@ it('should click a button in scrolling container with offset', async ({page, ser
   await page.click('button', { position: { x: 1900, y: 1910 } });
   expect(await page.evaluate(() => window['result'])).toBe('Clicked');
   // Safari reports border-relative offsetX/offsetY.
-  expect(await page.evaluate('offsetX')).toBe(isWebKit ? 1900 + 8 : 1900);
-  expect(await page.evaluate('offsetY')).toBe(isWebKit ? 1910 + 8 : 1910);
+  expect(await page.evaluate('offsetX')).toBe(browserName === 'webkit' ? 1900 + 8 : 1900);
+  expect(await page.evaluate('offsetY')).toBe(browserName === 'webkit' ? 1910 + 8 : 1910);
 });
 
 it('should wait for stable position', async ({page, server}) => {

--- a/tests/page/page-drag.spec.ts
+++ b/tests/page/page-drag.spec.ts
@@ -31,7 +31,7 @@ it.describe('Drag and drop', () => {
     expect(await page.$eval('#target', target => target.contains(document.querySelector('#source')))).toBe(true); // could not find source in target
   });
 
-  it('should send the right events', async ({server, page, isFirefox}) => {
+  it('should send the right events', async ({server, page, browserName}) => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');
     const events = await trackEvents(await page.$('body'));
     await page.hover('#source');
@@ -41,8 +41,8 @@ it.describe('Drag and drop', () => {
     expect(await events.jsonValue()).toEqual([
       'mousemove',
       'mousedown',
-      isFirefox ? 'dragstart' : 'mousemove',
-      isFirefox ? 'mousemove' : 'dragstart',
+      browserName === 'firefox' ? 'dragstart' : 'mousemove',
+      browserName === 'firefox' ? 'mousemove' : 'dragstart',
       'dragenter',
       'dragover',
       'drop',
@@ -50,7 +50,7 @@ it.describe('Drag and drop', () => {
     ]);
   });
 
-  it('should cancel on escape', async ({server, page, isFirefox}) => {
+  it('should cancel on escape', async ({server, page, browserName}) => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');
     const events = await trackEvents(await page.$('body'));
     await page.hover('#source');
@@ -62,8 +62,8 @@ it.describe('Drag and drop', () => {
     expect(await events.jsonValue()).toEqual([
       'mousemove',
       'mousedown',
-      isFirefox ? 'dragstart' : 'mousemove',
-      isFirefox ? 'mousemove' : 'dragstart',
+      browserName === 'firefox' ? 'dragstart' : 'mousemove',
+      browserName === 'firefox' ? 'mousemove' : 'dragstart',
       'dragenter',
       'dragover',
       'dragend',
@@ -74,7 +74,7 @@ it.describe('Drag and drop', () => {
   it.describe('iframe', () => {
     it.fixme('implement dragging with iframes');
 
-    it('should drag into an iframe', async ({server, page, isFirefox}) => {
+    it('should drag into an iframe', async ({server, page, browserName}) => {
       await page.goto(server.PREFIX + '/drag-n-drop.html');
       const frame = await attachFrame(page, 'oopif',server.PREFIX + '/drag-n-drop.html');
       const pageEvents = await trackEvents(await page.$('body'));
@@ -88,8 +88,8 @@ it.describe('Drag and drop', () => {
       expect(await pageEvents.jsonValue()).toEqual([
         'mousemove',
         'mousedown',
-        isFirefox ? 'dragstart' : 'mousemove',
-        isFirefox ? 'mousemove' : 'dragstart',
+        browserName === 'firefox' ? 'dragstart' : 'mousemove',
+        browserName === 'firefox' ? 'mousemove' : 'dragstart',
       ]);
       expect(await frameEvents.jsonValue()).toEqual([
         'dragenter',

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -415,8 +415,8 @@ it('should not throw an error when evaluation does a navigation', async ({ page,
   expect(result).toEqual([42]);
 });
 
-it('should not throw an error when evaluation does a synchronous navigation and returns an object', async ({ page, server, isWebKit }) => {
-  it.fixme(isWebKit);
+it('should not throw an error when evaluation does a synchronous navigation and returns an object', async ({ page, server, browserName }) => {
+  it.fixme(browserName === 'webkit');
 
   // It is imporant to be on about:blank for sync reload.
   const result = await page.evaluate(() => {

--- a/tests/page/page-event-network.spec.ts
+++ b/tests/page/page-event-network.spec.ts
@@ -41,7 +41,7 @@ it('Page.Events.Response', async ({page, server}) => {
   expect(responses[0].request()).toBeTruthy();
 });
 
-it('Page.Events.RequestFailed', async ({page, server, isChromium, isWebKit, isMac, isWindows}) => {
+it('Page.Events.RequestFailed', async ({page, server, browserName, isMac, isWindows}) => {
   server.setRoute('/one-style.css', (req, res) => {
     res.setHeader('Content-Type', 'text/css');
     res.connection.destroy();
@@ -53,9 +53,9 @@ it('Page.Events.RequestFailed', async ({page, server, isChromium, isWebKit, isMa
   expect(failedRequests[0].url()).toContain('one-style.css');
   expect(await failedRequests[0].response()).toBe(null);
   expect(failedRequests[0].resourceType()).toBe('stylesheet');
-  if (isChromium) {
+  if (browserName === 'chromium') {
     expect(failedRequests[0].failure().errorText).toBe('net::ERR_EMPTY_RESPONSE');
-  } else if (isWebKit) {
+  } else if (browserName === 'webkit') {
     if (isMac)
       expect(failedRequests[0].failure().errorText).toBe('The network connection was lost.');
     else if (isWindows)

--- a/tests/page/page-event-pageerror.spec.ts
+++ b/tests/page/page-event-pageerror.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should fire', async ({page, server, isWebKit}) => {
+it('should fire', async ({page, server, browserName}) => {
   const [error] = await Promise.all([
     page.waitForEvent('pageerror'),
     page.goto(server.PREFIX + '/error.html'),
@@ -26,13 +26,13 @@ it('should fire', async ({page, server, isWebKit}) => {
   expect(error.message).toBe('Fancy error!');
   let stack = await page.evaluate(() => window['e'].stack);
   // Note that WebKit reports the stack of the 'throw' statement instead of the Error constructor call.
-  if (isWebKit)
+  if (browserName === 'webkit')
     stack = stack.replace('14:25', '15:19');
   expect(error.stack).toBe(stack);
 });
 
-it('should contain sourceURL', async ({page, server, isWebKit}) => {
-  it.fail(isWebKit);
+it('should contain sourceURL', async ({page, server, browserName}) => {
+  it.fail(browserName === 'webkit');
 
   const [error] = await Promise.all([
     page.waitForEvent('pageerror'),
@@ -87,19 +87,19 @@ it('should handle odd values', async ({page}) => {
   }
 });
 
-it('should handle object', async ({page, isChromium}) => {
+it('should handle object', async ({page, browserName}) => {
   const [error] = await Promise.all([
     page.waitForEvent('pageerror'),
     page.evaluate(() => setTimeout(() => { throw {}; }, 0)),
   ]);
-  expect(error.message).toBe(isChromium ? 'Object' : '[object Object]');
+  expect(error.message).toBe(browserName === 'chromium' ? 'Object' : '[object Object]');
 });
 
-it('should handle window', async ({page, isChromium, isFirefox, isElectron}) => {
+it('should handle window', async ({page, browserName, isElectron}) => {
   it.skip(isElectron);
   const [error] = await Promise.all([
     page.waitForEvent('pageerror'),
     page.evaluate(() => setTimeout(() => { throw window; }, 0)),
   ]);
-  expect(error.message).toBe(isChromium ? 'Window' : '[object Window]');
+  expect(error.message).toBe(browserName === 'chromium' ? 'Window' : '[object Window]');
 });

--- a/tests/page/page-event-popup.spec.ts
+++ b/tests/page/page-event-popup.spec.ts
@@ -46,8 +46,8 @@ it('should emit for immediately closed popups', async ({page}) => {
   expect(popup).toBeTruthy();
 });
 
-it('should emit for immediately closed popups 2', async ({page, server, isFirefox, video}) => {
-  it.fixme(isFirefox && video);
+it('should emit for immediately closed popups 2', async ({page, server, browserName, video}) => {
+  it.fixme(browserName === 'firefox' && video);
 
   await page.goto(server.EMPTY_PAGE);
   const [popup] = await Promise.all([

--- a/tests/page/page-fill.spec.ts
+++ b/tests/page/page-fill.spec.ts
@@ -90,8 +90,8 @@ it('should fill date input after clicking', async ({page, server}) => {
   expect(await page.$eval('input', input => input.value)).toBe('2020-03-02');
 });
 
-it('should throw on incorrect date', async ({page, isWebKit}) => {
-  it.skip(isWebKit, 'WebKit does not support date inputs');
+it('should throw on incorrect date', async ({page, browserName}) => {
+  it.skip(browserName === 'webkit', 'WebKit does not support date inputs');
 
   await page.setContent('<input type=date>');
   const error = await page.fill('input', '2020-13-05').catch(e => e);
@@ -110,8 +110,8 @@ it('should fill month input', async ({page}) => {
   expect(await page.$eval('input', input => input.value)).toBe('2020-07');
 });
 
-it('should throw on incorrect month', async ({page, isChromium}) => {
-  it.skip(!isChromium, 'Only Chromium supports month inputs');
+it('should throw on incorrect month', async ({page, browserName}) => {
+  it.skip(browserName !== 'chromium', 'Only Chromium supports month inputs');
 
   await page.setContent('<input type=month>');
   const error = await page.fill('input', '2020-13').catch(e => e);
@@ -124,16 +124,16 @@ it('should fill week input', async ({page}) => {
   expect(await page.$eval('input', input => input.value)).toBe('2020-W50');
 });
 
-it('should throw on incorrect week', async ({page, isChromium}) => {
-  it.skip(!isChromium, 'Only Chromium supports week inputs');
+it('should throw on incorrect week', async ({page, browserName}) => {
+  it.skip(browserName !== 'chromium', 'Only Chromium supports week inputs');
 
   await page.setContent('<input type=week>');
   const error = await page.fill('input', '2020-123').catch(e => e);
   expect(error.message).toContain('Malformed value');
 });
 
-it('should throw on incorrect time', async ({page, isWebKit}) => {
-  it.skip(isWebKit, 'WebKit does not support time inputs');
+it('should throw on incorrect time', async ({page, browserName}) => {
+  it.skip(browserName === 'webkit', 'WebKit does not support time inputs');
 
   await page.setContent('<input type=time>');
   const error = await page.fill('input', '25:05').catch(e => e);
@@ -146,8 +146,8 @@ it('should fill datetime-local input', async ({page, server}) => {
   expect(await page.$eval('input', input => input.value)).toBe('2020-03-02T05:15');
 });
 
-it('should throw on incorrect datetime-local', async ({page, server, isChromium}) => {
-  it.skip(!isChromium, 'Only Chromium supports datetime-local inputs');
+it('should throw on incorrect datetime-local', async ({page, server, browserName}) => {
+  it.skip(browserName !== 'chromium', 'Only Chromium supports datetime-local inputs');
 
   await page.setContent('<input type=datetime-local>');
   const error = await page.fill('input', 'abc').catch(e => e);

--- a/tests/page/page-focus.spec.ts
+++ b/tests/page/page-focus.spec.ts
@@ -108,9 +108,9 @@ it('should traverse only form elements', async function({page, browserName, plat
   expect(await page.evaluate(() => document.activeElement.id)).toBe('input-1');
 });
 
-it('clicking checkbox should activate it', async ({ page, browserName, headful, platform }) => {
-  it.fixme(browserName === 'webkit' && !headful);
-  it.fixme(browserName === 'firefox' && !headful && platform === 'darwin');
+it('clicking checkbox should activate it', async ({ page, browserName, headless, platform }) => {
+  it.fixme(browserName === 'webkit' && headless);
+  it.fixme(browserName === 'firefox' && headless && platform === 'darwin');
 
   await page.setContent(`<input type=checkbox></input>`);
   await page.click('input');

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -137,7 +137,7 @@ it('should work with subframes return 204 with domcontentloaded', async ({page, 
   await page.goto(server.PREFIX + '/frames/one-frame.html', { waitUntil: 'domcontentloaded' });
 });
 
-it('should fail when server returns 204', async ({page, server, isChromium, isWebKit}) => {
+it('should fail when server returns 204', async ({page, server, browserName}) => {
   // WebKit just loads an empty page.
   server.setRoute('/empty.html', (req, res) => {
     res.statusCode = 204;
@@ -146,9 +146,9 @@ it('should fail when server returns 204', async ({page, server, isChromium, isWe
   let error = null;
   await page.goto(server.EMPTY_PAGE).catch(e => error = e);
   expect(error).not.toBe(null);
-  if (isChromium)
+  if (browserName === 'chromium')
     expect(error.message).toContain('net::ERR_ABORTED');
-  else if (isWebKit)
+  else if (browserName === 'webkit')
     expect(error.message).toContain('Aborted: 204 No Content');
   else
     expect(error.message).toContain('NS_BINDING_ABORTED');
@@ -168,10 +168,10 @@ it('should work when page calls history API in beforeunload', async ({page, serv
   expect(response.status()).toBe(200);
 });
 
-it('should fail when navigating to bad url', async ({page, isChromium, isWebKit}) => {
+it('should fail when navigating to bad url', async ({page, browserName}) => {
   let error = null;
   await page.goto('asdfasdf').catch(e => error = e);
-  if (isChromium || isWebKit)
+  if (browserName === 'chromium' || browserName === 'webkit')
     expect(error.message).toContain('Cannot navigate to invalid URL');
   else
     expect(error.message).toContain('Invalid url');
@@ -213,14 +213,14 @@ it('should throw if networkidle2 is passed as an option', async ({page, server})
   expect(error.message).toContain(`waitUntil: expected one of (load|domcontentloaded|networkidle)`);
 });
 
-it('should fail when main resources failed to load', async ({page, isChromium, isWebKit, isWindows}) => {
+it('should fail when main resources failed to load', async ({page, browserName, isWindows}) => {
   let error = null;
   await page.goto('http://localhost:44123/non-existing-url').catch(e => error = e);
-  if (isChromium)
+  if (browserName === 'chromium')
     expect(error.message).toContain('net::ERR_CONNECTION_REFUSED');
-  else if (isWebKit && isWindows)
+  else if (browserName === 'webkit' && isWindows)
     expect(error.message).toContain(`Couldn\'t connect to server`);
-  else if (isWebKit)
+  else if (browserName === 'webkit')
     expect(error.message).toContain('Could not connect');
   else
     expect(error.message).toContain('NS_ERROR_CONNECTION_REFUSED');
@@ -311,7 +311,7 @@ it('should disable timeout when its set to 0', async ({page, server}) => {
   expect(loaded).toBe(true);
 });
 
-it('should fail when replaced by another navigation', async ({page, server, isChromium, isWebKit}) => {
+it('should fail when replaced by another navigation', async ({page, server, browserName}) => {
   let anotherPromise;
   server.setRoute('/empty.html', (req, res) => {
     anotherPromise = page.goto(server.PREFIX + '/one-style.html');
@@ -319,9 +319,9 @@ it('should fail when replaced by another navigation', async ({page, server, isCh
   });
   const error = await page.goto(server.PREFIX + '/empty.html').catch(e => e);
   await anotherPromise;
-  if (isChromium)
+  if (browserName === 'chromium')
     expect(error.message).toContain('net::ERR_ABORTED');
-  else if (isWebKit)
+  else if (browserName === 'webkit')
     expect(error.message).toContain('cancelled');
   else
     expect(error.message).toContain('NS_BINDING_ABORTED');

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -358,21 +358,21 @@ it('should support MacOS shortcuts', async ({page, server, platform, browserName
   expect(await page.$eval('textarea', textarea => textarea.value)).toBe('some ');
 });
 
-it('should press the meta key', async ({page, isFirefox, isMac}) => {
+it('should press the meta key', async ({page, browserName, isMac}) => {
   const lastEvent = await captureLastKeydown(page);
   await page.keyboard.press('Meta');
   const {key, code, metaKey} = await lastEvent.jsonValue();
-  if (isFirefox && !isMac)
+  if (browserName === 'firefox' && !isMac)
     expect(key).toBe('OS');
   else
     expect(key).toBe('Meta');
 
-  if (isFirefox)
+  if (browserName === 'firefox')
     expect(code).toBe('OSLeft');
   else
     expect(code).toBe('MetaLeft');
 
-  if (isFirefox && !isMac)
+  if (browserName === 'firefox' && !isMac)
     expect(metaKey).toBe(false);
   else
     expect(metaKey).toBe(true);

--- a/tests/page/page-mouse.spec.ts
+++ b/tests/page/page-mouse.spec.ts
@@ -121,12 +121,12 @@ it('should trigger hover state with removed window.Node', async ({page, server})
   expect(await page.evaluate(() => document.querySelector('button:hover').id)).toBe('button-6');
 });
 
-it('should set modifier keys on click', async ({page, server, isFirefox, isMac}) => {
+it('should set modifier keys on click', async ({page, server, browserName, isMac}) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
   await page.evaluate(() => document.querySelector('#button-3').addEventListener('mousedown', e => window['lastEvent'] = e, true));
   const modifiers = {'Shift': 'shiftKey', 'Control': 'ctrlKey', 'Alt': 'altKey', 'Meta': 'metaKey'};
   // In Firefox, the Meta modifier only exists on Mac
-  if (isFirefox && !isMac)
+  if (browserName === 'firefox' && !isMac)
     delete modifiers['Meta'];
   for (const modifier in modifiers) {
     await page.keyboard.down(modifier);
@@ -142,11 +142,11 @@ it('should set modifier keys on click', async ({page, server, isFirefox, isMac})
   }
 });
 
-it('should tween mouse movement', async ({page, isWebKit, isAndroid}) => {
+it('should tween mouse movement', async ({page, browserName, isAndroid}) => {
   it.skip(isAndroid, 'Bad rounding');
 
   // The test becomes flaky on WebKit without next line.
-  if (isWebKit)
+  if (browserName === 'webkit')
     await page.evaluate(() => new Promise(requestAnimationFrame));
   await page.mouse.move(100, 100);
   await page.evaluate(() => {

--- a/tests/page/page-network-request.spec.ts
+++ b/tests/page/page-network-request.spec.ts
@@ -71,13 +71,13 @@ it('should not work for a redirect and interception', async ({page, server}) => 
   expect(requests[0].url()).toBe(server.PREFIX + '/foo.html');
 });
 
-it('should return headers', async ({page, server, isChromium, isFirefox, isWebKit}) => {
+it('should return headers', async ({page, server, browserName}) => {
   const response = await page.goto(server.EMPTY_PAGE);
-  if (isChromium)
+  if (browserName === 'chromium')
     expect(response.request().headers()['user-agent']).toContain('Chrome');
-  else if (isFirefox)
+  else if (browserName === 'firefox')
     expect(response.request().headers()['user-agent']).toContain('Firefox');
-  else if (isWebKit)
+  else if (browserName === 'webkit')
     expect(response.request().headers()['user-agent']).toContain('WebKit');
 });
 

--- a/tests/page/page-request-fulfill.spec.ts
+++ b/tests/page/page-request-fulfill.spec.ts
@@ -48,8 +48,8 @@ it('should work with status code 422', async ({page, server}) => {
   expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
 });
 
-it('should allow mocking binary responses', async ({page, server, browserName, headful, asset, isAndroid}) => {
-  it.skip(browserName === 'firefox' && headful, 'Firefox headful produces a different image.');
+it('should allow mocking binary responses', async ({page, server, browserName, headless, asset, isAndroid}) => {
+  it.skip(browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
   it.skip(isAndroid);
 
   await page.route('**/*', route => {
@@ -69,11 +69,10 @@ it('should allow mocking binary responses', async ({page, server, browserName, h
   expect(await img.screenshot()).toMatchSnapshot('mock-binary-response.png');
 });
 
-it('should allow mocking svg with charset', async ({page, server, browserName, headful, isAndroid}) => {
-  it.skip(browserName === 'firefox' && headful, 'Firefox headful produces a different image.');
+it('should allow mocking svg with charset', async ({page, server, browserName, headless, isAndroid}) => {
+  it.skip(browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
   it.skip(isAndroid);
 
-  // Firefox headful produces a different image.
   await page.route('**/*', route => {
     route.fulfill({
       contentType: 'image/svg+xml ; charset=utf-8',

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -162,8 +162,8 @@ it('should work with redirect inside sync XHR', async ({page, server}) => {
   expect(status).toBe(200);
 });
 
-it('should pause intercepted XHR until continue', async ({page, server, isWebKit}) => {
-  it.fixme(isWebKit, 'Redirected request is not paused in WebKit');
+it('should pause intercepted XHR until continue', async ({page, server, browserName}) => {
+  it.fixme(browserName === 'webkit', 'Redirected request is not paused in WebKit');
 
   await page.goto(server.EMPTY_PAGE);
   let resolveRoute;
@@ -237,15 +237,15 @@ it('should be abortable', async ({page, server}) => {
   expect(failed).toBe(true);
 });
 
-it('should be abortable with custom error codes', async ({page, server, isWebKit, isFirefox}) => {
+it('should be abortable with custom error codes', async ({page, server, browserName}) => {
   await page.route('**/*', route => route.abort('internetdisconnected'));
   let failedRequest = null;
   page.on('requestfailed', request => failedRequest = request);
   await page.goto(server.EMPTY_PAGE).catch(e => {});
   expect(failedRequest).toBeTruthy();
-  if (isWebKit)
+  if (browserName === 'webkit')
     expect(failedRequest.failure().errorText).toBe('Request intercepted');
-  else if (isFirefox)
+  else if (browserName === 'firefox')
     expect(failedRequest.failure().errorText).toBe('NS_ERROR_OFFLINE');
   else
     expect(failedRequest.failure().errorText).toBe('net::ERR_INTERNET_DISCONNECTED');
@@ -263,14 +263,14 @@ it('should send referer', async ({page, server}) => {
   expect(request.headers['referer']).toBe('http://google.com/');
 });
 
-it('should fail navigation when aborting main resource', async ({page, server, isWebKit, isFirefox}) => {
+it('should fail navigation when aborting main resource', async ({page, server, browserName}) => {
   await page.route('**/*', route => route.abort());
   let error = null;
   await page.goto(server.EMPTY_PAGE).catch(e => error = e);
   expect(error).toBeTruthy();
-  if (isWebKit)
+  if (browserName === 'webkit')
     expect(error.message).toContain('Request intercepted');
-  else if (isFirefox)
+  else if (browserName === 'firefox')
     expect(error.message).toContain('NS_ERROR_FAILURE');
   else
     expect(error.message).toContain('net::ERR_FAILED');
@@ -449,8 +449,8 @@ it('should intercept main resource during cross-process navigation', async ({pag
   expect(intercepted).toBe(true);
 });
 
-it('should fulfill with redirect status', async ({page, server, isWebKit}) => {
-  it.fixme(isWebKit, 'in WebKit the redirects are handled by the network stack and we intercept before');
+it('should fulfill with redirect status', async ({page, server, browserName}) => {
+  it.fixme(browserName === 'webkit', 'in WebKit the redirects are handled by the network stack and we intercept before');
 
   await page.goto(server.PREFIX + '/title.html');
   server.setRoute('/final', (req, res) => res.end('foo'));
@@ -472,8 +472,8 @@ it('should fulfill with redirect status', async ({page, server, isWebKit}) => {
   expect(text).toBe('foo');
 });
 
-it('should not fulfill with redirect status', async ({page, server, isWebKit}) => {
-  it.skip(!isWebKit, 'we should support fulfill with redirect in webkit and delete this test');
+it('should not fulfill with redirect status', async ({page, server, browserName}) => {
+  it.skip(browserName !== 'webkit', 'we should support fulfill with redirect in webkit and delete this test');
 
   await page.goto(server.PREFIX + '/empty.html');
 

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -21,7 +21,7 @@ import path from 'path';
 import fs from 'fs';
 
 it.describe('page screenshot', () => {
-  it.skip(({ browserName, headful }) => browserName === 'firefox' && headful, 'Firefox headful produces a different image.');
+  it.skip(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
   it.skip(({ isAndroid }) => isAndroid, 'Different viewport');
 
   it('should work', async ({page, server}) => {

--- a/tests/page/page-set-input-files.spec.ts
+++ b/tests/page/page-set-input-files.spec.ts
@@ -118,8 +118,8 @@ it('should work when file input is not attached to DOM', async ({page, asset}) =
   expect(content).toBe('contents of the file');
 });
 
-it('should not throw when filechooser belongs to iframe', async ({page, server, isFirefox}) => {
-  it.skip(isFirefox, 'Firefox ignores filechooser from child frame');
+it('should not throw when filechooser belongs to iframe', async ({page, server, browserName}) => {
+  it.skip(browserName === 'firefox', 'Firefox ignores filechooser from child frame');
 
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   const frame = page.mainFrame().childFrames()[0];

--- a/tests/page/page-wait-for-load-state.spec.ts
+++ b/tests/page/page-wait-for-load-state.spec.ts
@@ -69,7 +69,7 @@ it('should work with pages that have loaded before being connected to', async ({
   expect(popup.url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should wait for load state of empty url popup', async ({page, isFirefox}) => {
+it('should wait for load state of empty url popup', async ({page, browserName}) => {
   const [popup, readyState] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => {
@@ -78,8 +78,8 @@ it('should wait for load state of empty url popup', async ({page, isFirefox}) =>
     }),
   ]);
   await popup.waitForLoadState();
-  expect(readyState).toBe(isFirefox ? 'uninitialized' : 'complete');
-  expect(await popup.evaluate(() => document.readyState)).toBe(isFirefox ? 'uninitialized' : 'complete');
+  expect(readyState).toBe(browserName === 'firefox' ? 'uninitialized' : 'complete');
+  expect(await popup.evaluate(() => document.readyState)).toBe(browserName === 'firefox' ? 'uninitialized' : 'complete');
 });
 
 it('should wait for load state of about:blank popup ', async ({page}) => {

--- a/tests/pdf.spec.ts
+++ b/tests/pdf.spec.ts
@@ -17,8 +17,8 @@
 import { browserTest as it, expect } from './config/browserTest';
 import fs from 'fs';
 
-it('should be able to save file', async ({contextFactory, headful, browserName}, testInfo) => {
-  it.skip(headful || browserName !== 'chromium', 'Printing to pdf is currently only supported in headless chromium.');
+it('should be able to save file', async ({contextFactory, headless, browserName}, testInfo) => {
+  it.skip(!headless || browserName !== 'chromium', 'Printing to pdf is currently only supported in headless chromium.');
 
   const context = await contextFactory();
   const page = await context.newPage();

--- a/tests/permissions.spec.ts
+++ b/tests/permissions.spec.ts
@@ -100,9 +100,9 @@ it.describe('permissions', () => {
     expect(await getPermission(page, 'geolocation')).toBe('prompt');
   });
 
-  it('should trigger permission onchange', async ({page, context, server, browserName, headful}) => {
+  it('should trigger permission onchange', async ({page, context, server, browserName, headless}) => {
     it.fail(browserName === 'webkit');
-    it.fail(browserName === 'chromium' && headful);
+    it.fail(browserName === 'chromium' && !headless);
 
     await page.goto(server.EMPTY_PAGE);
     await page.evaluate(() => {
@@ -145,10 +145,10 @@ it.describe('permissions', () => {
     await context.close();
   });
 
-  it('should support clipboard read', async ({page, context, server, browserName, headful}) => {
+  it('should support clipboard read', async ({page, context, server, browserName, headless}) => {
     it.fail(browserName === 'webkit');
     it.fail(browserName === 'firefox', 'No such permissions (requires flag) in Firefox');
-    it.fixme(browserName === 'chromium' && headful);
+    it.fixme(browserName === 'chromium' && !headless);
 
     await page.goto(server.EMPTY_PAGE);
     expect(await getPermission(page, 'clipboard-read')).toBe('prompt');

--- a/tests/popup.spec.ts
+++ b/tests/popup.spec.ts
@@ -210,7 +210,7 @@ it('should expose function from browser context', async function({browser, serve
   expect(messages.join('|')).toBe('page|binding');
 });
 
-it('should not dispatch binding on a closed page', async function({browser, server, isFirefox}) {
+it('should not dispatch binding on a closed page', async function({browser, server, browserName}) {
   const context = await browser.newContext();
   const messages = [];
   await context.exposeFunction('add', (a, b) => {
@@ -233,7 +233,7 @@ it('should not dispatch binding on a closed page', async function({browser, serv
     }),
   ]);
   await context.close();
-  if (isFirefox)
+  if (browserName === 'firefox')
     expect(messages.join('|')).toBe('close');
   else
     expect(messages.join('|')).toBe('binding|close');

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -96,8 +96,8 @@ it('should authenticate', async ({browserType, browserOptions, server}) => {
   await browser.close();
 });
 
-it('should exclude patterns', async ({browserType, browserOptions, server, browserName, headful}) => {
-  it.fixme(browserName === 'chromium' && headful, 'Chromium headful crashes with CHECK(!in_frame_tree_) in RenderFrameImpl::OnDeleteFrame.');
+it('should exclude patterns', async ({browserType, browserOptions, server, browserName, headless}) => {
+  it.fixme(browserName === 'chromium' && !headless, 'Chromium headed crashes with CHECK(!in_frame_tree_) in RenderFrameImpl::OnDeleteFrame.');
 
   server.setRoute('/target.html', async (req, res) => {
     res.end('<html><title>Served by the proxy</title></html>');

--- a/tests/screenshot.spec.ts
+++ b/tests/screenshot.spec.ts
@@ -20,7 +20,7 @@ import { PNG } from 'pngjs';
 import { verifyViewport } from './config/utils';
 
 browserTest.describe('page screenshot', () => {
-  browserTest.skip(({ browserName, headful }) => browserName === 'firefox' && headful, 'Firefox headful produces a different image.');
+  browserTest.skip(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
 
   browserTest('should run in parallel in multiple pages', async ({server, contextFactory}) => {
     const context = await contextFactory();
@@ -83,8 +83,8 @@ browserTest.describe('page screenshot', () => {
     await context.close();
   });
 
-  browserTest('should work with large size', async ({ browserName, headful, platform, contextFactory }) => {
-    browserTest.fixme(browserName === 'chromium' && headful === true && platform === 'linux', 'Chromium has gpu problems on linux with large screnshots');
+  browserTest('should work with large size', async ({ browserName, headless, platform, contextFactory }) => {
+    browserTest.fixme(browserName === 'chromium' && !headless && platform === 'linux', 'Chromium has gpu problems on linux with large screnshots');
     browserTest.slow('Large screenshot is slow');
 
     const context = await contextFactory();
@@ -120,7 +120,7 @@ browserTest.describe('page screenshot', () => {
 });
 
 browserTest.describe('element sceenshot', () => {
-  browserTest.skip(({ browserName, headful }) => browserName === 'firefox' && headful);
+  browserTest.skip(({ browserName, headless }) => browserName === 'firefox' && !headless);
 
   browserTest('element screenshot should work with a mobile viewport', async ({browser, server, browserName}) => {
     browserTest.skip(browserName === 'firefox');

--- a/tests/signals.spec.ts
+++ b/tests/signals.spec.ts
@@ -32,7 +32,7 @@ test('should close the browser when the node process closes', async ({startRemot
 });
 
 test.describe('signals', () => {
-  test.skip(({platform, headful}) => platform === 'win32' || headful);
+  test.skip(({platform, headless}) => platform === 'win32' || !headless);
 
   test('should report browser close signal', async ({startRemoteServer, server}) => {
     const remoteServer = await startRemoteServer({ url: server.EMPTY_PAGE });
@@ -54,8 +54,8 @@ test.describe('signals', () => {
     await remoteServer.childExitCode();
   });
 
-  test('should close the browser on SIGINT', async ({startRemoteServer, server, browserChannel}) => {
-    test.fixme(!!browserChannel, 'Uncomment on roll');
+  test('should close the browser on SIGINT', async ({startRemoteServer, server, channel}) => {
+    test.fixme(!!channel, 'Uncomment on roll');
 
     const remoteServer = await startRemoteServer({ url: server.EMPTY_PAGE });
     process.kill(remoteServer.child().pid, 'SIGINT');
@@ -64,8 +64,8 @@ test.describe('signals', () => {
     expect(await remoteServer.childExitCode()).toBe(130);
   });
 
-  test('should close the browser on SIGTERM', async ({startRemoteServer, server, browserChannel}) => {
-    test.fixme(!!browserChannel, 'Uncomment on roll');
+  test('should close the browser on SIGTERM', async ({startRemoteServer, server, channel}) => {
+    test.fixme(!!channel, 'Uncomment on roll');
 
     const remoteServer = await startRemoteServer({ url: server.EMPTY_PAGE });
     process.kill(remoteServer.child().pid, 'SIGTERM');
@@ -74,8 +74,8 @@ test.describe('signals', () => {
     expect(await remoteServer.childExitCode()).toBe(0);
   });
 
-  test('should close the browser on SIGHUP', async ({startRemoteServer, server, browserChannel}) => {
-    test.fixme(!!browserChannel, 'Uncomment on roll');
+  test('should close the browser on SIGHUP', async ({startRemoteServer, server, channel}) => {
+    test.fixme(!!channel, 'Uncomment on roll');
 
     const remoteServer = await startRemoteServer({ url: server.EMPTY_PAGE });
     process.kill(remoteServer.child().pid, 'SIGHUP');

--- a/tests/tracing.spec.ts
+++ b/tests/tracing.spec.ts
@@ -23,8 +23,8 @@ import jpeg from 'jpeg-js';
 const traceDir = path.join(__dirname, '..', 'test-results', 'trace-' + process.env.FOLIO_WORKER_INDEX);
 test.useOptions({ traceDir });
 
-test.beforeEach(async ({ browserName, headful }) => {
-  test.fixme(browserName === 'chromium' && headful, 'Chromium screencast on headful has a min width issue');
+test.beforeEach(async ({ browserName, headless }) => {
+  test.fixme(browserName === 'chromium' && !headless, 'Chromium screencast on headed has a min width issue');
   await new Promise(f => removeFolder(traceDir, f));
 });
 

--- a/tests/video.spec.ts
+++ b/tests/video.spec.ts
@@ -159,7 +159,7 @@ it.describe('screencast', () => {
     expect(error.message).toContain('"videoSize" option requires "videosPath" to be specified');
   });
 
-  it('should work with old options', async ({browser, isFirefox, isWindows}, testInfo) => {
+  it('should work with old options', async ({browser}, testInfo) => {
     const videosPath = testInfo.outputPath('');
     const size = { width: 450, height: 240 };
     const context = await browser.newContext({
@@ -182,7 +182,7 @@ it.describe('screencast', () => {
     expect(error.message).toContain('recordVideo.dir: expected string, got undefined');
   });
 
-  it('should capture static page', async ({browser, isFirefox, isWindows}, testInfo) => {
+  it('should capture static page', async ({browser}, testInfo) => {
     const size = { width: 450, height: 240 };
     const context = await browser.newContext({
       recordVideo: {
@@ -359,9 +359,9 @@ it.describe('screencast', () => {
     }
   });
 
-  it('should capture css transformation', async ({browser, server, headful, browserName, platform}, testInfo) => {
-    it.fixme(headful, 'Fails on headful');
-    it.fixme(browserName === 'webkit' && platform === 'win32', 'Fails on headful');
+  it('should capture css transformation', async ({browser, server, headless, browserName, platform}, testInfo) => {
+    it.fixme(!headless, 'Fails on headed');
+    it.fixme(browserName === 'webkit' && platform === 'win32');
 
     const size = { width: 320, height: 240 };
     // Set viewport equal to screencast frame size to avoid scaling.
@@ -419,8 +419,8 @@ it.describe('screencast', () => {
     expect(videoFiles.length).toBe(2);
   });
 
-  it('should scale frames down to the requested size ', async ({browser, server, headful}, testInfo) => {
-    it.fixme(headful, 'Fails on headful');
+  it('should scale frames down to the requested size ', async ({browser, server, headless}, testInfo) => {
+    it.fixme(!headless, 'Fails on headed');
 
     const context = await browser.newContext({
       recordVideo: {
@@ -503,8 +503,8 @@ it.describe('screencast', () => {
     expect(videoPlayer.videoHeight).toBe(450);
   });
 
-  it('should be 800x600 with null viewport', async ({ browser, headful, browserName }, testInfo) => {
-    it.fixme(browserName === 'firefox' && !headful, 'Fails in headless on bots');
+  it('should be 800x600 with null viewport', async ({ browser, headless, browserName }, testInfo) => {
+    it.fixme(browserName === 'firefox' && headless, 'Fails in headless on bots');
 
     const context = await browser.newContext({
       recordVideo: {

--- a/tests/web-socket.spec.ts
+++ b/tests/web-socket.spec.ts
@@ -111,7 +111,7 @@ it('should emit binary frame events', async ({ page, server }) => {
     expect(sent[1][i]).toBe(i);
 });
 
-it('should emit error', async ({page, server, isFirefox}) => {
+it('should emit error', async ({page, server, browserName}) => {
   let callback;
   const result = new Promise(f => callback = f);
   page.on('websocket', ws => ws.on('socketerror', callback));
@@ -119,7 +119,7 @@ it('should emit error', async ({page, server, isFirefox}) => {
     new WebSocket('ws://localhost:' + port + '/bogus-ws');
   }, server.PORT);
   const message = await result;
-  if (isFirefox)
+  if (browserName === 'firefox')
     expect(message).toBe('CLOSE_ABNORMAL');
   else
     expect(message).toContain(': 400');


### PR DESCRIPTION
This changes `headful` to `headless` to align with launch options.
Also replaces `isChromium` and friends with `browserName`.