### PR TITLE
chore: ensure assertions result in a meaningful message

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -186,7 +186,7 @@ export function makeWaitForNextTask() {
 
 export function assert(value: any, message?: string): asserts value {
   if (!value)
-    throw new Error(message);
+    throw new Error(message || 'Assertion error');
 }
 
 export function debugAssert(value: any, message?: string): asserts value {


### PR DESCRIPTION
We saw user stacktraces which only contained "Error" and this should give "Assertion error" instead.