### PR TITLE
feat: response interception after redirects in chromium

### DIFF
--- a/src/server/chromium/crNetworkManager.ts
+++ b/src/server/chromium/crNetworkManager.ts
@@ -278,7 +278,7 @@ export class CRNetworkManager {
       redirectedFrom
     });
     this._requestIdToRequest.set(requestWillBeSentEvent.requestId, request);
-    this._page._frameManager.requestStarted(request.request, route ? new network.Route(request.request, route) : undefined);
+    this._page._frameManager.requestStarted(request.request, route || undefined);
   }
 
   _createResponse(request: InterceptableRequest, responsePayload: Protocol.Network.Response): network.Response {

--- a/src/server/chromium/crNetworkManager.ts
+++ b/src/server/chromium/crNetworkManager.ts
@@ -270,7 +270,6 @@ export class CRNetworkManager {
     const isNavigationRequest = requestWillBeSentEvent.requestId === requestWillBeSentEvent.loaderId && requestWillBeSentEvent.type === 'Document';
     const documentId = isNavigationRequest ? requestWillBeSentEvent.loaderId : undefined;
     const request = new InterceptableRequest({
-      client: this._client,
       frame,
       documentId,
       route,
@@ -411,14 +410,12 @@ class InterceptableRequest {
   _requestId: string;
   _interceptionId: string | null;
   _documentId: string | undefined;
-  private readonly _client: CRSession;
   _timestamp: number;
   _wallTime: number;
   private _route: RouteImpl | null;
   private _redirectedFrom: InterceptableRequest | null;
 
   constructor(options: {
-    client: CRSession;
     frame: frames.Frame;
     documentId?: string;
     route: RouteImpl | null;
@@ -426,8 +423,7 @@ class InterceptableRequest {
     requestPausedEvent: Protocol.Fetch.requestPausedPayload | null;
     redirectedFrom: InterceptableRequest | null;
   }) {
-    const { client, frame, documentId, route, requestWillBeSentEvent, requestPausedEvent, redirectedFrom } = options;
-    this._client = client;
+    const { frame, documentId, route, requestWillBeSentEvent, requestPausedEvent, redirectedFrom } = options;
     this._timestamp = requestWillBeSentEvent.timestamp;
     this._wallTime = requestWillBeSentEvent.wallTime;
     this._requestId = requestWillBeSentEvent.requestId;

--- a/src/server/firefox/ffNetworkManager.ts
+++ b/src/server/firefox/ffNetworkManager.ts
@@ -185,7 +185,7 @@ class InterceptableRequest {
     let postDataBuffer = null;
     if (payload.postData)
       postDataBuffer = Buffer.from(payload.postData, 'base64');
-    this.request = new network.Request(null, frame, redirectedFrom ? redirectedFrom.request : null, payload.navigationId,
+    this.request = new network.Request(frame, redirectedFrom ? redirectedFrom.request : null, payload.navigationId,
         payload.url, internalCauseToResourceType[payload.internalCause] || causeToResourceType[payload.cause] || 'other', payload.method, postDataBuffer, payload.headers);
   }
 }
@@ -209,7 +209,7 @@ class FFRouteImpl implements network.RouteDelegate {
     return Buffer.from(response.base64body, 'base64');
   }
 
-  async continue(overrides: types.NormalizedContinueOverrides): Promise<network.InterceptedResponse|null> {
+  async continue(request: network.Request, overrides: types.NormalizedContinueOverrides): Promise<network.InterceptedResponse|null> {
     const result = await this._session.sendMayFail('Network.resumeInterceptedRequest', {
       requestId: this._request._id,
       url: overrides.url,
@@ -220,7 +220,7 @@ class FFRouteImpl implements network.RouteDelegate {
     }) as any;
     if (!overrides.interceptResponse)
       return null;
-    return new InterceptedResponse(this._request.request._finalRequest(), result.response.status, result.response.statusText, result.response.headers);
+    return new InterceptedResponse(request, result.response.status, result.response.statusText, result.response.headers);
   }
 
   async fulfill(response: types.NormalizedFulfillResponse) {

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -261,7 +261,7 @@ export class FrameManager {
       frame.setPendingDocument({ documentId: request._documentId, request });
     if (request._isFavicon) {
       if (route)
-        route.continue({});
+        route.continue(request, {});
       return;
     }
     this._page._browserContext.emit(BrowserContext.Events.Request, request);

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -254,14 +254,14 @@ export class FrameManager {
       frame._onLifecycleEvent(event);
   }
 
-  requestStarted(request: network.Request, route?: network.Route) {
+  requestStarted(request: network.Request, route?: network.RouteDelegate) {
     const frame = request.frame();
     this._inflightRequestStarted(request);
     if (request._documentId)
       frame.setPendingDocument({ documentId: request._documentId, request });
     if (request._isFavicon) {
       if (route)
-        route.continue();
+        route.continue({});
       return;
     }
     this._page._browserContext.emit(BrowserContext.Events.Request, request);

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -254,19 +254,19 @@ export class FrameManager {
       frame._onLifecycleEvent(event);
   }
 
-  requestStarted(request: network.Request) {
+  requestStarted(request: network.Request, route?: network.Route) {
     const frame = request.frame();
     this._inflightRequestStarted(request);
     if (request._documentId)
       frame.setPendingDocument({ documentId: request._documentId, request });
     if (request._isFavicon) {
-      const route = request._route();
       if (route)
         route.continue();
       return;
     }
     this._page._browserContext.emit(BrowserContext.Events.Request, request);
-    this._page._requestStarted(request);
+    if (route)
+      this._page._requestStarted(request, route);
   }
 
   requestReceivedResponse(response: network.Response) {

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -96,7 +96,7 @@ export class Request extends SdkObject {
   private _waitForResponsePromiseCallback: (value: Response | null) => void = () => {};
   _responseEndTiming = -1;
 
-  constructor(routeDelegate: RouteDelegate | null, frame: frames.Frame, redirectedFrom: Request | null, documentId: string | undefined,
+  constructor(frame: frames.Frame, redirectedFrom: Request | null, documentId: string | undefined,
     url: string, resourceType: string, method: string, postData: Buffer | null, headers: types.HeadersArray) {
     super(frame, 'request');
     assert(!url.startsWith('data:'), 'Data urls should not fire requests');
@@ -248,7 +248,7 @@ export class Route extends SdkObject {
       if (oldUrl.protocol !== newUrl.protocol)
         throw new Error('New URL must have same protocol as overridden URL');
     }
-    this._response = await this._delegate.continue(overrides);
+    this._response = await this._delegate.continue(this._request, overrides);
     return this._response;
   }
 
@@ -411,7 +411,7 @@ export class InterceptedResponse extends SdkObject {
 
   constructor(request: Request, status: number, statusText: string, headers: types.HeadersArray) {
     super(request.frame(), 'interceptedResponse');
-    this._request = request;
+    this._request = request._finalRequest();
     this._status = status;
     this._statusText = statusText;
     this._headers = headers;
@@ -473,7 +473,7 @@ export class WebSocket extends SdkObject {
 export interface RouteDelegate {
   abort(errorCode: string): Promise<void>;
   fulfill(response: types.NormalizedFulfillResponse): Promise<void>;
-  continue(overrides: types.NormalizedContinueOverrides): Promise<InterceptedResponse|null>;
+  continue(request: Request, overrides: types.NormalizedContinueOverrides): Promise<InterceptedResponse|null>;
   responseBody(forFulfill: boolean): Promise<Buffer>;
 }
 

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -79,7 +79,6 @@ export function stripFragmentFromUrl(url: string): string {
 }
 
 export class Request extends SdkObject {
-  readonly _routeDelegate: RouteDelegate | null;
   private _response: Response | null = null;
   private _redirectedFrom: Request | null;
   private _redirectedTo: Request | null = null;
@@ -101,8 +100,6 @@ export class Request extends SdkObject {
     url: string, resourceType: string, method: string, postData: Buffer | null, headers: types.HeadersArray) {
     super(frame, 'request');
     assert(!url.startsWith('data:'), 'Data urls should not fire requests');
-    assert(!(routeDelegate && redirectedFrom), 'Should not be able to intercept redirects');
-    this._routeDelegate = routeDelegate;
     this._frame = frame;
     this._redirectedFrom = redirectedFrom;
     if (redirectedFrom)
@@ -183,12 +180,6 @@ export class Request extends SdkObject {
     return {
       errorText: this._failureText
     };
-  }
-
-  _route(): Route | null {
-    if (!this._routeDelegate)
-      return null;
-    return new Route(this, this._routeDelegate);
   }
 
   updateWithRawHeaders(headers: types.HeadersArray) {

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -405,10 +405,7 @@ export class Page extends SdkObject {
     await this._delegate.updateRequestInterception();
   }
 
-  _requestStarted(request: network.Request) {
-    const route = request._route();
-    if (!route)
-      return;
+  _requestStarted(request: network.Request, route: network.Route) {
     if (this._serverRequestInterceptor) {
       this._serverRequestInterceptor(route, request);
       return;

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -405,7 +405,8 @@ export class Page extends SdkObject {
     await this._delegate.updateRequestInterception();
   }
 
-  _requestStarted(request: network.Request, route: network.Route) {
+  _requestStarted(request: network.Request, routeDelegate: network.RouteDelegate) {
+    const route = new network.Route(request, routeDelegate);
     if (this._serverRequestInterceptor) {
       this._serverRequestInterceptor(route, request);
       return;

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -1008,7 +1008,7 @@ export class WKPage implements PageDelegate {
       session.sendMayFail('Network.interceptContinue', { requestId: event.requestId, stage: 'response' });
       return;
     }
-    route._responseInterceptedCallback({ request: request!, responsePayload: event.response });
+    route._responseInterceptedCallback(event.response);
   }
 
   _onResponseReceived(event: Protocol.Network.responseReceivedPayload) {

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -997,7 +997,7 @@ export class WKPage implements PageDelegate {
       // Just continue.
       session.sendMayFail('Network.interceptWithRequest', { requestId: request._requestId });
     } else {
-      request._route._interceptedCallback();
+      request._route._requestInterceptedCallback();
     }
   }
 

--- a/tests/page/page-request-intercept.spec.ts
+++ b/tests/page/page-request-intercept.spec.ts
@@ -161,7 +161,9 @@ it('should fulfill after redirects', async ({page, server, browserName}) => {
   page.on('request', request => requestUrls.push(request.url()));
   page.on('response', response => responseUrls.push(response.url()));
   page.on('requestfinished', request => requestFinishedUrls.push(request.url()));
+  let routeCalls = 0;
   await page.route('**/*', async route => {
+    ++routeCalls;
     // @ts-expect-error
     await route._intercept({});
     await route.fulfill({
@@ -178,6 +180,7 @@ it('should fulfill after redirects', async ({page, server, browserName}) => {
   expect(responseUrls).toEqual(expectedUrls);
   await response.finished();
   expect(requestFinishedUrls).toEqual(expectedUrls);
+  expect(routeCalls).toBe(1);
 
   const redirectChain = [];
   for (let req = response.request(); req; req = req.redirectedFrom())
@@ -201,7 +204,9 @@ it('should fulfill original response after redirects', async ({page, browserName
   page.on('request', request => requestUrls.push(request.url()));
   page.on('response', response => responseUrls.push(response.url()));
   page.on('requestfinished', request => requestFinishedUrls.push(request.url()));
+  let routeCalls = 0;
   await page.route('**/*', async route => {
+    ++routeCalls;
     // @ts-expect-error
     await route._intercept({});
     await route.fulfill();
@@ -211,6 +216,7 @@ it('should fulfill original response after redirects', async ({page, browserName
   expect(responseUrls).toEqual(expectedUrls);
   await response.finished();
   expect(requestFinishedUrls).toEqual(expectedUrls);
+  expect(routeCalls).toBe(1);
 
   const redirectChain = [];
   for (let req = response.request(); req; req = req.redirectedFrom())
@@ -234,7 +240,9 @@ it('should abort after redirects', async ({page, browserName, server}) => {
   page.on('response', response => responseUrls.push(response.url()));
   page.on('requestfinished', request => requestFinishedUrls.push(request.url()));
   page.on('requestfailed', request => requestFailedUrls.push(request.url()));
+  let routeCalls = 0;
   await page.route('**/*', async route => {
+    ++routeCalls;
     // @ts-expect-error
     await route._intercept({});
     await route.abort('connectionreset');
@@ -249,4 +257,5 @@ it('should abort after redirects', async ({page, browserName, server}) => {
   expect(responseUrls).toEqual(expectedUrls.slice(0, -1));
   expect(requestFinishedUrls).toEqual(expectedUrls.slice(0, -1));
   expect(requestFailedUrls).toEqual(expectedUrls.slice(-1));
+  expect(routeCalls).toBe(1);
 });


### PR DESCRIPTION
In case of redirects only response to the last request in a redirect chain is intercepted. Since the client API starts by calling route.intercept() holding a handle to the first request in the chain, on the server end we always redirect abort/fulfill calls to the last InterceptableRequest in the sequence. `InterceptableRequest._redirectedRequest` can be set only on the first request in the chain and it points to the final request of the redirect chain, i.e. that whose response is actually intercepted.

#1774