### PR TITLE
feat(test-runner): support esm modules in more places

### DIFF
--- a/src/test/workerRunner.ts
+++ b/src/test/workerRunner.ts
@@ -58,7 +58,7 @@ export class WorkerRunner extends EventEmitter {
 
   async cleanup() {
     // We have to load the project to get the right deadline below.
-    this._loadIfNeeded();
+    await this._loadIfNeeded();
     // TODO: separate timeout for teardown?
     const result = await raceAgainstDeadline((async () => {
       await this._fixtureRunner.teardownScope('test');

--- a/src/test/workerRunner.ts
+++ b/src/test/workerRunner.ts
@@ -89,11 +89,11 @@ export class WorkerRunner extends EventEmitter {
     return this._project.config.timeout ? monotonicTime() + this._project.config.timeout : undefined;
   }
 
-  private _loadIfNeeded() {
+  private async _loadIfNeeded() {
     if (this._loader)
       return;
 
-    this._loader = Loader.deserialize(this._params.loader);
+    this._loader = await Loader.deserialize(this._params.loader);
     this._project = this._loader.projects()[this._params.projectIndex];
 
     this._projectNamePathSegment = sanitizeForFilePath(this._project.config.name);
@@ -115,7 +115,7 @@ export class WorkerRunner extends EventEmitter {
   async run(runPayload: RunPayload) {
     this._entries = new Map(runPayload.entries.map(e => [ e.testId, e ]));
 
-    this._loadIfNeeded();
+    await this._loadIfNeeded();
     const fileSuite = await this._loader.loadTestFile(runPayload.file);
     let anySpec: Spec | undefined;
     fileSuite.findSpec(spec => {

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -176,3 +176,42 @@ test('should throw a nice error if a js file uses import', async ({ runInlineTes
   expect(output).toContain('a.spec.js');
   expect(output).toContain('JavaScript files must end with .mjs to use import.');
 });
+
+test('should load esm when package.json has type module', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.js': `
+      //@no-header
+      import * as fs from 'fs';
+      export default { projects: [{name: 'foo'}] };
+    `,
+    'package.json': JSON.stringify({type: 'module'}),
+    'a.test.ts': `
+      const { test } = pwt;
+      test('check project name', ({}, testInfo) => {
+        expect(testInfo.project.name).toBe('foo');
+      });
+    `
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
+test('should load esm config files', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.mjs': `
+      //@no-header
+      import * as fs from 'fs';
+      export default { projects: [{name: 'foo'}] };
+    `,
+    'a.test.ts': `
+      const { test } = pwt;
+      test('check project name', ({}, testInfo) => {
+        expect(testInfo.project.name).toBe('foo');
+      });
+    `
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -76,7 +76,9 @@ async function writeFiles(testInfo: TestInfo, files: Files) {
     const isTypeScriptSourceFile = name.endsWith('.ts') && !name.endsWith('.d.ts');
     const isJSModule = name.endsWith('.mjs');
     const header = isTypeScriptSourceFile ? headerTS : (isJSModule ? headerMJS : headerJS);
-    if (/(spec|test)\.(js|ts|mjs)$/.test(name)) {
+    if (typeof files[name] === 'string' && files[name].includes('//@no-header')) {
+      await fs.promises.writeFile(fullName, files[name]);
+    } else if (/(spec|test)\.(js|ts|mjs)$/.test(name)) {
       const fileHeader = header + 'const { expect } = pwt;\n';
       await fs.promises.writeFile(fullName, fileHeader + files[name]);
     } else if (/\.(js|ts)$/.test(name) && !name.endsWith('d.ts')) {


### PR DESCRIPTION
This extends our .mjs support everywhere to include config files, globalSetup/teardown, and reporters.﻿

If a user has `"type": "module"` in thier package.json, today we will fail with an `ERR_REQUIRE_ESM` error.
This patch makes it so that we catch this error and instead load the file as a module. Performance impact
of the try-catch is minimal.
