### PR TITLE
fix(deps): remove extra colors dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
         "@typescript-eslint/eslint-plugin": "^4.25.0",
         "@typescript-eslint/parser": "^4.25.0",
         "chokidar": "^3.5.0",
-        "colors": "^1.4.0",
         "commonmark": "^0.29.1",
         "cross-env": "^7.0.2",
         "css-loader": "^5.2.6",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
     "chokidar": "^3.5.0",
-    "colors": "^1.4.0",
     "commonmark": "^0.29.1",
     "cross-env": "^7.0.2",
     "css-loader": "^5.2.6",


### PR DESCRIPTION
The `colors` package was added as both a dependency and dev dependency. This caused my package-lock.json to sometimes
get confused about whether or not it was a dev dependency.
