### PR TITLE
fix: make generated example run with jbang

### DIFF
--- a/src/server/supplements/recorder/java.ts
+++ b/src/server/supplements/recorder/java.ts
@@ -128,6 +128,8 @@ export class JavaLanguageGenerator implements LanguageGenerator {
   generateHeader(options: LanguageGeneratorOptions): string {
     const formatter = new JavaScriptFormatter();
     formatter.add(`
+    ///usr/bin/env jbang "$0" "$@" ; exit $?
+    //DEPS com.microsoft.playwright:playwright:RELEASE
     import com.microsoft.playwright.*;
     import com.microsoft.playwright.options.*;
     import java.util.*;


### PR DESCRIPTION
I really like playwright and realised that if the java codegen would just add the following lines on top the generated examples just work if you have jbang.dev installed:

```
///usr/bin/env jbang "$0" "$@" ; exit $?
//DEPS com.microsoft.playwright:playwright:RELEASE
```

jbang is a small wrapper around javac and java that can take instructions like //DEPS <gav> and compile and run source code directly.

Can even run playwright cli without setting up a maven project first:

```
jbang -m com.microsoft.playwright.CLI com.microsoft.playwright:playwright:RELEASE codegen -o Example.java
```

would love to see this in - let me know what you think.

thanks.