### PR TITLE
fix(test runner): remove folio/jest namespaces in expect matchers

### DIFF
--- a/docs/src/test-advanced.md
+++ b/docs/src/test-advanced.md
@@ -467,16 +467,9 @@ For TypeScript, also add the following to `global.d.ts`. You don't need it for J
 
 ```js
 // global.d.ts
-declare namespace folio {
+declare namespace PlaywrightTest {
   interface Matchers<R> {
     toBeWithinRange(a: number, b: number): R;
   }
 }
-```
-
-To import expect matching libraries like [jest-extended](https://github.com/jest-community/jest-extended#installation) you can import it from your `global.d.ts`:
-
-```js
-// global.d.ts
-import 'jest-extended';
 ```

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -16,7 +16,7 @@
 
 import { test, expect } from './playwright-test-fixtures';
 
-test('should be able to extend the expect matchers with test.extend in the folio config', async ({ runInlineTest }) => {
+test('should be able to call expect.extend in config', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'helper.ts': `
       pwt.expect.extend({
@@ -73,36 +73,12 @@ test('should work with default expect matchers', async ({runTSC}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should work with jest-community/jest-extended', async ({runTSC}) => {
+test('should work with custom PlaywrightTest namespace', async ({runTSC}) => {
   const result = await runTSC({
     'global.d.ts': `
       // Extracted example from their typings.
       // Reference: https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts
-      declare namespace jest {
-        interface Matchers<R> {
-          toBeEmpty(): R;
-        }
-      }
-    `,
-    'a.spec.ts': `
-      const { test } = pwt;
-      test.expect('').toBeEmpty();
-      test.expect('hello').not.toBeEmpty();
-      test.expect([]).toBeEmpty();
-      test.expect(['hello']).not.toBeEmpty();
-      test.expect({}).toBeEmpty();
-      test.expect({ hello: 'world' }).not.toBeEmpty();
-    `
-  });
-  expect(result.exitCode).toBe(0);
-});
-
-test('should work with custom folio namespace', async ({runTSC}) => {
-  const result = await runTSC({
-    'global.d.ts': `
-      // Extracted example from their typings.
-      // Reference: https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts
-      declare namespace folio {
+      declare namespace PlaywrightTest {
         interface Matchers<R> {
           toBeEmpty(): R;
         }

--- a/types/testExpect.d.ts
+++ b/types/testExpect.d.ts
@@ -12,7 +12,7 @@ import type { ExpectedAssertionsErrors } from 'expect/build/types';
 export declare type AsymmetricMatcher = Record<string, any>;
 
 export declare type Expect = {
-  <T = unknown>(actual: T): folio.Matchers<T>;
+  <T = unknown>(actual: T): PlaywrightTest.Matchers<T>;
 
   // Sourced from node_modules/expect/build/types.d.ts
   assertions(arg0: number): void;
@@ -30,27 +30,22 @@ export declare type Expect = {
 };
 
 declare global {
-  export namespace jest {
+  export namespace PlaywrightTest {
     export interface Matchers<R> extends expect.Matchers<R> {
-
-    }
-  }
-  export namespace folio {
-    export interface Matchers<R> extends jest.Matchers<R> {
       /**
        * If you know how to test something, `.not` lets you test its opposite.
        */
-      not: folio.Matchers<R>;
+      not: PlaywrightTest.Matchers<R>;
       /**
        * Use resolves to unwrap the value of a fulfilled promise so any other
        * matcher can be chained. If the promise is rejected the assertion fails.
        */
-      resolves: folio.Matchers<Promise<R>>;
+      resolves: PlaywrightTest.Matchers<Promise<R>>;
       /**
       * Unwraps the reason of a rejected promise so any other matcher can be chained.
       * If the promise is fulfilled the assertion fails.
       */
-      rejects: folio.Matchers<Promise<R>>;
+      rejects: PlaywrightTest.Matchers<Promise<R>>;
       /**
        * Match snapshot
        */


### PR DESCRIPTION
We'll be able to bring jest namespace back if/when needed.