### PR TITLE
fix(test-runner): support ANSII terminals with list reporter

### DIFF
--- a/src/test/reporters/list.ts
+++ b/src/test/reporters/list.ts
@@ -20,6 +20,11 @@ import milliseconds from 'ms';
 import { BaseReporter, formatTestTitle } from './base';
 import { FullConfig, Suite, Test, TestResult } from '../reporter';
 
+// Allow it in the Visual Studio Code Terminal and the new Windows Terminal
+const DOES_NOT_SUPPORT_UTF8_IN_TERMINAL = process.platform === 'win32' && process.env.TERM_PROGRAM !== 'vscode' && !process.env.WT_SESSION;
+const POSITIVE_STATUS_MARK = DOES_NOT_SUPPORT_UTF8_IN_TERMINAL ? 'ok' : '✓';
+const NEGATIVE_STATUS_MARK = DOES_NOT_SUPPORT_UTF8_IN_TERMINAL ? 'x' : '✘';
+
 class ListReporter extends BaseReporter {
   private _failure = 0;
   private _lastRow = 0;
@@ -73,7 +78,7 @@ class ListReporter extends BaseReporter {
     if (result.status === 'skipped') {
       text = colors.green('  - ') + colors.cyan(title);
     } else {
-      const statusMark = result.status === 'passed' ? '  ✓ ' : '  x ';
+      const statusMark = ('  ' + (result.status === 'passed' ? POSITIVE_STATUS_MARK : NEGATIVE_STATUS_MARK)).padEnd(5);
       if (result.status === test.expectedStatus)
         text = '\u001b[2K\u001b[0G' + colors.green(statusMark) + colors.gray(title) + duration;
       else

--- a/tests/playwright-test/list-reporter.spec.ts
+++ b/tests/playwright-test/list-reporter.spec.ts
@@ -35,9 +35,11 @@ test('render each test with project name', async ({ runInlineTest }) => {
     `,
   }, { reporter: 'list' });
   const text = stripAscii(result.output);
-  expect(text).toContain('a.test.ts:6:7 › [foo] fails');
-  expect(text).toContain('a.test.ts:6:7 › [bar] fails');
-  expect(text).toContain('a.test.ts:9:7 › [foo] passes');
-  expect(text).toContain('a.test.ts:9:7 › [bar] passes');
+  const positiveStatusMarkPrefix = process.platform === 'win32' ? 'ok' : '✓ ';
+  const negativateStatusMarkPrefix = process.platform === 'win32' ? 'x ' : '✘ ';
+  expect(text).toContain(`${negativateStatusMarkPrefix} 1) a.test.ts:6:7 › [foo] fails`);
+  expect(text).toContain(`${negativateStatusMarkPrefix} 2) a.test.ts:6:7 › [bar] fails`);
+  expect(text).toContain(`${positiveStatusMarkPrefix} a.test.ts:9:7 › [foo] passes`);
+  expect(text).toContain(`${positiveStatusMarkPrefix} a.test.ts:9:7 › [bar] passes`);
   expect(result.exitCode).toBe(1);
 });


### PR DESCRIPTION
Tested with PowerShell, the Command Prompt, the new Windows Terminal and Visual Studio Code.

Fixes #7177.