### PR TITLE
chore: nuke 'webkit-technology-preview' experiment

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -30,11 +30,6 @@
       }
     },
     {
-      "name": "webkit-technology-preview",
-      "revision": "1443",
-      "installByDefault": false
-    },
-    {
       "name": "ffmpeg",
       "revision": "1005",
       "installByDefault": true

--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -27,8 +27,7 @@ build.
 ## WebKit
 
 Playwright's WebKit version matches the recent WebKit trunk build, before it is used in Apple Safari and
-other WebKit-based browsers. This gives a lot of lead time to react on the potential browser update issues. We are
-also working on a dedicated support for builds that would match Apple Safari Technology Preview.
+other WebKit-based browsers. This gives a lot of lead time to react on the potential browser update issues.
 
 ## Google Chrome & Microsoft Edge
 

--- a/src/server/validateDependencies.ts
+++ b/src/server/validateDependencies.ts
@@ -39,7 +39,6 @@ export async function validateHostRequirements(registry: registry.Registry, brow
 
 const DL_OPEN_LIBRARIES = {
   'webkit': ['libGLESv2.so.2', 'libx264.so'],
-  'webkit-technology-preview': ['libGLESv2.so.2', 'libx264.so'],
 };
 
 function isSupportedWindowsVersion(): boolean {

--- a/src/server/webkit/webkit.ts
+++ b/src/server/webkit/webkit.ts
@@ -31,18 +31,6 @@ export class WebKit extends BrowserType {
     super('webkit', playwrightOptions);
   }
 
-  executablePath(channel?: string): string {
-    if (channel) {
-      let executablePath = undefined;
-      if ((channel as any) === 'technology-preview')
-        executablePath = this._registry.executablePath('webkit-technology-preview');
-      assert(executablePath, `unsupported webkit channel "${channel}"`);
-      assert(fs.existsSync(executablePath), `webkit channel "${channel}" is not installed. Try running 'npx playwright install webkit-technology-preview'`);
-      return executablePath;
-    }
-    return super.executablePath(channel);
-  }
-
   _connectToTransport(transport: ConnectionTransport, options: BrowserOptions): Promise<WKBrowser> {
     return WKBrowser.connect(transport, options);
   }

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -22,8 +22,8 @@ import * as util from 'util';
 import { getUbuntuVersionSync } from './ubuntuVersion';
 import { assert, getFromENV } from './utils';
 
-export type BrowserName = 'chromium'|'chromium-with-symbols'|'webkit'|'firefox'|'firefox-beta'|'ffmpeg'|'webkit-technology-preview';
-export const allBrowserNames: Set<BrowserName> = new Set(['chromium', 'chromium-with-symbols', 'webkit', 'firefox', 'ffmpeg', 'webkit-technology-preview', 'firefox-beta']);
+export type BrowserName = 'chromium'|'chromium-with-symbols'|'webkit'|'firefox'|'firefox-beta'|'ffmpeg';
+export const allBrowserNames: Set<BrowserName> = new Set(['chromium', 'chromium-with-symbols', 'webkit', 'firefox', 'ffmpeg', 'firefox-beta']);
 
 const PACKAGE_PATH = path.join(__dirname, '..', '..');
 
@@ -81,17 +81,6 @@ const EXECUTABLE_PATHS = {
     'win64': ['firefox', 'firefox.exe'],
   },
   'webkit': {
-    'ubuntu18.04': ['pw_run.sh'],
-    'ubuntu20.04': ['pw_run.sh'],
-    'mac10.13': undefined,
-    'mac10.14': ['pw_run.sh'],
-    'mac10.15': ['pw_run.sh'],
-    'mac11': ['pw_run.sh'],
-    'mac11-arm64': ['pw_run.sh'],
-    'win32': ['Playwright.exe'],
-    'win64': ['Playwright.exe'],
-  },
-  'webkit-technology-preview': {
     'ubuntu18.04': ['pw_run.sh'],
     'ubuntu20.04': ['pw_run.sh'],
     'mac10.13': undefined,
@@ -165,17 +154,6 @@ const DOWNLOAD_URLS = {
     'ubuntu20.04': '%s/builds/webkit/%s/webkit-ubuntu-20.04.zip',
     'mac10.13': undefined,
     'mac10.14': '%s/builds/deprecated-webkit-mac-10.14/%s/deprecated-webkit-mac-10.14.zip',
-    'mac10.15': '%s/builds/webkit/%s/webkit-mac-10.15.zip',
-    'mac11': '%s/builds/webkit/%s/webkit-mac-10.15.zip',
-    'mac11-arm64': '%s/builds/webkit/%s/webkit-mac-11.0-arm64.zip',
-    'win32': '%s/builds/webkit/%s/webkit-win64.zip',
-    'win64': '%s/builds/webkit/%s/webkit-win64.zip',
-  },
-  'webkit-technology-preview': {
-    'ubuntu18.04': '%s/builds/webkit/%s/webkit-ubuntu-18.04.zip',
-    'ubuntu20.04': '%s/builds/webkit/%s/webkit-ubuntu-20.04.zip',
-    'mac10.13': undefined,
-    'mac10.14': undefined,
     'mac10.15': '%s/builds/webkit/%s/webkit-mac-10.15.zip',
     'mac11': '%s/builds/webkit/%s/webkit-mac-10.15.zip',
     'mac11-arm64': '%s/builds/webkit/%s/webkit-mac-11.0-arm64.zip',
@@ -326,7 +304,6 @@ export class Registry {
       case 'chromium-with-symbols':
         return [path.join(browserDirectory, 'chrome-linux')];
       case 'webkit':
-      case 'webkit-technology-preview':
         return [
           path.join(browserDirectory, 'minibrowser-gtk'),
           path.join(browserDirectory, 'minibrowser-gtk', 'bin'),
@@ -349,7 +326,7 @@ export class Registry {
       return [path.join(browserDirectory, 'chrome-win')];
     if (browserName === 'firefox' || browserName === 'firefox-beta')
       return [path.join(browserDirectory, 'firefox')];
-    if (browserName === 'webkit' || browserName === 'webkit-technology-preview')
+    if (browserName === 'webkit')
       return [browserDirectory];
     return [];
   }
@@ -369,7 +346,6 @@ export class Registry {
       'firefox': 'PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST',
       'firefox-beta': 'PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST',
       'webkit': 'PLAYWRIGHT_WEBKIT_DOWNLOAD_HOST',
-      'webkit-technology-preview': 'PLAYWRIGHT_WEBKIT_DOWNLOAD_HOST',
       'ffmpeg': 'PLAYWRIGHT_FFMPEG_DOWNLOAD_HOST',
     };
     const downloadHost = getFromENV(envDownloadHost[browserName]) ||

--- a/utils/roll_browser.js
+++ b/utils/roll_browser.js
@@ -30,7 +30,7 @@ function usage() {
 usage: ${SCRIPT_NAME} <browser> <revision>
 
 Roll the <browser> to a specific <revision> and generate new protocol.
-Supported browsers: chromium, firefox, webkit, ffmpeg, firefox-beta, webkit-technology-preview.
+Supported browsers: chromium, firefox, webkit, ffmpeg, firefox-beta.
 
 Example:
   ${SCRIPT_NAME} chromium 123456


### PR DESCRIPTION
It proved to be unmaintainable due to the following reasons:
- determining upstream branch for the technology preview was a manual
and tedious process
- once determined, actual Safari Technology Preview occasionally
diverted from the branch