### PR TITLE
fix: wait for video to finish when persistent context closes

### DIFF
--- a/src/server/browser.ts
+++ b/src/server/browser.ts
@@ -24,7 +24,6 @@ import { RecentLogsCollector } from '../utils/debugLogger';
 import * as registry from '../utils/registry';
 import { SdkObject } from './instrumentation';
 import { Artifact } from './artifact';
-import { kBrowserClosedError } from '../utils/errors';
 
 export interface BrowserProcess {
   onclose?: ((exitCode: number | null, signal: string | null) => void);

--- a/src/server/browser.ts
+++ b/src/server/browser.ts
@@ -120,9 +120,6 @@ export abstract class Browser extends SdkObject {
       context._browserClosed();
     if (this._defaultContext)
       this._defaultContext._browserClosed();
-    for (const video of this._idToVideo.values())
-      video.artifact.reportFinished(kBrowserClosedError);
-    this._idToVideo.clear();
     this.emit(Browser.Events.Disconnected);
   }
 

--- a/src/server/webkit/wkBrowser.ts
+++ b/src/server/webkit/wkBrowser.ts
@@ -26,6 +26,7 @@ import * as types from '../types';
 import { Protocol } from './protocol';
 import { kPageProxyMessageReceived, PageProxyMessageReceivedPayload, WKConnection, WKSession } from './wkConnection';
 import { WKPage } from './wkPage';
+import { kBrowserClosedError } from '../../utils/errors';
 
 const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.2 Safari/605.1.15';
 const BROWSER_VERSION = '14.2';
@@ -72,6 +73,9 @@ export class WKBrowser extends Browser {
   _onDisconnect() {
     for (const wkPage of this._wkPages.values())
       wkPage.dispose(true);
+    for (const video of this._idToVideo.values())
+      video.artifact.reportFinished(kBrowserClosedError);
+    this._idToVideo.clear();
     this._didClose();
   }
 


### PR DESCRIPTION
Browser._idToVideo map contains video artifact that are not yet fully written to the disk. In case of Chrome it means that the browser may be already dead but ffmpeg is still writing to the file. When browser disconnect event is received no need to interrupt video artifacts as we anyway close all contexts, which in turn closes all pages, which in turn stops all videos. The videos will be removed from the map once ffmpeg finishes.