### PR TITLE
feat: firefox is stable by default

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -257,8 +257,8 @@ jobs:
         name: chrome-stable-mac-test-results
         path: test-results
 
-  firefox_stable_linux:
-    name: "Firefox Stable (Linux)"
+  firefox_beta_linux:
+    name: "Firefox Beta (Linux)"
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -270,20 +270,20 @@ jobs:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
     - run: node lib/cli/cli install-deps firefox
-    - run: node lib/cli/cli install firefox-stable chromium
+    - run: node lib/cli/cli install firefox-beta chromium
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ftest
       env:
-        PWTEST_CHANNEL: firefox-stable
+        PWTEST_CHANNEL: firefox-beta
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
-        name: firefox-stable-linux-test-results
+        name: firefox-beta-linux-test-results
         path: test-results
 
-  firefox_stable_win:
-    name: "Firefox Stable (Win)"
+  firefox_beta_win:
+    name: "Firefox Beta (Win)"
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -295,22 +295,22 @@ jobs:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
     - run: node lib/cli/cli install-deps chromium
-    - run: node lib/cli/cli install firefox-stable chromium
+    - run: node lib/cli/cli install firefox-beta chromium
     - run: npm run ftest
       shell: bash
       env:
-        PWTEST_CHANNEL: firefox-stable
+        PWTEST_CHANNEL: firefox-beta
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
       shell: bash
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
-        name: firefox-stable-win-test-results
+        name: firefox-beta-win-test-results
         path: test-results
 
-  firefox_stable_mac:
-    name: "Firefox Stable (Mac)"
+  firefox_beta_mac:
+    name: "Firefox Beta (Mac)"
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
@@ -321,16 +321,16 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: node lib/cli/cli install firefox-stable chromium
+    - run: node lib/cli/cli install firefox-beta chromium
     - run: npm run ftest
       env:
-        PWTEST_CHANNEL: firefox-stable
+        PWTEST_CHANNEL: firefox-beta
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
     - uses: actions/upload-artifact@v1
       if: ${{ always() }}
       with:
-        name: firefox-stable-mac-test-results
+        name: firefox-beta-mac-test-results
         path: test-results
 
   edge_stable_mac:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎭 Playwright
 
