### PR TITLE
chore: perf measuring script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "doc": "node utils/doclint/cli.js",
     "lint": "npm run eslint && npm run tsc && npm run doc && npm run check-deps && node utils/generate_channels.js && node utils/generate_types/ --check-clean && npm run test-types",
     "clean": "rimraf lib && rimraf src/generated/",
+    "perf": "node utils/perf.js",
     "prepare": "node install-from-github.js",
     "build": "node utils/build/build.js",
     "watch": "node utils/build/build.js --watch --lint",

--- a/utils/perf.js
+++ b/utils/perf.js
@@ -1,0 +1,57 @@
+const { spawnSync } = require('child_process');
+
+measureJS('require', `require('..')`);
+
+for (const browserName of ['chromium', 'webkit', 'firefox'])
+    measureJS(browserName, `(${measurePlaywrightPerf})(${JSON.stringify(browserName)})`);
+
+try {
+    require.resolve('puppeteer');
+    measureJS('puppeteer', `(${measurePuppeteerPerf})()`);
+}
+catch {}
+
+try {
+    require.resolve('jsdom');
+    measureJS('jsdom', `(${measureJSDOMPerf})()`);
+}
+catch {}
+
+async function measurePlaywrightPerf(browserName) {
+    const playwright = require('..');
+    const browser = await playwright[browserName].launch();
+    const page = await browser.newPage();
+    const value = await page.evaluate(() => 1 + 2);
+    if (value !== 3)
+        throw new Error(`Expected value to be 3, got ${value}`);
+    await browser.close();
+}
+
+async function measurePuppeteerPerf() {
+    const browser = await require('puppeteer').launch();
+    const page = await browser.newPage();
+    const value = await page.evaluate(() => 1 + 2);
+    if (value !== 3)
+        throw new Error(`Expected value to be 3, got ${value}`);
+    await browser.close();
+}
+
+async function measureJSDOMPerf() {
+    const {JSDOM} = require('jsdom');
+    const {window} = new JSDOM(``);
+    const value = window.eval(`1 + 2`);
+    if (value !== 3)
+        throw new Error(`Expected value to be 3, got ${value}`);
+}
+
+function measureJS(name, js) {
+    const iterations = 30;
+    const start = Date.now();
+    for (let i = 0; i < iterations; i++) {
+        spawnSync(process.argv0, ['-e', js], {
+            stdio: 'inherit',
+            cwd: __dirname,
+        });
+    }
+    console.log(name, Math.round((Date.now() - start) / iterations));
+}


### PR DESCRIPTION
This script starts up playwright, launches a browser, creates a page, evaluates in the page, and closes the browser.

It also does this for JSDOM and Puppeteer for context.

Numbers from my Mac:

```
require 238
chromium 773
webkit 573
firefox 2047
puppeteer 727
jsdom 525﻿
```
