### PR TITLE
fix(test-runner): better test match glob

### DIFF
--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -191,7 +191,7 @@ export class Loader {
       name: takeFirst(this._configOverrides.name, projectConfig.name, this._config.name, ''),
       testDir,
       testIgnore: takeFirst(this._configOverrides.testIgnore, projectConfig.testIgnore, this._config.testIgnore, []),
-      testMatch: takeFirst(this._configOverrides.testMatch, projectConfig.testMatch, this._config.testMatch, '**/?(*.)+(spec|test).[jt]s'),
+      testMatch: takeFirst(this._configOverrides.testMatch, projectConfig.testMatch, this._config.testMatch, '**/?(*.)@(spec|test).[jt]s'),
       timeout: takeFirst(this._configOverrides.timeout, projectConfig.timeout, this._config.timeout, 10000),
       use: mergeObjects(mergeObjects(this._config.use, projectConfig.use), this._configOverrides.use),
     };

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -105,7 +105,7 @@ test('should validate configuration object', async ({ runInlineTest }) => {
   expect(result.output).toContain('playwright.config.ts: config.timeout must be a non-negative number');
 });
 
-test.only('should match tests well', async ({ runInlineTest }) => {
+test('should match tests well', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `
       const { test } = pwt;

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -104,3 +104,47 @@ test('should validate configuration object', async ({ runInlineTest }) => {
   expect(result.failed).toBe(0);
   expect(result.output).toContain('playwright.config.ts: config.timeout must be a non-negative number');
 });
+
+test.only('should match tests well', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      const { test } = pwt;
+      test('works', () => {});
+    `,
+    'hello.spec.ts': `
+      const { test } = pwt;
+      test('works', () => {});
+    `,
+    'test.ts': `
+      const { test } = pwt;
+      test('works', () => {});
+    `,
+    'spec.ts': `
+      const { test } = pwt;
+      test('works', () => {});
+    `,
+    'strange.....spec.ts': `
+      const { test } = pwt;
+      test('works', () => {});
+    `,
+    'badspec.ts': `
+      const { test } = pwt;
+      test('bad', () => { throw new Error('badspec.ts')});
+    `,
+    'specspec.ts': `
+      const { test } = pwt;
+      test('bad', () => { throw new Error('specspec.ts')});
+    `,
+    'a.testtest.ts': `
+      const { test } = pwt;
+      test('bad', () => { throw new Error('a.testtest.ts')});
+    `,
+    'b.testspec.ts': `
+      const { test } = pwt;
+      test('bad', () => { throw new Error('b.testspec.ts')});
+    `
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(5);
+});


### PR DESCRIPTION
We copied the test match from jest, but it incorrectly matches `specspecspec.ts`.
https://github.com/micromatch/micromatch#extglobs