### PR TITLE
feat(pwt): webServer config option

### DIFF
--- a/docs/src/test-advanced.md
+++ b/docs/src/test-advanced.md
@@ -41,6 +41,7 @@ These options would be typically different between local development and CI oper
 - `quiet: boolean` - Whether to suppress stdout and stderr from the tests.
 - `shard: { total: number, current: number } | null` - [Shard](./test-parallel.md#shards) information.
 - `updateSnapshots: boolean` - Whether to update expected snapshots with the actual results produced by the test run.
+- `webServer: { command: string, port: number, timeout?: number }` - Launch a web server before the tests start.
 - `workers: number` - The maximum number of concurrent worker processes to use for parallelizing tests.
 
 Note that each [test project](#projects) can provide its own test suite options, for example two projects can run different tests by providing different `testDir`s. However, test run options are shared between all projects.

--- a/docs/src/test-configuration.md
+++ b/docs/src/test-configuration.md
@@ -153,6 +153,7 @@ In addition to configuring [Browser] or [BrowserContext], videos or screenshots,
 - `testIgnore`: Glob patterns or regular expressions that should be ignored when looking for the test files. For example, `'**/test-assets'`.
 - `testMatch`: Glob patterns or regular expressions that match test files. For example, `'**/todo-tests/*.spec.ts'`. By default, Playwright Test runs `.*(test|spec)\.(js|ts|mjs)` files.
 - `timeout`: Time in milliseconds given to each test.
+- `webServer`: Launch a web server before the tests start
 - `workers`: The maximum number of concurrent worker processes to use for parallelizing tests.
 
 You can specify these options in the configuration file.

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -46,6 +46,12 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
     await browser.close();
   }, { scope: 'worker' } ],
 
+  baseURL: [async ({ }, use) => {
+    if (!process.env.PW_BASE_URL)
+      throw new Error('A web server must be specified to use baseURL. See `webServer` in the config options, or set the PW_BASE_URL environment variable.');
+    await use(process.env.PW_BASE_URL);
+  }, {scope: 'worker'}],
+
   screenshot: 'off',
   video: 'off',
   trace: 'off',

