### PR TITLE
test: skip some failing request interception tests for current Chrome stable

### DIFF
--- a/tests/page/page-request-intercept.spec.ts
+++ b/tests/page/page-request-intercept.spec.ts
@@ -57,8 +57,9 @@ it('should throw on continue after intercept', async ({page, server, browserName
   }
 });
 
-it('should support fulfill after intercept', async ({page, server, browserName}) => {
+it('should support fulfill after intercept', async ({page, server, browserName, browserMajorVersion}) => {
   it.fixme(browserName === 'firefox');
+  it.skip(browserName === 'chromium' && browserMajorVersion <= 91);
   const requestPromise = server.waitForRequest('/empty.html');
   await page.route('**', async route => {
     await route.intercept();
@@ -70,8 +71,9 @@ it('should support fulfill after intercept', async ({page, server, browserName})
 });
 
 
-it('should support request overrides', async ({page, server, browserName}) => {
+it('should support request overrides', async ({page, server, browserName, browserMajorVersion}) => {
   it.fixme(browserName === 'firefox');
+  it.skip(browserName === 'chromium' && browserMajorVersion <= 91);
   const requestPromise = server.waitForRequest('/empty.html');
   await page.route('**/foo', async route => {
     await route.intercept({


### PR DESCRIPTION
Some tests are currently failing Chrome/Edge stable and Electron:

- page/page-request-intercept.spec.ts:60:1 › [chromium] should support fulfill after intercept
- page/page-request-intercept.spec.ts:73:1 › [chromium] should support request overrides

Was introduced in #7122. This change should give us again full green bots.