### PR TITLE
chore(evaluate): remove private _evaluateInUtility methods

### DIFF
--- a/src/client/frame.ts
+++ b/src/client/frame.ts
@@ -181,30 +181,10 @@ export class Frame extends ChannelOwner<channels.FrameChannel, channels.FrameIni
     });
   }
 
-  async _evaluateHandleInUtility<R, Arg>(pageFunction: structs.PageFunction<Arg, R>, arg: Arg): Promise<structs.SmartHandle<R>>;
-  async _evaluateHandleInUtility<R>(pageFunction: structs.PageFunction<void, R>, arg?: any): Promise<structs.SmartHandle<R>>;
-  async _evaluateHandleInUtility<R, Arg>(pageFunction: structs.PageFunction<Arg, R>, arg?: Arg): Promise<structs.SmartHandle<R>> {
-    assertMaxArguments(arguments.length, 2);
-    return this._wrapApiCall(this._apiName('_evaluateHandleInUtility'), async (channel: channels.FrameChannel) => {
-      const result = await channel.evaluateExpressionHandle({ expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg), world: 'utility' });
-      return JSHandle.from(result.handle) as any as structs.SmartHandle<R>;
-    });
-  }
-
   async evaluate<R, Arg>(pageFunction: structs.PageFunction<Arg, R>, arg?: Arg): Promise<R> {
     assertMaxArguments(arguments.length, 2);
     return this._wrapApiCall(this._apiName('evaluate'), async (channel: channels.FrameChannel) => {
       const result = await channel.evaluateExpression({ expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg) });
-      return parseResult(result.value);
-    });
-  }
-
-  async _evaluateInUtility<R, Arg>(pageFunction: structs.PageFunction<Arg, R>, arg: Arg): Promise<R>;
-  async _evaluateInUtility<R>(pageFunction: structs.PageFunction<void, R>, arg?: any): Promise<R>;
-  async _evaluateInUtility<R, Arg>(pageFunction: structs.PageFunction<Arg, R>, arg?: Arg): Promise<R> {
-    assertMaxArguments(arguments.length, 2);
-    return this._wrapApiCall(this._apiName('evaluate'), async (channel: channels.FrameChannel) => {
-      const result = await channel.evaluateExpression({ expression: String(pageFunction), isFunction: typeof pageFunction === 'function', arg: serializeArgument(arg), world: 'utility' });
       return parseResult(result.value);
     });
   }

--- a/src/dispatchers/frameDispatcher.ts
+++ b/src/dispatchers/frameDispatcher.ts
@@ -61,11 +61,11 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameInitializer
   }
 
   async evaluateExpression(params: channels.FrameEvaluateExpressionParams, metadata: CallMetadata): Promise<channels.FrameEvaluateExpressionResult> {
-    return { value: serializeResult(await this._frame.evaluateExpressionAndWaitForSignals(params.expression, params.isFunction, parseArgument(params.arg), params.world)) };
+    return { value: serializeResult(await this._frame.evaluateExpressionAndWaitForSignals(params.expression, params.isFunction, parseArgument(params.arg), 'main')) };
   }
 
   async evaluateExpressionHandle(params: channels.FrameEvaluateExpressionHandleParams, metadata: CallMetadata): Promise<channels.FrameEvaluateExpressionHandleResult> {
-    return { handle: ElementHandleDispatcher.fromJSHandle(this._scope, await this._frame.evaluateExpressionHandleAndWaitForSignals(params.expression, params.isFunction, parseArgument(params.arg), params.world)) };
+    return { handle: ElementHandleDispatcher.fromJSHandle(this._scope, await this._frame.evaluateExpressionHandleAndWaitForSignals(params.expression, params.isFunction, parseArgument(params.arg), 'main')) };
   }
 
   async waitForSelector(params: channels.FrameWaitForSelectorParams, metadata: CallMetadata): Promise<channels.FrameWaitForSelectorResult> {

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -1458,11 +1458,9 @@ export type FrameEvaluateExpressionParams = {
   expression: string,
   isFunction?: boolean,
   arg: SerializedArgument,
-  world?: 'main' | 'utility',
 };
 export type FrameEvaluateExpressionOptions = {
   isFunction?: boolean,
-  world?: 'main' | 'utility',
 };
 export type FrameEvaluateExpressionResult = {
   value: SerializedValue,
@@ -1471,11 +1469,9 @@ export type FrameEvaluateExpressionHandleParams = {
   expression: string,
   isFunction?: boolean,
   arg: SerializedArgument,
-  world?: 'main' | 'utility',
 };
 export type FrameEvaluateExpressionHandleOptions = {
   isFunction?: boolean,
-  world?: 'main' | 'utility',
 };
 export type FrameEvaluateExpressionHandleResult = {
   handle: JSHandleChannel,

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -1148,11 +1148,6 @@ Frame:
         expression: string
         isFunction: boolean?
         arg: SerializedArgument
-        world:
-          type: enum?
-          literals:
-          - main
-          - utility
       returns:
         value: SerializedValue
 
@@ -1161,11 +1156,6 @@ Frame:
         expression: string
         isFunction: boolean?
         arg: SerializedArgument
-        world:
-          type: enum?
-          literals:
-          - main
-          - utility
       returns:
         handle: JSHandle
 

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -590,13 +590,11 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     expression: tString,
     isFunction: tOptional(tBoolean),
     arg: tType('SerializedArgument'),
-    world: tOptional(tEnum(['main', 'utility'])),
   });
   scheme.FrameEvaluateExpressionHandleParams = tObject({
     expression: tString,
     isFunction: tOptional(tBoolean),
     arg: tType('SerializedArgument'),
-    world: tOptional(tEnum(['main', 'utility'])),
   });
   scheme.FrameFillParams = tObject({
     selector: tString,

--- a/tests/page/frame-evaluate.spec.ts
+++ b/tests/page/frame-evaluate.spec.ts
@@ -17,7 +17,6 @@
 
 import { test as it, expect } from './pageTest';
 import { attachFrame, detachFrame } from '../config/utils';
-import type { Frame } from '../../src/client/frame';
 
 it('should have different execution contexts', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
@@ -184,22 +183,3 @@ it('evaluateHandle should work', async ({page, server}) => {
   expect(windowHandle).toBeTruthy();
 });
 
-it('evaluateInUtility should work', async ({page}) => {
-  await page.setContent('<body>hello</body>');
-  const mainFrame = page.mainFrame() as any as Frame;
-  await mainFrame.evaluate(() => window['foo'] = 42);
-  expect(await mainFrame.evaluate(() => window['foo'])).toBe(42);
-  expect(await mainFrame._evaluateInUtility(() => window['foo'])).toBe(undefined);
-  expect(await mainFrame._evaluateInUtility(() => document.body.textContent)).toBe('hello');
-});
-
-it('evaluateHandleInUtility should work', async ({page}) => {
-  await page.setContent('<body>hello</body>');
-  const mainFrame = page.mainFrame() as any as Frame;
-  await mainFrame.evaluate(() => window['foo'] = 42);
-  expect(await mainFrame.evaluate(() => window['foo'])).toBe(42);
-  const handle1 = await mainFrame._evaluateHandleInUtility(() => window['foo']);
-  expect(await handle1.jsonValue()).toBe(undefined);
-  const handle2 = await mainFrame._evaluateHandleInUtility(() => document.body);
-  expect(await handle2.evaluate(body => body.textContent)).toBe('hello');
-});


### PR DESCRIPTION
These methods aren't used anywhere and it's been more than a few months since they were added.
There is some confusing logic around them and slowMo which I am trying to straighten out. Removing them is of
course easier.
