### PR TITLE
feat(dragAndDrop): page.dragAndDrop

### DIFF
--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -374,6 +374,20 @@ Optional event-specific initialization properties.
 
 ### option: Frame.dispatchEvent.timeout = %%-input-timeout-%%
 
+## async method: Frame.dragAndDrop
+### param: Frame.dragAndDrop.selector1
+- `selector1` <[string]>
+
+### param: Frame.dragAndDrop.selector2
+- `selector2` <[string]>
+### option: Frame.dragAndDrop.force = %%-input-force-%%
+
+### option: Frame.dragAndDrop.noWaitAfter = %%-input-no-wait-after-%%
+
+### option: Frame.dragAndDrop.timeout = %%-input-timeout-%%
+
+### option: Frame.dragAndDrop.timeout = %%-input-trial-%%
+
 ## async method: Frame.evalOnSelector
 * langs:
   - alias-python: eval_on_selector

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -386,7 +386,7 @@ Optional event-specific initialization properties.
 
 ### option: Frame.dragAndDrop.timeout = %%-input-timeout-%%
 
-### option: Frame.dragAndDrop.timeout = %%-input-trial-%%
+### option: Frame.dragAndDrop.trial = %%-input-trial-%%
 
 ## async method: Frame.evalOnSelector
 * langs:

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -375,11 +375,11 @@ Optional event-specific initialization properties.
 ### option: Frame.dispatchEvent.timeout = %%-input-timeout-%%
 
 ## async method: Frame.dragAndDrop
-### param: Frame.dragAndDrop.selector1
-- `selector1` <[string]>
 
-### param: Frame.dragAndDrop.selector2
-- `selector2` <[string]>
+### param: Frame.dragAndDrop.source = %%-input-source-%%
+
+### param: Frame.dragAndDrop.target = %%-input-target-%%
+
 ### option: Frame.dragAndDrop.force = %%-input-force-%%
 
 ### option: Frame.dragAndDrop.noWaitAfter = %%-input-no-wait-after-%%

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -812,11 +812,11 @@ Optional event-specific initialization properties.
 ### option: Page.dispatchEvent.timeout = %%-input-timeout-%%
 
 ## async method: Page.dragAndDrop
-### param: Page.dragAndDrop.selector1
-- `selector1` <[string]>
 
-### param: Page.dragAndDrop.selector2
-- `selector2` <[string]>
+### param: Page.dragAndDrop.source = %%-input-source-%%
+
+### param: Page.dragAndDrop.target = %%-input-target-%%
+
 ### option: Page.dragAndDrop.force = %%-input-force-%%
 
 ### option: Page.dragAndDrop.noWaitAfter = %%-input-no-wait-after-%%

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -811,6 +811,20 @@ Optional event-specific initialization properties.
 
 ### option: Page.dispatchEvent.timeout = %%-input-timeout-%%
 
+## async method: Page.dragAndDrop
+### param: Page.dragAndDrop.selector1
+- `selector1` <[string]>
+
+### param: Page.dragAndDrop.selector2
+- `selector2` <[string]>
+### option: Page.dragAndDrop.force = %%-input-force-%%
+
+### option: Page.dragAndDrop.noWaitAfter = %%-input-no-wait-after-%%
+
+### option: Page.dragAndDrop.timeout = %%-input-timeout-%%
+
+### option: Page.dragAndDrop.timeout = %%-input-trial-%%
+
 ## async method: Page.emulateMedia
 
 This method changes the `CSS media type` through the `media` argument, and/or the `'prefers-colors-scheme'` media feature, using the `colorScheme` argument.

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -823,7 +823,7 @@ Optional event-specific initialization properties.
 
 ### option: Page.dragAndDrop.timeout = %%-input-timeout-%%
 
