### PR TITLE
fix(test-runner): default @playwright/test actions timeout to 0

### DIFF
--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -39,6 +39,7 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
       throw new Error(`Unexpected browserName "${browserName}", must be one of "chromium", "firefox" or "webkit"`);
     const options: LaunchOptions = {
       handleSIGINT: false,
+      timeout: 0,
       ...launchOptions,
     };
     if (headless !== undefined)
@@ -140,6 +141,7 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
       options.viewport = viewport;
 
     const context = await browser.newContext(options);
+    context.setDefaultTimeout(0);
     const allPages: Page[] = [];
     context.on('page', page => allPages.push(page));
 


### PR DESCRIPTION
All actions for the `@playwright/test` actions inside test should
have default 0 timeout. This way they will never clash with the
test timeout.