### PR TITLE
fix(test-runner): warn users who invoke the test-runner with Jest

### DIFF
--- a/src/test/testType.ts
+++ b/src/test/testType.ts
@@ -55,6 +55,7 @@ export class TestTypeImpl {
   }
 
   private _createTest(type: 'default' | 'only', location: Location, title: string, fn: Function) {
+    throwIfRunningInsideJest();
     const suite = currentlyLoadingFileSuite();
     if (!suite)
       throw new Error(`test() can only be called in a test file`);
@@ -71,6 +72,7 @@ export class TestTypeImpl {
   }
 
   private _describe(type: 'default' | 'only', location: Location, title: string, fn: Function) {
+    throwIfRunningInsideJest();
     const suite = currentlyLoadingFileSuite();
     if (!suite)
       throw new Error(`describe() can only be called in a test file`);
@@ -148,6 +150,16 @@ export class TestTypeImpl {
     const child = new TestTypeImpl([...this.fixtures, declared]);
     declared.testType = child;
     return child.test;
+  }
+}
+
+function throwIfRunningInsideJest() {
+  if (process.env.JEST_WORKER_ID) {
+    throw new Error(
+        `Playwright Test needs to be invoked via 'npx playwright test' and excluded from Jest test runs.\n` +
+        `Creating one directory for Playwright tests and one for Jest is the recommended way of doing it.\n` +
+        `See https://playwright.dev/docs/intro/ for more information about Playwright Test.`,
+    );
   }
 }
 


### PR DESCRIPTION
Relates:
- https://github.com/microsoft/playwright/issues/7714
- https://github.com/microsoft/playwright/issues/7587

See here about the worker-index env var: https://jestjs.io/docs/environment-variables. Its probably the easiest way to detect if its Jest or not.

Before it lead to when using Jest on Playwright tests:

```
 FAIL  tests/foo.spec.js
  ● Test suite failed to run

    test() can only be called in a test file

      1 | const { test, expect } = require('@playwright/test');
      2 |
    > 3 | test('basic test', async ({ page }) => {
        | ^
      4 |   await page.goto('https://playwright.dev/');
      5 |   const name = await page.innerText('.navbar__title');
      6 |   expect(name).toBe('Playwright');

      at Object.<anonymous> (tests/foo.spec.js:3:1)
```

Not sure where to put, we can also put it on the top-level at the end of the file.