### PR TITLE
fix(test-runner): do not require esModuleInterop=true

### DIFF
--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -73,6 +73,31 @@ test('should work with default expect matchers', async ({runTSC}) => {
   expect(result.exitCode).toBe(0);
 });
 
+test('should work with default expect matchers and esModuleInterop=false', async ({runTSC}) => {
+  const result = await runTSC({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test.expect(42).toBe(42);
+    `,
+    'tsconfig.json': JSON.stringify({
+      'compilerOptions': {
+        'target': 'ESNext',
+        'moduleResolution': 'node',
+        'module': 'commonjs',
+        'strict': true,
+        'rootDir': '.',
+        'esModuleInterop': false,
+        'allowSyntheticDefaultImports': false,
+        'lib': ['esnext', 'dom', 'DOM.Iterable']
+      },
+      'exclude': [
+        'node_modules'
+      ]
+    }),
+  });
+  expect(result.exitCode).toBe(0);
+});
+
 test('should work with custom PlaywrightTest namespace', async ({runTSC}) => {
   const result = await runTSC({
     'global.d.ts': `

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -229,7 +229,7 @@ export const test = base.extend<Fixtures>({
   runTSC: async ({}, use, testInfo) => {
     let tscResult: TSCResult | undefined;
     await use(async files => {
-      const baseDir = await writeFiles(testInfo, { ...files, 'tsconfig.json': JSON.stringify(TSCONFIG) });
+      const baseDir = await writeFiles(testInfo, { 'tsconfig.json': JSON.stringify(TSCONFIG), ...files });
       tscResult = await runTSC(baseDir);
       return tscResult;
     });

--- a/types/testExpect.d.ts
+++ b/types/testExpect.d.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type expect from 'expect';
+import type * as expect from 'expect';
 import type { ExpectedAssertionsErrors } from 'expect/build/types';
 
 export declare type AsymmetricMatcher = Record<string, any>;


### PR DESCRIPTION
They have a `export = foo` export [in place,](https://unpkg.com/browse/expect@27.0.2/build/index.d.ts) which would require `esModuleInterop` or `allowSyntheticDefaultImports`. This PR does workaround that, since its not a TypeScript default which confuses users.

Fixes #7099