### PR TITLE
chore(dotnet): Ignore `As` prefix in properties generation

### DIFF
--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -451,7 +451,8 @@ function renderMethod(member, parent, output, name) {
   // set-only methods to settable properties
   if (member.args.size == 0
     && type !== 'void'
-    && !name.startsWith('Get')) {
+    && !name.startsWith('Get')
+    && !name.startsWith('As')) {
     if (!member.async) {
       if (member.spec)
         output(XmlDoc.renderXmlDoc(member.spec, maxDocumentationColumnWidth));


### PR DESCRIPTION
Part of https://github.com/microsoft/playwright-sharp/issues/1357

Output code https://github.com/microsoft/playwright-sharp/pull/1374