### PR TITLE
feat: switch to the Firefox Stable equivalent by default

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -257,8 +257,8 @@ jobs:
         name: chrome-stable-mac-test-results
         path: test-results
 
-  firefox_stable_linux:
-    name: "Firefox Stable (Linux)"
+  firefox_beta_linux:
+    name: "Firefox Beta (Linux)"
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -270,20 +270,20 @@ jobs:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
     - run: node lib/cli/cli install-deps firefox
-    - run: node lib/cli/cli install firefox-stable chromium
+    - run: node lib/cli/cli install firefox chromium
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ftest
       env:
-        PWTEST_CHANNEL: firefox-stable
+        PWTEST_CHANNEL: firefox-beta
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
-        name: firefox-stable-linux-test-results
+        name: firefox-beta-linux-test-results
         path: test-results
 
-  firefox_stable_win:
-    name: "Firefox Stable (Win)"
+  firefox_beta_win:
+    name: "Firefox Beta (Win)"
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -295,22 +295,22 @@ jobs:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
     - run: node lib/cli/cli install-deps chromium
-    - run: node lib/cli/cli install firefox-stable chromium
+    - run: node lib/cli/cli install firefox chromium
     - run: npm run ftest
       shell: bash
       env:
-        PWTEST_CHANNEL: firefox-stable
+        PWTEST_CHANNEL: firefox-beta
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
       shell: bash
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
-        name: firefox-stable-win-test-results
+        name: firefox-beta-win-test-results
         path: test-results
 
-  firefox_stable_mac:
-    name: "Firefox Stable (Mac)"
+  firefox_beta_mac:
+    name: "Firefox Beta (Mac)"
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
@@ -321,16 +321,16 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: node lib/cli/cli install firefox-stable chromium
+    - run: node lib/cli/cli install firefox chromium
     - run: npm run ftest
       env:
-        PWTEST_CHANNEL: firefox-stable
+        PWTEST_CHANNEL: firefox-beta
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
-        name: firefox-stable-mac-test-results
+        name: firefox-beta-mac-test-results
         path: test-results
 
   edge_stable_win:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🎭 Playwright
+# 🎭 Playwright 
 
 [![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-93.0.4530.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-89.0-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-14.2-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎭 Playwright
 
-[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-93.0.4530.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-89.0b15-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-14.2-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
+[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-93.0.4530.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-89.0-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-14.2-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
 
 ## [Documentation](https://playwright.dev) | [API reference](https://playwright.dev/docs/api/class-playwright/)
 
@@ -10,7 +10,7 @@ Playwright is a Node.js library to automate [Chromium](https://www.chromium.org/
 |   :---   | :---: | :---: | :---:   |
 | Chromium <!-- GEN:chromium-version -->93.0.4530.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | WebKit <!-- GEN:webkit-version -->14.2<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Firefox <!-- GEN:firefox-version -->89.0b15<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Firefox <!-- GEN:firefox-version -->89.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 Headless execution is supported for all the browsers on all platforms. Check out [system requirements](https://playwright.dev/docs/intro/#system-requirements) for details.
 

--- a/browsers.json
+++ b/browsers.json
@@ -9,12 +9,12 @@
     {
       "name": "firefox",
       "revision": "1268",
-      "installByDefault": true
+      "installByDefault": false
     },
     {
       "name": "firefox-stable",
       "revision": "1259",
-      "installByDefault": false
+      "installByDefault": true
     },
     {
       "name": "webkit",

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -36,20 +36,22 @@ const existsAsync = (path: string): Promise<boolean> => new Promise(resolve => f
 const ARTIFACTS_FOLDER = path.join(os.tmpdir(), 'playwright-artifacts-');
 
 export abstract class BrowserType extends SdkObject {
-  private _name: registry.BrowserName;
+  private _name: 'chromium'|'firefox'|'webkit';
+  private _binaryName: registry.BrowserName;
   readonly _registry: registry.Registry;
   readonly _playwrightOptions: PlaywrightOptions;
 
-  constructor(browserName: registry.BrowserName, playwrightOptions: PlaywrightOptions) {
+  constructor(name: 'chromium'|'firefox'|'webkit', binaryName: registry.BrowserName, playwrightOptions: PlaywrightOptions) {
     super(playwrightOptions.rootSdkObject, 'browser-type');
     this.attribution.browserType = this;
     this._playwrightOptions = playwrightOptions;
-    this._name = browserName;
+    this._name = name;
+    this._binaryName = binaryName;
     this._registry = playwrightOptions.registry;
   }
 
   executablePath(channel?: string): string {
-    return this._registry.executablePath(this._name) || '';
+    return this._registry.executablePath(this._binaryName) || '';
   }
 
   name(): string {

--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -42,7 +42,7 @@ export class Chromium extends BrowserType {
   private _devtools: CRDevTools | undefined;
 
   constructor(playwrightOptions: PlaywrightOptions) {
-    super('chromium', playwrightOptions);
+    super('chromium', 'chromium', playwrightOptions);
 
     if (debugMode())
       this._devtools = this._createDevTools();

--- a/src/server/firefox/firefox.ts
+++ b/src/server/firefox/firefox.ts
@@ -29,14 +29,14 @@ import * as types from '../types';
 
 export class Firefox extends BrowserType {
   constructor(playwrightOptions: PlaywrightOptions) {
-    super('firefox', playwrightOptions);
+    super('firefox', 'firefox-stable', playwrightOptions);
   }
 
   executablePath(channel?: string): string {
     if (channel) {
       let executablePath = undefined;
-      if ((channel as any) === 'firefox-stable')
-        executablePath = this._registry.executablePath('firefox-stable');
+      if ((channel as any) === 'firefox-beta')
+        executablePath = this._registry.executablePath('firefox');
       assert(executablePath, `unsupported firefox channel "${channel}"`);
       assert(fs.existsSync(executablePath), `"${channel}" channel is not installed. Try running 'npx playwright install ${channel}'`);
       return executablePath;

--- a/src/server/webkit/webkit.ts
+++ b/src/server/webkit/webkit.ts
@@ -28,7 +28,7 @@ import { assert } from '../../utils/utils';
 
 export class WebKit extends BrowserType {
   constructor(playwrightOptions: PlaywrightOptions) {
-    super('webkit', playwrightOptions);
+    super('webkit', 'webkit', playwrightOptions);
   }
 
   executablePath(channel?: string): string {


### PR DESCRIPTION
This patch:
- starts downloading Firefox Stable equivalent by default
- starts running Firefox-Stable on our smoke tests (tests-1)
- starts running Firefox-Beta on our CQ1 tests (tests-2)

Note: there's a little confusion right now with browser names:
- `firefox-stable` - firefox-stable equivalent
- `firefox`- firefox-beta equivalent

I'll rename `firefox` to `firefox-beta` in a follow-up.

Fixes #6817