### PR TITLE
feat(api): add method to `setDefaultTimeout` for browser

### DIFF
--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -244,6 +244,11 @@ This setting will change the default maximum time for all the methods accepting 
 [`method: BrowserContext.setDefaultNavigationTimeout`] take priority over [`method: Browser.setDefaultTimeout`].
 :::
 
+### param: Browser.setDefaultTimeout.timeout
+- `timeout` <[float]>
+
+Maximum time in milliseconds
+
 ## async method: Browser.startTracing
 * langs: java, js, python
 

--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -235,6 +235,15 @@ testing frameworks should explicitly create [`method: Browser.newContext`] follo
 
 ### option: Browser.newPage.storageStatePath = %%-csharp-java-context-option-storage-state-path-%%
 
+## method: Browser.setDefaultTimeout
+
+This setting will change the default maximum time for all the methods accepting [`param: timeout`] option.
+
+:::note
+[`method: Page.setDefaultNavigationTimeout`], [`method: Page.setDefaultTimeout`], [`method: BrowserContext.setDefaultTimeout`] and
+[`method: BrowserContext.setDefaultNavigationTimeout`] take priority over [`method: Browser.setDefaultTimeout`].
+:::
+
 ## async method: Browser.startTracing
 * langs: java, js, python
 

--- a/src/browserServerImpl.ts
+++ b/src/browserServerImpl.ts
@@ -34,6 +34,7 @@ import { BrowserContext } from './server/browserContext';
 import { CRBrowser } from './server/chromium/crBrowser';
 import { CDPSessionDispatcher } from './dispatchers/cdpSessionDispatcher';
 import { PageDispatcher } from './dispatchers/pageDispatcher';
