### PR TITLE
feat(test-runner): use require to resolve reporters

### DIFF
--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -20,12 +20,12 @@ import * as commander from 'commander';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { Config } from './types';
-import { Runner } from './runner';
+import { Runner, builtInReporters, BuiltInReporter } from './runner';
 import { stopProfiling, startProfiling } from './profiler';
-import { FilePatternFilter, builtInReporters, BuiltInReporters } from './util';
+import { FilePatternFilter } from './util';
 
 const defaultTimeout = 30000;
-const defaultReporter: BuiltInReporters = process.env.CI ? 'dot' : 'list';
+const defaultReporter: BuiltInReporter = process.env.CI ? 'dot' : 'list';
 const tsConfig = 'playwright.config.ts';
 const jsConfig = 'playwright.config.js';
 const mjsConfig = 'playwright.config.mjs';

--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -16,7 +16,7 @@
 
 import { installTransform } from './transform';
 import type { FullConfig, Config, FullProject, Project, ReporterDescription, PreserveOutput } from './types';
-import { isRegExp, mergeObjects, errorWithFile, BuiltInReporters, builtInReporters } from './util';
+import { isRegExp, mergeObjects, errorWithFile } from './util';
 import { setCurrentlyLoadingFileSuite } from './globals';
 import { Suite } from './test';
 import { SerializedLoaderData } from './ipc';
@@ -25,6 +25,7 @@ import * as url from 'url';
 import { ProjectImpl } from './project';
 import { Reporter } from '../../types/testReporter';
 import { LaunchConfig } from '../../types/test';
