### PR TITLE
docs: chromiumSandbox is by default false

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -614,7 +614,7 @@ Browser distribution channel. Read more about using [Google Chrome and Microsoft
 ## browser-option-chromiumsandbox
 - `chromiumSandbox` <[boolean]>
 
-Enable Chromium sandboxing. Defaults to `true`.
+Enable Chromium sandboxing. Defaults to `false`.
 
 
 ## browser-option-downloadspath

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -7019,7 +7019,7 @@ export interface BrowserType<Unused = {}> {
     channel?: "chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary";
 
     /**
-     * Enable Chromium sandboxing. Defaults to `true`.
+     * Enable Chromium sandboxing. Defaults to `false`.
      */
     chromiumSandbox?: boolean;
 
@@ -7353,7 +7353,7 @@ export interface BrowserType<Unused = {}> {
     channel?: "chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary";
 
     /**
-     * Enable Chromium sandboxing. Defaults to `true`.
+     * Enable Chromium sandboxing. Defaults to `false`.
      */
     chromiumSandbox?: boolean;
 
@@ -11133,7 +11133,7 @@ export interface LaunchOptions {
   channel?: "chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary";
 
   /**
-   * Enable Chromium sandboxing. Defaults to `true`.
+   * Enable Chromium sandboxing. Defaults to `false`.
    */
   chromiumSandbox?: boolean;
 


### PR DESCRIPTION
This docs only bug was introduced in https://github.com/microsoft/playwright/pull/6545. Here is the implementation, so it's by default false:

https://github.com/microsoft/playwright/blob/fd31ea8b0d7e4a219abd76b0f8a1f4988fac5ef4/src/server/chromium/chromium.ts#L147-L148