### PR TITLE
fix(test-runner): sanitize snapshot name before constructing a path

### DIFF
--- a/docs/src/test-snapshots.md
+++ b/docs/src/test-snapshots.md
@@ -47,6 +47,8 @@ Sometimes you need to update the reference screenshot, for example when the page
 npx playwright test --update-snapshots
 ```
 
+Note that `snapshotName` is *not a path* relative to the test file, so don't try to use it like `expect(value).toMatchSnapshot('../../test-snapshots/snapshot.png')`.
+
 Playwright Test uses the [pixelmatch](https://github.com/mapbox/pixelmatch) library. You can pass comparison `threshold` as an option.
 
 ```js js-flavor=js

--- a/src/test/workerRunner.ts
+++ b/src/test/workerRunner.ts
@@ -243,13 +243,11 @@ export class WorkerRunner extends EventEmitter {
           suffix += '-' + this._projectNamePathSegment;
         if (testInfo.snapshotSuffix)
           suffix += '-' + testInfo.snapshotSuffix;
-        if (suffix) {
-          const ext = path.extname(snapshotName);
-          if (ext)
-            snapshotName = snapshotName.substring(0, snapshotName.length - ext.length) + suffix + ext;
-          else
-            snapshotName += suffix;
-        }
+        const ext = path.extname(snapshotName);
+        if (ext)
+          snapshotName = sanitizeForFilePath(snapshotName.substring(0, snapshotName.length - ext.length)) + suffix + ext;
+        else
+          snapshotName = sanitizeForFilePath(snapshotName) + suffix;
         return path.join(spec._requireFile + '-snapshots', snapshotName);
       },
       skip: (...args: [arg?: any, description?: string]) => modifier(testInfo, 'skip', args),


### PR DESCRIPTION
This avoids problems with `toMatchSnapshot('../../dir/file.png')` where we append this path to `snapshotDir` and end up in some random place instead of snapshots directory.

Also added a note to documentation.

References #7614, #7609.