### PR TITLE
chore(chromium): disable GlobalMediaControls feature

### DIFF
--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -189,7 +189,7 @@ const DEFAULT_ARGS = [
   '--disable-dev-shm-usage',
   '--disable-extensions',
   // BlinkGenPropertyTrees disabled due to crbug.com/937609
-  '--disable-features=TranslateUI,BlinkGenPropertyTrees,ImprovedCookieControls,SameSiteByDefaultCookies,LazyFrameLoading',
+  '--disable-features=TranslateUI,BlinkGenPropertyTrees,ImprovedCookieControls,SameSiteByDefaultCookies,LazyFrameLoading,GlobalMediaControls',
   '--allow-pre-commit-input',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',


### PR DESCRIPTION
As a user I don't want to control the Chromecast devices / media in my network when using Playwright. They added a popup recently which get's displayed if you have media playing.

![image](https://user-images.githubusercontent.com/17984549/119659895-ebdf8700-be2e-11eb-9ca4-18f0d117f6b9.png)
