### PR TITLE
fix(registry): make hostPlatform lazy

### DIFF
--- a/src/install/browserFetcher.ts
+++ b/src/install/browserFetcher.ts
@@ -20,7 +20,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import ProgressBar from 'progress';
-import { BrowserName, Registry, hostPlatform } from '../utils/registry';
+import { BrowserName, Registry } from '../utils/registry';
 import { downloadFile, existsAsync } from '../utils/utils';
 import { debugLogger } from '../utils/debugLogger';
 
@@ -53,7 +53,7 @@ export async function downloadBrowserWithProgressBar(registry: Registry, browser
   }
 
   const url = registry.downloadURL(browserName);
-  const zipPath = path.join(os.tmpdir(), `playwright-download-${browserName}-${hostPlatform}-${registry.revision(browserName)}.zip`);
+  const zipPath = path.join(os.tmpdir(), `playwright-download-${browserName}-${registry.hostPlatform()}-${registry.revision(browserName)}.zip`);
   try {
     for (let attempt = 1, N = 3; attempt <= N; ++attempt) {
       debugLogger.log('install', `downloading ${progressBarName} - attempt #${attempt}`);

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -19,7 +19,6 @@ import * as jpeg from 'jpeg-js';
 import path from 'path';
 import * as png from 'pngjs';
 import { splitErrorMessage } from '../../utils/stackTrace';
-import { hostPlatform } from '../../utils/registry';
 import { assert, createGuid, debugAssert, headersArrayToObject, headersObjectToArray } from '../../utils/utils';
 import * as accessibility from '../accessibility';
 import * as dialog from '../dialog';
@@ -762,14 +761,15 @@ export class WKPage implements PageDelegate {
   }
 
   private _toolbarHeight(): number {
-    if (this._page._browserContext._browser?.options.headful)
-      return hostPlatform.startsWith('10.15') ? 55 : 59;
+    const options = this._page._browserContext._browser.options;
+    if (options.headful)
+      return options.registry.hostPlatform().startsWith('10.15') ? 55 : 59;
     return 0;
   }
 
   private async _startVideo(options: types.PageScreencastOptions): Promise<void> {
     assert(!this._recordingVideoFile);
-    const START_VIDEO_PROTOCOL_COMMAND = hostPlatform === 'mac10.14' ? 'Screencast.start' : 'Screencast.startVideo';
+    const START_VIDEO_PROTOCOL_COMMAND = this._page._browserContext._browser.options.registry.hostPlatform() === 'mac10.14' ? 'Screencast.start' : 'Screencast.startVideo';
     const { screencastId } = await this._pageProxySession.send(START_VIDEO_PROTOCOL_COMMAND as any, {
       file: options.outputFile,
       width: options.width,
@@ -783,7 +783,7 @@ export class WKPage implements PageDelegate {
   private async _stopVideo(): Promise<void> {
     if (!this._recordingVideoFile)
       return;
-    const STOP_VIDEO_PROTOCOL_COMMAND = hostPlatform === 'mac10.14' ? 'Screencast.stop' : 'Screencast.stopVideo';
+    const STOP_VIDEO_PROTOCOL_COMMAND = this._page._browserContext._browser.options.registry.hostPlatform() === 'mac10.14' ? 'Screencast.stop' : 'Screencast.stopVideo';
     await this._pageProxySession.sendMayFail(STOP_VIDEO_PROTOCOL_COMMAND as any);
     this._recordingVideoFile = null;
   }


### PR DESCRIPTION
This avoids unnecessary execSync at the time of require('playwright').