### PR TITLE
chore(webkit): use GitHub as a remote origin

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1522
-Changed: dpino@igalia.com Wed Jul 28 18:26:16 UTC 2021
+1523
+Changed: max@schmitt.mx Wed Jul 28 20:26:16 UTC 2021

--- a/browser_patches/webkit/UPSTREAM_CONFIG.sh
+++ b/browser_patches/webkit/UPSTREAM_CONFIG.sh
@@ -1,3 +1,3 @@
-REMOTE_URL="https://git.webkit.org/git/WebKit.git"
-BASE_BRANCH="master"
-BASE_REVISION="176ea7884efcb0e844e193f908b02fe940c28872"
+REMOTE_URL="https://github.com/WebKit/WebKit.git"
+BASE_BRANCH="main"
+BASE_REVISION="2cf99c4a7d4fb944ebb1f2b7cb4ddd864be6d141"


### PR DESCRIPTION
Old: https://git.webkit.org/?p=WebKit.git;a=commit;h=176ea7884efcb0e844e193f908b02fe940c28872#
Corresponding new hash: https://github.com/WebKit/WebKit/commit/2cf99c4a7d4fb944ebb1f2b7cb4ddd864be6d141
