### PR TITLE
Use correct skip check when generating junit reports

### DIFF
--- a/src/test/reporters/junit.ts
+++ b/src/test/reporters/junit.ts
@@ -87,7 +87,7 @@ class JUnitReporter extends EmptyReporter {
 
     suite.findTest(test => {
       ++tests;
-      if (test.skipped)
+      if (test.status() == 'skipped')
         ++skipped;
       if (!test.ok())
         ++failures;
@@ -129,7 +129,7 @@ class JUnitReporter extends EmptyReporter {
     };
     entries.push(entry);
 
-    if (test.skipped) {
+    if (test.status() == 'skipped') {
       entry.children.push({ name: 'skipped'});
       return;
     }

--- a/src/test/reporters/junit.ts
+++ b/src/test/reporters/junit.ts
@@ -87,7 +87,7 @@ class JUnitReporter extends EmptyReporter {
 
     suite.findTest(test => {
       ++tests;
-      if (test.status() == 'skipped')
+      if (test.status() === 'skipped')
         ++skipped;
       if (!test.ok())
         ++failures;
@@ -129,7 +129,7 @@ class JUnitReporter extends EmptyReporter {
     };
     entries.push(entry);
 
-    if (test.status() == 'skipped') {
+    if (test.status() === 'skipped') {
       entry.children.push({ name: 'skipped'});
       return;
     }


### PR DESCRIPTION
Use the correct skip check when generating junit reports.
This should address the issue mentioned in https://github.com/microsoft/playwright/issues/7568