### PR TITLE
feat(tracing): introduce _reset() and _export()

### DIFF
--- a/src/client/tracing.ts
+++ b/src/client/tracing.ts
@@ -32,17 +32,32 @@ export class Tracing implements api.Tracing {
     });
   }
 
+  async _reset() {
+    await this._context._wrapApiCall(async (channel: channels.BrowserContextChannel) => {
+      return await channel.tracingReset();
+    });
+  }
+
+  async _export(options: { path: string }) {
+    await this._context._wrapApiCall(async (channel: channels.BrowserContextChannel) => {
+      await this._doExport(channel, options.path);
+    });
+  }
+
   async stop(options: { path?: string } = {}) {
     await this._context._wrapApiCall(async (channel: channels.BrowserContextChannel) => {
       await channel.tracingStop();
-      if (options.path) {
-        const result = await channel.tracingExport();
-        const artifact = Artifact.from(result.artifact);
-        if (this._context.browser()?._remoteType)
-          artifact._isRemote = true;
-        await artifact.saveAs(options.path);
-        await artifact.delete();
-      }
+      if (options.path)
+        await this._doExport(channel, options.path);
     });
+  }
+
+  private async _doExport(channel: channels.BrowserContextChannel, path: string) {
+    const result = await channel.tracingExport();
+    const artifact = Artifact.from(result.artifact);
+    if (this._context.browser()?._remoteType)
+      artifact._isRemote = true;
+    await artifact.saveAs(path);
+    await artifact.delete();
   }
 }

--- a/src/dispatchers/browserContextDispatcher.ts
+++ b/src/dispatchers/browserContextDispatcher.ts
@@ -184,6 +184,10 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     await this._context.tracing.start(params);
   }
 
+  async tracingReset(params: channels.BrowserContextTracingResetParams): Promise<channels.BrowserContextTracingResetResult> {
+    await this._context.tracing.reset();
+  }
+
   async tracingStop(params: channels.BrowserContextTracingStopParams): Promise<channels.BrowserContextTracingStopResult> {
     await this._context.tracing.stop();
   }

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -656,6 +656,7 @@ export interface BrowserContextChannel extends EventTargetChannel {
   recorderSupplementEnable(params: BrowserContextRecorderSupplementEnableParams, metadata?: Metadata): Promise<BrowserContextRecorderSupplementEnableResult>;
   newCDPSession(params: BrowserContextNewCDPSessionParams, metadata?: Metadata): Promise<BrowserContextNewCDPSessionResult>;
   tracingStart(params: BrowserContextTracingStartParams, metadata?: Metadata): Promise<BrowserContextTracingStartResult>;
+  tracingReset(params?: BrowserContextTracingResetParams, metadata?: Metadata): Promise<BrowserContextTracingResetResult>;
   tracingStop(params?: BrowserContextTracingStopParams, metadata?: Metadata): Promise<BrowserContextTracingStopResult>;
   tracingExport(params?: BrowserContextTracingExportParams, metadata?: Metadata): Promise<BrowserContextTracingExportResult>;
 }
@@ -864,6 +865,9 @@ export type BrowserContextTracingStartOptions = {
   screenshots?: boolean,
 };
 export type BrowserContextTracingStartResult = void;
+export type BrowserContextTracingResetParams = {};
+export type BrowserContextTracingResetOptions = {};
+export type BrowserContextTracingResetResult = void;
 export type BrowserContextTracingStopParams = {};
 export type BrowserContextTracingStopOptions = {};
 export type BrowserContextTracingStopResult = void;

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -639,6 +639,8 @@ BrowserContext:
         snapshots: boolean?
         screenshots: boolean?
 
+    tracingReset:
+
     tracingStop:
 
     tracingExport:

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -413,6 +413,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     snapshots: tOptional(tBoolean),
     screenshots: tOptional(tBoolean),
   });
+  scheme.BrowserContextTracingResetParams = tOptional(tObject({}));
   scheme.BrowserContextTracingStopParams = tOptional(tObject({}));
   scheme.BrowserContextTracingExportParams = tOptional(tObject({}));
   scheme.PageSetDefaultNavigationTimeoutNoReplyParams = tObject({

--- a/src/server/snapshot/snapshotter.ts
+++ b/src/server/snapshot/snapshotter.ts
@@ -62,13 +62,18 @@ export class Snapshotter {
       this._initialized = true;
       await this._initialize();
     }
-    await this._runInAllFrames(`window["${this._snapshotStreamer}"].reset()`);
+    await this.reset();
 
     // Replay resources loaded in all pages.
     for (const page of this._context.pages()) {
       for (const response of page._frameManager._responses)
         this._saveResource(response).catch(e => debugLogger.log('error', e));
     }
+  }
+
+  async reset() {
+    if (this._started)
+      await this._runInAllFrames(`window["${this._snapshotStreamer}"].reset()`);
   }
 
   async stop() {

--- a/src/server/trace/common/traceEvents.ts
+++ b/src/server/trace/common/traceEvents.ts
@@ -50,9 +50,15 @@ export type FrameSnapshotTraceEvent = {
   snapshot: FrameSnapshot,
 };
 
+export type MarkerTraceEvent = {
+  type: 'marker',
+  resetIndex?: number,
+};
+
 export type TraceEvent =
     ContextCreatedTraceEvent |
     ScreencastFrameTraceEvent |
     ActionTraceEvent |
     ResourceSnapshotTraceEvent |
-    FrameSnapshotTraceEvent;
+    FrameSnapshotTraceEvent |
+    MarkerTraceEvent;

--- a/src/server/trace/recorder/traceSnapshotter.ts
+++ b/src/server/trace/recorder/traceSnapshotter.ts
@@ -46,6 +46,14 @@ export class TraceSnapshotter extends EventEmitter implements SnapshotterDelegat
     await this._snapshotter.start();
   }
 
+  async reset() {
+    await this._snapshotter.reset();
+  }
+
+  async checkpoint() {
+    await this._writeArtifactChain;
+  }
+
   async stop(): Promise<void> {
     await this._snapshotter.stop();
     await this._writeArtifactChain;


### PR DESCRIPTION
`tracing._export({ path })` exports current tracing state into a file
and does not require tracing to be stopped.

`tracing._reset()` resets current tracing state, but keeps resources
around so they can be referenced in the future snapshots. Does not stop.

The usage pattern is:
```js
await tracing.start({ screenshots: true, snapshots: true });
// ...
await tracing._reset();
// Do stuff, it will all be in the export below.
await tracing._export({ path });
// ...
await tracing.stop();
```