### PR TITLE
feat: use WebKit stub on MacOS 10.14

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -21,7 +21,7 @@
       "revision": "1490",
       "installByDefault": true,
       "revisionOverrides": {
-        "mac10.14": "1444"
+        "mac10.14": "1445"
       }
     },
     {


### PR DESCRIPTION
This will yield the following error when installing new playwright
and launching WebbKit on MacOS 10.14

```
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^

browserType.launch: Protocol error (Playwright.enable): Browser closed.
==================== Browser output: ====================
<launching> /Users/aslushnikov/prog/playwright/browser_patches/deprecated-webkit-mac-10.14/pw_run.sh --inspector-pipe --headless --no-startup-window
<launched> pid=57578
[pid=57578][out] ERROR: this version of Playwright does not support running WebKit on MacOS 10.14. Please either update MacOS to 10.15+ or use Playwright@v1.11
[pid=57578] <process did exit: exitCode=1, signal=null>
[pid=57578] starting temporary directories cleanup
=========================== logs ===========================
<launching> /Users/aslushnikov/prog/playwright/browser_patches/deprecated-webkit-mac-10.14/pw_run.sh --inspector-pipe --headless --no-startup-window
<launched> pid=57578
[pid=57578][out] ERROR: this version of Playwright does not support running WebKit on MacOS 10.14. Please either update MacOS to 10.15+ or use Playwright@v1.11
[pid=57578] <process did exit: exitCode=1, signal=null>
[pid=57578] starting temporary directories cleanup
============================================================
```

References #6879