### PR TITLE
Revert "feat: add defaultTimeout browser context configuration option…

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -469,11 +469,6 @@ contexts override the proxy, global proxy will be never used and can be any stri
 `launch({ proxy: { server: 'http://per-context' } })`.
 :::
 
-## context-option-defaulttimeout
-- `defaultTimeout` <[float]>
-
-Set the default browser context timeout for the new context. Equivalent to calling [`method: BrowserContext.setDefaultTimeout`].
-
 ## select-options-values
 * langs: java, js, csharp
 - `values` <[null]|[string]|[ElementHandle]|[Array]<[string]>|[Object]|[Array]<[ElementHandle]>|[Array]<[Object]>>
@@ -599,7 +594,6 @@ using the [`method: AndroidDevice.setDefaultTimeout`] method.
 - %%-context-option-recordvideo-%%
 - %%-context-option-recordvideo-dir-%%
 - %%-context-option-recordvideo-size-%%
-- %%-context-option-defaulttimeout-%%
 
 ## browser-option-args
 - `args` <[Array]<[string]>>

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -339,7 +339,6 @@ export type BrowserTypeLaunchPersistentContextParams = {
     omitContent?: boolean,
     path: string,
   },
-  defaultTimeout?: number,
   userDataDir: string,
   slowMo?: number,
 };
@@ -410,7 +409,6 @@ export type BrowserTypeLaunchPersistentContextOptions = {
     omitContent?: boolean,
     path: string,
   },
-  defaultTimeout?: number,
   slowMo?: number,
 };
 export type BrowserTypeLaunchPersistentContextResult = {
@@ -501,7 +499,6 @@ export type BrowserNewContextParams = {
     omitContent?: boolean,
     path: string,
   },
-  defaultTimeout?: number,
   proxy?: {
     server: string,
     bypass?: string,
@@ -559,7 +556,6 @@ export type BrowserNewContextOptions = {
     omitContent?: boolean,
     path: string,
   },
-  defaultTimeout?: number,
   proxy?: {
     server: string,
     bypass?: string,

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -322,7 +322,6 @@ ContextOptions:
       properties:
         omitContent: boolean?
         path: string
-    defaultTimeout: number?
 
 
 Playwright:

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -248,7 +248,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
       omitContent: tOptional(tBoolean),
       path: tString,
     })),
-    defaultTimeout: tOptional(tNumber),
     userDataDir: tString,
     slowMo: tOptional(tNumber),
   });
@@ -308,7 +307,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
       omitContent: tOptional(tBoolean),
       path: tString,
     })),
-    defaultTimeout: tOptional(tNumber),
     proxy: tOptional(tObject({
       server: tString,
       bypass: tOptional(tString),

--- a/src/server/browserContext.ts
+++ b/src/server/browserContext.ts
@@ -76,9 +76,6 @@ export abstract class BrowserContext extends SdkObject {
     if (this._options.recordHar)
       this._harTracer = new HarTracer(this, this._options.recordHar);
     this.tracing = new Tracing(this);
-
-    if (typeof this._options.defaultTimeout === 'number' && !debugMode())
-      this._timeoutSettings.setDefaultTimeout(this._options.defaultTimeout);
   }
 
   _setSelectors(selectors: Selectors) {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -252,7 +252,6 @@ export type BrowserContextOptions = {
   },
   proxy?: ProxySettings,
   _debugName?: string,
-  defaultTimeout?: number,
 };
 
 export type EnvArray = { name: string, value: string }[];

--- a/tests/browsercontext-basic.spec.ts
+++ b/tests/browsercontext-basic.spec.ts
@@ -218,16 +218,6 @@ it('should be able to navigate after disabling javascript', async ({browser, ser
   await context.close();
 });
 
-it('should respect default timeout when configured', async ({browser, playwright}) => {
-  const context = await browser.newContext({ defaultTimeout: 5 });
-  const page = await context.newPage();
-  let error = null;
-  await page.waitForFunction('false').catch(e => error = e);
-  expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
-  expect(error.message).toContain('page.waitForFunction: Timeout 5ms exceeded');
-  await context.close();
-});
-
 it('should work with offline option', async ({browser, server}) => {
   const context = await browser.newContext({offline: true});
   const page = await context.newPage();

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6986,12 +6986,6 @@ export interface BrowserType<Unused = {}> {
     colorScheme?: "light"|"dark"|"no-preference";
 
     /**
-     * Set the default browser context timeout for the new context. Equivalent to calling
-     * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browsercontextsetdefaulttimeouttimeout).
-     */
-    defaultTimeout?: number;
-
-    /**
      * Specify device scale factor (can be thought of as dpr). Defaults to `1`.
      */
     deviceScaleFactor?: number;
@@ -8103,12 +8097,6 @@ export interface AndroidDevice {
     command?: string;
 
     /**
-     * Set the default browser context timeout for the new context. Equivalent to calling
-     * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browsercontextsetdefaulttimeouttimeout).
-     */
-    defaultTimeout?: number;
-
-    /**
      * Specify device scale factor (can be thought of as dpr). Defaults to `1`.
      */
     deviceScaleFactor?: number;
@@ -8861,12 +8849,6 @@ export interface Browser extends EventEmitter {
      * Defaults to `'light'`.
      */
     colorScheme?: "light"|"dark"|"no-preference";
-
-    /**
-     * Set the default browser context timeout for the new context. Equivalent to calling
-     * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browsercontextsetdefaulttimeouttimeout).
-     */
-    defaultTimeout?: number;
 
     /**
      * Specify device scale factor (can be thought of as dpr). Defaults to `1`.
@@ -10936,12 +10918,6 @@ export interface BrowserContextOptions {
    * Defaults to `'light'`.
    */
   colorScheme?: "light"|"dark"|"no-preference";
-
-  /**
-   * Set the default browser context timeout for the new context. Equivalent to calling
-   * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browsercontextsetdefaulttimeouttimeout).
-   */
-  defaultTimeout?: number;
 
   /**
    * Specify device scale factor (can be thought of as dpr). Defaults to `1`.


### PR DESCRIPTION
… (#6944)"

This reverts commit 617dfdef9e353cfe77129c69543aa25104df36d3.

It turns out this might conflict with our bright testrunner future.