### PR TITLE
docs(dotnet): fixed broken code snippets which contained Java

### DIFF
--- a/docs/src/cheat-sheet.md
+++ b/docs/src/cheat-sheet.md
@@ -126,7 +126,7 @@ await page.SetInputFilesAsync("input#upload", new FilePayload
 {
     Name = "file.txt",
     MimeType = "text/plain",
-    Buffer = "this is a test".getBytes(StandardCharsets.UTF_8),
+    Buffer = System.Text.Encoding.UTF8.GetBytes("this is a test"),
 });
 ```
 

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -713,7 +713,7 @@ await page.SetInputFilesAsync("input#upload", new FilePayload
 {
     Name = "file.txt",
     MimeType = "text/plain",
-    Buffer = "this is a test".getBytes(StandardCharsets.UTF_8),
+    Buffer = System.Text.Encoding.UTF8.GetBytes("this is a test"),
 });
 ```
 


### PR DESCRIPTION
Use the appropriate .NET API for converting a string to bytes in the code snippets for file uploads.
