### PR TITLE
feat(test-runner): implement test.step

### DIFF
--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -297,6 +297,54 @@ To update your golden files, you can use the `--update-snapshots` parameter.
 npx playwright test --update-snapshots
 ```
 
+### Use test steps
+
+If you have a long test, it will be useful to annotate different steps in the test. This way you can follow along while the test is running and get an exact step that failed.
+
+```js js-flavor=js
+const { test, expect } = require('@playwright/test');
+
+test('example test', async ({ page }) => {
+  await test.step('Sign in', async () => {
+    await page.fill('#username', 'Username');
+    await page.fill('#password', 'Password');
+    await page.click('text=Sign in');
+  });
+
+  await test.step('Go to cart', async () => {
+    await page.click('text=Cart');
+    // Do more actions...
+  });
+
+  // Do more steps...
+});
+```
+
+```js js-flavor=ts
+import { test, expect } from '@playwright/test';
+
+test('example test', async ({ page }) => {
+  await test.step('Sign in', async () => {
+    await page.fill('#username', 'Username');
+    await page.fill('#password', 'Password');
+    await page.click('text=Sign in');
+  });
+
+  await test.step('Go to cart', async () => {
+    await page.click('text=Cart');
+    // Do more actions...
+  });
+
+  // Do more steps...
+});
+```
+
+Here is a sample output from the `list` reporter:
+```bash
+  ✓ example.spec.ts:9:6 › [chromium] example test
+    example.spec.ts:9:6 › [firefox] example test › Go to cart
+  ✘ 1) example.spec.ts:9:6 › [webkit] example test › Sign in (419ms)
+```
 
 ## Learn the command line
 

--- a/docs/src/test-annotations.md
+++ b/docs/src/test-annotations.md
@@ -119,6 +119,55 @@ Or if you want the opposite, you can skip the tests with a certain tag:
 npx playwright test --grep-invert @slow
 ```
 
+## Use test steps
+
+If you have a long test, it will be useful to annotate different steps in the test. This way you can follow along while the test is running and get an exact step that failed.
+
+```js js-flavor=js
+const { test, expect } = require('@playwright/test');
+
+test('example test', async ({ page }) => {
+  await test.step('Sign in', async () => {
+    await page.fill('#username', 'Username');
+    await page.fill('#password', 'Password');
+    await page.click('text=Sign in');
+  });
+
+  await test.step('Go to cart', async () => {
+    await page.click('text=Cart');
+    // Do more actions...
+  });
+
+  // Do more steps...
+});
+```
+
+```js js-flavor=ts
+import { test, expect } from '@playwright/test';
+
+test('example test', async ({ page }) => {
+  await test.step('Sign in', async () => {
+    await page.fill('#username', 'Username');
+    await page.fill('#password', 'Password');
+    await page.click('text=Sign in');
+  });
+
+  await test.step('Go to cart', async () => {
+    await page.click('text=Cart');
+    // Do more actions...
+  });
+
+  // Do more steps...
+});
+```
+
+Here is a sample output from the `list` reporter:
+```bash
+  ✓ example.spec.ts:9:6 › [chromium] example test
+    example.spec.ts:9:6 › [firefox] example test › Go to cart
+  ✘ 1) example.spec.ts:9:6 › [webkit] example test › Sign in (419ms)
+```
+
 ## Conditionally skip a group of tests
 
 For example, you can run a group of tests just in Chromium by passing a callback.

