### PR TITLE
fix: compute payload mime type on server

### DIFF
--- a/src/client/elementHandle.ts
+++ b/src/client/elementHandle.ts
@@ -302,7 +302,6 @@ export async function convertInputFiles(files: string | FilePayload | string[] |
     if (typeof item === 'string') {
       return {
         name: path.basename(item),
-        mimeType: mime.getType(item) || 'application/octet-stream',
         buffer: (await util.promisify(fs.readFile)(item)).toString('base64')
       };
     } else {

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -1676,7 +1676,7 @@ export type FrameSetInputFilesParams = {
   selector: string,
   files: {
     name: string,
-    mimeType: string,
+    mimeType?: string,
     buffer: Binary,
   }[],
   timeout?: number,
@@ -2181,7 +2181,7 @@ export type ElementHandleSelectTextResult = void;
 export type ElementHandleSetInputFilesParams = {
   files: {
     name: string,
-    mimeType: string,
+    mimeType?: string,
     buffer: Binary,
   }[],
   timeout?: number,

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -1328,7 +1328,7 @@ Frame:
             type: object
             properties:
               name: string
-              mimeType: string
+              mimeType: string?
               buffer: binary
         timeout: number?
         noWaitAfter: boolean?
@@ -1747,7 +1747,7 @@ ElementHandle:
             type: object
             properties:
               name: string
-              mimeType: string
+              mimeType: string?
               buffer: binary
         timeout: number?
         noWaitAfter: boolean?

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -687,7 +687,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     selector: tString,
     files: tArray(tObject({
       name: tString,
-      mimeType: tString,
+      mimeType: tOptional(tString),
       buffer: tBinary,
     })),
     timeout: tOptional(tNumber),
@@ -874,7 +874,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   scheme.ElementHandleSetInputFilesParams = tObject({
     files: tArray(tObject({
       name: tString,
-      mimeType: tString,
+      mimeType: tOptional(tString),
       buffer: tBinary,
     })),
     timeout: tOptional(tNumber),

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as channels from '../protocol/channels';
 import { ConsoleMessage } from './console';
 import * as dom from './dom';
 import { helper, RegisteredListener } from './helper';
@@ -1060,7 +1061,7 @@ export class Frame extends SdkObject {
     }, this._page._timeoutSettings.timeout(options));
   }
 
-  async setInputFiles(metadata: CallMetadata, selector: string, files: types.FilePayload[], options: types.NavigatingActionWaitOptions = {}): Promise<void> {
+  async setInputFiles(metadata: CallMetadata, selector: string, files: channels.ElementHandleSetInputFilesParams['files'], options: types.NavigatingActionWaitOptions = {}): Promise<void> {
     const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, handle => handle._setInputFiles(progress, files, options)));


### PR DESCRIPTION
This way all language bindings will share same code, and could avoid lang-specific errors like [this one](https://github.com/microsoft/playwright-java/issues/412#issuecomment-834479711).

https://github.com/microsoft/playwright-java/issues/412