### PR TITLE
docs: add TypeScript $eval type-hint notes

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -995,6 +995,8 @@ Examples:
 const searchValue = await page.$eval('#search', el => el.value);
 const preloadHref = await page.$eval('link[rel=preload]', el => el.href);
 const html = await page.$eval('.main-container', (e, suffix) => e.outerHTML + suffix, 'hello');
+// In TypeScript, this example requires an explicit type annotation (HTMLLinkElement) on el:
+const preloadHrefTS = await page.$eval('link[rel=preload]', (el: HTMLLinkElement) => el.href);
 ```
 
 ```java

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -200,6 +200,8 @@ export interface Page {
    * const searchValue = await page.$eval('#search', el => el.value);
    * const preloadHref = await page.$eval('link[rel=preload]', el => el.href);
    * const html = await page.$eval('.main-container', (e, suffix) => e.outerHTML + suffix, 'hello');
+   * // In TypeScript, this example requires an explicit type annotation (HTMLLinkElement) on el:
+   * const preloadHrefTS = await page.$eval('link[rel=preload]', (el: HTMLLinkElement) => el.href);
    * ```
    *
    * Shortcut for main frame's


### PR DESCRIPTION
Some of the examples do not compile in TS as is, so this adds a hint
about what to do in TS.

This is based on feedback from a [Slack discussion][slack].

[slack]: https://playwright.slack.com/archives/CSUHZPVLM/p1621489888069900?thread_ts=1621486497.064200&cid=CSUHZPVLM