### PR TITLE
fix(tracing): error handling

### DIFF
--- a/src/server/snapshot/snapshotter.ts
+++ b/src/server/snapshot/snapshotter.ts
@@ -116,7 +116,7 @@ export class Snapshotter {
     const snapshots = page.frames().map(async frame => {
       const data = await frame.nonStallingRawEvaluateInExistingMainContext(expression).catch(e => debugLogger.log('error', e)) as SnapshotData;
       // Something went wrong -> bail out, our snapshots are best-efforty.
-      if (!data)
+      if (!data || !this._started)
         return;
 
       const snapshot: FrameSnapshot = {

--- a/src/server/trace/recorder/traceSnapshotter.ts
+++ b/src/server/trace/recorder/traceSnapshotter.ts
@@ -48,6 +48,7 @@ export class TraceSnapshotter extends EventEmitter implements SnapshotterDelegat
 
   async stop(): Promise<void> {
     await this._snapshotter.stop();
+    await this._writeArtifactChain;
   }
 
   async dispose() {

--- a/tests/tracing.spec.ts
+++ b/tests/tracing.spec.ts
@@ -38,7 +38,7 @@ test('should collect trace', async ({ context, page, server, browserName }, test
   expect(events.some(e => e.type === 'screencast-frame')).toBeTruthy();
 });
 
-test('should collect trace', async ({ context, page, server }, testInfo) => {
+test('should not collect snapshots by default', async ({ context, page, server }, testInfo) => {
   await context.tracing.start();
   await page.goto(server.EMPTY_PAGE);
   await page.setContent('<button>Click</button>');


### PR DESCRIPTION
- Reject when ZipFile signals an error.
- Make sure snapshotter does not save trace events after `stop()`.
- Await pending blob writes on `stop()`.