### PR TITLE
fix: specify the right apiName for artifact errors

### DIFF
--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -121,6 +121,7 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     this._channel.on('download', ({ url, suggestedFilename, artifact }) => {
       const artifactObject = Artifact.from(artifact);
       artifactObject._isRemote = !!this._browserContext._browser && !!this._browserContext._browser._remoteType;
+      artifactObject._apiName = 'download';
       this.emit(Events.Page.Download, new Download(this, url, suggestedFilename, artifactObject));
     });
     this._channel.on('fileChooser', ({ element, isMultiple }) => this.emit(Events.Page.FileChooser, new FileChooser(this, ElementHandle.from(element), isMultiple)));
@@ -131,6 +132,7 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     this._channel.on('route', ({ route, request }) => this._onRoute(Route.from(route), Request.from(request)));
     this._channel.on('video', ({ artifact }) => {
       const artifactObject = Artifact.from(artifact);
+      artifactObject._apiName = 'video';
       this._forceVideo()._artifactReady(artifactObject);
     });
     this._channel.on('webSocket', ({ webSocket }) => this.emit(Events.Page.WebSocket, WebSocket.from(webSocket)));

--- a/src/client/tracing.ts
+++ b/src/client/tracing.ts
@@ -38,6 +38,7 @@ export class Tracing implements api.Tracing {
       if (options.path) {
         const result = await channel.tracingExport();
         const artifact = Artifact.from(result.artifact);
+        artifact._apiName = 'tracing';
         if (this._context.browser()?._remoteType)
           artifact._isRemote = true;
         await artifact.saveAs(options.path);

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -383,7 +383,7 @@ it.describe('download event', () => {
     expect(saveError.message).toContain('File not found on disk. Check download.failure() for details.');
   });
 
-  it('should close the context without awaiting the download', async ({browser, server, browserName, platform, headless}, testInfo) => {
+  it('should close the context without awaiting the download', async ({browser, server, browserName, platform}, testInfo) => {
     it.skip(browserName === 'webkit' && platform === 'linux', 'WebKit on linux does not convert to the download immediately upon receiving headers');
 
     server.setRoute('/downloadStall', (req, res) => {
@@ -407,10 +407,12 @@ it.describe('download event', () => {
       page.context().close(),
     ]);
     expect(downloadPath).toBe(null);
-    if (browserName === 'chromium' && headless)
-      expect(saveError.message).toContain('.saveAs: canceled');
-    else
-      expect(saveError.message).toContain('File deleted upon browser context closure.');
+    // The exact error message is racy, because sometimes browser is fast enough
+    // to cancel the download.
+    expect([
+      'download.saveAs: canceled',
+      'download.saveAs: File deleted upon browser context closure.',
+    ]).toContain(saveError.message);
   });
 
   it('should throw if browser dies', async ({ server, browserType, browserName, browserOptions, platform}, testInfo) => {


### PR DESCRIPTION
This produces errors like `download.saveAs: <error>` instead of `.saveAs: <error>`.
Drive-by: fix the flaky test.