### PR TITLE
test: properly disable electron test

### DIFF
--- a/tests/page/page-autowaiting-no-hang.spec.ts
+++ b/tests/page/page-autowaiting-no-hang.spec.ts
@@ -24,7 +24,7 @@ it('clicking on links which do not commit navigation', async ({page, server, htt
 });
 
 it('calling window.stop async', async ({page, server, isElectron}) => {
-  it.fail(isElectron);
+  it.fixme(isElectron);
   server.setRoute('/empty.html', async (req, res) => {});
   await page.evaluate(url => {
     window.location.href = url;


### PR DESCRIPTION
This test is failing since https://github.com/microsoft/playwright/commit/ee7e38c60d6d79b0935ead24dbe69719d94ddcff
Dashboard: https://devops.aslushnikov.com/flakiness2.html#browser=electron&platform=Ubuntu+20.04&timestamp=1622444340000

P.S. this is a follow-up to a1106e5d4ed32a2dcf1a047459f382026b42491c -
turns out `it.fail` is still failing in case of a timeout.