### PR TITLE
chore(test-runner): misc changes to reporter api

### DIFF
--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -112,7 +112,7 @@ export class Loader {
     try {
       const suite = new Suite('');
       suite._requireFile = file;
-      suite.file = file;
+      suite.location.file = file;
       setCurrentlyLoadingFileSuite(suite);
       await this._requireOrImport(file);
       this._fileSuites.set(file, suite);

--- a/src/test/project.ts
+++ b/src/test/project.ts
@@ -60,17 +60,14 @@ export class ProjectImpl {
       if (Object.entries(overrides).length) {
         const overridesWithLocation = {
           fixtures: overrides,
-          location: {
-            file: test.file,
-            line: 1,  // TODO: capture location
-            column: 1,  // TODO: capture location
-          }
+          // TODO: pass location from test.use() callsite.
+          location: test.location,
         };
         pool = new FixturePool([overridesWithLocation], pool);
       }
       this.testPools.set(test, pool);
 
-      pool.validateFunction(test.fn, 'Test', true, test);
+      pool.validateFunction(test.fn, 'Test', true, test.location);
       for (let parent = test.parent; parent; parent = parent.parent) {
         for (const hook of parent._hooks)
           pool.validateFunction(hook.fn, hook.type + ' hook', hook.type === 'beforeEach' || hook.type === 'afterEach', hook.location);
@@ -98,7 +95,7 @@ export class ProjectImpl {
         test._workerHash = `run${this.index}-${pool.digest}-repeat${repeatEachIndex}`;
         test._id = `${entry._ordinalInFile}@${entry._requireFile}#run${this.index}-repeat${repeatEachIndex}`;
         test._pool = pool;
-        test._buildFullTitle(suite.fullTitle());
+        test._buildTitlePath(suite._titlePath);
         if (!filter(test))
           continue;
         result._addTest(test);

--- a/src/test/reporter.ts
+++ b/src/test/reporter.ts
@@ -17,29 +17,30 @@
 import type { FullConfig, TestStatus, TestError } from './types';
 export type { FullConfig, TestStatus, TestError } from './types';
 
+export interface Location {
+  file: string;
+  line: number;
+  column: number;
+}
 export interface Suite {
   title: string;
-  file: string;
-  line: number;
-  column: number;
+  location: Location;
   suites: Suite[];
   tests: Test[];
-  findTest(fn: (test: Test) => boolean | void): boolean;
-  totalTestCount(): number;
+  titlePath(): string[];
+  fullTitle(): string;
+  allTests(): Test[];
 }
 export interface Test {
-  suite: Suite;
   title: string;
-  file: string;
-  line: number;
-  column: number;
+  location: Location;
   results: TestResult[];
-  skipped: boolean;
   expectedStatus: TestStatus;
   timeout: number;
   annotations: { type: string, description?: string }[];
   projectName: string;
   retries: number;
+  titlePath(): string[];
   fullTitle(): string;
   status(): 'skipped' | 'expected' | 'unexpected' | 'flaky';
   ok(): boolean;
@@ -58,11 +59,11 @@ export interface FullResult {
   status: 'passed' | 'failed' | 'timedout' | 'interrupted';
 }
 export interface Reporter {
-  onBegin(config: FullConfig, suite: Suite): void;
-  onTestBegin(test: Test): void;
-  onStdOut(chunk: string | Buffer, test?: Test): void;
-  onStdErr(chunk: string | Buffer, test?: Test): void;
-  onTestEnd(test: Test, result: TestResult): void;
-  onError(error: TestError): void;
-  onEnd(result: FullResult): void | Promise<void>;
+  onBegin?(config: FullConfig, suite: Suite): void;
+  onTestBegin?(test: Test): void;
+  onStdOut?(chunk: string | Buffer, test?: Test): void;
+  onStdErr?(chunk: string | Buffer, test?: Test): void;
+  onTestEnd?(test: Test, result: TestResult): void;
+  onError?(error: TestError): void;
+  onEnd?(result: FullResult): void | Promise<void>;
 }

--- a/src/test/reporters/empty.ts
+++ b/src/test/reporters/empty.ts
@@ -14,16 +14,9 @@
  * limitations under the License.
  */
 
-import { FullConfig, TestResult, Test, Suite, TestError, Reporter, FullResult } from '../reporter';
+import { Reporter } from '../reporter';
 
 class EmptyReporter implements Reporter {
-  onBegin(config: FullConfig, suite: Suite) {}
-  onTestBegin(test: Test) {}
-  onStdOut(chunk: string | Buffer, test?: Test) {}
-  onStdErr(chunk: string | Buffer, test?: Test) {}
-  onTestEnd(test: Test, result: TestResult) {}
-  onError(error: TestError) {}
-  async onEnd(result: FullResult) {}
 }
 
 export default EmptyReporter;

--- a/src/test/reporters/line.ts
+++ b/src/test/reporters/line.ts
@@ -26,7 +26,7 @@ class LineReporter extends BaseReporter {
 
   onBegin(config: FullConfig, suite: Suite) {
     super.onBegin(config, suite);
-    this._total = suite.totalTestCount();
+    this._total = suite.allTests().length;
     console.log();
   }
 

--- a/src/test/reporters/list.ts
+++ b/src/test/reporters/list.ts
@@ -38,7 +38,6 @@ class ListReporter extends BaseReporter {
   }
 
   onTestBegin(test: Test) {
-    super.onTestBegin(test);
     if (process.stdout.isTTY) {
       if (this._needNewLine) {
         this._needNewLine = false;

--- a/src/test/reporters/multiplexer.ts
+++ b/src/test/reporters/multiplexer.ts
@@ -25,36 +25,36 @@ export class Multiplexer implements Reporter {
 
   onBegin(config: FullConfig, suite: Suite) {
     for (const reporter of this._reporters)
-      reporter.onBegin(config, suite);
+      reporter.onBegin?.(config, suite);
   }
 
   onTestBegin(test: Test) {
     for (const reporter of this._reporters)
-      reporter.onTestBegin(test);
+      reporter.onTestBegin?.(test);
   }
 
   onStdOut(chunk: string | Buffer, test?: Test) {
     for (const reporter of this._reporters)
-      reporter.onStdOut(chunk, test);
+      reporter.onStdOut?.(chunk, test);
   }
 
   onStdErr(chunk: string | Buffer, test?: Test) {
     for (const reporter of this._reporters)
-      reporter.onStdErr(chunk, test);
+      reporter.onStdErr?.(chunk, test);
   }
 
   onTestEnd(test: Test, result: TestResult) {
     for (const reporter of this._reporters)
-      reporter.onTestEnd(test, result);
+      reporter.onTestEnd?.(test, result);
   }
 
   async onEnd(result: FullResult) {
     for (const reporter of this._reporters)
-      await reporter.onEnd(result);
+      await reporter.onEnd?.(result);
   }
 
   onError(error: TestError) {
     for (const reporter of this._reporters)
-      reporter.onError(error);
+      reporter.onError?.(error);
   }
 }

--- a/src/test/testType.ts
+++ b/src/test/testType.ts
@@ -64,11 +64,9 @@ export class TestTypeImpl {
 
     const test = new Test(title, fn, ordinalInFile, this);
     test._requireFile = suite._requireFile;
-    test.file = location.file;
-    test.line = location.line;
-    test.column = location.column;
+    test.location = location;
     suite._addTest(test);
-    test._buildFullTitle(suite.fullTitle());
+    test._buildTitlePath(suite._titlePath);
 
     if (type === 'only')
       test._only = true;
@@ -81,11 +79,9 @@ export class TestTypeImpl {
 
     const child = new Suite(title);
     child._requireFile = suite._requireFile;
-    child.file = location.file;
-    child.line = location.line;
-    child.column = location.column;
+    child.location = location;
     suite._addSuite(child);
-    child._buildFullTitle(suite.fullTitle());
+    child._buildTitlePath(suite._titlePath);
 
     if (type === 'only')
       child._only = true;

--- a/src/test/types.ts
+++ b/src/test/types.ts
@@ -15,9 +15,10 @@
  */
 
 import type { Fixtures } from '../../types/test';
+import type { Location } from './reporter';
 export * from '../../types/test';
+export { Location } from './reporter';
 
-export type Location = { file: string, line: number, column: number };
 export type FixturesWithLocation = {
   fixtures: Fixtures;
   location: Location;

--- a/src/test/workerRunner.ts
+++ b/src/test/workerRunner.ts
@@ -218,9 +218,9 @@ export class WorkerRunner extends EventEmitter {
     const testInfo: TestInfo = {
       ...this._workerInfo,
       title: test.title,
-      file: test.file,
-      line: test.line,
-      column: test.column,
+      file: test.location.file,
+      line: test.location.line,
+      column: test.location.column,
       fn: test.fn,
       repeatEachIndex: this._params.repeatEachIndex,
       retry: entry.retry,

--- a/tests/playwright-test/junit-reporter.spec.ts
+++ b/tests/playwright-test/junit-reporter.spec.ts
@@ -211,7 +211,7 @@ test('should render projects', async ({ runInlineTest }) => {
   expect(xml['testsuites']['testsuite'][0]['$']['tests']).toBe('1');
   expect(xml['testsuites']['testsuite'][0]['$']['failures']).toBe('0');
   expect(xml['testsuites']['testsuite'][0]['$']['skipped']).toBe('0');
-  expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['name']).toBe('[project1] one');
+  expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['name']).toBe('one');
   expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['classname']).toContain('[project1] one');
   expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['classname']).toContain('a.test.js:6:7');
 
@@ -219,7 +219,7 @@ test('should render projects', async ({ runInlineTest }) => {
   expect(xml['testsuites']['testsuite'][1]['$']['tests']).toBe('1');
   expect(xml['testsuites']['testsuite'][1]['$']['failures']).toBe('0');
   expect(xml['testsuites']['testsuite'][1]['$']['skipped']).toBe('0');
-  expect(xml['testsuites']['testsuite'][1]['testcase'][0]['$']['name']).toBe('[project2] one');
+  expect(xml['testsuites']['testsuite'][1]['testcase'][0]['$']['name']).toBe('one');
   expect(xml['testsuites']['testsuite'][1]['testcase'][0]['$']['classname']).toContain('[project2] one');
   expect(xml['testsuites']['testsuite'][1]['testcase'][0]['$']['classname']).toContain('a.test.js:6:7');
   expect(result.exitCode).toBe(0);


### PR DESCRIPTION
- `Location` with `file`, `line` and `column`.
- `fullTitle` does not include project name.
- `titlePath` method.
- All methods of `Reporter` are optional.
- Removed `Test.skipped` property that is superseeded by `Test.status()`.
- Replaced `Suite.findTest()` with `Suite.allTests()`.
- Removed `Test.suite` property.