### PR TITLE
browser(firefox): introduce auto-open-devtools-for-tabs CLI flag

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1268
-Changed: lushnikov@chromium.org Thu 01 Jul 2021 03:59:44 AM PDT
+1269
+Changed: max@schmitt.mx Tue Jul 13 16:28:05 UTC 2021

--- a/browser_patches/firefox-beta/patches/bootstrap.diff
+++ b/browser_patches/firefox-beta/patches/bootstrap.diff
@@ -171,6 +171,67 @@ index 040c7b124dec6bb254563bbe74fe50012cb077a3..b4e6b8132786af70e8ad0dce88b67c28
  
    const transportProvider = {
      setListener(upgradeListener) {
+diff --git a/devtools/startup/DevToolsStartup.jsm b/devtools/startup/DevToolsStartup.jsm
+index 2c1f767f89f596fb5732572ad4e0cad3cafcc7c3..99401071ad93a2f2a3ba37e7643920f2e05e8b25 100644
+--- a/devtools/startup/DevToolsStartup.jsm
++++ b/devtools/startup/DevToolsStartup.jsm
+@@ -375,7 +375,7 @@ DevToolsStartup.prototype = {
+ 
+       // Store devtoolsFlag to check it later in onWindowReady.
+       this.devtoolsFlag = flags.devtools;
+-
++      this.autoOpenDevtoolsForTabs = flags.autoOpenDevtoolsForTabs;
+       /* eslint-disable mozilla/balanced-observers */
+       // We are not expecting to remove those listeners until Firefox closes.
+ 
+@@ -438,6 +438,7 @@ DevToolsStartup.prototype = {
+ 
+     const console = cmdLine.handleFlag("jsconsole", false);
+     const devtools = cmdLine.handleFlag("devtools", false);
++    const autoOpenDevtoolsForTabs = cmdLine.handleFlag("auto-open-devtools-for-tabs", false);
+ 
+     let devToolsServer;
+     try {
+@@ -460,7 +461,7 @@ DevToolsStartup.prototype = {
+       debuggerFlag = cmdLine.handleFlag("jsdebugger", false);
+     }
+ 
+-    return { console, debugger: debuggerFlag, devtools, devToolsServer };
++    return { console, debugger: debuggerFlag, devtools, autoOpenDevtoolsForTabs, devToolsServer };
+   },
+ 
+   /**
+@@ -482,9 +483,22 @@ DevToolsStartup.prototype = {
+       this._firstWindowReadyReceived = true;
+     }
+ 
++    if (this.autoOpenDevtoolsForTabs) {
++      this.handleDevToolsOpenForEveryTab(window);
++    }
++
+     JsonView.initialize();
+   },
+ 
++  handleDevToolsOpenForEveryTab(window) {
++    const require = this.initDevTools("CommandLine");
++    const { gDevTools } = require("devtools/client/framework/devtools");
++    window.gBrowser.tabContainer.addEventListener('TabOpen', async (event) => {
++      await gDevTools.showToolboxForTab(event.target);
++    });
++    gDevTools.showToolboxForTab(window.gBrowser.selectedTab).catch(() => {});
++  },
++
+   removeDevToolsMenus(window) {
+     // This will hide the "Tools > Web Developer" menu.
+     window.document.getElementById("webDeveloperMenu").hidden = true;
+@@ -1243,6 +1257,7 @@ DevToolsStartup.prototype = {
+     "                     Enables debugging (some) application startup code paths.\n" +
+     "                     Only has an effect when `--jsdebugger` is also supplied.\n" +
+     "  --devtools         Open DevTools on initial load.\n" +
++    "  --auto-open-devtools-for-tabs Open DevTools on new Tabs.\n" +
+     "  --start-debugger-server [ws:][ <port> | <path> ] Start the devtools server on\n" +
+     "                     a TCP port or Unix domain socket path. Defaults to TCP port\n" +
+     "                     6000. Use WebSocket protocol if ws: prefix is specified.\n",
 diff --git a/docshell/base/BrowsingContext.cpp b/docshell/base/BrowsingContext.cpp
 index 0093288d1a448afe7bd8e5b6e8c0cb31835ba3f5..93908f5719f2cb0fe2f58d7f3153a9af0e71f08b 100644
 --- a/docshell/base/BrowsingContext.cpp

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1275
-Changed: yurys@chromium.org Thu Jul  8 13:25:54 MSK 2021
+1276
+Changed: max@schmitt.mx Tue Jul 13 13:50:07 UTC 2021

--- a/browser_patches/firefox/patches/bootstrap.diff
+++ b/browser_patches/firefox/patches/bootstrap.diff
@@ -171,6 +171,67 @@ index 040c7b124dec6bb254563bbe74fe50012cb077a3..b4e6b8132786af70e8ad0dce88b67c28
  
    const transportProvider = {
      setListener(upgradeListener) {
+diff --git a/devtools/startup/DevToolsStartup.jsm b/devtools/startup/DevToolsStartup.jsm
+index e583547c071167d1072d2022ceec506e87647e50..138c28f76ffe9796b858796b54739e9a97822952 100644
+--- a/devtools/startup/DevToolsStartup.jsm
++++ b/devtools/startup/DevToolsStartup.jsm
+@@ -375,7 +375,7 @@ DevToolsStartup.prototype = {
+ 
+       // Store devtoolsFlag to check it later in onWindowReady.
+       this.devtoolsFlag = flags.devtools;
+-
++      this.autoOpenDevtoolsForTabs = flags.autoOpenDevtoolsForTabs;
+       /* eslint-disable mozilla/balanced-observers */
+       // We are not expecting to remove those listeners until Firefox closes.
+ 
+@@ -438,6 +438,7 @@ DevToolsStartup.prototype = {
+ 
+     const console = cmdLine.handleFlag("jsconsole", false);
+     const devtools = cmdLine.handleFlag("devtools", false);
++    const autoOpenDevtoolsForTabs = cmdLine.handleFlag("auto-open-devtools-for-tabs", false);
+ 
+     let devToolsServer;
+     try {
+@@ -460,7 +461,7 @@ DevToolsStartup.prototype = {
+       debuggerFlag = cmdLine.handleFlag("jsdebugger", false);
+     }
+ 
+-    return { console, debugger: debuggerFlag, devtools, devToolsServer };
++    return { console, debugger: debuggerFlag, devtools, autoOpenDevtoolsForTabs, devToolsServer };
+   },
+ 
+   /**
+@@ -482,9 +483,22 @@ DevToolsStartup.prototype = {
+       this._firstWindowReadyReceived = true;
+     }
+ 
++    if (this.autoOpenDevtoolsForTabs) {
++      this.handleDevToolsOpenForEveryTab(window);
++    }
++
+     JsonView.initialize();
+   },
+ 
++  handleDevToolsOpenForEveryTab(window) {
++    const require = this.initDevTools("CommandLine");
++    const { gDevTools } = require("devtools/client/framework/devtools");
++    window.gBrowser.tabContainer.addEventListener('TabOpen', async (event) => {
++      await gDevTools.showToolboxForTab(event.target);
++    });
++    gDevTools.showToolboxForTab(window.gBrowser.selectedTab).catch(() => {});
++  },
++
+   removeDevToolsMenus(window) {
+     // This will hide the "Tools > Web Developer" menu.
+     window.document.getElementById("webDeveloperMenu").hidden = true;
+@@ -1250,6 +1264,7 @@ DevToolsStartup.prototype = {
+     "                     Enables debugging (some) application startup code paths.\n" +
+     "                     Only has an effect when `--jsdebugger` is also supplied.\n" +
+     "  --devtools         Open DevTools on initial load.\n" +
++    "  --auto-open-devtools-for-tabs Open DevTools on new Tabs.\n" +
+     "  --start-debugger-server [ws:][ <port> | <path> ] Start the devtools server on\n" +
+     "                     a TCP port or Unix domain socket path. Defaults to TCP port\n" +
+     "                     6000. Use WebSocket protocol if ws: prefix is specified.\n",
 diff --git a/docshell/base/BrowsingContext.cpp b/docshell/base/BrowsingContext.cpp
 index f3292d8ae6da1865847ded8b1c79a80ba8fca70e..70a0aacfe2439bb8180f2f069f9e0db7059265ce 100644
 --- a/docshell/base/BrowsingContext.cpp


### PR DESCRIPTION
This adds support for the `auto-open-devtools-for-tabs` CLI flag like its implemented in Chromium. We then can use this to provide support for the `devtools: true` flag when launching Firefox.

Works fine in general except when you are creating a page and closing it's context in a short time interval (when it was not fully initialised) it leads to a broken open devtools instance (white window). I tried to fix it but was not able to, probably we can live with it.

https://github.com/mxschmitt/gecko-dev/commit/478dab6f4992660d9e93ef9ff6ab86ff5ac29a47