### PR TITLE
cherry-pick(release-1.11): wait for existing pages when connecting

### DIFF
--- a/src/client/electron.ts
+++ b/src/client/electron.ts
@@ -67,12 +67,16 @@ export class ElectronApplication extends ChannelOwner<channels.ElectronApplicati
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.ElectronApplicationInitializer) {
     super(parent, type, guid, initializer);
     this._context = BrowserContext.from(initializer.context);
-    this._context.on(Events.BrowserContext.Page, page => {
-      this._windows.add(page);
-      this.emit(Events.ElectronApplication.Window, page);
-      page.once(Events.Page.Close, () => this._windows.delete(page));
-    });
+    for (const page of this._context._pages)
+      this._onPage(page);
+    this._context.on(Events.BrowserContext.Page, page => this._onPage(page));
     this._channel.on('close', () => this.emit(Events.ElectronApplication.Close));
+  }
+
+  _onPage(page: Page) {
+    this._windows.add(page);
+    this.emit(Events.ElectronApplication.Window, page);
+    page.once(Events.Page.Close, () => this._windows.delete(page));
   }
 
   windows(): Page[] {

--- a/src/server/electron/electron.ts
+++ b/src/server/electron/electron.ts
@@ -63,6 +63,8 @@ export class ElectronApplication extends SdkObject {
       // Emit application closed after context closed.
       Promise.resolve().then(() => this.emit(ElectronApplication.Events.Close));
     });
+    for (const page of this._browserContext.pages())
+      this._onPage(page);
     this._browserContext.on(BrowserContext.Events.Page, event => this._onPage(event));
     this._nodeConnection = nodeConnection;
     this._nodeSession = nodeConnection.rootSession;
@@ -77,7 +79,7 @@ export class ElectronApplication extends SdkObject {
     this._nodeSession.send('Runtime.enable', {}).catch(e => {});
   }
 
-  private async _onPage(page: Page) {
+  private _onPage(page: Page) {
     // Needs to be sync.
     const windowId = ++this._lastWindowId;
     (page as any)._browserWindowId = windowId;

--- a/tests/chromium/chromium.spec.ts
+++ b/tests/chromium/chromium.spec.ts
@@ -246,3 +246,30 @@ playwrightTest.describe('chromium', () => {
     }
   });
 });
+
+playwrightTest('should report all pages in an existing browser', async ({ browserType, browserOptions }, testInfo) => {
+  const port = 9339 + testInfo.workerIndex;
+  const browserServer = await browserType.launch({
+    ...browserOptions,
+    args: ['--remote-debugging-port=' + port]
+  });
+  try {
+    const cdpBrowser = await browserType.connectOverCDP({
+      endpointURL: `http://localhost:${port}/`,
+    });
+    const contexts = cdpBrowser.contexts();
+    expect(contexts.length).toBe(1);
+    for (let i = 0; i < 3; i++)
+      await contexts[0].newPage();
+    await cdpBrowser.close();
+
+    const cdpBrowser2 = await browserType.connectOverCDP({
+      endpointURL: `http://localhost:${port}/`,
+    });
+    expect(cdpBrowser2.contexts()[0].pages().length).toBe(3);
+
+    await cdpBrowser2.close();
+  } finally {
+    await browserServer.close();
+  }
+});

--- a/tests/electron/electron-app.spec.ts
+++ b/tests/electron/electron-app.spec.ts
@@ -101,7 +101,7 @@ test('should return browser window', async ({ playwright }) => {
   const electronApp = await playwright._electron.launch({
     args: [path.join(__dirname, '..', 'config', 'electron-window-app.js')],
   });
-  const page = await electronApp.waitForEvent('window');
+  const page = await electronApp.firstWindow();
   const bwHandle = await electronApp.browserWindow(page);
   expect(await bwHandle.evaluate((bw: BrowserWindow) => bw.title)).toBe('Electron');
   await electronApp.close();


### PR DESCRIPTION
This cherry-picks two PRs:
- PR https://github.com/microsoft/playwright/pull/6502 SHA 2ea465bc82f596f37fddb59272437dc2f631f6de
- PR https://github.com/microsoft/playwright/pull/6511 SHA 3bded358342c9b73a872d1bfa783bcac2d50eb47