### PR TITLE
chore: create new Playwright instance when launching server

### DIFF
--- a/src/inprocess.ts
+++ b/src/inprocess.ts
@@ -34,9 +34,9 @@ function setupInProcess(): PlaywrightAPI {
   // Initialize Playwright channel.
   new PlaywrightDispatcher(dispatcherConnection.rootDispatcher(), playwright);
   const playwrightAPI = clientConnection.getObjectWithKnownName('Playwright') as PlaywrightAPI;
-  playwrightAPI.chromium._serverLauncher = new BrowserServerLauncherImpl(playwright, playwright.chromium);
-  playwrightAPI.firefox._serverLauncher = new BrowserServerLauncherImpl(playwright, playwright.firefox);
-  playwrightAPI.webkit._serverLauncher = new BrowserServerLauncherImpl(playwright, playwright.webkit);
+  playwrightAPI.chromium._serverLauncher = new BrowserServerLauncherImpl('chromium');
+  playwrightAPI.firefox._serverLauncher = new BrowserServerLauncherImpl('firefox');
+  playwrightAPI.webkit._serverLauncher = new BrowserServerLauncherImpl('webkit');
 
   // Switch to async dispatch after we got Playwright object.
   dispatcherConnection.onmessage = message => setImmediate(() => clientConnection.dispatch(message));


### PR DESCRIPTION
Extracted from #6786

Before it was re-used which lead to the case that the PlaywrightDispatcher was two or more times initialized on the same Playwright instance.