### PR TITLE
feat(playwright-test): scan the world

### DIFF
--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -122,8 +122,8 @@ async function runTests(args: string[], opts: { [key: string]: any }) {
     }
   } else if (!loadConfig(path.resolve(process.cwd(), tsConfig)) && !loadConfig(path.resolve(process.cwd(), jsConfig))) {
     // No --config option, let's look for the config file in the current directory.
-    // If not, do not assume that current directory is a root testing directory, to avoid scanning the world.
-    throw new Error(`Configuration file not found. Run "npx playwright test --help" for more information.`);
+    // If not, scan the world.
+    runner.loadEmptyConfig(process.cwd());
   }
 
   const result = await runner.run(!!opts.list, args.map(forceRegExp), opts.project || undefined);


### PR DESCRIPTION
Running `npx playwright test` results in a cryptic error message that says to check `--help` for more information.

I started to rewrite it, but I think instead it would be much nicer if we just treated `npx playwright test` as an alias for `npx playwright test -c .`. There is a comment in the code that worries this will be slow because it will scan the world. However we need to support this case anyway for the tests-next-to-code pattern.

It looks like this should be fast because we ignore node_modules/.gitignore entries. If this is still too slow we should make it faster. If we can't make it faster we should throw a more specific error telling the user how to make it faster.