### PR TITLE
docs: fix typo in Trace Viewer documentation

### DIFF
--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -141,7 +141,7 @@ That helps locating the action of interest very quickly.
 
 ## Snapshots
 
-When tracing with the [`option: snapshots`] option turned on, Playwright captures a set of complete DOM snapshots for each action. Depending on the typ of the action, it will capture:
+When tracing with the [`option: snapshots`] option turned on, Playwright captures a set of complete DOM snapshots for each action. Depending on the type of the action, it will capture:
 
 | Type | Description |
 |------|-------------|


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/187061/121893010-7824f180-cceb-11eb-9e85-b653db77da18.png)
