### PR TITLE
chore: add dummy playwright-test package for GitHub Dependents

### DIFF
--- a/.github/dummy-package-files-for-dependents-analytics/playwright-test/package.json
+++ b/.github/dummy-package-files-for-dependents-analytics/playwright-test/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "@playwright/test",
+    "version": "1.0.0",
+    "description": "A high-level API to automate web browsers",
+    "repository": "github:Microsoft/playwright",
+    "license": "Apache-2.0"
+}


### PR DESCRIPTION
This will list the users of `@playwright/test` in the Dependents graph: https://github.com/microsoft/playwright/network/dependents?package_id=UGFja2FnZS00MjQ2NjcwOQ%3D%3D

Similar to #4666