-[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-93.0.4530.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-89.0b15-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-14.2-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
+[![npm version](https://img.shields.io/npm/v/playwright.svg?style=flat)](https://www.npmjs.com/package/playwright) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-93.0.4530.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-89.0-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-14.2-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
 
 ## [Documentation](https://playwright.dev) | [API reference](https://playwright.dev/docs/api/class-playwright/)
 
@@ -10,7 +10,7 @@ Playwright is a Node.js library to automate [Chromium](https://www.chromium.org/
 |   :---   | :---: | :---: | :---:   |
 | Chromium <!-- GEN:chromium-version -->93.0.4530.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | WebKit <!-- GEN:webkit-version -->14.2<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Firefox <!-- GEN:firefox-version -->89.0b15<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Firefox <!-- GEN:firefox-version -->89.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 Headless execution is supported for all the browsers on all platforms. Check out [system requirements](https://playwright.dev/docs/intro/#system-requirements) for details.
 

--- a/browsers.json
+++ b/browsers.json
@@ -8,12 +8,12 @@
     },
     {
       "name": "firefox",
-      "revision": "1268",
+      "revision": "1269",
       "installByDefault": true
     },
     {
-      "name": "firefox-stable",
-      "revision": "1259",
+      "name": "firefox-beta",
+      "revision": "1260",
       "installByDefault": false
     },
     {

--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -11,8 +11,7 @@ of the browsers it supports, so that the latest Playwright would support the lat
 ## Chromium
 
 For Google Chrome, Microsoft Edge and other Chromium-based browsers, by default, Playwright uses open source Chromium builds.
-These builds match the current [Chrome Dev Channel](https://support.google.com/chrome/a/answer/9027636?hl=en) at the time
-of each Playwright release, i.e. it is new with every Playwright update. Since Chromium project is ahead of the branded browsers,
+ Since Chromium project is ahead of the branded browsers,
 when the world is on Google Chrome 89, Playwright already supports Chromium 91 that will hit Google Chrome and Microsoft Edge
 if a few weeks.
 
@@ -21,7 +20,7 @@ on when to opt into stable channels, refer to the [Google Chrome & Microsoft Edg
 
 ## Firefox
 
-Playwright's Firefox version matches the recent [Firefox Beta](https://www.mozilla.org/en-US/firefox/channel/desktop/)
+Playwright's Firefox version matches the recent [Firefox Stable](https://www.mozilla.org/en-US/firefox/new/)
 build.
 
 ## WebKit

--- a/src/server/firefox/firefox.ts
+++ b/src/server/firefox/firefox.ts
@@ -35,8 +35,8 @@ export class Firefox extends BrowserType {
   executablePath(channel?: string): string {
     if (channel) {
       let executablePath = undefined;
-      if ((channel as any) === 'firefox-stable')
-        executablePath = this._registry.executablePath('firefox-stable');
+      if ((channel as any) === 'firefox-beta')
+        executablePath = this._registry.executablePath('firefox-beta');
       assert(executablePath, `unsupported firefox channel "${channel}"`);
       assert(fs.existsSync(executablePath), `"${channel}" channel is not installed. Try running 'npx playwright install ${channel}'`);
       return executablePath;

--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -42,7 +42,7 @@ const DL_OPEN_LIBRARIES = {
   'webkit': ['libGLESv2.so.2', 'libx264.so'],
   'webkit-technology-preview': ['libGLESv2.so.2', 'libx264.so'],
   'firefox': [],
-  'firefox-stable': [],
+  'firefox-beta': [],
   'clank': [],
   'ffmpeg': [],
 };

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -22,8 +22,8 @@ import * as util from 'util';
 import { getUbuntuVersionSync } from './ubuntuVersion';
 import { assert, getFromENV } from './utils';
 
-export type BrowserName = 'chromium'|'webkit'|'firefox'|'firefox-stable'|'ffmpeg'|'webkit-technology-preview';
-export const allBrowserNames: Set<BrowserName> = new Set(['chromium', 'webkit', 'firefox', 'ffmpeg', 'webkit-technology-preview', 'firefox-stable']);
+export type BrowserName = 'chromium'|'webkit'|'firefox'|'firefox-beta'|'ffmpeg'|'webkit-technology-preview';
+export const allBrowserNames: Set<BrowserName> = new Set(['chromium', 'webkit', 'firefox', 'ffmpeg', 'webkit-technology-preview', 'firefox-beta']);
 
 const PACKAGE_PATH = path.join(__dirname, '..', '..');
 
@@ -58,7 +58,7 @@ const EXECUTABLE_PATHS = {
     'win32': ['firefox', 'firefox.exe'],
     'win64': ['firefox', 'firefox.exe'],
   },
-  'firefox-stable': {
+  'firefox-beta': {
     'ubuntu18.04': ['firefox', 'firefox'],
     'ubuntu20.04': ['firefox', 'firefox'],
     'mac10.13': ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox'],
@@ -127,16 +127,16 @@ const DOWNLOAD_URLS = {
     'win32': '%s/builds/firefox/%s/firefox-win32.zip',
     'win64': '%s/builds/firefox/%s/firefox-win64.zip',
   },
-  'firefox-stable': {
-    'ubuntu18.04': '%s/builds/firefox-stable/%s/firefox-stable-ubuntu-18.04.zip',
-    'ubuntu20.04': '%s/builds/firefox-stable/%s/firefox-stable-ubuntu-20.04.zip',
-    'mac10.13': '%s/builds/firefox-stable/%s/firefox-stable-mac-10.14.zip',
-    'mac10.14': '%s/builds/firefox-stable/%s/firefox-stable-mac-10.14.zip',
-    'mac10.15': '%s/builds/firefox-stable/%s/firefox-stable-mac-10.14.zip',
-    'mac11': '%s/builds/firefox-stable/%s/firefox-stable-mac-10.14.zip',
-    'mac11-arm64': '%s/builds/firefox-stable/%s/firefox-stable-mac-11.0-arm64.zip',
-    'win32': '%s/builds/firefox-stable/%s/firefox-stable-win32.zip',
-    'win64': '%s/builds/firefox-stable/%s/firefox-stable-win64.zip',
+  'firefox-beta': {
+    'ubuntu18.04': '%s/builds/firefox-beta/%s/firefox-beta-ubuntu-18.04.zip',
+    'ubuntu20.04': '%s/builds/firefox-beta/%s/firefox-beta-ubuntu-20.04.zip',
+    'mac10.13': '%s/builds/firefox-beta/%s/firefox-beta-mac-10.14.zip',
+    'mac10.14': '%s/builds/firefox-beta/%s/firefox-beta-mac-10.14.zip',
+    'mac10.15': '%s/builds/firefox-beta/%s/firefox-beta-mac-10.14.zip',
+    'mac11': '%s/builds/firefox-beta/%s/firefox-beta-mac-10.14.zip',
+    'mac11-arm64': '%s/builds/firefox-beta/%s/firefox-beta-mac-11.0-arm64.zip',
+    'win32': '%s/builds/firefox-beta/%s/firefox-beta-win32.zip',
+    'win64': '%s/builds/firefox-beta/%s/firefox-beta-win64.zip',
   },
   'webkit': {
     'ubuntu18.04': '%s/builds/webkit/%s/webkit-ubuntu-18.04.zip',
@@ -306,7 +306,7 @@ export class Registry {
           path.join(browserDirectory, 'minibrowser-wpe', 'lib'),
         ];
       case 'firefox':
-      case 'firefox-stable':
+      case 'firefox-beta':
         return [path.join(browserDirectory, 'firefox')];
       default:
         return [];
@@ -336,7 +336,7 @@ export class Registry {
     const envDownloadHost: { [key: string]: string } = {
       'chromium': 'PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST',
       'firefox': 'PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST',
-      'firefox-stable': 'PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST',
+      'firefox-beta': 'PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST',
       'webkit': 'PLAYWRIGHT_WEBKIT_DOWNLOAD_HOST',
       'webkit-technology-preview': 'PLAYWRIGHT_WEBKIT_DOWNLOAD_HOST',
       'ffmpeg': 'PLAYWRIGHT_FFMPEG_DOWNLOAD_HOST',

--- a/utils/roll_browser.js
+++ b/utils/roll_browser.js
@@ -30,7 +30,7 @@ function usage() {
 usage: ${SCRIPT_NAME} <browser> <revision>
 
 Roll the <browser> to a specific <revision> and generate new protocol.
-Supported browsers: chromium, firefox, webkit, ffmpeg, firefox-stable, webkit-technology-preview.
+Supported browsers: chromium, firefox, webkit, ffmpeg, firefox-beta, webkit-technology-preview.
 
 Example:
   ${SCRIPT_NAME} chromium 123456


### PR DESCRIPTION
This patch:
- rolls Firefox to v1269 which is now a firefox-stable build.
- introduces a new channel, `firefox-beta`, for our internal needs.

Fixes #6817