### PR TITLE
devops(GHA): move build-driver to secondary workflow

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -30,17 +30,3 @@ jobs:
           git diff
           exit 1
         fi
-
-  build-playwright-driver:
-    name: "build-playwright-driver"
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm ci
-    - run: npm run build
-    - run: node lib/cli/cli install-deps
-    - run: node utils/build/update_canary_version.js --today-date
-    - run: utils/build/build-playwright-driver.sh

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -547,3 +547,17 @@ jobs:
       with:
         name: electron-linux-test-results
         path: test-results
+
+  build-playwright-driver:
+    name: "build-playwright-driver"
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 12
+    - run: npm ci
+    - run: npm run build
+    - run: node lib/cli/cli install-deps
+    - run: node utils/build/update_canary_version.js --today-date
+    - run: utils/build/build-playwright-driver.sh


### PR DESCRIPTION
The chance that we break this in a PR is quite rare, so I moved it over to the secondary workflow. It still runs on master, which is enough.