### PR TITLE
feat(test-runner): smaller error message paths

### DIFF
--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { wrapInPromise } from './util';
+import { formatLocation, wrapInPromise } from './util';
 import * as crypto from 'crypto';
 import { FixturesWithLocation, Location, WorkerInfo, TestInfo } from './types';
 
@@ -352,8 +352,4 @@ function errorWithLocations(message: string, ...defined: { location: Location, n
     message += `\n  ${prefix}defined at ${formatLocation(location)}`;
   }
   return new Error(message);
-}
-
-function formatLocation(location: Location) {
-  return location.file + ':' + location.line + ':' + location.column;
 }

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import type { LaunchOptions, BrowserContextOptions, Page } from '../../types/types';
-import type { TestType, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, FullConfig, TestInfo } from '../../types/test';
+import type { TestType, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, TestInfo } from '../../types/test';
 import { rootTestType } from './testType';
 import { createGuid, removeFolders } from '../utils/utils';
 export { expect } from './expect';
@@ -219,13 +219,13 @@ function formatPendingCalls(calls: ProtocolCall[], testInfo: TestInfo) {
   if (!calls.length)
     return '';
   return 'Pending operations:\n' + calls.map(call => {
-    const frame = call.stack && call.stack[0] ? formatStackFrame(testInfo.config, call.stack[0]) : '<unknown>';
+    const frame = call.stack && call.stack[0] ? formatStackFrame(call.stack[0]) : '<unknown>';
     return `  - ${call.apiName} at ${frame}\n`;
   }).join('') + '\n';
 }
 
-function formatStackFrame(config: FullConfig, frame: StackFrame) {
-  const file = path.relative(config.rootDir, frame.file) || path.basename(frame.file);
+function formatStackFrame(frame: StackFrame) {
+  const file = path.relative(process.cwd(), frame.file) || path.basename(frame.file);
   return `${file}:${frame.line || 1}:${frame.column || 1}`;
 }
 

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import type { LaunchOptions, BrowserContextOptions, Page } from '../../types/types';
-import type { TestType, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, TestInfo } from '../../types/test';
+import type { TestType, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions } from '../../types/test';
 import { rootTestType } from './testType';
 import { createGuid, removeFolders } from '../utils/utils';
 export { expect } from './expect';
@@ -180,7 +180,7 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
       }));
     }
 
-    const prependToError = testInfo.status ===  'timedOut' ? formatPendingCalls((context as any)._connection.pendingProtocolCalls(), testInfo) : '';
+    const prependToError = testInfo.status ===  'timedOut' ? formatPendingCalls((context as any)._connection.pendingProtocolCalls()) : '';
     await context.close();
     if (prependToError) {
       if (!testInfo.error) {
@@ -215,7 +215,7 @@ export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions,
 });
 export default test;
 
-function formatPendingCalls(calls: ProtocolCall[], testInfo: TestInfo) {
+function formatPendingCalls(calls: ProtocolCall[]) {
   if (!calls.length)
     return '';
   return 'Pending operations:\n' + calls.map(call => {

--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -16,7 +16,7 @@
 
 import { installTransform } from './transform';
 import type { FullConfig, Config, FullProject, Project, ReporterDescription, PreserveOutput } from './types';
-import { isRegExp, mergeObjects } from './util';
+import { isRegExp, mergeObjects, errorWithFile } from './util';
 import { setCurrentlyLoadingFileSuite } from './globals';
 import { Suite } from './test';
 import { SerializedLoaderData } from './ipc';
@@ -234,10 +234,6 @@ function toLaunchServers(launchConfigs?: LaunchConfig | LaunchConfig[]): LaunchC
   if (!Array.isArray(launchConfigs))
     return [launchConfigs];
   return launchConfigs;
-}
-
-function errorWithFile(file: string, message: string) {
-  return new Error(`${file}: ${message}`);
 }
 
 function validateConfig(file: string, config: Config) {

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -15,7 +15,8 @@
  */
 
 import util from 'util';
-import type { TestError } from './types';
+import path from 'path';
+import type { TestError, Location } from './types';
 import { default as minimatch } from 'minimatch';
 
 export class DeadlineRunner<T> {
@@ -146,4 +147,18 @@ export function forceRegExp(pattern: string): RegExp {
   if (match)
     return new RegExp(match[1], match[2]);
   return new RegExp(pattern, 'g');
+}
+
+export function relativeFilePath(file: string): string {
+  if (!path.isAbsolute(file))
+    return file;
+  return path.relative(process.cwd(), file);
+}
+
+export function formatLocation(location: Location) {
+  return relativeFilePath(location.file) + ':' + location.line + ':' + location.column;
+}
+
+export function errorWithFile(file: string, message: string) {
+  return new Error(`${relativeFilePath(file)}: ${message}`);
 }


### PR DESCRIPTION
We were dumping absolute paths which is a bit impolite.

This uses process.cwd() instead of rootDir. My gut says cwd is better
and my brain says its because not all of these files are necessarily
in the rootDir. The config, for example, might be somewhere else.﻿
