### PR TITLE
feat(keyboard): low level override for text produced by keyboard.down

### DIFF
--- a/docs/src/api/class-keyboard.md
+++ b/docs/src/api/class-keyboard.md
@@ -172,6 +172,16 @@ Modifier keys DO influence `keyboard.down`. Holding down `Shift` will type the t
 
 Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
 
+### option: Keyboard.down.key
+- `key` <[string]>
+
+Override the event.key property of this event.
+
+### option: Keyboard.down.text
+- `text` <[string]>
+
+Override the text produced by this event.
+
 ## async method: Keyboard.insertText
 
 Dispatches only `input` event, does not emit the `keydown`, `keyup` or `keypress` events.

--- a/src/client/input.ts
+++ b/src/client/input.ts
@@ -25,8 +25,8 @@ export class Keyboard implements api.Keyboard {
     this._channel = channel;
   }
 
-  async down(key: string) {
-    await this._channel.keyboardDown({ key });
+  async down(key: string, overrides: channels.PageKeyboardDownOptions['overrides']) {
+    await this._channel.keyboardDown({ key, overrides });
   }
 
   async up(key: string) {

--- a/src/dispatchers/pageDispatcher.ts
+++ b/src/dispatchers/pageDispatcher.ts
@@ -156,7 +156,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageInitializer> i
   }
 
   async keyboardDown(params: channels.PageKeyboardDownParams, metadata: CallMetadata): Promise<void> {
-    await this._page.keyboard.down(params.key);
+    await this._page.keyboard.down(params.key, params.overrides);
   }
 
   async keyboardUp(params: channels.PageKeyboardUpParams, metadata: CallMetadata): Promise<void> {

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -1108,9 +1108,16 @@ export type PageSetViewportSizeOptions = {
 export type PageSetViewportSizeResult = void;
 export type PageKeyboardDownParams = {
   key: string,
+  overrides?: {
+    key?: string,
+    text?: string,
+  },
 };
 export type PageKeyboardDownOptions = {
-
+  overrides?: {
+    key?: string,
+    text?: string,
+  },
 };
 export type PageKeyboardDownResult = void;
 export type PageKeyboardUpParams = {

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -844,6 +844,11 @@ Page:
     keyboardDown:
       parameters:
         key: string
+        overrides:
+          type: object?
+          properties:
+            key: string?
+            text: string?
       tracing:
         snapshot: true
 

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -473,6 +473,10 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   });
   scheme.PageKeyboardDownParams = tObject({
     key: tString,
+    overrides: tOptional(tObject({
+      key: tOptional(tString),
+      text: tOptional(tString),
+    })),
   });
   scheme.PageKeyboardUpParams = tObject({
     key: tString,

--- a/src/server/input.ts
+++ b/src/server/input.ts
@@ -50,14 +50,17 @@ export class Keyboard {
     this._page = page;
   }
 
-  async down(key: string) {
+  async down(key: string, options: { key?: string, text?: string} = {}) {
     const description = this._keyDescriptionForString(key);
     const autoRepeat = this._pressedKeys.has(description.code);
     this._pressedKeys.add(description.code);
     if (kModifiers.includes(description.key as types.KeyboardModifier))
       this._pressedModifiers.add(description.key as types.KeyboardModifier);
-    const text = description.text;
-    await this._raw.keydown(this._pressedModifiers, description.code, description.keyCode, description.keyCodeWithoutLocation, description.key, description.location, autoRepeat, text);
+    if (options.key !== undefined)
+      description.key = options.key;
+    if (options.text !== undefined)
+      description.text = options.text;
+    await this._raw.keydown(this._pressedModifiers, description.code, description.keyCode, description.keyCodeWithoutLocation, description.key, description.location, autoRepeat, description.text);
     await this._page._doSlowMo();
   }
 
@@ -70,7 +73,7 @@ export class Keyboard {
     // if any modifiers besides shift are pressed, no text should be sent
     if (this._pressedModifiers.size > 1 || (!this._pressedModifiers.has('Shift') && this._pressedModifiers.size === 1))
       return { ...description, text: '' };
-    return description;
+    return { ...description};
   }
 
   async up(key: string) {

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -440,6 +440,29 @@ it('should move to the start of the document', async ({page, isMac}) => {
   expect(await page.evaluate(() => window.getSelection().toString())).toBe('1\n2\n3\n');
 });
 
+it('should allow overriding the key and text', async ({page, isMac}) => {
+  const eventLogHandle = await page.evaluateHandle(() => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+    const eventLog = [];
+    textarea.addEventListener('keydown', event => {
+      eventLog.push({key: event.key, code: event.code});
+    });
+    return eventLog;
+  });
+  await page.keyboard.down('a', {text: 'b'});
+  await page.keyboard.down('s', {text: '', key: 'と'});
+  expect(await page.inputValue('textarea')).toBe('b');
+  expect(await eventLogHandle.jsonValue()).toEqual([{
+    code: 'KeyA',
+    key: 'a',
+  }, {
+    code: 'KeyS',
+    key: 'と',
+  }]);
+});
+
 async function captureLastKeydown(page) {
   const lastEvent = await page.evaluateHandle(() => {
     const lastEvent = {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -2070,8 +2070,9 @@ export interface Page {
   }): Promise<Buffer>;
 
   /**
-   * Focuses the element, and then uses [keyboard.down(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-down)
-   * and [keyboard.up(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-up).
+   * Focuses the element, and then uses
+   * [keyboard.down(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-down) and
+   * [keyboard.up(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-up).
    *
    * `key` can specify the intended [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)
    * value or a single character to generate the text for. A superset of the `key` values can be found
@@ -6096,8 +6097,9 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
   ownerFrame(): Promise<null|Frame>;
 
   /**
-   * Focuses the element, and then uses [keyboard.down(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-down)
-   * and [keyboard.up(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-up).
+   * Focuses the element, and then uses
+   * [keyboard.down(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-down) and
+   * [keyboard.up(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-up).
    *
    * `key` can specify the intended [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)
    * value or a single character to generate the text for. A superset of the `key` values can be found
@@ -9547,7 +9549,8 @@ export interface FileChooser {
  * [keyboard.type(text[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-type), which takes raw
  * characters and generates proper keydown, keypress/input, and keyup events on your page.
  *
- * For finer control, you can use [keyboard.down(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-down),
+ * For finer control, you can use
+ * [keyboard.down(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-down),
  * [keyboard.up(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-up), and
  * [keyboard.insertText(text)](https://playwright.dev/docs/api/class-keyboard#keyboard-insert-text) to manually fire events
  * as if they were generated from a real keyboard.
@@ -9607,14 +9610,25 @@ export interface Keyboard {
    * active. To release the modifier key, use [keyboard.up(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-up).
    *
    * After the key is pressed once, subsequent calls to
-   * [keyboard.down(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-down) will have
+   * [keyboard.down(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-down) will have
    * [repeat](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat) set to true. To release the key, use
    * [keyboard.up(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-up).
    *
    * > NOTE: Modifier keys DO influence `keyboard.down`. Holding down `Shift` will type the text in upper case.
    * @param key Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
+   * @param options
    */
-  down(key: string): Promise<void>;
+  down(key: string, options?: {
+    /**
+     * Override the event.key property of this event.
+     */
+    key?: string;
+
+    /**
+     * Override the text produced by this event.
+     */
+    text?: string;
+  }): Promise<void>;
 
   /**
    * Dispatches only `input` event, does not emit the `keydown`, `keyup` or `keypress` events.
@@ -9658,7 +9672,7 @@ export interface Keyboard {
    * await browser.close();
    * ```
    *
-   * Shortcut for [keyboard.down(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-down) and
+   * Shortcut for [keyboard.down(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-down) and
    * [keyboard.up(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-up).
    * @param key Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
    * @param options


### PR DESCRIPTION
This adds options to `keyboard.down` to override the `event.key` property of the event (for non-US layouts) and the `text` generated (for IME when certain keys will produce no text).

This is a draft to talk about the api. The finished version would need `key` in `keyboard.up` and `key`/`text` in `keyboard.press`. There is also a juggler patch needed to allow overriding the `text` to be blank.