### PR TITLE
Revert "fix(test-runner): support passing slowMo option (#6991)"

### DIFF
--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -28,10 +28,9 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
   playwright: [ require('../inprocess'), { scope: 'worker' } ],
   headless: [ undefined, { scope: 'worker' } ],
   channel: [ undefined, { scope: 'worker' } ],
-  slowMo: [ undefined, { scope: 'worker' } ],
   launchOptions: [ {}, { scope: 'worker' } ],
 
-  browser: [ async ({ playwright, browserName, headless, channel, slowMo, launchOptions }, use) => {
+  browser: [ async ({ playwright, browserName, headless, channel, launchOptions }, use) => {
     if (!['chromium', 'firefox', 'webkit'].includes(browserName))
       throw new Error(`Unexpected browserName "${browserName}", must be one of "chromium", "firefox" or "webkit"`);
     const options: LaunchOptions = {
@@ -42,8 +41,6 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
       options.headless = headless;
     if (channel !== undefined)
       options.channel = channel;
-    if (slowMo !== undefined)
-      options.slowMo = slowMo;
     const browser = await playwright[browserName].launch(options);
     await use(browser);
     await browser.close();
@@ -55,7 +52,6 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
   acceptDownloads: undefined,
   bypassCSP: undefined,
   colorScheme: undefined,
-  reducedMotion: undefined,
   deviceScaleFactor: undefined,
   extraHTTPHeaders: undefined,
   geolocation: undefined,
@@ -74,7 +70,7 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
   viewport: undefined,
   contextOptions: {},
 
-  context: async ({ browser, screenshot, trace, video, acceptDownloads, bypassCSP, colorScheme, reducedMotion, deviceScaleFactor, extraHTTPHeaders, hasTouch, geolocation, httpCredentials, ignoreHTTPSErrors, isMobile, javaScriptEnabled, locale, offline, permissions, proxy, storageState, viewport, timezoneId, userAgent, contextOptions }, use, testInfo) => {
+  context: async ({ browser, screenshot, trace, video, acceptDownloads, bypassCSP, colorScheme, deviceScaleFactor, extraHTTPHeaders, hasTouch, geolocation, httpCredentials, ignoreHTTPSErrors, isMobile, javaScriptEnabled, locale, offline, permissions, proxy, storageState, viewport, timezoneId, userAgent, contextOptions }, use, testInfo) => {
     testInfo.snapshotSuffix = process.platform;
     if (process.env.PWDEBUG)
       testInfo.setTimeout(0);
@@ -91,8 +87,6 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
       options.bypassCSP = bypassCSP;
     if (colorScheme !== undefined)
       options.colorScheme = colorScheme;
-    if (reducedMotion !== undefined)
-      options.reducedMotion = reducedMotion;
     if (deviceScaleFactor !== undefined)
       options.deviceScaleFactor = deviceScaleFactor;
     if (extraHTTPHeaders !== undefined)

--- a/tests/playwright-test/fixtures.spec.ts
+++ b/tests/playwright-test/fixtures.spec.ts
@@ -529,7 +529,7 @@ test('should create a new worker for worker fixtures', async ({ runInlineTest })
     'a.test.ts': `
       const { test } = pwt;
       test('base test', async ({}, testInfo) => {
-        expect(testInfo.workerIndex).toBe(1);
+        expect(testInfo.workerIndex).toBe(0);
       });
 
       const test2 = test.extend({
@@ -539,7 +539,7 @@ test('should create a new worker for worker fixtures', async ({ runInlineTest })
         }, { scope: 'worker' }],
       });
       test2('a test', async ({ foo }, testInfo) => {
-        expect(testInfo.workerIndex).toBe(0);
+        expect(testInfo.workerIndex).toBe(1);
       });
     `,
     'b.test.ts': `
@@ -551,7 +551,7 @@ test('should create a new worker for worker fixtures', async ({ runInlineTest })
         },
       });
       test2('b test', async ({ bar }, testInfo) => {
-        expect(testInfo.workerIndex).toBe(1);
+        expect(testInfo.workerIndex).toBe(0);
       });
     `,
   }, { workers: 1 });

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -883,13 +883,6 @@ type BrowserChannel = Exclude<LaunchOptions['channel'], undefined>;
 type ColorScheme = Exclude<BrowserContextOptions['colorScheme'], undefined>;
 
 /**
- * Emulates `'prefers-reduced-motion'` media feature,
- * supported values are `'reduce'`, `'no-preference'`.
- * @see BrowserContextOptions
- */
- type ReducedMotion = Exclude<BrowserContextOptions['reducedMotion'], undefined>;
-
-/**
  * An object containing additional HTTP headers to be sent with every request. All header values must be strings.
  * @see BrowserContextOptions
  */
@@ -938,13 +931,6 @@ export type PlaywrightWorkerOptions = {
    * @see LaunchOptions
    */
   channel: BrowserChannel | undefined;
-
-  /**
-   * Slows down Playwright operations by the specified amount of milliseconds.
-   * Useful so that you can see what is going on.
-   * @see LaunchOptions
-   */
-   slowMo: number | undefined;
 
   /**
    * Options used to launch the browser. Other options above (e.g. `headless`) take priority.
@@ -1010,12 +996,6 @@ export type PlaywrightTestOptions = {
    * @see BrowserContextOptions
    */
   colorScheme: ColorScheme | undefined;
-
-  /**
-   * Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`.
-   * @see BrowserContextOptions
-   */
-   reducedMotion: ReducedMotion | undefined;
 
   /**
    * Specify device scale factor (can be thought of as dpr). Defaults to `1`.


### PR DESCRIPTION
This reverts commit 178489d091a5ee756e2575c2dd9932cb26d012e4.

Reason for revert: this clashes with testrunner options.