### PR TITLE
feat(test runner): support test.setTimeout for the whole block

### DIFF
--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -78,6 +78,7 @@ export class Suite extends Base implements reporterTypes.Suite {
     fn: Function,
     location: Location,
   }[] = [];
+  _timeout: number | undefined;
 
   _addSpec(spec: Spec) {
     spec.parent = this;

--- a/src/test/testType.ts
+++ b/src/test/testType.ts
@@ -125,9 +125,15 @@ export class TestTypeImpl {
   }
 
   private _setTimeout(timeout: number) {
+    const suite = currentlyLoadingFileSuite();
+    if (suite) {
+      suite._timeout = timeout;
+      return;
+    }
+
     const testInfo = currentTestInfo();
     if (!testInfo)
-      throw new Error(`test.setTimeout() can only be called inside test or fixture`);
+      throw new Error(`test.setTimeout() can only be called from a test file`);
     testInfo.setTimeout(timeout);
   }
 

--- a/src/test/workerRunner.ts
+++ b/src/test/workerRunner.ts
@@ -243,6 +243,15 @@ export class WorkerRunner extends EventEmitter {
           deadlineRunner.setDeadline(deadline());
       },
     };
+
+    // Inherit test.setTimeout() from parent suites.
+    for (let suite = spec.parent; suite; suite = suite.parent) {
+      if (suite._timeout !== undefined) {
+        testInfo.setTimeout(suite._timeout);
+        break;
+      }
+    }
+
     this._setCurrentTest({ testInfo, testId });
     const deadline = () => {
       return testInfo.timeout ? startTime + testInfo.timeout : undefined;


### PR DESCRIPTION
This enables `test.setTimeout()` outside of the test body, that affects all tests in the block (either file or describe).

Drive-by: fix list reporter regression.

Fixes #7266.