### PR TITLE
test: skip from toImpl fixture

### DIFF
--- a/tests/defaultbrowsercontext-2.spec.ts
+++ b/tests/defaultbrowsercontext-2.spec.ts
@@ -155,9 +155,7 @@ it('should throw if page argument is passed', async ({browserType, browserOption
   expect(error.message).toContain('can not specify page');
 });
 
-it('should have passed URL when launching with ignoreDefaultArgs: true', async ({browserType, browserOptions, server, createUserDataDir, toImpl, mode, browserName}) => {
-  it.skip(mode !== 'default');
-
+it('should have passed URL when launching with ignoreDefaultArgs: true', async ({browserType, browserOptions, server, createUserDataDir, toImpl, browserName}) => {
   const userDataDir = await createUserDataDir();
   const args = toImpl(browserType)._defaultArgs(browserOptions, 'persistent', userDataDir, 0).filter(a => a !== 'about:blank');
   const options = {

--- a/tests/inspector/cli-codegen-1.spec.ts
+++ b/tests/inspector/cli-codegen-1.spec.ts
@@ -17,7 +17,6 @@
 import { test, expect } from './inspectorTest';
 
 test.describe('cli codegen', () => {
-  test.skip(({ mode }) => mode !== 'default');
   test.fixme(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Focus is off');
 
   test('should click', async ({ page, openRecorder }) => {

--- a/tests/inspector/cli-codegen-2.spec.ts
+++ b/tests/inspector/cli-codegen-2.spec.ts
@@ -18,8 +18,6 @@ import { test, expect } from './inspectorTest';
 import * as url from 'url';
 
 test.describe('cli codegen', () => {
-  test.skip(({ mode }) => mode !== 'default');
-
   test('should contain open page', async ({ openRecorder }) => {
     const recorder = await openRecorder();
 

--- a/tests/inspector/inspectorTest.ts
+++ b/tests/inspector/inspectorTest.ts
@@ -29,9 +29,8 @@ type CLITestArgs = {
 };
 
 export const test = contextTest.extend<CLITestArgs>({
-  recorderPageGetter: async ({ page, context, toImpl, browserName, channel, headless, mode, executablePath }, run, testInfo) => {
+  recorderPageGetter: async ({ context, toImpl }, run, testInfo) => {
     process.env.PWTEST_RECORDER_PORT = String(10907 + testInfo.workerIndex);
-    testInfo.skip(mode === 'service');
     await run(async () => {
       while (!toImpl(context).recorderAppForTest)
         await new Promise(f => setTimeout(f, 100));

--- a/tests/inspector/pause.spec.ts
+++ b/tests/inspector/pause.spec.ts
@@ -18,8 +18,6 @@ import { Page } from '../../index';
 import { test as it, expect } from './inspectorTest';
 
 it.describe('pause', () => {
-  it.skip(({ mode }) => mode !== 'default');
-
   it.afterEach(async ({ recorderPageGetter }) => {
     try {
       const recorderPage = await recorderPageGetter();
@@ -38,10 +36,11 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should resume from console', async ({page}) => {
+  it('should resume from console', async ({page, recorderPageGetter}) => {
     const scriptPromise = (async () => {
       await page.pause();
     })();
+    await recorderPageGetter();
     await Promise.all([
       page.waitForFunction(() => (window as any).playwright && (window as any).playwright.resume).then(() => {
         return page.evaluate('window.playwright.resume()');

--- a/tests/page/frame-evaluate.spec.ts
+++ b/tests/page/frame-evaluate.spec.ts
@@ -43,9 +43,7 @@ function expectContexts(pageImpl, count, browserName) {
     expect(pageImpl._delegate._contextIdToContext.size).toBe(count);
 }
 
-it('should dispose context on navigation', async ({ page, server, toImpl, browserName, mode }) => {
-  it.skip(mode !== 'default');
-
+it('should dispose context on navigation', async ({ page, server, toImpl, browserName }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(page.frames().length).toBe(2);
   expectContexts(toImpl(page), 4, browserName);
@@ -53,9 +51,7 @@ it('should dispose context on navigation', async ({ page, server, toImpl, browse
   expectContexts(toImpl(page), 2, browserName);
 });
 
-it('should dispose context on cross-origin navigation', async ({ page, server, toImpl, browserName, mode }) => {
-  it.skip(mode !== 'default');
-
+it('should dispose context on cross-origin navigation', async ({ page, server, toImpl, browserName }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(page.frames().length).toBe(2);
   expectContexts(toImpl(page), 4, browserName);

--- a/tests/page/page-evaluate-no-stall.spec.ts
+++ b/tests/page/page-evaluate-no-stall.spec.ts
@@ -17,8 +17,6 @@
 import { test, expect } from './pageTest';
 
 test.describe('non-stalling evaluate', () => {
-  test.skip(({mode}) => mode !== 'default');
-
   test('should work', async ({page, server, toImpl}) => {
     await page.goto(server.EMPTY_PAGE);
     const result = await toImpl(page.mainFrame()).nonStallingRawEvaluateInExistingMainContext('2+2');

--- a/tests/page/page-event-crash.spec.ts
+++ b/tests/page/page-event-crash.spec.ts
@@ -18,60 +18,58 @@
 import { test as it, expect } from './pageTest';
 import * as os from 'os';
 
-function crash({ page, toImpl, browserName, platform, mode }: any) {
+function crash({ page, toImpl, browserName, platform }: any) {
   if (browserName === 'chromium') {
     page.goto('chrome://crash').catch(e => {});
   } else if (browserName === 'webkit') {
-    it.skip(mode !== 'default');
     it.fixme(platform === 'darwin' && parseInt(os.release(), 10) >= 20, 'Timing out after roll on BigSur');
     toImpl(page)._delegate._session.send('Page.crash', {}).catch(e => {});
   } else if (browserName === 'firefox') {
-    it.skip(mode !== 'default');
     toImpl(page)._delegate._session.send('Page.crash', {}).catch(e => {});
   }
 }
 
 it.describe('', () => {
-  it('should emit crash event when page crashes', async ({ page, toImpl, browserName, platform, mode }) => {
+  it('should emit crash event when page crashes', async ({ page, toImpl, browserName, platform }) => {
     await page.setContent(`<div>This page should crash</div>`);
-    crash({ page, toImpl, browserName, platform, mode });
+    crash({ page, toImpl, browserName, platform });
     const crashedPage = await new Promise(f => page.on('crash', f));
     expect(crashedPage).toBe(page);
   });
 
-  it('should throw on any action after page crashes', async ({ page, toImpl, browserName, platform, mode }) => {
+  it('should throw on any action after page crashes', async ({ page, toImpl, browserName, platform }) => {
     await page.setContent(`<div>This page should crash</div>`);
-    crash({ page, toImpl, browserName, platform, mode });
+    crash({ page, toImpl, browserName, platform });
     await page.waitForEvent('crash');
     const err = await page.evaluate(() => {}).then(() => null, e => e);
     expect(err).toBeTruthy();
     expect(err.message).toContain('crash');
   });
 
-  it('should cancel waitForEvent when page crashes', async ({ page, toImpl, browserName, platform, mode }) => {
+  it('should cancel waitForEvent when page crashes', async ({ page, toImpl, browserName, platform }) => {
     await page.setContent(`<div>This page should crash</div>`);
     const promise = page.waitForEvent('response').catch(e => e);
-    crash({ page, toImpl, browserName, platform, mode });
+    crash({ page, toImpl, browserName, platform });
     const error = await promise;
     expect(error.message).toContain('Page crashed');
   });
 
-  it('should cancel navigation when page crashes', async ({ server, page, toImpl, browserName, platform, mode }) => {
+  it('should cancel navigation when page crashes', async ({ server, page, toImpl, browserName, platform }) => {
     await page.setContent(`<div>This page should crash</div>`);
     server.setRoute('/one-style.css', () => {});
     const promise = page.goto(server.PREFIX + '/one-style.html').catch(e => e);
     await page.waitForNavigation({ waitUntil: 'domcontentloaded' });
-    crash({ page, toImpl, browserName, platform, mode });
+    crash({ page, toImpl, browserName, platform });
     const error = await promise;
     expect(error.message).toContain('Navigation failed because page crashed');
   });
 
-  it('should be able to close context when page crashes', async ({ isAndroid, isElectron, page, toImpl, browserName, platform, mode }) => {
+  it('should be able to close context when page crashes', async ({ isAndroid, isElectron, page, toImpl, browserName, platform }) => {
     it.skip(isAndroid);
     it.skip(isElectron);
 
     await page.setContent(`<div>This page should crash</div>`);
-    crash({ page, toImpl, browserName, platform, mode });
+    crash({ page, toImpl, browserName, platform });
     await page.waitForEvent('crash');
     await page.context().close();
   });

--- a/tests/page/page-expose-function.spec.ts
+++ b/tests/page/page-expose-function.spec.ts
@@ -238,8 +238,7 @@ it('should not result in unhandled rejection', async ({page, isAndroid}) => {
   expect(await page.evaluate('1 + 1').catch(e => e)).toBeInstanceOf(Error);
 });
 
-it('should work with internal bindings', async ({page, toImpl, server, mode, browserName, isElectron, isAndroid}) => {
-  it.skip(mode !== 'default');
+it('should work with internal bindings', async ({page, toImpl, server, browserName, isElectron, isAndroid}) => {
   it.skip(browserName !== 'chromium');
   it.skip(isAndroid);
   it.skip(isElectron);

--- a/tests/slowmo.spec.ts
+++ b/tests/slowmo.spec.ts
@@ -46,8 +46,6 @@ async function checkPageSlowMo(toImpl, page, task) {
 }
 
 it.describe('slowMo', () => {
-  it.skip(({ mode }) => mode !== 'default');
-
   it('Page SlowMo $$eval', async ({page, toImpl}) => {
     await checkPageSlowMo(toImpl, page, () => page.$$eval('button', () => void 0));
   });

--- a/tests/snapshotter.spec.ts
+++ b/tests/snapshotter.spec.ts
@@ -24,8 +24,7 @@ const it = contextTest.extend<{ snapshotPort: number, snapshotter: InMemorySnaps
     await run(11000 + testInfo.workerIndex);
   },
 
-  snapshotter: async ({ mode, toImpl, context, snapshotPort }, run, testInfo) => {
-    testInfo.skip(mode !== 'default');
+  snapshotter: async ({ toImpl, context, snapshotPort }, run, testInfo) => {
     const snapshotter = new InMemorySnapshotter(toImpl(context));
     await snapshotter.initialize();
     const httpServer = new HttpServer();


### PR DESCRIPTION
This way we don't need `skip(mode !== 'default')` everywhere.