### PR TITLE
fix(test-runner): case insensitive test filtering

### DIFF
--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -137,7 +137,7 @@ function forceRegExp(pattern: string): RegExp {
   const match = pattern.match(/^\/(.*)\/([gi]*)$/);
   if (match)
     return new RegExp(match[1], match[2]);
-  return new RegExp(pattern, 'g');
+  return new RegExp(pattern, 'gi');
 }
 
 function overridesFromOptions(options: { [key: string]: any }): Config {

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -161,7 +161,9 @@ export function createMatcher(patterns: string | RegExp | (string | RegExp)[]): 
         return true;
     }
     for (const pattern of filePatterns) {
-      if (minimatch(value, pattern))
+      if (minimatch(value, pattern, {
+        nocase: true,
+      }))
         return true;
     }
     return false;

--- a/tests/playwright-test/test-ignore.spec.ts
+++ b/tests/playwright-test/test-ignore.spec.ts
@@ -211,6 +211,26 @@ test('should match regex string argument', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
 });
 
+test('should match case insensitive', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'capital/A.test.ts': `
+      const { test } = pwt;
+      test('pass', ({}) => {});
+    `,
+    'lowercase/a.test.ts': `
+      const { test } = pwt;
+      test('pass', ({}) => {});
+    `,
+    'b.test.ts': `
+      const { test } = pwt;
+      test('pass', ({}) => {});
+    `
+  }, { args: ['a.test.ts'] });
+  expect(result.passed).toBe(2);
+  expect(result.report.suites.map(s => s.file).sort()).toEqual(['capital/A.test.ts', 'lowercase/a.test.ts']);
+  expect(result.exitCode).toBe(0);
+});
+
 test('should match by directory', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'dir-a/file.test.ts': `


### PR DESCRIPTION
fixes #7039

This makes regular test filters case insensitive, while it leaves regex behavior unchanged.

I think this is fine, but we could also try to match the current file system case sensitivity.
