### PR TITLE
feat(codegen): Add type annotations to Python output and make PEP8-compliant

### DIFF
--- a/src/server/supplements/recorder/python.ts
+++ b/src/server/supplements/recorder/python.ts
@@ -139,16 +139,19 @@ export class PythonLanguageGenerator implements LanguageGenerator {
     if (this._isAsync) {
       formatter.add(`
 import asyncio
-from playwright.async_api import async_playwright
 
-async def run(playwright) {
+from playwright.async_api import Playwright, async_playwright
+
+
+async def run(playwright: Playwright) -> None {
     browser = await playwright.${options.browserName}.launch(${formatOptions(options.launchOptions, false)})
     context = await browser.new_context(${formatContextOptions(options.contextOptions, options.deviceName)})`);
     } else {
       formatter.add(`
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import Playwright, sync_playwright
 
-def run(playwright) {
+
+def run(playwright: Playwright) -> None {
     browser = playwright.${options.browserName}.launch(${formatOptions(options.launchOptions, false)})
     context = browser.new_context(${formatContextOptions(options.contextOptions, options.deviceName)})`);
     }
@@ -162,18 +165,24 @@ def run(playwright) {
     await context.close()
     await browser.close()
 
-async def main():
+
+async def main() -> None:
     async with async_playwright() as playwright:
         await run(playwright)
-asyncio.run(main())`;
+
+
+asyncio.run(main())
+`;
     } else {
       const storageStateLine = saveStorage ? `\n    context.storage_state(path="${saveStorage}")` : '';
       return `\n    # ---------------------${storageStateLine}
     context.close()
     browser.close()
 
+
 with sync_playwright() as playwright:
-    run(playwright)`;
+    run(playwright)
+`;
     }
   }
 }

--- a/tests/inspector/cli-codegen-python-async.spec.ts
+++ b/tests/inspector/cli-codegen-python-async.spec.ts
@@ -26,9 +26,11 @@ const launchOptions = (channel: string) => {
 test('should print the correct imports and context options', async ({ browserName, channel, runCLI }) => {
   const cli = runCLI(['--target=python-async', emptyHTML]);
   const expectedResult = `import asyncio
-from playwright.async_api import async_playwright
 
-async def run(playwright):
+from playwright.async_api import Playwright, async_playwright
+
+
+async def run(playwright: Playwright) -> None:
     browser = await playwright.${browserName}.launch(${launchOptions(channel)})
     context = await browser.new_context()`;
   await cli.waitFor(expectedResult);
@@ -38,9 +40,11 @@ async def run(playwright):
 test('should print the correct context options for custom settings', async ({ browserName, channel, runCLI }) => {
   const cli = runCLI(['--color-scheme=light', '--target=python-async', emptyHTML]);
   const expectedResult = `import asyncio
-from playwright.async_api import async_playwright
 
-async def run(playwright):
+from playwright.async_api import Playwright, async_playwright
+
+
+async def run(playwright: Playwright) -> None:
     browser = await playwright.${browserName}.launch(${launchOptions(channel)})
     context = await browser.new_context(color_scheme="light")`;
   await cli.waitFor(expectedResult);
@@ -52,9 +56,11 @@ test('should print the correct context options when using a device', async ({ br
 
   const cli = runCLI(['--device=Pixel 2', '--target=python-async', emptyHTML]);
   const expectedResult = `import asyncio
-from playwright.async_api import async_playwright
 
-async def run(playwright):
+from playwright.async_api import Playwright, async_playwright
+
+
+async def run(playwright: Playwright) -> None:
     browser = await playwright.chromium.launch(${launchOptions(channel)})
     context = await browser.new_context(**playwright.devices["Pixel 2"])`;
   await cli.waitFor(expectedResult);
@@ -66,9 +72,11 @@ test('should print the correct context options when using a device and additiona
 
   const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', '--target=python-async', emptyHTML]);
   const expectedResult = `import asyncio
-from playwright.async_api import async_playwright
 
-async def run(playwright):
+from playwright.async_api import Playwright, async_playwright
+
+
+async def run(playwright: Playwright) -> None:
     browser = await playwright.webkit.launch(${launchOptions(channel)})
     context = await browser.new_context(**playwright.devices["iPhone 11"], color_scheme="light")`;
   await cli.waitFor(expectedResult);
@@ -81,9 +89,11 @@ test('should save the codegen output to a file if specified', async ({ browserNa
   await cli.exited;
   const content = await fs.readFileSync(tmpFile);
   expect(content.toString()).toBe(`import asyncio
-from playwright.async_api import async_playwright
 
-async def run(playwright):
+from playwright.async_api import Playwright, async_playwright
+
+
+async def run(playwright: Playwright) -> None:
     browser = await playwright.${browserName}.launch(${launchOptions(channel)})
     context = await browser.new_context()
 
@@ -100,10 +110,14 @@ async def run(playwright):
     await context.close()
     await browser.close()
 
-async def main():
+
+async def main() -> None:
     async with async_playwright() as playwright:
         await run(playwright)
-asyncio.run(main())`);
+
+
+asyncio.run(main())
+`);
 });
 
 test('should print load/save storage_state', async ({ browserName, channel, runCLI }, testInfo) => {
@@ -112,9 +126,11 @@ test('should print load/save storage_state', async ({ browserName, channel, runC
   await fs.promises.writeFile(loadFileName, JSON.stringify({ cookies: [], origins: [] }), 'utf8');
   const cli = runCLI([`--load-storage=${loadFileName}`, `--save-storage=${saveFileName}`, '--target=python-async', emptyHTML]);
   const expectedResult1 = `import asyncio
-from playwright.async_api import async_playwright
 
-async def run(playwright):
+from playwright.async_api import Playwright, async_playwright
+
+
+async def run(playwright: Playwright) -> None:
     browser = await playwright.${browserName}.launch(${launchOptions(channel)})
     context = await browser.new_context(storage_state="${loadFileName}")`;
   await cli.waitFor(expectedResult1);
@@ -125,9 +141,13 @@ async def run(playwright):
     await context.close()
     await browser.close()
 
-async def main():
+
+async def main() -> None:
     async with async_playwright() as playwright:
         await run(playwright)
-asyncio.run(main())`;
+
+
+asyncio.run(main())
+`;
   await cli.waitFor(expectedResult2);
 });

--- a/tests/inspector/cli-codegen-python.spec.ts
+++ b/tests/inspector/cli-codegen-python.spec.ts
@@ -25,9 +25,10 @@ const launchOptions = (channel: string) => {
 
 test('should print the correct imports and context options', async ({ runCLI, channel, browserName }) => {
   const cli = runCLI(['--target=python', emptyHTML]);
-  const expectedResult = `from playwright.sync_api import sync_playwright
+  const expectedResult = `from playwright.sync_api import Playwright, sync_playwright
 
-def run(playwright):
+
+def run(playwright: Playwright) -> None:
     browser = playwright.${browserName}.launch(${launchOptions(channel)})
     context = browser.new_context()`;
   await cli.waitFor(expectedResult);
@@ -36,9 +37,10 @@ def run(playwright):
 
 test('should print the correct context options for custom settings', async ({ runCLI, channel, browserName }) => {
   const cli = runCLI(['--color-scheme=light', '--target=python', emptyHTML]);
-  const expectedResult = `from playwright.sync_api import sync_playwright
+  const expectedResult = `from playwright.sync_api import Playwright, sync_playwright
 
-def run(playwright):
+
+def run(playwright: Playwright) -> None:
     browser = playwright.${browserName}.launch(${launchOptions(channel)})
     context = browser.new_context(color_scheme="light")`;
   await cli.waitFor(expectedResult);
@@ -49,9 +51,10 @@ test('should print the correct context options when using a device', async ({ br
   test.skip(browserName !== 'chromium');
 
   const cli = runCLI(['--device=Pixel 2', '--target=python', emptyHTML]);
-  const expectedResult = `from playwright.sync_api import sync_playwright
+  const expectedResult = `from playwright.sync_api import Playwright, sync_playwright
 
-def run(playwright):
+
+def run(playwright: Playwright) -> None:
     browser = playwright.chromium.launch(${launchOptions(channel)})
     context = browser.new_context(**playwright.devices["Pixel 2"])`;
   await cli.waitFor(expectedResult);
@@ -62,9 +65,10 @@ test('should print the correct context options when using a device and additiona
   test.skip(browserName !== 'webkit');
 
   const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', '--target=python', emptyHTML]);
-  const expectedResult = `from playwright.sync_api import sync_playwright
+  const expectedResult = `from playwright.sync_api import Playwright, sync_playwright
 
-def run(playwright):
+
+def run(playwright: Playwright) -> None:
     browser = playwright.webkit.launch(${launchOptions(channel)})
     context = browser.new_context(**playwright.devices["iPhone 11"], color_scheme="light")`;
   await cli.waitFor(expectedResult);
@@ -76,9 +80,10 @@ test('should save the codegen output to a file if specified', async ({ runCLI, c
   const cli = runCLI(['--target=python', '--output', tmpFile, emptyHTML]);
   await cli.exited;
   const content = fs.readFileSync(tmpFile);
-  expect(content.toString()).toBe(`from playwright.sync_api import sync_playwright
+  expect(content.toString()).toBe(`from playwright.sync_api import Playwright, sync_playwright
 
-def run(playwright):
+
+def run(playwright: Playwright) -> None:
     browser = playwright.${browserName}.launch(${launchOptions(channel)})
     context = browser.new_context()
 
@@ -95,8 +100,10 @@ def run(playwright):
     context.close()
     browser.close()
 
+
 with sync_playwright() as playwright:
-    run(playwright)`);
+    run(playwright)
+`);
 });
 
 test('should print load/save storage_state', async ({ runCLI, channel, browserName }, testInfo) => {
@@ -104,9 +111,10 @@ test('should print load/save storage_state', async ({ runCLI, channel, browserNa
   const saveFileName = testInfo.outputPath('save.json');
   await fs.promises.writeFile(loadFileName, JSON.stringify({ cookies: [], origins: [] }), 'utf8');
   const cli = runCLI([`--load-storage=${loadFileName}`, `--save-storage=${saveFileName}`, '--target=python', emptyHTML]);
-  const expectedResult1 = `from playwright.sync_api import sync_playwright
+  const expectedResult1 = `from playwright.sync_api import Playwright, sync_playwright
 
-def run(playwright):
+
+def run(playwright: Playwright) -> None:
     browser = playwright.${browserName}.launch(${launchOptions(channel)})
     context = browser.new_context(storage_state="${loadFileName}")`;
   await cli.waitFor(expectedResult1);
@@ -117,7 +125,9 @@ def run(playwright):
     context.close()
     browser.close()
 
+
 with sync_playwright() as playwright:
-    run(playwright)`;
+    run(playwright)
+`;
   await cli.waitFor(expectedResult2);
 });


### PR DESCRIPTION
This adds type annotations to Python output, make PEP8-compliant (e.g. 2 spaces before function, newline at end) and sort imports.

Resolves https://github.com/microsoft/playwright-python/issues/773