### PR TITLE
fix: wait for ffmpeg to finish writing even if page was closed

### DIFF
--- a/src/server/chromium/crPage.ts
+++ b/src/server/chromium/crPage.ts
@@ -900,9 +900,11 @@ class FrameSession {
     this._screencastId = null;
     const recorder = this._videoRecorder!;
     this._videoRecorder = null;
-    const video = this._crPage._browserContext._browser._takeVideo(screencastId);
     await this._stopScreencast(recorder);
     await recorder.stop().catch(() => {});
+    // Keep the video artifact in the map utntil encoding is fully finished, if the context
+    // starts closing before the video is fully written to disk it will wait for it.
+    const video = this._crPage._browserContext._browser._takeVideo(screencastId);
     video?.reportFinished();
   }
 

--- a/tests/video.spec.ts
+++ b/tests/video.spec.ts
@@ -615,4 +615,32 @@ it.describe('screencast', () => {
     const saveResult = await page.video().saveAs(file).catch(e => e);
     expect(saveResult.message).toContain('rowser has been closed');
   });
+
+  it('should wait for video to finish if page was closed', async ({browserType, browserOptions, contextOptions}, testInfo) => {
+    const size = { width: 320, height: 240 };
+    const browser = await browserType.launch(browserOptions);
+
+    const videoDir = testInfo.outputPath('');
+    const context = await browser.newContext({
+      ...contextOptions,
+      recordVideo: {
+        dir: videoDir,
+        size,
+      },
+      viewport: size,
+    });
+
+    const page = await context.newPage();
+    await new Promise(r => setTimeout(r, 1000));
+    await page.close();
+    await context.close();
+    await browser.close();
+
+    const videoFiles = findVideos(videoDir);
+    expect(videoFiles.length).toBe(1);
+    const videoPlayer = new VideoPlayer(videoFiles[0]);
+    expect(videoPlayer.videoWidth).toBe(320);
+    expect(videoPlayer.videoHeight).toBe(240);
+  });
+
 });


### PR DESCRIPTION
The bug was introduced in 53d50f9b7. The problem was that the video was removed from the map when the page was closing, after that `context.close()` wouldn't find the video artifact and wouldn't wait for it. Since page.close itself doesn't wait for the video to complete we could end up closing context and browser before the video was fully written to disk.

Refs: https://github.com/microsoft/playwright-java/issues/432