### PR TITLE
chore: rebase documentation and markdown classes from docs

### DIFF
--- a/utils/doclint/documentation.js
+++ b/utils/doclint/documentation.js
@@ -304,6 +304,11 @@ Documentation.Member = class {
     };
     this.async = false;
     this.alias = name;
+    /** 
+     * Param is true and option false
+     * @type {Boolean}
+     */
+    this.paramOrOption = null;
   }
 
   index() {
@@ -314,7 +319,8 @@ Documentation.Member = class {
       this.args.set(arg.name, arg);
       arg.enclosingMethod = this;
       if (arg.name === 'options') {
-        arg.type.properties.forEach(p => p.enclosingMethod = this );
+        arg.type.properties.sort((p1, p2) => p1.name.localeCompare(p2.name));
+        arg.type.properties.forEach(p => p.enclosingMethod = this);
       }
     }
   }
@@ -344,6 +350,7 @@ Documentation.Member = class {
   clone() {
     const result = new Documentation.Member(this.kind, this.langs, this.name, this.type, this.argsArray, this.spec, this.required);
     result.async = this.async;
+    result.paramOrOption = this.paramOrOption;
     return result;
   }
 

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -227,7 +227,7 @@ function render(nodes, maxColumns) {
  */
 function innerRenderMdNode(indent, node, lastNode, result, maxColumns) {
   const newLine = () => {
-    if (result.length && result[result.length - 1] !== '')
+    if (result[result.length - 1] !== '')
       result.push('');
   };
 
@@ -370,12 +370,13 @@ function visit(node, visitor, depth = 0) {
 
 /**
  * @param {MarkdownNode[]} nodes
+ * @param {boolean=} h3
  * @returns {string}
  */
-function generateToc(nodes) {
+function generateToc(nodes, h3) {
   const result = [];
   visitAll(nodes, (node, depth) => {
-    if (node.type === 'h1' || node.type === 'h2') {
+    if (node.type === 'h1' || node.type === 'h2' || (h3 && node.type === 'h3')) {
       let link = node.text.toLowerCase();
       link = link.replace(/[ ]+/g, '-');
       link = link.replace(/[^\w-_]/g, '');


### PR DESCRIPTION
Before we had a copy for markdown/documentation.js classes in our docs. They keep changing on both sides and its hard to maintain and rebase manually. With this change I updated/merged it with the classes from playwright.dev and added on the docs site a script which will sync the classes on each roll. See here: https://github.com/microsoft/playwright.dev/pull/249


This might break Java since I reverted: https://github.com/microsoft/playwright/pull/5629/files#diff-a98c2c034c3d7cc33f659fb7c6d1615f4b6377d9d3cb5a1a0a9443e8b24b8d32L230

