### PR TITLE
docs: change wording from C# to .NET

### DIFF
--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -34,13 +34,13 @@ The Playwright API is available in multiple languages.
 * [API](https://playwright.dev/java/docs/api/class-playwright)
 * [GitHub repo](https://github.com/microsoft/playwright-java)
 
-## C#
+## .NET
 
 [Playwright for .NET](https://playwright.dev/dotnet/docs/intro/) is available.
 
 * [Documentation](https://playwright.dev/dotnet/docs/intro/)
 * [API](https://playwright.dev/dotnet/docs/api/class-playwright)
-* [GitHub repo](https://github.com/microsoft/playwright-sharp)
+* [GitHub repo](https://github.com/microsoft/playwright-dotnet)
 * [Playwright on NuGet](https://www.nuget.org/packages/Microsoft.Playwright)
 
 ```

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -180,7 +180,7 @@ This version of Playwright was also tested against the following stable channels
 
 ## Version 1.7
 
-- **New Java SDK**: [Playwright for Java](https://github.com/microsoft/playwright-java) is now on par with [JavaScript](https://github.com/microsoft/playwright), [Python](https://github.com/microsoft/playwright-python) and [C# bindings](https://github.com/microsoft/playwright-sharp).
+- **New Java SDK**: [Playwright for Java](https://github.com/microsoft/playwright-java) is now on par with [JavaScript](https://github.com/microsoft/playwright), [Python](https://github.com/microsoft/playwright-python) and [.NET bindings](https://github.com/microsoft/playwright-dotnet).
 - **Browser storage API**: New convenience APIs to save and load browser storage state (cookies, local storage) to simplify automation scenarios with authentication.
 - **New CSS selectors**: We heard your feedback for more flexible selectors and have revamped the selectors implementation. Playwright 1.7 introduces [new CSS extensions](./selectors.md) and there's more coming soon.
 - **New website**: The docs website at [playwright.dev](https://playwright.dev/) has been updated and is now built with [Docusaurus](https://v2.docusaurus.io/).

--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -212,7 +212,7 @@ This version of Playwright was also tested against the following stable channels
 
 ## Version 1.7
 
-- **New Java SDK**: [Playwright for Java](https://github.com/microsoft/playwright-java) is now on par with [JavaScript](https://github.com/microsoft/playwright), [Python](https://github.com/microsoft/playwright-python) and [C# bindings](https://github.com/microsoft/playwright-sharp).
+- **New Java SDK**: [Playwright for Java](https://github.com/microsoft/playwright-java) is now on par with [JavaScript](https://github.com/microsoft/playwright), [Python](https://github.com/microsoft/playwright-python) and [.NET bindings](https://github.com/microsoft/playwright-dotnet).
 - **Browser storage API**: New convenience APIs to save and load browser storage state (cookies, local storage) to simplify automation scenarios with authentication.
 - **New CSS selectors**: We heard your feedback for more flexible selectors and have revamped the selectors implementation. Playwright 1.7 introduces [new CSS extensions](./selectors.md) and there's more coming soon.
 - **New website**: The docs website at [playwright.dev](https://playwright.dev/) has been updated and is now built with [Docusaurus](https://v2.docusaurus.io/).

--- a/docs/src/release-notes-python.md
+++ b/docs/src/release-notes-python.md
@@ -176,7 +176,7 @@ This version of Playwright was also tested against the following stable channels
 
 ## Version 1.7
 
-- **New Java SDK**: [Playwright for Java](https://github.com/microsoft/playwright-java) is now on par with [JavaScript](https://github.com/microsoft/playwright), [Python](https://github.com/microsoft/playwright-python) and [C# bindings](https://github.com/microsoft/playwright-sharp).
+- **New Java SDK**: [Playwright for Java](https://github.com/microsoft/playwright-java) is now on par with [JavaScript](https://github.com/microsoft/playwright), [Python](https://github.com/microsoft/playwright-python) and [.NET bindings](https://github.com/microsoft/playwright-dotnet).
 - **Browser storage API**: New convenience APIs to save and load browser storage state (cookies, local storage) to simplify automation scenarios with authentication.
 - **New CSS selectors**: We heard your feedback for more flexible selectors and have revamped the selectors implementation. Playwright 1.7 introduces [new CSS extensions](./selectors.md) and there's more coming soon.
 - **New website**: The docs website at [playwright.dev](https://playwright.dev/) has been updated and is now built with [Docusaurus](https://v2.docusaurus.io/).

--- a/docs/src/why-playwright.md
+++ b/docs/src/why-playwright.md
@@ -49,7 +49,7 @@ Playwright enables fast, reliable and capable automation across all modern brows
 
 * **Debugging tools**. Playwright works with the [editor debugger and browser developer tools](./debug.md) to pause execution and inspect the web page.
 
-* **Language bindings**. Playwright is available for [Node.js](https://github.com/microsoft/playwright) [Python](https://github.com/microsoft/playwright-python), [C#](https://github.com/microsoft/playwright-sharp) and
+* **Language bindings**. Playwright is available for [Node.js](https://github.com/microsoft/playwright) [Python](https://github.com/microsoft/playwright-python), [.NET](https://github.com/microsoft/playwright-dotnet) and
 [Java](https://github.com/microsoft/playwright-java). Learn more about [supported languages](./languages.md).
 
 * **Deploy tests to CI**. First-party [Docker image](./docker.md) and [GitHub Actions](https://github.com/microsoft/playwright-github-action) to deploy tests to [your preferred CI/CD provider](./ci.md).


### PR DESCRIPTION
Mainly the change the name on the languages section.

Drive-by adjust the other links.