### PR TITLE
fix(install): prevent new-lines on CI/without TTY

### DIFF
--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -54,6 +54,8 @@ export async function downloadBrowserWithProgressBar(registry: Registry, browser
   let lastDownloadedBytes = 0;
 
   function progress(downloadedBytes: number, totalBytes: number) {
+    if (!process.stderr.isTTY)
+      return;
     if (!progressBar) {
       progressBar = new ProgressBar(`Downloading ${progressBarName} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `, {
         complete: '=',


### PR DESCRIPTION
Before it resulted in:
```
chromium v879910 downloaded to /home/runner/.cache/ms-playwright/chromium-879910

firefox v1261 downloaded to /home/runner/.cache/ms-playwright/firefox-1261

webkit v1481 downloaded to /home/runner/.cache/ms-playwright/webkit-1481

ffmpeg v1005 downloaded to /home/runner/.cache/ms-playwright/ffmpeg-1005
```

now it results in
```
chromium v879910 downloaded to /home/runner/.cache/ms-playwright/chromium-879910
firefox v1261 downloaded to /home/runner/.cache/ms-playwright/firefox-1261
webkit v1481 downloaded to /home/runner/.cache/ms-playwright/webkit-1481
ffmpeg v1005 downloaded to /home/runner/.cache/ms-playwright/ffmpeg-1005
```

This was caused because the `progressBar.tick` function internally wrote a new line when a download of a browser/ffmpeg was completed. With this change we never invoke the progress-bar when there is no TTY on the stderr, thats the output which the progress-bar uses.

Affected was mostly CI/bots.