### PR TITLE
chore(evaluate): refactor evaluate more

### DIFF
--- a/src/dispatchers/electronDispatcher.ts
+++ b/src/dispatchers/electronDispatcher.ts
@@ -51,12 +51,25 @@ export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplicatio
 
   async evaluateExpression(params: channels.ElectronApplicationEvaluateExpressionParams): Promise<channels.ElectronApplicationEvaluateExpressionResult> {
     const handle = await this._object._nodeElectronHandlePromise;
-    return { value: serializeResult(await handle.evaluateExpressionAndWaitForSignals(params.expression, params.isFunction, true /* returnByValue */, parseArgument(params.arg))) };
+    const result = await handle._context.eval(params.expression, {
+      isFunction: params.isFunction,
+      args: [handle, parseArgument(params.arg)],
+      doSlowMo: true,
+      returnHandle: false,
+      waitForSignals: true,
+    });
+    return { value: serializeResult(result) };
   }
 
   async evaluateExpressionHandle(params: channels.ElectronApplicationEvaluateExpressionHandleParams): Promise<channels.ElectronApplicationEvaluateExpressionHandleResult> {
     const handle = await this._object._nodeElectronHandlePromise;
-    const result = await handle.evaluateExpressionAndWaitForSignals(params.expression, params.isFunction, false /* returnByValue */, parseArgument(params.arg));
+    const result = await handle._context.eval(params.expression, {
+      isFunction: params.isFunction,
+      args: [handle, parseArgument(params.arg)],
+      doSlowMo: true,
+      returnHandle: true,
+      waitForSignals: true,
+    });
     return { handle: ElementHandleDispatcher.fromJSHandle(this._scope, result) };
   }
 

--- a/src/dispatchers/frameDispatcher.ts
+++ b/src/dispatchers/frameDispatcher.ts
@@ -66,6 +66,7 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameInitializer
       isFunction: params.isFunction,
       waitForSignals: true,
       world: 'main',
+      doSlowMo: true,
     }))};
   }
 
@@ -76,6 +77,7 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameInitializer
       returnHandle: true,
       waitForSignals: true,
       world: 'main',
+      doSlowMo: true,
     }))};
   }
 

--- a/src/dispatchers/frameDispatcher.ts
+++ b/src/dispatchers/frameDispatcher.ts
@@ -61,11 +61,22 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameInitializer
   }
 
   async evaluateExpression(params: channels.FrameEvaluateExpressionParams, metadata: CallMetadata): Promise<channels.FrameEvaluateExpressionResult> {
-    return { value: serializeResult(await this._frame.evaluateExpressionAndWaitForSignals(params.expression, params.isFunction, parseArgument(params.arg), 'main')) };
+    return { value: serializeResult(await this._frame.eval(params.expression, {
+      arg: parseArgument(params.arg),
+      isFunction: params.isFunction,
+      waitForSignals: true,
+      world: 'main',
+    }))};
   }
 
   async evaluateExpressionHandle(params: channels.FrameEvaluateExpressionHandleParams, metadata: CallMetadata): Promise<channels.FrameEvaluateExpressionHandleResult> {
-    return { handle: ElementHandleDispatcher.fromJSHandle(this._scope, await this._frame.evaluateExpressionHandleAndWaitForSignals(params.expression, params.isFunction, parseArgument(params.arg), 'main')) };
+    return { handle: ElementHandleDispatcher.fromJSHandle(this._scope, await this._frame.eval(params.expression, {
+      arg: parseArgument(params.arg),
+      isFunction: params.isFunction,
+      returnHandle: true,
+      waitForSignals: true,
+      world: 'main',
+    }))};
   }
 
   async waitForSelector(params: channels.FrameWaitForSelectorParams, metadata: CallMetadata): Promise<channels.FrameWaitForSelectorResult> {

--- a/src/dispatchers/jsHandleDispatcher.ts
+++ b/src/dispatchers/jsHandleDispatcher.ts
@@ -31,11 +31,24 @@ export class JSHandleDispatcher extends Dispatcher<js.JSHandle, channels.JSHandl
   }
 
   async evaluateExpression(params: channels.JSHandleEvaluateExpressionParams): Promise<channels.JSHandleEvaluateExpressionResult> {
-    return { value: serializeResult(await this._object.evaluateExpressionAndWaitForSignals(params.expression, params.isFunction, true /* returnByValue */, parseArgument(params.arg))) };
+    const result = await this._object._context.eval(params.expression, {
+      isFunction: params.isFunction,
+      args: [this._object, parseArgument(params.arg)],
+      doSlowMo: true,
+      returnHandle: false,
+      waitForSignals: true,
+    });
+    return { value: serializeResult(result) };
   }
 
   async evaluateExpressionHandle(params: channels.JSHandleEvaluateExpressionHandleParams): Promise<channels.JSHandleEvaluateExpressionHandleResult> {
-    const jsHandle = await this._object.evaluateExpressionAndWaitForSignals(params.expression, params.isFunction, false /* returnByValue */, parseArgument(params.arg));
+    const jsHandle = await this._object._context.eval(params.expression, {
+      isFunction: params.isFunction,
+      args: [this._object, parseArgument(params.arg)],
+      doSlowMo: true,
+      returnHandle: true,
+      waitForSignals: true,
+    });
     return { handle: ElementHandleDispatcher.fromJSHandle(this._scope, jsHandle) };
   }
 

