### PR TITLE
test: added tests for WebSocket over Socks proxy

### DIFF
--- a/docs/src/assertions.md
+++ b/docs/src/assertions.md
@@ -265,7 +265,7 @@ expect(userId).toBeTruthy();
 
 // Assert value for input element
 await page.waitForSelector('#search');
-const value = await page.$eval('#search', el => el.value);
+const value = await page.inputValue('#search');
 expect(value === 'query').toBeTruthy();
 
 // Assert computed style

--- a/src/server/firefox/ffNetworkManager.ts
+++ b/src/server/firefox/ffNetworkManager.ts
@@ -94,7 +94,9 @@ export class FFNetworkManager {
         ipAddress: event.remoteIPAddress,
         port: event.remotePort,
       });
-    } else {response._serverAddrFinished();}
+    } else {
+      response._serverAddrFinished();
+    }
     response._securityDetailsFinished({
       protocol: event?.securityDetails?.protocol,
       subjectName: event?.securityDetails?.subjectName,

--- a/tests/config/baseTest.ts
+++ b/tests/config/baseTest.ts
@@ -135,7 +135,7 @@ type ServerFixtures = {
   asset: (p: string) => string;
 };
 
-type ServersInternal = ServerFixtures & { socksServer: any };
+type ServersInternal = ServerFixtures & { socksServer: socks.SocksServer };
 const serverFixtures: Fixtures<ServerFixtures, ServerOptions & { __servers: ServersInternal }> = {
   loopback: [ undefined, { scope: 'worker' } ],
   __servers: [ async ({ loopback }, run, workerInfo) => {
@@ -151,8 +151,8 @@ const serverFixtures: Fixtures<ServerFixtures, ServerOptions & { __servers: Serv
     httpsServer.enableHTTPCache(cachedPath);
 
     const socksServer = socks.createServer((info, accept, deny) => {
-      let socket;
-      if ((socket = accept(true))) {
+      const socket = accept(true);
+      if (socket) {
         // Catch and ignore ECONNRESET errors.
         socket.on('error', () => {});
         const body = '<html><title>Served by the SOCKS proxy</title></html>';

--- a/tests/index.d.ts
+++ b/tests/index.d.ts
@@ -1,0 +1,26 @@
+declare module 'socksv5' {
+    import type net from 'net';
+
+    class Auth { }
+
+    class SocksServer {
+        listen: net.Server['listen'];
+        useAuth(auth: Auth): void;
+        close: net.Server['close'];
+    }
+
+    type Info = {
+        srcAddr: string;
+        srcPort: number;
+        dstAddr: string;
+        dstPort: number;
+    }
+
+    function acceptHandler(intercept: true): net.Socket | undefined;
+    function acceptHandler(intercept: false): undefined;
+    export function createServer(cb: (info: Info, accept: typeof acceptHandler, deny: () => void) => void): SocksServer;
+
+    export const auth: {
+        None: () => Auth
+    };
+}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -9,5 +9,5 @@
         "strictBindCallApply": true,
         "allowSyntheticDefaultImports": true,
     },
-    "include": ["**/*.spec.js", "**/*.ts"]
+    "include": ["**/*.spec.js", "**/*.ts", "index.d.ts"]
 }


### PR DESCRIPTION
WebKit WebSocket proxy on Mac seems to work when its configured as a system proxy so there is a high chance that its easily fixable on our side.