### PR TITLE
fix(test runner): align shard info to be one-based everywhere

### DIFF
--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -179,7 +179,7 @@ function overridesFromOptions(options: { [key: string]: any }): Config {
     repeatEach: options.repeatEach ? parseInt(options.repeatEach, 10) : undefined,
     retries: options.retries ? parseInt(options.retries, 10) : undefined,
     reporter: (options.reporter && options.reporter.length) ? options.reporter.split(',').map((r: string) => [resolveReporter(r)]) : undefined,
-    shard: shardPair ? { current: shardPair[0] - 1, total: shardPair[1] } : undefined,
+    shard: shardPair ? { current: shardPair[0], total: shardPair[1] } : undefined,
     timeout: isDebuggerAttached ? 0 : (options.timeout ? parseInt(options.timeout, 10) : undefined),
     updateSnapshots: options.updateSnapshots ? 'all' as const : undefined,
     workers: options.workers ? parseInt(options.workers, 10) : undefined,

--- a/src/test/dispatcher.ts
+++ b/src/test/dispatcher.ts
@@ -61,8 +61,8 @@ export class Dispatcher {
     if (shard) {
       let total = this._suite.allTests().length;
       const shardSize = Math.ceil(total / shard.total);
-      const from = shardSize * shard.current;
-      const to = shardSize * (shard.current + 1);
+      const from = shardSize * (shard.current - 1);
+      const to = shardSize * shard.current;
       let current = 0;
       total = 0;
       const filteredQueue: DispatcherEntry[] = [];

--- a/src/test/runner.ts
+++ b/src/test/runner.ts
@@ -252,7 +252,7 @@ export class Runner {
         console.log();
         const jobs = Math.min(config.workers, workers.size);
         const shard = config.shard;
-        const shardDetails = shard ? `, shard ${shard.current + 1} of ${shard.total}` : '';
+        const shardDetails = shard ? `, shard ${shard.current} of ${shard.total}` : '';
         console.log(`Running ${total} test${total > 1 ? 's' : ''} using ${jobs} worker${jobs > 1 ? 's' : ''}${shardDetails}`);
       }
 

--- a/tests/playwright-test/shard.spec.ts
+++ b/tests/playwright-test/shard.spec.ts
@@ -54,3 +54,18 @@ test('should respect shard=2/2', async ({ runInlineTest }) => {
   expect(result.skipped).toBe(3);
   expect(result.output).toContain('test4-done');
 });
+
+test('should respect shard=1/2 in config', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    ...tests,
+    'playwright.config.js': `
+      module.exports = { shard: { current: 1, total: 2 } };
+    `,
+  }, { shard: '1/2' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+  expect(result.skipped).toBe(1);
+  expect(result.output).toContain('test1-done');
+  expect(result.output).toContain('test2-done');
+  expect(result.output).toContain('test3-done');
+});


### PR DESCRIPTION
We used to treat shard from cli and shard from config differently.

References #7849.