### PR TITLE
test: add tests for port-forwarding via playwrightclient

### DIFF
--- a/src/cli/driver.ts
+++ b/src/cli/driver.ts
@@ -54,7 +54,7 @@ export function runDriver() {
 }
 
 export async function runServer(port: number | undefined) {
-  const wsEndpoint = await PlaywrightServer.startDefault({port});
+  const wsEndpoint = await (await PlaywrightServer.startDefault()).listen(port);
   console.log('Listening on ' + wsEndpoint);  // eslint-disable-line no-console
 }
 

--- a/src/remote/playwrightServer.ts
+++ b/src/remote/playwrightServer.ts
@@ -33,7 +33,6 @@ export interface PlaywrightServerDelegate {
 }
 
 export type PlaywrightServerOptions = {
-  port?: number;
   acceptForwardedPorts?: boolean
 };
 
@@ -42,7 +41,7 @@ export class PlaywrightServer {
   private _clientsCount = 0;
   private _delegate: PlaywrightServerDelegate;
 
-  static async startDefault({port = 0, acceptForwardedPorts }: PlaywrightServerOptions): Promise<string> {
+  static async startDefault({ acceptForwardedPorts }: PlaywrightServerOptions = {}): Promise<PlaywrightServer> {
     const cleanup = async () => {
       await gracefullyCloseAll().catch(e => {});
       serverSelectors.unregisterAll();
@@ -62,8 +61,7 @@ export class PlaywrightServer {
         };
       },
     };
-    const server = new PlaywrightServer(delegate);
-    return server.listen(port);
+    return new PlaywrightServer(delegate);
   }
 
   constructor(delegate: PlaywrightServerDelegate) {

--- a/tests/config/baseTest.ts
+++ b/tests/config/baseTest.ts
@@ -74,7 +74,7 @@ class ServiceMode {
       });
     });
     this._serviceProcess.on('exit', this._onExit);
-    this._client = await PlaywrightClient.connect(`ws://localhost:${port}/ws`);
+    this._client = await PlaywrightClient.connect({wsEndpoint: `ws://localhost:${port}/ws`});
     this._playwrightObejct = this._client.playwright();
     return this._playwrightObejct;
   }


### PR DESCRIPTION
drive-by: allow getting the server instance when started via `startDefault()` to be able to close it from the server side.