-### option: Page.dragAndDrop.timeout = %%-input-trial-%%
+### option: Page.dragAndDrop.trial = %%-input-trial-%%
 
 ## async method: Page.emulateMedia
 

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -44,7 +44,17 @@ Whether to bypass the [actionability](./actionability.md) checks. Defaults to `f
 ## input-selector
 - `selector` <[string]>
 
-A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See
+A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See
+[working with selectors](./selectors.md) for more details.
+
+## input-source
+- `source` <[string]>
+A selector to search for an element to drag. If there are multiple elements satisfying the selector, the first will be used. See
+[working with selectors](./selectors.md) for more details.
+
+## input-target
+- `target` <[string]>
+A selector to search for an element to drop onto. If there are multiple elements satisfying the selector, the first will be used. See
 [working with selectors](./selectors.md) for more details.
 
 ## input-position

--- a/src/client/frame.ts
+++ b/src/client/frame.ts
@@ -298,9 +298,9 @@ export class Frame extends ChannelOwner<channels.FrameChannel, channels.FrameIni
     });
   }
 
-  async dragAndDrop(selector1: string, selector2: string, options: channels.FrameDragAndDropOptions = {}) {
+  async dragAndDrop(source: string, target: string, options: channels.FrameDragAndDropOptions = {}) {
     return this._wrapApiCall(async (channel: channels.FrameChannel) => {
-      return await channel.dragAndDrop({ selector1, selector2, ...options });
+      return await channel.dragAndDrop({ source, target, ...options });
     });
   }
 

--- a/src/client/frame.ts
+++ b/src/client/frame.ts
@@ -298,6 +298,12 @@ export class Frame extends ChannelOwner<channels.FrameChannel, channels.FrameIni
     });
   }
 
+  async dragAndDrop(selector1: string, selector2: string, options: channels.FrameDragAndDropOptions = {}) {
+    return this._wrapApiCall(async (channel: channels.FrameChannel) => {
+      return await channel.dragAndDrop({ selector1, selector2, ...options });
+    });
+  }
+
   async tap(selector: string, options: channels.FrameTapOptions = {}) {
     return this._wrapApiCall(async (channel: channels.FrameChannel) => {
       return await channel.tap({ selector, ...options });

--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -505,6 +505,10 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     return this._mainFrame.click(selector, options);
   }
 
+  async dragAndDrop(selector1: string, selector2: string, options?: channels.FrameDragAndDropOptions) {
+    return this._mainFrame.dragAndDrop(selector1, selector2, options);
+  }
+
   async dblclick(selector: string, options?: channels.FrameDblclickOptions) {
     return this._mainFrame.dblclick(selector, options);
   }

--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -505,8 +505,8 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     return this._mainFrame.click(selector, options);
   }
 
-  async dragAndDrop(selector1: string, selector2: string, options?: channels.FrameDragAndDropOptions) {
-    return this._mainFrame.dragAndDrop(selector1, selector2, options);
+  async dragAndDrop(source: string, target: string, options?: channels.FrameDragAndDropOptions) {
+    return this._mainFrame.dragAndDrop(source, target, options);
   }
 
   async dblclick(selector: string, options?: channels.FrameDblclickOptions) {

--- a/src/dispatchers/frameDispatcher.ts
+++ b/src/dispatchers/frameDispatcher.ts
@@ -124,7 +124,7 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameInitializer
   }
 
   async dragAndDrop(params: channels.FrameDragAndDropParams, metadata: CallMetadata): Promise<void> {
-    return await this._frame.dragAndDrop(metadata, params.selector1, params.selector2, params);
+    return await this._frame.dragAndDrop(metadata, params.source, params.target, params);
   }
 
   async tap(params: channels.FrameTapParams, metadata: CallMetadata): Promise<void> {

--- a/src/dispatchers/frameDispatcher.ts
+++ b/src/dispatchers/frameDispatcher.ts
@@ -123,6 +123,10 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameInitializer
     return await this._frame.dblclick(metadata, params.selector, params);
   }
 
+  async dragAndDrop(params: channels.FrameDragAndDropParams, metadata: CallMetadata): Promise<void> {
+    return await this._frame.dragAndDrop(metadata, params.selector1, params.selector2, params);
+  }
+
   async tap(params: channels.FrameTapParams, metadata: CallMetadata): Promise<void> {
     return await this._frame.tap(metadata, params.selector, params);
   }

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -1310,6 +1310,7 @@ export interface FrameChannel extends Channel {
   check(params: FrameCheckParams, metadata?: Metadata): Promise<FrameCheckResult>;
   click(params: FrameClickParams, metadata?: Metadata): Promise<FrameClickResult>;
   content(params?: FrameContentParams, metadata?: Metadata): Promise<FrameContentResult>;
+  dragAndDrop(params: FrameDragAndDropParams, metadata?: Metadata): Promise<FrameDragAndDropResult>;
   dblclick(params: FrameDblclickParams, metadata?: Metadata): Promise<FrameDblclickResult>;
   dispatchEvent(params: FrameDispatchEventParams, metadata?: Metadata): Promise<FrameDispatchEventResult>;
   evaluateExpression(params: FrameEvaluateExpressionParams, metadata?: Metadata): Promise<FrameEvaluateExpressionResult>;
@@ -1448,6 +1449,21 @@ export type FrameContentOptions = {};
 export type FrameContentResult = {
   value: string,
 };
+export type FrameDragAndDropParams = {
+  selector1: string,
+  selector2: string,
+  force?: boolean,
+  noWaitAfter?: boolean,
+  timeout?: number,
+  trial?: boolean,
+};
+export type FrameDragAndDropOptions = {
+  force?: boolean,
+  noWaitAfter?: boolean,
+  timeout?: number,
+  trial?: boolean,
+};
+export type FrameDragAndDropResult = void;
 export type FrameDblclickParams = {
   selector: string,
   force?: boolean,

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -1450,8 +1450,8 @@ export type FrameContentResult = {
   value: string,
 };
 export type FrameDragAndDropParams = {
-  selector1: string,
-  selector2: string,
+  source: string,
+  target: string,
   force?: boolean,
   noWaitAfter?: boolean,
   timeout?: number,

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -1179,8 +1179,8 @@ Frame:
 
     dragAndDrop:
       parameters:
-        selector1: string
-        selector2: string
+        source: string
+        target: string
         force: boolean?
         noWaitAfter: boolean?
         timeout: number?

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -1177,6 +1177,15 @@ Frame:
       returns:
         value: string
 
+    dragAndDrop:
+      parameters:
+        selector1: string
+        selector2: string
+        force: boolean?
+        noWaitAfter: boolean?
+        timeout: number?
+        trial: boolean?
+
     dblclick:
       parameters:
         selector: string

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -587,6 +587,14 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     trial: tOptional(tBoolean),
   });
   scheme.FrameContentParams = tOptional(tObject({}));
+  scheme.FrameDragAndDropParams = tObject({
+    selector1: tString,
+    selector2: tString,
+    force: tOptional(tBoolean),
+    noWaitAfter: tOptional(tBoolean),
+    timeout: tOptional(tNumber),
+    trial: tOptional(tBoolean),
+  });
   scheme.FrameDblclickParams = tObject({
     selector: tString,
     force: tOptional(tBoolean),

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -588,8 +588,8 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   });
   scheme.FrameContentParams = tOptional(tObject({}));
   scheme.FrameDragAndDropParams = tObject({
-    selector1: tString,
-    selector2: tString,
+    source: tString,
+    target: tString,
     force: tOptional(tBoolean),
     noWaitAfter: tOptional(tBoolean),
     timeout: tOptional(tNumber),

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -982,6 +982,24 @@ export class Frame extends SdkObject {
     }, this._page._timeoutSettings.timeout(options));
   }
 
+  async dragAndDrop(metadata: CallMetadata, selector1: string, selector2: string,  options: types.PointerActionWaitOptions & types.NavigatingActionWaitOptions = {}) {
+    const controller = new ProgressController(metadata, this);
+    await controller.run(async progress => {
+      await dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector1, async handle => {
+        return handle._retryPointerAction(progress, 'move and down', false, async point => {
+          await this._page.mouse.move(point.x, point.y);
+          await this._page.mouse.down();
+        }, options);
+      }));
+      await dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector2, async handle => {
+        return handle._retryPointerAction(progress, 'move and up', false, async point => {
+          await this._page.mouse.move(point.x, point.y);
+          await this._page.mouse.up();
+        }, options);
+      }));
+    }, this._page._timeoutSettings.timeout(options));
+  }
+
   async tap(metadata: CallMetadata, selector: string, options: types.PointerActionWaitOptions & types.NavigatingActionWaitOptions) {
     const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -982,10 +982,10 @@ export class Frame extends SdkObject {
     }, this._page._timeoutSettings.timeout(options));
   }
 
-  async dragAndDrop(metadata: CallMetadata, selector1: string, selector2: string,  options: types.PointerActionWaitOptions & types.NavigatingActionWaitOptions = {}) {
+  async dragAndDrop(metadata: CallMetadata, source: string, target: string,  options: types.PointerActionWaitOptions & types.NavigatingActionWaitOptions = {}) {
     const controller = new ProgressController(metadata, this);
     await controller.run(async progress => {
-      await dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector1, async handle => {
+      await dom.assertDone(await this._retryWithProgressIfNotConnected(progress, source, async handle => {
         return handle._retryPointerAction(progress, 'move and down', false, async point => {
           await this._page.mouse.move(point.x, point.y);
           await this._page.mouse.down();
@@ -994,7 +994,7 @@ export class Frame extends SdkObject {
           timeout: progress.timeUntilDeadline(),
         });
       }));
-      await dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector2, async handle => {
+      await dom.assertDone(await this._retryWithProgressIfNotConnected(progress, target, async handle => {
         return handle._retryPointerAction(progress, 'move and up', false, async point => {
           await this._page.mouse.move(point.x, point.y);
           await this._page.mouse.up();

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -989,13 +989,19 @@ export class Frame extends SdkObject {
         return handle._retryPointerAction(progress, 'move and down', false, async point => {
           await this._page.mouse.move(point.x, point.y);
           await this._page.mouse.down();
-        }, options);
+        }, {
+          ...options,
+          timeout: progress.timeUntilDeadline(),
+        });
       }));
       await dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector2, async handle => {
         return handle._retryPointerAction(progress, 'move and up', false, async point => {
           await this._page.mouse.move(point.x, point.y);
           await this._page.mouse.up();
-        }, options);
+        }, {
+          ...options,
+          timeout: progress.timeUntilDeadline(),
+        });
       }));
     }, this._page._timeoutSettings.timeout(options));
   }

--- a/tests/page/page-drag.spec.ts
+++ b/tests/page/page-drag.spec.ts
@@ -228,6 +228,12 @@ it.describe('Drag and drop', () => {
     expect(await page.$eval('#target', target => target.contains(document.querySelector('#source')))).toBe(true); // could not find source in target
   });
 
+  it('should work with the helper method', async ({page, server}) => {
+    await page.goto(server.PREFIX + '/drag-n-drop.html');
+    await page.dragAndDrop('#source', '#target');
+    expect(await page.$eval('#target', target => target.contains(document.querySelector('#source')))).toBe(true); // could not find source in target
+  });
+
   async function trackEvents(target: ElementHandle) {
     const eventsHandle = await target.evaluateHandle(target => {
       const events: string[] = [];

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1397,6 +1397,39 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * @param selector1
+   * @param selector2
+   * @param options
+   */
+  dragAndDrop(selector1: string, selector2: string, options?: {
+    /**
+     * Whether to bypass the [actionability](https://playwright.dev/docs/actionability) checks. Defaults to `false`.
+     */
+    force?: boolean;
+
+    /**
+     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can
+     * opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to
+     * inaccessible pages. Defaults to `false`.
+     */
+    noWaitAfter?: boolean;
+
+    /**
+     * Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by
+     * using the
+     * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
+     * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout) methods.
+     */
+    timeout?: number;
+
+    /**
+     * When set, this method only performs the [actionability](https://playwright.dev/docs/actionability) checks and skips the action. Defaults to
+     * `false`. Useful to wait until the element is ready for the action without performing it.
+     */
+    trial?: boolean;
+  }): Promise<void>;
+
+  /**
    * This method changes the `CSS media type` through the `media` argument, and/or the `'prefers-colors-scheme'` media
    * feature, using the `colorScheme` argument.
    *
@@ -3621,6 +3654,39 @@ export interface Frame {
      * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout) methods.
      */
     timeout?: number;
+  }): Promise<void>;
+
+  /**
+   * @param selector1
+   * @param selector2
+   * @param options
+   */
+  dragAndDrop(selector1: string, selector2: string, options?: {
+    /**
+     * Whether to bypass the [actionability](https://playwright.dev/docs/actionability) checks. Defaults to `false`.
+     */
+    force?: boolean;
+
+    /**
+     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can
+     * opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to
+     * inaccessible pages. Defaults to `false`.
+     */
+    noWaitAfter?: boolean;
+
+    /**
+     * Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by
+     * using the
+     * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
+     * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout) methods.
+     */
+    timeout?: number;
+
+    /**
+     * When set, this method only performs the [actionability](https://playwright.dev/docs/actionability) checks and skips the action. Defaults to
+     * `false`. Useful to wait until the element is ready for the action without performing it.
+     */
+    trial?: boolean;
   }): Promise<void>;
 
   /**

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1125,7 +1125,7 @@ export interface Page {
    * zero timeout disables this.
    *
    * Shortcut for main frame's [frame.check(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-check).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   check(selector: string, options?: {
@@ -1180,7 +1180,7 @@ export interface Page {
    * zero timeout disables this.
    *
    * Shortcut for main frame's [frame.click(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-click).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   click(selector: string, options?: {
@@ -1295,7 +1295,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.dblclick(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-dblclick).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   dblclick(selector: string, options?: {
@@ -1381,7 +1381,7 @@ export interface Page {
    * await page.dispatchEvent('#source', 'dragstart', { dataTransfer });
    * ```
    *
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param type DOM event type: `"click"`, `"dragstart"`, etc.
    * @param eventInit Optional event-specific initialization properties.
    * @param options
