### PR TITLE
feat(test-runner): add webServer

### DIFF
--- a/docs/src/test-advanced.md
+++ b/docs/src/test-advanced.md
@@ -42,6 +42,7 @@ These options would be typically different between local development and CI oper
 - `reportSlowTests: { max: number, threshold: number } | null` - Whether to report slow tests. When `null`, slow tests are not reported. Otherwise, tests that took more than `threshold` milliseconds are reported as slow, but no more than `max` number of them. Passing zero as `max` reports all slow tests that exceed the threshold.
 - `shard: { total: number, current: number } | null` - [Shard](./test-parallel.md#shards) information.
 - `updateSnapshots: boolean` - Whether to update expected snapshots with the actual results produced by the test run.
+- `webServer: { command: string, port?: number, cwd?: string, timeout?: number, env?: object }` - Launch a web server before the tests will start. It will automaticially detect the port when it got printed to the stdout which works for React.js, Vue.js, Angular etc.
 - `workers: number` - The maximum number of concurrent worker processes to use for parallelizing tests.
 
 Note that each [test project](#projects) can provide its own test suite options, for example two projects can run different tests by providing different `testDir`s. However, test run options are shared between all projects.
@@ -199,6 +200,57 @@ export const test = base.extend<{ saveLogs: void }>({
   }, { auto: true } ]
 });
 ```
+
+## Launching a development web server during the tests
+
+To launch a web server during the tests, use the `webServer` option in the [configuration file](#configuration-object).
+
+This will automatically launch and wait for the web server to be ready before the tests will start:
+
+```js js-flavor=ts
+// playwright.config.ts
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  webServer: {
+    command: 'npm run start',
+    timeout: 120 * 1000,
+  },
+  projects: [
+    {
+      name: 'Chrome',
+      use: {
+        browserName: 'chromium',
+      },
+    },
+  ],
+};
+
+export default config;
+```
+
+```js js-flavor=js
+// @ts-check
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  webServer: {
+    command: 'npm run start',
+    timeout: 120 * 1000,
+  },
+  projects: [
+    {
+      name: 'Chrome',
+      use: {
+        browserName: 'chromium',
+      },
+    },
+  ],
+};
+
+mode.exports = config;
+```
+
+If your dev web-server does not print the listening URL to the console, you can also manually specify a `port` or additional environment variables, see [here](#configuration-object).
 
 ## Global setup and teardown
 

--- a/docs/src/test-advanced.md
+++ b/docs/src/test-advanced.md
@@ -207,7 +207,7 @@ To launch a web server during the tests, use the `webServer` option in the [conf
 
 Playwright Test does automatically detect if a localhost URL like `http://localhost:3000` gets printed to the stdout.
 The port from the printed URL gets then used to check when its accepting requests and passed over to Playwright as a
