### PR TITLE
browser(webkit): add support to cancel a download

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1506
-Changed: dkolesa@igalia.com Thu Jul 1 14:56:59 CEST 2021
+1507
+Changed: max@schmitt.mx Mon Jul  5 07:01:00 UTC 2021

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -1,5 +1,5 @@
 diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
-index ad391d29fbf3..7361fa249d56 100644
+index ad391d29fbf3dc05e2092b436e2fa412199c3bea..7361fa249d564eac2032a3da771ec147012373ec 100644
 --- a/Source/JavaScriptCore/CMakeLists.txt
 +++ b/Source/JavaScriptCore/CMakeLists.txt
 @@ -1240,22 +1240,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
@@ -31,7 +31,7 @@ index ad391d29fbf3..7361fa249d56 100644
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/ServiceWorker.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Target.json
 diff --git a/Source/JavaScriptCore/DerivedSources.make b/Source/JavaScriptCore/DerivedSources.make
-index 9df8b244d4c4..2ea6388f09af 100644
+index 9df8b244d4c456901bddb412189963d065126327..2ea6388f09af272fa838ba257ee385cee7539aca 100644
 --- a/Source/JavaScriptCore/DerivedSources.make
 +++ b/Source/JavaScriptCore/DerivedSources.make
 @@ -265,22 +265,27 @@ INSPECTOR_DOMAINS := \
@@ -63,7 +63,7 @@ index 9df8b244d4c4..2ea6388f09af 100644
      $(JavaScriptCore)/inspector/protocol/ServiceWorker.json \
      $(JavaScriptCore)/inspector/protocol/Target.json \
 diff --git a/Source/JavaScriptCore/bindings/ScriptValue.cpp b/Source/JavaScriptCore/bindings/ScriptValue.cpp
-index 52d955b1e492..71c538e57acf 100644
+index 52d955b1e4929f6d0dede53097d275559b29b91d..71c538e57acf3912f9a777f7bc7eba6efb8877eb 100644
 --- a/Source/JavaScriptCore/bindings/ScriptValue.cpp
 +++ b/Source/JavaScriptCore/bindings/ScriptValue.cpp
 @@ -79,7 +79,10 @@ static RefPtr<JSON::Value> jsToInspectorValue(JSGlobalObject* globalObject, JSVa
@@ -79,7 +79,7 @@ index 52d955b1e492..71c538e57acf 100644
                  return nullptr;
              inspectorObject->setValue(name.string(), inspectorValue.releaseNonNull());
 diff --git a/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp b/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp
-index 95cd87b01b15..0481fa93227f 100644
+index 95cd87b01b15cb8667e57bc5bb51a71f06bc3760..0481fa93227f297be9d9cf000c5a72235956a390 100644
 --- a/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp
 +++ b/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp
 @@ -30,14 +30,21 @@
@@ -106,7 +106,7 @@ index 95cd87b01b15..0481fa93227f 100644
  {
      return addPrefixToIdentifier(String::number(++s_lastUsedIdentifier));
 diff --git a/Source/JavaScriptCore/inspector/IdentifiersFactory.h b/Source/JavaScriptCore/inspector/IdentifiersFactory.h
-index eb25aedee4cd..badf6559595c 100644
+index eb25aedee4cd9ebe007e06c2515b37ee095b06f4..badf6559595c8377db1089ca3c25008e1be2c8f1 100644
 --- a/Source/JavaScriptCore/inspector/IdentifiersFactory.h
 +++ b/Source/JavaScriptCore/inspector/IdentifiersFactory.h
 @@ -31,6 +31,7 @@ namespace Inspector {
@@ -118,7 +118,7 @@ index eb25aedee4cd..badf6559595c 100644
      static String requestId(unsigned long identifier);
  };
 diff --git a/Source/JavaScriptCore/inspector/InjectedScript.cpp b/Source/JavaScriptCore/inspector/InjectedScript.cpp
-index 8b290faebc18..53c68bca057c 100644
+index 8b290faebc1865519b0e7c514f497585dfc0bbda..53c68bca057c85c94201ef8e9870f0cb9e4cef6f 100644
 --- a/Source/JavaScriptCore/inspector/InjectedScript.cpp
 +++ b/Source/JavaScriptCore/inspector/InjectedScript.cpp
 @@ -91,7 +91,7 @@ void InjectedScript::awaitPromise(const String& promiseObjectId, bool returnByVa
@@ -155,7 +155,7 @@ index 8b290faebc18..53c68bca057c 100644
      auto resultValue = toInspectorValue(globalObject(), callResult.value());
      if (!resultValue)
 diff --git a/Source/JavaScriptCore/inspector/InjectedScript.h b/Source/JavaScriptCore/inspector/InjectedScript.h
-index e6b249672730..9f7b72259ab7 100644
+index e6b24967273095ae424ac9b3fe5e081ee8999ab7..9f7b72259ab79504b8bfcc24d35abe70d7372065 100644
 --- a/Source/JavaScriptCore/inspector/InjectedScript.h
 +++ b/Source/JavaScriptCore/inspector/InjectedScript.h
 @@ -64,7 +64,7 @@ public:
@@ -168,7 +168,7 @@ index e6b249672730..9f7b72259ab7 100644
      void functionDetails(Protocol::ErrorString&, JSC::JSValue, RefPtr<Protocol::Debugger::FunctionDetails>& result);
      void getPreview(Protocol::ErrorString&, const String& objectId, RefPtr<Protocol::Runtime::ObjectPreview>& result);
 diff --git a/Source/JavaScriptCore/inspector/InjectedScriptSource.js b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
-index 48baed6a1b7f..40d36f784f46 100644
+index 48baed6a1b7ffad453379a2f1eb71b8c4925f6c4..40d36f784f46e44dbad908402a71e6b02f499629 100644
 --- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
 +++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
 @@ -136,7 +136,7 @@ let InjectedScript = class InjectedScript
@@ -248,7 +248,7 @@ index 48baed6a1b7f..40d36f784f46 100644
      }
  
 diff --git a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
-index 4895c5a70d6a..e4905e0d4e5f 100644
+index 4895c5a70d6a4745597f77163bc92e0745594829..e4905e0d4e5ff88e479147c84e41359f9274b341 100644
 --- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
 +++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
 @@ -101,7 +101,7 @@ void BackendDispatcher::registerDispatcherForDomain(const String& domain, Supple
@@ -271,7 +271,7 @@ index 4895c5a70d6a..e4905e0d4e5f 100644
          // We could be called re-entrantly from a nested run loop, so restore the previous id.
          SetForScope<std::optional<long>> scopedRequestId(m_currentRequestId, requestId);
 diff --git a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
-index 37c4f9833d49..1c82cc978361 100644
+index 37c4f9833d4981b47bcd8debd4a79109254641a2..1c82cc9783618234bef7024d91821ce509912526 100644
 --- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
 +++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
 @@ -83,7 +83,10 @@ public:
@@ -287,7 +287,7 @@ index 37c4f9833d49..1c82cc978361 100644
      // Note that 'unused' is a workaround so the compiler can pick the right sendResponse based on arity.
      // When <http://webkit.org/b/179847> is fixed or this class is renamed for the JSON::Object case,
 diff --git a/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp b/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp
-index d408d364f198..1375ce9990f0 100644
+index d408d364f1986983161f9d44efbc8bc6f6898676..1375ce9990f0c63d7e6f33ee62930051d6cd44cb 100644
 --- a/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp
 +++ b/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp
 @@ -49,7 +49,7 @@ void FrontendRouter::connectFrontend(FrontendChannel& connection)
@@ -300,7 +300,7 @@ index d408d364f198..1375ce9990f0 100644
      }
  
 diff --git a/Source/JavaScriptCore/inspector/InspectorTarget.cpp b/Source/JavaScriptCore/inspector/InspectorTarget.cpp
-index 0cc2127c9c12..8ca65cc042d4 100644
+index 0cc2127c9c12c2d82dea9550bad73f4ffb99ba24..8ca65cc042d435cbc0e05dcc5c5dfc958eb24f5a 100644
 --- a/Source/JavaScriptCore/inspector/InspectorTarget.cpp
 +++ b/Source/JavaScriptCore/inspector/InspectorTarget.cpp
 @@ -44,6 +44,8 @@ void InspectorTarget::resume()
@@ -321,7 +321,7 @@ index 0cc2127c9c12..8ca65cc042d4 100644
  }
  
 diff --git a/Source/JavaScriptCore/inspector/InspectorTarget.h b/Source/JavaScriptCore/inspector/InspectorTarget.h
-index 4b95964db4d9..966a5927702b 100644
+index 4b95964db4d902b4b7f4b0b4c40afea51654ff2f..966a5927702b65edb343369decafda7fc83eaec7 100644
 --- a/Source/JavaScriptCore/inspector/InspectorTarget.h
 +++ b/Source/JavaScriptCore/inspector/InspectorTarget.h
 @@ -56,8 +56,12 @@ public:
@@ -338,7 +338,7 @@ index 4b95964db4d9..966a5927702b 100644
      bool m_isPaused { false };
  };
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
-index 76d72c7273f1..c0cf9588c04b 100644
+index 76d72c7273f1bb2170485015d931b1fba92d3b5a..c0cf9588c04bfba0d6176c4d6af691bd56ca6cec 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
 @@ -168,16 +168,15 @@ void InspectorRuntimeAgent::awaitPromise(const Protocol::Runtime::RemoteObjectId
@@ -386,7 +386,7 @@ index 76d72c7273f1..c0cf9588c04b 100644
  
  Protocol::ErrorStringOr<Ref<Protocol::Runtime::ObjectPreview>> InspectorRuntimeAgent::getPreview(const Protocol::Runtime::RemoteObjectId& objectId)
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
-index c4f6fa5b9de5..0d549faeb1f0 100644
+index c4f6fa5b9de54317da07c2371a7126aae1c967aa..0d549faeb1f0f80c7a6e7c208c72c6ef9cf4dbd5 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
 @@ -62,7 +62,7 @@ public:
@@ -399,7 +399,7 @@ index c4f6fa5b9de5..0d549faeb1f0 100644
      Protocol::ErrorStringOr<Ref<Protocol::Runtime::ObjectPreview>> getPreview(const Protocol::Runtime::RemoteObjectId&) final;
      Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Protocol::Runtime::PropertyDescriptor>>, RefPtr<JSON::ArrayOf<Protocol::Runtime::InternalPropertyDescriptor>>>> getProperties(const Protocol::Runtime::RemoteObjectId&, std::optional<bool>&& ownProperties, std::optional<int>&& fetchStart, std::optional<int>&& fetchCount, std::optional<bool>&& generatePreview) final;
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
-index 508eb02ec95c..c0099a56794a 100644
+index 508eb02ec95c52408384a1e2b77648afd426dd9d..c0099a56794ae411fe9cdce1a65a95f1a7e37924 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
 @@ -87,6 +87,34 @@ Protocol::ErrorStringOr<void> InspectorTargetAgent::sendMessageToTarget(const St
@@ -476,7 +476,7 @@ index 508eb02ec95c..c0099a56794a 100644
  {
      return m_router.hasLocalFrontend() ? Inspector::FrontendChannel::ConnectionType::Local : Inspector::FrontendChannel::ConnectionType::Remote;
 diff --git a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
-index e81573fd0fff..4169e227b5fb 100644
+index e81573fd0fffaaf6fd2af36635c78fcdf8608c69..4169e227b5fb5a3a7fb51396c4679100f495719c 100644
 --- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
 +++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
 @@ -50,15 +50,21 @@ public:
@@ -502,7 +502,7 @@ index e81573fd0fff..4169e227b5fb 100644
      // FrontendChannel
      FrontendChannel::ConnectionType connectionType() const;
 diff --git a/Source/JavaScriptCore/inspector/protocol/DOM.json b/Source/JavaScriptCore/inspector/protocol/DOM.json
-index 3a91ac6b57fa..ff51e7576281 100644
+index 3a91ac6b57fad7f472daa2e2107b3b483de70165..ff51e75762818b0bb5070ddf8de10e66018d63b0 100644
 --- a/Source/JavaScriptCore/inspector/protocol/DOM.json
 +++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
 @@ -80,6 +80,16 @@
@@ -598,7 +598,7 @@ index 3a91ac6b57fa..ff51e7576281 100644
      "events": [
 diff --git a/Source/JavaScriptCore/inspector/protocol/Dialog.json b/Source/JavaScriptCore/inspector/protocol/Dialog.json
 new file mode 100644
-index 000000000000..79edea03fed4
+index 0000000000000000000000000000000000000000..79edea03fed4e9be5da96e1275e182a479cb7a0a
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Dialog.json
 @@ -0,0 +1,36 @@
@@ -640,7 +640,7 @@ index 000000000000..79edea03fed4
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Emulation.json b/Source/JavaScriptCore/inspector/protocol/Emulation.json
 new file mode 100644
-index 000000000000..347a01b3fdd1
+index 0000000000000000000000000000000000000000..347a01b3fdd1a8277cb4104558e8bbfa63539374
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Emulation.json
 @@ -0,0 +1,51 @@
@@ -697,7 +697,7 @@ index 000000000000..347a01b3fdd1
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Input.json b/Source/JavaScriptCore/inspector/protocol/Input.json
 new file mode 100644
-index 000000000000..587287d52fde
+index 0000000000000000000000000000000000000000..587287d52fde2735cbae34a27a0f673b7e38e1a7
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Input.json
 @@ -0,0 +1,188 @@
@@ -890,7 +890,7 @@ index 000000000000..587287d52fde
 +    ]
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Network.json b/Source/JavaScriptCore/inspector/protocol/Network.json
-index 882a2d56befe..71d4bfc4a4bc 100644
+index 882a2d56befef0aba460cc8ff041969e0d2c1ed3..71d4bfc4a4bc5a43bd2b98aefa316b4e74e35b8f 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Network.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Network.json
 @@ -192,6 +192,17 @@
@@ -926,7 +926,7 @@ index 882a2d56befe..71d4bfc4a4bc 100644
      ],
      "events": [
 diff --git a/Source/JavaScriptCore/inspector/protocol/Page.json b/Source/JavaScriptCore/inspector/protocol/Page.json
-index db52479a72d4..5f7add78fefc 100644
+index db52479a72d459be23d4d8d080c0ed15ea9fc4c0..5f7add78fefc2bf8718ff8af7c49c169038e8226 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Page.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Page.json
 @@ -27,7 +27,7 @@
@@ -1234,10 +1234,10 @@ index db52479a72d4..5f7add78fefc 100644
  }
 diff --git a/Source/JavaScriptCore/inspector/protocol/Playwright.json b/Source/JavaScriptCore/inspector/protocol/Playwright.json
 new file mode 100644
-index 000000000000..c6cc36ee0e33
+index 0000000000000000000000000000000000000000..3aebbe625682094d0e8ac2f14ac33321dd475142
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Playwright.json
-@@ -0,0 +1,282 @@
+@@ -0,0 +1,289 @@
 +{
 +    "domain": "Playwright",
 +    "availability": ["web"],
@@ -1454,6 +1454,13 @@ index 000000000000..c6cc36ee0e33
 +                { "name": "downloadPath", "optional": true, "type": "string" },
 +                { "name": "browserContextId", "$ref": "ContextID", "optional": true, "description": "Browser context id." }
 +            ]
++        },
++        {
++            "name": "cancelDownload",
++            "parameters": [
++                { "name": "uuid", "type": "string" }
++            ],
++            "description": "Cancels a current running download."
 +        }
 +    ],
 +    "events": [
@@ -1521,7 +1528,7 @@ index 000000000000..c6cc36ee0e33
 +    ]
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Runtime.json b/Source/JavaScriptCore/inspector/protocol/Runtime.json
-index 274b01596d49..d08a9ddd745c 100644
+index 274b01596d490fb81b48cf89bf668e0634e8b423..d08a9ddd745c748767ba8055907daa7beeffc219 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Runtime.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Runtime.json
 @@ -261,12 +261,14 @@
@@ -1543,7 +1550,7 @@ index 274b01596d49..d08a9ddd745c 100644
              "name": "getPreview",
 diff --git a/Source/JavaScriptCore/inspector/protocol/Screencast.json b/Source/JavaScriptCore/inspector/protocol/Screencast.json
 new file mode 100644
-index 000000000000..f6c541d63c0b
+index 0000000000000000000000000000000000000000..f6c541d63c0b8251874eaf8818aabe0e0449401d
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Screencast.json
 @@ -0,0 +1,65 @@
@@ -1613,7 +1620,7 @@ index 000000000000..f6c541d63c0b
 +    ]
 +}
 diff --git a/Source/JavaScriptCore/inspector/protocol/Target.json b/Source/JavaScriptCore/inspector/protocol/Target.json
-index 52920cded24a..bbbabc4e7259 100644
+index 52920cded24a9c6b0ef6fb4e518664955db4f9fa..bbbabc4e7259088b9404e8cc07eecd6f45077da0 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Target.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Target.json
 @@ -10,7 +10,7 @@
