### PR TITLE
fix(trace-viewer): when clicking on a step no snapshot was shown

### DIFF
--- a/src/web/traceViewer/ui/snapshotTab.tsx
+++ b/src/web/traceViewer/ui/snapshotTab.tsx
@@ -37,7 +37,7 @@ export const SnapshotTab: React.FunctionComponent<{
   const snapshots = [actionSnapshot ? { ...actionSnapshot, title: 'action' } : undefined, snapshotMap.get('before'), snapshotMap.get('after')].filter(Boolean) as { title: string, snapshotName: string }[];
 
   React.useEffect(() => {
-    if (snapshotIndex >= snapshots.length)
+    if (snapshots.length >= 1 && snapshotIndex >= snapshots.length)
       setSnapshotIndex(snapshots.length - 1);
   }, [snapshotIndex, snapshots]);
 


### PR DESCRIPTION
Currently when using the ToT trace-viewer, opening a trace, clicking on a step no snapshot gets displayed. This is because:
1. `snapshotIndex` is 0
2. The if results in true (snapshots.length = 0) and snapshotIndex gets set to -1

Before:
 
![image](https://user-images.githubusercontent.com/17984549/128513183-801ccc1a-3d78-436b-8375-a8ae5dc01888.png)

After:

![image](https://user-images.githubusercontent.com/17984549/128513224-a01920bd-c0da-4012-9ec3-630cc01edeb9.png)
