### PR TITLE
feat(test runner): show errors from interrupted tests when available

### DIFF
--- a/docs/src/test-reporter-api/class-testresult.md
+++ b/docs/src/test-reporter-api/class-testresult.md
@@ -35,7 +35,7 @@ Learn more about [test retries](./test-retries.md).
 Start time of this particular test run.
 
 ## property: TestResult.status
-- type: <[void]|[TestStatus]<"passed"|"failed"|"timedOut"|"skipped">>
+- type: <[TestStatus]<"passed"|"failed"|"timedOut"|"skipped">>
 
 The status of this test result. See also [`property: TestCase.expectedStatus`].
 

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -141,20 +141,11 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   }
 
   outcome(): 'skipped' | 'expected' | 'unexpected' | 'flaky' {
-    if (!this.results.length)
+    if (!this.results.length || this.results[0].status === 'skipped')
       return 'skipped';
     if (this.results.length === 1 && this.expectedStatus === this.results[0].status)
-      return this.expectedStatus === 'skipped' ? 'skipped' : 'expected';
-    let hasPassedResults = false;
-    for (const result of this.results) {
-      // TODO: we should not report tests that do not belong to the shard.
-      // Missing status is Ok when running in shards mode.
-      if (!result.status)
-        return 'skipped';
-      if (result.status === this.expectedStatus)
-        hasPassedResults = true;
-    }
-    if (hasPassedResults)
+      return 'expected';
+    if (this.results.some(result => result.status === this.expectedStatus))
       return 'flaky';
     return 'unexpected';
   }
@@ -180,6 +171,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
       stdout: [],
       stderr: [],
       attachments: [],
+      status: 'skipped',
     };
     this.results.push(result);
     return result;

--- a/tests/playwright-test/retry.spec.ts
+++ b/tests/playwright-test/retry.spec.ts
@@ -134,7 +134,7 @@ test('should retry unhandled rejection', async ({ runInlineTest }) => {
         setTimeout(() => {
           throw new Error('Unhandled rejection in the test');
         });
-        await new Promise(f => setTimeout(f, 20));
+        await new Promise(f => setTimeout(f, 2000));
       });
     `
   }, { retries: 2 });

--- a/types/testReporter.d.ts
+++ b/types/testReporter.d.ts
@@ -194,7 +194,7 @@ export interface TestResult {
    * The status of this test result. See also
    * [testCase.expectedStatus](https://playwright.dev/docs/api/class-testcase#test-case-expected-status).
    */
-  status?: TestStatus;
+  status: TestStatus;
   /**
    * An error thrown during the test execution, if any.
    */

--- a/utils/generate_types/overrides-testReporter.d.ts
+++ b/utils/generate_types/overrides-testReporter.d.ts
@@ -50,7 +50,7 @@ export interface TestResult {
   workerIndex: number;
   startTime: Date;
   duration: number;
-  status?: TestStatus;
+  status: TestStatus;
   error?: TestError;
   attachments: { name: string, path?: string, body?: Buffer, contentType: string }[];
   stdout: (string | Buffer)[];


### PR DESCRIPTION
This shows the exact operation that is timing out (like click) when user hits Ctrl+C.