### PR TITLE
devops: enforce hard xcode version match for browser builds

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -13,6 +13,7 @@ EOF
 )
 
 SCRIPT_PATH=$(pwd -P)
+source "${SCRIPT_FOLDER}/../utils.sh"
 
 main() {
   if [[ $1 == "--help" || $1 == "-h" ]]; then
@@ -44,12 +45,7 @@ compile_chromium() {
 
   if [[ $1 == "--compile-mac"* ]]; then
     # As of Jan, 2021 Chromium mac compilation requires Xcode12.2
-    if [[ ! -d /Applications/Xcode12.2.app ]]; then
-      echo "ERROR: chromium mac compilation requires /Applications/Xcode12.2.app"
-      echo "Download one from https://developer.apple.com/download/more/"
-      exit 1
-    fi
-    export DEVELOPER_DIR=/Applications/Xcode12.2.app/Contents/Developer
+    selectXcodeVersionOrDie "12.2"
     # As of Jan, 2021 Chromium mac compilation is only possible on Intel macbooks.
     # See https://chromium.googlesource.com/chromium/src.git/+/master/docs/mac_arm64.md
     if [[ $1 == "--compile-mac-arm64" && $(uname -m) != "x86_64" ]]; then

--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1269
-Changed: max@schmitt.mx Tue Jul 13 16:28:05 UTC 2021
+1270
+Changed: aslushnikov@gmail.com Tue Jul 13 16:28:05 UTC 2021

--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -13,6 +13,7 @@ trap "cd $(pwd -P)" EXIT
 
 cd "$(dirname $0)"
 SCRIPT_FOLDER="$(pwd -P)"
+source "${SCRIPT_FOLDER}/../utils.sh"
 
 if [[ ! -z "${FF_CHECKOUT_PATH}" ]]; then
   cd "${FF_CHECKOUT_PATH}"
@@ -24,21 +25,21 @@ fi
 rm -rf .mozconfig
 
 if [[ "$(uname)" == "Darwin" ]]; then
-  if [[ $(uname -m) == "arm64" ]]; then
-    # Building on Apple Silicon requires XCode12.2 and does not require any extra SDKs.
-    if ! [[ -d "/Applications/Xcode12.2.app" ]]; then
-      echo "As of Jan 2021, building Firefox on Apple Silicon requires XCode 12.2"
-      echo "Make sure there's an /Applications/Xcode12.2.app"
-      echo "Download XCode from https://developer.apple.com/download/more/"
-      echo ""
-      exit 1
-    fi
-    export DEVELOPER_DIR=/Applications/Xcode12.2.app/Contents/Developer
+  CURRENT_HOST_OS_VERSION=$(getMacVersion)
+  if [[ "${CURRENT_HOST_OS_VERSION}" == "10.14" ]]; then
+    selectXcodeVersionOrDie "11.3.1"
+  elif [[ "${CURRENT_HOST_OS_VERSION}" == "11."* ]]; then
+    # As of Jan 2021, building Firefox on Apple Silicon requires XCode 12.2
+    selectXcodeVersionOrDie "12.2"
   else
-    # Firefox currently does not build on 10.15 out of the box - it requires SDK for 10.12.
+    echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"
+    exit 1
+  fi
+  if [[ "${CURRENT_HOST_OS_VERSION}" == "10."* ]]; then
+    # Firefox currently does not build on 10.14 or 10.15 out of the box - it requires SDK for 10.12.
     # Make sure the SDK is out there.
     if ! [[ -d $HOME/SDK-archive/MacOSX${MACOS_SDK_VERSION}.sdk ]]; then
-      echo "As of Dec 2020, Firefox does not build on Mac without ${MACOS_SDK_VERSION} SDK."
+      echo "As of Dec 2020, Firefox does not build on Mac ${CURRENT_HOST_OS_VERSION} without ${MACOS_SDK_VERSION} SDK."
       echo "Download XCode ${XCODE_VERSION_WITH_REQUIRED_SDK_VERSION} from https://developer.apple.com/download/more/ and"
       echo "extract SDK to $HOME/SDK-archive/MacOSX${MACOS_SDK_VERSION}.sdk"
       echo ""

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1276
-Changed: max@schmitt.mx Tue Jul 13 13:50:07 UTC 2021
+1277
+Changed: aslushnikov@gmail.com Tue Jul 13 16:28:05 UTC 2021

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -13,6 +13,7 @@ trap "cd $(pwd -P)" EXIT
 
 cd "$(dirname $0)"
 SCRIPT_FOLDER="$(pwd -P)"
+source "${SCRIPT_FOLDER}/../utils.sh"
 
 if [[ ! -z "${FF_CHECKOUT_PATH}" ]]; then
   cd "${FF_CHECKOUT_PATH}"
@@ -24,21 +25,21 @@ fi
 rm -rf .mozconfig
 
 if [[ "$(uname)" == "Darwin" ]]; then
-  if [[ $(uname -m) == "arm64" ]]; then
-    # Building on Apple Silicon requires XCode12.2 and does not require any extra SDKs.
-    if ! [[ -d "/Applications/Xcode12.2.app" ]]; then
-      echo "As of Jan 2021, building Firefox on Apple Silicon requires XCode 12.2"
-      echo "Make sure there's an /Applications/Xcode12.2.app"
-      echo "Download XCode from https://developer.apple.com/download/more/"
-      echo ""
-      exit 1
-    fi
-    export DEVELOPER_DIR=/Applications/Xcode12.2.app/Contents/Developer
+  CURRENT_HOST_OS_VERSION=$(getMacVersion)
+  if [[ "${CURRENT_HOST_OS_VERSION}" == "10.14" ]]; then
+    selectXcodeVersionOrDie "11.3.1"
+  elif [[ "${CURRENT_HOST_OS_VERSION}" == "11."* ]]; then
+    # As of Jan 2021, building Firefox on Apple Silicon requires XCode 12.2
+    selectXcodeVersionOrDie "12.2"
   else
-    # Firefox currently does not build on 10.15 out of the box - it requires SDK for 10.12.
+    echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"
+    exit 1
+  fi
+  if [[ "${CURRENT_HOST_OS_VERSION}" == "10."* ]]; then
+    # Firefox currently does not build on 10.14 or 10.15 out of the box - it requires SDK for 10.12.
     # Make sure the SDK is out there.
     if ! [[ -d $HOME/SDK-archive/MacOSX${MACOS_SDK_VERSION}.sdk ]]; then
-      echo "As of Dec 2020, Firefox does not build on Mac without ${MACOS_SDK_VERSION} SDK."
+      echo "As of Dec 2020, Firefox does not build on Mac ${CURRENT_HOST_OS_VERSION} without ${MACOS_SDK_VERSION} SDK."
       echo "Download XCode ${XCODE_VERSION_WITH_REQUIRED_SDK_VERSION} from https://developer.apple.com/download/more/ and"
       echo "extract SDK to $HOME/SDK-archive/MacOSX${MACOS_SDK_VERSION}.sdk"
       echo ""

--- a/browser_patches/utils.sh
+++ b/browser_patches/utils.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+function getMacVersion() {
+  sw_vers -productVersion | grep -o '^\d\+.\d\+'
+}
+
+function selectXcodeVersionOrDie() {
+  XCODE_VERSION="$1"
+  if [[ -z "${XCODE_VERSION}" ]]; then
+    echo "selectXcodeOrDie expects xcode vesion to be given!"
+    exit 1
+  fi
+  XCODE_DIRECTORY="/Applications/Xcode${XCODE_VERSION}.app"
+  if ! [[ -d "${XCODE_DIRECTORY}" ]]; then
+    echo "ERROR: Xcode ${XCODE_VERSION} is required to compile!"
+    echo
+    echo "Either:"
+    echo
+    echo "- download required Xcode version from the developer.apple.com/downloads"
+    echo "  once downloaded, make sure to run the following:"
+    echo
+    echo "     $ cd ${XCODE_DIRECTORY}/Contents/Resources/Packages"
+    echo "     $ sudo installer -pkg XcodeSystemResources.pkg -target /"
+    echo
+    echo "- if you have some Xcode installation and want to try building with it:"
+    echo
+    echo "     $ ln -s /Applications/Xcode.app ${XCODE_DIRECTORY}"
+    exit 1
+  fi
+  # This line sets XCode for all nested bash processes.
+  export DEVELOPER_DIR="${XCODE_DIRECTORY}/Contents/Developer"
+  echo "-- using ${XCODE_DIRECTORY}"
+}

--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1511
-Changed: pavel.feldman@gmail.com Wed Jul 14 03:36:24 MSK 2021
+1512
+Changed: aslushnikov@gmail.com Tue Jul 13 17:11:05 UTC 2021

--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -5,6 +5,7 @@ set +x
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname $0)"
 SCRIPT_FOLDER="$(pwd -P)"
+source "${SCRIPT_FOLDER}/../utils.sh"
 
 build_gtk() {
   if ! [[ -d ./WebKitBuild/GTK/DependenciesGTK ]]; then
@@ -43,6 +44,15 @@ else
 fi
 
 if [[ "$(uname)" == "Darwin" ]]; then
+  CURRENT_HOST_OS_VERSION=$(getMacVersion)
+  if [[ "${CURRENT_HOST_OS_VERSION}" == "10.15" ]]; then
+    selectXcodeVersionOrDie "11.7"
+  elif [[ "${CURRENT_HOST_OS_VERSION}" == "11."* ]]; then
+    selectXcodeVersionOrDie "12.2"
+  else
+    echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"
+    exit 1
+  fi
   ./Tools/Scripts/build-webkit --release --touch-events --orientation-events
 elif [[ "$(uname)" == "Linux" ]]; then
   if [[ $# == 0 || (-z "$1") ]]; then

--- a/browser_patches/webkit/pw_run.sh
+++ b/browser_patches/webkit/pw_run.sh
@@ -2,7 +2,9 @@
 
 function runOSX() {
   # if script is run as-is
-  if [[ -d $SCRIPT_PATH/checkout/WebKitBuild/Release/Playwright.app ]]; then
+  if [[ -f "${SCRIPT_PATH}/EXPECTED_BUILDS" && -n "$WK_CHECKOUT_PATH" -d "$WK_CHECKOUT_PATH/WebKitBuild/Release/Playwright.app" ]]; then
+    DYLIB_PATH="$WK_CHECKOUT_PATH/WebKitBuild/Release"
+  elif [[ -f "${SCRIPT_PATH}/EXPECTED_BUILDS" && -d $SCRIPT_PATH/checkout/WebKitBuild/Release/Playwright.app ]]; then
     DYLIB_PATH="$SCRIPT_PATH/checkout/WebKitBuild/Release"
   elif [[ -d $SCRIPT_PATH/Playwright.app ]]; then
     DYLIB_PATH="$SCRIPT_PATH"


### PR DESCRIPTION
Browsers require particular xcode versions to be installed on the host
machine to produce successful build.

This patch starts using explicit xcode versions for all mac browser
builds.
