### PR TITLE
fix(test-runner): with automatic fixtures workerInfo was undefined after conditional skip

### DIFF
--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -16,7 +16,7 @@
 
 import { wrapInPromise } from './util';
 import * as crypto from 'crypto';
-import { FixturesWithLocation, Location } from './types';
+import { FixturesWithLocation, Location, WorkerInfo, TestInfo } from './types';
 
 type FixtureScope = 'test' | 'worker';
 type FixtureRegistration = {
@@ -228,7 +228,7 @@ export class FixtureRunner {
       this.testScopeClean = true;
   }
 
-  async resolveParametersAndRunHookOrTest(fn: Function, scope: FixtureScope, info: any) {
+  async resolveParametersAndRunHookOrTest(fn: Function, scope: FixtureScope, info: WorkerInfo|TestInfo) {
     // Install all automatic fixtures.
     for (const registration of this.pool!.registrations.values()) {
       const shouldSkip = scope === 'worker' && registration.scope === 'test';

--- a/src/test/workerRunner.ts
+++ b/src/test/workerRunner.ts
@@ -147,7 +147,7 @@ export class WorkerRunner extends EventEmitter {
       if (!this._fixtureRunner.dependsOnWorkerFixturesOnly(beforeAllModifier.fn, beforeAllModifier.location))
         continue;
       // TODO: separate timeout for beforeAll modifiers?
-      const result = await raceAgainstDeadline(this._fixtureRunner.resolveParametersAndRunHookOrTest(beforeAllModifier.fn, 'worker', undefined), this._deadline());
+      const result = await raceAgainstDeadline(this._fixtureRunner.resolveParametersAndRunHookOrTest(beforeAllModifier.fn, 'worker', this._workerInfo), this._deadline());
       if (result.timedOut) {
         this._fatalError = serializeError(new Error(`Timeout of ${this._project.config.timeout}ms exceeded while running ${beforeAllModifier.type} modifier`));
         this._reportDoneAndStop();


### PR DESCRIPTION
Caused in #7436

On NPM:

- 1.13.0-next-alpha-jul-3-2021 bad
- 1.13.0-next-alpha-jul-2-2021  good

Fixes https://github.com/microsoft/playwright/pull/7519/checks?check_run_id=3021640189#step:7:17
Found during roll of the test-runner in #7519
