### PR TITLE
browser(firefox): properly handle HSTS redirects

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1266
-Changed: max@schmitt.mx Tue Jun 29 22:44:52 UTC 2021
+1267
+Changed: dgozman@gmail.com Tue Jun 30 16:15:40 PDT 2021

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1273
-Changed: max@schmitt.mx Tue Jun 29 22:39:37 UTC 2021
+1274
+Changed: dgozman@gmail.com Tue Jun 30 16:15:40 PDT 2021


### PR DESCRIPTION
When Firefox decides to perform an http->https redirect based on HSTS
information, it issues an "internal" redirect and cancels the http request.

Since there is no response for the http request, we forge 307 redirect
in this case, following Chromium lead.

The relevant code is in nsHttpChannel::StartRedirectChannelToHttps.

References #6848.