### PR TITLE
fix(tests): force a new worker for channels.spec

### DIFF
--- a/tests/channels.spec.ts
+++ b/tests/channels.spec.ts
@@ -18,6 +18,10 @@
 import domain from 'domain';
 import { playwrightTest as it, expect } from './config/browserTest';
 
+// Use something worker-scoped (e.g. launch args) to force a new worker for this file.
+// Otherwise, a browser launched for other tests in this worker will affect the expectations.
+it.use({ args: [] });
+
 it('should scope context handles', async ({browserType, browserOptions, server}) => {
   const browser = await browserType.launch(browserOptions);
   const GOLDEN_PRECONDITION = {


### PR DESCRIPTION
It has global-state expectations that do not play nicely with reusing `Browser` between test files.