### PR TITLE
fix(firefox): race between markAsError and Page.ready

### DIFF
--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -102,6 +102,8 @@ export class FFPage implements PageDelegate {
     });
     this._session.once('Page.ready', async () => {
       await this._page.initOpener(this._opener);
+      if (this._initializationFailed)
+        return;
       // Note: it is important to call |reportAsNew| before resolving pageOrError promise,
       // so that anyone who awaits pageOrError got a ready and reported page.
       this._initializedPage = this._page;


### PR DESCRIPTION
When new page turns into download, we can have `_markAsError` followed by the `Page.ready` signal and report the page twice (as an error and as a real page). This is flaky and depends on whether `Page.ready` is fast enough before the page closes or not.

Exposed by the "should report new window downloads" test.