### PR TITLE
devops: cleanup browser build configs

### DIFF
--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -300,11 +300,6 @@ elif [[ "$BUILD_FLAVOR" == "webkit-mac-10.15" ]]; then
   EXPECTED_HOST_OS="Darwin"
   EXPECTED_HOST_OS_VERSION="10.15"
   BUILD_BLOB_NAME="webkit-mac-10.15.zip"
-elif [[ "$BUILD_FLAVOR" == "webkit-mac-11.0" ]]; then
-  BROWSER_NAME="webkit"
-  EXPECTED_HOST_OS="Darwin"
-  EXPECTED_HOST_OS_VERSION="11.0"
-  BUILD_BLOB_NAME="webkit-mac-11.0.zip"
 elif [[ "$BUILD_FLAVOR" == "webkit-mac-11.0-arm64" ]]; then
   BROWSER_NAME="webkit"
   EXPECTED_HOST_OS="Darwin"

--- a/browser_patches/firefox-beta/EXPECTED_BUILDS
+++ b/browser_patches/firefox-beta/EXPECTED_BUILDS
@@ -1,4 +1,5 @@
 firefox-beta-mac-10.14.zip
+firefox-beta-mac-11.0-arm64.zip
 firefox-beta-ubuntu-18.04.zip
 firefox-beta-ubuntu-20.04.zip
 firefox-beta-win32.zip

--- a/browser_patches/firefox/EXPECTED_BUILDS
+++ b/browser_patches/firefox/EXPECTED_BUILDS
@@ -1,4 +1,5 @@
 firefox-mac-10.14.zip
+firefox-mac-11.0-arm64.zip
 firefox-ubuntu-18.04.zip
 firefox-ubuntu-20.04.zip
 firefox-win32.zip


### PR DESCRIPTION
- certain builds weren't listed in EXPECTED_BUILDS
- wekbit had one unused build configuration