### PR TITLE
[Proposal] chore: ship drivers with sha, instead of timestamp

### DIFF
--- a/.github/workflows/publish_canary_driver.yml
+++ b/.github/workflows/publish_canary_driver.yml
@@ -20,7 +20,7 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: node lib/cli/cli install-deps
-    - run: node utils/build/update_canary_version.js --commit-timestamp
+    - run: node utils/build/update_canary_version.js --commit-sha
     - run: utils/build/build-playwright-driver.sh
     - run: utils/build/upload-playwright-driver.sh
       env:

--- a/.github/workflows/publish_canary_npm.yml
+++ b/.github/workflows/publish_canary_npm.yml
@@ -24,7 +24,7 @@ jobs:
     - run: node lib/cli/cli install-deps
     - run: node utils/build/update_canary_version.js --today-date
       if: contains(github.ref, 'master') && github.event_name != 'workflow_dispatch'
-    - run: node utils/build/update_canary_version.js --commit-timestamp
+    - run: node utils/build/update_canary_version.js --commit-sha
       if: contains(github.ref, 'release') || github.event_name == 'workflow_dispatch'
     - run: utils/publish_all_packages.sh --tip-of-tree
       env:

--- a/utils/build/update_canary_version.js
+++ b/utils/build/update_canary_version.js
@@ -17,7 +17,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, spawnSync } = require('child_process');
 
 const packageJSON = require('../../package.json');
 if (process.argv[2] === '--today-date') {
@@ -26,13 +26,11 @@ if (process.argv[2] === '--today-date') {
   const day = date.getDate();
   const year = date.getFullYear();
   packageJSON.version = `${packageJSON.version}-alpha-${month}-${day}-${year}`;
-} else if (process.argv[2] === '--commit-timestamp') {
-  const timestamp = execSync('git show -s --format=%ct HEAD', {
-    stdio: ['ignore', 'pipe', 'ignore']
-  }).toString('utf8').trim();
-  packageJSON.version = `${packageJSON.version}-${timestamp}000`;
+} else if (process.argv[2] === '--commit-sha') {
+  const commitSHA = spawnSync('git', ['rev-parse', 'HEAD'], {cwd: __dirname, encoding: 'utf8'}).stdout.trim();
+  packageJSON.version = `${commitSHA}`;
 } else {
-  throw new Error('This script must be run with either --timestamp or --today-date parameter');
+  throw new Error('This script must be run with either --commit-sha or --today-date parameter');
 }
 console.log('Setting version to ' + packageJSON.version);
 fs.writeFileSync(path.join(__dirname, '..', '..', 'package.json'), JSON.stringify(packageJSON, undefined, 2) + '\n');


### PR DESCRIPTION
Instead of versioning our drivers with a timestamp, how about we version them with the commit sha from which they were built?

An advantage here would be, in combination with a submodule, an easy workflow for rolling and identifying API versions, etc. Basically, the roll would look at the submodule/package.json version to get the prefix, append the commit where it's at, and be able to download the correct driver. 