### PR TITLE
feat(test-runner): added Istanbul coverage collection

### DIFF
--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -986,6 +986,15 @@ export type PlaywrightWorkerOptions = {
    * @see LaunchOptions
    */
   launchOptions: LaunchOptions;
+
+  /**
+   * Enables coverage collection via Istanbul. The coverage data gets stored in the '.nyc_output' directory
+   * and can get processed via the [Istanbul CLI](https://github.com/istanbuljs/nyc#readme). For example
+   * - npx nyc report --reporter=html # open the coverage/index.html in your browser
+   * - npx nyc report --reporter=lcovonly # ready to get sent to code coverage providers
+   */
+   collectIstanbulCoverage: boolean,
+   _collectIstanbulCoverageWritenPages: Map<Page, Promise<any>>
 };
 
 /**


### PR DESCRIPTION
An experiment how it i works in general, implementation etc. is TBD. There are two way so far how to add it:
a) Chromium coverage with [v8-to-istanbul](https://www.npmjs.com/package/v8-to-istanbul) package and save the individual reports and then let the user merge it via [nyc](https://www.npmjs.com/package/nyc)
b) Use [babel-plugin-instanbul](https://github.com/istanbuljs/babel-plugin-istanbul) and save the individual reports and then let the user merge it via [nyc](https://www.npmjs.com/package/nyc)

We don't want the `nyc` dependency since it introduces too many dependencies.
