### PR TITLE
chore(CLI): let other langs specify exec name

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -38,7 +38,7 @@ import { allBrowserNames } from '../utils/registry';
 
 program
     .version('Version ' + require('../../package.json').version)
-    .name('npx playwright');
+    .name(process.env.PW_CLI_NAME || 'npx playwright');
 
 commandWithOpenOptions('open [url]', 'open page in browser specified via -b, --browser', [])
     .action(function(url, command) {


### PR DESCRIPTION
This is a naive attempt at getting the CLI to display

```powershell
~\src\playwright [dev/anvod/webkit-rename ≡ +2 ~0 -0 !]> npx playwright
Usage: playwrightcli [options] [command]
```

when ran from the dotnet CLI wrapper