### PR TITLE
feat(har): record remote IP:PORT and SSL details

### DIFF
--- a/src/server/chromium/crNetworkManager.ts
+++ b/src/server/chromium/crNetworkManager.ts
@@ -296,7 +296,22 @@ export class CRNetworkManager {
         responseStart: -1,
       };
     }
-    return new network.Response(request.request, responsePayload.status, responsePayload.statusText, headersObjectToArray(responsePayload.headers), timing, getResponseBody);
+    const response = new network.Response(request.request, responsePayload.status, responsePayload.statusText, headersObjectToArray(responsePayload.headers), timing, getResponseBody);
+    if (responsePayload?.remoteIPAddress && typeof responsePayload?.remotePort === 'number')
+      response._serverAddrFinished({
+        ipAddress: responsePayload.remoteIPAddress,
+        port: responsePayload.remotePort,
+      });
+    else
+      response._serverAddrFinished();
+    response._securityDetailsFinished({
+      protocol: responsePayload?.securityDetails?.protocol,
+      subjectName: responsePayload?.securityDetails?.subjectName,
+      issuer: responsePayload?.securityDetails?.issuer,
+      validFrom: responsePayload?.securityDetails?.validFrom,
+      validTo: responsePayload?.securityDetails?.validTo,
+    });
+    return response;
   }
 
   _handleRequestRedirect(request: InterceptableRequest, responsePayload: Protocol.Network.Response, timestamp: number) {

--- a/src/server/firefox/ffNetworkManager.ts
+++ b/src/server/firefox/ffNetworkManager.ts
@@ -89,6 +89,20 @@ export class FFNetworkManager {
       responseStart: this._relativeTiming(event.timing.responseStart),
     };
     const response = new network.Response(request.request, event.status, event.statusText, event.headers, timing, getResponseBody);
+    if (event?.remoteIPAddress && typeof event?.remotePort === 'number')
+      response._serverAddrFinished({
+        ipAddress: event.remoteIPAddress,
+        port: event.remotePort,
+      });
+    else
+      response._serverAddrFinished()
+    response._securityDetailsFinished({
+      protocol: event?.securityDetails?.protocol,
+      subjectName: event?.securityDetails?.subjectName,
+      issuer: event?.securityDetails?.issuer,
+      validFrom: event?.securityDetails?.validFrom,
+      validTo: event?.securityDetails?.validTo,
+    });
     this._page._frameManager.requestReceivedResponse(response);
   }
 

