### PR TITLE
feat(junit reporter): add attachments to stdout

### DIFF
--- a/src/test/reporters/junit.ts
+++ b/src/test/reporters/junit.ts
@@ -153,6 +153,15 @@ class JUnitReporter implements Reporter {
         });
       }
 
+      for (const attachment of result.attachments) {
+        if (attachment.path) {
+          entries.push({
+            name: 'system-out',
+            text: `[[ATTACHMENT|${path.relative(this.config.rootDir, attachment.path)}]]`
+          });
+        }
+      }
+
       for (const stderr of result.stderr) {
         entries.push({
           name: 'system-err',

--- a/tests/playwright-test/junit-reporter.spec.ts
+++ b/tests/playwright-test/junit-reporter.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import xml2js from 'xml2js';
+import path from 'path';
 import { test, expect } from './playwright-test-fixtures';
 
 test('should render expected', async ({ runInlineTest }) => {
@@ -217,6 +218,23 @@ test('should render projects', async ({ runInlineTest }) => {
   expect(xml['testsuites']['testsuite'][1]['$']['skipped']).toBe('0');
   expect(xml['testsuites']['testsuite'][1]['testcase'][0]['$']['name']).toBe('one');
   expect(xml['testsuites']['testsuite'][1]['testcase'][0]['$']['classname']).toContain('[project2] › a.test.js:6:7 › one');
+  expect(result.exitCode).toBe(0);
+});
+
+test('should render attachments', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test.use({ screenshot: 'on' });
+      test('one', async ({ page }) => {
+        await page.setContent('hello');
+      });
+    `,
+  }, { reporter: 'junit' });
+  const xml = parseXML(result.output);
+  const suite = xml['testsuites']['testsuite'][0];
+  expect(suite['system-out'].length).toBe(1);
+  expect(suite['system-out'][0].trim()).toBe(`[[ATTACHMENT|test-results${path.sep}a-one${path.sep}test-finished-1.png]]`);
   expect(result.exitCode).toBe(0);
 });
 


### PR DESCRIPTION
`JUnitReporter` follows the common format for attachments in JUnit reports, recognized by GitLab and Jenkins among others.

Fixes #7887.