### PR TITLE
browser(firefox): add transferSize to network.requestFinished

### DIFF
--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1271
-Changed: max@schmitt.mx Thu Jun 10 14:39:06 UTC 2021
+1272
+Changed: max@schmitt.mx Mon Jun 28 10:29:55 UTC 2021

--- a/browser_patches/firefox/juggler/NetworkObserver.js
+++ b/browser_patches/firefox/juggler/NetworkObserver.js
@@ -589,6 +589,7 @@ class NetworkRequest {
       pageNetwork.emit(PageNetwork.Events.RequestFinished, {
         requestId: this.requestId,
         responseEndTime: this.httpChannel.responseEndTime,
+        transferSize: this.httpChannel.transferSize,
       }, this._frameId);
     }
     this._networkObserver._channelToRequest.delete(this.httpChannel);

--- a/browser_patches/firefox/juggler/protocol/Protocol.js
+++ b/browser_patches/firefox/juggler/protocol/Protocol.js
@@ -488,6 +488,7 @@ const Network = {
     'requestFinished': {
       requestId: t.String,
       responseEndTime: t.Number,
+      transferSize: t.Number,
     },
     'requestFailed': {
       requestId: t.String,


### PR DESCRIPTION
It get's filled quite late, see [here](https://ffsearch.azurewebsites.net/#path=%2Fhome%2Fjoe%2Fplaywright%2Fbrowser_patches%2Ffirefox%2Fcheckout%2Fnetwerk%2Fprotocol%2Fhttp%2FHttpChannelChild.cpp&line=890) thats why I had to put it into requestFinished.

IMO RequestFailed is not relevant, since these completely failing requests.

Related to #6695