### PR TITLE
fix(chromium): fix a race when initialization does not finish before page close

### DIFF
--- a/src/server/chromium/crPage.ts
+++ b/src/server/chromium/crPage.ts
@@ -482,7 +482,7 @@ class FrameSession {
           // Ignore lifecycle events for the initial empty page. It is never the final page
           // hence we are going to get more lifecycle updates after the actual navigation has
           // started (even if the target url is about:blank).
-          lifecycleEventsEnabled.then(() => {
+          lifecycleEventsEnabled.catch(e => {}).then(() => {
             this._eventListeners.push(helper.addEventListener(this._client, 'Page.lifecycleEvent', event => this._onLifecycleEvent(event)));
           });
         } else {


### PR DESCRIPTION
This is exposed by the flaky "should report new window downloads" test. In this test a new page is created, initialized and closed before initialization finishes.

If `lifecycleEventsEnabled` fails with "Target closed error", we correctly ignore the initialization failure. However, a single usage of the failed promise with `.then` fails anyway.