### PR TITLE
docs: use bash instead of sh in code blocks

### DIFF
--- a/browser_patches/README.md
+++ b/browser_patches/README.md
@@ -25,7 +25,7 @@ and develop from there.
 
 From the `playwright` repo, run the following command:
 
-```sh
+```bash
 $ ./browser_patches/prepare_checkout.sh firefox <path to checkout>
 ```
 (you can optionally pass "webkit" for a webkit checkout)
@@ -45,7 +45,7 @@ You want to create a new branch off the `playwright-build` branch.
 
 Assuming that you're under `./browser_patches/firefox/checkout`:
 
-```sh
+```bash
 $ git checkout -b my-new-feature playwright-build
 $ # develop my feature on the my-new-feature branch ....
 ```
@@ -56,7 +56,7 @@ Once you're happy with the work you did in the browser-land, you want to export 
 
 Assuming that you're in the root of the `playwright` repo and that your browser checkout has your feature branch checked out:
 
-```sh
+```bash
 $ ./browser_patches/export.sh firefox <path to checkout>
 ```
 
@@ -73,7 +73,7 @@ Send a PR to the Playwright repo to be reviewed.
 
 Once the patch has been committed, the build bots will kick in, compile and upload a new browser version to all the platforms. Then you can roll the browser:
 
-```sh
+```bash
 $ node utils/roll_browser.js chromium 123456
 ```
 

--- a/docs/src/api/class-android.md
+++ b/docs/src/api/class-android.md
@@ -62,7 +62,7 @@ const { _android: android } = require('playwright');
 
 Note that since you don't need Playwright to install web browsers when testing Android, you can omit browser download via setting the following environment variable when installing Playwright:
 
-```sh js
+```bash js
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i -D playwright
 ```
 

--- a/docs/src/api/class-electron.md
+++ b/docs/src/api/class-electron.md
@@ -41,7 +41,7 @@ const { _electron: electron } = require('playwright');
 
 Note that since you don't need Playwright to install web browsers when testing Electron, you can omit browser download via setting the following environment variable when installing Playwright:
 
-```sh js
+```bash js
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i -D playwright
 ```
 

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -15,21 +15,21 @@ configurations for common CI providers.
 1. **Ensure CI agent can run browsers**: Use [our Docker image](./docker.md)
    in Linux agents. Windows and macOS agents do not require any additional dependencies.
 1. **Install Playwright**:
-   ```sh js
+   ```bash js
    npm ci
    # or
    npm install
    ```
-   ```sh python
+   ```bash python
    pip install playwright
    playwright install
    ```
 
 1. **Run your tests**:
-   ```sh js
+   ```bash js
    npm test
    ```
-   ```sh python
+   ```bash python
    pytest
    ```
 
@@ -344,10 +344,10 @@ configuration, against a hash of the Playwright version.
 
 Playwright supports the `DEBUG` environment variable to output debug logs during execution. Setting it to `pw:browser*` is helpful while debugging `Error: Failed to launch browser` errors.
 
-```sh js
+```bash js
 DEBUG=pw:browser* npm run test
 ```
-```sh python
+```bash python
 DEBUG=pw:browser* pytest
 ```
 
