### PR TITLE
fix(test runner): properly keep track of requireFile to support helpers/wrappers

### DIFF
--- a/src/test/dispatcher.ts
+++ b/src/test/dispatcher.ts
@@ -82,7 +82,7 @@ export class Dispatcher {
   _filesSortedByWorkerHash(): DispatcherEntry[] {
     const entriesByWorkerHashAndFile = new Map<string, Map<string, DispatcherEntry>>();
     for (const fileSuite of this._suite.suites) {
-      const file = fileSuite.file;
+      const file = fileSuite._requireFile;
       for (const spec of fileSuite._allSpecs()) {
         for (const test of spec.tests) {
           let entriesByFile = entriesByWorkerHashAndFile.get(test._workerHash);

--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -117,6 +117,7 @@ export class Loader {
     const revertBabelRequire = installTransform();
     try {
       const suite = new Suite('');
+      suite._requireFile = file;
       suite.file = file;
       setCurrentlyLoadingFileSuite(suite);
       require(file);

--- a/src/test/project.ts
+++ b/src/test/project.ts
@@ -90,7 +90,7 @@ export class ProjectImpl {
       test._repeatEachIndex = i;
       test._projectIndex = this.index;
       test._workerHash = `run${this.index}-${digest}-repeat${i}`;
-      test._id = `${spec._ordinalInFile}@${spec.file}#run${this.index}-repeat${i}`;
+      test._id = `${spec._ordinalInFile}@${spec._requireFile}#run${this.index}-repeat${i}`;
       spec.tests.push(test);
       tests.push(test);
     }

--- a/src/test/runner.ts
+++ b/src/test/runner.ts
@@ -165,7 +165,7 @@ export class Runner {
 
       const fileSuites = new Map<string, Suite>();
       for (const fileSuite of rootSuite.suites)
-        fileSuites.set(fileSuite.file, fileSuite);
+        fileSuites.set(fileSuite._requireFile, fileSuite);
 
       const outputDirs = new Set<string>();
       const grepMatcher = createMatcher(config.grep);
@@ -209,7 +209,7 @@ export class Runner {
       if (process.stdout.isTTY) {
         const workers = new Set();
         rootSuite.findTest(test => {
-          workers.add(test.spec.file + test._workerHash);
+          workers.add(test.spec._requireFile + test._workerHash);
         });
         console.log();
         const jobs = Math.min(config.workers, workers.size);

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -26,6 +26,7 @@ class Base {
   parent?: Suite;
 
   _only = false;
+  _requireFile: string = '';
 
   constructor(title: string) {
     this.title = title;

--- a/src/test/testType.ts
+++ b/src/test/testType.ts
@@ -63,10 +63,11 @@ export class TestTypeImpl {
       throw errorWithCallLocation(`test() can only be called in a test file`);
     const location = callLocation(suite.file);
 
-    const ordinalInFile = countByFile.get(suite.file) || 0;
-    countByFile.set(location.file, ordinalInFile + 1);
+    const ordinalInFile = countByFile.get(suite._requireFile) || 0;
+    countByFile.set(suite._requireFile, ordinalInFile + 1);
 
     const spec = new Spec(title, fn, ordinalInFile, this);
+    spec._requireFile = suite._requireFile;
     spec.file = location.file;
     spec.line = location.line;
     spec.column = location.column;
@@ -83,7 +84,8 @@ export class TestTypeImpl {
     const location = callLocation(suite.file);
 
     const child = new Suite(title);
-    child.file = suite.file;
+    child._requireFile = suite._requireFile;
+    child.file = location.file;
     child.line = location.line;
     child.column = location.column;
     suite._addSuite(child);

--- a/src/test/workerRunner.ts
+++ b/src/test/workerRunner.ts
@@ -184,7 +184,7 @@ export class WorkerRunner extends EventEmitter {
     const testId = test._id;
 
     const baseOutputDir = (() => {
-      const relativeTestFilePath = path.relative(this._project.config.testDir, spec.file.replace(/\.(spec|test)\.(js|ts)/, ''));
+      const relativeTestFilePath = path.relative(this._project.config.testDir, spec._requireFile.replace(/\.(spec|test)\.(js|ts)/, ''));
       const sanitizedRelativePath = relativeTestFilePath.replace(process.platform === 'win32' ? new RegExp('\\\\', 'g') : new RegExp('/', 'g'), '-');
       let testOutputDir = sanitizedRelativePath + '-' + sanitizeForFilePath(spec.title);
       if (this._uniqueProjectNamePathSegment)
@@ -231,7 +231,7 @@ export class WorkerRunner extends EventEmitter {
           else
             snapshotName += suffix;
         }
-        return path.join(spec.file + '-snapshots', snapshotName);
+        return path.join(spec._requireFile + '-snapshots', snapshotName);
       },
       skip: (...args: [arg?: any, description?: string]) => modifier(testInfo, 'skip', args),
       fixme: (...args: [arg?: any, description?: string]) => modifier(testInfo, 'fixme', args),


### PR DESCRIPTION
This fixes an issue where we incorrectly labeled and assigned ids for tests that declared tests in require'd files or used test wrappers.
See new tests for examples.