### PR TITLE
chore: improve connectOverCDP error handling

### DIFF
--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -229,6 +229,9 @@ async function urlToWSEndpoint(endpointURL: string) {
   const httpURL = endpointURL.endsWith('/') ? `${endpointURL}json/version/` : `${endpointURL}/json/version/`;
   const json = await new Promise<string>((resolve, reject) => {
     http.get(httpURL, resp => {
+      if (resp.statusCode! < 200 || resp.statusCode! >= 400)
+        reject(new Error(`Unexpected status ${resp.statusCode} when connecting to ${httpURL}.\n` +
+        `This does not look like a DevTools server, try connecting via ws://.`));
       let data = '';
       resp.on('data', chunk => data += chunk);
       resp.on('end', () => resolve(data));

--- a/tests/chromium/chromium.spec.ts
+++ b/tests/chromium/chromium.spec.ts
@@ -308,3 +308,26 @@ playwrightTest('should return valid browser from context.browser()', async ({ br
     await browserServer.close();
   }
 });
+
+test('should report an expected error when the endpointURL returns a non-expected status code', async ({ browserType, server }) => {
+  server.setRoute('/json/version/', (req, resp) => {
+    resp.statusCode = 404;
+    resp.end(JSON.stringify({
+      webSocketDebuggerUrl: 'dont-use-me',
+    }));
+  });
+  await expect(browserType.connectOverCDP({
+    endpointURL: server.PREFIX,
+  })).rejects.toThrowError(`browserType.connectOverCDP: Unexpected status 404 when connecting to ${server.PREFIX}/json/version/`)
+});
+
+test('should report an expected error when the endpoint URL JSON webSocketDebuggerUrl is undefined', async ({ browserType, server }) => {
+  server.setRoute('/json/version/', (req, resp) => {
+    resp.end(JSON.stringify({
+      webSocketDebuggerUrl: undefined,
+    }));
+  });
+  await expect(browserType.connectOverCDP({
+    endpointURL: server.PREFIX,
+  })).rejects.toThrowError('browserType.connectOverCDP: Invalid URL');
+});


### PR DESCRIPTION
Relates #7094

See also #7238 for the second test.