### PR TITLE
test: rework port forwarding server tests to launch server out of process

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -243,7 +243,7 @@ if (!process.env.PW_CLI_TARGET_LANG) {
 if (process.argv[2] === 'run-driver')
   runDriver();
 else if (process.argv[2] === 'run-server')
-  runServer(process.argv[3] ? +process.argv[3] : undefined, process.argv?.[4]).catch(logErrorAndExit);
+  runServer(process.argv[3] ? +process.argv[3] : undefined, process.argv[4]).catch(logErrorAndExit);
 else if (process.argv[2] === 'print-api-json')
   printApiJson();
 else if (process.argv[2] === 'launch-server')

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -243,7 +243,7 @@ if (!process.env.PW_CLI_TARGET_LANG) {
 if (process.argv[2] === 'run-driver')
   runDriver();
 else if (process.argv[2] === 'run-server')
-  runServer(process.argv[3] ? +process.argv[3] : undefined);
+  runServer(process.argv[3] ? +process.argv[3] : undefined, process.argv?.[4]).catch(logErrorAndExit);
 else if (process.argv[2] === 'print-api-json')
   printApiJson();
 else if (process.argv[2] === 'launch-server')

--- a/src/cli/driver.ts
+++ b/src/cli/driver.ts
@@ -23,7 +23,7 @@ import { LaunchServerOptions } from '../client/types';
 import { DispatcherConnection } from '../dispatchers/dispatcher';
 import { PlaywrightDispatcher } from '../dispatchers/playwrightDispatcher';
 import { Transport } from '../protocol/transport';
-import { PlaywrightServer } from '../remote/playwrightServer';
+import { PlaywrightServer, PlaywrightServerOptions } from '../remote/playwrightServer';
 import { createPlaywright } from '../server/playwright';
 import { gracefullyCloseAll } from '../utils/processLauncher';
 
@@ -51,8 +51,13 @@ export function runDriver() {
   new PlaywrightDispatcher(dispatcherConnection.rootDispatcher(), playwright);
 }
 
-export async function runServer(port: number | undefined) {
-  const wsEndpoint = await (await PlaywrightServer.startDefault()).listen(port);
+export async function runServer(port: number | undefined,  configFile?: string) {
+  let options: PlaywrightServerOptions = {};
+  if (configFile)
+    options = JSON.parse(fs.readFileSync(configFile).toString());
+  const server = await PlaywrightServer.startDefault(options);
+  const wsEndpoint = await server.listen(port);
+  process.on('exit', () => server.close().catch(console.error));
   console.log('Listening on ' + wsEndpoint);  // eslint-disable-line no-console
 }
 


### PR DESCRIPTION
Previously the PlaywrightServer instances were started in the same process. This lead to the problem when they closed to call the following method:
 
https://github.com/microsoft/playwright/blob/08da9d207effe7d888668a945d5a9c55e9ab21b0/src/remote/playwrightServer.ts#L44-L46

By calling that, other processes -> browsers got closed and future tests were failing which lead to

> browser.newContext: Target page, context or browser has been closed

When creating new contexts for future tests. This patch changes it to out of process instead and fixes random failing tests, including [this](https://devops.aslushnikov.com/flakiness2.html#filter_spec=resource-timing.spec.ts&commits=50&timestamp=1626519718412) one.

