### PR TITLE
feat(playwright-test): support `workerFixture` sugar

### DIFF
--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -183,4 +183,9 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
     await use(await context.newPage());
   },
 });
+
+export function workerFixture<T>(a: T) {
+    return [a, {scope: 'worker'}] as const;
+}
+
 export default test;

--- a/tests/playwright-test/fixtures.spec.ts
+++ b/tests/playwright-test/fixtures.spec.ts
@@ -210,7 +210,7 @@ test('should only run worker fixtures once', async ({ runInlineTest }) => {
     'a.test.js': `
       let counter = 0;
       const test = pwt.test.extend({
-        asdf: [ async ({}, test) => await test(counter++), { scope: 'worker' } ],
+        asdf: pwt.workerFixture(async ({}, test) => await test(counter++)),
       });
       test('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(0);

--- a/tests/playwright-test/types.spec.ts
+++ b/tests/playwright-test/types.spec.ts
@@ -30,10 +30,11 @@ test('sanity', async ({runTSC}) => {
 test('should check types of fixtures', async ({runTSC}) => {
   const result = await runTSC({
     'helper.ts': `
-      export type MyOptions = { foo: string, bar: number };
-      export const test = pwt.test.extend<{ foo: string }, { bar: number }>({
+      export type MyOptions = { foo: string, bar: number, foobar: string };
+      export const test = pwt.test.extend<{ foo: string }, { bar: number, foobar: string } >({
         foo: 'foo',
         bar: [ 42, { scope: 'worker' } ],
+        foobar: pwt.workerFixture('woof-woof'),
       });
 
       const good1 = test.extend<{}>({ foo: async ({ bar }, run) => run('foo') });
@@ -75,19 +76,21 @@ test('should check types of fixtures', async ({runTSC}) => {
     'playwright.config.ts': `
       import { MyOptions } from './helper';
       const configs1: pwt.Config[] = [];
-      configs1.push({ use: { foo: '42', bar: 42 } });
-      configs1.push({ use: { foo: '42', bar: 42 }, timeout: 100 });
+      configs1.push({ use: { foo: '42', bar: 42, foobar: 'woof-woof', } });
+      configs1.push({ use: { foo: '42', bar: 42, foobar: 'woof-woof', }, timeout: 100 });
 
       const configs2: pwt.Config<MyOptions>[] = [];
-      configs2.push({ use: { foo: '42', bar: 42 } });
+      configs2.push({ use: { foo: '42', bar: 42, foobar: 'woof-woof', } });
       // @ts-expect-error
-      pwt.runTests({ use: { foo: '42', bar: 42 } }, {});
+      pwt.runTests({ use: { foo: '42', bar: 42, foobar: 'woof-woof', } }, {});
       // @ts-expect-error
       configs2.push({ use: { bar: '42' } });
       // @ts-expect-error
       configs2.push(new Env2());
       // @ts-expect-error
       configs2.push({ use: { foo: 42, bar: 42 } });
+      // @ts-expect-error
+      configs2.push({ use: { foo: 42, bar: 42, foobar: 42 } });
       // @ts-expect-error
       configs2.push({ beforeAll: async () => { return {}; } });
       // TODO: next line should not compile.

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -1175,6 +1175,7 @@ export default test;
 
 export const _baseTest: TestType<{}, {}>;
 export const expect: Expect;
+export function workerFixture<T>(a: T): [T, { scope: 'worker' }];
 
 // This is required to not export everything by default. See https://github.com/Microsoft/TypeScript/issues/19545#issuecomment-340490459
 export {};


### PR DESCRIPTION
This sugar lets us quickly promote test fixtures to worker fixtures.

Usage:

```js
const pwt = require('@playwright/test');

const it = pwt.test.extend({
  server: pwt.workerFixture(async ({}, use) => {
    const server = await myServer.start();
    use(server);
    await server.stop();
  }),
});
```