### PR TITLE
fix(test-runner): do not override error with unhandled error

### DIFF
--- a/src/test/workerRunner.ts
+++ b/src/test/workerRunner.ts
@@ -72,6 +72,8 @@ export class WorkerRunner extends EventEmitter {
     if (this._isStopped)
       return;
     if (this._currentTest) {
+      if (this._currentTest.testInfo.error)
+        return;
       this._currentTest.testInfo.status = 'failed';
       this._currentTest.testInfo.error = serializeError(error);
       this._failedTestId = this._currentTest.testId;


### PR DESCRIPTION
Fixes #7506

The good error was thrown in the page fixture and then another unhandledException got thrown which was confusing.

Why was the error thrown in Playwright in the first place? See the following example which shows what Playwright Test is doing internally:

Assumtions:
- FFMPEG does not exist on the file-system

```js
const playwright = require("playwright-chromium"); 
 
(async () => { 
    const browser = await playwright.chromium.launch() 
    const context = await browser.newContext({ 
        recordVideo: { 
            dir: "./videos" 
        }, 
    }) 
    try { 
        const page = await context.newPage();  // <-- ffmpeg not found error gets thrown
        await page.goto("https://playwright.dev") 
        await page.close(); 
    } catch (error) { 
        console.log(error) 
        await context.close() // <-- Playwright Test does still call context.close() even when page.newPage() was failing.
        await browser.close(); 
    } 
})()
```
