### PR TITLE
fix(driver): fix compatibility when folder contains space

### DIFF
--- a/utils/build/run-driver-posix.sh
+++ b/utils/build/run-driver-posix.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 SCRIPT_PATH="$(cd "$(dirname "$0")" ; pwd -P)"
-$SCRIPT_PATH/node $SCRIPT_PATH/package/lib/cli/cli.js "$@"
+"$SCRIPT_PATH/node" "$SCRIPT_PATH/package/lib/cli/cli.js" "$@"


### PR DESCRIPTION
Tested on macOS to verify it works.

Fixes https://github.com/microsoft/playwright-python/issues/766