### PR TITLE
chore(typescript): turn on noImplicitOverride

### DIFF
--- a/src/client/elementHandle.ts
+++ b/src/client/elementHandle.ts
@@ -29,7 +29,7 @@ import * as structs from '../../types/structs';
 export class ElementHandle<T extends Node = Node> extends JSHandle<T> implements api.ElementHandle {
   readonly _elementChannel: channels.ElementHandleChannel;
 
-  static from(handle: channels.ElementHandleChannel): ElementHandle {
+  static override from(handle: channels.ElementHandleChannel): ElementHandle {
     return (handle as any)._object;
   }
 
@@ -42,7 +42,7 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> implements
     this._elementChannel = this._channel as channels.ElementHandleChannel;
   }
 
-  asElement(): T extends Node ? ElementHandle<T> : null {
+  override asElement(): T extends Node ? ElementHandle<T> : null {
     return this as any;
   }
 

--- a/src/client/jsHandle.ts
+++ b/src/client/jsHandle.ts
@@ -79,7 +79,7 @@ export class JSHandle<T = any> extends ChannelOwner<channels.JSHandleChannel, ch
     });
   }
 
-  toString(): string {
+  override toString(): string {
     return this._preview;
   }
 }

--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -615,28 +615,28 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     return [...this._workers];
   }
 
