### PR TITLE
fix(test-runner): handle negated toMatchSnapshot result

### DIFF
--- a/src/test/expect.ts
+++ b/src/test/expect.ts
@@ -21,7 +21,7 @@ import { compare } from './golden';
 
 export const expect: Expect = expectLibrary;
 
-function toMatchSnapshot(received: Buffer | string, nameOrOptions: string | { name: string, threshold?: number }, optOptions: { threshold?: number } = {}) {
+function toMatchSnapshot(this: ReturnType<Expect['getState']>, received: Buffer | string, nameOrOptions: string | { name: string, threshold?: number }, optOptions: { threshold?: number } = {}) {
   let options: { name: string, threshold?: number };
   const testInfo = currentTestInfo();
   if (!testInfo)
@@ -37,7 +37,16 @@ function toMatchSnapshot(received: Buffer | string, nameOrOptions: string | { na
   if (options.threshold === undefined && projectThreshold !== undefined)
     options.threshold = projectThreshold;
 
-  const { pass, message } = compare(received, options.name, testInfo.snapshotPath, testInfo.outputPath, testInfo.config.updateSnapshots, options);
+  const withNegateComparison = this.isNot;
+  const { pass, message } = compare(
+      received,
+      options.name,
+      testInfo.snapshotPath,
+      testInfo.outputPath,
+      testInfo.config.updateSnapshots,
+      withNegateComparison,
+      options
+  );
   return { pass, message: () => message };
 }
 

--- a/src/test/golden.ts
+++ b/src/test/golden.ts
@@ -138,7 +138,13 @@ export function compare(
     return { pass: true };
   }
 
-  if (updateSnapshots === 'all' && !withNegateComparison) {
+  if (withNegateComparison) {
+    return {
+      pass: false,
+    };
+  }
+
+  if (updateSnapshots === 'all') {
     fs.mkdirSync(path.dirname(snapshotFile), { recursive: true });
     fs.writeFileSync(snapshotFile, actual);
     console.log(snapshotFile + ' does not match, writing actual.');
@@ -156,12 +162,6 @@ export function compare(
   fs.writeFileSync(actualPath, actual);
   if (result.diff)
     fs.writeFileSync(diffPath, result.diff);
-
-  if (withNegateComparison) {
-    return {
-      pass: false,
-    };
-  }
 
   const output = [
     colors.red(`Snapshot comparison failed:`),

--- a/src/test/golden.ts
+++ b/src/test/golden.ts
@@ -61,7 +61,7 @@ function compareImages(actualBuffer: Buffer | string, expectedBuffer: Buffer, mi
       errorMessage: `Sizes differ; expected image ${expected.width}px X ${expected.height}px, but got ${actual.width}px X ${actual.height}px. `
     };
   }
-  const diff = new PNG({width: expected.width, height: expected.height});
+  const diff = new PNG({ width: expected.width, height: expected.height });
   const count = pixelmatch(expected.data, actual.data, diff.data, expected.width, expected.height, { threshold: 0.2, ...options });
   return count > 0 ? { diff: PNG.sync.write(diff) } : null;
 }
@@ -80,8 +80,17 @@ function compareText(actual: Buffer | string, expectedBuffer: Buffer): { diff?: 
   };
 }
 
-export function compare(actual: Buffer | string, name: string, snapshotPath: (name: string) => string, outputPath: (name: string) => string, updateSnapshots: UpdateSnapshots, options?: { threshold?: number }): { pass: boolean; message?: string; } {
+export function compare(
+  actual: Buffer | string,
+  name: string,
+  snapshotPath: (name: string) => string,
+  outputPath: (name: string) => string,
+  updateSnapshots: UpdateSnapshots,
+  withNegateComparison: boolean,
+  options?: { threshold?: number }
+): { pass: boolean; message?: string; } {
   const snapshotFile = snapshotPath(name);
+
   if (!fs.existsSync(snapshotFile)) {
     const writingActual = updateSnapshots === 'all' || updateSnapshots === 'missing';
     if (writingActual) {
@@ -91,9 +100,9 @@ export function compare(actual: Buffer | string, name: string, snapshotPath: (na
     const message = snapshotFile + ' is missing in snapshots' + (writingActual ? ', writing actual.' : '.');
     if (updateSnapshots === 'all') {
       console.log(message);
-      return { pass: true, message };
+      return { pass: withNegateComparison ? false : true, message };
     }
-    return { pass: false, message };
+    return { pass: withNegateComparison ? true : false, message };
   }
   const expected = fs.readFileSync(snapshotFile);
   const extension = path.extname(snapshotFile).substring(1);
@@ -102,23 +111,42 @@ export function compare(actual: Buffer | string, name: string, snapshotPath: (na
   if (!comparator) {
     return {
       pass: false,
-      message: 'Failed to find comparator with type ' + mimeType + ': '  + snapshotFile,
+      message: 'Failed to find comparator with type ' + mimeType + ': ' + snapshotFile,
     };
   }
 
   const result = comparator(actual, expected, mimeType, options);
-  if (!result)
-    return { pass: true };
+  if (!result) {
+    if (!withNegateComparison)
+      return { pass: true };
+
+    const message = [
+      colors.red('Snapshot comparison failed:'),
+      '',
+      indent('Expected result should be different from the actual one.', '  '),
+    ].join('\n');
+    return {
+      pass: true,
+      message,
+    };
+  }
 
   if (updateSnapshots === 'all') {
     fs.mkdirSync(path.dirname(snapshotFile), { recursive: true });
     fs.writeFileSync(snapshotFile, actual);
     console.log(snapshotFile + ' does not match, writing actual.');
     return {
-      pass: true,
+      pass: withNegateComparison ? false : true,
       message: snapshotFile + ' running with --update-snapshots, writing actual.'
     };
   }
+
+  if (withNegateComparison) {
+    return {
+      pass: false,
+    };
+  }
+
   const outputFile = outputPath(name);
   const expectedPath = addSuffix(outputFile, '-expected');
   const actualPath = addSuffix(outputFile, '-actual');

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -17,7 +17,7 @@
 import colors from 'colors/safe';
 import * as fs from 'fs';
 import * as path from 'path';
-import { test, expect } from './playwright-test-fixtures';
+import { test, expect, stripAscii } from './playwright-test-fixtures';
 
 test('should support golden', async ({runInlineTest}) => {
   const result = await runInlineTest({
@@ -77,11 +77,12 @@ test('should write detailed failure result to an output folder', async ({runInli
   });
 
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('Snapshot comparison failed:');
+  const outputText = stripAscii(result.output);
+  expect(outputText).toContain('Snapshot comparison failed:');
   const expectedSnapshotArtifactPath = testInfo.outputPath('test-results', 'a-is-a-test', 'snapshot-expected.txt');
   const actualSnapshotArtifactPath = testInfo.outputPath('test-results', 'a-is-a-test', 'snapshot-actual.txt');
-  expect(result.output).toMatch(new RegExp(` {4}Expected: .+?${expectedSnapshotArtifactPath}`));
-  expect(result.output).toMatch(new RegExp(` {4}Received: .+?${actualSnapshotArtifactPath}`));
+  expect(outputText).toContain(`Expected: ${expectedSnapshotArtifactPath}`);
+  expect(outputText).toContain(`Received: ${actualSnapshotArtifactPath}`);
   expect(fs.existsSync(expectedSnapshotArtifactPath)).toBe(true);
   expect(fs.existsSync(actualSnapshotArtifactPath)).toBe(true);
 });
@@ -98,10 +99,11 @@ test("doesn\'t create comparison artifacts in an output folder for passed negate
   });
 
   expect(result.exitCode).toBe(0);
+  const outputText = stripAscii(result.output);
   const expectedSnapshotArtifactPath = testInfo.outputPath('test-results', 'a-is-a-test', 'snapshot-expected.txt');
   const actualSnapshotArtifactPath = testInfo.outputPath('test-results', 'a-is-a-test', 'snapshot-actual.txt');
-  expect(result.output).not.toMatch(new RegExp(` {4}Expected: .+?${expectedSnapshotArtifactPath}`));
-  expect(result.output).not.toMatch(new RegExp(` {4}Received: .+?${actualSnapshotArtifactPath}`));
+  expect(outputText).not.toContain(`Expected: ${expectedSnapshotArtifactPath}`);
+  expect(outputText).not.toContain(`Received: ${actualSnapshotArtifactPath}`);
   expect(fs.existsSync(expectedSnapshotArtifactPath)).toBe(false);
   expect(fs.existsSync(actualSnapshotArtifactPath)).toBe(false);
 });
@@ -364,14 +366,15 @@ test('should compare different PNG images', async ({runInlineTest}, testInfo) =>
     `
   });
 
+  const outputText = stripAscii(result.output);
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('Snapshot comparison failed:');
+  expect(outputText).toContain('Snapshot comparison failed:');
   const expectedSnapshotArtifactPath = testInfo.outputPath('test-results', 'a-is-a-test', 'snapshot-expected.png');
   const actualSnapshotArtifactPath = testInfo.outputPath('test-results', 'a-is-a-test', 'snapshot-actual.png');
   const diffSnapshotArtifactPath = testInfo.outputPath('test-results', 'a-is-a-test', 'snapshot-diff.png');
-  expect(result.output).toMatch(new RegExp(` {4}Expected: .+?${expectedSnapshotArtifactPath}`));
-  expect(result.output).toMatch(new RegExp(` {4}Received: .+?${actualSnapshotArtifactPath}`));
-  expect(result.output).toMatch(new RegExp(` {8}Diff: .+?${diffSnapshotArtifactPath}`));
+  expect(outputText).toContain(`Expected: ${expectedSnapshotArtifactPath}`);
+  expect(outputText).toContain(`Received: ${actualSnapshotArtifactPath}`);
+  expect(outputText).toContain(`Diff: ${diffSnapshotArtifactPath}`);
   expect(fs.existsSync(expectedSnapshotArtifactPath)).toBe(true);
   expect(fs.existsSync(actualSnapshotArtifactPath)).toBe(true);
   expect(fs.existsSync(diffSnapshotArtifactPath)).toBe(true);

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -77,9 +77,9 @@ test('should write detailed failure result to an output folder', async ({runInli
   });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('Snapshot comparison failed:');
-  expect(result.output).toMatch(/ {4}Expected: .+?\/snapshot-expected\.txt/);
-  expect(result.output).toMatch(/ {4}Received: .+?\/snapshot-actual\.txt/);
-  expect(result.output).not.toMatch(/ {8}Diff: .+?\/snapshot-diff\.txt/);
+  expect(result.output).toMatch(/ {4}Expected: .+?(\/|\\\\)snapshot-expected\.txt/);
+  expect(result.output).toMatch(/ {4}Received: .+?(\/|\\\\)snapshot-actual\.txt/);
+  expect(result.output).not.toMatch(/ {8}Diff: .+?(\/|\\\\)snapshot-diff\.txt/);
 });
 
 test('should pass on different snapshots with negate matcher', async ({runInlineTest}, testInfo) => {
@@ -108,9 +108,9 @@ test('should fail on same snapshots with negate matcher', async ({runInlineTest}
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('Snapshot comparison failed:');
   expect(result.output).toContain('Expected result should be different from the actual one.');
-  expect(result.output).not.toMatch(/ {4}Expected: .+?\/snapshot-expected\.txt/);
-  expect(result.output).not.toMatch(/ {4}Received: .+?\/snapshot-actual\.txt/);
-  expect(result.output).not.toMatch(/ {8}Diff: .+?\/snapshot-diff\.txt/);
+  expect(result.output).not.toMatch(/ {4}Expected: .+?(\/|\\\\)snapshot-expected\.txt/);
+  expect(result.output).not.toMatch(/ {4}Received: .+?(\/|\\\\)snapshot-actual\.txt/);
+  expect(result.output).not.toMatch(/ {8}Diff: .+?(\/|\\\\)snapshot-diff\.txt/);
 });
 
 test('should fail on same snapshots with negate matcher', async ({runInlineTest}, testInfo) => {

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -77,9 +77,9 @@ test('should write detailed failure result to an output folder', async ({runInli
   });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('Snapshot comparison failed:');
-  expect(result.output).toMatch(/ {4}Expected: .+?(\/|\\\\)snapshot-expected\.txt/);
-  expect(result.output).toMatch(/ {4}Received: .+?(\/|\\\\)snapshot-actual\.txt/);
-  expect(result.output).not.toMatch(/ {8}Diff: .+?(\/|\\\\)snapshot-diff\.txt/);
+  expect(result.output).toMatch(/ {4}Expected: .+?snapshot-expected\.txt/);
+  expect(result.output).toMatch(/ {4}Received: .+?snapshot-actual\.txt/);
+  expect(result.output).not.toMatch(/ {8}Diff: .+?snapshot-diff\.txt/);
 });
 
 test('should pass on different snapshots with negate matcher', async ({runInlineTest}, testInfo) => {
@@ -108,9 +108,9 @@ test('should fail on same snapshots with negate matcher', async ({runInlineTest}
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('Snapshot comparison failed:');
   expect(result.output).toContain('Expected result should be different from the actual one.');
-  expect(result.output).not.toMatch(/ {4}Expected: .+?(\/|\\\\)snapshot-expected\.txt/);
-  expect(result.output).not.toMatch(/ {4}Received: .+?(\/|\\\\)snapshot-actual\.txt/);
-  expect(result.output).not.toMatch(/ {8}Diff: .+?(\/|\\\\)snapshot-diff\.txt/);
+  expect(result.output).not.toMatch(/ {4}Expected: .+?snapshot-expected\.txt/);
+  expect(result.output).not.toMatch(/ {4}Received: .+?snapshot-actual\.txt/);
+  expect(result.output).not.toMatch(/ {8}Diff: .+?snapshot-diff\.txt/);
 });
 
 test('should fail on same snapshots with negate matcher', async ({runInlineTest}, testInfo) => {


### PR DESCRIPTION
Fixed incorrect logic for `.not.toMatchSnapshot`:  

- Add detailed error instead of the "No message was specified for this matcher." from jest.
- Exit with the zero code if test runs with the "update-snapshots" flag
- Exit with the 1 code if missing an initial snapshot
- Doesn't create actual, diff, and expected snapshots as on fail artifacts, because there's no difference between them in this case.