-`baseURL`. You can also manually specify a `port` or additional environment variables, see [here](#configuration-object).
+[`param: baseURL`] when creating the context [`method: Browser.newContext`]. You can also manually specify a `port` or additional environment variables, see [here](#configuration-object).
 
 ```js js-flavor=ts
 // playwright.config.ts
@@ -223,6 +223,16 @@ const config: PlaywrightTestConfig = {
 export default config;
 ```
 
+```js js-flavor=ts
+// test.spec.ts
+import { test } = from '@playwright/test';
+
+test('test', async ({ page }) => {
+  // This will result in e.g. http://localhost:3000/foo when your dev-server prints a http://localhost:3000 address
+  await page.goto('/foo');
+});
+```
+
 ```js js-flavor=js
 // @ts-check
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
@@ -234,6 +244,16 @@ const config = {
 };
 
 mode.exports = config;
+```
+
+```js js-flavor=js
+// test.spec.js
+const { test } = require('@playwright/test');
+
+test('test', async ({ page }) => {
+  // This will result in e.g. http://localhost:3000/foo when your dev-server prints a http://localhost:3000 address
+  await page.goto('/foo');
+});
 ```
 
 ## Global setup and teardown

--- a/docs/src/test-advanced.md
+++ b/docs/src/test-advanced.md
@@ -42,7 +42,7 @@ These options would be typically different between local development and CI oper
 - `reportSlowTests: { max: number, threshold: number } | null` - Whether to report slow tests. When `null`, slow tests are not reported. Otherwise, tests that took more than `threshold` milliseconds are reported as slow, but no more than `max` number of them. Passing zero as `max` reports all slow tests that exceed the threshold.
 - `shard: { total: number, current: number } | null` - [Shard](./test-parallel.md#shards) information.
 - `updateSnapshots: boolean` - Whether to update expected snapshots with the actual results produced by the test run.
-- `webServer: { command: string, port?: number, cwd?: string, timeout?: number, env?: object }` - Launch a web server before the tests will start. It will automaticially detect the port when it got printed to the stdout which works for React.js, Vue.js, Angular etc.
+- `webServer: { command: string, port?: number, cwd?: string, timeout?: number, env?: object }` - Launch a web server before the tests will start. It will automaticially detect the port when it got printed to the stdout.
 - `workers: number` - The maximum number of concurrent worker processes to use for parallelizing tests.
 
 Note that each [test project](#projects) can provide its own test suite options, for example two projects can run different tests by providing different `testDir`s. However, test run options are shared between all projects.
@@ -205,7 +205,9 @@ export const test = base.extend<{ saveLogs: void }>({
 
 To launch a web server during the tests, use the `webServer` option in the [configuration file](#configuration-object).
 
-This will automatically launch and wait for the web server to be ready before the tests will start:
+Playwright Test does automatically detect if a localhost URL like `http://localhost:3000` gets printed to the stdout.
+The port from the printed URL gets then used to check when its accepting requests and passed over to Playwright as a
+`baseURL`. You can also manually specify a `port` or additional environment variables, see [here](#configuration-object).
 
 ```js js-flavor=ts
 // playwright.config.ts
@@ -216,14 +218,6 @@ const config: PlaywrightTestConfig = {
     command: 'npm run start',
     timeout: 120 * 1000,
   },
-  projects: [
-    {
-      name: 'Chrome',
-      use: {
-        browserName: 'chromium',
-      },
-    },
-  ],
 };
 
 export default config;
@@ -237,20 +231,10 @@ const config = {
     command: 'npm run start',
     timeout: 120 * 1000,
   },
-  projects: [
-    {
-      name: 'Chrome',
-      use: {
-        browserName: 'chromium',
-      },
-    },
-  ],
 };
 
 mode.exports = config;
 ```
-
-If your dev web-server does not print the listening URL to the console, you can also manually specify a `port` or additional environment variables, see [here](#configuration-object).
 
 ## Global setup and teardown
 

--- a/docs/src/test-configuration.md
+++ b/docs/src/test-configuration.md
@@ -161,6 +161,7 @@ In addition to configuring [Browser] or [BrowserContext], videos or screenshots,
 - `testIgnore`: Glob patterns or regular expressions that should be ignored when looking for the test files. For example, `'**/test-assets'`.
 - `testMatch`: Glob patterns or regular expressions that match test files. For example, `'**/todo-tests/*.spec.ts'`. By default, Playwright Test runs `.*(test|spec)\.(js|ts|mjs)` files.
 - `timeout`: Time in milliseconds given to each test.
+- `webServer: { command: string, port?: number, cwd?: string, timeout?: number, env?: object }` - Launch a web server before the tests will start. It will automaticially detect the port when it got printed to the stdout which works for React.js, Vue.js, Angular etc.
 - `workers`: The maximum number of concurrent worker processes to use for parallelizing tests.
 
 You can specify these options in the configuration file.

--- a/docs/src/test-configuration.md
+++ b/docs/src/test-configuration.md
@@ -161,7 +161,7 @@ In addition to configuring [Browser] or [BrowserContext], videos or screenshots,
 - `testIgnore`: Glob patterns or regular expressions that should be ignored when looking for the test files. For example, `'**/test-assets'`.
 - `testMatch`: Glob patterns or regular expressions that match test files. For example, `'**/todo-tests/*.spec.ts'`. By default, Playwright Test runs `.*(test|spec)\.(js|ts|mjs)` files.
 - `timeout`: Time in milliseconds given to each test.
-- `webServer: { command: string, port?: number, cwd?: string, timeout?: number, env?: object }` - Launch a web server before the tests will start. It will automaticially detect the port when it got printed to the stdout which works for React.js, Vue.js, Angular etc.
+- `webServer: { command: string, port?: number, cwd?: string, timeout?: number, env?: object }` - Launch a web server before the tests will start. It will automaticially detect the port when it got printed to the stdout.
 - `workers`: The maximum number of concurrent worker processes to use for parallelizing tests.
 
 You can specify these options in the configuration file.

--- a/src/server/browserType.ts
+++ b/src/server/browserType.ts
@@ -182,7 +182,7 @@ export abstract class BrowserType extends SdkObject {
     let transport: ConnectionTransport | undefined = undefined;
     let browserProcess: BrowserProcess | undefined = undefined;
     const { launchedProcess, gracefullyClose, kill } = await launchProcess({
-      executablePath: executable,
+      command: executable,
       args: browserArguments,
       env: this._amendEnvironment(env, userDataDir, executable, browserArguments),
       handleSIGINT,

--- a/src/server/chromium/videoRecorder.ts
+++ b/src/server/chromium/videoRecorder.ts
@@ -92,7 +92,7 @@ export class VideoRecorder {
     const progress = this._progress;
 
     const { launchedProcess, gracefullyClose } = await launchProcess({
-      executablePath: this._ffmpegPath,
+      command: this._ffmpegPath,
       args,
       stdio: 'stdin',
       log: (message: string) => progress.log(message),

--- a/src/server/electron/electron.ts
+++ b/src/server/electron/electron.ts
@@ -127,7 +127,7 @@ export class Electron extends SdkObject {
 
       const browserLogsCollector = new RecentLogsCollector();
       const { launchedProcess, gracefullyClose, kill } = await launchProcess({
-        executablePath: options.executablePath || require('electron/index.js'),
+        command: options.executablePath || require('electron/index.js'),
         args: electronArguments,
         env: options.env ? envArrayToObject(options.env) : process.env,
         log: (message: string) => {

--- a/src/server/processLauncher.ts
+++ b/src/server/processLauncher.ts
@@ -19,7 +19,7 @@ import * as childProcess from 'child_process';
 import * as readline from 'readline';
 import { helper } from './helper';
 import * as types from './types';
-import { isUnderTest, removeFolders } from '../utils/utils';
+import { isUnderTest, killProcessGroup, removeFolders } from '../utils/utils';
 
 export type Env = {[key: string]: string | number | boolean | undefined};
 

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -74,9 +74,12 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
   timezoneId: undefined,
   userAgent: undefined,
   viewport: undefined,
+  baseURL: async ({ }, use) => {
+    await use(process.env.PLAYWRIGHT_TEST_BASE_URL);
+  },
   contextOptions: {},
 
-  context: async ({ browser, screenshot, trace, video, acceptDownloads, bypassCSP, colorScheme, deviceScaleFactor, extraHTTPHeaders, hasTouch, geolocation, httpCredentials, ignoreHTTPSErrors, isMobile, javaScriptEnabled, locale, offline, permissions, proxy, storageState, viewport, timezoneId, userAgent, contextOptions }, use, testInfo) => {
+  context: async ({ browser, screenshot, trace, video, acceptDownloads, bypassCSP, colorScheme, deviceScaleFactor, extraHTTPHeaders, hasTouch, geolocation, httpCredentials, ignoreHTTPSErrors, isMobile, javaScriptEnabled, locale, offline, permissions, proxy, storageState, viewport, timezoneId, userAgent, baseURL, contextOptions }, use, testInfo) => {
     testInfo.snapshotSuffix = process.platform;
     if (process.env.PWDEBUG)
       testInfo.setTimeout(0);
@@ -139,6 +142,8 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
       options.userAgent = userAgent;
     if (viewport !== undefined)
       options.viewport = viewport;
+    if (baseURL !== undefined)
+      options.baseURL = baseURL;
 
     const context = await browser.newContext(options);
     context.setDefaultTimeout(0);

--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -103,6 +103,7 @@ export class Loader {
     this._fullConfig.shard = takeFirst(this._configOverrides.shard, this._config.shard, baseFullConfig.shard);
     this._fullConfig.updateSnapshots = takeFirst(this._configOverrides.updateSnapshots, this._config.updateSnapshots, baseFullConfig.updateSnapshots);
     this._fullConfig.workers = takeFirst(this._configOverrides.workers, this._config.workers, baseFullConfig.workers);
+    this._fullConfig.webServer = takeFirst(this._configOverrides.webServer, this._config.webServer, baseFullConfig.webServer);
 
     for (const project of projects)
       this._addProject(project, this._fullConfig.rootDir);
@@ -429,4 +430,5 @@ const baseFullConfig: FullConfig = {
   shard: null,
   updateSnapshots: 'missing',
   workers: 1,
+  webServer: null,
 };

--- a/src/test/webServer.ts
+++ b/src/test/webServer.ts
@@ -97,6 +97,7 @@ export class WebServer {
     this._killProcess = kill;
 
     launchedProcess.stderr.pipe(newProcessLogPrefixer()).pipe(process.stderr);
+    launchedProcess.stdout.on('data', () => {});
 
     if (this.config.port)
       return this.config.port;

--- a/src/test/webServer.ts
+++ b/src/test/webServer.ts
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable no-console */
+
+import { ChildProcess, spawn } from 'child_process';
+import net from 'net';
+import os from 'os';
+import stream from 'stream';
+import { monotonicTime, raceAgainstDeadline } from './util';
+import { WebServerConfig } from '../../types/test';
+import { assert, killProcessGroup } from '../utils/utils';
+
+const DEFAULT_ENVIRONMENT_VARIABLES = {
+  'BROWSER': 'none', // Disable that create-react-app will open the page in the browser
+};
+
+const newProcessLogPrefixer = () => new stream.Transform({
+  transform(this: stream.Transform, chunk: Buffer, encoding: string, callback: stream.TransformCallback) {
+    this.push(chunk.toString().split(os.EOL).map((line: string): string => line ? `[WebServer] ${line}` : line).join(os.EOL));
+    callback();
+  },
+});
+
+export class WebServer {
+  private _process?: ChildProcess;
+  private _processExitedWithNonZeroStatusCode!: Promise<any>;
+  constructor(private readonly config: WebServerConfig) { }
+
+  public static async create(config: WebServerConfig): Promise<WebServer> {
+    const webServer = new WebServer(config);
+    if (config.port)
+      await webServer._verifyFreePort(config.port);
+    try {
+      const port = await webServer._startWebServer();
+      await webServer._waitForAvailability(port);
+      process.env.PLAYWRIGHT_TEST_BASE_URL = `http://localhost:${port}`;
+      return webServer;
+    } catch (error) {
+      await webServer.kill();
+      throw error;
+    }
+  }
+
+  private async _verifyFreePort(port: number) {
+    const cancellationToken = { canceled: false };
+    const portIsUsed = await Promise.race([
+      new Promise(resolve => setTimeout(() => resolve(false), 100)),
+      waitForSocket(port, 100, cancellationToken),
+    ]);
+    cancellationToken.canceled = true;
+    if (portIsUsed)
+      throw new Error(`Port ${port} is used, make sure that nothing is running on the port`);
+  }
+
+  private async _startWebServer(): Promise<number> {
+    let collectPortResolve = (port: number) => { };
+    const collectPortPromise = new Promise<number>(resolve => collectPortResolve = resolve);
+    function collectPort(data: Buffer) {
+      const regExp = /http:\/\/localhost:(\d+)/.exec(data.toString());
+      if (regExp)
+        collectPortResolve(parseInt(regExp[1], 10));
+    }
+
+    this._process = spawn(this.config.command, {
+      env: {
+        ...DEFAULT_ENVIRONMENT_VARIABLES,
+        ...process.env,
+        ...this.config.env,
+      },
+      cwd: this.config.cwd,
+      shell: true,
+      // On non-windows platforms, `detached: true` makes child process a leader of a new
+      // process group, making it possible to kill child process tree with `.kill(-pid)` command.
+      // @see https://nodejs.org/api/child_process.html#child_process_options_detached
+      detached: process.platform !== 'win32',
+    });
+    this._process.stdout.pipe(newProcessLogPrefixer()).pipe(process.stdout);
+    this._process.stderr.pipe(newProcessLogPrefixer()).pipe(process.stderr);
+    if (!this.config.port)
+      this._process.stdout.on('data', collectPort);
+    let processExitedWithNonZeroStatusCodeCallback = (error: Error) => { };
+    this._processExitedWithNonZeroStatusCode = new Promise((_, reject) => processExitedWithNonZeroStatusCodeCallback = reject);
+    this._process.on('exit', code => processExitedWithNonZeroStatusCodeCallback(new Error(`WebServer was not able to start. Exit code: ${code}`)));
+    if (this.config.port)
+      return this.config.port;
+    console.log(`Starting WebServer port detection.`);
+    const detectedPort = await Promise.race([
+      this._processExitedWithNonZeroStatusCode,
+      collectPortPromise,
+    ]);
+    console.log(`Port ${detectedPort} by process '${this.config.command}' was automatically detected.`);
+    return detectedPort;
+  }
+
+  private async _waitForAvailability(port: number) {
+    const launchTimeout = this.config.timeout || 60 * 1000;
+    const cancellationToken = { canceled: false };
+    const { timedOut } = (await Promise.race([
+      raceAgainstDeadline(waitForSocket(port, 100, cancellationToken), launchTimeout + monotonicTime()),
+      this._processExitedWithNonZeroStatusCode,
+    ]));
+    cancellationToken.canceled = true;
+    if (timedOut)
+      throw new Error(`failed to start web server on port ${port} via "${this.config.command}"`);
+  }
+  public async kill() {
+    assert(this._process);
+    if (this._process.exitCode !== null || this._process.killed)
+      return;
+    const waitForExit = new Promise(resolve => this._process?.on('exit',resolve));
+    killProcessGroup(this._process.pid);
+    await waitForExit;
+  }
+}
+
+async function waitForSocket(port: number, delay: number, cancellationToken: { canceled: boolean }) {
+  while (!cancellationToken.canceled) {
+    const connected = await new Promise(resolve => {
+      const conn = net
+          .connect(port)
+          .on('error', () => {
+            resolve(false);
+          })
+          .on('connect', () => {
+            conn.end();
+            resolve(true);
+          });
+    });
+    if (connected)
+      return;
+    await new Promise(x => setTimeout(x, delay));
+  }
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -19,7 +19,7 @@ import fs from 'fs';
 import removeFolder from 'rimraf';
 import * as crypto from 'crypto';
 import os from 'os';
-import { spawn, execSync } from 'child_process';
+import { spawn } from 'child_process';
 import { getProxyForUrl } from 'proxy-from-env';
 import * as URL from 'url';
 
@@ -319,14 +319,5 @@ export function constructURLBasedOnBaseURL(baseURL: string | undefined, givenURL
     return (new URL.URL(givenURL, baseURL)).toString();
   } catch (e) {
     return givenURL;
-  }
-}
-
-export function killProcessGroup(pid: number, { onTaskkillExit }: { onTaskkillExit?: (stdout: Buffer) => void } = {}) {
-  if (process.platform === 'win32') {
-    const stdout = execSync(`taskkill /pid ${pid} /T /F`);
-    onTaskkillExit?.(stdout);
-  } else {
-    process.kill(-pid, 'SIGKILL');
   }
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -19,7 +19,7 @@ import fs from 'fs';
 import removeFolder from 'rimraf';
 import * as crypto from 'crypto';
 import os from 'os';
-import { spawn } from 'child_process';
+import { spawn, execSync } from 'child_process';
 import { getProxyForUrl } from 'proxy-from-env';
 import * as URL from 'url';
 
@@ -319,5 +319,14 @@ export function constructURLBasedOnBaseURL(baseURL: string | undefined, givenURL
     return (new URL.URL(givenURL, baseURL)).toString();
   } catch (e) {
     return givenURL;
+  }
+}
+
+export function killProcessGroup(pid: number, { onTaskkillExit }: { onTaskkillExit?: (stdout: Buffer) => void } = {}) {
+  if (process.platform === 'win32') {
+    const stdout = execSync(`taskkill /pid ${pid} /T /F`);
+    onTaskkillExit?.(stdout);
+  } else {
+    process.kill(-pid, 'SIGKILL');
   }
 }

--- a/tests/playwright-test/assets/simple-server-with-stdout.js
+++ b/tests/playwright-test/assets/simple-server-with-stdout.js
@@ -1,0 +1,10 @@
+const { TestServer } = require('../../../utils/testserver/');
+// delay creating the server to test waiting for it
+setTimeout(() => {
+  TestServer.create(__dirname, process.argv[2] || 3000).then(server => {
+    console.log(`Listening on http://localhost:${server.PORT}`);
+    server.setRoute('/hello', (message, response) => {
+      response.end('hello');
+    });
+  });
+}, 750);

--- a/tests/playwright-test/assets/simple-server.js
+++ b/tests/playwright-test/assets/simple-server.js
@@ -1,0 +1,13 @@
+const { TestServer } = require('../../../utils/testserver/');
+// delay creating the server to test waiting for it
+setTimeout(() => {
+  TestServer.create(__dirname, process.argv[2] || 3000).then(server => {
+    console.log('listening on port', server.PORT);
+    server.setRoute('/hello', (message, response) => {
+      response.end('hello');
+    });
+    server.setRoute('/env-FOO', (message, response) => {
+      response.end(process.env.FOO);
+    });
+  });
+}, 750);

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -23,15 +23,9 @@ test('should create a server', async ({ runInlineTest }, { workerIndex }) => {
   const result = await runInlineTest({
     'test.spec.ts': `
       const { test } = pwt;
-      test('connect to the server via the full URL navigation', async ({baseURL, page}) => {
-        expect(baseURL).toBe('http://localhost:${port}');
-        await page.goto(baseURL + '/hello');
-        expect(await page.textContent('body')).toBe('hello');
-      });
-
       test('connect to the server via the baseURL', async ({baseURL, page}) => {
         await page.goto('/hello');
-        expect(page.url()).toBe('http://localhost:${port}/hello');
+        expect(page.url()).toBe('/hello');
         expect(await page.textContent('body')).toBe('hello');
       });
     `,
@@ -150,30 +144,6 @@ test('should be able to specify the baseURL without the server', async ({ runInl
         }
       };
     `,
-  });
-  expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(1);
-  expect(result.report.suites[0].specs[0].tests[0].results[0].status).toContain('passed');
-  server.close();
-});
-
-test('should be able to specify the baseURL via the environment variable', async ({ runInlineTest }, { workerIndex }) => {
-  const port = workerIndex + 10500;
-  const server = http.createServer((req: http.IncomingMessage, res: http.ServerResponse) => {
-    res.end('<html><body>hello</body></html>');
-  });
-  await new Promise(resolve => server.listen(port, resolve));
-  const result = await runInlineTest({
-    'test.spec.ts': `
-      const { test } = pwt;
-      test('connect to the server', async ({baseURL, page}) => {
-        expect(baseURL).toBe('http://localhost:${port}');
-        await page.goto(baseURL + '/hello');
-        expect(await page.textContent('body')).toBe('hello');
-      });
-    `,
-  }, { }, {
-    PLAYWRIGHT_TEST_BASE_URL: `http://localhost:${port}`,
   });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -25,7 +25,8 @@ test('should create a server', async ({ runInlineTest }, { workerIndex }) => {
       const { test } = pwt;
       test('connect to the server via the baseURL', async ({baseURL, page}) => {
         await page.goto('/hello');
-        expect(page.url()).toBe('/hello');
+        await page.waitForURL('/hello');
+        expect(page.url()).toBe('http://localhost:${port}/hello');
         expect(await page.textContent('body')).toBe('hello');
       });
     `,
@@ -39,9 +40,8 @@ test('should create a server', async ({ runInlineTest }, { workerIndex }) => {
     `,
   });
   expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(2);
+  expect(result.passed).toBe(1);
   expect(result.report.suites[0].specs[0].tests[0].results[0].status).toContain('passed');
-  expect(result.report.suites[0].specs[1].tests[0].results[0].status).toContain('passed');
 });
 
 test('should create a server with environment variables', async ({ runInlineTest }, { workerIndex }) => {
@@ -94,7 +94,7 @@ test('should time out waiting for a server', async ({ runInlineTest }, { workerI
     `,
   });
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain(`failed to start web server on port ${port} via "node`);
+  expect(result.output).toContain(`Timed out waiting 100ms for WebServer`);
 });
 
 test('should be able to detect the port from the process stdout', async ({ runInlineTest }, { workerIndex }) => {
@@ -118,7 +118,6 @@ test('should be able to detect the port from the process stdout', async ({ runIn
   });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
-  expect(result.output).toContain(`Listening on http://localhost:${port}`);
   expect(result.report.suites[0].specs[0].tests[0].results[0].status).toContain('passed');
 });
 

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import http from 'http';
+import path from 'path';
+import { test, expect } from './playwright-test-fixtures';
+
+test('should create a server', async ({ runInlineTest }, { workerIndex }) => {
+  const port = workerIndex + 10500;
+  const result = await runInlineTest({
+    'test.spec.ts': `
+      const { test } = pwt;
+      test('connect to the server via the full URL navigation', async ({baseURL, page}) => {
+        expect(baseURL).toBe('http://localhost:${port}');
+        await page.goto(baseURL + '/hello');
+        expect(await page.textContent('body')).toBe('hello');
+      });
+
+      test('connect to the server via the baseURL', async ({baseURL, page}) => {
+        await page.goto('/hello');
+        expect(page.url()).toBe('http://localhost:${port}/hello');
+        expect(await page.textContent('body')).toBe('hello');
+      });
+    `,
+    'playwright.config.ts': `
+      module.exports = {
+        webServer: {
+          command: 'node ${JSON.stringify(path.join(__dirname, 'assets', 'simple-server.js'))} ${port}',
+          port: ${port},
+        }
+      };
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+  expect(result.report.suites[0].specs[0].tests[0].results[0].status).toContain('passed');
+  expect(result.report.suites[0].specs[1].tests[0].results[0].status).toContain('passed');
+});
+
+test('should create a server with environment variables', async ({ runInlineTest }, { workerIndex }) => {
+  const port = workerIndex + 10500;
+  const result = await runInlineTest({
+    'test.spec.ts': `
+      const { test } = pwt;
+      test('connect to the server', async ({baseURL, page}) => {
+        expect(baseURL).toBe('http://localhost:${port}');
+        await page.goto(baseURL + '/env-FOO');
+        expect(await page.textContent('body')).toBe('BAR');
+      });
+    `,
+    'playwright.config.ts': `
+      module.exports = {
+        webServer: {
+          command: 'node ${JSON.stringify(path.join(__dirname, 'assets', 'simple-server.js'))} ${port}',
+          port: ${port},
+          env: {
+            'FOO': 'BAR',
+          }
+        }
+      };
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.report.suites[0].specs[0].tests[0].results[0].status).toContain('passed');
+});
+
+test('should time out waiting for a server', async ({ runInlineTest }, { workerIndex }) => {
+  const port = workerIndex + 10500;
+  const result = await runInlineTest({
+    'test.spec.ts': `
+      const { test } = pwt;
+      test('connect to the server', async ({baseURL, page}) => {
+        expect(baseURL).toBe('http://localhost:${port}');
+        await page.goto(baseURL + '/hello');
+        expect(await page.textContent('body')).toBe('hello');
+      });
+    `,
+    'playwright.config.ts': `
+      module.exports = {
+        webServer: {
+          command: 'node ${JSON.stringify(JSON.stringify(path.join(__dirname, 'assets', 'simple-server.js')))} ${port}',
+          port: ${port},
+          timeout: 100,
+        }
+      };
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`failed to start web server on port ${port} via "node`);
+});
+
+test('should be able to detect the port from the process stdout', async ({ runInlineTest }, { workerIndex }) => {
+  const port = workerIndex + 10500;
+  const result = await runInlineTest({
+    'test.spec.ts': `
+      const { test } = pwt;
+      test('connect to the server', async ({baseURL, page}) => {
+        expect(baseURL).toBe('http://localhost:${port}');
+        await page.goto(baseURL + '/hello');
+        expect(await page.textContent('body')).toBe('hello');
+      });
+    `,
+    'playwright.config.ts': `
+      module.exports = {
+        webServer: {
+          command: 'node ${JSON.stringify(path.join(__dirname, 'assets', 'simple-server-with-stdout.js'))} ${port}',
+        }
+      };
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.output).toContain(`Listening on http://localhost:${port}`);
+  expect(result.report.suites[0].specs[0].tests[0].results[0].status).toContain('passed');
+});
+
+test('should be able to specify the baseURL without the server', async ({ runInlineTest }, { workerIndex }) => {
+  const port = workerIndex + 10500;
+  const server = http.createServer((req: http.IncomingMessage, res: http.ServerResponse) => {
+    res.end('<html><body>hello</body></html>');
+  });
+  await new Promise(resolve => server.listen(port, resolve));
+  const result = await runInlineTest({
+    'test.spec.ts': `
+      const { test } = pwt;
+      test('connect to the server', async ({baseURL, page}) => {
+        expect(baseURL).toBe('http://localhost:${port}');
+        await page.goto(baseURL + '/hello');
+        expect(await page.textContent('body')).toBe('hello');
+      });
+    `,
+    'playwright.config.ts': `
+      module.exports = {
+        use: {
+          baseURL: 'http://localhost:${port}',
+        }
+      };
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.report.suites[0].specs[0].tests[0].results[0].status).toContain('passed');
+  server.close();
+});
+
+test('should be able to specify the baseURL via the environment variable', async ({ runInlineTest }, { workerIndex }) => {
+  const port = workerIndex + 10500;
+  const server = http.createServer((req: http.IncomingMessage, res: http.ServerResponse) => {
+    res.end('<html><body>hello</body></html>');
+  });
+  await new Promise(resolve => server.listen(port, resolve));
+  const result = await runInlineTest({
+    'test.spec.ts': `
+      const { test } = pwt;
+      test('connect to the server', async ({baseURL, page}) => {
+        expect(baseURL).toBe('http://localhost:${port}');
+        await page.goto(baseURL + '/hello');
+        expect(await page.textContent('body')).toBe('hello');
+      });
+    `,
+  }, { }, {
+    PLAYWRIGHT_TEST_BASE_URL: `http://localhost:${port}`,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.report.suites[0].specs[0].tests[0].results[0].status).toContain('passed');
+  server.close();
+});

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -129,13 +129,13 @@ export type WebServerConfig = {
    */
   port?: number,
   /**
-   * Environment variables which get set during the execution. Default it will use the environment variables from the current process.
+   * WebServer environment variables, process.env by default
    */
-  env?: Record<string, string>
+  env?: Record<string, string>,
   /**
-   * Current working directory of the spawned process. Default its process.cwd().
+   * Current working directory of the spawned process. Default is process.cwd().
    */
-  cwd?: string 
+  cwd?: string,
   /**
    * How long to wait for the server to start up in milliseconds. Defaults to 60000.
    */
@@ -231,7 +231,7 @@ interface ConfigBase {
   updateSnapshots?: UpdateSnapshots;
 
   /**
-   * Launch a web server before the tests start.
+   * Launch a web server before running tests.
    */
    webServer?: WebServerConfig;
 

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -118,6 +118,30 @@ export interface Project<TestArgs = {}, WorkerArgs = {}> extends ProjectBase {
 
 export type FullProject<TestArgs = {}, WorkerArgs = {}> = Required<Project<TestArgs, WorkerArgs>>;
 
+export type WebServerConfig = {
+  /**
+   * Shell command to start the webserver. For example `npm run start`.
+   */
+  command: string,
+  /**
+   * The port that your server is expected to appear on. If not specified, it does get automatically collected via the 
+   * command output when a localhost URL gets printed.
+   */
+  port?: number,
+  /**
+   * Environment variables which get set during the execution. Default it will use the environment variables from the current process.
+   */
+  env?: Record<string, string>
+  /**
+   * Current working directory of the spawned process. Default its process.cwd().
+   */
+  cwd?: string 
+  /**
+   * How long to wait for the server to start up in milliseconds. Defaults to 60000.
+   */
+  timeout?: number,
+};
+
 /**
  * Testing configuration.
  */
@@ -207,6 +231,11 @@ interface ConfigBase {
   updateSnapshots?: UpdateSnapshots;
 
   /**
+   * Launch a web server before the tests start.
+   */
+   webServer?: WebServerConfig;
+
+  /**
    * The maximum number of concurrent worker processes to use for parallelizing tests.
    */
   workers?: number;
@@ -239,6 +268,7 @@ export interface FullConfig {
   shard: Shard;
   updateSnapshots: UpdateSnapshots;
   workers: number;
+  webServer: WebServerConfig | null;
 }
 
 export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped';
@@ -1146,6 +1176,12 @@ export type PlaywrightTestOptions = {
    * @see BrowserContextOptions
    */
   viewport: ViewportSize | null | undefined;
+
+  /**
+   * BaseURL used for all the contexts in the test. Takes priority over `contextOptions`.
+   * @see BrowserContextOptions
+   */
+  baseURL: string | undefined;
 
   /**
    * Options used to create the context. Other options above (e.g. `viewport`) take priority.

--- a/utils/check_deps.js
+++ b/utils/check_deps.js
@@ -161,7 +161,7 @@ DEPS['src/utils/'] = ['src/common/', 'src/protocol/'];
 DEPS['src/server/trace/common/'] = ['src/server/snapshot/', ...DEPS['src/server/']];
 DEPS['src/server/trace/recorder/'] = ['src/server/trace/common/', ...DEPS['src/server/trace/common/']];
 DEPS['src/server/trace/viewer/'] = ['src/server/trace/common/', 'src/server/trace/recorder/', 'src/server/chromium/', ...DEPS['src/server/trace/common/']];
-DEPS['src/test/'] = ['src/test/**', 'src/utils/utils.ts'];
+DEPS['src/test/'] = ['src/test/**', 'src/utils/utils.ts', 'src/server/processLauncher.ts'];
 
 checkDeps().catch(e => {
   console.error(e && e.stack ? e.stack : e);


### PR DESCRIPTION
Tested with React, Vue.js and Angular which works. The big difference to jest-dev-server is that we don't wait for 2xx, we only wait for accepted TCP connections.

Supersedes #6959
Fixes #7398
