### PR TITLE
chore: make WebKit @ MacOS 10.14 error more prominent

### DIFF
--- a/browser_patches/deprecated-webkit-mac-10.14/BUILD_NUMBER
+++ b/browser_patches/deprecated-webkit-mac-10.14/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1445
-Changed: lushnikov@chromium.org Thu Jun  3 15:24:06 PDT 2021
+1446
+Changed: lushnikov@chromium.org Mon Jun  7 14:01:01 PDT 2021

--- a/browser_patches/deprecated-webkit-mac-10.14/pw_run.sh
+++ b/browser_patches/deprecated-webkit-mac-10.14/pw_run.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
 
-echo "ERROR: this version of Playwright does not support running WebKit on MacOS 10.14. Please either update MacOS to 10.15+ or use Playwright@v1.11"
+cat << EndOfMessage
+****************************************************************
+****************************************************************
+
+ERROR: MacOS version is too old!
+
+This version of Playwright does not support running
+WebKit on MacOS 10.14. Please either:
+- update your operating system to version 10.15 or higher
+- use Playwright v1.11 or older
+
+****************************************************************
+****************************************************************
+EndOfMessage
 exit 1;


### PR DESCRIPTION
The new message is much more prominent in the logs:

```
aslushnikov:~/prog/playwright(make-deprecation-error-more-prominent)$ node a.js
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^

browserType.launch: Protocol error (Playwright.enable): Browser closed.
==================== Browser output: ====================
<launching> /Users/aslushnikov/prog/playwright/browser_patches/deprecated-webkit-mac-10.14/pw_run.sh --inspector-pipe --headless --no-startup-window
<launched> pid=5120
[pid=5120][out] ****************************************************************
[pid=5120][out] ****************************************************************
[pid=5120][out]
[pid=5120][out] ERROR: MacOS version is too old!
[pid=5120][out]
[pid=5120][out] This version of Playwright does not support running
[pid=5120][out] WebKit on MacOS 10.14. Please either:
[pid=5120][out] - update your operating system to version 10.15 or higher
[pid=5120][out] - use Playwright v1.11 or older
[pid=5120][out]
[pid=5120][out] ****************************************************************
[pid=5120][out] ****************************************************************
[pid=5120] <process did exit: exitCode=1, signal=null>
[pid=5120] starting temporary directories cleanup
```