### PR TITLE
fix(chromium): close background pages on close

### DIFF
--- a/src/server/browserContext.ts
+++ b/src/server/browserContext.ts
@@ -151,6 +151,7 @@ export abstract class BrowserContext extends SdkObject {
   abstract _doExposeBinding(binding: PageBinding): Promise<void>;
   abstract _doUpdateRequestInterception(): Promise<void>;
   abstract _doClose(): Promise<void>;
+  abstract _onClosePersistent(): Promise<void>;
 
   async cookies(urls: string | string[] | undefined = []): Promise<types.NetworkCookie[]> {
     if (urls && !Array.isArray(urls))
@@ -283,6 +284,7 @@ export abstract class BrowserContext extends SdkObject {
         // Close all the pages instead of the context,
         // because we cannot close the default context.
         await Promise.all(this.pages().map(page => page.close(metadata)));
+        await this._onClosePersistent();
       } else {
         // Close the context.
         await this._doClose();

--- a/src/server/chromium/crBrowser.ts
+++ b/src/server/chromium/crBrowser.ts
@@ -437,6 +437,15 @@ export class CRBrowserContext extends BrowserContext {
     }
   }
 
+  async _onClosePersistent() {
+    for (const [targetId, backgroundPage] of this._browser._backgroundPages.entries()) {
+      if (backgroundPage._browserContext === this && backgroundPage._initializedPage) {
+        backgroundPage.didClose();
+        this._browser._backgroundPages.delete(targetId);
+      }
+    }
+  }
+
   backgroundPages(): Page[] {
     const result: Page[] = [];
     for (const backgroundPage of this._browser._backgroundPages.values()) {

--- a/src/server/firefox/ffBrowser.ts
+++ b/src/server/firefox/ffBrowser.ts
@@ -311,6 +311,8 @@ export class FFBrowserContext extends BrowserContext {
     await this._browser._connection.send('Browser.setRequestInterception', { browserContextId: this._browserContextId, enabled: !!this._requestInterceptor });
   }
 
+  async _onClosePersistent() {}
+
   async _doClose() {
     assert(this._browserContextId);
     await this._browser._connection.send('Browser.removeBrowserContext', { browserContextId: this._browserContextId });

--- a/src/server/webkit/wkBrowser.ts
+++ b/src/server/webkit/wkBrowser.ts
@@ -317,6 +317,8 @@ export class WKBrowserContext extends BrowserContext {
       await (page._delegate as WKPage).updateRequestInterception();
   }
 
+  async _onClosePersistent() {}
+
   async _doClose() {
     assert(this._browserContextId);
     await this._browser._browserSession.send('Playwright.deleteContext', { browserContextId: this._browserContextId });

--- a/tests/chromium/launcher.spec.ts
+++ b/tests/chromium/launcher.spec.ts
@@ -72,8 +72,7 @@ it('should return background pages', async ({browserType, browserOptions, create
   expect(context.pages()).not.toContain(backgroundPage);
   await context.close();
   expect(context.pages().length).toBe(0);
-  // TODO: the following line is flaky, uncomment once fixed.
-  // expect(context.backgroundPages().length).toBe(0);
+  expect(context.backgroundPages().length).toBe(0);
 });
 
 it('should return background pages when recording video', async ({browserType, browserOptions, createUserDataDir, asset}, testInfo) => {


### PR DESCRIPTION
I'm not sure if we should wait until the background pages are closed, but currently on Python side we run into flakes on Windows when closing the persistent context that the background pages's close event didn't have fired. By that the background page is still in the background_pages array on the client side when the user is testing extensions.

Good log (2 times page.close event):

```log
2021-05-16T20:41:06.8048181Z     ],
2021-05-16T20:41:06.8048552Z     "apiName": "browser_context.close"
2021-05-16T20:41:06.8049167Z   }
2021-05-16T20:41:07.2530269Z }
2021-05-16T20:41:07.2532508Z [33mRECV>[0m {
2021-05-16T20:41:07.2537051Z   "guid": "page@4d328fdbe0aabdf84856e9fcaa9317e0",
2021-05-16T20:41:07.2539483Z   "method": "close",
2021-05-16T20:41:07.2540606Z   "params": {}
2021-05-16T20:41:07.2541277Z }
2021-05-16T20:41:07.2554637Z [33mRECV>[0m {
2021-05-16T20:41:07.2555360Z   "guid": "page@4d328fdbe0aabdf84856e9fcaa9317e0",
2021-05-16T20:41:07.2556220Z   "method": "__dispose__",
2021-05-16T20:41:07.2556632Z   "params": {}
2021-05-16T20:41:07.2556998Z }
2021-05-16T20:41:07.2557363Z [33mRECV>[0m {
2021-05-16T20:41:07.2557919Z   "guid": "page@eab85f7cd5b40baa91045b2e821ac830",
2021-05-16T20:41:07.2558496Z   "method": "close",
2021-05-16T20:41:07.2558890Z   "params": {}
2021-05-16T20:41:07.2559251Z }
2021-05-16T20:41:07.2559599Z [33mRECV>[0m {
2021-05-16T20:41:07.2560164Z   "guid": "page@eab85f7cd5b40baa91045b2e821ac830",
2021-05-16T20:41:07.2560753Z   "method": "__dispose__",
2021-05-16T20:41:07.2561158Z   "params": {}
2021-05-16T20:41:07.2561515Z }
2021-05-16T20:41:07.2561856Z [33mRECV>[0m {
2021-05-16T20:41:07.2567811Z   "guid": "browser-context@f8891bd4ab908f477de523f74c9c3b86",
2021-05-16T20:41:07.2569681Z   "method": "close",
2021-05-16T20:41:07.2570648Z   "params": {}
2021-05-16T20:41:07.2571508Z }
2021-05-16T20:41:07.2571827Z [33mRECV>[0m {
2021-05-16T20:41:07.2572542Z   "guid": "browser-context@f8891bd4ab908f477de523f74c9c3b86",
2021-05-16T20:41:07.2573179Z   "method": "__dispose__",
2021-05-16T20:41:07.2573576Z   "params": {}
2021-05-16T20:41:07.2573885Z }
2021-05-16T20:41:07.2574494Z [33mRECV>[0m {
2021-05-16T20:41:07.2574850Z   "id": 338
2021-05-16T20:41:07.2575725Z }
```

Bad log (1 time page.close event. Only for the actual page, not background page):

```log
2021-05-16T20:41:08.1119105Z     "apiName": "browser_context.close"
2021-05-16T20:41:08.1119466Z   }
2021-05-16T20:41:08.2989093Z }
2021-05-16T20:41:08.2989800Z [33mRECV>[0m {
2021-05-16T20:41:08.2990389Z   "guid": "page@cd18443df4fe5efdb49a41493b873f9c",
2021-05-16T20:41:08.2990955Z   "method": "close",
2021-05-16T20:41:08.2991350Z   "params": {}
2021-05-16T20:41:08.2991701Z }
2021-05-16T20:41:08.2992034Z [33mRECV>[0m {
2021-05-16T20:41:08.2992559Z   "guid": "page@cd18443df4fe5efdb49a41493b873f9c",
2021-05-16T20:41:08.2993096Z   "method": "__dispose__",
2021-05-16T20:41:08.2993501Z   "params": {}
2021-05-16T20:41:08.2993850Z }
2021-05-16T20:41:08.2994186Z [33mRECV>[0m {
2021-05-16T20:41:08.2994950Z   "guid": "browser-context@0d58c1fd1e1fc7e4c961896cb385b224",
2021-05-16T20:41:08.2996032Z   "method": "close",
2021-05-16T20:41:08.2996516Z   "params": {}
2021-05-16T20:41:08.2996886Z }
2021-05-16T20:41:08.2997221Z [33mRECV>[0m {
2021-05-16T20:41:08.2997746Z   "guid": "page@a27ddcf4175ae2929d603be00e77c1a4",
2021-05-16T20:41:08.2998298Z   "method": "__dispose__",
2021-05-16T20:41:08.2998692Z   "params": {}
2021-05-16T20:41:08.2999058Z }
2021-05-16T20:41:08.2999400Z [33mRECV>[0m {
2021-05-16T20:41:08.2999988Z   "guid": "browser-context@0d58c1fd1e1fc7e4c961896cb385b224",
2021-05-16T20:41:08.3000606Z   "method": "__dispose__",
2021-05-16T20:41:08.3001001Z   "params": {}
2021-05-16T20:41:08.3001352Z }
2021-05-16T20:41:08.3001689Z [33mRECV>[0m {
2021-05-16T20:41:08.3002050Z   "id": 343
2021-05-16T20:41:08.3002369Z }
```

This PR should fix that and close all background pages on close. See here for the full logs (helpful to download them, since its quite verbose): https://github.com/microsoft/playwright-python/pull/695/checks?check_run_id=2595393470#step:12:955

Relates https://github.com/microsoft/playwright-python/pull/695