### PR TITLE
browser(firefox): make Juggler types compliant with protocol viewer

### DIFF
--- a/browser_patches/firefox-stable/BUILD_NUMBER
+++ b/browser_patches/firefox-stable/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1252
-Changed: joel.einbinder@gmail.com Fri 14 May 2021 08:01:19 AM PDT
+1253
+Changed: aslushnikov@gmail.com Fri 14 May 2021 21:37:19 PM PDT

--- a/browser_patches/firefox-stable/juggler/protocol/Protocol.js
+++ b/browser_patches/firefox-stable/juggler/protocol/Protocol.js
@@ -130,6 +130,11 @@ runtimeTypes.CallFunctionArgument = {
   value: t.Any,
 };
 
+runtimeTypes.AuxData = {
+  frameId: t.Optional(t.String),
+  name: t.Optional(t.String),
+};
+
 const axTypes = {};
 axTypes.AXTree = {
   role: t.String,
@@ -530,10 +535,7 @@ const Runtime = {
   events: {
     'executionContextCreated': {
       executionContextId: t.String,
-      auxData: {
-        frameId: t.Optional(t.String),
-        name: t.Optional(t.String),
-      },
+      auxData: runtimeTypes.AuxData,
     },
     'executionContextDestroyed': {
       executionContextId: t.String,

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1262
-Changed: joel.einbinder@gmail.com Fri 14 May 2021 08:00:09 AM PDT
+1263
+Changed: aslushnikov@gmail.com Mon 14 May 2021 21:37:09 PM PDT

--- a/browser_patches/firefox/juggler/protocol/Protocol.js
+++ b/browser_patches/firefox/juggler/protocol/Protocol.js
@@ -130,6 +130,11 @@ runtimeTypes.CallFunctionArgument = {
   value: t.Any,
 };
 
+runtimeTypes.AuxData = {
+  frameId: t.Optional(t.String),
+  name: t.Optional(t.String),
+};
+
 const axTypes = {};
 axTypes.AXTree = {
   role: t.String,
@@ -530,10 +535,7 @@ const Runtime = {
   events: {
     'executionContextCreated': {
       executionContextId: t.String,
-      auxData: {
-        frameId: t.Optional(t.String),
-        name: t.Optional(t.String),
-      },
+      auxData: runtimeTypes.AuxData,
     },
     'executionContextDestroyed': {
       executionContextId: t.String,


### PR DESCRIPTION
Protocol viewer can't handle anonymous objects since it's not clear how
to refer to them.

For the record, Juggler protocol viewer is hosted at https://ffprotocol.aslushnikov.com