### PR TITLE
Revert "chore(eval): merge internal evaluate functions (#7517)"

### DIFF
--- a/src/dispatchers/frameDispatcher.ts
+++ b/src/dispatchers/frameDispatcher.ts
@@ -67,22 +67,11 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameInitializer
   }
 
   async evaluateExpression(params: channels.FrameEvaluateExpressionParams, metadata: CallMetadata): Promise<channels.FrameEvaluateExpressionResult> {
-    return { value: serializeResult(await this._frame.eval(params.expression, {
-      arg: parseArgument(params.arg),
-      isFunction: params.isFunction,
-      waitForSignals: true,
-      world: 'main',
-    }))};
+    return { value: serializeResult(await this._frame.evaluateExpressionAndWaitForSignals(params.expression, params.isFunction, parseArgument(params.arg), 'main')) };
   }
 
   async evaluateExpressionHandle(params: channels.FrameEvaluateExpressionHandleParams, metadata: CallMetadata): Promise<channels.FrameEvaluateExpressionHandleResult> {
-    return { handle: ElementHandleDispatcher.fromJSHandle(this._scope, await this._frame.eval(params.expression, {
-      arg: parseArgument(params.arg),
-      isFunction: params.isFunction,
-      returnHandle: true,
-      waitForSignals: true,
-      world: 'main',
-    }))};
+    return { handle: ElementHandleDispatcher.fromJSHandle(this._scope, await this._frame.evaluateExpressionHandleAndWaitForSignals(params.expression, params.isFunction, parseArgument(params.arg), 'main')) };
   }
 
   async waitForSelector(params: channels.FrameWaitForSelectorParams, metadata: CallMetadata): Promise<channels.FrameWaitForSelectorResult> {

--- a/src/server/chromium/crPage.ts
+++ b/src/server/chromium/crPage.ts
@@ -171,7 +171,7 @@ export class CRPage implements PageDelegate {
 
   async exposeBinding(binding: PageBinding) {
     await this._forAllFrameSessions(frame => frame._initBinding(binding));
-    await Promise.all(this._page.frames().map(frame => frame.eval(binding.source, {world: binding.world}).catch(e => {})));
+    await Promise.all(this._page.frames().map(frame => frame.evaluateExpression(binding.source, false, {}, binding.world).catch(e => {})));
   }
 
   async updateExtraHTTPHeaders(): Promise<void> {
@@ -473,9 +473,9 @@ class FrameSession {
             worldName: UTILITY_WORLD_NAME,
           });
           for (const binding of this._crPage._browserContext._pageBindings.values())
-            frame.eval(binding.source, {world: binding.world}).catch(e => {});
+            frame.evaluateExpression(binding.source, false, undefined, binding.world).catch(e => {});
           for (const source of this._crPage._browserContext._evaluateOnNewDocumentSources)
-            frame.eval(source).catch(e => {});
+            frame.evaluateExpression(source, false, undefined, 'main').catch(e => {});
         }
         const isInitialEmptyPage = this._isMainFrame() && this._page.mainFrame().url() === ':';
         if (isInitialEmptyPage) {

--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -50,6 +50,36 @@ export class FrameExecutionContext extends js.ExecutionContext {
     return null;
   }
 
+  async evaluate<Arg, R>(pageFunction: js.Func1<Arg, R>, arg?: Arg): Promise<R> {
+    return js.evaluate(this, true /* returnByValue */, pageFunction, arg);
+  }
+
+  async evaluateHandle<Arg, R>(pageFunction: js.Func1<Arg, R>, arg?: Arg): Promise<js.SmartHandle<R>> {
+    return js.evaluate(this, false /* returnByValue */, pageFunction, arg);
+  }
+
+  async evaluateExpression(expression: string, isFunction: boolean | undefined, arg?: any): Promise<any> {
+    return js.evaluateExpression(this, true /* returnByValue */, expression, isFunction, arg);
+  }
+
+  async evaluateAndWaitForSignals<Arg, R>(pageFunction: js.Func1<Arg, R>, arg?: Arg): Promise<R> {
+    return await this.frame._page._frameManager.waitForSignalsCreatedBy(null, false /* noWaitFor */, async () => {
+      return this.evaluate(pageFunction, arg);
+    });
+  }
+
+  async evaluateExpressionAndWaitForSignals(expression: string, isFunction: boolean | undefined, arg?: any): Promise<any> {
+    return await this.frame._page._frameManager.waitForSignalsCreatedBy(null, false /* noWaitFor */, async () => {
+      return this.evaluateExpression(expression, isFunction, arg);
+    });
+  }
+
+  async evaluateExpressionHandleAndWaitForSignals(expression: string, isFunction: boolean | undefined, arg: any): Promise<any> {
+    return await this.frame._page._frameManager.waitForSignalsCreatedBy(null, false /* noWaitFor */, async () => {
+      return js.evaluateExpression(this, false /* returnByValue */, expression, isFunction, arg);
+    });
+  }
+
   createHandle(remoteObject: js.RemoteObject): js.JSHandle {
     if (this.frame._page._delegate.isElementHandle(remoteObject))
       return new ElementHandle(this, remoteObject.objectId!);
@@ -105,7 +135,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
   private async _evaluateInMainAndWaitForSignals<R, Arg>(pageFunction: js.Func1<[js.JSHandle<InjectedScript>, ElementHandle<T>, Arg], R>, arg: Arg): Promise<R> {
     const main = await this._context.frame._mainContext();
-    return main.eval(pageFunction, {arg: [await main.injectedScript(), this, arg], waitForSignals: true});
+    return main.evaluateAndWaitForSignals(pageFunction, [await main.injectedScript(), this, arg]);
   }
 
   async evaluateInUtility<R, Arg>(pageFunction: js.Func1<[js.JSHandle<InjectedScript>, ElementHandle<T>, Arg], R>, arg: Arg): Promise<R> {

--- a/src/server/electron/electron.ts
+++ b/src/server/electron/electron.ts
@@ -68,7 +68,7 @@ export class ElectronApplication extends SdkObject {
       this._nodeSession.on('Runtime.executionContextCreated', async (event: any) => {
         if (event.context.auxData && event.context.auxData.isDefault) {
           this._nodeExecutionContext = new js.ExecutionContext(this, new CRExecutionContext(this._nodeSession, event.context));
-          f(this._nodeExecutionContext.eval(`process.mainModule.require('electron')`, { returnHandle: true }));
+          f(await js.evaluate(this._nodeExecutionContext, false /* returnByValue */, `process.mainModule.require('electron')`));
         }
       });
     });

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -508,7 +508,7 @@ export class Frame extends SdkObject {
     this._nonStallingEvaluations.add(callback);
     try {
       return await Promise.race([
-        context.eval(expression, { isFunction }),
+        context.evaluateExpression(expression, isFunction),
         frameInvalidated
       ]);
     } finally {
@@ -658,10 +658,25 @@ export class Frame extends SdkObject {
     return this._context('utility');
   }
 
-  async eval(pageFunction: string|Function, options: js.EvalOptions & {world?: types.World} = {}) {
-    const {world = 'main'} = options;
+  async evaluateExpressionHandleAndWaitForSignals(expression: string, isFunction: boolean | undefined, arg: any, world: types.World = 'main'): Promise<any> {
     const context = await this._context(world);
-    const value = await context.eval(pageFunction, options);
+    const handle = await context.evaluateExpressionHandleAndWaitForSignals(expression, isFunction, arg);
+    if (world === 'main')
+      await this._page._doSlowMo();
+    return handle;
+  }
+
+  async evaluateExpression(expression: string, isFunction: boolean | undefined, arg: any, world: types.World = 'main'): Promise<any> {
+    const context = await this._context(world);
+    const value = await context.evaluateExpression(expression, isFunction, arg);
+    if (world === 'main')
+      await this._page._doSlowMo();
+    return value;
+  }
+
+  async evaluateExpressionAndWaitForSignals(expression: string, isFunction: boolean | undefined, arg: any, world: types.World = 'main'): Promise<any> {
+    const context = await this._context(world);
+    const value = await context.evaluateExpressionAndWaitForSignals(expression, isFunction, arg);
     if (world === 'main')
       await this._page._doSlowMo();
     return value;

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -537,11 +537,11 @@ export class Worker extends SdkObject {
   }
 
   async evaluateExpression(expression: string, isFunction: boolean | undefined, arg: any): Promise<any> {
-    return (await this._executionContextPromise).eval(expression, {isFunction, arg});
+    return js.evaluateExpression(await this._executionContextPromise, true /* returnByValue */, expression, isFunction, arg);
   }
 
   async evaluateExpressionHandle(expression: string, isFunction: boolean | undefined, arg: any): Promise<any> {
-    return (await this._executionContextPromise).eval(expression, {isFunction, arg, returnHandle: true});
+    return js.evaluateExpression(await this._executionContextPromise, false /* returnByValue */, expression, isFunction, arg);
   }
 }
 

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -82,12 +82,12 @@ export class HarTracer {
 
   private _onDOMContentLoaded(page: Page) {
     const pageEntry = this._ensurePageEntry(page);
-    const promise = page.mainFrame().eval(() => {
+    const promise = page.mainFrame().evaluateExpression(String(() => {
       return {
         title: document.title,
         domContentLoaded: performance.timing.domContentLoadedEventStart,
       };
-    }, {world: 'utility'}).then(result => {
+    }), true, undefined, 'utility').then(result => {
       pageEntry.title = result.title;
       pageEntry.pageTimings.onContentLoad = result.domContentLoaded;
     }).catch(() => {});
@@ -96,12 +96,12 @@ export class HarTracer {
 
   private _onLoad(page: Page) {
     const pageEntry = this._ensurePageEntry(page);
-    const promise = page.mainFrame().eval(() => {
+    const promise = page.mainFrame().evaluateExpression(String(() => {
       return {
         title: document.title,
         loaded: performance.timing.loadEventStart,
       };
-    }, {world: 'utility'}).then(result => {
+    }), true, undefined, 'utility').then(result => {
       pageEntry.title = result.title;
       pageEntry.pageTimings.onLoad = result.loaded;
     }).catch(() => {});

--- a/src/server/supplements/recorder/recorderApp.ts
+++ b/src/server/supplements/recorder/recorderApp.ts
@@ -122,27 +122,27 @@ export class RecorderApp extends EventEmitter {
   }
 
   async setMode(mode: 'none' | 'recording' | 'inspecting'): Promise<void> {
-    await this._page.mainFrame().eval((mode: Mode) => {
+    await this._page.mainFrame().evaluateExpression(((mode: Mode) => {
       window.playwrightSetMode(mode);
-    }, {arg: mode}).catch(() => {});
+    }).toString(), true, mode, 'main').catch(() => {});
   }
 
   async setFile(file: string): Promise<void> {
-    await this._page.mainFrame().eval((file: string) => {
+    await this._page.mainFrame().evaluateExpression(((file: string) => {
       window.playwrightSetFile(file);
-    }, {arg: file}).catch(() => {});
+    }).toString(), true, file, 'main').catch(() => {});
   }
 
   async setPaused(paused: boolean): Promise<void> {
-    await this._page.mainFrame().eval((paused: boolean) => {
+    await this._page.mainFrame().evaluateExpression(((paused: boolean) => {
       window.playwrightSetPaused(paused);
-    }, {arg: paused}).catch(() => {});
+    }).toString(), true, paused, 'main').catch(() => {});
   }
 
   async setSources(sources: Source[]): Promise<void> {
-    await this._page.mainFrame().eval((sources: Source[]) => {
+    await this._page.mainFrame().evaluateExpression(((sources: Source[]) => {
       window.playwrightSetSources(sources);
-    }, {arg: sources}).catch(() => {});
+    }).toString(), true, sources, 'main').catch(() => {});
 
     // Testing harness for runCLI mode.
     {
@@ -155,15 +155,15 @@ export class RecorderApp extends EventEmitter {
   }
 
   async setSelector(selector: string, focus?: boolean): Promise<void> {
-    await this._page.mainFrame().eval((selector: string, focus?: boolean) => {
-      window.playwrightSetSelector(selector, focus);
-    }, {args: [selector, focus]}).catch(() => {});
+    await this._page.mainFrame().evaluateExpression(((arg: any) => {
+      window.playwrightSetSelector(arg.selector, arg.focus);
+    }).toString(), true, { selector, focus }, 'main').catch(() => {});
   }
 
   async updateCallLogs(callLogs: CallLog[]): Promise<void> {
-    await this._page.mainFrame().eval((callLogs: CallLog[]) => {
+    await this._page.mainFrame().evaluateExpression(((callLogs: CallLog[]) => {
       window.playwrightUpdateLogs(callLogs);
-    }, {arg: callLogs}).catch(() => {});
+    }).toString(), true, callLogs, 'main').catch(() => {});
   }
 
   async bringToFront() {

--- a/src/server/supplements/recorderSupplement.ts
+++ b/src/server/supplements/recorderSupplement.ts
@@ -249,7 +249,7 @@ export class RecorderSupplement implements InstrumentationListener {
 
   private _refreshOverlay() {
     for (const page of this._context.pages())
-      page.mainFrame().eval('window._playwrightRefreshOverlay()').catch(() => {});
+      page.mainFrame().evaluateExpression('window._playwrightRefreshOverlay()', false, undefined, 'main').catch(() => {});
   }
 
   private async _onPage(page: Page) {

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -191,7 +191,7 @@ export class WKPage implements PageDelegate {
       const bootstrapScript = this._calculateBootstrapScript(world);
       if (bootstrapScript.length)
         promises.push(session.send('Page.setBootstrapScript', { source: bootstrapScript, worldName: webkitWorldName(world) }));
-      this._page.frames().map(frame => frame.eval(bootstrapScript, {world}).catch(e => {}));
+      this._page.frames().map(frame => frame.evaluateExpression(bootstrapScript, false, undefined, world).catch(e => {}));
     }
     if (contextOptions.bypassCSP)
       promises.push(session.send('Page.setBypassCSP', { enabled: true }));
@@ -723,7 +723,7 @@ export class WKPage implements PageDelegate {
 
   private async _evaluateBindingScript(binding: PageBinding): Promise<void> {
     const script = this._bindingToScript(binding);
-    await Promise.all(this._page.frames().map(frame => frame.eval(script, {world: binding.world}).catch(e => {})));
+    await Promise.all(this._page.frames().map(frame => frame.evaluateExpression(script, false, {}, binding.world).catch(e => {})));
   }
 
   async evaluateOnNewDocument(script: string): Promise<void> {

--- a/tests/browsercontext-expose-function.spec.ts
+++ b/tests/browsercontext-expose-function.spec.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { JSHandle } from '..';
 import { contextTest as it, expect } from './config/browserTest';
 
 it('expose binding should work', async ({context}) => {
@@ -74,7 +73,7 @@ it('should be callable from-inside addInitScript', async ({context, server}) => 
 });
 
 it('exposeBindingHandle should work', async ({context}) => {
-  let target: JSHandle;
+  let target;
   await context.exposeBinding('logme', (source, t) => {
     target = t;
     return 17;

--- a/tests/page/page-expose-function.spec.ts
+++ b/tests/page/page-expose-function.spec.ts
@@ -250,22 +250,22 @@ it('should work with internal bindings', async ({page, toImpl, server, mode, bro
     foo = arg;
   }, 'utility');
   expect(await page.evaluate('!!window.foo')).toBe(false);
-  expect(await implPage.mainFrame().eval('!!window.foo', {world: 'utility'})).toBe(true);
+  expect(await implPage.mainFrame().evaluateExpression('!!window.foo', false, {}, 'utility')).toBe(true);
   expect(foo).toBe(undefined);
-  await implPage.mainFrame().eval('window.foo(123)', {world: 'utility'});
+  await implPage.mainFrame().evaluateExpression('window.foo(123)', false, {}, 'utility');
   expect(foo).toBe(123);
 
   // should work after reload
   await page.goto(server.EMPTY_PAGE);
   expect(await page.evaluate('!!window.foo')).toBe(false);
-  await implPage.mainFrame().eval('window.foo(456)', {world: 'utility'});
+  await implPage.mainFrame().evaluateExpression('window.foo(456)', false, {}, 'utility');
   expect(foo).toBe(456);
 
   // should work inside frames
   const frame = await attachFrame(page, 'myframe', server.CROSS_PROCESS_PREFIX + '/empty.html');
   expect(await frame.evaluate('!!window.foo')).toBe(false);
   const implFrame: import('../../src/server/frames').Frame = toImpl(frame);
-  await implFrame.eval('window.foo(789)', {world: 'utility'});
+  await implFrame.evaluateExpression('window.foo(789)', false, {}, 'utility');
   expect(foo).toBe(789);
 });
 


### PR DESCRIPTION
This reverts commit 7a5ef0d157d57b9ebb04f8387956f1ef365badc2.

This broke the following which was working in Python:

```py
import asyncio
from playwright.async_api import async_playwright

async def main():
    async with async_playwright() as p:
        browser = await p.chromium.launch()
        page = await browser.new_page()
        await page.goto("https://example.com")

        await page.route("**/", lambda route, _: route.fulfill(body="OK"))

        response = await page.evaluate("""async () => (await fetch("/")).text()""")
        assert response == "OK"
        print(response)

        await browser.close()

asyncio.run(main())
```

protocol logs:

```
SEND> {
  "id": 6,
  "guid": "frame@a28ad22eb2d5bcc31acd72118c816774",
  "method": "evaluateExpression",
  "params": {
    "expression": "async () => (await fetch(\"/\")).text()",
    "arg": {
      "value": {
        "v": "null"
      },
      "handles": []
    }
  },
---

RECV> {
  "id": 6,
  "result": {
    "value": {
      "v": "undefined"
    }
  }
}
```