### PR TITLE
docs(dotnet): rename webkit to WebKit

### DIFF
--- a/docs/src/api/class-playwright.md
+++ b/docs/src/api/class-playwright.md
@@ -221,6 +221,8 @@ Selectors can be used to install custom selector engines. See
 [Working with selectors](./selectors.md) for more information.
 
 ## property: Playwright.webkit
+* langs:
+  - alias-csharp: WebKit
 - type: <[BrowserType]>
 
 This object can be used to launch or connect to WebKit, returning instances of [Browser].


### PR DESCRIPTION
Proposal to change this to keep the name "correct" as `WebKit`. 