### PR TITLE
devops: disable dchecks when building chromium

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -59,6 +59,7 @@ compile_chromium() {
   # Prepare build folder.
   mkdir -p "./out/Default"
   echo "is_debug = false" > ./out/Default/args.gn
+  echo "dcheck_always_on = false" >> ./out/Default/args.gn
   if [[ $2 == "--symbols" ]]; then
     echo "symbol_level = 1" >> ./out/Default/args.gn
   else


### PR DESCRIPTION
As of https://chromium-review.googlesource.com/c/chromium/src/+/3053740,
Chromium defaults to building with dchecks always on.

We don't want dchecks enabled in our builds so we must disable them
explicitly.

References #8052