### PR TITLE
fix(test runner): do not override browserName when using without --browser

### DIFF
--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -84,16 +84,18 @@ export function addTestCommand(program: commander.CommanderStatic) {
 async function runTests(args: string[], opts: { [key: string]: any }) {
   await startProfiling();
 
-  const browserOpt = opts.browser ? opts.browser.toLowerCase() : 'chromium';
-  if (!['all', 'chromium', 'firefox', 'webkit'].includes(browserOpt))
-    throw new Error(`Unsupported browser "${opts.browser}", must be one of "all", "chromium", "firefox" or "webkit"`);
-  const browserNames = browserOpt === 'all' ? ['chromium', 'firefox', 'webkit'] : [browserOpt];
-  defaultConfig.projects = browserNames.map(browserName => {
-    return {
-      name: browserName,
-      use: { browserName },
-    };
-  });
+  if (opts.browser) {
+    const browserOpt = opts.browser.toLowerCase();
+    if (!['all', 'chromium', 'firefox', 'webkit'].includes(browserOpt))
+      throw new Error(`Unsupported browser "${opts.browser}", must be one of "all", "chromium", "firefox" or "webkit"`);
+    const browserNames = browserOpt === 'all' ? ['chromium', 'firefox', 'webkit'] : [browserOpt];
+    defaultConfig.projects = browserNames.map(browserName => {
+      return {
+        name: browserName,
+        use: { browserName },
+      };
+    });
+  }
 
   const overrides = overridesFromOptions(opts);
   if (opts.headed)

--- a/tests/playwright-test/test-output-dir.spec.ts
+++ b/tests/playwright-test/test-output-dir.spec.ts
@@ -22,6 +22,7 @@ test('should work and remove non-failures', async ({ runInlineTest }, testInfo) 
   const result = await runInlineTest({
     'playwright.config.ts': `
       module.exports = {
+        name: 'chromium',
         preserveOutput: 'failures-only',
         testDir: 'dir',
       };


### PR DESCRIPTION
This has a small side-effect that we do not show `[chromium]` project name anymore, when not using `config.projects` or `--browser` option.

Fixes #7746.