### PR TITLE
docs(dotnet): remove async event handlers in dialog

### DIFF
--- a/docs/src/api/class-dialog.md
+++ b/docs/src/api/class-dialog.md
@@ -91,13 +91,7 @@ class DialogExample
         using var playwright = await Playwright.CreateAsync();
         await using var browser = await playwright.Chromium.LaunchAsync();
         var page = await browser.NewPageAsync();
-
-        page.Dialog += async (_, dialog) =>
-        {
-            System.Console.WriteLine(dialog.Message);
-            await dialog.DismissAsync();
-        };
-
+        page.Dialog += (p, dialog) => dialog.DismissAsync();
         await page.EvaluateAsync("alert('1');");
     }
 }


### PR DESCRIPTION
This is the start (and place for discussion) for cleaning up `async` event handlers. 

cc: @kblok and @pfeldman

In places like this, this "fire & forget" pattern is good enough. That said, I think we should be careful about promoting potential bad practices, but maybe that's a topic for the guides, rather than API docs.