### PR TITLE
fix(test-runner): move OverriddenExpectProperties outside the namespace

### DIFF
--- a/types/testExpect.d.ts
+++ b/types/testExpect.d.ts
@@ -29,17 +29,18 @@ export declare type Expect = {
   stringMatching(expected: string | RegExp): AsymmetricMatcher;
 };
 
+type OverriddenExpectProperties = 
+'not' |
+'resolves' |
+'rejects' |
+'toMatchInlineSnapshot' |
+'toThrowErrorMatchingInlineSnapshot' |
+'toMatchSnapshot' | 
+'toThrowErrorMatchingSnapshot';
+
 declare global {
   export namespace PlaywrightTest {
-    type OverriddenProperties = 
-      'not' |
-      'resolves' |
-      'rejects' |
-      'toMatchInlineSnapshot' |
-      'toThrowErrorMatchingInlineSnapshot' |
-      'toMatchSnapshot' | 
-      'toThrowErrorMatchingSnapshot';
-    export interface Matchers<R> extends Omit<expect.Matchers<R>, OverriddenProperties> {
+    export interface Matchers<R> extends Omit<expect.Matchers<R>, OverriddenExpectProperties> {
       /**
        * If you know how to test something, `.not` lets you test its opposite.
        */


### PR DESCRIPTION
Otherwise it will yield to - we can't roll:

```
Error: tests/config/test-runner/node_modules/@playwright/test/types/testExpect.d.ts(34,10): error TS2300: Duplicate identifier 'OverriddenProperties'.
Error: types/testExpect.d.ts(34,10): error TS2300: Duplicate identifier 'OverriddenProperties'.
```

because we are polluting this namespace.