### PR TITLE
feat(firefox-beta): roll to 1273

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "firefox-beta",
-      "revision": "1267",
+      "revision": "1273",
       "installByDefault": false
     },
     {


### PR DESCRIPTION
### Firefox Beta Linux

- [ ]     [firefox] › video.spec.ts:361:3 › screencast should capture css transformation =================
- [ ]    [firefox] › video.spec.ts:421:3 › screencast should scale frames down to the requested size  ===
- [x] Build failed because Rust was on the wrong version

### Firefox Beta Win

- [x]      [firefox] › page\page-request-intercept.spec.ts:59:1 › should support fulfill after intercept ==
  -  Fixed in https://github.com/microsoft/playwright/pull/7988
- [ ]      [firefox] › video.spec.ts:361:3 › screencast should capture css transformation =================
- [ ]      [firefox] › video.spec.ts:421:3 › screencast should scale frames down to the requested size  ===

### Firefox Beta Mac

- [x] Build failed because Rust was on the wrong version