@@ -414,9 +414,9 @@ class Program
 
 On Linux agents, headed execution requires [Xvfb](https://en.wikipedia.org/wiki/Xvfb) to be installed. Our [Docker image](./docker.md) and GitHub Action have Xvfb pre-installed. To run browsers in headed mode with Xvfb, add `xvfb-run` before the Node.js command.
 
-```sh js
+```bash js
 xvfb-run node index.js
 ```
-```sh python
+```bash python
 xvfb-run python test.py
 ```

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -9,15 +9,15 @@ Playwright comes with the command line tools that run via `npx` or as a part of 
 
 ## Usage
 
-```sh js
+```bash js
 npx playwright --help
 ```
 
-```sh java
+```bash java
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI
 ```
 
-```sh python
+```bash python
 playwright
 ```
 
@@ -32,15 +32,15 @@ playwright
 
 ## Generate code
 
-```sh js
+```bash js
 npx playwright codegen wikipedia.org
 ```
 
-```sh java
+```bash java
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen wikipedia.org"
 ```
 
-```sh python
+```bash python
 playwright codegen wikipedia.org
 ```
 
@@ -52,19 +52,19 @@ Run `codegen` and perform actions in the browser. Playwright CLI will generate J
 
 Run `codegen` with `--save-storage` to save [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) and [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) at the end. This is useful to separately record authentication step and reuse it later.
 
-```sh js
+```bash js
 npx playwright codegen --save-storage=auth.json
 # Perform authentication and exit.
 # auth.json will contain the storage state.
 ```
 
-```sh java
+```bash java
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen  --save-storage=auth.json"
 # Perform authentication and exit.
 # auth.json will contain the storage state.
 ```
 
-```sh python
+```bash python
 playwright codegen --save-storage=auth.json
 # Perform authentication and exit.
 # auth.json will contain the storage state.
@@ -72,20 +72,20 @@ playwright codegen --save-storage=auth.json
 
 Run with `--load-storage` to consume previously loaded storage. This way, all [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) and [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) will be restored, bringing most web apps to the authenticated state.
 
-```sh js
+```bash js
 npx playwright open --load-storage=auth.json my.web.app
 npx playwright codegen --load-storage=auth.json my.web.app
 # Perform actions in authenticated state.
 ```
 
-```sh java
+```bash java
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="open --load-storage=auth.json my.web.app"
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen --load-storage=auth.json my.web.app"
 # Perform authentication and exit.
 # auth.json will contain the storage state.
 ```
 
-```sh python
+```bash python
 playwright open --load-storage=auth.json my.web.app
 playwright codegen --load-storage=auth.json my.web.app
 # Perform actions in authenticated state.
@@ -196,32 +196,32 @@ class Program
 
 With `open`, you can use Playwright bundled browsers to browse web pages. Playwright provides cross-platform WebKit builds that can be used to reproduce Safari rendering across Windows, Linux and macOS.
 
-```sh js
+```bash js
 # Open page in Chromium
 npx playwright open example.com
 ```
 
-```sh java
+```bash java
 # Open page in Chromium
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="open example.com"
 ```
 
-```sh python
+```bash python
 # Open page in Chromium
 playwright open example.com
 ```
 
-```sh js
+```bash js
 # Open page in WebKit
 npx playwright wk example.com
 ```
 
-```sh java
+```bash java
 # Open page in WebKit
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="wk example.com"
 ```
 
-```sh python
+```bash python
 # Open page in WebKit
 playwright wk example.com
 ```
@@ -229,47 +229,47 @@ playwright wk example.com
 ### Emulate devices
 `open` can emulate mobile and tablet devices from the [`playwright.devices`](https://playwright.dev/docs/api/class-playwright#playwrightdevices) list.
 
-```sh js
+```bash js
 # Emulate iPhone 11.
 npx playwright open --device="iPhone 11" wikipedia.org
 ```
 
-```sh java
+```bash java
 # Emulate iPhone 11.
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args='open --device="iPhone 11" wikipedia.org'
 ```
 
-```sh python
+```bash python
 # Emulate iPhone 11.
 playwright open --device="iPhone 11" wikipedia.org
 ```
 
 ### Emulate color scheme and viewport size
-```sh js
+```bash js
 # Emulate screen size and color scheme.
 npx playwright open --viewport-size=800,600 --color-scheme=dark twitter.com
 ```
-```sh java
+```bash java
 # Emulate screen size and color scheme.
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="open --viewport-size=800,600 --color-scheme=dark twitter.com"
 ```
-```sh python
+```bash python
 # Emulate screen size and color scheme.
 playwright open --viewport-size=800,600 --color-scheme=dark twitter.com
 ```
 
 ### Emulate geolocation, language and timezone
-```sh js
+```bash js
 # Emulate timezone, language & location
 # Once page opens, click the "my location" button to see geolocation in action
 npx playwright open --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" maps.google.com
 ```
-```sh java
+```bash java
 # Emulate timezone, language & location
 # Once page opens, click the "my location" button to see geolocation in action
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args='open --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" maps.google.com'
 ```
-```sh python
+```bash python
 # Emulate timezone, language & location
 # Once page opens, click the "my location" button to see geolocation in action
 playwright open --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" maps.google.com
@@ -320,22 +320,22 @@ Generates selector for the given element.
 
 ## Take screenshot
 
-```sh js
+```bash js
 # See command help
 npx playwright screenshot --help
 ```
 
-```sh java
+```bash java
 # See command help
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="screenshot --help"
 ```
 
-```sh python
+```bash python
 # See command help
 playwright screenshot --help
 ```
 
-```sh js
+```bash js
 # Wait 3 seconds before capturing a screenshot after page loads ('load' event fires)
 npx playwright screenshot \
     --device="iPhone 11" \
@@ -344,12 +344,12 @@ npx playwright screenshot \
     twitter.com twitter-iphone.png
 ```
 
-```sh java
+```bash java
 # Wait 3 seconds before capturing a screenshot after page loads ('load' event fires)
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args='screenshot --device="iPhone 11" --color-scheme=dark --wait-for-timeout=3000 twitter.com twitter-iphone.png'
 ```
 
-```sh python
+```bash python
 # Wait 3 seconds before capturing a screenshot after page loads ('load' event fires)
 playwright screenshot \
     --device="iPhone 11" \
@@ -358,17 +358,17 @@ playwright screenshot \
     twitter.com twitter-iphone.png
 ```
 
-```sh js
+```bash js
 # Capture a full page screenshot
 npx playwright screenshot --full-page en.wikipedia.org wiki-full.png
 ```
 
-```sh java
+```bash java
 # Capture a full page screenshot
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args='screenshot --full-page en.wikipedia.org wiki-full.png'
 ```
 
-```sh python
+```bash python
 # Capture a full page screenshot
 playwright screenshot --full-page en.wikipedia.org wiki-full.png
 ```
@@ -377,17 +377,17 @@ playwright screenshot --full-page en.wikipedia.org wiki-full.png
 
 PDF generation only works in Headless Chromium.
 
-```sh js
+```bash js
 # See command help
 npx playwright pdf https://en.wikipedia.org/wiki/PDF wiki.pdf
 ```
 
-```sh java
+```bash java
 # See command help
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="pdf https://en.wikipedia.org/wiki/PDF wiki.pdf"
 ```
 
-```sh python
+```bash python
 # See command help
 playwright pdf https://en.wikipedia.org/wiki/PDF wiki.pdf
 ```
@@ -396,32 +396,32 @@ playwright pdf https://en.wikipedia.org/wiki/PDF wiki.pdf
 
 Ubuntu 18.04 and Ubuntu 20.04 system dependencies can get installed automatically. This is useful for CI environments.
 
-```sh js
+```bash js
 # See command help
 npx playwright install-deps
 ```
 
-```sh java
+```bash java
 # See command help
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install-deps"
 ```
 
-```sh python
+```bash python
 # See command help
 playwright install-deps
 ```
 
 You can also install the dependencies for a single browser only by passing it as an argument:
 
-```sh js
+```bash js
 npx playwright install-deps chromium
 ```
 
-```sh java
+```bash java
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install-deps chromium"
 ```
 
-```sh python
+```bash python
 playwright install-deps chromium
 ```
 

--- a/docs/src/debug.md
+++ b/docs/src/debug.md
@@ -105,7 +105,7 @@ Using `PWDEBUG=console` will configure the browser for debugging in Developer to
 [Playwright selectors](./selectors.md). This can be used to verify text or
 composite selectors.
 
-```sh js
+```bash js
 # Linux/macOS
 PWDEBUG=console npm run test
 
@@ -118,7 +118,7 @@ $env:PWDEBUG="console"
 npm run test
 ```
 
-```sh java
+```bash java
 # Linux/macOS
 PWDEBUG=console mvn test
 
@@ -131,7 +131,7 @@ $env:PWDEBUG="console"
 mvn test
 ```
 
-```sh python
+```bash python
 # Linux/macOS
 PWDEBUG=console pytest -s
 
@@ -184,7 +184,7 @@ breakpoints.
 
 Playwright supports verbose logging with the `DEBUG` environment variable.
 
-```sh js
+```bash js
 # Linux/macOS
 DEBUG=pw:api npm run test
 
@@ -197,7 +197,7 @@ $env:DEBUG="pw:api"
 npm run test
 ```
 
-```sh java
+```bash java
 # Linux/macOS
 DEBUG=pw:api mvn test
 
@@ -210,7 +210,7 @@ $env:DEBUG="pw:api"
 mvn test
 ```
 
-```sh python
+```bash python
 # Linux/macOS
 DEBUG=pw:api pytest -s
 
@@ -223,7 +223,7 @@ $env:DEBUG="pw:api"
 pytest -s
 ```
 
-```sh csharp
+```bash csharp
 # Linux/macOS
 DEBUG=pw:api dotnet run
 

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -13,21 +13,21 @@ This image is published on [Docker Hub].
 
 ### Pull the image
 
-```sh js python csharp
+```bash js python csharp
 docker pull mcr.microsoft.com/playwright:focal
 ```
 
-```sh java
+```bash java
 docker pull mcr.microsoft.com/playwright/java:focal
 ```
 
 or pinned to a specific Playwright version (recommended). Replace 1.10.0 with your Playwright version:
 
-```sh js python csharp
+```bash js python csharp
 docker pull mcr.microsoft.com/playwright:v1.10.0-focal
 ```
 
-```sh java
+```bash java
 docker pull mcr.microsoft.com/playwright/java:v1.10.0-focal
 ```
 
@@ -39,11 +39,11 @@ By default, the Docker image will use the `root` user to run the browsers. This 
 
 On trusted websites, you can avoid creating a separate user and use root for it since you trust the code which will run on the browsers.
 
-```sh js python csharp
+```bash js python csharp
 docker run -it --rm --ipc=host mcr.microsoft.com/playwright:focal /bin/bash
 ```
 
-```sh java
+```bash java
 docker run -it --rm --ipc=host mcr.microsoft.com/playwright/java:focal /bin/bash
 ```
 
@@ -51,11 +51,11 @@ docker run -it --rm --ipc=host mcr.microsoft.com/playwright/java:focal /bin/bash
 
 On untrusted websites, it's recommended to use a separate user for launching the browsers in combination with the seccomp profile. Inside the container or if you are using the Docker image as a base image you have to use `adduser` for it.
 
-```sh js python csharp
+```bash js python csharp
 docker run -it --rm --ipc=host --user pwuser --security-opt seccomp=seccomp_profile.json mcr.microsoft.com/playwright:focal /bin/bash
 ```
 
-```sh java
+```bash java
 docker run -it --rm --ipc=host --user pwuser --security-opt seccomp=seccomp_profile.json mcr.microsoft.com/playwright/java:focal /bin/bash
 ```
 

--- a/docs/src/inspector.md
+++ b/docs/src/inspector.md
@@ -15,7 +15,7 @@ There are several ways of opening Playwright Inspector:
 
 - Set the `PWDEBUG` environment variable to run your scripts in debug mode. This
 configures Playwright for debugging and opens the inspector.
-  ```sh js
+  ```bash js
   # Linux/macOS
   PWDEBUG=1 npm run test
 
@@ -28,7 +28,7 @@ configures Playwright for debugging and opens the inspector.
   npm run test
   ```
 
-  ```sh java
+  ```bash java
   # Linux/macOS
   PWDEBUG=1 PLAYWRIGHT_JAVA_SRC=<java src root> mvn test
 
@@ -43,7 +43,7 @@ configures Playwright for debugging and opens the inspector.
   mvn test
   ```
 
-  ```sh python
+  ```bash python
   # Linux/macOS
   PWDEBUG=1 pytest -s
 
@@ -89,15 +89,15 @@ configures Playwright for debugging and opens the inspector.
 
 
 - Use `open` or `codegen` commands in the Playwright [CLI](./cli.md):
-  ```sh js
+  ```bash js
   npx playwright codegen wikipedia.org
   ```
 
-  ```sh java
+  ```bash java
   mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen wikipedia.org"
   ```
 
-  ```sh python
+  ```bash python
   playwright codegen wikipedia.org
   ```
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -13,18 +13,18 @@ Each version of Playwright needs specific versions of browser binaries to operat
 - `~/Library/Caches/ms-playwright` on MacOS
 - `~/.cache/ms-playwright` on Linux
 
-```sh js
+```bash js
 npm i -D playwright
 ```
 
-```sh python
+```bash python
 pip install playwright
 playwright install
 ```
 
 These browsers will take few hundreds of megabytes of the disk space when installed:
 
-```sh
+```bash
 du -hs ./Library/Caches/ms-playwright/*
 281M  chromium-XXXXXX
 187M  firefox-XXXX
@@ -33,7 +33,7 @@ du -hs ./Library/Caches/ms-playwright/*
 
 You can override default behavior using environment variables. When installing Playwright, ask it to download browsers into a specific location:
 
-```sh js
+```bash js
 # Linux/macOS
 PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers npm i -D playwright
 
@@ -46,7 +46,7 @@ $env:PLAYWRIGHT_BROWSERS_PATH="$env:USERPROFILE\pw-browsers"
 npm i -D playwright
 ```
 
-```sh python
+```bash python
 # Linux/macOS
 pip install playwright
 PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers python -m playwright install
@@ -62,14 +62,14 @@ pip install playwright
 playwright install
 ```
 
-```sh java
+```bash java
 # Linux/macOS
 PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers mvn test
 ```
 
 When running Playwright scripts, ask it to search for browsers in a shared location.
 
-```sh js
+```bash js
 # Linux/macOS
 PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers node playwright-script.js
 
@@ -82,7 +82,7 @@ $env:PLAYWRIGHT_BROWSERS_PATH="$env:USERPROFILE\pw-browsers"
 node playwright-script.js
 ```
 
-```sh python
+```bash python
 # Linux/macOS
 PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers python playwright_script.js
 
@@ -95,7 +95,7 @@ $env:PLAYWRIGHT_BROWSERS_PATH="$env:USERPROFILE\pw-browsers"
 python playwright_script.py
 ```
 
-```sh java
+```bash java
 # Windows with cmd.exe
 set PLAYWRIGHT_BROWSERS_PATH=%USERPROFILE%\pw-browsers
 mvn test
@@ -107,7 +107,7 @@ mvn test
 
 Or you can opt into the hermetic install and place binaries in the local folder:
 
-```sh js
+```bash js
 # Linux/macOS
 # Places binaries to node_modules/playwright
 PLAYWRIGHT_BROWSERS_PATH=0 npm i -D playwright
@@ -123,7 +123,7 @@ $env:PLAYWRIGHT_BROWSERS_PATH=0
 npm i -D playwright
 ```
 
-```sh python
+```bash python
 # Linux/macOS
 pip install playwright
 PLAYWRIGHT_BROWSERS_PATH=0 playwright install
@@ -152,7 +152,7 @@ By default, Playwright downloads browsers from Microsoft CDN.
 Sometimes companies maintain an internal proxy that blocks direct access to the public
 resources. In this case, Playwright can be configured to download browsers via a proxy server.
 
-```sh js
+```bash js
 # Linux/macOS
 HTTPS_PROXY=https://192.0.2.1 npm i -D playwright
 
@@ -165,7 +165,7 @@ $env:HTTPS_PROXY="https://192.0.2.1"
 npm i -D playwright
 ```
 
-```sh python
+```bash python
 # Linux/macOS
 pip install playwright
 HTTPS_PROXY=https://192.0.2.1 playwright install
@@ -181,7 +181,7 @@ pip install playwright
 playwright install
 ```
 
-```sh java
+```bash java
 # Linux/macOS
 HTTPS_PROXY=https://192.0.2.1 mvn test
 
@@ -202,7 +202,7 @@ Sometimes companies maintain an internal artifact repository to host browser
 binaries. In this case, Playwright can be configured to download from a custom
 location using the `PLAYWRIGHT_DOWNLOAD_HOST` env variable.
 
-```sh js
+```bash js
 # Linux/macOS
 PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 npm i -D playwright
 
@@ -215,7 +215,7 @@ $env:PLAYWRIGHT_DOWNLOAD_HOST="192.0.2.1"
 npm i -D playwright
 ```
 
-```sh python
+```bash python
 # Linux/macOS
 pip install playwright
 PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 playwright install
@@ -231,7 +231,7 @@ pip install playwright
 playwright install
 ```
 
-```sh java
+```bash java
 # Linux/macOS
 PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 mvn test
 
@@ -249,18 +249,18 @@ take precedence over `PLAYWRIGHT_DOWNLOAD_HOST`.
 
 It is also possible to use a per-browser download hosts using `PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST`, `PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST` and `PLAYWRIGHT_WEBKIT_DOWNLOAD_HOST` env variables that take precedence over `PLAYWRIGHT_DOWNLOAD_HOST`.
 
-```sh js
+```bash js
 # Linux/macOS
 PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=203.0.113.3 PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 npm i -D playwright
 ```
 
-```sh python
+```bash python
 # Linux/macOS
 pip install playwright
 PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=203.0.113.3 PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 python -m playwright install
 ```
 
-```sh java
+```bash java
 # Linux/macOS
 PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=203.0.113.3 PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 mvn test
 ```
@@ -272,7 +272,7 @@ browser binaries are managed separately.
 
 This can be done by setting `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` variable before installation.
 
-```sh js
+```bash js
 # Linux/macOS
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i -D playwright
 
@@ -285,7 +285,7 @@ $env:PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 npm i -D playwright
 ```
 
-```sh python
+```bash python
 # Linux/macOS
 pip install playwright
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 python -m playwright install
@@ -301,7 +301,7 @@ pip install playwright
 playwright install
 ```
 
-```sh java
+```bash java
 # Linux/macOS
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 mvn test
 
@@ -330,7 +330,7 @@ Using these packages is as easy as using a regular Playwright:
 
 Install a specific package
 
-```sh
+```bash
 npm i -D playwright-webkit
 ```
 
@@ -351,7 +351,7 @@ const { webkit } = require('playwright-webkit');
 
 Playwright downloads Chromium, Firefox and WebKit browsers by default. To install a specific browser, pass it as an argument during installation.
 
-```sh
+```bash
 pip install playwright
 playwright install firefox
 ```

--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -10,7 +10,7 @@ title: "Getting Started"
 
 Install Microsoft.Playwright package from NuGet in Visual Studio or from the CLI in your project root directory:
 
-```sh
+```bash
 dotnet add package Microsoft.Playwright
 ```
 
@@ -35,7 +35,7 @@ class Program
 
 Create a console project and add the Playwright dependency.
 
-```sh
+```bash
 dotnet new console -n pw_demo
 cd pw_demo
 dotnet add package Microsoft.Playwright --prerelease
@@ -62,7 +62,7 @@ class Program
 
 Now build it and run it.
 
-```sh
+```bash
 dotnet build
 dotnet run
 ```
@@ -77,7 +77,7 @@ await playwright.Firefox.LaunchAsync(new BrowserTypeLaunchOptions { Headless = f
 
 Command Line Interface [CLI](./cli.md) can be used to record user interactions and generate C# code.
 
-```sh
+```bash
 # FIXME:
 ```
 

--- a/docs/src/intro-java.md
+++ b/docs/src/intro-java.md
@@ -83,7 +83,7 @@ public class Example {
 
 With the Example.java and pom.xml above, compile and execute your new program as follows:
 
-```sh
+```bash
 mvn compile exec:java -Dexec.mainClass="org.example.Example"
 ```
 
@@ -119,7 +119,7 @@ playwright.firefox().launch(new BrowserType.LaunchOptions().setHeadless(false).s
 
 Command Line Interface [CLI](./cli.md) can be used to record user interactions and generate Java code.
 
-```sh
+```bash
 mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen wikipedia.org"
 ```
 

--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -10,7 +10,7 @@ title: "Getting Started"
 
 Use npm or Yarn to install Playwright in your Node.js project. See [system requirements](#system-requirements).
 
-```sh
+```bash
 npm i -D playwright
 ```
 
@@ -65,7 +65,7 @@ firefox.launch({ headless: false, slowMo: 50 });
 
 Command Line Interface [CLI](./cli.md) can be used to record user interactions and generate JavaScript code.
 
-```sh
+```bash
 npx playwright codegen wikipedia.org
 ```
 

--- a/docs/src/intro-python.md
+++ b/docs/src/intro-python.md
@@ -10,7 +10,7 @@ title: "Getting Started"
 
 Use pip to install Playwright in your Python project. See [system requirements](#system-requirements).
 
-```sh
+```bash
 pip install playwright
 playwright install
 ```
@@ -74,7 +74,7 @@ firefox.launch(headless=False, slow_mo=50)
 
 Command Line Interface [CLI](./cli.md) can be used to record user interactions and generate Python code.
 
-```sh
+```bash
 playwright codegen wikipedia.org
 ```
 

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -83,10 +83,10 @@ This version of Playwright was also tested against the following stable channels
 
 - [Selecting elements based on layout](./selectors.md#selecting-elements-based-on-layout) with `:left-of()`, `:right-of()`, `:above()` and `:below()`.
 - Playwright now includes [command line interface](./cli.md), former playwright-cli.
-  ```sh js
+  ```bash js
   npx playwright --help
   ```
-  ```sh python
+  ```bash python
   playwright --help
   ```
 - [`method: Page.selectOption`] now waits for the options to be present.

--- a/docs/src/test-advanced.md
+++ b/docs/src/test-advanced.md
@@ -111,7 +111,7 @@ Each project can be configured separately, and run different set of tests with d
 Supported options are `name`, `outputDir`, `repeatEach`, `retries`, `snapshotDir`, `testDir`, `testIgnore`, `testMatch` and `timeout`. See [configuration object](#configuration-object) for detailed description.
 
 You can run all projects or just a single one:
-```sh
+```bash
 # Run both projects - each test will be run twice
 npx playwright test
 

--- a/docs/src/test-cli.md
+++ b/docs/src/test-cli.md
@@ -3,7 +3,7 @@ id: test-cli
 title: "Advanced: command line"
 ---
 
-```sh
+```bash
 # Ask for help!
 npx playwright test --help
 ```

--- a/docs/src/test-configuration.md
+++ b/docs/src/test-configuration.md
@@ -68,13 +68,13 @@ export default config;
 
 Now run tests as usual, Playwright Test will pick up the configuration file automatically.
 
-```sh
+```bash
 npx playwright test --browser=firefox
 ```
 
 If you put your configuration file in a different place, pass it with `--config` option.
 
-```sh
+```bash
 npx playwright test --config=tests/my.config.js
 ```
 
@@ -276,7 +276,7 @@ export default config;
 
 Playwright Test will run all projects by default.
 
-```sh
+```bash
 $ npx playwright test
 
 Running 3 tests using 3 workers
@@ -288,7 +288,7 @@ Running 3 tests using 3 workers
 
 Use `--project` command line option to run a single project.
 
-```sh
+```bash
 $ npx playwright test --project=webkit
 
 Running 1 test using 1 worker

--- a/docs/src/test-intro.md
+++ b/docs/src/test-intro.md
@@ -21,7 +21,7 @@ Playwright Test Runner was created specifically to accommodate the needs of the 
 
 Playwright already includes a test runner for end-to-end tests.
 
-```sh
+```bash
 npm i -D playwright
 ```
 
@@ -51,25 +51,25 @@ test('basic test', async ({ page }) => {
 
 Now run your tests, assuming that test files are in the `tests` directory.
 
-```sh
+```bash
 npx playwright test -c tests
 ```
 
 Playwright Test just ran a test using Chromium browser, in a headless manner. Let's tell it to use headed browser:
 
-```sh
+```bash
 npx playwright test -c tests --headed
 ```
 
 What about other browsers? Let's run the same test using Firefox:
 
-```sh
+```bash
 npx playwright test -c tests --browser=firefox
 ```
 
 And finally, on all three browsers:
 
-```sh
+```bash
 npx playwright test -c tests --browser=all
 ```
 
@@ -273,47 +273,47 @@ test('my test', async ({ page }) => {
 Here are the most common options available in the [command line](./test-cli.md).
 
 - Run tests in headed browsers
-  ```sh
+  ```bash
   npx playwright test --headed
   ```
 
 - Run tests in a particular browser
-  ```sh
+  ```bash
   npx playwright test --browser=webkit
   ```
 
 - Run tests in all browsers
-  ```sh
+  ```bash
   npx playwright test --browser=all
   ```
 
 - Run a single test file
-  ```sh
+  ```bash
   npx playwright test tests/todo-page.spec.ts
   ```
 
 - Run a set of test files
-  ```sh
+  ```bash
   npx playwright test tests/todo-page/ tests/landing-page/
   ```
 
 - Run a test with specific title
-  ```sh
+  ```bash
   npx playwright test -g "add a todo item"
   ```
 
 - Run tests [in parallel](./test-parallel.md) - that's the default
-  ```sh
+  ```bash
   npx playwright test
   ```
 
 - Disable [parallelization](./test-parallel.md)
-  ```sh
+  ```bash
   npx playwright test --workers=1
   ```
 
 - Choose a [reporter](./test-reporters.md)
-  ```sh
+  ```bash
   npx playwright test --reporter=dot
   ```
 

--- a/docs/src/test-parallel.md
+++ b/docs/src/test-parallel.md
@@ -16,17 +16,17 @@ However, test runner will create a new worker when retrying tests, after any tes
 You can control the maximum number of worker processes via [command line](./test-cli.md) or in the [configuration file](./test-configuration.md).
 
 - Run in parallel by default
-  ```sh
+  ```bash
   npx playwright test
   ```
 
 - Disable parallelization
-  ```sh
+  ```bash
   npx playwright test --worker 1
   ```
 
 - Control the number of workers
-  ```sh
+  ```bash
   npx playwright test --worker 4
   ```
 
@@ -56,7 +56,7 @@ Each worker process is assigned a unique sequential index that is accessible thr
 
 Playwright Test can shard a test suite, so that it can be executed on multiple machines. For that,  pass `--shard=x/y` to the command line. For example, to split the suite into three shards, each running one third of the tests:
 
-```sh
+```bash
 npx playwright test --shard=1/3
 npx playwright test --shard=2/3
 npx playwright test --shard=3/3

--- a/docs/src/test-reporters.md
+++ b/docs/src/test-reporters.md
@@ -10,7 +10,7 @@ title: "Reporters"
 Playwright Test comes with a few built-in reporters for different needs and ability to provide custom reporters. The easiest way to try out built-in reporters is to pass `--reporter` [command line option](./cli.md).
 
 
-```sh
+```bash
 npx playwright test --reporter=line
 ```
 
@@ -68,7 +68,7 @@ All built-in reporters show detailed information about failures, and mostly diff
 
 List reporter is default. It prints a line for each test being run.
 
-```sh
+```bash
 npx playwright test --reporter=list
 ```
 
@@ -90,7 +90,7 @@ export default config;
 ```
 
 Here is an example output in the middle of a test run. Failures will be listed at the end.
-```sh
+```bash
 npx playwright test --reporter=list
 Running 124 tests using 6 workers
 
@@ -110,7 +110,7 @@ Running 124 tests using 6 workers
 
 Line reporter is more concise than the list reporter. It uses a single line to report last finished test, and prints failures when they occur. Line reporter is useful for large test suites where it shows the progress but does not spam the output by listing all the tests.
 
-```sh
+```bash
 npx playwright test --reporter=line
 ```
 
@@ -132,7 +132,7 @@ export default config;
 ```
 
 Here is an example output in the middle of a test run. Failures are reported inline.
-```sh
+```bash
 npx playwright test --reporter=line
 Running 124 tests using 6 workers
   1) dot-reporter.spec.ts:20:1 › render expected ===================================================
@@ -149,7 +149,7 @@ Running 124 tests using 6 workers
 
 Dot reporter is very concise - it only produces a single character per successful test run. It is useful on CI where you don't want a lot of output.
 
-```sh
+```bash
 npx playwright test --reporter=dot
 ```
 
@@ -171,7 +171,7 @@ export default config;
 ```
 
 Here is an example output in the middle of a test run. Failures will be listed at the end.
-```sh
+```bash
 npx playwright test --reporter=dot
 Running 124 tests using 6 workers
 ······F·············································
@@ -182,7 +182,7 @@ Running 124 tests using 6 workers
 JSON reporter produces an object with all information about the test run. It is usually used together with some terminal reporter like `dot` or `line`.
 
 Most likely you want to write the JSON to a file. When running with `--reporter=json`, use `PLAYWRIGHT_JSON_OUTPUT_NAME` environment variable:
-```sh
+```bash
 PLAYWRIGHT_JSON_OUTPUT_NAME=results.json npx playwright test --reporter=json,dot
 ```
 
@@ -209,7 +209,7 @@ export default config;
 JUnit reporter produces a JUnit-style xml report. It is usually used together with some terminal reporter like `dot` or `line`.
 
 Most likely you want to write the report to an xml file. When running with `--reporter=junit`, use `PLAYWRIGHT_JUNIT_OUTPUT_NAME` environment variable:
-```sh
+```bash
 PLAYWRIGHT_JUNIT_OUTPUT_NAME=results.xml npx playwright test --reporter=junit,line
 ```
 

--- a/docs/src/test-retries.md
+++ b/docs/src/test-retries.md
@@ -5,7 +5,7 @@ title: "Test retry"
 
 Playwright Test will retry tests if they failed. Pass the maximum number of retries when running the tests, or set them in the [configuration file](./test-configuration.md).
 
-```sh
+```bash
 npx playwright test --retries=3
 ```
 
@@ -28,7 +28,7 @@ export default config;
 
 Failing tests will be retried multiple times until they pass, or until the maximum number of retries is reached. Playwright Test will report all tests that failed at least once.
 
-```sh
+```bash
 Running 1 test using 1 worker
 ××±
 1 flaky

--- a/docs/src/test-runners-java.md
+++ b/docs/src/test-runners-java.md
@@ -179,7 +179,7 @@ class Test2 extends TestFixtures {
 Configure JUnit to run tests in each class sequentially and run multiple classes on parallel threads (with max
 number of thread equal to 1/2 of the number of CPU cores):
 
-```sh
+```bash
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = same_thread
 junit.jupiter.execution.parallel.mode.classes.default = concurrent

--- a/docs/src/test-runners-python.md
+++ b/docs/src/test-runners-python.md
@@ -10,7 +10,7 @@ in Python.
 
 ## Usage
 
-```sh
+```bash
 pip install pytest-playwright
 ```
 
@@ -25,7 +25,7 @@ def test_example_is_working(page):
 
 To run your tests, use pytest CLI.
 
-```sh
+```bash
 # Run tests (Chromium and headless by default)
 pytest
 
@@ -113,7 +113,7 @@ def test_visit_example(page):
 
 Start Pytest with the `base-url` argument.
 
-```sh
+```bash
 pytest --base-url http://localhost:8080
 ```
 

--- a/docs/src/test-snapshots.md
+++ b/docs/src/test-snapshots.md
@@ -27,7 +27,7 @@ test('example test', async ({ page }) => {
 
 Sometimes you need to update the reference screenshot, for example when the page has changed. Do this with the  `--update-snapshots` flag.
 
-```sh
+```bash
 npx playwright test --update-snapshots
 ```
 

--- a/docs/src/why-playwright.md
+++ b/docs/src/why-playwright.md
@@ -37,10 +37,10 @@ Playwright enables fast, reliable and capable automation across all modern brows
 
 ## Integrates with your workflow
 * **One-line installation**. Installing Playwright auto-downloads browser dependencies for your team to be onboarded quickly.
-  ```sh js
+  ```bash js
   npm i playwright
   ```
-  ```sh python
+  ```bash python
   pip install playwright
   playwright install
   ```

--- a/packages/README.md
+++ b/packages/README.md
@@ -25,13 +25,13 @@ As of May 20, 2020, [`//packages/build_package.js`](./build_package.js) does the
 
 To build `playwright` package and save result as `./playwright.tgz` file:
 
-```sh
+```bash
 ./packages/build_package.js playwright ./playwright.tgz
 ```
 
 To debug what files are put into the folder, use `--no-cleanup` flag and inspect the package folder:
 
-```sh
+```bash
 ./packages/build_package.js playwright ./playwright.tgz --no-cleanup
 ls ./packages/playwright # inspect the folder
 ```

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -7933,7 +7933,7 @@ export {};
  * Note that since you don't need Playwright to install web browsers when testing Android, you can omit browser download
  * via setting the following environment variable when installing Playwright:
  *
- * ```sh js
+ * ```bash js
  * PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i -D playwright
  * ```
  *
@@ -9583,7 +9583,7 @@ export interface Download {
  * Note that since you don't need Playwright to install web browsers when testing Electron, you can omit browser download
  * via setting the following environment variable when installing Playwright:
  *
- * ```sh js
+ * ```bash js
  * PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i -D playwright
  * ```
  *

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -283,7 +283,7 @@ function writeComment(comment, indent = '') {
     const match = line.match(/```(\w+)/);
     if (match) {
       const lang = match[1];
-      skipExample = !["html", "yml", "sh", "js"].includes(lang);
+      skipExample = !["html", "yml", "bash", "js"].includes(lang);
     } else if (skipExample && line.trim().startsWith('```')) {
       skipExample = false;
       continue;

--- a/utils/linux-browser-dependencies/README.md
+++ b/utils/linux-browser-dependencies/README.md
@@ -12,7 +12,7 @@ and shared libraries it provides, per distribution.
 
 To generate a map of browser library to package name on Ubuntu:bionic:
 
-```sh
+```bash
 ./run.sh ubuntu:bionic
 ```
 


### PR DESCRIPTION
This fixes the highlighting in the code-blocks on playwright.dev for shell code blocks.

We could also add language aliases on playwright.dev but this has a maintenance burden since we would need to maintain our own code block React component.