### PR TITLE
fix(chromium): don't cancel downloads with interception

### DIFF
--- a/src/server/chromium/crNetworkManager.ts
+++ b/src/server/chromium/crNetworkManager.ts
@@ -165,6 +165,22 @@ export class CRNetworkManager {
       });
     }
     if (!event.networkId) {
+      // Some downloads come in as document requests without a network id.
+      // Forge a requestWillBeSent event for them so that users can handle them.
+      if (event.resourceType === 'Document') {
+        this._onRequest(workerFrame, {
+          documentURL: event.request.url,
+          initiator: {type: 'other'},
+          loaderId: '',
+          timestamp: 0,
+          wallTime: 0,
+          request: event.request,
+          requestId: event.requestId,
+          frameId: event.frameId,
+          type: event.resourceType
+        }, event);
+        return;
+      }
       // Fetch without networkId means that request was not recongnized by inspector, and
       // it will never receive Network.requestWillBeSent. Most likely, this is an internal request
       // that we can safely fail.

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -484,4 +484,18 @@ it.describe('download event', () => {
     await page.close();
   });
 
+  it('should report downloads with interception and a download attribute', async ({browser, server}) => {
+    const page = await browser.newPage({ acceptDownloads: true });
+    await page.goto(server.EMPTY_PAGE);
+    await page.route(/.*/, r => r.continue());
+    await page.setContent(`<a download="download.txt" href="${server.PREFIX}/download">download</a>`);
+    const [ download ] = await Promise.all([
+      page.waitForEvent('download'),
+      page.click('a')
+    ]);
+    const path = await download.path();
+    expect(fs.existsSync(path)).toBeTruthy();
+    expect(fs.readFileSync(path).toString()).toBe('Hello world');
+    await page.close();
+  });
 });


### PR DESCRIPTION
Fixes #6573

Links with a download attribute are caught by Fetch but don't send Network.requestWillBeSent events.
We were canceling these, which canceled the downloads.﻿
