### PR TITLE
browser(webkit): fix compilation on Ubuntu 18

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1487
-Changed: yurys@chromium.org Fri 28 May 2021 11:40:58 AM PDT
+1488
+Changed: yurys@chromium.org Fri 28 May 2021 06:16:59 PM PDT

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -4663,6 +4663,19 @@ index 16edb3bc689b8e2dde17597b642b706c1343e1f5..f363b2ca2410f22cff8d6ad908a88527
      ~UserGestureEmulationScope();
  
  private:
+diff --git a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
+index 6820b0faaa69d454d992bd9d0fbb07aa1c2e547f..89caf34c9b4b85aec8fb7e7889338de566650fd9 100644
+--- a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
++++ b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
+@@ -251,7 +251,7 @@ void LineLayout::prepareLayoutState()
+ 
+     auto& rootGeometry = m_layoutState.ensureGeometryForBox(rootLayoutBox());
+     rootGeometry.setContentBoxWidth(flow().contentSize().width());
+-    rootGeometry.setPadding({ { } });
++    rootGeometry.setPadding(Layout::Edges{});
+     rootGeometry.setBorder({ });
+     rootGeometry.setHorizontalMargin({ });
+     rootGeometry.setVerticalMargin({ });
 diff --git a/Source/WebCore/loader/CookieJar.h b/Source/WebCore/loader/CookieJar.h
 index 07b4ede9fb784ffe1b8030929217e10415e7ff82..9bce3c64607dd621c21117211af660c69d2ae3b2 100644
 --- a/Source/WebCore/loader/CookieJar.h


### PR DESCRIPTION
https://github.com/yury-s/webkit/commit/fbed11c8bc629117dbc28f8f8f2d3e855241c300

Fix for:

```
../../../Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp: In member function ‘void WebCore::LayoutIntegration::LineLayout::prepareLayoutState()’:
../../../Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp:254:36: error: converting to ‘WTF::Optional<WebCore::Layout::Edges>’ {aka ‘std::optional<WebCore::Layout::Edges>’} from initializer list would use explicit constructor ‘constexpr std::optional<_Tp>::optional(std::in_place_t, _Args&& ...) [with _Args = {}; typename std::enable_if<is_constructible_v<_Tp, _Args&& ...>, bool>::type <anonymous> = 0; _Tp = WebCore::Layout::Edges]’
     rootGeometry.setPadding({ { } });
                                    ^
../../../Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp:254:36: error: converting to ‘std::in_place_t’ from initializer list would use explicit constructor ‘constexpr std::in_place_t::in_place_t()’

```