### PR TITLE
fix(codegen): still open a page after clearing the codegen

### DIFF
--- a/src/server/supplements/recorder/codeGenerator.ts
+++ b/src/server/supplements/recorder/codeGenerator.ts
@@ -174,4 +174,8 @@ export class CodeGenerator extends EventEmitter {
       text.push(languageGenerator.generateFooter(this._options.saveStorage));
     return text.join('\n');
   }
+
+  hasDefaultPage() {
+    return !this._options.generateHeaders;
+  }
 }


### PR DESCRIPTION
Clicking the 'Clear' button after running `npx playwright codegen` would remove the
line that opened a new page. This caused the generated code to fail.

I am not sure if `this._params.startRecording` or `this._options.generateHeaders` is
the right signal to know if we need to generate the `const page = context.newPage()` code.

I am also not sure where tests for this should go. Do we have a test that presses
the clear button somehow?
