### PR TITLE
chore hide Download._cancel

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,3 +15,4 @@ browser_patches/*/checkout/
 browser_patches/chromium/output/
 **/*.d.ts
 output/
+/test-results/

--- a/docs/src/api/class-download.md
+++ b/docs/src/api/class-download.md
@@ -62,14 +62,6 @@ downloaded content. If [`option: acceptDownloads`] is not set, download events a
 not performed and user has no access to the downloaded files.
 :::
 
-## async method: Download._cancel
-
-**Chromium-only** Cancels a download.
-Will not fail if the download is already finished or canceled.
-Upon successful cancellations, `download.failure()` would resolve to `'canceled'`.
-
-Currently **experimental** and may subject to further changes.
-
 ## async method: Download.createReadStream
 * langs: java, js, csharp
 - returns: <[null]|[Readable]>

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -481,7 +481,7 @@ it.describe('download event', () => {
       page.waitForEvent('download'),
       page.click('a')
     ]);
-    await download._cancel();
+    await (download as any)._cancel();
     const failure = await download.failure();
     expect(failure).toBe('canceled');
     await page.close();
@@ -500,7 +500,7 @@ it.describe('download event', () => {
     const path = await download.path();
     expect(fs.existsSync(path)).toBeTruthy();
     expect(fs.readFileSync(path).toString()).toBe('Hello world');
-    await download._cancel();
+    await (download as any)._cancel();
     const failure = await download.failure();
     expect(failure).toBe(null);
     await page.close();

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -9480,14 +9480,6 @@ export interface Dialog {
  */
 export interface Download {
   /**
-   * **Chromium-only** Cancels a download. Will not fail if the download is already finished or canceled. Upon successful
-   * cancellations, `download.failure()` would resolve to `'canceled'`.
-   *
-   * Currently **experimental** and may subject to further changes.
-   */
-  _cancel(): Promise<void>;
-
-  /**
    * Returns readable stream for current download or `null` if download failed.
    */
   createReadStream(): Promise<null|Readable>;

--- a/utils/doclint/missingDocs.js
+++ b/utils/doclint/missingDocs.js
@@ -78,9 +78,6 @@ function paramsForMember(member) {
   return new Set(member.argsArray.map(a => a.alias));
 }
 
-// Including experimental method names (with a leading underscore) that would be otherwise skipped
-const allowExperimentalMethods = new Set([ 'Download._cancel' ]);
-
 /**
  * @param {string[]} rootNames
  */
@@ -117,8 +114,6 @@ function listMethods(rootNames, apiFileName) {
    * @param {string} methodName
    */
   function shouldSkipMethodByName(className, methodName) {
-    if (allowExperimentalMethods.has(`${className}.${methodName}`))
-      return false;
     if (methodName.startsWith('_') || methodName === 'T' || methodName === 'toString')
       return true;
     if (/** @type {any} */(EventEmitter).prototype.hasOwnProperty(methodName))


### PR DESCRIPTION
Fixes #7279
Hides #6236 until we have implementations in Firefox and WebKit.

Created an issue to track the missing functionality in #7283.