### PR TITLE
doc(test-runner): add example of compiling tests with typescript

### DIFF
--- a/docs/src/test-typescript-js.md
+++ b/docs/src/test-typescript-js.md
@@ -29,6 +29,6 @@ In my `package.json`, I have two scripts:
 }
 ```
 
-The `pretest` script runs typescript on the tests.  `test` will run the tests that have been generated to the `tests-out` directory. The `-c` argument configures the test runner to look for tests inside the `tests-out` directory.
+The `pretest` script runs typescript on the tests. `test` will run the tests that have been generated to the `tests-out` directory. The `-c` argument configures the test runner to look for tests inside the `tests-out` directory.
 
 Then `npm run test` will build the tests and run them.

--- a/docs/src/typescript-js.md
+++ b/docs/src/typescript-js.md
@@ -1,0 +1,34 @@
+## Manually compile tests with TypeScript
+
+Playwright Test supports TypeScript out the box. We automatically transform
+TypeScript code to javascript to run it.
+
+However if you find that the TypeScript code is not being transpiled correctly,
+you can perform your own TypeScript compilation before sending the tests to Playwright.
+
+First I add a `tsconfig.json` file inside my tests directory.
+```json
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "module": "commonjs",
+        "moduleResolution": "Node",
+        "sourceMap": true,
+        "outDir": "../tests-out",
+    }
+}
+```
+
+In my `package.json`, I have two scripts:
+```json
+{
+  "scripts": {
+    "pretest": "tsc --incremental -p tests/tsconfig.json",
+    "test": "playwright test -c tests-out"
+  }
+}
+```
+
+The `pretest` script runs typescript on the tests.  `test` will run the tests that have been generated to the `tests-out` directory. The `-c` argument configures the test runner to look for tests inside the `tests-out` directory.
+
+Then `npm run test` will build the tests and run them.


### PR DESCRIPTION
I was having trouble figuring out how the docs are structured. Will this file be
automatically picked up by the search? Should it be linked from somewhere? Does it
need to be called `typescript-js.md`?﻿
