### PR TITLE
browser(webkit): implement Network.getInterceptedResponseBody

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1500
-Changed: dpino@igalia.com Thu, Jun 17, 2021 09:05:47 AM
+1501
+Changed: yurys@chromium.org Mon 21 Jun 2021 10:52:51 AM PDT

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -1,5 +1,5 @@
 diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
-index 3566ca4859e0..ebab5e27a3dd 100644
+index 3566ca4859e09aaddaa7f97175a4b12f902780fc..ebab5e27a3dd4760291acaf74a5db117539fa8d8 100644
 --- a/Source/JavaScriptCore/CMakeLists.txt
 +++ b/Source/JavaScriptCore/CMakeLists.txt
 @@ -1239,22 +1239,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
@@ -31,7 +31,7 @@ index 3566ca4859e0..ebab5e27a3dd 100644
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/ServiceWorker.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Target.json
 diff --git a/Source/JavaScriptCore/DerivedSources.make b/Source/JavaScriptCore/DerivedSources.make
-index 9df8b244d4c4..2ea6388f09af 100644
+index 9df8b244d4c456901bddb412189963d065126327..2ea6388f09af272fa838ba257ee385cee7539aca 100644
 --- a/Source/JavaScriptCore/DerivedSources.make
 +++ b/Source/JavaScriptCore/DerivedSources.make
 @@ -265,22 +265,27 @@ INSPECTOR_DOMAINS := \
@@ -63,7 +63,7 @@ index 9df8b244d4c4..2ea6388f09af 100644
      $(JavaScriptCore)/inspector/protocol/ServiceWorker.json \
      $(JavaScriptCore)/inspector/protocol/Target.json \
 diff --git a/Source/JavaScriptCore/bindings/ScriptValue.cpp b/Source/JavaScriptCore/bindings/ScriptValue.cpp
-index 52d955b1e492..71c538e57acf 100644
+index 52d955b1e4929f6d0dede53097d275559b29b91d..71c538e57acf3912f9a777f7bc7eba6efb8877eb 100644
 --- a/Source/JavaScriptCore/bindings/ScriptValue.cpp
 +++ b/Source/JavaScriptCore/bindings/ScriptValue.cpp
 @@ -79,7 +79,10 @@ static RefPtr<JSON::Value> jsToInspectorValue(JSGlobalObject* globalObject, JSVa
@@ -79,7 +79,7 @@ index 52d955b1e492..71c538e57acf 100644
                  return nullptr;
              inspectorObject->setValue(name.string(), inspectorValue.releaseNonNull());
 diff --git a/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp b/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp
-index 95cd87b01b15..0481fa93227f 100644
+index 95cd87b01b15cb8667e57bc5bb51a71f06bc3760..0481fa93227f297be9d9cf000c5a72235956a390 100644
 --- a/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp
 +++ b/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp
 @@ -30,14 +30,21 @@
@@ -106,7 +106,7 @@ index 95cd87b01b15..0481fa93227f 100644
  {
      return addPrefixToIdentifier(String::number(++s_lastUsedIdentifier));
 diff --git a/Source/JavaScriptCore/inspector/IdentifiersFactory.h b/Source/JavaScriptCore/inspector/IdentifiersFactory.h
-index eb25aedee4cd..badf6559595c 100644
+index eb25aedee4cd9ebe007e06c2515b37ee095b06f4..badf6559595c8377db1089ca3c25008e1be2c8f1 100644
 --- a/Source/JavaScriptCore/inspector/IdentifiersFactory.h
 +++ b/Source/JavaScriptCore/inspector/IdentifiersFactory.h
 @@ -31,6 +31,7 @@ namespace Inspector {
@@ -118,7 +118,7 @@ index eb25aedee4cd..badf6559595c 100644
      static String requestId(unsigned long identifier);
  };
 diff --git a/Source/JavaScriptCore/inspector/InjectedScript.cpp b/Source/JavaScriptCore/inspector/InjectedScript.cpp
-index 8b290faebc18..53c68bca057c 100644
+index 8b290faebc1865519b0e7c514f497585dfc0bbda..53c68bca057c85c94201ef8e9870f0cb9e4cef6f 100644
 --- a/Source/JavaScriptCore/inspector/InjectedScript.cpp
 +++ b/Source/JavaScriptCore/inspector/InjectedScript.cpp
 @@ -91,7 +91,7 @@ void InjectedScript::awaitPromise(const String& promiseObjectId, bool returnByVa
@@ -155,7 +155,7 @@ index 8b290faebc18..53c68bca057c 100644
      auto resultValue = toInspectorValue(globalObject(), callResult.value());
      if (!resultValue)
 diff --git a/Source/JavaScriptCore/inspector/InjectedScript.h b/Source/JavaScriptCore/inspector/InjectedScript.h
-index e6b249672730..9f7b72259ab7 100644
+index e6b24967273095ae424ac9b3fe5e081ee8999ab7..9f7b72259ab79504b8bfcc24d35abe70d7372065 100644
 --- a/Source/JavaScriptCore/inspector/InjectedScript.h
 +++ b/Source/JavaScriptCore/inspector/InjectedScript.h
 @@ -64,7 +64,7 @@ public:
@@ -168,7 +168,7 @@ index e6b249672730..9f7b72259ab7 100644
      void functionDetails(Protocol::ErrorString&, JSC::JSValue, RefPtr<Protocol::Debugger::FunctionDetails>& result);
      void getPreview(Protocol::ErrorString&, const String& objectId, RefPtr<Protocol::Runtime::ObjectPreview>& result);
 diff --git a/Source/JavaScriptCore/inspector/InjectedScriptSource.js b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
-index 48baed6a1b7f..40d36f784f46 100644
+index 48baed6a1b7ffad453379a2f1eb71b8c4925f6c4..40d36f784f46e44dbad908402a71e6b02f499629 100644
 --- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
 +++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
 @@ -136,7 +136,7 @@ let InjectedScript = class InjectedScript
@@ -248,7 +248,7 @@ index 48baed6a1b7f..40d36f784f46 100644
      }
  
 diff --git a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
-index 4895c5a70d6a..e4905e0d4e5f 100644
+index 4895c5a70d6a4745597f77163bc92e0745594829..e4905e0d4e5ff88e479147c84e41359f9274b341 100644
 --- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
 +++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
 @@ -101,7 +101,7 @@ void BackendDispatcher::registerDispatcherForDomain(const String& domain, Supple
@@ -271,7 +271,7 @@ index 4895c5a70d6a..e4905e0d4e5f 100644
          // We could be called re-entrantly from a nested run loop, so restore the previous id.
          SetForScope<std::optional<long>> scopedRequestId(m_currentRequestId, requestId);
 diff --git a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
-index 37c4f9833d49..1c82cc978361 100644
+index 37c4f9833d4981b47bcd8debd4a79109254641a2..1c82cc9783618234bef7024d91821ce509912526 100644
 --- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
 +++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
 @@ -83,7 +83,10 @@ public:
@@ -287,7 +287,7 @@ index 37c4f9833d49..1c82cc978361 100644
      // Note that 'unused' is a workaround so the compiler can pick the right sendResponse based on arity.
      // When <http://webkit.org/b/179847> is fixed or this class is renamed for the JSON::Object case,
 diff --git a/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp b/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp
-index d408d364f198..1375ce9990f0 100644
+index d408d364f1986983161f9d44efbc8bc6f6898676..1375ce9990f0c63d7e6f33ee62930051d6cd44cb 100644
 --- a/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp
 +++ b/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp
 @@ -49,7 +49,7 @@ void FrontendRouter::connectFrontend(FrontendChannel& connection)
@@ -300,7 +300,7 @@ index d408d364f198..1375ce9990f0 100644
      }
  
 diff --git a/Source/JavaScriptCore/inspector/InspectorTarget.cpp b/Source/JavaScriptCore/inspector/InspectorTarget.cpp
-index 0cc2127c9c12..8ca65cc042d4 100644
+index 0cc2127c9c12c2d82dea9550bad73f4ffb99ba24..8ca65cc042d435cbc0e05dcc5c5dfc958eb24f5a 100644
 --- a/Source/JavaScriptCore/inspector/InspectorTarget.cpp
 +++ b/Source/JavaScriptCore/inspector/InspectorTarget.cpp
 @@ -44,6 +44,8 @@ void InspectorTarget::resume()
@@ -321,7 +321,7 @@ index 0cc2127c9c12..8ca65cc042d4 100644
  }
  
 diff --git a/Source/JavaScriptCore/inspector/InspectorTarget.h b/Source/JavaScriptCore/inspector/InspectorTarget.h
-index 4b95964db4d9..966a5927702b 100644
+index 4b95964db4d902b4b7f4b0b4c40afea51654ff2f..966a5927702b65edb343369decafda7fc83eaec7 100644
 --- a/Source/JavaScriptCore/inspector/InspectorTarget.h
 +++ b/Source/JavaScriptCore/inspector/InspectorTarget.h
 @@ -56,8 +56,12 @@ public:
@@ -338,7 +338,7 @@ index 4b95964db4d9..966a5927702b 100644
      bool m_isPaused { false };
  };
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
-index 76d72c7273f1..c0cf9588c04b 100644
+index 76d72c7273f1bb2170485015d931b1fba92d3b5a..c0cf9588c04bfba0d6176c4d6af691bd56ca6cec 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
 @@ -168,16 +168,15 @@ void InspectorRuntimeAgent::awaitPromise(const Protocol::Runtime::RemoteObjectId
@@ -386,7 +386,7 @@ index 76d72c7273f1..c0cf9588c04b 100644
  
  Protocol::ErrorStringOr<Ref<Protocol::Runtime::ObjectPreview>> InspectorRuntimeAgent::getPreview(const Protocol::Runtime::RemoteObjectId& objectId)
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
-index c4f6fa5b9de5..0d549faeb1f0 100644
+index c4f6fa5b9de54317da07c2371a7126aae1c967aa..0d549faeb1f0f80c7a6e7c208c72c6ef9cf4dbd5 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
 @@ -62,7 +62,7 @@ public:
@@ -399,7 +399,7 @@ index c4f6fa5b9de5..0d549faeb1f0 100644
      Protocol::ErrorStringOr<Ref<Protocol::Runtime::ObjectPreview>> getPreview(const Protocol::Runtime::RemoteObjectId&) final;
      Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Protocol::Runtime::PropertyDescriptor>>, RefPtr<JSON::ArrayOf<Protocol::Runtime::InternalPropertyDescriptor>>>> getProperties(const Protocol::Runtime::RemoteObjectId&, std::optional<bool>&& ownProperties, std::optional<int>&& fetchStart, std::optional<int>&& fetchCount, std::optional<bool>&& generatePreview) final;
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
-index 508eb02ec95c..c0099a56794a 100644
+index 508eb02ec95c52408384a1e2b77648afd426dd9d..c0099a56794ae411fe9cdce1a65a95f1a7e37924 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
 @@ -87,6 +87,34 @@ Protocol::ErrorStringOr<void> InspectorTargetAgent::sendMessageToTarget(const St
@@ -476,7 +476,7 @@ index 508eb02ec95c..c0099a56794a 100644
  {
      return m_router.hasLocalFrontend() ? Inspector::FrontendChannel::ConnectionType::Local : Inspector::FrontendChannel::ConnectionType::Remote;
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
-index e81573fd0fff..4169e227b5fb 100644
+index e81573fd0fffaaf6fd2af36635c78fcdf8608c69..4169e227b5fb5a3a7fb51396c4679100f495719c 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
 @@ -50,15 +50,21 @@ public:
@@ -502,7 +502,7 @@ index e81573fd0fff..4169e227b5fb 100644
      // FrontendChannel
      FrontendChannel::ConnectionType connectionType() const;
 diff --git a/Source/JavaScriptCore/inspector/protocol/DOM.json b/Source/JavaScriptCore/inspector/protocol/DOM.json
-index 3a91ac6b57fa..ff51e7576281 100644
+index 3a91ac6b57fad7f472daa2e2107b3b483de70165..ff51e75762818b0bb5070ddf8de10e66018d63b0 100644
 --- a/Source/JavaScriptCore/inspector/protocol/DOM.json
 +++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
 @@ -80,6 +80,16 @@
@@ -598,7 +598,7 @@ index 3a91ac6b57fa..ff51e7576281 100644
      "events": [
 diff --git a/Source/JavaScriptCore/inspector/protocol/Dialog.json b/Source/JavaScriptCore/inspector/protocol/Dialog.json
 new file mode 100644
-index 000000000000..79edea03fed4
+index 0000000000000000000000000000000000000000..79edea03fed4e9be5da96e1275e182a479cb7a0a
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Dialog.json
 @@ -0,0 +1,36 @@
@@ -640,7 +640,7 @@ index 000000000000..79edea03fed4
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Emulation.json b/Source/JavaScriptCore/inspector/protocol/Emulation.json
 new file mode 100644
-index 000000000000..347a01b3fdd1
+index 0000000000000000000000000000000000000000..347a01b3fdd1a8277cb4104558e8bbfa63539374
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Emulation.json
 @@ -0,0 +1,51 @@
@@ -697,7 +697,7 @@ index 000000000000..347a01b3fdd1
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Input.json b/Source/JavaScriptCore/inspector/protocol/Input.json
 new file mode 100644
-index 000000000000..587287d52fde
+index 0000000000000000000000000000000000000000..587287d52fde2735cbae34a27a0f673b7e38e1a7
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Input.json
 @@ -0,0 +1,188 @@
@@ -890,10 +890,28 @@ index 000000000000..587287d52fde
 +    ]
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Network.json b/Source/JavaScriptCore/inspector/protocol/Network.json
-index 882a2d56befe..9aecd6067741 100644
+index 882a2d56befef0aba460cc8ff041969e0d2c1ed3..71d4bfc4a4bc5a43bd2b98aefa316b4e74e35b8f 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Network.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Network.json
-@@ -324,6 +324,13 @@
+@@ -192,6 +192,17 @@
+                 { "name": "base64Encoded", "type": "boolean", "description": "True, if content was sent as base64." }
+             ]
+         },
++        {
++            "name": "getInterceptedResponseBody",
++            "description": "Returns content served for the given request. Will wait for the request to finish loading.",
++            "async": true,
++            "parameters": [
++                { "name": "requestId", "$ref": "RequestId", "description": "Identifier of the intercepted network response's request." }
++            ],
++            "returns": [
++                { "name": "body", "type": "string", "description": "Base64 encoded response body." }
++            ]
++        },
+         {
+             "name": "setResourceCachingDisabled",
+             "description": "Toggles whether the resource cache may be used when loading resources in the inspected page. If <code>true</code>, the resource cache will not be used when loading resources.",
+@@ -324,6 +335,13 @@
                  { "name": "requestId", "$ref": "RequestId", "description": "Identifier for the intercepted Network request to fail." },
                  { "name": "errorType", "$ref": "ResourceErrorType", "description": "Deliver error reason for the request failure." }
              ]
@@ -908,7 +926,7 @@ index 882a2d56befe..9aecd6067741 100644
      ],
      "events": [
 diff --git a/Source/JavaScriptCore/inspector/protocol/Page.json b/Source/JavaScriptCore/inspector/protocol/Page.json
-index db52479a72d4..5f7add78fefc 100644
+index db52479a72d459be23d4d8d080c0ed15ea9fc4c0..5f7add78fefc2bf8718ff8af7c49c169038e8226 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Page.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Page.json
 @@ -27,7 +27,7 @@
@@ -1216,7 +1234,7 @@ index db52479a72d4..5f7add78fefc 100644
  }
 diff --git a/Source/JavaScriptCore/inspector/protocol/Playwright.json b/Source/JavaScriptCore/inspector/protocol/Playwright.json
 new file mode 100644
-index 000000000000..c6cc36ee0e33
+index 0000000000000000000000000000000000000000..c6cc36ee0e33e868d5c507203c284835fa2ce63f
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Playwright.json
 @@ -0,0 +1,282 @@
@@ -1503,7 +1521,7 @@ index 000000000000..c6cc36ee0e33
 +    ]
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Runtime.json b/Source/JavaScriptCore/inspector/protocol/Runtime.json
-index 274b01596d49..d08a9ddd745c 100644
+index 274b01596d490fb81b48cf89bf668e0634e8b423..d08a9ddd745c748767ba8055907daa7beeffc219 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Runtime.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Runtime.json
 @@ -261,12 +261,14 @@
@@ -1525,7 +1543,7 @@ index 274b01596d49..d08a9ddd745c 100644
              "name": "getPreview",
 diff --git a/Source/JavaScriptCore/inspector/protocol/Screencast.json b/Source/JavaScriptCore/inspector/protocol/Screencast.json
 new file mode 100644
-index 000000000000..f6c541d63c0b
+index 0000000000000000000000000000000000000000..f6c541d63c0b8251874eaf8818aabe0e0449401d
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Screencast.json
 @@ -0,0 +1,65 @@
@@ -1595,7 +1613,7 @@ index 000000000000..f6c541d63c0b
 +    ]
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Target.json b/Source/JavaScriptCore/inspector/protocol/Target.json
-index 52920cded24a..bbbabc4e7259 100644
+index 52920cded24a9c6b0ef6fb4e518664955db4f9fa..bbbabc4e7259088b9404e8cc07eecd6f45077da0 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Target.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Target.json
 @@ -10,7 +10,7 @@
