### PR TITLE
Follow-up #7202. Use WTFMove to avoid extra copy.

### DIFF
--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -3308,7 +3308,7 @@ index 6459cedc046c..a7167e7db8a7 100644
 +            return makeUnexpected("Unable to decode given content"_s);
 +
 +        ScriptExecutionContext* context = element->scriptExecutionContext();
-+	fileObjects.append(File::create(context, Blob::create(context, Vector { buffer->data(), buffer->size() }, type), name));
++        fileObjects.append(File::create(context, Blob::create(context, WTFMove(*buffer), type), name));
 +    }
 +    RefPtr<FileList> fileList = FileList::create(WTFMove(fileObjects));
 +    element->setFiles(WTFMove(fileList));


### PR DESCRIPTION
Applies change suggested in https://github.com/microsoft/playwright/pull/7202#discussion_r653723896.