### PR TITLE
feat(firefox-beta): roll to 1267

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "firefox-beta",
-      "revision": "1264",
+      "revision": "1267",
       "installByDefault": false
     },
     {


### PR DESCRIPTION
Currently blocked that the MacOS 10.14 bots are busted.