### PR TITLE
fix(test-runner): print full syntax errors

### DIFF
--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -61,7 +61,7 @@ export function addTestCommand(program: commander.CommanderStatic) {
     try {
       await runTests(args, opts);
     } catch (e) {
-      console.error(e.toString());
+      console.error(e && typeof e === 'object' && e.stack ? e.stack : String(e));
       process.exit(1);
     }
   });

--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -16,7 +16,7 @@
 
 import { installTransform } from './transform';
 import type { FullConfig, Config, FullProject, Project, ReporterDescription, PreserveOutput } from './types';
-import { errorWithCallLocation, isRegExp, mergeObjects, prependErrorMessage } from './util';
+import { errorWithCallLocation, isRegExp, mergeObjects } from './util';
 import { setCurrentlyLoadingFileSuite } from './globals';
 import { Suite } from './test';
 import { SerializedLoaderData } from './ipc';
@@ -61,9 +61,6 @@ export class Loader {
       this._processConfigObject(path.dirname(file));
       this._configFile = file;
       return rawConfig;
-    } catch (e) {
-      prependErrorMessage(e, `Error while reading ${file}:\n`);
-      throw e;
     } finally {
       revertBabelRequire();
     }
@@ -114,9 +111,6 @@ export class Loader {
       require(file);
       this._fileSuites.set(file, suite);
       return suite;
-    } catch (e) {
-      prependErrorMessage(e, `Error while reading ${file}:\n`);
-      throw e;
     } finally {
       revertBabelRequire();
       setCurrentlyLoadingFileSuite(undefined);
@@ -132,9 +126,6 @@ export class Loader {
       if (typeof hook !== 'function')
         throw errorWithCallLocation(`${name} file must export a single function.`);
       return hook;
-    } catch (e) {
-      prependErrorMessage(e, `Error while reading ${file}:\n`);
-      throw e;
     } finally {
       revertBabelRequire();
     }
@@ -149,9 +140,6 @@ export class Loader {
       if (typeof func !== 'function')
         throw errorWithCallLocation(`Reporter file "${file}" must export a single class.`);
       return func;
-    } catch (e) {
-      prependErrorMessage(e, `Error while reading ${file}:\n`);
-      throw e;
     } finally {
       revertBabelRequire();
     }

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -123,17 +123,6 @@ export function monotonicTime(): number {
   return seconds * 1000 + (nanoseconds / 1000000 | 0);
 }
 
-export function prependErrorMessage(e: Error, message: string) {
-  let stack = e.stack || '';
-  if (stack.includes(e.message))
-    stack = stack.substring(stack.indexOf(e.message) + e.message.length);
-  let m = e.message;
-  if (m.startsWith('Error:'))
-    m = m.substring('Error:'.length);
-  e.message = message + m;
-  e.stack = e.message + stack;
-}
-
 export function isRegExp(e: any): e is RegExp {
   return e && typeof e === 'object' && (e instanceof RegExp || Object.prototype.toString.call(e) === '[object RegExp]');
 }

--- a/tests/playwright-test/fixture-errors.spec.ts
+++ b/tests/playwright-test/fixture-errors.spec.ts
@@ -367,7 +367,7 @@ test('should print nice error message for problematic fixtures', async ({ runInl
   });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('oh my!');
-  expect(result.output).toContain('x.spec.ts:5:29');
+  expect(result.output).toContain('x.spec.ts:6:49');
 });
 
 test('should exit with timeout when fixture causes an exception in the test', async ({ runInlineTest }) => {

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import { test, expect } from './playwright-test-fixtures';
+
+ test('should return the location of a syntax error', async ({ runInlineTest }) => {
+   const result = await runInlineTest({
+     'error.spec.js': `
+       const x = {
+         foo: 'bar';
+       };
+     `
+   });
+   expect(result.exitCode).toBe(1);
+   expect(result.passed).toBe(0);
+   expect(result.failed).toBe(0);
+   expect(result.output).toContain('/error.spec.js:6');
+ });
+ 
+ test('should print an improper error', async ({ runInlineTest }) => {
+   const result = await runInlineTest({
+     'error.spec.js': `
+       throw 123;
+     `
+   });
+   expect(result.exitCode).toBe(1);
+   expect(result.passed).toBe(0);
+   expect(result.failed).toBe(0);
+   expect(result.output).toContain('123');
+ });
+ 
+ 
+ test('should print a null error', async ({ runInlineTest }) => {
+   const result = await runInlineTest({
+     'error.spec.js': `
+       throw null;
+     `
+   });
+   expect(result.exitCode).toBe(1);
+   expect(result.passed).toBe(0);
+   expect(result.failed).toBe(0);
+   expect(result.output).toContain('null');
+ });
+ 
+ test('should return the location of a syntax error in typescript', async ({ runInlineTest }) => {
+   const result = await runInlineTest({
+     'error.spec.ts': `
+       const x = {
+         foo: 'bar';
+       };
+     `
+   }, {}, {
+     FORCE_COLOR: '0'
+   });
+   expect(result.exitCode).toBe(1);
+   expect(result.passed).toBe(0);
+   expect(result.failed).toBe(0);
+   expect(result.output).toContain('/error.spec.ts');
+   expect(result.output).toContain('\'bar\';');
+ });
+ 


### PR DESCRIPTION
Folio was printing errors with `error.toString()` which does not include
the full syntax error.

The prependErrorMessage method was used everywhere to add extra info,
but I could not find a place where it actually made the error messages better.﻿
I removed it for now.