@@ -1640,7 +1658,7 @@ index 52920cded24a..bbbabc4e7259 100644
          },
          {
 diff --git a/Source/JavaScriptCore/inspector/protocol/Worker.json b/Source/JavaScriptCore/inspector/protocol/Worker.json
-index 638612413466..6f9e518ff0bf 100644
+index 638612413466efc87b737e8a81042ed07ca12703..6f9e518ff0bfa2a6228675d25b6b785f1ed3022a 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Worker.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Worker.json
 @@ -16,7 +16,7 @@
@@ -1663,7 +1681,7 @@ index 638612413466..6f9e518ff0bf 100644
          },
          {
 diff --git a/Source/JavaScriptCore/runtime/DateConversion.cpp b/Source/JavaScriptCore/runtime/DateConversion.cpp
-index 2decf8a83c80..9010384a32f7 100644
+index 2decf8a83c80e80ca8677f4c787bf79c6c2995fa..9010384a32f7c2ab69a8fb20eb19cd566fd9f434 100644
 --- a/Source/JavaScriptCore/runtime/DateConversion.cpp
 +++ b/Source/JavaScriptCore/runtime/DateConversion.cpp
 @@ -97,6 +97,9 @@ String formatDateTime(const GregorianDateTime& t, DateTimeFormat format, bool as
@@ -1685,7 +1703,7 @@ index 2decf8a83c80..9010384a32f7 100644
      }
  
 diff --git a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
-index 2729df9dd4d1..a7fdc92d594a 100644
+index 2729df9dd4d15e19b7b2019ca94dd7647c5a6706..a7fdc92d594a7930ca029f162cc385bbdb949597 100644
 --- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
 +++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
 @@ -36,6 +36,7 @@
@@ -1697,7 +1715,7 @@ index 2729df9dd4d1..a7fdc92d594a 100644
  #include <wtf/unicode/icu/ICUHelpers.h>
  
 diff --git a/Source/JavaScriptCore/runtime/JSDateMath.cpp b/Source/JavaScriptCore/runtime/JSDateMath.cpp
-index ea0bfb0d7a5a..2ebe8c6c5ac4 100644
+index ea0bfb0d7a5a64c1570da5333199f99b552a5ff6..2ebe8c6c5ac4343e0b373ccc271e86a4080a98dc 100644
 --- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
 +++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
 @@ -76,6 +76,7 @@
@@ -1752,7 +1770,7 @@ index ea0bfb0d7a5a..2ebe8c6c5ac4 100644
      m_timeZoneCache = std::unique_ptr<OpaqueICUTimeZone, OpaqueICUTimeZoneDeleter>(bitwise_cast<OpaqueICUTimeZone*>(icu::TimeZone::detectHostTimeZone()));
  #endif
 diff --git a/Source/ThirdParty/libwebrtc/CMakeLists.txt b/Source/ThirdParty/libwebrtc/CMakeLists.txt
-index cb557f6c526c..9c95b2fab2bc 100644
+index cb557f6c526cb5afdefd3c1ba64659bafee44e2e..9c95b2fab2bc1e885dfd61e063fcbecad439b5d0 100644
 --- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
 +++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
 @@ -292,6 +292,11 @@ set(webrtc_SOURCES
@@ -1779,7 +1797,7 @@ index cb557f6c526c..9c95b2fab2bc 100644
      Source/third_party/libvpx/source/libvpx
      Source/third_party/opus/src/celt
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
-index 7d225cc2c64b..685154543606 100644
+index 7d225cc2c64b66bfbc0f2aeb0f6184280d294263..6851545436064cc23e1f8862e8f1c5d51ef6bece 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
 @@ -321,3 +321,23 @@ __ZN3rtc14RTCCertificateD1Ev
@@ -1807,7 +1825,7 @@ index 7d225cc2c64b..685154543606 100644
 +_vpx_codec_version_str
 +_vpx_codec_vp8_cx
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
-index dd884b222501..9927a937145f 100644
+index dd884b22250114627213c4827ca176c283ec2525..9927a937145f23d05e907083a01748dd8015eb98 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 @@ -43,7 +43,7 @@ DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_ = $(DYLIB_INSTALL_NAME_BASE);
@@ -1820,7 +1838,7 @@ index dd884b222501..9927a937145f 100644
  PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/libwebrtc;
  USE_HEADERMAP = NO;
 diff --git a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
-index d8677555342e..b9ee7198a702 100644
+index d8677555342ee0168223a0bc3ef54603b1a23460..b9ee7198a702cbc0241de3a33b65a6940ad48bc6 100644
 --- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
 +++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
 @@ -3856,6 +3856,9 @@
@@ -1902,7 +1920,7 @@ index d8677555342e..b9ee7198a702 100644
  				41323A1D2665288B00B38623 /* packet_sequencer.cc in Sources */,
  				4131BF2D234B88200028A615 /* rtc_stats_collector.cc in Sources */,
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferences.yaml b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
-index e7331574bbfe..8333ecf890ba 100644
+index e7331574bbfe695080432c506a393ed218d0e651..8333ecf890ba03175aa5fa9afe89217f6a377f4c 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
 @@ -1010,7 +1010,7 @@ InspectorStartsAttached:
@@ -1915,7 +1933,7 @@ index e7331574bbfe..8333ecf890ba 100644
  InspectorWindowFrame:
    type: String
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index d42b23b6abbe..a5e8526cd3b3 100644
+index d42b23b6abbe757643faf137e3bb954642ac587f..a5e8526cd3b341038ec0dabb5da7920d3453cae6 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 @@ -622,9 +622,9 @@ MaskWebGLStringsEnabled:
@@ -1931,7 +1949,7 @@ index d42b23b6abbe..a5e8526cd3b3 100644
  # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
  MediaCapabilitiesExtensionsEnabled:
 diff --git a/Source/WTF/wtf/DateMath.cpp b/Source/WTF/wtf/DateMath.cpp
-index ebd69a4c76cd..2ee388e94a56 100644
+index ebd69a4c76cd7acb0a233be552071158ca2171ca..2ee388e94a56d3de9c9fb2506d2ddead2db1ef87 100644
 --- a/Source/WTF/wtf/DateMath.cpp
 +++ b/Source/WTF/wtf/DateMath.cpp
 @@ -76,9 +76,14 @@
@@ -2050,7 +2068,7 @@ index ebd69a4c76cd..2ee388e94a56 100644
 +
  } // namespace WTF
 diff --git a/Source/WTF/wtf/DateMath.h b/Source/WTF/wtf/DateMath.h
-index de0b45bd0a88..81857a2be24f 100644
+index de0b45bd0a88eaba466b6e6c0ad66dc02f525741..81857a2be24fa3ff0a60ebbcd01130969456b31e 100644
 --- a/Source/WTF/wtf/DateMath.h
 +++ b/Source/WTF/wtf/DateMath.h
 @@ -388,6 +388,10 @@ inline int dayInMonthFromDayInYear(int dayInYear, bool leapYear)
@@ -2065,7 +2083,7 @@ index de0b45bd0a88..81857a2be24f 100644
  WTF_EXPORT_PRIVATE LocalTimeOffset calculateLocalTimeOffset(double utcInMilliseconds, TimeType = UTCTime);
  
 diff --git a/Source/WTF/wtf/PlatformEnable.h b/Source/WTF/wtf/PlatformEnable.h
-index e132f8b56fe2..9035512cb303 100644
+index e132f8b56fe209153de089d2ef782183116ac4d6..9035512cb303b616479ecaf85baa77b70ec0ff7c 100644
 --- a/Source/WTF/wtf/PlatformEnable.h
 +++ b/Source/WTF/wtf/PlatformEnable.h
 @@ -417,7 +417,7 @@
@@ -2087,7 +2105,7 @@ index e132f8b56fe2..9035512cb303 100644
  
  #if !defined(ENABLE_TOUCH_ACTION_REGIONS)
 diff --git a/Source/WTF/wtf/PlatformGTK.cmake b/Source/WTF/wtf/PlatformGTK.cmake
-index fa6958fbd30f..c0d6541242d7 100644
+index fa6958fbd30fabfd1d237aaf1a89f6eb5fa3b366..c0d6541242d79dc6d615a43710343b895e23aadc 100644
 --- a/Source/WTF/wtf/PlatformGTK.cmake
 +++ b/Source/WTF/wtf/PlatformGTK.cmake
 @@ -73,6 +73,7 @@ list(APPEND WTF_LIBRARIES
@@ -2099,7 +2117,7 @@ index fa6958fbd30f..c0d6541242d7 100644
  
  if (Systemd_FOUND)
 diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
-index 8efd5f73956c..0218bed8af51 100644
+index 8efd5f73956c38156e4c91c388fa7584fb24e627..0218bed8af5118af4d5b8d49e57cd2bf63896cdf 100644
 --- a/Source/WTF/wtf/PlatformHave.h
 +++ b/Source/WTF/wtf/PlatformHave.h
 @@ -391,7 +391,7 @@
@@ -2112,7 +2130,7 @@ index 8efd5f73956c..0218bed8af51 100644
  #endif
  
 diff --git a/Source/WTF/wtf/PlatformWPE.cmake b/Source/WTF/wtf/PlatformWPE.cmake
-index 46148f8b54b0..c35180cd3327 100644
+index 46148f8b54b062bd7f8d6c3fd76c18983d6be28f..c35180cd3327e9331c4ebc097acb318d4611ebe1 100644
 --- a/Source/WTF/wtf/PlatformWPE.cmake
 +++ b/Source/WTF/wtf/PlatformWPE.cmake
 @@ -47,6 +47,7 @@ list(APPEND WTF_LIBRARIES
@@ -2124,7 +2142,7 @@ index 46148f8b54b0..c35180cd3327 100644
  
  if (Systemd_FOUND)
 diff --git a/Source/WebCore/DerivedSources.make b/Source/WebCore/DerivedSources.make
-index d9daeb5ab328..3f955d78a57d 100644
+index d9daeb5ab32846b2222641f9213b5c5b1a374e90..3f955d78a57deecd02a10eb6215896391aa6bba0 100644
 --- a/Source/WebCore/DerivedSources.make
 +++ b/Source/WebCore/DerivedSources.make
 @@ -778,6 +778,10 @@ JS_BINDING_IDLS := \
@@ -2149,7 +2167,7 @@ index d9daeb5ab328..3f955d78a57d 100644
  
  vpath %.in $(WEBKITADDITIONS_HEADER_SEARCH_PATHS)
 diff --git a/Source/WebCore/Modules/geolocation/Geolocation.cpp b/Source/WebCore/Modules/geolocation/Geolocation.cpp
-index 7995d4dd461d..49207cd294ac 100644
+index 7995d4dd461de036cd8691b3ff181aeaefb12d92..49207cd294acebb4bac53ecb28817baa827d389f 100644
 --- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
 +++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
 @@ -358,8 +358,9 @@ bool Geolocation::shouldBlockGeolocationRequests()
@@ -2164,7 +2182,7 @@ index 7995d4dd461d..49207cd294ac 100644
      }
  
 diff --git a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
-index f1b96958057d..29e51dad3802 100644
+index f1b96958057d2fe6044d2c7b259db6c5ceb44efe..29e51dad380285fb16bd32ef04efde2ac4ed6479 100644
 --- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
 +++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
 @@ -202,6 +202,7 @@ NS_ASSUME_NONNULL_BEGIN
@@ -2200,7 +2218,7 @@ index f1b96958057d..29e51dad3802 100644
  
      [self sendSpeechEndIfNeeded];
 diff --git a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
-index 66cec91542b7..9a2a89a09279 100644
+index 66cec91542b74765a9c1ffbc2f28e1a5085c55e0..9a2a89a09279b3b7102282de6bfc4cc7e2b5925f 100644
 --- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
 +++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
 @@ -36,6 +36,9 @@ NS_ASSUME_NONNULL_BEGIN
@@ -2222,7 +2240,7 @@ index 66cec91542b7..9a2a89a09279 100644
          _hasSentSpeechStart = true;
          _delegateCallback(SpeechRecognitionUpdate::create(_identifier, SpeechRecognitionUpdateType::SpeechStart));
 diff --git a/Source/WebCore/PlatformWPE.cmake b/Source/WebCore/PlatformWPE.cmake
-index 9d4f3bd1ade0..17b2b6cfb52d 100644
+index 9d4f3bd1ade02a378340961d617aae1c5e0776a3..17b2b6cfb52d94d8104b68b9250883c40f69f975 100644
 --- a/Source/WebCore/PlatformWPE.cmake
 +++ b/Source/WebCore/PlatformWPE.cmake
 @@ -38,6 +38,7 @@ list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
@@ -2234,7 +2252,7 @@ index 9d4f3bd1ade0..17b2b6cfb52d 100644
  
  list(APPEND WebCore_USER_AGENT_STYLE_SHEETS
 diff --git a/Source/WebCore/SourcesCocoa.txt b/Source/WebCore/SourcesCocoa.txt
-index 471d8a51ba23..dd3196e33857 100644
+index 471d8a51ba23cb5b8cd53143492b61156e45a5b3..dd3196e33857bb3730abce3d58cb90e60551f52b 100644
 --- a/Source/WebCore/SourcesCocoa.txt
 +++ b/Source/WebCore/SourcesCocoa.txt
 @@ -621,3 +621,9 @@ platform/graphics/angle/TemporaryANGLESetting.cpp @no-unify
@@ -2248,7 +2266,7 @@ index 471d8a51ba23..dd3196e33857 100644
 +JSTouchList.cpp
 +// Playwright end
 diff --git a/Source/WebCore/SourcesWPE.txt b/Source/WebCore/SourcesWPE.txt
-index b10c1ece5207..8520d6b90ccb 100644
+index b10c1ece52075b7535da51c2cc316dc9343fd081..8520d6b90ccb2aa2762d83fab0f63c1e7107aed3 100644
 --- a/Source/WebCore/SourcesWPE.txt
 +++ b/Source/WebCore/SourcesWPE.txt
 @@ -44,6 +44,8 @@ editing/libwpe/EditorLibWPE.cpp
@@ -2274,7 +2292,7 @@ index b10c1ece5207..8520d6b90ccb 100644
 +
 +platform/wpe/SelectionData.cpp
 diff --git a/Source/WebCore/WebCore.order b/Source/WebCore/WebCore.order
-index ef168b768192..2d6cf51f3b45 100644
+index ef168b76819216d984b7a2d0f760005fb9d24de8..2d6cf51f3b45191ad84106429d4f108f85679123 100644
 --- a/Source/WebCore/WebCore.order
 +++ b/Source/WebCore/WebCore.order
 @@ -3093,7 +3093,6 @@ __ZN7WebCore14DocumentLoader23stopLoadingSubresourcesEv
@@ -2286,7 +2304,7 @@ index ef168b768192..2d6cf51f3b45 100644
  __ZN7WebCore14DocumentLoaderD2Ev
  __ZN7WebCore14DocumentLoader17clearMainResourceEv
 diff --git a/Source/WebCore/WebCore.xcodeproj/project.pbxproj b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-index 7babd538701a..84f328c4df79 100644
+index 7babd538701a77a890f761d24d8903b85e0a713f..84f328c4df793dd3c28c0deccd506706a040c10b 100644
 --- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 +++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 @@ -5349,6 +5349,14 @@
@@ -2410,7 +2428,7 @@ index 7babd538701a..84f328c4df79 100644
  				2D8B92F5203D13E1009C868F /* UnifiedSource520.cpp in Sources */,
  				2D8B92F6203D13E1009C868F /* UnifiedSource521.cpp in Sources */,
 diff --git a/Source/WebCore/accessibility/AccessibilityObject.cpp b/Source/WebCore/accessibility/AccessibilityObject.cpp
-index 34ea8f48c903..d3dc7852c192 100644
+index 34ea8f48c903860c1df3f3fe86b44c7cb57270d3..d3dc7852c192675f6d185ce59d1fabe10a2ffbc9 100644
 --- a/Source/WebCore/accessibility/AccessibilityObject.cpp
 +++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
 @@ -59,6 +59,7 @@
@@ -2441,7 +2459,7 @@ index 34ea8f48c903..d3dc7852c192 100644
  {
      AXComputedObjectAttributeCache* attributeCache = nullptr;
 diff --git a/Source/WebCore/css/MediaQueryEvaluator.cpp b/Source/WebCore/css/MediaQueryEvaluator.cpp
-index a47b2fe549a8..53357bc9ce11 100644
+index a47b2fe549a89414a207864aabe897d07a59727c..53357bc9ce111bcb1241256647c3630ae767213d 100644
 --- a/Source/WebCore/css/MediaQueryEvaluator.cpp
 +++ b/Source/WebCore/css/MediaQueryEvaluator.cpp
 @@ -844,7 +844,11 @@ static bool prefersContrastEvaluate(CSSValue* value, const CSSToLengthConversion
@@ -2466,7 +2484,7 @@ index a47b2fe549a8..53357bc9ce11 100644
      if (!value)
          return userPrefersReducedMotion;
 diff --git a/Source/WebCore/dom/DataTransfer.cpp b/Source/WebCore/dom/DataTransfer.cpp
-index 1deac4f41cf4..c691eeccd75f 100644
+index 1deac4f41cf49f1f882dccefd48cf6a9732f3ed9..c691eeccd75fc76f5df367b9fb5b95435e92ab79 100644
 --- a/Source/WebCore/dom/DataTransfer.cpp
 +++ b/Source/WebCore/dom/DataTransfer.cpp
 @@ -494,6 +494,14 @@ Ref<DataTransfer> DataTransfer::createForDrag(const Document& document)
@@ -2485,7 +2503,7 @@ index 1deac4f41cf4..c691eeccd75f 100644
  {
      auto dataTransfer = adoptRef(*new DataTransfer(StoreMode::ReadWrite, makeUnique<StaticPasteboard>(), Type::DragAndDropData));
 diff --git a/Source/WebCore/dom/DataTransfer.h b/Source/WebCore/dom/DataTransfer.h
-index b084ee416512..b250f3d01618 100644
+index b084ee416512652220e43a6d4bcccaff7c666d5a..b250f3d0161817efef7e2634a16713b0a0f1fa71 100644
 --- a/Source/WebCore/dom/DataTransfer.h
 +++ b/Source/WebCore/dom/DataTransfer.h
 @@ -90,6 +90,9 @@ public:
@@ -2499,7 +2517,7 @@ index b084ee416512..b250f3d01618 100644
      static Ref<DataTransfer> createForDrop(const Document&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
      static Ref<DataTransfer> createForUpdatingDropTarget(const Document&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
 diff --git a/Source/WebCore/dom/PointerEvent.cpp b/Source/WebCore/dom/PointerEvent.cpp
-index f21879fdfbc6..151c9b72f0f5 100644
+index f21879fdfbc64e7d2f11ab084d46794a9e601110..151c9b72f0f552c2ff741305c4c0a8c7f51a92e3 100644
 --- a/Source/WebCore/dom/PointerEvent.cpp
 +++ b/Source/WebCore/dom/PointerEvent.cpp
 @@ -114,4 +114,61 @@ EventInterface PointerEvent::eventInterface() const
@@ -2565,7 +2583,7 @@ index f21879fdfbc6..151c9b72f0f5 100644
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/dom/PointerEvent.h b/Source/WebCore/dom/PointerEvent.h
-index 9d60b85152f3..9811ce9aa6f0 100644
+index 9d60b85152f378566118574663701c25b001df3d..9811ce9aa6f066c57acf65f629d2ab8155c090e1 100644
 --- a/Source/WebCore/dom/PointerEvent.h
 +++ b/Source/WebCore/dom/PointerEvent.h
 @@ -33,6 +33,8 @@
@@ -2596,7 +2614,7 @@ index 9d60b85152f3..9811ce9aa6f0 100644
  #endif
  
 diff --git a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
-index 9dd41d636651..d6bb529fb891 100644
+index 9dd41d6366512fd385937a7608bd3fc9b5b90f60..d6bb529fb891a65c8f6dcc6cff1e718c7a40b8dd 100644
 --- a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
 +++ b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
 @@ -33,6 +33,7 @@
@@ -2623,7 +2641,7 @@ index 9dd41d636651..d6bb529fb891 100644
  
  #endif // USE(LIBWPE)
 diff --git a/Source/WebCore/html/FileInputType.cpp b/Source/WebCore/html/FileInputType.cpp
-index bb8ca873e34b..472f21b21db9 100644
+index bb8ca873e34b367e91b4927b78b7ce38ef641293..472f21b21db90f505a8a226d9a982ad007cc86c0 100644
 --- a/Source/WebCore/html/FileInputType.cpp
 +++ b/Source/WebCore/html/FileInputType.cpp
 @@ -36,6 +36,7 @@
@@ -2647,7 +2665,7 @@ index bb8ca873e34b..472f21b21db9 100644
          return;
  
 diff --git a/Source/WebCore/inspector/InspectorController.cpp b/Source/WebCore/inspector/InspectorController.cpp
-index c33bc989d95a..d54965c544b8 100644
+index c33bc989d95a21425d43643795190cf40f7e9684..d54965c544b8cac7ebc1e9e408db8ae08e25be61 100644
 --- a/Source/WebCore/inspector/InspectorController.cpp
 +++ b/Source/WebCore/inspector/InspectorController.cpp
 @@ -374,8 +374,8 @@ void InspectorController::inspect(Node* node)
@@ -2687,7 +2705,7 @@ index c33bc989d95a..d54965c544b8 100644
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/InspectorController.h b/Source/WebCore/inspector/InspectorController.h
-index 784bf482fd68..6cdf012453ff 100644
+index 784bf482fd68da68e1f38fd5cd6bcedc8971dfda..6cdf012453ff31120adbe5946ce23f075761ebef 100644
 --- a/Source/WebCore/inspector/InspectorController.h
 +++ b/Source/WebCore/inspector/InspectorController.h
 @@ -101,6 +101,10 @@ public:
@@ -2710,7 +2728,7 @@ index 784bf482fd68..6cdf012453ff 100644
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/InspectorInstrumentation.cpp b/Source/WebCore/inspector/InspectorInstrumentation.cpp
-index c121523071a0..9a25d620db36 100644
+index c121523071a026888cbd608031ad15dc85af1719..c8557a307178db00b79e7e1c4156242b242bc7d1 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
 +++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
 @@ -641,6 +641,12 @@ void InspectorInstrumentation::didFailLoadingImpl(InstrumentingAgents& instrumen
@@ -2776,7 +2794,32 @@ index c121523071a0..9a25d620db36 100644
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
  void InspectorInstrumentation::defaultAppearanceDidChangeImpl(InstrumentingAgents& instrumentingAgents, bool useDarkAppearance)
  {
-@@ -1328,6 +1331,36 @@ void InspectorInstrumentation::renderLayerDestroyedImpl(InstrumentingAgents& ins
+@@ -861,6 +864,24 @@ void InspectorInstrumentation::interceptResponseImpl(InstrumentingAgents& instru
+         networkAgent->interceptResponse(response, identifier, WTFMove(handler));
+ }
+ 
++void InspectorInstrumentation::interceptDidReceiveDataImpl(InstrumentingAgents& instrumentingAgents, unsigned long identifier, const SharedBuffer& buffer)
++{
++    if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
++        networkAgent->interceptDidReceiveData(identifier, buffer);
++}
++
++void InspectorInstrumentation::interceptDidFinishResourceLoadImpl(InstrumentingAgents& instrumentingAgents, unsigned long identifier)
++{
++    if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
++        networkAgent->interceptDidFinishResourceLoad(identifier);
++}
++
++void InspectorInstrumentation::interceptDidFailResourceLoadImpl(InstrumentingAgents& instrumentingAgents, unsigned long identifier, const ResourceError& error)
++{
++    if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
++        networkAgent->interceptDidFailResourceLoad(identifier, error);
++}
++
+ // JavaScriptCore InspectorDebuggerAgent should know Console MessageTypes.
+ static bool isConsoleAssertMessage(MessageSource source, MessageType type)
+ {
+@@ -1328,6 +1349,36 @@ void InspectorInstrumentation::renderLayerDestroyedImpl(InstrumentingAgents& ins
          layerTreeAgent->renderLayerDestroyed(renderLayer);
  }
  
@@ -2813,7 +2856,7 @@ index c121523071a0..9a25d620db36 100644
  InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(WorkerOrWorkletGlobalScope& globalScope)
  {
      return globalScope.inspectorController().m_instrumentingAgents;
-@@ -1339,6 +1372,13 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
+@@ -1339,6 +1390,13 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
      return page.inspectorController().m_instrumentingAgents.get();
  }
  
@@ -2828,7 +2871,7 @@ index c121523071a0..9a25d620db36 100644
  {
      if (is<Document>(context))
 diff --git a/Source/WebCore/inspector/InspectorInstrumentation.h b/Source/WebCore/inspector/InspectorInstrumentation.h
-index 7d5e7d57bf91..f132ab1566bb 100644
+index 7d5e7d57bf911fddf90ed400a225afa083e6c871..f217152b91bdd208556d125ea3b013e9a30882a4 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentation.h
 +++ b/Source/WebCore/inspector/InspectorInstrumentation.h
 @@ -31,6 +31,7 @@
@@ -2868,7 +2911,17 @@ index 7d5e7d57bf91..f132ab1566bb 100644
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
      static void defaultAppearanceDidChange(Page&, bool useDarkAppearance);
  #endif
-@@ -325,6 +328,12 @@ public:
+@@ -242,6 +245,9 @@ public:
+     static bool shouldInterceptResponse(const Frame&, const ResourceResponse&);
+     static void interceptRequest(ResourceLoader&, Function<void(const ResourceRequest&)>&&);
+     static void interceptResponse(const Frame&, const ResourceResponse&, unsigned long identifier, CompletionHandler<void(const ResourceResponse&, RefPtr<SharedBuffer>)>&&);
++    static void interceptDidReceiveData(const Frame&, unsigned long identifier, const SharedBuffer&);
++    static void interceptDidFinishResourceLoad(const Frame&, unsigned long identifier);
++    static void interceptDidFailResourceLoad(const Frame&, unsigned long identifier, const ResourceError& error);
+ 
+     static void addMessageToConsole(Page&, std::unique_ptr<Inspector::ConsoleMessage>);
+     static void addMessageToConsole(WorkerOrWorkletGlobalScope&, std::unique_ptr<Inspector::ConsoleMessage>);
+@@ -325,6 +331,12 @@ public:
      static void layerTreeDidChange(Page*);
      static void renderLayerDestroyed(Page*, const RenderLayer&);
  
@@ -2881,7 +2934,7 @@ index 7d5e7d57bf91..f132ab1566bb 100644
      static void frontendCreated();
      static void frontendDeleted();
      static bool hasFrontends() { return InspectorInstrumentationPublic::hasFrontends(); }
-@@ -341,6 +350,8 @@ public:
+@@ -341,6 +353,8 @@ public:
      static void registerInstrumentingAgents(InstrumentingAgents&);
      static void unregisterInstrumentingAgents(InstrumentingAgents&);
  
@@ -2890,7 +2943,7 @@ index 7d5e7d57bf91..f132ab1566bb 100644
  private:
      static void didClearWindowObjectInWorldImpl(InstrumentingAgents&, Frame&, DOMWrapperWorld&);
      static bool isDebuggerPausedImpl(InstrumentingAgents&);
-@@ -429,6 +440,7 @@ private:
+@@ -429,6 +443,7 @@ private:
      static void didReceiveDataImpl(InstrumentingAgents&, unsigned long identifier, const uint8_t* data, int dataLength, int encodedDataLength);
      static void didFinishLoadingImpl(InstrumentingAgents&, unsigned long identifier, DocumentLoader*, const NetworkLoadMetrics&, ResourceLoader*);
      static void didFailLoadingImpl(InstrumentingAgents&, unsigned long identifier, DocumentLoader*, const ResourceError&);
@@ -2898,7 +2951,7 @@ index 7d5e7d57bf91..f132ab1566bb 100644
      static void willLoadXHRSynchronouslyImpl(InstrumentingAgents&);
      static void didLoadXHRSynchronouslyImpl(InstrumentingAgents&);
      static void scriptImportedImpl(InstrumentingAgents&, unsigned long identifier, const String& sourceString);
-@@ -439,11 +451,11 @@ private:
+@@ -439,11 +454,11 @@ private:
      static void frameDetachedFromParentImpl(InstrumentingAgents&, Frame&);
      static void didCommitLoadImpl(InstrumentingAgents&, Frame&, DocumentLoader*);
      static void frameDocumentUpdatedImpl(InstrumentingAgents&, Frame&);
@@ -2911,7 +2964,17 @@ index 7d5e7d57bf91..f132ab1566bb 100644
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
      static void defaultAppearanceDidChangeImpl(InstrumentingAgents&, bool useDarkAppearance);
  #endif
-@@ -533,6 +545,12 @@ private:
+@@ -454,6 +469,9 @@ private:
+     static bool shouldInterceptResponseImpl(InstrumentingAgents&, const ResourceResponse&);
+     static void interceptRequestImpl(InstrumentingAgents&, ResourceLoader&, Function<void(const ResourceRequest&)>&&);
+     static void interceptResponseImpl(InstrumentingAgents&, const ResourceResponse&, unsigned long identifier, CompletionHandler<void(const ResourceResponse&, RefPtr<SharedBuffer>)>&&);
++    static void interceptDidReceiveDataImpl(InstrumentingAgents&, unsigned long identifier, const SharedBuffer&);
++    static void interceptDidFinishResourceLoadImpl(InstrumentingAgents&, unsigned long identifier);
++    static void interceptDidFailResourceLoadImpl(InstrumentingAgents&, unsigned long identifier, const ResourceError& error);
+ 
+     static void addMessageToConsoleImpl(InstrumentingAgents&, std::unique_ptr<Inspector::ConsoleMessage>);
+ 
+@@ -533,6 +551,12 @@ private:
      static void layerTreeDidChangeImpl(InstrumentingAgents&);
      static void renderLayerDestroyedImpl(InstrumentingAgents&, const RenderLayer&);
  
@@ -2924,7 +2987,7 @@ index 7d5e7d57bf91..f132ab1566bb 100644
      static InstrumentingAgents& instrumentingAgents(Page&);
      static InstrumentingAgents& instrumentingAgents(WorkerOrWorkletGlobalScope&);
  
-@@ -1134,6 +1152,13 @@ inline void InspectorInstrumentation::didFailLoading(Frame* frame, DocumentLoade
+@@ -1134,6 +1158,13 @@ inline void InspectorInstrumentation::didFailLoading(Frame* frame, DocumentLoade
          didFailLoadingImpl(*agents, identifier, loader, error);
  }
  
@@ -2938,7 +3001,7 @@ index 7d5e7d57bf91..f132ab1566bb 100644
  inline void InspectorInstrumentation::didFailLoading(WorkerOrWorkletGlobalScope& globalScope, unsigned long identifier, const ResourceError& error)
  {
      didFailLoadingImpl(instrumentingAgents(globalScope), identifier, nullptr, error);
-@@ -1229,13 +1254,6 @@ inline void InspectorInstrumentation::frameDocumentUpdated(Frame& frame)
+@@ -1229,13 +1260,6 @@ inline void InspectorInstrumentation::frameDocumentUpdated(Frame& frame)
          frameDocumentUpdatedImpl(*agents, frame);
  }
  
@@ -2952,7 +3015,7 @@ index 7d5e7d57bf91..f132ab1566bb 100644
  inline void InspectorInstrumentation::frameStartedLoading(Frame& frame)
  {
      FAST_RETURN_IF_NO_FRONTENDS(void());
-@@ -1264,6 +1282,13 @@ inline void InspectorInstrumentation::frameClearedScheduledNavigation(Frame& fra
+@@ -1264,6 +1288,13 @@ inline void InspectorInstrumentation::frameClearedScheduledNavigation(Frame& fra
          frameClearedScheduledNavigationImpl(*agents, frame);
  }
  
@@ -2966,7 +3029,30 @@ index 7d5e7d57bf91..f132ab1566bb 100644
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
  inline void InspectorInstrumentation::defaultAppearanceDidChange(Page& page, bool useDarkAppearance)
  {
-@@ -1731,6 +1756,42 @@ inline void InspectorInstrumentation::renderLayerDestroyed(Page* page, const Ren
+@@ -1316,6 +1347,22 @@ inline void InspectorInstrumentation::interceptResponse(const Frame& frame, cons
+         interceptResponseImpl(*agents, response, identifier, WTFMove(handler));
+ }
+ 
++inline void InspectorInstrumentation::interceptDidReceiveData(const Frame& frame, unsigned long identifier, const SharedBuffer& buffer)
++{
++    if (auto* agents = instrumentingAgents(frame))
++        interceptDidReceiveDataImpl(*agents, identifier, buffer);
++}
++inline void InspectorInstrumentation::interceptDidFinishResourceLoad(const Frame& frame, unsigned long identifier)
++{
++    if (auto* agents = instrumentingAgents(frame))
++        interceptDidFinishResourceLoadImpl(*agents, identifier);
++}
++inline void InspectorInstrumentation::interceptDidFailResourceLoad(const Frame& frame, unsigned long identifier, const ResourceError& error)
++{
++    if (auto* agents = instrumentingAgents(frame))
++        interceptDidFailResourceLoadImpl(*agents, identifier, error);
++}
++
+ inline void InspectorInstrumentation::didOpenDatabase(Database& database)
+ {
+     FAST_RETURN_IF_NO_FRONTENDS(void());
+@@ -1731,6 +1778,42 @@ inline void InspectorInstrumentation::renderLayerDestroyed(Page* page, const Ren
          renderLayerDestroyedImpl(*agents, renderLayer);
  }
  
@@ -3009,8 +3095,92 @@ index 7d5e7d57bf91..f132ab1566bb 100644
  inline InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(ScriptExecutionContext* context)
  {
      return context ? instrumentingAgents(*context) : nullptr;
+diff --git a/Source/WebCore/inspector/InspectorInstrumentationWebKit.cpp b/Source/WebCore/inspector/InspectorInstrumentationWebKit.cpp
+index 73163278cca3998f4f0122d5cb0577da46a50747..85b9127228ea9c8d89b4b3fd028e0ec4a5b3f820 100644
+--- a/Source/WebCore/inspector/InspectorInstrumentationWebKit.cpp
++++ b/Source/WebCore/inspector/InspectorInstrumentationWebKit.cpp
+@@ -50,4 +50,19 @@ void InspectorInstrumentationWebKit::interceptResponseInternal(const Frame& fram
+     InspectorInstrumentation::interceptResponse(frame, response, identifier, WTFMove(handler));
+ }
+ 
++void InspectorInstrumentationWebKit::interceptDidReceiveDataInternal(const Frame& frame, unsigned long identifier, const SharedBuffer& buffer)
++{
++    InspectorInstrumentation::interceptDidReceiveData(frame, identifier, buffer);
++}
++
++void InspectorInstrumentationWebKit::interceptDidFinishResourceLoadInternal(const Frame& frame, unsigned long identifier)
++{
++    InspectorInstrumentation::interceptDidFinishResourceLoad(frame, identifier);
++}
++
++void InspectorInstrumentationWebKit::interceptDidFailResourceLoadInternal(const Frame& frame, unsigned long identifier, const ResourceError& error)
++{
++    InspectorInstrumentation::interceptDidFailResourceLoad(frame, identifier, error);
++}
++
+ } // namespace WebCore
+diff --git a/Source/WebCore/inspector/InspectorInstrumentationWebKit.h b/Source/WebCore/inspector/InspectorInstrumentationWebKit.h
+index bffc870806476538115e80f20ddca4e8222e629b..aa56e1f1714b9b51486d9d130e18e29a70576e0f 100644
+--- a/Source/WebCore/inspector/InspectorInstrumentationWebKit.h
++++ b/Source/WebCore/inspector/InspectorInstrumentationWebKit.h
+@@ -33,6 +33,7 @@
+ namespace WebCore {
+ 
+ class Frame;
++class ResourceError;
+ class ResourceLoader;
+ class ResourceRequest;
+ class ResourceResponse;
+@@ -44,12 +45,18 @@ public:
+     static bool shouldInterceptResponse(const Frame*, const ResourceResponse&);
+     static void interceptRequest(ResourceLoader&, Function<void(const ResourceRequest&)>&&);
+     static void interceptResponse(const Frame*, const ResourceResponse&, unsigned long identifier, CompletionHandler<void(const ResourceResponse&, RefPtr<SharedBuffer>)>&&);
++    static void interceptDidReceiveData(const Frame*, unsigned long identifier, const SharedBuffer&);
++    static void interceptDidFinishResourceLoad(const Frame*, unsigned long identifier);
++    static void interceptDidFailResourceLoad(const Frame*, unsigned long identifier, const ResourceError& error);
+ 
+ private:
+     static bool shouldInterceptRequestInternal(const Frame&, const ResourceRequest&);
+     static bool shouldInterceptResponseInternal(const Frame&, const ResourceResponse&);
+     static void interceptRequestInternal(ResourceLoader&, Function<void(const ResourceRequest&)>&&);
+     static void interceptResponseInternal(const Frame&, const ResourceResponse&, unsigned long identifier, CompletionHandler<void(const ResourceResponse&, RefPtr<SharedBuffer>)>&&);
++    static void interceptDidReceiveDataInternal(const Frame&, unsigned long identifier, const SharedBuffer&);
++    static void interceptDidFinishResourceLoadInternal(const Frame&, unsigned long identifier);
++    static void interceptDidFailResourceLoadInternal(const Frame&, unsigned long identifier, const ResourceError& error);
+ };
+ 
+ inline bool InspectorInstrumentationWebKit::shouldInterceptRequest(const Frame* frame, const ResourceRequest& request)
+@@ -82,4 +89,28 @@ inline void InspectorInstrumentationWebKit::interceptResponse(const Frame* frame
+     interceptResponseInternal(*frame, response, identifier, WTFMove(handler));
+ }
+ 
++inline void InspectorInstrumentationWebKit::interceptDidReceiveData(const Frame* frame, unsigned long identifier, const SharedBuffer& buffer)
++{
++    if (!frame)
++        return;
++
++    interceptDidReceiveDataInternal(*frame, identifier, buffer);
++}
++
++inline void InspectorInstrumentationWebKit::interceptDidFinishResourceLoad(const Frame* frame, unsigned long identifier)
++{
++    if (!frame)
++        return;
++
++    interceptDidFinishResourceLoadInternal(*frame, identifier);
++}
++
++inline void InspectorInstrumentationWebKit::interceptDidFailResourceLoad(const Frame* frame, unsigned long identifier, const ResourceError& error)
++{
++    if (!frame)
++        return;
++
++    interceptDidFailResourceLoadInternal(*frame, identifier, error);
++}
++
+ }
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
-index 6459cedc046c..a7167e7db8a7 100644
+index 6459cedc046c479334d3e983672b04e04dbdad53..a7167e7db8a7f95de53dc2b90ffdaa2a645275ff 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 @@ -62,12 +62,16 @@
@@ -3317,7 +3487,7 @@ index 6459cedc046c..a7167e7db8a7 100644
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.h b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
-index 33b8284ea079..d883cd81d42f 100644
+index 33b8284ea07928818b2bc88bd754df3717076bf6..d883cd81d42f4fd3a99d4e3aa6cae15681560c73 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
 @@ -56,6 +56,7 @@ namespace WebCore {
@@ -3390,7 +3560,7 @@ index 33b8284ea079..d883cd81d42f 100644
      void discardBindings();
  
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
-index 3386cb879f11..d2350182f5f0 100644
+index 3386cb879f1178c1b9635775c9a0e864f5b94c52..d2350182f5f061855e8ca172779ad60ee73b39fb 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
 @@ -40,6 +40,7 @@ class DOMStorageFrontendDispatcher;
@@ -3402,7 +3572,7 @@ index 3386cb879f11..d2350182f5f0 100644
  class Page;
  class SecurityOrigin;
 diff --git a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
-index 767046d37bc0..07da2c81b9df 100644
+index 767046d37bc06b97b0de7340e7098bbc1a835121..92482b5c4a6610183c2ab5239a16f54c3a3523db 100644
 --- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
 @@ -45,6 +45,7 @@
@@ -3421,7 +3591,15 @@ index 767046d37bc0..07da2c81b9df 100644
  #include "Page.h"
  #include "PlatformStrategies.h"
  #include "ProgressTracker.h"
-@@ -305,8 +307,8 @@ static Ref<Protocol::Network::Request> buildObjectForResourceRequest(const Resou
+@@ -91,6 +93,7 @@
+ #include <wtf/text/WTFString.h>
+ 
+ typedef Inspector::NetworkBackendDispatcherHandler::LoadResourceCallback LoadResourceCallback;
++using GetInterceptedResponseBodyCallback = Inspector::NetworkBackendDispatcherHandler::GetInterceptedResponseBodyCallback;
+ 
+ namespace WebCore {
+ 
+@@ -305,8 +308,8 @@ static Ref<Protocol::Network::Request> buildObjectForResourceRequest(const Resou
          .setHeaders(buildObjectForHeaders(request.httpHeaderFields()))
          .release();
      if (request.httpBody() && !request.httpBody()->isEmpty()) {
@@ -3432,7 +3610,7 @@ index 767046d37bc0..07da2c81b9df 100644
      }
      return requestObject;
  }
-@@ -351,6 +353,8 @@ RefPtr<Protocol::Network::Response> InspectorNetworkAgent::buildObjectForResourc
+@@ -351,6 +354,8 @@ RefPtr<Protocol::Network::Response> InspectorNetworkAgent::buildObjectForResourc
          .setSource(responseSource(response.source()))
          .release();
  
@@ -3441,7 +3619,7 @@ index 767046d37bc0..07da2c81b9df 100644
      if (resourceLoader) {
          auto* metrics = response.deprecatedNetworkLoadMetricsOrNull();
          responseObject->setTiming(buildObjectForTiming(metrics ? *metrics : NetworkLoadMetrics { }, *resourceLoader));
-@@ -488,9 +492,15 @@ static InspectorPageAgent::ResourceType resourceTypeForLoadType(InspectorInstrum
+@@ -488,9 +493,15 @@ static InspectorPageAgent::ResourceType resourceTypeForLoadType(InspectorInstrum
  
  void InspectorNetworkAgent::willSendRequest(unsigned long identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource)
  {
@@ -3460,7 +3638,26 @@ index 767046d37bc0..07da2c81b9df 100644
  }
  
  void InspectorNetworkAgent::willSendRequestOfType(unsigned long identifier, DocumentLoader* loader, ResourceRequest& request, InspectorInstrumentation::LoadType loadType)
-@@ -1104,8 +1114,7 @@ bool InspectorNetworkAgent::willIntercept(const ResourceRequest& request)
+@@ -950,6 +961,18 @@ Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorN
+     return makeUnexpected("Missing content of resource for given requestId"_s);
+ }
+ 
++void InspectorNetworkAgent::getInterceptedResponseBody(const Inspector::Protocol::Network::RequestId& requestId, Ref<GetInterceptedResponseBodyCallback>&& callback)
++{
++    auto pendingInterceptResponse = m_pendingInterceptResponses.get(requestId);
++    if (!pendingInterceptResponse) {
++        callback->sendFailure("Missing pending intercept response for given requestId"_s);
++        return;
++    }
++    pendingInterceptResponse->getReceivedData([callback = WTFMove(callback)] (const SharedBuffer& buffer) {
++        callback->sendSuccess(base64EncodeToString(buffer.data(), buffer.size()));
++    });
++}
++
+ Protocol::ErrorStringOr<void> InspectorNetworkAgent::setResourceCachingDisabled(bool disabled)
+ {
+     setResourceCachingDisabledInternal(disabled);
+@@ -1104,8 +1127,7 @@ bool InspectorNetworkAgent::willIntercept(const ResourceRequest& request)
      if (!m_interceptionEnabled)
          return false;
  
@@ -3470,7 +3667,41 @@ index 767046d37bc0..07da2c81b9df 100644
  }
  
  bool InspectorNetworkAgent::shouldInterceptRequest(const ResourceRequest& request)
-@@ -1188,6 +1197,9 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithRequest(const
+@@ -1159,6 +1181,33 @@ void InspectorNetworkAgent::interceptResponse(const ResourceResponse& response,
+     m_frontendDispatcher->responseIntercepted(requestId, resourceResponse.releaseNonNull());
+ }
+ 
++void InspectorNetworkAgent::interceptDidReceiveData(unsigned long identifier, const SharedBuffer& buffer)
++{
++    String requestId = IdentifiersFactory::requestId(identifier);
++    auto* interceptedResponse = m_pendingInterceptResponses.get(requestId);
++    if (!interceptedResponse) {
++        ASSERT_NOT_REACHED();
++        return;
++    }
++    interceptedResponse->didReceiveData(buffer);
++}
++
++void InspectorNetworkAgent::interceptDidFinishResourceLoad(unsigned long identifier)
++{
++    String requestId = IdentifiersFactory::requestId(identifier);
++    auto* interceptedResponse = m_pendingInterceptResponses.get(requestId);
++    if (!interceptedResponse) {
++        ASSERT_NOT_REACHED();
++        return;
++    }
++    interceptedResponse->didFinishLoading();
++}
++
++void InspectorNetworkAgent::interceptDidFailResourceLoad(unsigned long identifier, const ResourceError& error)
++{
++    interceptDidFinishResourceLoad(identifier);
++}
++
+ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptContinue(const Protocol::Network::RequestId& requestId, Protocol::Network::NetworkStage networkStage)
+ {
+     switch (networkStage) {
+@@ -1188,6 +1237,9 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithRequest(const
          return makeUnexpected("Missing pending intercept request for given requestId"_s);
  
      auto& loader = *pendingRequest->m_loader;
@@ -3480,7 +3711,7 @@ index 767046d37bc0..07da2c81b9df 100644
      ResourceRequest request = loader.request();
      if (!!url)
          request.setURL(URL({ }, url));
-@@ -1287,14 +1299,24 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithRespons
+@@ -1287,14 +1339,24 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithRespons
      response.setHTTPStatusCode(status);
      response.setHTTPStatusText(statusText);
      HTTPHeaderMap explicitHeaders;
@@ -3505,7 +3736,7 @@ index 767046d37bc0..07da2c81b9df 100644
          if (buffer->size())
              loader->didReceiveBuffer(WTFMove(buffer), buffer->size(), DataPayloadWholeResource);
          loader->didFinishLoading(NetworkLoadMetrics());
-@@ -1335,6 +1357,12 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithError(c
+@@ -1335,6 +1397,12 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithError(c
      return { };
  }
  
@@ -3518,7 +3749,7 @@ index 767046d37bc0..07da2c81b9df 100644
  bool InspectorNetworkAgent::shouldTreatAsText(const String& mimeType)
  {
      return startsWithLettersIgnoringASCIICase(mimeType, "text/")
-@@ -1376,6 +1404,12 @@ std::optional<String> InspectorNetworkAgent::textContentForCachedResource(Cached
+@@ -1376,6 +1444,12 @@ std::optional<String> InspectorNetworkAgent::textContentForCachedResource(Cached
      return std::nullopt;
  }
  
@@ -3532,7 +3763,7 @@ index 767046d37bc0..07da2c81b9df 100644
  {
      ASSERT(result);
 diff --git a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
-index 7cdc5865e58e..f5712075bb6f 100644
+index 7cdc5865e58e9a9a30ea25202692d4b9aa77b2d6..7c42be0cbadf9a594926cbe89ce510b0f0827397 100644
 --- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
 @@ -72,6 +72,7 @@ public:
@@ -3543,7 +3774,15 @@ index 7cdc5865e58e..f5712075bb6f 100644
  
      // InspectorAgentBase
      void didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher*) final;
-@@ -94,6 +95,7 @@ public:
+@@ -82,6 +83,7 @@ public:
+     Inspector::Protocol::ErrorStringOr<void> disable() final;
+     Inspector::Protocol::ErrorStringOr<void> setExtraHTTPHeaders(Ref<JSON::Object>&&) final;
+     Inspector::Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> getResponseBody(const Inspector::Protocol::Network::RequestId&) final;
++    void getInterceptedResponseBody(const Inspector::Protocol::Network::RequestId&, Ref<GetInterceptedResponseBodyCallback>&&) final;
+     Inspector::Protocol::ErrorStringOr<void> setResourceCachingDisabled(bool) final;
+     void loadResource(const Inspector::Protocol::Network::FrameId&, const String& url, Ref<LoadResourceCallback>&&) final;
+     Inspector::Protocol::ErrorStringOr<String> getSerializedCertificate(const Inspector::Protocol::Network::RequestId&) final;
+@@ -94,6 +96,7 @@ public:
      Inspector::Protocol::ErrorStringOr<void> interceptWithResponse(const Inspector::Protocol::Network::RequestId&, const String& content, bool base64Encoded, const String& mimeType, std::optional<int>&& status, const String& statusText, RefPtr<JSON::Object>&& headers) final;
      Inspector::Protocol::ErrorStringOr<void> interceptRequestWithResponse(const Inspector::Protocol::Network::RequestId&, const String& content, bool base64Encoded, const String& mimeType, int status, const String& statusText, Ref<JSON::Object>&& headers) final;
      Inspector::Protocol::ErrorStringOr<void> interceptRequestWithError(const Inspector::Protocol::Network::RequestId&, Inspector::Protocol::Network::ResourceErrorType) final;
@@ -3551,8 +3790,71 @@ index 7cdc5865e58e..f5712075bb6f 100644
  
      // InspectorInstrumentation
      void willRecalculateStyle();
+@@ -125,6 +128,9 @@ public:
+     bool shouldInterceptResponse(const ResourceResponse&);
+     void interceptResponse(const ResourceResponse&, unsigned long identifier, CompletionHandler<void(const ResourceResponse&, RefPtr<SharedBuffer>)>&&);
+     void interceptRequest(ResourceLoader&, Function<void(const ResourceRequest&)>&&);
++    void interceptDidReceiveData(unsigned long identifier, const SharedBuffer&);
++    void interceptDidFinishResourceLoad(unsigned long identifier);
++    void interceptDidFailResourceLoad(unsigned long identifier, const ResourceError& error);
+ 
+     void searchOtherRequests(const JSC::Yarr::RegularExpression&, Ref<JSON::ArrayOf<Inspector::Protocol::Page::SearchResult>>&);
+     void searchInRequest(Inspector::Protocol::ErrorString&, const Inspector::Protocol::Network::RequestId&, const String& query, bool caseSensitive, bool isRegex, RefPtr<JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>>&);
+@@ -188,6 +194,7 @@ private:
+         PendingInterceptResponse(const ResourceResponse& originalResponse, CompletionHandler<void(const ResourceResponse&, RefPtr<SharedBuffer>)>&& completionHandler)
+             : m_originalResponse(originalResponse)
+             , m_completionHandler(WTFMove(completionHandler))
++            , m_receivedData(SharedBuffer::create())
+         { }
+ 
+         ~PendingInterceptResponse()
+@@ -211,12 +218,44 @@ private:
+             m_responded = true;
+ 
+             m_completionHandler(response, data);
++
++            m_receivedData->clear();
++            notifyDataHandlers();
++        }
++
++        void didReceiveData(const SharedBuffer& buffer)
++        {
++            m_receivedData->append(buffer);
++        }
++
++        void getReceivedData(CompletionHandler<void(const SharedBuffer&)>&& completionHandler)
++        {
++            if (m_finishedLoading || m_responded) {
++                completionHandler(m_receivedData.get());
++                return;
++            }
++            m_receivedDataHandlers.append(WTFMove(completionHandler));
++        }
++
++        void didFinishLoading() {
++            m_finishedLoading = true;
++            notifyDataHandlers();
+         }
+ 
+     private:
++        void notifyDataHandlers()
++        {
++            for (auto& handler : m_receivedDataHandlers)
++                handler(m_receivedData.get());
++            m_receivedDataHandlers.clear();
++        }
++
+         ResourceResponse m_originalResponse;
+         CompletionHandler<void(const ResourceResponse&, RefPtr<SharedBuffer>)> m_completionHandler;
++        Ref<SharedBuffer> m_receivedData;
++        Vector<CompletionHandler<void(const SharedBuffer&)>> m_receivedDataHandlers;
+         bool m_responded { false };
++        bool m_finishedLoading { false };
+     };
+ 
+     std::unique_ptr<Inspector::NetworkFrontendDispatcher> m_frontendDispatcher;
 diff --git a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
-index 64117425ba5c..8fa02250a9c5 100644
+index 64117425ba5c5b6a71d190dfc8f1eefb4ffc637c..8fa02250a9c5736a7a8099840bf8f263a43f6604 100644
 --- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
 @@ -32,19 +32,25 @@
@@ -4552,7 +4854,7 @@ index 64117425ba5c..8fa02250a9c5 100644
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorPageAgent.h b/Source/WebCore/inspector/agents/InspectorPageAgent.h
-index b51addb1bd8f..2ad11ef1993e 100644
+index b51addb1bd8f2cce69560799cd1d952d2de42838..2ad11ef1993ed5a223f63073c4b4464bfde93a34 100644
 --- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
 @@ -34,17 +34,23 @@
@@ -4701,7 +5003,7 @@ index b51addb1bd8f..2ad11ef1993e 100644
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
-index 33caa0aa2079..4b74d397d4de 100644
+index 33caa0aa2079ad4081cc29605a53537c24d66bef..4b74d397d4de9a7eba3d5530538443d8907726aa 100644
 --- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
 @@ -161,7 +161,11 @@ void InspectorWorkerAgent::connectToWorkerInspectorProxy(WorkerInspectorProxy& p
@@ -4718,7 +5020,7 @@ index 33caa0aa2079..4b74d397d4de 100644
  
  void InspectorWorkerAgent::disconnectFromWorkerInspectorProxy(WorkerInspectorProxy& proxy)
 diff --git a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
-index 55d951849419..98035b606587 100644
+index 55d9518494195b96df165a94c1c2963adceb8395..98035b606587337e5fdacd31459a196fa7c28702 100644
 --- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
 +++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
 @@ -38,6 +38,7 @@
@@ -4754,7 +5056,7 @@ index 55d951849419..98035b606587 100644
  
  void PageDebuggerAgent::debuggerDidEvaluate(JSC::Debugger&, const JSC::Breakpoint::Action& action)
 diff --git a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
-index b32f3f699c2d..48f0fab7f07b 100644
+index b32f3f699c2d2a377289760b245ac81784102458..48f0fab7f07bfc2b2408764e9adec252cc380705 100644
 --- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
 +++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
 @@ -35,12 +35,14 @@
@@ -4818,7 +5120,7 @@ index b32f3f699c2d..48f0fab7f07b 100644
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
-index 6aba3a2c6e8b..537e3b34d640 100644
+index 6aba3a2c6e8bbb7a0bca4f07824cf4de8ce36f8e..537e3b34d6405e412bf0e2350909c9afda06bed8 100644
 --- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
 +++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
 @@ -54,25 +54,25 @@ public:
@@ -4856,7 +5158,7 @@ index 6aba3a2c6e8b..537e3b34d640 100644
  
      Page& m_inspectedPage;
 diff --git a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp
-index 8699436e3f96..35fbd46627f6 100644
+index 8699436e3f962b465b47aebebd601ee90152ef83..35fbd46627f68d9ebac52500bc560d4fd9866166 100644
 --- a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp
 +++ b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp
 @@ -38,9 +38,9 @@
@@ -4872,7 +5174,7 @@ index 8699436e3f96..35fbd46627f6 100644
      , m_userWasInteracting(false)
  {
 diff --git a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h
-index 16edb3bc689b..f363b2ca2410 100644
+index 16edb3bc689b8e2dde17597b642b706c1343e1f5..f363b2ca2410f22cff8d6ad908a88527970ab1d8 100644
 --- a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h
 +++ b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h
 @@ -38,12 +38,13 @@ namespace WebCore {
@@ -4891,7 +5193,7 @@ index 16edb3bc689b..f363b2ca2410 100644
  
  private:
 diff --git a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
-index 92a0b1d304cc..18617fb37245 100644
+index 92a0b1d304cca9ab0170d135e8c9537f65f469db..18617fb37245d7087825fe3c94feda94b117a320 100644
 --- a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
 +++ b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
 @@ -250,7 +250,7 @@ void LineLayout::prepareLayoutState()
@@ -4904,7 +5206,7 @@ index 92a0b1d304cc..18617fb37245 100644
      rootGeometry.setHorizontalMargin({ });
      rootGeometry.setVerticalMargin({ });
 diff --git a/Source/WebCore/loader/CookieJar.h b/Source/WebCore/loader/CookieJar.h
-index 982691dd2dfe..4af72beb3b14 100644
+index 982691dd2dfe2f65201370a12302b5086703c126..4af72beb3b1405ffac78e89e7fbb2b14d6647903 100644
 --- a/Source/WebCore/loader/CookieJar.h
 +++ b/Source/WebCore/loader/CookieJar.h
 @@ -43,6 +43,7 @@ struct CookieRequestHeaderFieldProxy;
@@ -4926,7 +5228,7 @@ index 982691dd2dfe..4af72beb3b14 100644
  protected:
      static SameSiteInfo sameSiteInfo(const Document&, IsForDOMCookieAccess = IsForDOMCookieAccess::No);
 diff --git a/Source/WebCore/loader/DocumentLoader.cpp b/Source/WebCore/loader/DocumentLoader.cpp
-index 367675741089..b15bf5fd3188 100644
+index 367675741089a498870aa9e16a20b419bee0eef9..b15bf5fd318862fd50aa2f5cf26cd29d75618aa2 100644
 --- a/Source/WebCore/loader/DocumentLoader.cpp
 +++ b/Source/WebCore/loader/DocumentLoader.cpp
 @@ -1408,8 +1408,6 @@ void DocumentLoader::detachFromFrame()
@@ -4939,7 +5241,7 @@ index 367675741089..b15bf5fd3188 100644
  }
  
 diff --git a/Source/WebCore/loader/DocumentLoader.h b/Source/WebCore/loader/DocumentLoader.h
-index e693532ebd64..242829bb5200 100644
+index e693532ebd64f5c042c7c37d839189597d6e6909..242829bb5200d6524978594cdc9061dc538c3cdd 100644
 --- a/Source/WebCore/loader/DocumentLoader.h
 +++ b/Source/WebCore/loader/DocumentLoader.h
 @@ -166,9 +166,13 @@ public:
@@ -4957,7 +5259,7 @@ index e693532ebd64..242829bb5200 100644
      DocumentWriter& writer() const { return m_writer; }
  
 diff --git a/Source/WebCore/loader/FrameLoader.cpp b/Source/WebCore/loader/FrameLoader.cpp
-index d713f7dd4a49..6fd9f81126ef 100644
+index d713f7dd4a492cfc36a83e10da26213dabe275fe..6fd9f81126ef6a9fe0041e2db7061f182120a092 100644
 --- a/Source/WebCore/loader/FrameLoader.cpp
 +++ b/Source/WebCore/loader/FrameLoader.cpp
 @@ -1152,6 +1152,7 @@ void FrameLoader::loadInSameDocument(const URL& url, SerializedScriptValue* stat
@@ -5025,7 +5327,7 @@ index d713f7dd4a49..6fd9f81126ef 100644
      InspectorInstrumentation::didClearWindowObjectInWorld(m_frame, world);
  }
 diff --git a/Source/WebCore/loader/LoaderStrategy.h b/Source/WebCore/loader/LoaderStrategy.h
-index b018af04d05c..6929c01318f5 100644
+index b018af04d05ce3ac38bb57d8e50a7b063ee51733..6929c01318f509ed560276168d18e0112b116bc2 100644
 --- a/Source/WebCore/loader/LoaderStrategy.h
 +++ b/Source/WebCore/loader/LoaderStrategy.h
 @@ -84,6 +84,7 @@ public:
@@ -5037,7 +5339,7 @@ index b018af04d05c..6929c01318f5 100644
      virtual bool shouldPerformSecurityChecks() const { return false; }
      virtual bool havePerformedSecurityChecks(const ResourceResponse&) const { return false; }
 diff --git a/Source/WebCore/loader/PolicyChecker.cpp b/Source/WebCore/loader/PolicyChecker.cpp
-index c082a981526d..2f8eb1b0cabb 100644
+index c082a981526d40408c85bb16683ab14ef6dd6e88..2f8eb1b0cabb23b230ea37254e7a18077335bc30 100644
 --- a/Source/WebCore/loader/PolicyChecker.cpp
 +++ b/Source/WebCore/loader/PolicyChecker.cpp
 @@ -46,6 +46,7 @@
@@ -5083,7 +5385,7 @@ index c082a981526d..2f8eb1b0cabb 100644
              return;
          }
 diff --git a/Source/WebCore/loader/ProgressTracker.cpp b/Source/WebCore/loader/ProgressTracker.cpp
-index 0dcb47556d04..df57e9a47160 100644
+index 0dcb47556d04874878656e459c9bac9af64dcfbf..df57e9a47160bfbeb8188d80afd175c756e982f9 100644
 --- a/Source/WebCore/loader/ProgressTracker.cpp
 +++ b/Source/WebCore/loader/ProgressTracker.cpp
 @@ -154,6 +154,8 @@ void ProgressTracker::progressCompleted(Frame& frame)
@@ -5105,7 +5407,7 @@ index 0dcb47556d04..df57e9a47160 100644
  
  void ProgressTracker::incrementProgress(unsigned long identifier, const ResourceResponse& response)
 diff --git a/Source/WebCore/page/ChromeClient.h b/Source/WebCore/page/ChromeClient.h
-index 6d84f6944df6..a404540c0330 100644
+index 6d84f6944df6177405c1faf3babde10d9bbf5993..a404540c03300e1e76888a8a0360ee6aaec2e0d9 100644
 --- a/Source/WebCore/page/ChromeClient.h
 +++ b/Source/WebCore/page/ChromeClient.h
 @@ -297,7 +297,7 @@ public:
@@ -5118,7 +5420,7 @@ index 6d84f6944df6..a404540c0330 100644
  
  #if ENABLE(INPUT_TYPE_COLOR)
 diff --git a/Source/WebCore/page/EventHandler.cpp b/Source/WebCore/page/EventHandler.cpp
-index 27337d865a6a..50204bc37a9e 100644
+index 27337d865a6a0f0c262bae4d5b92532e2da98371..50204bc37a9e2641867aac08e2dccaf7b05da4de 100644
 --- a/Source/WebCore/page/EventHandler.cpp
 +++ b/Source/WebCore/page/EventHandler.cpp
 @@ -125,6 +125,7 @@
@@ -5253,7 +5555,7 @@ index 27337d865a6a..50204bc37a9e 100644
      m_touchPressed = touches->length() > 0;
      if (allTouchReleased)
 diff --git a/Source/WebCore/page/EventHandler.h b/Source/WebCore/page/EventHandler.h
-index 9fb52b2e9fbd..393f7720588c 100644
+index 9fb52b2e9fbd85731534a6b28a91a369c37877d2..393f7720588cb4801b46828940ab90b6ea547ff2 100644
 --- a/Source/WebCore/page/EventHandler.h
 +++ b/Source/WebCore/page/EventHandler.h
 @@ -135,9 +135,7 @@ public:
@@ -5311,7 +5613,7 @@ index 9fb52b2e9fbd..393f7720588c 100644
      bool m_mouseDownMayStartDrag { false };
      bool m_dragMayStartSelectionInstead { false };
 diff --git a/Source/WebCore/page/EventSource.cpp b/Source/WebCore/page/EventSource.cpp
-index 7b77e407ee5d..0060ebfb1128 100644
+index 7b77e407ee5d08ab3784d0899cfa33f0177f0648..0060ebfb1128cc5eb28baa5ecf4538a203ba82e1 100644
 --- a/Source/WebCore/page/EventSource.cpp
 +++ b/Source/WebCore/page/EventSource.cpp
 @@ -36,6 +36,7 @@
@@ -5331,7 +5633,7 @@ index 7b77e407ee5d..0060ebfb1128 100644
      request.setHTTPHeaderField(HTTPHeaderName::Accept, "text/event-stream");
      request.setHTTPHeaderField(HTTPHeaderName::CacheControl, "no-cache");
 diff --git a/Source/WebCore/page/Frame.cpp b/Source/WebCore/page/Frame.cpp
-index 7054acc90214..658520b15acd 100644
+index 7054acc90214eb817bd784298ce77f76d32c5dee..658520b15acdd632aa01576fea1f49df3aa722f7 100644
 --- a/Source/WebCore/page/Frame.cpp
 +++ b/Source/WebCore/page/Frame.cpp
 @@ -39,6 +39,7 @@
@@ -5727,7 +6029,7 @@ index 7054acc90214..658520b15acd 100644
  
  #undef FRAME_RELEASE_LOG_ERROR
 diff --git a/Source/WebCore/page/Frame.h b/Source/WebCore/page/Frame.h
-index f0743e939757..f1863e330e7f 100644
+index f0743e939757f672a7276fabe3b6596e3179ae2b..f1863e330e7ff386bfbf664df1c798436c1dd57e 100644
 --- a/Source/WebCore/page/Frame.h
 +++ b/Source/WebCore/page/Frame.h
 @@ -110,8 +110,8 @@ enum {
@@ -5787,7 +6089,7 @@ index f0743e939757..f1863e330e7f 100644
  
      ViewportArguments m_viewportArguments;
 diff --git a/Source/WebCore/page/FrameSnapshotting.cpp b/Source/WebCore/page/FrameSnapshotting.cpp
-index 8273a64fcdfb..8a2f97ac8f93 100644
+index 8273a64fcdfb7d34eaa76f98ba7a2117eafbfbe6..8a2f97ac8f935a71fce96913f8b10551a85de563 100644
 --- a/Source/WebCore/page/FrameSnapshotting.cpp
 +++ b/Source/WebCore/page/FrameSnapshotting.cpp
 @@ -103,7 +103,7 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(Frame& frame, const IntRect& image
@@ -5825,7 +6127,7 @@ index 8273a64fcdfb..8a2f97ac8f93 100644
  }
  
 diff --git a/Source/WebCore/page/FrameSnapshotting.h b/Source/WebCore/page/FrameSnapshotting.h
-index 1b77026f5109..6026bc235080 100644
+index 1b77026f51092001cda86e32480890395b145b2e..6026bc23508016454f331b06c9f071a88f55cccc 100644
 --- a/Source/WebCore/page/FrameSnapshotting.h
 +++ b/Source/WebCore/page/FrameSnapshotting.h
 @@ -50,6 +50,7 @@ enum class SnapshotFlags : uint8_t {
@@ -5837,7 +6139,7 @@ index 1b77026f5109..6026bc235080 100644
  
  struct SnapshotOptions {
 diff --git a/Source/WebCore/page/FrameView.cpp b/Source/WebCore/page/FrameView.cpp
-index a2129f7769fd..f0f30d0e7ce7 100644
+index a2129f7769fd10d2960c764dd68457867106ab59..f0f30d0e7ce72bc089f77abda92648dfc8c9d66e 100644
 --- a/Source/WebCore/page/FrameView.cpp
 +++ b/Source/WebCore/page/FrameView.cpp
 @@ -3028,7 +3028,7 @@ void FrameView::setBaseBackgroundColor(const Color& backgroundColor)
@@ -5850,7 +6152,7 @@ index a2129f7769fd..f0f30d0e7ce7 100644
  #else
      Color baseBackgroundColor = backgroundColor.value_or(Color::white);
 diff --git a/Source/WebCore/page/History.cpp b/Source/WebCore/page/History.cpp
-index 28d1fc324217..058b5309eed0 100644
+index 28d1fc3242174a680711027877d4153923790220..058b5309eed081fcc1e4158f66e806421dcc9d56 100644
 --- a/Source/WebCore/page/History.cpp
 +++ b/Source/WebCore/page/History.cpp
 @@ -33,6 +33,7 @@
@@ -5870,7 +6172,7 @@ index 28d1fc324217..058b5309eed0 100644
      if (stateObjectType == StateObjectType::Push) {
          frame->loader().history().pushState(WTFMove(data), title, fullURL.string());
 diff --git a/Source/WebCore/page/Page.cpp b/Source/WebCore/page/Page.cpp
-index 2c6951c24d7a..71511627d2e0 100644
+index 2c6951c24d7aea5873276d1db27e01d3a3711821..71511627d2e0b2ffcde9f742ef8bd3ab94b792ce 100644
 --- a/Source/WebCore/page/Page.cpp
 +++ b/Source/WebCore/page/Page.cpp
 @@ -447,6 +447,37 @@ void Page::setOverrideViewportArguments(const std::optional<ViewportArguments>&
@@ -5941,7 +6243,7 @@ index 2c6951c24d7a..71511627d2e0 100644
  {
      if (insets == m_fullscreenInsets)
 diff --git a/Source/WebCore/page/Page.h b/Source/WebCore/page/Page.h
-index d671e78aae96..9b57c4c4c0f0 100644
+index d671e78aae960a97676ba1b91233dd82d76a8990..9b57c4c4c0f0f1ce7c0b2b2cf284d04d13b9fb4c 100644
 --- a/Source/WebCore/page/Page.h
 +++ b/Source/WebCore/page/Page.h
 @@ -256,6 +256,9 @@ public:
@@ -6017,7 +6319,7 @@ index d671e78aae96..9b57c4c4c0f0 100644
  #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
      RefPtr<DeviceOrientationUpdateProvider> m_deviceOrientationUpdateProvider;
 diff --git a/Source/WebCore/page/PointerCaptureController.cpp b/Source/WebCore/page/PointerCaptureController.cpp
-index 2903e934ebf5..8d644b579ebd 100644
+index 2903e934ebf5cf0e755d817d778717fe01ae066b..8d644b579ebd02761a4f6ff7db5f526623bc376c 100644
 --- a/Source/WebCore/page/PointerCaptureController.cpp
 +++ b/Source/WebCore/page/PointerCaptureController.cpp
 @@ -202,7 +202,7 @@ bool PointerCaptureController::preventsCompatibilityMouseEventsForIdentifier(Poi
@@ -6039,7 +6341,7 @@ index 2903e934ebf5..8d644b579ebd 100644
  #endif
  
 diff --git a/Source/WebCore/page/PointerCaptureController.h b/Source/WebCore/page/PointerCaptureController.h
-index 27ee79477915..cad99479d445 100644
+index 27ee794779152f113b49391e4e59614cb5794764..cad99479d44588710bb87dd1a6c6c367149c515a 100644
 --- a/Source/WebCore/page/PointerCaptureController.h
 +++ b/Source/WebCore/page/PointerCaptureController.h
 @@ -57,7 +57,7 @@ public:
@@ -6061,7 +6363,7 @@ index 27ee79477915..cad99479d445 100644
  #endif
          bool hasAnyElement() const {
 diff --git a/Source/WebCore/page/RuntimeEnabledFeatures.cpp b/Source/WebCore/page/RuntimeEnabledFeatures.cpp
-index 6b2bc1bdb38b..68a1773c0f57 100644
+index 6b2bc1bdb38be0543f20d51d200944b3f547f6a9..68a1773c0f578ecf8d5d7aa15ec1d34d9ad7a0a2 100644
 --- a/Source/WebCore/page/RuntimeEnabledFeatures.cpp
 +++ b/Source/WebCore/page/RuntimeEnabledFeatures.cpp
 @@ -56,7 +56,11 @@ RuntimeEnabledFeatures& RuntimeEnabledFeatures::sharedFeatures()
@@ -6078,7 +6380,7 @@ index 6b2bc1bdb38b..68a1773c0f57 100644
  #endif
  
 diff --git a/Source/WebCore/page/RuntimeEnabledFeatures.h b/Source/WebCore/page/RuntimeEnabledFeatures.h
-index d0774fd91166..73061176c6f2 100644
+index d0774fd91166b2b977f2e930c5909f35a215be8e..73061176c6f23eaead3add9a71a42de3962dec76 100644
 --- a/Source/WebCore/page/RuntimeEnabledFeatures.h
 +++ b/Source/WebCore/page/RuntimeEnabledFeatures.h
 @@ -200,6 +200,7 @@ public:
@@ -6090,7 +6392,7 @@ index d0774fd91166..73061176c6f2 100644
  
      bool pageAtRuleSupportEnabled() const { return m_pageAtRuleSupportEnabled; }
 diff --git a/Source/WebCore/page/Screen.cpp b/Source/WebCore/page/Screen.cpp
-index 7ac11c828934..764b2d4fe36a 100644
+index 7ac11c8289347e3a2f3e7316cf9e32932b9544ed..764b2d4fe36ac2e5588bd22595424ac11d42acd0 100644
 --- a/Source/WebCore/page/Screen.cpp
 +++ b/Source/WebCore/page/Screen.cpp
 @@ -102,6 +102,8 @@ int Screen::availLeft() const
@@ -6130,7 +6432,7 @@ index 7ac11c828934..764b2d4fe36a 100644
  }
  
 diff --git a/Source/WebCore/page/SocketProvider.cpp b/Source/WebCore/page/SocketProvider.cpp
-index 3bec0aef1743..566ef3806be3 100644
+index 3bec0aef174336939838fb1069fffbcb9f3d5604..566ef3806be3c5ccf1bb951251c2a90dba7071a3 100644
 --- a/Source/WebCore/page/SocketProvider.cpp
 +++ b/Source/WebCore/page/SocketProvider.cpp
 @@ -33,7 +33,7 @@ namespace WebCore {
@@ -6143,7 +6445,7 @@ index 3bec0aef1743..566ef3806be3 100644
  
  RefPtr<ThreadableWebSocketChannel> SocketProvider::createWebSocketChannel(Document&, WebSocketChannelClient&)
 diff --git a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
-index fc85fffa9b20..1070a1973d0e 100644
+index fc85fffa9b20cf5d3a2cff89b7d38ecf84aa0ff6..1070a1973d0ea23c6781df4269fc43498ce18608 100644
 --- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
 +++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
 @@ -281,6 +281,8 @@ bool ContentSecurityPolicy::protocolMatchesSelf(const URL& url) const
@@ -6174,7 +6476,7 @@ index fc85fffa9b20..1070a1973d0e 100644
      for (auto& policy : m_policies) {
          if (const ContentSecurityPolicyDirective* violatedDirective = (policy.get()->*predicate)(std::forward<Args>(args)...)) {
 diff --git a/Source/WebCore/page/ios/FrameIOS.mm b/Source/WebCore/page/ios/FrameIOS.mm
-index 12cc7336ae87..b97227e21bf9 100644
+index 12cc7336ae87b6d9d8ea83cf543d029914eaf1db..b97227e21bf9e7166980c20d2efdc24ea28058a2 100644
 --- a/Source/WebCore/page/ios/FrameIOS.mm
 +++ b/Source/WebCore/page/ios/FrameIOS.mm
 @@ -226,354 +226,6 @@ CGRect Frame::renderRectForPoint(CGPoint point, bool* isReplaced, float* fontSiz
@@ -6534,7 +6836,7 @@ index 12cc7336ae87..b97227e21bf9 100644
      Document* document = this->document();
 diff --git a/Source/WebCore/page/wpe/DragControllerWPE.cpp b/Source/WebCore/page/wpe/DragControllerWPE.cpp
 new file mode 100644
-index 000000000000..3dedfa855f99
+index 0000000000000000000000000000000000000000..3dedfa855f990643e3e7bbe7754abca4e88a0f1c
 --- /dev/null
 +++ b/Source/WebCore/page/wpe/DragControllerWPE.cpp
 @@ -0,0 +1,79 @@
@@ -6618,7 +6920,7 @@ index 000000000000..3dedfa855f99
 +
 +}
 diff --git a/Source/WebCore/platform/Cairo.cmake b/Source/WebCore/platform/Cairo.cmake
-index 237ebfbb8033..134b26cecc94 100644
+index 237ebfbb80338d313d2a51a77e28309d705fbf69..134b26cecc94e6989126a9f40d1d42a49815d0d4 100644
 --- a/Source/WebCore/platform/Cairo.cmake
 +++ b/Source/WebCore/platform/Cairo.cmake
 @@ -16,6 +16,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
@@ -6630,7 +6932,7 @@ index 237ebfbb8033..134b26cecc94 100644
      platform/graphics/cairo/RefPtrCairo.h
  )
 diff --git a/Source/WebCore/platform/DragData.h b/Source/WebCore/platform/DragData.h
-index 6600dfa7b189..4c0bc485ca92 100644
+index 6600dfa7b189e15fab7fb796f66ef1a79dcd22f3..4c0bc485ca92614efca23a5a2da871b77d5285d3 100644
 --- a/Source/WebCore/platform/DragData.h
 +++ b/Source/WebCore/platform/DragData.h
 @@ -48,7 +48,7 @@ typedef void* DragDataRef;
@@ -6643,7 +6945,7 @@ index 6600dfa7b189..4c0bc485ca92 100644
  class SelectionData;
  }
 diff --git a/Source/WebCore/platform/DragImage.cpp b/Source/WebCore/platform/DragImage.cpp
-index 6dfe0dd3ea4d..683c1bdb2cb3 100644
+index 6dfe0dd3ea4da3a1f5f0f6c79d6d1a3bf00c3159..683c1bdb2cb33538af14dcc5dab89d07dcd34eff 100644
 --- a/Source/WebCore/platform/DragImage.cpp
 +++ b/Source/WebCore/platform/DragImage.cpp
 @@ -279,7 +279,7 @@ DragImage::~DragImage()
@@ -6656,7 +6958,7 @@ index 6dfe0dd3ea4d..683c1bdb2cb3 100644
  IntSize dragImageSize(DragImageRef)
  {
 diff --git a/Source/WebCore/platform/Pasteboard.h b/Source/WebCore/platform/Pasteboard.h
-index 7d247dcd1a16..6903f0a0ab25 100644
+index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e578fb03d 100644
 --- a/Source/WebCore/platform/Pasteboard.h
 +++ b/Source/WebCore/platform/Pasteboard.h
 @@ -44,7 +44,7 @@ OBJC_CLASS NSString;
@@ -6748,7 +7050,7 @@ index 7d247dcd1a16..6903f0a0ab25 100644
  };
  
 diff --git a/Source/WebCore/platform/PlatformKeyboardEvent.h b/Source/WebCore/platform/PlatformKeyboardEvent.h
-index f90f1dad6b7b..9ad9c22488cc 100644
+index f90f1dad6b7b4e6703745c9cb97a32c872fa1aa8..9ad9c22488cc001cade2e8e8a6f4e9b8dc515cbd 100644
 --- a/Source/WebCore/platform/PlatformKeyboardEvent.h
 +++ b/Source/WebCore/platform/PlatformKeyboardEvent.h
 @@ -134,6 +134,7 @@ namespace WebCore {
@@ -6768,7 +7070,7 @@ index f90f1dad6b7b..9ad9c22488cc 100644
  #endif
  
 diff --git a/Source/WebCore/platform/PlatformScreen.cpp b/Source/WebCore/platform/PlatformScreen.cpp
-index ba50b688ab6d..0b83a798b008 100644
+index ba50b688ab6d0bae5d199fa0bac4b7e2004baf81..0b83a798b00835635a95a0db22173de094ba4035 100644
 --- a/Source/WebCore/platform/PlatformScreen.cpp
 +++ b/Source/WebCore/platform/PlatformScreen.cpp
 @@ -25,6 +25,7 @@
@@ -6797,7 +7099,7 @@ index ba50b688ab6d..0b83a798b008 100644
 +} // namespace WebCore
 +#endif
 diff --git a/Source/WebCore/platform/PlatformScreen.h b/Source/WebCore/platform/PlatformScreen.h
-index bb5411ad58c4..0bc31619d5f8 100644
+index bb5411ad58c4ea427837dc7ffeb8687d51e79061..0bc31619d5f8ce268cfbe8b4ee54f8c5d7903aa5 100644
 --- a/Source/WebCore/platform/PlatformScreen.h
 +++ b/Source/WebCore/platform/PlatformScreen.h
 @@ -146,12 +146,14 @@ WEBCORE_EXPORT float screenScaleFactor(UIScreen * = nullptr);
@@ -6819,7 +7121,7 @@ index bb5411ad58c4..0bc31619d5f8 100644
  #endif
  
 diff --git a/Source/WebCore/platform/ScrollableArea.h b/Source/WebCore/platform/ScrollableArea.h
-index 959e8f82f065..557632002250 100644
+index 959e8f82f06545dcbdb90a2b78c0bcb909c803ba..55763200225066abe67b62b5c9c9ca699d0d8672 100644
 --- a/Source/WebCore/platform/ScrollableArea.h
 +++ b/Source/WebCore/platform/ScrollableArea.h
 @@ -103,7 +103,7 @@ public:
@@ -6832,7 +7134,7 @@ index 959e8f82f065..557632002250 100644
  
  #if PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebCore/platform/graphics/FontCascade.h b/Source/WebCore/platform/graphics/FontCascade.h
-index 6dade9146fe9..16a641f4237a 100644
+index 6dade9146fe99078ac1a58b28cf0c5dd0c351095..16a641f4237a8a3a7a40461e3429551f7ca96203 100644
 --- a/Source/WebCore/platform/graphics/FontCascade.h
 +++ b/Source/WebCore/platform/graphics/FontCascade.h
 @@ -283,7 +283,8 @@ private:
@@ -6846,7 +7148,7 @@ index 6dade9146fe9..16a641f4237a 100644
  #else
          return false;
 diff --git a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
-index 4db603a94f3a..c1820f48eb86 100644
+index 4db603a94f3af1b1bce94ab0f1ae36054c004fcc..c1820f48eb86348f8ca678fde636244e8c91267e 100644
 --- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
 +++ b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
 @@ -48,6 +48,13 @@
@@ -6941,7 +7243,7 @@ index 4db603a94f3a..c1820f48eb86 100644
      if (!image || !encodeImage(image, mimeType, &encodedImage))
          return { };
 diff --git a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
-index eac8346d3e17..2ddd1dc81003 100644
+index eac8346d3e177f87792fb0a8fc9dd0fb3b2f6efc..2ddd1dc810033a7f60f17ba555813f1b529d71f7 100644
 --- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
 +++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
 @@ -36,10 +36,10 @@ class PixelBuffer;
@@ -6958,7 +7260,7 @@ index eac8346d3e17..2ddd1dc81003 100644
  
  String dataURL(CGImageRef, CFStringRef destinationUTI, const String& mimeType, std::optional<double> quality);
 diff --git a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
-index 2e46b61536c8..fa0c72d80d83 100644
+index 2e46b61536c835dfcacf9f79e10e6d59ae7a3836..fa0c72d80d83c58a8407e78988de010fe97d7c38 100644
 --- a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
 +++ b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
 @@ -27,7 +27,7 @@
@@ -6971,7 +7273,7 @@ index 2e46b61536c8..fa0c72d80d83 100644
  #include "ExtensionsGLOpenGL.h"
  #include "IntRect.h"
 diff --git a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
-index 774a52a28693..cd714a7298fe 100644
+index 774a52a28693bc51dde10a0875ea379afb06fd3c..cd714a7298fe4f5d2c9b580697a5c4cd22d25870 100644
 --- a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
 +++ b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
 @@ -172,6 +172,33 @@ static Vector<unsigned> stringIndicesFromClusters(const Vector<WORD>& clusters,
@@ -7018,7 +7320,7 @@ index 774a52a28693..cd714a7298fe 100644
          // Determine the string for this item.
          const UChar* str = cp + items[i].iCharPos;
 diff --git a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
-index 0516e70973e0..ffd9a02deb55 100644
+index 0516e70973e0078de6ad0216375d34dd9ef51a8d..ffd9a02deb5518e0c8c77b156815c11eb4b16829 100644
 --- a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
 +++ b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
 @@ -37,8 +37,10 @@
@@ -7280,7 +7582,7 @@ index 0516e70973e0..ffd9a02deb55 100644
  {
      switch (val) {
 diff --git a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
-index 7a3b4723f48c..a741751acad0 100644
+index 7a3b4723f48c179864b2dd6d5b1ed8d27492358e..a741751acad01f11d7da0f6896eeb0023b9a3fcc 100644
 --- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
 +++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
 @@ -224,7 +224,7 @@ bool screenSupportsExtendedColor(Widget*)
@@ -7302,7 +7604,7 @@ index 7a3b4723f48c..a741751acad0 100644
      auto* display = gdk_display_get_default();
      if (!display)
 diff --git a/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp b/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
-index f4c905dc15a2..e9925e7a9fc3 100644
+index f4c905dc15a2183629b0e9817dc24135e0ff7fe5..e9925e7a9fc3cbf5fefffaf38f409fbeec189cb0 100644
 --- a/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
 +++ b/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
 @@ -32,6 +32,10 @@
@@ -7431,7 +7733,7 @@ index f4c905dc15a2..e9925e7a9fc3 100644
  
  #endif // USE(LIBWPE)
 diff --git a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
-index a34dc220bbb9..8ecedd5dae88 100644
+index a34dc220bbb9a92b40dfb463e8724e81ac745b2c..8ecedd5dae88469366a619b96960598c1232a32d 100644
 --- a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
 +++ b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
 @@ -30,8 +30,10 @@
@@ -7693,7 +7995,7 @@ index a34dc220bbb9..8ecedd5dae88 100644
  {
      switch (val) {
 diff --git a/Source/WebCore/platform/network/HTTPHeaderMap.cpp b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
-index 39cb560e54bf..91c132460d4b 100644
+index 39cb560e54bf9efd2dad6e1fb60dd0f609daf6bf..91c132460d4b466f61a8c579f70329fdde3b130f 100644
 --- a/Source/WebCore/platform/network/HTTPHeaderMap.cpp
 +++ b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
 @@ -205,8 +205,11 @@ void HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
@@ -7710,7 +8012,7 @@ index 39cb560e54bf..91c132460d4b 100644
          m_commonHeaders.append(CommonHeader { name, value });
  }
 diff --git a/Source/WebCore/platform/network/ResourceResponseBase.h b/Source/WebCore/platform/network/ResourceResponseBase.h
-index f5c0970b031a..713ade70c5be 100644
+index f5c0970b031a2e9e2a176af81e6cf510ace4cb4a..713ade70c5bec341613bb0b5997c5c64382f41e3 100644
 --- a/Source/WebCore/platform/network/ResourceResponseBase.h
 +++ b/Source/WebCore/platform/network/ResourceResponseBase.h
 @@ -217,6 +217,8 @@ public:
@@ -7744,7 +8046,7 @@ index f5c0970b031a..713ade70c5be 100644
      if constexpr (Decoder::isIPCDecoder) {
          std::optional<Box<NetworkLoadMetrics>> networkLoadMetrics;
 diff --git a/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h b/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h
-index 7330aa933924..a5238a748d1f 100644
+index 7330aa933924791f1292c0847921e3b367493d96..a5238a748d1fb4bfa5b3e0882fe62f4029f84e5f 100644
 --- a/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h
 +++ b/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h
 @@ -47,7 +47,7 @@ class SocketStreamHandleClient;
@@ -7774,7 +8076,7 @@ index 7330aa933924..a5238a748d1f 100644
      StreamBuffer<uint8_t, 1024 * 1024> m_buffer;
      static const unsigned maxBufferSize = 100 * 1024 * 1024;
 diff --git a/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp b/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
-index 55b9f1ed4a0d..2279824540b8 100644
+index 55b9f1ed4a0d325a6b16a114389f39c7ded36ca6..2279824540b85405ec3ccac709026a381063bac8 100644
 --- a/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
 +++ b/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
 @@ -96,7 +96,7 @@ static inline auto callbacksRunLoopMode()
@@ -7804,7 +8106,7 @@ index 55b9f1ed4a0d..2279824540b8 100644
              kCFStreamSSLPeerName,
              kCFStreamSSLLevel,
 diff --git a/Source/WebCore/platform/network/curl/CookieJarDB.h b/Source/WebCore/platform/network/curl/CookieJarDB.h
-index c4eb67d6f7c3..ce86ab28225a 100644
+index c4eb67d6f7c334076b32b798dcea40b570681e6f..ce86ab28225aa466350671441294f2ace8851bbd 100644
 --- a/Source/WebCore/platform/network/curl/CookieJarDB.h
 +++ b/Source/WebCore/platform/network/curl/CookieJarDB.h
 @@ -72,7 +72,7 @@ public:
@@ -7817,7 +8119,7 @@ index c4eb67d6f7c3..ce86ab28225a 100644
  
      bool m_detectedDatabaseCorruption { false };
 diff --git a/Source/WebCore/platform/network/curl/CurlStream.cpp b/Source/WebCore/platform/network/curl/CurlStream.cpp
-index ff55d3523427..37a657851d84 100644
+index ff55d352342786fcdeaefc64f6ccbe015f4c5b5f..37a657851d84c3693c1e31239a19d9edd935d039 100644
 --- a/Source/WebCore/platform/network/curl/CurlStream.cpp
 +++ b/Source/WebCore/platform/network/curl/CurlStream.cpp
 @@ -33,7 +33,7 @@
@@ -7840,7 +8142,7 @@ index ff55d3523427..37a657851d84 100644
      auto errorCode = m_curlHandle->perform();
      if (errorCode != CURLE_OK) {
 diff --git a/Source/WebCore/platform/network/curl/CurlStream.h b/Source/WebCore/platform/network/curl/CurlStream.h
-index e64629fc22a2..920a8c12c6c6 100644
+index e64629fc22a2097a2af0b0c0139b23d7908cf3dc..920a8c12c6c69afc5aec6de12e9f5fba312237a0 100644
 --- a/Source/WebCore/platform/network/curl/CurlStream.h
 +++ b/Source/WebCore/platform/network/curl/CurlStream.h
 @@ -50,12 +50,12 @@ public:
@@ -7860,7 +8162,7 @@ index e64629fc22a2..920a8c12c6c6 100644
  
      void send(UniqueArray<uint8_t>&&, size_t);
 diff --git a/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp b/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
-index b4a9abd45307..d750af7d2e6e 100644
+index b4a9abd45307e14b1b0080c5fd8490acaf7bb599..d750af7d2e6e25b9df9fada78ae1fe3767066fbb 100644
 --- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
 +++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
 @@ -40,7 +40,7 @@ CurlStreamScheduler::~CurlStreamScheduler()
@@ -7884,7 +8186,7 @@ index b4a9abd45307..d750af7d2e6e 100644
  
      return streamID;
 diff --git a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
-index 7d881206c968..2e8118f11f87 100644
+index 7d881206c9689f433227969c9b7f9ff268bdaaed..2e8118f11f87fa5f32adcedc165aec8220b36d58 100644
 --- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
 +++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
 @@ -38,7 +38,7 @@ public:
@@ -7897,7 +8199,7 @@ index 7d881206c968..2e8118f11f87 100644
      void send(CurlStreamID, UniqueArray<uint8_t>&&, size_t);
  
 diff --git a/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h b/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h
-index b804fde0973b..af3005261593 100644
+index b804fde0973bbfb28331cf7c3a1f20b043e74fe8..af3005261593b5fa91484c98c43d021227716231 100644
 --- a/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h
 +++ b/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h
 @@ -44,7 +44,7 @@ class StorageSessionProvider;
@@ -7919,7 +8221,7 @@ index b804fde0973b..af3005261593 100644
      size_t bufferedAmount() final;
      std::optional<size_t> platformSendInternal(const uint8_t*, size_t);
 diff --git a/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp b/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp
-index 4b9491c11543..e907fc00a2a4 100644
+index 4b9491c11543f2b60f12d36e9e6a0cbaae34a72e..e907fc00a2a426384ce1e471847911c9ba1739af 100644
 --- a/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp
 +++ b/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp
 @@ -43,7 +43,7 @@
@@ -7941,7 +8243,7 @@ index 4b9491c11543..e907fc00a2a4 100644
  
  SocketStreamHandleImpl::~SocketStreamHandleImpl()
 diff --git a/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h b/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h
-index 88df3748e980..f83c7f2535fd 100644
+index 88df3748e980a22e71bd835864caf24b6b7ea50b..f83c7f2535fd1abae7b1cccca946254b9407f86f 100644
 --- a/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h
 +++ b/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h
 @@ -47,7 +47,7 @@ class StorageSessionProvider;
@@ -7954,7 +8256,7 @@ index 88df3748e980..f83c7f2535fd 100644
          RELEASE_ASSERT_NOT_REACHED();
      }
 diff --git a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
-index 3e97e804e115..86a1b22913c9 100644
+index 3e97e804e115e0e37814ddf670e9e3ba4b3bbc73..86a1b22913c9ed6563f0d56c7ebd74c16dc829b9 100644
 --- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
 +++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
 @@ -38,6 +38,7 @@
@@ -7978,7 +8280,7 @@ index 3e97e804e115..86a1b22913c9 100644
      ReleaseStgMedium(&store);
  }
 diff --git a/Source/WebCore/platform/win/ClipboardUtilitiesWin.h b/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
-index c50799b63e05..9cf1cc7ec4ea 100644
+index c50799b63e05adbe32bae3535d786c7d268f980f..9cf1cc7ec4eaae22947f80ba272dfae272167bd6 100644
 --- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
 +++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
 @@ -34,6 +34,7 @@ namespace WebCore {
@@ -7990,7 +8292,7 @@ index c50799b63e05..9cf1cc7ec4ea 100644
  HGLOBAL createGlobalData(const String&);
  HGLOBAL createGlobalData(const Vector<char>&);
 diff --git a/Source/WebCore/platform/win/DragDataWin.cpp b/Source/WebCore/platform/win/DragDataWin.cpp
-index 579a112579af..82c566c9d2ce 100644
+index 579a112579af39fc12ef024979d81fc55af36c2b..82c566c9d2ced02a92902a90e7ff97c142fa1903 100644
 --- a/Source/WebCore/platform/win/DragDataWin.cpp
 +++ b/Source/WebCore/platform/win/DragDataWin.cpp
 @@ -48,6 +48,7 @@ DragData::DragData(const DragDataMap& data, const IntPoint& clientPosition, cons
@@ -8002,7 +8304,7 @@ index 579a112579af..82c566c9d2ce 100644
  }
  
 diff --git a/Source/WebCore/platform/win/KeyEventWin.cpp b/Source/WebCore/platform/win/KeyEventWin.cpp
-index aae6c99dd052..7e2e5d0c1de9 100644
+index aae6c99dd052985a43718846b68536454050c234..7e2e5d0c1de90f1454f7fdb71a40ab71228dcbe9 100644
 --- a/Source/WebCore/platform/win/KeyEventWin.cpp
 +++ b/Source/WebCore/platform/win/KeyEventWin.cpp
 @@ -239,10 +239,16 @@ PlatformKeyboardEvent::PlatformKeyboardEvent(HWND, WPARAM code, LPARAM keyData,
@@ -8026,7 +8328,7 @@ index aae6c99dd052..7e2e5d0c1de9 100644
  
  bool PlatformKeyboardEvent::currentCapsLockState()
 diff --git a/Source/WebCore/platform/win/PasteboardWin.cpp b/Source/WebCore/platform/win/PasteboardWin.cpp
-index 9e3357b20e60..be6579859e80 100644
+index 9e3357b20e60f47829ced8d2849f5d8c9a7bb50a..be6579859e80c846235b7f94f2ec7551078c9fdd 100644
 --- a/Source/WebCore/platform/win/PasteboardWin.cpp
 +++ b/Source/WebCore/platform/win/PasteboardWin.cpp
 @@ -1134,7 +1134,21 @@ void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
@@ -8079,7 +8381,7 @@ index 9e3357b20e60..be6579859e80 100644
  } // namespace WebCore
 diff --git a/Source/WebCore/platform/wpe/DragDataWPE.cpp b/Source/WebCore/platform/wpe/DragDataWPE.cpp
 new file mode 100644
-index 000000000000..07fb260a5203
+index 0000000000000000000000000000000000000000..07fb260a5203167fdf94a552949394bb73ca8c61
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/DragDataWPE.cpp
 @@ -0,0 +1,87 @@
@@ -8172,7 +8474,7 @@ index 000000000000..07fb260a5203
 +}
 diff --git a/Source/WebCore/platform/wpe/DragImageWPE.cpp b/Source/WebCore/platform/wpe/DragImageWPE.cpp
 new file mode 100644
-index 000000000000..0c684ea504c0
+index 0000000000000000000000000000000000000000..0c684ea504c0c93895ab75a880b4d2febc946813
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/DragImageWPE.cpp
 @@ -0,0 +1,68 @@
@@ -8245,7 +8547,7 @@ index 000000000000..0c684ea504c0
 +
 +}
 diff --git a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
-index bbdd1ce76241..e6ae01a77350 100644
+index bbdd1ce76241d933ada9c43fabae4912cbfa64e1..e6ae01a77350c519b203f6ed2910f63871b9b829 100644
 --- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
 +++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
 @@ -93,12 +93,12 @@ bool screenSupportsExtendedColor(Widget*)
@@ -8265,7 +8567,7 @@ index bbdd1ce76241..e6ae01a77350 100644
  }
 diff --git a/Source/WebCore/platform/wpe/SelectionData.cpp b/Source/WebCore/platform/wpe/SelectionData.cpp
 new file mode 100644
-index 000000000000..9f181fdfe507
+index 0000000000000000000000000000000000000000..9f181fdfe507ad5b7a47b5c58295cf4f2725e7d8
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/SelectionData.cpp
 @@ -0,0 +1,134 @@
@@ -8405,7 +8707,7 @@ index 000000000000..9f181fdfe507
 +} // namespace WebCore
 diff --git a/Source/WebCore/platform/wpe/SelectionData.h b/Source/WebCore/platform/wpe/SelectionData.h
 new file mode 100644
-index 000000000000..cf2b51f6f028
+index 0000000000000000000000000000000000000000..cf2b51f6f02837a1106f4d999f2f130e2580986a
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/SelectionData.h
 @@ -0,0 +1,82 @@
@@ -8492,7 +8794,7 @@ index 000000000000..cf2b51f6f028
 +
 +} // namespace WebCore
 diff --git a/Source/WebCore/rendering/RenderLayer.cpp b/Source/WebCore/rendering/RenderLayer.cpp
-index 99c70209c462..0a069c3e6ee7 100644
+index 99c70209c462235fcf95a009bc1fe53e207c59ee..0a069c3e6ee75ae8795011e3f2ea1082ae87a2db 100644
 --- a/Source/WebCore/rendering/RenderLayer.cpp
 +++ b/Source/WebCore/rendering/RenderLayer.cpp
 @@ -2560,7 +2560,7 @@ LayoutRect RenderLayer::getRectToExpose(const LayoutRect& visibleRect, const Lay
@@ -8505,7 +8807,7 @@ index 99c70209c462..0a069c3e6ee7 100644
          // If the rectangle is partially visible, but over a certain threshold,
          // then treat it as fully visible to avoid unnecessary horizontal scrolling
 diff --git a/Source/WebCore/rendering/RenderTextControl.cpp b/Source/WebCore/rendering/RenderTextControl.cpp
-index 242aca3a06b9..4dcd61750471 100644
+index 242aca3a06b91574a748b13ecefa80c6172b9c59..4dcd61750471013be4455b0270a8a21a7b489d47 100644
 --- a/Source/WebCore/rendering/RenderTextControl.cpp
 +++ b/Source/WebCore/rendering/RenderTextControl.cpp
 @@ -207,13 +207,13 @@ void RenderTextControl::layoutExcludedChildren(bool relayoutChildren)
@@ -8524,7 +8826,7 @@ index 242aca3a06b9..4dcd61750471 100644
  {
      auto innerText = innerTextElement();
 diff --git a/Source/WebCore/rendering/RenderTextControl.h b/Source/WebCore/rendering/RenderTextControl.h
-index 2e90534ffd8d..2493c00d5895 100644
+index 2e90534ffd8da83b7dc54d46fa7def16319bbb43..2493c00d58957751c65c37eb409fa8d675efd5ca 100644
 --- a/Source/WebCore/rendering/RenderTextControl.h
 +++ b/Source/WebCore/rendering/RenderTextControl.h
 @@ -36,9 +36,9 @@ public:
@@ -8539,7 +8841,7 @@ index 2e90534ffd8d..2493c00d5895 100644
      int innerLineHeight() const override;
  #endif
 diff --git a/Source/WebCore/rendering/ScrollAlignment.h b/Source/WebCore/rendering/ScrollAlignment.h
-index 694008e0451e..ec93869f9486 100644
+index 694008e0451edc5770142a0a6d9eed52b04ded80..ec93869f9486bdf7bd3bb56478c62469d2fa58b6 100644
 --- a/Source/WebCore/rendering/ScrollAlignment.h
 +++ b/Source/WebCore/rendering/ScrollAlignment.h
 @@ -78,6 +78,7 @@ struct ScrollAlignment {
@@ -8551,7 +8853,7 @@ index 694008e0451e..ec93869f9486 100644
      
  WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollAlignment::Behavior);
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
-index a8216b6ca250..9e972fdbff35 100644
+index a8216b6ca250fea6e14cf02ce2e674847063d5ee..9e972fdbff3553ba26e1c1de994453fb3c1bcd50 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 @@ -74,6 +74,11 @@
@@ -8583,7 +8885,7 @@ index a8216b6ca250..9e972fdbff35 100644
  void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier frameID, PageIdentifier pageID)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
-index 30b8dae1b63f..47f7e34d87c3 100644
+index 30b8dae1b63f62af7077d9566cb1cfc6fed7da5c..47f7e34d87c36226a0244f38d7456853da90860d 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 @@ -285,6 +285,8 @@ private:
@@ -8596,7 +8898,7 @@ index 30b8dae1b63f..47f7e34d87c3 100644
      void removeStorageAccessForFrame(WebCore::FrameIdentifier, WebCore::PageIdentifier);
  
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
-index 063ee6a461bb..d7db79273b77 100644
+index 063ee6a461bb68ebde70c6f9ee4e83961d03354b..d7db79273b77296864150d1bc00363291c343947 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 @@ -64,6 +64,8 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
@@ -8609,7 +8911,7 @@ index 063ee6a461bb..d7db79273b77 100644
      RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
      LogUserInteraction(WebCore::RegistrableDomain domain)
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.cpp b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
-index 49bdd3fec681..5a47aa54e4bb 100644
+index 49bdd3fec68137ce4353950034adc6b2752af9e5..5a47aa54e4bb4bfc5bd216a027c62c0ce3df36cf 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 @@ -26,7 +26,6 @@
@@ -8681,7 +8983,7 @@ index 49bdd3fec681..5a47aa54e4bb 100644
  void NetworkProcess::dumpResourceLoadStatistics(PAL::SessionID sessionID, CompletionHandler<void(String)>&& completionHandler)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.h b/Source/WebKit/NetworkProcess/NetworkProcess.h
-index 447784b1a783..9aad05a798d0 100644
+index 447784b1a7838dd7bdc95cf374057bcc59d8a33d..9aad05a798d00dfb7346a2fbb78a947686e7e715 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
 @@ -34,6 +34,7 @@
@@ -8716,7 +9018,7 @@ index 447784b1a783..9aad05a798d0 100644
      void clearPrevalentResource(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
      void clearUserInteraction(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
-index ae15ff0e12ca..4ee782cbb1e4 100644
+index ae15ff0e12ca545178907d972a09ce6d2321a2d4..4ee782cbb1e4ce8228785f63fa1ca868276a2be9 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 @@ -79,6 +79,14 @@ messages -> NetworkProcess LegacyReceiver {
@@ -8735,7 +9037,7 @@ index ae15ff0e12ca..4ee782cbb1e4 100644
      ClearPrevalentResource(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> () Async
      ClearUserInteraction(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> () Async
 diff --git a/Source/WebKit/NetworkProcess/NetworkSession.h b/Source/WebKit/NetworkProcess/NetworkSession.h
-index 7fa92744f215..4208e0e69d15 100644
+index 7fa92744f2152dc363015b8ac2d82650435dcb24..4208e0e69d15886843517d795a366d798b666d5a 100644
 --- a/Source/WebKit/NetworkProcess/NetworkSession.h
 +++ b/Source/WebKit/NetworkProcess/NetworkSession.h
 @@ -152,6 +152,9 @@ public:
@@ -8757,7 +9059,7 @@ index 7fa92744f215..4208e0e69d15 100644
      HashSet<Ref<NetworkResourceLoader>> m_keptAliveLoads;
  
 diff --git a/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp b/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp
-index 52eb5b08f16c..1f541ccfbe18 100644
+index 52eb5b08f16cba232149028cdaa8150ad04e4a9f..1f541ccfbe183ee152cea69108b80ffd3b1ff34f 100644
 --- a/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp
 @@ -43,7 +43,7 @@ Ref<NetworkSocketStream> NetworkSocketStream::create(NetworkProcess& networkProc
@@ -8770,7 +9072,7 @@ index 52eb5b08f16c..1f541ccfbe18 100644
  {
  }
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp
-index 60153bf7d6b0..5c0907b31551 100644
+index 60153bf7d6b07f58e0ea1595a14fc8c81353c149..5c0907b31551b576aeed1e9d26f4f5bcce055ec2 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp
 @@ -29,6 +29,7 @@
@@ -8794,7 +9096,7 @@ index 60153bf7d6b0..5c0907b31551 100644
 +
  } // namespace WebKit
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h
-index adca9f4a255f..81f6c0bde82e 100644
+index adca9f4a255f58e2106dd6a4eceaddfff2451ac3..81f6c0bde82ea58ed5abc5e3653bb64a3377f531 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h
 @@ -28,7 +28,7 @@
@@ -8816,7 +9118,7 @@ index adca9f4a255f..81f6c0bde82e 100644
      StorageManager& m_storageManager;
      unsigned m_quotaInBytes { 0 };
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp
-index 83194b05fb4e..9c9357eb7466 100644
+index 83194b05fb4ee11777ddf10aed278f60c0b9982c..9c9357eb7466b82379f394aee3ff383784483ee1 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp
 @@ -111,6 +111,18 @@ void StorageArea::setItem(IPC::Connection::UniqueID sourceConnection, StorageAre
@@ -8839,7 +9141,7 @@ index 83194b05fb4e..9c9357eb7466 100644
  {
      ASSERT(!RunLoop::isMain());
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h
-index 9c715702dbe6..9174bb3f38b6 100644
+index 9c715702dbe69b7f33c7c31be45779b32ea96a34..9174bb3f38b63d431fe2a8932d2646dea1c682ff 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h
 @@ -64,6 +64,7 @@ public:
@@ -8851,7 +9153,7 @@ index 9c715702dbe6..9174bb3f38b6 100644
      void clear();
  
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
-index 5bcca299ba41..a7526a2adbd9 100644
+index 5bcca299ba415e39c02845997e5806b2846da93c..a7526a2adbd93ecb3e16a9b8b8f754152c79f2d4 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
 @@ -147,6 +147,19 @@ HashSet<SecurityOriginData> StorageManager::getLocalStorageOriginsCrossThreadCop
@@ -8875,7 +9177,7 @@ index 5bcca299ba41..a7526a2adbd9 100644
  {
      ASSERT(!RunLoop::isMain());
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
-index 0d6e7aedff68..67b616d818aa 100644
+index 0d6e7aedff68227bf7dc8ab7184abc6fd3321c54..67b616d818aa42f8cae33f0535c888cd4c5ec07e 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
 @@ -66,6 +66,7 @@ public:
@@ -8887,7 +9189,7 @@ index 0d6e7aedff68..67b616d818aa 100644
      void deleteLocalStorageEntriesForOrigins(const Vector<WebCore::SecurityOriginData>&);
      Vector<LocalStorageDatabaseTracker::OriginDetails> getLocalStorageOriginDetailsCrossThreadCopy() const;
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
-index 61d0b3c77ce5..0ddfcc2014f3 100644
+index 61d0b3c77ce5c8dcd741c7d04ad4145f6b47f66e..0ddfcc2014f3edc9a593de8fd87c9423940a7ee6 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
 @@ -262,6 +262,50 @@ void StorageManagerSet::getLocalStorageOrigins(PAL::SessionID sessionID, GetOrig
@@ -8942,7 +9244,7 @@ index 61d0b3c77ce5..0ddfcc2014f3 100644
  {
      ASSERT(RunLoop::isMain());
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
-index 4243f32573bd..023416d6e453 100644
+index 4243f32573bdad1452107f55c82328961cd5b0d4..023416d6e453431167441504ea38b3b2f19330fd 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
 @@ -45,6 +45,7 @@ using ConnectToStorageAreaCallback = CompletionHandler<void(const std::optional<
@@ -8963,7 +9265,7 @@ index 4243f32573bd..023416d6e453 100644
  
      void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
-index 4ebbd90cc645..3d5d56a5a1b4 100644
+index 4ebbd90cc645df5f9ddbb860d08aa3eb053c2ff6..3d5d56a5a1b407f27e533c9c71d3e4c4fb012c36 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
 @@ -86,6 +86,8 @@ public:
@@ -8976,7 +9278,7 @@ index 4ebbd90cc645..3d5d56a5a1b4 100644
      NetworkDataTaskCocoa(NetworkSession&, NetworkDataTaskClient&, const NetworkLoadParameters&);
  
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
-index 340d7dac286b..0dfa57520b46 100644
+index 340d7dac286b73b83c51ebd0f680fc4abf9daf95..0dfa57520b46eecccf1156d285778086ff3fee0f 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
 @@ -42,6 +42,7 @@
@@ -9048,7 +9350,7 @@ index 340d7dac286b..0dfa57520b46 100644
 +
  }
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-index f77ce79491ae..366dd8851191 100644
+index f77ce79491ae0eaa311563d81a7bd0a3f464ea5c..366dd8851191c7a5cf3dd99240d96cd7c9108132 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 @@ -681,7 +681,7 @@ static inline void processServerTrustEvaluation(NetworkSessionCocoa& session, Se
@@ -9075,7 +9377,7 @@ index f77ce79491ae..366dd8851191 100644
  #if !LOG_DISABLED
              LOG(NetworkSession, "%llu didReceiveResponse completionHandler (%d)", taskIdentifier, policyAction);
 diff --git a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
-index e9f9b2c25786..c45d2f047614 100644
+index e9f9b2c257866d9300e79781cbef3addc59cd9de..c45d2f047614da8a5e360b88960fbd2afb16072f 100644
 --- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
 +++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
 @@ -26,9 +26,13 @@
@@ -9211,7 +9513,7 @@ index e9f9b2c25786..c45d2f047614 100644
  
          if (m_state != State::Suspended) {
 diff --git a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
-index 1c427ddb78d6..cf33ff6076dd 100644
+index 1c427ddb78d6953fe8960c5692afde4f4f0eee85..cf33ff6076dd95ffe564f1dde89c177acd27b02c 100644
 --- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
 +++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
 @@ -32,6 +32,7 @@
@@ -9248,7 +9550,7 @@ index 1c427ddb78d6..cf33ff6076dd 100644
  
      WebCore::ShouldRelaxThirdPartyCookieBlocking m_shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
 diff --git a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
-index 3a71cdccc686..05cb24fc79d5 100644
+index 3a71cdccc68610042daf087d881c349ac3e077ce..05cb24fc79d5526dd6cfed196e9b796bc19d19ef 100644
 --- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 +++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 @@ -483,6 +483,7 @@ void NetworkDataTaskSoup::didSendRequest(GRefPtr<GInputStream>&& inputStream)
@@ -9269,7 +9571,7 @@ index 3a71cdccc686..05cb24fc79d5 100644
      if (!error)
          return true;
 diff --git a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
-index 06ca252b0439..597e63aca71d 100644
+index 06ca252b043959d457814d45886949a85b1a19c1..597e63aca71d213526d953ead357fbc0e0405f8d 100644
 --- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
 +++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
 @@ -113,6 +113,11 @@ static gboolean webSocketAcceptCertificateCallback(GTlsConnection* connection, G
@@ -9330,7 +9632,7 @@ index 06ca252b0439..597e63aca71d 100644
      }
      return makeUnique<WebSocketTask>(channel, request, soupSession(), soupMessage.get(), protocol);
 diff --git a/Source/WebKit/PlatformGTK.cmake b/Source/WebKit/PlatformGTK.cmake
-index d679785ca3bd..14de9b9f902d 100644
+index d679785ca3bd58b2ed2ce08765eb55701bf5e723..14de9b9f902d7d131f44d0aedcf7ed751e55e7ca 100644
 --- a/Source/WebKit/PlatformGTK.cmake
 +++ b/Source/WebKit/PlatformGTK.cmake
 @@ -450,6 +450,9 @@ list(APPEND WebKit_SYSTEM_INCLUDE_DIRECTORIES
@@ -9367,7 +9669,7 @@ index d679785ca3bd..14de9b9f902d 100644
  set(WebKit2GTK_ENUM_GENERATION_HEADERS ${WebKit2GTK_INSTALLED_HEADERS})
  list(REMOVE_ITEM WebKit2GTK_ENUM_GENERATION_HEADERS ${WebKit2Gtk_DERIVED_SOURCES_DIR}/webkit2/WebKitEnumTypes.h)
 diff --git a/Source/WebKit/PlatformWPE.cmake b/Source/WebKit/PlatformWPE.cmake
-index e397c07b7cf7..ba2270f561b9 100644
+index e397c07b7cf7170f4d833997d499b4ac7ffcd898..ba2270f561b90cc54682b77c02c9028552e951fa 100644
 --- a/Source/WebKit/PlatformWPE.cmake
 +++ b/Source/WebKit/PlatformWPE.cmake
 @@ -278,6 +278,7 @@ list(APPEND WebKit_INCLUDE_DIRECTORIES
@@ -9397,7 +9699,7 @@ index e397c07b7cf7..ba2270f561b9 100644
      Cairo::Cairo
      Freetype::Freetype
 diff --git a/Source/WebKit/PlatformWin.cmake b/Source/WebKit/PlatformWin.cmake
-index 01565d550697..98fb300309de 100644
+index 01565d550697b25367bb36971d6fe5ec33f712f0..98fb300309de1c0567912158f23ab39e7c0e21d5 100644
 --- a/Source/WebKit/PlatformWin.cmake
 +++ b/Source/WebKit/PlatformWin.cmake
 @@ -69,8 +69,12 @@ list(APPEND WebKit_SOURCES
@@ -9503,7 +9805,7 @@ index 01565d550697..98fb300309de 100644
  endif ()
  
 diff --git a/Source/WebKit/Shared/API/c/wpe/WebKit.h b/Source/WebKit/Shared/API/c/wpe/WebKit.h
-index caf67e1dece5..740150d2589d 100644
+index caf67e1dece5b727e43eba780e70814f8fdb0f63..740150d2589d6e16a516daa3bf6ef899ac538c99 100644
 --- a/Source/WebKit/Shared/API/c/wpe/WebKit.h
 +++ b/Source/WebKit/Shared/API/c/wpe/WebKit.h
 @@ -77,6 +77,7 @@
@@ -9515,7 +9817,7 @@ index caf67e1dece5..740150d2589d 100644
  #include <WebKit/WKContextConfigurationRef.h>
  #include <WebKit/WKCredential.h>
 diff --git a/Source/WebKit/Shared/NativeWebKeyboardEvent.h b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
-index ee8cac1c9800..deae2be9e720 100644
+index ee8cac1c980039c4a36de5501ab7f135e710d06b..deae2be9e720ff76186ecea89920dfc39c4f186a 100644
 --- a/Source/WebKit/Shared/NativeWebKeyboardEvent.h
 +++ b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
 @@ -33,6 +33,7 @@
@@ -9563,7 +9865,7 @@ index ee8cac1c9800..deae2be9e720 100644
  
  #if USE(APPKIT)
 diff --git a/Source/WebKit/Shared/NativeWebMouseEvent.h b/Source/WebKit/Shared/NativeWebMouseEvent.h
-index 001558dd58f4..1e0898f985f1 100644
+index 001558dd58f4d85f360d5711caa03db33889011e..1e0898f985f1d13036d31e3e284258a3c64fa0a4 100644
 --- a/Source/WebKit/Shared/NativeWebMouseEvent.h
 +++ b/Source/WebKit/Shared/NativeWebMouseEvent.h
 @@ -77,6 +77,11 @@ public:
@@ -9579,7 +9881,7 @@ index 001558dd58f4..1e0898f985f1 100644
      NSEvent* nativeEvent() const { return m_nativeEvent.get(); }
  #elif PLATFORM(GTK)
 diff --git a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
-index 91d21d8f236b..6c4caa100f78 100644
+index 91d21d8f236bd18832b50d2cad311cc6f2488cee..6c4caa100f785aa896569f24539467693295746c 100644
 --- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 +++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 @@ -120,6 +120,10 @@
@@ -9671,7 +9973,7 @@ index 91d21d8f236b..6c4caa100f78 100644
      return true;
  }
 diff --git a/Source/WebKit/Shared/WebEvent.h b/Source/WebKit/Shared/WebEvent.h
-index 3ae6504779d3..72d44c33953c 100644
+index 3ae6504779d3917a79f69f32b58260afeda270b4..72d44c33953cc13bf2ed7c762b4f9a7b88571b56 100644
 --- a/Source/WebKit/Shared/WebEvent.h
 +++ b/Source/WebKit/Shared/WebEvent.h
 @@ -31,6 +31,7 @@
@@ -9683,7 +9985,7 @@ index 3ae6504779d3..72d44c33953c 100644
  #include <wtf/text/WTFString.h>
  
 diff --git a/Source/WebKit/Shared/WebKeyboardEvent.cpp b/Source/WebKit/Shared/WebKeyboardEvent.cpp
-index a70eb76c5c22..f97fa9dec785 100644
+index a70eb76c5c22a2c779c30874433ac19036b5f1a4..f97fa9dec785fd6327bb7847454e8a32b8a0d3ac 100644
 --- a/Source/WebKit/Shared/WebKeyboardEvent.cpp
 +++ b/Source/WebKit/Shared/WebKeyboardEvent.cpp
 @@ -35,6 +35,7 @@ WebKeyboardEvent::WebKeyboardEvent()
@@ -9773,7 +10075,7 @@ index a70eb76c5c22..f97fa9dec785 100644
  {
  }
 diff --git a/Source/WebKit/Shared/WebKeyboardEvent.h b/Source/WebKit/Shared/WebKeyboardEvent.h
-index 7a5893eb68ad..a2d68a5eb59d 100644
+index 7a5893eb68ad24cf92c832070485489b7cfafa0c..a2d68a5eb59d8b7155c1e17b75a12e55f299b868 100644
 --- a/Source/WebKit/Shared/WebKeyboardEvent.h
 +++ b/Source/WebKit/Shared/WebKeyboardEvent.h
 @@ -43,14 +43,18 @@ public:
@@ -9796,7 +10098,7 @@ index 7a5893eb68ad..a2d68a5eb59d 100644
  
      const String& text() const { return m_text; }
 diff --git a/Source/WebKit/Shared/WebPageCreationParameters.cpp b/Source/WebKit/Shared/WebPageCreationParameters.cpp
-index 9e7b7f2fbda1..e0952a57de56 100644
+index 9e7b7f2fbda107d1cd900248a5d9b6ac6ba729d6..e0952a57de56fd65b343d5cf6bd8e92730d0fd56 100644
 --- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
 +++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
 @@ -156,6 +156,8 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
@@ -9821,7 +10123,7 @@ index 9e7b7f2fbda1..e0952a57de56 100644
          return std::nullopt;
  
 diff --git a/Source/WebKit/Shared/WebPageCreationParameters.h b/Source/WebKit/Shared/WebPageCreationParameters.h
-index d5b13d2b0915..df80ba50ff7e 100644
+index d5b13d2b0915b48ece9bf6de96e87ba59094efe5..df80ba50ff7e319ef00e2812c3a62c6d4add8f8d 100644
 --- a/Source/WebKit/Shared/WebPageCreationParameters.h
 +++ b/Source/WebKit/Shared/WebPageCreationParameters.h
 @@ -246,6 +246,8 @@ struct WebPageCreationParameters {
@@ -9834,7 +10136,7 @@ index d5b13d2b0915..df80ba50ff7e 100644
      String themeName;
  #endif
 diff --git a/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp b/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp
-index c204637774ee..345f5b08179e 100644
+index c204637774ee803eac42a34cde79aa556f143b82..345f5b08179e3dd239725bed06e48b46bc718336 100644
 --- a/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp
 +++ b/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp
 @@ -50,7 +50,7 @@ NativeWebKeyboardEvent::NativeWebKeyboardEvent(Type type, const String& text, co
@@ -9847,7 +10149,7 @@ index c204637774ee..345f5b08179e 100644
  {
  }
 diff --git a/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp b/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
-index 7cc65739c320..da53885517d5 100644
+index 7cc65739c320cb4312d9d705284220a383a0293a..da53885517d55d424423ee3d0dcead25825cc022 100644
 --- a/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
 +++ b/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
 @@ -54,7 +54,7 @@ NativeWebMouseEvent::NativeWebMouseEvent(Type type, Button button, unsigned shor
@@ -9860,7 +10162,7 @@ index 7cc65739c320..da53885517d5 100644
  {
  }
 diff --git a/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp b/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp
-index 03e118154f6b..9725caaac6ee 100644
+index 03e118154f6bb5b704b4ecb83d3d9543f8c5a5fa..9725caaac6ee65a96ea324ddbb4e1a3785bbc028 100644
 --- a/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp
 +++ b/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp
 @@ -26,7 +26,7 @@
@@ -9879,7 +10181,7 @@ index 03e118154f6b..9725caaac6ee 100644
 -#endif // ENABLE(TOUCH_EVENTS)
 +#endif // ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp b/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp
-index e40a6e172bfd..2516655bbc9e 100644
+index e40a6e172bfd2b75076fd4053da643ebab9eb81f..2516655bbc9e5bc863537a554c5faac0f6fc1a09 100644
 --- a/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp
 +++ b/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp
 @@ -26,7 +26,7 @@
@@ -9899,7 +10201,7 @@ index e40a6e172bfd..2516655bbc9e 100644
 +#endif // ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.cpp b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.cpp
 new file mode 100644
-index 000000000000..678010b33d70
+index 0000000000000000000000000000000000000000..678010b33d70dae6369ace4337b4c0eb81152250
 --- /dev/null
 +++ b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.cpp
 @@ -0,0 +1,173 @@
@@ -10078,7 +10380,7 @@ index 000000000000..678010b33d70
 +}
 diff --git a/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.h b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.h
 new file mode 100644
-index 000000000000..789a0d7cf697
+index 0000000000000000000000000000000000000000..789a0d7cf69704c8f665a9ed79348fbcbc1301c4
 --- /dev/null
 +++ b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.h
 @@ -0,0 +1,41 @@
@@ -10124,7 +10426,7 @@ index 000000000000..789a0d7cf697
 +
 +} // namespace IPC
 diff --git a/Source/WebKit/Shared/win/WebEventFactory.cpp b/Source/WebKit/Shared/win/WebEventFactory.cpp
-index 85d6f74114f4..6896c9756edb 100644
+index 85d6f74114f4e7f82d9502d1b99d69098d6a49b6..6896c9756edb233dda46c7031e1af69923da8c23 100644
 --- a/Source/WebKit/Shared/win/WebEventFactory.cpp
 +++ b/Source/WebKit/Shared/win/WebEventFactory.cpp
 @@ -473,7 +473,7 @@ WebKeyboardEvent WebEventFactory::createWebKeyboardEvent(HWND hwnd, UINT message
@@ -10137,7 +10439,7 @@ index 85d6f74114f4..6896c9756edb 100644
      return WebTouchEvent();
  }
 diff --git a/Source/WebKit/Sources.txt b/Source/WebKit/Sources.txt
-index 92e147b8f3b0..09d4f0d322d8 100644
+index 92e147b8f3b04a7cce76ade81b8566fa947fa4e8..09d4f0d322d8779e6982170a712f934c87d8e0d5 100644
 --- a/Source/WebKit/Sources.txt
 +++ b/Source/WebKit/Sources.txt
 @@ -291,11 +291,14 @@ Shared/WebsiteData/WebsiteData.cpp
@@ -10185,7 +10487,7 @@ index 92e147b8f3b0..09d4f0d322d8 100644
  UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
  UIProcess/Media/MediaUsageManager.cpp
 diff --git a/Source/WebKit/SourcesCocoa.txt b/Source/WebKit/SourcesCocoa.txt
-index 67f325597989..26cb20a052de 100644
+index 67f325597989607545fbb688e2d279e08842646e..26cb20a052de06e878f795b02ec797e1873eb728 100644
 --- a/Source/WebKit/SourcesCocoa.txt
 +++ b/Source/WebKit/SourcesCocoa.txt
 @@ -267,6 +267,7 @@ UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -10205,7 +10507,7 @@ index 67f325597989..26cb20a052de 100644
  UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
  UIProcess/Inspector/mac/WKInspectorViewController.mm
 diff --git a/Source/WebKit/SourcesGTK.txt b/Source/WebKit/SourcesGTK.txt
-index a4391be7b637..3f7d5e6c9deb 100644
+index a4391be7b637fd96d880cb06838b6deb5db552b6..3f7d5e6c9debc1cf1155da11bad14fc5c3b01dc8 100644
 --- a/Source/WebKit/SourcesGTK.txt
 +++ b/Source/WebKit/SourcesGTK.txt
 @@ -125,6 +125,7 @@ UIProcess/API/glib/WebKitAuthenticationRequest.cpp @no-unify
@@ -10242,7 +10544,7 @@ index a4391be7b637..3f7d5e6c9deb 100644
  UIProcess/gtk/WebPasteboardProxyGtk.cpp
  UIProcess/gtk/WebPopupMenuProxyGtk.cpp
 diff --git a/Source/WebKit/SourcesWPE.txt b/Source/WebKit/SourcesWPE.txt
-index 0775acec279c..8dd0f26df697 100644
+index 0775acec279c873b2fd81c02c2962763ff497db5..8dd0f26df6972bd3f3cdc6e4bcc90cd9ffbafc2c 100644
 --- a/Source/WebKit/SourcesWPE.txt
 +++ b/Source/WebKit/SourcesWPE.txt
 @@ -86,6 +86,7 @@ Shared/glib/ProcessExecutablePathGLib.cpp
@@ -10290,7 +10592,7 @@ index 0775acec279c..8dd0f26df697 100644
  
  WebProcess/WebPage/AcceleratedSurface.cpp
 diff --git a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
-index d16ed7753fa5..60a3d2f1e9cb 100644
+index d16ed7753fa59fc87ea9402f5ff4872525ed32f6..60a3d2f1e9cbb415ce8196b6a780fb44e8d51e77 100644
 --- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
 +++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
 @@ -54,6 +54,9 @@ Ref<ProcessPoolConfiguration> ProcessPoolConfiguration::copy()
@@ -10304,7 +10606,7 @@ index d16ed7753fa5..60a3d2f1e9cb 100644
      copy->m_shouldTakeUIBackgroundAssertion = this->m_shouldTakeUIBackgroundAssertion;
      copy->m_shouldCaptureDisplayInUIProcess = this->m_shouldCaptureDisplayInUIProcess;
 diff --git a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
-index 9fb2d63f614e..0dbfc99449f3 100644
+index 9fb2d63f614e1ed79da3fba1826e89fc5bd737b4..0dbfc99449f353cf803d7517dcce867fe3adf646 100644
 --- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
 +++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
 @@ -101,6 +101,11 @@ public:
@@ -10330,7 +10632,7 @@ index 9fb2d63f614e..0dbfc99449f3 100644
      bool m_shouldTakeUIBackgroundAssertion { true };
      bool m_shouldCaptureDisplayInUIProcess { DEFAULT_CAPTURE_DISPLAY_IN_UI_PROCESS };
 diff --git a/Source/WebKit/UIProcess/API/APIUIClient.h b/Source/WebKit/UIProcess/API/APIUIClient.h
-index 2175c518821e..a2489687cc2e 100644
+index 2175c518821effff060578c418e224817610d644..a2489687cc2efd5a59fc987a350a618c662c3734 100644
 --- a/Source/WebKit/UIProcess/API/APIUIClient.h
 +++ b/Source/WebKit/UIProcess/API/APIUIClient.h
 @@ -93,6 +93,7 @@ public:
@@ -10342,7 +10644,7 @@ index 2175c518821e..a2489687cc2e 100644
      virtual void setStatusText(WebKit::WebPageProxy*, const WTF::String&) { }
      virtual void mouseDidMoveOverElement(WebKit::WebPageProxy&, const WebKit::WebHitTestResultData&, OptionSet<WebKit::WebEvent::Modifier>, Object*) { }
 diff --git a/Source/WebKit/UIProcess/API/C/WKInspector.cpp b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
-index e1465edd29ca..32d569d3240c 100644
+index e1465edd29caf3109c17d44bb3c88aaba98cfbb5..32d569d3240c583334b8b6512407430fd448ae75 100644
 --- a/Source/WebKit/UIProcess/API/C/WKInspector.cpp
 +++ b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
 @@ -28,6 +28,11 @@
@@ -10370,7 +10672,7 @@ index e1465edd29ca..32d569d3240c 100644
 +
  #endif // !PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebKit/UIProcess/API/C/WKInspector.h b/Source/WebKit/UIProcess/API/C/WKInspector.h
-index 026121d114c5..edd6e5cae033 100644
+index 026121d114c5fcad84c1396be8d692625beaa3bd..edd6e5cae033124c589959a42522fde07a42fdf6 100644
 --- a/Source/WebKit/UIProcess/API/C/WKInspector.h
 +++ b/Source/WebKit/UIProcess/API/C/WKInspector.h
 @@ -66,6 +66,10 @@ WK_EXPORT void WKInspectorTogglePageProfiling(WKInspectorRef inspector);
@@ -10385,7 +10687,7 @@ index 026121d114c5..edd6e5cae033 100644
  }
  #endif
 diff --git a/Source/WebKit/UIProcess/API/C/WKPage.cpp b/Source/WebKit/UIProcess/API/C/WKPage.cpp
-index 702efb299a41..657d69666f19 100644
+index 702efb299a41b013c856905e9e6b80262770afe1..657d69666f19aef2ac262408fa61283173994027 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
 +++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
 @@ -1778,6 +1778,13 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
@@ -10412,7 +10714,7 @@ index 702efb299a41..657d69666f19 100644
          }
  
 diff --git a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
-index ed980be17cdf..ca3c0ff1ec6d 100644
+index ed980be17cdf9faec3f7af1bdc7cfd640bab8fc2..ca3c0ff1ec6d30173ae15e786f30ef1bad0e5bb6 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
 +++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
 @@ -90,6 +90,7 @@ typedef void (*WKPageRunBeforeUnloadConfirmPanelCallback)(WKPageRef page, WKStri
@@ -10448,7 +10750,7 @@ index ed980be17cdf..ca3c0ff1ec6d 100644
      // Version 15.
      WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
-index 198068cf35f6..985b67a387b7 100644
+index 198068cf35f63bf0f7ea16526aba65ef5b61bf20..985b67a387b74029542f8d7b141150d9921bf423 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
 @@ -135,6 +135,12 @@ typedef NS_ENUM(NSInteger, WKMediaCaptureType) {
@@ -10465,7 +10767,7 @@ index 198068cf35f6..985b67a387b7 100644
  /*! @abstract A delegate to request permission for microphone audio and camera video access.
   @param webView The web view invoking the delegate method.
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
-index afa925f36c29..42d396342acd 100644
+index afa925f36c29db9c23921298dead9cce737500d6..42d396342acdb6d39830f611df0ee40ea6ec879e 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
 @@ -24,7 +24,6 @@
@@ -10486,7 +10788,7 @@ index afa925f36c29..42d396342acd 100644
  
  NS_ASSUME_NONNULL_END
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
-index 672b2053442e..3d49ea06d6cd 100644
+index 672b2053442e7e834aa453c40d32c9d90701e103..3d49ea06d6cda6c274ef9c59c003a1275e916810 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 @@ -42,6 +42,7 @@
@@ -10511,7 +10813,7 @@ index 672b2053442e..3d49ea06d6cd 100644
      Vector<WebKit::WebsiteDataRecord> result;
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.h b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.h
 new file mode 100644
-index 000000000000..5fabe06a3289
+index 0000000000000000000000000000000000000000..5fabe06a3289689246c36dfd96eb9900a48b2b0f
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.h
 @@ -0,0 +1,55 @@
@@ -10572,7 +10874,7 @@ index 000000000000..5fabe06a3289
 +
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.mm
 new file mode 100644
-index 000000000000..e7143513ea2b
+index 0000000000000000000000000000000000000000..e7143513ea2be8e1cdab5c86a28643fffea626dd
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.mm
 @@ -0,0 +1,60 @@
@@ -10637,7 +10939,7 @@ index 000000000000..e7143513ea2b
 +}
 +@end
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
-index 0b32900879f7..d3bac7b11303 100644
+index 0b32900879f73b9776f1bfbb6aec73c0553f7ac0..d3bac7b1130311c1094401b57c28b8f617d153aa 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
 @@ -32,6 +32,7 @@
@@ -10649,7 +10951,7 @@ index 0b32900879f7..d3bac7b11303 100644
  
  ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h b/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h
-index ca94c2173757..422c1379da9b 100644
+index ca94c2173757a54a0c755cbf30f8e05a0b75c9cb..422c1379da9b091ae5903a42bc7625be78030016 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h
 @@ -24,6 +24,7 @@
@@ -10661,7 +10963,7 @@ index ca94c2173757..422c1379da9b 100644
  #import <wtf/RetainPtr.h>
  
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
-index 46561d34314a..c84cbe9adc52 100644
+index 46561d34314a79d42c57e59bf7927ad1fa451045..c84cbe9adc5236ad64240a18f5ff9a7215ba2ba2 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
 @@ -24,7 +24,10 @@
@@ -10676,7 +10978,7 @@ index 46561d34314a..c84cbe9adc52 100644
  #if ENABLE(INSPECTOR_EXTENSIONS)
  
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
-index d4b65177f9fe..875a3e26f359 100644
+index d4b65177f9fe593510bea64832d4255693be54b3..875a3e26f359023b0d1896e6544e6dd6488d98b7 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
 @@ -65,6 +65,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
@@ -10688,7 +10990,7 @@ index d4b65177f9fe..875a3e26f359 100644
  @property (nonatomic) BOOL processSwapsOnWindowOpenWithOpener WK_API_AVAILABLE(macos(10.14), ios(12.0));
  @property (nonatomic) BOOL prewarmsProcessesAutomatically WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
-index 93d0b1ed806e..0cf8411ceb0f 100644
+index 93d0b1ed806ee698bdf51a7022b0cb5eabbaa943..0cf8411ceb0f24ca58140541d1f10925a926fc8e 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 @@ -245,6 +245,16 @@
@@ -10709,7 +11011,7 @@ index 93d0b1ed806e..0cf8411ceb0f 100644
  {
      _processPoolConfiguration->setIsAutomaticProcessWarmingEnabled(prewarms);
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
-index c130399cf9f3..3c10bb7e9dc8 100644
+index c130399cf9f3063f5a2dcc392e19eefd763c153a..3c10bb7e9dc8d9834b90a8d8faaac361f1268504 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 @@ -24,6 +24,7 @@
@@ -10721,7 +11023,7 @@ index c130399cf9f3..3c10bb7e9dc8 100644
  
  #if PLATFORM(MAC)
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h
-index 4974e14214e2..cacdf8c71fab 100644
+index 4974e14214e2bb3e982325b885bab33e54f83998..cacdf8c71fab248d38d2faf03f7affdcfed1ef62 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h
 @@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
@@ -10733,7 +11035,7 @@ index 4974e14214e2..cacdf8c71fab 100644
  typedef NS_ENUM(NSInteger, _WKUserStyleLevel) {
      _WKUserStyleUserLevel,
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
-index 1e827013c603..2075bc78069b 100644
+index 1e827013c603ae8bd43d798170deb98fc3153852..2075bc78069bde530ec237c0b761773c10013948 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 @@ -35,6 +35,7 @@
@@ -10746,7 +11048,7 @@ index 1e827013c603..2075bc78069b 100644
  @implementation _WKUserStyleSheet
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspector.cpp b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspector.cpp
 new file mode 100644
-index 000000000000..54529a23f53c
+index 0000000000000000000000000000000000000000..54529a23f53cebe6f8a96873ca6c2f31f0481ae0
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspector.cpp
 @@ -0,0 +1,158 @@
@@ -10910,7 +11212,7 @@ index 000000000000..54529a23f53c
 +}
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspectorPrivate.h b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspectorPrivate.h
 new file mode 100644
-index 000000000000..e0b1da48465c
+index 0000000000000000000000000000000000000000..e0b1da48465c850f541532ed961d1b778bea6028
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspectorPrivate.h
 @@ -0,0 +1,32 @@
@@ -10947,7 +11249,7 @@ index 000000000000..e0b1da48465c
 +WebKit::WebPageProxy* webkitBrowserInspectorCreateNewPageInContext(WebKitWebContext*);
 +void webkitBrowserInspectorQuitApplication();
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
-index 0afd97be464c..0826356fe6d3 100644
+index 0afd97be464ceb609f1c43aa720f3b4c297778bd..0826356fe6d35615e9b2c84647dfe3dadab73eb1 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
 @@ -98,6 +98,10 @@ private:
@@ -10962,7 +11264,7 @@ index 0afd97be464c..0826356fe6d3 100644
      bool canRunBeforeUnloadConfirmPanel() const final { return true; }
  
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
-index 6dd9f20e4ff2..7a5f57daa838 100644
+index 6dd9f20e4ff2bda0184d0645301cef22e47dcf15..7a5f57daa83818b2dfb4bcbcbf5c18c8621a6b25 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
 @@ -118,8 +118,8 @@ enum {
@@ -11077,7 +11379,7 @@ index 6dd9f20e4ff2..7a5f57daa838 100644
      /**
       * WebKitWebContext:use-system-appearance-for-scrollbars:
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h b/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
-index 78d1578f9479..493cdadac387 100644
+index 78d1578f94793e9e59a3d4d2b33e79ea8530fa04..493cdadac3873508b3efa3048638e73a13f4c976 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
 @@ -45,3 +45,4 @@ void webkitWebContextInitializeNotificationPermissions(WebKitWebContext*);
@@ -11086,7 +11388,7 @@ index 78d1578f9479..493cdadac387 100644
  #endif
 +int webkitWebContextExistingCount();
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
-index a6859136ae70..6a5e4f7afd14 100644
+index a6859136ae70d6589916c4dc519aca0f213d711a..6a5e4f7afd148e8ed87a0b950b2891af9886b9b5 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 @@ -32,6 +32,7 @@
@@ -11164,7 +11466,7 @@ index a6859136ae70..6a5e4f7afd14 100644
  {
      if (!webView->priv->currentScriptDialog)
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
-index d7a43204be69..0e247c488585 100644
+index d7a43204be693f2a7ef86240eaf567fe70052a2c..0e247c48858522e55f65957fd0d1e147cafce092 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
 @@ -60,6 +60,7 @@ void webkitWebViewRunJavaScriptAlert(WebKitWebView*, const CString& message, Fun
@@ -11176,7 +11478,7 @@ index d7a43204be69..0e247c488585 100644
  bool webkitWebViewIsScriptDialogRunning(WebKitWebView*, WebKitScriptDialog*);
  String webkitWebViewGetCurrentScriptDialogMessage(WebKitWebView*);
 diff --git a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
-index 2bf03eec17b9..9ca44d654605 100644
+index 2bf03eec17b9d2add76b180b6a2bc41d8fba9602..9ca44d65460528b9b8e6f3b91aff8f91e81a29dc 100644
 --- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
 +++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
 @@ -244,6 +244,8 @@ void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool
@@ -11190,7 +11492,7 @@ index 2bf03eec17b9..9ca44d654605 100644
      webkitWebViewBaseForwardNextKeyEvent(webkitWebViewBase);
 diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitBrowserInspector.h b/Source/WebKit/UIProcess/API/gtk/WebKitBrowserInspector.h
 new file mode 100644
-index 000000000000..9f1a0173a564
+index 0000000000000000000000000000000000000000..9f1a0173a5641d6f158d815b8f7b9ea66f65c26d
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/gtk/WebKitBrowserInspector.h
 @@ -0,0 +1,81 @@
@@ -11276,7 +11578,7 @@ index 000000000000..9f1a0173a564
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
-index e9cf71352ba2..3daa3b84f5c8 100644
+index e9cf71352ba2d4bce1a23b0eefcf42cff26de393..3daa3b84f5c8f424b68bf1764ca8e0c74788d0b2 100644
 --- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
 +++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
 @@ -2462,6 +2462,11 @@ void webkitWebViewBaseResetClickCounter(WebKitWebViewBase* webkitWebViewBase)
@@ -11292,7 +11594,7 @@ index e9cf71352ba2..3daa3b84f5c8 100644
  {
      ASSERT(webkitWebViewBase->priv->acceleratedBackingStore);
 diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
-index d28f9c69cabe..ece01f3d3e2f 100644
+index d28f9c69cabe96554daddfec77e6f007aa0987da..ece01f3d3e2f6aaca191975048320b6a91b946ea 100644
 --- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
 +++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
 @@ -27,6 +27,7 @@
@@ -11310,7 +11612,7 @@ index d28f9c69cabe..ece01f3d3e2f 100644
 +
 +WebKit::AcceleratedBackingStore* webkitWebViewBaseGetAcceleratedBackingStore(WebKitWebViewBase*);
 diff --git a/Source/WebKit/UIProcess/API/gtk/webkit2.h b/Source/WebKit/UIProcess/API/gtk/webkit2.h
-index ecbe433ed888..7385877fe664 100644
+index ecbe433ed888353b1e6013943b4463835c3582d2..7385877fe664515814fc5c3380a2b7298ff90e1e 100644
 --- a/Source/WebKit/UIProcess/API/gtk/webkit2.h
 +++ b/Source/WebKit/UIProcess/API/gtk/webkit2.h
 @@ -32,6 +32,7 @@
@@ -11322,7 +11624,7 @@ index ecbe433ed888..7385877fe664 100644
  #include <webkit2/WebKitContextMenu.h>
  #include <webkit2/WebKitContextMenuActions.h>
 diff --git a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
-index 7dfe3ef401aa..1d27a04639e1 100644
+index 7dfe3ef401aa20d63377152c879fbd44d83d17fe..1d27a04639e1448c547b793f2b9de8e63d10e19c 100644
 --- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
 +++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
 @@ -194,7 +194,7 @@ WebCore::IntPoint PageClientImpl::accessibilityScreenToRootView(const WebCore::I
@@ -11336,7 +11638,7 @@ index 7dfe3ef401aa..1d27a04639e1 100644
  void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent&, bool)
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitBrowserInspector.h b/Source/WebKit/UIProcess/API/wpe/WebKitBrowserInspector.h
 new file mode 100644
-index 000000000000..cb1a540d341b
+index 0000000000000000000000000000000000000000..cb1a540d341b07581ec87b922b7d007ce45ba989
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitBrowserInspector.h
 @@ -0,0 +1,81 @@
@@ -11422,7 +11724,7 @@ index 000000000000..cb1a540d341b
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp
-index e0fc205b3909..872186ad99a7 100644
+index e0fc205b39095cf8aae201a1dcca520461c60de4..872186ad99a7b82f0c61705ff6c5ae4453e5e1d4 100644
 --- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp
 @@ -54,6 +54,7 @@ struct _WebKitWebViewBackend {
@@ -11454,7 +11756,7 @@ index e0fc205b3909..872186ad99a7 100644
  
  template <> WebKitWebViewBackend* refGPtr(WebKitWebViewBackend* ptr)
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h
-index 6663964d5aba..13ba5e7c3895 100644
+index 6663964d5abac79e123d90e0351590884c66aa72..13ba5e7c3895c6e4efda95f1f90b9baea1c1bf30 100644
 --- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h
 @@ -27,6 +27,7 @@
@@ -11479,7 +11781,7 @@ index 6663964d5aba..13ba5e7c3895 100644
  
  #endif /* WebKitWebViewBackend_h */
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h
-index e4b92ace1531..43690f9ef496 100644
+index e4b92ace1531090ae38a7aec3d3d4febf19aee84..43690f9ef4969a39084501613bfc00a77fd5df49 100644
 --- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h
 @@ -31,3 +31,5 @@ template <> void derefGPtr(WebKitWebViewBackend* ptr);
@@ -11489,7 +11791,7 @@ index e4b92ace1531..43690f9ef496 100644
 +
 +cairo_surface_t* webkitWebViewBackendTakeScreenshot(WebKitWebViewBackend*);
 diff --git a/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt b/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt
-index 8cf9d4ff3838..052e75a649f4 100644
+index 8cf9d4ff38382b3d348a732d69d00e7720576777..052e75a649f49ca8704d013a03299fd4aca68fa1 100644
 --- a/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt
 +++ b/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt
 @@ -320,6 +320,8 @@ WEBKIT_TYPE_WEB_VIEW_BACKEND
@@ -11502,7 +11804,7 @@ index 8cf9d4ff3838..052e75a649f4 100644
  <SUBSECTION Private>
  webkit_web_view_backend_get_type
 diff --git a/Source/WebKit/UIProcess/API/wpe/webkit.h b/Source/WebKit/UIProcess/API/wpe/webkit.h
-index 87929257bf73..5d47bce94b6d 100644
+index 87929257bf73aba684a380accd8c1bbb394bad87..5d47bce94b6d4b9e54fc1fef794bde7506310e32 100644
 --- a/Source/WebKit/UIProcess/API/wpe/webkit.h
 +++ b/Source/WebKit/UIProcess/API/wpe/webkit.h
 @@ -32,6 +32,7 @@
@@ -11514,7 +11816,7 @@ index 87929257bf73..5d47bce94b6d 100644
  #include <wpe/WebKitContextMenuActions.h>
  #include <wpe/WebKitContextMenuItem.h>
 diff --git a/Source/WebKit/UIProcess/BackingStore.h b/Source/WebKit/UIProcess/BackingStore.h
-index fe3c63e61f77..c43a8226c9be 100644
+index fe3c63e61f778762dc2c2080c74ec53fdf8c2e5f..c43a8226c9be702e248f1712e465efa396ee8969 100644
 --- a/Source/WebKit/UIProcess/BackingStore.h
 +++ b/Source/WebKit/UIProcess/BackingStore.h
 @@ -60,6 +60,7 @@ public:
@@ -11527,7 +11829,7 @@ index fe3c63e61f77..c43a8226c9be 100644
          ID3D11DeviceContext1* immediateContext { nullptr };
 diff --git a/Source/WebKit/UIProcess/BrowserInspectorPipe.cpp b/Source/WebKit/UIProcess/BrowserInspectorPipe.cpp
 new file mode 100644
-index 000000000000..cfb57a48ce38
+index 0000000000000000000000000000000000000000..cfb57a48ce387b79613b757e2eb4de2c378aac30
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/BrowserInspectorPipe.cpp
 @@ -0,0 +1,61 @@
@@ -11594,7 +11896,7 @@ index 000000000000..cfb57a48ce38
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/BrowserInspectorPipe.h b/Source/WebKit/UIProcess/BrowserInspectorPipe.h
 new file mode 100644
-index 000000000000..cd66887de171
+index 0000000000000000000000000000000000000000..cd66887de171cda7d15a8e4dc6dbff63665dc619
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/BrowserInspectorPipe.h
 @@ -0,0 +1,38 @@
@@ -11637,7 +11939,7 @@ index 000000000000..cd66887de171
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
-index 02dadcc4c813..5211c6b38efa 100644
+index 02dadcc4c813ad82c718f16a583616e03e35a195..5211c6b38efaf2a62eb556ec060cd9caa5e5d40e 100644
 --- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
 @@ -35,6 +35,7 @@
@@ -11649,7 +11951,7 @@ index 02dadcc4c813..5211c6b38efa 100644
  using namespace Inspector;
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
-index 454c61ffdefe..6de7509037b7 100644
+index 454c61ffdefecc476d1560c7c43f5b5d345f281d..6de7509037b7683ddd403ee247bdf2845ce4e87a 100644
 --- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
 +++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
 @@ -27,6 +27,8 @@
@@ -11671,7 +11973,7 @@ index 454c61ffdefe..6de7509037b7 100644
  class PopUpSOAuthorizationSession final : public SOAuthorizationSession {
  public:
 diff --git a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
-index 7871ed4738b5..04b55aa99531 100644
+index 7871ed4738b5cfc7e64757ff642cfbe51303a4eb..04b55aa995316d4d8cd467cf62d1a19f83ec8df7 100644
 --- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
 +++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
 @@ -92,6 +92,7 @@ private:
@@ -11691,7 +11993,7 @@ index 7871ed4738b5..04b55aa99531 100644
          bool webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler : 1;
          bool webViewRequestGeolocationPermissionForFrameDecisionHandler : 1;
 diff --git a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
-index ecf7213858b8..7d0fd38d5e29 100644
+index ecf7213858b8d7b3eb2a54f3b3a8c12eed4bdd85..7d0fd38d5e29a97945ff248be054036193b1ff51 100644
 --- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
 @@ -104,6 +104,7 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
@@ -11719,7 +12021,7 @@ index ecf7213858b8..7d0fd38d5e29 100644
  {
      if (!m_uiDelegate)
 diff --git a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
-index 7a18a6184a04..92bb58f42cf5 100644
+index 7a18a6184a04aa37bb6d328a817b0a0a3e03cb50..92bb58f42cf5ff592b6d465f16ffcf283f381462 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
 +++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
 @@ -27,6 +27,7 @@
@@ -11731,7 +12033,7 @@ index 7a18a6184a04..92bb58f42cf5 100644
  
  @class WKWebView;
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
-index 84b26a5f6c0d..f3e898a74db3 100644
+index 84b26a5f6c0d25c0c520c6767f5893b0b9dd869f..f3e898a74db3788ef51bf11228ebd584ab9986b1 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 @@ -34,6 +34,7 @@
@@ -11810,7 +12112,7 @@ index 84b26a5f6c0d..f3e898a74db3 100644
  #if PLATFORM(IOS_FAMILY)
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-index 1505b5583029..7127333640fa 100644
+index 1505b5583029c5dbdbe7172628c1a97dec170f44..7127333640fa5f0adf5236e388d636041f66e9b3 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
 @@ -398,7 +398,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
@@ -11834,7 +12136,7 @@ index 1505b5583029..7127333640fa 100644
  
      m_activationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidBecomeActiveNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
-index bbc683ac0715..4b74373d6780 100644
+index bbc683ac0715138a601f8d85796b901fdc170b2e..4b74373d67807eba427c91e66e3b8607654ff0c0 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
 @@ -512,6 +512,9 @@ public:
@@ -11848,7 +12150,7 @@ index bbc683ac0715..4b74373d6780 100644
      void saveBackForwardSnapshotForCurrentItem();
      void saveBackForwardSnapshotForItem(WebBackForwardListItem&);
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
-index 49e746ea4359..ea2e729874c0 100644
+index 49e746ea43599cd2a9eff27c197cec9091293470..ea2e729874c058a58bd6a3035d1013cc4db91349 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 @@ -2593,6 +2593,11 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
@@ -11883,7 +12185,7 @@ index 49e746ea4359..ea2e729874c0 100644
  {
      NSWindow *window = [m_view window];
 diff --git a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
-index 038d9ee2f41c..5be10b7bbdc8 100644
+index 038d9ee2f41cdeba4ae7b597311b663a58b6d629..5be10b7bbdc8b28db255baf7a4187cfd761fa83d 100644
 --- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 +++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 @@ -32,13 +32,16 @@
@@ -11987,7 +12289,7 @@ index 038d9ee2f41c..5be10b7bbdc8 100644
  void DrawingAreaProxyCoordinatedGraphics::incorporateUpdate(const UpdateInfo& updateInfo)
  {
 diff --git a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
-index b23a45ff7d31..8419b69c5e27 100644
+index b23a45ff7d313317d8ba64fb430ebba3b6adef71..8419b69c5e278cf88a3ab6b98c335eddeea44e53 100644
 --- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
 +++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
 @@ -30,6 +30,7 @@
@@ -12039,7 +12341,7 @@ index b23a45ff7d31..8419b69c5e27 100644
  
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
-index c61bb3fd2ee0..0fee368e9364 100644
+index c61bb3fd2ee046f3824c40ab99181c0fcee2a197..0fee368e936443cc15f02903f97fb6ad60f6091e 100644
 --- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
 +++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
 @@ -42,8 +42,10 @@
@@ -12113,7 +12415,7 @@ index c61bb3fd2ee0..0fee368e9364 100644
      // This can cause the DownloadProxy object to be deleted.
      m_downloadProxyMap.downloadFinished(*this);
 diff --git a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
-index 4b9e12c40517..f56879a5a799 100644
+index 4b9e12c40517fb84cb23d2de3e2adaa66c69da59..f56879a5a799115ef7353c060b00b842b8702408 100644
 --- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
 +++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
 @@ -146,6 +146,7 @@ private:
@@ -12125,7 +12427,7 @@ index 4b9e12c40517..f56879a5a799 100644
  
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/DrawingAreaProxy.h b/Source/WebKit/UIProcess/DrawingAreaProxy.h
-index 826c417c6c9b..641f418f78c5 100644
+index 826c417c6c9ba1c7e6c2c32a6ab0f3ab8d72f0e0..641f418f78c56aba25740586bb982231997b6bf5 100644
 --- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
 +++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
 @@ -75,6 +75,7 @@ public:
@@ -12147,7 +12449,7 @@ index 826c417c6c9b..641f418f78c5 100644
      bool m_startedReceivingMessages { false };
  };
 diff --git a/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in b/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
-index b0722e7da81e..05ec3e3ea97b 100644
+index b0722e7da81e56530deb570b82ed7cfece970362..05ec3e3ea97ba49135a27d7f9b91f14c507d9318 100644
 --- a/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
 +++ b/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
 @@ -36,4 +36,7 @@ messages -> DrawingAreaProxy NotRefCounted {
@@ -12160,7 +12462,7 @@ index b0722e7da81e..05ec3e3ea97b 100644
  }
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.cpp b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.cpp
 new file mode 100644
-index 000000000000..9426d9eed59f
+index 0000000000000000000000000000000000000000..9426d9eed59f433eac62b8eb6a16139b84079949
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.cpp
 @@ -0,0 +1,244 @@
@@ -12410,7 +12712,7 @@ index 000000000000..9426d9eed59f
 +#endif
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.h b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.h
 new file mode 100644
-index 000000000000..4ec8b96bbbdd
+index 0000000000000000000000000000000000000000..4ec8b96bbbddf8a7b042f53a8068754a384fc7ad
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.h
 @@ -0,0 +1,30 @@
@@ -12446,7 +12748,7 @@ index 000000000000..4ec8b96bbbdd
 +cairo_status_t cairo_image_surface_write_to_jpeg_mem(cairo_surface_t *sfc, unsigned char **data, size_t *len, int quality);
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.cpp b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.cpp
 new file mode 100644
-index 000000000000..20122bd89c3b
+index 0000000000000000000000000000000000000000..20122bd89c3ba0ec4ff878ac895bddd497cc9789
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.cpp
 @@ -0,0 +1,269 @@
@@ -12721,7 +13023,7 @@ index 000000000000..20122bd89c3b
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.h b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.h
 new file mode 100644
-index 000000000000..8f2795dbf132
+index 0000000000000000000000000000000000000000..8f2795dbf1323dd8d5f986f18e6fe16431dd7f70
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.h
 @@ -0,0 +1,96 @@
@@ -12823,7 +13125,7 @@ index 000000000000..8f2795dbf132
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp
 new file mode 100644
-index 000000000000..62f20814b72e
+index 0000000000000000000000000000000000000000..62f20814b72e90275eb4fa0e8302fc15abdaaab2
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp
 @@ -0,0 +1,393 @@
@@ -13222,7 +13524,7 @@ index 000000000000..62f20814b72e
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.h b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.h
 new file mode 100644
-index 000000000000..1683da93db6b
+index 0000000000000000000000000000000000000000..1683da93db6b9088c3a472472c1b71477b47a7fd
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.h
 @@ -0,0 +1,81 @@
@@ -13309,7 +13611,7 @@ index 000000000000..1683da93db6b
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.cpp b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.cpp
 new file mode 100644
-index 000000000000..9b269b356e20
+index 0000000000000000000000000000000000000000..9b269b356e206f0252245a1497adb0d05128c9b4
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.cpp
 @@ -0,0 +1,69 @@
@@ -13384,7 +13686,7 @@ index 000000000000..9b269b356e20
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.h b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.h
 new file mode 100644
-index 000000000000..e2ce910f3fd7
+index 0000000000000000000000000000000000000000..e2ce910f3fd7f587add552275b7e7176cf8b2723
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.h
 @@ -0,0 +1,53 @@
@@ -13442,7 +13744,7 @@ index 000000000000..e2ce910f3fd7
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
-index 6928ca2fbfb6..621b99e233ed 100644
+index 6928ca2fbfb6939062e3cd14bb7ba6f2fdc87f5f..621b99e233ed5cf504fedbd3ca3209c03bcd611f 100644
 --- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
 +++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
 @@ -27,11 +27,10 @@
@@ -13515,7 +13817,7 @@ index 6928ca2fbfb6..621b99e233ed 100644
  {
      return !!m_provisionalPage;
 diff --git a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
-index a2239cec8e18..79f3ff84327d 100644
+index a2239cec8e18850f35f7f88a9c4ebadc62bf4023..79f3ff84327dc075ec96983e04db4b10343b7fae 100644
 --- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
 +++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
 @@ -37,13 +37,13 @@ class WebPageProxy;
@@ -13555,7 +13857,7 @@ index a2239cec8e18..79f3ff84327d 100644
  
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
-index ed4e6f30b8c3..2357769f3f78 100644
+index ed4e6f30b8c35966075573dccee801daceec865e..2357769f3f78a7fda3d3fff1005e77c5d082948d 100644
 --- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
 +++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
 @@ -26,13 +26,21 @@
@@ -13862,7 +14164,7 @@ index ed4e6f30b8c3..2357769f3f78 100644
 +
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
-index 8c1339345d45..331b61c70c73 100644
+index 8c1339345d451874502b271f6aa2eca3fa0d3faf..331b61c70c7370ace480724bdb53c99a54897374 100644
 --- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
 +++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
 @@ -26,17 +26,35 @@
@@ -14000,7 +14302,7 @@ index 8c1339345d45..331b61c70c73 100644
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/mac/ScreencastEncoderMac.mm b/Source/WebKit/UIProcess/Inspector/mac/ScreencastEncoderMac.mm
 new file mode 100644
-index 000000000000..66d1c743de1c
+index 0000000000000000000000000000000000000000..66d1c743de1cb35e29d6fc9b69379d265a59961f
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/mac/ScreencastEncoderMac.mm
 @@ -0,0 +1,58 @@
@@ -14064,7 +14366,7 @@ index 000000000000..66d1c743de1c
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorDialogAgent.cpp b/Source/WebKit/UIProcess/InspectorDialogAgent.cpp
 new file mode 100644
-index 000000000000..663f92f0df76
+index 0000000000000000000000000000000000000000..663f92f0df76042cf6385b056f8a917d688259f9
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorDialogAgent.cpp
 @@ -0,0 +1,88 @@
@@ -14158,7 +14460,7 @@ index 000000000000..663f92f0df76
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorDialogAgent.h b/Source/WebKit/UIProcess/InspectorDialogAgent.h
 new file mode 100644
-index 000000000000..d0e11ed81a62
+index 0000000000000000000000000000000000000000..d0e11ed81a6257c011df23d5870da7403f8e9fe4
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorDialogAgent.h
 @@ -0,0 +1,70 @@
@@ -14234,7 +14536,7 @@ index 000000000000..d0e11ed81a62
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
 new file mode 100644
-index 000000000000..92fb6acfb614
+index 0000000000000000000000000000000000000000..92fb6acfb614f4f48f115372fef79afde4fd6517
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
 @@ -0,0 +1,997 @@
@@ -15237,7 +15539,7 @@ index 000000000000..92fb6acfb614
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h
 new file mode 100644
-index 000000000000..07de509499e7
+index 0000000000000000000000000000000000000000..07de509499e725dae6e2fdbb260b0e439f92633f
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h
 @@ -0,0 +1,126 @@
@@ -15369,7 +15671,7 @@ index 000000000000..07de509499e7
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgentClient.h b/Source/WebKit/UIProcess/InspectorPlaywrightAgentClient.h
 new file mode 100644
-index 000000000000..11c8eadafca7
+index 0000000000000000000000000000000000000000..11c8eadafca764aa549cb27c24967e15e6975774
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgentClient.h
 @@ -0,0 +1,66 @@
@@ -15440,7 +15742,7 @@ index 000000000000..11c8eadafca7
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp b/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
-index 7a14cfba15c1..3ee0e1543496 100644
+index 7a14cfba15c103a2d4fe263fa49d25af3c396ec2..3ee0e154349661632799057c71f1d1f1551c2d69 100644
 --- a/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
 +++ b/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
 @@ -96,8 +96,11 @@ void ProcessLauncher::launchProcess()
@@ -15457,7 +15759,7 @@ index 7a14cfba15c1..3ee0e1543496 100644
      BOOL result = ::CreateProcess(0, commandLine.data(), 0, 0, true, 0, 0, 0, &startupInfo, &processInformation);
  
 diff --git a/Source/WebKit/UIProcess/PageClient.h b/Source/WebKit/UIProcess/PageClient.h
-index 8770ad463816..e16f20b54132 100644
+index 8770ad463816bfef4c4a993746539e02d21cd572..e16f20b54132e19b34b74ae85271d3fa44f76af2 100644
 --- a/Source/WebKit/UIProcess/PageClient.h
 +++ b/Source/WebKit/UIProcess/PageClient.h
 @@ -314,6 +314,11 @@ public:
@@ -15473,7 +15775,7 @@ index 8770ad463816..e16f20b54132 100644
      virtual RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) = 0;
  #endif
 diff --git a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
-index bb4a4c2f6a17..49cd5218f23a 100644
+index bb4a4c2f6a17f4ada269a3450f9c276f648c72e1..49cd5218f23a6e8b8b8cf9d33542795dca95e548 100644
 --- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
 @@ -598,3 +598,5 @@ bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Option
@@ -15484,7 +15786,7 @@ index bb4a4c2f6a17..49cd5218f23a 100644
 +#undef MESSAGE_CHECK
 diff --git a/Source/WebKit/UIProcess/RemoteInspectorPipe.cpp b/Source/WebKit/UIProcess/RemoteInspectorPipe.cpp
 new file mode 100644
-index 000000000000..dd8b28e692dc
+index 0000000000000000000000000000000000000000..dd8b28e692dca4078eb710b2a97e61716126a4cb
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/RemoteInspectorPipe.cpp
 @@ -0,0 +1,224 @@
@@ -15714,7 +16016,7 @@ index 000000000000..dd8b28e692dc
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/RemoteInspectorPipe.h b/Source/WebKit/UIProcess/RemoteInspectorPipe.h
 new file mode 100644
-index 000000000000..6d04f9290135
+index 0000000000000000000000000000000000000000..6d04f9290135069359ce6bf8726546482fd1dc95
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/RemoteInspectorPipe.h
 @@ -0,0 +1,65 @@
@@ -15784,7 +16086,7 @@ index 000000000000..6d04f9290135
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
-index e42dbf1281d3..80fab5d4ac00 100644
+index e42dbf1281d36fef2e303e707d5b5baf166ee152..80fab5d4ac007f0d2da9f58bee03a5ab3c845b83 100644
 --- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
 +++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
 @@ -37,6 +37,8 @@
@@ -15797,7 +16099,7 @@ index e42dbf1281d3..80fab5d4ac00 100644
  
  Ref<WebCore::RealtimeMediaSource> SpeechRecognitionRemoteRealtimeMediaSource::create(SpeechRecognitionRemoteRealtimeMediaSourceManager& manager, const WebCore::CaptureDevice& captureDevice)
 diff --git a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
-index 684b96165737..51ff18323ece 100644
+index 684b9616573761123fbcc0d94be29de519ecced6..51ff18323ece0ee15c87d63a1d6fd604377ee968 100644
 --- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
 +++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
 @@ -28,6 +28,7 @@
@@ -15809,7 +16111,7 @@ index 684b96165737..51ff18323ece 100644
  
  namespace WebKit {
 diff --git a/Source/WebKit/UIProcess/WebContextMenuProxy.h b/Source/WebKit/UIProcess/WebContextMenuProxy.h
-index 1b8fcc84664f..280cf47fe75b 100644
+index 1b8fcc84664f309afe5f4eacd28b5413c1b1b907..280cf47fe75b2c13062090512b3250c9012984a9 100644
 --- a/Source/WebKit/UIProcess/WebContextMenuProxy.h
 +++ b/Source/WebKit/UIProcess/WebContextMenuProxy.h
 @@ -33,6 +33,7 @@
@@ -15829,7 +16131,7 @@ index 1b8fcc84664f..280cf47fe75b 100644
      WebPageProxy* page() const { return m_page.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
-index 04f3227cd55c..f0d36935f47b 100644
+index 04f3227cd55c992a42cd96a3f25d697aed7965a2..f0d36935f47bab03ea2ec50b705092068ecd3efa 100644
 --- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
 @@ -128,7 +128,8 @@ void WebGeolocationManagerProxy::startUpdating(IPC::Connection& connection, WebP
@@ -15844,7 +16146,7 @@ index 04f3227cd55c..f0d36935f47b 100644
  
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp
 new file mode 100644
-index 000000000000..ae45b4212bdb
+index 0000000000000000000000000000000000000000..ae45b4212bdb3f6a004cc80a1d91146b540f86f5
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp
 @@ -0,0 +1,147 @@
@@ -15997,7 +16299,7 @@ index 000000000000..ae45b4212bdb
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.h b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.h
 new file mode 100644
-index 000000000000..b3bb4880a866
+index 0000000000000000000000000000000000000000..b3bb4880a866ee6132b8b26acf8dad81afe14d85
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.h
 @@ -0,0 +1,75 @@
@@ -16078,7 +16380,7 @@ index 000000000000..b3bb4880a866
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorInputAgent.cpp b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.cpp
 new file mode 100644
-index 000000000000..eb16b3aa8912
+index 0000000000000000000000000000000000000000..eb16b3aa8912b4cc26a2e555669c27682b76378d
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.cpp
 @@ -0,0 +1,288 @@
@@ -16372,7 +16674,7 @@ index 000000000000..eb16b3aa8912
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorInputAgent.h b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.h
 new file mode 100644
-index 000000000000..94e9f2435333
+index 0000000000000000000000000000000000000000..94e9f24353337169992724e2fcdf7086dd888fa6
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.h
 @@ -0,0 +1,85 @@
@@ -16462,7 +16764,7 @@ index 000000000000..94e9f2435333
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index 9c7566dba21b..ac473eaa2c6c 100644
+index 9c7566dba21b9da9a8eee47ee9b76b8f0f9f086b..ac473eaa2c6cfd6e732ea20ea9c5871b155a6443 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
 @@ -240,7 +240,7 @@
@@ -16964,7 +17266,7 @@ index 9c7566dba21b..ac473eaa2c6c 100644
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index 3aaa64d1be42..d54b7ea95f83 100644
+index 3aaa64d1be42ea7ca0f08f97d90e3c47fadcdc6a..d54b7ea95f83497141048665d70c65264fbd41e8 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -38,6 +38,7 @@
@@ -17126,7 +17428,7 @@ index 3aaa64d1be42..d54b7ea95f83 100644
  #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
      std::unique_ptr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.messages.in b/Source/WebKit/UIProcess/WebPageProxy.messages.in
-index ab324811e168..57733275e2a3 100644
+index ab324811e16862d4eab1e8c6efd0183f9c64b8dd..57733275e2a3451973a7410ae09d7942da8e04c7 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
 +++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
 @@ -29,6 +29,7 @@ messages -> WebPageProxy {
@@ -17161,7 +17463,7 @@ index ab324811e168..57733275e2a3 100644
      DidPerformDragOperation(bool handled)
  #endif
 diff --git a/Source/WebKit/UIProcess/WebProcessPool.cpp b/Source/WebKit/UIProcess/WebProcessPool.cpp
-index b27685769445..126db68d6b60 100644
+index b27685769445ec7a15766a96e4d9ac69021fcc81..126db68d6b6029ea1a0a3183d4c9f5ef68bb3820 100644
 --- a/Source/WebKit/UIProcess/WebProcessPool.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
 @@ -507,6 +507,14 @@ void WebProcessPool::establishWorkerContextConnectionToNetworkProcess(NetworkPro
@@ -17192,7 +17494,7 @@ index b27685769445..126db68d6b60 100644
      parameters.urlSchemesRegisteredAsEmptyDocument = copyToVector(m_schemesToRegisterAsEmptyDocument);
      parameters.urlSchemesRegisteredAsSecure = copyToVector(LegacyGlobalSettings::singleton().schemesToRegisterAsSecure());
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.cpp b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-index ae9a29985cc5..9e54346f0576 100644
+index ae9a29985cc561b72ef05a5f21a38e366bde0d39..9e54346f05766075c987cce9aa496744081c5f96 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
 @@ -123,6 +123,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
@@ -17208,7 +17510,7 @@ index ae9a29985cc5..9e54346f0576 100644
  {
      return allProcesses().get(identifier);
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.h b/Source/WebKit/UIProcess/WebProcessProxy.h
-index e225ff467dc8..520716c830b2 100644
+index e225ff467dc84b576dc25d6625028b6019cf5e89..520716c830b2e0f29a9059b6c7e6f7534d7d3481 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.h
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.h
 @@ -137,6 +137,7 @@ public:
@@ -17220,7 +17522,7 @@ index e225ff467dc8..520716c830b2 100644
      WebConnection* webConnection() const { return m_webConnection.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-index d4090a9bb77e..7aea872d4053 100644
+index d4090a9bb77ece44f93a182c74c700aa016ae266..7aea872d4053fab26664dffad8a1313eb05e8461 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 @@ -2123,6 +2123,17 @@ void WebsiteDataStore::renameOriginInWebsiteData(URL&& oldName, URL&& newName, O
@@ -17242,7 +17544,7 @@ index d4090a9bb77e..7aea872d4053 100644
  void WebsiteDataStore::hasAppBoundSession(CompletionHandler<void(bool)>&& completionHandler) const
  {
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
-index 9957e51ac587..d1835053592b 100644
+index 9957e51ac587b36660bd6b2e20925811136e7a50..d1835053592b21b3d014e90d8a3e0c58dfc2073c 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
 @@ -92,6 +92,7 @@ enum class CacheModel : uint8_t;
@@ -17326,7 +17628,7 @@ index 9957e51ac587..d1835053592b 100644
      UniqueRef<SOAuthorizationCoordinator> m_soAuthorizationCoordinator;
  #endif
 diff --git a/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp b/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
-index 4f78b5eb5cdb..a2dc89ddf668 100644
+index 4f78b5eb5cdb51f2ebfcaff64ecd19b1e630ad9f..a2dc89ddf668e1be7b8f343a5df542b3141216cc 100644
 --- a/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
 +++ b/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
 @@ -27,9 +27,11 @@
@@ -17356,7 +17658,7 @@ index 4f78b5eb5cdb..a2dc89ddf668 100644
  {
      ASSERT(m_backend);
 diff --git a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
-index 692a45a48fa0..db8c761c71cc 100644
+index 692a45a48fa027f9221338d74f5351bef4baf00f..db8c761c71cc7009be66255c2668de4eff36dee0 100644
 --- a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
 +++ b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
 @@ -60,6 +60,8 @@ void GeoclueGeolocationProvider::start(UpdateNotifyFunction&& updateNotifyFuncti
@@ -17391,7 +17693,7 @@ index 692a45a48fa0..db8c761c71cc 100644
          "org.freedesktop.GeoClue2", clientPath, "org.freedesktop.GeoClue2.Client", m_cancellable.get(),
          [](GObject*, GAsyncResult* result, gpointer userData) {
 diff --git a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
-index b5e48e6c61a8..46747b1d78bf 100644
+index b5e48e6c61a8a3f4b40b84112c4010101c4d5f41..46747b1d78bfe0270178609867c0d710807fa668 100644
 --- a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
 +++ b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
 @@ -71,6 +71,9 @@ private:
@@ -17406,7 +17708,7 @@ index b5e48e6c61a8..46747b1d78bf 100644
  };
 diff --git a/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.cpp b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.cpp
 new file mode 100644
-index 000000000000..31a4e32d4cf8
+index 0000000000000000000000000000000000000000..31a4e32d4cf8442049f0bea04c817a40b801c1f7
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.cpp
 @@ -0,0 +1,147 @@
@@ -17559,7 +17861,7 @@ index 000000000000..31a4e32d4cf8
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.h b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.h
 new file mode 100644
-index 000000000000..8006336003a4
+index 0000000000000000000000000000000000000000..8006336003a4512b4c63bc8272d4b3507bb63159
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.h
 @@ -0,0 +1,60 @@
@@ -17624,7 +17926,7 @@ index 000000000000..8006336003a4
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
-index 39aeff71fe05..32e96cdd0bdb 100644
+index 39aeff71fe05354cf63d3b3701d363642d63aca4..32e96cdd0bdbd8c5dcde43fdf60052ac13a226f7 100644
 --- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
 +++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
 @@ -28,6 +28,7 @@
@@ -17645,7 +17947,7 @@ index 39aeff71fe05..32e96cdd0bdb 100644
      virtual void unrealize() { };
      virtual bool makeContextCurrent() { return false; }
 diff --git a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h
-index 054e80bd900c..8245d7ed5800 100644
+index 054e80bd900cf16d69801e8102ca989ff0563e1d..8245d7ed58008dbb6152e55e619e4331d30ae674 100644
 --- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h
 +++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h
 @@ -52,6 +52,7 @@ private:
@@ -17658,7 +17960,7 @@ index 054e80bd900c..8245d7ed5800 100644
      WebCore::XUniqueDamage m_damage;
 diff --git a/Source/WebKit/UIProcess/gtk/InspectorTargetProxyGtk.cpp b/Source/WebKit/UIProcess/gtk/InspectorTargetProxyGtk.cpp
 new file mode 100644
-index 000000000000..8a86cc348bc2
+index 0000000000000000000000000000000000000000..8a86cc348bc210b71bb463dcb3057f575ad7c1d3
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/gtk/InspectorTargetProxyGtk.cpp
 @@ -0,0 +1,44 @@
@@ -17707,7 +18009,7 @@ index 000000000000..8a86cc348bc2
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp b/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp
-index 2ac15c9d7f1f..111cd5464a19 100644
+index 2ac15c9d7f1f19947b449794862555e913e211b7..111cd5464a19b81e73ba1bd02a2d76918cb40612 100644
 --- a/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp
 +++ b/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp
 @@ -34,6 +34,8 @@
@@ -17721,7 +18023,7 @@ index 2ac15c9d7f1f..111cd5464a19 100644
  Ref<WebDateTimePickerGtk> WebDateTimePickerGtk::create(WebPageProxy& page)
 diff --git a/Source/WebKit/UIProcess/gtk/WebPageInspectorEmulationAgentGtk.cpp b/Source/WebKit/UIProcess/gtk/WebPageInspectorEmulationAgentGtk.cpp
 new file mode 100644
-index 000000000000..e5e25acebabb
+index 0000000000000000000000000000000000000000..e5e25acebabb76a05a77db02a99f1267bd99a3af
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/gtk/WebPageInspectorEmulationAgentGtk.cpp
 @@ -0,0 +1,69 @@
@@ -17796,7 +18098,7 @@ index 000000000000..e5e25acebabb
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/gtk/WebPageInspectorInputAgentGtk.cpp b/Source/WebKit/UIProcess/gtk/WebPageInspectorInputAgentGtk.cpp
 new file mode 100644
-index 000000000000..d0f982754499
+index 0000000000000000000000000000000000000000..d0f9827544994e450e24e3f7a427c35eeff94d67
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/gtk/WebPageInspectorInputAgentGtk.cpp
 @@ -0,0 +1,105 @@
@@ -17906,7 +18208,7 @@ index 000000000000..d0f982754499
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
-index 56b32598708d..d6c213d4cfa3 100644
+index 56b32598708dbac89156336dc12ef2d194d597c8..d6c213d4cfa3159849a09423b85ce0900d27b080 100644
 --- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 +++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 @@ -441,6 +441,8 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
@@ -17920,7 +18222,7 @@ index 56b32598708d..d6c213d4cfa3 100644
  
 diff --git a/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.h b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.h
 new file mode 100644
-index 000000000000..a16815a6759d
+index 0000000000000000000000000000000000000000..a16815a6759da61a6a61e3d79058228af887fd7c
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.h
 @@ -0,0 +1,51 @@
@@ -17977,7 +18279,7 @@ index 000000000000..a16815a6759d
 +} // namespace API
 diff --git a/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.mm b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.mm
 new file mode 100644
-index 000000000000..8e588f7b8c8c
+index 0000000000000000000000000000000000000000..8e588f7b8c8c29fb53dd37ea41d46f3d753077fd
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.mm
 @@ -0,0 +1,77 @@
@@ -18060,7 +18362,7 @@ index 000000000000..8e588f7b8c8c
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/mac/InspectorTargetProxyMac.mm b/Source/WebKit/UIProcess/mac/InspectorTargetProxyMac.mm
 new file mode 100644
-index 000000000000..721826c8c98f
+index 0000000000000000000000000000000000000000..721826c8c98fc85b68a4f45deaee69c1219a7254
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/InspectorTargetProxyMac.mm
 @@ -0,0 +1,42 @@
@@ -18107,7 +18409,7 @@ index 000000000000..721826c8c98f
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/mac/PageClientImplMac.h b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
-index dd7b497aa64b..5062b795b591 100644
+index dd7b497aa64bf7a23eef18486ebcb443a35871e4..5062b795b591e75df484c6c6c5df90432dffed2d 100644
 --- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
 +++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
 @@ -53,6 +53,8 @@ class PageClientImpl final : public PageClientImplCocoa
@@ -18141,7 +18443,7 @@ index dd7b497aa64b..5062b795b591 100644
      void navigationGestureWillEnd(bool willNavigate, WebBackForwardListItem&) override;
      void navigationGestureDidEnd(bool willNavigate, WebBackForwardListItem&) override;
 diff --git a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
-index c2de8d6ea7c0..c019122519ad 100644
+index c2de8d6ea7c0bcafa0914c1f52ae4d645df869dc..c019122519adf07c4d9dbb87551325aa9b6b661d 100644
 --- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
 +++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
 @@ -81,6 +81,7 @@
@@ -18262,7 +18564,7 @@ index c2de8d6ea7c0..c019122519ad 100644
  }
  
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
-index 56061afc3d03..7a148e644329 100644
+index 56061afc3d03eb1d3ed99a39dacd6ccad36109be..7a148e64432926fce48e13fad5e8476609d607d4 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
 @@ -63,6 +63,7 @@ private:
@@ -18274,7 +18576,7 @@ index 56061afc3d03..7a148e644329 100644
      void getContextMenuItem(const WebContextMenuItemData&, CompletionHandler<void(NSMenuItem *)>&&);
      void getContextMenuFromItems(const Vector<WebContextMenuItemData>&, CompletionHandler<void(NSMenu *)>&&);
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-index 655b0b839d35..e0ba34e2c304 100644
+index 655b0b839d3536ba3b754e4138a87705d610dae8..e0ba34e2c3040153748e955c5856d145cb0351b5 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 @@ -361,6 +361,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
@@ -18292,7 +18594,7 @@ index 655b0b839d35..e0ba34e2c304 100644
  #if ENABLE(SERVICE_CONTROLS)
 diff --git a/Source/WebKit/UIProcess/mac/WebPageInspectorEmulationAgentMac.mm b/Source/WebKit/UIProcess/mac/WebPageInspectorEmulationAgentMac.mm
 new file mode 100644
-index 000000000000..6113f4cd60a5
+index 0000000000000000000000000000000000000000..6113f4cd60a5d72b8ead61176cb43200803478ed
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/WebPageInspectorEmulationAgentMac.mm
 @@ -0,0 +1,44 @@
@@ -18342,7 +18644,7 @@ index 000000000000..6113f4cd60a5
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/mac/WebPageInspectorInputAgentMac.mm b/Source/WebKit/UIProcess/mac/WebPageInspectorInputAgentMac.mm
 new file mode 100644
-index 000000000000..e6e2c8c2769e
+index 0000000000000000000000000000000000000000..e6e2c8c2769e4657c01f1452e554fd6f6d457279
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/WebPageInspectorInputAgentMac.mm
 @@ -0,0 +1,124 @@
@@ -18472,7 +18774,7 @@ index 000000000000..e6e2c8c2769e
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.cpp b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.cpp
 new file mode 100644
-index 000000000000..dd7fe0604188
+index 0000000000000000000000000000000000000000..dd7fe0604188bb025f361f1c44685e38bbf935ca
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.cpp
 @@ -0,0 +1,90 @@
@@ -18568,7 +18870,7 @@ index 000000000000..dd7fe0604188
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.h b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.h
 new file mode 100644
-index 000000000000..df18883b2b7d
+index 0000000000000000000000000000000000000000..df18883b2b7d22d73540cb084d3dd5291231097d
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.h
 @@ -0,0 +1,60 @@
@@ -18634,7 +18936,7 @@ index 000000000000..df18883b2b7d
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/win/InspectorTargetProxyWin.cpp b/Source/WebKit/UIProcess/win/InspectorTargetProxyWin.cpp
 new file mode 100644
-index 000000000000..135a60361fa8
+index 0000000000000000000000000000000000000000..135a60361fa8fbf907382625e7c8dd4ea64ceb94
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/InspectorTargetProxyWin.cpp
 @@ -0,0 +1,36 @@
@@ -18675,7 +18977,7 @@ index 000000000000..135a60361fa8
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
-index 3dcd0ec35c92..84ba07c57f2a 100644
+index 3dcd0ec35c92e37239208a8f5d4f461fbeaac3ce..84ba07c57f2abac1bd0ca5d0af2e7366ad036892 100644
 --- a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
 +++ b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
 @@ -112,5 +112,11 @@ WebContextMenuProxyWin::~WebContextMenuProxyWin()
@@ -18691,7 +18993,7 @@ index 3dcd0ec35c92..84ba07c57f2a 100644
  } // namespace WebKit
  #endif // ENABLE(CONTEXT_MENUS)
 diff --git a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
-index 0c80d970c3f9..1467e5481f74 100644
+index 0c80d970c3f9a987faf620081c909f6c7021970d..1467e5481f7417913c0d12a1cb492d02b2a7d1b7 100644
 --- a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
 +++ b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
 @@ -47,6 +47,7 @@ public:
@@ -18704,7 +19006,7 @@ index 0c80d970c3f9..1467e5481f74 100644
  };
 diff --git a/Source/WebKit/UIProcess/win/WebPageInspectorEmulationAgentWin.cpp b/Source/WebKit/UIProcess/win/WebPageInspectorEmulationAgentWin.cpp
 new file mode 100644
-index 000000000000..62b841fe1d0d
+index 0000000000000000000000000000000000000000..62b841fe1d0de2296e1c61e328cff564f5aa1c0f
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/WebPageInspectorEmulationAgentWin.cpp
 @@ -0,0 +1,58 @@
@@ -18768,7 +19070,7 @@ index 000000000000..62b841fe1d0d
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/win/WebPageInspectorInputAgentWin.cpp b/Source/WebKit/UIProcess/win/WebPageInspectorInputAgentWin.cpp
 new file mode 100644
-index 000000000000..5cf8a010e980
+index 0000000000000000000000000000000000000000..5cf8a010e9809e6a95741cdb7c2cbeb445ab638b
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/WebPageInspectorInputAgentWin.cpp
 @@ -0,0 +1,55 @@
@@ -18829,7 +19131,7 @@ index 000000000000..5cf8a010e980
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/wpe/InspectorTargetProxyWPE.cpp b/Source/WebKit/UIProcess/wpe/InspectorTargetProxyWPE.cpp
 new file mode 100644
-index 000000000000..7453194ca6f0
+index 0000000000000000000000000000000000000000..7453194ca6f032ba86a4c67f5bf12688ab6ec1be
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/wpe/InspectorTargetProxyWPE.cpp
 @@ -0,0 +1,40 @@
@@ -18875,7 +19177,7 @@ index 000000000000..7453194ca6f0
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/wpe/WebPageInspectorEmulationAgentWPE.cpp b/Source/WebKit/UIProcess/wpe/WebPageInspectorEmulationAgentWPE.cpp
 new file mode 100644
-index 000000000000..5dc76aa302cb
+index 0000000000000000000000000000000000000000..5dc76aa302cb574307059e66a1b73730efe920da
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/wpe/WebPageInspectorEmulationAgentWPE.cpp
 @@ -0,0 +1,41 @@
@@ -18922,7 +19224,7 @@ index 000000000000..5dc76aa302cb
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/wpe/WebPageInspectorInputAgentWPE.cpp b/Source/WebKit/UIProcess/wpe/WebPageInspectorInputAgentWPE.cpp
 new file mode 100644
-index 000000000000..c3d7cacea987
+index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705ef6ced129
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/wpe/WebPageInspectorInputAgentWPE.cpp
 @@ -0,0 +1,55 @@
@@ -18982,7 +19284,7 @@ index 000000000000..c3d7cacea987
 + 
 +} // namespace WebKit
 diff --git a/Source/WebKit/WebKit.xcodeproj/project.pbxproj b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-index 927525368116..2caf7e4571f3 100644
+index 9275253681163208714c7b4af22d59a1faa40501..2caf7e4571f329ae6dd81e137213c6378f307ded 100644
 --- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 +++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 @@ -1954,6 +1954,18 @@
@@ -19240,7 +19542,7 @@ index 927525368116..2caf7e4571f3 100644
  				BCBD3914125BB1A800D2C29F /* WebPageProxyMessageReceiver.cpp in Sources */,
  				7CE9CE101FA0767A000177DE /* WebPageUpdatePreferences.cpp in Sources */,
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
-index c42d2c00f798..50da344e6bd2 100644
+index c42d2c00f7982ea3fe19401cd076c24a0b649ebf..50da344e6bd20b85e122c3c36aebcab2b7765bc2 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 @@ -231,6 +231,11 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
@@ -19353,7 +19655,7 @@ index c42d2c00f798..50da344e6bd2 100644
  {
      WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::SetCaptureExtraNetworkLoadMetricsEnabled(enabled), 0);
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
-index ca2349958666..b5529ff5a2e2 100644
+index ca2349958666a801b0e0a6bd767dbbcccfb716ae..b5529ff5a2e2fa97bccc21f88689624b3d5a3624 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
 @@ -40,6 +40,7 @@ struct FetchOptions;
@@ -19383,8 +19685,36 @@ index ca2349958666..b5529ff5a2e2 100644
  };
  
  } // namespace WebKit
+diff --git a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+index ecd4052eac038028255a786236e1969853afa1d8..2adc87a59c12d15c651909e67670ac354b59092b 100644
+--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
++++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+@@ -196,6 +196,7 @@ void WebResourceLoader::didReceiveData(const IPC::DataReference& data, int64_t e
+ 
+     if (UNLIKELY(m_interceptController.isIntercepting(m_coreLoader->identifier()))) {
+         auto buffer = SharedBuffer::create(data.data(), data.size());
++        InspectorInstrumentationWebKit::interceptDidReceiveData(m_coreLoader->frame(), m_coreLoader->identifier(), buffer.get());
+         m_interceptController.defer(m_coreLoader->identifier(), [this, protectedThis = makeRef(*this), buffer = WTFMove(buffer), encodedDataLength]() mutable {
+             if (m_coreLoader)
+                 didReceiveData({ buffer->data(), buffer->size() }, encodedDataLength);
+@@ -216,6 +217,7 @@ void WebResourceLoader::didFinishResourceLoad(const NetworkLoadMetrics& networkL
+     WEBRESOURCELOADER_RELEASE_LOG("didFinishResourceLoad: (length=%zd)", m_numBytesReceived);
+ 
+     if (UNLIKELY(m_interceptController.isIntercepting(m_coreLoader->identifier()))) {
++        InspectorInstrumentationWebKit::interceptDidFinishResourceLoad(m_coreLoader->frame(), m_coreLoader->identifier());
+         m_interceptController.defer(m_coreLoader->identifier(), [this, protectedThis = makeRef(*this), networkLoadMetrics]() mutable {
+             if (m_coreLoader)
+                 didFinishResourceLoad(networkLoadMetrics);
+@@ -259,6 +261,7 @@ void WebResourceLoader::didFailResourceLoad(const ResourceError& error)
+     WEBRESOURCELOADER_RELEASE_LOG("didFailResourceLoad:");
+ 
+     if (UNLIKELY(m_interceptController.isIntercepting(m_coreLoader->identifier()))) {
++        InspectorInstrumentationWebKit::interceptDidFailResourceLoad(m_coreLoader->frame(), m_coreLoader->identifier(), error);
+         m_interceptController.defer(m_coreLoader->identifier(), [this, protectedThis = makeRef(*this), error]() mutable {
+             if (m_coreLoader)
+                 didFailResourceLoad(error);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
-index 7d62e5e9a39d..1ac2495b9eba 100644
+index 7d62e5e9a39d15caa375a11c9967456764df8997..1ac2495b9eba1df232c34a422c3c5cbb1571bc1b 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 @@ -398,6 +398,8 @@ void WebChromeClient::setResizable(bool resizable)
@@ -19411,7 +19741,7 @@ index 7d62e5e9a39d..1ac2495b9eba 100644
  {
      if (m_page.activeOpenPanelResultListener())
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
-index 2eb0886f13ed..c46393209cb4 100644
+index 2eb0886f13ed035a53b8eaa60605de4dfe53fbe3..c46393209cb4f80704bbc9268fad4371347d5b30 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
 @@ -29,6 +29,13 @@
@@ -19438,7 +19768,7 @@ index 2eb0886f13ed..c46393209cb4 100644
  {
  }
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
-index 5da2bb9f4a2d..91bf00964333 100644
+index 5da2bb9f4a2d7d423bee854471fe853d3e4a261d..91bf00964333903912e8d6899b1a64d1e7d3d2a7 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 @@ -1566,13 +1566,6 @@ void WebFrameLoaderClient::transitionToCommittedForNewPage()
@@ -19456,7 +19786,7 @@ index 5da2bb9f4a2d..91bf00964333 100644
  
  void WebFrameLoaderClient::didRestoreFromBackForwardCache()
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
-index e9f2b2237b1d..b2d3ca7cc093 100644
+index e9f2b2237b1d8a1b21ad28e0fa309b80252b5ebd..b2d3ca7cc093ed428f95df992c208b1b9491067d 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 @@ -127,7 +127,8 @@ static WebCore::CachedImage* cachedImage(Element& element)
@@ -19471,7 +19801,7 @@ index e9f2b2237b1d..b2d3ca7cc093 100644
      WebCore::CachedImage* image = cachedImage(element);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/win/WebDragClientWin.cpp b/Source/WebKit/WebProcess/WebCoreSupport/win/WebDragClientWin.cpp
 new file mode 100644
-index 000000000000..2606914d22e8
+index 0000000000000000000000000000000000000000..2606914d22e85affd9b2f71c361c9db3a14da4f3
 --- /dev/null
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/win/WebDragClientWin.cpp
 @@ -0,0 +1,58 @@
@@ -19535,7 +19865,7 @@ index 000000000000..2606914d22e8
 +#endif // ENABLE(DRAG_SUPPORT)
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebDragClientWPE.cpp b/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebDragClientWPE.cpp
 new file mode 100644
-index 000000000000..9b413bb8150a
+index 0000000000000000000000000000000000000000..9b413bb8150a1633d29b6e2606127c9c1d02442b
 --- /dev/null
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebDragClientWPE.cpp
 @@ -0,0 +1,57 @@
@@ -19597,7 +19927,7 @@ index 000000000000..9b413bb8150a
 +
 +#endif // ENABLE(DRAG_SUPPORT)
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
-index 4a087235e7bc..3ea0a7106906 100644
+index 4a087235e7bcf915f6e9d4daf8ad48b748ce3b91..3ea0a7106906f4cda63f1b0ce7c595496326e1c3 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
 @@ -36,7 +36,9 @@
@@ -19660,7 +19990,7 @@ index 4a087235e7bc..3ea0a7106906 100644
  
  void DrawingAreaCoordinatedGraphics::scheduleDisplay()
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
-index 91226dd76b3f..71db76c7fa64 100644
+index 91226dd76b3f18b1eb5aabd99cd840509bf309f4..71db76c7fa649de2dd19e2c6e7f307cb9810049b 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
 @@ -183,8 +183,16 @@ void LayerTreeHost::setViewOverlayRootLayer(GraphicsLayer* viewOverlayRootLayer)
@@ -19692,7 +20022,7 @@ index 91226dd76b3f..71db76c7fa64 100644
  
      if (m_lastPageScaleFactor != pageScale) {
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
-index 4943393a2c35..e2bc9cd5cfc6 100644
+index 4943393a2c351f91147e1e2369870b42439e2ff1..e2bc9cd5cfc6e906fd8931c2525f6dba6f53441a 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
 @@ -105,6 +105,13 @@ public:
@@ -19710,7 +20040,7 @@ index 4943393a2c35..e2bc9cd5cfc6 100644
  #if USE(COORDINATED_GRAPHICS)
      void layerFlushTimerFired();
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
-index be37cb482bcc..aebb82d4e149 100644
+index be37cb482bccc92412701ba41951c3da57cb7e2e..aebb82d4e149c192bc28383fc722ae1b0a2f5d14 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
 @@ -29,6 +29,7 @@
@@ -19722,7 +20052,7 @@ index be37cb482bcc..aebb82d4e149 100644
  #include <GLES2/gl2.h>
  #include <WebCore/Document.h>
 diff --git a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
-index cdba5ae658de..90d718d74188 100644
+index cdba5ae658de5bda9ef87a2b6ebc99a44d33d658..90d718d74188fcb2ae05ba7b1dd741054d061366 100644
 --- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
 @@ -27,6 +27,7 @@
@@ -19748,7 +20078,7 @@ index cdba5ae658de..90d718d74188 100644
  {
      if (m_hasRemovedMessageReceiver)
 diff --git a/Source/WebKit/WebProcess/WebPage/DrawingArea.h b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
-index 74771ec40ccb..74ff494c1abe 100644
+index 74771ec40ccbcb0329ba09784d8e6a9e512cbc93..74ff494c1abeb8e628ec1ec8f9eef30670af2946 100644
 --- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
 +++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
 @@ -144,6 +144,9 @@ public:
@@ -19762,7 +20092,7 @@ index 74771ec40ccb..74ff494c1abe 100644
      virtual void adoptLayersFromDrawingArea(DrawingArea&) { }
      virtual void adoptDisplayRefreshMonitorsFromDrawingArea(DrawingArea&) { }
 diff --git a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
-index 633828983ef7..91a09a613a00 100644
+index 633828983ef77632392d0dbc2e4a90489e340b9e..91a09a613a0031fc3ba5ee452ac4bb843a216ffe 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
 @@ -28,15 +28,19 @@
@@ -19809,7 +20139,7 @@ index 633828983ef7..91a09a613a00 100644
 +
  } // namespace WebKit
 diff --git a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
-index bc78502b18b9..f4c95fcbc0a1 100644
+index bc78502b18b994a3ffa47b933273ebdb84fafde9..f4c95fcbc0a1d618cc51f748a0df82b7ebe20cab 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
 @@ -52,6 +52,8 @@ public:
@@ -19822,7 +20152,7 @@ index bc78502b18b9..f4c95fcbc0a1 100644
      WebCookieJar();
  
 diff --git a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
-index b2d54a627b94..d407e32b6a7b 100644
+index b2d54a627b94583bda3518c4e7c3364481b605a4..d407e32b6a7b8b27925c49391e86d42c9b3dfa8b 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
 @@ -47,6 +47,14 @@ void WebDocumentLoader::detachFromFrame()
@@ -19841,7 +20171,7 @@ index b2d54a627b94..d407e32b6a7b 100644
  {
      ASSERT(navigationID);
 diff --git a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h
-index f127d64d005a..df0de26e4dc4 100644
+index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4e5365822 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h
 @@ -43,7 +43,10 @@ public:
@@ -19856,7 +20186,7 @@ index f127d64d005a..df0de26e4dc4 100644
      uint64_t m_navigationID;
  };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index 2d4a141fe05e..476a708e1754 100644
+index 2d4a141fe05e5c0b97302fd2e5b2c1398eff6661..476a708e17547692b0d38cb0323669baf72156f2 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 @@ -874,6 +874,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
@@ -20119,7 +20449,7 @@ index 2d4a141fe05e..476a708e1754 100644
  
      return documentLoader;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.h b/Source/WebKit/WebProcess/WebPage/WebPage.h
-index d676e701560f..52f4c9054c68 100644
+index d676e701560ffe038c2ca37d4731a48a0860b3c6..52f4c9054c68295dfa49f37c4397af8c4e044dab 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
 @@ -111,6 +111,10 @@ typedef struct _AtkObject AtkObject;
@@ -20200,7 +20530,7 @@ index d676e701560f..52f4c9054c68 100644
  
      bool m_mainFrameProgressCompleted { false };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-index 5bde3f8da91c..db386f614801 100644
+index 5bde3f8da91c6c5a65c6fba838b1ed6738d020db..db386f61480131b6470c28a99c2e9175142d5afe 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 @@ -133,6 +133,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
@@ -20252,7 +20582,7 @@ index 5bde3f8da91c..db386f614801 100644
      RequestDragStart(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
      RequestAdditionalItemsForDragSession(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
 diff --git a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
-index 2ab1084c5cdc..68c300f49fce 100644
+index 2ab1084c5cdc4b3fa8e4eb725541b6860502484e..68c300f49fce77b0273a45a0bfc4acbc3b9d6cbd 100644
 --- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
 +++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
 @@ -830,21 +830,37 @@ String WebPage::platformUserAgent(const URL&) const
@@ -20294,7 +20624,7 @@ index 2ab1084c5cdc..68c300f49fce 100644
  }
  
 diff --git a/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp b/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
-index 8e9454597bb2..9730e673e85d 100644
+index 8e9454597bb23b22c506f929020fc3c37ffaa71a..9730e673e85da143a3acdda03fb9fa3fb4fb1119 100644
 --- a/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
 @@ -43,6 +43,7 @@
@@ -20344,7 +20674,7 @@ index 8e9454597bb2..9730e673e85d 100644
  }
  
 diff --git a/Source/WebKit/WebProcess/WebProcess.cpp b/Source/WebKit/WebProcess/WebProcess.cpp
-index db4c228323a8..16f73b56d9f1 100644
+index db4c228323a803160a09d569f753d280c4cbc82f..16f73b56d9f14038a8083e78439f7f1cd6d89837 100644
 --- a/Source/WebKit/WebProcess/WebProcess.cpp
 +++ b/Source/WebKit/WebProcess/WebProcess.cpp
 @@ -87,6 +87,7 @@
@@ -20365,7 +20695,7 @@ index db4c228323a8..16f73b56d9f1 100644
  
  void WebProcess::initializeConnection(IPC::Connection* connection)
 diff --git a/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp b/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp
-index 8987c3964a93..bcac0afeb94e 100644
+index 8987c3964a9308f2454759de7f8972215a3ae416..bcac0afeb94ed8123d1f9fb0b932c8497d157b49 100644
 --- a/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp
 +++ b/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp
 @@ -42,7 +42,9 @@ public:
@@ -20380,7 +20710,7 @@ index 8987c3964a93..bcac0afeb94e 100644
              SetProcessDPIAware();
          return true;
 diff --git a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-index d60519bc434c..f7f08e5fe361 100644
+index d60519bc434ca4c8e2b0b0f836e14de59bb230a5..f7f08e5fe361a92523e0c85243615fdfb5384209 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 @@ -4237,7 +4237,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
@@ -20393,7 +20723,7 @@ index d60519bc434c..f7f08e5fe361 100644
  - (void)touch:(WebEvent *)event
  {
 diff --git a/Source/WebKitLegacy/mac/WebView/WebView.mm b/Source/WebKitLegacy/mac/WebView/WebView.mm
-index 8a4ec8910ca2..ef1933c8030f 100644
+index 8a4ec8910ca2f4104e4b59b22f1081200f280f9b..ef1933c8030f40d9deed891fcef31a93ad037c7d 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
 @@ -4027,7 +4027,7 @@ IGNORE_WARNINGS_END
@@ -20416,7 +20746,7 @@ index 8a4ec8910ca2..ef1933c8030f 100644
  // a per-WebView and a per-preferences setting for whether to use the back/forward cache.
 diff --git a/Source/cmake/FindLibVPX.cmake b/Source/cmake/FindLibVPX.cmake
 new file mode 100644
-index 000000000000..dd6a53e2d573
+index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d5d9dc387
 --- /dev/null
 +++ b/Source/cmake/FindLibVPX.cmake
 @@ -0,0 +1,25 @@
@@ -20446,7 +20776,7 @@ index 000000000000..dd6a53e2d573
 +    LIBVPX_LIBRARIES
 +)
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index 7de2d6046a98..177951f94be6 100644
+index 7de2d6046a98839687ed277009bd9fd4eb5c2fe0..177951f94be605c998c7dc9f7bd2d0f1f3a3270e 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
 @@ -5,6 +5,8 @@ WEBKIT_OPTION_BEGIN()
@@ -20510,7 +20840,7 @@ index 7de2d6046a98..177951f94be6 100644
  
  # Finalize the value for all options. Do not attempt to use an option before
 diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
-index aefcaae96be0..78d5b8bae595 100644
+index aefcaae96be00bfef8332861112343f5cad9901b..78d5b8bae595e8d746a0641fcbeba8874ddaaf60 100644
 --- a/Source/cmake/OptionsWPE.cmake
 +++ b/Source/cmake/OptionsWPE.cmake
 @@ -3,6 +3,7 @@ include(VersioningUtils)
@@ -20549,7 +20879,7 @@ index aefcaae96be0..78d5b8bae595 100644
  WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." PUBLIC ON)
  
 diff --git a/Source/cmake/OptionsWin.cmake b/Source/cmake/OptionsWin.cmake
-index 1ecfd21e4470..02791cd57e26 100644
+index 1ecfd21e44703b2d61aff5494414d33878f0cfcd..02791cd57e26c6e07dc759a77e22ea77767f6bc6 100644
 --- a/Source/cmake/OptionsWin.cmake
 +++ b/Source/cmake/OptionsWin.cmake
 @@ -7,8 +7,9 @@ add_definitions(-D_WINDOWS -DWINVER=0x601 -D_WIN32_WINNT=0x601)
@@ -20578,7 +20908,7 @@ index 1ecfd21e4470..02791cd57e26 100644
      WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETSCAPE_PLUGIN_API PRIVATE OFF)
  else ()
 diff --git a/Source/cmake/OptionsWinCairo.cmake b/Source/cmake/OptionsWinCairo.cmake
-index 512392e6424e..90b7c9614333 100644
+index 512392e6424ea64ff65fffc14df30344ce6cbe99..90b7c9614333868ff8c157f5bd938da98be4871d 100644
 --- a/Source/cmake/OptionsWinCairo.cmake
 +++ b/Source/cmake/OptionsWinCairo.cmake
 @@ -32,15 +32,36 @@ if (OpenJPEG_FOUND)
@@ -20622,7 +20952,7 @@ index 512392e6424e..90b7c9614333 100644
  set(USE_ANGLE_WEBGL ON)
  
 diff --git a/Tools/MiniBrowser/gtk/BrowserTab.c b/Tools/MiniBrowser/gtk/BrowserTab.c
-index ab75a69f64aa..e82450546a7d 100644
+index ab75a69f64aadee2b22e0d8d114932db55aaa000..e82450546a7dba66155b26c3d841d0a74675c701 100644
 --- a/Tools/MiniBrowser/gtk/BrowserTab.c
 +++ b/Tools/MiniBrowser/gtk/BrowserTab.c
 @@ -161,6 +161,11 @@ static void loadChanged(WebKitWebView *webView, WebKitLoadEvent loadEvent, Brows
@@ -20656,7 +20986,7 @@ index ab75a69f64aa..e82450546a7d 100644
  }
  
 diff --git a/Tools/MiniBrowser/gtk/BrowserWindow.c b/Tools/MiniBrowser/gtk/BrowserWindow.c
-index 063e94568490..e08bed7942be 100644
+index 063e94568490cc72193222987b805e7dfff94fea..e08bed7942be0352317ffe6bf92b710aba9d050b 100644
 --- a/Tools/MiniBrowser/gtk/BrowserWindow.c
 +++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
 @@ -1373,6 +1373,12 @@ static gboolean browserWindowDeleteEvent(GtkWidget *widget, GdkEventAny* event)
@@ -20688,7 +21018,7 @@ index 063e94568490..e08bed7942be 100644
  
  /* Public API. */
 diff --git a/Tools/MiniBrowser/gtk/BrowserWindow.h b/Tools/MiniBrowser/gtk/BrowserWindow.h
-index 62629b4c1c25..5de7900a29b0 100644
+index 62629b4c1c25ae82bd797b39bbf9de0331f8eed2..5de7900a29b0e629f1ac404bbb0dc5b4e605294d 100644
 --- a/Tools/MiniBrowser/gtk/BrowserWindow.h
 +++ b/Tools/MiniBrowser/gtk/BrowserWindow.h
 @@ -37,7 +37,7 @@ G_BEGIN_DECLS
@@ -20701,7 +21031,7 @@ index 62629b4c1c25..5de7900a29b0 100644
  
  typedef struct _BrowserWindow        BrowserWindow;
 diff --git a/Tools/MiniBrowser/gtk/main.c b/Tools/MiniBrowser/gtk/main.c
-index b4ad6cad7ee3..0ef28c90628d 100644
+index b4ad6cad7ee375d92cb12a4f168418e67fe1afb6..0ef28c90628dc8e9d5ac521db489180de913f881 100644
 --- a/Tools/MiniBrowser/gtk/main.c
 +++ b/Tools/MiniBrowser/gtk/main.c
 @@ -54,7 +54,12 @@ static gboolean darkMode;
@@ -20834,7 +21164,7 @@ index b4ad6cad7ee3..0ef28c90628d 100644
  
      return exitAfterLoad && webProcessCrashed ? 1 : 0;
 diff --git a/Tools/MiniBrowser/wpe/main.cpp b/Tools/MiniBrowser/wpe/main.cpp
-index 2e5c76219de1..cf6650a4fda1 100644
+index 2e5c76219de1a60dccae1c8088ceabd8b12c95d0..cf6650a4fda1516b2adf578fc263ad874b200c01 100644
 --- a/Tools/MiniBrowser/wpe/main.cpp
 +++ b/Tools/MiniBrowser/wpe/main.cpp
 @@ -40,6 +40,9 @@ static gboolean headlessMode;
@@ -21062,7 +21392,7 @@ index 2e5c76219de1..cf6650a4fda1 100644
  
      return 0;
 diff --git a/Tools/PlatformWin.cmake b/Tools/PlatformWin.cmake
-index ef4407cfc114..448dd4837151 100644
+index ef4407cfc114e602d98ed81724da504f453e258f..448dd483715162baba484f756fbcc1d72de4ba0c 100644
 --- a/Tools/PlatformWin.cmake
 +++ b/Tools/PlatformWin.cmake
 @@ -12,4 +12,5 @@ endif ()
@@ -21072,7 +21402,7 @@ index ef4407cfc114..448dd4837151 100644
 +    add_subdirectory(Playwright/win)
  endif ()
 diff --git a/Tools/Scripts/build-webkit b/Tools/Scripts/build-webkit
-index ddc2a96ac68c..57a78f54e72d 100755
+index ddc2a96ac68cd51d5f4efeca78a118db91709aa2..57a78f54e72d264daa27faa53ac2a30cab98dd82 100755
 --- a/Tools/Scripts/build-webkit
 +++ b/Tools/Scripts/build-webkit
 @@ -247,7 +247,7 @@ if (isAppleCocoaWebKit()) {
@@ -21085,7 +21415,7 @@ index ddc2a96ac68c..57a78f54e72d 100755
          # WebInspectorUI must come after JavaScriptCore and WebCore but before WebKit and WebKit2
          my $webKitIndex = first { $projects[$_] eq "Source/WebKitLegacy" } 0..$#projects;
 diff --git a/Tools/WebKitTestRunner/PlatformGTK.cmake b/Tools/WebKitTestRunner/PlatformGTK.cmake
-index 6f8366b63e43..cc8299dfa438 100644
+index 6f8366b63e43eca6b95b67bb47fee9e7a1970cf9..cc8299dfa4380b833e79a870779a222059579d3b 100644
 --- a/Tools/WebKitTestRunner/PlatformGTK.cmake
 +++ b/Tools/WebKitTestRunner/PlatformGTK.cmake
 @@ -26,6 +26,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
@@ -21097,7 +21427,7 @@ index 6f8366b63e43..cc8299dfa438 100644
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
 diff --git a/Tools/WebKitTestRunner/PlatformWPE.cmake b/Tools/WebKitTestRunner/PlatformWPE.cmake
-index 775b41868718..68a720c0cb01 100644
+index 775b41868718ea6734efc9082f8161eee2e0015e..68a720c0cb01d534653a259536c481683873680d 100644
 --- a/Tools/WebKitTestRunner/PlatformWPE.cmake
 +++ b/Tools/WebKitTestRunner/PlatformWPE.cmake
 @@ -31,6 +31,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
@@ -21109,7 +21439,7 @@ index 775b41868718..68a720c0cb01 100644
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
 diff --git a/Tools/WebKitTestRunner/TestController.cpp b/Tools/WebKitTestRunner/TestController.cpp
-index cfc9c4483c82..a14886f89ce6 100644
+index cfc9c4483c825d913ed27a4d55884f242d76f002..a14886f89ce62981006517ef528481ab2c9ff116 100644
 --- a/Tools/WebKitTestRunner/TestController.cpp
 +++ b/Tools/WebKitTestRunner/TestController.cpp
 @@ -787,6 +787,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
@@ -21121,7 +21451,7 @@ index cfc9c4483c82..a14886f89ce6 100644
          decidePolicyForMediaKeySystemPermissionRequest
      };
 diff --git a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
-index 296c902f375b..45d8ca4bdd18 100644
+index 296c902f375b1189f45ee56bb3ffd4d826dd26f6..45d8ca4bdd18e2467b26b0c6998b4dc58dde7634 100644
 --- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
 +++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
 @@ -977,4 +977,51 @@ void EventSenderProxy::scaleGestureEnd(double scale)
@@ -21177,7 +21507,7 @@ index 296c902f375b..45d8ca4bdd18 100644
 +
  } // namespace WTR
 diff --git a/Tools/gtk/install-dependencies b/Tools/gtk/install-dependencies
-index 46388b47a0f4..d42933e66178 100755
+index 46388b47a0f433fbdae3874a958fb2d207916c45..d42933e66178ff007a5008dc807483c4896ea5e1 100755
 --- a/Tools/gtk/install-dependencies
 +++ b/Tools/gtk/install-dependencies
 @@ -120,6 +120,7 @@ function installDependenciesWithApt {
@@ -21205,7 +21535,7 @@ index 46388b47a0f4..d42933e66178 100755
          xfonts-utils"
  
 diff --git a/Tools/win/DLLLauncher/DLLLauncherMain.cpp b/Tools/win/DLLLauncher/DLLLauncherMain.cpp
-index 52605867b930..6edf24ab6024 100644
+index 52605867b9302d1afcc56c5e9b0c54acf0827900..6edf24ab60249241ba2969531ef55f4b495dce9e 100644
 --- a/Tools/win/DLLLauncher/DLLLauncherMain.cpp
 +++ b/Tools/win/DLLLauncher/DLLLauncherMain.cpp
 @@ -99,11 +99,9 @@ static bool prependPath(const std::wstring& directoryToPrepend)
@@ -21223,7 +21553,7 @@ index 52605867b930..6edf24ab6024 100644
  }
  
 diff --git a/Tools/wpe/backends/HeadlessViewBackend.cpp b/Tools/wpe/backends/HeadlessViewBackend.cpp
-index c09b6f39f894..bc21acb64856 100644
+index c09b6f39f894943f11b7a453428fab7d6f6e68fb..bc21acb648562ee0380811599b08f7d26c3e706a 100644
 --- a/Tools/wpe/backends/HeadlessViewBackend.cpp
 +++ b/Tools/wpe/backends/HeadlessViewBackend.cpp
 @@ -145,27 +145,24 @@ void HeadlessViewBackend::updateSnapshot(struct wpe_fdo_shm_exported_buffer* exp
@@ -21278,7 +21608,7 @@ index c09b6f39f894..bc21acb64856 100644
      static cairo_user_data_key_t bufferKey;
      cairo_surface_set_user_data(m_snapshot, &bufferKey, buffer,
 diff --git a/Tools/wpe/install-dependencies b/Tools/wpe/install-dependencies
-index 6bc2db3024aa..09774119a487 100755
+index 6bc2db3024aa3466200f70d20b425227215b6a43..09774119a487ffc4df80ae6f49dd4f31c4021a70 100755
 --- a/Tools/wpe/install-dependencies
 +++ b/Tools/wpe/install-dependencies
 @@ -78,6 +78,7 @@ function installDependenciesWithApt {


### PR DESCRIPTION
When response interception is enabled `CachedResource` is not created until response is fulflilled/resumed so normal mechanism employed by `Network.getResponseBody` will not work until interception is finished. To overcome that we now intercept `didReceiveData` messages, stash received data inside network agent and use it if `getInterceptedResponseBody` is called. Since response body data is sent asynchronously from the network to the we process after `didReceiveResponse`, the command handler will wait until request is finished loading (either successfully or with an error) to ensure that all data have been received.

~https://github.com/yury-s/webkit/commit/fda6465f0e220e6146c1e2ed52a59a2d366f539e~
https://github.com/yury-s/webkit/commit/bf6e61a88d4326a500fb4efee0cb07b66a069014

#1774