--- a/src/server/chromium/crPage.ts
+++ b/src/server/chromium/crPage.ts
@@ -165,7 +165,7 @@ export class CRPage implements PageDelegate {
 
   async exposeBinding(binding: PageBinding) {
     await this._forAllFrameSessions(frame => frame._initBinding(binding));
-    await Promise.all(this._page.frames().map(frame => frame.evaluateExpression(binding.source, false, {}, binding.world).catch(e => {})));
+    await Promise.all(this._page.frames().map(frame => frame.eval(binding.source, {world: binding.world}).catch(e => {})));
   }
 
   async updateExtraHTTPHeaders(): Promise<void> {
@@ -469,9 +469,9 @@ class FrameSession {
             worldName: UTILITY_WORLD_NAME,
           });
           for (const binding of this._crPage._browserContext._pageBindings.values())
-            frame.evaluateExpression(binding.source, false, undefined, binding.world).catch(e => {});
+            frame.eval(binding.source, {world: binding.world}).catch(e => {});
           for (const source of this._crPage._browserContext._evaluateOnNewDocumentSources)
-            frame.evaluateExpression(source, false, undefined, 'main').catch(e => {});
+            frame.eval(source).catch(e => {});
         }
         const isInitialEmptyPage = this._isMainFrame() && this._page.mainFrame().url() === ':';
         if (isInitialEmptyPage) {

--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -171,7 +171,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
   async dispatchEvent(type: string, eventInit: Object = {}) {
     const main = await this._context.frame._mainContext();
-    return main.eval(([injected, node, { type, eventInit }]) => injected.dispatchEvent(node, type, eventInit), {
+    await main.eval(([injected, node, { type, eventInit }]) => injected.dispatchEvent(node, type, eventInit), {
       arg: [await main.injectedScript(), this, { type, eventInit }] as const,
       waitForSignals: true,
       doSlowMo: true,

--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -51,36 +51,6 @@ export class FrameExecutionContext extends js.ExecutionContext {
     return null;
   }
 
-  async evaluate<Arg, R>(pageFunction: js.Func1<Arg, R>, arg?: Arg): Promise<R> {
-    return js.evaluate(this, true /* returnByValue */, pageFunction, arg);
-  }
-
-  async evaluateHandle<Arg, R>(pageFunction: js.Func1<Arg, R>, arg?: Arg): Promise<js.SmartHandle<R>> {
-    return js.evaluate(this, false /* returnByValue */, pageFunction, arg);
-  }
-
-  async evaluateExpression(expression: string, isFunction: boolean | undefined, arg?: any): Promise<any> {
-    return js.evaluateExpression(this, true /* returnByValue */, expression, isFunction, arg);
-  }
-
-  async evaluateAndWaitForSignals<Arg, R>(pageFunction: js.Func1<Arg, R>, arg?: Arg): Promise<R> {
-    return await this.frame._page._frameManager.waitForSignalsCreatedBy(null, false /* noWaitFor */, async () => {
-      return this.evaluate(pageFunction, arg);
-    });
-  }
-
-  async evaluateExpressionAndWaitForSignals(expression: string, isFunction: boolean | undefined, arg?: any): Promise<any> {
-    return await this.frame._page._frameManager.waitForSignalsCreatedBy(null, false /* noWaitFor */, async () => {
-      return this.evaluateExpression(expression, isFunction, arg);
-    });
-  }
-
-  async evaluateExpressionHandleAndWaitForSignals(expression: string, isFunction: boolean | undefined, arg: any): Promise<any> {
-    return await this.frame._page._frameManager.waitForSignalsCreatedBy(null, false /* noWaitFor */, async () => {
-      return js.evaluateExpression(this, false /* returnByValue */, expression, isFunction, arg);
-    });
-  }
-
   createHandle(remoteObject: js.RemoteObject): js.JSHandle {
     if (this.frame._page._delegate.isElementHandle(remoteObject))
       return new ElementHandle(this, remoteObject.objectId!);
@@ -136,7 +106,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
   private async _evaluateInMainAndWaitForSignals<R, Arg>(pageFunction: js.Func1<[js.JSHandle<InjectedScript>, ElementHandle<T>, Arg], R>, arg: Arg): Promise<R> {
     const main = await this._context.frame._mainContext();
-    return main.evaluateAndWaitForSignals(pageFunction, [await main.injectedScript(), this, arg]);
+    return main.eval(pageFunction, {arg: [await main.injectedScript(), this, arg], waitForSignals: true});
   }
 
   async evaluateInUtility<R, Arg>(pageFunction: js.Func1<[js.JSHandle<InjectedScript>, ElementHandle<T>, Arg], R>, arg: Arg): Promise<R> {

--- a/src/server/electron/electron.ts
+++ b/src/server/electron/electron.ts
@@ -63,7 +63,7 @@ export class ElectronApplication extends SdkObject {
       this._nodeSession.on('Runtime.executionContextCreated', async (event: any) => {
         if (event.context.auxData && event.context.auxData.isDefault) {
           this._nodeExecutionContext = new js.ExecutionContext(this, new CRExecutionContext(this._nodeSession, event.context));
-          f(await js.evaluate(this._nodeExecutionContext, false /* returnByValue */, `process.mainModule.require('electron')`));
+          f(this._nodeExecutionContext.evaluate(`process.mainModule.require('electron')`, { returnHandle: true }));
         }
       });
     });

--- a/src/server/electron/electron.ts
+++ b/src/server/electron/electron.ts
@@ -63,7 +63,7 @@ export class ElectronApplication extends SdkObject {
       this._nodeSession.on('Runtime.executionContextCreated', async (event: any) => {
         if (event.context.auxData && event.context.auxData.isDefault) {
           this._nodeExecutionContext = new js.ExecutionContext(this, new CRExecutionContext(this._nodeSession, event.context));
-          f(this._nodeExecutionContext.evaluate(`process.mainModule.require('electron')`, { returnHandle: true }));
+          f(this._nodeExecutionContext.eval(`process.mainModule.require('electron')`, { returnHandle: true }));
         }
       });
     });

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -636,25 +636,10 @@ export class Frame extends SdkObject {
     return this._context('utility');
   }
 
-  async evaluateExpressionHandleAndWaitForSignals(expression: string, isFunction: boolean | undefined, arg: any, world: types.World = 'main'): Promise<any> {
+  async eval(pageFunction: string|Function, options: Parameters<js.ExecutionContext['eval']>[1] & {world?: types.World} = {}) {
+    const {world = 'main'} = options;
     const context = await this._context(world);
-    const handle = await context.evaluateExpressionHandleAndWaitForSignals(expression, isFunction, arg);
-    if (world === 'main')
-      await this._page._doSlowMo();
-    return handle;
-  }
-
-  async evaluateExpression(expression: string, isFunction: boolean | undefined, arg: any, world: types.World = 'main'): Promise<any> {
-    const context = await this._context(world);
-    const value = await context.evaluateExpression(expression, isFunction, arg);
-    if (world === 'main')
-      await this._page._doSlowMo();
-    return value;
-  }
-
-  async evaluateExpressionAndWaitForSignals(expression: string, isFunction: boolean | undefined, arg: any, world: types.World = 'main'): Promise<any> {
-    const context = await this._context(world);
-    const value = await context.evaluateExpressionAndWaitForSignals(expression, isFunction, arg);
+    const value = await context.eval(pageFunction, options);
     if (world === 'main')
       await this._page._doSlowMo();
     return value;

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -636,7 +636,7 @@ export class Frame extends SdkObject {
     return this._context('utility');
   }
 
-  async eval(pageFunction: string|Function, options: Parameters<js.ExecutionContext['eval']>[1] & {world?: types.World} = {}) {
+  async eval(pageFunction: string|Function, options: js.EvalOptions & {world?: types.World} = {}) {
     const {world = 'main'} = options;
     const context = await this._context(world);
     const value = await context.eval(pageFunction, options);

--- a/src/server/javascript.ts
+++ b/src/server/javascript.ts
@@ -52,6 +52,13 @@ export interface ExecutionContextDelegate {
   releaseHandle(objectId: ObjectId): Promise<void>;
 }
 
+export type EvalOptions = {
+  arg?: any;
+  args?: any[];
+  returnHandle?: boolean;
+  isFunction?: boolean;
+  waitForSignals?: boolean;
+}
 export class ExecutionContext extends SdkObject {
   readonly _delegate: ExecutionContextDelegate;
   private _utilityScriptPromise: Promise<JSHandle> | undefined;
@@ -95,7 +102,7 @@ export class ExecutionContext extends SdkObject {
     returnHandle = false,
     isFunction = typeof pageFunction === 'function',
     waitForSignals = false
-  }: { arg?: any, args?: any[], returnHandle?: boolean, isFunction?: boolean, waitForSignals?: boolean }): Promise<any> {
+  }: EvalOptions): Promise<any> {
     const action = () => evaluateExpression(this, !returnHandle, String(pageFunction), isFunction, ...args);
     if (waitForSignals)
       return this.waitForSignalsCreatedBy(action);

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -533,11 +533,11 @@ export class Worker extends SdkObject {
   }
 
   async evaluateExpression(expression: string, isFunction: boolean | undefined, arg: any): Promise<any> {
-    return js.evaluateExpression(await this._executionContextPromise, true /* returnByValue */, expression, isFunction, arg);
+    return (await this._executionContextPromise).eval(expression, {isFunction, arg});
   }
 
   async evaluateExpressionHandle(expression: string, isFunction: boolean | undefined, arg: any): Promise<any> {
-    return js.evaluateExpression(await this._executionContextPromise, false /* returnByValue */, expression, isFunction, arg);
+    return (await this._executionContextPromise).eval(expression, {isFunction, arg, returnHandle: true});
   }
 }
 

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -80,12 +80,12 @@ export class HarTracer {
 
   private _onDOMContentLoaded(page: Page) {
     const pageEntry = this._ensurePageEntry(page);
-    const promise = page.mainFrame().evaluateExpression(String(() => {
+    const promise = page.mainFrame().eval(() => {
       return {
         title: document.title,
         domContentLoaded: performance.timing.domContentLoadedEventStart,
       };
-    }), true, undefined, 'utility').then(result => {
+    }, {world: 'utility'}).then(result => {
       pageEntry.title = result.title;
       pageEntry.pageTimings.onContentLoad = result.domContentLoaded;
     }).catch(() => {});
@@ -94,12 +94,12 @@ export class HarTracer {
 
   private _onLoad(page: Page) {
     const pageEntry = this._ensurePageEntry(page);
-    const promise = page.mainFrame().evaluateExpression(String(() => {
+    const promise = page.mainFrame().eval(() => {
       return {
         title: document.title,
         loaded: performance.timing.loadEventStart,
       };
-    }), true, undefined, 'utility').then(result => {
+    }, {world: 'utility'}).then(result => {
       pageEntry.title = result.title;
       pageEntry.pageTimings.onLoad = result.loaded;
     }).catch(() => {});

--- a/src/server/supplements/recorder/recorderApp.ts
+++ b/src/server/supplements/recorder/recorderApp.ts
@@ -130,27 +130,27 @@ export class RecorderApp extends EventEmitter {
   }
 
   async setMode(mode: 'none' | 'recording' | 'inspecting'): Promise<void> {
-    await this._page.mainFrame().evaluateExpression(((mode: Mode) => {
+    await this._page.mainFrame().eval((mode: Mode) => {
       window.playwrightSetMode(mode);
-    }).toString(), true, mode, 'main').catch(() => {});
+    }, {arg: mode}).catch(() => {});
   }
 
   async setFile(file: string): Promise<void> {
-    await this._page.mainFrame().evaluateExpression(((file: string) => {
+    await this._page.mainFrame().eval((file: string) => {
       window.playwrightSetFile(file);
-    }).toString(), true, file, 'main').catch(() => {});
+    }, {arg: file}).catch(() => {});
   }
 
   async setPaused(paused: boolean): Promise<void> {
-    await this._page.mainFrame().evaluateExpression(((paused: boolean) => {
+    await this._page.mainFrame().eval((paused: boolean) => {
       window.playwrightSetPaused(paused);
-    }).toString(), true, paused, 'main').catch(() => {});
+    }, {arg: paused}).catch(() => {});
   }
 
   async setSources(sources: Source[]): Promise<void> {
-    await this._page.mainFrame().evaluateExpression(((sources: Source[]) => {
+    await this._page.mainFrame().eval((sources: Source[]) => {
       window.playwrightSetSources(sources);
-    }).toString(), true, sources, 'main').catch(() => {});
+    }, {arg: sources}).catch(() => {});
 
     // Testing harness for runCLI mode.
     {
@@ -163,15 +163,15 @@ export class RecorderApp extends EventEmitter {
   }
 
   async setSelector(selector: string, focus?: boolean): Promise<void> {
-    await this._page.mainFrame().evaluateExpression(((arg: any) => {
-      window.playwrightSetSelector(arg.selector, arg.focus);
-    }).toString(), true, { selector, focus }, 'main').catch(() => {});
+    await this._page.mainFrame().eval((selector: string, focus?: boolean) => {
+      window.playwrightSetSelector(selector, focus);
+    }, {args: [selector, focus]}).catch(() => {});
   }
 
   async updateCallLogs(callLogs: CallLog[]): Promise<void> {
-    await this._page.mainFrame().evaluateExpression(((callLogs: CallLog[]) => {
+    await this._page.mainFrame().eval((callLogs: CallLog[]) => {
       window.playwrightUpdateLogs(callLogs);
-    }).toString(), true, callLogs, 'main').catch(() => {});
+    }, {arg: callLogs}).catch(() => {});
   }
 
   async bringToFront() {

--- a/src/server/supplements/recorderSupplement.ts
+++ b/src/server/supplements/recorderSupplement.ts
@@ -269,7 +269,7 @@ export class RecorderSupplement implements InstrumentationListener {
 
   private _refreshOverlay() {
     for (const page of this._context.pages())
-      page.mainFrame().evaluateExpression('window._playwrightRefreshOverlay()', false, undefined, 'main').catch(() => {});
+      page.mainFrame().eval('window._playwrightRefreshOverlay()').catch(() => {});
   }
 
   private async _onPage(page: Page) {

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -186,7 +186,7 @@ export class WKPage implements PageDelegate {
       const bootstrapScript = this._calculateBootstrapScript(world);
       if (bootstrapScript.length)
         promises.push(session.send('Page.setBootstrapScript', { source: bootstrapScript, worldName: webkitWorldName(world) }));
-      this._page.frames().map(frame => frame.evaluateExpression(bootstrapScript, false, undefined, world).catch(e => {}));
+      this._page.frames().map(frame => frame.eval(bootstrapScript, {world}).catch(e => {}));
     }
     if (contextOptions.bypassCSP)
       promises.push(session.send('Page.setBypassCSP', { enabled: true }));
@@ -703,7 +703,7 @@ export class WKPage implements PageDelegate {
 
   private async _evaluateBindingScript(binding: PageBinding): Promise<void> {
     const script = this._bindingToScript(binding);
-    await Promise.all(this._page.frames().map(frame => frame.evaluateExpression(script, false, {}, binding.world).catch(e => {})));
+    await Promise.all(this._page.frames().map(frame => frame.eval(script, {world: binding.world}).catch(e => {})));
   }
 
   async evaluateOnNewDocument(script: string): Promise<void> {

--- a/tests/browsercontext-expose-function.spec.ts
+++ b/tests/browsercontext-expose-function.spec.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { JSHandle } from '..';
 import { contextTest as it, expect } from './config/browserTest';
 
 it('expose binding should work', async ({context}) => {
@@ -73,7 +74,7 @@ it('should be callable from-inside addInitScript', async ({context, server}) => 
 });
 
 it('exposeBindingHandle should work', async ({context}) => {
-  let target;
+  let target: JSHandle;
   await context.exposeBinding('logme', (source, t) => {
     target = t;
     return 17;

--- a/tests/page/page-expose-function.spec.ts
+++ b/tests/page/page-expose-function.spec.ts
@@ -250,22 +250,22 @@ it('should work with internal bindings', async ({page, toImpl, server, mode, bro
     foo = arg;
   }, 'utility');
   expect(await page.evaluate('!!window.foo')).toBe(false);
-  expect(await implPage.mainFrame().evaluateExpression('!!window.foo', false, {}, 'utility')).toBe(true);
+  expect(await implPage.mainFrame().eval('!!window.foo', {world: 'utility'})).toBe(true);
   expect(foo).toBe(undefined);
-  await implPage.mainFrame().evaluateExpression('window.foo(123)', false, {}, 'utility');
+  await implPage.mainFrame().eval('window.foo(123)', {world: 'utility'});
   expect(foo).toBe(123);
 
   // should work after reload
   await page.goto(server.EMPTY_PAGE);
   expect(await page.evaluate('!!window.foo')).toBe(false);
-  await implPage.mainFrame().evaluateExpression('window.foo(456)', false, {}, 'utility');
+  await implPage.mainFrame().eval('window.foo(456)', {world: 'utility'});
   expect(foo).toBe(456);
 
   // should work inside frames
   const frame = await attachFrame(page, 'myframe', server.CROSS_PROCESS_PREFIX + '/empty.html');
   expect(await frame.evaluate('!!window.foo')).toBe(false);
   const implFrame: import('../../src/server/frames').Frame = toImpl(frame);
-  await implFrame.evaluateExpression('window.foo(789)', false, {}, 'utility');
+  await implFrame.eval('window.foo(789)', {world: 'utility'});
   expect(foo).toBe(789);
 });
 


### PR DESCRIPTION
Follow up to #6769

Deletes a few more evaluation methods in favor of `.eval`, adds types for `.eval`, and
simplifies the slowMo logic.
