### PR TITLE
feat: add browser.newContext({ baseUrl })

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -852,6 +852,7 @@ Returns all open pages in the context.
 
 Routing provides the capability to modify network requests that are made by any page in the browser context. Once route
 is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
+It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
 
 An example of a naive handler that aborts all image requests:
 

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -852,7 +852,6 @@ Returns all open pages in the context.
 
 Routing provides the capability to modify network requests that are made by any page in the browser context. Once route
 is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
-It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
 
 An example of a naive handler that aborts all image requests:
 
@@ -1002,6 +1001,8 @@ Enabling routing disables http cache.
 - `url` <[string]|[RegExp]|[function]\([URL]\):[boolean]>
 
 A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
+When a [`option: baseURL`] via the context options was provided and the passed URL is a path,
+it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
 
 ### param: BrowserContext.route.handler
 * langs: js, python

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1874,7 +1874,7 @@ Navigate to the next page in history.
 - returns: <[null]|[Response]>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
-last redirect. It will consider a base URL if you set it via [`option: baseURL`] when creating the context.
+last redirect. It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
 
 `page.goto` will throw an error if:
 * there's an SSL error (e.g. in case of self-signed certificates).
@@ -2505,6 +2505,8 @@ Page routes take precedence over browser context routes (set up with [`method: B
 matches both handlers.
 
 To remove a route with its handler you can use [`method: Page.unroute`].
+
+It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
 
 :::note
 Enabling routing disables http cache.
@@ -3330,7 +3332,8 @@ Receives the [Page] object and resolves to truthy value when the waiting should 
   * alias-csharp: RunAndWaitForRequest
 - returns: <[Request]>
 
-Waits for the matching request and returns it.  See [waiting for event](./events.md#waiting-for-event) for more details about events.
+Waits for the matching request and returns it. See [waiting for event](./events.md#waiting-for-event) for more details about events.
+It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
 
 ```js
 // Note that Promise.all prevents a race condition
@@ -3446,6 +3449,7 @@ Receives the [Request] object and resolves to truthy value when the waiting shou
 - returns: <[Response]>
 
 Returns the matched response. See [waiting for event](./events.md#waiting-for-event) for more details about events.
+It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
 
 ```js
 // Note that Promise.all prevents a race condition
@@ -3697,6 +3701,7 @@ A timeout to wait for
 ## async method: Page.waitForURL
 
 Waits for the main frame to navigate to the given URL.
+It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
 
 ```js
 await page.click('a.delayed-navigation'); // Clicking the link will indirectly cause a navigation

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1874,7 +1874,7 @@ Navigate to the next page in history.
 - returns: <[null]|[Response]>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
-last redirect. It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
+last redirect.
 
 `page.goto` will throw an error if:
 * there's an SSL error (e.g. in case of self-signed certificates).
@@ -1903,6 +1903,8 @@ Shortcut for main frame's [`method: Frame.goto`]
 - `url` <[string]>
 
 URL to navigate page to. The url should include scheme, e.g. `https://`.
+When a [`option: baseURL`] via the context options was provided and the passed URL is a path,
+it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
 
 ### option: Page.goto.waitUntil = %%-navigation-wait-until-%%
 
@@ -2506,8 +2508,6 @@ matches both handlers.
 
 To remove a route with its handler you can use [`method: Page.unroute`].
 
-It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
-
 :::note
 Enabling routing disables http cache.
 :::
@@ -2516,7 +2516,8 @@ Enabling routing disables http cache.
 - `url` <[string]|[RegExp]|[function]\([URL]\):[boolean]>
 
 A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
-
+When a [`option: baseURL`] via the context options was provided and the passed URL is a path,
+it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
 ### param: Page.route.handler
 * langs: js, python
 - `handler` <[function]\([Route], [Request]\)>
@@ -3333,7 +3334,6 @@ Receives the [Page] object and resolves to truthy value when the waiting should 
 - returns: <[Request]>
 
 Waits for the matching request and returns it. See [waiting for event](./events.md#waiting-for-event) for more details about events.
-It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
 
 ```js
 // Note that Promise.all prevents a race condition
@@ -3410,6 +3410,8 @@ await page.RunAndWaitForRequestAsync(async () =>
 - `urlOrPredicate` <[string]|[RegExp]|[function]\([Request]\):[boolean]>
 
 Request URL string, regex or predicate receiving [Request] object.
+When a [`option: baseURL`] via the context options was provided and the passed URL is a path,
+it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
 
 ### param: Page.waitForRequest.urlOrPredicate
 * langs: js
@@ -3449,7 +3451,6 @@ Receives the [Request] object and resolves to truthy value when the waiting shou
 - returns: <[Response]>
 
 Returns the matched response. See [waiting for event](./events.md#waiting-for-event) for more details about events.
-It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
 
 ```js
 // Note that Promise.all prevents a race condition
@@ -3530,12 +3531,16 @@ await page.RunAndWaitForResponseAsync(async () =>
 - `urlOrPredicate` <[string]|[RegExp]|[function]\([Response]\):[boolean]>
 
 Request URL string, regex or predicate receiving [Response] object.
+When a [`option: baseURL`] via the context options was provided and the passed URL is a path,
+it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
 
 ### param: Page.waitForResponse.urlOrPredicate
 * langs: js
 - `urlOrPredicate` <[string]|[RegExp]|[function]\([Response]\):[boolean]|[Promise]<[boolean]>>
 
 Request URL string, regex or predicate receiving [Response] object.
+When a [`option: baseURL`] via the context options was provided and the passed URL is a path,
+it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
 
 ### option: Page.waitForResponse.timeout
 - `timeout` <[float]>
@@ -3701,7 +3706,6 @@ A timeout to wait for
 ## async method: Page.waitForURL
 
 Waits for the main frame to navigate to the given URL.
-It will consider the base URL if you set it via [`option: baseURL`] when creating the context.
 
 ```js
 await page.click('a.delayed-navigation'); // Clicking the link will indirectly cause a navigation

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1874,7 +1874,7 @@ Navigate to the next page in history.
 - returns: <[null]|[Response]>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
-last redirect.
+last redirect. It will consider a base URL if you set it via [`option: baseURL`] when creating the context.
 
 `page.goto` will throw an error if:
 * there's an SSL error (e.g. in case of self-signed certificates).

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -216,10 +216,9 @@ Toggles bypassing page's Content-Security-Policy.
 ## context-option-baseURL
 - `baseURL` <[string]>
 
-Prefixes the URL on navigations when a path (no origin) is passed to [`method: Page.goto`]. You can specify also a
-base URL with a path. Examples:
+When using [`method: Page.goto`], [`method: Page.route`], [`method: Page.waitForURL`], [`method: Page.waitForRequest`], or [`method: Page.waitForResponse`] it takes the base URL in consideration by using the [`URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor for building the corresponding URL. Examples:
 * baseURL: `http://localhost:3000` and navigating to `/bar.html` results in `http://localhost:3000/bar.html`
-* baseURL: `http://localhost:3000/foo/` and navigating to `/bar.html` results in `http://localhost:3000/foo/bar.html`
+* baseURL: `http://localhost:3000/foo/` and navigating to `./bar.html` results in `http://localhost:3000/foo/bar.html`
 
 ## context-option-viewport
 * langs: js, java

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -213,6 +213,14 @@ Whether to ignore HTTPS errors during navigation. Defaults to `false`.
 
 Toggles bypassing page's Content-Security-Policy.
 
+## context-option-baseURL
+- `baseURL` <[string]>
+
+Prefixes the URL on navigations when a path (no origin) is passed to [`method: Page.goto`]. You can specify also a
+base URL with a path. Examples:
+* baseURL: `http://localhost:3000` and navigating to `/bar.html` results in `http://localhost:3000/bar.html`
+* baseURL: `http://localhost:3000/foo/` and navigating to `/bar.html` results in `http://localhost:3000/foo/bar.html`
+
 ## context-option-viewport
 * langs: js, java
   - alias-java: viewportSize
@@ -566,6 +574,7 @@ using the [`method: AndroidDevice.setDefaultTimeout`] method.
 - %%-context-option-acceptdownloads-%%
 - %%-context-option-ignorehttpserrors-%%
 - %%-context-option-bypasscsp-%%
+- %%-context-option-baseURL-%%
 - %%-context-option-viewport-%%
 - %%-csharp-context-option-viewport-%%
 - %%-python-context-option-viewport-%%

--- a/src/client/browserContext.ts
+++ b/src/client/browserContext.ts
@@ -128,7 +128,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel,
 
   _onRoute(route: network.Route, request: network.Request) {
     for (const {url, handler} of this._routes) {
-      if (urlMatches(request.url(), url)) {
+      if (urlMatches(this._options.baseURL, request.url(), url)) {
         handler(route, request);
         return;
       }

--- a/src/client/clientHelper.ts
+++ b/src/client/clientHelper.ts
@@ -17,7 +17,7 @@
 
 import * as types from './types';
 import fs from 'fs';
-import { isString, isRegExp } from '../utils/utils';
+import { isString, isRegExp, constructURLBasedOnBaseURL } from '../utils/utils';
 
 const deprecatedHits = new Set();
 export function deprecate(methodName: string, message: string) {
@@ -65,8 +65,10 @@ export function parsedURL(url: string): URL | null {
   }
 }
 
-export function urlMatches(urlString: string, match: types.URLMatch | undefined): boolean {
+export function urlMatches(baseURL: string | undefined, urlString: string, match: types.URLMatch | undefined): boolean {
   if (match === undefined || match === '')
+    return true;
+  if (baseURL && isString(match) && !match.startsWith('*') && urlMatches(undefined, urlString, constructURLBasedOnBaseURL(baseURL, match)))
     return true;
   if (isString(match))
     match = globToRegex(match);

--- a/src/client/clientHelper.ts
+++ b/src/client/clientHelper.ts
@@ -68,8 +68,8 @@ export function parsedURL(url: string): URL | null {
 export function urlMatches(baseURL: string | undefined, urlString: string, match: types.URLMatch | undefined): boolean {
   if (match === undefined || match === '')
     return true;
-  if (baseURL && isString(match) && !match.startsWith('*') && urlMatches(undefined, urlString, constructURLBasedOnBaseURL(baseURL, match)))
-    return true;
+  if (isString(match) && !match.startsWith('*'))
+    match = constructURLBasedOnBaseURL(baseURL, match);
   if (isString(match))
     match = globToRegex(match);
   if (isRegExp(match))

--- a/src/client/frame.ts
+++ b/src/client/frame.ts
@@ -119,7 +119,7 @@ export class Frame extends ChannelOwner<channels.FrameChannel, channels.FrameIni
         if (event.error)
           return true;
         waiter.log(`  navigated to "${event.url}"`);
-        return urlMatches(event.url, options.url);
+        return urlMatches(this._page?.context()._options.baseURL, event.url, options.url);
       });
       if (navigatedEvent.error) {
         const e = new Error(navigatedEvent.error);
@@ -156,7 +156,7 @@ export class Frame extends ChannelOwner<channels.FrameChannel, channels.FrameIni
   }
 
   async waitForURL(url: URLMatch, options: { waitUntil?: LifecycleEvent, timeout?: number } = {}): Promise<void> {
-    if (urlMatches(this.url(), url))
+    if (urlMatches(this._page?.context()._options.baseURL, this.url(), url))
       return await this.waitForLoadState(options?.waitUntil, options);
     await this.waitForNavigation({ url, ...options });
   }

--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -162,7 +162,7 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
 
   private _onRoute(route: Route, request: Request) {
     for (const {url, handler} of this._routes) {
-      if (urlMatches(request.url(), url)) {
+      if (urlMatches(this._browserContext._options.baseURL, request.url(), url)) {
         handler(route, request);
         return;
       }
@@ -217,7 +217,7 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     return this.frames().find(f => {
       if (name)
         return f.name() === name;
-      return urlMatches(f.url(), url);
+      return urlMatches(this._browserContext._options.baseURL, f.url(), url);
     }) || null;
   }
 
@@ -352,7 +352,7 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     return this._wrapApiCall(async (channel: channels.PageChannel, stackTrace: ParsedStackTrace) => {
       const predicate = (request: Request) => {
         if (isString(urlOrPredicate) || isRegExp(urlOrPredicate))
-          return urlMatches(request.url(), urlOrPredicate);
+          return urlMatches(this._browserContext._options.baseURL, request.url(), urlOrPredicate);
         return urlOrPredicate(request);
       };
       const trimmedUrl = trimUrl(urlOrPredicate);
@@ -365,7 +365,7 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     return this._wrapApiCall(async (channel: channels.PageChannel, stackTrace: ParsedStackTrace) => {
       const predicate = (response: Response) => {
         if (isString(urlOrPredicate) || isRegExp(urlOrPredicate))
-          return urlMatches(response.url(), urlOrPredicate);
+          return urlMatches(this._browserContext._options.baseURL, response.url(), urlOrPredicate);
         return urlOrPredicate(response);
       };
       const trimmedUrl = trimUrl(urlOrPredicate);

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -337,6 +337,7 @@ export type BrowserTypeLaunchPersistentContextParams = {
   colorScheme?: 'dark' | 'light' | 'no-preference',
   reducedMotion?: 'reduce' | 'no-preference',
   acceptDownloads?: boolean,
+  baseURL?: string,
   _debugName?: string,
   recordVideo?: {
     dir: string,
@@ -407,6 +408,7 @@ export type BrowserTypeLaunchPersistentContextOptions = {
   colorScheme?: 'dark' | 'light' | 'no-preference',
   reducedMotion?: 'reduce' | 'no-preference',
   acceptDownloads?: boolean,
+  baseURL?: string,
   _debugName?: string,
   recordVideo?: {
     dir: string,
@@ -497,6 +499,7 @@ export type BrowserNewContextParams = {
   colorScheme?: 'dark' | 'light' | 'no-preference',
   reducedMotion?: 'reduce' | 'no-preference',
   acceptDownloads?: boolean,
+  baseURL?: string,
   _debugName?: string,
   recordVideo?: {
     dir: string,
@@ -554,6 +557,7 @@ export type BrowserNewContextOptions = {
   colorScheme?: 'dark' | 'light' | 'no-preference',
   reducedMotion?: 'reduce' | 'no-preference',
   acceptDownloads?: boolean,
+  baseURL?: string,
   _debugName?: string,
   recordVideo?: {
     dir: string,

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -322,6 +322,7 @@ ContextOptions:
       - reduce
       - no-preference
     acceptDownloads: boolean?
+    baseURL: string?
     _debugName: string?
     recordVideo:
       type: object?

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -245,6 +245,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     colorScheme: tOptional(tEnum(['dark', 'light', 'no-preference'])),
     reducedMotion: tOptional(tEnum(['reduce', 'no-preference'])),
     acceptDownloads: tOptional(tBoolean),
+    baseURL: tOptional(tString),
     _debugName: tOptional(tString),
     recordVideo: tOptional(tObject({
       dir: tString,
@@ -304,6 +305,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     colorScheme: tOptional(tEnum(['dark', 'light', 'no-preference'])),
     reducedMotion: tOptional(tEnum(['reduce', 'no-preference'])),
     acceptDownloads: tOptional(tBoolean),
+    baseURL: tOptional(tString),
     _debugName: tOptional(tString),
     recordVideo: tOptional(tObject({
       dir: tString,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -263,6 +263,7 @@ export type BrowserContextOptions = {
     path: string
   },
   proxy?: ProxySettings,
+  baseURL?: string,
   _debugName?: string,
 };
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -315,14 +315,9 @@ export function getUserAgent() {
 }
 
 export function constructURLBasedOnBaseURL(baseURL: string | undefined, givenURL: string): string {
-  if (!baseURL)
-    return givenURL;
   try {
-    new URL.URL(givenURL);
-    return givenURL;
-  } catch (error) {
-    if (givenURL === '/' || givenURL === '')
-      return baseURL + givenURL;
     return (new URL.URL(givenURL, baseURL)).toString();
+  } catch (e) {
+    return givenURL;
   }
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -323,8 +323,6 @@ export function constructURLBasedOnBaseURL(baseURL: string | undefined, givenURL
   } catch (error) {
     if (givenURL === '/' || givenURL === '')
       return baseURL + givenURL;
-    const hasNoSlashes = baseURL[baseURL.length - 1] !== '/' && givenURL[0] !== '/';
-    const hasDoubleSlashes = baseURL[baseURL.length - 1] === '/' && givenURL[0] === '/';
-    return baseURL + (hasNoSlashes ? '/' : '') + (hasDoubleSlashes ? givenURL.substr(1) : givenURL);
+    return (new URL.URL(givenURL, baseURL)).toString();
   }
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -313,3 +313,18 @@ export function getUserAgent() {
   const packageJson = require('./../../package.json');
   return `Playwright/${packageJson.version} (${os.arch()}/${os.platform()}/${os.release()})`;
 }
+
+export function constructURLBasedOnBaseURL(baseURL: string | undefined, givenURL: string): string {
+  if (!baseURL)
+    return givenURL;
+  try {
+    new URL.URL(givenURL);
+    return givenURL;
+  } catch (error) {
+    if (givenURL === '/' || givenURL === '')
+      return baseURL + givenURL;
+    const hasNoSlashes = baseURL[baseURL.length - 1] !== '/' && givenURL[0] !== '/';
+    const hasDoubleSlashes = baseURL[baseURL.length - 1] === '/' && givenURL[0] === '/';
+    return baseURL + (hasNoSlashes ? '/' : '') + (hasDoubleSlashes ? givenURL.substr(1) : givenURL);
+  }
+}

--- a/tests/browsercontext-base-url.spec.ts
+++ b/tests/browsercontext-base-url.spec.ts
@@ -38,9 +38,9 @@ it('should construct a new URL when a relative path in browser.newPage is passed
   const page = await browser.newPage({
     baseURL: server.PREFIX + '/url-construction',
   });
-  expect((await page.goto('mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
-  expect((await page.goto('./mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
-  expect((await page.goto('/mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
+  expect((await page.goto('mypage.html')).url()).toBe(server.PREFIX + '/mypage.html');
+  expect((await page.goto('./mypage.html')).url()).toBe(server.PREFIX + '/mypage.html');
+  expect((await page.goto('/mypage.html')).url()).toBe(server.PREFIX + '/mypage.html');
   await page.close();
 });
 
@@ -50,7 +50,7 @@ it('should construct a new URL when a relative path in browser.newPage is passed
   });
   expect((await page.goto('mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
   expect((await page.goto('./mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
-  expect((await page.goto('/mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
+  expect((await page.goto('/mypage.html')).url()).toBe(server.PREFIX + '/mypage.html');
   await page.close();
 });
 
@@ -89,13 +89,14 @@ it('should be able to match a URL relative to its given URL with urlMatcher', as
   });
   await page.goto('/kek/index.html');
   await page.waitForURL('/kek/index.html');
-  await page.route('/kek/index.html', route => route.fulfill({
+  expect(page.url()).toBe(server.PREFIX + '/kek/index.html');
+  await page.route('./kek/index.html', route => route.fulfill({
     body: 'base-url-matched-route',
   }));
   const [request, response] = await Promise.all([
-    page.waitForRequest('/kek/index.html'),
-    page.waitForResponse('/kek/index.html'),
-    page.goto('/kek/index.html'),
+    page.waitForRequest('./kek/index.html'),
+    page.waitForResponse('./kek/index.html'),
+    page.goto('./kek/index.html'),
   ]);
   expect(request.url()).toBe(server.PREFIX + '/foobar/kek/index.html');
   expect(response.url()).toBe(server.PREFIX + '/foobar/kek/index.html');

--- a/tests/browsercontext-base-url.spec.ts
+++ b/tests/browsercontext-base-url.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ * Modifications copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { browserTest as it, expect } from './config/browserTest';
+
+it('should construct a new URL when a path in browser.newContext is passed to page.goto', async function({browser, server}) {
+  const context = await browser.newContext({
+    baseURL: server.PREFIX,
+  });
+  const page = await context.newPage();
+  expect((await page.goto('/empty.html')).url()).toBe(server.EMPTY_PAGE);
+  await context.close();
+});
+
+it('should construct a new URL when a path in browser.newPage is passed to page.goto', async function({browser, server}) {
+  const page = await browser.newPage({
+    baseURL: server.PREFIX,
+  });
+  expect((await page.goto('/empty.html')).url()).toBe(server.EMPTY_PAGE);
+  await page.close();
+});
+
+it('should construct a new URL when a relative path in browser.newPage is passed to page.goto', async function({browser, server}) {
+  const page = await browser.newPage({
+    baseURL: server.PREFIX + '/url-construction',
+  });
+  expect((await page.goto('mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
+  expect((await page.goto('./mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
+  await page.close();
+});
+
+it('should construct a new URL when a relative path in browser.newPage is passed to page.goto', async function({browser, server}) {
+  const page = await browser.newPage({
+    baseURL: server.PREFIX + '/url-construction/',
+  });
+  expect((await page.goto('mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
+  expect((await page.goto('./mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
+  await page.close();
+});
+
+it('should navigate to the base URL if / or empty string is passed', async function({browser, server}) {
+  const page = await browser.newPage({
+    baseURL: server.PREFIX + '/url-construction',
+  });
+  expect((await page.goto('')).url()).toBe(server.PREFIX + '/url-construction');
+  expect((await page.goto('/')).url()).toBe(server.PREFIX + '/url-construction/');
+  await page.close();
+});
+
+it('should not construct a new URL when the given URL is valid', async function({browser, server}) {
+  const page = await browser.newPage({
+    baseURL: 'http://microsoft.com',
+  });
+  expect((await page.goto(server.EMPTY_PAGE)).url()).toBe(server.EMPTY_PAGE);
+  await page.close();
+});
+
+it('should not construct a new URL when no valid HTTP URLs are passed', async function({browser, server}) {
+  const page = await browser.newPage({
+    baseURL: 'http://microsoft.com',
+  });
+  await page.goto('data:text/html,Hello world');
+  expect(await page.evaluate(() => window.location.href)).toBe('data:text/html,Hello world');
+
+  await page.goto('about:blank');
+  expect(await page.evaluate(() => window.location.href)).toBe('about:blank');
+  await page.close();
+});

--- a/tests/browsercontext-base-url.spec.ts
+++ b/tests/browsercontext-base-url.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should construct a new URL when a path in browser.newContext is passed to page.goto', async function({browser, server}) {
+it('should construct a new URL when a baseURL in browser.newContext is passed to page.goto', async function({browser, server}) {
   const context = await browser.newContext({
     baseURL: server.PREFIX,
   });
@@ -26,7 +26,7 @@ it('should construct a new URL when a path in browser.newContext is passed to pa
   await context.close();
 });
 
-it('should construct a new URL when a path in browser.newPage is passed to page.goto', async function({browser, server}) {
+it('should construct a new URL when a baseURL in browser.newPage is passed to page.goto', async function({browser, server}) {
   const page = await browser.newPage({
     baseURL: server.PREFIX,
   });
@@ -34,7 +34,7 @@ it('should construct a new URL when a path in browser.newPage is passed to page.
   await page.close();
 });
 
-it('should construct a new URL when a relative path in browser.newPage is passed to page.goto', async function({browser, server}) {
+it('should construct the URLs correctly when a baseURL without a trailing slash in browser.newPage is passed to page.goto', async function({browser, server}) {
   const page = await browser.newPage({
     baseURL: server.PREFIX + '/url-construction',
   });
@@ -44,37 +44,24 @@ it('should construct a new URL when a relative path in browser.newPage is passed
   await page.close();
 });
 
-it('should construct a new URL when a relative path in browser.newPage is passed to page.goto', async function({browser, server}) {
+it('should construct the URLs correctly when a baseURL with a trailing slash in browser.newPage is passed to page.goto', async function({browser, server}) {
   const page = await browser.newPage({
     baseURL: server.PREFIX + '/url-construction/',
   });
   expect((await page.goto('mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
   expect((await page.goto('./mypage.html')).url()).toBe(server.PREFIX + '/url-construction/mypage.html');
   expect((await page.goto('/mypage.html')).url()).toBe(server.PREFIX + '/mypage.html');
+  expect((await page.goto('.')).url()).toBe(server.PREFIX + '/url-construction/');
+  expect((await page.goto('/')).url()).toBe(server.PREFIX + '/');
   await page.close();
 });
 
-it('should navigate to the base URL if / or empty string is passed', async function({browser, server}) {
-  const page = await browser.newPage({
-    baseURL: server.PREFIX + '/url-construction',
-  });
-  expect((await page.goto('')).url()).toBe(server.PREFIX + '/url-construction');
-  expect((await page.goto('/')).url()).toBe(server.PREFIX + '/url-construction/');
-  await page.close();
-});
-
-it('should not construct a new URL when the given URL is valid', async function({browser, server}) {
+it('should not construct a new URL when valid URLs are passed', async function({browser, server}) {
   const page = await browser.newPage({
     baseURL: 'http://microsoft.com',
   });
   expect((await page.goto(server.EMPTY_PAGE)).url()).toBe(server.EMPTY_PAGE);
-  await page.close();
-});
 
-it('should not construct a new URL when no valid HTTP URLs are passed', async function({browser, server}) {
-  const page = await browser.newPage({
-    baseURL: 'http://microsoft.com',
-  });
   await page.goto('data:text/html,Hello world');
   expect(await page.evaluate(() => window.location.href)).toBe('data:text/html,Hello world');
 
@@ -90,6 +77,7 @@ it('should be able to match a URL relative to its given URL with urlMatcher', as
   await page.goto('/kek/index.html');
   await page.waitForURL('/kek/index.html');
   expect(page.url()).toBe(server.PREFIX + '/kek/index.html');
+
   await page.route('./kek/index.html', route => route.fulfill({
     body: 'base-url-matched-route',
   }));

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1897,7 +1897,7 @@ export interface Page {
 
   /**
    * Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
-   * last redirect.
+   * last redirect. It will consider a base URL if you set it via `baseURL` when creating the context.
    *
    * `page.goto` will throw an error if:
    * - there's an SSL error (e.g. in case of self-signed certificates).
@@ -7021,6 +7021,15 @@ export interface BrowserType<Unused = {}> {
     args?: Array<string>;
 
     /**
+     * Prefixes the URL on navigations when a path (no origin) is passed to
+     * [page.goto(url[, options])](https://playwright.dev/docs/api/class-page#page-goto). You can specify also a base URL with
+     * a path. Examples:
+     * - baseURL: `http://localhost:3000` and navigating to `/bar.html` results in `http://localhost:3000/bar.html`
+     * - baseURL: `http://localhost:3000/foo/` and navigating to `/bar.html` results in `http://localhost:3000/foo/bar.html`
+     */
+    baseURL?: string;
+
+    /**
      * Toggles bypassing page's Content-Security-Policy.
      */
     bypassCSP?: boolean;
@@ -8145,6 +8154,15 @@ export interface AndroidDevice {
     acceptDownloads?: boolean;
 
     /**
+     * Prefixes the URL on navigations when a path (no origin) is passed to
+     * [page.goto(url[, options])](https://playwright.dev/docs/api/class-page#page-goto). You can specify also a base URL with
+     * a path. Examples:
+     * - baseURL: `http://localhost:3000` and navigating to `/bar.html` results in `http://localhost:3000/bar.html`
+     * - baseURL: `http://localhost:3000/foo/` and navigating to `/bar.html` results in `http://localhost:3000/foo/bar.html`
+     */
+    baseURL?: string;
+
+    /**
      * Toggles bypassing page's Content-Security-Policy.
      */
     bypassCSP?: boolean;
@@ -8901,6 +8919,15 @@ export interface Browser extends EventEmitter {
      * Whether to automatically download all the attachments. Defaults to `false` where all the downloads are canceled.
      */
     acceptDownloads?: boolean;
+
+    /**
+     * Prefixes the URL on navigations when a path (no origin) is passed to
+     * [page.goto(url[, options])](https://playwright.dev/docs/api/class-page#page-goto). You can specify also a base URL with
+     * a path. Examples:
+     * - baseURL: `http://localhost:3000` and navigating to `/bar.html` results in `http://localhost:3000/bar.html`
+     * - baseURL: `http://localhost:3000/foo/` and navigating to `/bar.html` results in `http://localhost:3000/foo/bar.html`
+     */
+    baseURL?: string;
 
     /**
      * Toggles bypassing page's Content-Security-Policy.
@@ -11038,6 +11065,15 @@ export interface BrowserContextOptions {
    * Whether to automatically download all the attachments. Defaults to `false` where all the downloads are canceled.
    */
   acceptDownloads?: boolean;
+
+  /**
+   * Prefixes the URL on navigations when a path (no origin) is passed to
+   * [page.goto(url[, options])](https://playwright.dev/docs/api/class-page#page-goto). You can specify also a base URL with
+   * a path. Examples:
+   * - baseURL: `http://localhost:3000` and navigating to `/bar.html` results in `http://localhost:3000/bar.html`
+   * - baseURL: `http://localhost:3000/foo/` and navigating to `/bar.html` results in `http://localhost:3000/foo/bar.html`
+   */
+  baseURL?: string;
 
   /**
    * Toggles bypassing page's Content-Security-Policy.

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1897,7 +1897,7 @@ export interface Page {
 
   /**
    * Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
-   * last redirect. It will consider a base URL if you set it via `baseURL` when creating the context.
+   * last redirect. It will consider the base URL if you set it via `baseURL` when creating the context.
    *
    * `page.goto` will throw an error if:
    * - there's an SSL error (e.g. in case of self-signed certificates).
@@ -2438,6 +2438,8 @@ export interface Page {
    *
    * To remove a route with its handler you can use
    * [page.unroute(url[, handler])](https://playwright.dev/docs/api/class-page#page-unroute).
+   *
+   * It will consider the base URL if you set it via `baseURL` when creating the context.
    *
    * > NOTE: Enabling routing disables http cache.
    * @param url A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
@@ -3169,8 +3171,8 @@ export interface Page {
   }): Promise<null|Response>;
 
   /**
-   * Waits for the matching request and returns it.  See [waiting for event](https://playwright.dev/docs/events#waiting-for-event) for more details
-   * about events.
+   * Waits for the matching request and returns it. See [waiting for event](https://playwright.dev/docs/events#waiting-for-event) for more details
+   * about events. It will consider the base URL if you set it via `baseURL` when creating the context.
    *
    * ```js
    * // Note that Promise.all prevents a race condition
@@ -3204,7 +3206,8 @@ export interface Page {
   }): Promise<Request>;
 
   /**
-   * Returns the matched response. See [waiting for event](https://playwright.dev/docs/events#waiting-for-event) for more details about events.
+   * Returns the matched response. See [waiting for event](https://playwright.dev/docs/events#waiting-for-event) for more details about events. It
+   * will consider the base URL if you set it via `baseURL` when creating the context.
    *
    * ```js
    * // Note that Promise.all prevents a race condition
@@ -3256,7 +3259,8 @@ export interface Page {
   waitForTimeout(timeout: number): Promise<void>;
 
   /**
-   * Waits for the main frame to navigate to the given URL.
+   * Waits for the main frame to navigate to the given URL. It will consider the base URL if you set it via `baseURL` when
+   * creating the context.
    *
    * ```js
    * await page.click('a.delayed-navigation'); // Clicking the link will indirectly cause a navigation
@@ -5446,7 +5450,8 @@ export interface BrowserContext {
 
   /**
    * Routing provides the capability to modify network requests that are made by any page in the browser context. Once route
-   * is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
+   * is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted. It will
+   * consider the base URL if you set it via `baseURL` when creating the context.
    *
    * An example of a naive handler that aborts all image requests:
    *


### PR DESCRIPTION
Relevant related implementation for customers who are migrating see [here](https://github.com/cypress-io/cypress/blob/b457010bd742a64da64daf7816ce8832f63990f7/packages/driver/src/cypress/location.js#L199).

There is `pytest-base-url`, but they don't construct a new URL, see [here](https://github.com/pytest-dev/pytest-base-url).

Fixes #7408
