### PR TITLE
fix(test runner): skip without a callback inside describe should prevent hooks

### DIFF
--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -16,7 +16,7 @@
 
 import * as reporterTypes from './reporter';
 import type { TestTypeImpl } from './testType';
-import { Location } from './types';
+import { Annotations, Location } from './types';
 
 class Base {
   title: string;
@@ -78,6 +78,7 @@ export class Suite extends Base implements reporterTypes.Suite {
     fn: Function,
     location: Location,
   } [] = [];
+  _annotations: Annotations = [];
 
   _addSpec(spec: Spec) {
     spec.parent = this;

--- a/src/test/types.ts
+++ b/src/test/types.ts
@@ -22,3 +22,4 @@ export type FixturesWithLocation = {
   fixtures: Fixtures;
   location: Location;
 };
+export type Annotations = { type: 'fixme' | 'slow' | 'fail' | 'skip', description?: string }[];


### PR DESCRIPTION
References #7262.