### PR TITLE
docs(test-reporters.md): fix missing reporter key config

### DIFF
--- a/docs/src/test-reporters.md
+++ b/docs/src/test-reporters.md
@@ -53,6 +53,7 @@ module.exports = {
 import { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
+  reporter: !process.env.CI
     // Default 'list' reporter for the terminal
     ? 'list'
     // Two reporters for CI:


### PR DESCRIPTION
* As of now the current doc is render like below which is missing `reporter` key.
	  
  ```ts
	  // playwright.config.ts
	  import { PlaywrightTestConfig } from '@playwright/test';
	  
	  const config: PlaywrightTestConfig = {
	      // Default 'list' reporter for the terminal
	      ? 'list'
	      // Two reporters for CI:
	      // - concise "dot"
	      // - comprehensive json report
	      : [ ['dot'], [ 'json', {  outputFile: 'test-results.json' }] ],
	  };
	  export default config;
  ```
* Doc url: https://playwright.dev/docs/test-reporters/#using-reporters

