### PR TITLE
docs(mobile): make experimental Android support more present

### DIFF
--- a/docs/src/api/class-android.md
+++ b/docs/src/api/class-android.md
@@ -1,7 +1,7 @@
 # class: Android
 * langs: js
 
-Playwright has **experimental** support for Android automation. You can access android namespace via:
+Playwright has **experimental** support for Android automation. See [here](./mobile.md) for more information. You can access android namespace via:
 
 ```js
 const { _android: android } = require('playwright');

--- a/docs/src/why-playwright.md
+++ b/docs/src/why-playwright.md
@@ -58,4 +58,4 @@ Playwright enables fast, reliable and capable automation across all modern brows
 
 * **Legacy Edge and IE11 support**. Playwright does not support legacy Microsoft Edge or IE11 ([deprecation notice](https://techcommunity.microsoft.com/t5/microsoft-365-blog/microsoft-365-apps-say-farewell-to-internet-explorer-11-and/ba-p/1591666)). The new Microsoft Edge (on Chromium) is supported.
 
-* **Test on real mobile devices**: Playwright uses desktop browsers to emulate mobile devices. If you are interested in running on real mobile devices, please [upvote this issue](https://github.com/microsoft/playwright/issues/1122).
+* **Test on real mobile devices**: Playwright uses desktop browsers to emulate mobile devices. There is experimental Android support available see [here](https://playwright.dev/docs/mobile). If you are interested in iOS, please [upvote this issue](https://github.com/microsoft/playwright/issues/1122).

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -7871,7 +7871,8 @@ export {};
 
 
 /**
- * Playwright has **experimental** support for Android automation. You can access android namespace via:
+ * Playwright has **experimental** support for Android automation. See [here](https://playwright.dev/docs/mobile) for more information. You can
+ * access android namespace via:
  *
  * ```js
  * const { _android: android } = require('playwright');


### PR DESCRIPTION
This should explain why the issue was upvoted so much. Also added a cross-link from Android to the mobile guide since it contains the requirements.