--- a/src/test/ipc.ts
+++ b/src/test/ipc.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import type { TestError } from './reporter';
-import type { Config, TestStatus } from './types';
+import type { Config, TestStatus, TestError } from './types';
 
 export type SerializedLoaderData = {
   defaultConfig: Config;
@@ -34,11 +33,24 @@ export type TestBeginPayload = {
   workerIndex: number,
 };
 
+export type TestStepBeginPayload = {
+  testId: string;
+  title: string;
+  stepId: string;
+  parentId?: string;
+};
+
+export type TestStepEndPayload = {
+  testId: string;
+  stepId: string;
+};
+
 export type TestEndPayload = {
   testId: string;
   duration: number;
   status: TestStatus;
   error?: TestError;
+  errorStepId?: string;
   expectedStatus: TestStatus;
   annotations: { type: string, description?: string }[];
   timeout: number;

--- a/src/test/reporter.ts
+++ b/src/test/reporter.ts
@@ -57,18 +57,26 @@ export interface TestResult {
   duration: number;
   status?: TestStatus;
   error?: TestError;
+  errorStep?: TestStep;
   data: { [key: string]: any };
   stdout: (string | Buffer)[];
   stderr: (string | Buffer)[];
+  steps: TestStep[];
 }
-export type FullResult = {
+export interface TestStep {
+  title: string;
+  steps: TestStep[];
+  titlePath(): string[];
+}
+export interface FullResult {
   status: 'passed' | 'failed' | 'timedout' | 'interrupted';
-};
+}
 export interface Reporter {
   onBegin(config: FullConfig, suite: Suite): void;
   onTestBegin(test: Test): void;
   onStdOut(chunk: string | Buffer, test?: Test): void;
   onStdErr(chunk: string | Buffer, test?: Test): void;
+  onTestStep(test: Test, step?: TestStep): void;
   onTestEnd(test: Test, result: TestResult): void;
   onError(error: TestError): void;
   onEnd(result: FullResult): void | Promise<void>;

--- a/src/test/reporters/empty.ts
+++ b/src/test/reporters/empty.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import { FullConfig, TestResult, Test, Suite, TestError, Reporter, FullResult } from '../reporter';
+import { FullConfig, TestResult, Test, Suite, TestError, Reporter, FullResult, TestStep } from '../reporter';
 
 class EmptyReporter implements Reporter {
   onBegin(config: FullConfig, suite: Suite) {}
   onTestBegin(test: Test) {}
   onStdOut(chunk: string | Buffer, test?: Test) {}
   onStdErr(chunk: string | Buffer, test?: Test) {}
+  onTestStep(test: Test, step?: TestStep) {}
   onTestEnd(test: Test, result: TestResult) {}
   onError(error: TestError) {}
   async onEnd(result: FullResult) {}

--- a/src/test/reporters/json.ts
+++ b/src/test/reporters/json.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 import EmptyReporter from './empty';
-import { FullConfig, Test, Suite, Spec, TestResult, TestError, FullResult, TestStatus } from '../reporter';
+import { FullConfig, Test, Suite, Spec, TestResult, TestError, FullResult, TestStatus, TestStep } from '../reporter';
 
 export interface JSONReport {
   config: Omit<FullConfig, 'projects'> & {
@@ -69,6 +69,11 @@ export interface JSONReportTestResult {
   stderr: JSONReportSTDIOEntry[],
   retry: number;
   data: { [key: string]: any },
+  steps: JSONReportTestStep[];
+}
+export interface JSONReportTestStep {
+  title: string;
+  steps: JSONReportTestStep[];
 }
 export type JSONReportSTDIOEntry = { text: string } | { buffer: string };
 
@@ -170,6 +175,14 @@ class JSONReporter extends EmptyReporter {
       stderr: result.stderr.map(s => stdioEntry(s)),
       retry: result.retry,
       data: result.data,
+      steps: result.steps.map(s => this._serializeTestStep(s)),
+    };
+  }
+
+  private _serializeTestStep(step: TestStep): JSONReportTestStep {
+    return {
+      title: step.title,
+      steps: step.steps.map(s => this._serializeTestStep(s)),
     };
   }
 }

--- a/src/test/reporters/multiplexer.ts
+++ b/src/test/reporters/multiplexer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FullConfig, Suite, Test, TestError, TestResult, Reporter, FullResult } from '../reporter';
+import { FullConfig, Suite, Test, TestError, TestResult, Reporter, FullResult, TestStep } from '../reporter';
 
 export class Multiplexer implements Reporter {
   private _reporters: Reporter[];
@@ -41,6 +41,11 @@ export class Multiplexer implements Reporter {
   onStdErr(chunk: string | Buffer, test?: Test) {
     for (const reporter of this._reporters)
       reporter.onStdErr(chunk, test);
+  }
+
+  onTestStep(test: Test, step?: TestStep) {
+    for (const reporter of this._reporters)
+      reporter.onTestStep(test, step);
   }
 
   onTestEnd(test: Test, result: TestResult) {

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -228,8 +228,25 @@ export class Test implements reporterTypes.Test {
       stdout: [],
       stderr: [],
       data: {},
+      steps: [],
     };
     this.results.push(result);
     return result;
+  }
+}
+
+export class TestStep implements reporterTypes.TestStep {
+  title: string = '';
+  steps: TestStep[] = [];
+
+  _parent?: TestStep;
+  _id: string = '';
+  _ended = false;
+
+  titlePath(): string[] {
+    const titles = this._parent ? this._parent.titlePath() : [];
+    if (this.title)
+      titles.push(this.title);
+    return titles;
   }
 }

--- a/src/test/testType.ts
+++ b/src/test/testType.ts
@@ -49,6 +49,7 @@ export class TestTypeImpl {
     test.slow = wrapFunctionWithLocation(this._modifier.bind(this, 'slow'));
     test.setTimeout = this._setTimeout.bind(this);
     test.use = wrapFunctionWithLocation(this._use.bind(this));
+    test.step = wrapFunctionWithLocation(this._step.bind(this));
     test.extend = wrapFunctionWithLocation(this._extend.bind(this));
     test.declare = wrapFunctionWithLocation(this._declare.bind(this));
     this.test = test;
@@ -140,6 +141,13 @@ export class TestTypeImpl {
     if (!suite)
       throw new Error(`test.use() can only be called in a test file`);
     suite._fixtureOverrides = { ...suite._fixtureOverrides, ...fixtures };
+  }
+
+  private _step(location: Location, title: string, callback: () => any) {
+    const testInfo = currentTestInfo();
+    if (!testInfo)
+      throw new Error(`test.step() can only be called inside test`);
+    return testInfo.step(title, callback);
   }
 
   private _extend(location: Location, fixtures: Fixtures) {

--- a/src/test/worker.ts
+++ b/src/test/worker.ts
@@ -74,7 +74,7 @@ process.on('message', async message => {
     workerIndex = initParams.workerIndex;
     startProfiling();
     workerRunner = new WorkerRunner(initParams);
-    for (const event of ['testBegin', 'testEnd', 'done'])
+    for (const event of ['testBegin', 'testStepBegin', 'testStepEnd', 'testEnd', 'done'])
       workerRunner.on(event, sendMessageToParent.bind(null, event));
     return;
   }

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './playwright-test-fixtures';
+
+test('test.step should work', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      const { test } = pwt;
+
+      test('passed', async ({}) => {
+        expect(1).toBe(1);
+        await test.step('step 1', async () => {
+          expect(1).toBe(1);
+          console.log('should run 1.0');
+          await test.step('step 1.1', () => {
+            expect(1).toBe(1);
+            console.log('should run 1.1');
+          });
+          await test.step('step 1.2', () => {
+            expect(1).toBe(1);
+            console.log('should run 1.2');
+          });
+        });
+        await test.step('step 2', async () => {
+          expect(1).toBe(1);
+          console.log('should run 2');
+        });
+        console.log('should run end');
+      });
+
+      test('failed', async ({}) => {
+        expect(1).toBe(1);
+        await test.step('step 1', async () => {
+          expect(1).toBe(1);
+          await test.step('step 1.1', () => {
+            expect(1).toBe(2);
+          });
+          console.log('\\nshould not run');
+          await test.step('step 1.2', () => {
+            expect(1).toBe(1);
+          });
+        });
+        console.log('\\nshould not run');
+        await test.step('step 2', async () => {
+          expect(1).toBe(1);
+        });
+      });
+    `,
+  });
+
+  expect(result.passed).toBe(1);
+  expect(result.output).toContain('should run 1.0');
+  expect(result.output).toContain('should run 1.1');
+  expect(result.output).toContain('should run 1.2');
+  expect(result.output).toContain('should run 2');
+  expect(result.output).toContain('should run end');
+  expect(result.report.suites[0].specs[0].tests[0].results[0].steps).toEqual([
+    { title: 'step 1', steps: [{ title: 'step 1.1', steps: [] }, { title: 'step 1.2', steps: [] }] },
+    { title: 'step 2', steps: [] },
+  ]);
+
+  expect(result.failed).toBe(1);
+  expect(result.output).not.toContain('\nshould not run');
+  expect(result.report.suites[0].specs[1].tests[0].results[0].steps).toEqual([
+    { title: 'step 1', steps: [{ title: 'step 1.1', steps: [] }] },
+  ]);
+});

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -377,6 +377,11 @@ export interface TestInfo extends WorkerInfo {
   setTimeout(timeout: number): void;
 
   /**
+   * Mark a part of the test as a "step" with the given title.
+   */
+  step(title: string, callback: () => Promise<any> | any): Promise<void>;
+
+  /**
    * The expected status for the test:
    * - `'passed'` for most tests;
    * - `'failed'` for tests marked with `test.fail()`;
@@ -876,6 +881,29 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * When called inside a `test.describe()` block, fixtures/options only apply to the tests from the block.
    */
   use(fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs>): void;
+
+  /**
+   * Mark a part of the test as a "step" with the given title. Steps get a special treatment
+   * in reporters and other test tools. Step will wait for the callback to finish.
+   *
+   * ```js
+   * test('example test', async ({ page }) => {
+   *   await test.step('Sign in', async () => {
+   *     await page.fill('#username', 'Username');
+   *     await page.fill('#password', 'Password');
+   *     await page.click('text=Sign in');
+   *   });
+   *
+   *   await test.step('Go to cart', async () => {
+   *     await page.click('text=Cart');
+   *     // Do more actions...
+   *   });
+   *
+   *   // Do more steps...
+   * });
+   * ```
+   */
+  step(title: string, callback: () => Promise<any> | any): Promise<void>;
 
   /**
    * Use `test.expect(value).toBe(expected)` to assert something in the test.


### PR DESCRIPTION
```js
test('example test', async ({ page }) => {
  await test.step('Sign in', async () => {
    await page.fill('#username', 'Username');
    await page.fill('#password', 'Password');
    await page.click('text=Sign in');
  });
  ...
});
```

Test step title is printed next to the test title when available:

```sh
  ✓ example.spec.ts:9:6 › [chromium] example test
    example.spec.ts:9:6 › [firefox] example test › Go to cart › substep
  ✘ 1) example.spec.ts:9:6 › [webkit] example test › Sign in (419ms)
```