### PR TITLE
devops(dependencies): Add missing package libxshmfence1 to ubuntu:20.04

### DIFF
--- a/src/utils/dependencies.ts
+++ b/src/utils/dependencies.ts
@@ -463,6 +463,7 @@ const LIBRARY_TO_PACKAGE_NAME_UBUNTU_20_04: { [s: string]: string} = {
   'libxslt.so.1': 'libxslt1.1',
   'libXt.so.6': 'libxt6',
   'libXtst.so.6': 'libxtst6',
+  'libxshmfence.so.1': 'libxshmfence1',
 };
 
 const LIBRARY_TO_PACKAGE_NAME_UBUNTU_21_04: { [s: string]: string} = {


### PR DESCRIPTION
This PR adds the missing package needed in ubuntu:20.04 named `libxshmfence1` which I experienced when trying to run Playwright tests on `ubuntu:20.04` after running `DEBIAN_FRONTEND=noninteractive npx playwright install-deps`