### PR TITLE
fix: add log entry if selector resolves to multiple elements on click

### DIFF
--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -938,15 +938,19 @@ export function waitForSelectorTask(selector: SelectorInfo, state: 'attached' | 
     let lastElement: Element | undefined;
 
     return injected.pollRaf((progress, continuePolling) => {
-      const element = injected.querySelector(parsed, root || document);
+      const elements = injected.querySelectorAll(parsed, root || document);
+      const element = elements[0];
       const visible = element ? injected.isVisible(element) : false;
 
       if (lastElement !== element) {
         lastElement = element;
-        if (!element)
+        if (!element) {
           progress.log(`  selector did not resolve to any element`);
-        else
+        } else {
+          if (elements.length > 1)
+            progress.log(`  selector resolved to ${elements.length} elements. Proceeding with the first one.`);
           progress.log(`  selector resolved to ${visible ? 'visible' : 'hidden'} ${injected.previewNode(element)}`);
+        }
       }
 
       switch (state) {

--- a/tests/page/page-wait-for-selector-1.spec.ts
+++ b/tests/page/page-wait-for-selector-1.spec.ts
@@ -169,6 +169,22 @@ it('should report logs while waiting for hidden', async ({page, server}) => {
   expect(error.message).toContain(`selector resolved to visible <div class="another">hello</div>`);
 });
 
+it('should report logs when the selector resolves to multiple elements', async ({page, server}) => {
+  await page.goto(server.EMPTY_PAGE);
+  await page.setContent(`
+    <button style="display: none; position: absolute; top: 0px; left: 0px; width: 100%;">
+      Reset
+    </button>
+    <button>
+      Reset
+    </button>
+  `);
+  const error = await page.click('text=Reset', {
+    timeout: 1000
+  }).catch(e => e);
+  expect(error.toString()).toContain('selector resolved to 2 elements. Proceeding with the first one.');
+});
+
 it('should resolve promise when node is added in shadow dom', async ({page, server}) => {
   await page.goto(server.EMPTY_PAGE);
   const watchdog = page.waitForSelector('span');


### PR DESCRIPTION
Should bring value in the trace viewer and when using debug logs.

~~Probably its better to get away from querySelector + querySelectorAll and use just querySelectorAll at the top?~~

Fixes #3264