### PR TITLE
feat(cli codegen): added authentication proxy function

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -296,6 +296,8 @@ type Options = {
   lang?: string;
   loadStorage?: string;
   proxyServer?: string;
+  proxyUsername?: string;
+  proxyPassword?: string;
   saveStorage?: string;
   timeout: string;
   timezone?: string;
@@ -341,7 +343,9 @@ async function launchContext(options: Options, headless: boolean, executablePath
 
   if (options.proxyServer) {
     launchOptions.proxy = {
-      server: options.proxyServer
+      server: options.proxyServer,
+      username: options.proxyUsername,
+      password: options.proxyPassword
     };
   }
 
@@ -570,6 +574,8 @@ function commandWithOpenOptions(command: string, description: string, options: a
       .option('--load-storage <filename>', 'load context storage state from the file, previously saved with --save-storage')
       .option('--lang <language>', 'specify language / locale, for example "en-GB"')
       .option('--proxy-server <proxy>', 'specify proxy server, for example "http://myproxy:3128" or "socks5://myproxy:8080"')
+      .option('--proxy-username <proxy>', 'proxy user information')
+      .option('--proxy-password <proxy>', 'proxy password information')
       .option('--save-storage <filename>', 'save context storage state at the end, for later use with --load-storage')
       .option('--timezone <time zone>', 'time zone to emulate, for example "Europe/Rome"')
       .option('--timeout <timeout>', 'timeout for Playwright actions in milliseconds', '10000')

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -344,8 +344,8 @@ async function launchContext(options: Options, headless: boolean, executablePath
   if (options.proxyServer) {
     launchOptions.proxy = {
       server: options.proxyServer,
-      username: options.proxyUsername,
-      password: options.proxyPassword
+      ...(options.proxyUsername && {username: options.proxyUsername}),
+      ...(options.proxyPassword && {password: options.proxyPassword}),
     };
   }
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -343,8 +343,8 @@ async function launchContext(options: Options, headless: boolean, executablePath
     const proxyUrl = new URL(options.proxyServer);
     launchOptions.proxy = {
       server: proxyUrl.origin,
-      username: proxyUrl.username,
-      password: proxyUrl.password
+      ...(proxyUrl.username && {username: proxyUrl.username}),
+      ...(proxyUrl.password && {password: proxyUrl.password})
     };
   }
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -296,8 +296,6 @@ type Options = {
   lang?: string;
   loadStorage?: string;
   proxyServer?: string;
-  proxyUsername?: string;
-  proxyPassword?: string;
   saveStorage?: string;
   timeout: string;
   timezone?: string;
@@ -342,10 +340,11 @@ async function launchContext(options: Options, headless: boolean, executablePath
   // Proxy
 
   if (options.proxyServer) {
+    const proxyUrl = new URL(options.proxyServer);
     launchOptions.proxy = {
-      server: options.proxyServer,
-      ...(options.proxyUsername && {username: options.proxyUsername}),
-      ...(options.proxyPassword && {password: options.proxyPassword}),
+      server: proxyUrl.origin,
+      username: proxyUrl.username,
+      password: proxyUrl.password
     };
   }
 
@@ -574,8 +573,6 @@ function commandWithOpenOptions(command: string, description: string, options: a
       .option('--load-storage <filename>', 'load context storage state from the file, previously saved with --save-storage')
       .option('--lang <language>', 'specify language / locale, for example "en-GB"')
       .option('--proxy-server <proxy>', 'specify proxy server, for example "http://myproxy:3128" or "socks5://myproxy:8080"')
-      .option('--proxy-username <proxy>', 'proxy user information')
-      .option('--proxy-password <proxy>', 'proxy password information')
       .option('--save-storage <filename>', 'save context storage state at the end, for later use with --load-storage')
       .option('--timezone <time zone>', 'time zone to emulate, for example "Europe/Rome"')
       .option('--timeout <timeout>', 'timeout for Playwright actions in milliseconds', '10000')


### PR DESCRIPTION
The current `codegen` specification has failed to break through proxies that require authentication.
Therefore, by adding the `--proxy-username` and `--proxy-password` options, codegen can be used even for proxies that require authentication.

example:
```bash
npx playwright codegen --proxy-server "https://proxy.xxx.yyy.zz:8080" --proxy-username "xxxxx" --proxy-password "yyyyy"
```