### PR TITLE
docs: added extensions page

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -1,6 +1,6 @@
 ---
 id: extensions
-title: "Testing extensions (experimental)"
+title: "Testing extensions"
 ---
 
 :::note

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -1,0 +1,29 @@
+---
+id: extensions
+title: "Testing extensions (experimental)"
+---
+
+:::note
+Extensions only work in Chrome / Chromium in non-headless mode.
+:::
+
+The following is code for getting a handle to the [background page](https://developer.chrome.com/extensions/background_pages) of an extension whose source is located in `./my-extension`:
+
+```js
+const { chromium } = require('playwright');
+
+(async () => {
+  const pathToExtension = require('path').join(__dirname, 'my-extension');
+  const userDataDir = '/tmp/test-user-data-dir';
+  const browserContext = await chromium.launchPersistentContext(userDataDir,{
+    headless: false,
+    args: [
+      `--disable-extensions-except=${pathToExtension}`,
+      `--load-extension=${pathToExtension}`
+    ]
+  });
+  const backgroundPage = browserContext.backgroundPages()[0];
+  // Test the background page as you would any other page.
+  await browserContext.close();
+})();
+```


### PR DESCRIPTION
Fixes #5586

When we moved from `ChromiumBrowser` to Browser this [got deleted ](https://github.com/microsoft/playwright/blob/cac119f3bf1b6e86462fa3556760b585d91d0ffd/docs/src/api/class-chromiumbrowser.md#class-chromiumbrowser)and users keep asking for it. My idea would be to add it like that, since we also don't refer to the mobile page.

![image](https://user-images.githubusercontent.com/17984549/121497587-e318b480-c9db-11eb-8644-feb771ece90f.png)


