### PR TITLE
test: disable test that fails on Electron

### DIFF
--- a/tests/page/page-autowaiting-no-hang.spec.ts
+++ b/tests/page/page-autowaiting-no-hang.spec.ts
@@ -23,7 +23,8 @@ it('clicking on links which do not commit navigation', async ({page, server, htt
   await page.click('a');
 });
 
-it('calling window.stop async', async ({page, server}) => {
+it('calling window.stop async', async ({page, server, isElectron}) => {
+  it.fail(isElectron);
   server.setRoute('/empty.html', async (req, res) => {});
   await page.evaluate(url => {
     window.location.href = url;


### PR DESCRIPTION
This test is failing since https://github.com/microsoft/playwright/commit/ee7e38c60d6d79b0935ead24dbe69719d94ddcff
Dashboard: https://devops.aslushnikov.com/flakiness2.html#browser=electron&platform=Ubuntu+20.04&timestamp=1622444340000