### PR TITLE
fix(chromium): disable use-zoom-for-dsf

### DIFF
--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -150,6 +150,11 @@ export class Chromium extends BrowserType {
       throw new Error('Arguments can not specify page to be opened');
     const chromeArguments = [...DEFAULT_ARGS];
     chromeArguments.push(`--user-data-dir=${userDataDir}`);
+
+    // See https://github.com/microsoft/playwright/issues/7362
+    if (os.platform() === 'darwin')
+      chromeArguments.push('--enable-use-zoom-for-dsf=false');
+
     if (options.useWebSocket)
       chromeArguments.push('--remote-debugging-port=0');
     else


### PR DESCRIPTION
On Mac, use-zoom-for-dsf﻿was enabled by default which caused `Input.dispatchDragEvent` to miss
its target. Disabling the flag while we wait for an upstream fix.

Fixes #7362