@@ -1397,11 +1397,11 @@ export interface Page {
   }): Promise<void>;
 
   /**
-   * @param selector1
-   * @param selector2
+   * @param source
+   * @param target
    * @param options
    */
-  dragAndDrop(selector1: string, selector2: string, options?: {
+  dragAndDrop(source: string, target: string, options?: {
     /**
      * Whether to bypass the [actionability](https://playwright.dev/docs/actionability) checks. Defaults to `false`.
      */
@@ -1541,7 +1541,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.fill(selector, value[, options])](https://playwright.dev/docs/api/class-frame#frame-fill).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param value Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
    * @param options
    */
@@ -1572,7 +1572,7 @@ export interface Page {
    * waits until a matching element appears in the DOM.
    *
    * Shortcut for main frame's [frame.focus(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-focus).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   focus(selector: string, options?: {
@@ -1617,7 +1617,7 @@ export interface Page {
 
   /**
    * Returns element attribute value.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param name Attribute name to get the value for.
    * @param options
    */
@@ -1750,7 +1750,7 @@ export interface Page {
    * zero timeout disables this.
    *
    * Shortcut for main frame's [frame.hover(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-hover).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   hover(selector: string, options?: {
@@ -1792,7 +1792,7 @@ export interface Page {
 
   /**
    * Returns `element.innerHTML`.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   innerHTML(selector: string, options?: {
@@ -1807,7 +1807,7 @@ export interface Page {
 
   /**
    * Returns `element.innerText`.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   innerText(selector: string, options?: {
@@ -1822,7 +1822,7 @@ export interface Page {
 
   /**
    * Returns `input.value` for the selected `<input>` or `<textarea>` element. Throws for non-input elements.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   inputValue(selector: string, options?: {
@@ -1837,7 +1837,7 @@ export interface Page {
 
   /**
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isChecked(selector: string, options?: {
@@ -1857,7 +1857,7 @@ export interface Page {
 
   /**
    * Returns whether the element is disabled, the opposite of [enabled](https://playwright.dev/docs/actionability#enabled).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isDisabled(selector: string, options?: {
@@ -1872,7 +1872,7 @@ export interface Page {
 
   /**
    * Returns whether the element is [editable](https://playwright.dev/docs/actionability#editable).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isEditable(selector: string, options?: {
@@ -1887,7 +1887,7 @@ export interface Page {
 
   /**
    * Returns whether the element is [enabled](https://playwright.dev/docs/actionability#enabled).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isEnabled(selector: string, options?: {
@@ -1903,7 +1903,7 @@ export interface Page {
   /**
    * Returns whether the element is hidden, the opposite of [visible](https://playwright.dev/docs/actionability#visible).  `selector` that does not
    * match any elements is considered hidden.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isHidden(selector: string, options?: {
@@ -1919,7 +1919,7 @@ export interface Page {
   /**
    * Returns whether the element is [visible](https://playwright.dev/docs/actionability#visible). `selector` that does not match any elements is
    * considered not visible.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isVisible(selector: string, options?: {
@@ -2135,7 +2135,7 @@ export interface Page {
    * await browser.close();
    * ```
    *
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param key Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
    * @param options
    */
@@ -2269,7 +2269,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.selectOption(selector, values[, options])](https://playwright.dev/docs/api/class-frame#frame-select-option).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param values Options to select. If the `<select>` has the `multiple` attribute, all matching options are selected, otherwise only the first option matching one of the passed options is selected. String values are equivalent to `{value:'string'}`. Option
    * is considered matching if all specified properties match.
    * @param options
@@ -2397,7 +2397,7 @@ export interface Page {
    *
    * Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then they
    * are resolved relative to the the current working directory. For empty array, clears the selected files.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param files
    * @param options
    */
@@ -2496,7 +2496,7 @@ export interface Page {
    * `hasTouch` option of the browser context be set to true.
    *
    * Shortcut for main frame's [frame.tap(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-tap).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   tap(selector: string, options?: {
@@ -2545,7 +2545,7 @@ export interface Page {
 
   /**
    * Returns `element.textContent`.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   textContent(selector: string, options?: {
@@ -2581,7 +2581,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.type(selector, text[, options])](https://playwright.dev/docs/api/class-frame#frame-type).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param text A text to type into a focused element.
    * @param options
    */
@@ -2624,7 +2624,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.uncheck(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-uncheck).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   uncheck(selector: string, options?: {
@@ -3418,7 +3418,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   check(selector: string, options?: {
@@ -3473,7 +3473,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   click(selector: string, options?: {
@@ -3555,7 +3555,7 @@ export interface Frame {
    * zero timeout disables this.
    *
    * > NOTE: `frame.dblclick()` dispatches two `click` events and a single `dblclick` event.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   dblclick(selector: string, options?: {
@@ -3641,7 +3641,7 @@ export interface Frame {
    * await frame.dispatchEvent('#source', 'dragstart', { dataTransfer });
    * ```
    *
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param type DOM event type: `"click"`, `"dragstart"`, etc.
    * @param eventInit Optional event-specific initialization properties.
    * @param options
@@ -3657,11 +3657,11 @@ export interface Frame {
   }): Promise<void>;
 
   /**
-   * @param selector1
-   * @param selector2
+   * @param source
+   * @param target
    * @param options
    */
-  dragAndDrop(selector1: string, selector2: string, options?: {
+  dragAndDrop(source: string, target: string, options?: {
     /**
      * Whether to bypass the [actionability](https://playwright.dev/docs/actionability) checks. Defaults to `false`.
      */
@@ -3701,7 +3701,7 @@ export interface Frame {
    *
    * To send fine-grained keyboard events, use
    * [frame.type(selector, text[, options])](https://playwright.dev/docs/api/class-frame#frame-type).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param value Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
    * @param options
    */
@@ -3730,7 +3730,7 @@ export interface Frame {
   /**
    * This method fetches an element with `selector` and focuses it. If there's no element matching `selector`, the method
    * waits until a matching element appears in the DOM.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   focus(selector: string, options?: {
@@ -3763,7 +3763,7 @@ export interface Frame {
 
   /**
    * Returns element attribute value.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param name Attribute name to get the value for.
    * @param options
    */
@@ -3837,7 +3837,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   hover(selector: string, options?: {
@@ -3879,7 +3879,7 @@ export interface Frame {
 
   /**
    * Returns `element.innerHTML`.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   innerHTML(selector: string, options?: {
@@ -3894,7 +3894,7 @@ export interface Frame {
 
   /**
    * Returns `element.innerText`.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   innerText(selector: string, options?: {
@@ -3909,7 +3909,7 @@ export interface Frame {
 
   /**
    * Returns `input.value` for the selected `<input>` or `<textarea>` element. Throws for non-input elements.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   inputValue(selector: string, options?: {
@@ -3924,7 +3924,7 @@ export interface Frame {
 
   /**
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isChecked(selector: string, options?: {
@@ -3944,7 +3944,7 @@ export interface Frame {
 
   /**
    * Returns whether the element is disabled, the opposite of [enabled](https://playwright.dev/docs/actionability#enabled).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isDisabled(selector: string, options?: {
@@ -3959,7 +3959,7 @@ export interface Frame {
 
   /**
    * Returns whether the element is [editable](https://playwright.dev/docs/actionability#editable).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isEditable(selector: string, options?: {
@@ -3974,7 +3974,7 @@ export interface Frame {
 
   /**
    * Returns whether the element is [enabled](https://playwright.dev/docs/actionability#enabled).
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isEnabled(selector: string, options?: {
@@ -3990,7 +3990,7 @@ export interface Frame {
   /**
    * Returns whether the element is hidden, the opposite of [visible](https://playwright.dev/docs/actionability#visible).  `selector` that does not
    * match any elements is considered hidden.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isHidden(selector: string, options?: {
@@ -4006,7 +4006,7 @@ export interface Frame {
   /**
    * Returns whether the element is [visible](https://playwright.dev/docs/actionability#visible). `selector` that does not match any elements is
    * considered not visible.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   isVisible(selector: string, options?: {
@@ -4055,7 +4055,7 @@ export interface Frame {
    *
    * Shortcuts such as `key: "Control+o"` or `key: "Control+Shift+T"` are supported as well. When specified with the
    * modifier, modifier is pressed and being held while the subsequent key is being pressed.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param key Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
    * @param options
    */
@@ -4191,7 +4191,7 @@ export interface Frame {
    *
    * Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then they
    * are resolved relative to the the current working directory. For empty array, clears the selected files.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param files
    * @param options
    */
@@ -4256,7 +4256,7 @@ export interface Frame {
    * zero timeout disables this.
    *
    * > NOTE: `frame.tap()` requires that the `hasTouch` option of the browser context be set to true.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   tap(selector: string, options?: {
@@ -4305,7 +4305,7 @@ export interface Frame {
 
   /**
    * Returns `element.textContent`.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   textContent(selector: string, options?: {
@@ -4336,7 +4336,7 @@ export interface Frame {
    * await frame.type('#mytextarea', 'World', {delay: 100}); // Types slower, like a user
    * ```
    *
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param text A text to type into a focused element.
    * @param options
    */
@@ -4376,7 +4376,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
-   * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   uncheck(selector: string, options?: {


### PR DESCRIPTION
Waiting for the chromium specific changes to land.

Proposed api: `page.dragAndDrop(selector1, selector2, options)`

Also exists on the frame.

Assuming people like the api I will go write some docs.

#7562 
