### PR TITLE
feat(webkit): roll Deprecated WebKit to 1444

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -21,7 +21,7 @@
       "revision": "1482",
       "installByDefault": true,
       "revisionOverrides": {
-        "mac10.14": "1443"
+        "mac10.14": "1444"
       }
     },
     {


### PR DESCRIPTION
Otherwise webkit on 10.14 fails all CLI tests and renders flakiness
dashboard unpleasant.