### PR TITLE
Revert "feat: switch to the Firefox Stable equivalent by default (#69…

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -19,9 +19,9 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+    - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
-    - run: node lib/cli/cli install-deps chromium firefox webkit
     - run: npm run lint
     - name: Verify clean tree
       run: |
@@ -39,8 +39,8 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+    - uses: microsoft/playwright-github-action@v1
     - run: npm ci
     - run: npm run build
-    - run: node lib/cli/cli install-deps chromium
     - run: node utils/build/update_canary_version.js --today-date
     - run: utils/build/build-playwright-driver.sh

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -257,8 +257,8 @@ jobs:
         name: chrome-stable-mac-test-results
         path: test-results
 
-  firefox_beta_linux:
-    name: "Firefox Beta (Linux)"
+  firefox_stable_linux:
+    name: "Firefox Stable (Linux)"
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -270,20 +270,20 @@ jobs:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
     - run: node lib/cli/cli install-deps firefox
-    - run: node lib/cli/cli install firefox chromium
+    - run: node lib/cli/cli install firefox-stable chromium
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ftest
       env:
-        PWTEST_CHANNEL: firefox-beta
+        PWTEST_CHANNEL: firefox-stable
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
-        name: firefox-beta-linux-test-results
+        name: firefox-stable-linux-test-results
         path: test-results
 
-  firefox_beta_win:
-    name: "Firefox Beta (Win)"
+  firefox_stable_win:
+    name: "Firefox Stable (Win)"
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -295,22 +295,22 @@ jobs:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
     - run: node lib/cli/cli install-deps chromium
-    - run: node lib/cli/cli install firefox chromium
+    - run: node lib/cli/cli install firefox-stable chromium
     - run: npm run ftest
       shell: bash
       env:
-        PWTEST_CHANNEL: firefox-beta
+        PWTEST_CHANNEL: firefox-stable
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
       shell: bash
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
-        name: firefox-beta-win-test-results
+        name: firefox-stable-win-test-results
         path: test-results
 
-  firefox_beta_mac:
-    name: "Firefox Beta (Mac)"
+  firefox_stable_mac:
+    name: "Firefox Stable (Mac)"
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
@@ -321,16 +321,16 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: node lib/cli/cli install firefox chromium
+    - run: node lib/cli/cli install firefox-stable chromium
     - run: npm run ftest
       env:
-        PWTEST_CHANNEL: firefox-beta
+        PWTEST_CHANNEL: firefox-stable
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
-        name: firefox-beta-mac-test-results
+        name: firefox-stable-mac-test-results
         path: test-results
 
   edge_stable_mac:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎭 Playwright
 