+import { TimeoutSettings } from './utils/timeoutSettings';
 
 export class BrowserServerLauncherImpl implements BrowserServerLauncher {
   private _browserName: 'chromium' | 'firefox' | 'webkit';
@@ -100,6 +101,7 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
 class ConnectedBrowserDispatcher extends Dispatcher<Browser, channels.BrowserInitializer> implements channels.BrowserChannel {
   private _contexts = new Set<BrowserContext>();
   private _selectors: Selectors;
+  private _timeoutSettings = new TimeoutSettings();
 
   constructor(scope: DispatcherScope, browser: Browser, selectors: Selectors) {
     super(scope, browser, 'Browser', { version: browser.version(), name: browser.options.name }, true);
@@ -150,6 +152,10 @@ class ConnectedBrowserDispatcher extends Dispatcher<Browser, channels.BrowserIni
 
   async cleanupContexts() {
     await Promise.all(Array.from(this._contexts).map(context => context.close(internalCallMetadata())));
+  }
+
+  async setDefaultTimeout(params: channels.BrowserSetDefaultTimeoutParams) {
+    this._timeoutSettings.setDefaultTimeout(params.timeout);
   }
 }
 

--- a/src/client/browser.ts
+++ b/src/client/browser.ts
@@ -86,7 +86,7 @@ export class Browser extends ChannelOwner<channels.BrowserChannel, channels.Brow
 
   setDefaultTimeout(timeout: number) {
     this._timeoutSettings.setDefaultTimeout(timeout);
-    this._channel.setDefaultTimeoutNoReply({ timeout });
+    this._channel.setDefaultTimeout({ timeout });
   }
 
   async startTracing(page?: Page, options: { path?: string; screenshots?: boolean; categories?: string[]; } = {}) {

--- a/src/client/browser.ts
+++ b/src/client/browser.ts
@@ -31,7 +31,7 @@ export class Browser extends ChannelOwner<channels.BrowserChannel, channels.Brow
   _remoteType: 'owns-connection' | 'uses-connection' | null = null;
   readonly _name: string;
   _timeoutSettings = new TimeoutSettings();
-  
+
   static from(browser: channels.BrowserChannel): Browser {
     return (browser as any)._object;
   }

--- a/src/client/browser.ts
+++ b/src/client/browser.ts
@@ -23,14 +23,15 @@ import { BrowserContextOptions } from './types';
 import { isSafeCloseError } from '../utils/errors';
 import * as api from '../../types/types';
 import { CDPSession } from './cdpSession';
-
+import { TimeoutSettings } from '../utils/timeoutSettings';
 export class Browser extends ChannelOwner<channels.BrowserChannel, channels.BrowserInitializer> implements api.Browser {
   readonly _contexts = new Set<BrowserContext>();
   private _isConnected = true;
   private _closedPromise: Promise<void>;
   _remoteType: 'owns-connection' | 'uses-connection' | null = null;
   readonly _name: string;
-
+  _timeoutSettings = new TimeoutSettings();
+  
   static from(browser: channels.BrowserChannel): Browser {
     return (browser as any)._object;
   }
@@ -81,6 +82,11 @@ export class Browser extends ChannelOwner<channels.BrowserChannel, channels.Brow
     return this._wrapApiCall(async (channel: channels.BrowserChannel) => {
       return CDPSession.from((await channel.newBrowserCDPSession()).session);
     });
+  }
+
+  setDefaultTimeout(timeout: number) {
+    this._timeoutSettings.setDefaultTimeout(timeout);
+    this._channel.setDefaultTimeoutNoReply({ timeout });
   }
 
   async startTracing(page?: Page, options: { path?: string; screenshots?: boolean; categories?: string[]; } = {}) {

--- a/src/client/browserContext.ts
+++ b/src/client/browserContext.ts
@@ -65,10 +65,10 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel,
     if (parent instanceof Browser) {
       this._browser = parent;
       this._timeoutSettings = new TimeoutSettings(this._browser._timeoutSettings);
-    }
-    else
+    } else {
       this._timeoutSettings = new TimeoutSettings();
-    
+    }
+
     this._isChromium = this._browser?._name === 'chromium';
     this.tracing = new Tracing(this);
 

--- a/src/client/browserContext.ts
+++ b/src/client/browserContext.ts
@@ -39,7 +39,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel,
   private _routes: { url: URLMatch, handler: network.RouteHandler }[] = [];
   readonly _browser: Browser | null = null;
   readonly _bindings = new Map<string, (source: structs.BindingSource, ...args: any[]) => any>();
-  _timeoutSettings = new TimeoutSettings();
+  readonly _timeoutSettings: TimeoutSettings;
   _ownerPage: Page | undefined;
   private _closedPromise: Promise<void>;
   _options: channels.BrowserNewContextParams = {
@@ -62,8 +62,13 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel,
 
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.BrowserContextInitializer) {
     super(parent, type, guid, initializer);
-    if (parent instanceof Browser)
+    if (parent instanceof Browser) {
       this._browser = parent;
+      this._timeoutSettings = new TimeoutSettings(this._browser._timeoutSettings);
+    }
+    else
+      this._timeoutSettings = new TimeoutSettings();
+    
     this._isChromium = this._browser?._name === 'chromium';
     this.tracing = new Tracing(this);
 

--- a/src/dispatchers/browserDispatcher.ts
+++ b/src/dispatchers/browserDispatcher.ts
@@ -56,6 +56,10 @@ export class BrowserDispatcher extends Dispatcher<Browser, channels.BrowserIniti
     return { session: new CDPSessionDispatcher(this._scope, await crBrowser.newBrowserCDPSession()) };
   }
 
+  async setDefaultTimeoutNoReply(params: channels.BrowserSetDefaultTimeoutNoReplyParams) {
+    this._object.setDefaultTimeout(params.timeout);
+  }
+
   async startTracing(params: channels.BrowserStartTracingParams): Promise<void> {
     if (!this._object.options.isChromium)
       throw new Error(`Tracing is only available in Chromium`);

--- a/src/dispatchers/browserDispatcher.ts
+++ b/src/dispatchers/browserDispatcher.ts
@@ -56,7 +56,7 @@ export class BrowserDispatcher extends Dispatcher<Browser, channels.BrowserIniti
     return { session: new CDPSessionDispatcher(this._scope, await crBrowser.newBrowserCDPSession()) };
   }
 
-  async setDefaultTimeoutNoReply(params: channels.BrowserSetDefaultTimeoutNoReplyParams) {
+  async setDefaultTimeout(params: channels.BrowserSetDefaultTimeoutParams) {
     this._object.setDefaultTimeout(params.timeout);
   }
 

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -446,7 +446,7 @@ export interface BrowserChannel extends Channel {
   newBrowserCDPSession(params?: BrowserNewBrowserCDPSessionParams, metadata?: Metadata): Promise<BrowserNewBrowserCDPSessionResult>;
   startTracing(params: BrowserStartTracingParams, metadata?: Metadata): Promise<BrowserStartTracingResult>;
   stopTracing(params?: BrowserStopTracingParams, metadata?: Metadata): Promise<BrowserStopTracingResult>;
-  setDefaultTimeoutNoReply(params: BrowserSetDefaultTimeoutNoReplyParams, metadata?: Metadata): Promise<BrowserSetDefaultTimeoutNoReplyResult>;
+  setDefaultTimeout(params: BrowserSetDefaultTimeoutParams, metadata?: Metadata): Promise<BrowserSetDefaultTimeoutResult>;
 }
 export type BrowserCloseEvent = {};
 export type BrowserCloseParams = {};
@@ -596,13 +596,13 @@ export type BrowserStopTracingOptions = {};
 export type BrowserStopTracingResult = {
   binary: Binary,
 };
-export type BrowserSetDefaultTimeoutNoReplyParams = {
+export type BrowserSetDefaultTimeoutParams = {
   timeout: number,
 };
-export type BrowserSetDefaultTimeoutNoReplyOptions = {
+export type BrowserSetDefaultTimeoutOptions = {
 
 };
-export type BrowserSetDefaultTimeoutNoReplyResult = void;
+export type BrowserSetDefaultTimeoutResult = void;
 
 // ----------- EventTarget -----------
 export type EventTargetInitializer = {};

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -446,6 +446,7 @@ export interface BrowserChannel extends Channel {
   newBrowserCDPSession(params?: BrowserNewBrowserCDPSessionParams, metadata?: Metadata): Promise<BrowserNewBrowserCDPSessionResult>;
   startTracing(params: BrowserStartTracingParams, metadata?: Metadata): Promise<BrowserStartTracingResult>;
   stopTracing(params?: BrowserStopTracingParams, metadata?: Metadata): Promise<BrowserStopTracingResult>;
+  setDefaultTimeoutNoReply(params: BrowserSetDefaultTimeoutNoReplyParams, metadata?: Metadata): Promise<BrowserSetDefaultTimeoutNoReplyResult>;
 }
 export type BrowserCloseEvent = {};
 export type BrowserCloseParams = {};
@@ -595,6 +596,13 @@ export type BrowserStopTracingOptions = {};
 export type BrowserStopTracingResult = {
   binary: Binary,
 };
+export type BrowserSetDefaultTimeoutNoReplyParams = {
+  timeout: number,
+};
+export type BrowserSetDefaultTimeoutNoReplyOptions = {
+
+};
+export type BrowserSetDefaultTimeoutNoReplyResult = void;
 
 // ----------- EventTarget -----------
 export type EventTargetInitializer = {};

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -484,7 +484,7 @@ Browser:
       returns:
         binary: binary
     
-    setDefaultTimeoutNoReply:
+    setDefaultTimeout:
       parameters:
         timeout: number
 

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -483,6 +483,10 @@ Browser:
     stopTracing:
       returns:
         binary: binary
+    
+    setDefaultTimeoutNoReply:
+      parameters:
+        timeout: number
 
   events:
 

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -328,7 +328,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     categories: tOptional(tArray(tString)),
   });
   scheme.BrowserStopTracingParams = tOptional(tObject({}));
-  scheme.BrowserSetDefaultTimeoutNoReplyParams = tObject({
+  scheme.BrowserSetDefaultTimeoutParams = tObject({
     timeout: tNumber,
   });
   scheme.EventTargetWaitForEventInfoParams = tObject({

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -328,6 +328,9 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     categories: tOptional(tArray(tString)),
   });
   scheme.BrowserStopTracingParams = tOptional(tObject({}));
+  scheme.BrowserSetDefaultTimeoutNoReplyParams = tObject({
+    timeout: tNumber,
+  });
   scheme.EventTargetWaitForEventInfoParams = tObject({
     info: tObject({
       waitId: tString,

--- a/src/server/browser.ts
+++ b/src/server/browser.ts
@@ -25,7 +25,7 @@ import * as registry from '../utils/registry';
 import { SdkObject } from './instrumentation';
 import { Artifact } from './artifact';
 import { Selectors } from './selectors';
-
+import { TimeoutSettings } from '../utils/timeoutSettings';
 export interface BrowserProcess {
   onclose?: ((exitCode: number | null, signal: string | null) => void);
   process?: ChildProcess;
@@ -68,6 +68,7 @@ export abstract class Browser extends SdkObject {
   _defaultContext: BrowserContext | null = null;
   private _startedClosing = false;
   readonly _idToVideo = new Map<string, { context: BrowserContext, artifact: Artifact }>();
+  readonly _timeoutSettings = new TimeoutSettings();
 
   constructor(options: BrowserOptions) {
     super(options.rootSdkObject, 'browser');
@@ -124,6 +125,10 @@ export abstract class Browser extends SdkObject {
     if (this._defaultContext)
       this._defaultContext._browserClosed();
     this.emit(Browser.Events.Disconnected);
+  }
+
+  setDefaultTimeout(timeout: number) {
+    this._timeoutSettings.setDefaultTimeout(timeout);
   }
 
   async close() {

--- a/src/server/browserContext.ts
+++ b/src/server/browserContext.ts
@@ -47,7 +47,7 @@ export abstract class BrowserContext extends SdkObject {
     VideoStarted: 'videostarted',
   };
 
-  readonly _timeoutSettings = new TimeoutSettings();
+  readonly _timeoutSettings: TimeoutSettings;
   readonly _pageBindings = new Map<string, PageBinding>();
   readonly _options: types.BrowserContextOptions;
   _requestInterceptor?: network.RouteHandler;
@@ -72,6 +72,8 @@ export abstract class BrowserContext extends SdkObject {
     this._browserContextId = browserContextId;
     this._isPersistentContext = !browserContextId;
     this._closePromise = new Promise(fulfill => this._closePromiseFulfill = fulfill);
+    // to ensure that timeout settings are inherited from browser
+    this._timeoutSettings = new TimeoutSettings(browser._timeoutSettings);
 
     if (this._options.recordHar)
       this._harTracer = new HarTracer(this, this._options.recordHar);

--- a/tests/browser.spec.ts
+++ b/tests/browser.spec.ts
@@ -46,17 +46,16 @@ test('version should work', async function({browser, browserName}) {
     expect(version.match(/^\d+\.\d+/)).toBeTruthy();
 });
 
-test('should fail when exceeding browser timeout', async function ({ browser,server, browserName,playwright }) {
-  
-    // Hang for request to the empty.html
+test('should fail when exceeding browser timeout', async function({ browser,server, browserName,playwright }) {
+  // Hang for request to the empty.html
   server.setRoute('/empty.html', (req, res) => { });
   const page = await browser.newPage();
-    let error = null
+  let error = null;
   browser.setDefaultTimeout(2);
-    await page.goto(server.PREFIX + '/empty.html').catch(e => error = e);
-    expect(error.message).toContain('page.goto: Timeout 2ms exceeded.');
-    expect(error.message).toContain(server.PREFIX + '/empty.html');
-    expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
+  await page.goto(server.PREFIX + '/empty.html').catch(e => error = e);
+  expect(error.message).toContain('page.goto: Timeout 2ms exceeded.');
+  expect(error.message).toContain(server.PREFIX + '/empty.html');
+  expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
   const version = browser.version();
   if (browserName === 'chromium')
     expect(version.match(/^\d+\.\d+\.\d+\.\d+$/)).toBeTruthy();

--- a/tests/browser.spec.ts
+++ b/tests/browser.spec.ts
@@ -45,3 +45,21 @@ test('version should work', async function({browser, browserName}) {
   else
     expect(version.match(/^\d+\.\d+/)).toBeTruthy();
 });
+
+test('should fail when exceeding browser timeout', async function ({ browser,server, browserName,playwright }) {
+  
+    // Hang for request to the empty.html
+  server.setRoute('/empty.html', (req, res) => { });
+  const page = await browser.newPage();
+    let error = null
+  browser.setDefaultTimeout(2);
+    await page.goto(server.PREFIX + '/empty.html').catch(e => error = e);
+    expect(error.message).toContain('page.goto: Timeout 2ms exceeded.');
+    expect(error.message).toContain(server.PREFIX + '/empty.html');
+    expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
+  const version = browser.version();
+  if (browserName === 'chromium')
+    expect(version.match(/^\d+\.\d+\.\d+\.\d+$/)).toBeTruthy();
+  else
+    expect(version.match(/^\d+\.\d+/)).toBeTruthy();
+});

--- a/tests/browser.spec.ts
+++ b/tests/browser.spec.ts
@@ -46,7 +46,7 @@ test('version should work', async function({browser, browserName}) {
     expect(version.match(/^\d+\.\d+/)).toBeTruthy();
 });
 
-test('should fail when exceeding browser timeout', async function({ browser,server, browserName,playwright }) {
+test('should fail when exceeding browser timeout', async function({ browser, server, browserName, playwright }) {
   // Hang for request to the empty.html
   server.setRoute('/empty.html', (req, res) => { });
   const page = await browser.newPage();

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -9253,6 +9253,8 @@ export interface Browser extends EventEmitter {
    * Returns the browser version.
    */
   version(): string;
+
+  setDefaultTimeout(timeout: number): void;
 }
 
 export interface BrowserServer {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -9210,6 +9210,21 @@ export interface Browser extends EventEmitter {
   }): Promise<Page>;
 
   /**
+   * This setting will change the default maximum time for all the methods accepting `timeout` option.
+   *
+   * > NOTE:
+   * [page.setDefaultNavigationTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-navigation-timeout),
+   * [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout),
+   * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
+   * and
+   * [browserContext.setDefaultNavigationTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-navigation-timeout)
+   * take priority over
+   * [browser.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browser#browser-set-default-timeout).
+   * @param timeout Maximum time in milliseconds
+   */
+  setDefaultTimeout(timeout: number): void;
+
+  /**
    * > NOTE: Tracing is only supported on Chromium-based browsers.
    *
    * You can use [browser.startTracing([page, options])](https://playwright.dev/docs/api/class-browser#browser-start-tracing)

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -9253,8 +9253,6 @@ export interface Browser extends EventEmitter {
    * Returns the browser version.
    */
   version(): string;
-
-  setDefaultTimeout(timeout: number): void;
 }
 
 export interface BrowserServer {


### PR DESCRIPTION
Closes #5495 

## Todo
- [x] Add `setDefaultTimeout` for browser
- [x] Add new base test case for fallback to browser level timeout
- [x] Update docs for support of `setDefaultTimeout` for browser