--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -97,6 +97,7 @@ export class Loader {
     this._fullConfig.shard = takeFirst(this._configOverrides.shard, this._config.shard, baseFullConfig.shard);
     this._fullConfig.updateSnapshots = takeFirst(this._configOverrides.updateSnapshots, this._config.updateSnapshots, baseFullConfig.updateSnapshots);
     this._fullConfig.workers = takeFirst(this._configOverrides.workers, this._config.workers, baseFullConfig.workers);
+    this._fullConfig.webServer = takeFirst(this._configOverrides.webServer, this._config.webServer, baseFullConfig.webServer);
 
     for (const project of projects)
       this._addProject(project, this._fullConfig.rootDir);
@@ -394,4 +395,5 @@ const baseFullConfig: FullConfig = {
   shard: null,
   updateSnapshots: 'missing',
   workers: 1,
+  webServer: null,
 };

--- a/src/test/server.ts
+++ b/src/test/server.ts
@@ -1,0 +1,37 @@
+import { exec } from 'child_process';
+import net from 'net';
+import { monotonicTime, raceAgainstDeadline } from './util';
+import { WebServerConfig } from '../../types/test';
+export async function launchWebServer(config: WebServerConfig) {
+    const {command, port, timeout = 10000} = config;
+    const webServer = exec(command);
+    const cancellationToken = {canceled: false};
+    const {timedOut} = await raceAgainstDeadline(waitForSocket(port, 100, cancellationToken), timeout + monotonicTime());
+    cancellationToken.canceled = true;
+    if (timedOut) {
+        webServer.kill();
+        throw new Error(`failed to start web server on port ${port} via "${command}"`);
+    }
+    process.env.PW_BASE_URL = `http://localhost:${port}`;
+    return webServer;
+}
+async function waitForSocket(port: number, delay: number, cancellationToken: {canceled: boolean}) {    
+    while (!cancellationToken.canceled) {
+        const connected = await new Promise((resolve) => {
+        const conn = net
+            .connect(port)
+            .on('error', () => {
+            resolve(false);
+            })
+            .on('connect', () => {
+            conn.end();
+            resolve(true);
+            });
+        });
+        if (connected)
+            return;
+        await new Promise(x => setTimeout(x, delay));
+    }
+
+  }
+  

--- a/tests/playwright-test/assets/simple-server.js
+++ b/tests/playwright-test/assets/simple-server.js
@@ -1,0 +1,10 @@
+const {TestServer} = require('../../../utils/testserver/');
+// delay creating the server to test waiting for it
+setTimeout(() => {
+    TestServer.create(__dirname, process.argv[2] || 3000).then(server => {
+        console.log('listening on port', server.PORT);
+        server.setRoute('/hello', (message, response) => {
+            response.end('hello');
+        });
+    });
+}, 750);

--- a/tests/playwright-test/server.spec.ts
+++ b/tests/playwright-test/server.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './playwright-test-fixtures';
+import path from 'path';
+
+test('should create a server', async ({ runInlineTest }, { workerIndex }) => {
+  const port = workerIndex + 10500;
+  const result = await runInlineTest({
+    'test.spec.ts': `
+      const { test } = pwt;
+      test('connect to the server', async ({baseURL, page}) => {
+        expect(baseURL).toBe('http://localhost:${port}');
+        await page.goto(baseURL + '/hello');
+        expect(await page.textContent('body')).toBe('hello');
+      });
+    `,
+    'playwright.config.ts': `
+      module.exports = {
+        webServer: {
+          command: 'node ${path.join(__dirname, 'assets', 'simple-server.js')} ${port}',
+          port: ${port},
+        }
+      };
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
+
+test('should time out waiting for a server', async ({ runInlineTest }, { workerIndex }) => {
+  const port = workerIndex + 10500;
+  const result = await runInlineTest({
+    'test.spec.ts': `
+      const { test } = pwt;
+      test('connect to the server', async ({baseURL, page}) => {
+        expect(baseURL).toBe('http://localhost:${port}');
+        await page.goto(baseURL + '/hello');
+        expect(await page.textContent('body')).toBe('hello');
+      });
+    `,
+    'playwright.config.ts': `
+      module.exports = {
+        webServer: {
+          command: 'node ${path.join(__dirname, 'assets', 'simple-server.js')} ${port}',
+          port: ${port},
+          timeout: 100,
+        }
+      };
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`failed to start web server on port ${port} via "node`);
+});

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -104,6 +104,21 @@ export interface Project<TestArgs = {}, WorkerArgs = {}> extends ProjectBase {
 }
 export type FullProject<TestArgs = {}, WorkerArgs = {}> = Required<Project<TestArgs, WorkerArgs>>;
 
+export type WebServerConfig = {
+  /**
+   * Shell command to start the webserver. For example `npm run start`
+   */
+  command: string,
+  /**
+   * The port that your server is expected to appear on.
+   */
+  port: number,
+  /**
+   * How long to wait for the server to start up in milliseconds. Defaults to 10000.
+   */
+  timeout?: number,
+};
+
 /**
  * Testing configuration.
  */
@@ -180,6 +195,11 @@ interface ConfigBase {
   updateSnapshots?: UpdateSnapshots;
 
   /**
+   * Launch a web server before the tests start.
+   */
+   webServer?: WebServerConfig;
+
+  /**
    * The maximum number of concurrent worker processes to use for parallelizing tests.
    */
   workers?: number;
@@ -210,6 +230,7 @@ export interface FullConfig {
   shard: Shard;
   updateSnapshots: UpdateSnapshots;
   workers: number;
+  webServer: WebServerConfig | null;
 }
 
 export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped';
@@ -1114,6 +1135,11 @@ export type PlaywrightWorkerArgs = {
    * Browser instance, shared between multiple tests.
    */
   browser: Browser;
+
+  /**
+   * URL of the web server. For example, http://localhost:1234
+   */
+  baseURL: String;
 };
 
 /**


### PR DESCRIPTION
Adds a new fixture `baseURL` that can be used in tests. `baseURL` is either set by the `PW_BASE_URL` environment variable
or by a `webServer` config option. `webServer` accepts a shell command to run and a port on which to wait for a server to appear.

