### PR TITLE
browser(firefox-beta): add transferSize to Network.requestFinished

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1264
-Changed: lushnikov@chromium.org Tue 15 Jun 2021 03:35:19 PM PDT
+1265
+Changed: max@schmitt.mx Mon Jun 28 22:40:00 UTC 2021

--- a/browser_patches/firefox-beta/juggler/NetworkObserver.js
+++ b/browser_patches/firefox-beta/juggler/NetworkObserver.js
@@ -589,6 +589,7 @@ class NetworkRequest {
       pageNetwork.emit(PageNetwork.Events.RequestFinished, {
         requestId: this.requestId,
         responseEndTime: this.httpChannel.responseEndTime,
+        transferSize: this.httpChannel.transferSize,
       }, this._frameId);
     }
     this._networkObserver._channelToRequest.delete(this.httpChannel);

--- a/browser_patches/firefox-beta/juggler/protocol/Protocol.js
+++ b/browser_patches/firefox-beta/juggler/protocol/Protocol.js
@@ -488,6 +488,7 @@ const Network = {
     'requestFinished': {
       requestId: t.String,
       responseEndTime: t.Number,
+      transferSize: t.Number,
     },
     'requestFailed': {
       requestId: t.String,


### PR DESCRIPTION
(Forgot to also apply it do beta.)

follow-up for #7355
Related to #6695