### PR TITLE
browser(firefox): move to the hand-written JSON serializer

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1264
-Changed: lushnikov@chromium.org Tue 15 Jun 2021 03:35:19 PM PDT
+1265
+Changed: lushnikov@chromium.org Tue 16 Jun 2021 15:28:19 PM PDT

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1271
-Changed: max@schmitt.mx Thu Jun 10 14:39:06 UTC 2021
+1272
+Changed: lushnikov@chromium.org Wed Jun 16 14:27:06 PST 2021


### PR DESCRIPTION
The hand-written JSON serializer works in user context and doesn't
invoke `toJSON` methods.

References #7015