### PR TITLE
cherry-pick(release-1.12): have the proper default export (#7328)

### DIFF
--- a/packages/installation-tests/esm-playwright-test.mjs
+++ b/packages/installation-tests/esm-playwright-test.mjs
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import { chromium, firefox, webkit, selectors, devices, errors } from '@playwright/test';
-import playwright from '@playwright/test';
+import { chromium, firefox, webkit, selectors, devices, errors, test } from '@playwright/test';
+import * as playwright from '@playwright/test';
+import defaultExport from '@playwright/test';
 import errorsFile from '@playwright/test/lib/utils/errors.js';
-
 import testESM from './esm.mjs';
+if (defaultExport !== test)
+  process.exit(1);
 testESM({ chromium, firefox, webkit, selectors, devices, errors, playwright, errorsFile }, [chromium, firefox, webkit]);

--- a/packages/playwright-test/index.d.ts
+++ b/packages/playwright-test/index.d.ts
@@ -23,3 +23,4 @@ export const webkit: types.BrowserType;
 export const _electron: types.Electron;
 export const _android: types.Android;
 export * from './types/test';
+export { default } from './types/test';

--- a/packages/playwright-test/index.js
+++ b/packages/playwright-test/index.js
@@ -13,8 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-module.exports = {
-  ...require('./lib/inprocess'),
-  ...require('./lib/test/index')
+const pwt = require('./lib/test/index');
+const playwright = require('./lib/inprocess');
+const combinedExports = {
+  ...playwright,
+  ...pwt,
 };
+
+Object.defineProperty(combinedExports, '__esModule', { value: true });
+
+module.exports = combinedExports;

--- a/packages/playwright-test/index.mjs
+++ b/packages/playwright-test/index.mjs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import playwright from './index.js';
+import * as playwright from './index.js';
 
 export const chromium = playwright.chromium;
 export const firefox = playwright.firefox;
@@ -25,4 +25,4 @@ export const errors = playwright.errors;
 export const _electron = playwright._electron;
 export const _android = playwright._android;
 export const test = playwright.test;
-export default playwright;
+export default playwright.default;


### PR DESCRIPTION
There are 3 ways to import `@playwright/test` library in the modern Node.js ecosystem:
- Using `require`: works great, this patch doesn't change it
- Using `import` statement from `.mjs` file - we have wrong `default` for @playwright/test that should be a `test`. This is what test checks for
- Using `import test from '@playwright/test'` from `.ts` file - was broken because TypeScript thought it's a CJS module, whereas it's a ESM module in reality.

Also, typescript types import from `.d.ts` file was broken because we had no default export (`export *` syntax does not export default).
