### PR TITLE
docs(python): fixed broken snippet in assertions.md

### DIFF
--- a/docs/src/assertions.md
+++ b/docs/src/assertions.md
@@ -88,7 +88,7 @@ assert alt == "Text"
 ```
 
 ```python sync
-checked = page.get_attribute("input", "alt")
+alt = page.get_attribute("input", "alt")
 assert alt == "Text"
 ```
 

--- a/docs/src/assertions.md
+++ b/docs/src/assertions.md
@@ -83,7 +83,7 @@ assertEquals("Text", alt);
 ```
 
 ```python async
-checked = await page.get_attribute("input", "alt")
+alt = await page.get_attribute("input", "alt")
 assert alt == "Text"
 ```
 


### PR DESCRIPTION
alt variable names incorrectly in python docs