### PR TITLE
docs(python): add missing closing parenthesis

### DIFF
--- a/docs/src/selectors.md
+++ b/docs/src/selectors.md
@@ -153,10 +153,10 @@ methods accept [`param: selector`] as their first argument.
   page.click(":nth-match(:text('Buy'), 3)");
   ```
   ```python async
-  await page.click(":nth-match(:text('Buy'), 3)"
+  await page.click(":nth-match(:text('Buy'), 3)")
   ```
   ```python sync
-  page.click(":nth-match(:text('Buy'), 3)"
+  page.click(":nth-match(:text('Buy'), 3)")
   ```
   ```csharp
   await page.ClickAsync(":nth-match(:text('Buy'), 3)");


### PR DESCRIPTION
- Fixes syntax error in python documentation for Pick n-th match from the query result example