### PR TITLE
feat(cli): allow to list-only the dependencies without installing them

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -152,10 +152,11 @@ async function installChromeChannel(channel: string) {
 
 program
     .command('install-deps [browserType...]')
+    .option('--list-only', 'List the dependencies without installing them')
     .description('install dependencies necessary to run browsers (will ask for sudo permissions)')
-    .action(async function(browserType) {
+    .action(async function(browserType, options) {
       try {
-        await installDeps(browserType);
+        await installDeps(browserType, !!options.listOnly);
       } catch (e) {
         console.log(`Failed to install browser dependencies\n${e}`);
         process.exit(1);

--- a/src/install/installDeps.ts
+++ b/src/install/installDeps.ts
@@ -24,7 +24,7 @@ const { deps } = require('../nativeDeps');
 
 const SCRIPTS_DIRECTORY = path.join(__dirname, '..', '..', 'bin');
 
-export async function installDeps(browserTypes: string[]) {
+export async function installDeps(browserTypes: string[], listOnly: boolean) {
   if (!browserTypes.length)
     browserTypes = ['chromium', 'firefox', 'webkit'];
   if (os.platform() === 'win32') {
@@ -55,6 +55,12 @@ export async function installDeps(browserTypes: string[]) {
       libraries.push(...deps['hirsute'][browserType]);
   }
   const uniqueLibraries = Array.from(new Set(libraries));
+
+  if (listOnly) {
+    console.log(uniqueLibraries.join('\n'));
+    return;
+  }
+
   console.log('Installing Ubuntu dependencies...');  // eslint-disable-line no-console
   const commands: string[] = [];
   commands.push('apt-get update');


### PR DESCRIPTION
I want to leverage this in the Heroku buildpack. There I don't need the to install it via APT, I need to pipe the list of dependencies into a special file which contains the dependencies. This can also get re-used by other tools probably.

Maybe `--dry` is a better name?


For that: https://github.com/mxschmitt/heroku-playwright-buildpack