### PR TITLE
fix(docker): use node 14 not node 16

### DIFF
--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -2,9 +2,9 @@ FROM ubuntu:bionic
 
 # === INSTALL Node.js ===
 
-# Install node16
+# Install node14
 RUN apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs
 
 # Feature-parity with node.js base images.

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -2,9 +2,9 @@ FROM ubuntu:focal
 
 # === INSTALL Node.js ===
 
-# Install node16
+# Install node14
 RUN apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs
 
 # Feature-parity with node.js base images.


### PR DESCRIPTION
The current LTS is Node 14. Node 16 is a bit unstable to ship to users.