--- a/src/server/supplements/har/har.ts
+++ b/src/server/supplements/har/har.ts
@@ -55,6 +55,8 @@ export type Entry = {
   timings: Timings;
   serverIPAddress?: string;
   connection?: string;
+  _serverPort?: number;
+  _securityDetails?: SecurityDetails;
 };
 
 export type Request = {
@@ -143,4 +145,12 @@ export type Timings = {
   wait: number;
   receive: number;
   ssl?: number;
+};
+
+export type SecurityDetails = {
+  protocol?: string;
+  subjectName?: string;
+  issuer?: string;
+  validFrom?: number;
+  validTo?: number;
 };

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -209,6 +209,18 @@ export class HarTracer {
       receive,
     };
     harEntry.time = [dns, connect, ssl, wait, receive].reduce((pre, cur) => cur > 0 ? cur + pre : pre, 0);
+
+    this._addBarrier(page, response.serverAddr().then(server => {
+      if (server?.ipAddress)
+        harEntry.serverIPAddress = server.ipAddress;
+      if (server?.port)
+        harEntry._serverPort = server.port;
+    }));
+    this._addBarrier(page, response.securityDetails().then(details => {
+      if (details)
+        harEntry._securityDetails = details;
+    }));
+
     if (!this._options.omitContent && response.status() === 200) {
       const promise = response.body().then(buffer => {
         harEntry.response.content.text = buffer.toString('base64');

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -322,7 +322,7 @@ it('should have security details', async ({ contextFactory, httpsServer, browser
   expect(serverIPAddress).toMatch(/^127\.0\.0\.1|\[::1\]/);
   expect(port).toBe(httpsServer.PORT);
   if (browserName === 'webkit' && platform === 'win32')
-    expect(securityDetails).toEqual({subjectName: 'puppeteer-tests', validFrom: 1550084863});
+    expect(securityDetails).toEqual({subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: -1});
   else if (browserName === 'webkit')
     expect(securityDetails).toEqual({protocol: 'TLS 1.3', subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: 33086084863});
   else

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -301,3 +301,65 @@ it('should not contain internal pages', async ({ browserName, contextFactory, se
   const log = await getLog();
   expect(log.pages.length).toBe(1);
 });
+
+it('should have connection details', async ({ contextFactory, server, browserName, platform }, testInfo) => {
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo);
+  await page.goto(server.EMPTY_PAGE);
+  const log = await getLog();
+  const { serverIPAddress, _serverPort: port, _securityDetails: securityDetails } = log.entries[0];
+  expect(serverIPAddress).toMatch(/^127\.0\.0\.1|\[::1\]/);
+  expect(port).toBe(server.PORT);
+  expect(securityDetails).toEqual({});
+});
+
+it('should have security details', async ({ contextFactory, httpsServer, browserName, platform }, testInfo) => {
+  it.fail(browserName === 'webkit' && platform === 'linux', 'https://github.com/microsoft/playwright/issues/6759');
+
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo);
+  await page.goto(httpsServer.EMPTY_PAGE);
+  const log = await getLog();
+  const { serverIPAddress, _serverPort: port, _securityDetails: securityDetails } = log.entries[0];
+  expect(serverIPAddress).toMatch(/^127\.0\.0\.1|\[::1\]/);
+  expect(port).toBe(httpsServer.PORT);
+  if (browserName === 'webkit' && platform === 'win32')
+    expect(securityDetails).toEqual({subjectName: 'puppeteer-tests', validFrom: 1550084863});
+  else if (browserName === 'webkit')
+    expect(securityDetails).toEqual({protocol: 'TLS 1.3', subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: 33086084863});
+  else
+    expect(securityDetails).toEqual({issuer: 'puppeteer-tests', protocol: 'TLS 1.3', subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: 33086084863});
+});
+
+it('should have connection details for redirects', async ({ contextFactory, server, browserName }, testInfo) => {
+  server.setRedirect('/foo.html', '/empty.html');
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo);
+  await page.goto(server.PREFIX + '/foo.html');
+  const log = await getLog();
+  expect(log.entries.length).toBe(2);
+
+  const detailsFoo = log.entries[0];
+
+  if (browserName === 'webkit') {
+    expect(detailsFoo.serverIPAddress).toBeUndefined();
+    expect(detailsFoo._serverPort).toBeUndefined();
+  } else {
+    expect(detailsFoo.serverIPAddress).toMatch(/^127\.0\.0\.1|\[::1\]/);
+    expect(detailsFoo._serverPort).toBe(server.PORT);
+  }
+
+  const detailsEmpty = log.entries[1];
+  expect(detailsEmpty.serverIPAddress).toMatch(/^127\.0\.0\.1|\[::1\]/);
+  expect(detailsEmpty._serverPort).toBe(server.PORT);
+});
+
+it('should have connection details for failed requests', async ({ contextFactory, server, browserName, platform }, testInfo) => {
+  server.setRoute('/one-style.css', (_, res) => {
+    res.setHeader('Content-Type', 'text/css');
+    res.connection.destroy();
+  });
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo);
+  await page.goto(server.PREFIX + '/one-style.html');
+  const log = await getLog();
+  const { serverIPAddress, _serverPort: port } = log.entries[0];
+  expect(serverIPAddress).toMatch(/^127\.0\.0\.1|\[::1\]/);
+  expect(port).toBe(server.PORT);
+});


### PR DESCRIPTION
Updates in the HAR capture Log Entries:

* `serverIPAddress`: (string) This now gets populated.
* `_serverPort`: (number) This now gets populated. There isn't an
  official field according to this [w3 doc][w3] (and I didn't see
  a suitable field in a HAR download from Chromium DevTools).

  I used the field name from [WK WebInspector HARBuilder.js][wk].
* `_securityDetails`: non-standard info that is helpful in making
  assertions about cert expiries.

This also introduces new APIs on `network.Response` exposing the
new info.

NB: At first these APIs were synchronous and populated with info that is
readily available at the beginning of the Response creation, but WK does
not emit IP address info until _loadingFinished, so the API's were all
turned into Promise-based approaches.

Closes #6624.

[w3]: https://www.w3.org/community/bigdata-tools/files/2017/10/HAR_Spec_TO_HAR_Vocabulary.pdf
[wk]: https://opensource.apple.com/source/WebInspectorUI/WebInspectorUI-7608.4.9.1.3/UserInterface/Controllers/HARBuilder.js.auto.html
