### PR TITLE
perf(test-runner): lazy require playwright from fixtures

### DIFF
--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -29,7 +29,7 @@ const artifactsFolder = path.join(os.tmpdir(), 'pwt-' + createGuid());
 export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions, PlaywrightWorkerArgs & PlaywrightWorkerOptions>({
   defaultBrowserType: [ 'chromium', { scope: 'worker' } ],
   browserName: [ ({ defaultBrowserType }, use) => use(defaultBrowserType), { scope: 'worker' } ],
-  playwright: [ () => require('../inprocess'), { scope: 'worker' } ],
+  playwright: [ ({}, use) => use(require('../inprocess')), { scope: 'worker' } ],
   headless: [ undefined, { scope: 'worker' } ],
   channel: [ undefined, { scope: 'worker' } ],
   launchOptions: [ {}, { scope: 'worker' } ],

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -29,7 +29,7 @@ const artifactsFolder = path.join(os.tmpdir(), 'pwt-' + createGuid());
 export const test = _baseTest.extend<PlaywrightTestArgs & PlaywrightTestOptions, PlaywrightWorkerArgs & PlaywrightWorkerOptions>({
   defaultBrowserType: [ 'chromium', { scope: 'worker' } ],
   browserName: [ ({ defaultBrowserType }, use) => use(defaultBrowserType), { scope: 'worker' } ],
-  playwright: [ require('../inprocess'), { scope: 'worker' } ],
+  playwright: [ () => require('../inprocess'), { scope: 'worker' } ],
   headless: [ undefined, { scope: 'worker' } ],
   channel: [ undefined, { scope: 'worker' } ],
   launchOptions: [ {}, { scope: 'worker' } ],


### PR DESCRIPTION
Saves about 100ms in tests that don't use playwright.﻿
