### PR TITLE
test: update evaluate-no-stall test to get a proper error

### DIFF
--- a/tests/page/page-evaluate-no-stall.spec.ts
+++ b/tests/page/page-evaluate-no-stall.spec.ts
@@ -48,7 +48,9 @@ test.describe('non-stalling evaluate', () => {
     if (error === 4)
       return;
     // Testing this as a race.
-    const success = error.message === 'Frame does not yet have a main execution context' || error.message === 'Frame is currently attempting a navigation';
-    expect(success).toBeTruthy();
+    expect([
+      'Frame does not yet have a main execution context',
+      'Frame is currently attempting a navigation'
+    ]).toContain(error.message);
   });
 });


### PR DESCRIPTION
This test is flaky, and gives us "expected true, got false".
We should see the actual error message instead.