### PR TITLE
chore(android): fix type in DeviceBackend

### DIFF
--- a/src/server/android/android.ts
+++ b/src/server/android/android.ts
@@ -40,7 +40,7 @@ export interface Backend {
 export interface DeviceBackend {
   serial: string;
   status: string;
-  close(): void;
+  close(): Promise<void>;
   init(): Promise<void>;
   runCommand(command: string): Promise<Buffer>;
   open(command: string): Promise<SocketBackend>;


### PR DESCRIPTION
Fixed method `close` type in DeviceBackend interface since the extended
implementation is designed as an async function.