-  on(event: string | symbol, listener: Listener): this {
+  override on(event: string | symbol, listener: Listener): this {
     if (event === Events.Page.FileChooser && !this.listenerCount(event))
       this._channel.setFileChooserInterceptedNoReply({ intercepted: true });
     super.on(event, listener);
     return this;
   }
 
-  addListener(event: string | symbol, listener: Listener): this {
+  override addListener(event: string | symbol, listener: Listener): this {
     if (event === Events.Page.FileChooser && !this.listenerCount(event))
       this._channel.setFileChooserInterceptedNoReply({ intercepted: true });
     super.addListener(event, listener);
     return this;
   }
 
-  off(event: string | symbol, listener: Listener): this {
+  override off(event: string | symbol, listener: Listener): this {
     super.off(event, listener);
     if (event === Events.Page.FileChooser && !this.listenerCount(event))
       this._channel.setFileChooserInterceptedNoReply({ intercepted: false });
     return this;
   }
 
-  removeListener(event: string | symbol, listener: Listener): this {
+  override removeListener(event: string | symbol, listener: Listener): this {
     super.removeListener(event, listener);
     if (event === Events.Page.FileChooser && !this.listenerCount(event))
       this._channel.setFileChooserInterceptedNoReply({ intercepted: false });

--- a/src/client/stream.ts
+++ b/src/client/stream.ts
@@ -40,7 +40,7 @@ class StreamImpl extends Readable {
     this._channel = channel;
   }
 
-  async _read(size: number) {
+  override async _read(size: number) {
     const result = await this._channel.read({ size });
     if (result.binary)
       this.push(Buffer.from(result.binary, 'base64'));
@@ -48,7 +48,7 @@ class StreamImpl extends Readable {
       this.push(null);
   }
 
-  _destroy(error: Error | null, callback: (error: Error | null) => void): void {
+  override _destroy(error: Error | null, callback: (error: Error | null) => void): void {
     // Stream might be destroyed after the connection was closed.
     this._channel.close().catch(e => null);
     super._destroy(error, callback);

--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -48,7 +48,7 @@ export class Chromium extends BrowserType {
       this._devtools = this._createDevTools();
   }
 
-  async connectOverCDP(metadata: CallMetadata, endpointURL: string, options: { slowMo?: number, headers?: types.HeadersArray }, timeout?: number) {
+  override async connectOverCDP(metadata: CallMetadata, endpointURL: string, options: { slowMo?: number, headers?: types.HeadersArray }, timeout?: number) {
     const controller = new ProgressController(metadata, this);
     controller.setLogName('browser');
     const browserLogsCollector = new RecentLogsCollector();

--- a/src/server/chromium/crBrowser.ts
+++ b/src/server/chromium/crBrowser.ts
@@ -308,7 +308,7 @@ export class CRBrowserContext extends BrowserContext {
     this._authenticateProxyViaCredentials();
   }
 
-  async _initialize() {
+  override async _initialize() {
     assert(!Array.from(this._browser._crPages.values()).some(page => page._browserContext === this));
     const promises: Promise<any>[] = [ super._initialize() ];
     if (this._browser.options.name !== 'electron' && this._browser.options.name !== 'clank') {

--- a/src/server/chromium/crConnection.ts
+++ b/src/server/chromium/crConnection.ts
@@ -132,11 +132,11 @@ export class CRSession extends EventEmitter {
   private readonly _rootSessionId: string;
   private _crashed: boolean = false;
   private _browserDisconnectedLogs: string | undefined;
-  on: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  addListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  off: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  removeListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  once: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override on: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override addListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override off: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override removeListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override once: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
   readonly guid: string;
 
   constructor(connection: CRConnection, rootSessionId: string, targetType: string, sessionId: string) {

--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -40,11 +40,11 @@ export class FrameExecutionContext extends js.ExecutionContext {
     this.world = world;
   }
 
-  async waitForSignalsCreatedBy<T>(action: () => Promise<T>): Promise<T> {
+  override async waitForSignalsCreatedBy<T>(action: () => Promise<T>): Promise<T> {
     return this.frame._page._frameManager.waitForSignalsCreatedBy(null, false, action);
   }
 
-  adoptIfNeeded(handle: js.JSHandle): Promise<js.JSHandle> | null {
+  override adoptIfNeeded(handle: js.JSHandle): Promise<js.JSHandle> | null {
     if (handle instanceof ElementHandle && handle._context !== this)
       return this.frame._page._delegate.adoptElementHandle(handle, this);
     return null;
@@ -80,7 +80,7 @@ export class FrameExecutionContext extends js.ExecutionContext {
     });
   }
 
-  createHandle(remoteObject: js.RemoteObject): js.JSHandle {
+  override createHandle(remoteObject: js.RemoteObject): js.JSHandle {
     if (this.frame._page._delegate.isElementHandle(remoteObject))
       return new ElementHandle(this, remoteObject.objectId!);
     return super.createHandle(remoteObject);
@@ -106,7 +106,7 @@ export class FrameExecutionContext extends js.ExecutionContext {
     return this._injectedScriptPromise;
   }
 
-  async doSlowMo() {
+  override async doSlowMo() {
     return this.frame._page._doSlowMo();
   }
 }
@@ -127,7 +127,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     this._setPreview(await utility.evaluate((injected, e) => 'JSHandle@' + injected.previewNode(e), this));
   }
 
-  asElement(): ElementHandle<T> | null {
+  override asElement(): ElementHandle<T> | null {
     return this;
   }
 

--- a/src/server/firefox/ffBrowser.ts
+++ b/src/server/firefox/ffBrowser.ts
@@ -153,7 +153,7 @@ export class FFBrowserContext extends BrowserContext {
     super(browser, options, browserContextId);
   }
 
-  async _initialize() {
+  override async _initialize() {
     assert(!this._ffPages().length);
     const browserContextId = this._browserContextId;
     const promises: Promise<any>[] = [ super._initialize() ];

--- a/src/server/firefox/ffConnection.ts
+++ b/src/server/firefox/ffConnection.ts
@@ -41,11 +41,11 @@ export class FFConnection extends EventEmitter {
   readonly _sessions: Map<string, FFSession>;
   _closed: boolean;
 
-  on: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  addListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  off: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  removeListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  once: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override on: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override addListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override off: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override removeListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override once: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
 
   constructor(transport: ConnectionTransport, protocolLogger: ProtocolLogger, browserLogsCollector: RecentLogsCollector) {
     super();
@@ -155,11 +155,11 @@ export class FFSession extends EventEmitter {
   private _sessionId: string;
   private _rawSend: (message: any) => void;
   private _crashed: boolean = false;
-  on: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  addListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  off: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  removeListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  once: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override on: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override addListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override off: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override removeListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override once: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
 
   constructor(connection: FFConnection, targetType: string, sessionId: string, rawSend: (message: any) => void) {
     super();

--- a/src/server/javascript.ts
+++ b/src/server/javascript.ts
@@ -172,7 +172,7 @@ export class JSHandle<T = any> extends SdkObject {
       this._context._delegate.releaseHandle(this._objectId).catch(e => {});
   }
 
-  toString(): string {
+  override toString(): string {
     return this._preview;
   }
 

--- a/src/server/webkit/wkBrowser.ts
+++ b/src/server/webkit/wkBrowser.ts
@@ -207,7 +207,7 @@ export class WKBrowserContext extends BrowserContext {
     this._authenticateProxyViaHeader();
   }
 
-  async _initialize() {
+  override async _initialize() {
     assert(!this._wkPages().length);
     const browserContextId = this._browserContextId;
     const promises: Promise<any>[] = [ super._initialize() ];

--- a/src/server/webkit/wkConnection.ts
+++ b/src/server/webkit/wkConnection.ts
@@ -104,11 +104,11 @@ export class WKSession extends EventEmitter {
   private readonly _callbacks = new Map<number, {resolve: (o: any) => void, reject: (e: Error) => void, error: Error, method: string}>();
   private _crashed: boolean = false;
 
-  on: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  addListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  off: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  removeListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  once: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override on: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override addListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override off: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override removeListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
+  override once: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
 
   constructor(connection: WKConnection, sessionId: string, errorText: string, rawSend: (message: any) => void) {
     super();

--- a/src/test/reporters/dot.ts
+++ b/src/test/reporters/dot.ts
@@ -21,19 +21,19 @@ import { FullResult, TestCase, TestResult } from '../../../types/testReporter';
 class DotReporter extends BaseReporter {
   private _counter = 0;
 
-  onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+  override onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
     super.onStdOut(chunk, test, result);
     if (!this.config.quiet)
       process.stdout.write(chunk);
   }
 
-  onStdErr(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+  override onStdErr(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
     super.onStdErr(chunk, test, result);
     if (!this.config.quiet)
       process.stderr.write(chunk);
   }
 
-  onTestEnd(test: TestCase, result: TestResult) {
+  override onTestEnd(test: TestCase, result: TestResult) {
     super.onTestEnd(test, result);
     if (this._counter === 80) {
       process.stdout.write('\n');
@@ -55,7 +55,7 @@ class DotReporter extends BaseReporter {
     }
   }
 
-  async onEnd(result: FullResult) {
+  override async onEnd(result: FullResult) {
     await super.onEnd(result);
     process.stdout.write('\n');
     this.epilogue(true);

--- a/src/test/reporters/line.ts
+++ b/src/test/reporters/line.ts
@@ -24,18 +24,18 @@ class LineReporter extends BaseReporter {
   private _failures = 0;
   private _lastTest: TestCase | undefined;
 
-  onBegin(config: FullConfig, suite: Suite) {
+  override onBegin(config: FullConfig, suite: Suite) {
     super.onBegin(config, suite);
     this._total = suite.allTests().length;
     console.log();
   }
 
-  onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+  override onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
     super.onStdOut(chunk, test, result);
     this._dumpToStdio(test, chunk, process.stdout);
   }
 
-  onStdErr(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+  override onStdErr(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
     super.onStdErr(chunk, test, result);
     this._dumpToStdio(test, chunk, process.stderr);
   }
@@ -54,7 +54,7 @@ class LineReporter extends BaseReporter {
     console.log();
   }
 
-  onTestEnd(test: TestCase, result: TestResult) {
+  override onTestEnd(test: TestCase, result: TestResult) {
     super.onTestEnd(test, result);
     const width = process.stdout.columns! - 1;
     const title = `[${++this._current}/${this._total}] ${formatTestTitle(this.config, test)}`.substring(0, width);
@@ -66,7 +66,7 @@ class LineReporter extends BaseReporter {
     }
   }
 
-  async onEnd(result: FullResult) {
+  override async onEnd(result: FullResult) {
     process.stdout.write(`\u001B[1A\u001B[2K`);
     await super.onEnd(result);
     this.epilogue(false);

--- a/src/test/reporters/list.ts
+++ b/src/test/reporters/list.ts
@@ -37,7 +37,7 @@ class ListReporter extends BaseReporter {
     this._liveTerminal = process.stdout.isTTY || process.env.PWTEST_SKIP_TEST_OUTPUT;
   }
 
-  onBegin(config: FullConfig, suite: Suite) {
+  override onBegin(config: FullConfig, suite: Suite) {
     super.onBegin(config, suite);
     console.log();
   }
@@ -54,12 +54,12 @@ class ListReporter extends BaseReporter {
     this._testRows.set(test, this._lastRow++);
   }
 
-  onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+  override onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
     super.onStdOut(chunk, test, result);
     this._dumpToStdio(test, chunk, process.stdout);
   }
 
-  onStdErr(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+  override onStdErr(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
     super.onStdErr(chunk, test, result);
     this._dumpToStdio(test, chunk, process.stdout);
   }
@@ -92,7 +92,7 @@ class ListReporter extends BaseReporter {
     stream.write(chunk);
   }
 
-  onTestEnd(test: TestCase, result: TestResult) {
+  override onTestEnd(test: TestCase, result: TestResult) {
     super.onTestEnd(test, result);
 
     const duration = colors.dim(` (${milliseconds(result.duration)})`);
@@ -145,7 +145,7 @@ class ListReporter extends BaseReporter {
     process.stdout.write(testRow + ' : ' + line + '\n');
   }
 
-  async onEnd(result: FullResult) {
+  override async onEnd(result: FullResult) {
     await super.onEnd(result);
     process.stdout.write('\n');
     this.epilogue(true);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -270,7 +270,7 @@ export function monotonicTime(): number {
 class HashStream extends stream.Writable {
   private _hash = crypto.createHash('sha1');
 
-  _write(chunk: Buffer, encoding: string, done: () => void) {
+  override _write(chunk: Buffer, encoding: string, done: () => void) {
     this._hash.update(chunk);
     done();
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "jsx": "react",
     "resolveJsonModule": true,
     "noEmit": true,
+    "noImplicitOverride": true,
   },
   "compileOnSave": true,
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/server/deviceDescriptorsSource.json"],


### PR DESCRIPTION
TypeScript added a feature to force all overrides to be marked as such. We use to do this in the DevTools days with `@override`. We can land it if we like how it looks.