### PR TITLE
feat(test runner): configurable reportSlowTests

### DIFF
--- a/docs/src/test-advanced.md
+++ b/docs/src/test-advanced.md
@@ -37,8 +37,9 @@ These options would be typically different between local development and CI oper
   - `'never'` - do not preserve output for any tests;
   - `'failures-only'` - only preserve output for failed tests.
 - `projects: Project[]` - Multiple [projects](#projects) configuration.
-- `reporter: 'list' | 'line' | 'dot' | 'json' | 'junit'` - The reporter to use. See [reporters](./test-reporters.md) for details.
 - `quiet: boolean` - Whether to suppress stdout and stderr from the tests.
+- `reporter: 'list' | 'line' | 'dot' | 'json' | 'junit'` - The reporter to use. See [reporters](./test-reporters.md) for details.
+- `reportSlowTests: { max: number, threshold: number } | null` - Whether to report slow tests. When `null`, slow tests are not reported. Otherwise, tests that took more than `threshold` milliseconds are reported as slow, but no more than `max` number of them. Passing zero as `max` reports all slow tests that exceed the threshold.
 - `shard: { total: number, current: number } | null` - [Shard](./test-parallel.md#shards) information.
 - `updateSnapshots: boolean` - Whether to update expected snapshots with the actual results produced by the test run.
 - `workers: number` - The maximum number of concurrent worker processes to use for parallelizing tests.

--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -30,6 +30,7 @@ const jsConfig = 'playwright.config.js';
 const defaultConfig: Config = {
   preserveOutput: process.env.CI ? 'failures-only' : 'always',
   reporter: [ [defaultReporter] ],
+  reportSlowTests: { max: 5, threshold: 15000 },
   timeout: defaultTimeout,
   updateSnapshots: process.env.CI ? 'none' : 'missing',
   workers: Math.ceil(require('os').cpus().length / 2),

--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -99,6 +99,7 @@ export class Loader {
     this._fullConfig.maxFailures = takeFirst(this._configOverrides.maxFailures, this._config.maxFailures, baseFullConfig.maxFailures);
     this._fullConfig.preserveOutput = takeFirst<PreserveOutput>(this._configOverrides.preserveOutput, this._config.preserveOutput, baseFullConfig.preserveOutput);
     this._fullConfig.reporter = takeFirst(toReporters(this._configOverrides.reporter), toReporters(this._config.reporter), baseFullConfig.reporter);
+    this._fullConfig.reportSlowTests = takeFirst(this._configOverrides.reportSlowTests, this._config.reportSlowTests, baseFullConfig.reportSlowTests);
     this._fullConfig.quiet = takeFirst(this._configOverrides.quiet, this._config.quiet, baseFullConfig.quiet);
     this._fullConfig.shard = takeFirst(this._configOverrides.shard, this._config.shard, baseFullConfig.shard);
     this._fullConfig.updateSnapshots = takeFirst(this._configOverrides.updateSnapshots, this._config.updateSnapshots, baseFullConfig.updateSnapshots);
@@ -294,6 +295,15 @@ function validateConfig(config: Config) {
     }
   }
 
+  if ('reportSlowTests' in config && config.reportSlowTests !== undefined && config.reportSlowTests !== null) {
+    if (!config.reportSlowTests || typeof config.reportSlowTests !== 'object')
+      throw new Error(`config.reportSlowTests must be an object`);
+    if (!('max' in config.reportSlowTests) || typeof config.reportSlowTests.max !== 'number' || config.reportSlowTests.max < 0)
+      throw new Error(`config.reportSlowTests.max must be a non-negative number`);
+    if (!('threshold' in config.reportSlowTests) || typeof config.reportSlowTests.threshold !== 'number' || config.reportSlowTests.threshold < 0)
+      throw new Error(`config.reportSlowTests.threshold must be a non-negative number`);
+  }
+
   if ('shard' in config && config.shard !== undefined && config.shard !== null) {
     if (!config.shard || typeof config.shard !== 'object')
       throw new Error(`config.shard must be an object`);
@@ -395,6 +405,7 @@ const baseFullConfig: FullConfig = {
   preserveOutput: 'always',
   projects: [],
   reporter: [ ['list'] ],
+  reportSlowTests: null,
   rootDir: path.resolve(process.cwd()),
   quiet: false,
   shard: null,

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -29,6 +29,7 @@ export type ReporterDescription =
   [string] | [string, any];
 
 export type Shard = { total: number, current: number } | null;
+export type ReportSlowTests = { max: number, threshold: number } | null;
 export type PreserveOutput = 'always' | 'never' | 'failures-only';
 export type UpdateSnapshots = 'all' | 'none' | 'missing';
 
@@ -150,6 +151,11 @@ interface ConfigBase {
   preserveOutput?: PreserveOutput;
 
   /**
+   * Whether to suppress stdio output from the tests.
+   */
+   quiet?: boolean;
+
+  /**
    * Reporter to use. Available options:
    * - `'list'` - default reporter, prints a single line per test;
    * - `'dot'` - minimal reporter that prints a single character per test run, useful on CI;
@@ -164,9 +170,12 @@ interface ConfigBase {
   reporter?: 'dot' | 'line' | 'list' | 'junit' | 'json' | 'null' | ReporterDescription[];
 
   /**
-   * Whether to suppress stdio output from the tests.
+   * Whether to report slow tests. When `null`, slow tests are not reported.
+   * Otherwise, tests that took more than `threshold` milliseconds are reported as slow,
+   * but no more than `max` number of them. Passing zero as `max` reports all slow tests
+   * that exceed the threshold.
    */
-  quiet?: boolean;
+  reportSlowTests?: ReportSlowTests;
 
   /**
    * Shard tests and execute only the selected shard.
@@ -205,6 +214,7 @@ export interface FullConfig {
   preserveOutput: PreserveOutput;
   projects: FullProject[];
   reporter: ReporterDescription[];
+  reportSlowTests: ReportSlowTests;
   rootDir: string;
   quiet: boolean;
   shard: Shard;


### PR DESCRIPTION
Also splits tests by projects and reports them with nice relative paths.

Fixes #7117.