### PR TITLE
docs(test-reporters.md): fix link to test runner CLI docs

### DIFF
--- a/docs/src/test-reporters.md
+++ b/docs/src/test-reporters.md
@@ -7,7 +7,7 @@ title: "Reporters"
 
 ## Using reporters
 
-Playwright Test comes with a few built-in reporters for different needs and ability to provide custom reporters. The easiest way to try out built-in reporters is to pass `--reporter` [command line option](./cli.md).
+Playwright Test comes with a few built-in reporters for different needs and ability to provide custom reporters. The easiest way to try out built-in reporters is to pass `--reporter` [command line option](./test-cli.md).
 
 
 ```bash


### PR DESCRIPTION
Corrects the link to the PW test runner CLI documentation.

Fixes #7694