### PR TITLE
feat(tracing): allow calling tracing.start multiple times

### DIFF
--- a/src/client/tracing.ts
+++ b/src/client/tracing.ts
@@ -32,12 +32,6 @@ export class Tracing implements api.Tracing {
     });
   }
 
-  async _reset() {
-    await this._context._wrapApiCall(async (channel: channels.BrowserContextChannel) => {
-      return await channel.tracingReset();
-    });
-  }
-
   async _export(options: { path: string }) {
     await this._context._wrapApiCall(async (channel: channels.BrowserContextChannel) => {
       await this._doExport(channel, options.path);
@@ -46,9 +40,9 @@ export class Tracing implements api.Tracing {
 
   async stop(options: { path?: string } = {}) {
     await this._context._wrapApiCall(async (channel: channels.BrowserContextChannel) => {
-      await channel.tracingStop();
       if (options.path)
         await this._doExport(channel, options.path);
+      await channel.tracingStop();
     });
   }
 

--- a/src/dispatchers/browserContextDispatcher.ts
+++ b/src/dispatchers/browserContextDispatcher.ts
@@ -184,10 +184,6 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     await this._context.tracing.start(params);
   }
 
-  async tracingReset(params: channels.BrowserContextTracingResetParams): Promise<channels.BrowserContextTracingResetResult> {
-    await this._context.tracing.reset();
-  }
-
   async tracingStop(params: channels.BrowserContextTracingStopParams): Promise<channels.BrowserContextTracingStopResult> {
     await this._context.tracing.stop();
   }

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -656,7 +656,6 @@ export interface BrowserContextChannel extends EventTargetChannel {
   recorderSupplementEnable(params: BrowserContextRecorderSupplementEnableParams, metadata?: Metadata): Promise<BrowserContextRecorderSupplementEnableResult>;
   newCDPSession(params: BrowserContextNewCDPSessionParams, metadata?: Metadata): Promise<BrowserContextNewCDPSessionResult>;
   tracingStart(params: BrowserContextTracingStartParams, metadata?: Metadata): Promise<BrowserContextTracingStartResult>;
-  tracingReset(params?: BrowserContextTracingResetParams, metadata?: Metadata): Promise<BrowserContextTracingResetResult>;
   tracingStop(params?: BrowserContextTracingStopParams, metadata?: Metadata): Promise<BrowserContextTracingStopResult>;
   tracingExport(params?: BrowserContextTracingExportParams, metadata?: Metadata): Promise<BrowserContextTracingExportResult>;
 }
@@ -865,9 +864,6 @@ export type BrowserContextTracingStartOptions = {
   screenshots?: boolean,
 };
 export type BrowserContextTracingStartResult = void;
-export type BrowserContextTracingResetParams = {};
-export type BrowserContextTracingResetOptions = {};
-export type BrowserContextTracingResetResult = void;
 export type BrowserContextTracingStopParams = {};
 export type BrowserContextTracingStopOptions = {};
 export type BrowserContextTracingStopResult = void;

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -639,8 +639,6 @@ BrowserContext:
         snapshots: boolean?
         screenshots: boolean?
 
-    tracingReset:
-
     tracingStop:
 
     tracingExport:

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -413,7 +413,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     snapshots: tOptional(tBoolean),
     screenshots: tOptional(tBoolean),
   });
-  scheme.BrowserContextTracingResetParams = tOptional(tObject({}));
   scheme.BrowserContextTracingStopParams = tOptional(tObject({}));
   scheme.BrowserContextTracingExportParams = tOptional(tObject({}));
   scheme.PageSetDefaultNavigationTimeoutNoReplyParams = tObject({

--- a/src/server/snapshot/inMemorySnapshotter.ts
+++ b/src/server/snapshot/inMemorySnapshotter.ts
@@ -42,6 +42,11 @@ export class InMemorySnapshotter extends BaseSnapshotStorage implements Snapshot
     return await this._server.start();
   }
 
+  async reset() {
+    await this._snapshotter.reset();
+    this.clear();
+  }
+
   async dispose() {
     this._snapshotter.dispose();
     await this._server.stop();

--- a/src/server/snapshot/snapshotterInjected.ts
+++ b/src/server/snapshot/snapshotterInjected.ts
@@ -177,6 +177,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string) {
           visitNode(child);
       };
       visitNode(document.documentElement);
+      visitNode(this._fakeBase);
     }
 
     private _sanitizeUrl(url: string): string {

--- a/tests/snapshotter.spec.ts
+++ b/tests/snapshotter.spec.ts
@@ -44,6 +44,17 @@ it.describe('snapshots', () => {
     expect(distillSnapshot(snapshot)).toBe('<BUTTON>Hello</BUTTON>');
   });
 
+  it('should preserve BASE and other content on reset', async ({ page, toImpl, snapshotter, server }) => {
+    await page.goto(server.EMPTY_PAGE);
+    const snapshot1 = await snapshotter.captureSnapshot(toImpl(page), 'snapshot1');
+    const html1 = snapshot1.render().html;
+    expect(html1).toContain(`<BASE href="${server.EMPTY_PAGE}"`);
+    await snapshotter.reset();
+    const snapshot2 = await snapshotter.captureSnapshot(toImpl(page), 'snapshot2');
+    const html2 = snapshot2.render().html;
+    expect(html2.replace(`"snapshot2"`, `"snapshot1"`)).toEqual(html1);
+  });
+
   it('should capture resources', async ({ page, toImpl, server, snapshotter }) => {
     await page.goto(server.EMPTY_PAGE);
     await page.route('**/style.css', route => {


### PR DESCRIPTION
Subsequent invocations reset the trace. This removes the `tracing._reset` method.

Also fixed a bug where BASE element was not reset properly.
Also fixed a bug where tracing would affect the result of protocol call by setting `callMetadata.error` property.