### PR TITLE
test: mark "should produce screencast frames fit" as flaky on wk linux

### DIFF
--- a/tests/tracing.spec.ts
+++ b/tests/tracing.spec.ts
@@ -118,6 +118,7 @@ for (const params of [
   browserTest(`should produce screencast frames ${params.id}`, async ({ video, contextFactory, browserName, platform }, testInfo) => {
     browserTest.fixme(browserName === 'chromium' && video, 'Same screencast resolution conflicts');
     browserTest.fixme(params.id === 'fit' && browserName === 'chromium' && platform === 'darwin', 'High DPI maxes image at 600x600');
+    browserTest.fixme(params.id === 'fit' && browserName === 'webkit' && platform === 'linux', 'Image size is flaky');
 
     const scale = Math.min(800 / params.width, 600 / params.height, 1);
     const previewWidth = params.width * scale;


### PR DESCRIPTION
https://devops.aslushnikov.com/flakiness2.html#filter_spec=should+produce+screencast+frames+fit&browser=webkit&timestamp=1621276450700

![image](https://user-images.githubusercontent.com/9798949/118539623-81c73380-b704-11eb-9b48-4c834726e6a1.png)
