### PR TITLE
feat(inspector): force zero timeout under PWDEBUG

### DIFF
--- a/src/utils/timeoutSettings.ts
+++ b/src/utils/timeoutSettings.ts
@@ -18,7 +18,6 @@
 import { debugMode } from './utils';
 
 export const DEFAULT_TIMEOUT = 30000;
-const TIMEOUT = debugMode() ? 0 : DEFAULT_TIMEOUT;
 
 export class TimeoutSettings {
   private _parent: TimeoutSettings | undefined;
@@ -38,6 +37,8 @@ export class TimeoutSettings {
   }
 
   navigationTimeout(options: { timeout?: number }): number {
+    if (debugMode())
+      return 0;
     if (typeof options.timeout === 'number')
       return options.timeout;
     if (this._defaultNavigationTimeout !== null)
@@ -46,22 +47,26 @@ export class TimeoutSettings {
       return this._defaultTimeout;
     if (this._parent)
       return this._parent.navigationTimeout(options);
-    return TIMEOUT;
+    return DEFAULT_TIMEOUT;
   }
 
   timeout(options: { timeout?: number }): number {
+    if (debugMode())
+      return 0;
     if (typeof options.timeout === 'number')
       return options.timeout;
     if (this._defaultTimeout !== null)
       return this._defaultTimeout;
     if (this._parent)
       return this._parent.timeout(options);
-    return TIMEOUT;
+    return DEFAULT_TIMEOUT;
   }
 
   static timeout(options: { timeout?: number }): number {
+    if (debugMode())
+      return 0;
     if (typeof options.timeout === 'number')
       return options.timeout;
-    return TIMEOUT;
+    return DEFAULT_TIMEOUT;
   }
 }


### PR DESCRIPTION
Before this change, `page.click('div', { timeout: 1000 })` would time out with inspector. Now it does not.

Note this might be unexpected in some situations, but I think this brings useful behavior in more usecases.