### PR TITLE
browser(firefox-stable): disable proton UI in firefox stable

### DIFF
--- a/browser_patches/firefox-stable/BUILD_NUMBER
+++ b/browser_patches/firefox-stable/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1258
-Changed: lushnikov@chromium.org Tue Jun  1 12:53:28 PDT 2021
+1259
+Changed: lushnikov@chromium.org Tue Jun  1 19:07:28 PDT 2021

--- a/browser_patches/firefox-stable/preferences/playwright.cfg
+++ b/browser_patches/firefox-stable/preferences/playwright.cfg
@@ -11,6 +11,11 @@ pref("browser.tabs.remote.useCrossOriginOpenerPolicy", false);
 // support for the new modal UI (see Bug 1686743).
 pref("prompts.contentPromptSubDialog", false);
 
+
+// The new "proton" UI breaks our screencast tests.
+// Disable the UI until we figure what is going on.
+pref("browser.proton.enabled", false);
+
 // Increase max number of child web processes so that new pages
 // get a new process by default and we have a process isolation
 // between pages from different contexts. If this becomes a performance


### PR DESCRIPTION
See f4b8c3a848bc178ec92a086a7c7e998fac38d811 for details.