### PR TITLE
feat(test runner): add type to TestInfo.error

### DIFF
--- a/src/test/reporter.ts
+++ b/src/test/reporter.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { FullConfig, TestStatus } from './types';
-export type { FullConfig, TestStatus } from './types';
+import type { FullConfig, TestStatus, TestError } from './types';
+export type { FullConfig, TestStatus, TestError } from './types';
 
 export interface Suite {
   title: string;
@@ -59,11 +59,6 @@ export interface TestResult {
   error?: TestError;
   stdout: (string | Buffer)[];
   stderr: (string | Buffer)[];
-}
-export interface TestError {
-  message?: string;
-  stack?: string;
-  value?: string;
 }
 export interface Reporter {
   onBegin(config: FullConfig, suite: Suite): void;

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -17,8 +17,7 @@
 import path from 'path';
 import util from 'util';
 import StackUtils from 'stack-utils';
-import type { Location } from './types';
-import type { TestError } from './reporter';
+import type { Location, TestError } from './types';
 import { default as minimatch } from 'minimatch';
 
 const TEST_RUNNER_DIRS = [

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -238,6 +238,26 @@ export interface FullConfig {
 export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped';
 
 /**
+ * Information about an error caught during test execution.
+ */
+export interface TestError {
+  /**
+   * Error message. Set when Error (or its subclass) has been thrown.
+   */
+  message?: string;
+
+  /**
+   * Error stack. Set when Error (or its subclass) has been thrown.
+   */
+  stack?: string;
+
+  /**
+   * The thrown value. Set when anything except the Error (or its subclass) has been thrown.
+   */
+  value?: string;
+}
+
+/**
  * Information common for all tests run in the same worker process.
  */
 export interface WorkerInfo {
@@ -367,7 +387,7 @@ export interface TestInfo extends WorkerInfo {
    * The error thrown by the test if any.
    * Only available after the test has finished.
    */
-  error?: any;
+  error?: TestError;
 
   /**
    * Output written to `process.stdout` or `console.log` from the test.


### PR DESCRIPTION
It has a very special `TestError` type, but we say it's `any` for some reason.