### PR TITLE
fix(port-forwarding): on WebKit Win

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -178,6 +178,14 @@ export function canAccessFile(file: string) {
   }
 }
 
+const localIpAddresses = [
+  'localhost',
+  '127.0.0.1',
+  '::ffff:127.0.0.1',
+  '::1',
+  '0000:0000:0000:0000:0000:0000:0000:0001', // WebKit (Windows)
+];
+
 export function isLocalIpAddress(ipAdress: string): boolean {
-  return ['localhost', '127.0.0.1', '::ffff:127.0.0.1', '::1'].includes(ipAdress);
+  return localIpAddresses.includes(ipAdress);
 }

--- a/tests/portForwardingServer.spec.ts
+++ b/tests/portForwardingServer.spec.ts
@@ -20,7 +20,7 @@ import { contextTest as it, expect } from './config/browserTest';
 import type { LaunchOptions, ConnectOptions } from '../index';
 
 it.skip(({ mode }) => mode !== 'default');
-it.fixme(({platform}) => platform === 'darwin');
+it.fixme(({platform, browserName}) => platform === 'darwin' && browserName === 'webkit');
 
 let targetTestServer: http.Server;
 let port!: number;

--- a/tests/portForwardingServer.spec.ts
+++ b/tests/portForwardingServer.spec.ts
@@ -20,6 +20,7 @@ import { contextTest as it, expect } from './config/browserTest';
 import type { LaunchOptions, ConnectOptions } from '../index';
 
 it.skip(({ mode }) => mode !== 'default');
+it.fixme(({platform}) => platform === 'darwin');
 
 let targetTestServer: http.Server;
 let port!: number;


### PR DESCRIPTION
Should fix the red bots on master, will follow-up with Mac fixes, needs to be in WK.