### PR TITLE
test: unflake webview tests

### DIFF
--- a/tests/android/webview.spec.ts
+++ b/tests/android/webview.spec.ts
@@ -16,6 +16,10 @@
 
 import { androidTest as test, expect } from './androidTest';
 
+test.afterEach(async ({ androidDevice }) => {
+  await androidDevice.shell('am force-stop org.chromium.webview_shell');
+});
+
 test('androidDevice.webView', async function({ androidDevice }) {
   expect(androidDevice.webViews().length).toBe(0);
   await androidDevice.shell('am start org.chromium.webview_shell/.WebViewBrowserActivity');


### PR DESCRIPTION
We close webviews after each test, for the safe `webViews().length` assertions.