### PR TITLE
test(test-runner): unflake override-timeout.spec.ts

### DIFF
--- a/tests/playwright-test/override-timeout.spec.ts
+++ b/tests/playwright-test/override-timeout.spec.ts
@@ -19,12 +19,12 @@ import { test, expect } from './playwright-test-fixtures';
 test('should consider dynamically set value', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.js': `
-      module.exports = { timeout: 100 };
+      module.exports = { timeout: 2000 };
     `,
     'a.test.js': `
       const { test } = pwt;
       test('pass', ({}, testInfo) => {
-        expect(testInfo.timeout).toBe(100);
+        expect(testInfo.timeout).toBe(2000);
       })
     `
   });
@@ -36,8 +36,8 @@ test('should allow different timeouts', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.js': `
       module.exports = { projects: [
-        { timeout: 200 },
-        { timeout: 100 },
+        { timeout: 2000 },
+        { timeout: 4000 },
       ] };
     `,
     'a.test.js': `
@@ -49,14 +49,14 @@ test('should allow different timeouts', async ({ runInlineTest }) => {
   });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(2);
-  expect(result.output).toContain('timeout:100');
-  expect(result.output).toContain('timeout:200');
+  expect(result.output).toContain('timeout:2000');
+  expect(result.output).toContain('timeout:4000');
 });
 
 test('should prioritize value set via command line', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.js': `
-      module.exports = { timeout: 100 };
+      module.exports = { timeout: 2000 };
     `,
     'a.test.js': `
       const { test } = pwt;


### PR DESCRIPTION
This test was flaky sometimes because the timeout of 100/200ms was too low.﻿
