### PR TITLE
Resolves: Add native GitHub continuous code security and quality analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,30 @@
+name: CodeQL Analysis
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        id: checkout_repo
+        uses: actions/checkout@v2
+
+      - name: Initialize CodeQL
+        id: init_codeql
+        uses: github/codeql-action/init@v1
+        with:
+          languages: javascript
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        id: analyze_codeql
+        uses: github/codeql-action/analyze@v1
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
- add `codeql-analysis.yml` which automatically enables CodeQL code security and quality scanner. It executes on every push commit, PR, manually and every day at 8:00AM UTC. A scan check can be viewed on commits and PRs. All alerts and fix suggestion can be viewed at **Security** tab -> **Code scanning alerts** -> **CodeQL**

Resolves #6867 