+import { BuiltInReporter, builtInReporters } from './runner';
 
 export class Loader {
   private _defaultConfig: Config;
@@ -220,7 +221,7 @@ function takeFirst<T>(...args: (T | undefined)[]): T {
   return undefined as any as T;
 }
 
-function toReporters(reporters: BuiltInReporters | ReporterDescription[] | undefined): ReporterDescription[] | undefined {
+function toReporters(reporters: BuiltInReporter | ReporterDescription[] | undefined): ReporterDescription[] | undefined {
   if (!reporters)
     return;
   if (typeof reporters === 'string')

--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -16,7 +16,7 @@
 
 import { installTransform } from './transform';
 import type { FullConfig, Config, FullProject, Project, ReporterDescription, PreserveOutput } from './types';
-import { isRegExp, mergeObjects, errorWithFile } from './util';
+import { isRegExp, mergeObjects, errorWithFile, BuiltInReporters, builtInReporters } from './util';
 import { setCurrentlyLoadingFileSuite } from './globals';
 import { Suite } from './test';
 import { SerializedLoaderData } from './ipc';
@@ -80,7 +80,7 @@ export class Loader {
     const configUse = mergeObjects(this._defaultConfig.use, this._config.use);
     this._config = mergeObjects(mergeObjects(this._defaultConfig, this._config), { use: configUse });
 
-    if (('testDir' in this._config) && this._config.testDir !== undefined && !path.isAbsolute(this._config.testDir))
+    if (this._config.testDir !== undefined)
       this._config.testDir = path.resolve(rootDir, this._config.testDir);
     const projects: Project[] = ('projects' in this._config) && this._config.projects !== undefined ? this._config.projects : [this._config];
 
@@ -93,7 +93,7 @@ export class Loader {
     this._fullConfig.grepInvert = takeFirst(this._configOverrides.grepInvert, this._config.grepInvert, baseFullConfig.grepInvert);
     this._fullConfig.maxFailures = takeFirst(this._configOverrides.maxFailures, this._config.maxFailures, baseFullConfig.maxFailures);
     this._fullConfig.preserveOutput = takeFirst<PreserveOutput>(this._configOverrides.preserveOutput, this._config.preserveOutput, baseFullConfig.preserveOutput);
-    this._fullConfig.reporter = takeFirst(toReporters(this._configOverrides.reporter), toReporters(this._config.reporter), baseFullConfig.reporter);
+    this._fullConfig.reporter = takeFirst(toReporters(this._configOverrides.reporter), resolveReporters(this._config.reporter, rootDir), baseFullConfig.reporter);
     this._fullConfig.reportSlowTests = takeFirst(this._configOverrides.reportSlowTests, this._config.reportSlowTests, baseFullConfig.reportSlowTests);
     this._fullConfig.quiet = takeFirst(this._configOverrides.quiet, this._config.quiet, baseFullConfig.quiet);
     this._fullConfig.shard = takeFirst(this._configOverrides.shard, this._config.shard, baseFullConfig.shard);
@@ -220,7 +220,7 @@ function takeFirst<T>(...args: (T | undefined)[]): T {
   return undefined as any as T;
 }
 
-function toReporters(reporters: 'dot' | 'line' | 'list' | 'junit' | 'json' | 'null' | ReporterDescription[] | undefined): ReporterDescription[] | undefined {
+function toReporters(reporters: BuiltInReporters | ReporterDescription[] | undefined): ReporterDescription[] | undefined {
   if (!reporters)
     return;
   if (typeof reporters === 'string')
@@ -313,10 +313,8 @@ function validateConfig(file: string, config: Config) {
         if (!Array.isArray(item) || item.length <= 0 || item.length > 2 || typeof item[0] !== 'string')
           throw errorWithFile(file, `config.reporter[${index}] must be a tuple [name, optionalArgument]`);
       });
-    } else {
-      const builtinReporters = ['dot', 'line', 'list', 'junit', 'json', 'null'];
-      if (typeof config.reporter !== 'string' || !builtinReporters.includes(config.reporter))
-        throw errorWithFile(file, `config.reporter must be one of ${builtinReporters.map(name => `"${name}"`).join(', ')}`);
+    } else if (typeof config.reporter !== 'string') {
+      throw errorWithFile(file, `config.reporter must be a string`);
     }
   }
 
@@ -437,3 +435,11 @@ const baseFullConfig: FullConfig = {
   workers: 1,
   launch: [],
 };
+
+function resolveReporters(reporters: Config['reporter'], rootDir: string): ReporterDescription[]|undefined {
+  return toReporters(reporters)?.map(([id, arg]) => {
+    if (builtInReporters.includes(id as any))
+      return [id, arg];
+    return [require.resolve(id, { paths: [ rootDir ] }), arg];
+  });
+}

--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -93,7 +93,7 @@ export class Loader {
     this._fullConfig.grepInvert = takeFirst(this._configOverrides.grepInvert, this._config.grepInvert, baseFullConfig.grepInvert);
     this._fullConfig.maxFailures = takeFirst(this._configOverrides.maxFailures, this._config.maxFailures, baseFullConfig.maxFailures);
     this._fullConfig.preserveOutput = takeFirst<PreserveOutput>(this._configOverrides.preserveOutput, this._config.preserveOutput, baseFullConfig.preserveOutput);
-    this._fullConfig.reporter = takeFirst(toReporters(this._configOverrides.reporter), resolveReporters(this._config.reporter, rootDir), baseFullConfig.reporter);
+    this._fullConfig.reporter = takeFirst(toReporters(this._configOverrides.reporter as any), resolveReporters(this._config.reporter, rootDir), baseFullConfig.reporter);
     this._fullConfig.reportSlowTests = takeFirst(this._configOverrides.reportSlowTests, this._config.reportSlowTests, baseFullConfig.reportSlowTests);
     this._fullConfig.quiet = takeFirst(this._configOverrides.quiet, this._config.quiet, baseFullConfig.quiet);
     this._fullConfig.shard = takeFirst(this._configOverrides.shard, this._config.shard, baseFullConfig.shard);
@@ -437,7 +437,7 @@ const baseFullConfig: FullConfig = {
 };
 
 function resolveReporters(reporters: Config['reporter'], rootDir: string): ReporterDescription[]|undefined {
-  return toReporters(reporters)?.map(([id, arg]) => {
+  return toReporters(reporters as any)?.map(([id, arg]) => {
     if (builtInReporters.includes(id as any))
       return [id, arg];
     return [require.resolve(id, { paths: [ rootDir ] }), arg];

--- a/src/test/runner.ts
+++ b/src/test/runner.ts
@@ -21,7 +21,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';
 import { Dispatcher } from './dispatcher';
-import { createMatcher, FilePatternFilter, monotonicTime, raceAgainstDeadline } from './util';
+import { BuiltInReporters, createMatcher, FilePatternFilter, monotonicTime, raceAgainstDeadline } from './util';
 import { TestCase, Suite } from './test';
 import { Loader } from './loader';
 import { Reporter } from '../../types/testReporter';
@@ -64,7 +64,7 @@ export class Runner {
 
   private async _createReporter(list: boolean) {
     const reporters: Reporter[] = [];
-    const defaultReporters = {
+    const defaultReporters: {[key in BuiltInReporters]: new(arg: any) => Reporter} = {
       dot: list ? ListModeReporter : DotReporter,
       line: list ? ListModeReporter : LineReporter,
       list: list ? ListModeReporter : ListReporter,

--- a/src/test/runner.ts
+++ b/src/test/runner.ts
@@ -21,7 +21,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';
 import { Dispatcher } from './dispatcher';
-import { BuiltInReporters, createMatcher, FilePatternFilter, monotonicTime, raceAgainstDeadline } from './util';
+import { createMatcher, FilePatternFilter, monotonicTime, raceAgainstDeadline } from './util';
 import { TestCase, Suite } from './test';
 import { Loader } from './loader';
 import { Reporter } from '../../types/testReporter';
@@ -64,7 +64,7 @@ export class Runner {
 
   private async _createReporter(list: boolean) {
     const reporters: Reporter[] = [];
-    const defaultReporters: {[key in BuiltInReporters]: new(arg: any) => Reporter} = {
+    const defaultReporters: {[key in BuiltInReporter]: new(arg: any) => Reporter} = {
       dot: list ? ListModeReporter : DotReporter,
       line: list ? ListModeReporter : LineReporter,
       list: list ? ListModeReporter : ListReporter,
@@ -427,3 +427,6 @@ class ListModeReporter implements Reporter {
     console.log(`Total: ${tests.length} ${tests.length === 1 ? 'test' : 'tests'} in ${files.size} ${files.size === 1 ? 'file' : 'files'}`);
   }
 }
+
+export const builtInReporters = ['list', 'line', 'dot', 'json', 'junit', 'null'] as const;
+export type BuiltInReporter = typeof builtInReporters[number];

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -162,3 +162,6 @@ export function formatLocation(location: Location) {
 export function errorWithFile(file: string, message: string) {
   return new Error(`${relativeFilePath(file)}: ${message}`);
 }
+
+export const builtInReporters = ['list', 'line', 'dot', 'json', 'junit', 'null'] as const;
+export type BuiltInReporters = typeof builtInReporters[number];

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -162,6 +162,3 @@ export function formatLocation(location: Location) {
 export function errorWithFile(file: string, message: string) {
   return new Error(`${relativeFilePath(file)}: ${message}`);
 }
-
-export const builtInReporters = ['list', 'line', 'dot', 'json', 'junit', 'null'] as const;
-export type BuiltInReporters = typeof builtInReporters[number];

--- a/tests/playwright-test/global-setup.spec.ts
+++ b/tests/playwright-test/global-setup.spec.ts
@@ -21,7 +21,7 @@ test('globalSetup and globalTeardown should work', async ({ runInlineTest }) => 
     'playwright.config.ts': `
       import * as path from 'path';
       module.exports = {
-        globalSetup: 'globalSetup.ts',
+        globalSetup: './globalSetup.ts',
         globalTeardown: path.join(__dirname, 'globalTeardown.ts'),
       };
     `,

--- a/tests/playwright-test/reporter.spec.ts
+++ b/tests/playwright-test/reporter.spec.ts
@@ -133,7 +133,7 @@ test('should work without a file extension', async ({ runInlineTest }) => {
   ]);
 });
 
-test('should work load from node_modules', async ({ runInlineTest }) => {
+test('should load reporter from node_modules', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'node_modules/my-reporter/index.js': smallReporterJS,
     'playwright.config.ts': `

--- a/tests/playwright-test/reporter.spec.ts
+++ b/tests/playwright-test/reporter.spec.ts
@@ -111,7 +111,7 @@ test('should work with custom reporter', async ({ runInlineTest }) => {
 });
 
 
-test.only('should work without a file extension', async ({ runInlineTest }) => {
+test('should work without a file extension', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'reporter.ts': smallReporterJS,
     'playwright.config.ts': `

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -146,6 +146,9 @@ export type LaunchConfig = {
   cwd?: string,
 };
 
+type LiteralUnion<T extends U, U = string> = T | (U & { zz_IGNORE_ME?: never })
+
+
 /**
  * Testing configuration.
  */
@@ -213,7 +216,7 @@ interface ConfigBase {
    * It is possible to pass multiple reporters. A common pattern is using one terminal reporter
    * like `'line'` or `'list'`, and one file reporter like `'json'` or `'junit'`.
    */
-  reporter?: string | ReporterDescription[];
+  reporter?: LiteralUnion<'list'|'dot'|'line'|'json'|'junit'|'null', string> | ReporterDescription[];
 
   /**
    * Whether to report slow tests. When `null`, slow tests are not reported.

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -213,7 +213,7 @@ interface ConfigBase {
    * It is possible to pass multiple reporters. A common pattern is using one terminal reporter
    * like `'line'` or `'list'`, and one file reporter like `'json'` or `'junit'`.
    */
-  reporter?: 'dot' | 'line' | 'list' | 'junit' | 'json' | 'null' | ReporterDescription[];
+  reporter?: string | ReporterDescription[];
 
   /**
    * Whether to report slow tests. When `null`, slow tests are not reported.


### PR DESCRIPTION
We import four different kinds of files:

config - has some very custom logic around folders and playwright.config.js
globalSetup/globalTeardown - Surprisingly allows relative paths without `./`
tests - custom logic with matches
reporters - updated in this patch to use require.resolve

I can update globalSetup/globalTeardown to use require.resolve. I think
it is a bug that they accept relative paths without `./`. But it would be
a breaking change, so I'll do it in another patch.

