### PR TITLE
chore: create Selectors for each Playwright object

### DIFF
--- a/src/remote/playwrightServer.ts
+++ b/src/remote/playwrightServer.ts
@@ -21,7 +21,6 @@ import { DispatcherConnection, DispatcherScope } from '../dispatchers/dispatcher
 import { PlaywrightDispatcher } from '../dispatchers/playwrightDispatcher';
 import { createPlaywright } from '../server/playwright';
 import { gracefullyCloseAll } from '../server/processLauncher';
-import { serverSelectors } from '../server/selectors';
 
 const debugLog = debug('pw:server');
 
@@ -44,7 +43,6 @@ export class PlaywrightServer {
   static async startDefault({ acceptForwardedPorts }: PlaywrightServerOptions = {}): Promise<PlaywrightServer> {
     const cleanup = async () => {
       await gracefullyCloseAll().catch(e => {});
-      serverSelectors.unregisterAll();
     };
     const delegate: PlaywrightServerDelegate = {
       path: '/ws',
@@ -58,6 +56,7 @@ export class PlaywrightServer {
         return () => {
           cleanup();
           playwright._disablePortForwarding();
+          playwright.selectors.unregisterAll();
         };
       },
     };

--- a/src/server/browser.ts
+++ b/src/server/browser.ts
@@ -24,6 +24,7 @@ import { RecentLogsCollector } from '../utils/debugLogger';
 import * as registry from '../utils/registry';
 import { SdkObject } from './instrumentation';
 import { Artifact } from './artifact';
+import { Selectors } from './selectors';
 
 export interface BrowserProcess {
   onclose?: ((exitCode: number | null, signal: string | null) => void);
@@ -35,6 +36,7 @@ export interface BrowserProcess {
 export type PlaywrightOptions = {
   registry: registry.Registry,
   rootSdkObject: SdkObject,
+  selectors: Selectors,
   loopbackProxyOverride?: () => string,
 };
 

--- a/src/server/browserContext.ts
+++ b/src/server/browserContext.ts
@@ -25,7 +25,7 @@ import { helper } from './helper';
 import * as network from './network';
 import { Page, PageBinding, PageDelegate } from './page';
 import { Progress } from './progress';
-import { Selectors, serverSelectors } from './selectors';
+import { Selectors } from './selectors';
 import * as types from './types';
 import path from 'path';
 import { CallMetadata, internalCallMetadata, createInstrumentation, SdkObject } from './instrumentation';
@@ -83,7 +83,7 @@ export abstract class BrowserContext extends SdkObject {
   }
 
   selectors(): Selectors {
-    return this._selectors || serverSelectors;
+    return this._selectors || this._browser.options.selectors;
   }
 
   async _initialize() {

--- a/src/server/playwright.ts
+++ b/src/server/playwright.ts
@@ -21,7 +21,7 @@ import { PlaywrightOptions } from './browser';
 import { Chromium } from './chromium/chromium';
 import { Electron } from './electron/electron';
 import { Firefox } from './firefox/firefox';
-import { Selectors, serverSelectors } from './selectors';
+import { Selectors } from './selectors';
 import { WebKit } from './webkit/webkit';
 import { Registry } from '../utils/registry';
 import { CallMetadata, createInstrumentation, SdkObject } from './instrumentation';
@@ -50,13 +50,14 @@ export class Playwright extends SdkObject {
     this.options = {
       registry: new Registry(path.join(__dirname, '..', '..')),
       rootSdkObject: this,
+      selectors: new Selectors(),
     };
     this.chromium = new Chromium(this.options);
     this.firefox = new Firefox(this.options);
     this.webkit = new WebKit(this.options);
     this.electron = new Electron(this.options);
     this.android = new Android(new AdbBackend(), this.options);
-    this.selectors = serverSelectors;
+    this.selectors = this.options.selectors;
   }
 
   async _enablePortForwarding() {

--- a/src/server/selectors.ts
+++ b/src/server/selectors.ts
@@ -139,5 +139,3 @@ export class Selectors {
     };
   }
 }
-
-export const serverSelectors = new Selectors();


### PR DESCRIPTION
We currently have singleton `serverSelectors` that is shared between
the real Playwright and internal Playwrights.