### PR TITLE
test: unskip/unfixme tests which are in Chrome stable now

### DIFF
--- a/tests/browsercontext-base-url.spec.ts
+++ b/tests/browsercontext-base-url.spec.ts
@@ -34,6 +34,17 @@ it('should construct a new URL when a baseURL in browser.newPage is passed to pa
   await page.close();
 });
 
+it('should construct a new URL when a baseURL in browserType.launchPersistentContext is passed to page.goto', async function({browserType, server, createUserDataDir, browserOptions}) {
+  const userDataDir = await createUserDataDir();
+  const context = await browserType.launchPersistentContext(userDataDir, {
+    ...browserOptions,
+    baseURL: server.PREFIX,
+  });
+  const page = await context.newPage();
+  expect((await page.goto('/empty.html')).url()).toBe(server.EMPTY_PAGE);
+  await context.close();
+});
+
 it('should construct the URLs correctly when a baseURL without a trailing slash in browser.newPage is passed to page.goto', async function({browser, server}) {
   const page = await browser.newPage({
     baseURL: server.PREFIX + '/url-construction',
@@ -63,10 +74,10 @@ it('should not construct a new URL when valid URLs are passed', async function({
   expect((await page.goto(server.EMPTY_PAGE)).url()).toBe(server.EMPTY_PAGE);
 
   await page.goto('data:text/html,Hello world');
-  expect(await page.evaluate(() => window.location.href)).toBe('data:text/html,Hello world');
+  expect(page.url()).toBe('data:text/html,Hello world');
 
   await page.goto('about:blank');
-  expect(await page.evaluate(() => window.location.href)).toBe('about:blank');
+  expect(page.url()).toBe('about:blank');
   await page.close();
 });
 

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -471,9 +471,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should be able to cancel pending downloads', async ({browser, server, browserName, browserVersion}) => {
-    // The exact upstream change is in b449b5c, which still does not appear in the first few 91.* tags until 91.0.4437.0.
-    it.fixme(browserName === 'chromium' && Number(browserVersion.split('.')[0]) < 91, 'The upstream Browser.cancelDownload command is not available before Chrome 91');
+  it('should be able to cancel pending downloads', async ({browser, server}) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/downloadWithDelay">download</a>`);
     const [ download ] = await Promise.all([
@@ -486,9 +484,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should not fail explicitly to cancel a download even if that is already finished', async ({browser, server, browserName, browserVersion}) => {
-    // The exact upstream change is in b449b5c, which still does not appear in the first few 91.* tags until 91.0.4437.0.
-    it.fixme(browserName === 'chromium' && Number(browserVersion.split('.')[0]) < 91, 'The upstream Browser.cancelDownload command is not available before Chrome 91');
+  it('should not fail explicitly to cancel a download even if that is already finished', async ({browser, server}) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -149,9 +149,7 @@ it('should work with regular expression passed from a different context', async 
   expect(intercepted).toBe(true);
 });
 
-it('should not break remote worker importScripts', async ({ page, server, browserName, browserMajorVersion }) => {
-  it.fixme(browserName && browserMajorVersion < 91);
-
+it('should not break remote worker importScripts', async ({ page, server }) => {
   await page.route('**', async route => {
     await route.continue();
   });

--- a/tests/page/page-drag.spec.ts
+++ b/tests/page/page-drag.spec.ts
@@ -20,7 +20,6 @@ import { attachFrame } from '../config/utils';
 
 it.describe('Drag and drop', () => {
   it.skip(({isAndroid}) => isAndroid);
-  it.skip(({browserName, browserMajorVersion}) => browserName === 'chromium' && browserMajorVersion < 91);
 
   it('should work', async ({page, server}) => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');

--- a/tests/page/selectors-misc.spec.ts
+++ b/tests/page/selectors-misc.spec.ts
@@ -27,8 +27,7 @@ it('should work for open shadow roots', async ({page, server}) => {
   expect(await page.$$(`data-testid:light=foo`)).toEqual([]);
 });
 
-it('should click on links in shadow dom', async ({page, server, browserName, browserMajorVersion, isElectron, isAndroid}) => {
-  it.fixme(browserName === 'chromium' && browserMajorVersion < 91, 'Remove when crrev.com/864024 gets to the stable channel');
+it('should click on links in shadow dom', async ({page, server, isElectron, isAndroid}) => {
   it.fixme(isAndroid);
   it.fixme(isElectron);
 


### PR DESCRIPTION
drive-by some minor cleanups and a new TC.

Download.cancel is by that ready.