### PR TITLE
cherry-pick(release-1.12): roll Firefox to r1271

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1269",
+      "revision": "1271",
       "installByDefault": true
     },
     {

--- a/src/server/firefox/protocol.ts
+++ b/src/server/firefox/protocol.ts
@@ -276,6 +276,11 @@ export module Protocol {
       reducedMotion: ("reduce"|"no-preference")|null;
     };
     export type setReducedMotionReturnValue = void;
+    export type setForcedColorsParameters = {
+      browserContextId?: string;
+      forcedColors: ("active"|"none")|null;
+    };
+    export type setForcedColorsReturnValue = void;
     export type setVideoRecordingOptionsParameters = {
       browserContextId?: string;
       dir: string;
@@ -486,6 +491,7 @@ export module Protocol {
       type?: ("screen"|"print"|"");
       colorScheme?: ("dark"|"light"|"no-preference");
       reducedMotion?: ("reduce"|"no-preference");
+      forcedColors?: ("active"|"none");
     };
     export type setEmulatedMediaReturnValue = void;
     export type setCacheDisabledParameters = {
@@ -1066,6 +1072,7 @@ export module Protocol {
     "Browser.setOnlineOverride": Browser.setOnlineOverrideParameters;
     "Browser.setColorScheme": Browser.setColorSchemeParameters;
     "Browser.setReducedMotion": Browser.setReducedMotionParameters;
+    "Browser.setForcedColors": Browser.setForcedColorsParameters;
     "Browser.setVideoRecordingOptions": Browser.setVideoRecordingOptionsParameters;
     "Page.close": Page.closeParameters;
     "Page.setFileInputFiles": Page.setFileInputFilesParameters;
@@ -1141,6 +1148,7 @@ export module Protocol {
     "Browser.setOnlineOverride": Browser.setOnlineOverrideReturnValue;
     "Browser.setColorScheme": Browser.setColorSchemeReturnValue;
     "Browser.setReducedMotion": Browser.setReducedMotionReturnValue;
+    "Browser.setForcedColors": Browser.setForcedColorsReturnValue;
     "Browser.setVideoRecordingOptions": Browser.setVideoRecordingOptionsReturnValue;
     "Page.close": Page.closeReturnValue;
     "Page.setFileInputFiles": Page.setFileInputFilesReturnValue;

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -556,6 +556,13 @@ it('should not use Array.prototype.toJSON when evaluating', async ({ page, brows
   expect(result).toEqual([1,2,3]);
 });
 
+it('should not add a toJSON property to newly created Arrays after evaluation', async ({ page, browserName, channel }) => {
+  it.fixme(browserName === 'firefox' && channel === 'firefox-beta')
+  await page.evaluate(() => []);
+  const hasToJSONProperty = await page.evaluate(() => "toJSON" in []);
+  expect(hasToJSONProperty).toEqual(false);
+});
+
 it('should not use toJSON in jsonValue', async ({ page }) => {
   const resultHandle = await page.evaluateHandle(() => ({ toJSON: () => 'string', data: 'data' }));
   expect(await resultHandle.jsonValue()).toEqual({ data: 'data', toJSON: {} });


### PR DESCRIPTION
Cherry-Pick #7067 SHA d6831df26fe19c8785893ffa8f5f8787790419a0

NOTE: this cherry-pick updates only firefox-stable build revision
and keeps the firefox-beta as-is since it's been rolled already.
Thus, the new test is explicitly skipped on firefox-beta.

Fixes #7015