@@ -1658,7 +1665,7 @@ index 52920cded24a..bbbabc4e7259 100644
          },
          {
 diff --git a/Source/JavaScriptCore/inspector/protocol/Worker.json b/Source/JavaScriptCore/inspector/protocol/Worker.json
-index 638612413466..6f9e518ff0bf 100644
+index 638612413466efc87b737e8a81042ed07ca12703..6f9e518ff0bfa2a6228675d25b6b785f1ed3022a 100644
 --- a/Source/JavaScriptCore/inspector/protocol/Worker.json
 +++ b/Source/JavaScriptCore/inspector/protocol/Worker.json
 @@ -16,7 +16,7 @@
@@ -1681,7 +1688,7 @@ index 638612413466..6f9e518ff0bf 100644
          },
          {
 diff --git a/Source/JavaScriptCore/runtime/DateConversion.cpp b/Source/JavaScriptCore/runtime/DateConversion.cpp
-index 2decf8a83c80..9010384a32f7 100644
+index 2decf8a83c80e80ca8677f4c787bf79c6c2995fa..9010384a32f7c2ab69a8fb20eb19cd566fd9f434 100644
 --- a/Source/JavaScriptCore/runtime/DateConversion.cpp
 +++ b/Source/JavaScriptCore/runtime/DateConversion.cpp
 @@ -97,6 +97,9 @@ String formatDateTime(const GregorianDateTime& t, DateTimeFormat format, bool as
@@ -1703,7 +1710,7 @@ index 2decf8a83c80..9010384a32f7 100644
      }
  
 diff --git a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
-index 2729df9dd4d1..a7fdc92d594a 100644
+index 2729df9dd4d15e19b7b2019ca94dd7647c5a6706..a7fdc92d594a7930ca029f162cc385bbdb949597 100644
 --- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
 +++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
 @@ -36,6 +36,7 @@
@@ -1715,7 +1722,7 @@ index 2729df9dd4d1..a7fdc92d594a 100644
  #include <wtf/unicode/icu/ICUHelpers.h>
  
 diff --git a/Source/JavaScriptCore/runtime/JSDateMath.cpp b/Source/JavaScriptCore/runtime/JSDateMath.cpp
-index ea0bfb0d7a5a..2ebe8c6c5ac4 100644
+index ea0bfb0d7a5a64c1570da5333199f99b552a5ff6..2ebe8c6c5ac4343e0b373ccc271e86a4080a98dc 100644
 --- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
 +++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
 @@ -76,6 +76,7 @@
@@ -1770,7 +1777,7 @@ index ea0bfb0d7a5a..2ebe8c6c5ac4 100644
      m_timeZoneCache = std::unique_ptr<OpaqueICUTimeZone, OpaqueICUTimeZoneDeleter>(bitwise_cast<OpaqueICUTimeZone*>(icu::TimeZone::detectHostTimeZone()));
  #endif
 diff --git a/Source/ThirdParty/libwebrtc/CMakeLists.txt b/Source/ThirdParty/libwebrtc/CMakeLists.txt
-index 4345be388119..d8ea7866e3df 100644
+index 4345be38811965680c7c8e80d64234e130b16548..d8ea7866e3df2d8dcc6adc7a0dd021c4b96d4249 100644
 --- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
 +++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
 @@ -292,6 +292,11 @@ set(webrtc_SOURCES
@@ -1797,7 +1804,7 @@ index 4345be388119..d8ea7866e3df 100644
      Source/third_party/opus/src/celt
      Source/third_party/opus/src/include
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
-index 7d225cc2c64b..685154543606 100644
+index 7d225cc2c64b66bfbc0f2aeb0f6184280d294263..6851545436064cc23e1f8862e8f1c5d51ef6bece 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
 @@ -321,3 +321,23 @@ __ZN3rtc14RTCCertificateD1Ev
@@ -1825,7 +1832,7 @@ index 7d225cc2c64b..685154543606 100644
 +_vpx_codec_version_str
 +_vpx_codec_vp8_cx
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
-index dd884b222501..9927a937145f 100644
+index dd884b22250114627213c4827ca176c283ec2525..9927a937145f23d05e907083a01748dd8015eb98 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 @@ -43,7 +43,7 @@ DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_ = $(DYLIB_INSTALL_NAME_BASE);
@@ -1838,7 +1845,7 @@ index dd884b222501..9927a937145f 100644
  PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/libwebrtc;
  USE_HEADERMAP = NO;
 diff --git a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
-index d8677555342e..b9ee7198a702 100644
+index d8677555342ee0168223a0bc3ef54603b1a23460..b9ee7198a702cbc0241de3a33b65a6940ad48bc6 100644
 --- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
 +++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
 @@ -3856,6 +3856,9 @@
@@ -1920,7 +1927,7 @@ index d8677555342e..b9ee7198a702 100644
  				41323A1D2665288B00B38623 /* packet_sequencer.cc in Sources */,
  				4131BF2D234B88200028A615 /* rtc_stats_collector.cc in Sources */,
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferences.yaml b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
-index e7331574bbfe..8333ecf890ba 100644
+index e7331574bbfe695080432c506a393ed218d0e651..8333ecf890ba03175aa5fa9afe89217f6a377f4c 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
 @@ -1010,7 +1010,7 @@ InspectorStartsAttached:
@@ -1933,7 +1940,7 @@ index e7331574bbfe..8333ecf890ba 100644
  InspectorWindowFrame:
    type: String
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index 323dc5f26262..9a4ed5d76409 100644
+index 323dc5f2626234fd49dff18148eb4fadfe635b3f..9a4ed5d76409b2de9ea1fabfa372132f4e9c7fd0 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 @@ -622,9 +622,9 @@ MaskWebGLStringsEnabled:
@@ -1949,7 +1956,7 @@ index 323dc5f26262..9a4ed5d76409 100644
  # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
  MediaCapabilitiesExtensionsEnabled:
 diff --git a/Source/WTF/wtf/DateMath.cpp b/Source/WTF/wtf/DateMath.cpp
-index ebd69a4c76cd..2ee388e94a56 100644
+index ebd69a4c76cd7acb0a233be552071158ca2171ca..2ee388e94a56d3de9c9fb2506d2ddead2db1ef87 100644
 --- a/Source/WTF/wtf/DateMath.cpp
 +++ b/Source/WTF/wtf/DateMath.cpp
 @@ -76,9 +76,14 @@
@@ -2068,7 +2075,7 @@ index ebd69a4c76cd..2ee388e94a56 100644
 +
  } // namespace WTF
 diff --git a/Source/WTF/wtf/DateMath.h b/Source/WTF/wtf/DateMath.h
-index de0b45bd0a88..81857a2be24f 100644
+index de0b45bd0a88eaba466b6e6c0ad66dc02f525741..81857a2be24fa3ff0a60ebbcd01130969456b31e 100644
 --- a/Source/WTF/wtf/DateMath.h
 +++ b/Source/WTF/wtf/DateMath.h
 @@ -388,6 +388,10 @@ inline int dayInMonthFromDayInYear(int dayInYear, bool leapYear)
@@ -2083,7 +2090,7 @@ index de0b45bd0a88..81857a2be24f 100644
  WTF_EXPORT_PRIVATE LocalTimeOffset calculateLocalTimeOffset(double utcInMilliseconds, TimeType = UTCTime);
  
 diff --git a/Source/WTF/wtf/PlatformEnable.h b/Source/WTF/wtf/PlatformEnable.h
-index d10aa42b80a2..94ebea19af93 100644
+index d10aa42b80a2b576c9e8c5c699a5d8b0ee2d8009..94ebea19af93d8282246c6af6e8d4a1e3e35fe40 100644
 --- a/Source/WTF/wtf/PlatformEnable.h
 +++ b/Source/WTF/wtf/PlatformEnable.h
 @@ -413,7 +413,7 @@
@@ -2105,7 +2112,7 @@ index d10aa42b80a2..94ebea19af93 100644
  
  #if !defined(ENABLE_TOUCH_ACTION_REGIONS)
 diff --git a/Source/WTF/wtf/PlatformGTK.cmake b/Source/WTF/wtf/PlatformGTK.cmake
-index 9bd5fde5bc38..3f3be653fef9 100644
+index 9bd5fde5bc38355e25bc09d05a045df31efaa259..3f3be653fef9930a7ac8a348c8b9f9a281eea363 100644
 --- a/Source/WTF/wtf/PlatformGTK.cmake
 +++ b/Source/WTF/wtf/PlatformGTK.cmake
 @@ -73,6 +73,7 @@ list(APPEND WTF_LIBRARIES
@@ -2117,7 +2124,7 @@ index 9bd5fde5bc38..3f3be653fef9 100644
  
  if (Systemd_FOUND)
 diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
-index 6e1113146ac0..c80511f5b516 100644
+index 6e1113146ac02498d5b6e92e45748ea37f00f998..c80511f5b516fe143e9dcf2aee33406c405c6e55 100644
 --- a/Source/WTF/wtf/PlatformHave.h
 +++ b/Source/WTF/wtf/PlatformHave.h
 @@ -391,7 +391,7 @@
@@ -2130,7 +2137,7 @@ index 6e1113146ac0..c80511f5b516 100644
  #endif
  
 diff --git a/Source/WTF/wtf/PlatformWPE.cmake b/Source/WTF/wtf/PlatformWPE.cmake
-index a840a487ff03..29dd6a14f172 100644
+index a840a487ff03a3c827455cab67faa8f83d20bfa9..29dd6a14f17295f1611451e6f53866175c8748d8 100644
 --- a/Source/WTF/wtf/PlatformWPE.cmake
 +++ b/Source/WTF/wtf/PlatformWPE.cmake
 @@ -47,6 +47,7 @@ list(APPEND WTF_LIBRARIES
@@ -2142,7 +2149,7 @@ index a840a487ff03..29dd6a14f172 100644
  
  if (Systemd_FOUND)
 diff --git a/Source/WebCore/DerivedSources.make b/Source/WebCore/DerivedSources.make
-index 6c1bb60d7681..06d3d504a41e 100644
+index 6c1bb60d7681b205d1dc66409daf932c3ac51ff9..06d3d504a41e848781038fb01b4d99dd17848899 100644
 --- a/Source/WebCore/DerivedSources.make
 +++ b/Source/WebCore/DerivedSources.make
 @@ -778,6 +778,10 @@ JS_BINDING_IDLS := \
@@ -2167,7 +2174,7 @@ index 6c1bb60d7681..06d3d504a41e 100644
  
  vpath %.in $(WEBKITADDITIONS_HEADER_SEARCH_PATHS)
 diff --git a/Source/WebCore/Modules/geolocation/Geolocation.cpp b/Source/WebCore/Modules/geolocation/Geolocation.cpp
-index 7995d4dd461d..49207cd294ac 100644
+index 7995d4dd461de036cd8691b3ff181aeaefb12d92..49207cd294acebb4bac53ecb28817baa827d389f 100644
 --- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
 +++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
 @@ -358,8 +358,9 @@ bool Geolocation::shouldBlockGeolocationRequests()
@@ -2182,7 +2189,7 @@ index 7995d4dd461d..49207cd294ac 100644
      }
  
 diff --git a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
-index f1b96958057d..29e51dad3802 100644
+index f1b96958057d2fe6044d2c7b259db6c5ceb44efe..29e51dad380285fb16bd32ef04efde2ac4ed6479 100644
 --- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
 +++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
 @@ -202,6 +202,7 @@ NS_ASSUME_NONNULL_BEGIN
@@ -2218,7 +2225,7 @@ index f1b96958057d..29e51dad3802 100644
  
      [self sendSpeechEndIfNeeded];
 diff --git a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
-index 66cec91542b7..9a2a89a09279 100644
+index 66cec91542b74765a9c1ffbc2f28e1a5085c55e0..9a2a89a09279b3b7102282de6bfc4cc7e2b5925f 100644
 --- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
 +++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
 @@ -36,6 +36,9 @@ NS_ASSUME_NONNULL_BEGIN
@@ -2240,7 +2247,7 @@ index 66cec91542b7..9a2a89a09279 100644
          _hasSentSpeechStart = true;
          _delegateCallback(SpeechRecognitionUpdate::create(_identifier, SpeechRecognitionUpdateType::SpeechStart));
 diff --git a/Source/WebCore/PlatformWPE.cmake b/Source/WebCore/PlatformWPE.cmake
-index 9d4f3bd1ade0..17b2b6cfb52d 100644
+index 9d4f3bd1ade02a378340961d617aae1c5e0776a3..17b2b6cfb52d94d8104b68b9250883c40f69f975 100644
 --- a/Source/WebCore/PlatformWPE.cmake
 +++ b/Source/WebCore/PlatformWPE.cmake
 @@ -38,6 +38,7 @@ list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
@@ -2252,7 +2259,7 @@ index 9d4f3bd1ade0..17b2b6cfb52d 100644
  
  list(APPEND WebCore_USER_AGENT_STYLE_SHEETS
 diff --git a/Source/WebCore/SourcesCocoa.txt b/Source/WebCore/SourcesCocoa.txt
-index 682dbcc06cea..9548501875df 100644
+index 682dbcc06ceae7d76c1e0e9a66abf427e1ccb49b..9548501875df91a2901d01cfcdf9c4c43170c026 100644
 --- a/Source/WebCore/SourcesCocoa.txt
 +++ b/Source/WebCore/SourcesCocoa.txt
 @@ -620,3 +620,9 @@ platform/graphics/angle/TemporaryANGLESetting.cpp @no-unify
@@ -2266,7 +2273,7 @@ index 682dbcc06cea..9548501875df 100644
 +JSTouchList.cpp
 +// Playwright end
 diff --git a/Source/WebCore/SourcesWPE.txt b/Source/WebCore/SourcesWPE.txt
-index b10c1ece5207..8520d6b90ccb 100644
+index b10c1ece52075b7535da51c2cc316dc9343fd081..8520d6b90ccb2aa2762d83fab0f63c1e7107aed3 100644
 --- a/Source/WebCore/SourcesWPE.txt
 +++ b/Source/WebCore/SourcesWPE.txt
 @@ -44,6 +44,8 @@ editing/libwpe/EditorLibWPE.cpp
@@ -2292,7 +2299,7 @@ index b10c1ece5207..8520d6b90ccb 100644
 +
 +platform/wpe/SelectionData.cpp
 diff --git a/Source/WebCore/WebCore.order b/Source/WebCore/WebCore.order
-index ef168b768192..2d6cf51f3b45 100644
+index ef168b76819216d984b7a2d0f760005fb9d24de8..2d6cf51f3b45191ad84106429d4f108f85679123 100644
 --- a/Source/WebCore/WebCore.order
 +++ b/Source/WebCore/WebCore.order
 @@ -3093,7 +3093,6 @@ __ZN7WebCore14DocumentLoader23stopLoadingSubresourcesEv
@@ -2304,7 +2311,7 @@ index ef168b768192..2d6cf51f3b45 100644
  __ZN7WebCore14DocumentLoaderD2Ev
  __ZN7WebCore14DocumentLoader17clearMainResourceEv
 diff --git a/Source/WebCore/WebCore.xcodeproj/project.pbxproj b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-index 7449fc649ba8..f59a0247ddd1 100644
+index 7449fc649ba8f4676e7b7dc9636ee7394b9dbd2b..f59a0247ddd177b8605255b6b62c2359ae384d01 100644
 --- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 +++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 @@ -5348,6 +5348,14 @@
@@ -2428,7 +2435,7 @@ index 7449fc649ba8..f59a0247ddd1 100644
  				2D8B92F5203D13E1009C868F /* UnifiedSource520.cpp in Sources */,
  				2D8B92F6203D13E1009C868F /* UnifiedSource521.cpp in Sources */,
 diff --git a/Source/WebCore/accessibility/AccessibilityObject.cpp b/Source/WebCore/accessibility/AccessibilityObject.cpp
-index 4436fd8ca990..9ebf2f8e4990 100644
+index 4436fd8ca990af2e5cc147047fc39c2470104e64..9ebf2f8e499066a5e7461cfa1f8287f54a12e60c 100644
 --- a/Source/WebCore/accessibility/AccessibilityObject.cpp
 +++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
 @@ -59,6 +59,7 @@
@@ -2459,7 +2466,7 @@ index 4436fd8ca990..9ebf2f8e4990 100644
  {
      AXComputedObjectAttributeCache* attributeCache = nullptr;
 diff --git a/Source/WebCore/css/MediaQueryEvaluator.cpp b/Source/WebCore/css/MediaQueryEvaluator.cpp
-index a47b2fe549a8..53357bc9ce11 100644
+index a47b2fe549a89414a207864aabe897d07a59727c..53357bc9ce111bcb1241256647c3630ae767213d 100644
 --- a/Source/WebCore/css/MediaQueryEvaluator.cpp
 +++ b/Source/WebCore/css/MediaQueryEvaluator.cpp
 @@ -844,7 +844,11 @@ static bool prefersContrastEvaluate(CSSValue* value, const CSSToLengthConversion
@@ -2484,7 +2491,7 @@ index a47b2fe549a8..53357bc9ce11 100644
      if (!value)
          return userPrefersReducedMotion;
 diff --git a/Source/WebCore/dom/DataTransfer.cpp b/Source/WebCore/dom/DataTransfer.cpp
-index 1deac4f41cf4..c691eeccd75f 100644
+index 1deac4f41cf49f1f882dccefd48cf6a9732f3ed9..c691eeccd75fc76f5df367b9fb5b95435e92ab79 100644
 --- a/Source/WebCore/dom/DataTransfer.cpp
 +++ b/Source/WebCore/dom/DataTransfer.cpp
 @@ -494,6 +494,14 @@ Ref<DataTransfer> DataTransfer::createForDrag(const Document& document)
@@ -2503,7 +2510,7 @@ index 1deac4f41cf4..c691eeccd75f 100644
  {
      auto dataTransfer = adoptRef(*new DataTransfer(StoreMode::ReadWrite, makeUnique<StaticPasteboard>(), Type::DragAndDropData));
 diff --git a/Source/WebCore/dom/DataTransfer.h b/Source/WebCore/dom/DataTransfer.h
-index b084ee416512..b250f3d01618 100644
+index b084ee416512652220e43a6d4bcccaff7c666d5a..b250f3d0161817efef7e2634a16713b0a0f1fa71 100644
 --- a/Source/WebCore/dom/DataTransfer.h
 +++ b/Source/WebCore/dom/DataTransfer.h
 @@ -90,6 +90,9 @@ public:
@@ -2517,7 +2524,7 @@ index b084ee416512..b250f3d01618 100644
      static Ref<DataTransfer> createForDrop(const Document&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
      static Ref<DataTransfer> createForUpdatingDropTarget(const Document&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
 diff --git a/Source/WebCore/dom/PointerEvent.cpp b/Source/WebCore/dom/PointerEvent.cpp
-index f21879fdfbc6..151c9b72f0f5 100644
+index f21879fdfbc64e7d2f11ab084d46794a9e601110..151c9b72f0f552c2ff741305c4c0a8c7f51a92e3 100644
 --- a/Source/WebCore/dom/PointerEvent.cpp
 +++ b/Source/WebCore/dom/PointerEvent.cpp
 @@ -114,4 +114,61 @@ EventInterface PointerEvent::eventInterface() const
@@ -2583,7 +2590,7 @@ index f21879fdfbc6..151c9b72f0f5 100644
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/dom/PointerEvent.h b/Source/WebCore/dom/PointerEvent.h
-index 9d60b85152f3..9811ce9aa6f0 100644
+index 9d60b85152f378566118574663701c25b001df3d..9811ce9aa6f066c57acf65f629d2ab8155c090e1 100644
 --- a/Source/WebCore/dom/PointerEvent.h
 +++ b/Source/WebCore/dom/PointerEvent.h
 @@ -33,6 +33,8 @@
@@ -2614,7 +2621,7 @@ index 9d60b85152f3..9811ce9aa6f0 100644
  #endif
  
 diff --git a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
-index 9dd41d636651..d6bb529fb891 100644
+index 9dd41d6366512fd385937a7608bd3fc9b5b90f60..d6bb529fb891a65c8f6dcc6cff1e718c7a40b8dd 100644
 --- a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
 +++ b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
 @@ -33,6 +33,7 @@
@@ -2641,7 +2648,7 @@ index 9dd41d636651..d6bb529fb891 100644
  
  #endif // USE(LIBWPE)
 diff --git a/Source/WebCore/html/FileInputType.cpp b/Source/WebCore/html/FileInputType.cpp
-index 50fc3c950f53..45994eb21c50 100644
+index 50fc3c950f53eca3355c9fa8bc45a73a279b2a07..45994eb21c5034f9efaddb5569473b55b493a36e 100644
 --- a/Source/WebCore/html/FileInputType.cpp
 +++ b/Source/WebCore/html/FileInputType.cpp
 @@ -36,6 +36,7 @@
@@ -2665,7 +2672,7 @@ index 50fc3c950f53..45994eb21c50 100644
          return;
  
 diff --git a/Source/WebCore/inspector/InspectorController.cpp b/Source/WebCore/inspector/InspectorController.cpp
-index c33bc989d95a..d54965c544b8 100644
+index c33bc989d95a21425d43643795190cf40f7e9684..d54965c544b8cac7ebc1e9e408db8ae08e25be61 100644
 --- a/Source/WebCore/inspector/InspectorController.cpp
 +++ b/Source/WebCore/inspector/InspectorController.cpp
 @@ -374,8 +374,8 @@ void InspectorController::inspect(Node* node)
@@ -2705,7 +2712,7 @@ index c33bc989d95a..d54965c544b8 100644
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/InspectorController.h b/Source/WebCore/inspector/InspectorController.h
-index 784bf482fd68..6cdf012453ff 100644
+index 784bf482fd68da68e1f38fd5cd6bcedc8971dfda..6cdf012453ff31120adbe5946ce23f075761ebef 100644
 --- a/Source/WebCore/inspector/InspectorController.h
 +++ b/Source/WebCore/inspector/InspectorController.h
 @@ -101,6 +101,10 @@ public:
@@ -2728,7 +2735,7 @@ index 784bf482fd68..6cdf012453ff 100644
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/InspectorInstrumentation.cpp b/Source/WebCore/inspector/InspectorInstrumentation.cpp
-index c121523071a0..c8557a307178 100644
+index c121523071a026888cbd608031ad15dc85af1719..c8557a307178db00b79e7e1c4156242b242bc7d1 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
 +++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
 @@ -641,6 +641,12 @@ void InspectorInstrumentation::didFailLoadingImpl(InstrumentingAgents& instrumen
@@ -2871,7 +2878,7 @@ index c121523071a0..c8557a307178 100644
  {
      if (is<Document>(context))
 diff --git a/Source/WebCore/inspector/InspectorInstrumentation.h b/Source/WebCore/inspector/InspectorInstrumentation.h
-index 7d5e7d57bf91..f217152b91bd 100644
+index 7d5e7d57bf911fddf90ed400a225afa083e6c871..f217152b91bdd208556d125ea3b013e9a30882a4 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentation.h
 +++ b/Source/WebCore/inspector/InspectorInstrumentation.h
 @@ -31,6 +31,7 @@
@@ -3096,7 +3103,7 @@ index 7d5e7d57bf91..f217152b91bd 100644
  {
      return context ? instrumentingAgents(*context) : nullptr;
 diff --git a/Source/WebCore/inspector/InspectorInstrumentationWebKit.cpp b/Source/WebCore/inspector/InspectorInstrumentationWebKit.cpp
-index 73163278cca3..85b9127228ea 100644
+index 73163278cca3998f4f0122d5cb0577da46a50747..85b9127228ea9c8d89b4b3fd028e0ec4a5b3f820 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentationWebKit.cpp
 +++ b/Source/WebCore/inspector/InspectorInstrumentationWebKit.cpp
 @@ -50,4 +50,19 @@ void InspectorInstrumentationWebKit::interceptResponseInternal(const Frame& fram
@@ -3120,7 +3127,7 @@ index 73163278cca3..85b9127228ea 100644
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/InspectorInstrumentationWebKit.h b/Source/WebCore/inspector/InspectorInstrumentationWebKit.h
-index bffc87080647..aa56e1f1714b 100644
+index bffc870806476538115e80f20ddca4e8222e629b..aa56e1f1714b9b51486d9d130e18e29a70576e0f 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentationWebKit.h
 +++ b/Source/WebCore/inspector/InspectorInstrumentationWebKit.h
 @@ -33,6 +33,7 @@
@@ -3180,7 +3187,7 @@ index bffc87080647..aa56e1f1714b 100644
 +
  }
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
-index dadfa3012201..a6502edece9b 100644
+index dadfa3012201c0eb036a142bafa9eb528efb1c56..a6502edece9b79b070d8d611ed9572187d97c463 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 @@ -62,12 +62,16 @@
@@ -3487,7 +3494,7 @@ index dadfa3012201..a6502edece9b 100644
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.h b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
-index 4eb63b798572..b0e628854f24 100644
+index 4eb63b7985721ac6ea6003c884989179c78eda00..b0e628854f24c15a25fbad6aebab1c55a6568545 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
 @@ -57,6 +57,7 @@ namespace WebCore {
@@ -3560,7 +3567,7 @@ index 4eb63b798572..b0e628854f24 100644
      void discardBindings();
  
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
-index 3386cb879f11..d2350182f5f0 100644
+index 3386cb879f1178c1b9635775c9a0e864f5b94c52..d2350182f5f061855e8ca172779ad60ee73b39fb 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
 @@ -40,6 +40,7 @@ class DOMStorageFrontendDispatcher;
@@ -3572,7 +3579,7 @@ index 3386cb879f11..d2350182f5f0 100644
  class Page;
  class SecurityOrigin;
 diff --git a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
-index 7948852dd9a6..2beb7e9bce93 100644
+index 7948852dd9a6bc42b40116941ce0346c32e16f2d..2beb7e9bce93556cb6537b18a98649eceee6806c 100644
 --- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
 @@ -45,6 +45,7 @@
@@ -3763,7 +3770,7 @@ index 7948852dd9a6..2beb7e9bce93 100644
  {
      ASSERT(result);
 diff --git a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
-index 7cdc5865e58e..7c42be0cbadf 100644
+index 7cdc5865e58e9a9a30ea25202692d4b9aa77b2d6..7c42be0cbadf9a594926cbe89ce510b0f0827397 100644
 --- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
 @@ -72,6 +72,7 @@ public:
@@ -3854,7 +3861,7 @@ index 7cdc5865e58e..7c42be0cbadf 100644
  
      std::unique_ptr<Inspector::NetworkFrontendDispatcher> m_frontendDispatcher;
 diff --git a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
-index 64117425ba5c..8fa02250a9c5 100644
+index 64117425ba5c5b6a71d190dfc8f1eefb4ffc637c..8fa02250a9c5736a7a8099840bf8f263a43f6604 100644
 --- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
 @@ -32,19 +32,25 @@
@@ -4854,7 +4861,7 @@ index 64117425ba5c..8fa02250a9c5 100644
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorPageAgent.h b/Source/WebCore/inspector/agents/InspectorPageAgent.h
-index b51addb1bd8f..2ad11ef1993e 100644
+index b51addb1bd8f2cce69560799cd1d952d2de42838..2ad11ef1993ed5a223f63073c4b4464bfde93a34 100644
 --- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
 @@ -34,17 +34,23 @@
@@ -5003,7 +5010,7 @@ index b51addb1bd8f..2ad11ef1993e 100644
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
-index 33caa0aa2079..4b74d397d4de 100644
+index 33caa0aa2079ad4081cc29605a53537c24d66bef..4b74d397d4de9a7eba3d5530538443d8907726aa 100644
 --- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
 @@ -161,7 +161,11 @@ void InspectorWorkerAgent::connectToWorkerInspectorProxy(WorkerInspectorProxy& p
@@ -5020,7 +5027,7 @@ index 33caa0aa2079..4b74d397d4de 100644
  
  void InspectorWorkerAgent::disconnectFromWorkerInspectorProxy(WorkerInspectorProxy& proxy)
 diff --git a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
-index 55d951849419..98035b606587 100644
+index 55d9518494195b96df165a94c1c2963adceb8395..98035b606587337e5fdacd31459a196fa7c28702 100644
 --- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
 +++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
 @@ -38,6 +38,7 @@
@@ -5056,7 +5063,7 @@ index 55d951849419..98035b606587 100644
  
  void PageDebuggerAgent::debuggerDidEvaluate(JSC::Debugger&, const JSC::Breakpoint::Action& action)
 diff --git a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
-index b32f3f699c2d..48f0fab7f07b 100644
+index b32f3f699c2d2a377289760b245ac81784102458..48f0fab7f07bfc2b2408764e9adec252cc380705 100644
 --- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
 +++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
 @@ -35,12 +35,14 @@
@@ -5120,7 +5127,7 @@ index b32f3f699c2d..48f0fab7f07b 100644
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
-index 6aba3a2c6e8b..537e3b34d640 100644
+index 6aba3a2c6e8bbb7a0bca4f07824cf4de8ce36f8e..537e3b34d6405e412bf0e2350909c9afda06bed8 100644
 --- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
 +++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
 @@ -54,25 +54,25 @@ public:
@@ -5158,7 +5165,7 @@ index 6aba3a2c6e8b..537e3b34d640 100644
  
      Page& m_inspectedPage;
 diff --git a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp
-index 8699436e3f96..35fbd46627f6 100644
+index 8699436e3f962b465b47aebebd601ee90152ef83..35fbd46627f68d9ebac52500bc560d4fd9866166 100644
 --- a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp
 +++ b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.cpp
 @@ -38,9 +38,9 @@
@@ -5174,7 +5181,7 @@ index 8699436e3f96..35fbd46627f6 100644
      , m_userWasInteracting(false)
  {
 diff --git a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h
-index 16edb3bc689b..f363b2ca2410 100644
+index 16edb3bc689b8e2dde17597b642b706c1343e1f5..f363b2ca2410f22cff8d6ad908a88527970ab1d8 100644
 --- a/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h
 +++ b/Source/WebCore/inspector/agents/page/UserGestureEmulationScope.h
 @@ -38,12 +38,13 @@ namespace WebCore {
@@ -5193,7 +5200,7 @@ index 16edb3bc689b..f363b2ca2410 100644
  
  private:
 diff --git a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
-index 7f9397a2aa7b..18617fb37245 100644
+index 7f9397a2aa7b8e611886c5bfa23019a578c1f354..18617fb37245d7087825fe3c94feda94b117a320 100644
 --- a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
 +++ b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
 @@ -250,7 +250,7 @@ void LineLayout::prepareLayoutState()
@@ -5206,7 +5213,7 @@ index 7f9397a2aa7b..18617fb37245 100644
      rootGeometry.setHorizontalMargin({ });
      rootGeometry.setVerticalMargin({ });
 diff --git a/Source/WebCore/loader/CookieJar.h b/Source/WebCore/loader/CookieJar.h
-index 982691dd2dfe..4af72beb3b14 100644
+index 982691dd2dfe2f65201370a12302b5086703c126..4af72beb3b1405ffac78e89e7fbb2b14d6647903 100644
 --- a/Source/WebCore/loader/CookieJar.h
 +++ b/Source/WebCore/loader/CookieJar.h
 @@ -43,6 +43,7 @@ struct CookieRequestHeaderFieldProxy;
@@ -5228,7 +5235,7 @@ index 982691dd2dfe..4af72beb3b14 100644
  protected:
      static SameSiteInfo sameSiteInfo(const Document&, IsForDOMCookieAccess = IsForDOMCookieAccess::No);
 diff --git a/Source/WebCore/loader/DocumentLoader.cpp b/Source/WebCore/loader/DocumentLoader.cpp
-index 367675741089..b15bf5fd3188 100644
+index 367675741089a498870aa9e16a20b419bee0eef9..b15bf5fd318862fd50aa2f5cf26cd29d75618aa2 100644
 --- a/Source/WebCore/loader/DocumentLoader.cpp
 +++ b/Source/WebCore/loader/DocumentLoader.cpp
 @@ -1408,8 +1408,6 @@ void DocumentLoader::detachFromFrame()
@@ -5241,7 +5248,7 @@ index 367675741089..b15bf5fd3188 100644
  }
  
 diff --git a/Source/WebCore/loader/DocumentLoader.h b/Source/WebCore/loader/DocumentLoader.h
-index e693532ebd64..242829bb5200 100644
+index e693532ebd64f5c042c7c37d839189597d6e6909..242829bb5200d6524978594cdc9061dc538c3cdd 100644
 --- a/Source/WebCore/loader/DocumentLoader.h
 +++ b/Source/WebCore/loader/DocumentLoader.h
 @@ -166,9 +166,13 @@ public:
@@ -5259,7 +5266,7 @@ index e693532ebd64..242829bb5200 100644
      DocumentWriter& writer() const { return m_writer; }
  
 diff --git a/Source/WebCore/loader/FrameLoader.cpp b/Source/WebCore/loader/FrameLoader.cpp
-index cf22e4f086a2..8d7bfb190c74 100644
+index cf22e4f086a275725a943e4069e073e29067f16d..8d7bfb190c746a5dd0876ad4acd6571fe8f529ec 100644
 --- a/Source/WebCore/loader/FrameLoader.cpp
 +++ b/Source/WebCore/loader/FrameLoader.cpp
 @@ -1153,6 +1153,7 @@ void FrameLoader::loadInSameDocument(const URL& url, SerializedScriptValue* stat
@@ -5327,7 +5334,7 @@ index cf22e4f086a2..8d7bfb190c74 100644
      InspectorInstrumentation::didClearWindowObjectInWorld(m_frame, world);
  }
 diff --git a/Source/WebCore/loader/LoaderStrategy.h b/Source/WebCore/loader/LoaderStrategy.h
-index b018af04d05c..6929c01318f5 100644
+index b018af04d05ce3ac38bb57d8e50a7b063ee51733..6929c01318f509ed560276168d18e0112b116bc2 100644
 --- a/Source/WebCore/loader/LoaderStrategy.h
 +++ b/Source/WebCore/loader/LoaderStrategy.h
 @@ -84,6 +84,7 @@ public:
@@ -5339,7 +5346,7 @@ index b018af04d05c..6929c01318f5 100644
      virtual bool shouldPerformSecurityChecks() const { return false; }
      virtual bool havePerformedSecurityChecks(const ResourceResponse&) const { return false; }
 diff --git a/Source/WebCore/loader/PolicyChecker.cpp b/Source/WebCore/loader/PolicyChecker.cpp
-index c082a981526d..2f8eb1b0cabb 100644
+index c082a981526d40408c85bb16683ab14ef6dd6e88..2f8eb1b0cabb23b230ea37254e7a18077335bc30 100644
 --- a/Source/WebCore/loader/PolicyChecker.cpp
 +++ b/Source/WebCore/loader/PolicyChecker.cpp
 @@ -46,6 +46,7 @@
@@ -5385,7 +5392,7 @@ index c082a981526d..2f8eb1b0cabb 100644
              return;
          }
 diff --git a/Source/WebCore/loader/ProgressTracker.cpp b/Source/WebCore/loader/ProgressTracker.cpp
-index 0dcb47556d04..df57e9a47160 100644
+index 0dcb47556d04874878656e459c9bac9af64dcfbf..df57e9a47160bfbeb8188d80afd175c756e982f9 100644
 --- a/Source/WebCore/loader/ProgressTracker.cpp
 +++ b/Source/WebCore/loader/ProgressTracker.cpp
 @@ -154,6 +154,8 @@ void ProgressTracker::progressCompleted(Frame& frame)
@@ -5407,7 +5414,7 @@ index 0dcb47556d04..df57e9a47160 100644
  
  void ProgressTracker::incrementProgress(unsigned long identifier, const ResourceResponse& response)
 diff --git a/Source/WebCore/page/ChromeClient.h b/Source/WebCore/page/ChromeClient.h
-index 0f622ffb9698..c494f4bc5de2 100644
+index 0f622ffb96980fb5f191ed17b240b6a587075c54..c494f4bc5de2a2f6a8e2d30818debbc1fc957e63 100644
 --- a/Source/WebCore/page/ChromeClient.h
 +++ b/Source/WebCore/page/ChromeClient.h
 @@ -306,7 +306,7 @@ public:
@@ -5420,7 +5427,7 @@ index 0f622ffb9698..c494f4bc5de2 100644
  
  #if ENABLE(INPUT_TYPE_COLOR)
 diff --git a/Source/WebCore/page/EventHandler.cpp b/Source/WebCore/page/EventHandler.cpp
-index 3252c71339fa..7af194dffd34 100644
+index 3252c71339fa5a852fba962f6f35be0b08485c14..7af194dffd349cb93b40072806ac7e5735b85352 100644
 --- a/Source/WebCore/page/EventHandler.cpp
 +++ b/Source/WebCore/page/EventHandler.cpp
 @@ -126,6 +126,7 @@
@@ -5555,7 +5562,7 @@ index 3252c71339fa..7af194dffd34 100644
      m_touchPressed = touches->length() > 0;
      if (allTouchReleased)
 diff --git a/Source/WebCore/page/EventHandler.h b/Source/WebCore/page/EventHandler.h
-index a5af404614e6..769570c304bc 100644
+index a5af404614e6cf86d0bc5cc65024553032f8bb42..769570c304bce902ac17f130d139224f41bf1503 100644
 --- a/Source/WebCore/page/EventHandler.h
 +++ b/Source/WebCore/page/EventHandler.h
 @@ -136,9 +136,7 @@ public:
@@ -5613,7 +5620,7 @@ index a5af404614e6..769570c304bc 100644
      bool m_mouseDownMayStartDrag { false };
      bool m_dragMayStartSelectionInstead { false };
 diff --git a/Source/WebCore/page/EventSource.cpp b/Source/WebCore/page/EventSource.cpp
-index 7b77e407ee5d..0060ebfb1128 100644
+index 7b77e407ee5d08ab3784d0899cfa33f0177f0648..0060ebfb1128cc5eb28baa5ecf4538a203ba82e1 100644
 --- a/Source/WebCore/page/EventSource.cpp
 +++ b/Source/WebCore/page/EventSource.cpp
 @@ -36,6 +36,7 @@
@@ -5633,7 +5640,7 @@ index 7b77e407ee5d..0060ebfb1128 100644
      request.setHTTPHeaderField(HTTPHeaderName::Accept, "text/event-stream");
      request.setHTTPHeaderField(HTTPHeaderName::CacheControl, "no-cache");
 diff --git a/Source/WebCore/page/Frame.cpp b/Source/WebCore/page/Frame.cpp
-index 7054acc90214..658520b15acd 100644
+index 7054acc90214eb817bd784298ce77f76d32c5dee..658520b15acdd632aa01576fea1f49df3aa722f7 100644
 --- a/Source/WebCore/page/Frame.cpp
 +++ b/Source/WebCore/page/Frame.cpp
 @@ -39,6 +39,7 @@
@@ -6029,7 +6036,7 @@ index 7054acc90214..658520b15acd 100644
  
  #undef FRAME_RELEASE_LOG_ERROR
 diff --git a/Source/WebCore/page/Frame.h b/Source/WebCore/page/Frame.h
-index f0743e939757..f1863e330e7f 100644
+index f0743e939757f672a7276fabe3b6596e3179ae2b..f1863e330e7ff386bfbf664df1c798436c1dd57e 100644
 --- a/Source/WebCore/page/Frame.h
 +++ b/Source/WebCore/page/Frame.h
 @@ -110,8 +110,8 @@ enum {
@@ -6089,7 +6096,7 @@ index f0743e939757..f1863e330e7f 100644
  
      ViewportArguments m_viewportArguments;
 diff --git a/Source/WebCore/page/FrameSnapshotting.cpp b/Source/WebCore/page/FrameSnapshotting.cpp
-index 8273a64fcdfb..8a2f97ac8f93 100644
+index 8273a64fcdfb7d34eaa76f98ba7a2117eafbfbe6..8a2f97ac8f935a71fce96913f8b10551a85de563 100644
 --- a/Source/WebCore/page/FrameSnapshotting.cpp
 +++ b/Source/WebCore/page/FrameSnapshotting.cpp
 @@ -103,7 +103,7 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(Frame& frame, const IntRect& image
@@ -6127,7 +6134,7 @@ index 8273a64fcdfb..8a2f97ac8f93 100644
  }
  
 diff --git a/Source/WebCore/page/FrameSnapshotting.h b/Source/WebCore/page/FrameSnapshotting.h
-index 1b77026f5109..6026bc235080 100644
+index 1b77026f51092001cda86e32480890395b145b2e..6026bc23508016454f331b06c9f071a88f55cccc 100644
 --- a/Source/WebCore/page/FrameSnapshotting.h
 +++ b/Source/WebCore/page/FrameSnapshotting.h
 @@ -50,6 +50,7 @@ enum class SnapshotFlags : uint8_t {
@@ -6139,7 +6146,7 @@ index 1b77026f5109..6026bc235080 100644
  
  struct SnapshotOptions {
 diff --git a/Source/WebCore/page/FrameView.cpp b/Source/WebCore/page/FrameView.cpp
-index a7e9f33ea6ef..fab672e5ae85 100644
+index a7e9f33ea6effcda12ab56bb8618c8eb5e2cda60..fab672e5ae8559348059e360dfc0614ff4813d4a 100644
 --- a/Source/WebCore/page/FrameView.cpp
 +++ b/Source/WebCore/page/FrameView.cpp
 @@ -3026,7 +3026,7 @@ void FrameView::setBaseBackgroundColor(const Color& backgroundColor)
@@ -6152,7 +6159,7 @@ index a7e9f33ea6ef..fab672e5ae85 100644
  #else
      Color baseBackgroundColor = backgroundColor.value_or(Color::white);
 diff --git a/Source/WebCore/page/History.cpp b/Source/WebCore/page/History.cpp
-index 28d1fc324217..058b5309eed0 100644
+index 28d1fc3242174a680711027877d4153923790220..058b5309eed081fcc1e4158f66e806421dcc9d56 100644
 --- a/Source/WebCore/page/History.cpp
 +++ b/Source/WebCore/page/History.cpp
 @@ -33,6 +33,7 @@
@@ -6172,7 +6179,7 @@ index 28d1fc324217..058b5309eed0 100644
      if (stateObjectType == StateObjectType::Push) {
          frame->loader().history().pushState(WTFMove(data), title, fullURL.string());
 diff --git a/Source/WebCore/page/Page.cpp b/Source/WebCore/page/Page.cpp
-index f2f01ac8074e..c6e857d2daa0 100644
+index f2f01ac8074e7208218ac3f749a27394b3cd1ba0..c6e857d2daa0b0141de6629e571ca82256e760f2 100644
 --- a/Source/WebCore/page/Page.cpp
 +++ b/Source/WebCore/page/Page.cpp
 @@ -448,6 +448,37 @@ void Page::setOverrideViewportArguments(const std::optional<ViewportArguments>&
@@ -6243,7 +6250,7 @@ index f2f01ac8074e..c6e857d2daa0 100644
  {
      if (insets == m_fullscreenInsets)
 diff --git a/Source/WebCore/page/Page.h b/Source/WebCore/page/Page.h
-index 2079c5a54bb1..daeaece6c1be 100644
+index 2079c5a54bb1084eaec1b5553a6115103b097c80..daeaece6c1bed4d37e19df2471b25e6ae3517d72 100644
 --- a/Source/WebCore/page/Page.h
 +++ b/Source/WebCore/page/Page.h
 @@ -256,6 +256,9 @@ public:
@@ -6319,7 +6326,7 @@ index 2079c5a54bb1..daeaece6c1be 100644
  #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
      RefPtr<DeviceOrientationUpdateProvider> m_deviceOrientationUpdateProvider;
 diff --git a/Source/WebCore/page/PointerCaptureController.cpp b/Source/WebCore/page/PointerCaptureController.cpp
-index 2903e934ebf5..8d644b579ebd 100644
+index 2903e934ebf5cf0e755d817d778717fe01ae066b..8d644b579ebd02761a4f6ff7db5f526623bc376c 100644
 --- a/Source/WebCore/page/PointerCaptureController.cpp
 +++ b/Source/WebCore/page/PointerCaptureController.cpp
 @@ -202,7 +202,7 @@ bool PointerCaptureController::preventsCompatibilityMouseEventsForIdentifier(Poi
@@ -6341,7 +6348,7 @@ index 2903e934ebf5..8d644b579ebd 100644
  #endif
  
 diff --git a/Source/WebCore/page/PointerCaptureController.h b/Source/WebCore/page/PointerCaptureController.h
-index 27ee79477915..cad99479d445 100644
+index 27ee794779152f113b49391e4e59614cb5794764..cad99479d44588710bb87dd1a6c6c367149c515a 100644
 --- a/Source/WebCore/page/PointerCaptureController.h
 +++ b/Source/WebCore/page/PointerCaptureController.h
 @@ -57,7 +57,7 @@ public:
@@ -6363,7 +6370,7 @@ index 27ee79477915..cad99479d445 100644
  #endif
          bool hasAnyElement() const {
 diff --git a/Source/WebCore/page/RuntimeEnabledFeatures.cpp b/Source/WebCore/page/RuntimeEnabledFeatures.cpp
-index 6b2bc1bdb38b..68a1773c0f57 100644
+index 6b2bc1bdb38be0543f20d51d200944b3f547f6a9..68a1773c0f578ecf8d5d7aa15ec1d34d9ad7a0a2 100644
 --- a/Source/WebCore/page/RuntimeEnabledFeatures.cpp
 +++ b/Source/WebCore/page/RuntimeEnabledFeatures.cpp
 @@ -56,7 +56,11 @@ RuntimeEnabledFeatures& RuntimeEnabledFeatures::sharedFeatures()
@@ -6380,7 +6387,7 @@ index 6b2bc1bdb38b..68a1773c0f57 100644
  #endif
  
 diff --git a/Source/WebCore/page/RuntimeEnabledFeatures.h b/Source/WebCore/page/RuntimeEnabledFeatures.h
-index d0774fd91166..73061176c6f2 100644
+index d0774fd91166b2b977f2e930c5909f35a215be8e..73061176c6f23eaead3add9a71a42de3962dec76 100644
 --- a/Source/WebCore/page/RuntimeEnabledFeatures.h
 +++ b/Source/WebCore/page/RuntimeEnabledFeatures.h
 @@ -200,6 +200,7 @@ public:
@@ -6392,7 +6399,7 @@ index d0774fd91166..73061176c6f2 100644
  
      bool pageAtRuleSupportEnabled() const { return m_pageAtRuleSupportEnabled; }
 diff --git a/Source/WebCore/page/Screen.cpp b/Source/WebCore/page/Screen.cpp
-index 7ac11c828934..764b2d4fe36a 100644
+index 7ac11c8289347e3a2f3e7316cf9e32932b9544ed..764b2d4fe36ac2e5588bd22595424ac11d42acd0 100644
 --- a/Source/WebCore/page/Screen.cpp
 +++ b/Source/WebCore/page/Screen.cpp
 @@ -102,6 +102,8 @@ int Screen::availLeft() const
@@ -6432,7 +6439,7 @@ index 7ac11c828934..764b2d4fe36a 100644
  }
  
 diff --git a/Source/WebCore/page/SocketProvider.cpp b/Source/WebCore/page/SocketProvider.cpp
-index 3bec0aef1743..566ef3806be3 100644
+index 3bec0aef174336939838fb1069fffbcb9f3d5604..566ef3806be3c5ccf1bb951251c2a90dba7071a3 100644
 --- a/Source/WebCore/page/SocketProvider.cpp
 +++ b/Source/WebCore/page/SocketProvider.cpp
 @@ -33,7 +33,7 @@ namespace WebCore {
@@ -6445,7 +6452,7 @@ index 3bec0aef1743..566ef3806be3 100644
  
  RefPtr<ThreadableWebSocketChannel> SocketProvider::createWebSocketChannel(Document&, WebSocketChannelClient&)
 diff --git a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
-index fc85fffa9b20..1070a1973d0e 100644
+index fc85fffa9b20cf5d3a2cff89b7d38ecf84aa0ff6..1070a1973d0ea23c6781df4269fc43498ce18608 100644
 --- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
 +++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
 @@ -281,6 +281,8 @@ bool ContentSecurityPolicy::protocolMatchesSelf(const URL& url) const
@@ -6476,7 +6483,7 @@ index fc85fffa9b20..1070a1973d0e 100644
      for (auto& policy : m_policies) {
          if (const ContentSecurityPolicyDirective* violatedDirective = (policy.get()->*predicate)(std::forward<Args>(args)...)) {
 diff --git a/Source/WebCore/page/ios/FrameIOS.mm b/Source/WebCore/page/ios/FrameIOS.mm
-index 12cc7336ae87..b97227e21bf9 100644
+index 12cc7336ae87b6d9d8ea83cf543d029914eaf1db..b97227e21bf9e7166980c20d2efdc24ea28058a2 100644
 --- a/Source/WebCore/page/ios/FrameIOS.mm
 +++ b/Source/WebCore/page/ios/FrameIOS.mm
 @@ -226,354 +226,6 @@ CGRect Frame::renderRectForPoint(CGPoint point, bool* isReplaced, float* fontSiz
@@ -6836,7 +6843,7 @@ index 12cc7336ae87..b97227e21bf9 100644
      Document* document = this->document();
 diff --git a/Source/WebCore/page/wpe/DragControllerWPE.cpp b/Source/WebCore/page/wpe/DragControllerWPE.cpp
 new file mode 100644
-index 000000000000..3dedfa855f99
+index 0000000000000000000000000000000000000000..3dedfa855f990643e3e7bbe7754abca4e88a0f1c
 --- /dev/null
 +++ b/Source/WebCore/page/wpe/DragControllerWPE.cpp
 @@ -0,0 +1,79 @@
@@ -6920,7 +6927,7 @@ index 000000000000..3dedfa855f99
 +
 +}
 diff --git a/Source/WebCore/platform/Cairo.cmake b/Source/WebCore/platform/Cairo.cmake
-index 237ebfbb8033..134b26cecc94 100644
+index 237ebfbb80338d313d2a51a77e28309d705fbf69..134b26cecc94e6989126a9f40d1d42a49815d0d4 100644
 --- a/Source/WebCore/platform/Cairo.cmake
 +++ b/Source/WebCore/platform/Cairo.cmake
 @@ -16,6 +16,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
@@ -6932,7 +6939,7 @@ index 237ebfbb8033..134b26cecc94 100644
      platform/graphics/cairo/RefPtrCairo.h
  )
 diff --git a/Source/WebCore/platform/DragData.h b/Source/WebCore/platform/DragData.h
-index 6600dfa7b189..4c0bc485ca92 100644
+index 6600dfa7b189e15fab7fb796f66ef1a79dcd22f3..4c0bc485ca92614efca23a5a2da871b77d5285d3 100644
 --- a/Source/WebCore/platform/DragData.h
 +++ b/Source/WebCore/platform/DragData.h
 @@ -48,7 +48,7 @@ typedef void* DragDataRef;
@@ -6945,7 +6952,7 @@ index 6600dfa7b189..4c0bc485ca92 100644
  class SelectionData;
  }
 diff --git a/Source/WebCore/platform/DragImage.cpp b/Source/WebCore/platform/DragImage.cpp
-index 6dfe0dd3ea4d..683c1bdb2cb3 100644
+index 6dfe0dd3ea4da3a1f5f0f6c79d6d1a3bf00c3159..683c1bdb2cb33538af14dcc5dab89d07dcd34eff 100644
 --- a/Source/WebCore/platform/DragImage.cpp
 +++ b/Source/WebCore/platform/DragImage.cpp
 @@ -279,7 +279,7 @@ DragImage::~DragImage()
@@ -6958,7 +6965,7 @@ index 6dfe0dd3ea4d..683c1bdb2cb3 100644
  IntSize dragImageSize(DragImageRef)
  {
 diff --git a/Source/WebCore/platform/Pasteboard.h b/Source/WebCore/platform/Pasteboard.h
-index 7d247dcd1a16..6903f0a0ab25 100644
+index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e578fb03d 100644
 --- a/Source/WebCore/platform/Pasteboard.h
 +++ b/Source/WebCore/platform/Pasteboard.h
 @@ -44,7 +44,7 @@ OBJC_CLASS NSString;
@@ -7050,7 +7057,7 @@ index 7d247dcd1a16..6903f0a0ab25 100644
  };
  
 diff --git a/Source/WebCore/platform/PlatformKeyboardEvent.h b/Source/WebCore/platform/PlatformKeyboardEvent.h
-index f90f1dad6b7b..9ad9c22488cc 100644
+index f90f1dad6b7b4e6703745c9cb97a32c872fa1aa8..9ad9c22488cc001cade2e8e8a6f4e9b8dc515cbd 100644
 --- a/Source/WebCore/platform/PlatformKeyboardEvent.h
 +++ b/Source/WebCore/platform/PlatformKeyboardEvent.h
 @@ -134,6 +134,7 @@ namespace WebCore {
@@ -7070,7 +7077,7 @@ index f90f1dad6b7b..9ad9c22488cc 100644
  #endif
  
 diff --git a/Source/WebCore/platform/PlatformScreen.cpp b/Source/WebCore/platform/PlatformScreen.cpp
-index ba50b688ab6d..0b83a798b008 100644
+index ba50b688ab6d0bae5d199fa0bac4b7e2004baf81..0b83a798b00835635a95a0db22173de094ba4035 100644
 --- a/Source/WebCore/platform/PlatformScreen.cpp
 +++ b/Source/WebCore/platform/PlatformScreen.cpp
 @@ -25,6 +25,7 @@
@@ -7099,7 +7106,7 @@ index ba50b688ab6d..0b83a798b008 100644
 +} // namespace WebCore
 +#endif
 diff --git a/Source/WebCore/platform/PlatformScreen.h b/Source/WebCore/platform/PlatformScreen.h
-index bb5411ad58c4..0bc31619d5f8 100644
+index bb5411ad58c4ea427837dc7ffeb8687d51e79061..0bc31619d5f8ce268cfbe8b4ee54f8c5d7903aa5 100644
 --- a/Source/WebCore/platform/PlatformScreen.h
 +++ b/Source/WebCore/platform/PlatformScreen.h
 @@ -146,12 +146,14 @@ WEBCORE_EXPORT float screenScaleFactor(UIScreen * = nullptr);
@@ -7121,7 +7128,7 @@ index bb5411ad58c4..0bc31619d5f8 100644
  #endif
  
 diff --git a/Source/WebCore/platform/ScrollableArea.h b/Source/WebCore/platform/ScrollableArea.h
-index fd39633380b9..a9e564cee2d4 100644
+index fd39633380b947a2050a7b8680c57990f6d75cb6..a9e564cee2d4b8e72344f31491a1561971d7dcf9 100644
 --- a/Source/WebCore/platform/ScrollableArea.h
 +++ b/Source/WebCore/platform/ScrollableArea.h
 @@ -101,7 +101,7 @@ public:
@@ -7134,7 +7141,7 @@ index fd39633380b9..a9e564cee2d4 100644
  
  #if PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebCore/platform/graphics/FontCascade.h b/Source/WebCore/platform/graphics/FontCascade.h
-index 6dade9146fe9..16a641f4237a 100644
+index 6dade9146fe99078ac1a58b28cf0c5dd0c351095..16a641f4237a8a3a7a40461e3429551f7ca96203 100644
 --- a/Source/WebCore/platform/graphics/FontCascade.h
 +++ b/Source/WebCore/platform/graphics/FontCascade.h
 @@ -283,7 +283,8 @@ private:
@@ -7148,7 +7155,7 @@ index 6dade9146fe9..16a641f4237a 100644
  #else
          return false;
 diff --git a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
-index 4db603a94f3a..c1820f48eb86 100644
+index 4db603a94f3af1b1bce94ab0f1ae36054c004fcc..c1820f48eb86348f8ca678fde636244e8c91267e 100644
 --- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
 +++ b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
 @@ -48,6 +48,13 @@
@@ -7243,7 +7250,7 @@ index 4db603a94f3a..c1820f48eb86 100644
      if (!image || !encodeImage(image, mimeType, &encodedImage))
          return { };
 diff --git a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
-index eac8346d3e17..2ddd1dc81003 100644
+index eac8346d3e177f87792fb0a8fc9dd0fb3b2f6efc..2ddd1dc810033a7f60f17ba555813f1b529d71f7 100644
 --- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
 +++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
 @@ -36,10 +36,10 @@ class PixelBuffer;
@@ -7260,7 +7267,7 @@ index eac8346d3e17..2ddd1dc81003 100644
  
  String dataURL(CGImageRef, CFStringRef destinationUTI, const String& mimeType, std::optional<double> quality);
 diff --git a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
-index 2e46b61536c8..fa0c72d80d83 100644
+index 2e46b61536c835dfcacf9f79e10e6d59ae7a3836..fa0c72d80d83c58a8407e78988de010fe97d7c38 100644
 --- a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
 +++ b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
 @@ -27,7 +27,7 @@
@@ -7273,7 +7280,7 @@ index 2e46b61536c8..fa0c72d80d83 100644
  #include "ExtensionsGLOpenGL.h"
  #include "IntRect.h"
 diff --git a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
-index 774a52a28693..cd714a7298fe 100644
+index 774a52a28693bc51dde10a0875ea379afb06fd3c..cd714a7298fe4f5d2c9b580697a5c4cd22d25870 100644
 --- a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
 +++ b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
 @@ -172,6 +172,33 @@ static Vector<unsigned> stringIndicesFromClusters(const Vector<WORD>& clusters,
@@ -7320,7 +7327,7 @@ index 774a52a28693..cd714a7298fe 100644
          // Determine the string for this item.
          const UChar* str = cp + items[i].iCharPos;
 diff --git a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
-index 0516e70973e0..ffd9a02deb55 100644
+index 0516e70973e0078de6ad0216375d34dd9ef51a8d..ffd9a02deb5518e0c8c77b156815c11eb4b16829 100644
 --- a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
 +++ b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
 @@ -37,8 +37,10 @@
@@ -7582,7 +7589,7 @@ index 0516e70973e0..ffd9a02deb55 100644
  {
      switch (val) {
 diff --git a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
-index 7a3b4723f48c..a741751acad0 100644
+index 7a3b4723f48c179864b2dd6d5b1ed8d27492358e..a741751acad01f11d7da0f6896eeb0023b9a3fcc 100644
 --- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
 +++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
 @@ -224,7 +224,7 @@ bool screenSupportsExtendedColor(Widget*)
@@ -7604,7 +7611,7 @@ index 7a3b4723f48c..a741751acad0 100644
      auto* display = gdk_display_get_default();
      if (!display)
 diff --git a/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp b/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
-index f4c905dc15a2..e9925e7a9fc3 100644
+index f4c905dc15a2183629b0e9817dc24135e0ff7fe5..e9925e7a9fc3cbf5fefffaf38f409fbeec189cb0 100644
 --- a/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
 +++ b/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
 @@ -32,6 +32,10 @@
@@ -7733,7 +7740,7 @@ index f4c905dc15a2..e9925e7a9fc3 100644
  
  #endif // USE(LIBWPE)
 diff --git a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
-index a34dc220bbb9..8ecedd5dae88 100644
+index a34dc220bbb9a92b40dfb463e8724e81ac745b2c..8ecedd5dae88469366a619b96960598c1232a32d 100644
 --- a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
 +++ b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
 @@ -30,8 +30,10 @@
@@ -7995,7 +8002,7 @@ index a34dc220bbb9..8ecedd5dae88 100644
  {
      switch (val) {
 diff --git a/Source/WebCore/platform/network/HTTPHeaderMap.cpp b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
-index 39cb560e54bf..91c132460d4b 100644
+index 39cb560e54bf9efd2dad6e1fb60dd0f609daf6bf..91c132460d4b466f61a8c579f70329fdde3b130f 100644
 --- a/Source/WebCore/platform/network/HTTPHeaderMap.cpp
 +++ b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
 @@ -205,8 +205,11 @@ void HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
@@ -8012,7 +8019,7 @@ index 39cb560e54bf..91c132460d4b 100644
          m_commonHeaders.append(CommonHeader { name, value });
  }
 diff --git a/Source/WebCore/platform/network/ResourceResponseBase.h b/Source/WebCore/platform/network/ResourceResponseBase.h
-index f5c0970b031a..713ade70c5be 100644
+index f5c0970b031a2e9e2a176af81e6cf510ace4cb4a..713ade70c5bec341613bb0b5997c5c64382f41e3 100644
 --- a/Source/WebCore/platform/network/ResourceResponseBase.h
 +++ b/Source/WebCore/platform/network/ResourceResponseBase.h
 @@ -217,6 +217,8 @@ public:
@@ -8046,7 +8053,7 @@ index f5c0970b031a..713ade70c5be 100644
      if constexpr (Decoder::isIPCDecoder) {
          std::optional<Box<NetworkLoadMetrics>> networkLoadMetrics;
 diff --git a/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h b/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h
-index 7330aa933924..a5238a748d1f 100644
+index 7330aa933924791f1292c0847921e3b367493d96..a5238a748d1fb4bfa5b3e0882fe62f4029f84e5f 100644
 --- a/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h
 +++ b/Source/WebCore/platform/network/cf/SocketStreamHandleImpl.h
 @@ -47,7 +47,7 @@ class SocketStreamHandleClient;
@@ -8076,7 +8083,7 @@ index 7330aa933924..a5238a748d1f 100644
      StreamBuffer<uint8_t, 1024 * 1024> m_buffer;
      static const unsigned maxBufferSize = 100 * 1024 * 1024;
 diff --git a/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp b/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
-index 55b9f1ed4a0d..2279824540b8 100644
+index 55b9f1ed4a0d325a6b16a114389f39c7ded36ca6..2279824540b85405ec3ccac709026a381063bac8 100644
 --- a/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
 +++ b/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
 @@ -96,7 +96,7 @@ static inline auto callbacksRunLoopMode()
@@ -8106,7 +8113,7 @@ index 55b9f1ed4a0d..2279824540b8 100644
              kCFStreamSSLPeerName,
              kCFStreamSSLLevel,
 diff --git a/Source/WebCore/platform/network/curl/CookieJarDB.h b/Source/WebCore/platform/network/curl/CookieJarDB.h
-index c4eb67d6f7c3..ce86ab28225a 100644
+index c4eb67d6f7c334076b32b798dcea40b570681e6f..ce86ab28225aa466350671441294f2ace8851bbd 100644
 --- a/Source/WebCore/platform/network/curl/CookieJarDB.h
 +++ b/Source/WebCore/platform/network/curl/CookieJarDB.h
 @@ -72,7 +72,7 @@ public:
@@ -8119,7 +8126,7 @@ index c4eb67d6f7c3..ce86ab28225a 100644
  
      bool m_detectedDatabaseCorruption { false };
 diff --git a/Source/WebCore/platform/network/curl/CurlStream.cpp b/Source/WebCore/platform/network/curl/CurlStream.cpp
-index ff55d3523427..37a657851d84 100644
+index ff55d352342786fcdeaefc64f6ccbe015f4c5b5f..37a657851d84c3693c1e31239a19d9edd935d039 100644
 --- a/Source/WebCore/platform/network/curl/CurlStream.cpp
 +++ b/Source/WebCore/platform/network/curl/CurlStream.cpp
 @@ -33,7 +33,7 @@
@@ -8142,7 +8149,7 @@ index ff55d3523427..37a657851d84 100644
      auto errorCode = m_curlHandle->perform();
      if (errorCode != CURLE_OK) {
 diff --git a/Source/WebCore/platform/network/curl/CurlStream.h b/Source/WebCore/platform/network/curl/CurlStream.h
-index e64629fc22a2..920a8c12c6c6 100644
+index e64629fc22a2097a2af0b0c0139b23d7908cf3dc..920a8c12c6c69afc5aec6de12e9f5fba312237a0 100644
 --- a/Source/WebCore/platform/network/curl/CurlStream.h
 +++ b/Source/WebCore/platform/network/curl/CurlStream.h
 @@ -50,12 +50,12 @@ public:
@@ -8162,7 +8169,7 @@ index e64629fc22a2..920a8c12c6c6 100644
  
      void send(UniqueArray<uint8_t>&&, size_t);
 diff --git a/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp b/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
-index b4a9abd45307..d750af7d2e6e 100644
+index b4a9abd45307e14b1b0080c5fd8490acaf7bb599..d750af7d2e6e25b9df9fada78ae1fe3767066fbb 100644
 --- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
 +++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
 @@ -40,7 +40,7 @@ CurlStreamScheduler::~CurlStreamScheduler()
@@ -8186,7 +8193,7 @@ index b4a9abd45307..d750af7d2e6e 100644
  
      return streamID;
 diff --git a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
-index 7d881206c968..2e8118f11f87 100644
+index 7d881206c9689f433227969c9b7f9ff268bdaaed..2e8118f11f87fa5f32adcedc165aec8220b36d58 100644
 --- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
 +++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
 @@ -38,7 +38,7 @@ public:
@@ -8199,7 +8206,7 @@ index 7d881206c968..2e8118f11f87 100644
      void send(CurlStreamID, UniqueArray<uint8_t>&&, size_t);
  
 diff --git a/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h b/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h
-index b804fde0973b..af3005261593 100644
+index b804fde0973bbfb28331cf7c3a1f20b043e74fe8..af3005261593b5fa91484c98c43d021227716231 100644
 --- a/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h
 +++ b/Source/WebCore/platform/network/curl/SocketStreamHandleImpl.h
 @@ -44,7 +44,7 @@ class StorageSessionProvider;
@@ -8221,7 +8228,7 @@ index b804fde0973b..af3005261593 100644
      size_t bufferedAmount() final;
      std::optional<size_t> platformSendInternal(const uint8_t*, size_t);
 diff --git a/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp b/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp
-index 4b9491c11543..e907fc00a2a4 100644
+index 4b9491c11543f2b60f12d36e9e6a0cbaae34a72e..e907fc00a2a426384ce1e471847911c9ba1739af 100644
 --- a/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp
 +++ b/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp
 @@ -43,7 +43,7 @@
@@ -8243,7 +8250,7 @@ index 4b9491c11543..e907fc00a2a4 100644
  
  SocketStreamHandleImpl::~SocketStreamHandleImpl()
 diff --git a/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h b/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h
-index 88df3748e980..f83c7f2535fd 100644
+index 88df3748e980a22e71bd835864caf24b6b7ea50b..f83c7f2535fd1abae7b1cccca946254b9407f86f 100644
 --- a/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h
 +++ b/Source/WebCore/platform/network/soup/SocketStreamHandleImpl.h
 @@ -47,7 +47,7 @@ class StorageSessionProvider;
@@ -8256,7 +8263,7 @@ index 88df3748e980..f83c7f2535fd 100644
          RELEASE_ASSERT_NOT_REACHED();
      }
 diff --git a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
-index 3e97e804e115..86a1b22913c9 100644
+index 3e97e804e115e0e37814ddf670e9e3ba4b3bbc73..86a1b22913c9ed6563f0d56c7ebd74c16dc829b9 100644
 --- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
 +++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
 @@ -38,6 +38,7 @@
@@ -8280,7 +8287,7 @@ index 3e97e804e115..86a1b22913c9 100644
      ReleaseStgMedium(&store);
  }
 diff --git a/Source/WebCore/platform/win/ClipboardUtilitiesWin.h b/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
-index c50799b63e05..9cf1cc7ec4ea 100644
+index c50799b63e05adbe32bae3535d786c7d268f980f..9cf1cc7ec4eaae22947f80ba272dfae272167bd6 100644
 --- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
 +++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
 @@ -34,6 +34,7 @@ namespace WebCore {
@@ -8292,7 +8299,7 @@ index c50799b63e05..9cf1cc7ec4ea 100644
  HGLOBAL createGlobalData(const String&);
  HGLOBAL createGlobalData(const Vector<char>&);
 diff --git a/Source/WebCore/platform/win/DragDataWin.cpp b/Source/WebCore/platform/win/DragDataWin.cpp
-index 579a112579af..82c566c9d2ce 100644
+index 579a112579af39fc12ef024979d81fc55af36c2b..82c566c9d2ced02a92902a90e7ff97c142fa1903 100644
 --- a/Source/WebCore/platform/win/DragDataWin.cpp
 +++ b/Source/WebCore/platform/win/DragDataWin.cpp
 @@ -48,6 +48,7 @@ DragData::DragData(const DragDataMap& data, const IntPoint& clientPosition, cons
@@ -8304,7 +8311,7 @@ index 579a112579af..82c566c9d2ce 100644
  }
  
 diff --git a/Source/WebCore/platform/win/KeyEventWin.cpp b/Source/WebCore/platform/win/KeyEventWin.cpp
-index aae6c99dd052..7e2e5d0c1de9 100644
+index aae6c99dd052985a43718846b68536454050c234..7e2e5d0c1de90f1454f7fdb71a40ab71228dcbe9 100644
 --- a/Source/WebCore/platform/win/KeyEventWin.cpp
 +++ b/Source/WebCore/platform/win/KeyEventWin.cpp
 @@ -239,10 +239,16 @@ PlatformKeyboardEvent::PlatformKeyboardEvent(HWND, WPARAM code, LPARAM keyData,
@@ -8328,7 +8335,7 @@ index aae6c99dd052..7e2e5d0c1de9 100644
  
  bool PlatformKeyboardEvent::currentCapsLockState()
 diff --git a/Source/WebCore/platform/win/PasteboardWin.cpp b/Source/WebCore/platform/win/PasteboardWin.cpp
-index 9e3357b20e60..be6579859e80 100644
+index 9e3357b20e60f47829ced8d2849f5d8c9a7bb50a..be6579859e80c846235b7f94f2ec7551078c9fdd 100644
 --- a/Source/WebCore/platform/win/PasteboardWin.cpp
 +++ b/Source/WebCore/platform/win/PasteboardWin.cpp
 @@ -1134,7 +1134,21 @@ void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
@@ -8381,7 +8388,7 @@ index 9e3357b20e60..be6579859e80 100644
  } // namespace WebCore
 diff --git a/Source/WebCore/platform/wpe/DragDataWPE.cpp b/Source/WebCore/platform/wpe/DragDataWPE.cpp
 new file mode 100644
-index 000000000000..07fb260a5203
+index 0000000000000000000000000000000000000000..07fb260a5203167fdf94a552949394bb73ca8c61
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/DragDataWPE.cpp
 @@ -0,0 +1,87 @@
@@ -8474,7 +8481,7 @@ index 000000000000..07fb260a5203
 +}
 diff --git a/Source/WebCore/platform/wpe/DragImageWPE.cpp b/Source/WebCore/platform/wpe/DragImageWPE.cpp
 new file mode 100644
-index 000000000000..0c684ea504c0
+index 0000000000000000000000000000000000000000..0c684ea504c0c93895ab75a880b4d2febc946813
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/DragImageWPE.cpp
 @@ -0,0 +1,68 @@
@@ -8547,7 +8554,7 @@ index 000000000000..0c684ea504c0
 +
 +}
 diff --git a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
-index bbdd1ce76241..e6ae01a77350 100644
+index bbdd1ce76241d933ada9c43fabae4912cbfa64e1..e6ae01a77350c519b203f6ed2910f63871b9b829 100644
 --- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
 +++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
 @@ -93,12 +93,12 @@ bool screenSupportsExtendedColor(Widget*)
@@ -8567,7 +8574,7 @@ index bbdd1ce76241..e6ae01a77350 100644
  }
 diff --git a/Source/WebCore/platform/wpe/SelectionData.cpp b/Source/WebCore/platform/wpe/SelectionData.cpp
 new file mode 100644
-index 000000000000..9f181fdfe507
+index 0000000000000000000000000000000000000000..9f181fdfe507ad5b7a47b5c58295cf4f2725e7d8
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/SelectionData.cpp
 @@ -0,0 +1,134 @@
@@ -8707,7 +8714,7 @@ index 000000000000..9f181fdfe507
 +} // namespace WebCore
 diff --git a/Source/WebCore/platform/wpe/SelectionData.h b/Source/WebCore/platform/wpe/SelectionData.h
 new file mode 100644
-index 000000000000..cf2b51f6f028
+index 0000000000000000000000000000000000000000..cf2b51f6f02837a1106f4d999f2f130e2580986a
 --- /dev/null
 +++ b/Source/WebCore/platform/wpe/SelectionData.h
 @@ -0,0 +1,82 @@
@@ -8794,7 +8801,7 @@ index 000000000000..cf2b51f6f028
 +
 +} // namespace WebCore
 diff --git a/Source/WebCore/rendering/RenderLayer.cpp b/Source/WebCore/rendering/RenderLayer.cpp
-index 26574299dc3d..24e28cf37466 100644
+index 26574299dc3df17d9fcace7768dd1ba607ceb52a..24e28cf374662689439ce3054eb7b6c2ec1c732e 100644
 --- a/Source/WebCore/rendering/RenderLayer.cpp
 +++ b/Source/WebCore/rendering/RenderLayer.cpp
 @@ -2560,7 +2560,7 @@ LayoutRect RenderLayer::getRectToExpose(const LayoutRect& visibleRect, const Lay
@@ -8807,7 +8814,7 @@ index 26574299dc3d..24e28cf37466 100644
          // If the rectangle is partially visible, but over a certain threshold,
          // then treat it as fully visible to avoid unnecessary horizontal scrolling
 diff --git a/Source/WebCore/rendering/RenderTextControl.cpp b/Source/WebCore/rendering/RenderTextControl.cpp
-index 242aca3a06b9..4dcd61750471 100644
+index 242aca3a06b91574a748b13ecefa80c6172b9c59..4dcd61750471013be4455b0270a8a21a7b489d47 100644
 --- a/Source/WebCore/rendering/RenderTextControl.cpp
 +++ b/Source/WebCore/rendering/RenderTextControl.cpp
 @@ -207,13 +207,13 @@ void RenderTextControl::layoutExcludedChildren(bool relayoutChildren)
@@ -8826,7 +8833,7 @@ index 242aca3a06b9..4dcd61750471 100644
  {
      auto innerText = innerTextElement();
 diff --git a/Source/WebCore/rendering/RenderTextControl.h b/Source/WebCore/rendering/RenderTextControl.h
-index 2e90534ffd8d..2493c00d5895 100644
+index 2e90534ffd8da83b7dc54d46fa7def16319bbb43..2493c00d58957751c65c37eb409fa8d675efd5ca 100644
 --- a/Source/WebCore/rendering/RenderTextControl.h
 +++ b/Source/WebCore/rendering/RenderTextControl.h
 @@ -36,9 +36,9 @@ public:
@@ -8841,7 +8848,7 @@ index 2e90534ffd8d..2493c00d5895 100644
      int innerLineHeight() const override;
  #endif
 diff --git a/Source/WebCore/rendering/ScrollAlignment.h b/Source/WebCore/rendering/ScrollAlignment.h
-index 694008e0451e..ec93869f9486 100644
+index 694008e0451edc5770142a0a6d9eed52b04ded80..ec93869f9486bdf7bd3bb56478c62469d2fa58b6 100644
 --- a/Source/WebCore/rendering/ScrollAlignment.h
 +++ b/Source/WebCore/rendering/ScrollAlignment.h
 @@ -78,6 +78,7 @@ struct ScrollAlignment {
@@ -8853,7 +8860,7 @@ index 694008e0451e..ec93869f9486 100644
      
  WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollAlignment::Behavior);
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
-index a8216b6ca250..9e972fdbff35 100644
+index a8216b6ca250fea6e14cf02ce2e674847063d5ee..9e972fdbff3553ba26e1c1de994453fb3c1bcd50 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 @@ -74,6 +74,11 @@
@@ -8885,7 +8892,7 @@ index a8216b6ca250..9e972fdbff35 100644
  void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier frameID, PageIdentifier pageID)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
-index 30b8dae1b63f..47f7e34d87c3 100644
+index 30b8dae1b63f62af7077d9566cb1cfc6fed7da5c..47f7e34d87c36226a0244f38d7456853da90860d 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 @@ -285,6 +285,8 @@ private:
@@ -8898,7 +8905,7 @@ index 30b8dae1b63f..47f7e34d87c3 100644
      void removeStorageAccessForFrame(WebCore::FrameIdentifier, WebCore::PageIdentifier);
  
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
-index 063ee6a461bb..d7db79273b77 100644
+index 063ee6a461bb68ebde70c6f9ee4e83961d03354b..d7db79273b77296864150d1bc00363291c343947 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 @@ -64,6 +64,8 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
@@ -8911,7 +8918,7 @@ index 063ee6a461bb..d7db79273b77 100644
      RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
      LogUserInteraction(WebCore::RegistrableDomain domain)
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.cpp b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
-index 49bdd3fec681..5a47aa54e4bb 100644
+index 49bdd3fec68137ce4353950034adc6b2752af9e5..5a47aa54e4bb4bfc5bd216a027c62c0ce3df36cf 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 @@ -26,7 +26,6 @@
@@ -8983,7 +8990,7 @@ index 49bdd3fec681..5a47aa54e4bb 100644
  void NetworkProcess::dumpResourceLoadStatistics(PAL::SessionID sessionID, CompletionHandler<void(String)>&& completionHandler)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.h b/Source/WebKit/NetworkProcess/NetworkProcess.h
-index 447784b1a783..9aad05a798d0 100644
+index 447784b1a7838dd7bdc95cf374057bcc59d8a33d..9aad05a798d00dfb7346a2fbb78a947686e7e715 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
 @@ -34,6 +34,7 @@
@@ -9018,7 +9025,7 @@ index 447784b1a783..9aad05a798d0 100644
      void clearPrevalentResource(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
      void clearUserInteraction(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
-index ae15ff0e12ca..4ee782cbb1e4 100644
+index ae15ff0e12ca545178907d972a09ce6d2321a2d4..4ee782cbb1e4ce8228785f63fa1ca868276a2be9 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 @@ -79,6 +79,14 @@ messages -> NetworkProcess LegacyReceiver {
@@ -9037,7 +9044,7 @@ index ae15ff0e12ca..4ee782cbb1e4 100644
      ClearPrevalentResource(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> () Async
      ClearUserInteraction(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> () Async
 diff --git a/Source/WebKit/NetworkProcess/NetworkSession.h b/Source/WebKit/NetworkProcess/NetworkSession.h
-index 2bff182280c4..ba3b95d38633 100644
+index 2bff182280c428e81b6c3684f5aaf928db897932..ba3b95d3863362e3926de2b8aa6b14e6fb668467 100644
 --- a/Source/WebKit/NetworkProcess/NetworkSession.h
 +++ b/Source/WebKit/NetworkProcess/NetworkSession.h
 @@ -153,6 +153,9 @@ public:
@@ -9059,7 +9066,7 @@ index 2bff182280c4..ba3b95d38633 100644
      HashSet<Ref<NetworkResourceLoader>> m_keptAliveLoads;
  
 diff --git a/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp b/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp
-index 52eb5b08f16c..1f541ccfbe18 100644
+index 52eb5b08f16cba232149028cdaa8150ad04e4a9f..1f541ccfbe183ee152cea69108b80ffd3b1ff34f 100644
 --- a/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkSocketStream.cpp
 @@ -43,7 +43,7 @@ Ref<NetworkSocketStream> NetworkSocketStream::create(NetworkProcess& networkProc
@@ -9072,7 +9079,7 @@ index 52eb5b08f16c..1f541ccfbe18 100644
  {
  }
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp
-index 60153bf7d6b0..5c0907b31551 100644
+index 60153bf7d6b07f58e0ea1595a14fc8c81353c149..5c0907b31551b576aeed1e9d26f4f5bcce055ec2 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.cpp
 @@ -29,6 +29,7 @@
@@ -9096,7 +9103,7 @@ index 60153bf7d6b0..5c0907b31551 100644
 +
  } // namespace WebKit
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h
-index adca9f4a255f..81f6c0bde82e 100644
+index adca9f4a255f58e2106dd6a4eceaddfff2451ac3..81f6c0bde82ea58ed5abc5e3653bb64a3377f531 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageNamespace.h
 @@ -28,7 +28,7 @@
@@ -9118,7 +9125,7 @@ index adca9f4a255f..81f6c0bde82e 100644
      StorageManager& m_storageManager;
      unsigned m_quotaInBytes { 0 };
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp
-index 83194b05fb4e..9c9357eb7466 100644
+index 83194b05fb4ee11777ddf10aed278f60c0b9982c..9c9357eb7466b82379f394aee3ff383784483ee1 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.cpp
 @@ -111,6 +111,18 @@ void StorageArea::setItem(IPC::Connection::UniqueID sourceConnection, StorageAre
@@ -9141,7 +9148,7 @@ index 83194b05fb4e..9c9357eb7466 100644
  {
      ASSERT(!RunLoop::isMain());
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h
-index 9c715702dbe6..9174bb3f38b6 100644
+index 9c715702dbe69b7f33c7c31be45779b32ea96a34..9174bb3f38b63d431fe2a8932d2646dea1c682ff 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageArea.h
 @@ -64,6 +64,7 @@ public:
@@ -9153,7 +9160,7 @@ index 9c715702dbe6..9174bb3f38b6 100644
      void clear();
  
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
-index 5bcca299ba41..a7526a2adbd9 100644
+index 5bcca299ba415e39c02845997e5806b2846da93c..a7526a2adbd93ecb3e16a9b8b8f754152c79f2d4 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
 @@ -147,6 +147,19 @@ HashSet<SecurityOriginData> StorageManager::getLocalStorageOriginsCrossThreadCop
@@ -9177,7 +9184,7 @@ index 5bcca299ba41..a7526a2adbd9 100644
  {
      ASSERT(!RunLoop::isMain());
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
-index 0d6e7aedff68..67b616d818aa 100644
+index 0d6e7aedff68227bf7dc8ab7184abc6fd3321c54..67b616d818aa42f8cae33f0535c888cd4c5ec07e 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
 @@ -66,6 +66,7 @@ public:
@@ -9189,7 +9196,7 @@ index 0d6e7aedff68..67b616d818aa 100644
      void deleteLocalStorageEntriesForOrigins(const Vector<WebCore::SecurityOriginData>&);
      Vector<LocalStorageDatabaseTracker::OriginDetails> getLocalStorageOriginDetailsCrossThreadCopy() const;
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
-index 61d0b3c77ce5..0ddfcc2014f3 100644
+index 61d0b3c77ce5c8dcd741c7d04ad4145f6b47f66e..0ddfcc2014f3edc9a593de8fd87c9423940a7ee6 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
 @@ -262,6 +262,50 @@ void StorageManagerSet::getLocalStorageOrigins(PAL::SessionID sessionID, GetOrig
@@ -9244,7 +9251,7 @@ index 61d0b3c77ce5..0ddfcc2014f3 100644
  {
      ASSERT(RunLoop::isMain());
 diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
-index 4243f32573bd..023416d6e453 100644
+index 4243f32573bdad1452107f55c82328961cd5b0d4..023416d6e453431167441504ea38b3b2f19330fd 100644
 --- a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
 +++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
 @@ -45,6 +45,7 @@ using ConnectToStorageAreaCallback = CompletionHandler<void(const std::optional<
@@ -9265,7 +9272,7 @@ index 4243f32573bd..023416d6e453 100644
  
      void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
-index 4ebbd90cc645..3d5d56a5a1b4 100644
+index 4ebbd90cc645df5f9ddbb860d08aa3eb053c2ff6..3d5d56a5a1b407f27e533c9c71d3e4c4fb012c36 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
 @@ -86,6 +86,8 @@ public:
@@ -9278,7 +9285,7 @@ index 4ebbd90cc645..3d5d56a5a1b4 100644
      NetworkDataTaskCocoa(NetworkSession&, NetworkDataTaskClient&, const NetworkLoadParameters&);
  
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
-index f74b3129fe72..f2d20693b81f 100644
+index f74b3129fe72bc9fce62360606d3b39b0712cf89..f2d20693b81f3a953102ab335f3744c28be4a0ea 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
 @@ -42,6 +42,7 @@
@@ -9350,7 +9357,7 @@ index f74b3129fe72..f2d20693b81f 100644
 +
  }
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-index fdce7681fe6f..2ba62f93a3c4 100644
+index fdce7681fe6f28872b422e63549192d519476729..2ba62f93a3c4dfe91f77097ad98748486f6d3471 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 @@ -700,7 +700,7 @@ static inline void processServerTrustEvaluation(NetworkSessionCocoa& session, Se
@@ -9377,7 +9384,7 @@ index fdce7681fe6f..2ba62f93a3c4 100644
  #if !LOG_DISABLED
              LOG(NetworkSession, "%llu didReceiveResponse completionHandler (%d)", taskIdentifier, policyAction);
 diff --git a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
-index e9f9b2c25786..c45d2f047614 100644
+index e9f9b2c257866d9300e79781cbef3addc59cd9de..c45d2f047614da8a5e360b88960fbd2afb16072f 100644
 --- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
 +++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
 @@ -26,9 +26,13 @@
@@ -9513,7 +9520,7 @@ index e9f9b2c25786..c45d2f047614 100644
  
          if (m_state != State::Suspended) {
 diff --git a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
-index 1c427ddb78d6..cf33ff6076dd 100644
+index 1c427ddb78d6953fe8960c5692afde4f4f0eee85..cf33ff6076dd95ffe564f1dde89c177acd27b02c 100644
 --- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
 +++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
 @@ -32,6 +32,7 @@
@@ -9550,7 +9557,7 @@ index 1c427ddb78d6..cf33ff6076dd 100644
  
      WebCore::ShouldRelaxThirdPartyCookieBlocking m_shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
 diff --git a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
-index dbdfe70ca4f5..5f5ef27c9bfd 100644
+index dbdfe70ca4f50f2aaba4e9f51037b8a89aad69e8..5f5ef27c9bfd20c5006dac8741ead2579704d17b 100644
 --- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 +++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 @@ -491,6 +491,7 @@ void NetworkDataTaskSoup::didSendRequest(GRefPtr<GInputStream>&& inputStream)
@@ -9571,7 +9578,7 @@ index dbdfe70ca4f5..5f5ef27c9bfd 100644
      if (!error)
          return true;
 diff --git a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
-index 06ca252b0439..597e63aca71d 100644
+index 06ca252b043959d457814d45886949a85b1a19c1..597e63aca71d213526d953ead357fbc0e0405f8d 100644
 --- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
 +++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
 @@ -113,6 +113,11 @@ static gboolean webSocketAcceptCertificateCallback(GTlsConnection* connection, G
@@ -9632,7 +9639,7 @@ index 06ca252b0439..597e63aca71d 100644
      }
      return makeUnique<WebSocketTask>(channel, request, soupSession(), soupMessage.get(), protocol);
 diff --git a/Source/WebKit/PlatformGTK.cmake b/Source/WebKit/PlatformGTK.cmake
-index d679785ca3bd..14de9b9f902d 100644
+index d679785ca3bd58b2ed2ce08765eb55701bf5e723..14de9b9f902d7d131f44d0aedcf7ed751e55e7ca 100644
 --- a/Source/WebKit/PlatformGTK.cmake
 +++ b/Source/WebKit/PlatformGTK.cmake
 @@ -450,6 +450,9 @@ list(APPEND WebKit_SYSTEM_INCLUDE_DIRECTORIES
@@ -9669,7 +9676,7 @@ index d679785ca3bd..14de9b9f902d 100644
  set(WebKit2GTK_ENUM_GENERATION_HEADERS ${WebKit2GTK_INSTALLED_HEADERS})
  list(REMOVE_ITEM WebKit2GTK_ENUM_GENERATION_HEADERS ${WebKit2Gtk_DERIVED_SOURCES_DIR}/webkit2/WebKitEnumTypes.h)
 diff --git a/Source/WebKit/PlatformWPE.cmake b/Source/WebKit/PlatformWPE.cmake
-index e397c07b7cf7..ba2270f561b9 100644
+index e397c07b7cf7170f4d833997d499b4ac7ffcd898..ba2270f561b90cc54682b77c02c9028552e951fa 100644
 --- a/Source/WebKit/PlatformWPE.cmake
 +++ b/Source/WebKit/PlatformWPE.cmake
 @@ -278,6 +278,7 @@ list(APPEND WebKit_INCLUDE_DIRECTORIES
@@ -9699,7 +9706,7 @@ index e397c07b7cf7..ba2270f561b9 100644
      Cairo::Cairo
      Freetype::Freetype
 diff --git a/Source/WebKit/PlatformWin.cmake b/Source/WebKit/PlatformWin.cmake
-index 01565d550697..98fb300309de 100644
+index 01565d550697b25367bb36971d6fe5ec33f712f0..98fb300309de1c0567912158f23ab39e7c0e21d5 100644
 --- a/Source/WebKit/PlatformWin.cmake
 +++ b/Source/WebKit/PlatformWin.cmake
 @@ -69,8 +69,12 @@ list(APPEND WebKit_SOURCES
@@ -9805,7 +9812,7 @@ index 01565d550697..98fb300309de 100644
  endif ()
  
 diff --git a/Source/WebKit/Shared/API/c/wpe/WebKit.h b/Source/WebKit/Shared/API/c/wpe/WebKit.h
-index caf67e1dece5..740150d2589d 100644
+index caf67e1dece5b727e43eba780e70814f8fdb0f63..740150d2589d6e16a516daa3bf6ef899ac538c99 100644
 --- a/Source/WebKit/Shared/API/c/wpe/WebKit.h
 +++ b/Source/WebKit/Shared/API/c/wpe/WebKit.h
 @@ -77,6 +77,7 @@
@@ -9817,7 +9824,7 @@ index caf67e1dece5..740150d2589d 100644
  #include <WebKit/WKContextConfigurationRef.h>
  #include <WebKit/WKCredential.h>
 diff --git a/Source/WebKit/Shared/NativeWebKeyboardEvent.h b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
-index ee8cac1c9800..deae2be9e720 100644
+index ee8cac1c980039c4a36de5501ab7f135e710d06b..deae2be9e720ff76186ecea89920dfc39c4f186a 100644
 --- a/Source/WebKit/Shared/NativeWebKeyboardEvent.h
 +++ b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
 @@ -33,6 +33,7 @@
@@ -9865,7 +9872,7 @@ index ee8cac1c9800..deae2be9e720 100644
  
  #if USE(APPKIT)
 diff --git a/Source/WebKit/Shared/NativeWebMouseEvent.h b/Source/WebKit/Shared/NativeWebMouseEvent.h
-index 001558dd58f4..1e0898f985f1 100644
+index 001558dd58f4d85f360d5711caa03db33889011e..1e0898f985f1d13036d31e3e284258a3c64fa0a4 100644
 --- a/Source/WebKit/Shared/NativeWebMouseEvent.h
 +++ b/Source/WebKit/Shared/NativeWebMouseEvent.h
 @@ -77,6 +77,11 @@ public:
@@ -9881,7 +9888,7 @@ index 001558dd58f4..1e0898f985f1 100644
      NSEvent* nativeEvent() const { return m_nativeEvent.get(); }
  #elif PLATFORM(GTK)
 diff --git a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
-index 91d21d8f236b..6c4caa100f78 100644
+index 91d21d8f236bd18832b50d2cad311cc6f2488cee..6c4caa100f785aa896569f24539467693295746c 100644
 --- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 +++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 @@ -120,6 +120,10 @@
@@ -9973,7 +9980,7 @@ index 91d21d8f236b..6c4caa100f78 100644
      return true;
  }
 diff --git a/Source/WebKit/Shared/WebEvent.h b/Source/WebKit/Shared/WebEvent.h
-index 3ae6504779d3..72d44c33953c 100644
+index 3ae6504779d3917a79f69f32b58260afeda270b4..72d44c33953cc13bf2ed7c762b4f9a7b88571b56 100644
 --- a/Source/WebKit/Shared/WebEvent.h
 +++ b/Source/WebKit/Shared/WebEvent.h
 @@ -31,6 +31,7 @@
@@ -9985,7 +9992,7 @@ index 3ae6504779d3..72d44c33953c 100644
  #include <wtf/text/WTFString.h>
  
 diff --git a/Source/WebKit/Shared/WebKeyboardEvent.cpp b/Source/WebKit/Shared/WebKeyboardEvent.cpp
-index a70eb76c5c22..f97fa9dec785 100644
+index a70eb76c5c22a2c779c30874433ac19036b5f1a4..f97fa9dec785fd6327bb7847454e8a32b8a0d3ac 100644
 --- a/Source/WebKit/Shared/WebKeyboardEvent.cpp
 +++ b/Source/WebKit/Shared/WebKeyboardEvent.cpp
 @@ -35,6 +35,7 @@ WebKeyboardEvent::WebKeyboardEvent()
@@ -10075,7 +10082,7 @@ index a70eb76c5c22..f97fa9dec785 100644
  {
  }
 diff --git a/Source/WebKit/Shared/WebKeyboardEvent.h b/Source/WebKit/Shared/WebKeyboardEvent.h
-index 7a5893eb68ad..a2d68a5eb59d 100644
+index 7a5893eb68ad24cf92c832070485489b7cfafa0c..a2d68a5eb59d8b7155c1e17b75a12e55f299b868 100644
 --- a/Source/WebKit/Shared/WebKeyboardEvent.h
 +++ b/Source/WebKit/Shared/WebKeyboardEvent.h
 @@ -43,14 +43,18 @@ public:
@@ -10098,7 +10105,7 @@ index 7a5893eb68ad..a2d68a5eb59d 100644
  
      const String& text() const { return m_text; }
 diff --git a/Source/WebKit/Shared/WebPageCreationParameters.cpp b/Source/WebKit/Shared/WebPageCreationParameters.cpp
-index 6a25231f6fc2..b25472d15a30 100644
+index 6a25231f6fc258c1e38aa05ce12aa444fd7096c8..b25472d15a30834997e39632144a44aa25103654 100644
 --- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
 +++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
 @@ -156,6 +156,8 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
@@ -10123,7 +10130,7 @@ index 6a25231f6fc2..b25472d15a30 100644
          return std::nullopt;
  
 diff --git a/Source/WebKit/Shared/WebPageCreationParameters.h b/Source/WebKit/Shared/WebPageCreationParameters.h
-index c58e6c220b1a..f2d004ec0703 100644
+index c58e6c220b1a03766aae548472f16b783e0402ac..f2d004ec07037b483c3ff0ea20c7f38a07084ad5 100644
 --- a/Source/WebKit/Shared/WebPageCreationParameters.h
 +++ b/Source/WebKit/Shared/WebPageCreationParameters.h
 @@ -247,6 +247,8 @@ struct WebPageCreationParameters {
@@ -10136,7 +10143,7 @@ index c58e6c220b1a..f2d004ec0703 100644
      String themeName;
  #endif
 diff --git a/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp b/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp
-index c204637774ee..345f5b08179e 100644
+index c204637774ee803eac42a34cde79aa556f143b82..345f5b08179e3dd239725bed06e48b46bc718336 100644
 --- a/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp
 +++ b/Source/WebKit/Shared/gtk/NativeWebKeyboardEventGtk.cpp
 @@ -50,7 +50,7 @@ NativeWebKeyboardEvent::NativeWebKeyboardEvent(Type type, const String& text, co
@@ -10149,7 +10156,7 @@ index c204637774ee..345f5b08179e 100644
  {
  }
 diff --git a/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp b/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
-index 7cc65739c320..da53885517d5 100644
+index 7cc65739c320cb4312d9d705284220a383a0293a..da53885517d55d424423ee3d0dcead25825cc022 100644
 --- a/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
 +++ b/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
 @@ -54,7 +54,7 @@ NativeWebMouseEvent::NativeWebMouseEvent(Type type, Button button, unsigned shor
@@ -10162,7 +10169,7 @@ index 7cc65739c320..da53885517d5 100644
  {
  }
 diff --git a/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp b/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp
-index 03e118154f6b..9725caaac6ee 100644
+index 03e118154f6bb5b704b4ecb83d3d9543f8c5a5fa..9725caaac6ee65a96ea324ddbb4e1a3785bbc028 100644
 --- a/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp
 +++ b/Source/WebKit/Shared/ios/WebPlatformTouchPointIOS.cpp
 @@ -26,7 +26,7 @@
@@ -10181,7 +10188,7 @@ index 03e118154f6b..9725caaac6ee 100644
 -#endif // ENABLE(TOUCH_EVENTS)
 +#endif // ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp b/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp
-index e40a6e172bfd..2516655bbc9e 100644
+index e40a6e172bfd2b75076fd4053da643ebab9eb81f..2516655bbc9e5bc863537a554c5faac0f6fc1a09 100644
 --- a/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp
 +++ b/Source/WebKit/Shared/ios/WebTouchEventIOS.cpp
 @@ -26,7 +26,7 @@
@@ -10201,7 +10208,7 @@ index e40a6e172bfd..2516655bbc9e 100644
 +#endif // ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.cpp b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.cpp
 new file mode 100644
-index 000000000000..678010b33d70
+index 0000000000000000000000000000000000000000..678010b33d70dae6369ace4337b4c0eb81152250
 --- /dev/null
 +++ b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.cpp
 @@ -0,0 +1,173 @@
@@ -10380,7 +10387,7 @@ index 000000000000..678010b33d70
 +}
 diff --git a/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.h b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.h
 new file mode 100644
-index 000000000000..789a0d7cf697
+index 0000000000000000000000000000000000000000..789a0d7cf69704c8f665a9ed79348fbcbc1301c4
 --- /dev/null
 +++ b/Source/WebKit/Shared/libwpe/ArgumentCodersWPE.h
 @@ -0,0 +1,41 @@
@@ -10426,7 +10433,7 @@ index 000000000000..789a0d7cf697
 +
 +} // namespace IPC
 diff --git a/Source/WebKit/Shared/win/WebEventFactory.cpp b/Source/WebKit/Shared/win/WebEventFactory.cpp
-index 85d6f74114f4..6896c9756edb 100644
+index 85d6f74114f4e7f82d9502d1b99d69098d6a49b6..6896c9756edb233dda46c7031e1af69923da8c23 100644
 --- a/Source/WebKit/Shared/win/WebEventFactory.cpp
 +++ b/Source/WebKit/Shared/win/WebEventFactory.cpp
 @@ -473,7 +473,7 @@ WebKeyboardEvent WebEventFactory::createWebKeyboardEvent(HWND hwnd, UINT message
@@ -10439,7 +10446,7 @@ index 85d6f74114f4..6896c9756edb 100644
      return WebTouchEvent();
  }
 diff --git a/Source/WebKit/Sources.txt b/Source/WebKit/Sources.txt
-index d488a3d966ec..aa66ba61048e 100644
+index d488a3d966ec641d8dcf652fa37b2b49d9cd45d7..aa66ba61048e23194fbd24e955ecd68e6a5031ba 100644
 --- a/Source/WebKit/Sources.txt
 +++ b/Source/WebKit/Sources.txt
 @@ -289,11 +289,14 @@ Shared/WebsiteData/WebsiteData.cpp
@@ -10487,7 +10494,7 @@ index d488a3d966ec..aa66ba61048e 100644
  UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
  UIProcess/Media/MediaUsageManager.cpp
 diff --git a/Source/WebKit/SourcesCocoa.txt b/Source/WebKit/SourcesCocoa.txt
-index c939c114fd9d..809ab842f496 100644
+index c939c114fd9dab77a3c2ff005cfc669667dc9563..809ab842f496eebafe593e8143bd492665331bf9 100644
 --- a/Source/WebKit/SourcesCocoa.txt
 +++ b/Source/WebKit/SourcesCocoa.txt
 @@ -267,6 +267,7 @@ UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -10507,7 +10514,7 @@ index c939c114fd9d..809ab842f496 100644
  UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
  UIProcess/Inspector/mac/WKInspectorViewController.mm
 diff --git a/Source/WebKit/SourcesGTK.txt b/Source/WebKit/SourcesGTK.txt
-index a4391be7b637..3f7d5e6c9deb 100644
+index a4391be7b637fd96d880cb06838b6deb5db552b6..3f7d5e6c9debc1cf1155da11bad14fc5c3b01dc8 100644
 --- a/Source/WebKit/SourcesGTK.txt
 +++ b/Source/WebKit/SourcesGTK.txt
 @@ -125,6 +125,7 @@ UIProcess/API/glib/WebKitAuthenticationRequest.cpp @no-unify
@@ -10544,7 +10551,7 @@ index a4391be7b637..3f7d5e6c9deb 100644
  UIProcess/gtk/WebPasteboardProxyGtk.cpp
  UIProcess/gtk/WebPopupMenuProxyGtk.cpp
 diff --git a/Source/WebKit/SourcesWPE.txt b/Source/WebKit/SourcesWPE.txt
-index f8fb1511f2a0..c086fd981369 100644
+index f8fb1511f2a019a08a896f7cbf45ca470da28185..c086fd981369d998ae39b836d4a71504d9b1aeea 100644
 --- a/Source/WebKit/SourcesWPE.txt
 +++ b/Source/WebKit/SourcesWPE.txt
 @@ -86,6 +86,7 @@ Shared/glib/ProcessExecutablePathGLib.cpp
@@ -10592,7 +10599,7 @@ index f8fb1511f2a0..c086fd981369 100644
  
  WebProcess/WebPage/AcceleratedSurface.cpp
 diff --git a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
-index 95ffe0584caa..afd48bd8e3bc 100644
+index 95ffe0584caa71911dabce619d8429df55daece0..afd48bd8e3bc1ada31d6b2d1d84097f878bb36f5 100644
 --- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
 +++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
 @@ -54,6 +54,9 @@ Ref<ProcessPoolConfiguration> ProcessPoolConfiguration::copy()
@@ -10606,7 +10613,7 @@ index 95ffe0584caa..afd48bd8e3bc 100644
      copy->m_shouldTakeUIBackgroundAssertion = this->m_shouldTakeUIBackgroundAssertion;
      copy->m_shouldCaptureDisplayInUIProcess = this->m_shouldCaptureDisplayInUIProcess;
 diff --git a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
-index fa69a4b457ee..a0134fe49a44 100644
+index fa69a4b457ee31cec78765e262b0af13fe40b87d..a0134fe49a4404f0441bfa8e8720273c6cad3835 100644
 --- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
 +++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
 @@ -101,6 +101,11 @@ public:
@@ -10632,7 +10639,7 @@ index fa69a4b457ee..a0134fe49a44 100644
      bool m_shouldTakeUIBackgroundAssertion { true };
      bool m_shouldCaptureDisplayInUIProcess { DEFAULT_CAPTURE_DISPLAY_IN_UI_PROCESS };
 diff --git a/Source/WebKit/UIProcess/API/APIUIClient.h b/Source/WebKit/UIProcess/API/APIUIClient.h
-index 2175c518821e..a2489687cc2e 100644
+index 2175c518821effff060578c418e224817610d644..a2489687cc2efd5a59fc987a350a618c662c3734 100644
 --- a/Source/WebKit/UIProcess/API/APIUIClient.h
 +++ b/Source/WebKit/UIProcess/API/APIUIClient.h
 @@ -93,6 +93,7 @@ public:
@@ -10644,7 +10651,7 @@ index 2175c518821e..a2489687cc2e 100644
      virtual void setStatusText(WebKit::WebPageProxy*, const WTF::String&) { }
      virtual void mouseDidMoveOverElement(WebKit::WebPageProxy&, const WebKit::WebHitTestResultData&, OptionSet<WebKit::WebEvent::Modifier>, Object*) { }
 diff --git a/Source/WebKit/UIProcess/API/C/WKInspector.cpp b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
-index e1465edd29ca..32d569d3240c 100644
+index e1465edd29caf3109c17d44bb3c88aaba98cfbb5..32d569d3240c583334b8b6512407430fd448ae75 100644
 --- a/Source/WebKit/UIProcess/API/C/WKInspector.cpp
 +++ b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
 @@ -28,6 +28,11 @@
@@ -10672,7 +10679,7 @@ index e1465edd29ca..32d569d3240c 100644
 +
  #endif // !PLATFORM(IOS_FAMILY)
 diff --git a/Source/WebKit/UIProcess/API/C/WKInspector.h b/Source/WebKit/UIProcess/API/C/WKInspector.h
-index 026121d114c5..edd6e5cae033 100644
+index 026121d114c5fcad84c1396be8d692625beaa3bd..edd6e5cae033124c589959a42522fde07a42fdf6 100644
 --- a/Source/WebKit/UIProcess/API/C/WKInspector.h
 +++ b/Source/WebKit/UIProcess/API/C/WKInspector.h
 @@ -66,6 +66,10 @@ WK_EXPORT void WKInspectorTogglePageProfiling(WKInspectorRef inspector);
@@ -10687,7 +10694,7 @@ index 026121d114c5..edd6e5cae033 100644
  }
  #endif
 diff --git a/Source/WebKit/UIProcess/API/C/WKPage.cpp b/Source/WebKit/UIProcess/API/C/WKPage.cpp
-index 702efb299a41..657d69666f19 100644
+index 702efb299a41b013c856905e9e6b80262770afe1..657d69666f19aef2ac262408fa61283173994027 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
 +++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
 @@ -1778,6 +1778,13 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
@@ -10714,7 +10721,7 @@ index 702efb299a41..657d69666f19 100644
          }
  
 diff --git a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
-index ed980be17cdf..ca3c0ff1ec6d 100644
+index ed980be17cdf9faec3f7af1bdc7cfd640bab8fc2..ca3c0ff1ec6d30173ae15e786f30ef1bad0e5bb6 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
 +++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
 @@ -90,6 +90,7 @@ typedef void (*WKPageRunBeforeUnloadConfirmPanelCallback)(WKPageRef page, WKStri
@@ -10750,7 +10757,7 @@ index ed980be17cdf..ca3c0ff1ec6d 100644
      // Version 15.
      WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
-index 82003ea11098..b0ebb2874de8 100644
+index 82003ea11098fa60e7ac7e2cdd29ea86154c7ccb..b0ebb2874de88f8e11c515d973b4e2cea160304a 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
 @@ -135,6 +135,12 @@ typedef NS_ENUM(NSInteger, WKMediaCaptureType) {
@@ -10767,7 +10774,7 @@ index 82003ea11098..b0ebb2874de8 100644
  /*! @abstract A delegate to request permission for microphone audio and camera video access.
   @param webView The web view invoking the delegate method.
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
-index afa925f36c29..42d396342acd 100644
+index afa925f36c29db9c23921298dead9cce737500d6..42d396342acdb6d39830f611df0ee40ea6ec879e 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
 @@ -24,7 +24,6 @@
@@ -10788,7 +10795,7 @@ index afa925f36c29..42d396342acd 100644
  
  NS_ASSUME_NONNULL_END
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
-index 672b2053442e..3d49ea06d6cd 100644
+index 672b2053442e7e834aa453c40d32c9d90701e103..3d49ea06d6cda6c274ef9c59c003a1275e916810 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 @@ -42,6 +42,7 @@
@@ -10813,7 +10820,7 @@ index 672b2053442e..3d49ea06d6cd 100644
      Vector<WebKit::WebsiteDataRecord> result;
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.h b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.h
 new file mode 100644
-index 000000000000..5fabe06a3289
+index 0000000000000000000000000000000000000000..5fabe06a3289689246c36dfd96eb9900a48b2b0f
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.h
 @@ -0,0 +1,55 @@
@@ -10874,7 +10881,7 @@ index 000000000000..5fabe06a3289
 +
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.mm
 new file mode 100644
-index 000000000000..e7143513ea2b
+index 0000000000000000000000000000000000000000..e7143513ea2be8e1cdab5c86a28643fffea626dd
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKBrowserInspector.mm
 @@ -0,0 +1,60 @@
@@ -10939,7 +10946,7 @@ index 000000000000..e7143513ea2b
 +}
 +@end
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
-index 0b32900879f7..d3bac7b11303 100644
+index 0b32900879f73b9776f1bfbb6aec73c0553f7ac0..d3bac7b1130311c1094401b57c28b8f617d153aa 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
 @@ -32,6 +32,7 @@
@@ -10951,7 +10958,7 @@ index 0b32900879f7..d3bac7b11303 100644
  
  ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h b/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h
-index ca94c2173757..422c1379da9b 100644
+index ca94c2173757a54a0c755cbf30f8e05a0b75c9cb..422c1379da9b091ae5903a42bc7625be78030016 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h
 @@ -24,6 +24,7 @@
@@ -10963,7 +10970,7 @@ index ca94c2173757..422c1379da9b 100644
  #import <wtf/RetainPtr.h>
  
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
-index 46561d34314a..c84cbe9adc52 100644
+index 46561d34314a79d42c57e59bf7927ad1fa451045..c84cbe9adc5236ad64240a18f5ff9a7215ba2ba2 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
 @@ -24,7 +24,10 @@
@@ -10978,7 +10985,7 @@ index 46561d34314a..c84cbe9adc52 100644
  #if ENABLE(INSPECTOR_EXTENSIONS)
  
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
-index 8a62271a7c58..950059171602 100644
+index 8a62271a7c58409835f1d7bfe993220207c85457..9500591716027a3a09bee5dc0608f64991b06ce5 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
 @@ -65,6 +65,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
@@ -10990,7 +10997,7 @@ index 8a62271a7c58..950059171602 100644
  @property (nonatomic) BOOL processSwapsOnWindowOpenWithOpener WK_API_AVAILABLE(macos(10.14), ios(12.0));
  @property (nonatomic) BOOL processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol WK_API_AVAILABLE(macos(12.0), ios(15.0));
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
-index e23314a2904c..941d0b483bba 100644
+index e23314a2904c781ca23a9f8d906299740677759e..941d0b483bba4647a9b4b160e9c3c9a79b9c0494 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 @@ -245,6 +245,16 @@
@@ -11011,7 +11018,7 @@ index e23314a2904c..941d0b483bba 100644
  {
      _processPoolConfiguration->setIsAutomaticProcessWarmingEnabled(prewarms);
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
-index c130399cf9f3..3c10bb7e9dc8 100644
+index c130399cf9f3063f5a2dcc392e19eefd763c153a..3c10bb7e9dc8d9834b90a8d8faaac361f1268504 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 @@ -24,6 +24,7 @@
@@ -11023,7 +11030,7 @@ index c130399cf9f3..3c10bb7e9dc8 100644
  
  #if PLATFORM(MAC)
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h
-index 4974e14214e2..cacdf8c71fab 100644
+index 4974e14214e2bb3e982325b885bab33e54f83998..cacdf8c71fab248d38d2faf03f7affdcfed1ef62 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.h
 @@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
@@ -11035,7 +11042,7 @@ index 4974e14214e2..cacdf8c71fab 100644
  typedef NS_ENUM(NSInteger, _WKUserStyleLevel) {
      _WKUserStyleUserLevel,
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
-index 1e827013c603..2075bc78069b 100644
+index 1e827013c603ae8bd43d798170deb98fc3153852..2075bc78069bde530ec237c0b761773c10013948 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 @@ -35,6 +35,7 @@
@@ -11048,7 +11055,7 @@ index 1e827013c603..2075bc78069b 100644
  @implementation _WKUserStyleSheet
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspector.cpp b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspector.cpp
 new file mode 100644
-index 000000000000..54529a23f53c
+index 0000000000000000000000000000000000000000..54529a23f53cebe6f8a96873ca6c2f31f0481ae0
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspector.cpp
 @@ -0,0 +1,158 @@
@@ -11212,7 +11219,7 @@ index 000000000000..54529a23f53c
 +}
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspectorPrivate.h b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspectorPrivate.h
 new file mode 100644
-index 000000000000..e0b1da48465c
+index 0000000000000000000000000000000000000000..e0b1da48465c850f541532ed961d1b778bea6028
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspectorPrivate.h
 @@ -0,0 +1,32 @@
@@ -11249,7 +11256,7 @@ index 000000000000..e0b1da48465c
 +WebKit::WebPageProxy* webkitBrowserInspectorCreateNewPageInContext(WebKitWebContext*);
 +void webkitBrowserInspectorQuitApplication();
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
-index 0afd97be464c..0826356fe6d3 100644
+index 0afd97be464ceb609f1c43aa720f3b4c297778bd..0826356fe6d35615e9b2c84647dfe3dadab73eb1 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
 @@ -98,6 +98,10 @@ private:
@@ -11264,7 +11271,7 @@ index 0afd97be464c..0826356fe6d3 100644
      bool canRunBeforeUnloadConfirmPanel() const final { return true; }
  
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
-index 6dd9f20e4ff2..7a5f57daa838 100644
+index 6dd9f20e4ff2bda0184d0645301cef22e47dcf15..7a5f57daa83818b2dfb4bcbcbf5c18c8621a6b25 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
 @@ -118,8 +118,8 @@ enum {
@@ -11379,7 +11386,7 @@ index 6dd9f20e4ff2..7a5f57daa838 100644
      /**
       * WebKitWebContext:use-system-appearance-for-scrollbars:
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h b/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
-index 78d1578f9479..493cdadac387 100644
+index 78d1578f94793e9e59a3d4d2b33e79ea8530fa04..493cdadac3873508b3efa3048638e73a13f4c976 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
 @@ -45,3 +45,4 @@ void webkitWebContextInitializeNotificationPermissions(WebKitWebContext*);
@@ -11388,7 +11395,7 @@ index 78d1578f9479..493cdadac387 100644
  #endif
 +int webkitWebContextExistingCount();
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
-index d93eab93a79b..52de3373ce03 100644
+index d93eab93a79bbe3005a510224798ff9956c9ae19..52de3373ce0353e9d7dc3e3d7a2d85f3643c8593 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 @@ -32,6 +32,7 @@
@@ -11466,7 +11473,7 @@ index d93eab93a79b..52de3373ce03 100644
  {
      if (!webView->priv->currentScriptDialog)
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
-index d7a43204be69..0e247c488585 100644
+index d7a43204be693f2a7ef86240eaf567fe70052a2c..0e247c48858522e55f65957fd0d1e147cafce092 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
 @@ -60,6 +60,7 @@ void webkitWebViewRunJavaScriptAlert(WebKitWebView*, const CString& message, Fun
@@ -11478,7 +11485,7 @@ index d7a43204be69..0e247c488585 100644
  bool webkitWebViewIsScriptDialogRunning(WebKitWebView*, WebKitScriptDialog*);
  String webkitWebViewGetCurrentScriptDialogMessage(WebKitWebView*);
 diff --git a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
-index 2bf03eec17b9..9ca44d654605 100644
+index 2bf03eec17b9d2add76b180b6a2bc41d8fba9602..9ca44d65460528b9b8e6f3b91aff8f91e81a29dc 100644
 --- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
 +++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
 @@ -244,6 +244,8 @@ void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool
@@ -11492,7 +11499,7 @@ index 2bf03eec17b9..9ca44d654605 100644
      webkitWebViewBaseForwardNextKeyEvent(webkitWebViewBase);
 diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitBrowserInspector.h b/Source/WebKit/UIProcess/API/gtk/WebKitBrowserInspector.h
 new file mode 100644
-index 000000000000..9f1a0173a564
+index 0000000000000000000000000000000000000000..9f1a0173a5641d6f158d815b8f7b9ea66f65c26d
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/gtk/WebKitBrowserInspector.h
 @@ -0,0 +1,81 @@
@@ -11578,7 +11585,7 @@ index 000000000000..9f1a0173a564
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
-index e9cf71352ba2..3daa3b84f5c8 100644
+index e9cf71352ba2d4bce1a23b0eefcf42cff26de393..3daa3b84f5c8f424b68bf1764ca8e0c74788d0b2 100644
 --- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
 +++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
 @@ -2462,6 +2462,11 @@ void webkitWebViewBaseResetClickCounter(WebKitWebViewBase* webkitWebViewBase)
@@ -11594,7 +11601,7 @@ index e9cf71352ba2..3daa3b84f5c8 100644
  {
      ASSERT(webkitWebViewBase->priv->acceleratedBackingStore);
 diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
-index d28f9c69cabe..ece01f3d3e2f 100644
+index d28f9c69cabe96554daddfec77e6f007aa0987da..ece01f3d3e2f6aaca191975048320b6a91b946ea 100644
 --- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
 +++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
 @@ -27,6 +27,7 @@
@@ -11612,7 +11619,7 @@ index d28f9c69cabe..ece01f3d3e2f 100644
 +
 +WebKit::AcceleratedBackingStore* webkitWebViewBaseGetAcceleratedBackingStore(WebKitWebViewBase*);
 diff --git a/Source/WebKit/UIProcess/API/gtk/webkit2.h b/Source/WebKit/UIProcess/API/gtk/webkit2.h
-index ecbe433ed888..7385877fe664 100644
+index ecbe433ed888353b1e6013943b4463835c3582d2..7385877fe664515814fc5c3380a2b7298ff90e1e 100644
 --- a/Source/WebKit/UIProcess/API/gtk/webkit2.h
 +++ b/Source/WebKit/UIProcess/API/gtk/webkit2.h
 @@ -32,6 +32,7 @@
@@ -11624,7 +11631,7 @@ index ecbe433ed888..7385877fe664 100644
  #include <webkit2/WebKitContextMenu.h>
  #include <webkit2/WebKitContextMenuActions.h>
 diff --git a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
-index 9631a3f19d24..eb465be92781 100644
+index 9631a3f19d24c29286ab634c0bd65cfbc83f9334..eb465be92781c91a7c6df0b52f7b637694cfdd76 100644
 --- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
 +++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
 @@ -194,7 +194,7 @@ WebCore::IntPoint PageClientImpl::accessibilityScreenToRootView(const WebCore::I
@@ -11638,7 +11645,7 @@ index 9631a3f19d24..eb465be92781 100644
  void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent&, bool)
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitBrowserInspector.h b/Source/WebKit/UIProcess/API/wpe/WebKitBrowserInspector.h
 new file mode 100644
-index 000000000000..cb1a540d341b
+index 0000000000000000000000000000000000000000..cb1a540d341b07581ec87b922b7d007ce45ba989
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitBrowserInspector.h
 @@ -0,0 +1,81 @@
@@ -11724,7 +11731,7 @@ index 000000000000..cb1a540d341b
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp
-index e0fc205b3909..872186ad99a7 100644
+index e0fc205b39095cf8aae201a1dcca520461c60de4..872186ad99a7b82f0c61705ff6c5ae4453e5e1d4 100644
 --- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.cpp
 @@ -54,6 +54,7 @@ struct _WebKitWebViewBackend {
@@ -11756,7 +11763,7 @@ index e0fc205b3909..872186ad99a7 100644
  
  template <> WebKitWebViewBackend* refGPtr(WebKitWebViewBackend* ptr)
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h
-index 6663964d5aba..13ba5e7c3895 100644
+index 6663964d5abac79e123d90e0351590884c66aa72..13ba5e7c3895c6e4efda95f1f90b9baea1c1bf30 100644
 --- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackend.h
 @@ -27,6 +27,7 @@
@@ -11781,7 +11788,7 @@ index 6663964d5aba..13ba5e7c3895 100644
  
  #endif /* WebKitWebViewBackend_h */
 diff --git a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h
-index e4b92ace1531..43690f9ef496 100644
+index e4b92ace1531090ae38a7aec3d3d4febf19aee84..43690f9ef4969a39084501613bfc00a77fd5df49 100644
 --- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h
 +++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewBackendPrivate.h
 @@ -31,3 +31,5 @@ template <> void derefGPtr(WebKitWebViewBackend* ptr);
@@ -11791,7 +11798,7 @@ index e4b92ace1531..43690f9ef496 100644
 +
 +cairo_surface_t* webkitWebViewBackendTakeScreenshot(WebKitWebViewBackend*);
 diff --git a/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt b/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt
-index 8cf9d4ff3838..052e75a649f4 100644
+index 8cf9d4ff38382b3d348a732d69d00e7720576777..052e75a649f49ca8704d013a03299fd4aca68fa1 100644
 --- a/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt
 +++ b/Source/WebKit/UIProcess/API/wpe/docs/wpe-1.0-sections.txt
 @@ -320,6 +320,8 @@ WEBKIT_TYPE_WEB_VIEW_BACKEND
@@ -11804,7 +11811,7 @@ index 8cf9d4ff3838..052e75a649f4 100644
  <SUBSECTION Private>
  webkit_web_view_backend_get_type
 diff --git a/Source/WebKit/UIProcess/API/wpe/webkit.h b/Source/WebKit/UIProcess/API/wpe/webkit.h
-index 87929257bf73..5d47bce94b6d 100644
+index 87929257bf73aba684a380accd8c1bbb394bad87..5d47bce94b6d4b9e54fc1fef794bde7506310e32 100644
 --- a/Source/WebKit/UIProcess/API/wpe/webkit.h
 +++ b/Source/WebKit/UIProcess/API/wpe/webkit.h
 @@ -32,6 +32,7 @@
@@ -11816,7 +11823,7 @@ index 87929257bf73..5d47bce94b6d 100644
  #include <wpe/WebKitContextMenuActions.h>
  #include <wpe/WebKitContextMenuItem.h>
 diff --git a/Source/WebKit/UIProcess/BackingStore.h b/Source/WebKit/UIProcess/BackingStore.h
-index fe3c63e61f77..c43a8226c9be 100644
+index fe3c63e61f778762dc2c2080c74ec53fdf8c2e5f..c43a8226c9be702e248f1712e465efa396ee8969 100644
 --- a/Source/WebKit/UIProcess/BackingStore.h
 +++ b/Source/WebKit/UIProcess/BackingStore.h
 @@ -60,6 +60,7 @@ public:
@@ -11829,7 +11836,7 @@ index fe3c63e61f77..c43a8226c9be 100644
          ID3D11DeviceContext1* immediateContext { nullptr };
 diff --git a/Source/WebKit/UIProcess/BrowserInspectorPipe.cpp b/Source/WebKit/UIProcess/BrowserInspectorPipe.cpp
 new file mode 100644
-index 000000000000..cfb57a48ce38
+index 0000000000000000000000000000000000000000..cfb57a48ce387b79613b757e2eb4de2c378aac30
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/BrowserInspectorPipe.cpp
 @@ -0,0 +1,61 @@
@@ -11896,7 +11903,7 @@ index 000000000000..cfb57a48ce38
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/BrowserInspectorPipe.h b/Source/WebKit/UIProcess/BrowserInspectorPipe.h
 new file mode 100644
-index 000000000000..cd66887de171
+index 0000000000000000000000000000000000000000..cd66887de171cda7d15a8e4dc6dbff63665dc619
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/BrowserInspectorPipe.h
 @@ -0,0 +1,38 @@
@@ -11939,7 +11946,7 @@ index 000000000000..cd66887de171
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
-index 02dadcc4c813..5211c6b38efa 100644
+index 02dadcc4c813ad82c718f16a583616e03e35a195..5211c6b38efaf2a62eb556ec060cd9caa5e5d40e 100644
 --- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
 @@ -35,6 +35,7 @@
@@ -11951,7 +11958,7 @@ index 02dadcc4c813..5211c6b38efa 100644
  using namespace Inspector;
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
-index 454c61ffdefe..6de7509037b7 100644
+index 454c61ffdefecc476d1560c7c43f5b5d345f281d..6de7509037b7683ddd403ee247bdf2845ce4e87a 100644
 --- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
 +++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
 @@ -27,6 +27,8 @@
@@ -11973,7 +11980,7 @@ index 454c61ffdefe..6de7509037b7 100644
  class PopUpSOAuthorizationSession final : public SOAuthorizationSession {
  public:
 diff --git a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
-index 7871ed4738b5..04b55aa99531 100644
+index 7871ed4738b5cfc7e64757ff642cfbe51303a4eb..04b55aa995316d4d8cd467cf62d1a19f83ec8df7 100644
 --- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
 +++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
 @@ -92,6 +92,7 @@ private:
@@ -11993,7 +12000,7 @@ index 7871ed4738b5..04b55aa99531 100644
          bool webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler : 1;
          bool webViewRequestGeolocationPermissionForFrameDecisionHandler : 1;
 diff --git a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
-index ecf7213858b8..7d0fd38d5e29 100644
+index ecf7213858b8d7b3eb2a54f3b3a8c12eed4bdd85..7d0fd38d5e29a97945ff248be054036193b1ff51 100644
 --- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
 @@ -104,6 +104,7 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
@@ -12021,7 +12028,7 @@ index ecf7213858b8..7d0fd38d5e29 100644
  {
      if (!m_uiDelegate)
 diff --git a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
-index 7a18a6184a04..92bb58f42cf5 100644
+index 7a18a6184a04aa37bb6d328a817b0a0a3e03cb50..92bb58f42cf5ff592b6d465f16ffcf283f381462 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
 +++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
 @@ -27,6 +27,7 @@
@@ -12033,7 +12040,7 @@ index 7a18a6184a04..92bb58f42cf5 100644
  
  @class WKWebView;
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
-index f9b2765398f7..a3b9caaf176b 100644
+index f9b2765398f7fff3147c5bd0a9c2dd24aeeda12b..a3b9caaf176b689c45211842c19ddc467f83b493 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 @@ -34,6 +34,7 @@
@@ -12112,7 +12119,7 @@ index f9b2765398f7..a3b9caaf176b 100644
  #if PLATFORM(IOS_FAMILY)
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-index f14f67727920..deba91603dd6 100644
+index f14f67727920f0011c6aab8fa74019776cf73693..deba91603dd608abf279c0e541c41c018d87787a 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
 @@ -398,7 +398,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
@@ -12136,7 +12143,7 @@ index f14f67727920..deba91603dd6 100644
  
      m_activationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidBecomeActiveNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
-index ac5058b8131b..fcaa8dd5100a 100644
+index ac5058b8131b1dad3fa1560a08173074ff3c1432..fcaa8dd5100af18b7d9531249c39c0b5068b80d0 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
 @@ -513,6 +513,9 @@ public:
@@ -12150,7 +12157,7 @@ index ac5058b8131b..fcaa8dd5100a 100644
      void saveBackForwardSnapshotForCurrentItem();
      void saveBackForwardSnapshotForItem(WebBackForwardListItem&);
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
-index 71789e102305..a4a5e294315f 100644
+index 71789e1023058446ae1cc8d912993252276453d0..a4a5e294315f27feb5dc92c059dbcdce404bf51c 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 @@ -2594,6 +2594,11 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
@@ -12185,7 +12192,7 @@ index 71789e102305..a4a5e294315f 100644
  {
      NSWindow *window = [m_view window];
 diff --git a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
-index 038d9ee2f41c..5be10b7bbdc8 100644
+index 038d9ee2f41cdeba4ae7b597311b663a58b6d629..5be10b7bbdc8b28db255baf7a4187cfd761fa83d 100644
 --- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 +++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 @@ -32,13 +32,16 @@
@@ -12289,7 +12296,7 @@ index 038d9ee2f41c..5be10b7bbdc8 100644
  void DrawingAreaProxyCoordinatedGraphics::incorporateUpdate(const UpdateInfo& updateInfo)
  {
 diff --git a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
-index b23a45ff7d31..8419b69c5e27 100644
+index b23a45ff7d313317d8ba64fb430ebba3b6adef71..8419b69c5e278cf88a3ab6b98c335eddeea44e53 100644
 --- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
 +++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
 @@ -30,6 +30,7 @@
@@ -12341,7 +12348,7 @@ index b23a45ff7d31..8419b69c5e27 100644
  
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
-index c61bb3fd2ee0..0fee368e9364 100644
+index c61bb3fd2ee046f3824c40ab99181c0fcee2a197..c0cf2a03b51dc58d76b1cf7e9d7c3fffdc264836 100644
 --- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
 +++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
 @@ -42,8 +42,10 @@
@@ -12362,20 +12369,25 @@ index c61bb3fd2ee0..0fee368e9364 100644
 +    , m_uuid(createCanonicalUUIDString())
  {
 +    if (auto* instrumentation = m_dataStore->downloadInstrumentation())
-+      instrumentation->downloadCreated(m_uuid, m_request, frameInfoData, originatingPage);
++      instrumentation->downloadCreated(m_uuid, m_request, frameInfoData, originatingPage, this);
  }
  
  DownloadProxy::~DownloadProxy()
-@@ -79,6 +84,8 @@ void DownloadProxy::cancel(CompletionHandler<void(API::Data*)>&& completionHandl
+@@ -75,9 +80,12 @@ static RefPtr<API::Data> createData(const IPC::DataReference& data)
+ void DownloadProxy::cancel(CompletionHandler<void(API::Data*)>&& completionHandler)
+ {
+     if (m_dataStore) {
+-        m_dataStore->networkProcess().sendWithAsyncReply(Messages::NetworkProcess::CancelDownload(m_downloadID), [this, protectedThis = makeRef(*this), completionHandler = WTFMove(completionHandler)] (const IPC::DataReference& resumeData) mutable {
++        auto* instrumentation = m_dataStore->downloadInstrumentation();
++        m_dataStore->networkProcess().sendWithAsyncReply(Messages::NetworkProcess::CancelDownload(m_downloadID), [this, protectedThis = makeRef(*this), completionHandler = WTFMove(completionHandler), instrumentation] (const IPC::DataReference& resumeData) mutable {
              m_legacyResumeData = createData(resumeData);
              completionHandler(m_legacyResumeData.get());
-             m_downloadProxyMap.downloadFinished(*this);
-+            if (auto* instrumentation = m_dataStore->downloadInstrumentation())
++            if (instrumentation)
 +                instrumentation->downloadFinished(m_uuid, "canceled"_s);
+             m_downloadProxyMap.downloadFinished(*this);
          });
      } else
-         completionHandler(nullptr);
-@@ -161,6 +168,20 @@ void DownloadProxy::decideDestinationWithSuggestedFilename(const WebCore::Resour
+@@ -161,6 +169,20 @@ void DownloadProxy::decideDestinationWithSuggestedFilename(const WebCore::Resour
          suggestedFilename = m_suggestedFilename;
      suggestedFilename = MIMETypeRegistry::appendFileExtensionIfNecessary(suggestedFilename, response.mimeType());
  
@@ -12396,7 +12408,7 @@ index c61bb3fd2ee0..0fee368e9364 100644
      m_client->decideDestinationWithSuggestedFilename(*this, response, ResourceResponseBase::sanitizeSuggestedFilename(suggestedFilename), [this, protectedThis = makeRef(*this), completionHandler = WTFMove(completionHandler)] (AllowOverwrite allowOverwrite, String destination) mutable {
          SandboxExtension::Handle sandboxExtensionHandle;
          if (!destination.isNull())
-@@ -179,6 +200,8 @@ void DownloadProxy::didCreateDestination(const String& path)
+@@ -179,6 +201,8 @@ void DownloadProxy::didCreateDestination(const String& path)
  void DownloadProxy::didFinish()
  {
      m_client->didFinish(*this);
@@ -12405,7 +12417,7 @@ index c61bb3fd2ee0..0fee368e9364 100644
  
      // This can cause the DownloadProxy object to be deleted.
      m_downloadProxyMap.downloadFinished(*this);
-@@ -189,6 +212,8 @@ void DownloadProxy::didFail(const ResourceError& error, const IPC::DataReference
+@@ -189,6 +213,8 @@ void DownloadProxy::didFail(const ResourceError& error, const IPC::DataReference
      m_legacyResumeData = createData(resumeData);
  
      m_client->didFail(*this, error, m_legacyResumeData.get());
@@ -12415,7 +12427,7 @@ index c61bb3fd2ee0..0fee368e9364 100644
      // This can cause the DownloadProxy object to be deleted.
      m_downloadProxyMap.downloadFinished(*this);
 diff --git a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
-index 4b9e12c40517..f56879a5a799 100644
+index 4b9e12c40517fb84cb23d2de3e2adaa66c69da59..f56879a5a799115ef7353c060b00b842b8702408 100644
 --- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
 +++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
 @@ -146,6 +146,7 @@ private:
@@ -12427,7 +12439,7 @@ index 4b9e12c40517..f56879a5a799 100644
  
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/DrawingAreaProxy.h b/Source/WebKit/UIProcess/DrawingAreaProxy.h
-index 826c417c6c9b..641f418f78c5 100644
+index 826c417c6c9ba1c7e6c2c32a6ab0f3ab8d72f0e0..641f418f78c56aba25740586bb982231997b6bf5 100644
 --- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
 +++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
 @@ -75,6 +75,7 @@ public:
@@ -12449,7 +12461,7 @@ index 826c417c6c9b..641f418f78c5 100644
      bool m_startedReceivingMessages { false };
  };
 diff --git a/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in b/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
-index b0722e7da81e..05ec3e3ea97b 100644
+index b0722e7da81e56530deb570b82ed7cfece970362..05ec3e3ea97ba49135a27d7f9b91f14c507d9318 100644
 --- a/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
 +++ b/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
 @@ -36,4 +36,7 @@ messages -> DrawingAreaProxy NotRefCounted {
@@ -12462,7 +12474,7 @@ index b0722e7da81e..05ec3e3ea97b 100644
  }
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.cpp b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.cpp
 new file mode 100644
-index 000000000000..9426d9eed59f
+index 0000000000000000000000000000000000000000..9426d9eed59f433eac62b8eb6a16139b84079949
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.cpp
 @@ -0,0 +1,244 @@
@@ -12712,7 +12724,7 @@ index 000000000000..9426d9eed59f
 +#endif
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.h b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.h
 new file mode 100644
-index 000000000000..4ec8b96bbbdd
+index 0000000000000000000000000000000000000000..4ec8b96bbbddf8a7b042f53a8068754a384fc7ad
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/CairoJpegEncoder.h
 @@ -0,0 +1,30 @@
@@ -12748,7 +12760,7 @@ index 000000000000..4ec8b96bbbdd
 +cairo_status_t cairo_image_surface_write_to_jpeg_mem(cairo_surface_t *sfc, unsigned char **data, size_t *len, int quality);
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.cpp b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.cpp
 new file mode 100644
-index 000000000000..20122bd89c3b
+index 0000000000000000000000000000000000000000..20122bd89c3ba0ec4ff878ac895bddd497cc9789
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.cpp
 @@ -0,0 +1,269 @@
@@ -13023,7 +13035,7 @@ index 000000000000..20122bd89c3b
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.h b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.h
 new file mode 100644
-index 000000000000..8f2795dbf132
+index 0000000000000000000000000000000000000000..8f2795dbf1323dd8d5f986f18e6fe16431dd7f70
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorScreencastAgent.h
 @@ -0,0 +1,96 @@
@@ -13125,7 +13137,7 @@ index 000000000000..8f2795dbf132
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp
 new file mode 100644
-index 000000000000..62f20814b72e
+index 0000000000000000000000000000000000000000..62f20814b72e90275eb4fa0e8302fc15abdaaab2
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.cpp
 @@ -0,0 +1,393 @@
@@ -13524,7 +13536,7 @@ index 000000000000..62f20814b72e
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.h b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.h
 new file mode 100644
-index 000000000000..1683da93db6b
+index 0000000000000000000000000000000000000000..1683da93db6b9088c3a472472c1b71477b47a7fd
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/ScreencastEncoder.h
 @@ -0,0 +1,81 @@
@@ -13611,7 +13623,7 @@ index 000000000000..1683da93db6b
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.cpp b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.cpp
 new file mode 100644
-index 000000000000..9b269b356e20
+index 0000000000000000000000000000000000000000..9b269b356e206f0252245a1497adb0d05128c9b4
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.cpp
 @@ -0,0 +1,69 @@
@@ -13686,7 +13698,7 @@ index 000000000000..9b269b356e20
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.h b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.h
 new file mode 100644
-index 000000000000..e2ce910f3fd7
+index 0000000000000000000000000000000000000000..e2ce910f3fd7f587add552275b7e7176cf8b2723
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/Agents/WebMFileWriter.h
 @@ -0,0 +1,53 @@
@@ -13744,7 +13756,7 @@ index 000000000000..e2ce910f3fd7
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
-index 6928ca2fbfb6..621b99e233ed 100644
+index 6928ca2fbfb6939062e3cd14bb7ba6f2fdc87f5f..621b99e233ed5cf504fedbd3ca3209c03bcd611f 100644
 --- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
 +++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
 @@ -27,11 +27,10 @@
@@ -13817,7 +13829,7 @@ index 6928ca2fbfb6..621b99e233ed 100644
  {
      return !!m_provisionalPage;
 diff --git a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
-index a2239cec8e18..79f3ff84327d 100644
+index a2239cec8e18850f35f7f88a9c4ebadc62bf4023..79f3ff84327dc075ec96983e04db4b10343b7fae 100644
 --- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
 +++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
 @@ -37,13 +37,13 @@ class WebPageProxy;
@@ -13857,7 +13869,7 @@ index a2239cec8e18..79f3ff84327d 100644
  
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
-index ed4e6f30b8c3..2357769f3f78 100644
+index ed4e6f30b8c35966075573dccee801daceec865e..2357769f3f78a7fda3d3fff1005e77c5d082948d 100644
 --- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
 +++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
 @@ -26,13 +26,21 @@
@@ -14164,7 +14176,7 @@ index ed4e6f30b8c3..2357769f3f78 100644
 +
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
-index 8c1339345d45..331b61c70c73 100644
+index 8c1339345d451874502b271f6aa2eca3fa0d3faf..331b61c70c7370ace480724bdb53c99a54897374 100644
 --- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
 +++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
 @@ -26,17 +26,35 @@
@@ -14302,7 +14314,7 @@ index 8c1339345d45..331b61c70c73 100644
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Inspector/mac/ScreencastEncoderMac.mm b/Source/WebKit/UIProcess/Inspector/mac/ScreencastEncoderMac.mm
 new file mode 100644
-index 000000000000..66d1c743de1c
+index 0000000000000000000000000000000000000000..66d1c743de1cb35e29d6fc9b69379d265a59961f
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/Inspector/mac/ScreencastEncoderMac.mm
 @@ -0,0 +1,58 @@
@@ -14366,7 +14378,7 @@ index 000000000000..66d1c743de1c
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorDialogAgent.cpp b/Source/WebKit/UIProcess/InspectorDialogAgent.cpp
 new file mode 100644
-index 000000000000..663f92f0df76
+index 0000000000000000000000000000000000000000..663f92f0df76042cf6385b056f8a917d688259f9
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorDialogAgent.cpp
 @@ -0,0 +1,88 @@
@@ -14460,7 +14472,7 @@ index 000000000000..663f92f0df76
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorDialogAgent.h b/Source/WebKit/UIProcess/InspectorDialogAgent.h
 new file mode 100644
-index 000000000000..d0e11ed81a62
+index 0000000000000000000000000000000000000000..d0e11ed81a6257c011df23d5870da7403f8e9fe4
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorDialogAgent.h
 @@ -0,0 +1,70 @@
@@ -14536,10 +14548,10 @@ index 000000000000..d0e11ed81a62
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
 new file mode 100644
-index 000000000000..1484aa4a192e
+index 0000000000000000000000000000000000000000..bc6dff4a863aea91fd67c51ff24b44943cb46095
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
-@@ -0,0 +1,997 @@
+@@ -0,0 +1,1010 @@
 +/*
 + * Copyright (C) 2019 Microsoft Corporation.
 + *
@@ -15484,11 +15496,12 @@ index 000000000000..1484aa4a192e
 +    return { };
 +}
 +
-+void InspectorPlaywrightAgent::downloadCreated(const String& uuid, const WebCore::ResourceRequest& request, const FrameInfoData& frameInfoData, WebPageProxy* page)
++void InspectorPlaywrightAgent::downloadCreated(const String& uuid, const WebCore::ResourceRequest& request, const FrameInfoData& frameInfoData, WebPageProxy* page, RefPtr<DownloadProxy> download)
 +{
 +    if (!m_isEnabled)
 +        return;
 +    String frameID = WebCore::InspectorPageAgent::makeFrameID(page->process().coreProcessIdentifier(), frameInfoData.frameID ? *frameInfoData.frameID : page->mainFrame()->frameID());
++    m_downloads.set(uuid, download);
 +    m_frontendDispatcher->downloadCreated(
 +        toPageProxyIDProtocolString(*page),
 +        frameID,
@@ -15507,6 +15520,18 @@ index 000000000000..1484aa4a192e
 +    if (!m_isEnabled)
 +        return;
 +    m_frontendDispatcher->downloadFinished(uuid, error);
++    m_downloads.remove(uuid);
++}
++
++Inspector::Protocol::ErrorStringOr<void> InspectorPlaywrightAgent::cancelDownload(const String& uuid)
++{
++    if (!m_isEnabled)
++        return { };
++    auto download = m_downloads.get(uuid);
++    if (!download)
++        return { };
++    download->cancel([] (auto*) {});
++    return { };
 +}
 +
 +BrowserContext* InspectorPlaywrightAgent::getExistingBrowserContext(const String& browserContextID)
@@ -15539,10 +15564,10 @@ index 000000000000..1484aa4a192e
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h
 new file mode 100644
-index 000000000000..07de509499e7
+index 0000000000000000000000000000000000000000..1d1f360f01740c001507acac6b1ba90598934917
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h
-@@ -0,0 +1,126 @@
+@@ -0,0 +1,129 @@
 +/*
 + * Copyright (C) 2019 Microsoft Corporation.
 + *
@@ -15576,6 +15601,7 @@ index 000000000000..07de509499e7
 +#include <JavaScriptCore/InspectorBackendDispatchers.h>
 +#include "WebPageInspectorController.h"
 +#include "WebProcessPool.h"
++#include "DownloadProxy.h"
 +#include <wtf/HashMap.h>
 +#include <wtf/Forward.h>
 +#include <wtf/Noncopyable.h>
@@ -15642,9 +15668,10 @@ index 000000000000..07de509499e7
 +    Inspector::Protocol::ErrorStringOr<void> setGeolocationOverride(const String& browserContextID, RefPtr<JSON::Object>&& geolocation) override;
 +    Inspector::Protocol::ErrorStringOr<void> setLanguages(Ref<JSON::Array>&& languages, const String& browserContextID) override;
 +    Inspector::Protocol::ErrorStringOr<void> setDownloadBehavior(const String& behavior, const String& downloadPath, const String& browserContextID) override;
++    Inspector::Protocol::ErrorStringOr<void> cancelDownload(const String& uuid) override;
 +
 +    // DownloadInstrumentation
-+    void downloadCreated(const String& uuid, const WebCore::ResourceRequest&, const FrameInfoData& frameInfoData, WebPageProxy* page) override;
++    void downloadCreated(const String& uuid, const WebCore::ResourceRequest&, const FrameInfoData& frameInfoData, WebPageProxy* page, RefPtr<DownloadProxy> download) override;
 +    void downloadFilenameSuggested(const String& uuid, const String& suggestedFilename) override;
 +    void downloadFinished(const String& uuid, const String& error) override;
 +
@@ -15661,6 +15688,7 @@ index 000000000000..07de509499e7
 +    Ref<Inspector::PlaywrightBackendDispatcher> m_playwrightDispatcher;
 +    HashMap<String, std::unique_ptr<PageProxyChannel>> m_pageProxyChannels;
 +    BrowserContext* m_defaultContext;
++    HashMap<String, RefPtr<DownloadProxy>> m_downloads;
 +    HashMap<String, std::unique_ptr<BrowserContext>> m_browserContexts;
 +    HashMap<String, std::unique_ptr<BrowserContextDeletion>> m_browserContextDeletions;
 +    bool m_isEnabled { false };
@@ -15671,7 +15699,7 @@ index 000000000000..07de509499e7
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgentClient.h b/Source/WebKit/UIProcess/InspectorPlaywrightAgentClient.h
 new file mode 100644
-index 000000000000..11c8eadafca7
+index 0000000000000000000000000000000000000000..11c8eadafca764aa549cb27c24967e15e6975774
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgentClient.h
 @@ -0,0 +1,66 @@
@@ -15742,7 +15770,7 @@ index 000000000000..11c8eadafca7
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp b/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
-index 7a14cfba15c1..3ee0e1543496 100644
+index 7a14cfba15c103a2d4fe263fa49d25af3c396ec2..3ee0e154349661632799057c71f1d1f1551c2d69 100644
 --- a/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
 +++ b/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
 @@ -96,8 +96,11 @@ void ProcessLauncher::launchProcess()
@@ -15759,7 +15787,7 @@ index 7a14cfba15c1..3ee0e1543496 100644
      BOOL result = ::CreateProcess(0, commandLine.data(), 0, 0, true, 0, 0, 0, &startupInfo, &processInformation);
  
 diff --git a/Source/WebKit/UIProcess/PageClient.h b/Source/WebKit/UIProcess/PageClient.h
-index 0650f60cb79e..bdfd91f0c69e 100644
+index 0650f60cb79ed94e96c709a26d992dd54c8764ab..bdfd91f0c69ec17dc5f1c58e2a9f30355348b90d 100644
 --- a/Source/WebKit/UIProcess/PageClient.h
 +++ b/Source/WebKit/UIProcess/PageClient.h
 @@ -322,6 +322,11 @@ public:
@@ -15775,7 +15803,7 @@ index 0650f60cb79e..bdfd91f0c69e 100644
      virtual RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) = 0;
  #endif
 diff --git a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
-index bb4a4c2f6a17..49cd5218f23a 100644
+index bb4a4c2f6a17f4ada269a3450f9c276f648c72e1..49cd5218f23a6e8b8b8cf9d33542795dca95e548 100644
 --- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
 @@ -598,3 +598,5 @@ bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Option
@@ -15786,7 +15814,7 @@ index bb4a4c2f6a17..49cd5218f23a 100644
 +#undef MESSAGE_CHECK
 diff --git a/Source/WebKit/UIProcess/RemoteInspectorPipe.cpp b/Source/WebKit/UIProcess/RemoteInspectorPipe.cpp
 new file mode 100644
-index 000000000000..dd8b28e692dc
+index 0000000000000000000000000000000000000000..dd8b28e692dca4078eb710b2a97e61716126a4cb
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/RemoteInspectorPipe.cpp
 @@ -0,0 +1,224 @@
@@ -16016,7 +16044,7 @@ index 000000000000..dd8b28e692dc
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/RemoteInspectorPipe.h b/Source/WebKit/UIProcess/RemoteInspectorPipe.h
 new file mode 100644
-index 000000000000..6d04f9290135
+index 0000000000000000000000000000000000000000..6d04f9290135069359ce6bf8726546482fd1dc95
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/RemoteInspectorPipe.h
 @@ -0,0 +1,65 @@
@@ -16086,7 +16114,7 @@ index 000000000000..6d04f9290135
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
-index e42dbf1281d3..80fab5d4ac00 100644
+index e42dbf1281d36fef2e303e707d5b5baf166ee152..80fab5d4ac007f0d2da9f58bee03a5ab3c845b83 100644
 --- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
 +++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
 @@ -37,6 +37,8 @@
@@ -16099,7 +16127,7 @@ index e42dbf1281d3..80fab5d4ac00 100644
  
  Ref<WebCore::RealtimeMediaSource> SpeechRecognitionRemoteRealtimeMediaSource::create(SpeechRecognitionRemoteRealtimeMediaSourceManager& manager, const WebCore::CaptureDevice& captureDevice)
 diff --git a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
-index 684b96165737..51ff18323ece 100644
+index 684b9616573761123fbcc0d94be29de519ecced6..51ff18323ece0ee15c87d63a1d6fd604377ee968 100644
 --- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
 +++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
 @@ -28,6 +28,7 @@
@@ -16111,7 +16139,7 @@ index 684b96165737..51ff18323ece 100644
  
  namespace WebKit {
 diff --git a/Source/WebKit/UIProcess/WebContextMenuProxy.h b/Source/WebKit/UIProcess/WebContextMenuProxy.h
-index 630bf1170da1..ec12ef12dfc7 100644
+index 630bf1170da176dcc65d659c1fdf7c05185910e5..ec12ef12dfc7e7c00ed69e2afb10367cb02a1edf 100644
 --- a/Source/WebKit/UIProcess/WebContextMenuProxy.h
 +++ b/Source/WebKit/UIProcess/WebContextMenuProxy.h
 @@ -37,6 +37,7 @@
@@ -16131,7 +16159,7 @@ index 630bf1170da1..ec12ef12dfc7 100644
      WebPageProxy* page() const { return m_page.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
-index 04f3227cd55c..f0d36935f47b 100644
+index 04f3227cd55c992a42cd96a3f25d697aed7965a2..f0d36935f47bab03ea2ec50b705092068ecd3efa 100644
 --- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
 @@ -128,7 +128,8 @@ void WebGeolocationManagerProxy::startUpdating(IPC::Connection& connection, WebP
@@ -16146,7 +16174,7 @@ index 04f3227cd55c..f0d36935f47b 100644
  
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp
 new file mode 100644
-index 000000000000..ae45b4212bdb
+index 0000000000000000000000000000000000000000..ae45b4212bdb3f6a004cc80a1d91146b540f86f5
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp
 @@ -0,0 +1,147 @@
@@ -16299,7 +16327,7 @@ index 000000000000..ae45b4212bdb
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.h b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.h
 new file mode 100644
-index 000000000000..b3bb4880a866
+index 0000000000000000000000000000000000000000..b3bb4880a866ee6132b8b26acf8dad81afe14d85
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.h
 @@ -0,0 +1,75 @@
@@ -16380,7 +16408,7 @@ index 000000000000..b3bb4880a866
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorInputAgent.cpp b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.cpp
 new file mode 100644
-index 000000000000..eb16b3aa8912
+index 0000000000000000000000000000000000000000..eb16b3aa8912b4cc26a2e555669c27682b76378d
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.cpp
 @@ -0,0 +1,288 @@
@@ -16674,7 +16702,7 @@ index 000000000000..eb16b3aa8912
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorInputAgent.h b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.h
 new file mode 100644
-index 000000000000..94e9f2435333
+index 0000000000000000000000000000000000000000..94e9f24353337169992724e2fcdf7086dd888fa6
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/WebPageInspectorInputAgent.h
 @@ -0,0 +1,85 @@
@@ -16764,7 +16792,7 @@ index 000000000000..94e9f2435333
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index 9ff0c246e1d3..176d2387db8d 100644
+index 9ff0c246e1d3100b08b998153287c117d288d401..176d2387db8dc694020d006e51b479083992a41b 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
 @@ -241,7 +241,7 @@
@@ -17266,7 +17294,7 @@ index 9ff0c246e1d3..176d2387db8d 100644
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index 7a837f3c45b9..c13019099366 100644
+index 7a837f3c45b996f97fa961e60ea96aecb8f74214..c13019099366ba06487f6d3c152f116a060117b2 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -38,6 +38,7 @@
@@ -17428,7 +17456,7 @@ index 7a837f3c45b9..c13019099366 100644
  #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
      std::unique_ptr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.messages.in b/Source/WebKit/UIProcess/WebPageProxy.messages.in
-index 027a70c8d829..8b771c9a4396 100644
+index 027a70c8d829062019a216705378b8d8727d10af..8b771c9a43967d99a61cb243f32df19c24b99b56 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
 +++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
 @@ -29,6 +29,7 @@ messages -> WebPageProxy {
@@ -17463,7 +17491,7 @@ index 027a70c8d829..8b771c9a4396 100644
      DidPerformDragOperation(bool handled)
  #endif
 diff --git a/Source/WebKit/UIProcess/WebProcessPool.cpp b/Source/WebKit/UIProcess/WebProcessPool.cpp
-index ba9e7ce342d9..89abe3cf1849 100644
+index ba9e7ce342d9e6621df307b130636bf60fc5c5cc..89abe3cf1849fc56504bfd311e4db43c9958ebca 100644
 --- a/Source/WebKit/UIProcess/WebProcessPool.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
 @@ -509,6 +509,14 @@ void WebProcessPool::establishWorkerContextConnectionToNetworkProcess(NetworkPro
@@ -17494,7 +17522,7 @@ index ba9e7ce342d9..89abe3cf1849 100644
      parameters.urlSchemesRegisteredAsEmptyDocument = copyToVector(m_schemesToRegisterAsEmptyDocument);
      parameters.urlSchemesRegisteredAsSecure = copyToVector(LegacyGlobalSettings::singleton().schemesToRegisterAsSecure());
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.cpp b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-index 98b83690ec50..adda1f2732a3 100644
+index 98b83690ec50bccd8866cdb4c7dc9d83c78292de..adda1f2732a36ee47fcb4dce01411d111ef06256 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
 @@ -126,6 +126,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
@@ -17510,7 +17538,7 @@ index 98b83690ec50..adda1f2732a3 100644
  {
      return allProcesses().get(identifier);
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.h b/Source/WebKit/UIProcess/WebProcessProxy.h
-index e225ff467dc8..520716c830b2 100644
+index e225ff467dc84b576dc25d6625028b6019cf5e89..520716c830b2e0f29a9059b6c7e6f7534d7d3481 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.h
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.h
 @@ -137,6 +137,7 @@ public:
@@ -17522,7 +17550,7 @@ index e225ff467dc8..520716c830b2 100644
      WebConnection* webConnection() const { return m_webConnection.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-index f1421227047e..cfd13e410b7a 100644
+index f1421227047e94d2ea3ae0b06fc8ab37f3066c72..cfd13e410b7a8ecd4ef2614042e0a432b3d0304e 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 @@ -2127,6 +2127,17 @@ void WebsiteDataStore::renameOriginInWebsiteData(URL&& oldName, URL&& newName, O
@@ -17544,10 +17572,18 @@ index f1421227047e..cfd13e410b7a 100644
  void WebsiteDataStore::hasAppBoundSession(CompletionHandler<void(bool)>&& completionHandler) const
  {
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
-index 648bd4ce9b80..093d7da93aec 100644
+index 648bd4ce9b80e2356ee2b1928875f041317995ba..0ae5f94a1b89bb266dc915172abbafb3ab132df6 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
-@@ -92,6 +92,7 @@ enum class CacheModel : uint8_t;
+@@ -84,6 +84,7 @@ class DeviceIdHashSaltStorage;
+ class NetworkProcessProxy;
+ class SOAuthorizationCoordinator;
+ class WebCertificateInfo;
++class DownloadProxy;
+ class WebPageProxy;
+ class WebProcessPool;
+ class WebProcessProxy;
+@@ -92,6 +93,7 @@ enum class CacheModel : uint8_t;
  enum class WebsiteDataFetchOption : uint8_t;
  enum class WebsiteDataType : uint32_t;
  
@@ -17555,7 +17591,7 @@ index 648bd4ce9b80..093d7da93aec 100644
  struct NetworkProcessConnectionInfo;
  struct WebsiteDataRecord;
  struct WebsiteDataStoreParameters;
-@@ -106,6 +107,16 @@ enum class StorageAccessPromptStatus;
+@@ -106,6 +108,16 @@ enum class StorageAccessPromptStatus;
  struct PluginModuleInfo;
  #endif
  
@@ -17563,7 +17599,7 @@ index 648bd4ce9b80..093d7da93aec 100644
 +
 +class DownloadInstrumentation {
 +public:
-+    virtual void downloadCreated(const String& uuid, const WebCore::ResourceRequest&, const FrameInfoData& frameInfoData, WebPageProxy* page) = 0;
++    virtual void downloadCreated(const String& uuid, const WebCore::ResourceRequest&, const FrameInfoData& frameInfoData, WebPageProxy* page, RefPtr<DownloadProxy> download) = 0;
 +    virtual void downloadFilenameSuggested(const String& uuid, const String& suggestedFilename) = 0;
 +    virtual void downloadFinished(const String& uuid, const String& error) = 0;
 +    virtual ~DownloadInstrumentation() = default;
@@ -17572,7 +17608,7 @@ index 648bd4ce9b80..093d7da93aec 100644
  class WebsiteDataStore : public API::ObjectImpl<API::Object::Type::WebsiteDataStore>, public Identified<WebsiteDataStore>, public CanMakeWeakPtr<WebsiteDataStore>  {
  public:
      static Ref<WebsiteDataStore> defaultDataStore();
-@@ -283,11 +294,13 @@ public:
+@@ -283,11 +295,13 @@ public:
      const WebCore::CurlProxySettings& networkProxySettings() const { return m_proxySettings; }
  #endif
  
@@ -17587,7 +17623,7 @@ index 648bd4ce9b80..093d7da93aec 100644
      void setNetworkProxySettings(WebCore::SoupNetworkProxySettings&&);
      const WebCore::SoupNetworkProxySettings& networkProxySettings() const { return m_networkProxySettings; }
  #endif
-@@ -343,6 +356,14 @@ public:
+@@ -343,6 +357,14 @@ public:
      static WTF::String defaultJavaScriptConfigurationDirectory();
      static bool http3Enabled();
  
@@ -17602,7 +17638,7 @@ index 648bd4ce9b80..093d7da93aec 100644
      void resetQuota(CompletionHandler<void()>&&);
  
  #if ENABLE(APP_BOUND_DOMAINS)
-@@ -429,9 +450,11 @@ private:
+@@ -429,9 +451,11 @@ private:
      WebCore::CurlProxySettings m_proxySettings;
  #endif
  
@@ -17615,7 +17651,7 @@ index 648bd4ce9b80..093d7da93aec 100644
      WebCore::SoupNetworkProxySettings m_networkProxySettings;
  #endif
  
-@@ -456,6 +479,11 @@ private:
+@@ -456,6 +480,11 @@ private:
      RefPtr<API::HTTPCookieStore> m_cookieStore;
      RefPtr<NetworkProcessProxy> m_networkProcess;
  
@@ -17628,7 +17664,7 @@ index 648bd4ce9b80..093d7da93aec 100644
      UniqueRef<SOAuthorizationCoordinator> m_soAuthorizationCoordinator;
  #endif
 diff --git a/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp b/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
-index 4f78b5eb5cdb..a2dc89ddf668 100644
+index 4f78b5eb5cdb51f2ebfcaff64ecd19b1e630ad9f..a2dc89ddf668e1be7b8f343a5df542b3141216cc 100644
 --- a/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
 +++ b/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
 @@ -27,9 +27,11 @@
@@ -17658,7 +17694,7 @@ index 4f78b5eb5cdb..a2dc89ddf668 100644
  {
      ASSERT(m_backend);
 diff --git a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
-index 692a45a48fa0..db8c761c71cc 100644
+index 692a45a48fa027f9221338d74f5351bef4baf00f..db8c761c71cc7009be66255c2668de4eff36dee0 100644
 --- a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
 +++ b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
 @@ -60,6 +60,8 @@ void GeoclueGeolocationProvider::start(UpdateNotifyFunction&& updateNotifyFuncti
@@ -17693,7 +17729,7 @@ index 692a45a48fa0..db8c761c71cc 100644
          "org.freedesktop.GeoClue2", clientPath, "org.freedesktop.GeoClue2.Client", m_cancellable.get(),
          [](GObject*, GAsyncResult* result, gpointer userData) {
 diff --git a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
-index b5e48e6c61a8..46747b1d78bf 100644
+index b5e48e6c61a8a3f4b40b84112c4010101c4d5f41..46747b1d78bfe0270178609867c0d710807fa668 100644
 --- a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
 +++ b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
 @@ -71,6 +71,9 @@ private:
@@ -17708,7 +17744,7 @@ index b5e48e6c61a8..46747b1d78bf 100644
  };
 diff --git a/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.cpp b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.cpp
 new file mode 100644
-index 000000000000..31a4e32d4cf8
+index 0000000000000000000000000000000000000000..31a4e32d4cf8442049f0bea04c817a40b801c1f7
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.cpp
 @@ -0,0 +1,147 @@
@@ -17861,7 +17897,7 @@ index 000000000000..31a4e32d4cf8
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.h b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.h
 new file mode 100644
-index 000000000000..8006336003a4
+index 0000000000000000000000000000000000000000..8006336003a4512b4c63bc8272d4b3507bb63159
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/glib/InspectorPlaywrightAgentClientGLib.h
 @@ -0,0 +1,60 @@
@@ -17926,7 +17962,7 @@ index 000000000000..8006336003a4
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
-index 39aeff71fe05..32e96cdd0bdb 100644
+index 39aeff71fe05354cf63d3b3701d363642d63aca4..32e96cdd0bdbd8c5dcde43fdf60052ac13a226f7 100644
 --- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
 +++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
 @@ -28,6 +28,7 @@
@@ -17947,7 +17983,7 @@ index 39aeff71fe05..32e96cdd0bdb 100644
      virtual void unrealize() { };
      virtual bool makeContextCurrent() { return false; }
 diff --git a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h
-index 054e80bd900c..8245d7ed5800 100644
+index 054e80bd900cf16d69801e8102ca989ff0563e1d..8245d7ed58008dbb6152e55e619e4331d30ae674 100644
 --- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h
 +++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreX11.h
 @@ -52,6 +52,7 @@ private:
@@ -17960,7 +17996,7 @@ index 054e80bd900c..8245d7ed5800 100644
      WebCore::XUniqueDamage m_damage;
 diff --git a/Source/WebKit/UIProcess/gtk/InspectorTargetProxyGtk.cpp b/Source/WebKit/UIProcess/gtk/InspectorTargetProxyGtk.cpp
 new file mode 100644
-index 000000000000..8a86cc348bc2
+index 0000000000000000000000000000000000000000..8a86cc348bc210b71bb463dcb3057f575ad7c1d3
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/gtk/InspectorTargetProxyGtk.cpp
 @@ -0,0 +1,44 @@
@@ -18009,7 +18045,7 @@ index 000000000000..8a86cc348bc2
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp b/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp
-index 2ac15c9d7f1f..111cd5464a19 100644
+index 2ac15c9d7f1f19947b449794862555e913e211b7..111cd5464a19b81e73ba1bd02a2d76918cb40612 100644
 --- a/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp
 +++ b/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp
 @@ -34,6 +34,8 @@
@@ -18023,7 +18059,7 @@ index 2ac15c9d7f1f..111cd5464a19 100644
  Ref<WebDateTimePickerGtk> WebDateTimePickerGtk::create(WebPageProxy& page)
 diff --git a/Source/WebKit/UIProcess/gtk/WebPageInspectorEmulationAgentGtk.cpp b/Source/WebKit/UIProcess/gtk/WebPageInspectorEmulationAgentGtk.cpp
 new file mode 100644
-index 000000000000..e5e25acebabb
+index 0000000000000000000000000000000000000000..e5e25acebabb76a05a77db02a99f1267bd99a3af
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/gtk/WebPageInspectorEmulationAgentGtk.cpp
 @@ -0,0 +1,69 @@
@@ -18098,7 +18134,7 @@ index 000000000000..e5e25acebabb
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/gtk/WebPageInspectorInputAgentGtk.cpp b/Source/WebKit/UIProcess/gtk/WebPageInspectorInputAgentGtk.cpp
 new file mode 100644
-index 000000000000..d0f982754499
+index 0000000000000000000000000000000000000000..d0f9827544994e450e24e3f7a427c35eeff94d67
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/gtk/WebPageInspectorInputAgentGtk.cpp
 @@ -0,0 +1,105 @@
@@ -18208,7 +18244,7 @@ index 000000000000..d0f982754499
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
-index 56b32598708d..d6c213d4cfa3 100644
+index 56b32598708dbac89156336dc12ef2d194d597c8..d6c213d4cfa3159849a09423b85ce0900d27b080 100644
 --- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 +++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 @@ -441,6 +441,8 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
@@ -18222,7 +18258,7 @@ index 56b32598708d..d6c213d4cfa3 100644
  
 diff --git a/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.h b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.h
 new file mode 100644
-index 000000000000..a16815a6759d
+index 0000000000000000000000000000000000000000..a16815a6759da61a6a61e3d79058228af887fd7c
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.h
 @@ -0,0 +1,51 @@
@@ -18279,7 +18315,7 @@ index 000000000000..a16815a6759d
 +} // namespace API
 diff --git a/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.mm b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.mm
 new file mode 100644
-index 000000000000..8e588f7b8c8c
+index 0000000000000000000000000000000000000000..8e588f7b8c8c29fb53dd37ea41d46f3d753077fd
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/InspectorPlaywrightAgentClientMac.mm
 @@ -0,0 +1,77 @@
@@ -18362,7 +18398,7 @@ index 000000000000..8e588f7b8c8c
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/mac/InspectorTargetProxyMac.mm b/Source/WebKit/UIProcess/mac/InspectorTargetProxyMac.mm
 new file mode 100644
-index 000000000000..721826c8c98f
+index 0000000000000000000000000000000000000000..721826c8c98fc85b68a4f45deaee69c1219a7254
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/InspectorTargetProxyMac.mm
 @@ -0,0 +1,42 @@
@@ -18409,7 +18445,7 @@ index 000000000000..721826c8c98f
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/mac/PageClientImplMac.h b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
-index 6c5c4e39c614..3a559999da9f 100644
+index 6c5c4e39c61483dae90e692cc78669dab749e5da..3a559999da9fa8c7765f3bff63eab63fee1df8b8 100644
 --- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
 +++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
 @@ -53,6 +53,8 @@ class PageClientImpl final : public PageClientImplCocoa
@@ -18443,7 +18479,7 @@ index 6c5c4e39c614..3a559999da9f 100644
      void navigationGestureWillEnd(bool willNavigate, WebBackForwardListItem&) override;
      void navigationGestureDidEnd(bool willNavigate, WebBackForwardListItem&) override;
 diff --git a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
-index 8b74b4545d89..b58607377d21 100644
+index 8b74b4545d897a999294f815c7c1f67b38fd3c2c..b58607377d21a7593c7b890321f81ab53e167688 100644
 --- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
 +++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
 @@ -81,6 +81,7 @@
@@ -18564,7 +18600,7 @@ index 8b74b4545d89..b58607377d21 100644
  }
  
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
-index 34e2d00746eb..bf496a6327b9 100644
+index 34e2d00746ebb079719becbe781f5bc6cea1d480..bf496a6327b962f8f40c207c9e2023d2152aded1 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
 @@ -70,6 +70,7 @@ private:
@@ -18576,7 +18612,7 @@ index 34e2d00746eb..bf496a6327b9 100644
      void getContextMenuItem(const WebContextMenuItemData&, CompletionHandler<void(NSMenuItem *)>&&);
      void getContextMenuFromItems(const Vector<WebContextMenuItemData>&, CompletionHandler<void(NSMenu *)>&&);
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-index 3e0090b5875b..4293eb5e02a9 100644
+index 3e0090b5875b34887c3aeed45eb3333e3452a413..4293eb5e02a93d7b2feedc47810164b4e6ac5e44 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 @@ -362,6 +362,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
@@ -18594,7 +18630,7 @@ index 3e0090b5875b..4293eb5e02a9 100644
  #if ENABLE(SERVICE_CONTROLS)
 diff --git a/Source/WebKit/UIProcess/mac/WebPageInspectorEmulationAgentMac.mm b/Source/WebKit/UIProcess/mac/WebPageInspectorEmulationAgentMac.mm
 new file mode 100644
-index 000000000000..6113f4cd60a5
+index 0000000000000000000000000000000000000000..6113f4cd60a5d72b8ead61176cb43200803478ed
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/WebPageInspectorEmulationAgentMac.mm
 @@ -0,0 +1,44 @@
@@ -18644,7 +18680,7 @@ index 000000000000..6113f4cd60a5
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/mac/WebPageInspectorInputAgentMac.mm b/Source/WebKit/UIProcess/mac/WebPageInspectorInputAgentMac.mm
 new file mode 100644
-index 000000000000..e6e2c8c2769e
+index 0000000000000000000000000000000000000000..e6e2c8c2769e4657c01f1452e554fd6f6d457279
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/mac/WebPageInspectorInputAgentMac.mm
 @@ -0,0 +1,124 @@
@@ -18774,7 +18810,7 @@ index 000000000000..e6e2c8c2769e
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.cpp b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.cpp
 new file mode 100644
-index 000000000000..dd7fe0604188
+index 0000000000000000000000000000000000000000..dd7fe0604188bb025f361f1c44685e38bbf935ca
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.cpp
 @@ -0,0 +1,90 @@
@@ -18870,7 +18906,7 @@ index 000000000000..dd7fe0604188
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.h b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.h
 new file mode 100644
-index 000000000000..df18883b2b7d
+index 0000000000000000000000000000000000000000..df18883b2b7d22d73540cb084d3dd5291231097d
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/InspectorPlaywrightAgentClientWin.h
 @@ -0,0 +1,60 @@
@@ -18936,7 +18972,7 @@ index 000000000000..df18883b2b7d
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/win/InspectorTargetProxyWin.cpp b/Source/WebKit/UIProcess/win/InspectorTargetProxyWin.cpp
 new file mode 100644
-index 000000000000..135a60361fa8
+index 0000000000000000000000000000000000000000..135a60361fa8fbf907382625e7c8dd4ea64ceb94
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/InspectorTargetProxyWin.cpp
 @@ -0,0 +1,36 @@
@@ -18977,7 +19013,7 @@ index 000000000000..135a60361fa8
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
-index 3dcd0ec35c92..84ba07c57f2a 100644
+index 3dcd0ec35c92e37239208a8f5d4f461fbeaac3ce..84ba07c57f2abac1bd0ca5d0af2e7366ad036892 100644
 --- a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
 +++ b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
 @@ -112,5 +112,11 @@ WebContextMenuProxyWin::~WebContextMenuProxyWin()
@@ -18993,7 +19029,7 @@ index 3dcd0ec35c92..84ba07c57f2a 100644
  } // namespace WebKit
  #endif // ENABLE(CONTEXT_MENUS)
 diff --git a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
-index 0c80d970c3f9..1467e5481f74 100644
+index 0c80d970c3f9a987faf620081c909f6c7021970d..1467e5481f7417913c0d12a1cb492d02b2a7d1b7 100644
 --- a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
 +++ b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
 @@ -47,6 +47,7 @@ public:
@@ -19006,7 +19042,7 @@ index 0c80d970c3f9..1467e5481f74 100644
  };
 diff --git a/Source/WebKit/UIProcess/win/WebPageInspectorEmulationAgentWin.cpp b/Source/WebKit/UIProcess/win/WebPageInspectorEmulationAgentWin.cpp
 new file mode 100644
-index 000000000000..62b841fe1d0d
+index 0000000000000000000000000000000000000000..62b841fe1d0de2296e1c61e328cff564f5aa1c0f
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/WebPageInspectorEmulationAgentWin.cpp
 @@ -0,0 +1,58 @@
@@ -19070,7 +19106,7 @@ index 000000000000..62b841fe1d0d
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/win/WebPageInspectorInputAgentWin.cpp b/Source/WebKit/UIProcess/win/WebPageInspectorInputAgentWin.cpp
 new file mode 100644
-index 000000000000..5cf8a010e980
+index 0000000000000000000000000000000000000000..5cf8a010e9809e6a95741cdb7c2cbeb445ab638b
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/win/WebPageInspectorInputAgentWin.cpp
 @@ -0,0 +1,55 @@
@@ -19131,7 +19167,7 @@ index 000000000000..5cf8a010e980
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/wpe/InspectorTargetProxyWPE.cpp b/Source/WebKit/UIProcess/wpe/InspectorTargetProxyWPE.cpp
 new file mode 100644
-index 000000000000..7453194ca6f0
+index 0000000000000000000000000000000000000000..7453194ca6f032ba86a4c67f5bf12688ab6ec1be
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/wpe/InspectorTargetProxyWPE.cpp
 @@ -0,0 +1,40 @@
@@ -19177,7 +19213,7 @@ index 000000000000..7453194ca6f0
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/wpe/WebPageInspectorEmulationAgentWPE.cpp b/Source/WebKit/UIProcess/wpe/WebPageInspectorEmulationAgentWPE.cpp
 new file mode 100644
-index 000000000000..5dc76aa302cb
+index 0000000000000000000000000000000000000000..5dc76aa302cb574307059e66a1b73730efe920da
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/wpe/WebPageInspectorEmulationAgentWPE.cpp
 @@ -0,0 +1,41 @@
@@ -19224,7 +19260,7 @@ index 000000000000..5dc76aa302cb
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/wpe/WebPageInspectorInputAgentWPE.cpp b/Source/WebKit/UIProcess/wpe/WebPageInspectorInputAgentWPE.cpp
 new file mode 100644
-index 000000000000..c3d7cacea987
+index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705ef6ced129
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/wpe/WebPageInspectorInputAgentWPE.cpp
 @@ -0,0 +1,55 @@
@@ -19284,7 +19320,7 @@ index 000000000000..c3d7cacea987
 + 
 +} // namespace WebKit
 diff --git a/Source/WebKit/WebKit.xcodeproj/project.pbxproj b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-index 57f0933e4dfb..070286815387 100644
+index 57f0933e4dfbd6f1feb5daf8a43c498b2e0e91aa..07028681538738e36be8822816680c26fb495c10 100644
 --- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 +++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 @@ -1958,6 +1958,18 @@
@@ -19542,7 +19578,7 @@ index 57f0933e4dfb..070286815387 100644
  				BCBD3914125BB1A800D2C29F /* WebPageProxyMessageReceiver.cpp in Sources */,
  				7CE9CE101FA0767A000177DE /* WebPageUpdatePreferences.cpp in Sources */,
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
-index c42d2c00f798..50da344e6bd2 100644
+index c42d2c00f7982ea3fe19401cd076c24a0b649ebf..50da344e6bd20b85e122c3c36aebcab2b7765bc2 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 @@ -231,6 +231,11 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
@@ -19655,7 +19691,7 @@ index c42d2c00f798..50da344e6bd2 100644
  {
      WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::SetCaptureExtraNetworkLoadMetricsEnabled(enabled), 0);
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
-index ca2349958666..b5529ff5a2e2 100644
+index ca2349958666a801b0e0a6bd767dbbcccfb716ae..b5529ff5a2e2fa97bccc21f88689624b3d5a3624 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
 @@ -40,6 +40,7 @@ struct FetchOptions;
@@ -19686,7 +19722,7 @@ index ca2349958666..b5529ff5a2e2 100644
  
  } // namespace WebKit
 diff --git a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
-index ecd4052eac03..2adc87a59c12 100644
+index ecd4052eac038028255a786236e1969853afa1d8..2adc87a59c12d15c651909e67670ac354b59092b 100644
 --- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
 @@ -196,6 +196,7 @@ void WebResourceLoader::didReceiveData(const IPC::DataReference& data, int64_t e
@@ -19714,7 +19750,7 @@ index ecd4052eac03..2adc87a59c12 100644
              if (m_coreLoader)
                  didFailResourceLoad(error);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
-index 8cd4c8a0122d..fa689f8a219e 100644
+index 8cd4c8a0122d43c304083b26e0aa510b337a00bd..fa689f8a219e7d3c9179b58e5751ee89ea16eddd 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 @@ -398,6 +398,8 @@ void WebChromeClient::setResizable(bool resizable)
@@ -19741,7 +19777,7 @@ index 8cd4c8a0122d..fa689f8a219e 100644
  {
      if (m_page.activeOpenPanelResultListener())
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
-index 2eb0886f13ed..c46393209cb4 100644
+index 2eb0886f13ed035a53b8eaa60605de4dfe53fbe3..c46393209cb4f80704bbc9268fad4371347d5b30 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
 @@ -29,6 +29,13 @@
@@ -19768,7 +19804,7 @@ index 2eb0886f13ed..c46393209cb4 100644
  {
  }
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
-index 6c904c9862dc..4166ea3112a5 100644
+index 6c904c9862dce939273e25063f1ac83ce6558cd0..4166ea3112a537257e976fa800266fdc4ddf2d15 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 @@ -1569,13 +1569,6 @@ void WebFrameLoaderClient::transitionToCommittedForNewPage()
@@ -19786,7 +19822,7 @@ index 6c904c9862dc..4166ea3112a5 100644
  
  void WebFrameLoaderClient::didRestoreFromBackForwardCache()
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
-index e9f2b2237b1d..b2d3ca7cc093 100644
+index e9f2b2237b1d8a1b21ad28e0fa309b80252b5ebd..b2d3ca7cc093ed428f95df992c208b1b9491067d 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 @@ -127,7 +127,8 @@ static WebCore::CachedImage* cachedImage(Element& element)
@@ -19801,7 +19837,7 @@ index e9f2b2237b1d..b2d3ca7cc093 100644
      WebCore::CachedImage* image = cachedImage(element);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/win/WebDragClientWin.cpp b/Source/WebKit/WebProcess/WebCoreSupport/win/WebDragClientWin.cpp
 new file mode 100644
-index 000000000000..2606914d22e8
+index 0000000000000000000000000000000000000000..2606914d22e85affd9b2f71c361c9db3a14da4f3
 --- /dev/null
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/win/WebDragClientWin.cpp
 @@ -0,0 +1,58 @@
@@ -19865,7 +19901,7 @@ index 000000000000..2606914d22e8
 +#endif // ENABLE(DRAG_SUPPORT)
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebDragClientWPE.cpp b/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebDragClientWPE.cpp
 new file mode 100644
-index 000000000000..9b413bb8150a
+index 0000000000000000000000000000000000000000..9b413bb8150a1633d29b6e2606127c9c1d02442b
 --- /dev/null
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebDragClientWPE.cpp
 @@ -0,0 +1,57 @@
@@ -19927,7 +19963,7 @@ index 000000000000..9b413bb8150a
 +
 +#endif // ENABLE(DRAG_SUPPORT)
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
-index 4a087235e7bc..3ea0a7106906 100644
+index 4a087235e7bcf915f6e9d4daf8ad48b748ce3b91..3ea0a7106906f4cda63f1b0ce7c595496326e1c3 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
 @@ -36,7 +36,9 @@
@@ -19990,7 +20026,7 @@ index 4a087235e7bc..3ea0a7106906 100644
  
  void DrawingAreaCoordinatedGraphics::scheduleDisplay()
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
-index 91226dd76b3f..71db76c7fa64 100644
+index 91226dd76b3f18b1eb5aabd99cd840509bf309f4..71db76c7fa649de2dd19e2c6e7f307cb9810049b 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
 @@ -183,8 +183,16 @@ void LayerTreeHost::setViewOverlayRootLayer(GraphicsLayer* viewOverlayRootLayer)
@@ -20022,7 +20058,7 @@ index 91226dd76b3f..71db76c7fa64 100644
  
      if (m_lastPageScaleFactor != pageScale) {
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
-index 4943393a2c35..e2bc9cd5cfc6 100644
+index 4943393a2c351f91147e1e2369870b42439e2ff1..e2bc9cd5cfc6e906fd8931c2525f6dba6f53441a 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
 @@ -105,6 +105,13 @@ public:
@@ -20040,7 +20076,7 @@ index 4943393a2c35..e2bc9cd5cfc6 100644
  #if USE(COORDINATED_GRAPHICS)
      void layerFlushTimerFired();
 diff --git a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
-index be37cb482bcc..aebb82d4e149 100644
+index be37cb482bccc92412701ba41951c3da57cb7e2e..aebb82d4e149c192bc28383fc722ae1b0a2f5d14 100644
 --- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
 @@ -29,6 +29,7 @@
@@ -20052,7 +20088,7 @@ index be37cb482bcc..aebb82d4e149 100644
  #include <GLES2/gl2.h>
  #include <WebCore/Document.h>
 diff --git a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
-index cdba5ae658de..90d718d74188 100644
+index cdba5ae658de5bda9ef87a2b6ebc99a44d33d658..90d718d74188fcb2ae05ba7b1dd741054d061366 100644
 --- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
 @@ -27,6 +27,7 @@
@@ -20078,7 +20114,7 @@ index cdba5ae658de..90d718d74188 100644
  {
      if (m_hasRemovedMessageReceiver)
 diff --git a/Source/WebKit/WebProcess/WebPage/DrawingArea.h b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
-index 74771ec40ccb..74ff494c1abe 100644
+index 74771ec40ccbcb0329ba09784d8e6a9e512cbc93..74ff494c1abeb8e628ec1ec8f9eef30670af2946 100644
 --- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
 +++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
 @@ -144,6 +144,9 @@ public:
@@ -20092,7 +20128,7 @@ index 74771ec40ccb..74ff494c1abe 100644
      virtual void adoptLayersFromDrawingArea(DrawingArea&) { }
      virtual void adoptDisplayRefreshMonitorsFromDrawingArea(DrawingArea&) { }
 diff --git a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
-index 633828983ef7..91a09a613a00 100644
+index 633828983ef77632392d0dbc2e4a90489e340b9e..91a09a613a0031fc3ba5ee452ac4bb843a216ffe 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
 @@ -28,15 +28,19 @@
@@ -20139,7 +20175,7 @@ index 633828983ef7..91a09a613a00 100644
 +
  } // namespace WebKit
 diff --git a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
-index bc78502b18b9..f4c95fcbc0a1 100644
+index bc78502b18b994a3ffa47b933273ebdb84fafde9..f4c95fcbc0a1d618cc51f748a0df82b7ebe20cab 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
 @@ -52,6 +52,8 @@ public:
@@ -20152,7 +20188,7 @@ index bc78502b18b9..f4c95fcbc0a1 100644
      WebCookieJar();
  
 diff --git a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
-index b2d54a627b94..d407e32b6a7b 100644
+index b2d54a627b94583bda3518c4e7c3364481b605a4..d407e32b6a7b8b27925c49391e86d42c9b3dfa8b 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
 @@ -47,6 +47,14 @@ void WebDocumentLoader::detachFromFrame()
@@ -20171,7 +20207,7 @@ index b2d54a627b94..d407e32b6a7b 100644
  {
      ASSERT(navigationID);
 diff --git a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h
-index f127d64d005a..df0de26e4dc4 100644
+index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4e5365822 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h
 @@ -43,7 +43,10 @@ public:
@@ -20186,7 +20222,7 @@ index f127d64d005a..df0de26e4dc4 100644
      uint64_t m_navigationID;
  };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index 7080a77e4ecc..0925a3703537 100644
+index 7080a77e4eccda34ceb02681733b2a03ff0f4290..0925a37035376249af9be6d87525daaf9c1ecaf3 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 @@ -882,6 +882,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
@@ -20449,7 +20485,7 @@ index 7080a77e4ecc..0925a3703537 100644
  
      return documentLoader;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.h b/Source/WebKit/WebProcess/WebPage/WebPage.h
-index 7901db2bae33..15f562b20c78 100644
+index 7901db2bae3396cf294b2bb7d074d1e2ae2ba857..15f562b20c7847f27576951ec857925f338649d3 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
 @@ -111,6 +111,10 @@ typedef struct _AtkObject AtkObject;
@@ -20530,7 +20566,7 @@ index 7901db2bae33..15f562b20c78 100644
  
      bool m_mainFrameProgressCompleted { false };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-index 320a27e7ac44..12ce55dc6e89 100644
+index 320a27e7ac44c7d1054c3d333d4e6451c43d1377..12ce55dc6e8949e3c2315d8278a0ac1d408e2300 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 @@ -133,6 +133,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
@@ -20582,7 +20618,7 @@ index 320a27e7ac44..12ce55dc6e89 100644
      RequestDragStart(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
      RequestAdditionalItemsForDragSession(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
 diff --git a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
-index 375e5e97370d..3ce7528d64a3 100644
+index 375e5e97370d73edce1afe1dc704a851921427f8..3ce7528d64a3695e6c87b78df3e219b855789fbb 100644
 --- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
 +++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
 @@ -833,21 +833,37 @@ String WebPage::platformUserAgent(const URL&) const
@@ -20624,7 +20660,7 @@ index 375e5e97370d..3ce7528d64a3 100644
  }
  
 diff --git a/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp b/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
-index 8e9454597bb2..9730e673e85d 100644
+index 8e9454597bb23b22c506f929020fc3c37ffaa71a..9730e673e85da143a3acdda03fb9fa3fb4fb1119 100644
 --- a/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
 @@ -43,6 +43,7 @@
@@ -20674,7 +20710,7 @@ index 8e9454597bb2..9730e673e85d 100644
  }
  
 diff --git a/Source/WebKit/WebProcess/WebProcess.cpp b/Source/WebKit/WebProcess/WebProcess.cpp
-index 7c4effdb7431..f62bec5195b8 100644
+index 7c4effdb74316dacdc1a3431a92e3b2f9c8b7479..f62bec5195b896afa5a81d2219f430502aef0a7d 100644
 --- a/Source/WebKit/WebProcess/WebProcess.cpp
 +++ b/Source/WebKit/WebProcess/WebProcess.cpp
 @@ -87,6 +87,7 @@
@@ -20695,7 +20731,7 @@ index 7c4effdb7431..f62bec5195b8 100644
  
  void WebProcess::initializeConnection(IPC::Connection* connection)
 diff --git a/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp b/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp
-index 8987c3964a93..bcac0afeb94e 100644
+index 8987c3964a9308f2454759de7f8972215a3ae416..bcac0afeb94ed8123d1f9fb0b932c8497d157b49 100644
 --- a/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp
 +++ b/Source/WebKit/WebProcess/win/WebProcessMainWin.cpp
 @@ -42,7 +42,9 @@ public:
@@ -20710,7 +20746,7 @@ index 8987c3964a93..bcac0afeb94e 100644
              SetProcessDPIAware();
          return true;
 diff --git a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-index c020b8bba2d0..88ccc0d2354e 100644
+index c020b8bba2d0041f3e54e7f18c6a3776833ef049..88ccc0d2354e95feeaef730a5a10f59eb1bbb818 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 @@ -4236,7 +4236,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
@@ -20723,7 +20759,7 @@ index c020b8bba2d0..88ccc0d2354e 100644
  - (void)touch:(WebEvent *)event
  {
 diff --git a/Source/WebKitLegacy/mac/WebView/WebView.mm b/Source/WebKitLegacy/mac/WebView/WebView.mm
-index 8a4ec8910ca2..ef1933c8030f 100644
+index 8a4ec8910ca2f4104e4b59b22f1081200f280f9b..ef1933c8030f40d9deed891fcef31a93ad037c7d 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
 @@ -4027,7 +4027,7 @@ IGNORE_WARNINGS_END
@@ -20746,7 +20782,7 @@ index 8a4ec8910ca2..ef1933c8030f 100644
  // a per-WebView and a per-preferences setting for whether to use the back/forward cache.
 diff --git a/Source/cmake/FindLibVPX.cmake b/Source/cmake/FindLibVPX.cmake
 new file mode 100644
-index 000000000000..dd6a53e2d573
+index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d5d9dc387
 --- /dev/null
 +++ b/Source/cmake/FindLibVPX.cmake
 @@ -0,0 +1,25 @@
@@ -20776,7 +20812,7 @@ index 000000000000..dd6a53e2d573
 +    LIBVPX_LIBRARIES
 +)
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index 7de2d6046a98..177951f94be6 100644
+index 7de2d6046a98839687ed277009bd9fd4eb5c2fe0..177951f94be605c998c7dc9f7bd2d0f1f3a3270e 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
 @@ -5,6 +5,8 @@ WEBKIT_OPTION_BEGIN()
@@ -20840,7 +20876,7 @@ index 7de2d6046a98..177951f94be6 100644
  
  # Finalize the value for all options. Do not attempt to use an option before
 diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
-index ed79aed95af5..660b1dc93f1d 100644
+index ed79aed95af5c7cf5525f8647258f4747a5b2553..660b1dc93f1d7dae6f3aaeca58131d32a696eda4 100644
 --- a/Source/cmake/OptionsWPE.cmake
 +++ b/Source/cmake/OptionsWPE.cmake
 @@ -3,6 +3,7 @@ include(VersioningUtils)
@@ -20879,7 +20915,7 @@ index ed79aed95af5..660b1dc93f1d 100644
  WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." PUBLIC ON)
  
 diff --git a/Source/cmake/OptionsWin.cmake b/Source/cmake/OptionsWin.cmake
-index ae2ab4d10367..e1b8732496b4 100644
+index ae2ab4d10367dbf6bc38f9a0246cab2485b6fb67..e1b8732496b4adc13551a7b3d7cbd6e1cc961bd9 100644
 --- a/Source/cmake/OptionsWin.cmake
 +++ b/Source/cmake/OptionsWin.cmake
 @@ -7,8 +7,9 @@ add_definitions(-D_WINDOWS -DWINVER=0x601 -D_WIN32_WINNT=0x601)
@@ -20908,7 +20944,7 @@ index ae2ab4d10367..e1b8732496b4 100644
      WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETSCAPE_PLUGIN_API PRIVATE OFF)
  else ()
 diff --git a/Source/cmake/OptionsWinCairo.cmake b/Source/cmake/OptionsWinCairo.cmake
-index 512392e6424e..90b7c9614333 100644
+index 512392e6424ea64ff65fffc14df30344ce6cbe99..90b7c9614333868ff8c157f5bd938da98be4871d 100644
 --- a/Source/cmake/OptionsWinCairo.cmake
 +++ b/Source/cmake/OptionsWinCairo.cmake
 @@ -32,15 +32,36 @@ if (OpenJPEG_FOUND)
@@ -20952,7 +20988,7 @@ index 512392e6424e..90b7c9614333 100644
  set(USE_ANGLE_WEBGL ON)
  
 diff --git a/Tools/MiniBrowser/gtk/BrowserTab.c b/Tools/MiniBrowser/gtk/BrowserTab.c
-index ab75a69f64aa..e82450546a7d 100644
+index ab75a69f64aadee2b22e0d8d114932db55aaa000..e82450546a7dba66155b26c3d841d0a74675c701 100644
 --- a/Tools/MiniBrowser/gtk/BrowserTab.c
 +++ b/Tools/MiniBrowser/gtk/BrowserTab.c
 @@ -161,6 +161,11 @@ static void loadChanged(WebKitWebView *webView, WebKitLoadEvent loadEvent, Brows
@@ -20986,7 +21022,7 @@ index ab75a69f64aa..e82450546a7d 100644
  }
  
 diff --git a/Tools/MiniBrowser/gtk/BrowserWindow.c b/Tools/MiniBrowser/gtk/BrowserWindow.c
-index 063e94568490..76ba6df237dd 100644
+index 063e94568490cc72193222987b805e7dfff94fea..76ba6df237dd8c2c2bcf339541751e82d842bf76 100644
 --- a/Tools/MiniBrowser/gtk/BrowserWindow.c
 +++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
 @@ -70,7 +70,7 @@ struct _BrowserWindowClass {
@@ -21044,7 +21080,7 @@ index 063e94568490..76ba6df237dd 100644
  
  /* Public API. */
 diff --git a/Tools/MiniBrowser/gtk/BrowserWindow.h b/Tools/MiniBrowser/gtk/BrowserWindow.h
-index 62629b4c1c25..5de7900a29b0 100644
+index 62629b4c1c25ae82bd797b39bbf9de0331f8eed2..5de7900a29b0e629f1ac404bbb0dc5b4e605294d 100644
 --- a/Tools/MiniBrowser/gtk/BrowserWindow.h
 +++ b/Tools/MiniBrowser/gtk/BrowserWindow.h
 @@ -37,7 +37,7 @@ G_BEGIN_DECLS
@@ -21057,7 +21093,7 @@ index 62629b4c1c25..5de7900a29b0 100644
  
  typedef struct _BrowserWindow        BrowserWindow;
 diff --git a/Tools/MiniBrowser/gtk/main.c b/Tools/MiniBrowser/gtk/main.c
-index 241ac28e0d59..6554de7369b9 100644
+index 241ac28e0d59d93c81bad88bcddcb197620b3f2a..6554de7369b99556ff558a0340dd580bf9420393 100644
 --- a/Tools/MiniBrowser/gtk/main.c
 +++ b/Tools/MiniBrowser/gtk/main.c
 @@ -55,7 +55,12 @@ static gboolean enableITP;
@@ -21190,7 +21226,7 @@ index 241ac28e0d59..6554de7369b9 100644
  
      return exitAfterLoad && webProcessCrashed ? 1 : 0;
 diff --git a/Tools/MiniBrowser/wpe/main.cpp b/Tools/MiniBrowser/wpe/main.cpp
-index 2e5c76219de1..cf6650a4fda1 100644
+index 2e5c76219de1a60dccae1c8088ceabd8b12c95d0..cf6650a4fda1516b2adf578fc263ad874b200c01 100644
 --- a/Tools/MiniBrowser/wpe/main.cpp
 +++ b/Tools/MiniBrowser/wpe/main.cpp
 @@ -40,6 +40,9 @@ static gboolean headlessMode;
@@ -21418,7 +21454,7 @@ index 2e5c76219de1..cf6650a4fda1 100644
  
      return 0;
 diff --git a/Tools/PlatformWin.cmake b/Tools/PlatformWin.cmake
-index ef4407cfc114..448dd4837151 100644
+index ef4407cfc114e602d98ed81724da504f453e258f..448dd483715162baba484f756fbcc1d72de4ba0c 100644
 --- a/Tools/PlatformWin.cmake
 +++ b/Tools/PlatformWin.cmake
 @@ -12,4 +12,5 @@ endif ()
@@ -21428,7 +21464,7 @@ index ef4407cfc114..448dd4837151 100644
 +    add_subdirectory(Playwright/win)
  endif ()
 diff --git a/Tools/Scripts/build-webkit b/Tools/Scripts/build-webkit
-index ddc2a96ac68c..57a78f54e72d 100755
+index ddc2a96ac68cd51d5f4efeca78a118db91709aa2..57a78f54e72d264daa27faa53ac2a30cab98dd82 100755
 --- a/Tools/Scripts/build-webkit
 +++ b/Tools/Scripts/build-webkit
 @@ -247,7 +247,7 @@ if (isAppleCocoaWebKit()) {
@@ -21441,7 +21477,7 @@ index ddc2a96ac68c..57a78f54e72d 100755
          # WebInspectorUI must come after JavaScriptCore and WebCore but before WebKit and WebKit2
          my $webKitIndex = first { $projects[$_] eq "Source/WebKitLegacy" } 0..$#projects;
 diff --git a/Tools/WebKitTestRunner/PlatformGTK.cmake b/Tools/WebKitTestRunner/PlatformGTK.cmake
-index 6f8366b63e43..cc8299dfa438 100644
+index 6f8366b63e43eca6b95b67bb47fee9e7a1970cf9..cc8299dfa4380b833e79a870779a222059579d3b 100644
 --- a/Tools/WebKitTestRunner/PlatformGTK.cmake
 +++ b/Tools/WebKitTestRunner/PlatformGTK.cmake
 @@ -26,6 +26,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
@@ -21453,7 +21489,7 @@ index 6f8366b63e43..cc8299dfa438 100644
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
 diff --git a/Tools/WebKitTestRunner/PlatformWPE.cmake b/Tools/WebKitTestRunner/PlatformWPE.cmake
-index 775b41868718..68a720c0cb01 100644
+index 775b41868718ea6734efc9082f8161eee2e0015e..68a720c0cb01d534653a259536c481683873680d 100644
 --- a/Tools/WebKitTestRunner/PlatformWPE.cmake
 +++ b/Tools/WebKitTestRunner/PlatformWPE.cmake
 @@ -31,6 +31,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
@@ -21465,7 +21501,7 @@ index 775b41868718..68a720c0cb01 100644
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
 diff --git a/Tools/WebKitTestRunner/TestController.cpp b/Tools/WebKitTestRunner/TestController.cpp
-index cfc9c4483c82..a14886f89ce6 100644
+index cfc9c4483c825d913ed27a4d55884f242d76f002..a14886f89ce62981006517ef528481ab2c9ff116 100644
 --- a/Tools/WebKitTestRunner/TestController.cpp
 +++ b/Tools/WebKitTestRunner/TestController.cpp
 @@ -787,6 +787,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
@@ -21477,7 +21513,7 @@ index cfc9c4483c82..a14886f89ce6 100644
          decidePolicyForMediaKeySystemPermissionRequest
      };
 diff --git a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
-index 296c902f375b..45d8ca4bdd18 100644
+index 296c902f375b1189f45ee56bb3ffd4d826dd26f6..45d8ca4bdd18e2467b26b0c6998b4dc58dde7634 100644
 --- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
 +++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
 @@ -977,4 +977,51 @@ void EventSenderProxy::scaleGestureEnd(double scale)
@@ -21533,7 +21569,7 @@ index 296c902f375b..45d8ca4bdd18 100644
 +
  } // namespace WTR
 diff --git a/Tools/gtk/install-dependencies b/Tools/gtk/install-dependencies
-index 46388b47a0f4..d42933e66178 100755
+index 46388b47a0f433fbdae3874a958fb2d207916c45..d42933e66178ff007a5008dc807483c4896ea5e1 100755
 --- a/Tools/gtk/install-dependencies
 +++ b/Tools/gtk/install-dependencies
 @@ -120,6 +120,7 @@ function installDependenciesWithApt {
@@ -21561,7 +21597,7 @@ index 46388b47a0f4..d42933e66178 100755
          xfonts-utils"
  
 diff --git a/Tools/win/DLLLauncher/DLLLauncherMain.cpp b/Tools/win/DLLLauncher/DLLLauncherMain.cpp
-index 52605867b930..6edf24ab6024 100644
+index 52605867b9302d1afcc56c5e9b0c54acf0827900..6edf24ab60249241ba2969531ef55f4b495dce9e 100644
 --- a/Tools/win/DLLLauncher/DLLLauncherMain.cpp
 +++ b/Tools/win/DLLLauncher/DLLLauncherMain.cpp
 @@ -99,11 +99,9 @@ static bool prependPath(const std::wstring& directoryToPrepend)
@@ -21579,7 +21615,7 @@ index 52605867b930..6edf24ab6024 100644
  }
  
 diff --git a/Tools/wpe/backends/HeadlessViewBackend.cpp b/Tools/wpe/backends/HeadlessViewBackend.cpp
-index c09b6f39f894..bc21acb64856 100644
+index c09b6f39f894943f11b7a453428fab7d6f6e68fb..bc21acb648562ee0380811599b08f7d26c3e706a 100644
 --- a/Tools/wpe/backends/HeadlessViewBackend.cpp
 +++ b/Tools/wpe/backends/HeadlessViewBackend.cpp
 @@ -145,27 +145,24 @@ void HeadlessViewBackend::updateSnapshot(struct wpe_fdo_shm_exported_buffer* exp
@@ -21634,7 +21670,7 @@ index c09b6f39f894..bc21acb64856 100644
      static cairo_user_data_key_t bufferKey;
      cairo_surface_set_user_data(m_snapshot, &bufferKey, buffer,
 diff --git a/Tools/wpe/install-dependencies b/Tools/wpe/install-dependencies
-index 6bc2db3024aa..09774119a487 100755
+index 6bc2db3024aa3466200f70d20b425227215b6a43..09774119a487ffc4df80ae6f49dd4f31c4021a70 100755
 --- a/Tools/wpe/install-dependencies
 +++ b/Tools/wpe/install-dependencies
 @@ -78,6 +78,7 @@ function installDependenciesWithApt {


### PR DESCRIPTION
~~Seems like the upstream repo (WebKit/WebKit) is too big for some reason and does not allow me to push my branches anymore - trying to figure there something out.~~ -> use WebKit/WebKit-http instead fixes it

Changes: https://github.com/mxschmitt/WebKit-http/commit/93e624d34eaa2098a628a496b34381b730041432

(I'm in contact with Igalia why their hash-length differs on their environment - probably they are not using the export.sh script and doing it manually).

I tested this change on Linux and Mac. Also quite confident that it works on Windows.

Relates #7283