### PR TITLE
types: move exported objects from index.d.ts to overrides.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,11 +14,4 @@
  * limitations under the License.
  */
 
-import * as types from './types/types';
-
 export * from './types/types';
-export const webkit: types.BrowserType;
-export const chromium: types.BrowserType;
-export const firefox: types.BrowserType;
-export const _electron: types.Electron;
-export const _android: types.Android;

--- a/packages/common/index.d.ts
+++ b/packages/common/index.d.ts
@@ -14,11 +14,4 @@
  * limitations under the License.
  */
 
-import * as types from './types/types';
-
 export * from './types/types';
-export const chromium: types.BrowserType;
-export const firefox: types.BrowserType;
-export const webkit: types.BrowserType;
-export const _electron: types.Electron;
-export const _android: types.Android;

--- a/packages/playwright-test/index.d.ts
+++ b/packages/playwright-test/index.d.ts
@@ -14,12 +14,5 @@
  * limitations under the License.
  */
 
-import * as types from './types/types';
-
 export * from './types/types';
-export const chromium: types.BrowserType;
-export const firefox: types.BrowserType;
-export const webkit: types.BrowserType;
-export const _electron: types.Electron;
-export const _android: types.Android;
 export * from './types/test';

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -7846,6 +7846,12 @@ export type AndroidKey =
   'Copy' |
   'Paste';
 
+export const chromium: BrowserType;
+export const firefox: BrowserType;
+export const webkit: BrowserType;
+export const _electron: Electron;
+export const _android: Android;
+
 // This is required to not export everything by default. See https://github.com/Microsoft/TypeScript/issues/19545#issuecomment-340490459
 export {};
 

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -321,5 +321,11 @@ export type AndroidKey =
   'Copy' |
   'Paste';
 
+export const chromium: BrowserType;
+export const firefox: BrowserType;
+export const webkit: BrowserType;
+export const _electron: Electron;
+export const _android: Android;
+
 // This is required to not export everything by default. See https://github.com/Microsoft/TypeScript/issues/19545#issuecomment-340490459
 export {};


### PR DESCRIPTION
This way we generate these types right away, without duplicating them everywhere.