### PR TITLE
chore: install all FF system dependencies with --full on build

### DIFF
--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -87,7 +87,7 @@ if [[ $1 == "--full" || $2 == "--full" ]]; then
     rm -rf "$HOME/.mozbuild/node"
     mv node "$HOME/.mozbuild/"
   elif [[ "$(uname)" == "Darwin" || "$(uname)" == "Linux" ]]; then
-    SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser --no-system-changes
+    SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser
   fi
   if [[ ! -z "${WIN32_REDIST_DIR}" ]]; then
     # Having this option in .mozconfig kills incremental compilation.


### PR DESCRIPTION
Before that it actually didn't install all needed dependencies and failed after that when starting the compiler suite. WebKit also installs dependencies with apt, so it should be fine to install them on OS level.