### PR TITLE
browser(webkit): roll to 06/17/21

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,4 +1,2 @@
-1499
-Changed: yurys@chromium.org Thu, Jun 10, 2021 11:01:06 PM
 1500
 Changed: dpino@igalia.com Thu, Jun 17, 2021 09:05:47 AM

--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,4 @@
 1499
 Changed: yurys@chromium.org Thu, Jun 10, 2021 11:01:06 PM
+1500
+Changed: dpino@igalia.com Thu, Jun 17, 2021 09:05:47 AM

--- a/browser_patches/webkit/UPSTREAM_CONFIG.sh
+++ b/browser_patches/webkit/UPSTREAM_CONFIG.sh
@@ -1,3 +1,3 @@
 REMOTE_URL="https://git.webkit.org/git/WebKit.git"
 BASE_BRANCH="master"
-BASE_REVISION="05a7c4e065b6bc9bb79a8a1b49d5cb41de4c3401"
+BASE_REVISION="a60349c98390c46d865cbaa55431b074c2144639"

--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -25,7 +25,7 @@ build_wpe() {
   if [[ -n "${EXPORT_COMPILE_COMMANDS}" ]]; then
     CMAKE_ARGS="--cmakeargs=\"-DCMAKE_EXPORT_COMPILE_COMMANDS=1\""
   fi
-  WEBKIT_JHBUILD=1 WEBKIT_JHBUILD_MODULESET=minimal WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/WPE ./Tools/Scripts/build-webkit --wpe --release "${CMAKE_ARGS}" --touch-events --orientation-events --no-bubblewrap-sandbox --no-webxr MiniBrowser
+  WEBKIT_JHBUILD=1 WEBKIT_JHBUILD_MODULESET=minimal WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/WPE ./Tools/Scripts/build-webkit --wpe --release "${CMAKE_ARGS}" --touch-events --orientation-events --no-bubblewrap-sandbox --no-webxr --cmakeargs=-DENABLE_COG=OFF MiniBrowser
 }
 
 ensure_linux_deps() {

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -1,8 +1,8 @@
 diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
-index 653c5f33811ae5eda7e680df85be7250dde1c950..a2cd767df2d3d25d491447baa120f451eab23895 100644
+index 3566ca4859e0..ebab5e27a3dd 100644
 --- a/Source/JavaScriptCore/CMakeLists.txt
 +++ b/Source/JavaScriptCore/CMakeLists.txt
-@@ -1241,22 +1241,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
+@@ -1239,22 +1239,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/CSS.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Canvas.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Console.json
@@ -31,7 +31,7 @@ index 653c5f33811ae5eda7e680df85be7250dde1c950..a2cd767df2d3d25d491447baa120f451
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/ServiceWorker.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Target.json
 diff --git a/Source/JavaScriptCore/DerivedSources.make b/Source/JavaScriptCore/DerivedSources.make
-index 9df8b244d4c456901bddb412189963d065126327..2ea6388f09af272fa838ba257ee385cee7539aca 100644
+index 9df8b244d4c4..2ea6388f09af 100644
 --- a/Source/JavaScriptCore/DerivedSources.make
 +++ b/Source/JavaScriptCore/DerivedSources.make
 @@ -265,22 +265,27 @@ INSPECTOR_DOMAINS := \
@@ -63,7 +63,7 @@ index 9df8b244d4c456901bddb412189963d065126327..2ea6388f09af272fa838ba257ee385ce
      $(JavaScriptCore)/inspector/protocol/ServiceWorker.json \
      $(JavaScriptCore)/inspector/protocol/Target.json \
 diff --git a/Source/JavaScriptCore/bindings/ScriptValue.cpp b/Source/JavaScriptCore/bindings/ScriptValue.cpp
-index 52d955b1e4929f6d0dede53097d275559b29b91d..71c538e57acf3912f9a777f7bc7eba6efb8877eb 100644
+index 52d955b1e492..71c538e57acf 100644
 --- a/Source/JavaScriptCore/bindings/ScriptValue.cpp
 +++ b/Source/JavaScriptCore/bindings/ScriptValue.cpp
 @@ -79,7 +79,10 @@ static RefPtr<JSON::Value> jsToInspectorValue(JSGlobalObject* globalObject, JSVa
@@ -79,7 +79,7 @@ index 52d955b1e4929f6d0dede53097d275559b29b91d..71c538e57acf3912f9a777f7bc7eba6e
                  return nullptr;
              inspectorObject->setValue(name.string(), inspectorValue.releaseNonNull());
 diff --git a/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp b/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp
-index 95cd87b01b15cb8667e57bc5bb51a71f06bc3760..0481fa93227f297be9d9cf000c5a72235956a390 100644
+index 95cd87b01b15..0481fa93227f 100644
 --- a/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp
 +++ b/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp
 @@ -30,14 +30,21 @@
@@ -106,7 +106,7 @@ index 95cd87b01b15cb8667e57bc5bb51a71f06bc3760..0481fa93227f297be9d9cf000c5a7223
  {
      return addPrefixToIdentifier(String::number(++s_lastUsedIdentifier));
 diff --git a/Source/JavaScriptCore/inspector/IdentifiersFactory.h b/Source/JavaScriptCore/inspector/IdentifiersFactory.h
-index eb25aedee4cd9ebe007e06c2515b37ee095b06f4..badf6559595c8377db1089ca3c25008e1be2c8f1 100644
+index eb25aedee4cd..badf6559595c 100644
 --- a/Source/JavaScriptCore/inspector/IdentifiersFactory.h
 +++ b/Source/JavaScriptCore/inspector/IdentifiersFactory.h
 @@ -31,6 +31,7 @@ namespace Inspector {
@@ -118,7 +118,7 @@ index eb25aedee4cd9ebe007e06c2515b37ee095b06f4..badf6559595c8377db1089ca3c25008e
      static String requestId(unsigned long identifier);
  };
 diff --git a/Source/JavaScriptCore/inspector/InjectedScript.cpp b/Source/JavaScriptCore/inspector/InjectedScript.cpp
-index 8b290faebc1865519b0e7c514f497585dfc0bbda..53c68bca057c85c94201ef8e9870f0cb9e4cef6f 100644
+index 8b290faebc18..53c68bca057c 100644
 --- a/Source/JavaScriptCore/inspector/InjectedScript.cpp
 +++ b/Source/JavaScriptCore/inspector/InjectedScript.cpp
 @@ -91,7 +91,7 @@ void InjectedScript::awaitPromise(const String& promiseObjectId, bool returnByVa
@@ -155,7 +155,7 @@ index 8b290faebc1865519b0e7c514f497585dfc0bbda..53c68bca057c85c94201ef8e9870f0cb
      auto resultValue = toInspectorValue(globalObject(), callResult.value());
      if (!resultValue)
 diff --git a/Source/JavaScriptCore/inspector/InjectedScript.h b/Source/JavaScriptCore/inspector/InjectedScript.h
-index e6b24967273095ae424ac9b3fe5e081ee8999ab7..9f7b72259ab79504b8bfcc24d35abe70d7372065 100644
+index e6b249672730..9f7b72259ab7 100644
 --- a/Source/JavaScriptCore/inspector/InjectedScript.h
 +++ b/Source/JavaScriptCore/inspector/InjectedScript.h
 @@ -64,7 +64,7 @@ public:
@@ -168,7 +168,7 @@ index e6b24967273095ae424ac9b3fe5e081ee8999ab7..9f7b72259ab79504b8bfcc24d35abe70
      void functionDetails(Protocol::ErrorString&, JSC::JSValue, RefPtr<Protocol::Debugger::FunctionDetails>& result);
      void getPreview(Protocol::ErrorString&, const String& objectId, RefPtr<Protocol::Runtime::ObjectPreview>& result);
 diff --git a/Source/JavaScriptCore/inspector/InjectedScriptSource.js b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
-index 48baed6a1b7ffad453379a2f1eb71b8c4925f6c4..40d36f784f46e44dbad908402a71e6b02f499629 100644
+index 48baed6a1b7f..40d36f784f46 100644
 --- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
 +++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
 @@ -136,7 +136,7 @@ let InjectedScript = class InjectedScript
@@ -248,7 +248,7 @@ index 48baed6a1b7ffad453379a2f1eb71b8c4925f6c4..40d36f784f46e44dbad908402a71e6b0
      }
  
 diff --git a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
-index 4895c5a70d6a4745597f77163bc92e0745594829..e4905e0d4e5ff88e479147c84e41359f9274b341 100644
+index 4895c5a70d6a..e4905e0d4e5f 100644
 --- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
 +++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
 @@ -101,7 +101,7 @@ void BackendDispatcher::registerDispatcherForDomain(const String& domain, Supple
@@ -271,7 +271,7 @@ index 4895c5a70d6a4745597f77163bc92e0745594829..e4905e0d4e5ff88e479147c84e41359f
          // We could be called re-entrantly from a nested run loop, so restore the previous id.
          SetForScope<std::optional<long>> scopedRequestId(m_currentRequestId, requestId);
 diff --git a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
-index 37c4f9833d4981b47bcd8debd4a79109254641a2..1c82cc9783618234bef7024d91821ce509912526 100644
+index 37c4f9833d49..1c82cc978361 100644
 --- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
 +++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
 @@ -83,7 +83,10 @@ public:
@@ -287,7 +287,7 @@ index 37c4f9833d4981b47bcd8debd4a79109254641a2..1c82cc9783618234bef7024d91821ce5
      // Note that 'unused' is a workaround so the compiler can pick the right sendResponse based on arity.
      // When <http://webkit.org/b/179847> is fixed or this class is renamed for the JSON::Object case,
 diff --git a/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp b/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp
-index d408d364f1986983161f9d44efbc8bc6f6898676..1375ce9990f0c63d7e6f33ee62930051d6cd44cb 100644
+index d408d364f198..1375ce9990f0 100644
 --- a/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp
 +++ b/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp
 @@ -49,7 +49,7 @@ void FrontendRouter::connectFrontend(FrontendChannel& connection)
@@ -300,7 +300,7 @@ index d408d364f1986983161f9d44efbc8bc6f6898676..1375ce9990f0c63d7e6f33ee62930051
      }
  
 diff --git a/Source/JavaScriptCore/inspector/InspectorTarget.cpp b/Source/JavaScriptCore/inspector/InspectorTarget.cpp
-index 0cc2127c9c12c2d82dea9550bad73f4ffb99ba24..8ca65cc042d435cbc0e05dcc5c5dfc958eb24f5a 100644
+index 0cc2127c9c12..8ca65cc042d4 100644
 --- a/Source/JavaScriptCore/inspector/InspectorTarget.cpp
 +++ b/Source/JavaScriptCore/inspector/InspectorTarget.cpp
 @@ -44,6 +44,8 @@ void InspectorTarget::resume()
@@ -321,7 +321,7 @@ index 0cc2127c9c12c2d82dea9550bad73f4ffb99ba24..8ca65cc042d435cbc0e05dcc5c5dfc95
  }
  
 diff --git a/Source/JavaScriptCore/inspector/InspectorTarget.h b/Source/JavaScriptCore/inspector/InspectorTarget.h
-index 4b95964db4d902b4b7f4b0b4c40afea51654ff2f..966a5927702b65edb343369decafda7fc83eaec7 100644
+index 4b95964db4d9..966a5927702b 100644
 --- a/Source/JavaScriptCore/inspector/InspectorTarget.h
 +++ b/Source/JavaScriptCore/inspector/InspectorTarget.h
 @@ -56,8 +56,12 @@ public:
@@ -338,7 +338,7 @@ index 4b95964db4d902b4b7f4b0b4c40afea51654ff2f..966a5927702b65edb343369decafda7f
      bool m_isPaused { false };
  };
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
-index 76d72c7273f1bb2170485015d931b1fba92d3b5a..c0cf9588c04bfba0d6176c4d6af691bd56ca6cec 100644
+index 76d72c7273f1..c0cf9588c04b 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
 @@ -168,16 +168,15 @@ void InspectorRuntimeAgent::awaitPromise(const Protocol::Runtime::RemoteObjectId
@@ -386,7 +386,7 @@ index 76d72c7273f1bb2170485015d931b1fba92d3b5a..c0cf9588c04bfba0d6176c4d6af691bd
  
  Protocol::ErrorStringOr<Ref<Protocol::Runtime::ObjectPreview>> InspectorRuntimeAgent::getPreview(const Protocol::Runtime::RemoteObjectId& objectId)
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
-index c4f6fa5b9de54317da07c2371a7126aae1c967aa..0d549faeb1f0f80c7a6e7c208c72c6ef9cf4dbd5 100644
+index c4f6fa5b9de5..0d549faeb1f0 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
 @@ -62,7 +62,7 @@ public:
@@ -399,7 +399,7 @@ index c4f6fa5b9de54317da07c2371a7126aae1c967aa..0d549faeb1f0f80c7a6e7c208c72c6ef
      Protocol::ErrorStringOr<Ref<Protocol::Runtime::ObjectPreview>> getPreview(const Protocol::Runtime::RemoteObjectId&) final;
      Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Protocol::Runtime::PropertyDescriptor>>, RefPtr<JSON::ArrayOf<Protocol::Runtime::InternalPropertyDescriptor>>>> getProperties(const Protocol::Runtime::RemoteObjectId&, std::optional<bool>&& ownProperties, std::optional<int>&& fetchStart, std::optional<int>&& fetchCount, std::optional<bool>&& generatePreview) final;
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
-index 508eb02ec95c52408384a1e2b77648afd426dd9d..c0099a56794ae411fe9cdce1a65a95f1a7e37924 100644
+index 508eb02ec95c..c0099a56794a 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
 @@ -87,6 +87,34 @@ Protocol::ErrorStringOr<void> InspectorTargetAgent::sendMessageToTarget(const St
@@ -476,7 +476,7 @@ index 508eb02ec95c52408384a1e2b77648afd426dd9d..c0099a56794ae411fe9cdce1a65a95f1
  {
      return m_router.hasLocalFrontend() ? Inspector::FrontendChannel::ConnectionType::Local : Inspector::FrontendChannel::ConnectionType::Remote;
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
-index e81573fd0fffaaf6fd2af36635c78fcdf8608c69..4169e227b5fb5a3a7fb51396c4679100f495719c 100644
+index e81573fd0fff..4169e227b5fb 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
 @@ -50,15 +50,21 @@ public:
@@ -502,7 +502,7 @@ index e81573fd0fffaaf6fd2af36635c78fcdf8608c69..4169e227b5fb5a3a7fb51396c4679100
      // FrontendChannel
      FrontendChannel::ConnectionType connectionType() const;
 diff --git a/Source/JavaScriptCore/inspector/protocol/DOM.json b/Source/JavaScriptCore/inspector/protocol/DOM.json
-index 1620c003f076eee31ddc8be69a84e4995299892a..424b110d0e82e8ddbc4c7f44dfe87ba6c8f84a4f 100644
+index 3a91ac6b57fa..ff51e7576281 100644
 --- a/Source/JavaScriptCore/inspector/protocol/DOM.json
 +++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
 @@ -80,6 +80,16 @@
@@ -598,7 +598,7 @@ index 1620c003f076eee31ddc8be69a84e4995299892a..424b110d0e82e8ddbc4c7f44dfe87ba6
      "events": [
 diff --git a/Source/JavaScriptCore/inspector/protocol/Dialog.json b/Source/JavaScriptCore/inspector/protocol/Dialog.json
 new file mode 100644
-index 0000000000000000000000000000000000000000..79edea03fed4e9be5da96e1275e182a479cb7a0a
+index 000000000000..79edea03fed4
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Dialog.json
 @@ -0,0 +1,36 @@
@@ -640,7 +640,7 @@ index 0000000000000000000000000000000000000000..79edea03fed4e9be5da96e1275e182a4
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Emulation.json b/Source/JavaScriptCore/inspector/protocol/Emulation.json
 new file mode 100644
-index 0000000000000000000000000000000000000000..347a01b3fdd1a8277cb4104558e8bbfa63539374
+index 000000000000..347a01b3fdd1
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Emulation.json
 @@ -0,0 +1,51 @@
@@ -697,7 +697,7 @@ index 0000000000000000000000000000000000000000..347a01b3fdd1a8277cb4104558e8bbfa
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Input.json b/Source/JavaScriptCore/inspector/protocol/Input.json
 new file mode 100644
-index 0000000000000000000000000000000000000000..587287d52fde2735cbae34a27a0f673b7e38e1a7
+index 000000000000..587287d52fde
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Input.json
 @@ -0,0 +1,188 @@
@@ -890,7 +890,7 @@ index 0000000000000000000000000000000000000000..587287d52fde2735cbae34a27a0f673b
 +    ]
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Network.json b/Source/JavaScriptCore/inspector/protocol/Network.json
-index 882a2d56befef0aba460cc8ff041969e0d2c1ed3..9aecd6067741af596e5ec7fdf9c832ea1267715a 100644
+index 882a2d56befe..9aecd6067741 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Network.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Network.json
 @@ -324,6 +324,13 @@
@@ -908,7 +908,7 @@ index 882a2d56befef0aba460cc8ff041969e0d2c1ed3..9aecd6067741af596e5ec7fdf9c832ea
      ],
      "events": [
 diff --git a/Source/JavaScriptCore/inspector/protocol/Page.json b/Source/JavaScriptCore/inspector/protocol/Page.json
-index db52479a72d459be23d4d8d080c0ed15ea9fc4c0..5f7add78fefc2bf8718ff8af7c49c169038e8226 100644
+index db52479a72d4..5f7add78fefc 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Page.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Page.json
 @@ -27,7 +27,7 @@
@@ -1216,7 +1216,7 @@ index db52479a72d459be23d4d8d080c0ed15ea9fc4c0..5f7add78fefc2bf8718ff8af7c49c169
  }
 diff --git a/Source/JavaScriptCore/inspector/protocol/Playwright.json b/Source/JavaScriptCore/inspector/protocol/Playwright.json
 new file mode 100644
-index 0000000000000000000000000000000000000000..c6cc36ee0e33e868d5c507203c284835fa2ce63f
+index 000000000000..c6cc36ee0e33
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Playwright.json
 @@ -0,0 +1,282 @@
@@ -1503,7 +1503,7 @@ index 0000000000000000000000000000000000000000..c6cc36ee0e33e868d5c507203c284835
 +    ]
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Runtime.json b/Source/JavaScriptCore/inspector/protocol/Runtime.json
-index 274b01596d490fb81b48cf89bf668e0634e8b423..d08a9ddd745c748767ba8055907daa7beeffc219 100644
+index 274b01596d49..d08a9ddd745c 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Runtime.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Runtime.json
 @@ -261,12 +261,14 @@
@@ -1525,7 +1525,7 @@ index 274b01596d490fb81b48cf89bf668e0634e8b423..d08a9ddd745c748767ba8055907daa7b
              "name": "getPreview",
 diff --git a/Source/JavaScriptCore/inspector/protocol/Screencast.json b/Source/JavaScriptCore/inspector/protocol/Screencast.json
 new file mode 100644
-index 0000000000000000000000000000000000000000..f6c541d63c0b8251874eaf8818aabe0e0449401d
+index 000000000000..f6c541d63c0b
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Screencast.json
 @@ -0,0 +1,65 @@
@@ -1595,7 +1595,7 @@ index 0000000000000000000000000000000000000000..f6c541d63c0b8251874eaf8818aabe0e
 +    ]
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Target.json b/Source/JavaScriptCore/inspector/protocol/Target.json
-index 52920cded24a9c6b0ef6fb4e518664955db4f9fa..bbbabc4e7259088b9404e8cc07eecd6f45077da0 100644
+index 52920cded24a..bbbabc4e7259 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Target.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Target.json
 @@ -10,7 +10,7 @@
@@ -1640,7 +1640,7 @@ index 52920cded24a9c6b0ef6fb4e518664955db4f9fa..bbbabc4e7259088b9404e8cc07eecd6f
          },
          {
 diff --git a/Source/JavaScriptCore/inspector/protocol/Worker.json b/Source/JavaScriptCore/inspector/protocol/Worker.json
-index 638612413466efc87b737e8a81042ed07ca12703..6f9e518ff0bfa2a6228675d25b6b785f1ed3022a 100644
+index 638612413466..6f9e518ff0bf 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Worker.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Worker.json
 @@ -16,7 +16,7 @@
@@ -1663,7 +1663,7 @@ index 638612413466efc87b737e8a81042ed07ca12703..6f9e518ff0bfa2a6228675d25b6b785f
          },
          {
 diff --git a/Source/JavaScriptCore/runtime/DateConversion.cpp b/Source/JavaScriptCore/runtime/DateConversion.cpp
-index 2decf8a83c80e80ca8677f4c787bf79c6c2995fa..9010384a32f7c2ab69a8fb20eb19cd566fd9f434 100644
+index 2decf8a83c80..9010384a32f7 100644
 --- a/Source/JavaScriptCore/runtime/DateConversion.cpp
 +++ b/Source/JavaScriptCore/runtime/DateConversion.cpp
 @@ -97,6 +97,9 @@ String formatDateTime(const GregorianDateTime& t, DateTimeFormat format, bool as
@@ -1685,7 +1685,7 @@ index 2decf8a83c80e80ca8677f4c787bf79c6c2995fa..9010384a32f7c2ab69a8fb20eb19cd56
      }
  
 diff --git a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
-index 2729df9dd4d15e19b7b2019ca94dd7647c5a6706..a7fdc92d594a7930ca029f162cc385bbdb949597 100644
+index 2729df9dd4d1..a7fdc92d594a 100644
 --- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
 +++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
 @@ -36,6 +36,7 @@
@@ -1697,7 +1697,7 @@ index 2729df9dd4d15e19b7b2019ca94dd7647c5a6706..a7fdc92d594a7930ca029f162cc385bb
  #include <wtf/unicode/icu/ICUHelpers.h>
  
 diff --git a/Source/JavaScriptCore/runtime/JSDateMath.cpp b/Source/JavaScriptCore/runtime/JSDateMath.cpp
-index ea0bfb0d7a5a64c1570da5333199f99b552a5ff6..2ebe8c6c5ac4343e0b373ccc271e86a4080a98dc 100644
+index ea0bfb0d7a5a..2ebe8c6c5ac4 100644
 --- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
 +++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
 @@ -76,6 +76,7 @@
@@ -1752,7 +1752,7 @@ index ea0bfb0d7a5a64c1570da5333199f99b552a5ff6..2ebe8c6c5ac4343e0b373ccc271e86a4
      m_timeZoneCache = std::unique_ptr<OpaqueICUTimeZone, OpaqueICUTimeZoneDeleter>(bitwise_cast<OpaqueICUTimeZone*>(icu::TimeZone::detectHostTimeZone()));
  #endif
 diff --git a/Source/ThirdParty/libwebrtc/CMakeLists.txt b/Source/ThirdParty/libwebrtc/CMakeLists.txt
-index 8704a1e42febf05286927078af70805ab7af4445..10ceace3974e6b4aa0205f5703ecddcab026e5fa 100644
+index cb557f6c526c..9c95b2fab2bc 100644
 --- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
 +++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
 @@ -292,6 +292,11 @@ set(webrtc_SOURCES
@@ -1767,7 +1767,7 @@ index 8704a1e42febf05286927078af70805ab7af4445..10ceace3974e6b4aa0205f5703ecddca
      Source/third_party/libyuv/source/compare_common.cc
      Source/third_party/libyuv/source/compare_gcc.cc
      Source/third_party/libyuv/source/convert.cc
-@@ -1700,6 +1705,10 @@ set(webrtc_INCLUDE_DIRECTORIES PRIVATE
+@@ -1730,6 +1735,10 @@ set(webrtc_INCLUDE_DIRECTORIES PRIVATE
      Source/third_party/libsrtp/config
      Source/third_party/libsrtp/crypto/include
      Source/third_party/libsrtp/include
@@ -1779,13 +1779,13 @@ index 8704a1e42febf05286927078af70805ab7af4445..10ceace3974e6b4aa0205f5703ecddca
      Source/third_party/libvpx/source/libvpx
      Source/third_party/opus/src/celt
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
-index 7c198f241b7447f3c7b2c89755e748ba6ae4e1d7..aa235c5d0bc199eda1cd6e77b5b51b2beb49f925 100644
+index 7d225cc2c64b..685154543606 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
-@@ -318,3 +318,23 @@ __ZN6webrtc23RtpTransceiverInterface4StopEv
- __ZNK6webrtc23RtpTransceiverInterface23HeaderExtensionsToOfferEv
- __ZNK6webrtc23RtpTransceiverInterface8stoppingEv
- __ZNK3rtc9IPAddresseqERKS0_
+@@ -321,3 +321,23 @@ __ZN3rtc14RTCCertificateD1Ev
+ __ZN6webrtc27CreatePeerConnectionFactoryEPN3rtc6ThreadES2_S2_NS0_13scoped_refptrINS_17AudioDeviceModuleEEENS3_INS_19AudioEncoderFactoryEEENS3_INS_19AudioDecoderFactoryEEENSt3__110unique_ptrINS_19VideoEncoderFactoryENSA_14default_deleteISC_EEEENSB_INS_19VideoDecoderFactoryENSD_ISG_EEEENS3_INS_10AudioMixerEEENS3_INS_15AudioProcessingEEEPNS_19AudioFrameProcessorE
+ __ZNK6webrtc23RtpTransceiverInterface26HeaderExtensionsNegotiatedEv
+ __ZN6webrtc30PeerConnectionFactoryInterface20CreatePeerConnectionERKNS_23PeerConnectionInterface16RTCConfigurationENS_26PeerConnectionDependenciesE
 +__ZN8mkvmuxer11SegmentInfo15set_writing_appEPKc
 +__ZN8mkvmuxer11SegmentInfo4InitEv
 +__ZN8mkvmuxer7Segment10OutputCuesEb
@@ -1807,7 +1807,7 @@ index 7c198f241b7447f3c7b2c89755e748ba6ae4e1d7..aa235c5d0bc199eda1cd6e77b5b51b2b
 +_vpx_codec_version_str
 +_vpx_codec_vp8_cx
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
-index 5dfabd5717a8297192f06c046c7cd7fdee3d468d..6437ad739fbffaf92bf04b202a3f40af87479a23 100644
+index dd884b222501..9927a937145f 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 @@ -43,7 +43,7 @@ DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_ = $(DYLIB_INSTALL_NAME_BASE);
@@ -1820,10 +1820,10 @@ index 5dfabd5717a8297192f06c046c7cd7fdee3d468d..6437ad739fbffaf92bf04b202a3f40af
  PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/libwebrtc;
  USE_HEADERMAP = NO;
 diff --git a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
-index a3f118101eac4da24425a067227b4e33c2f68b5a..aad07e9615a2c56e4bd7ce5cc17459a8b732f1d0 100644
+index d8677555342e..b9ee7198a702 100644
 --- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
 +++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
-@@ -3799,6 +3799,9 @@
+@@ -3856,6 +3856,9 @@
  		CDFD2FCC24C4DAF70048DAC3 /* reader.h in Copy webm headers */ = {isa = PBXBuildFile; fileRef = CDEBB40524C0191A00ADBD44 /* reader.h */; };
  		CDFD2FCD24C4DAF70048DAC3 /* status.h in Copy webm headers */ = {isa = PBXBuildFile; fileRef = CDEBB40624C0191A00ADBD44 /* status.h */; };
  		CDFD2FCE24C4DAF70048DAC3 /* webm_parser.h in Copy webm headers */ = {isa = PBXBuildFile; fileRef = CDEBB40824C0191A00ADBD44 /* webm_parser.h */; };
@@ -1833,7 +1833,7 @@ index a3f118101eac4da24425a067227b4e33c2f68b5a..aad07e9615a2c56e4bd7ce5cc17459a8
  /* End PBXBuildFile section */
  
  /* Begin PBXBuildRule section */
-@@ -8237,6 +8240,9 @@
+@@ -8318,6 +8321,9 @@
  		CDEBB49D24C0191A00ADBD44 /* master_parser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = master_parser.h; sourceTree = "<group>"; };
  		CDFD2F9624C4B2F90048DAC3 /* vp9_header_parser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vp9_header_parser.h; sourceTree = "<group>"; };
  		CDFD2F9A24C4B2F90048DAC3 /* vp9_header_parser.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = vp9_header_parser.cc; sourceTree = "<group>"; };
@@ -1843,7 +1843,7 @@ index a3f118101eac4da24425a067227b4e33c2f68b5a..aad07e9615a2c56e4bd7ce5cc17459a8
  		FB39D0D11200F0E300088E69 /* libwebrtc.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libwebrtc.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
  /* End PBXFileReference section */
  
-@@ -15126,6 +15132,7 @@
+@@ -15298,6 +15304,7 @@
  			isa = PBXGroup;
  			children = (
  				CDFD2F9224C4B2F90048DAC3 /* common */,
@@ -1851,7 +1851,7 @@ index a3f118101eac4da24425a067227b4e33c2f68b5a..aad07e9615a2c56e4bd7ce5cc17459a8
  				CDEBB19224C0191800ADBD44 /* webm_parser */,
  			);
  			path = libwebm;
-@@ -15260,6 +15267,16 @@
+@@ -15432,6 +15439,16 @@
  			path = common;
  			sourceTree = "<group>";
  		};
@@ -1868,7 +1868,7 @@ index a3f118101eac4da24425a067227b4e33c2f68b5a..aad07e9615a2c56e4bd7ce5cc17459a8
  		FB39D06E1200ED9200088E69 = {
  			isa = PBXGroup;
  			children = (
-@@ -17321,7 +17338,7 @@
+@@ -17491,7 +17508,7 @@
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  			shellPath = /bin/sh;
@@ -1877,7 +1877,7 @@ index a3f118101eac4da24425a067227b4e33c2f68b5a..aad07e9615a2c56e4bd7ce5cc17459a8
  		};
  		5CD286461E6E154E0094FDC8 /* Check for Weak VTables and Externals */ = {
  			isa = PBXShellScriptBuildPhase;
-@@ -18470,6 +18487,7 @@
+@@ -18634,6 +18651,7 @@
  				419C82F51FE20EB50040C30F /* audio_encoder_opus.cc in Sources */,
  				419C82F31FE20EB50040C30F /* audio_encoder_opus_config.cc in Sources */,
  				4140B8201E4E3383007409E6 /* audio_encoder_pcm.cc in Sources */,
@@ -1885,7 +1885,7 @@ index a3f118101eac4da24425a067227b4e33c2f68b5a..aad07e9615a2c56e4bd7ce5cc17459a8
  				5CDD8FFE1E43CE3A00621E92 /* audio_encoder_pcm16b.cc in Sources */,
  				5CD285461E6A61D20094FDC8 /* audio_format.cc in Sources */,
  				41DDB26F212679D200296D47 /* audio_format_to_string.cc in Sources */,
-@@ -18888,6 +18906,7 @@
+@@ -19071,6 +19089,7 @@
  				417953DB216983910028266B /* metrics.cc in Sources */,
  				5CDD865E1E43B8B500621E92 /* min_max_operations.c in Sources */,
  				4189395B242A71F5007FDC41 /* min_video_bitrate_experiment.cc in Sources */,
@@ -1893,16 +1893,16 @@ index a3f118101eac4da24425a067227b4e33c2f68b5a..aad07e9615a2c56e4bd7ce5cc17459a8
  				4131C387234B957D0028A615 /* moving_average.cc in Sources */,
  				41FCBB1521B1F7AA00A5DF27 /* moving_average.cc in Sources */,
  				5CD286101E6A64C90094FDC8 /* moving_max.cc in Sources */,
-@@ -19113,6 +19132,7 @@
+@@ -19303,6 +19322,7 @@
  				4131C53B234C8B190028A615 /* rtc_event_rtp_packet_outgoing.cc in Sources */,
  				4131C552234C8B190028A615 /* rtc_event_video_receive_stream_config.cc in Sources */,
  				4131C554234C8B190028A615 /* rtc_event_video_send_stream_config.cc in Sources */,
 +				F3B7819924C7CC5200FCB122 /* mkvmuxerutil.cc in Sources */,
  				4131C3CF234B98420028A615 /* rtc_stats.cc in Sources */,
+ 				41323A1D2665288B00B38623 /* packet_sequencer.cc in Sources */,
  				4131BF2D234B88200028A615 /* rtc_stats_collector.cc in Sources */,
- 				4131C3CE234B98420028A615 /* rtc_stats_report.cc in Sources */,
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferences.yaml b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
-index e7331574bbfe695080432c506a393ed218d0e651..8333ecf890ba03175aa5fa9afe89217f6a377f4c 100644
+index e7331574bbfe..8333ecf890ba 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
 @@ -1010,7 +1010,7 @@ InspectorStartsAttached:
@@ -1915,7 +1915,7 @@ index e7331574bbfe695080432c506a393ed218d0e651..8333ecf890ba03175aa5fa9afe89217f
  InspectorWindowFrame:
    type: String
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index d42b23b6abbe757643faf137e3bb954642ac587f..a5e8526cd3b341038ec0dabb5da7920d3453cae6 100644
+index d42b23b6abbe..a5e8526cd3b3 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 @@ -622,9 +622,9 @@ MaskWebGLStringsEnabled:
@@ -1931,7 +1931,7 @@ index d42b23b6abbe757643faf137e3bb954642ac587f..a5e8526cd3b341038ec0dabb5da7920d
  # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
  MediaCapabilitiesExtensionsEnabled:
 diff --git a/Source/WTF/wtf/DateMath.cpp b/Source/WTF/wtf/DateMath.cpp
-index ebd69a4c76cd7acb0a233be552071158ca2171ca..2ee388e94a56d3de9c9fb2506d2ddead2db1ef87 100644
+index ebd69a4c76cd..2ee388e94a56 100644
 --- a/Source/WTF/wtf/DateMath.cpp
 +++ b/Source/WTF/wtf/DateMath.cpp
 @@ -76,9 +76,14 @@
@@ -2050,7 +2050,7 @@ index ebd69a4c76cd7acb0a233be552071158ca2171ca..2ee388e94a56d3de9c9fb2506d2ddead
 +
  } // namespace WTF
 diff --git a/Source/WTF/wtf/DateMath.h b/Source/WTF/wtf/DateMath.h
-index de0b45bd0a88eaba466b6e6c0ad66dc02f525741..81857a2be24fa3ff0a60ebbcd01130969456b31e 100644
+index de0b45bd0a88..81857a2be24f 100644
 --- a/Source/WTF/wtf/DateMath.h
 +++ b/Source/WTF/wtf/DateMath.h
 @@ -388,6 +388,10 @@ inline int dayInMonthFromDayInYear(int dayInYear, bool leapYear)
@@ -2065,7 +2065,7 @@ index de0b45bd0a88eaba466b6e6c0ad66dc02f525741..81857a2be24fa3ff0a60ebbcd0113096
  WTF_EXPORT_PRIVATE LocalTimeOffset calculateLocalTimeOffset(double utcInMilliseconds, TimeType = UTCTime);
  
 diff --git a/Source/WTF/wtf/PlatformEnable.h b/Source/WTF/wtf/PlatformEnable.h
-index be8f6f20017976fd307f362da8b77a5c956309f8..423ca56b17713e0d8058531c19ca26926bc7c20e 100644
+index e132f8b56fe2..9035512cb303 100644
 --- a/Source/WTF/wtf/PlatformEnable.h
 +++ b/Source/WTF/wtf/PlatformEnable.h
 @@ -417,7 +417,7 @@
@@ -2087,7 +2087,7 @@ index be8f6f20017976fd307f362da8b77a5c956309f8..423ca56b17713e0d8058531c19ca2692
  
  #if !defined(ENABLE_TOUCH_ACTION_REGIONS)
 diff --git a/Source/WTF/wtf/PlatformGTK.cmake b/Source/WTF/wtf/PlatformGTK.cmake
-index fa6958fbd30fabfd1d237aaf1a89f6eb5fa3b366..c0d6541242d79dc6d615a43710343b895e23aadc 100644
+index fa6958fbd30f..c0d6541242d7 100644
 --- a/Source/WTF/wtf/PlatformGTK.cmake
 +++ b/Source/WTF/wtf/PlatformGTK.cmake
 @@ -73,6 +73,7 @@ list(APPEND WTF_LIBRARIES
@@ -2099,10 +2099,10 @@ index fa6958fbd30fabfd1d237aaf1a89f6eb5fa3b366..c0d6541242d79dc6d615a43710343b89
  
  if (Systemd_FOUND)
 diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
-index 27dc96a632b239db66d7e033cd3376f182485d61..15447e2e9c4fa414c3a75327da086f5640dec89b 100644
+index 8efd5f73956c..0218bed8af51 100644
 --- a/Source/WTF/wtf/PlatformHave.h
 +++ b/Source/WTF/wtf/PlatformHave.h
-@@ -384,7 +384,7 @@
+@@ -391,7 +391,7 @@
  #define HAVE_NSHTTPCOOKIESTORAGE__INITWITHIDENTIFIER_WITH_INACCURATE_NULLABILITY 1
  #endif
  
@@ -2112,7 +2112,7 @@ index 27dc96a632b239db66d7e033cd3376f182485d61..15447e2e9c4fa414c3a75327da086f56
  #endif
  
 diff --git a/Source/WTF/wtf/PlatformWPE.cmake b/Source/WTF/wtf/PlatformWPE.cmake
-index 46148f8b54b062bd7f8d6c3fd76c18983d6be28f..c35180cd3327e9331c4ebc097acb318d4611ebe1 100644
+index 46148f8b54b0..c35180cd3327 100644
 --- a/Source/WTF/wtf/PlatformWPE.cmake
 +++ b/Source/WTF/wtf/PlatformWPE.cmake
 @@ -47,6 +47,7 @@ list(APPEND WTF_LIBRARIES
@@ -2124,10 +2124,10 @@ index 46148f8b54b062bd7f8d6c3fd76c18983d6be28f..c35180cd3327e9331c4ebc097acb318d
  
  if (Systemd_FOUND)
 diff --git a/Source/WebCore/DerivedSources.make b/Source/WebCore/DerivedSources.make
-index bf89cae2cd1be60572395c162f92fa170988e7fc..8908069e4371fb3ff8a03a2001709b833728bd3c 100644
+index d9daeb5ab328..3f955d78a57d 100644
 --- a/Source/WebCore/DerivedSources.make
 +++ b/Source/WebCore/DerivedSources.make
-@@ -774,6 +774,10 @@ JS_BINDING_IDLS := \
+@@ -778,6 +778,10 @@ JS_BINDING_IDLS := \
      $(WebCore)/dom/Slotable.idl \
      $(WebCore)/dom/StaticRange.idl \
      $(WebCore)/dom/StringCallback.idl \
@@ -2138,7 +2138,7 @@ index bf89cae2cd1be60572395c162f92fa170988e7fc..8908069e4371fb3ff8a03a2001709b83
      $(WebCore)/dom/Text.idl \
      $(WebCore)/dom/TextDecoder.idl \
      $(WebCore)/dom/TextDecoderStream.idl \
-@@ -1303,9 +1307,6 @@ JS_BINDING_IDLS := \
+@@ -1307,9 +1311,6 @@ JS_BINDING_IDLS := \
  ADDITIONAL_BINDING_IDLS = \
      DocumentTouch.idl \
      GestureEvent.idl \
@@ -2149,7 +2149,7 @@ index bf89cae2cd1be60572395c162f92fa170988e7fc..8908069e4371fb3ff8a03a2001709b83
  
  vpath %.in $(WEBKITADDITIONS_HEADER_SEARCH_PATHS)
 diff --git a/Source/WebCore/Modules/geolocation/Geolocation.cpp b/Source/WebCore/Modules/geolocation/Geolocation.cpp
-index 7995d4dd461de036cd8691b3ff181aeaefb12d92..49207cd294acebb4bac53ecb28817baa827d389f 100644
+index 7995d4dd461d..49207cd294ac 100644
 --- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
 +++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
 @@ -358,8 +358,9 @@ bool Geolocation::shouldBlockGeolocationRequests()
@@ -2164,7 +2164,7 @@ index 7995d4dd461de036cd8691b3ff181aeaefb12d92..49207cd294acebb4bac53ecb28817baa
      }
  
 diff --git a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
-index f1b96958057d2fe6044d2c7b259db6c5ceb44efe..29e51dad380285fb16bd32ef04efde2ac4ed6479 100644
+index f1b96958057d..29e51dad3802 100644
 --- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
 +++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
 @@ -202,6 +202,7 @@ NS_ASSUME_NONNULL_BEGIN
@@ -2200,7 +2200,7 @@ index f1b96958057d2fe6044d2c7b259db6c5ceb44efe..29e51dad380285fb16bd32ef04efde2a
  
      [self sendSpeechEndIfNeeded];
 diff --git a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
-index 66cec91542b74765a9c1ffbc2f28e1a5085c55e0..9a2a89a09279b3b7102282de6bfc4cc7e2b5925f 100644
+index 66cec91542b7..9a2a89a09279 100644
 --- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
 +++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
 @@ -36,6 +36,9 @@ NS_ASSUME_NONNULL_BEGIN
@@ -2222,7 +2222,7 @@ index 66cec91542b74765a9c1ffbc2f28e1a5085c55e0..9a2a89a09279b3b7102282de6bfc4cc7
          _hasSentSpeechStart = true;
          _delegateCallback(SpeechRecognitionUpdate::create(_identifier, SpeechRecognitionUpdateType::SpeechStart));
 diff --git a/Source/WebCore/PlatformWPE.cmake b/Source/WebCore/PlatformWPE.cmake
-index 9d4f3bd1ade02a378340961d617aae1c5e0776a3..17b2b6cfb52d94d8104b68b9250883c40f69f975 100644
+index 9d4f3bd1ade0..17b2b6cfb52d 100644
 --- a/Source/WebCore/PlatformWPE.cmake
 +++ b/Source/WebCore/PlatformWPE.cmake
 @@ -38,6 +38,7 @@ list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
@@ -2234,10 +2234,10 @@ index 9d4f3bd1ade02a378340961d617aae1c5e0776a3..17b2b6cfb52d94d8104b68b9250883c4
  
  list(APPEND WebCore_USER_AGENT_STYLE_SHEETS
 diff --git a/Source/WebCore/SourcesCocoa.txt b/Source/WebCore/SourcesCocoa.txt
-index 7bcd8d1d4ee09ac6ec205a709485491c878a2370..073b7c3514ffc5538a7dd0a4005e0c3c33f2bcf0 100644
+index 471d8a51ba23..dd3196e33857 100644
 --- a/Source/WebCore/SourcesCocoa.txt
 +++ b/Source/WebCore/SourcesCocoa.txt
-@@ -616,3 +616,9 @@ platform/graphics/angle/TemporaryANGLESetting.cpp @no-unify
+@@ -621,3 +621,9 @@ platform/graphics/angle/TemporaryANGLESetting.cpp @no-unify
  // Derived Sources
  
  WHLSLStandardLibraryFunctionMap.cpp
@@ -2248,7 +2248,7 @@ index 7bcd8d1d4ee09ac6ec205a709485491c878a2370..073b7c3514ffc5538a7dd0a4005e0c3c
 +JSTouchList.cpp
 +// Playwright end
 diff --git a/Source/WebCore/SourcesWPE.txt b/Source/WebCore/SourcesWPE.txt
-index b10c1ece52075b7535da51c2cc316dc9343fd081..8520d6b90ccb2aa2762d83fab0f63c1e7107aed3 100644
+index b10c1ece5207..8520d6b90ccb 100644
 --- a/Source/WebCore/SourcesWPE.txt
 +++ b/Source/WebCore/SourcesWPE.txt
 @@ -44,6 +44,8 @@ editing/libwpe/EditorLibWPE.cpp
@@ -2274,7 +2274,7 @@ index b10c1ece52075b7535da51c2cc316dc9343fd081..8520d6b90ccb2aa2762d83fab0f63c1e
 +
 +platform/wpe/SelectionData.cpp
 diff --git a/Source/WebCore/WebCore.order b/Source/WebCore/WebCore.order
-index ef168b76819216d984b7a2d0f760005fb9d24de8..2d6cf51f3b45191ad84106429d4f108f85679123 100644
+index ef168b768192..2d6cf51f3b45 100644
 --- a/Source/WebCore/WebCore.order
 +++ b/Source/WebCore/WebCore.order
 @@ -3093,7 +3093,6 @@ __ZN7WebCore14DocumentLoader23stopLoadingSubresourcesEv
@@ -2286,10 +2286,10 @@ index ef168b76819216d984b7a2d0f760005fb9d24de8..2d6cf51f3b45191ad84106429d4f108f
  __ZN7WebCore14DocumentLoaderD2Ev
  __ZN7WebCore14DocumentLoader17clearMainResourceEv
 diff --git a/Source/WebCore/WebCore.xcodeproj/project.pbxproj b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125d2d8605c 100644
+index 7babd538701a..84f328c4df79 100644
 --- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 +++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-@@ -5340,6 +5340,14 @@
+@@ -5349,6 +5349,14 @@
  		EDE3A5000C7A430600956A37 /* ColorMac.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE3A4FF0C7A430600956A37 /* ColorMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		EDEC98030AED7E170059137F /* WebCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEC98020AED7E170059137F /* WebCorePrefix.h */; };
  		EFCC6C8F20FE914400A2321B /* CanvasActivityRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2304,7 +2304,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  		F12171F616A8CF0B000053CA /* WebVTTElement.h in Headers */ = {isa = PBXBuildFile; fileRef = F12171F416A8BC63000053CA /* WebVTTElement.h */; };
  		F32BDCD92363AACA0073B6AE /* UserGestureEmulationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F32BDCD72363AACA0073B6AE /* UserGestureEmulationScope.h */; };
  		F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
-@@ -16827,6 +16835,14 @@
+@@ -16854,6 +16862,14 @@
  		EDEC98020AED7E170059137F /* WebCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCorePrefix.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
  		EFB7287B2124C73D005C2558 /* CanvasActivityRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasActivityRecord.cpp; sourceTree = "<group>"; };
  		EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasActivityRecord.h; sourceTree = "<group>"; };
@@ -2319,7 +2319,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  		F12171F316A8BC63000053CA /* WebVTTElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebVTTElement.cpp; sourceTree = "<group>"; };
  		F12171F416A8BC63000053CA /* WebVTTElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebVTTElement.h; sourceTree = "<group>"; };
  		F32BDCD52363AAC90073B6AE /* UserGestureEmulationScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserGestureEmulationScope.cpp; sourceTree = "<group>"; };
-@@ -22427,7 +22443,12 @@
+@@ -22474,7 +22490,12 @@
  				93D6B7A62551D3ED0058DD3A /* DummySpeechRecognitionProvider.h */,
  				1AF326770D78B9440068F0C4 /* EditorClient.h */,
  				93C09A800B064F00005ABD4D /* EventHandler.cpp */,
@@ -2332,7 +2332,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  				E0FEF371B27C53EAC1C1FBEE /* EventSource.cpp */,
  				E0FEF371B17C53EAC1C1FBEE /* EventSource.h */,
  				E0FEF371B07C53EAC1C1FBEE /* EventSource.idl */,
-@@ -28135,6 +28156,8 @@
+@@ -28184,6 +28205,8 @@
  				29E4D8DF16B0940F00C84704 /* PlatformSpeechSynthesizer.h */,
  				1AD8F81A11CAB9E900E93E54 /* PlatformStrategies.cpp */,
  				1AD8F81911CAB9E900E93E54 /* PlatformStrategies.h */,
@@ -2341,7 +2341,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  				0FD7C21D23CE41E30096D102 /* PlatformWheelEvent.cpp */,
  				935C476A09AC4D4F00A6AAB4 /* PlatformWheelEvent.h */,
  				BCBB8AB513F1AFB000734DF0 /* PODInterval.h */,
-@@ -30573,6 +30596,7 @@
+@@ -30620,6 +30643,7 @@
  				BCCFBAE70B5152ED0001F1D7 /* DocumentParser.h */,
  				AD6E71AA1668899D00320C13 /* DocumentSharedObjectPool.cpp */,
  				AD6E71AB1668899D00320C13 /* DocumentSharedObjectPool.h */,
@@ -2349,7 +2349,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  				6BDB5DC1227BD3B800919770 /* DocumentStorageAccess.cpp */,
  				6BDB5DC0227BD3B800919770 /* DocumentStorageAccess.h */,
  				7CE7FA5B1EF882300060C9D6 /* DocumentTouch.cpp */,
-@@ -31585,6 +31609,7 @@
+@@ -31630,6 +31654,7 @@
  				93C4F6EB1108F9A50099D0DB /* AccessibilityScrollbar.h in Headers */,
  				29489FC712C00F0300D83F0F /* AccessibilityScrollView.h in Headers */,
  				0709FC4E1025DEE30059CDBA /* AccessibilitySlider.h in Headers */,
@@ -2357,7 +2357,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  				29D7BCFA1444AF7D0070619C /* AccessibilitySpinButton.h in Headers */,
  				69A6CBAD1C6BE42C00B836E9 /* AccessibilitySVGElement.h in Headers */,
  				AAC08CF315F941FD00F1E188 /* AccessibilitySVGRoot.h in Headers */,
-@@ -33613,6 +33638,7 @@
+@@ -33667,6 +33692,7 @@
  				6E4ABCD5138EA0B70071D291 /* JSHTMLUnknownElement.h in Headers */,
  				E44614170CD6826900FADA75 /* JSHTMLVideoElement.h in Headers */,
  				81BE20D311F4BC3200915DFA /* JSIDBCursor.h in Headers */,
@@ -2365,7 +2365,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  				7C3D8EF01E0B21430023B084 /* JSIDBCursorDirection.h in Headers */,
  				C585A68311D4FB08004C3E4B /* JSIDBDatabase.h in Headers */,
  				C585A69711D4FB13004C3E4B /* JSIDBFactory.h in Headers */,
-@@ -35677,9 +35703,11 @@
+@@ -35730,9 +35756,11 @@
  				B2C3DA3A0D006C1D00EF6F26 /* TextCodec.h in Headers */,
  				26E98A10130A9FCA008EB7B2 /* TextCodecASCIIFastPath.h in Headers */,
  				DF95B14A24FDAFD300B1F4D7 /* TextCodecCJK.h in Headers */,
@@ -2377,7 +2377,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  				B2C3DA400D006C1D00EF6F26 /* TextCodecUserDefined.h in Headers */,
  				B2C3DA420D006C1D00EF6F26 /* TextCodecUTF16.h in Headers */,
  				9343CB8212F25E510033C5EE /* TextCodecUTF8.h in Headers */,
-@@ -36641,6 +36669,7 @@
+@@ -36695,6 +36723,7 @@
  				1ABA76CA11D20E50004C201C /* CSSPropertyNames.cpp in Sources */,
  				2D22830323A8470700364B7E /* CursorMac.mm in Sources */,
  				5CBD59592280E926002B22AA /* CustomHeaderFields.cpp in Sources */,
@@ -2385,7 +2385,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  				6E72F54C229DCD0C00B3E151 /* ExtensionsGLANGLE.cpp in Sources */,
  				7CE6CBFD187F394900D46BF5 /* FormatConverter.cpp in Sources */,
  				5130F2F624AEA60A00E1D0A0 /* GameControllerSoftLink.mm in Sources */,
-@@ -36727,6 +36756,7 @@
+@@ -36781,6 +36810,7 @@
  				6E72F54F229DCD1300B3E151 /* TemporaryANGLESetting.cpp in Sources */,
  				CE88EE262414467B007F29C2 /* TextAlternativeWithRange.mm in Sources */,
  				51DF6D800B92A18E00C2DC85 /* ThreadCheck.mm in Sources */,
@@ -2393,7 +2393,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  				538EC8031F96AF81004D22A8 /* UnifiedSource1-mm.mm in Sources */,
  				538EC8021F96AF81004D22A8 /* UnifiedSource1.cpp in Sources */,
  				538EC8051F96AF81004D22A8 /* UnifiedSource2-mm.mm in Sources */,
-@@ -36775,6 +36805,7 @@
+@@ -36829,6 +36859,7 @@
  				538EC8881F993F9C004D22A8 /* UnifiedSource23.cpp in Sources */,
  				DE5F85801FA1ABF4006DB63A /* UnifiedSource24-mm.mm in Sources */,
  				538EC8891F993F9D004D22A8 /* UnifiedSource24.cpp in Sources */,
@@ -2401,7 +2401,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  				DE5F85811FA1ABF4006DB63A /* UnifiedSource25-mm.mm in Sources */,
  				538EC88A1F993F9D004D22A8 /* UnifiedSource25.cpp in Sources */,
  				DE5F85821FA1ABF4006DB63A /* UnifiedSource26-mm.mm in Sources */,
-@@ -37307,6 +37338,7 @@
+@@ -37361,6 +37392,7 @@
  				2D8B92F1203D13E1009C868F /* UnifiedSource516.cpp in Sources */,
  				2D8B92F2203D13E1009C868F /* UnifiedSource517.cpp in Sources */,
  				2D8B92F3203D13E1009C868F /* UnifiedSource518.cpp in Sources */,
@@ -2410,7 +2410,7 @@ index d77b8fe9f72c6ab500cf56713b6c2419b4a4bd9d..3de37e5bd51b3be0190d72e13987a125
  				2D8B92F5203D13E1009C868F /* UnifiedSource520.cpp in Sources */,
  				2D8B92F6203D13E1009C868F /* UnifiedSource521.cpp in Sources */,
 diff --git a/Source/WebCore/accessibility/AccessibilityObject.cpp b/Source/WebCore/accessibility/AccessibilityObject.cpp
-index 34ea8f48c903860c1df3f3fe86b44c7cb57270d3..d3dc7852c192675f6d185ce59d1fabe10a2ffbc9 100644
+index 34ea8f48c903..d3dc7852c192 100644
 --- a/Source/WebCore/accessibility/AccessibilityObject.cpp
 +++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
 @@ -59,6 +59,7 @@
@@ -2441,7 +2441,7 @@ index 34ea8f48c903860c1df3f3fe86b44c7cb57270d3..d3dc7852c192675f6d185ce59d1fabe1
  {
      AXComputedObjectAttributeCache* attributeCache = nullptr;
 diff --git a/Source/WebCore/css/MediaQueryEvaluator.cpp b/Source/WebCore/css/MediaQueryEvaluator.cpp
-index a47b2fe549a89414a207864aabe897d07a59727c..53357bc9ce111bcb1241256647c3630ae767213d 100644
+index a47b2fe549a8..53357bc9ce11 100644
 --- a/Source/WebCore/css/MediaQueryEvaluator.cpp
 +++ b/Source/WebCore/css/MediaQueryEvaluator.cpp
 @@ -844,7 +844,11 @@ static bool prefersContrastEvaluate(CSSValue* value, const CSSToLengthConversion
@@ -2466,7 +2466,7 @@ index a47b2fe549a89414a207864aabe897d07a59727c..53357bc9ce111bcb1241256647c3630a
      if (!value)
          return userPrefersReducedMotion;
 diff --git a/Source/WebCore/dom/DataTransfer.cpp b/Source/WebCore/dom/DataTransfer.cpp
-index 1deac4f41cf49f1f882dccefd48cf6a9732f3ed9..c691eeccd75fc76f5df367b9fb5b95435e92ab79 100644
+index 1deac4f41cf4..c691eeccd75f 100644
 --- a/Source/WebCore/dom/DataTransfer.cpp
 +++ b/Source/WebCore/dom/DataTransfer.cpp
 @@ -494,6 +494,14 @@ Ref<DataTransfer> DataTransfer::createForDrag(const Document& document)
@@ -2485,7 +2485,7 @@ index 1deac4f41cf49f1f882dccefd48cf6a9732f3ed9..c691eeccd75fc76f5df367b9fb5b9543
  {
      auto dataTransfer = adoptRef(*new DataTransfer(StoreMode::ReadWrite, makeUnique<StaticPasteboard>(), Type::DragAndDropData));
 diff --git a/Source/WebCore/dom/DataTransfer.h b/Source/WebCore/dom/DataTransfer.h
-index b084ee416512652220e43a6d4bcccaff7c666d5a..b250f3d0161817efef7e2634a16713b0a0f1fa71 100644
+index b084ee416512..b250f3d01618 100644
 --- a/Source/WebCore/dom/DataTransfer.h
 +++ b/Source/WebCore/dom/DataTransfer.h
 @@ -90,6 +90,9 @@ public:
@@ -2499,7 +2499,7 @@ index b084ee416512652220e43a6d4bcccaff7c666d5a..b250f3d0161817efef7e2634a16713b0
      static Ref<DataTransfer> createForDrop(const Document&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
      static Ref<DataTransfer> createForUpdatingDropTarget(const Document&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
 diff --git a/Source/WebCore/dom/PointerEvent.cpp b/Source/WebCore/dom/PointerEvent.cpp
-index f21879fdfbc64e7d2f11ab084d46794a9e601110..151c9b72f0f552c2ff741305c4c0a8c7f51a92e3 100644
+index f21879fdfbc6..151c9b72f0f5 100644
 --- a/Source/WebCore/dom/PointerEvent.cpp
 +++ b/Source/WebCore/dom/PointerEvent.cpp
 @@ -114,4 +114,61 @@ EventInterface PointerEvent::eventInterface() const
@@ -2565,7 +2565,7 @@ index f21879fdfbc64e7d2f11ab084d46794a9e601110..151c9b72f0f552c2ff741305c4c0a8c7
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/dom/PointerEvent.h b/Source/WebCore/dom/PointerEvent.h
-index 9d60b85152f378566118574663701c25b001df3d..9811ce9aa6f066c57acf65f629d2ab8155c090e1 100644
+index 9d60b85152f3..9811ce9aa6f0 100644
 --- a/Source/WebCore/dom/PointerEvent.h
 +++ b/Source/WebCore/dom/PointerEvent.h
 @@ -33,6 +33,8 @@
@@ -2596,7 +2596,7 @@ index 9d60b85152f378566118574663701c25b001df3d..9811ce9aa6f066c57acf65f629d2ab81
  #endif
  
 diff --git a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
-index 9dd41d6366512fd385937a7608bd3fc9b5b90f60..d6bb529fb891a65c8f6dcc6cff1e718c7a40b8dd 100644
+index 9dd41d636651..d6bb529fb891 100644
 --- a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
 +++ b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
 @@ -33,6 +33,7 @@
@@ -2623,7 +2623,7 @@ index 9dd41d6366512fd385937a7608bd3fc9b5b90f60..d6bb529fb891a65c8f6dcc6cff1e718c
  
  #endif // USE(LIBWPE)
 diff --git a/Source/WebCore/html/FileInputType.cpp b/Source/WebCore/html/FileInputType.cpp
-index bb8ca873e34b367e91b4927b78b7ce38ef641293..472f21b21db90f505a8a226d9a982ad007cc86c0 100644
+index bb8ca873e34b..472f21b21db9 100644
 --- a/Source/WebCore/html/FileInputType.cpp
 +++ b/Source/WebCore/html/FileInputType.cpp
 @@ -36,6 +36,7 @@
@@ -2647,7 +2647,7 @@ index bb8ca873e34b367e91b4927b78b7ce38ef641293..472f21b21db90f505a8a226d9a982ad0
          return;
  
 diff --git a/Source/WebCore/inspector/InspectorController.cpp b/Source/WebCore/inspector/InspectorController.cpp
-index c33bc989d95a21425d43643795190cf40f7e9684..d54965c544b8cac7ebc1e9e408db8ae08e25be61 100644
+index c33bc989d95a..d54965c544b8 100644
 --- a/Source/WebCore/inspector/InspectorController.cpp
 +++ b/Source/WebCore/inspector/InspectorController.cpp
 @@ -374,8 +374,8 @@ void InspectorController::inspect(Node* node)
@@ -2687,7 +2687,7 @@ index c33bc989d95a21425d43643795190cf40f7e9684..d54965c544b8cac7ebc1e9e408db8ae0
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/InspectorController.h b/Source/WebCore/inspector/InspectorController.h
-index 784bf482fd68da68e1f38fd5cd6bcedc8971dfda..6cdf012453ff31120adbe5946ce23f075761ebef 100644
+index 784bf482fd68..6cdf012453ff 100644
 --- a/Source/WebCore/inspector/InspectorController.h
 +++ b/Source/WebCore/inspector/InspectorController.h
 @@ -101,6 +101,10 @@ public:
@@ -2710,10 +2710,10 @@ index 784bf482fd68da68e1f38fd5cd6bcedc8971dfda..6cdf012453ff31120adbe5946ce23f07
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/InspectorInstrumentation.cpp b/Source/WebCore/inspector/InspectorInstrumentation.cpp
-index a8f2a657e3ab7f8d318e2065cc5e5d45b59deeb5..c1e12e3033135db23ef11e408639c2ca0ce211a9 100644
+index c121523071a0..9a25d620db36 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
 +++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
-@@ -633,6 +633,12 @@ void InspectorInstrumentation::didFailLoadingImpl(InstrumentingAgents& instrumen
+@@ -641,6 +641,12 @@ void InspectorInstrumentation::didFailLoadingImpl(InstrumentingAgents& instrumen
          consoleAgent->didFailLoading(identifier, error); // This should come AFTER resource notification, front-end relies on this.
  }
  
@@ -2726,7 +2726,7 @@ index a8f2a657e3ab7f8d318e2065cc5e5d45b59deeb5..c1e12e3033135db23ef11e408639c2ca
  void InspectorInstrumentation::willLoadXHRSynchronouslyImpl(InstrumentingAgents& instrumentingAgents)
  {
      if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
-@@ -665,20 +671,17 @@ void InspectorInstrumentation::didReceiveScriptResponseImpl(InstrumentingAgents&
+@@ -673,20 +679,17 @@ void InspectorInstrumentation::didReceiveScriptResponseImpl(InstrumentingAgents&
  
  void InspectorInstrumentation::domContentLoadedEventFiredImpl(InstrumentingAgents& instrumentingAgents, Frame& frame)
  {
@@ -2750,7 +2750,7 @@ index a8f2a657e3ab7f8d318e2065cc5e5d45b59deeb5..c1e12e3033135db23ef11e408639c2ca
  }
  
  void InspectorInstrumentation::frameDetachedFromParentImpl(InstrumentingAgents& instrumentingAgents, Frame& frame)
-@@ -759,12 +762,6 @@ void InspectorInstrumentation::frameDocumentUpdatedImpl(InstrumentingAgents& ins
+@@ -767,12 +770,6 @@ void InspectorInstrumentation::frameDocumentUpdatedImpl(InstrumentingAgents& ins
          pageDOMDebuggerAgent->frameDocumentUpdated(frame);
  }
  
@@ -2763,7 +2763,7 @@ index a8f2a657e3ab7f8d318e2065cc5e5d45b59deeb5..c1e12e3033135db23ef11e408639c2ca
  void InspectorInstrumentation::frameStartedLoadingImpl(InstrumentingAgents& instrumentingAgents, Frame& frame)
  {
      if (frame.isMainFrame()) {
-@@ -801,6 +798,12 @@ void InspectorInstrumentation::frameClearedScheduledNavigationImpl(Instrumenting
+@@ -809,6 +806,12 @@ void InspectorInstrumentation::frameClearedScheduledNavigationImpl(Instrumenting
          inspectorPageAgent->frameClearedScheduledNavigation(frame);
  }
  
@@ -2776,7 +2776,7 @@ index a8f2a657e3ab7f8d318e2065cc5e5d45b59deeb5..c1e12e3033135db23ef11e408639c2ca
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
  void InspectorInstrumentation::defaultAppearanceDidChangeImpl(InstrumentingAgents& instrumentingAgents, bool useDarkAppearance)
  {
-@@ -1320,6 +1323,36 @@ void InspectorInstrumentation::renderLayerDestroyedImpl(InstrumentingAgents& ins
+@@ -1328,6 +1331,36 @@ void InspectorInstrumentation::renderLayerDestroyedImpl(InstrumentingAgents& ins
          layerTreeAgent->renderLayerDestroyed(renderLayer);
  }
  
@@ -2813,7 +2813,7 @@ index a8f2a657e3ab7f8d318e2065cc5e5d45b59deeb5..c1e12e3033135db23ef11e408639c2ca
  InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(WorkerOrWorkletGlobalScope& globalScope)
  {
      return globalScope.inspectorController().m_instrumentingAgents;
-@@ -1331,6 +1364,13 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
+@@ -1339,6 +1372,13 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
      return page.inspectorController().m_instrumentingAgents.get();
  }
  
@@ -2828,7 +2828,7 @@ index a8f2a657e3ab7f8d318e2065cc5e5d45b59deeb5..c1e12e3033135db23ef11e408639c2ca
  {
      if (is<Document>(context))
 diff --git a/Source/WebCore/inspector/InspectorInstrumentation.h b/Source/WebCore/inspector/InspectorInstrumentation.h
-index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5f0de1445 100644
+index 7d5e7d57bf91..f132ab1566bb 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentation.h
 +++ b/Source/WebCore/inspector/InspectorInstrumentation.h
 @@ -31,6 +31,7 @@
@@ -2847,7 +2847,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
  class HTTPHeaderMap;
  class InspectorTimelineAgent;
  class InstrumentingAgents;
-@@ -200,6 +202,7 @@ public:
+@@ -201,6 +203,7 @@ public:
      static void didReceiveData(Frame*, unsigned long identifier, const uint8_t* data, int dataLength, int encodedDataLength);
      static void didFinishLoading(Frame*, DocumentLoader*, unsigned long identifier, const NetworkLoadMetrics&, ResourceLoader*);
      static void didFailLoading(Frame*, DocumentLoader*, unsigned long identifier, const ResourceError&);
@@ -2855,7 +2855,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
  
      static void willSendRequest(WorkerOrWorkletGlobalScope&, unsigned long identifier, ResourceRequest&);
      static void didReceiveResourceResponse(WorkerOrWorkletGlobalScope&, unsigned long identifier, const ResourceResponse&);
-@@ -226,11 +229,11 @@ public:
+@@ -227,11 +230,11 @@ public:
      static void frameDetachedFromParent(Frame&);
      static void didCommitLoad(Frame&, DocumentLoader*);
      static void frameDocumentUpdated(Frame&);
@@ -2868,7 +2868,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
      static void defaultAppearanceDidChange(Page&, bool useDarkAppearance);
  #endif
-@@ -324,6 +327,12 @@ public:
+@@ -325,6 +328,12 @@ public:
      static void layerTreeDidChange(Page*);
      static void renderLayerDestroyed(Page*, const RenderLayer&);
  
@@ -2881,7 +2881,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
      static void frontendCreated();
      static void frontendDeleted();
      static bool hasFrontends() { return InspectorInstrumentationPublic::hasFrontends(); }
-@@ -340,6 +349,8 @@ public:
+@@ -341,6 +350,8 @@ public:
      static void registerInstrumentingAgents(InstrumentingAgents&);
      static void unregisterInstrumentingAgents(InstrumentingAgents&);
  
@@ -2890,7 +2890,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
  private:
      static void didClearWindowObjectInWorldImpl(InstrumentingAgents&, Frame&, DOMWrapperWorld&);
      static bool isDebuggerPausedImpl(InstrumentingAgents&);
-@@ -427,6 +438,7 @@ private:
+@@ -429,6 +440,7 @@ private:
      static void didReceiveDataImpl(InstrumentingAgents&, unsigned long identifier, const uint8_t* data, int dataLength, int encodedDataLength);
      static void didFinishLoadingImpl(InstrumentingAgents&, unsigned long identifier, DocumentLoader*, const NetworkLoadMetrics&, ResourceLoader*);
      static void didFailLoadingImpl(InstrumentingAgents&, unsigned long identifier, DocumentLoader*, const ResourceError&);
@@ -2898,7 +2898,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
      static void willLoadXHRSynchronouslyImpl(InstrumentingAgents&);
      static void didLoadXHRSynchronouslyImpl(InstrumentingAgents&);
      static void scriptImportedImpl(InstrumentingAgents&, unsigned long identifier, const String& sourceString);
-@@ -437,11 +449,11 @@ private:
+@@ -439,11 +451,11 @@ private:
      static void frameDetachedFromParentImpl(InstrumentingAgents&, Frame&);
      static void didCommitLoadImpl(InstrumentingAgents&, Frame&, DocumentLoader*);
      static void frameDocumentUpdatedImpl(InstrumentingAgents&, Frame&);
@@ -2911,7 +2911,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
      static void defaultAppearanceDidChangeImpl(InstrumentingAgents&, bool useDarkAppearance);
  #endif
-@@ -531,6 +543,12 @@ private:
+@@ -533,6 +545,12 @@ private:
      static void layerTreeDidChangeImpl(InstrumentingAgents&);
      static void renderLayerDestroyedImpl(InstrumentingAgents&, const RenderLayer&);
  
@@ -2924,7 +2924,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
      static InstrumentingAgents& instrumentingAgents(Page&);
      static InstrumentingAgents& instrumentingAgents(WorkerOrWorkletGlobalScope&);
  
-@@ -1125,6 +1143,13 @@ inline void InspectorInstrumentation::didFailLoading(Frame* frame, DocumentLoade
+@@ -1134,6 +1152,13 @@ inline void InspectorInstrumentation::didFailLoading(Frame* frame, DocumentLoade
          didFailLoadingImpl(*agents, identifier, loader, error);
  }
  
@@ -2938,7 +2938,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
  inline void InspectorInstrumentation::didFailLoading(WorkerOrWorkletGlobalScope& globalScope, unsigned long identifier, const ResourceError& error)
  {
      didFailLoadingImpl(instrumentingAgents(globalScope), identifier, nullptr, error);
-@@ -1220,13 +1245,6 @@ inline void InspectorInstrumentation::frameDocumentUpdated(Frame& frame)
+@@ -1229,13 +1254,6 @@ inline void InspectorInstrumentation::frameDocumentUpdated(Frame& frame)
          frameDocumentUpdatedImpl(*agents, frame);
  }
  
@@ -2952,7 +2952,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
  inline void InspectorInstrumentation::frameStartedLoading(Frame& frame)
  {
      FAST_RETURN_IF_NO_FRONTENDS(void());
-@@ -1255,6 +1273,13 @@ inline void InspectorInstrumentation::frameClearedScheduledNavigation(Frame& fra
+@@ -1264,6 +1282,13 @@ inline void InspectorInstrumentation::frameClearedScheduledNavigation(Frame& fra
          frameClearedScheduledNavigationImpl(*agents, frame);
  }
  
@@ -2966,7 +2966,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
  inline void InspectorInstrumentation::defaultAppearanceDidChange(Page& page, bool useDarkAppearance)
  {
-@@ -1722,6 +1747,42 @@ inline void InspectorInstrumentation::renderLayerDestroyed(Page* page, const Ren
+@@ -1731,6 +1756,42 @@ inline void InspectorInstrumentation::renderLayerDestroyed(Page* page, const Ren
          renderLayerDestroyedImpl(*agents, renderLayer);
  }
  
@@ -3010,7 +3010,7 @@ index bc63ef8c1f43c8adce7d17bea9004717ad841695..fa01cec093a4e5e69aed21cb6eb102c5
  {
      return context ? instrumentingAgents(*context) : nullptr;
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
-index f52e4abc8e76c02285b9c68ac9c7a98bd203e0dd..a3f08d8c0644ac2ca61c66c979d3ae7a529dced7 100644
+index 6459cedc046c..a7167e7db8a7 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 @@ -62,12 +62,16 @@
@@ -3064,7 +3064,7 @@ index f52e4abc8e76c02285b9c68ac9c7a98bd203e0dd..a3f08d8c0644ac2ca61c66c979d3ae7a
  }
  
  static bool parseQuad(Ref<JSON::Array>&& quadArray, FloatQuad* quad)
-@@ -435,6 +443,20 @@ Node* InspectorDOMAgent::assertNode(Protocol::ErrorString& errorString, Protocol
+@@ -431,6 +439,20 @@ Node* InspectorDOMAgent::assertNode(Protocol::ErrorString& errorString, Protocol
      return node;
  }
  
@@ -3085,7 +3085,7 @@ index f52e4abc8e76c02285b9c68ac9c7a98bd203e0dd..a3f08d8c0644ac2ca61c66c979d3ae7a
  Document* InspectorDOMAgent::assertDocument(Protocol::ErrorString& errorString, Protocol::DOM::NodeId nodeId)
  {
      Node* node = assertNode(errorString, nodeId);
-@@ -1394,16 +1416,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(Ref<JSON::Obj
+@@ -1384,16 +1406,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(Ref<JSON::Obj
  Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNode(Ref<JSON::Object>&& highlightInspectorObject, std::optional<Protocol::DOM::NodeId>&& nodeId, const Protocol::Runtime::RemoteObjectId& objectId)
  {
      Protocol::ErrorString errorString;
@@ -3103,7 +3103,7 @@ index f52e4abc8e76c02285b9c68ac9c7a98bd203e0dd..a3f08d8c0644ac2ca61c66c979d3ae7a
      if (!node)
          return makeUnexpected(errorString);
  
-@@ -1605,15 +1618,136 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Protocol::DOM:
+@@ -1595,15 +1608,136 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Protocol::DOM:
      return { };
  }
  
@@ -3244,7 +3244,7 @@ index f52e4abc8e76c02285b9c68ac9c7a98bd203e0dd..a3f08d8c0644ac2ca61c66c979d3ae7a
      if (!object)
          return makeUnexpected("Missing injected script for given nodeId"_s);
  
-@@ -2805,7 +2939,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPath
+@@ -2837,7 +2971,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPath
      return makeUnexpected("Missing node for given path"_s);
  }
  
@@ -3253,7 +3253,7 @@ index f52e4abc8e76c02285b9c68ac9c7a98bd203e0dd..a3f08d8c0644ac2ca61c66c979d3ae7a
  {
      Document* document = &node->document();
      if (auto* templateHost = document->templateDocumentHost())
-@@ -2814,12 +2948,16 @@ RefPtr<Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* nod
+@@ -2846,12 +2980,16 @@ RefPtr<Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* nod
      if (!frame)
          return nullptr;
  
@@ -3273,7 +3273,7 @@ index f52e4abc8e76c02285b9c68ac9c7a98bd203e0dd..a3f08d8c0644ac2ca61c66c979d3ae7a
  }
  
  Node* InspectorDOMAgent::scriptValueAsNode(JSC::JSValue value)
-@@ -2842,4 +2980,42 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowT
+@@ -2874,4 +3012,42 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowT
      return { };
  }
  
@@ -3308,7 +3308,7 @@ index f52e4abc8e76c02285b9c68ac9c7a98bd203e0dd..a3f08d8c0644ac2ca61c66c979d3ae7a
 +            return makeUnexpected("Unable to decode given content"_s);
 +
 +        ScriptExecutionContext* context = element->scriptExecutionContext();
-+        fileObjects.append(File::create(context, Blob::create(context, SharedBuffer::create(WTFMove(*buffer)), type), name));
++	fileObjects.append(File::create(context, Blob::create(context, Vector { buffer->data(), buffer->size() }, type), name));
 +    }
 +    RefPtr<FileList> fileList = FileList::create(WTFMove(fileObjects));
 +    element->setFiles(WTFMove(fileList));
@@ -3317,7 +3317,7 @@ index f52e4abc8e76c02285b9c68ac9c7a98bd203e0dd..a3f08d8c0644ac2ca61c66c979d3ae7a
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.h b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
-index 74a60f618092676d8bee87538c9d697f3c584304..055e6f68ef4940618fa5e74d3a64eb3ebb27bc6a 100644
+index 33b8284ea079..d883cd81d42f 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
 @@ -56,6 +56,7 @@ namespace WebCore {
@@ -3381,7 +3381,7 @@ index 74a60f618092676d8bee87538c9d697f3c584304..055e6f68ef4940618fa5e74d3a64eb3e
  private:
  #if ENABLE(VIDEO)
      void mediaMetricsTimerFired();
-@@ -236,7 +245,6 @@ private:
+@@ -235,7 +244,6 @@ private:
      void processAccessibilityChildren(AXCoreObject&, JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>&);
      
      Node* nodeForPath(const String& path);
@@ -3390,7 +3390,7 @@ index 74a60f618092676d8bee87538c9d697f3c584304..055e6f68ef4940618fa5e74d3a64eb3e
      void discardBindings();
  
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
-index 3386cb879f1178c1b9635775c9a0e864f5b94c52..d2350182f5f061855e8ca172779ad60ee73b39fb 100644
+index 3386cb879f11..d2350182f5f0 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
 @@ -40,6 +40,7 @@ class DOMStorageFrontendDispatcher;
@@ -3402,7 +3402,7 @@ index 3386cb879f1178c1b9635775c9a0e864f5b94c52..d2350182f5f061855e8ca172779ad60e
  class Page;
  class SecurityOrigin;
 diff --git a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
-index d4f7873e85f91316012b944084f92097601e066d..05ce7e70327dfea3bd09523e55cdb1fb6183d1a4 100644
+index 767046d37bc0..07da2c81b9df 100644
 --- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
 @@ -45,6 +45,7 @@
@@ -3441,24 +3441,26 @@ index d4f7873e85f91316012b944084f92097601e066d..05ce7e70327dfea3bd09523e55cdb1fb
      if (resourceLoader) {
          auto* metrics = response.deprecatedNetworkLoadMetricsOrNull();
          responseObject->setTiming(buildObjectForTiming(metrics ? *metrics : NetworkLoadMetrics { }, *resourceLoader));
-@@ -488,8 +492,14 @@ static InspectorPageAgent::ResourceType resourceTypeForLoadType(InspectorInstrum
+@@ -488,9 +492,15 @@ static InspectorPageAgent::ResourceType resourceTypeForLoadType(InspectorInstrum
  
- void InspectorNetworkAgent::willSendRequest(unsigned long identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse)
+ void InspectorNetworkAgent::willSendRequest(unsigned long identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource)
  {
--    auto* cachedResource = loader ? InspectorPageAgent::cachedResource(loader->frame(), request.url()) : nullptr;
+-    if (!cachedResource && loader)
+-        cachedResource = InspectorPageAgent::cachedResource(loader->frame(), request.url());
 -    willSendRequest(identifier, loader, request, redirectResponse, resourceTypeForCachedResource(cachedResource));
 +    InspectorPageAgent::ResourceType resourceType;
 +    if (request.initiatorIdentifier() == initiatorIdentifierForEventSource()) {
-+      resourceType = InspectorPageAgent::EventSource;
++        resourceType = InspectorPageAgent::EventSource;
 +    } else {
-+      auto* cachedResource = loader ? InspectorPageAgent::cachedResource(loader->frame(), request.url()) : nullptr;
-+      resourceType = resourceTypeForCachedResource(cachedResource);
++        if (!cachedResource && loader)
++            cachedResource = InspectorPageAgent::cachedResource(loader->frame(), request.url());
++        resourceType = resourceTypeForCachedResource(cachedResource);
 +    }
 +    willSendRequest(identifier, loader, request, redirectResponse, resourceType);
  }
  
  void InspectorNetworkAgent::willSendRequestOfType(unsigned long identifier, DocumentLoader* loader, ResourceRequest& request, InspectorInstrumentation::LoadType loadType)
-@@ -1101,8 +1111,7 @@ bool InspectorNetworkAgent::willIntercept(const ResourceRequest& request)
+@@ -1104,8 +1114,7 @@ bool InspectorNetworkAgent::willIntercept(const ResourceRequest& request)
      if (!m_interceptionEnabled)
          return false;
  
@@ -3468,7 +3470,7 @@ index d4f7873e85f91316012b944084f92097601e066d..05ce7e70327dfea3bd09523e55cdb1fb
  }
  
  bool InspectorNetworkAgent::shouldInterceptRequest(const ResourceRequest& request)
-@@ -1185,6 +1194,9 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithRequest(const
+@@ -1188,6 +1197,9 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithRequest(const
          return makeUnexpected("Missing pending intercept request for given requestId"_s);
  
      auto& loader = *pendingRequest->m_loader;
@@ -3478,7 +3480,7 @@ index d4f7873e85f91316012b944084f92097601e066d..05ce7e70327dfea3bd09523e55cdb1fb
      ResourceRequest request = loader.request();
      if (!!url)
          request.setURL(URL({ }, url));
-@@ -1284,14 +1296,24 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithRespons
+@@ -1287,14 +1299,24 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithRespons
      response.setHTTPStatusCode(status);
      response.setHTTPStatusText(statusText);
      HTTPHeaderMap explicitHeaders;
@@ -3503,7 +3505,7 @@ index d4f7873e85f91316012b944084f92097601e066d..05ce7e70327dfea3bd09523e55cdb1fb
          if (buffer->size())
              loader->didReceiveBuffer(WTFMove(buffer), buffer->size(), DataPayloadWholeResource);
          loader->didFinishLoading(NetworkLoadMetrics());
-@@ -1332,6 +1354,12 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithError(c
+@@ -1335,6 +1357,12 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithError(c
      return { };
  }
  
@@ -3516,7 +3518,7 @@ index d4f7873e85f91316012b944084f92097601e066d..05ce7e70327dfea3bd09523e55cdb1fb
  bool InspectorNetworkAgent::shouldTreatAsText(const String& mimeType)
  {
      return startsWithLettersIgnoringASCIICase(mimeType, "text/")
-@@ -1373,6 +1401,12 @@ std::optional<String> InspectorNetworkAgent::textContentForCachedResource(Cached
+@@ -1376,6 +1404,12 @@ std::optional<String> InspectorNetworkAgent::textContentForCachedResource(Cached
      return std::nullopt;
  }
  
@@ -3530,7 +3532,7 @@ index d4f7873e85f91316012b944084f92097601e066d..05ce7e70327dfea3bd09523e55cdb1fb
  {
      ASSERT(result);
 diff --git a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
-index 66ae7a46fe7991b392bb06531d36506ba31e2414..74fd279a05329e9d0c49bfa9f883e4a797eefc7a 100644
+index 7cdc5865e58e..f5712075bb6f 100644
 --- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
 @@ -72,6 +72,7 @@ public:
@@ -3550,7 +3552,7 @@ index 66ae7a46fe7991b392bb06531d36506ba31e2414..74fd279a05329e9d0c49bfa9f883e4a7
      // InspectorInstrumentation
      void willRecalculateStyle();
 diff --git a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
-index f0806ed36dc6b72fb9a97c4a4fb22bc8a0956e1a..4820c81a7ff0a79fdc740a6d0d8dfeb91ec26c51 100644
+index 64117425ba5c..8fa02250a9c5 100644
 --- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
 @@ -32,19 +32,25 @@
@@ -3889,7 +3891,7 @@ index f0806ed36dc6b72fb9a97c4a4fb22bc8a0956e1a..4820c81a7ff0a79fdc740a6d0d8dfeb9
 -Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotRect(int x, int y, int width, int height, Protocol::Page::CoordinateSystem coordinateSystem)
 +Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotRect(int x, int y, int width, int height, Protocol::Page::CoordinateSystem coordinateSystem, std::optional<bool>&& omitDeviceScaleFactor)
  {
-     SnapshotOptions options;
+     SnapshotOptions options { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() };
      if (coordinateSystem == Protocol::Page::CoordinateSystem::Viewport)
          options.flags.add(SnapshotFlags::InViewCoordinates);
 +    if (omitDeviceScaleFactor.has_value() && *omitDeviceScaleFactor)
@@ -4550,7 +4552,7 @@ index f0806ed36dc6b72fb9a97c4a4fb22bc8a0956e1a..4820c81a7ff0a79fdc740a6d0d8dfeb9
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorPageAgent.h b/Source/WebCore/inspector/agents/InspectorPageAgent.h
-index b51addb1bd8f2cce69560799cd1d952d2de42838..2ad11ef1993ed5a223f63073c4b4464bfde93a34 100644
+index b51addb1bd8f..2ad11ef1993e 100644
 --- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
 @@ -34,17 +34,23 @@
@@ -4699,7 +4701,7 @@ index b51addb1bd8f2cce69560799cd1d952d2de42838..2ad11ef1993ed5a223f63073c4b4464b
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
-index 33caa0aa2079ad4081cc29605a53537c24d66bef..4b74d397d4de9a7eba3d5530538443d8907726aa 100644
+index 33caa0aa2079..4b74d397d4de 100644
 --- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
 @@ -161,7 +161,11 @@ void InspectorWorkerAgent::connectToWorkerInspectorProxy(WorkerInspectorProxy& p
@@ -4716,7 +4718,7 @@ index 33caa0aa2079ad4081cc29605a53537c24d66bef..4b74d397d4de9a7eba3d5530538443d8
  
  void InspectorWorkerAgent::disconnectFromWorkerInspectorProxy(WorkerInspectorProxy& proxy)
 diff --git a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
-index 55d9518494195b96df165a94c1c2963adceb8395..98035b606587337e5fdacd31459a196fa7c28702 100644
+index 55d951849419..98035b606587 100644
 --- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
 +++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
 @@ -38,6 +38,7 @@
@@ -4752,7 +4754,7 @@ index 55d9518494195b96df165a94c1c2963adceb8395..98035b606587337e5fdacd31459a196f
  
  void PageDebuggerAgent::debuggerDidEvaluate(JSC::Debugger&, const JSC::Breakpoint::Action& action)
 diff --git a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
-index b32f3f699c2d2a377289760b245ac81784102458..48f0fab7f07bfc2b2408764e9adec252cc380705 100644
+index b32f3f699c2d..48f0fab7f07b 100644
 --- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
 +++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
 @@ -35,12 +35,14 @@
@@ -4816,7 +4818,7 @@ index b32f3f699c2d2a377289760b245ac81784102458..48f0fab7f07bfc2b2408764e9adec252
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
-index 6aba3a2c6e8bbb7a0bca4f07824cf4de8ce36f8e..537e3b34d6405e412bf0e2350909c9afda06bed8 100644
+index 6aba3a2c6e8b..537e3b34d640 100644
 --- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
 +++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
 @@ -54,25 +54,25 @@ public:
@@ -4854,7 +4856,7 @@ index 6aba3a2c6e8bbb7a0bca4f07824cf4de8ce36f8e..537e3b34d6405e412bf0e2350909c9af
  
      Page& m_inspectedPage;
 diff --git a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp
-index 8699436e3f962b465b47aebebd601ee90152ef83..35fbd46627f68d9ebac52500bc560d4fd9866166 100644
+index 8699436e3f96..35fbd46627f6 100644
 --- a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp
 +++ b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp
 @@ -38,9 +38,9 @@
@@ -4870,7 +4872,7 @@ index 8699436e3f962b465b47aebebd601ee90152ef83..35fbd46627f68d9ebac52500bc560d4f
      , m_userWasInteracting(false)
  {
 diff --git a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h
-index 16edb3bc689b8e2dde17597b642b706c1343e1f5..f363b2ca2410f22cff8d6ad908a88527970ab1d8 100644
+index 16edb3bc689b..f363b2ca2410 100644
 --- a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h
 +++ b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h
 @@ -38,12 +38,13 @@ namespace WebCore {
@@ -4889,7 +4891,7 @@ index 16edb3bc689b8e2dde17597b642b706c1343e1f5..f363b2ca2410f22cff8d6ad908a88527
  
  private:
 diff --git a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
-index 92a0b1d304cca9ab0170d135e8c9537f65f469db..18617fb37245d7087825fe3c94feda94b117a320 100644
+index 92a0b1d304cc..18617fb37245 100644
 --- a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
 +++ b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
 @@ -250,7 +250,7 @@ void LineLayout::prepareLayoutState()
@@ -4902,7 +4904,7 @@ index 92a0b1d304cca9ab0170d135e8c9537f65f469db..18617fb37245d7087825fe3c94feda94
      rootGeometry.setHorizontalMargin({ });
      rootGeometry.setVerticalMargin({ });
 diff --git a/Source/WebCore/loader/CookieJar.h b/Source/WebCore/loader/CookieJar.h
-index 982691dd2dfe2f65201370a12302b5086703c126..4af72beb3b1405ffac78e89e7fbb2b14d6647903 100644
+index 982691dd2dfe..4af72beb3b14 100644
 --- a/Source/WebCore/loader/CookieJar.h
 +++ b/Source/WebCore/loader/CookieJar.h
 @@ -43,6 +43,7 @@ struct CookieRequestHeaderFieldProxy;
@@ -4924,10 +4926,10 @@ index 982691dd2dfe2f65201370a12302b5086703c126..4af72beb3b1405ffac78e89e7fbb2b14
  protected:
      static SameSiteInfo sameSiteInfo(const Document&, IsForDOMCookieAccess = IsForDOMCookieAccess::No);
 diff --git a/Source/WebCore/loader/DocumentLoader.cpp b/Source/WebCore/loader/DocumentLoader.cpp
-index df67c1544844827739ad3e27c0c369723ae79391..7b5d137d72420100204797ae16e454ba6247140f 100644
+index 367675741089..b15bf5fd3188 100644
 --- a/Source/WebCore/loader/DocumentLoader.cpp
 +++ b/Source/WebCore/loader/DocumentLoader.cpp
-@@ -1405,8 +1405,6 @@ void DocumentLoader::detachFromFrame()
+@@ -1408,8 +1408,6 @@ void DocumentLoader::detachFromFrame()
      if (!m_frame)
          return;
  
@@ -4937,7 +4939,7 @@ index df67c1544844827739ad3e27c0c369723ae79391..7b5d137d72420100204797ae16e454ba
  }
  
 diff --git a/Source/WebCore/loader/DocumentLoader.h b/Source/WebCore/loader/DocumentLoader.h
-index d537947e02fadff26bfab0e83d895ca873ce0852..428f46a69f22af3a7ff498495189c6cf26a69a19 100644
+index e693532ebd64..242829bb5200 100644
 --- a/Source/WebCore/loader/DocumentLoader.h
 +++ b/Source/WebCore/loader/DocumentLoader.h
 @@ -166,9 +166,13 @@ public:
@@ -4955,7 +4957,7 @@ index d537947e02fadff26bfab0e83d895ca873ce0852..428f46a69f22af3a7ff498495189c6cf
      DocumentWriter& writer() const { return m_writer; }
  
 diff --git a/Source/WebCore/loader/FrameLoader.cpp b/Source/WebCore/loader/FrameLoader.cpp
-index 0f09d26dac13136ff8b3d9e5af4143e30f8c57c8..6356c03c524a83296d6fc5fbd1b3dd2dc8061bff 100644
+index d713f7dd4a49..6fd9f81126ef 100644
 --- a/Source/WebCore/loader/FrameLoader.cpp
 +++ b/Source/WebCore/loader/FrameLoader.cpp
 @@ -1152,6 +1152,7 @@ void FrameLoader::loadInSameDocument(const URL& url, SerializedScriptValue* stat
@@ -4971,7 +4973,7 @@ index 0f09d26dac13136ff8b3d9e5af4143e30f8c57c8..6356c03c524a83296d6fc5fbd1b3dd2d
  void FrameLoader::loadWithNavigationAction(const ResourceRequest& request, NavigationAction&& action, FrameLoadType type, RefPtr<FormState>&& formState, AllowNavigationToInvalidURL allowNavigationToInvalidURL, CompletionHandler<void()>&& completionHandler)
  {
 +    InspectorInstrumentation::frameScheduledNavigation(m_frame, Seconds(0));
-     FRAMELOADER_RELEASE_LOG_IF_ALLOWED(ResourceLoading, "loadWithNavigationAction: frame load started");
+     FRAMELOADER_RELEASE_LOG(ResourceLoading, "loadWithNavigationAction: frame load started");
  
      Ref<DocumentLoader> loader = m_client->createDocumentLoader(request, defaultSubstituteDataForURL(request.url()));
 @@ -1573,6 +1575,8 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
@@ -5023,7 +5025,7 @@ index 0f09d26dac13136ff8b3d9e5af4143e30f8c57c8..6356c03c524a83296d6fc5fbd1b3dd2d
      InspectorInstrumentation::didClearWindowObjectInWorld(m_frame, world);
  }
 diff --git a/Source/WebCore/loader/LoaderStrategy.h b/Source/WebCore/loader/LoaderStrategy.h
-index b018af04d05ce3ac38bb57d8e50a7b063ee51733..6929c01318f509ed560276168d18e0112b116bc2 100644
+index b018af04d05c..6929c01318f5 100644
 --- a/Source/WebCore/loader/LoaderStrategy.h
 +++ b/Source/WebCore/loader/LoaderStrategy.h
 @@ -84,6 +84,7 @@ public:
@@ -5035,7 +5037,7 @@ index b018af04d05ce3ac38bb57d8e50a7b063ee51733..6929c01318f509ed560276168d18e011
      virtual bool shouldPerformSecurityChecks() const { return false; }
      virtual bool havePerformedSecurityChecks(const ResourceResponse&) const { return false; }
 diff --git a/Source/WebCore/loader/PolicyChecker.cpp b/Source/WebCore/loader/PolicyChecker.cpp
-index 98e961977567080e848095fe1023666ede05d0ea..33e100b34079152390e53d3af13e3ff478f7275e 100644
+index c082a981526d..2f8eb1b0cabb 100644
 --- a/Source/WebCore/loader/PolicyChecker.cpp
 +++ b/Source/WebCore/loader/PolicyChecker.cpp
 @@ -46,6 +46,7 @@
@@ -5046,7 +5048,7 @@ index 98e961977567080e848095fe1023666ede05d0ea..33e100b34079152390e53d3af13e3ff4
  #include "Logging.h"
  #include "ThreadableBlobRegistry.h"
  #include <wtf/CompletionHandler.h>
-@@ -262,26 +263,32 @@ void FrameLoader::PolicyChecker::checkNewWindowPolicy(NavigationAction&& navigat
+@@ -261,26 +262,32 @@ void FrameLoader::PolicyChecker::checkNewWindowPolicy(NavigationAction&& navigat
  
      auto blobURLLifetimeExtension = extendBlobURLLifetimeIfNecessary(request, nullptr);
  
@@ -5081,7 +5083,7 @@ index 98e961977567080e848095fe1023666ede05d0ea..33e100b34079152390e53d3af13e3ff4
              return;
          }
 diff --git a/Source/WebCore/loader/ProgressTracker.cpp b/Source/WebCore/loader/ProgressTracker.cpp
-index e24fded2225f1c1918f454017566717e20484eab..30e4b7a986418c4b4f6c799b858b608206e22bb5 100644
+index 0dcb47556d04..df57e9a47160 100644
 --- a/Source/WebCore/loader/ProgressTracker.cpp
 +++ b/Source/WebCore/loader/ProgressTracker.cpp
 @@ -154,6 +154,8 @@ void ProgressTracker::progressCompleted(Frame& frame)
@@ -5103,7 +5105,7 @@ index e24fded2225f1c1918f454017566717e20484eab..30e4b7a986418c4b4f6c799b858b6082
  
  void ProgressTracker::incrementProgress(unsigned long identifier, const ResourceResponse& response)
 diff --git a/Source/WebCore/page/ChromeClient.h b/Source/WebCore/page/ChromeClient.h
-index 6d84f6944df6177405c1faf3babde10d9bbf5993..a404540c03300e1e76888a8a0360ee6aaec2e0d9 100644
+index 6d84f6944df6..a404540c0330 100644
 --- a/Source/WebCore/page/ChromeClient.h
 +++ b/Source/WebCore/page/ChromeClient.h
 @@ -297,7 +297,7 @@ public:
@@ -5116,7 +5118,7 @@ index 6d84f6944df6177405c1faf3babde10d9bbf5993..a404540c03300e1e76888a8a0360ee6a
  
  #if ENABLE(INPUT_TYPE_COLOR)
 diff --git a/Source/WebCore/page/EventHandler.cpp b/Source/WebCore/page/EventHandler.cpp
-index 96986b53091bc690e6fcd4cb067aba021a356072..0d3cc97860c059fe103e6eeac9cbff713d2bc930 100644
+index 27337d865a6a..50204bc37a9e 100644
 --- a/Source/WebCore/page/EventHandler.cpp
 +++ b/Source/WebCore/page/EventHandler.cpp
 @@ -125,6 +125,7 @@
@@ -5214,7 +5216,7 @@ index 96986b53091bc690e6fcd4cb067aba021a356072..0d3cc97860c059fe103e6eeac9cbff71
  
      return swallowEvent;
  }
-@@ -4046,7 +4046,14 @@ bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDr
+@@ -4048,7 +4048,14 @@ bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDr
      if (!m_frame.document())
          return false;
  
@@ -5230,7 +5232,7 @@ index 96986b53091bc690e6fcd4cb067aba021a356072..0d3cc97860c059fe103e6eeac9cbff71
      auto hasNonDefaultPasteboardData = HasNonDefaultPasteboardData::No;
      
      if (dragState().shouldDispatchEvents) {
-@@ -4402,7 +4409,8 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
+@@ -4404,7 +4411,8 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
              allTouchReleased = false;
      }
  
@@ -5240,7 +5242,7 @@ index 96986b53091bc690e6fcd4cb067aba021a356072..0d3cc97860c059fe103e6eeac9cbff71
          PlatformTouchPoint::State pointState = point.state();
          LayoutPoint pagePoint = documentPointForWindowPoint(m_frame, point.pos());
  
-@@ -4528,6 +4536,9 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
+@@ -4530,6 +4538,9 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
              changedTouches[pointState].m_touches->append(WTFMove(touch));
              changedTouches[pointState].m_targets.add(touchTarget);
          }
@@ -5251,7 +5253,7 @@ index 96986b53091bc690e6fcd4cb067aba021a356072..0d3cc97860c059fe103e6eeac9cbff71
      m_touchPressed = touches->length() > 0;
      if (allTouchReleased)
 diff --git a/Source/WebCore/page/EventHandler.h b/Source/WebCore/page/EventHandler.h
-index 9fb52b2e9fbd85731534a6b28a91a369c37877d2..393f7720588cb4801b46828940ab90b6ea547ff2 100644
+index 9fb52b2e9fbd..393f7720588c 100644
 --- a/Source/WebCore/page/EventHandler.h
 +++ b/Source/WebCore/page/EventHandler.h
 @@ -135,9 +135,7 @@ public:
@@ -5309,7 +5311,7 @@ index 9fb52b2e9fbd85731534a6b28a91a369c37877d2..393f7720588cb4801b46828940ab90b6
      bool m_mouseDownMayStartDrag { false };
      bool m_dragMayStartSelectionInstead { false };
 diff --git a/Source/WebCore/page/EventSource.cpp b/Source/WebCore/page/EventSource.cpp
-index b6e68f3c729fb41c929a6d178da60399fdc91f2b..64286a09d57c800257e25f78345394d8d4e1bdd4 100644
+index 7b77e407ee5d..0060ebfb1128 100644
 --- a/Source/WebCore/page/EventSource.cpp
 +++ b/Source/WebCore/page/EventSource.cpp
 @@ -36,6 +36,7 @@
@@ -5320,7 +5322,7 @@ index b6e68f3c729fb41c929a6d178da60399fdc91f2b..64286a09d57c800257e25f78345394d8
  #include "MessageEvent.h"
  #include "ResourceError.h"
  #include "ResourceRequest.h"
-@@ -97,6 +98,7 @@ void EventSource::connect()
+@@ -94,6 +95,7 @@ void EventSource::connect()
      ASSERT(!m_requestInFlight);
  
      ResourceRequest request { m_url };
@@ -5329,7 +5331,7 @@ index b6e68f3c729fb41c929a6d178da60399fdc91f2b..64286a09d57c800257e25f78345394d8
      request.setHTTPHeaderField(HTTPHeaderName::Accept, "text/event-stream");
      request.setHTTPHeaderField(HTTPHeaderName::CacheControl, "no-cache");
 diff --git a/Source/WebCore/page/Frame.cpp b/Source/WebCore/page/Frame.cpp
-index 1af27d84f35af0d3ba1fb9dbafa31e43c6661332..151625332aef8f5d7bcdc44acc7ca8369404ee30 100644
+index 7054acc90214..658520b15acd 100644
 --- a/Source/WebCore/page/Frame.cpp
 +++ b/Source/WebCore/page/Frame.cpp
 @@ -39,6 +39,7 @@
@@ -5365,7 +5367,7 @@ index 1af27d84f35af0d3ba1fb9dbafa31e43c6661332..151625332aef8f5d7bcdc44acc7ca836
      return 0;
  }
  #endif // ENABLE(ORIENTATION_EVENTS)
-@@ -1144,6 +1147,358 @@ DataDetectionResultsStorage& Frame::dataDetectionResults()
+@@ -1139,6 +1142,358 @@ DataDetectionResultsStorage& Frame::dataDetectionResults()
  
  #endif
  
@@ -5723,9 +5725,9 @@ index 1af27d84f35af0d3ba1fb9dbafa31e43c6661332..151625332aef8f5d7bcdc44acc7ca836
 +
  } // namespace WebCore
  
- #undef RELEASE_LOG_ERROR_IF_ALLOWED
+ #undef FRAME_RELEASE_LOG_ERROR
 diff --git a/Source/WebCore/page/Frame.h b/Source/WebCore/page/Frame.h
-index 37b1af211e340974e0c527bee8b173b6668eee0c..57d07c9196c714846177d529e2c66370d873a3ad 100644
+index f0743e939757..f1863e330e7f 100644
 --- a/Source/WebCore/page/Frame.h
 +++ b/Source/WebCore/page/Frame.h
 @@ -110,8 +110,8 @@ enum {
@@ -5760,7 +5762,7 @@ index 37b1af211e340974e0c527bee8b173b6668eee0c..57d07c9196c714846177d529e2c66370
      WEBCORE_EXPORT NSArray *wordsInCurrentParagraph() const;
      WEBCORE_EXPORT CGRect renderRectForPoint(CGPoint, bool* isReplaced, float* fontSize) const;
  
-@@ -313,6 +313,7 @@ public:
+@@ -311,6 +311,7 @@ public:
  
      WEBCORE_EXPORT FloatSize screenSize() const;
      void setOverrideScreenSize(FloatSize&&);
@@ -5768,7 +5770,7 @@ index 37b1af211e340974e0c527bee8b173b6668eee0c..57d07c9196c714846177d529e2c66370
  
      void selfOnlyRef();
      void selfOnlyDeref();
-@@ -351,7 +352,6 @@ private:
+@@ -349,7 +350,6 @@ private:
  #if ENABLE(DATA_DETECTION)
      std::unique_ptr<DataDetectionResultsStorage> m_dataDetectionResults;
  #endif
@@ -5776,7 +5778,7 @@ index 37b1af211e340974e0c527bee8b173b6668eee0c..57d07c9196c714846177d529e2c66370
      void betterApproximateNode(const IntPoint& testPoint, const NodeQualifier&, Node*& best, Node* failedNode, IntPoint& bestPoint, IntRect& bestRect, const IntRect& testRect);
      bool hitTestResultAtViewportLocation(const FloatPoint& viewportLocation, HitTestResult&, IntPoint& center);
      
-@@ -359,6 +359,7 @@ private:
+@@ -357,6 +357,7 @@ private:
      enum class ShouldFindRootEditableElement : bool { No, Yes };
      Node* qualifyingNodeAtViewportLocation(const FloatPoint& viewportLocation, FloatPoint& adjustedViewportLocation, const NodeQualifier&, ShouldApproximate, ShouldFindRootEditableElement = ShouldFindRootEditableElement::Yes);
  
@@ -5785,10 +5787,10 @@ index 37b1af211e340974e0c527bee8b173b6668eee0c..57d07c9196c714846177d529e2c66370
  
      ViewportArguments m_viewportArguments;
 diff --git a/Source/WebCore/page/FrameSnapshotting.cpp b/Source/WebCore/page/FrameSnapshotting.cpp
-index 1a8eb236f326a9f8fb45c7d988b8796b2b237223..a546f6b38f7bc513212b3bb50c35a15af3c690b7 100644
+index 8273a64fcdfb..8a2f97ac8f93 100644
 --- a/Source/WebCore/page/FrameSnapshotting.cpp
 +++ b/Source/WebCore/page/FrameSnapshotting.cpp
-@@ -106,7 +106,7 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(Frame& frame, const IntRect& image
+@@ -103,7 +103,7 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(Frame& frame, const IntRect& image
      // Other paint behaviors are set by paintContentsForSnapshot.
      frame.view()->setPaintBehavior(paintBehavior);
  
@@ -5797,8 +5799,8 @@ index 1a8eb236f326a9f8fb45c7d988b8796b2b237223..a546f6b38f7bc513212b3bb50c35a15a
  
      if (frame.page()->delegatesScaling())
          scaleFactor *= frame.page()->pageScaleFactor();
-@@ -117,7 +117,12 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(Frame& frame, const IntRect& image
-     auto buffer = ImageBuffer::create(imageRect.size(), RenderingMode::Unaccelerated, scaleFactor, options.colorSpace.value_or(DestinationColorSpace::SRGB()), options.pixelFormat.value_or(PixelFormat::BGRA8));
+@@ -114,7 +114,12 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(Frame& frame, const IntRect& image
+     auto buffer = ImageBuffer::create(imageRect.size(), RenderingMode::Unaccelerated, scaleFactor, options.colorSpace, options.pixelFormat);
      if (!buffer)
          return nullptr;
 +#if !PLATFORM(MAC)
@@ -5810,7 +5812,7 @@ index 1a8eb236f326a9f8fb45c7d988b8796b2b237223..a546f6b38f7bc513212b3bb50c35a15a
  
      if (!clipRects.isEmpty()) {
          Path clipPath;
-@@ -126,7 +131,10 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(Frame& frame, const IntRect& image
+@@ -123,7 +128,10 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(Frame& frame, const IntRect& image
          buffer->context().clipPath(clipPath);
      }
  
@@ -5823,10 +5825,10 @@ index 1a8eb236f326a9f8fb45c7d988b8796b2b237223..a546f6b38f7bc513212b3bb50c35a15a
  }
  
 diff --git a/Source/WebCore/page/FrameSnapshotting.h b/Source/WebCore/page/FrameSnapshotting.h
-index 0886a71486768c843166936887d8a38aff6a86c9..71f2d5b0578173342d9b3d353266785f1f9bb676 100644
+index 1b77026f5109..6026bc235080 100644
 --- a/Source/WebCore/page/FrameSnapshotting.h
 +++ b/Source/WebCore/page/FrameSnapshotting.h
-@@ -51,6 +51,7 @@ enum class SnapshotFlags : uint8_t {
+@@ -50,6 +50,7 @@ enum class SnapshotFlags : uint8_t {
      PaintSelectionAndBackgroundsOnly = 1 << 4,
      PaintEverythingExcludingSelection = 1 << 5,
      PaintWithIntegralScaleFactor = 1 << 6,
@@ -5835,7 +5837,7 @@ index 0886a71486768c843166936887d8a38aff6a86c9..71f2d5b0578173342d9b3d353266785f
  
  struct SnapshotOptions {
 diff --git a/Source/WebCore/page/FrameView.cpp b/Source/WebCore/page/FrameView.cpp
-index 4f670736b7841a93e00e54a9889e7e823b07b844..5190228608e4ec877158e9fb5f2f709ed6980921 100644
+index a2129f7769fd..f0f30d0e7ce7 100644
 --- a/Source/WebCore/page/FrameView.cpp
 +++ b/Source/WebCore/page/FrameView.cpp
 @@ -3028,7 +3028,7 @@ void FrameView::setBaseBackgroundColor(const Color& backgroundColor)
@@ -5848,7 +5850,7 @@ index 4f670736b7841a93e00e54a9889e7e823b07b844..5190228608e4ec877158e9fb5f2f709e
  #else
      Color baseBackgroundColor = backgroundColor.value_or(Color::white);
 diff --git a/Source/WebCore/page/History.cpp b/Source/WebCore/page/History.cpp
-index 28d1fc3242174a680711027877d4153923790220..058b5309eed081fcc1e4158f66e806421dcc9d56 100644
+index 28d1fc324217..058b5309eed0 100644
 --- a/Source/WebCore/page/History.cpp
 +++ b/Source/WebCore/page/History.cpp
 @@ -33,6 +33,7 @@
@@ -5868,10 +5870,10 @@ index 28d1fc3242174a680711027877d4153923790220..058b5309eed081fcc1e4158f66e80642
      if (stateObjectType == StateObjectType::Push) {
          frame->loader().history().pushState(WTFMove(data), title, fullURL.string());
 diff --git a/Source/WebCore/page/Page.cpp b/Source/WebCore/page/Page.cpp
-index 318ab13712bf685271812250cb2d46545c29c175..21b994189f01e3d8fafad8baaa9d7cb91fcbc763 100644
+index 2c6951c24d7a..71511627d2e0 100644
 --- a/Source/WebCore/page/Page.cpp
 +++ b/Source/WebCore/page/Page.cpp
-@@ -446,6 +446,37 @@ void Page::setOverrideViewportArguments(const std::optional<ViewportArguments>&
+@@ -447,6 +447,37 @@ void Page::setOverrideViewportArguments(const std::optional<ViewportArguments>&
          document->updateViewportArguments();
  }
  
@@ -5909,7 +5911,7 @@ index 318ab13712bf685271812250cb2d46545c29c175..21b994189f01e3d8fafad8baaa9d7cb9
  ScrollingCoordinator* Page::scrollingCoordinator()
  {
      if (!m_scrollingCoordinator && m_settings->scrollingCoordinatorEnabled()) {
-@@ -1267,11 +1298,6 @@ void Page::didCommitLoad()
+@@ -1268,11 +1299,6 @@ void Page::didCommitLoad()
  #if ENABLE(EDITABLE_REGION)
      m_isEditableRegionEnabled = false;
  #endif
@@ -5920,8 +5922,8 @@ index 318ab13712bf685271812250cb2d46545c29c175..21b994189f01e3d8fafad8baaa9d7cb9
 -
      resetSeenPlugins();
      resetSeenMediaEngines();
- }
-@@ -3246,6 +3272,16 @@ void Page::setUseDarkAppearanceOverride(std::optional<bool> valueOverride)
+ 
+@@ -3250,6 +3276,16 @@ void Page::setUseDarkAppearanceOverride(std::optional<bool> valueOverride)
  #endif
  }
  
@@ -5939,10 +5941,10 @@ index 318ab13712bf685271812250cb2d46545c29c175..21b994189f01e3d8fafad8baaa9d7cb9
  {
      if (insets == m_fullscreenInsets)
 diff --git a/Source/WebCore/page/Page.h b/Source/WebCore/page/Page.h
-index b432645259476352c65245850f35ee9c6e758d1d..014e4c20bab319f1919774f52e2924f0ef8e7b7f 100644
+index d671e78aae96..9b57c4c4c0f0 100644
 --- a/Source/WebCore/page/Page.h
 +++ b/Source/WebCore/page/Page.h
-@@ -253,6 +253,9 @@ public:
+@@ -256,6 +256,9 @@ public:
      const std::optional<ViewportArguments>& overrideViewportArguments() const { return m_overrideViewportArguments; }
      WEBCORE_EXPORT void setOverrideViewportArguments(const std::optional<ViewportArguments>&);
  
@@ -5952,7 +5954,7 @@ index b432645259476352c65245850f35ee9c6e758d1d..014e4c20bab319f1919774f52e2924f0
      static void refreshPlugins(bool reload);
      WEBCORE_EXPORT PluginData& pluginData();
      void clearPluginData();
-@@ -299,6 +302,10 @@ public:
+@@ -302,6 +305,10 @@ public:
      DragCaretController& dragCaretController() const { return *m_dragCaretController; }
  #if ENABLE(DRAG_SUPPORT)
      DragController& dragController() const { return *m_dragController; }
@@ -5963,7 +5965,7 @@ index b432645259476352c65245850f35ee9c6e758d1d..014e4c20bab319f1919774f52e2924f0
  #endif
      FocusController& focusController() const { return *m_focusController; }
  #if ENABLE(CONTEXT_MENUS)
-@@ -457,6 +464,8 @@ public:
+@@ -460,6 +467,8 @@ public:
      WEBCORE_EXPORT void effectiveAppearanceDidChange(bool useDarkAppearance, bool useElevatedUserInterfaceLevel);
      bool defaultUseDarkAppearance() const { return m_useDarkAppearance; }
      void setUseDarkAppearanceOverride(std::optional<bool>);
@@ -5972,7 +5974,7 @@ index b432645259476352c65245850f35ee9c6e758d1d..014e4c20bab319f1919774f52e2924f0
  
  #if ENABLE(TEXT_AUTOSIZING)
      float textAutosizingWidth() const { return m_textAutosizingWidth; }
-@@ -835,6 +844,11 @@ public:
+@@ -836,6 +845,11 @@ public:
  
      WEBCORE_EXPORT Vector<Ref<Element>> editableElementsInRect(const FloatRect&) const;
  
@@ -5984,7 +5986,7 @@ index b432645259476352c65245850f35ee9c6e758d1d..014e4c20bab319f1919774f52e2924f0
  #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
      DeviceOrientationUpdateProvider* deviceOrientationUpdateProvider() const { return m_deviceOrientationUpdateProvider.get(); }
  #endif
-@@ -910,6 +924,9 @@ private:
+@@ -921,6 +935,9 @@ private:
  
  #if ENABLE(DRAG_SUPPORT)
      const std::unique_ptr<DragController> m_dragController;
@@ -5994,7 +5996,7 @@ index b432645259476352c65245850f35ee9c6e758d1d..014e4c20bab319f1919774f52e2924f0
  #endif
      const std::unique_ptr<FocusController> m_focusController;
  #if ENABLE(CONTEXT_MENUS)
-@@ -989,6 +1006,7 @@ private:
+@@ -1000,6 +1017,7 @@ private:
      bool m_useElevatedUserInterfaceLevel { false };
      bool m_useDarkAppearance { false };
      std::optional<bool> m_useDarkAppearanceOverride;
@@ -6002,7 +6004,7 @@ index b432645259476352c65245850f35ee9c6e758d1d..014e4c20bab319f1919774f52e2924f0
  
  #if ENABLE(TEXT_AUTOSIZING)
      float m_textAutosizingWidth { 0 };
-@@ -1149,6 +1167,11 @@ private:
+@@ -1160,6 +1178,11 @@ private:
  #endif
  
      std::optional<ViewportArguments> m_overrideViewportArguments;
@@ -6015,7 +6017,7 @@ index b432645259476352c65245850f35ee9c6e758d1d..014e4c20bab319f1919774f52e2924f0
  #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
      RefPtr<DeviceOrientationUpdateProvider> m_deviceOrientationUpdateProvider;
 diff --git a/Source/WebCore/page/PointerCaptureController.cpp b/Source/WebCore/page/PointerCaptureController.cpp
-index 2903e934ebf5cf0e755d817d778717fe01ae066b..8d644b579ebd02761a4f6ff7db5f526623bc376c 100644
+index 2903e934ebf5..8d644b579ebd 100644
 --- a/Source/WebCore/page/PointerCaptureController.cpp
 +++ b/Source/WebCore/page/PointerCaptureController.cpp
 @@ -202,7 +202,7 @@ bool PointerCaptureController::preventsCompatibilityMouseEventsForIdentifier(Poi
@@ -6037,7 +6039,7 @@ index 2903e934ebf5cf0e755d817d778717fe01ae066b..8d644b579ebd02761a4f6ff7db5f5266
  #endif
  
 diff --git a/Source/WebCore/page/PointerCaptureController.h b/Source/WebCore/page/PointerCaptureController.h
-index 27ee794779152f113b49391e4e59614cb5794764..cad99479d44588710bb87dd1a6c6c367149c515a 100644
+index 27ee79477915..cad99479d445 100644
 --- a/Source/WebCore/page/PointerCaptureController.h
 +++ b/Source/WebCore/page/PointerCaptureController.h
 @@ -57,7 +57,7 @@ public:
@@ -6059,7 +6061,7 @@ index 27ee794779152f113b49391e4e59614cb5794764..cad99479d44588710bb87dd1a6c6c367
  #endif
          bool hasAnyElement() const {
 diff --git a/Source/WebCore/page/RuntimeEnabledFeatures.cpp b/Source/WebCore/page/RuntimeEnabledFeatures.cpp
-index 6b2bc1bdb38be0543f20d51d200944b3f547f6a9..68a1773c0f578ecf8d5d7aa15ec1d34d9ad7a0a2 100644
+index 6b2bc1bdb38b..68a1773c0f57 100644
 --- a/Source/WebCore/page/RuntimeEnabledFeatures.cpp
 +++ b/Source/WebCore/page/RuntimeEnabledFeatures.cpp
 @@ -56,7 +56,11 @@ RuntimeEnabledFeatures& RuntimeEnabledFeatures::sharedFeatures()
@@ -6076,7 +6078,7 @@ index 6b2bc1bdb38be0543f20d51d200944b3f547f6a9..68a1773c0f578ecf8d5d7aa15ec1d34d
  #endif
  
 diff --git a/Source/WebCore/page/RuntimeEnabledFeatures.h b/Source/WebCore/page/RuntimeEnabledFeatures.h
-index d0774fd91166b2b977f2e930c5909f35a215be8e..73061176c6f23eaead3add9a71a42de3962dec76 100644
+index d0774fd91166..73061176c6f2 100644
 --- a/Source/WebCore/page/RuntimeEnabledFeatures.h
 +++ b/Source/WebCore/page/RuntimeEnabledFeatures.h
 @@ -200,6 +200,7 @@ public:
@@ -6088,7 +6090,7 @@ index d0774fd91166b2b977f2e930c5909f35a215be8e..73061176c6f23eaead3add9a71a42de3
  
      bool pageAtRuleSupportEnabled() const { return m_pageAtRuleSupportEnabled; }
 diff --git a/Source/WebCore/page/Screen.cpp b/Source/WebCore/page/Screen.cpp
-index 7ac11c8289347e3a2f3e7316cf9e32932b9544ed..764b2d4fe36ac2e5588bd22595424ac11d42acd0 100644
+index 7ac11c828934..764b2d4fe36a 100644
 --- a/Source/WebCore/page/Screen.cpp
 +++ b/Source/WebCore/page/Screen.cpp
 @@ -102,6 +102,8 @@ int Screen::availLeft() const
@@ -6128,7 +6130,7 @@ index 7ac11c8289347e3a2f3e7316cf9e32932b9544ed..764b2d4fe36ac2e5588bd22595424ac1
  }
  
 diff --git a/Source/WebCore/page/SocketProvider.cpp b/Source/WebCore/page/SocketProvider.cpp
-index 3bec0aef174336939838fb1069fffbcb9f3d5604..566ef3806be3c5ccf1bb951251c2a90dba7071a3 100644
+index 3bec0aef1743..566ef3806be3 100644
 --- a/Source/WebCore/page/SocketProvider.cpp
 +++ b/Source/WebCore/page/SocketProvider.cpp
 @@ -33,7 +33,7 @@ namespace WebCore {
@@ -6141,7 +6143,7 @@ index 3bec0aef174336939838fb1069fffbcb9f3d5604..566ef3806be3c5ccf1bb951251c2a90d
  
  RefPtr<ThreadableWebSocketChannel> SocketProvider::createWebSocketChannel(Document&, WebSocketChannelClient&)
 diff --git a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
-index 6ad6b23777ea62fae078f4f8a835d2c96ce64f70..0d595e4a3a6144c94c71f073dfa8feaf61437f0b 100644
+index fc85fffa9b20..1070a1973d0e 100644
 --- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
 +++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
 @@ -281,6 +281,8 @@ bool ContentSecurityPolicy::protocolMatchesSelf(const URL& url) const
@@ -6172,7 +6174,7 @@ index 6ad6b23777ea62fae078f4f8a835d2c96ce64f70..0d595e4a3a6144c94c71f073dfa8feaf
      for (auto& policy : m_policies) {
          if (const ContentSecurityPolicyDirective* violatedDirective = (policy.get()->*predicate)(std::forward<Args>(args)...)) {
 diff --git a/Source/WebCore/page/ios/FrameIOS.mm b/Source/WebCore/page/ios/FrameIOS.mm
-index 12cc7336ae87b6d9d8ea83cf543d029914eaf1db..b97227e21bf9e7166980c20d2efdc24ea28058a2 100644
+index 12cc7336ae87..b97227e21bf9 100644
 --- a/Source/WebCore/page/ios/FrameIOS.mm
 +++ b/Source/WebCore/page/ios/FrameIOS.mm
 @@ -226,354 +226,6 @@ CGRect Frame::renderRectForPoint(CGPoint point, bool* isReplaced, float* fontSiz
@@ -6532,7 +6534,7 @@ index 12cc7336ae87b6d9d8ea83cf543d029914eaf1db..b97227e21bf9e7166980c20d2efdc24e
      Document* document = this->document();
 diff --git a/Source/WebCore/page/wpe/DragControllerWPE.cpp b/Source/WebCore/page/wpe/DragControllerWPE.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..3dedfa855f990643e3e7bbe7754abca4e88a0f1c
+index 000000000000..3dedfa855f99
 --- /dev/null
 +++ b/Source/WebCore/page/wpe/DragControllerWPE.cpp
 @@ -0,0 +1,79 @@
@@ -6616,7 +6618,7 @@ index 0000000000000000000000000000000000000000..3dedfa855f990643e3e7bbe7754abca4
 +
 +}
 diff --git a/Source/WebCore/platform/Cairo.cmake b/Source/WebCore/platform/Cairo.cmake
-index 237ebfbb80338d313d2a51a77e28309d705fbf69..134b26cecc94e6989126a9f40d1d42a49815d0d4 100644
+index 237ebfbb8033..134b26cecc94 100644
 --- a/Source/WebCore/platform/Cairo.cmake
 +++ b/Source/WebCore/platform/Cairo.cmake
 @@ -16,6 +16,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
@@ -6628,7 +6630,7 @@ index 237ebfbb80338d313d2a51a77e28309d705fbf69..134b26cecc94e6989126a9f40d1d42a4
      platform/graphics/cairo/RefPtrCairo.h
  )
 diff --git a/Source/WebCore/platform/DragData.h b/Source/WebCore/platform/DragData.h
-index 6600dfa7b189e15fab7fb796f66ef1a79dcd22f3..4c0bc485ca92614efca23a5a2da871b77d5285d3 100644
+index 6600dfa7b189..4c0bc485ca92 100644
 --- a/Source/WebCore/platform/DragData.h
 +++ b/Source/WebCore/platform/DragData.h
 @@ -48,7 +48,7 @@ typedef void* DragDataRef;
@@ -6641,10 +6643,10 @@ index 6600dfa7b189e15fab7fb796f66ef1a79dcd22f3..4c0bc485ca92614efca23a5a2da871b7
  class SelectionData;
  }
 diff --git a/Source/WebCore/platform/DragImage.cpp b/Source/WebCore/platform/DragImage.cpp
-index 7bc536cf5db50e71a0495b28eb9373ec1199e583..c164ae567e4a4a9d6f192757dce69a43abb52264 100644
+index 6dfe0dd3ea4d..683c1bdb2cb3 100644
 --- a/Source/WebCore/platform/DragImage.cpp
 +++ b/Source/WebCore/platform/DragImage.cpp
-@@ -280,7 +280,7 @@ DragImage::~DragImage()
+@@ -279,7 +279,7 @@ DragImage::~DragImage()
          deleteDragImage(m_dragImageRef);
  }
  
@@ -6654,7 +6656,7 @@ index 7bc536cf5db50e71a0495b28eb9373ec1199e583..c164ae567e4a4a9d6f192757dce69a43
  IntSize dragImageSize(DragImageRef)
  {
 diff --git a/Source/WebCore/platform/Pasteboard.h b/Source/WebCore/platform/Pasteboard.h
-index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e578fb03d 100644
+index 7d247dcd1a16..6903f0a0ab25 100644
 --- a/Source/WebCore/platform/Pasteboard.h
 +++ b/Source/WebCore/platform/Pasteboard.h
 @@ -44,7 +44,7 @@ OBJC_CLASS NSString;
@@ -6746,7 +6748,7 @@ index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e
  };
  
 diff --git a/Source/WebCore/platform/PlatformKeyboardEvent.h b/Source/WebCore/platform/PlatformKeyboardEvent.h
-index f90f1dad6b7b4e6703745c9cb97a32c872fa1aa8..9ad9c22488cc001cade2e8e8a6f4e9b8dc515cbd 100644
+index f90f1dad6b7b..9ad9c22488cc 100644
 --- a/Source/WebCore/platform/PlatformKeyboardEvent.h
 +++ b/Source/WebCore/platform/PlatformKeyboardEvent.h
 @@ -134,6 +134,7 @@ namespace WebCore {
@@ -6766,7 +6768,7 @@ index f90f1dad6b7b4e6703745c9cb97a32c872fa1aa8..9ad9c22488cc001cade2e8e8a6f4e9b8
  #endif
  
 diff --git a/Source/WebCore/platform/PlatformScreen.cpp b/Source/WebCore/platform/PlatformScreen.cpp
-index ba50b688ab6d0bae5d199fa0bac4b7e2004baf81..0b83a798b00835635a95a0db22173de094ba4035 100644
+index ba50b688ab6d..0b83a798b008 100644
 --- a/Source/WebCore/platform/PlatformScreen.cpp
 +++ b/Source/WebCore/platform/PlatformScreen.cpp
 @@ -25,6 +25,7 @@
@@ -6795,7 +6797,7 @@ index ba50b688ab6d0bae5d199fa0bac4b7e2004baf81..0b83a798b00835635a95a0db22173de0
 +} // namespace WebCore
 +#endif
 diff --git a/Source/WebCore/platform/PlatformScreen.h b/Source/WebCore/platform/PlatformScreen.h
-index bb5411ad58c4ea427837dc7ffeb8687d51e79061..0bc31619d5f8ce268cfbe8b4ee54f8c5d7903aa5 100644
+index bb5411ad58c4..0bc31619d5f8 100644
 --- a/Source/WebCore/platform/PlatformScreen.h
 +++ b/Source/WebCore/platform/PlatformScreen.h
 @@ -146,12 +146,14 @@ WEBCORE_EXPORT float screenScaleFactor(UIScreen * = nullptr);
@@ -6817,7 +6819,7 @@ index bb5411ad58c4ea427837dc7ffeb8687d51e79061..0bc31619d5f8ce268cfbe8b4ee54f8c5
  #endif
  
 diff --git a/Source/WebCore/platform/ScrollableArea.h b/Source/WebCore/platform/ScrollableArea.h
-index e27e01cc803431a185f6d1b45538a5c4e5f73383..9fe6ac53e7aec2d2a882ee91a9b80834c586e065 100644
+index 959e8f82f065..557632002250 100644
 --- a/Source/WebCore/platform/ScrollableArea.h
 +++ b/Source/WebCore/platform/ScrollableArea.h
 @@ -103,7 +103,7 @@ public:
@@ -6830,7 +6832,7 @@ index e27e01cc803431a185f6d1b45538a5c4e5f73383..9fe6ac53e7aec2d2a882ee91a9b80834
  
  #if PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebCore/platform/graphics/FontCascade.h b/Source/WebCore/platform/graphics/FontCascade.h
-index 6dade9146fe99078ac1a58b28cf0c5dd0c351095..16a641f4237a8a3a7a40461e3429551f7ca96203 100644
+index 6dade9146fe9..16a641f4237a 100644
 --- a/Source/WebCore/platform/graphics/FontCascade.h
 +++ b/Source/WebCore/platform/graphics/FontCascade.h
 @@ -283,7 +283,8 @@ private:
@@ -6844,7 +6846,7 @@ index 6dade9146fe99078ac1a58b28cf0c5dd0c351095..16a641f4237a8a3a7a40461e3429551f
  #else
          return false;
 diff --git a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
-index 4db603a94f3af1b1bce94ab0f1ae36054c004fcc..c1820f48eb86348f8ca678fde636244e8c91267e 100644
+index 4db603a94f3a..c1820f48eb86 100644
 --- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
 +++ b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
 @@ -48,6 +48,13 @@
@@ -6939,7 +6941,7 @@ index 4db603a94f3af1b1bce94ab0f1ae36054c004fcc..c1820f48eb86348f8ca678fde636244e
      if (!image || !encodeImage(image, mimeType, &encodedImage))
          return { };
 diff --git a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
-index eac8346d3e177f87792fb0a8fc9dd0fb3b2f6efc..2ddd1dc810033a7f60f17ba555813f1b529d71f7 100644
+index eac8346d3e17..2ddd1dc81003 100644
 --- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
 +++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
 @@ -36,10 +36,10 @@ class PixelBuffer;
@@ -6956,7 +6958,7 @@ index eac8346d3e177f87792fb0a8fc9dd0fb3b2f6efc..2ddd1dc810033a7f60f17ba555813f1b
  
  String dataURL(CGImageRef, CFStringRef destinationUTI, const String& mimeType, std::optional<double> quality);
 diff --git a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
-index 2e46b61536c835dfcacf9f79e10e6d59ae7a3836..fa0c72d80d83c58a8407e78988de010fe97d7c38 100644
+index 2e46b61536c8..fa0c72d80d83 100644
 --- a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
 +++ b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
 @@ -27,7 +27,7 @@
@@ -6969,7 +6971,7 @@ index 2e46b61536c835dfcacf9f79e10e6d59ae7a3836..fa0c72d80d83c58a8407e78988de010f
  #include "ExtensionsGLOpenGL.h"
  #include "IntRect.h"
 diff --git a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
-index 774a52a28693bc51dde10a0875ea379afb06fd3c..cd714a7298fe4f5d2c9b580697a5c4cd22d25870 100644
+index 774a52a28693..cd714a7298fe 100644
 --- a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
 +++ b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
 @@ -172,6 +172,33 @@ static Vector<unsigned> stringIndicesFromClusters(const Vector<WORD>& clusters,
@@ -7016,7 +7018,7 @@ index 774a52a28693bc51dde10a0875ea379afb06fd3c..cd714a7298fe4f5d2c9b580697a5c4cd
          // Determine the string for this item.
          const UChar* str = cp + items[i].iCharPos;
 diff --git a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
-index 0516e70973e0078de6ad0216375d34dd9ef51a8d..ffd9a02deb5518e0c8c77b156815c11eb4b16829 100644
+index 0516e70973e0..ffd9a02deb55 100644
 --- a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
 +++ b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
 @@ -37,8 +37,10 @@
@@ -7278,7 +7280,7 @@ index 0516e70973e0078de6ad0216375d34dd9ef51a8d..ffd9a02deb5518e0c8c77b156815c11e
  {
      switch (val) {
 diff --git a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
-index 7a3b4723f48c179864b2dd6d5b1ed8d27492358e..a741751acad01f11d7da0f6896eeb0023b9a3fcc 100644
+index 7a3b4723f48c..a741751acad0 100644
 --- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
 +++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
 @@ -224,7 +224,7 @@ bool screenSupportsExtendedColor(Widget*)
@@ -7300,7 +7302,7 @@ index 7a3b4723f48c179864b2dd6d5b1ed8d27492358e..a741751acad01f11d7da0f6896eeb002
      auto* display = gdk_display_get_default();
      if (!display)
 diff --git a/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp b/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
-index f4c905dc15a2183629b0e9817dc24135e0ff7fe5..e9925e7a9fc3cbf5fefffaf38f409fbeec189cb0 100644
+index f4c905dc15a2..e9925e7a9fc3 100644
 --- a/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
 +++ b/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
 @@ -32,6 +32,10 @@
@@ -7429,7 +7431,7 @@ index f4c905dc15a2183629b0e9817dc24135e0ff7fe5..e9925e7a9fc3cbf5fefffaf38f409fbe
  
  #endif // USE(LIBWPE)
 diff --git a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
-index a34dc220bbb9a92b40dfb463e8724e81ac745b2c..8ecedd5dae88469366a619b96960598c1232a32d 100644
+index a34dc220bbb9..8ecedd5dae88 100644
 --- a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
 +++ b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
 @@ -30,8 +30,10 @@
@@ -7691,7 +7693,7 @@ index a34dc220bbb9a92b40dfb463e8724e81ac745b2c..8ecedd5dae88469366a619b96960598c
  {
      switch (val) {
 diff --git a/Source/WebCore/platform/network/HTTPHeaderMap.cpp b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
-index 39cb560e54bf9efd2dad6e1fb60dd0f609daf6bf..91c132460d4b466f61a8c579f70329fdde3b130f 100644
+index 39cb560e54bf..91c132460d4b 100644
 --- a/Source/WebCore/platform/network/HTTPHeaderMap.cpp
 +++ b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
 @@ -205,8 +205,11 @@ void HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
@@ -7708,7 +7710,7 @@ index 39cb560e54bf9efd2dad6e1fb60dd0f609daf6bf..91c132460d4b466f61a8c579f70329fd
          m_commonHeaders.append(CommonHeader { name, value });
  }
 diff --git a/Source/WebCore/platform/network/ResourceResponseBase.h b/Source/WebCore/platform/network/ResourceResponseBase.h
-index f5c0970b031a2e9e2a176af81e6cf510ace4cb4a..713ade70c5bec341613bb0b5997c5c64382f41e3 100644
+index f5c0970b031a..713ade70c5be 100644
 --- a/Source/WebCore/platform/network/ResourceResponseBase.h
 +++ b/Source/WebCore/platform/network/ResourceResponseBase.h
 @@ -217,6 +217,8 @@ public:
@@ -7742,7 +7744,7 @@ index f5c0970b031a2e9e2a176af81e6cf510ace4cb4a..713ade70c5bec341613bb0b5997c5c64
      if constexpr (Decoder::isIPCDecoder) {
          std::optional<Box<NetworkLoadMetrics>> networkLoadMetrics;
 diff --git a/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h b/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h
-index 7330aa933924791f1292c0847921e3b367493d96..a5238a748d1fb4bfa5b3e0882fe62f4029f84e5f 100644
+index 7330aa933924..a5238a748d1f 100644
 --- a/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h
 +++ b/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h
 @@ -47,7 +47,7 @@ class SocketStreamHandleClient;
@@ -7772,7 +7774,7 @@ index 7330aa933924791f1292c0847921e3b367493d96..a5238a748d1fb4bfa5b3e0882fe62f40
      StreamBuffer<uint8_t, 1024 * 1024> m_buffer;
      static const unsigned maxBufferSize = 100 * 1024 * 1024;
 diff --git a/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp b/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
-index d1379498aab81ee2ca7aa089b1b50f995c282947..7ad34577cf2dfb36e4eb369fd5060c53eebae71d 100644
+index 55b9f1ed4a0d..2279824540b8 100644
 --- a/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
 +++ b/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
 @@ -96,7 +96,7 @@ static inline auto callbacksRunLoopMode()
@@ -7802,7 +7804,7 @@ index d1379498aab81ee2ca7aa089b1b50f995c282947..7ad34577cf2dfb36e4eb369fd5060c53
              kCFStreamSSLPeerName,
              kCFStreamSSLLevel,
 diff --git a/Source/WebCore/platform/network/curl/CookieJarDB.h b/Source/WebCore/platform/network/curl/CookieJarDB.h
-index c4eb67d6f7c334076b32b798dcea40b570681e6f..ce86ab28225aa466350671441294f2ace8851bbd 100644
+index c4eb67d6f7c3..ce86ab28225a 100644
 --- a/Source/WebCore/platform/network/curl/CookieJarDB.h
 +++ b/Source/WebCore/platform/network/curl/CookieJarDB.h
 @@ -72,7 +72,7 @@ public:
@@ -7814,23 +7816,8 @@ index c4eb67d6f7c334076b32b798dcea40b570681e6f..ce86ab28225aa466350671441294f2ac
      String m_databasePath;
  
      bool m_detectedDatabaseCorruption { false };
-diff --git a/Source/WebCore/platform/network/curl/CurlContext.cpp b/Source/WebCore/platform/network/curl/CurlContext.cpp
-index 8ed09b2abc5d647fab6dc01b98616e153f678b4e..6f2dd5cfcb8fd48985b92c783608011ca98bcabc 100644
---- a/Source/WebCore/platform/network/curl/CurlContext.cpp
-+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
-@@ -793,6 +793,10 @@ std::optional<NetworkLoadMetrics> CurlHandle::getNetworkLoadMetrics(MonotonicTim
- 
-     NetworkLoadMetrics networkLoadMetrics;
- 
-+    // Playwright begin
-+    // FIXME: workaround for https://bugs.webkit.org/show_bug.cgi?id=226901
-+    networkLoadMetrics.fetchStart = startTime;
-+    // Playwright end
-     networkLoadMetrics.domainLookupStart = startTime;
-     networkLoadMetrics.domainLookupEnd = startTime + Seconds(nameLookup);
-     networkLoadMetrics.connectStart = networkLoadMetrics.domainLookupEnd;
 diff --git a/Source/WebCore/platform/network/curl/CurlStream.cpp b/Source/WebCore/platform/network/curl/CurlStream.cpp
-index ff55d352342786fcdeaefc64f6ccbe015f4c5b5f..37a657851d84c3693c1e31239a19d9edd935d039 100644
+index ff55d3523427..37a657851d84 100644
 --- a/Source/WebCore/platform/network/curl/CurlStream.cpp
 +++ b/Source/WebCore/platform/network/curl/CurlStream.cpp
 @@ -33,7 +33,7 @@
@@ -7853,7 +7840,7 @@ index ff55d352342786fcdeaefc64f6ccbe015f4c5b5f..37a657851d84c3693c1e31239a19d9ed
      auto errorCode = m_curlHandle->perform();
      if (errorCode != CURLE_OK) {
 diff --git a/Source/WebCore/platform/network/curl/CurlStream.h b/Source/WebCore/platform/network/curl/CurlStream.h
-index e64629fc22a2097a2af0b0c0139b23d7908cf3dc..920a8c12c6c69afc5aec6de12e9f5fba312237a0 100644
+index e64629fc22a2..920a8c12c6c6 100644
 --- a/Source/WebCore/platform/network/curl/CurlStream.h
 +++ b/Source/WebCore/platform/network/curl/CurlStream.h
 @@ -50,12 +50,12 @@ public:
@@ -7873,7 +7860,7 @@ index e64629fc22a2097a2af0b0c0139b23d7908cf3dc..920a8c12c6c69afc5aec6de12e9f5fba
  
      void send(UniqueArray<uint8_t>&&, size_t);
 diff --git a/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp b/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
-index b4a9abd45307e14b1b0080c5fd8490acaf7bb599..d750af7d2e6e25b9df9fada78ae1fe3767066fbb 100644
+index b4a9abd45307..d750af7d2e6e 100644
 --- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
 +++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
 @@ -40,7 +40,7 @@ CurlStreamScheduler::~CurlStreamScheduler()
@@ -7897,7 +7884,7 @@ index b4a9abd45307e14b1b0080c5fd8490acaf7bb599..d750af7d2e6e25b9df9fada78ae1fe37
  
      return streamID;
 diff --git a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
-index 7d881206c9689f433227969c9b7f9ff268bdaaed..2e8118f11f87fa5f32adcedc165aec8220b36d58 100644
+index 7d881206c968..2e8118f11f87 100644
 --- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
 +++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
 @@ -38,7 +38,7 @@ public:
@@ -7910,7 +7897,7 @@ index 7d881206c9689f433227969c9b7f9ff268bdaaed..2e8118f11f87fa5f32adcedc165aec82
      void send(CurlStreamID, UniqueArray<uint8_t>&&, size_t);
  
 diff --git a/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h b/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h
-index b804fde0973bbfb28331cf7c3a1f20b043e74fe8..af3005261593b5fa91484c98c43d021227716231 100644
+index b804fde0973b..af3005261593 100644
 --- a/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h
 +++ b/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h
 @@ -44,7 +44,7 @@ class StorageSessionProvider;
@@ -7932,7 +7919,7 @@ index b804fde0973bbfb28331cf7c3a1f20b043e74fe8..af3005261593b5fa91484c98c43d0212
      size_t bufferedAmount() final;
      std::optional<size_t> platformSendInternal(const uint8_t*, size_t);
 diff --git a/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp b/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp
-index 4b9491c11543f2b60f12d36e9e6a0cbaae34a72e..e907fc00a2a426384ce1e471847911c9ba1739af 100644
+index 4b9491c11543..e907fc00a2a4 100644
 --- a/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp
 +++ b/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp
 @@ -43,7 +43,7 @@
@@ -7954,7 +7941,7 @@ index 4b9491c11543f2b60f12d36e9e6a0cbaae34a72e..e907fc00a2a426384ce1e471847911c9
  
  SocketStreamHandleImpl::~SocketStreamHandleImpl()
 diff --git a/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h b/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h
-index 88df3748e980a22e71bd835864caf24b6b7ea50b..f83c7f2535fd1abae7b1cccca946254b9407f86f 100644
+index 88df3748e980..f83c7f2535fd 100644
 --- a/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h
 +++ b/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h
 @@ -47,7 +47,7 @@ class StorageSessionProvider;
@@ -7967,7 +7954,7 @@ index 88df3748e980a22e71bd835864caf24b6b7ea50b..f83c7f2535fd1abae7b1cccca946254b
          RELEASE_ASSERT_NOT_REACHED();
      }
 diff --git a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
-index 3e97e804e115e0e37814ddf670e9e3ba4b3bbc73..86a1b22913c9ed6563f0d56c7ebd74c16dc829b9 100644
+index 3e97e804e115..86a1b22913c9 100644
 --- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
 +++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
 @@ -38,6 +38,7 @@
@@ -7991,7 +7978,7 @@ index 3e97e804e115e0e37814ddf670e9e3ba4b3bbc73..86a1b22913c9ed6563f0d56c7ebd74c1
      ReleaseStgMedium(&store);
  }
 diff --git a/Source/WebCore/platform/win/ClipboardUtilitiesWin.h b/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
-index c50799b63e05adbe32bae3535d786c7d268f980f..9cf1cc7ec4eaae22947f80ba272dfae272167bd6 100644
+index c50799b63e05..9cf1cc7ec4ea 100644
 --- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
 +++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
 @@ -34,6 +34,7 @@ namespace WebCore {
@@ -8003,7 +7990,7 @@ index c50799b63e05adbe32bae3535d786c7d268f980f..9cf1cc7ec4eaae22947f80ba272dfae2
  HGLOBAL createGlobalData(const String&);
  HGLOBAL createGlobalData(const Vector<char>&);
 diff --git a/Source/WebCore/platform/win/DragDataWin.cpp b/Source/WebCore/platform/win/DragDataWin.cpp
-index 579a112579af39fc12ef024979d81fc55af36c2b..82c566c9d2ced02a92902a90e7ff97c142fa1903 100644
+index 579a112579af..82c566c9d2ce 100644
 --- a/Source/WebCore/platform/win/DragDataWin.cpp
 +++ b/Source/WebCore/platform/win/DragDataWin.cpp
 @@ -48,6 +48,7 @@ DragData::DragData(const DragDataMap& data, const IntPoint& clientPosition, cons
@@ -8015,7 +8002,7 @@ index 579a112579af39fc12ef024979d81fc55af36c2b..82c566c9d2ced02a92902a90e7ff97c1
  }
  
 diff --git a/Source/WebCore/platform/win/KeyEventWin.cpp b/Source/WebCore/platform/win/KeyEventWin.cpp
-index aae6c99dd052985a43718846b68536454050c234..7e2e5d0c1de90f1454f7fdb71a40ab71228dcbe9 100644
+index aae6c99dd052..7e2e5d0c1de9 100644
 --- a/Source/WebCore/platform/win/KeyEventWin.cpp
 +++ b/Source/WebCore/platform/win/KeyEventWin.cpp
 @@ -239,10 +239,16 @@ PlatformKeyboardEvent::PlatformKeyboardEvent(HWND, WPARAM code, LPARAM keyData,
@@ -8039,7 +8026,7 @@ index aae6c99dd052985a43718846b68536454050c234..7e2e5d0c1de90f1454f7fdb71a40ab71
  
  bool PlatformKeyboardEvent::currentCapsLockState()
 diff --git a/Source/WebCore/platform/win/PasteboardWin.cpp b/Source/WebCore/platform/win/PasteboardWin.cpp
-index 9e3357b20e60f47829ced8d2849f5d8c9a7bb50a..be6579859e80c846235b7f94f2ec7551078c9fdd 100644
+index 9e3357b20e60..be6579859e80 100644
 --- a/Source/WebCore/platform/win/PasteboardWin.cpp
 +++ b/Source/WebCore/platform/win/PasteboardWin.cpp
 @@ -1134,7 +1134,21 @@ void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
@@ -8092,7 +8079,7 @@ index 9e3357b20e60f47829ced8d2849f5d8c9a7bb50a..be6579859e80c846235b7f94f2ec7551
  } // namespace WebCore
 diff --git a/Source/WebCore/platform/wpe/DragDataWPE.cpp b/Source/WebCore/platform/wpe/DragDataWPE.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..07fb260a5203167fdf94a552949394bb73ca8c61
+index 000000000000..07fb260a5203
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/DragDataWPE.cpp
 @@ -0,0 +1,87 @@
@@ -8185,7 +8172,7 @@ index 0000000000000000000000000000000000000000..07fb260a5203167fdf94a552949394bb
 +}
 diff --git a/Source/WebCore/platform/wpe/DragImageWPE.cpp b/Source/WebCore/platform/wpe/DragImageWPE.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..0c684ea504c0c93895ab75a880b4d2febc946813
+index 000000000000..0c684ea504c0
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/DragImageWPE.cpp
 @@ -0,0 +1,68 @@
@@ -8258,7 +8245,7 @@ index 0000000000000000000000000000000000000000..0c684ea504c0c93895ab75a880b4d2fe
 +
 +}
 diff --git a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
-index bbdd1ce76241d933ada9c43fabae4912cbfa64e1..e6ae01a77350c519b203f6ed2910f63871b9b829 100644
+index bbdd1ce76241..e6ae01a77350 100644
 --- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
 +++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
 @@ -93,12 +93,12 @@ bool screenSupportsExtendedColor(Widget*)
@@ -8278,7 +8265,7 @@ index bbdd1ce76241d933ada9c43fabae4912cbfa64e1..e6ae01a77350c519b203f6ed2910f638
  }
 diff --git a/Source/WebCore/platform/wpe/SelectionData.cpp b/Source/WebCore/platform/wpe/SelectionData.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..9f181fdfe507ad5b7a47b5c58295cf4f2725e7d8
+index 000000000000..9f181fdfe507
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/SelectionData.cpp
 @@ -0,0 +1,134 @@
@@ -8418,7 +8405,7 @@ index 0000000000000000000000000000000000000000..9f181fdfe507ad5b7a47b5c58295cf4f
 +} // namespace WebCore
 diff --git a/Source/WebCore/platform/wpe/SelectionData.h b/Source/WebCore/platform/wpe/SelectionData.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..cf2b51f6f02837a1106f4d999f2f130e2580986a
+index 000000000000..cf2b51f6f028
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/SelectionData.h
 @@ -0,0 +1,82 @@
@@ -8505,7 +8492,7 @@ index 0000000000000000000000000000000000000000..cf2b51f6f02837a1106f4d999f2f130e
 +
 +} // namespace WebCore
 diff --git a/Source/WebCore/rendering/RenderLayer.cpp b/Source/WebCore/rendering/RenderLayer.cpp
-index 1f11a978e315badd7acc823b71d7d85088f03ef3..085492154fba257f37521c765564ac49b7669474 100644
+index 99c70209c462..0a069c3e6ee7 100644
 --- a/Source/WebCore/rendering/RenderLayer.cpp
 +++ b/Source/WebCore/rendering/RenderLayer.cpp
 @@ -2560,7 +2560,7 @@ LayoutRect RenderLayer::getRectToExpose(const LayoutRect& visibleRect, const Lay
@@ -8518,7 +8505,7 @@ index 1f11a978e315badd7acc823b71d7d85088f03ef3..085492154fba257f37521c765564ac49
          // If the rectangle is partially visible, but over a certain threshold,
          // then treat it as fully visible to avoid unnecessary horizontal scrolling
 diff --git a/Source/WebCore/rendering/RenderTextControl.cpp b/Source/WebCore/rendering/RenderTextControl.cpp
-index 242aca3a06b91574a748b13ecefa80c6172b9c59..4dcd61750471013be4455b0270a8a21a7b489d47 100644
+index 242aca3a06b9..4dcd61750471 100644
 --- a/Source/WebCore/rendering/RenderTextControl.cpp
 +++ b/Source/WebCore/rendering/RenderTextControl.cpp
 @@ -207,13 +207,13 @@ void RenderTextControl::layoutExcludedChildren(bool relayoutChildren)
@@ -8537,7 +8524,7 @@ index 242aca3a06b91574a748b13ecefa80c6172b9c59..4dcd61750471013be4455b0270a8a21a
  {
      auto innerText = innerTextElement();
 diff --git a/Source/WebCore/rendering/RenderTextControl.h b/Source/WebCore/rendering/RenderTextControl.h
-index 2e90534ffd8da83b7dc54d46fa7def16319bbb43..2493c00d58957751c65c37eb409fa8d675efd5ca 100644
+index 2e90534ffd8d..2493c00d5895 100644
 --- a/Source/WebCore/rendering/RenderTextControl.h
 +++ b/Source/WebCore/rendering/RenderTextControl.h
 @@ -36,9 +36,9 @@ public:
@@ -8552,7 +8539,7 @@ index 2e90534ffd8da83b7dc54d46fa7def16319bbb43..2493c00d58957751c65c37eb409fa8d6
      int innerLineHeight() const override;
  #endif
 diff --git a/Source/WebCore/rendering/ScrollAlignment.h b/Source/WebCore/rendering/ScrollAlignment.h
-index 694008e0451edc5770142a0a6d9eed52b04ded80..ec93869f9486bdf7bd3bb56478c62469d2fa58b6 100644
+index 694008e0451e..ec93869f9486 100644
 --- a/Source/WebCore/rendering/ScrollAlignment.h
 +++ b/Source/WebCore/rendering/ScrollAlignment.h
 @@ -78,6 +78,7 @@ struct ScrollAlignment {
@@ -8564,7 +8551,7 @@ index 694008e0451edc5770142a0a6d9eed52b04ded80..ec93869f9486bdf7bd3bb56478c62469
      
  WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollAlignment::Behavior);
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
-index 2d19190a3470dfb523585f22f7f465050df33929..2595f7ddf6e1cf0c2013e92f6298e0573fbde005 100644
+index a8216b6ca250..9e972fdbff35 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 @@ -74,6 +74,11 @@
@@ -8579,7 +8566,7 @@ index 2d19190a3470dfb523585f22f7f465050df33929..2595f7ddf6e1cf0c2013e92f6298e057
  #if ENABLE(APPLE_PAY_REMOTE_UI)
  #include "WebPaymentCoordinatorProxyMessages.h"
  #endif
-@@ -904,6 +909,15 @@ void NetworkConnectionToWebProcess::clearPageSpecificData(PageIdentifier pageID)
+@@ -903,6 +908,15 @@ void NetworkConnectionToWebProcess::clearPageSpecificData(PageIdentifier pageID)
  #endif
  }
  
@@ -8596,7 +8583,7 @@ index 2d19190a3470dfb523585f22f7f465050df33929..2595f7ddf6e1cf0c2013e92f6298e057
  void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier frameID, PageIdentifier pageID)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
-index 30b8dae1b63f62af7077d9566cb1cfc6fed7da5c..47f7e34d87c36226a0244f38d7456853da90860d 100644
+index 30b8dae1b63f..47f7e34d87c3 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 @@ -285,6 +285,8 @@ private:
@@ -8609,7 +8596,7 @@ index 30b8dae1b63f62af7077d9566cb1cfc6fed7da5c..47f7e34d87c36226a0244f38d7456853
      void removeStorageAccessForFrame(WebCore::FrameIdentifier, WebCore::PageIdentifier);
  
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
-index 063ee6a461bb68ebde70c6f9ee4e83961d03354b..d7db79273b77296864150d1bc00363291c343947 100644
+index 063ee6a461bb..d7db79273b77 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 @@ -64,6 +64,8 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
@@ -8622,7 +8609,7 @@ index 063ee6a461bb68ebde70c6f9ee4e83961d03354b..d7db79273b77296864150d1bc0036329
      RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
      LogUserInteraction(WebCore::RegistrableDomain domain)
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.cpp b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
-index b9819db9d18967bed0c488b46380618447beb680..705312588f364aca63fffac2b8f1c4fa1cdb2495 100644
+index 49bdd3fec681..5a47aa54e4bb 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 @@ -26,7 +26,6 @@
@@ -8694,7 +8681,7 @@ index b9819db9d18967bed0c488b46380618447beb680..705312588f364aca63fffac2b8f1c4fa
  void NetworkProcess::dumpResourceLoadStatistics(PAL::SessionID sessionID, CompletionHandler<void(String)>&& completionHandler)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.h b/Source/WebKit/NetworkProcess/NetworkProcess.h
-index e9a21b0831c73b3ea4994c6b9880ad543edfff75..464f532911f04fe96bf91c7058f16d6e131bd5a2 100644
+index 447784b1a783..9aad05a798d0 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
 @@ -34,6 +34,7 @@
@@ -8729,7 +8716,7 @@ index e9a21b0831c73b3ea4994c6b9880ad543edfff75..464f532911f04fe96bf91c7058f16d6e
      void clearPrevalentResource(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
      void clearUserInteraction(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
-index ae15ff0e12ca545178907d972a09ce6d2321a2d4..4ee782cbb1e4ce8228785f63fa1ca868276a2be9 100644
+index ae15ff0e12ca..4ee782cbb1e4 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 @@ -79,6 +79,14 @@ messages -> NetworkProcess LegacyReceiver {
@@ -8748,7 +8735,7 @@ index ae15ff0e12ca545178907d972a09ce6d2321a2d4..4ee782cbb1e4ce8228785f63fa1ca868
      ClearPrevalentResource(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> () Async
      ClearUserInteraction(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> () Async
 diff --git a/Source/WebKit/NetworkProcess/NetworkSession.h b/Source/WebKit/NetworkProcess/NetworkSession.h
-index 7fa92744f2152dc363015b8ac2d82650435dcb24..4208e0e69d15886843517d795a366d798b666d5a 100644
+index 7fa92744f215..4208e0e69d15 100644
 --- a/Source/WebKit/NetworkProcess/NetworkSession.h
 +++ b/Source/WebKit/NetworkProcess/NetworkSession.h
 @@ -152,6 +152,9 @@ public:
@@ -8770,7 +8757,7 @@ index 7fa92744f2152dc363015b8ac2d82650435dcb24..4208e0e69d15886843517d795a366d79
      HashSet<Ref<NetworkResourceLoader>> m_keptAliveLoads;
  
 diff --git a/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp b/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp
-index 52eb5b08f16cba232149028cdaa8150ad04e4a9f..1f541ccfbe183ee152cea69108b80ffd3b1ff34f 100644
+index 52eb5b08f16c..1f541ccfbe18 100644
 --- a/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp
 @@ -43,7 +43,7 @@ Ref<NetworkSocketStream> NetworkSocketStream::create(NetworkProcess& networkProc
@@ -8783,7 +8770,7 @@ index 52eb5b08f16cba232149028cdaa8150ad04e4a9f..1f541ccfbe183ee152cea69108b80ffd
  {
  }
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp
-index 60153bf7d6b07f58e0ea1595a14fc8c81353c149..5c0907b31551b576aeed1e9d26f4f5bcce055ec2 100644
+index 60153bf7d6b0..5c0907b31551 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp
 @@ -29,6 +29,7 @@
@@ -8807,7 +8794,7 @@ index 60153bf7d6b07f58e0ea1595a14fc8c81353c149..5c0907b31551b576aeed1e9d26f4f5bc
 +
  } // namespace WebKit
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h
-index adca9f4a255f58e2106dd6a4eceaddfff2451ac3..81f6c0bde82ea58ed5abc5e3653bb64a3377f531 100644
+index adca9f4a255f..81f6c0bde82e 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h
 @@ -28,7 +28,7 @@
@@ -8829,7 +8816,7 @@ index adca9f4a255f58e2106dd6a4eceaddfff2451ac3..81f6c0bde82ea58ed5abc5e3653bb64a
      StorageManager& m_storageManager;
      unsigned m_quotaInBytes { 0 };
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp
-index ea84823ce2fef556a8db955737ddb3cb914cf198..2d3c01099e322ad863beacf746aab685097decc9 100644
+index 83194b05fb4e..9c9357eb7466 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp
 @@ -111,6 +111,18 @@ void StorageArea::setItem(IPC::Connection::UniqueID sourceConnection, StorageAre
@@ -8852,7 +8839,7 @@ index ea84823ce2fef556a8db955737ddb3cb914cf198..2d3c01099e322ad863beacf746aab685
  {
      ASSERT(!RunLoop::isMain());
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h
-index b9ccae3481578510ef8b4abdf95b4e051b88b8d0..8c193855fd45d1e4004b88265b235a6eecf0b366 100644
+index 9c715702dbe6..9174bb3f38b6 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h
 @@ -64,6 +64,7 @@ public:
@@ -8864,7 +8851,7 @@ index b9ccae3481578510ef8b4abdf95b4e051b88b8d0..8c193855fd45d1e4004b88265b235a6e
      void clear();
  
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
-index 5bcca299ba415e39c02845997e5806b2846da93c..a7526a2adbd93ecb3e16a9b8b8f754152c79f2d4 100644
+index 5bcca299ba41..a7526a2adbd9 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
 @@ -147,6 +147,19 @@ HashSet<SecurityOriginData> StorageManager::getLocalStorageOriginsCrossThreadCop
@@ -8888,7 +8875,7 @@ index 5bcca299ba415e39c02845997e5806b2846da93c..a7526a2adbd93ecb3e16a9b8b8f75415
  {
      ASSERT(!RunLoop::isMain());
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
-index 0d6e7aedff68227bf7dc8ab7184abc6fd3321c54..67b616d818aa42f8cae33f0535c888cd4c5ec07e 100644
+index 0d6e7aedff68..67b616d818aa 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
 @@ -66,6 +66,7 @@ public:
@@ -8900,10 +8887,10 @@ index 0d6e7aedff68227bf7dc8ab7184abc6fd3321c54..67b616d818aa42f8cae33f0535c888cd
      void deleteLocalStorageEntriesForOrigins(const Vector<WebCore::SecurityOriginData>&);
      Vector<LocalStorageDatabaseTracker::OriginDetails> getLocalStorageOriginDetailsCrossThreadCopy() const;
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
-index 4655487a6ecd300c413c1aa5613bdffb48ce8da6..be373d5fc9dda9f53401dec4976bed599c011bb5 100644
+index 61d0b3c77ce5..0ddfcc2014f3 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
-@@ -253,6 +253,50 @@ void StorageManagerSet::getLocalStorageOrigins(PAL::SessionID sessionID, GetOrig
+@@ -262,6 +262,50 @@ void StorageManagerSet::getLocalStorageOrigins(PAL::SessionID sessionID, GetOrig
      });
  }
  
@@ -8955,7 +8942,7 @@ index 4655487a6ecd300c413c1aa5613bdffb48ce8da6..be373d5fc9dda9f53401dec4976bed59
  {
      ASSERT(RunLoop::isMain());
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
-index 4243f32573bdad1452107f55c82328961cd5b0d4..023416d6e453431167441504ea38b3b2f19330fd 100644
+index 4243f32573bd..023416d6e453 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
 @@ -45,6 +45,7 @@ using ConnectToStorageAreaCallback = CompletionHandler<void(const std::optional<
@@ -8976,12 +8963,12 @@ index 4243f32573bdad1452107f55c82328961cd5b0d4..023416d6e453431167441504ea38b3b2
  
      void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
-index fad248e93946873c269bd98ad434ca74218004a3..04113bce857b400c24f80ba6366511b94f8a10f1 100644
+index 4ebbd90cc645..3d5d56a5a1b4 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
-@@ -84,6 +84,8 @@ public:
-     void setH2PingCallback(const URL&, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&&) override;
-     void setPriority(WebCore::ResourceLoadPriority) override;
+@@ -86,6 +86,8 @@ public:
+ 
+     void checkTAO(const WebCore::ResourceResponse&);
  
 +    static void setCookieFromResponse(NetworkSessionCocoa& session, const NetworkLoadParameters&, const URL& mainDocumentURL, const String& setCookieValue);
 +
@@ -8989,19 +8976,19 @@ index fad248e93946873c269bd98ad434ca74218004a3..04113bce857b400c24f80ba6366511b9
      NetworkDataTaskCocoa(NetworkSession&, NetworkDataTaskClient&, const NetworkLoadParameters&);
  
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
-index cfdfe1369ce6a8e5fbe3f6fa41157730294f7323..43a131b2e3617a6421a73a9db38cad3292a9d72a 100644
+index 340d7dac286b..0dfa57520b46 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
-@@ -41,6 +41,7 @@
- #import <WebCore/RegistrableDomain.h>
+@@ -42,6 +42,7 @@
  #import <WebCore/ResourceRequest.h>
+ #import <WebCore/TimingAllowOrigin.h>
  #import <pal/spi/cf/CFNetworkSPI.h>
 +#import <wtf/BlockObjCExceptions.h>
  #import <wtf/BlockPtr.h>
  #import <wtf/FileSystem.h>
  #import <wtf/MainThread.h>
-@@ -719,4 +720,59 @@ void NetworkDataTaskCocoa::setPriority(WebCore::ResourceLoadPriority priority)
-     m_task.get().priority = toNSURLSessionTaskPriority(priority);
+@@ -734,4 +735,59 @@ void NetworkDataTaskCocoa::checkTAO(const WebCore::ResourceResponse& response)
+         networkLoadMetrics().failsTAOCheck = !passesTimingAllowOriginCheck(response, *origin);
  }
  
 +class DummyNetworkDataTaskClient: public NetworkDataTaskClient {
@@ -9061,10 +9048,10 @@ index cfdfe1369ce6a8e5fbe3f6fa41157730294f7323..43a131b2e3617a6421a73a9db38cad32
 +
  }
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-index 355867c2060d68bc933dae07f8a607f1dcec4d03..4eb9f77257ada6d9af38516733fa690cd2ddb740 100644
+index f77ce79491ae..366dd8851191 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-@@ -662,7 +662,7 @@ static inline void processServerTrustEvaluation(NetworkSessionCocoa& session, Se
+@@ -681,7 +681,7 @@ static inline void processServerTrustEvaluation(NetworkSessionCocoa& session, Se
      NegotiatedLegacyTLS negotiatedLegacyTLS = NegotiatedLegacyTLS::No;
  
      if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
@@ -9073,9 +9060,9 @@ index 355867c2060d68bc933dae07f8a607f1dcec4d03..4eb9f77257ada6d9af38516733fa690c
              return completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
  
  #if HAVE(TLS_PROTOCOL_VERSION_T)
-@@ -917,6 +917,13 @@ static inline void processServerTrustEvaluation(NetworkSessionCocoa& session, Se
+@@ -940,6 +940,13 @@ static inline void processServerTrustEvaluation(NetworkSessionCocoa& session, Se
  
-         resourceResponse.setDeprecatedNetworkLoadMetrics(WebCore::copyTimingData(taskMetrics, networkDataTask->networkLoadMetrics().hasCrossOriginRedirect));
+         resourceResponse.setDeprecatedNetworkLoadMetrics(WebCore::copyTimingData(taskMetrics, networkDataTask->networkLoadMetrics()));
  
 +        __block WebCore::HTTPHeaderMap requestHeaders;
 +        NSURLSessionTaskTransactionMetrics *m = dataTask._incompleteTaskMetrics.transactionMetrics.lastObject;
@@ -9088,7 +9075,7 @@ index 355867c2060d68bc933dae07f8a607f1dcec4d03..4eb9f77257ada6d9af38516733fa690c
  #if !LOG_DISABLED
              LOG(NetworkSession, "%llu didReceiveResponse completionHandler (%d)", taskIdentifier, policyAction);
 diff --git a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
-index e9f9b2c257866d9300e79781cbef3addc59cd9de..c45d2f047614da8a5e360b88960fbd2afb16072f 100644
+index e9f9b2c25786..c45d2f047614 100644
 --- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
 +++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
 @@ -26,9 +26,13 @@
@@ -9224,7 +9211,7 @@ index e9f9b2c257866d9300e79781cbef3addc59cd9de..c45d2f047614da8a5e360b88960fbd2a
  
          if (m_state != State::Suspended) {
 diff --git a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
-index 1c427ddb78d6953fe8960c5692afde4f4f0eee85..cf33ff6076dd95ffe564f1dde89c177acd27b02c 100644
+index 1c427ddb78d6..cf33ff6076dd 100644
 --- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
 +++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
 @@ -32,6 +32,7 @@
@@ -9261,7 +9248,7 @@ index 1c427ddb78d6953fe8960c5692afde4f4f0eee85..cf33ff6076dd95ffe564f1dde89c177a
  
      WebCore::ShouldRelaxThirdPartyCookieBlocking m_shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
 diff --git a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
-index 0f37bb4cfbdf348958aa178343b5d7e8d369c44a..274b26410539bddedd3c03fee903e7db89a8c63c 100644
+index 3a71cdccc686..05cb24fc79d5 100644
 --- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 +++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 @@ -483,6 +483,7 @@ void NetworkDataTaskSoup::didSendRequest(GRefPtr<GInputStream>&& inputStream)
@@ -9282,7 +9269,7 @@ index 0f37bb4cfbdf348958aa178343b5d7e8d369c44a..274b26410539bddedd3c03fee903e7db
      if (!error)
          return true;
 diff --git a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
-index 06ca252b043959d457814d45886949a85b1a19c1..597e63aca71d213526d953ead357fbc0e0405f8d 100644
+index 06ca252b0439..597e63aca71d 100644
 --- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
 +++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
 @@ -113,6 +113,11 @@ static gboolean webSocketAcceptCertificateCallback(GTlsConnection* connection, G
@@ -9343,7 +9330,7 @@ index 06ca252b043959d457814d45886949a85b1a19c1..597e63aca71d213526d953ead357fbc0
      }
      return makeUnique<WebSocketTask>(channel, request, soupSession(), soupMessage.get(), protocol);
 diff --git a/Source/WebKit/PlatformGTK.cmake b/Source/WebKit/PlatformGTK.cmake
-index 6cfaf2882a71e787f9819f6f072f43945b24edb5..690729aaeca6a06b960b1034d888e6a1d9ae1fed 100644
+index d679785ca3bd..14de9b9f902d 100644
 --- a/Source/WebKit/PlatformGTK.cmake
 +++ b/Source/WebKit/PlatformGTK.cmake
 @@ -450,6 +450,9 @@ list(APPEND WebKit_SYSTEM_INCLUDE_DIRECTORIES
@@ -9380,7 +9367,7 @@ index 6cfaf2882a71e787f9819f6f072f43945b24edb5..690729aaeca6a06b960b1034d888e6a1
  set(WebKit2GTK_ENUM_GENERATION_HEADERS ${WebKit2GTK_INSTALLED_HEADERS})
  list(REMOVE_ITEM WebKit2GTK_ENUM_GENERATION_HEADERS ${WebKit2Gtk_DERIVED_SOURCES_DIR}/webkit2/WebKitEnumTypes.h)
 diff --git a/Source/WebKit/PlatformWPE.cmake b/Source/WebKit/PlatformWPE.cmake
-index e397c07b7cf7170f4d833997d499b4ac7ffcd898..ba2270f561b90cc54682b77c02c9028552e951fa 100644
+index e397c07b7cf7..ba2270f561b9 100644
 --- a/Source/WebKit/PlatformWPE.cmake
 +++ b/Source/WebKit/PlatformWPE.cmake
 @@ -278,6 +278,7 @@ list(APPEND WebKit_INCLUDE_DIRECTORIES
@@ -9410,7 +9397,7 @@ index e397c07b7cf7170f4d833997d499b4ac7ffcd898..ba2270f561b90cc54682b77c02c90285
      Cairo::Cairo
      Freetype::Freetype
 diff --git a/Source/WebKit/PlatformWin.cmake b/Source/WebKit/PlatformWin.cmake
-index 01565d550697b25367bb36971d6fe5ec33f712f0..98fb300309de1c0567912158f23ab39e7c0e21d5 100644
+index 01565d550697..98fb300309de 100644
 --- a/Source/WebKit/PlatformWin.cmake
 +++ b/Source/WebKit/PlatformWin.cmake
 @@ -69,8 +69,12 @@ list(APPEND WebKit_SOURCES
@@ -9516,7 +9503,7 @@ index 01565d550697b25367bb36971d6fe5ec33f712f0..98fb300309de1c0567912158f23ab39e
  endif ()
  
 diff --git a/Source/WebKit/Shared/API/c/wpe/WebKit.h b/Source/WebKit/Shared/API/c/wpe/WebKit.h
-index caf67e1dece5b727e43eba780e70814f8fdb0f63..740150d2589d6e16a516daa3bf6ef899ac538c99 100644
+index caf67e1dece5..740150d2589d 100644
 --- a/Source/WebKit/Shared/API/c/wpe/WebKit.h
 +++ b/Source/WebKit/Shared/API/c/wpe/WebKit.h
 @@ -77,6 +77,7 @@
@@ -9528,7 +9515,7 @@ index caf67e1dece5b727e43eba780e70814f8fdb0f63..740150d2589d6e16a516daa3bf6ef899
  #include <WebKit/WKContextConfigurationRef.h>
  #include <WebKit/WKCredential.h>
 diff --git a/Source/WebKit/Shared/NativeWebKeyboardEvent.h b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
-index ee8cac1c980039c4a36de5501ab7f135e710d06b..deae2be9e720ff76186ecea89920dfc39c4f186a 100644
+index ee8cac1c9800..deae2be9e720 100644
 --- a/Source/WebKit/Shared/NativeWebKeyboardEvent.h
 +++ b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
 @@ -33,6 +33,7 @@
@@ -9576,7 +9563,7 @@ index ee8cac1c980039c4a36de5501ab7f135e710d06b..deae2be9e720ff76186ecea89920dfc3
  
  #if USE(APPKIT)
 diff --git a/Source/WebKit/Shared/NativeWebMouseEvent.h b/Source/WebKit/Shared/NativeWebMouseEvent.h
-index 001558dd58f4d85f360d5711caa03db33889011e..1e0898f985f1d13036d31e3e284258a3c64fa0a4 100644
+index 001558dd58f4..1e0898f985f1 100644
 --- a/Source/WebKit/Shared/NativeWebMouseEvent.h
 +++ b/Source/WebKit/Shared/NativeWebMouseEvent.h
 @@ -77,6 +77,11 @@ public:
@@ -9592,7 +9579,7 @@ index 001558dd58f4d85f360d5711caa03db33889011e..1e0898f985f1d13036d31e3e284258a3
      NSEvent* nativeEvent() const { return m_nativeEvent.get(); }
  #elif PLATFORM(GTK)
 diff --git a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
-index 91d21d8f236bd18832b50d2cad311cc6f2488cee..6c4caa100f785aa896569f24539467693295746c 100644
+index 91d21d8f236b..6c4caa100f78 100644
 --- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 +++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 @@ -120,6 +120,10 @@
@@ -9684,7 +9671,7 @@ index 91d21d8f236bd18832b50d2cad311cc6f2488cee..6c4caa100f785aa896569f2453946769
      return true;
  }
 diff --git a/Source/WebKit/Shared/WebEvent.h b/Source/WebKit/Shared/WebEvent.h
-index 3ae6504779d3917a79f69f32b58260afeda270b4..72d44c33953cc13bf2ed7c762b4f9a7b88571b56 100644
+index 3ae6504779d3..72d44c33953c 100644
 --- a/Source/WebKit/Shared/WebEvent.h
 +++ b/Source/WebKit/Shared/WebEvent.h
 @@ -31,6 +31,7 @@
@@ -9696,7 +9683,7 @@ index 3ae6504779d3917a79f69f32b58260afeda270b4..72d44c33953cc13bf2ed7c762b4f9a7b
  #include <wtf/text/WTFString.h>
  
 diff --git a/Source/WebKit/Shared/WebKeyboardEvent.cpp b/Source/WebKit/Shared/WebKeyboardEvent.cpp
-index a70eb76c5c22a2c779c30874433ac19036b5f1a4..f97fa9dec785fd6327bb7847454e8a32b8a0d3ac 100644
+index a70eb76c5c22..f97fa9dec785 100644
 --- a/Source/WebKit/Shared/WebKeyboardEvent.cpp
 +++ b/Source/WebKit/Shared/WebKeyboardEvent.cpp
 @@ -35,6 +35,7 @@ WebKeyboardEvent::WebKeyboardEvent()
@@ -9786,7 +9773,7 @@ index a70eb76c5c22a2c779c30874433ac19036b5f1a4..f97fa9dec785fd6327bb7847454e8a32
  {
  }
 diff --git a/Source/WebKit/Shared/WebKeyboardEvent.h b/Source/WebKit/Shared/WebKeyboardEvent.h
-index 7a5893eb68ad24cf92c832070485489b7cfafa0c..a2d68a5eb59d8b7155c1e17b75a12e55f299b868 100644
+index 7a5893eb68ad..a2d68a5eb59d 100644
 --- a/Source/WebKit/Shared/WebKeyboardEvent.h
 +++ b/Source/WebKit/Shared/WebKeyboardEvent.h
 @@ -43,14 +43,18 @@ public:
@@ -9809,7 +9796,7 @@ index 7a5893eb68ad24cf92c832070485489b7cfafa0c..a2d68a5eb59d8b7155c1e17b75a12e55
  
      const String& text() const { return m_text; }
 diff --git a/Source/WebKit/Shared/WebPageCreationParameters.cpp b/Source/WebKit/Shared/WebPageCreationParameters.cpp
-index 9e7b7f2fbda107d1cd900248a5d9b6ac6ba729d6..e0952a57de56fd65b343d5cf6bd8e92730d0fd56 100644
+index 9e7b7f2fbda1..e0952a57de56 100644
 --- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
 +++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
 @@ -156,6 +156,8 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
@@ -9834,7 +9821,7 @@ index 9e7b7f2fbda107d1cd900248a5d9b6ac6ba729d6..e0952a57de56fd65b343d5cf6bd8e927
          return std::nullopt;
  
 diff --git a/Source/WebKit/Shared/WebPageCreationParameters.h b/Source/WebKit/Shared/WebPageCreationParameters.h
-index d5b13d2b0915b48ece9bf6de96e87ba59094efe5..df80ba50ff7e319ef00e2812c3a62c6d4add8f8d 100644
+index d5b13d2b0915..df80ba50ff7e 100644
 --- a/Source/WebKit/Shared/WebPageCreationParameters.h
 +++ b/Source/WebKit/Shared/WebPageCreationParameters.h
 @@ -246,6 +246,8 @@ struct WebPageCreationParameters {
@@ -9847,7 +9834,7 @@ index d5b13d2b0915b48ece9bf6de96e87ba59094efe5..df80ba50ff7e319ef00e2812c3a62c6d
      String themeName;
  #endif
 diff --git a/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp b/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp
-index c204637774ee803eac42a34cde79aa556f143b82..345f5b08179e3dd239725bed06e48b46bc718336 100644
+index c204637774ee..345f5b08179e 100644
 --- a/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp
 +++ b/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp
 @@ -50,7 +50,7 @@ NativeWebKeyboardEvent::NativeWebKeyboardEvent(Type type, const String& text, co
@@ -9860,7 +9847,7 @@ index c204637774ee803eac42a34cde79aa556f143b82..345f5b08179e3dd239725bed06e48b46
  {
  }
 diff --git a/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp b/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
-index 7cc65739c320cb4312d9d705284220a383a0293a..da53885517d55d424423ee3d0dcead25825cc022 100644
+index 7cc65739c320..da53885517d5 100644
 --- a/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
 +++ b/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
 @@ -54,7 +54,7 @@ NativeWebMouseEvent::NativeWebMouseEvent(Type type, Button button, unsigned shor
@@ -9873,7 +9860,7 @@ index 7cc65739c320cb4312d9d705284220a383a0293a..da53885517d55d424423ee3d0dcead25
  {
  }
 diff --git a/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp b/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp
-index 03e118154f6bb5b704b4ecb83d3d9543f8c5a5fa..9725caaac6ee65a96ea324ddbb4e1a3785bbc028 100644
+index 03e118154f6b..9725caaac6ee 100644
 --- a/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp
 +++ b/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp
 @@ -26,7 +26,7 @@
@@ -9892,7 +9879,7 @@ index 03e118154f6bb5b704b4ecb83d3d9543f8c5a5fa..9725caaac6ee65a96ea324ddbb4e1a37
 -#endif // ENABLE(TOUCH_EVENTS)
 +#endif // ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp b/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp
-index e40a6e172bfd2b75076fd4053da643ebab9eb81f..2516655bbc9e5bc863537a554c5faac0f6fc1a09 100644
+index e40a6e172bfd..2516655bbc9e 100644
 --- a/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp
 +++ b/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp
 @@ -26,7 +26,7 @@
@@ -9912,7 +9899,7 @@ index e40a6e172bfd2b75076fd4053da643ebab9eb81f..2516655bbc9e5bc863537a554c5faac0
 +#endif // ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.cpp b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..678010b33d70dae6369ace4337b4c0eb81152250
+index 000000000000..678010b33d70
 --- /dev/null
 +++ b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.cpp
 @@ -0,0 +1,173 @@
@@ -10091,7 +10078,7 @@ index 0000000000000000000000000000000000000000..678010b33d70dae6369ace4337b4c0eb
 +}
 diff --git a/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.h b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..789a0d7cf69704c8f665a9ed79348fbcbc1301c4
+index 000000000000..789a0d7cf697
 --- /dev/null
 +++ b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.h
 @@ -0,0 +1,41 @@
@@ -10137,7 +10124,7 @@ index 0000000000000000000000000000000000000000..789a0d7cf69704c8f665a9ed79348fbc
 +
 +} // namespace IPC
 diff --git a/Source/WebKit/Shared/win/WebEventFactory.cpp b/Source/WebKit/Shared/win/WebEventFactory.cpp
-index 85d6f74114f4e7f82d9502d1b99d69098d6a49b6..6896c9756edb233dda46c7031e1af69923da8c23 100644
+index 85d6f74114f4..6896c9756edb 100644
 --- a/Source/WebKit/Shared/win/WebEventFactory.cpp
 +++ b/Source/WebKit/Shared/win/WebEventFactory.cpp
 @@ -473,7 +473,7 @@ WebKeyboardEvent WebEventFactory::createWebKeyboardEvent(HWND hwnd, UINT message
@@ -10150,10 +10137,10 @@ index 85d6f74114f4e7f82d9502d1b99d69098d6a49b6..6896c9756edb233dda46c7031e1af699
      return WebTouchEvent();
  }
 diff --git a/Source/WebKit/Sources.txt b/Source/WebKit/Sources.txt
-index 3b86cf5d9b54cae7390bd13a6507b36729ebd626..98a6b7fb057e9fe8816c0ecd9058ba763e973eb8 100644
+index 92e147b8f3b0..09d4f0d322d8 100644
 --- a/Source/WebKit/Sources.txt
 +++ b/Source/WebKit/Sources.txt
-@@ -290,11 +290,14 @@ Shared/WebsiteData/WebsiteData.cpp
+@@ -291,11 +291,14 @@ Shared/WebsiteData/WebsiteData.cpp
  
  UIProcess/AuxiliaryProcessProxy.cpp
  UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -10168,7 +10155,7 @@ index 3b86cf5d9b54cae7390bd13a6507b36729ebd626..98a6b7fb057e9fe8816c0ecd9058ba76
  UIProcess/LegacyGlobalSettings.cpp
  UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
  UIProcess/MediaKeySystemPermissionRequestProxy.cpp
-@@ -302,6 +305,7 @@ UIProcess/PageLoadState.cpp
+@@ -303,6 +306,7 @@ UIProcess/PageLoadState.cpp
  UIProcess/ProcessAssertion.cpp
  UIProcess/ProcessThrottler.cpp
  UIProcess/ProvisionalPageProxy.cpp
@@ -10198,7 +10185,7 @@ index 3b86cf5d9b54cae7390bd13a6507b36729ebd626..98a6b7fb057e9fe8816c0ecd9058ba76
  UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
  UIProcess/Media/MediaUsageManager.cpp
 diff --git a/Source/WebKit/SourcesCocoa.txt b/Source/WebKit/SourcesCocoa.txt
-index 8cfc6074d0562aa582c5c0d23488ee636b2c9a9c..628c0559d2061158a7a35bfc2b30b7a55b51c542 100644
+index 67f325597989..26cb20a052de 100644
 --- a/Source/WebKit/SourcesCocoa.txt
 +++ b/Source/WebKit/SourcesCocoa.txt
 @@ -267,6 +267,7 @@ UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -10209,7 +10196,7 @@ index 8cfc6074d0562aa582c5c0d23488ee636b2c9a9c..628c0559d2061158a7a35bfc2b30b7a5
  UIProcess/API/Cocoa/_WKContentRuleListAction.mm
  UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
  UIProcess/API/Cocoa/_WKCustomHeaderFields.mm @no-unify
-@@ -434,6 +435,7 @@ UIProcess/Inspector/ios/WKInspectorHighlightView.mm
+@@ -433,6 +434,7 @@ UIProcess/Inspector/ios/WKInspectorHighlightView.mm
  UIProcess/Inspector/ios/WKInspectorNodeSearchGestureRecognizer.mm
  
  UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -10218,7 +10205,7 @@ index 8cfc6074d0562aa582c5c0d23488ee636b2c9a9c..628c0559d2061158a7a35bfc2b30b7a5
  UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
  UIProcess/Inspector/mac/WKInspectorViewController.mm
 diff --git a/Source/WebKit/SourcesGTK.txt b/Source/WebKit/SourcesGTK.txt
-index 894e5d4d325e10aeea0ada6124cedfb1aa024a89..6b0f2fcbffb2dc657a91645a3ce39c6d2263016e 100644
+index a4391be7b637..3f7d5e6c9deb 100644
 --- a/Source/WebKit/SourcesGTK.txt
 +++ b/Source/WebKit/SourcesGTK.txt
 @@ -125,6 +125,7 @@ UIProcess/API/glib/WebKitAuthenticationRequest.cpp @no-unify
@@ -10245,7 +10232,7 @@ index 894e5d4d325e10aeea0ada6124cedfb1aa024a89..6b0f2fcbffb2dc657a91645a3ce39c6d
  UIProcess/gtk/KeyBindingTranslator.cpp
  UIProcess/gtk/PointerLockManager.cpp @no-unify
  UIProcess/gtk/PointerLockManagerWayland.cpp @no-unify
-@@ -265,6 +268,8 @@ UIProcess/gtk/WaylandCompositor.cpp @no-unify
+@@ -266,6 +269,8 @@ UIProcess/gtk/WaylandCompositor.cpp @no-unify
  UIProcess/gtk/WebColorPickerGtk.cpp
  UIProcess/gtk/WebContextMenuProxyGtk.cpp
  UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
@@ -10255,7 +10242,7 @@ index 894e5d4d325e10aeea0ada6124cedfb1aa024a89..6b0f2fcbffb2dc657a91645a3ce39c6d
  UIProcess/gtk/WebPasteboardProxyGtk.cpp
  UIProcess/gtk/WebPopupMenuProxyGtk.cpp
 diff --git a/Source/WebKit/SourcesWPE.txt b/Source/WebKit/SourcesWPE.txt
-index 0775acec279c873b2fd81c02c2962763ff497db5..8dd0f26df6972bd3f3cdc6e4bcc90cd9ffbafc2c 100644
+index 0775acec279c..8dd0f26df697 100644
 --- a/Source/WebKit/SourcesWPE.txt
 +++ b/Source/WebKit/SourcesWPE.txt
 @@ -86,6 +86,7 @@ Shared/glib/ProcessExecutablePathGLib.cpp
@@ -10303,7 +10290,7 @@ index 0775acec279c873b2fd81c02c2962763ff497db5..8dd0f26df6972bd3f3cdc6e4bcc90cd9
  
  WebProcess/WebPage/AcceleratedSurface.cpp
 diff --git a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
-index d16ed7753fa59fc87ea9402f5ff4872525ed32f6..60a3d2f1e9cbb415ce8196b6a780fb44e8d51e77 100644
+index d16ed7753fa5..60a3d2f1e9cb 100644
 --- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
 +++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
 @@ -54,6 +54,9 @@ Ref<ProcessPoolConfiguration> ProcessPoolConfiguration::copy()
@@ -10317,7 +10304,7 @@ index d16ed7753fa59fc87ea9402f5ff4872525ed32f6..60a3d2f1e9cbb415ce8196b6a780fb44
      copy->m_shouldTakeUIBackgroundAssertion = this->m_shouldTakeUIBackgroundAssertion;
      copy->m_shouldCaptureDisplayInUIProcess = this->m_shouldCaptureDisplayInUIProcess;
 diff --git a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
-index 9fb2d63f614e1ed79da3fba1826e89fc5bd737b4..0dbfc99449f353cf803d7517dcce867fe3adf646 100644
+index 9fb2d63f614e..0dbfc99449f3 100644
 --- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
 +++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
 @@ -101,6 +101,11 @@ public:
@@ -10343,7 +10330,7 @@ index 9fb2d63f614e1ed79da3fba1826e89fc5bd737b4..0dbfc99449f353cf803d7517dcce867f
      bool m_shouldTakeUIBackgroundAssertion { true };
      bool m_shouldCaptureDisplayInUIProcess { DEFAULT_CAPTURE_DISPLAY_IN_UI_PROCESS };
 diff --git a/Source/WebKit/UIProcess/API/APIUIClient.h b/Source/WebKit/UIProcess/API/APIUIClient.h
-index 2175c518821effff060578c418e224817610d644..a2489687cc2efd5a59fc987a350a618c662c3734 100644
+index 2175c518821e..a2489687cc2e 100644
 --- a/Source/WebKit/UIProcess/API/APIUIClient.h
 +++ b/Source/WebKit/UIProcess/API/APIUIClient.h
 @@ -93,6 +93,7 @@ public:
@@ -10355,7 +10342,7 @@ index 2175c518821effff060578c418e224817610d644..a2489687cc2efd5a59fc987a350a618c
      virtual void setStatusText(WebKit::WebPageProxy*, const WTF::String&) { }
      virtual void mouseDidMoveOverElement(WebKit::WebPageProxy&, const WebKit::WebHitTestResultData&, OptionSet<WebKit::WebEvent::Modifier>, Object*) { }
 diff --git a/Source/WebKit/UIProcess/API/C/WKInspector.cpp b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
-index e1465edd29caf3109c17d44bb3c88aaba98cfbb5..32d569d3240c583334b8b6512407430fd448ae75 100644
+index e1465edd29ca..32d569d3240c 100644
 --- a/Source/WebKit/UIProcess/API/C/WKInspector.cpp
 +++ b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
 @@ -28,6 +28,11 @@
@@ -10383,7 +10370,7 @@ index e1465edd29caf3109c17d44bb3c88aaba98cfbb5..32d569d3240c583334b8b6512407430f
 +
  #endif // !PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebKit/UIProcess/API/C/WKInspector.h b/Source/WebKit/UIProcess/API/C/WKInspector.h
-index 026121d114c5fcad84c1396be8d692625beaa3bd..edd6e5cae033124c589959a42522fde07a42fdf6 100644
+index 026121d114c5..edd6e5cae033 100644
 --- a/Source/WebKit/UIProcess/API/C/WKInspector.h
 +++ b/Source/WebKit/UIProcess/API/C/WKInspector.h
 @@ -66,6 +66,10 @@ WK_EXPORT void WKInspectorTogglePageProfiling(WKInspectorRef inspector);
@@ -10398,7 +10385,7 @@ index 026121d114c5fcad84c1396be8d692625beaa3bd..edd6e5cae033124c589959a42522fde0
  }
  #endif
 diff --git a/Source/WebKit/UIProcess/API/C/WKPage.cpp b/Source/WebKit/UIProcess/API/C/WKPage.cpp
-index b7bd0985481cea81f3e9c46f8fd58b2b6c3e71dc..e67213f737b9734a9b3943f17d3becd358a43dab 100644
+index 702efb299a41..657d69666f19 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
 +++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
 @@ -1778,6 +1778,13 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
@@ -10425,7 +10412,7 @@ index b7bd0985481cea81f3e9c46f8fd58b2b6c3e71dc..e67213f737b9734a9b3943f17d3becd3
          }
  
 diff --git a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
-index ed980be17cdf9faec3f7af1bdc7cfd640bab8fc2..ca3c0ff1ec6d30173ae15e786f30ef1bad0e5bb6 100644
+index ed980be17cdf..ca3c0ff1ec6d 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
 +++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
 @@ -90,6 +90,7 @@ typedef void (*WKPageRunBeforeUnloadConfirmPanelCallback)(WKPageRef page, WKStri
@@ -10460,20 +10447,8 @@ index ed980be17cdf9faec3f7af1bdc7cfd640bab8fc2..ca3c0ff1ec6d30173ae15e786f30ef1b
  
      // Version 15.
      WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
-diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKDownloadInternal.h b/Source/WebKit/UIProcess/API/Cocoa/WKDownloadInternal.h
-index 06c89420e6e27b143db025405cb33b7a9d7c4af9..cc0258b9dadf38dce74cabab479881b444a41167 100644
---- a/Source/WebKit/UIProcess/API/Cocoa/WKDownloadInternal.h
-+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownloadInternal.h
-@@ -26,6 +26,7 @@
- #import "DownloadProxy.h"
- #import "WKDownload.h"
- #import "WKObject.h"
-+#import <wtf/WeakObjCPtr.h>
- 
- namespace WebKit {
- 
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
-index 198068cf35f63bf0f7ea16526aba65ef5b61bf20..985b67a387b74029542f8d7b141150d9921bf423 100644
+index 198068cf35f6..985b67a387b7 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
 @@ -135,6 +135,12 @@ typedef NS_ENUM(NSInteger, WKMediaCaptureType) {
@@ -10490,7 +10465,7 @@ index 198068cf35f63bf0f7ea16526aba65ef5b61bf20..985b67a387b74029542f8d7b141150d9
  /*! @abstract A delegate to request permission for microphone audio and camera video access.
   @param webView The web view invoking the delegate method.
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
-index afa925f36c29db9c23921298dead9cce737500d6..42d396342acdb6d39830f611df0ee40ea6ec879e 100644
+index afa925f36c29..42d396342acd 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
 @@ -24,7 +24,6 @@
@@ -10511,7 +10486,7 @@ index afa925f36c29db9c23921298dead9cce737500d6..42d396342acdb6d39830f611df0ee40e
  
  NS_ASSUME_NONNULL_END
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
-index 672b2053442e7e834aa453c40d32c9d90701e103..3d49ea06d6cda6c274ef9c59c003a1275e916810 100644
+index 672b2053442e..3d49ea06d6cd 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 @@ -42,6 +42,7 @@
@@ -10536,7 +10511,7 @@ index 672b2053442e7e834aa453c40d32c9d90701e103..3d49ea06d6cda6c274ef9c59c003a127
      Vector<WebKit::WebsiteDataRecord> result;
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.h b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..5fabe06a3289689246c36dfd96eb9900a48b2b0f
+index 000000000000..5fabe06a3289
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.h
 @@ -0,0 +1,55 @@
@@ -10597,7 +10572,7 @@ index 0000000000000000000000000000000000000000..5fabe06a3289689246c36dfd96eb9900
 +
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.mm
 new file mode 100644
-index 0000000000000000000000000000000000000000..e7143513ea2be8e1cdab5c86a28643fffea626dd
+index 000000000000..e7143513ea2b
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.mm
 @@ -0,0 +1,60 @@
@@ -10662,7 +10637,7 @@ index 0000000000000000000000000000000000000000..e7143513ea2be8e1cdab5c86a28643ff
 +}
 +@end
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
-index 0b32900879f73b9776f1bfbb6aec73c0553f7ac0..d3bac7b1130311c1094401b57c28b8f617d153aa 100644
+index 0b32900879f7..d3bac7b11303 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
 @@ -32,6 +32,7 @@
@@ -10674,7 +10649,7 @@ index 0b32900879f73b9776f1bfbb6aec73c0553f7ac0..d3bac7b1130311c1094401b57c28b8f6
  
  ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h b/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h
-index ca94c2173757a54a0c755cbf30f8e05a0b75c9cb..422c1379da9b091ae5903a42bc7625be78030016 100644
+index ca94c2173757..422c1379da9b 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h
 @@ -24,6 +24,7 @@
@@ -10686,7 +10661,7 @@ index ca94c2173757a54a0c755cbf30f8e05a0b75c9cb..422c1379da9b091ae5903a42bc7625be
  #import <wtf/RetainPtr.h>
  
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
-index 46561d34314a79d42c57e59bf7927ad1fa451045..c84cbe9adc5236ad64240a18f5ff9a7215ba2ba2 100644
+index 46561d34314a..c84cbe9adc52 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
 @@ -24,7 +24,10 @@
@@ -10701,7 +10676,7 @@ index 46561d34314a79d42c57e59bf7927ad1fa451045..c84cbe9adc5236ad64240a18f5ff9a72
  #if ENABLE(INSPECTOR_EXTENSIONS)
  
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
-index d4b65177f9fe593510bea64832d4255693be54b3..875a3e26f359023b0d1896e6544e6dd6488d98b7 100644
+index d4b65177f9fe..875a3e26f359 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
 @@ -65,6 +65,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
@@ -10713,7 +10688,7 @@ index d4b65177f9fe593510bea64832d4255693be54b3..875a3e26f359023b0d1896e6544e6dd6
  @property (nonatomic) BOOL processSwapsOnWindowOpenWithOpener WK_API_AVAILABLE(macos(10.14), ios(12.0));
  @property (nonatomic) BOOL prewarmsProcessesAutomatically WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
-index 93d0b1ed806ee698bdf51a7022b0cb5eabbaa943..0cf8411ceb0f24ca58140541d1f10925a926fc8e 100644
+index 93d0b1ed806e..0cf8411ceb0f 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 @@ -245,6 +245,16 @@
@@ -10734,7 +10709,7 @@ index 93d0b1ed806ee698bdf51a7022b0cb5eabbaa943..0cf8411ceb0f24ca58140541d1f10925
  {
      _processPoolConfiguration->setIsAutomaticProcessWarmingEnabled(prewarms);
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
-index c130399cf9f3063f5a2dcc392e19eefd763c153a..3c10bb7e9dc8d9834b90a8d8faaac361f1268504 100644
+index c130399cf9f3..3c10bb7e9dc8 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 @@ -24,6 +24,7 @@
@@ -10746,7 +10721,7 @@ index c130399cf9f3063f5a2dcc392e19eefd763c153a..3c10bb7e9dc8d9834b90a8d8faaac361
  
  #if PLATFORM(MAC)
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h
-index 4974e14214e2bb3e982325b885bab33e54f83998..cacdf8c71fab248d38d2faf03f7affdcfed1ef62 100644
+index 4974e14214e2..cacdf8c71fab 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h
 @@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
@@ -10758,7 +10733,7 @@ index 4974e14214e2bb3e982325b885bab33e54f83998..cacdf8c71fab248d38d2faf03f7affdc
  typedef NS_ENUM(NSInteger, _WKUserStyleLevel) {
      _WKUserStyleUserLevel,
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
-index 1e827013c603ae8bd43d798170deb98fc3153852..2075bc78069bde530ec237c0b761773c10013948 100644
+index 1e827013c603..2075bc78069b 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 @@ -35,6 +35,7 @@
@@ -10771,7 +10746,7 @@ index 1e827013c603ae8bd43d798170deb98fc3153852..2075bc78069bde530ec237c0b761773c
  @implementation _WKUserStyleSheet
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspector.cpp b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspector.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..54529a23f53cebe6f8a96873ca6c2f31f0481ae0
+index 000000000000..54529a23f53c
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspector.cpp
 @@ -0,0 +1,158 @@
@@ -10935,7 +10910,7 @@ index 0000000000000000000000000000000000000000..54529a23f53cebe6f8a96873ca6c2f31
 +}
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspectorPrivate.h b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspectorPrivate.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..e0b1da48465c850f541532ed961d1b778bea6028
+index 000000000000..e0b1da48465c
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspectorPrivate.h
 @@ -0,0 +1,32 @@
@@ -10972,7 +10947,7 @@ index 0000000000000000000000000000000000000000..e0b1da48465c850f541532ed961d1b77
 +WebKit::WebPageProxy* webkitBrowserInspectorCreateNewPageInContext(WebKitWebContext*);
 +void webkitBrowserInspectorQuitApplication();
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
-index 0afd97be464ceb609f1c43aa720f3b4c297778bd..0826356fe6d35615e9b2c84647dfe3dadab73eb1 100644
+index 0afd97be464c..0826356fe6d3 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
 @@ -98,6 +98,10 @@ private:
@@ -10987,7 +10962,7 @@ index 0afd97be464ceb609f1c43aa720f3b4c297778bd..0826356fe6d35615e9b2c84647dfe3da
      bool canRunBeforeUnloadConfirmPanel() const final { return true; }
  
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
-index 6dd9f20e4ff2bda0184d0645301cef22e47dcf15..7a5f57daa83818b2dfb4bcbcbf5c18c8621a6b25 100644
+index 6dd9f20e4ff2..7a5f57daa838 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
 @@ -118,8 +118,8 @@ enum {
@@ -11102,7 +11077,7 @@ index 6dd9f20e4ff2bda0184d0645301cef22e47dcf15..7a5f57daa83818b2dfb4bcbcbf5c18c8
      /**
       * WebKitWebContext:use-system-appearance-for-scrollbars:
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h b/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
-index 78d1578f94793e9e59a3d4d2b33e79ea8530fa04..493cdadac3873508b3efa3048638e73a13f4c976 100644
+index 78d1578f9479..493cdadac387 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
 @@ -45,3 +45,4 @@ void webkitWebContextInitializeNotificationPermissions(WebKitWebContext*);
@@ -11111,7 +11086,7 @@ index 78d1578f94793e9e59a3d4d2b33e79ea8530fa04..493cdadac3873508b3efa3048638e73a
  #endif
 +int webkitWebContextExistingCount();
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
-index f2a886fffc36608c632b0349b4fe517dacfb1514..86d3491f48f785a18a424d128a413b91ff09acdc 100644
+index a6859136ae70..6a5e4f7afd14 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 @@ -32,6 +32,7 @@
@@ -11164,7 +11139,7 @@ index f2a886fffc36608c632b0349b4fe517dacfb1514..86d3491f48f785a18a424d128a413b91
      /**
       * WebKitWebView::decide-policy:
       * @web_view: the #WebKitWebView on which the signal is emitted
-@@ -2502,6 +2517,23 @@ void webkitWebViewRunJavaScriptBeforeUnloadConfirm(WebKitWebView* webView, const
+@@ -2441,6 +2456,23 @@ void webkitWebViewRunJavaScriptBeforeUnloadConfirm(WebKitWebView* webView, const
      webkit_script_dialog_unref(webView->priv->currentScriptDialog);
  }
  
@@ -11189,7 +11164,7 @@ index f2a886fffc36608c632b0349b4fe517dacfb1514..86d3491f48f785a18a424d128a413b91
  {
      if (!webView->priv->currentScriptDialog)
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
-index 0d98a9ed60616c7a893736b795adf90f2b7b33e0..ccd5124baeb5188b202818a23da1740c9bb989b2 100644
+index d7a43204be69..0e247c488585 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
 @@ -60,6 +60,7 @@ void webkitWebViewRunJavaScriptAlert(WebKitWebView*, const CString& message, Fun
@@ -11201,7 +11176,7 @@ index 0d98a9ed60616c7a893736b795adf90f2b7b33e0..ccd5124baeb5188b202818a23da1740c
  bool webkitWebViewIsScriptDialogRunning(WebKitWebView*, WebKitScriptDialog*);
  String webkitWebViewGetCurrentScriptDialogMessage(WebKitWebView*);
 diff --git a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
-index 2bf03eec17b9d2add76b180b6a2bc41d8fba9602..9ca44d65460528b9b8e6f3b91aff8f91e81a29dc 100644
+index 2bf03eec17b9..9ca44d654605 100644
 --- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
 +++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
 @@ -244,6 +244,8 @@ void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool
@@ -11215,7 +11190,7 @@ index 2bf03eec17b9d2add76b180b6a2bc41d8fba9602..9ca44d65460528b9b8e6f3b91aff8f91
      webkitWebViewBaseForwardNextKeyEvent(webkitWebViewBase);
 diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitBrowserInspector.h b/Source/WebKit/UIProcess/API/gtk/WebKitBrowserInspector.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..9f1a0173a5641d6f158d815b8f7b9ea66f65c26d
+index 000000000000..9f1a0173a564
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/gtk/WebKitBrowserInspector.h
 @@ -0,0 +1,81 @@
@@ -11301,10 +11276,10 @@ index 0000000000000000000000000000000000000000..9f1a0173a5641d6f158d815b8f7b9ea6
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
-index bf4a2138ad5149722d89f436f53b393b30887c5a..045440b4dc7cbab2baf9759a8ff656fed3bc93a7 100644
+index e9cf71352ba2..3daa3b84f5c8 100644
 --- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
 +++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
-@@ -2460,6 +2460,11 @@ void webkitWebViewBaseResetClickCounter(WebKitWebViewBase* webkitWebViewBase)
+@@ -2462,6 +2462,11 @@ void webkitWebViewBaseResetClickCounter(WebKitWebViewBase* webkitWebViewBase)
  #endif
  }
  
@@ -11317,7 +11292,7 @@ index bf4a2138ad5149722d89f436f53b393b30887c5a..045440b4dc7cbab2baf9759a8ff656fe
  {
      ASSERT(webkitWebViewBase->priv->acceleratedBackingStore);
 diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
-index d28f9c69cabe96554daddfec77e6f007aa0987da..ece01f3d3e2f6aaca191975048320b6a91b946ea 100644
+index d28f9c69cabe..ece01f3d3e2f 100644
 --- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
 +++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
 @@ -27,6 +27,7 @@
@@ -11335,7 +11310,7 @@ index d28f9c69cabe96554daddfec77e6f007aa0987da..ece01f3d3e2f6aaca191975048320b6a
 +
 +WebKit::AcceleratedBackingStore* webkitWebViewBaseGetAcceleratedBackingStore(WebKitWebViewBase*);
 diff --git a/Source/WebKit/UIProcess/API/gtk/webkit2.h b/Source/WebKit/UIProcess/API/gtk/webkit2.h
-index ecbe433ed888353b1e6013943b4463835c3582d2..7385877fe664515814fc5c3380a2b7298ff90e1e 100644
+index ecbe433ed888..7385877fe664 100644
 --- a/Source/WebKit/UIProcess/API/gtk/webkit2.h
 +++ b/Source/WebKit/UIProcess/API/gtk/webkit2.h
 @@ -32,6 +32,7 @@
@@ -11347,7 +11322,7 @@ index ecbe433ed888353b1e6013943b4463835c3582d2..7385877fe664515814fc5c3380a2b729
  #include <webkit2/WebKitContextMenu.h>
  #include <webkit2/WebKitContextMenuActions.h>
 diff --git a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
-index 7dfe3ef401aa20d63377152c879fbd44d83d17fe..1d27a04639e1448c547b793f2b9de8e63d10e19c 100644
+index 7dfe3ef401aa..1d27a04639e1 100644
 --- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
 +++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
 @@ -194,7 +194,7 @@ WebCore::IntPoint PageClientImpl::accessibilityScreenToRootView(const WebCore::I
@@ -11361,7 +11336,7 @@ index 7dfe3ef401aa20d63377152c879fbd44d83d17fe..1d27a04639e1448c547b793f2b9de8e6
  void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent&, bool)
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitBrowserInspector.h b/Source/WebKit/UIProcess/API/wpe/WebKitBrowserInspector.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..cb1a540d341b07581ec87b922b7d007ce45ba989
+index 000000000000..cb1a540d341b
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitBrowserInspector.h
 @@ -0,0 +1,81 @@
@@ -11447,7 +11422,7 @@ index 0000000000000000000000000000000000000000..cb1a540d341b07581ec87b922b7d007c
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp
-index e0fc205b39095cf8aae201a1dcca520461c60de4..872186ad99a7b82f0c61705ff6c5ae4453e5e1d4 100644
+index e0fc205b3909..872186ad99a7 100644
 --- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp
 @@ -54,6 +54,7 @@ struct _WebKitWebViewBackend {
@@ -11479,7 +11454,7 @@ index e0fc205b39095cf8aae201a1dcca520461c60de4..872186ad99a7b82f0c61705ff6c5ae44
  
  template <> WebKitWebViewBackend* refGPtr(WebKitWebViewBackend* ptr)
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h
-index 6663964d5abac79e123d90e0351590884c66aa72..13ba5e7c3895c6e4efda95f1f90b9baea1c1bf30 100644
+index 6663964d5aba..13ba5e7c3895 100644
 --- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h
 @@ -27,6 +27,7 @@
@@ -11504,7 +11479,7 @@ index 6663964d5abac79e123d90e0351590884c66aa72..13ba5e7c3895c6e4efda95f1f90b9bae
  
  #endif /* WebKitWebViewBackend_h */
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h
-index e4b92ace1531090ae38a7aec3d3d4febf19aee84..43690f9ef4969a39084501613bfc00a77fd5df49 100644
+index e4b92ace1531..43690f9ef496 100644
 --- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h
 @@ -31,3 +31,5 @@ template <> void derefGPtr(WebKitWebViewBackend* ptr);
@@ -11514,7 +11489,7 @@ index e4b92ace1531090ae38a7aec3d3d4febf19aee84..43690f9ef4969a39084501613bfc00a7
 +
 +cairo_surface_t* webkitWebViewBackendTakeScreenshot(WebKitWebViewBackend*);
 diff --git a/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt b/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt
-index 8cf9d4ff38382b3d348a732d69d00e7720576777..052e75a649f49ca8704d013a03299fd4aca68fa1 100644
+index 8cf9d4ff3838..052e75a649f4 100644
 --- a/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt
 +++ b/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt
 @@ -320,6 +320,8 @@ WEBKIT_TYPE_WEB_VIEW_BACKEND
@@ -11527,7 +11502,7 @@ index 8cf9d4ff38382b3d348a732d69d00e7720576777..052e75a649f49ca8704d013a03299fd4
  <SUBSECTION Private>
  webkit_web_view_backend_get_type
 diff --git a/Source/WebKit/UIProcess/API/wpe/webkit.h b/Source/WebKit/UIProcess/API/wpe/webkit.h
-index 87929257bf73aba684a380accd8c1bbb394bad87..5d47bce94b6d4b9e54fc1fef794bde7506310e32 100644
+index 87929257bf73..5d47bce94b6d 100644
 --- a/Source/WebKit/UIProcess/API/wpe/webkit.h
 +++ b/Source/WebKit/UIProcess/API/wpe/webkit.h
 @@ -32,6 +32,7 @@
@@ -11539,7 +11514,7 @@ index 87929257bf73aba684a380accd8c1bbb394bad87..5d47bce94b6d4b9e54fc1fef794bde75
  #include <wpe/WebKitContextMenuActions.h>
  #include <wpe/WebKitContextMenuItem.h>
 diff --git a/Source/WebKit/UIProcess/BackingStore.h b/Source/WebKit/UIProcess/BackingStore.h
-index fe3c63e61f778762dc2c2080c74ec53fdf8c2e5f..c43a8226c9be702e248f1712e465efa396ee8969 100644
+index fe3c63e61f77..c43a8226c9be 100644
 --- a/Source/WebKit/UIProcess/BackingStore.h
 +++ b/Source/WebKit/UIProcess/BackingStore.h
 @@ -60,6 +60,7 @@ public:
@@ -11552,7 +11527,7 @@ index fe3c63e61f778762dc2c2080c74ec53fdf8c2e5f..c43a8226c9be702e248f1712e465efa3
          ID3D11DeviceContext1* immediateContext { nullptr };
 diff --git a/Source/WebKit/UIProcess/BrowserInspectorPipe.cpp b/Source/WebKit/UIProcess/BrowserInspectorPipe.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..cfb57a48ce387b79613b757e2eb4de2c378aac30
+index 000000000000..cfb57a48ce38
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/BrowserInspectorPipe.cpp
 @@ -0,0 +1,61 @@
@@ -11619,7 +11594,7 @@ index 0000000000000000000000000000000000000000..cfb57a48ce387b79613b757e2eb4de2c
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/BrowserInspectorPipe.h b/Source/WebKit/UIProcess/BrowserInspectorPipe.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..cd66887de171cda7d15a8e4dc6dbff63665dc619
+index 000000000000..cd66887de171
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/BrowserInspectorPipe.h
 @@ -0,0 +1,38 @@
@@ -11662,7 +11637,7 @@ index 0000000000000000000000000000000000000000..cd66887de171cda7d15a8e4dc6dbff63
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
-index 02dadcc4c813ad82c718f16a583616e03e35a195..5211c6b38efaf2a62eb556ec060cd9caa5e5d40e 100644
+index 02dadcc4c813..5211c6b38efa 100644
 --- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
 @@ -35,6 +35,7 @@
@@ -11674,7 +11649,7 @@ index 02dadcc4c813ad82c718f16a583616e03e35a195..5211c6b38efaf2a62eb556ec060cd9ca
  using namespace Inspector;
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
-index 454c61ffdefecc476d1560c7c43f5b5d345f281d..6de7509037b7683ddd403ee247bdf2845ce4e87a 100644
+index 454c61ffdefe..6de7509037b7 100644
 --- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
 +++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
 @@ -27,6 +27,8 @@
@@ -11696,7 +11671,7 @@ index 454c61ffdefecc476d1560c7c43f5b5d345f281d..6de7509037b7683ddd403ee247bdf284
  class PopUpSOAuthorizationSession final : public SOAuthorizationSession {
  public:
 diff --git a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
-index 7871ed4738b5cfc7e64757ff642cfbe51303a4eb..04b55aa995316d4d8cd467cf62d1a19f83ec8df7 100644
+index 7871ed4738b5..04b55aa99531 100644
 --- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
 +++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
 @@ -92,6 +92,7 @@ private:
@@ -11716,7 +11691,7 @@ index 7871ed4738b5cfc7e64757ff642cfbe51303a4eb..04b55aa995316d4d8cd467cf62d1a19f
          bool webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler : 1;
          bool webViewRequestGeolocationPermissionForFrameDecisionHandler : 1;
 diff --git a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
-index ecf7213858b8d7b3eb2a54f3b3a8c12eed4bdd85..7d0fd38d5e29a97945ff248be054036193b1ff51 100644
+index ecf7213858b8..7d0fd38d5e29 100644
 --- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
 @@ -104,6 +104,7 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
@@ -11744,7 +11719,7 @@ index ecf7213858b8d7b3eb2a54f3b3a8c12eed4bdd85..7d0fd38d5e29a97945ff248be0540361
  {
      if (!m_uiDelegate)
 diff --git a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
-index 7a18a6184a04aa37bb6d328a817b0a0a3e03cb50..92bb58f42cf5ff592b6d465f16ffcf283f381462 100644
+index 7a18a6184a04..92bb58f42cf5 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
 +++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
 @@ -27,6 +27,7 @@
@@ -11756,7 +11731,7 @@ index 7a18a6184a04aa37bb6d328a817b0a0a3e03cb50..92bb58f42cf5ff592b6d465f16ffcf28
  
  @class WKWebView;
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
-index 5167bdb8a50af3d33e9971efe288fb2c6840eff3..f38d7872046347ff5a8c5b2f4376bf8cfc883752 100644
+index 84b26a5f6c0d..f3e898a74db3 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 @@ -34,6 +34,7 @@
@@ -11767,7 +11742,7 @@ index 5167bdb8a50af3d33e9971efe288fb2c6840eff3..f38d7872046347ff5a8c5b2f4376bf8c
  #import "QuickLookThumbnailLoader.h"
  #import "SafeBrowsingSPI.h"
  #import "SafeBrowsingWarning.h"
-@@ -223,9 +224,66 @@ bool WebPageProxy::scrollingUpdatesDisabledForTesting()
+@@ -230,9 +231,66 @@ bool WebPageProxy::scrollingUpdatesDisabledForTesting()
  
  void WebPageProxy::startDrag(const DragItem& dragItem, const ShareableBitmap::Handle& dragImageHandle)
  {
@@ -11835,10 +11810,10 @@ index 5167bdb8a50af3d33e9971efe288fb2c6840eff3..f38d7872046347ff5a8c5b2f4376bf8c
  #if PLATFORM(IOS_FAMILY)
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-index 6cd0c0136e1f8d9bb24679af22551aa7d66e930b..71058bba5e0e1b24605d89289da3119b7a6c0e5c 100644
+index 1505b5583029..7127333640fa 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-@@ -373,7 +373,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
+@@ -398,7 +398,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
      auto screenProperties = WebCore::collectScreenProperties();
      parameters.screenProperties = WTFMove(screenProperties);
  #if PLATFORM(MAC)
@@ -11847,7 +11822,7 @@ index 6cd0c0136e1f8d9bb24679af22551aa7d66e930b..71058bba5e0e1b24605d89289da3119b
  #endif
      
  #if PLATFORM(IOS)
-@@ -633,8 +633,8 @@ void WebProcessPool::registerNotificationObservers()
+@@ -666,8 +666,8 @@ void WebProcessPool::registerNotificationObservers()
      }];
  
      m_scrollerStyleNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSPreferredScrollerStyleDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
@@ -11859,7 +11834,7 @@ index 6cd0c0136e1f8d9bb24679af22551aa7d66e930b..71058bba5e0e1b24605d89289da3119b
  
      m_activationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidBecomeActiveNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
-index bbc683ac0715138a601f8d85796b901fdc170b2e..4b74373d67807eba427c91e66e3b8607654ff0c0 100644
+index bbc683ac0715..4b74373d6780 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
 @@ -512,6 +512,9 @@ public:
@@ -11873,10 +11848,10 @@ index bbc683ac0715138a601f8d85796b901fdc170b2e..4b74373d67807eba427c91e66e3b8607
      void saveBackForwardSnapshotForCurrentItem();
      void saveBackForwardSnapshotForItem(WebBackForwardListItem&);
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
-index e32221c3524a8c662cc0ac84847b188b9cc463b8..58df7fff1719223c62fcac1cc734c01d48964a50 100644
+index 49e746ea4359..ea2e729874c0 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
-@@ -2608,6 +2608,11 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
+@@ -2593,6 +2593,11 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
          if (!m_colorSpace)
              m_colorSpace = [NSColorSpace sRGBColorSpace];
      }
@@ -11888,7 +11863,7 @@ index e32221c3524a8c662cc0ac84847b188b9cc463b8..58df7fff1719223c62fcac1cc734c01d
  
      ASSERT(m_colorSpace);
      return WebCore::DestinationColorSpace { [m_colorSpace CGColorSpace] };
-@@ -4686,6 +4691,18 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
+@@ -4671,6 +4676,18 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
      return adoptCF(CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
  }
  
@@ -11908,7 +11883,7 @@ index e32221c3524a8c662cc0ac84847b188b9cc463b8..58df7fff1719223c62fcac1cc734c01d
  {
      NSWindow *window = [m_view window];
 diff --git a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
-index 5a51b9ec1d68feecb5cf46a10d07c62785ad1fb0..1e165124020ac9e520123a0503d2a4ec30d7c32b 100644
+index 038d9ee2f41c..5be10b7bbdc8 100644
 --- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 +++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 @@ -32,13 +32,16 @@
@@ -11965,7 +11940,7 @@ index 5a51b9ec1d68feecb5cf46a10d07c62785ad1fb0..1e165124020ac9e520123a0503d2a4ec
  void DrawingAreaProxyCoordinatedGraphics::waitForBackingStoreUpdateOnNextPaint()
  {
      m_hasReceivedFirstUpdate = true;
-@@ -238,6 +257,45 @@ void DrawingAreaProxyCoordinatedGraphics::updateAcceleratedCompositingMode(uint6
+@@ -250,6 +269,45 @@ void DrawingAreaProxyCoordinatedGraphics::updateAcceleratedCompositingMode(uint6
      updateAcceleratedCompositingMode(layerTreeContext);
  }
  
@@ -12012,7 +11987,7 @@ index 5a51b9ec1d68feecb5cf46a10d07c62785ad1fb0..1e165124020ac9e520123a0503d2a4ec
  void DrawingAreaProxyCoordinatedGraphics::incorporateUpdate(const UpdateInfo& updateInfo)
  {
 diff --git a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
-index d7695088e7cfc4f638f157338754f9f157489749..f99c2b7c2a2b5fa666aa7db96a124717eee0e922 100644
+index b23a45ff7d31..8419b69c5e27 100644
 --- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
 +++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
 @@ -30,6 +30,7 @@
@@ -12034,7 +12009,7 @@ index d7695088e7cfc4f638f157338754f9f157489749..f99c2b7c2a2b5fa666aa7db96a124717
  
  private:
      // DrawingAreaProxy
-@@ -63,6 +68,9 @@ private:
+@@ -68,6 +73,9 @@ private:
      void enterAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext&) override;
      void exitAcceleratedCompositingMode(uint64_t backingStoreStateID, const UpdateInfo&) override;
      void updateAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext&) override;
@@ -12044,7 +12019,7 @@ index d7695088e7cfc4f638f157338754f9f157489749..f99c2b7c2a2b5fa666aa7db96a124717
  
  #if !PLATFORM(WPE)
      void incorporateUpdate(const UpdateInfo&);
-@@ -126,12 +134,18 @@ private:
+@@ -131,12 +139,18 @@ private:
      // For a new Drawing Area don't draw anything until the WebProcess has sent over the first content.
      bool m_hasReceivedFirstUpdate { false };
  
@@ -12064,7 +12039,7 @@ index d7695088e7cfc4f638f157338754f9f157489749..f99c2b7c2a2b5fa666aa7db96a124717
  
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
-index c61bb3fd2ee046f3824c40ab99181c0fcee2a197..0fee368e936443cc15f02903f97fb6ad60f6091e 100644
+index c61bb3fd2ee0..0fee368e9364 100644
 --- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
 +++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
 @@ -42,8 +42,10 @@
@@ -12138,7 +12113,7 @@ index c61bb3fd2ee046f3824c40ab99181c0fcee2a197..0fee368e936443cc15f02903f97fb6ad
      // This can cause the DownloadProxy object to be deleted.
      m_downloadProxyMap.downloadFinished(*this);
 diff --git a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
-index 4b9e12c40517fb84cb23d2de3e2adaa66c69da59..f56879a5a799115ef7353c060b00b842b8702408 100644
+index 4b9e12c40517..f56879a5a799 100644
 --- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
 +++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
 @@ -146,6 +146,7 @@ private:
@@ -12150,7 +12125,7 @@ index 4b9e12c40517fb84cb23d2de3e2adaa66c69da59..f56879a5a799115ef7353c060b00b842
  
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/DrawingAreaProxy.h b/Source/WebKit/UIProcess/DrawingAreaProxy.h
-index 826c417c6c9ba1c7e6c2c32a6ab0f3ab8d72f0e0..641f418f78c56aba25740586bb982231997b6bf5 100644
+index 826c417c6c9b..641f418f78c5 100644
 --- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
 +++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
 @@ -75,6 +75,7 @@ public:
@@ -12172,7 +12147,7 @@ index 826c417c6c9ba1c7e6c2c32a6ab0f3ab8d72f0e0..641f418f78c56aba25740586bb982231
      bool m_startedReceivingMessages { false };
  };
 diff --git a/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in b/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
-index b0722e7da81e56530deb570b82ed7cfece970362..05ec3e3ea97ba49135a27d7f9b91f14c507d9318 100644
+index b0722e7da81e..05ec3e3ea97b 100644
 --- a/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
 +++ b/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
 @@ -36,4 +36,7 @@ messages -> DrawingAreaProxy NotRefCounted {
@@ -12185,7 +12160,7 @@ index b0722e7da81e56530deb570b82ed7cfece970362..05ec3e3ea97ba49135a27d7f9b91f14c
  }
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.cpp b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..9426d9eed59f433eac62b8eb6a16139b84079949
+index 000000000000..9426d9eed59f
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.cpp
 @@ -0,0 +1,244 @@
@@ -12435,7 +12410,7 @@ index 0000000000000000000000000000000000000000..9426d9eed59f433eac62b8eb6a16139b
 +#endif
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.h b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..4ec8b96bbbddf8a7b042f53a8068754a384fc7ad
+index 000000000000..4ec8b96bbbdd
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.h
 @@ -0,0 +1,30 @@
@@ -12471,7 +12446,7 @@ index 0000000000000000000000000000000000000000..4ec8b96bbbddf8a7b042f53a8068754a
 +cairo_status_t cairo_image_surface_write_to_jpeg_mem(cairo_surface_t *sfc, unsigned char **data, size_t *len, int quality);
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.cpp b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..20122bd89c3ba0ec4ff878ac895bddd497cc9789
+index 000000000000..20122bd89c3b
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.cpp
 @@ -0,0 +1,269 @@
@@ -12746,7 +12721,7 @@ index 0000000000000000000000000000000000000000..20122bd89c3ba0ec4ff878ac895bddd4
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.h b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..8f2795dbf1323dd8d5f986f18e6fe16431dd7f70
+index 000000000000..8f2795dbf132
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.h
 @@ -0,0 +1,96 @@
@@ -12848,7 +12823,7 @@ index 0000000000000000000000000000000000000000..8f2795dbf1323dd8d5f986f18e6fe164
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..62f20814b72e90275eb4fa0e8302fc15abdaaab2
+index 000000000000..62f20814b72e
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp
 @@ -0,0 +1,393 @@
@@ -13247,7 +13222,7 @@ index 0000000000000000000000000000000000000000..62f20814b72e90275eb4fa0e8302fc15
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.h b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..1683da93db6b9088c3a472472c1b71477b47a7fd
+index 000000000000..1683da93db6b
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.h
 @@ -0,0 +1,81 @@
@@ -13334,7 +13309,7 @@ index 0000000000000000000000000000000000000000..1683da93db6b9088c3a472472c1b7147
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.cpp b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..9b269b356e206f0252245a1497adb0d05128c9b4
+index 000000000000..9b269b356e20
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.cpp
 @@ -0,0 +1,69 @@
@@ -13409,7 +13384,7 @@ index 0000000000000000000000000000000000000000..9b269b356e206f0252245a1497adb0d0
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.h b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..e2ce910f3fd7f587add552275b7e7176cf8b2723
+index 000000000000..e2ce910f3fd7
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.h
 @@ -0,0 +1,53 @@
@@ -13467,7 +13442,7 @@ index 0000000000000000000000000000000000000000..e2ce910f3fd7f587add552275b7e7176
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
-index 6928ca2fbfb6939062e3cd14bb7ba6f2fdc87f5f..621b99e233ed5cf504fedbd3ca3209c03bcd611f 100644
+index 6928ca2fbfb6..621b99e233ed 100644
 --- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
 +++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
 @@ -27,11 +27,10 @@
@@ -13540,7 +13515,7 @@ index 6928ca2fbfb6939062e3cd14bb7ba6f2fdc87f5f..621b99e233ed5cf504fedbd3ca3209c0
  {
      return !!m_provisionalPage;
 diff --git a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
-index a2239cec8e18850f35f7f88a9c4ebadc62bf4023..79f3ff84327dc075ec96983e04db4b10343b7fae 100644
+index a2239cec8e18..79f3ff84327d 100644
 --- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
 +++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
 @@ -37,13 +37,13 @@ class WebPageProxy;
@@ -13580,7 +13555,7 @@ index a2239cec8e18850f35f7f88a9c4ebadc62bf4023..79f3ff84327dc075ec96983e04db4b10
  
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
-index ed4e6f30b8c35966075573dccee801daceec865e..2357769f3f78a7fda3d3fff1005e77c5d082948d 100644
+index ed4e6f30b8c3..2357769f3f78 100644
 --- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
 +++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
 @@ -26,13 +26,21 @@
@@ -13887,7 +13862,7 @@ index ed4e6f30b8c35966075573dccee801daceec865e..2357769f3f78a7fda3d3fff1005e77c5
 +
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
-index 8c1339345d451874502b271f6aa2eca3fa0d3faf..331b61c70c7370ace480724bdb53c99a54897374 100644
+index 8c1339345d45..331b61c70c73 100644
 --- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
 +++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
 @@ -26,17 +26,35 @@
@@ -14025,7 +14000,7 @@ index 8c1339345d451874502b271f6aa2eca3fa0d3faf..331b61c70c7370ace480724bdb53c99a
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/mac/ScreencastEncoderMac.mm b/Source/WebKit/UIProcess/Inspector/mac/ScreencastEncoderMac.mm
 new file mode 100644
-index 0000000000000000000000000000000000000000..66d1c743de1cb35e29d6fc9b69379d265a59961f
+index 000000000000..66d1c743de1c
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/mac/ScreencastEncoderMac.mm
 @@ -0,0 +1,58 @@
@@ -14089,7 +14064,7 @@ index 0000000000000000000000000000000000000000..66d1c743de1cb35e29d6fc9b69379d26
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorDialogAgent.cpp b/Source/WebKit/UIProcess/InspectorDialogAgent.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..663f92f0df76042cf6385b056f8a917d688259f9
+index 000000000000..663f92f0df76
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorDialogAgent.cpp
 @@ -0,0 +1,88 @@
@@ -14183,7 +14158,7 @@ index 0000000000000000000000000000000000000000..663f92f0df76042cf6385b056f8a917d
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorDialogAgent.h b/Source/WebKit/UIProcess/InspectorDialogAgent.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..d0e11ed81a6257c011df23d5870da7403f8e9fe4
+index 000000000000..d0e11ed81a62
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorDialogAgent.h
 @@ -0,0 +1,70 @@
@@ -14259,7 +14234,7 @@ index 0000000000000000000000000000000000000000..d0e11ed81a6257c011df23d5870da740
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..92fb6acfb614f4f48f115372fef79afde4fd6517
+index 000000000000..92fb6acfb614
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
 @@ -0,0 +1,997 @@
@@ -15262,7 +15237,7 @@ index 0000000000000000000000000000000000000000..92fb6acfb614f4f48f115372fef79afd
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..07de509499e725dae6e2fdbb260b0e439f92633f
+index 000000000000..07de509499e7
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h
 @@ -0,0 +1,126 @@
@@ -15394,7 +15369,7 @@ index 0000000000000000000000000000000000000000..07de509499e725dae6e2fdbb260b0e43
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgentClient.h b/Source/WebKit/UIProcess/InspectorPlaywrightAgentClient.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..11c8eadafca764aa549cb27c24967e15e6975774
+index 000000000000..11c8eadafca7
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgentClient.h
 @@ -0,0 +1,66 @@
@@ -15465,7 +15440,7 @@ index 0000000000000000000000000000000000000000..11c8eadafca764aa549cb27c24967e15
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp b/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
-index 7a14cfba15c103a2d4fe263fa49d25af3c396ec2..3ee0e154349661632799057c71f1d1f1551c2d69 100644
+index 7a14cfba15c1..3ee0e1543496 100644
 --- a/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
 +++ b/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
 @@ -96,8 +96,11 @@ void ProcessLauncher::launchProcess()
@@ -15482,7 +15457,7 @@ index 7a14cfba15c103a2d4fe263fa49d25af3c396ec2..3ee0e154349661632799057c71f1d1f1
      BOOL result = ::CreateProcess(0, commandLine.data(), 0, 0, true, 0, 0, 0, &startupInfo, &processInformation);
  
 diff --git a/Source/WebKit/UIProcess/PageClient.h b/Source/WebKit/UIProcess/PageClient.h
-index 8770ad463816bfef4c4a993746539e02d21cd572..e16f20b54132e19b34b74ae85271d3fa44f76af2 100644
+index 8770ad463816..e16f20b54132 100644
 --- a/Source/WebKit/UIProcess/PageClient.h
 +++ b/Source/WebKit/UIProcess/PageClient.h
 @@ -314,6 +314,11 @@ public:
@@ -15498,7 +15473,7 @@ index 8770ad463816bfef4c4a993746539e02d21cd572..e16f20b54132e19b34b74ae85271d3fa
      virtual RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) = 0;
  #endif
 diff --git a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
-index bb4a4c2f6a17f4ada269a3450f9c276f648c72e1..49cd5218f23a6e8b8b8cf9d33542795dca95e548 100644
+index bb4a4c2f6a17..49cd5218f23a 100644
 --- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
 @@ -598,3 +598,5 @@ bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Option
@@ -15509,7 +15484,7 @@ index bb4a4c2f6a17f4ada269a3450f9c276f648c72e1..49cd5218f23a6e8b8b8cf9d33542795d
 +#undef MESSAGE_CHECK
 diff --git a/Source/WebKit/UIProcess/RemoteInspectorPipe.cpp b/Source/WebKit/UIProcess/RemoteInspectorPipe.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..dd8b28e692dca4078eb710b2a97e61716126a4cb
+index 000000000000..dd8b28e692dc
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/RemoteInspectorPipe.cpp
 @@ -0,0 +1,224 @@
@@ -15739,7 +15714,7 @@ index 0000000000000000000000000000000000000000..dd8b28e692dca4078eb710b2a97e6171
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/RemoteInspectorPipe.h b/Source/WebKit/UIProcess/RemoteInspectorPipe.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..6d04f9290135069359ce6bf8726546482fd1dc95
+index 000000000000..6d04f9290135
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/RemoteInspectorPipe.h
 @@ -0,0 +1,65 @@
@@ -15809,7 +15784,7 @@ index 0000000000000000000000000000000000000000..6d04f9290135069359ce6bf872654648
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
-index e42dbf1281d36fef2e303e707d5b5baf166ee152..80fab5d4ac007f0d2da9f58bee03a5ab3c845b83 100644
+index e42dbf1281d3..80fab5d4ac00 100644
 --- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
 +++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
 @@ -37,6 +37,8 @@
@@ -15822,7 +15797,7 @@ index e42dbf1281d36fef2e303e707d5b5baf166ee152..80fab5d4ac007f0d2da9f58bee03a5ab
  
  Ref<WebCore::RealtimeMediaSource> SpeechRecognitionRemoteRealtimeMediaSource::create(SpeechRecognitionRemoteRealtimeMediaSourceManager& manager, const WebCore::CaptureDevice& captureDevice)
 diff --git a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
-index 684b9616573761123fbcc0d94be29de519ecced6..51ff18323ece0ee15c87d63a1d6fd604377ee968 100644
+index 684b96165737..51ff18323ece 100644
 --- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
 +++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
 @@ -28,6 +28,7 @@
@@ -15834,7 +15809,7 @@ index 684b9616573761123fbcc0d94be29de519ecced6..51ff18323ece0ee15c87d63a1d6fd604
  
  namespace WebKit {
 diff --git a/Source/WebKit/UIProcess/WebContextMenuProxy.h b/Source/WebKit/UIProcess/WebContextMenuProxy.h
-index 1b8fcc84664f309afe5f4eacd28b5413c1b1b907..280cf47fe75b2c13062090512b3250c9012984a9 100644
+index 1b8fcc84664f..280cf47fe75b 100644
 --- a/Source/WebKit/UIProcess/WebContextMenuProxy.h
 +++ b/Source/WebKit/UIProcess/WebContextMenuProxy.h
 @@ -33,6 +33,7 @@
@@ -15854,7 +15829,7 @@ index 1b8fcc84664f309afe5f4eacd28b5413c1b1b907..280cf47fe75b2c13062090512b3250c9
      WebPageProxy* page() const { return m_page.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
-index 04f3227cd55c992a42cd96a3f25d697aed7965a2..f0d36935f47bab03ea2ec50b705092068ecd3efa 100644
+index 04f3227cd55c..f0d36935f47b 100644
 --- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
 @@ -128,7 +128,8 @@ void WebGeolocationManagerProxy::startUpdating(IPC::Connection& connection, WebP
@@ -15869,7 +15844,7 @@ index 04f3227cd55c992a42cd96a3f25d697aed7965a2..f0d36935f47bab03ea2ec50b70509206
  
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..ae45b4212bdb3f6a004cc80a1d91146b540f86f5
+index 000000000000..ae45b4212bdb
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp
 @@ -0,0 +1,147 @@
@@ -16022,7 +15997,7 @@ index 0000000000000000000000000000000000000000..ae45b4212bdb3f6a004cc80a1d91146b
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.h b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..b3bb4880a866ee6132b8b26acf8dad81afe14d85
+index 000000000000..b3bb4880a866
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.h
 @@ -0,0 +1,75 @@
@@ -16103,7 +16078,7 @@ index 0000000000000000000000000000000000000000..b3bb4880a866ee6132b8b26acf8dad81
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorInputAgent.cpp b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..eb16b3aa8912b4cc26a2e555669c27682b76378d
+index 000000000000..eb16b3aa8912
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.cpp
 @@ -0,0 +1,288 @@
@@ -16397,7 +16372,7 @@ index 0000000000000000000000000000000000000000..eb16b3aa8912b4cc26a2e555669c2768
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorInputAgent.h b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..94e9f24353337169992724e2fcdf7086dd888fa6
+index 000000000000..94e9f2435333
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.h
 @@ -0,0 +1,85 @@
@@ -16487,7 +16462,7 @@ index 0000000000000000000000000000000000000000..94e9f24353337169992724e2fcdf7086
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a03a795f7c 100644
+index 9c7566dba21b..ac473eaa2c6c 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
 @@ -240,7 +240,7 @@
@@ -16540,7 +16515,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  RefPtr<API::Navigation> WebPageProxy::loadRequest(ResourceRequest&& request, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, API::Object* userData)
  {
      if (m_isClosed)
-@@ -1832,6 +1852,31 @@ void WebPageProxy::setControlledByAutomation(bool controlled)
+@@ -1840,6 +1860,31 @@ void WebPageProxy::setControlledByAutomation(bool controlled)
      websiteDataStore().networkProcess().send(Messages::NetworkProcess::SetSessionIsControlledByAutomation(m_websiteDataStore->sessionID(), m_controlledByAutomation), 0);
  }
  
@@ -16572,7 +16547,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  void WebPageProxy::createInspectorTarget(const String& targetId, Inspector::InspectorTargetType type)
  {
      MESSAGE_CHECK(m_process, !targetId.isEmpty());
-@@ -2022,6 +2067,25 @@ void WebPageProxy::updateActivityState(OptionSet<ActivityState::Flag> flagsToUpd
+@@ -2030,6 +2075,25 @@ void WebPageProxy::updateActivityState(OptionSet<ActivityState::Flag> flagsToUpd
  {
      bool wasVisible = isViewVisible();
      m_activityState.remove(flagsToUpdate);
@@ -16598,7 +16573,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
      if (flagsToUpdate & ActivityState::IsFocused && pageClient().isViewFocused())
          m_activityState.add(ActivityState::IsFocused);
      if (flagsToUpdate & ActivityState::WindowIsActive && pageClient().isViewWindowActive())
-@@ -2594,6 +2658,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
+@@ -2602,6 +2666,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
  {
      if (!hasRunningProcess())
          return;
@@ -16607,7 +16582,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  #if PLATFORM(GTK)
      UNUSED_PARAM(dragStorageName);
      UNUSED_PARAM(sandboxExtensionHandle);
-@@ -2604,6 +2670,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
+@@ -2612,6 +2678,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
          m_process->assumeReadAccessToBaseURL(*this, url);
  
      ASSERT(dragData.platformData());
@@ -16616,7 +16591,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
      send(Messages::WebPage::PerformDragControllerAction(action, dragData.clientPosition(), dragData.globalPosition(), dragData.draggingSourceOperationMask(), *dragData.platformData(), dragData.flags()));
  #else
      send(Messages::WebPage::PerformDragControllerAction(action, dragData, sandboxExtensionHandle, sandboxExtensionsForUpload));
-@@ -2619,18 +2687,41 @@ void WebPageProxy::didPerformDragControllerAction(std::optional<WebCore::DragOpe
+@@ -2627,18 +2695,41 @@ void WebPageProxy::didPerformDragControllerAction(std::optional<WebCore::DragOpe
      m_currentDragCaretEditableElementRect = editableElementRect;
      setDragCaretRect(insertionRect);
      pageClient().didPerformDragControllerAction();
@@ -16661,7 +16636,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<WebCore::DragOperation> dragOperationMask)
  {
      if (!hasRunningProcess())
-@@ -2639,6 +2730,24 @@ void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& glo
+@@ -2647,6 +2738,24 @@ void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& glo
      setDragCaretRect({ });
  }
  
@@ -16686,7 +16661,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  void WebPageProxy::didPerformDragOperation(bool handled)
  {
      pageClient().didPerformDragOperation(handled);
-@@ -2651,8 +2760,18 @@ void WebPageProxy::didStartDrag()
+@@ -2659,8 +2768,18 @@ void WebPageProxy::didStartDrag()
  
      discardQueuedMouseEvents();
      send(Messages::WebPage::DidStartDrag());
@@ -16706,7 +16681,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  void WebPageProxy::dragCancelled()
  {
      if (hasRunningProcess())
-@@ -2757,16 +2876,38 @@ void WebPageProxy::processNextQueuedMouseEvent()
+@@ -2765,16 +2884,38 @@ void WebPageProxy::processNextQueuedMouseEvent()
          m_process->startResponsivenessTimer();
      }
  
@@ -16752,7 +16727,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  }
  
  void WebPageProxy::doAfterProcessingAllPendingMouseEvents(WTF::Function<void ()>&& action)
-@@ -2986,7 +3127,7 @@ static TrackingType mergeTrackingTypes(TrackingType a, TrackingType b)
+@@ -2994,7 +3135,7 @@ static TrackingType mergeTrackingTypes(TrackingType a, TrackingType b)
  
  void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent)
  {
@@ -16761,7 +16736,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
      const EventNames& names = eventNames();
      for (auto& touchPoint : touchStartEvent.touchPoints()) {
          IntPoint location = touchPoint.location();
-@@ -3019,7 +3160,7 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
+@@ -3027,7 +3168,7 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
      m_touchAndPointerEventTracking.touchStartTracking = TrackingType::Synchronous;
      m_touchAndPointerEventTracking.touchMoveTracking = TrackingType::Synchronous;
      m_touchAndPointerEventTracking.touchEndTracking = TrackingType::Synchronous;
@@ -16770,7 +16745,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  }
  
  TrackingType WebPageProxy::touchEventTrackingType(const WebTouchEvent& touchStartEvent) const
-@@ -3402,6 +3543,8 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
+@@ -3410,6 +3551,8 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
          policyAction = PolicyAction::Download;
  
      if (policyAction != PolicyAction::Use || !frame.isMainFrame() || !navigation) {
@@ -16779,7 +16754,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
          receivedPolicyDecision(policyAction, navigation, WTFMove(policies), WTFMove(navigationAction), WTFMove(sender));
          return;
      }
-@@ -3468,6 +3611,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
+@@ -3476,6 +3619,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
  
  void WebPageProxy::receivedPolicyDecision(PolicyAction action, API::Navigation* navigation, RefPtr<API::WebsitePolicies>&& websitePolicies, Variant<Ref<API::NavigationResponse>, Ref<API::NavigationAction>>&& navigationActionOrResponse, Ref<PolicyDecisionSender>&& sender, std::optional<SandboxExtension::Handle> sandboxExtensionHandle, WillContinueLoadInNewProcess willContinueLoadInNewProcess)
  {
@@ -16787,7 +16762,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
      if (!hasRunningProcess()) {
          sender->send(PolicyDecision { sender->identifier(), isNavigatingToAppBoundDomain(), PolicyAction::Ignore, 0, std::nullopt, std::nullopt });
          return;
-@@ -4206,6 +4350,11 @@ void WebPageProxy::pageScaleFactorDidChange(double scaleFactor)
+@@ -4214,6 +4358,11 @@ void WebPageProxy::pageScaleFactorDidChange(double scaleFactor)
      m_pageScaleFactor = scaleFactor;
  }
  
@@ -16799,7 +16774,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  void WebPageProxy::pluginScaleFactorDidChange(double pluginScaleFactor)
  {
      m_pluginScaleFactor = pluginScaleFactor;
-@@ -4538,6 +4687,7 @@ void WebPageProxy::didDestroyNavigation(uint64_t navigationID)
+@@ -4546,6 +4695,7 @@ void WebPageProxy::didDestroyNavigation(uint64_t navigationID)
          return;
  
      m_navigationState->didDestroyNavigation(navigationID);
@@ -16807,7 +16782,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  }
  
  void WebPageProxy::didStartProvisionalLoadForFrame(FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, uint64_t navigationID, URL&& url, URL&& unreachableURL, const UserData& userData)
-@@ -4760,6 +4910,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
+@@ -4768,6 +4918,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
  
      m_failingProvisionalLoadURL = { };
  
@@ -16816,7 +16791,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
      // If the provisional page's load fails then we destroy the provisional page.
      if (m_provisionalPage && m_provisionalPage->mainFrame() == frame && willContinueLoading == WillContinueLoading::No)
          m_provisionalPage = nullptr;
-@@ -5201,7 +5353,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
+@@ -5209,7 +5361,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
      NavigationActionData&& navigationActionData, FrameInfoData&& originatingFrameInfo, std::optional<WebPageProxyIdentifier> originatingPageID, const WebCore::ResourceRequest& originalRequest, WebCore::ResourceRequest&& request,
      IPC::FormDataReference&& requestBody, WebCore::ResourceResponse&& redirectResponse, const UserData& userData, uint64_t listenerID)
  {
@@ -16832,7 +16807,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  }
  
  void WebPageProxy::decidePolicyForNavigationActionAsyncShared(Ref<WebProcessProxy>&& process, PageIdentifier webPageID, FrameIdentifier frameID, FrameInfoData&& frameInfo,
-@@ -5718,6 +5877,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -5726,6 +5885,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
      auto* originatingPage = m_process->webPage(originatingPageID);
      auto originatingFrameInfo = API::FrameInfo::create(WTFMove(originatingFrameInfoData), originatingPage);
      auto mainFrameURL = m_mainFrame ? m_mainFrame->url() : URL();
@@ -16840,7 +16815,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
      auto completionHandler = [this, protectedThis = makeRef(*this), mainFrameURL, request, reply = WTFMove(reply), privateClickMeasurement = navigationActionData.privateClickMeasurement] (RefPtr<WebPageProxy> newPage) mutable {
          if (!newPage) {
              reply(std::nullopt, std::nullopt);
-@@ -5758,6 +5918,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -5766,6 +5926,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
  void WebPageProxy::showPage()
  {
      m_uiClient->showPage(this);
@@ -16848,7 +16823,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  }
  
  void WebPageProxy::exitFullscreenImmediately()
-@@ -5793,6 +5954,10 @@ void WebPageProxy::closePage()
+@@ -5801,6 +5962,10 @@ void WebPageProxy::closePage()
      if (isClosed())
          return;
  
@@ -16859,7 +16834,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
      WEBPAGEPROXY_RELEASE_LOG(Process, "closePage:");
      pageClient().clearAllEditCommands();
      m_uiClient->close(this);
-@@ -5829,6 +5994,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
+@@ -5837,6 +6002,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
      }
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
@@ -16868,7 +16843,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
          page.m_uiClient->runJavaScriptAlert(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)]() mutable {
              reply();
              completion();
-@@ -5850,6 +6017,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
+@@ -5858,6 +6025,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -16877,7 +16852,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptConfirm(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](bool result) mutable {
-@@ -5873,6 +6042,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
+@@ -5881,6 +6050,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -16886,7 +16861,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply), defaultValue](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptPrompt(page, message, defaultValue, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](auto& result) mutable {
-@@ -6033,6 +6204,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
+@@ -6041,6 +6212,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
              return;
          }
      }
@@ -16895,7 +16870,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  
      // Since runBeforeUnloadConfirmPanel() can spin a nested run loop we need to turn off the responsiveness timer and the tryClose timer.
      m_process->stopResponsivenessTimer();
-@@ -7239,6 +7412,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7247,6 +7420,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->mouseEventsFlushedForPage(*this);
              didFinishProcessingAllPendingMouseEvents();
@@ -16904,7 +16879,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
          }
          break;
      }
-@@ -7265,7 +7440,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7273,7 +7448,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
      case WebEvent::RawKeyDown:
      case WebEvent::Char: {
          LOG(KeyHandling, "WebPageProxy::didReceiveEvent: %s (queue empty %d)", webKeyboardEventTypeString(type), m_keyEventQueue.isEmpty());
@@ -16912,7 +16887,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
          MESSAGE_CHECK(m_process, !m_keyEventQueue.isEmpty());
          auto event = m_keyEventQueue.takeFirst();
          MESSAGE_CHECK(m_process, type == event.type());
-@@ -7284,7 +7458,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7292,7 +7466,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          // The call to doneWithKeyEvent may close this WebPage.
          // Protect against this being destroyed.
          Ref<WebPageProxy> protect(*this);
@@ -16920,7 +16895,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
          pageClient().doneWithKeyEvent(event, handled);
          if (!handled)
              m_uiClient->didNotHandleKeyEvent(this, event);
-@@ -7293,6 +7466,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7301,6 +7474,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          if (!canProcessMoreKeyEvents) {
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->keyboardEventsFlushedForPage(*this);
@@ -16928,7 +16903,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
          }
          break;
      }
-@@ -7623,7 +7797,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
+@@ -7631,7 +7805,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
  {
      WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "dispatchProcessDidTerminate: reason=%d", reason);
  
@@ -16940,7 +16915,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
      if (m_loaderClient)
          handledByClient = reason != ProcessTerminationReason::RequestedByClient && m_loaderClient->processDidCrash(*this);
      else
-@@ -7993,6 +8170,7 @@ static const Vector<ASCIILiteral>& mediaRelatedIOKitClasses()
+@@ -8001,6 +8178,7 @@ static const Vector<ASCIILiteral>& mediaRelatedIOKitClasses()
  
  WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& process, DrawingAreaProxy& drawingArea, RefPtr<API::WebsitePolicies>&& websitePolicies)
  {
@@ -16948,7 +16923,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
      WebPageCreationParameters parameters;
  
      parameters.processDisplayName = configuration().processDisplayName();
-@@ -8185,6 +8363,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
+@@ -8193,6 +8371,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
      parameters.shouldRelaxThirdPartyCookieBlocking = m_configuration->shouldRelaxThirdPartyCookieBlocking();
      parameters.canUseCredentialStorage = m_canUseCredentialStorage;
  
@@ -16957,7 +16932,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
  #if PLATFORM(GTK)
      parameters.themeName = pageClient().themeName();
  #endif
-@@ -8257,6 +8437,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
+@@ -8265,6 +8445,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
  
  void WebPageProxy::didReceiveAuthenticationChallengeProxy(Ref<AuthenticationChallengeProxy>&& authenticationChallenge, NegotiatedLegacyTLS negotiatedLegacyTLS)
  {
@@ -16972,7 +16947,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
      if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes) {
          m_navigationClient->shouldAllowLegacyTLS(*this, authenticationChallenge.get(), [this, protectedThis = makeRef(*this), authenticationChallenge] (bool shouldAllowLegacyTLS) {
              if (shouldAllowLegacyTLS)
-@@ -8350,6 +8538,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
+@@ -8358,6 +8546,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
              request->deny();
      };
  
@@ -16989,7 +16964,7 @@ index 35fc94bfd4e14ba33cd67ba4c6e787f361709af0..ab4430494958320408f0481d59dc21a0
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f1071c7b36e 100644
+index 3aaa64d1be42..d54b7ea95f83 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -38,6 +38,7 @@
@@ -17027,7 +17002,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
  #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
  #include <WebCore/MediaPlaybackTargetPicker.h>
  #include <WebCore/WebMediaSessionManagerClient.h>
-@@ -242,6 +254,7 @@ class AuthenticationChallenge;
+@@ -239,6 +251,7 @@ class AuthenticationChallenge;
  class CertificateInfo;
  class Cursor;
  class DragData;
@@ -17035,7 +17010,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
  class FloatRect;
  class FontAttributeChanges;
  class FontChanges;
-@@ -249,7 +262,6 @@ class GraphicsLayer;
+@@ -246,7 +259,6 @@ class GraphicsLayer;
  class IntSize;
  class ProtectionSpace;
  class RunLoopObserver;
@@ -17043,7 +17018,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
  class SharedBuffer;
  class SpeechRecognitionRequest;
  class TextIndicator;
-@@ -525,6 +537,8 @@ public:
+@@ -522,6 +534,8 @@ public:
      void setControlledByAutomation(bool);
  
      WebPageInspectorController& inspectorController() { return *m_inspectorController; }
@@ -17052,7 +17027,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
  
  #if PLATFORM(IOS_FAMILY)
      void showInspectorIndication();
-@@ -596,6 +610,11 @@ public:
+@@ -593,6 +607,11 @@ public:
  
      void setPageLoadStateObserver(std::unique_ptr<PageLoadState::Observer>&&);
  
@@ -17064,7 +17039,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
      void initializeWebPage();
      void setDrawingArea(std::unique_ptr<DrawingAreaProxy>&&);
  
-@@ -623,6 +642,7 @@ public:
+@@ -620,6 +639,7 @@ public:
      void closePage();
  
      void addPlatformLoadParameters(WebProcessProxy&, LoadParameters&);
@@ -17072,7 +17047,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
      RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadData(const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
-@@ -1141,6 +1161,7 @@ public:
+@@ -1134,6 +1154,7 @@ public:
  #endif
  
      void pageScaleFactorDidChange(double);
@@ -17080,7 +17055,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
      void pluginScaleFactorDidChange(double);
      void pluginZoomFactorDidChange(double);
  
-@@ -1215,14 +1236,20 @@ public:
+@@ -1208,14 +1229,20 @@ public:
      void didStartDrag();
      void dragCancelled();
      void setDragCaretRect(const WebCore::IntRect&);
@@ -17102,7 +17077,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
  #endif
  
      void processDidBecomeUnresponsive();
-@@ -1464,6 +1491,8 @@ public:
+@@ -1457,6 +1484,8 @@ public:
  
  #if PLATFORM(COCOA) || PLATFORM(GTK)
      RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
@@ -17111,7 +17086,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
  #endif
  
  #if ENABLE(WEB_CRYPTO)
-@@ -2551,6 +2580,7 @@ private:
+@@ -2549,6 +2578,7 @@ private:
      String m_overrideContentSecurityPolicy;
  
      RefPtr<WebInspectorUIProxy> m_inspector;
@@ -17119,7 +17094,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
  
  #if PLATFORM(COCOA)
      WeakObjCPtr<WKWebView> m_cocoaView;
-@@ -2800,6 +2830,20 @@ private:
+@@ -2798,6 +2828,20 @@ private:
      unsigned m_currentDragNumberOfFilesToBeAccepted { 0 };
      WebCore::IntRect m_currentDragCaretRect;
      WebCore::IntRect m_currentDragCaretEditableElementRect;
@@ -17140,7 +17115,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
  #endif
  
      PageLoadState m_pageLoadState;
-@@ -3013,6 +3057,9 @@ private:
+@@ -3011,6 +3055,9 @@ private:
          RefPtr<API::Object> messageBody;
      };
      Vector<InjectedBundleMessage> m_pendingInjectedBundleMessages;
@@ -17151,7 +17126,7 @@ index 6d05d6fc7908e4b2db85a6423c4fce6966600c4a..d447eb81730b2a048258f92cf6fb5f10
  #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
      std::unique_ptr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.messages.in b/Source/WebKit/UIProcess/WebPageProxy.messages.in
-index ab324811e16862d4eab1e8c6efd0183f9c64b8dd..57733275e2a3451973a7410ae09d7942da8e04c7 100644
+index ab324811e168..57733275e2a3 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
 +++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
 @@ -29,6 +29,7 @@ messages -> WebPageProxy {
@@ -17186,10 +17161,10 @@ index ab324811e16862d4eab1e8c6efd0183f9c64b8dd..57733275e2a3451973a7410ae09d7942
      DidPerformDragOperation(bool handled)
  #endif
 diff --git a/Source/WebKit/UIProcess/WebProcessPool.cpp b/Source/WebKit/UIProcess/WebProcessPool.cpp
-index c1330e7437ef932b6d532a01b45456d610368e9d..e33705b9c2ce085bb85209d9a3b5b738dfca87ed 100644
+index b27685769445..126db68d6b60 100644
 --- a/Source/WebKit/UIProcess/WebProcessPool.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
-@@ -571,6 +571,14 @@ void WebProcessPool::establishWorkerContextConnectionToNetworkProcess(NetworkPro
+@@ -507,6 +507,14 @@ void WebProcessPool::establishWorkerContextConnectionToNetworkProcess(NetworkPro
  
      // Arbitrarily choose the first process pool to host the service worker process.
      auto* processPool = processPools()[0];
@@ -17204,7 +17179,7 @@ index c1330e7437ef932b6d532a01b45456d610368e9d..e33705b9c2ce085bb85209d9a3b5b738
      ASSERT(processPool);
  
      WebProcessProxy* serviceWorkerProcessProxy { nullptr };
-@@ -802,7 +810,10 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
+@@ -738,7 +746,10 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
  #endif
  
      parameters.cacheModel = LegacyGlobalSettings::singleton().cacheModel();
@@ -17217,10 +17192,10 @@ index c1330e7437ef932b6d532a01b45456d610368e9d..e33705b9c2ce085bb85209d9a3b5b738
      parameters.urlSchemesRegisteredAsEmptyDocument = copyToVector(m_schemesToRegisterAsEmptyDocument);
      parameters.urlSchemesRegisteredAsSecure = copyToVector(LegacyGlobalSettings::singleton().schemesToRegisterAsSecure());
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.cpp b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-index 447216b5c9fa428660f030d7a9599a2e2c78fc5f..dcff288102a46c7a377c6185597888be7f8b1fa6 100644
+index ae9a29985cc5..9e54346f0576 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-@@ -122,6 +122,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
+@@ -123,6 +123,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
      return map;
  }
  
@@ -17233,7 +17208,7 @@ index 447216b5c9fa428660f030d7a9599a2e2c78fc5f..dcff288102a46c7a377c6185597888be
  {
      return allProcesses().get(identifier);
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.h b/Source/WebKit/UIProcess/WebProcessProxy.h
-index 55c58c43ca7a96a7c93681616e3828660b106f7c..2e648b2610e3f7fc415e424687c937497d2c7205 100644
+index e225ff467dc8..520716c830b2 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.h
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.h
 @@ -137,6 +137,7 @@ public:
@@ -17245,7 +17220,7 @@ index 55c58c43ca7a96a7c93681616e3828660b106f7c..2e648b2610e3f7fc415e424687c93749
      WebConnection* webConnection() const { return m_webConnection.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-index d4090a9bb77ece44f93a182c74c700aa016ae266..7aea872d4053fab26664dffad8a1313eb05e8461 100644
+index d4090a9bb77e..7aea872d4053 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 @@ -2123,6 +2123,17 @@ void WebsiteDataStore::renameOriginInWebsiteData(URL&& oldName, URL&& newName, O
@@ -17267,7 +17242,7 @@ index d4090a9bb77ece44f93a182c74c700aa016ae266..7aea872d4053fab26664dffad8a1313e
  void WebsiteDataStore::hasAppBoundSession(CompletionHandler<void(bool)>&& completionHandler) const
  {
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
-index 9957e51ac587b36660bd6b2e20925811136e7a50..d1835053592b21b3d014e90d8a3e0c58dfc2073c 100644
+index 9957e51ac587..d1835053592b 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
 @@ -92,6 +92,7 @@ enum class CacheModel : uint8_t;
@@ -17351,7 +17326,7 @@ index 9957e51ac587b36660bd6b2e20925811136e7a50..d1835053592b21b3d014e90d8a3e0c58
      UniqueRef<SOAuthorizationCoordinator> m_soAuthorizationCoordinator;
  #endif
 diff --git a/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp b/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
-index 4f78b5eb5cdb51f2ebfcaff64ecd19b1e630ad9f..a2dc89ddf668e1be7b8f343a5df542b3141216cc 100644
+index 4f78b5eb5cdb..a2dc89ddf668 100644
 --- a/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
 +++ b/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
 @@ -27,9 +27,11 @@
@@ -17381,7 +17356,7 @@ index 4f78b5eb5cdb51f2ebfcaff64ecd19b1e630ad9f..a2dc89ddf668e1be7b8f343a5df542b3
  {
      ASSERT(m_backend);
 diff --git a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
-index 692a45a48fa027f9221338d74f5351bef4baf00f..db8c761c71cc7009be66255c2668de4eff36dee0 100644
+index 692a45a48fa0..db8c761c71cc 100644
 --- a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
 +++ b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
 @@ -60,6 +60,8 @@ void GeoclueGeolocationProvider::start(UpdateNotifyFunction&& updateNotifyFuncti
@@ -17416,7 +17391,7 @@ index 692a45a48fa027f9221338d74f5351bef4baf00f..db8c761c71cc7009be66255c2668de4e
          "org.freedesktop.GeoClue2", clientPath, "org.freedesktop.GeoClue2.Client", m_cancellable.get(),
          [](GObject*, GAsyncResult* result, gpointer userData) {
 diff --git a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
-index b5e48e6c61a8a3f4b40b84112c4010101c4d5f41..46747b1d78bfe0270178609867c0d710807fa668 100644
+index b5e48e6c61a8..46747b1d78bf 100644
 --- a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
 +++ b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
 @@ -71,6 +71,9 @@ private:
@@ -17431,7 +17406,7 @@ index b5e48e6c61a8a3f4b40b84112c4010101c4d5f41..46747b1d78bfe0270178609867c0d710
  };
 diff --git a/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.cpp b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..31a4e32d4cf8442049f0bea04c817a40b801c1f7
+index 000000000000..31a4e32d4cf8
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.cpp
 @@ -0,0 +1,147 @@
@@ -17584,7 +17559,7 @@ index 0000000000000000000000000000000000000000..31a4e32d4cf8442049f0bea04c817a40
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.h b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..8006336003a4512b4c63bc8272d4b3507bb63159
+index 000000000000..8006336003a4
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.h
 @@ -0,0 +1,60 @@
@@ -17649,7 +17624,7 @@ index 0000000000000000000000000000000000000000..8006336003a4512b4c63bc8272d4b350
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
-index 39aeff71fe05354cf63d3b3701d363642d63aca4..32e96cdd0bdbd8c5dcde43fdf60052ac13a226f7 100644
+index 39aeff71fe05..32e96cdd0bdb 100644
 --- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
 +++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
 @@ -28,6 +28,7 @@
@@ -17670,7 +17645,7 @@ index 39aeff71fe05354cf63d3b3701d363642d63aca4..32e96cdd0bdbd8c5dcde43fdf60052ac
      virtual void unrealize() { };
      virtual bool makeContextCurrent() { return false; }
 diff --git a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h
-index 054e80bd900cf16d69801e8102ca989ff0563e1d..8245d7ed58008dbb6152e55e619e4331d30ae674 100644
+index 054e80bd900c..8245d7ed5800 100644
 --- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h
 +++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h
 @@ -52,6 +52,7 @@ private:
@@ -17683,7 +17658,7 @@ index 054e80bd900cf16d69801e8102ca989ff0563e1d..8245d7ed58008dbb6152e55e619e4331
      WebCore::XUniqueDamage m_damage;
 diff --git a/Source/WebKit/UIProcess/gtk/InspectorTargetProxyGtk.cpp b/Source/WebKit/UIProcess/gtk/InspectorTargetProxyGtk.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..8a86cc348bc210b71bb463dcb3057f575ad7c1d3
+index 000000000000..8a86cc348bc2
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/gtk/InspectorTargetProxyGtk.cpp
 @@ -0,0 +1,44 @@
@@ -17732,7 +17707,7 @@ index 0000000000000000000000000000000000000000..8a86cc348bc210b71bb463dcb3057f57
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp b/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp
-index 2ac15c9d7f1f19947b449794862555e913e211b7..111cd5464a19b81e73ba1bd02a2d76918cb40612 100644
+index 2ac15c9d7f1f..111cd5464a19 100644
 --- a/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp
 +++ b/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp
 @@ -34,6 +34,8 @@
@@ -17746,7 +17721,7 @@ index 2ac15c9d7f1f19947b449794862555e913e211b7..111cd5464a19b81e73ba1bd02a2d7691
  Ref<WebDateTimePickerGtk> WebDateTimePickerGtk::create(WebPageProxy& page)
 diff --git a/Source/WebKit/UIProcess/gtk/WebPageInspectorEmulationAgentGtk.cpp b/Source/WebKit/UIProcess/gtk/WebPageInspectorEmulationAgentGtk.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..e5e25acebabb76a05a77db02a99f1267bd99a3af
+index 000000000000..e5e25acebabb
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/gtk/WebPageInspectorEmulationAgentGtk.cpp
 @@ -0,0 +1,69 @@
@@ -17821,7 +17796,7 @@ index 0000000000000000000000000000000000000000..e5e25acebabb76a05a77db02a99f1267
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/gtk/WebPageInspectorInputAgentGtk.cpp b/Source/WebKit/UIProcess/gtk/WebPageInspectorInputAgentGtk.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..d0f9827544994e450e24e3f7a427c35eeff94d67
+index 000000000000..d0f982754499
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/gtk/WebPageInspectorInputAgentGtk.cpp
 @@ -0,0 +1,105 @@
@@ -17931,7 +17906,7 @@ index 0000000000000000000000000000000000000000..d0f9827544994e450e24e3f7a427c35e
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
-index 56b32598708dbac89156336dc12ef2d194d597c8..d6c213d4cfa3159849a09423b85ce0900d27b080 100644
+index 56b32598708d..d6c213d4cfa3 100644
 --- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 +++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 @@ -441,6 +441,8 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
@@ -17945,7 +17920,7 @@ index 56b32598708dbac89156336dc12ef2d194d597c8..d6c213d4cfa3159849a09423b85ce090
  
 diff --git a/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.h b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..a16815a6759da61a6a61e3d79058228af887fd7c
+index 000000000000..a16815a6759d
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.h
 @@ -0,0 +1,51 @@
@@ -18002,7 +17977,7 @@ index 0000000000000000000000000000000000000000..a16815a6759da61a6a61e3d79058228a
 +} // namespace API
 diff --git a/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.mm b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.mm
 new file mode 100644
-index 0000000000000000000000000000000000000000..8e588f7b8c8c29fb53dd37ea41d46f3d753077fd
+index 000000000000..8e588f7b8c8c
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.mm
 @@ -0,0 +1,77 @@
@@ -18085,7 +18060,7 @@ index 0000000000000000000000000000000000000000..8e588f7b8c8c29fb53dd37ea41d46f3d
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/mac/InspectorTargetProxyMac.mm b/Source/WebKit/UIProcess/mac/InspectorTargetProxyMac.mm
 new file mode 100644
-index 0000000000000000000000000000000000000000..721826c8c98fc85b68a4f45deaee69c1219a7254
+index 000000000000..721826c8c98f
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/InspectorTargetProxyMac.mm
 @@ -0,0 +1,42 @@
@@ -18132,7 +18107,7 @@ index 0000000000000000000000000000000000000000..721826c8c98fc85b68a4f45deaee69c1
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/mac/PageClientImplMac.h b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
-index dd7b497aa64bf7a23eef18486ebcb443a35871e4..5062b795b591e75df484c6c6c5df90432dffed2d 100644
+index dd7b497aa64b..5062b795b591 100644
 --- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
 +++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
 @@ -53,6 +53,8 @@ class PageClientImpl final : public PageClientImplCocoa
@@ -18166,7 +18141,7 @@ index dd7b497aa64bf7a23eef18486ebcb443a35871e4..5062b795b591e75df484c6c6c5df9043
      void navigationGestureWillEnd(bool willNavigate, WebBackForwardListItem&) override;
      void navigationGestureDidEnd(bool willNavigate, WebBackForwardListItem&) override;
 diff --git a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
-index c2de8d6ea7c0bcafa0914c1f52ae4d645df869dc..c019122519adf07c4d9dbb87551325aa9b6b661d 100644
+index c2de8d6ea7c0..c019122519ad 100644
 --- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
 +++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
 @@ -81,6 +81,7 @@
@@ -18287,7 +18262,7 @@ index c2de8d6ea7c0bcafa0914c1f52ae4d645df869dc..c019122519adf07c4d9dbb87551325aa
  }
  
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
-index 56061afc3d03eb1d3ed99a39dacd6ccad36109be..7a148e64432926fce48e13fad5e8476609d607d4 100644
+index 56061afc3d03..7a148e644329 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
 @@ -63,6 +63,7 @@ private:
@@ -18299,7 +18274,7 @@ index 56061afc3d03eb1d3ed99a39dacd6ccad36109be..7a148e64432926fce48e13fad5e84766
      void getContextMenuItem(const WebContextMenuItemData&, CompletionHandler<void(NSMenuItem *)>&&);
      void getContextMenuFromItems(const Vector<WebContextMenuItemData>&, CompletionHandler<void(NSMenu *)>&&);
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-index f8090ad16dd3d696d0daf3baa41604c868d08684..696c745c42f445482d71e315dd1f159d3db71de7 100644
+index 655b0b839d35..e0ba34e2c304 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 @@ -361,6 +361,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
@@ -18317,7 +18292,7 @@ index f8090ad16dd3d696d0daf3baa41604c868d08684..696c745c42f445482d71e315dd1f159d
  #if ENABLE(SERVICE_CONTROLS)
 diff --git a/Source/WebKit/UIProcess/mac/WebPageInspectorEmulationAgentMac.mm b/Source/WebKit/UIProcess/mac/WebPageInspectorEmulationAgentMac.mm
 new file mode 100644
-index 0000000000000000000000000000000000000000..6113f4cd60a5d72b8ead61176cb43200803478ed
+index 000000000000..6113f4cd60a5
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/WebPageInspectorEmulationAgentMac.mm
 @@ -0,0 +1,44 @@
@@ -18367,7 +18342,7 @@ index 0000000000000000000000000000000000000000..6113f4cd60a5d72b8ead61176cb43200
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/mac/WebPageInspectorInputAgentMac.mm b/Source/WebKit/UIProcess/mac/WebPageInspectorInputAgentMac.mm
 new file mode 100644
-index 0000000000000000000000000000000000000000..e6e2c8c2769e4657c01f1452e554fd6f6d457279
+index 000000000000..e6e2c8c2769e
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/WebPageInspectorInputAgentMac.mm
 @@ -0,0 +1,124 @@
@@ -18497,7 +18472,7 @@ index 0000000000000000000000000000000000000000..e6e2c8c2769e4657c01f1452e554fd6f
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.cpp b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..dd7fe0604188bb025f361f1c44685e38bbf935ca
+index 000000000000..dd7fe0604188
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.cpp
 @@ -0,0 +1,90 @@
@@ -18593,7 +18568,7 @@ index 0000000000000000000000000000000000000000..dd7fe0604188bb025f361f1c44685e38
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.h b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..df18883b2b7d22d73540cb084d3dd5291231097d
+index 000000000000..df18883b2b7d
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.h
 @@ -0,0 +1,60 @@
@@ -18659,7 +18634,7 @@ index 0000000000000000000000000000000000000000..df18883b2b7d22d73540cb084d3dd529
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/win/InspectorTargetProxyWin.cpp b/Source/WebKit/UIProcess/win/InspectorTargetProxyWin.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..135a60361fa8fbf907382625e7c8dd4ea64ceb94
+index 000000000000..135a60361fa8
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/InspectorTargetProxyWin.cpp
 @@ -0,0 +1,36 @@
@@ -18700,7 +18675,7 @@ index 0000000000000000000000000000000000000000..135a60361fa8fbf907382625e7c8dd4e
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
-index 3dcd0ec35c92e37239208a8f5d4f461fbeaac3ce..84ba07c57f2abac1bd0ca5d0af2e7366ad036892 100644
+index 3dcd0ec35c92..84ba07c57f2a 100644
 --- a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
 +++ b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
 @@ -112,5 +112,11 @@ WebContextMenuProxyWin::~WebContextMenuProxyWin()
@@ -18716,7 +18691,7 @@ index 3dcd0ec35c92e37239208a8f5d4f461fbeaac3ce..84ba07c57f2abac1bd0ca5d0af2e7366
  } // namespace WebKit
  #endif // ENABLE(CONTEXT_MENUS)
 diff --git a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
-index 0c80d970c3f9a987faf620081c909f6c7021970d..1467e5481f7417913c0d12a1cb492d02b2a7d1b7 100644
+index 0c80d970c3f9..1467e5481f74 100644
 --- a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
 +++ b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
 @@ -47,6 +47,7 @@ public:
@@ -18729,7 +18704,7 @@ index 0c80d970c3f9a987faf620081c909f6c7021970d..1467e5481f7417913c0d12a1cb492d02
  };
 diff --git a/Source/WebKit/UIProcess/win/WebPageInspectorEmulationAgentWin.cpp b/Source/WebKit/UIProcess/win/WebPageInspectorEmulationAgentWin.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..62b841fe1d0de2296e1c61e328cff564f5aa1c0f
+index 000000000000..62b841fe1d0d
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/WebPageInspectorEmulationAgentWin.cpp
 @@ -0,0 +1,58 @@
@@ -18793,7 +18768,7 @@ index 0000000000000000000000000000000000000000..62b841fe1d0de2296e1c61e328cff564
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/win/WebPageInspectorInputAgentWin.cpp b/Source/WebKit/UIProcess/win/WebPageInspectorInputAgentWin.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..5cf8a010e9809e6a95741cdb7c2cbeb445ab638b
+index 000000000000..5cf8a010e980
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/WebPageInspectorInputAgentWin.cpp
 @@ -0,0 +1,55 @@
@@ -18854,7 +18829,7 @@ index 0000000000000000000000000000000000000000..5cf8a010e9809e6a95741cdb7c2cbeb4
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/wpe/InspectorTargetProxyWPE.cpp b/Source/WebKit/UIProcess/wpe/InspectorTargetProxyWPE.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..7453194ca6f032ba86a4c67f5bf12688ab6ec1be
+index 000000000000..7453194ca6f0
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/wpe/InspectorTargetProxyWPE.cpp
 @@ -0,0 +1,40 @@
@@ -18900,7 +18875,7 @@ index 0000000000000000000000000000000000000000..7453194ca6f032ba86a4c67f5bf12688
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/wpe/WebPageInspectorEmulationAgentWPE.cpp b/Source/WebKit/UIProcess/wpe/WebPageInspectorEmulationAgentWPE.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..5dc76aa302cb574307059e66a1b73730efe920da
+index 000000000000..5dc76aa302cb
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/wpe/WebPageInspectorEmulationAgentWPE.cpp
 @@ -0,0 +1,41 @@
@@ -18947,7 +18922,7 @@ index 0000000000000000000000000000000000000000..5dc76aa302cb574307059e66a1b73730
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/wpe/WebPageInspectorInputAgentWPE.cpp b/Source/WebKit/UIProcess/wpe/WebPageInspectorInputAgentWPE.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705ef6ced129
+index 000000000000..c3d7cacea987
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/wpe/WebPageInspectorInputAgentWPE.cpp
 @@ -0,0 +1,55 @@
@@ -19007,10 +18982,10 @@ index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705e
 + 
 +} // namespace WebKit
 diff --git a/Source/WebKit/WebKit.xcodeproj/project.pbxproj b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10aa2dd6818 100644
+index 927525368116..2caf7e4571f3 100644
 --- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 +++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-@@ -1953,6 +1953,18 @@
+@@ -1954,6 +1954,18 @@
  		DF0C5F28252ECB8E00D921DB /* WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F24252ECB8D00D921DB /* WKDownload.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2A252ECB8E00D921DB /* WKDownloadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2B252ED44000D921DB /* WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */; };
@@ -19029,7 +19004,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  		DF462E0F23F22F5500EFF35F /* WKHTTPCookieStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */; };
-@@ -2009,6 +2021,9 @@
+@@ -2010,6 +2022,9 @@
  		E5BEF6822130C48000F31111 /* WebDataListSuggestionsDropdownIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E5BEF6802130C47F00F31111 /* WebDataListSuggestionsDropdownIOS.h */; };
  		E5CB07DC20E1678F0022C183 /* WKFormColorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */; };
  		ED82A7F2128C6FAF004477B3 /* WKBundlePageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22F0FF1289FCD90085E74F /* WKBundlePageOverlay.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -19059,7 +19034,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  		DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHTTPCookieStorePrivate.h; sourceTree = "<group>"; };
  		DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKContentWorldPrivate.h; sourceTree = "<group>"; };
  		DF58C6311371AC5800F9A37C /* NativeWebWheelEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeWebWheelEvent.h; sourceTree = "<group>"; };
-@@ -5952,6 +5980,14 @@
+@@ -5954,6 +5982,14 @@
  		ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtraPrivateSymbolsForTAPI.h; sourceTree = "<group>"; };
  		ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExtraPublicSymbolsForTAPI.h; sourceTree = "<group>"; };
  		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
@@ -19082,7 +19057,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -7921,6 +7958,7 @@
+@@ -7925,6 +7962,7 @@
  		37C4C08318149C2A003688B9 /* Cocoa */ = {
  			isa = PBXGroup;
  			children = (
@@ -19090,7 +19065,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				1A43E826188F38E2009E4D30 /* Deprecated */,
  				37A5E01218BBF937000A081E /* _WKActivatedElementInfo.h */,
  				37A5E01118BBF937000A081E /* _WKActivatedElementInfo.mm */,
-@@ -8993,6 +9031,7 @@
+@@ -8996,6 +9034,7 @@
  			isa = PBXGroup;
  			children = (
  				57A9FF15252C6AEF006A2040 /* libWTF.a */,
@@ -19098,7 +19073,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				5750F32A2032D4E500389347 /* LocalAuthentication.framework */,
  				570DAAB0230273D200E8FC04 /* NearField.framework */,
  			);
-@@ -9428,6 +9467,12 @@
+@@ -9431,6 +9470,12 @@
  			children = (
  				9197940423DBC4BB00257892 /* InspectorBrowserAgent.cpp */,
  				9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */,
@@ -19111,7 +19086,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  			);
  			path = Agents;
  			sourceTree = "<group>";
-@@ -9436,6 +9481,7 @@
+@@ -9439,6 +9484,7 @@
  			isa = PBXGroup;
  			children = (
  				A5D3504D1D78F0D2005124A9 /* RemoteWebInspectorUIProxyMac.mm */,
@@ -19119,7 +19094,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */,
  				99A7ACE326012919006D57FD /* WKInspectorResourceURLSchemeHandler.h */,
  				99A7ACE42601291A006D57FD /* WKInspectorResourceURLSchemeHandler.mm */,
-@@ -9925,6 +9971,12 @@
+@@ -9928,6 +9974,12 @@
  		BC032DC310F438260058C15A /* UIProcess */ = {
  			isa = PBXGroup;
  			children = (
@@ -19132,7 +19107,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				BC032DC410F4387C0058C15A /* API */,
  				512F588D12A8836F00629530 /* Authentication */,
  				9955A6E81C79809000EB6A93 /* Automation */,
-@@ -10223,6 +10275,7 @@
+@@ -10224,6 +10276,7 @@
  		BC0C376610F807660076D7CB /* C */ = {
  			isa = PBXGroup;
  			children = (
@@ -19140,7 +19115,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				5123CF18133D25E60056F800 /* cg */,
  				6EE849C41368D9040038D481 /* mac */,
  				BCB63477116BF10600603215 /* WebKit2_C.h */,
-@@ -10818,6 +10871,11 @@
+@@ -10819,6 +10872,11 @@
  		BCCF085C113F3B7500C650C5 /* mac */ = {
  			isa = PBXGroup;
  			children = (
@@ -19152,7 +19127,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				B878B613133428DC006888E9 /* CorrectionPanel.h */,
  				B878B614133428DC006888E9 /* CorrectionPanel.mm */,
  				C1817362205844A900DFDA65 /* DisplayLink.cpp */,
-@@ -11653,6 +11711,7 @@
+@@ -11652,6 +11710,7 @@
  				99788ACB1F421DDA00C08000 /* _WKAutomationSessionConfiguration.h in Headers */,
  				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
  				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
@@ -19160,7 +19135,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
  				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
  				1A5704F81BE01FF400874AF1 /* _WKContextMenuElementInfo.h in Headers */,
-@@ -11950,6 +12009,7 @@
+@@ -11949,6 +12008,7 @@
  				1A14F8E21D74C834006CBEC6 /* FrameInfoData.h in Headers */,
  				1AE00D611831792100087DD7 /* FrameLoadState.h in Headers */,
  				5C121E842410208D00486F9B /* FrameTreeNodeData.h in Headers */,
@@ -19168,7 +19143,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				2D4AF0892044C3C4006C8817 /* FrontBoardServicesSPI.h in Headers */,
  				CD78E1151DB7D7ED0014A2DE /* FullscreenClient.h in Headers */,
  				CD19D2EA2046406F0017074A /* FullscreenTouchSecheuristic.h in Headers */,
-@@ -11965,6 +12025,7 @@
+@@ -11964,6 +12024,7 @@
  				4614F13225DED875007006E7 /* GPUProcessConnectionParameters.h in Headers */,
  				F40BBB41257FF46E0067463A /* GPUProcessWakeupMessageArguments.h in Headers */,
  				2DA049B8180CCD0A00AAFA9E /* GraphicsLayerCARemote.h in Headers */,
@@ -19176,7 +19151,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				C0CE72AD1247E78D00BC0EC4 /* HandleMessage.h in Headers */,
  				1AC75A1B1B3368270056745B /* HangDetectionDisabler.h in Headers */,
  				57AC8F50217FEED90055438C /* HidConnection.h in Headers */,
-@@ -12110,6 +12171,7 @@
+@@ -12109,6 +12170,7 @@
  				413075AC1DE85F370039EC69 /* NetworkRTCMonitor.h in Headers */,
  				41DC45961E3D6E2200B11F51 /* NetworkRTCProvider.h in Headers */,
  				5C20CBA01BB1ECD800895BB1 /* NetworkSession.h in Headers */,
@@ -19184,7 +19159,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				532159551DBAE7290054AA3C /* NetworkSessionCocoa.h in Headers */,
  				417915B92257046F00D6F97E /* NetworkSocketChannel.h in Headers */,
  				5183247C26168C62003F239E /* NetworkURLSchemeHandler.h in Headers */,
-@@ -12197,6 +12259,7 @@
+@@ -12196,6 +12258,7 @@
  				BC1A7C581136E19C00FB7167 /* ProcessLauncher.h in Headers */,
  				463FD4821EB94EC000A2982C /* ProcessTerminationReason.h in Headers */,
  				86E67A251910B9D100004AB7 /* ProcessThrottler.h in Headers */,
@@ -19192,7 +19167,7 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				83048AE61ACA45DC0082C832 /* ProcessThrottlerClient.h in Headers */,
  				A1E688701F6E2BAB007006A6 /* QuarantineSPI.h in Headers */,
  				1A0C227E2451130A00ED614D /* QuickLookThumbnailingSoftLink.h in Headers */,
-@@ -12217,6 +12280,7 @@
+@@ -12216,6 +12279,7 @@
  				CDAC20B423FB58F20021DEE3 /* RemoteCDMInstanceProxy.h in Headers */,
  				CDAC20CA23FC2F750021DEE3 /* RemoteCDMInstanceSession.h in Headers */,
  				CDAC20C923FC2F750021DEE3 /* RemoteCDMInstanceSessionIdentifier.h in Headers */,
@@ -19265,10 +19240,10 @@ index 7e316a5b3af95919e663342c38ce38a9c547ec7b..2c56603b03c7e090e22b734c0266f10a
  				BCBD3914125BB1A800D2C29F /* WebPageProxyMessageReceiver.cpp in Sources */,
  				7CE9CE101FA0767A000177DE /* WebPageUpdatePreferences.cpp in Sources */,
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
-index 4b0b66bebbf7609bca40f928e64018a310d99b5a..78c482769cb9b8fc690d10fba5f9cd79f0b87c4d 100644
+index c42d2c00f798..50da344e6bd2 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
-@@ -235,6 +235,11 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
+@@ -231,6 +231,11 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
      }
  #endif
  
@@ -19278,9 +19253,9 @@ index 4b0b66bebbf7609bca40f928e64018a310d99b5a..78c482769cb9b8fc690d10fba5f9cd79
 +    }
 +
      if (!tryLoadingUsingURLSchemeHandler(resourceLoader, trackingParameters)) {
-         WEBLOADERSTRATEGY_RELEASE_LOG_IF_ALLOWED("scheduleLoad: URL will be scheduled with the NetworkProcess");
+         WEBLOADERSTRATEGY_RELEASE_LOG("scheduleLoad: URL will be scheduled with the NetworkProcess");
  
-@@ -292,7 +297,8 @@ static void addParametersShared(const Frame* frame, NetworkResourceLoadParameter
+@@ -288,7 +293,8 @@ static void addParametersShared(const Frame* frame, NetworkResourceLoadParameter
      }
  }
  
@@ -19290,7 +19265,7 @@ index 4b0b66bebbf7609bca40f928e64018a310d99b5a..78c482769cb9b8fc690d10fba5f9cd79
  {
      ResourceLoadIdentifier identifier = resourceLoader.identifier();
      ASSERT(identifier);
-@@ -305,7 +311,6 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -301,7 +307,6 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
  
      auto* frame = resourceLoader.frame();
  
@@ -19298,12 +19273,12 @@ index 4b0b66bebbf7609bca40f928e64018a310d99b5a..78c482769cb9b8fc690d10fba5f9cd79
      loadParameters.identifier = identifier;
      loadParameters.webPageProxyID = trackingParameters.webPageProxyID;
      loadParameters.webPageID = trackingParameters.pageID;
-@@ -384,14 +389,11 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -380,14 +385,11 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
  
      if (loadParameters.options.mode != FetchOptions::Mode::Navigate) {
          ASSERT(loadParameters.sourceOrigin);
 -        if (!loadParameters.sourceOrigin) {
--            WEBLOADERSTRATEGY_RELEASE_LOG_ERROR_IF_ALLOWED("scheduleLoad: no sourceOrigin (priority=%d)", static_cast<int>(resourceLoader.request().priority()));
+-            WEBLOADERSTRATEGY_RELEASE_LOG_ERROR("scheduleLoad: no sourceOrigin (priority=%d)", static_cast<int>(resourceLoader.request().priority()));
 -            scheduleInternallyFailedLoad(resourceLoader);
 -            return;
 -        }
@@ -19316,7 +19291,7 @@ index 4b0b66bebbf7609bca40f928e64018a310d99b5a..78c482769cb9b8fc690d10fba5f9cd79
  
      loadParameters.isMainFrameNavigation = resourceLoader.frame() && resourceLoader.frame()->isMainFrame() && resourceLoader.options().mode == FetchOptions::Mode::Navigate;
  
-@@ -407,6 +409,17 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -403,6 +405,17 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
      }
  
      ASSERT((loadParameters.webPageID && loadParameters.webFrameID) || loadParameters.clientCredentialPolicy == ClientCredentialPolicy::CannotAskClientForCredentials);
@@ -19327,14 +19302,14 @@ index 4b0b66bebbf7609bca40f928e64018a310d99b5a..78c482769cb9b8fc690d10fba5f9cd79
 +{
 +    NetworkResourceLoadParameters loadParameters;
 +    if (!fillParametersForNetworkProcessLoad(resourceLoader, request, trackingParameters, shouldClearReferrerOnHTTPSToHTTPRedirect, maximumBufferingTime, loadParameters)) {
-+        WEBLOADERSTRATEGY_RELEASE_LOG_ERROR_IF_ALLOWED("scheduleLoad: no sourceOrigin (priority=%d)", static_cast<int>(resourceLoader.request().priority()));
++        WEBLOADERSTRATEGY_RELEASE_LOG_ERROR("scheduleLoad: no sourceOrigin (priority=%d)", static_cast<int>(resourceLoader.request().priority()));
 +        scheduleInternallyFailedLoad(resourceLoader);
 +        return;
 +    }
  
-     WEBLOADERSTRATEGY_RELEASE_LOG_IF_ALLOWED("scheduleLoad: Resource is being scheduled with the NetworkProcess (priority=%d)", static_cast<int>(resourceLoader.request().priority()));
+     WEBLOADERSTRATEGY_RELEASE_LOG("scheduleLoad: Resource is being scheduled with the NetworkProcess (priority=%d)", static_cast<int>(resourceLoader.request().priority()));
      if (!WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ScheduleResourceLoad(loadParameters), 0)) {
-@@ -418,7 +431,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -414,7 +427,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
      }
  
      auto loader = WebResourceLoader::create(resourceLoader, trackingParameters);
@@ -19343,7 +19318,7 @@ index 4b0b66bebbf7609bca40f928e64018a310d99b5a..78c482769cb9b8fc690d10fba5f9cd79
  }
  
  void WebLoaderStrategy::scheduleInternallyFailedLoad(WebCore::ResourceLoader& resourceLoader)
-@@ -817,7 +830,7 @@ void WebLoaderStrategy::didFinishPreconnection(uint64_t preconnectionIdentifier,
+@@ -813,7 +826,7 @@ void WebLoaderStrategy::didFinishPreconnection(uint64_t preconnectionIdentifier,
  
  bool WebLoaderStrategy::isOnLine() const
  {
@@ -19352,7 +19327,7 @@ index 4b0b66bebbf7609bca40f928e64018a310d99b5a..78c482769cb9b8fc690d10fba5f9cd79
  }
  
  void WebLoaderStrategy::addOnlineStateChangeListener(Function<void(bool)>&& listener)
-@@ -837,6 +850,11 @@ void WebLoaderStrategy::isResourceLoadFinished(CachedResource& resource, Complet
+@@ -833,6 +846,11 @@ void WebLoaderStrategy::isResourceLoadFinished(CachedResource& resource, Complet
  
  void WebLoaderStrategy::setOnLineState(bool isOnLine)
  {
@@ -19364,7 +19339,7 @@ index 4b0b66bebbf7609bca40f928e64018a310d99b5a..78c482769cb9b8fc690d10fba5f9cd79
      if (m_isOnLine == isOnLine)
          return;
  
-@@ -845,6 +863,12 @@ void WebLoaderStrategy::setOnLineState(bool isOnLine)
+@@ -841,6 +859,12 @@ void WebLoaderStrategy::setOnLineState(bool isOnLine)
          listener(isOnLine);
  }
  
@@ -19378,7 +19353,7 @@ index 4b0b66bebbf7609bca40f928e64018a310d99b5a..78c482769cb9b8fc690d10fba5f9cd79
  {
      WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::SetCaptureExtraNetworkLoadMetricsEnabled(enabled), 0);
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
-index ca2349958666a801b0e0a6bd767dbbcccfb716ae..b5529ff5a2e2fa97bccc21f88689624b3d5a3624 100644
+index ca2349958666..b5529ff5a2e2 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
 @@ -40,6 +40,7 @@ struct FetchOptions;
@@ -19409,7 +19384,7 @@ index ca2349958666a801b0e0a6bd767dbbcccfb716ae..b5529ff5a2e2fa97bccc21f88689624b
  
  } // namespace WebKit
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
-index 7d62e5e9a39d15caa375a11c9967456764df8997..1ac2495b9eba1df232c34a422c3c5cbb1571bc1b 100644
+index 7d62e5e9a39d..1ac2495b9eba 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 @@ -398,6 +398,8 @@ void WebChromeClient::setResizable(bool resizable)
@@ -19436,7 +19411,7 @@ index 7d62e5e9a39d15caa375a11c9967456764df8997..1ac2495b9eba1df232c34a422c3c5cbb
  {
      if (m_page.activeOpenPanelResultListener())
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
-index 2eb0886f13ed035a53b8eaa60605de4dfe53fbe3..c46393209cb4f80704bbc9268fad4371347d5b30 100644
+index 2eb0886f13ed..c46393209cb4 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
 @@ -29,6 +29,13 @@
@@ -19463,7 +19438,7 @@ index 2eb0886f13ed035a53b8eaa60605de4dfe53fbe3..c46393209cb4f80704bbc9268fad4371
  {
  }
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
-index 5da2bb9f4a2d7d423bee854471fe853d3e4a261d..91bf00964333903912e8d6899b1a64d1e7d3d2a7 100644
+index 5da2bb9f4a2d..91bf00964333 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 @@ -1566,13 +1566,6 @@ void WebFrameLoaderClient::transitionToCommittedForNewPage()
@@ -19481,7 +19456,7 @@ index 5da2bb9f4a2d7d423bee854471fe853d3e4a261d..91bf00964333903912e8d6899b1a64d1
  
  void WebFrameLoaderClient::didRestoreFromBackForwardCache()
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
-index e9f2b2237b1d8a1b21ad28e0fa309b80252b5ebd..b2d3ca7cc093ed428f95df992c208b1b9491067d 100644
+index e9f2b2237b1d..b2d3ca7cc093 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 @@ -127,7 +127,8 @@ static WebCore::CachedImage* cachedImage(Element& element)
@@ -19496,7 +19471,7 @@ index e9f2b2237b1d8a1b21ad28e0fa309b80252b5ebd..b2d3ca7cc093ed428f95df992c208b1b
      WebCore::CachedImage* image = cachedImage(element);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/win/WebDragClientWin.cpp b/Source/WebKit/WebProcess/WebCoreSupport/win/WebDragClientWin.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..2606914d22e85affd9b2f71c361c9db3a14da4f3
+index 000000000000..2606914d22e8
 --- /dev/null
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/win/WebDragClientWin.cpp
 @@ -0,0 +1,58 @@
@@ -19560,7 +19535,7 @@ index 0000000000000000000000000000000000000000..2606914d22e85affd9b2f71c361c9db3
 +#endif // ENABLE(DRAG_SUPPORT)
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebDragClientWPE.cpp b/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebDragClientWPE.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..9b413bb8150a1633d29b6e2606127c9c1d02442b
+index 000000000000..9b413bb8150a
 --- /dev/null
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebDragClientWPE.cpp
 @@ -0,0 +1,57 @@
@@ -19622,7 +19597,7 @@ index 0000000000000000000000000000000000000000..9b413bb8150a1633d29b6e2606127c9c
 +
 +#endif // ENABLE(DRAG_SUPPORT)
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
-index bc6d937bd62c1c9a801080f242b40da6d4c80c2c..cf4afa63bfb6b7b6d1b37456f1ed6ea7b74b2b4a 100644
+index 4a087235e7bc..3ea0a7106906 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
 @@ -36,7 +36,9 @@
@@ -19660,7 +19635,7 @@ index bc6d937bd62c1c9a801080f242b40da6d4c80c2c..cf4afa63bfb6b7b6d1b37456f1ed6ea7
      settings.setForceCompositingMode(store.getBoolValueForKey(WebPreferencesKey::forceCompositingModeKey()));
      // Fixed position elements need to be composited and create stacking contexts
      // in order to be scrolled by the ScrollingCoordinator.
-@@ -628,6 +641,11 @@ void DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode(GraphicsLay
+@@ -666,6 +679,11 @@ void DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode(GraphicsLay
      m_scrollOffset = IntSize();
      m_displayTimer.stop();
      m_isWaitingForDidUpdate = false;
@@ -19672,7 +19647,7 @@ index bc6d937bd62c1c9a801080f242b40da6d4c80c2c..cf4afa63bfb6b7b6d1b37456f1ed6ea7
  }
  
  void DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingMode()
-@@ -677,6 +695,11 @@ void DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingMode()
+@@ -715,6 +733,11 @@ void DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingMode()
          // UI process, we still need to let it know about the new contents, so send an Update message.
          send(Messages::DrawingAreaProxy::Update(m_backingStoreStateID, updateInfo));
      }
@@ -19685,10 +19660,10 @@ index bc6d937bd62c1c9a801080f242b40da6d4c80c2c..cf4afa63bfb6b7b6d1b37456f1ed6ea7
  
  void DrawingAreaCoordinatedGraphics::scheduleDisplay()
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
-index 407f4f3fb1fc69a6be366a4a5fb37b3dd4bb2252..ee32e49c7bee97bf4269df1d8e7599edf4a7f1ff 100644
+index 91226dd76b3f..71db76c7fa64 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
-@@ -166,8 +166,16 @@ void LayerTreeHost::setViewOverlayRootLayer(GraphicsLayer* viewOverlayRootLayer)
+@@ -183,8 +183,16 @@ void LayerTreeHost::setViewOverlayRootLayer(GraphicsLayer* viewOverlayRootLayer)
  void LayerTreeHost::scrollNonCompositedContents(const IntRect& rect)
  {
      auto* frameView = m_webPage.mainFrameView();
@@ -19705,7 +19680,7 @@ index 407f4f3fb1fc69a6be366a4a5fb37b3dd4bb2252..ee32e49c7bee97bf4269df1d8e7599ed
  
      m_viewportController.didScroll(rect.location());
      if (m_isDiscardable)
-@@ -286,6 +294,10 @@ void LayerTreeHost::didChangeViewport()
+@@ -313,6 +321,10 @@ void LayerTreeHost::didChangeViewport()
  
          if (!view->useFixedLayout())
              view->notifyScrollPositionChanged(m_lastScrollPosition);
@@ -19717,24 +19692,25 @@ index 407f4f3fb1fc69a6be366a4a5fb37b3dd4bb2252..ee32e49c7bee97bf4269df1d8e7599ed
  
      if (m_lastPageScaleFactor != pageScale) {
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
-index db65f813267df986b7156c38f8d0259bc266a60b..9677ab1cfe53a589e0282f61f25beca3718f2a1e 100644
+index 4943393a2c35..e2bc9cd5cfc6 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
-@@ -97,7 +97,11 @@ public:
-     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID);
- 
-     WebCore::PlatformDisplayID displayID() const { return m_displayID; }
--
+@@ -105,6 +105,13 @@ public:
+     void adjustTransientZoom(double, WebCore::FloatPoint);
+     void commitTransientZoom(double, WebCore::FloatPoint);
+ #endif
++
 +// Playwright begin
 +#if USE(COORDINATED_GRAPHICS)
 +    const SimpleViewportController& viewportController() const { return m_viewportController; }
 +#endif
 +// Playwright end
++
  private:
  #if USE(COORDINATED_GRAPHICS)
      void layerFlushTimerFired();
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
-index be37cb482bccc92412701ba41951c3da57cb7e2e..aebb82d4e149c192bc28383fc722ae1b0a2f5d14 100644
+index be37cb482bcc..aebb82d4e149 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
 @@ -29,6 +29,7 @@
@@ -19746,7 +19722,7 @@ index be37cb482bccc92412701ba41951c3da57cb7e2e..aebb82d4e149c192bc28383fc722ae1b
  #include <GLES2/gl2.h>
  #include <WebCore/Document.h>
 diff --git a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
-index cdba5ae658de5bda9ef87a2b6ebc99a44d33d658..90d718d74188fcb2ae05ba7b1dd741054d061366 100644
+index cdba5ae658de..90d718d74188 100644
 --- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
 @@ -27,6 +27,7 @@
@@ -19772,7 +19748,7 @@ index cdba5ae658de5bda9ef87a2b6ebc99a44d33d658..90d718d74188fcb2ae05ba7b1dd74105
  {
      if (m_hasRemovedMessageReceiver)
 diff --git a/Source/WebKit/WebProcess/WebPage/DrawingArea.h b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
-index bdc3dbee7e58bdcca551b85d9258f70dc34dda9b..a882d868046265efb85f2635adccdad35b31e374 100644
+index 74771ec40ccb..74ff494c1abe 100644
 --- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
 +++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
 @@ -144,6 +144,9 @@ public:
@@ -19786,7 +19762,7 @@ index bdc3dbee7e58bdcca551b85d9258f70dc34dda9b..a882d868046265efb85f2635adccdad3
      virtual void adoptLayersFromDrawingArea(DrawingArea&) { }
      virtual void adoptDisplayRefreshMonitorsFromDrawingArea(DrawingArea&) { }
 diff --git a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
-index 633828983ef77632392d0dbc2e4a90489e340b9e..91a09a613a0031fc3ba5ee452ac4bb843a216ffe 100644
+index 633828983ef7..91a09a613a00 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
 @@ -28,15 +28,19 @@
@@ -19833,7 +19809,7 @@ index 633828983ef77632392d0dbc2e4a90489e340b9e..91a09a613a0031fc3ba5ee452ac4bb84
 +
  } // namespace WebKit
 diff --git a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
-index bc78502b18b994a3ffa47b933273ebdb84fafde9..f4c95fcbc0a1d618cc51f748a0df82b7ebe20cab 100644
+index bc78502b18b9..f4c95fcbc0a1 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
 @@ -52,6 +52,8 @@ public:
@@ -19846,7 +19822,7 @@ index bc78502b18b994a3ffa47b933273ebdb84fafde9..f4c95fcbc0a1d618cc51f748a0df82b7
      WebCookieJar();
  
 diff --git a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
-index b2d54a627b94583bda3518c4e7c3364481b605a4..d407e32b6a7b8b27925c49391e86d42c9b3dfa8b 100644
+index b2d54a627b94..d407e32b6a7b 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
 @@ -47,6 +47,14 @@ void WebDocumentLoader::detachFromFrame()
@@ -19865,7 +19841,7 @@ index b2d54a627b94583bda3518c4e7c3364481b605a4..d407e32b6a7b8b27925c49391e86d42c
  {
      ASSERT(navigationID);
 diff --git a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h
-index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4e5365822 100644
+index f127d64d005a..df0de26e4dc4 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h
 @@ -43,7 +43,10 @@ public:
@@ -19880,10 +19856,10 @@ index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4
      uint64_t m_navigationID;
  };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2b49d8f35 100644
+index 2d4a141fe05e..476a708e1754 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-@@ -875,6 +875,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
+@@ -874,6 +874,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
  
      m_page->setCanUseCredentialStorage(parameters.canUseCredentialStorage);
  
@@ -19893,7 +19869,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
      updateThrottleState();
  }
  
-@@ -1660,6 +1663,22 @@ void WebPage::platformDidReceiveLoadParameters(const LoadParameters& loadParamet
+@@ -1659,6 +1662,22 @@ void WebPage::platformDidReceiveLoadParameters(const LoadParameters& loadParamet
  }
  #endif
  
@@ -19916,7 +19892,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
  void WebPage::loadRequest(LoadParameters&& loadParameters)
  {
      setLastNavigationWasAppBound(loadParameters.request.isAppBound());
-@@ -1920,17 +1939,13 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
+@@ -1928,17 +1947,13 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
      view->resize(viewSize);
      m_drawingArea->setNeedsDisplay();
  
@@ -19935,7 +19911,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
  
      // Viewport properties have no impact on zero sized fixed viewports.
      if (m_viewSize.isEmpty())
-@@ -1947,20 +1962,18 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
+@@ -1955,20 +1970,18 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
  
      ViewportAttributes attr = computeViewportAttributes(viewportArguments, minimumLayoutFallbackWidth, deviceWidth, deviceHeight, 1, m_viewSize);
  
@@ -19963,7 +19939,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
  
  #if USE(COORDINATED_GRAPHICS)
      m_drawingArea->didChangeViewportAttributes(WTFMove(attr));
-@@ -1968,7 +1981,6 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
+@@ -1976,7 +1989,6 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
      send(Messages::WebPageProxy::DidChangeViewportProperties(attr));
  #endif
  }
@@ -19971,7 +19947,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
  
  void WebPage::scrollMainFrameIfNotAtMaxScrollPosition(const IntSize& scrollOffset)
  {
-@@ -2263,6 +2275,7 @@ void WebPage::scaleView(double scale)
+@@ -2271,6 +2283,7 @@ void WebPage::scaleView(double scale)
      }
  
      m_page->setViewScaleFactor(scale);
@@ -19979,7 +19955,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
      scalePage(pageScale, scrollPositionAtNewScale);
  }
  
-@@ -2367,17 +2380,13 @@ void WebPage::viewportPropertiesDidChange(const ViewportArguments& viewportArgum
+@@ -2375,17 +2388,13 @@ void WebPage::viewportPropertiesDidChange(const ViewportArguments& viewportArgum
          viewportConfigurationChanged();
  #endif
  
@@ -19998,7 +19974,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
  }
  
  void WebPage::listenForLayoutMilestones(OptionSet<WebCore::LayoutMilestone> milestones)
-@@ -3244,6 +3253,104 @@ void WebPage::touchEvent(const WebTouchEvent& touchEvent)
+@@ -3252,6 +3261,104 @@ void WebPage::touchEvent(const WebTouchEvent& touchEvent)
  
      send(Messages::WebPageProxy::DidReceiveEvent(static_cast<uint32_t>(touchEvent.type()), handled));
  }
@@ -20103,7 +20079,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
  #endif
  
  void WebPage::cancelPointer(WebCore::PointerID pointerId, const WebCore::IntPoint& documentPoint)
-@@ -3320,6 +3427,11 @@ void WebPage::sendMessageToTargetBackend(const String& targetId, const String& m
+@@ -3328,6 +3435,11 @@ void WebPage::sendMessageToTargetBackend(const String& targetId, const String& m
      m_inspectorTargetController->sendMessageToTargetBackend(targetId, message);
  }
  
@@ -20115,7 +20091,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
  void WebPage::insertNewlineInQuotedContent()
  {
      Frame& frame = m_page->focusController().focusedOrMainFrame();
-@@ -3557,6 +3669,7 @@ void WebPage::didCompletePageTransition()
+@@ -3565,6 +3677,7 @@ void WebPage::didCompletePageTransition()
  void WebPage::show()
  {
      send(Messages::WebPageProxy::ShowPage());
@@ -20123,7 +20099,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
  }
  
  void WebPage::setIsTakingSnapshotsForApplicationSuspension(bool isTakingSnapshotsForApplicationSuspension)
-@@ -4297,7 +4410,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
+@@ -4305,7 +4418,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
  
  #if ENABLE(DRAG_SUPPORT)
  
@@ -20132,7 +20108,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
  void WebPage::performDragControllerAction(DragControllerAction action, const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation> draggingSourceOperationMask, SelectionData&& selectionData, OptionSet<DragApplicationFlags> flags)
  {
      if (!m_page) {
-@@ -6625,6 +6738,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
+@@ -6627,6 +6740,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
              WebsitePoliciesData::applyToDocumentLoader(WTFMove(*m_pendingWebsitePolicies), documentLoader);
              m_pendingWebsitePolicies = std::nullopt;
          }
@@ -20143,7 +20119,7 @@ index 1f2ac39c6f16b25754523b2bb0f87d6e705946a7..7a00e3dabe06a101f449ebdfbd4474c2
  
      return documentLoader;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.h b/Source/WebKit/WebProcess/WebPage/WebPage.h
-index 0e341b60cc8295145dbfa5b53e40889b5d3d98fc..dd712d8e15498ae5c91091369463c1cded5a31ff 100644
+index d676e701560f..52f4c9054c68 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
 @@ -111,6 +111,10 @@ typedef struct _AtkObject AtkObject;
@@ -20157,7 +20133,7 @@ index 0e341b60cc8295145dbfa5b53e40889b5d3d98fc..dd712d8e15498ae5c91091369463c1cd
  #if PLATFORM(GTK) || PLATFORM(WPE)
  #include "InputMethodState.h"
  #endif
-@@ -962,11 +966,11 @@ public:
+@@ -960,11 +964,11 @@ public:
      void clearSelection();
      void restoreSelectionInFocusedEditableElement();
  
@@ -20171,7 +20147,7 @@ index 0e341b60cc8295145dbfa5b53e40889b5d3d98fc..dd712d8e15498ae5c91091369463c1cd
      void performDragControllerAction(DragControllerAction, const WebCore::DragData&, SandboxExtension::Handle&&, SandboxExtension::HandleArray&&);
  #endif
  
-@@ -980,6 +984,9 @@ public:
+@@ -978,6 +982,9 @@ public:
      void didStartDrag();
      void dragCancelled();
      OptionSet<WebCore::DragSourceAction> allowedDragSourceActions() const { return m_allowedDragSourceActions; }
@@ -20181,7 +20157,7 @@ index 0e341b60cc8295145dbfa5b53e40889b5d3d98fc..dd712d8e15498ae5c91091369463c1cd
  #endif
  
      void beginPrinting(WebCore::FrameIdentifier, const PrintInfo&);
-@@ -1212,6 +1219,7 @@ public:
+@@ -1210,6 +1217,7 @@ public:
      void connectInspector(const String& targetId, Inspector::FrontendChannel::ConnectionType);
      void disconnectInspector(const String& targetId);
      void sendMessageToTargetBackend(const String& targetId, const String& message);
@@ -20189,7 +20165,7 @@ index 0e341b60cc8295145dbfa5b53e40889b5d3d98fc..dd712d8e15498ae5c91091369463c1cd
  
      void insertNewlineInQuotedContent();
  
-@@ -1561,6 +1569,7 @@ private:
+@@ -1559,6 +1567,7 @@ private:
      // Actions
      void tryClose(CompletionHandler<void(bool)>&&);
      void platformDidReceiveLoadParameters(const LoadParameters&);
@@ -20197,7 +20173,7 @@ index 0e341b60cc8295145dbfa5b53e40889b5d3d98fc..dd712d8e15498ae5c91091369463c1cd
      void loadRequest(LoadParameters&&);
      NO_RETURN void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
      void loadData(LoadParameters&&);
-@@ -1598,6 +1607,7 @@ private:
+@@ -1596,6 +1605,7 @@ private:
      void updatePotentialTapSecurityOrigin(const WebTouchEvent&, bool wasHandled);
  #elif ENABLE(TOUCH_EVENTS)
      void touchEvent(const WebTouchEvent&);
@@ -20205,7 +20181,7 @@ index 0e341b60cc8295145dbfa5b53e40889b5d3d98fc..dd712d8e15498ae5c91091369463c1cd
  #endif
  
      void cancelPointer(WebCore::PointerID, const WebCore::IntPoint&);
-@@ -1720,9 +1730,7 @@ private:
+@@ -1718,9 +1728,7 @@ private:
      void countStringMatches(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount);
      void replaceMatches(const Vector<uint32_t>& matchIndices, const String& replacementText, bool selectionOnly, CompletionHandler<void(uint64_t)>&&);
  
@@ -20215,7 +20191,7 @@ index 0e341b60cc8295145dbfa5b53e40889b5d3d98fc..dd712d8e15498ae5c91091369463c1cd
  
      void didChangeSelectedIndexForActivePopupMenu(int32_t newIndex);
      void setTextForActivePopupMenu(int32_t index);
-@@ -2248,6 +2256,7 @@ private:
+@@ -2246,6 +2254,7 @@ private:
      UserActivity m_userActivity;
  
      uint64_t m_pendingNavigationID { 0 };
@@ -20224,7 +20200,7 @@ index 0e341b60cc8295145dbfa5b53e40889b5d3d98fc..dd712d8e15498ae5c91091369463c1cd
  
      bool m_mainFrameProgressCompleted { false };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-index 5618a343de4a5746b59cbb0f1714af8c752fc34a..ce8bec4b8d1548044df81b4bf9b86424047dfc2a 100644
+index 5bde3f8da91c..db386f614801 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 @@ -133,6 +133,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
@@ -20276,7 +20252,7 @@ index 5618a343de4a5746b59cbb0f1714af8c752fc34a..ce8bec4b8d1548044df81b4bf9b86424
      RequestDragStart(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
      RequestAdditionalItemsForDragSession(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
 diff --git a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
-index 2ab1084c5cdc4b3fa8e4eb725541b6860502484e..68c300f49fce77b0273a45a0bfc4acbc3b9d6cbd 100644
+index 2ab1084c5cdc..68c300f49fce 100644
 --- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
 +++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
 @@ -830,21 +830,37 @@ String WebPage::platformUserAgent(const URL&) const
@@ -20318,7 +20294,7 @@ index 2ab1084c5cdc4b3fa8e4eb725541b6860502484e..68c300f49fce77b0273a45a0bfc4acbc
  }
  
 diff --git a/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp b/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
-index 8e9454597bb23b22c506f929020fc3c37ffaa71a..9730e673e85da143a3acdda03fb9fa3fb4fb1119 100644
+index 8e9454597bb2..9730e673e85d 100644
 --- a/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
 @@ -43,6 +43,7 @@
@@ -20368,7 +20344,7 @@ index 8e9454597bb23b22c506f929020fc3c37ffaa71a..9730e673e85da143a3acdda03fb9fa3f
  }
  
 diff --git a/Source/WebKit/WebProcess/WebProcess.cpp b/Source/WebKit/WebProcess/WebProcess.cpp
-index 788278943a817f3c4def4ad08e685fe3a639907e..5361d8458851e5ebeda4ee68809c39e79f26c228 100644
+index db4c228323a8..16f73b56d9f1 100644
 --- a/Source/WebKit/WebProcess/WebProcess.cpp
 +++ b/Source/WebKit/WebProcess/WebProcess.cpp
 @@ -87,6 +87,7 @@
@@ -20389,7 +20365,7 @@ index 788278943a817f3c4def4ad08e685fe3a639907e..5361d8458851e5ebeda4ee68809c39e7
  
  void WebProcess::initializeConnection(IPC::Connection* connection)
 diff --git a/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp b/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp
-index 8987c3964a9308f2454759de7f8972215a3ae416..bcac0afeb94ed8123d1f9fb0b932c8497d157b49 100644
+index 8987c3964a93..bcac0afeb94e 100644
 --- a/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp
 +++ b/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp
 @@ -42,7 +42,9 @@ public:
@@ -20404,7 +20380,7 @@ index 8987c3964a9308f2454759de7f8972215a3ae416..bcac0afeb94ed8123d1f9fb0b932c849
              SetProcessDPIAware();
          return true;
 diff --git a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-index e3c71afc331fae75c1cbae370a944e31b68b8d02..a4ed6d666b5c68ebeeacab52c0bff80f7526b6d5 100644
+index d60519bc434c..f7f08e5fe361 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 @@ -4237,7 +4237,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
@@ -20417,7 +20393,7 @@ index e3c71afc331fae75c1cbae370a944e31b68b8d02..a4ed6d666b5c68ebeeacab52c0bff80f
  - (void)touch:(WebEvent *)event
  {
 diff --git a/Source/WebKitLegacy/mac/WebView/WebView.mm b/Source/WebKitLegacy/mac/WebView/WebView.mm
-index 8a4ec8910ca2f4104e4b59b22f1081200f280f9b..ef1933c8030f40d9deed891fcef31a93ad037c7d 100644
+index 8a4ec8910ca2..ef1933c8030f 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
 @@ -4027,7 +4027,7 @@ IGNORE_WARNINGS_END
@@ -20440,7 +20416,7 @@ index 8a4ec8910ca2f4104e4b59b22f1081200f280f9b..ef1933c8030f40d9deed891fcef31a93
  // a per-WebView and a per-preferences setting for whether to use the back/forward cache.
 diff --git a/Source/cmake/FindLibVPX.cmake b/Source/cmake/FindLibVPX.cmake
 new file mode 100644
-index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d5d9dc387
+index 000000000000..dd6a53e2d573
 --- /dev/null
 +++ b/Source/cmake/FindLibVPX.cmake
 @@ -0,0 +1,25 @@
@@ -20470,7 +20446,7 @@ index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d
 +    LIBVPX_LIBRARIES
 +)
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index ff62987d6ed6e113d600d272b38909287b3aced0..5bd739b752e4b2f5ae4772ff9e70f9a32ee39628 100644
+index 7de2d6046a98..177951f94be6 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
 @@ -5,6 +5,8 @@ WEBKIT_OPTION_BEGIN()
@@ -20534,12 +20510,12 @@ index ff62987d6ed6e113d600d272b38909287b3aced0..5bd739b752e4b2f5ae4772ff9e70f9a3
  
  # Finalize the value for all options. Do not attempt to use an option before
 diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
-index 8156841e97f680838fa1ae8f0bcf1799bf612e56..71dcf356359969e7ec900dde68f79e115df1035f 100644
+index aefcaae96be0..78d5b8bae595 100644
 --- a/Source/cmake/OptionsWPE.cmake
 +++ b/Source/cmake/OptionsWPE.cmake
 @@ -3,6 +3,7 @@ include(VersioningUtils)
  
- SET_PROJECT_VERSION(2 33 1)
+ SET_PROJECT_VERSION(2 33 2)
  
 +set(ENABLE_WEBKIT_LEGACY OFF)
  set(USER_AGENT_BRANDING "" CACHE STRING "Branding to add to user agent string")
@@ -20573,7 +20549,7 @@ index 8156841e97f680838fa1ae8f0bcf1799bf612e56..71dcf356359969e7ec900dde68f79e11
  WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." PUBLIC ON)
  
 diff --git a/Source/cmake/OptionsWin.cmake b/Source/cmake/OptionsWin.cmake
-index 1ecfd21e44703b2d61aff5494414d33878f0cfcd..02791cd57e26c6e07dc759a77e22ea77767f6bc6 100644
+index 1ecfd21e4470..02791cd57e26 100644
 --- a/Source/cmake/OptionsWin.cmake
 +++ b/Source/cmake/OptionsWin.cmake
 @@ -7,8 +7,9 @@ add_definitions(-D_WINDOWS -DWINVER=0x601 -D_WIN32_WINNT=0x601)
@@ -20602,7 +20578,7 @@ index 1ecfd21e44703b2d61aff5494414d33878f0cfcd..02791cd57e26c6e07dc759a77e22ea77
      WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETSCAPE_PLUGIN_API PRIVATE OFF)
  else ()
 diff --git a/Source/cmake/OptionsWinCairo.cmake b/Source/cmake/OptionsWinCairo.cmake
-index 512392e6424ea64ff65fffc14df30344ce6cbe99..90b7c9614333868ff8c157f5bd938da98be4871d 100644
+index 512392e6424e..90b7c9614333 100644
 --- a/Source/cmake/OptionsWinCairo.cmake
 +++ b/Source/cmake/OptionsWinCairo.cmake
 @@ -32,15 +32,36 @@ if (OpenJPEG_FOUND)
@@ -20646,7 +20622,7 @@ index 512392e6424ea64ff65fffc14df30344ce6cbe99..90b7c9614333868ff8c157f5bd938da9
  set(USE_ANGLE_WEBGL ON)
  
 diff --git a/Tools/MiniBrowser/gtk/BrowserTab.c b/Tools/MiniBrowser/gtk/BrowserTab.c
-index ab75a69f64aadee2b22e0d8d114932db55aaa000..e82450546a7dba66155b26c3d841d0a74675c701 100644
+index ab75a69f64aa..e82450546a7d 100644
 --- a/Tools/MiniBrowser/gtk/BrowserTab.c
 +++ b/Tools/MiniBrowser/gtk/BrowserTab.c
 @@ -161,6 +161,11 @@ static void loadChanged(WebKitWebView *webView, WebKitLoadEvent loadEvent, Brows
@@ -20680,7 +20656,7 @@ index ab75a69f64aadee2b22e0d8d114932db55aaa000..e82450546a7dba66155b26c3d841d0a7
  }
  
 diff --git a/Tools/MiniBrowser/gtk/BrowserWindow.c b/Tools/MiniBrowser/gtk/BrowserWindow.c
-index 063e94568490cc72193222987b805e7dfff94fea..e08bed7942be0352317ffe6bf92b710aba9d050b 100644
+index 063e94568490..e08bed7942be 100644
 --- a/Tools/MiniBrowser/gtk/BrowserWindow.c
 +++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
 @@ -1373,6 +1373,12 @@ static gboolean browserWindowDeleteEvent(GtkWidget *widget, GdkEventAny* event)
@@ -20712,7 +20688,7 @@ index 063e94568490cc72193222987b805e7dfff94fea..e08bed7942be0352317ffe6bf92b710a
  
  /* Public API. */
 diff --git a/Tools/MiniBrowser/gtk/BrowserWindow.h b/Tools/MiniBrowser/gtk/BrowserWindow.h
-index 62629b4c1c25ae82bd797b39bbf9de0331f8eed2..5de7900a29b0e629f1ac404bbb0dc5b4e605294d 100644
+index 62629b4c1c25..5de7900a29b0 100644
 --- a/Tools/MiniBrowser/gtk/BrowserWindow.h
 +++ b/Tools/MiniBrowser/gtk/BrowserWindow.h
 @@ -37,7 +37,7 @@ G_BEGIN_DECLS
@@ -20725,7 +20701,7 @@ index 62629b4c1c25ae82bd797b39bbf9de0331f8eed2..5de7900a29b0e629f1ac404bbb0dc5b4
  
  typedef struct _BrowserWindow        BrowserWindow;
 diff --git a/Tools/MiniBrowser/gtk/main.c b/Tools/MiniBrowser/gtk/main.c
-index b4ad6cad7ee375d92cb12a4f168418e67fe1afb6..0ef28c90628dc8e9d5ac521db489180de913f881 100644
+index b4ad6cad7ee3..0ef28c90628d 100644
 --- a/Tools/MiniBrowser/gtk/main.c
 +++ b/Tools/MiniBrowser/gtk/main.c
 @@ -54,7 +54,12 @@ static gboolean darkMode;
@@ -20858,7 +20834,7 @@ index b4ad6cad7ee375d92cb12a4f168418e67fe1afb6..0ef28c90628dc8e9d5ac521db489180d
  
      return exitAfterLoad && webProcessCrashed ? 1 : 0;
 diff --git a/Tools/MiniBrowser/wpe/main.cpp b/Tools/MiniBrowser/wpe/main.cpp
-index 2e5c76219de1a60dccae1c8088ceabd8b12c95d0..cf6650a4fda1516b2adf578fc263ad874b200c01 100644
+index 2e5c76219de1..cf6650a4fda1 100644
 --- a/Tools/MiniBrowser/wpe/main.cpp
 +++ b/Tools/MiniBrowser/wpe/main.cpp
 @@ -40,6 +40,9 @@ static gboolean headlessMode;
@@ -21086,7 +21062,7 @@ index 2e5c76219de1a60dccae1c8088ceabd8b12c95d0..cf6650a4fda1516b2adf578fc263ad87
  
      return 0;
 diff --git a/Tools/PlatformWin.cmake b/Tools/PlatformWin.cmake
-index ef4407cfc114e602d98ed81724da504f453e258f..448dd483715162baba484f756fbcc1d72de4ba0c 100644
+index ef4407cfc114..448dd4837151 100644
 --- a/Tools/PlatformWin.cmake
 +++ b/Tools/PlatformWin.cmake
 @@ -12,4 +12,5 @@ endif ()
@@ -21096,7 +21072,7 @@ index ef4407cfc114e602d98ed81724da504f453e258f..448dd483715162baba484f756fbcc1d7
 +    add_subdirectory(Playwright/win)
  endif ()
 diff --git a/Tools/Scripts/build-webkit b/Tools/Scripts/build-webkit
-index ddc2a96ac68cd51d5f4efeca78a118db91709aa2..57a78f54e72d264daa27faa53ac2a30cab98dd82 100755
+index ddc2a96ac68c..57a78f54e72d 100755
 --- a/Tools/Scripts/build-webkit
 +++ b/Tools/Scripts/build-webkit
 @@ -247,7 +247,7 @@ if (isAppleCocoaWebKit()) {
@@ -21109,7 +21085,7 @@ index ddc2a96ac68cd51d5f4efeca78a118db91709aa2..57a78f54e72d264daa27faa53ac2a30c
          # WebInspectorUI must come after JavaScriptCore and WebCore but before WebKit and WebKit2
          my $webKitIndex = first { $projects[$_] eq "Source/WebKitLegacy" } 0..$#projects;
 diff --git a/Tools/WebKitTestRunner/PlatformGTK.cmake b/Tools/WebKitTestRunner/PlatformGTK.cmake
-index 6f8366b63e43eca6b95b67bb47fee9e7a1970cf9..cc8299dfa4380b833e79a870779a222059579d3b 100644
+index 6f8366b63e43..cc8299dfa438 100644
 --- a/Tools/WebKitTestRunner/PlatformGTK.cmake
 +++ b/Tools/WebKitTestRunner/PlatformGTK.cmake
 @@ -26,6 +26,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
@@ -21121,7 +21097,7 @@ index 6f8366b63e43eca6b95b67bb47fee9e7a1970cf9..cc8299dfa4380b833e79a870779a2220
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
 diff --git a/Tools/WebKitTestRunner/PlatformWPE.cmake b/Tools/WebKitTestRunner/PlatformWPE.cmake
-index 775b41868718ea6734efc9082f8161eee2e0015e..68a720c0cb01d534653a259536c481683873680d 100644
+index 775b41868718..68a720c0cb01 100644
 --- a/Tools/WebKitTestRunner/PlatformWPE.cmake
 +++ b/Tools/WebKitTestRunner/PlatformWPE.cmake
 @@ -31,6 +31,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
@@ -21133,7 +21109,7 @@ index 775b41868718ea6734efc9082f8161eee2e0015e..68a720c0cb01d534653a259536c48168
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
 diff --git a/Tools/WebKitTestRunner/TestController.cpp b/Tools/WebKitTestRunner/TestController.cpp
-index cfc9c4483c825d913ed27a4d55884f242d76f002..a14886f89ce62981006517ef528481ab2c9ff116 100644
+index cfc9c4483c82..a14886f89ce6 100644
 --- a/Tools/WebKitTestRunner/TestController.cpp
 +++ b/Tools/WebKitTestRunner/TestController.cpp
 @@ -787,6 +787,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
@@ -21145,7 +21121,7 @@ index cfc9c4483c825d913ed27a4d55884f242d76f002..a14886f89ce62981006517ef528481ab
          decidePolicyForMediaKeySystemPermissionRequest
      };
 diff --git a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
-index 296c902f375b1189f45ee56bb3ffd4d826dd26f6..45d8ca4bdd18e2467b26b0c6998b4dc58dde7634 100644
+index 296c902f375b..45d8ca4bdd18 100644
 --- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
 +++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
 @@ -977,4 +977,51 @@ void EventSenderProxy::scaleGestureEnd(double scale)
@@ -21201,7 +21177,7 @@ index 296c902f375b1189f45ee56bb3ffd4d826dd26f6..45d8ca4bdd18e2467b26b0c6998b4dc5
 +
  } // namespace WTR
 diff --git a/Tools/gtk/install-dependencies b/Tools/gtk/install-dependencies
-index 46388b47a0f433fbdae3874a958fb2d207916c45..d42933e66178ff007a5008dc807483c4896ea5e1 100755
+index 46388b47a0f4..d42933e66178 100755
 --- a/Tools/gtk/install-dependencies
 +++ b/Tools/gtk/install-dependencies
 @@ -120,6 +120,7 @@ function installDependenciesWithApt {
@@ -21229,7 +21205,7 @@ index 46388b47a0f433fbdae3874a958fb2d207916c45..d42933e66178ff007a5008dc807483c4
          xfonts-utils"
  
 diff --git a/Tools/win/DLLLauncher/DLLLauncherMain.cpp b/Tools/win/DLLLauncher/DLLLauncherMain.cpp
-index 52605867b9302d1afcc56c5e9b0c54acf0827900..6edf24ab60249241ba2969531ef55f4b495dce9e 100644
+index 52605867b930..6edf24ab6024 100644
 --- a/Tools/win/DLLLauncher/DLLLauncherMain.cpp
 +++ b/Tools/win/DLLLauncher/DLLLauncherMain.cpp
 @@ -99,11 +99,9 @@ static bool prependPath(const std::wstring& directoryToPrepend)
@@ -21247,7 +21223,7 @@ index 52605867b9302d1afcc56c5e9b0c54acf0827900..6edf24ab60249241ba2969531ef55f4b
  }
  
 diff --git a/Tools/wpe/backends/HeadlessViewBackend.cpp b/Tools/wpe/backends/HeadlessViewBackend.cpp
-index c09b6f39f894943f11b7a453428fab7d6f6e68fb..bc21acb648562ee0380811599b08f7d26c3e706a 100644
+index c09b6f39f894..bc21acb64856 100644
 --- a/Tools/wpe/backends/HeadlessViewBackend.cpp
 +++ b/Tools/wpe/backends/HeadlessViewBackend.cpp
 @@ -145,27 +145,24 @@ void HeadlessViewBackend::updateSnapshot(struct wpe_fdo_shm_exported_buffer* exp
@@ -21302,7 +21278,7 @@ index c09b6f39f894943f11b7a453428fab7d6f6e68fb..bc21acb648562ee0380811599b08f7d2
      static cairo_user_data_key_t bufferKey;
      cairo_surface_set_user_data(m_snapshot, &bufferKey, buffer,
 diff --git a/Tools/wpe/install-dependencies b/Tools/wpe/install-dependencies
-index 6bc2db3024aa3466200f70d20b425227215b6a43..09774119a487ffc4df80ae6f49dd4f31c4021a70 100755
+index 6bc2db3024aa..09774119a487 100755
 --- a/Tools/wpe/install-dependencies
 +++ b/Tools/wpe/install-dependencies
 @@ -78,6 +78,7 @@ function installDependenciesWithApt {


### PR DESCRIPTION
This pull-request rebases `webkit/bootstrap.diff` to webkit ToT (a60349c98390c46d865cbaa55431b074c2144639).

It was necessary to disable Cog compilation as it was producing a compilation error in WPE.