### PR TITLE
fix(test runner): keep track of remaining tests on the runner side

### DIFF
--- a/src/test/ipc.ts
+++ b/src/test/ipc.ts
@@ -56,8 +56,7 @@ export type RunPayload = {
 
 export type DonePayload = {
   failedTestId?: string;
-  fatalError?: any;
-  remaining: TestEntry[];
+  fatalError?: TestError;
 };
 
 export type TestOutputPayload = {

--- a/src/test/reporters/base.ts
+++ b/src/test/reporters/base.ts
@@ -226,7 +226,7 @@ function indent(lines: string, tab: string) {
   return lines.replace(/^(?=.+$)/gm, tab);
 }
 
-function positionInFile(stack: string, file: string): { column: number; line: number; } {
+function positionInFile(stack: string, file: string): { column: number; line: number; } | undefined {
   // Stack will have /private/var/folders instead of /var/folders on Mac.
   file = fs.realpathSync(file);
   for (const line of stack.split('\n')) {
@@ -236,7 +236,6 @@ function positionInFile(stack: string, file: string): { column: number; line: nu
     if (path.resolve(process.cwd(), parsed.file) === file)
       return {column: parsed.column || 0, line: parsed.line || 0};
   }
-  return { column: 0, line: 0 };
 }
 
 function monotonicTime(): number {

--- a/src/test/reporters/list.ts
+++ b/src/test/reporters/list.ts
@@ -45,7 +45,7 @@ class ListReporter extends BaseReporter {
         process.stdout.write('\n');
         this._lastRow++;
       }
-      process.stdout.write('    ' + colors.gray(formatTestTitle(this.config, test) + ': ') + '\n');
+      process.stdout.write('     ' + colors.gray(formatTestTitle(this.config, test) + ': ') + '\n');
     }
     this._testRows.set(test, this._lastRow++);
   }

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -59,3 +59,54 @@ test('it should not allow a focused test when forbid-only is used', async ({ run
   expect(result.output).toContain('--forbid-only found a focused test.');
   expect(result.output).toContain(`- tests${path.sep}focused-test.spec.js:6 > i-am-focused`);
 });
+
+test('it should not hang and report results when worker process suddenly exits', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const { test } = pwt;
+      test('passed1', () => {});
+      test('passed2', () => {});
+      test('failed1', () => { process.exit(0); });
+      test('failed2', () => {});
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(2);
+  expect(result.failed).toBe(2);
+  expect(result.output).toContain('Worker process exited unexpectedly');
+});
+
+test('sigint should stop workers', async ({ runInlineTest }) => {
+  test.skip(process.platform === 'win32', 'No sending SIGINT on Windows');
+
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const { test } = pwt;
+      test('interrupted1', async () => {
+        console.log('\\n%%SEND-SIGINT%%1');
+        await new Promise(f => setTimeout(f, 1000));
+      });
+      test('skipped1', async () => {
+        console.log('\\n%%skipped1');
+      });
+    `,
+    'b.spec.js': `
+      const { test } = pwt;
+      test('interrupted2', async () => {
+        console.log('\\n%%SEND-SIGINT%%2');
+        await new Promise(f => setTimeout(f, 1000));
+      });
+      test('skipped2', async () => {
+        console.log('\\n%%skipped2');
+      });
+    `,
+  }, { 'workers': 2 }, {}, { sendSIGINTAfter: 2 });
+  expect(result.exitCode).toBe(130);
+  expect(result.passed).toBe(0);
+  expect(result.failed).toBe(0);
+  expect(result.skipped).toBe(4);
+  expect(result.output).toContain('%%SEND-SIGINT%%1');
+  expect(result.output).toContain('%%SEND-SIGINT%%2');
+  expect(result.output).not.toContain('%%skipped1');
+  expect(result.output).not.toContain('%%skipped2');
+});


### PR DESCRIPTION
This fixes two issues:
- Sudden worker process exit is properly accounted for.
- We can `stop()` workers willy-nilly, e.g. after reaching maxFailures.

Details:
- DonePayload does not send `remaining` anymore, and worker does not track it.
- Instead, `Dispatcher._runJob` track remaining tests and acts accordingly.
- Upon worker exit, we emulate a fatal error for all remaining tests.

Drive-by:
- Do not report `onTestBegin` after reaching `maxFailures` to avoid confusion. Before, we did report `onTestBegin`, but not `onTestEnd`.
- List reporter aligned between "running" and "finished" state - it was one character misplaced.
- Do not show the first 3 lines of test file when we cannot locate the error location in it - that's just noise.
- Added a SIGINT test.

Fixes #7444.