### PR TITLE
feat(har): record sizes, compression and httpVersion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.swp
 *.pyc
 .vscode
+.idea
 yarn.lock
 /src/generated/*
 lib/

--- a/src/server/chromium/crNetworkManager.ts
+++ b/src/server/chromium/crNetworkManager.ts
@@ -296,7 +296,7 @@ export class CRNetworkManager {
         responseStart: -1,
       };
     }
-    return new network.Response(request.request, responsePayload.status, responsePayload.statusText, headersObjectToArray(responsePayload.headers), timing, getResponseBody);
+    return new network.Response(request.request, responsePayload.status, responsePayload.statusText, headersObjectToArray(responsePayload.headers), timing, getResponseBody, responsePayload.protocol);
   }
 
   _handleRequestRedirect(request: InterceptableRequest, responsePayload: Protocol.Network.Response, timestamp: number) {
@@ -330,8 +330,10 @@ export class CRNetworkManager {
     // Under certain conditions we never get the Network.responseReceived
     // event from protocol. @see https://crbug.com/883475
     const response = request.request._existingResponse();
-    if (response)
+    if (response) {
+      response.setEncodedDataLength(event.encodedDataLength);
       response._requestFinished(helper.secondsToRoundishMillis(event.timestamp - request._timestamp));
+    }
     this._requestIdToRequest.delete(request._requestId);
     if (request._interceptionId)
       this._attemptedAuthentications.delete(request._interceptionId);

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -352,8 +352,8 @@ export class Response extends SdkObject {
   frame(): frames.Frame {
     return this._request.frame();
   }
-  protocol(): string {
-    return this._protocol || 'http/1.1';
+  protocol(): string | undefined {
+    return this._protocol;
   }
 
   encodedDataLength(): number {

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -275,8 +275,10 @@ export class Response extends SdkObject {
   private _headersMap = new Map<string, string>();
   private _getResponseBodyCallback: GetResponseBodyCallback;
   private _timing: ResourceTiming;
+  private _protocol: string | undefined;
+  private _encodedDataLength: number;
 
-  constructor(request: Request, status: number, statusText: string, headers: types.HeadersArray, timing: ResourceTiming, getResponseBodyCallback: GetResponseBodyCallback) {
+  constructor(request: Request, status: number, statusText: string, headers: types.HeadersArray, timing: ResourceTiming, getResponseBodyCallback: GetResponseBodyCallback, protocol: string | undefined) {
     super(request.frame(), 'response');
     this._request = request;
     this._timing = timing;
@@ -291,11 +293,17 @@ export class Response extends SdkObject {
       this._finishedPromiseCallback = f;
     });
     this._request._setResponse(this);
+    this._protocol = protocol;
+    this._encodedDataLength = -1;
   }
 
   _requestFinished(responseEndTiming: number, error?: string) {
     this._request._responseEndTiming = Math.max(responseEndTiming, this._timing.responseStart);
     this._finishedPromiseCallback({ error });
+  }
+
+  setEncodedDataLength(bytes: number) {
+    this._encodedDataLength = bytes;
   }
 
   url(): string {
@@ -343,6 +351,13 @@ export class Response extends SdkObject {
 
   frame(): frames.Frame {
     return this._request.frame();
+  }
+  protocol(): string {
+    return this._protocol || 'http/1.1';
+  }
+
+  encodedDataLength(): number {
+    return this._encodedDataLength;
   }
 }
 

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -306,6 +306,10 @@ export class Response extends SdkObject {
     this._encodedDataLength = bytes;
   }
 
+  setProtocol(protocol: string) {
+    this._protocol = protocol;
+  }
+
   url(): string {
     return this._url;
   }

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -278,7 +278,7 @@ export class Response extends SdkObject {
   private _protocol: string | undefined;
   private _encodedDataLength: number;
 
-  constructor(request: Request, status: number, statusText: string, headers: types.HeadersArray, timing: ResourceTiming, getResponseBodyCallback: GetResponseBodyCallback, protocol: string | undefined) {
+  constructor(request: Request, status: number, statusText: string, headers: types.HeadersArray, timing: ResourceTiming, getResponseBodyCallback: GetResponseBodyCallback, protocol?: string) {
     super(request.frame(), 'response');
     this._request = request;
     this._timing = timing;

--- a/src/server/supplements/har/har.ts
+++ b/src/server/supplements/har/har.ts
@@ -79,6 +79,7 @@ export type Response = {
   redirectURL: string;
   headersSize: number;
   bodySize: number;
+  _transferSize: number;
 };
 
 export type Cookie = {

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -174,6 +174,7 @@ export class HarTracer {
 
     const httpVersion = response.protocol() || FALLBACK_HTTP_VERSION;
     const transferSize = response.encodedDataLength();
+    // TODO: replace with "native" headers size if/when supported in the telemetry by all supported browsers.
     const headersSize = calcResponseHeadersSize(httpVersion, response.status(), response.statusText(), response.headers());
     const bodySize = transferSize - headersSize;
     harEntry.request.httpVersion = httpVersion;

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -211,8 +211,10 @@ export class HarTracer {
     };
     if (!this._options.omitContent && response.status() === 200) {
       const promise = response.body().then(buffer => {
-        harEntry.response.content.text = buffer.toString('base64');
-        harEntry.response.content.encoding = 'base64';
+        if (buffer && buffer.length > 0) {
+          harEntry.response.content.text = buffer.toString('base64');
+          harEntry.response.content.encoding = 'base64';
+        }
         harEntry.response.content.size = buffer.length;
         harEntry.response.content.compression = buffer.length - harEntry.response.bodySize;
       }).catch(() => {});

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -138,7 +138,7 @@ export class HarTracer {
         headers: [],
         content: {
           size: -1,
-          mimeType: request.headerValue('content-type') || 'application/octet-stream',
+          mimeType: request.headerValue('content-type') || 'x-unknown',
         },
         headersSize: -1,
         bodySize: -1,

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -169,7 +169,8 @@ export class HarTracer {
 
     const response = await request.response();
 
-    if (!response) return;
+    if (!response)
+      return;
 
     const httpVersion = response.protocol() ? response.protocol() : FALLBACK_HTTP_VERSION;
     const transferSize = response.encodedDataLength();

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -185,7 +185,7 @@ export class HarTracer {
       headers: response.headers().map(header => ({ name: header.name, value: header.value })),
       content: {
         size: -1,
-        mimeType: response.headerValue('content-type') || 'application/octet-stream',
+        mimeType: response.headerValue('content-type') || 'x-unknown',
       },
       headersSize: headersSize || -1,
       bodySize: bodySize || -1,

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -24,7 +24,7 @@ import * as har from './har';
 import * as types from '../../types';
 
 const fsWriteFileAsync = util.promisify(fs.writeFile.bind(fs));
-const FALLBACK_HTTP_VERSION = 'HTTP/1.1'
+const FALLBACK_HTTP_VERSION = 'HTTP/1.1';
 
 type HarOptions = {
   path: string;

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -24,7 +24,7 @@ import * as har from './har';
 import * as types from '../../types';
 
 const fsWriteFileAsync = util.promisify(fs.writeFile.bind(fs));
-const FALLBACK_HTTP_VERSION = 'HTTP/1.1';
+const FALLBACK_HTTP_VERSION = 'http/1.1';
 
 type HarOptions = {
   path: string;
@@ -171,7 +171,7 @@ export class HarTracer {
 
     if (!response) return;
 
-    const httpVersion = response.protocol() ? response.protocol().toUpperCase() : FALLBACK_HTTP_VERSION;
+    const httpVersion = response.protocol() ? response.protocol() : FALLBACK_HTTP_VERSION;
     const transferSize = response.encodedDataLength();
     const headersSize = calcResponseHeadersSize(httpVersion, response.status(), response.statusText(), response.headers());
     const bodySize = transferSize - headersSize;

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -173,7 +173,7 @@ export class HarTracer {
 
     const httpVersion = response.protocol() ? response.protocol().toUpperCase() : FALLBACK_HTTP_VERSION;
     const transferSize = response.encodedDataLength();
-    const headersSize = calcResponseHeadersSize(response.protocol(), response.status(), response.statusText(), response.headers());
+    const headersSize = calcResponseHeadersSize(httpVersion, response.status(), response.statusText(), response.headers());
     const bodySize = transferSize - headersSize;
     harEntry.request.httpVersion = httpVersion;
 

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -172,7 +172,7 @@ export class HarTracer {
     if (!response)
       return;
 
-    const httpVersion = response.protocol() ? response.protocol() : FALLBACK_HTTP_VERSION;
+    const httpVersion = response.protocol() || FALLBACK_HTTP_VERSION;
     const transferSize = response.encodedDataLength();
     const headersSize = calcResponseHeadersSize(httpVersion, response.status(), response.statusText(), response.headers());
     const bodySize = transferSize - headersSize;

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -122,7 +122,7 @@ export class HarTracer {
       request: {
         method: request.method(),
         url: request.url(),
-        httpVersion: 'http/1.1',
+        httpVersion: FALLBACK_HTTP_VERSION,
         cookies: [],
         headers: [],
         queryString: [...url.searchParams].map(e => ({ name: e[0], value: e[1] })),
@@ -133,7 +133,7 @@ export class HarTracer {
       response: {
         status: -1,
         statusText: '',
-        httpVersion: 'http/1.1',
+        httpVersion: FALLBACK_HTTP_VERSION,
         cookies: [],
         headers: [],
         content: {
@@ -171,14 +171,16 @@ export class HarTracer {
 
     if (!response) return;
 
+    const httpVersion = response.protocol() ? response.protocol().toUpperCase() : FALLBACK_HTTP_VERSION;
     const transferSize = response.encodedDataLength();
     const headersSize = calcResponseHeadersSize(response.protocol(), response.status(), response.statusText(), response.headers());
     const bodySize = transferSize - headersSize;
+    harEntry.request.httpVersion = httpVersion;
 
     harEntry.response = {
       status: response.status(),
       statusText: response.statusText(),
-      httpVersion: response.protocol() ? response.protocol().toUpperCase() : FALLBACK_HTTP_VERSION,
+      httpVersion: httpVersion,
       cookies: cookiesForHar(response.headerValue('set-cookie'), '\n'),
       headers: response.headers().map(header => ({ name: header.name, value: header.value })),
       content: {

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -24,6 +24,7 @@ import * as har from './har';
 import * as types from '../../types';
 
 const fsWriteFileAsync = util.promisify(fs.writeFile.bind(fs));
+const FALLBACK_HTTP_VERSION = 'HTTP/1.1'
 
 type HarOptions = {
   path: string;
@@ -177,7 +178,7 @@ export class HarTracer {
     harEntry.response = {
       status: response.status(),
       statusText: response.statusText(),
-      httpVersion: response.protocol() || 'http/1.1',
+      httpVersion: response.protocol() ? response.protocol().toUpperCase() : FALLBACK_HTTP_VERSION,
       cookies: cookiesForHar(response.headerValue('set-cookie'), '\n'),
       headers: response.headers().map(header => ({ name: header.name, value: header.value })),
       content: {

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -970,6 +970,8 @@ export class WKPage implements PageDelegate {
       response._requestFinished(helper.secondsToRoundishMillis(event.timestamp - request._timestamp));
       if (event.metrics?.responseHeaderBytesReceived && event.metrics?.responseBodyBytesReceived)
         response.setEncodedDataLength(event.metrics.responseBodyBytesReceived  + event.metrics.responseHeaderBytesReceived);
+      if (event.metrics?.protocol)
+        response.setProtocol(event.metrics.protocol);
     }
     this._requestIdToRequest.delete(request._requestId);
     this._page._frameManager.requestFinished(request.request);

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -966,8 +966,11 @@ export class WKPage implements PageDelegate {
     // Under certain conditions we never get the Network.responseReceived
     // event from protocol. @see https://crbug.com/883475
     const response = request.request._existingResponse();
-    if (response)
+    if (response) {
       response._requestFinished(helper.secondsToRoundishMillis(event.timestamp - request._timestamp));
+      if (event.metrics?.responseHeaderBytesReceived && event.metrics?.responseBodyBytesReceived)
+        response.setEncodedDataLength(event.metrics.responseBodyBytesReceived  + event.metrics.responseHeaderBytesReceived);
+    }
     this._requestIdToRequest.delete(request._requestId);
     this._page._frameManager.requestFinished(request.request);
   }

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -92,7 +92,7 @@ it('should include request', async ({ contextFactory, server }, testInfo) => {
   expect(entry.pageref).toBe('page_0');
   expect(entry.request.url).toBe(server.EMPTY_PAGE);
   expect(entry.request.method).toBe('GET');
-  expect(entry.request.httpVersion).toBe('HTTP/1.1');
+  expect(entry.request.httpVersion).toBe('http/1.1');
   expect(entry.request.headers.length).toBeGreaterThan(1);
   expect(entry.request.headers.find(h => h.name.toLowerCase() === 'user-agent')).toBeTruthy();
 });
@@ -104,7 +104,7 @@ it('should include response', async ({ contextFactory, server }, testInfo) => {
   const entry = log.entries[0];
   expect(entry.response.status).toBe(200);
   expect(entry.response.statusText).toBe('OK');
-  expect(entry.response.httpVersion).toBe('HTTP/1.1');
+  expect(entry.response.httpVersion).toBe('http/1.1');
   expect(entry.response.headers.length).toBeGreaterThan(1);
   expect(entry.response.headers.find(h => h.name.toLowerCase() === 'content-type').value).toContain('text/html');
 });
@@ -241,13 +241,24 @@ it('should include content', async ({ contextFactory, server }, testInfo) => {
   await page.goto(server.PREFIX + '/har.html');
   const log = await getLog();
 
-  const content1 = log.entries[0].response.content;
-  expect(content1.encoding).toBe('base64');
-  expect(content1.mimeType).toBe('text/html; charset=utf-8');
-  expect(Buffer.from(content1.text, 'base64').toString()).toContain('HAR Page');
+  const response1 = log.entries[0].response;
+  expect(response1.content.encoding).toBe('base64');
+  expect(response1.content.mimeType).toBe('text/html; charset=utf-8');
+  expect(Buffer.from(response1.content.text, 'base64').toString()).toContain('HAR Page');
+  expect(response1.bodySize).toBe(96);
+  expect(response1.headersSize).toBe(198);
+  expect(response1._transferSize).toBe(294);
+  expect(response1.content.size).toBe(96);
+  expect(response1.content.compression).toBe(0);
 
-  const content2 = log.entries[1].response.content;
-  expect(content2.encoding).toBe('base64');
-  expect(content2.mimeType).toBe('text/css; charset=utf-8');
-  expect(Buffer.from(content2.text, 'base64').toString()).toContain('pink');
+  const response2 = log.entries[1].response;
+  expect(response2.content.encoding).toBe('base64');
+  expect(response2.content.mimeType).toBe('text/css; charset=utf-8');
+  expect(Buffer.from(response2.content.text, 'base64').toString()).toContain('pink');
+  expect(response2.bodySize).toBe(37);
+  expect(response2.headersSize).toBe(197);
+  expect(response2._transferSize).toBe(234);
+  expect(response2.content.size).toBe(37);
+  expect(response2.content.compression).toBe(0);
 });
+

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -236,28 +236,30 @@ it('should include secure set-cookies', async ({ contextFactory, httpsServer }, 
   expect(cookies[0]).toEqual({ name: 'name1', value: 'value1', secure: true });
 });
 
-it('should include content', async ({ contextFactory, server }, testInfo) => {
+it.only('should include content', async ({ contextFactory, server }, testInfo) => {
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
   await page.goto(server.PREFIX + '/har.html');
   const log = await getLog();
 
   const response1 = log.entries[0].response;
+  expect(response1.bodySize).toBe(96);
+  expect(response1.headersSize).toBe(198);
+  expect(response1.httpVersion).toBe('HTTP/1.1');
+  expect(response1._transferSize).toBe(294);
   expect(response1.content.encoding).toBe('base64');
   expect(response1.content.mimeType).toBe('text/html; charset=utf-8');
   expect(Buffer.from(response1.content.text, 'base64').toString()).toContain('HAR Page');
-  expect(response1.bodySize).toBe(96);
-  expect(response1.headersSize).toBe(198);
-  expect(response1._transferSize).toBe(294);
   expect(response1.content.size).toBe(96);
   expect(response1.content.compression).toBe(0);
 
   const response2 = log.entries[1].response;
+  expect(response2.bodySize).toBe(37);
+  expect(response2.headersSize).toBe(197);
+  expect(response2.httpVersion).toBe('HTTP/1.1');
+  expect(response2._transferSize).toBe(234);
   expect(response2.content.encoding).toBe('base64');
   expect(response2.content.mimeType).toBe('text/css; charset=utf-8');
   expect(Buffer.from(response2.content.text, 'base64').toString()).toContain('pink');
-  expect(response2.bodySize).toBe(37);
-  expect(response2.headersSize).toBe(197);
-  expect(response2._transferSize).toBe(234);
   expect(response2.content.size).toBe(37);
   expect(response2.content.compression).toBe(0);
 });

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -236,7 +236,7 @@ it('should include secure set-cookies', async ({ contextFactory, httpsServer }, 
   expect(cookies[0]).toEqual({ name: 'name1', value: 'value1', secure: true });
 });
 
-it.only('should include content', async ({ contextFactory, server }, testInfo) => {
+it('should include content', async ({ contextFactory, server }, testInfo) => {
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
   await page.goto(server.PREFIX + '/har.html');
   const log = await getLog();
@@ -244,7 +244,7 @@ it.only('should include content', async ({ contextFactory, server }, testInfo) =
   const response1 = log.entries[0].response;
   expect(response1.bodySize).toBe(96);
   expect(response1.headersSize).toBe(198);
-  expect(response1.httpVersion).toBe('HTTP/1.1');
+  expect(response1.httpVersion).toBe('http/1.1');
   expect(response1._transferSize).toBe(294);
   expect(response1.content.encoding).toBe('base64');
   expect(response1.content.mimeType).toBe('text/html; charset=utf-8');
@@ -255,7 +255,7 @@ it.only('should include content', async ({ contextFactory, server }, testInfo) =
   const response2 = log.entries[1].response;
   expect(response2.bodySize).toBe(37);
   expect(response2.headersSize).toBe(197);
-  expect(response2.httpVersion).toBe('HTTP/1.1');
+  expect(response2.httpVersion).toBe('http/1.1');
   expect(response2._transferSize).toBe(234);
   expect(response2.content.encoding).toBe('base64');
   expect(response2.content.mimeType).toBe('text/css; charset=utf-8');


### PR DESCRIPTION
This PR attempts to update a set of missing properties in the HAR file, where earlier a default -1 was reported and also report the correct HTTP Version, which was hard coded to `HTTP/1.1`

The test in `tests/har.spec.ts:244` should show what is being done.
- `bodySize`
- `headersSize`
- `httpVersion`
- `_transferSize`: note this is not an official property, but used by Chrome.
- `content.size`
- `content.compression`

The biggest change is that the fields at the end of the request/response cycle are now done on `Page.Events.onRequestFinished` instead of `Page.Events.onResponse`.


## Note 1
This does not work yet for Firefox as no `transferSize` like property is available. However, we can probably make that happen with some work on the NetworkObserver.js patches.

## Note 2
I went down the rabbit hole of solving this problem by populating the various `size` using the `performance.getEntriesByName()` API from the browser. However, CORS settings makes this unreliable.