-[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-93.0.4530.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-89.0-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-14.2-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
+[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-93.0.4530.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-89.0b15-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-14.2-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
 
 ## [Documentation](https://playwright.dev) | [API reference](https://playwright.dev/docs/api/class-playwright/)
 
@@ -10,7 +10,7 @@ Playwright is a Node.js library to automate [Chromium](https://www.chromium.org/
 |   :---   | :---: | :---: | :---:   |
 | Chromium <!-- GEN:chromium-version -->93.0.4530.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | WebKit <!-- GEN:webkit-version -->14.2<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Firefox <!-- GEN:firefox-version -->89.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Firefox <!-- GEN:firefox-version -->89.0b15<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 Headless execution is supported for all the browsers on all platforms. Check out [system requirements](https://playwright.dev/docs/intro/#system-requirements) for details.
 

--- a/browsers.json
+++ b/browsers.json
@@ -9,12 +9,12 @@
     {
       "name": "firefox",
       "revision": "1268",
-      "installByDefault": false
+      "installByDefault": true
     },
     {
       "name": "firefox-stable",
       "revision": "1259",
-      "installByDefault": true
+      "installByDefault": false
     },
     {
       "name": "webkit",

--- a/packages/build_package.js
+++ b/packages/build_package.js
@@ -33,7 +33,7 @@ const PLAYWRIGHT_CORE_FILES = ['bin', 'lib', 'types', 'NOTICE', 'LICENSE', ];
 const PACKAGES = {
   'playwright': {
     description: 'A high-level API to automate web browsers',
-    browsers: ['chromium', 'firefox-stable', 'webkit', 'ffmpeg'],
+    browsers: ['chromium', 'firefox', 'webkit', 'ffmpeg'],
     // We copy README.md additionally for Playwright so that it looks nice on NPM.
     files: [...PLAYWRIGHT_CORE_FILES, 'README.md'],
   },
@@ -44,7 +44,7 @@ const PACKAGES = {
   },
   'playwright-test': {
     description: 'Playwright Test Runner',
-    browsers: ['chromium', 'firefox-stable', 'webkit', 'ffmpeg'],
+    browsers: ['chromium', 'firefox', 'webkit', 'ffmpeg'],
     files: PLAYWRIGHT_CORE_FILES,
     name: '@playwright/test',
   },
@@ -55,7 +55,7 @@ const PACKAGES = {
   },
   'playwright-firefox': {
     description: 'A high-level API to automate Firefox',
-    browsers: ['firefox-stable'],
+    browsers: ['firefox'],
     files: PLAYWRIGHT_CORE_FILES,
   },
   'playwright-chromium': {

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -35,22 +35,20 @@ import { CallMetadata, SdkObject } from './instrumentation';
 const ARTIFACTS_FOLDER = path.join(os.tmpdir(), 'playwright-artifacts-');
 
 export abstract class BrowserType extends SdkObject {
-  private _name: 'chromium'|'firefox'|'webkit';
-  private _binaryName: registry.BrowserName;
+  private _name: registry.BrowserName;
   readonly _registry: registry.Registry;
   readonly _playwrightOptions: PlaywrightOptions;
 
-  constructor(name: 'chromium'|'firefox'|'webkit', binaryName: registry.BrowserName, playwrightOptions: PlaywrightOptions) {
+  constructor(browserName: registry.BrowserName, playwrightOptions: PlaywrightOptions) {
     super(playwrightOptions.rootSdkObject, 'browser-type');
     this.attribution.browserType = this;
     this._playwrightOptions = playwrightOptions;
-    this._name = name;
-    this._binaryName = binaryName;
+    this._name = browserName;
     this._registry = playwrightOptions.registry;
   }
 
   executablePath(channel?: string): string {
-    return this._registry.executablePath(this._binaryName) || '';
+    return this._registry.executablePath(this._name) || '';
   }
 
   name(): string {
@@ -174,7 +172,7 @@ export abstract class BrowserType extends SdkObject {
 
     // Only validate dependencies for downloadable browsers.
     if (!executablePath && !options.channel)
-      await validateHostRequirements(this._registry, this._binaryName);
+      await validateHostRequirements(this._registry, this._name);
     else if (!executablePath && options.channel && this._registry.isSupportedBrowser(options.channel))
       await validateHostRequirements(this._registry, options.channel as registry.BrowserName);
 

--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -42,7 +42,7 @@ export class Chromium extends BrowserType {
   private _devtools: CRDevTools | undefined;
 
   constructor(playwrightOptions: PlaywrightOptions) {
-    super('chromium', 'chromium', playwrightOptions);
+    super('chromium', playwrightOptions);
 
     if (debugMode())
       this._devtools = this._createDevTools();

--- a/src/server/firefox/firefox.ts
+++ b/src/server/firefox/firefox.ts
@@ -29,14 +29,14 @@ import * as types from '../types';
 
 export class Firefox extends BrowserType {
   constructor(playwrightOptions: PlaywrightOptions) {
-    super('firefox', 'firefox-stable', playwrightOptions);
+    super('firefox', playwrightOptions);
   }
 
   executablePath(channel?: string): string {
     if (channel) {
       let executablePath = undefined;
-      if ((channel as any) === 'firefox-beta')
-        executablePath = this._registry.executablePath('firefox');
+      if ((channel as any) === 'firefox-stable')
+        executablePath = this._registry.executablePath('firefox-stable');
       assert(executablePath, `unsupported firefox channel "${channel}"`);
       assert(fs.existsSync(executablePath), `"${channel}" channel is not installed. Try running 'npx playwright install ${channel}'`);
       return executablePath;

--- a/src/server/webkit/webkit.ts
+++ b/src/server/webkit/webkit.ts
@@ -28,7 +28,7 @@ import { assert } from '../../utils/utils';
 
 export class WebKit extends BrowserType {
   constructor(playwrightOptions: PlaywrightOptions) {
-    super('webkit', 'webkit', playwrightOptions);
+    super('webkit', playwrightOptions);
   }
 
   executablePath(channel?: string): string {


### PR DESCRIPTION
…26)"

This reverts commit a25b11659be8887b700311180fcd3653aa9e472b.

In a discussion with @dgozman we decided to revert this and instead
proceed with the following approach:
- rename `//browser_patches/firefox` to `//browser_patches/firefox-beta`
- rename `//browser_patches/firefox-stable` folder to
  `//browser_patches/firefox`

In all of the folders, we will keep the `BUILD_NUMBER` original so that
it doesn't clash on the CDN.