### PR TITLE
feat: introduce react selectors

### DIFF
--- a/docs/src/selectors.md
+++ b/docs/src/selectors.md
@@ -179,6 +179,25 @@ methods accept [`param: selector`] as their first argument.
   await page.ClickAsync("xpath=//button");
   ```
   Learn more about [XPath selector][xpath].
+- React selector
+  ```js
+  await page.click('react=DatePickerComponent');
+  ```
+  ```java
+  page.click("react=DatePickerComponent");
+  ```
+  ```python async
+  await page.click("react=DatePickerComponent")
+  ```
+  ```python sync
+  page.click("react=DatePickerComponent")
+  ```
+  ```csharp
+  await page.ClickAsync("react=DatePickerComponent");
+  ```
+  Learn more about [React selector][react].
+
+
 
 ## Text selector
 
@@ -625,6 +644,25 @@ converts `'//html/body'` to `'xpath=//html/body'`.
 `xpath` does not pierce shadow roots
 :::
 
+## React selectors
+
+React selectors allow selecting elements by its component name. If component
+ has multiple root elements (see [React Fragments](https://reactjs.org/docs/fragments.html)),
+ `react` selector will return all of them.
+
+To find React element names in a tree use [React DevTools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi).
+
+Example: `react=MyComponent`
+
+:::note
+React selectors support React 15 and above.
+:::
+
+:::note
+React selectors, as well as [React DevTools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi), only work against **unminified** application builds.
+:::
+
+
 ## id, data-testid, data-test-id, data-test selectors
 
 Playwright supports a shorthand for selecting elements using certain attributes. Currently, only
@@ -966,4 +1004,5 @@ await page.ClickAsync("//*[@id='tsf']/div[2]/div[1]/div[1]/div/div[2]/input");
 [text]: #text-selector
 [css]: #css-selector
 [xpath]: #xpath-selectors
+[react]: #react-selectors
 [id]: #id-data-testid-data-test-id-data-test-selectors

--- a/docs/src/selectors.md
+++ b/docs/src/selectors.md
@@ -646,9 +646,7 @@ converts `'//html/body'` to `'xpath=//html/body'`.
 
 ## React selectors
 
-React selectors allow selecting elements by its component name. If component
- has multiple root elements (see [React Fragments](https://reactjs.org/docs/fragments.html)),
- `react` selector will return all of them.
+React selectors allow selecting elements by its component name.
 
 To find React element names in a tree use [React DevTools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi).
 

--- a/src/server/injected/injectedScript.ts
+++ b/src/server/injected/injectedScript.ts
@@ -16,6 +16,7 @@
 
 import { SelectorEngine, SelectorRoot } from './selectorEngine';
 import { XPathEngine } from './xpathSelectorEngine';
+import { ReactEngine } from './reactSelectorEngine';
 import { ParsedSelector, ParsedSelectorPart, parseSelector } from '../common/selectorParser';
 import { FatalDOMError } from '../common/domErrors';
 import { SelectorEvaluatorImpl, isVisible, parentElementOrShadowHost, elementMatchesText, TextMatcher, createRegexTextMatcher, createStrictTextMatcher, createLaxTextMatcher } from './selectorEvaluator';
@@ -62,6 +63,7 @@ export class InjectedScript {
     this._engines = new Map();
     this._engines.set('xpath', XPathEngine);
     this._engines.set('xpath:light', XPathEngine);
+    this._engines.set('react', ReactEngine);
     this._engines.set('text', this._createTextEngine(true));
     this._engines.set('text:light', this._createTextEngine(false));
     this._engines.set('id', this._createAttributeEngine('id', true));

--- a/src/server/injected/reactSelectorEngine.ts
+++ b/src/server/injected/reactSelectorEngine.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SelectorEngine, SelectorRoot } from './selectorEngine';
+
+type ComponentNode = {
+  name: string,
+  children: ComponentNode[],
+  rootElements: Element[],
+};
+
+type ReactVNode = {
+  // React 16+
+  type: any,
+  child?: ReactVNode,
+  sibling?: ReactVNode,
+  stateNode?: Node,
+
+  // React 15
+  _hostNode?: any,
+  _currentElement?: any,
+  _renderedComponent?: any,
+  _renderedChildren?: any[],
+};
+
+function getComponentName(reactElement: ReactVNode): string {
+  // React 16+
+  if (typeof reactElement.type === 'function')
+    return reactElement.type.displayName || reactElement.type.name || 'Anonymous';
+  if (typeof reactElement.type === 'string')
+    return reactElement.type;
+
+  // React 15
+  if (reactElement._currentElement) {
+    const elementType = reactElement._currentElement.type;
+    if (typeof elementType === 'string')
+      return elementType;
+    if (typeof elementType === 'function')
+      return elementType.displayName || elementType.name || 'Anonymous';
+  }
+  return '';
+}
+
+function getChildren(reactElement: ReactVNode): ReactVNode[] {
+  // React 16+
+  if (reactElement.child) {
+    const children: ReactVNode[] = [];
+    for (let child: ReactVNode|undefined = reactElement.child; child; child = child.sibling)
+      children.push(child);
+    return children;
+  }
+
+  // React 15
+  if (!reactElement._currentElement)
+    return [];
+  const isKnownElement = (reactElement: ReactVNode) => {
+    const elementType = reactElement._currentElement?.type;
+    return typeof elementType === 'function' || typeof elementType === 'string';
+  };
+
+  if (reactElement._renderedComponent) {
+    const child = reactElement._renderedComponent;
+    return isKnownElement(child) ? [child] : [];
+  }
+  if (reactElement._renderedChildren)
+    return [...Object.values(reactElement._renderedChildren)].filter(isKnownElement);
+  return [];
+}
+
+function buildComponentsTree(reactElement: ReactVNode): ComponentNode {
+  const treeNode: ComponentNode = {
+    name: getComponentName(reactElement),
+    children: getChildren(reactElement).map(buildComponentsTree),
+    rootElements: [],
+  };
+
+  const rootElement =
+      // React 16+
+      reactElement.stateNode ||
+      // React 15
+      reactElement._hostNode || reactElement._renderedComponent?._hostNode;
+  if (rootElement instanceof Element) {
+    treeNode.rootElements.push(rootElement);
+  } else {
+    for (const child of treeNode.children)
+      treeNode.rootElements.push(...child.rootElements);
+  }
+  return treeNode;
+}
+
+function filterComponentsTree(treeNode: ComponentNode, searchFn: (node: ComponentNode) => boolean, result: ComponentNode[] = []) {
+  if (searchFn(treeNode))
+    result.push(treeNode);
+  for (const child of treeNode.children)
+    filterComponentsTree(child, searchFn, result);
+  return result;
+}
+
+function findReactRoot(): ReactVNode | undefined {
+  const walker = document.createTreeWalker(document);
+  while (walker.nextNode()) {
+    if (walker.currentNode.hasOwnProperty('_reactRootContainer'))
+      return (walker.currentNode as any)._reactRootContainer._internalRoot.current;
+    for (const key of Object.keys(walker.currentNode)) {
+      if (key.startsWith('__reactInternalInstance') || key.startsWith('__reactFiber'))
+        return (walker.currentNode as any)[key];
+    }
+  }
+  return undefined;
+}
+
+export const ReactEngine: SelectorEngine = {
+  queryAll(scope: SelectorRoot, name: string): Element[] {
+    const reactRoot = findReactRoot();
+    if (!reactRoot)
+      return [];
+    const tree = buildComponentsTree(reactRoot);
+    const treeNodes = filterComponentsTree(tree, treeNode => {
+      if (treeNode.name !== name)
+        return false;
+      if (treeNode.rootElements.some(domNode => !scope.contains(domNode)))
+        return false;
+      return true;
+    });
+    const allRootElements: Set<Element> = new Set();
+    for (const treeNode of treeNodes) {
+      for (const domNode of treeNode.rootElements)
+        allRootElements.add(domNode);
+    }
+    return [...allRootElements];
+  }
+};

--- a/src/server/injected/reactSelectorEngine.ts
+++ b/src/server/injected/reactSelectorEngine.ts
@@ -38,12 +38,14 @@ type ReactVNode = {
 
 function getComponentName(reactElement: ReactVNode): string {
   // React 16+
+  // @see https://github.com/baruchvlz/resq/blob/5c15a5e04d3f7174087248f5a158c3d6dcc1ec72/src/utils.js#L16
   if (typeof reactElement.type === 'function')
     return reactElement.type.displayName || reactElement.type.name || 'Anonymous';
   if (typeof reactElement.type === 'string')
     return reactElement.type;
 
   // React 15
+  // @see https://github.com/facebook/react/blob/2edf449803378b5c58168727d4f123de3ba5d37f/packages/react-devtools-shared/src/backend/legacy/renderer.js#L59
   if (reactElement._currentElement) {
     const elementType = reactElement._currentElement.type;
     if (typeof elementType === 'string')
@@ -56,6 +58,7 @@ function getComponentName(reactElement: ReactVNode): string {
 
 function getChildren(reactElement: ReactVNode): ReactVNode[] {
   // React 16+
+  // @see https://github.com/baruchvlz/resq/blob/5c15a5e04d3f7174087248f5a158c3d6dcc1ec72/src/utils.js#L192
   if (reactElement.child) {
     const children: ReactVNode[] = [];
     for (let child: ReactVNode|undefined = reactElement.child; child; child = child.sibling)
@@ -64,6 +67,7 @@ function getChildren(reactElement: ReactVNode): ReactVNode[] {
   }
 
   // React 15
+  // @see https://github.com/facebook/react/blob/2edf449803378b5c58168727d4f123de3ba5d37f/packages/react-devtools-shared/src/backend/legacy/renderer.js#L101
   if (!reactElement._currentElement)
     return [];
   const isKnownElement = (reactElement: ReactVNode) => {
@@ -89,6 +93,7 @@ function buildComponentsTree(reactElement: ReactVNode): ComponentNode {
 
   const rootElement =
       // React 16+
+      // @see https://github.com/baruchvlz/resq/blob/5c15a5e04d3f7174087248f5a158c3d6dcc1ec72/src/utils.js#L29
       reactElement.stateNode ||
       // React 15
       reactElement._hostNode || reactElement._renderedComponent?._hostNode;
@@ -112,9 +117,11 @@ function filterComponentsTree(treeNode: ComponentNode, searchFn: (node: Componen
 function findReactRoot(): ReactVNode | undefined {
   const walker = document.createTreeWalker(document);
   while (walker.nextNode()) {
+    // @see https://github.com/baruchvlz/resq/blob/5c15a5e04d3f7174087248f5a158c3d6dcc1ec72/src/utils.js#L329
     if (walker.currentNode.hasOwnProperty('_reactRootContainer'))
       return (walker.currentNode as any)._reactRootContainer._internalRoot.current;
     for (const key of Object.keys(walker.currentNode)) {
+      // @see https://github.com/baruchvlz/resq/blob/5c15a5e04d3f7174087248f5a158c3d6dcc1ec72/src/utils.js#L334
       if (key.startsWith('__reactInternalInstance') || key.startsWith('__reactFiber'))
         return (walker.currentNode as any)[key];
     }

--- a/src/server/selectors.ts
+++ b/src/server/selectors.ts
@@ -38,6 +38,7 @@ export class Selectors {
     this._builtinEngines = new Set([
       'css', 'css:light',
       'xpath', 'xpath:light',
+      'react',
       'text', 'text:light',
       'id', 'id:light',
       'data-testid', 'data-testid:light',

--- a/src/server/selectors.ts
+++ b/src/server/selectors.ts
@@ -30,6 +30,7 @@ export type SelectorInfo = {
 
 export class Selectors {
   readonly _builtinEngines: Set<string>;
+  readonly _builtinEnginesInMainWorld: Set<string>;
   readonly _engines: Map<string, { source: string, contentScript: boolean }>;
   readonly guid = `selectors@${createGuid()}`;
 
@@ -45,6 +46,9 @@ export class Selectors {
       'data-test-id', 'data-test-id:light',
       'data-test', 'data-test:light',
       '_visible', '_nth'
+    ]);
+    this._builtinEnginesInMainWorld = new Set([
+      'react',
     ]);
     this._engines = new Map();
   }
@@ -131,6 +135,8 @@ export class Selectors {
       if (!custom && !this._builtinEngines.has(part.name))
         throw new Error(`Unknown engine "${part.name}" while parsing selector ${selector}`);
       if (custom && !custom.contentScript)
+        needsMainWorld = true;
+      if (this._builtinEnginesInMainWorld.has(part.name))
         needsMainWorld = true;
     }
     return {

--- a/tests/assets/reading-list/react-dom_15.7.0.js
+++ b/tests/assets/reading-list/react-dom_15.7.0.js
@@ -1,0 +1,18853 @@
+ /**
+  * ReactDOM v15.7.0
+  */
+
+;(function(f) {
+  // CommonJS
+  if (typeof exports === "object" && typeof module !== "undefined") {
+    module.exports = f(require('react'));
+
+  // RequireJS
+  } else if (typeof define === "function" && define.amd) {
+    define(['react'], f);
+
+  // <script>
+  } else {
+    var g;
+    if (typeof window !== "undefined") {
+      g = window;
+    } else if (typeof global !== "undefined") {
+      g = global;
+    } else if (typeof self !== "undefined") {
+      g = self;
+    } else {
+      // works providing we're not in "use strict";
+      // needed for Java 8 Nashorn
+      // see https://github.com/facebook/react/issues/3037
+      g = this;
+    }
+    g.ReactDOM = f(g.React);
+  }
+})(function(React) {
+  return (function(f){return f()})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ARIADOMPropertyConfig = {
+  Properties: {
+    // Global States and Properties
+    'aria-current': 0, // state
+    'aria-details': 0,
+    'aria-disabled': 0, // state
+    'aria-hidden': 0, // state
+    'aria-invalid': 0, // state
+    'aria-keyshortcuts': 0,
+    'aria-label': 0,
+    'aria-roledescription': 0,
+    // Widget Attributes
+    'aria-autocomplete': 0,
+    'aria-checked': 0,
+    'aria-expanded': 0,
+    'aria-haspopup': 0,
+    'aria-level': 0,
+    'aria-modal': 0,
+    'aria-multiline': 0,
+    'aria-multiselectable': 0,
+    'aria-orientation': 0,
+    'aria-placeholder': 0,
+    'aria-pressed': 0,
+    'aria-readonly': 0,
+    'aria-required': 0,
+    'aria-selected': 0,
+    'aria-sort': 0,
+    'aria-valuemax': 0,
+    'aria-valuemin': 0,
+    'aria-valuenow': 0,
+    'aria-valuetext': 0,
+    // Live Region Attributes
+    'aria-atomic': 0,
+    'aria-busy': 0,
+    'aria-live': 0,
+    'aria-relevant': 0,
+    // Drag-and-Drop Attributes
+    'aria-dropeffect': 0,
+    'aria-grabbed': 0,
+    // Relationship Attributes
+    'aria-activedescendant': 0,
+    'aria-colcount': 0,
+    'aria-colindex': 0,
+    'aria-colspan': 0,
+    'aria-controls': 0,
+    'aria-describedby': 0,
+    'aria-errormessage': 0,
+    'aria-flowto': 0,
+    'aria-labelledby': 0,
+    'aria-owns': 0,
+    'aria-posinset': 0,
+    'aria-rowcount': 0,
+    'aria-rowindex': 0,
+    'aria-rowspan': 0,
+    'aria-setsize': 0
+  },
+  DOMAttributeNames: {},
+  DOMPropertyNames: {}
+};
+
+module.exports = ARIADOMPropertyConfig;
+},{}],2:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ReactDOMComponentTree = _dereq_(34);
+
+var focusNode = _dereq_(146);
+
+var AutoFocusUtils = {
+  focusDOMComponent: function () {
+    focusNode(ReactDOMComponentTree.getNodeFromInstance(this));
+  }
+};
+
+module.exports = AutoFocusUtils;
+},{"146":146,"34":34}],3:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var EventPropagators = _dereq_(20);
+var ExecutionEnvironment = _dereq_(138);
+var FallbackCompositionState = _dereq_(21);
+var SyntheticCompositionEvent = _dereq_(89);
+var SyntheticInputEvent = _dereq_(93);
+
+var END_KEYCODES = [9, 13, 27, 32]; // Tab, Return, Esc, Space
+var START_KEYCODE = 229;
+
+var canUseCompositionEvent = ExecutionEnvironment.canUseDOM && 'CompositionEvent' in window;
+
+var documentMode = null;
+if (ExecutionEnvironment.canUseDOM && 'documentMode' in document) {
+  documentMode = document.documentMode;
+}
+
+// Webkit offers a very useful `textInput` event that can be used to
+// directly represent `beforeInput`. The IE `textinput` event is not as
+// useful, so we don't use it.
+var canUseTextInputEvent = ExecutionEnvironment.canUseDOM && 'TextEvent' in window && !documentMode && !isPresto();
+
+// In IE9+, we have access to composition events, but the data supplied
+// by the native compositionend event may be incorrect. Japanese ideographic
+// spaces, for instance (\u3000) are not recorded correctly.
+var useFallbackCompositionData = ExecutionEnvironment.canUseDOM && (!canUseCompositionEvent || documentMode && documentMode > 8 && documentMode <= 11);
+
+/**
+ * Opera <= 12 includes TextEvent in window, but does not fire
+ * text input events. Rely on keypress instead.
+ */
+function isPresto() {
+  var opera = window.opera;
+  return typeof opera === 'object' && typeof opera.version === 'function' && parseInt(opera.version(), 10) <= 12;
+}
+
+var SPACEBAR_CODE = 32;
+var SPACEBAR_CHAR = String.fromCharCode(SPACEBAR_CODE);
+
+// Events and their corresponding property names.
+var eventTypes = {
+  beforeInput: {
+    phasedRegistrationNames: {
+      bubbled: 'onBeforeInput',
+      captured: 'onBeforeInputCapture'
+    },
+    dependencies: ['topCompositionEnd', 'topKeyPress', 'topTextInput', 'topPaste']
+  },
+  compositionEnd: {
+    phasedRegistrationNames: {
+      bubbled: 'onCompositionEnd',
+      captured: 'onCompositionEndCapture'
+    },
+    dependencies: ['topBlur', 'topCompositionEnd', 'topKeyDown', 'topKeyPress', 'topKeyUp', 'topMouseDown']
+  },
+  compositionStart: {
+    phasedRegistrationNames: {
+      bubbled: 'onCompositionStart',
+      captured: 'onCompositionStartCapture'
+    },
+    dependencies: ['topBlur', 'topCompositionStart', 'topKeyDown', 'topKeyPress', 'topKeyUp', 'topMouseDown']
+  },
+  compositionUpdate: {
+    phasedRegistrationNames: {
+      bubbled: 'onCompositionUpdate',
+      captured: 'onCompositionUpdateCapture'
+    },
+    dependencies: ['topBlur', 'topCompositionUpdate', 'topKeyDown', 'topKeyPress', 'topKeyUp', 'topMouseDown']
+  }
+};
+
+// Track whether we've ever handled a keypress on the space key.
+var hasSpaceKeypress = false;
+
+/**
+ * Return whether a native keypress event is assumed to be a command.
+ * This is required because Firefox fires `keypress` events for key commands
+ * (cut, copy, select-all, etc.) even though no character is inserted.
+ */
+function isKeypressCommand(nativeEvent) {
+  return (nativeEvent.ctrlKey || nativeEvent.altKey || nativeEvent.metaKey) &&
+  // ctrlKey && altKey is equivalent to AltGr, and is not a command.
+  !(nativeEvent.ctrlKey && nativeEvent.altKey);
+}
+
+/**
+ * Translate native top level events into event types.
+ *
+ * @param {string} topLevelType
+ * @return {object}
+ */
+function getCompositionEventType(topLevelType) {
+  switch (topLevelType) {
+    case 'topCompositionStart':
+      return eventTypes.compositionStart;
+    case 'topCompositionEnd':
+      return eventTypes.compositionEnd;
+    case 'topCompositionUpdate':
+      return eventTypes.compositionUpdate;
+  }
+}
+
+/**
+ * Does our fallback best-guess model think this event signifies that
+ * composition has begun?
+ *
+ * @param {string} topLevelType
+ * @param {object} nativeEvent
+ * @return {boolean}
+ */
+function isFallbackCompositionStart(topLevelType, nativeEvent) {
+  return topLevelType === 'topKeyDown' && nativeEvent.keyCode === START_KEYCODE;
+}
+
+/**
+ * Does our fallback mode think that this event is the end of composition?
+ *
+ * @param {string} topLevelType
+ * @param {object} nativeEvent
+ * @return {boolean}
+ */
+function isFallbackCompositionEnd(topLevelType, nativeEvent) {
+  switch (topLevelType) {
+    case 'topKeyUp':
+      // Command keys insert or clear IME input.
+      return END_KEYCODES.indexOf(nativeEvent.keyCode) !== -1;
+    case 'topKeyDown':
+      // Expect IME keyCode on each keydown. If we get any other
+      // code we must have exited earlier.
+      return nativeEvent.keyCode !== START_KEYCODE;
+    case 'topKeyPress':
+    case 'topMouseDown':
+    case 'topBlur':
+      // Events are not possible without cancelling IME.
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Google Input Tools provides composition data via a CustomEvent,
+ * with the `data` property populated in the `detail` object. If this
+ * is available on the event object, use it. If not, this is a plain
+ * composition event and we have nothing special to extract.
+ *
+ * @param {object} nativeEvent
+ * @return {?string}
+ */
+function getDataFromCustomEvent(nativeEvent) {
+  var detail = nativeEvent.detail;
+  if (typeof detail === 'object' && 'data' in detail) {
+    return detail.data;
+  }
+  return null;
+}
+
+// Track the current IME composition fallback object, if any.
+var currentComposition = null;
+
+/**
+ * @return {?object} A SyntheticCompositionEvent.
+ */
+function extractCompositionEvent(topLevelType, targetInst, nativeEvent, nativeEventTarget) {
+  var eventType;
+  var fallbackData;
+
+  if (canUseCompositionEvent) {
+    eventType = getCompositionEventType(topLevelType);
+  } else if (!currentComposition) {
+    if (isFallbackCompositionStart(topLevelType, nativeEvent)) {
+      eventType = eventTypes.compositionStart;
+    }
+  } else if (isFallbackCompositionEnd(topLevelType, nativeEvent)) {
+    eventType = eventTypes.compositionEnd;
+  }
+
+  if (!eventType) {
+    return null;
+  }
+
+  if (useFallbackCompositionData) {
+    // The current composition is stored statically and must not be
+    // overwritten while composition continues.
+    if (!currentComposition && eventType === eventTypes.compositionStart) {
+      currentComposition = FallbackCompositionState.getPooled(nativeEventTarget);
+    } else if (eventType === eventTypes.compositionEnd) {
+      if (currentComposition) {
+        fallbackData = currentComposition.getData();
+      }
+    }
+  }
+
+  var event = SyntheticCompositionEvent.getPooled(eventType, targetInst, nativeEvent, nativeEventTarget);
+
+  if (fallbackData) {
+    // Inject data generated from fallback path into the synthetic event.
+    // This matches the property of native CompositionEventInterface.
+    event.data = fallbackData;
+  } else {
+    var customData = getDataFromCustomEvent(nativeEvent);
+    if (customData !== null) {
+      event.data = customData;
+    }
+  }
+
+  EventPropagators.accumulateTwoPhaseDispatches(event);
+  return event;
+}
+
+/**
+ * @param {string} topLevelType Record from `EventConstants`.
+ * @param {object} nativeEvent Native browser event.
+ * @return {?string} The string corresponding to this `beforeInput` event.
+ */
+function getNativeBeforeInputChars(topLevelType, nativeEvent) {
+  switch (topLevelType) {
+    case 'topCompositionEnd':
+      return getDataFromCustomEvent(nativeEvent);
+    case 'topKeyPress':
+      /**
+       * If native `textInput` events are available, our goal is to make
+       * use of them. However, there is a special case: the spacebar key.
+       * In Webkit, preventing default on a spacebar `textInput` event
+       * cancels character insertion, but it *also* causes the browser
+       * to fall back to its default spacebar behavior of scrolling the
+       * page.
+       *
+       * Tracking at:
+       * https://code.google.com/p/chromium/issues/detail?id=355103
+       *
+       * To avoid this issue, use the keypress event as if no `textInput`
+       * event is available.
+       */
+      var which = nativeEvent.which;
+      if (which !== SPACEBAR_CODE) {
+        return null;
+      }
+
+      hasSpaceKeypress = true;
+      return SPACEBAR_CHAR;
+
+    case 'topTextInput':
+      // Record the characters to be added to the DOM.
+      var chars = nativeEvent.data;
+
+      // If it's a spacebar character, assume that we have already handled
+      // it at the keypress level and bail immediately. Android Chrome
+      // doesn't give us keycodes, so we need to blacklist it.
+      if (chars === SPACEBAR_CHAR && hasSpaceKeypress) {
+        return null;
+      }
+
+      return chars;
+
+    default:
+      // For other native event types, do nothing.
+      return null;
+  }
+}
+
+/**
+ * For browsers that do not provide the `textInput` event, extract the
+ * appropriate string to use for SyntheticInputEvent.
+ *
+ * @param {string} topLevelType Record from `EventConstants`.
+ * @param {object} nativeEvent Native browser event.
+ * @return {?string} The fallback string for this `beforeInput` event.
+ */
+function getFallbackBeforeInputChars(topLevelType, nativeEvent) {
+  // If we are currently composing (IME) and using a fallback to do so,
+  // try to extract the composed characters from the fallback object.
+  // If composition event is available, we extract a string only at
+  // compositionevent, otherwise extract it at fallback events.
+  if (currentComposition) {
+    if (topLevelType === 'topCompositionEnd' || !canUseCompositionEvent && isFallbackCompositionEnd(topLevelType, nativeEvent)) {
+      var chars = currentComposition.getData();
+      FallbackCompositionState.release(currentComposition);
+      currentComposition = null;
+      return chars;
+    }
+    return null;
+  }
+
+  switch (topLevelType) {
+    case 'topPaste':
+      // If a paste event occurs after a keypress, throw out the input
+      // chars. Paste events should not lead to BeforeInput events.
+      return null;
+    case 'topKeyPress':
+      /**
+       * As of v27, Firefox may fire keypress events even when no character
+       * will be inserted. A few possibilities:
+       *
+       * - `which` is `0`. Arrow keys, Esc key, etc.
+       *
+       * - `which` is the pressed key code, but no char is available.
+       *   Ex: 'AltGr + d` in Polish. There is no modified character for
+       *   this key combination and no character is inserted into the
+       *   document, but FF fires the keypress for char code `100` anyway.
+       *   No `input` event will occur.
+       *
+       * - `which` is the pressed key code, but a command combination is
+       *   being used. Ex: `Cmd+C`. No character is inserted, and no
+       *   `input` event will occur.
+       */
+      if (nativeEvent.which && !isKeypressCommand(nativeEvent)) {
+        return String.fromCharCode(nativeEvent.which);
+      }
+      return null;
+    case 'topCompositionEnd':
+      return useFallbackCompositionData ? null : nativeEvent.data;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Extract a SyntheticInputEvent for `beforeInput`, based on either native
+ * `textInput` or fallback behavior.
+ *
+ * @return {?object} A SyntheticInputEvent.
+ */
+function extractBeforeInputEvent(topLevelType, targetInst, nativeEvent, nativeEventTarget) {
+  var chars;
+
+  if (canUseTextInputEvent) {
+    chars = getNativeBeforeInputChars(topLevelType, nativeEvent);
+  } else {
+    chars = getFallbackBeforeInputChars(topLevelType, nativeEvent);
+  }
+
+  // If no characters are being inserted, no BeforeInput event should
+  // be fired.
+  if (!chars) {
+    return null;
+  }
+
+  var event = SyntheticInputEvent.getPooled(eventTypes.beforeInput, targetInst, nativeEvent, nativeEventTarget);
+
+  event.data = chars;
+  EventPropagators.accumulateTwoPhaseDispatches(event);
+  return event;
+}
+
+/**
+ * Create an `onBeforeInput` event to match
+ * http://www.w3.org/TR/2013/WD-DOM-Level-3-Events-20131105/#events-inputevents.
+ *
+ * This event plugin is based on the native `textInput` event
+ * available in Chrome, Safari, Opera, and IE. This event fires after
+ * `onKeyPress` and `onCompositionEnd`, but before `onInput`.
+ *
+ * `beforeInput` is spec'd but not implemented in any browsers, and
+ * the `input` event does not provide any useful information about what has
+ * actually been added, contrary to the spec. Thus, `textInput` is the best
+ * available event to identify the characters that have actually been inserted
+ * into the target node.
+ *
+ * This plugin is also responsible for emitting `composition` events, thus
+ * allowing us to share composition fallback code for both `beforeInput` and
+ * `composition` event types.
+ */
+var BeforeInputEventPlugin = {
+  eventTypes: eventTypes,
+
+  extractEvents: function (topLevelType, targetInst, nativeEvent, nativeEventTarget) {
+    return [extractCompositionEvent(topLevelType, targetInst, nativeEvent, nativeEventTarget), extractBeforeInputEvent(topLevelType, targetInst, nativeEvent, nativeEventTarget)];
+  }
+};
+
+module.exports = BeforeInputEventPlugin;
+},{"138":138,"20":20,"21":21,"89":89,"93":93}],4:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+/**
+ * CSS properties which accept numbers but are not in units of "px".
+ */
+
+var isUnitlessNumber = {
+  animationIterationCount: true,
+  borderImageOutset: true,
+  borderImageSlice: true,
+  borderImageWidth: true,
+  boxFlex: true,
+  boxFlexGroup: true,
+  boxOrdinalGroup: true,
+  columnCount: true,
+  columns: true,
+  flex: true,
+  flexGrow: true,
+  flexPositive: true,
+  flexShrink: true,
+  flexNegative: true,
+  flexOrder: true,
+  gridRow: true,
+  gridRowEnd: true,
+  gridRowSpan: true,
+  gridRowStart: true,
+  gridColumn: true,
+  gridColumnEnd: true,
+  gridColumnSpan: true,
+  gridColumnStart: true,
+  fontWeight: true,
+  lineClamp: true,
+  lineHeight: true,
+  opacity: true,
+  order: true,
+  orphans: true,
+  tabSize: true,
+  widows: true,
+  zIndex: true,
+  zoom: true,
+
+  // SVG-related properties
+  fillOpacity: true,
+  floodOpacity: true,
+  stopOpacity: true,
+  strokeDasharray: true,
+  strokeDashoffset: true,
+  strokeMiterlimit: true,
+  strokeOpacity: true,
+  strokeWidth: true
+};
+
+/**
+ * @param {string} prefix vendor-specific prefix, eg: Webkit
+ * @param {string} key style name, eg: transitionDuration
+ * @return {string} style name prefixed with `prefix`, properly camelCased, eg:
+ * WebkitTransitionDuration
+ */
+function prefixKey(prefix, key) {
+  return prefix + key.charAt(0).toUpperCase() + key.substring(1);
+}
+
+/**
+ * Support style names that may come passed in prefixed by adding permutations
+ * of vendor prefixes.
+ */
+var prefixes = ['Webkit', 'ms', 'Moz', 'O'];
+
+// Using Object.keys here, or else the vanilla for-in loop makes IE8 go into an
+// infinite loop, because it iterates over the newly added props too.
+Object.keys(isUnitlessNumber).forEach(function (prop) {
+  prefixes.forEach(function (prefix) {
+    isUnitlessNumber[prefixKey(prefix, prop)] = isUnitlessNumber[prop];
+  });
+});
+
+/**
+ * Most style properties can be unset by doing .style[prop] = '' but IE8
+ * doesn't like doing that with shorthand properties so for the properties that
+ * IE8 breaks on, which are listed here, we instead unset each of the
+ * individual properties. See http://bugs.jquery.com/ticket/12385.
+ * The 4-value 'clock' properties like margin, padding, border-width seem to
+ * behave without any problems. Curiously, list-style works too without any
+ * special prodding.
+ */
+var shorthandPropertyExpansions = {
+  background: {
+    backgroundAttachment: true,
+    backgroundColor: true,
+    backgroundImage: true,
+    backgroundPositionX: true,
+    backgroundPositionY: true,
+    backgroundRepeat: true
+  },
+  backgroundPosition: {
+    backgroundPositionX: true,
+    backgroundPositionY: true
+  },
+  border: {
+    borderWidth: true,
+    borderStyle: true,
+    borderColor: true
+  },
+  borderBottom: {
+    borderBottomWidth: true,
+    borderBottomStyle: true,
+    borderBottomColor: true
+  },
+  borderLeft: {
+    borderLeftWidth: true,
+    borderLeftStyle: true,
+    borderLeftColor: true
+  },
+  borderRight: {
+    borderRightWidth: true,
+    borderRightStyle: true,
+    borderRightColor: true
+  },
+  borderTop: {
+    borderTopWidth: true,
+    borderTopStyle: true,
+    borderTopColor: true
+  },
+  font: {
+    fontStyle: true,
+    fontVariant: true,
+    fontWeight: true,
+    fontSize: true,
+    lineHeight: true,
+    fontFamily: true
+  },
+  outline: {
+    outlineWidth: true,
+    outlineStyle: true,
+    outlineColor: true
+  }
+};
+
+var CSSProperty = {
+  isUnitlessNumber: isUnitlessNumber,
+  shorthandPropertyExpansions: shorthandPropertyExpansions
+};
+
+module.exports = CSSProperty;
+},{}],5:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var CSSProperty = _dereq_(4);
+var ExecutionEnvironment = _dereq_(138);
+var ReactInstrumentation = _dereq_(64);
+
+var camelizeStyleName = _dereq_(140);
+var dangerousStyleValue = _dereq_(106);
+var hyphenateStyleName = _dereq_(151);
+var memoizeStringOnly = _dereq_(155);
+var warning = _dereq_(159);
+
+var processStyleName = memoizeStringOnly(function (styleName) {
+  return hyphenateStyleName(styleName);
+});
+
+var hasShorthandPropertyBug = false;
+var styleFloatAccessor = 'cssFloat';
+if (ExecutionEnvironment.canUseDOM) {
+  var tempStyle = document.createElement('div').style;
+  try {
+    // IE8 throws "Invalid argument." if resetting shorthand style properties.
+    tempStyle.font = '';
+  } catch (e) {
+    hasShorthandPropertyBug = true;
+  }
+  // IE8 only supports accessing cssFloat (standard) as styleFloat
+  if (document.documentElement.style.cssFloat === undefined) {
+    styleFloatAccessor = 'styleFloat';
+  }
+}
+
+if ("development" !== 'production') {
+  // 'msTransform' is correct, but the other prefixes should be capitalized
+  var badVendoredStyleNamePattern = /^(?:webkit|moz|o)[A-Z]/;
+
+  // style values shouldn't contain a semicolon
+  var badStyleValueWithSemicolonPattern = /;\s*$/;
+
+  var warnedStyleNames = {};
+  var warnedStyleValues = {};
+  var warnedForNaNValue = false;
+
+  var warnHyphenatedStyleName = function (name, owner) {
+    if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
+      return;
+    }
+
+    warnedStyleNames[name] = true;
+    "development" !== 'production' ? warning(false, 'Unsupported style property %s. Did you mean %s?%s', name, camelizeStyleName(name), checkRenderMessage(owner)) : void 0;
+  };
+
+  var warnBadVendoredStyleName = function (name, owner) {
+    if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
+      return;
+    }
+
+    warnedStyleNames[name] = true;
+    "development" !== 'production' ? warning(false, 'Unsupported vendor-prefixed style property %s. Did you mean %s?%s', name, name.charAt(0).toUpperCase() + name.slice(1), checkRenderMessage(owner)) : void 0;
+  };
+
+  var warnStyleValueWithSemicolon = function (name, value, owner) {
+    if (warnedStyleValues.hasOwnProperty(value) && warnedStyleValues[value]) {
+      return;
+    }
+
+    warnedStyleValues[value] = true;
+    "development" !== 'production' ? warning(false, "Style property values shouldn't contain a semicolon.%s " + 'Try "%s: %s" instead.', checkRenderMessage(owner), name, value.replace(badStyleValueWithSemicolonPattern, '')) : void 0;
+  };
+
+  var warnStyleValueIsNaN = function (name, value, owner) {
+    if (warnedForNaNValue) {
+      return;
+    }
+
+    warnedForNaNValue = true;
+    "development" !== 'production' ? warning(false, '`NaN` is an invalid value for the `%s` css style property.%s', name, checkRenderMessage(owner)) : void 0;
+  };
+
+  var checkRenderMessage = function (owner) {
+    if (owner) {
+      var name = owner.getName();
+      if (name) {
+        return ' Check the render method of `' + name + '`.';
+      }
+    }
+    return '';
+  };
+
+  /**
+   * @param {string} name
+   * @param {*} value
+   * @param {ReactDOMComponent} component
+   */
+  var warnValidStyle = function (name, value, component) {
+    var owner;
+    if (component) {
+      owner = component._currentElement._owner;
+    }
+    if (name.indexOf('-') > -1) {
+      warnHyphenatedStyleName(name, owner);
+    } else if (badVendoredStyleNamePattern.test(name)) {
+      warnBadVendoredStyleName(name, owner);
+    } else if (badStyleValueWithSemicolonPattern.test(value)) {
+      warnStyleValueWithSemicolon(name, value, owner);
+    }
+
+    if (typeof value === 'number' && isNaN(value)) {
+      warnStyleValueIsNaN(name, value, owner);
+    }
+  };
+}
+
+/**
+ * Operations for dealing with CSS properties.
+ */
+var CSSPropertyOperations = {
+  /**
+   * Serializes a mapping of style properties for use as inline styles:
+   *
+   *   > createMarkupForStyles({width: '200px', height: 0})
+   *   "width:200px;height:0;"
+   *
+   * Undefined values are ignored so that declarative programming is easier.
+   * The result should be HTML-escaped before insertion into the DOM.
+   *
+   * @param {object} styles
+   * @param {ReactDOMComponent} component
+   * @return {?string}
+   */
+  createMarkupForStyles: function (styles, component) {
+    var serialized = '';
+    for (var styleName in styles) {
+      if (!styles.hasOwnProperty(styleName)) {
+        continue;
+      }
+      var isCustomProperty = styleName.indexOf('--') === 0;
+      var styleValue = styles[styleName];
+      if ("development" !== 'production') {
+        if (!isCustomProperty) {
+          warnValidStyle(styleName, styleValue, component);
+        }
+      }
+      if (styleValue != null) {
+        serialized += processStyleName(styleName) + ':';
+        serialized += dangerousStyleValue(styleName, styleValue, component, isCustomProperty) + ';';
+      }
+    }
+    return serialized || null;
+  },
+
+  /**
+   * Sets the value for multiple styles on a node.  If a value is specified as
+   * '' (empty string), the corresponding style property will be unset.
+   *
+   * @param {DOMElement} node
+   * @param {object} styles
+   * @param {ReactDOMComponent} component
+   */
+  setValueForStyles: function (node, styles, component) {
+    if ("development" !== 'production') {
+      ReactInstrumentation.debugTool.onHostOperation({
+        instanceID: component._debugID,
+        type: 'update styles',
+        payload: styles
+      });
+    }
+
+    var style = node.style;
+    for (var styleName in styles) {
+      if (!styles.hasOwnProperty(styleName)) {
+        continue;
+      }
+      var isCustomProperty = styleName.indexOf('--') === 0;
+      if ("development" !== 'production') {
+        if (!isCustomProperty) {
+          warnValidStyle(styleName, styles[styleName], component);
+        }
+      }
+      var styleValue = dangerousStyleValue(styleName, styles[styleName], component, isCustomProperty);
+      if (styleName === 'float' || styleName === 'cssFloat') {
+        styleName = styleFloatAccessor;
+      }
+      if (isCustomProperty) {
+        style.setProperty(styleName, styleValue);
+      } else if (styleValue) {
+        style[styleName] = styleValue;
+      } else {
+        var expansion = hasShorthandPropertyBug && CSSProperty.shorthandPropertyExpansions[styleName];
+        if (expansion) {
+          // Shorthand property that IE8 won't like unsetting, so unset each
+          // component to placate it
+          for (var individualStyleName in expansion) {
+            style[individualStyleName] = '';
+          }
+        } else {
+          style[styleName] = '';
+        }
+      }
+    }
+  }
+};
+
+module.exports = CSSPropertyOperations;
+},{"106":106,"138":138,"140":140,"151":151,"155":155,"159":159,"4":4,"64":64}],6:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var PooledClass = _dereq_(25);
+
+var invariant = _dereq_(152);
+
+/**
+ * A specialized pseudo-event module to help keep track of components waiting to
+ * be notified when their DOM representations are available for use.
+ *
+ * This implements `PooledClass`, so you should never need to instantiate this.
+ * Instead, use `CallbackQueue.getPooled()`.
+ *
+ * @class ReactMountReady
+ * @implements PooledClass
+ * @internal
+ */
+
+var CallbackQueue = function () {
+  function CallbackQueue(arg) {
+    _classCallCheck(this, CallbackQueue);
+
+    this._callbacks = null;
+    this._contexts = null;
+    this._arg = arg;
+  }
+
+  /**
+   * Enqueues a callback to be invoked when `notifyAll` is invoked.
+   *
+   * @param {function} callback Invoked when `notifyAll` is invoked.
+   * @param {?object} context Context to call `callback` with.
+   * @internal
+   */
+
+
+  CallbackQueue.prototype.enqueue = function enqueue(callback, context) {
+    this._callbacks = this._callbacks || [];
+    this._callbacks.push(callback);
+    this._contexts = this._contexts || [];
+    this._contexts.push(context);
+  };
+
+  /**
+   * Invokes all enqueued callbacks and clears the queue. This is invoked after
+   * the DOM representation of a component has been created or updated.
+   *
+   * @internal
+   */
+
+
+  CallbackQueue.prototype.notifyAll = function notifyAll() {
+    var callbacks = this._callbacks;
+    var contexts = this._contexts;
+    var arg = this._arg;
+    if (callbacks && contexts) {
+      !(callbacks.length === contexts.length) ? "development" !== 'production' ? invariant(false, 'Mismatched list of contexts in callback queue') : _prodInvariant('24') : void 0;
+      this._callbacks = null;
+      this._contexts = null;
+      for (var i = 0; i < callbacks.length; i++) {
+        callbacks[i].call(contexts[i], arg);
+      }
+      callbacks.length = 0;
+      contexts.length = 0;
+    }
+  };
+
+  CallbackQueue.prototype.checkpoint = function checkpoint() {
+    return this._callbacks ? this._callbacks.length : 0;
+  };
+
+  CallbackQueue.prototype.rollback = function rollback(len) {
+    if (this._callbacks && this._contexts) {
+      this._callbacks.length = len;
+      this._contexts.length = len;
+    }
+  };
+
+  /**
+   * Resets the internal queue.
+   *
+   * @internal
+   */
+
+
+  CallbackQueue.prototype.reset = function reset() {
+    this._callbacks = null;
+    this._contexts = null;
+  };
+
+  /**
+   * `PooledClass` looks for this.
+   */
+
+
+  CallbackQueue.prototype.destructor = function destructor() {
+    this.reset();
+  };
+
+  return CallbackQueue;
+}();
+
+module.exports = PooledClass.addPoolingTo(CallbackQueue);
+},{"126":126,"152":152,"25":25}],7:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var EventPluginHub = _dereq_(17);
+var EventPropagators = _dereq_(20);
+var ExecutionEnvironment = _dereq_(138);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactUpdates = _dereq_(82);
+var SyntheticEvent = _dereq_(91);
+
+var inputValueTracking = _dereq_(120);
+var getEventTarget = _dereq_(114);
+var isEventSupported = _dereq_(122);
+var isTextInputElement = _dereq_(123);
+
+var eventTypes = {
+  change: {
+    phasedRegistrationNames: {
+      bubbled: 'onChange',
+      captured: 'onChangeCapture'
+    },
+    dependencies: ['topBlur', 'topChange', 'topClick', 'topFocus', 'topInput', 'topKeyDown', 'topKeyUp', 'topSelectionChange']
+  }
+};
+
+function createAndAccumulateChangeEvent(inst, nativeEvent, target) {
+  var event = SyntheticEvent.getPooled(eventTypes.change, inst, nativeEvent, target);
+  event.type = 'change';
+  EventPropagators.accumulateTwoPhaseDispatches(event);
+  return event;
+}
+/**
+ * For IE shims
+ */
+var activeElement = null;
+var activeElementInst = null;
+
+/**
+ * SECTION: handle `change` event
+ */
+function shouldUseChangeEvent(elem) {
+  var nodeName = elem.nodeName && elem.nodeName.toLowerCase();
+  return nodeName === 'select' || nodeName === 'input' && elem.type === 'file';
+}
+
+var doesChangeEventBubble = false;
+if (ExecutionEnvironment.canUseDOM) {
+  // See `handleChange` comment below
+  doesChangeEventBubble = isEventSupported('change') && (!document.documentMode || document.documentMode > 8);
+}
+
+function manualDispatchChangeEvent(nativeEvent) {
+  var event = createAndAccumulateChangeEvent(activeElementInst, nativeEvent, getEventTarget(nativeEvent));
+
+  // If change and propertychange bubbled, we'd just bind to it like all the
+  // other events and have it go through ReactBrowserEventEmitter. Since it
+  // doesn't, we manually listen for the events and so we have to enqueue and
+  // process the abstract event manually.
+  //
+  // Batching is necessary here in order to ensure that all event handlers run
+  // before the next rerender (including event handlers attached to ancestor
+  // elements instead of directly on the input). Without this, controlled
+  // components don't work properly in conjunction with event bubbling because
+  // the component is rerendered and the value reverted before all the event
+  // handlers can run. See https://github.com/facebook/react/issues/708.
+  ReactUpdates.batchedUpdates(runEventInBatch, event);
+}
+
+function runEventInBatch(event) {
+  EventPluginHub.enqueueEvents(event);
+  EventPluginHub.processEventQueue(false);
+}
+
+function startWatchingForChangeEventIE8(target, targetInst) {
+  activeElement = target;
+  activeElementInst = targetInst;
+  activeElement.attachEvent('onchange', manualDispatchChangeEvent);
+}
+
+function stopWatchingForChangeEventIE8() {
+  if (!activeElement) {
+    return;
+  }
+  activeElement.detachEvent('onchange', manualDispatchChangeEvent);
+  activeElement = null;
+  activeElementInst = null;
+}
+
+function getInstIfValueChanged(targetInst, nativeEvent) {
+  var updated = inputValueTracking.updateValueIfChanged(targetInst);
+  var simulated = nativeEvent.simulated === true && ChangeEventPlugin._allowSimulatedPassThrough;
+
+  if (updated || simulated) {
+    return targetInst;
+  }
+}
+
+function getTargetInstForChangeEvent(topLevelType, targetInst) {
+  if (topLevelType === 'topChange') {
+    return targetInst;
+  }
+}
+
+function handleEventsForChangeEventIE8(topLevelType, target, targetInst) {
+  if (topLevelType === 'topFocus') {
+    // stopWatching() should be a noop here but we call it just in case we
+    // missed a blur event somehow.
+    stopWatchingForChangeEventIE8();
+    startWatchingForChangeEventIE8(target, targetInst);
+  } else if (topLevelType === 'topBlur') {
+    stopWatchingForChangeEventIE8();
+  }
+}
+
+/**
+ * SECTION: handle `input` event
+ */
+var isInputEventSupported = false;
+if (ExecutionEnvironment.canUseDOM) {
+  // IE9 claims to support the input event but fails to trigger it when
+  // deleting text, so we ignore its input events.
+
+  isInputEventSupported = isEventSupported('input') && (!document.documentMode || document.documentMode > 9);
+}
+
+/**
+ * (For IE <=9) Starts tracking propertychange events on the passed-in element
+ * and override the value property so that we can distinguish user events from
+ * value changes in JS.
+ */
+function startWatchingForValueChange(target, targetInst) {
+  activeElement = target;
+  activeElementInst = targetInst;
+  activeElement.attachEvent('onpropertychange', handlePropertyChange);
+}
+
+/**
+ * (For IE <=9) Removes the event listeners from the currently-tracked element,
+ * if any exists.
+ */
+function stopWatchingForValueChange() {
+  if (!activeElement) {
+    return;
+  }
+  activeElement.detachEvent('onpropertychange', handlePropertyChange);
+
+  activeElement = null;
+  activeElementInst = null;
+}
+
+/**
+ * (For IE <=9) Handles a propertychange event, sending a `change` event if
+ * the value of the active element has changed.
+ */
+function handlePropertyChange(nativeEvent) {
+  if (nativeEvent.propertyName !== 'value') {
+    return;
+  }
+  if (getInstIfValueChanged(activeElementInst, nativeEvent)) {
+    manualDispatchChangeEvent(nativeEvent);
+  }
+}
+
+function handleEventsForInputEventPolyfill(topLevelType, target, targetInst) {
+  if (topLevelType === 'topFocus') {
+    // In IE8, we can capture almost all .value changes by adding a
+    // propertychange handler and looking for events with propertyName
+    // equal to 'value'
+    // In IE9, propertychange fires for most input events but is buggy and
+    // doesn't fire when text is deleted, but conveniently, selectionchange
+    // appears to fire in all of the remaining cases so we catch those and
+    // forward the event if the value has changed
+    // In either case, we don't want to call the event handler if the value
+    // is changed from JS so we redefine a setter for `.value` that updates
+    // our activeElementValue variable, allowing us to ignore those changes
+    //
+    // stopWatching() should be a noop here but we call it just in case we
+    // missed a blur event somehow.
+    stopWatchingForValueChange();
+    startWatchingForValueChange(target, targetInst);
+  } else if (topLevelType === 'topBlur') {
+    stopWatchingForValueChange();
+  }
+}
+
+// For IE8 and IE9.
+function getTargetInstForInputEventPolyfill(topLevelType, targetInst, nativeEvent) {
+  if (topLevelType === 'topSelectionChange' || topLevelType === 'topKeyUp' || topLevelType === 'topKeyDown') {
+    // On the selectionchange event, the target is just document which isn't
+    // helpful for us so just check activeElement instead.
+    //
+    // 99% of the time, keydown and keyup aren't necessary. IE8 fails to fire
+    // propertychange on the first input event after setting `value` from a
+    // script and fires only keydown, keypress, keyup. Catching keyup usually
+    // gets it and catching keydown lets us fire an event for the first
+    // keystroke if user does a key repeat (it'll be a little delayed: right
+    // before the second keystroke). Other input methods (e.g., paste) seem to
+    // fire selectionchange normally.
+    return getInstIfValueChanged(activeElementInst, nativeEvent);
+  }
+}
+
+/**
+ * SECTION: handle `click` event
+ */
+function shouldUseClickEvent(elem) {
+  // Use the `click` event to detect changes to checkbox and radio inputs.
+  // This approach works across all browsers, whereas `change` does not fire
+  // until `blur` in IE8.
+  var nodeName = elem.nodeName;
+  return nodeName && nodeName.toLowerCase() === 'input' && (elem.type === 'checkbox' || elem.type === 'radio');
+}
+
+function getTargetInstForClickEvent(topLevelType, targetInst, nativeEvent) {
+  if (topLevelType === 'topClick') {
+    return getInstIfValueChanged(targetInst, nativeEvent);
+  }
+}
+
+function getTargetInstForInputOrChangeEvent(topLevelType, targetInst, nativeEvent) {
+  if (topLevelType === 'topInput' || topLevelType === 'topChange') {
+    return getInstIfValueChanged(targetInst, nativeEvent);
+  }
+}
+
+function handleControlledInputBlur(inst, node) {
+  // TODO: In IE, inst is occasionally null. Why?
+  if (inst == null) {
+    return;
+  }
+
+  // Fiber and ReactDOM keep wrapper state in separate places
+  var state = inst._wrapperState || node._wrapperState;
+
+  if (!state || !state.controlled || node.type !== 'number') {
+    return;
+  }
+
+  // If controlled, assign the value attribute to the current value on blur
+  var value = '' + node.value;
+  if (node.getAttribute('value') !== value) {
+    node.setAttribute('value', value);
+  }
+}
+
+/**
+ * This plugin creates an `onChange` event that normalizes change events
+ * across form elements. This event fires at a time when it's possible to
+ * change the element's value without seeing a flicker.
+ *
+ * Supported elements are:
+ * - input (see `isTextInputElement`)
+ * - textarea
+ * - select
+ */
+var ChangeEventPlugin = {
+  eventTypes: eventTypes,
+
+  _allowSimulatedPassThrough: true,
+  _isInputEventSupported: isInputEventSupported,
+
+  extractEvents: function (topLevelType, targetInst, nativeEvent, nativeEventTarget) {
+    var targetNode = targetInst ? ReactDOMComponentTree.getNodeFromInstance(targetInst) : window;
+
+    var getTargetInstFunc, handleEventFunc;
+    if (shouldUseChangeEvent(targetNode)) {
+      if (doesChangeEventBubble) {
+        getTargetInstFunc = getTargetInstForChangeEvent;
+      } else {
+        handleEventFunc = handleEventsForChangeEventIE8;
+      }
+    } else if (isTextInputElement(targetNode)) {
+      if (isInputEventSupported) {
+        getTargetInstFunc = getTargetInstForInputOrChangeEvent;
+      } else {
+        getTargetInstFunc = getTargetInstForInputEventPolyfill;
+        handleEventFunc = handleEventsForInputEventPolyfill;
+      }
+    } else if (shouldUseClickEvent(targetNode)) {
+      getTargetInstFunc = getTargetInstForClickEvent;
+    }
+
+    if (getTargetInstFunc) {
+      var inst = getTargetInstFunc(topLevelType, targetInst, nativeEvent);
+      if (inst) {
+        var event = createAndAccumulateChangeEvent(inst, nativeEvent, nativeEventTarget);
+        return event;
+      }
+    }
+
+    if (handleEventFunc) {
+      handleEventFunc(topLevelType, targetNode, targetInst);
+    }
+
+    // When blurring, set the value attribute for number inputs
+    if (topLevelType === 'topBlur') {
+      handleControlledInputBlur(targetInst, targetNode);
+    }
+  }
+};
+
+module.exports = ChangeEventPlugin;
+},{"114":114,"120":120,"122":122,"123":123,"138":138,"17":17,"20":20,"34":34,"82":82,"91":91}],8:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var DOMLazyTree = _dereq_(9);
+var Danger = _dereq_(13);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactInstrumentation = _dereq_(64);
+
+var createMicrosoftUnsafeLocalFunction = _dereq_(105);
+var setInnerHTML = _dereq_(128);
+var setTextContent = _dereq_(129);
+
+function getNodeAfter(parentNode, node) {
+  // Special case for text components, which return [open, close] comments
+  // from getHostNode.
+  if (Array.isArray(node)) {
+    node = node[1];
+  }
+  return node ? node.nextSibling : parentNode.firstChild;
+}
+
+/**
+ * Inserts `childNode` as a child of `parentNode` at the `index`.
+ *
+ * @param {DOMElement} parentNode Parent node in which to insert.
+ * @param {DOMElement} childNode Child node to insert.
+ * @param {number} index Index at which to insert the child.
+ * @internal
+ */
+var insertChildAt = createMicrosoftUnsafeLocalFunction(function (parentNode, childNode, referenceNode) {
+  // We rely exclusively on `insertBefore(node, null)` instead of also using
+  // `appendChild(node)`. (Using `undefined` is not allowed by all browsers so
+  // we are careful to use `null`.)
+  parentNode.insertBefore(childNode, referenceNode);
+});
+
+function insertLazyTreeChildAt(parentNode, childTree, referenceNode) {
+  DOMLazyTree.insertTreeBefore(parentNode, childTree, referenceNode);
+}
+
+function moveChild(parentNode, childNode, referenceNode) {
+  if (Array.isArray(childNode)) {
+    moveDelimitedText(parentNode, childNode[0], childNode[1], referenceNode);
+  } else {
+    insertChildAt(parentNode, childNode, referenceNode);
+  }
+}
+
+function removeChild(parentNode, childNode) {
+  if (Array.isArray(childNode)) {
+    var closingComment = childNode[1];
+    childNode = childNode[0];
+    removeDelimitedText(parentNode, childNode, closingComment);
+    parentNode.removeChild(closingComment);
+  }
+  parentNode.removeChild(childNode);
+}
+
+function moveDelimitedText(parentNode, openingComment, closingComment, referenceNode) {
+  var node = openingComment;
+  while (true) {
+    var nextNode = node.nextSibling;
+    insertChildAt(parentNode, node, referenceNode);
+    if (node === closingComment) {
+      break;
+    }
+    node = nextNode;
+  }
+}
+
+function removeDelimitedText(parentNode, startNode, closingComment) {
+  while (true) {
+    var node = startNode.nextSibling;
+    if (node === closingComment) {
+      // The closing comment is removed by ReactMultiChild.
+      break;
+    } else {
+      parentNode.removeChild(node);
+    }
+  }
+}
+
+function replaceDelimitedText(openingComment, closingComment, stringText) {
+  var parentNode = openingComment.parentNode;
+  var nodeAfterComment = openingComment.nextSibling;
+  if (nodeAfterComment === closingComment) {
+    // There are no text nodes between the opening and closing comments; insert
+    // a new one if stringText isn't empty.
+    if (stringText) {
+      insertChildAt(parentNode, document.createTextNode(stringText), nodeAfterComment);
+    }
+  } else {
+    if (stringText) {
+      // Set the text content of the first node after the opening comment, and
+      // remove all following nodes up until the closing comment.
+      setTextContent(nodeAfterComment, stringText);
+      removeDelimitedText(parentNode, nodeAfterComment, closingComment);
+    } else {
+      removeDelimitedText(parentNode, openingComment, closingComment);
+    }
+  }
+
+  if ("development" !== 'production') {
+    ReactInstrumentation.debugTool.onHostOperation({
+      instanceID: ReactDOMComponentTree.getInstanceFromNode(openingComment)._debugID,
+      type: 'replace text',
+      payload: stringText
+    });
+  }
+}
+
+var dangerouslyReplaceNodeWithMarkup = Danger.dangerouslyReplaceNodeWithMarkup;
+if ("development" !== 'production') {
+  dangerouslyReplaceNodeWithMarkup = function (oldChild, markup, prevInstance) {
+    Danger.dangerouslyReplaceNodeWithMarkup(oldChild, markup);
+    if (prevInstance._debugID !== 0) {
+      ReactInstrumentation.debugTool.onHostOperation({
+        instanceID: prevInstance._debugID,
+        type: 'replace with',
+        payload: markup.toString()
+      });
+    } else {
+      var nextInstance = ReactDOMComponentTree.getInstanceFromNode(markup.node);
+      if (nextInstance._debugID !== 0) {
+        ReactInstrumentation.debugTool.onHostOperation({
+          instanceID: nextInstance._debugID,
+          type: 'mount',
+          payload: markup.toString()
+        });
+      }
+    }
+  };
+}
+
+/**
+ * Operations for updating with DOM children.
+ */
+var DOMChildrenOperations = {
+  dangerouslyReplaceNodeWithMarkup: dangerouslyReplaceNodeWithMarkup,
+
+  replaceDelimitedText: replaceDelimitedText,
+
+  /**
+   * Updates a component's children by processing a series of updates. The
+   * update configurations are each expected to have a `parentNode` property.
+   *
+   * @param {array<object>} updates List of update configurations.
+   * @internal
+   */
+  processUpdates: function (parentNode, updates) {
+    if ("development" !== 'production') {
+      var parentNodeDebugID = ReactDOMComponentTree.getInstanceFromNode(parentNode)._debugID;
+    }
+
+    for (var k = 0; k < updates.length; k++) {
+      var update = updates[k];
+      switch (update.type) {
+        case 'INSERT_MARKUP':
+          insertLazyTreeChildAt(parentNode, update.content, getNodeAfter(parentNode, update.afterNode));
+          if ("development" !== 'production') {
+            ReactInstrumentation.debugTool.onHostOperation({
+              instanceID: parentNodeDebugID,
+              type: 'insert child',
+              payload: {
+                toIndex: update.toIndex,
+                content: update.content.toString()
+              }
+            });
+          }
+          break;
+        case 'MOVE_EXISTING':
+          moveChild(parentNode, update.fromNode, getNodeAfter(parentNode, update.afterNode));
+          if ("development" !== 'production') {
+            ReactInstrumentation.debugTool.onHostOperation({
+              instanceID: parentNodeDebugID,
+              type: 'move child',
+              payload: { fromIndex: update.fromIndex, toIndex: update.toIndex }
+            });
+          }
+          break;
+        case 'SET_MARKUP':
+          setInnerHTML(parentNode, update.content);
+          if ("development" !== 'production') {
+            ReactInstrumentation.debugTool.onHostOperation({
+              instanceID: parentNodeDebugID,
+              type: 'replace children',
+              payload: update.content.toString()
+            });
+          }
+          break;
+        case 'TEXT_CONTENT':
+          setTextContent(parentNode, update.content);
+          if ("development" !== 'production') {
+            ReactInstrumentation.debugTool.onHostOperation({
+              instanceID: parentNodeDebugID,
+              type: 'replace text',
+              payload: update.content.toString()
+            });
+          }
+          break;
+        case 'REMOVE_NODE':
+          removeChild(parentNode, update.fromNode);
+          if ("development" !== 'production') {
+            ReactInstrumentation.debugTool.onHostOperation({
+              instanceID: parentNodeDebugID,
+              type: 'remove child',
+              payload: { fromIndex: update.fromIndex }
+            });
+          }
+          break;
+      }
+    }
+  }
+};
+
+module.exports = DOMChildrenOperations;
+},{"105":105,"128":128,"129":129,"13":13,"34":34,"64":64,"9":9}],9:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var DOMNamespaces = _dereq_(10);
+var setInnerHTML = _dereq_(128);
+
+var createMicrosoftUnsafeLocalFunction = _dereq_(105);
+var setTextContent = _dereq_(129);
+
+var ELEMENT_NODE_TYPE = 1;
+var DOCUMENT_FRAGMENT_NODE_TYPE = 11;
+
+/**
+ * In IE (8-11) and Edge, appending nodes with no children is dramatically
+ * faster than appending a full subtree, so we essentially queue up the
+ * .appendChild calls here and apply them so each node is added to its parent
+ * before any children are added.
+ *
+ * In other browsers, doing so is slower or neutral compared to the other order
+ * (in Firefox, twice as slow) so we only do this inversion in IE.
+ *
+ * See https://github.com/spicyj/innerhtml-vs-createelement-vs-clonenode.
+ */
+var enableLazy = typeof document !== 'undefined' && typeof document.documentMode === 'number' || typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string' && /\bEdge\/\d/.test(navigator.userAgent);
+
+function insertTreeChildren(tree) {
+  if (!enableLazy) {
+    return;
+  }
+  var node = tree.node;
+  var children = tree.children;
+  if (children.length) {
+    for (var i = 0; i < children.length; i++) {
+      insertTreeBefore(node, children[i], null);
+    }
+  } else if (tree.html != null) {
+    setInnerHTML(node, tree.html);
+  } else if (tree.text != null) {
+    setTextContent(node, tree.text);
+  }
+}
+
+var insertTreeBefore = createMicrosoftUnsafeLocalFunction(function (parentNode, tree, referenceNode) {
+  // DocumentFragments aren't actually part of the DOM after insertion so
+  // appending children won't update the DOM. We need to ensure the fragment
+  // is properly populated first, breaking out of our lazy approach for just
+  // this level. Also, some <object> plugins (like Flash Player) will read
+  // <param> nodes immediately upon insertion into the DOM, so <object>
+  // must also be populated prior to insertion into the DOM.
+  if (tree.node.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE || tree.node.nodeType === ELEMENT_NODE_TYPE && tree.node.nodeName.toLowerCase() === 'object' && (tree.node.namespaceURI == null || tree.node.namespaceURI === DOMNamespaces.html)) {
+    insertTreeChildren(tree);
+    parentNode.insertBefore(tree.node, referenceNode);
+  } else {
+    parentNode.insertBefore(tree.node, referenceNode);
+    insertTreeChildren(tree);
+  }
+});
+
+function replaceChildWithTree(oldNode, newTree) {
+  oldNode.parentNode.replaceChild(newTree.node, oldNode);
+  insertTreeChildren(newTree);
+}
+
+function queueChild(parentTree, childTree) {
+  if (enableLazy) {
+    parentTree.children.push(childTree);
+  } else {
+    parentTree.node.appendChild(childTree.node);
+  }
+}
+
+function queueHTML(tree, html) {
+  if (enableLazy) {
+    tree.html = html;
+  } else {
+    setInnerHTML(tree.node, html);
+  }
+}
+
+function queueText(tree, text) {
+  if (enableLazy) {
+    tree.text = text;
+  } else {
+    setTextContent(tree.node, text);
+  }
+}
+
+function toString() {
+  return this.node.nodeName;
+}
+
+function DOMLazyTree(node) {
+  return {
+    node: node,
+    children: [],
+    html: null,
+    text: null,
+    toString: toString
+  };
+}
+
+DOMLazyTree.insertTreeBefore = insertTreeBefore;
+DOMLazyTree.replaceChildWithTree = replaceChildWithTree;
+DOMLazyTree.queueChild = queueChild;
+DOMLazyTree.queueHTML = queueHTML;
+DOMLazyTree.queueText = queueText;
+
+module.exports = DOMLazyTree;
+},{"10":10,"105":105,"128":128,"129":129}],10:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var DOMNamespaces = {
+  html: 'http://www.w3.org/1999/xhtml',
+  mathml: 'http://www.w3.org/1998/Math/MathML',
+  svg: 'http://www.w3.org/2000/svg'
+};
+
+module.exports = DOMNamespaces;
+},{}],11:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var invariant = _dereq_(152);
+
+function checkMask(value, bitmask) {
+  return (value & bitmask) === bitmask;
+}
+
+var DOMPropertyInjection = {
+  /**
+   * Mapping from normalized, camelcased property names to a configuration that
+   * specifies how the associated DOM property should be accessed or rendered.
+   */
+  MUST_USE_PROPERTY: 0x1,
+  HAS_BOOLEAN_VALUE: 0x4,
+  HAS_NUMERIC_VALUE: 0x8,
+  HAS_POSITIVE_NUMERIC_VALUE: 0x10 | 0x8,
+  HAS_OVERLOADED_BOOLEAN_VALUE: 0x20,
+
+  /**
+   * Inject some specialized knowledge about the DOM. This takes a config object
+   * with the following properties:
+   *
+   * isCustomAttribute: function that given an attribute name will return true
+   * if it can be inserted into the DOM verbatim. Useful for data-* or aria-*
+   * attributes where it's impossible to enumerate all of the possible
+   * attribute names,
+   *
+   * Properties: object mapping DOM property name to one of the
+   * DOMPropertyInjection constants or null. If your attribute isn't in here,
+   * it won't get written to the DOM.
+   *
+   * DOMAttributeNames: object mapping React attribute name to the DOM
+   * attribute name. Attribute names not specified use the **lowercase**
+   * normalized name.
+   *
+   * DOMAttributeNamespaces: object mapping React attribute name to the DOM
+   * attribute namespace URL. (Attribute names not specified use no namespace.)
+   *
+   * DOMPropertyNames: similar to DOMAttributeNames but for DOM properties.
+   * Property names not specified use the normalized name.
+   *
+   * DOMMutationMethods: Properties that require special mutation methods. If
+   * `value` is undefined, the mutation method should unset the property.
+   *
+   * @param {object} domPropertyConfig the config as described above.
+   */
+  injectDOMPropertyConfig: function (domPropertyConfig) {
+    var Injection = DOMPropertyInjection;
+    var Properties = domPropertyConfig.Properties || {};
+    var DOMAttributeNamespaces = domPropertyConfig.DOMAttributeNamespaces || {};
+    var DOMAttributeNames = domPropertyConfig.DOMAttributeNames || {};
+    var DOMPropertyNames = domPropertyConfig.DOMPropertyNames || {};
+    var DOMMutationMethods = domPropertyConfig.DOMMutationMethods || {};
+
+    if (domPropertyConfig.isCustomAttribute) {
+      DOMProperty._isCustomAttributeFunctions.push(domPropertyConfig.isCustomAttribute);
+    }
+
+    for (var propName in Properties) {
+      !!DOMProperty.properties.hasOwnProperty(propName) ? "development" !== 'production' ? invariant(false, 'injectDOMPropertyConfig(...): You\'re trying to inject DOM property \'%s\' which has already been injected. You may be accidentally injecting the same DOM property config twice, or you may be injecting two configs that have conflicting property names.', propName) : _prodInvariant('48', propName) : void 0;
+
+      var lowerCased = propName.toLowerCase();
+      var propConfig = Properties[propName];
+
+      var propertyInfo = {
+        attributeName: lowerCased,
+        attributeNamespace: null,
+        propertyName: propName,
+        mutationMethod: null,
+
+        mustUseProperty: checkMask(propConfig, Injection.MUST_USE_PROPERTY),
+        hasBooleanValue: checkMask(propConfig, Injection.HAS_BOOLEAN_VALUE),
+        hasNumericValue: checkMask(propConfig, Injection.HAS_NUMERIC_VALUE),
+        hasPositiveNumericValue: checkMask(propConfig, Injection.HAS_POSITIVE_NUMERIC_VALUE),
+        hasOverloadedBooleanValue: checkMask(propConfig, Injection.HAS_OVERLOADED_BOOLEAN_VALUE)
+      };
+      !(propertyInfo.hasBooleanValue + propertyInfo.hasNumericValue + propertyInfo.hasOverloadedBooleanValue <= 1) ? "development" !== 'production' ? invariant(false, 'DOMProperty: Value can be one of boolean, overloaded boolean, or numeric value, but not a combination: %s', propName) : _prodInvariant('50', propName) : void 0;
+
+      if ("development" !== 'production') {
+        DOMProperty.getPossibleStandardName[lowerCased] = propName;
+      }
+
+      if (DOMAttributeNames.hasOwnProperty(propName)) {
+        var attributeName = DOMAttributeNames[propName];
+        propertyInfo.attributeName = attributeName;
+        if ("development" !== 'production') {
+          DOMProperty.getPossibleStandardName[attributeName] = propName;
+        }
+      }
+
+      if (DOMAttributeNamespaces.hasOwnProperty(propName)) {
+        propertyInfo.attributeNamespace = DOMAttributeNamespaces[propName];
+      }
+
+      if (DOMPropertyNames.hasOwnProperty(propName)) {
+        propertyInfo.propertyName = DOMPropertyNames[propName];
+      }
+
+      if (DOMMutationMethods.hasOwnProperty(propName)) {
+        propertyInfo.mutationMethod = DOMMutationMethods[propName];
+      }
+
+      DOMProperty.properties[propName] = propertyInfo;
+    }
+  }
+};
+
+/* eslint-disable max-len */
+var ATTRIBUTE_NAME_START_CHAR = ':A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD';
+/* eslint-enable max-len */
+
+/**
+ * DOMProperty exports lookup objects that can be used like functions:
+ *
+ *   > DOMProperty.isValid['id']
+ *   true
+ *   > DOMProperty.isValid['foobar']
+ *   undefined
+ *
+ * Although this may be confusing, it performs better in general.
+ *
+ * @see http://jsperf.com/key-exists
+ * @see http://jsperf.com/key-missing
+ */
+var DOMProperty = {
+  ID_ATTRIBUTE_NAME: 'data-reactid',
+  ROOT_ATTRIBUTE_NAME: 'data-reactroot',
+
+  ATTRIBUTE_NAME_START_CHAR: ATTRIBUTE_NAME_START_CHAR,
+  ATTRIBUTE_NAME_CHAR: ATTRIBUTE_NAME_START_CHAR + '\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040',
+
+  /**
+   * Map from property "standard name" to an object with info about how to set
+   * the property in the DOM. Each object contains:
+   *
+   * attributeName:
+   *   Used when rendering markup or with `*Attribute()`.
+   * attributeNamespace
+   * propertyName:
+   *   Used on DOM node instances. (This includes properties that mutate due to
+   *   external factors.)
+   * mutationMethod:
+   *   If non-null, used instead of the property or `setAttribute()` after
+   *   initial render.
+   * mustUseProperty:
+   *   Whether the property must be accessed and mutated as an object property.
+   * hasBooleanValue:
+   *   Whether the property should be removed when set to a falsey value.
+   * hasNumericValue:
+   *   Whether the property must be numeric or parse as a numeric and should be
+   *   removed when set to a falsey value.
+   * hasPositiveNumericValue:
+   *   Whether the property must be positive numeric or parse as a positive
+   *   numeric and should be removed when set to a falsey value.
+   * hasOverloadedBooleanValue:
+   *   Whether the property can be used as a flag as well as with a value.
+   *   Removed when strictly equal to false; present without a value when
+   *   strictly equal to true; present with a value otherwise.
+   */
+  properties: {},
+
+  /**
+   * Mapping from lowercase property names to the properly cased version, used
+   * to warn in the case of missing properties. Available only in __DEV__.
+   *
+   * autofocus is predefined, because adding it to the property whitelist
+   * causes unintended side effects.
+   *
+   * @type {Object}
+   */
+  getPossibleStandardName: "development" !== 'production' ? { autofocus: 'autoFocus' } : null,
+
+  /**
+   * All of the isCustomAttribute() functions that have been injected.
+   */
+  _isCustomAttributeFunctions: [],
+
+  /**
+   * Checks whether a property name is a custom attribute.
+   * @method
+   */
+  isCustomAttribute: function (attributeName) {
+    for (var i = 0; i < DOMProperty._isCustomAttributeFunctions.length; i++) {
+      var isCustomAttributeFn = DOMProperty._isCustomAttributeFunctions[i];
+      if (isCustomAttributeFn(attributeName)) {
+        return true;
+      }
+    }
+    return false;
+  },
+
+  injection: DOMPropertyInjection
+};
+
+module.exports = DOMProperty;
+},{"126":126,"152":152}],12:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var DOMProperty = _dereq_(11);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactInstrumentation = _dereq_(64);
+
+var quoteAttributeValueForBrowser = _dereq_(125);
+var warning = _dereq_(159);
+
+var VALID_ATTRIBUTE_NAME_REGEX = new RegExp('^[' + DOMProperty.ATTRIBUTE_NAME_START_CHAR + '][' + DOMProperty.ATTRIBUTE_NAME_CHAR + ']*$');
+var illegalAttributeNameCache = {};
+var validatedAttributeNameCache = {};
+
+function isAttributeNameSafe(attributeName) {
+  if (validatedAttributeNameCache.hasOwnProperty(attributeName)) {
+    return true;
+  }
+  if (illegalAttributeNameCache.hasOwnProperty(attributeName)) {
+    return false;
+  }
+  if (VALID_ATTRIBUTE_NAME_REGEX.test(attributeName)) {
+    validatedAttributeNameCache[attributeName] = true;
+    return true;
+  }
+  illegalAttributeNameCache[attributeName] = true;
+  "development" !== 'production' ? warning(false, 'Invalid attribute name: `%s`', attributeName) : void 0;
+  return false;
+}
+
+function shouldIgnoreValue(propertyInfo, value) {
+  return value == null || propertyInfo.hasBooleanValue && !value || propertyInfo.hasNumericValue && isNaN(value) || propertyInfo.hasPositiveNumericValue && value < 1 || propertyInfo.hasOverloadedBooleanValue && value === false;
+}
+
+/**
+ * Operations for dealing with DOM properties.
+ */
+var DOMPropertyOperations = {
+  /**
+   * Creates markup for the ID property.
+   *
+   * @param {string} id Unescaped ID.
+   * @return {string} Markup string.
+   */
+  createMarkupForID: function (id) {
+    return DOMProperty.ID_ATTRIBUTE_NAME + '=' + quoteAttributeValueForBrowser(id);
+  },
+
+  setAttributeForID: function (node, id) {
+    node.setAttribute(DOMProperty.ID_ATTRIBUTE_NAME, id);
+  },
+
+  createMarkupForRoot: function () {
+    return DOMProperty.ROOT_ATTRIBUTE_NAME + '=""';
+  },
+
+  setAttributeForRoot: function (node) {
+    node.setAttribute(DOMProperty.ROOT_ATTRIBUTE_NAME, '');
+  },
+
+  /**
+   * Creates markup for a property.
+   *
+   * @param {string} name
+   * @param {*} value
+   * @return {?string} Markup string, or null if the property was invalid.
+   */
+  createMarkupForProperty: function (name, value) {
+    var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ? DOMProperty.properties[name] : null;
+    if (propertyInfo) {
+      if (shouldIgnoreValue(propertyInfo, value)) {
+        return '';
+      }
+      var attributeName = propertyInfo.attributeName;
+      if (propertyInfo.hasBooleanValue || propertyInfo.hasOverloadedBooleanValue && value === true) {
+        return attributeName + '=""';
+      }
+      return attributeName + '=' + quoteAttributeValueForBrowser(value);
+    } else if (DOMProperty.isCustomAttribute(name)) {
+      if (value == null) {
+        return '';
+      }
+      return name + '=' + quoteAttributeValueForBrowser(value);
+    }
+    return null;
+  },
+
+  /**
+   * Creates markup for a custom property.
+   *
+   * @param {string} name
+   * @param {*} value
+   * @return {string} Markup string, or empty string if the property was invalid.
+   */
+  createMarkupForCustomAttribute: function (name, value) {
+    if (!isAttributeNameSafe(name) || value == null) {
+      return '';
+    }
+    return name + '=' + quoteAttributeValueForBrowser(value);
+  },
+
+  /**
+   * Sets the value for a property on a node.
+   *
+   * @param {DOMElement} node
+   * @param {string} name
+   * @param {*} value
+   */
+  setValueForProperty: function (node, name, value) {
+    var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ? DOMProperty.properties[name] : null;
+    if (propertyInfo) {
+      var mutationMethod = propertyInfo.mutationMethod;
+      if (mutationMethod) {
+        mutationMethod(node, value);
+      } else if (shouldIgnoreValue(propertyInfo, value)) {
+        this.deleteValueForProperty(node, name);
+        return;
+      } else if (propertyInfo.mustUseProperty) {
+        // Contrary to `setAttribute`, object properties are properly
+        // `toString`ed by IE8/9.
+        node[propertyInfo.propertyName] = value;
+      } else {
+        var attributeName = propertyInfo.attributeName;
+        var namespace = propertyInfo.attributeNamespace;
+        // `setAttribute` with objects becomes only `[object]` in IE8/9,
+        // ('' + value) makes it output the correct toString()-value.
+        if (namespace) {
+          node.setAttributeNS(namespace, attributeName, '' + value);
+        } else if (propertyInfo.hasBooleanValue || propertyInfo.hasOverloadedBooleanValue && value === true) {
+          node.setAttribute(attributeName, '');
+        } else {
+          node.setAttribute(attributeName, '' + value);
+        }
+      }
+    } else if (DOMProperty.isCustomAttribute(name)) {
+      DOMPropertyOperations.setValueForAttribute(node, name, value);
+      return;
+    }
+
+    if ("development" !== 'production') {
+      var payload = {};
+      payload[name] = value;
+      ReactInstrumentation.debugTool.onHostOperation({
+        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+        type: 'update attribute',
+        payload: payload
+      });
+    }
+  },
+
+  setValueForAttribute: function (node, name, value) {
+    if (!isAttributeNameSafe(name)) {
+      return;
+    }
+    if (value == null) {
+      node.removeAttribute(name);
+    } else {
+      node.setAttribute(name, '' + value);
+    }
+
+    if ("development" !== 'production') {
+      var payload = {};
+      payload[name] = value;
+      ReactInstrumentation.debugTool.onHostOperation({
+        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+        type: 'update attribute',
+        payload: payload
+      });
+    }
+  },
+
+  /**
+   * Deletes an attributes from a node.
+   *
+   * @param {DOMElement} node
+   * @param {string} name
+   */
+  deleteValueForAttribute: function (node, name) {
+    node.removeAttribute(name);
+    if ("development" !== 'production') {
+      ReactInstrumentation.debugTool.onHostOperation({
+        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+        type: 'remove attribute',
+        payload: name
+      });
+    }
+  },
+
+  /**
+   * Deletes the value for a property on a node.
+   *
+   * @param {DOMElement} node
+   * @param {string} name
+   */
+  deleteValueForProperty: function (node, name) {
+    var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ? DOMProperty.properties[name] : null;
+    if (propertyInfo) {
+      var mutationMethod = propertyInfo.mutationMethod;
+      if (mutationMethod) {
+        mutationMethod(node, undefined);
+      } else if (propertyInfo.mustUseProperty) {
+        var propName = propertyInfo.propertyName;
+        if (propertyInfo.hasBooleanValue) {
+          node[propName] = false;
+        } else {
+          node[propName] = '';
+        }
+      } else {
+        node.removeAttribute(propertyInfo.attributeName);
+      }
+    } else if (DOMProperty.isCustomAttribute(name)) {
+      node.removeAttribute(name);
+    }
+
+    if ("development" !== 'production') {
+      ReactInstrumentation.debugTool.onHostOperation({
+        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+        type: 'remove attribute',
+        payload: name
+      });
+    }
+  }
+};
+
+module.exports = DOMPropertyOperations;
+},{"11":11,"125":125,"159":159,"34":34,"64":64}],13:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var DOMLazyTree = _dereq_(9);
+var ExecutionEnvironment = _dereq_(138);
+
+var createNodesFromMarkup = _dereq_(143);
+var emptyFunction = _dereq_(144);
+var invariant = _dereq_(152);
+
+var Danger = {
+  /**
+   * Replaces a node with a string of markup at its current position within its
+   * parent. The markup must render into a single root node.
+   *
+   * @param {DOMElement} oldChild Child node to replace.
+   * @param {string} markup Markup to render in place of the child node.
+   * @internal
+   */
+  dangerouslyReplaceNodeWithMarkup: function (oldChild, markup) {
+    !ExecutionEnvironment.canUseDOM ? "development" !== 'production' ? invariant(false, 'dangerouslyReplaceNodeWithMarkup(...): Cannot render markup in a worker thread. Make sure `window` and `document` are available globally before requiring React when unit testing or use ReactDOMServer.renderToString() for server rendering.') : _prodInvariant('56') : void 0;
+    !markup ? "development" !== 'production' ? invariant(false, 'dangerouslyReplaceNodeWithMarkup(...): Missing markup.') : _prodInvariant('57') : void 0;
+    !(oldChild.nodeName !== 'HTML') ? "development" !== 'production' ? invariant(false, 'dangerouslyReplaceNodeWithMarkup(...): Cannot replace markup of the <html> node. This is because browser quirks make this unreliable and/or slow. If you want to render to the root you must use server rendering. See ReactDOMServer.renderToString().') : _prodInvariant('58') : void 0;
+
+    if (typeof markup === 'string') {
+      var newChild = createNodesFromMarkup(markup, emptyFunction)[0];
+      oldChild.parentNode.replaceChild(newChild, oldChild);
+    } else {
+      DOMLazyTree.replaceChildWithTree(oldChild, markup);
+    }
+  }
+};
+
+module.exports = Danger;
+},{"126":126,"138":138,"143":143,"144":144,"152":152,"9":9}],14:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+/**
+ * Module that is injectable into `EventPluginHub`, that specifies a
+ * deterministic ordering of `EventPlugin`s. A convenient way to reason about
+ * plugins, without having to package every one of them. This is better than
+ * having plugins be ordered in the same order that they are injected because
+ * that ordering would be influenced by the packaging order.
+ * `ResponderEventPlugin` must occur before `SimpleEventPlugin` so that
+ * preventing default on events is convenient in `SimpleEventPlugin` handlers.
+ */
+
+var DefaultEventPluginOrder = ['ResponderEventPlugin', 'SimpleEventPlugin', 'TapEventPlugin', 'EnterLeaveEventPlugin', 'ChangeEventPlugin', 'SelectEventPlugin', 'BeforeInputEventPlugin'];
+
+module.exports = DefaultEventPluginOrder;
+},{}],15:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var EventPropagators = _dereq_(20);
+var ReactDOMComponentTree = _dereq_(34);
+var SyntheticMouseEvent = _dereq_(95);
+
+var eventTypes = {
+  mouseEnter: {
+    registrationName: 'onMouseEnter',
+    dependencies: ['topMouseOut', 'topMouseOver']
+  },
+  mouseLeave: {
+    registrationName: 'onMouseLeave',
+    dependencies: ['topMouseOut', 'topMouseOver']
+  }
+};
+
+var EnterLeaveEventPlugin = {
+  eventTypes: eventTypes,
+
+  /**
+   * For almost every interaction we care about, there will be both a top-level
+   * `mouseover` and `mouseout` event that occurs. Only use `mouseout` so that
+   * we do not extract duplicate events. However, moving the mouse into the
+   * browser from outside will not fire a `mouseout` event. In this case, we use
+   * the `mouseover` top-level event.
+   */
+  extractEvents: function (topLevelType, targetInst, nativeEvent, nativeEventTarget) {
+    if (topLevelType === 'topMouseOver' && (nativeEvent.relatedTarget || nativeEvent.fromElement)) {
+      return null;
+    }
+    if (topLevelType !== 'topMouseOut' && topLevelType !== 'topMouseOver') {
+      // Must not be a mouse in or mouse out - ignoring.
+      return null;
+    }
+
+    var win;
+    if (nativeEventTarget.window === nativeEventTarget) {
+      // `nativeEventTarget` is probably a window object.
+      win = nativeEventTarget;
+    } else {
+      // TODO: Figure out why `ownerDocument` is sometimes undefined in IE8.
+      var doc = nativeEventTarget.ownerDocument;
+      if (doc) {
+        win = doc.defaultView || doc.parentWindow;
+      } else {
+        win = window;
+      }
+    }
+
+    var from;
+    var to;
+    if (topLevelType === 'topMouseOut') {
+      from = targetInst;
+      var related = nativeEvent.relatedTarget || nativeEvent.toElement;
+      to = related ? ReactDOMComponentTree.getClosestInstanceFromNode(related) : null;
+    } else {
+      // Moving to a node from outside the window.
+      from = null;
+      to = targetInst;
+    }
+
+    if (from === to) {
+      // Nothing pertains to our managed components.
+      return null;
+    }
+
+    var fromNode = from == null ? win : ReactDOMComponentTree.getNodeFromInstance(from);
+    var toNode = to == null ? win : ReactDOMComponentTree.getNodeFromInstance(to);
+
+    var leave = SyntheticMouseEvent.getPooled(eventTypes.mouseLeave, from, nativeEvent, nativeEventTarget);
+    leave.type = 'mouseleave';
+    leave.target = fromNode;
+    leave.relatedTarget = toNode;
+
+    var enter = SyntheticMouseEvent.getPooled(eventTypes.mouseEnter, to, nativeEvent, nativeEventTarget);
+    enter.type = 'mouseenter';
+    enter.target = toNode;
+    enter.relatedTarget = fromNode;
+
+    EventPropagators.accumulateEnterLeaveDispatches(leave, enter, from, to);
+
+    return [leave, enter];
+  }
+};
+
+module.exports = EnterLeaveEventPlugin;
+},{"20":20,"34":34,"95":95}],16:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+/**
+ * Types of raw signals from the browser caught at the top level.
+ */
+var topLevelTypes = {
+  topAbort: null,
+  topAnimationEnd: null,
+  topAnimationIteration: null,
+  topAnimationStart: null,
+  topBlur: null,
+  topCanPlay: null,
+  topCanPlayThrough: null,
+  topChange: null,
+  topClick: null,
+  topCompositionEnd: null,
+  topCompositionStart: null,
+  topCompositionUpdate: null,
+  topContextMenu: null,
+  topCopy: null,
+  topCut: null,
+  topDoubleClick: null,
+  topDrag: null,
+  topDragEnd: null,
+  topDragEnter: null,
+  topDragExit: null,
+  topDragLeave: null,
+  topDragOver: null,
+  topDragStart: null,
+  topDrop: null,
+  topDurationChange: null,
+  topEmptied: null,
+  topEncrypted: null,
+  topEnded: null,
+  topError: null,
+  topFocus: null,
+  topInput: null,
+  topInvalid: null,
+  topKeyDown: null,
+  topKeyPress: null,
+  topKeyUp: null,
+  topLoad: null,
+  topLoadedData: null,
+  topLoadedMetadata: null,
+  topLoadStart: null,
+  topMouseDown: null,
+  topMouseMove: null,
+  topMouseOut: null,
+  topMouseOver: null,
+  topMouseUp: null,
+  topPaste: null,
+  topPause: null,
+  topPlay: null,
+  topPlaying: null,
+  topProgress: null,
+  topRateChange: null,
+  topReset: null,
+  topScroll: null,
+  topSeeked: null,
+  topSeeking: null,
+  topSelectionChange: null,
+  topStalled: null,
+  topSubmit: null,
+  topSuspend: null,
+  topTextInput: null,
+  topTimeUpdate: null,
+  topTouchCancel: null,
+  topTouchEnd: null,
+  topTouchMove: null,
+  topTouchStart: null,
+  topTransitionEnd: null,
+  topVolumeChange: null,
+  topWaiting: null,
+  topWheel: null
+};
+
+var EventConstants = {
+  topLevelTypes: topLevelTypes
+};
+
+module.exports = EventConstants;
+},{}],17:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var EventPluginRegistry = _dereq_(18);
+var EventPluginUtils = _dereq_(19);
+var ReactErrorUtils = _dereq_(55);
+
+var accumulateInto = _dereq_(102);
+var forEachAccumulated = _dereq_(110);
+var invariant = _dereq_(152);
+
+/**
+ * Internal store for event listeners
+ */
+var listenerBank = {};
+
+/**
+ * Internal queue of events that have accumulated their dispatches and are
+ * waiting to have their dispatches executed.
+ */
+var eventQueue = null;
+
+/**
+ * Dispatches an event and releases it back into the pool, unless persistent.
+ *
+ * @param {?object} event Synthetic event to be dispatched.
+ * @param {boolean} simulated If the event is simulated (changes exn behavior)
+ * @private
+ */
+var executeDispatchesAndRelease = function (event, simulated) {
+  if (event) {
+    EventPluginUtils.executeDispatchesInOrder(event, simulated);
+
+    if (!event.isPersistent()) {
+      event.constructor.release(event);
+    }
+  }
+};
+var executeDispatchesAndReleaseSimulated = function (e) {
+  return executeDispatchesAndRelease(e, true);
+};
+var executeDispatchesAndReleaseTopLevel = function (e) {
+  return executeDispatchesAndRelease(e, false);
+};
+
+var getDictionaryKey = function (inst) {
+  // Prevents V8 performance issue:
+  // https://github.com/facebook/react/pull/7232
+  return '.' + inst._rootNodeID;
+};
+
+function isInteractive(tag) {
+  return tag === 'button' || tag === 'input' || tag === 'select' || tag === 'textarea';
+}
+
+function shouldPreventMouseEvent(name, type, props) {
+  switch (name) {
+    case 'onClick':
+    case 'onClickCapture':
+    case 'onDoubleClick':
+    case 'onDoubleClickCapture':
+    case 'onMouseDown':
+    case 'onMouseDownCapture':
+    case 'onMouseMove':
+    case 'onMouseMoveCapture':
+    case 'onMouseUp':
+    case 'onMouseUpCapture':
+      return !!(props.disabled && isInteractive(type));
+    default:
+      return false;
+  }
+}
+
+/**
+ * This is a unified interface for event plugins to be installed and configured.
+ *
+ * Event plugins can implement the following properties:
+ *
+ *   `extractEvents` {function(string, DOMEventTarget, string, object): *}
+ *     Required. When a top-level event is fired, this method is expected to
+ *     extract synthetic events that will in turn be queued and dispatched.
+ *
+ *   `eventTypes` {object}
+ *     Optional, plugins that fire events must publish a mapping of registration
+ *     names that are used to register listeners. Values of this mapping must
+ *     be objects that contain `registrationName` or `phasedRegistrationNames`.
+ *
+ *   `executeDispatch` {function(object, function, string)}
+ *     Optional, allows plugins to override how an event gets dispatched. By
+ *     default, the listener is simply invoked.
+ *
+ * Each plugin that is injected into `EventsPluginHub` is immediately operable.
+ *
+ * @public
+ */
+var EventPluginHub = {
+  /**
+   * Methods for injecting dependencies.
+   */
+  injection: {
+    /**
+     * @param {array} InjectedEventPluginOrder
+     * @public
+     */
+    injectEventPluginOrder: EventPluginRegistry.injectEventPluginOrder,
+
+    /**
+     * @param {object} injectedNamesToPlugins Map from names to plugin modules.
+     */
+    injectEventPluginsByName: EventPluginRegistry.injectEventPluginsByName
+  },
+
+  /**
+   * Stores `listener` at `listenerBank[registrationName][key]`. Is idempotent.
+   *
+   * @param {object} inst The instance, which is the source of events.
+   * @param {string} registrationName Name of listener (e.g. `onClick`).
+   * @param {function} listener The callback to store.
+   */
+  putListener: function (inst, registrationName, listener) {
+    !(typeof listener === 'function') ? "development" !== 'production' ? invariant(false, 'Expected %s listener to be a function, instead got type %s', registrationName, typeof listener) : _prodInvariant('94', registrationName, typeof listener) : void 0;
+
+    var key = getDictionaryKey(inst);
+    var bankForRegistrationName = listenerBank[registrationName] || (listenerBank[registrationName] = {});
+    bankForRegistrationName[key] = listener;
+
+    var PluginModule = EventPluginRegistry.registrationNameModules[registrationName];
+    if (PluginModule && PluginModule.didPutListener) {
+      PluginModule.didPutListener(inst, registrationName, listener);
+    }
+  },
+
+  /**
+   * @param {object} inst The instance, which is the source of events.
+   * @param {string} registrationName Name of listener (e.g. `onClick`).
+   * @return {?function} The stored callback.
+   */
+  getListener: function (inst, registrationName) {
+    // TODO: shouldPreventMouseEvent is DOM-specific and definitely should not
+    // live here; needs to be moved to a better place soon
+    var bankForRegistrationName = listenerBank[registrationName];
+    if (shouldPreventMouseEvent(registrationName, inst._currentElement.type, inst._currentElement.props)) {
+      return null;
+    }
+    var key = getDictionaryKey(inst);
+    return bankForRegistrationName && bankForRegistrationName[key];
+  },
+
+  /**
+   * Deletes a listener from the registration bank.
+   *
+   * @param {object} inst The instance, which is the source of events.
+   * @param {string} registrationName Name of listener (e.g. `onClick`).
+   */
+  deleteListener: function (inst, registrationName) {
+    var PluginModule = EventPluginRegistry.registrationNameModules[registrationName];
+    if (PluginModule && PluginModule.willDeleteListener) {
+      PluginModule.willDeleteListener(inst, registrationName);
+    }
+
+    var bankForRegistrationName = listenerBank[registrationName];
+    // TODO: This should never be null -- when is it?
+    if (bankForRegistrationName) {
+      var key = getDictionaryKey(inst);
+      delete bankForRegistrationName[key];
+    }
+  },
+
+  /**
+   * Deletes all listeners for the DOM element with the supplied ID.
+   *
+   * @param {object} inst The instance, which is the source of events.
+   */
+  deleteAllListeners: function (inst) {
+    var key = getDictionaryKey(inst);
+    for (var registrationName in listenerBank) {
+      if (!listenerBank.hasOwnProperty(registrationName)) {
+        continue;
+      }
+
+      if (!listenerBank[registrationName][key]) {
+        continue;
+      }
+
+      var PluginModule = EventPluginRegistry.registrationNameModules[registrationName];
+      if (PluginModule && PluginModule.willDeleteListener) {
+        PluginModule.willDeleteListener(inst, registrationName);
+      }
+
+      delete listenerBank[registrationName][key];
+    }
+  },
+
+  /**
+   * Allows registered plugins an opportunity to extract events from top-level
+   * native browser events.
+   *
+   * @return {*} An accumulation of synthetic events.
+   * @internal
+   */
+  extractEvents: function (topLevelType, targetInst, nativeEvent, nativeEventTarget) {
+    var events;
+    var plugins = EventPluginRegistry.plugins;
+    for (var i = 0; i < plugins.length; i++) {
+      // Not every plugin in the ordering may be loaded at runtime.
+      var possiblePlugin = plugins[i];
+      if (possiblePlugin) {
+        var extractedEvents = possiblePlugin.extractEvents(topLevelType, targetInst, nativeEvent, nativeEventTarget);
+        if (extractedEvents) {
+          events = accumulateInto(events, extractedEvents);
+        }
+      }
+    }
+    return events;
+  },
+
+  /**
+   * Enqueues a synthetic event that should be dispatched when
+   * `processEventQueue` is invoked.
+   *
+   * @param {*} events An accumulation of synthetic events.
+   * @internal
+   */
+  enqueueEvents: function (events) {
+    if (events) {
+      eventQueue = accumulateInto(eventQueue, events);
+    }
+  },
+
+  /**
+   * Dispatches all synthetic events on the event queue.
+   *
+   * @internal
+   */
+  processEventQueue: function (simulated) {
+    // Set `eventQueue` to null before processing it so that we can tell if more
+    // events get enqueued while processing.
+    var processingEventQueue = eventQueue;
+    eventQueue = null;
+    if (simulated) {
+      forEachAccumulated(processingEventQueue, executeDispatchesAndReleaseSimulated);
+    } else {
+      forEachAccumulated(processingEventQueue, executeDispatchesAndReleaseTopLevel);
+    }
+    !!eventQueue ? "development" !== 'production' ? invariant(false, 'processEventQueue(): Additional events were enqueued while processing an event queue. Support for this has not yet been implemented.') : _prodInvariant('95') : void 0;
+    // This would be a good time to rethrow if any of the event handlers threw.
+    ReactErrorUtils.rethrowCaughtError();
+  },
+
+  /**
+   * These are needed for tests only. Do not use!
+   */
+  __purge: function () {
+    listenerBank = {};
+  },
+
+  __getListenerBank: function () {
+    return listenerBank;
+  }
+};
+
+module.exports = EventPluginHub;
+},{"102":102,"110":110,"126":126,"152":152,"18":18,"19":19,"55":55}],18:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var invariant = _dereq_(152);
+
+/**
+ * Injectable ordering of event plugins.
+ */
+var eventPluginOrder = null;
+
+/**
+ * Injectable mapping from names to event plugin modules.
+ */
+var namesToPlugins = {};
+
+/**
+ * Recomputes the plugin list using the injected plugins and plugin ordering.
+ *
+ * @private
+ */
+function recomputePluginOrdering() {
+  if (!eventPluginOrder) {
+    // Wait until an `eventPluginOrder` is injected.
+    return;
+  }
+  for (var pluginName in namesToPlugins) {
+    var pluginModule = namesToPlugins[pluginName];
+    var pluginIndex = eventPluginOrder.indexOf(pluginName);
+    !(pluginIndex > -1) ? "development" !== 'production' ? invariant(false, 'EventPluginRegistry: Cannot inject event plugins that do not exist in the plugin ordering, `%s`.', pluginName) : _prodInvariant('96', pluginName) : void 0;
+    if (EventPluginRegistry.plugins[pluginIndex]) {
+      continue;
+    }
+    !pluginModule.extractEvents ? "development" !== 'production' ? invariant(false, 'EventPluginRegistry: Event plugins must implement an `extractEvents` method, but `%s` does not.', pluginName) : _prodInvariant('97', pluginName) : void 0;
+    EventPluginRegistry.plugins[pluginIndex] = pluginModule;
+    var publishedEvents = pluginModule.eventTypes;
+    for (var eventName in publishedEvents) {
+      !publishEventForPlugin(publishedEvents[eventName], pluginModule, eventName) ? "development" !== 'production' ? invariant(false, 'EventPluginRegistry: Failed to publish event `%s` for plugin `%s`.', eventName, pluginName) : _prodInvariant('98', eventName, pluginName) : void 0;
+    }
+  }
+}
+
+/**
+ * Publishes an event so that it can be dispatched by the supplied plugin.
+ *
+ * @param {object} dispatchConfig Dispatch configuration for the event.
+ * @param {object} PluginModule Plugin publishing the event.
+ * @return {boolean} True if the event was successfully published.
+ * @private
+ */
+function publishEventForPlugin(dispatchConfig, pluginModule, eventName) {
+  !!EventPluginRegistry.eventNameDispatchConfigs.hasOwnProperty(eventName) ? "development" !== 'production' ? invariant(false, 'EventPluginHub: More than one plugin attempted to publish the same event name, `%s`.', eventName) : _prodInvariant('99', eventName) : void 0;
+  EventPluginRegistry.eventNameDispatchConfigs[eventName] = dispatchConfig;
+
+  var phasedRegistrationNames = dispatchConfig.phasedRegistrationNames;
+  if (phasedRegistrationNames) {
+    for (var phaseName in phasedRegistrationNames) {
+      if (phasedRegistrationNames.hasOwnProperty(phaseName)) {
+        var phasedRegistrationName = phasedRegistrationNames[phaseName];
+        publishRegistrationName(phasedRegistrationName, pluginModule, eventName);
+      }
+    }
+    return true;
+  } else if (dispatchConfig.registrationName) {
+    publishRegistrationName(dispatchConfig.registrationName, pluginModule, eventName);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Publishes a registration name that is used to identify dispatched events and
+ * can be used with `EventPluginHub.putListener` to register listeners.
+ *
+ * @param {string} registrationName Registration name to add.
+ * @param {object} PluginModule Plugin publishing the event.
+ * @private
+ */
+function publishRegistrationName(registrationName, pluginModule, eventName) {
+  !!EventPluginRegistry.registrationNameModules[registrationName] ? "development" !== 'production' ? invariant(false, 'EventPluginHub: More than one plugin attempted to publish the same registration name, `%s`.', registrationName) : _prodInvariant('100', registrationName) : void 0;
+  EventPluginRegistry.registrationNameModules[registrationName] = pluginModule;
+  EventPluginRegistry.registrationNameDependencies[registrationName] = pluginModule.eventTypes[eventName].dependencies;
+
+  if ("development" !== 'production') {
+    var lowerCasedName = registrationName.toLowerCase();
+    EventPluginRegistry.possibleRegistrationNames[lowerCasedName] = registrationName;
+
+    if (registrationName === 'onDoubleClick') {
+      EventPluginRegistry.possibleRegistrationNames.ondblclick = registrationName;
+    }
+  }
+}
+
+/**
+ * Registers plugins so that they can extract and dispatch events.
+ *
+ * @see {EventPluginHub}
+ */
+var EventPluginRegistry = {
+  /**
+   * Ordered list of injected plugins.
+   */
+  plugins: [],
+
+  /**
+   * Mapping from event name to dispatch config
+   */
+  eventNameDispatchConfigs: {},
+
+  /**
+   * Mapping from registration name to plugin module
+   */
+  registrationNameModules: {},
+
+  /**
+   * Mapping from registration name to event name
+   */
+  registrationNameDependencies: {},
+
+  /**
+   * Mapping from lowercase registration names to the properly cased version,
+   * used to warn in the case of missing event handlers. Available
+   * only in __DEV__.
+   * @type {Object}
+   */
+  possibleRegistrationNames: "development" !== 'production' ? {} : null,
+  // Trust the developer to only use possibleRegistrationNames in __DEV__
+
+  /**
+   * Injects an ordering of plugins (by plugin name). This allows the ordering
+   * to be decoupled from injection of the actual plugins so that ordering is
+   * always deterministic regardless of packaging, on-the-fly injection, etc.
+   *
+   * @param {array} InjectedEventPluginOrder
+   * @internal
+   * @see {EventPluginHub.injection.injectEventPluginOrder}
+   */
+  injectEventPluginOrder: function (injectedEventPluginOrder) {
+    !!eventPluginOrder ? "development" !== 'production' ? invariant(false, 'EventPluginRegistry: Cannot inject event plugin ordering more than once. You are likely trying to load more than one copy of React.') : _prodInvariant('101') : void 0;
+    // Clone the ordering so it cannot be dynamically mutated.
+    eventPluginOrder = Array.prototype.slice.call(injectedEventPluginOrder);
+    recomputePluginOrdering();
+  },
+
+  /**
+   * Injects plugins to be used by `EventPluginHub`. The plugin names must be
+   * in the ordering injected by `injectEventPluginOrder`.
+   *
+   * Plugins can be injected as part of page initialization or on-the-fly.
+   *
+   * @param {object} injectedNamesToPlugins Map from names to plugin modules.
+   * @internal
+   * @see {EventPluginHub.injection.injectEventPluginsByName}
+   */
+  injectEventPluginsByName: function (injectedNamesToPlugins) {
+    var isOrderingDirty = false;
+    for (var pluginName in injectedNamesToPlugins) {
+      if (!injectedNamesToPlugins.hasOwnProperty(pluginName)) {
+        continue;
+      }
+      var pluginModule = injectedNamesToPlugins[pluginName];
+      if (!namesToPlugins.hasOwnProperty(pluginName) || namesToPlugins[pluginName] !== pluginModule) {
+        !!namesToPlugins[pluginName] ? "development" !== 'production' ? invariant(false, 'EventPluginRegistry: Cannot inject two different event plugins using the same name, `%s`.', pluginName) : _prodInvariant('102', pluginName) : void 0;
+        namesToPlugins[pluginName] = pluginModule;
+        isOrderingDirty = true;
+      }
+    }
+    if (isOrderingDirty) {
+      recomputePluginOrdering();
+    }
+  },
+
+  /**
+   * Looks up the plugin for the supplied event.
+   *
+   * @param {object} event A synthetic event.
+   * @return {?object} The plugin that created the supplied event.
+   * @internal
+   */
+  getPluginModuleForEvent: function (event) {
+    var dispatchConfig = event.dispatchConfig;
+    if (dispatchConfig.registrationName) {
+      return EventPluginRegistry.registrationNameModules[dispatchConfig.registrationName] || null;
+    }
+    if (dispatchConfig.phasedRegistrationNames !== undefined) {
+      // pulling phasedRegistrationNames out of dispatchConfig helps Flow see
+      // that it is not undefined.
+      var phasedRegistrationNames = dispatchConfig.phasedRegistrationNames;
+
+      for (var phase in phasedRegistrationNames) {
+        if (!phasedRegistrationNames.hasOwnProperty(phase)) {
+          continue;
+        }
+        var pluginModule = EventPluginRegistry.registrationNameModules[phasedRegistrationNames[phase]];
+        if (pluginModule) {
+          return pluginModule;
+        }
+      }
+    }
+    return null;
+  },
+
+  /**
+   * Exposed for unit testing.
+   * @private
+   */
+  _resetEventPlugins: function () {
+    eventPluginOrder = null;
+    for (var pluginName in namesToPlugins) {
+      if (namesToPlugins.hasOwnProperty(pluginName)) {
+        delete namesToPlugins[pluginName];
+      }
+    }
+    EventPluginRegistry.plugins.length = 0;
+
+    var eventNameDispatchConfigs = EventPluginRegistry.eventNameDispatchConfigs;
+    for (var eventName in eventNameDispatchConfigs) {
+      if (eventNameDispatchConfigs.hasOwnProperty(eventName)) {
+        delete eventNameDispatchConfigs[eventName];
+      }
+    }
+
+    var registrationNameModules = EventPluginRegistry.registrationNameModules;
+    for (var registrationName in registrationNameModules) {
+      if (registrationNameModules.hasOwnProperty(registrationName)) {
+        delete registrationNameModules[registrationName];
+      }
+    }
+
+    if ("development" !== 'production') {
+      var possibleRegistrationNames = EventPluginRegistry.possibleRegistrationNames;
+      for (var lowerCasedName in possibleRegistrationNames) {
+        if (possibleRegistrationNames.hasOwnProperty(lowerCasedName)) {
+          delete possibleRegistrationNames[lowerCasedName];
+        }
+      }
+    }
+  }
+};
+
+module.exports = EventPluginRegistry;
+},{"126":126,"152":152}],19:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var ReactErrorUtils = _dereq_(55);
+
+var invariant = _dereq_(152);
+var warning = _dereq_(159);
+
+/**
+ * Injected dependencies:
+ */
+
+/**
+ * - `ComponentTree`: [required] Module that can convert between React instances
+ *   and actual node references.
+ */
+var ComponentTree;
+var TreeTraversal;
+var injection = {
+  injectComponentTree: function (Injected) {
+    ComponentTree = Injected;
+    if ("development" !== 'production') {
+      "development" !== 'production' ? warning(Injected && Injected.getNodeFromInstance && Injected.getInstanceFromNode, 'EventPluginUtils.injection.injectComponentTree(...): Injected ' + 'module is missing getNodeFromInstance or getInstanceFromNode.') : void 0;
+    }
+  },
+  injectTreeTraversal: function (Injected) {
+    TreeTraversal = Injected;
+    if ("development" !== 'production') {
+      "development" !== 'production' ? warning(Injected && Injected.isAncestor && Injected.getLowestCommonAncestor, 'EventPluginUtils.injection.injectTreeTraversal(...): Injected ' + 'module is missing isAncestor or getLowestCommonAncestor.') : void 0;
+    }
+  }
+};
+
+function isEndish(topLevelType) {
+  return topLevelType === 'topMouseUp' || topLevelType === 'topTouchEnd' || topLevelType === 'topTouchCancel';
+}
+
+function isMoveish(topLevelType) {
+  return topLevelType === 'topMouseMove' || topLevelType === 'topTouchMove';
+}
+function isStartish(topLevelType) {
+  return topLevelType === 'topMouseDown' || topLevelType === 'topTouchStart';
+}
+
+var validateEventDispatches;
+if ("development" !== 'production') {
+  validateEventDispatches = function (event) {
+    var dispatchListeners = event._dispatchListeners;
+    var dispatchInstances = event._dispatchInstances;
+
+    var listenersIsArr = Array.isArray(dispatchListeners);
+    var listenersLen = listenersIsArr ? dispatchListeners.length : dispatchListeners ? 1 : 0;
+
+    var instancesIsArr = Array.isArray(dispatchInstances);
+    var instancesLen = instancesIsArr ? dispatchInstances.length : dispatchInstances ? 1 : 0;
+
+    "development" !== 'production' ? warning(instancesIsArr === listenersIsArr && instancesLen === listenersLen, 'EventPluginUtils: Invalid `event`.') : void 0;
+  };
+}
+
+/**
+ * Dispatch the event to the listener.
+ * @param {SyntheticEvent} event SyntheticEvent to handle
+ * @param {boolean} simulated If the event is simulated (changes exn behavior)
+ * @param {function} listener Application-level callback
+ * @param {*} inst Internal component instance
+ */
+function executeDispatch(event, simulated, listener, inst) {
+  var type = event.type || 'unknown-event';
+  event.currentTarget = EventPluginUtils.getNodeFromInstance(inst);
+  if (simulated) {
+    ReactErrorUtils.invokeGuardedCallbackWithCatch(type, listener, event);
+  } else {
+    ReactErrorUtils.invokeGuardedCallback(type, listener, event);
+  }
+  event.currentTarget = null;
+}
+
+/**
+ * Standard/simple iteration through an event's collected dispatches.
+ */
+function executeDispatchesInOrder(event, simulated) {
+  var dispatchListeners = event._dispatchListeners;
+  var dispatchInstances = event._dispatchInstances;
+  if ("development" !== 'production') {
+    validateEventDispatches(event);
+  }
+  if (Array.isArray(dispatchListeners)) {
+    for (var i = 0; i < dispatchListeners.length; i++) {
+      if (event.isPropagationStopped()) {
+        break;
+      }
+      // Listeners and Instances are two parallel arrays that are always in sync.
+      executeDispatch(event, simulated, dispatchListeners[i], dispatchInstances[i]);
+    }
+  } else if (dispatchListeners) {
+    executeDispatch(event, simulated, dispatchListeners, dispatchInstances);
+  }
+  event._dispatchListeners = null;
+  event._dispatchInstances = null;
+}
+
+/**
+ * Standard/simple iteration through an event's collected dispatches, but stops
+ * at the first dispatch execution returning true, and returns that id.
+ *
+ * @return {?string} id of the first dispatch execution who's listener returns
+ * true, or null if no listener returned true.
+ */
+function executeDispatchesInOrderStopAtTrueImpl(event) {
+  var dispatchListeners = event._dispatchListeners;
+  var dispatchInstances = event._dispatchInstances;
+  if ("development" !== 'production') {
+    validateEventDispatches(event);
+  }
+  if (Array.isArray(dispatchListeners)) {
+    for (var i = 0; i < dispatchListeners.length; i++) {
+      if (event.isPropagationStopped()) {
+        break;
+      }
+      // Listeners and Instances are two parallel arrays that are always in sync.
+      if (dispatchListeners[i](event, dispatchInstances[i])) {
+        return dispatchInstances[i];
+      }
+    }
+  } else if (dispatchListeners) {
+    if (dispatchListeners(event, dispatchInstances)) {
+      return dispatchInstances;
+    }
+  }
+  return null;
+}
+
+/**
+ * @see executeDispatchesInOrderStopAtTrueImpl
+ */
+function executeDispatchesInOrderStopAtTrue(event) {
+  var ret = executeDispatchesInOrderStopAtTrueImpl(event);
+  event._dispatchInstances = null;
+  event._dispatchListeners = null;
+  return ret;
+}
+
+/**
+ * Execution of a "direct" dispatch - there must be at most one dispatch
+ * accumulated on the event or it is considered an error. It doesn't really make
+ * sense for an event with multiple dispatches (bubbled) to keep track of the
+ * return values at each dispatch execution, but it does tend to make sense when
+ * dealing with "direct" dispatches.
+ *
+ * @return {*} The return value of executing the single dispatch.
+ */
+function executeDirectDispatch(event) {
+  if ("development" !== 'production') {
+    validateEventDispatches(event);
+  }
+  var dispatchListener = event._dispatchListeners;
+  var dispatchInstance = event._dispatchInstances;
+  !!Array.isArray(dispatchListener) ? "development" !== 'production' ? invariant(false, 'executeDirectDispatch(...): Invalid `event`.') : _prodInvariant('103') : void 0;
+  event.currentTarget = dispatchListener ? EventPluginUtils.getNodeFromInstance(dispatchInstance) : null;
+  var res = dispatchListener ? dispatchListener(event) : null;
+  event.currentTarget = null;
+  event._dispatchListeners = null;
+  event._dispatchInstances = null;
+  return res;
+}
+
+/**
+ * @param {SyntheticEvent} event
+ * @return {boolean} True iff number of dispatches accumulated is greater than 0.
+ */
+function hasDispatches(event) {
+  return !!event._dispatchListeners;
+}
+
+/**
+ * General utilities that are useful in creating custom Event Plugins.
+ */
+var EventPluginUtils = {
+  isEndish: isEndish,
+  isMoveish: isMoveish,
+  isStartish: isStartish,
+
+  executeDirectDispatch: executeDirectDispatch,
+  executeDispatchesInOrder: executeDispatchesInOrder,
+  executeDispatchesInOrderStopAtTrue: executeDispatchesInOrderStopAtTrue,
+  hasDispatches: hasDispatches,
+
+  getInstanceFromNode: function (node) {
+    return ComponentTree.getInstanceFromNode(node);
+  },
+  getNodeFromInstance: function (node) {
+    return ComponentTree.getNodeFromInstance(node);
+  },
+  isAncestor: function (a, b) {
+    return TreeTraversal.isAncestor(a, b);
+  },
+  getLowestCommonAncestor: function (a, b) {
+    return TreeTraversal.getLowestCommonAncestor(a, b);
+  },
+  getParentInstance: function (inst) {
+    return TreeTraversal.getParentInstance(inst);
+  },
+  traverseTwoPhase: function (target, fn, arg) {
+    return TreeTraversal.traverseTwoPhase(target, fn, arg);
+  },
+  traverseEnterLeave: function (from, to, fn, argFrom, argTo) {
+    return TreeTraversal.traverseEnterLeave(from, to, fn, argFrom, argTo);
+  },
+
+  injection: injection
+};
+
+module.exports = EventPluginUtils;
+},{"126":126,"152":152,"159":159,"55":55}],20:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var EventPluginHub = _dereq_(17);
+var EventPluginUtils = _dereq_(19);
+
+var accumulateInto = _dereq_(102);
+var forEachAccumulated = _dereq_(110);
+var warning = _dereq_(159);
+
+var getListener = EventPluginHub.getListener;
+
+/**
+ * Some event types have a notion of different registration names for different
+ * "phases" of propagation. This finds listeners by a given phase.
+ */
+function listenerAtPhase(inst, event, propagationPhase) {
+  var registrationName = event.dispatchConfig.phasedRegistrationNames[propagationPhase];
+  return getListener(inst, registrationName);
+}
+
+/**
+ * Tags a `SyntheticEvent` with dispatched listeners. Creating this function
+ * here, allows us to not have to bind or create functions for each event.
+ * Mutating the event's members allows us to not have to create a wrapping
+ * "dispatch" object that pairs the event with the listener.
+ */
+function accumulateDirectionalDispatches(inst, phase, event) {
+  if ("development" !== 'production') {
+    "development" !== 'production' ? warning(inst, 'Dispatching inst must not be null') : void 0;
+  }
+  var listener = listenerAtPhase(inst, event, phase);
+  if (listener) {
+    event._dispatchListeners = accumulateInto(event._dispatchListeners, listener);
+    event._dispatchInstances = accumulateInto(event._dispatchInstances, inst);
+  }
+}
+
+/**
+ * Collect dispatches (must be entirely collected before dispatching - see unit
+ * tests). Lazily allocate the array to conserve memory.  We must loop through
+ * each event and perform the traversal for each one. We cannot perform a
+ * single traversal for the entire collection of events because each event may
+ * have a different target.
+ */
+function accumulateTwoPhaseDispatchesSingle(event) {
+  if (event && event.dispatchConfig.phasedRegistrationNames) {
+    EventPluginUtils.traverseTwoPhase(event._targetInst, accumulateDirectionalDispatches, event);
+  }
+}
+
+/**
+ * Same as `accumulateTwoPhaseDispatchesSingle`, but skips over the targetID.
+ */
+function accumulateTwoPhaseDispatchesSingleSkipTarget(event) {
+  if (event && event.dispatchConfig.phasedRegistrationNames) {
+    var targetInst = event._targetInst;
+    var parentInst = targetInst ? EventPluginUtils.getParentInstance(targetInst) : null;
+    EventPluginUtils.traverseTwoPhase(parentInst, accumulateDirectionalDispatches, event);
+  }
+}
+
+/**
+ * Accumulates without regard to direction, does not look for phased
+ * registration names. Same as `accumulateDirectDispatchesSingle` but without
+ * requiring that the `dispatchMarker` be the same as the dispatched ID.
+ */
+function accumulateDispatches(inst, ignoredDirection, event) {
+  if (event && event.dispatchConfig.registrationName) {
+    var registrationName = event.dispatchConfig.registrationName;
+    var listener = getListener(inst, registrationName);
+    if (listener) {
+      event._dispatchListeners = accumulateInto(event._dispatchListeners, listener);
+      event._dispatchInstances = accumulateInto(event._dispatchInstances, inst);
+    }
+  }
+}
+
+/**
+ * Accumulates dispatches on an `SyntheticEvent`, but only for the
+ * `dispatchMarker`.
+ * @param {SyntheticEvent} event
+ */
+function accumulateDirectDispatchesSingle(event) {
+  if (event && event.dispatchConfig.registrationName) {
+    accumulateDispatches(event._targetInst, null, event);
+  }
+}
+
+function accumulateTwoPhaseDispatches(events) {
+  forEachAccumulated(events, accumulateTwoPhaseDispatchesSingle);
+}
+
+function accumulateTwoPhaseDispatchesSkipTarget(events) {
+  forEachAccumulated(events, accumulateTwoPhaseDispatchesSingleSkipTarget);
+}
+
+function accumulateEnterLeaveDispatches(leave, enter, from, to) {
+  EventPluginUtils.traverseEnterLeave(from, to, accumulateDispatches, leave, enter);
+}
+
+function accumulateDirectDispatches(events) {
+  forEachAccumulated(events, accumulateDirectDispatchesSingle);
+}
+
+/**
+ * A small set of propagation patterns, each of which will accept a small amount
+ * of information, and generate a set of "dispatch ready event objects" - which
+ * are sets of events that have already been annotated with a set of dispatched
+ * listener functions/ids. The API is designed this way to discourage these
+ * propagation strategies from actually executing the dispatches, since we
+ * always want to collect the entire set of dispatches before executing event a
+ * single one.
+ *
+ * @constructor EventPropagators
+ */
+var EventPropagators = {
+  accumulateTwoPhaseDispatches: accumulateTwoPhaseDispatches,
+  accumulateTwoPhaseDispatchesSkipTarget: accumulateTwoPhaseDispatchesSkipTarget,
+  accumulateDirectDispatches: accumulateDirectDispatches,
+  accumulateEnterLeaveDispatches: accumulateEnterLeaveDispatches
+};
+
+module.exports = EventPropagators;
+},{"102":102,"110":110,"159":159,"17":17,"19":19}],21:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var PooledClass = _dereq_(25);
+
+var getTextContentAccessor = _dereq_(118);
+
+/**
+ * This helper class stores information about text content of a target node,
+ * allowing comparison of content before and after a given event.
+ *
+ * Identify the node where selection currently begins, then observe
+ * both its text content and its current position in the DOM. Since the
+ * browser may natively replace the target node during composition, we can
+ * use its position to find its replacement.
+ *
+ * @param {DOMEventTarget} root
+ */
+function FallbackCompositionState(root) {
+  this._root = root;
+  this._startText = this.getText();
+  this._fallbackText = null;
+}
+
+_assign(FallbackCompositionState.prototype, {
+  destructor: function () {
+    this._root = null;
+    this._startText = null;
+    this._fallbackText = null;
+  },
+
+  /**
+   * Get current text of input.
+   *
+   * @return {string}
+   */
+  getText: function () {
+    if ('value' in this._root) {
+      return this._root.value;
+    }
+    return this._root[getTextContentAccessor()];
+  },
+
+  /**
+   * Determine the differing substring between the initially stored
+   * text content and the current content.
+   *
+   * @return {string}
+   */
+  getData: function () {
+    if (this._fallbackText) {
+      return this._fallbackText;
+    }
+
+    var start;
+    var startValue = this._startText;
+    var startLength = startValue.length;
+    var end;
+    var endValue = this.getText();
+    var endLength = endValue.length;
+
+    for (start = 0; start < startLength; start++) {
+      if (startValue[start] !== endValue[start]) {
+        break;
+      }
+    }
+
+    var minEnd = startLength - start;
+    for (end = 1; end <= minEnd; end++) {
+      if (startValue[startLength - end] !== endValue[endLength - end]) {
+        break;
+      }
+    }
+
+    var sliceTail = end > 1 ? 1 - end : undefined;
+    this._fallbackText = endValue.slice(start, sliceTail);
+    return this._fallbackText;
+  }
+});
+
+PooledClass.addPoolingTo(FallbackCompositionState);
+
+module.exports = FallbackCompositionState;
+},{"118":118,"160":160,"25":25}],22:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var DOMProperty = _dereq_(11);
+
+var MUST_USE_PROPERTY = DOMProperty.injection.MUST_USE_PROPERTY;
+var HAS_BOOLEAN_VALUE = DOMProperty.injection.HAS_BOOLEAN_VALUE;
+var HAS_NUMERIC_VALUE = DOMProperty.injection.HAS_NUMERIC_VALUE;
+var HAS_POSITIVE_NUMERIC_VALUE = DOMProperty.injection.HAS_POSITIVE_NUMERIC_VALUE;
+var HAS_OVERLOADED_BOOLEAN_VALUE = DOMProperty.injection.HAS_OVERLOADED_BOOLEAN_VALUE;
+
+var HTMLDOMPropertyConfig = {
+  isCustomAttribute: RegExp.prototype.test.bind(new RegExp('^(data|aria)-[' + DOMProperty.ATTRIBUTE_NAME_CHAR + ']*$')),
+  Properties: {
+    /**
+     * Standard Properties
+     */
+    accept: 0,
+    acceptCharset: 0,
+    accessKey: 0,
+    action: 0,
+    allowFullScreen: HAS_BOOLEAN_VALUE,
+    allowTransparency: 0,
+    alt: 0,
+    // specifies target context for links with `preload` type
+    as: 0,
+    async: HAS_BOOLEAN_VALUE,
+    autoComplete: 0,
+    // autoFocus is polyfilled/normalized by AutoFocusUtils
+    // autoFocus: HAS_BOOLEAN_VALUE,
+    autoPlay: HAS_BOOLEAN_VALUE,
+    capture: HAS_BOOLEAN_VALUE,
+    cellPadding: 0,
+    cellSpacing: 0,
+    charSet: 0,
+    challenge: 0,
+    checked: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
+    cite: 0,
+    classID: 0,
+    className: 0,
+    cols: HAS_POSITIVE_NUMERIC_VALUE,
+    colSpan: 0,
+    content: 0,
+    contentEditable: 0,
+    contextMenu: 0,
+    controls: HAS_BOOLEAN_VALUE,
+    controlsList: 0,
+    coords: 0,
+    crossOrigin: 0,
+    data: 0, // For `<object />` acts as `src`.
+    dateTime: 0,
+    'default': HAS_BOOLEAN_VALUE,
+    defer: HAS_BOOLEAN_VALUE,
+    dir: 0,
+    disabled: HAS_BOOLEAN_VALUE,
+    download: HAS_OVERLOADED_BOOLEAN_VALUE,
+    draggable: 0,
+    encType: 0,
+    form: 0,
+    formAction: 0,
+    formEncType: 0,
+    formMethod: 0,
+    formNoValidate: HAS_BOOLEAN_VALUE,
+    formTarget: 0,
+    frameBorder: 0,
+    headers: 0,
+    height: 0,
+    hidden: HAS_BOOLEAN_VALUE,
+    high: 0,
+    href: 0,
+    hrefLang: 0,
+    htmlFor: 0,
+    httpEquiv: 0,
+    icon: 0,
+    id: 0,
+    inputMode: 0,
+    integrity: 0,
+    is: 0,
+    keyParams: 0,
+    keyType: 0,
+    kind: 0,
+    label: 0,
+    lang: 0,
+    list: 0,
+    loop: HAS_BOOLEAN_VALUE,
+    low: 0,
+    manifest: 0,
+    marginHeight: 0,
+    marginWidth: 0,
+    max: 0,
+    maxLength: 0,
+    media: 0,
+    mediaGroup: 0,
+    method: 0,
+    min: 0,
+    minLength: 0,
+    // Caution; `option.selected` is not updated if `select.multiple` is
+    // disabled with `removeAttribute`.
+    multiple: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
+    muted: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
+    name: 0,
+    nonce: 0,
+    noValidate: HAS_BOOLEAN_VALUE,
+    open: HAS_BOOLEAN_VALUE,
+    optimum: 0,
+    pattern: 0,
+    placeholder: 0,
+    playsInline: HAS_BOOLEAN_VALUE,
+    poster: 0,
+    preload: 0,
+    profile: 0,
+    radioGroup: 0,
+    readOnly: HAS_BOOLEAN_VALUE,
+    referrerPolicy: 0,
+    rel: 0,
+    required: HAS_BOOLEAN_VALUE,
+    reversed: HAS_BOOLEAN_VALUE,
+    role: 0,
+    rows: HAS_POSITIVE_NUMERIC_VALUE,
+    rowSpan: HAS_NUMERIC_VALUE,
+    sandbox: 0,
+    scope: 0,
+    scoped: HAS_BOOLEAN_VALUE,
+    scrolling: 0,
+    seamless: HAS_BOOLEAN_VALUE,
+    selected: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
+    shape: 0,
+    size: HAS_POSITIVE_NUMERIC_VALUE,
+    sizes: 0,
+    span: HAS_POSITIVE_NUMERIC_VALUE,
+    spellCheck: 0,
+    src: 0,
+    srcDoc: 0,
+    srcLang: 0,
+    srcSet: 0,
+    start: HAS_NUMERIC_VALUE,
+    step: 0,
+    style: 0,
+    summary: 0,
+    tabIndex: 0,
+    target: 0,
+    title: 0,
+    // Setting .type throws on non-<input> tags
+    type: 0,
+    useMap: 0,
+    value: 0,
+    width: 0,
+    wmode: 0,
+    wrap: 0,
+
+    /**
+     * RDFa Properties
+     */
+    about: 0,
+    datatype: 0,
+    inlist: 0,
+    prefix: 0,
+    // property is also supported for OpenGraph in meta tags.
+    property: 0,
+    resource: 0,
+    'typeof': 0,
+    vocab: 0,
+
+    /**
+     * Non-standard Properties
+     */
+    // autoCapitalize and autoCorrect are supported in Mobile Safari for
+    // keyboard hints.
+    autoCapitalize: 0,
+    autoCorrect: 0,
+    // autoSave allows WebKit/Blink to persist values of input fields on page reloads
+    autoSave: 0,
+    // color is for Safari mask-icon link
+    color: 0,
+    // itemProp, itemScope, itemType are for
+    // Microdata support. See http://schema.org/docs/gs.html
+    itemProp: 0,
+    itemScope: HAS_BOOLEAN_VALUE,
+    itemType: 0,
+    // itemID and itemRef are for Microdata support as well but
+    // only specified in the WHATWG spec document. See
+    // https://html.spec.whatwg.org/multipage/microdata.html#microdata-dom-api
+    itemID: 0,
+    itemRef: 0,
+    // results show looking glass icon and recent searches on input
+    // search fields in WebKit/Blink
+    results: 0,
+    // IE-only attribute that specifies security restrictions on an iframe
+    // as an alternative to the sandbox attribute on IE<10
+    security: 0,
+    // IE-only attribute that controls focus behavior
+    unselectable: 0
+  },
+  DOMAttributeNames: {
+    acceptCharset: 'accept-charset',
+    className: 'class',
+    htmlFor: 'for',
+    httpEquiv: 'http-equiv'
+  },
+  DOMPropertyNames: {},
+  DOMMutationMethods: {
+    value: function (node, value) {
+      if (value == null) {
+        return node.removeAttribute('value');
+      }
+
+      // Number inputs get special treatment due to some edge cases in
+      // Chrome. Let everything else assign the value attribute as normal.
+      // https://github.com/facebook/react/issues/7253#issuecomment-236074326
+      if (node.type !== 'number' || node.hasAttribute('value') === false) {
+        node.setAttribute('value', '' + value);
+      } else if (node.validity && !node.validity.badInput && node.ownerDocument.activeElement !== node) {
+        // Don't assign an attribute if validation reports bad
+        // input. Chrome will clear the value. Additionally, don't
+        // operate on inputs that have focus, otherwise Chrome might
+        // strip off trailing decimal places and cause the user's
+        // cursor position to jump to the beginning of the input.
+        //
+        // In ReactDOMInput, we have an onBlur event that will trigger
+        // this function again when focus is lost.
+        node.setAttribute('value', '' + value);
+      }
+    }
+  }
+};
+
+module.exports = HTMLDOMPropertyConfig;
+},{"11":11}],23:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+/**
+ * Escape and wrap key so it is safe to use as a reactid
+ *
+ * @param {string} key to be escaped.
+ * @return {string} the escaped key.
+ */
+
+function escape(key) {
+  var escapeRegex = /[=:]/g;
+  var escaperLookup = {
+    '=': '=0',
+    ':': '=2'
+  };
+  var escapedString = ('' + key).replace(escapeRegex, function (match) {
+    return escaperLookup[match];
+  });
+
+  return '$' + escapedString;
+}
+
+/**
+ * Unescape and unwrap key for human-readable display
+ *
+ * @param {string} key to unescape.
+ * @return {string} the unescaped key.
+ */
+function unescape(key) {
+  var unescapeRegex = /(=0|=2)/g;
+  var unescaperLookup = {
+    '=0': '=',
+    '=2': ':'
+  };
+  var keySubstring = key[0] === '.' && key[1] === '$' ? key.substring(2) : key.substring(1);
+
+  return ('' + keySubstring).replace(unescapeRegex, function (match) {
+    return unescaperLookup[match];
+  });
+}
+
+var KeyEscapeUtils = {
+  escape: escape,
+  unescape: unescape
+};
+
+module.exports = KeyEscapeUtils;
+},{}],24:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var ReactPropTypesSecret = _dereq_(73);
+var propTypesFactory = _dereq_(162);
+
+var React = _dereq_(135);
+var PropTypes = propTypesFactory(React.isValidElement);
+
+var invariant = _dereq_(152);
+var warning = _dereq_(159);
+
+var hasReadOnlyValue = {
+  button: true,
+  checkbox: true,
+  image: true,
+  hidden: true,
+  radio: true,
+  reset: true,
+  submit: true
+};
+
+function _assertSingleLink(inputProps) {
+  !(inputProps.checkedLink == null || inputProps.valueLink == null) ? "development" !== 'production' ? invariant(false, 'Cannot provide a checkedLink and a valueLink. If you want to use checkedLink, you probably don\'t want to use valueLink and vice versa.') : _prodInvariant('87') : void 0;
+}
+function _assertValueLink(inputProps) {
+  _assertSingleLink(inputProps);
+  !(inputProps.value == null && inputProps.onChange == null) ? "development" !== 'production' ? invariant(false, 'Cannot provide a valueLink and a value or onChange event. If you want to use value or onChange, you probably don\'t want to use valueLink.') : _prodInvariant('88') : void 0;
+}
+
+function _assertCheckedLink(inputProps) {
+  _assertSingleLink(inputProps);
+  !(inputProps.checked == null && inputProps.onChange == null) ? "development" !== 'production' ? invariant(false, 'Cannot provide a checkedLink and a checked property or onChange event. If you want to use checked or onChange, you probably don\'t want to use checkedLink') : _prodInvariant('89') : void 0;
+}
+
+var propTypes = {
+  value: function (props, propName, componentName) {
+    if (!props[propName] || hasReadOnlyValue[props.type] || props.onChange || props.readOnly || props.disabled) {
+      return null;
+    }
+    return new Error('You provided a `value` prop to a form field without an ' + '`onChange` handler. This will render a read-only field. If ' + 'the field should be mutable use `defaultValue`. Otherwise, ' + 'set either `onChange` or `readOnly`.');
+  },
+  checked: function (props, propName, componentName) {
+    if (!props[propName] || props.onChange || props.readOnly || props.disabled) {
+      return null;
+    }
+    return new Error('You provided a `checked` prop to a form field without an ' + '`onChange` handler. This will render a read-only field. If ' + 'the field should be mutable use `defaultChecked`. Otherwise, ' + 'set either `onChange` or `readOnly`.');
+  },
+  onChange: PropTypes.func
+};
+
+var loggedTypeFailures = {};
+function getDeclarationErrorAddendum(owner) {
+  if (owner) {
+    var name = owner.getName();
+    if (name) {
+      return ' Check the render method of `' + name + '`.';
+    }
+  }
+  return '';
+}
+
+/**
+ * Provide a linked `value` attribute for controlled forms. You should not use
+ * this outside of the ReactDOM controlled form components.
+ */
+var LinkedValueUtils = {
+  checkPropTypes: function (tagName, props, owner) {
+    for (var propName in propTypes) {
+      if (propTypes.hasOwnProperty(propName)) {
+        var error = propTypes[propName](props, propName, tagName, 'prop', null, ReactPropTypesSecret);
+      }
+      if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+        // Only monitor this failure once because there tends to be a lot of the
+        // same error.
+        loggedTypeFailures[error.message] = true;
+
+        var addendum = getDeclarationErrorAddendum(owner);
+        "development" !== 'production' ? warning(false, 'Failed form propType: %s%s', error.message, addendum) : void 0;
+      }
+    }
+  },
+
+  /**
+   * @param {object} inputProps Props for form component
+   * @return {*} current value of the input either from value prop or link.
+   */
+  getValue: function (inputProps) {
+    if (inputProps.valueLink) {
+      _assertValueLink(inputProps);
+      return inputProps.valueLink.value;
+    }
+    return inputProps.value;
+  },
+
+  /**
+   * @param {object} inputProps Props for form component
+   * @return {*} current checked status of the input either from checked prop
+   *             or link.
+   */
+  getChecked: function (inputProps) {
+    if (inputProps.checkedLink) {
+      _assertCheckedLink(inputProps);
+      return inputProps.checkedLink.value;
+    }
+    return inputProps.checked;
+  },
+
+  /**
+   * @param {object} inputProps Props for form component
+   * @param {SyntheticEvent} event change event to handle
+   */
+  executeOnChange: function (inputProps, event) {
+    if (inputProps.valueLink) {
+      _assertValueLink(inputProps);
+      return inputProps.valueLink.requestChange(event.target.value);
+    } else if (inputProps.checkedLink) {
+      _assertCheckedLink(inputProps);
+      return inputProps.checkedLink.requestChange(event.target.checked);
+    } else if (inputProps.onChange) {
+      return inputProps.onChange.call(undefined, event);
+    }
+  }
+};
+
+module.exports = LinkedValueUtils;
+},{"126":126,"135":135,"152":152,"159":159,"162":162,"73":73}],25:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var invariant = _dereq_(152);
+
+/**
+ * Static poolers. Several custom versions for each potential number of
+ * arguments. A completely generic pooler is easy to implement, but would
+ * require accessing the `arguments` object. In each of these, `this` refers to
+ * the Class itself, not an instance. If any others are needed, simply add them
+ * here, or in their own files.
+ */
+var oneArgumentPooler = function (copyFieldsFrom) {
+  var Klass = this;
+  if (Klass.instancePool.length) {
+    var instance = Klass.instancePool.pop();
+    Klass.call(instance, copyFieldsFrom);
+    return instance;
+  } else {
+    return new Klass(copyFieldsFrom);
+  }
+};
+
+var twoArgumentPooler = function (a1, a2) {
+  var Klass = this;
+  if (Klass.instancePool.length) {
+    var instance = Klass.instancePool.pop();
+    Klass.call(instance, a1, a2);
+    return instance;
+  } else {
+    return new Klass(a1, a2);
+  }
+};
+
+var threeArgumentPooler = function (a1, a2, a3) {
+  var Klass = this;
+  if (Klass.instancePool.length) {
+    var instance = Klass.instancePool.pop();
+    Klass.call(instance, a1, a2, a3);
+    return instance;
+  } else {
+    return new Klass(a1, a2, a3);
+  }
+};
+
+var fourArgumentPooler = function (a1, a2, a3, a4) {
+  var Klass = this;
+  if (Klass.instancePool.length) {
+    var instance = Klass.instancePool.pop();
+    Klass.call(instance, a1, a2, a3, a4);
+    return instance;
+  } else {
+    return new Klass(a1, a2, a3, a4);
+  }
+};
+
+var standardReleaser = function (instance) {
+  var Klass = this;
+  !(instance instanceof Klass) ? "development" !== 'production' ? invariant(false, 'Trying to release an instance into a pool of a different type.') : _prodInvariant('25') : void 0;
+  instance.destructor();
+  if (Klass.instancePool.length < Klass.poolSize) {
+    Klass.instancePool.push(instance);
+  }
+};
+
+var DEFAULT_POOL_SIZE = 10;
+var DEFAULT_POOLER = oneArgumentPooler;
+
+/**
+ * Augments `CopyConstructor` to be a poolable class, augmenting only the class
+ * itself (statically) not adding any prototypical fields. Any CopyConstructor
+ * you give this may have a `poolSize` property, and will look for a
+ * prototypical `destructor` on instances.
+ *
+ * @param {Function} CopyConstructor Constructor that can be used to reset.
+ * @param {Function} pooler Customizable pooler.
+ */
+var addPoolingTo = function (CopyConstructor, pooler) {
+  // Casting as any so that flow ignores the actual implementation and trusts
+  // it to match the type we declared
+  var NewKlass = CopyConstructor;
+  NewKlass.instancePool = [];
+  NewKlass.getPooled = pooler || DEFAULT_POOLER;
+  if (!NewKlass.poolSize) {
+    NewKlass.poolSize = DEFAULT_POOL_SIZE;
+  }
+  NewKlass.release = standardReleaser;
+  return NewKlass;
+};
+
+var PooledClass = {
+  addPoolingTo: addPoolingTo,
+  oneArgumentPooler: oneArgumentPooler,
+  twoArgumentPooler: twoArgumentPooler,
+  threeArgumentPooler: threeArgumentPooler,
+  fourArgumentPooler: fourArgumentPooler
+};
+
+module.exports = PooledClass;
+},{"126":126,"152":152}],26:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var EventPluginRegistry = _dereq_(18);
+var ReactEventEmitterMixin = _dereq_(56);
+var ViewportMetrics = _dereq_(101);
+
+var getVendorPrefixedEventName = _dereq_(119);
+var isEventSupported = _dereq_(122);
+
+/**
+ * Summary of `ReactBrowserEventEmitter` event handling:
+ *
+ *  - Top-level delegation is used to trap most native browser events. This
+ *    may only occur in the main thread and is the responsibility of
+ *    ReactEventListener, which is injected and can therefore support pluggable
+ *    event sources. This is the only work that occurs in the main thread.
+ *
+ *  - We normalize and de-duplicate events to account for browser quirks. This
+ *    may be done in the worker thread.
+ *
+ *  - Forward these native events (with the associated top-level type used to
+ *    trap it) to `EventPluginHub`, which in turn will ask plugins if they want
+ *    to extract any synthetic events.
+ *
+ *  - The `EventPluginHub` will then process each event by annotating them with
+ *    "dispatches", a sequence of listeners and IDs that care about that event.
+ *
+ *  - The `EventPluginHub` then dispatches the events.
+ *
+ * Overview of React and the event system:
+ *
+ * +------------+    .
+ * |    DOM     |    .
+ * +------------+    .
+ *       |           .
+ *       v           .
+ * +------------+    .
+ * | ReactEvent |    .
+ * |  Listener  |    .
+ * +------------+    .                         +-----------+
+ *       |           .               +--------+|SimpleEvent|
+ *       |           .               |         |Plugin     |
+ * +-----|------+    .               v         +-----------+
+ * |     |      |    .    +--------------+                    +------------+
+ * |     +-----------.--->|EventPluginHub|                    |    Event   |
+ * |            |    .    |              |     +-----------+  | Propagators|
+ * | ReactEvent |    .    |              |     |TapEvent   |  |------------|
+ * |  Emitter   |    .    |              |<---+|Plugin     |  |other plugin|
+ * |            |    .    |              |     +-----------+  |  utilities |
+ * |     +-----------.--->|              |                    +------------+
+ * |     |      |    .    +--------------+
+ * +-----|------+    .                ^        +-----------+
+ *       |           .                |        |Enter/Leave|
+ *       +           .                +-------+|Plugin     |
+ * +-------------+   .                         +-----------+
+ * | application |   .
+ * |-------------|   .
+ * |             |   .
+ * |             |   .
+ * +-------------+   .
+ *                   .
+ *    React Core     .  General Purpose Event Plugin System
+ */
+
+var hasEventPageXY;
+var alreadyListeningTo = {};
+var isMonitoringScrollValue = false;
+var reactTopListenersCounter = 0;
+
+// For events like 'submit' which don't consistently bubble (which we trap at a
+// lower node than `document`), binding at `document` would cause duplicate
+// events so we don't include them here
+var topEventMapping = {
+  topAbort: 'abort',
+  topAnimationEnd: getVendorPrefixedEventName('animationend') || 'animationend',
+  topAnimationIteration: getVendorPrefixedEventName('animationiteration') || 'animationiteration',
+  topAnimationStart: getVendorPrefixedEventName('animationstart') || 'animationstart',
+  topBlur: 'blur',
+  topCanPlay: 'canplay',
+  topCanPlayThrough: 'canplaythrough',
+  topChange: 'change',
+  topClick: 'click',
+  topCompositionEnd: 'compositionend',
+  topCompositionStart: 'compositionstart',
+  topCompositionUpdate: 'compositionupdate',
+  topContextMenu: 'contextmenu',
+  topCopy: 'copy',
+  topCut: 'cut',
+  topDoubleClick: 'dblclick',
+  topDrag: 'drag',
+  topDragEnd: 'dragend',
+  topDragEnter: 'dragenter',
+  topDragExit: 'dragexit',
+  topDragLeave: 'dragleave',
+  topDragOver: 'dragover',
+  topDragStart: 'dragstart',
+  topDrop: 'drop',
+  topDurationChange: 'durationchange',
+  topEmptied: 'emptied',
+  topEncrypted: 'encrypted',
+  topEnded: 'ended',
+  topError: 'error',
+  topFocus: 'focus',
+  topInput: 'input',
+  topKeyDown: 'keydown',
+  topKeyPress: 'keypress',
+  topKeyUp: 'keyup',
+  topLoadedData: 'loadeddata',
+  topLoadedMetadata: 'loadedmetadata',
+  topLoadStart: 'loadstart',
+  topMouseDown: 'mousedown',
+  topMouseMove: 'mousemove',
+  topMouseOut: 'mouseout',
+  topMouseOver: 'mouseover',
+  topMouseUp: 'mouseup',
+  topPaste: 'paste',
+  topPause: 'pause',
+  topPlay: 'play',
+  topPlaying: 'playing',
+  topProgress: 'progress',
+  topRateChange: 'ratechange',
+  topScroll: 'scroll',
+  topSeeked: 'seeked',
+  topSeeking: 'seeking',
+  topSelectionChange: 'selectionchange',
+  topStalled: 'stalled',
+  topSuspend: 'suspend',
+  topTextInput: 'textInput',
+  topTimeUpdate: 'timeupdate',
+  topTouchCancel: 'touchcancel',
+  topTouchEnd: 'touchend',
+  topTouchMove: 'touchmove',
+  topTouchStart: 'touchstart',
+  topTransitionEnd: getVendorPrefixedEventName('transitionend') || 'transitionend',
+  topVolumeChange: 'volumechange',
+  topWaiting: 'waiting',
+  topWheel: 'wheel'
+};
+
+/**
+ * To ensure no conflicts with other potential React instances on the page
+ */
+var topListenersIDKey = '_reactListenersID' + String(Math.random()).slice(2);
+
+function getListeningForDocument(mountAt) {
+  // In IE8, `mountAt` is a host object and doesn't have `hasOwnProperty`
+  // directly.
+  if (!Object.prototype.hasOwnProperty.call(mountAt, topListenersIDKey)) {
+    mountAt[topListenersIDKey] = reactTopListenersCounter++;
+    alreadyListeningTo[mountAt[topListenersIDKey]] = {};
+  }
+  return alreadyListeningTo[mountAt[topListenersIDKey]];
+}
+
+/**
+ * `ReactBrowserEventEmitter` is used to attach top-level event listeners. For
+ * example:
+ *
+ *   EventPluginHub.putListener('myID', 'onClick', myFunction);
+ *
+ * This would allocate a "registration" of `('onClick', myFunction)` on 'myID'.
+ *
+ * @internal
+ */
+var ReactBrowserEventEmitter = _assign({}, ReactEventEmitterMixin, {
+  /**
+   * Injectable event backend
+   */
+  ReactEventListener: null,
+
+  injection: {
+    /**
+     * @param {object} ReactEventListener
+     */
+    injectReactEventListener: function (ReactEventListener) {
+      ReactEventListener.setHandleTopLevel(ReactBrowserEventEmitter.handleTopLevel);
+      ReactBrowserEventEmitter.ReactEventListener = ReactEventListener;
+    }
+  },
+
+  /**
+   * Sets whether or not any created callbacks should be enabled.
+   *
+   * @param {boolean} enabled True if callbacks should be enabled.
+   */
+  setEnabled: function (enabled) {
+    if (ReactBrowserEventEmitter.ReactEventListener) {
+      ReactBrowserEventEmitter.ReactEventListener.setEnabled(enabled);
+    }
+  },
+
+  /**
+   * @return {boolean} True if callbacks are enabled.
+   */
+  isEnabled: function () {
+    return !!(ReactBrowserEventEmitter.ReactEventListener && ReactBrowserEventEmitter.ReactEventListener.isEnabled());
+  },
+
+  /**
+   * We listen for bubbled touch events on the document object.
+   *
+   * Firefox v8.01 (and possibly others) exhibited strange behavior when
+   * mounting `onmousemove` events at some node that was not the document
+   * element. The symptoms were that if your mouse is not moving over something
+   * contained within that mount point (for example on the background) the
+   * top-level listeners for `onmousemove` won't be called. However, if you
+   * register the `mousemove` on the document object, then it will of course
+   * catch all `mousemove`s. This along with iOS quirks, justifies restricting
+   * top-level listeners to the document object only, at least for these
+   * movement types of events and possibly all events.
+   *
+   * @see http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
+   *
+   * Also, `keyup`/`keypress`/`keydown` do not bubble to the window on IE, but
+   * they bubble to document.
+   *
+   * @param {string} registrationName Name of listener (e.g. `onClick`).
+   * @param {object} contentDocumentHandle Document which owns the container
+   */
+  listenTo: function (registrationName, contentDocumentHandle) {
+    var mountAt = contentDocumentHandle;
+    var isListening = getListeningForDocument(mountAt);
+    var dependencies = EventPluginRegistry.registrationNameDependencies[registrationName];
+
+    for (var i = 0; i < dependencies.length; i++) {
+      var dependency = dependencies[i];
+      if (!(isListening.hasOwnProperty(dependency) && isListening[dependency])) {
+        if (dependency === 'topWheel') {
+          if (isEventSupported('wheel')) {
+            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topWheel', 'wheel', mountAt);
+          } else if (isEventSupported('mousewheel')) {
+            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topWheel', 'mousewheel', mountAt);
+          } else {
+            // Firefox needs to capture a different mouse scroll event.
+            // @see http://www.quirksmode.org/dom/events/tests/scroll.html
+            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topWheel', 'DOMMouseScroll', mountAt);
+          }
+        } else if (dependency === 'topScroll') {
+          if (isEventSupported('scroll', true)) {
+            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent('topScroll', 'scroll', mountAt);
+          } else {
+            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topScroll', 'scroll', ReactBrowserEventEmitter.ReactEventListener.WINDOW_HANDLE);
+          }
+        } else if (dependency === 'topFocus' || dependency === 'topBlur') {
+          if (isEventSupported('focus', true)) {
+            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent('topFocus', 'focus', mountAt);
+            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent('topBlur', 'blur', mountAt);
+          } else if (isEventSupported('focusin')) {
+            // IE has `focusin` and `focusout` events which bubble.
+            // @see http://www.quirksmode.org/blog/archives/2008/04/delegating_the.html
+            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topFocus', 'focusin', mountAt);
+            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topBlur', 'focusout', mountAt);
+          }
+
+          // to make sure blur and focus event listeners are only attached once
+          isListening.topBlur = true;
+          isListening.topFocus = true;
+        } else if (topEventMapping.hasOwnProperty(dependency)) {
+          ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(dependency, topEventMapping[dependency], mountAt);
+        }
+
+        isListening[dependency] = true;
+      }
+    }
+  },
+
+  trapBubbledEvent: function (topLevelType, handlerBaseName, handle) {
+    return ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(topLevelType, handlerBaseName, handle);
+  },
+
+  trapCapturedEvent: function (topLevelType, handlerBaseName, handle) {
+    return ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(topLevelType, handlerBaseName, handle);
+  },
+
+  /**
+   * Protect against document.createEvent() returning null
+   * Some popup blocker extensions appear to do this:
+   * https://github.com/facebook/react/issues/6887
+   */
+  supportsEventPageXY: function () {
+    if (!document.createEvent) {
+      return false;
+    }
+    var ev = document.createEvent('MouseEvent');
+    return ev != null && 'pageX' in ev;
+  },
+
+  /**
+   * Listens to window scroll and resize events. We cache scroll values so that
+   * application code can access them without triggering reflows.
+   *
+   * ViewportMetrics is only used by SyntheticMouse/TouchEvent and only when
+   * pageX/pageY isn't supported (legacy browsers).
+   *
+   * NOTE: Scroll events do not bubble.
+   *
+   * @see http://www.quirksmode.org/dom/events/scroll.html
+   */
+  ensureScrollValueMonitoring: function () {
+    if (hasEventPageXY === undefined) {
+      hasEventPageXY = ReactBrowserEventEmitter.supportsEventPageXY();
+    }
+    if (!hasEventPageXY && !isMonitoringScrollValue) {
+      var refresh = ViewportMetrics.refreshScrollValues;
+      ReactBrowserEventEmitter.ReactEventListener.monitorScrollValue(refresh);
+      isMonitoringScrollValue = true;
+    }
+  }
+});
+
+module.exports = ReactBrowserEventEmitter;
+},{"101":101,"119":119,"122":122,"160":160,"18":18,"56":56}],27:[function(_dereq_,module,exports){
+(function (process){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ReactReconciler = _dereq_(75);
+
+var instantiateReactComponent = _dereq_(121);
+var KeyEscapeUtils = _dereq_(23);
+var shouldUpdateReactComponent = _dereq_(130);
+var traverseAllChildren = _dereq_(131);
+var warning = _dereq_(159);
+
+var ReactComponentTreeHook;
+
+if (typeof process !== 'undefined' && process.env && "development" === 'test') {
+  // Temporary hack.
+  // Inline requires don't work well with Jest:
+  // https://github.com/facebook/react/issues/7240
+  // Remove the inline requires when we don't need them anymore:
+  // https://github.com/facebook/react/pull/7178
+  ReactComponentTreeHook = _dereq_(133);
+}
+
+function instantiateChild(childInstances, child, name, selfDebugID) {
+  // We found a component instance.
+  var keyUnique = childInstances[name] === undefined;
+  if ("development" !== 'production') {
+    if (!ReactComponentTreeHook) {
+      ReactComponentTreeHook = _dereq_(133);
+    }
+    if (!keyUnique) {
+      "development" !== 'production' ? warning(false, 'flattenChildren(...): Encountered two children with the same key, ' + '`%s`. Child keys must be unique; when two children share a key, only ' + 'the first child will be used.%s', KeyEscapeUtils.unescape(name), ReactComponentTreeHook.getStackAddendumByID(selfDebugID)) : void 0;
+    }
+  }
+  if (child != null && keyUnique) {
+    childInstances[name] = instantiateReactComponent(child, true);
+  }
+}
+
+/**
+ * ReactChildReconciler provides helpers for initializing or updating a set of
+ * children. Its output is suitable for passing it onto ReactMultiChild which
+ * does diffed reordering and insertion.
+ */
+var ReactChildReconciler = {
+  /**
+   * Generates a "mount image" for each of the supplied children. In the case
+   * of `ReactDOMComponent`, a mount image is a string of markup.
+   *
+   * @param {?object} nestedChildNodes Nested child maps.
+   * @return {?object} A set of child instances.
+   * @internal
+   */
+  instantiateChildren: function (nestedChildNodes, transaction, context, selfDebugID) // 0 in production and for roots
+  {
+    if (nestedChildNodes == null) {
+      return null;
+    }
+    var childInstances = {};
+
+    if ("development" !== 'production') {
+      traverseAllChildren(nestedChildNodes, function (childInsts, child, name) {
+        return instantiateChild(childInsts, child, name, selfDebugID);
+      }, childInstances);
+    } else {
+      traverseAllChildren(nestedChildNodes, instantiateChild, childInstances);
+    }
+    return childInstances;
+  },
+
+  /**
+   * Updates the rendered children and returns a new set of children.
+   *
+   * @param {?object} prevChildren Previously initialized set of children.
+   * @param {?object} nextChildren Flat child element maps.
+   * @param {ReactReconcileTransaction} transaction
+   * @param {object} context
+   * @return {?object} A new set of child instances.
+   * @internal
+   */
+  updateChildren: function (prevChildren, nextChildren, mountImages, removedNodes, transaction, hostParent, hostContainerInfo, context, selfDebugID) // 0 in production and for roots
+  {
+    // We currently don't have a way to track moves here but if we use iterators
+    // instead of for..in we can zip the iterators and check if an item has
+    // moved.
+    // TODO: If nothing has changed, return the prevChildren object so that we
+    // can quickly bailout if nothing has changed.
+    if (!nextChildren && !prevChildren) {
+      return;
+    }
+    var name;
+    var prevChild;
+    for (name in nextChildren) {
+      if (!nextChildren.hasOwnProperty(name)) {
+        continue;
+      }
+      prevChild = prevChildren && prevChildren[name];
+      var prevElement = prevChild && prevChild._currentElement;
+      var nextElement = nextChildren[name];
+      if (prevChild != null && shouldUpdateReactComponent(prevElement, nextElement)) {
+        ReactReconciler.receiveComponent(prevChild, nextElement, transaction, context);
+        nextChildren[name] = prevChild;
+      } else {
+        if (prevChild) {
+          removedNodes[name] = ReactReconciler.getHostNode(prevChild);
+          ReactReconciler.unmountComponent(prevChild, false);
+        }
+        // The child must be instantiated before it's mounted.
+        var nextChildInstance = instantiateReactComponent(nextElement, true);
+        nextChildren[name] = nextChildInstance;
+        // Creating mount image now ensures refs are resolved in right order
+        // (see https://github.com/facebook/react/pull/7101 for explanation).
+        var nextChildMountImage = ReactReconciler.mountComponent(nextChildInstance, transaction, hostParent, hostContainerInfo, context, selfDebugID);
+        mountImages.push(nextChildMountImage);
+      }
+    }
+    // Unmount children that are no longer present.
+    for (name in prevChildren) {
+      if (prevChildren.hasOwnProperty(name) && !(nextChildren && nextChildren.hasOwnProperty(name))) {
+        prevChild = prevChildren[name];
+        removedNodes[name] = ReactReconciler.getHostNode(prevChild);
+        ReactReconciler.unmountComponent(prevChild, false);
+      }
+    }
+  },
+
+  /**
+   * Unmounts all rendered children. This should be used to clean up children
+   * when this component is unmounted.
+   *
+   * @param {?object} renderedChildren Previously initialized set of children.
+   * @internal
+   */
+  unmountChildren: function (renderedChildren, safely) {
+    for (var name in renderedChildren) {
+      if (renderedChildren.hasOwnProperty(name)) {
+        var renderedChild = renderedChildren[name];
+        ReactReconciler.unmountComponent(renderedChild, safely);
+      }
+    }
+  }
+};
+
+module.exports = ReactChildReconciler;
+}).call(this,undefined)
+},{"121":121,"130":130,"131":131,"133":133,"159":159,"23":23,"75":75}],28:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var DOMChildrenOperations = _dereq_(8);
+var ReactDOMIDOperations = _dereq_(38);
+
+/**
+ * Abstracts away all functionality of the reconciler that requires knowledge of
+ * the browser context. TODO: These callers should be refactored to avoid the
+ * need for this injection.
+ */
+var ReactComponentBrowserEnvironment = {
+  processChildrenUpdates: ReactDOMIDOperations.dangerouslyProcessChildrenUpdates,
+
+  replaceNodeWithMarkup: DOMChildrenOperations.dangerouslyReplaceNodeWithMarkup
+};
+
+module.exports = ReactComponentBrowserEnvironment;
+},{"38":38,"8":8}],29:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var invariant = _dereq_(152);
+
+var injected = false;
+
+var ReactComponentEnvironment = {
+  /**
+   * Optionally injectable hook for swapping out mount images in the middle of
+   * the tree.
+   */
+  replaceNodeWithMarkup: null,
+
+  /**
+   * Optionally injectable hook for processing a queue of child updates. Will
+   * later move into MultiChildComponents.
+   */
+  processChildrenUpdates: null,
+
+  injection: {
+    injectEnvironment: function (environment) {
+      !!injected ? "development" !== 'production' ? invariant(false, 'ReactCompositeComponent: injectEnvironment() can only be called once.') : _prodInvariant('104') : void 0;
+      ReactComponentEnvironment.replaceNodeWithMarkup = environment.replaceNodeWithMarkup;
+      ReactComponentEnvironment.processChildrenUpdates = environment.processChildrenUpdates;
+      injected = true;
+    }
+  }
+};
+
+module.exports = ReactComponentEnvironment;
+},{"126":126,"152":152}],30:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126),
+    _assign = _dereq_(160);
+
+var React = _dereq_(135);
+var ReactComponentEnvironment = _dereq_(29);
+var ReactCurrentOwner = _dereq_(134);
+var ReactErrorUtils = _dereq_(55);
+var ReactInstanceMap = _dereq_(63);
+var ReactInstrumentation = _dereq_(64);
+var ReactNodeTypes = _dereq_(69);
+var ReactReconciler = _dereq_(75);
+
+if ("development" !== 'production') {
+  var checkReactTypeSpec = _dereq_(104);
+}
+
+var emptyObject = _dereq_(145);
+var invariant = _dereq_(152);
+var shallowEqual = _dereq_(158);
+var shouldUpdateReactComponent = _dereq_(130);
+var warning = _dereq_(159);
+
+var CompositeTypes = {
+  ImpureClass: 0,
+  PureClass: 1,
+  StatelessFunctional: 2
+};
+
+function StatelessComponent(Component) {}
+StatelessComponent.prototype.render = function () {
+  var Component = ReactInstanceMap.get(this)._currentElement.type;
+  var element = Component(this.props, this.context, this.updater);
+  warnIfInvalidElement(Component, element);
+  return element;
+};
+
+function warnIfInvalidElement(Component, element) {
+  if ("development" !== 'production') {
+    "development" !== 'production' ? warning(element === null || element === false || React.isValidElement(element), '%s(...): A valid React element (or null) must be returned. You may have ' + 'returned undefined, an array or some other invalid object.', Component.displayName || Component.name || 'Component') : void 0;
+    "development" !== 'production' ? warning(!Component.childContextTypes, '%s(...): childContextTypes cannot be defined on a functional component.', Component.displayName || Component.name || 'Component') : void 0;
+  }
+}
+
+function shouldConstruct(Component) {
+  return !!(Component.prototype && Component.prototype.isReactComponent);
+}
+
+function isPureComponent(Component) {
+  return !!(Component.prototype && Component.prototype.isPureReactComponent);
+}
+
+// Separated into a function to contain deoptimizations caused by try/finally.
+function measureLifeCyclePerf(fn, debugID, timerType) {
+  if (debugID === 0) {
+    // Top-level wrappers (see ReactMount) and empty components (see
+    // ReactDOMEmptyComponent) are invisible to hooks and devtools.
+    // Both are implementation details that should go away in the future.
+    return fn();
+  }
+
+  ReactInstrumentation.debugTool.onBeginLifeCycleTimer(debugID, timerType);
+  try {
+    return fn();
+  } finally {
+    ReactInstrumentation.debugTool.onEndLifeCycleTimer(debugID, timerType);
+  }
+}
+
+/**
+ * ------------------ The Life-Cycle of a Composite Component ------------------
+ *
+ * - constructor: Initialization of state. The instance is now retained.
+ *   - componentWillMount
+ *   - render
+ *   - [children's constructors]
+ *     - [children's componentWillMount and render]
+ *     - [children's componentDidMount]
+ *     - componentDidMount
+ *
+ *       Update Phases:
+ *       - componentWillReceiveProps (only called if parent updated)
+ *       - shouldComponentUpdate
+ *         - componentWillUpdate
+ *           - render
+ *           - [children's constructors or receive props phases]
+ *         - componentDidUpdate
+ *
+ *     - componentWillUnmount
+ *     - [children's componentWillUnmount]
+ *   - [children destroyed]
+ * - (destroyed): The instance is now blank, released by React and ready for GC.
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+/**
+ * An incrementing ID assigned to each component when it is mounted. This is
+ * used to enforce the order in which `ReactUpdates` updates dirty components.
+ *
+ * @private
+ */
+var nextMountID = 1;
+
+/**
+ * @lends {ReactCompositeComponent.prototype}
+ */
+var ReactCompositeComponent = {
+  /**
+   * Base constructor for all composite component.
+   *
+   * @param {ReactElement} element
+   * @final
+   * @internal
+   */
+  construct: function (element) {
+    this._currentElement = element;
+    this._rootNodeID = 0;
+    this._compositeType = null;
+    this._instance = null;
+    this._hostParent = null;
+    this._hostContainerInfo = null;
+
+    // See ReactUpdateQueue
+    this._updateBatchNumber = null;
+    this._pendingElement = null;
+    this._pendingStateQueue = null;
+    this._pendingReplaceState = false;
+    this._pendingForceUpdate = false;
+
+    this._renderedNodeType = null;
+    this._renderedComponent = null;
+    this._context = null;
+    this._mountOrder = 0;
+    this._topLevelWrapper = null;
+
+    // See ReactUpdates and ReactUpdateQueue.
+    this._pendingCallbacks = null;
+
+    // ComponentWillUnmount shall only be called once
+    this._calledComponentWillUnmount = false;
+
+    if ("development" !== 'production') {
+      this._warnedAboutRefsInRender = false;
+    }
+  },
+
+  /**
+   * Initializes the component, renders markup, and registers event listeners.
+   *
+   * @param {ReactReconcileTransaction|ReactServerRenderingTransaction} transaction
+   * @param {?object} hostParent
+   * @param {?object} hostContainerInfo
+   * @param {?object} context
+   * @return {?string} Rendered markup to be inserted into the DOM.
+   * @final
+   * @internal
+   */
+  mountComponent: function (transaction, hostParent, hostContainerInfo, context) {
+    var _this = this;
+
+    this._context = context;
+    this._mountOrder = nextMountID++;
+    this._hostParent = hostParent;
+    this._hostContainerInfo = hostContainerInfo;
+
+    var publicProps = this._currentElement.props;
+    var publicContext = this._processContext(context);
+
+    var Component = this._currentElement.type;
+
+    var updateQueue = transaction.getUpdateQueue();
+
+    // Initialize the public class
+    var doConstruct = shouldConstruct(Component);
+    var inst = this._constructComponent(doConstruct, publicProps, publicContext, updateQueue);
+    var renderedElement;
+
+    // Support functional components
+    if (!doConstruct && (inst == null || inst.render == null)) {
+      renderedElement = inst;
+      warnIfInvalidElement(Component, renderedElement);
+      !(inst === null || inst === false || React.isValidElement(inst)) ? "development" !== 'production' ? invariant(false, '%s(...): A valid React element (or null) must be returned. You may have returned undefined, an array or some other invalid object.', Component.displayName || Component.name || 'Component') : _prodInvariant('105', Component.displayName || Component.name || 'Component') : void 0;
+      inst = new StatelessComponent(Component);
+      this._compositeType = CompositeTypes.StatelessFunctional;
+    } else {
+      if (isPureComponent(Component)) {
+        this._compositeType = CompositeTypes.PureClass;
+      } else {
+        this._compositeType = CompositeTypes.ImpureClass;
+      }
+    }
+
+    if ("development" !== 'production') {
+      // This will throw later in _renderValidatedComponent, but add an early
+      // warning now to help debugging
+      if (inst.render == null) {
+        "development" !== 'production' ? warning(false, '%s(...): No `render` method found on the returned component ' + 'instance: you may have forgotten to define `render`.', Component.displayName || Component.name || 'Component') : void 0;
+      }
+
+      var propsMutated = inst.props !== publicProps;
+      var componentName = Component.displayName || Component.name || 'Component';
+
+      "development" !== 'production' ? warning(inst.props === undefined || !propsMutated, '%s(...): When calling super() in `%s`, make sure to pass ' + "up the same props that your component's constructor was passed.", componentName, componentName) : void 0;
+    }
+
+    // These should be set up in the constructor, but as a convenience for
+    // simpler class abstractions, we set them up after the fact.
+    inst.props = publicProps;
+    inst.context = publicContext;
+    inst.refs = emptyObject;
+    inst.updater = updateQueue;
+
+    this._instance = inst;
+
+    // Store a reference from the instance back to the internal representation
+    ReactInstanceMap.set(inst, this);
+
+    if ("development" !== 'production') {
+      // Since plain JS classes are defined without any special initialization
+      // logic, we can not catch common errors early. Therefore, we have to
+      // catch them here, at initialization time, instead.
+      "development" !== 'production' ? warning(!inst.getInitialState || inst.getInitialState.isReactClassApproved || inst.state, 'getInitialState was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Did you mean to define a state property instead?', this.getName() || 'a component') : void 0;
+      "development" !== 'production' ? warning(!inst.getDefaultProps || inst.getDefaultProps.isReactClassApproved, 'getDefaultProps was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Use a static property to define defaultProps instead.', this.getName() || 'a component') : void 0;
+      "development" !== 'production' ? warning(!inst.propTypes, 'propTypes was defined as an instance property on %s. Use a static ' + 'property to define propTypes instead.', this.getName() || 'a component') : void 0;
+      "development" !== 'production' ? warning(!inst.contextTypes, 'contextTypes was defined as an instance property on %s. Use a ' + 'static property to define contextTypes instead.', this.getName() || 'a component') : void 0;
+      "development" !== 'production' ? warning(typeof inst.componentShouldUpdate !== 'function', '%s has a method called ' + 'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' + 'The name is phrased as a question because the function is ' + 'expected to return a value.', this.getName() || 'A component') : void 0;
+      "development" !== 'production' ? warning(typeof inst.componentDidUnmount !== 'function', '%s has a method called ' + 'componentDidUnmount(). But there is no such lifecycle method. ' + 'Did you mean componentWillUnmount()?', this.getName() || 'A component') : void 0;
+      "development" !== 'production' ? warning(typeof inst.componentWillRecieveProps !== 'function', '%s has a method called ' + 'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?', this.getName() || 'A component') : void 0;
+    }
+
+    var initialState = inst.state;
+    if (initialState === undefined) {
+      inst.state = initialState = null;
+    }
+    !(typeof initialState === 'object' && !Array.isArray(initialState)) ? "development" !== 'production' ? invariant(false, '%s.state: must be set to an object or null', this.getName() || 'ReactCompositeComponent') : _prodInvariant('106', this.getName() || 'ReactCompositeComponent') : void 0;
+
+    this._pendingStateQueue = null;
+    this._pendingReplaceState = false;
+    this._pendingForceUpdate = false;
+
+    var markup;
+    if (inst.unstable_handleError) {
+      markup = this.performInitialMountWithErrorHandling(renderedElement, hostParent, hostContainerInfo, transaction, context);
+    } else {
+      markup = this.performInitialMount(renderedElement, hostParent, hostContainerInfo, transaction, context);
+    }
+
+    if (inst.componentDidMount) {
+      if ("development" !== 'production') {
+        transaction.getReactMountReady().enqueue(function () {
+          measureLifeCyclePerf(function () {
+            return inst.componentDidMount();
+          }, _this._debugID, 'componentDidMount');
+        });
+      } else {
+        transaction.getReactMountReady().enqueue(inst.componentDidMount, inst);
+      }
+    }
+
+    return markup;
+  },
+
+  _constructComponent: function (doConstruct, publicProps, publicContext, updateQueue) {
+    if ("development" !== 'production' && !doConstruct) {
+      ReactCurrentOwner.current = this;
+      try {
+        return this._constructComponentWithoutOwner(doConstruct, publicProps, publicContext, updateQueue);
+      } finally {
+        ReactCurrentOwner.current = null;
+      }
+    } else {
+      return this._constructComponentWithoutOwner(doConstruct, publicProps, publicContext, updateQueue);
+    }
+  },
+
+  _constructComponentWithoutOwner: function (doConstruct, publicProps, publicContext, updateQueue) {
+    var Component = this._currentElement.type;
+
+    if (doConstruct) {
+      if ("development" !== 'production') {
+        return measureLifeCyclePerf(function () {
+          return new Component(publicProps, publicContext, updateQueue);
+        }, this._debugID, 'ctor');
+      } else {
+        return new Component(publicProps, publicContext, updateQueue);
+      }
+    }
+
+    // This can still be an instance in case of factory components
+    // but we'll count this as time spent rendering as the more common case.
+    if ("development" !== 'production') {
+      return measureLifeCyclePerf(function () {
+        return Component(publicProps, publicContext, updateQueue);
+      }, this._debugID, 'render');
+    } else {
+      return Component(publicProps, publicContext, updateQueue);
+    }
+  },
+
+  performInitialMountWithErrorHandling: function (renderedElement, hostParent, hostContainerInfo, transaction, context) {
+    var markup;
+    var checkpoint = transaction.checkpoint();
+    try {
+      markup = this.performInitialMount(renderedElement, hostParent, hostContainerInfo, transaction, context);
+    } catch (e) {
+      // Roll back to checkpoint, handle error (which may add items to the transaction), and take a new checkpoint
+      transaction.rollback(checkpoint);
+      this._instance.unstable_handleError(e);
+      if (this._pendingStateQueue) {
+        this._instance.state = this._processPendingState(this._instance.props, this._instance.context);
+      }
+      checkpoint = transaction.checkpoint();
+
+      this._renderedComponent.unmountComponent(true);
+      transaction.rollback(checkpoint);
+
+      // Try again - we've informed the component about the error, so they can render an error message this time.
+      // If this throws again, the error will bubble up (and can be caught by a higher error boundary).
+      markup = this.performInitialMount(renderedElement, hostParent, hostContainerInfo, transaction, context);
+    }
+    return markup;
+  },
+
+  performInitialMount: function (renderedElement, hostParent, hostContainerInfo, transaction, context) {
+    var inst = this._instance;
+
+    var debugID = 0;
+    if ("development" !== 'production') {
+      debugID = this._debugID;
+    }
+
+    if (inst.componentWillMount) {
+      if ("development" !== 'production') {
+        measureLifeCyclePerf(function () {
+          return inst.componentWillMount();
+        }, debugID, 'componentWillMount');
+      } else {
+        inst.componentWillMount();
+      }
+      // When mounting, calls to `setState` by `componentWillMount` will set
+      // `this._pendingStateQueue` without triggering a re-render.
+      if (this._pendingStateQueue) {
+        inst.state = this._processPendingState(inst.props, inst.context);
+      }
+    }
+
+    // If not a stateless component, we now render
+    if (renderedElement === undefined) {
+      renderedElement = this._renderValidatedComponent();
+    }
+
+    var nodeType = ReactNodeTypes.getType(renderedElement);
+    this._renderedNodeType = nodeType;
+    var child = this._instantiateReactComponent(renderedElement, nodeType !== ReactNodeTypes.EMPTY /* shouldHaveDebugID */
+    );
+    this._renderedComponent = child;
+
+    var markup = ReactReconciler.mountComponent(child, transaction, hostParent, hostContainerInfo, this._processChildContext(context), debugID);
+
+    if ("development" !== 'production') {
+      if (debugID !== 0) {
+        var childDebugIDs = child._debugID !== 0 ? [child._debugID] : [];
+        ReactInstrumentation.debugTool.onSetChildren(debugID, childDebugIDs);
+      }
+    }
+
+    return markup;
+  },
+
+  getHostNode: function () {
+    return ReactReconciler.getHostNode(this._renderedComponent);
+  },
+
+  /**
+   * Releases any resources allocated by `mountComponent`.
+   *
+   * @final
+   * @internal
+   */
+  unmountComponent: function (safely) {
+    if (!this._renderedComponent) {
+      return;
+    }
+
+    var inst = this._instance;
+
+    if (inst.componentWillUnmount && !inst._calledComponentWillUnmount) {
+      inst._calledComponentWillUnmount = true;
+
+      if (safely) {
+        var name = this.getName() + '.componentWillUnmount()';
+        ReactErrorUtils.invokeGuardedCallback(name, inst.componentWillUnmount.bind(inst));
+      } else {
+        if ("development" !== 'production') {
+          measureLifeCyclePerf(function () {
+            return inst.componentWillUnmount();
+          }, this._debugID, 'componentWillUnmount');
+        } else {
+          inst.componentWillUnmount();
+        }
+      }
+    }
+
+    if (this._renderedComponent) {
+      ReactReconciler.unmountComponent(this._renderedComponent, safely);
+      this._renderedNodeType = null;
+      this._renderedComponent = null;
+      this._instance = null;
+    }
+
+    // Reset pending fields
+    // Even if this component is scheduled for another update in ReactUpdates,
+    // it would still be ignored because these fields are reset.
+    this._pendingStateQueue = null;
+    this._pendingReplaceState = false;
+    this._pendingForceUpdate = false;
+    this._pendingCallbacks = null;
+    this._pendingElement = null;
+
+    // These fields do not really need to be reset since this object is no
+    // longer accessible.
+    this._context = null;
+    this._rootNodeID = 0;
+    this._topLevelWrapper = null;
+
+    // Delete the reference from the instance to this internal representation
+    // which allow the internals to be properly cleaned up even if the user
+    // leaks a reference to the public instance.
+    ReactInstanceMap.remove(inst);
+
+    // Some existing components rely on inst.props even after they've been
+    // destroyed (in event handlers).
+    // TODO: inst.props = null;
+    // TODO: inst.state = null;
+    // TODO: inst.context = null;
+  },
+
+  /**
+   * Filters the context object to only contain keys specified in
+   * `contextTypes`
+   *
+   * @param {object} context
+   * @return {?object}
+   * @private
+   */
+  _maskContext: function (context) {
+    var Component = this._currentElement.type;
+    var contextTypes = Component.contextTypes;
+    if (!contextTypes) {
+      return emptyObject;
+    }
+    var maskedContext = {};
+    for (var contextName in contextTypes) {
+      maskedContext[contextName] = context[contextName];
+    }
+    return maskedContext;
+  },
+
+  /**
+   * Filters the context object to only contain keys specified in
+   * `contextTypes`, and asserts that they are valid.
+   *
+   * @param {object} context
+   * @return {?object}
+   * @private
+   */
+  _processContext: function (context) {
+    var maskedContext = this._maskContext(context);
+    if ("development" !== 'production') {
+      var Component = this._currentElement.type;
+      if (Component.contextTypes) {
+        this._checkContextTypes(Component.contextTypes, maskedContext, 'context');
+      }
+    }
+    return maskedContext;
+  },
+
+  /**
+   * @param {object} currentContext
+   * @return {object}
+   * @private
+   */
+  _processChildContext: function (currentContext) {
+    var Component = this._currentElement.type;
+    var inst = this._instance;
+    var childContext;
+
+    if (inst.getChildContext) {
+      if ("development" !== 'production') {
+        ReactInstrumentation.debugTool.onBeginProcessingChildContext();
+        try {
+          childContext = inst.getChildContext();
+        } finally {
+          ReactInstrumentation.debugTool.onEndProcessingChildContext();
+        }
+      } else {
+        childContext = inst.getChildContext();
+      }
+    }
+
+    if (childContext) {
+      !(typeof Component.childContextTypes === 'object') ? "development" !== 'production' ? invariant(false, '%s.getChildContext(): childContextTypes must be defined in order to use getChildContext().', this.getName() || 'ReactCompositeComponent') : _prodInvariant('107', this.getName() || 'ReactCompositeComponent') : void 0;
+      if ("development" !== 'production') {
+        this._checkContextTypes(Component.childContextTypes, childContext, 'child context');
+      }
+      for (var name in childContext) {
+        !(name in Component.childContextTypes) ? "development" !== 'production' ? invariant(false, '%s.getChildContext(): key "%s" is not defined in childContextTypes.', this.getName() || 'ReactCompositeComponent', name) : _prodInvariant('108', this.getName() || 'ReactCompositeComponent', name) : void 0;
+      }
+      return _assign({}, currentContext, childContext);
+    }
+    return currentContext;
+  },
+
+  /**
+   * Assert that the context types are valid
+   *
+   * @param {object} typeSpecs Map of context field to a ReactPropType
+   * @param {object} values Runtime values that need to be type-checked
+   * @param {string} location e.g. "prop", "context", "child context"
+   * @private
+   */
+  _checkContextTypes: function (typeSpecs, values, location) {
+    if ("development" !== 'production') {
+      checkReactTypeSpec(typeSpecs, values, location, this.getName(), null, this._debugID);
+    }
+  },
+
+  receiveComponent: function (nextElement, transaction, nextContext) {
+    var prevElement = this._currentElement;
+    var prevContext = this._context;
+
+    this._pendingElement = null;
+
+    this.updateComponent(transaction, prevElement, nextElement, prevContext, nextContext);
+  },
+
+  /**
+   * If any of `_pendingElement`, `_pendingStateQueue`, or `_pendingForceUpdate`
+   * is set, update the component.
+   *
+   * @param {ReactReconcileTransaction} transaction
+   * @internal
+   */
+  performUpdateIfNecessary: function (transaction) {
+    if (this._pendingElement != null) {
+      ReactReconciler.receiveComponent(this, this._pendingElement, transaction, this._context);
+    } else if (this._pendingStateQueue !== null || this._pendingForceUpdate) {
+      this.updateComponent(transaction, this._currentElement, this._currentElement, this._context, this._context);
+    } else {
+      this._updateBatchNumber = null;
+    }
+  },
+
+  /**
+   * Perform an update to a mounted component. The componentWillReceiveProps and
+   * shouldComponentUpdate methods are called, then (assuming the update isn't
+   * skipped) the remaining update lifecycle methods are called and the DOM
+   * representation is updated.
+   *
+   * By default, this implements React's rendering and reconciliation algorithm.
+   * Sophisticated clients may wish to override this.
+   *
+   * @param {ReactReconcileTransaction} transaction
+   * @param {ReactElement} prevParentElement
+   * @param {ReactElement} nextParentElement
+   * @internal
+   * @overridable
+   */
+  updateComponent: function (transaction, prevParentElement, nextParentElement, prevUnmaskedContext, nextUnmaskedContext) {
+    var inst = this._instance;
+    !(inst != null) ? "development" !== 'production' ? invariant(false, 'Attempted to update component `%s` that has already been unmounted (or failed to mount).', this.getName() || 'ReactCompositeComponent') : _prodInvariant('136', this.getName() || 'ReactCompositeComponent') : void 0;
+
+    var willReceive = false;
+    var nextContext;
+
+    // Determine if the context has changed or not
+    if (this._context === nextUnmaskedContext) {
+      nextContext = inst.context;
+    } else {
+      nextContext = this._processContext(nextUnmaskedContext);
+      willReceive = true;
+    }
+
+    var prevProps = prevParentElement.props;
+    var nextProps = nextParentElement.props;
+
+    // Not a simple state update but a props update
+    if (prevParentElement !== nextParentElement) {
+      willReceive = true;
+    }
+
+    // An update here will schedule an update but immediately set
+    // _pendingStateQueue which will ensure that any state updates gets
+    // immediately reconciled instead of waiting for the next batch.
+    if (willReceive && inst.componentWillReceiveProps) {
+      if ("development" !== 'production') {
+        measureLifeCyclePerf(function () {
+          return inst.componentWillReceiveProps(nextProps, nextContext);
+        }, this._debugID, 'componentWillReceiveProps');
+      } else {
+        inst.componentWillReceiveProps(nextProps, nextContext);
+      }
+    }
+
+    var nextState = this._processPendingState(nextProps, nextContext);
+    var shouldUpdate = true;
+
+    if (!this._pendingForceUpdate) {
+      if (inst.shouldComponentUpdate) {
+        if ("development" !== 'production') {
+          shouldUpdate = measureLifeCyclePerf(function () {
+            return inst.shouldComponentUpdate(nextProps, nextState, nextContext);
+          }, this._debugID, 'shouldComponentUpdate');
+        } else {
+          shouldUpdate = inst.shouldComponentUpdate(nextProps, nextState, nextContext);
+        }
+      } else {
+        if (this._compositeType === CompositeTypes.PureClass) {
+          shouldUpdate = !shallowEqual(prevProps, nextProps) || !shallowEqual(inst.state, nextState);
+        }
+      }
+    }
+
+    if ("development" !== 'production') {
+      "development" !== 'production' ? warning(shouldUpdate !== undefined, '%s.shouldComponentUpdate(): Returned undefined instead of a ' + 'boolean value. Make sure to return true or false.', this.getName() || 'ReactCompositeComponent') : void 0;
+    }
+
+    this._updateBatchNumber = null;
+    if (shouldUpdate) {
+      this._pendingForceUpdate = false;
+      // Will set `this.props`, `this.state` and `this.context`.
+      this._performComponentUpdate(nextParentElement, nextProps, nextState, nextContext, transaction, nextUnmaskedContext);
+    } else {
+      // If it's determined that a component should not update, we still want
+      // to set props and state but we shortcut the rest of the update.
+      this._currentElement = nextParentElement;
+      this._context = nextUnmaskedContext;
+      inst.props = nextProps;
+      inst.state = nextState;
+      inst.context = nextContext;
+    }
+  },
+
+  _processPendingState: function (props, context) {
+    var inst = this._instance;
+    var queue = this._pendingStateQueue;
+    var replace = this._pendingReplaceState;
+    this._pendingReplaceState = false;
+    this._pendingStateQueue = null;
+
+    if (!queue) {
+      return inst.state;
+    }
+
+    if (replace && queue.length === 1) {
+      return queue[0];
+    }
+
+    var nextState = _assign({}, replace ? queue[0] : inst.state);
+    for (var i = replace ? 1 : 0; i < queue.length; i++) {
+      var partial = queue[i];
+      _assign(nextState, typeof partial === 'function' ? partial.call(inst, nextState, props, context) : partial);
+    }
+
+    return nextState;
+  },
+
+  /**
+   * Merges new props and state, notifies delegate methods of update and
+   * performs update.
+   *
+   * @param {ReactElement} nextElement Next element
+   * @param {object} nextProps Next public object to set as properties.
+   * @param {?object} nextState Next object to set as state.
+   * @param {?object} nextContext Next public object to set as context.
+   * @param {ReactReconcileTransaction} transaction
+   * @param {?object} unmaskedContext
+   * @private
+   */
+  _performComponentUpdate: function (nextElement, nextProps, nextState, nextContext, transaction, unmaskedContext) {
+    var _this2 = this;
+
+    var inst = this._instance;
+
+    var hasComponentDidUpdate = Boolean(inst.componentDidUpdate);
+    var prevProps;
+    var prevState;
+    var prevContext;
+    if (hasComponentDidUpdate) {
+      prevProps = inst.props;
+      prevState = inst.state;
+      prevContext = inst.context;
+    }
+
+    if (inst.componentWillUpdate) {
+      if ("development" !== 'production') {
+        measureLifeCyclePerf(function () {
+          return inst.componentWillUpdate(nextProps, nextState, nextContext);
+        }, this._debugID, 'componentWillUpdate');
+      } else {
+        inst.componentWillUpdate(nextProps, nextState, nextContext);
+      }
+    }
+
+    this._currentElement = nextElement;
+    this._context = unmaskedContext;
+    inst.props = nextProps;
+    inst.state = nextState;
+    inst.context = nextContext;
+
+    this._updateRenderedComponent(transaction, unmaskedContext);
+
+    if (hasComponentDidUpdate) {
+      if ("development" !== 'production') {
+        transaction.getReactMountReady().enqueue(function () {
+          measureLifeCyclePerf(inst.componentDidUpdate.bind(inst, prevProps, prevState, prevContext), _this2._debugID, 'componentDidUpdate');
+        });
+      } else {
+        transaction.getReactMountReady().enqueue(inst.componentDidUpdate.bind(inst, prevProps, prevState, prevContext), inst);
+      }
+    }
+  },
+
+  /**
+   * Call the component's `render` method and update the DOM accordingly.
+   *
+   * @param {ReactReconcileTransaction} transaction
+   * @internal
+   */
+  _updateRenderedComponent: function (transaction, context) {
+    var prevComponentInstance = this._renderedComponent;
+    var prevRenderedElement = prevComponentInstance._currentElement;
+    var nextRenderedElement = this._renderValidatedComponent();
+
+    var debugID = 0;
+    if ("development" !== 'production') {
+      debugID = this._debugID;
+    }
+
+    if (shouldUpdateReactComponent(prevRenderedElement, nextRenderedElement)) {
+      ReactReconciler.receiveComponent(prevComponentInstance, nextRenderedElement, transaction, this._processChildContext(context));
+    } else {
+      var oldHostNode = ReactReconciler.getHostNode(prevComponentInstance);
+      ReactReconciler.unmountComponent(prevComponentInstance, false);
+
+      var nodeType = ReactNodeTypes.getType(nextRenderedElement);
+      this._renderedNodeType = nodeType;
+      var child = this._instantiateReactComponent(nextRenderedElement, nodeType !== ReactNodeTypes.EMPTY /* shouldHaveDebugID */
+      );
+      this._renderedComponent = child;
+
+      var nextMarkup = ReactReconciler.mountComponent(child, transaction, this._hostParent, this._hostContainerInfo, this._processChildContext(context), debugID);
+
+      if ("development" !== 'production') {
+        if (debugID !== 0) {
+          var childDebugIDs = child._debugID !== 0 ? [child._debugID] : [];
+          ReactInstrumentation.debugTool.onSetChildren(debugID, childDebugIDs);
+        }
+      }
+
+      this._replaceNodeWithMarkup(oldHostNode, nextMarkup, prevComponentInstance);
+    }
+  },
+
+  /**
+   * Overridden in shallow rendering.
+   *
+   * @protected
+   */
+  _replaceNodeWithMarkup: function (oldHostNode, nextMarkup, prevInstance) {
+    ReactComponentEnvironment.replaceNodeWithMarkup(oldHostNode, nextMarkup, prevInstance);
+  },
+
+  /**
+   * @protected
+   */
+  _renderValidatedComponentWithoutOwnerOrContext: function () {
+    var inst = this._instance;
+    var renderedElement;
+
+    if ("development" !== 'production') {
+      renderedElement = measureLifeCyclePerf(function () {
+        return inst.render();
+      }, this._debugID, 'render');
+    } else {
+      renderedElement = inst.render();
+    }
+
+    if ("development" !== 'production') {
+      // We allow auto-mocks to proceed as if they're returning null.
+      if (renderedElement === undefined && inst.render._isMockFunction) {
+        // This is probably bad practice. Consider warning here and
+        // deprecating this convenience.
+        renderedElement = null;
+      }
+    }
+
+    return renderedElement;
+  },
+
+  /**
+   * @private
+   */
+  _renderValidatedComponent: function () {
+    var renderedElement;
+    if ("development" !== 'production' || this._compositeType !== CompositeTypes.StatelessFunctional) {
+      ReactCurrentOwner.current = this;
+      try {
+        renderedElement = this._renderValidatedComponentWithoutOwnerOrContext();
+      } finally {
+        ReactCurrentOwner.current = null;
+      }
+    } else {
+      renderedElement = this._renderValidatedComponentWithoutOwnerOrContext();
+    }
+    !(
+    // TODO: An `isValidNode` function would probably be more appropriate
+    renderedElement === null || renderedElement === false || React.isValidElement(renderedElement)) ? "development" !== 'production' ? invariant(false, '%s.render(): A valid React element (or null) must be returned. You may have returned undefined, an array or some other invalid object.', this.getName() || 'ReactCompositeComponent') : _prodInvariant('109', this.getName() || 'ReactCompositeComponent') : void 0;
+
+    return renderedElement;
+  },
+
+  /**
+   * Lazily allocates the refs object and stores `component` as `ref`.
+   *
+   * @param {string} ref Reference name.
+   * @param {component} component Component to store as `ref`.
+   * @final
+   * @private
+   */
+  attachRef: function (ref, component) {
+    var inst = this.getPublicInstance();
+    !(inst != null) ? "development" !== 'production' ? invariant(false, 'Stateless function components cannot have refs.') : _prodInvariant('110') : void 0;
+    var publicComponentInstance = component.getPublicInstance();
+    if ("development" !== 'production') {
+      var componentName = component && component.getName ? component.getName() : 'a component';
+      "development" !== 'production' ? warning(publicComponentInstance != null || component._compositeType !== CompositeTypes.StatelessFunctional, 'Stateless function components cannot be given refs ' + '(See ref "%s" in %s created by %s). ' + 'Attempts to access this ref will fail.', ref, componentName, this.getName()) : void 0;
+    }
+    var refs = inst.refs === emptyObject ? inst.refs = {} : inst.refs;
+    refs[ref] = publicComponentInstance;
+  },
+
+  /**
+   * Detaches a reference name.
+   *
+   * @param {string} ref Name to dereference.
+   * @final
+   * @private
+   */
+  detachRef: function (ref) {
+    var refs = this.getPublicInstance().refs;
+    delete refs[ref];
+  },
+
+  /**
+   * Get a text description of the component that can be used to identify it
+   * in error messages.
+   * @return {string} The name or null.
+   * @internal
+   */
+  getName: function () {
+    var type = this._currentElement.type;
+    var constructor = this._instance && this._instance.constructor;
+    return type.displayName || constructor && constructor.displayName || type.name || constructor && constructor.name || null;
+  },
+
+  /**
+   * Get the publicly accessible representation of this component - i.e. what
+   * is exposed by refs and returned by render. Can be null for stateless
+   * components.
+   *
+   * @return {ReactComponent} the public component instance.
+   * @internal
+   */
+  getPublicInstance: function () {
+    var inst = this._instance;
+    if (this._compositeType === CompositeTypes.StatelessFunctional) {
+      return null;
+    }
+    return inst;
+  },
+
+  // Stub
+  _instantiateReactComponent: null
+};
+
+module.exports = ReactCompositeComponent;
+},{"104":104,"126":126,"130":130,"134":134,"135":135,"145":145,"152":152,"158":158,"159":159,"160":160,"29":29,"55":55,"63":63,"64":64,"69":69,"75":75}],31:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/* globals __REACT_DEVTOOLS_GLOBAL_HOOK__*/
+
+'use strict';
+
+var ReactDOMComponentTree = _dereq_(34);
+var ReactDefaultInjection = _dereq_(52);
+var ReactMount = _dereq_(67);
+var ReactReconciler = _dereq_(75);
+var ReactUpdates = _dereq_(82);
+var ReactVersion = _dereq_(83);
+
+var findDOMNode = _dereq_(108);
+var getHostComponentFromComposite = _dereq_(115);
+var renderSubtreeIntoContainer = _dereq_(127);
+var warning = _dereq_(159);
+
+ReactDefaultInjection.inject();
+
+var ReactDOM = {
+  findDOMNode: findDOMNode,
+  render: ReactMount.render,
+  unmountComponentAtNode: ReactMount.unmountComponentAtNode,
+  version: ReactVersion,
+
+  /* eslint-disable camelcase */
+  unstable_batchedUpdates: ReactUpdates.batchedUpdates,
+  unstable_renderSubtreeIntoContainer: renderSubtreeIntoContainer
+  /* eslint-enable camelcase */
+};
+
+// Inject the runtime into a devtools global hook regardless of browser.
+// Allows for debugging when the hook is injected on the page.
+if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' && typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.inject === 'function') {
+  __REACT_DEVTOOLS_GLOBAL_HOOK__.inject({
+    ComponentTree: {
+      getClosestInstanceFromNode: ReactDOMComponentTree.getClosestInstanceFromNode,
+      getNodeFromInstance: function (inst) {
+        // inst is an internal instance (but could be a composite)
+        if (inst._renderedComponent) {
+          inst = getHostComponentFromComposite(inst);
+        }
+        if (inst) {
+          return ReactDOMComponentTree.getNodeFromInstance(inst);
+        } else {
+          return null;
+        }
+      }
+    },
+    Mount: ReactMount,
+    Reconciler: ReactReconciler
+  });
+}
+
+if ("development" !== 'production') {
+  var ExecutionEnvironment = _dereq_(138);
+  if (ExecutionEnvironment.canUseDOM && window.top === window.self) {
+    // First check if devtools is not installed
+    if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+      // If we're in Chrome or Firefox, provide a download link if not installed.
+      if (navigator.userAgent.indexOf('Chrome') > -1 && navigator.userAgent.indexOf('Edge') === -1 || navigator.userAgent.indexOf('Firefox') > -1) {
+        // Firefox does not have the issue with devtools loaded over file://
+        var showFileUrlMessage = window.location.protocol.indexOf('http') === -1 && navigator.userAgent.indexOf('Firefox') === -1;
+        console.debug('Download the React DevTools ' + (showFileUrlMessage ? 'and use an HTTP server (instead of a file: URL) ' : '') + 'for a better development experience: ' + 'https://fb.me/react-devtools');
+      }
+    }
+
+    var testFunc = function testFn() {};
+    "development" !== 'production' ? warning((testFunc.name || testFunc.toString()).indexOf('testFn') !== -1, "It looks like you're using a minified copy of the development build " + 'of React. When deploying React apps to production, make sure to use ' + 'the production build which skips development warnings and is faster. ' + 'See https://fb.me/react-minification for more details.') : void 0;
+
+    // If we're in IE8, check to see if we are in compatibility mode and provide
+    // information on preventing compatibility mode
+    var ieCompatibilityMode = document.documentMode && document.documentMode < 8;
+
+    "development" !== 'production' ? warning(!ieCompatibilityMode, 'Internet Explorer is running in compatibility mode; please add the ' + 'following tag to your HTML to prevent this from happening: ' + '<meta http-equiv="X-UA-Compatible" content="IE=edge" />') : void 0;
+
+    var expectedFeatures = [
+    // shims
+    Array.isArray, Array.prototype.every, Array.prototype.forEach, Array.prototype.indexOf, Array.prototype.map, Date.now, Function.prototype.bind, Object.keys, String.prototype.trim];
+
+    for (var i = 0; i < expectedFeatures.length; i++) {
+      if (!expectedFeatures[i]) {
+        "development" !== 'production' ? warning(false, 'One or more ES5 shims expected by React are not available: ' + 'https://fb.me/react-warning-polyfills') : void 0;
+        break;
+      }
+    }
+  }
+}
+
+if ("development" !== 'production') {
+  var ReactInstrumentation = _dereq_(64);
+  var ReactDOMUnknownPropertyHook = _dereq_(49);
+  var ReactDOMNullInputValuePropHook = _dereq_(41);
+  var ReactDOMInvalidARIAHook = _dereq_(40);
+
+  ReactInstrumentation.debugTool.addHook(ReactDOMUnknownPropertyHook);
+  ReactInstrumentation.debugTool.addHook(ReactDOMNullInputValuePropHook);
+  ReactInstrumentation.debugTool.addHook(ReactDOMInvalidARIAHook);
+}
+
+module.exports = ReactDOM;
+},{"108":108,"115":115,"127":127,"138":138,"159":159,"34":34,"40":40,"41":41,"49":49,"52":52,"64":64,"67":67,"75":75,"82":82,"83":83}],32:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/* global hasOwnProperty:true */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126),
+    _assign = _dereq_(160);
+
+var AutoFocusUtils = _dereq_(2);
+var CSSPropertyOperations = _dereq_(5);
+var DOMLazyTree = _dereq_(9);
+var DOMNamespaces = _dereq_(10);
+var DOMProperty = _dereq_(11);
+var DOMPropertyOperations = _dereq_(12);
+var EventPluginHub = _dereq_(17);
+var EventPluginRegistry = _dereq_(18);
+var ReactBrowserEventEmitter = _dereq_(26);
+var ReactDOMComponentFlags = _dereq_(33);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactDOMInput = _dereq_(39);
+var ReactDOMOption = _dereq_(42);
+var ReactDOMSelect = _dereq_(43);
+var ReactDOMTextarea = _dereq_(46);
+var ReactInstrumentation = _dereq_(64);
+var ReactMultiChild = _dereq_(68);
+var ReactServerRenderingTransaction = _dereq_(77);
+
+var emptyFunction = _dereq_(144);
+var escapeTextContentForBrowser = _dereq_(107);
+var invariant = _dereq_(152);
+var isEventSupported = _dereq_(122);
+var shallowEqual = _dereq_(158);
+var inputValueTracking = _dereq_(120);
+var validateDOMNesting = _dereq_(132);
+var warning = _dereq_(159);
+
+var Flags = ReactDOMComponentFlags;
+var deleteListener = EventPluginHub.deleteListener;
+var getNode = ReactDOMComponentTree.getNodeFromInstance;
+var listenTo = ReactBrowserEventEmitter.listenTo;
+var registrationNameModules = EventPluginRegistry.registrationNameModules;
+
+// For quickly matching children type, to test if can be treated as content.
+var CONTENT_TYPES = { string: true, number: true };
+
+var STYLE = 'style';
+var HTML = '__html';
+var RESERVED_PROPS = {
+  children: null,
+  dangerouslySetInnerHTML: null,
+  suppressContentEditableWarning: null
+};
+
+// Node type for document fragments (Node.DOCUMENT_FRAGMENT_NODE).
+var DOC_FRAGMENT_TYPE = 11;
+
+function getDeclarationErrorAddendum(internalInstance) {
+  if (internalInstance) {
+    var owner = internalInstance._currentElement._owner || null;
+    if (owner) {
+      var name = owner.getName();
+      if (name) {
+        return ' This DOM node was rendered by `' + name + '`.';
+      }
+    }
+  }
+  return '';
+}
+
+function friendlyStringify(obj) {
+  if (typeof obj === 'object') {
+    if (Array.isArray(obj)) {
+      return '[' + obj.map(friendlyStringify).join(', ') + ']';
+    } else {
+      var pairs = [];
+      for (var key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          var keyEscaped = /^[a-z$_][\w$_]*$/i.test(key) ? key : JSON.stringify(key);
+          pairs.push(keyEscaped + ': ' + friendlyStringify(obj[key]));
+        }
+      }
+      return '{' + pairs.join(', ') + '}';
+    }
+  } else if (typeof obj === 'string') {
+    return JSON.stringify(obj);
+  } else if (typeof obj === 'function') {
+    return '[function object]';
+  }
+  // Differs from JSON.stringify in that undefined because undefined and that
+  // inf and nan don't become null
+  return String(obj);
+}
+
+var styleMutationWarning = {};
+
+function checkAndWarnForMutatedStyle(style1, style2, component) {
+  if (style1 == null || style2 == null) {
+    return;
+  }
+  if (shallowEqual(style1, style2)) {
+    return;
+  }
+
+  var componentName = component._tag;
+  var owner = component._currentElement._owner;
+  var ownerName;
+  if (owner) {
+    ownerName = owner.getName();
+  }
+
+  var hash = ownerName + '|' + componentName;
+
+  if (styleMutationWarning.hasOwnProperty(hash)) {
+    return;
+  }
+
+  styleMutationWarning[hash] = true;
+
+  "development" !== 'production' ? warning(false, '`%s` was passed a style object that has previously been mutated. ' + 'Mutating `style` is deprecated. Consider cloning it beforehand. Check ' + 'the `render` %s. Previous style: %s. Mutated style: %s.', componentName, owner ? 'of `' + ownerName + '`' : 'using <' + componentName + '>', friendlyStringify(style1), friendlyStringify(style2)) : void 0;
+}
+
+/**
+ * @param {object} component
+ * @param {?object} props
+ */
+function assertValidProps(component, props) {
+  if (!props) {
+    return;
+  }
+  // Note the use of `==` which checks for null or undefined.
+  if (voidElementTags[component._tag]) {
+    !(props.children == null && props.dangerouslySetInnerHTML == null) ? "development" !== 'production' ? invariant(false, '%s is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.%s', component._tag, component._currentElement._owner ? ' Check the render method of ' + component._currentElement._owner.getName() + '.' : '') : _prodInvariant('137', component._tag, component._currentElement._owner ? ' Check the render method of ' + component._currentElement._owner.getName() + '.' : '') : void 0;
+  }
+  if (props.dangerouslySetInnerHTML != null) {
+    !(props.children == null) ? "development" !== 'production' ? invariant(false, 'Can only set one of `children` or `props.dangerouslySetInnerHTML`.') : _prodInvariant('60') : void 0;
+    !(typeof props.dangerouslySetInnerHTML === 'object' && HTML in props.dangerouslySetInnerHTML) ? "development" !== 'production' ? invariant(false, '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.') : _prodInvariant('61') : void 0;
+  }
+  if ("development" !== 'production') {
+    "development" !== 'production' ? warning(props.innerHTML == null, 'Directly setting property `innerHTML` is not permitted. ' + 'For more information, lookup documentation on `dangerouslySetInnerHTML`.') : void 0;
+    "development" !== 'production' ? warning(props.suppressContentEditableWarning || !props.contentEditable || props.children == null, 'A component is `contentEditable` and contains `children` managed by ' + 'React. It is now your responsibility to guarantee that none of ' + 'those nodes are unexpectedly modified or duplicated. This is ' + 'probably not intentional.') : void 0;
+    "development" !== 'production' ? warning(props.onFocusIn == null && props.onFocusOut == null, 'React uses onFocus and onBlur instead of onFocusIn and onFocusOut. ' + 'All React events are normalized to bubble, so onFocusIn and onFocusOut ' + 'are not needed/supported by React.') : void 0;
+  }
+  !(props.style == null || typeof props.style === 'object') ? "development" !== 'production' ? invariant(false, 'The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX.%s', getDeclarationErrorAddendum(component)) : _prodInvariant('62', getDeclarationErrorAddendum(component)) : void 0;
+}
+
+function enqueuePutListener(inst, registrationName, listener, transaction) {
+  if (transaction instanceof ReactServerRenderingTransaction) {
+    return;
+  }
+  if ("development" !== 'production') {
+    // IE8 has no API for event capturing and the `onScroll` event doesn't
+    // bubble.
+    "development" !== 'production' ? warning(registrationName !== 'onScroll' || isEventSupported('scroll', true), "This browser doesn't support the `onScroll` event") : void 0;
+  }
+  var containerInfo = inst._hostContainerInfo;
+  var isDocumentFragment = containerInfo._node && containerInfo._node.nodeType === DOC_FRAGMENT_TYPE;
+  var doc = isDocumentFragment ? containerInfo._node : containerInfo._ownerDocument;
+  listenTo(registrationName, doc);
+  transaction.getReactMountReady().enqueue(putListener, {
+    inst: inst,
+    registrationName: registrationName,
+    listener: listener
+  });
+}
+
+function putListener() {
+  var listenerToPut = this;
+  EventPluginHub.putListener(listenerToPut.inst, listenerToPut.registrationName, listenerToPut.listener);
+}
+
+function inputPostMount() {
+  var inst = this;
+  ReactDOMInput.postMountWrapper(inst);
+}
+
+function textareaPostMount() {
+  var inst = this;
+  ReactDOMTextarea.postMountWrapper(inst);
+}
+
+function optionPostMount() {
+  var inst = this;
+  ReactDOMOption.postMountWrapper(inst);
+}
+
+var setAndValidateContentChildDev = emptyFunction;
+if ("development" !== 'production') {
+  setAndValidateContentChildDev = function (content) {
+    var hasExistingContent = this._contentDebugID != null;
+    var debugID = this._debugID;
+    // This ID represents the inlined child that has no backing instance:
+    var contentDebugID = -debugID;
+
+    if (content == null) {
+      if (hasExistingContent) {
+        ReactInstrumentation.debugTool.onUnmountComponent(this._contentDebugID);
+      }
+      this._contentDebugID = null;
+      return;
+    }
+
+    validateDOMNesting(null, String(content), this, this._ancestorInfo);
+    this._contentDebugID = contentDebugID;
+    if (hasExistingContent) {
+      ReactInstrumentation.debugTool.onBeforeUpdateComponent(contentDebugID, content);
+      ReactInstrumentation.debugTool.onUpdateComponent(contentDebugID);
+    } else {
+      ReactInstrumentation.debugTool.onBeforeMountComponent(contentDebugID, content, debugID);
+      ReactInstrumentation.debugTool.onMountComponent(contentDebugID);
+      ReactInstrumentation.debugTool.onSetChildren(debugID, [contentDebugID]);
+    }
+  };
+}
+
+// There are so many media events, it makes sense to just
+// maintain a list rather than create a `trapBubbledEvent` for each
+var mediaEvents = {
+  topAbort: 'abort',
+  topCanPlay: 'canplay',
+  topCanPlayThrough: 'canplaythrough',
+  topDurationChange: 'durationchange',
+  topEmptied: 'emptied',
+  topEncrypted: 'encrypted',
+  topEnded: 'ended',
+  topError: 'error',
+  topLoadedData: 'loadeddata',
+  topLoadedMetadata: 'loadedmetadata',
+  topLoadStart: 'loadstart',
+  topPause: 'pause',
+  topPlay: 'play',
+  topPlaying: 'playing',
+  topProgress: 'progress',
+  topRateChange: 'ratechange',
+  topSeeked: 'seeked',
+  topSeeking: 'seeking',
+  topStalled: 'stalled',
+  topSuspend: 'suspend',
+  topTimeUpdate: 'timeupdate',
+  topVolumeChange: 'volumechange',
+  topWaiting: 'waiting'
+};
+
+function trackInputValue() {
+  inputValueTracking.track(this);
+}
+
+function trapBubbledEventsLocal() {
+  var inst = this;
+  // If a component renders to null or if another component fatals and causes
+  // the state of the tree to be corrupted, `node` here can be null.
+  !inst._rootNodeID ? "development" !== 'production' ? invariant(false, 'Must be mounted to trap events') : _prodInvariant('63') : void 0;
+  var node = getNode(inst);
+  !node ? "development" !== 'production' ? invariant(false, 'trapBubbledEvent(...): Requires node to be rendered.') : _prodInvariant('64') : void 0;
+
+  switch (inst._tag) {
+    case 'iframe':
+    case 'object':
+      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node)];
+      break;
+    case 'video':
+    case 'audio':
+      inst._wrapperState.listeners = [];
+      // Create listener for each media event
+      for (var event in mediaEvents) {
+        if (mediaEvents.hasOwnProperty(event)) {
+          inst._wrapperState.listeners.push(ReactBrowserEventEmitter.trapBubbledEvent(event, mediaEvents[event], node));
+        }
+      }
+      break;
+    case 'source':
+      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node)];
+      break;
+    case 'img':
+      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node), ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node)];
+      break;
+    case 'form':
+      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent('topReset', 'reset', node), ReactBrowserEventEmitter.trapBubbledEvent('topSubmit', 'submit', node)];
+      break;
+    case 'input':
+    case 'select':
+    case 'textarea':
+      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', node)];
+      break;
+  }
+}
+
+function postUpdateSelectWrapper() {
+  ReactDOMSelect.postUpdateWrapper(this);
+}
+
+// For HTML, certain tags should omit their close tag. We keep a whitelist for
+// those special-case tags.
+
+var omittedCloseTags = {
+  area: true,
+  base: true,
+  br: true,
+  col: true,
+  embed: true,
+  hr: true,
+  img: true,
+  input: true,
+  keygen: true,
+  link: true,
+  meta: true,
+  param: true,
+  source: true,
+  track: true,
+  wbr: true
+  // NOTE: menuitem's close tag should be omitted, but that causes problems.
+};
+
+var newlineEatingTags = {
+  listing: true,
+  pre: true,
+  textarea: true
+};
+
+// For HTML, certain tags cannot have children. This has the same purpose as
+// `omittedCloseTags` except that `menuitem` should still have its closing tag.
+
+var voidElementTags = _assign({
+  menuitem: true
+}, omittedCloseTags);
+
+// We accept any tag to be rendered but since this gets injected into arbitrary
+// HTML, we want to make sure that it's a safe tag.
+// http://www.w3.org/TR/REC-xml/#NT-Name
+
+var VALID_TAG_REGEX = /^[a-zA-Z][a-zA-Z:_\.\-\d]*$/; // Simplified subset
+var validatedTagCache = {};
+var hasOwnProperty = {}.hasOwnProperty;
+
+function validateDangerousTag(tag) {
+  if (!hasOwnProperty.call(validatedTagCache, tag)) {
+    !VALID_TAG_REGEX.test(tag) ? "development" !== 'production' ? invariant(false, 'Invalid tag: %s', tag) : _prodInvariant('65', tag) : void 0;
+    validatedTagCache[tag] = true;
+  }
+}
+
+function isCustomComponent(tagName, props) {
+  return tagName.indexOf('-') >= 0 || props.is != null;
+}
+
+var globalIdCounter = 1;
+
+/**
+ * Creates a new React class that is idempotent and capable of containing other
+ * React components. It accepts event listeners and DOM properties that are
+ * valid according to `DOMProperty`.
+ *
+ *  - Event listeners: `onClick`, `onMouseDown`, etc.
+ *  - DOM properties: `className`, `name`, `title`, etc.
+ *
+ * The `style` property functions differently from the DOM API. It accepts an
+ * object mapping of style properties to values.
+ *
+ * @constructor ReactDOMComponent
+ * @extends ReactMultiChild
+ */
+function ReactDOMComponent(element) {
+  var tag = element.type;
+  validateDangerousTag(tag);
+  this._currentElement = element;
+  this._tag = tag.toLowerCase();
+  this._namespaceURI = null;
+  this._renderedChildren = null;
+  this._previousStyle = null;
+  this._previousStyleCopy = null;
+  this._hostNode = null;
+  this._hostParent = null;
+  this._rootNodeID = 0;
+  this._domID = 0;
+  this._hostContainerInfo = null;
+  this._wrapperState = null;
+  this._topLevelWrapper = null;
+  this._flags = 0;
+  if ("development" !== 'production') {
+    this._ancestorInfo = null;
+    setAndValidateContentChildDev.call(this, null);
+  }
+}
+
+ReactDOMComponent.displayName = 'ReactDOMComponent';
+
+ReactDOMComponent.Mixin = {
+  /**
+   * Generates root tag markup then recurses. This method has side effects and
+   * is not idempotent.
+   *
+   * @internal
+   * @param {ReactReconcileTransaction|ReactServerRenderingTransaction} transaction
+   * @param {?ReactDOMComponent} the parent component instance
+   * @param {?object} info about the host container
+   * @param {object} context
+   * @return {string} The computed markup.
+   */
+  mountComponent: function (transaction, hostParent, hostContainerInfo, context) {
+    this._rootNodeID = globalIdCounter++;
+    this._domID = hostContainerInfo._idCounter++;
+    this._hostParent = hostParent;
+    this._hostContainerInfo = hostContainerInfo;
+
+    var props = this._currentElement.props;
+
+    switch (this._tag) {
+      case 'audio':
+      case 'form':
+      case 'iframe':
+      case 'img':
+      case 'link':
+      case 'object':
+      case 'source':
+      case 'video':
+        this._wrapperState = {
+          listeners: null
+        };
+        transaction.getReactMountReady().enqueue(trapBubbledEventsLocal, this);
+        break;
+      case 'input':
+        ReactDOMInput.mountWrapper(this, props, hostParent);
+        props = ReactDOMInput.getHostProps(this, props);
+        transaction.getReactMountReady().enqueue(trackInputValue, this);
+        transaction.getReactMountReady().enqueue(trapBubbledEventsLocal, this);
+        break;
+      case 'option':
+        ReactDOMOption.mountWrapper(this, props, hostParent);
+        props = ReactDOMOption.getHostProps(this, props);
+        break;
+      case 'select':
+        ReactDOMSelect.mountWrapper(this, props, hostParent);
+        props = ReactDOMSelect.getHostProps(this, props);
+        transaction.getReactMountReady().enqueue(trapBubbledEventsLocal, this);
+        break;
+      case 'textarea':
+        ReactDOMTextarea.mountWrapper(this, props, hostParent);
+        props = ReactDOMTextarea.getHostProps(this, props);
+        transaction.getReactMountReady().enqueue(trackInputValue, this);
+        transaction.getReactMountReady().enqueue(trapBubbledEventsLocal, this);
+        break;
+    }
+
+    assertValidProps(this, props);
+
+    // We create tags in the namespace of their parent container, except HTML
+    // tags get no namespace.
+    var namespaceURI;
+    var parentTag;
+    if (hostParent != null) {
+      namespaceURI = hostParent._namespaceURI;
+      parentTag = hostParent._tag;
+    } else if (hostContainerInfo._tag) {
+      namespaceURI = hostContainerInfo._namespaceURI;
+      parentTag = hostContainerInfo._tag;
+    }
+    if (namespaceURI == null || namespaceURI === DOMNamespaces.svg && parentTag === 'foreignobject') {
+      namespaceURI = DOMNamespaces.html;
+    }
+    if (namespaceURI === DOMNamespaces.html) {
+      if (this._tag === 'svg') {
+        namespaceURI = DOMNamespaces.svg;
+      } else if (this._tag === 'math') {
+        namespaceURI = DOMNamespaces.mathml;
+      }
+    }
+    this._namespaceURI = namespaceURI;
+
+    if ("development" !== 'production') {
+      var parentInfo;
+      if (hostParent != null) {
+        parentInfo = hostParent._ancestorInfo;
+      } else if (hostContainerInfo._tag) {
+        parentInfo = hostContainerInfo._ancestorInfo;
+      }
+      if (parentInfo) {
+        // parentInfo should always be present except for the top-level
+        // component when server rendering
+        validateDOMNesting(this._tag, null, this, parentInfo);
+      }
+      this._ancestorInfo = validateDOMNesting.updatedAncestorInfo(parentInfo, this._tag, this);
+    }
+
+    var mountImage;
+    if (transaction.useCreateElement) {
+      var ownerDocument = hostContainerInfo._ownerDocument;
+      var el;
+      if (namespaceURI === DOMNamespaces.html) {
+        if (this._tag === 'script') {
+          // Create the script via .innerHTML so its "parser-inserted" flag is
+          // set to true and it does not execute
+          var div = ownerDocument.createElement('div');
+          var type = this._currentElement.type;
+          div.innerHTML = '<' + type + '></' + type + '>';
+          el = div.removeChild(div.firstChild);
+        } else if (props.is) {
+          el = ownerDocument.createElement(this._currentElement.type, props.is);
+        } else {
+          // Separate else branch instead of using `props.is || undefined` above becuase of a Firefox bug.
+          // See discussion in https://github.com/facebook/react/pull/6896
+          // and discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1276240
+          el = ownerDocument.createElement(this._currentElement.type);
+        }
+      } else {
+        el = ownerDocument.createElementNS(namespaceURI, this._currentElement.type);
+      }
+      ReactDOMComponentTree.precacheNode(this, el);
+      this._flags |= Flags.hasCachedChildNodes;
+      if (!this._hostParent) {
+        DOMPropertyOperations.setAttributeForRoot(el);
+      }
+      this._updateDOMProperties(null, props, transaction);
+      var lazyTree = DOMLazyTree(el);
+      this._createInitialChildren(transaction, props, context, lazyTree);
+      mountImage = lazyTree;
+    } else {
+      var tagOpen = this._createOpenTagMarkupAndPutListeners(transaction, props);
+      var tagContent = this._createContentMarkup(transaction, props, context);
+      if (!tagContent && omittedCloseTags[this._tag]) {
+        mountImage = tagOpen + '/>';
+      } else {
+        mountImage = tagOpen + '>' + tagContent + '</' + this._currentElement.type + '>';
+      }
+    }
+
+    switch (this._tag) {
+      case 'input':
+        transaction.getReactMountReady().enqueue(inputPostMount, this);
+        if (props.autoFocus) {
+          transaction.getReactMountReady().enqueue(AutoFocusUtils.focusDOMComponent, this);
+        }
+        break;
+      case 'textarea':
+        transaction.getReactMountReady().enqueue(textareaPostMount, this);
+        if (props.autoFocus) {
+          transaction.getReactMountReady().enqueue(AutoFocusUtils.focusDOMComponent, this);
+        }
+        break;
+      case 'select':
+        if (props.autoFocus) {
+          transaction.getReactMountReady().enqueue(AutoFocusUtils.focusDOMComponent, this);
+        }
+        break;
+      case 'button':
+        if (props.autoFocus) {
+          transaction.getReactMountReady().enqueue(AutoFocusUtils.focusDOMComponent, this);
+        }
+        break;
+      case 'option':
+        transaction.getReactMountReady().enqueue(optionPostMount, this);
+        break;
+    }
+
+    return mountImage;
+  },
+
+  /**
+   * Creates markup for the open tag and all attributes.
+   *
+   * This method has side effects because events get registered.
+   *
+   * Iterating over object properties is faster than iterating over arrays.
+   * @see http://jsperf.com/obj-vs-arr-iteration
+   *
+   * @private
+   * @param {ReactReconcileTransaction|ReactServerRenderingTransaction} transaction
+   * @param {object} props
+   * @return {string} Markup of opening tag.
+   */
+  _createOpenTagMarkupAndPutListeners: function (transaction, props) {
+    var ret = '<' + this._currentElement.type;
+
+    for (var propKey in props) {
+      if (!props.hasOwnProperty(propKey)) {
+        continue;
+      }
+      var propValue = props[propKey];
+      if (propValue == null) {
+        continue;
+      }
+      if (registrationNameModules.hasOwnProperty(propKey)) {
+        if (propValue) {
+          enqueuePutListener(this, propKey, propValue, transaction);
+        }
+      } else {
+        if (propKey === STYLE) {
+          if (propValue) {
+            if ("development" !== 'production') {
+              // See `_updateDOMProperties`. style block
+              this._previousStyle = propValue;
+            }
+            propValue = this._previousStyleCopy = _assign({}, props.style);
+          }
+          propValue = CSSPropertyOperations.createMarkupForStyles(propValue, this);
+        }
+        var markup = null;
+        if (this._tag != null && isCustomComponent(this._tag, props)) {
+          if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
+            markup = DOMPropertyOperations.createMarkupForCustomAttribute(propKey, propValue);
+          }
+        } else {
+          markup = DOMPropertyOperations.createMarkupForProperty(propKey, propValue);
+        }
+        if (markup) {
+          ret += ' ' + markup;
+        }
+      }
+    }
+
+    // For static pages, no need to put React ID and checksum. Saves lots of
+    // bytes.
+    if (transaction.renderToStaticMarkup) {
+      return ret;
+    }
+
+    if (!this._hostParent) {
+      ret += ' ' + DOMPropertyOperations.createMarkupForRoot();
+    }
+    ret += ' ' + DOMPropertyOperations.createMarkupForID(this._domID);
+    return ret;
+  },
+
+  /**
+   * Creates markup for the content between the tags.
+   *
+   * @private
+   * @param {ReactReconcileTransaction|ReactServerRenderingTransaction} transaction
+   * @param {object} props
+   * @param {object} context
+   * @return {string} Content markup.
+   */
+  _createContentMarkup: function (transaction, props, context) {
+    var ret = '';
+
+    // Intentional use of != to avoid catching zero/false.
+    var innerHTML = props.dangerouslySetInnerHTML;
+    if (innerHTML != null) {
+      if (innerHTML.__html != null) {
+        ret = innerHTML.__html;
+      }
+    } else {
+      var contentToUse = CONTENT_TYPES[typeof props.children] ? props.children : null;
+      var childrenToUse = contentToUse != null ? null : props.children;
+      if (contentToUse != null) {
+        // TODO: Validate that text is allowed as a child of this node
+        ret = escapeTextContentForBrowser(contentToUse);
+        if ("development" !== 'production') {
+          setAndValidateContentChildDev.call(this, contentToUse);
+        }
+      } else if (childrenToUse != null) {
+        var mountImages = this.mountChildren(childrenToUse, transaction, context);
+        ret = mountImages.join('');
+      }
+    }
+    if (newlineEatingTags[this._tag] && ret.charAt(0) === '\n') {
+      // text/html ignores the first character in these tags if it's a newline
+      // Prefer to break application/xml over text/html (for now) by adding
+      // a newline specifically to get eaten by the parser. (Alternately for
+      // textareas, replacing "^\n" with "\r\n" doesn't get eaten, and the first
+      // \r is normalized out by HTMLTextAreaElement#value.)
+      // See: <http://www.w3.org/TR/html-polyglot/#newlines-in-textarea-and-pre>
+      // See: <http://www.w3.org/TR/html5/syntax.html#element-restrictions>
+      // See: <http://www.w3.org/TR/html5/syntax.html#newlines>
+      // See: Parsing of "textarea" "listing" and "pre" elements
+      //  from <http://www.w3.org/TR/html5/syntax.html#parsing-main-inbody>
+      return '\n' + ret;
+    } else {
+      return ret;
+    }
+  },
+
+  _createInitialChildren: function (transaction, props, context, lazyTree) {
+    // Intentional use of != to avoid catching zero/false.
+    var innerHTML = props.dangerouslySetInnerHTML;
+    if (innerHTML != null) {
+      if (innerHTML.__html != null) {
+        DOMLazyTree.queueHTML(lazyTree, innerHTML.__html);
+      }
+    } else {
+      var contentToUse = CONTENT_TYPES[typeof props.children] ? props.children : null;
+      var childrenToUse = contentToUse != null ? null : props.children;
+      // TODO: Validate that text is allowed as a child of this node
+      if (contentToUse != null) {
+        // Avoid setting textContent when the text is empty. In IE11 setting
+        // textContent on a text area will cause the placeholder to not
+        // show within the textarea until it has been focused and blurred again.
+        // https://github.com/facebook/react/issues/6731#issuecomment-254874553
+        if (contentToUse !== '') {
+          if ("development" !== 'production') {
+            setAndValidateContentChildDev.call(this, contentToUse);
+          }
+          DOMLazyTree.queueText(lazyTree, contentToUse);
+        }
+      } else if (childrenToUse != null) {
+        var mountImages = this.mountChildren(childrenToUse, transaction, context);
+        for (var i = 0; i < mountImages.length; i++) {
+          DOMLazyTree.queueChild(lazyTree, mountImages[i]);
+        }
+      }
+    }
+  },
+
+  /**
+   * Receives a next element and updates the component.
+   *
+   * @internal
+   * @param {ReactElement} nextElement
+   * @param {ReactReconcileTransaction|ReactServerRenderingTransaction} transaction
+   * @param {object} context
+   */
+  receiveComponent: function (nextElement, transaction, context) {
+    var prevElement = this._currentElement;
+    this._currentElement = nextElement;
+    this.updateComponent(transaction, prevElement, nextElement, context);
+  },
+
+  /**
+   * Updates a DOM component after it has already been allocated and
+   * attached to the DOM. Reconciles the root DOM node, then recurses.
+   *
+   * @param {ReactReconcileTransaction} transaction
+   * @param {ReactElement} prevElement
+   * @param {ReactElement} nextElement
+   * @internal
+   * @overridable
+   */
+  updateComponent: function (transaction, prevElement, nextElement, context) {
+    var lastProps = prevElement.props;
+    var nextProps = this._currentElement.props;
+
+    switch (this._tag) {
+      case 'input':
+        lastProps = ReactDOMInput.getHostProps(this, lastProps);
+        nextProps = ReactDOMInput.getHostProps(this, nextProps);
+        break;
+      case 'option':
+        lastProps = ReactDOMOption.getHostProps(this, lastProps);
+        nextProps = ReactDOMOption.getHostProps(this, nextProps);
+        break;
+      case 'select':
+        lastProps = ReactDOMSelect.getHostProps(this, lastProps);
+        nextProps = ReactDOMSelect.getHostProps(this, nextProps);
+        break;
+      case 'textarea':
+        lastProps = ReactDOMTextarea.getHostProps(this, lastProps);
+        nextProps = ReactDOMTextarea.getHostProps(this, nextProps);
+        break;
+    }
+
+    assertValidProps(this, nextProps);
+    this._updateDOMProperties(lastProps, nextProps, transaction);
+    this._updateDOMChildren(lastProps, nextProps, transaction, context);
+
+    switch (this._tag) {
+      case 'input':
+        // Update the wrapper around inputs *after* updating props. This has to
+        // happen after `_updateDOMProperties`. Otherwise HTML5 input validations
+        // raise warnings and prevent the new value from being assigned.
+        ReactDOMInput.updateWrapper(this);
+
+        // We also check that we haven't missed a value update, such as a
+        // Radio group shifting the checked value to another named radio input.
+        inputValueTracking.updateValueIfChanged(this);
+        break;
+      case 'textarea':
+        ReactDOMTextarea.updateWrapper(this);
+        break;
+      case 'select':
+        // <select> value update needs to occur after <option> children
+        // reconciliation
+        transaction.getReactMountReady().enqueue(postUpdateSelectWrapper, this);
+        break;
+    }
+  },
+
+  /**
+   * Reconciles the properties by detecting differences in property values and
+   * updating the DOM as necessary. This function is probably the single most
+   * critical path for performance optimization.
+   *
+   * TODO: Benchmark whether checking for changed values in memory actually
+   *       improves performance (especially statically positioned elements).
+   * TODO: Benchmark the effects of putting this at the top since 99% of props
+   *       do not change for a given reconciliation.
+   * TODO: Benchmark areas that can be improved with caching.
+   *
+   * @private
+   * @param {object} lastProps
+   * @param {object} nextProps
+   * @param {?DOMElement} node
+   */
+  _updateDOMProperties: function (lastProps, nextProps, transaction) {
+    var propKey;
+    var styleName;
+    var styleUpdates;
+    for (propKey in lastProps) {
+      if (nextProps.hasOwnProperty(propKey) || !lastProps.hasOwnProperty(propKey) || lastProps[propKey] == null) {
+        continue;
+      }
+      if (propKey === STYLE) {
+        var lastStyle = this._previousStyleCopy;
+        for (styleName in lastStyle) {
+          if (lastStyle.hasOwnProperty(styleName)) {
+            styleUpdates = styleUpdates || {};
+            styleUpdates[styleName] = '';
+          }
+        }
+        this._previousStyleCopy = null;
+      } else if (registrationNameModules.hasOwnProperty(propKey)) {
+        if (lastProps[propKey]) {
+          // Only call deleteListener if there was a listener previously or
+          // else willDeleteListener gets called when there wasn't actually a
+          // listener (e.g., onClick={null})
+          deleteListener(this, propKey);
+        }
+      } else if (isCustomComponent(this._tag, lastProps)) {
+        if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
+          DOMPropertyOperations.deleteValueForAttribute(getNode(this), propKey);
+        }
+      } else if (DOMProperty.properties[propKey] || DOMProperty.isCustomAttribute(propKey)) {
+        DOMPropertyOperations.deleteValueForProperty(getNode(this), propKey);
+      }
+    }
+    for (propKey in nextProps) {
+      var nextProp = nextProps[propKey];
+      var lastProp = propKey === STYLE ? this._previousStyleCopy : lastProps != null ? lastProps[propKey] : undefined;
+      if (!nextProps.hasOwnProperty(propKey) || nextProp === lastProp || nextProp == null && lastProp == null) {
+        continue;
+      }
+      if (propKey === STYLE) {
+        if (nextProp) {
+          if ("development" !== 'production') {
+            checkAndWarnForMutatedStyle(this._previousStyleCopy, this._previousStyle, this);
+            this._previousStyle = nextProp;
+          }
+          nextProp = this._previousStyleCopy = _assign({}, nextProp);
+        } else {
+          this._previousStyleCopy = null;
+        }
+        if (lastProp) {
+          // Unset styles on `lastProp` but not on `nextProp`.
+          for (styleName in lastProp) {
+            if (lastProp.hasOwnProperty(styleName) && (!nextProp || !nextProp.hasOwnProperty(styleName))) {
+              styleUpdates = styleUpdates || {};
+              styleUpdates[styleName] = '';
+            }
+          }
+          // Update styles that changed since `lastProp`.
+          for (styleName in nextProp) {
+            if (nextProp.hasOwnProperty(styleName) && lastProp[styleName] !== nextProp[styleName]) {
+              styleUpdates = styleUpdates || {};
+              styleUpdates[styleName] = nextProp[styleName];
+            }
+          }
+        } else {
+          // Relies on `updateStylesByID` not mutating `styleUpdates`.
+          styleUpdates = nextProp;
+        }
+      } else if (registrationNameModules.hasOwnProperty(propKey)) {
+        if (nextProp) {
+          enqueuePutListener(this, propKey, nextProp, transaction);
+        } else if (lastProp) {
+          deleteListener(this, propKey);
+        }
+      } else if (isCustomComponent(this._tag, nextProps)) {
+        if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
+          DOMPropertyOperations.setValueForAttribute(getNode(this), propKey, nextProp);
+        }
+      } else if (DOMProperty.properties[propKey] || DOMProperty.isCustomAttribute(propKey)) {
+        var node = getNode(this);
+        // If we're updating to null or undefined, we should remove the property
+        // from the DOM node instead of inadvertently setting to a string. This
+        // brings us in line with the same behavior we have on initial render.
+        if (nextProp != null) {
+          DOMPropertyOperations.setValueForProperty(node, propKey, nextProp);
+        } else {
+          DOMPropertyOperations.deleteValueForProperty(node, propKey);
+        }
+      }
+    }
+    if (styleUpdates) {
+      CSSPropertyOperations.setValueForStyles(getNode(this), styleUpdates, this);
+    }
+  },
+
+  /**
+   * Reconciles the children with the various properties that affect the
+   * children content.
+   *
+   * @param {object} lastProps
+   * @param {object} nextProps
+   * @param {ReactReconcileTransaction} transaction
+   * @param {object} context
+   */
+  _updateDOMChildren: function (lastProps, nextProps, transaction, context) {
+    var lastContent = CONTENT_TYPES[typeof lastProps.children] ? lastProps.children : null;
+    var nextContent = CONTENT_TYPES[typeof nextProps.children] ? nextProps.children : null;
+
+    var lastHtml = lastProps.dangerouslySetInnerHTML && lastProps.dangerouslySetInnerHTML.__html;
+    var nextHtml = nextProps.dangerouslySetInnerHTML && nextProps.dangerouslySetInnerHTML.__html;
+
+    // Note the use of `!=` which checks for null or undefined.
+    var lastChildren = lastContent != null ? null : lastProps.children;
+    var nextChildren = nextContent != null ? null : nextProps.children;
+
+    // If we're switching from children to content/html or vice versa, remove
+    // the old content
+    var lastHasContentOrHtml = lastContent != null || lastHtml != null;
+    var nextHasContentOrHtml = nextContent != null || nextHtml != null;
+    if (lastChildren != null && nextChildren == null) {
+      this.updateChildren(null, transaction, context);
+    } else if (lastHasContentOrHtml && !nextHasContentOrHtml) {
+      this.updateTextContent('');
+      if ("development" !== 'production') {
+        ReactInstrumentation.debugTool.onSetChildren(this._debugID, []);
+      }
+    }
+
+    if (nextContent != null) {
+      if (lastContent !== nextContent) {
+        this.updateTextContent('' + nextContent);
+        if ("development" !== 'production') {
+          setAndValidateContentChildDev.call(this, nextContent);
+        }
+      }
+    } else if (nextHtml != null) {
+      if (lastHtml !== nextHtml) {
+        this.updateMarkup('' + nextHtml);
+      }
+      if ("development" !== 'production') {
+        ReactInstrumentation.debugTool.onSetChildren(this._debugID, []);
+      }
+    } else if (nextChildren != null) {
+      if ("development" !== 'production') {
+        setAndValidateContentChildDev.call(this, null);
+      }
+
+      this.updateChildren(nextChildren, transaction, context);
+    }
+  },
+
+  getHostNode: function () {
+    return getNode(this);
+  },
+
+  /**
+   * Destroys all event registrations for this instance. Does not remove from
+   * the DOM. That must be done by the parent.
+   *
+   * @internal
+   */
+  unmountComponent: function (safely) {
+    switch (this._tag) {
+      case 'audio':
+      case 'form':
+      case 'iframe':
+      case 'img':
+      case 'link':
+      case 'object':
+      case 'source':
+      case 'video':
+        var listeners = this._wrapperState.listeners;
+        if (listeners) {
+          for (var i = 0; i < listeners.length; i++) {
+            listeners[i].remove();
+          }
+        }
+        break;
+      case 'input':
+      case 'textarea':
+        inputValueTracking.stopTracking(this);
+        break;
+      case 'html':
+      case 'head':
+      case 'body':
+        /**
+         * Components like <html> <head> and <body> can't be removed or added
+         * easily in a cross-browser way, however it's valuable to be able to
+         * take advantage of React's reconciliation for styling and <title>
+         * management. So we just document it and throw in dangerous cases.
+         */
+        !false ? "development" !== 'production' ? invariant(false, '<%s> tried to unmount. Because of cross-browser quirks it is impossible to unmount some top-level components (eg <html>, <head>, and <body>) reliably and efficiently. To fix this, have a single top-level component that never unmounts render these elements.', this._tag) : _prodInvariant('66', this._tag) : void 0;
+        break;
+    }
+
+    this.unmountChildren(safely);
+    ReactDOMComponentTree.uncacheNode(this);
+    EventPluginHub.deleteAllListeners(this);
+    this._rootNodeID = 0;
+    this._domID = 0;
+    this._wrapperState = null;
+
+    if ("development" !== 'production') {
+      setAndValidateContentChildDev.call(this, null);
+    }
+  },
+
+  getPublicInstance: function () {
+    return getNode(this);
+  }
+};
+
+_assign(ReactDOMComponent.prototype, ReactDOMComponent.Mixin, ReactMultiChild.Mixin);
+
+module.exports = ReactDOMComponent;
+},{"10":10,"107":107,"11":11,"12":12,"120":120,"122":122,"126":126,"132":132,"144":144,"152":152,"158":158,"159":159,"160":160,"17":17,"18":18,"2":2,"26":26,"33":33,"34":34,"39":39,"42":42,"43":43,"46":46,"5":5,"64":64,"68":68,"77":77,"9":9}],33:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ReactDOMComponentFlags = {
+  hasCachedChildNodes: 1 << 0
+};
+
+module.exports = ReactDOMComponentFlags;
+},{}],34:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var DOMProperty = _dereq_(11);
+var ReactDOMComponentFlags = _dereq_(33);
+
+var invariant = _dereq_(152);
+
+var ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
+var Flags = ReactDOMComponentFlags;
+
+var internalInstanceKey = '__reactInternalInstance$' + Math.random().toString(36).slice(2);
+
+/**
+ * Check if a given node should be cached.
+ */
+function shouldPrecacheNode(node, nodeID) {
+  return node.nodeType === 1 && node.getAttribute(ATTR_NAME) === String(nodeID) || node.nodeType === 8 && node.nodeValue === ' react-text: ' + nodeID + ' ' || node.nodeType === 8 && node.nodeValue === ' react-empty: ' + nodeID + ' ';
+}
+
+/**
+ * Drill down (through composites and empty components) until we get a host or
+ * host text component.
+ *
+ * This is pretty polymorphic but unavoidable with the current structure we have
+ * for `_renderedChildren`.
+ */
+function getRenderedHostOrTextFromComponent(component) {
+  var rendered;
+  while (rendered = component._renderedComponent) {
+    component = rendered;
+  }
+  return component;
+}
+
+/**
+ * Populate `_hostNode` on the rendered host/text component with the given
+ * DOM node. The passed `inst` can be a composite.
+ */
+function precacheNode(inst, node) {
+  var hostInst = getRenderedHostOrTextFromComponent(inst);
+  hostInst._hostNode = node;
+  node[internalInstanceKey] = hostInst;
+}
+
+function uncacheNode(inst) {
+  var node = inst._hostNode;
+  if (node) {
+    delete node[internalInstanceKey];
+    inst._hostNode = null;
+  }
+}
+
+/**
+ * Populate `_hostNode` on each child of `inst`, assuming that the children
+ * match up with the DOM (element) children of `node`.
+ *
+ * We cache entire levels at once to avoid an n^2 problem where we access the
+ * children of a node sequentially and have to walk from the start to our target
+ * node every time.
+ *
+ * Since we update `_renderedChildren` and the actual DOM at (slightly)
+ * different times, we could race here and see a newer `_renderedChildren` than
+ * the DOM nodes we see. To avoid this, ReactMultiChild calls
+ * `prepareToManageChildren` before we change `_renderedChildren`, at which
+ * time the container's child nodes are always cached (until it unmounts).
+ */
+function precacheChildNodes(inst, node) {
+  if (inst._flags & Flags.hasCachedChildNodes) {
+    return;
+  }
+  var children = inst._renderedChildren;
+  var childNode = node.firstChild;
+  outer: for (var name in children) {
+    if (!children.hasOwnProperty(name)) {
+      continue;
+    }
+    var childInst = children[name];
+    var childID = getRenderedHostOrTextFromComponent(childInst)._domID;
+    if (childID === 0) {
+      // We're currently unmounting this child in ReactMultiChild; skip it.
+      continue;
+    }
+    // We assume the child nodes are in the same order as the child instances.
+    for (; childNode !== null; childNode = childNode.nextSibling) {
+      if (shouldPrecacheNode(childNode, childID)) {
+        precacheNode(childInst, childNode);
+        continue outer;
+      }
+    }
+    // We reached the end of the DOM children without finding an ID match.
+    !false ? "development" !== 'production' ? invariant(false, 'Unable to find element with ID %s.', childID) : _prodInvariant('32', childID) : void 0;
+  }
+  inst._flags |= Flags.hasCachedChildNodes;
+}
+
+/**
+ * Given a DOM node, return the closest ReactDOMComponent or
+ * ReactDOMTextComponent instance ancestor.
+ */
+function getClosestInstanceFromNode(node) {
+  if (node[internalInstanceKey]) {
+    return node[internalInstanceKey];
+  }
+
+  // Walk up the tree until we find an ancestor whose instance we have cached.
+  var parents = [];
+  while (!node[internalInstanceKey]) {
+    parents.push(node);
+    if (node.parentNode) {
+      node = node.parentNode;
+    } else {
+      // Top of the tree. This node must not be part of a React tree (or is
+      // unmounted, potentially).
+      return null;
+    }
+  }
+
+  var closest;
+  var inst;
+  for (; node && (inst = node[internalInstanceKey]); node = parents.pop()) {
+    closest = inst;
+    if (parents.length) {
+      precacheChildNodes(inst, node);
+    }
+  }
+
+  return closest;
+}
+
+/**
+ * Given a DOM node, return the ReactDOMComponent or ReactDOMTextComponent
+ * instance, or null if the node was not rendered by this React.
+ */
+function getInstanceFromNode(node) {
+  var inst = getClosestInstanceFromNode(node);
+  if (inst != null && inst._hostNode === node) {
+    return inst;
+  } else {
+    return null;
+  }
+}
+
+/**
+ * Given a ReactDOMComponent or ReactDOMTextComponent, return the corresponding
+ * DOM node.
+ */
+function getNodeFromInstance(inst) {
+  // Without this first invariant, passing a non-DOM-component triggers the next
+  // invariant for a missing parent, which is super confusing.
+  !(inst._hostNode !== undefined) ? "development" !== 'production' ? invariant(false, 'getNodeFromInstance: Invalid argument.') : _prodInvariant('33') : void 0;
+
+  if (inst._hostNode) {
+    return inst._hostNode;
+  }
+
+  // Walk up the tree until we find an ancestor whose DOM node we have cached.
+  var parents = [];
+  while (!inst._hostNode) {
+    parents.push(inst);
+    !inst._hostParent ? "development" !== 'production' ? invariant(false, 'React DOM tree root should always have a node reference.') : _prodInvariant('34') : void 0;
+    inst = inst._hostParent;
+  }
+
+  // Now parents contains each ancestor that does *not* have a cached native
+  // node, and `inst` is the deepest ancestor that does.
+  for (; parents.length; inst = parents.pop()) {
+    precacheChildNodes(inst, inst._hostNode);
+  }
+
+  return inst._hostNode;
+}
+
+var ReactDOMComponentTree = {
+  getClosestInstanceFromNode: getClosestInstanceFromNode,
+  getInstanceFromNode: getInstanceFromNode,
+  getNodeFromInstance: getNodeFromInstance,
+  precacheChildNodes: precacheChildNodes,
+  precacheNode: precacheNode,
+  uncacheNode: uncacheNode
+};
+
+module.exports = ReactDOMComponentTree;
+},{"11":11,"126":126,"152":152,"33":33}],35:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var validateDOMNesting = _dereq_(132);
+
+var DOC_NODE_TYPE = 9;
+
+function ReactDOMContainerInfo(topLevelWrapper, node) {
+  var info = {
+    _topLevelWrapper: topLevelWrapper,
+    _idCounter: 1,
+    _ownerDocument: node ? node.nodeType === DOC_NODE_TYPE ? node : node.ownerDocument : null,
+    _node: node,
+    _tag: node ? node.nodeName.toLowerCase() : null,
+    _namespaceURI: node ? node.namespaceURI : null
+  };
+  if ("development" !== 'production') {
+    info._ancestorInfo = node ? validateDOMNesting.updatedAncestorInfo(null, info._tag, null) : null;
+  }
+  return info;
+}
+
+module.exports = ReactDOMContainerInfo;
+},{"132":132}],36:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var DOMLazyTree = _dereq_(9);
+var ReactDOMComponentTree = _dereq_(34);
+
+var ReactDOMEmptyComponent = function (instantiate) {
+  // ReactCompositeComponent uses this:
+  this._currentElement = null;
+  // ReactDOMComponentTree uses these:
+  this._hostNode = null;
+  this._hostParent = null;
+  this._hostContainerInfo = null;
+  this._domID = 0;
+};
+_assign(ReactDOMEmptyComponent.prototype, {
+  mountComponent: function (transaction, hostParent, hostContainerInfo, context) {
+    var domID = hostContainerInfo._idCounter++;
+    this._domID = domID;
+    this._hostParent = hostParent;
+    this._hostContainerInfo = hostContainerInfo;
+
+    var nodeValue = ' react-empty: ' + this._domID + ' ';
+    if (transaction.useCreateElement) {
+      var ownerDocument = hostContainerInfo._ownerDocument;
+      var node = ownerDocument.createComment(nodeValue);
+      ReactDOMComponentTree.precacheNode(this, node);
+      return DOMLazyTree(node);
+    } else {
+      if (transaction.renderToStaticMarkup) {
+        // Normally we'd insert a comment node, but since this is a situation
+        // where React won't take over (static pages), we can simply return
+        // nothing.
+        return '';
+      }
+      return '<!--' + nodeValue + '-->';
+    }
+  },
+  receiveComponent: function () {},
+  getHostNode: function () {
+    return ReactDOMComponentTree.getNodeFromInstance(this);
+  },
+  unmountComponent: function () {
+    ReactDOMComponentTree.uncacheNode(this);
+  }
+});
+
+module.exports = ReactDOMEmptyComponent;
+},{"160":160,"34":34,"9":9}],37:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ReactDOMFeatureFlags = {
+  useCreateElement: true,
+  useFiber: false
+};
+
+module.exports = ReactDOMFeatureFlags;
+},{}],38:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var DOMChildrenOperations = _dereq_(8);
+var ReactDOMComponentTree = _dereq_(34);
+
+/**
+ * Operations used to process updates to DOM nodes.
+ */
+var ReactDOMIDOperations = {
+  /**
+   * Updates a component's children by processing a series of updates.
+   *
+   * @param {array<object>} updates List of update configurations.
+   * @internal
+   */
+  dangerouslyProcessChildrenUpdates: function (parentInst, updates) {
+    var node = ReactDOMComponentTree.getNodeFromInstance(parentInst);
+    DOMChildrenOperations.processUpdates(node, updates);
+  }
+};
+
+module.exports = ReactDOMIDOperations;
+},{"34":34,"8":8}],39:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126),
+    _assign = _dereq_(160);
+
+var DOMPropertyOperations = _dereq_(12);
+var LinkedValueUtils = _dereq_(24);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactUpdates = _dereq_(82);
+
+var invariant = _dereq_(152);
+var warning = _dereq_(159);
+
+var didWarnValueLink = false;
+var didWarnCheckedLink = false;
+var didWarnValueDefaultValue = false;
+var didWarnCheckedDefaultChecked = false;
+var didWarnControlledToUncontrolled = false;
+var didWarnUncontrolledToControlled = false;
+
+function forceUpdateIfMounted() {
+  if (this._rootNodeID) {
+    // DOM component is still mounted; update
+    ReactDOMInput.updateWrapper(this);
+  }
+}
+
+function isControlled(props) {
+  var usesChecked = props.type === 'checkbox' || props.type === 'radio';
+  return usesChecked ? props.checked != null : props.value != null;
+}
+
+/**
+ * Implements an <input> host component that allows setting these optional
+ * props: `checked`, `value`, `defaultChecked`, and `defaultValue`.
+ *
+ * If `checked` or `value` are not supplied (or null/undefined), user actions
+ * that affect the checked state or value will trigger updates to the element.
+ *
+ * If they are supplied (and not null/undefined), the rendered element will not
+ * trigger updates to the element. Instead, the props must change in order for
+ * the rendered element to be updated.
+ *
+ * The rendered element will be initialized as unchecked (or `defaultChecked`)
+ * with an empty value (or `defaultValue`).
+ *
+ * @see http://www.w3.org/TR/2012/WD-html5-20121025/the-input-element.html
+ */
+var ReactDOMInput = {
+  getHostProps: function (inst, props) {
+    var value = LinkedValueUtils.getValue(props);
+    var checked = LinkedValueUtils.getChecked(props);
+
+    var hostProps = _assign({
+      // Make sure we set .type before any other properties (setting .value
+      // before .type means .value is lost in IE11 and below)
+      type: undefined,
+      // Make sure we set .step before .value (setting .value before .step
+      // means .value is rounded on mount, based upon step precision)
+      step: undefined,
+      // Make sure we set .min & .max before .value (to ensure proper order
+      // in corner cases such as min or max deriving from value, e.g. Issue #7170)
+      min: undefined,
+      max: undefined
+    }, props, {
+      defaultChecked: undefined,
+      defaultValue: undefined,
+      value: value != null ? value : inst._wrapperState.initialValue,
+      checked: checked != null ? checked : inst._wrapperState.initialChecked,
+      onChange: inst._wrapperState.onChange
+    });
+
+    return hostProps;
+  },
+
+  mountWrapper: function (inst, props) {
+    if ("development" !== 'production') {
+      LinkedValueUtils.checkPropTypes('input', props, inst._currentElement._owner);
+
+      var owner = inst._currentElement._owner;
+
+      if (props.valueLink !== undefined && !didWarnValueLink) {
+        "development" !== 'production' ? warning(false, '`valueLink` prop on `input` is deprecated; set `value` and `onChange` instead.') : void 0;
+        didWarnValueLink = true;
+      }
+      if (props.checkedLink !== undefined && !didWarnCheckedLink) {
+        "development" !== 'production' ? warning(false, '`checkedLink` prop on `input` is deprecated; set `value` and `onChange` instead.') : void 0;
+        didWarnCheckedLink = true;
+      }
+      if (props.checked !== undefined && props.defaultChecked !== undefined && !didWarnCheckedDefaultChecked) {
+        "development" !== 'production' ? warning(false, '%s contains an input of type %s with both checked and defaultChecked props. ' + 'Input elements must be either controlled or uncontrolled ' + '(specify either the checked prop, or the defaultChecked prop, but not ' + 'both). Decide between using a controlled or uncontrolled input ' + 'element and remove one of these props. More info: ' + 'https://fb.me/react-controlled-components', owner && owner.getName() || 'A component', props.type) : void 0;
+        didWarnCheckedDefaultChecked = true;
+      }
+      if (props.value !== undefined && props.defaultValue !== undefined && !didWarnValueDefaultValue) {
+        "development" !== 'production' ? warning(false, '%s contains an input of type %s with both value and defaultValue props. ' + 'Input elements must be either controlled or uncontrolled ' + '(specify either the value prop, or the defaultValue prop, but not ' + 'both). Decide between using a controlled or uncontrolled input ' + 'element and remove one of these props. More info: ' + 'https://fb.me/react-controlled-components', owner && owner.getName() || 'A component', props.type) : void 0;
+        didWarnValueDefaultValue = true;
+      }
+    }
+
+    var defaultValue = props.defaultValue;
+    inst._wrapperState = {
+      initialChecked: props.checked != null ? props.checked : props.defaultChecked,
+      initialValue: props.value != null ? props.value : defaultValue,
+      listeners: null,
+      onChange: _handleChange.bind(inst),
+      controlled: isControlled(props)
+    };
+  },
+
+  updateWrapper: function (inst) {
+    var props = inst._currentElement.props;
+
+    if ("development" !== 'production') {
+      var controlled = isControlled(props);
+      var owner = inst._currentElement._owner;
+
+      if (!inst._wrapperState.controlled && controlled && !didWarnUncontrolledToControlled) {
+        "development" !== 'production' ? warning(false, '%s is changing an uncontrolled input of type %s to be controlled. ' + 'Input elements should not switch from uncontrolled to controlled (or vice versa). ' + 'Decide between using a controlled or uncontrolled input ' + 'element for the lifetime of the component. More info: https://fb.me/react-controlled-components', owner && owner.getName() || 'A component', props.type) : void 0;
+        didWarnUncontrolledToControlled = true;
+      }
+      if (inst._wrapperState.controlled && !controlled && !didWarnControlledToUncontrolled) {
+        "development" !== 'production' ? warning(false, '%s is changing a controlled input of type %s to be uncontrolled. ' + 'Input elements should not switch from controlled to uncontrolled (or vice versa). ' + 'Decide between using a controlled or uncontrolled input ' + 'element for the lifetime of the component. More info: https://fb.me/react-controlled-components', owner && owner.getName() || 'A component', props.type) : void 0;
+        didWarnControlledToUncontrolled = true;
+      }
+    }
+
+    // TODO: Shouldn't this be getChecked(props)?
+    var checked = props.checked;
+    if (checked != null) {
+      DOMPropertyOperations.setValueForProperty(ReactDOMComponentTree.getNodeFromInstance(inst), 'checked', checked || false);
+    }
+
+    var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+    var value = LinkedValueUtils.getValue(props);
+    if (value != null) {
+      if (value === 0 && node.value === '') {
+        node.value = '0';
+        // Note: IE9 reports a number inputs as 'text', so check props instead.
+      } else if (props.type === 'number') {
+        // Simulate `input.valueAsNumber`. IE9 does not support it
+        var valueAsNumber = parseFloat(node.value, 10) || 0;
+
+        if (
+        // eslint-disable-next-line
+        value != valueAsNumber ||
+        // eslint-disable-next-line
+        value == valueAsNumber && node.value != value) {
+          // Cast `value` to a string to ensure the value is set correctly. While
+          // browsers typically do this as necessary, jsdom doesn't.
+          node.value = '' + value;
+        }
+      } else if (node.value !== '' + value) {
+        // Cast `value` to a string to ensure the value is set correctly. While
+        // browsers typically do this as necessary, jsdom doesn't.
+        node.value = '' + value;
+      }
+    } else {
+      if (props.value == null && props.defaultValue != null) {
+        // In Chrome, assigning defaultValue to certain input types triggers input validation.
+        // For number inputs, the display value loses trailing decimal points. For email inputs,
+        // Chrome raises "The specified value <x> is not a valid email address".
+        //
+        // Here we check to see if the defaultValue has actually changed, avoiding these problems
+        // when the user is inputting text
+        //
+        // https://github.com/facebook/react/issues/7253
+        if (node.defaultValue !== '' + props.defaultValue) {
+          node.defaultValue = '' + props.defaultValue;
+        }
+      }
+      if (props.checked == null && props.defaultChecked != null) {
+        node.defaultChecked = !!props.defaultChecked;
+      }
+    }
+  },
+
+  postMountWrapper: function (inst) {
+    var props = inst._currentElement.props;
+
+    // This is in postMount because we need access to the DOM node, which is not
+    // available until after the component has mounted.
+    var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+
+    // Detach value from defaultValue. We won't do anything if we're working on
+    // submit or reset inputs as those values & defaultValues are linked. They
+    // are not resetable nodes so this operation doesn't matter and actually
+    // removes browser-default values (eg "Submit Query") when no value is
+    // provided.
+
+    switch (props.type) {
+      case 'submit':
+      case 'reset':
+        break;
+      case 'color':
+      case 'date':
+      case 'datetime':
+      case 'datetime-local':
+      case 'month':
+      case 'time':
+      case 'week':
+        // This fixes the no-show issue on iOS Safari and Android Chrome:
+        // https://github.com/facebook/react/issues/7233
+        node.value = '';
+        node.value = node.defaultValue;
+        break;
+      default:
+        node.value = node.value;
+        break;
+    }
+
+    // Normally, we'd just do `node.checked = node.checked` upon initial mount, less this bug
+    // this is needed to work around a chrome bug where setting defaultChecked
+    // will sometimes influence the value of checked (even after detachment).
+    // Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=608416
+    // We need to temporarily unset name to avoid disrupting radio button groups.
+    var name = node.name;
+    if (name !== '') {
+      node.name = '';
+    }
+    node.defaultChecked = !node.defaultChecked;
+    node.defaultChecked = !node.defaultChecked;
+    if (name !== '') {
+      node.name = name;
+    }
+  }
+};
+
+function _handleChange(event) {
+  var props = this._currentElement.props;
+
+  var returnValue = LinkedValueUtils.executeOnChange(props, event);
+
+  // Here we use asap to wait until all updates have propagated, which
+  // is important when using controlled components within layers:
+  // https://github.com/facebook/react/issues/1698
+  ReactUpdates.asap(forceUpdateIfMounted, this);
+
+  var name = props.name;
+  if (props.type === 'radio' && name != null) {
+    var rootNode = ReactDOMComponentTree.getNodeFromInstance(this);
+    var queryRoot = rootNode;
+
+    while (queryRoot.parentNode) {
+      queryRoot = queryRoot.parentNode;
+    }
+
+    // If `rootNode.form` was non-null, then we could try `form.elements`,
+    // but that sometimes behaves strangely in IE8. We could also try using
+    // `form.getElementsByName`, but that will only return direct children
+    // and won't include inputs that use the HTML5 `form=` attribute. Since
+    // the input might not even be in a form, let's just use the global
+    // `querySelectorAll` to ensure we don't miss anything.
+    var group = queryRoot.querySelectorAll('input[name=' + JSON.stringify('' + name) + '][type="radio"]');
+
+    for (var i = 0; i < group.length; i++) {
+      var otherNode = group[i];
+      if (otherNode === rootNode || otherNode.form !== rootNode.form) {
+        continue;
+      }
+      // This will throw if radio buttons rendered by different copies of React
+      // and the same name are rendered into the same form (same as #1939).
+      // That's probably okay; we don't support it just as we don't support
+      // mixing React radio buttons with non-React ones.
+      var otherInstance = ReactDOMComponentTree.getInstanceFromNode(otherNode);
+      !otherInstance ? "development" !== 'production' ? invariant(false, 'ReactDOMInput: Mixing React and non-React radio inputs with the same `name` is not supported.') : _prodInvariant('90') : void 0;
+      // If this is a controlled radio button group, forcing the input that
+      // was previously checked to update will cause it to be come re-checked
+      // as appropriate.
+      ReactUpdates.asap(forceUpdateIfMounted, otherInstance);
+    }
+  }
+
+  return returnValue;
+}
+
+module.exports = ReactDOMInput;
+},{"12":12,"126":126,"152":152,"159":159,"160":160,"24":24,"34":34,"82":82}],40:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var DOMProperty = _dereq_(11);
+var ReactComponentTreeHook = _dereq_(133);
+
+var warning = _dereq_(159);
+
+var warnedProperties = {};
+var rARIA = new RegExp('^(aria)-[' + DOMProperty.ATTRIBUTE_NAME_CHAR + ']*$');
+
+function validateProperty(tagName, name, debugID) {
+  if (warnedProperties.hasOwnProperty(name) && warnedProperties[name]) {
+    return true;
+  }
+
+  if (rARIA.test(name)) {
+    var lowerCasedName = name.toLowerCase();
+    var standardName = DOMProperty.getPossibleStandardName.hasOwnProperty(lowerCasedName) ? DOMProperty.getPossibleStandardName[lowerCasedName] : null;
+
+    // If this is an aria-* attribute, but is not listed in the known DOM
+    // DOM properties, then it is an invalid aria-* attribute.
+    if (standardName == null) {
+      warnedProperties[name] = true;
+      return false;
+    }
+    // aria-* attributes should be lowercase; suggest the lowercase version.
+    if (name !== standardName) {
+      "development" !== 'production' ? warning(false, 'Unknown ARIA attribute %s. Did you mean %s?%s', name, standardName, ReactComponentTreeHook.getStackAddendumByID(debugID)) : void 0;
+      warnedProperties[name] = true;
+      return true;
+    }
+  }
+
+  return true;
+}
+
+function warnInvalidARIAProps(debugID, element) {
+  var invalidProps = [];
+
+  for (var key in element.props) {
+    var isValid = validateProperty(element.type, key, debugID);
+    if (!isValid) {
+      invalidProps.push(key);
+    }
+  }
+
+  var unknownPropString = invalidProps.map(function (prop) {
+    return '`' + prop + '`';
+  }).join(', ');
+
+  if (invalidProps.length === 1) {
+    "development" !== 'production' ? warning(false, 'Invalid aria prop %s on <%s> tag. ' + 'For details, see https://fb.me/invalid-aria-prop%s', unknownPropString, element.type, ReactComponentTreeHook.getStackAddendumByID(debugID)) : void 0;
+  } else if (invalidProps.length > 1) {
+    "development" !== 'production' ? warning(false, 'Invalid aria props %s on <%s> tag. ' + 'For details, see https://fb.me/invalid-aria-prop%s', unknownPropString, element.type, ReactComponentTreeHook.getStackAddendumByID(debugID)) : void 0;
+  }
+}
+
+function handleElement(debugID, element) {
+  if (element == null || typeof element.type !== 'string') {
+    return;
+  }
+  if (element.type.indexOf('-') >= 0 || element.props.is) {
+    return;
+  }
+
+  warnInvalidARIAProps(debugID, element);
+}
+
+var ReactDOMInvalidARIAHook = {
+  onBeforeMountComponent: function (debugID, element) {
+    if ("development" !== 'production') {
+      handleElement(debugID, element);
+    }
+  },
+  onBeforeUpdateComponent: function (debugID, element) {
+    if ("development" !== 'production') {
+      handleElement(debugID, element);
+    }
+  }
+};
+
+module.exports = ReactDOMInvalidARIAHook;
+},{"11":11,"133":133,"159":159}],41:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ReactComponentTreeHook = _dereq_(133);
+
+var warning = _dereq_(159);
+
+var didWarnValueNull = false;
+
+function handleElement(debugID, element) {
+  if (element == null) {
+    return;
+  }
+  if (element.type !== 'input' && element.type !== 'textarea' && element.type !== 'select') {
+    return;
+  }
+  if (element.props != null && element.props.value === null && !didWarnValueNull) {
+    "development" !== 'production' ? warning(false, '`value` prop on `%s` should not be null. ' + 'Consider using the empty string to clear the component or `undefined` ' + 'for uncontrolled components.%s', element.type, ReactComponentTreeHook.getStackAddendumByID(debugID)) : void 0;
+
+    didWarnValueNull = true;
+  }
+}
+
+var ReactDOMNullInputValuePropHook = {
+  onBeforeMountComponent: function (debugID, element) {
+    handleElement(debugID, element);
+  },
+  onBeforeUpdateComponent: function (debugID, element) {
+    handleElement(debugID, element);
+  }
+};
+
+module.exports = ReactDOMNullInputValuePropHook;
+},{"133":133,"159":159}],42:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var React = _dereq_(135);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactDOMSelect = _dereq_(43);
+
+var warning = _dereq_(159);
+var didWarnInvalidOptionChildren = false;
+
+function flattenChildren(children) {
+  var content = '';
+
+  // Flatten children and warn if they aren't strings or numbers;
+  // invalid types are ignored.
+  React.Children.forEach(children, function (child) {
+    if (child == null) {
+      return;
+    }
+    if (typeof child === 'string' || typeof child === 'number') {
+      content += child;
+    } else if (!didWarnInvalidOptionChildren) {
+      didWarnInvalidOptionChildren = true;
+      "development" !== 'production' ? warning(false, 'Only strings and numbers are supported as <option> children.') : void 0;
+    }
+  });
+
+  return content;
+}
+
+/**
+ * Implements an <option> host component that warns when `selected` is set.
+ */
+var ReactDOMOption = {
+  mountWrapper: function (inst, props, hostParent) {
+    // TODO (yungsters): Remove support for `selected` in <option>.
+    if ("development" !== 'production') {
+      "development" !== 'production' ? warning(props.selected == null, 'Use the `defaultValue` or `value` props on <select> instead of ' + 'setting `selected` on <option>.') : void 0;
+    }
+
+    // Look up whether this option is 'selected'
+    var selectValue = null;
+    if (hostParent != null) {
+      var selectParent = hostParent;
+
+      if (selectParent._tag === 'optgroup') {
+        selectParent = selectParent._hostParent;
+      }
+
+      if (selectParent != null && selectParent._tag === 'select') {
+        selectValue = ReactDOMSelect.getSelectValueContext(selectParent);
+      }
+    }
+
+    // If the value is null (e.g., no specified value or after initial mount)
+    // or missing (e.g., for <datalist>), we don't change props.selected
+    var selected = null;
+    if (selectValue != null) {
+      var value;
+      if (props.value != null) {
+        value = props.value + '';
+      } else {
+        value = flattenChildren(props.children);
+      }
+      selected = false;
+      if (Array.isArray(selectValue)) {
+        // multiple
+        for (var i = 0; i < selectValue.length; i++) {
+          if ('' + selectValue[i] === value) {
+            selected = true;
+            break;
+          }
+        }
+      } else {
+        selected = '' + selectValue === value;
+      }
+    }
+
+    inst._wrapperState = { selected: selected };
+  },
+
+  postMountWrapper: function (inst) {
+    // value="" should make a value attribute (#6219)
+    var props = inst._currentElement.props;
+    if (props.value != null) {
+      var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+      node.setAttribute('value', props.value);
+    }
+  },
+
+  getHostProps: function (inst, props) {
+    var hostProps = _assign({ selected: undefined, children: undefined }, props);
+
+    // Read state only from initial mount because <select> updates value
+    // manually; we need the initial state only for server rendering
+    if (inst._wrapperState.selected != null) {
+      hostProps.selected = inst._wrapperState.selected;
+    }
+
+    var content = flattenChildren(props.children);
+
+    if (content) {
+      hostProps.children = content;
+    }
+
+    return hostProps;
+  }
+};
+
+module.exports = ReactDOMOption;
+},{"135":135,"159":159,"160":160,"34":34,"43":43}],43:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var LinkedValueUtils = _dereq_(24);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactUpdates = _dereq_(82);
+
+var warning = _dereq_(159);
+
+var didWarnValueLink = false;
+var didWarnValueDefaultValue = false;
+
+function updateOptionsIfPendingUpdateAndMounted() {
+  if (this._rootNodeID && this._wrapperState.pendingUpdate) {
+    this._wrapperState.pendingUpdate = false;
+
+    var props = this._currentElement.props;
+    var value = LinkedValueUtils.getValue(props);
+
+    if (value != null) {
+      updateOptions(this, Boolean(props.multiple), value);
+    }
+  }
+}
+
+function getDeclarationErrorAddendum(owner) {
+  if (owner) {
+    var name = owner.getName();
+    if (name) {
+      return ' Check the render method of `' + name + '`.';
+    }
+  }
+  return '';
+}
+
+var valuePropNames = ['value', 'defaultValue'];
+
+/**
+ * Validation function for `value` and `defaultValue`.
+ * @private
+ */
+function checkSelectPropTypes(inst, props) {
+  var owner = inst._currentElement._owner;
+  LinkedValueUtils.checkPropTypes('select', props, owner);
+
+  if (props.valueLink !== undefined && !didWarnValueLink) {
+    "development" !== 'production' ? warning(false, '`valueLink` prop on `select` is deprecated; set `value` and `onChange` instead.') : void 0;
+    didWarnValueLink = true;
+  }
+
+  for (var i = 0; i < valuePropNames.length; i++) {
+    var propName = valuePropNames[i];
+    if (props[propName] == null) {
+      continue;
+    }
+    var isArray = Array.isArray(props[propName]);
+    if (props.multiple && !isArray) {
+      "development" !== 'production' ? warning(false, 'The `%s` prop supplied to <select> must be an array if ' + '`multiple` is true.%s', propName, getDeclarationErrorAddendum(owner)) : void 0;
+    } else if (!props.multiple && isArray) {
+      "development" !== 'production' ? warning(false, 'The `%s` prop supplied to <select> must be a scalar ' + 'value if `multiple` is false.%s', propName, getDeclarationErrorAddendum(owner)) : void 0;
+    }
+  }
+}
+
+/**
+ * @param {ReactDOMComponent} inst
+ * @param {boolean} multiple
+ * @param {*} propValue A stringable (with `multiple`, a list of stringables).
+ * @private
+ */
+function updateOptions(inst, multiple, propValue) {
+  var selectedValue, i;
+  var options = ReactDOMComponentTree.getNodeFromInstance(inst).options;
+
+  if (multiple) {
+    selectedValue = {};
+    for (i = 0; i < propValue.length; i++) {
+      selectedValue['' + propValue[i]] = true;
+    }
+    for (i = 0; i < options.length; i++) {
+      var selected = selectedValue.hasOwnProperty(options[i].value);
+      if (options[i].selected !== selected) {
+        options[i].selected = selected;
+      }
+    }
+  } else {
+    // Do not set `select.value` as exact behavior isn't consistent across all
+    // browsers for all cases.
+    selectedValue = '' + propValue;
+    for (i = 0; i < options.length; i++) {
+      if (options[i].value === selectedValue) {
+        options[i].selected = true;
+        return;
+      }
+    }
+    if (options.length) {
+      options[0].selected = true;
+    }
+  }
+}
+
+/**
+ * Implements a <select> host component that allows optionally setting the
+ * props `value` and `defaultValue`. If `multiple` is false, the prop must be a
+ * stringable. If `multiple` is true, the prop must be an array of stringables.
+ *
+ * If `value` is not supplied (or null/undefined), user actions that change the
+ * selected option will trigger updates to the rendered options.
+ *
+ * If it is supplied (and not null/undefined), the rendered options will not
+ * update in response to user actions. Instead, the `value` prop must change in
+ * order for the rendered options to update.
+ *
+ * If `defaultValue` is provided, any options with the supplied values will be
+ * selected.
+ */
+var ReactDOMSelect = {
+  getHostProps: function (inst, props) {
+    return _assign({}, props, {
+      onChange: inst._wrapperState.onChange,
+      value: undefined
+    });
+  },
+
+  mountWrapper: function (inst, props) {
+    if ("development" !== 'production') {
+      checkSelectPropTypes(inst, props);
+    }
+
+    var value = LinkedValueUtils.getValue(props);
+    inst._wrapperState = {
+      pendingUpdate: false,
+      initialValue: value != null ? value : props.defaultValue,
+      listeners: null,
+      onChange: _handleChange.bind(inst),
+      wasMultiple: Boolean(props.multiple)
+    };
+
+    if (props.value !== undefined && props.defaultValue !== undefined && !didWarnValueDefaultValue) {
+      "development" !== 'production' ? warning(false, 'Select elements must be either controlled or uncontrolled ' + '(specify either the value prop, or the defaultValue prop, but not ' + 'both). Decide between using a controlled or uncontrolled select ' + 'element and remove one of these props. More info: ' + 'https://fb.me/react-controlled-components') : void 0;
+      didWarnValueDefaultValue = true;
+    }
+  },
+
+  getSelectValueContext: function (inst) {
+    // ReactDOMOption looks at this initial value so the initial generated
+    // markup has correct `selected` attributes
+    return inst._wrapperState.initialValue;
+  },
+
+  postUpdateWrapper: function (inst) {
+    var props = inst._currentElement.props;
+
+    // After the initial mount, we control selected-ness manually so don't pass
+    // this value down
+    inst._wrapperState.initialValue = undefined;
+
+    var wasMultiple = inst._wrapperState.wasMultiple;
+    inst._wrapperState.wasMultiple = Boolean(props.multiple);
+
+    var value = LinkedValueUtils.getValue(props);
+    if (value != null) {
+      inst._wrapperState.pendingUpdate = false;
+      updateOptions(inst, Boolean(props.multiple), value);
+    } else if (wasMultiple !== Boolean(props.multiple)) {
+      // For simplicity, reapply `defaultValue` if `multiple` is toggled.
+      if (props.defaultValue != null) {
+        updateOptions(inst, Boolean(props.multiple), props.defaultValue);
+      } else {
+        // Revert the select back to its default unselected state.
+        updateOptions(inst, Boolean(props.multiple), props.multiple ? [] : '');
+      }
+    }
+  }
+};
+
+function _handleChange(event) {
+  var props = this._currentElement.props;
+  var returnValue = LinkedValueUtils.executeOnChange(props, event);
+
+  if (this._rootNodeID) {
+    this._wrapperState.pendingUpdate = true;
+  }
+  ReactUpdates.asap(updateOptionsIfPendingUpdateAndMounted, this);
+  return returnValue;
+}
+
+module.exports = ReactDOMSelect;
+},{"159":159,"160":160,"24":24,"34":34,"82":82}],44:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ExecutionEnvironment = _dereq_(138);
+
+var getNodeForCharacterOffset = _dereq_(117);
+var getTextContentAccessor = _dereq_(118);
+
+/**
+ * While `isCollapsed` is available on the Selection object and `collapsed`
+ * is available on the Range object, IE11 sometimes gets them wrong.
+ * If the anchor/focus nodes and offsets are the same, the range is collapsed.
+ */
+function isCollapsed(anchorNode, anchorOffset, focusNode, focusOffset) {
+  return anchorNode === focusNode && anchorOffset === focusOffset;
+}
+
+/**
+ * Get the appropriate anchor and focus node/offset pairs for IE.
+ *
+ * The catch here is that IE's selection API doesn't provide information
+ * about whether the selection is forward or backward, so we have to
+ * behave as though it's always forward.
+ *
+ * IE text differs from modern selection in that it behaves as though
+ * block elements end with a new line. This means character offsets will
+ * differ between the two APIs.
+ *
+ * @param {DOMElement} node
+ * @return {object}
+ */
+function getIEOffsets(node) {
+  var selection = document.selection;
+  var selectedRange = selection.createRange();
+  var selectedLength = selectedRange.text.length;
+
+  // Duplicate selection so we can move range without breaking user selection.
+  var fromStart = selectedRange.duplicate();
+  fromStart.moveToElementText(node);
+  fromStart.setEndPoint('EndToStart', selectedRange);
+
+  var startOffset = fromStart.text.length;
+  var endOffset = startOffset + selectedLength;
+
+  return {
+    start: startOffset,
+    end: endOffset
+  };
+}
+
+/**
+ * @param {DOMElement} node
+ * @return {?object}
+ */
+function getModernOffsets(node) {
+  var selection = window.getSelection && window.getSelection();
+
+  if (!selection || selection.rangeCount === 0) {
+    return null;
+  }
+
+  var anchorNode = selection.anchorNode;
+  var anchorOffset = selection.anchorOffset;
+  var focusNode = selection.focusNode;
+  var focusOffset = selection.focusOffset;
+
+  var currentRange = selection.getRangeAt(0);
+
+  // In Firefox, range.startContainer and range.endContainer can be "anonymous
+  // divs", e.g. the up/down buttons on an <input type="number">. Anonymous
+  // divs do not seem to expose properties, triggering a "Permission denied
+  // error" if any of its properties are accessed. The only seemingly possible
+  // way to avoid erroring is to access a property that typically works for
+  // non-anonymous divs and catch any error that may otherwise arise. See
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=208427
+  try {
+    /* eslint-disable no-unused-expressions */
+    currentRange.startContainer.nodeType;
+    currentRange.endContainer.nodeType;
+    /* eslint-enable no-unused-expressions */
+  } catch (e) {
+    return null;
+  }
+
+  // If the node and offset values are the same, the selection is collapsed.
+  // `Selection.isCollapsed` is available natively, but IE sometimes gets
+  // this value wrong.
+  var isSelectionCollapsed = isCollapsed(selection.anchorNode, selection.anchorOffset, selection.focusNode, selection.focusOffset);
+
+  var rangeLength = isSelectionCollapsed ? 0 : currentRange.toString().length;
+
+  var tempRange = currentRange.cloneRange();
+  tempRange.selectNodeContents(node);
+  tempRange.setEnd(currentRange.startContainer, currentRange.startOffset);
+
+  var isTempRangeCollapsed = isCollapsed(tempRange.startContainer, tempRange.startOffset, tempRange.endContainer, tempRange.endOffset);
+
+  var start = isTempRangeCollapsed ? 0 : tempRange.toString().length;
+  var end = start + rangeLength;
+
+  // Detect whether the selection is backward.
+  var detectionRange = document.createRange();
+  detectionRange.setStart(anchorNode, anchorOffset);
+  detectionRange.setEnd(focusNode, focusOffset);
+  var isBackward = detectionRange.collapsed;
+
+  return {
+    start: isBackward ? end : start,
+    end: isBackward ? start : end
+  };
+}
+
+/**
+ * @param {DOMElement|DOMTextNode} node
+ * @param {object} offsets
+ */
+function setIEOffsets(node, offsets) {
+  var range = document.selection.createRange().duplicate();
+  var start, end;
+
+  if (offsets.end === undefined) {
+    start = offsets.start;
+    end = start;
+  } else if (offsets.start > offsets.end) {
+    start = offsets.end;
+    end = offsets.start;
+  } else {
+    start = offsets.start;
+    end = offsets.end;
+  }
+
+  range.moveToElementText(node);
+  range.moveStart('character', start);
+  range.setEndPoint('EndToStart', range);
+  range.moveEnd('character', end - start);
+  range.select();
+}
+
+/**
+ * In modern non-IE browsers, we can support both forward and backward
+ * selections.
+ *
+ * Note: IE10+ supports the Selection object, but it does not support
+ * the `extend` method, which means that even in modern IE, it's not possible
+ * to programmatically create a backward selection. Thus, for all IE
+ * versions, we use the old IE API to create our selections.
+ *
+ * @param {DOMElement|DOMTextNode} node
+ * @param {object} offsets
+ */
+function setModernOffsets(node, offsets) {
+  if (!window.getSelection) {
+    return;
+  }
+
+  var selection = window.getSelection();
+  var length = node[getTextContentAccessor()].length;
+  var start = Math.min(offsets.start, length);
+  var end = offsets.end === undefined ? start : Math.min(offsets.end, length);
+
+  // IE 11 uses modern selection, but doesn't support the extend method.
+  // Flip backward selections, so we can set with a single range.
+  if (!selection.extend && start > end) {
+    var temp = end;
+    end = start;
+    start = temp;
+  }
+
+  var startMarker = getNodeForCharacterOffset(node, start);
+  var endMarker = getNodeForCharacterOffset(node, end);
+
+  if (startMarker && endMarker) {
+    var range = document.createRange();
+    range.setStart(startMarker.node, startMarker.offset);
+    selection.removeAllRanges();
+
+    if (start > end) {
+      selection.addRange(range);
+      selection.extend(endMarker.node, endMarker.offset);
+    } else {
+      range.setEnd(endMarker.node, endMarker.offset);
+      selection.addRange(range);
+    }
+  }
+}
+
+var useIEOffsets = ExecutionEnvironment.canUseDOM && 'selection' in document && !('getSelection' in window);
+
+var ReactDOMSelection = {
+  /**
+   * @param {DOMElement} node
+   */
+  getOffsets: useIEOffsets ? getIEOffsets : getModernOffsets,
+
+  /**
+   * @param {DOMElement|DOMTextNode} node
+   * @param {object} offsets
+   */
+  setOffsets: useIEOffsets ? setIEOffsets : setModernOffsets
+};
+
+module.exports = ReactDOMSelection;
+},{"117":117,"118":118,"138":138}],45:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126),
+    _assign = _dereq_(160);
+
+var DOMChildrenOperations = _dereq_(8);
+var DOMLazyTree = _dereq_(9);
+var ReactDOMComponentTree = _dereq_(34);
+
+var escapeTextContentForBrowser = _dereq_(107);
+var invariant = _dereq_(152);
+var validateDOMNesting = _dereq_(132);
+
+/**
+ * Text nodes violate a couple assumptions that React makes about components:
+ *
+ *  - When mounting text into the DOM, adjacent text nodes are merged.
+ *  - Text nodes cannot be assigned a React root ID.
+ *
+ * This component is used to wrap strings between comment nodes so that they
+ * can undergo the same reconciliation that is applied to elements.
+ *
+ * TODO: Investigate representing React components in the DOM with text nodes.
+ *
+ * @class ReactDOMTextComponent
+ * @extends ReactComponent
+ * @internal
+ */
+var ReactDOMTextComponent = function (text) {
+  // TODO: This is really a ReactText (ReactNode), not a ReactElement
+  this._currentElement = text;
+  this._stringText = '' + text;
+  // ReactDOMComponentTree uses these:
+  this._hostNode = null;
+  this._hostParent = null;
+
+  // Properties
+  this._domID = 0;
+  this._mountIndex = 0;
+  this._closingComment = null;
+  this._commentNodes = null;
+};
+
+_assign(ReactDOMTextComponent.prototype, {
+  /**
+   * Creates the markup for this text node. This node is not intended to have
+   * any features besides containing text content.
+   *
+   * @param {ReactReconcileTransaction|ReactServerRenderingTransaction} transaction
+   * @return {string} Markup for this text node.
+   * @internal
+   */
+  mountComponent: function (transaction, hostParent, hostContainerInfo, context) {
+    if ("development" !== 'production') {
+      var parentInfo;
+      if (hostParent != null) {
+        parentInfo = hostParent._ancestorInfo;
+      } else if (hostContainerInfo != null) {
+        parentInfo = hostContainerInfo._ancestorInfo;
+      }
+      if (parentInfo) {
+        // parentInfo should always be present except for the top-level
+        // component when server rendering
+        validateDOMNesting(null, this._stringText, this, parentInfo);
+      }
+    }
+
+    var domID = hostContainerInfo._idCounter++;
+    var openingValue = ' react-text: ' + domID + ' ';
+    var closingValue = ' /react-text ';
+    this._domID = domID;
+    this._hostParent = hostParent;
+    if (transaction.useCreateElement) {
+      var ownerDocument = hostContainerInfo._ownerDocument;
+      var openingComment = ownerDocument.createComment(openingValue);
+      var closingComment = ownerDocument.createComment(closingValue);
+      var lazyTree = DOMLazyTree(ownerDocument.createDocumentFragment());
+      DOMLazyTree.queueChild(lazyTree, DOMLazyTree(openingComment));
+      if (this._stringText) {
+        DOMLazyTree.queueChild(lazyTree, DOMLazyTree(ownerDocument.createTextNode(this._stringText)));
+      }
+      DOMLazyTree.queueChild(lazyTree, DOMLazyTree(closingComment));
+      ReactDOMComponentTree.precacheNode(this, openingComment);
+      this._closingComment = closingComment;
+      return lazyTree;
+    } else {
+      var escapedText = escapeTextContentForBrowser(this._stringText);
+
+      if (transaction.renderToStaticMarkup) {
+        // Normally we'd wrap this between comment nodes for the reasons stated
+        // above, but since this is a situation where React won't take over
+        // (static pages), we can simply return the text as it is.
+        return escapedText;
+      }
+
+      return '<!--' + openingValue + '-->' + escapedText + '<!--' + closingValue + '-->';
+    }
+  },
+
+  /**
+   * Updates this component by updating the text content.
+   *
+   * @param {ReactText} nextText The next text content
+   * @param {ReactReconcileTransaction} transaction
+   * @internal
+   */
+  receiveComponent: function (nextText, transaction) {
+    if (nextText !== this._currentElement) {
+      this._currentElement = nextText;
+      var nextStringText = '' + nextText;
+      if (nextStringText !== this._stringText) {
+        // TODO: Save this as pending props and use performUpdateIfNecessary
+        // and/or updateComponent to do the actual update for consistency with
+        // other component types?
+        this._stringText = nextStringText;
+        var commentNodes = this.getHostNode();
+        DOMChildrenOperations.replaceDelimitedText(commentNodes[0], commentNodes[1], nextStringText);
+      }
+    }
+  },
+
+  getHostNode: function () {
+    var hostNode = this._commentNodes;
+    if (hostNode) {
+      return hostNode;
+    }
+    if (!this._closingComment) {
+      var openingComment = ReactDOMComponentTree.getNodeFromInstance(this);
+      var node = openingComment.nextSibling;
+      while (true) {
+        !(node != null) ? "development" !== 'production' ? invariant(false, 'Missing closing comment for text component %s', this._domID) : _prodInvariant('67', this._domID) : void 0;
+        if (node.nodeType === 8 && node.nodeValue === ' /react-text ') {
+          this._closingComment = node;
+          break;
+        }
+        node = node.nextSibling;
+      }
+    }
+    hostNode = [this._hostNode, this._closingComment];
+    this._commentNodes = hostNode;
+    return hostNode;
+  },
+
+  unmountComponent: function () {
+    this._closingComment = null;
+    this._commentNodes = null;
+    ReactDOMComponentTree.uncacheNode(this);
+  }
+});
+
+module.exports = ReactDOMTextComponent;
+},{"107":107,"126":126,"132":132,"152":152,"160":160,"34":34,"8":8,"9":9}],46:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126),
+    _assign = _dereq_(160);
+
+var LinkedValueUtils = _dereq_(24);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactUpdates = _dereq_(82);
+
+var invariant = _dereq_(152);
+var warning = _dereq_(159);
+
+var didWarnValueLink = false;
+var didWarnValDefaultVal = false;
+
+function forceUpdateIfMounted() {
+  if (this._rootNodeID) {
+    // DOM component is still mounted; update
+    ReactDOMTextarea.updateWrapper(this);
+  }
+}
+
+/**
+ * Implements a <textarea> host component that allows setting `value`, and
+ * `defaultValue`. This differs from the traditional DOM API because value is
+ * usually set as PCDATA children.
+ *
+ * If `value` is not supplied (or null/undefined), user actions that affect the
+ * value will trigger updates to the element.
+ *
+ * If `value` is supplied (and not null/undefined), the rendered element will
+ * not trigger updates to the element. Instead, the `value` prop must change in
+ * order for the rendered element to be updated.
+ *
+ * The rendered element will be initialized with an empty value, the prop
+ * `defaultValue` if specified, or the children content (deprecated).
+ */
+var ReactDOMTextarea = {
+  getHostProps: function (inst, props) {
+    !(props.dangerouslySetInnerHTML == null) ? "development" !== 'production' ? invariant(false, '`dangerouslySetInnerHTML` does not make sense on <textarea>.') : _prodInvariant('91') : void 0;
+
+    // Always set children to the same thing. In IE9, the selection range will
+    // get reset if `textContent` is mutated.  We could add a check in setTextContent
+    // to only set the value if/when the value differs from the node value (which would
+    // completely solve this IE9 bug), but Sebastian+Ben seemed to like this solution.
+    // The value can be a boolean or object so that's why it's forced to be a string.
+    var hostProps = _assign({}, props, {
+      value: undefined,
+      defaultValue: undefined,
+      children: '' + inst._wrapperState.initialValue,
+      onChange: inst._wrapperState.onChange
+    });
+
+    return hostProps;
+  },
+
+  mountWrapper: function (inst, props) {
+    if ("development" !== 'production') {
+      LinkedValueUtils.checkPropTypes('textarea', props, inst._currentElement._owner);
+      if (props.valueLink !== undefined && !didWarnValueLink) {
+        "development" !== 'production' ? warning(false, '`valueLink` prop on `textarea` is deprecated; set `value` and `onChange` instead.') : void 0;
+        didWarnValueLink = true;
+      }
+      if (props.value !== undefined && props.defaultValue !== undefined && !didWarnValDefaultVal) {
+        "development" !== 'production' ? warning(false, 'Textarea elements must be either controlled or uncontrolled ' + '(specify either the value prop, or the defaultValue prop, but not ' + 'both). Decide between using a controlled or uncontrolled textarea ' + 'and remove one of these props. More info: ' + 'https://fb.me/react-controlled-components') : void 0;
+        didWarnValDefaultVal = true;
+      }
+    }
+
+    var value = LinkedValueUtils.getValue(props);
+    var initialValue = value;
+
+    // Only bother fetching default value if we're going to use it
+    if (value == null) {
+      var defaultValue = props.defaultValue;
+      // TODO (yungsters): Remove support for children content in <textarea>.
+      var children = props.children;
+      if (children != null) {
+        if ("development" !== 'production') {
+          "development" !== 'production' ? warning(false, 'Use the `defaultValue` or `value` props instead of setting ' + 'children on <textarea>.') : void 0;
+        }
+        !(defaultValue == null) ? "development" !== 'production' ? invariant(false, 'If you supply `defaultValue` on a <textarea>, do not pass children.') : _prodInvariant('92') : void 0;
+        if (Array.isArray(children)) {
+          !(children.length <= 1) ? "development" !== 'production' ? invariant(false, '<textarea> can only have at most one child.') : _prodInvariant('93') : void 0;
+          children = children[0];
+        }
+
+        defaultValue = '' + children;
+      }
+      if (defaultValue == null) {
+        defaultValue = '';
+      }
+      initialValue = defaultValue;
+    }
+
+    inst._wrapperState = {
+      initialValue: '' + initialValue,
+      listeners: null,
+      onChange: _handleChange.bind(inst)
+    };
+  },
+
+  updateWrapper: function (inst) {
+    var props = inst._currentElement.props;
+
+    var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+    var value = LinkedValueUtils.getValue(props);
+    if (value != null) {
+      // Cast `value` to a string to ensure the value is set correctly. While
+      // browsers typically do this as necessary, jsdom doesn't.
+      var newValue = '' + value;
+
+      // To avoid side effects (such as losing text selection), only set value if changed
+      if (newValue !== node.value) {
+        node.value = newValue;
+      }
+      if (props.defaultValue == null) {
+        node.defaultValue = newValue;
+      }
+    }
+    if (props.defaultValue != null) {
+      node.defaultValue = props.defaultValue;
+    }
+  },
+
+  postMountWrapper: function (inst) {
+    // This is in postMount because we need access to the DOM node, which is not
+    // available until after the component has mounted.
+    var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+    var textContent = node.textContent;
+
+    // Only set node.value if textContent is equal to the expected
+    // initial value. In IE10/IE11 there is a bug where the placeholder attribute
+    // will populate textContent as well.
+    // https://developer.microsoft.com/microsoft-edge/platform/issues/101525/
+    if (textContent === inst._wrapperState.initialValue) {
+      node.value = textContent;
+    }
+  }
+};
+
+function _handleChange(event) {
+  var props = this._currentElement.props;
+  var returnValue = LinkedValueUtils.executeOnChange(props, event);
+  ReactUpdates.asap(forceUpdateIfMounted, this);
+  return returnValue;
+}
+
+module.exports = ReactDOMTextarea;
+},{"126":126,"152":152,"159":159,"160":160,"24":24,"34":34,"82":82}],47:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var invariant = _dereq_(152);
+
+/**
+ * Return the lowest common ancestor of A and B, or null if they are in
+ * different trees.
+ */
+function getLowestCommonAncestor(instA, instB) {
+  !('_hostNode' in instA) ? "development" !== 'production' ? invariant(false, 'getNodeFromInstance: Invalid argument.') : _prodInvariant('33') : void 0;
+  !('_hostNode' in instB) ? "development" !== 'production' ? invariant(false, 'getNodeFromInstance: Invalid argument.') : _prodInvariant('33') : void 0;
+
+  var depthA = 0;
+  for (var tempA = instA; tempA; tempA = tempA._hostParent) {
+    depthA++;
+  }
+  var depthB = 0;
+  for (var tempB = instB; tempB; tempB = tempB._hostParent) {
+    depthB++;
+  }
+
+  // If A is deeper, crawl up.
+  while (depthA - depthB > 0) {
+    instA = instA._hostParent;
+    depthA--;
+  }
+
+  // If B is deeper, crawl up.
+  while (depthB - depthA > 0) {
+    instB = instB._hostParent;
+    depthB--;
+  }
+
+  // Walk in lockstep until we find a match.
+  var depth = depthA;
+  while (depth--) {
+    if (instA === instB) {
+      return instA;
+    }
+    instA = instA._hostParent;
+    instB = instB._hostParent;
+  }
+  return null;
+}
+
+/**
+ * Return if A is an ancestor of B.
+ */
+function isAncestor(instA, instB) {
+  !('_hostNode' in instA) ? "development" !== 'production' ? invariant(false, 'isAncestor: Invalid argument.') : _prodInvariant('35') : void 0;
+  !('_hostNode' in instB) ? "development" !== 'production' ? invariant(false, 'isAncestor: Invalid argument.') : _prodInvariant('35') : void 0;
+
+  while (instB) {
+    if (instB === instA) {
+      return true;
+    }
+    instB = instB._hostParent;
+  }
+  return false;
+}
+
+/**
+ * Return the parent instance of the passed-in instance.
+ */
+function getParentInstance(inst) {
+  !('_hostNode' in inst) ? "development" !== 'production' ? invariant(false, 'getParentInstance: Invalid argument.') : _prodInvariant('36') : void 0;
+
+  return inst._hostParent;
+}
+
+/**
+ * Simulates the traversal of a two-phase, capture/bubble event dispatch.
+ */
+function traverseTwoPhase(inst, fn, arg) {
+  var path = [];
+  while (inst) {
+    path.push(inst);
+    inst = inst._hostParent;
+  }
+  var i;
+  for (i = path.length; i-- > 0;) {
+    fn(path[i], 'captured', arg);
+  }
+  for (i = 0; i < path.length; i++) {
+    fn(path[i], 'bubbled', arg);
+  }
+}
+
+/**
+ * Traverses the ID hierarchy and invokes the supplied `cb` on any IDs that
+ * should would receive a `mouseEnter` or `mouseLeave` event.
+ *
+ * Does not invoke the callback on the nearest common ancestor because nothing
+ * "entered" or "left" that element.
+ */
+function traverseEnterLeave(from, to, fn, argFrom, argTo) {
+  var common = from && to ? getLowestCommonAncestor(from, to) : null;
+  var pathFrom = [];
+  while (from && from !== common) {
+    pathFrom.push(from);
+    from = from._hostParent;
+  }
+  var pathTo = [];
+  while (to && to !== common) {
+    pathTo.push(to);
+    to = to._hostParent;
+  }
+  var i;
+  for (i = 0; i < pathFrom.length; i++) {
+    fn(pathFrom[i], 'bubbled', argFrom);
+  }
+  for (i = pathTo.length; i-- > 0;) {
+    fn(pathTo[i], 'captured', argTo);
+  }
+}
+
+module.exports = {
+  isAncestor: isAncestor,
+  getLowestCommonAncestor: getLowestCommonAncestor,
+  getParentInstance: getParentInstance,
+  traverseTwoPhase: traverseTwoPhase,
+  traverseEnterLeave: traverseEnterLeave
+};
+},{"126":126,"152":152}],48:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var React = _dereq_(135);
+var ReactDOM = _dereq_(31);
+
+var ReactDOMUMDEntry = ReactDOM;
+
+if ("development" !== 'production') {
+  ReactDOMUMDEntry.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = {
+    // ReactPerf and ReactTestUtils currently only work with the DOM renderer
+    // so we expose them from here, but only in DEV mode.
+    ReactPerf: _dereq_(71),
+    ReactTestUtils: _dereq_(80)
+  };
+}
+
+// Inject ReactDOM into React for the addons UMD build that depends on ReactDOM (TransitionGroup).
+// We can remove this after we deprecate and remove the addons UMD build.
+if (React.addons) {
+  React.__SECRET_INJECTED_REACT_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = ReactDOMUMDEntry;
+}
+
+module.exports = ReactDOMUMDEntry;
+},{"135":135,"31":31,"71":71,"80":80}],49:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var DOMProperty = _dereq_(11);
+var EventPluginRegistry = _dereq_(18);
+var ReactComponentTreeHook = _dereq_(133);
+
+var warning = _dereq_(159);
+
+if ("development" !== 'production') {
+  var reactProps = {
+    children: true,
+    dangerouslySetInnerHTML: true,
+    key: true,
+    ref: true,
+
+    autoFocus: true,
+    defaultValue: true,
+    valueLink: true,
+    defaultChecked: true,
+    checkedLink: true,
+    innerHTML: true,
+    suppressContentEditableWarning: true,
+    onFocusIn: true,
+    onFocusOut: true
+  };
+  var warnedProperties = {};
+
+  var validateProperty = function (tagName, name, debugID) {
+    if (DOMProperty.properties.hasOwnProperty(name) || DOMProperty.isCustomAttribute(name)) {
+      return true;
+    }
+    if (reactProps.hasOwnProperty(name) && reactProps[name] || warnedProperties.hasOwnProperty(name) && warnedProperties[name]) {
+      return true;
+    }
+    if (EventPluginRegistry.registrationNameModules.hasOwnProperty(name)) {
+      return true;
+    }
+    warnedProperties[name] = true;
+    var lowerCasedName = name.toLowerCase();
+
+    // data-* attributes should be lowercase; suggest the lowercase version
+    var standardName = DOMProperty.isCustomAttribute(lowerCasedName) ? lowerCasedName : DOMProperty.getPossibleStandardName.hasOwnProperty(lowerCasedName) ? DOMProperty.getPossibleStandardName[lowerCasedName] : null;
+
+    var registrationName = EventPluginRegistry.possibleRegistrationNames.hasOwnProperty(lowerCasedName) ? EventPluginRegistry.possibleRegistrationNames[lowerCasedName] : null;
+
+    if (standardName != null) {
+      "development" !== 'production' ? warning(false, 'Unknown DOM property %s. Did you mean %s?%s', name, standardName, ReactComponentTreeHook.getStackAddendumByID(debugID)) : void 0;
+      return true;
+    } else if (registrationName != null) {
+      "development" !== 'production' ? warning(false, 'Unknown event handler property %s. Did you mean `%s`?%s', name, registrationName, ReactComponentTreeHook.getStackAddendumByID(debugID)) : void 0;
+      return true;
+    } else {
+      // We were unable to guess which prop the user intended.
+      // It is likely that the user was just blindly spreading/forwarding props
+      // Components should be careful to only render valid props/attributes.
+      // Warning will be invoked in warnUnknownProperties to allow grouping.
+      return false;
+    }
+  };
+}
+
+var warnUnknownProperties = function (debugID, element) {
+  var unknownProps = [];
+  for (var key in element.props) {
+    var isValid = validateProperty(element.type, key, debugID);
+    if (!isValid) {
+      unknownProps.push(key);
+    }
+  }
+
+  var unknownPropString = unknownProps.map(function (prop) {
+    return '`' + prop + '`';
+  }).join(', ');
+
+  if (unknownProps.length === 1) {
+    "development" !== 'production' ? warning(false, 'Unknown prop %s on <%s> tag. Remove this prop from the element. ' + 'For details, see https://fb.me/react-unknown-prop%s', unknownPropString, element.type, ReactComponentTreeHook.getStackAddendumByID(debugID)) : void 0;
+  } else if (unknownProps.length > 1) {
+    "development" !== 'production' ? warning(false, 'Unknown props %s on <%s> tag. Remove these props from the element. ' + 'For details, see https://fb.me/react-unknown-prop%s', unknownPropString, element.type, ReactComponentTreeHook.getStackAddendumByID(debugID)) : void 0;
+  }
+};
+
+function handleElement(debugID, element) {
+  if (element == null || typeof element.type !== 'string') {
+    return;
+  }
+  if (element.type.indexOf('-') >= 0 || element.props.is) {
+    return;
+  }
+  warnUnknownProperties(debugID, element);
+}
+
+var ReactDOMUnknownPropertyHook = {
+  onBeforeMountComponent: function (debugID, element) {
+    handleElement(debugID, element);
+  },
+  onBeforeUpdateComponent: function (debugID, element) {
+    handleElement(debugID, element);
+  }
+};
+
+module.exports = ReactDOMUnknownPropertyHook;
+},{"11":11,"133":133,"159":159,"18":18}],50:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var ReactInvalidSetStateWarningHook = _dereq_(65);
+var ReactHostOperationHistoryHook = _dereq_(60);
+var ReactComponentTreeHook = _dereq_(133);
+var ExecutionEnvironment = _dereq_(138);
+
+var performanceNow = _dereq_(157);
+var warning = _dereq_(159);
+
+var hooks = [];
+var didHookThrowForEvent = {};
+
+function callHook(event, fn, context, arg1, arg2, arg3, arg4, arg5) {
+  try {
+    fn.call(context, arg1, arg2, arg3, arg4, arg5);
+  } catch (e) {
+    "development" !== 'production' ? warning(didHookThrowForEvent[event], 'Exception thrown by hook while handling %s: %s', event, e + '\n' + e.stack) : void 0;
+    didHookThrowForEvent[event] = true;
+  }
+}
+
+function emitEvent(event, arg1, arg2, arg3, arg4, arg5) {
+  for (var i = 0; i < hooks.length; i++) {
+    var hook = hooks[i];
+    var fn = hook[event];
+    if (fn) {
+      callHook(event, fn, hook, arg1, arg2, arg3, arg4, arg5);
+    }
+  }
+}
+
+var isProfiling = false;
+var flushHistory = [];
+var lifeCycleTimerStack = [];
+var currentFlushNesting = 0;
+var currentFlushMeasurements = [];
+var currentFlushStartTime = 0;
+var currentTimerDebugID = null;
+var currentTimerStartTime = 0;
+var currentTimerNestedFlushDuration = 0;
+var currentTimerType = null;
+
+var lifeCycleTimerHasWarned = false;
+
+function clearHistory() {
+  ReactComponentTreeHook.purgeUnmountedComponents();
+  ReactHostOperationHistoryHook.clearHistory();
+}
+
+function getTreeSnapshot(registeredIDs) {
+  return registeredIDs.reduce(function (tree, id) {
+    var ownerID = ReactComponentTreeHook.getOwnerID(id);
+    var parentID = ReactComponentTreeHook.getParentID(id);
+    tree[id] = {
+      displayName: ReactComponentTreeHook.getDisplayName(id),
+      text: ReactComponentTreeHook.getText(id),
+      updateCount: ReactComponentTreeHook.getUpdateCount(id),
+      childIDs: ReactComponentTreeHook.getChildIDs(id),
+      // Text nodes don't have owners but this is close enough.
+      ownerID: ownerID || parentID && ReactComponentTreeHook.getOwnerID(parentID) || 0,
+      parentID: parentID
+    };
+    return tree;
+  }, {});
+}
+
+function resetMeasurements() {
+  var previousStartTime = currentFlushStartTime;
+  var previousMeasurements = currentFlushMeasurements;
+  var previousOperations = ReactHostOperationHistoryHook.getHistory();
+
+  if (currentFlushNesting === 0) {
+    currentFlushStartTime = 0;
+    currentFlushMeasurements = [];
+    clearHistory();
+    return;
+  }
+
+  if (previousMeasurements.length || previousOperations.length) {
+    var registeredIDs = ReactComponentTreeHook.getRegisteredIDs();
+    flushHistory.push({
+      duration: performanceNow() - previousStartTime,
+      measurements: previousMeasurements || [],
+      operations: previousOperations || [],
+      treeSnapshot: getTreeSnapshot(registeredIDs)
+    });
+  }
+
+  clearHistory();
+  currentFlushStartTime = performanceNow();
+  currentFlushMeasurements = [];
+}
+
+function checkDebugID(debugID) {
+  var allowRoot = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+
+  if (allowRoot && debugID === 0) {
+    return;
+  }
+  if (!debugID) {
+    "development" !== 'production' ? warning(false, 'ReactDebugTool: debugID may not be empty.') : void 0;
+  }
+}
+
+function beginLifeCycleTimer(debugID, timerType) {
+  if (currentFlushNesting === 0) {
+    return;
+  }
+  if (currentTimerType && !lifeCycleTimerHasWarned) {
+    "development" !== 'production' ? warning(false, 'There is an internal error in the React performance measurement code. ' + 'Did not expect %s timer to start while %s timer is still in ' + 'progress for %s instance.', timerType, currentTimerType || 'no', debugID === currentTimerDebugID ? 'the same' : 'another') : void 0;
+    lifeCycleTimerHasWarned = true;
+  }
+  currentTimerStartTime = performanceNow();
+  currentTimerNestedFlushDuration = 0;
+  currentTimerDebugID = debugID;
+  currentTimerType = timerType;
+}
+
+function endLifeCycleTimer(debugID, timerType) {
+  if (currentFlushNesting === 0) {
+    return;
+  }
+  if (currentTimerType !== timerType && !lifeCycleTimerHasWarned) {
+    "development" !== 'production' ? warning(false, 'There is an internal error in the React performance measurement code. ' + 'We did not expect %s timer to stop while %s timer is still in ' + 'progress for %s instance. Please report this as a bug in React.', timerType, currentTimerType || 'no', debugID === currentTimerDebugID ? 'the same' : 'another') : void 0;
+    lifeCycleTimerHasWarned = true;
+  }
+  if (isProfiling) {
+    currentFlushMeasurements.push({
+      timerType: timerType,
+      instanceID: debugID,
+      duration: performanceNow() - currentTimerStartTime - currentTimerNestedFlushDuration
+    });
+  }
+  currentTimerStartTime = 0;
+  currentTimerNestedFlushDuration = 0;
+  currentTimerDebugID = null;
+  currentTimerType = null;
+}
+
+function pauseCurrentLifeCycleTimer() {
+  var currentTimer = {
+    startTime: currentTimerStartTime,
+    nestedFlushStartTime: performanceNow(),
+    debugID: currentTimerDebugID,
+    timerType: currentTimerType
+  };
+  lifeCycleTimerStack.push(currentTimer);
+  currentTimerStartTime = 0;
+  currentTimerNestedFlushDuration = 0;
+  currentTimerDebugID = null;
+  currentTimerType = null;
+}
+
+function resumeCurrentLifeCycleTimer() {
+  var _lifeCycleTimerStack$ = lifeCycleTimerStack.pop(),
+      startTime = _lifeCycleTimerStack$.startTime,
+      nestedFlushStartTime = _lifeCycleTimerStack$.nestedFlushStartTime,
+      debugID = _lifeCycleTimerStack$.debugID,
+      timerType = _lifeCycleTimerStack$.timerType;
+
+  var nestedFlushDuration = performanceNow() - nestedFlushStartTime;
+  currentTimerStartTime = startTime;
+  currentTimerNestedFlushDuration += nestedFlushDuration;
+  currentTimerDebugID = debugID;
+  currentTimerType = timerType;
+}
+
+var lastMarkTimeStamp = 0;
+var canUsePerformanceMeasure = typeof performance !== 'undefined' && typeof performance.mark === 'function' && typeof performance.clearMarks === 'function' && typeof performance.measure === 'function' && typeof performance.clearMeasures === 'function';
+
+function shouldMark(debugID) {
+  if (!isProfiling || !canUsePerformanceMeasure) {
+    return false;
+  }
+  var element = ReactComponentTreeHook.getElement(debugID);
+  if (element == null || typeof element !== 'object') {
+    return false;
+  }
+  var isHostElement = typeof element.type === 'string';
+  if (isHostElement) {
+    return false;
+  }
+  return true;
+}
+
+function markBegin(debugID, markType) {
+  if (!shouldMark(debugID)) {
+    return;
+  }
+
+  var markName = debugID + '::' + markType;
+  lastMarkTimeStamp = performanceNow();
+  performance.mark(markName);
+}
+
+function markEnd(debugID, markType) {
+  if (!shouldMark(debugID)) {
+    return;
+  }
+
+  var markName = debugID + '::' + markType;
+  var displayName = ReactComponentTreeHook.getDisplayName(debugID) || 'Unknown';
+
+  // Chrome has an issue of dropping markers recorded too fast:
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=640652
+  // To work around this, we will not report very small measurements.
+  // I determined the magic number by tweaking it back and forth.
+  // 0.05ms was enough to prevent the issue, but I set it to 0.1ms to be safe.
+  // When the bug is fixed, we can `measure()` unconditionally if we want to.
+  var timeStamp = performanceNow();
+  if (timeStamp - lastMarkTimeStamp > 0.1) {
+    var measurementName = displayName + ' [' + markType + ']';
+    performance.measure(measurementName, markName);
+  }
+
+  performance.clearMarks(markName);
+  if (measurementName) {
+    performance.clearMeasures(measurementName);
+  }
+}
+
+var ReactDebugTool = {
+  addHook: function (hook) {
+    hooks.push(hook);
+  },
+  removeHook: function (hook) {
+    for (var i = 0; i < hooks.length; i++) {
+      if (hooks[i] === hook) {
+        hooks.splice(i, 1);
+        i--;
+      }
+    }
+  },
+  isProfiling: function () {
+    return isProfiling;
+  },
+  beginProfiling: function () {
+    if (isProfiling) {
+      return;
+    }
+
+    isProfiling = true;
+    flushHistory.length = 0;
+    resetMeasurements();
+    ReactDebugTool.addHook(ReactHostOperationHistoryHook);
+  },
+  endProfiling: function () {
+    if (!isProfiling) {
+      return;
+    }
+
+    isProfiling = false;
+    resetMeasurements();
+    ReactDebugTool.removeHook(ReactHostOperationHistoryHook);
+  },
+  getFlushHistory: function () {
+    return flushHistory;
+  },
+  onBeginFlush: function () {
+    currentFlushNesting++;
+    resetMeasurements();
+    pauseCurrentLifeCycleTimer();
+    emitEvent('onBeginFlush');
+  },
+  onEndFlush: function () {
+    resetMeasurements();
+    currentFlushNesting--;
+    resumeCurrentLifeCycleTimer();
+    emitEvent('onEndFlush');
+  },
+  onBeginLifeCycleTimer: function (debugID, timerType) {
+    checkDebugID(debugID);
+    emitEvent('onBeginLifeCycleTimer', debugID, timerType);
+    markBegin(debugID, timerType);
+    beginLifeCycleTimer(debugID, timerType);
+  },
+  onEndLifeCycleTimer: function (debugID, timerType) {
+    checkDebugID(debugID);
+    endLifeCycleTimer(debugID, timerType);
+    markEnd(debugID, timerType);
+    emitEvent('onEndLifeCycleTimer', debugID, timerType);
+  },
+  onBeginProcessingChildContext: function () {
+    emitEvent('onBeginProcessingChildContext');
+  },
+  onEndProcessingChildContext: function () {
+    emitEvent('onEndProcessingChildContext');
+  },
+  onHostOperation: function (operation) {
+    checkDebugID(operation.instanceID);
+    emitEvent('onHostOperation', operation);
+  },
+  onSetState: function () {
+    emitEvent('onSetState');
+  },
+  onSetChildren: function (debugID, childDebugIDs) {
+    checkDebugID(debugID);
+    childDebugIDs.forEach(checkDebugID);
+    emitEvent('onSetChildren', debugID, childDebugIDs);
+  },
+  onBeforeMountComponent: function (debugID, element, parentDebugID) {
+    checkDebugID(debugID);
+    checkDebugID(parentDebugID, true);
+    emitEvent('onBeforeMountComponent', debugID, element, parentDebugID);
+    markBegin(debugID, 'mount');
+  },
+  onMountComponent: function (debugID) {
+    checkDebugID(debugID);
+    markEnd(debugID, 'mount');
+    emitEvent('onMountComponent', debugID);
+  },
+  onBeforeUpdateComponent: function (debugID, element) {
+    checkDebugID(debugID);
+    emitEvent('onBeforeUpdateComponent', debugID, element);
+    markBegin(debugID, 'update');
+  },
+  onUpdateComponent: function (debugID) {
+    checkDebugID(debugID);
+    markEnd(debugID, 'update');
+    emitEvent('onUpdateComponent', debugID);
+  },
+  onBeforeUnmountComponent: function (debugID) {
+    checkDebugID(debugID);
+    emitEvent('onBeforeUnmountComponent', debugID);
+    markBegin(debugID, 'unmount');
+  },
+  onUnmountComponent: function (debugID) {
+    checkDebugID(debugID);
+    markEnd(debugID, 'unmount');
+    emitEvent('onUnmountComponent', debugID);
+  },
+  onTestEvent: function () {
+    emitEvent('onTestEvent');
+  }
+};
+
+// TODO remove these when RN/www gets updated
+ReactDebugTool.addDevtool = ReactDebugTool.addHook;
+ReactDebugTool.removeDevtool = ReactDebugTool.removeHook;
+
+ReactDebugTool.addHook(ReactInvalidSetStateWarningHook);
+ReactDebugTool.addHook(ReactComponentTreeHook);
+var url = ExecutionEnvironment.canUseDOM && window.location.href || '';
+if (/[?&]react_perf\b/.test(url)) {
+  ReactDebugTool.beginProfiling();
+}
+
+module.exports = ReactDebugTool;
+},{"133":133,"138":138,"157":157,"159":159,"60":60,"65":65}],51:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var ReactUpdates = _dereq_(82);
+var Transaction = _dereq_(100);
+
+var emptyFunction = _dereq_(144);
+
+var RESET_BATCHED_UPDATES = {
+  initialize: emptyFunction,
+  close: function () {
+    ReactDefaultBatchingStrategy.isBatchingUpdates = false;
+  }
+};
+
+var FLUSH_BATCHED_UPDATES = {
+  initialize: emptyFunction,
+  close: ReactUpdates.flushBatchedUpdates.bind(ReactUpdates)
+};
+
+var TRANSACTION_WRAPPERS = [FLUSH_BATCHED_UPDATES, RESET_BATCHED_UPDATES];
+
+function ReactDefaultBatchingStrategyTransaction() {
+  this.reinitializeTransaction();
+}
+
+_assign(ReactDefaultBatchingStrategyTransaction.prototype, Transaction, {
+  getTransactionWrappers: function () {
+    return TRANSACTION_WRAPPERS;
+  }
+});
+
+var transaction = new ReactDefaultBatchingStrategyTransaction();
+
+var ReactDefaultBatchingStrategy = {
+  isBatchingUpdates: false,
+
+  /**
+   * Call the provided function in a context within which calls to `setState`
+   * and friends are batched such that components aren't updated unnecessarily.
+   */
+  batchedUpdates: function (callback, a, b, c, d, e) {
+    var alreadyBatchingUpdates = ReactDefaultBatchingStrategy.isBatchingUpdates;
+
+    ReactDefaultBatchingStrategy.isBatchingUpdates = true;
+
+    // The code is written this way to avoid extra allocations
+    if (alreadyBatchingUpdates) {
+      return callback(a, b, c, d, e);
+    } else {
+      return transaction.perform(callback, null, a, b, c, d, e);
+    }
+  }
+};
+
+module.exports = ReactDefaultBatchingStrategy;
+},{"100":100,"144":144,"160":160,"82":82}],52:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ARIADOMPropertyConfig = _dereq_(1);
+var BeforeInputEventPlugin = _dereq_(3);
+var ChangeEventPlugin = _dereq_(7);
+var DefaultEventPluginOrder = _dereq_(14);
+var EnterLeaveEventPlugin = _dereq_(15);
+var HTMLDOMPropertyConfig = _dereq_(22);
+var ReactComponentBrowserEnvironment = _dereq_(28);
+var ReactDOMComponent = _dereq_(32);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactDOMEmptyComponent = _dereq_(36);
+var ReactDOMTreeTraversal = _dereq_(47);
+var ReactDOMTextComponent = _dereq_(45);
+var ReactDefaultBatchingStrategy = _dereq_(51);
+var ReactEventListener = _dereq_(57);
+var ReactInjection = _dereq_(61);
+var ReactReconcileTransaction = _dereq_(74);
+var SVGDOMPropertyConfig = _dereq_(84);
+var SelectEventPlugin = _dereq_(85);
+var SimpleEventPlugin = _dereq_(86);
+
+var alreadyInjected = false;
+
+function inject() {
+  if (alreadyInjected) {
+    // TODO: This is currently true because these injections are shared between
+    // the client and the server package. They should be built independently
+    // and not share any injection state. Then this problem will be solved.
+    return;
+  }
+  alreadyInjected = true;
+
+  ReactInjection.EventEmitter.injectReactEventListener(ReactEventListener);
+
+  /**
+   * Inject modules for resolving DOM hierarchy and plugin ordering.
+   */
+  ReactInjection.EventPluginHub.injectEventPluginOrder(DefaultEventPluginOrder);
+  ReactInjection.EventPluginUtils.injectComponentTree(ReactDOMComponentTree);
+  ReactInjection.EventPluginUtils.injectTreeTraversal(ReactDOMTreeTraversal);
+
+  /**
+   * Some important event plugins included by default (without having to require
+   * them).
+   */
+  ReactInjection.EventPluginHub.injectEventPluginsByName({
+    SimpleEventPlugin: SimpleEventPlugin,
+    EnterLeaveEventPlugin: EnterLeaveEventPlugin,
+    ChangeEventPlugin: ChangeEventPlugin,
+    SelectEventPlugin: SelectEventPlugin,
+    BeforeInputEventPlugin: BeforeInputEventPlugin
+  });
+
+  ReactInjection.HostComponent.injectGenericComponentClass(ReactDOMComponent);
+
+  ReactInjection.HostComponent.injectTextComponentClass(ReactDOMTextComponent);
+
+  ReactInjection.DOMProperty.injectDOMPropertyConfig(ARIADOMPropertyConfig);
+  ReactInjection.DOMProperty.injectDOMPropertyConfig(HTMLDOMPropertyConfig);
+  ReactInjection.DOMProperty.injectDOMPropertyConfig(SVGDOMPropertyConfig);
+
+  ReactInjection.EmptyComponent.injectEmptyComponentFactory(function (instantiate) {
+    return new ReactDOMEmptyComponent(instantiate);
+  });
+
+  ReactInjection.Updates.injectReconcileTransaction(ReactReconcileTransaction);
+  ReactInjection.Updates.injectBatchingStrategy(ReactDefaultBatchingStrategy);
+
+  ReactInjection.Component.injectEnvironment(ReactComponentBrowserEnvironment);
+}
+
+module.exports = {
+  inject: inject
+};
+},{"1":1,"14":14,"15":15,"22":22,"28":28,"3":3,"32":32,"34":34,"36":36,"45":45,"47":47,"51":51,"57":57,"61":61,"7":7,"74":74,"84":84,"85":85,"86":86}],53:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+// The Symbol used to tag the ReactElement type. If there is no native Symbol
+// nor polyfill, then a plain number is used for performance.
+
+var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol['for'] && Symbol['for']('react.element') || 0xeac7;
+
+module.exports = REACT_ELEMENT_TYPE;
+},{}],54:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var emptyComponentFactory;
+
+var ReactEmptyComponentInjection = {
+  injectEmptyComponentFactory: function (factory) {
+    emptyComponentFactory = factory;
+  }
+};
+
+var ReactEmptyComponent = {
+  create: function (instantiate) {
+    return emptyComponentFactory(instantiate);
+  }
+};
+
+ReactEmptyComponent.injection = ReactEmptyComponentInjection;
+
+module.exports = ReactEmptyComponent;
+},{}],55:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var caughtError = null;
+
+/**
+ * Call a function while guarding against errors that happens within it.
+ *
+ * @param {String} name of the guard to use for logging or debugging
+ * @param {Function} func The function to invoke
+ * @param {*} a First argument
+ * @param {*} b Second argument
+ */
+function invokeGuardedCallback(name, func, a) {
+  try {
+    func(a);
+  } catch (x) {
+    if (caughtError === null) {
+      caughtError = x;
+    }
+  }
+}
+
+var ReactErrorUtils = {
+  invokeGuardedCallback: invokeGuardedCallback,
+
+  /**
+   * Invoked by ReactTestUtils.Simulate so that any errors thrown by the event
+   * handler are sure to be rethrown by rethrowCaughtError.
+   */
+  invokeGuardedCallbackWithCatch: invokeGuardedCallback,
+
+  /**
+   * During execution of guarded functions we will capture the first error which
+   * we will rethrow to be handled by the top level error handler.
+   */
+  rethrowCaughtError: function () {
+    if (caughtError) {
+      var error = caughtError;
+      caughtError = null;
+      throw error;
+    }
+  }
+};
+
+if ("development" !== 'production') {
+  /**
+   * To help development we can get better devtools integration by simulating a
+   * real browser event.
+   */
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function' && typeof document !== 'undefined' && typeof document.createEvent === 'function') {
+    var fakeNode = document.createElement('react');
+    ReactErrorUtils.invokeGuardedCallback = function (name, func, a) {
+      var boundFunc = function () {
+        func(a);
+      };
+      var evtType = 'react-' + name;
+      fakeNode.addEventListener(evtType, boundFunc, false);
+      var evt = document.createEvent('Event');
+      evt.initEvent(evtType, false, false);
+      fakeNode.dispatchEvent(evt);
+      fakeNode.removeEventListener(evtType, boundFunc, false);
+    };
+  }
+}
+
+module.exports = ReactErrorUtils;
+},{}],56:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var EventPluginHub = _dereq_(17);
+
+function runEventQueueInBatch(events) {
+  EventPluginHub.enqueueEvents(events);
+  EventPluginHub.processEventQueue(false);
+}
+
+var ReactEventEmitterMixin = {
+  /**
+   * Streams a fired top-level event to `EventPluginHub` where plugins have the
+   * opportunity to create `ReactEvent`s to be dispatched.
+   */
+  handleTopLevel: function (topLevelType, targetInst, nativeEvent, nativeEventTarget) {
+    var events = EventPluginHub.extractEvents(topLevelType, targetInst, nativeEvent, nativeEventTarget);
+    runEventQueueInBatch(events);
+  }
+};
+
+module.exports = ReactEventEmitterMixin;
+},{"17":17}],57:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var EventListener = _dereq_(137);
+var ExecutionEnvironment = _dereq_(138);
+var PooledClass = _dereq_(25);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactUpdates = _dereq_(82);
+
+var getEventTarget = _dereq_(114);
+var getUnboundedScrollPosition = _dereq_(149);
+
+/**
+ * Find the deepest React component completely containing the root of the
+ * passed-in instance (for use when entire React trees are nested within each
+ * other). If React trees are not nested, returns null.
+ */
+function findParent(inst) {
+  // TODO: It may be a good idea to cache this to prevent unnecessary DOM
+  // traversal, but caching is difficult to do correctly without using a
+  // mutation observer to listen for all DOM changes.
+  while (inst._hostParent) {
+    inst = inst._hostParent;
+  }
+  var rootNode = ReactDOMComponentTree.getNodeFromInstance(inst);
+  var container = rootNode.parentNode;
+  return ReactDOMComponentTree.getClosestInstanceFromNode(container);
+}
+
+// Used to store ancestor hierarchy in top level callback
+function TopLevelCallbackBookKeeping(topLevelType, nativeEvent) {
+  this.topLevelType = topLevelType;
+  this.nativeEvent = nativeEvent;
+  this.ancestors = [];
+}
+_assign(TopLevelCallbackBookKeeping.prototype, {
+  destructor: function () {
+    this.topLevelType = null;
+    this.nativeEvent = null;
+    this.ancestors.length = 0;
+  }
+});
+PooledClass.addPoolingTo(TopLevelCallbackBookKeeping, PooledClass.twoArgumentPooler);
+
+function handleTopLevelImpl(bookKeeping) {
+  var nativeEventTarget = getEventTarget(bookKeeping.nativeEvent);
+  var targetInst = ReactDOMComponentTree.getClosestInstanceFromNode(nativeEventTarget);
+
+  // Loop through the hierarchy, in case there's any nested components.
+  // It's important that we build the array of ancestors before calling any
+  // event handlers, because event handlers can modify the DOM, leading to
+  // inconsistencies with ReactMount's node cache. See #1105.
+  var ancestor = targetInst;
+  do {
+    bookKeeping.ancestors.push(ancestor);
+    ancestor = ancestor && findParent(ancestor);
+  } while (ancestor);
+
+  for (var i = 0; i < bookKeeping.ancestors.length; i++) {
+    targetInst = bookKeeping.ancestors[i];
+    ReactEventListener._handleTopLevel(bookKeeping.topLevelType, targetInst, bookKeeping.nativeEvent, getEventTarget(bookKeeping.nativeEvent));
+  }
+}
+
+function scrollValueMonitor(cb) {
+  var scrollPosition = getUnboundedScrollPosition(window);
+  cb(scrollPosition);
+}
+
+var ReactEventListener = {
+  _enabled: true,
+  _handleTopLevel: null,
+
+  WINDOW_HANDLE: ExecutionEnvironment.canUseDOM ? window : null,
+
+  setHandleTopLevel: function (handleTopLevel) {
+    ReactEventListener._handleTopLevel = handleTopLevel;
+  },
+
+  setEnabled: function (enabled) {
+    ReactEventListener._enabled = !!enabled;
+  },
+
+  isEnabled: function () {
+    return ReactEventListener._enabled;
+  },
+
+  /**
+   * Traps top-level events by using event bubbling.
+   *
+   * @param {string} topLevelType Record from `EventConstants`.
+   * @param {string} handlerBaseName Event name (e.g. "click").
+   * @param {object} element Element on which to attach listener.
+   * @return {?object} An object with a remove function which will forcefully
+   *                  remove the listener.
+   * @internal
+   */
+  trapBubbledEvent: function (topLevelType, handlerBaseName, element) {
+    if (!element) {
+      return null;
+    }
+    return EventListener.listen(element, handlerBaseName, ReactEventListener.dispatchEvent.bind(null, topLevelType));
+  },
+
+  /**
+   * Traps a top-level event by using event capturing.
+   *
+   * @param {string} topLevelType Record from `EventConstants`.
+   * @param {string} handlerBaseName Event name (e.g. "click").
+   * @param {object} element Element on which to attach listener.
+   * @return {?object} An object with a remove function which will forcefully
+   *                  remove the listener.
+   * @internal
+   */
+  trapCapturedEvent: function (topLevelType, handlerBaseName, element) {
+    if (!element) {
+      return null;
+    }
+    return EventListener.capture(element, handlerBaseName, ReactEventListener.dispatchEvent.bind(null, topLevelType));
+  },
+
+  monitorScrollValue: function (refresh) {
+    var callback = scrollValueMonitor.bind(null, refresh);
+    EventListener.listen(window, 'scroll', callback);
+  },
+
+  dispatchEvent: function (topLevelType, nativeEvent) {
+    if (!ReactEventListener._enabled) {
+      return;
+    }
+
+    var bookKeeping = TopLevelCallbackBookKeeping.getPooled(topLevelType, nativeEvent);
+    try {
+      // Event queue being processed in the same cycle allows
+      // `preventDefault`.
+      ReactUpdates.batchedUpdates(handleTopLevelImpl, bookKeeping);
+    } finally {
+      TopLevelCallbackBookKeeping.release(bookKeeping);
+    }
+  }
+};
+
+module.exports = ReactEventListener;
+},{"114":114,"137":137,"138":138,"149":149,"160":160,"25":25,"34":34,"82":82}],58:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var ReactFeatureFlags = {
+  // When true, call console.time() before and .timeEnd() after each top-level
+  // render (both initial renders and updates). Useful when looking at prod-mode
+  // timeline profiles in Chrome, for example.
+  logTopLevelRenders: false
+};
+
+module.exports = ReactFeatureFlags;
+},{}],59:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var invariant = _dereq_(152);
+
+var genericComponentClass = null;
+var textComponentClass = null;
+
+var ReactHostComponentInjection = {
+  // This accepts a class that receives the tag string. This is a catch all
+  // that can render any kind of tag.
+  injectGenericComponentClass: function (componentClass) {
+    genericComponentClass = componentClass;
+  },
+  // This accepts a text component class that takes the text string to be
+  // rendered as props.
+  injectTextComponentClass: function (componentClass) {
+    textComponentClass = componentClass;
+  }
+};
+
+/**
+ * Get a host internal component class for a specific tag.
+ *
+ * @param {ReactElement} element The element to create.
+ * @return {function} The internal class constructor function.
+ */
+function createInternalComponent(element) {
+  !genericComponentClass ? "development" !== 'production' ? invariant(false, 'There is no registered component for the tag %s', element.type) : _prodInvariant('111', element.type) : void 0;
+  return new genericComponentClass(element);
+}
+
+/**
+ * @param {ReactText} text
+ * @return {ReactComponent}
+ */
+function createInstanceForText(text) {
+  return new textComponentClass(text);
+}
+
+/**
+ * @param {ReactComponent} component
+ * @return {boolean}
+ */
+function isTextComponent(component) {
+  return component instanceof textComponentClass;
+}
+
+var ReactHostComponent = {
+  createInternalComponent: createInternalComponent,
+  createInstanceForText: createInstanceForText,
+  isTextComponent: isTextComponent,
+  injection: ReactHostComponentInjection
+};
+
+module.exports = ReactHostComponent;
+},{"126":126,"152":152}],60:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var history = [];
+
+var ReactHostOperationHistoryHook = {
+  onHostOperation: function (operation) {
+    history.push(operation);
+  },
+  clearHistory: function () {
+    if (ReactHostOperationHistoryHook._preventClearing) {
+      // Should only be used for tests.
+      return;
+    }
+
+    history = [];
+  },
+  getHistory: function () {
+    return history;
+  }
+};
+
+module.exports = ReactHostOperationHistoryHook;
+},{}],61:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var DOMProperty = _dereq_(11);
+var EventPluginHub = _dereq_(17);
+var EventPluginUtils = _dereq_(19);
+var ReactComponentEnvironment = _dereq_(29);
+var ReactEmptyComponent = _dereq_(54);
+var ReactBrowserEventEmitter = _dereq_(26);
+var ReactHostComponent = _dereq_(59);
+var ReactUpdates = _dereq_(82);
+
+var ReactInjection = {
+  Component: ReactComponentEnvironment.injection,
+  DOMProperty: DOMProperty.injection,
+  EmptyComponent: ReactEmptyComponent.injection,
+  EventPluginHub: EventPluginHub.injection,
+  EventPluginUtils: EventPluginUtils.injection,
+  EventEmitter: ReactBrowserEventEmitter.injection,
+  HostComponent: ReactHostComponent.injection,
+  Updates: ReactUpdates.injection
+};
+
+module.exports = ReactInjection;
+},{"11":11,"17":17,"19":19,"26":26,"29":29,"54":54,"59":59,"82":82}],62:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ReactDOMSelection = _dereq_(44);
+
+var containsNode = _dereq_(141);
+var focusNode = _dereq_(146);
+var getActiveElement = _dereq_(147);
+
+function isInDocument(node) {
+  return containsNode(document.documentElement, node);
+}
+
+/**
+ * @ReactInputSelection: React input selection module. Based on Selection.js,
+ * but modified to be suitable for react and has a couple of bug fixes (doesn't
+ * assume buttons have range selections allowed).
+ * Input selection module for React.
+ */
+var ReactInputSelection = {
+  hasSelectionCapabilities: function (elem) {
+    var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+    return nodeName && (nodeName === 'input' && elem.type === 'text' || nodeName === 'textarea' || elem.contentEditable === 'true');
+  },
+
+  getSelectionInformation: function () {
+    var focusedElem = getActiveElement();
+    return {
+      focusedElem: focusedElem,
+      selectionRange: ReactInputSelection.hasSelectionCapabilities(focusedElem) ? ReactInputSelection.getSelection(focusedElem) : null
+    };
+  },
+
+  /**
+   * @restoreSelection: If any selection information was potentially lost,
+   * restore it. This is useful when performing operations that could remove dom
+   * nodes and place them back in, resulting in focus being lost.
+   */
+  restoreSelection: function (priorSelectionInformation) {
+    var curFocusedElem = getActiveElement();
+    var priorFocusedElem = priorSelectionInformation.focusedElem;
+    var priorSelectionRange = priorSelectionInformation.selectionRange;
+    if (curFocusedElem !== priorFocusedElem && isInDocument(priorFocusedElem)) {
+      if (ReactInputSelection.hasSelectionCapabilities(priorFocusedElem)) {
+        ReactInputSelection.setSelection(priorFocusedElem, priorSelectionRange);
+      }
+      focusNode(priorFocusedElem);
+    }
+  },
+
+  /**
+   * @getSelection: Gets the selection bounds of a focused textarea, input or
+   * contentEditable node.
+   * -@input: Look up selection bounds of this input
+   * -@return {start: selectionStart, end: selectionEnd}
+   */
+  getSelection: function (input) {
+    var selection;
+
+    if ('selectionStart' in input) {
+      // Modern browser with input or textarea.
+      selection = {
+        start: input.selectionStart,
+        end: input.selectionEnd
+      };
+    } else if (document.selection && input.nodeName && input.nodeName.toLowerCase() === 'input') {
+      // IE8 input.
+      var range = document.selection.createRange();
+      // There can only be one selection per document in IE, so it must
+      // be in our element.
+      if (range.parentElement() === input) {
+        selection = {
+          start: -range.moveStart('character', -input.value.length),
+          end: -range.moveEnd('character', -input.value.length)
+        };
+      }
+    } else {
+      // Content editable or old IE textarea.
+      selection = ReactDOMSelection.getOffsets(input);
+    }
+
+    return selection || { start: 0, end: 0 };
+  },
+
+  /**
+   * @setSelection: Sets the selection bounds of a textarea or input and focuses
+   * the input.
+   * -@input     Set selection bounds of this input or textarea
+   * -@offsets   Object of same form that is returned from get*
+   */
+  setSelection: function (input, offsets) {
+    var start = offsets.start;
+    var end = offsets.end;
+    if (end === undefined) {
+      end = start;
+    }
+
+    if ('selectionStart' in input) {
+      input.selectionStart = start;
+      input.selectionEnd = Math.min(end, input.value.length);
+    } else if (document.selection && input.nodeName && input.nodeName.toLowerCase() === 'input') {
+      var range = input.createTextRange();
+      range.collapse(true);
+      range.moveStart('character', start);
+      range.moveEnd('character', end - start);
+      range.select();
+    } else {
+      ReactDOMSelection.setOffsets(input, offsets);
+    }
+  }
+};
+
+module.exports = ReactInputSelection;
+},{"141":141,"146":146,"147":147,"44":44}],63:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+/**
+ * `ReactInstanceMap` maintains a mapping from a public facing stateful
+ * instance (key) and the internal representation (value). This allows public
+ * methods to accept the user facing instance as an argument and map them back
+ * to internal methods.
+ */
+
+// TODO: Replace this with ES6: var ReactInstanceMap = new Map();
+
+var ReactInstanceMap = {
+  /**
+   * This API should be called `delete` but we'd have to make sure to always
+   * transform these to strings for IE support. When this transform is fully
+   * supported we can rename it.
+   */
+  remove: function (key) {
+    key._reactInternalInstance = undefined;
+  },
+
+  get: function (key) {
+    return key._reactInternalInstance;
+  },
+
+  has: function (key) {
+    return key._reactInternalInstance !== undefined;
+  },
+
+  set: function (key, value) {
+    key._reactInternalInstance = value;
+  }
+};
+
+module.exports = ReactInstanceMap;
+},{}],64:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+// Trust the developer to only use ReactInstrumentation with a __DEV__ check
+
+var debugTool = null;
+
+if ("development" !== 'production') {
+  var ReactDebugTool = _dereq_(50);
+  debugTool = ReactDebugTool;
+}
+
+module.exports = { debugTool: debugTool };
+},{"50":50}],65:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var warning = _dereq_(159);
+
+if ("development" !== 'production') {
+  var processingChildContext = false;
+
+  var warnInvalidSetState = function () {
+    "development" !== 'production' ? warning(!processingChildContext, 'setState(...): Cannot call setState() inside getChildContext()') : void 0;
+  };
+}
+
+var ReactInvalidSetStateWarningHook = {
+  onBeginProcessingChildContext: function () {
+    processingChildContext = true;
+  },
+  onEndProcessingChildContext: function () {
+    processingChildContext = false;
+  },
+  onSetState: function () {
+    warnInvalidSetState();
+  }
+};
+
+module.exports = ReactInvalidSetStateWarningHook;
+},{"159":159}],66:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var adler32 = _dereq_(103);
+
+var TAG_END = /\/?>/;
+var COMMENT_START = /^<\!\-\-/;
+
+var ReactMarkupChecksum = {
+  CHECKSUM_ATTR_NAME: 'data-react-checksum',
+
+  /**
+   * @param {string} markup Markup string
+   * @return {string} Markup string with checksum attribute attached
+   */
+  addChecksumToMarkup: function (markup) {
+    var checksum = adler32(markup);
+
+    // Add checksum (handle both parent tags, comments and self-closing tags)
+    if (COMMENT_START.test(markup)) {
+      return markup;
+    } else {
+      return markup.replace(TAG_END, ' ' + ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="' + checksum + '"$&');
+    }
+  },
+
+  /**
+   * @param {string} markup to use
+   * @param {DOMElement} element root React element
+   * @returns {boolean} whether or not the markup is the same
+   */
+  canReuseMarkup: function (markup, element) {
+    var existingChecksum = element.getAttribute(ReactMarkupChecksum.CHECKSUM_ATTR_NAME);
+    existingChecksum = existingChecksum && parseInt(existingChecksum, 10);
+    var markupChecksum = adler32(markup);
+    return markupChecksum === existingChecksum;
+  }
+};
+
+module.exports = ReactMarkupChecksum;
+},{"103":103}],67:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var DOMLazyTree = _dereq_(9);
+var DOMProperty = _dereq_(11);
+var React = _dereq_(135);
+var ReactBrowserEventEmitter = _dereq_(26);
+var ReactCurrentOwner = _dereq_(134);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactDOMContainerInfo = _dereq_(35);
+var ReactDOMFeatureFlags = _dereq_(37);
+var ReactFeatureFlags = _dereq_(58);
+var ReactInstanceMap = _dereq_(63);
+var ReactInstrumentation = _dereq_(64);
+var ReactMarkupChecksum = _dereq_(66);
+var ReactReconciler = _dereq_(75);
+var ReactUpdateQueue = _dereq_(81);
+var ReactUpdates = _dereq_(82);
+
+var emptyObject = _dereq_(145);
+var instantiateReactComponent = _dereq_(121);
+var invariant = _dereq_(152);
+var setInnerHTML = _dereq_(128);
+var shouldUpdateReactComponent = _dereq_(130);
+var warning = _dereq_(159);
+
+var ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
+var ROOT_ATTR_NAME = DOMProperty.ROOT_ATTRIBUTE_NAME;
+
+var ELEMENT_NODE_TYPE = 1;
+var DOC_NODE_TYPE = 9;
+var DOCUMENT_FRAGMENT_NODE_TYPE = 11;
+
+var instancesByReactRootID = {};
+
+/**
+ * Finds the index of the first character
+ * that's not common between the two given strings.
+ *
+ * @return {number} the index of the character where the strings diverge
+ */
+function firstDifferenceIndex(string1, string2) {
+  var minLen = Math.min(string1.length, string2.length);
+  for (var i = 0; i < minLen; i++) {
+    if (string1.charAt(i) !== string2.charAt(i)) {
+      return i;
+    }
+  }
+  return string1.length === string2.length ? -1 : minLen;
+}
+
+/**
+ * @param {DOMElement|DOMDocument} container DOM element that may contain
+ * a React component
+ * @return {?*} DOM element that may have the reactRoot ID, or null.
+ */
+function getReactRootElementInContainer(container) {
+  if (!container) {
+    return null;
+  }
+
+  if (container.nodeType === DOC_NODE_TYPE) {
+    return container.documentElement;
+  } else {
+    return container.firstChild;
+  }
+}
+
+function internalGetID(node) {
+  // If node is something like a window, document, or text node, none of
+  // which support attributes or a .getAttribute method, gracefully return
+  // the empty string, as if the attribute were missing.
+  return node.getAttribute && node.getAttribute(ATTR_NAME) || '';
+}
+
+/**
+ * Mounts this component and inserts it into the DOM.
+ *
+ * @param {ReactComponent} componentInstance The instance to mount.
+ * @param {DOMElement} container DOM element to mount into.
+ * @param {ReactReconcileTransaction} transaction
+ * @param {boolean} shouldReuseMarkup If true, do not insert markup
+ */
+function mountComponentIntoNode(wrapperInstance, container, transaction, shouldReuseMarkup, context) {
+  var markerName;
+  if (ReactFeatureFlags.logTopLevelRenders) {
+    var wrappedElement = wrapperInstance._currentElement.props.child;
+    var type = wrappedElement.type;
+    markerName = 'React mount: ' + (typeof type === 'string' ? type : type.displayName || type.name);
+    console.time(markerName);
+  }
+
+  var markup = ReactReconciler.mountComponent(wrapperInstance, transaction, null, ReactDOMContainerInfo(wrapperInstance, container), context, 0 /* parentDebugID */
+  );
+
+  if (markerName) {
+    console.timeEnd(markerName);
+  }
+
+  wrapperInstance._renderedComponent._topLevelWrapper = wrapperInstance;
+  ReactMount._mountImageIntoNode(markup, container, wrapperInstance, shouldReuseMarkup, transaction);
+}
+
+/**
+ * Batched mount.
+ *
+ * @param {ReactComponent} componentInstance The instance to mount.
+ * @param {DOMElement} container DOM element to mount into.
+ * @param {boolean} shouldReuseMarkup If true, do not insert markup
+ */
+function batchedMountComponentIntoNode(componentInstance, container, shouldReuseMarkup, context) {
+  var transaction = ReactUpdates.ReactReconcileTransaction.getPooled(
+  /* useCreateElement */
+  !shouldReuseMarkup && ReactDOMFeatureFlags.useCreateElement);
+  transaction.perform(mountComponentIntoNode, null, componentInstance, container, transaction, shouldReuseMarkup, context);
+  ReactUpdates.ReactReconcileTransaction.release(transaction);
+}
+
+/**
+ * Unmounts a component and removes it from the DOM.
+ *
+ * @param {ReactComponent} instance React component instance.
+ * @param {DOMElement} container DOM element to unmount from.
+ * @final
+ * @internal
+ * @see {ReactMount.unmountComponentAtNode}
+ */
+function unmountComponentFromNode(instance, container, safely) {
+  if ("development" !== 'production') {
+    ReactInstrumentation.debugTool.onBeginFlush();
+  }
+  ReactReconciler.unmountComponent(instance, safely);
+  if ("development" !== 'production') {
+    ReactInstrumentation.debugTool.onEndFlush();
+  }
+
+  if (container.nodeType === DOC_NODE_TYPE) {
+    container = container.documentElement;
+  }
+
+  // http://jsperf.com/emptying-a-node
+  while (container.lastChild) {
+    container.removeChild(container.lastChild);
+  }
+}
+
+/**
+ * True if the supplied DOM node has a direct React-rendered child that is
+ * not a React root element. Useful for warning in `render`,
+ * `unmountComponentAtNode`, etc.
+ *
+ * @param {?DOMElement} node The candidate DOM node.
+ * @return {boolean} True if the DOM element contains a direct child that was
+ * rendered by React but is not a root element.
+ * @internal
+ */
+function hasNonRootReactChild(container) {
+  var rootEl = getReactRootElementInContainer(container);
+  if (rootEl) {
+    var inst = ReactDOMComponentTree.getInstanceFromNode(rootEl);
+    return !!(inst && inst._hostParent);
+  }
+}
+
+/**
+ * True if the supplied DOM node is a React DOM element and
+ * it has been rendered by another copy of React.
+ *
+ * @param {?DOMElement} node The candidate DOM node.
+ * @return {boolean} True if the DOM has been rendered by another copy of React
+ * @internal
+ */
+function nodeIsRenderedByOtherInstance(container) {
+  var rootEl = getReactRootElementInContainer(container);
+  return !!(rootEl && isReactNode(rootEl) && !ReactDOMComponentTree.getInstanceFromNode(rootEl));
+}
+
+/**
+ * True if the supplied DOM node is a valid node element.
+ *
+ * @param {?DOMElement} node The candidate DOM node.
+ * @return {boolean} True if the DOM is a valid DOM node.
+ * @internal
+ */
+function isValidContainer(node) {
+  return !!(node && (node.nodeType === ELEMENT_NODE_TYPE || node.nodeType === DOC_NODE_TYPE || node.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE));
+}
+
+/**
+ * True if the supplied DOM node is a valid React node element.
+ *
+ * @param {?DOMElement} node The candidate DOM node.
+ * @return {boolean} True if the DOM is a valid React DOM node.
+ * @internal
+ */
+function isReactNode(node) {
+  return isValidContainer(node) && (node.hasAttribute(ROOT_ATTR_NAME) || node.hasAttribute(ATTR_NAME));
+}
+
+function getHostRootInstanceInContainer(container) {
+  var rootEl = getReactRootElementInContainer(container);
+  var prevHostInstance = rootEl && ReactDOMComponentTree.getInstanceFromNode(rootEl);
+  return prevHostInstance && !prevHostInstance._hostParent ? prevHostInstance : null;
+}
+
+function getTopLevelWrapperInContainer(container) {
+  var root = getHostRootInstanceInContainer(container);
+  return root ? root._hostContainerInfo._topLevelWrapper : null;
+}
+
+/**
+ * Temporary (?) hack so that we can store all top-level pending updates on
+ * composites instead of having to worry about different types of components
+ * here.
+ */
+var topLevelRootCounter = 1;
+var TopLevelWrapper = function () {
+  this.rootID = topLevelRootCounter++;
+};
+TopLevelWrapper.prototype.isReactComponent = {};
+if ("development" !== 'production') {
+  TopLevelWrapper.displayName = 'TopLevelWrapper';
+}
+TopLevelWrapper.prototype.render = function () {
+  return this.props.child;
+};
+TopLevelWrapper.isReactTopLevelWrapper = true;
+
+/**
+ * Mounting is the process of initializing a React component by creating its
+ * representative DOM elements and inserting them into a supplied `container`.
+ * Any prior content inside `container` is destroyed in the process.
+ *
+ *   ReactMount.render(
+ *     component,
+ *     document.getElementById('container')
+ *   );
+ *
+ *   <div id="container">                   <-- Supplied `container`.
+ *     <div data-reactid=".3">              <-- Rendered reactRoot of React
+ *       // ...                                 component.
+ *     </div>
+ *   </div>
+ *
+ * Inside of `container`, the first element rendered is the "reactRoot".
+ */
+var ReactMount = {
+  TopLevelWrapper: TopLevelWrapper,
+
+  /**
+   * Used by devtools. The keys are not important.
+   */
+  _instancesByReactRootID: instancesByReactRootID,
+
+  /**
+   * This is a hook provided to support rendering React components while
+   * ensuring that the apparent scroll position of its `container` does not
+   * change.
+   *
+   * @param {DOMElement} container The `container` being rendered into.
+   * @param {function} renderCallback This must be called once to do the render.
+   */
+  scrollMonitor: function (container, renderCallback) {
+    renderCallback();
+  },
+
+  /**
+   * Take a component that's already mounted into the DOM and replace its props
+   * @param {ReactComponent} prevComponent component instance already in the DOM
+   * @param {ReactElement} nextElement component instance to render
+   * @param {DOMElement} container container to render into
+   * @param {?function} callback function triggered on completion
+   */
+  _updateRootComponent: function (prevComponent, nextElement, nextContext, container, callback) {
+    ReactMount.scrollMonitor(container, function () {
+      ReactUpdateQueue.enqueueElementInternal(prevComponent, nextElement, nextContext);
+      if (callback) {
+        ReactUpdateQueue.enqueueCallbackInternal(prevComponent, callback);
+      }
+    });
+
+    return prevComponent;
+  },
+
+  /**
+   * Render a new component into the DOM. Hooked by hooks!
+   *
+   * @param {ReactElement} nextElement element to render
+   * @param {DOMElement} container container to render into
+   * @param {boolean} shouldReuseMarkup if we should skip the markup insertion
+   * @return {ReactComponent} nextComponent
+   */
+  _renderNewRootComponent: function (nextElement, container, shouldReuseMarkup, context) {
+    // Various parts of our code (such as ReactCompositeComponent's
+    // _renderValidatedComponent) assume that calls to render aren't nested;
+    // verify that that's the case.
+    "development" !== 'production' ? warning(ReactCurrentOwner.current == null, '_renderNewRootComponent(): Render methods should be a pure function ' + 'of props and state; triggering nested component updates from ' + 'render is not allowed. If necessary, trigger nested updates in ' + 'componentDidUpdate. Check the render method of %s.', ReactCurrentOwner.current && ReactCurrentOwner.current.getName() || 'ReactCompositeComponent') : void 0;
+
+    !isValidContainer(container) ? "development" !== 'production' ? invariant(false, '_registerComponent(...): Target container is not a DOM element.') : _prodInvariant('37') : void 0;
+
+    ReactBrowserEventEmitter.ensureScrollValueMonitoring();
+    var componentInstance = instantiateReactComponent(nextElement, false);
+
+    // The initial render is synchronous but any updates that happen during
+    // rendering, in componentWillMount or componentDidMount, will be batched
+    // according to the current batching strategy.
+
+    ReactUpdates.batchedUpdates(batchedMountComponentIntoNode, componentInstance, container, shouldReuseMarkup, context);
+
+    var wrapperID = componentInstance._instance.rootID;
+    instancesByReactRootID[wrapperID] = componentInstance;
+
+    return componentInstance;
+  },
+
+  /**
+   * Renders a React component into the DOM in the supplied `container`.
+   *
+   * If the React component was previously rendered into `container`, this will
+   * perform an update on it and only mutate the DOM as necessary to reflect the
+   * latest React component.
+   *
+   * @param {ReactComponent} parentComponent The conceptual parent of this render tree.
+   * @param {ReactElement} nextElement Component element to render.
+   * @param {DOMElement} container DOM element to render into.
+   * @param {?function} callback function triggered on completion
+   * @return {ReactComponent} Component instance rendered in `container`.
+   */
+  renderSubtreeIntoContainer: function (parentComponent, nextElement, container, callback) {
+    !(parentComponent != null && ReactInstanceMap.has(parentComponent)) ? "development" !== 'production' ? invariant(false, 'parentComponent must be a valid React Component') : _prodInvariant('38') : void 0;
+    return ReactMount._renderSubtreeIntoContainer(parentComponent, nextElement, container, callback);
+  },
+
+  _renderSubtreeIntoContainer: function (parentComponent, nextElement, container, callback) {
+    ReactUpdateQueue.validateCallback(callback, 'ReactDOM.render');
+    !React.isValidElement(nextElement) ? "development" !== 'production' ? invariant(false, 'ReactDOM.render(): Invalid component element.%s', typeof nextElement === 'string' ? " Instead of passing a string like 'div', pass " + "React.createElement('div') or <div />." : typeof nextElement === 'function' ? ' Instead of passing a class like Foo, pass ' + 'React.createElement(Foo) or <Foo />.' : // Check if it quacks like an element
+    nextElement != null && nextElement.props !== undefined ? ' This may be caused by unintentionally loading two independent ' + 'copies of React.' : '') : _prodInvariant('39', typeof nextElement === 'string' ? " Instead of passing a string like 'div', pass " + "React.createElement('div') or <div />." : typeof nextElement === 'function' ? ' Instead of passing a class like Foo, pass ' + 'React.createElement(Foo) or <Foo />.' : nextElement != null && nextElement.props !== undefined ? ' This may be caused by unintentionally loading two independent ' + 'copies of React.' : '') : void 0;
+
+    "development" !== 'production' ? warning(!container || !container.tagName || container.tagName.toUpperCase() !== 'BODY', 'render(): Rendering components directly into document.body is ' + 'discouraged, since its children are often manipulated by third-party ' + 'scripts and browser extensions. This may lead to subtle ' + 'reconciliation issues. Try rendering into a container element created ' + 'for your app.') : void 0;
+
+    var nextWrappedElement = React.createElement(TopLevelWrapper, {
+      child: nextElement
+    });
+
+    var nextContext;
+    if (parentComponent) {
+      var parentInst = ReactInstanceMap.get(parentComponent);
+      nextContext = parentInst._processChildContext(parentInst._context);
+    } else {
+      nextContext = emptyObject;
+    }
+
+    var prevComponent = getTopLevelWrapperInContainer(container);
+
+    if (prevComponent) {
+      var prevWrappedElement = prevComponent._currentElement;
+      var prevElement = prevWrappedElement.props.child;
+      if (shouldUpdateReactComponent(prevElement, nextElement)) {
+        var publicInst = prevComponent._renderedComponent.getPublicInstance();
+        var updatedCallback = callback && function () {
+          callback.call(publicInst);
+        };
+        ReactMount._updateRootComponent(prevComponent, nextWrappedElement, nextContext, container, updatedCallback);
+        return publicInst;
+      } else {
+        ReactMount.unmountComponentAtNode(container);
+      }
+    }
+
+    var reactRootElement = getReactRootElementInContainer(container);
+    var containerHasReactMarkup = reactRootElement && !!internalGetID(reactRootElement);
+    var containerHasNonRootReactChild = hasNonRootReactChild(container);
+
+    if ("development" !== 'production') {
+      "development" !== 'production' ? warning(!containerHasNonRootReactChild, 'render(...): Replacing React-rendered children with a new root ' + 'component. If you intended to update the children of this node, ' + 'you should instead have the existing children update their state ' + 'and render the new components instead of calling ReactDOM.render.') : void 0;
+
+      if (!containerHasReactMarkup || reactRootElement.nextSibling) {
+        var rootElementSibling = reactRootElement;
+        while (rootElementSibling) {
+          if (internalGetID(rootElementSibling)) {
+            "development" !== 'production' ? warning(false, 'render(): Target node has markup rendered by React, but there ' + 'are unrelated nodes as well. This is most commonly caused by ' + 'white-space inserted around server-rendered markup.') : void 0;
+            break;
+          }
+          rootElementSibling = rootElementSibling.nextSibling;
+        }
+      }
+    }
+
+    var shouldReuseMarkup = containerHasReactMarkup && !prevComponent && !containerHasNonRootReactChild;
+    var component = ReactMount._renderNewRootComponent(nextWrappedElement, container, shouldReuseMarkup, nextContext)._renderedComponent.getPublicInstance();
+    if (callback) {
+      callback.call(component);
+    }
+    return component;
+  },
+
+  /**
+   * Renders a React component into the DOM in the supplied `container`.
+   * See https://facebook.github.io/react/docs/top-level-api.html#reactdom.render
+   *
+   * If the React component was previously rendered into `container`, this will
+   * perform an update on it and only mutate the DOM as necessary to reflect the
+   * latest React component.
+   *
+   * @param {ReactElement} nextElement Component element to render.
+   * @param {DOMElement} container DOM element to render into.
+   * @param {?function} callback function triggered on completion
+   * @return {ReactComponent} Component instance rendered in `container`.
+   */
+  render: function (nextElement, container, callback) {
+    return ReactMount._renderSubtreeIntoContainer(null, nextElement, container, callback);
+  },
+
+  /**
+   * Unmounts and destroys the React component rendered in the `container`.
+   * See https://facebook.github.io/react/docs/top-level-api.html#reactdom.unmountcomponentatnode
+   *
+   * @param {DOMElement} container DOM element containing a React component.
+   * @return {boolean} True if a component was found in and unmounted from
+   *                   `container`
+   */
+  unmountComponentAtNode: function (container) {
+    // Various parts of our code (such as ReactCompositeComponent's
+    // _renderValidatedComponent) assume that calls to render aren't nested;
+    // verify that that's the case. (Strictly speaking, unmounting won't cause a
+    // render but we still don't expect to be in a render call here.)
+    "development" !== 'production' ? warning(ReactCurrentOwner.current == null, 'unmountComponentAtNode(): Render methods should be a pure function ' + 'of props and state; triggering nested component updates from render ' + 'is not allowed. If necessary, trigger nested updates in ' + 'componentDidUpdate. Check the render method of %s.', ReactCurrentOwner.current && ReactCurrentOwner.current.getName() || 'ReactCompositeComponent') : void 0;
+
+    !isValidContainer(container) ? "development" !== 'production' ? invariant(false, 'unmountComponentAtNode(...): Target container is not a DOM element.') : _prodInvariant('40') : void 0;
+
+    if ("development" !== 'production') {
+      "development" !== 'production' ? warning(!nodeIsRenderedByOtherInstance(container), "unmountComponentAtNode(): The node you're attempting to unmount " + 'was rendered by another copy of React.') : void 0;
+    }
+
+    var prevComponent = getTopLevelWrapperInContainer(container);
+    if (!prevComponent) {
+      // Check if the node being unmounted was rendered by React, but isn't a
+      // root node.
+      var containerHasNonRootReactChild = hasNonRootReactChild(container);
+
+      // Check if the container itself is a React root node.
+      var isContainerReactRoot = container.nodeType === 1 && container.hasAttribute(ROOT_ATTR_NAME);
+
+      if ("development" !== 'production') {
+        "development" !== 'production' ? warning(!containerHasNonRootReactChild, "unmountComponentAtNode(): The node you're attempting to unmount " + 'was rendered by React and is not a top-level container. %s', isContainerReactRoot ? 'You may have accidentally passed in a React root node instead ' + 'of its container.' : 'Instead, have the parent component update its state and ' + 'rerender in order to remove this component.') : void 0;
+      }
+
+      return false;
+    }
+    delete instancesByReactRootID[prevComponent._instance.rootID];
+    ReactUpdates.batchedUpdates(unmountComponentFromNode, prevComponent, container, false);
+    return true;
+  },
+
+  _mountImageIntoNode: function (markup, container, instance, shouldReuseMarkup, transaction) {
+    !isValidContainer(container) ? "development" !== 'production' ? invariant(false, 'mountComponentIntoNode(...): Target container is not valid.') : _prodInvariant('41') : void 0;
+
+    if (shouldReuseMarkup) {
+      var rootElement = getReactRootElementInContainer(container);
+      if (ReactMarkupChecksum.canReuseMarkup(markup, rootElement)) {
+        ReactDOMComponentTree.precacheNode(instance, rootElement);
+        return;
+      } else {
+        var checksum = rootElement.getAttribute(ReactMarkupChecksum.CHECKSUM_ATTR_NAME);
+        rootElement.removeAttribute(ReactMarkupChecksum.CHECKSUM_ATTR_NAME);
+
+        var rootMarkup = rootElement.outerHTML;
+        rootElement.setAttribute(ReactMarkupChecksum.CHECKSUM_ATTR_NAME, checksum);
+
+        var normalizedMarkup = markup;
+        if ("development" !== 'production') {
+          // because rootMarkup is retrieved from the DOM, various normalizations
+          // will have occurred which will not be present in `markup`. Here,
+          // insert markup into a <div> or <iframe> depending on the container
+          // type to perform the same normalizations before comparing.
+          var normalizer;
+          if (container.nodeType === ELEMENT_NODE_TYPE) {
+            normalizer = document.createElement('div');
+            normalizer.innerHTML = markup;
+            normalizedMarkup = normalizer.innerHTML;
+          } else {
+            normalizer = document.createElement('iframe');
+            document.body.appendChild(normalizer);
+            normalizer.contentDocument.write(markup);
+            normalizedMarkup = normalizer.contentDocument.documentElement.outerHTML;
+            document.body.removeChild(normalizer);
+          }
+        }
+
+        var diffIndex = firstDifferenceIndex(normalizedMarkup, rootMarkup);
+        var difference = ' (client) ' + normalizedMarkup.substring(diffIndex - 20, diffIndex + 20) + '\n (server) ' + rootMarkup.substring(diffIndex - 20, diffIndex + 20);
+
+        !(container.nodeType !== DOC_NODE_TYPE) ? "development" !== 'production' ? invariant(false, 'You\'re trying to render a component to the document using server rendering but the checksum was invalid. This usually means you rendered a different component type or props on the client from the one on the server, or your render() methods are impure. React cannot handle this case due to cross-browser quirks by rendering at the document root. You should look for environment dependent code in your components and ensure the props are the same client and server side:\n%s', difference) : _prodInvariant('42', difference) : void 0;
+
+        if ("development" !== 'production') {
+          "development" !== 'production' ? warning(false, 'React attempted to reuse markup in a container but the ' + 'checksum was invalid. This generally means that you are ' + 'using server rendering and the markup generated on the ' + 'server was not what the client was expecting. React injected ' + 'new markup to compensate which works but you have lost many ' + 'of the benefits of server rendering. Instead, figure out ' + 'why the markup being generated is different on the client ' + 'or server:\n%s', difference) : void 0;
+        }
+      }
+    }
+
+    !(container.nodeType !== DOC_NODE_TYPE) ? "development" !== 'production' ? invariant(false, 'You\'re trying to render a component to the document but you didn\'t use server rendering. We can\'t do this without using server rendering due to cross-browser quirks. See ReactDOMServer.renderToString() for server rendering.') : _prodInvariant('43') : void 0;
+
+    if (transaction.useCreateElement) {
+      while (container.lastChild) {
+        container.removeChild(container.lastChild);
+      }
+      DOMLazyTree.insertTreeBefore(container, markup, null);
+    } else {
+      setInnerHTML(container, markup);
+      ReactDOMComponentTree.precacheNode(instance, container.firstChild);
+    }
+
+    if ("development" !== 'production') {
+      var hostNode = ReactDOMComponentTree.getInstanceFromNode(container.firstChild);
+      if (hostNode._debugID !== 0) {
+        ReactInstrumentation.debugTool.onHostOperation({
+          instanceID: hostNode._debugID,
+          type: 'mount',
+          payload: markup.toString()
+        });
+      }
+    }
+  }
+};
+
+module.exports = ReactMount;
+},{"11":11,"121":121,"126":126,"128":128,"130":130,"134":134,"135":135,"145":145,"152":152,"159":159,"26":26,"34":34,"35":35,"37":37,"58":58,"63":63,"64":64,"66":66,"75":75,"81":81,"82":82,"9":9}],68:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var ReactComponentEnvironment = _dereq_(29);
+var ReactInstanceMap = _dereq_(63);
+var ReactInstrumentation = _dereq_(64);
+
+var ReactCurrentOwner = _dereq_(134);
+var ReactReconciler = _dereq_(75);
+var ReactChildReconciler = _dereq_(27);
+
+var emptyFunction = _dereq_(144);
+var flattenChildren = _dereq_(109);
+var invariant = _dereq_(152);
+
+/**
+ * Make an update for markup to be rendered and inserted at a supplied index.
+ *
+ * @param {string} markup Markup that renders into an element.
+ * @param {number} toIndex Destination index.
+ * @private
+ */
+function makeInsertMarkup(markup, afterNode, toIndex) {
+  // NOTE: Null values reduce hidden classes.
+  return {
+    type: 'INSERT_MARKUP',
+    content: markup,
+    fromIndex: null,
+    fromNode: null,
+    toIndex: toIndex,
+    afterNode: afterNode
+  };
+}
+
+/**
+ * Make an update for moving an existing element to another index.
+ *
+ * @param {number} fromIndex Source index of the existing element.
+ * @param {number} toIndex Destination index of the element.
+ * @private
+ */
+function makeMove(child, afterNode, toIndex) {
+  // NOTE: Null values reduce hidden classes.
+  return {
+    type: 'MOVE_EXISTING',
+    content: null,
+    fromIndex: child._mountIndex,
+    fromNode: ReactReconciler.getHostNode(child),
+    toIndex: toIndex,
+    afterNode: afterNode
+  };
+}
+
+/**
+ * Make an update for removing an element at an index.
+ *
+ * @param {number} fromIndex Index of the element to remove.
+ * @private
+ */
+function makeRemove(child, node) {
+  // NOTE: Null values reduce hidden classes.
+  return {
+    type: 'REMOVE_NODE',
+    content: null,
+    fromIndex: child._mountIndex,
+    fromNode: node,
+    toIndex: null,
+    afterNode: null
+  };
+}
+
+/**
+ * Make an update for setting the markup of a node.
+ *
+ * @param {string} markup Markup that renders into an element.
+ * @private
+ */
+function makeSetMarkup(markup) {
+  // NOTE: Null values reduce hidden classes.
+  return {
+    type: 'SET_MARKUP',
+    content: markup,
+    fromIndex: null,
+    fromNode: null,
+    toIndex: null,
+    afterNode: null
+  };
+}
+
+/**
+ * Make an update for setting the text content.
+ *
+ * @param {string} textContent Text content to set.
+ * @private
+ */
+function makeTextContent(textContent) {
+  // NOTE: Null values reduce hidden classes.
+  return {
+    type: 'TEXT_CONTENT',
+    content: textContent,
+    fromIndex: null,
+    fromNode: null,
+    toIndex: null,
+    afterNode: null
+  };
+}
+
+/**
+ * Push an update, if any, onto the queue. Creates a new queue if none is
+ * passed and always returns the queue. Mutative.
+ */
+function enqueue(queue, update) {
+  if (update) {
+    queue = queue || [];
+    queue.push(update);
+  }
+  return queue;
+}
+
+/**
+ * Processes any enqueued updates.
+ *
+ * @private
+ */
+function processQueue(inst, updateQueue) {
+  ReactComponentEnvironment.processChildrenUpdates(inst, updateQueue);
+}
+
+var setChildrenForInstrumentation = emptyFunction;
+if ("development" !== 'production') {
+  var getDebugID = function (inst) {
+    if (!inst._debugID) {
+      // Check for ART-like instances. TODO: This is silly/gross.
+      var internal;
+      if (internal = ReactInstanceMap.get(inst)) {
+        inst = internal;
+      }
+    }
+    return inst._debugID;
+  };
+  setChildrenForInstrumentation = function (children) {
+    var debugID = getDebugID(this);
+    // TODO: React Native empty components are also multichild.
+    // This means they still get into this method but don't have _debugID.
+    if (debugID !== 0) {
+      ReactInstrumentation.debugTool.onSetChildren(debugID, children ? Object.keys(children).map(function (key) {
+        return children[key]._debugID;
+      }) : []);
+    }
+  };
+}
+
+/**
+ * ReactMultiChild are capable of reconciling multiple children.
+ *
+ * @class ReactMultiChild
+ * @internal
+ */
+var ReactMultiChild = {
+  /**
+   * Provides common functionality for components that must reconcile multiple
+   * children. This is used by `ReactDOMComponent` to mount, update, and
+   * unmount child components.
+   *
+   * @lends {ReactMultiChild.prototype}
+   */
+  Mixin: {
+    _reconcilerInstantiateChildren: function (nestedChildren, transaction, context) {
+      if ("development" !== 'production') {
+        var selfDebugID = getDebugID(this);
+        if (this._currentElement) {
+          try {
+            ReactCurrentOwner.current = this._currentElement._owner;
+            return ReactChildReconciler.instantiateChildren(nestedChildren, transaction, context, selfDebugID);
+          } finally {
+            ReactCurrentOwner.current = null;
+          }
+        }
+      }
+      return ReactChildReconciler.instantiateChildren(nestedChildren, transaction, context);
+    },
+
+    _reconcilerUpdateChildren: function (prevChildren, nextNestedChildrenElements, mountImages, removedNodes, transaction, context) {
+      var nextChildren;
+      var selfDebugID = 0;
+      if ("development" !== 'production') {
+        selfDebugID = getDebugID(this);
+        if (this._currentElement) {
+          try {
+            ReactCurrentOwner.current = this._currentElement._owner;
+            nextChildren = flattenChildren(nextNestedChildrenElements, selfDebugID);
+          } finally {
+            ReactCurrentOwner.current = null;
+          }
+          ReactChildReconciler.updateChildren(prevChildren, nextChildren, mountImages, removedNodes, transaction, this, this._hostContainerInfo, context, selfDebugID);
+          return nextChildren;
+        }
+      }
+      nextChildren = flattenChildren(nextNestedChildrenElements, selfDebugID);
+      ReactChildReconciler.updateChildren(prevChildren, nextChildren, mountImages, removedNodes, transaction, this, this._hostContainerInfo, context, selfDebugID);
+      return nextChildren;
+    },
+
+    /**
+     * Generates a "mount image" for each of the supplied children. In the case
+     * of `ReactDOMComponent`, a mount image is a string of markup.
+     *
+     * @param {?object} nestedChildren Nested child maps.
+     * @return {array} An array of mounted representations.
+     * @internal
+     */
+    mountChildren: function (nestedChildren, transaction, context) {
+      var children = this._reconcilerInstantiateChildren(nestedChildren, transaction, context);
+      this._renderedChildren = children;
+
+      var mountImages = [];
+      var index = 0;
+      for (var name in children) {
+        if (children.hasOwnProperty(name)) {
+          var child = children[name];
+          var selfDebugID = 0;
+          if ("development" !== 'production') {
+            selfDebugID = getDebugID(this);
+          }
+          var mountImage = ReactReconciler.mountComponent(child, transaction, this, this._hostContainerInfo, context, selfDebugID);
+          child._mountIndex = index++;
+          mountImages.push(mountImage);
+        }
+      }
+
+      if ("development" !== 'production') {
+        setChildrenForInstrumentation.call(this, children);
+      }
+
+      return mountImages;
+    },
+
+    /**
+     * Replaces any rendered children with a text content string.
+     *
+     * @param {string} nextContent String of content.
+     * @internal
+     */
+    updateTextContent: function (nextContent) {
+      var prevChildren = this._renderedChildren;
+      // Remove any rendered children.
+      ReactChildReconciler.unmountChildren(prevChildren, false);
+      for (var name in prevChildren) {
+        if (prevChildren.hasOwnProperty(name)) {
+          !false ? "development" !== 'production' ? invariant(false, 'updateTextContent called on non-empty component.') : _prodInvariant('118') : void 0;
+        }
+      }
+      // Set new text content.
+      var updates = [makeTextContent(nextContent)];
+      processQueue(this, updates);
+    },
+
+    /**
+     * Replaces any rendered children with a markup string.
+     *
+     * @param {string} nextMarkup String of markup.
+     * @internal
+     */
+    updateMarkup: function (nextMarkup) {
+      var prevChildren = this._renderedChildren;
+      // Remove any rendered children.
+      ReactChildReconciler.unmountChildren(prevChildren, false);
+      for (var name in prevChildren) {
+        if (prevChildren.hasOwnProperty(name)) {
+          !false ? "development" !== 'production' ? invariant(false, 'updateTextContent called on non-empty component.') : _prodInvariant('118') : void 0;
+        }
+      }
+      var updates = [makeSetMarkup(nextMarkup)];
+      processQueue(this, updates);
+    },
+
+    /**
+     * Updates the rendered children with new children.
+     *
+     * @param {?object} nextNestedChildrenElements Nested child element maps.
+     * @param {ReactReconcileTransaction} transaction
+     * @internal
+     */
+    updateChildren: function (nextNestedChildrenElements, transaction, context) {
+      // Hook used by React ART
+      this._updateChildren(nextNestedChildrenElements, transaction, context);
+    },
+
+    /**
+     * @param {?object} nextNestedChildrenElements Nested child element maps.
+     * @param {ReactReconcileTransaction} transaction
+     * @final
+     * @protected
+     */
+    _updateChildren: function (nextNestedChildrenElements, transaction, context) {
+      var prevChildren = this._renderedChildren;
+      var removedNodes = {};
+      var mountImages = [];
+      var nextChildren = this._reconcilerUpdateChildren(prevChildren, nextNestedChildrenElements, mountImages, removedNodes, transaction, context);
+      if (!nextChildren && !prevChildren) {
+        return;
+      }
+      var updates = null;
+      var name;
+      // `nextIndex` will increment for each child in `nextChildren`, but
+      // `lastIndex` will be the last index visited in `prevChildren`.
+      var nextIndex = 0;
+      var lastIndex = 0;
+      // `nextMountIndex` will increment for each newly mounted child.
+      var nextMountIndex = 0;
+      var lastPlacedNode = null;
+      for (name in nextChildren) {
+        if (!nextChildren.hasOwnProperty(name)) {
+          continue;
+        }
+        var prevChild = prevChildren && prevChildren[name];
+        var nextChild = nextChildren[name];
+        if (prevChild === nextChild) {
+          updates = enqueue(updates, this.moveChild(prevChild, lastPlacedNode, nextIndex, lastIndex));
+          lastIndex = Math.max(prevChild._mountIndex, lastIndex);
+          prevChild._mountIndex = nextIndex;
+        } else {
+          if (prevChild) {
+            // Update `lastIndex` before `_mountIndex` gets unset by unmounting.
+            lastIndex = Math.max(prevChild._mountIndex, lastIndex);
+            // The `removedNodes` loop below will actually remove the child.
+          }
+          // The child must be instantiated before it's mounted.
+          updates = enqueue(updates, this._mountChildAtIndex(nextChild, mountImages[nextMountIndex], lastPlacedNode, nextIndex, transaction, context));
+          nextMountIndex++;
+        }
+        nextIndex++;
+        lastPlacedNode = ReactReconciler.getHostNode(nextChild);
+      }
+      // Remove children that are no longer present.
+      for (name in removedNodes) {
+        if (removedNodes.hasOwnProperty(name)) {
+          updates = enqueue(updates, this._unmountChild(prevChildren[name], removedNodes[name]));
+        }
+      }
+      if (updates) {
+        processQueue(this, updates);
+      }
+      this._renderedChildren = nextChildren;
+
+      if ("development" !== 'production') {
+        setChildrenForInstrumentation.call(this, nextChildren);
+      }
+    },
+
+    /**
+     * Unmounts all rendered children. This should be used to clean up children
+     * when this component is unmounted. It does not actually perform any
+     * backend operations.
+     *
+     * @internal
+     */
+    unmountChildren: function (safely) {
+      var renderedChildren = this._renderedChildren;
+      ReactChildReconciler.unmountChildren(renderedChildren, safely);
+      this._renderedChildren = null;
+    },
+
+    /**
+     * Moves a child component to the supplied index.
+     *
+     * @param {ReactComponent} child Component to move.
+     * @param {number} toIndex Destination index of the element.
+     * @param {number} lastIndex Last index visited of the siblings of `child`.
+     * @protected
+     */
+    moveChild: function (child, afterNode, toIndex, lastIndex) {
+      // If the index of `child` is less than `lastIndex`, then it needs to
+      // be moved. Otherwise, we do not need to move it because a child will be
+      // inserted or moved before `child`.
+      if (child._mountIndex < lastIndex) {
+        return makeMove(child, afterNode, toIndex);
+      }
+    },
+
+    /**
+     * Creates a child component.
+     *
+     * @param {ReactComponent} child Component to create.
+     * @param {string} mountImage Markup to insert.
+     * @protected
+     */
+    createChild: function (child, afterNode, mountImage) {
+      return makeInsertMarkup(mountImage, afterNode, child._mountIndex);
+    },
+
+    /**
+     * Removes a child component.
+     *
+     * @param {ReactComponent} child Child to remove.
+     * @protected
+     */
+    removeChild: function (child, node) {
+      return makeRemove(child, node);
+    },
+
+    /**
+     * Mounts a child with the supplied name.
+     *
+     * NOTE: This is part of `updateChildren` and is here for readability.
+     *
+     * @param {ReactComponent} child Component to mount.
+     * @param {string} name Name of the child.
+     * @param {number} index Index at which to insert the child.
+     * @param {ReactReconcileTransaction} transaction
+     * @private
+     */
+    _mountChildAtIndex: function (child, mountImage, afterNode, index, transaction, context) {
+      child._mountIndex = index;
+      return this.createChild(child, afterNode, mountImage);
+    },
+
+    /**
+     * Unmounts a rendered child.
+     *
+     * NOTE: This is part of `updateChildren` and is here for readability.
+     *
+     * @param {ReactComponent} child Component to unmount.
+     * @private
+     */
+    _unmountChild: function (child, node) {
+      var update = this.removeChild(child, node);
+      child._mountIndex = null;
+      return update;
+    }
+  }
+};
+
+module.exports = ReactMultiChild;
+},{"109":109,"126":126,"134":134,"144":144,"152":152,"27":27,"29":29,"63":63,"64":64,"75":75}],69:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var React = _dereq_(135);
+
+var invariant = _dereq_(152);
+
+var ReactNodeTypes = {
+  HOST: 0,
+  COMPOSITE: 1,
+  EMPTY: 2,
+
+  getType: function (node) {
+    if (node === null || node === false) {
+      return ReactNodeTypes.EMPTY;
+    } else if (React.isValidElement(node)) {
+      if (typeof node.type === 'function') {
+        return ReactNodeTypes.COMPOSITE;
+      } else {
+        return ReactNodeTypes.HOST;
+      }
+    }
+    !false ? "development" !== 'production' ? invariant(false, 'Unexpected node: %s', node) : _prodInvariant('26', node) : void 0;
+  }
+};
+
+module.exports = ReactNodeTypes;
+},{"126":126,"135":135,"152":152}],70:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var invariant = _dereq_(152);
+
+/**
+ * @param {?object} object
+ * @return {boolean} True if `object` is a valid owner.
+ * @final
+ */
+function isValidOwner(object) {
+  return !!(object && typeof object.attachRef === 'function' && typeof object.detachRef === 'function');
+}
+
+/**
+ * ReactOwners are capable of storing references to owned components.
+ *
+ * All components are capable of //being// referenced by owner components, but
+ * only ReactOwner components are capable of //referencing// owned components.
+ * The named reference is known as a "ref".
+ *
+ * Refs are available when mounted and updated during reconciliation.
+ *
+ *   var MyComponent = React.createClass({
+ *     render: function() {
+ *       return (
+ *         <div onClick={this.handleClick}>
+ *           <CustomComponent ref="custom" />
+ *         </div>
+ *       );
+ *     },
+ *     handleClick: function() {
+ *       this.refs.custom.handleClick();
+ *     },
+ *     componentDidMount: function() {
+ *       this.refs.custom.initialize();
+ *     }
+ *   });
+ *
+ * Refs should rarely be used. When refs are used, they should only be done to
+ * control data that is not handled by React's data flow.
+ *
+ * @class ReactOwner
+ */
+var ReactOwner = {
+  /**
+   * Adds a component by ref to an owner component.
+   *
+   * @param {ReactComponent} component Component to reference.
+   * @param {string} ref Name by which to refer to the component.
+   * @param {ReactOwner} owner Component on which to record the ref.
+   * @final
+   * @internal
+   */
+  addComponentAsRefTo: function (component, ref, owner) {
+    !isValidOwner(owner) ? "development" !== 'production' ? invariant(false, 'addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component\'s `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).') : _prodInvariant('119') : void 0;
+    owner.attachRef(ref, component);
+  },
+
+  /**
+   * Removes a component by ref from an owner component.
+   *
+   * @param {ReactComponent} component Component to dereference.
+   * @param {string} ref Name of the ref to remove.
+   * @param {ReactOwner} owner Component on which the ref is recorded.
+   * @final
+   * @internal
+   */
+  removeComponentAsRefFrom: function (component, ref, owner) {
+    !isValidOwner(owner) ? "development" !== 'production' ? invariant(false, 'removeComponentAsRefFrom(...): Only a ReactOwner can have refs. You might be removing a ref to a component that was not created inside a component\'s `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).') : _prodInvariant('120') : void 0;
+    var ownerPublicInstance = owner.getPublicInstance();
+    // Check that `component`'s owner is still alive and that `component` is still the current ref
+    // because we do not want to detach the ref if another component stole it.
+    if (ownerPublicInstance && ownerPublicInstance.refs[ref] === component.getPublicInstance()) {
+      owner.detachRef(ref);
+    }
+  }
+};
+
+module.exports = ReactOwner;
+},{"126":126,"152":152}],71:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var _extends = _assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var ReactDebugTool = _dereq_(50);
+var lowPriorityWarning = _dereq_(124);
+var alreadyWarned = false;
+
+function roundFloat(val) {
+  var base = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
+
+  var n = Math.pow(10, base);
+  return Math.floor(val * n) / n;
+}
+
+// Flow type definition of console.table is too strict right now, see
+// https://github.com/facebook/flow/pull/2353 for updates
+function consoleTable(table) {
+  console.table(table);
+}
+
+function warnInProduction() {
+  if (alreadyWarned) {
+    return;
+  }
+  alreadyWarned = true;
+  if (typeof console !== 'undefined') {
+    console.error('ReactPerf is not supported in the production builds of React. ' + 'To collect measurements, please use the development build of React instead.');
+  }
+}
+
+function getLastMeasurements() {
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return [];
+  }
+
+  return ReactDebugTool.getFlushHistory();
+}
+
+function getExclusive() {
+  var flushHistory = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getLastMeasurements();
+
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return [];
+  }
+
+  var aggregatedStats = {};
+  var affectedIDs = {};
+
+  function updateAggregatedStats(treeSnapshot, instanceID, timerType, applyUpdate) {
+    var displayName = treeSnapshot[instanceID].displayName;
+
+    var key = displayName;
+    var stats = aggregatedStats[key];
+    if (!stats) {
+      affectedIDs[key] = {};
+      stats = aggregatedStats[key] = {
+        key: key,
+        instanceCount: 0,
+        counts: {},
+        durations: {},
+        totalDuration: 0
+      };
+    }
+    if (!stats.durations[timerType]) {
+      stats.durations[timerType] = 0;
+    }
+    if (!stats.counts[timerType]) {
+      stats.counts[timerType] = 0;
+    }
+    affectedIDs[key][instanceID] = true;
+    applyUpdate(stats);
+  }
+
+  flushHistory.forEach(function (flush) {
+    var measurements = flush.measurements,
+        treeSnapshot = flush.treeSnapshot;
+
+    measurements.forEach(function (measurement) {
+      var duration = measurement.duration,
+          instanceID = measurement.instanceID,
+          timerType = measurement.timerType;
+
+      updateAggregatedStats(treeSnapshot, instanceID, timerType, function (stats) {
+        stats.totalDuration += duration;
+        stats.durations[timerType] += duration;
+        stats.counts[timerType]++;
+      });
+    });
+  });
+
+  return Object.keys(aggregatedStats).map(function (key) {
+    return _extends({}, aggregatedStats[key], {
+      instanceCount: Object.keys(affectedIDs[key]).length
+    });
+  }).sort(function (a, b) {
+    return b.totalDuration - a.totalDuration;
+  });
+}
+
+function getInclusive() {
+  var flushHistory = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getLastMeasurements();
+
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return [];
+  }
+
+  var aggregatedStats = {};
+  var affectedIDs = {};
+
+  function updateAggregatedStats(treeSnapshot, instanceID, applyUpdate) {
+    var _treeSnapshot$instanc = treeSnapshot[instanceID],
+        displayName = _treeSnapshot$instanc.displayName,
+        ownerID = _treeSnapshot$instanc.ownerID;
+
+    var owner = treeSnapshot[ownerID];
+    var key = (owner ? owner.displayName + ' > ' : '') + displayName;
+    var stats = aggregatedStats[key];
+    if (!stats) {
+      affectedIDs[key] = {};
+      stats = aggregatedStats[key] = {
+        key: key,
+        instanceCount: 0,
+        inclusiveRenderDuration: 0,
+        renderCount: 0
+      };
+    }
+    affectedIDs[key][instanceID] = true;
+    applyUpdate(stats);
+  }
+
+  var isCompositeByID = {};
+  flushHistory.forEach(function (flush) {
+    var measurements = flush.measurements;
+
+    measurements.forEach(function (measurement) {
+      var instanceID = measurement.instanceID,
+          timerType = measurement.timerType;
+
+      if (timerType !== 'render') {
+        return;
+      }
+      isCompositeByID[instanceID] = true;
+    });
+  });
+
+  flushHistory.forEach(function (flush) {
+    var measurements = flush.measurements,
+        treeSnapshot = flush.treeSnapshot;
+
+    measurements.forEach(function (measurement) {
+      var duration = measurement.duration,
+          instanceID = measurement.instanceID,
+          timerType = measurement.timerType;
+
+      if (timerType !== 'render') {
+        return;
+      }
+      updateAggregatedStats(treeSnapshot, instanceID, function (stats) {
+        stats.renderCount++;
+      });
+      var nextParentID = instanceID;
+      while (nextParentID) {
+        // As we traverse parents, only count inclusive time towards composites.
+        // We know something is a composite if its render() was called.
+        if (isCompositeByID[nextParentID]) {
+          updateAggregatedStats(treeSnapshot, nextParentID, function (stats) {
+            stats.inclusiveRenderDuration += duration;
+          });
+        }
+        nextParentID = treeSnapshot[nextParentID].parentID;
+      }
+    });
+  });
+
+  return Object.keys(aggregatedStats).map(function (key) {
+    return _extends({}, aggregatedStats[key], {
+      instanceCount: Object.keys(affectedIDs[key]).length
+    });
+  }).sort(function (a, b) {
+    return b.inclusiveRenderDuration - a.inclusiveRenderDuration;
+  });
+}
+
+function getWasted() {
+  var flushHistory = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getLastMeasurements();
+
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return [];
+  }
+
+  var aggregatedStats = {};
+  var affectedIDs = {};
+
+  function updateAggregatedStats(treeSnapshot, instanceID, applyUpdate) {
+    var _treeSnapshot$instanc2 = treeSnapshot[instanceID],
+        displayName = _treeSnapshot$instanc2.displayName,
+        ownerID = _treeSnapshot$instanc2.ownerID;
+
+    var owner = treeSnapshot[ownerID];
+    var key = (owner ? owner.displayName + ' > ' : '') + displayName;
+    var stats = aggregatedStats[key];
+    if (!stats) {
+      affectedIDs[key] = {};
+      stats = aggregatedStats[key] = {
+        key: key,
+        instanceCount: 0,
+        inclusiveRenderDuration: 0,
+        renderCount: 0
+      };
+    }
+    affectedIDs[key][instanceID] = true;
+    applyUpdate(stats);
+  }
+
+  flushHistory.forEach(function (flush) {
+    var measurements = flush.measurements,
+        treeSnapshot = flush.treeSnapshot,
+        operations = flush.operations;
+
+    var isDefinitelyNotWastedByID = {};
+
+    // Find host components associated with an operation in this batch.
+    // Mark all components in their parent tree as definitely not wasted.
+    operations.forEach(function (operation) {
+      var instanceID = operation.instanceID;
+
+      var nextParentID = instanceID;
+      while (nextParentID) {
+        isDefinitelyNotWastedByID[nextParentID] = true;
+        nextParentID = treeSnapshot[nextParentID].parentID;
+      }
+    });
+
+    // Find composite components that rendered in this batch.
+    // These are potential candidates for being wasted renders.
+    var renderedCompositeIDs = {};
+    measurements.forEach(function (measurement) {
+      var instanceID = measurement.instanceID,
+          timerType = measurement.timerType;
+
+      if (timerType !== 'render') {
+        return;
+      }
+      renderedCompositeIDs[instanceID] = true;
+    });
+
+    measurements.forEach(function (measurement) {
+      var duration = measurement.duration,
+          instanceID = measurement.instanceID,
+          timerType = measurement.timerType;
+
+      if (timerType !== 'render') {
+        return;
+      }
+
+      // If there was a DOM update below this component, or it has just been
+      // mounted, its render() is not considered wasted.
+      var updateCount = treeSnapshot[instanceID].updateCount;
+
+      if (isDefinitelyNotWastedByID[instanceID] || updateCount === 0) {
+        return;
+      }
+
+      // We consider this render() wasted.
+      updateAggregatedStats(treeSnapshot, instanceID, function (stats) {
+        stats.renderCount++;
+      });
+
+      var nextParentID = instanceID;
+      while (nextParentID) {
+        // Any parents rendered during this batch are considered wasted
+        // unless we previously marked them as dirty.
+        var isWasted = renderedCompositeIDs[nextParentID] && !isDefinitelyNotWastedByID[nextParentID];
+        if (isWasted) {
+          updateAggregatedStats(treeSnapshot, nextParentID, function (stats) {
+            stats.inclusiveRenderDuration += duration;
+          });
+        }
+        nextParentID = treeSnapshot[nextParentID].parentID;
+      }
+    });
+  });
+
+  return Object.keys(aggregatedStats).map(function (key) {
+    return _extends({}, aggregatedStats[key], {
+      instanceCount: Object.keys(affectedIDs[key]).length
+    });
+  }).sort(function (a, b) {
+    return b.inclusiveRenderDuration - a.inclusiveRenderDuration;
+  });
+}
+
+function getOperations() {
+  var flushHistory = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getLastMeasurements();
+
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return [];
+  }
+
+  var stats = [];
+  flushHistory.forEach(function (flush, flushIndex) {
+    var operations = flush.operations,
+        treeSnapshot = flush.treeSnapshot;
+
+    operations.forEach(function (operation) {
+      var instanceID = operation.instanceID,
+          type = operation.type,
+          payload = operation.payload;
+      var _treeSnapshot$instanc3 = treeSnapshot[instanceID],
+          displayName = _treeSnapshot$instanc3.displayName,
+          ownerID = _treeSnapshot$instanc3.ownerID;
+
+      var owner = treeSnapshot[ownerID];
+      var key = (owner ? owner.displayName + ' > ' : '') + displayName;
+
+      stats.push({
+        flushIndex: flushIndex,
+        instanceID: instanceID,
+        key: key,
+        type: type,
+        ownerID: ownerID,
+        payload: payload
+      });
+    });
+  });
+  return stats;
+}
+
+function printExclusive(flushHistory) {
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return;
+  }
+
+  var stats = getExclusive(flushHistory);
+  var table = stats.map(function (item) {
+    var key = item.key,
+        instanceCount = item.instanceCount,
+        totalDuration = item.totalDuration;
+
+    var renderCount = item.counts.render || 0;
+    var renderDuration = item.durations.render || 0;
+    return {
+      Component: key,
+      'Total time (ms)': roundFloat(totalDuration),
+      'Instance count': instanceCount,
+      'Total render time (ms)': roundFloat(renderDuration),
+      'Average render time (ms)': renderCount ? roundFloat(renderDuration / renderCount) : undefined,
+      'Render count': renderCount,
+      'Total lifecycle time (ms)': roundFloat(totalDuration - renderDuration)
+    };
+  });
+  consoleTable(table);
+}
+
+function printInclusive(flushHistory) {
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return;
+  }
+
+  var stats = getInclusive(flushHistory);
+  var table = stats.map(function (item) {
+    var key = item.key,
+        instanceCount = item.instanceCount,
+        inclusiveRenderDuration = item.inclusiveRenderDuration,
+        renderCount = item.renderCount;
+
+    return {
+      'Owner > Component': key,
+      'Inclusive render time (ms)': roundFloat(inclusiveRenderDuration),
+      'Instance count': instanceCount,
+      'Render count': renderCount
+    };
+  });
+  consoleTable(table);
+}
+
+function printWasted(flushHistory) {
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return;
+  }
+
+  var stats = getWasted(flushHistory);
+  var table = stats.map(function (item) {
+    var key = item.key,
+        instanceCount = item.instanceCount,
+        inclusiveRenderDuration = item.inclusiveRenderDuration,
+        renderCount = item.renderCount;
+
+    return {
+      'Owner > Component': key,
+      'Inclusive wasted time (ms)': roundFloat(inclusiveRenderDuration),
+      'Instance count': instanceCount,
+      'Render count': renderCount
+    };
+  });
+  consoleTable(table);
+}
+
+function printOperations(flushHistory) {
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return;
+  }
+
+  var stats = getOperations(flushHistory);
+  var table = stats.map(function (stat) {
+    return {
+      'Owner > Node': stat.key,
+      Operation: stat.type,
+      Payload: typeof stat.payload === 'object' ? JSON.stringify(stat.payload) : stat.payload,
+      'Flush index': stat.flushIndex,
+      'Owner Component ID': stat.ownerID,
+      'DOM Component ID': stat.instanceID
+    };
+  });
+  consoleTable(table);
+}
+
+var warnedAboutPrintDOM = false;
+function printDOM(measurements) {
+  lowPriorityWarning(warnedAboutPrintDOM, '`ReactPerf.printDOM(...)` is deprecated. Use ' + '`ReactPerf.printOperations(...)` instead.');
+  warnedAboutPrintDOM = true;
+  return printOperations(measurements);
+}
+
+var warnedAboutGetMeasurementsSummaryMap = false;
+function getMeasurementsSummaryMap(measurements) {
+  lowPriorityWarning(warnedAboutGetMeasurementsSummaryMap, '`ReactPerf.getMeasurementsSummaryMap(...)` is deprecated. Use ' + '`ReactPerf.getWasted(...)` instead.');
+  warnedAboutGetMeasurementsSummaryMap = true;
+  return getWasted(measurements);
+}
+
+function start() {
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return;
+  }
+
+  ReactDebugTool.beginProfiling();
+}
+
+function stop() {
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return;
+  }
+
+  ReactDebugTool.endProfiling();
+}
+
+function isRunning() {
+  if (!("development" !== 'production')) {
+    warnInProduction();
+    return false;
+  }
+
+  return ReactDebugTool.isProfiling();
+}
+
+var ReactPerfAnalysis = {
+  getLastMeasurements: getLastMeasurements,
+  getExclusive: getExclusive,
+  getInclusive: getInclusive,
+  getWasted: getWasted,
+  getOperations: getOperations,
+  printExclusive: printExclusive,
+  printInclusive: printInclusive,
+  printWasted: printWasted,
+  printOperations: printOperations,
+  start: start,
+  stop: stop,
+  isRunning: isRunning,
+  // Deprecated:
+  printDOM: printDOM,
+  getMeasurementsSummaryMap: getMeasurementsSummaryMap
+};
+
+module.exports = ReactPerfAnalysis;
+},{"124":124,"160":160,"50":50}],72:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var ReactPropTypeLocationNames = {};
+
+if ("development" !== 'production') {
+  ReactPropTypeLocationNames = {
+    prop: 'prop',
+    context: 'context',
+    childContext: 'child context'
+  };
+}
+
+module.exports = ReactPropTypeLocationNames;
+},{}],73:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+
+module.exports = ReactPropTypesSecret;
+},{}],74:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var CallbackQueue = _dereq_(6);
+var PooledClass = _dereq_(25);
+var ReactBrowserEventEmitter = _dereq_(26);
+var ReactInputSelection = _dereq_(62);
+var ReactInstrumentation = _dereq_(64);
+var Transaction = _dereq_(100);
+var ReactUpdateQueue = _dereq_(81);
+
+/**
+ * Ensures that, when possible, the selection range (currently selected text
+ * input) is not disturbed by performing the transaction.
+ */
+var SELECTION_RESTORATION = {
+  /**
+   * @return {Selection} Selection information.
+   */
+  initialize: ReactInputSelection.getSelectionInformation,
+  /**
+   * @param {Selection} sel Selection information returned from `initialize`.
+   */
+  close: ReactInputSelection.restoreSelection
+};
+
+/**
+ * Suppresses events (blur/focus) that could be inadvertently dispatched due to
+ * high level DOM manipulations (like temporarily removing a text input from the
+ * DOM).
+ */
+var EVENT_SUPPRESSION = {
+  /**
+   * @return {boolean} The enabled status of `ReactBrowserEventEmitter` before
+   * the reconciliation.
+   */
+  initialize: function () {
+    var currentlyEnabled = ReactBrowserEventEmitter.isEnabled();
+    ReactBrowserEventEmitter.setEnabled(false);
+    return currentlyEnabled;
+  },
+
+  /**
+   * @param {boolean} previouslyEnabled Enabled status of
+   *   `ReactBrowserEventEmitter` before the reconciliation occurred. `close`
+   *   restores the previous value.
+   */
+  close: function (previouslyEnabled) {
+    ReactBrowserEventEmitter.setEnabled(previouslyEnabled);
+  }
+};
+
+/**
+ * Provides a queue for collecting `componentDidMount` and
+ * `componentDidUpdate` callbacks during the transaction.
+ */
+var ON_DOM_READY_QUEUEING = {
+  /**
+   * Initializes the internal `onDOMReady` queue.
+   */
+  initialize: function () {
+    this.reactMountReady.reset();
+  },
+
+  /**
+   * After DOM is flushed, invoke all registered `onDOMReady` callbacks.
+   */
+  close: function () {
+    this.reactMountReady.notifyAll();
+  }
+};
+
+/**
+ * Executed within the scope of the `Transaction` instance. Consider these as
+ * being member methods, but with an implied ordering while being isolated from
+ * each other.
+ */
+var TRANSACTION_WRAPPERS = [SELECTION_RESTORATION, EVENT_SUPPRESSION, ON_DOM_READY_QUEUEING];
+
+if ("development" !== 'production') {
+  TRANSACTION_WRAPPERS.push({
+    initialize: ReactInstrumentation.debugTool.onBeginFlush,
+    close: ReactInstrumentation.debugTool.onEndFlush
+  });
+}
+
+/**
+ * Currently:
+ * - The order that these are listed in the transaction is critical:
+ * - Suppresses events.
+ * - Restores selection range.
+ *
+ * Future:
+ * - Restore document/overflow scroll positions that were unintentionally
+ *   modified via DOM insertions above the top viewport boundary.
+ * - Implement/integrate with customized constraint based layout system and keep
+ *   track of which dimensions must be remeasured.
+ *
+ * @class ReactReconcileTransaction
+ */
+function ReactReconcileTransaction(useCreateElement) {
+  this.reinitializeTransaction();
+  // Only server-side rendering really needs this option (see
+  // `ReactServerRendering`), but server-side uses
+  // `ReactServerRenderingTransaction` instead. This option is here so that it's
+  // accessible and defaults to false when `ReactDOMComponent` and
+  // `ReactDOMTextComponent` checks it in `mountComponent`.`
+  this.renderToStaticMarkup = false;
+  this.reactMountReady = CallbackQueue.getPooled(null);
+  this.useCreateElement = useCreateElement;
+}
+
+var Mixin = {
+  /**
+   * @see Transaction
+   * @abstract
+   * @final
+   * @return {array<object>} List of operation wrap procedures.
+   *   TODO: convert to array<TransactionWrapper>
+   */
+  getTransactionWrappers: function () {
+    return TRANSACTION_WRAPPERS;
+  },
+
+  /**
+   * @return {object} The queue to collect `onDOMReady` callbacks with.
+   */
+  getReactMountReady: function () {
+    return this.reactMountReady;
+  },
+
+  /**
+   * @return {object} The queue to collect React async events.
+   */
+  getUpdateQueue: function () {
+    return ReactUpdateQueue;
+  },
+
+  /**
+   * Save current transaction state -- if the return value from this method is
+   * passed to `rollback`, the transaction will be reset to that state.
+   */
+  checkpoint: function () {
+    // reactMountReady is the our only stateful wrapper
+    return this.reactMountReady.checkpoint();
+  },
+
+  rollback: function (checkpoint) {
+    this.reactMountReady.rollback(checkpoint);
+  },
+
+  /**
+   * `PooledClass` looks for this, and will invoke this before allowing this
+   * instance to be reused.
+   */
+  destructor: function () {
+    CallbackQueue.release(this.reactMountReady);
+    this.reactMountReady = null;
+  }
+};
+
+_assign(ReactReconcileTransaction.prototype, Transaction, Mixin);
+
+PooledClass.addPoolingTo(ReactReconcileTransaction);
+
+module.exports = ReactReconcileTransaction;
+},{"100":100,"160":160,"25":25,"26":26,"6":6,"62":62,"64":64,"81":81}],75:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ReactRef = _dereq_(76);
+var ReactInstrumentation = _dereq_(64);
+
+var warning = _dereq_(159);
+
+/**
+ * Helper to call ReactRef.attachRefs with this composite component, split out
+ * to avoid allocations in the transaction mount-ready queue.
+ */
+function attachRefs() {
+  ReactRef.attachRefs(this, this._currentElement);
+}
+
+var ReactReconciler = {
+  /**
+   * Initializes the component, renders markup, and registers event listeners.
+   *
+   * @param {ReactComponent} internalInstance
+   * @param {ReactReconcileTransaction|ReactServerRenderingTransaction} transaction
+   * @param {?object} the containing host component instance
+   * @param {?object} info about the host container
+   * @return {?string} Rendered markup to be inserted into the DOM.
+   * @final
+   * @internal
+   */
+  mountComponent: function (internalInstance, transaction, hostParent, hostContainerInfo, context, parentDebugID) // 0 in production and for roots
+  {
+    if ("development" !== 'production') {
+      if (internalInstance._debugID !== 0) {
+        ReactInstrumentation.debugTool.onBeforeMountComponent(internalInstance._debugID, internalInstance._currentElement, parentDebugID);
+      }
+    }
+    var markup = internalInstance.mountComponent(transaction, hostParent, hostContainerInfo, context, parentDebugID);
+    if (internalInstance._currentElement && internalInstance._currentElement.ref != null) {
+      transaction.getReactMountReady().enqueue(attachRefs, internalInstance);
+    }
+    if ("development" !== 'production') {
+      if (internalInstance._debugID !== 0) {
+        ReactInstrumentation.debugTool.onMountComponent(internalInstance._debugID);
+      }
+    }
+    return markup;
+  },
+
+  /**
+   * Returns a value that can be passed to
+   * ReactComponentEnvironment.replaceNodeWithMarkup.
+   */
+  getHostNode: function (internalInstance) {
+    return internalInstance.getHostNode();
+  },
+
+  /**
+   * Releases any resources allocated by `mountComponent`.
+   *
+   * @final
+   * @internal
+   */
+  unmountComponent: function (internalInstance, safely) {
+    if ("development" !== 'production') {
+      if (internalInstance._debugID !== 0) {
+        ReactInstrumentation.debugTool.onBeforeUnmountComponent(internalInstance._debugID);
+      }
+    }
+    ReactRef.detachRefs(internalInstance, internalInstance._currentElement);
+    internalInstance.unmountComponent(safely);
+    if ("development" !== 'production') {
+      if (internalInstance._debugID !== 0) {
+        ReactInstrumentation.debugTool.onUnmountComponent(internalInstance._debugID);
+      }
+    }
+  },
+
+  /**
+   * Update a component using a new element.
+   *
+   * @param {ReactComponent} internalInstance
+   * @param {ReactElement} nextElement
+   * @param {ReactReconcileTransaction} transaction
+   * @param {object} context
+   * @internal
+   */
+  receiveComponent: function (internalInstance, nextElement, transaction, context) {
+    var prevElement = internalInstance._currentElement;
+
+    if (nextElement === prevElement && context === internalInstance._context) {
+      // Since elements are immutable after the owner is rendered,
+      // we can do a cheap identity compare here to determine if this is a
+      // superfluous reconcile. It's possible for state to be mutable but such
+      // change should trigger an update of the owner which would recreate
+      // the element. We explicitly check for the existence of an owner since
+      // it's possible for an element created outside a composite to be
+      // deeply mutated and reused.
+
+      // TODO: Bailing out early is just a perf optimization right?
+      // TODO: Removing the return statement should affect correctness?
+      return;
+    }
+
+    if ("development" !== 'production') {
+      if (internalInstance._debugID !== 0) {
+        ReactInstrumentation.debugTool.onBeforeUpdateComponent(internalInstance._debugID, nextElement);
+      }
+    }
+
+    var refsChanged = ReactRef.shouldUpdateRefs(prevElement, nextElement);
+
+    if (refsChanged) {
+      ReactRef.detachRefs(internalInstance, prevElement);
+    }
+
+    internalInstance.receiveComponent(nextElement, transaction, context);
+
+    if (refsChanged && internalInstance._currentElement && internalInstance._currentElement.ref != null) {
+      transaction.getReactMountReady().enqueue(attachRefs, internalInstance);
+    }
+
+    if ("development" !== 'production') {
+      if (internalInstance._debugID !== 0) {
+        ReactInstrumentation.debugTool.onUpdateComponent(internalInstance._debugID);
+      }
+    }
+  },
+
+  /**
+   * Flush any dirty changes in a component.
+   *
+   * @param {ReactComponent} internalInstance
+   * @param {ReactReconcileTransaction} transaction
+   * @internal
+   */
+  performUpdateIfNecessary: function (internalInstance, transaction, updateBatchNumber) {
+    if (internalInstance._updateBatchNumber !== updateBatchNumber) {
+      // The component's enqueued batch number should always be the current
+      // batch or the following one.
+      "development" !== 'production' ? warning(internalInstance._updateBatchNumber == null || internalInstance._updateBatchNumber === updateBatchNumber + 1, 'performUpdateIfNecessary: Unexpected batch number (current %s, ' + 'pending %s)', updateBatchNumber, internalInstance._updateBatchNumber) : void 0;
+      return;
+    }
+    if ("development" !== 'production') {
+      if (internalInstance._debugID !== 0) {
+        ReactInstrumentation.debugTool.onBeforeUpdateComponent(internalInstance._debugID, internalInstance._currentElement);
+      }
+    }
+    internalInstance.performUpdateIfNecessary(transaction);
+    if ("development" !== 'production') {
+      if (internalInstance._debugID !== 0) {
+        ReactInstrumentation.debugTool.onUpdateComponent(internalInstance._debugID);
+      }
+    }
+  }
+};
+
+module.exports = ReactReconciler;
+},{"159":159,"64":64,"76":76}],76:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var ReactOwner = _dereq_(70);
+
+var ReactRef = {};
+
+function attachRef(ref, component, owner) {
+  if (typeof ref === 'function') {
+    ref(component.getPublicInstance());
+  } else {
+    // Legacy ref
+    ReactOwner.addComponentAsRefTo(component, ref, owner);
+  }
+}
+
+function detachRef(ref, component, owner) {
+  if (typeof ref === 'function') {
+    ref(null);
+  } else {
+    // Legacy ref
+    ReactOwner.removeComponentAsRefFrom(component, ref, owner);
+  }
+}
+
+ReactRef.attachRefs = function (instance, element) {
+  if (element === null || typeof element !== 'object') {
+    return;
+  }
+  var ref = element.ref;
+  if (ref != null) {
+    attachRef(ref, instance, element._owner);
+  }
+};
+
+ReactRef.shouldUpdateRefs = function (prevElement, nextElement) {
+  // If either the owner or a `ref` has changed, make sure the newest owner
+  // has stored a reference to `this`, and the previous owner (if different)
+  // has forgotten the reference to `this`. We use the element instead
+  // of the public this.props because the post processing cannot determine
+  // a ref. The ref conceptually lives on the element.
+
+  // TODO: Should this even be possible? The owner cannot change because
+  // it's forbidden by shouldUpdateReactComponent. The ref can change
+  // if you swap the keys of but not the refs. Reconsider where this check
+  // is made. It probably belongs where the key checking and
+  // instantiateReactComponent is done.
+
+  var prevRef = null;
+  var prevOwner = null;
+  if (prevElement !== null && typeof prevElement === 'object') {
+    prevRef = prevElement.ref;
+    prevOwner = prevElement._owner;
+  }
+
+  var nextRef = null;
+  var nextOwner = null;
+  if (nextElement !== null && typeof nextElement === 'object') {
+    nextRef = nextElement.ref;
+    nextOwner = nextElement._owner;
+  }
+
+  return prevRef !== nextRef ||
+  // If owner changes but we have an unchanged function ref, don't update refs
+  typeof nextRef === 'string' && nextOwner !== prevOwner;
+};
+
+ReactRef.detachRefs = function (instance, element) {
+  if (element === null || typeof element !== 'object') {
+    return;
+  }
+  var ref = element.ref;
+  if (ref != null) {
+    detachRef(ref, instance, element._owner);
+  }
+};
+
+module.exports = ReactRef;
+},{"70":70}],77:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var PooledClass = _dereq_(25);
+var Transaction = _dereq_(100);
+var ReactInstrumentation = _dereq_(64);
+var ReactServerUpdateQueue = _dereq_(78);
+
+/**
+ * Executed within the scope of the `Transaction` instance. Consider these as
+ * being member methods, but with an implied ordering while being isolated from
+ * each other.
+ */
+var TRANSACTION_WRAPPERS = [];
+
+if ("development" !== 'production') {
+  TRANSACTION_WRAPPERS.push({
+    initialize: ReactInstrumentation.debugTool.onBeginFlush,
+    close: ReactInstrumentation.debugTool.onEndFlush
+  });
+}
+
+var noopCallbackQueue = {
+  enqueue: function () {}
+};
+
+/**
+ * @class ReactServerRenderingTransaction
+ * @param {boolean} renderToStaticMarkup
+ */
+function ReactServerRenderingTransaction(renderToStaticMarkup) {
+  this.reinitializeTransaction();
+  this.renderToStaticMarkup = renderToStaticMarkup;
+  this.useCreateElement = false;
+  this.updateQueue = new ReactServerUpdateQueue(this);
+}
+
+var Mixin = {
+  /**
+   * @see Transaction
+   * @abstract
+   * @final
+   * @return {array} Empty list of operation wrap procedures.
+   */
+  getTransactionWrappers: function () {
+    return TRANSACTION_WRAPPERS;
+  },
+
+  /**
+   * @return {object} The queue to collect `onDOMReady` callbacks with.
+   */
+  getReactMountReady: function () {
+    return noopCallbackQueue;
+  },
+
+  /**
+   * @return {object} The queue to collect React async events.
+   */
+  getUpdateQueue: function () {
+    return this.updateQueue;
+  },
+
+  /**
+   * `PooledClass` looks for this, and will invoke this before allowing this
+   * instance to be reused.
+   */
+  destructor: function () {},
+
+  checkpoint: function () {},
+
+  rollback: function () {}
+};
+
+_assign(ReactServerRenderingTransaction.prototype, Transaction, Mixin);
+
+PooledClass.addPoolingTo(ReactServerRenderingTransaction);
+
+module.exports = ReactServerRenderingTransaction;
+},{"100":100,"160":160,"25":25,"64":64,"78":78}],78:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var ReactUpdateQueue = _dereq_(81);
+
+var warning = _dereq_(159);
+
+function warnNoop(publicInstance, callerName) {
+  if ("development" !== 'production') {
+    var constructor = publicInstance.constructor;
+    "development" !== 'production' ? warning(false, '%s(...): Can only update a mounting component. ' + 'This usually means you called %s() outside componentWillMount() on the server. ' + 'This is a no-op. Please check the code for the %s component.', callerName, callerName, constructor && (constructor.displayName || constructor.name) || 'ReactClass') : void 0;
+  }
+}
+
+/**
+ * This is the update queue used for server rendering.
+ * It delegates to ReactUpdateQueue while server rendering is in progress and
+ * switches to ReactNoopUpdateQueue after the transaction has completed.
+ * @class ReactServerUpdateQueue
+ * @param {Transaction} transaction
+ */
+
+var ReactServerUpdateQueue = function () {
+  function ReactServerUpdateQueue(transaction) {
+    _classCallCheck(this, ReactServerUpdateQueue);
+
+    this.transaction = transaction;
+  }
+
+  /**
+   * Checks whether or not this composite component is mounted.
+   * @param {ReactClass} publicInstance The instance we want to test.
+   * @return {boolean} True if mounted, false otherwise.
+   * @protected
+   * @final
+   */
+
+
+  ReactServerUpdateQueue.prototype.isMounted = function isMounted(publicInstance) {
+    return false;
+  };
+
+  /**
+   * Enqueue a callback that will be executed after all the pending updates
+   * have processed.
+   *
+   * @param {ReactClass} publicInstance The instance to use as `this` context.
+   * @param {?function} callback Called after state is updated.
+   * @internal
+   */
+
+
+  ReactServerUpdateQueue.prototype.enqueueCallback = function enqueueCallback(publicInstance, callback, callerName) {
+    if (this.transaction.isInTransaction()) {
+      ReactUpdateQueue.enqueueCallback(publicInstance, callback, callerName);
+    }
+  };
+
+  /**
+   * Forces an update. This should only be invoked when it is known with
+   * certainty that we are **not** in a DOM transaction.
+   *
+   * You may want to call this when you know that some deeper aspect of the
+   * component's state has changed but `setState` was not called.
+   *
+   * This will not invoke `shouldComponentUpdate`, but it will invoke
+   * `componentWillUpdate` and `componentDidUpdate`.
+   *
+   * @param {ReactClass} publicInstance The instance that should rerender.
+   * @internal
+   */
+
+
+  ReactServerUpdateQueue.prototype.enqueueForceUpdate = function enqueueForceUpdate(publicInstance) {
+    if (this.transaction.isInTransaction()) {
+      ReactUpdateQueue.enqueueForceUpdate(publicInstance);
+    } else {
+      warnNoop(publicInstance, 'forceUpdate');
+    }
+  };
+
+  /**
+   * Replaces all of the state. Always use this or `setState` to mutate state.
+   * You should treat `this.state` as immutable.
+   *
+   * There is no guarantee that `this.state` will be immediately updated, so
+   * accessing `this.state` after calling this method may return the old value.
+   *
+   * @param {ReactClass} publicInstance The instance that should rerender.
+   * @param {object|function} completeState Next state.
+   * @internal
+   */
+
+
+  ReactServerUpdateQueue.prototype.enqueueReplaceState = function enqueueReplaceState(publicInstance, completeState) {
+    if (this.transaction.isInTransaction()) {
+      ReactUpdateQueue.enqueueReplaceState(publicInstance, completeState);
+    } else {
+      warnNoop(publicInstance, 'replaceState');
+    }
+  };
+
+  /**
+   * Sets a subset of the state. This only exists because _pendingState is
+   * internal. This provides a merging strategy that is not available to deep
+   * properties which is confusing. TODO: Expose pendingState or don't use it
+   * during the merge.
+   *
+   * @param {ReactClass} publicInstance The instance that should rerender.
+   * @param {object|function} partialState Next partial state to be merged with state.
+   * @internal
+   */
+
+
+  ReactServerUpdateQueue.prototype.enqueueSetState = function enqueueSetState(publicInstance, partialState) {
+    if (this.transaction.isInTransaction()) {
+      ReactUpdateQueue.enqueueSetState(publicInstance, partialState);
+    } else {
+      warnNoop(publicInstance, 'setState');
+    }
+  };
+
+  return ReactServerUpdateQueue;
+}();
+
+module.exports = ReactServerUpdateQueue;
+},{"159":159,"81":81}],79:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126),
+    _assign = _dereq_(160);
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var React = _dereq_(135);
+var ReactCompositeComponent = _dereq_(30);
+var ReactDefaultBatchingStrategy = _dereq_(51);
+var ReactReconciler = _dereq_(75);
+var ReactReconcileTransaction = _dereq_(74);
+var ReactUpdates = _dereq_(82);
+
+var emptyObject = _dereq_(145);
+var getNextDebugID = _dereq_(136);
+var invariant = _dereq_(152);
+
+function injectDefaults() {
+  ReactUpdates.injection.injectReconcileTransaction(ReactReconcileTransaction);
+  ReactUpdates.injection.injectBatchingStrategy(ReactDefaultBatchingStrategy);
+}
+
+var NoopInternalComponent = function () {
+  function NoopInternalComponent(element) {
+    _classCallCheck(this, NoopInternalComponent);
+
+    this._renderedOutput = element;
+    this._currentElement = element;
+
+    if ("development" !== 'production') {
+      this._debugID = getNextDebugID();
+    }
+  }
+
+  NoopInternalComponent.prototype.mountComponent = function mountComponent() {};
+
+  NoopInternalComponent.prototype.receiveComponent = function receiveComponent(element) {
+    this._renderedOutput = element;
+    this._currentElement = element;
+  };
+
+  NoopInternalComponent.prototype.unmountComponent = function unmountComponent() {};
+
+  NoopInternalComponent.prototype.getHostNode = function getHostNode() {
+    return undefined;
+  };
+
+  NoopInternalComponent.prototype.getPublicInstance = function getPublicInstance() {
+    return null;
+  };
+
+  return NoopInternalComponent;
+}();
+
+var ShallowComponentWrapper = function (element) {
+  // TODO: Consolidate with instantiateReactComponent
+  if ("development" !== 'production') {
+    this._debugID = getNextDebugID();
+  }
+
+  this.construct(element);
+};
+_assign(ShallowComponentWrapper.prototype, ReactCompositeComponent, {
+  _constructComponent: ReactCompositeComponent._constructComponentWithoutOwner,
+  _instantiateReactComponent: function (element) {
+    return new NoopInternalComponent(element);
+  },
+  _replaceNodeWithMarkup: function () {},
+  _renderValidatedComponent: ReactCompositeComponent._renderValidatedComponentWithoutOwnerOrContext
+});
+
+function _batchedRender(renderer, element, context) {
+  var transaction = ReactUpdates.ReactReconcileTransaction.getPooled(true);
+  renderer._render(element, transaction, context);
+  ReactUpdates.ReactReconcileTransaction.release(transaction);
+}
+
+var ReactShallowRenderer = function () {
+  function ReactShallowRenderer() {
+    _classCallCheck(this, ReactShallowRenderer);
+
+    this._instance = null;
+  }
+
+  ReactShallowRenderer.prototype.getMountedInstance = function getMountedInstance() {
+    return this._instance ? this._instance._instance : null;
+  };
+
+  ReactShallowRenderer.prototype.render = function render(element, context) {
+    // Ensure we've done the default injections. This might not be true in the
+    // case of a simple test that only requires React and the TestUtils in
+    // conjunction with an inline-requires transform.
+    injectDefaults();
+
+    !React.isValidElement(element) ? "development" !== 'production' ? invariant(false, 'ReactShallowRenderer render(): Invalid component element.%s', typeof element === 'function' ? ' Instead of passing a component class, make sure to instantiate ' + 'it by passing it to React.createElement.' : '') : _prodInvariant('12', typeof element === 'function' ? ' Instead of passing a component class, make sure to instantiate ' + 'it by passing it to React.createElement.' : '') : void 0;
+    !(typeof element.type !== 'string') ? "development" !== 'production' ? invariant(false, 'ReactShallowRenderer render(): Shallow rendering works only with custom components, not primitives (%s). Instead of calling `.render(el)` and inspecting the rendered output, look at `el.props` directly instead.', element.type) : _prodInvariant('13', element.type) : void 0;
+
+    if (!context) {
+      context = emptyObject;
+    }
+    ReactUpdates.batchedUpdates(_batchedRender, this, element, context);
+
+    return this.getRenderOutput();
+  };
+
+  ReactShallowRenderer.prototype.getRenderOutput = function getRenderOutput() {
+    return this._instance && this._instance._renderedComponent && this._instance._renderedComponent._renderedOutput || null;
+  };
+
+  ReactShallowRenderer.prototype.unmount = function unmount() {
+    if (this._instance) {
+      ReactReconciler.unmountComponent(this._instance, false);
+    }
+  };
+
+  ReactShallowRenderer.prototype.unstable_batchedUpdates = function unstable_batchedUpdates(callback, bookkeeping) {
+    // This is used by Enzyme for fake-simulating events in shallow mode.
+    injectDefaults();
+    return ReactUpdates.batchedUpdates(callback, bookkeeping);
+  };
+
+  ReactShallowRenderer.prototype._render = function _render(element, transaction, context) {
+    if (this._instance) {
+      ReactReconciler.receiveComponent(this._instance, element, transaction, context);
+    } else {
+      var instance = new ShallowComponentWrapper(element);
+      ReactReconciler.mountComponent(instance, transaction, null, null, context, 0);
+      this._instance = instance;
+    }
+  };
+
+  return ReactShallowRenderer;
+}();
+
+ReactShallowRenderer.createRenderer = function () {
+  return new ReactShallowRenderer();
+};
+
+module.exports = ReactShallowRenderer;
+},{"126":126,"135":135,"136":136,"145":145,"152":152,"160":160,"30":30,"51":51,"74":74,"75":75,"82":82}],80:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126),
+    _assign = _dereq_(160);
+
+var EventConstants = _dereq_(16);
+var EventPluginHub = _dereq_(17);
+var EventPluginRegistry = _dereq_(18);
+var EventPropagators = _dereq_(20);
+var React = _dereq_(135);
+var ReactDOM = _dereq_(31);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactBrowserEventEmitter = _dereq_(26);
+var ReactInstanceMap = _dereq_(63);
+var ReactUpdates = _dereq_(82);
+var SyntheticEvent = _dereq_(91);
+var ReactShallowRenderer = _dereq_(79);
+
+var findDOMNode = _dereq_(108);
+var invariant = _dereq_(152);
+var warning = _dereq_(159);
+
+var topLevelTypes = EventConstants.topLevelTypes;
+
+function Event(suffix) {}
+
+// In react 16+ shallowRenderer will not be accessible via ReactTestUtils.createRenderer()
+// Instead it will be available via react-test-renderer/shallow
+// Maintain backwards compat for 15.5.0 release, but warn about using the deprecated method
+var hasWarnedAboutCreateRenderer = false;
+function createRendererWithWarning() {
+  "development" !== 'production' ? warning(hasWarnedAboutCreateRenderer, 'Shallow renderer has been moved to react-test-renderer/shallow. ' + 'Update references to remove this warning.') : void 0;
+  hasWarnedAboutCreateRenderer = true;
+
+  return new ReactShallowRenderer();
+}
+
+/**
+ * @class ReactTestUtils
+ */
+
+function findAllInRenderedTreeInternal(inst, test) {
+  if (!inst || !inst.getPublicInstance) {
+    return [];
+  }
+  var publicInst = inst.getPublicInstance();
+  var ret = test(publicInst) ? [publicInst] : [];
+  var currentElement = inst._currentElement;
+  if (ReactTestUtils.isDOMComponent(publicInst)) {
+    var renderedChildren = inst._renderedChildren;
+    var key;
+    for (key in renderedChildren) {
+      if (!renderedChildren.hasOwnProperty(key)) {
+        continue;
+      }
+      ret = ret.concat(findAllInRenderedTreeInternal(renderedChildren[key], test));
+    }
+  } else if (React.isValidElement(currentElement) && typeof currentElement.type === 'function') {
+    ret = ret.concat(findAllInRenderedTreeInternal(inst._renderedComponent, test));
+  }
+  return ret;
+}
+
+/**
+ * Utilities for making it easy to test React components.
+ *
+ * See https://facebook.github.io/react/docs/test-utils.html
+ *
+ * Todo: Support the entire DOM.scry query syntax. For now, these simple
+ * utilities will suffice for testing purposes.
+ * @lends ReactTestUtils
+ */
+var ReactTestUtils = {
+  renderIntoDocument: function (element) {
+    var div = document.createElement('div');
+    // None of our tests actually require attaching the container to the
+    // DOM, and doing so creates a mess that we rely on test isolation to
+    // clean up, so we're going to stop honoring the name of this method
+    // (and probably rename it eventually) if no problems arise.
+    // document.documentElement.appendChild(div);
+    return ReactDOM.render(element, div);
+  },
+
+  isElement: function (element) {
+    return React.isValidElement(element);
+  },
+
+  isElementOfType: function (inst, convenienceConstructor) {
+    return React.isValidElement(inst) && inst.type === convenienceConstructor;
+  },
+
+  isDOMComponent: function (inst) {
+    return !!(inst && inst.nodeType === 1 && inst.tagName);
+  },
+
+  isDOMComponentElement: function (inst) {
+    return !!(inst && React.isValidElement(inst) && !!inst.tagName);
+  },
+
+  isCompositeComponent: function (inst) {
+    if (ReactTestUtils.isDOMComponent(inst)) {
+      // Accessing inst.setState warns; just return false as that'll be what
+      // this returns when we have DOM nodes as refs directly
+      return false;
+    }
+    return inst != null && typeof inst.render === 'function' && typeof inst.setState === 'function';
+  },
+
+  isCompositeComponentWithType: function (inst, type) {
+    if (!ReactTestUtils.isCompositeComponent(inst)) {
+      return false;
+    }
+    var internalInstance = ReactInstanceMap.get(inst);
+    var constructor = internalInstance._currentElement.type;
+
+    return constructor === type;
+  },
+
+  isCompositeComponentElement: function (inst) {
+    if (!React.isValidElement(inst)) {
+      return false;
+    }
+    // We check the prototype of the type that will get mounted, not the
+    // instance itself. This is a future proof way of duck typing.
+    var prototype = inst.type.prototype;
+    return typeof prototype.render === 'function' && typeof prototype.setState === 'function';
+  },
+
+  isCompositeComponentElementWithType: function (inst, type) {
+    var internalInstance = ReactInstanceMap.get(inst);
+    var constructor = internalInstance._currentElement.type;
+
+    return !!(ReactTestUtils.isCompositeComponentElement(inst) && constructor === type);
+  },
+
+  getRenderedChildOfCompositeComponent: function (inst) {
+    if (!ReactTestUtils.isCompositeComponent(inst)) {
+      return null;
+    }
+    var internalInstance = ReactInstanceMap.get(inst);
+    return internalInstance._renderedComponent.getPublicInstance();
+  },
+
+  findAllInRenderedTree: function (inst, test) {
+    if (!inst) {
+      return [];
+    }
+    !ReactTestUtils.isCompositeComponent(inst) ? "development" !== 'production' ? invariant(false, 'findAllInRenderedTree(...): instance must be a composite component') : _prodInvariant('10') : void 0;
+    return findAllInRenderedTreeInternal(ReactInstanceMap.get(inst), test);
+  },
+
+  /**
+   * Finds all instance of components in the rendered tree that are DOM
+   * components with the class name matching `className`.
+   * @return {array} an array of all the matches.
+   */
+  scryRenderedDOMComponentsWithClass: function (root, classNames) {
+    return ReactTestUtils.findAllInRenderedTree(root, function (inst) {
+      if (ReactTestUtils.isDOMComponent(inst)) {
+        var className = inst.className;
+        if (typeof className !== 'string') {
+          // SVG, probably.
+          className = inst.getAttribute('class') || '';
+        }
+        var classList = className.split(/\s+/);
+
+        if (!Array.isArray(classNames)) {
+          !(classNames !== undefined) ? "development" !== 'production' ? invariant(false, 'TestUtils.scryRenderedDOMComponentsWithClass expects a className as a second argument.') : _prodInvariant('11') : void 0;
+          classNames = classNames.split(/\s+/);
+        }
+        return classNames.every(function (name) {
+          return classList.indexOf(name) !== -1;
+        });
+      }
+      return false;
+    });
+  },
+
+  /**
+   * Like scryRenderedDOMComponentsWithClass but expects there to be one result,
+   * and returns that one result, or throws exception if there is any other
+   * number of matches besides one.
+   * @return {!ReactDOMComponent} The one match.
+   */
+  findRenderedDOMComponentWithClass: function (root, className) {
+    var all = ReactTestUtils.scryRenderedDOMComponentsWithClass(root, className);
+    if (all.length !== 1) {
+      throw new Error('Did not find exactly one match (found: ' + all.length + ') ' + 'for class:' + className);
+    }
+    return all[0];
+  },
+
+  /**
+   * Finds all instance of components in the rendered tree that are DOM
+   * components with the tag name matching `tagName`.
+   * @return {array} an array of all the matches.
+   */
+  scryRenderedDOMComponentsWithTag: function (root, tagName) {
+    return ReactTestUtils.findAllInRenderedTree(root, function (inst) {
+      return ReactTestUtils.isDOMComponent(inst) && inst.tagName.toUpperCase() === tagName.toUpperCase();
+    });
+  },
+
+  /**
+   * Like scryRenderedDOMComponentsWithTag but expects there to be one result,
+   * and returns that one result, or throws exception if there is any other
+   * number of matches besides one.
+   * @return {!ReactDOMComponent} The one match.
+   */
+  findRenderedDOMComponentWithTag: function (root, tagName) {
+    var all = ReactTestUtils.scryRenderedDOMComponentsWithTag(root, tagName);
+    if (all.length !== 1) {
+      throw new Error('Did not find exactly one match (found: ' + all.length + ') ' + 'for tag:' + tagName);
+    }
+    return all[0];
+  },
+
+  /**
+   * Finds all instances of components with type equal to `componentType`.
+   * @return {array} an array of all the matches.
+   */
+  scryRenderedComponentsWithType: function (root, componentType) {
+    return ReactTestUtils.findAllInRenderedTree(root, function (inst) {
+      return ReactTestUtils.isCompositeComponentWithType(inst, componentType);
+    });
+  },
+
+  /**
+   * Same as `scryRenderedComponentsWithType` but expects there to be one result
+   * and returns that one result, or throws exception if there is any other
+   * number of matches besides one.
+   * @return {!ReactComponent} The one match.
+   */
+  findRenderedComponentWithType: function (root, componentType) {
+    var all = ReactTestUtils.scryRenderedComponentsWithType(root, componentType);
+    if (all.length !== 1) {
+      throw new Error('Did not find exactly one match (found: ' + all.length + ') ' + 'for componentType:' + componentType);
+    }
+    return all[0];
+  },
+
+  /**
+   * Pass a mocked component module to this method to augment it with
+   * useful methods that allow it to be used as a dummy React component.
+   * Instead of rendering as usual, the component will become a simple
+   * <div> containing any provided children.
+   *
+   * @param {object} module the mock function object exported from a
+   *                        module that defines the component to be mocked
+   * @param {?string} mockTagName optional dummy root tag name to return
+   *                              from render method (overrides
+   *                              module.mockTagName if provided)
+   * @return {object} the ReactTestUtils object (for chaining)
+   */
+  mockComponent: function (module, mockTagName) {
+    mockTagName = mockTagName || module.mockTagName || 'div';
+
+    module.prototype.render.mockImplementation(function () {
+      return React.createElement(mockTagName, null, this.props.children);
+    });
+
+    return this;
+  },
+
+  /**
+   * Simulates a top level event being dispatched from a raw event that occurred
+   * on an `Element` node.
+   * @param {Object} topLevelType A type from `EventConstants.topLevelTypes`
+   * @param {!Element} node The dom to simulate an event occurring on.
+   * @param {?Event} fakeNativeEvent Fake native event to use in SyntheticEvent.
+   */
+  simulateNativeEventOnNode: function (topLevelType, node, fakeNativeEvent) {
+    fakeNativeEvent.target = node;
+    fakeNativeEvent.simulated = true;
+    ReactBrowserEventEmitter.ReactEventListener.dispatchEvent(topLevelType, fakeNativeEvent);
+  },
+
+  /**
+   * Simulates a top level event being dispatched from a raw event that occurred
+   * on the `ReactDOMComponent` `comp`.
+   * @param {Object} topLevelType A type from `EventConstants.topLevelTypes`.
+   * @param {!ReactDOMComponent} comp
+   * @param {?Event} fakeNativeEvent Fake native event to use in SyntheticEvent.
+   */
+  simulateNativeEventOnDOMComponent: function (topLevelType, comp, fakeNativeEvent) {
+    ReactTestUtils.simulateNativeEventOnNode(topLevelType, findDOMNode(comp), fakeNativeEvent);
+  },
+
+  nativeTouchData: function (x, y) {
+    return {
+      touches: [{ pageX: x, pageY: y }]
+    };
+  },
+
+  createRenderer: createRendererWithWarning,
+
+  Simulate: null,
+  SimulateNative: {}
+};
+
+/**
+ * Exports:
+ *
+ * - `ReactTestUtils.Simulate.click(Element/ReactDOMComponent)`
+ * - `ReactTestUtils.Simulate.mouseMove(Element/ReactDOMComponent)`
+ * - `ReactTestUtils.Simulate.change(Element/ReactDOMComponent)`
+ * - ... (All keys from event plugin `eventTypes` objects)
+ */
+function makeSimulator(eventType) {
+  return function (domComponentOrNode, eventData) {
+    var node;
+    !!React.isValidElement(domComponentOrNode) ? "development" !== 'production' ? invariant(false, 'TestUtils.Simulate expects a component instance and not a ReactElement.TestUtils.Simulate will not work if you are using shallow rendering.') : _prodInvariant('14') : void 0;
+    if (ReactTestUtils.isDOMComponent(domComponentOrNode)) {
+      node = findDOMNode(domComponentOrNode);
+    } else if (domComponentOrNode.tagName) {
+      node = domComponentOrNode;
+    }
+
+    var dispatchConfig = EventPluginRegistry.eventNameDispatchConfigs[eventType];
+
+    var fakeNativeEvent = new Event();
+    fakeNativeEvent.target = node;
+    fakeNativeEvent.type = eventType.toLowerCase();
+
+    // We don't use SyntheticEvent.getPooled in order to not have to worry about
+    // properly destroying any properties assigned from `eventData` upon release
+    var event = new SyntheticEvent(dispatchConfig, ReactDOMComponentTree.getInstanceFromNode(node), fakeNativeEvent, node);
+    // Since we aren't using pooling, always persist the event. This will make
+    // sure it's marked and won't warn when setting additional properties.
+    event.persist();
+    _assign(event, eventData);
+
+    if (dispatchConfig.phasedRegistrationNames) {
+      EventPropagators.accumulateTwoPhaseDispatches(event);
+    } else {
+      EventPropagators.accumulateDirectDispatches(event);
+    }
+
+    ReactUpdates.batchedUpdates(function () {
+      EventPluginHub.enqueueEvents(event);
+      EventPluginHub.processEventQueue(true);
+    });
+  };
+}
+
+function buildSimulators() {
+  ReactTestUtils.Simulate = {};
+
+  var eventType;
+  for (eventType in EventPluginRegistry.eventNameDispatchConfigs) {
+    /**
+     * @param {!Element|ReactDOMComponent} domComponentOrNode
+     * @param {?object} eventData Fake event data to use in SyntheticEvent.
+     */
+    ReactTestUtils.Simulate[eventType] = makeSimulator(eventType);
+  }
+}
+
+// Rebuild ReactTestUtils.Simulate whenever event plugins are injected
+var oldInjectEventPluginOrder = EventPluginHub.injection.injectEventPluginOrder;
+EventPluginHub.injection.injectEventPluginOrder = function () {
+  oldInjectEventPluginOrder.apply(this, arguments);
+  buildSimulators();
+};
+var oldInjectEventPlugins = EventPluginHub.injection.injectEventPluginsByName;
+EventPluginHub.injection.injectEventPluginsByName = function () {
+  oldInjectEventPlugins.apply(this, arguments);
+  buildSimulators();
+};
+
+buildSimulators();
+
+/**
+ * Exports:
+ *
+ * - `ReactTestUtils.SimulateNative.click(Element/ReactDOMComponent)`
+ * - `ReactTestUtils.SimulateNative.mouseMove(Element/ReactDOMComponent)`
+ * - `ReactTestUtils.SimulateNative.mouseIn/ReactDOMComponent)`
+ * - `ReactTestUtils.SimulateNative.mouseOut(Element/ReactDOMComponent)`
+ * - ... (All keys from `EventConstants.topLevelTypes`)
+ *
+ * Note: Top level event types are a subset of the entire set of handler types
+ * (which include a broader set of "synthetic" events). For example, onDragDone
+ * is a synthetic event. Except when testing an event plugin or React's event
+ * handling code specifically, you probably want to use ReactTestUtils.Simulate
+ * to dispatch synthetic events.
+ */
+
+function makeNativeSimulator(eventType) {
+  return function (domComponentOrNode, nativeEventData) {
+    var fakeNativeEvent = new Event(eventType);
+    _assign(fakeNativeEvent, nativeEventData);
+    if (ReactTestUtils.isDOMComponent(domComponentOrNode)) {
+      ReactTestUtils.simulateNativeEventOnDOMComponent(eventType, domComponentOrNode, fakeNativeEvent);
+    } else if (domComponentOrNode.tagName) {
+      // Will allow on actual dom nodes.
+      ReactTestUtils.simulateNativeEventOnNode(eventType, domComponentOrNode, fakeNativeEvent);
+    }
+  };
+}
+
+Object.keys(topLevelTypes).forEach(function (eventType) {
+  // Event type is stored as 'topClick' - we transform that to 'click'
+  var convenienceName = eventType.indexOf('top') === 0 ? eventType.charAt(3).toLowerCase() + eventType.substr(4) : eventType;
+  /**
+   * @param {!Element|ReactDOMComponent} domComponentOrNode
+   * @param {?Event} nativeEventData Fake native event to use in SyntheticEvent.
+   */
+  ReactTestUtils.SimulateNative[convenienceName] = makeNativeSimulator(eventType);
+});
+
+module.exports = ReactTestUtils;
+},{"108":108,"126":126,"135":135,"152":152,"159":159,"16":16,"160":160,"17":17,"18":18,"20":20,"26":26,"31":31,"34":34,"63":63,"79":79,"82":82,"91":91}],81:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var ReactCurrentOwner = _dereq_(134);
+var ReactInstanceMap = _dereq_(63);
+var ReactInstrumentation = _dereq_(64);
+var ReactUpdates = _dereq_(82);
+
+var invariant = _dereq_(152);
+var warning = _dereq_(159);
+
+function enqueueUpdate(internalInstance) {
+  ReactUpdates.enqueueUpdate(internalInstance);
+}
+
+function formatUnexpectedArgument(arg) {
+  var type = typeof arg;
+  if (type !== 'object') {
+    return type;
+  }
+  var displayName = arg.constructor && arg.constructor.name || type;
+  var keys = Object.keys(arg);
+  if (keys.length > 0 && keys.length < 20) {
+    return displayName + ' (keys: ' + keys.join(', ') + ')';
+  }
+  return displayName;
+}
+
+function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
+  var internalInstance = ReactInstanceMap.get(publicInstance);
+  if (!internalInstance) {
+    if ("development" !== 'production') {
+      var ctor = publicInstance.constructor;
+      // Only warn when we have a callerName. Otherwise we should be silent.
+      // We're probably calling from enqueueCallback. We don't want to warn
+      // there because we already warned for the corresponding lifecycle method.
+      "development" !== 'production' ? warning(!callerName, '%s(...): Can only update a mounted or mounting component. ' + 'This usually means you called %s() on an unmounted component. ' + 'This is a no-op. Please check the code for the %s component.', callerName, callerName, ctor && (ctor.displayName || ctor.name) || 'ReactClass') : void 0;
+    }
+    return null;
+  }
+
+  if ("development" !== 'production') {
+    "development" !== 'production' ? warning(ReactCurrentOwner.current == null, '%s(...): Cannot update during an existing state transition (such as ' + "within `render` or another component's constructor). Render methods " + 'should be a pure function of props and state; constructor ' + 'side-effects are an anti-pattern, but can be moved to ' + '`componentWillMount`.', callerName) : void 0;
+  }
+
+  return internalInstance;
+}
+
+/**
+ * ReactUpdateQueue allows for state updates to be scheduled into a later
+ * reconciliation step.
+ */
+var ReactUpdateQueue = {
+  /**
+   * Checks whether or not this composite component is mounted.
+   * @param {ReactClass} publicInstance The instance we want to test.
+   * @return {boolean} True if mounted, false otherwise.
+   * @protected
+   * @final
+   */
+  isMounted: function (publicInstance) {
+    if ("development" !== 'production') {
+      var owner = ReactCurrentOwner.current;
+      if (owner !== null) {
+        "development" !== 'production' ? warning(owner._warnedAboutRefsInRender, '%s is accessing isMounted inside its render() function. ' + 'render() should be a pure function of props and state. It should ' + 'never access something that requires stale data from the previous ' + 'render, such as refs. Move this logic to componentDidMount and ' + 'componentDidUpdate instead.', owner.getName() || 'A component') : void 0;
+        owner._warnedAboutRefsInRender = true;
+      }
+    }
+    var internalInstance = ReactInstanceMap.get(publicInstance);
+    if (internalInstance) {
+      // During componentWillMount and render this will still be null but after
+      // that will always render to something. At least for now. So we can use
+      // this hack.
+      return !!internalInstance._renderedComponent;
+    } else {
+      return false;
+    }
+  },
+
+  /**
+   * Enqueue a callback that will be executed after all the pending updates
+   * have processed.
+   *
+   * @param {ReactClass} publicInstance The instance to use as `this` context.
+   * @param {?function} callback Called after state is updated.
+   * @param {string} callerName Name of the calling function in the public API.
+   * @internal
+   */
+  enqueueCallback: function (publicInstance, callback, callerName) {
+    ReactUpdateQueue.validateCallback(callback, callerName);
+    var internalInstance = getInternalInstanceReadyForUpdate(publicInstance);
+
+    // Previously we would throw an error if we didn't have an internal
+    // instance. Since we want to make it a no-op instead, we mirror the same
+    // behavior we have in other enqueue* methods.
+    // We also need to ignore callbacks in componentWillMount. See
+    // enqueueUpdates.
+    if (!internalInstance) {
+      return null;
+    }
+
+    if (internalInstance._pendingCallbacks) {
+      internalInstance._pendingCallbacks.push(callback);
+    } else {
+      internalInstance._pendingCallbacks = [callback];
+    }
+    // TODO: The callback here is ignored when setState is called from
+    // componentWillMount. Either fix it or disallow doing so completely in
+    // favor of getInitialState. Alternatively, we can disallow
+    // componentWillMount during server-side rendering.
+    enqueueUpdate(internalInstance);
+  },
+
+  enqueueCallbackInternal: function (internalInstance, callback) {
+    if (internalInstance._pendingCallbacks) {
+      internalInstance._pendingCallbacks.push(callback);
+    } else {
+      internalInstance._pendingCallbacks = [callback];
+    }
+    enqueueUpdate(internalInstance);
+  },
+
+  /**
+   * Forces an update. This should only be invoked when it is known with
+   * certainty that we are **not** in a DOM transaction.
+   *
+   * You may want to call this when you know that some deeper aspect of the
+   * component's state has changed but `setState` was not called.
+   *
+   * This will not invoke `shouldComponentUpdate`, but it will invoke
+   * `componentWillUpdate` and `componentDidUpdate`.
+   *
+   * @param {ReactClass} publicInstance The instance that should rerender.
+   * @internal
+   */
+  enqueueForceUpdate: function (publicInstance) {
+    var internalInstance = getInternalInstanceReadyForUpdate(publicInstance, 'forceUpdate');
+
+    if (!internalInstance) {
+      return;
+    }
+
+    internalInstance._pendingForceUpdate = true;
+
+    enqueueUpdate(internalInstance);
+  },
+
+  /**
+   * Replaces all of the state. Always use this or `setState` to mutate state.
+   * You should treat `this.state` as immutable.
+   *
+   * There is no guarantee that `this.state` will be immediately updated, so
+   * accessing `this.state` after calling this method may return the old value.
+   *
+   * @param {ReactClass} publicInstance The instance that should rerender.
+   * @param {object} completeState Next state.
+   * @internal
+   */
+  enqueueReplaceState: function (publicInstance, completeState, callback) {
+    var internalInstance = getInternalInstanceReadyForUpdate(publicInstance, 'replaceState');
+
+    if (!internalInstance) {
+      return;
+    }
+
+    internalInstance._pendingStateQueue = [completeState];
+    internalInstance._pendingReplaceState = true;
+
+    // Future-proof 15.5
+    if (callback !== undefined && callback !== null) {
+      ReactUpdateQueue.validateCallback(callback, 'replaceState');
+      if (internalInstance._pendingCallbacks) {
+        internalInstance._pendingCallbacks.push(callback);
+      } else {
+        internalInstance._pendingCallbacks = [callback];
+      }
+    }
+
+    enqueueUpdate(internalInstance);
+  },
+
+  /**
+   * Sets a subset of the state. This only exists because _pendingState is
+   * internal. This provides a merging strategy that is not available to deep
+   * properties which is confusing. TODO: Expose pendingState or don't use it
+   * during the merge.
+   *
+   * @param {ReactClass} publicInstance The instance that should rerender.
+   * @param {object} partialState Next partial state to be merged with state.
+   * @internal
+   */
+  enqueueSetState: function (publicInstance, partialState) {
+    if ("development" !== 'production') {
+      ReactInstrumentation.debugTool.onSetState();
+      "development" !== 'production' ? warning(partialState != null, 'setState(...): You passed an undefined or null state object; ' + 'instead, use forceUpdate().') : void 0;
+    }
+
+    var internalInstance = getInternalInstanceReadyForUpdate(publicInstance, 'setState');
+
+    if (!internalInstance) {
+      return;
+    }
+
+    var queue = internalInstance._pendingStateQueue || (internalInstance._pendingStateQueue = []);
+    queue.push(partialState);
+
+    enqueueUpdate(internalInstance);
+  },
+
+  enqueueElementInternal: function (internalInstance, nextElement, nextContext) {
+    internalInstance._pendingElement = nextElement;
+    // TODO: introduce _pendingContext instead of setting it directly.
+    internalInstance._context = nextContext;
+    enqueueUpdate(internalInstance);
+  },
+
+  validateCallback: function (callback, callerName) {
+    !(!callback || typeof callback === 'function') ? "development" !== 'production' ? invariant(false, '%s(...): Expected the last optional `callback` argument to be a function. Instead received: %s.', callerName, formatUnexpectedArgument(callback)) : _prodInvariant('122', callerName, formatUnexpectedArgument(callback)) : void 0;
+  }
+};
+
+module.exports = ReactUpdateQueue;
+},{"126":126,"134":134,"152":152,"159":159,"63":63,"64":64,"82":82}],82:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126),
+    _assign = _dereq_(160);
+
+var CallbackQueue = _dereq_(6);
+var PooledClass = _dereq_(25);
+var ReactFeatureFlags = _dereq_(58);
+var ReactReconciler = _dereq_(75);
+var Transaction = _dereq_(100);
+
+var invariant = _dereq_(152);
+
+var dirtyComponents = [];
+var updateBatchNumber = 0;
+var asapCallbackQueue = CallbackQueue.getPooled();
+var asapEnqueued = false;
+
+var batchingStrategy = null;
+
+function ensureInjected() {
+  !(ReactUpdates.ReactReconcileTransaction && batchingStrategy) ? "development" !== 'production' ? invariant(false, 'ReactUpdates: must inject a reconcile transaction class and batching strategy') : _prodInvariant('123') : void 0;
+}
+
+var NESTED_UPDATES = {
+  initialize: function () {
+    this.dirtyComponentsLength = dirtyComponents.length;
+  },
+  close: function () {
+    if (this.dirtyComponentsLength !== dirtyComponents.length) {
+      // Additional updates were enqueued by componentDidUpdate handlers or
+      // similar; before our own UPDATE_QUEUEING wrapper closes, we want to run
+      // these new updates so that if A's componentDidUpdate calls setState on
+      // B, B will update before the callback A's updater provided when calling
+      // setState.
+      dirtyComponents.splice(0, this.dirtyComponentsLength);
+      flushBatchedUpdates();
+    } else {
+      dirtyComponents.length = 0;
+    }
+  }
+};
+
+var UPDATE_QUEUEING = {
+  initialize: function () {
+    this.callbackQueue.reset();
+  },
+  close: function () {
+    this.callbackQueue.notifyAll();
+  }
+};
+
+var TRANSACTION_WRAPPERS = [NESTED_UPDATES, UPDATE_QUEUEING];
+
+function ReactUpdatesFlushTransaction() {
+  this.reinitializeTransaction();
+  this.dirtyComponentsLength = null;
+  this.callbackQueue = CallbackQueue.getPooled();
+  this.reconcileTransaction = ReactUpdates.ReactReconcileTransaction.getPooled(
+  /* useCreateElement */true);
+}
+
+_assign(ReactUpdatesFlushTransaction.prototype, Transaction, {
+  getTransactionWrappers: function () {
+    return TRANSACTION_WRAPPERS;
+  },
+
+  destructor: function () {
+    this.dirtyComponentsLength = null;
+    CallbackQueue.release(this.callbackQueue);
+    this.callbackQueue = null;
+    ReactUpdates.ReactReconcileTransaction.release(this.reconcileTransaction);
+    this.reconcileTransaction = null;
+  },
+
+  perform: function (method, scope, a) {
+    // Essentially calls `this.reconcileTransaction.perform(method, scope, a)`
+    // with this transaction's wrappers around it.
+    return Transaction.perform.call(this, this.reconcileTransaction.perform, this.reconcileTransaction, method, scope, a);
+  }
+});
+
+PooledClass.addPoolingTo(ReactUpdatesFlushTransaction);
+
+function batchedUpdates(callback, a, b, c, d, e) {
+  ensureInjected();
+  return batchingStrategy.batchedUpdates(callback, a, b, c, d, e);
+}
+
+/**
+ * Array comparator for ReactComponents by mount ordering.
+ *
+ * @param {ReactComponent} c1 first component you're comparing
+ * @param {ReactComponent} c2 second component you're comparing
+ * @return {number} Return value usable by Array.prototype.sort().
+ */
+function mountOrderComparator(c1, c2) {
+  return c1._mountOrder - c2._mountOrder;
+}
+
+function runBatchedUpdates(transaction) {
+  var len = transaction.dirtyComponentsLength;
+  !(len === dirtyComponents.length) ? "development" !== 'production' ? invariant(false, 'Expected flush transaction\'s stored dirty-components length (%s) to match dirty-components array length (%s).', len, dirtyComponents.length) : _prodInvariant('124', len, dirtyComponents.length) : void 0;
+
+  // Since reconciling a component higher in the owner hierarchy usually (not
+  // always -- see shouldComponentUpdate()) will reconcile children, reconcile
+  // them before their children by sorting the array.
+  dirtyComponents.sort(mountOrderComparator);
+
+  // Any updates enqueued while reconciling must be performed after this entire
+  // batch. Otherwise, if dirtyComponents is [A, B] where A has children B and
+  // C, B could update twice in a single batch if C's render enqueues an update
+  // to B (since B would have already updated, we should skip it, and the only
+  // way we can know to do so is by checking the batch counter).
+  updateBatchNumber++;
+
+  for (var i = 0; i < len; i++) {
+    // If a component is unmounted before pending changes apply, it will still
+    // be here, but we assume that it has cleared its _pendingCallbacks and
+    // that performUpdateIfNecessary is a noop.
+    var component = dirtyComponents[i];
+
+    // If performUpdateIfNecessary happens to enqueue any new updates, we
+    // shouldn't execute the callbacks until the next render happens, so
+    // stash the callbacks first
+    var callbacks = component._pendingCallbacks;
+    component._pendingCallbacks = null;
+
+    var markerName;
+    if (ReactFeatureFlags.logTopLevelRenders) {
+      var namedComponent = component;
+      // Duck type TopLevelWrapper. This is probably always true.
+      if (component._currentElement.type.isReactTopLevelWrapper) {
+        namedComponent = component._renderedComponent;
+      }
+      markerName = 'React update: ' + namedComponent.getName();
+      console.time(markerName);
+    }
+
+    ReactReconciler.performUpdateIfNecessary(component, transaction.reconcileTransaction, updateBatchNumber);
+
+    if (markerName) {
+      console.timeEnd(markerName);
+    }
+
+    if (callbacks) {
+      for (var j = 0; j < callbacks.length; j++) {
+        transaction.callbackQueue.enqueue(callbacks[j], component.getPublicInstance());
+      }
+    }
+  }
+}
+
+var flushBatchedUpdates = function () {
+  // ReactUpdatesFlushTransaction's wrappers will clear the dirtyComponents
+  // array and perform any updates enqueued by mount-ready handlers (i.e.,
+  // componentDidUpdate) but we need to check here too in order to catch
+  // updates enqueued by setState callbacks and asap calls.
+  while (dirtyComponents.length || asapEnqueued) {
+    if (dirtyComponents.length) {
+      var transaction = ReactUpdatesFlushTransaction.getPooled();
+      transaction.perform(runBatchedUpdates, null, transaction);
+      ReactUpdatesFlushTransaction.release(transaction);
+    }
+
+    if (asapEnqueued) {
+      asapEnqueued = false;
+      var queue = asapCallbackQueue;
+      asapCallbackQueue = CallbackQueue.getPooled();
+      queue.notifyAll();
+      CallbackQueue.release(queue);
+    }
+  }
+};
+
+/**
+ * Mark a component as needing a rerender, adding an optional callback to a
+ * list of functions which will be executed once the rerender occurs.
+ */
+function enqueueUpdate(component) {
+  ensureInjected();
+
+  // Various parts of our code (such as ReactCompositeComponent's
+  // _renderValidatedComponent) assume that calls to render aren't nested;
+  // verify that that's the case. (This is called by each top-level update
+  // function, like setState, forceUpdate, etc.; creation and
+  // destruction of top-level components is guarded in ReactMount.)
+
+  if (!batchingStrategy.isBatchingUpdates) {
+    batchingStrategy.batchedUpdates(enqueueUpdate, component);
+    return;
+  }
+
+  dirtyComponents.push(component);
+  if (component._updateBatchNumber == null) {
+    component._updateBatchNumber = updateBatchNumber + 1;
+  }
+}
+
+/**
+ * Enqueue a callback to be run at the end of the current batching cycle. Throws
+ * if no updates are currently being performed.
+ */
+function asap(callback, context) {
+  invariant(batchingStrategy.isBatchingUpdates, "ReactUpdates.asap: Can't enqueue an asap callback in a context where" + 'updates are not being batched.');
+  asapCallbackQueue.enqueue(callback, context);
+  asapEnqueued = true;
+}
+
+var ReactUpdatesInjection = {
+  injectReconcileTransaction: function (ReconcileTransaction) {
+    !ReconcileTransaction ? "development" !== 'production' ? invariant(false, 'ReactUpdates: must provide a reconcile transaction class') : _prodInvariant('126') : void 0;
+    ReactUpdates.ReactReconcileTransaction = ReconcileTransaction;
+  },
+
+  injectBatchingStrategy: function (_batchingStrategy) {
+    !_batchingStrategy ? "development" !== 'production' ? invariant(false, 'ReactUpdates: must provide a batching strategy') : _prodInvariant('127') : void 0;
+    !(typeof _batchingStrategy.batchedUpdates === 'function') ? "development" !== 'production' ? invariant(false, 'ReactUpdates: must provide a batchedUpdates() function') : _prodInvariant('128') : void 0;
+    !(typeof _batchingStrategy.isBatchingUpdates === 'boolean') ? "development" !== 'production' ? invariant(false, 'ReactUpdates: must provide an isBatchingUpdates boolean attribute') : _prodInvariant('129') : void 0;
+    batchingStrategy = _batchingStrategy;
+  }
+};
+
+var ReactUpdates = {
+  /**
+   * React references `ReactReconcileTransaction` using this property in order
+   * to allow dependency injection.
+   *
+   * @internal
+   */
+  ReactReconcileTransaction: null,
+
+  batchedUpdates: batchedUpdates,
+  enqueueUpdate: enqueueUpdate,
+  flushBatchedUpdates: flushBatchedUpdates,
+  injection: ReactUpdatesInjection,
+  asap: asap
+};
+
+module.exports = ReactUpdates;
+},{"100":100,"126":126,"152":152,"160":160,"25":25,"58":58,"6":6,"75":75}],83:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+module.exports = '15.7.0';
+},{}],84:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var NS = {
+  xlink: 'http://www.w3.org/1999/xlink',
+  xml: 'http://www.w3.org/XML/1998/namespace'
+};
+
+// We use attributes for everything SVG so let's avoid some duplication and run
+// code instead.
+// The following are all specified in the HTML config already so we exclude here.
+// - class (as className)
+// - color
+// - height
+// - id
+// - lang
+// - max
+// - media
+// - method
+// - min
+// - name
+// - style
+// - target
+// - type
+// - width
+var ATTRS = {
+  accentHeight: 'accent-height',
+  accumulate: 0,
+  additive: 0,
+  alignmentBaseline: 'alignment-baseline',
+  allowReorder: 'allowReorder',
+  alphabetic: 0,
+  amplitude: 0,
+  arabicForm: 'arabic-form',
+  ascent: 0,
+  attributeName: 'attributeName',
+  attributeType: 'attributeType',
+  autoReverse: 'autoReverse',
+  azimuth: 0,
+  baseFrequency: 'baseFrequency',
+  baseProfile: 'baseProfile',
+  baselineShift: 'baseline-shift',
+  bbox: 0,
+  begin: 0,
+  bias: 0,
+  by: 0,
+  calcMode: 'calcMode',
+  capHeight: 'cap-height',
+  clip: 0,
+  clipPath: 'clip-path',
+  clipRule: 'clip-rule',
+  clipPathUnits: 'clipPathUnits',
+  colorInterpolation: 'color-interpolation',
+  colorInterpolationFilters: 'color-interpolation-filters',
+  colorProfile: 'color-profile',
+  colorRendering: 'color-rendering',
+  contentScriptType: 'contentScriptType',
+  contentStyleType: 'contentStyleType',
+  cursor: 0,
+  cx: 0,
+  cy: 0,
+  d: 0,
+  decelerate: 0,
+  descent: 0,
+  diffuseConstant: 'diffuseConstant',
+  direction: 0,
+  display: 0,
+  divisor: 0,
+  dominantBaseline: 'dominant-baseline',
+  dur: 0,
+  dx: 0,
+  dy: 0,
+  edgeMode: 'edgeMode',
+  elevation: 0,
+  enableBackground: 'enable-background',
+  end: 0,
+  exponent: 0,
+  externalResourcesRequired: 'externalResourcesRequired',
+  fill: 0,
+  fillOpacity: 'fill-opacity',
+  fillRule: 'fill-rule',
+  filter: 0,
+  filterRes: 'filterRes',
+  filterUnits: 'filterUnits',
+  floodColor: 'flood-color',
+  floodOpacity: 'flood-opacity',
+  focusable: 0,
+  fontFamily: 'font-family',
+  fontSize: 'font-size',
+  fontSizeAdjust: 'font-size-adjust',
+  fontStretch: 'font-stretch',
+  fontStyle: 'font-style',
+  fontVariant: 'font-variant',
+  fontWeight: 'font-weight',
+  format: 0,
+  from: 0,
+  fx: 0,
+  fy: 0,
+  g1: 0,
+  g2: 0,
+  glyphName: 'glyph-name',
+  glyphOrientationHorizontal: 'glyph-orientation-horizontal',
+  glyphOrientationVertical: 'glyph-orientation-vertical',
+  glyphRef: 'glyphRef',
+  gradientTransform: 'gradientTransform',
+  gradientUnits: 'gradientUnits',
+  hanging: 0,
+  horizAdvX: 'horiz-adv-x',
+  horizOriginX: 'horiz-origin-x',
+  ideographic: 0,
+  imageRendering: 'image-rendering',
+  'in': 0,
+  in2: 0,
+  intercept: 0,
+  k: 0,
+  k1: 0,
+  k2: 0,
+  k3: 0,
+  k4: 0,
+  kernelMatrix: 'kernelMatrix',
+  kernelUnitLength: 'kernelUnitLength',
+  kerning: 0,
+  keyPoints: 'keyPoints',
+  keySplines: 'keySplines',
+  keyTimes: 'keyTimes',
+  lengthAdjust: 'lengthAdjust',
+  letterSpacing: 'letter-spacing',
+  lightingColor: 'lighting-color',
+  limitingConeAngle: 'limitingConeAngle',
+  local: 0,
+  markerEnd: 'marker-end',
+  markerMid: 'marker-mid',
+  markerStart: 'marker-start',
+  markerHeight: 'markerHeight',
+  markerUnits: 'markerUnits',
+  markerWidth: 'markerWidth',
+  mask: 0,
+  maskContentUnits: 'maskContentUnits',
+  maskUnits: 'maskUnits',
+  mathematical: 0,
+  mode: 0,
+  numOctaves: 'numOctaves',
+  offset: 0,
+  opacity: 0,
+  operator: 0,
+  order: 0,
+  orient: 0,
+  orientation: 0,
+  origin: 0,
+  overflow: 0,
+  overlinePosition: 'overline-position',
+  overlineThickness: 'overline-thickness',
+  paintOrder: 'paint-order',
+  panose1: 'panose-1',
+  pathLength: 'pathLength',
+  patternContentUnits: 'patternContentUnits',
+  patternTransform: 'patternTransform',
+  patternUnits: 'patternUnits',
+  pointerEvents: 'pointer-events',
+  points: 0,
+  pointsAtX: 'pointsAtX',
+  pointsAtY: 'pointsAtY',
+  pointsAtZ: 'pointsAtZ',
+  preserveAlpha: 'preserveAlpha',
+  preserveAspectRatio: 'preserveAspectRatio',
+  primitiveUnits: 'primitiveUnits',
+  r: 0,
+  radius: 0,
+  refX: 'refX',
+  refY: 'refY',
+  renderingIntent: 'rendering-intent',
+  repeatCount: 'repeatCount',
+  repeatDur: 'repeatDur',
+  requiredExtensions: 'requiredExtensions',
+  requiredFeatures: 'requiredFeatures',
+  restart: 0,
+  result: 0,
+  rotate: 0,
+  rx: 0,
+  ry: 0,
+  scale: 0,
+  seed: 0,
+  shapeRendering: 'shape-rendering',
+  slope: 0,
+  spacing: 0,
+  specularConstant: 'specularConstant',
+  specularExponent: 'specularExponent',
+  speed: 0,
+  spreadMethod: 'spreadMethod',
+  startOffset: 'startOffset',
+  stdDeviation: 'stdDeviation',
+  stemh: 0,
+  stemv: 0,
+  stitchTiles: 'stitchTiles',
+  stopColor: 'stop-color',
+  stopOpacity: 'stop-opacity',
+  strikethroughPosition: 'strikethrough-position',
+  strikethroughThickness: 'strikethrough-thickness',
+  string: 0,
+  stroke: 0,
+  strokeDasharray: 'stroke-dasharray',
+  strokeDashoffset: 'stroke-dashoffset',
+  strokeLinecap: 'stroke-linecap',
+  strokeLinejoin: 'stroke-linejoin',
+  strokeMiterlimit: 'stroke-miterlimit',
+  strokeOpacity: 'stroke-opacity',
+  strokeWidth: 'stroke-width',
+  surfaceScale: 'surfaceScale',
+  systemLanguage: 'systemLanguage',
+  tableValues: 'tableValues',
+  targetX: 'targetX',
+  targetY: 'targetY',
+  textAnchor: 'text-anchor',
+  textDecoration: 'text-decoration',
+  textRendering: 'text-rendering',
+  textLength: 'textLength',
+  to: 0,
+  transform: 0,
+  u1: 0,
+  u2: 0,
+  underlinePosition: 'underline-position',
+  underlineThickness: 'underline-thickness',
+  unicode: 0,
+  unicodeBidi: 'unicode-bidi',
+  unicodeRange: 'unicode-range',
+  unitsPerEm: 'units-per-em',
+  vAlphabetic: 'v-alphabetic',
+  vHanging: 'v-hanging',
+  vIdeographic: 'v-ideographic',
+  vMathematical: 'v-mathematical',
+  values: 0,
+  vectorEffect: 'vector-effect',
+  version: 0,
+  vertAdvY: 'vert-adv-y',
+  vertOriginX: 'vert-origin-x',
+  vertOriginY: 'vert-origin-y',
+  viewBox: 'viewBox',
+  viewTarget: 'viewTarget',
+  visibility: 0,
+  widths: 0,
+  wordSpacing: 'word-spacing',
+  writingMode: 'writing-mode',
+  x: 0,
+  xHeight: 'x-height',
+  x1: 0,
+  x2: 0,
+  xChannelSelector: 'xChannelSelector',
+  xlinkActuate: 'xlink:actuate',
+  xlinkArcrole: 'xlink:arcrole',
+  xlinkHref: 'xlink:href',
+  xlinkRole: 'xlink:role',
+  xlinkShow: 'xlink:show',
+  xlinkTitle: 'xlink:title',
+  xlinkType: 'xlink:type',
+  xmlBase: 'xml:base',
+  xmlns: 0,
+  xmlnsXlink: 'xmlns:xlink',
+  xmlLang: 'xml:lang',
+  xmlSpace: 'xml:space',
+  y: 0,
+  y1: 0,
+  y2: 0,
+  yChannelSelector: 'yChannelSelector',
+  z: 0,
+  zoomAndPan: 'zoomAndPan'
+};
+
+var SVGDOMPropertyConfig = {
+  Properties: {},
+  DOMAttributeNamespaces: {
+    xlinkActuate: NS.xlink,
+    xlinkArcrole: NS.xlink,
+    xlinkHref: NS.xlink,
+    xlinkRole: NS.xlink,
+    xlinkShow: NS.xlink,
+    xlinkTitle: NS.xlink,
+    xlinkType: NS.xlink,
+    xmlBase: NS.xml,
+    xmlLang: NS.xml,
+    xmlSpace: NS.xml
+  },
+  DOMAttributeNames: {}
+};
+
+Object.keys(ATTRS).forEach(function (key) {
+  SVGDOMPropertyConfig.Properties[key] = 0;
+  if (ATTRS[key]) {
+    SVGDOMPropertyConfig.DOMAttributeNames[key] = ATTRS[key];
+  }
+});
+
+module.exports = SVGDOMPropertyConfig;
+},{}],85:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var EventPropagators = _dereq_(20);
+var ExecutionEnvironment = _dereq_(138);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactInputSelection = _dereq_(62);
+var SyntheticEvent = _dereq_(91);
+
+var getActiveElement = _dereq_(147);
+var isTextInputElement = _dereq_(123);
+var shallowEqual = _dereq_(158);
+
+var skipSelectionChangeEvent = ExecutionEnvironment.canUseDOM && 'documentMode' in document && document.documentMode <= 11;
+
+var eventTypes = {
+  select: {
+    phasedRegistrationNames: {
+      bubbled: 'onSelect',
+      captured: 'onSelectCapture'
+    },
+    dependencies: ['topBlur', 'topContextMenu', 'topFocus', 'topKeyDown', 'topKeyUp', 'topMouseDown', 'topMouseUp', 'topSelectionChange']
+  }
+};
+
+var activeElement = null;
+var activeElementInst = null;
+var lastSelection = null;
+var mouseDown = false;
+
+// Track whether a listener exists for this plugin. If none exist, we do
+// not extract events. See #3639.
+var hasListener = false;
+
+/**
+ * Get an object which is a unique representation of the current selection.
+ *
+ * The return value will not be consistent across nodes or browsers, but
+ * two identical selections on the same node will return identical objects.
+ *
+ * @param {DOMElement} node
+ * @return {object}
+ */
+function getSelection(node) {
+  if ('selectionStart' in node && ReactInputSelection.hasSelectionCapabilities(node)) {
+    return {
+      start: node.selectionStart,
+      end: node.selectionEnd
+    };
+  } else if (window.getSelection) {
+    var selection = window.getSelection();
+    return {
+      anchorNode: selection.anchorNode,
+      anchorOffset: selection.anchorOffset,
+      focusNode: selection.focusNode,
+      focusOffset: selection.focusOffset
+    };
+  } else if (document.selection) {
+    var range = document.selection.createRange();
+    return {
+      parentElement: range.parentElement(),
+      text: range.text,
+      top: range.boundingTop,
+      left: range.boundingLeft
+    };
+  }
+}
+
+/**
+ * Poll selection to see whether it's changed.
+ *
+ * @param {object} nativeEvent
+ * @return {?SyntheticEvent}
+ */
+function constructSelectEvent(nativeEvent, nativeEventTarget) {
+  // Ensure we have the right element, and that the user is not dragging a
+  // selection (this matches native `select` event behavior). In HTML5, select
+  // fires only on input and textarea thus if there's no focused element we
+  // won't dispatch.
+  if (mouseDown || activeElement == null || activeElement !== getActiveElement()) {
+    return null;
+  }
+
+  // Only fire when selection has actually changed.
+  var currentSelection = getSelection(activeElement);
+  if (!lastSelection || !shallowEqual(lastSelection, currentSelection)) {
+    lastSelection = currentSelection;
+
+    var syntheticEvent = SyntheticEvent.getPooled(eventTypes.select, activeElementInst, nativeEvent, nativeEventTarget);
+
+    syntheticEvent.type = 'select';
+    syntheticEvent.target = activeElement;
+
+    EventPropagators.accumulateTwoPhaseDispatches(syntheticEvent);
+
+    return syntheticEvent;
+  }
+
+  return null;
+}
+
+/**
+ * This plugin creates an `onSelect` event that normalizes select events
+ * across form elements.
+ *
+ * Supported elements are:
+ * - input (see `isTextInputElement`)
+ * - textarea
+ * - contentEditable
+ *
+ * This differs from native browser implementations in the following ways:
+ * - Fires on contentEditable fields as well as inputs.
+ * - Fires for collapsed selection.
+ * - Fires after user input.
+ */
+var SelectEventPlugin = {
+  eventTypes: eventTypes,
+
+  extractEvents: function (topLevelType, targetInst, nativeEvent, nativeEventTarget) {
+    if (!hasListener) {
+      return null;
+    }
+
+    var targetNode = targetInst ? ReactDOMComponentTree.getNodeFromInstance(targetInst) : window;
+
+    switch (topLevelType) {
+      // Track the input node that has focus.
+      case 'topFocus':
+        if (isTextInputElement(targetNode) || targetNode.contentEditable === 'true') {
+          activeElement = targetNode;
+          activeElementInst = targetInst;
+          lastSelection = null;
+        }
+        break;
+      case 'topBlur':
+        activeElement = null;
+        activeElementInst = null;
+        lastSelection = null;
+        break;
+      // Don't fire the event while the user is dragging. This matches the
+      // semantics of the native select event.
+      case 'topMouseDown':
+        mouseDown = true;
+        break;
+      case 'topContextMenu':
+      case 'topMouseUp':
+        mouseDown = false;
+        return constructSelectEvent(nativeEvent, nativeEventTarget);
+      // Chrome and IE fire non-standard event when selection is changed (and
+      // sometimes when it hasn't). IE's event fires out of order with respect
+      // to key and input events on deletion, so we discard it.
+      //
+      // Firefox doesn't support selectionchange, so check selection status
+      // after each key entry. The selection changes after keydown and before
+      // keyup, but we check on keydown as well in the case of holding down a
+      // key, when multiple keydown events are fired but only one keyup is.
+      // This is also our approach for IE handling, for the reason above.
+      case 'topSelectionChange':
+        if (skipSelectionChangeEvent) {
+          break;
+        }
+      // falls through
+      case 'topKeyDown':
+      case 'topKeyUp':
+        return constructSelectEvent(nativeEvent, nativeEventTarget);
+    }
+
+    return null;
+  },
+
+  didPutListener: function (inst, registrationName, listener) {
+    if (registrationName === 'onSelect') {
+      hasListener = true;
+    }
+  }
+};
+
+module.exports = SelectEventPlugin;
+},{"123":123,"138":138,"147":147,"158":158,"20":20,"34":34,"62":62,"91":91}],86:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var EventListener = _dereq_(137);
+var EventPropagators = _dereq_(20);
+var ReactDOMComponentTree = _dereq_(34);
+var SyntheticAnimationEvent = _dereq_(87);
+var SyntheticClipboardEvent = _dereq_(88);
+var SyntheticEvent = _dereq_(91);
+var SyntheticFocusEvent = _dereq_(92);
+var SyntheticKeyboardEvent = _dereq_(94);
+var SyntheticMouseEvent = _dereq_(95);
+var SyntheticDragEvent = _dereq_(90);
+var SyntheticTouchEvent = _dereq_(96);
+var SyntheticTransitionEvent = _dereq_(97);
+var SyntheticUIEvent = _dereq_(98);
+var SyntheticWheelEvent = _dereq_(99);
+
+var emptyFunction = _dereq_(144);
+var getEventCharCode = _dereq_(111);
+var invariant = _dereq_(152);
+
+/**
+ * Turns
+ * ['abort', ...]
+ * into
+ * eventTypes = {
+ *   'abort': {
+ *     phasedRegistrationNames: {
+ *       bubbled: 'onAbort',
+ *       captured: 'onAbortCapture',
+ *     },
+ *     dependencies: ['topAbort'],
+ *   },
+ *   ...
+ * };
+ * topLevelEventsToDispatchConfig = {
+ *   'topAbort': { sameConfig }
+ * };
+ */
+var eventTypes = {};
+var topLevelEventsToDispatchConfig = {};
+['abort', 'animationEnd', 'animationIteration', 'animationStart', 'blur', 'canPlay', 'canPlayThrough', 'click', 'contextMenu', 'copy', 'cut', 'doubleClick', 'drag', 'dragEnd', 'dragEnter', 'dragExit', 'dragLeave', 'dragOver', 'dragStart', 'drop', 'durationChange', 'emptied', 'encrypted', 'ended', 'error', 'focus', 'input', 'invalid', 'keyDown', 'keyPress', 'keyUp', 'load', 'loadedData', 'loadedMetadata', 'loadStart', 'mouseDown', 'mouseMove', 'mouseOut', 'mouseOver', 'mouseUp', 'paste', 'pause', 'play', 'playing', 'progress', 'rateChange', 'reset', 'scroll', 'seeked', 'seeking', 'stalled', 'submit', 'suspend', 'timeUpdate', 'touchCancel', 'touchEnd', 'touchMove', 'touchStart', 'transitionEnd', 'volumeChange', 'waiting', 'wheel'].forEach(function (event) {
+  var capitalizedEvent = event[0].toUpperCase() + event.slice(1);
+  var onEvent = 'on' + capitalizedEvent;
+  var topEvent = 'top' + capitalizedEvent;
+
+  var type = {
+    phasedRegistrationNames: {
+      bubbled: onEvent,
+      captured: onEvent + 'Capture'
+    },
+    dependencies: [topEvent]
+  };
+  eventTypes[event] = type;
+  topLevelEventsToDispatchConfig[topEvent] = type;
+});
+
+var onClickListeners = {};
+
+function getDictionaryKey(inst) {
+  // Prevents V8 performance issue:
+  // https://github.com/facebook/react/pull/7232
+  return '.' + inst._rootNodeID;
+}
+
+function isInteractive(tag) {
+  return tag === 'button' || tag === 'input' || tag === 'select' || tag === 'textarea';
+}
+
+var SimpleEventPlugin = {
+  eventTypes: eventTypes,
+
+  extractEvents: function (topLevelType, targetInst, nativeEvent, nativeEventTarget) {
+    var dispatchConfig = topLevelEventsToDispatchConfig[topLevelType];
+    if (!dispatchConfig) {
+      return null;
+    }
+    var EventConstructor;
+    switch (topLevelType) {
+      case 'topAbort':
+      case 'topCanPlay':
+      case 'topCanPlayThrough':
+      case 'topDurationChange':
+      case 'topEmptied':
+      case 'topEncrypted':
+      case 'topEnded':
+      case 'topError':
+      case 'topInput':
+      case 'topInvalid':
+      case 'topLoad':
+      case 'topLoadedData':
+      case 'topLoadedMetadata':
+      case 'topLoadStart':
+      case 'topPause':
+      case 'topPlay':
+      case 'topPlaying':
+      case 'topProgress':
+      case 'topRateChange':
+      case 'topReset':
+      case 'topSeeked':
+      case 'topSeeking':
+      case 'topStalled':
+      case 'topSubmit':
+      case 'topSuspend':
+      case 'topTimeUpdate':
+      case 'topVolumeChange':
+      case 'topWaiting':
+        // HTML Events
+        // @see http://www.w3.org/TR/html5/index.html#events-0
+        EventConstructor = SyntheticEvent;
+        break;
+      case 'topKeyPress':
+        // Firefox creates a keypress event for function keys too. This removes
+        // the unwanted keypress events. Enter is however both printable and
+        // non-printable. One would expect Tab to be as well (but it isn't).
+        if (getEventCharCode(nativeEvent) === 0) {
+          return null;
+        }
+      /* falls through */
+      case 'topKeyDown':
+      case 'topKeyUp':
+        EventConstructor = SyntheticKeyboardEvent;
+        break;
+      case 'topBlur':
+      case 'topFocus':
+        EventConstructor = SyntheticFocusEvent;
+        break;
+      case 'topClick':
+        // Firefox creates a click event on right mouse clicks. This removes the
+        // unwanted click events.
+        if (nativeEvent.button === 2) {
+          return null;
+        }
+      /* falls through */
+      case 'topDoubleClick':
+      case 'topMouseDown':
+      case 'topMouseMove':
+      case 'topMouseUp':
+      // TODO: Disabled elements should not respond to mouse events
+      /* falls through */
+      case 'topMouseOut':
+      case 'topMouseOver':
+      case 'topContextMenu':
+        EventConstructor = SyntheticMouseEvent;
+        break;
+      case 'topDrag':
+      case 'topDragEnd':
+      case 'topDragEnter':
+      case 'topDragExit':
+      case 'topDragLeave':
+      case 'topDragOver':
+      case 'topDragStart':
+      case 'topDrop':
+        EventConstructor = SyntheticDragEvent;
+        break;
+      case 'topTouchCancel':
+      case 'topTouchEnd':
+      case 'topTouchMove':
+      case 'topTouchStart':
+        EventConstructor = SyntheticTouchEvent;
+        break;
+      case 'topAnimationEnd':
+      case 'topAnimationIteration':
+      case 'topAnimationStart':
+        EventConstructor = SyntheticAnimationEvent;
+        break;
+      case 'topTransitionEnd':
+        EventConstructor = SyntheticTransitionEvent;
+        break;
+      case 'topScroll':
+        EventConstructor = SyntheticUIEvent;
+        break;
+      case 'topWheel':
+        EventConstructor = SyntheticWheelEvent;
+        break;
+      case 'topCopy':
+      case 'topCut':
+      case 'topPaste':
+        EventConstructor = SyntheticClipboardEvent;
+        break;
+    }
+    !EventConstructor ? "development" !== 'production' ? invariant(false, 'SimpleEventPlugin: Unhandled event type, `%s`.', topLevelType) : _prodInvariant('86', topLevelType) : void 0;
+    var event = EventConstructor.getPooled(dispatchConfig, targetInst, nativeEvent, nativeEventTarget);
+    EventPropagators.accumulateTwoPhaseDispatches(event);
+    return event;
+  },
+
+  didPutListener: function (inst, registrationName, listener) {
+    // Mobile Safari does not fire properly bubble click events on
+    // non-interactive elements, which means delegated click listeners do not
+    // fire. The workaround for this bug involves attaching an empty click
+    // listener on the target node.
+    // http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
+    if (registrationName === 'onClick' && !isInteractive(inst._tag)) {
+      var key = getDictionaryKey(inst);
+      var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+      if (!onClickListeners[key]) {
+        onClickListeners[key] = EventListener.listen(node, 'click', emptyFunction);
+      }
+    }
+  },
+
+  willDeleteListener: function (inst, registrationName) {
+    if (registrationName === 'onClick' && !isInteractive(inst._tag)) {
+      var key = getDictionaryKey(inst);
+      onClickListeners[key].remove();
+      delete onClickListeners[key];
+    }
+  }
+};
+
+module.exports = SimpleEventPlugin;
+},{"111":111,"126":126,"137":137,"144":144,"152":152,"20":20,"34":34,"87":87,"88":88,"90":90,"91":91,"92":92,"94":94,"95":95,"96":96,"97":97,"98":98,"99":99}],87:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticEvent = _dereq_(91);
+
+/**
+ * @interface Event
+ * @see http://www.w3.org/TR/css3-animations/#AnimationEvent-interface
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/AnimationEvent
+ */
+var AnimationEventInterface = {
+  animationName: null,
+  elapsedTime: null,
+  pseudoElement: null
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticEvent}
+ */
+function SyntheticAnimationEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticEvent.augmentClass(SyntheticAnimationEvent, AnimationEventInterface);
+
+module.exports = SyntheticAnimationEvent;
+},{"91":91}],88:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticEvent = _dereq_(91);
+
+/**
+ * @interface Event
+ * @see http://www.w3.org/TR/clipboard-apis/
+ */
+var ClipboardEventInterface = {
+  clipboardData: function (event) {
+    return 'clipboardData' in event ? event.clipboardData : window.clipboardData;
+  }
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticUIEvent}
+ */
+function SyntheticClipboardEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticEvent.augmentClass(SyntheticClipboardEvent, ClipboardEventInterface);
+
+module.exports = SyntheticClipboardEvent;
+},{"91":91}],89:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticEvent = _dereq_(91);
+
+/**
+ * @interface Event
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/#events-compositionevents
+ */
+var CompositionEventInterface = {
+  data: null
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticUIEvent}
+ */
+function SyntheticCompositionEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticEvent.augmentClass(SyntheticCompositionEvent, CompositionEventInterface);
+
+module.exports = SyntheticCompositionEvent;
+},{"91":91}],90:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticMouseEvent = _dereq_(95);
+
+/**
+ * @interface DragEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+var DragEventInterface = {
+  dataTransfer: null
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticUIEvent}
+ */
+function SyntheticDragEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticMouseEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticMouseEvent.augmentClass(SyntheticDragEvent, DragEventInterface);
+
+module.exports = SyntheticDragEvent;
+},{"95":95}],91:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var PooledClass = _dereq_(25);
+
+var emptyFunction = _dereq_(144);
+var warning = _dereq_(159);
+
+var didWarnForAddedNewProperty = false;
+var isProxySupported = typeof Proxy === 'function';
+
+var shouldBeReleasedProperties = ['dispatchConfig', '_targetInst', 'nativeEvent', 'isDefaultPrevented', 'isPropagationStopped', '_dispatchListeners', '_dispatchInstances'];
+
+/**
+ * @interface Event
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+var EventInterface = {
+  type: null,
+  target: null,
+  // currentTarget is set when dispatching; no use in copying it here
+  currentTarget: emptyFunction.thatReturnsNull,
+  eventPhase: null,
+  bubbles: null,
+  cancelable: null,
+  timeStamp: function (event) {
+    return event.timeStamp || Date.now();
+  },
+  defaultPrevented: null,
+  isTrusted: null
+};
+
+/**
+ * Synthetic events are dispatched by event plugins, typically in response to a
+ * top-level event delegation handler.
+ *
+ * These systems should generally use pooling to reduce the frequency of garbage
+ * collection. The system should check `isPersistent` to determine whether the
+ * event should be released into the pool after being dispatched. Users that
+ * need a persisted event should invoke `persist`.
+ *
+ * Synthetic events (and subclasses) implement the DOM Level 3 Events API by
+ * normalizing browser quirks. Subclasses do not necessarily have to implement a
+ * DOM interface; custom application-specific events can also subclass this.
+ *
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {*} targetInst Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @param {DOMEventTarget} nativeEventTarget Target node.
+ */
+function SyntheticEvent(dispatchConfig, targetInst, nativeEvent, nativeEventTarget) {
+  if ("development" !== 'production') {
+    // these have a getter/setter for warnings
+    delete this.nativeEvent;
+    delete this.preventDefault;
+    delete this.stopPropagation;
+  }
+
+  this.dispatchConfig = dispatchConfig;
+  this._targetInst = targetInst;
+  this.nativeEvent = nativeEvent;
+
+  var Interface = this.constructor.Interface;
+  for (var propName in Interface) {
+    if (!Interface.hasOwnProperty(propName)) {
+      continue;
+    }
+    if ("development" !== 'production') {
+      delete this[propName]; // this has a getter/setter for warnings
+    }
+    var normalize = Interface[propName];
+    if (normalize) {
+      this[propName] = normalize(nativeEvent);
+    } else {
+      if (propName === 'target') {
+        this.target = nativeEventTarget;
+      } else {
+        this[propName] = nativeEvent[propName];
+      }
+    }
+  }
+
+  var defaultPrevented = nativeEvent.defaultPrevented != null ? nativeEvent.defaultPrevented : nativeEvent.returnValue === false;
+  if (defaultPrevented) {
+    this.isDefaultPrevented = emptyFunction.thatReturnsTrue;
+  } else {
+    this.isDefaultPrevented = emptyFunction.thatReturnsFalse;
+  }
+  this.isPropagationStopped = emptyFunction.thatReturnsFalse;
+  return this;
+}
+
+_assign(SyntheticEvent.prototype, {
+  preventDefault: function () {
+    this.defaultPrevented = true;
+    var event = this.nativeEvent;
+    if (!event) {
+      return;
+    }
+
+    if (event.preventDefault) {
+      event.preventDefault();
+      // eslint-disable-next-line valid-typeof
+    } else if (typeof event.returnValue !== 'unknown') {
+      event.returnValue = false;
+    }
+    this.isDefaultPrevented = emptyFunction.thatReturnsTrue;
+  },
+
+  stopPropagation: function () {
+    var event = this.nativeEvent;
+    if (!event) {
+      return;
+    }
+
+    if (event.stopPropagation) {
+      event.stopPropagation();
+      // eslint-disable-next-line valid-typeof
+    } else if (typeof event.cancelBubble !== 'unknown') {
+      // The ChangeEventPlugin registers a "propertychange" event for
+      // IE. This event does not support bubbling or cancelling, and
+      // any references to cancelBubble throw "Member not found".  A
+      // typeof check of "unknown" circumvents this issue (and is also
+      // IE specific).
+      event.cancelBubble = true;
+    }
+
+    this.isPropagationStopped = emptyFunction.thatReturnsTrue;
+  },
+
+  /**
+   * We release all dispatched `SyntheticEvent`s after each event loop, adding
+   * them back into the pool. This allows a way to hold onto a reference that
+   * won't be added back into the pool.
+   */
+  persist: function () {
+    this.isPersistent = emptyFunction.thatReturnsTrue;
+  },
+
+  /**
+   * Checks if this event should be released back into the pool.
+   *
+   * @return {boolean} True if this should not be released, false otherwise.
+   */
+  isPersistent: emptyFunction.thatReturnsFalse,
+
+  /**
+   * `PooledClass` looks for `destructor` on each instance it releases.
+   */
+  destructor: function () {
+    var Interface = this.constructor.Interface;
+    for (var propName in Interface) {
+      if ("development" !== 'production') {
+        Object.defineProperty(this, propName, getPooledWarningPropertyDefinition(propName, Interface[propName]));
+      } else {
+        this[propName] = null;
+      }
+    }
+    for (var i = 0; i < shouldBeReleasedProperties.length; i++) {
+      this[shouldBeReleasedProperties[i]] = null;
+    }
+    if ("development" !== 'production') {
+      Object.defineProperty(this, 'nativeEvent', getPooledWarningPropertyDefinition('nativeEvent', null));
+      Object.defineProperty(this, 'preventDefault', getPooledWarningPropertyDefinition('preventDefault', emptyFunction));
+      Object.defineProperty(this, 'stopPropagation', getPooledWarningPropertyDefinition('stopPropagation', emptyFunction));
+    }
+  }
+});
+
+SyntheticEvent.Interface = EventInterface;
+
+/**
+ * Helper to reduce boilerplate when creating subclasses.
+ *
+ * @param {function} Class
+ * @param {?object} Interface
+ */
+SyntheticEvent.augmentClass = function (Class, Interface) {
+  var Super = this;
+
+  var E = function () {};
+  E.prototype = Super.prototype;
+  var prototype = new E();
+
+  _assign(prototype, Class.prototype);
+  Class.prototype = prototype;
+  Class.prototype.constructor = Class;
+
+  Class.Interface = _assign({}, Super.Interface, Interface);
+  Class.augmentClass = Super.augmentClass;
+
+  PooledClass.addPoolingTo(Class, PooledClass.fourArgumentPooler);
+};
+
+/** Proxying after everything set on SyntheticEvent
+  * to resolve Proxy issue on some WebKit browsers
+  * in which some Event properties are set to undefined (GH#10010)
+  */
+if ("development" !== 'production') {
+  if (isProxySupported) {
+    /*eslint-disable no-func-assign */
+    SyntheticEvent = new Proxy(SyntheticEvent, {
+      construct: function (target, args) {
+        return this.apply(target, Object.create(target.prototype), args);
+      },
+      apply: function (constructor, that, args) {
+        return new Proxy(constructor.apply(that, args), {
+          set: function (target, prop, value) {
+            if (prop !== 'isPersistent' && !target.constructor.Interface.hasOwnProperty(prop) && shouldBeReleasedProperties.indexOf(prop) === -1) {
+              "development" !== 'production' ? warning(didWarnForAddedNewProperty || target.isPersistent(), "This synthetic event is reused for performance reasons. If you're " + "seeing this, you're adding a new property in the synthetic event object. " + 'The property is never released. See ' + 'https://fb.me/react-event-pooling for more information.') : void 0;
+              didWarnForAddedNewProperty = true;
+            }
+            target[prop] = value;
+            return true;
+          }
+        });
+      }
+    });
+    /*eslint-enable no-func-assign */
+  }
+}
+
+PooledClass.addPoolingTo(SyntheticEvent, PooledClass.fourArgumentPooler);
+
+module.exports = SyntheticEvent;
+
+/**
+  * Helper to nullify syntheticEvent instance properties when destructing
+  *
+  * @param {object} SyntheticEvent
+  * @param {String} propName
+  * @return {object} defineProperty object
+  */
+function getPooledWarningPropertyDefinition(propName, getVal) {
+  var isFunction = typeof getVal === 'function';
+  return {
+    configurable: true,
+    set: set,
+    get: get
+  };
+
+  function set(val) {
+    var action = isFunction ? 'setting the method' : 'setting the property';
+    warn(action, 'This is effectively a no-op');
+    return val;
+  }
+
+  function get() {
+    var action = isFunction ? 'accessing the method' : 'accessing the property';
+    var result = isFunction ? 'This is a no-op function' : 'This is set to null';
+    warn(action, result);
+    return getVal;
+  }
+
+  function warn(action, result) {
+    var warningCondition = false;
+    "development" !== 'production' ? warning(warningCondition, "This synthetic event is reused for performance reasons. If you're seeing this, " + "you're %s `%s` on a released/nullified synthetic event. %s. " + 'If you must keep the original synthetic event around, use event.persist(). ' + 'See https://fb.me/react-event-pooling for more information.', action, propName, result) : void 0;
+  }
+}
+},{"144":144,"159":159,"160":160,"25":25}],92:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticUIEvent = _dereq_(98);
+
+/**
+ * @interface FocusEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+var FocusEventInterface = {
+  relatedTarget: null
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticUIEvent}
+ */
+function SyntheticFocusEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticUIEvent.augmentClass(SyntheticFocusEvent, FocusEventInterface);
+
+module.exports = SyntheticFocusEvent;
+},{"98":98}],93:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticEvent = _dereq_(91);
+
+/**
+ * @interface Event
+ * @see http://www.w3.org/TR/2013/WD-DOM-Level-3-Events-20131105
+ *      /#events-inputevents
+ */
+var InputEventInterface = {
+  data: null
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticUIEvent}
+ */
+function SyntheticInputEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticEvent.augmentClass(SyntheticInputEvent, InputEventInterface);
+
+module.exports = SyntheticInputEvent;
+},{"91":91}],94:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticUIEvent = _dereq_(98);
+
+var getEventCharCode = _dereq_(111);
+var getEventKey = _dereq_(112);
+var getEventModifierState = _dereq_(113);
+
+/**
+ * @interface KeyboardEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+var KeyboardEventInterface = {
+  key: getEventKey,
+  location: null,
+  ctrlKey: null,
+  shiftKey: null,
+  altKey: null,
+  metaKey: null,
+  repeat: null,
+  locale: null,
+  getModifierState: getEventModifierState,
+  // Legacy Interface
+  charCode: function (event) {
+    // `charCode` is the result of a KeyPress event and represents the value of
+    // the actual printable character.
+
+    // KeyPress is deprecated, but its replacement is not yet final and not
+    // implemented in any major browser. Only KeyPress has charCode.
+    if (event.type === 'keypress') {
+      return getEventCharCode(event);
+    }
+    return 0;
+  },
+  keyCode: function (event) {
+    // `keyCode` is the result of a KeyDown/Up event and represents the value of
+    // physical keyboard key.
+
+    // The actual meaning of the value depends on the users' keyboard layout
+    // which cannot be detected. Assuming that it is a US keyboard layout
+    // provides a surprisingly accurate mapping for US and European users.
+    // Due to this, it is left to the user to implement at this time.
+    if (event.type === 'keydown' || event.type === 'keyup') {
+      return event.keyCode;
+    }
+    return 0;
+  },
+  which: function (event) {
+    // `which` is an alias for either `keyCode` or `charCode` depending on the
+    // type of the event.
+    if (event.type === 'keypress') {
+      return getEventCharCode(event);
+    }
+    if (event.type === 'keydown' || event.type === 'keyup') {
+      return event.keyCode;
+    }
+    return 0;
+  }
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticUIEvent}
+ */
+function SyntheticKeyboardEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticUIEvent.augmentClass(SyntheticKeyboardEvent, KeyboardEventInterface);
+
+module.exports = SyntheticKeyboardEvent;
+},{"111":111,"112":112,"113":113,"98":98}],95:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticUIEvent = _dereq_(98);
+var ViewportMetrics = _dereq_(101);
+
+var getEventModifierState = _dereq_(113);
+
+/**
+ * @interface MouseEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+var MouseEventInterface = {
+  screenX: null,
+  screenY: null,
+  clientX: null,
+  clientY: null,
+  ctrlKey: null,
+  shiftKey: null,
+  altKey: null,
+  metaKey: null,
+  getModifierState: getEventModifierState,
+  button: function (event) {
+    // Webkit, Firefox, IE9+
+    // which:  1 2 3
+    // button: 0 1 2 (standard)
+    var button = event.button;
+    if ('which' in event) {
+      return button;
+    }
+    // IE<9
+    // which:  undefined
+    // button: 0 0 0
+    // button: 1 4 2 (onmouseup)
+    return button === 2 ? 2 : button === 4 ? 1 : 0;
+  },
+  buttons: null,
+  relatedTarget: function (event) {
+    return event.relatedTarget || (event.fromElement === event.srcElement ? event.toElement : event.fromElement);
+  },
+  // "Proprietary" Interface.
+  pageX: function (event) {
+    return 'pageX' in event ? event.pageX : event.clientX + ViewportMetrics.currentScrollLeft;
+  },
+  pageY: function (event) {
+    return 'pageY' in event ? event.pageY : event.clientY + ViewportMetrics.currentScrollTop;
+  }
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticUIEvent}
+ */
+function SyntheticMouseEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticUIEvent.augmentClass(SyntheticMouseEvent, MouseEventInterface);
+
+module.exports = SyntheticMouseEvent;
+},{"101":101,"113":113,"98":98}],96:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticUIEvent = _dereq_(98);
+
+var getEventModifierState = _dereq_(113);
+
+/**
+ * @interface TouchEvent
+ * @see http://www.w3.org/TR/touch-events/
+ */
+var TouchEventInterface = {
+  touches: null,
+  targetTouches: null,
+  changedTouches: null,
+  altKey: null,
+  metaKey: null,
+  ctrlKey: null,
+  shiftKey: null,
+  getModifierState: getEventModifierState
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticUIEvent}
+ */
+function SyntheticTouchEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticUIEvent.augmentClass(SyntheticTouchEvent, TouchEventInterface);
+
+module.exports = SyntheticTouchEvent;
+},{"113":113,"98":98}],97:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticEvent = _dereq_(91);
+
+/**
+ * @interface Event
+ * @see http://www.w3.org/TR/2009/WD-css3-transitions-20090320/#transition-events-
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent
+ */
+var TransitionEventInterface = {
+  propertyName: null,
+  elapsedTime: null,
+  pseudoElement: null
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticEvent}
+ */
+function SyntheticTransitionEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticEvent.augmentClass(SyntheticTransitionEvent, TransitionEventInterface);
+
+module.exports = SyntheticTransitionEvent;
+},{"91":91}],98:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticEvent = _dereq_(91);
+
+var getEventTarget = _dereq_(114);
+
+/**
+ * @interface UIEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+var UIEventInterface = {
+  view: function (event) {
+    if (event.view) {
+      return event.view;
+    }
+
+    var target = getEventTarget(event);
+    if (target.window === target) {
+      // target is a window object
+      return target;
+    }
+
+    var doc = target.ownerDocument;
+    // TODO: Figure out why `ownerDocument` is sometimes undefined in IE8.
+    if (doc) {
+      return doc.defaultView || doc.parentWindow;
+    } else {
+      return window;
+    }
+  },
+  detail: function (event) {
+    return event.detail || 0;
+  }
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticEvent}
+ */
+function SyntheticUIEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticEvent.augmentClass(SyntheticUIEvent, UIEventInterface);
+
+module.exports = SyntheticUIEvent;
+},{"114":114,"91":91}],99:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var SyntheticMouseEvent = _dereq_(95);
+
+/**
+ * @interface WheelEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+var WheelEventInterface = {
+  deltaX: function (event) {
+    return 'deltaX' in event ? event.deltaX : // Fallback to `wheelDeltaX` for Webkit and normalize (right is positive).
+    'wheelDeltaX' in event ? -event.wheelDeltaX : 0;
+  },
+  deltaY: function (event) {
+    return 'deltaY' in event ? event.deltaY : // Fallback to `wheelDeltaY` for Webkit and normalize (down is positive).
+    'wheelDeltaY' in event ? -event.wheelDeltaY : // Fallback to `wheelDelta` for IE<9 and normalize (down is positive).
+    'wheelDelta' in event ? -event.wheelDelta : 0;
+  },
+  deltaZ: null,
+
+  // Browsers without "deltaMode" is reporting in raw wheel delta where one
+  // notch on the scroll is always +/- 120, roughly equivalent to pixels.
+  // A good approximation of DOM_DELTA_LINE (1) is 5% of viewport size or
+  // ~40 pixels, for DOM_DELTA_SCREEN (2) it is 87.5% of viewport size.
+  deltaMode: null
+};
+
+/**
+ * @param {object} dispatchConfig Configuration used to dispatch this event.
+ * @param {string} dispatchMarker Marker identifying the event target.
+ * @param {object} nativeEvent Native browser event.
+ * @extends {SyntheticMouseEvent}
+ */
+function SyntheticWheelEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  return SyntheticMouseEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+}
+
+SyntheticMouseEvent.augmentClass(SyntheticWheelEvent, WheelEventInterface);
+
+module.exports = SyntheticWheelEvent;
+},{"95":95}],100:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var invariant = _dereq_(152);
+
+var OBSERVED_ERROR = {};
+
+/**
+ * `Transaction` creates a black box that is able to wrap any method such that
+ * certain invariants are maintained before and after the method is invoked
+ * (Even if an exception is thrown while invoking the wrapped method). Whoever
+ * instantiates a transaction can provide enforcers of the invariants at
+ * creation time. The `Transaction` class itself will supply one additional
+ * automatic invariant for you - the invariant that any transaction instance
+ * should not be run while it is already being run. You would typically create a
+ * single instance of a `Transaction` for reuse multiple times, that potentially
+ * is used to wrap several different methods. Wrappers are extremely simple -
+ * they only require implementing two methods.
+ *
+ * <pre>
+ *                       wrappers (injected at creation time)
+ *                                      +        +
+ *                                      |        |
+ *                    +-----------------|--------|--------------+
+ *                    |                 v        |              |
+ *                    |      +---------------+   |              |
+ *                    |   +--|    wrapper1   |---|----+         |
+ *                    |   |  +---------------+   v    |         |
+ *                    |   |          +-------------+  |         |
+ *                    |   |     +----|   wrapper2  |--------+   |
+ *                    |   |     |    +-------------+  |     |   |
+ *                    |   |     |                     |     |   |
+ *                    |   v     v                     v     v   | wrapper
+ *                    | +---+ +---+   +---------+   +---+ +---+ | invariants
+ * perform(anyMethod) | |   | |   |   |         |   |   | |   | | maintained
+ * +----------------->|-|---|-|---|-->|anyMethod|---|---|-|---|-|-------->
+ *                    | |   | |   |   |         |   |   | |   | |
+ *                    | |   | |   |   |         |   |   | |   | |
+ *                    | |   | |   |   |         |   |   | |   | |
+ *                    | +---+ +---+   +---------+   +---+ +---+ |
+ *                    |  initialize                    close    |
+ *                    +-----------------------------------------+
+ * </pre>
+ *
+ * Use cases:
+ * - Preserving the input selection ranges before/after reconciliation.
+ *   Restoring selection even in the event of an unexpected error.
+ * - Deactivating events while rearranging the DOM, preventing blurs/focuses,
+ *   while guaranteeing that afterwards, the event system is reactivated.
+ * - Flushing a queue of collected DOM mutations to the main UI thread after a
+ *   reconciliation takes place in a worker thread.
+ * - Invoking any collected `componentDidUpdate` callbacks after rendering new
+ *   content.
+ * - (Future use case): Wrapping particular flushes of the `ReactWorker` queue
+ *   to preserve the `scrollTop` (an automatic scroll aware DOM).
+ * - (Future use case): Layout calculations before and after DOM updates.
+ *
+ * Transactional plugin API:
+ * - A module that has an `initialize` method that returns any precomputation.
+ * - and a `close` method that accepts the precomputation. `close` is invoked
+ *   when the wrapped process is completed, or has failed.
+ *
+ * @param {Array<TransactionalWrapper>} transactionWrapper Wrapper modules
+ * that implement `initialize` and `close`.
+ * @return {Transaction} Single transaction for reuse in thread.
+ *
+ * @class Transaction
+ */
+var TransactionImpl = {
+  /**
+   * Sets up this instance so that it is prepared for collecting metrics. Does
+   * so such that this setup method may be used on an instance that is already
+   * initialized, in a way that does not consume additional memory upon reuse.
+   * That can be useful if you decide to make your subclass of this mixin a
+   * "PooledClass".
+   */
+  reinitializeTransaction: function () {
+    this.transactionWrappers = this.getTransactionWrappers();
+    if (this.wrapperInitData) {
+      this.wrapperInitData.length = 0;
+    } else {
+      this.wrapperInitData = [];
+    }
+    this._isInTransaction = false;
+  },
+
+  _isInTransaction: false,
+
+  /**
+   * @abstract
+   * @return {Array<TransactionWrapper>} Array of transaction wrappers.
+   */
+  getTransactionWrappers: null,
+
+  isInTransaction: function () {
+    return !!this._isInTransaction;
+  },
+
+  /* eslint-disable space-before-function-paren */
+
+  /**
+   * Executes the function within a safety window. Use this for the top level
+   * methods that result in large amounts of computation/mutations that would
+   * need to be safety checked. The optional arguments helps prevent the need
+   * to bind in many cases.
+   *
+   * @param {function} method Member of scope to call.
+   * @param {Object} scope Scope to invoke from.
+   * @param {Object?=} a Argument to pass to the method.
+   * @param {Object?=} b Argument to pass to the method.
+   * @param {Object?=} c Argument to pass to the method.
+   * @param {Object?=} d Argument to pass to the method.
+   * @param {Object?=} e Argument to pass to the method.
+   * @param {Object?=} f Argument to pass to the method.
+   *
+   * @return {*} Return value from `method`.
+   */
+  perform: function (method, scope, a, b, c, d, e, f) {
+    /* eslint-enable space-before-function-paren */
+    !!this.isInTransaction() ? "development" !== 'production' ? invariant(false, 'Transaction.perform(...): Cannot initialize a transaction when there is already an outstanding transaction.') : _prodInvariant('27') : void 0;
+    var errorThrown;
+    var ret;
+    try {
+      this._isInTransaction = true;
+      // Catching errors makes debugging more difficult, so we start with
+      // errorThrown set to true before setting it to false after calling
+      // close -- if it's still set to true in the finally block, it means
+      // one of these calls threw.
+      errorThrown = true;
+      this.initializeAll(0);
+      ret = method.call(scope, a, b, c, d, e, f);
+      errorThrown = false;
+    } finally {
+      try {
+        if (errorThrown) {
+          // If `method` throws, prefer to show that stack trace over any thrown
+          // by invoking `closeAll`.
+          try {
+            this.closeAll(0);
+          } catch (err) {}
+        } else {
+          // Since `method` didn't throw, we don't want to silence the exception
+          // here.
+          this.closeAll(0);
+        }
+      } finally {
+        this._isInTransaction = false;
+      }
+    }
+    return ret;
+  },
+
+  initializeAll: function (startIndex) {
+    var transactionWrappers = this.transactionWrappers;
+    for (var i = startIndex; i < transactionWrappers.length; i++) {
+      var wrapper = transactionWrappers[i];
+      try {
+        // Catching errors makes debugging more difficult, so we start with the
+        // OBSERVED_ERROR state before overwriting it with the real return value
+        // of initialize -- if it's still set to OBSERVED_ERROR in the finally
+        // block, it means wrapper.initialize threw.
+        this.wrapperInitData[i] = OBSERVED_ERROR;
+        this.wrapperInitData[i] = wrapper.initialize ? wrapper.initialize.call(this) : null;
+      } finally {
+        if (this.wrapperInitData[i] === OBSERVED_ERROR) {
+          // The initializer for wrapper i threw an error; initialize the
+          // remaining wrappers but silence any exceptions from them to ensure
+          // that the first error is the one to bubble up.
+          try {
+            this.initializeAll(i + 1);
+          } catch (err) {}
+        }
+      }
+    }
+  },
+
+  /**
+   * Invokes each of `this.transactionWrappers.close[i]` functions, passing into
+   * them the respective return values of `this.transactionWrappers.init[i]`
+   * (`close`rs that correspond to initializers that failed will not be
+   * invoked).
+   */
+  closeAll: function (startIndex) {
+    !this.isInTransaction() ? "development" !== 'production' ? invariant(false, 'Transaction.closeAll(): Cannot close transaction when none are open.') : _prodInvariant('28') : void 0;
+    var transactionWrappers = this.transactionWrappers;
+    for (var i = startIndex; i < transactionWrappers.length; i++) {
+      var wrapper = transactionWrappers[i];
+      var initData = this.wrapperInitData[i];
+      var errorThrown;
+      try {
+        // Catching errors makes debugging more difficult, so we start with
+        // errorThrown set to true before setting it to false after calling
+        // close -- if it's still set to true in the finally block, it means
+        // wrapper.close threw.
+        errorThrown = true;
+        if (initData !== OBSERVED_ERROR && wrapper.close) {
+          wrapper.close.call(this, initData);
+        }
+        errorThrown = false;
+      } finally {
+        if (errorThrown) {
+          // The closer for wrapper i threw an error; close the remaining
+          // wrappers but silence any exceptions from them to ensure that the
+          // first error is the one to bubble up.
+          try {
+            this.closeAll(i + 1);
+          } catch (e) {}
+        }
+      }
+    }
+    this.wrapperInitData.length = 0;
+  }
+};
+
+module.exports = TransactionImpl;
+},{"126":126,"152":152}],101:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ViewportMetrics = {
+  currentScrollLeft: 0,
+
+  currentScrollTop: 0,
+
+  refreshScrollValues: function (scrollPosition) {
+    ViewportMetrics.currentScrollLeft = scrollPosition.x;
+    ViewportMetrics.currentScrollTop = scrollPosition.y;
+  }
+};
+
+module.exports = ViewportMetrics;
+},{}],102:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var invariant = _dereq_(152);
+
+/**
+ * Accumulates items that must not be null or undefined into the first one. This
+ * is used to conserve memory by avoiding array allocations, and thus sacrifices
+ * API cleanness. Since `current` can be null before being passed in and not
+ * null after this function, make sure to assign it back to `current`:
+ *
+ * `a = accumulateInto(a, b);`
+ *
+ * This API should be sparingly used. Try `accumulate` for something cleaner.
+ *
+ * @return {*|array<*>} An accumulation of items.
+ */
+
+function accumulateInto(current, next) {
+  !(next != null) ? "development" !== 'production' ? invariant(false, 'accumulateInto(...): Accumulated items must not be null or undefined.') : _prodInvariant('30') : void 0;
+
+  if (current == null) {
+    return next;
+  }
+
+  // Both are not empty. Warning: Never call x.concat(y) when you are not
+  // certain that x is an Array (x could be a string with concat method).
+  if (Array.isArray(current)) {
+    if (Array.isArray(next)) {
+      current.push.apply(current, next);
+      return current;
+    }
+    current.push(next);
+    return current;
+  }
+
+  if (Array.isArray(next)) {
+    // A bit too dangerous to mutate `next`.
+    return [current].concat(next);
+  }
+
+  return [current, next];
+}
+
+module.exports = accumulateInto;
+},{"126":126,"152":152}],103:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var MOD = 65521;
+
+// adler32 is not cryptographically strong, and is only used to sanity check that
+// markup generated on the server matches the markup generated on the client.
+// This implementation (a modified version of the SheetJS version) has been optimized
+// for our use case, at the expense of conforming to the adler32 specification
+// for non-ascii inputs.
+function adler32(data) {
+  var a = 1;
+  var b = 0;
+  var i = 0;
+  var l = data.length;
+  var m = l & ~0x3;
+  while (i < m) {
+    var n = Math.min(i + 4096, m);
+    for (; i < n; i += 4) {
+      b += (a += data.charCodeAt(i)) + (a += data.charCodeAt(i + 1)) + (a += data.charCodeAt(i + 2)) + (a += data.charCodeAt(i + 3));
+    }
+    a %= MOD;
+    b %= MOD;
+  }
+  for (; i < l; i++) {
+    b += a += data.charCodeAt(i);
+  }
+  a %= MOD;
+  b %= MOD;
+  return a | b << 16;
+}
+
+module.exports = adler32;
+},{}],104:[function(_dereq_,module,exports){
+(function (process){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var ReactPropTypeLocationNames = _dereq_(72);
+var ReactPropTypesSecret = _dereq_(73);
+
+var invariant = _dereq_(152);
+var warning = _dereq_(159);
+
+var ReactComponentTreeHook;
+
+if (typeof process !== 'undefined' && process.env && "development" === 'test') {
+  // Temporary hack.
+  // Inline requires don't work well with Jest:
+  // https://github.com/facebook/react/issues/7240
+  // Remove the inline requires when we don't need them anymore:
+  // https://github.com/facebook/react/pull/7178
+  ReactComponentTreeHook = _dereq_(133);
+}
+
+var loggedTypeFailures = {};
+
+/**
+ * Assert that the values match with the type specs.
+ * Error messages are memorized and will only be shown once.
+ *
+ * @param {object} typeSpecs Map of name to a ReactPropType
+ * @param {object} values Runtime values that need to be type-checked
+ * @param {string} location e.g. "prop", "context", "child context"
+ * @param {string} componentName Name of the component for error messages.
+ * @param {?object} element The React element that is being type-checked
+ * @param {?number} debugID The React component instance that is being type-checked
+ * @private
+ */
+function checkReactTypeSpec(typeSpecs, values, location, componentName, element, debugID) {
+  for (var typeSpecName in typeSpecs) {
+    if (typeSpecs.hasOwnProperty(typeSpecName)) {
+      var error;
+      // Prop type validation may throw. In case they do, we don't want to
+      // fail the render phase where it didn't fail before. So we log it.
+      // After these have been cleaned up, we'll let them throw.
+      try {
+        // This is intentionally an invariant that gets caught. It's the same
+        // behavior as without this statement except with a better message.
+        !(typeof typeSpecs[typeSpecName] === 'function') ? "development" !== 'production' ? invariant(false, '%s: %s type `%s` is invalid; it must be a function, usually from React.PropTypes.', componentName || 'React class', ReactPropTypeLocationNames[location], typeSpecName) : _prodInvariant('84', componentName || 'React class', ReactPropTypeLocationNames[location], typeSpecName) : void 0;
+        error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
+      } catch (ex) {
+        error = ex;
+      }
+      "development" !== 'production' ? warning(!error || error instanceof Error, '%s: type specification of %s `%s` is invalid; the type checker ' + 'function must return `null` or an `Error` but returned a %s. ' + 'You may have forgotten to pass an argument to the type checker ' + 'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' + 'shape all require an argument).', componentName || 'React class', ReactPropTypeLocationNames[location], typeSpecName, typeof error) : void 0;
+      if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+        // Only monitor this failure once because there tends to be a lot of the
+        // same error.
+        loggedTypeFailures[error.message] = true;
+
+        var componentStackInfo = '';
+
+        if ("development" !== 'production') {
+          if (!ReactComponentTreeHook) {
+            ReactComponentTreeHook = _dereq_(133);
+          }
+          if (debugID !== null) {
+            componentStackInfo = ReactComponentTreeHook.getStackAddendumByID(debugID);
+          } else if (element !== null) {
+            componentStackInfo = ReactComponentTreeHook.getCurrentStackAddendum(element);
+          }
+        }
+
+        "development" !== 'production' ? warning(false, 'Failed %s type: %s%s', location, error.message, componentStackInfo) : void 0;
+      }
+    }
+  }
+}
+
+module.exports = checkReactTypeSpec;
+}).call(this,undefined)
+},{"126":126,"133":133,"152":152,"159":159,"72":72,"73":73}],105:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/* globals MSApp */
+
+'use strict';
+
+/**
+ * Create a function which has 'unsafe' privileges (required by windows8 apps)
+ */
+
+var createMicrosoftUnsafeLocalFunction = function (func) {
+  if (typeof MSApp !== 'undefined' && MSApp.execUnsafeLocalFunction) {
+    return function (arg0, arg1, arg2, arg3) {
+      MSApp.execUnsafeLocalFunction(function () {
+        return func(arg0, arg1, arg2, arg3);
+      });
+    };
+  } else {
+    return func;
+  }
+};
+
+module.exports = createMicrosoftUnsafeLocalFunction;
+},{}],106:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var CSSProperty = _dereq_(4);
+var warning = _dereq_(159);
+
+var isUnitlessNumber = CSSProperty.isUnitlessNumber;
+var styleWarnings = {};
+
+/**
+ * Convert a value into the proper css writable value. The style name `name`
+ * should be logical (no hyphens), as specified
+ * in `CSSProperty.isUnitlessNumber`.
+ *
+ * @param {string} name CSS property name such as `topMargin`.
+ * @param {*} value CSS property value such as `10px`.
+ * @param {ReactDOMComponent} component
+ * @return {string} Normalized style value with dimensions applied.
+ */
+function dangerousStyleValue(name, value, component, isCustomProperty) {
+  // Note that we've removed escapeTextForBrowser() calls here since the
+  // whole string will be escaped when the attribute is injected into
+  // the markup. If you provide unsafe user data here they can inject
+  // arbitrary CSS which may be problematic (I couldn't repro this):
+  // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet
+  // http://www.thespanner.co.uk/2007/11/26/ultimate-xss-css-injection/
+  // This is not an XSS hole but instead a potential CSS injection issue
+  // which has lead to a greater discussion about how we're going to
+  // trust URLs moving forward. See #2115901
+
+  var isEmpty = value == null || typeof value === 'boolean' || value === '';
+  if (isEmpty) {
+    return '';
+  }
+
+  var isNonNumeric = isNaN(value);
+  if (isCustomProperty || isNonNumeric || value === 0 || isUnitlessNumber.hasOwnProperty(name) && isUnitlessNumber[name]) {
+    return '' + value; // cast to string
+  }
+
+  if (typeof value === 'string') {
+    if ("development" !== 'production') {
+      // Allow '0' to pass through without warning. 0 is already special and
+      // doesn't require units, so we don't need to warn about it.
+      if (component && value !== '0') {
+        var owner = component._currentElement._owner;
+        var ownerName = owner ? owner.getName() : null;
+        if (ownerName && !styleWarnings[ownerName]) {
+          styleWarnings[ownerName] = {};
+        }
+        var warned = false;
+        if (ownerName) {
+          var warnings = styleWarnings[ownerName];
+          warned = warnings[name];
+          if (!warned) {
+            warnings[name] = true;
+          }
+        }
+        if (!warned) {
+          "development" !== 'production' ? warning(false, 'a `%s` tag (owner: `%s`) was passed a numeric string value ' + 'for CSS property `%s` (value: `%s`) which will be treated ' + 'as a unitless number in a future version of React.', component._currentElement.type, ownerName || 'unknown', name, value) : void 0;
+        }
+      }
+    }
+    value = value.trim();
+  }
+  return value + 'px';
+}
+
+module.exports = dangerousStyleValue;
+},{"159":159,"4":4}],107:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Based on the escape-html library, which is used under the MIT License below:
+ *
+ * Copyright (c) 2012-2013 TJ Holowaychuk
+ * Copyright (c) 2015 Andreas Lubbe
+ * Copyright (c) 2015 Tiancheng "Timothy" Gu
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * 'Software'), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+'use strict';
+
+// code copied and modified from escape-html
+/**
+ * Module variables.
+ * @private
+ */
+
+var matchHtmlRegExp = /["'&<>]/;
+
+/**
+ * Escape special characters in the given string of html.
+ *
+ * @param  {string} string The string to escape for inserting into HTML
+ * @return {string}
+ * @public
+ */
+
+function escapeHtml(string) {
+  var str = '' + string;
+  var match = matchHtmlRegExp.exec(str);
+
+  if (!match) {
+    return str;
+  }
+
+  var escape;
+  var html = '';
+  var index = 0;
+  var lastIndex = 0;
+
+  for (index = match.index; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 34:
+        // "
+        escape = '&quot;';
+        break;
+      case 38:
+        // &
+        escape = '&amp;';
+        break;
+      case 39:
+        // '
+        escape = '&#x27;'; // modified from escape-html; used to be '&#39'
+        break;
+      case 60:
+        // <
+        escape = '&lt;';
+        break;
+      case 62:
+        // >
+        escape = '&gt;';
+        break;
+      default:
+        continue;
+    }
+
+    if (lastIndex !== index) {
+      html += str.substring(lastIndex, index);
+    }
+
+    lastIndex = index + 1;
+    html += escape;
+  }
+
+  return lastIndex !== index ? html + str.substring(lastIndex, index) : html;
+}
+// end code copied and modified from escape-html
+
+/**
+ * Escapes text to prevent scripting attacks.
+ *
+ * @param {*} text Text value to escape.
+ * @return {string} An escaped string.
+ */
+function escapeTextContentForBrowser(text) {
+  if (typeof text === 'boolean' || typeof text === 'number') {
+    // this shortcircuit helps perf for types that we know will never have
+    // special characters, especially given that this function is used often
+    // for numeric dom ids.
+    return '' + text;
+  }
+  return escapeHtml(text);
+}
+
+module.exports = escapeTextContentForBrowser;
+},{}],108:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var ReactCurrentOwner = _dereq_(134);
+var ReactDOMComponentTree = _dereq_(34);
+var ReactInstanceMap = _dereq_(63);
+
+var getHostComponentFromComposite = _dereq_(115);
+var invariant = _dereq_(152);
+var warning = _dereq_(159);
+
+/**
+ * Returns the DOM node rendered by this element.
+ *
+ * See https://facebook.github.io/react/docs/top-level-api.html#reactdom.finddomnode
+ *
+ * @param {ReactComponent|DOMElement} componentOrElement
+ * @return {?DOMElement} The root node of this element.
+ */
+function findDOMNode(componentOrElement) {
+  if ("development" !== 'production') {
+    var owner = ReactCurrentOwner.current;
+    if (owner !== null) {
+      "development" !== 'production' ? warning(owner._warnedAboutRefsInRender, '%s is accessing findDOMNode inside its render(). ' + 'render() should be a pure function of props and state. It should ' + 'never access something that requires stale data from the previous ' + 'render, such as refs. Move this logic to componentDidMount and ' + 'componentDidUpdate instead.', owner.getName() || 'A component') : void 0;
+      owner._warnedAboutRefsInRender = true;
+    }
+  }
+  if (componentOrElement == null) {
+    return null;
+  }
+  if (componentOrElement.nodeType === 1) {
+    return componentOrElement;
+  }
+
+  var inst = ReactInstanceMap.get(componentOrElement);
+  if (inst) {
+    inst = getHostComponentFromComposite(inst);
+    return inst ? ReactDOMComponentTree.getNodeFromInstance(inst) : null;
+  }
+
+  if (typeof componentOrElement.render === 'function') {
+    !false ? "development" !== 'production' ? invariant(false, 'findDOMNode was called on an unmounted component.') : _prodInvariant('44') : void 0;
+  } else {
+    !false ? "development" !== 'production' ? invariant(false, 'Element appears to be neither ReactComponent nor DOMNode (keys: %s)', Object.keys(componentOrElement)) : _prodInvariant('45', Object.keys(componentOrElement)) : void 0;
+  }
+}
+
+module.exports = findDOMNode;
+},{"115":115,"126":126,"134":134,"152":152,"159":159,"34":34,"63":63}],109:[function(_dereq_,module,exports){
+(function (process){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var KeyEscapeUtils = _dereq_(23);
+var traverseAllChildren = _dereq_(131);
+var warning = _dereq_(159);
+
+var ReactComponentTreeHook;
+
+if (typeof process !== 'undefined' && process.env && "development" === 'test') {
+  // Temporary hack.
+  // Inline requires don't work well with Jest:
+  // https://github.com/facebook/react/issues/7240
+  // Remove the inline requires when we don't need them anymore:
+  // https://github.com/facebook/react/pull/7178
+  ReactComponentTreeHook = _dereq_(133);
+}
+
+/**
+ * @param {function} traverseContext Context passed through traversal.
+ * @param {?ReactComponent} child React child component.
+ * @param {!string} name String name of key path to child.
+ * @param {number=} selfDebugID Optional debugID of the current internal instance.
+ */
+function flattenSingleChildIntoContext(traverseContext, child, name, selfDebugID) {
+  // We found a component instance.
+  if (traverseContext && typeof traverseContext === 'object') {
+    var result = traverseContext;
+    var keyUnique = result[name] === undefined;
+    if ("development" !== 'production') {
+      if (!ReactComponentTreeHook) {
+        ReactComponentTreeHook = _dereq_(133);
+      }
+      if (!keyUnique) {
+        "development" !== 'production' ? warning(false, 'flattenChildren(...): Encountered two children with the same key, ' + '`%s`. Child keys must be unique; when two children share a key, only ' + 'the first child will be used.%s', KeyEscapeUtils.unescape(name), ReactComponentTreeHook.getStackAddendumByID(selfDebugID)) : void 0;
+      }
+    }
+    if (keyUnique && child != null) {
+      result[name] = child;
+    }
+  }
+}
+
+/**
+ * Flattens children that are typically specified as `props.children`. Any null
+ * children will not be included in the resulting object.
+ * @return {!object} flattened children keyed by name.
+ */
+function flattenChildren(children, selfDebugID) {
+  if (children == null) {
+    return children;
+  }
+  var result = {};
+
+  if ("development" !== 'production') {
+    traverseAllChildren(children, function (traverseContext, child, name) {
+      return flattenSingleChildIntoContext(traverseContext, child, name, selfDebugID);
+    }, result);
+  } else {
+    traverseAllChildren(children, flattenSingleChildIntoContext, result);
+  }
+  return result;
+}
+
+module.exports = flattenChildren;
+}).call(this,undefined)
+},{"131":131,"133":133,"159":159,"23":23}],110:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+/**
+ * @param {array} arr an "accumulation" of items which is either an Array or
+ * a single item. Useful when paired with the `accumulate` module. This is a
+ * simple utility that allows us to reason about a collection of items, but
+ * handling the case when there is exactly one item (and we do not need to
+ * allocate an array).
+ */
+
+function forEachAccumulated(arr, cb, scope) {
+  if (Array.isArray(arr)) {
+    arr.forEach(cb, scope);
+  } else if (arr) {
+    cb.call(scope, arr);
+  }
+}
+
+module.exports = forEachAccumulated;
+},{}],111:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+/**
+ * `charCode` represents the actual "character code" and is safe to use with
+ * `String.fromCharCode`. As such, only keys that correspond to printable
+ * characters produce a valid `charCode`, the only exception to this is Enter.
+ * The Tab-key is considered non-printable and does not have a `charCode`,
+ * presumably because it does not produce a tab-character in browsers.
+ *
+ * @param {object} nativeEvent Native browser event.
+ * @return {number} Normalized `charCode` property.
+ */
+
+function getEventCharCode(nativeEvent) {
+  var charCode;
+  var keyCode = nativeEvent.keyCode;
+
+  if ('charCode' in nativeEvent) {
+    charCode = nativeEvent.charCode;
+
+    // FF does not set `charCode` for the Enter-key, check against `keyCode`.
+    if (charCode === 0 && keyCode === 13) {
+      charCode = 13;
+    }
+  } else {
+    // IE8 does not implement `charCode`, but `keyCode` has the correct value.
+    charCode = keyCode;
+  }
+
+  // Some non-printable keys are reported in `charCode`/`keyCode`, discard them.
+  // Must not discard the (non-)printable Enter-key.
+  if (charCode >= 32 || charCode === 13) {
+    return charCode;
+  }
+
+  return 0;
+}
+
+module.exports = getEventCharCode;
+},{}],112:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var getEventCharCode = _dereq_(111);
+
+/**
+ * Normalization of deprecated HTML5 `key` values
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+ */
+var normalizeKey = {
+  Esc: 'Escape',
+  Spacebar: ' ',
+  Left: 'ArrowLeft',
+  Up: 'ArrowUp',
+  Right: 'ArrowRight',
+  Down: 'ArrowDown',
+  Del: 'Delete',
+  Win: 'OS',
+  Menu: 'ContextMenu',
+  Apps: 'ContextMenu',
+  Scroll: 'ScrollLock',
+  MozPrintableKey: 'Unidentified'
+};
+
+/**
+ * Translation from legacy `keyCode` to HTML5 `key`
+ * Only special keys supported, all others depend on keyboard layout or browser
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+ */
+var translateToKey = {
+  8: 'Backspace',
+  9: 'Tab',
+  12: 'Clear',
+  13: 'Enter',
+  16: 'Shift',
+  17: 'Control',
+  18: 'Alt',
+  19: 'Pause',
+  20: 'CapsLock',
+  27: 'Escape',
+  32: ' ',
+  33: 'PageUp',
+  34: 'PageDown',
+  35: 'End',
+  36: 'Home',
+  37: 'ArrowLeft',
+  38: 'ArrowUp',
+  39: 'ArrowRight',
+  40: 'ArrowDown',
+  45: 'Insert',
+  46: 'Delete',
+  112: 'F1',
+  113: 'F2',
+  114: 'F3',
+  115: 'F4',
+  116: 'F5',
+  117: 'F6',
+  118: 'F7',
+  119: 'F8',
+  120: 'F9',
+  121: 'F10',
+  122: 'F11',
+  123: 'F12',
+  144: 'NumLock',
+  145: 'ScrollLock',
+  224: 'Meta'
+};
+
+/**
+ * @param {object} nativeEvent Native browser event.
+ * @return {string} Normalized `key` property.
+ */
+function getEventKey(nativeEvent) {
+  if (nativeEvent.key) {
+    // Normalize inconsistent values reported by browsers due to
+    // implementations of a working draft specification.
+
+    // FireFox implements `key` but returns `MozPrintableKey` for all
+    // printable characters (normalized to `Unidentified`), ignore it.
+    var key = normalizeKey[nativeEvent.key] || nativeEvent.key;
+    if (key !== 'Unidentified') {
+      return key;
+    }
+  }
+
+  // Browser does not implement `key`, polyfill as much of it as we can.
+  if (nativeEvent.type === 'keypress') {
+    var charCode = getEventCharCode(nativeEvent);
+
+    // The enter-key is technically both printable and non-printable and can
+    // thus be captured by `keypress`, no other non-printable key should.
+    return charCode === 13 ? 'Enter' : String.fromCharCode(charCode);
+  }
+  if (nativeEvent.type === 'keydown' || nativeEvent.type === 'keyup') {
+    // While user keyboard layout determines the actual meaning of each
+    // `keyCode` value, almost all function keys have a universal value.
+    return translateToKey[nativeEvent.keyCode] || 'Unidentified';
+  }
+  return '';
+}
+
+module.exports = getEventKey;
+},{"111":111}],113:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+/**
+ * Translation from modifier key to the associated property in the event.
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/#keys-Modifiers
+ */
+
+var modifierKeyToProp = {
+  Alt: 'altKey',
+  Control: 'ctrlKey',
+  Meta: 'metaKey',
+  Shift: 'shiftKey'
+};
+
+// IE8 does not implement getModifierState so we simply map it to the only
+// modifier keys exposed by the event itself, does not support Lock-keys.
+// Currently, all major browsers except Chrome seems to support Lock-keys.
+function modifierStateGetter(keyArg) {
+  var syntheticEvent = this;
+  var nativeEvent = syntheticEvent.nativeEvent;
+  if (nativeEvent.getModifierState) {
+    return nativeEvent.getModifierState(keyArg);
+  }
+  var keyProp = modifierKeyToProp[keyArg];
+  return keyProp ? !!nativeEvent[keyProp] : false;
+}
+
+function getEventModifierState(nativeEvent) {
+  return modifierStateGetter;
+}
+
+module.exports = getEventModifierState;
+},{}],114:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+/**
+ * Gets the target node from a native browser event by accounting for
+ * inconsistencies in browser DOM APIs.
+ *
+ * @param {object} nativeEvent Native browser event.
+ * @return {DOMEventTarget} Target node.
+ */
+
+function getEventTarget(nativeEvent) {
+  var target = nativeEvent.target || nativeEvent.srcElement || window;
+
+  // Normalize SVG <use> element events #4963
+  if (target.correspondingUseElement) {
+    target = target.correspondingUseElement;
+  }
+
+  // Safari may fire events on text nodes (Node.TEXT_NODE is 3).
+  // @see http://www.quirksmode.org/js/events_properties.html
+  return target.nodeType === 3 ? target.parentNode : target;
+}
+
+module.exports = getEventTarget;
+},{}],115:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ReactNodeTypes = _dereq_(69);
+
+function getHostComponentFromComposite(inst) {
+  var type;
+
+  while ((type = inst._renderedNodeType) === ReactNodeTypes.COMPOSITE) {
+    inst = inst._renderedComponent;
+  }
+
+  if (type === ReactNodeTypes.HOST) {
+    return inst._renderedComponent;
+  } else if (type === ReactNodeTypes.EMPTY) {
+    return null;
+  }
+}
+
+module.exports = getHostComponentFromComposite;
+},{"69":69}],116:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+/* global Symbol */
+
+var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+
+/**
+ * Returns the iterator method function contained on the iterable object.
+ *
+ * Be sure to invoke the function with the iterable as context:
+ *
+ *     var iteratorFn = getIteratorFn(myIterable);
+ *     if (iteratorFn) {
+ *       var iterator = iteratorFn.call(myIterable);
+ *       ...
+ *     }
+ *
+ * @param {?object} maybeIterable
+ * @return {?function}
+ */
+function getIteratorFn(maybeIterable) {
+  var iteratorFn = maybeIterable && (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL]);
+  if (typeof iteratorFn === 'function') {
+    return iteratorFn;
+  }
+}
+
+module.exports = getIteratorFn;
+},{}],117:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+/**
+ * Given any node return the first leaf node without children.
+ *
+ * @param {DOMElement|DOMTextNode} node
+ * @return {DOMElement|DOMTextNode}
+ */
+
+function getLeafNode(node) {
+  while (node && node.firstChild) {
+    node = node.firstChild;
+  }
+  return node;
+}
+
+/**
+ * Get the next sibling within a container. This will walk up the
+ * DOM if a node's siblings have been exhausted.
+ *
+ * @param {DOMElement|DOMTextNode} node
+ * @return {?DOMElement|DOMTextNode}
+ */
+function getSiblingNode(node) {
+  while (node) {
+    if (node.nextSibling) {
+      return node.nextSibling;
+    }
+    node = node.parentNode;
+  }
+}
+
+/**
+ * Get object describing the nodes which contain characters at offset.
+ *
+ * @param {DOMElement|DOMTextNode} root
+ * @param {number} offset
+ * @return {?object}
+ */
+function getNodeForCharacterOffset(root, offset) {
+  var node = getLeafNode(root);
+  var nodeStart = 0;
+  var nodeEnd = 0;
+
+  while (node) {
+    if (node.nodeType === 3) {
+      nodeEnd = nodeStart + node.textContent.length;
+
+      if (nodeStart <= offset && nodeEnd >= offset) {
+        return {
+          node: node,
+          offset: offset - nodeStart
+        };
+      }
+
+      nodeStart = nodeEnd;
+    }
+
+    node = getLeafNode(getSiblingNode(node));
+  }
+}
+
+module.exports = getNodeForCharacterOffset;
+},{}],118:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ExecutionEnvironment = _dereq_(138);
+
+var contentKey = null;
+
+/**
+ * Gets the key used to access text content on a DOM node.
+ *
+ * @return {?string} Key used to access text content.
+ * @internal
+ */
+function getTextContentAccessor() {
+  if (!contentKey && ExecutionEnvironment.canUseDOM) {
+    // Prefer textContent to innerText because many browsers support both but
+    // SVG <text> elements don't support innerText even when <div> does.
+    contentKey = 'textContent' in document.documentElement ? 'textContent' : 'innerText';
+  }
+  return contentKey;
+}
+
+module.exports = getTextContentAccessor;
+},{"138":138}],119:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ExecutionEnvironment = _dereq_(138);
+
+/**
+ * Generate a mapping of standard vendor prefixes using the defined style property and event name.
+ *
+ * @param {string} styleProp
+ * @param {string} eventName
+ * @returns {object}
+ */
+function makePrefixMap(styleProp, eventName) {
+  var prefixes = {};
+
+  prefixes[styleProp.toLowerCase()] = eventName.toLowerCase();
+  prefixes['Webkit' + styleProp] = 'webkit' + eventName;
+  prefixes['Moz' + styleProp] = 'moz' + eventName;
+  prefixes['ms' + styleProp] = 'MS' + eventName;
+  prefixes['O' + styleProp] = 'o' + eventName.toLowerCase();
+
+  return prefixes;
+}
+
+/**
+ * A list of event names to a configurable list of vendor prefixes.
+ */
+var vendorPrefixes = {
+  animationend: makePrefixMap('Animation', 'AnimationEnd'),
+  animationiteration: makePrefixMap('Animation', 'AnimationIteration'),
+  animationstart: makePrefixMap('Animation', 'AnimationStart'),
+  transitionend: makePrefixMap('Transition', 'TransitionEnd')
+};
+
+/**
+ * Event names that have already been detected and prefixed (if applicable).
+ */
+var prefixedEventNames = {};
+
+/**
+ * Element to check for prefixes on.
+ */
+var style = {};
+
+/**
+ * Bootstrap if a DOM exists.
+ */
+if (ExecutionEnvironment.canUseDOM) {
+  style = document.createElement('div').style;
+
+  // On some platforms, in particular some releases of Android 4.x,
+  // the un-prefixed "animation" and "transition" properties are defined on the
+  // style object but the events that fire will still be prefixed, so we need
+  // to check if the un-prefixed events are usable, and if not remove them from the map.
+  if (!('AnimationEvent' in window)) {
+    delete vendorPrefixes.animationend.animation;
+    delete vendorPrefixes.animationiteration.animation;
+    delete vendorPrefixes.animationstart.animation;
+  }
+
+  // Same as above
+  if (!('TransitionEvent' in window)) {
+    delete vendorPrefixes.transitionend.transition;
+  }
+}
+
+/**
+ * Attempts to determine the correct vendor prefixed event name.
+ *
+ * @param {string} eventName
+ * @returns {string}
+ */
+function getVendorPrefixedEventName(eventName) {
+  if (prefixedEventNames[eventName]) {
+    return prefixedEventNames[eventName];
+  } else if (!vendorPrefixes[eventName]) {
+    return eventName;
+  }
+
+  var prefixMap = vendorPrefixes[eventName];
+
+  for (var styleProp in prefixMap) {
+    if (prefixMap.hasOwnProperty(styleProp) && styleProp in style) {
+      return prefixedEventNames[eventName] = prefixMap[styleProp];
+    }
+  }
+
+  return '';
+}
+
+module.exports = getVendorPrefixedEventName;
+},{"138":138}],120:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ReactDOMComponentTree = _dereq_(34);
+
+function isCheckable(elem) {
+  var type = elem.type;
+  var nodeName = elem.nodeName;
+  return nodeName && nodeName.toLowerCase() === 'input' && (type === 'checkbox' || type === 'radio');
+}
+
+function getTracker(inst) {
+  return inst._wrapperState.valueTracker;
+}
+
+function attachTracker(inst, tracker) {
+  inst._wrapperState.valueTracker = tracker;
+}
+
+function detachTracker(inst) {
+  inst._wrapperState.valueTracker = null;
+}
+
+function getValueFromNode(node) {
+  var value;
+  if (node) {
+    value = isCheckable(node) ? '' + node.checked : node.value;
+  }
+  return value;
+}
+
+var inputValueTracking = {
+  // exposed for testing
+  _getTrackerFromNode: function (node) {
+    return getTracker(ReactDOMComponentTree.getInstanceFromNode(node));
+  },
+
+
+  track: function (inst) {
+    if (getTracker(inst)) {
+      return;
+    }
+
+    var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+    var valueField = isCheckable(node) ? 'checked' : 'value';
+    var descriptor = Object.getOwnPropertyDescriptor(node.constructor.prototype, valueField);
+
+    var currentValue = '' + node[valueField];
+
+    // if someone has already defined a value or Safari, then bail
+    // and don't track value will cause over reporting of changes,
+    // but it's better then a hard failure
+    // (needed for certain tests that spyOn input values and Safari)
+    if (node.hasOwnProperty(valueField) || typeof descriptor.get !== 'function' || typeof descriptor.set !== 'function') {
+      return;
+    }
+
+    Object.defineProperty(node, valueField, {
+      enumerable: descriptor.enumerable,
+      configurable: true,
+      get: function () {
+        return descriptor.get.call(this);
+      },
+      set: function (value) {
+        currentValue = '' + value;
+        descriptor.set.call(this, value);
+      }
+    });
+
+    attachTracker(inst, {
+      getValue: function () {
+        return currentValue;
+      },
+      setValue: function (value) {
+        currentValue = '' + value;
+      },
+      stopTracking: function () {
+        detachTracker(inst);
+        delete node[valueField];
+      }
+    });
+  },
+
+  updateValueIfChanged: function (inst) {
+    if (!inst) {
+      return false;
+    }
+    var tracker = getTracker(inst);
+
+    if (!tracker) {
+      inputValueTracking.track(inst);
+      return true;
+    }
+
+    var lastValue = tracker.getValue();
+    var nextValue = getValueFromNode(ReactDOMComponentTree.getNodeFromInstance(inst));
+
+    if (nextValue !== lastValue) {
+      tracker.setValue(nextValue);
+      return true;
+    }
+
+    return false;
+  },
+  stopTracking: function (inst) {
+    var tracker = getTracker(inst);
+    if (tracker) {
+      tracker.stopTracking();
+    }
+  }
+};
+
+module.exports = inputValueTracking;
+},{"34":34}],121:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126),
+    _assign = _dereq_(160);
+
+var ReactCompositeComponent = _dereq_(30);
+var ReactEmptyComponent = _dereq_(54);
+var ReactHostComponent = _dereq_(59);
+
+var getNextDebugID = _dereq_(136);
+var invariant = _dereq_(152);
+var warning = _dereq_(159);
+
+// To avoid a cyclic dependency, we create the final class in this module
+var ReactCompositeComponentWrapper = function (element) {
+  this.construct(element);
+};
+
+function getDeclarationErrorAddendum(owner) {
+  if (owner) {
+    var name = owner.getName();
+    if (name) {
+      return ' Check the render method of `' + name + '`.';
+    }
+  }
+  return '';
+}
+
+/**
+ * Check if the type reference is a known internal type. I.e. not a user
+ * provided composite type.
+ *
+ * @param {function} type
+ * @return {boolean} Returns true if this is a valid internal type.
+ */
+function isInternalComponentType(type) {
+  return typeof type === 'function' && typeof type.prototype !== 'undefined' && typeof type.prototype.mountComponent === 'function' && typeof type.prototype.receiveComponent === 'function';
+}
+
+/**
+ * Given a ReactNode, create an instance that will actually be mounted.
+ *
+ * @param {ReactNode} node
+ * @param {boolean} shouldHaveDebugID
+ * @return {object} A new instance of the element's constructor.
+ * @protected
+ */
+function instantiateReactComponent(node, shouldHaveDebugID) {
+  var instance;
+
+  if (node === null || node === false) {
+    instance = ReactEmptyComponent.create(instantiateReactComponent);
+  } else if (typeof node === 'object') {
+    var element = node;
+    var type = element.type;
+    if (typeof type !== 'function' && typeof type !== 'string') {
+      var info = '';
+      if ("development" !== 'production') {
+        if (type === undefined || typeof type === 'object' && type !== null && Object.keys(type).length === 0) {
+          info += ' You likely forgot to export your component from the file ' + "it's defined in.";
+        }
+      }
+      info += getDeclarationErrorAddendum(element._owner);
+      !false ? "development" !== 'production' ? invariant(false, 'Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s', type == null ? type : typeof type, info) : _prodInvariant('130', type == null ? type : typeof type, info) : void 0;
+    }
+
+    // Special case string values
+    if (typeof element.type === 'string') {
+      instance = ReactHostComponent.createInternalComponent(element);
+    } else if (isInternalComponentType(element.type)) {
+      // This is temporarily available for custom components that are not string
+      // representations. I.e. ART. Once those are updated to use the string
+      // representation, we can drop this code path.
+      instance = new element.type(element);
+
+      // We renamed this. Allow the old name for compat. :(
+      if (!instance.getHostNode) {
+        instance.getHostNode = instance.getNativeNode;
+      }
+    } else {
+      instance = new ReactCompositeComponentWrapper(element);
+    }
+  } else if (typeof node === 'string' || typeof node === 'number') {
+    instance = ReactHostComponent.createInstanceForText(node);
+  } else {
+    !false ? "development" !== 'production' ? invariant(false, 'Encountered invalid React node of type %s', typeof node) : _prodInvariant('131', typeof node) : void 0;
+  }
+
+  if ("development" !== 'production') {
+    "development" !== 'production' ? warning(typeof instance.mountComponent === 'function' && typeof instance.receiveComponent === 'function' && typeof instance.getHostNode === 'function' && typeof instance.unmountComponent === 'function', 'Only React Components can be mounted.') : void 0;
+  }
+
+  // These two fields are used by the DOM and ART diffing algorithms
+  // respectively. Instead of using expandos on components, we should be
+  // storing the state needed by the diffing algorithms elsewhere.
+  instance._mountIndex = 0;
+  instance._mountImage = null;
+
+  if ("development" !== 'production') {
+    instance._debugID = shouldHaveDebugID ? getNextDebugID() : 0;
+  }
+
+  // Internal instances should fully constructed at this point, so they should
+  // not get any new fields added to them at this point.
+  if ("development" !== 'production') {
+    if (Object.preventExtensions) {
+      Object.preventExtensions(instance);
+    }
+  }
+
+  return instance;
+}
+
+_assign(ReactCompositeComponentWrapper.prototype, ReactCompositeComponent, {
+  _instantiateReactComponent: instantiateReactComponent
+});
+
+module.exports = instantiateReactComponent;
+},{"126":126,"136":136,"152":152,"159":159,"160":160,"30":30,"54":54,"59":59}],122:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ExecutionEnvironment = _dereq_(138);
+
+var useHasFeature;
+if (ExecutionEnvironment.canUseDOM) {
+  useHasFeature = document.implementation && document.implementation.hasFeature &&
+  // always returns true in newer browsers as per the standard.
+  // @see http://dom.spec.whatwg.org/#dom-domimplementation-hasfeature
+  document.implementation.hasFeature('', '') !== true;
+}
+
+/**
+ * Checks if an event is supported in the current execution environment.
+ *
+ * NOTE: This will not work correctly for non-generic events such as `change`,
+ * `reset`, `load`, `error`, and `select`.
+ *
+ * Borrows from Modernizr.
+ *
+ * @param {string} eventNameSuffix Event name, e.g. "click".
+ * @param {?boolean} capture Check if the capture phase is supported.
+ * @return {boolean} True if the event is supported.
+ * @internal
+ * @license Modernizr 3.0.0pre (Custom Build) | MIT
+ */
+function isEventSupported(eventNameSuffix, capture) {
+  if (!ExecutionEnvironment.canUseDOM || capture && !('addEventListener' in document)) {
+    return false;
+  }
+
+  var eventName = 'on' + eventNameSuffix;
+  var isSupported = eventName in document;
+
+  if (!isSupported) {
+    var element = document.createElement('div');
+    element.setAttribute(eventName, 'return;');
+    isSupported = typeof element[eventName] === 'function';
+  }
+
+  if (!isSupported && useHasFeature && eventNameSuffix === 'wheel') {
+    // This is the only way to test support for the `wheel` event in IE9+.
+    isSupported = document.implementation.hasFeature('Events.wheel', '3.0');
+  }
+
+  return isSupported;
+}
+
+module.exports = isEventSupported;
+},{"138":138}],123:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+/**
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html#input-type-attr-summary
+ */
+
+var supportedInputTypes = {
+  color: true,
+  date: true,
+  datetime: true,
+  'datetime-local': true,
+  email: true,
+  month: true,
+  number: true,
+  password: true,
+  range: true,
+  search: true,
+  tel: true,
+  text: true,
+  time: true,
+  url: true,
+  week: true
+};
+
+function isTextInputElement(elem) {
+  var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+
+  if (nodeName === 'input') {
+    return !!supportedInputTypes[elem.type];
+  }
+
+  if (nodeName === 'textarea') {
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = isTextInputElement;
+},{}],124:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+/**
+ * Forked from fbjs/warning:
+ * https://github.com/facebook/fbjs/blob/e66ba20ad5be433eb54423f2b097d829324d9de6/packages/fbjs/src/__forks__/warning.js
+ *
+ * Only change is we use console.warn instead of console.error,
+ * and do nothing when 'console' is not supported.
+ * This really simplifies the code.
+ * ---
+ * Similar to invariant but only logs a warning if the condition is not met.
+ * This can be used to log issues in development environments in critical
+ * paths. Removing the logging code for production environments will keep the
+ * same logic and follow the same code paths.
+ */
+
+var lowPriorityWarning = function () {};
+
+if ("development" !== 'production') {
+  var printWarning = function (format) {
+    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      args[_key - 1] = arguments[_key];
+    }
+
+    var argIndex = 0;
+    var message = 'Warning: ' + format.replace(/%s/g, function () {
+      return args[argIndex++];
+    });
+    if (typeof console !== 'undefined') {
+      console.warn(message);
+    }
+    try {
+      // --- Welcome to debugging React ---
+      // This error was thrown as a convenience so that you can use this stack
+      // to find the callsite that caused this warning to fire.
+      throw new Error(message);
+    } catch (x) {}
+  };
+
+  lowPriorityWarning = function (condition, format) {
+    if (format === undefined) {
+      throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
+    }
+    if (!condition) {
+      for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+        args[_key2 - 2] = arguments[_key2];
+      }
+
+      printWarning.apply(undefined, [format].concat(args));
+    }
+  };
+}
+
+module.exports = lowPriorityWarning;
+},{}],125:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var escapeTextContentForBrowser = _dereq_(107);
+
+/**
+ * Escapes attribute value to prevent scripting attacks.
+ *
+ * @param {*} value Value to escape.
+ * @return {string} An escaped string.
+ */
+function quoteAttributeValueForBrowser(value) {
+  return '"' + escapeTextContentForBrowser(value) + '"';
+}
+
+module.exports = quoteAttributeValueForBrowser;
+},{"107":107}],126:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+'use strict';
+
+/**
+ * WARNING: DO NOT manually require this module.
+ * This is a replacement for `invariant(...)` used by the error code system
+ * and will _only_ be required by the corresponding babel pass.
+ * It always throws.
+ */
+
+function reactProdInvariant(code) {
+  var argCount = arguments.length - 1;
+
+  var message = 'Minified React error #' + code + '; visit ' + 'http://facebook.github.io/react/docs/error-decoder.html?invariant=' + code;
+
+  for (var argIdx = 0; argIdx < argCount; argIdx++) {
+    message += '&args[]=' + encodeURIComponent(arguments[argIdx + 1]);
+  }
+
+  message += ' for the full message or use the non-minified dev environment' + ' for full errors and additional helpful warnings.';
+
+  var error = new Error(message);
+  error.name = 'Invariant Violation';
+  error.framesToPop = 1; // we don't care about reactProdInvariant's own frame
+
+  throw error;
+}
+
+module.exports = reactProdInvariant;
+},{}],127:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ReactMount = _dereq_(67);
+
+module.exports = ReactMount.renderSubtreeIntoContainer;
+},{"67":67}],128:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ExecutionEnvironment = _dereq_(138);
+var DOMNamespaces = _dereq_(10);
+
+var WHITESPACE_TEST = /^[ \r\n\t\f]/;
+var NONVISIBLE_TEST = /<(!--|link|noscript|meta|script|style)[ \r\n\t\f\/>]/;
+
+var createMicrosoftUnsafeLocalFunction = _dereq_(105);
+
+// SVG temp container for IE lacking innerHTML
+var reusableSVGContainer;
+
+/**
+ * Set the innerHTML property of a node, ensuring that whitespace is preserved
+ * even in IE8.
+ *
+ * @param {DOMElement} node
+ * @param {string} html
+ * @internal
+ */
+var setInnerHTML = createMicrosoftUnsafeLocalFunction(function (node, html) {
+  // IE does not have innerHTML for SVG nodes, so instead we inject the
+  // new markup in a temp node and then move the child nodes across into
+  // the target node
+  if (node.namespaceURI === DOMNamespaces.svg && !('innerHTML' in node)) {
+    reusableSVGContainer = reusableSVGContainer || document.createElement('div');
+    reusableSVGContainer.innerHTML = '<svg>' + html + '</svg>';
+    var svgNode = reusableSVGContainer.firstChild;
+    while (svgNode.firstChild) {
+      node.appendChild(svgNode.firstChild);
+    }
+  } else {
+    node.innerHTML = html;
+  }
+});
+
+if (ExecutionEnvironment.canUseDOM) {
+  // IE8: When updating a just created node with innerHTML only leading
+  // whitespace is removed. When updating an existing node with innerHTML
+  // whitespace in root TextNodes is also collapsed.
+  // @see quirksmode.org/bugreports/archives/2004/11/innerhtml_and_t.html
+
+  // Feature detection; only IE8 is known to behave improperly like this.
+  var testElement = document.createElement('div');
+  testElement.innerHTML = ' ';
+  if (testElement.innerHTML === '') {
+    setInnerHTML = function (node, html) {
+      // Magic theory: IE8 supposedly differentiates between added and updated
+      // nodes when processing innerHTML, innerHTML on updated nodes suffers
+      // from worse whitespace behavior. Re-adding a node like this triggers
+      // the initial and more favorable whitespace behavior.
+      // TODO: What to do on a detached node?
+      if (node.parentNode) {
+        node.parentNode.replaceChild(node, node);
+      }
+
+      // We also implement a workaround for non-visible tags disappearing into
+      // thin air on IE8, this only happens if there is no visible text
+      // in-front of the non-visible tags. Piggyback on the whitespace fix
+      // and simply check if any non-visible tags appear in the source.
+      if (WHITESPACE_TEST.test(html) || html[0] === '<' && NONVISIBLE_TEST.test(html)) {
+        // Recover leading whitespace by temporarily prepending any character.
+        // \uFEFF has the potential advantage of being zero-width/invisible.
+        // UglifyJS drops U+FEFF chars when parsing, so use String.fromCharCode
+        // in hopes that this is preserved even if "\uFEFF" is transformed to
+        // the actual Unicode character (by Babel, for example).
+        // https://github.com/mishoo/UglifyJS2/blob/v2.4.20/lib/parse.js#L216
+        node.innerHTML = String.fromCharCode(0xfeff) + html;
+
+        // deleteData leaves an empty `TextNode` which offsets the index of all
+        // children. Definitely want to avoid this.
+        var textNode = node.firstChild;
+        if (textNode.data.length === 1) {
+          node.removeChild(textNode);
+        } else {
+          textNode.deleteData(0, 1);
+        }
+      } else {
+        node.innerHTML = html;
+      }
+    };
+  }
+  testElement = null;
+}
+
+module.exports = setInnerHTML;
+},{"10":10,"105":105,"138":138}],129:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ExecutionEnvironment = _dereq_(138);
+var escapeTextContentForBrowser = _dereq_(107);
+var setInnerHTML = _dereq_(128);
+
+/**
+ * Set the textContent property of a node, ensuring that whitespace is preserved
+ * even in IE8. innerText is a poor substitute for textContent and, among many
+ * issues, inserts <br> instead of the literal newline chars. innerHTML behaves
+ * as it should.
+ *
+ * @param {DOMElement} node
+ * @param {string} text
+ * @internal
+ */
+var setTextContent = function (node, text) {
+  if (text) {
+    var firstChild = node.firstChild;
+
+    if (firstChild && firstChild === node.lastChild && firstChild.nodeType === 3) {
+      firstChild.nodeValue = text;
+      return;
+    }
+  }
+  node.textContent = text;
+};
+
+if (ExecutionEnvironment.canUseDOM) {
+  if (!('textContent' in document.documentElement)) {
+    setTextContent = function (node, text) {
+      if (node.nodeType === 3) {
+        node.nodeValue = text;
+        return;
+      }
+      setInnerHTML(node, escapeTextContentForBrowser(text));
+    };
+  }
+}
+
+module.exports = setTextContent;
+},{"107":107,"128":128,"138":138}],130:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+/**
+ * Given a `prevElement` and `nextElement`, determines if the existing
+ * instance should be updated as opposed to being destroyed or replaced by a new
+ * instance. Both arguments are elements. This ensures that this logic can
+ * operate on stateless trees without any backing instance.
+ *
+ * @param {?object} prevElement
+ * @param {?object} nextElement
+ * @return {boolean} True if the existing instance should be updated.
+ * @protected
+ */
+
+function shouldUpdateReactComponent(prevElement, nextElement) {
+  var prevEmpty = prevElement === null || prevElement === false;
+  var nextEmpty = nextElement === null || nextElement === false;
+  if (prevEmpty || nextEmpty) {
+    return prevEmpty === nextEmpty;
+  }
+
+  var prevType = typeof prevElement;
+  var nextType = typeof nextElement;
+  if (prevType === 'string' || prevType === 'number') {
+    return nextType === 'string' || nextType === 'number';
+  } else {
+    return nextType === 'object' && prevElement.type === nextElement.type && prevElement.key === nextElement.key;
+  }
+}
+
+module.exports = shouldUpdateReactComponent;
+},{}],131:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(126);
+
+var ReactCurrentOwner = _dereq_(134);
+var REACT_ELEMENT_TYPE = _dereq_(53);
+
+var getIteratorFn = _dereq_(116);
+var invariant = _dereq_(152);
+var KeyEscapeUtils = _dereq_(23);
+var warning = _dereq_(159);
+
+var SEPARATOR = '.';
+var SUBSEPARATOR = ':';
+
+/**
+ * This is inlined from ReactElement since this file is shared between
+ * isomorphic and renderers. We could extract this to a
+ *
+ */
+
+/**
+ * TODO: Test that a single child and an array with one item have the same key
+ * pattern.
+ */
+
+var didWarnAboutMaps = false;
+
+/**
+ * Generate a key string that identifies a component within a set.
+ *
+ * @param {*} component A component that could contain a manual key.
+ * @param {number} index Index that is used if a manual key is not provided.
+ * @return {string}
+ */
+function getComponentKey(component, index) {
+  // Do some typechecking here since we call this blindly. We want to ensure
+  // that we don't block potential future ES APIs.
+  if (component && typeof component === 'object' && component.key != null) {
+    // Explicit key
+    return KeyEscapeUtils.escape(component.key);
+  }
+  // Implicit key determined by the index in the set
+  return index.toString(36);
+}
+
+/**
+ * @param {?*} children Children tree container.
+ * @param {!string} nameSoFar Name of the key path so far.
+ * @param {!function} callback Callback to invoke with each child found.
+ * @param {?*} traverseContext Used to pass information throughout the traversal
+ * process.
+ * @return {!number} The number of children in this subtree.
+ */
+function traverseAllChildrenImpl(children, nameSoFar, callback, traverseContext) {
+  var type = typeof children;
+
+  if (type === 'undefined' || type === 'boolean') {
+    // All of the above are perceived as null.
+    children = null;
+  }
+
+  if (children === null || type === 'string' || type === 'number' ||
+  // The following is inlined from ReactElement. This means we can optimize
+  // some checks. React Fiber also inlines this logic for similar purposes.
+  type === 'object' && children.$$typeof === REACT_ELEMENT_TYPE) {
+    callback(traverseContext, children,
+    // If it's the only child, treat the name as if it was wrapped in an array
+    // so that it's consistent if the number of children grows.
+    nameSoFar === '' ? SEPARATOR + getComponentKey(children, 0) : nameSoFar);
+    return 1;
+  }
+
+  var child;
+  var nextName;
+  var subtreeCount = 0; // Count of children found in the current subtree.
+  var nextNamePrefix = nameSoFar === '' ? SEPARATOR : nameSoFar + SUBSEPARATOR;
+
+  if (Array.isArray(children)) {
+    for (var i = 0; i < children.length; i++) {
+      child = children[i];
+      nextName = nextNamePrefix + getComponentKey(child, i);
+      subtreeCount += traverseAllChildrenImpl(child, nextName, callback, traverseContext);
+    }
+  } else {
+    var iteratorFn = getIteratorFn(children);
+    if (iteratorFn) {
+      var iterator = iteratorFn.call(children);
+      var step;
+      if (iteratorFn !== children.entries) {
+        var ii = 0;
+        while (!(step = iterator.next()).done) {
+          child = step.value;
+          nextName = nextNamePrefix + getComponentKey(child, ii++);
+          subtreeCount += traverseAllChildrenImpl(child, nextName, callback, traverseContext);
+        }
+      } else {
+        if ("development" !== 'production') {
+          var mapsAsChildrenAddendum = '';
+          if (ReactCurrentOwner.current) {
+            var mapsAsChildrenOwnerName = ReactCurrentOwner.current.getName();
+            if (mapsAsChildrenOwnerName) {
+              mapsAsChildrenAddendum = ' Check the render method of `' + mapsAsChildrenOwnerName + '`.';
+            }
+          }
+          "development" !== 'production' ? warning(didWarnAboutMaps, 'Using Maps as children is not yet fully supported. It is an ' + 'experimental feature that might be removed. Convert it to a ' + 'sequence / iterable of keyed ReactElements instead.%s', mapsAsChildrenAddendum) : void 0;
+          didWarnAboutMaps = true;
+        }
+        // Iterator will provide entry [k,v] tuples rather than values.
+        while (!(step = iterator.next()).done) {
+          var entry = step.value;
+          if (entry) {
+            child = entry[1];
+            nextName = nextNamePrefix + KeyEscapeUtils.escape(entry[0]) + SUBSEPARATOR + getComponentKey(child, 0);
+            subtreeCount += traverseAllChildrenImpl(child, nextName, callback, traverseContext);
+          }
+        }
+      }
+    } else if (type === 'object') {
+      var addendum = '';
+      if ("development" !== 'production') {
+        addendum = ' If you meant to render a collection of children, use an array ' + 'instead or wrap the object using createFragment(object) from the ' + 'React add-ons.';
+        if (children._isReactElement) {
+          addendum = " It looks like you're using an element created by a different " + 'version of React. Make sure to use only one copy of React.';
+        }
+        if (ReactCurrentOwner.current) {
+          var name = ReactCurrentOwner.current.getName();
+          if (name) {
+            addendum += ' Check the render method of `' + name + '`.';
+          }
+        }
+      }
+      var childrenString = String(children);
+      !false ? "development" !== 'production' ? invariant(false, 'Objects are not valid as a React child (found: %s).%s', childrenString === '[object Object]' ? 'object with keys {' + Object.keys(children).join(', ') + '}' : childrenString, addendum) : _prodInvariant('31', childrenString === '[object Object]' ? 'object with keys {' + Object.keys(children).join(', ') + '}' : childrenString, addendum) : void 0;
+    }
+  }
+
+  return subtreeCount;
+}
+
+/**
+ * Traverses children that are typically specified as `props.children`, but
+ * might also be specified through attributes:
+ *
+ * - `traverseAllChildren(this.props.children, ...)`
+ * - `traverseAllChildren(this.props.leftPanelChildren, ...)`
+ *
+ * The `traverseContext` is an optional argument that is passed through the
+ * entire traversal. It can be used to store accumulations or anything else that
+ * the callback might find relevant.
+ *
+ * @param {?*} children Children tree object.
+ * @param {!function} callback To invoke upon traversing each child.
+ * @param {?*} traverseContext Context for traversal.
+ * @return {!number} The number of children in this subtree.
+ */
+function traverseAllChildren(children, callback, traverseContext) {
+  if (children == null) {
+    return 0;
+  }
+
+  return traverseAllChildrenImpl(children, '', callback, traverseContext);
+}
+
+module.exports = traverseAllChildren;
+},{"116":116,"126":126,"134":134,"152":152,"159":159,"23":23,"53":53}],132:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(160);
+
+var emptyFunction = _dereq_(144);
+var warning = _dereq_(159);
+
+var validateDOMNesting = emptyFunction;
+
+if ("development" !== 'production') {
+  // This validation code was written based on the HTML5 parsing spec:
+  // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-scope
+  //
+  // Note: this does not catch all invalid nesting, nor does it try to (as it's
+  // not clear what practical benefit doing so provides); instead, we warn only
+  // for cases where the parser will give a parse tree differing from what React
+  // intended. For example, <b><div></div></b> is invalid but we don't warn
+  // because it still parses correctly; we do warn for other cases like nested
+  // <p> tags where the beginning of the second element implicitly closes the
+  // first, causing a confusing mess.
+
+  // https://html.spec.whatwg.org/multipage/syntax.html#special
+  var specialTags = ['address', 'applet', 'area', 'article', 'aside', 'base', 'basefont', 'bgsound', 'blockquote', 'body', 'br', 'button', 'caption', 'center', 'col', 'colgroup', 'dd', 'details', 'dir', 'div', 'dl', 'dt', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'frame', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'iframe', 'img', 'input', 'isindex', 'li', 'link', 'listing', 'main', 'marquee', 'menu', 'menuitem', 'meta', 'nav', 'noembed', 'noframes', 'noscript', 'object', 'ol', 'p', 'param', 'plaintext', 'pre', 'script', 'section', 'select', 'source', 'style', 'summary', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'title', 'tr', 'track', 'ul', 'wbr', 'xmp'];
+
+  // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-scope
+  var inScopeTags = ['applet', 'caption', 'html', 'table', 'td', 'th', 'marquee', 'object', 'template',
+
+  // https://html.spec.whatwg.org/multipage/syntax.html#html-integration-point
+  // TODO: Distinguish by namespace here -- for <title>, including it here
+  // errs on the side of fewer warnings
+  'foreignObject', 'desc', 'title'];
+
+  // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-button-scope
+  var buttonScopeTags = inScopeTags.concat(['button']);
+
+  // https://html.spec.whatwg.org/multipage/syntax.html#generate-implied-end-tags
+  var impliedEndTags = ['dd', 'dt', 'li', 'option', 'optgroup', 'p', 'rp', 'rt'];
+
+  var emptyAncestorInfo = {
+    current: null,
+
+    formTag: null,
+    aTagInScope: null,
+    buttonTagInScope: null,
+    nobrTagInScope: null,
+    pTagInButtonScope: null,
+
+    listItemTagAutoclosing: null,
+    dlItemTagAutoclosing: null
+  };
+
+  var updatedAncestorInfo = function (oldInfo, tag, instance) {
+    var ancestorInfo = _assign({}, oldInfo || emptyAncestorInfo);
+    var info = { tag: tag, instance: instance };
+
+    if (inScopeTags.indexOf(tag) !== -1) {
+      ancestorInfo.aTagInScope = null;
+      ancestorInfo.buttonTagInScope = null;
+      ancestorInfo.nobrTagInScope = null;
+    }
+    if (buttonScopeTags.indexOf(tag) !== -1) {
+      ancestorInfo.pTagInButtonScope = null;
+    }
+
+    // See rules for 'li', 'dd', 'dt' start tags in
+    // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inbody
+    if (specialTags.indexOf(tag) !== -1 && tag !== 'address' && tag !== 'div' && tag !== 'p') {
+      ancestorInfo.listItemTagAutoclosing = null;
+      ancestorInfo.dlItemTagAutoclosing = null;
+    }
+
+    ancestorInfo.current = info;
+
+    if (tag === 'form') {
+      ancestorInfo.formTag = info;
+    }
+    if (tag === 'a') {
+      ancestorInfo.aTagInScope = info;
+    }
+    if (tag === 'button') {
+      ancestorInfo.buttonTagInScope = info;
+    }
+    if (tag === 'nobr') {
+      ancestorInfo.nobrTagInScope = info;
+    }
+    if (tag === 'p') {
+      ancestorInfo.pTagInButtonScope = info;
+    }
+    if (tag === 'li') {
+      ancestorInfo.listItemTagAutoclosing = info;
+    }
+    if (tag === 'dd' || tag === 'dt') {
+      ancestorInfo.dlItemTagAutoclosing = info;
+    }
+
+    return ancestorInfo;
+  };
+
+  /**
+   * Returns whether
+   */
+  var isTagValidWithParent = function (tag, parentTag) {
+    // First, let's check if we're in an unusual parsing mode...
+    switch (parentTag) {
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inselect
+      case 'select':
+        return tag === 'option' || tag === 'optgroup' || tag === '#text';
+      case 'optgroup':
+        return tag === 'option' || tag === '#text';
+      // Strictly speaking, seeing an <option> doesn't mean we're in a <select>
+      // but
+      case 'option':
+        return tag === '#text';
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intd
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-incaption
+      // No special behavior since these rules fall back to "in body" mode for
+      // all except special table nodes which cause bad parsing behavior anyway.
+
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intr
+      case 'tr':
+        return tag === 'th' || tag === 'td' || tag === 'style' || tag === 'script' || tag === 'template';
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intbody
+      case 'tbody':
+      case 'thead':
+      case 'tfoot':
+        return tag === 'tr' || tag === 'style' || tag === 'script' || tag === 'template';
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-incolgroup
+      case 'colgroup':
+        return tag === 'col' || tag === 'template';
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intable
+      case 'table':
+        return tag === 'caption' || tag === 'colgroup' || tag === 'tbody' || tag === 'tfoot' || tag === 'thead' || tag === 'style' || tag === 'script' || tag === 'template';
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inhead
+      case 'head':
+        return tag === 'base' || tag === 'basefont' || tag === 'bgsound' || tag === 'link' || tag === 'meta' || tag === 'title' || tag === 'noscript' || tag === 'noframes' || tag === 'style' || tag === 'script' || tag === 'template';
+      // https://html.spec.whatwg.org/multipage/semantics.html#the-html-element
+      case 'html':
+        return tag === 'head' || tag === 'body';
+      case '#document':
+        return tag === 'html';
+    }
+
+    // Probably in the "in body" parsing mode, so we outlaw only tag combos
+    // where the parsing rules cause implicit opens or closes to be added.
+    // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inbody
+    switch (tag) {
+      case 'h1':
+      case 'h2':
+      case 'h3':
+      case 'h4':
+      case 'h5':
+      case 'h6':
+        return parentTag !== 'h1' && parentTag !== 'h2' && parentTag !== 'h3' && parentTag !== 'h4' && parentTag !== 'h5' && parentTag !== 'h6';
+
+      case 'rp':
+      case 'rt':
+        return impliedEndTags.indexOf(parentTag) === -1;
+
+      case 'body':
+      case 'caption':
+      case 'col':
+      case 'colgroup':
+      case 'frame':
+      case 'head':
+      case 'html':
+      case 'tbody':
+      case 'td':
+      case 'tfoot':
+      case 'th':
+      case 'thead':
+      case 'tr':
+        // These tags are only valid with a few parents that have special child
+        // parsing rules -- if we're down here, then none of those matched and
+        // so we allow it only if we don't know what the parent is, as all other
+        // cases are invalid.
+        return parentTag == null;
+    }
+
+    return true;
+  };
+
+  /**
+   * Returns whether
+   */
+  var findInvalidAncestorForTag = function (tag, ancestorInfo) {
+    switch (tag) {
+      case 'address':
+      case 'article':
+      case 'aside':
+      case 'blockquote':
+      case 'center':
+      case 'details':
+      case 'dialog':
+      case 'dir':
+      case 'div':
+      case 'dl':
+      case 'fieldset':
+      case 'figcaption':
+      case 'figure':
+      case 'footer':
+      case 'header':
+      case 'hgroup':
+      case 'main':
+      case 'menu':
+      case 'nav':
+      case 'ol':
+      case 'p':
+      case 'section':
+      case 'summary':
+      case 'ul':
+      case 'pre':
+      case 'listing':
+      case 'table':
+      case 'hr':
+      case 'xmp':
+      case 'h1':
+      case 'h2':
+      case 'h3':
+      case 'h4':
+      case 'h5':
+      case 'h6':
+        return ancestorInfo.pTagInButtonScope;
+
+      case 'form':
+        return ancestorInfo.formTag || ancestorInfo.pTagInButtonScope;
+
+      case 'li':
+        return ancestorInfo.listItemTagAutoclosing;
+
+      case 'dd':
+      case 'dt':
+        return ancestorInfo.dlItemTagAutoclosing;
+
+      case 'button':
+        return ancestorInfo.buttonTagInScope;
+
+      case 'a':
+        // Spec says something about storing a list of markers, but it sounds
+        // equivalent to this check.
+        return ancestorInfo.aTagInScope;
+
+      case 'nobr':
+        return ancestorInfo.nobrTagInScope;
+    }
+
+    return null;
+  };
+
+  /**
+   * Given a ReactCompositeComponent instance, return a list of its recursive
+   * owners, starting at the root and ending with the instance itself.
+   */
+  var findOwnerStack = function (instance) {
+    if (!instance) {
+      return [];
+    }
+
+    var stack = [];
+    do {
+      stack.push(instance);
+    } while (instance = instance._currentElement._owner);
+    stack.reverse();
+    return stack;
+  };
+
+  var didWarn = {};
+
+  validateDOMNesting = function (childTag, childText, childInstance, ancestorInfo) {
+    ancestorInfo = ancestorInfo || emptyAncestorInfo;
+    var parentInfo = ancestorInfo.current;
+    var parentTag = parentInfo && parentInfo.tag;
+
+    if (childText != null) {
+      "development" !== 'production' ? warning(childTag == null, 'validateDOMNesting: when childText is passed, childTag should be null') : void 0;
+      childTag = '#text';
+    }
+
+    var invalidParent = isTagValidWithParent(childTag, parentTag) ? null : parentInfo;
+    var invalidAncestor = invalidParent ? null : findInvalidAncestorForTag(childTag, ancestorInfo);
+    var problematic = invalidParent || invalidAncestor;
+
+    if (problematic) {
+      var ancestorTag = problematic.tag;
+      var ancestorInstance = problematic.instance;
+
+      var childOwner = childInstance && childInstance._currentElement._owner;
+      var ancestorOwner = ancestorInstance && ancestorInstance._currentElement._owner;
+
+      var childOwners = findOwnerStack(childOwner);
+      var ancestorOwners = findOwnerStack(ancestorOwner);
+
+      var minStackLen = Math.min(childOwners.length, ancestorOwners.length);
+      var i;
+
+      var deepestCommon = -1;
+      for (i = 0; i < minStackLen; i++) {
+        if (childOwners[i] === ancestorOwners[i]) {
+          deepestCommon = i;
+        } else {
+          break;
+        }
+      }
+
+      var UNKNOWN = '(unknown)';
+      var childOwnerNames = childOwners.slice(deepestCommon + 1).map(function (inst) {
+        return inst.getName() || UNKNOWN;
+      });
+      var ancestorOwnerNames = ancestorOwners.slice(deepestCommon + 1).map(function (inst) {
+        return inst.getName() || UNKNOWN;
+      });
+      var ownerInfo = [].concat(
+      // If the parent and child instances have a common owner ancestor, start
+      // with that -- otherwise we just start with the parent's owners.
+      deepestCommon !== -1 ? childOwners[deepestCommon].getName() || UNKNOWN : [], ancestorOwnerNames, ancestorTag,
+      // If we're warning about an invalid (non-parent) ancestry, add '...'
+      invalidAncestor ? ['...'] : [], childOwnerNames, childTag).join(' > ');
+
+      var warnKey = !!invalidParent + '|' + childTag + '|' + ancestorTag + '|' + ownerInfo;
+      if (didWarn[warnKey]) {
+        return;
+      }
+      didWarn[warnKey] = true;
+
+      var tagDisplayName = childTag;
+      var whitespaceInfo = '';
+      if (childTag === '#text') {
+        if (/\S/.test(childText)) {
+          tagDisplayName = 'Text nodes';
+        } else {
+          tagDisplayName = 'Whitespace text nodes';
+          whitespaceInfo = " Make sure you don't have any extra whitespace between tags on " + 'each line of your source code.';
+        }
+      } else {
+        tagDisplayName = '<' + childTag + '>';
+      }
+
+      if (invalidParent) {
+        var info = '';
+        if (ancestorTag === 'table' && childTag === 'tr') {
+          info += ' Add a <tbody> to your code to match the DOM tree generated by ' + 'the browser.';
+        }
+        "development" !== 'production' ? warning(false, 'validateDOMNesting(...): %s cannot appear as a child of <%s>.%s ' + 'See %s.%s', tagDisplayName, ancestorTag, whitespaceInfo, ownerInfo, info) : void 0;
+      } else {
+        "development" !== 'production' ? warning(false, 'validateDOMNesting(...): %s cannot appear as a descendant of ' + '<%s>. See %s.', tagDisplayName, ancestorTag, ownerInfo) : void 0;
+      }
+    }
+  };
+
+  validateDOMNesting.updatedAncestorInfo = updatedAncestorInfo;
+
+  // For testing
+  validateDOMNesting.isTagValidInContext = function (tag, ancestorInfo) {
+    ancestorInfo = ancestorInfo || emptyAncestorInfo;
+    var parentInfo = ancestorInfo.current;
+    var parentTag = parentInfo && parentInfo.tag;
+    return isTagValidWithParent(tag, parentTag) && !findInvalidAncestorForTag(tag, ancestorInfo);
+  };
+}
+
+module.exports = validateDOMNesting;
+},{"144":144,"159":159,"160":160}],133:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/* globals React */
+
+'use strict';
+
+var ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+module.exports = ReactInternals.ReactComponentTreeHook;
+},{}],134:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/* globals React */
+
+'use strict';
+
+var ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+module.exports = ReactInternals.ReactCurrentOwner;
+},{}],135:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/* globals React */
+
+'use strict';
+
+module.exports = React;
+},{}],136:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/* globals React */
+
+'use strict';
+
+var ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+module.exports = ReactInternals.getNextDebugID;
+},{}],137:[function(_dereq_,module,exports){
+'use strict';
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @typechecks
+ */
+
+var emptyFunction = _dereq_(144);
+
+/**
+ * Upstream version of event listener. Does not take into account specific
+ * nature of platform.
+ */
+var EventListener = {
+  /**
+   * Listen to DOM events during the bubble phase.
+   *
+   * @param {DOMEventTarget} target DOM element to register listener on.
+   * @param {string} eventType Event type, e.g. 'click' or 'mouseover'.
+   * @param {function} callback Callback function.
+   * @return {object} Object with a `remove` method.
+   */
+  listen: function listen(target, eventType, callback) {
+    if (target.addEventListener) {
+      target.addEventListener(eventType, callback, false);
+      return {
+        remove: function remove() {
+          target.removeEventListener(eventType, callback, false);
+        }
+      };
+    } else if (target.attachEvent) {
+      target.attachEvent('on' + eventType, callback);
+      return {
+        remove: function remove() {
+          target.detachEvent('on' + eventType, callback);
+        }
+      };
+    }
+  },
+
+  /**
+   * Listen to DOM events during the capture phase.
+   *
+   * @param {DOMEventTarget} target DOM element to register listener on.
+   * @param {string} eventType Event type, e.g. 'click' or 'mouseover'.
+   * @param {function} callback Callback function.
+   * @return {object} Object with a `remove` method.
+   */
+  capture: function capture(target, eventType, callback) {
+    if (target.addEventListener) {
+      target.addEventListener(eventType, callback, true);
+      return {
+        remove: function remove() {
+          target.removeEventListener(eventType, callback, true);
+        }
+      };
+    } else {
+      if ("development" !== 'production') {
+        console.error('Attempted to listen to events during the capture phase on a ' + 'browser that does not support the capture phase. Your application ' + 'will not receive some events.');
+      }
+      return {
+        remove: emptyFunction
+      };
+    }
+  },
+
+  registerDefault: function registerDefault() {}
+};
+
+module.exports = EventListener;
+},{"144":144}],138:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+var canUseDOM = !!(typeof window !== 'undefined' && window.document && window.document.createElement);
+
+/**
+ * Simple, lightweight module assisting with the detection and context of
+ * Worker. Helps avoid circular dependencies and allows code to reason about
+ * whether or not they are in a Worker, even if they never include the main
+ * `ReactWorker` dependency.
+ */
+var ExecutionEnvironment = {
+
+  canUseDOM: canUseDOM,
+
+  canUseWorkers: typeof Worker !== 'undefined',
+
+  canUseEventListeners: canUseDOM && !!(window.addEventListener || window.attachEvent),
+
+  canUseViewport: canUseDOM && !!window.screen,
+
+  isInWorker: !canUseDOM // For now, this is true - might change in the future.
+
+};
+
+module.exports = ExecutionEnvironment;
+},{}],139:[function(_dereq_,module,exports){
+"use strict";
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+var _hyphenPattern = /-(.)/g;
+
+/**
+ * Camelcases a hyphenated string, for example:
+ *
+ *   > camelize('background-color')
+ *   < "backgroundColor"
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function camelize(string) {
+  return string.replace(_hyphenPattern, function (_, character) {
+    return character.toUpperCase();
+  });
+}
+
+module.exports = camelize;
+},{}],140:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+'use strict';
+
+var camelize = _dereq_(139);
+
+var msPattern = /^-ms-/;
+
+/**
+ * Camelcases a hyphenated CSS property name, for example:
+ *
+ *   > camelizeStyleName('background-color')
+ *   < "backgroundColor"
+ *   > camelizeStyleName('-moz-transition')
+ *   < "MozTransition"
+ *   > camelizeStyleName('-ms-transition')
+ *   < "msTransition"
+ *
+ * As Andi Smith suggests
+ * (http://www.andismith.com/blog/2012/02/modernizr-prefixed/), an `-ms` prefix
+ * is converted to lowercase `ms`.
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function camelizeStyleName(string) {
+  return camelize(string.replace(msPattern, 'ms-'));
+}
+
+module.exports = camelizeStyleName;
+},{"139":139}],141:[function(_dereq_,module,exports){
+'use strict';
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *
+ */
+
+var isTextNode = _dereq_(154);
+
+/*eslint-disable no-bitwise */
+
+/**
+ * Checks if a given DOM node contains or is another DOM node.
+ */
+function containsNode(outerNode, innerNode) {
+  if (!outerNode || !innerNode) {
+    return false;
+  } else if (outerNode === innerNode) {
+    return true;
+  } else if (isTextNode(outerNode)) {
+    return false;
+  } else if (isTextNode(innerNode)) {
+    return containsNode(outerNode, innerNode.parentNode);
+  } else if ('contains' in outerNode) {
+    return outerNode.contains(innerNode);
+  } else if (outerNode.compareDocumentPosition) {
+    return !!(outerNode.compareDocumentPosition(innerNode) & 16);
+  } else {
+    return false;
+  }
+}
+
+module.exports = containsNode;
+},{"154":154}],142:[function(_dereq_,module,exports){
+'use strict';
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+var invariant = _dereq_(152);
+
+/**
+ * Convert array-like objects to arrays.
+ *
+ * This API assumes the caller knows the contents of the data type. For less
+ * well defined inputs use createArrayFromMixed.
+ *
+ * @param {object|function|filelist} obj
+ * @return {array}
+ */
+function toArray(obj) {
+  var length = obj.length;
+
+  // Some browsers builtin objects can report typeof 'function' (e.g. NodeList
+  // in old versions of Safari).
+  !(!Array.isArray(obj) && (typeof obj === 'object' || typeof obj === 'function')) ? "development" !== 'production' ? invariant(false, 'toArray: Array-like object expected') : invariant(false) : void 0;
+
+  !(typeof length === 'number') ? "development" !== 'production' ? invariant(false, 'toArray: Object needs a length property') : invariant(false) : void 0;
+
+  !(length === 0 || length - 1 in obj) ? "development" !== 'production' ? invariant(false, 'toArray: Object should have keys for indices') : invariant(false) : void 0;
+
+  !(typeof obj.callee !== 'function') ? "development" !== 'production' ? invariant(false, 'toArray: Object can\'t be `arguments`. Use rest params ' + '(function(...args) {}) or Array.from() instead.') : invariant(false) : void 0;
+
+  // Old IE doesn't give collections access to hasOwnProperty. Assume inputs
+  // without method will throw during the slice call and skip straight to the
+  // fallback.
+  if (obj.hasOwnProperty) {
+    try {
+      return Array.prototype.slice.call(obj);
+    } catch (e) {
+      // IE < 9 does not support Array#slice on collections objects
+    }
+  }
+
+  // Fall back to copying key by key. This assumes all keys have a value,
+  // so will not preserve sparsely populated inputs.
+  var ret = Array(length);
+  for (var ii = 0; ii < length; ii++) {
+    ret[ii] = obj[ii];
+  }
+  return ret;
+}
+
+/**
+ * Perform a heuristic test to determine if an object is "array-like".
+ *
+ *   A monk asked Joshu, a Zen master, "Has a dog Buddha nature?"
+ *   Joshu replied: "Mu."
+ *
+ * This function determines if its argument has "array nature": it returns
+ * true if the argument is an actual array, an `arguments' object, or an
+ * HTMLCollection (e.g. node.childNodes or node.getElementsByTagName()).
+ *
+ * It will return false for other array-like objects like Filelist.
+ *
+ * @param {*} obj
+ * @return {boolean}
+ */
+function hasArrayNature(obj) {
+  return (
+    // not null/false
+    !!obj && (
+    // arrays are objects, NodeLists are functions in Safari
+    typeof obj == 'object' || typeof obj == 'function') &&
+    // quacks like an array
+    'length' in obj &&
+    // not window
+    !('setInterval' in obj) &&
+    // no DOM node should be considered an array-like
+    // a 'select' element has 'length' and 'item' properties on IE8
+    typeof obj.nodeType != 'number' && (
+    // a real array
+    Array.isArray(obj) ||
+    // arguments
+    'callee' in obj ||
+    // HTMLCollection/NodeList
+    'item' in obj)
+  );
+}
+
+/**
+ * Ensure that the argument is an array by wrapping it in an array if it is not.
+ * Creates a copy of the argument if it is already an array.
+ *
+ * This is mostly useful idiomatically:
+ *
+ *   var createArrayFromMixed = require('createArrayFromMixed');
+ *
+ *   function takesOneOrMoreThings(things) {
+ *     things = createArrayFromMixed(things);
+ *     ...
+ *   }
+ *
+ * This allows you to treat `things' as an array, but accept scalars in the API.
+ *
+ * If you need to convert an array-like object, like `arguments`, into an array
+ * use toArray instead.
+ *
+ * @param {*} obj
+ * @return {array}
+ */
+function createArrayFromMixed(obj) {
+  if (!hasArrayNature(obj)) {
+    return [obj];
+  } else if (Array.isArray(obj)) {
+    return obj.slice();
+  } else {
+    return toArray(obj);
+  }
+}
+
+module.exports = createArrayFromMixed;
+},{"152":152}],143:[function(_dereq_,module,exports){
+'use strict';
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+/*eslint-disable fb-www/unsafe-html*/
+
+var ExecutionEnvironment = _dereq_(138);
+
+var createArrayFromMixed = _dereq_(142);
+var getMarkupWrap = _dereq_(148);
+var invariant = _dereq_(152);
+
+/**
+ * Dummy container used to render all markup.
+ */
+var dummyNode = ExecutionEnvironment.canUseDOM ? document.createElement('div') : null;
+
+/**
+ * Pattern used by `getNodeName`.
+ */
+var nodeNamePattern = /^\s*<(\w+)/;
+
+/**
+ * Extracts the `nodeName` of the first element in a string of markup.
+ *
+ * @param {string} markup String of markup.
+ * @return {?string} Node name of the supplied markup.
+ */
+function getNodeName(markup) {
+  var nodeNameMatch = markup.match(nodeNamePattern);
+  return nodeNameMatch && nodeNameMatch[1].toLowerCase();
+}
+
+/**
+ * Creates an array containing the nodes rendered from the supplied markup. The
+ * optionally supplied `handleScript` function will be invoked once for each
+ * <script> element that is rendered. If no `handleScript` function is supplied,
+ * an exception is thrown if any <script> elements are rendered.
+ *
+ * @param {string} markup A string of valid HTML markup.
+ * @param {?function} handleScript Invoked once for each rendered <script>.
+ * @return {array<DOMElement|DOMTextNode>} An array of rendered nodes.
+ */
+function createNodesFromMarkup(markup, handleScript) {
+  var node = dummyNode;
+  !!!dummyNode ? "development" !== 'production' ? invariant(false, 'createNodesFromMarkup dummy not initialized') : invariant(false) : void 0;
+  var nodeName = getNodeName(markup);
+
+  var wrap = nodeName && getMarkupWrap(nodeName);
+  if (wrap) {
+    node.innerHTML = wrap[1] + markup + wrap[2];
+
+    var wrapDepth = wrap[0];
+    while (wrapDepth--) {
+      node = node.lastChild;
+    }
+  } else {
+    node.innerHTML = markup;
+  }
+
+  var scripts = node.getElementsByTagName('script');
+  if (scripts.length) {
+    !handleScript ? "development" !== 'production' ? invariant(false, 'createNodesFromMarkup(...): Unexpected <script> element rendered.') : invariant(false) : void 0;
+    createArrayFromMixed(scripts).forEach(handleScript);
+  }
+
+  var nodes = Array.from(node.childNodes);
+  while (node.lastChild) {
+    node.removeChild(node.lastChild);
+  }
+  return nodes;
+}
+
+module.exports = createNodesFromMarkup;
+},{"138":138,"142":142,"148":148,"152":152}],144:[function(_dereq_,module,exports){
+"use strict";
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *
+ */
+
+function makeEmptyFunction(arg) {
+  return function () {
+    return arg;
+  };
+}
+
+/**
+ * This function accepts and discards inputs; it has no side effects. This is
+ * primarily useful idiomatically for overridable function endpoints which
+ * always need to be callable, since JS lacks a null-call idiom ala Cocoa.
+ */
+var emptyFunction = function emptyFunction() {};
+
+emptyFunction.thatReturns = makeEmptyFunction;
+emptyFunction.thatReturnsFalse = makeEmptyFunction(false);
+emptyFunction.thatReturnsTrue = makeEmptyFunction(true);
+emptyFunction.thatReturnsNull = makeEmptyFunction(null);
+emptyFunction.thatReturnsThis = function () {
+  return this;
+};
+emptyFunction.thatReturnsArgument = function (arg) {
+  return arg;
+};
+
+module.exports = emptyFunction;
+},{}],145:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+var emptyObject = {};
+
+if ("development" !== 'production') {
+  Object.freeze(emptyObject);
+}
+
+module.exports = emptyObject;
+},{}],146:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+/**
+ * @param {DOMElement} node input/textarea to focus
+ */
+
+function focusNode(node) {
+  // IE8 can throw "Can't move focus to the control because it is invisible,
+  // not enabled, or of a type that does not accept the focus." for all kinds of
+  // reasons that are too expensive and fragile to test.
+  try {
+    node.focus();
+  } catch (e) {}
+}
+
+module.exports = focusNode;
+},{}],147:[function(_dereq_,module,exports){
+'use strict';
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+/* eslint-disable fb-www/typeof-undefined */
+
+/**
+ * Same as document.activeElement but wraps in a try-catch block. In IE it is
+ * not safe to call document.activeElement if there is nothing focused.
+ *
+ * The activeElement will be null only if the document or document body is not
+ * yet defined.
+ *
+ * @param {?DOMDocument} doc Defaults to current document.
+ * @return {?DOMElement}
+ */
+function getActiveElement(doc) /*?DOMElement*/{
+  doc = doc || (typeof document !== 'undefined' ? document : undefined);
+  if (typeof doc === 'undefined') {
+    return null;
+  }
+  try {
+    return doc.activeElement || doc.body;
+  } catch (e) {
+    return doc.body;
+  }
+}
+
+module.exports = getActiveElement;
+},{}],148:[function(_dereq_,module,exports){
+'use strict';
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/*eslint-disable fb-www/unsafe-html */
+
+var ExecutionEnvironment = _dereq_(138);
+
+var invariant = _dereq_(152);
+
+/**
+ * Dummy container used to detect which wraps are necessary.
+ */
+var dummyNode = ExecutionEnvironment.canUseDOM ? document.createElement('div') : null;
+
+/**
+ * Some browsers cannot use `innerHTML` to render certain elements standalone,
+ * so we wrap them, render the wrapped nodes, then extract the desired node.
+ *
+ * In IE8, certain elements cannot render alone, so wrap all elements ('*').
+ */
+
+var shouldWrap = {};
+
+var selectWrap = [1, '<select multiple="true">', '</select>'];
+var tableWrap = [1, '<table>', '</table>'];
+var trWrap = [3, '<table><tbody><tr>', '</tr></tbody></table>'];
+
+var svgWrap = [1, '<svg xmlns="http://www.w3.org/2000/svg">', '</svg>'];
+
+var markupWrap = {
+  '*': [1, '?<div>', '</div>'],
+
+  'area': [1, '<map>', '</map>'],
+  'col': [2, '<table><tbody></tbody><colgroup>', '</colgroup></table>'],
+  'legend': [1, '<fieldset>', '</fieldset>'],
+  'param': [1, '<object>', '</object>'],
+  'tr': [2, '<table><tbody>', '</tbody></table>'],
+
+  'optgroup': selectWrap,
+  'option': selectWrap,
+
+  'caption': tableWrap,
+  'colgroup': tableWrap,
+  'tbody': tableWrap,
+  'tfoot': tableWrap,
+  'thead': tableWrap,
+
+  'td': trWrap,
+  'th': trWrap
+};
+
+// Initialize the SVG elements since we know they'll always need to be wrapped
+// consistently. If they are created inside a <div> they will be initialized in
+// the wrong namespace (and will not display).
+var svgElements = ['circle', 'clipPath', 'defs', 'ellipse', 'g', 'image', 'line', 'linearGradient', 'mask', 'path', 'pattern', 'polygon', 'polyline', 'radialGradient', 'rect', 'stop', 'text', 'tspan'];
+svgElements.forEach(function (nodeName) {
+  markupWrap[nodeName] = svgWrap;
+  shouldWrap[nodeName] = true;
+});
+
+/**
+ * Gets the markup wrap configuration for the supplied `nodeName`.
+ *
+ * NOTE: This lazily detects which wraps are necessary for the current browser.
+ *
+ * @param {string} nodeName Lowercase `nodeName`.
+ * @return {?array} Markup wrap configuration, if applicable.
+ */
+function getMarkupWrap(nodeName) {
+  !!!dummyNode ? "development" !== 'production' ? invariant(false, 'Markup wrapping node not initialized') : invariant(false) : void 0;
+  if (!markupWrap.hasOwnProperty(nodeName)) {
+    nodeName = '*';
+  }
+  if (!shouldWrap.hasOwnProperty(nodeName)) {
+    if (nodeName === '*') {
+      dummyNode.innerHTML = '<link />';
+    } else {
+      dummyNode.innerHTML = '<' + nodeName + '></' + nodeName + '>';
+    }
+    shouldWrap[nodeName] = !dummyNode.firstChild;
+  }
+  return shouldWrap[nodeName] ? markupWrap[nodeName] : null;
+}
+
+module.exports = getMarkupWrap;
+},{"138":138,"152":152}],149:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+'use strict';
+
+/**
+ * Gets the scroll position of the supplied element or window.
+ *
+ * The return values are unbounded, unlike `getScrollPosition`. This means they
+ * may be negative or exceed the element boundaries (which is possible using
+ * inertial scrolling).
+ *
+ * @param {DOMWindow|DOMElement} scrollable
+ * @return {object} Map with `x` and `y` keys.
+ */
+
+function getUnboundedScrollPosition(scrollable) {
+  if (scrollable.Window && scrollable instanceof scrollable.Window) {
+    return {
+      x: scrollable.pageXOffset || scrollable.document.documentElement.scrollLeft,
+      y: scrollable.pageYOffset || scrollable.document.documentElement.scrollTop
+    };
+  }
+  return {
+    x: scrollable.scrollLeft,
+    y: scrollable.scrollTop
+  };
+}
+
+module.exports = getUnboundedScrollPosition;
+},{}],150:[function(_dereq_,module,exports){
+'use strict';
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+var _uppercasePattern = /([A-Z])/g;
+
+/**
+ * Hyphenates a camelcased string, for example:
+ *
+ *   > hyphenate('backgroundColor')
+ *   < "background-color"
+ *
+ * For CSS style names, use `hyphenateStyleName` instead which works properly
+ * with all vendor prefixes, including `ms`.
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function hyphenate(string) {
+  return string.replace(_uppercasePattern, '-$1').toLowerCase();
+}
+
+module.exports = hyphenate;
+},{}],151:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+'use strict';
+
+var hyphenate = _dereq_(150);
+
+var msPattern = /^ms-/;
+
+/**
+ * Hyphenates a camelcased CSS property name, for example:
+ *
+ *   > hyphenateStyleName('backgroundColor')
+ *   < "background-color"
+ *   > hyphenateStyleName('MozTransition')
+ *   < "-moz-transition"
+ *   > hyphenateStyleName('msTransition')
+ *   < "-ms-transition"
+ *
+ * As Modernizr suggests (http://modernizr.com/docs/#prefixed), an `ms` prefix
+ * is converted to `-ms-`.
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function hyphenateStyleName(string) {
+  return hyphenate(string).replace(msPattern, '-ms-');
+}
+
+module.exports = hyphenateStyleName;
+},{"150":150}],152:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+/**
+ * Use invariant() to assert state which your program assumes to be true.
+ *
+ * Provide sprintf-style format (only %s is supported) and arguments
+ * to provide information about what broke and what you were
+ * expecting.
+ *
+ * The invariant message will be stripped in production, but the invariant
+ * will remain to ensure logic does not differ in production.
+ */
+
+var validateFormat = function validateFormat(format) {};
+
+if ("development" !== 'production') {
+  validateFormat = function validateFormat(format) {
+    if (format === undefined) {
+      throw new Error('invariant requires an error message argument');
+    }
+  };
+}
+
+function invariant(condition, format, a, b, c, d, e, f) {
+  validateFormat(format);
+
+  if (!condition) {
+    var error;
+    if (format === undefined) {
+      error = new Error('Minified exception occurred; use the non-minified dev environment ' + 'for the full error message and additional helpful warnings.');
+    } else {
+      var args = [a, b, c, d, e, f];
+      var argIndex = 0;
+      error = new Error(format.replace(/%s/g, function () {
+        return args[argIndex++];
+      }));
+      error.name = 'Invariant Violation';
+    }
+
+    error.framesToPop = 1; // we don't care about invariant's own frame
+    throw error;
+  }
+}
+
+module.exports = invariant;
+},{}],153:[function(_dereq_,module,exports){
+'use strict';
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+/**
+ * @param {*} object The object to check.
+ * @return {boolean} Whether or not the object is a DOM node.
+ */
+function isNode(object) {
+  var doc = object ? object.ownerDocument || object : document;
+  var defaultView = doc.defaultView || window;
+  return !!(object && (typeof defaultView.Node === 'function' ? object instanceof defaultView.Node : typeof object === 'object' && typeof object.nodeType === 'number' && typeof object.nodeName === 'string'));
+}
+
+module.exports = isNode;
+},{}],154:[function(_dereq_,module,exports){
+'use strict';
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+var isNode = _dereq_(153);
+
+/**
+ * @param {*} object The object to check.
+ * @return {boolean} Whether or not the object is a DOM text node.
+ */
+function isTextNode(object) {
+  return isNode(object) && object.nodeType == 3;
+}
+
+module.exports = isTextNode;
+},{"153":153}],155:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *
+ * @typechecks static-only
+ */
+
+'use strict';
+
+/**
+ * Memoizes the return value of a function that accepts one string argument.
+ */
+
+function memoizeStringOnly(callback) {
+  var cache = {};
+  return function (string) {
+    if (!cache.hasOwnProperty(string)) {
+      cache[string] = callback.call(this, string);
+    }
+    return cache[string];
+  };
+}
+
+module.exports = memoizeStringOnly;
+},{}],156:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+'use strict';
+
+var ExecutionEnvironment = _dereq_(138);
+
+var performance;
+
+if (ExecutionEnvironment.canUseDOM) {
+  performance = window.performance || window.msPerformance || window.webkitPerformance;
+}
+
+module.exports = performance || {};
+},{"138":138}],157:[function(_dereq_,module,exports){
+'use strict';
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ */
+
+var performance = _dereq_(156);
+
+var performanceNow;
+
+/**
+ * Detect if we can use `window.performance.now()` and gracefully fallback to
+ * `Date.now()` if it doesn't exist. We need to support Firefox < 15 for now
+ * because of Facebook's testing infrastructure.
+ */
+if (performance.now) {
+  performanceNow = function performanceNow() {
+    return performance.now();
+  };
+} else {
+  performanceNow = function performanceNow() {
+    return Date.now();
+  };
+}
+
+module.exports = performanceNow;
+},{"156":156}],158:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ *
+ */
+
+/*eslint-disable no-self-compare */
+
+'use strict';
+
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * inlined Object.is polyfill to avoid requiring consumers ship their own
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+ */
+function is(x, y) {
+  // SameValue algorithm
+  if (x === y) {
+    // Steps 1-5, 7-10
+    // Steps 6.b-6.e: +0 != -0
+    // Added the nonzero y check to make Flow happy, but it is redundant
+    return x !== 0 || y !== 0 || 1 / x === 1 / y;
+  } else {
+    // Step 6.a: NaN == NaN
+    return x !== x && y !== y;
+  }
+}
+
+/**
+ * Performs equality by iterating through keys on an object and returning false
+ * when any key has values which are not strictly equal between the arguments.
+ * Returns true when the values of all keys are strictly equal.
+ */
+function shallowEqual(objA, objB) {
+  if (is(objA, objB)) {
+    return true;
+  }
+
+  if (typeof objA !== 'object' || objA === null || typeof objB !== 'object' || objB === null) {
+    return false;
+  }
+
+  var keysA = Object.keys(objA);
+  var keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  for (var i = 0; i < keysA.length; i++) {
+    if (!hasOwnProperty.call(objB, keysA[i]) || !is(objA[keysA[i]], objB[keysA[i]])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+module.exports = shallowEqual;
+},{}],159:[function(_dereq_,module,exports){
+/**
+ * Copyright 2014-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+var emptyFunction = _dereq_(144);
+
+/**
+ * Similar to invariant but only logs a warning if the condition is not met.
+ * This can be used to log issues in development environments in critical
+ * paths. Removing the logging code for production environments will keep the
+ * same logic and follow the same code paths.
+ */
+
+var warning = emptyFunction;
+
+if ("development" !== 'production') {
+  (function () {
+    var printWarning = function printWarning(format) {
+      for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      var argIndex = 0;
+      var message = 'Warning: ' + format.replace(/%s/g, function () {
+        return args[argIndex++];
+      });
+      if (typeof console !== 'undefined') {
+        console.error(message);
+      }
+      try {
+        // --- Welcome to debugging React ---
+        // This error was thrown as a convenience so that you can use this stack
+        // to find the callsite that caused this warning to fire.
+        throw new Error(message);
+      } catch (x) {}
+    };
+
+    warning = function warning(condition, format) {
+      if (format === undefined) {
+        throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
+      }
+
+      if (format.indexOf('Failed Composite propType: ') === 0) {
+        return; // Ignore CompositeComponent proptype check.
+      }
+
+      if (!condition) {
+        for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+          args[_key2 - 2] = arguments[_key2];
+        }
+
+        printWarning.apply(undefined, [format].concat(args));
+      }
+    };
+  })();
+}
+
+module.exports = warning;
+},{"144":144}],160:[function(_dereq_,module,exports){
+/*
+object-assign
+(c) Sindre Sorhus
+@license MIT
+*/
+
+'use strict';
+/* eslint-disable no-unused-vars */
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+function toObject(val) {
+	if (val === null || val === undefined) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+function shouldUseNative() {
+	try {
+		if (!Object.assign) {
+			return false;
+		}
+
+		// Detect buggy property enumeration order in older V8 versions.
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
+		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
+		test1[5] = 'de';
+		if (Object.getOwnPropertyNames(test1)[0] === '5') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test2 = {};
+		for (var i = 0; i < 10; i++) {
+			test2['_' + String.fromCharCode(i)] = i;
+		}
+		var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
+			return test2[n];
+		});
+		if (order2.join('') !== '0123456789') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test3 = {};
+		'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
+			test3[letter] = letter;
+		});
+		if (Object.keys(Object.assign({}, test3)).join('') !==
+				'abcdefghijklmnopqrst') {
+			return false;
+		}
+
+		return true;
+	} catch (err) {
+		// We don't expect any of the above to throw, but better to be safe.
+		return false;
+	}
+}
+
+module.exports = shouldUseNative() ? Object.assign : function (target, source) {
+	var from;
+	var to = toObject(target);
+	var symbols;
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = Object(arguments[s]);
+
+		for (var key in from) {
+			if (hasOwnProperty.call(from, key)) {
+				to[key] = from[key];
+			}
+		}
+
+		if (getOwnPropertySymbols) {
+			symbols = getOwnPropertySymbols(from);
+			for (var i = 0; i < symbols.length; i++) {
+				if (propIsEnumerable.call(from, symbols[i])) {
+					to[symbols[i]] = from[symbols[i]];
+				}
+			}
+		}
+	}
+
+	return to;
+};
+
+},{}],161:[function(_dereq_,module,exports){
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+if ("development" !== 'production') {
+  var invariant = _dereq_(152);
+  var warning = _dereq_(159);
+  var ReactPropTypesSecret = _dereq_(164);
+  var loggedTypeFailures = {};
+}
+
+/**
+ * Assert that the values match with the type specs.
+ * Error messages are memorized and will only be shown once.
+ *
+ * @param {object} typeSpecs Map of name to a ReactPropType
+ * @param {object} values Runtime values that need to be type-checked
+ * @param {string} location e.g. "prop", "context", "child context"
+ * @param {string} componentName Name of the component for error messages.
+ * @param {?Function} getStack Returns the component stack.
+ * @private
+ */
+function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
+  if ("development" !== 'production') {
+    for (var typeSpecName in typeSpecs) {
+      if (typeSpecs.hasOwnProperty(typeSpecName)) {
+        var error;
+        // Prop type validation may throw. In case they do, we don't want to
+        // fail the render phase where it didn't fail before. So we log it.
+        // After these have been cleaned up, we'll let them throw.
+        try {
+          // This is intentionally an invariant that gets caught. It's the same
+          // behavior as without this statement except with a better message.
+          invariant(typeof typeSpecs[typeSpecName] === 'function', '%s: %s type `%s` is invalid; it must be a function, usually from ' + 'React.PropTypes.', componentName || 'React class', location, typeSpecName);
+          error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
+        } catch (ex) {
+          error = ex;
+        }
+        warning(!error || error instanceof Error, '%s: type specification of %s `%s` is invalid; the type checker ' + 'function must return `null` or an `Error` but returned a %s. ' + 'You may have forgotten to pass an argument to the type checker ' + 'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' + 'shape all require an argument).', componentName || 'React class', location, typeSpecName, typeof error);
+        if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+          // Only monitor this failure once because there tends to be a lot of the
+          // same error.
+          loggedTypeFailures[error.message] = true;
+
+          var stack = getStack ? getStack() : '';
+
+          warning(false, 'Failed %s type: %s%s', location, error.message, stack != null ? stack : '');
+        }
+      }
+    }
+  }
+}
+
+module.exports = checkPropTypes;
+
+},{"152":152,"159":159,"164":164}],162:[function(_dereq_,module,exports){
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+// React 15.5 references this module, and assumes PropTypes are still callable in production.
+// Therefore we re-export development-only version with all the PropTypes checks here.
+// However if one is migrating to the `prop-types` npm library, they will go through the
+// `index.js` entry point, and it will branch depending on the environment.
+var factory = _dereq_(163);
+module.exports = function(isValidElement) {
+  // It is still allowed in 15.5.
+  var throwOnDirectAccess = false;
+  return factory(isValidElement, throwOnDirectAccess);
+};
+
+},{"163":163}],163:[function(_dereq_,module,exports){
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var emptyFunction = _dereq_(144);
+var invariant = _dereq_(152);
+var warning = _dereq_(159);
+
+var ReactPropTypesSecret = _dereq_(164);
+var checkPropTypes = _dereq_(161);
+
+module.exports = function(isValidElement, throwOnDirectAccess) {
+  /* global Symbol */
+  var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+  var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+
+  /**
+   * Returns the iterator method function contained on the iterable object.
+   *
+   * Be sure to invoke the function with the iterable as context:
+   *
+   *     var iteratorFn = getIteratorFn(myIterable);
+   *     if (iteratorFn) {
+   *       var iterator = iteratorFn.call(myIterable);
+   *       ...
+   *     }
+   *
+   * @param {?object} maybeIterable
+   * @return {?function}
+   */
+  function getIteratorFn(maybeIterable) {
+    var iteratorFn = maybeIterable && (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL]);
+    if (typeof iteratorFn === 'function') {
+      return iteratorFn;
+    }
+  }
+
+  /**
+   * Collection of methods that allow declaration and validation of props that are
+   * supplied to React components. Example usage:
+   *
+   *   var Props = require('ReactPropTypes');
+   *   var MyArticle = React.createClass({
+   *     propTypes: {
+   *       // An optional string prop named "description".
+   *       description: Props.string,
+   *
+   *       // A required enum prop named "category".
+   *       category: Props.oneOf(['News','Photos']).isRequired,
+   *
+   *       // A prop named "dialog" that requires an instance of Dialog.
+   *       dialog: Props.instanceOf(Dialog).isRequired
+   *     },
+   *     render: function() { ... }
+   *   });
+   *
+   * A more formal specification of how these methods are used:
+   *
+   *   type := array|bool|func|object|number|string|oneOf([...])|instanceOf(...)
+   *   decl := ReactPropTypes.{type}(.isRequired)?
+   *
+   * Each and every declaration produces a function with the same signature. This
+   * allows the creation of custom validation functions. For example:
+   *
+   *  var MyLink = React.createClass({
+   *    propTypes: {
+   *      // An optional string or URI prop named "href".
+   *      href: function(props, propName, componentName) {
+   *        var propValue = props[propName];
+   *        if (propValue != null && typeof propValue !== 'string' &&
+   *            !(propValue instanceof URI)) {
+   *          return new Error(
+   *            'Expected a string or an URI for ' + propName + ' in ' +
+   *            componentName
+   *          );
+   *        }
+   *      }
+   *    },
+   *    render: function() {...}
+   *  });
+   *
+   * @internal
+   */
+
+  var ANONYMOUS = '<<anonymous>>';
+
+  // Important!
+  // Keep this list in sync with production version in `./factoryWithThrowingShims.js`.
+  var ReactPropTypes = {
+    array: createPrimitiveTypeChecker('array'),
+    bool: createPrimitiveTypeChecker('boolean'),
+    func: createPrimitiveTypeChecker('function'),
+    number: createPrimitiveTypeChecker('number'),
+    object: createPrimitiveTypeChecker('object'),
+    string: createPrimitiveTypeChecker('string'),
+    symbol: createPrimitiveTypeChecker('symbol'),
+
+    any: createAnyTypeChecker(),
+    arrayOf: createArrayOfTypeChecker,
+    element: createElementTypeChecker(),
+    instanceOf: createInstanceTypeChecker,
+    node: createNodeChecker(),
+    objectOf: createObjectOfTypeChecker,
+    oneOf: createEnumTypeChecker,
+    oneOfType: createUnionTypeChecker,
+    shape: createShapeTypeChecker
+  };
+
+  /**
+   * inlined Object.is polyfill to avoid requiring consumers ship their own
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+   */
+  /*eslint-disable no-self-compare*/
+  function is(x, y) {
+    // SameValue algorithm
+    if (x === y) {
+      // Steps 1-5, 7-10
+      // Steps 6.b-6.e: +0 != -0
+      return x !== 0 || 1 / x === 1 / y;
+    } else {
+      // Step 6.a: NaN == NaN
+      return x !== x && y !== y;
+    }
+  }
+  /*eslint-enable no-self-compare*/
+
+  /**
+   * We use an Error-like object for backward compatibility as people may call
+   * PropTypes directly and inspect their output. However, we don't use real
+   * Errors anymore. We don't inspect their stack anyway, and creating them
+   * is prohibitively expensive if they are created too often, such as what
+   * happens in oneOfType() for any type before the one that matched.
+   */
+  function PropTypeError(message) {
+    this.message = message;
+    this.stack = '';
+  }
+  // Make `instanceof Error` still work for returned errors.
+  PropTypeError.prototype = Error.prototype;
+
+  function createChainableTypeChecker(validate) {
+    if ("development" !== 'production') {
+      var manualPropTypeCallCache = {};
+      var manualPropTypeWarningCount = 0;
+    }
+    function checkType(isRequired, props, propName, componentName, location, propFullName, secret) {
+      componentName = componentName || ANONYMOUS;
+      propFullName = propFullName || propName;
+
+      if (secret !== ReactPropTypesSecret) {
+        if (throwOnDirectAccess) {
+          // New behavior only for users of `prop-types` package
+          invariant(
+            false,
+            'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
+            'Use `PropTypes.checkPropTypes()` to call them. ' +
+            'Read more at http://fb.me/use-check-prop-types'
+          );
+        } else if ("development" !== 'production' && typeof console !== 'undefined') {
+          // Old behavior for people using React.PropTypes
+          var cacheKey = componentName + ':' + propName;
+          if (
+            !manualPropTypeCallCache[cacheKey] &&
+            // Avoid spamming the console because they are often not actionable except for lib authors
+            manualPropTypeWarningCount < 3
+          ) {
+            warning(
+              false,
+              'You are manually calling a React.PropTypes validation ' +
+              'function for the `%s` prop on `%s`. This is deprecated ' +
+              'and will throw in the standalone `prop-types` package. ' +
+              'You may be seeing this warning due to a third-party PropTypes ' +
+              'library. See https://fb.me/react-warning-dont-call-proptypes ' + 'for details.',
+              propFullName,
+              componentName
+            );
+            manualPropTypeCallCache[cacheKey] = true;
+            manualPropTypeWarningCount++;
+          }
+        }
+      }
+      if (props[propName] == null) {
+        if (isRequired) {
+          if (props[propName] === null) {
+            return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required ' + ('in `' + componentName + '`, but its value is `null`.'));
+          }
+          return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required in ' + ('`' + componentName + '`, but its value is `undefined`.'));
+        }
+        return null;
+      } else {
+        return validate(props, propName, componentName, location, propFullName);
+      }
+    }
+
+    var chainedCheckType = checkType.bind(null, false);
+    chainedCheckType.isRequired = checkType.bind(null, true);
+
+    return chainedCheckType;
+  }
+
+  function createPrimitiveTypeChecker(expectedType) {
+    function validate(props, propName, componentName, location, propFullName, secret) {
+      var propValue = props[propName];
+      var propType = getPropType(propValue);
+      if (propType !== expectedType) {
+        // `propValue` being instance of, say, date/regexp, pass the 'object'
+        // check, but we can offer a more precise error message here rather than
+        // 'of type `object`'.
+        var preciseType = getPreciseType(propValue);
+
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + preciseType + '` supplied to `' + componentName + '`, expected ') + ('`' + expectedType + '`.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createAnyTypeChecker() {
+    return createChainableTypeChecker(emptyFunction.thatReturnsNull);
+  }
+
+  function createArrayOfTypeChecker(typeChecker) {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (typeof typeChecker !== 'function') {
+        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside arrayOf.');
+      }
+      var propValue = props[propName];
+      if (!Array.isArray(propValue)) {
+        var propType = getPropType(propValue);
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an array.'));
+      }
+      for (var i = 0; i < propValue.length; i++) {
+        var error = typeChecker(propValue, i, componentName, location, propFullName + '[' + i + ']', ReactPropTypesSecret);
+        if (error instanceof Error) {
+          return error;
+        }
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createElementTypeChecker() {
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      if (!isValidElement(propValue)) {
+        var propType = getPropType(propValue);
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createInstanceTypeChecker(expectedClass) {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (!(props[propName] instanceof expectedClass)) {
+        var expectedClassName = expectedClass.name || ANONYMOUS;
+        var actualClassName = getClassName(props[propName]);
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + actualClassName + '` supplied to `' + componentName + '`, expected ') + ('instance of `' + expectedClassName + '`.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createEnumTypeChecker(expectedValues) {
+    if (!Array.isArray(expectedValues)) {
+      "development" !== 'production' ? warning(false, 'Invalid argument supplied to oneOf, expected an instance of array.') : void 0;
+      return emptyFunction.thatReturnsNull;
+    }
+
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      for (var i = 0; i < expectedValues.length; i++) {
+        if (is(propValue, expectedValues[i])) {
+          return null;
+        }
+      }
+
+      var valuesString = JSON.stringify(expectedValues);
+      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of value `' + propValue + '` ' + ('supplied to `' + componentName + '`, expected one of ' + valuesString + '.'));
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createObjectOfTypeChecker(typeChecker) {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (typeof typeChecker !== 'function') {
+        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside objectOf.');
+      }
+      var propValue = props[propName];
+      var propType = getPropType(propValue);
+      if (propType !== 'object') {
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an object.'));
+      }
+      for (var key in propValue) {
+        if (propValue.hasOwnProperty(key)) {
+          var error = typeChecker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+          if (error instanceof Error) {
+            return error;
+          }
+        }
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createUnionTypeChecker(arrayOfTypeCheckers) {
+    if (!Array.isArray(arrayOfTypeCheckers)) {
+      "development" !== 'production' ? warning(false, 'Invalid argument supplied to oneOfType, expected an instance of array.') : void 0;
+      return emptyFunction.thatReturnsNull;
+    }
+
+    for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+      var checker = arrayOfTypeCheckers[i];
+      if (typeof checker !== 'function') {
+        warning(
+          false,
+          'Invalid argument supplid to oneOfType. Expected an array of check functions, but ' +
+          'received %s at index %s.',
+          getPostfixForTypeWarning(checker),
+          i
+        );
+        return emptyFunction.thatReturnsNull;
+      }
+    }
+
+    function validate(props, propName, componentName, location, propFullName) {
+      for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+        var checker = arrayOfTypeCheckers[i];
+        if (checker(props, propName, componentName, location, propFullName, ReactPropTypesSecret) == null) {
+          return null;
+        }
+      }
+
+      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`.'));
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createNodeChecker() {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (!isNode(props[propName])) {
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`, expected a ReactNode.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createShapeTypeChecker(shapeTypes) {
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      var propType = getPropType(propValue);
+      if (propType !== 'object') {
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
+      }
+      for (var key in shapeTypes) {
+        var checker = shapeTypes[key];
+        if (!checker) {
+          continue;
+        }
+        var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+        if (error) {
+          return error;
+        }
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function isNode(propValue) {
+    switch (typeof propValue) {
+      case 'number':
+      case 'string':
+      case 'undefined':
+        return true;
+      case 'boolean':
+        return !propValue;
+      case 'object':
+        if (Array.isArray(propValue)) {
+          return propValue.every(isNode);
+        }
+        if (propValue === null || isValidElement(propValue)) {
+          return true;
+        }
+
+        var iteratorFn = getIteratorFn(propValue);
+        if (iteratorFn) {
+          var iterator = iteratorFn.call(propValue);
+          var step;
+          if (iteratorFn !== propValue.entries) {
+            while (!(step = iterator.next()).done) {
+              if (!isNode(step.value)) {
+                return false;
+              }
+            }
+          } else {
+            // Iterator will provide entry [k,v] tuples rather than values.
+            while (!(step = iterator.next()).done) {
+              var entry = step.value;
+              if (entry) {
+                if (!isNode(entry[1])) {
+                  return false;
+                }
+              }
+            }
+          }
+        } else {
+          return false;
+        }
+
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  function isSymbol(propType, propValue) {
+    // Native Symbol.
+    if (propType === 'symbol') {
+      return true;
+    }
+
+    // 19.4.3.5 Symbol.prototype[@@toStringTag] === 'Symbol'
+    if (propValue['@@toStringTag'] === 'Symbol') {
+      return true;
+    }
+
+    // Fallback for non-spec compliant Symbols which are polyfilled.
+    if (typeof Symbol === 'function' && propValue instanceof Symbol) {
+      return true;
+    }
+
+    return false;
+  }
+
+  // Equivalent of `typeof` but with special handling for array and regexp.
+  function getPropType(propValue) {
+    var propType = typeof propValue;
+    if (Array.isArray(propValue)) {
+      return 'array';
+    }
+    if (propValue instanceof RegExp) {
+      // Old webkits (at least until Android 4.0) return 'function' rather than
+      // 'object' for typeof a RegExp. We'll normalize this here so that /bla/
+      // passes PropTypes.object.
+      return 'object';
+    }
+    if (isSymbol(propType, propValue)) {
+      return 'symbol';
+    }
+    return propType;
+  }
+
+  // This handles more types than `getPropType`. Only used for error messages.
+  // See `createPrimitiveTypeChecker`.
+  function getPreciseType(propValue) {
+    if (typeof propValue === 'undefined' || propValue === null) {
+      return '' + propValue;
+    }
+    var propType = getPropType(propValue);
+    if (propType === 'object') {
+      if (propValue instanceof Date) {
+        return 'date';
+      } else if (propValue instanceof RegExp) {
+        return 'regexp';
+      }
+    }
+    return propType;
+  }
+
+  // Returns a string that is postfixed to a warning about an invalid type.
+  // For example, "undefined" or "of type array"
+  function getPostfixForTypeWarning(value) {
+    var type = getPreciseType(value);
+    switch (type) {
+      case 'array':
+      case 'object':
+        return 'an ' + type;
+      case 'boolean':
+      case 'date':
+      case 'regexp':
+        return 'a ' + type;
+      default:
+        return type;
+    }
+  }
+
+  // Returns class name of the object, if any.
+  function getClassName(propValue) {
+    if (!propValue.constructor || !propValue.constructor.name) {
+      return ANONYMOUS;
+    }
+    return propValue.constructor.name;
+  }
+
+  ReactPropTypes.checkPropTypes = checkPropTypes;
+  ReactPropTypes.PropTypes = ReactPropTypes;
+
+  return ReactPropTypes;
+};
+
+},{"144":144,"152":152,"159":159,"161":161,"164":164}],164:[function(_dereq_,module,exports){
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+
+module.exports = ReactPropTypesSecret;
+
+},{}]},{},[48])(48)
+});
+});

--- a/tests/assets/reading-list/react-dom_16.14.0.js
+++ b/tests/assets/reading-list/react-dom_16.14.0.js
@@ -1,0 +1,25147 @@
+/** @license React v16.14.0
+ * react-dom.development.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('react')) :
+  typeof define === 'function' && define.amd ? define(['exports', 'react'], factory) :
+  (global = global || self, factory(global.ReactDOM = {}, global.React));
+}(this, (function (exports, React) { 'use strict';
+
+  var ReactSharedInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED; // Prevent newer renderers from RTE when used with older react package versions.
+  // Current owner and dispatcher used to share the same ref,
+  // but PR #14548 split them out to better support the react-debug-tools package.
+
+  if (!ReactSharedInternals.hasOwnProperty('ReactCurrentDispatcher')) {
+    ReactSharedInternals.ReactCurrentDispatcher = {
+      current: null
+    };
+  }
+
+  if (!ReactSharedInternals.hasOwnProperty('ReactCurrentBatchConfig')) {
+    ReactSharedInternals.ReactCurrentBatchConfig = {
+      suspense: null
+    };
+  }
+
+  // by calls to these methods by a Babel plugin.
+  //
+  // In PROD (or in packages without access to React internals),
+  // they are left as they are instead.
+
+  function warn(format) {
+    {
+      for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      printWarning('warn', format, args);
+    }
+  }
+  function error(format) {
+    {
+      for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+        args[_key2 - 1] = arguments[_key2];
+      }
+
+      printWarning('error', format, args);
+    }
+  }
+
+  function printWarning(level, format, args) {
+    // When changing this logic, you might want to also
+    // update consoleWithStackDev.www.js as well.
+    {
+      var hasExistingStack = args.length > 0 && typeof args[args.length - 1] === 'string' && args[args.length - 1].indexOf('\n    in') === 0;
+
+      if (!hasExistingStack) {
+        var ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+        var stack = ReactDebugCurrentFrame.getStackAddendum();
+
+        if (stack !== '') {
+          format += '%s';
+          args = args.concat([stack]);
+        }
+      }
+
+      var argsWithFormat = args.map(function (item) {
+        return '' + item;
+      }); // Careful: RN currently depends on this prefix
+
+      argsWithFormat.unshift('Warning: ' + format); // We intentionally don't use spread (or .apply) directly because it
+      // breaks IE9: https://github.com/facebook/react/issues/13610
+      // eslint-disable-next-line react-internal/no-production-logging
+
+      Function.prototype.apply.call(console[level], console, argsWithFormat);
+
+      try {
+        // --- Welcome to debugging React ---
+        // This error was thrown as a convenience so that you can use this stack
+        // to find the callsite that caused this warning to fire.
+        var argIndex = 0;
+        var message = 'Warning: ' + format.replace(/%s/g, function () {
+          return args[argIndex++];
+        });
+        throw new Error(message);
+      } catch (x) {}
+    }
+  }
+
+  if (!React) {
+    {
+      throw Error( "ReactDOM was loaded before React. Make sure you load the React package before loading ReactDOM." );
+    }
+  }
+
+  var invokeGuardedCallbackImpl = function (name, func, context, a, b, c, d, e, f) {
+    var funcArgs = Array.prototype.slice.call(arguments, 3);
+
+    try {
+      func.apply(context, funcArgs);
+    } catch (error) {
+      this.onError(error);
+    }
+  };
+
+  {
+    // In DEV mode, we swap out invokeGuardedCallback for a special version
+    // that plays more nicely with the browser's DevTools. The idea is to preserve
+    // "Pause on exceptions" behavior. Because React wraps all user-provided
+    // functions in invokeGuardedCallback, and the production version of
+    // invokeGuardedCallback uses a try-catch, all user exceptions are treated
+    // like caught exceptions, and the DevTools won't pause unless the developer
+    // takes the extra step of enabling pause on caught exceptions. This is
+    // unintuitive, though, because even though React has caught the error, from
+    // the developer's perspective, the error is uncaught.
+    //
+    // To preserve the expected "Pause on exceptions" behavior, we don't use a
+    // try-catch in DEV. Instead, we synchronously dispatch a fake event to a fake
+    // DOM node, and call the user-provided callback from inside an event handler
+    // for that fake event. If the callback throws, the error is "captured" using
+    // a global event handler. But because the error happens in a different
+    // event loop context, it does not interrupt the normal program flow.
+    // Effectively, this gives us try-catch behavior without actually using
+    // try-catch. Neat!
+    // Check that the browser supports the APIs we need to implement our special
+    // DEV version of invokeGuardedCallback
+    if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function' && typeof document !== 'undefined' && typeof document.createEvent === 'function') {
+      var fakeNode = document.createElement('react');
+
+      var invokeGuardedCallbackDev = function (name, func, context, a, b, c, d, e, f) {
+        // If document doesn't exist we know for sure we will crash in this method
+        // when we call document.createEvent(). However this can cause confusing
+        // errors: https://github.com/facebookincubator/create-react-app/issues/3482
+        // So we preemptively throw with a better message instead.
+        if (!(typeof document !== 'undefined')) {
+          {
+            throw Error( "The `document` global was defined when React was initialized, but is not defined anymore. This can happen in a test environment if a component schedules an update from an asynchronous callback, but the test has already finished running. To solve this, you can either unmount the component at the end of your test (and ensure that any asynchronous operations get canceled in `componentWillUnmount`), or you can change the test itself to be asynchronous." );
+          }
+        }
+
+        var evt = document.createEvent('Event'); // Keeps track of whether the user-provided callback threw an error. We
+        // set this to true at the beginning, then set it to false right after
+        // calling the function. If the function errors, `didError` will never be
+        // set to false. This strategy works even if the browser is flaky and
+        // fails to call our global error handler, because it doesn't rely on
+        // the error event at all.
+
+        var didError = true; // Keeps track of the value of window.event so that we can reset it
+        // during the callback to let user code access window.event in the
+        // browsers that support it.
+
+        var windowEvent = window.event; // Keeps track of the descriptor of window.event to restore it after event
+        // dispatching: https://github.com/facebook/react/issues/13688
+
+        var windowEventDescriptor = Object.getOwnPropertyDescriptor(window, 'event'); // Create an event handler for our fake event. We will synchronously
+        // dispatch our fake event using `dispatchEvent`. Inside the handler, we
+        // call the user-provided callback.
+
+        var funcArgs = Array.prototype.slice.call(arguments, 3);
+
+        function callCallback() {
+          // We immediately remove the callback from event listeners so that
+          // nested `invokeGuardedCallback` calls do not clash. Otherwise, a
+          // nested call would trigger the fake event handlers of any call higher
+          // in the stack.
+          fakeNode.removeEventListener(evtType, callCallback, false); // We check for window.hasOwnProperty('event') to prevent the
+          // window.event assignment in both IE <= 10 as they throw an error
+          // "Member not found" in strict mode, and in Firefox which does not
+          // support window.event.
+
+          if (typeof window.event !== 'undefined' && window.hasOwnProperty('event')) {
+            window.event = windowEvent;
+          }
+
+          func.apply(context, funcArgs);
+          didError = false;
+        } // Create a global error event handler. We use this to capture the value
+        // that was thrown. It's possible that this error handler will fire more
+        // than once; for example, if non-React code also calls `dispatchEvent`
+        // and a handler for that event throws. We should be resilient to most of
+        // those cases. Even if our error event handler fires more than once, the
+        // last error event is always used. If the callback actually does error,
+        // we know that the last error event is the correct one, because it's not
+        // possible for anything else to have happened in between our callback
+        // erroring and the code that follows the `dispatchEvent` call below. If
+        // the callback doesn't error, but the error event was fired, we know to
+        // ignore it because `didError` will be false, as described above.
+
+
+        var error; // Use this to track whether the error event is ever called.
+
+        var didSetError = false;
+        var isCrossOriginError = false;
+
+        function handleWindowError(event) {
+          error = event.error;
+          didSetError = true;
+
+          if (error === null && event.colno === 0 && event.lineno === 0) {
+            isCrossOriginError = true;
+          }
+
+          if (event.defaultPrevented) {
+            // Some other error handler has prevented default.
+            // Browsers silence the error report if this happens.
+            // We'll remember this to later decide whether to log it or not.
+            if (error != null && typeof error === 'object') {
+              try {
+                error._suppressLogging = true;
+              } catch (inner) {// Ignore.
+              }
+            }
+          }
+        } // Create a fake event type.
+
+
+        var evtType = "react-" + (name ? name : 'invokeguardedcallback'); // Attach our event handlers
+
+        window.addEventListener('error', handleWindowError);
+        fakeNode.addEventListener(evtType, callCallback, false); // Synchronously dispatch our fake event. If the user-provided function
+        // errors, it will trigger our global error handler.
+
+        evt.initEvent(evtType, false, false);
+        fakeNode.dispatchEvent(evt);
+
+        if (windowEventDescriptor) {
+          Object.defineProperty(window, 'event', windowEventDescriptor);
+        }
+
+        if (didError) {
+          if (!didSetError) {
+            // The callback errored, but the error event never fired.
+            error = new Error('An error was thrown inside one of your components, but React ' + "doesn't know what it was. This is likely due to browser " + 'flakiness. React does its best to preserve the "Pause on ' + 'exceptions" behavior of the DevTools, which requires some ' + "DEV-mode only tricks. It's possible that these don't work in " + 'your browser. Try triggering the error in production mode, ' + 'or switching to a modern browser. If you suspect that this is ' + 'actually an issue with React, please file an issue.');
+          } else if (isCrossOriginError) {
+            error = new Error("A cross-origin error was thrown. React doesn't have access to " + 'the actual error object in development. ' + 'See https://fb.me/react-crossorigin-error for more information.');
+          }
+
+          this.onError(error);
+        } // Remove our event listeners
+
+
+        window.removeEventListener('error', handleWindowError);
+      };
+
+      invokeGuardedCallbackImpl = invokeGuardedCallbackDev;
+    }
+  }
+
+  var invokeGuardedCallbackImpl$1 = invokeGuardedCallbackImpl;
+
+  var hasError = false;
+  var caughtError = null; // Used by event system to capture/rethrow the first error.
+
+  var hasRethrowError = false;
+  var rethrowError = null;
+  var reporter = {
+    onError: function (error) {
+      hasError = true;
+      caughtError = error;
+    }
+  };
+  /**
+   * Call a function while guarding against errors that happens within it.
+   * Returns an error if it throws, otherwise null.
+   *
+   * In production, this is implemented using a try-catch. The reason we don't
+   * use a try-catch directly is so that we can swap out a different
+   * implementation in DEV mode.
+   *
+   * @param {String} name of the guard to use for logging or debugging
+   * @param {Function} func The function to invoke
+   * @param {*} context The context to use when calling the function
+   * @param {...*} args Arguments for function
+   */
+
+  function invokeGuardedCallback(name, func, context, a, b, c, d, e, f) {
+    hasError = false;
+    caughtError = null;
+    invokeGuardedCallbackImpl$1.apply(reporter, arguments);
+  }
+  /**
+   * Same as invokeGuardedCallback, but instead of returning an error, it stores
+   * it in a global so it can be rethrown by `rethrowCaughtError` later.
+   * TODO: See if caughtError and rethrowError can be unified.
+   *
+   * @param {String} name of the guard to use for logging or debugging
+   * @param {Function} func The function to invoke
+   * @param {*} context The context to use when calling the function
+   * @param {...*} args Arguments for function
+   */
+
+  function invokeGuardedCallbackAndCatchFirstError(name, func, context, a, b, c, d, e, f) {
+    invokeGuardedCallback.apply(this, arguments);
+
+    if (hasError) {
+      var error = clearCaughtError();
+
+      if (!hasRethrowError) {
+        hasRethrowError = true;
+        rethrowError = error;
+      }
+    }
+  }
+  /**
+   * During execution of guarded functions we will capture the first error which
+   * we will rethrow to be handled by the top level error handler.
+   */
+
+  function rethrowCaughtError() {
+    if (hasRethrowError) {
+      var error = rethrowError;
+      hasRethrowError = false;
+      rethrowError = null;
+      throw error;
+    }
+  }
+  function hasCaughtError() {
+    return hasError;
+  }
+  function clearCaughtError() {
+    if (hasError) {
+      var error = caughtError;
+      hasError = false;
+      caughtError = null;
+      return error;
+    } else {
+      {
+        {
+          throw Error( "clearCaughtError was called but no error was captured. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+    }
+  }
+
+  var getFiberCurrentPropsFromNode = null;
+  var getInstanceFromNode = null;
+  var getNodeFromInstance = null;
+  function setComponentTree(getFiberCurrentPropsFromNodeImpl, getInstanceFromNodeImpl, getNodeFromInstanceImpl) {
+    getFiberCurrentPropsFromNode = getFiberCurrentPropsFromNodeImpl;
+    getInstanceFromNode = getInstanceFromNodeImpl;
+    getNodeFromInstance = getNodeFromInstanceImpl;
+
+    {
+      if (!getNodeFromInstance || !getInstanceFromNode) {
+        error('EventPluginUtils.setComponentTree(...): Injected ' + 'module is missing getNodeFromInstance or getInstanceFromNode.');
+      }
+    }
+  }
+  var validateEventDispatches;
+
+  {
+    validateEventDispatches = function (event) {
+      var dispatchListeners = event._dispatchListeners;
+      var dispatchInstances = event._dispatchInstances;
+      var listenersIsArr = Array.isArray(dispatchListeners);
+      var listenersLen = listenersIsArr ? dispatchListeners.length : dispatchListeners ? 1 : 0;
+      var instancesIsArr = Array.isArray(dispatchInstances);
+      var instancesLen = instancesIsArr ? dispatchInstances.length : dispatchInstances ? 1 : 0;
+
+      if (instancesIsArr !== listenersIsArr || instancesLen !== listenersLen) {
+        error('EventPluginUtils: Invalid `event`.');
+      }
+    };
+  }
+  /**
+   * Dispatch the event to the listener.
+   * @param {SyntheticEvent} event SyntheticEvent to handle
+   * @param {function} listener Application-level callback
+   * @param {*} inst Internal component instance
+   */
+
+
+  function executeDispatch(event, listener, inst) {
+    var type = event.type || 'unknown-event';
+    event.currentTarget = getNodeFromInstance(inst);
+    invokeGuardedCallbackAndCatchFirstError(type, listener, undefined, event);
+    event.currentTarget = null;
+  }
+  /**
+   * Standard/simple iteration through an event's collected dispatches.
+   */
+
+  function executeDispatchesInOrder(event) {
+    var dispatchListeners = event._dispatchListeners;
+    var dispatchInstances = event._dispatchInstances;
+
+    {
+      validateEventDispatches(event);
+    }
+
+    if (Array.isArray(dispatchListeners)) {
+      for (var i = 0; i < dispatchListeners.length; i++) {
+        if (event.isPropagationStopped()) {
+          break;
+        } // Listeners and Instances are two parallel arrays that are always in sync.
+
+
+        executeDispatch(event, dispatchListeners[i], dispatchInstances[i]);
+      }
+    } else if (dispatchListeners) {
+      executeDispatch(event, dispatchListeners, dispatchInstances);
+    }
+
+    event._dispatchListeners = null;
+    event._dispatchInstances = null;
+  }
+
+  var FunctionComponent = 0;
+  var ClassComponent = 1;
+  var IndeterminateComponent = 2; // Before we know whether it is function or class
+
+  var HostRoot = 3; // Root of a host tree. Could be nested inside another node.
+
+  var HostPortal = 4; // A subtree. Could be an entry point to a different renderer.
+
+  var HostComponent = 5;
+  var HostText = 6;
+  var Fragment = 7;
+  var Mode = 8;
+  var ContextConsumer = 9;
+  var ContextProvider = 10;
+  var ForwardRef = 11;
+  var Profiler = 12;
+  var SuspenseComponent = 13;
+  var MemoComponent = 14;
+  var SimpleMemoComponent = 15;
+  var LazyComponent = 16;
+  var IncompleteClassComponent = 17;
+  var DehydratedFragment = 18;
+  var SuspenseListComponent = 19;
+  var FundamentalComponent = 20;
+  var ScopeComponent = 21;
+  var Block = 22;
+
+  /**
+   * Injectable ordering of event plugins.
+   */
+  var eventPluginOrder = null;
+  /**
+   * Injectable mapping from names to event plugin modules.
+   */
+
+  var namesToPlugins = {};
+  /**
+   * Recomputes the plugin list using the injected plugins and plugin ordering.
+   *
+   * @private
+   */
+
+  function recomputePluginOrdering() {
+    if (!eventPluginOrder) {
+      // Wait until an `eventPluginOrder` is injected.
+      return;
+    }
+
+    for (var pluginName in namesToPlugins) {
+      var pluginModule = namesToPlugins[pluginName];
+      var pluginIndex = eventPluginOrder.indexOf(pluginName);
+
+      if (!(pluginIndex > -1)) {
+        {
+          throw Error( "EventPluginRegistry: Cannot inject event plugins that do not exist in the plugin ordering, `" + pluginName + "`." );
+        }
+      }
+
+      if (plugins[pluginIndex]) {
+        continue;
+      }
+
+      if (!pluginModule.extractEvents) {
+        {
+          throw Error( "EventPluginRegistry: Event plugins must implement an `extractEvents` method, but `" + pluginName + "` does not." );
+        }
+      }
+
+      plugins[pluginIndex] = pluginModule;
+      var publishedEvents = pluginModule.eventTypes;
+
+      for (var eventName in publishedEvents) {
+        if (!publishEventForPlugin(publishedEvents[eventName], pluginModule, eventName)) {
+          {
+            throw Error( "EventPluginRegistry: Failed to publish event `" + eventName + "` for plugin `" + pluginName + "`." );
+          }
+        }
+      }
+    }
+  }
+  /**
+   * Publishes an event so that it can be dispatched by the supplied plugin.
+   *
+   * @param {object} dispatchConfig Dispatch configuration for the event.
+   * @param {object} PluginModule Plugin publishing the event.
+   * @return {boolean} True if the event was successfully published.
+   * @private
+   */
+
+
+  function publishEventForPlugin(dispatchConfig, pluginModule, eventName) {
+    if (!!eventNameDispatchConfigs.hasOwnProperty(eventName)) {
+      {
+        throw Error( "EventPluginRegistry: More than one plugin attempted to publish the same event name, `" + eventName + "`." );
+      }
+    }
+
+    eventNameDispatchConfigs[eventName] = dispatchConfig;
+    var phasedRegistrationNames = dispatchConfig.phasedRegistrationNames;
+
+    if (phasedRegistrationNames) {
+      for (var phaseName in phasedRegistrationNames) {
+        if (phasedRegistrationNames.hasOwnProperty(phaseName)) {
+          var phasedRegistrationName = phasedRegistrationNames[phaseName];
+          publishRegistrationName(phasedRegistrationName, pluginModule, eventName);
+        }
+      }
+
+      return true;
+    } else if (dispatchConfig.registrationName) {
+      publishRegistrationName(dispatchConfig.registrationName, pluginModule, eventName);
+      return true;
+    }
+
+    return false;
+  }
+  /**
+   * Publishes a registration name that is used to identify dispatched events.
+   *
+   * @param {string} registrationName Registration name to add.
+   * @param {object} PluginModule Plugin publishing the event.
+   * @private
+   */
+
+
+  function publishRegistrationName(registrationName, pluginModule, eventName) {
+    if (!!registrationNameModules[registrationName]) {
+      {
+        throw Error( "EventPluginRegistry: More than one plugin attempted to publish the same registration name, `" + registrationName + "`." );
+      }
+    }
+
+    registrationNameModules[registrationName] = pluginModule;
+    registrationNameDependencies[registrationName] = pluginModule.eventTypes[eventName].dependencies;
+
+    {
+      var lowerCasedName = registrationName.toLowerCase();
+      possibleRegistrationNames[lowerCasedName] = registrationName;
+
+      if (registrationName === 'onDoubleClick') {
+        possibleRegistrationNames.ondblclick = registrationName;
+      }
+    }
+  }
+  /**
+   * Registers plugins so that they can extract and dispatch events.
+   */
+
+  /**
+   * Ordered list of injected plugins.
+   */
+
+
+  var plugins = [];
+  /**
+   * Mapping from event name to dispatch config
+   */
+
+  var eventNameDispatchConfigs = {};
+  /**
+   * Mapping from registration name to plugin module
+   */
+
+  var registrationNameModules = {};
+  /**
+   * Mapping from registration name to event name
+   */
+
+  var registrationNameDependencies = {};
+  /**
+   * Mapping from lowercase registration names to the properly cased version,
+   * used to warn in the case of missing event handlers. Available
+   * only in true.
+   * @type {Object}
+   */
+
+  var possibleRegistrationNames =  {} ; // Trust the developer to only use possibleRegistrationNames in true
+
+  /**
+   * Injects an ordering of plugins (by plugin name). This allows the ordering
+   * to be decoupled from injection of the actual plugins so that ordering is
+   * always deterministic regardless of packaging, on-the-fly injection, etc.
+   *
+   * @param {array} InjectedEventPluginOrder
+   * @internal
+   */
+
+  function injectEventPluginOrder(injectedEventPluginOrder) {
+    if (!!eventPluginOrder) {
+      {
+        throw Error( "EventPluginRegistry: Cannot inject event plugin ordering more than once. You are likely trying to load more than one copy of React." );
+      }
+    } // Clone the ordering so it cannot be dynamically mutated.
+
+
+    eventPluginOrder = Array.prototype.slice.call(injectedEventPluginOrder);
+    recomputePluginOrdering();
+  }
+  /**
+   * Injects plugins to be used by plugin event system. The plugin names must be
+   * in the ordering injected by `injectEventPluginOrder`.
+   *
+   * Plugins can be injected as part of page initialization or on-the-fly.
+   *
+   * @param {object} injectedNamesToPlugins Map from names to plugin modules.
+   * @internal
+   */
+
+  function injectEventPluginsByName(injectedNamesToPlugins) {
+    var isOrderingDirty = false;
+
+    for (var pluginName in injectedNamesToPlugins) {
+      if (!injectedNamesToPlugins.hasOwnProperty(pluginName)) {
+        continue;
+      }
+
+      var pluginModule = injectedNamesToPlugins[pluginName];
+
+      if (!namesToPlugins.hasOwnProperty(pluginName) || namesToPlugins[pluginName] !== pluginModule) {
+        if (!!namesToPlugins[pluginName]) {
+          {
+            throw Error( "EventPluginRegistry: Cannot inject two different event plugins using the same name, `" + pluginName + "`." );
+          }
+        }
+
+        namesToPlugins[pluginName] = pluginModule;
+        isOrderingDirty = true;
+      }
+    }
+
+    if (isOrderingDirty) {
+      recomputePluginOrdering();
+    }
+  }
+
+  var canUseDOM = !!(typeof window !== 'undefined' && typeof window.document !== 'undefined' && typeof window.document.createElement !== 'undefined');
+
+  var ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+  var _assign = ReactInternals.assign;
+
+  var PLUGIN_EVENT_SYSTEM = 1;
+  var IS_REPLAYED = 1 << 5;
+  var IS_FIRST_ANCESTOR = 1 << 6;
+
+  var restoreImpl = null;
+  var restoreTarget = null;
+  var restoreQueue = null;
+
+  function restoreStateOfTarget(target) {
+    // We perform this translation at the end of the event loop so that we
+    // always receive the correct fiber here
+    var internalInstance = getInstanceFromNode(target);
+
+    if (!internalInstance) {
+      // Unmounted
+      return;
+    }
+
+    if (!(typeof restoreImpl === 'function')) {
+      {
+        throw Error( "setRestoreImplementation() needs to be called to handle a target for controlled events. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+
+    var stateNode = internalInstance.stateNode; // Guard against Fiber being unmounted.
+
+    if (stateNode) {
+      var _props = getFiberCurrentPropsFromNode(stateNode);
+
+      restoreImpl(internalInstance.stateNode, internalInstance.type, _props);
+    }
+  }
+
+  function setRestoreImplementation(impl) {
+    restoreImpl = impl;
+  }
+  function enqueueStateRestore(target) {
+    if (restoreTarget) {
+      if (restoreQueue) {
+        restoreQueue.push(target);
+      } else {
+        restoreQueue = [target];
+      }
+    } else {
+      restoreTarget = target;
+    }
+  }
+  function needsStateRestore() {
+    return restoreTarget !== null || restoreQueue !== null;
+  }
+  function restoreStateIfNeeded() {
+    if (!restoreTarget) {
+      return;
+    }
+
+    var target = restoreTarget;
+    var queuedTargets = restoreQueue;
+    restoreTarget = null;
+    restoreQueue = null;
+    restoreStateOfTarget(target);
+
+    if (queuedTargets) {
+      for (var i = 0; i < queuedTargets.length; i++) {
+        restoreStateOfTarget(queuedTargets[i]);
+      }
+    }
+  }
+
+  var enableProfilerTimer = true; // Trace which interactions trigger each commit.
+
+  var enableDeprecatedFlareAPI = false; // Experimental Host Component support.
+
+  var enableFundamentalAPI = false; // Experimental Scope support.
+  var warnAboutStringRefs = false;
+
+  // the renderer. Such as when we're dispatching events or if third party
+  // libraries need to call batchedUpdates. Eventually, this API will go away when
+  // everything is batched by default. We'll then have a similar API to opt-out of
+  // scheduled work and instead do synchronous work.
+  // Defaults
+
+  var batchedUpdatesImpl = function (fn, bookkeeping) {
+    return fn(bookkeeping);
+  };
+
+  var discreteUpdatesImpl = function (fn, a, b, c, d) {
+    return fn(a, b, c, d);
+  };
+
+  var flushDiscreteUpdatesImpl = function () {};
+
+  var batchedEventUpdatesImpl = batchedUpdatesImpl;
+  var isInsideEventHandler = false;
+  var isBatchingEventUpdates = false;
+
+  function finishEventHandler() {
+    // Here we wait until all updates have propagated, which is important
+    // when using controlled components within layers:
+    // https://github.com/facebook/react/issues/1698
+    // Then we restore state of any controlled component.
+    var controlledComponentsHavePendingUpdates = needsStateRestore();
+
+    if (controlledComponentsHavePendingUpdates) {
+      // If a controlled event was fired, we may need to restore the state of
+      // the DOM node back to the controlled value. This is necessary when React
+      // bails out of the update without touching the DOM.
+      flushDiscreteUpdatesImpl();
+      restoreStateIfNeeded();
+    }
+  }
+
+  function batchedUpdates(fn, bookkeeping) {
+    if (isInsideEventHandler) {
+      // If we are currently inside another batch, we need to wait until it
+      // fully completes before restoring state.
+      return fn(bookkeeping);
+    }
+
+    isInsideEventHandler = true;
+
+    try {
+      return batchedUpdatesImpl(fn, bookkeeping);
+    } finally {
+      isInsideEventHandler = false;
+      finishEventHandler();
+    }
+  }
+  function batchedEventUpdates(fn, a, b) {
+    if (isBatchingEventUpdates) {
+      // If we are currently inside another batch, we need to wait until it
+      // fully completes before restoring state.
+      return fn(a, b);
+    }
+
+    isBatchingEventUpdates = true;
+
+    try {
+      return batchedEventUpdatesImpl(fn, a, b);
+    } finally {
+      isBatchingEventUpdates = false;
+      finishEventHandler();
+    }
+  } // This is for the React Flare event system
+  function discreteUpdates(fn, a, b, c, d) {
+    var prevIsInsideEventHandler = isInsideEventHandler;
+    isInsideEventHandler = true;
+
+    try {
+      return discreteUpdatesImpl(fn, a, b, c, d);
+    } finally {
+      isInsideEventHandler = prevIsInsideEventHandler;
+
+      if (!isInsideEventHandler) {
+        finishEventHandler();
+      }
+    }
+  }
+  function flushDiscreteUpdatesIfNeeded(timeStamp) {
+    // event.timeStamp isn't overly reliable due to inconsistencies in
+    // how different browsers have historically provided the time stamp.
+    // Some browsers provide high-resolution time stamps for all events,
+    // some provide low-resolution time stamps for all events. FF < 52
+    // even mixes both time stamps together. Some browsers even report
+    // negative time stamps or time stamps that are 0 (iOS9) in some cases.
+    // Given we are only comparing two time stamps with equality (!==),
+    // we are safe from the resolution differences. If the time stamp is 0
+    // we bail-out of preventing the flush, which can affect semantics,
+    // such as if an earlier flush removes or adds event listeners that
+    // are fired in the subsequent flush. However, this is the same
+    // behaviour as we had before this change, so the risks are low.
+    if (!isInsideEventHandler && (!enableDeprecatedFlareAPI  )) {
+      flushDiscreteUpdatesImpl();
+    }
+  }
+  function setBatchingImplementation(_batchedUpdatesImpl, _discreteUpdatesImpl, _flushDiscreteUpdatesImpl, _batchedEventUpdatesImpl) {
+    batchedUpdatesImpl = _batchedUpdatesImpl;
+    discreteUpdatesImpl = _discreteUpdatesImpl;
+    flushDiscreteUpdatesImpl = _flushDiscreteUpdatesImpl;
+    batchedEventUpdatesImpl = _batchedEventUpdatesImpl;
+  }
+
+  var DiscreteEvent = 0;
+  var UserBlockingEvent = 1;
+  var ContinuousEvent = 2;
+
+  var ReactInternals$1 = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+  var _ReactInternals$Sched = ReactInternals$1.Scheduler,
+      unstable_cancelCallback = _ReactInternals$Sched.unstable_cancelCallback,
+      unstable_now = _ReactInternals$Sched.unstable_now,
+      unstable_scheduleCallback = _ReactInternals$Sched.unstable_scheduleCallback,
+      unstable_shouldYield = _ReactInternals$Sched.unstable_shouldYield,
+      unstable_requestPaint = _ReactInternals$Sched.unstable_requestPaint,
+      unstable_getFirstCallbackNode = _ReactInternals$Sched.unstable_getFirstCallbackNode,
+      unstable_runWithPriority = _ReactInternals$Sched.unstable_runWithPriority,
+      unstable_next = _ReactInternals$Sched.unstable_next,
+      unstable_continueExecution = _ReactInternals$Sched.unstable_continueExecution,
+      unstable_pauseExecution = _ReactInternals$Sched.unstable_pauseExecution,
+      unstable_getCurrentPriorityLevel = _ReactInternals$Sched.unstable_getCurrentPriorityLevel,
+      unstable_ImmediatePriority = _ReactInternals$Sched.unstable_ImmediatePriority,
+      unstable_UserBlockingPriority = _ReactInternals$Sched.unstable_UserBlockingPriority,
+      unstable_NormalPriority = _ReactInternals$Sched.unstable_NormalPriority,
+      unstable_LowPriority = _ReactInternals$Sched.unstable_LowPriority,
+      unstable_IdlePriority = _ReactInternals$Sched.unstable_IdlePriority,
+      unstable_forceFrameRate = _ReactInternals$Sched.unstable_forceFrameRate,
+      unstable_flushAllWithoutAsserting = _ReactInternals$Sched.unstable_flushAllWithoutAsserting;
+
+  // A reserved attribute.
+  // It is handled by React separately and shouldn't be written to the DOM.
+  var RESERVED = 0; // A simple string attribute.
+  // Attributes that aren't in the whitelist are presumed to have this type.
+
+  var STRING = 1; // A string attribute that accepts booleans in React. In HTML, these are called
+  // "enumerated" attributes with "true" and "false" as possible values.
+  // When true, it should be set to a "true" string.
+  // When false, it should be set to a "false" string.
+
+  var BOOLEANISH_STRING = 2; // A real boolean attribute.
+  // When true, it should be present (set either to an empty string or its name).
+  // When false, it should be omitted.
+
+  var BOOLEAN = 3; // An attribute that can be used as a flag as well as with a value.
+  // When true, it should be present (set either to an empty string or its name).
+  // When false, it should be omitted.
+  // For any other value, should be present with that value.
+
+  var OVERLOADED_BOOLEAN = 4; // An attribute that must be numeric or parse as a numeric.
+  // When falsy, it should be removed.
+
+  var NUMERIC = 5; // An attribute that must be positive numeric or parse as a positive numeric.
+  // When falsy, it should be removed.
+
+  var POSITIVE_NUMERIC = 6;
+
+  /* eslint-disable max-len */
+  var ATTRIBUTE_NAME_START_CHAR = ":A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
+  /* eslint-enable max-len */
+
+  var ATTRIBUTE_NAME_CHAR = ATTRIBUTE_NAME_START_CHAR + "\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
+  var ROOT_ATTRIBUTE_NAME = 'data-reactroot';
+  var VALID_ATTRIBUTE_NAME_REGEX = new RegExp('^[' + ATTRIBUTE_NAME_START_CHAR + '][' + ATTRIBUTE_NAME_CHAR + ']*$');
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
+  var illegalAttributeNameCache = {};
+  var validatedAttributeNameCache = {};
+  function isAttributeNameSafe(attributeName) {
+    if (hasOwnProperty.call(validatedAttributeNameCache, attributeName)) {
+      return true;
+    }
+
+    if (hasOwnProperty.call(illegalAttributeNameCache, attributeName)) {
+      return false;
+    }
+
+    if (VALID_ATTRIBUTE_NAME_REGEX.test(attributeName)) {
+      validatedAttributeNameCache[attributeName] = true;
+      return true;
+    }
+
+    illegalAttributeNameCache[attributeName] = true;
+
+    {
+      error('Invalid attribute name: `%s`', attributeName);
+    }
+
+    return false;
+  }
+  function shouldIgnoreAttribute(name, propertyInfo, isCustomComponentTag) {
+    if (propertyInfo !== null) {
+      return propertyInfo.type === RESERVED;
+    }
+
+    if (isCustomComponentTag) {
+      return false;
+    }
+
+    if (name.length > 2 && (name[0] === 'o' || name[0] === 'O') && (name[1] === 'n' || name[1] === 'N')) {
+      return true;
+    }
+
+    return false;
+  }
+  function shouldRemoveAttributeWithWarning(name, value, propertyInfo, isCustomComponentTag) {
+    if (propertyInfo !== null && propertyInfo.type === RESERVED) {
+      return false;
+    }
+
+    switch (typeof value) {
+      case 'function': // $FlowIssue symbol is perfectly valid here
+
+      case 'symbol':
+        // eslint-disable-line
+        return true;
+
+      case 'boolean':
+        {
+          if (isCustomComponentTag) {
+            return false;
+          }
+
+          if (propertyInfo !== null) {
+            return !propertyInfo.acceptsBooleans;
+          } else {
+            var prefix = name.toLowerCase().slice(0, 5);
+            return prefix !== 'data-' && prefix !== 'aria-';
+          }
+        }
+
+      default:
+        return false;
+    }
+  }
+  function shouldRemoveAttribute(name, value, propertyInfo, isCustomComponentTag) {
+    if (value === null || typeof value === 'undefined') {
+      return true;
+    }
+
+    if (shouldRemoveAttributeWithWarning(name, value, propertyInfo, isCustomComponentTag)) {
+      return true;
+    }
+
+    if (isCustomComponentTag) {
+      return false;
+    }
+
+    if (propertyInfo !== null) {
+      switch (propertyInfo.type) {
+        case BOOLEAN:
+          return !value;
+
+        case OVERLOADED_BOOLEAN:
+          return value === false;
+
+        case NUMERIC:
+          return isNaN(value);
+
+        case POSITIVE_NUMERIC:
+          return isNaN(value) || value < 1;
+      }
+    }
+
+    return false;
+  }
+  function getPropertyInfo(name) {
+    return properties.hasOwnProperty(name) ? properties[name] : null;
+  }
+
+  function PropertyInfoRecord(name, type, mustUseProperty, attributeName, attributeNamespace, sanitizeURL) {
+    this.acceptsBooleans = type === BOOLEANISH_STRING || type === BOOLEAN || type === OVERLOADED_BOOLEAN;
+    this.attributeName = attributeName;
+    this.attributeNamespace = attributeNamespace;
+    this.mustUseProperty = mustUseProperty;
+    this.propertyName = name;
+    this.type = type;
+    this.sanitizeURL = sanitizeURL;
+  } // When adding attributes to this list, be sure to also add them to
+  // the `possibleStandardNames` module to ensure casing and incorrect
+  // name warnings.
+
+
+  var properties = {}; // These props are reserved by React. They shouldn't be written to the DOM.
+
+  var reservedProps = ['children', 'dangerouslySetInnerHTML', // TODO: This prevents the assignment of defaultValue to regular
+  // elements (not just inputs). Now that ReactDOMInput assigns to the
+  // defaultValue property -- do we need this?
+  'defaultValue', 'defaultChecked', 'innerHTML', 'suppressContentEditableWarning', 'suppressHydrationWarning', 'style'];
+
+  reservedProps.forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, RESERVED, false, // mustUseProperty
+    name, // attributeName
+    null, // attributeNamespace
+    false);
+  }); // A few React string attributes have a different name.
+  // This is a mapping from React prop names to the attribute names.
+
+  [['acceptCharset', 'accept-charset'], ['className', 'class'], ['htmlFor', 'for'], ['httpEquiv', 'http-equiv']].forEach(function (_ref) {
+    var name = _ref[0],
+        attributeName = _ref[1];
+    properties[name] = new PropertyInfoRecord(name, STRING, false, // mustUseProperty
+    attributeName, // attributeName
+    null, // attributeNamespace
+    false);
+  }); // These are "enumerated" HTML attributes that accept "true" and "false".
+  // In React, we let users pass `true` and `false` even though technically
+  // these aren't boolean attributes (they are coerced to strings).
+
+  ['contentEditable', 'draggable', 'spellCheck', 'value'].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, BOOLEANISH_STRING, false, // mustUseProperty
+    name.toLowerCase(), // attributeName
+    null, // attributeNamespace
+    false);
+  }); // These are "enumerated" SVG attributes that accept "true" and "false".
+  // In React, we let users pass `true` and `false` even though technically
+  // these aren't boolean attributes (they are coerced to strings).
+  // Since these are SVG attributes, their attribute names are case-sensitive.
+
+  ['autoReverse', 'externalResourcesRequired', 'focusable', 'preserveAlpha'].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, BOOLEANISH_STRING, false, // mustUseProperty
+    name, // attributeName
+    null, // attributeNamespace
+    false);
+  }); // These are HTML boolean attributes.
+
+  ['allowFullScreen', 'async', // Note: there is a special case that prevents it from being written to the DOM
+  // on the client side because the browsers are inconsistent. Instead we call focus().
+  'autoFocus', 'autoPlay', 'controls', 'default', 'defer', 'disabled', 'disablePictureInPicture', 'formNoValidate', 'hidden', 'loop', 'noModule', 'noValidate', 'open', 'playsInline', 'readOnly', 'required', 'reversed', 'scoped', 'seamless', // Microdata
+  'itemScope'].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, BOOLEAN, false, // mustUseProperty
+    name.toLowerCase(), // attributeName
+    null, // attributeNamespace
+    false);
+  }); // These are the few React props that we set as DOM properties
+  // rather than attributes. These are all booleans.
+
+  ['checked', // Note: `option.selected` is not updated if `select.multiple` is
+  // disabled with `removeAttribute`. We have special logic for handling this.
+  'multiple', 'muted', 'selected' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, BOOLEAN, true, // mustUseProperty
+    name, // attributeName
+    null, // attributeNamespace
+    false);
+  }); // These are HTML attributes that are "overloaded booleans": they behave like
+  // booleans, but can also accept a string value.
+
+  ['capture', 'download' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, OVERLOADED_BOOLEAN, false, // mustUseProperty
+    name, // attributeName
+    null, // attributeNamespace
+    false);
+  }); // These are HTML attributes that must be positive numbers.
+
+  ['cols', 'rows', 'size', 'span' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, POSITIVE_NUMERIC, false, // mustUseProperty
+    name, // attributeName
+    null, // attributeNamespace
+    false);
+  }); // These are HTML attributes that must be numbers.
+
+  ['rowSpan', 'start'].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, NUMERIC, false, // mustUseProperty
+    name.toLowerCase(), // attributeName
+    null, // attributeNamespace
+    false);
+  });
+  var CAMELIZE = /[\-\:]([a-z])/g;
+
+  var capitalize = function (token) {
+    return token[1].toUpperCase();
+  }; // This is a list of all SVG attributes that need special casing, namespacing,
+  // or boolean value assignment. Regular attributes that just accept strings
+  // and have the same names are omitted, just like in the HTML whitelist.
+  // Some of these attributes can be hard to find. This list was created by
+  // scraping the MDN documentation.
+
+
+  ['accent-height', 'alignment-baseline', 'arabic-form', 'baseline-shift', 'cap-height', 'clip-path', 'clip-rule', 'color-interpolation', 'color-interpolation-filters', 'color-profile', 'color-rendering', 'dominant-baseline', 'enable-background', 'fill-opacity', 'fill-rule', 'flood-color', 'flood-opacity', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', 'font-weight', 'glyph-name', 'glyph-orientation-horizontal', 'glyph-orientation-vertical', 'horiz-adv-x', 'horiz-origin-x', 'image-rendering', 'letter-spacing', 'lighting-color', 'marker-end', 'marker-mid', 'marker-start', 'overline-position', 'overline-thickness', 'paint-order', 'panose-1', 'pointer-events', 'rendering-intent', 'shape-rendering', 'stop-color', 'stop-opacity', 'strikethrough-position', 'strikethrough-thickness', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'text-anchor', 'text-decoration', 'text-rendering', 'underline-position', 'underline-thickness', 'unicode-bidi', 'unicode-range', 'units-per-em', 'v-alphabetic', 'v-hanging', 'v-ideographic', 'v-mathematical', 'vector-effect', 'vert-adv-y', 'vert-origin-x', 'vert-origin-y', 'word-spacing', 'writing-mode', 'xmlns:xlink', 'x-height' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (attributeName) {
+    var name = attributeName.replace(CAMELIZE, capitalize);
+    properties[name] = new PropertyInfoRecord(name, STRING, false, // mustUseProperty
+    attributeName, null, // attributeNamespace
+    false);
+  }); // String SVG attributes with the xlink namespace.
+
+  ['xlink:actuate', 'xlink:arcrole', 'xlink:role', 'xlink:show', 'xlink:title', 'xlink:type' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (attributeName) {
+    var name = attributeName.replace(CAMELIZE, capitalize);
+    properties[name] = new PropertyInfoRecord(name, STRING, false, // mustUseProperty
+    attributeName, 'http://www.w3.org/1999/xlink', false);
+  }); // String SVG attributes with the xml namespace.
+
+  ['xml:base', 'xml:lang', 'xml:space' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (attributeName) {
+    var name = attributeName.replace(CAMELIZE, capitalize);
+    properties[name] = new PropertyInfoRecord(name, STRING, false, // mustUseProperty
+    attributeName, 'http://www.w3.org/XML/1998/namespace', false);
+  }); // These attribute exists both in HTML and SVG.
+  // The attribute name is case-sensitive in SVG so we can't just use
+  // the React name like we do for attributes that exist only in HTML.
+
+  ['tabIndex', 'crossOrigin'].forEach(function (attributeName) {
+    properties[attributeName] = new PropertyInfoRecord(attributeName, STRING, false, // mustUseProperty
+    attributeName.toLowerCase(), // attributeName
+    null, // attributeNamespace
+    false);
+  }); // These attributes accept URLs. These must not allow javascript: URLS.
+  // These will also need to accept Trusted Types object in the future.
+
+  var xlinkHref = 'xlinkHref';
+  properties[xlinkHref] = new PropertyInfoRecord('xlinkHref', STRING, false, // mustUseProperty
+  'xlink:href', 'http://www.w3.org/1999/xlink', true);
+  ['src', 'href', 'action', 'formAction'].forEach(function (attributeName) {
+    properties[attributeName] = new PropertyInfoRecord(attributeName, STRING, false, // mustUseProperty
+    attributeName.toLowerCase(), // attributeName
+    null, // attributeNamespace
+    true);
+  });
+
+  var ReactDebugCurrentFrame = null;
+
+  {
+    ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+  } // A javascript: URL can contain leading C0 control or \u0020 SPACE,
+  // and any newline or tab are filtered out as if they're not part of the URL.
+  // https://url.spec.whatwg.org/#url-parsing
+  // Tab or newline are defined as \r\n\t:
+  // https://infra.spec.whatwg.org/#ascii-tab-or-newline
+  // A C0 control is a code point in the range \u0000 NULL to \u001F
+  // INFORMATION SEPARATOR ONE, inclusive:
+  // https://infra.spec.whatwg.org/#c0-control-or-space
+
+  /* eslint-disable max-len */
+
+
+  var isJavaScriptProtocol = /^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*\:/i;
+  var didWarn = false;
+
+  function sanitizeURL(url) {
+    {
+      if (!didWarn && isJavaScriptProtocol.test(url)) {
+        didWarn = true;
+
+        error('A future version of React will block javascript: URLs as a security precaution. ' + 'Use event handlers instead if you can. If you need to generate unsafe HTML try ' + 'using dangerouslySetInnerHTML instead. React was passed %s.', JSON.stringify(url));
+      }
+    }
+  }
+
+  /**
+   * Get the value for a property on a node. Only used in DEV for SSR validation.
+   * The "expected" argument is used as a hint of what the expected value is.
+   * Some properties have multiple equivalent values.
+   */
+  function getValueForProperty(node, name, expected, propertyInfo) {
+    {
+      if (propertyInfo.mustUseProperty) {
+        var propertyName = propertyInfo.propertyName;
+        return node[propertyName];
+      } else {
+        if ( propertyInfo.sanitizeURL) {
+          // If we haven't fully disabled javascript: URLs, and if
+          // the hydration is successful of a javascript: URL, we
+          // still want to warn on the client.
+          sanitizeURL('' + expected);
+        }
+
+        var attributeName = propertyInfo.attributeName;
+        var stringValue = null;
+
+        if (propertyInfo.type === OVERLOADED_BOOLEAN) {
+          if (node.hasAttribute(attributeName)) {
+            var value = node.getAttribute(attributeName);
+
+            if (value === '') {
+              return true;
+            }
+
+            if (shouldRemoveAttribute(name, expected, propertyInfo, false)) {
+              return value;
+            }
+
+            if (value === '' + expected) {
+              return expected;
+            }
+
+            return value;
+          }
+        } else if (node.hasAttribute(attributeName)) {
+          if (shouldRemoveAttribute(name, expected, propertyInfo, false)) {
+            // We had an attribute but shouldn't have had one, so read it
+            // for the error message.
+            return node.getAttribute(attributeName);
+          }
+
+          if (propertyInfo.type === BOOLEAN) {
+            // If this was a boolean, it doesn't matter what the value is
+            // the fact that we have it is the same as the expected.
+            return expected;
+          } // Even if this property uses a namespace we use getAttribute
+          // because we assume its namespaced name is the same as our config.
+          // To use getAttributeNS we need the local name which we don't have
+          // in our config atm.
+
+
+          stringValue = node.getAttribute(attributeName);
+        }
+
+        if (shouldRemoveAttribute(name, expected, propertyInfo, false)) {
+          return stringValue === null ? expected : stringValue;
+        } else if (stringValue === '' + expected) {
+          return expected;
+        } else {
+          return stringValue;
+        }
+      }
+    }
+  }
+  /**
+   * Get the value for a attribute on a node. Only used in DEV for SSR validation.
+   * The third argument is used as a hint of what the expected value is. Some
+   * attributes have multiple equivalent values.
+   */
+
+  function getValueForAttribute(node, name, expected) {
+    {
+      if (!isAttributeNameSafe(name)) {
+        return;
+      }
+
+      if (!node.hasAttribute(name)) {
+        return expected === undefined ? undefined : null;
+      }
+
+      var value = node.getAttribute(name);
+
+      if (value === '' + expected) {
+        return expected;
+      }
+
+      return value;
+    }
+  }
+  /**
+   * Sets the value for a property on a node.
+   *
+   * @param {DOMElement} node
+   * @param {string} name
+   * @param {*} value
+   */
+
+  function setValueForProperty(node, name, value, isCustomComponentTag) {
+    var propertyInfo = getPropertyInfo(name);
+
+    if (shouldIgnoreAttribute(name, propertyInfo, isCustomComponentTag)) {
+      return;
+    }
+
+    if (shouldRemoveAttribute(name, value, propertyInfo, isCustomComponentTag)) {
+      value = null;
+    } // If the prop isn't in the special list, treat it as a simple attribute.
+
+
+    if (isCustomComponentTag || propertyInfo === null) {
+      if (isAttributeNameSafe(name)) {
+        var _attributeName = name;
+
+        if (value === null) {
+          node.removeAttribute(_attributeName);
+        } else {
+          node.setAttribute(_attributeName,  '' + value);
+        }
+      }
+
+      return;
+    }
+
+    var mustUseProperty = propertyInfo.mustUseProperty;
+
+    if (mustUseProperty) {
+      var propertyName = propertyInfo.propertyName;
+
+      if (value === null) {
+        var type = propertyInfo.type;
+        node[propertyName] = type === BOOLEAN ? false : '';
+      } else {
+        // Contrary to `setAttribute`, object properties are properly
+        // `toString`ed by IE8/9.
+        node[propertyName] = value;
+      }
+
+      return;
+    } // The rest are treated as attributes with special cases.
+
+
+    var attributeName = propertyInfo.attributeName,
+        attributeNamespace = propertyInfo.attributeNamespace;
+
+    if (value === null) {
+      node.removeAttribute(attributeName);
+    } else {
+      var _type = propertyInfo.type;
+      var attributeValue;
+
+      if (_type === BOOLEAN || _type === OVERLOADED_BOOLEAN && value === true) {
+        // If attribute type is boolean, we know for sure it won't be an execution sink
+        // and we won't require Trusted Type here.
+        attributeValue = '';
+      } else {
+        // `setAttribute` with objects becomes only `[object]` in IE8/9,
+        // ('' + value) makes it output the correct toString()-value.
+        {
+          attributeValue = '' + value;
+        }
+
+        if (propertyInfo.sanitizeURL) {
+          sanitizeURL(attributeValue.toString());
+        }
+      }
+
+      if (attributeNamespace) {
+        node.setAttributeNS(attributeNamespace, attributeName, attributeValue);
+      } else {
+        node.setAttribute(attributeName, attributeValue);
+      }
+    }
+  }
+
+  var BEFORE_SLASH_RE = /^(.*)[\\\/]/;
+  function describeComponentFrame (name, source, ownerName) {
+    var sourceInfo = '';
+
+    if (source) {
+      var path = source.fileName;
+      var fileName = path.replace(BEFORE_SLASH_RE, '');
+
+      {
+        // In DEV, include code for a common special case:
+        // prefer "folder/index.js" instead of just "index.js".
+        if (/^index\./.test(fileName)) {
+          var match = path.match(BEFORE_SLASH_RE);
+
+          if (match) {
+            var pathBeforeSlash = match[1];
+
+            if (pathBeforeSlash) {
+              var folderName = pathBeforeSlash.replace(BEFORE_SLASH_RE, '');
+              fileName = folderName + '/' + fileName;
+            }
+          }
+        }
+      }
+
+      sourceInfo = ' (at ' + fileName + ':' + source.lineNumber + ')';
+    } else if (ownerName) {
+      sourceInfo = ' (created by ' + ownerName + ')';
+    }
+
+    return '\n    in ' + (name || 'Unknown') + sourceInfo;
+  }
+
+  // The Symbol used to tag the ReactElement-like types. If there is no native Symbol
+  // nor polyfill, then a plain number is used for performance.
+  var hasSymbol = typeof Symbol === 'function' && Symbol.for;
+  var REACT_ELEMENT_TYPE = hasSymbol ? Symbol.for('react.element') : 0xeac7;
+  var REACT_PORTAL_TYPE = hasSymbol ? Symbol.for('react.portal') : 0xeaca;
+  var REACT_FRAGMENT_TYPE = hasSymbol ? Symbol.for('react.fragment') : 0xeacb;
+  var REACT_STRICT_MODE_TYPE = hasSymbol ? Symbol.for('react.strict_mode') : 0xeacc;
+  var REACT_PROFILER_TYPE = hasSymbol ? Symbol.for('react.profiler') : 0xead2;
+  var REACT_PROVIDER_TYPE = hasSymbol ? Symbol.for('react.provider') : 0xeacd;
+  var REACT_CONTEXT_TYPE = hasSymbol ? Symbol.for('react.context') : 0xeace; // TODO: We don't use AsyncMode or ConcurrentMode anymore. They were temporary
+  var REACT_CONCURRENT_MODE_TYPE = hasSymbol ? Symbol.for('react.concurrent_mode') : 0xeacf;
+  var REACT_FORWARD_REF_TYPE = hasSymbol ? Symbol.for('react.forward_ref') : 0xead0;
+  var REACT_SUSPENSE_TYPE = hasSymbol ? Symbol.for('react.suspense') : 0xead1;
+  var REACT_SUSPENSE_LIST_TYPE = hasSymbol ? Symbol.for('react.suspense_list') : 0xead8;
+  var REACT_MEMO_TYPE = hasSymbol ? Symbol.for('react.memo') : 0xead3;
+  var REACT_LAZY_TYPE = hasSymbol ? Symbol.for('react.lazy') : 0xead4;
+  var REACT_BLOCK_TYPE = hasSymbol ? Symbol.for('react.block') : 0xead9;
+  var MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+  var FAUX_ITERATOR_SYMBOL = '@@iterator';
+  function getIteratorFn(maybeIterable) {
+    if (maybeIterable === null || typeof maybeIterable !== 'object') {
+      return null;
+    }
+
+    var maybeIterator = MAYBE_ITERATOR_SYMBOL && maybeIterable[MAYBE_ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL];
+
+    if (typeof maybeIterator === 'function') {
+      return maybeIterator;
+    }
+
+    return null;
+  }
+
+  var Uninitialized = -1;
+  var Pending = 0;
+  var Resolved = 1;
+  var Rejected = 2;
+  function refineResolvedLazyComponent(lazyComponent) {
+    return lazyComponent._status === Resolved ? lazyComponent._result : null;
+  }
+  function initializeLazyComponentType(lazyComponent) {
+    if (lazyComponent._status === Uninitialized) {
+      lazyComponent._status = Pending;
+      var ctor = lazyComponent._ctor;
+      var thenable = ctor();
+      lazyComponent._result = thenable;
+      thenable.then(function (moduleObject) {
+        if (lazyComponent._status === Pending) {
+          var defaultExport = moduleObject.default;
+
+          {
+            if (defaultExport === undefined) {
+              error('lazy: Expected the result of a dynamic import() call. ' + 'Instead received: %s\n\nYour code should look like: \n  ' + "const MyComponent = lazy(() => import('./MyComponent'))", moduleObject);
+            }
+          }
+
+          lazyComponent._status = Resolved;
+          lazyComponent._result = defaultExport;
+        }
+      }, function (error) {
+        if (lazyComponent._status === Pending) {
+          lazyComponent._status = Rejected;
+          lazyComponent._result = error;
+        }
+      });
+    }
+  }
+
+  function getWrappedName(outerType, innerType, wrapperName) {
+    var functionName = innerType.displayName || innerType.name || '';
+    return outerType.displayName || (functionName !== '' ? wrapperName + "(" + functionName + ")" : wrapperName);
+  }
+
+  function getComponentName(type) {
+    if (type == null) {
+      // Host root, text node or just invalid type.
+      return null;
+    }
+
+    {
+      if (typeof type.tag === 'number') {
+        error('Received an unexpected object in getComponentName(). ' + 'This is likely a bug in React. Please file an issue.');
+      }
+    }
+
+    if (typeof type === 'function') {
+      return type.displayName || type.name || null;
+    }
+
+    if (typeof type === 'string') {
+      return type;
+    }
+
+    switch (type) {
+      case REACT_FRAGMENT_TYPE:
+        return 'Fragment';
+
+      case REACT_PORTAL_TYPE:
+        return 'Portal';
+
+      case REACT_PROFILER_TYPE:
+        return "Profiler";
+
+      case REACT_STRICT_MODE_TYPE:
+        return 'StrictMode';
+
+      case REACT_SUSPENSE_TYPE:
+        return 'Suspense';
+
+      case REACT_SUSPENSE_LIST_TYPE:
+        return 'SuspenseList';
+    }
+
+    if (typeof type === 'object') {
+      switch (type.$$typeof) {
+        case REACT_CONTEXT_TYPE:
+          return 'Context.Consumer';
+
+        case REACT_PROVIDER_TYPE:
+          return 'Context.Provider';
+
+        case REACT_FORWARD_REF_TYPE:
+          return getWrappedName(type, type.render, 'ForwardRef');
+
+        case REACT_MEMO_TYPE:
+          return getComponentName(type.type);
+
+        case REACT_BLOCK_TYPE:
+          return getComponentName(type.render);
+
+        case REACT_LAZY_TYPE:
+          {
+            var thenable = type;
+            var resolvedThenable = refineResolvedLazyComponent(thenable);
+
+            if (resolvedThenable) {
+              return getComponentName(resolvedThenable);
+            }
+
+            break;
+          }
+      }
+    }
+
+    return null;
+  }
+
+  var ReactDebugCurrentFrame$1 = ReactSharedInternals.ReactDebugCurrentFrame;
+
+  function describeFiber(fiber) {
+    switch (fiber.tag) {
+      case HostRoot:
+      case HostPortal:
+      case HostText:
+      case Fragment:
+      case ContextProvider:
+      case ContextConsumer:
+        return '';
+
+      default:
+        var owner = fiber._debugOwner;
+        var source = fiber._debugSource;
+        var name = getComponentName(fiber.type);
+        var ownerName = null;
+
+        if (owner) {
+          ownerName = getComponentName(owner.type);
+        }
+
+        return describeComponentFrame(name, source, ownerName);
+    }
+  }
+
+  function getStackByFiberInDevAndProd(workInProgress) {
+    var info = '';
+    var node = workInProgress;
+
+    do {
+      info += describeFiber(node);
+      node = node.return;
+    } while (node);
+
+    return info;
+  }
+  var current = null;
+  var isRendering = false;
+  function getCurrentFiberOwnerNameInDevOrNull() {
+    {
+      if (current === null) {
+        return null;
+      }
+
+      var owner = current._debugOwner;
+
+      if (owner !== null && typeof owner !== 'undefined') {
+        return getComponentName(owner.type);
+      }
+    }
+
+    return null;
+  }
+  function getCurrentFiberStackInDev() {
+    {
+      if (current === null) {
+        return '';
+      } // Safe because if current fiber exists, we are reconciling,
+      // and it is guaranteed to be the work-in-progress version.
+
+
+      return getStackByFiberInDevAndProd(current);
+    }
+  }
+  function resetCurrentFiber() {
+    {
+      ReactDebugCurrentFrame$1.getCurrentStack = null;
+      current = null;
+      isRendering = false;
+    }
+  }
+  function setCurrentFiber(fiber) {
+    {
+      ReactDebugCurrentFrame$1.getCurrentStack = getCurrentFiberStackInDev;
+      current = fiber;
+      isRendering = false;
+    }
+  }
+  function setIsRendering(rendering) {
+    {
+      isRendering = rendering;
+    }
+  }
+
+  // Flow does not allow string concatenation of most non-string types. To work
+  // around this limitation, we use an opaque type that can only be obtained by
+  // passing the value through getToStringValue first.
+  function toString(value) {
+    return '' + value;
+  }
+  function getToStringValue(value) {
+    switch (typeof value) {
+      case 'boolean':
+      case 'number':
+      case 'object':
+      case 'string':
+      case 'undefined':
+        return value;
+
+      default:
+        // function, symbol are assigned as empty strings
+        return '';
+    }
+  }
+
+  /**
+   * Copyright (c) 2013-present, Facebook, Inc.
+   *
+   * This source code is licensed under the MIT license found in the
+   * LICENSE file in the root directory of this source tree.
+   */
+
+  var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+
+  var ReactPropTypesSecret_1 = ReactPropTypesSecret;
+
+  var printWarning$1 = function() {};
+
+  {
+    var ReactPropTypesSecret$1 = ReactPropTypesSecret_1;
+    var loggedTypeFailures = {};
+    var has = Function.call.bind(Object.prototype.hasOwnProperty);
+
+    printWarning$1 = function(text) {
+      var message = 'Warning: ' + text;
+      if (typeof console !== 'undefined') {
+        console.error(message);
+      }
+      try {
+        // --- Welcome to debugging React ---
+        // This error was thrown as a convenience so that you can use this stack
+        // to find the callsite that caused this warning to fire.
+        throw new Error(message);
+      } catch (x) {}
+    };
+  }
+
+  /**
+   * Assert that the values match with the type specs.
+   * Error messages are memorized and will only be shown once.
+   *
+   * @param {object} typeSpecs Map of name to a ReactPropType
+   * @param {object} values Runtime values that need to be type-checked
+   * @param {string} location e.g. "prop", "context", "child context"
+   * @param {string} componentName Name of the component for error messages.
+   * @param {?Function} getStack Returns the component stack.
+   * @private
+   */
+  function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
+    {
+      for (var typeSpecName in typeSpecs) {
+        if (has(typeSpecs, typeSpecName)) {
+          var error;
+          // Prop type validation may throw. In case they do, we don't want to
+          // fail the render phase where it didn't fail before. So we log it.
+          // After these have been cleaned up, we'll let them throw.
+          try {
+            // This is intentionally an invariant that gets caught. It's the same
+            // behavior as without this statement except with a better message.
+            if (typeof typeSpecs[typeSpecName] !== 'function') {
+              var err = Error(
+                (componentName || 'React class') + ': ' + location + ' type `' + typeSpecName + '` is invalid; ' +
+                'it must be a function, usually from the `prop-types` package, but received `' + typeof typeSpecs[typeSpecName] + '`.'
+              );
+              err.name = 'Invariant Violation';
+              throw err;
+            }
+            error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret$1);
+          } catch (ex) {
+            error = ex;
+          }
+          if (error && !(error instanceof Error)) {
+            printWarning$1(
+              (componentName || 'React class') + ': type specification of ' +
+              location + ' `' + typeSpecName + '` is invalid; the type checker ' +
+              'function must return `null` or an `Error` but returned a ' + typeof error + '. ' +
+              'You may have forgotten to pass an argument to the type checker ' +
+              'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' +
+              'shape all require an argument).'
+            );
+          }
+          if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+            // Only monitor this failure once because there tends to be a lot of the
+            // same error.
+            loggedTypeFailures[error.message] = true;
+
+            var stack = getStack ? getStack() : '';
+
+            printWarning$1(
+              'Failed ' + location + ' type: ' + error.message + (stack != null ? stack : '')
+            );
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Resets warning cache when testing.
+   *
+   * @private
+   */
+  checkPropTypes.resetWarningCache = function() {
+    {
+      loggedTypeFailures = {};
+    }
+  };
+
+  var checkPropTypes_1 = checkPropTypes;
+
+  var ReactDebugCurrentFrame$2 = null;
+  var ReactControlledValuePropTypes = {
+    checkPropTypes: null
+  };
+
+  {
+    ReactDebugCurrentFrame$2 = ReactSharedInternals.ReactDebugCurrentFrame;
+    var hasReadOnlyValue = {
+      button: true,
+      checkbox: true,
+      image: true,
+      hidden: true,
+      radio: true,
+      reset: true,
+      submit: true
+    };
+    var propTypes = {
+      value: function (props, propName, componentName) {
+        if (hasReadOnlyValue[props.type] || props.onChange || props.readOnly || props.disabled || props[propName] == null || enableDeprecatedFlareAPI ) {
+          return null;
+        }
+
+        return new Error('You provided a `value` prop to a form field without an ' + '`onChange` handler. This will render a read-only field. If ' + 'the field should be mutable use `defaultValue`. Otherwise, ' + 'set either `onChange` or `readOnly`.');
+      },
+      checked: function (props, propName, componentName) {
+        if (props.onChange || props.readOnly || props.disabled || props[propName] == null || enableDeprecatedFlareAPI ) {
+          return null;
+        }
+
+        return new Error('You provided a `checked` prop to a form field without an ' + '`onChange` handler. This will render a read-only field. If ' + 'the field should be mutable use `defaultChecked`. Otherwise, ' + 'set either `onChange` or `readOnly`.');
+      }
+    };
+    /**
+     * Provide a linked `value` attribute for controlled forms. You should not use
+     * this outside of the ReactDOM controlled form components.
+     */
+
+    ReactControlledValuePropTypes.checkPropTypes = function (tagName, props) {
+      checkPropTypes_1(propTypes, props, 'prop', tagName, ReactDebugCurrentFrame$2.getStackAddendum);
+    };
+  }
+
+  function isCheckable(elem) {
+    var type = elem.type;
+    var nodeName = elem.nodeName;
+    return nodeName && nodeName.toLowerCase() === 'input' && (type === 'checkbox' || type === 'radio');
+  }
+
+  function getTracker(node) {
+    return node._valueTracker;
+  }
+
+  function detachTracker(node) {
+    node._valueTracker = null;
+  }
+
+  function getValueFromNode(node) {
+    var value = '';
+
+    if (!node) {
+      return value;
+    }
+
+    if (isCheckable(node)) {
+      value = node.checked ? 'true' : 'false';
+    } else {
+      value = node.value;
+    }
+
+    return value;
+  }
+
+  function trackValueOnNode(node) {
+    var valueField = isCheckable(node) ? 'checked' : 'value';
+    var descriptor = Object.getOwnPropertyDescriptor(node.constructor.prototype, valueField);
+    var currentValue = '' + node[valueField]; // if someone has already defined a value or Safari, then bail
+    // and don't track value will cause over reporting of changes,
+    // but it's better then a hard failure
+    // (needed for certain tests that spyOn input values and Safari)
+
+    if (node.hasOwnProperty(valueField) || typeof descriptor === 'undefined' || typeof descriptor.get !== 'function' || typeof descriptor.set !== 'function') {
+      return;
+    }
+
+    var get = descriptor.get,
+        set = descriptor.set;
+    Object.defineProperty(node, valueField, {
+      configurable: true,
+      get: function () {
+        return get.call(this);
+      },
+      set: function (value) {
+        currentValue = '' + value;
+        set.call(this, value);
+      }
+    }); // We could've passed this the first time
+    // but it triggers a bug in IE11 and Edge 14/15.
+    // Calling defineProperty() again should be equivalent.
+    // https://github.com/facebook/react/issues/11768
+
+    Object.defineProperty(node, valueField, {
+      enumerable: descriptor.enumerable
+    });
+    var tracker = {
+      getValue: function () {
+        return currentValue;
+      },
+      setValue: function (value) {
+        currentValue = '' + value;
+      },
+      stopTracking: function () {
+        detachTracker(node);
+        delete node[valueField];
+      }
+    };
+    return tracker;
+  }
+
+  function track(node) {
+    if (getTracker(node)) {
+      return;
+    } // TODO: Once it's just Fiber we can move this to node._wrapperState
+
+
+    node._valueTracker = trackValueOnNode(node);
+  }
+  function updateValueIfChanged(node) {
+    if (!node) {
+      return false;
+    }
+
+    var tracker = getTracker(node); // if there is no tracker at this point it's unlikely
+    // that trying again will succeed
+
+    if (!tracker) {
+      return true;
+    }
+
+    var lastValue = tracker.getValue();
+    var nextValue = getValueFromNode(node);
+
+    if (nextValue !== lastValue) {
+      tracker.setValue(nextValue);
+      return true;
+    }
+
+    return false;
+  }
+
+  var didWarnValueDefaultValue = false;
+  var didWarnCheckedDefaultChecked = false;
+  var didWarnControlledToUncontrolled = false;
+  var didWarnUncontrolledToControlled = false;
+
+  function isControlled(props) {
+    var usesChecked = props.type === 'checkbox' || props.type === 'radio';
+    return usesChecked ? props.checked != null : props.value != null;
+  }
+  /**
+   * Implements an <input> host component that allows setting these optional
+   * props: `checked`, `value`, `defaultChecked`, and `defaultValue`.
+   *
+   * If `checked` or `value` are not supplied (or null/undefined), user actions
+   * that affect the checked state or value will trigger updates to the element.
+   *
+   * If they are supplied (and not null/undefined), the rendered element will not
+   * trigger updates to the element. Instead, the props must change in order for
+   * the rendered element to be updated.
+   *
+   * The rendered element will be initialized as unchecked (or `defaultChecked`)
+   * with an empty value (or `defaultValue`).
+   *
+   * See http://www.w3.org/TR/2012/WD-html5-20121025/the-input-element.html
+   */
+
+
+  function getHostProps(element, props) {
+    var node = element;
+    var checked = props.checked;
+
+    var hostProps = _assign({}, props, {
+      defaultChecked: undefined,
+      defaultValue: undefined,
+      value: undefined,
+      checked: checked != null ? checked : node._wrapperState.initialChecked
+    });
+
+    return hostProps;
+  }
+  function initWrapperState(element, props) {
+    {
+      ReactControlledValuePropTypes.checkPropTypes('input', props);
+
+      if (props.checked !== undefined && props.defaultChecked !== undefined && !didWarnCheckedDefaultChecked) {
+        error('%s contains an input of type %s with both checked and defaultChecked props. ' + 'Input elements must be either controlled or uncontrolled ' + '(specify either the checked prop, or the defaultChecked prop, but not ' + 'both). Decide between using a controlled or uncontrolled input ' + 'element and remove one of these props. More info: ' + 'https://fb.me/react-controlled-components', getCurrentFiberOwnerNameInDevOrNull() || 'A component', props.type);
+
+        didWarnCheckedDefaultChecked = true;
+      }
+
+      if (props.value !== undefined && props.defaultValue !== undefined && !didWarnValueDefaultValue) {
+        error('%s contains an input of type %s with both value and defaultValue props. ' + 'Input elements must be either controlled or uncontrolled ' + '(specify either the value prop, or the defaultValue prop, but not ' + 'both). Decide between using a controlled or uncontrolled input ' + 'element and remove one of these props. More info: ' + 'https://fb.me/react-controlled-components', getCurrentFiberOwnerNameInDevOrNull() || 'A component', props.type);
+
+        didWarnValueDefaultValue = true;
+      }
+    }
+
+    var node = element;
+    var defaultValue = props.defaultValue == null ? '' : props.defaultValue;
+    node._wrapperState = {
+      initialChecked: props.checked != null ? props.checked : props.defaultChecked,
+      initialValue: getToStringValue(props.value != null ? props.value : defaultValue),
+      controlled: isControlled(props)
+    };
+  }
+  function updateChecked(element, props) {
+    var node = element;
+    var checked = props.checked;
+
+    if (checked != null) {
+      setValueForProperty(node, 'checked', checked, false);
+    }
+  }
+  function updateWrapper(element, props) {
+    var node = element;
+
+    {
+      var controlled = isControlled(props);
+
+      if (!node._wrapperState.controlled && controlled && !didWarnUncontrolledToControlled) {
+        error('A component is changing an uncontrolled input of type %s to be controlled. ' + 'Input elements should not switch from uncontrolled to controlled (or vice versa). ' + 'Decide between using a controlled or uncontrolled input ' + 'element for the lifetime of the component. More info: https://fb.me/react-controlled-components', props.type);
+
+        didWarnUncontrolledToControlled = true;
+      }
+
+      if (node._wrapperState.controlled && !controlled && !didWarnControlledToUncontrolled) {
+        error('A component is changing a controlled input of type %s to be uncontrolled. ' + 'Input elements should not switch from controlled to uncontrolled (or vice versa). ' + 'Decide between using a controlled or uncontrolled input ' + 'element for the lifetime of the component. More info: https://fb.me/react-controlled-components', props.type);
+
+        didWarnControlledToUncontrolled = true;
+      }
+    }
+
+    updateChecked(element, props);
+    var value = getToStringValue(props.value);
+    var type = props.type;
+
+    if (value != null) {
+      if (type === 'number') {
+        if (value === 0 && node.value === '' || // We explicitly want to coerce to number here if possible.
+        // eslint-disable-next-line
+        node.value != value) {
+          node.value = toString(value);
+        }
+      } else if (node.value !== toString(value)) {
+        node.value = toString(value);
+      }
+    } else if (type === 'submit' || type === 'reset') {
+      // Submit/reset inputs need the attribute removed completely to avoid
+      // blank-text buttons.
+      node.removeAttribute('value');
+      return;
+    }
+
+    {
+      // When syncing the value attribute, the value comes from a cascade of
+      // properties:
+      //  1. The value React property
+      //  2. The defaultValue React property
+      //  3. Otherwise there should be no change
+      if (props.hasOwnProperty('value')) {
+        setDefaultValue(node, props.type, value);
+      } else if (props.hasOwnProperty('defaultValue')) {
+        setDefaultValue(node, props.type, getToStringValue(props.defaultValue));
+      }
+    }
+
+    {
+      // When syncing the checked attribute, it only changes when it needs
+      // to be removed, such as transitioning from a checkbox into a text input
+      if (props.checked == null && props.defaultChecked != null) {
+        node.defaultChecked = !!props.defaultChecked;
+      }
+    }
+  }
+  function postMountWrapper(element, props, isHydrating) {
+    var node = element; // Do not assign value if it is already set. This prevents user text input
+    // from being lost during SSR hydration.
+
+    if (props.hasOwnProperty('value') || props.hasOwnProperty('defaultValue')) {
+      var type = props.type;
+      var isButton = type === 'submit' || type === 'reset'; // Avoid setting value attribute on submit/reset inputs as it overrides the
+      // default value provided by the browser. See: #12872
+
+      if (isButton && (props.value === undefined || props.value === null)) {
+        return;
+      }
+
+      var initialValue = toString(node._wrapperState.initialValue); // Do not assign value if it is already set. This prevents user text input
+      // from being lost during SSR hydration.
+
+      if (!isHydrating) {
+        {
+          // When syncing the value attribute, the value property should use
+          // the wrapperState._initialValue property. This uses:
+          //
+          //   1. The value React property when present
+          //   2. The defaultValue React property when present
+          //   3. An empty string
+          if (initialValue !== node.value) {
+            node.value = initialValue;
+          }
+        }
+      }
+
+      {
+        // Otherwise, the value attribute is synchronized to the property,
+        // so we assign defaultValue to the same thing as the value property
+        // assignment step above.
+        node.defaultValue = initialValue;
+      }
+    } // Normally, we'd just do `node.checked = node.checked` upon initial mount, less this bug
+    // this is needed to work around a chrome bug where setting defaultChecked
+    // will sometimes influence the value of checked (even after detachment).
+    // Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=608416
+    // We need to temporarily unset name to avoid disrupting radio button groups.
+
+
+    var name = node.name;
+
+    if (name !== '') {
+      node.name = '';
+    }
+
+    {
+      // When syncing the checked attribute, both the checked property and
+      // attribute are assigned at the same time using defaultChecked. This uses:
+      //
+      //   1. The checked React property when present
+      //   2. The defaultChecked React property when present
+      //   3. Otherwise, false
+      node.defaultChecked = !node.defaultChecked;
+      node.defaultChecked = !!node._wrapperState.initialChecked;
+    }
+
+    if (name !== '') {
+      node.name = name;
+    }
+  }
+  function restoreControlledState(element, props) {
+    var node = element;
+    updateWrapper(node, props);
+    updateNamedCousins(node, props);
+  }
+
+  function updateNamedCousins(rootNode, props) {
+    var name = props.name;
+
+    if (props.type === 'radio' && name != null) {
+      var queryRoot = rootNode;
+
+      while (queryRoot.parentNode) {
+        queryRoot = queryRoot.parentNode;
+      } // If `rootNode.form` was non-null, then we could try `form.elements`,
+      // but that sometimes behaves strangely in IE8. We could also try using
+      // `form.getElementsByName`, but that will only return direct children
+      // and won't include inputs that use the HTML5 `form=` attribute. Since
+      // the input might not even be in a form. It might not even be in the
+      // document. Let's just use the local `querySelectorAll` to ensure we don't
+      // miss anything.
+
+
+      var group = queryRoot.querySelectorAll('input[name=' + JSON.stringify('' + name) + '][type="radio"]');
+
+      for (var i = 0; i < group.length; i++) {
+        var otherNode = group[i];
+
+        if (otherNode === rootNode || otherNode.form !== rootNode.form) {
+          continue;
+        } // This will throw if radio buttons rendered by different copies of React
+        // and the same name are rendered into the same form (same as #1939).
+        // That's probably okay; we don't support it just as we don't support
+        // mixing React radio buttons with non-React ones.
+
+
+        var otherProps = getFiberCurrentPropsFromNode$1(otherNode);
+
+        if (!otherProps) {
+          {
+            throw Error( "ReactDOMInput: Mixing React and non-React radio inputs with the same `name` is not supported." );
+          }
+        } // We need update the tracked value on the named cousin since the value
+        // was changed but the input saw no event or value set
+
+
+        updateValueIfChanged(otherNode); // If this is a controlled radio button group, forcing the input that
+        // was previously checked to update will cause it to be come re-checked
+        // as appropriate.
+
+        updateWrapper(otherNode, otherProps);
+      }
+    }
+  } // In Chrome, assigning defaultValue to certain input types triggers input validation.
+  // For number inputs, the display value loses trailing decimal points. For email inputs,
+  // Chrome raises "The specified value <x> is not a valid email address".
+  //
+  // Here we check to see if the defaultValue has actually changed, avoiding these problems
+  // when the user is inputting text
+  //
+  // https://github.com/facebook/react/issues/7253
+
+
+  function setDefaultValue(node, type, value) {
+    if ( // Focused number inputs synchronize on blur. See ChangeEventPlugin.js
+    type !== 'number' || node.ownerDocument.activeElement !== node) {
+      if (value == null) {
+        node.defaultValue = toString(node._wrapperState.initialValue);
+      } else if (node.defaultValue !== toString(value)) {
+        node.defaultValue = toString(value);
+      }
+    }
+  }
+
+  var didWarnSelectedSetOnOption = false;
+  var didWarnInvalidChild = false;
+
+  function flattenChildren(children) {
+    var content = ''; // Flatten children. We'll warn if they are invalid
+    // during validateProps() which runs for hydration too.
+    // Note that this would throw on non-element objects.
+    // Elements are stringified (which is normally irrelevant
+    // but matters for <fbt>).
+
+    React.Children.forEach(children, function (child) {
+      if (child == null) {
+        return;
+      }
+
+      content += child; // Note: we don't warn about invalid children here.
+      // Instead, this is done separately below so that
+      // it happens during the hydration codepath too.
+    });
+    return content;
+  }
+  /**
+   * Implements an <option> host component that warns when `selected` is set.
+   */
+
+
+  function validateProps(element, props) {
+    {
+      // This mirrors the codepath above, but runs for hydration too.
+      // Warn about invalid children here so that client and hydration are consistent.
+      // TODO: this seems like it could cause a DEV-only throw for hydration
+      // if children contains a non-element object. We should try to avoid that.
+      if (typeof props.children === 'object' && props.children !== null) {
+        React.Children.forEach(props.children, function (child) {
+          if (child == null) {
+            return;
+          }
+
+          if (typeof child === 'string' || typeof child === 'number') {
+            return;
+          }
+
+          if (typeof child.type !== 'string') {
+            return;
+          }
+
+          if (!didWarnInvalidChild) {
+            didWarnInvalidChild = true;
+
+            error('Only strings and numbers are supported as <option> children.');
+          }
+        });
+      } // TODO: Remove support for `selected` in <option>.
+
+
+      if (props.selected != null && !didWarnSelectedSetOnOption) {
+        error('Use the `defaultValue` or `value` props on <select> instead of ' + 'setting `selected` on <option>.');
+
+        didWarnSelectedSetOnOption = true;
+      }
+    }
+  }
+  function postMountWrapper$1(element, props) {
+    // value="" should make a value attribute (#6219)
+    if (props.value != null) {
+      element.setAttribute('value', toString(getToStringValue(props.value)));
+    }
+  }
+  function getHostProps$1(element, props) {
+    var hostProps = _assign({
+      children: undefined
+    }, props);
+
+    var content = flattenChildren(props.children);
+
+    if (content) {
+      hostProps.children = content;
+    }
+
+    return hostProps;
+  }
+
+  var didWarnValueDefaultValue$1;
+
+  {
+    didWarnValueDefaultValue$1 = false;
+  }
+
+  function getDeclarationErrorAddendum() {
+    var ownerName = getCurrentFiberOwnerNameInDevOrNull();
+
+    if (ownerName) {
+      return '\n\nCheck the render method of `' + ownerName + '`.';
+    }
+
+    return '';
+  }
+
+  var valuePropNames = ['value', 'defaultValue'];
+  /**
+   * Validation function for `value` and `defaultValue`.
+   */
+
+  function checkSelectPropTypes(props) {
+    {
+      ReactControlledValuePropTypes.checkPropTypes('select', props);
+
+      for (var i = 0; i < valuePropNames.length; i++) {
+        var propName = valuePropNames[i];
+
+        if (props[propName] == null) {
+          continue;
+        }
+
+        var isArray = Array.isArray(props[propName]);
+
+        if (props.multiple && !isArray) {
+          error('The `%s` prop supplied to <select> must be an array if ' + '`multiple` is true.%s', propName, getDeclarationErrorAddendum());
+        } else if (!props.multiple && isArray) {
+          error('The `%s` prop supplied to <select> must be a scalar ' + 'value if `multiple` is false.%s', propName, getDeclarationErrorAddendum());
+        }
+      }
+    }
+  }
+
+  function updateOptions(node, multiple, propValue, setDefaultSelected) {
+    var options = node.options;
+
+    if (multiple) {
+      var selectedValues = propValue;
+      var selectedValue = {};
+
+      for (var i = 0; i < selectedValues.length; i++) {
+        // Prefix to avoid chaos with special keys.
+        selectedValue['$' + selectedValues[i]] = true;
+      }
+
+      for (var _i = 0; _i < options.length; _i++) {
+        var selected = selectedValue.hasOwnProperty('$' + options[_i].value);
+
+        if (options[_i].selected !== selected) {
+          options[_i].selected = selected;
+        }
+
+        if (selected && setDefaultSelected) {
+          options[_i].defaultSelected = true;
+        }
+      }
+    } else {
+      // Do not set `select.value` as exact behavior isn't consistent across all
+      // browsers for all cases.
+      var _selectedValue = toString(getToStringValue(propValue));
+
+      var defaultSelected = null;
+
+      for (var _i2 = 0; _i2 < options.length; _i2++) {
+        if (options[_i2].value === _selectedValue) {
+          options[_i2].selected = true;
+
+          if (setDefaultSelected) {
+            options[_i2].defaultSelected = true;
+          }
+
+          return;
+        }
+
+        if (defaultSelected === null && !options[_i2].disabled) {
+          defaultSelected = options[_i2];
+        }
+      }
+
+      if (defaultSelected !== null) {
+        defaultSelected.selected = true;
+      }
+    }
+  }
+  /**
+   * Implements a <select> host component that allows optionally setting the
+   * props `value` and `defaultValue`. If `multiple` is false, the prop must be a
+   * stringable. If `multiple` is true, the prop must be an array of stringables.
+   *
+   * If `value` is not supplied (or null/undefined), user actions that change the
+   * selected option will trigger updates to the rendered options.
+   *
+   * If it is supplied (and not null/undefined), the rendered options will not
+   * update in response to user actions. Instead, the `value` prop must change in
+   * order for the rendered options to update.
+   *
+   * If `defaultValue` is provided, any options with the supplied values will be
+   * selected.
+   */
+
+
+  function getHostProps$2(element, props) {
+    return _assign({}, props, {
+      value: undefined
+    });
+  }
+  function initWrapperState$1(element, props) {
+    var node = element;
+
+    {
+      checkSelectPropTypes(props);
+    }
+
+    node._wrapperState = {
+      wasMultiple: !!props.multiple
+    };
+
+    {
+      if (props.value !== undefined && props.defaultValue !== undefined && !didWarnValueDefaultValue$1) {
+        error('Select elements must be either controlled or uncontrolled ' + '(specify either the value prop, or the defaultValue prop, but not ' + 'both). Decide between using a controlled or uncontrolled select ' + 'element and remove one of these props. More info: ' + 'https://fb.me/react-controlled-components');
+
+        didWarnValueDefaultValue$1 = true;
+      }
+    }
+  }
+  function postMountWrapper$2(element, props) {
+    var node = element;
+    node.multiple = !!props.multiple;
+    var value = props.value;
+
+    if (value != null) {
+      updateOptions(node, !!props.multiple, value, false);
+    } else if (props.defaultValue != null) {
+      updateOptions(node, !!props.multiple, props.defaultValue, true);
+    }
+  }
+  function postUpdateWrapper(element, props) {
+    var node = element;
+    var wasMultiple = node._wrapperState.wasMultiple;
+    node._wrapperState.wasMultiple = !!props.multiple;
+    var value = props.value;
+
+    if (value != null) {
+      updateOptions(node, !!props.multiple, value, false);
+    } else if (wasMultiple !== !!props.multiple) {
+      // For simplicity, reapply `defaultValue` if `multiple` is toggled.
+      if (props.defaultValue != null) {
+        updateOptions(node, !!props.multiple, props.defaultValue, true);
+      } else {
+        // Revert the select back to its default unselected state.
+        updateOptions(node, !!props.multiple, props.multiple ? [] : '', false);
+      }
+    }
+  }
+  function restoreControlledState$1(element, props) {
+    var node = element;
+    var value = props.value;
+
+    if (value != null) {
+      updateOptions(node, !!props.multiple, value, false);
+    }
+  }
+
+  var didWarnValDefaultVal = false;
+
+  /**
+   * Implements a <textarea> host component that allows setting `value`, and
+   * `defaultValue`. This differs from the traditional DOM API because value is
+   * usually set as PCDATA children.
+   *
+   * If `value` is not supplied (or null/undefined), user actions that affect the
+   * value will trigger updates to the element.
+   *
+   * If `value` is supplied (and not null/undefined), the rendered element will
+   * not trigger updates to the element. Instead, the `value` prop must change in
+   * order for the rendered element to be updated.
+   *
+   * The rendered element will be initialized with an empty value, the prop
+   * `defaultValue` if specified, or the children content (deprecated).
+   */
+  function getHostProps$3(element, props) {
+    var node = element;
+
+    if (!(props.dangerouslySetInnerHTML == null)) {
+      {
+        throw Error( "`dangerouslySetInnerHTML` does not make sense on <textarea>." );
+      }
+    } // Always set children to the same thing. In IE9, the selection range will
+    // get reset if `textContent` is mutated.  We could add a check in setTextContent
+    // to only set the value if/when the value differs from the node value (which would
+    // completely solve this IE9 bug), but Sebastian+Sophie seemed to like this
+    // solution. The value can be a boolean or object so that's why it's forced
+    // to be a string.
+
+
+    var hostProps = _assign({}, props, {
+      value: undefined,
+      defaultValue: undefined,
+      children: toString(node._wrapperState.initialValue)
+    });
+
+    return hostProps;
+  }
+  function initWrapperState$2(element, props) {
+    var node = element;
+
+    {
+      ReactControlledValuePropTypes.checkPropTypes('textarea', props);
+
+      if (props.value !== undefined && props.defaultValue !== undefined && !didWarnValDefaultVal) {
+        error('%s contains a textarea with both value and defaultValue props. ' + 'Textarea elements must be either controlled or uncontrolled ' + '(specify either the value prop, or the defaultValue prop, but not ' + 'both). Decide between using a controlled or uncontrolled textarea ' + 'and remove one of these props. More info: ' + 'https://fb.me/react-controlled-components', getCurrentFiberOwnerNameInDevOrNull() || 'A component');
+
+        didWarnValDefaultVal = true;
+      }
+    }
+
+    var initialValue = props.value; // Only bother fetching default value if we're going to use it
+
+    if (initialValue == null) {
+      var children = props.children,
+          defaultValue = props.defaultValue;
+
+      if (children != null) {
+        {
+          error('Use the `defaultValue` or `value` props instead of setting ' + 'children on <textarea>.');
+        }
+
+        {
+          if (!(defaultValue == null)) {
+            {
+              throw Error( "If you supply `defaultValue` on a <textarea>, do not pass children." );
+            }
+          }
+
+          if (Array.isArray(children)) {
+            if (!(children.length <= 1)) {
+              {
+                throw Error( "<textarea> can only have at most one child." );
+              }
+            }
+
+            children = children[0];
+          }
+
+          defaultValue = children;
+        }
+      }
+
+      if (defaultValue == null) {
+        defaultValue = '';
+      }
+
+      initialValue = defaultValue;
+    }
+
+    node._wrapperState = {
+      initialValue: getToStringValue(initialValue)
+    };
+  }
+  function updateWrapper$1(element, props) {
+    var node = element;
+    var value = getToStringValue(props.value);
+    var defaultValue = getToStringValue(props.defaultValue);
+
+    if (value != null) {
+      // Cast `value` to a string to ensure the value is set correctly. While
+      // browsers typically do this as necessary, jsdom doesn't.
+      var newValue = toString(value); // To avoid side effects (such as losing text selection), only set value if changed
+
+      if (newValue !== node.value) {
+        node.value = newValue;
+      }
+
+      if (props.defaultValue == null && node.defaultValue !== newValue) {
+        node.defaultValue = newValue;
+      }
+    }
+
+    if (defaultValue != null) {
+      node.defaultValue = toString(defaultValue);
+    }
+  }
+  function postMountWrapper$3(element, props) {
+    var node = element; // This is in postMount because we need access to the DOM node, which is not
+    // available until after the component has mounted.
+
+    var textContent = node.textContent; // Only set node.value if textContent is equal to the expected
+    // initial value. In IE10/IE11 there is a bug where the placeholder attribute
+    // will populate textContent as well.
+    // https://developer.microsoft.com/microsoft-edge/platform/issues/101525/
+
+    if (textContent === node._wrapperState.initialValue) {
+      if (textContent !== '' && textContent !== null) {
+        node.value = textContent;
+      }
+    }
+  }
+  function restoreControlledState$2(element, props) {
+    // DOM component is still mounted; update
+    updateWrapper$1(element, props);
+  }
+
+  var HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+  var MATH_NAMESPACE = 'http://www.w3.org/1998/Math/MathML';
+  var SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+  var Namespaces = {
+    html: HTML_NAMESPACE,
+    mathml: MATH_NAMESPACE,
+    svg: SVG_NAMESPACE
+  }; // Assumes there is no parent namespace.
+
+  function getIntrinsicNamespace(type) {
+    switch (type) {
+      case 'svg':
+        return SVG_NAMESPACE;
+
+      case 'math':
+        return MATH_NAMESPACE;
+
+      default:
+        return HTML_NAMESPACE;
+    }
+  }
+  function getChildNamespace(parentNamespace, type) {
+    if (parentNamespace == null || parentNamespace === HTML_NAMESPACE) {
+      // No (or default) parent namespace: potential entry point.
+      return getIntrinsicNamespace(type);
+    }
+
+    if (parentNamespace === SVG_NAMESPACE && type === 'foreignObject') {
+      // We're leaving SVG.
+      return HTML_NAMESPACE;
+    } // By default, pass namespace below.
+
+
+    return parentNamespace;
+  }
+
+  /* globals MSApp */
+
+  /**
+   * Create a function which has 'unsafe' privileges (required by windows8 apps)
+   */
+  var createMicrosoftUnsafeLocalFunction = function (func) {
+    if (typeof MSApp !== 'undefined' && MSApp.execUnsafeLocalFunction) {
+      return function (arg0, arg1, arg2, arg3) {
+        MSApp.execUnsafeLocalFunction(function () {
+          return func(arg0, arg1, arg2, arg3);
+        });
+      };
+    } else {
+      return func;
+    }
+  };
+
+  var reusableSVGContainer;
+  /**
+   * Set the innerHTML property of a node
+   *
+   * @param {DOMElement} node
+   * @param {string} html
+   * @internal
+   */
+
+  var setInnerHTML = createMicrosoftUnsafeLocalFunction(function (node, html) {
+    if (node.namespaceURI === Namespaces.svg) {
+
+      if (!('innerHTML' in node)) {
+        // IE does not have innerHTML for SVG nodes, so instead we inject the
+        // new markup in a temp node and then move the child nodes across into
+        // the target node
+        reusableSVGContainer = reusableSVGContainer || document.createElement('div');
+        reusableSVGContainer.innerHTML = '<svg>' + html.valueOf().toString() + '</svg>';
+        var svgNode = reusableSVGContainer.firstChild;
+
+        while (node.firstChild) {
+          node.removeChild(node.firstChild);
+        }
+
+        while (svgNode.firstChild) {
+          node.appendChild(svgNode.firstChild);
+        }
+
+        return;
+      }
+    }
+
+    node.innerHTML = html;
+  });
+
+  /**
+   * HTML nodeType values that represent the type of the node
+   */
+  var ELEMENT_NODE = 1;
+  var TEXT_NODE = 3;
+  var COMMENT_NODE = 8;
+  var DOCUMENT_NODE = 9;
+  var DOCUMENT_FRAGMENT_NODE = 11;
+
+  /**
+   * Set the textContent property of a node. For text updates, it's faster
+   * to set the `nodeValue` of the Text node directly instead of using
+   * `.textContent` which will remove the existing node and create a new one.
+   *
+   * @param {DOMElement} node
+   * @param {string} text
+   * @internal
+   */
+
+  var setTextContent = function (node, text) {
+    if (text) {
+      var firstChild = node.firstChild;
+
+      if (firstChild && firstChild === node.lastChild && firstChild.nodeType === TEXT_NODE) {
+        firstChild.nodeValue = text;
+        return;
+      }
+    }
+
+    node.textContent = text;
+  };
+
+  // Do not use the below two methods directly!
+  // Instead use constants exported from DOMTopLevelEventTypes in ReactDOM.
+  // (It is the only module that is allowed to access these methods.)
+  function unsafeCastStringToDOMTopLevelType(topLevelType) {
+    return topLevelType;
+  }
+  function unsafeCastDOMTopLevelTypeToString(topLevelType) {
+    return topLevelType;
+  }
+
+  /**
+   * Generate a mapping of standard vendor prefixes using the defined style property and event name.
+   *
+   * @param {string} styleProp
+   * @param {string} eventName
+   * @returns {object}
+   */
+
+  function makePrefixMap(styleProp, eventName) {
+    var prefixes = {};
+    prefixes[styleProp.toLowerCase()] = eventName.toLowerCase();
+    prefixes['Webkit' + styleProp] = 'webkit' + eventName;
+    prefixes['Moz' + styleProp] = 'moz' + eventName;
+    return prefixes;
+  }
+  /**
+   * A list of event names to a configurable list of vendor prefixes.
+   */
+
+
+  var vendorPrefixes = {
+    animationend: makePrefixMap('Animation', 'AnimationEnd'),
+    animationiteration: makePrefixMap('Animation', 'AnimationIteration'),
+    animationstart: makePrefixMap('Animation', 'AnimationStart'),
+    transitionend: makePrefixMap('Transition', 'TransitionEnd')
+  };
+  /**
+   * Event names that have already been detected and prefixed (if applicable).
+   */
+
+  var prefixedEventNames = {};
+  /**
+   * Element to check for prefixes on.
+   */
+
+  var style = {};
+  /**
+   * Bootstrap if a DOM exists.
+   */
+
+  if (canUseDOM) {
+    style = document.createElement('div').style; // On some platforms, in particular some releases of Android 4.x,
+    // the un-prefixed "animation" and "transition" properties are defined on the
+    // style object but the events that fire will still be prefixed, so we need
+    // to check if the un-prefixed events are usable, and if not remove them from the map.
+
+    if (!('AnimationEvent' in window)) {
+      delete vendorPrefixes.animationend.animation;
+      delete vendorPrefixes.animationiteration.animation;
+      delete vendorPrefixes.animationstart.animation;
+    } // Same as above
+
+
+    if (!('TransitionEvent' in window)) {
+      delete vendorPrefixes.transitionend.transition;
+    }
+  }
+  /**
+   * Attempts to determine the correct vendor prefixed event name.
+   *
+   * @param {string} eventName
+   * @returns {string}
+   */
+
+
+  function getVendorPrefixedEventName(eventName) {
+    if (prefixedEventNames[eventName]) {
+      return prefixedEventNames[eventName];
+    } else if (!vendorPrefixes[eventName]) {
+      return eventName;
+    }
+
+    var prefixMap = vendorPrefixes[eventName];
+
+    for (var styleProp in prefixMap) {
+      if (prefixMap.hasOwnProperty(styleProp) && styleProp in style) {
+        return prefixedEventNames[eventName] = prefixMap[styleProp];
+      }
+    }
+
+    return eventName;
+  }
+
+  /**
+   * To identify top level events in ReactDOM, we use constants defined by this
+   * module. This is the only module that uses the unsafe* methods to express
+   * that the constants actually correspond to the browser event names. This lets
+   * us save some bundle size by avoiding a top level type -> event name map.
+   * The rest of ReactDOM code should import top level types from this file.
+   */
+
+  var TOP_ABORT = unsafeCastStringToDOMTopLevelType('abort');
+  var TOP_ANIMATION_END = unsafeCastStringToDOMTopLevelType(getVendorPrefixedEventName('animationend'));
+  var TOP_ANIMATION_ITERATION = unsafeCastStringToDOMTopLevelType(getVendorPrefixedEventName('animationiteration'));
+  var TOP_ANIMATION_START = unsafeCastStringToDOMTopLevelType(getVendorPrefixedEventName('animationstart'));
+  var TOP_BLUR = unsafeCastStringToDOMTopLevelType('blur');
+  var TOP_CAN_PLAY = unsafeCastStringToDOMTopLevelType('canplay');
+  var TOP_CAN_PLAY_THROUGH = unsafeCastStringToDOMTopLevelType('canplaythrough');
+  var TOP_CANCEL = unsafeCastStringToDOMTopLevelType('cancel');
+  var TOP_CHANGE = unsafeCastStringToDOMTopLevelType('change');
+  var TOP_CLICK = unsafeCastStringToDOMTopLevelType('click');
+  var TOP_CLOSE = unsafeCastStringToDOMTopLevelType('close');
+  var TOP_COMPOSITION_END = unsafeCastStringToDOMTopLevelType('compositionend');
+  var TOP_COMPOSITION_START = unsafeCastStringToDOMTopLevelType('compositionstart');
+  var TOP_COMPOSITION_UPDATE = unsafeCastStringToDOMTopLevelType('compositionupdate');
+  var TOP_CONTEXT_MENU = unsafeCastStringToDOMTopLevelType('contextmenu');
+  var TOP_COPY = unsafeCastStringToDOMTopLevelType('copy');
+  var TOP_CUT = unsafeCastStringToDOMTopLevelType('cut');
+  var TOP_DOUBLE_CLICK = unsafeCastStringToDOMTopLevelType('dblclick');
+  var TOP_AUX_CLICK = unsafeCastStringToDOMTopLevelType('auxclick');
+  var TOP_DRAG = unsafeCastStringToDOMTopLevelType('drag');
+  var TOP_DRAG_END = unsafeCastStringToDOMTopLevelType('dragend');
+  var TOP_DRAG_ENTER = unsafeCastStringToDOMTopLevelType('dragenter');
+  var TOP_DRAG_EXIT = unsafeCastStringToDOMTopLevelType('dragexit');
+  var TOP_DRAG_LEAVE = unsafeCastStringToDOMTopLevelType('dragleave');
+  var TOP_DRAG_OVER = unsafeCastStringToDOMTopLevelType('dragover');
+  var TOP_DRAG_START = unsafeCastStringToDOMTopLevelType('dragstart');
+  var TOP_DROP = unsafeCastStringToDOMTopLevelType('drop');
+  var TOP_DURATION_CHANGE = unsafeCastStringToDOMTopLevelType('durationchange');
+  var TOP_EMPTIED = unsafeCastStringToDOMTopLevelType('emptied');
+  var TOP_ENCRYPTED = unsafeCastStringToDOMTopLevelType('encrypted');
+  var TOP_ENDED = unsafeCastStringToDOMTopLevelType('ended');
+  var TOP_ERROR = unsafeCastStringToDOMTopLevelType('error');
+  var TOP_FOCUS = unsafeCastStringToDOMTopLevelType('focus');
+  var TOP_GOT_POINTER_CAPTURE = unsafeCastStringToDOMTopLevelType('gotpointercapture');
+  var TOP_INPUT = unsafeCastStringToDOMTopLevelType('input');
+  var TOP_INVALID = unsafeCastStringToDOMTopLevelType('invalid');
+  var TOP_KEY_DOWN = unsafeCastStringToDOMTopLevelType('keydown');
+  var TOP_KEY_PRESS = unsafeCastStringToDOMTopLevelType('keypress');
+  var TOP_KEY_UP = unsafeCastStringToDOMTopLevelType('keyup');
+  var TOP_LOAD = unsafeCastStringToDOMTopLevelType('load');
+  var TOP_LOAD_START = unsafeCastStringToDOMTopLevelType('loadstart');
+  var TOP_LOADED_DATA = unsafeCastStringToDOMTopLevelType('loadeddata');
+  var TOP_LOADED_METADATA = unsafeCastStringToDOMTopLevelType('loadedmetadata');
+  var TOP_LOST_POINTER_CAPTURE = unsafeCastStringToDOMTopLevelType('lostpointercapture');
+  var TOP_MOUSE_DOWN = unsafeCastStringToDOMTopLevelType('mousedown');
+  var TOP_MOUSE_MOVE = unsafeCastStringToDOMTopLevelType('mousemove');
+  var TOP_MOUSE_OUT = unsafeCastStringToDOMTopLevelType('mouseout');
+  var TOP_MOUSE_OVER = unsafeCastStringToDOMTopLevelType('mouseover');
+  var TOP_MOUSE_UP = unsafeCastStringToDOMTopLevelType('mouseup');
+  var TOP_PASTE = unsafeCastStringToDOMTopLevelType('paste');
+  var TOP_PAUSE = unsafeCastStringToDOMTopLevelType('pause');
+  var TOP_PLAY = unsafeCastStringToDOMTopLevelType('play');
+  var TOP_PLAYING = unsafeCastStringToDOMTopLevelType('playing');
+  var TOP_POINTER_CANCEL = unsafeCastStringToDOMTopLevelType('pointercancel');
+  var TOP_POINTER_DOWN = unsafeCastStringToDOMTopLevelType('pointerdown');
+  var TOP_POINTER_MOVE = unsafeCastStringToDOMTopLevelType('pointermove');
+  var TOP_POINTER_OUT = unsafeCastStringToDOMTopLevelType('pointerout');
+  var TOP_POINTER_OVER = unsafeCastStringToDOMTopLevelType('pointerover');
+  var TOP_POINTER_UP = unsafeCastStringToDOMTopLevelType('pointerup');
+  var TOP_PROGRESS = unsafeCastStringToDOMTopLevelType('progress');
+  var TOP_RATE_CHANGE = unsafeCastStringToDOMTopLevelType('ratechange');
+  var TOP_RESET = unsafeCastStringToDOMTopLevelType('reset');
+  var TOP_SCROLL = unsafeCastStringToDOMTopLevelType('scroll');
+  var TOP_SEEKED = unsafeCastStringToDOMTopLevelType('seeked');
+  var TOP_SEEKING = unsafeCastStringToDOMTopLevelType('seeking');
+  var TOP_SELECTION_CHANGE = unsafeCastStringToDOMTopLevelType('selectionchange');
+  var TOP_STALLED = unsafeCastStringToDOMTopLevelType('stalled');
+  var TOP_SUBMIT = unsafeCastStringToDOMTopLevelType('submit');
+  var TOP_SUSPEND = unsafeCastStringToDOMTopLevelType('suspend');
+  var TOP_TEXT_INPUT = unsafeCastStringToDOMTopLevelType('textInput');
+  var TOP_TIME_UPDATE = unsafeCastStringToDOMTopLevelType('timeupdate');
+  var TOP_TOGGLE = unsafeCastStringToDOMTopLevelType('toggle');
+  var TOP_TOUCH_CANCEL = unsafeCastStringToDOMTopLevelType('touchcancel');
+  var TOP_TOUCH_END = unsafeCastStringToDOMTopLevelType('touchend');
+  var TOP_TOUCH_MOVE = unsafeCastStringToDOMTopLevelType('touchmove');
+  var TOP_TOUCH_START = unsafeCastStringToDOMTopLevelType('touchstart');
+  var TOP_TRANSITION_END = unsafeCastStringToDOMTopLevelType(getVendorPrefixedEventName('transitionend'));
+  var TOP_VOLUME_CHANGE = unsafeCastStringToDOMTopLevelType('volumechange');
+  var TOP_WAITING = unsafeCastStringToDOMTopLevelType('waiting');
+  var TOP_WHEEL = unsafeCastStringToDOMTopLevelType('wheel'); // List of events that need to be individually attached to media elements.
+  // Note that events in this list will *not* be listened to at the top level
+  // unless they're explicitly whitelisted in `ReactBrowserEventEmitter.listenTo`.
+
+  var mediaEventTypes = [TOP_ABORT, TOP_CAN_PLAY, TOP_CAN_PLAY_THROUGH, TOP_DURATION_CHANGE, TOP_EMPTIED, TOP_ENCRYPTED, TOP_ENDED, TOP_ERROR, TOP_LOADED_DATA, TOP_LOADED_METADATA, TOP_LOAD_START, TOP_PAUSE, TOP_PLAY, TOP_PLAYING, TOP_PROGRESS, TOP_RATE_CHANGE, TOP_SEEKED, TOP_SEEKING, TOP_STALLED, TOP_SUSPEND, TOP_TIME_UPDATE, TOP_VOLUME_CHANGE, TOP_WAITING];
+  function getRawEventName(topLevelType) {
+    return unsafeCastDOMTopLevelTypeToString(topLevelType);
+  }
+
+  var PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map; // prettier-ignore
+
+  var elementListenerMap = new PossiblyWeakMap();
+  function getListenerMapForElement(element) {
+    var listenerMap = elementListenerMap.get(element);
+
+    if (listenerMap === undefined) {
+      listenerMap = new Map();
+      elementListenerMap.set(element, listenerMap);
+    }
+
+    return listenerMap;
+  }
+
+  /**
+   * `ReactInstanceMap` maintains a mapping from a public facing stateful
+   * instance (key) and the internal representation (value). This allows public
+   * methods to accept the user facing instance as an argument and map them back
+   * to internal methods.
+   *
+   * Note that this module is currently shared and assumed to be stateless.
+   * If this becomes an actual Map, that will break.
+   */
+  function get(key) {
+    return key._reactInternalFiber;
+  }
+  function has$1(key) {
+    return key._reactInternalFiber !== undefined;
+  }
+  function set(key, value) {
+    key._reactInternalFiber = value;
+  }
+
+  // Don't change these two values. They're used by React Dev Tools.
+  var NoEffect =
+  /*              */
+  0;
+  var PerformedWork =
+  /*         */
+  1; // You can change the rest (and add more).
+
+  var Placement =
+  /*             */
+  2;
+  var Update =
+  /*                */
+  4;
+  var PlacementAndUpdate =
+  /*    */
+  6;
+  var Deletion =
+  /*              */
+  8;
+  var ContentReset =
+  /*          */
+  16;
+  var Callback =
+  /*              */
+  32;
+  var DidCapture =
+  /*            */
+  64;
+  var Ref =
+  /*                   */
+  128;
+  var Snapshot =
+  /*              */
+  256;
+  var Passive =
+  /*               */
+  512;
+  var Hydrating =
+  /*             */
+  1024;
+  var HydratingAndUpdate =
+  /*    */
+  1028; // Passive & Update & Callback & Ref & Snapshot
+
+  var LifecycleEffectMask =
+  /*   */
+  932; // Union of all host effects
+
+  var HostEffectMask =
+  /*        */
+  2047;
+  var Incomplete =
+  /*            */
+  2048;
+  var ShouldCapture =
+  /*         */
+  4096;
+
+  var ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
+  function getNearestMountedFiber(fiber) {
+    var node = fiber;
+    var nearestMounted = fiber;
+
+    if (!fiber.alternate) {
+      // If there is no alternate, this might be a new tree that isn't inserted
+      // yet. If it is, then it will have a pending insertion effect on it.
+      var nextNode = node;
+
+      do {
+        node = nextNode;
+
+        if ((node.effectTag & (Placement | Hydrating)) !== NoEffect) {
+          // This is an insertion or in-progress hydration. The nearest possible
+          // mounted fiber is the parent but we need to continue to figure out
+          // if that one is still mounted.
+          nearestMounted = node.return;
+        }
+
+        nextNode = node.return;
+      } while (nextNode);
+    } else {
+      while (node.return) {
+        node = node.return;
+      }
+    }
+
+    if (node.tag === HostRoot) {
+      // TODO: Check if this was a nested HostRoot when used with
+      // renderContainerIntoSubtree.
+      return nearestMounted;
+    } // If we didn't hit the root, that means that we're in an disconnected tree
+    // that has been unmounted.
+
+
+    return null;
+  }
+  function getSuspenseInstanceFromFiber(fiber) {
+    if (fiber.tag === SuspenseComponent) {
+      var suspenseState = fiber.memoizedState;
+
+      if (suspenseState === null) {
+        var current = fiber.alternate;
+
+        if (current !== null) {
+          suspenseState = current.memoizedState;
+        }
+      }
+
+      if (suspenseState !== null) {
+        return suspenseState.dehydrated;
+      }
+    }
+
+    return null;
+  }
+  function getContainerFromFiber(fiber) {
+    return fiber.tag === HostRoot ? fiber.stateNode.containerInfo : null;
+  }
+  function isFiberMounted(fiber) {
+    return getNearestMountedFiber(fiber) === fiber;
+  }
+  function isMounted(component) {
+    {
+      var owner = ReactCurrentOwner.current;
+
+      if (owner !== null && owner.tag === ClassComponent) {
+        var ownerFiber = owner;
+        var instance = ownerFiber.stateNode;
+
+        if (!instance._warnedAboutRefsInRender) {
+          error('%s is accessing isMounted inside its render() function. ' + 'render() should be a pure function of props and state. It should ' + 'never access something that requires stale data from the previous ' + 'render, such as refs. Move this logic to componentDidMount and ' + 'componentDidUpdate instead.', getComponentName(ownerFiber.type) || 'A component');
+        }
+
+        instance._warnedAboutRefsInRender = true;
+      }
+    }
+
+    var fiber = get(component);
+
+    if (!fiber) {
+      return false;
+    }
+
+    return getNearestMountedFiber(fiber) === fiber;
+  }
+
+  function assertIsMounted(fiber) {
+    if (!(getNearestMountedFiber(fiber) === fiber)) {
+      {
+        throw Error( "Unable to find node on an unmounted component." );
+      }
+    }
+  }
+
+  function findCurrentFiberUsingSlowPath(fiber) {
+    var alternate = fiber.alternate;
+
+    if (!alternate) {
+      // If there is no alternate, then we only need to check if it is mounted.
+      var nearestMounted = getNearestMountedFiber(fiber);
+
+      if (!(nearestMounted !== null)) {
+        {
+          throw Error( "Unable to find node on an unmounted component." );
+        }
+      }
+
+      if (nearestMounted !== fiber) {
+        return null;
+      }
+
+      return fiber;
+    } // If we have two possible branches, we'll walk backwards up to the root
+    // to see what path the root points to. On the way we may hit one of the
+    // special cases and we'll deal with them.
+
+
+    var a = fiber;
+    var b = alternate;
+
+    while (true) {
+      var parentA = a.return;
+
+      if (parentA === null) {
+        // We're at the root.
+        break;
+      }
+
+      var parentB = parentA.alternate;
+
+      if (parentB === null) {
+        // There is no alternate. This is an unusual case. Currently, it only
+        // happens when a Suspense component is hidden. An extra fragment fiber
+        // is inserted in between the Suspense fiber and its children. Skip
+        // over this extra fragment fiber and proceed to the next parent.
+        var nextParent = parentA.return;
+
+        if (nextParent !== null) {
+          a = b = nextParent;
+          continue;
+        } // If there's no parent, we're at the root.
+
+
+        break;
+      } // If both copies of the parent fiber point to the same child, we can
+      // assume that the child is current. This happens when we bailout on low
+      // priority: the bailed out fiber's child reuses the current child.
+
+
+      if (parentA.child === parentB.child) {
+        var child = parentA.child;
+
+        while (child) {
+          if (child === a) {
+            // We've determined that A is the current branch.
+            assertIsMounted(parentA);
+            return fiber;
+          }
+
+          if (child === b) {
+            // We've determined that B is the current branch.
+            assertIsMounted(parentA);
+            return alternate;
+          }
+
+          child = child.sibling;
+        } // We should never have an alternate for any mounting node. So the only
+        // way this could possibly happen is if this was unmounted, if at all.
+
+
+        {
+          {
+            throw Error( "Unable to find node on an unmounted component." );
+          }
+        }
+      }
+
+      if (a.return !== b.return) {
+        // The return pointer of A and the return pointer of B point to different
+        // fibers. We assume that return pointers never criss-cross, so A must
+        // belong to the child set of A.return, and B must belong to the child
+        // set of B.return.
+        a = parentA;
+        b = parentB;
+      } else {
+        // The return pointers point to the same fiber. We'll have to use the
+        // default, slow path: scan the child sets of each parent alternate to see
+        // which child belongs to which set.
+        //
+        // Search parent A's child set
+        var didFindChild = false;
+        var _child = parentA.child;
+
+        while (_child) {
+          if (_child === a) {
+            didFindChild = true;
+            a = parentA;
+            b = parentB;
+            break;
+          }
+
+          if (_child === b) {
+            didFindChild = true;
+            b = parentA;
+            a = parentB;
+            break;
+          }
+
+          _child = _child.sibling;
+        }
+
+        if (!didFindChild) {
+          // Search parent B's child set
+          _child = parentB.child;
+
+          while (_child) {
+            if (_child === a) {
+              didFindChild = true;
+              a = parentB;
+              b = parentA;
+              break;
+            }
+
+            if (_child === b) {
+              didFindChild = true;
+              b = parentB;
+              a = parentA;
+              break;
+            }
+
+            _child = _child.sibling;
+          }
+
+          if (!didFindChild) {
+            {
+              throw Error( "Child was not found in either parent set. This indicates a bug in React related to the return pointer. Please file an issue." );
+            }
+          }
+        }
+      }
+
+      if (!(a.alternate === b)) {
+        {
+          throw Error( "Return fibers should always be each others' alternates. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+    } // If the root is not a host container, we're in a disconnected tree. I.e.
+    // unmounted.
+
+
+    if (!(a.tag === HostRoot)) {
+      {
+        throw Error( "Unable to find node on an unmounted component." );
+      }
+    }
+
+    if (a.stateNode.current === a) {
+      // We've determined that A is the current branch.
+      return fiber;
+    } // Otherwise B has to be current branch.
+
+
+    return alternate;
+  }
+  function findCurrentHostFiber(parent) {
+    var currentParent = findCurrentFiberUsingSlowPath(parent);
+
+    if (!currentParent) {
+      return null;
+    } // Next we'll drill down this component to find the first HostComponent/Text.
+
+
+    var node = currentParent;
+
+    while (true) {
+      if (node.tag === HostComponent || node.tag === HostText) {
+        return node;
+      } else if (node.child) {
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
+
+      if (node === currentParent) {
+        return null;
+      }
+
+      while (!node.sibling) {
+        if (!node.return || node.return === currentParent) {
+          return null;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    } // Flow needs the return null here, but ESLint complains about it.
+    // eslint-disable-next-line no-unreachable
+
+
+    return null;
+  }
+  function findCurrentHostFiberWithNoPortals(parent) {
+    var currentParent = findCurrentFiberUsingSlowPath(parent);
+
+    if (!currentParent) {
+      return null;
+    } // Next we'll drill down this component to find the first HostComponent/Text.
+
+
+    var node = currentParent;
+
+    while (true) {
+      if (node.tag === HostComponent || node.tag === HostText || enableFundamentalAPI ) {
+        return node;
+      } else if (node.child && node.tag !== HostPortal) {
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
+
+      if (node === currentParent) {
+        return null;
+      }
+
+      while (!node.sibling) {
+        if (!node.return || node.return === currentParent) {
+          return null;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    } // Flow needs the return null here, but ESLint complains about it.
+    // eslint-disable-next-line no-unreachable
+
+
+    return null;
+  }
+
+  /**
+   * Accumulates items that must not be null or undefined into the first one. This
+   * is used to conserve memory by avoiding array allocations, and thus sacrifices
+   * API cleanness. Since `current` can be null before being passed in and not
+   * null after this function, make sure to assign it back to `current`:
+   *
+   * `a = accumulateInto(a, b);`
+   *
+   * This API should be sparingly used. Try `accumulate` for something cleaner.
+   *
+   * @return {*|array<*>} An accumulation of items.
+   */
+
+  function accumulateInto(current, next) {
+    if (!(next != null)) {
+      {
+        throw Error( "accumulateInto(...): Accumulated items must not be null or undefined." );
+      }
+    }
+
+    if (current == null) {
+      return next;
+    } // Both are not empty. Warning: Never call x.concat(y) when you are not
+    // certain that x is an Array (x could be a string with concat method).
+
+
+    if (Array.isArray(current)) {
+      if (Array.isArray(next)) {
+        current.push.apply(current, next);
+        return current;
+      }
+
+      current.push(next);
+      return current;
+    }
+
+    if (Array.isArray(next)) {
+      // A bit too dangerous to mutate `next`.
+      return [current].concat(next);
+    }
+
+    return [current, next];
+  }
+
+  /**
+   * @param {array} arr an "accumulation" of items which is either an Array or
+   * a single item. Useful when paired with the `accumulate` module. This is a
+   * simple utility that allows us to reason about a collection of items, but
+   * handling the case when there is exactly one item (and we do not need to
+   * allocate an array).
+   * @param {function} cb Callback invoked with each element or a collection.
+   * @param {?} [scope] Scope used as `this` in a callback.
+   */
+  function forEachAccumulated(arr, cb, scope) {
+    if (Array.isArray(arr)) {
+      arr.forEach(cb, scope);
+    } else if (arr) {
+      cb.call(scope, arr);
+    }
+  }
+
+  /**
+   * Internal queue of events that have accumulated their dispatches and are
+   * waiting to have their dispatches executed.
+   */
+
+  var eventQueue = null;
+  /**
+   * Dispatches an event and releases it back into the pool, unless persistent.
+   *
+   * @param {?object} event Synthetic event to be dispatched.
+   * @private
+   */
+
+  var executeDispatchesAndRelease = function (event) {
+    if (event) {
+      executeDispatchesInOrder(event);
+
+      if (!event.isPersistent()) {
+        event.constructor.release(event);
+      }
+    }
+  };
+
+  var executeDispatchesAndReleaseTopLevel = function (e) {
+    return executeDispatchesAndRelease(e);
+  };
+
+  function runEventsInBatch(events) {
+    if (events !== null) {
+      eventQueue = accumulateInto(eventQueue, events);
+    } // Set `eventQueue` to null before processing it so that we can tell if more
+    // events get enqueued while processing.
+
+
+    var processingEventQueue = eventQueue;
+    eventQueue = null;
+
+    if (!processingEventQueue) {
+      return;
+    }
+
+    forEachAccumulated(processingEventQueue, executeDispatchesAndReleaseTopLevel);
+
+    if (!!eventQueue) {
+      {
+        throw Error( "processEventQueue(): Additional events were enqueued while processing an event queue. Support for this has not yet been implemented." );
+      }
+    } // This would be a good time to rethrow if any of the event handlers threw.
+
+
+    rethrowCaughtError();
+  }
+
+  /**
+   * Gets the target node from a native browser event by accounting for
+   * inconsistencies in browser DOM APIs.
+   *
+   * @param {object} nativeEvent Native browser event.
+   * @return {DOMEventTarget} Target node.
+   */
+
+  function getEventTarget(nativeEvent) {
+    // Fallback to nativeEvent.srcElement for IE9
+    // https://github.com/facebook/react/issues/12506
+    var target = nativeEvent.target || nativeEvent.srcElement || window; // Normalize SVG <use> element events #4963
+
+    if (target.correspondingUseElement) {
+      target = target.correspondingUseElement;
+    } // Safari may fire events on text nodes (Node.TEXT_NODE is 3).
+    // @see http://www.quirksmode.org/js/events_properties.html
+
+
+    return target.nodeType === TEXT_NODE ? target.parentNode : target;
+  }
+
+  /**
+   * Checks if an event is supported in the current execution environment.
+   *
+   * NOTE: This will not work correctly for non-generic events such as `change`,
+   * `reset`, `load`, `error`, and `select`.
+   *
+   * Borrows from Modernizr.
+   *
+   * @param {string} eventNameSuffix Event name, e.g. "click".
+   * @return {boolean} True if the event is supported.
+   * @internal
+   * @license Modernizr 3.0.0pre (Custom Build) | MIT
+   */
+
+  function isEventSupported(eventNameSuffix) {
+    if (!canUseDOM) {
+      return false;
+    }
+
+    var eventName = 'on' + eventNameSuffix;
+    var isSupported = eventName in document;
+
+    if (!isSupported) {
+      var element = document.createElement('div');
+      element.setAttribute(eventName, 'return;');
+      isSupported = typeof element[eventName] === 'function';
+    }
+
+    return isSupported;
+  }
+
+  /**
+   * Summary of `DOMEventPluginSystem` event handling:
+   *
+   *  - Top-level delegation is used to trap most native browser events. This
+   *    may only occur in the main thread and is the responsibility of
+   *    ReactDOMEventListener, which is injected and can therefore support
+   *    pluggable event sources. This is the only work that occurs in the main
+   *    thread.
+   *
+   *  - We normalize and de-duplicate events to account for browser quirks. This
+   *    may be done in the worker thread.
+   *
+   *  - Forward these native events (with the associated top-level type used to
+   *    trap it) to `EventPluginRegistry`, which in turn will ask plugins if they want
+   *    to extract any synthetic events.
+   *
+   *  - The `EventPluginRegistry` will then process each event by annotating them with
+   *    "dispatches", a sequence of listeners and IDs that care about that event.
+   *
+   *  - The `EventPluginRegistry` then dispatches the events.
+   *
+   * Overview of React and the event system:
+   *
+   * +------------+    .
+   * |    DOM     |    .
+   * +------------+    .
+   *       |           .
+   *       v           .
+   * +------------+    .
+   * | ReactEvent |    .
+   * |  Listener  |    .
+   * +------------+    .                         +-----------+
+   *       |           .               +--------+|SimpleEvent|
+   *       |           .               |         |Plugin     |
+   * +-----|------+    .               v         +-----------+
+   * |     |      |    .    +--------------+                    +------------+
+   * |     +-----------.--->|PluginRegistry|                    |    Event   |
+   * |            |    .    |              |     +-----------+  | Propagators|
+   * | ReactEvent |    .    |              |     |TapEvent   |  |------------|
+   * |  Emitter   |    .    |              |<---+|Plugin     |  |other plugin|
+   * |            |    .    |              |     +-----------+  |  utilities |
+   * |     +-----------.--->|              |                    +------------+
+   * |     |      |    .    +--------------+
+   * +-----|------+    .                ^        +-----------+
+   *       |           .                |        |Enter/Leave|
+   *       +           .                +-------+|Plugin     |
+   * +-------------+   .                         +-----------+
+   * | application |   .
+   * |-------------|   .
+   * |             |   .
+   * |             |   .
+   * +-------------+   .
+   *                   .
+   *    React Core     .  General Purpose Event Plugin System
+   */
+
+  var CALLBACK_BOOKKEEPING_POOL_SIZE = 10;
+  var callbackBookkeepingPool = [];
+
+  function releaseTopLevelCallbackBookKeeping(instance) {
+    instance.topLevelType = null;
+    instance.nativeEvent = null;
+    instance.targetInst = null;
+    instance.ancestors.length = 0;
+
+    if (callbackBookkeepingPool.length < CALLBACK_BOOKKEEPING_POOL_SIZE) {
+      callbackBookkeepingPool.push(instance);
+    }
+  } // Used to store ancestor hierarchy in top level callback
+
+
+  function getTopLevelCallbackBookKeeping(topLevelType, nativeEvent, targetInst, eventSystemFlags) {
+    if (callbackBookkeepingPool.length) {
+      var instance = callbackBookkeepingPool.pop();
+      instance.topLevelType = topLevelType;
+      instance.eventSystemFlags = eventSystemFlags;
+      instance.nativeEvent = nativeEvent;
+      instance.targetInst = targetInst;
+      return instance;
+    }
+
+    return {
+      topLevelType: topLevelType,
+      eventSystemFlags: eventSystemFlags,
+      nativeEvent: nativeEvent,
+      targetInst: targetInst,
+      ancestors: []
+    };
+  }
+  /**
+   * Find the deepest React component completely containing the root of the
+   * passed-in instance (for use when entire React trees are nested within each
+   * other). If React trees are not nested, returns null.
+   */
+
+
+  function findRootContainerNode(inst) {
+    if (inst.tag === HostRoot) {
+      return inst.stateNode.containerInfo;
+    } // TODO: It may be a good idea to cache this to prevent unnecessary DOM
+    // traversal, but caching is difficult to do correctly without using a
+    // mutation observer to listen for all DOM changes.
+
+
+    while (inst.return) {
+      inst = inst.return;
+    }
+
+    if (inst.tag !== HostRoot) {
+      // This can happen if we're in a detached tree.
+      return null;
+    }
+
+    return inst.stateNode.containerInfo;
+  }
+  /**
+   * Allows registered plugins an opportunity to extract events from top-level
+   * native browser events.
+   *
+   * @return {*} An accumulation of synthetic events.
+   * @internal
+   */
+
+
+  function extractPluginEvents(topLevelType, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags) {
+    var events = null;
+
+    for (var i = 0; i < plugins.length; i++) {
+      // Not every plugin in the ordering may be loaded at runtime.
+      var possiblePlugin = plugins[i];
+
+      if (possiblePlugin) {
+        var extractedEvents = possiblePlugin.extractEvents(topLevelType, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags);
+
+        if (extractedEvents) {
+          events = accumulateInto(events, extractedEvents);
+        }
+      }
+    }
+
+    return events;
+  }
+
+  function runExtractedPluginEventsInBatch(topLevelType, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags) {
+    var events = extractPluginEvents(topLevelType, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags);
+    runEventsInBatch(events);
+  }
+
+  function handleTopLevel(bookKeeping) {
+    var targetInst = bookKeeping.targetInst; // Loop through the hierarchy, in case there's any nested components.
+    // It's important that we build the array of ancestors before calling any
+    // event handlers, because event handlers can modify the DOM, leading to
+    // inconsistencies with ReactMount's node cache. See #1105.
+
+    var ancestor = targetInst;
+
+    do {
+      if (!ancestor) {
+        var ancestors = bookKeeping.ancestors;
+        ancestors.push(ancestor);
+        break;
+      }
+
+      var root = findRootContainerNode(ancestor);
+
+      if (!root) {
+        break;
+      }
+
+      var tag = ancestor.tag;
+
+      if (tag === HostComponent || tag === HostText) {
+        bookKeeping.ancestors.push(ancestor);
+      }
+
+      ancestor = getClosestInstanceFromNode(root);
+    } while (ancestor);
+
+    for (var i = 0; i < bookKeeping.ancestors.length; i++) {
+      targetInst = bookKeeping.ancestors[i];
+      var eventTarget = getEventTarget(bookKeeping.nativeEvent);
+      var topLevelType = bookKeeping.topLevelType;
+      var nativeEvent = bookKeeping.nativeEvent;
+      var eventSystemFlags = bookKeeping.eventSystemFlags; // If this is the first ancestor, we mark it on the system flags
+
+      if (i === 0) {
+        eventSystemFlags |= IS_FIRST_ANCESTOR;
+      }
+
+      runExtractedPluginEventsInBatch(topLevelType, targetInst, nativeEvent, eventTarget, eventSystemFlags);
+    }
+  }
+
+  function dispatchEventForLegacyPluginEventSystem(topLevelType, eventSystemFlags, nativeEvent, targetInst) {
+    var bookKeeping = getTopLevelCallbackBookKeeping(topLevelType, nativeEvent, targetInst, eventSystemFlags);
+
+    try {
+      // Event queue being processed in the same cycle allows
+      // `preventDefault`.
+      batchedEventUpdates(handleTopLevel, bookKeeping);
+    } finally {
+      releaseTopLevelCallbackBookKeeping(bookKeeping);
+    }
+  }
+  /**
+   * We listen for bubbled touch events on the document object.
+   *
+   * Firefox v8.01 (and possibly others) exhibited strange behavior when
+   * mounting `onmousemove` events at some node that was not the document
+   * element. The symptoms were that if your mouse is not moving over something
+   * contained within that mount point (for example on the background) the
+   * top-level listeners for `onmousemove` won't be called. However, if you
+   * register the `mousemove` on the document object, then it will of course
+   * catch all `mousemove`s. This along with iOS quirks, justifies restricting
+   * top-level listeners to the document object only, at least for these
+   * movement types of events and possibly all events.
+   *
+   * @see http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
+   *
+   * Also, `keyup`/`keypress`/`keydown` do not bubble to the window on IE, but
+   * they bubble to document.
+   *
+   * @param {string} registrationName Name of listener (e.g. `onClick`).
+   * @param {object} mountAt Container where to mount the listener
+   */
+
+  function legacyListenToEvent(registrationName, mountAt) {
+    var listenerMap = getListenerMapForElement(mountAt);
+    var dependencies = registrationNameDependencies[registrationName];
+
+    for (var i = 0; i < dependencies.length; i++) {
+      var dependency = dependencies[i];
+      legacyListenToTopLevelEvent(dependency, mountAt, listenerMap);
+    }
+  }
+  function legacyListenToTopLevelEvent(topLevelType, mountAt, listenerMap) {
+    if (!listenerMap.has(topLevelType)) {
+      switch (topLevelType) {
+        case TOP_SCROLL:
+          trapCapturedEvent(TOP_SCROLL, mountAt);
+          break;
+
+        case TOP_FOCUS:
+        case TOP_BLUR:
+          trapCapturedEvent(TOP_FOCUS, mountAt);
+          trapCapturedEvent(TOP_BLUR, mountAt); // We set the flag for a single dependency later in this function,
+          // but this ensures we mark both as attached rather than just one.
+
+          listenerMap.set(TOP_BLUR, null);
+          listenerMap.set(TOP_FOCUS, null);
+          break;
+
+        case TOP_CANCEL:
+        case TOP_CLOSE:
+          if (isEventSupported(getRawEventName(topLevelType))) {
+            trapCapturedEvent(topLevelType, mountAt);
+          }
+
+          break;
+
+        case TOP_INVALID:
+        case TOP_SUBMIT:
+        case TOP_RESET:
+          // We listen to them on the target DOM elements.
+          // Some of them bubble so we don't want them to fire twice.
+          break;
+
+        default:
+          // By default, listen on the top level to all non-media events.
+          // Media events don't bubble so adding the listener wouldn't do anything.
+          var isMediaEvent = mediaEventTypes.indexOf(topLevelType) !== -1;
+
+          if (!isMediaEvent) {
+            trapBubbledEvent(topLevelType, mountAt);
+          }
+
+          break;
+      }
+
+      listenerMap.set(topLevelType, null);
+    }
+  }
+  function isListeningToAllDependencies(registrationName, mountAt) {
+    var listenerMap = getListenerMapForElement(mountAt);
+    var dependencies = registrationNameDependencies[registrationName];
+
+    for (var i = 0; i < dependencies.length; i++) {
+      var dependency = dependencies[i];
+
+      if (!listenerMap.has(dependency)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  var attemptUserBlockingHydration;
+  function setAttemptUserBlockingHydration(fn) {
+    attemptUserBlockingHydration = fn;
+  }
+  var attemptContinuousHydration;
+  function setAttemptContinuousHydration(fn) {
+    attemptContinuousHydration = fn;
+  }
+  var attemptHydrationAtCurrentPriority;
+  function setAttemptHydrationAtCurrentPriority(fn) {
+    attemptHydrationAtCurrentPriority = fn;
+  } // TODO: Upgrade this definition once we're on a newer version of Flow that
+  var hasScheduledReplayAttempt = false; // The queue of discrete events to be replayed.
+
+  var queuedDiscreteEvents = []; // Indicates if any continuous event targets are non-null for early bailout.
+  // if the last target was dehydrated.
+
+  var queuedFocus = null;
+  var queuedDrag = null;
+  var queuedMouse = null; // For pointer events there can be one latest event per pointerId.
+
+  var queuedPointers = new Map();
+  var queuedPointerCaptures = new Map(); // We could consider replaying selectionchange and touchmoves too.
+
+  var queuedExplicitHydrationTargets = [];
+  function hasQueuedDiscreteEvents() {
+    return queuedDiscreteEvents.length > 0;
+  }
+  var discreteReplayableEvents = [TOP_MOUSE_DOWN, TOP_MOUSE_UP, TOP_TOUCH_CANCEL, TOP_TOUCH_END, TOP_TOUCH_START, TOP_AUX_CLICK, TOP_DOUBLE_CLICK, TOP_POINTER_CANCEL, TOP_POINTER_DOWN, TOP_POINTER_UP, TOP_DRAG_END, TOP_DRAG_START, TOP_DROP, TOP_COMPOSITION_END, TOP_COMPOSITION_START, TOP_KEY_DOWN, TOP_KEY_PRESS, TOP_KEY_UP, TOP_INPUT, TOP_TEXT_INPUT, TOP_CLOSE, TOP_CANCEL, TOP_COPY, TOP_CUT, TOP_PASTE, TOP_CLICK, TOP_CHANGE, TOP_CONTEXT_MENU, TOP_RESET, TOP_SUBMIT];
+  var continuousReplayableEvents = [TOP_FOCUS, TOP_BLUR, TOP_DRAG_ENTER, TOP_DRAG_LEAVE, TOP_MOUSE_OVER, TOP_MOUSE_OUT, TOP_POINTER_OVER, TOP_POINTER_OUT, TOP_GOT_POINTER_CAPTURE, TOP_LOST_POINTER_CAPTURE];
+  function isReplayableDiscreteEvent(eventType) {
+    return discreteReplayableEvents.indexOf(eventType) > -1;
+  }
+
+  function trapReplayableEventForDocument(topLevelType, document, listenerMap) {
+    legacyListenToTopLevelEvent(topLevelType, document, listenerMap);
+  }
+
+  function eagerlyTrapReplayableEvents(container, document) {
+    var listenerMapForDoc = getListenerMapForElement(document); // Discrete
+
+    discreteReplayableEvents.forEach(function (topLevelType) {
+      trapReplayableEventForDocument(topLevelType, document, listenerMapForDoc);
+    }); // Continuous
+
+    continuousReplayableEvents.forEach(function (topLevelType) {
+      trapReplayableEventForDocument(topLevelType, document, listenerMapForDoc);
+    });
+  }
+
+  function createQueuedReplayableEvent(blockedOn, topLevelType, eventSystemFlags, container, nativeEvent) {
+    return {
+      blockedOn: blockedOn,
+      topLevelType: topLevelType,
+      eventSystemFlags: eventSystemFlags | IS_REPLAYED,
+      nativeEvent: nativeEvent,
+      container: container
+    };
+  }
+
+  function queueDiscreteEvent(blockedOn, topLevelType, eventSystemFlags, container, nativeEvent) {
+    var queuedEvent = createQueuedReplayableEvent(blockedOn, topLevelType, eventSystemFlags, container, nativeEvent);
+    queuedDiscreteEvents.push(queuedEvent);
+  } // Resets the replaying for this type of continuous event to no event.
+
+  function clearIfContinuousEvent(topLevelType, nativeEvent) {
+    switch (topLevelType) {
+      case TOP_FOCUS:
+      case TOP_BLUR:
+        queuedFocus = null;
+        break;
+
+      case TOP_DRAG_ENTER:
+      case TOP_DRAG_LEAVE:
+        queuedDrag = null;
+        break;
+
+      case TOP_MOUSE_OVER:
+      case TOP_MOUSE_OUT:
+        queuedMouse = null;
+        break;
+
+      case TOP_POINTER_OVER:
+      case TOP_POINTER_OUT:
+        {
+          var pointerId = nativeEvent.pointerId;
+          queuedPointers.delete(pointerId);
+          break;
+        }
+
+      case TOP_GOT_POINTER_CAPTURE:
+      case TOP_LOST_POINTER_CAPTURE:
+        {
+          var _pointerId = nativeEvent.pointerId;
+          queuedPointerCaptures.delete(_pointerId);
+          break;
+        }
+    }
+  }
+
+  function accumulateOrCreateContinuousQueuedReplayableEvent(existingQueuedEvent, blockedOn, topLevelType, eventSystemFlags, container, nativeEvent) {
+    if (existingQueuedEvent === null || existingQueuedEvent.nativeEvent !== nativeEvent) {
+      var queuedEvent = createQueuedReplayableEvent(blockedOn, topLevelType, eventSystemFlags, container, nativeEvent);
+
+      if (blockedOn !== null) {
+        var _fiber2 = getInstanceFromNode$1(blockedOn);
+
+        if (_fiber2 !== null) {
+          // Attempt to increase the priority of this target.
+          attemptContinuousHydration(_fiber2);
+        }
+      }
+
+      return queuedEvent;
+    } // If we have already queued this exact event, then it's because
+    // the different event systems have different DOM event listeners.
+    // We can accumulate the flags and store a single event to be
+    // replayed.
+
+
+    existingQueuedEvent.eventSystemFlags |= eventSystemFlags;
+    return existingQueuedEvent;
+  }
+
+  function queueIfContinuousEvent(blockedOn, topLevelType, eventSystemFlags, container, nativeEvent) {
+    // These set relatedTarget to null because the replayed event will be treated as if we
+    // moved from outside the window (no target) onto the target once it hydrates.
+    // Instead of mutating we could clone the event.
+    switch (topLevelType) {
+      case TOP_FOCUS:
+        {
+          var focusEvent = nativeEvent;
+          queuedFocus = accumulateOrCreateContinuousQueuedReplayableEvent(queuedFocus, blockedOn, topLevelType, eventSystemFlags, container, focusEvent);
+          return true;
+        }
+
+      case TOP_DRAG_ENTER:
+        {
+          var dragEvent = nativeEvent;
+          queuedDrag = accumulateOrCreateContinuousQueuedReplayableEvent(queuedDrag, blockedOn, topLevelType, eventSystemFlags, container, dragEvent);
+          return true;
+        }
+
+      case TOP_MOUSE_OVER:
+        {
+          var mouseEvent = nativeEvent;
+          queuedMouse = accumulateOrCreateContinuousQueuedReplayableEvent(queuedMouse, blockedOn, topLevelType, eventSystemFlags, container, mouseEvent);
+          return true;
+        }
+
+      case TOP_POINTER_OVER:
+        {
+          var pointerEvent = nativeEvent;
+          var pointerId = pointerEvent.pointerId;
+          queuedPointers.set(pointerId, accumulateOrCreateContinuousQueuedReplayableEvent(queuedPointers.get(pointerId) || null, blockedOn, topLevelType, eventSystemFlags, container, pointerEvent));
+          return true;
+        }
+
+      case TOP_GOT_POINTER_CAPTURE:
+        {
+          var _pointerEvent = nativeEvent;
+          var _pointerId2 = _pointerEvent.pointerId;
+          queuedPointerCaptures.set(_pointerId2, accumulateOrCreateContinuousQueuedReplayableEvent(queuedPointerCaptures.get(_pointerId2) || null, blockedOn, topLevelType, eventSystemFlags, container, _pointerEvent));
+          return true;
+        }
+    }
+
+    return false;
+  } // Check if this target is unblocked. Returns true if it's unblocked.
+
+  function attemptExplicitHydrationTarget(queuedTarget) {
+    // TODO: This function shares a lot of logic with attemptToDispatchEvent.
+    // Try to unify them. It's a bit tricky since it would require two return
+    // values.
+    var targetInst = getClosestInstanceFromNode(queuedTarget.target);
+
+    if (targetInst !== null) {
+      var nearestMounted = getNearestMountedFiber(targetInst);
+
+      if (nearestMounted !== null) {
+        var tag = nearestMounted.tag;
+
+        if (tag === SuspenseComponent) {
+          var instance = getSuspenseInstanceFromFiber(nearestMounted);
+
+          if (instance !== null) {
+            // We're blocked on hydrating this boundary.
+            // Increase its priority.
+            queuedTarget.blockedOn = instance;
+            unstable_runWithPriority(queuedTarget.priority, function () {
+              attemptHydrationAtCurrentPriority(nearestMounted);
+            });
+            return;
+          }
+        } else if (tag === HostRoot) {
+          var root = nearestMounted.stateNode;
+
+          if (root.hydrate) {
+            queuedTarget.blockedOn = getContainerFromFiber(nearestMounted); // We don't currently have a way to increase the priority of
+            // a root other than sync.
+
+            return;
+          }
+        }
+      }
+    }
+
+    queuedTarget.blockedOn = null;
+  }
+
+  function attemptReplayContinuousQueuedEvent(queuedEvent) {
+    if (queuedEvent.blockedOn !== null) {
+      return false;
+    }
+
+    var nextBlockedOn = attemptToDispatchEvent(queuedEvent.topLevelType, queuedEvent.eventSystemFlags, queuedEvent.container, queuedEvent.nativeEvent);
+
+    if (nextBlockedOn !== null) {
+      // We're still blocked. Try again later.
+      var _fiber3 = getInstanceFromNode$1(nextBlockedOn);
+
+      if (_fiber3 !== null) {
+        attemptContinuousHydration(_fiber3);
+      }
+
+      queuedEvent.blockedOn = nextBlockedOn;
+      return false;
+    }
+
+    return true;
+  }
+
+  function attemptReplayContinuousQueuedEventInMap(queuedEvent, key, map) {
+    if (attemptReplayContinuousQueuedEvent(queuedEvent)) {
+      map.delete(key);
+    }
+  }
+
+  function replayUnblockedEvents() {
+    hasScheduledReplayAttempt = false; // First replay discrete events.
+
+    while (queuedDiscreteEvents.length > 0) {
+      var nextDiscreteEvent = queuedDiscreteEvents[0];
+
+      if (nextDiscreteEvent.blockedOn !== null) {
+        // We're still blocked.
+        // Increase the priority of this boundary to unblock
+        // the next discrete event.
+        var _fiber4 = getInstanceFromNode$1(nextDiscreteEvent.blockedOn);
+
+        if (_fiber4 !== null) {
+          attemptUserBlockingHydration(_fiber4);
+        }
+
+        break;
+      }
+
+      var nextBlockedOn = attemptToDispatchEvent(nextDiscreteEvent.topLevelType, nextDiscreteEvent.eventSystemFlags, nextDiscreteEvent.container, nextDiscreteEvent.nativeEvent);
+
+      if (nextBlockedOn !== null) {
+        // We're still blocked. Try again later.
+        nextDiscreteEvent.blockedOn = nextBlockedOn;
+      } else {
+        // We've successfully replayed the first event. Let's try the next one.
+        queuedDiscreteEvents.shift();
+      }
+    } // Next replay any continuous events.
+
+
+    if (queuedFocus !== null && attemptReplayContinuousQueuedEvent(queuedFocus)) {
+      queuedFocus = null;
+    }
+
+    if (queuedDrag !== null && attemptReplayContinuousQueuedEvent(queuedDrag)) {
+      queuedDrag = null;
+    }
+
+    if (queuedMouse !== null && attemptReplayContinuousQueuedEvent(queuedMouse)) {
+      queuedMouse = null;
+    }
+
+    queuedPointers.forEach(attemptReplayContinuousQueuedEventInMap);
+    queuedPointerCaptures.forEach(attemptReplayContinuousQueuedEventInMap);
+  }
+
+  function scheduleCallbackIfUnblocked(queuedEvent, unblocked) {
+    if (queuedEvent.blockedOn === unblocked) {
+      queuedEvent.blockedOn = null;
+
+      if (!hasScheduledReplayAttempt) {
+        hasScheduledReplayAttempt = true; // Schedule a callback to attempt replaying as many events as are
+        // now unblocked. This first might not actually be unblocked yet.
+        // We could check it early to avoid scheduling an unnecessary callback.
+
+        unstable_scheduleCallback(unstable_NormalPriority, replayUnblockedEvents);
+      }
+    }
+  }
+
+  function retryIfBlockedOn(unblocked) {
+    // Mark anything that was blocked on this as no longer blocked
+    // and eligible for a replay.
+    if (queuedDiscreteEvents.length > 0) {
+      scheduleCallbackIfUnblocked(queuedDiscreteEvents[0], unblocked); // This is a exponential search for each boundary that commits. I think it's
+      // worth it because we expect very few discrete events to queue up and once
+      // we are actually fully unblocked it will be fast to replay them.
+
+      for (var i = 1; i < queuedDiscreteEvents.length; i++) {
+        var queuedEvent = queuedDiscreteEvents[i];
+
+        if (queuedEvent.blockedOn === unblocked) {
+          queuedEvent.blockedOn = null;
+        }
+      }
+    }
+
+    if (queuedFocus !== null) {
+      scheduleCallbackIfUnblocked(queuedFocus, unblocked);
+    }
+
+    if (queuedDrag !== null) {
+      scheduleCallbackIfUnblocked(queuedDrag, unblocked);
+    }
+
+    if (queuedMouse !== null) {
+      scheduleCallbackIfUnblocked(queuedMouse, unblocked);
+    }
+
+    var unblock = function (queuedEvent) {
+      return scheduleCallbackIfUnblocked(queuedEvent, unblocked);
+    };
+
+    queuedPointers.forEach(unblock);
+    queuedPointerCaptures.forEach(unblock);
+
+    for (var _i = 0; _i < queuedExplicitHydrationTargets.length; _i++) {
+      var queuedTarget = queuedExplicitHydrationTargets[_i];
+
+      if (queuedTarget.blockedOn === unblocked) {
+        queuedTarget.blockedOn = null;
+      }
+    }
+
+    while (queuedExplicitHydrationTargets.length > 0) {
+      var nextExplicitTarget = queuedExplicitHydrationTargets[0];
+
+      if (nextExplicitTarget.blockedOn !== null) {
+        // We're still blocked.
+        break;
+      } else {
+        attemptExplicitHydrationTarget(nextExplicitTarget);
+
+        if (nextExplicitTarget.blockedOn === null) {
+          // We're unblocked.
+          queuedExplicitHydrationTargets.shift();
+        }
+      }
+    }
+  }
+
+  function addEventBubbleListener(element, eventType, listener) {
+    element.addEventListener(eventType, listener, false);
+  }
+  function addEventCaptureListener(element, eventType, listener) {
+    element.addEventListener(eventType, listener, true);
+  }
+
+  // do it in two places, which duplicates logic
+  // and increases the bundle size, we do it all
+  // here once. If we remove or refactor the
+  // SimpleEventPlugin, we should also remove or
+  // update the below line.
+
+  var simpleEventPluginEventTypes = {};
+  var topLevelEventsToDispatchConfig = new Map();
+  var eventPriorities = new Map(); // We store most of the events in this module in pairs of two strings so we can re-use
+  // the code required to apply the same logic for event prioritization and that of the
+  // SimpleEventPlugin. This complicates things slightly, but the aim is to reduce code
+  // duplication (for which there would be quite a bit). For the events that are not needed
+  // for the SimpleEventPlugin (otherDiscreteEvents) we process them separately as an
+  // array of top level events.
+  // Lastly, we ignore prettier so we can keep the formatting sane.
+  // prettier-ignore
+
+  var discreteEventPairsForSimpleEventPlugin = [TOP_BLUR, 'blur', TOP_CANCEL, 'cancel', TOP_CLICK, 'click', TOP_CLOSE, 'close', TOP_CONTEXT_MENU, 'contextMenu', TOP_COPY, 'copy', TOP_CUT, 'cut', TOP_AUX_CLICK, 'auxClick', TOP_DOUBLE_CLICK, 'doubleClick', TOP_DRAG_END, 'dragEnd', TOP_DRAG_START, 'dragStart', TOP_DROP, 'drop', TOP_FOCUS, 'focus', TOP_INPUT, 'input', TOP_INVALID, 'invalid', TOP_KEY_DOWN, 'keyDown', TOP_KEY_PRESS, 'keyPress', TOP_KEY_UP, 'keyUp', TOP_MOUSE_DOWN, 'mouseDown', TOP_MOUSE_UP, 'mouseUp', TOP_PASTE, 'paste', TOP_PAUSE, 'pause', TOP_PLAY, 'play', TOP_POINTER_CANCEL, 'pointerCancel', TOP_POINTER_DOWN, 'pointerDown', TOP_POINTER_UP, 'pointerUp', TOP_RATE_CHANGE, 'rateChange', TOP_RESET, 'reset', TOP_SEEKED, 'seeked', TOP_SUBMIT, 'submit', TOP_TOUCH_CANCEL, 'touchCancel', TOP_TOUCH_END, 'touchEnd', TOP_TOUCH_START, 'touchStart', TOP_VOLUME_CHANGE, 'volumeChange'];
+  var otherDiscreteEvents = [TOP_CHANGE, TOP_SELECTION_CHANGE, TOP_TEXT_INPUT, TOP_COMPOSITION_START, TOP_COMPOSITION_END, TOP_COMPOSITION_UPDATE]; // prettier-ignore
+
+  var userBlockingPairsForSimpleEventPlugin = [TOP_DRAG, 'drag', TOP_DRAG_ENTER, 'dragEnter', TOP_DRAG_EXIT, 'dragExit', TOP_DRAG_LEAVE, 'dragLeave', TOP_DRAG_OVER, 'dragOver', TOP_MOUSE_MOVE, 'mouseMove', TOP_MOUSE_OUT, 'mouseOut', TOP_MOUSE_OVER, 'mouseOver', TOP_POINTER_MOVE, 'pointerMove', TOP_POINTER_OUT, 'pointerOut', TOP_POINTER_OVER, 'pointerOver', TOP_SCROLL, 'scroll', TOP_TOGGLE, 'toggle', TOP_TOUCH_MOVE, 'touchMove', TOP_WHEEL, 'wheel']; // prettier-ignore
+
+  var continuousPairsForSimpleEventPlugin = [TOP_ABORT, 'abort', TOP_ANIMATION_END, 'animationEnd', TOP_ANIMATION_ITERATION, 'animationIteration', TOP_ANIMATION_START, 'animationStart', TOP_CAN_PLAY, 'canPlay', TOP_CAN_PLAY_THROUGH, 'canPlayThrough', TOP_DURATION_CHANGE, 'durationChange', TOP_EMPTIED, 'emptied', TOP_ENCRYPTED, 'encrypted', TOP_ENDED, 'ended', TOP_ERROR, 'error', TOP_GOT_POINTER_CAPTURE, 'gotPointerCapture', TOP_LOAD, 'load', TOP_LOADED_DATA, 'loadedData', TOP_LOADED_METADATA, 'loadedMetadata', TOP_LOAD_START, 'loadStart', TOP_LOST_POINTER_CAPTURE, 'lostPointerCapture', TOP_PLAYING, 'playing', TOP_PROGRESS, 'progress', TOP_SEEKING, 'seeking', TOP_STALLED, 'stalled', TOP_SUSPEND, 'suspend', TOP_TIME_UPDATE, 'timeUpdate', TOP_TRANSITION_END, 'transitionEnd', TOP_WAITING, 'waiting'];
+  /**
+   * Turns
+   * ['abort', ...]
+   * into
+   * eventTypes = {
+   *   'abort': {
+   *     phasedRegistrationNames: {
+   *       bubbled: 'onAbort',
+   *       captured: 'onAbortCapture',
+   *     },
+   *     dependencies: [TOP_ABORT],
+   *   },
+   *   ...
+   * };
+   * topLevelEventsToDispatchConfig = new Map([
+   *   [TOP_ABORT, { sameConfig }],
+   * ]);
+   */
+
+  function processSimpleEventPluginPairsByPriority(eventTypes, priority) {
+    // As the event types are in pairs of two, we need to iterate
+    // through in twos. The events are in pairs of two to save code
+    // and improve init perf of processing this array, as it will
+    // result in far fewer object allocations and property accesses
+    // if we only use three arrays to process all the categories of
+    // instead of tuples.
+    for (var i = 0; i < eventTypes.length; i += 2) {
+      var topEvent = eventTypes[i];
+      var event = eventTypes[i + 1];
+      var capitalizedEvent = event[0].toUpperCase() + event.slice(1);
+      var onEvent = 'on' + capitalizedEvent;
+      var config = {
+        phasedRegistrationNames: {
+          bubbled: onEvent,
+          captured: onEvent + 'Capture'
+        },
+        dependencies: [topEvent],
+        eventPriority: priority
+      };
+      eventPriorities.set(topEvent, priority);
+      topLevelEventsToDispatchConfig.set(topEvent, config);
+      simpleEventPluginEventTypes[event] = config;
+    }
+  }
+
+  function processTopEventPairsByPriority(eventTypes, priority) {
+    for (var i = 0; i < eventTypes.length; i++) {
+      eventPriorities.set(eventTypes[i], priority);
+    }
+  } // SimpleEventPlugin
+
+
+  processSimpleEventPluginPairsByPriority(discreteEventPairsForSimpleEventPlugin, DiscreteEvent);
+  processSimpleEventPluginPairsByPriority(userBlockingPairsForSimpleEventPlugin, UserBlockingEvent);
+  processSimpleEventPluginPairsByPriority(continuousPairsForSimpleEventPlugin, ContinuousEvent); // Not used by SimpleEventPlugin
+
+  processTopEventPairsByPriority(otherDiscreteEvents, DiscreteEvent);
+  function getEventPriorityForPluginSystem(topLevelType) {
+    var priority = eventPriorities.get(topLevelType); // Default to a ContinuousEvent. Note: we might
+    // want to warn if we can't detect the priority
+    // for the event.
+
+    return priority === undefined ? ContinuousEvent : priority;
+  }
+
+  // Intentionally not named imports because Rollup would use dynamic dispatch for
+  var UserBlockingPriority = unstable_UserBlockingPriority,
+      runWithPriority = unstable_runWithPriority; // TODO: can we stop exporting these?
+
+  var _enabled = true;
+  function setEnabled(enabled) {
+    _enabled = !!enabled;
+  }
+  function isEnabled() {
+    return _enabled;
+  }
+  function trapBubbledEvent(topLevelType, element) {
+    trapEventForPluginEventSystem(element, topLevelType, false);
+  }
+  function trapCapturedEvent(topLevelType, element) {
+    trapEventForPluginEventSystem(element, topLevelType, true);
+  }
+
+  function trapEventForPluginEventSystem(container, topLevelType, capture) {
+    var listener;
+
+    switch (getEventPriorityForPluginSystem(topLevelType)) {
+      case DiscreteEvent:
+        listener = dispatchDiscreteEvent.bind(null, topLevelType, PLUGIN_EVENT_SYSTEM, container);
+        break;
+
+      case UserBlockingEvent:
+        listener = dispatchUserBlockingUpdate.bind(null, topLevelType, PLUGIN_EVENT_SYSTEM, container);
+        break;
+
+      case ContinuousEvent:
+      default:
+        listener = dispatchEvent.bind(null, topLevelType, PLUGIN_EVENT_SYSTEM, container);
+        break;
+    }
+
+    var rawEventName = getRawEventName(topLevelType);
+
+    if (capture) {
+      addEventCaptureListener(container, rawEventName, listener);
+    } else {
+      addEventBubbleListener(container, rawEventName, listener);
+    }
+  }
+
+  function dispatchDiscreteEvent(topLevelType, eventSystemFlags, container, nativeEvent) {
+    flushDiscreteUpdatesIfNeeded(nativeEvent.timeStamp);
+    discreteUpdates(dispatchEvent, topLevelType, eventSystemFlags, container, nativeEvent);
+  }
+
+  function dispatchUserBlockingUpdate(topLevelType, eventSystemFlags, container, nativeEvent) {
+    runWithPriority(UserBlockingPriority, dispatchEvent.bind(null, topLevelType, eventSystemFlags, container, nativeEvent));
+  }
+
+  function dispatchEvent(topLevelType, eventSystemFlags, container, nativeEvent) {
+    if (!_enabled) {
+      return;
+    }
+
+    if (hasQueuedDiscreteEvents() && isReplayableDiscreteEvent(topLevelType)) {
+      // If we already have a queue of discrete events, and this is another discrete
+      // event, then we can't dispatch it regardless of its target, since they
+      // need to dispatch in order.
+      queueDiscreteEvent(null, // Flags that we're not actually blocked on anything as far as we know.
+      topLevelType, eventSystemFlags, container, nativeEvent);
+      return;
+    }
+
+    var blockedOn = attemptToDispatchEvent(topLevelType, eventSystemFlags, container, nativeEvent);
+
+    if (blockedOn === null) {
+      // We successfully dispatched this event.
+      clearIfContinuousEvent(topLevelType, nativeEvent);
+      return;
+    }
+
+    if (isReplayableDiscreteEvent(topLevelType)) {
+      // This this to be replayed later once the target is available.
+      queueDiscreteEvent(blockedOn, topLevelType, eventSystemFlags, container, nativeEvent);
+      return;
+    }
+
+    if (queueIfContinuousEvent(blockedOn, topLevelType, eventSystemFlags, container, nativeEvent)) {
+      return;
+    } // We need to clear only if we didn't queue because
+    // queueing is accummulative.
+
+
+    clearIfContinuousEvent(topLevelType, nativeEvent); // This is not replayable so we'll invoke it but without a target,
+    // in case the event system needs to trace it.
+
+    {
+      dispatchEventForLegacyPluginEventSystem(topLevelType, eventSystemFlags, nativeEvent, null);
+    }
+  } // Attempt dispatching an event. Returns a SuspenseInstance or Container if it's blocked.
+
+  function attemptToDispatchEvent(topLevelType, eventSystemFlags, container, nativeEvent) {
+    // TODO: Warn if _enabled is false.
+    var nativeEventTarget = getEventTarget(nativeEvent);
+    var targetInst = getClosestInstanceFromNode(nativeEventTarget);
+
+    if (targetInst !== null) {
+      var nearestMounted = getNearestMountedFiber(targetInst);
+
+      if (nearestMounted === null) {
+        // This tree has been unmounted already. Dispatch without a target.
+        targetInst = null;
+      } else {
+        var tag = nearestMounted.tag;
+
+        if (tag === SuspenseComponent) {
+          var instance = getSuspenseInstanceFromFiber(nearestMounted);
+
+          if (instance !== null) {
+            // Queue the event to be replayed later. Abort dispatching since we
+            // don't want this event dispatched twice through the event system.
+            // TODO: If this is the first discrete event in the queue. Schedule an increased
+            // priority for this boundary.
+            return instance;
+          } // This shouldn't happen, something went wrong but to avoid blocking
+          // the whole system, dispatch the event without a target.
+          // TODO: Warn.
+
+
+          targetInst = null;
+        } else if (tag === HostRoot) {
+          var root = nearestMounted.stateNode;
+
+          if (root.hydrate) {
+            // If this happens during a replay something went wrong and it might block
+            // the whole system.
+            return getContainerFromFiber(nearestMounted);
+          }
+
+          targetInst = null;
+        } else if (nearestMounted !== targetInst) {
+          // If we get an event (ex: img onload) before committing that
+          // component's mount, ignore it for now (that is, treat it as if it was an
+          // event on a non-React tree). We might also consider queueing events and
+          // dispatching them after the mount.
+          targetInst = null;
+        }
+      }
+    }
+
+    {
+      dispatchEventForLegacyPluginEventSystem(topLevelType, eventSystemFlags, nativeEvent, targetInst);
+    } // We're not blocked on anything.
+
+
+    return null;
+  }
+
+  // List derived from Gecko source code:
+  // https://github.com/mozilla/gecko-dev/blob/4e638efc71/layout/style/test/property_database.js
+  var shorthandToLonghand = {
+    animation: ['animationDelay', 'animationDirection', 'animationDuration', 'animationFillMode', 'animationIterationCount', 'animationName', 'animationPlayState', 'animationTimingFunction'],
+    background: ['backgroundAttachment', 'backgroundClip', 'backgroundColor', 'backgroundImage', 'backgroundOrigin', 'backgroundPositionX', 'backgroundPositionY', 'backgroundRepeat', 'backgroundSize'],
+    backgroundPosition: ['backgroundPositionX', 'backgroundPositionY'],
+    border: ['borderBottomColor', 'borderBottomStyle', 'borderBottomWidth', 'borderImageOutset', 'borderImageRepeat', 'borderImageSlice', 'borderImageSource', 'borderImageWidth', 'borderLeftColor', 'borderLeftStyle', 'borderLeftWidth', 'borderRightColor', 'borderRightStyle', 'borderRightWidth', 'borderTopColor', 'borderTopStyle', 'borderTopWidth'],
+    borderBlockEnd: ['borderBlockEndColor', 'borderBlockEndStyle', 'borderBlockEndWidth'],
+    borderBlockStart: ['borderBlockStartColor', 'borderBlockStartStyle', 'borderBlockStartWidth'],
+    borderBottom: ['borderBottomColor', 'borderBottomStyle', 'borderBottomWidth'],
+    borderColor: ['borderBottomColor', 'borderLeftColor', 'borderRightColor', 'borderTopColor'],
+    borderImage: ['borderImageOutset', 'borderImageRepeat', 'borderImageSlice', 'borderImageSource', 'borderImageWidth'],
+    borderInlineEnd: ['borderInlineEndColor', 'borderInlineEndStyle', 'borderInlineEndWidth'],
+    borderInlineStart: ['borderInlineStartColor', 'borderInlineStartStyle', 'borderInlineStartWidth'],
+    borderLeft: ['borderLeftColor', 'borderLeftStyle', 'borderLeftWidth'],
+    borderRadius: ['borderBottomLeftRadius', 'borderBottomRightRadius', 'borderTopLeftRadius', 'borderTopRightRadius'],
+    borderRight: ['borderRightColor', 'borderRightStyle', 'borderRightWidth'],
+    borderStyle: ['borderBottomStyle', 'borderLeftStyle', 'borderRightStyle', 'borderTopStyle'],
+    borderTop: ['borderTopColor', 'borderTopStyle', 'borderTopWidth'],
+    borderWidth: ['borderBottomWidth', 'borderLeftWidth', 'borderRightWidth', 'borderTopWidth'],
+    columnRule: ['columnRuleColor', 'columnRuleStyle', 'columnRuleWidth'],
+    columns: ['columnCount', 'columnWidth'],
+    flex: ['flexBasis', 'flexGrow', 'flexShrink'],
+    flexFlow: ['flexDirection', 'flexWrap'],
+    font: ['fontFamily', 'fontFeatureSettings', 'fontKerning', 'fontLanguageOverride', 'fontSize', 'fontSizeAdjust', 'fontStretch', 'fontStyle', 'fontVariant', 'fontVariantAlternates', 'fontVariantCaps', 'fontVariantEastAsian', 'fontVariantLigatures', 'fontVariantNumeric', 'fontVariantPosition', 'fontWeight', 'lineHeight'],
+    fontVariant: ['fontVariantAlternates', 'fontVariantCaps', 'fontVariantEastAsian', 'fontVariantLigatures', 'fontVariantNumeric', 'fontVariantPosition'],
+    gap: ['columnGap', 'rowGap'],
+    grid: ['gridAutoColumns', 'gridAutoFlow', 'gridAutoRows', 'gridTemplateAreas', 'gridTemplateColumns', 'gridTemplateRows'],
+    gridArea: ['gridColumnEnd', 'gridColumnStart', 'gridRowEnd', 'gridRowStart'],
+    gridColumn: ['gridColumnEnd', 'gridColumnStart'],
+    gridColumnGap: ['columnGap'],
+    gridGap: ['columnGap', 'rowGap'],
+    gridRow: ['gridRowEnd', 'gridRowStart'],
+    gridRowGap: ['rowGap'],
+    gridTemplate: ['gridTemplateAreas', 'gridTemplateColumns', 'gridTemplateRows'],
+    listStyle: ['listStyleImage', 'listStylePosition', 'listStyleType'],
+    margin: ['marginBottom', 'marginLeft', 'marginRight', 'marginTop'],
+    marker: ['markerEnd', 'markerMid', 'markerStart'],
+    mask: ['maskClip', 'maskComposite', 'maskImage', 'maskMode', 'maskOrigin', 'maskPositionX', 'maskPositionY', 'maskRepeat', 'maskSize'],
+    maskPosition: ['maskPositionX', 'maskPositionY'],
+    outline: ['outlineColor', 'outlineStyle', 'outlineWidth'],
+    overflow: ['overflowX', 'overflowY'],
+    padding: ['paddingBottom', 'paddingLeft', 'paddingRight', 'paddingTop'],
+    placeContent: ['alignContent', 'justifyContent'],
+    placeItems: ['alignItems', 'justifyItems'],
+    placeSelf: ['alignSelf', 'justifySelf'],
+    textDecoration: ['textDecorationColor', 'textDecorationLine', 'textDecorationStyle'],
+    textEmphasis: ['textEmphasisColor', 'textEmphasisStyle'],
+    transition: ['transitionDelay', 'transitionDuration', 'transitionProperty', 'transitionTimingFunction'],
+    wordWrap: ['overflowWrap']
+  };
+
+  /**
+   * CSS properties which accept numbers but are not in units of "px".
+   */
+  var isUnitlessNumber = {
+    animationIterationCount: true,
+    borderImageOutset: true,
+    borderImageSlice: true,
+    borderImageWidth: true,
+    boxFlex: true,
+    boxFlexGroup: true,
+    boxOrdinalGroup: true,
+    columnCount: true,
+    columns: true,
+    flex: true,
+    flexGrow: true,
+    flexPositive: true,
+    flexShrink: true,
+    flexNegative: true,
+    flexOrder: true,
+    gridArea: true,
+    gridRow: true,
+    gridRowEnd: true,
+    gridRowSpan: true,
+    gridRowStart: true,
+    gridColumn: true,
+    gridColumnEnd: true,
+    gridColumnSpan: true,
+    gridColumnStart: true,
+    fontWeight: true,
+    lineClamp: true,
+    lineHeight: true,
+    opacity: true,
+    order: true,
+    orphans: true,
+    tabSize: true,
+    widows: true,
+    zIndex: true,
+    zoom: true,
+    // SVG-related properties
+    fillOpacity: true,
+    floodOpacity: true,
+    stopOpacity: true,
+    strokeDasharray: true,
+    strokeDashoffset: true,
+    strokeMiterlimit: true,
+    strokeOpacity: true,
+    strokeWidth: true
+  };
+  /**
+   * @param {string} prefix vendor-specific prefix, eg: Webkit
+   * @param {string} key style name, eg: transitionDuration
+   * @return {string} style name prefixed with `prefix`, properly camelCased, eg:
+   * WebkitTransitionDuration
+   */
+
+  function prefixKey(prefix, key) {
+    return prefix + key.charAt(0).toUpperCase() + key.substring(1);
+  }
+  /**
+   * Support style names that may come passed in prefixed by adding permutations
+   * of vendor prefixes.
+   */
+
+
+  var prefixes = ['Webkit', 'ms', 'Moz', 'O']; // Using Object.keys here, or else the vanilla for-in loop makes IE8 go into an
+  // infinite loop, because it iterates over the newly added props too.
+
+  Object.keys(isUnitlessNumber).forEach(function (prop) {
+    prefixes.forEach(function (prefix) {
+      isUnitlessNumber[prefixKey(prefix, prop)] = isUnitlessNumber[prop];
+    });
+  });
+
+  /**
+   * Convert a value into the proper css writable value. The style name `name`
+   * should be logical (no hyphens), as specified
+   * in `CSSProperty.isUnitlessNumber`.
+   *
+   * @param {string} name CSS property name such as `topMargin`.
+   * @param {*} value CSS property value such as `10px`.
+   * @return {string} Normalized style value with dimensions applied.
+   */
+
+  function dangerousStyleValue(name, value, isCustomProperty) {
+    // Note that we've removed escapeTextForBrowser() calls here since the
+    // whole string will be escaped when the attribute is injected into
+    // the markup. If you provide unsafe user data here they can inject
+    // arbitrary CSS which may be problematic (I couldn't repro this):
+    // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet
+    // http://www.thespanner.co.uk/2007/11/26/ultimate-xss-css-injection/
+    // This is not an XSS hole but instead a potential CSS injection issue
+    // which has lead to a greater discussion about how we're going to
+    // trust URLs moving forward. See #2115901
+    var isEmpty = value == null || typeof value === 'boolean' || value === '';
+
+    if (isEmpty) {
+      return '';
+    }
+
+    if (!isCustomProperty && typeof value === 'number' && value !== 0 && !(isUnitlessNumber.hasOwnProperty(name) && isUnitlessNumber[name])) {
+      return value + 'px'; // Presumes implicit 'px' suffix for unitless numbers
+    }
+
+    return ('' + value).trim();
+  }
+
+  var uppercasePattern = /([A-Z])/g;
+  var msPattern = /^ms-/;
+  /**
+   * Hyphenates a camelcased CSS property name, for example:
+   *
+   *   > hyphenateStyleName('backgroundColor')
+   *   < "background-color"
+   *   > hyphenateStyleName('MozTransition')
+   *   < "-moz-transition"
+   *   > hyphenateStyleName('msTransition')
+   *   < "-ms-transition"
+   *
+   * As Modernizr suggests (http://modernizr.com/docs/#prefixed), an `ms` prefix
+   * is converted to `-ms-`.
+   */
+
+  function hyphenateStyleName(name) {
+    return name.replace(uppercasePattern, '-$1').toLowerCase().replace(msPattern, '-ms-');
+  }
+
+  var warnValidStyle = function () {};
+
+  {
+    // 'msTransform' is correct, but the other prefixes should be capitalized
+    var badVendoredStyleNamePattern = /^(?:webkit|moz|o)[A-Z]/;
+    var msPattern$1 = /^-ms-/;
+    var hyphenPattern = /-(.)/g; // style values shouldn't contain a semicolon
+
+    var badStyleValueWithSemicolonPattern = /;\s*$/;
+    var warnedStyleNames = {};
+    var warnedStyleValues = {};
+    var warnedForNaNValue = false;
+    var warnedForInfinityValue = false;
+
+    var camelize = function (string) {
+      return string.replace(hyphenPattern, function (_, character) {
+        return character.toUpperCase();
+      });
+    };
+
+    var warnHyphenatedStyleName = function (name) {
+      if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
+        return;
+      }
+
+      warnedStyleNames[name] = true;
+
+      error('Unsupported style property %s. Did you mean %s?', name, // As Andi Smith suggests
+      // (http://www.andismith.com/blog/2012/02/modernizr-prefixed/), an `-ms` prefix
+      // is converted to lowercase `ms`.
+      camelize(name.replace(msPattern$1, 'ms-')));
+    };
+
+    var warnBadVendoredStyleName = function (name) {
+      if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
+        return;
+      }
+
+      warnedStyleNames[name] = true;
+
+      error('Unsupported vendor-prefixed style property %s. Did you mean %s?', name, name.charAt(0).toUpperCase() + name.slice(1));
+    };
+
+    var warnStyleValueWithSemicolon = function (name, value) {
+      if (warnedStyleValues.hasOwnProperty(value) && warnedStyleValues[value]) {
+        return;
+      }
+
+      warnedStyleValues[value] = true;
+
+      error("Style property values shouldn't contain a semicolon. " + 'Try "%s: %s" instead.', name, value.replace(badStyleValueWithSemicolonPattern, ''));
+    };
+
+    var warnStyleValueIsNaN = function (name, value) {
+      if (warnedForNaNValue) {
+        return;
+      }
+
+      warnedForNaNValue = true;
+
+      error('`NaN` is an invalid value for the `%s` css style property.', name);
+    };
+
+    var warnStyleValueIsInfinity = function (name, value) {
+      if (warnedForInfinityValue) {
+        return;
+      }
+
+      warnedForInfinityValue = true;
+
+      error('`Infinity` is an invalid value for the `%s` css style property.', name);
+    };
+
+    warnValidStyle = function (name, value) {
+      if (name.indexOf('-') > -1) {
+        warnHyphenatedStyleName(name);
+      } else if (badVendoredStyleNamePattern.test(name)) {
+        warnBadVendoredStyleName(name);
+      } else if (badStyleValueWithSemicolonPattern.test(value)) {
+        warnStyleValueWithSemicolon(name, value);
+      }
+
+      if (typeof value === 'number') {
+        if (isNaN(value)) {
+          warnStyleValueIsNaN(name, value);
+        } else if (!isFinite(value)) {
+          warnStyleValueIsInfinity(name, value);
+        }
+      }
+    };
+  }
+
+  var warnValidStyle$1 = warnValidStyle;
+
+  /**
+   * Operations for dealing with CSS properties.
+   */
+
+  /**
+   * This creates a string that is expected to be equivalent to the style
+   * attribute generated by server-side rendering. It by-passes warnings and
+   * security checks so it's not safe to use this value for anything other than
+   * comparison. It is only used in DEV for SSR validation.
+   */
+
+  function createDangerousStringForStyles(styles) {
+    {
+      var serialized = '';
+      var delimiter = '';
+
+      for (var styleName in styles) {
+        if (!styles.hasOwnProperty(styleName)) {
+          continue;
+        }
+
+        var styleValue = styles[styleName];
+
+        if (styleValue != null) {
+          var isCustomProperty = styleName.indexOf('--') === 0;
+          serialized += delimiter + (isCustomProperty ? styleName : hyphenateStyleName(styleName)) + ':';
+          serialized += dangerousStyleValue(styleName, styleValue, isCustomProperty);
+          delimiter = ';';
+        }
+      }
+
+      return serialized || null;
+    }
+  }
+  /**
+   * Sets the value for multiple styles on a node.  If a value is specified as
+   * '' (empty string), the corresponding style property will be unset.
+   *
+   * @param {DOMElement} node
+   * @param {object} styles
+   */
+
+  function setValueForStyles(node, styles) {
+    var style = node.style;
+
+    for (var styleName in styles) {
+      if (!styles.hasOwnProperty(styleName)) {
+        continue;
+      }
+
+      var isCustomProperty = styleName.indexOf('--') === 0;
+
+      {
+        if (!isCustomProperty) {
+          warnValidStyle$1(styleName, styles[styleName]);
+        }
+      }
+
+      var styleValue = dangerousStyleValue(styleName, styles[styleName], isCustomProperty);
+
+      if (styleName === 'float') {
+        styleName = 'cssFloat';
+      }
+
+      if (isCustomProperty) {
+        style.setProperty(styleName, styleValue);
+      } else {
+        style[styleName] = styleValue;
+      }
+    }
+  }
+
+  function isValueEmpty(value) {
+    return value == null || typeof value === 'boolean' || value === '';
+  }
+  /**
+   * Given {color: 'red', overflow: 'hidden'} returns {
+   *   color: 'color',
+   *   overflowX: 'overflow',
+   *   overflowY: 'overflow',
+   * }. This can be read as "the overflowY property was set by the overflow
+   * shorthand". That is, the values are the property that each was derived from.
+   */
+
+
+  function expandShorthandMap(styles) {
+    var expanded = {};
+
+    for (var key in styles) {
+      var longhands = shorthandToLonghand[key] || [key];
+
+      for (var i = 0; i < longhands.length; i++) {
+        expanded[longhands[i]] = key;
+      }
+    }
+
+    return expanded;
+  }
+  /**
+   * When mixing shorthand and longhand property names, we warn during updates if
+   * we expect an incorrect result to occur. In particular, we warn for:
+   *
+   * Updating a shorthand property (longhand gets overwritten):
+   *   {font: 'foo', fontVariant: 'bar'} -> {font: 'baz', fontVariant: 'bar'}
+   *   becomes .style.font = 'baz'
+   * Removing a shorthand property (longhand gets lost too):
+   *   {font: 'foo', fontVariant: 'bar'} -> {fontVariant: 'bar'}
+   *   becomes .style.font = ''
+   * Removing a longhand property (should revert to shorthand; doesn't):
+   *   {font: 'foo', fontVariant: 'bar'} -> {font: 'foo'}
+   *   becomes .style.fontVariant = ''
+   */
+
+
+  function validateShorthandPropertyCollisionInDev(styleUpdates, nextStyles) {
+    {
+
+      if (!nextStyles) {
+        return;
+      }
+
+      var expandedUpdates = expandShorthandMap(styleUpdates);
+      var expandedStyles = expandShorthandMap(nextStyles);
+      var warnedAbout = {};
+
+      for (var key in expandedUpdates) {
+        var originalKey = expandedUpdates[key];
+        var correctOriginalKey = expandedStyles[key];
+
+        if (correctOriginalKey && originalKey !== correctOriginalKey) {
+          var warningKey = originalKey + ',' + correctOriginalKey;
+
+          if (warnedAbout[warningKey]) {
+            continue;
+          }
+
+          warnedAbout[warningKey] = true;
+
+          error('%s a style property during rerender (%s) when a ' + 'conflicting property is set (%s) can lead to styling bugs. To ' + "avoid this, don't mix shorthand and non-shorthand properties " + 'for the same value; instead, replace the shorthand with ' + 'separate values.', isValueEmpty(styleUpdates[originalKey]) ? 'Removing' : 'Updating', originalKey, correctOriginalKey);
+        }
+      }
+    }
+  }
+
+  // For HTML, certain tags should omit their close tag. We keep a whitelist for
+  // those special-case tags.
+  var omittedCloseTags = {
+    area: true,
+    base: true,
+    br: true,
+    col: true,
+    embed: true,
+    hr: true,
+    img: true,
+    input: true,
+    keygen: true,
+    link: true,
+    meta: true,
+    param: true,
+    source: true,
+    track: true,
+    wbr: true // NOTE: menuitem's close tag should be omitted, but that causes problems.
+
+  };
+
+  // `omittedCloseTags` except that `menuitem` should still have its closing tag.
+
+  var voidElementTags = _assign({
+    menuitem: true
+  }, omittedCloseTags);
+
+  var HTML = '__html';
+  var ReactDebugCurrentFrame$3 = null;
+
+  {
+    ReactDebugCurrentFrame$3 = ReactSharedInternals.ReactDebugCurrentFrame;
+  }
+
+  function assertValidProps(tag, props) {
+    if (!props) {
+      return;
+    } // Note the use of `==` which checks for null or undefined.
+
+
+    if (voidElementTags[tag]) {
+      if (!(props.children == null && props.dangerouslySetInnerHTML == null)) {
+        {
+          throw Error( tag + " is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`." + ( ReactDebugCurrentFrame$3.getStackAddendum() ) );
+        }
+      }
+    }
+
+    if (props.dangerouslySetInnerHTML != null) {
+      if (!(props.children == null)) {
+        {
+          throw Error( "Can only set one of `children` or `props.dangerouslySetInnerHTML`." );
+        }
+      }
+
+      if (!(typeof props.dangerouslySetInnerHTML === 'object' && HTML in props.dangerouslySetInnerHTML)) {
+        {
+          throw Error( "`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information." );
+        }
+      }
+    }
+
+    {
+      if (!props.suppressContentEditableWarning && props.contentEditable && props.children != null) {
+        error('A component is `contentEditable` and contains `children` managed by ' + 'React. It is now your responsibility to guarantee that none of ' + 'those nodes are unexpectedly modified or duplicated. This is ' + 'probably not intentional.');
+      }
+    }
+
+    if (!(props.style == null || typeof props.style === 'object')) {
+      {
+        throw Error( "The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + 'em'}} when using JSX." + ( ReactDebugCurrentFrame$3.getStackAddendum() ) );
+      }
+    }
+  }
+
+  function isCustomComponent(tagName, props) {
+    if (tagName.indexOf('-') === -1) {
+      return typeof props.is === 'string';
+    }
+
+    switch (tagName) {
+      // These are reserved SVG and MathML elements.
+      // We don't mind this whitelist too much because we expect it to never grow.
+      // The alternative is to track the namespace in a few places which is convoluted.
+      // https://w3c.github.io/webcomponents/spec/custom/#custom-elements-core-concepts
+      case 'annotation-xml':
+      case 'color-profile':
+      case 'font-face':
+      case 'font-face-src':
+      case 'font-face-uri':
+      case 'font-face-format':
+      case 'font-face-name':
+      case 'missing-glyph':
+        return false;
+
+      default:
+        return true;
+    }
+  }
+
+  // When adding attributes to the HTML or SVG whitelist, be sure to
+  // also add them to this module to ensure casing and incorrect name
+  // warnings.
+  var possibleStandardNames = {
+    // HTML
+    accept: 'accept',
+    acceptcharset: 'acceptCharset',
+    'accept-charset': 'acceptCharset',
+    accesskey: 'accessKey',
+    action: 'action',
+    allowfullscreen: 'allowFullScreen',
+    alt: 'alt',
+    as: 'as',
+    async: 'async',
+    autocapitalize: 'autoCapitalize',
+    autocomplete: 'autoComplete',
+    autocorrect: 'autoCorrect',
+    autofocus: 'autoFocus',
+    autoplay: 'autoPlay',
+    autosave: 'autoSave',
+    capture: 'capture',
+    cellpadding: 'cellPadding',
+    cellspacing: 'cellSpacing',
+    challenge: 'challenge',
+    charset: 'charSet',
+    checked: 'checked',
+    children: 'children',
+    cite: 'cite',
+    class: 'className',
+    classid: 'classID',
+    classname: 'className',
+    cols: 'cols',
+    colspan: 'colSpan',
+    content: 'content',
+    contenteditable: 'contentEditable',
+    contextmenu: 'contextMenu',
+    controls: 'controls',
+    controlslist: 'controlsList',
+    coords: 'coords',
+    crossorigin: 'crossOrigin',
+    dangerouslysetinnerhtml: 'dangerouslySetInnerHTML',
+    data: 'data',
+    datetime: 'dateTime',
+    default: 'default',
+    defaultchecked: 'defaultChecked',
+    defaultvalue: 'defaultValue',
+    defer: 'defer',
+    dir: 'dir',
+    disabled: 'disabled',
+    disablepictureinpicture: 'disablePictureInPicture',
+    download: 'download',
+    draggable: 'draggable',
+    enctype: 'encType',
+    for: 'htmlFor',
+    form: 'form',
+    formmethod: 'formMethod',
+    formaction: 'formAction',
+    formenctype: 'formEncType',
+    formnovalidate: 'formNoValidate',
+    formtarget: 'formTarget',
+    frameborder: 'frameBorder',
+    headers: 'headers',
+    height: 'height',
+    hidden: 'hidden',
+    high: 'high',
+    href: 'href',
+    hreflang: 'hrefLang',
+    htmlfor: 'htmlFor',
+    httpequiv: 'httpEquiv',
+    'http-equiv': 'httpEquiv',
+    icon: 'icon',
+    id: 'id',
+    innerhtml: 'innerHTML',
+    inputmode: 'inputMode',
+    integrity: 'integrity',
+    is: 'is',
+    itemid: 'itemID',
+    itemprop: 'itemProp',
+    itemref: 'itemRef',
+    itemscope: 'itemScope',
+    itemtype: 'itemType',
+    keyparams: 'keyParams',
+    keytype: 'keyType',
+    kind: 'kind',
+    label: 'label',
+    lang: 'lang',
+    list: 'list',
+    loop: 'loop',
+    low: 'low',
+    manifest: 'manifest',
+    marginwidth: 'marginWidth',
+    marginheight: 'marginHeight',
+    max: 'max',
+    maxlength: 'maxLength',
+    media: 'media',
+    mediagroup: 'mediaGroup',
+    method: 'method',
+    min: 'min',
+    minlength: 'minLength',
+    multiple: 'multiple',
+    muted: 'muted',
+    name: 'name',
+    nomodule: 'noModule',
+    nonce: 'nonce',
+    novalidate: 'noValidate',
+    open: 'open',
+    optimum: 'optimum',
+    pattern: 'pattern',
+    placeholder: 'placeholder',
+    playsinline: 'playsInline',
+    poster: 'poster',
+    preload: 'preload',
+    profile: 'profile',
+    radiogroup: 'radioGroup',
+    readonly: 'readOnly',
+    referrerpolicy: 'referrerPolicy',
+    rel: 'rel',
+    required: 'required',
+    reversed: 'reversed',
+    role: 'role',
+    rows: 'rows',
+    rowspan: 'rowSpan',
+    sandbox: 'sandbox',
+    scope: 'scope',
+    scoped: 'scoped',
+    scrolling: 'scrolling',
+    seamless: 'seamless',
+    selected: 'selected',
+    shape: 'shape',
+    size: 'size',
+    sizes: 'sizes',
+    span: 'span',
+    spellcheck: 'spellCheck',
+    src: 'src',
+    srcdoc: 'srcDoc',
+    srclang: 'srcLang',
+    srcset: 'srcSet',
+    start: 'start',
+    step: 'step',
+    style: 'style',
+    summary: 'summary',
+    tabindex: 'tabIndex',
+    target: 'target',
+    title: 'title',
+    type: 'type',
+    usemap: 'useMap',
+    value: 'value',
+    width: 'width',
+    wmode: 'wmode',
+    wrap: 'wrap',
+    // SVG
+    about: 'about',
+    accentheight: 'accentHeight',
+    'accent-height': 'accentHeight',
+    accumulate: 'accumulate',
+    additive: 'additive',
+    alignmentbaseline: 'alignmentBaseline',
+    'alignment-baseline': 'alignmentBaseline',
+    allowreorder: 'allowReorder',
+    alphabetic: 'alphabetic',
+    amplitude: 'amplitude',
+    arabicform: 'arabicForm',
+    'arabic-form': 'arabicForm',
+    ascent: 'ascent',
+    attributename: 'attributeName',
+    attributetype: 'attributeType',
+    autoreverse: 'autoReverse',
+    azimuth: 'azimuth',
+    basefrequency: 'baseFrequency',
+    baselineshift: 'baselineShift',
+    'baseline-shift': 'baselineShift',
+    baseprofile: 'baseProfile',
+    bbox: 'bbox',
+    begin: 'begin',
+    bias: 'bias',
+    by: 'by',
+    calcmode: 'calcMode',
+    capheight: 'capHeight',
+    'cap-height': 'capHeight',
+    clip: 'clip',
+    clippath: 'clipPath',
+    'clip-path': 'clipPath',
+    clippathunits: 'clipPathUnits',
+    cliprule: 'clipRule',
+    'clip-rule': 'clipRule',
+    color: 'color',
+    colorinterpolation: 'colorInterpolation',
+    'color-interpolation': 'colorInterpolation',
+    colorinterpolationfilters: 'colorInterpolationFilters',
+    'color-interpolation-filters': 'colorInterpolationFilters',
+    colorprofile: 'colorProfile',
+    'color-profile': 'colorProfile',
+    colorrendering: 'colorRendering',
+    'color-rendering': 'colorRendering',
+    contentscripttype: 'contentScriptType',
+    contentstyletype: 'contentStyleType',
+    cursor: 'cursor',
+    cx: 'cx',
+    cy: 'cy',
+    d: 'd',
+    datatype: 'datatype',
+    decelerate: 'decelerate',
+    descent: 'descent',
+    diffuseconstant: 'diffuseConstant',
+    direction: 'direction',
+    display: 'display',
+    divisor: 'divisor',
+    dominantbaseline: 'dominantBaseline',
+    'dominant-baseline': 'dominantBaseline',
+    dur: 'dur',
+    dx: 'dx',
+    dy: 'dy',
+    edgemode: 'edgeMode',
+    elevation: 'elevation',
+    enablebackground: 'enableBackground',
+    'enable-background': 'enableBackground',
+    end: 'end',
+    exponent: 'exponent',
+    externalresourcesrequired: 'externalResourcesRequired',
+    fill: 'fill',
+    fillopacity: 'fillOpacity',
+    'fill-opacity': 'fillOpacity',
+    fillrule: 'fillRule',
+    'fill-rule': 'fillRule',
+    filter: 'filter',
+    filterres: 'filterRes',
+    filterunits: 'filterUnits',
+    floodopacity: 'floodOpacity',
+    'flood-opacity': 'floodOpacity',
+    floodcolor: 'floodColor',
+    'flood-color': 'floodColor',
+    focusable: 'focusable',
+    fontfamily: 'fontFamily',
+    'font-family': 'fontFamily',
+    fontsize: 'fontSize',
+    'font-size': 'fontSize',
+    fontsizeadjust: 'fontSizeAdjust',
+    'font-size-adjust': 'fontSizeAdjust',
+    fontstretch: 'fontStretch',
+    'font-stretch': 'fontStretch',
+    fontstyle: 'fontStyle',
+    'font-style': 'fontStyle',
+    fontvariant: 'fontVariant',
+    'font-variant': 'fontVariant',
+    fontweight: 'fontWeight',
+    'font-weight': 'fontWeight',
+    format: 'format',
+    from: 'from',
+    fx: 'fx',
+    fy: 'fy',
+    g1: 'g1',
+    g2: 'g2',
+    glyphname: 'glyphName',
+    'glyph-name': 'glyphName',
+    glyphorientationhorizontal: 'glyphOrientationHorizontal',
+    'glyph-orientation-horizontal': 'glyphOrientationHorizontal',
+    glyphorientationvertical: 'glyphOrientationVertical',
+    'glyph-orientation-vertical': 'glyphOrientationVertical',
+    glyphref: 'glyphRef',
+    gradienttransform: 'gradientTransform',
+    gradientunits: 'gradientUnits',
+    hanging: 'hanging',
+    horizadvx: 'horizAdvX',
+    'horiz-adv-x': 'horizAdvX',
+    horizoriginx: 'horizOriginX',
+    'horiz-origin-x': 'horizOriginX',
+    ideographic: 'ideographic',
+    imagerendering: 'imageRendering',
+    'image-rendering': 'imageRendering',
+    in2: 'in2',
+    in: 'in',
+    inlist: 'inlist',
+    intercept: 'intercept',
+    k1: 'k1',
+    k2: 'k2',
+    k3: 'k3',
+    k4: 'k4',
+    k: 'k',
+    kernelmatrix: 'kernelMatrix',
+    kernelunitlength: 'kernelUnitLength',
+    kerning: 'kerning',
+    keypoints: 'keyPoints',
+    keysplines: 'keySplines',
+    keytimes: 'keyTimes',
+    lengthadjust: 'lengthAdjust',
+    letterspacing: 'letterSpacing',
+    'letter-spacing': 'letterSpacing',
+    lightingcolor: 'lightingColor',
+    'lighting-color': 'lightingColor',
+    limitingconeangle: 'limitingConeAngle',
+    local: 'local',
+    markerend: 'markerEnd',
+    'marker-end': 'markerEnd',
+    markerheight: 'markerHeight',
+    markermid: 'markerMid',
+    'marker-mid': 'markerMid',
+    markerstart: 'markerStart',
+    'marker-start': 'markerStart',
+    markerunits: 'markerUnits',
+    markerwidth: 'markerWidth',
+    mask: 'mask',
+    maskcontentunits: 'maskContentUnits',
+    maskunits: 'maskUnits',
+    mathematical: 'mathematical',
+    mode: 'mode',
+    numoctaves: 'numOctaves',
+    offset: 'offset',
+    opacity: 'opacity',
+    operator: 'operator',
+    order: 'order',
+    orient: 'orient',
+    orientation: 'orientation',
+    origin: 'origin',
+    overflow: 'overflow',
+    overlineposition: 'overlinePosition',
+    'overline-position': 'overlinePosition',
+    overlinethickness: 'overlineThickness',
+    'overline-thickness': 'overlineThickness',
+    paintorder: 'paintOrder',
+    'paint-order': 'paintOrder',
+    panose1: 'panose1',
+    'panose-1': 'panose1',
+    pathlength: 'pathLength',
+    patterncontentunits: 'patternContentUnits',
+    patterntransform: 'patternTransform',
+    patternunits: 'patternUnits',
+    pointerevents: 'pointerEvents',
+    'pointer-events': 'pointerEvents',
+    points: 'points',
+    pointsatx: 'pointsAtX',
+    pointsaty: 'pointsAtY',
+    pointsatz: 'pointsAtZ',
+    prefix: 'prefix',
+    preservealpha: 'preserveAlpha',
+    preserveaspectratio: 'preserveAspectRatio',
+    primitiveunits: 'primitiveUnits',
+    property: 'property',
+    r: 'r',
+    radius: 'radius',
+    refx: 'refX',
+    refy: 'refY',
+    renderingintent: 'renderingIntent',
+    'rendering-intent': 'renderingIntent',
+    repeatcount: 'repeatCount',
+    repeatdur: 'repeatDur',
+    requiredextensions: 'requiredExtensions',
+    requiredfeatures: 'requiredFeatures',
+    resource: 'resource',
+    restart: 'restart',
+    result: 'result',
+    results: 'results',
+    rotate: 'rotate',
+    rx: 'rx',
+    ry: 'ry',
+    scale: 'scale',
+    security: 'security',
+    seed: 'seed',
+    shaperendering: 'shapeRendering',
+    'shape-rendering': 'shapeRendering',
+    slope: 'slope',
+    spacing: 'spacing',
+    specularconstant: 'specularConstant',
+    specularexponent: 'specularExponent',
+    speed: 'speed',
+    spreadmethod: 'spreadMethod',
+    startoffset: 'startOffset',
+    stddeviation: 'stdDeviation',
+    stemh: 'stemh',
+    stemv: 'stemv',
+    stitchtiles: 'stitchTiles',
+    stopcolor: 'stopColor',
+    'stop-color': 'stopColor',
+    stopopacity: 'stopOpacity',
+    'stop-opacity': 'stopOpacity',
+    strikethroughposition: 'strikethroughPosition',
+    'strikethrough-position': 'strikethroughPosition',
+    strikethroughthickness: 'strikethroughThickness',
+    'strikethrough-thickness': 'strikethroughThickness',
+    string: 'string',
+    stroke: 'stroke',
+    strokedasharray: 'strokeDasharray',
+    'stroke-dasharray': 'strokeDasharray',
+    strokedashoffset: 'strokeDashoffset',
+    'stroke-dashoffset': 'strokeDashoffset',
+    strokelinecap: 'strokeLinecap',
+    'stroke-linecap': 'strokeLinecap',
+    strokelinejoin: 'strokeLinejoin',
+    'stroke-linejoin': 'strokeLinejoin',
+    strokemiterlimit: 'strokeMiterlimit',
+    'stroke-miterlimit': 'strokeMiterlimit',
+    strokewidth: 'strokeWidth',
+    'stroke-width': 'strokeWidth',
+    strokeopacity: 'strokeOpacity',
+    'stroke-opacity': 'strokeOpacity',
+    suppresscontenteditablewarning: 'suppressContentEditableWarning',
+    suppresshydrationwarning: 'suppressHydrationWarning',
+    surfacescale: 'surfaceScale',
+    systemlanguage: 'systemLanguage',
+    tablevalues: 'tableValues',
+    targetx: 'targetX',
+    targety: 'targetY',
+    textanchor: 'textAnchor',
+    'text-anchor': 'textAnchor',
+    textdecoration: 'textDecoration',
+    'text-decoration': 'textDecoration',
+    textlength: 'textLength',
+    textrendering: 'textRendering',
+    'text-rendering': 'textRendering',
+    to: 'to',
+    transform: 'transform',
+    typeof: 'typeof',
+    u1: 'u1',
+    u2: 'u2',
+    underlineposition: 'underlinePosition',
+    'underline-position': 'underlinePosition',
+    underlinethickness: 'underlineThickness',
+    'underline-thickness': 'underlineThickness',
+    unicode: 'unicode',
+    unicodebidi: 'unicodeBidi',
+    'unicode-bidi': 'unicodeBidi',
+    unicoderange: 'unicodeRange',
+    'unicode-range': 'unicodeRange',
+    unitsperem: 'unitsPerEm',
+    'units-per-em': 'unitsPerEm',
+    unselectable: 'unselectable',
+    valphabetic: 'vAlphabetic',
+    'v-alphabetic': 'vAlphabetic',
+    values: 'values',
+    vectoreffect: 'vectorEffect',
+    'vector-effect': 'vectorEffect',
+    version: 'version',
+    vertadvy: 'vertAdvY',
+    'vert-adv-y': 'vertAdvY',
+    vertoriginx: 'vertOriginX',
+    'vert-origin-x': 'vertOriginX',
+    vertoriginy: 'vertOriginY',
+    'vert-origin-y': 'vertOriginY',
+    vhanging: 'vHanging',
+    'v-hanging': 'vHanging',
+    videographic: 'vIdeographic',
+    'v-ideographic': 'vIdeographic',
+    viewbox: 'viewBox',
+    viewtarget: 'viewTarget',
+    visibility: 'visibility',
+    vmathematical: 'vMathematical',
+    'v-mathematical': 'vMathematical',
+    vocab: 'vocab',
+    widths: 'widths',
+    wordspacing: 'wordSpacing',
+    'word-spacing': 'wordSpacing',
+    writingmode: 'writingMode',
+    'writing-mode': 'writingMode',
+    x1: 'x1',
+    x2: 'x2',
+    x: 'x',
+    xchannelselector: 'xChannelSelector',
+    xheight: 'xHeight',
+    'x-height': 'xHeight',
+    xlinkactuate: 'xlinkActuate',
+    'xlink:actuate': 'xlinkActuate',
+    xlinkarcrole: 'xlinkArcrole',
+    'xlink:arcrole': 'xlinkArcrole',
+    xlinkhref: 'xlinkHref',
+    'xlink:href': 'xlinkHref',
+    xlinkrole: 'xlinkRole',
+    'xlink:role': 'xlinkRole',
+    xlinkshow: 'xlinkShow',
+    'xlink:show': 'xlinkShow',
+    xlinktitle: 'xlinkTitle',
+    'xlink:title': 'xlinkTitle',
+    xlinktype: 'xlinkType',
+    'xlink:type': 'xlinkType',
+    xmlbase: 'xmlBase',
+    'xml:base': 'xmlBase',
+    xmllang: 'xmlLang',
+    'xml:lang': 'xmlLang',
+    xmlns: 'xmlns',
+    'xml:space': 'xmlSpace',
+    xmlnsxlink: 'xmlnsXlink',
+    'xmlns:xlink': 'xmlnsXlink',
+    xmlspace: 'xmlSpace',
+    y1: 'y1',
+    y2: 'y2',
+    y: 'y',
+    ychannelselector: 'yChannelSelector',
+    z: 'z',
+    zoomandpan: 'zoomAndPan'
+  };
+
+  var ariaProperties = {
+    'aria-current': 0,
+    // state
+    'aria-details': 0,
+    'aria-disabled': 0,
+    // state
+    'aria-hidden': 0,
+    // state
+    'aria-invalid': 0,
+    // state
+    'aria-keyshortcuts': 0,
+    'aria-label': 0,
+    'aria-roledescription': 0,
+    // Widget Attributes
+    'aria-autocomplete': 0,
+    'aria-checked': 0,
+    'aria-expanded': 0,
+    'aria-haspopup': 0,
+    'aria-level': 0,
+    'aria-modal': 0,
+    'aria-multiline': 0,
+    'aria-multiselectable': 0,
+    'aria-orientation': 0,
+    'aria-placeholder': 0,
+    'aria-pressed': 0,
+    'aria-readonly': 0,
+    'aria-required': 0,
+    'aria-selected': 0,
+    'aria-sort': 0,
+    'aria-valuemax': 0,
+    'aria-valuemin': 0,
+    'aria-valuenow': 0,
+    'aria-valuetext': 0,
+    // Live Region Attributes
+    'aria-atomic': 0,
+    'aria-busy': 0,
+    'aria-live': 0,
+    'aria-relevant': 0,
+    // Drag-and-Drop Attributes
+    'aria-dropeffect': 0,
+    'aria-grabbed': 0,
+    // Relationship Attributes
+    'aria-activedescendant': 0,
+    'aria-colcount': 0,
+    'aria-colindex': 0,
+    'aria-colspan': 0,
+    'aria-controls': 0,
+    'aria-describedby': 0,
+    'aria-errormessage': 0,
+    'aria-flowto': 0,
+    'aria-labelledby': 0,
+    'aria-owns': 0,
+    'aria-posinset': 0,
+    'aria-rowcount': 0,
+    'aria-rowindex': 0,
+    'aria-rowspan': 0,
+    'aria-setsize': 0
+  };
+
+  var warnedProperties = {};
+  var rARIA = new RegExp('^(aria)-[' + ATTRIBUTE_NAME_CHAR + ']*$');
+  var rARIACamel = new RegExp('^(aria)[A-Z][' + ATTRIBUTE_NAME_CHAR + ']*$');
+  var hasOwnProperty$1 = Object.prototype.hasOwnProperty;
+
+  function validateProperty(tagName, name) {
+    {
+      if (hasOwnProperty$1.call(warnedProperties, name) && warnedProperties[name]) {
+        return true;
+      }
+
+      if (rARIACamel.test(name)) {
+        var ariaName = 'aria-' + name.slice(4).toLowerCase();
+        var correctName = ariaProperties.hasOwnProperty(ariaName) ? ariaName : null; // If this is an aria-* attribute, but is not listed in the known DOM
+        // DOM properties, then it is an invalid aria-* attribute.
+
+        if (correctName == null) {
+          error('Invalid ARIA attribute `%s`. ARIA attributes follow the pattern aria-* and must be lowercase.', name);
+
+          warnedProperties[name] = true;
+          return true;
+        } // aria-* attributes should be lowercase; suggest the lowercase version.
+
+
+        if (name !== correctName) {
+          error('Invalid ARIA attribute `%s`. Did you mean `%s`?', name, correctName);
+
+          warnedProperties[name] = true;
+          return true;
+        }
+      }
+
+      if (rARIA.test(name)) {
+        var lowerCasedName = name.toLowerCase();
+        var standardName = ariaProperties.hasOwnProperty(lowerCasedName) ? lowerCasedName : null; // If this is an aria-* attribute, but is not listed in the known DOM
+        // DOM properties, then it is an invalid aria-* attribute.
+
+        if (standardName == null) {
+          warnedProperties[name] = true;
+          return false;
+        } // aria-* attributes should be lowercase; suggest the lowercase version.
+
+
+        if (name !== standardName) {
+          error('Unknown ARIA attribute `%s`. Did you mean `%s`?', name, standardName);
+
+          warnedProperties[name] = true;
+          return true;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  function warnInvalidARIAProps(type, props) {
+    {
+      var invalidProps = [];
+
+      for (var key in props) {
+        var isValid = validateProperty(type, key);
+
+        if (!isValid) {
+          invalidProps.push(key);
+        }
+      }
+
+      var unknownPropString = invalidProps.map(function (prop) {
+        return '`' + prop + '`';
+      }).join(', ');
+
+      if (invalidProps.length === 1) {
+        error('Invalid aria prop %s on <%s> tag. ' + 'For details, see https://fb.me/invalid-aria-prop', unknownPropString, type);
+      } else if (invalidProps.length > 1) {
+        error('Invalid aria props %s on <%s> tag. ' + 'For details, see https://fb.me/invalid-aria-prop', unknownPropString, type);
+      }
+    }
+  }
+
+  function validateProperties(type, props) {
+    if (isCustomComponent(type, props)) {
+      return;
+    }
+
+    warnInvalidARIAProps(type, props);
+  }
+
+  var didWarnValueNull = false;
+  function validateProperties$1(type, props) {
+    {
+      if (type !== 'input' && type !== 'textarea' && type !== 'select') {
+        return;
+      }
+
+      if (props != null && props.value === null && !didWarnValueNull) {
+        didWarnValueNull = true;
+
+        if (type === 'select' && props.multiple) {
+          error('`value` prop on `%s` should not be null. ' + 'Consider using an empty array when `multiple` is set to `true` ' + 'to clear the component or `undefined` for uncontrolled components.', type);
+        } else {
+          error('`value` prop on `%s` should not be null. ' + 'Consider using an empty string to clear the component or `undefined` ' + 'for uncontrolled components.', type);
+        }
+      }
+    }
+  }
+
+  var validateProperty$1 = function () {};
+
+  {
+    var warnedProperties$1 = {};
+    var _hasOwnProperty = Object.prototype.hasOwnProperty;
+    var EVENT_NAME_REGEX = /^on./;
+    var INVALID_EVENT_NAME_REGEX = /^on[^A-Z]/;
+    var rARIA$1 = new RegExp('^(aria)-[' + ATTRIBUTE_NAME_CHAR + ']*$');
+    var rARIACamel$1 = new RegExp('^(aria)[A-Z][' + ATTRIBUTE_NAME_CHAR + ']*$');
+
+    validateProperty$1 = function (tagName, name, value, canUseEventSystem) {
+      if (_hasOwnProperty.call(warnedProperties$1, name) && warnedProperties$1[name]) {
+        return true;
+      }
+
+      var lowerCasedName = name.toLowerCase();
+
+      if (lowerCasedName === 'onfocusin' || lowerCasedName === 'onfocusout') {
+        error('React uses onFocus and onBlur instead of onFocusIn and onFocusOut. ' + 'All React events are normalized to bubble, so onFocusIn and onFocusOut ' + 'are not needed/supported by React.');
+
+        warnedProperties$1[name] = true;
+        return true;
+      } // We can't rely on the event system being injected on the server.
+
+
+      if (canUseEventSystem) {
+        if (registrationNameModules.hasOwnProperty(name)) {
+          return true;
+        }
+
+        var registrationName = possibleRegistrationNames.hasOwnProperty(lowerCasedName) ? possibleRegistrationNames[lowerCasedName] : null;
+
+        if (registrationName != null) {
+          error('Invalid event handler property `%s`. Did you mean `%s`?', name, registrationName);
+
+          warnedProperties$1[name] = true;
+          return true;
+        }
+
+        if (EVENT_NAME_REGEX.test(name)) {
+          error('Unknown event handler property `%s`. It will be ignored.', name);
+
+          warnedProperties$1[name] = true;
+          return true;
+        }
+      } else if (EVENT_NAME_REGEX.test(name)) {
+        // If no event plugins have been injected, we are in a server environment.
+        // So we can't tell if the event name is correct for sure, but we can filter
+        // out known bad ones like `onclick`. We can't suggest a specific replacement though.
+        if (INVALID_EVENT_NAME_REGEX.test(name)) {
+          error('Invalid event handler property `%s`. ' + 'React events use the camelCase naming convention, for example `onClick`.', name);
+        }
+
+        warnedProperties$1[name] = true;
+        return true;
+      } // Let the ARIA attribute hook validate ARIA attributes
+
+
+      if (rARIA$1.test(name) || rARIACamel$1.test(name)) {
+        return true;
+      }
+
+      if (lowerCasedName === 'innerhtml') {
+        error('Directly setting property `innerHTML` is not permitted. ' + 'For more information, lookup documentation on `dangerouslySetInnerHTML`.');
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      if (lowerCasedName === 'aria') {
+        error('The `aria` attribute is reserved for future use in React. ' + 'Pass individual `aria-` attributes instead.');
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      if (lowerCasedName === 'is' && value !== null && value !== undefined && typeof value !== 'string') {
+        error('Received a `%s` for a string attribute `is`. If this is expected, cast ' + 'the value to a string.', typeof value);
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      if (typeof value === 'number' && isNaN(value)) {
+        error('Received NaN for the `%s` attribute. If this is expected, cast ' + 'the value to a string.', name);
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      var propertyInfo = getPropertyInfo(name);
+      var isReserved = propertyInfo !== null && propertyInfo.type === RESERVED; // Known attributes should match the casing specified in the property config.
+
+      if (possibleStandardNames.hasOwnProperty(lowerCasedName)) {
+        var standardName = possibleStandardNames[lowerCasedName];
+
+        if (standardName !== name) {
+          error('Invalid DOM property `%s`. Did you mean `%s`?', name, standardName);
+
+          warnedProperties$1[name] = true;
+          return true;
+        }
+      } else if (!isReserved && name !== lowerCasedName) {
+        // Unknown attributes should have lowercase casing since that's how they
+        // will be cased anyway with server rendering.
+        error('React does not recognize the `%s` prop on a DOM element. If you ' + 'intentionally want it to appear in the DOM as a custom ' + 'attribute, spell it as lowercase `%s` instead. ' + 'If you accidentally passed it from a parent component, remove ' + 'it from the DOM element.', name, lowerCasedName);
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      if (typeof value === 'boolean' && shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)) {
+        if (value) {
+          error('Received `%s` for a non-boolean attribute `%s`.\n\n' + 'If you want to write it to the DOM, pass a string instead: ' + '%s="%s" or %s={value.toString()}.', value, name, name, value, name);
+        } else {
+          error('Received `%s` for a non-boolean attribute `%s`.\n\n' + 'If you want to write it to the DOM, pass a string instead: ' + '%s="%s" or %s={value.toString()}.\n\n' + 'If you used to conditionally omit it with %s={condition && value}, ' + 'pass %s={condition ? value : undefined} instead.', value, name, name, value, name, name, name);
+        }
+
+        warnedProperties$1[name] = true;
+        return true;
+      } // Now that we've validated casing, do not validate
+      // data types for reserved props
+
+
+      if (isReserved) {
+        return true;
+      } // Warn when a known attribute is a bad type
+
+
+      if (shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)) {
+        warnedProperties$1[name] = true;
+        return false;
+      } // Warn when passing the strings 'false' or 'true' into a boolean prop
+
+
+      if ((value === 'false' || value === 'true') && propertyInfo !== null && propertyInfo.type === BOOLEAN) {
+        error('Received the string `%s` for the boolean attribute `%s`. ' + '%s ' + 'Did you mean %s={%s}?', value, name, value === 'false' ? 'The browser will interpret it as a truthy value.' : 'Although this works, it will not work as expected if you pass the string "false".', name, value);
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      return true;
+    };
+  }
+
+  var warnUnknownProperties = function (type, props, canUseEventSystem) {
+    {
+      var unknownProps = [];
+
+      for (var key in props) {
+        var isValid = validateProperty$1(type, key, props[key], canUseEventSystem);
+
+        if (!isValid) {
+          unknownProps.push(key);
+        }
+      }
+
+      var unknownPropString = unknownProps.map(function (prop) {
+        return '`' + prop + '`';
+      }).join(', ');
+
+      if (unknownProps.length === 1) {
+        error('Invalid value for prop %s on <%s> tag. Either remove it from the element, ' + 'or pass a string or number value to keep it in the DOM. ' + 'For details, see https://fb.me/react-attribute-behavior', unknownPropString, type);
+      } else if (unknownProps.length > 1) {
+        error('Invalid values for props %s on <%s> tag. Either remove them from the element, ' + 'or pass a string or number value to keep them in the DOM. ' + 'For details, see https://fb.me/react-attribute-behavior', unknownPropString, type);
+      }
+    }
+  };
+
+  function validateProperties$2(type, props, canUseEventSystem) {
+    if (isCustomComponent(type, props)) {
+      return;
+    }
+
+    warnUnknownProperties(type, props, canUseEventSystem);
+  }
+
+  var didWarnInvalidHydration = false;
+  var DANGEROUSLY_SET_INNER_HTML = 'dangerouslySetInnerHTML';
+  var SUPPRESS_CONTENT_EDITABLE_WARNING = 'suppressContentEditableWarning';
+  var SUPPRESS_HYDRATION_WARNING = 'suppressHydrationWarning';
+  var AUTOFOCUS = 'autoFocus';
+  var CHILDREN = 'children';
+  var STYLE = 'style';
+  var HTML$1 = '__html';
+  var HTML_NAMESPACE$1 = Namespaces.html;
+  var warnedUnknownTags;
+  var suppressHydrationWarning;
+  var validatePropertiesInDevelopment;
+  var warnForTextDifference;
+  var warnForPropDifference;
+  var warnForExtraAttributes;
+  var warnForInvalidEventListener;
+  var canDiffStyleForHydrationWarning;
+  var normalizeMarkupForTextOrAttribute;
+  var normalizeHTML;
+
+  {
+    warnedUnknownTags = {
+      // Chrome is the only major browser not shipping <time>. But as of July
+      // 2017 it intends to ship it due to widespread usage. We intentionally
+      // *don't* warn for <time> even if it's unrecognized by Chrome because
+      // it soon will be, and many apps have been using it anyway.
+      time: true,
+      // There are working polyfills for <dialog>. Let people use it.
+      dialog: true,
+      // Electron ships a custom <webview> tag to display external web content in
+      // an isolated frame and process.
+      // This tag is not present in non Electron environments such as JSDom which
+      // is often used for testing purposes.
+      // @see https://electronjs.org/docs/api/webview-tag
+      webview: true
+    };
+
+    validatePropertiesInDevelopment = function (type, props) {
+      validateProperties(type, props);
+      validateProperties$1(type, props);
+      validateProperties$2(type, props,
+      /* canUseEventSystem */
+      true);
+    }; // IE 11 parses & normalizes the style attribute as opposed to other
+    // browsers. It adds spaces and sorts the properties in some
+    // non-alphabetical order. Handling that would require sorting CSS
+    // properties in the client & server versions or applying
+    // `expectedStyle` to a temporary DOM node to read its `style` attribute
+    // normalized. Since it only affects IE, we're skipping style warnings
+    // in that browser completely in favor of doing all that work.
+    // See https://github.com/facebook/react/issues/11807
+
+
+    canDiffStyleForHydrationWarning = canUseDOM && !document.documentMode; // HTML parsing normalizes CR and CRLF to LF.
+    // It also can turn \u0000 into \uFFFD inside attributes.
+    // https://www.w3.org/TR/html5/single-page.html#preprocessing-the-input-stream
+    // If we have a mismatch, it might be caused by that.
+    // We will still patch up in this case but not fire the warning.
+
+    var NORMALIZE_NEWLINES_REGEX = /\r\n?/g;
+    var NORMALIZE_NULL_AND_REPLACEMENT_REGEX = /\u0000|\uFFFD/g;
+
+    normalizeMarkupForTextOrAttribute = function (markup) {
+      var markupString = typeof markup === 'string' ? markup : '' + markup;
+      return markupString.replace(NORMALIZE_NEWLINES_REGEX, '\n').replace(NORMALIZE_NULL_AND_REPLACEMENT_REGEX, '');
+    };
+
+    warnForTextDifference = function (serverText, clientText) {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      var normalizedClientText = normalizeMarkupForTextOrAttribute(clientText);
+      var normalizedServerText = normalizeMarkupForTextOrAttribute(serverText);
+
+      if (normalizedServerText === normalizedClientText) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Text content did not match. Server: "%s" Client: "%s"', normalizedServerText, normalizedClientText);
+    };
+
+    warnForPropDifference = function (propName, serverValue, clientValue) {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      var normalizedClientValue = normalizeMarkupForTextOrAttribute(clientValue);
+      var normalizedServerValue = normalizeMarkupForTextOrAttribute(serverValue);
+
+      if (normalizedServerValue === normalizedClientValue) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Prop `%s` did not match. Server: %s Client: %s', propName, JSON.stringify(normalizedServerValue), JSON.stringify(normalizedClientValue));
+    };
+
+    warnForExtraAttributes = function (attributeNames) {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+      var names = [];
+      attributeNames.forEach(function (name) {
+        names.push(name);
+      });
+
+      error('Extra attributes from the server: %s', names);
+    };
+
+    warnForInvalidEventListener = function (registrationName, listener) {
+      if (listener === false) {
+        error('Expected `%s` listener to be a function, instead got `false`.\n\n' + 'If you used to conditionally omit it with %s={condition && value}, ' + 'pass %s={condition ? value : undefined} instead.', registrationName, registrationName, registrationName);
+      } else {
+        error('Expected `%s` listener to be a function, instead got a value of `%s` type.', registrationName, typeof listener);
+      }
+    }; // Parse the HTML and read it back to normalize the HTML string so that it
+    // can be used for comparison.
+
+
+    normalizeHTML = function (parent, html) {
+      // We could have created a separate document here to avoid
+      // re-initializing custom elements if they exist. But this breaks
+      // how <noscript> is being handled. So we use the same document.
+      // See the discussion in https://github.com/facebook/react/pull/11157.
+      var testElement = parent.namespaceURI === HTML_NAMESPACE$1 ? parent.ownerDocument.createElement(parent.tagName) : parent.ownerDocument.createElementNS(parent.namespaceURI, parent.tagName);
+      testElement.innerHTML = html;
+      return testElement.innerHTML;
+    };
+  }
+
+  function ensureListeningTo(rootContainerElement, registrationName) {
+    var isDocumentOrFragment = rootContainerElement.nodeType === DOCUMENT_NODE || rootContainerElement.nodeType === DOCUMENT_FRAGMENT_NODE;
+    var doc = isDocumentOrFragment ? rootContainerElement : rootContainerElement.ownerDocument;
+    legacyListenToEvent(registrationName, doc);
+  }
+
+  function getOwnerDocumentFromRootContainer(rootContainerElement) {
+    return rootContainerElement.nodeType === DOCUMENT_NODE ? rootContainerElement : rootContainerElement.ownerDocument;
+  }
+
+  function noop() {}
+
+  function trapClickOnNonInteractiveElement(node) {
+    // Mobile Safari does not fire properly bubble click events on
+    // non-interactive elements, which means delegated click listeners do not
+    // fire. The workaround for this bug involves attaching an empty click
+    // listener on the target node.
+    // http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
+    // Just set it using the onclick property so that we don't have to manage any
+    // bookkeeping for it. Not sure if we need to clear it when the listener is
+    // removed.
+    // TODO: Only do this for the relevant Safaris maybe?
+    node.onclick = noop;
+  }
+
+  function setInitialDOMProperties(tag, domElement, rootContainerElement, nextProps, isCustomComponentTag) {
+    for (var propKey in nextProps) {
+      if (!nextProps.hasOwnProperty(propKey)) {
+        continue;
+      }
+
+      var nextProp = nextProps[propKey];
+
+      if (propKey === STYLE) {
+        {
+          if (nextProp) {
+            // Freeze the next style object so that we can assume it won't be
+            // mutated. We have already warned for this in the past.
+            Object.freeze(nextProp);
+          }
+        } // Relies on `updateStylesByID` not mutating `styleUpdates`.
+
+
+        setValueForStyles(domElement, nextProp);
+      } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
+        var nextHtml = nextProp ? nextProp[HTML$1] : undefined;
+
+        if (nextHtml != null) {
+          setInnerHTML(domElement, nextHtml);
+        }
+      } else if (propKey === CHILDREN) {
+        if (typeof nextProp === 'string') {
+          // Avoid setting initial textContent when the text is empty. In IE11 setting
+          // textContent on a <textarea> will cause the placeholder to not
+          // show within the <textarea> until it has been focused and blurred again.
+          // https://github.com/facebook/react/issues/6731#issuecomment-254874553
+          var canSetTextContent = tag !== 'textarea' || nextProp !== '';
+
+          if (canSetTextContent) {
+            setTextContent(domElement, nextProp);
+          }
+        } else if (typeof nextProp === 'number') {
+          setTextContent(domElement, '' + nextProp);
+        }
+      } else if ( propKey === SUPPRESS_CONTENT_EDITABLE_WARNING || propKey === SUPPRESS_HYDRATION_WARNING) ; else if (propKey === AUTOFOCUS) ; else if (registrationNameModules.hasOwnProperty(propKey)) {
+        if (nextProp != null) {
+          if ( typeof nextProp !== 'function') {
+            warnForInvalidEventListener(propKey, nextProp);
+          }
+
+          ensureListeningTo(rootContainerElement, propKey);
+        }
+      } else if (nextProp != null) {
+        setValueForProperty(domElement, propKey, nextProp, isCustomComponentTag);
+      }
+    }
+  }
+
+  function updateDOMProperties(domElement, updatePayload, wasCustomComponentTag, isCustomComponentTag) {
+    // TODO: Handle wasCustomComponentTag
+    for (var i = 0; i < updatePayload.length; i += 2) {
+      var propKey = updatePayload[i];
+      var propValue = updatePayload[i + 1];
+
+      if (propKey === STYLE) {
+        setValueForStyles(domElement, propValue);
+      } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
+        setInnerHTML(domElement, propValue);
+      } else if (propKey === CHILDREN) {
+        setTextContent(domElement, propValue);
+      } else {
+        setValueForProperty(domElement, propKey, propValue, isCustomComponentTag);
+      }
+    }
+  }
+
+  function createElement(type, props, rootContainerElement, parentNamespace) {
+    var isCustomComponentTag; // We create tags in the namespace of their parent container, except HTML
+    // tags get no namespace.
+
+    var ownerDocument = getOwnerDocumentFromRootContainer(rootContainerElement);
+    var domElement;
+    var namespaceURI = parentNamespace;
+
+    if (namespaceURI === HTML_NAMESPACE$1) {
+      namespaceURI = getIntrinsicNamespace(type);
+    }
+
+    if (namespaceURI === HTML_NAMESPACE$1) {
+      {
+        isCustomComponentTag = isCustomComponent(type, props); // Should this check be gated by parent namespace? Not sure we want to
+        // allow <SVG> or <mATH>.
+
+        if (!isCustomComponentTag && type !== type.toLowerCase()) {
+          error('<%s /> is using incorrect casing. ' + 'Use PascalCase for React components, ' + 'or lowercase for HTML elements.', type);
+        }
+      }
+
+      if (type === 'script') {
+        // Create the script via .innerHTML so its "parser-inserted" flag is
+        // set to true and it does not execute
+        var div = ownerDocument.createElement('div');
+
+        div.innerHTML = '<script><' + '/script>'; // eslint-disable-line
+        // This is guaranteed to yield a script element.
+
+        var firstChild = div.firstChild;
+        domElement = div.removeChild(firstChild);
+      } else if (typeof props.is === 'string') {
+        // $FlowIssue `createElement` should be updated for Web Components
+        domElement = ownerDocument.createElement(type, {
+          is: props.is
+        });
+      } else {
+        // Separate else branch instead of using `props.is || undefined` above because of a Firefox bug.
+        // See discussion in https://github.com/facebook/react/pull/6896
+        // and discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1276240
+        domElement = ownerDocument.createElement(type); // Normally attributes are assigned in `setInitialDOMProperties`, however the `multiple` and `size`
+        // attributes on `select`s needs to be added before `option`s are inserted.
+        // This prevents:
+        // - a bug where the `select` does not scroll to the correct option because singular
+        //  `select` elements automatically pick the first item #13222
+        // - a bug where the `select` set the first item as selected despite the `size` attribute #14239
+        // See https://github.com/facebook/react/issues/13222
+        // and https://github.com/facebook/react/issues/14239
+
+        if (type === 'select') {
+          var node = domElement;
+
+          if (props.multiple) {
+            node.multiple = true;
+          } else if (props.size) {
+            // Setting a size greater than 1 causes a select to behave like `multiple=true`, where
+            // it is possible that no option is selected.
+            //
+            // This is only necessary when a select in "single selection mode".
+            node.size = props.size;
+          }
+        }
+      }
+    } else {
+      domElement = ownerDocument.createElementNS(namespaceURI, type);
+    }
+
+    {
+      if (namespaceURI === HTML_NAMESPACE$1) {
+        if (!isCustomComponentTag && Object.prototype.toString.call(domElement) === '[object HTMLUnknownElement]' && !Object.prototype.hasOwnProperty.call(warnedUnknownTags, type)) {
+          warnedUnknownTags[type] = true;
+
+          error('The tag <%s> is unrecognized in this browser. ' + 'If you meant to render a React component, start its name with ' + 'an uppercase letter.', type);
+        }
+      }
+    }
+
+    return domElement;
+  }
+  function createTextNode(text, rootContainerElement) {
+    return getOwnerDocumentFromRootContainer(rootContainerElement).createTextNode(text);
+  }
+  function setInitialProperties(domElement, tag, rawProps, rootContainerElement) {
+    var isCustomComponentTag = isCustomComponent(tag, rawProps);
+
+    {
+      validatePropertiesInDevelopment(tag, rawProps);
+    } // TODO: Make sure that we check isMounted before firing any of these events.
+
+
+    var props;
+
+    switch (tag) {
+      case 'iframe':
+      case 'object':
+      case 'embed':
+        trapBubbledEvent(TOP_LOAD, domElement);
+        props = rawProps;
+        break;
+
+      case 'video':
+      case 'audio':
+        // Create listener for each media event
+        for (var i = 0; i < mediaEventTypes.length; i++) {
+          trapBubbledEvent(mediaEventTypes[i], domElement);
+        }
+
+        props = rawProps;
+        break;
+
+      case 'source':
+        trapBubbledEvent(TOP_ERROR, domElement);
+        props = rawProps;
+        break;
+
+      case 'img':
+      case 'image':
+      case 'link':
+        trapBubbledEvent(TOP_ERROR, domElement);
+        trapBubbledEvent(TOP_LOAD, domElement);
+        props = rawProps;
+        break;
+
+      case 'form':
+        trapBubbledEvent(TOP_RESET, domElement);
+        trapBubbledEvent(TOP_SUBMIT, domElement);
+        props = rawProps;
+        break;
+
+      case 'details':
+        trapBubbledEvent(TOP_TOGGLE, domElement);
+        props = rawProps;
+        break;
+
+      case 'input':
+        initWrapperState(domElement, rawProps);
+        props = getHostProps(domElement, rawProps);
+        trapBubbledEvent(TOP_INVALID, domElement); // For controlled components we always need to ensure we're listening
+        // to onChange. Even if there is no listener.
+
+        ensureListeningTo(rootContainerElement, 'onChange');
+        break;
+
+      case 'option':
+        validateProps(domElement, rawProps);
+        props = getHostProps$1(domElement, rawProps);
+        break;
+
+      case 'select':
+        initWrapperState$1(domElement, rawProps);
+        props = getHostProps$2(domElement, rawProps);
+        trapBubbledEvent(TOP_INVALID, domElement); // For controlled components we always need to ensure we're listening
+        // to onChange. Even if there is no listener.
+
+        ensureListeningTo(rootContainerElement, 'onChange');
+        break;
+
+      case 'textarea':
+        initWrapperState$2(domElement, rawProps);
+        props = getHostProps$3(domElement, rawProps);
+        trapBubbledEvent(TOP_INVALID, domElement); // For controlled components we always need to ensure we're listening
+        // to onChange. Even if there is no listener.
+
+        ensureListeningTo(rootContainerElement, 'onChange');
+        break;
+
+      default:
+        props = rawProps;
+    }
+
+    assertValidProps(tag, props);
+    setInitialDOMProperties(tag, domElement, rootContainerElement, props, isCustomComponentTag);
+
+    switch (tag) {
+      case 'input':
+        // TODO: Make sure we check if this is still unmounted or do any clean
+        // up necessary since we never stop tracking anymore.
+        track(domElement);
+        postMountWrapper(domElement, rawProps, false);
+        break;
+
+      case 'textarea':
+        // TODO: Make sure we check if this is still unmounted or do any clean
+        // up necessary since we never stop tracking anymore.
+        track(domElement);
+        postMountWrapper$3(domElement);
+        break;
+
+      case 'option':
+        postMountWrapper$1(domElement, rawProps);
+        break;
+
+      case 'select':
+        postMountWrapper$2(domElement, rawProps);
+        break;
+
+      default:
+        if (typeof props.onClick === 'function') {
+          // TODO: This cast may not be sound for SVG, MathML or custom elements.
+          trapClickOnNonInteractiveElement(domElement);
+        }
+
+        break;
+    }
+  } // Calculate the diff between the two objects.
+
+  function diffProperties(domElement, tag, lastRawProps, nextRawProps, rootContainerElement) {
+    {
+      validatePropertiesInDevelopment(tag, nextRawProps);
+    }
+
+    var updatePayload = null;
+    var lastProps;
+    var nextProps;
+
+    switch (tag) {
+      case 'input':
+        lastProps = getHostProps(domElement, lastRawProps);
+        nextProps = getHostProps(domElement, nextRawProps);
+        updatePayload = [];
+        break;
+
+      case 'option':
+        lastProps = getHostProps$1(domElement, lastRawProps);
+        nextProps = getHostProps$1(domElement, nextRawProps);
+        updatePayload = [];
+        break;
+
+      case 'select':
+        lastProps = getHostProps$2(domElement, lastRawProps);
+        nextProps = getHostProps$2(domElement, nextRawProps);
+        updatePayload = [];
+        break;
+
+      case 'textarea':
+        lastProps = getHostProps$3(domElement, lastRawProps);
+        nextProps = getHostProps$3(domElement, nextRawProps);
+        updatePayload = [];
+        break;
+
+      default:
+        lastProps = lastRawProps;
+        nextProps = nextRawProps;
+
+        if (typeof lastProps.onClick !== 'function' && typeof nextProps.onClick === 'function') {
+          // TODO: This cast may not be sound for SVG, MathML or custom elements.
+          trapClickOnNonInteractiveElement(domElement);
+        }
+
+        break;
+    }
+
+    assertValidProps(tag, nextProps);
+    var propKey;
+    var styleName;
+    var styleUpdates = null;
+
+    for (propKey in lastProps) {
+      if (nextProps.hasOwnProperty(propKey) || !lastProps.hasOwnProperty(propKey) || lastProps[propKey] == null) {
+        continue;
+      }
+
+      if (propKey === STYLE) {
+        var lastStyle = lastProps[propKey];
+
+        for (styleName in lastStyle) {
+          if (lastStyle.hasOwnProperty(styleName)) {
+            if (!styleUpdates) {
+              styleUpdates = {};
+            }
+
+            styleUpdates[styleName] = '';
+          }
+        }
+      } else if (propKey === DANGEROUSLY_SET_INNER_HTML || propKey === CHILDREN) ; else if ( propKey === SUPPRESS_CONTENT_EDITABLE_WARNING || propKey === SUPPRESS_HYDRATION_WARNING) ; else if (propKey === AUTOFOCUS) ; else if (registrationNameModules.hasOwnProperty(propKey)) {
+        // This is a special case. If any listener updates we need to ensure
+        // that the "current" fiber pointer gets updated so we need a commit
+        // to update this element.
+        if (!updatePayload) {
+          updatePayload = [];
+        }
+      } else {
+        // For all other deleted properties we add it to the queue. We use
+        // the whitelist in the commit phase instead.
+        (updatePayload = updatePayload || []).push(propKey, null);
+      }
+    }
+
+    for (propKey in nextProps) {
+      var nextProp = nextProps[propKey];
+      var lastProp = lastProps != null ? lastProps[propKey] : undefined;
+
+      if (!nextProps.hasOwnProperty(propKey) || nextProp === lastProp || nextProp == null && lastProp == null) {
+        continue;
+      }
+
+      if (propKey === STYLE) {
+        {
+          if (nextProp) {
+            // Freeze the next style object so that we can assume it won't be
+            // mutated. We have already warned for this in the past.
+            Object.freeze(nextProp);
+          }
+        }
+
+        if (lastProp) {
+          // Unset styles on `lastProp` but not on `nextProp`.
+          for (styleName in lastProp) {
+            if (lastProp.hasOwnProperty(styleName) && (!nextProp || !nextProp.hasOwnProperty(styleName))) {
+              if (!styleUpdates) {
+                styleUpdates = {};
+              }
+
+              styleUpdates[styleName] = '';
+            }
+          } // Update styles that changed since `lastProp`.
+
+
+          for (styleName in nextProp) {
+            if (nextProp.hasOwnProperty(styleName) && lastProp[styleName] !== nextProp[styleName]) {
+              if (!styleUpdates) {
+                styleUpdates = {};
+              }
+
+              styleUpdates[styleName] = nextProp[styleName];
+            }
+          }
+        } else {
+          // Relies on `updateStylesByID` not mutating `styleUpdates`.
+          if (!styleUpdates) {
+            if (!updatePayload) {
+              updatePayload = [];
+            }
+
+            updatePayload.push(propKey, styleUpdates);
+          }
+
+          styleUpdates = nextProp;
+        }
+      } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
+        var nextHtml = nextProp ? nextProp[HTML$1] : undefined;
+        var lastHtml = lastProp ? lastProp[HTML$1] : undefined;
+
+        if (nextHtml != null) {
+          if (lastHtml !== nextHtml) {
+            (updatePayload = updatePayload || []).push(propKey, nextHtml);
+          }
+        }
+      } else if (propKey === CHILDREN) {
+        if (lastProp !== nextProp && (typeof nextProp === 'string' || typeof nextProp === 'number')) {
+          (updatePayload = updatePayload || []).push(propKey, '' + nextProp);
+        }
+      } else if ( propKey === SUPPRESS_CONTENT_EDITABLE_WARNING || propKey === SUPPRESS_HYDRATION_WARNING) ; else if (registrationNameModules.hasOwnProperty(propKey)) {
+        if (nextProp != null) {
+          // We eagerly listen to this even though we haven't committed yet.
+          if ( typeof nextProp !== 'function') {
+            warnForInvalidEventListener(propKey, nextProp);
+          }
+
+          ensureListeningTo(rootContainerElement, propKey);
+        }
+
+        if (!updatePayload && lastProp !== nextProp) {
+          // This is a special case. If any listener updates we need to ensure
+          // that the "current" props pointer gets updated so we need a commit
+          // to update this element.
+          updatePayload = [];
+        }
+      } else {
+        // For any other property we always add it to the queue and then we
+        // filter it out using the whitelist during the commit.
+        (updatePayload = updatePayload || []).push(propKey, nextProp);
+      }
+    }
+
+    if (styleUpdates) {
+      {
+        validateShorthandPropertyCollisionInDev(styleUpdates, nextProps[STYLE]);
+      }
+
+      (updatePayload = updatePayload || []).push(STYLE, styleUpdates);
+    }
+
+    return updatePayload;
+  } // Apply the diff.
+
+  function updateProperties(domElement, updatePayload, tag, lastRawProps, nextRawProps) {
+    // Update checked *before* name.
+    // In the middle of an update, it is possible to have multiple checked.
+    // When a checked radio tries to change name, browser makes another radio's checked false.
+    if (tag === 'input' && nextRawProps.type === 'radio' && nextRawProps.name != null) {
+      updateChecked(domElement, nextRawProps);
+    }
+
+    var wasCustomComponentTag = isCustomComponent(tag, lastRawProps);
+    var isCustomComponentTag = isCustomComponent(tag, nextRawProps); // Apply the diff.
+
+    updateDOMProperties(domElement, updatePayload, wasCustomComponentTag, isCustomComponentTag); // TODO: Ensure that an update gets scheduled if any of the special props
+    // changed.
+
+    switch (tag) {
+      case 'input':
+        // Update the wrapper around inputs *after* updating props. This has to
+        // happen after `updateDOMProperties`. Otherwise HTML5 input validations
+        // raise warnings and prevent the new value from being assigned.
+        updateWrapper(domElement, nextRawProps);
+        break;
+
+      case 'textarea':
+        updateWrapper$1(domElement, nextRawProps);
+        break;
+
+      case 'select':
+        // <select> value update needs to occur after <option> children
+        // reconciliation
+        postUpdateWrapper(domElement, nextRawProps);
+        break;
+    }
+  }
+
+  function getPossibleStandardName(propName) {
+    {
+      var lowerCasedName = propName.toLowerCase();
+
+      if (!possibleStandardNames.hasOwnProperty(lowerCasedName)) {
+        return null;
+      }
+
+      return possibleStandardNames[lowerCasedName] || null;
+    }
+  }
+
+  function diffHydratedProperties(domElement, tag, rawProps, parentNamespace, rootContainerElement) {
+    var isCustomComponentTag;
+    var extraAttributeNames;
+
+    {
+      suppressHydrationWarning = rawProps[SUPPRESS_HYDRATION_WARNING] === true;
+      isCustomComponentTag = isCustomComponent(tag, rawProps);
+      validatePropertiesInDevelopment(tag, rawProps);
+    } // TODO: Make sure that we check isMounted before firing any of these events.
+
+
+    switch (tag) {
+      case 'iframe':
+      case 'object':
+      case 'embed':
+        trapBubbledEvent(TOP_LOAD, domElement);
+        break;
+
+      case 'video':
+      case 'audio':
+        // Create listener for each media event
+        for (var i = 0; i < mediaEventTypes.length; i++) {
+          trapBubbledEvent(mediaEventTypes[i], domElement);
+        }
+
+        break;
+
+      case 'source':
+        trapBubbledEvent(TOP_ERROR, domElement);
+        break;
+
+      case 'img':
+      case 'image':
+      case 'link':
+        trapBubbledEvent(TOP_ERROR, domElement);
+        trapBubbledEvent(TOP_LOAD, domElement);
+        break;
+
+      case 'form':
+        trapBubbledEvent(TOP_RESET, domElement);
+        trapBubbledEvent(TOP_SUBMIT, domElement);
+        break;
+
+      case 'details':
+        trapBubbledEvent(TOP_TOGGLE, domElement);
+        break;
+
+      case 'input':
+        initWrapperState(domElement, rawProps);
+        trapBubbledEvent(TOP_INVALID, domElement); // For controlled components we always need to ensure we're listening
+        // to onChange. Even if there is no listener.
+
+        ensureListeningTo(rootContainerElement, 'onChange');
+        break;
+
+      case 'option':
+        validateProps(domElement, rawProps);
+        break;
+
+      case 'select':
+        initWrapperState$1(domElement, rawProps);
+        trapBubbledEvent(TOP_INVALID, domElement); // For controlled components we always need to ensure we're listening
+        // to onChange. Even if there is no listener.
+
+        ensureListeningTo(rootContainerElement, 'onChange');
+        break;
+
+      case 'textarea':
+        initWrapperState$2(domElement, rawProps);
+        trapBubbledEvent(TOP_INVALID, domElement); // For controlled components we always need to ensure we're listening
+        // to onChange. Even if there is no listener.
+
+        ensureListeningTo(rootContainerElement, 'onChange');
+        break;
+    }
+
+    assertValidProps(tag, rawProps);
+
+    {
+      extraAttributeNames = new Set();
+      var attributes = domElement.attributes;
+
+      for (var _i = 0; _i < attributes.length; _i++) {
+        var name = attributes[_i].name.toLowerCase();
+
+        switch (name) {
+          // Built-in SSR attribute is whitelisted
+          case 'data-reactroot':
+            break;
+          // Controlled attributes are not validated
+          // TODO: Only ignore them on controlled tags.
+
+          case 'value':
+            break;
+
+          case 'checked':
+            break;
+
+          case 'selected':
+            break;
+
+          default:
+            // Intentionally use the original name.
+            // See discussion in https://github.com/facebook/react/pull/10676.
+            extraAttributeNames.add(attributes[_i].name);
+        }
+      }
+    }
+
+    var updatePayload = null;
+
+    for (var propKey in rawProps) {
+      if (!rawProps.hasOwnProperty(propKey)) {
+        continue;
+      }
+
+      var nextProp = rawProps[propKey];
+
+      if (propKey === CHILDREN) {
+        // For text content children we compare against textContent. This
+        // might match additional HTML that is hidden when we read it using
+        // textContent. E.g. "foo" will match "f<span>oo</span>" but that still
+        // satisfies our requirement. Our requirement is not to produce perfect
+        // HTML and attributes. Ideally we should preserve structure but it's
+        // ok not to if the visible content is still enough to indicate what
+        // even listeners these nodes might be wired up to.
+        // TODO: Warn if there is more than a single textNode as a child.
+        // TODO: Should we use domElement.firstChild.nodeValue to compare?
+        if (typeof nextProp === 'string') {
+          if (domElement.textContent !== nextProp) {
+            if ( !suppressHydrationWarning) {
+              warnForTextDifference(domElement.textContent, nextProp);
+            }
+
+            updatePayload = [CHILDREN, nextProp];
+          }
+        } else if (typeof nextProp === 'number') {
+          if (domElement.textContent !== '' + nextProp) {
+            if ( !suppressHydrationWarning) {
+              warnForTextDifference(domElement.textContent, nextProp);
+            }
+
+            updatePayload = [CHILDREN, '' + nextProp];
+          }
+        }
+      } else if (registrationNameModules.hasOwnProperty(propKey)) {
+        if (nextProp != null) {
+          if ( typeof nextProp !== 'function') {
+            warnForInvalidEventListener(propKey, nextProp);
+          }
+
+          ensureListeningTo(rootContainerElement, propKey);
+        }
+      } else if ( // Convince Flow we've calculated it (it's DEV-only in this method.)
+      typeof isCustomComponentTag === 'boolean') {
+        // Validate that the properties correspond to their expected values.
+        var serverValue = void 0;
+        var propertyInfo = getPropertyInfo(propKey);
+
+        if (suppressHydrationWarning) ; else if ( propKey === SUPPRESS_CONTENT_EDITABLE_WARNING || propKey === SUPPRESS_HYDRATION_WARNING || // Controlled attributes are not validated
+        // TODO: Only ignore them on controlled tags.
+        propKey === 'value' || propKey === 'checked' || propKey === 'selected') ; else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
+          var serverHTML = domElement.innerHTML;
+          var nextHtml = nextProp ? nextProp[HTML$1] : undefined;
+          var expectedHTML = normalizeHTML(domElement, nextHtml != null ? nextHtml : '');
+
+          if (expectedHTML !== serverHTML) {
+            warnForPropDifference(propKey, serverHTML, expectedHTML);
+          }
+        } else if (propKey === STYLE) {
+          // $FlowFixMe - Should be inferred as not undefined.
+          extraAttributeNames.delete(propKey);
+
+          if (canDiffStyleForHydrationWarning) {
+            var expectedStyle = createDangerousStringForStyles(nextProp);
+            serverValue = domElement.getAttribute('style');
+
+            if (expectedStyle !== serverValue) {
+              warnForPropDifference(propKey, serverValue, expectedStyle);
+            }
+          }
+        } else if (isCustomComponentTag) {
+          // $FlowFixMe - Should be inferred as not undefined.
+          extraAttributeNames.delete(propKey.toLowerCase());
+          serverValue = getValueForAttribute(domElement, propKey, nextProp);
+
+          if (nextProp !== serverValue) {
+            warnForPropDifference(propKey, serverValue, nextProp);
+          }
+        } else if (!shouldIgnoreAttribute(propKey, propertyInfo, isCustomComponentTag) && !shouldRemoveAttribute(propKey, nextProp, propertyInfo, isCustomComponentTag)) {
+          var isMismatchDueToBadCasing = false;
+
+          if (propertyInfo !== null) {
+            // $FlowFixMe - Should be inferred as not undefined.
+            extraAttributeNames.delete(propertyInfo.attributeName);
+            serverValue = getValueForProperty(domElement, propKey, nextProp, propertyInfo);
+          } else {
+            var ownNamespace = parentNamespace;
+
+            if (ownNamespace === HTML_NAMESPACE$1) {
+              ownNamespace = getIntrinsicNamespace(tag);
+            }
+
+            if (ownNamespace === HTML_NAMESPACE$1) {
+              // $FlowFixMe - Should be inferred as not undefined.
+              extraAttributeNames.delete(propKey.toLowerCase());
+            } else {
+              var standardName = getPossibleStandardName(propKey);
+
+              if (standardName !== null && standardName !== propKey) {
+                // If an SVG prop is supplied with bad casing, it will
+                // be successfully parsed from HTML, but will produce a mismatch
+                // (and would be incorrectly rendered on the client).
+                // However, we already warn about bad casing elsewhere.
+                // So we'll skip the misleading extra mismatch warning in this case.
+                isMismatchDueToBadCasing = true; // $FlowFixMe - Should be inferred as not undefined.
+
+                extraAttributeNames.delete(standardName);
+              } // $FlowFixMe - Should be inferred as not undefined.
+
+
+              extraAttributeNames.delete(propKey);
+            }
+
+            serverValue = getValueForAttribute(domElement, propKey, nextProp);
+          }
+
+          if (nextProp !== serverValue && !isMismatchDueToBadCasing) {
+            warnForPropDifference(propKey, serverValue, nextProp);
+          }
+        }
+      }
+    }
+
+    {
+      // $FlowFixMe - Should be inferred as not undefined.
+      if (extraAttributeNames.size > 0 && !suppressHydrationWarning) {
+        // $FlowFixMe - Should be inferred as not undefined.
+        warnForExtraAttributes(extraAttributeNames);
+      }
+    }
+
+    switch (tag) {
+      case 'input':
+        // TODO: Make sure we check if this is still unmounted or do any clean
+        // up necessary since we never stop tracking anymore.
+        track(domElement);
+        postMountWrapper(domElement, rawProps, true);
+        break;
+
+      case 'textarea':
+        // TODO: Make sure we check if this is still unmounted or do any clean
+        // up necessary since we never stop tracking anymore.
+        track(domElement);
+        postMountWrapper$3(domElement);
+        break;
+
+      case 'select':
+      case 'option':
+        // For input and textarea we current always set the value property at
+        // post mount to force it to diverge from attributes. However, for
+        // option and select we don't quite do the same thing and select
+        // is not resilient to the DOM state changing so we don't do that here.
+        // TODO: Consider not doing this for input and textarea.
+        break;
+
+      default:
+        if (typeof rawProps.onClick === 'function') {
+          // TODO: This cast may not be sound for SVG, MathML or custom elements.
+          trapClickOnNonInteractiveElement(domElement);
+        }
+
+        break;
+    }
+
+    return updatePayload;
+  }
+  function diffHydratedText(textNode, text) {
+    var isDifferent = textNode.nodeValue !== text;
+    return isDifferent;
+  }
+  function warnForUnmatchedText(textNode, text) {
+    {
+      warnForTextDifference(textNode.nodeValue, text);
+    }
+  }
+  function warnForDeletedHydratableElement(parentNode, child) {
+    {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Did not expect server HTML to contain a <%s> in <%s>.', child.nodeName.toLowerCase(), parentNode.nodeName.toLowerCase());
+    }
+  }
+  function warnForDeletedHydratableText(parentNode, child) {
+    {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Did not expect server HTML to contain the text node "%s" in <%s>.', child.nodeValue, parentNode.nodeName.toLowerCase());
+    }
+  }
+  function warnForInsertedHydratedElement(parentNode, tag, props) {
+    {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Expected server HTML to contain a matching <%s> in <%s>.', tag, parentNode.nodeName.toLowerCase());
+    }
+  }
+  function warnForInsertedHydratedText(parentNode, text) {
+    {
+      if (text === '') {
+        // We expect to insert empty text nodes since they're not represented in
+        // the HTML.
+        // TODO: Remove this special case if we can just avoid inserting empty
+        // text nodes.
+        return;
+      }
+
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Expected server HTML to contain a matching text node for "%s" in <%s>.', text, parentNode.nodeName.toLowerCase());
+    }
+  }
+  function restoreControlledState$3(domElement, tag, props) {
+    switch (tag) {
+      case 'input':
+        restoreControlledState(domElement, props);
+        return;
+
+      case 'textarea':
+        restoreControlledState$2(domElement, props);
+        return;
+
+      case 'select':
+        restoreControlledState$1(domElement, props);
+        return;
+    }
+  }
+
+  function getActiveElement(doc) {
+    doc = doc || (typeof document !== 'undefined' ? document : undefined);
+
+    if (typeof doc === 'undefined') {
+      return null;
+    }
+
+    try {
+      return doc.activeElement || doc.body;
+    } catch (e) {
+      return doc.body;
+    }
+  }
+
+  /**
+   * Given any node return the first leaf node without children.
+   *
+   * @param {DOMElement|DOMTextNode} node
+   * @return {DOMElement|DOMTextNode}
+   */
+
+  function getLeafNode(node) {
+    while (node && node.firstChild) {
+      node = node.firstChild;
+    }
+
+    return node;
+  }
+  /**
+   * Get the next sibling within a container. This will walk up the
+   * DOM if a node's siblings have been exhausted.
+   *
+   * @param {DOMElement|DOMTextNode} node
+   * @return {?DOMElement|DOMTextNode}
+   */
+
+
+  function getSiblingNode(node) {
+    while (node) {
+      if (node.nextSibling) {
+        return node.nextSibling;
+      }
+
+      node = node.parentNode;
+    }
+  }
+  /**
+   * Get object describing the nodes which contain characters at offset.
+   *
+   * @param {DOMElement|DOMTextNode} root
+   * @param {number} offset
+   * @return {?object}
+   */
+
+
+  function getNodeForCharacterOffset(root, offset) {
+    var node = getLeafNode(root);
+    var nodeStart = 0;
+    var nodeEnd = 0;
+
+    while (node) {
+      if (node.nodeType === TEXT_NODE) {
+        nodeEnd = nodeStart + node.textContent.length;
+
+        if (nodeStart <= offset && nodeEnd >= offset) {
+          return {
+            node: node,
+            offset: offset - nodeStart
+          };
+        }
+
+        nodeStart = nodeEnd;
+      }
+
+      node = getLeafNode(getSiblingNode(node));
+    }
+  }
+
+  /**
+   * @param {DOMElement} outerNode
+   * @return {?object}
+   */
+
+  function getOffsets(outerNode) {
+    var ownerDocument = outerNode.ownerDocument;
+    var win = ownerDocument && ownerDocument.defaultView || window;
+    var selection = win.getSelection && win.getSelection();
+
+    if (!selection || selection.rangeCount === 0) {
+      return null;
+    }
+
+    var anchorNode = selection.anchorNode,
+        anchorOffset = selection.anchorOffset,
+        focusNode = selection.focusNode,
+        focusOffset = selection.focusOffset; // In Firefox, anchorNode and focusNode can be "anonymous divs", e.g. the
+    // up/down buttons on an <input type="number">. Anonymous divs do not seem to
+    // expose properties, triggering a "Permission denied error" if any of its
+    // properties are accessed. The only seemingly possible way to avoid erroring
+    // is to access a property that typically works for non-anonymous divs and
+    // catch any error that may otherwise arise. See
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=208427
+
+    try {
+      /* eslint-disable no-unused-expressions */
+      anchorNode.nodeType;
+      focusNode.nodeType;
+      /* eslint-enable no-unused-expressions */
+    } catch (e) {
+      return null;
+    }
+
+    return getModernOffsetsFromPoints(outerNode, anchorNode, anchorOffset, focusNode, focusOffset);
+  }
+  /**
+   * Returns {start, end} where `start` is the character/codepoint index of
+   * (anchorNode, anchorOffset) within the textContent of `outerNode`, and
+   * `end` is the index of (focusNode, focusOffset).
+   *
+   * Returns null if you pass in garbage input but we should probably just crash.
+   *
+   * Exported only for testing.
+   */
+
+  function getModernOffsetsFromPoints(outerNode, anchorNode, anchorOffset, focusNode, focusOffset) {
+    var length = 0;
+    var start = -1;
+    var end = -1;
+    var indexWithinAnchor = 0;
+    var indexWithinFocus = 0;
+    var node = outerNode;
+    var parentNode = null;
+
+    outer: while (true) {
+      var next = null;
+
+      while (true) {
+        if (node === anchorNode && (anchorOffset === 0 || node.nodeType === TEXT_NODE)) {
+          start = length + anchorOffset;
+        }
+
+        if (node === focusNode && (focusOffset === 0 || node.nodeType === TEXT_NODE)) {
+          end = length + focusOffset;
+        }
+
+        if (node.nodeType === TEXT_NODE) {
+          length += node.nodeValue.length;
+        }
+
+        if ((next = node.firstChild) === null) {
+          break;
+        } // Moving from `node` to its first child `next`.
+
+
+        parentNode = node;
+        node = next;
+      }
+
+      while (true) {
+        if (node === outerNode) {
+          // If `outerNode` has children, this is always the second time visiting
+          // it. If it has no children, this is still the first loop, and the only
+          // valid selection is anchorNode and focusNode both equal to this node
+          // and both offsets 0, in which case we will have handled above.
+          break outer;
+        }
+
+        if (parentNode === anchorNode && ++indexWithinAnchor === anchorOffset) {
+          start = length;
+        }
+
+        if (parentNode === focusNode && ++indexWithinFocus === focusOffset) {
+          end = length;
+        }
+
+        if ((next = node.nextSibling) !== null) {
+          break;
+        }
+
+        node = parentNode;
+        parentNode = node.parentNode;
+      } // Moving from `node` to its next sibling `next`.
+
+
+      node = next;
+    }
+
+    if (start === -1 || end === -1) {
+      // This should never happen. (Would happen if the anchor/focus nodes aren't
+      // actually inside the passed-in node.)
+      return null;
+    }
+
+    return {
+      start: start,
+      end: end
+    };
+  }
+  /**
+   * In modern non-IE browsers, we can support both forward and backward
+   * selections.
+   *
+   * Note: IE10+ supports the Selection object, but it does not support
+   * the `extend` method, which means that even in modern IE, it's not possible
+   * to programmatically create a backward selection. Thus, for all IE
+   * versions, we use the old IE API to create our selections.
+   *
+   * @param {DOMElement|DOMTextNode} node
+   * @param {object} offsets
+   */
+
+  function setOffsets(node, offsets) {
+    var doc = node.ownerDocument || document;
+    var win = doc && doc.defaultView || window; // Edge fails with "Object expected" in some scenarios.
+    // (For instance: TinyMCE editor used in a list component that supports pasting to add more,
+    // fails when pasting 100+ items)
+
+    if (!win.getSelection) {
+      return;
+    }
+
+    var selection = win.getSelection();
+    var length = node.textContent.length;
+    var start = Math.min(offsets.start, length);
+    var end = offsets.end === undefined ? start : Math.min(offsets.end, length); // IE 11 uses modern selection, but doesn't support the extend method.
+    // Flip backward selections, so we can set with a single range.
+
+    if (!selection.extend && start > end) {
+      var temp = end;
+      end = start;
+      start = temp;
+    }
+
+    var startMarker = getNodeForCharacterOffset(node, start);
+    var endMarker = getNodeForCharacterOffset(node, end);
+
+    if (startMarker && endMarker) {
+      if (selection.rangeCount === 1 && selection.anchorNode === startMarker.node && selection.anchorOffset === startMarker.offset && selection.focusNode === endMarker.node && selection.focusOffset === endMarker.offset) {
+        return;
+      }
+
+      var range = doc.createRange();
+      range.setStart(startMarker.node, startMarker.offset);
+      selection.removeAllRanges();
+
+      if (start > end) {
+        selection.addRange(range);
+        selection.extend(endMarker.node, endMarker.offset);
+      } else {
+        range.setEnd(endMarker.node, endMarker.offset);
+        selection.addRange(range);
+      }
+    }
+  }
+
+  function isTextNode(node) {
+    return node && node.nodeType === TEXT_NODE;
+  }
+
+  function containsNode(outerNode, innerNode) {
+    if (!outerNode || !innerNode) {
+      return false;
+    } else if (outerNode === innerNode) {
+      return true;
+    } else if (isTextNode(outerNode)) {
+      return false;
+    } else if (isTextNode(innerNode)) {
+      return containsNode(outerNode, innerNode.parentNode);
+    } else if ('contains' in outerNode) {
+      return outerNode.contains(innerNode);
+    } else if (outerNode.compareDocumentPosition) {
+      return !!(outerNode.compareDocumentPosition(innerNode) & 16);
+    } else {
+      return false;
+    }
+  }
+
+  function isInDocument(node) {
+    return node && node.ownerDocument && containsNode(node.ownerDocument.documentElement, node);
+  }
+
+  function isSameOriginFrame(iframe) {
+    try {
+      // Accessing the contentDocument of a HTMLIframeElement can cause the browser
+      // to throw, e.g. if it has a cross-origin src attribute.
+      // Safari will show an error in the console when the access results in "Blocked a frame with origin". e.g:
+      // iframe.contentDocument.defaultView;
+      // A safety way is to access one of the cross origin properties: Window or Location
+      // Which might result in "SecurityError" DOM Exception and it is compatible to Safari.
+      // https://html.spec.whatwg.org/multipage/browsers.html#integration-with-idl
+      return typeof iframe.contentWindow.location.href === 'string';
+    } catch (err) {
+      return false;
+    }
+  }
+
+  function getActiveElementDeep() {
+    var win = window;
+    var element = getActiveElement();
+
+    while (element instanceof win.HTMLIFrameElement) {
+      if (isSameOriginFrame(element)) {
+        win = element.contentWindow;
+      } else {
+        return element;
+      }
+
+      element = getActiveElement(win.document);
+    }
+
+    return element;
+  }
+  /**
+   * @ReactInputSelection: React input selection module. Based on Selection.js,
+   * but modified to be suitable for react and has a couple of bug fixes (doesn't
+   * assume buttons have range selections allowed).
+   * Input selection module for React.
+   */
+
+  /**
+   * @hasSelectionCapabilities: we get the element types that support selection
+   * from https://html.spec.whatwg.org/#do-not-apply, looking at `selectionStart`
+   * and `selectionEnd` rows.
+   */
+
+
+  function hasSelectionCapabilities(elem) {
+    var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+    return nodeName && (nodeName === 'input' && (elem.type === 'text' || elem.type === 'search' || elem.type === 'tel' || elem.type === 'url' || elem.type === 'password') || nodeName === 'textarea' || elem.contentEditable === 'true');
+  }
+  function getSelectionInformation() {
+    var focusedElem = getActiveElementDeep();
+    return {
+      // Used by Flare
+      activeElementDetached: null,
+      focusedElem: focusedElem,
+      selectionRange: hasSelectionCapabilities(focusedElem) ? getSelection(focusedElem) : null
+    };
+  }
+  /**
+   * @restoreSelection: If any selection information was potentially lost,
+   * restore it. This is useful when performing operations that could remove dom
+   * nodes and place them back in, resulting in focus being lost.
+   */
+
+  function restoreSelection(priorSelectionInformation) {
+    var curFocusedElem = getActiveElementDeep();
+    var priorFocusedElem = priorSelectionInformation.focusedElem;
+    var priorSelectionRange = priorSelectionInformation.selectionRange;
+
+    if (curFocusedElem !== priorFocusedElem && isInDocument(priorFocusedElem)) {
+      if (priorSelectionRange !== null && hasSelectionCapabilities(priorFocusedElem)) {
+        setSelection(priorFocusedElem, priorSelectionRange);
+      } // Focusing a node can change the scroll position, which is undesirable
+
+
+      var ancestors = [];
+      var ancestor = priorFocusedElem;
+
+      while (ancestor = ancestor.parentNode) {
+        if (ancestor.nodeType === ELEMENT_NODE) {
+          ancestors.push({
+            element: ancestor,
+            left: ancestor.scrollLeft,
+            top: ancestor.scrollTop
+          });
+        }
+      }
+
+      if (typeof priorFocusedElem.focus === 'function') {
+        priorFocusedElem.focus();
+      }
+
+      for (var i = 0; i < ancestors.length; i++) {
+        var info = ancestors[i];
+        info.element.scrollLeft = info.left;
+        info.element.scrollTop = info.top;
+      }
+    }
+  }
+  /**
+   * @getSelection: Gets the selection bounds of a focused textarea, input or
+   * contentEditable node.
+   * -@input: Look up selection bounds of this input
+   * -@return {start: selectionStart, end: selectionEnd}
+   */
+
+  function getSelection(input) {
+    var selection;
+
+    if ('selectionStart' in input) {
+      // Modern browser with input or textarea.
+      selection = {
+        start: input.selectionStart,
+        end: input.selectionEnd
+      };
+    } else {
+      // Content editable or old IE textarea.
+      selection = getOffsets(input);
+    }
+
+    return selection || {
+      start: 0,
+      end: 0
+    };
+  }
+  /**
+   * @setSelection: Sets the selection bounds of a textarea or input and focuses
+   * the input.
+   * -@input     Set selection bounds of this input or textarea
+   * -@offsets   Object of same form that is returned from get*
+   */
+
+  function setSelection(input, offsets) {
+    var start = offsets.start,
+        end = offsets.end;
+
+    if (end === undefined) {
+      end = start;
+    }
+
+    if ('selectionStart' in input) {
+      input.selectionStart = start;
+      input.selectionEnd = Math.min(end, input.value.length);
+    } else {
+      setOffsets(input, offsets);
+    }
+  }
+
+  var validateDOMNesting = function () {};
+
+  var updatedAncestorInfo = function () {};
+
+  {
+    // This validation code was written based on the HTML5 parsing spec:
+    // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-scope
+    //
+    // Note: this does not catch all invalid nesting, nor does it try to (as it's
+    // not clear what practical benefit doing so provides); instead, we warn only
+    // for cases where the parser will give a parse tree differing from what React
+    // intended. For example, <b><div></div></b> is invalid but we don't warn
+    // because it still parses correctly; we do warn for other cases like nested
+    // <p> tags where the beginning of the second element implicitly closes the
+    // first, causing a confusing mess.
+    // https://html.spec.whatwg.org/multipage/syntax.html#special
+    var specialTags = ['address', 'applet', 'area', 'article', 'aside', 'base', 'basefont', 'bgsound', 'blockquote', 'body', 'br', 'button', 'caption', 'center', 'col', 'colgroup', 'dd', 'details', 'dir', 'div', 'dl', 'dt', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'frame', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'iframe', 'img', 'input', 'isindex', 'li', 'link', 'listing', 'main', 'marquee', 'menu', 'menuitem', 'meta', 'nav', 'noembed', 'noframes', 'noscript', 'object', 'ol', 'p', 'param', 'plaintext', 'pre', 'script', 'section', 'select', 'source', 'style', 'summary', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'title', 'tr', 'track', 'ul', 'wbr', 'xmp']; // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-scope
+
+    var inScopeTags = ['applet', 'caption', 'html', 'table', 'td', 'th', 'marquee', 'object', 'template', // https://html.spec.whatwg.org/multipage/syntax.html#html-integration-point
+    // TODO: Distinguish by namespace here -- for <title>, including it here
+    // errs on the side of fewer warnings
+    'foreignObject', 'desc', 'title']; // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-button-scope
+
+    var buttonScopeTags = inScopeTags.concat(['button']); // https://html.spec.whatwg.org/multipage/syntax.html#generate-implied-end-tags
+
+    var impliedEndTags = ['dd', 'dt', 'li', 'option', 'optgroup', 'p', 'rp', 'rt'];
+    var emptyAncestorInfo = {
+      current: null,
+      formTag: null,
+      aTagInScope: null,
+      buttonTagInScope: null,
+      nobrTagInScope: null,
+      pTagInButtonScope: null,
+      listItemTagAutoclosing: null,
+      dlItemTagAutoclosing: null
+    };
+
+    updatedAncestorInfo = function (oldInfo, tag) {
+      var ancestorInfo = _assign({}, oldInfo || emptyAncestorInfo);
+
+      var info = {
+        tag: tag
+      };
+
+      if (inScopeTags.indexOf(tag) !== -1) {
+        ancestorInfo.aTagInScope = null;
+        ancestorInfo.buttonTagInScope = null;
+        ancestorInfo.nobrTagInScope = null;
+      }
+
+      if (buttonScopeTags.indexOf(tag) !== -1) {
+        ancestorInfo.pTagInButtonScope = null;
+      } // See rules for 'li', 'dd', 'dt' start tags in
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inbody
+
+
+      if (specialTags.indexOf(tag) !== -1 && tag !== 'address' && tag !== 'div' && tag !== 'p') {
+        ancestorInfo.listItemTagAutoclosing = null;
+        ancestorInfo.dlItemTagAutoclosing = null;
+      }
+
+      ancestorInfo.current = info;
+
+      if (tag === 'form') {
+        ancestorInfo.formTag = info;
+      }
+
+      if (tag === 'a') {
+        ancestorInfo.aTagInScope = info;
+      }
+
+      if (tag === 'button') {
+        ancestorInfo.buttonTagInScope = info;
+      }
+
+      if (tag === 'nobr') {
+        ancestorInfo.nobrTagInScope = info;
+      }
+
+      if (tag === 'p') {
+        ancestorInfo.pTagInButtonScope = info;
+      }
+
+      if (tag === 'li') {
+        ancestorInfo.listItemTagAutoclosing = info;
+      }
+
+      if (tag === 'dd' || tag === 'dt') {
+        ancestorInfo.dlItemTagAutoclosing = info;
+      }
+
+      return ancestorInfo;
+    };
+    /**
+     * Returns whether
+     */
+
+
+    var isTagValidWithParent = function (tag, parentTag) {
+      // First, let's check if we're in an unusual parsing mode...
+      switch (parentTag) {
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inselect
+        case 'select':
+          return tag === 'option' || tag === 'optgroup' || tag === '#text';
+
+        case 'optgroup':
+          return tag === 'option' || tag === '#text';
+        // Strictly speaking, seeing an <option> doesn't mean we're in a <select>
+        // but
+
+        case 'option':
+          return tag === '#text';
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intd
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-incaption
+        // No special behavior since these rules fall back to "in body" mode for
+        // all except special table nodes which cause bad parsing behavior anyway.
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intr
+
+        case 'tr':
+          return tag === 'th' || tag === 'td' || tag === 'style' || tag === 'script' || tag === 'template';
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intbody
+
+        case 'tbody':
+        case 'thead':
+        case 'tfoot':
+          return tag === 'tr' || tag === 'style' || tag === 'script' || tag === 'template';
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-incolgroup
+
+        case 'colgroup':
+          return tag === 'col' || tag === 'template';
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intable
+
+        case 'table':
+          return tag === 'caption' || tag === 'colgroup' || tag === 'tbody' || tag === 'tfoot' || tag === 'thead' || tag === 'style' || tag === 'script' || tag === 'template';
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inhead
+
+        case 'head':
+          return tag === 'base' || tag === 'basefont' || tag === 'bgsound' || tag === 'link' || tag === 'meta' || tag === 'title' || tag === 'noscript' || tag === 'noframes' || tag === 'style' || tag === 'script' || tag === 'template';
+        // https://html.spec.whatwg.org/multipage/semantics.html#the-html-element
+
+        case 'html':
+          return tag === 'head' || tag === 'body' || tag === 'frameset';
+
+        case 'frameset':
+          return tag === 'frame';
+
+        case '#document':
+          return tag === 'html';
+      } // Probably in the "in body" parsing mode, so we outlaw only tag combos
+      // where the parsing rules cause implicit opens or closes to be added.
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inbody
+
+
+      switch (tag) {
+        case 'h1':
+        case 'h2':
+        case 'h3':
+        case 'h4':
+        case 'h5':
+        case 'h6':
+          return parentTag !== 'h1' && parentTag !== 'h2' && parentTag !== 'h3' && parentTag !== 'h4' && parentTag !== 'h5' && parentTag !== 'h6';
+
+        case 'rp':
+        case 'rt':
+          return impliedEndTags.indexOf(parentTag) === -1;
+
+        case 'body':
+        case 'caption':
+        case 'col':
+        case 'colgroup':
+        case 'frameset':
+        case 'frame':
+        case 'head':
+        case 'html':
+        case 'tbody':
+        case 'td':
+        case 'tfoot':
+        case 'th':
+        case 'thead':
+        case 'tr':
+          // These tags are only valid with a few parents that have special child
+          // parsing rules -- if we're down here, then none of those matched and
+          // so we allow it only if we don't know what the parent is, as all other
+          // cases are invalid.
+          return parentTag == null;
+      }
+
+      return true;
+    };
+    /**
+     * Returns whether
+     */
+
+
+    var findInvalidAncestorForTag = function (tag, ancestorInfo) {
+      switch (tag) {
+        case 'address':
+        case 'article':
+        case 'aside':
+        case 'blockquote':
+        case 'center':
+        case 'details':
+        case 'dialog':
+        case 'dir':
+        case 'div':
+        case 'dl':
+        case 'fieldset':
+        case 'figcaption':
+        case 'figure':
+        case 'footer':
+        case 'header':
+        case 'hgroup':
+        case 'main':
+        case 'menu':
+        case 'nav':
+        case 'ol':
+        case 'p':
+        case 'section':
+        case 'summary':
+        case 'ul':
+        case 'pre':
+        case 'listing':
+        case 'table':
+        case 'hr':
+        case 'xmp':
+        case 'h1':
+        case 'h2':
+        case 'h3':
+        case 'h4':
+        case 'h5':
+        case 'h6':
+          return ancestorInfo.pTagInButtonScope;
+
+        case 'form':
+          return ancestorInfo.formTag || ancestorInfo.pTagInButtonScope;
+
+        case 'li':
+          return ancestorInfo.listItemTagAutoclosing;
+
+        case 'dd':
+        case 'dt':
+          return ancestorInfo.dlItemTagAutoclosing;
+
+        case 'button':
+          return ancestorInfo.buttonTagInScope;
+
+        case 'a':
+          // Spec says something about storing a list of markers, but it sounds
+          // equivalent to this check.
+          return ancestorInfo.aTagInScope;
+
+        case 'nobr':
+          return ancestorInfo.nobrTagInScope;
+      }
+
+      return null;
+    };
+
+    var didWarn$1 = {};
+
+    validateDOMNesting = function (childTag, childText, ancestorInfo) {
+      ancestorInfo = ancestorInfo || emptyAncestorInfo;
+      var parentInfo = ancestorInfo.current;
+      var parentTag = parentInfo && parentInfo.tag;
+
+      if (childText != null) {
+        if (childTag != null) {
+          error('validateDOMNesting: when childText is passed, childTag should be null');
+        }
+
+        childTag = '#text';
+      }
+
+      var invalidParent = isTagValidWithParent(childTag, parentTag) ? null : parentInfo;
+      var invalidAncestor = invalidParent ? null : findInvalidAncestorForTag(childTag, ancestorInfo);
+      var invalidParentOrAncestor = invalidParent || invalidAncestor;
+
+      if (!invalidParentOrAncestor) {
+        return;
+      }
+
+      var ancestorTag = invalidParentOrAncestor.tag;
+      var addendum = getCurrentFiberStackInDev();
+      var warnKey = !!invalidParent + '|' + childTag + '|' + ancestorTag + '|' + addendum;
+
+      if (didWarn$1[warnKey]) {
+        return;
+      }
+
+      didWarn$1[warnKey] = true;
+      var tagDisplayName = childTag;
+      var whitespaceInfo = '';
+
+      if (childTag === '#text') {
+        if (/\S/.test(childText)) {
+          tagDisplayName = 'Text nodes';
+        } else {
+          tagDisplayName = 'Whitespace text nodes';
+          whitespaceInfo = " Make sure you don't have any extra whitespace between tags on " + 'each line of your source code.';
+        }
+      } else {
+        tagDisplayName = '<' + childTag + '>';
+      }
+
+      if (invalidParent) {
+        var info = '';
+
+        if (ancestorTag === 'table' && childTag === 'tr') {
+          info += ' Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated by ' + 'the browser.';
+        }
+
+        error('validateDOMNesting(...): %s cannot appear as a child of <%s>.%s%s', tagDisplayName, ancestorTag, whitespaceInfo, info);
+      } else {
+        error('validateDOMNesting(...): %s cannot appear as a descendant of ' + '<%s>.', tagDisplayName, ancestorTag);
+      }
+    };
+  }
+
+  var SUPPRESS_HYDRATION_WARNING$1;
+
+  {
+    SUPPRESS_HYDRATION_WARNING$1 = 'suppressHydrationWarning';
+  }
+
+  var SUSPENSE_START_DATA = '$';
+  var SUSPENSE_END_DATA = '/$';
+  var SUSPENSE_PENDING_START_DATA = '$?';
+  var SUSPENSE_FALLBACK_START_DATA = '$!';
+  var STYLE$1 = 'style';
+  var eventsEnabled = null;
+  var selectionInformation = null;
+
+  function shouldAutoFocusHostComponent(type, props) {
+    switch (type) {
+      case 'button':
+      case 'input':
+      case 'select':
+      case 'textarea':
+        return !!props.autoFocus;
+    }
+
+    return false;
+  }
+  function getRootHostContext(rootContainerInstance) {
+    var type;
+    var namespace;
+    var nodeType = rootContainerInstance.nodeType;
+
+    switch (nodeType) {
+      case DOCUMENT_NODE:
+      case DOCUMENT_FRAGMENT_NODE:
+        {
+          type = nodeType === DOCUMENT_NODE ? '#document' : '#fragment';
+          var root = rootContainerInstance.documentElement;
+          namespace = root ? root.namespaceURI : getChildNamespace(null, '');
+          break;
+        }
+
+      default:
+        {
+          var container = nodeType === COMMENT_NODE ? rootContainerInstance.parentNode : rootContainerInstance;
+          var ownNamespace = container.namespaceURI || null;
+          type = container.tagName;
+          namespace = getChildNamespace(ownNamespace, type);
+          break;
+        }
+    }
+
+    {
+      var validatedTag = type.toLowerCase();
+      var ancestorInfo = updatedAncestorInfo(null, validatedTag);
+      return {
+        namespace: namespace,
+        ancestorInfo: ancestorInfo
+      };
+    }
+  }
+  function getChildHostContext(parentHostContext, type, rootContainerInstance) {
+    {
+      var parentHostContextDev = parentHostContext;
+      var namespace = getChildNamespace(parentHostContextDev.namespace, type);
+      var ancestorInfo = updatedAncestorInfo(parentHostContextDev.ancestorInfo, type);
+      return {
+        namespace: namespace,
+        ancestorInfo: ancestorInfo
+      };
+    }
+  }
+  function getPublicInstance(instance) {
+    return instance;
+  }
+  function prepareForCommit(containerInfo) {
+    eventsEnabled = isEnabled();
+    selectionInformation = getSelectionInformation();
+    setEnabled(false);
+  }
+  function resetAfterCommit(containerInfo) {
+    restoreSelection(selectionInformation);
+    setEnabled(eventsEnabled);
+    eventsEnabled = null;
+
+    selectionInformation = null;
+  }
+  function createInstance(type, props, rootContainerInstance, hostContext, internalInstanceHandle) {
+    var parentNamespace;
+
+    {
+      // TODO: take namespace into account when validating.
+      var hostContextDev = hostContext;
+      validateDOMNesting(type, null, hostContextDev.ancestorInfo);
+
+      if (typeof props.children === 'string' || typeof props.children === 'number') {
+        var string = '' + props.children;
+        var ownAncestorInfo = updatedAncestorInfo(hostContextDev.ancestorInfo, type);
+        validateDOMNesting(null, string, ownAncestorInfo);
+      }
+
+      parentNamespace = hostContextDev.namespace;
+    }
+
+    var domElement = createElement(type, props, rootContainerInstance, parentNamespace);
+    precacheFiberNode(internalInstanceHandle, domElement);
+    updateFiberProps(domElement, props);
+    return domElement;
+  }
+  function appendInitialChild(parentInstance, child) {
+    parentInstance.appendChild(child);
+  }
+  function finalizeInitialChildren(domElement, type, props, rootContainerInstance, hostContext) {
+    setInitialProperties(domElement, type, props, rootContainerInstance);
+    return shouldAutoFocusHostComponent(type, props);
+  }
+  function prepareUpdate(domElement, type, oldProps, newProps, rootContainerInstance, hostContext) {
+    {
+      var hostContextDev = hostContext;
+
+      if (typeof newProps.children !== typeof oldProps.children && (typeof newProps.children === 'string' || typeof newProps.children === 'number')) {
+        var string = '' + newProps.children;
+        var ownAncestorInfo = updatedAncestorInfo(hostContextDev.ancestorInfo, type);
+        validateDOMNesting(null, string, ownAncestorInfo);
+      }
+    }
+
+    return diffProperties(domElement, type, oldProps, newProps, rootContainerInstance);
+  }
+  function shouldSetTextContent(type, props) {
+    return type === 'textarea' || type === 'option' || type === 'noscript' || typeof props.children === 'string' || typeof props.children === 'number' || typeof props.dangerouslySetInnerHTML === 'object' && props.dangerouslySetInnerHTML !== null && props.dangerouslySetInnerHTML.__html != null;
+  }
+  function shouldDeprioritizeSubtree(type, props) {
+    return !!props.hidden;
+  }
+  function createTextInstance(text, rootContainerInstance, hostContext, internalInstanceHandle) {
+    {
+      var hostContextDev = hostContext;
+      validateDOMNesting(null, text, hostContextDev.ancestorInfo);
+    }
+
+    var textNode = createTextNode(text, rootContainerInstance);
+    precacheFiberNode(internalInstanceHandle, textNode);
+    return textNode;
+  }
+  // if a component just imports ReactDOM (e.g. for findDOMNode).
+  // Some environments might not have setTimeout or clearTimeout.
+
+  var scheduleTimeout = typeof setTimeout === 'function' ? setTimeout : undefined;
+  var cancelTimeout = typeof clearTimeout === 'function' ? clearTimeout : undefined;
+  var noTimeout = -1; // -------------------
+  function commitMount(domElement, type, newProps, internalInstanceHandle) {
+    // Despite the naming that might imply otherwise, this method only
+    // fires if there is an `Update` effect scheduled during mounting.
+    // This happens if `finalizeInitialChildren` returns `true` (which it
+    // does to implement the `autoFocus` attribute on the client). But
+    // there are also other cases when this might happen (such as patching
+    // up text content during hydration mismatch). So we'll check this again.
+    if (shouldAutoFocusHostComponent(type, newProps)) {
+      domElement.focus();
+    }
+  }
+  function commitUpdate(domElement, updatePayload, type, oldProps, newProps, internalInstanceHandle) {
+    // Update the props handle so that we know which props are the ones with
+    // with current event handlers.
+    updateFiberProps(domElement, newProps); // Apply the diff to the DOM node.
+
+    updateProperties(domElement, updatePayload, type, oldProps, newProps);
+  }
+  function resetTextContent(domElement) {
+    setTextContent(domElement, '');
+  }
+  function commitTextUpdate(textInstance, oldText, newText) {
+    textInstance.nodeValue = newText;
+  }
+  function appendChild(parentInstance, child) {
+    parentInstance.appendChild(child);
+  }
+  function appendChildToContainer(container, child) {
+    var parentNode;
+
+    if (container.nodeType === COMMENT_NODE) {
+      parentNode = container.parentNode;
+      parentNode.insertBefore(child, container);
+    } else {
+      parentNode = container;
+      parentNode.appendChild(child);
+    } // This container might be used for a portal.
+    // If something inside a portal is clicked, that click should bubble
+    // through the React tree. However, on Mobile Safari the click would
+    // never bubble through the *DOM* tree unless an ancestor with onclick
+    // event exists. So we wouldn't see it and dispatch it.
+    // This is why we ensure that non React root containers have inline onclick
+    // defined.
+    // https://github.com/facebook/react/issues/11918
+
+
+    var reactRootContainer = container._reactRootContainer;
+
+    if ((reactRootContainer === null || reactRootContainer === undefined) && parentNode.onclick === null) {
+      // TODO: This cast may not be sound for SVG, MathML or custom elements.
+      trapClickOnNonInteractiveElement(parentNode);
+    }
+  }
+  function insertBefore(parentInstance, child, beforeChild) {
+    parentInstance.insertBefore(child, beforeChild);
+  }
+  function insertInContainerBefore(container, child, beforeChild) {
+    if (container.nodeType === COMMENT_NODE) {
+      container.parentNode.insertBefore(child, beforeChild);
+    } else {
+      container.insertBefore(child, beforeChild);
+    }
+  }
+  function removeChild(parentInstance, child) {
+    parentInstance.removeChild(child);
+  }
+  function removeChildFromContainer(container, child) {
+    if (container.nodeType === COMMENT_NODE) {
+      container.parentNode.removeChild(child);
+    } else {
+      container.removeChild(child);
+    }
+  }
+
+  function hideInstance(instance) {
+    // pass host context to this method?
+
+
+    instance = instance;
+    var style = instance.style;
+
+    if (typeof style.setProperty === 'function') {
+      style.setProperty('display', 'none', 'important');
+    } else {
+      style.display = 'none';
+    }
+  }
+  function hideTextInstance(textInstance) {
+    textInstance.nodeValue = '';
+  }
+  function unhideInstance(instance, props) {
+    instance = instance;
+    var styleProp = props[STYLE$1];
+    var display = styleProp !== undefined && styleProp !== null && styleProp.hasOwnProperty('display') ? styleProp.display : null;
+    instance.style.display = dangerousStyleValue('display', display);
+  }
+  function unhideTextInstance(textInstance, text) {
+    textInstance.nodeValue = text;
+  } // -------------------
+  function canHydrateInstance(instance, type, props) {
+    if (instance.nodeType !== ELEMENT_NODE || type.toLowerCase() !== instance.nodeName.toLowerCase()) {
+      return null;
+    } // This has now been refined to an element node.
+
+
+    return instance;
+  }
+  function canHydrateTextInstance(instance, text) {
+    if (text === '' || instance.nodeType !== TEXT_NODE) {
+      // Empty strings are not parsed by HTML so there won't be a correct match here.
+      return null;
+    } // This has now been refined to a text node.
+
+
+    return instance;
+  }
+  function isSuspenseInstancePending(instance) {
+    return instance.data === SUSPENSE_PENDING_START_DATA;
+  }
+  function isSuspenseInstanceFallback(instance) {
+    return instance.data === SUSPENSE_FALLBACK_START_DATA;
+  }
+
+  function getNextHydratable(node) {
+    // Skip non-hydratable nodes.
+    for (; node != null; node = node.nextSibling) {
+      var nodeType = node.nodeType;
+
+      if (nodeType === ELEMENT_NODE || nodeType === TEXT_NODE) {
+        break;
+      }
+    }
+
+    return node;
+  }
+
+  function getNextHydratableSibling(instance) {
+    return getNextHydratable(instance.nextSibling);
+  }
+  function getFirstHydratableChild(parentInstance) {
+    return getNextHydratable(parentInstance.firstChild);
+  }
+  function hydrateInstance(instance, type, props, rootContainerInstance, hostContext, internalInstanceHandle) {
+    precacheFiberNode(internalInstanceHandle, instance); // TODO: Possibly defer this until the commit phase where all the events
+    // get attached.
+
+    updateFiberProps(instance, props);
+    var parentNamespace;
+
+    {
+      var hostContextDev = hostContext;
+      parentNamespace = hostContextDev.namespace;
+    }
+
+    return diffHydratedProperties(instance, type, props, parentNamespace, rootContainerInstance);
+  }
+  function hydrateTextInstance(textInstance, text, internalInstanceHandle) {
+    precacheFiberNode(internalInstanceHandle, textInstance);
+    return diffHydratedText(textInstance, text);
+  }
+  function getNextHydratableInstanceAfterSuspenseInstance(suspenseInstance) {
+    var node = suspenseInstance.nextSibling; // Skip past all nodes within this suspense boundary.
+    // There might be nested nodes so we need to keep track of how
+    // deep we are and only break out when we're back on top.
+
+    var depth = 0;
+
+    while (node) {
+      if (node.nodeType === COMMENT_NODE) {
+        var data = node.data;
+
+        if (data === SUSPENSE_END_DATA) {
+          if (depth === 0) {
+            return getNextHydratableSibling(node);
+          } else {
+            depth--;
+          }
+        } else if (data === SUSPENSE_START_DATA || data === SUSPENSE_FALLBACK_START_DATA || data === SUSPENSE_PENDING_START_DATA) {
+          depth++;
+        }
+      }
+
+      node = node.nextSibling;
+    } // TODO: Warn, we didn't find the end comment boundary.
+
+
+    return null;
+  } // Returns the SuspenseInstance if this node is a direct child of a
+  // SuspenseInstance. I.e. if its previous sibling is a Comment with
+  // SUSPENSE_x_START_DATA. Otherwise, null.
+
+  function getParentSuspenseInstance(targetInstance) {
+    var node = targetInstance.previousSibling; // Skip past all nodes within this suspense boundary.
+    // There might be nested nodes so we need to keep track of how
+    // deep we are and only break out when we're back on top.
+
+    var depth = 0;
+
+    while (node) {
+      if (node.nodeType === COMMENT_NODE) {
+        var data = node.data;
+
+        if (data === SUSPENSE_START_DATA || data === SUSPENSE_FALLBACK_START_DATA || data === SUSPENSE_PENDING_START_DATA) {
+          if (depth === 0) {
+            return node;
+          } else {
+            depth--;
+          }
+        } else if (data === SUSPENSE_END_DATA) {
+          depth++;
+        }
+      }
+
+      node = node.previousSibling;
+    }
+
+    return null;
+  }
+  function commitHydratedContainer(container) {
+    // Retry if any event replaying was blocked on this.
+    retryIfBlockedOn(container);
+  }
+  function commitHydratedSuspenseInstance(suspenseInstance) {
+    // Retry if any event replaying was blocked on this.
+    retryIfBlockedOn(suspenseInstance);
+  }
+  function didNotMatchHydratedContainerTextInstance(parentContainer, textInstance, text) {
+    {
+      warnForUnmatchedText(textInstance, text);
+    }
+  }
+  function didNotMatchHydratedTextInstance(parentType, parentProps, parentInstance, textInstance, text) {
+    if ( parentProps[SUPPRESS_HYDRATION_WARNING$1] !== true) {
+      warnForUnmatchedText(textInstance, text);
+    }
+  }
+  function didNotHydrateContainerInstance(parentContainer, instance) {
+    {
+      if (instance.nodeType === ELEMENT_NODE) {
+        warnForDeletedHydratableElement(parentContainer, instance);
+      } else if (instance.nodeType === COMMENT_NODE) ; else {
+        warnForDeletedHydratableText(parentContainer, instance);
+      }
+    }
+  }
+  function didNotHydrateInstance(parentType, parentProps, parentInstance, instance) {
+    if ( parentProps[SUPPRESS_HYDRATION_WARNING$1] !== true) {
+      if (instance.nodeType === ELEMENT_NODE) {
+        warnForDeletedHydratableElement(parentInstance, instance);
+      } else if (instance.nodeType === COMMENT_NODE) ; else {
+        warnForDeletedHydratableText(parentInstance, instance);
+      }
+    }
+  }
+  function didNotFindHydratableContainerInstance(parentContainer, type, props) {
+    {
+      warnForInsertedHydratedElement(parentContainer, type);
+    }
+  }
+  function didNotFindHydratableContainerTextInstance(parentContainer, text) {
+    {
+      warnForInsertedHydratedText(parentContainer, text);
+    }
+  }
+  function didNotFindHydratableInstance(parentType, parentProps, parentInstance, type, props) {
+    if ( parentProps[SUPPRESS_HYDRATION_WARNING$1] !== true) {
+      warnForInsertedHydratedElement(parentInstance, type);
+    }
+  }
+  function didNotFindHydratableTextInstance(parentType, parentProps, parentInstance, text) {
+    if ( parentProps[SUPPRESS_HYDRATION_WARNING$1] !== true) {
+      warnForInsertedHydratedText(parentInstance, text);
+    }
+  }
+  function didNotFindHydratableSuspenseInstance(parentType, parentProps, parentInstance) {
+    if ( parentProps[SUPPRESS_HYDRATION_WARNING$1] !== true) ;
+  }
+
+  var randomKey = Math.random().toString(36).slice(2);
+  var internalInstanceKey = '__reactInternalInstance$' + randomKey;
+  var internalEventHandlersKey = '__reactEventHandlers$' + randomKey;
+  var internalContainerInstanceKey = '__reactContainere$' + randomKey;
+  function precacheFiberNode(hostInst, node) {
+    node[internalInstanceKey] = hostInst;
+  }
+  function markContainerAsRoot(hostRoot, node) {
+    node[internalContainerInstanceKey] = hostRoot;
+  }
+  function unmarkContainerAsRoot(node) {
+    node[internalContainerInstanceKey] = null;
+  }
+  function isContainerMarkedAsRoot(node) {
+    return !!node[internalContainerInstanceKey];
+  } // Given a DOM node, return the closest HostComponent or HostText fiber ancestor.
+  // If the target node is part of a hydrated or not yet rendered subtree, then
+  // this may also return a SuspenseComponent or HostRoot to indicate that.
+  // Conceptually the HostRoot fiber is a child of the Container node. So if you
+  // pass the Container node as the targetNode, you will not actually get the
+  // HostRoot back. To get to the HostRoot, you need to pass a child of it.
+  // The same thing applies to Suspense boundaries.
+
+  function getClosestInstanceFromNode(targetNode) {
+    var targetInst = targetNode[internalInstanceKey];
+
+    if (targetInst) {
+      // Don't return HostRoot or SuspenseComponent here.
+      return targetInst;
+    } // If the direct event target isn't a React owned DOM node, we need to look
+    // to see if one of its parents is a React owned DOM node.
+
+
+    var parentNode = targetNode.parentNode;
+
+    while (parentNode) {
+      // We'll check if this is a container root that could include
+      // React nodes in the future. We need to check this first because
+      // if we're a child of a dehydrated container, we need to first
+      // find that inner container before moving on to finding the parent
+      // instance. Note that we don't check this field on  the targetNode
+      // itself because the fibers are conceptually between the container
+      // node and the first child. It isn't surrounding the container node.
+      // If it's not a container, we check if it's an instance.
+      targetInst = parentNode[internalContainerInstanceKey] || parentNode[internalInstanceKey];
+
+      if (targetInst) {
+        // Since this wasn't the direct target of the event, we might have
+        // stepped past dehydrated DOM nodes to get here. However they could
+        // also have been non-React nodes. We need to answer which one.
+        // If we the instance doesn't have any children, then there can't be
+        // a nested suspense boundary within it. So we can use this as a fast
+        // bailout. Most of the time, when people add non-React children to
+        // the tree, it is using a ref to a child-less DOM node.
+        // Normally we'd only need to check one of the fibers because if it
+        // has ever gone from having children to deleting them or vice versa
+        // it would have deleted the dehydrated boundary nested inside already.
+        // However, since the HostRoot starts out with an alternate it might
+        // have one on the alternate so we need to check in case this was a
+        // root.
+        var alternate = targetInst.alternate;
+
+        if (targetInst.child !== null || alternate !== null && alternate.child !== null) {
+          // Next we need to figure out if the node that skipped past is
+          // nested within a dehydrated boundary and if so, which one.
+          var suspenseInstance = getParentSuspenseInstance(targetNode);
+
+          while (suspenseInstance !== null) {
+            // We found a suspense instance. That means that we haven't
+            // hydrated it yet. Even though we leave the comments in the
+            // DOM after hydrating, and there are boundaries in the DOM
+            // that could already be hydrated, we wouldn't have found them
+            // through this pass since if the target is hydrated it would
+            // have had an internalInstanceKey on it.
+            // Let's get the fiber associated with the SuspenseComponent
+            // as the deepest instance.
+            var targetSuspenseInst = suspenseInstance[internalInstanceKey];
+
+            if (targetSuspenseInst) {
+              return targetSuspenseInst;
+            } // If we don't find a Fiber on the comment, it might be because
+            // we haven't gotten to hydrate it yet. There might still be a
+            // parent boundary that hasn't above this one so we need to find
+            // the outer most that is known.
+
+
+            suspenseInstance = getParentSuspenseInstance(suspenseInstance); // If we don't find one, then that should mean that the parent
+            // host component also hasn't hydrated yet. We can return it
+            // below since it will bail out on the isMounted check later.
+          }
+        }
+
+        return targetInst;
+      }
+
+      targetNode = parentNode;
+      parentNode = targetNode.parentNode;
+    }
+
+    return null;
+  }
+  /**
+   * Given a DOM node, return the ReactDOMComponent or ReactDOMTextComponent
+   * instance, or null if the node was not rendered by this React.
+   */
+
+  function getInstanceFromNode$1(node) {
+    var inst = node[internalInstanceKey] || node[internalContainerInstanceKey];
+
+    if (inst) {
+      if (inst.tag === HostComponent || inst.tag === HostText || inst.tag === SuspenseComponent || inst.tag === HostRoot) {
+        return inst;
+      } else {
+        return null;
+      }
+    }
+
+    return null;
+  }
+  /**
+   * Given a ReactDOMComponent or ReactDOMTextComponent, return the corresponding
+   * DOM node.
+   */
+
+  function getNodeFromInstance$1(inst) {
+    if (inst.tag === HostComponent || inst.tag === HostText) {
+      // In Fiber this, is just the state node right now. We assume it will be
+      // a host component or host text.
+      return inst.stateNode;
+    } // Without this first invariant, passing a non-DOM-component triggers the next
+    // invariant for a missing parent, which is super confusing.
+
+
+    {
+      {
+        throw Error( "getNodeFromInstance: Invalid argument." );
+      }
+    }
+  }
+  function getFiberCurrentPropsFromNode$1(node) {
+    return node[internalEventHandlersKey] || null;
+  }
+  function updateFiberProps(node, props) {
+    node[internalEventHandlersKey] = props;
+  }
+
+  function getParent(inst) {
+    do {
+      inst = inst.return; // TODO: If this is a HostRoot we might want to bail out.
+      // That is depending on if we want nested subtrees (layers) to bubble
+      // events to their parent. We could also go through parentNode on the
+      // host node but that wouldn't work for React Native and doesn't let us
+      // do the portal feature.
+    } while (inst && inst.tag !== HostComponent);
+
+    if (inst) {
+      return inst;
+    }
+
+    return null;
+  }
+  /**
+   * Return the lowest common ancestor of A and B, or null if they are in
+   * different trees.
+   */
+
+
+  function getLowestCommonAncestor(instA, instB) {
+    var depthA = 0;
+
+    for (var tempA = instA; tempA; tempA = getParent(tempA)) {
+      depthA++;
+    }
+
+    var depthB = 0;
+
+    for (var tempB = instB; tempB; tempB = getParent(tempB)) {
+      depthB++;
+    } // If A is deeper, crawl up.
+
+
+    while (depthA - depthB > 0) {
+      instA = getParent(instA);
+      depthA--;
+    } // If B is deeper, crawl up.
+
+
+    while (depthB - depthA > 0) {
+      instB = getParent(instB);
+      depthB--;
+    } // Walk in lockstep until we find a match.
+
+
+    var depth = depthA;
+
+    while (depth--) {
+      if (instA === instB || instA === instB.alternate) {
+        return instA;
+      }
+
+      instA = getParent(instA);
+      instB = getParent(instB);
+    }
+
+    return null;
+  }
+  /**
+   * Simulates the traversal of a two-phase, capture/bubble event dispatch.
+   */
+
+  function traverseTwoPhase(inst, fn, arg) {
+    var path = [];
+
+    while (inst) {
+      path.push(inst);
+      inst = getParent(inst);
+    }
+
+    var i;
+
+    for (i = path.length; i-- > 0;) {
+      fn(path[i], 'captured', arg);
+    }
+
+    for (i = 0; i < path.length; i++) {
+      fn(path[i], 'bubbled', arg);
+    }
+  }
+  /**
+   * Traverses the ID hierarchy and invokes the supplied `cb` on any IDs that
+   * should would receive a `mouseEnter` or `mouseLeave` event.
+   *
+   * Does not invoke the callback on the nearest common ancestor because nothing
+   * "entered" or "left" that element.
+   */
+
+  function traverseEnterLeave(from, to, fn, argFrom, argTo) {
+    var common = from && to ? getLowestCommonAncestor(from, to) : null;
+    var pathFrom = [];
+
+    while (true) {
+      if (!from) {
+        break;
+      }
+
+      if (from === common) {
+        break;
+      }
+
+      var alternate = from.alternate;
+
+      if (alternate !== null && alternate === common) {
+        break;
+      }
+
+      pathFrom.push(from);
+      from = getParent(from);
+    }
+
+    var pathTo = [];
+
+    while (true) {
+      if (!to) {
+        break;
+      }
+
+      if (to === common) {
+        break;
+      }
+
+      var _alternate = to.alternate;
+
+      if (_alternate !== null && _alternate === common) {
+        break;
+      }
+
+      pathTo.push(to);
+      to = getParent(to);
+    }
+
+    for (var i = 0; i < pathFrom.length; i++) {
+      fn(pathFrom[i], 'bubbled', argFrom);
+    }
+
+    for (var _i = pathTo.length; _i-- > 0;) {
+      fn(pathTo[_i], 'captured', argTo);
+    }
+  }
+
+  function isInteractive(tag) {
+    return tag === 'button' || tag === 'input' || tag === 'select' || tag === 'textarea';
+  }
+
+  function shouldPreventMouseEvent(name, type, props) {
+    switch (name) {
+      case 'onClick':
+      case 'onClickCapture':
+      case 'onDoubleClick':
+      case 'onDoubleClickCapture':
+      case 'onMouseDown':
+      case 'onMouseDownCapture':
+      case 'onMouseMove':
+      case 'onMouseMoveCapture':
+      case 'onMouseUp':
+      case 'onMouseUpCapture':
+      case 'onMouseEnter':
+        return !!(props.disabled && isInteractive(type));
+
+      default:
+        return false;
+    }
+  }
+  /**
+   * @param {object} inst The instance, which is the source of events.
+   * @param {string} registrationName Name of listener (e.g. `onClick`).
+   * @return {?function} The stored callback.
+   */
+
+
+  function getListener(inst, registrationName) {
+    var listener; // TODO: shouldPreventMouseEvent is DOM-specific and definitely should not
+    // live here; needs to be moved to a better place soon
+
+    var stateNode = inst.stateNode;
+
+    if (!stateNode) {
+      // Work in progress (ex: onload events in incremental mode).
+      return null;
+    }
+
+    var props = getFiberCurrentPropsFromNode(stateNode);
+
+    if (!props) {
+      // Work in progress.
+      return null;
+    }
+
+    listener = props[registrationName];
+
+    if (shouldPreventMouseEvent(registrationName, inst.type, props)) {
+      return null;
+    }
+
+    if (!(!listener || typeof listener === 'function')) {
+      {
+        throw Error( "Expected `" + registrationName + "` listener to be a function, instead got a value of `" + typeof listener + "` type." );
+      }
+    }
+
+    return listener;
+  }
+
+  /**
+   * Some event types have a notion of different registration names for different
+   * "phases" of propagation. This finds listeners by a given phase.
+   */
+  function listenerAtPhase(inst, event, propagationPhase) {
+    var registrationName = event.dispatchConfig.phasedRegistrationNames[propagationPhase];
+    return getListener(inst, registrationName);
+  }
+  /**
+   * A small set of propagation patterns, each of which will accept a small amount
+   * of information, and generate a set of "dispatch ready event objects" - which
+   * are sets of events that have already been annotated with a set of dispatched
+   * listener functions/ids. The API is designed this way to discourage these
+   * propagation strategies from actually executing the dispatches, since we
+   * always want to collect the entire set of dispatches before executing even a
+   * single one.
+   */
+
+  /**
+   * Tags a `SyntheticEvent` with dispatched listeners. Creating this function
+   * here, allows us to not have to bind or create functions for each event.
+   * Mutating the event's members allows us to not have to create a wrapping
+   * "dispatch" object that pairs the event with the listener.
+   */
+
+
+  function accumulateDirectionalDispatches(inst, phase, event) {
+    {
+      if (!inst) {
+        error('Dispatching inst must not be null');
+      }
+    }
+
+    var listener = listenerAtPhase(inst, event, phase);
+
+    if (listener) {
+      event._dispatchListeners = accumulateInto(event._dispatchListeners, listener);
+      event._dispatchInstances = accumulateInto(event._dispatchInstances, inst);
+    }
+  }
+  /**
+   * Collect dispatches (must be entirely collected before dispatching - see unit
+   * tests). Lazily allocate the array to conserve memory.  We must loop through
+   * each event and perform the traversal for each one. We cannot perform a
+   * single traversal for the entire collection of events because each event may
+   * have a different target.
+   */
+
+
+  function accumulateTwoPhaseDispatchesSingle(event) {
+    if (event && event.dispatchConfig.phasedRegistrationNames) {
+      traverseTwoPhase(event._targetInst, accumulateDirectionalDispatches, event);
+    }
+  }
+  /**
+   * Accumulates without regard to direction, does not look for phased
+   * registration names. Same as `accumulateDirectDispatchesSingle` but without
+   * requiring that the `dispatchMarker` be the same as the dispatched ID.
+   */
+
+
+  function accumulateDispatches(inst, ignoredDirection, event) {
+    if (inst && event && event.dispatchConfig.registrationName) {
+      var registrationName = event.dispatchConfig.registrationName;
+      var listener = getListener(inst, registrationName);
+
+      if (listener) {
+        event._dispatchListeners = accumulateInto(event._dispatchListeners, listener);
+        event._dispatchInstances = accumulateInto(event._dispatchInstances, inst);
+      }
+    }
+  }
+  /**
+   * Accumulates dispatches on an `SyntheticEvent`, but only for the
+   * `dispatchMarker`.
+   * @param {SyntheticEvent} event
+   */
+
+
+  function accumulateDirectDispatchesSingle(event) {
+    if (event && event.dispatchConfig.registrationName) {
+      accumulateDispatches(event._targetInst, null, event);
+    }
+  }
+
+  function accumulateTwoPhaseDispatches(events) {
+    forEachAccumulated(events, accumulateTwoPhaseDispatchesSingle);
+  }
+  function accumulateEnterLeaveDispatches(leave, enter, from, to) {
+    traverseEnterLeave(from, to, accumulateDispatches, leave, enter);
+  }
+  function accumulateDirectDispatches(events) {
+    forEachAccumulated(events, accumulateDirectDispatchesSingle);
+  }
+
+  /**
+   * These variables store information about text content of a target node,
+   * allowing comparison of content before and after a given event.
+   *
+   * Identify the node where selection currently begins, then observe
+   * both its text content and its current position in the DOM. Since the
+   * browser may natively replace the target node during composition, we can
+   * use its position to find its replacement.
+   *
+   *
+   */
+  var root = null;
+  var startText = null;
+  var fallbackText = null;
+  function initialize(nativeEventTarget) {
+    root = nativeEventTarget;
+    startText = getText();
+    return true;
+  }
+  function reset() {
+    root = null;
+    startText = null;
+    fallbackText = null;
+  }
+  function getData() {
+    if (fallbackText) {
+      return fallbackText;
+    }
+
+    var start;
+    var startValue = startText;
+    var startLength = startValue.length;
+    var end;
+    var endValue = getText();
+    var endLength = endValue.length;
+
+    for (start = 0; start < startLength; start++) {
+      if (startValue[start] !== endValue[start]) {
+        break;
+      }
+    }
+
+    var minEnd = startLength - start;
+
+    for (end = 1; end <= minEnd; end++) {
+      if (startValue[startLength - end] !== endValue[endLength - end]) {
+        break;
+      }
+    }
+
+    var sliceTail = end > 1 ? 1 - end : undefined;
+    fallbackText = endValue.slice(start, sliceTail);
+    return fallbackText;
+  }
+  function getText() {
+    if ('value' in root) {
+      return root.value;
+    }
+
+    return root.textContent;
+  }
+
+  var EVENT_POOL_SIZE = 10;
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+  var EventInterface = {
+    type: null,
+    target: null,
+    // currentTarget is set when dispatching; no use in copying it here
+    currentTarget: function () {
+      return null;
+    },
+    eventPhase: null,
+    bubbles: null,
+    cancelable: null,
+    timeStamp: function (event) {
+      return event.timeStamp || Date.now();
+    },
+    defaultPrevented: null,
+    isTrusted: null
+  };
+
+  function functionThatReturnsTrue() {
+    return true;
+  }
+
+  function functionThatReturnsFalse() {
+    return false;
+  }
+  /**
+   * Synthetic events are dispatched by event plugins, typically in response to a
+   * top-level event delegation handler.
+   *
+   * These systems should generally use pooling to reduce the frequency of garbage
+   * collection. The system should check `isPersistent` to determine whether the
+   * event should be released into the pool after being dispatched. Users that
+   * need a persisted event should invoke `persist`.
+   *
+   * Synthetic events (and subclasses) implement the DOM Level 3 Events API by
+   * normalizing browser quirks. Subclasses do not necessarily have to implement a
+   * DOM interface; custom application-specific events can also subclass this.
+   *
+   * @param {object} dispatchConfig Configuration used to dispatch this event.
+   * @param {*} targetInst Marker identifying the event target.
+   * @param {object} nativeEvent Native browser event.
+   * @param {DOMEventTarget} nativeEventTarget Target node.
+   */
+
+
+  function SyntheticEvent(dispatchConfig, targetInst, nativeEvent, nativeEventTarget) {
+    {
+      // these have a getter/setter for warnings
+      delete this.nativeEvent;
+      delete this.preventDefault;
+      delete this.stopPropagation;
+      delete this.isDefaultPrevented;
+      delete this.isPropagationStopped;
+    }
+
+    this.dispatchConfig = dispatchConfig;
+    this._targetInst = targetInst;
+    this.nativeEvent = nativeEvent;
+    var Interface = this.constructor.Interface;
+
+    for (var propName in Interface) {
+      if (!Interface.hasOwnProperty(propName)) {
+        continue;
+      }
+
+      {
+        delete this[propName]; // this has a getter/setter for warnings
+      }
+
+      var normalize = Interface[propName];
+
+      if (normalize) {
+        this[propName] = normalize(nativeEvent);
+      } else {
+        if (propName === 'target') {
+          this.target = nativeEventTarget;
+        } else {
+          this[propName] = nativeEvent[propName];
+        }
+      }
+    }
+
+    var defaultPrevented = nativeEvent.defaultPrevented != null ? nativeEvent.defaultPrevented : nativeEvent.returnValue === false;
+
+    if (defaultPrevented) {
+      this.isDefaultPrevented = functionThatReturnsTrue;
+    } else {
+      this.isDefaultPrevented = functionThatReturnsFalse;
+    }
+
+    this.isPropagationStopped = functionThatReturnsFalse;
+    return this;
+  }
+
+  _assign(SyntheticEvent.prototype, {
+    preventDefault: function () {
+      this.defaultPrevented = true;
+      var event = this.nativeEvent;
+
+      if (!event) {
+        return;
+      }
+
+      if (event.preventDefault) {
+        event.preventDefault();
+      } else if (typeof event.returnValue !== 'unknown') {
+        event.returnValue = false;
+      }
+
+      this.isDefaultPrevented = functionThatReturnsTrue;
+    },
+    stopPropagation: function () {
+      var event = this.nativeEvent;
+
+      if (!event) {
+        return;
+      }
+
+      if (event.stopPropagation) {
+        event.stopPropagation();
+      } else if (typeof event.cancelBubble !== 'unknown') {
+        // The ChangeEventPlugin registers a "propertychange" event for
+        // IE. This event does not support bubbling or cancelling, and
+        // any references to cancelBubble throw "Member not found".  A
+        // typeof check of "unknown" circumvents this issue (and is also
+        // IE specific).
+        event.cancelBubble = true;
+      }
+
+      this.isPropagationStopped = functionThatReturnsTrue;
+    },
+
+    /**
+     * We release all dispatched `SyntheticEvent`s after each event loop, adding
+     * them back into the pool. This allows a way to hold onto a reference that
+     * won't be added back into the pool.
+     */
+    persist: function () {
+      this.isPersistent = functionThatReturnsTrue;
+    },
+
+    /**
+     * Checks if this event should be released back into the pool.
+     *
+     * @return {boolean} True if this should not be released, false otherwise.
+     */
+    isPersistent: functionThatReturnsFalse,
+
+    /**
+     * `PooledClass` looks for `destructor` on each instance it releases.
+     */
+    destructor: function () {
+      var Interface = this.constructor.Interface;
+
+      for (var propName in Interface) {
+        {
+          Object.defineProperty(this, propName, getPooledWarningPropertyDefinition(propName, Interface[propName]));
+        }
+      }
+
+      this.dispatchConfig = null;
+      this._targetInst = null;
+      this.nativeEvent = null;
+      this.isDefaultPrevented = functionThatReturnsFalse;
+      this.isPropagationStopped = functionThatReturnsFalse;
+      this._dispatchListeners = null;
+      this._dispatchInstances = null;
+
+      {
+        Object.defineProperty(this, 'nativeEvent', getPooledWarningPropertyDefinition('nativeEvent', null));
+        Object.defineProperty(this, 'isDefaultPrevented', getPooledWarningPropertyDefinition('isDefaultPrevented', functionThatReturnsFalse));
+        Object.defineProperty(this, 'isPropagationStopped', getPooledWarningPropertyDefinition('isPropagationStopped', functionThatReturnsFalse));
+        Object.defineProperty(this, 'preventDefault', getPooledWarningPropertyDefinition('preventDefault', function () {}));
+        Object.defineProperty(this, 'stopPropagation', getPooledWarningPropertyDefinition('stopPropagation', function () {}));
+      }
+    }
+  });
+
+  SyntheticEvent.Interface = EventInterface;
+  /**
+   * Helper to reduce boilerplate when creating subclasses.
+   */
+
+  SyntheticEvent.extend = function (Interface) {
+    var Super = this;
+
+    var E = function () {};
+
+    E.prototype = Super.prototype;
+    var prototype = new E();
+
+    function Class() {
+      return Super.apply(this, arguments);
+    }
+
+    _assign(prototype, Class.prototype);
+
+    Class.prototype = prototype;
+    Class.prototype.constructor = Class;
+    Class.Interface = _assign({}, Super.Interface, Interface);
+    Class.extend = Super.extend;
+    addEventPoolingTo(Class);
+    return Class;
+  };
+
+  addEventPoolingTo(SyntheticEvent);
+  /**
+   * Helper to nullify syntheticEvent instance properties when destructing
+   *
+   * @param {String} propName
+   * @param {?object} getVal
+   * @return {object} defineProperty object
+   */
+
+  function getPooledWarningPropertyDefinition(propName, getVal) {
+    var isFunction = typeof getVal === 'function';
+    return {
+      configurable: true,
+      set: set,
+      get: get
+    };
+
+    function set(val) {
+      var action = isFunction ? 'setting the method' : 'setting the property';
+      warn(action, 'This is effectively a no-op');
+      return val;
+    }
+
+    function get() {
+      var action = isFunction ? 'accessing the method' : 'accessing the property';
+      var result = isFunction ? 'This is a no-op function' : 'This is set to null';
+      warn(action, result);
+      return getVal;
+    }
+
+    function warn(action, result) {
+      {
+        error("This synthetic event is reused for performance reasons. If you're seeing this, " + "you're %s `%s` on a released/nullified synthetic event. %s. " + 'If you must keep the original synthetic event around, use event.persist(). ' + 'See https://fb.me/react-event-pooling for more information.', action, propName, result);
+      }
+    }
+  }
+
+  function getPooledEvent(dispatchConfig, targetInst, nativeEvent, nativeInst) {
+    var EventConstructor = this;
+
+    if (EventConstructor.eventPool.length) {
+      var instance = EventConstructor.eventPool.pop();
+      EventConstructor.call(instance, dispatchConfig, targetInst, nativeEvent, nativeInst);
+      return instance;
+    }
+
+    return new EventConstructor(dispatchConfig, targetInst, nativeEvent, nativeInst);
+  }
+
+  function releasePooledEvent(event) {
+    var EventConstructor = this;
+
+    if (!(event instanceof EventConstructor)) {
+      {
+        throw Error( "Trying to release an event instance into a pool of a different type." );
+      }
+    }
+
+    event.destructor();
+
+    if (EventConstructor.eventPool.length < EVENT_POOL_SIZE) {
+      EventConstructor.eventPool.push(event);
+    }
+  }
+
+  function addEventPoolingTo(EventConstructor) {
+    EventConstructor.eventPool = [];
+    EventConstructor.getPooled = getPooledEvent;
+    EventConstructor.release = releasePooledEvent;
+  }
+
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/#events-compositionevents
+   */
+
+  var SyntheticCompositionEvent = SyntheticEvent.extend({
+    data: null
+  });
+
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/2013/WD-DOM-Level-3-Events-20131105
+   *      /#events-inputevents
+   */
+
+  var SyntheticInputEvent = SyntheticEvent.extend({
+    data: null
+  });
+
+  var END_KEYCODES = [9, 13, 27, 32]; // Tab, Return, Esc, Space
+
+  var START_KEYCODE = 229;
+  var canUseCompositionEvent = canUseDOM && 'CompositionEvent' in window;
+  var documentMode = null;
+
+  if (canUseDOM && 'documentMode' in document) {
+    documentMode = document.documentMode;
+  } // Webkit offers a very useful `textInput` event that can be used to
+  // directly represent `beforeInput`. The IE `textinput` event is not as
+  // useful, so we don't use it.
+
+
+  var canUseTextInputEvent = canUseDOM && 'TextEvent' in window && !documentMode; // In IE9+, we have access to composition events, but the data supplied
+  // by the native compositionend event may be incorrect. Japanese ideographic
+  // spaces, for instance (\u3000) are not recorded correctly.
+
+  var useFallbackCompositionData = canUseDOM && (!canUseCompositionEvent || documentMode && documentMode > 8 && documentMode <= 11);
+  var SPACEBAR_CODE = 32;
+  var SPACEBAR_CHAR = String.fromCharCode(SPACEBAR_CODE); // Events and their corresponding property names.
+
+  var eventTypes = {
+    beforeInput: {
+      phasedRegistrationNames: {
+        bubbled: 'onBeforeInput',
+        captured: 'onBeforeInputCapture'
+      },
+      dependencies: [TOP_COMPOSITION_END, TOP_KEY_PRESS, TOP_TEXT_INPUT, TOP_PASTE]
+    },
+    compositionEnd: {
+      phasedRegistrationNames: {
+        bubbled: 'onCompositionEnd',
+        captured: 'onCompositionEndCapture'
+      },
+      dependencies: [TOP_BLUR, TOP_COMPOSITION_END, TOP_KEY_DOWN, TOP_KEY_PRESS, TOP_KEY_UP, TOP_MOUSE_DOWN]
+    },
+    compositionStart: {
+      phasedRegistrationNames: {
+        bubbled: 'onCompositionStart',
+        captured: 'onCompositionStartCapture'
+      },
+      dependencies: [TOP_BLUR, TOP_COMPOSITION_START, TOP_KEY_DOWN, TOP_KEY_PRESS, TOP_KEY_UP, TOP_MOUSE_DOWN]
+    },
+    compositionUpdate: {
+      phasedRegistrationNames: {
+        bubbled: 'onCompositionUpdate',
+        captured: 'onCompositionUpdateCapture'
+      },
+      dependencies: [TOP_BLUR, TOP_COMPOSITION_UPDATE, TOP_KEY_DOWN, TOP_KEY_PRESS, TOP_KEY_UP, TOP_MOUSE_DOWN]
+    }
+  }; // Track whether we've ever handled a keypress on the space key.
+
+  var hasSpaceKeypress = false;
+  /**
+   * Return whether a native keypress event is assumed to be a command.
+   * This is required because Firefox fires `keypress` events for key commands
+   * (cut, copy, select-all, etc.) even though no character is inserted.
+   */
+
+  function isKeypressCommand(nativeEvent) {
+    return (nativeEvent.ctrlKey || nativeEvent.altKey || nativeEvent.metaKey) && // ctrlKey && altKey is equivalent to AltGr, and is not a command.
+    !(nativeEvent.ctrlKey && nativeEvent.altKey);
+  }
+  /**
+   * Translate native top level events into event types.
+   *
+   * @param {string} topLevelType
+   * @return {object}
+   */
+
+
+  function getCompositionEventType(topLevelType) {
+    switch (topLevelType) {
+      case TOP_COMPOSITION_START:
+        return eventTypes.compositionStart;
+
+      case TOP_COMPOSITION_END:
+        return eventTypes.compositionEnd;
+
+      case TOP_COMPOSITION_UPDATE:
+        return eventTypes.compositionUpdate;
+    }
+  }
+  /**
+   * Does our fallback best-guess model think this event signifies that
+   * composition has begun?
+   *
+   * @param {string} topLevelType
+   * @param {object} nativeEvent
+   * @return {boolean}
+   */
+
+
+  function isFallbackCompositionStart(topLevelType, nativeEvent) {
+    return topLevelType === TOP_KEY_DOWN && nativeEvent.keyCode === START_KEYCODE;
+  }
+  /**
+   * Does our fallback mode think that this event is the end of composition?
+   *
+   * @param {string} topLevelType
+   * @param {object} nativeEvent
+   * @return {boolean}
+   */
+
+
+  function isFallbackCompositionEnd(topLevelType, nativeEvent) {
+    switch (topLevelType) {
+      case TOP_KEY_UP:
+        // Command keys insert or clear IME input.
+        return END_KEYCODES.indexOf(nativeEvent.keyCode) !== -1;
+
+      case TOP_KEY_DOWN:
+        // Expect IME keyCode on each keydown. If we get any other
+        // code we must have exited earlier.
+        return nativeEvent.keyCode !== START_KEYCODE;
+
+      case TOP_KEY_PRESS:
+      case TOP_MOUSE_DOWN:
+      case TOP_BLUR:
+        // Events are not possible without cancelling IME.
+        return true;
+
+      default:
+        return false;
+    }
+  }
+  /**
+   * Google Input Tools provides composition data via a CustomEvent,
+   * with the `data` property populated in the `detail` object. If this
+   * is available on the event object, use it. If not, this is a plain
+   * composition event and we have nothing special to extract.
+   *
+   * @param {object} nativeEvent
+   * @return {?string}
+   */
+
+
+  function getDataFromCustomEvent(nativeEvent) {
+    var detail = nativeEvent.detail;
+
+    if (typeof detail === 'object' && 'data' in detail) {
+      return detail.data;
+    }
+
+    return null;
+  }
+  /**
+   * Check if a composition event was triggered by Korean IME.
+   * Our fallback mode does not work well with IE's Korean IME,
+   * so just use native composition events when Korean IME is used.
+   * Although CompositionEvent.locale property is deprecated,
+   * it is available in IE, where our fallback mode is enabled.
+   *
+   * @param {object} nativeEvent
+   * @return {boolean}
+   */
+
+
+  function isUsingKoreanIME(nativeEvent) {
+    return nativeEvent.locale === 'ko';
+  } // Track the current IME composition status, if any.
+
+
+  var isComposing = false;
+  /**
+   * @return {?object} A SyntheticCompositionEvent.
+   */
+
+  function extractCompositionEvent(topLevelType, targetInst, nativeEvent, nativeEventTarget) {
+    var eventType;
+    var fallbackData;
+
+    if (canUseCompositionEvent) {
+      eventType = getCompositionEventType(topLevelType);
+    } else if (!isComposing) {
+      if (isFallbackCompositionStart(topLevelType, nativeEvent)) {
+        eventType = eventTypes.compositionStart;
+      }
+    } else if (isFallbackCompositionEnd(topLevelType, nativeEvent)) {
+      eventType = eventTypes.compositionEnd;
+    }
+
+    if (!eventType) {
+      return null;
+    }
+
+    if (useFallbackCompositionData && !isUsingKoreanIME(nativeEvent)) {
+      // The current composition is stored statically and must not be
+      // overwritten while composition continues.
+      if (!isComposing && eventType === eventTypes.compositionStart) {
+        isComposing = initialize(nativeEventTarget);
+      } else if (eventType === eventTypes.compositionEnd) {
+        if (isComposing) {
+          fallbackData = getData();
+        }
+      }
+    }
+
+    var event = SyntheticCompositionEvent.getPooled(eventType, targetInst, nativeEvent, nativeEventTarget);
+
+    if (fallbackData) {
+      // Inject data generated from fallback path into the synthetic event.
+      // This matches the property of native CompositionEventInterface.
+      event.data = fallbackData;
+    } else {
+      var customData = getDataFromCustomEvent(nativeEvent);
+
+      if (customData !== null) {
+        event.data = customData;
+      }
+    }
+
+    accumulateTwoPhaseDispatches(event);
+    return event;
+  }
+  /**
+   * @param {TopLevelType} topLevelType Number from `TopLevelType`.
+   * @param {object} nativeEvent Native browser event.
+   * @return {?string} The string corresponding to this `beforeInput` event.
+   */
+
+
+  function getNativeBeforeInputChars(topLevelType, nativeEvent) {
+    switch (topLevelType) {
+      case TOP_COMPOSITION_END:
+        return getDataFromCustomEvent(nativeEvent);
+
+      case TOP_KEY_PRESS:
+        /**
+         * If native `textInput` events are available, our goal is to make
+         * use of them. However, there is a special case: the spacebar key.
+         * In Webkit, preventing default on a spacebar `textInput` event
+         * cancels character insertion, but it *also* causes the browser
+         * to fall back to its default spacebar behavior of scrolling the
+         * page.
+         *
+         * Tracking at:
+         * https://code.google.com/p/chromium/issues/detail?id=355103
+         *
+         * To avoid this issue, use the keypress event as if no `textInput`
+         * event is available.
+         */
+        var which = nativeEvent.which;
+
+        if (which !== SPACEBAR_CODE) {
+          return null;
+        }
+
+        hasSpaceKeypress = true;
+        return SPACEBAR_CHAR;
+
+      case TOP_TEXT_INPUT:
+        // Record the characters to be added to the DOM.
+        var chars = nativeEvent.data; // If it's a spacebar character, assume that we have already handled
+        // it at the keypress level and bail immediately. Android Chrome
+        // doesn't give us keycodes, so we need to ignore it.
+
+        if (chars === SPACEBAR_CHAR && hasSpaceKeypress) {
+          return null;
+        }
+
+        return chars;
+
+      default:
+        // For other native event types, do nothing.
+        return null;
+    }
+  }
+  /**
+   * For browsers that do not provide the `textInput` event, extract the
+   * appropriate string to use for SyntheticInputEvent.
+   *
+   * @param {number} topLevelType Number from `TopLevelEventTypes`.
+   * @param {object} nativeEvent Native browser event.
+   * @return {?string} The fallback string for this `beforeInput` event.
+   */
+
+
+  function getFallbackBeforeInputChars(topLevelType, nativeEvent) {
+    // If we are currently composing (IME) and using a fallback to do so,
+    // try to extract the composed characters from the fallback object.
+    // If composition event is available, we extract a string only at
+    // compositionevent, otherwise extract it at fallback events.
+    if (isComposing) {
+      if (topLevelType === TOP_COMPOSITION_END || !canUseCompositionEvent && isFallbackCompositionEnd(topLevelType, nativeEvent)) {
+        var chars = getData();
+        reset();
+        isComposing = false;
+        return chars;
+      }
+
+      return null;
+    }
+
+    switch (topLevelType) {
+      case TOP_PASTE:
+        // If a paste event occurs after a keypress, throw out the input
+        // chars. Paste events should not lead to BeforeInput events.
+        return null;
+
+      case TOP_KEY_PRESS:
+        /**
+         * As of v27, Firefox may fire keypress events even when no character
+         * will be inserted. A few possibilities:
+         *
+         * - `which` is `0`. Arrow keys, Esc key, etc.
+         *
+         * - `which` is the pressed key code, but no char is available.
+         *   Ex: 'AltGr + d` in Polish. There is no modified character for
+         *   this key combination and no character is inserted into the
+         *   document, but FF fires the keypress for char code `100` anyway.
+         *   No `input` event will occur.
+         *
+         * - `which` is the pressed key code, but a command combination is
+         *   being used. Ex: `Cmd+C`. No character is inserted, and no
+         *   `input` event will occur.
+         */
+        if (!isKeypressCommand(nativeEvent)) {
+          // IE fires the `keypress` event when a user types an emoji via
+          // Touch keyboard of Windows.  In such a case, the `char` property
+          // holds an emoji character like `\uD83D\uDE0A`.  Because its length
+          // is 2, the property `which` does not represent an emoji correctly.
+          // In such a case, we directly return the `char` property instead of
+          // using `which`.
+          if (nativeEvent.char && nativeEvent.char.length > 1) {
+            return nativeEvent.char;
+          } else if (nativeEvent.which) {
+            return String.fromCharCode(nativeEvent.which);
+          }
+        }
+
+        return null;
+
+      case TOP_COMPOSITION_END:
+        return useFallbackCompositionData && !isUsingKoreanIME(nativeEvent) ? null : nativeEvent.data;
+
+      default:
+        return null;
+    }
+  }
+  /**
+   * Extract a SyntheticInputEvent for `beforeInput`, based on either native
+   * `textInput` or fallback behavior.
+   *
+   * @return {?object} A SyntheticInputEvent.
+   */
+
+
+  function extractBeforeInputEvent(topLevelType, targetInst, nativeEvent, nativeEventTarget) {
+    var chars;
+
+    if (canUseTextInputEvent) {
+      chars = getNativeBeforeInputChars(topLevelType, nativeEvent);
+    } else {
+      chars = getFallbackBeforeInputChars(topLevelType, nativeEvent);
+    } // If no characters are being inserted, no BeforeInput event should
+    // be fired.
+
+
+    if (!chars) {
+      return null;
+    }
+
+    var event = SyntheticInputEvent.getPooled(eventTypes.beforeInput, targetInst, nativeEvent, nativeEventTarget);
+    event.data = chars;
+    accumulateTwoPhaseDispatches(event);
+    return event;
+  }
+  /**
+   * Create an `onBeforeInput` event to match
+   * http://www.w3.org/TR/2013/WD-DOM-Level-3-Events-20131105/#events-inputevents.
+   *
+   * This event plugin is based on the native `textInput` event
+   * available in Chrome, Safari, Opera, and IE. This event fires after
+   * `onKeyPress` and `onCompositionEnd`, but before `onInput`.
+   *
+   * `beforeInput` is spec'd but not implemented in any browsers, and
+   * the `input` event does not provide any useful information about what has
+   * actually been added, contrary to the spec. Thus, `textInput` is the best
+   * available event to identify the characters that have actually been inserted
+   * into the target node.
+   *
+   * This plugin is also responsible for emitting `composition` events, thus
+   * allowing us to share composition fallback code for both `beforeInput` and
+   * `composition` event types.
+   */
+
+
+  var BeforeInputEventPlugin = {
+    eventTypes: eventTypes,
+    extractEvents: function (topLevelType, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags) {
+      var composition = extractCompositionEvent(topLevelType, targetInst, nativeEvent, nativeEventTarget);
+      var beforeInput = extractBeforeInputEvent(topLevelType, targetInst, nativeEvent, nativeEventTarget);
+
+      if (composition === null) {
+        return beforeInput;
+      }
+
+      if (beforeInput === null) {
+        return composition;
+      }
+
+      return [composition, beforeInput];
+    }
+  };
+
+  /**
+   * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html#input-type-attr-summary
+   */
+  var supportedInputTypes = {
+    color: true,
+    date: true,
+    datetime: true,
+    'datetime-local': true,
+    email: true,
+    month: true,
+    number: true,
+    password: true,
+    range: true,
+    search: true,
+    tel: true,
+    text: true,
+    time: true,
+    url: true,
+    week: true
+  };
+
+  function isTextInputElement(elem) {
+    var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+
+    if (nodeName === 'input') {
+      return !!supportedInputTypes[elem.type];
+    }
+
+    if (nodeName === 'textarea') {
+      return true;
+    }
+
+    return false;
+  }
+
+  var eventTypes$1 = {
+    change: {
+      phasedRegistrationNames: {
+        bubbled: 'onChange',
+        captured: 'onChangeCapture'
+      },
+      dependencies: [TOP_BLUR, TOP_CHANGE, TOP_CLICK, TOP_FOCUS, TOP_INPUT, TOP_KEY_DOWN, TOP_KEY_UP, TOP_SELECTION_CHANGE]
+    }
+  };
+
+  function createAndAccumulateChangeEvent(inst, nativeEvent, target) {
+    var event = SyntheticEvent.getPooled(eventTypes$1.change, inst, nativeEvent, target);
+    event.type = 'change'; // Flag this event loop as needing state restore.
+
+    enqueueStateRestore(target);
+    accumulateTwoPhaseDispatches(event);
+    return event;
+  }
+  /**
+   * For IE shims
+   */
+
+
+  var activeElement = null;
+  var activeElementInst = null;
+  /**
+   * SECTION: handle `change` event
+   */
+
+  function shouldUseChangeEvent(elem) {
+    var nodeName = elem.nodeName && elem.nodeName.toLowerCase();
+    return nodeName === 'select' || nodeName === 'input' && elem.type === 'file';
+  }
+
+  function manualDispatchChangeEvent(nativeEvent) {
+    var event = createAndAccumulateChangeEvent(activeElementInst, nativeEvent, getEventTarget(nativeEvent)); // If change and propertychange bubbled, we'd just bind to it like all the
+    // other events and have it go through ReactBrowserEventEmitter. Since it
+    // doesn't, we manually listen for the events and so we have to enqueue and
+    // process the abstract event manually.
+    //
+    // Batching is necessary here in order to ensure that all event handlers run
+    // before the next rerender (including event handlers attached to ancestor
+    // elements instead of directly on the input). Without this, controlled
+    // components don't work properly in conjunction with event bubbling because
+    // the component is rerendered and the value reverted before all the event
+    // handlers can run. See https://github.com/facebook/react/issues/708.
+
+    batchedUpdates(runEventInBatch, event);
+  }
+
+  function runEventInBatch(event) {
+    runEventsInBatch(event);
+  }
+
+  function getInstIfValueChanged(targetInst) {
+    var targetNode = getNodeFromInstance$1(targetInst);
+
+    if (updateValueIfChanged(targetNode)) {
+      return targetInst;
+    }
+  }
+
+  function getTargetInstForChangeEvent(topLevelType, targetInst) {
+    if (topLevelType === TOP_CHANGE) {
+      return targetInst;
+    }
+  }
+  /**
+   * SECTION: handle `input` event
+   */
+
+
+  var isInputEventSupported = false;
+
+  if (canUseDOM) {
+    // IE9 claims to support the input event but fails to trigger it when
+    // deleting text, so we ignore its input events.
+    isInputEventSupported = isEventSupported('input') && (!document.documentMode || document.documentMode > 9);
+  }
+  /**
+   * (For IE <=9) Starts tracking propertychange events on the passed-in element
+   * and override the value property so that we can distinguish user events from
+   * value changes in JS.
+   */
+
+
+  function startWatchingForValueChange(target, targetInst) {
+    activeElement = target;
+    activeElementInst = targetInst;
+    activeElement.attachEvent('onpropertychange', handlePropertyChange);
+  }
+  /**
+   * (For IE <=9) Removes the event listeners from the currently-tracked element,
+   * if any exists.
+   */
+
+
+  function stopWatchingForValueChange() {
+    if (!activeElement) {
+      return;
+    }
+
+    activeElement.detachEvent('onpropertychange', handlePropertyChange);
+    activeElement = null;
+    activeElementInst = null;
+  }
+  /**
+   * (For IE <=9) Handles a propertychange event, sending a `change` event if
+   * the value of the active element has changed.
+   */
+
+
+  function handlePropertyChange(nativeEvent) {
+    if (nativeEvent.propertyName !== 'value') {
+      return;
+    }
+
+    if (getInstIfValueChanged(activeElementInst)) {
+      manualDispatchChangeEvent(nativeEvent);
+    }
+  }
+
+  function handleEventsForInputEventPolyfill(topLevelType, target, targetInst) {
+    if (topLevelType === TOP_FOCUS) {
+      // In IE9, propertychange fires for most input events but is buggy and
+      // doesn't fire when text is deleted, but conveniently, selectionchange
+      // appears to fire in all of the remaining cases so we catch those and
+      // forward the event if the value has changed
+      // In either case, we don't want to call the event handler if the value
+      // is changed from JS so we redefine a setter for `.value` that updates
+      // our activeElementValue variable, allowing us to ignore those changes
+      //
+      // stopWatching() should be a noop here but we call it just in case we
+      // missed a blur event somehow.
+      stopWatchingForValueChange();
+      startWatchingForValueChange(target, targetInst);
+    } else if (topLevelType === TOP_BLUR) {
+      stopWatchingForValueChange();
+    }
+  } // For IE8 and IE9.
+
+
+  function getTargetInstForInputEventPolyfill(topLevelType, targetInst) {
+    if (topLevelType === TOP_SELECTION_CHANGE || topLevelType === TOP_KEY_UP || topLevelType === TOP_KEY_DOWN) {
+      // On the selectionchange event, the target is just document which isn't
+      // helpful for us so just check activeElement instead.
+      //
+      // 99% of the time, keydown and keyup aren't necessary. IE8 fails to fire
+      // propertychange on the first input event after setting `value` from a
+      // script and fires only keydown, keypress, keyup. Catching keyup usually
+      // gets it and catching keydown lets us fire an event for the first
+      // keystroke if user does a key repeat (it'll be a little delayed: right
+      // before the second keystroke). Other input methods (e.g., paste) seem to
+      // fire selectionchange normally.
+      return getInstIfValueChanged(activeElementInst);
+    }
+  }
+  /**
+   * SECTION: handle `click` event
+   */
+
+
+  function shouldUseClickEvent(elem) {
+    // Use the `click` event to detect changes to checkbox and radio inputs.
+    // This approach works across all browsers, whereas `change` does not fire
+    // until `blur` in IE8.
+    var nodeName = elem.nodeName;
+    return nodeName && nodeName.toLowerCase() === 'input' && (elem.type === 'checkbox' || elem.type === 'radio');
+  }
+
+  function getTargetInstForClickEvent(topLevelType, targetInst) {
+    if (topLevelType === TOP_CLICK) {
+      return getInstIfValueChanged(targetInst);
+    }
+  }
+
+  function getTargetInstForInputOrChangeEvent(topLevelType, targetInst) {
+    if (topLevelType === TOP_INPUT || topLevelType === TOP_CHANGE) {
+      return getInstIfValueChanged(targetInst);
+    }
+  }
+
+  function handleControlledInputBlur(node) {
+    var state = node._wrapperState;
+
+    if (!state || !state.controlled || node.type !== 'number') {
+      return;
+    }
+
+    {
+      // If controlled, assign the value attribute to the current value on blur
+      setDefaultValue(node, 'number', node.value);
+    }
+  }
+  /**
+   * This plugin creates an `onChange` event that normalizes change events
+   * across form elements. This event fires at a time when it's possible to
+   * change the element's value without seeing a flicker.
+   *
+   * Supported elements are:
+   * - input (see `isTextInputElement`)
+   * - textarea
+   * - select
+   */
+
+
+  var ChangeEventPlugin = {
+    eventTypes: eventTypes$1,
+    _isInputEventSupported: isInputEventSupported,
+    extractEvents: function (topLevelType, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags) {
+      var targetNode = targetInst ? getNodeFromInstance$1(targetInst) : window;
+      var getTargetInstFunc, handleEventFunc;
+
+      if (shouldUseChangeEvent(targetNode)) {
+        getTargetInstFunc = getTargetInstForChangeEvent;
+      } else if (isTextInputElement(targetNode)) {
+        if (isInputEventSupported) {
+          getTargetInstFunc = getTargetInstForInputOrChangeEvent;
+        } else {
+          getTargetInstFunc = getTargetInstForInputEventPolyfill;
+          handleEventFunc = handleEventsForInputEventPolyfill;
+        }
+      } else if (shouldUseClickEvent(targetNode)) {
+        getTargetInstFunc = getTargetInstForClickEvent;
+      }
+
+      if (getTargetInstFunc) {
+        var inst = getTargetInstFunc(topLevelType, targetInst);
+
+        if (inst) {
+          var event = createAndAccumulateChangeEvent(inst, nativeEvent, nativeEventTarget);
+          return event;
+        }
+      }
+
+      if (handleEventFunc) {
+        handleEventFunc(topLevelType, targetNode, targetInst);
+      } // When blurring, set the value attribute for number inputs
+
+
+      if (topLevelType === TOP_BLUR) {
+        handleControlledInputBlur(targetNode);
+      }
+    }
+  };
+
+  var SyntheticUIEvent = SyntheticEvent.extend({
+    view: null,
+    detail: null
+  });
+
+  /**
+   * Translation from modifier key to the associated property in the event.
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/#keys-Modifiers
+   */
+  var modifierKeyToProp = {
+    Alt: 'altKey',
+    Control: 'ctrlKey',
+    Meta: 'metaKey',
+    Shift: 'shiftKey'
+  }; // Older browsers (Safari <= 10, iOS Safari <= 10.2) do not support
+  // getModifierState. If getModifierState is not supported, we map it to a set of
+  // modifier keys exposed by the event. In this case, Lock-keys are not supported.
+
+  function modifierStateGetter(keyArg) {
+    var syntheticEvent = this;
+    var nativeEvent = syntheticEvent.nativeEvent;
+
+    if (nativeEvent.getModifierState) {
+      return nativeEvent.getModifierState(keyArg);
+    }
+
+    var keyProp = modifierKeyToProp[keyArg];
+    return keyProp ? !!nativeEvent[keyProp] : false;
+  }
+
+  function getEventModifierState(nativeEvent) {
+    return modifierStateGetter;
+  }
+
+  var previousScreenX = 0;
+  var previousScreenY = 0; // Use flags to signal movementX/Y has already been set
+
+  var isMovementXSet = false;
+  var isMovementYSet = false;
+  /**
+   * @interface MouseEvent
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+  var SyntheticMouseEvent = SyntheticUIEvent.extend({
+    screenX: null,
+    screenY: null,
+    clientX: null,
+    clientY: null,
+    pageX: null,
+    pageY: null,
+    ctrlKey: null,
+    shiftKey: null,
+    altKey: null,
+    metaKey: null,
+    getModifierState: getEventModifierState,
+    button: null,
+    buttons: null,
+    relatedTarget: function (event) {
+      return event.relatedTarget || (event.fromElement === event.srcElement ? event.toElement : event.fromElement);
+    },
+    movementX: function (event) {
+      if ('movementX' in event) {
+        return event.movementX;
+      }
+
+      var screenX = previousScreenX;
+      previousScreenX = event.screenX;
+
+      if (!isMovementXSet) {
+        isMovementXSet = true;
+        return 0;
+      }
+
+      return event.type === 'mousemove' ? event.screenX - screenX : 0;
+    },
+    movementY: function (event) {
+      if ('movementY' in event) {
+        return event.movementY;
+      }
+
+      var screenY = previousScreenY;
+      previousScreenY = event.screenY;
+
+      if (!isMovementYSet) {
+        isMovementYSet = true;
+        return 0;
+      }
+
+      return event.type === 'mousemove' ? event.screenY - screenY : 0;
+    }
+  });
+
+  /**
+   * @interface PointerEvent
+   * @see http://www.w3.org/TR/pointerevents/
+   */
+
+  var SyntheticPointerEvent = SyntheticMouseEvent.extend({
+    pointerId: null,
+    width: null,
+    height: null,
+    pressure: null,
+    tangentialPressure: null,
+    tiltX: null,
+    tiltY: null,
+    twist: null,
+    pointerType: null,
+    isPrimary: null
+  });
+
+  var eventTypes$2 = {
+    mouseEnter: {
+      registrationName: 'onMouseEnter',
+      dependencies: [TOP_MOUSE_OUT, TOP_MOUSE_OVER]
+    },
+    mouseLeave: {
+      registrationName: 'onMouseLeave',
+      dependencies: [TOP_MOUSE_OUT, TOP_MOUSE_OVER]
+    },
+    pointerEnter: {
+      registrationName: 'onPointerEnter',
+      dependencies: [TOP_POINTER_OUT, TOP_POINTER_OVER]
+    },
+    pointerLeave: {
+      registrationName: 'onPointerLeave',
+      dependencies: [TOP_POINTER_OUT, TOP_POINTER_OVER]
+    }
+  };
+  var EnterLeaveEventPlugin = {
+    eventTypes: eventTypes$2,
+
+    /**
+     * For almost every interaction we care about, there will be both a top-level
+     * `mouseover` and `mouseout` event that occurs. Only use `mouseout` so that
+     * we do not extract duplicate events. However, moving the mouse into the
+     * browser from outside will not fire a `mouseout` event. In this case, we use
+     * the `mouseover` top-level event.
+     */
+    extractEvents: function (topLevelType, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags) {
+      var isOverEvent = topLevelType === TOP_MOUSE_OVER || topLevelType === TOP_POINTER_OVER;
+      var isOutEvent = topLevelType === TOP_MOUSE_OUT || topLevelType === TOP_POINTER_OUT;
+
+      if (isOverEvent && (eventSystemFlags & IS_REPLAYED) === 0 && (nativeEvent.relatedTarget || nativeEvent.fromElement)) {
+        // If this is an over event with a target, then we've already dispatched
+        // the event in the out event of the other target. If this is replayed,
+        // then it's because we couldn't dispatch against this target previously
+        // so we have to do it now instead.
+        return null;
+      }
+
+      if (!isOutEvent && !isOverEvent) {
+        // Must not be a mouse or pointer in or out - ignoring.
+        return null;
+      }
+
+      var win;
+
+      if (nativeEventTarget.window === nativeEventTarget) {
+        // `nativeEventTarget` is probably a window object.
+        win = nativeEventTarget;
+      } else {
+        // TODO: Figure out why `ownerDocument` is sometimes undefined in IE8.
+        var doc = nativeEventTarget.ownerDocument;
+
+        if (doc) {
+          win = doc.defaultView || doc.parentWindow;
+        } else {
+          win = window;
+        }
+      }
+
+      var from;
+      var to;
+
+      if (isOutEvent) {
+        from = targetInst;
+        var related = nativeEvent.relatedTarget || nativeEvent.toElement;
+        to = related ? getClosestInstanceFromNode(related) : null;
+
+        if (to !== null) {
+          var nearestMounted = getNearestMountedFiber(to);
+
+          if (to !== nearestMounted || to.tag !== HostComponent && to.tag !== HostText) {
+            to = null;
+          }
+        }
+      } else {
+        // Moving to a node from outside the window.
+        from = null;
+        to = targetInst;
+      }
+
+      if (from === to) {
+        // Nothing pertains to our managed components.
+        return null;
+      }
+
+      var eventInterface, leaveEventType, enterEventType, eventTypePrefix;
+
+      if (topLevelType === TOP_MOUSE_OUT || topLevelType === TOP_MOUSE_OVER) {
+        eventInterface = SyntheticMouseEvent;
+        leaveEventType = eventTypes$2.mouseLeave;
+        enterEventType = eventTypes$2.mouseEnter;
+        eventTypePrefix = 'mouse';
+      } else if (topLevelType === TOP_POINTER_OUT || topLevelType === TOP_POINTER_OVER) {
+        eventInterface = SyntheticPointerEvent;
+        leaveEventType = eventTypes$2.pointerLeave;
+        enterEventType = eventTypes$2.pointerEnter;
+        eventTypePrefix = 'pointer';
+      }
+
+      var fromNode = from == null ? win : getNodeFromInstance$1(from);
+      var toNode = to == null ? win : getNodeFromInstance$1(to);
+      var leave = eventInterface.getPooled(leaveEventType, from, nativeEvent, nativeEventTarget);
+      leave.type = eventTypePrefix + 'leave';
+      leave.target = fromNode;
+      leave.relatedTarget = toNode;
+      var enter = eventInterface.getPooled(enterEventType, to, nativeEvent, nativeEventTarget);
+      enter.type = eventTypePrefix + 'enter';
+      enter.target = toNode;
+      enter.relatedTarget = fromNode;
+      accumulateEnterLeaveDispatches(leave, enter, from, to); // If we are not processing the first ancestor, then we
+      // should not process the same nativeEvent again, as we
+      // will have already processed it in the first ancestor.
+
+      if ((eventSystemFlags & IS_FIRST_ANCESTOR) === 0) {
+        return [leave];
+      }
+
+      return [leave, enter];
+    }
+  };
+
+  /**
+   * inlined Object.is polyfill to avoid requiring consumers ship their own
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+   */
+  function is(x, y) {
+    return x === y && (x !== 0 || 1 / x === 1 / y) || x !== x && y !== y // eslint-disable-line no-self-compare
+    ;
+  }
+
+  var objectIs = typeof Object.is === 'function' ? Object.is : is;
+
+  var hasOwnProperty$2 = Object.prototype.hasOwnProperty;
+  /**
+   * Performs equality by iterating through keys on an object and returning false
+   * when any key has values which are not strictly equal between the arguments.
+   * Returns true when the values of all keys are strictly equal.
+   */
+
+  function shallowEqual(objA, objB) {
+    if (objectIs(objA, objB)) {
+      return true;
+    }
+
+    if (typeof objA !== 'object' || objA === null || typeof objB !== 'object' || objB === null) {
+      return false;
+    }
+
+    var keysA = Object.keys(objA);
+    var keysB = Object.keys(objB);
+
+    if (keysA.length !== keysB.length) {
+      return false;
+    } // Test for A's keys different from B.
+
+
+    for (var i = 0; i < keysA.length; i++) {
+      if (!hasOwnProperty$2.call(objB, keysA[i]) || !objectIs(objA[keysA[i]], objB[keysA[i]])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  var skipSelectionChangeEvent = canUseDOM && 'documentMode' in document && document.documentMode <= 11;
+  var eventTypes$3 = {
+    select: {
+      phasedRegistrationNames: {
+        bubbled: 'onSelect',
+        captured: 'onSelectCapture'
+      },
+      dependencies: [TOP_BLUR, TOP_CONTEXT_MENU, TOP_DRAG_END, TOP_FOCUS, TOP_KEY_DOWN, TOP_KEY_UP, TOP_MOUSE_DOWN, TOP_MOUSE_UP, TOP_SELECTION_CHANGE]
+    }
+  };
+  var activeElement$1 = null;
+  var activeElementInst$1 = null;
+  var lastSelection = null;
+  var mouseDown = false;
+  /**
+   * Get an object which is a unique representation of the current selection.
+   *
+   * The return value will not be consistent across nodes or browsers, but
+   * two identical selections on the same node will return identical objects.
+   *
+   * @param {DOMElement} node
+   * @return {object}
+   */
+
+  function getSelection$1(node) {
+    if ('selectionStart' in node && hasSelectionCapabilities(node)) {
+      return {
+        start: node.selectionStart,
+        end: node.selectionEnd
+      };
+    } else {
+      var win = node.ownerDocument && node.ownerDocument.defaultView || window;
+      var selection = win.getSelection();
+      return {
+        anchorNode: selection.anchorNode,
+        anchorOffset: selection.anchorOffset,
+        focusNode: selection.focusNode,
+        focusOffset: selection.focusOffset
+      };
+    }
+  }
+  /**
+   * Get document associated with the event target.
+   *
+   * @param {object} nativeEventTarget
+   * @return {Document}
+   */
+
+
+  function getEventTargetDocument(eventTarget) {
+    return eventTarget.window === eventTarget ? eventTarget.document : eventTarget.nodeType === DOCUMENT_NODE ? eventTarget : eventTarget.ownerDocument;
+  }
+  /**
+   * Poll selection to see whether it's changed.
+   *
+   * @param {object} nativeEvent
+   * @param {object} nativeEventTarget
+   * @return {?SyntheticEvent}
+   */
+
+
+  function constructSelectEvent(nativeEvent, nativeEventTarget) {
+    // Ensure we have the right element, and that the user is not dragging a
+    // selection (this matches native `select` event behavior). In HTML5, select
+    // fires only on input and textarea thus if there's no focused element we
+    // won't dispatch.
+    var doc = getEventTargetDocument(nativeEventTarget);
+
+    if (mouseDown || activeElement$1 == null || activeElement$1 !== getActiveElement(doc)) {
+      return null;
+    } // Only fire when selection has actually changed.
+
+
+    var currentSelection = getSelection$1(activeElement$1);
+
+    if (!lastSelection || !shallowEqual(lastSelection, currentSelection)) {
+      lastSelection = currentSelection;
+      var syntheticEvent = SyntheticEvent.getPooled(eventTypes$3.select, activeElementInst$1, nativeEvent, nativeEventTarget);
+      syntheticEvent.type = 'select';
+      syntheticEvent.target = activeElement$1;
+      accumulateTwoPhaseDispatches(syntheticEvent);
+      return syntheticEvent;
+    }
+
+    return null;
+  }
+  /**
+   * This plugin creates an `onSelect` event that normalizes select events
+   * across form elements.
+   *
+   * Supported elements are:
+   * - input (see `isTextInputElement`)
+   * - textarea
+   * - contentEditable
+   *
+   * This differs from native browser implementations in the following ways:
+   * - Fires on contentEditable fields as well as inputs.
+   * - Fires for collapsed selection.
+   * - Fires after user input.
+   */
+
+
+  var SelectEventPlugin = {
+    eventTypes: eventTypes$3,
+    extractEvents: function (topLevelType, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags, container) {
+      var containerOrDoc = container || getEventTargetDocument(nativeEventTarget); // Track whether all listeners exists for this plugin. If none exist, we do
+      // not extract events. See #3639.
+
+      if (!containerOrDoc || !isListeningToAllDependencies('onSelect', containerOrDoc)) {
+        return null;
+      }
+
+      var targetNode = targetInst ? getNodeFromInstance$1(targetInst) : window;
+
+      switch (topLevelType) {
+        // Track the input node that has focus.
+        case TOP_FOCUS:
+          if (isTextInputElement(targetNode) || targetNode.contentEditable === 'true') {
+            activeElement$1 = targetNode;
+            activeElementInst$1 = targetInst;
+            lastSelection = null;
+          }
+
+          break;
+
+        case TOP_BLUR:
+          activeElement$1 = null;
+          activeElementInst$1 = null;
+          lastSelection = null;
+          break;
+        // Don't fire the event while the user is dragging. This matches the
+        // semantics of the native select event.
+
+        case TOP_MOUSE_DOWN:
+          mouseDown = true;
+          break;
+
+        case TOP_CONTEXT_MENU:
+        case TOP_MOUSE_UP:
+        case TOP_DRAG_END:
+          mouseDown = false;
+          return constructSelectEvent(nativeEvent, nativeEventTarget);
+        // Chrome and IE fire non-standard event when selection is changed (and
+        // sometimes when it hasn't). IE's event fires out of order with respect
+        // to key and input events on deletion, so we discard it.
+        //
+        // Firefox doesn't support selectionchange, so check selection status
+        // after each key entry. The selection changes after keydown and before
+        // keyup, but we check on keydown as well in the case of holding down a
+        // key, when multiple keydown events are fired but only one keyup is.
+        // This is also our approach for IE handling, for the reason above.
+
+        case TOP_SELECTION_CHANGE:
+          if (skipSelectionChangeEvent) {
+            break;
+          }
+
+        // falls through
+
+        case TOP_KEY_DOWN:
+        case TOP_KEY_UP:
+          return constructSelectEvent(nativeEvent, nativeEventTarget);
+      }
+
+      return null;
+    }
+  };
+
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/css3-animations/#AnimationEvent-interface
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/AnimationEvent
+   */
+
+  var SyntheticAnimationEvent = SyntheticEvent.extend({
+    animationName: null,
+    elapsedTime: null,
+    pseudoElement: null
+  });
+
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/clipboard-apis/
+   */
+
+  var SyntheticClipboardEvent = SyntheticEvent.extend({
+    clipboardData: function (event) {
+      return 'clipboardData' in event ? event.clipboardData : window.clipboardData;
+    }
+  });
+
+  /**
+   * @interface FocusEvent
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+  var SyntheticFocusEvent = SyntheticUIEvent.extend({
+    relatedTarget: null
+  });
+
+  /**
+   * `charCode` represents the actual "character code" and is safe to use with
+   * `String.fromCharCode`. As such, only keys that correspond to printable
+   * characters produce a valid `charCode`, the only exception to this is Enter.
+   * The Tab-key is considered non-printable and does not have a `charCode`,
+   * presumably because it does not produce a tab-character in browsers.
+   *
+   * @param {object} nativeEvent Native browser event.
+   * @return {number} Normalized `charCode` property.
+   */
+  function getEventCharCode(nativeEvent) {
+    var charCode;
+    var keyCode = nativeEvent.keyCode;
+
+    if ('charCode' in nativeEvent) {
+      charCode = nativeEvent.charCode; // FF does not set `charCode` for the Enter-key, check against `keyCode`.
+
+      if (charCode === 0 && keyCode === 13) {
+        charCode = 13;
+      }
+    } else {
+      // IE8 does not implement `charCode`, but `keyCode` has the correct value.
+      charCode = keyCode;
+    } // IE and Edge (on Windows) and Chrome / Safari (on Windows and Linux)
+    // report Enter as charCode 10 when ctrl is pressed.
+
+
+    if (charCode === 10) {
+      charCode = 13;
+    } // Some non-printable keys are reported in `charCode`/`keyCode`, discard them.
+    // Must not discard the (non-)printable Enter-key.
+
+
+    if (charCode >= 32 || charCode === 13) {
+      return charCode;
+    }
+
+    return 0;
+  }
+
+  /**
+   * Normalization of deprecated HTML5 `key` values
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+   */
+
+  var normalizeKey = {
+    Esc: 'Escape',
+    Spacebar: ' ',
+    Left: 'ArrowLeft',
+    Up: 'ArrowUp',
+    Right: 'ArrowRight',
+    Down: 'ArrowDown',
+    Del: 'Delete',
+    Win: 'OS',
+    Menu: 'ContextMenu',
+    Apps: 'ContextMenu',
+    Scroll: 'ScrollLock',
+    MozPrintableKey: 'Unidentified'
+  };
+  /**
+   * Translation from legacy `keyCode` to HTML5 `key`
+   * Only special keys supported, all others depend on keyboard layout or browser
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+   */
+
+  var translateToKey = {
+    '8': 'Backspace',
+    '9': 'Tab',
+    '12': 'Clear',
+    '13': 'Enter',
+    '16': 'Shift',
+    '17': 'Control',
+    '18': 'Alt',
+    '19': 'Pause',
+    '20': 'CapsLock',
+    '27': 'Escape',
+    '32': ' ',
+    '33': 'PageUp',
+    '34': 'PageDown',
+    '35': 'End',
+    '36': 'Home',
+    '37': 'ArrowLeft',
+    '38': 'ArrowUp',
+    '39': 'ArrowRight',
+    '40': 'ArrowDown',
+    '45': 'Insert',
+    '46': 'Delete',
+    '112': 'F1',
+    '113': 'F2',
+    '114': 'F3',
+    '115': 'F4',
+    '116': 'F5',
+    '117': 'F6',
+    '118': 'F7',
+    '119': 'F8',
+    '120': 'F9',
+    '121': 'F10',
+    '122': 'F11',
+    '123': 'F12',
+    '144': 'NumLock',
+    '145': 'ScrollLock',
+    '224': 'Meta'
+  };
+  /**
+   * @param {object} nativeEvent Native browser event.
+   * @return {string} Normalized `key` property.
+   */
+
+  function getEventKey(nativeEvent) {
+    if (nativeEvent.key) {
+      // Normalize inconsistent values reported by browsers due to
+      // implementations of a working draft specification.
+      // FireFox implements `key` but returns `MozPrintableKey` for all
+      // printable characters (normalized to `Unidentified`), ignore it.
+      var key = normalizeKey[nativeEvent.key] || nativeEvent.key;
+
+      if (key !== 'Unidentified') {
+        return key;
+      }
+    } // Browser does not implement `key`, polyfill as much of it as we can.
+
+
+    if (nativeEvent.type === 'keypress') {
+      var charCode = getEventCharCode(nativeEvent); // The enter-key is technically both printable and non-printable and can
+      // thus be captured by `keypress`, no other non-printable key should.
+
+      return charCode === 13 ? 'Enter' : String.fromCharCode(charCode);
+    }
+
+    if (nativeEvent.type === 'keydown' || nativeEvent.type === 'keyup') {
+      // While user keyboard layout determines the actual meaning of each
+      // `keyCode` value, almost all function keys have a universal value.
+      return translateToKey[nativeEvent.keyCode] || 'Unidentified';
+    }
+
+    return '';
+  }
+
+  /**
+   * @interface KeyboardEvent
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+  var SyntheticKeyboardEvent = SyntheticUIEvent.extend({
+    key: getEventKey,
+    location: null,
+    ctrlKey: null,
+    shiftKey: null,
+    altKey: null,
+    metaKey: null,
+    repeat: null,
+    locale: null,
+    getModifierState: getEventModifierState,
+    // Legacy Interface
+    charCode: function (event) {
+      // `charCode` is the result of a KeyPress event and represents the value of
+      // the actual printable character.
+      // KeyPress is deprecated, but its replacement is not yet final and not
+      // implemented in any major browser. Only KeyPress has charCode.
+      if (event.type === 'keypress') {
+        return getEventCharCode(event);
+      }
+
+      return 0;
+    },
+    keyCode: function (event) {
+      // `keyCode` is the result of a KeyDown/Up event and represents the value of
+      // physical keyboard key.
+      // The actual meaning of the value depends on the users' keyboard layout
+      // which cannot be detected. Assuming that it is a US keyboard layout
+      // provides a surprisingly accurate mapping for US and European users.
+      // Due to this, it is left to the user to implement at this time.
+      if (event.type === 'keydown' || event.type === 'keyup') {
+        return event.keyCode;
+      }
+
+      return 0;
+    },
+    which: function (event) {
+      // `which` is an alias for either `keyCode` or `charCode` depending on the
+      // type of the event.
+      if (event.type === 'keypress') {
+        return getEventCharCode(event);
+      }
+
+      if (event.type === 'keydown' || event.type === 'keyup') {
+        return event.keyCode;
+      }
+
+      return 0;
+    }
+  });
+
+  /**
+   * @interface DragEvent
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+  var SyntheticDragEvent = SyntheticMouseEvent.extend({
+    dataTransfer: null
+  });
+
+  /**
+   * @interface TouchEvent
+   * @see http://www.w3.org/TR/touch-events/
+   */
+
+  var SyntheticTouchEvent = SyntheticUIEvent.extend({
+    touches: null,
+    targetTouches: null,
+    changedTouches: null,
+    altKey: null,
+    metaKey: null,
+    ctrlKey: null,
+    shiftKey: null,
+    getModifierState: getEventModifierState
+  });
+
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/2009/WD-css3-transitions-20090320/#transition-events-
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent
+   */
+
+  var SyntheticTransitionEvent = SyntheticEvent.extend({
+    propertyName: null,
+    elapsedTime: null,
+    pseudoElement: null
+  });
+
+  /**
+   * @interface WheelEvent
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+  var SyntheticWheelEvent = SyntheticMouseEvent.extend({
+    deltaX: function (event) {
+      return 'deltaX' in event ? event.deltaX : // Fallback to `wheelDeltaX` for Webkit and normalize (right is positive).
+      'wheelDeltaX' in event ? -event.wheelDeltaX : 0;
+    },
+    deltaY: function (event) {
+      return 'deltaY' in event ? event.deltaY : // Fallback to `wheelDeltaY` for Webkit and normalize (down is positive).
+      'wheelDeltaY' in event ? -event.wheelDeltaY : // Fallback to `wheelDelta` for IE<9 and normalize (down is positive).
+      'wheelDelta' in event ? -event.wheelDelta : 0;
+    },
+    deltaZ: null,
+    // Browsers without "deltaMode" is reporting in raw wheel delta where one
+    // notch on the scroll is always +/- 120, roughly equivalent to pixels.
+    // A good approximation of DOM_DELTA_LINE (1) is 5% of viewport size or
+    // ~40 pixels, for DOM_DELTA_SCREEN (2) it is 87.5% of viewport size.
+    deltaMode: null
+  });
+
+  var knownHTMLTopLevelTypes = [TOP_ABORT, TOP_CANCEL, TOP_CAN_PLAY, TOP_CAN_PLAY_THROUGH, TOP_CLOSE, TOP_DURATION_CHANGE, TOP_EMPTIED, TOP_ENCRYPTED, TOP_ENDED, TOP_ERROR, TOP_INPUT, TOP_INVALID, TOP_LOAD, TOP_LOADED_DATA, TOP_LOADED_METADATA, TOP_LOAD_START, TOP_PAUSE, TOP_PLAY, TOP_PLAYING, TOP_PROGRESS, TOP_RATE_CHANGE, TOP_RESET, TOP_SEEKED, TOP_SEEKING, TOP_STALLED, TOP_SUBMIT, TOP_SUSPEND, TOP_TIME_UPDATE, TOP_TOGGLE, TOP_VOLUME_CHANGE, TOP_WAITING];
+  var SimpleEventPlugin = {
+    // simpleEventPluginEventTypes gets populated from
+    // the DOMEventProperties module.
+    eventTypes: simpleEventPluginEventTypes,
+    extractEvents: function (topLevelType, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags) {
+      var dispatchConfig = topLevelEventsToDispatchConfig.get(topLevelType);
+
+      if (!dispatchConfig) {
+        return null;
+      }
+
+      var EventConstructor;
+
+      switch (topLevelType) {
+        case TOP_KEY_PRESS:
+          // Firefox creates a keypress event for function keys too. This removes
+          // the unwanted keypress events. Enter is however both printable and
+          // non-printable. One would expect Tab to be as well (but it isn't).
+          if (getEventCharCode(nativeEvent) === 0) {
+            return null;
+          }
+
+        /* falls through */
+
+        case TOP_KEY_DOWN:
+        case TOP_KEY_UP:
+          EventConstructor = SyntheticKeyboardEvent;
+          break;
+
+        case TOP_BLUR:
+        case TOP_FOCUS:
+          EventConstructor = SyntheticFocusEvent;
+          break;
+
+        case TOP_CLICK:
+          // Firefox creates a click event on right mouse clicks. This removes the
+          // unwanted click events.
+          if (nativeEvent.button === 2) {
+            return null;
+          }
+
+        /* falls through */
+
+        case TOP_AUX_CLICK:
+        case TOP_DOUBLE_CLICK:
+        case TOP_MOUSE_DOWN:
+        case TOP_MOUSE_MOVE:
+        case TOP_MOUSE_UP: // TODO: Disabled elements should not respond to mouse events
+
+        /* falls through */
+
+        case TOP_MOUSE_OUT:
+        case TOP_MOUSE_OVER:
+        case TOP_CONTEXT_MENU:
+          EventConstructor = SyntheticMouseEvent;
+          break;
+
+        case TOP_DRAG:
+        case TOP_DRAG_END:
+        case TOP_DRAG_ENTER:
+        case TOP_DRAG_EXIT:
+        case TOP_DRAG_LEAVE:
+        case TOP_DRAG_OVER:
+        case TOP_DRAG_START:
+        case TOP_DROP:
+          EventConstructor = SyntheticDragEvent;
+          break;
+
+        case TOP_TOUCH_CANCEL:
+        case TOP_TOUCH_END:
+        case TOP_TOUCH_MOVE:
+        case TOP_TOUCH_START:
+          EventConstructor = SyntheticTouchEvent;
+          break;
+
+        case TOP_ANIMATION_END:
+        case TOP_ANIMATION_ITERATION:
+        case TOP_ANIMATION_START:
+          EventConstructor = SyntheticAnimationEvent;
+          break;
+
+        case TOP_TRANSITION_END:
+          EventConstructor = SyntheticTransitionEvent;
+          break;
+
+        case TOP_SCROLL:
+          EventConstructor = SyntheticUIEvent;
+          break;
+
+        case TOP_WHEEL:
+          EventConstructor = SyntheticWheelEvent;
+          break;
+
+        case TOP_COPY:
+        case TOP_CUT:
+        case TOP_PASTE:
+          EventConstructor = SyntheticClipboardEvent;
+          break;
+
+        case TOP_GOT_POINTER_CAPTURE:
+        case TOP_LOST_POINTER_CAPTURE:
+        case TOP_POINTER_CANCEL:
+        case TOP_POINTER_DOWN:
+        case TOP_POINTER_MOVE:
+        case TOP_POINTER_OUT:
+        case TOP_POINTER_OVER:
+        case TOP_POINTER_UP:
+          EventConstructor = SyntheticPointerEvent;
+          break;
+
+        default:
+          {
+            if (knownHTMLTopLevelTypes.indexOf(topLevelType) === -1) {
+              error('SimpleEventPlugin: Unhandled event type, `%s`. This warning ' + 'is likely caused by a bug in React. Please file an issue.', topLevelType);
+            }
+          } // HTML Events
+          // @see http://www.w3.org/TR/html5/index.html#events-0
+
+
+          EventConstructor = SyntheticEvent;
+          break;
+      }
+
+      var event = EventConstructor.getPooled(dispatchConfig, targetInst, nativeEvent, nativeEventTarget);
+      accumulateTwoPhaseDispatches(event);
+      return event;
+    }
+  };
+
+  /**
+   * Specifies a deterministic ordering of `EventPlugin`s. A convenient way to
+   * reason about plugins, without having to package every one of them. This
+   * is better than having plugins be ordered in the same order that they
+   * are injected because that ordering would be influenced by the packaging order.
+   * `ResponderEventPlugin` must occur before `SimpleEventPlugin` so that
+   * preventing default on events is convenient in `SimpleEventPlugin` handlers.
+   */
+
+  var DOMEventPluginOrder = ['ResponderEventPlugin', 'SimpleEventPlugin', 'EnterLeaveEventPlugin', 'ChangeEventPlugin', 'SelectEventPlugin', 'BeforeInputEventPlugin'];
+  /**
+   * Inject modules for resolving DOM hierarchy and plugin ordering.
+   */
+
+  injectEventPluginOrder(DOMEventPluginOrder);
+  setComponentTree(getFiberCurrentPropsFromNode$1, getInstanceFromNode$1, getNodeFromInstance$1);
+  /**
+   * Some important event plugins included by default (without having to require
+   * them).
+   */
+
+  injectEventPluginsByName({
+    SimpleEventPlugin: SimpleEventPlugin,
+    EnterLeaveEventPlugin: EnterLeaveEventPlugin,
+    ChangeEventPlugin: ChangeEventPlugin,
+    SelectEventPlugin: SelectEventPlugin,
+    BeforeInputEventPlugin: BeforeInputEventPlugin
+  });
+
+  // Prefix measurements so that it's possible to filter them.
+  // Longer prefixes are hard to read in DevTools.
+  var reactEmoji = "\u269B";
+  var warningEmoji = "\u26D4";
+  var supportsUserTiming = typeof performance !== 'undefined' && typeof performance.mark === 'function' && typeof performance.clearMarks === 'function' && typeof performance.measure === 'function' && typeof performance.clearMeasures === 'function'; // Keep track of current fiber so that we know the path to unwind on pause.
+  // TODO: this looks the same as nextUnitOfWork in scheduler. Can we unify them?
+
+  var currentFiber = null; // If we're in the middle of user code, which fiber and method is it?
+  // Reusing `currentFiber` would be confusing for this because user code fiber
+  // can change during commit phase too, but we don't need to unwind it (since
+  // lifecycles in the commit phase don't resemble a tree).
+
+  var currentPhase = null;
+  var currentPhaseFiber = null; // Did lifecycle hook schedule an update? This is often a performance problem,
+  // so we will keep track of it, and include it in the report.
+  // Track commits caused by cascading updates.
+
+  var isCommitting = false;
+  var hasScheduledUpdateInCurrentCommit = false;
+  var hasScheduledUpdateInCurrentPhase = false;
+  var commitCountInCurrentWorkLoop = 0;
+  var effectCountInCurrentCommit = 0;
+  // to avoid stretch the commit phase with measurement overhead.
+
+  var labelsInCurrentCommit = new Set();
+
+  var formatMarkName = function (markName) {
+    return reactEmoji + " " + markName;
+  };
+
+  var formatLabel = function (label, warning) {
+    var prefix = warning ? warningEmoji + " " : reactEmoji + " ";
+    var suffix = warning ? " Warning: " + warning : '';
+    return "" + prefix + label + suffix;
+  };
+
+  var beginMark = function (markName) {
+    performance.mark(formatMarkName(markName));
+  };
+
+  var clearMark = function (markName) {
+    performance.clearMarks(formatMarkName(markName));
+  };
+
+  var endMark = function (label, markName, warning) {
+    var formattedMarkName = formatMarkName(markName);
+    var formattedLabel = formatLabel(label, warning);
+
+    try {
+      performance.measure(formattedLabel, formattedMarkName);
+    } catch (err) {} // If previous mark was missing for some reason, this will throw.
+    // This could only happen if React crashed in an unexpected place earlier.
+    // Don't pile on with more errors.
+    // Clear marks immediately to avoid growing buffer.
+
+
+    performance.clearMarks(formattedMarkName);
+    performance.clearMeasures(formattedLabel);
+  };
+
+  var getFiberMarkName = function (label, debugID) {
+    return label + " (#" + debugID + ")";
+  };
+
+  var getFiberLabel = function (componentName, isMounted, phase) {
+    if (phase === null) {
+      // These are composite component total time measurements.
+      return componentName + " [" + (isMounted ? 'update' : 'mount') + "]";
+    } else {
+      // Composite component methods.
+      return componentName + "." + phase;
+    }
+  };
+
+  var beginFiberMark = function (fiber, phase) {
+    var componentName = getComponentName(fiber.type) || 'Unknown';
+    var debugID = fiber._debugID;
+    var isMounted = fiber.alternate !== null;
+    var label = getFiberLabel(componentName, isMounted, phase);
+
+    if (isCommitting && labelsInCurrentCommit.has(label)) {
+      // During the commit phase, we don't show duplicate labels because
+      // there is a fixed overhead for every measurement, and we don't
+      // want to stretch the commit phase beyond necessary.
+      return false;
+    }
+
+    labelsInCurrentCommit.add(label);
+    var markName = getFiberMarkName(label, debugID);
+    beginMark(markName);
+    return true;
+  };
+
+  var clearFiberMark = function (fiber, phase) {
+    var componentName = getComponentName(fiber.type) || 'Unknown';
+    var debugID = fiber._debugID;
+    var isMounted = fiber.alternate !== null;
+    var label = getFiberLabel(componentName, isMounted, phase);
+    var markName = getFiberMarkName(label, debugID);
+    clearMark(markName);
+  };
+
+  var endFiberMark = function (fiber, phase, warning) {
+    var componentName = getComponentName(fiber.type) || 'Unknown';
+    var debugID = fiber._debugID;
+    var isMounted = fiber.alternate !== null;
+    var label = getFiberLabel(componentName, isMounted, phase);
+    var markName = getFiberMarkName(label, debugID);
+    endMark(label, markName, warning);
+  };
+
+  var shouldIgnoreFiber = function (fiber) {
+    // Host components should be skipped in the timeline.
+    // We could check typeof fiber.type, but does this work with RN?
+    switch (fiber.tag) {
+      case HostRoot:
+      case HostComponent:
+      case HostText:
+      case HostPortal:
+      case Fragment:
+      case ContextProvider:
+      case ContextConsumer:
+      case Mode:
+        return true;
+
+      default:
+        return false;
+    }
+  };
+
+  var clearPendingPhaseMeasurement = function () {
+    if (currentPhase !== null && currentPhaseFiber !== null) {
+      clearFiberMark(currentPhaseFiber, currentPhase);
+    }
+
+    currentPhaseFiber = null;
+    currentPhase = null;
+    hasScheduledUpdateInCurrentPhase = false;
+  };
+
+  var pauseTimers = function () {
+    // Stops all currently active measurements so that they can be resumed
+    // if we continue in a later deferred loop from the same unit of work.
+    var fiber = currentFiber;
+
+    while (fiber) {
+      if (fiber._debugIsCurrentlyTiming) {
+        endFiberMark(fiber, null, null);
+      }
+
+      fiber = fiber.return;
+    }
+  };
+
+  var resumeTimersRecursively = function (fiber) {
+    if (fiber.return !== null) {
+      resumeTimersRecursively(fiber.return);
+    }
+
+    if (fiber._debugIsCurrentlyTiming) {
+      beginFiberMark(fiber, null);
+    }
+  };
+
+  var resumeTimers = function () {
+    // Resumes all measurements that were active during the last deferred loop.
+    if (currentFiber !== null) {
+      resumeTimersRecursively(currentFiber);
+    }
+  };
+
+  function recordEffect() {
+    {
+      effectCountInCurrentCommit++;
+    }
+  }
+  function recordScheduleUpdate() {
+    {
+      if (isCommitting) {
+        hasScheduledUpdateInCurrentCommit = true;
+      }
+
+      if (currentPhase !== null && currentPhase !== 'componentWillMount' && currentPhase !== 'componentWillReceiveProps') {
+        hasScheduledUpdateInCurrentPhase = true;
+      }
+    }
+  }
+  function startWorkTimer(fiber) {
+    {
+      if (!supportsUserTiming || shouldIgnoreFiber(fiber)) {
+        return;
+      } // If we pause, this is the fiber to unwind from.
+
+
+      currentFiber = fiber;
+
+      if (!beginFiberMark(fiber, null)) {
+        return;
+      }
+
+      fiber._debugIsCurrentlyTiming = true;
+    }
+  }
+  function cancelWorkTimer(fiber) {
+    {
+      if (!supportsUserTiming || shouldIgnoreFiber(fiber)) {
+        return;
+      } // Remember we shouldn't complete measurement for this fiber.
+      // Otherwise flamechart will be deep even for small updates.
+
+
+      fiber._debugIsCurrentlyTiming = false;
+      clearFiberMark(fiber, null);
+    }
+  }
+  function stopWorkTimer(fiber) {
+    {
+      if (!supportsUserTiming || shouldIgnoreFiber(fiber)) {
+        return;
+      } // If we pause, its parent is the fiber to unwind from.
+
+
+      currentFiber = fiber.return;
+
+      if (!fiber._debugIsCurrentlyTiming) {
+        return;
+      }
+
+      fiber._debugIsCurrentlyTiming = false;
+      endFiberMark(fiber, null, null);
+    }
+  }
+  function stopFailedWorkTimer(fiber) {
+    {
+      if (!supportsUserTiming || shouldIgnoreFiber(fiber)) {
+        return;
+      } // If we pause, its parent is the fiber to unwind from.
+
+
+      currentFiber = fiber.return;
+
+      if (!fiber._debugIsCurrentlyTiming) {
+        return;
+      }
+
+      fiber._debugIsCurrentlyTiming = false;
+      var warning = fiber.tag === SuspenseComponent ? 'Rendering was suspended' : 'An error was thrown inside this error boundary';
+      endFiberMark(fiber, null, warning);
+    }
+  }
+  function startPhaseTimer(fiber, phase) {
+    {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      clearPendingPhaseMeasurement();
+
+      if (!beginFiberMark(fiber, phase)) {
+        return;
+      }
+
+      currentPhaseFiber = fiber;
+      currentPhase = phase;
+    }
+  }
+  function stopPhaseTimer() {
+    {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      if (currentPhase !== null && currentPhaseFiber !== null) {
+        var warning = hasScheduledUpdateInCurrentPhase ? 'Scheduled a cascading update' : null;
+        endFiberMark(currentPhaseFiber, currentPhase, warning);
+      }
+
+      currentPhase = null;
+      currentPhaseFiber = null;
+    }
+  }
+  function startWorkLoopTimer(nextUnitOfWork) {
+    {
+      currentFiber = nextUnitOfWork;
+
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      commitCountInCurrentWorkLoop = 0; // This is top level call.
+      // Any other measurements are performed within.
+
+      beginMark('(React Tree Reconciliation)'); // Resume any measurements that were in progress during the last loop.
+
+      resumeTimers();
+    }
+  }
+  function stopWorkLoopTimer(interruptedBy, didCompleteRoot) {
+    {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      var warning = null;
+
+      if (interruptedBy !== null) {
+        if (interruptedBy.tag === HostRoot) {
+          warning = 'A top-level update interrupted the previous render';
+        } else {
+          var componentName = getComponentName(interruptedBy.type) || 'Unknown';
+          warning = "An update to " + componentName + " interrupted the previous render";
+        }
+      } else if (commitCountInCurrentWorkLoop > 1) {
+        warning = 'There were cascading updates';
+      }
+
+      commitCountInCurrentWorkLoop = 0;
+      var label = didCompleteRoot ? '(React Tree Reconciliation: Completed Root)' : '(React Tree Reconciliation: Yielded)'; // Pause any measurements until the next loop.
+
+      pauseTimers();
+      endMark(label, '(React Tree Reconciliation)', warning);
+    }
+  }
+  function startCommitTimer() {
+    {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      isCommitting = true;
+      hasScheduledUpdateInCurrentCommit = false;
+      labelsInCurrentCommit.clear();
+      beginMark('(Committing Changes)');
+    }
+  }
+  function stopCommitTimer() {
+    {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      var warning = null;
+
+      if (hasScheduledUpdateInCurrentCommit) {
+        warning = 'Lifecycle hook scheduled a cascading update';
+      } else if (commitCountInCurrentWorkLoop > 0) {
+        warning = 'Caused by a cascading update in earlier commit';
+      }
+
+      hasScheduledUpdateInCurrentCommit = false;
+      commitCountInCurrentWorkLoop++;
+      isCommitting = false;
+      labelsInCurrentCommit.clear();
+      endMark('(Committing Changes)', '(Committing Changes)', warning);
+    }
+  }
+  function startCommitSnapshotEffectsTimer() {
+    {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      effectCountInCurrentCommit = 0;
+      beginMark('(Committing Snapshot Effects)');
+    }
+  }
+  function stopCommitSnapshotEffectsTimer() {
+    {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      var count = effectCountInCurrentCommit;
+      effectCountInCurrentCommit = 0;
+      endMark("(Committing Snapshot Effects: " + count + " Total)", '(Committing Snapshot Effects)', null);
+    }
+  }
+  function startCommitHostEffectsTimer() {
+    {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      effectCountInCurrentCommit = 0;
+      beginMark('(Committing Host Effects)');
+    }
+  }
+  function stopCommitHostEffectsTimer() {
+    {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      var count = effectCountInCurrentCommit;
+      effectCountInCurrentCommit = 0;
+      endMark("(Committing Host Effects: " + count + " Total)", '(Committing Host Effects)', null);
+    }
+  }
+  function startCommitLifeCyclesTimer() {
+    {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      effectCountInCurrentCommit = 0;
+      beginMark('(Calling Lifecycle Methods)');
+    }
+  }
+  function stopCommitLifeCyclesTimer() {
+    {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      var count = effectCountInCurrentCommit;
+      effectCountInCurrentCommit = 0;
+      endMark("(Calling Lifecycle Methods: " + count + " Total)", '(Calling Lifecycle Methods)', null);
+    }
+  }
+
+  var valueStack = [];
+  var fiberStack;
+
+  {
+    fiberStack = [];
+  }
+
+  var index = -1;
+
+  function createCursor(defaultValue) {
+    return {
+      current: defaultValue
+    };
+  }
+
+  function pop(cursor, fiber) {
+    if (index < 0) {
+      {
+        error('Unexpected pop.');
+      }
+
+      return;
+    }
+
+    {
+      if (fiber !== fiberStack[index]) {
+        error('Unexpected Fiber popped.');
+      }
+    }
+
+    cursor.current = valueStack[index];
+    valueStack[index] = null;
+
+    {
+      fiberStack[index] = null;
+    }
+
+    index--;
+  }
+
+  function push(cursor, value, fiber) {
+    index++;
+    valueStack[index] = cursor.current;
+
+    {
+      fiberStack[index] = fiber;
+    }
+
+    cursor.current = value;
+  }
+
+  var warnedAboutMissingGetChildContext;
+
+  {
+    warnedAboutMissingGetChildContext = {};
+  }
+
+  var emptyContextObject = {};
+
+  {
+    Object.freeze(emptyContextObject);
+  } // A cursor to the current merged context object on the stack.
+
+
+  var contextStackCursor = createCursor(emptyContextObject); // A cursor to a boolean indicating whether the context has changed.
+
+  var didPerformWorkStackCursor = createCursor(false); // Keep track of the previous context object that was on the stack.
+  // We use this to get access to the parent context after we have already
+  // pushed the next context provider, and now need to merge their contexts.
+
+  var previousContext = emptyContextObject;
+
+  function getUnmaskedContext(workInProgress, Component, didPushOwnContextIfProvider) {
+    {
+      if (didPushOwnContextIfProvider && isContextProvider(Component)) {
+        // If the fiber is a context provider itself, when we read its context
+        // we may have already pushed its own child context on the stack. A context
+        // provider should not "see" its own child context. Therefore we read the
+        // previous (parent) context instead for a context provider.
+        return previousContext;
+      }
+
+      return contextStackCursor.current;
+    }
+  }
+
+  function cacheContext(workInProgress, unmaskedContext, maskedContext) {
+    {
+      var instance = workInProgress.stateNode;
+      instance.__reactInternalMemoizedUnmaskedChildContext = unmaskedContext;
+      instance.__reactInternalMemoizedMaskedChildContext = maskedContext;
+    }
+  }
+
+  function getMaskedContext(workInProgress, unmaskedContext) {
+    {
+      var type = workInProgress.type;
+      var contextTypes = type.contextTypes;
+
+      if (!contextTypes) {
+        return emptyContextObject;
+      } // Avoid recreating masked context unless unmasked context has changed.
+      // Failing to do this will result in unnecessary calls to componentWillReceiveProps.
+      // This may trigger infinite loops if componentWillReceiveProps calls setState.
+
+
+      var instance = workInProgress.stateNode;
+
+      if (instance && instance.__reactInternalMemoizedUnmaskedChildContext === unmaskedContext) {
+        return instance.__reactInternalMemoizedMaskedChildContext;
+      }
+
+      var context = {};
+
+      for (var key in contextTypes) {
+        context[key] = unmaskedContext[key];
+      }
+
+      {
+        var name = getComponentName(type) || 'Unknown';
+        checkPropTypes_1(contextTypes, context, 'context', name, getCurrentFiberStackInDev);
+      } // Cache unmasked context so we can avoid recreating masked context unless necessary.
+      // Context is created before the class component is instantiated so check for instance.
+
+
+      if (instance) {
+        cacheContext(workInProgress, unmaskedContext, context);
+      }
+
+      return context;
+    }
+  }
+
+  function hasContextChanged() {
+    {
+      return didPerformWorkStackCursor.current;
+    }
+  }
+
+  function isContextProvider(type) {
+    {
+      var childContextTypes = type.childContextTypes;
+      return childContextTypes !== null && childContextTypes !== undefined;
+    }
+  }
+
+  function popContext(fiber) {
+    {
+      pop(didPerformWorkStackCursor, fiber);
+      pop(contextStackCursor, fiber);
+    }
+  }
+
+  function popTopLevelContextObject(fiber) {
+    {
+      pop(didPerformWorkStackCursor, fiber);
+      pop(contextStackCursor, fiber);
+    }
+  }
+
+  function pushTopLevelContextObject(fiber, context, didChange) {
+    {
+      if (!(contextStackCursor.current === emptyContextObject)) {
+        {
+          throw Error( "Unexpected context found on stack. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+
+      push(contextStackCursor, context, fiber);
+      push(didPerformWorkStackCursor, didChange, fiber);
+    }
+  }
+
+  function processChildContext(fiber, type, parentContext) {
+    {
+      var instance = fiber.stateNode;
+      var childContextTypes = type.childContextTypes; // TODO (bvaughn) Replace this behavior with an invariant() in the future.
+      // It has only been added in Fiber to match the (unintentional) behavior in Stack.
+
+      if (typeof instance.getChildContext !== 'function') {
+        {
+          var componentName = getComponentName(type) || 'Unknown';
+
+          if (!warnedAboutMissingGetChildContext[componentName]) {
+            warnedAboutMissingGetChildContext[componentName] = true;
+
+            error('%s.childContextTypes is specified but there is no getChildContext() method ' + 'on the instance. You can either define getChildContext() on %s or remove ' + 'childContextTypes from it.', componentName, componentName);
+          }
+        }
+
+        return parentContext;
+      }
+
+      var childContext;
+      startPhaseTimer(fiber, 'getChildContext');
+      childContext = instance.getChildContext();
+      stopPhaseTimer();
+
+      for (var contextKey in childContext) {
+        if (!(contextKey in childContextTypes)) {
+          {
+            throw Error( (getComponentName(type) || 'Unknown') + ".getChildContext(): key \"" + contextKey + "\" is not defined in childContextTypes." );
+          }
+        }
+      }
+
+      {
+        var name = getComponentName(type) || 'Unknown';
+        checkPropTypes_1(childContextTypes, childContext, 'child context', name, // In practice, there is one case in which we won't get a stack. It's when
+        // somebody calls unstable_renderSubtreeIntoContainer() and we process
+        // context from the parent component instance. The stack will be missing
+        // because it's outside of the reconciliation, and so the pointer has not
+        // been set. This is rare and doesn't matter. We'll also remove that API.
+        getCurrentFiberStackInDev);
+      }
+
+      return _assign({}, parentContext, {}, childContext);
+    }
+  }
+
+  function pushContextProvider(workInProgress) {
+    {
+      var instance = workInProgress.stateNode; // We push the context as early as possible to ensure stack integrity.
+      // If the instance does not exist yet, we will push null at first,
+      // and replace it on the stack later when invalidating the context.
+
+      var memoizedMergedChildContext = instance && instance.__reactInternalMemoizedMergedChildContext || emptyContextObject; // Remember the parent context so we can merge with it later.
+      // Inherit the parent's did-perform-work value to avoid inadvertently blocking updates.
+
+      previousContext = contextStackCursor.current;
+      push(contextStackCursor, memoizedMergedChildContext, workInProgress);
+      push(didPerformWorkStackCursor, didPerformWorkStackCursor.current, workInProgress);
+      return true;
+    }
+  }
+
+  function invalidateContextProvider(workInProgress, type, didChange) {
+    {
+      var instance = workInProgress.stateNode;
+
+      if (!instance) {
+        {
+          throw Error( "Expected to have an instance by this point. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+
+      if (didChange) {
+        // Merge parent and own context.
+        // Skip this if we're not updating due to sCU.
+        // This avoids unnecessarily recomputing memoized values.
+        var mergedContext = processChildContext(workInProgress, type, previousContext);
+        instance.__reactInternalMemoizedMergedChildContext = mergedContext; // Replace the old (or empty) context with the new one.
+        // It is important to unwind the context in the reverse order.
+
+        pop(didPerformWorkStackCursor, workInProgress);
+        pop(contextStackCursor, workInProgress); // Now push the new context and mark that it has changed.
+
+        push(contextStackCursor, mergedContext, workInProgress);
+        push(didPerformWorkStackCursor, didChange, workInProgress);
+      } else {
+        pop(didPerformWorkStackCursor, workInProgress);
+        push(didPerformWorkStackCursor, didChange, workInProgress);
+      }
+    }
+  }
+
+  function findCurrentUnmaskedContext(fiber) {
+    {
+      // Currently this is only used with renderSubtreeIntoContainer; not sure if it
+      // makes sense elsewhere
+      if (!(isFiberMounted(fiber) && fiber.tag === ClassComponent)) {
+        {
+          throw Error( "Expected subtree parent to be a mounted class component. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+
+      var node = fiber;
+
+      do {
+        switch (node.tag) {
+          case HostRoot:
+            return node.stateNode.context;
+
+          case ClassComponent:
+            {
+              var Component = node.type;
+
+              if (isContextProvider(Component)) {
+                return node.stateNode.__reactInternalMemoizedMergedChildContext;
+              }
+
+              break;
+            }
+        }
+
+        node = node.return;
+      } while (node !== null);
+
+      {
+        {
+          throw Error( "Found unexpected detached subtree parent. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+    }
+  }
+
+  var LegacyRoot = 0;
+  var BlockingRoot = 1;
+  var ConcurrentRoot = 2;
+
+  var ReactInternals$2 = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+  var _ReactInternals$Sched$1 = ReactInternals$2.SchedulerTracing,
+      __interactionsRef = _ReactInternals$Sched$1.__interactionsRef,
+      __subscriberRef = _ReactInternals$Sched$1.__subscriberRef,
+      unstable_clear = _ReactInternals$Sched$1.unstable_clear,
+      unstable_getCurrent = _ReactInternals$Sched$1.unstable_getCurrent,
+      unstable_getThreadID = _ReactInternals$Sched$1.unstable_getThreadID,
+      unstable_subscribe = _ReactInternals$Sched$1.unstable_subscribe,
+      unstable_trace = _ReactInternals$Sched$1.unstable_trace,
+      unstable_unsubscribe = _ReactInternals$Sched$1.unstable_unsubscribe,
+      unstable_wrap = _ReactInternals$Sched$1.unstable_wrap;
+
+  var Scheduler_runWithPriority = unstable_runWithPriority,
+      Scheduler_scheduleCallback = unstable_scheduleCallback,
+      Scheduler_cancelCallback = unstable_cancelCallback,
+      Scheduler_shouldYield = unstable_shouldYield,
+      Scheduler_requestPaint = unstable_requestPaint,
+      Scheduler_now = unstable_now,
+      Scheduler_getCurrentPriorityLevel = unstable_getCurrentPriorityLevel,
+      Scheduler_ImmediatePriority = unstable_ImmediatePriority,
+      Scheduler_UserBlockingPriority = unstable_UserBlockingPriority,
+      Scheduler_NormalPriority = unstable_NormalPriority,
+      Scheduler_LowPriority = unstable_LowPriority,
+      Scheduler_IdlePriority = unstable_IdlePriority;
+
+  {
+    // Provide explicit error message when production+profiling bundle of e.g.
+    // react-dom is used with production (non-profiling) bundle of
+    // scheduler/tracing
+    if (!(__interactionsRef != null && __interactionsRef.current != null)) {
+      {
+        throw Error( "It is not supported to run the profiling version of a renderer (for example, `react-dom/profiling`) without also replacing the `scheduler/tracing` module with `scheduler/tracing-profiling`. Your bundler might have a setting for aliasing both modules. Learn more at http://fb.me/react-profiling" );
+      }
+    }
+  }
+
+  var fakeCallbackNode = {}; // Except for NoPriority, these correspond to Scheduler priorities. We use
+  // ascending numbers so we can compare them like numbers. They start at 90 to
+  // avoid clashing with Scheduler's priorities.
+
+  var ImmediatePriority = 99;
+  var UserBlockingPriority$1 = 98;
+  var NormalPriority = 97;
+  var LowPriority = 96;
+  var IdlePriority = 95; // NoPriority is the absence of priority. Also React-only.
+
+  var NoPriority = 90;
+  var shouldYield = Scheduler_shouldYield;
+  var requestPaint = // Fall back gracefully if we're running an older version of Scheduler.
+  Scheduler_requestPaint !== undefined ? Scheduler_requestPaint : function () {};
+  var syncQueue = null;
+  var immediateQueueCallbackNode = null;
+  var isFlushingSyncQueue = false;
+  var initialTimeMs = Scheduler_now(); // If the initial timestamp is reasonably small, use Scheduler's `now` directly.
+  // This will be the case for modern browsers that support `performance.now`. In
+  // older browsers, Scheduler falls back to `Date.now`, which returns a Unix
+  // timestamp. In that case, subtract the module initialization time to simulate
+  // the behavior of performance.now and keep our times small enough to fit
+  // within 32 bits.
+  // TODO: Consider lifting this into Scheduler.
+
+  var now = initialTimeMs < 10000 ? Scheduler_now : function () {
+    return Scheduler_now() - initialTimeMs;
+  };
+  function getCurrentPriorityLevel() {
+    switch (Scheduler_getCurrentPriorityLevel()) {
+      case Scheduler_ImmediatePriority:
+        return ImmediatePriority;
+
+      case Scheduler_UserBlockingPriority:
+        return UserBlockingPriority$1;
+
+      case Scheduler_NormalPriority:
+        return NormalPriority;
+
+      case Scheduler_LowPriority:
+        return LowPriority;
+
+      case Scheduler_IdlePriority:
+        return IdlePriority;
+
+      default:
+        {
+          {
+            throw Error( "Unknown priority level." );
+          }
+        }
+
+    }
+  }
+
+  function reactPriorityToSchedulerPriority(reactPriorityLevel) {
+    switch (reactPriorityLevel) {
+      case ImmediatePriority:
+        return Scheduler_ImmediatePriority;
+
+      case UserBlockingPriority$1:
+        return Scheduler_UserBlockingPriority;
+
+      case NormalPriority:
+        return Scheduler_NormalPriority;
+
+      case LowPriority:
+        return Scheduler_LowPriority;
+
+      case IdlePriority:
+        return Scheduler_IdlePriority;
+
+      default:
+        {
+          {
+            throw Error( "Unknown priority level." );
+          }
+        }
+
+    }
+  }
+
+  function runWithPriority$1(reactPriorityLevel, fn) {
+    var priorityLevel = reactPriorityToSchedulerPriority(reactPriorityLevel);
+    return Scheduler_runWithPriority(priorityLevel, fn);
+  }
+  function scheduleCallback(reactPriorityLevel, callback, options) {
+    var priorityLevel = reactPriorityToSchedulerPriority(reactPriorityLevel);
+    return Scheduler_scheduleCallback(priorityLevel, callback, options);
+  }
+  function scheduleSyncCallback(callback) {
+    // Push this callback into an internal queue. We'll flush these either in
+    // the next tick, or earlier if something calls `flushSyncCallbackQueue`.
+    if (syncQueue === null) {
+      syncQueue = [callback]; // Flush the queue in the next tick, at the earliest.
+
+      immediateQueueCallbackNode = Scheduler_scheduleCallback(Scheduler_ImmediatePriority, flushSyncCallbackQueueImpl);
+    } else {
+      // Push onto existing queue. Don't need to schedule a callback because
+      // we already scheduled one when we created the queue.
+      syncQueue.push(callback);
+    }
+
+    return fakeCallbackNode;
+  }
+  function cancelCallback(callbackNode) {
+    if (callbackNode !== fakeCallbackNode) {
+      Scheduler_cancelCallback(callbackNode);
+    }
+  }
+  function flushSyncCallbackQueue() {
+    if (immediateQueueCallbackNode !== null) {
+      var node = immediateQueueCallbackNode;
+      immediateQueueCallbackNode = null;
+      Scheduler_cancelCallback(node);
+    }
+
+    flushSyncCallbackQueueImpl();
+  }
+
+  function flushSyncCallbackQueueImpl() {
+    if (!isFlushingSyncQueue && syncQueue !== null) {
+      // Prevent re-entrancy.
+      isFlushingSyncQueue = true;
+      var i = 0;
+
+      try {
+        var _isSync = true;
+        var queue = syncQueue;
+        runWithPriority$1(ImmediatePriority, function () {
+          for (; i < queue.length; i++) {
+            var callback = queue[i];
+
+            do {
+              callback = callback(_isSync);
+            } while (callback !== null);
+          }
+        });
+        syncQueue = null;
+      } catch (error) {
+        // If something throws, leave the remaining callbacks on the queue.
+        if (syncQueue !== null) {
+          syncQueue = syncQueue.slice(i + 1);
+        } // Resume flushing in the next tick
+
+
+        Scheduler_scheduleCallback(Scheduler_ImmediatePriority, flushSyncCallbackQueue);
+        throw error;
+      } finally {
+        isFlushingSyncQueue = false;
+      }
+    }
+  }
+
+  var NoMode = 0;
+  var StrictMode = 1; // TODO: Remove BlockingMode and ConcurrentMode by reading from the root
+  // tag instead
+
+  var BlockingMode = 2;
+  var ConcurrentMode = 4;
+  var ProfileMode = 8;
+
+  // Max 31 bit integer. The max integer size in V8 for 32-bit systems.
+  // Math.pow(2, 30) - 1
+  // 0b111111111111111111111111111111
+  var MAX_SIGNED_31_BIT_INT = 1073741823;
+
+  var NoWork = 0; // TODO: Think of a better name for Never. The key difference with Idle is that
+  // Never work can be committed in an inconsistent state without tearing the UI.
+  // The main example is offscreen content, like a hidden subtree. So one possible
+  // name is Offscreen. However, it also includes dehydrated Suspense boundaries,
+  // which are inconsistent in the sense that they haven't finished yet, but
+  // aren't visibly inconsistent because the server rendered HTML matches what the
+  // hydrated tree would look like.
+
+  var Never = 1; // Idle is slightly higher priority than Never. It must completely finish in
+  // order to be consistent.
+
+  var Idle = 2; // Continuous Hydration is slightly higher than Idle and is used to increase
+  // priority of hover targets.
+
+  var ContinuousHydration = 3;
+  var Sync = MAX_SIGNED_31_BIT_INT;
+  var Batched = Sync - 1;
+  var UNIT_SIZE = 10;
+  var MAGIC_NUMBER_OFFSET = Batched - 1; // 1 unit of expiration time represents 10ms.
+
+  function msToExpirationTime(ms) {
+    // Always subtract from the offset so that we don't clash with the magic number for NoWork.
+    return MAGIC_NUMBER_OFFSET - (ms / UNIT_SIZE | 0);
+  }
+  function expirationTimeToMs(expirationTime) {
+    return (MAGIC_NUMBER_OFFSET - expirationTime) * UNIT_SIZE;
+  }
+
+  function ceiling(num, precision) {
+    return ((num / precision | 0) + 1) * precision;
+  }
+
+  function computeExpirationBucket(currentTime, expirationInMs, bucketSizeMs) {
+    return MAGIC_NUMBER_OFFSET - ceiling(MAGIC_NUMBER_OFFSET - currentTime + expirationInMs / UNIT_SIZE, bucketSizeMs / UNIT_SIZE);
+  } // TODO: This corresponds to Scheduler's NormalPriority, not LowPriority. Update
+  // the names to reflect.
+
+
+  var LOW_PRIORITY_EXPIRATION = 5000;
+  var LOW_PRIORITY_BATCH_SIZE = 250;
+  function computeAsyncExpiration(currentTime) {
+    return computeExpirationBucket(currentTime, LOW_PRIORITY_EXPIRATION, LOW_PRIORITY_BATCH_SIZE);
+  }
+  function computeSuspenseExpiration(currentTime, timeoutMs) {
+    // TODO: Should we warn if timeoutMs is lower than the normal pri expiration time?
+    return computeExpirationBucket(currentTime, timeoutMs, LOW_PRIORITY_BATCH_SIZE);
+  } // We intentionally set a higher expiration time for interactive updates in
+  // dev than in production.
+  //
+  // If the main thread is being blocked so long that you hit the expiration,
+  // it's a problem that could be solved with better scheduling.
+  //
+  // People will be more likely to notice this and fix it with the long
+  // expiration time in development.
+  //
+  // In production we opt for better UX at the risk of masking scheduling
+  // problems, by expiring fast.
+
+  var HIGH_PRIORITY_EXPIRATION =  500 ;
+  var HIGH_PRIORITY_BATCH_SIZE = 100;
+  function computeInteractiveExpiration(currentTime) {
+    return computeExpirationBucket(currentTime, HIGH_PRIORITY_EXPIRATION, HIGH_PRIORITY_BATCH_SIZE);
+  }
+  function inferPriorityFromExpirationTime(currentTime, expirationTime) {
+    if (expirationTime === Sync) {
+      return ImmediatePriority;
+    }
+
+    if (expirationTime === Never || expirationTime === Idle) {
+      return IdlePriority;
+    }
+
+    var msUntil = expirationTimeToMs(expirationTime) - expirationTimeToMs(currentTime);
+
+    if (msUntil <= 0) {
+      return ImmediatePriority;
+    }
+
+    if (msUntil <= HIGH_PRIORITY_EXPIRATION + HIGH_PRIORITY_BATCH_SIZE) {
+      return UserBlockingPriority$1;
+    }
+
+    if (msUntil <= LOW_PRIORITY_EXPIRATION + LOW_PRIORITY_BATCH_SIZE) {
+      return NormalPriority;
+    } // TODO: Handle LowPriority
+    // Assume anything lower has idle priority
+
+
+    return IdlePriority;
+  }
+
+  var ReactStrictModeWarnings = {
+    recordUnsafeLifecycleWarnings: function (fiber, instance) {},
+    flushPendingUnsafeLifecycleWarnings: function () {},
+    recordLegacyContextWarning: function (fiber, instance) {},
+    flushLegacyContextWarning: function () {},
+    discardPendingWarnings: function () {}
+  };
+
+  {
+    var findStrictRoot = function (fiber) {
+      var maybeStrictRoot = null;
+      var node = fiber;
+
+      while (node !== null) {
+        if (node.mode & StrictMode) {
+          maybeStrictRoot = node;
+        }
+
+        node = node.return;
+      }
+
+      return maybeStrictRoot;
+    };
+
+    var setToSortedString = function (set) {
+      var array = [];
+      set.forEach(function (value) {
+        array.push(value);
+      });
+      return array.sort().join(', ');
+    };
+
+    var pendingComponentWillMountWarnings = [];
+    var pendingUNSAFE_ComponentWillMountWarnings = [];
+    var pendingComponentWillReceivePropsWarnings = [];
+    var pendingUNSAFE_ComponentWillReceivePropsWarnings = [];
+    var pendingComponentWillUpdateWarnings = [];
+    var pendingUNSAFE_ComponentWillUpdateWarnings = []; // Tracks components we have already warned about.
+
+    var didWarnAboutUnsafeLifecycles = new Set();
+
+    ReactStrictModeWarnings.recordUnsafeLifecycleWarnings = function (fiber, instance) {
+      // Dedup strategy: Warn once per component.
+      if (didWarnAboutUnsafeLifecycles.has(fiber.type)) {
+        return;
+      }
+
+      if (typeof instance.componentWillMount === 'function' && // Don't warn about react-lifecycles-compat polyfilled components.
+      instance.componentWillMount.__suppressDeprecationWarning !== true) {
+        pendingComponentWillMountWarnings.push(fiber);
+      }
+
+      if (fiber.mode & StrictMode && typeof instance.UNSAFE_componentWillMount === 'function') {
+        pendingUNSAFE_ComponentWillMountWarnings.push(fiber);
+      }
+
+      if (typeof instance.componentWillReceiveProps === 'function' && instance.componentWillReceiveProps.__suppressDeprecationWarning !== true) {
+        pendingComponentWillReceivePropsWarnings.push(fiber);
+      }
+
+      if (fiber.mode & StrictMode && typeof instance.UNSAFE_componentWillReceiveProps === 'function') {
+        pendingUNSAFE_ComponentWillReceivePropsWarnings.push(fiber);
+      }
+
+      if (typeof instance.componentWillUpdate === 'function' && instance.componentWillUpdate.__suppressDeprecationWarning !== true) {
+        pendingComponentWillUpdateWarnings.push(fiber);
+      }
+
+      if (fiber.mode & StrictMode && typeof instance.UNSAFE_componentWillUpdate === 'function') {
+        pendingUNSAFE_ComponentWillUpdateWarnings.push(fiber);
+      }
+    };
+
+    ReactStrictModeWarnings.flushPendingUnsafeLifecycleWarnings = function () {
+      // We do an initial pass to gather component names
+      var componentWillMountUniqueNames = new Set();
+
+      if (pendingComponentWillMountWarnings.length > 0) {
+        pendingComponentWillMountWarnings.forEach(function (fiber) {
+          componentWillMountUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingComponentWillMountWarnings = [];
+      }
+
+      var UNSAFE_componentWillMountUniqueNames = new Set();
+
+      if (pendingUNSAFE_ComponentWillMountWarnings.length > 0) {
+        pendingUNSAFE_ComponentWillMountWarnings.forEach(function (fiber) {
+          UNSAFE_componentWillMountUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingUNSAFE_ComponentWillMountWarnings = [];
+      }
+
+      var componentWillReceivePropsUniqueNames = new Set();
+
+      if (pendingComponentWillReceivePropsWarnings.length > 0) {
+        pendingComponentWillReceivePropsWarnings.forEach(function (fiber) {
+          componentWillReceivePropsUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingComponentWillReceivePropsWarnings = [];
+      }
+
+      var UNSAFE_componentWillReceivePropsUniqueNames = new Set();
+
+      if (pendingUNSAFE_ComponentWillReceivePropsWarnings.length > 0) {
+        pendingUNSAFE_ComponentWillReceivePropsWarnings.forEach(function (fiber) {
+          UNSAFE_componentWillReceivePropsUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingUNSAFE_ComponentWillReceivePropsWarnings = [];
+      }
+
+      var componentWillUpdateUniqueNames = new Set();
+
+      if (pendingComponentWillUpdateWarnings.length > 0) {
+        pendingComponentWillUpdateWarnings.forEach(function (fiber) {
+          componentWillUpdateUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingComponentWillUpdateWarnings = [];
+      }
+
+      var UNSAFE_componentWillUpdateUniqueNames = new Set();
+
+      if (pendingUNSAFE_ComponentWillUpdateWarnings.length > 0) {
+        pendingUNSAFE_ComponentWillUpdateWarnings.forEach(function (fiber) {
+          UNSAFE_componentWillUpdateUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingUNSAFE_ComponentWillUpdateWarnings = [];
+      } // Finally, we flush all the warnings
+      // UNSAFE_ ones before the deprecated ones, since they'll be 'louder'
+
+
+      if (UNSAFE_componentWillMountUniqueNames.size > 0) {
+        var sortedNames = setToSortedString(UNSAFE_componentWillMountUniqueNames);
+
+        error('Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. ' + 'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' + '* Move code with side effects to componentDidMount, and set initial state in the constructor.\n' + '\nPlease update the following components: %s', sortedNames);
+      }
+
+      if (UNSAFE_componentWillReceivePropsUniqueNames.size > 0) {
+        var _sortedNames = setToSortedString(UNSAFE_componentWillReceivePropsUniqueNames);
+
+        error('Using UNSAFE_componentWillReceiveProps in strict mode is not recommended ' + 'and may indicate bugs in your code. ' + 'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' + '* Move data fetching code or side effects to componentDidUpdate.\n' + "* If you're updating state whenever props change, " + 'refactor your code to use memoization techniques or move it to ' + 'static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state\n' + '\nPlease update the following components: %s', _sortedNames);
+      }
+
+      if (UNSAFE_componentWillUpdateUniqueNames.size > 0) {
+        var _sortedNames2 = setToSortedString(UNSAFE_componentWillUpdateUniqueNames);
+
+        error('Using UNSAFE_componentWillUpdate in strict mode is not recommended ' + 'and may indicate bugs in your code. ' + 'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' + '* Move data fetching code or side effects to componentDidUpdate.\n' + '\nPlease update the following components: %s', _sortedNames2);
+      }
+
+      if (componentWillMountUniqueNames.size > 0) {
+        var _sortedNames3 = setToSortedString(componentWillMountUniqueNames);
+
+        warn('componentWillMount has been renamed, and is not recommended for use. ' + 'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' + '* Move code with side effects to componentDidMount, and set initial state in the constructor.\n' + '* Rename componentWillMount to UNSAFE_componentWillMount to suppress ' + 'this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. ' + 'To rename all deprecated lifecycles to their new names, you can run ' + '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' + '\nPlease update the following components: %s', _sortedNames3);
+      }
+
+      if (componentWillReceivePropsUniqueNames.size > 0) {
+        var _sortedNames4 = setToSortedString(componentWillReceivePropsUniqueNames);
+
+        warn('componentWillReceiveProps has been renamed, and is not recommended for use. ' + 'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' + '* Move data fetching code or side effects to componentDidUpdate.\n' + "* If you're updating state whenever props change, refactor your " + 'code to use memoization techniques or move it to ' + 'static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state\n' + '* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress ' + 'this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. ' + 'To rename all deprecated lifecycles to their new names, you can run ' + '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' + '\nPlease update the following components: %s', _sortedNames4);
+      }
+
+      if (componentWillUpdateUniqueNames.size > 0) {
+        var _sortedNames5 = setToSortedString(componentWillUpdateUniqueNames);
+
+        warn('componentWillUpdate has been renamed, and is not recommended for use. ' + 'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' + '* Move data fetching code or side effects to componentDidUpdate.\n' + '* Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress ' + 'this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. ' + 'To rename all deprecated lifecycles to their new names, you can run ' + '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' + '\nPlease update the following components: %s', _sortedNames5);
+      }
+    };
+
+    var pendingLegacyContextWarning = new Map(); // Tracks components we have already warned about.
+
+    var didWarnAboutLegacyContext = new Set();
+
+    ReactStrictModeWarnings.recordLegacyContextWarning = function (fiber, instance) {
+      var strictRoot = findStrictRoot(fiber);
+
+      if (strictRoot === null) {
+        error('Expected to find a StrictMode component in a strict mode tree. ' + 'This error is likely caused by a bug in React. Please file an issue.');
+
+        return;
+      } // Dedup strategy: Warn once per component.
+
+
+      if (didWarnAboutLegacyContext.has(fiber.type)) {
+        return;
+      }
+
+      var warningsForRoot = pendingLegacyContextWarning.get(strictRoot);
+
+      if (fiber.type.contextTypes != null || fiber.type.childContextTypes != null || instance !== null && typeof instance.getChildContext === 'function') {
+        if (warningsForRoot === undefined) {
+          warningsForRoot = [];
+          pendingLegacyContextWarning.set(strictRoot, warningsForRoot);
+        }
+
+        warningsForRoot.push(fiber);
+      }
+    };
+
+    ReactStrictModeWarnings.flushLegacyContextWarning = function () {
+      pendingLegacyContextWarning.forEach(function (fiberArray, strictRoot) {
+        if (fiberArray.length === 0) {
+          return;
+        }
+
+        var firstFiber = fiberArray[0];
+        var uniqueNames = new Set();
+        fiberArray.forEach(function (fiber) {
+          uniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutLegacyContext.add(fiber.type);
+        });
+        var sortedNames = setToSortedString(uniqueNames);
+        var firstComponentStack = getStackByFiberInDevAndProd(firstFiber);
+
+        error('Legacy context API has been detected within a strict-mode tree.' + '\n\nThe old API will be supported in all 16.x releases, but applications ' + 'using it should migrate to the new version.' + '\n\nPlease update the following components: %s' + '\n\nLearn more about this warning here: https://fb.me/react-legacy-context' + '%s', sortedNames, firstComponentStack);
+      });
+    };
+
+    ReactStrictModeWarnings.discardPendingWarnings = function () {
+      pendingComponentWillMountWarnings = [];
+      pendingUNSAFE_ComponentWillMountWarnings = [];
+      pendingComponentWillReceivePropsWarnings = [];
+      pendingUNSAFE_ComponentWillReceivePropsWarnings = [];
+      pendingComponentWillUpdateWarnings = [];
+      pendingUNSAFE_ComponentWillUpdateWarnings = [];
+      pendingLegacyContextWarning = new Map();
+    };
+  }
+
+  var resolveFamily = null; // $FlowFixMe Flow gets confused by a WeakSet feature check below.
+
+  var failedBoundaries = null;
+  var setRefreshHandler = function (handler) {
+    {
+      resolveFamily = handler;
+    }
+  };
+  function resolveFunctionForHotReloading(type) {
+    {
+      if (resolveFamily === null) {
+        // Hot reloading is disabled.
+        return type;
+      }
+
+      var family = resolveFamily(type);
+
+      if (family === undefined) {
+        return type;
+      } // Use the latest known implementation.
+
+
+      return family.current;
+    }
+  }
+  function resolveClassForHotReloading(type) {
+    // No implementation differences.
+    return resolveFunctionForHotReloading(type);
+  }
+  function resolveForwardRefForHotReloading(type) {
+    {
+      if (resolveFamily === null) {
+        // Hot reloading is disabled.
+        return type;
+      }
+
+      var family = resolveFamily(type);
+
+      if (family === undefined) {
+        // Check if we're dealing with a real forwardRef. Don't want to crash early.
+        if (type !== null && type !== undefined && typeof type.render === 'function') {
+          // ForwardRef is special because its resolved .type is an object,
+          // but it's possible that we only have its inner render function in the map.
+          // If that inner render function is different, we'll build a new forwardRef type.
+          var currentRender = resolveFunctionForHotReloading(type.render);
+
+          if (type.render !== currentRender) {
+            var syntheticType = {
+              $$typeof: REACT_FORWARD_REF_TYPE,
+              render: currentRender
+            };
+
+            if (type.displayName !== undefined) {
+              syntheticType.displayName = type.displayName;
+            }
+
+            return syntheticType;
+          }
+        }
+
+        return type;
+      } // Use the latest known implementation.
+
+
+      return family.current;
+    }
+  }
+  function isCompatibleFamilyForHotReloading(fiber, element) {
+    {
+      if (resolveFamily === null) {
+        // Hot reloading is disabled.
+        return false;
+      }
+
+      var prevType = fiber.elementType;
+      var nextType = element.type; // If we got here, we know types aren't === equal.
+
+      var needsCompareFamilies = false;
+      var $$typeofNextType = typeof nextType === 'object' && nextType !== null ? nextType.$$typeof : null;
+
+      switch (fiber.tag) {
+        case ClassComponent:
+          {
+            if (typeof nextType === 'function') {
+              needsCompareFamilies = true;
+            }
+
+            break;
+          }
+
+        case FunctionComponent:
+          {
+            if (typeof nextType === 'function') {
+              needsCompareFamilies = true;
+            } else if ($$typeofNextType === REACT_LAZY_TYPE) {
+              // We don't know the inner type yet.
+              // We're going to assume that the lazy inner type is stable,
+              // and so it is sufficient to avoid reconciling it away.
+              // We're not going to unwrap or actually use the new lazy type.
+              needsCompareFamilies = true;
+            }
+
+            break;
+          }
+
+        case ForwardRef:
+          {
+            if ($$typeofNextType === REACT_FORWARD_REF_TYPE) {
+              needsCompareFamilies = true;
+            } else if ($$typeofNextType === REACT_LAZY_TYPE) {
+              needsCompareFamilies = true;
+            }
+
+            break;
+          }
+
+        case MemoComponent:
+        case SimpleMemoComponent:
+          {
+            if ($$typeofNextType === REACT_MEMO_TYPE) {
+              // TODO: if it was but can no longer be simple,
+              // we shouldn't set this.
+              needsCompareFamilies = true;
+            } else if ($$typeofNextType === REACT_LAZY_TYPE) {
+              needsCompareFamilies = true;
+            }
+
+            break;
+          }
+
+        default:
+          return false;
+      } // Check if both types have a family and it's the same one.
+
+
+      if (needsCompareFamilies) {
+        // Note: memo() and forwardRef() we'll compare outer rather than inner type.
+        // This means both of them need to be registered to preserve state.
+        // If we unwrapped and compared the inner types for wrappers instead,
+        // then we would risk falsely saying two separate memo(Foo)
+        // calls are equivalent because they wrap the same Foo function.
+        var prevFamily = resolveFamily(prevType);
+
+        if (prevFamily !== undefined && prevFamily === resolveFamily(nextType)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  }
+  function markFailedErrorBoundaryForHotReloading(fiber) {
+    {
+      if (resolveFamily === null) {
+        // Hot reloading is disabled.
+        return;
+      }
+
+      if (typeof WeakSet !== 'function') {
+        return;
+      }
+
+      if (failedBoundaries === null) {
+        failedBoundaries = new WeakSet();
+      }
+
+      failedBoundaries.add(fiber);
+    }
+  }
+  var scheduleRefresh = function (root, update) {
+    {
+      if (resolveFamily === null) {
+        // Hot reloading is disabled.
+        return;
+      }
+
+      var staleFamilies = update.staleFamilies,
+          updatedFamilies = update.updatedFamilies;
+      flushPassiveEffects();
+      flushSync(function () {
+        scheduleFibersWithFamiliesRecursively(root.current, updatedFamilies, staleFamilies);
+      });
+    }
+  };
+  var scheduleRoot = function (root, element) {
+    {
+      if (root.context !== emptyContextObject) {
+        // Super edge case: root has a legacy _renderSubtree context
+        // but we don't know the parentComponent so we can't pass it.
+        // Just ignore. We'll delete this with _renderSubtree code path later.
+        return;
+      }
+
+      flushPassiveEffects();
+      syncUpdates(function () {
+        updateContainer(element, root, null, null);
+      });
+    }
+  };
+
+  function scheduleFibersWithFamiliesRecursively(fiber, updatedFamilies, staleFamilies) {
+    {
+      var alternate = fiber.alternate,
+          child = fiber.child,
+          sibling = fiber.sibling,
+          tag = fiber.tag,
+          type = fiber.type;
+      var candidateType = null;
+
+      switch (tag) {
+        case FunctionComponent:
+        case SimpleMemoComponent:
+        case ClassComponent:
+          candidateType = type;
+          break;
+
+        case ForwardRef:
+          candidateType = type.render;
+          break;
+      }
+
+      if (resolveFamily === null) {
+        throw new Error('Expected resolveFamily to be set during hot reload.');
+      }
+
+      var needsRender = false;
+      var needsRemount = false;
+
+      if (candidateType !== null) {
+        var family = resolveFamily(candidateType);
+
+        if (family !== undefined) {
+          if (staleFamilies.has(family)) {
+            needsRemount = true;
+          } else if (updatedFamilies.has(family)) {
+            if (tag === ClassComponent) {
+              needsRemount = true;
+            } else {
+              needsRender = true;
+            }
+          }
+        }
+      }
+
+      if (failedBoundaries !== null) {
+        if (failedBoundaries.has(fiber) || alternate !== null && failedBoundaries.has(alternate)) {
+          needsRemount = true;
+        }
+      }
+
+      if (needsRemount) {
+        fiber._debugNeedsRemount = true;
+      }
+
+      if (needsRemount || needsRender) {
+        scheduleWork(fiber, Sync);
+      }
+
+      if (child !== null && !needsRemount) {
+        scheduleFibersWithFamiliesRecursively(child, updatedFamilies, staleFamilies);
+      }
+
+      if (sibling !== null) {
+        scheduleFibersWithFamiliesRecursively(sibling, updatedFamilies, staleFamilies);
+      }
+    }
+  }
+
+  var findHostInstancesForRefresh = function (root, families) {
+    {
+      var hostInstances = new Set();
+      var types = new Set(families.map(function (family) {
+        return family.current;
+      }));
+      findHostInstancesForMatchingFibersRecursively(root.current, types, hostInstances);
+      return hostInstances;
+    }
+  };
+
+  function findHostInstancesForMatchingFibersRecursively(fiber, types, hostInstances) {
+    {
+      var child = fiber.child,
+          sibling = fiber.sibling,
+          tag = fiber.tag,
+          type = fiber.type;
+      var candidateType = null;
+
+      switch (tag) {
+        case FunctionComponent:
+        case SimpleMemoComponent:
+        case ClassComponent:
+          candidateType = type;
+          break;
+
+        case ForwardRef:
+          candidateType = type.render;
+          break;
+      }
+
+      var didMatch = false;
+
+      if (candidateType !== null) {
+        if (types.has(candidateType)) {
+          didMatch = true;
+        }
+      }
+
+      if (didMatch) {
+        // We have a match. This only drills down to the closest host components.
+        // There's no need to search deeper because for the purpose of giving
+        // visual feedback, "flashing" outermost parent rectangles is sufficient.
+        findHostInstancesForFiberShallowly(fiber, hostInstances);
+      } else {
+        // If there's no match, maybe there will be one further down in the child tree.
+        if (child !== null) {
+          findHostInstancesForMatchingFibersRecursively(child, types, hostInstances);
+        }
+      }
+
+      if (sibling !== null) {
+        findHostInstancesForMatchingFibersRecursively(sibling, types, hostInstances);
+      }
+    }
+  }
+
+  function findHostInstancesForFiberShallowly(fiber, hostInstances) {
+    {
+      var foundHostInstances = findChildHostInstancesForFiberShallowly(fiber, hostInstances);
+
+      if (foundHostInstances) {
+        return;
+      } // If we didn't find any host children, fallback to closest host parent.
+
+
+      var node = fiber;
+
+      while (true) {
+        switch (node.tag) {
+          case HostComponent:
+            hostInstances.add(node.stateNode);
+            return;
+
+          case HostPortal:
+            hostInstances.add(node.stateNode.containerInfo);
+            return;
+
+          case HostRoot:
+            hostInstances.add(node.stateNode.containerInfo);
+            return;
+        }
+
+        if (node.return === null) {
+          throw new Error('Expected to reach root first.');
+        }
+
+        node = node.return;
+      }
+    }
+  }
+
+  function findChildHostInstancesForFiberShallowly(fiber, hostInstances) {
+    {
+      var node = fiber;
+      var foundHostInstances = false;
+
+      while (true) {
+        if (node.tag === HostComponent) {
+          // We got a match.
+          foundHostInstances = true;
+          hostInstances.add(node.stateNode); // There may still be more, so keep searching.
+        } else if (node.child !== null) {
+          node.child.return = node;
+          node = node.child;
+          continue;
+        }
+
+        if (node === fiber) {
+          return foundHostInstances;
+        }
+
+        while (node.sibling === null) {
+          if (node.return === null || node.return === fiber) {
+            return foundHostInstances;
+          }
+
+          node = node.return;
+        }
+
+        node.sibling.return = node.return;
+        node = node.sibling;
+      }
+    }
+
+    return false;
+  }
+
+  function resolveDefaultProps(Component, baseProps) {
+    if (Component && Component.defaultProps) {
+      // Resolve default props. Taken from ReactElement
+      var props = _assign({}, baseProps);
+
+      var defaultProps = Component.defaultProps;
+
+      for (var propName in defaultProps) {
+        if (props[propName] === undefined) {
+          props[propName] = defaultProps[propName];
+        }
+      }
+
+      return props;
+    }
+
+    return baseProps;
+  }
+  function readLazyComponentType(lazyComponent) {
+    initializeLazyComponentType(lazyComponent);
+
+    if (lazyComponent._status !== Resolved) {
+      throw lazyComponent._result;
+    }
+
+    return lazyComponent._result;
+  }
+
+  var valueCursor = createCursor(null);
+  var rendererSigil;
+
+  {
+    // Use this to detect multiple renderers using the same context
+    rendererSigil = {};
+  }
+
+  var currentlyRenderingFiber = null;
+  var lastContextDependency = null;
+  var lastContextWithAllBitsObserved = null;
+  var isDisallowedContextReadInDEV = false;
+  function resetContextDependencies() {
+    // This is called right before React yields execution, to ensure `readContext`
+    // cannot be called outside the render phase.
+    currentlyRenderingFiber = null;
+    lastContextDependency = null;
+    lastContextWithAllBitsObserved = null;
+
+    {
+      isDisallowedContextReadInDEV = false;
+    }
+  }
+  function enterDisallowedContextReadInDEV() {
+    {
+      isDisallowedContextReadInDEV = true;
+    }
+  }
+  function exitDisallowedContextReadInDEV() {
+    {
+      isDisallowedContextReadInDEV = false;
+    }
+  }
+  function pushProvider(providerFiber, nextValue) {
+    var context = providerFiber.type._context;
+
+    {
+      push(valueCursor, context._currentValue, providerFiber);
+      context._currentValue = nextValue;
+
+      {
+        if (context._currentRenderer !== undefined && context._currentRenderer !== null && context._currentRenderer !== rendererSigil) {
+          error('Detected multiple renderers concurrently rendering the ' + 'same context provider. This is currently unsupported.');
+        }
+
+        context._currentRenderer = rendererSigil;
+      }
+    }
+  }
+  function popProvider(providerFiber) {
+    var currentValue = valueCursor.current;
+    pop(valueCursor, providerFiber);
+    var context = providerFiber.type._context;
+
+    {
+      context._currentValue = currentValue;
+    }
+  }
+  function calculateChangedBits(context, newValue, oldValue) {
+    if (objectIs(oldValue, newValue)) {
+      // No change
+      return 0;
+    } else {
+      var changedBits = typeof context._calculateChangedBits === 'function' ? context._calculateChangedBits(oldValue, newValue) : MAX_SIGNED_31_BIT_INT;
+
+      {
+        if ((changedBits & MAX_SIGNED_31_BIT_INT) !== changedBits) {
+          error('calculateChangedBits: Expected the return value to be a ' + '31-bit integer. Instead received: %s', changedBits);
+        }
+      }
+
+      return changedBits | 0;
+    }
+  }
+  function scheduleWorkOnParentPath(parent, renderExpirationTime) {
+    // Update the child expiration time of all the ancestors, including
+    // the alternates.
+    var node = parent;
+
+    while (node !== null) {
+      var alternate = node.alternate;
+
+      if (node.childExpirationTime < renderExpirationTime) {
+        node.childExpirationTime = renderExpirationTime;
+
+        if (alternate !== null && alternate.childExpirationTime < renderExpirationTime) {
+          alternate.childExpirationTime = renderExpirationTime;
+        }
+      } else if (alternate !== null && alternate.childExpirationTime < renderExpirationTime) {
+        alternate.childExpirationTime = renderExpirationTime;
+      } else {
+        // Neither alternate was updated, which means the rest of the
+        // ancestor path already has sufficient priority.
+        break;
+      }
+
+      node = node.return;
+    }
+  }
+  function propagateContextChange(workInProgress, context, changedBits, renderExpirationTime) {
+    var fiber = workInProgress.child;
+
+    if (fiber !== null) {
+      // Set the return pointer of the child to the work-in-progress fiber.
+      fiber.return = workInProgress;
+    }
+
+    while (fiber !== null) {
+      var nextFiber = void 0; // Visit this fiber.
+
+      var list = fiber.dependencies;
+
+      if (list !== null) {
+        nextFiber = fiber.child;
+        var dependency = list.firstContext;
+
+        while (dependency !== null) {
+          // Check if the context matches.
+          if (dependency.context === context && (dependency.observedBits & changedBits) !== 0) {
+            // Match! Schedule an update on this fiber.
+            if (fiber.tag === ClassComponent) {
+              // Schedule a force update on the work-in-progress.
+              var update = createUpdate(renderExpirationTime, null);
+              update.tag = ForceUpdate; // TODO: Because we don't have a work-in-progress, this will add the
+              // update to the current fiber, too, which means it will persist even if
+              // this render is thrown away. Since it's a race condition, not sure it's
+              // worth fixing.
+
+              enqueueUpdate(fiber, update);
+            }
+
+            if (fiber.expirationTime < renderExpirationTime) {
+              fiber.expirationTime = renderExpirationTime;
+            }
+
+            var alternate = fiber.alternate;
+
+            if (alternate !== null && alternate.expirationTime < renderExpirationTime) {
+              alternate.expirationTime = renderExpirationTime;
+            }
+
+            scheduleWorkOnParentPath(fiber.return, renderExpirationTime); // Mark the expiration time on the list, too.
+
+            if (list.expirationTime < renderExpirationTime) {
+              list.expirationTime = renderExpirationTime;
+            } // Since we already found a match, we can stop traversing the
+            // dependency list.
+
+
+            break;
+          }
+
+          dependency = dependency.next;
+        }
+      } else if (fiber.tag === ContextProvider) {
+        // Don't scan deeper if this is a matching provider
+        nextFiber = fiber.type === workInProgress.type ? null : fiber.child;
+      } else {
+        // Traverse down.
+        nextFiber = fiber.child;
+      }
+
+      if (nextFiber !== null) {
+        // Set the return pointer of the child to the work-in-progress fiber.
+        nextFiber.return = fiber;
+      } else {
+        // No child. Traverse to next sibling.
+        nextFiber = fiber;
+
+        while (nextFiber !== null) {
+          if (nextFiber === workInProgress) {
+            // We're back to the root of this subtree. Exit.
+            nextFiber = null;
+            break;
+          }
+
+          var sibling = nextFiber.sibling;
+
+          if (sibling !== null) {
+            // Set the return pointer of the sibling to the work-in-progress fiber.
+            sibling.return = nextFiber.return;
+            nextFiber = sibling;
+            break;
+          } // No more siblings. Traverse up.
+
+
+          nextFiber = nextFiber.return;
+        }
+      }
+
+      fiber = nextFiber;
+    }
+  }
+  function prepareToReadContext(workInProgress, renderExpirationTime) {
+    currentlyRenderingFiber = workInProgress;
+    lastContextDependency = null;
+    lastContextWithAllBitsObserved = null;
+    var dependencies = workInProgress.dependencies;
+
+    if (dependencies !== null) {
+      var firstContext = dependencies.firstContext;
+
+      if (firstContext !== null) {
+        if (dependencies.expirationTime >= renderExpirationTime) {
+          // Context list has a pending update. Mark that this fiber performed work.
+          markWorkInProgressReceivedUpdate();
+        } // Reset the work-in-progress list
+
+
+        dependencies.firstContext = null;
+      }
+    }
+  }
+  function readContext(context, observedBits) {
+    {
+      // This warning would fire if you read context inside a Hook like useMemo.
+      // Unlike the class check below, it's not enforced in production for perf.
+      if (isDisallowedContextReadInDEV) {
+        error('Context can only be read while React is rendering. ' + 'In classes, you can read it in the render method or getDerivedStateFromProps. ' + 'In function components, you can read it directly in the function body, but not ' + 'inside Hooks like useReducer() or useMemo().');
+      }
+    }
+
+    if (lastContextWithAllBitsObserved === context) ; else if (observedBits === false || observedBits === 0) ; else {
+      var resolvedObservedBits; // Avoid deopting on observable arguments or heterogeneous types.
+
+      if (typeof observedBits !== 'number' || observedBits === MAX_SIGNED_31_BIT_INT) {
+        // Observe all updates.
+        lastContextWithAllBitsObserved = context;
+        resolvedObservedBits = MAX_SIGNED_31_BIT_INT;
+      } else {
+        resolvedObservedBits = observedBits;
+      }
+
+      var contextItem = {
+        context: context,
+        observedBits: resolvedObservedBits,
+        next: null
+      };
+
+      if (lastContextDependency === null) {
+        if (!(currentlyRenderingFiber !== null)) {
+          {
+            throw Error( "Context can only be read while React is rendering. In classes, you can read it in the render method or getDerivedStateFromProps. In function components, you can read it directly in the function body, but not inside Hooks like useReducer() or useMemo()." );
+          }
+        } // This is the first dependency for this component. Create a new list.
+
+
+        lastContextDependency = contextItem;
+        currentlyRenderingFiber.dependencies = {
+          expirationTime: NoWork,
+          firstContext: contextItem,
+          responders: null
+        };
+      } else {
+        // Append a new context item.
+        lastContextDependency = lastContextDependency.next = contextItem;
+      }
+    }
+
+    return  context._currentValue ;
+  }
+
+  var UpdateState = 0;
+  var ReplaceState = 1;
+  var ForceUpdate = 2;
+  var CaptureUpdate = 3; // Global state that is reset at the beginning of calling `processUpdateQueue`.
+  // It should only be read right after calling `processUpdateQueue`, via
+  // `checkHasForceUpdateAfterProcessing`.
+
+  var hasForceUpdate = false;
+  var didWarnUpdateInsideUpdate;
+  var currentlyProcessingQueue;
+
+  {
+    didWarnUpdateInsideUpdate = false;
+    currentlyProcessingQueue = null;
+  }
+
+  function initializeUpdateQueue(fiber) {
+    var queue = {
+      baseState: fiber.memoizedState,
+      baseQueue: null,
+      shared: {
+        pending: null
+      },
+      effects: null
+    };
+    fiber.updateQueue = queue;
+  }
+  function cloneUpdateQueue(current, workInProgress) {
+    // Clone the update queue from current. Unless it's already a clone.
+    var queue = workInProgress.updateQueue;
+    var currentQueue = current.updateQueue;
+
+    if (queue === currentQueue) {
+      var clone = {
+        baseState: currentQueue.baseState,
+        baseQueue: currentQueue.baseQueue,
+        shared: currentQueue.shared,
+        effects: currentQueue.effects
+      };
+      workInProgress.updateQueue = clone;
+    }
+  }
+  function createUpdate(expirationTime, suspenseConfig) {
+    var update = {
+      expirationTime: expirationTime,
+      suspenseConfig: suspenseConfig,
+      tag: UpdateState,
+      payload: null,
+      callback: null,
+      next: null
+    };
+    update.next = update;
+
+    {
+      update.priority = getCurrentPriorityLevel();
+    }
+
+    return update;
+  }
+  function enqueueUpdate(fiber, update) {
+    var updateQueue = fiber.updateQueue;
+
+    if (updateQueue === null) {
+      // Only occurs if the fiber has been unmounted.
+      return;
+    }
+
+    var sharedQueue = updateQueue.shared;
+    var pending = sharedQueue.pending;
+
+    if (pending === null) {
+      // This is the first update. Create a circular list.
+      update.next = update;
+    } else {
+      update.next = pending.next;
+      pending.next = update;
+    }
+
+    sharedQueue.pending = update;
+
+    {
+      if (currentlyProcessingQueue === sharedQueue && !didWarnUpdateInsideUpdate) {
+        error('An update (setState, replaceState, or forceUpdate) was scheduled ' + 'from inside an update function. Update functions should be pure, ' + 'with zero side-effects. Consider using componentDidUpdate or a ' + 'callback.');
+
+        didWarnUpdateInsideUpdate = true;
+      }
+    }
+  }
+  function enqueueCapturedUpdate(workInProgress, update) {
+    var current = workInProgress.alternate;
+
+    if (current !== null) {
+      // Ensure the work-in-progress queue is a clone
+      cloneUpdateQueue(current, workInProgress);
+    } // Captured updates go only on the work-in-progress queue.
+
+
+    var queue = workInProgress.updateQueue; // Append the update to the end of the list.
+
+    var last = queue.baseQueue;
+
+    if (last === null) {
+      queue.baseQueue = update.next = update;
+      update.next = update;
+    } else {
+      update.next = last.next;
+      last.next = update;
+    }
+  }
+
+  function getStateFromUpdate(workInProgress, queue, update, prevState, nextProps, instance) {
+    switch (update.tag) {
+      case ReplaceState:
+        {
+          var payload = update.payload;
+
+          if (typeof payload === 'function') {
+            // Updater function
+            {
+              enterDisallowedContextReadInDEV();
+
+              if ( workInProgress.mode & StrictMode) {
+                payload.call(instance, prevState, nextProps);
+              }
+            }
+
+            var nextState = payload.call(instance, prevState, nextProps);
+
+            {
+              exitDisallowedContextReadInDEV();
+            }
+
+            return nextState;
+          } // State object
+
+
+          return payload;
+        }
+
+      case CaptureUpdate:
+        {
+          workInProgress.effectTag = workInProgress.effectTag & ~ShouldCapture | DidCapture;
+        }
+      // Intentional fallthrough
+
+      case UpdateState:
+        {
+          var _payload = update.payload;
+          var partialState;
+
+          if (typeof _payload === 'function') {
+            // Updater function
+            {
+              enterDisallowedContextReadInDEV();
+
+              if ( workInProgress.mode & StrictMode) {
+                _payload.call(instance, prevState, nextProps);
+              }
+            }
+
+            partialState = _payload.call(instance, prevState, nextProps);
+
+            {
+              exitDisallowedContextReadInDEV();
+            }
+          } else {
+            // Partial state object
+            partialState = _payload;
+          }
+
+          if (partialState === null || partialState === undefined) {
+            // Null and undefined are treated as no-ops.
+            return prevState;
+          } // Merge the partial state and the previous state.
+
+
+          return _assign({}, prevState, partialState);
+        }
+
+      case ForceUpdate:
+        {
+          hasForceUpdate = true;
+          return prevState;
+        }
+    }
+
+    return prevState;
+  }
+
+  function processUpdateQueue(workInProgress, props, instance, renderExpirationTime) {
+    // This is always non-null on a ClassComponent or HostRoot
+    var queue = workInProgress.updateQueue;
+    hasForceUpdate = false;
+
+    {
+      currentlyProcessingQueue = queue.shared;
+    } // The last rebase update that is NOT part of the base state.
+
+
+    var baseQueue = queue.baseQueue; // The last pending update that hasn't been processed yet.
+
+    var pendingQueue = queue.shared.pending;
+
+    if (pendingQueue !== null) {
+      // We have new updates that haven't been processed yet.
+      // We'll add them to the base queue.
+      if (baseQueue !== null) {
+        // Merge the pending queue and the base queue.
+        var baseFirst = baseQueue.next;
+        var pendingFirst = pendingQueue.next;
+        baseQueue.next = pendingFirst;
+        pendingQueue.next = baseFirst;
+      }
+
+      baseQueue = pendingQueue;
+      queue.shared.pending = null; // TODO: Pass `current` as argument
+
+      var current = workInProgress.alternate;
+
+      if (current !== null) {
+        var currentQueue = current.updateQueue;
+
+        if (currentQueue !== null) {
+          currentQueue.baseQueue = pendingQueue;
+        }
+      }
+    } // These values may change as we process the queue.
+
+
+    if (baseQueue !== null) {
+      var first = baseQueue.next; // Iterate through the list of updates to compute the result.
+
+      var newState = queue.baseState;
+      var newExpirationTime = NoWork;
+      var newBaseState = null;
+      var newBaseQueueFirst = null;
+      var newBaseQueueLast = null;
+
+      if (first !== null) {
+        var update = first;
+
+        do {
+          var updateExpirationTime = update.expirationTime;
+
+          if (updateExpirationTime < renderExpirationTime) {
+            // Priority is insufficient. Skip this update. If this is the first
+            // skipped update, the previous update/state is the new base
+            // update/state.
+            var clone = {
+              expirationTime: update.expirationTime,
+              suspenseConfig: update.suspenseConfig,
+              tag: update.tag,
+              payload: update.payload,
+              callback: update.callback,
+              next: null
+            };
+
+            if (newBaseQueueLast === null) {
+              newBaseQueueFirst = newBaseQueueLast = clone;
+              newBaseState = newState;
+            } else {
+              newBaseQueueLast = newBaseQueueLast.next = clone;
+            } // Update the remaining priority in the queue.
+
+
+            if (updateExpirationTime > newExpirationTime) {
+              newExpirationTime = updateExpirationTime;
+            }
+          } else {
+            // This update does have sufficient priority.
+            if (newBaseQueueLast !== null) {
+              var _clone = {
+                expirationTime: Sync,
+                // This update is going to be committed so we never want uncommit it.
+                suspenseConfig: update.suspenseConfig,
+                tag: update.tag,
+                payload: update.payload,
+                callback: update.callback,
+                next: null
+              };
+              newBaseQueueLast = newBaseQueueLast.next = _clone;
+            } // Mark the event time of this update as relevant to this render pass.
+            // TODO: This should ideally use the true event time of this update rather than
+            // its priority which is a derived and not reverseable value.
+            // TODO: We should skip this update if it was already committed but currently
+            // we have no way of detecting the difference between a committed and suspended
+            // update here.
+
+
+            markRenderEventTimeAndConfig(updateExpirationTime, update.suspenseConfig); // Process this update.
+
+            newState = getStateFromUpdate(workInProgress, queue, update, newState, props, instance);
+            var callback = update.callback;
+
+            if (callback !== null) {
+              workInProgress.effectTag |= Callback;
+              var effects = queue.effects;
+
+              if (effects === null) {
+                queue.effects = [update];
+              } else {
+                effects.push(update);
+              }
+            }
+          }
+
+          update = update.next;
+
+          if (update === null || update === first) {
+            pendingQueue = queue.shared.pending;
+
+            if (pendingQueue === null) {
+              break;
+            } else {
+              // An update was scheduled from inside a reducer. Add the new
+              // pending updates to the end of the list and keep processing.
+              update = baseQueue.next = pendingQueue.next;
+              pendingQueue.next = first;
+              queue.baseQueue = baseQueue = pendingQueue;
+              queue.shared.pending = null;
+            }
+          }
+        } while (true);
+      }
+
+      if (newBaseQueueLast === null) {
+        newBaseState = newState;
+      } else {
+        newBaseQueueLast.next = newBaseQueueFirst;
+      }
+
+      queue.baseState = newBaseState;
+      queue.baseQueue = newBaseQueueLast; // Set the remaining expiration time to be whatever is remaining in the queue.
+      // This should be fine because the only two other things that contribute to
+      // expiration time are props and context. We're already in the middle of the
+      // begin phase by the time we start processing the queue, so we've already
+      // dealt with the props. Context in components that specify
+      // shouldComponentUpdate is tricky; but we'll have to account for
+      // that regardless.
+
+      markUnprocessedUpdateTime(newExpirationTime);
+      workInProgress.expirationTime = newExpirationTime;
+      workInProgress.memoizedState = newState;
+    }
+
+    {
+      currentlyProcessingQueue = null;
+    }
+  }
+
+  function callCallback(callback, context) {
+    if (!(typeof callback === 'function')) {
+      {
+        throw Error( "Invalid argument passed as callback. Expected a function. Instead received: " + callback );
+      }
+    }
+
+    callback.call(context);
+  }
+
+  function resetHasForceUpdateBeforeProcessing() {
+    hasForceUpdate = false;
+  }
+  function checkHasForceUpdateAfterProcessing() {
+    return hasForceUpdate;
+  }
+  function commitUpdateQueue(finishedWork, finishedQueue, instance) {
+    // Commit the effects
+    var effects = finishedQueue.effects;
+    finishedQueue.effects = null;
+
+    if (effects !== null) {
+      for (var i = 0; i < effects.length; i++) {
+        var effect = effects[i];
+        var callback = effect.callback;
+
+        if (callback !== null) {
+          effect.callback = null;
+          callCallback(callback, instance);
+        }
+      }
+    }
+  }
+
+  var ReactCurrentBatchConfig = ReactSharedInternals.ReactCurrentBatchConfig;
+  function requestCurrentSuspenseConfig() {
+    return ReactCurrentBatchConfig.suspense;
+  }
+
+  var fakeInternalInstance = {};
+  var isArray = Array.isArray; // React.Component uses a shared frozen object by default.
+  // We'll use it to determine whether we need to initialize legacy refs.
+
+  var emptyRefsObject = new React.Component().refs;
+  var didWarnAboutStateAssignmentForComponent;
+  var didWarnAboutUninitializedState;
+  var didWarnAboutGetSnapshotBeforeUpdateWithoutDidUpdate;
+  var didWarnAboutLegacyLifecyclesAndDerivedState;
+  var didWarnAboutUndefinedDerivedState;
+  var warnOnUndefinedDerivedState;
+  var warnOnInvalidCallback;
+  var didWarnAboutDirectlyAssigningPropsToState;
+  var didWarnAboutContextTypeAndContextTypes;
+  var didWarnAboutInvalidateContextType;
+
+  {
+    didWarnAboutStateAssignmentForComponent = new Set();
+    didWarnAboutUninitializedState = new Set();
+    didWarnAboutGetSnapshotBeforeUpdateWithoutDidUpdate = new Set();
+    didWarnAboutLegacyLifecyclesAndDerivedState = new Set();
+    didWarnAboutDirectlyAssigningPropsToState = new Set();
+    didWarnAboutUndefinedDerivedState = new Set();
+    didWarnAboutContextTypeAndContextTypes = new Set();
+    didWarnAboutInvalidateContextType = new Set();
+    var didWarnOnInvalidCallback = new Set();
+
+    warnOnInvalidCallback = function (callback, callerName) {
+      if (callback === null || typeof callback === 'function') {
+        return;
+      }
+
+      var key = callerName + "_" + callback;
+
+      if (!didWarnOnInvalidCallback.has(key)) {
+        didWarnOnInvalidCallback.add(key);
+
+        error('%s(...): Expected the last optional `callback` argument to be a ' + 'function. Instead received: %s.', callerName, callback);
+      }
+    };
+
+    warnOnUndefinedDerivedState = function (type, partialState) {
+      if (partialState === undefined) {
+        var componentName = getComponentName(type) || 'Component';
+
+        if (!didWarnAboutUndefinedDerivedState.has(componentName)) {
+          didWarnAboutUndefinedDerivedState.add(componentName);
+
+          error('%s.getDerivedStateFromProps(): A valid state object (or null) must be returned. ' + 'You have returned undefined.', componentName);
+        }
+      }
+    }; // This is so gross but it's at least non-critical and can be removed if
+    // it causes problems. This is meant to give a nicer error message for
+    // ReactDOM15.unstable_renderSubtreeIntoContainer(reactDOM16Component,
+    // ...)) which otherwise throws a "_processChildContext is not a function"
+    // exception.
+
+
+    Object.defineProperty(fakeInternalInstance, '_processChildContext', {
+      enumerable: false,
+      value: function () {
+        {
+          {
+            throw Error( "_processChildContext is not available in React 16+. This likely means you have multiple copies of React and are attempting to nest a React 15 tree inside a React 16 tree using unstable_renderSubtreeIntoContainer, which isn't supported. Try to make sure you have only one copy of React (and ideally, switch to ReactDOM.createPortal)." );
+          }
+        }
+      }
+    });
+    Object.freeze(fakeInternalInstance);
+  }
+
+  function applyDerivedStateFromProps(workInProgress, ctor, getDerivedStateFromProps, nextProps) {
+    var prevState = workInProgress.memoizedState;
+
+    {
+      if ( workInProgress.mode & StrictMode) {
+        // Invoke the function an extra time to help detect side-effects.
+        getDerivedStateFromProps(nextProps, prevState);
+      }
+    }
+
+    var partialState = getDerivedStateFromProps(nextProps, prevState);
+
+    {
+      warnOnUndefinedDerivedState(ctor, partialState);
+    } // Merge the partial state and the previous state.
+
+
+    var memoizedState = partialState === null || partialState === undefined ? prevState : _assign({}, prevState, partialState);
+    workInProgress.memoizedState = memoizedState; // Once the update queue is empty, persist the derived state onto the
+    // base state.
+
+    if (workInProgress.expirationTime === NoWork) {
+      // Queue is always non-null for classes
+      var updateQueue = workInProgress.updateQueue;
+      updateQueue.baseState = memoizedState;
+    }
+  }
+  var classComponentUpdater = {
+    isMounted: isMounted,
+    enqueueSetState: function (inst, payload, callback) {
+      var fiber = get(inst);
+      var currentTime = requestCurrentTimeForUpdate();
+      var suspenseConfig = requestCurrentSuspenseConfig();
+      var expirationTime = computeExpirationForFiber(currentTime, fiber, suspenseConfig);
+      var update = createUpdate(expirationTime, suspenseConfig);
+      update.payload = payload;
+
+      if (callback !== undefined && callback !== null) {
+        {
+          warnOnInvalidCallback(callback, 'setState');
+        }
+
+        update.callback = callback;
+      }
+
+      enqueueUpdate(fiber, update);
+      scheduleWork(fiber, expirationTime);
+    },
+    enqueueReplaceState: function (inst, payload, callback) {
+      var fiber = get(inst);
+      var currentTime = requestCurrentTimeForUpdate();
+      var suspenseConfig = requestCurrentSuspenseConfig();
+      var expirationTime = computeExpirationForFiber(currentTime, fiber, suspenseConfig);
+      var update = createUpdate(expirationTime, suspenseConfig);
+      update.tag = ReplaceState;
+      update.payload = payload;
+
+      if (callback !== undefined && callback !== null) {
+        {
+          warnOnInvalidCallback(callback, 'replaceState');
+        }
+
+        update.callback = callback;
+      }
+
+      enqueueUpdate(fiber, update);
+      scheduleWork(fiber, expirationTime);
+    },
+    enqueueForceUpdate: function (inst, callback) {
+      var fiber = get(inst);
+      var currentTime = requestCurrentTimeForUpdate();
+      var suspenseConfig = requestCurrentSuspenseConfig();
+      var expirationTime = computeExpirationForFiber(currentTime, fiber, suspenseConfig);
+      var update = createUpdate(expirationTime, suspenseConfig);
+      update.tag = ForceUpdate;
+
+      if (callback !== undefined && callback !== null) {
+        {
+          warnOnInvalidCallback(callback, 'forceUpdate');
+        }
+
+        update.callback = callback;
+      }
+
+      enqueueUpdate(fiber, update);
+      scheduleWork(fiber, expirationTime);
+    }
+  };
+
+  function checkShouldComponentUpdate(workInProgress, ctor, oldProps, newProps, oldState, newState, nextContext) {
+    var instance = workInProgress.stateNode;
+
+    if (typeof instance.shouldComponentUpdate === 'function') {
+      {
+        if ( workInProgress.mode & StrictMode) {
+          // Invoke the function an extra time to help detect side-effects.
+          instance.shouldComponentUpdate(newProps, newState, nextContext);
+        }
+      }
+
+      startPhaseTimer(workInProgress, 'shouldComponentUpdate');
+      var shouldUpdate = instance.shouldComponentUpdate(newProps, newState, nextContext);
+      stopPhaseTimer();
+
+      {
+        if (shouldUpdate === undefined) {
+          error('%s.shouldComponentUpdate(): Returned undefined instead of a ' + 'boolean value. Make sure to return true or false.', getComponentName(ctor) || 'Component');
+        }
+      }
+
+      return shouldUpdate;
+    }
+
+    if (ctor.prototype && ctor.prototype.isPureReactComponent) {
+      return !shallowEqual(oldProps, newProps) || !shallowEqual(oldState, newState);
+    }
+
+    return true;
+  }
+
+  function checkClassInstance(workInProgress, ctor, newProps) {
+    var instance = workInProgress.stateNode;
+
+    {
+      var name = getComponentName(ctor) || 'Component';
+      var renderPresent = instance.render;
+
+      if (!renderPresent) {
+        if (ctor.prototype && typeof ctor.prototype.render === 'function') {
+          error('%s(...): No `render` method found on the returned component ' + 'instance: did you accidentally return an object from the constructor?', name);
+        } else {
+          error('%s(...): No `render` method found on the returned component ' + 'instance: you may have forgotten to define `render`.', name);
+        }
+      }
+
+      if (instance.getInitialState && !instance.getInitialState.isReactClassApproved && !instance.state) {
+        error('getInitialState was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Did you mean to define a state property instead?', name);
+      }
+
+      if (instance.getDefaultProps && !instance.getDefaultProps.isReactClassApproved) {
+        error('getDefaultProps was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Use a static property to define defaultProps instead.', name);
+      }
+
+      if (instance.propTypes) {
+        error('propTypes was defined as an instance property on %s. Use a static ' + 'property to define propTypes instead.', name);
+      }
+
+      if (instance.contextType) {
+        error('contextType was defined as an instance property on %s. Use a static ' + 'property to define contextType instead.', name);
+      }
+
+      {
+        if (instance.contextTypes) {
+          error('contextTypes was defined as an instance property on %s. Use a static ' + 'property to define contextTypes instead.', name);
+        }
+
+        if (ctor.contextType && ctor.contextTypes && !didWarnAboutContextTypeAndContextTypes.has(ctor)) {
+          didWarnAboutContextTypeAndContextTypes.add(ctor);
+
+          error('%s declares both contextTypes and contextType static properties. ' + 'The legacy contextTypes property will be ignored.', name);
+        }
+      }
+
+      if (typeof instance.componentShouldUpdate === 'function') {
+        error('%s has a method called ' + 'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' + 'The name is phrased as a question because the function is ' + 'expected to return a value.', name);
+      }
+
+      if (ctor.prototype && ctor.prototype.isPureReactComponent && typeof instance.shouldComponentUpdate !== 'undefined') {
+        error('%s has a method called shouldComponentUpdate(). ' + 'shouldComponentUpdate should not be used when extending React.PureComponent. ' + 'Please extend React.Component if shouldComponentUpdate is used.', getComponentName(ctor) || 'A pure component');
+      }
+
+      if (typeof instance.componentDidUnmount === 'function') {
+        error('%s has a method called ' + 'componentDidUnmount(). But there is no such lifecycle method. ' + 'Did you mean componentWillUnmount()?', name);
+      }
+
+      if (typeof instance.componentDidReceiveProps === 'function') {
+        error('%s has a method called ' + 'componentDidReceiveProps(). But there is no such lifecycle method. ' + 'If you meant to update the state in response to changing props, ' + 'use componentWillReceiveProps(). If you meant to fetch data or ' + 'run side-effects or mutations after React has updated the UI, use componentDidUpdate().', name);
+      }
+
+      if (typeof instance.componentWillRecieveProps === 'function') {
+        error('%s has a method called ' + 'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?', name);
+      }
+
+      if (typeof instance.UNSAFE_componentWillRecieveProps === 'function') {
+        error('%s has a method called ' + 'UNSAFE_componentWillRecieveProps(). Did you mean UNSAFE_componentWillReceiveProps()?', name);
+      }
+
+      var hasMutatedProps = instance.props !== newProps;
+
+      if (instance.props !== undefined && hasMutatedProps) {
+        error('%s(...): When calling super() in `%s`, make sure to pass ' + "up the same props that your component's constructor was passed.", name, name);
+      }
+
+      if (instance.defaultProps) {
+        error('Setting defaultProps as an instance property on %s is not supported and will be ignored.' + ' Instead, define defaultProps as a static property on %s.', name, name);
+      }
+
+      if (typeof instance.getSnapshotBeforeUpdate === 'function' && typeof instance.componentDidUpdate !== 'function' && !didWarnAboutGetSnapshotBeforeUpdateWithoutDidUpdate.has(ctor)) {
+        didWarnAboutGetSnapshotBeforeUpdateWithoutDidUpdate.add(ctor);
+
+        error('%s: getSnapshotBeforeUpdate() should be used with componentDidUpdate(). ' + 'This component defines getSnapshotBeforeUpdate() only.', getComponentName(ctor));
+      }
+
+      if (typeof instance.getDerivedStateFromProps === 'function') {
+        error('%s: getDerivedStateFromProps() is defined as an instance method ' + 'and will be ignored. Instead, declare it as a static method.', name);
+      }
+
+      if (typeof instance.getDerivedStateFromError === 'function') {
+        error('%s: getDerivedStateFromError() is defined as an instance method ' + 'and will be ignored. Instead, declare it as a static method.', name);
+      }
+
+      if (typeof ctor.getSnapshotBeforeUpdate === 'function') {
+        error('%s: getSnapshotBeforeUpdate() is defined as a static method ' + 'and will be ignored. Instead, declare it as an instance method.', name);
+      }
+
+      var _state = instance.state;
+
+      if (_state && (typeof _state !== 'object' || isArray(_state))) {
+        error('%s.state: must be set to an object or null', name);
+      }
+
+      if (typeof instance.getChildContext === 'function' && typeof ctor.childContextTypes !== 'object') {
+        error('%s.getChildContext(): childContextTypes must be defined in order to ' + 'use getChildContext().', name);
+      }
+    }
+  }
+
+  function adoptClassInstance(workInProgress, instance) {
+    instance.updater = classComponentUpdater;
+    workInProgress.stateNode = instance; // The instance needs access to the fiber so that it can schedule updates
+
+    set(instance, workInProgress);
+
+    {
+      instance._reactInternalInstance = fakeInternalInstance;
+    }
+  }
+
+  function constructClassInstance(workInProgress, ctor, props) {
+    var isLegacyContextConsumer = false;
+    var unmaskedContext = emptyContextObject;
+    var context = emptyContextObject;
+    var contextType = ctor.contextType;
+
+    {
+      if ('contextType' in ctor) {
+        var isValid = // Allow null for conditional declaration
+        contextType === null || contextType !== undefined && contextType.$$typeof === REACT_CONTEXT_TYPE && contextType._context === undefined; // Not a <Context.Consumer>
+
+        if (!isValid && !didWarnAboutInvalidateContextType.has(ctor)) {
+          didWarnAboutInvalidateContextType.add(ctor);
+          var addendum = '';
+
+          if (contextType === undefined) {
+            addendum = ' However, it is set to undefined. ' + 'This can be caused by a typo or by mixing up named and default imports. ' + 'This can also happen due to a circular dependency, so ' + 'try moving the createContext() call to a separate file.';
+          } else if (typeof contextType !== 'object') {
+            addendum = ' However, it is set to a ' + typeof contextType + '.';
+          } else if (contextType.$$typeof === REACT_PROVIDER_TYPE) {
+            addendum = ' Did you accidentally pass the Context.Provider instead?';
+          } else if (contextType._context !== undefined) {
+            // <Context.Consumer>
+            addendum = ' Did you accidentally pass the Context.Consumer instead?';
+          } else {
+            addendum = ' However, it is set to an object with keys {' + Object.keys(contextType).join(', ') + '}.';
+          }
+
+          error('%s defines an invalid contextType. ' + 'contextType should point to the Context object returned by React.createContext().%s', getComponentName(ctor) || 'Component', addendum);
+        }
+      }
+    }
+
+    if (typeof contextType === 'object' && contextType !== null) {
+      context = readContext(contextType);
+    } else {
+      unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
+      var contextTypes = ctor.contextTypes;
+      isLegacyContextConsumer = contextTypes !== null && contextTypes !== undefined;
+      context = isLegacyContextConsumer ? getMaskedContext(workInProgress, unmaskedContext) : emptyContextObject;
+    } // Instantiate twice to help detect side-effects.
+
+
+    {
+      if ( workInProgress.mode & StrictMode) {
+        new ctor(props, context); // eslint-disable-line no-new
+      }
+    }
+
+    var instance = new ctor(props, context);
+    var state = workInProgress.memoizedState = instance.state !== null && instance.state !== undefined ? instance.state : null;
+    adoptClassInstance(workInProgress, instance);
+
+    {
+      if (typeof ctor.getDerivedStateFromProps === 'function' && state === null) {
+        var componentName = getComponentName(ctor) || 'Component';
+
+        if (!didWarnAboutUninitializedState.has(componentName)) {
+          didWarnAboutUninitializedState.add(componentName);
+
+          error('`%s` uses `getDerivedStateFromProps` but its initial state is ' + '%s. This is not recommended. Instead, define the initial state by ' + 'assigning an object to `this.state` in the constructor of `%s`. ' + 'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.', componentName, instance.state === null ? 'null' : 'undefined', componentName);
+        }
+      } // If new component APIs are defined, "unsafe" lifecycles won't be called.
+      // Warn about these lifecycles if they are present.
+      // Don't warn about react-lifecycles-compat polyfilled methods though.
+
+
+      if (typeof ctor.getDerivedStateFromProps === 'function' || typeof instance.getSnapshotBeforeUpdate === 'function') {
+        var foundWillMountName = null;
+        var foundWillReceivePropsName = null;
+        var foundWillUpdateName = null;
+
+        if (typeof instance.componentWillMount === 'function' && instance.componentWillMount.__suppressDeprecationWarning !== true) {
+          foundWillMountName = 'componentWillMount';
+        } else if (typeof instance.UNSAFE_componentWillMount === 'function') {
+          foundWillMountName = 'UNSAFE_componentWillMount';
+        }
+
+        if (typeof instance.componentWillReceiveProps === 'function' && instance.componentWillReceiveProps.__suppressDeprecationWarning !== true) {
+          foundWillReceivePropsName = 'componentWillReceiveProps';
+        } else if (typeof instance.UNSAFE_componentWillReceiveProps === 'function') {
+          foundWillReceivePropsName = 'UNSAFE_componentWillReceiveProps';
+        }
+
+        if (typeof instance.componentWillUpdate === 'function' && instance.componentWillUpdate.__suppressDeprecationWarning !== true) {
+          foundWillUpdateName = 'componentWillUpdate';
+        } else if (typeof instance.UNSAFE_componentWillUpdate === 'function') {
+          foundWillUpdateName = 'UNSAFE_componentWillUpdate';
+        }
+
+        if (foundWillMountName !== null || foundWillReceivePropsName !== null || foundWillUpdateName !== null) {
+          var _componentName = getComponentName(ctor) || 'Component';
+
+          var newApiName = typeof ctor.getDerivedStateFromProps === 'function' ? 'getDerivedStateFromProps()' : 'getSnapshotBeforeUpdate()';
+
+          if (!didWarnAboutLegacyLifecyclesAndDerivedState.has(_componentName)) {
+            didWarnAboutLegacyLifecyclesAndDerivedState.add(_componentName);
+
+            error('Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' + '%s uses %s but also contains the following legacy lifecycles:%s%s%s\n\n' + 'The above lifecycles should be removed. Learn more about this warning here:\n' + 'https://fb.me/react-unsafe-component-lifecycles', _componentName, newApiName, foundWillMountName !== null ? "\n  " + foundWillMountName : '', foundWillReceivePropsName !== null ? "\n  " + foundWillReceivePropsName : '', foundWillUpdateName !== null ? "\n  " + foundWillUpdateName : '');
+          }
+        }
+      }
+    } // Cache unmasked context so we can avoid recreating masked context unless necessary.
+    // ReactFiberContext usually updates this cache but can't for newly-created instances.
+
+
+    if (isLegacyContextConsumer) {
+      cacheContext(workInProgress, unmaskedContext, context);
+    }
+
+    return instance;
+  }
+
+  function callComponentWillMount(workInProgress, instance) {
+    startPhaseTimer(workInProgress, 'componentWillMount');
+    var oldState = instance.state;
+
+    if (typeof instance.componentWillMount === 'function') {
+      instance.componentWillMount();
+    }
+
+    if (typeof instance.UNSAFE_componentWillMount === 'function') {
+      instance.UNSAFE_componentWillMount();
+    }
+
+    stopPhaseTimer();
+
+    if (oldState !== instance.state) {
+      {
+        error('%s.componentWillMount(): Assigning directly to this.state is ' + "deprecated (except inside a component's " + 'constructor). Use setState instead.', getComponentName(workInProgress.type) || 'Component');
+      }
+
+      classComponentUpdater.enqueueReplaceState(instance, instance.state, null);
+    }
+  }
+
+  function callComponentWillReceiveProps(workInProgress, instance, newProps, nextContext) {
+    var oldState = instance.state;
+    startPhaseTimer(workInProgress, 'componentWillReceiveProps');
+
+    if (typeof instance.componentWillReceiveProps === 'function') {
+      instance.componentWillReceiveProps(newProps, nextContext);
+    }
+
+    if (typeof instance.UNSAFE_componentWillReceiveProps === 'function') {
+      instance.UNSAFE_componentWillReceiveProps(newProps, nextContext);
+    }
+
+    stopPhaseTimer();
+
+    if (instance.state !== oldState) {
+      {
+        var componentName = getComponentName(workInProgress.type) || 'Component';
+
+        if (!didWarnAboutStateAssignmentForComponent.has(componentName)) {
+          didWarnAboutStateAssignmentForComponent.add(componentName);
+
+          error('%s.componentWillReceiveProps(): Assigning directly to ' + "this.state is deprecated (except inside a component's " + 'constructor). Use setState instead.', componentName);
+        }
+      }
+
+      classComponentUpdater.enqueueReplaceState(instance, instance.state, null);
+    }
+  } // Invokes the mount life-cycles on a previously never rendered instance.
+
+
+  function mountClassInstance(workInProgress, ctor, newProps, renderExpirationTime) {
+    {
+      checkClassInstance(workInProgress, ctor, newProps);
+    }
+
+    var instance = workInProgress.stateNode;
+    instance.props = newProps;
+    instance.state = workInProgress.memoizedState;
+    instance.refs = emptyRefsObject;
+    initializeUpdateQueue(workInProgress);
+    var contextType = ctor.contextType;
+
+    if (typeof contextType === 'object' && contextType !== null) {
+      instance.context = readContext(contextType);
+    } else {
+      var unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
+      instance.context = getMaskedContext(workInProgress, unmaskedContext);
+    }
+
+    {
+      if (instance.state === newProps) {
+        var componentName = getComponentName(ctor) || 'Component';
+
+        if (!didWarnAboutDirectlyAssigningPropsToState.has(componentName)) {
+          didWarnAboutDirectlyAssigningPropsToState.add(componentName);
+
+          error('%s: It is not recommended to assign props directly to state ' + "because updates to props won't be reflected in state. " + 'In most cases, it is better to use props directly.', componentName);
+        }
+      }
+
+      if (workInProgress.mode & StrictMode) {
+        ReactStrictModeWarnings.recordLegacyContextWarning(workInProgress, instance);
+      }
+
+      {
+        ReactStrictModeWarnings.recordUnsafeLifecycleWarnings(workInProgress, instance);
+      }
+    }
+
+    processUpdateQueue(workInProgress, newProps, instance, renderExpirationTime);
+    instance.state = workInProgress.memoizedState;
+    var getDerivedStateFromProps = ctor.getDerivedStateFromProps;
+
+    if (typeof getDerivedStateFromProps === 'function') {
+      applyDerivedStateFromProps(workInProgress, ctor, getDerivedStateFromProps, newProps);
+      instance.state = workInProgress.memoizedState;
+    } // In order to support react-lifecycles-compat polyfilled components,
+    // Unsafe lifecycles should not be invoked for components using the new APIs.
+
+
+    if (typeof ctor.getDerivedStateFromProps !== 'function' && typeof instance.getSnapshotBeforeUpdate !== 'function' && (typeof instance.UNSAFE_componentWillMount === 'function' || typeof instance.componentWillMount === 'function')) {
+      callComponentWillMount(workInProgress, instance); // If we had additional state updates during this life-cycle, let's
+      // process them now.
+
+      processUpdateQueue(workInProgress, newProps, instance, renderExpirationTime);
+      instance.state = workInProgress.memoizedState;
+    }
+
+    if (typeof instance.componentDidMount === 'function') {
+      workInProgress.effectTag |= Update;
+    }
+  }
+
+  function resumeMountClassInstance(workInProgress, ctor, newProps, renderExpirationTime) {
+    var instance = workInProgress.stateNode;
+    var oldProps = workInProgress.memoizedProps;
+    instance.props = oldProps;
+    var oldContext = instance.context;
+    var contextType = ctor.contextType;
+    var nextContext = emptyContextObject;
+
+    if (typeof contextType === 'object' && contextType !== null) {
+      nextContext = readContext(contextType);
+    } else {
+      var nextLegacyUnmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
+      nextContext = getMaskedContext(workInProgress, nextLegacyUnmaskedContext);
+    }
+
+    var getDerivedStateFromProps = ctor.getDerivedStateFromProps;
+    var hasNewLifecycles = typeof getDerivedStateFromProps === 'function' || typeof instance.getSnapshotBeforeUpdate === 'function'; // Note: During these life-cycles, instance.props/instance.state are what
+    // ever the previously attempted to render - not the "current". However,
+    // during componentDidUpdate we pass the "current" props.
+    // In order to support react-lifecycles-compat polyfilled components,
+    // Unsafe lifecycles should not be invoked for components using the new APIs.
+
+    if (!hasNewLifecycles && (typeof instance.UNSAFE_componentWillReceiveProps === 'function' || typeof instance.componentWillReceiveProps === 'function')) {
+      if (oldProps !== newProps || oldContext !== nextContext) {
+        callComponentWillReceiveProps(workInProgress, instance, newProps, nextContext);
+      }
+    }
+
+    resetHasForceUpdateBeforeProcessing();
+    var oldState = workInProgress.memoizedState;
+    var newState = instance.state = oldState;
+    processUpdateQueue(workInProgress, newProps, instance, renderExpirationTime);
+    newState = workInProgress.memoizedState;
+
+    if (oldProps === newProps && oldState === newState && !hasContextChanged() && !checkHasForceUpdateAfterProcessing()) {
+      // If an update was already in progress, we should schedule an Update
+      // effect even though we're bailing out, so that cWU/cDU are called.
+      if (typeof instance.componentDidMount === 'function') {
+        workInProgress.effectTag |= Update;
+      }
+
+      return false;
+    }
+
+    if (typeof getDerivedStateFromProps === 'function') {
+      applyDerivedStateFromProps(workInProgress, ctor, getDerivedStateFromProps, newProps);
+      newState = workInProgress.memoizedState;
+    }
+
+    var shouldUpdate = checkHasForceUpdateAfterProcessing() || checkShouldComponentUpdate(workInProgress, ctor, oldProps, newProps, oldState, newState, nextContext);
+
+    if (shouldUpdate) {
+      // In order to support react-lifecycles-compat polyfilled components,
+      // Unsafe lifecycles should not be invoked for components using the new APIs.
+      if (!hasNewLifecycles && (typeof instance.UNSAFE_componentWillMount === 'function' || typeof instance.componentWillMount === 'function')) {
+        startPhaseTimer(workInProgress, 'componentWillMount');
+
+        if (typeof instance.componentWillMount === 'function') {
+          instance.componentWillMount();
+        }
+
+        if (typeof instance.UNSAFE_componentWillMount === 'function') {
+          instance.UNSAFE_componentWillMount();
+        }
+
+        stopPhaseTimer();
+      }
+
+      if (typeof instance.componentDidMount === 'function') {
+        workInProgress.effectTag |= Update;
+      }
+    } else {
+      // If an update was already in progress, we should schedule an Update
+      // effect even though we're bailing out, so that cWU/cDU are called.
+      if (typeof instance.componentDidMount === 'function') {
+        workInProgress.effectTag |= Update;
+      } // If shouldComponentUpdate returned false, we should still update the
+      // memoized state to indicate that this work can be reused.
+
+
+      workInProgress.memoizedProps = newProps;
+      workInProgress.memoizedState = newState;
+    } // Update the existing instance's state, props, and context pointers even
+    // if shouldComponentUpdate returns false.
+
+
+    instance.props = newProps;
+    instance.state = newState;
+    instance.context = nextContext;
+    return shouldUpdate;
+  } // Invokes the update life-cycles and returns false if it shouldn't rerender.
+
+
+  function updateClassInstance(current, workInProgress, ctor, newProps, renderExpirationTime) {
+    var instance = workInProgress.stateNode;
+    cloneUpdateQueue(current, workInProgress);
+    var oldProps = workInProgress.memoizedProps;
+    instance.props = workInProgress.type === workInProgress.elementType ? oldProps : resolveDefaultProps(workInProgress.type, oldProps);
+    var oldContext = instance.context;
+    var contextType = ctor.contextType;
+    var nextContext = emptyContextObject;
+
+    if (typeof contextType === 'object' && contextType !== null) {
+      nextContext = readContext(contextType);
+    } else {
+      var nextUnmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
+      nextContext = getMaskedContext(workInProgress, nextUnmaskedContext);
+    }
+
+    var getDerivedStateFromProps = ctor.getDerivedStateFromProps;
+    var hasNewLifecycles = typeof getDerivedStateFromProps === 'function' || typeof instance.getSnapshotBeforeUpdate === 'function'; // Note: During these life-cycles, instance.props/instance.state are what
+    // ever the previously attempted to render - not the "current". However,
+    // during componentDidUpdate we pass the "current" props.
+    // In order to support react-lifecycles-compat polyfilled components,
+    // Unsafe lifecycles should not be invoked for components using the new APIs.
+
+    if (!hasNewLifecycles && (typeof instance.UNSAFE_componentWillReceiveProps === 'function' || typeof instance.componentWillReceiveProps === 'function')) {
+      if (oldProps !== newProps || oldContext !== nextContext) {
+        callComponentWillReceiveProps(workInProgress, instance, newProps, nextContext);
+      }
+    }
+
+    resetHasForceUpdateBeforeProcessing();
+    var oldState = workInProgress.memoizedState;
+    var newState = instance.state = oldState;
+    processUpdateQueue(workInProgress, newProps, instance, renderExpirationTime);
+    newState = workInProgress.memoizedState;
+
+    if (oldProps === newProps && oldState === newState && !hasContextChanged() && !checkHasForceUpdateAfterProcessing()) {
+      // If an update was already in progress, we should schedule an Update
+      // effect even though we're bailing out, so that cWU/cDU are called.
+      if (typeof instance.componentDidUpdate === 'function') {
+        if (oldProps !== current.memoizedProps || oldState !== current.memoizedState) {
+          workInProgress.effectTag |= Update;
+        }
+      }
+
+      if (typeof instance.getSnapshotBeforeUpdate === 'function') {
+        if (oldProps !== current.memoizedProps || oldState !== current.memoizedState) {
+          workInProgress.effectTag |= Snapshot;
+        }
+      }
+
+      return false;
+    }
+
+    if (typeof getDerivedStateFromProps === 'function') {
+      applyDerivedStateFromProps(workInProgress, ctor, getDerivedStateFromProps, newProps);
+      newState = workInProgress.memoizedState;
+    }
+
+    var shouldUpdate = checkHasForceUpdateAfterProcessing() || checkShouldComponentUpdate(workInProgress, ctor, oldProps, newProps, oldState, newState, nextContext);
+
+    if (shouldUpdate) {
+      // In order to support react-lifecycles-compat polyfilled components,
+      // Unsafe lifecycles should not be invoked for components using the new APIs.
+      if (!hasNewLifecycles && (typeof instance.UNSAFE_componentWillUpdate === 'function' || typeof instance.componentWillUpdate === 'function')) {
+        startPhaseTimer(workInProgress, 'componentWillUpdate');
+
+        if (typeof instance.componentWillUpdate === 'function') {
+          instance.componentWillUpdate(newProps, newState, nextContext);
+        }
+
+        if (typeof instance.UNSAFE_componentWillUpdate === 'function') {
+          instance.UNSAFE_componentWillUpdate(newProps, newState, nextContext);
+        }
+
+        stopPhaseTimer();
+      }
+
+      if (typeof instance.componentDidUpdate === 'function') {
+        workInProgress.effectTag |= Update;
+      }
+
+      if (typeof instance.getSnapshotBeforeUpdate === 'function') {
+        workInProgress.effectTag |= Snapshot;
+      }
+    } else {
+      // If an update was already in progress, we should schedule an Update
+      // effect even though we're bailing out, so that cWU/cDU are called.
+      if (typeof instance.componentDidUpdate === 'function') {
+        if (oldProps !== current.memoizedProps || oldState !== current.memoizedState) {
+          workInProgress.effectTag |= Update;
+        }
+      }
+
+      if (typeof instance.getSnapshotBeforeUpdate === 'function') {
+        if (oldProps !== current.memoizedProps || oldState !== current.memoizedState) {
+          workInProgress.effectTag |= Snapshot;
+        }
+      } // If shouldComponentUpdate returned false, we should still update the
+      // memoized props/state to indicate that this work can be reused.
+
+
+      workInProgress.memoizedProps = newProps;
+      workInProgress.memoizedState = newState;
+    } // Update the existing instance's state, props, and context pointers even
+    // if shouldComponentUpdate returns false.
+
+
+    instance.props = newProps;
+    instance.state = newState;
+    instance.context = nextContext;
+    return shouldUpdate;
+  }
+
+  var didWarnAboutMaps;
+  var didWarnAboutGenerators;
+  var didWarnAboutStringRefs;
+  var ownerHasKeyUseWarning;
+  var ownerHasFunctionTypeWarning;
+
+  var warnForMissingKey = function (child) {};
+
+  {
+    didWarnAboutMaps = false;
+    didWarnAboutGenerators = false;
+    didWarnAboutStringRefs = {};
+    /**
+     * Warn if there's no key explicitly set on dynamic arrays of children or
+     * object keys are not valid. This allows us to keep track of children between
+     * updates.
+     */
+
+    ownerHasKeyUseWarning = {};
+    ownerHasFunctionTypeWarning = {};
+
+    warnForMissingKey = function (child) {
+      if (child === null || typeof child !== 'object') {
+        return;
+      }
+
+      if (!child._store || child._store.validated || child.key != null) {
+        return;
+      }
+
+      if (!(typeof child._store === 'object')) {
+        {
+          throw Error( "React Component in warnForMissingKey should have a _store. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+
+      child._store.validated = true;
+      var currentComponentErrorInfo = 'Each child in a list should have a unique ' + '"key" prop. See https://fb.me/react-warning-keys for ' + 'more information.' + getCurrentFiberStackInDev();
+
+      if (ownerHasKeyUseWarning[currentComponentErrorInfo]) {
+        return;
+      }
+
+      ownerHasKeyUseWarning[currentComponentErrorInfo] = true;
+
+      error('Each child in a list should have a unique ' + '"key" prop. See https://fb.me/react-warning-keys for ' + 'more information.');
+    };
+  }
+
+  var isArray$1 = Array.isArray;
+
+  function coerceRef(returnFiber, current, element) {
+    var mixedRef = element.ref;
+
+    if (mixedRef !== null && typeof mixedRef !== 'function' && typeof mixedRef !== 'object') {
+      {
+        // TODO: Clean this up once we turn on the string ref warning for
+        // everyone, because the strict mode case will no longer be relevant
+        if ((returnFiber.mode & StrictMode || warnAboutStringRefs) && // We warn in ReactElement.js if owner and self are equal for string refs
+        // because these cannot be automatically converted to an arrow function
+        // using a codemod. Therefore, we don't have to warn about string refs again.
+        !(element._owner && element._self && element._owner.stateNode !== element._self)) {
+          var componentName = getComponentName(returnFiber.type) || 'Component';
+
+          if (!didWarnAboutStringRefs[componentName]) {
+            {
+              error('A string ref, "%s", has been found within a strict mode tree. ' + 'String refs are a source of potential bugs and should be avoided. ' + 'We recommend using useRef() or createRef() instead. ' + 'Learn more about using refs safely here: ' + 'https://fb.me/react-strict-mode-string-ref%s', mixedRef, getStackByFiberInDevAndProd(returnFiber));
+            }
+
+            didWarnAboutStringRefs[componentName] = true;
+          }
+        }
+      }
+
+      if (element._owner) {
+        var owner = element._owner;
+        var inst;
+
+        if (owner) {
+          var ownerFiber = owner;
+
+          if (!(ownerFiber.tag === ClassComponent)) {
+            {
+              throw Error( "Function components cannot have string refs. We recommend using useRef() instead. Learn more about using refs safely here: https://fb.me/react-strict-mode-string-ref" );
+            }
+          }
+
+          inst = ownerFiber.stateNode;
+        }
+
+        if (!inst) {
+          {
+            throw Error( "Missing owner for string ref " + mixedRef + ". This error is likely caused by a bug in React. Please file an issue." );
+          }
+        }
+
+        var stringRef = '' + mixedRef; // Check if previous string ref matches new string ref
+
+        if (current !== null && current.ref !== null && typeof current.ref === 'function' && current.ref._stringRef === stringRef) {
+          return current.ref;
+        }
+
+        var ref = function (value) {
+          var refs = inst.refs;
+
+          if (refs === emptyRefsObject) {
+            // This is a lazy pooled frozen object, so we need to initialize.
+            refs = inst.refs = {};
+          }
+
+          if (value === null) {
+            delete refs[stringRef];
+          } else {
+            refs[stringRef] = value;
+          }
+        };
+
+        ref._stringRef = stringRef;
+        return ref;
+      } else {
+        if (!(typeof mixedRef === 'string')) {
+          {
+            throw Error( "Expected ref to be a function, a string, an object returned by React.createRef(), or null." );
+          }
+        }
+
+        if (!element._owner) {
+          {
+            throw Error( "Element ref was specified as a string (" + mixedRef + ") but no owner was set. This could happen for one of the following reasons:\n1. You may be adding a ref to a function component\n2. You may be adding a ref to a component that was not created inside a component's render method\n3. You have multiple copies of React loaded\nSee https://fb.me/react-refs-must-have-owner for more information." );
+          }
+        }
+      }
+    }
+
+    return mixedRef;
+  }
+
+  function throwOnInvalidObjectType(returnFiber, newChild) {
+    if (returnFiber.type !== 'textarea') {
+      var addendum = '';
+
+      {
+        addendum = ' If you meant to render a collection of children, use an array ' + 'instead.' + getCurrentFiberStackInDev();
+      }
+
+      {
+        {
+          throw Error( "Objects are not valid as a React child (found: " + (Object.prototype.toString.call(newChild) === '[object Object]' ? 'object with keys {' + Object.keys(newChild).join(', ') + '}' : newChild) + ")." + addendum );
+        }
+      }
+    }
+  }
+
+  function warnOnFunctionType() {
+    {
+      var currentComponentErrorInfo = 'Functions are not valid as a React child. This may happen if ' + 'you return a Component instead of <Component /> from render. ' + 'Or maybe you meant to call this function rather than return it.' + getCurrentFiberStackInDev();
+
+      if (ownerHasFunctionTypeWarning[currentComponentErrorInfo]) {
+        return;
+      }
+
+      ownerHasFunctionTypeWarning[currentComponentErrorInfo] = true;
+
+      error('Functions are not valid as a React child. This may happen if ' + 'you return a Component instead of <Component /> from render. ' + 'Or maybe you meant to call this function rather than return it.');
+    }
+  } // This wrapper function exists because I expect to clone the code in each path
+  // to be able to optimize each path individually by branching early. This needs
+  // a compiler or we can do it manually. Helpers that don't need this branching
+  // live outside of this function.
+
+
+  function ChildReconciler(shouldTrackSideEffects) {
+    function deleteChild(returnFiber, childToDelete) {
+      if (!shouldTrackSideEffects) {
+        // Noop.
+        return;
+      } // Deletions are added in reversed order so we add it to the front.
+      // At this point, the return fiber's effect list is empty except for
+      // deletions, so we can just append the deletion to the list. The remaining
+      // effects aren't added until the complete phase. Once we implement
+      // resuming, this may not be true.
+
+
+      var last = returnFiber.lastEffect;
+
+      if (last !== null) {
+        last.nextEffect = childToDelete;
+        returnFiber.lastEffect = childToDelete;
+      } else {
+        returnFiber.firstEffect = returnFiber.lastEffect = childToDelete;
+      }
+
+      childToDelete.nextEffect = null;
+      childToDelete.effectTag = Deletion;
+    }
+
+    function deleteRemainingChildren(returnFiber, currentFirstChild) {
+      if (!shouldTrackSideEffects) {
+        // Noop.
+        return null;
+      } // TODO: For the shouldClone case, this could be micro-optimized a bit by
+      // assuming that after the first child we've already added everything.
+
+
+      var childToDelete = currentFirstChild;
+
+      while (childToDelete !== null) {
+        deleteChild(returnFiber, childToDelete);
+        childToDelete = childToDelete.sibling;
+      }
+
+      return null;
+    }
+
+    function mapRemainingChildren(returnFiber, currentFirstChild) {
+      // Add the remaining children to a temporary map so that we can find them by
+      // keys quickly. Implicit (null) keys get added to this set with their index
+      // instead.
+      var existingChildren = new Map();
+      var existingChild = currentFirstChild;
+
+      while (existingChild !== null) {
+        if (existingChild.key !== null) {
+          existingChildren.set(existingChild.key, existingChild);
+        } else {
+          existingChildren.set(existingChild.index, existingChild);
+        }
+
+        existingChild = existingChild.sibling;
+      }
+
+      return existingChildren;
+    }
+
+    function useFiber(fiber, pendingProps) {
+      // We currently set sibling to null and index to 0 here because it is easy
+      // to forget to do before returning it. E.g. for the single child case.
+      var clone = createWorkInProgress(fiber, pendingProps);
+      clone.index = 0;
+      clone.sibling = null;
+      return clone;
+    }
+
+    function placeChild(newFiber, lastPlacedIndex, newIndex) {
+      newFiber.index = newIndex;
+
+      if (!shouldTrackSideEffects) {
+        // Noop.
+        return lastPlacedIndex;
+      }
+
+      var current = newFiber.alternate;
+
+      if (current !== null) {
+        var oldIndex = current.index;
+
+        if (oldIndex < lastPlacedIndex) {
+          // This is a move.
+          newFiber.effectTag = Placement;
+          return lastPlacedIndex;
+        } else {
+          // This item can stay in place.
+          return oldIndex;
+        }
+      } else {
+        // This is an insertion.
+        newFiber.effectTag = Placement;
+        return lastPlacedIndex;
+      }
+    }
+
+    function placeSingleChild(newFiber) {
+      // This is simpler for the single child case. We only need to do a
+      // placement for inserting new children.
+      if (shouldTrackSideEffects && newFiber.alternate === null) {
+        newFiber.effectTag = Placement;
+      }
+
+      return newFiber;
+    }
+
+    function updateTextNode(returnFiber, current, textContent, expirationTime) {
+      if (current === null || current.tag !== HostText) {
+        // Insert
+        var created = createFiberFromText(textContent, returnFiber.mode, expirationTime);
+        created.return = returnFiber;
+        return created;
+      } else {
+        // Update
+        var existing = useFiber(current, textContent);
+        existing.return = returnFiber;
+        return existing;
+      }
+    }
+
+    function updateElement(returnFiber, current, element, expirationTime) {
+      if (current !== null) {
+        if (current.elementType === element.type || ( // Keep this check inline so it only runs on the false path:
+         isCompatibleFamilyForHotReloading(current, element) )) {
+          // Move based on index
+          var existing = useFiber(current, element.props);
+          existing.ref = coerceRef(returnFiber, current, element);
+          existing.return = returnFiber;
+
+          {
+            existing._debugSource = element._source;
+            existing._debugOwner = element._owner;
+          }
+
+          return existing;
+        }
+      } // Insert
+
+
+      var created = createFiberFromElement(element, returnFiber.mode, expirationTime);
+      created.ref = coerceRef(returnFiber, current, element);
+      created.return = returnFiber;
+      return created;
+    }
+
+    function updatePortal(returnFiber, current, portal, expirationTime) {
+      if (current === null || current.tag !== HostPortal || current.stateNode.containerInfo !== portal.containerInfo || current.stateNode.implementation !== portal.implementation) {
+        // Insert
+        var created = createFiberFromPortal(portal, returnFiber.mode, expirationTime);
+        created.return = returnFiber;
+        return created;
+      } else {
+        // Update
+        var existing = useFiber(current, portal.children || []);
+        existing.return = returnFiber;
+        return existing;
+      }
+    }
+
+    function updateFragment(returnFiber, current, fragment, expirationTime, key) {
+      if (current === null || current.tag !== Fragment) {
+        // Insert
+        var created = createFiberFromFragment(fragment, returnFiber.mode, expirationTime, key);
+        created.return = returnFiber;
+        return created;
+      } else {
+        // Update
+        var existing = useFiber(current, fragment);
+        existing.return = returnFiber;
+        return existing;
+      }
+    }
+
+    function createChild(returnFiber, newChild, expirationTime) {
+      if (typeof newChild === 'string' || typeof newChild === 'number') {
+        // Text nodes don't have keys. If the previous node is implicitly keyed
+        // we can continue to replace it without aborting even if it is not a text
+        // node.
+        var created = createFiberFromText('' + newChild, returnFiber.mode, expirationTime);
+        created.return = returnFiber;
+        return created;
+      }
+
+      if (typeof newChild === 'object' && newChild !== null) {
+        switch (newChild.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+            {
+              var _created = createFiberFromElement(newChild, returnFiber.mode, expirationTime);
+
+              _created.ref = coerceRef(returnFiber, null, newChild);
+              _created.return = returnFiber;
+              return _created;
+            }
+
+          case REACT_PORTAL_TYPE:
+            {
+              var _created2 = createFiberFromPortal(newChild, returnFiber.mode, expirationTime);
+
+              _created2.return = returnFiber;
+              return _created2;
+            }
+        }
+
+        if (isArray$1(newChild) || getIteratorFn(newChild)) {
+          var _created3 = createFiberFromFragment(newChild, returnFiber.mode, expirationTime, null);
+
+          _created3.return = returnFiber;
+          return _created3;
+        }
+
+        throwOnInvalidObjectType(returnFiber, newChild);
+      }
+
+      {
+        if (typeof newChild === 'function') {
+          warnOnFunctionType();
+        }
+      }
+
+      return null;
+    }
+
+    function updateSlot(returnFiber, oldFiber, newChild, expirationTime) {
+      // Update the fiber if the keys match, otherwise return null.
+      var key = oldFiber !== null ? oldFiber.key : null;
+
+      if (typeof newChild === 'string' || typeof newChild === 'number') {
+        // Text nodes don't have keys. If the previous node is implicitly keyed
+        // we can continue to replace it without aborting even if it is not a text
+        // node.
+        if (key !== null) {
+          return null;
+        }
+
+        return updateTextNode(returnFiber, oldFiber, '' + newChild, expirationTime);
+      }
+
+      if (typeof newChild === 'object' && newChild !== null) {
+        switch (newChild.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+            {
+              if (newChild.key === key) {
+                if (newChild.type === REACT_FRAGMENT_TYPE) {
+                  return updateFragment(returnFiber, oldFiber, newChild.props.children, expirationTime, key);
+                }
+
+                return updateElement(returnFiber, oldFiber, newChild, expirationTime);
+              } else {
+                return null;
+              }
+            }
+
+          case REACT_PORTAL_TYPE:
+            {
+              if (newChild.key === key) {
+                return updatePortal(returnFiber, oldFiber, newChild, expirationTime);
+              } else {
+                return null;
+              }
+            }
+        }
+
+        if (isArray$1(newChild) || getIteratorFn(newChild)) {
+          if (key !== null) {
+            return null;
+          }
+
+          return updateFragment(returnFiber, oldFiber, newChild, expirationTime, null);
+        }
+
+        throwOnInvalidObjectType(returnFiber, newChild);
+      }
+
+      {
+        if (typeof newChild === 'function') {
+          warnOnFunctionType();
+        }
+      }
+
+      return null;
+    }
+
+    function updateFromMap(existingChildren, returnFiber, newIdx, newChild, expirationTime) {
+      if (typeof newChild === 'string' || typeof newChild === 'number') {
+        // Text nodes don't have keys, so we neither have to check the old nor
+        // new node for the key. If both are text nodes, they match.
+        var matchedFiber = existingChildren.get(newIdx) || null;
+        return updateTextNode(returnFiber, matchedFiber, '' + newChild, expirationTime);
+      }
+
+      if (typeof newChild === 'object' && newChild !== null) {
+        switch (newChild.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+            {
+              var _matchedFiber = existingChildren.get(newChild.key === null ? newIdx : newChild.key) || null;
+
+              if (newChild.type === REACT_FRAGMENT_TYPE) {
+                return updateFragment(returnFiber, _matchedFiber, newChild.props.children, expirationTime, newChild.key);
+              }
+
+              return updateElement(returnFiber, _matchedFiber, newChild, expirationTime);
+            }
+
+          case REACT_PORTAL_TYPE:
+            {
+              var _matchedFiber2 = existingChildren.get(newChild.key === null ? newIdx : newChild.key) || null;
+
+              return updatePortal(returnFiber, _matchedFiber2, newChild, expirationTime);
+            }
+        }
+
+        if (isArray$1(newChild) || getIteratorFn(newChild)) {
+          var _matchedFiber3 = existingChildren.get(newIdx) || null;
+
+          return updateFragment(returnFiber, _matchedFiber3, newChild, expirationTime, null);
+        }
+
+        throwOnInvalidObjectType(returnFiber, newChild);
+      }
+
+      {
+        if (typeof newChild === 'function') {
+          warnOnFunctionType();
+        }
+      }
+
+      return null;
+    }
+    /**
+     * Warns if there is a duplicate or missing key
+     */
+
+
+    function warnOnInvalidKey(child, knownKeys) {
+      {
+        if (typeof child !== 'object' || child === null) {
+          return knownKeys;
+        }
+
+        switch (child.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+          case REACT_PORTAL_TYPE:
+            warnForMissingKey(child);
+            var key = child.key;
+
+            if (typeof key !== 'string') {
+              break;
+            }
+
+            if (knownKeys === null) {
+              knownKeys = new Set();
+              knownKeys.add(key);
+              break;
+            }
+
+            if (!knownKeys.has(key)) {
+              knownKeys.add(key);
+              break;
+            }
+
+            error('Encountered two children with the same key, `%s`. ' + 'Keys should be unique so that components maintain their identity ' + 'across updates. Non-unique keys may cause children to be ' + 'duplicated and/or omitted — the behavior is unsupported and ' + 'could change in a future version.', key);
+
+            break;
+        }
+      }
+
+      return knownKeys;
+    }
+
+    function reconcileChildrenArray(returnFiber, currentFirstChild, newChildren, expirationTime) {
+      // This algorithm can't optimize by searching from both ends since we
+      // don't have backpointers on fibers. I'm trying to see how far we can get
+      // with that model. If it ends up not being worth the tradeoffs, we can
+      // add it later.
+      // Even with a two ended optimization, we'd want to optimize for the case
+      // where there are few changes and brute force the comparison instead of
+      // going for the Map. It'd like to explore hitting that path first in
+      // forward-only mode and only go for the Map once we notice that we need
+      // lots of look ahead. This doesn't handle reversal as well as two ended
+      // search but that's unusual. Besides, for the two ended optimization to
+      // work on Iterables, we'd need to copy the whole set.
+      // In this first iteration, we'll just live with hitting the bad case
+      // (adding everything to a Map) in for every insert/move.
+      // If you change this code, also update reconcileChildrenIterator() which
+      // uses the same algorithm.
+      {
+        // First, validate keys.
+        var knownKeys = null;
+
+        for (var i = 0; i < newChildren.length; i++) {
+          var child = newChildren[i];
+          knownKeys = warnOnInvalidKey(child, knownKeys);
+        }
+      }
+
+      var resultingFirstChild = null;
+      var previousNewFiber = null;
+      var oldFiber = currentFirstChild;
+      var lastPlacedIndex = 0;
+      var newIdx = 0;
+      var nextOldFiber = null;
+
+      for (; oldFiber !== null && newIdx < newChildren.length; newIdx++) {
+        if (oldFiber.index > newIdx) {
+          nextOldFiber = oldFiber;
+          oldFiber = null;
+        } else {
+          nextOldFiber = oldFiber.sibling;
+        }
+
+        var newFiber = updateSlot(returnFiber, oldFiber, newChildren[newIdx], expirationTime);
+
+        if (newFiber === null) {
+          // TODO: This breaks on empty slots like null children. That's
+          // unfortunate because it triggers the slow path all the time. We need
+          // a better way to communicate whether this was a miss or null,
+          // boolean, undefined, etc.
+          if (oldFiber === null) {
+            oldFiber = nextOldFiber;
+          }
+
+          break;
+        }
+
+        if (shouldTrackSideEffects) {
+          if (oldFiber && newFiber.alternate === null) {
+            // We matched the slot, but we didn't reuse the existing fiber, so we
+            // need to delete the existing child.
+            deleteChild(returnFiber, oldFiber);
+          }
+        }
+
+        lastPlacedIndex = placeChild(newFiber, lastPlacedIndex, newIdx);
+
+        if (previousNewFiber === null) {
+          // TODO: Move out of the loop. This only happens for the first run.
+          resultingFirstChild = newFiber;
+        } else {
+          // TODO: Defer siblings if we're not at the right index for this slot.
+          // I.e. if we had null values before, then we want to defer this
+          // for each null value. However, we also don't want to call updateSlot
+          // with the previous one.
+          previousNewFiber.sibling = newFiber;
+        }
+
+        previousNewFiber = newFiber;
+        oldFiber = nextOldFiber;
+      }
+
+      if (newIdx === newChildren.length) {
+        // We've reached the end of the new children. We can delete the rest.
+        deleteRemainingChildren(returnFiber, oldFiber);
+        return resultingFirstChild;
+      }
+
+      if (oldFiber === null) {
+        // If we don't have any more existing children we can choose a fast path
+        // since the rest will all be insertions.
+        for (; newIdx < newChildren.length; newIdx++) {
+          var _newFiber = createChild(returnFiber, newChildren[newIdx], expirationTime);
+
+          if (_newFiber === null) {
+            continue;
+          }
+
+          lastPlacedIndex = placeChild(_newFiber, lastPlacedIndex, newIdx);
+
+          if (previousNewFiber === null) {
+            // TODO: Move out of the loop. This only happens for the first run.
+            resultingFirstChild = _newFiber;
+          } else {
+            previousNewFiber.sibling = _newFiber;
+          }
+
+          previousNewFiber = _newFiber;
+        }
+
+        return resultingFirstChild;
+      } // Add all children to a key map for quick lookups.
+
+
+      var existingChildren = mapRemainingChildren(returnFiber, oldFiber); // Keep scanning and use the map to restore deleted items as moves.
+
+      for (; newIdx < newChildren.length; newIdx++) {
+        var _newFiber2 = updateFromMap(existingChildren, returnFiber, newIdx, newChildren[newIdx], expirationTime);
+
+        if (_newFiber2 !== null) {
+          if (shouldTrackSideEffects) {
+            if (_newFiber2.alternate !== null) {
+              // The new fiber is a work in progress, but if there exists a
+              // current, that means that we reused the fiber. We need to delete
+              // it from the child list so that we don't add it to the deletion
+              // list.
+              existingChildren.delete(_newFiber2.key === null ? newIdx : _newFiber2.key);
+            }
+          }
+
+          lastPlacedIndex = placeChild(_newFiber2, lastPlacedIndex, newIdx);
+
+          if (previousNewFiber === null) {
+            resultingFirstChild = _newFiber2;
+          } else {
+            previousNewFiber.sibling = _newFiber2;
+          }
+
+          previousNewFiber = _newFiber2;
+        }
+      }
+
+      if (shouldTrackSideEffects) {
+        // Any existing children that weren't consumed above were deleted. We need
+        // to add them to the deletion list.
+        existingChildren.forEach(function (child) {
+          return deleteChild(returnFiber, child);
+        });
+      }
+
+      return resultingFirstChild;
+    }
+
+    function reconcileChildrenIterator(returnFiber, currentFirstChild, newChildrenIterable, expirationTime) {
+      // This is the same implementation as reconcileChildrenArray(),
+      // but using the iterator instead.
+      var iteratorFn = getIteratorFn(newChildrenIterable);
+
+      if (!(typeof iteratorFn === 'function')) {
+        {
+          throw Error( "An object is not an iterable. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+
+      {
+        // We don't support rendering Generators because it's a mutation.
+        // See https://github.com/facebook/react/issues/12995
+        if (typeof Symbol === 'function' && // $FlowFixMe Flow doesn't know about toStringTag
+        newChildrenIterable[Symbol.toStringTag] === 'Generator') {
+          if (!didWarnAboutGenerators) {
+            error('Using Generators as children is unsupported and will likely yield ' + 'unexpected results because enumerating a generator mutates it. ' + 'You may convert it to an array with `Array.from()` or the ' + '`[...spread]` operator before rendering. Keep in mind ' + 'you might need to polyfill these features for older browsers.');
+          }
+
+          didWarnAboutGenerators = true;
+        } // Warn about using Maps as children
+
+
+        if (newChildrenIterable.entries === iteratorFn) {
+          if (!didWarnAboutMaps) {
+            error('Using Maps as children is unsupported and will likely yield ' + 'unexpected results. Convert it to a sequence/iterable of keyed ' + 'ReactElements instead.');
+          }
+
+          didWarnAboutMaps = true;
+        } // First, validate keys.
+        // We'll get a different iterator later for the main pass.
+
+
+        var _newChildren = iteratorFn.call(newChildrenIterable);
+
+        if (_newChildren) {
+          var knownKeys = null;
+
+          var _step = _newChildren.next();
+
+          for (; !_step.done; _step = _newChildren.next()) {
+            var child = _step.value;
+            knownKeys = warnOnInvalidKey(child, knownKeys);
+          }
+        }
+      }
+
+      var newChildren = iteratorFn.call(newChildrenIterable);
+
+      if (!(newChildren != null)) {
+        {
+          throw Error( "An iterable object provided no iterator." );
+        }
+      }
+
+      var resultingFirstChild = null;
+      var previousNewFiber = null;
+      var oldFiber = currentFirstChild;
+      var lastPlacedIndex = 0;
+      var newIdx = 0;
+      var nextOldFiber = null;
+      var step = newChildren.next();
+
+      for (; oldFiber !== null && !step.done; newIdx++, step = newChildren.next()) {
+        if (oldFiber.index > newIdx) {
+          nextOldFiber = oldFiber;
+          oldFiber = null;
+        } else {
+          nextOldFiber = oldFiber.sibling;
+        }
+
+        var newFiber = updateSlot(returnFiber, oldFiber, step.value, expirationTime);
+
+        if (newFiber === null) {
+          // TODO: This breaks on empty slots like null children. That's
+          // unfortunate because it triggers the slow path all the time. We need
+          // a better way to communicate whether this was a miss or null,
+          // boolean, undefined, etc.
+          if (oldFiber === null) {
+            oldFiber = nextOldFiber;
+          }
+
+          break;
+        }
+
+        if (shouldTrackSideEffects) {
+          if (oldFiber && newFiber.alternate === null) {
+            // We matched the slot, but we didn't reuse the existing fiber, so we
+            // need to delete the existing child.
+            deleteChild(returnFiber, oldFiber);
+          }
+        }
+
+        lastPlacedIndex = placeChild(newFiber, lastPlacedIndex, newIdx);
+
+        if (previousNewFiber === null) {
+          // TODO: Move out of the loop. This only happens for the first run.
+          resultingFirstChild = newFiber;
+        } else {
+          // TODO: Defer siblings if we're not at the right index for this slot.
+          // I.e. if we had null values before, then we want to defer this
+          // for each null value. However, we also don't want to call updateSlot
+          // with the previous one.
+          previousNewFiber.sibling = newFiber;
+        }
+
+        previousNewFiber = newFiber;
+        oldFiber = nextOldFiber;
+      }
+
+      if (step.done) {
+        // We've reached the end of the new children. We can delete the rest.
+        deleteRemainingChildren(returnFiber, oldFiber);
+        return resultingFirstChild;
+      }
+
+      if (oldFiber === null) {
+        // If we don't have any more existing children we can choose a fast path
+        // since the rest will all be insertions.
+        for (; !step.done; newIdx++, step = newChildren.next()) {
+          var _newFiber3 = createChild(returnFiber, step.value, expirationTime);
+
+          if (_newFiber3 === null) {
+            continue;
+          }
+
+          lastPlacedIndex = placeChild(_newFiber3, lastPlacedIndex, newIdx);
+
+          if (previousNewFiber === null) {
+            // TODO: Move out of the loop. This only happens for the first run.
+            resultingFirstChild = _newFiber3;
+          } else {
+            previousNewFiber.sibling = _newFiber3;
+          }
+
+          previousNewFiber = _newFiber3;
+        }
+
+        return resultingFirstChild;
+      } // Add all children to a key map for quick lookups.
+
+
+      var existingChildren = mapRemainingChildren(returnFiber, oldFiber); // Keep scanning and use the map to restore deleted items as moves.
+
+      for (; !step.done; newIdx++, step = newChildren.next()) {
+        var _newFiber4 = updateFromMap(existingChildren, returnFiber, newIdx, step.value, expirationTime);
+
+        if (_newFiber4 !== null) {
+          if (shouldTrackSideEffects) {
+            if (_newFiber4.alternate !== null) {
+              // The new fiber is a work in progress, but if there exists a
+              // current, that means that we reused the fiber. We need to delete
+              // it from the child list so that we don't add it to the deletion
+              // list.
+              existingChildren.delete(_newFiber4.key === null ? newIdx : _newFiber4.key);
+            }
+          }
+
+          lastPlacedIndex = placeChild(_newFiber4, lastPlacedIndex, newIdx);
+
+          if (previousNewFiber === null) {
+            resultingFirstChild = _newFiber4;
+          } else {
+            previousNewFiber.sibling = _newFiber4;
+          }
+
+          previousNewFiber = _newFiber4;
+        }
+      }
+
+      if (shouldTrackSideEffects) {
+        // Any existing children that weren't consumed above were deleted. We need
+        // to add them to the deletion list.
+        existingChildren.forEach(function (child) {
+          return deleteChild(returnFiber, child);
+        });
+      }
+
+      return resultingFirstChild;
+    }
+
+    function reconcileSingleTextNode(returnFiber, currentFirstChild, textContent, expirationTime) {
+      // There's no need to check for keys on text nodes since we don't have a
+      // way to define them.
+      if (currentFirstChild !== null && currentFirstChild.tag === HostText) {
+        // We already have an existing node so let's just update it and delete
+        // the rest.
+        deleteRemainingChildren(returnFiber, currentFirstChild.sibling);
+        var existing = useFiber(currentFirstChild, textContent);
+        existing.return = returnFiber;
+        return existing;
+      } // The existing first child is not a text node so we need to create one
+      // and delete the existing ones.
+
+
+      deleteRemainingChildren(returnFiber, currentFirstChild);
+      var created = createFiberFromText(textContent, returnFiber.mode, expirationTime);
+      created.return = returnFiber;
+      return created;
+    }
+
+    function reconcileSingleElement(returnFiber, currentFirstChild, element, expirationTime) {
+      var key = element.key;
+      var child = currentFirstChild;
+
+      while (child !== null) {
+        // TODO: If key === null and child.key === null, then this only applies to
+        // the first item in the list.
+        if (child.key === key) {
+          switch (child.tag) {
+            case Fragment:
+              {
+                if (element.type === REACT_FRAGMENT_TYPE) {
+                  deleteRemainingChildren(returnFiber, child.sibling);
+                  var existing = useFiber(child, element.props.children);
+                  existing.return = returnFiber;
+
+                  {
+                    existing._debugSource = element._source;
+                    existing._debugOwner = element._owner;
+                  }
+
+                  return existing;
+                }
+
+                break;
+              }
+
+            case Block:
+
+            // We intentionally fallthrough here if enableBlocksAPI is not on.
+            // eslint-disable-next-lined no-fallthrough
+
+            default:
+              {
+                if (child.elementType === element.type || ( // Keep this check inline so it only runs on the false path:
+                 isCompatibleFamilyForHotReloading(child, element) )) {
+                  deleteRemainingChildren(returnFiber, child.sibling);
+
+                  var _existing3 = useFiber(child, element.props);
+
+                  _existing3.ref = coerceRef(returnFiber, child, element);
+                  _existing3.return = returnFiber;
+
+                  {
+                    _existing3._debugSource = element._source;
+                    _existing3._debugOwner = element._owner;
+                  }
+
+                  return _existing3;
+                }
+
+                break;
+              }
+          } // Didn't match.
+
+
+          deleteRemainingChildren(returnFiber, child);
+          break;
+        } else {
+          deleteChild(returnFiber, child);
+        }
+
+        child = child.sibling;
+      }
+
+      if (element.type === REACT_FRAGMENT_TYPE) {
+        var created = createFiberFromFragment(element.props.children, returnFiber.mode, expirationTime, element.key);
+        created.return = returnFiber;
+        return created;
+      } else {
+        var _created4 = createFiberFromElement(element, returnFiber.mode, expirationTime);
+
+        _created4.ref = coerceRef(returnFiber, currentFirstChild, element);
+        _created4.return = returnFiber;
+        return _created4;
+      }
+    }
+
+    function reconcileSinglePortal(returnFiber, currentFirstChild, portal, expirationTime) {
+      var key = portal.key;
+      var child = currentFirstChild;
+
+      while (child !== null) {
+        // TODO: If key === null and child.key === null, then this only applies to
+        // the first item in the list.
+        if (child.key === key) {
+          if (child.tag === HostPortal && child.stateNode.containerInfo === portal.containerInfo && child.stateNode.implementation === portal.implementation) {
+            deleteRemainingChildren(returnFiber, child.sibling);
+            var existing = useFiber(child, portal.children || []);
+            existing.return = returnFiber;
+            return existing;
+          } else {
+            deleteRemainingChildren(returnFiber, child);
+            break;
+          }
+        } else {
+          deleteChild(returnFiber, child);
+        }
+
+        child = child.sibling;
+      }
+
+      var created = createFiberFromPortal(portal, returnFiber.mode, expirationTime);
+      created.return = returnFiber;
+      return created;
+    } // This API will tag the children with the side-effect of the reconciliation
+    // itself. They will be added to the side-effect list as we pass through the
+    // children and the parent.
+
+
+    function reconcileChildFibers(returnFiber, currentFirstChild, newChild, expirationTime) {
+      // This function is not recursive.
+      // If the top level item is an array, we treat it as a set of children,
+      // not as a fragment. Nested arrays on the other hand will be treated as
+      // fragment nodes. Recursion happens at the normal flow.
+      // Handle top level unkeyed fragments as if they were arrays.
+      // This leads to an ambiguity between <>{[...]}</> and <>...</>.
+      // We treat the ambiguous cases above the same.
+      var isUnkeyedTopLevelFragment = typeof newChild === 'object' && newChild !== null && newChild.type === REACT_FRAGMENT_TYPE && newChild.key === null;
+
+      if (isUnkeyedTopLevelFragment) {
+        newChild = newChild.props.children;
+      } // Handle object types
+
+
+      var isObject = typeof newChild === 'object' && newChild !== null;
+
+      if (isObject) {
+        switch (newChild.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+            return placeSingleChild(reconcileSingleElement(returnFiber, currentFirstChild, newChild, expirationTime));
+
+          case REACT_PORTAL_TYPE:
+            return placeSingleChild(reconcileSinglePortal(returnFiber, currentFirstChild, newChild, expirationTime));
+        }
+      }
+
+      if (typeof newChild === 'string' || typeof newChild === 'number') {
+        return placeSingleChild(reconcileSingleTextNode(returnFiber, currentFirstChild, '' + newChild, expirationTime));
+      }
+
+      if (isArray$1(newChild)) {
+        return reconcileChildrenArray(returnFiber, currentFirstChild, newChild, expirationTime);
+      }
+
+      if (getIteratorFn(newChild)) {
+        return reconcileChildrenIterator(returnFiber, currentFirstChild, newChild, expirationTime);
+      }
+
+      if (isObject) {
+        throwOnInvalidObjectType(returnFiber, newChild);
+      }
+
+      {
+        if (typeof newChild === 'function') {
+          warnOnFunctionType();
+        }
+      }
+
+      if (typeof newChild === 'undefined' && !isUnkeyedTopLevelFragment) {
+        // If the new child is undefined, and the return fiber is a composite
+        // component, throw an error. If Fiber return types are disabled,
+        // we already threw above.
+        switch (returnFiber.tag) {
+          case ClassComponent:
+            {
+              {
+                var instance = returnFiber.stateNode;
+
+                if (instance.render._isMockFunction) {
+                  // We allow auto-mocks to proceed as if they're returning null.
+                  break;
+                }
+              }
+            }
+          // Intentionally fall through to the next case, which handles both
+          // functions and classes
+          // eslint-disable-next-lined no-fallthrough
+
+          case FunctionComponent:
+            {
+              var Component = returnFiber.type;
+
+              {
+                {
+                  throw Error( (Component.displayName || Component.name || 'Component') + "(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null." );
+                }
+              }
+            }
+        }
+      } // Remaining cases are all treated as empty.
+
+
+      return deleteRemainingChildren(returnFiber, currentFirstChild);
+    }
+
+    return reconcileChildFibers;
+  }
+
+  var reconcileChildFibers = ChildReconciler(true);
+  var mountChildFibers = ChildReconciler(false);
+  function cloneChildFibers(current, workInProgress) {
+    if (!(current === null || workInProgress.child === current.child)) {
+      {
+        throw Error( "Resuming work not yet implemented." );
+      }
+    }
+
+    if (workInProgress.child === null) {
+      return;
+    }
+
+    var currentChild = workInProgress.child;
+    var newChild = createWorkInProgress(currentChild, currentChild.pendingProps);
+    workInProgress.child = newChild;
+    newChild.return = workInProgress;
+
+    while (currentChild.sibling !== null) {
+      currentChild = currentChild.sibling;
+      newChild = newChild.sibling = createWorkInProgress(currentChild, currentChild.pendingProps);
+      newChild.return = workInProgress;
+    }
+
+    newChild.sibling = null;
+  } // Reset a workInProgress child set to prepare it for a second pass.
+
+  function resetChildFibers(workInProgress, renderExpirationTime) {
+    var child = workInProgress.child;
+
+    while (child !== null) {
+      resetWorkInProgress(child, renderExpirationTime);
+      child = child.sibling;
+    }
+  }
+
+  var NO_CONTEXT = {};
+  var contextStackCursor$1 = createCursor(NO_CONTEXT);
+  var contextFiberStackCursor = createCursor(NO_CONTEXT);
+  var rootInstanceStackCursor = createCursor(NO_CONTEXT);
+
+  function requiredContext(c) {
+    if (!(c !== NO_CONTEXT)) {
+      {
+        throw Error( "Expected host context to exist. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+
+    return c;
+  }
+
+  function getRootHostContainer() {
+    var rootInstance = requiredContext(rootInstanceStackCursor.current);
+    return rootInstance;
+  }
+
+  function pushHostContainer(fiber, nextRootInstance) {
+    // Push current root instance onto the stack;
+    // This allows us to reset root when portals are popped.
+    push(rootInstanceStackCursor, nextRootInstance, fiber); // Track the context and the Fiber that provided it.
+    // This enables us to pop only Fibers that provide unique contexts.
+
+    push(contextFiberStackCursor, fiber, fiber); // Finally, we need to push the host context to the stack.
+    // However, we can't just call getRootHostContext() and push it because
+    // we'd have a different number of entries on the stack depending on
+    // whether getRootHostContext() throws somewhere in renderer code or not.
+    // So we push an empty value first. This lets us safely unwind on errors.
+
+    push(contextStackCursor$1, NO_CONTEXT, fiber);
+    var nextRootContext = getRootHostContext(nextRootInstance); // Now that we know this function doesn't throw, replace it.
+
+    pop(contextStackCursor$1, fiber);
+    push(contextStackCursor$1, nextRootContext, fiber);
+  }
+
+  function popHostContainer(fiber) {
+    pop(contextStackCursor$1, fiber);
+    pop(contextFiberStackCursor, fiber);
+    pop(rootInstanceStackCursor, fiber);
+  }
+
+  function getHostContext() {
+    var context = requiredContext(contextStackCursor$1.current);
+    return context;
+  }
+
+  function pushHostContext(fiber) {
+    var rootInstance = requiredContext(rootInstanceStackCursor.current);
+    var context = requiredContext(contextStackCursor$1.current);
+    var nextContext = getChildHostContext(context, fiber.type); // Don't push this Fiber's context unless it's unique.
+
+    if (context === nextContext) {
+      return;
+    } // Track the context and the Fiber that provided it.
+    // This enables us to pop only Fibers that provide unique contexts.
+
+
+    push(contextFiberStackCursor, fiber, fiber);
+    push(contextStackCursor$1, nextContext, fiber);
+  }
+
+  function popHostContext(fiber) {
+    // Do not pop unless this Fiber provided the current context.
+    // pushHostContext() only pushes Fibers that provide unique contexts.
+    if (contextFiberStackCursor.current !== fiber) {
+      return;
+    }
+
+    pop(contextStackCursor$1, fiber);
+    pop(contextFiberStackCursor, fiber);
+  }
+
+  var DefaultSuspenseContext = 0; // The Suspense Context is split into two parts. The lower bits is
+  // inherited deeply down the subtree. The upper bits only affect
+  // this immediate suspense boundary and gets reset each new
+  // boundary or suspense list.
+
+  var SubtreeSuspenseContextMask = 1; // Subtree Flags:
+  // InvisibleParentSuspenseContext indicates that one of our parent Suspense
+  // boundaries is not currently showing visible main content.
+  // Either because it is already showing a fallback or is not mounted at all.
+  // We can use this to determine if it is desirable to trigger a fallback at
+  // the parent. If not, then we might need to trigger undesirable boundaries
+  // and/or suspend the commit to avoid hiding the parent content.
+
+  var InvisibleParentSuspenseContext = 1; // Shallow Flags:
+  // ForceSuspenseFallback can be used by SuspenseList to force newly added
+  // items into their fallback state during one of the render passes.
+
+  var ForceSuspenseFallback = 2;
+  var suspenseStackCursor = createCursor(DefaultSuspenseContext);
+  function hasSuspenseContext(parentContext, flag) {
+    return (parentContext & flag) !== 0;
+  }
+  function setDefaultShallowSuspenseContext(parentContext) {
+    return parentContext & SubtreeSuspenseContextMask;
+  }
+  function setShallowSuspenseContext(parentContext, shallowContext) {
+    return parentContext & SubtreeSuspenseContextMask | shallowContext;
+  }
+  function addSubtreeSuspenseContext(parentContext, subtreeContext) {
+    return parentContext | subtreeContext;
+  }
+  function pushSuspenseContext(fiber, newContext) {
+    push(suspenseStackCursor, newContext, fiber);
+  }
+  function popSuspenseContext(fiber) {
+    pop(suspenseStackCursor, fiber);
+  }
+
+  function shouldCaptureSuspense(workInProgress, hasInvisibleParent) {
+    // If it was the primary children that just suspended, capture and render the
+    // fallback. Otherwise, don't capture and bubble to the next boundary.
+    var nextState = workInProgress.memoizedState;
+
+    if (nextState !== null) {
+      if (nextState.dehydrated !== null) {
+        // A dehydrated boundary always captures.
+        return true;
+      }
+
+      return false;
+    }
+
+    var props = workInProgress.memoizedProps; // In order to capture, the Suspense component must have a fallback prop.
+
+    if (props.fallback === undefined) {
+      return false;
+    } // Regular boundaries always capture.
+
+
+    if (props.unstable_avoidThisFallback !== true) {
+      return true;
+    } // If it's a boundary we should avoid, then we prefer to bubble up to the
+    // parent boundary if it is currently invisible.
+
+
+    if (hasInvisibleParent) {
+      return false;
+    } // If the parent is not able to handle it, we must handle it.
+
+
+    return true;
+  }
+  function findFirstSuspended(row) {
+    var node = row;
+
+    while (node !== null) {
+      if (node.tag === SuspenseComponent) {
+        var state = node.memoizedState;
+
+        if (state !== null) {
+          var dehydrated = state.dehydrated;
+
+          if (dehydrated === null || isSuspenseInstancePending(dehydrated) || isSuspenseInstanceFallback(dehydrated)) {
+            return node;
+          }
+        }
+      } else if (node.tag === SuspenseListComponent && // revealOrder undefined can't be trusted because it don't
+      // keep track of whether it suspended or not.
+      node.memoizedProps.revealOrder !== undefined) {
+        var didSuspend = (node.effectTag & DidCapture) !== NoEffect;
+
+        if (didSuspend) {
+          return node;
+        }
+      } else if (node.child !== null) {
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
+
+      if (node === row) {
+        return null;
+      }
+
+      while (node.sibling === null) {
+        if (node.return === null || node.return === row) {
+          return null;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    }
+
+    return null;
+  }
+
+  function createDeprecatedResponderListener(responder, props) {
+    var eventResponderListener = {
+      responder: responder,
+      props: props
+    };
+
+    {
+      Object.freeze(eventResponderListener);
+    }
+
+    return eventResponderListener;
+  }
+
+  var HasEffect =
+  /* */
+  1; // Represents the phase in which the effect (not the clean-up) fires.
+
+  var Layout =
+  /*    */
+  2;
+  var Passive$1 =
+  /*   */
+  4;
+
+  var ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher,
+      ReactCurrentBatchConfig$1 = ReactSharedInternals.ReactCurrentBatchConfig;
+  var didWarnAboutMismatchedHooksForComponent;
+
+  {
+    didWarnAboutMismatchedHooksForComponent = new Set();
+  }
+
+  // These are set right before calling the component.
+  var renderExpirationTime = NoWork; // The work-in-progress fiber. I've named it differently to distinguish it from
+  // the work-in-progress hook.
+
+  var currentlyRenderingFiber$1 = null; // Hooks are stored as a linked list on the fiber's memoizedState field. The
+  // current hook list is the list that belongs to the current fiber. The
+  // work-in-progress hook list is a new list that will be added to the
+  // work-in-progress fiber.
+
+  var currentHook = null;
+  var workInProgressHook = null; // Whether an update was scheduled at any point during the render phase. This
+  // does not get reset if we do another render pass; only when we're completely
+  // finished evaluating this component. This is an optimization so we know
+  // whether we need to clear render phase updates after a throw.
+
+  var didScheduleRenderPhaseUpdate = false;
+  var RE_RENDER_LIMIT = 25; // In DEV, this is the name of the currently executing primitive hook
+
+  var currentHookNameInDev = null; // In DEV, this list ensures that hooks are called in the same order between renders.
+  // The list stores the order of hooks used during the initial render (mount).
+  // Subsequent renders (updates) reference this list.
+
+  var hookTypesDev = null;
+  var hookTypesUpdateIndexDev = -1; // In DEV, this tracks whether currently rendering component needs to ignore
+  // the dependencies for Hooks that need them (e.g. useEffect or useMemo).
+  // When true, such Hooks will always be "remounted". Only used during hot reload.
+
+  var ignorePreviousDependencies = false;
+
+  function mountHookTypesDev() {
+    {
+      var hookName = currentHookNameInDev;
+
+      if (hookTypesDev === null) {
+        hookTypesDev = [hookName];
+      } else {
+        hookTypesDev.push(hookName);
+      }
+    }
+  }
+
+  function updateHookTypesDev() {
+    {
+      var hookName = currentHookNameInDev;
+
+      if (hookTypesDev !== null) {
+        hookTypesUpdateIndexDev++;
+
+        if (hookTypesDev[hookTypesUpdateIndexDev] !== hookName) {
+          warnOnHookMismatchInDev(hookName);
+        }
+      }
+    }
+  }
+
+  function checkDepsAreArrayDev(deps) {
+    {
+      if (deps !== undefined && deps !== null && !Array.isArray(deps)) {
+        // Verify deps, but only on mount to avoid extra checks.
+        // It's unlikely their type would change as usually you define them inline.
+        error('%s received a final argument that is not an array (instead, received `%s`). When ' + 'specified, the final argument must be an array.', currentHookNameInDev, typeof deps);
+      }
+    }
+  }
+
+  function warnOnHookMismatchInDev(currentHookName) {
+    {
+      var componentName = getComponentName(currentlyRenderingFiber$1.type);
+
+      if (!didWarnAboutMismatchedHooksForComponent.has(componentName)) {
+        didWarnAboutMismatchedHooksForComponent.add(componentName);
+
+        if (hookTypesDev !== null) {
+          var table = '';
+          var secondColumnStart = 30;
+
+          for (var i = 0; i <= hookTypesUpdateIndexDev; i++) {
+            var oldHookName = hookTypesDev[i];
+            var newHookName = i === hookTypesUpdateIndexDev ? currentHookName : oldHookName;
+            var row = i + 1 + ". " + oldHookName; // Extra space so second column lines up
+            // lol @ IE not supporting String#repeat
+
+            while (row.length < secondColumnStart) {
+              row += ' ';
+            }
+
+            row += newHookName + '\n';
+            table += row;
+          }
+
+          error('React has detected a change in the order of Hooks called by %s. ' + 'This will lead to bugs and errors if not fixed. ' + 'For more information, read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' + '   Previous render            Next render\n' + '   ------------------------------------------------------\n' + '%s' + '   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n', componentName, table);
+        }
+      }
+    }
+  }
+
+  function throwInvalidHookError() {
+    {
+      {
+        throw Error( "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem." );
+      }
+    }
+  }
+
+  function areHookInputsEqual(nextDeps, prevDeps) {
+    {
+      if (ignorePreviousDependencies) {
+        // Only true when this component is being hot reloaded.
+        return false;
+      }
+    }
+
+    if (prevDeps === null) {
+      {
+        error('%s received a final argument during this render, but not during ' + 'the previous render. Even though the final argument is optional, ' + 'its type cannot change between renders.', currentHookNameInDev);
+      }
+
+      return false;
+    }
+
+    {
+      // Don't bother comparing lengths in prod because these arrays should be
+      // passed inline.
+      if (nextDeps.length !== prevDeps.length) {
+        error('The final argument passed to %s changed size between renders. The ' + 'order and size of this array must remain constant.\n\n' + 'Previous: %s\n' + 'Incoming: %s', currentHookNameInDev, "[" + prevDeps.join(', ') + "]", "[" + nextDeps.join(', ') + "]");
+      }
+    }
+
+    for (var i = 0; i < prevDeps.length && i < nextDeps.length; i++) {
+      if (objectIs(nextDeps[i], prevDeps[i])) {
+        continue;
+      }
+
+      return false;
+    }
+
+    return true;
+  }
+
+  function renderWithHooks(current, workInProgress, Component, props, secondArg, nextRenderExpirationTime) {
+    renderExpirationTime = nextRenderExpirationTime;
+    currentlyRenderingFiber$1 = workInProgress;
+
+    {
+      hookTypesDev = current !== null ? current._debugHookTypes : null;
+      hookTypesUpdateIndexDev = -1; // Used for hot reloading:
+
+      ignorePreviousDependencies = current !== null && current.type !== workInProgress.type;
+    }
+
+    workInProgress.memoizedState = null;
+    workInProgress.updateQueue = null;
+    workInProgress.expirationTime = NoWork; // The following should have already been reset
+    // currentHook = null;
+    // workInProgressHook = null;
+    // didScheduleRenderPhaseUpdate = false;
+    // TODO Warn if no hooks are used at all during mount, then some are used during update.
+    // Currently we will identify the update render as a mount because memoizedState === null.
+    // This is tricky because it's valid for certain types of components (e.g. React.lazy)
+    // Using memoizedState to differentiate between mount/update only works if at least one stateful hook is used.
+    // Non-stateful hooks (e.g. context) don't get added to memoizedState,
+    // so memoizedState would be null during updates and mounts.
+
+    {
+      if (current !== null && current.memoizedState !== null) {
+        ReactCurrentDispatcher.current = HooksDispatcherOnUpdateInDEV;
+      } else if (hookTypesDev !== null) {
+        // This dispatcher handles an edge case where a component is updating,
+        // but no stateful hooks have been used.
+        // We want to match the production code behavior (which will use HooksDispatcherOnMount),
+        // but with the extra DEV validation to ensure hooks ordering hasn't changed.
+        // This dispatcher does that.
+        ReactCurrentDispatcher.current = HooksDispatcherOnMountWithHookTypesInDEV;
+      } else {
+        ReactCurrentDispatcher.current = HooksDispatcherOnMountInDEV;
+      }
+    }
+
+    var children = Component(props, secondArg); // Check if there was a render phase update
+
+    if (workInProgress.expirationTime === renderExpirationTime) {
+      // Keep rendering in a loop for as long as render phase updates continue to
+      // be scheduled. Use a counter to prevent infinite loops.
+      var numberOfReRenders = 0;
+
+      do {
+        workInProgress.expirationTime = NoWork;
+
+        if (!(numberOfReRenders < RE_RENDER_LIMIT)) {
+          {
+            throw Error( "Too many re-renders. React limits the number of renders to prevent an infinite loop." );
+          }
+        }
+
+        numberOfReRenders += 1;
+
+        {
+          // Even when hot reloading, allow dependencies to stabilize
+          // after first render to prevent infinite render phase updates.
+          ignorePreviousDependencies = false;
+        } // Start over from the beginning of the list
+
+
+        currentHook = null;
+        workInProgressHook = null;
+        workInProgress.updateQueue = null;
+
+        {
+          // Also validate hook order for cascading updates.
+          hookTypesUpdateIndexDev = -1;
+        }
+
+        ReactCurrentDispatcher.current =  HooksDispatcherOnRerenderInDEV ;
+        children = Component(props, secondArg);
+      } while (workInProgress.expirationTime === renderExpirationTime);
+    } // We can assume the previous dispatcher is always this one, since we set it
+    // at the beginning of the render phase and there's no re-entrancy.
+
+
+    ReactCurrentDispatcher.current = ContextOnlyDispatcher;
+
+    {
+      workInProgress._debugHookTypes = hookTypesDev;
+    } // This check uses currentHook so that it works the same in DEV and prod bundles.
+    // hookTypesDev could catch more cases (e.g. context) but only in DEV bundles.
+
+
+    var didRenderTooFewHooks = currentHook !== null && currentHook.next !== null;
+    renderExpirationTime = NoWork;
+    currentlyRenderingFiber$1 = null;
+    currentHook = null;
+    workInProgressHook = null;
+
+    {
+      currentHookNameInDev = null;
+      hookTypesDev = null;
+      hookTypesUpdateIndexDev = -1;
+    }
+
+    didScheduleRenderPhaseUpdate = false;
+
+    if (!!didRenderTooFewHooks) {
+      {
+        throw Error( "Rendered fewer hooks than expected. This may be caused by an accidental early return statement." );
+      }
+    }
+
+    return children;
+  }
+  function bailoutHooks(current, workInProgress, expirationTime) {
+    workInProgress.updateQueue = current.updateQueue;
+    workInProgress.effectTag &= ~(Passive | Update);
+
+    if (current.expirationTime <= expirationTime) {
+      current.expirationTime = NoWork;
+    }
+  }
+  function resetHooksAfterThrow() {
+    // We can assume the previous dispatcher is always this one, since we set it
+    // at the beginning of the render phase and there's no re-entrancy.
+    ReactCurrentDispatcher.current = ContextOnlyDispatcher;
+
+    if (didScheduleRenderPhaseUpdate) {
+      // There were render phase updates. These are only valid for this render
+      // phase, which we are now aborting. Remove the updates from the queues so
+      // they do not persist to the next render. Do not remove updates from hooks
+      // that weren't processed.
+      //
+      // Only reset the updates from the queue if it has a clone. If it does
+      // not have a clone, that means it wasn't processed, and the updates were
+      // scheduled before we entered the render phase.
+      var hook = currentlyRenderingFiber$1.memoizedState;
+
+      while (hook !== null) {
+        var queue = hook.queue;
+
+        if (queue !== null) {
+          queue.pending = null;
+        }
+
+        hook = hook.next;
+      }
+    }
+
+    renderExpirationTime = NoWork;
+    currentlyRenderingFiber$1 = null;
+    currentHook = null;
+    workInProgressHook = null;
+
+    {
+      hookTypesDev = null;
+      hookTypesUpdateIndexDev = -1;
+      currentHookNameInDev = null;
+    }
+
+    didScheduleRenderPhaseUpdate = false;
+  }
+
+  function mountWorkInProgressHook() {
+    var hook = {
+      memoizedState: null,
+      baseState: null,
+      baseQueue: null,
+      queue: null,
+      next: null
+    };
+
+    if (workInProgressHook === null) {
+      // This is the first hook in the list
+      currentlyRenderingFiber$1.memoizedState = workInProgressHook = hook;
+    } else {
+      // Append to the end of the list
+      workInProgressHook = workInProgressHook.next = hook;
+    }
+
+    return workInProgressHook;
+  }
+
+  function updateWorkInProgressHook() {
+    // This function is used both for updates and for re-renders triggered by a
+    // render phase update. It assumes there is either a current hook we can
+    // clone, or a work-in-progress hook from a previous render pass that we can
+    // use as a base. When we reach the end of the base list, we must switch to
+    // the dispatcher used for mounts.
+    var nextCurrentHook;
+
+    if (currentHook === null) {
+      var current = currentlyRenderingFiber$1.alternate;
+
+      if (current !== null) {
+        nextCurrentHook = current.memoizedState;
+      } else {
+        nextCurrentHook = null;
+      }
+    } else {
+      nextCurrentHook = currentHook.next;
+    }
+
+    var nextWorkInProgressHook;
+
+    if (workInProgressHook === null) {
+      nextWorkInProgressHook = currentlyRenderingFiber$1.memoizedState;
+    } else {
+      nextWorkInProgressHook = workInProgressHook.next;
+    }
+
+    if (nextWorkInProgressHook !== null) {
+      // There's already a work-in-progress. Reuse it.
+      workInProgressHook = nextWorkInProgressHook;
+      nextWorkInProgressHook = workInProgressHook.next;
+      currentHook = nextCurrentHook;
+    } else {
+      // Clone from the current hook.
+      if (!(nextCurrentHook !== null)) {
+        {
+          throw Error( "Rendered more hooks than during the previous render." );
+        }
+      }
+
+      currentHook = nextCurrentHook;
+      var newHook = {
+        memoizedState: currentHook.memoizedState,
+        baseState: currentHook.baseState,
+        baseQueue: currentHook.baseQueue,
+        queue: currentHook.queue,
+        next: null
+      };
+
+      if (workInProgressHook === null) {
+        // This is the first hook in the list.
+        currentlyRenderingFiber$1.memoizedState = workInProgressHook = newHook;
+      } else {
+        // Append to the end of the list.
+        workInProgressHook = workInProgressHook.next = newHook;
+      }
+    }
+
+    return workInProgressHook;
+  }
+
+  function createFunctionComponentUpdateQueue() {
+    return {
+      lastEffect: null
+    };
+  }
+
+  function basicStateReducer(state, action) {
+    // $FlowFixMe: Flow doesn't like mixed types
+    return typeof action === 'function' ? action(state) : action;
+  }
+
+  function mountReducer(reducer, initialArg, init) {
+    var hook = mountWorkInProgressHook();
+    var initialState;
+
+    if (init !== undefined) {
+      initialState = init(initialArg);
+    } else {
+      initialState = initialArg;
+    }
+
+    hook.memoizedState = hook.baseState = initialState;
+    var queue = hook.queue = {
+      pending: null,
+      dispatch: null,
+      lastRenderedReducer: reducer,
+      lastRenderedState: initialState
+    };
+    var dispatch = queue.dispatch = dispatchAction.bind(null, currentlyRenderingFiber$1, queue);
+    return [hook.memoizedState, dispatch];
+  }
+
+  function updateReducer(reducer, initialArg, init) {
+    var hook = updateWorkInProgressHook();
+    var queue = hook.queue;
+
+    if (!(queue !== null)) {
+      {
+        throw Error( "Should have a queue. This is likely a bug in React. Please file an issue." );
+      }
+    }
+
+    queue.lastRenderedReducer = reducer;
+    var current = currentHook; // The last rebase update that is NOT part of the base state.
+
+    var baseQueue = current.baseQueue; // The last pending update that hasn't been processed yet.
+
+    var pendingQueue = queue.pending;
+
+    if (pendingQueue !== null) {
+      // We have new updates that haven't been processed yet.
+      // We'll add them to the base queue.
+      if (baseQueue !== null) {
+        // Merge the pending queue and the base queue.
+        var baseFirst = baseQueue.next;
+        var pendingFirst = pendingQueue.next;
+        baseQueue.next = pendingFirst;
+        pendingQueue.next = baseFirst;
+      }
+
+      current.baseQueue = baseQueue = pendingQueue;
+      queue.pending = null;
+    }
+
+    if (baseQueue !== null) {
+      // We have a queue to process.
+      var first = baseQueue.next;
+      var newState = current.baseState;
+      var newBaseState = null;
+      var newBaseQueueFirst = null;
+      var newBaseQueueLast = null;
+      var update = first;
+
+      do {
+        var updateExpirationTime = update.expirationTime;
+
+        if (updateExpirationTime < renderExpirationTime) {
+          // Priority is insufficient. Skip this update. If this is the first
+          // skipped update, the previous update/state is the new base
+          // update/state.
+          var clone = {
+            expirationTime: update.expirationTime,
+            suspenseConfig: update.suspenseConfig,
+            action: update.action,
+            eagerReducer: update.eagerReducer,
+            eagerState: update.eagerState,
+            next: null
+          };
+
+          if (newBaseQueueLast === null) {
+            newBaseQueueFirst = newBaseQueueLast = clone;
+            newBaseState = newState;
+          } else {
+            newBaseQueueLast = newBaseQueueLast.next = clone;
+          } // Update the remaining priority in the queue.
+
+
+          if (updateExpirationTime > currentlyRenderingFiber$1.expirationTime) {
+            currentlyRenderingFiber$1.expirationTime = updateExpirationTime;
+            markUnprocessedUpdateTime(updateExpirationTime);
+          }
+        } else {
+          // This update does have sufficient priority.
+          if (newBaseQueueLast !== null) {
+            var _clone = {
+              expirationTime: Sync,
+              // This update is going to be committed so we never want uncommit it.
+              suspenseConfig: update.suspenseConfig,
+              action: update.action,
+              eagerReducer: update.eagerReducer,
+              eagerState: update.eagerState,
+              next: null
+            };
+            newBaseQueueLast = newBaseQueueLast.next = _clone;
+          } // Mark the event time of this update as relevant to this render pass.
+          // TODO: This should ideally use the true event time of this update rather than
+          // its priority which is a derived and not reverseable value.
+          // TODO: We should skip this update if it was already committed but currently
+          // we have no way of detecting the difference between a committed and suspended
+          // update here.
+
+
+          markRenderEventTimeAndConfig(updateExpirationTime, update.suspenseConfig); // Process this update.
+
+          if (update.eagerReducer === reducer) {
+            // If this update was processed eagerly, and its reducer matches the
+            // current reducer, we can use the eagerly computed state.
+            newState = update.eagerState;
+          } else {
+            var action = update.action;
+            newState = reducer(newState, action);
+          }
+        }
+
+        update = update.next;
+      } while (update !== null && update !== first);
+
+      if (newBaseQueueLast === null) {
+        newBaseState = newState;
+      } else {
+        newBaseQueueLast.next = newBaseQueueFirst;
+      } // Mark that the fiber performed work, but only if the new state is
+      // different from the current state.
+
+
+      if (!objectIs(newState, hook.memoizedState)) {
+        markWorkInProgressReceivedUpdate();
+      }
+
+      hook.memoizedState = newState;
+      hook.baseState = newBaseState;
+      hook.baseQueue = newBaseQueueLast;
+      queue.lastRenderedState = newState;
+    }
+
+    var dispatch = queue.dispatch;
+    return [hook.memoizedState, dispatch];
+  }
+
+  function rerenderReducer(reducer, initialArg, init) {
+    var hook = updateWorkInProgressHook();
+    var queue = hook.queue;
+
+    if (!(queue !== null)) {
+      {
+        throw Error( "Should have a queue. This is likely a bug in React. Please file an issue." );
+      }
+    }
+
+    queue.lastRenderedReducer = reducer; // This is a re-render. Apply the new render phase updates to the previous
+    // work-in-progress hook.
+
+    var dispatch = queue.dispatch;
+    var lastRenderPhaseUpdate = queue.pending;
+    var newState = hook.memoizedState;
+
+    if (lastRenderPhaseUpdate !== null) {
+      // The queue doesn't persist past this render pass.
+      queue.pending = null;
+      var firstRenderPhaseUpdate = lastRenderPhaseUpdate.next;
+      var update = firstRenderPhaseUpdate;
+
+      do {
+        // Process this render phase update. We don't have to check the
+        // priority because it will always be the same as the current
+        // render's.
+        var action = update.action;
+        newState = reducer(newState, action);
+        update = update.next;
+      } while (update !== firstRenderPhaseUpdate); // Mark that the fiber performed work, but only if the new state is
+      // different from the current state.
+
+
+      if (!objectIs(newState, hook.memoizedState)) {
+        markWorkInProgressReceivedUpdate();
+      }
+
+      hook.memoizedState = newState; // Don't persist the state accumulated from the render phase updates to
+      // the base state unless the queue is empty.
+      // TODO: Not sure if this is the desired semantics, but it's what we
+      // do for gDSFP. I can't remember why.
+
+      if (hook.baseQueue === null) {
+        hook.baseState = newState;
+      }
+
+      queue.lastRenderedState = newState;
+    }
+
+    return [newState, dispatch];
+  }
+
+  function mountState(initialState) {
+    var hook = mountWorkInProgressHook();
+
+    if (typeof initialState === 'function') {
+      // $FlowFixMe: Flow doesn't like mixed types
+      initialState = initialState();
+    }
+
+    hook.memoizedState = hook.baseState = initialState;
+    var queue = hook.queue = {
+      pending: null,
+      dispatch: null,
+      lastRenderedReducer: basicStateReducer,
+      lastRenderedState: initialState
+    };
+    var dispatch = queue.dispatch = dispatchAction.bind(null, currentlyRenderingFiber$1, queue);
+    return [hook.memoizedState, dispatch];
+  }
+
+  function updateState(initialState) {
+    return updateReducer(basicStateReducer);
+  }
+
+  function rerenderState(initialState) {
+    return rerenderReducer(basicStateReducer);
+  }
+
+  function pushEffect(tag, create, destroy, deps) {
+    var effect = {
+      tag: tag,
+      create: create,
+      destroy: destroy,
+      deps: deps,
+      // Circular
+      next: null
+    };
+    var componentUpdateQueue = currentlyRenderingFiber$1.updateQueue;
+
+    if (componentUpdateQueue === null) {
+      componentUpdateQueue = createFunctionComponentUpdateQueue();
+      currentlyRenderingFiber$1.updateQueue = componentUpdateQueue;
+      componentUpdateQueue.lastEffect = effect.next = effect;
+    } else {
+      var lastEffect = componentUpdateQueue.lastEffect;
+
+      if (lastEffect === null) {
+        componentUpdateQueue.lastEffect = effect.next = effect;
+      } else {
+        var firstEffect = lastEffect.next;
+        lastEffect.next = effect;
+        effect.next = firstEffect;
+        componentUpdateQueue.lastEffect = effect;
+      }
+    }
+
+    return effect;
+  }
+
+  function mountRef(initialValue) {
+    var hook = mountWorkInProgressHook();
+    var ref = {
+      current: initialValue
+    };
+
+    {
+      Object.seal(ref);
+    }
+
+    hook.memoizedState = ref;
+    return ref;
+  }
+
+  function updateRef(initialValue) {
+    var hook = updateWorkInProgressHook();
+    return hook.memoizedState;
+  }
+
+  function mountEffectImpl(fiberEffectTag, hookEffectTag, create, deps) {
+    var hook = mountWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    currentlyRenderingFiber$1.effectTag |= fiberEffectTag;
+    hook.memoizedState = pushEffect(HasEffect | hookEffectTag, create, undefined, nextDeps);
+  }
+
+  function updateEffectImpl(fiberEffectTag, hookEffectTag, create, deps) {
+    var hook = updateWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    var destroy = undefined;
+
+    if (currentHook !== null) {
+      var prevEffect = currentHook.memoizedState;
+      destroy = prevEffect.destroy;
+
+      if (nextDeps !== null) {
+        var prevDeps = prevEffect.deps;
+
+        if (areHookInputsEqual(nextDeps, prevDeps)) {
+          pushEffect(hookEffectTag, create, destroy, nextDeps);
+          return;
+        }
+      }
+    }
+
+    currentlyRenderingFiber$1.effectTag |= fiberEffectTag;
+    hook.memoizedState = pushEffect(HasEffect | hookEffectTag, create, destroy, nextDeps);
+  }
+
+  function mountEffect(create, deps) {
+    {
+      // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+      if ('undefined' !== typeof jest) {
+        warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber$1);
+      }
+    }
+
+    return mountEffectImpl(Update | Passive, Passive$1, create, deps);
+  }
+
+  function updateEffect(create, deps) {
+    {
+      // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+      if ('undefined' !== typeof jest) {
+        warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber$1);
+      }
+    }
+
+    return updateEffectImpl(Update | Passive, Passive$1, create, deps);
+  }
+
+  function mountLayoutEffect(create, deps) {
+    return mountEffectImpl(Update, Layout, create, deps);
+  }
+
+  function updateLayoutEffect(create, deps) {
+    return updateEffectImpl(Update, Layout, create, deps);
+  }
+
+  function imperativeHandleEffect(create, ref) {
+    if (typeof ref === 'function') {
+      var refCallback = ref;
+
+      var _inst = create();
+
+      refCallback(_inst);
+      return function () {
+        refCallback(null);
+      };
+    } else if (ref !== null && ref !== undefined) {
+      var refObject = ref;
+
+      {
+        if (!refObject.hasOwnProperty('current')) {
+          error('Expected useImperativeHandle() first argument to either be a ' + 'ref callback or React.createRef() object. Instead received: %s.', 'an object with keys {' + Object.keys(refObject).join(', ') + '}');
+        }
+      }
+
+      var _inst2 = create();
+
+      refObject.current = _inst2;
+      return function () {
+        refObject.current = null;
+      };
+    }
+  }
+
+  function mountImperativeHandle(ref, create, deps) {
+    {
+      if (typeof create !== 'function') {
+        error('Expected useImperativeHandle() second argument to be a function ' + 'that creates a handle. Instead received: %s.', create !== null ? typeof create : 'null');
+      }
+    } // TODO: If deps are provided, should we skip comparing the ref itself?
+
+
+    var effectDeps = deps !== null && deps !== undefined ? deps.concat([ref]) : null;
+    return mountEffectImpl(Update, Layout, imperativeHandleEffect.bind(null, create, ref), effectDeps);
+  }
+
+  function updateImperativeHandle(ref, create, deps) {
+    {
+      if (typeof create !== 'function') {
+        error('Expected useImperativeHandle() second argument to be a function ' + 'that creates a handle. Instead received: %s.', create !== null ? typeof create : 'null');
+      }
+    } // TODO: If deps are provided, should we skip comparing the ref itself?
+
+
+    var effectDeps = deps !== null && deps !== undefined ? deps.concat([ref]) : null;
+    return updateEffectImpl(Update, Layout, imperativeHandleEffect.bind(null, create, ref), effectDeps);
+  }
+
+  function mountDebugValue(value, formatterFn) {// This hook is normally a no-op.
+    // The react-debug-hooks package injects its own implementation
+    // so that e.g. DevTools can display custom hook values.
+  }
+
+  var updateDebugValue = mountDebugValue;
+
+  function mountCallback(callback, deps) {
+    var hook = mountWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    hook.memoizedState = [callback, nextDeps];
+    return callback;
+  }
+
+  function updateCallback(callback, deps) {
+    var hook = updateWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    var prevState = hook.memoizedState;
+
+    if (prevState !== null) {
+      if (nextDeps !== null) {
+        var prevDeps = prevState[1];
+
+        if (areHookInputsEqual(nextDeps, prevDeps)) {
+          return prevState[0];
+        }
+      }
+    }
+
+    hook.memoizedState = [callback, nextDeps];
+    return callback;
+  }
+
+  function mountMemo(nextCreate, deps) {
+    var hook = mountWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    var nextValue = nextCreate();
+    hook.memoizedState = [nextValue, nextDeps];
+    return nextValue;
+  }
+
+  function updateMemo(nextCreate, deps) {
+    var hook = updateWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    var prevState = hook.memoizedState;
+
+    if (prevState !== null) {
+      // Assume these are defined. If they're not, areHookInputsEqual will warn.
+      if (nextDeps !== null) {
+        var prevDeps = prevState[1];
+
+        if (areHookInputsEqual(nextDeps, prevDeps)) {
+          return prevState[0];
+        }
+      }
+    }
+
+    var nextValue = nextCreate();
+    hook.memoizedState = [nextValue, nextDeps];
+    return nextValue;
+  }
+
+  function mountDeferredValue(value, config) {
+    var _mountState = mountState(value),
+        prevValue = _mountState[0],
+        setValue = _mountState[1];
+
+    mountEffect(function () {
+      var previousConfig = ReactCurrentBatchConfig$1.suspense;
+      ReactCurrentBatchConfig$1.suspense = config === undefined ? null : config;
+
+      try {
+        setValue(value);
+      } finally {
+        ReactCurrentBatchConfig$1.suspense = previousConfig;
+      }
+    }, [value, config]);
+    return prevValue;
+  }
+
+  function updateDeferredValue(value, config) {
+    var _updateState = updateState(),
+        prevValue = _updateState[0],
+        setValue = _updateState[1];
+
+    updateEffect(function () {
+      var previousConfig = ReactCurrentBatchConfig$1.suspense;
+      ReactCurrentBatchConfig$1.suspense = config === undefined ? null : config;
+
+      try {
+        setValue(value);
+      } finally {
+        ReactCurrentBatchConfig$1.suspense = previousConfig;
+      }
+    }, [value, config]);
+    return prevValue;
+  }
+
+  function rerenderDeferredValue(value, config) {
+    var _rerenderState = rerenderState(),
+        prevValue = _rerenderState[0],
+        setValue = _rerenderState[1];
+
+    updateEffect(function () {
+      var previousConfig = ReactCurrentBatchConfig$1.suspense;
+      ReactCurrentBatchConfig$1.suspense = config === undefined ? null : config;
+
+      try {
+        setValue(value);
+      } finally {
+        ReactCurrentBatchConfig$1.suspense = previousConfig;
+      }
+    }, [value, config]);
+    return prevValue;
+  }
+
+  function startTransition(setPending, config, callback) {
+    var priorityLevel = getCurrentPriorityLevel();
+    runWithPriority$1(priorityLevel < UserBlockingPriority$1 ? UserBlockingPriority$1 : priorityLevel, function () {
+      setPending(true);
+    });
+    runWithPriority$1(priorityLevel > NormalPriority ? NormalPriority : priorityLevel, function () {
+      var previousConfig = ReactCurrentBatchConfig$1.suspense;
+      ReactCurrentBatchConfig$1.suspense = config === undefined ? null : config;
+
+      try {
+        setPending(false);
+        callback();
+      } finally {
+        ReactCurrentBatchConfig$1.suspense = previousConfig;
+      }
+    });
+  }
+
+  function mountTransition(config) {
+    var _mountState2 = mountState(false),
+        isPending = _mountState2[0],
+        setPending = _mountState2[1];
+
+    var start = mountCallback(startTransition.bind(null, setPending, config), [setPending, config]);
+    return [start, isPending];
+  }
+
+  function updateTransition(config) {
+    var _updateState2 = updateState(),
+        isPending = _updateState2[0],
+        setPending = _updateState2[1];
+
+    var start = updateCallback(startTransition.bind(null, setPending, config), [setPending, config]);
+    return [start, isPending];
+  }
+
+  function rerenderTransition(config) {
+    var _rerenderState2 = rerenderState(),
+        isPending = _rerenderState2[0],
+        setPending = _rerenderState2[1];
+
+    var start = updateCallback(startTransition.bind(null, setPending, config), [setPending, config]);
+    return [start, isPending];
+  }
+
+  function dispatchAction(fiber, queue, action) {
+    {
+      if (typeof arguments[3] === 'function') {
+        error("State updates from the useState() and useReducer() Hooks don't support the " + 'second callback argument. To execute a side effect after ' + 'rendering, declare it in the component body with useEffect().');
+      }
+    }
+
+    var currentTime = requestCurrentTimeForUpdate();
+    var suspenseConfig = requestCurrentSuspenseConfig();
+    var expirationTime = computeExpirationForFiber(currentTime, fiber, suspenseConfig);
+    var update = {
+      expirationTime: expirationTime,
+      suspenseConfig: suspenseConfig,
+      action: action,
+      eagerReducer: null,
+      eagerState: null,
+      next: null
+    };
+
+    {
+      update.priority = getCurrentPriorityLevel();
+    } // Append the update to the end of the list.
+
+
+    var pending = queue.pending;
+
+    if (pending === null) {
+      // This is the first update. Create a circular list.
+      update.next = update;
+    } else {
+      update.next = pending.next;
+      pending.next = update;
+    }
+
+    queue.pending = update;
+    var alternate = fiber.alternate;
+
+    if (fiber === currentlyRenderingFiber$1 || alternate !== null && alternate === currentlyRenderingFiber$1) {
+      // This is a render phase update. Stash it in a lazily-created map of
+      // queue -> linked list of updates. After this render pass, we'll restart
+      // and apply the stashed updates on top of the work-in-progress hook.
+      didScheduleRenderPhaseUpdate = true;
+      update.expirationTime = renderExpirationTime;
+      currentlyRenderingFiber$1.expirationTime = renderExpirationTime;
+    } else {
+      if (fiber.expirationTime === NoWork && (alternate === null || alternate.expirationTime === NoWork)) {
+        // The queue is currently empty, which means we can eagerly compute the
+        // next state before entering the render phase. If the new state is the
+        // same as the current state, we may be able to bail out entirely.
+        var lastRenderedReducer = queue.lastRenderedReducer;
+
+        if (lastRenderedReducer !== null) {
+          var prevDispatcher;
+
+          {
+            prevDispatcher = ReactCurrentDispatcher.current;
+            ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+          }
+
+          try {
+            var currentState = queue.lastRenderedState;
+            var eagerState = lastRenderedReducer(currentState, action); // Stash the eagerly computed state, and the reducer used to compute
+            // it, on the update object. If the reducer hasn't changed by the
+            // time we enter the render phase, then the eager state can be used
+            // without calling the reducer again.
+
+            update.eagerReducer = lastRenderedReducer;
+            update.eagerState = eagerState;
+
+            if (objectIs(eagerState, currentState)) {
+              // Fast path. We can bail out without scheduling React to re-render.
+              // It's still possible that we'll need to rebase this update later,
+              // if the component re-renders for a different reason and by that
+              // time the reducer has changed.
+              return;
+            }
+          } catch (error) {// Suppress the error. It will throw again in the render phase.
+          } finally {
+            {
+              ReactCurrentDispatcher.current = prevDispatcher;
+            }
+          }
+        }
+      }
+
+      {
+        // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+        if ('undefined' !== typeof jest) {
+          warnIfNotScopedWithMatchingAct(fiber);
+          warnIfNotCurrentlyActingUpdatesInDev(fiber);
+        }
+      }
+
+      scheduleWork(fiber, expirationTime);
+    }
+  }
+
+  var ContextOnlyDispatcher = {
+    readContext: readContext,
+    useCallback: throwInvalidHookError,
+    useContext: throwInvalidHookError,
+    useEffect: throwInvalidHookError,
+    useImperativeHandle: throwInvalidHookError,
+    useLayoutEffect: throwInvalidHookError,
+    useMemo: throwInvalidHookError,
+    useReducer: throwInvalidHookError,
+    useRef: throwInvalidHookError,
+    useState: throwInvalidHookError,
+    useDebugValue: throwInvalidHookError,
+    useResponder: throwInvalidHookError,
+    useDeferredValue: throwInvalidHookError,
+    useTransition: throwInvalidHookError
+  };
+  var HooksDispatcherOnMountInDEV = null;
+  var HooksDispatcherOnMountWithHookTypesInDEV = null;
+  var HooksDispatcherOnUpdateInDEV = null;
+  var HooksDispatcherOnRerenderInDEV = null;
+  var InvalidNestedHooksDispatcherOnMountInDEV = null;
+  var InvalidNestedHooksDispatcherOnUpdateInDEV = null;
+  var InvalidNestedHooksDispatcherOnRerenderInDEV = null;
+
+  {
+    var warnInvalidContextAccess = function () {
+      error('Context can only be read while React is rendering. ' + 'In classes, you can read it in the render method or getDerivedStateFromProps. ' + 'In function components, you can read it directly in the function body, but not ' + 'inside Hooks like useReducer() or useMemo().');
+    };
+
+    var warnInvalidHookAccess = function () {
+      error('Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks. ' + 'You can only call Hooks at the top level of your React function. ' + 'For more information, see ' + 'https://fb.me/rules-of-hooks');
+    };
+
+    HooksDispatcherOnMountInDEV = {
+      readContext: function (context, observedBits) {
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        mountHookTypesDev();
+        checkDepsAreArrayDev(deps);
+        return mountCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        mountHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        mountHookTypesDev();
+        checkDepsAreArrayDev(deps);
+        return mountEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        mountHookTypesDev();
+        checkDepsAreArrayDev(deps);
+        return mountImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        mountHookTypesDev();
+        checkDepsAreArrayDev(deps);
+        return mountLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        mountHookTypesDev();
+        checkDepsAreArrayDev(deps);
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        mountHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        mountHookTypesDev();
+        return mountRef(initialValue);
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        mountHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountState(initialState);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        mountHookTypesDev();
+        return mountDebugValue();
+      },
+      useResponder: function (responder, props) {
+        currentHookNameInDev = 'useResponder';
+        mountHookTypesDev();
+        return createDeprecatedResponderListener(responder, props);
+      },
+      useDeferredValue: function (value, config) {
+        currentHookNameInDev = 'useDeferredValue';
+        mountHookTypesDev();
+        return mountDeferredValue(value, config);
+      },
+      useTransition: function (config) {
+        currentHookNameInDev = 'useTransition';
+        mountHookTypesDev();
+        return mountTransition(config);
+      }
+    };
+    HooksDispatcherOnMountWithHookTypesInDEV = {
+      readContext: function (context, observedBits) {
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        updateHookTypesDev();
+        return mountCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        updateHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        updateHookTypesDev();
+        return mountEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        updateHookTypesDev();
+        return mountImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        updateHookTypesDev();
+        return mountLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        updateHookTypesDev();
+        return mountRef(initialValue);
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountState(initialState);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        updateHookTypesDev();
+        return mountDebugValue();
+      },
+      useResponder: function (responder, props) {
+        currentHookNameInDev = 'useResponder';
+        updateHookTypesDev();
+        return createDeprecatedResponderListener(responder, props);
+      },
+      useDeferredValue: function (value, config) {
+        currentHookNameInDev = 'useDeferredValue';
+        updateHookTypesDev();
+        return mountDeferredValue(value, config);
+      },
+      useTransition: function (config) {
+        currentHookNameInDev = 'useTransition';
+        updateHookTypesDev();
+        return mountTransition(config);
+      }
+    };
+    HooksDispatcherOnUpdateInDEV = {
+      readContext: function (context, observedBits) {
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        updateHookTypesDev();
+        return updateCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        updateHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        updateHookTypesDev();
+        return updateEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        updateHookTypesDev();
+        return updateImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        updateHookTypesDev();
+        return updateLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        updateHookTypesDev();
+        return updateRef();
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateState(initialState);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        updateHookTypesDev();
+        return updateDebugValue();
+      },
+      useResponder: function (responder, props) {
+        currentHookNameInDev = 'useResponder';
+        updateHookTypesDev();
+        return createDeprecatedResponderListener(responder, props);
+      },
+      useDeferredValue: function (value, config) {
+        currentHookNameInDev = 'useDeferredValue';
+        updateHookTypesDev();
+        return updateDeferredValue(value, config);
+      },
+      useTransition: function (config) {
+        currentHookNameInDev = 'useTransition';
+        updateHookTypesDev();
+        return updateTransition(config);
+      }
+    };
+    HooksDispatcherOnRerenderInDEV = {
+      readContext: function (context, observedBits) {
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        updateHookTypesDev();
+        return updateCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        updateHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        updateHookTypesDev();
+        return updateEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        updateHookTypesDev();
+        return updateImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        updateHookTypesDev();
+        return updateLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnRerenderInDEV;
+
+        try {
+          return updateMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnRerenderInDEV;
+
+        try {
+          return rerenderReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        updateHookTypesDev();
+        return updateRef();
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnRerenderInDEV;
+
+        try {
+          return rerenderState(initialState);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        updateHookTypesDev();
+        return updateDebugValue();
+      },
+      useResponder: function (responder, props) {
+        currentHookNameInDev = 'useResponder';
+        updateHookTypesDev();
+        return createDeprecatedResponderListener(responder, props);
+      },
+      useDeferredValue: function (value, config) {
+        currentHookNameInDev = 'useDeferredValue';
+        updateHookTypesDev();
+        return rerenderDeferredValue(value, config);
+      },
+      useTransition: function (config) {
+        currentHookNameInDev = 'useTransition';
+        updateHookTypesDev();
+        return rerenderTransition(config);
+      }
+    };
+    InvalidNestedHooksDispatcherOnMountInDEV = {
+      readContext: function (context, observedBits) {
+        warnInvalidContextAccess();
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountRef(initialValue);
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountState(initialState);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountDebugValue();
+      },
+      useResponder: function (responder, props) {
+        currentHookNameInDev = 'useResponder';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return createDeprecatedResponderListener(responder, props);
+      },
+      useDeferredValue: function (value, config) {
+        currentHookNameInDev = 'useDeferredValue';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountDeferredValue(value, config);
+      },
+      useTransition: function (config) {
+        currentHookNameInDev = 'useTransition';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountTransition(config);
+      }
+    };
+    InvalidNestedHooksDispatcherOnUpdateInDEV = {
+      readContext: function (context, observedBits) {
+        warnInvalidContextAccess();
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateRef();
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateState(initialState);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateDebugValue();
+      },
+      useResponder: function (responder, props) {
+        currentHookNameInDev = 'useResponder';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return createDeprecatedResponderListener(responder, props);
+      },
+      useDeferredValue: function (value, config) {
+        currentHookNameInDev = 'useDeferredValue';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateDeferredValue(value, config);
+      },
+      useTransition: function (config) {
+        currentHookNameInDev = 'useTransition';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateTransition(config);
+      }
+    };
+    InvalidNestedHooksDispatcherOnRerenderInDEV = {
+      readContext: function (context, observedBits) {
+        warnInvalidContextAccess();
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return rerenderReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateRef();
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher.current;
+        ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return rerenderState(initialState);
+        } finally {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateDebugValue();
+      },
+      useResponder: function (responder, props) {
+        currentHookNameInDev = 'useResponder';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return createDeprecatedResponderListener(responder, props);
+      },
+      useDeferredValue: function (value, config) {
+        currentHookNameInDev = 'useDeferredValue';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return rerenderDeferredValue(value, config);
+      },
+      useTransition: function (config) {
+        currentHookNameInDev = 'useTransition';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return rerenderTransition(config);
+      }
+    };
+  }
+
+  var now$1 = unstable_now;
+  var commitTime = 0;
+  var profilerStartTime = -1;
+
+  function getCommitTime() {
+    return commitTime;
+  }
+
+  function recordCommitTime() {
+
+    commitTime = now$1();
+  }
+
+  function startProfilerTimer(fiber) {
+
+    profilerStartTime = now$1();
+
+    if (fiber.actualStartTime < 0) {
+      fiber.actualStartTime = now$1();
+    }
+  }
+
+  function stopProfilerTimerIfRunning(fiber) {
+
+    profilerStartTime = -1;
+  }
+
+  function stopProfilerTimerIfRunningAndRecordDelta(fiber, overrideBaseTime) {
+
+    if (profilerStartTime >= 0) {
+      var elapsedTime = now$1() - profilerStartTime;
+      fiber.actualDuration += elapsedTime;
+
+      if (overrideBaseTime) {
+        fiber.selfBaseDuration = elapsedTime;
+      }
+
+      profilerStartTime = -1;
+    }
+  }
+
+  // This may have been an insertion or a hydration.
+
+  var hydrationParentFiber = null;
+  var nextHydratableInstance = null;
+  var isHydrating = false;
+
+  function enterHydrationState(fiber) {
+
+    var parentInstance = fiber.stateNode.containerInfo;
+    nextHydratableInstance = getFirstHydratableChild(parentInstance);
+    hydrationParentFiber = fiber;
+    isHydrating = true;
+    return true;
+  }
+
+  function deleteHydratableInstance(returnFiber, instance) {
+    {
+      switch (returnFiber.tag) {
+        case HostRoot:
+          didNotHydrateContainerInstance(returnFiber.stateNode.containerInfo, instance);
+          break;
+
+        case HostComponent:
+          didNotHydrateInstance(returnFiber.type, returnFiber.memoizedProps, returnFiber.stateNode, instance);
+          break;
+      }
+    }
+
+    var childToDelete = createFiberFromHostInstanceForDeletion();
+    childToDelete.stateNode = instance;
+    childToDelete.return = returnFiber;
+    childToDelete.effectTag = Deletion; // This might seem like it belongs on progressedFirstDeletion. However,
+    // these children are not part of the reconciliation list of children.
+    // Even if we abort and rereconcile the children, that will try to hydrate
+    // again and the nodes are still in the host tree so these will be
+    // recreated.
+
+    if (returnFiber.lastEffect !== null) {
+      returnFiber.lastEffect.nextEffect = childToDelete;
+      returnFiber.lastEffect = childToDelete;
+    } else {
+      returnFiber.firstEffect = returnFiber.lastEffect = childToDelete;
+    }
+  }
+
+  function insertNonHydratedInstance(returnFiber, fiber) {
+    fiber.effectTag = fiber.effectTag & ~Hydrating | Placement;
+
+    {
+      switch (returnFiber.tag) {
+        case HostRoot:
+          {
+            var parentContainer = returnFiber.stateNode.containerInfo;
+
+            switch (fiber.tag) {
+              case HostComponent:
+                var type = fiber.type;
+                var props = fiber.pendingProps;
+                didNotFindHydratableContainerInstance(parentContainer, type);
+                break;
+
+              case HostText:
+                var text = fiber.pendingProps;
+                didNotFindHydratableContainerTextInstance(parentContainer, text);
+                break;
+            }
+
+            break;
+          }
+
+        case HostComponent:
+          {
+            var parentType = returnFiber.type;
+            var parentProps = returnFiber.memoizedProps;
+            var parentInstance = returnFiber.stateNode;
+
+            switch (fiber.tag) {
+              case HostComponent:
+                var _type = fiber.type;
+                var _props = fiber.pendingProps;
+                didNotFindHydratableInstance(parentType, parentProps, parentInstance, _type);
+                break;
+
+              case HostText:
+                var _text = fiber.pendingProps;
+                didNotFindHydratableTextInstance(parentType, parentProps, parentInstance, _text);
+                break;
+
+              case SuspenseComponent:
+                didNotFindHydratableSuspenseInstance(parentType, parentProps);
+                break;
+            }
+
+            break;
+          }
+
+        default:
+          return;
+      }
+    }
+  }
+
+  function tryHydrate(fiber, nextInstance) {
+    switch (fiber.tag) {
+      case HostComponent:
+        {
+          var type = fiber.type;
+          var props = fiber.pendingProps;
+          var instance = canHydrateInstance(nextInstance, type);
+
+          if (instance !== null) {
+            fiber.stateNode = instance;
+            return true;
+          }
+
+          return false;
+        }
+
+      case HostText:
+        {
+          var text = fiber.pendingProps;
+          var textInstance = canHydrateTextInstance(nextInstance, text);
+
+          if (textInstance !== null) {
+            fiber.stateNode = textInstance;
+            return true;
+          }
+
+          return false;
+        }
+
+      case SuspenseComponent:
+        {
+
+          return false;
+        }
+
+      default:
+        return false;
+    }
+  }
+
+  function tryToClaimNextHydratableInstance(fiber) {
+    if (!isHydrating) {
+      return;
+    }
+
+    var nextInstance = nextHydratableInstance;
+
+    if (!nextInstance) {
+      // Nothing to hydrate. Make it an insertion.
+      insertNonHydratedInstance(hydrationParentFiber, fiber);
+      isHydrating = false;
+      hydrationParentFiber = fiber;
+      return;
+    }
+
+    var firstAttemptedInstance = nextInstance;
+
+    if (!tryHydrate(fiber, nextInstance)) {
+      // If we can't hydrate this instance let's try the next one.
+      // We use this as a heuristic. It's based on intuition and not data so it
+      // might be flawed or unnecessary.
+      nextInstance = getNextHydratableSibling(firstAttemptedInstance);
+
+      if (!nextInstance || !tryHydrate(fiber, nextInstance)) {
+        // Nothing to hydrate. Make it an insertion.
+        insertNonHydratedInstance(hydrationParentFiber, fiber);
+        isHydrating = false;
+        hydrationParentFiber = fiber;
+        return;
+      } // We matched the next one, we'll now assume that the first one was
+      // superfluous and we'll delete it. Since we can't eagerly delete it
+      // we'll have to schedule a deletion. To do that, this node needs a dummy
+      // fiber associated with it.
+
+
+      deleteHydratableInstance(hydrationParentFiber, firstAttemptedInstance);
+    }
+
+    hydrationParentFiber = fiber;
+    nextHydratableInstance = getFirstHydratableChild(nextInstance);
+  }
+
+  function prepareToHydrateHostInstance(fiber, rootContainerInstance, hostContext) {
+
+    var instance = fiber.stateNode;
+    var updatePayload = hydrateInstance(instance, fiber.type, fiber.memoizedProps, rootContainerInstance, hostContext, fiber); // TODO: Type this specific to this type of component.
+
+    fiber.updateQueue = updatePayload; // If the update payload indicates that there is a change or if there
+    // is a new ref we mark this as an update.
+
+    if (updatePayload !== null) {
+      return true;
+    }
+
+    return false;
+  }
+
+  function prepareToHydrateHostTextInstance(fiber) {
+
+    var textInstance = fiber.stateNode;
+    var textContent = fiber.memoizedProps;
+    var shouldUpdate = hydrateTextInstance(textInstance, textContent, fiber);
+
+    {
+      if (shouldUpdate) {
+        // We assume that prepareToHydrateHostTextInstance is called in a context where the
+        // hydration parent is the parent host component of this host text.
+        var returnFiber = hydrationParentFiber;
+
+        if (returnFiber !== null) {
+          switch (returnFiber.tag) {
+            case HostRoot:
+              {
+                var parentContainer = returnFiber.stateNode.containerInfo;
+                didNotMatchHydratedContainerTextInstance(parentContainer, textInstance, textContent);
+                break;
+              }
+
+            case HostComponent:
+              {
+                var parentType = returnFiber.type;
+                var parentProps = returnFiber.memoizedProps;
+                var parentInstance = returnFiber.stateNode;
+                didNotMatchHydratedTextInstance(parentType, parentProps, parentInstance, textInstance, textContent);
+                break;
+              }
+          }
+        }
+      }
+    }
+
+    return shouldUpdate;
+  }
+
+  function skipPastDehydratedSuspenseInstance(fiber) {
+
+    var suspenseState = fiber.memoizedState;
+    var suspenseInstance = suspenseState !== null ? suspenseState.dehydrated : null;
+
+    if (!suspenseInstance) {
+      {
+        throw Error( "Expected to have a hydrated suspense instance. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+
+    return getNextHydratableInstanceAfterSuspenseInstance(suspenseInstance);
+  }
+
+  function popToNextHostParent(fiber) {
+    var parent = fiber.return;
+
+    while (parent !== null && parent.tag !== HostComponent && parent.tag !== HostRoot && parent.tag !== SuspenseComponent) {
+      parent = parent.return;
+    }
+
+    hydrationParentFiber = parent;
+  }
+
+  function popHydrationState(fiber) {
+
+    if (fiber !== hydrationParentFiber) {
+      // We're deeper than the current hydration context, inside an inserted
+      // tree.
+      return false;
+    }
+
+    if (!isHydrating) {
+      // If we're not currently hydrating but we're in a hydration context, then
+      // we were an insertion and now need to pop up reenter hydration of our
+      // siblings.
+      popToNextHostParent(fiber);
+      isHydrating = true;
+      return false;
+    }
+
+    var type = fiber.type; // If we have any remaining hydratable nodes, we need to delete them now.
+    // We only do this deeper than head and body since they tend to have random
+    // other nodes in them. We also ignore components with pure text content in
+    // side of them.
+    // TODO: Better heuristic.
+
+    if (fiber.tag !== HostComponent || type !== 'head' && type !== 'body' && !shouldSetTextContent(type, fiber.memoizedProps)) {
+      var nextInstance = nextHydratableInstance;
+
+      while (nextInstance) {
+        deleteHydratableInstance(fiber, nextInstance);
+        nextInstance = getNextHydratableSibling(nextInstance);
+      }
+    }
+
+    popToNextHostParent(fiber);
+
+    if (fiber.tag === SuspenseComponent) {
+      nextHydratableInstance = skipPastDehydratedSuspenseInstance(fiber);
+    } else {
+      nextHydratableInstance = hydrationParentFiber ? getNextHydratableSibling(fiber.stateNode) : null;
+    }
+
+    return true;
+  }
+
+  function resetHydrationState() {
+
+    hydrationParentFiber = null;
+    nextHydratableInstance = null;
+    isHydrating = false;
+  }
+
+  var ReactCurrentOwner$1 = ReactSharedInternals.ReactCurrentOwner;
+  var didReceiveUpdate = false;
+  var didWarnAboutBadClass;
+  var didWarnAboutModulePatternComponent;
+  var didWarnAboutContextTypeOnFunctionComponent;
+  var didWarnAboutGetDerivedStateOnFunctionComponent;
+  var didWarnAboutFunctionRefs;
+  var didWarnAboutReassigningProps;
+  var didWarnAboutRevealOrder;
+  var didWarnAboutTailOptions;
+
+  {
+    didWarnAboutBadClass = {};
+    didWarnAboutModulePatternComponent = {};
+    didWarnAboutContextTypeOnFunctionComponent = {};
+    didWarnAboutGetDerivedStateOnFunctionComponent = {};
+    didWarnAboutFunctionRefs = {};
+    didWarnAboutReassigningProps = false;
+    didWarnAboutRevealOrder = {};
+    didWarnAboutTailOptions = {};
+  }
+
+  function reconcileChildren(current, workInProgress, nextChildren, renderExpirationTime) {
+    if (current === null) {
+      // If this is a fresh new component that hasn't been rendered yet, we
+      // won't update its child set by applying minimal side-effects. Instead,
+      // we will add them all to the child before it gets rendered. That means
+      // we can optimize this reconciliation pass by not tracking side-effects.
+      workInProgress.child = mountChildFibers(workInProgress, null, nextChildren, renderExpirationTime);
+    } else {
+      // If the current child is the same as the work in progress, it means that
+      // we haven't yet started any work on these children. Therefore, we use
+      // the clone algorithm to create a copy of all the current children.
+      // If we had any progressed work already, that is invalid at this point so
+      // let's throw it out.
+      workInProgress.child = reconcileChildFibers(workInProgress, current.child, nextChildren, renderExpirationTime);
+    }
+  }
+
+  function forceUnmountCurrentAndReconcile(current, workInProgress, nextChildren, renderExpirationTime) {
+    // This function is fork of reconcileChildren. It's used in cases where we
+    // want to reconcile without matching against the existing set. This has the
+    // effect of all current children being unmounted; even if the type and key
+    // are the same, the old child is unmounted and a new child is created.
+    //
+    // To do this, we're going to go through the reconcile algorithm twice. In
+    // the first pass, we schedule a deletion for all the current children by
+    // passing null.
+    workInProgress.child = reconcileChildFibers(workInProgress, current.child, null, renderExpirationTime); // In the second pass, we mount the new children. The trick here is that we
+    // pass null in place of where we usually pass the current child set. This has
+    // the effect of remounting all children regardless of whether their
+    // identities match.
+
+    workInProgress.child = reconcileChildFibers(workInProgress, null, nextChildren, renderExpirationTime);
+  }
+
+  function updateForwardRef(current, workInProgress, Component, nextProps, renderExpirationTime) {
+    // TODO: current can be non-null here even if the component
+    // hasn't yet mounted. This happens after the first render suspends.
+    // We'll need to figure out if this is fine or can cause issues.
+    {
+      if (workInProgress.type !== workInProgress.elementType) {
+        // Lazy component props can't be validated in createElement
+        // because they're only guaranteed to be resolved here.
+        var innerPropTypes = Component.propTypes;
+
+        if (innerPropTypes) {
+          checkPropTypes_1(innerPropTypes, nextProps, // Resolved props
+          'prop', getComponentName(Component), getCurrentFiberStackInDev);
+        }
+      }
+    }
+
+    var render = Component.render;
+    var ref = workInProgress.ref; // The rest is a fork of updateFunctionComponent
+
+    var nextChildren;
+    prepareToReadContext(workInProgress, renderExpirationTime);
+
+    {
+      ReactCurrentOwner$1.current = workInProgress;
+      setIsRendering(true);
+      nextChildren = renderWithHooks(current, workInProgress, render, nextProps, ref, renderExpirationTime);
+
+      if ( workInProgress.mode & StrictMode) {
+        // Only double-render components with Hooks
+        if (workInProgress.memoizedState !== null) {
+          nextChildren = renderWithHooks(current, workInProgress, render, nextProps, ref, renderExpirationTime);
+        }
+      }
+
+      setIsRendering(false);
+    }
+
+    if (current !== null && !didReceiveUpdate) {
+      bailoutHooks(current, workInProgress, renderExpirationTime);
+      return bailoutOnAlreadyFinishedWork(current, workInProgress, renderExpirationTime);
+    } // React DevTools reads this flag.
+
+
+    workInProgress.effectTag |= PerformedWork;
+    reconcileChildren(current, workInProgress, nextChildren, renderExpirationTime);
+    return workInProgress.child;
+  }
+
+  function updateMemoComponent(current, workInProgress, Component, nextProps, updateExpirationTime, renderExpirationTime) {
+    if (current === null) {
+      var type = Component.type;
+
+      if (isSimpleFunctionComponent(type) && Component.compare === null && // SimpleMemoComponent codepath doesn't resolve outer props either.
+      Component.defaultProps === undefined) {
+        var resolvedType = type;
+
+        {
+          resolvedType = resolveFunctionForHotReloading(type);
+        } // If this is a plain function component without default props,
+        // and with only the default shallow comparison, we upgrade it
+        // to a SimpleMemoComponent to allow fast path updates.
+
+
+        workInProgress.tag = SimpleMemoComponent;
+        workInProgress.type = resolvedType;
+
+        {
+          validateFunctionComponentInDev(workInProgress, type);
+        }
+
+        return updateSimpleMemoComponent(current, workInProgress, resolvedType, nextProps, updateExpirationTime, renderExpirationTime);
+      }
+
+      {
+        var innerPropTypes = type.propTypes;
+
+        if (innerPropTypes) {
+          // Inner memo component props aren't currently validated in createElement.
+          // We could move it there, but we'd still need this for lazy code path.
+          checkPropTypes_1(innerPropTypes, nextProps, // Resolved props
+          'prop', getComponentName(type), getCurrentFiberStackInDev);
+        }
+      }
+
+      var child = createFiberFromTypeAndProps(Component.type, null, nextProps, null, workInProgress.mode, renderExpirationTime);
+      child.ref = workInProgress.ref;
+      child.return = workInProgress;
+      workInProgress.child = child;
+      return child;
+    }
+
+    {
+      var _type = Component.type;
+      var _innerPropTypes = _type.propTypes;
+
+      if (_innerPropTypes) {
+        // Inner memo component props aren't currently validated in createElement.
+        // We could move it there, but we'd still need this for lazy code path.
+        checkPropTypes_1(_innerPropTypes, nextProps, // Resolved props
+        'prop', getComponentName(_type), getCurrentFiberStackInDev);
+      }
+    }
+
+    var currentChild = current.child; // This is always exactly one child
+
+    if (updateExpirationTime < renderExpirationTime) {
+      // This will be the props with resolved defaultProps,
+      // unlike current.memoizedProps which will be the unresolved ones.
+      var prevProps = currentChild.memoizedProps; // Default to shallow comparison
+
+      var compare = Component.compare;
+      compare = compare !== null ? compare : shallowEqual;
+
+      if (compare(prevProps, nextProps) && current.ref === workInProgress.ref) {
+        return bailoutOnAlreadyFinishedWork(current, workInProgress, renderExpirationTime);
+      }
+    } // React DevTools reads this flag.
+
+
+    workInProgress.effectTag |= PerformedWork;
+    var newChild = createWorkInProgress(currentChild, nextProps);
+    newChild.ref = workInProgress.ref;
+    newChild.return = workInProgress;
+    workInProgress.child = newChild;
+    return newChild;
+  }
+
+  function updateSimpleMemoComponent(current, workInProgress, Component, nextProps, updateExpirationTime, renderExpirationTime) {
+    // TODO: current can be non-null here even if the component
+    // hasn't yet mounted. This happens when the inner render suspends.
+    // We'll need to figure out if this is fine or can cause issues.
+    {
+      if (workInProgress.type !== workInProgress.elementType) {
+        // Lazy component props can't be validated in createElement
+        // because they're only guaranteed to be resolved here.
+        var outerMemoType = workInProgress.elementType;
+
+        if (outerMemoType.$$typeof === REACT_LAZY_TYPE) {
+          // We warn when you define propTypes on lazy()
+          // so let's just skip over it to find memo() outer wrapper.
+          // Inner props for memo are validated later.
+          outerMemoType = refineResolvedLazyComponent(outerMemoType);
+        }
+
+        var outerPropTypes = outerMemoType && outerMemoType.propTypes;
+
+        if (outerPropTypes) {
+          checkPropTypes_1(outerPropTypes, nextProps, // Resolved (SimpleMemoComponent has no defaultProps)
+          'prop', getComponentName(outerMemoType), getCurrentFiberStackInDev);
+        } // Inner propTypes will be validated in the function component path.
+
+      }
+    }
+
+    if (current !== null) {
+      var prevProps = current.memoizedProps;
+
+      if (shallowEqual(prevProps, nextProps) && current.ref === workInProgress.ref && ( // Prevent bailout if the implementation changed due to hot reload.
+       workInProgress.type === current.type )) {
+        didReceiveUpdate = false;
+
+        if (updateExpirationTime < renderExpirationTime) {
+          // The pending update priority was cleared at the beginning of
+          // beginWork. We're about to bail out, but there might be additional
+          // updates at a lower priority. Usually, the priority level of the
+          // remaining updates is accumlated during the evaluation of the
+          // component (i.e. when processing the update queue). But since since
+          // we're bailing out early *without* evaluating the component, we need
+          // to account for it here, too. Reset to the value of the current fiber.
+          // NOTE: This only applies to SimpleMemoComponent, not MemoComponent,
+          // because a MemoComponent fiber does not have hooks or an update queue;
+          // rather, it wraps around an inner component, which may or may not
+          // contains hooks.
+          // TODO: Move the reset at in beginWork out of the common path so that
+          // this is no longer necessary.
+          workInProgress.expirationTime = current.expirationTime;
+          return bailoutOnAlreadyFinishedWork(current, workInProgress, renderExpirationTime);
+        }
+      }
+    }
+
+    return updateFunctionComponent(current, workInProgress, Component, nextProps, renderExpirationTime);
+  }
+
+  function updateFragment(current, workInProgress, renderExpirationTime) {
+    var nextChildren = workInProgress.pendingProps;
+    reconcileChildren(current, workInProgress, nextChildren, renderExpirationTime);
+    return workInProgress.child;
+  }
+
+  function updateMode(current, workInProgress, renderExpirationTime) {
+    var nextChildren = workInProgress.pendingProps.children;
+    reconcileChildren(current, workInProgress, nextChildren, renderExpirationTime);
+    return workInProgress.child;
+  }
+
+  function updateProfiler(current, workInProgress, renderExpirationTime) {
+    {
+      workInProgress.effectTag |= Update;
+    }
+
+    var nextProps = workInProgress.pendingProps;
+    var nextChildren = nextProps.children;
+    reconcileChildren(current, workInProgress, nextChildren, renderExpirationTime);
+    return workInProgress.child;
+  }
+
+  function markRef(current, workInProgress) {
+    var ref = workInProgress.ref;
+
+    if (current === null && ref !== null || current !== null && current.ref !== ref) {
+      // Schedule a Ref effect
+      workInProgress.effectTag |= Ref;
+    }
+  }
+
+  function updateFunctionComponent(current, workInProgress, Component, nextProps, renderExpirationTime) {
+    {
+      if (workInProgress.type !== workInProgress.elementType) {
+        // Lazy component props can't be validated in createElement
+        // because they're only guaranteed to be resolved here.
+        var innerPropTypes = Component.propTypes;
+
+        if (innerPropTypes) {
+          checkPropTypes_1(innerPropTypes, nextProps, // Resolved props
+          'prop', getComponentName(Component), getCurrentFiberStackInDev);
+        }
+      }
+    }
+
+    var context;
+
+    {
+      var unmaskedContext = getUnmaskedContext(workInProgress, Component, true);
+      context = getMaskedContext(workInProgress, unmaskedContext);
+    }
+
+    var nextChildren;
+    prepareToReadContext(workInProgress, renderExpirationTime);
+
+    {
+      ReactCurrentOwner$1.current = workInProgress;
+      setIsRendering(true);
+      nextChildren = renderWithHooks(current, workInProgress, Component, nextProps, context, renderExpirationTime);
+
+      if ( workInProgress.mode & StrictMode) {
+        // Only double-render components with Hooks
+        if (workInProgress.memoizedState !== null) {
+          nextChildren = renderWithHooks(current, workInProgress, Component, nextProps, context, renderExpirationTime);
+        }
+      }
+
+      setIsRendering(false);
+    }
+
+    if (current !== null && !didReceiveUpdate) {
+      bailoutHooks(current, workInProgress, renderExpirationTime);
+      return bailoutOnAlreadyFinishedWork(current, workInProgress, renderExpirationTime);
+    } // React DevTools reads this flag.
+
+
+    workInProgress.effectTag |= PerformedWork;
+    reconcileChildren(current, workInProgress, nextChildren, renderExpirationTime);
+    return workInProgress.child;
+  }
+
+  function updateClassComponent(current, workInProgress, Component, nextProps, renderExpirationTime) {
+    {
+      if (workInProgress.type !== workInProgress.elementType) {
+        // Lazy component props can't be validated in createElement
+        // because they're only guaranteed to be resolved here.
+        var innerPropTypes = Component.propTypes;
+
+        if (innerPropTypes) {
+          checkPropTypes_1(innerPropTypes, nextProps, // Resolved props
+          'prop', getComponentName(Component), getCurrentFiberStackInDev);
+        }
+      }
+    } // Push context providers early to prevent context stack mismatches.
+    // During mounting we don't know the child context yet as the instance doesn't exist.
+    // We will invalidate the child context in finishClassComponent() right after rendering.
+
+
+    var hasContext;
+
+    if (isContextProvider(Component)) {
+      hasContext = true;
+      pushContextProvider(workInProgress);
+    } else {
+      hasContext = false;
+    }
+
+    prepareToReadContext(workInProgress, renderExpirationTime);
+    var instance = workInProgress.stateNode;
+    var shouldUpdate;
+
+    if (instance === null) {
+      if (current !== null) {
+        // A class component without an instance only mounts if it suspended
+        // inside a non-concurrent tree, in an inconsistent state. We want to
+        // treat it like a new mount, even though an empty version of it already
+        // committed. Disconnect the alternate pointers.
+        current.alternate = null;
+        workInProgress.alternate = null; // Since this is conceptually a new fiber, schedule a Placement effect
+
+        workInProgress.effectTag |= Placement;
+      } // In the initial pass we might need to construct the instance.
+
+
+      constructClassInstance(workInProgress, Component, nextProps);
+      mountClassInstance(workInProgress, Component, nextProps, renderExpirationTime);
+      shouldUpdate = true;
+    } else if (current === null) {
+      // In a resume, we'll already have an instance we can reuse.
+      shouldUpdate = resumeMountClassInstance(workInProgress, Component, nextProps, renderExpirationTime);
+    } else {
+      shouldUpdate = updateClassInstance(current, workInProgress, Component, nextProps, renderExpirationTime);
+    }
+
+    var nextUnitOfWork = finishClassComponent(current, workInProgress, Component, shouldUpdate, hasContext, renderExpirationTime);
+
+    {
+      var inst = workInProgress.stateNode;
+
+      if (inst.props !== nextProps) {
+        if (!didWarnAboutReassigningProps) {
+          error('It looks like %s is reassigning its own `this.props` while rendering. ' + 'This is not supported and can lead to confusing bugs.', getComponentName(workInProgress.type) || 'a component');
+        }
+
+        didWarnAboutReassigningProps = true;
+      }
+    }
+
+    return nextUnitOfWork;
+  }
+
+  function finishClassComponent(current, workInProgress, Component, shouldUpdate, hasContext, renderExpirationTime) {
+    // Refs should update even if shouldComponentUpdate returns false
+    markRef(current, workInProgress);
+    var didCaptureError = (workInProgress.effectTag & DidCapture) !== NoEffect;
+
+    if (!shouldUpdate && !didCaptureError) {
+      // Context providers should defer to sCU for rendering
+      if (hasContext) {
+        invalidateContextProvider(workInProgress, Component, false);
+      }
+
+      return bailoutOnAlreadyFinishedWork(current, workInProgress, renderExpirationTime);
+    }
+
+    var instance = workInProgress.stateNode; // Rerender
+
+    ReactCurrentOwner$1.current = workInProgress;
+    var nextChildren;
+
+    if (didCaptureError && typeof Component.getDerivedStateFromError !== 'function') {
+      // If we captured an error, but getDerivedStateFromError is not defined,
+      // unmount all the children. componentDidCatch will schedule an update to
+      // re-render a fallback. This is temporary until we migrate everyone to
+      // the new API.
+      // TODO: Warn in a future release.
+      nextChildren = null;
+
+      {
+        stopProfilerTimerIfRunning();
+      }
+    } else {
+      {
+        setIsRendering(true);
+        nextChildren = instance.render();
+
+        if ( workInProgress.mode & StrictMode) {
+          instance.render();
+        }
+
+        setIsRendering(false);
+      }
+    } // React DevTools reads this flag.
+
+
+    workInProgress.effectTag |= PerformedWork;
+
+    if (current !== null && didCaptureError) {
+      // If we're recovering from an error, reconcile without reusing any of
+      // the existing children. Conceptually, the normal children and the children
+      // that are shown on error are two different sets, so we shouldn't reuse
+      // normal children even if their identities match.
+      forceUnmountCurrentAndReconcile(current, workInProgress, nextChildren, renderExpirationTime);
+    } else {
+      reconcileChildren(current, workInProgress, nextChildren, renderExpirationTime);
+    } // Memoize state using the values we just used to render.
+    // TODO: Restructure so we never read values from the instance.
+
+
+    workInProgress.memoizedState = instance.state; // The context might have changed so we need to recalculate it.
+
+    if (hasContext) {
+      invalidateContextProvider(workInProgress, Component, true);
+    }
+
+    return workInProgress.child;
+  }
+
+  function pushHostRootContext(workInProgress) {
+    var root = workInProgress.stateNode;
+
+    if (root.pendingContext) {
+      pushTopLevelContextObject(workInProgress, root.pendingContext, root.pendingContext !== root.context);
+    } else if (root.context) {
+      // Should always be set
+      pushTopLevelContextObject(workInProgress, root.context, false);
+    }
+
+    pushHostContainer(workInProgress, root.containerInfo);
+  }
+
+  function updateHostRoot(current, workInProgress, renderExpirationTime) {
+    pushHostRootContext(workInProgress);
+    var updateQueue = workInProgress.updateQueue;
+
+    if (!(current !== null && updateQueue !== null)) {
+      {
+        throw Error( "If the root does not have an updateQueue, we should have already bailed out. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+
+    var nextProps = workInProgress.pendingProps;
+    var prevState = workInProgress.memoizedState;
+    var prevChildren = prevState !== null ? prevState.element : null;
+    cloneUpdateQueue(current, workInProgress);
+    processUpdateQueue(workInProgress, nextProps, null, renderExpirationTime);
+    var nextState = workInProgress.memoizedState; // Caution: React DevTools currently depends on this property
+    // being called "element".
+
+    var nextChildren = nextState.element;
+
+    if (nextChildren === prevChildren) {
+      // If the state is the same as before, that's a bailout because we had
+      // no work that expires at this time.
+      resetHydrationState();
+      return bailoutOnAlreadyFinishedWork(current, workInProgress, renderExpirationTime);
+    }
+
+    var root = workInProgress.stateNode;
+
+    if (root.hydrate && enterHydrationState(workInProgress)) {
+      // If we don't have any current children this might be the first pass.
+      // We always try to hydrate. If this isn't a hydration pass there won't
+      // be any children to hydrate which is effectively the same thing as
+      // not hydrating.
+      var child = mountChildFibers(workInProgress, null, nextChildren, renderExpirationTime);
+      workInProgress.child = child;
+      var node = child;
+
+      while (node) {
+        // Mark each child as hydrating. This is a fast path to know whether this
+        // tree is part of a hydrating tree. This is used to determine if a child
+        // node has fully mounted yet, and for scheduling event replaying.
+        // Conceptually this is similar to Placement in that a new subtree is
+        // inserted into the React tree here. It just happens to not need DOM
+        // mutations because it already exists.
+        node.effectTag = node.effectTag & ~Placement | Hydrating;
+        node = node.sibling;
+      }
+    } else {
+      // Otherwise reset hydration state in case we aborted and resumed another
+      // root.
+      reconcileChildren(current, workInProgress, nextChildren, renderExpirationTime);
+      resetHydrationState();
+    }
+
+    return workInProgress.child;
+  }
+
+  function updateHostComponent(current, workInProgress, renderExpirationTime) {
+    pushHostContext(workInProgress);
+
+    if (current === null) {
+      tryToClaimNextHydratableInstance(workInProgress);
+    }
+
+    var type = workInProgress.type;
+    var nextProps = workInProgress.pendingProps;
+    var prevProps = current !== null ? current.memoizedProps : null;
+    var nextChildren = nextProps.children;
+    var isDirectTextChild = shouldSetTextContent(type, nextProps);
+
+    if (isDirectTextChild) {
+      // We special case a direct text child of a host node. This is a common
+      // case. We won't handle it as a reified child. We will instead handle
+      // this in the host environment that also has access to this prop. That
+      // avoids allocating another HostText fiber and traversing it.
+      nextChildren = null;
+    } else if (prevProps !== null && shouldSetTextContent(type, prevProps)) {
+      // If we're switching from a direct text child to a normal child, or to
+      // empty, we need to schedule the text content to be reset.
+      workInProgress.effectTag |= ContentReset;
+    }
+
+    markRef(current, workInProgress); // Check the host config to see if the children are offscreen/hidden.
+
+    if (workInProgress.mode & ConcurrentMode && renderExpirationTime !== Never && shouldDeprioritizeSubtree(type, nextProps)) {
+      {
+        markSpawnedWork(Never);
+      } // Schedule this fiber to re-render at offscreen priority. Then bailout.
+
+
+      workInProgress.expirationTime = workInProgress.childExpirationTime = Never;
+      return null;
+    }
+
+    reconcileChildren(current, workInProgress, nextChildren, renderExpirationTime);
+    return workInProgress.child;
+  }
+
+  function updateHostText(current, workInProgress) {
+    if (current === null) {
+      tryToClaimNextHydratableInstance(workInProgress);
+    } // Nothing to do here. This is terminal. We'll do the completion step
+    // immediately after.
+
+
+    return null;
+  }
+
+  function mountLazyComponent(_current, workInProgress, elementType, updateExpirationTime, renderExpirationTime) {
+    if (_current !== null) {
+      // A lazy component only mounts if it suspended inside a non-
+      // concurrent tree, in an inconsistent state. We want to treat it like
+      // a new mount, even though an empty version of it already committed.
+      // Disconnect the alternate pointers.
+      _current.alternate = null;
+      workInProgress.alternate = null; // Since this is conceptually a new fiber, schedule a Placement effect
+
+      workInProgress.effectTag |= Placement;
+    }
+
+    var props = workInProgress.pendingProps; // We can't start a User Timing measurement with correct label yet.
+    // Cancel and resume right after we know the tag.
+
+    cancelWorkTimer(workInProgress);
+    var Component = readLazyComponentType(elementType); // Store the unwrapped component in the type.
+
+    workInProgress.type = Component;
+    var resolvedTag = workInProgress.tag = resolveLazyComponentTag(Component);
+    startWorkTimer(workInProgress);
+    var resolvedProps = resolveDefaultProps(Component, props);
+    var child;
+
+    switch (resolvedTag) {
+      case FunctionComponent:
+        {
+          {
+            validateFunctionComponentInDev(workInProgress, Component);
+            workInProgress.type = Component = resolveFunctionForHotReloading(Component);
+          }
+
+          child = updateFunctionComponent(null, workInProgress, Component, resolvedProps, renderExpirationTime);
+          return child;
+        }
+
+      case ClassComponent:
+        {
+          {
+            workInProgress.type = Component = resolveClassForHotReloading(Component);
+          }
+
+          child = updateClassComponent(null, workInProgress, Component, resolvedProps, renderExpirationTime);
+          return child;
+        }
+
+      case ForwardRef:
+        {
+          {
+            workInProgress.type = Component = resolveForwardRefForHotReloading(Component);
+          }
+
+          child = updateForwardRef(null, workInProgress, Component, resolvedProps, renderExpirationTime);
+          return child;
+        }
+
+      case MemoComponent:
+        {
+          {
+            if (workInProgress.type !== workInProgress.elementType) {
+              var outerPropTypes = Component.propTypes;
+
+              if (outerPropTypes) {
+                checkPropTypes_1(outerPropTypes, resolvedProps, // Resolved for outer only
+                'prop', getComponentName(Component), getCurrentFiberStackInDev);
+              }
+            }
+          }
+
+          child = updateMemoComponent(null, workInProgress, Component, resolveDefaultProps(Component.type, resolvedProps), // The inner type can have defaults too
+          updateExpirationTime, renderExpirationTime);
+          return child;
+        }
+    }
+
+    var hint = '';
+
+    {
+      if (Component !== null && typeof Component === 'object' && Component.$$typeof === REACT_LAZY_TYPE) {
+        hint = ' Did you wrap a component in React.lazy() more than once?';
+      }
+    } // This message intentionally doesn't mention ForwardRef or MemoComponent
+    // because the fact that it's a separate type of work is an
+    // implementation detail.
+
+
+    {
+      {
+        throw Error( "Element type is invalid. Received a promise that resolves to: " + Component + ". Lazy element type must resolve to a class or function." + hint );
+      }
+    }
+  }
+
+  function mountIncompleteClassComponent(_current, workInProgress, Component, nextProps, renderExpirationTime) {
+    if (_current !== null) {
+      // An incomplete component only mounts if it suspended inside a non-
+      // concurrent tree, in an inconsistent state. We want to treat it like
+      // a new mount, even though an empty version of it already committed.
+      // Disconnect the alternate pointers.
+      _current.alternate = null;
+      workInProgress.alternate = null; // Since this is conceptually a new fiber, schedule a Placement effect
+
+      workInProgress.effectTag |= Placement;
+    } // Promote the fiber to a class and try rendering again.
+
+
+    workInProgress.tag = ClassComponent; // The rest of this function is a fork of `updateClassComponent`
+    // Push context providers early to prevent context stack mismatches.
+    // During mounting we don't know the child context yet as the instance doesn't exist.
+    // We will invalidate the child context in finishClassComponent() right after rendering.
+
+    var hasContext;
+
+    if (isContextProvider(Component)) {
+      hasContext = true;
+      pushContextProvider(workInProgress);
+    } else {
+      hasContext = false;
+    }
+
+    prepareToReadContext(workInProgress, renderExpirationTime);
+    constructClassInstance(workInProgress, Component, nextProps);
+    mountClassInstance(workInProgress, Component, nextProps, renderExpirationTime);
+    return finishClassComponent(null, workInProgress, Component, true, hasContext, renderExpirationTime);
+  }
+
+  function mountIndeterminateComponent(_current, workInProgress, Component, renderExpirationTime) {
+    if (_current !== null) {
+      // An indeterminate component only mounts if it suspended inside a non-
+      // concurrent tree, in an inconsistent state. We want to treat it like
+      // a new mount, even though an empty version of it already committed.
+      // Disconnect the alternate pointers.
+      _current.alternate = null;
+      workInProgress.alternate = null; // Since this is conceptually a new fiber, schedule a Placement effect
+
+      workInProgress.effectTag |= Placement;
+    }
+
+    var props = workInProgress.pendingProps;
+    var context;
+
+    {
+      var unmaskedContext = getUnmaskedContext(workInProgress, Component, false);
+      context = getMaskedContext(workInProgress, unmaskedContext);
+    }
+
+    prepareToReadContext(workInProgress, renderExpirationTime);
+    var value;
+
+    {
+      if (Component.prototype && typeof Component.prototype.render === 'function') {
+        var componentName = getComponentName(Component) || 'Unknown';
+
+        if (!didWarnAboutBadClass[componentName]) {
+          error("The <%s /> component appears to have a render method, but doesn't extend React.Component. " + 'This is likely to cause errors. Change %s to extend React.Component instead.', componentName, componentName);
+
+          didWarnAboutBadClass[componentName] = true;
+        }
+      }
+
+      if (workInProgress.mode & StrictMode) {
+        ReactStrictModeWarnings.recordLegacyContextWarning(workInProgress, null);
+      }
+
+      setIsRendering(true);
+      ReactCurrentOwner$1.current = workInProgress;
+      value = renderWithHooks(null, workInProgress, Component, props, context, renderExpirationTime);
+      setIsRendering(false);
+    } // React DevTools reads this flag.
+
+
+    workInProgress.effectTag |= PerformedWork;
+
+    if (typeof value === 'object' && value !== null && typeof value.render === 'function' && value.$$typeof === undefined) {
+      {
+        var _componentName = getComponentName(Component) || 'Unknown';
+
+        if (!didWarnAboutModulePatternComponent[_componentName]) {
+          error('The <%s /> component appears to be a function component that returns a class instance. ' + 'Change %s to a class that extends React.Component instead. ' + "If you can't use a class try assigning the prototype on the function as a workaround. " + "`%s.prototype = React.Component.prototype`. Don't use an arrow function since it " + 'cannot be called with `new` by React.', _componentName, _componentName, _componentName);
+
+          didWarnAboutModulePatternComponent[_componentName] = true;
+        }
+      } // Proceed under the assumption that this is a class instance
+
+
+      workInProgress.tag = ClassComponent; // Throw out any hooks that were used.
+
+      workInProgress.memoizedState = null;
+      workInProgress.updateQueue = null; // Push context providers early to prevent context stack mismatches.
+      // During mounting we don't know the child context yet as the instance doesn't exist.
+      // We will invalidate the child context in finishClassComponent() right after rendering.
+
+      var hasContext = false;
+
+      if (isContextProvider(Component)) {
+        hasContext = true;
+        pushContextProvider(workInProgress);
+      } else {
+        hasContext = false;
+      }
+
+      workInProgress.memoizedState = value.state !== null && value.state !== undefined ? value.state : null;
+      initializeUpdateQueue(workInProgress);
+      var getDerivedStateFromProps = Component.getDerivedStateFromProps;
+
+      if (typeof getDerivedStateFromProps === 'function') {
+        applyDerivedStateFromProps(workInProgress, Component, getDerivedStateFromProps, props);
+      }
+
+      adoptClassInstance(workInProgress, value);
+      mountClassInstance(workInProgress, Component, props, renderExpirationTime);
+      return finishClassComponent(null, workInProgress, Component, true, hasContext, renderExpirationTime);
+    } else {
+      // Proceed under the assumption that this is a function component
+      workInProgress.tag = FunctionComponent;
+
+      {
+
+        if ( workInProgress.mode & StrictMode) {
+          // Only double-render components with Hooks
+          if (workInProgress.memoizedState !== null) {
+            value = renderWithHooks(null, workInProgress, Component, props, context, renderExpirationTime);
+          }
+        }
+      }
+
+      reconcileChildren(null, workInProgress, value, renderExpirationTime);
+
+      {
+        validateFunctionComponentInDev(workInProgress, Component);
+      }
+
+      return workInProgress.child;
+    }
+  }
+
+  function validateFunctionComponentInDev(workInProgress, Component) {
+    {
+      if (Component) {
+        if (Component.childContextTypes) {
+          error('%s(...): childContextTypes cannot be defined on a function component.', Component.displayName || Component.name || 'Component');
+        }
+      }
+
+      if (workInProgress.ref !== null) {
+        var info = '';
+        var ownerName = getCurrentFiberOwnerNameInDevOrNull();
+
+        if (ownerName) {
+          info += '\n\nCheck the render method of `' + ownerName + '`.';
+        }
+
+        var warningKey = ownerName || workInProgress._debugID || '';
+        var debugSource = workInProgress._debugSource;
+
+        if (debugSource) {
+          warningKey = debugSource.fileName + ':' + debugSource.lineNumber;
+        }
+
+        if (!didWarnAboutFunctionRefs[warningKey]) {
+          didWarnAboutFunctionRefs[warningKey] = true;
+
+          error('Function components cannot be given refs. ' + 'Attempts to access this ref will fail. ' + 'Did you mean to use React.forwardRef()?%s', info);
+        }
+      }
+
+      if (typeof Component.getDerivedStateFromProps === 'function') {
+        var _componentName2 = getComponentName(Component) || 'Unknown';
+
+        if (!didWarnAboutGetDerivedStateOnFunctionComponent[_componentName2]) {
+          error('%s: Function components do not support getDerivedStateFromProps.', _componentName2);
+
+          didWarnAboutGetDerivedStateOnFunctionComponent[_componentName2] = true;
+        }
+      }
+
+      if (typeof Component.contextType === 'object' && Component.contextType !== null) {
+        var _componentName3 = getComponentName(Component) || 'Unknown';
+
+        if (!didWarnAboutContextTypeOnFunctionComponent[_componentName3]) {
+          error('%s: Function components do not support contextType.', _componentName3);
+
+          didWarnAboutContextTypeOnFunctionComponent[_componentName3] = true;
+        }
+      }
+    }
+  }
+
+  var SUSPENDED_MARKER = {
+    dehydrated: null,
+    retryTime: NoWork
+  };
+
+  function shouldRemainOnFallback(suspenseContext, current, workInProgress) {
+    // If the context is telling us that we should show a fallback, and we're not
+    // already showing content, then we should show the fallback instead.
+    return hasSuspenseContext(suspenseContext, ForceSuspenseFallback) && (current === null || current.memoizedState !== null);
+  }
+
+  function updateSuspenseComponent(current, workInProgress, renderExpirationTime) {
+    var mode = workInProgress.mode;
+    var nextProps = workInProgress.pendingProps; // This is used by DevTools to force a boundary to suspend.
+
+    {
+      if (shouldSuspend(workInProgress)) {
+        workInProgress.effectTag |= DidCapture;
+      }
+    }
+
+    var suspenseContext = suspenseStackCursor.current;
+    var nextDidTimeout = false;
+    var didSuspend = (workInProgress.effectTag & DidCapture) !== NoEffect;
+
+    if (didSuspend || shouldRemainOnFallback(suspenseContext, current)) {
+      // Something in this boundary's subtree already suspended. Switch to
+      // rendering the fallback children.
+      nextDidTimeout = true;
+      workInProgress.effectTag &= ~DidCapture;
+    } else {
+      // Attempting the main content
+      if (current === null || current.memoizedState !== null) {
+        // This is a new mount or this boundary is already showing a fallback state.
+        // Mark this subtree context as having at least one invisible parent that could
+        // handle the fallback state.
+        // Boundaries without fallbacks or should be avoided are not considered since
+        // they cannot handle preferred fallback states.
+        if (nextProps.fallback !== undefined && nextProps.unstable_avoidThisFallback !== true) {
+          suspenseContext = addSubtreeSuspenseContext(suspenseContext, InvisibleParentSuspenseContext);
+        }
+      }
+    }
+
+    suspenseContext = setDefaultShallowSuspenseContext(suspenseContext);
+    pushSuspenseContext(workInProgress, suspenseContext); // This next part is a bit confusing. If the children timeout, we switch to
+    // showing the fallback children in place of the "primary" children.
+    // However, we don't want to delete the primary children because then their
+    // state will be lost (both the React state and the host state, e.g.
+    // uncontrolled form inputs). Instead we keep them mounted and hide them.
+    // Both the fallback children AND the primary children are rendered at the
+    // same time. Once the primary children are un-suspended, we can delete
+    // the fallback children — don't need to preserve their state.
+    //
+    // The two sets of children are siblings in the host environment, but
+    // semantically, for purposes of reconciliation, they are two separate sets.
+    // So we store them using two fragment fibers.
+    //
+    // However, we want to avoid allocating extra fibers for every placeholder.
+    // They're only necessary when the children time out, because that's the
+    // only time when both sets are mounted.
+    //
+    // So, the extra fragment fibers are only used if the children time out.
+    // Otherwise, we render the primary children directly. This requires some
+    // custom reconciliation logic to preserve the state of the primary
+    // children. It's essentially a very basic form of re-parenting.
+
+    if (current === null) {
+      // If we're currently hydrating, try to hydrate this boundary.
+      // But only if this has a fallback.
+      if (nextProps.fallback !== undefined) {
+        tryToClaimNextHydratableInstance(workInProgress); // This could've been a dehydrated suspense component.
+      } // This is the initial mount. This branch is pretty simple because there's
+      // no previous state that needs to be preserved.
+
+
+      if (nextDidTimeout) {
+        // Mount separate fragments for primary and fallback children.
+        var nextFallbackChildren = nextProps.fallback;
+        var primaryChildFragment = createFiberFromFragment(null, mode, NoWork, null);
+        primaryChildFragment.return = workInProgress;
+
+        if ((workInProgress.mode & BlockingMode) === NoMode) {
+          // Outside of blocking mode, we commit the effects from the
+          // partially completed, timed-out tree, too.
+          var progressedState = workInProgress.memoizedState;
+          var progressedPrimaryChild = progressedState !== null ? workInProgress.child.child : workInProgress.child;
+          primaryChildFragment.child = progressedPrimaryChild;
+          var progressedChild = progressedPrimaryChild;
+
+          while (progressedChild !== null) {
+            progressedChild.return = primaryChildFragment;
+            progressedChild = progressedChild.sibling;
+          }
+        }
+
+        var fallbackChildFragment = createFiberFromFragment(nextFallbackChildren, mode, renderExpirationTime, null);
+        fallbackChildFragment.return = workInProgress;
+        primaryChildFragment.sibling = fallbackChildFragment; // Skip the primary children, and continue working on the
+        // fallback children.
+
+        workInProgress.memoizedState = SUSPENDED_MARKER;
+        workInProgress.child = primaryChildFragment;
+        return fallbackChildFragment;
+      } else {
+        // Mount the primary children without an intermediate fragment fiber.
+        var nextPrimaryChildren = nextProps.children;
+        workInProgress.memoizedState = null;
+        return workInProgress.child = mountChildFibers(workInProgress, null, nextPrimaryChildren, renderExpirationTime);
+      }
+    } else {
+      // This is an update. This branch is more complicated because we need to
+      // ensure the state of the primary children is preserved.
+      var prevState = current.memoizedState;
+
+      if (prevState !== null) {
+        // wrapped in a fragment fiber.
+
+
+        var currentPrimaryChildFragment = current.child;
+        var currentFallbackChildFragment = currentPrimaryChildFragment.sibling;
+
+        if (nextDidTimeout) {
+          // Still timed out. Reuse the current primary children by cloning
+          // its fragment. We're going to skip over these entirely.
+          var _nextFallbackChildren2 = nextProps.fallback;
+
+          var _primaryChildFragment2 = createWorkInProgress(currentPrimaryChildFragment, currentPrimaryChildFragment.pendingProps);
+
+          _primaryChildFragment2.return = workInProgress;
+
+          if ((workInProgress.mode & BlockingMode) === NoMode) {
+            // Outside of blocking mode, we commit the effects from the
+            // partially completed, timed-out tree, too.
+            var _progressedState = workInProgress.memoizedState;
+
+            var _progressedPrimaryChild = _progressedState !== null ? workInProgress.child.child : workInProgress.child;
+
+            if (_progressedPrimaryChild !== currentPrimaryChildFragment.child) {
+              _primaryChildFragment2.child = _progressedPrimaryChild;
+              var _progressedChild2 = _progressedPrimaryChild;
+
+              while (_progressedChild2 !== null) {
+                _progressedChild2.return = _primaryChildFragment2;
+                _progressedChild2 = _progressedChild2.sibling;
+              }
+            }
+          } // Because primaryChildFragment is a new fiber that we're inserting as the
+          // parent of a new tree, we need to set its treeBaseDuration.
+
+
+          if ( workInProgress.mode & ProfileMode) {
+            // treeBaseDuration is the sum of all the child tree base durations.
+            var _treeBaseDuration = 0;
+            var _hiddenChild = _primaryChildFragment2.child;
+
+            while (_hiddenChild !== null) {
+              _treeBaseDuration += _hiddenChild.treeBaseDuration;
+              _hiddenChild = _hiddenChild.sibling;
+            }
+
+            _primaryChildFragment2.treeBaseDuration = _treeBaseDuration;
+          } // Clone the fallback child fragment, too. These we'll continue
+          // working on.
+
+
+          var _fallbackChildFragment2 = createWorkInProgress(currentFallbackChildFragment, _nextFallbackChildren2);
+
+          _fallbackChildFragment2.return = workInProgress;
+          _primaryChildFragment2.sibling = _fallbackChildFragment2;
+          _primaryChildFragment2.childExpirationTime = NoWork; // Skip the primary children, and continue working on the
+          // fallback children.
+
+          workInProgress.memoizedState = SUSPENDED_MARKER;
+          workInProgress.child = _primaryChildFragment2;
+          return _fallbackChildFragment2;
+        } else {
+          // No longer suspended. Switch back to showing the primary children,
+          // and remove the intermediate fragment fiber.
+          var _nextPrimaryChildren = nextProps.children;
+          var currentPrimaryChild = currentPrimaryChildFragment.child;
+          var primaryChild = reconcileChildFibers(workInProgress, currentPrimaryChild, _nextPrimaryChildren, renderExpirationTime); // If this render doesn't suspend, we need to delete the fallback
+          // children. Wait until the complete phase, after we've confirmed the
+          // fallback is no longer needed.
+          // TODO: Would it be better to store the fallback fragment on
+          // the stateNode?
+          // Continue rendering the children, like we normally do.
+
+          workInProgress.memoizedState = null;
+          return workInProgress.child = primaryChild;
+        }
+      } else {
+        // The current tree has not already timed out. That means the primary
+        // children are not wrapped in a fragment fiber.
+        var _currentPrimaryChild = current.child;
+
+        if (nextDidTimeout) {
+          // Timed out. Wrap the children in a fragment fiber to keep them
+          // separate from the fallback children.
+          var _nextFallbackChildren3 = nextProps.fallback;
+
+          var _primaryChildFragment3 = createFiberFromFragment( // It shouldn't matter what the pending props are because we aren't
+          // going to render this fragment.
+          null, mode, NoWork, null);
+
+          _primaryChildFragment3.return = workInProgress;
+          _primaryChildFragment3.child = _currentPrimaryChild;
+
+          if (_currentPrimaryChild !== null) {
+            _currentPrimaryChild.return = _primaryChildFragment3;
+          } // Even though we're creating a new fiber, there are no new children,
+          // because we're reusing an already mounted tree. So we don't need to
+          // schedule a placement.
+          // primaryChildFragment.effectTag |= Placement;
+
+
+          if ((workInProgress.mode & BlockingMode) === NoMode) {
+            // Outside of blocking mode, we commit the effects from the
+            // partially completed, timed-out tree, too.
+            var _progressedState2 = workInProgress.memoizedState;
+
+            var _progressedPrimaryChild2 = _progressedState2 !== null ? workInProgress.child.child : workInProgress.child;
+
+            _primaryChildFragment3.child = _progressedPrimaryChild2;
+            var _progressedChild3 = _progressedPrimaryChild2;
+
+            while (_progressedChild3 !== null) {
+              _progressedChild3.return = _primaryChildFragment3;
+              _progressedChild3 = _progressedChild3.sibling;
+            }
+          } // Because primaryChildFragment is a new fiber that we're inserting as the
+          // parent of a new tree, we need to set its treeBaseDuration.
+
+
+          if ( workInProgress.mode & ProfileMode) {
+            // treeBaseDuration is the sum of all the child tree base durations.
+            var _treeBaseDuration2 = 0;
+            var _hiddenChild2 = _primaryChildFragment3.child;
+
+            while (_hiddenChild2 !== null) {
+              _treeBaseDuration2 += _hiddenChild2.treeBaseDuration;
+              _hiddenChild2 = _hiddenChild2.sibling;
+            }
+
+            _primaryChildFragment3.treeBaseDuration = _treeBaseDuration2;
+          } // Create a fragment from the fallback children, too.
+
+
+          var _fallbackChildFragment3 = createFiberFromFragment(_nextFallbackChildren3, mode, renderExpirationTime, null);
+
+          _fallbackChildFragment3.return = workInProgress;
+          _primaryChildFragment3.sibling = _fallbackChildFragment3;
+          _fallbackChildFragment3.effectTag |= Placement;
+          _primaryChildFragment3.childExpirationTime = NoWork; // Skip the primary children, and continue working on the
+          // fallback children.
+
+          workInProgress.memoizedState = SUSPENDED_MARKER;
+          workInProgress.child = _primaryChildFragment3;
+          return _fallbackChildFragment3;
+        } else {
+          // Still haven't timed out. Continue rendering the children, like we
+          // normally do.
+          workInProgress.memoizedState = null;
+          var _nextPrimaryChildren2 = nextProps.children;
+          return workInProgress.child = reconcileChildFibers(workInProgress, _currentPrimaryChild, _nextPrimaryChildren2, renderExpirationTime);
+        }
+      }
+    }
+  }
+
+  function scheduleWorkOnFiber(fiber, renderExpirationTime) {
+    if (fiber.expirationTime < renderExpirationTime) {
+      fiber.expirationTime = renderExpirationTime;
+    }
+
+    var alternate = fiber.alternate;
+
+    if (alternate !== null && alternate.expirationTime < renderExpirationTime) {
+      alternate.expirationTime = renderExpirationTime;
+    }
+
+    scheduleWorkOnParentPath(fiber.return, renderExpirationTime);
+  }
+
+  function propagateSuspenseContextChange(workInProgress, firstChild, renderExpirationTime) {
+    // Mark any Suspense boundaries with fallbacks as having work to do.
+    // If they were previously forced into fallbacks, they may now be able
+    // to unblock.
+    var node = firstChild;
+
+    while (node !== null) {
+      if (node.tag === SuspenseComponent) {
+        var state = node.memoizedState;
+
+        if (state !== null) {
+          scheduleWorkOnFiber(node, renderExpirationTime);
+        }
+      } else if (node.tag === SuspenseListComponent) {
+        // If the tail is hidden there might not be an Suspense boundaries
+        // to schedule work on. In this case we have to schedule it on the
+        // list itself.
+        // We don't have to traverse to the children of the list since
+        // the list will propagate the change when it rerenders.
+        scheduleWorkOnFiber(node, renderExpirationTime);
+      } else if (node.child !== null) {
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
+
+      if (node === workInProgress) {
+        return;
+      }
+
+      while (node.sibling === null) {
+        if (node.return === null || node.return === workInProgress) {
+          return;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    }
+  }
+
+  function findLastContentRow(firstChild) {
+    // This is going to find the last row among these children that is already
+    // showing content on the screen, as opposed to being in fallback state or
+    // new. If a row has multiple Suspense boundaries, any of them being in the
+    // fallback state, counts as the whole row being in a fallback state.
+    // Note that the "rows" will be workInProgress, but any nested children
+    // will still be current since we haven't rendered them yet. The mounted
+    // order may not be the same as the new order. We use the new order.
+    var row = firstChild;
+    var lastContentRow = null;
+
+    while (row !== null) {
+      var currentRow = row.alternate; // New rows can't be content rows.
+
+      if (currentRow !== null && findFirstSuspended(currentRow) === null) {
+        lastContentRow = row;
+      }
+
+      row = row.sibling;
+    }
+
+    return lastContentRow;
+  }
+
+  function validateRevealOrder(revealOrder) {
+    {
+      if (revealOrder !== undefined && revealOrder !== 'forwards' && revealOrder !== 'backwards' && revealOrder !== 'together' && !didWarnAboutRevealOrder[revealOrder]) {
+        didWarnAboutRevealOrder[revealOrder] = true;
+
+        if (typeof revealOrder === 'string') {
+          switch (revealOrder.toLowerCase()) {
+            case 'together':
+            case 'forwards':
+            case 'backwards':
+              {
+                error('"%s" is not a valid value for revealOrder on <SuspenseList />. ' + 'Use lowercase "%s" instead.', revealOrder, revealOrder.toLowerCase());
+
+                break;
+              }
+
+            case 'forward':
+            case 'backward':
+              {
+                error('"%s" is not a valid value for revealOrder on <SuspenseList />. ' + 'React uses the -s suffix in the spelling. Use "%ss" instead.', revealOrder, revealOrder.toLowerCase());
+
+                break;
+              }
+
+            default:
+              error('"%s" is not a supported revealOrder on <SuspenseList />. ' + 'Did you mean "together", "forwards" or "backwards"?', revealOrder);
+
+              break;
+          }
+        } else {
+          error('%s is not a supported value for revealOrder on <SuspenseList />. ' + 'Did you mean "together", "forwards" or "backwards"?', revealOrder);
+        }
+      }
+    }
+  }
+
+  function validateTailOptions(tailMode, revealOrder) {
+    {
+      if (tailMode !== undefined && !didWarnAboutTailOptions[tailMode]) {
+        if (tailMode !== 'collapsed' && tailMode !== 'hidden') {
+          didWarnAboutTailOptions[tailMode] = true;
+
+          error('"%s" is not a supported value for tail on <SuspenseList />. ' + 'Did you mean "collapsed" or "hidden"?', tailMode);
+        } else if (revealOrder !== 'forwards' && revealOrder !== 'backwards') {
+          didWarnAboutTailOptions[tailMode] = true;
+
+          error('<SuspenseList tail="%s" /> is only valid if revealOrder is ' + '"forwards" or "backwards". ' + 'Did you mean to specify revealOrder="forwards"?', tailMode);
+        }
+      }
+    }
+  }
+
+  function validateSuspenseListNestedChild(childSlot, index) {
+    {
+      var isArray = Array.isArray(childSlot);
+      var isIterable = !isArray && typeof getIteratorFn(childSlot) === 'function';
+
+      if (isArray || isIterable) {
+        var type = isArray ? 'array' : 'iterable';
+
+        error('A nested %s was passed to row #%s in <SuspenseList />. Wrap it in ' + 'an additional SuspenseList to configure its revealOrder: ' + '<SuspenseList revealOrder=...> ... ' + '<SuspenseList revealOrder=...>{%s}</SuspenseList> ... ' + '</SuspenseList>', type, index, type);
+
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  function validateSuspenseListChildren(children, revealOrder) {
+    {
+      if ((revealOrder === 'forwards' || revealOrder === 'backwards') && children !== undefined && children !== null && children !== false) {
+        if (Array.isArray(children)) {
+          for (var i = 0; i < children.length; i++) {
+            if (!validateSuspenseListNestedChild(children[i], i)) {
+              return;
+            }
+          }
+        } else {
+          var iteratorFn = getIteratorFn(children);
+
+          if (typeof iteratorFn === 'function') {
+            var childrenIterator = iteratorFn.call(children);
+
+            if (childrenIterator) {
+              var step = childrenIterator.next();
+              var _i = 0;
+
+              for (; !step.done; step = childrenIterator.next()) {
+                if (!validateSuspenseListNestedChild(step.value, _i)) {
+                  return;
+                }
+
+                _i++;
+              }
+            }
+          } else {
+            error('A single row was passed to a <SuspenseList revealOrder="%s" />. ' + 'This is not useful since it needs multiple rows. ' + 'Did you mean to pass multiple children or an array?', revealOrder);
+          }
+        }
+      }
+    }
+  }
+
+  function initSuspenseListRenderState(workInProgress, isBackwards, tail, lastContentRow, tailMode, lastEffectBeforeRendering) {
+    var renderState = workInProgress.memoizedState;
+
+    if (renderState === null) {
+      workInProgress.memoizedState = {
+        isBackwards: isBackwards,
+        rendering: null,
+        renderingStartTime: 0,
+        last: lastContentRow,
+        tail: tail,
+        tailExpiration: 0,
+        tailMode: tailMode,
+        lastEffect: lastEffectBeforeRendering
+      };
+    } else {
+      // We can reuse the existing object from previous renders.
+      renderState.isBackwards = isBackwards;
+      renderState.rendering = null;
+      renderState.renderingStartTime = 0;
+      renderState.last = lastContentRow;
+      renderState.tail = tail;
+      renderState.tailExpiration = 0;
+      renderState.tailMode = tailMode;
+      renderState.lastEffect = lastEffectBeforeRendering;
+    }
+  } // This can end up rendering this component multiple passes.
+  // The first pass splits the children fibers into two sets. A head and tail.
+  // We first render the head. If anything is in fallback state, we do another
+  // pass through beginWork to rerender all children (including the tail) with
+  // the force suspend context. If the first render didn't have anything in
+  // in fallback state. Then we render each row in the tail one-by-one.
+  // That happens in the completeWork phase without going back to beginWork.
+
+
+  function updateSuspenseListComponent(current, workInProgress, renderExpirationTime) {
+    var nextProps = workInProgress.pendingProps;
+    var revealOrder = nextProps.revealOrder;
+    var tailMode = nextProps.tail;
+    var newChildren = nextProps.children;
+    validateRevealOrder(revealOrder);
+    validateTailOptions(tailMode, revealOrder);
+    validateSuspenseListChildren(newChildren, revealOrder);
+    reconcileChildren(current, workInProgress, newChildren, renderExpirationTime);
+    var suspenseContext = suspenseStackCursor.current;
+    var shouldForceFallback = hasSuspenseContext(suspenseContext, ForceSuspenseFallback);
+
+    if (shouldForceFallback) {
+      suspenseContext = setShallowSuspenseContext(suspenseContext, ForceSuspenseFallback);
+      workInProgress.effectTag |= DidCapture;
+    } else {
+      var didSuspendBefore = current !== null && (current.effectTag & DidCapture) !== NoEffect;
+
+      if (didSuspendBefore) {
+        // If we previously forced a fallback, we need to schedule work
+        // on any nested boundaries to let them know to try to render
+        // again. This is the same as context updating.
+        propagateSuspenseContextChange(workInProgress, workInProgress.child, renderExpirationTime);
+      }
+
+      suspenseContext = setDefaultShallowSuspenseContext(suspenseContext);
+    }
+
+    pushSuspenseContext(workInProgress, suspenseContext);
+
+    if ((workInProgress.mode & BlockingMode) === NoMode) {
+      // Outside of blocking mode, SuspenseList doesn't work so we just
+      // use make it a noop by treating it as the default revealOrder.
+      workInProgress.memoizedState = null;
+    } else {
+      switch (revealOrder) {
+        case 'forwards':
+          {
+            var lastContentRow = findLastContentRow(workInProgress.child);
+            var tail;
+
+            if (lastContentRow === null) {
+              // The whole list is part of the tail.
+              // TODO: We could fast path by just rendering the tail now.
+              tail = workInProgress.child;
+              workInProgress.child = null;
+            } else {
+              // Disconnect the tail rows after the content row.
+              // We're going to render them separately later.
+              tail = lastContentRow.sibling;
+              lastContentRow.sibling = null;
+            }
+
+            initSuspenseListRenderState(workInProgress, false, // isBackwards
+            tail, lastContentRow, tailMode, workInProgress.lastEffect);
+            break;
+          }
+
+        case 'backwards':
+          {
+            // We're going to find the first row that has existing content.
+            // At the same time we're going to reverse the list of everything
+            // we pass in the meantime. That's going to be our tail in reverse
+            // order.
+            var _tail = null;
+            var row = workInProgress.child;
+            workInProgress.child = null;
+
+            while (row !== null) {
+              var currentRow = row.alternate; // New rows can't be content rows.
+
+              if (currentRow !== null && findFirstSuspended(currentRow) === null) {
+                // This is the beginning of the main content.
+                workInProgress.child = row;
+                break;
+              }
+
+              var nextRow = row.sibling;
+              row.sibling = _tail;
+              _tail = row;
+              row = nextRow;
+            } // TODO: If workInProgress.child is null, we can continue on the tail immediately.
+
+
+            initSuspenseListRenderState(workInProgress, true, // isBackwards
+            _tail, null, // last
+            tailMode, workInProgress.lastEffect);
+            break;
+          }
+
+        case 'together':
+          {
+            initSuspenseListRenderState(workInProgress, false, // isBackwards
+            null, // tail
+            null, // last
+            undefined, workInProgress.lastEffect);
+            break;
+          }
+
+        default:
+          {
+            // The default reveal order is the same as not having
+            // a boundary.
+            workInProgress.memoizedState = null;
+          }
+      }
+    }
+
+    return workInProgress.child;
+  }
+
+  function updatePortalComponent(current, workInProgress, renderExpirationTime) {
+    pushHostContainer(workInProgress, workInProgress.stateNode.containerInfo);
+    var nextChildren = workInProgress.pendingProps;
+
+    if (current === null) {
+      // Portals are special because we don't append the children during mount
+      // but at commit. Therefore we need to track insertions which the normal
+      // flow doesn't do during mount. This doesn't happen at the root because
+      // the root always starts with a "current" with a null child.
+      // TODO: Consider unifying this with how the root works.
+      workInProgress.child = reconcileChildFibers(workInProgress, null, nextChildren, renderExpirationTime);
+    } else {
+      reconcileChildren(current, workInProgress, nextChildren, renderExpirationTime);
+    }
+
+    return workInProgress.child;
+  }
+
+  function updateContextProvider(current, workInProgress, renderExpirationTime) {
+    var providerType = workInProgress.type;
+    var context = providerType._context;
+    var newProps = workInProgress.pendingProps;
+    var oldProps = workInProgress.memoizedProps;
+    var newValue = newProps.value;
+
+    {
+      var providerPropTypes = workInProgress.type.propTypes;
+
+      if (providerPropTypes) {
+        checkPropTypes_1(providerPropTypes, newProps, 'prop', 'Context.Provider', getCurrentFiberStackInDev);
+      }
+    }
+
+    pushProvider(workInProgress, newValue);
+
+    if (oldProps !== null) {
+      var oldValue = oldProps.value;
+      var changedBits = calculateChangedBits(context, newValue, oldValue);
+
+      if (changedBits === 0) {
+        // No change. Bailout early if children are the same.
+        if (oldProps.children === newProps.children && !hasContextChanged()) {
+          return bailoutOnAlreadyFinishedWork(current, workInProgress, renderExpirationTime);
+        }
+      } else {
+        // The context value changed. Search for matching consumers and schedule
+        // them to update.
+        propagateContextChange(workInProgress, context, changedBits, renderExpirationTime);
+      }
+    }
+
+    var newChildren = newProps.children;
+    reconcileChildren(current, workInProgress, newChildren, renderExpirationTime);
+    return workInProgress.child;
+  }
+
+  var hasWarnedAboutUsingContextAsConsumer = false;
+
+  function updateContextConsumer(current, workInProgress, renderExpirationTime) {
+    var context = workInProgress.type; // The logic below for Context differs depending on PROD or DEV mode. In
+    // DEV mode, we create a separate object for Context.Consumer that acts
+    // like a proxy to Context. This proxy object adds unnecessary code in PROD
+    // so we use the old behaviour (Context.Consumer references Context) to
+    // reduce size and overhead. The separate object references context via
+    // a property called "_context", which also gives us the ability to check
+    // in DEV mode if this property exists or not and warn if it does not.
+
+    {
+      if (context._context === undefined) {
+        // This may be because it's a Context (rather than a Consumer).
+        // Or it may be because it's older React where they're the same thing.
+        // We only want to warn if we're sure it's a new React.
+        if (context !== context.Consumer) {
+          if (!hasWarnedAboutUsingContextAsConsumer) {
+            hasWarnedAboutUsingContextAsConsumer = true;
+
+            error('Rendering <Context> directly is not supported and will be removed in ' + 'a future major release. Did you mean to render <Context.Consumer> instead?');
+          }
+        }
+      } else {
+        context = context._context;
+      }
+    }
+
+    var newProps = workInProgress.pendingProps;
+    var render = newProps.children;
+
+    {
+      if (typeof render !== 'function') {
+        error('A context consumer was rendered with multiple children, or a child ' + "that isn't a function. A context consumer expects a single child " + 'that is a function. If you did pass a function, make sure there ' + 'is no trailing or leading whitespace around it.');
+      }
+    }
+
+    prepareToReadContext(workInProgress, renderExpirationTime);
+    var newValue = readContext(context, newProps.unstable_observedBits);
+    var newChildren;
+
+    {
+      ReactCurrentOwner$1.current = workInProgress;
+      setIsRendering(true);
+      newChildren = render(newValue);
+      setIsRendering(false);
+    } // React DevTools reads this flag.
+
+
+    workInProgress.effectTag |= PerformedWork;
+    reconcileChildren(current, workInProgress, newChildren, renderExpirationTime);
+    return workInProgress.child;
+  }
+
+  function markWorkInProgressReceivedUpdate() {
+    didReceiveUpdate = true;
+  }
+
+  function bailoutOnAlreadyFinishedWork(current, workInProgress, renderExpirationTime) {
+    cancelWorkTimer(workInProgress);
+
+    if (current !== null) {
+      // Reuse previous dependencies
+      workInProgress.dependencies = current.dependencies;
+    }
+
+    {
+      // Don't update "base" render times for bailouts.
+      stopProfilerTimerIfRunning();
+    }
+
+    var updateExpirationTime = workInProgress.expirationTime;
+
+    if (updateExpirationTime !== NoWork) {
+      markUnprocessedUpdateTime(updateExpirationTime);
+    } // Check if the children have any pending work.
+
+
+    var childExpirationTime = workInProgress.childExpirationTime;
+
+    if (childExpirationTime < renderExpirationTime) {
+      // The children don't have any work either. We can skip them.
+      // TODO: Once we add back resuming, we should check if the children are
+      // a work-in-progress set. If so, we need to transfer their effects.
+      return null;
+    } else {
+      // This fiber doesn't have work, but its subtree does. Clone the child
+      // fibers and continue.
+      cloneChildFibers(current, workInProgress);
+      return workInProgress.child;
+    }
+  }
+
+  function remountFiber(current, oldWorkInProgress, newWorkInProgress) {
+    {
+      var returnFiber = oldWorkInProgress.return;
+
+      if (returnFiber === null) {
+        throw new Error('Cannot swap the root fiber.');
+      } // Disconnect from the old current.
+      // It will get deleted.
+
+
+      current.alternate = null;
+      oldWorkInProgress.alternate = null; // Connect to the new tree.
+
+      newWorkInProgress.index = oldWorkInProgress.index;
+      newWorkInProgress.sibling = oldWorkInProgress.sibling;
+      newWorkInProgress.return = oldWorkInProgress.return;
+      newWorkInProgress.ref = oldWorkInProgress.ref; // Replace the child/sibling pointers above it.
+
+      if (oldWorkInProgress === returnFiber.child) {
+        returnFiber.child = newWorkInProgress;
+      } else {
+        var prevSibling = returnFiber.child;
+
+        if (prevSibling === null) {
+          throw new Error('Expected parent to have a child.');
+        }
+
+        while (prevSibling.sibling !== oldWorkInProgress) {
+          prevSibling = prevSibling.sibling;
+
+          if (prevSibling === null) {
+            throw new Error('Expected to find the previous sibling.');
+          }
+        }
+
+        prevSibling.sibling = newWorkInProgress;
+      } // Delete the old fiber and place the new one.
+      // Since the old fiber is disconnected, we have to schedule it manually.
+
+
+      var last = returnFiber.lastEffect;
+
+      if (last !== null) {
+        last.nextEffect = current;
+        returnFiber.lastEffect = current;
+      } else {
+        returnFiber.firstEffect = returnFiber.lastEffect = current;
+      }
+
+      current.nextEffect = null;
+      current.effectTag = Deletion;
+      newWorkInProgress.effectTag |= Placement; // Restart work from the new fiber.
+
+      return newWorkInProgress;
+    }
+  }
+
+  function beginWork(current, workInProgress, renderExpirationTime) {
+    var updateExpirationTime = workInProgress.expirationTime;
+
+    {
+      if (workInProgress._debugNeedsRemount && current !== null) {
+        // This will restart the begin phase with a new fiber.
+        return remountFiber(current, workInProgress, createFiberFromTypeAndProps(workInProgress.type, workInProgress.key, workInProgress.pendingProps, workInProgress._debugOwner || null, workInProgress.mode, workInProgress.expirationTime));
+      }
+    }
+
+    if (current !== null) {
+      var oldProps = current.memoizedProps;
+      var newProps = workInProgress.pendingProps;
+
+      if (oldProps !== newProps || hasContextChanged() || ( // Force a re-render if the implementation changed due to hot reload:
+       workInProgress.type !== current.type )) {
+        // If props or context changed, mark the fiber as having performed work.
+        // This may be unset if the props are determined to be equal later (memo).
+        didReceiveUpdate = true;
+      } else if (updateExpirationTime < renderExpirationTime) {
+        didReceiveUpdate = false; // This fiber does not have any pending work. Bailout without entering
+        // the begin phase. There's still some bookkeeping we that needs to be done
+        // in this optimized path, mostly pushing stuff onto the stack.
+
+        switch (workInProgress.tag) {
+          case HostRoot:
+            pushHostRootContext(workInProgress);
+            resetHydrationState();
+            break;
+
+          case HostComponent:
+            pushHostContext(workInProgress);
+
+            if (workInProgress.mode & ConcurrentMode && renderExpirationTime !== Never && shouldDeprioritizeSubtree(workInProgress.type, newProps)) {
+              {
+                markSpawnedWork(Never);
+              } // Schedule this fiber to re-render at offscreen priority. Then bailout.
+
+
+              workInProgress.expirationTime = workInProgress.childExpirationTime = Never;
+              return null;
+            }
+
+            break;
+
+          case ClassComponent:
+            {
+              var Component = workInProgress.type;
+
+              if (isContextProvider(Component)) {
+                pushContextProvider(workInProgress);
+              }
+
+              break;
+            }
+
+          case HostPortal:
+            pushHostContainer(workInProgress, workInProgress.stateNode.containerInfo);
+            break;
+
+          case ContextProvider:
+            {
+              var newValue = workInProgress.memoizedProps.value;
+              pushProvider(workInProgress, newValue);
+              break;
+            }
+
+          case Profiler:
+            {
+              // Profiler should only call onRender when one of its descendants actually rendered.
+              var hasChildWork = workInProgress.childExpirationTime >= renderExpirationTime;
+
+              if (hasChildWork) {
+                workInProgress.effectTag |= Update;
+              }
+            }
+
+            break;
+
+          case SuspenseComponent:
+            {
+              var state = workInProgress.memoizedState;
+
+              if (state !== null) {
+                // whether to retry the primary children, or to skip over it and
+                // go straight to the fallback. Check the priority of the primary
+                // child fragment.
+
+
+                var primaryChildFragment = workInProgress.child;
+                var primaryChildExpirationTime = primaryChildFragment.childExpirationTime;
+
+                if (primaryChildExpirationTime !== NoWork && primaryChildExpirationTime >= renderExpirationTime) {
+                  // The primary children have pending work. Use the normal path
+                  // to attempt to render the primary children again.
+                  return updateSuspenseComponent(current, workInProgress, renderExpirationTime);
+                } else {
+                  pushSuspenseContext(workInProgress, setDefaultShallowSuspenseContext(suspenseStackCursor.current)); // The primary children do not have pending work with sufficient
+                  // priority. Bailout.
+
+                  var child = bailoutOnAlreadyFinishedWork(current, workInProgress, renderExpirationTime);
+
+                  if (child !== null) {
+                    // The fallback children have pending work. Skip over the
+                    // primary children and work on the fallback.
+                    return child.sibling;
+                  } else {
+                    return null;
+                  }
+                }
+              } else {
+                pushSuspenseContext(workInProgress, setDefaultShallowSuspenseContext(suspenseStackCursor.current));
+              }
+
+              break;
+            }
+
+          case SuspenseListComponent:
+            {
+              var didSuspendBefore = (current.effectTag & DidCapture) !== NoEffect;
+
+              var _hasChildWork = workInProgress.childExpirationTime >= renderExpirationTime;
+
+              if (didSuspendBefore) {
+                if (_hasChildWork) {
+                  // If something was in fallback state last time, and we have all the
+                  // same children then we're still in progressive loading state.
+                  // Something might get unblocked by state updates or retries in the
+                  // tree which will affect the tail. So we need to use the normal
+                  // path to compute the correct tail.
+                  return updateSuspenseListComponent(current, workInProgress, renderExpirationTime);
+                } // If none of the children had any work, that means that none of
+                // them got retried so they'll still be blocked in the same way
+                // as before. We can fast bail out.
+
+
+                workInProgress.effectTag |= DidCapture;
+              } // If nothing suspended before and we're rendering the same children,
+              // then the tail doesn't matter. Anything new that suspends will work
+              // in the "together" mode, so we can continue from the state we had.
+
+
+              var renderState = workInProgress.memoizedState;
+
+              if (renderState !== null) {
+                // Reset to the "together" mode in case we've started a different
+                // update in the past but didn't complete it.
+                renderState.rendering = null;
+                renderState.tail = null;
+              }
+
+              pushSuspenseContext(workInProgress, suspenseStackCursor.current);
+
+              if (_hasChildWork) {
+                break;
+              } else {
+                // If none of the children had any work, that means that none of
+                // them got retried so they'll still be blocked in the same way
+                // as before. We can fast bail out.
+                return null;
+              }
+            }
+        }
+
+        return bailoutOnAlreadyFinishedWork(current, workInProgress, renderExpirationTime);
+      } else {
+        // An update was scheduled on this fiber, but there are no new props
+        // nor legacy context. Set this to false. If an update queue or context
+        // consumer produces a changed value, it will set this to true. Otherwise,
+        // the component will assume the children have not changed and bail out.
+        didReceiveUpdate = false;
+      }
+    } else {
+      didReceiveUpdate = false;
+    } // Before entering the begin phase, clear pending update priority.
+    // TODO: This assumes that we're about to evaluate the component and process
+    // the update queue. However, there's an exception: SimpleMemoComponent
+    // sometimes bails out later in the begin phase. This indicates that we should
+    // move this assignment out of the common path and into each branch.
+
+
+    workInProgress.expirationTime = NoWork;
+
+    switch (workInProgress.tag) {
+      case IndeterminateComponent:
+        {
+          return mountIndeterminateComponent(current, workInProgress, workInProgress.type, renderExpirationTime);
+        }
+
+      case LazyComponent:
+        {
+          var elementType = workInProgress.elementType;
+          return mountLazyComponent(current, workInProgress, elementType, updateExpirationTime, renderExpirationTime);
+        }
+
+      case FunctionComponent:
+        {
+          var _Component = workInProgress.type;
+          var unresolvedProps = workInProgress.pendingProps;
+          var resolvedProps = workInProgress.elementType === _Component ? unresolvedProps : resolveDefaultProps(_Component, unresolvedProps);
+          return updateFunctionComponent(current, workInProgress, _Component, resolvedProps, renderExpirationTime);
+        }
+
+      case ClassComponent:
+        {
+          var _Component2 = workInProgress.type;
+          var _unresolvedProps = workInProgress.pendingProps;
+
+          var _resolvedProps = workInProgress.elementType === _Component2 ? _unresolvedProps : resolveDefaultProps(_Component2, _unresolvedProps);
+
+          return updateClassComponent(current, workInProgress, _Component2, _resolvedProps, renderExpirationTime);
+        }
+
+      case HostRoot:
+        return updateHostRoot(current, workInProgress, renderExpirationTime);
+
+      case HostComponent:
+        return updateHostComponent(current, workInProgress, renderExpirationTime);
+
+      case HostText:
+        return updateHostText(current, workInProgress);
+
+      case SuspenseComponent:
+        return updateSuspenseComponent(current, workInProgress, renderExpirationTime);
+
+      case HostPortal:
+        return updatePortalComponent(current, workInProgress, renderExpirationTime);
+
+      case ForwardRef:
+        {
+          var type = workInProgress.type;
+          var _unresolvedProps2 = workInProgress.pendingProps;
+
+          var _resolvedProps2 = workInProgress.elementType === type ? _unresolvedProps2 : resolveDefaultProps(type, _unresolvedProps2);
+
+          return updateForwardRef(current, workInProgress, type, _resolvedProps2, renderExpirationTime);
+        }
+
+      case Fragment:
+        return updateFragment(current, workInProgress, renderExpirationTime);
+
+      case Mode:
+        return updateMode(current, workInProgress, renderExpirationTime);
+
+      case Profiler:
+        return updateProfiler(current, workInProgress, renderExpirationTime);
+
+      case ContextProvider:
+        return updateContextProvider(current, workInProgress, renderExpirationTime);
+
+      case ContextConsumer:
+        return updateContextConsumer(current, workInProgress, renderExpirationTime);
+
+      case MemoComponent:
+        {
+          var _type2 = workInProgress.type;
+          var _unresolvedProps3 = workInProgress.pendingProps; // Resolve outer props first, then resolve inner props.
+
+          var _resolvedProps3 = resolveDefaultProps(_type2, _unresolvedProps3);
+
+          {
+            if (workInProgress.type !== workInProgress.elementType) {
+              var outerPropTypes = _type2.propTypes;
+
+              if (outerPropTypes) {
+                checkPropTypes_1(outerPropTypes, _resolvedProps3, // Resolved for outer only
+                'prop', getComponentName(_type2), getCurrentFiberStackInDev);
+              }
+            }
+          }
+
+          _resolvedProps3 = resolveDefaultProps(_type2.type, _resolvedProps3);
+          return updateMemoComponent(current, workInProgress, _type2, _resolvedProps3, updateExpirationTime, renderExpirationTime);
+        }
+
+      case SimpleMemoComponent:
+        {
+          return updateSimpleMemoComponent(current, workInProgress, workInProgress.type, workInProgress.pendingProps, updateExpirationTime, renderExpirationTime);
+        }
+
+      case IncompleteClassComponent:
+        {
+          var _Component3 = workInProgress.type;
+          var _unresolvedProps4 = workInProgress.pendingProps;
+
+          var _resolvedProps4 = workInProgress.elementType === _Component3 ? _unresolvedProps4 : resolveDefaultProps(_Component3, _unresolvedProps4);
+
+          return mountIncompleteClassComponent(current, workInProgress, _Component3, _resolvedProps4, renderExpirationTime);
+        }
+
+      case SuspenseListComponent:
+        {
+          return updateSuspenseListComponent(current, workInProgress, renderExpirationTime);
+        }
+    }
+
+    {
+      {
+        throw Error( "Unknown unit of work tag (" + workInProgress.tag + "). This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function markUpdate(workInProgress) {
+    // Tag the fiber with an update effect. This turns a Placement into
+    // a PlacementAndUpdate.
+    workInProgress.effectTag |= Update;
+  }
+
+  function markRef$1(workInProgress) {
+    workInProgress.effectTag |= Ref;
+  }
+
+  var appendAllChildren;
+  var updateHostContainer;
+  var updateHostComponent$1;
+  var updateHostText$1;
+
+  {
+    // Mutation mode
+    appendAllChildren = function (parent, workInProgress, needsVisibilityToggle, isHidden) {
+      // We only have the top Fiber that was created but we need recurse down its
+      // children to find all the terminal nodes.
+      var node = workInProgress.child;
+
+      while (node !== null) {
+        if (node.tag === HostComponent || node.tag === HostText) {
+          appendInitialChild(parent, node.stateNode);
+        } else if (node.tag === HostPortal) ; else if (node.child !== null) {
+          node.child.return = node;
+          node = node.child;
+          continue;
+        }
+
+        if (node === workInProgress) {
+          return;
+        }
+
+        while (node.sibling === null) {
+          if (node.return === null || node.return === workInProgress) {
+            return;
+          }
+
+          node = node.return;
+        }
+
+        node.sibling.return = node.return;
+        node = node.sibling;
+      }
+    };
+
+    updateHostContainer = function (workInProgress) {// Noop
+    };
+
+    updateHostComponent$1 = function (current, workInProgress, type, newProps, rootContainerInstance) {
+      // If we have an alternate, that means this is an update and we need to
+      // schedule a side-effect to do the updates.
+      var oldProps = current.memoizedProps;
+
+      if (oldProps === newProps) {
+        // In mutation mode, this is sufficient for a bailout because
+        // we won't touch this node even if children changed.
+        return;
+      } // If we get updated because one of our children updated, we don't
+      // have newProps so we'll have to reuse them.
+      // TODO: Split the update API as separate for the props vs. children.
+      // Even better would be if children weren't special cased at all tho.
+
+
+      var instance = workInProgress.stateNode;
+      var currentHostContext = getHostContext(); // TODO: Experiencing an error where oldProps is null. Suggests a host
+      // component is hitting the resume path. Figure out why. Possibly
+      // related to `hidden`.
+
+      var updatePayload = prepareUpdate(instance, type, oldProps, newProps, rootContainerInstance, currentHostContext); // TODO: Type this specific to this type of component.
+
+      workInProgress.updateQueue = updatePayload; // If the update payload indicates that there is a change or if there
+      // is a new ref we mark this as an update. All the work is done in commitWork.
+
+      if (updatePayload) {
+        markUpdate(workInProgress);
+      }
+    };
+
+    updateHostText$1 = function (current, workInProgress, oldText, newText) {
+      // If the text differs, mark it as an update. All the work in done in commitWork.
+      if (oldText !== newText) {
+        markUpdate(workInProgress);
+      }
+    };
+  }
+
+  function cutOffTailIfNeeded(renderState, hasRenderedATailFallback) {
+    switch (renderState.tailMode) {
+      case 'hidden':
+        {
+          // Any insertions at the end of the tail list after this point
+          // should be invisible. If there are already mounted boundaries
+          // anything before them are not considered for collapsing.
+          // Therefore we need to go through the whole tail to find if
+          // there are any.
+          var tailNode = renderState.tail;
+          var lastTailNode = null;
+
+          while (tailNode !== null) {
+            if (tailNode.alternate !== null) {
+              lastTailNode = tailNode;
+            }
+
+            tailNode = tailNode.sibling;
+          } // Next we're simply going to delete all insertions after the
+          // last rendered item.
+
+
+          if (lastTailNode === null) {
+            // All remaining items in the tail are insertions.
+            renderState.tail = null;
+          } else {
+            // Detach the insertion after the last node that was already
+            // inserted.
+            lastTailNode.sibling = null;
+          }
+
+          break;
+        }
+
+      case 'collapsed':
+        {
+          // Any insertions at the end of the tail list after this point
+          // should be invisible. If there are already mounted boundaries
+          // anything before them are not considered for collapsing.
+          // Therefore we need to go through the whole tail to find if
+          // there are any.
+          var _tailNode = renderState.tail;
+          var _lastTailNode = null;
+
+          while (_tailNode !== null) {
+            if (_tailNode.alternate !== null) {
+              _lastTailNode = _tailNode;
+            }
+
+            _tailNode = _tailNode.sibling;
+          } // Next we're simply going to delete all insertions after the
+          // last rendered item.
+
+
+          if (_lastTailNode === null) {
+            // All remaining items in the tail are insertions.
+            if (!hasRenderedATailFallback && renderState.tail !== null) {
+              // We suspended during the head. We want to show at least one
+              // row at the tail. So we'll keep on and cut off the rest.
+              renderState.tail.sibling = null;
+            } else {
+              renderState.tail = null;
+            }
+          } else {
+            // Detach the insertion after the last node that was already
+            // inserted.
+            _lastTailNode.sibling = null;
+          }
+
+          break;
+        }
+    }
+  }
+
+  function completeWork(current, workInProgress, renderExpirationTime) {
+    var newProps = workInProgress.pendingProps;
+
+    switch (workInProgress.tag) {
+      case IndeterminateComponent:
+      case LazyComponent:
+      case SimpleMemoComponent:
+      case FunctionComponent:
+      case ForwardRef:
+      case Fragment:
+      case Mode:
+      case Profiler:
+      case ContextConsumer:
+      case MemoComponent:
+        return null;
+
+      case ClassComponent:
+        {
+          var Component = workInProgress.type;
+
+          if (isContextProvider(Component)) {
+            popContext(workInProgress);
+          }
+
+          return null;
+        }
+
+      case HostRoot:
+        {
+          popHostContainer(workInProgress);
+          popTopLevelContextObject(workInProgress);
+          var fiberRoot = workInProgress.stateNode;
+
+          if (fiberRoot.pendingContext) {
+            fiberRoot.context = fiberRoot.pendingContext;
+            fiberRoot.pendingContext = null;
+          }
+
+          if (current === null || current.child === null) {
+            // If we hydrated, pop so that we can delete any remaining children
+            // that weren't hydrated.
+            var wasHydrated = popHydrationState(workInProgress);
+
+            if (wasHydrated) {
+              // If we hydrated, then we'll need to schedule an update for
+              // the commit side-effects on the root.
+              markUpdate(workInProgress);
+            }
+          }
+
+          updateHostContainer(workInProgress);
+          return null;
+        }
+
+      case HostComponent:
+        {
+          popHostContext(workInProgress);
+          var rootContainerInstance = getRootHostContainer();
+          var type = workInProgress.type;
+
+          if (current !== null && workInProgress.stateNode != null) {
+            updateHostComponent$1(current, workInProgress, type, newProps, rootContainerInstance);
+
+            if (current.ref !== workInProgress.ref) {
+              markRef$1(workInProgress);
+            }
+          } else {
+            if (!newProps) {
+              if (!(workInProgress.stateNode !== null)) {
+                {
+                  throw Error( "We must have new props for new mounts. This error is likely caused by a bug in React. Please file an issue." );
+                }
+              } // This can happen when we abort work.
+
+
+              return null;
+            }
+
+            var currentHostContext = getHostContext(); // TODO: Move createInstance to beginWork and keep it on a context
+            // "stack" as the parent. Then append children as we go in beginWork
+            // or completeWork depending on whether we want to add them top->down or
+            // bottom->up. Top->down is faster in IE11.
+
+            var _wasHydrated = popHydrationState(workInProgress);
+
+            if (_wasHydrated) {
+              // TODO: Move this and createInstance step into the beginPhase
+              // to consolidate.
+              if (prepareToHydrateHostInstance(workInProgress, rootContainerInstance, currentHostContext)) {
+                // If changes to the hydrated node need to be applied at the
+                // commit-phase we mark this as such.
+                markUpdate(workInProgress);
+              }
+            } else {
+              var instance = createInstance(type, newProps, rootContainerInstance, currentHostContext, workInProgress);
+              appendAllChildren(instance, workInProgress, false, false); // This needs to be set before we mount Flare event listeners
+
+              workInProgress.stateNode = instance;
+              // (eg DOM renderer supports auto-focus for certain elements).
+              // Make sure such renderers get scheduled for later work.
+
+
+              if (finalizeInitialChildren(instance, type, newProps, rootContainerInstance)) {
+                markUpdate(workInProgress);
+              }
+            }
+
+            if (workInProgress.ref !== null) {
+              // If there is a ref on a host node we need to schedule a callback
+              markRef$1(workInProgress);
+            }
+          }
+
+          return null;
+        }
+
+      case HostText:
+        {
+          var newText = newProps;
+
+          if (current && workInProgress.stateNode != null) {
+            var oldText = current.memoizedProps; // If we have an alternate, that means this is an update and we need
+            // to schedule a side-effect to do the updates.
+
+            updateHostText$1(current, workInProgress, oldText, newText);
+          } else {
+            if (typeof newText !== 'string') {
+              if (!(workInProgress.stateNode !== null)) {
+                {
+                  throw Error( "We must have new props for new mounts. This error is likely caused by a bug in React. Please file an issue." );
+                }
+              } // This can happen when we abort work.
+
+            }
+
+            var _rootContainerInstance = getRootHostContainer();
+
+            var _currentHostContext = getHostContext();
+
+            var _wasHydrated2 = popHydrationState(workInProgress);
+
+            if (_wasHydrated2) {
+              if (prepareToHydrateHostTextInstance(workInProgress)) {
+                markUpdate(workInProgress);
+              }
+            } else {
+              workInProgress.stateNode = createTextInstance(newText, _rootContainerInstance, _currentHostContext, workInProgress);
+            }
+          }
+
+          return null;
+        }
+
+      case SuspenseComponent:
+        {
+          popSuspenseContext(workInProgress);
+          var nextState = workInProgress.memoizedState;
+
+          if ((workInProgress.effectTag & DidCapture) !== NoEffect) {
+            // Something suspended. Re-render with the fallback children.
+            workInProgress.expirationTime = renderExpirationTime; // Do not reset the effect list.
+
+            return workInProgress;
+          }
+
+          var nextDidTimeout = nextState !== null;
+          var prevDidTimeout = false;
+
+          if (current === null) {
+            if (workInProgress.memoizedProps.fallback !== undefined) {
+              popHydrationState(workInProgress);
+            }
+          } else {
+            var prevState = current.memoizedState;
+            prevDidTimeout = prevState !== null;
+
+            if (!nextDidTimeout && prevState !== null) {
+              // We just switched from the fallback to the normal children.
+              // Delete the fallback.
+              // TODO: Would it be better to store the fallback fragment on
+              // the stateNode during the begin phase?
+              var currentFallbackChild = current.child.sibling;
+
+              if (currentFallbackChild !== null) {
+                // Deletions go at the beginning of the return fiber's effect list
+                var first = workInProgress.firstEffect;
+
+                if (first !== null) {
+                  workInProgress.firstEffect = currentFallbackChild;
+                  currentFallbackChild.nextEffect = first;
+                } else {
+                  workInProgress.firstEffect = workInProgress.lastEffect = currentFallbackChild;
+                  currentFallbackChild.nextEffect = null;
+                }
+
+                currentFallbackChild.effectTag = Deletion;
+              }
+            }
+          }
+
+          if (nextDidTimeout && !prevDidTimeout) {
+            // If this subtreee is running in blocking mode we can suspend,
+            // otherwise we won't suspend.
+            // TODO: This will still suspend a synchronous tree if anything
+            // in the concurrent tree already suspended during this render.
+            // This is a known bug.
+            if ((workInProgress.mode & BlockingMode) !== NoMode) {
+              // TODO: Move this back to throwException because this is too late
+              // if this is a large tree which is common for initial loads. We
+              // don't know if we should restart a render or not until we get
+              // this marker, and this is too late.
+              // If this render already had a ping or lower pri updates,
+              // and this is the first time we know we're going to suspend we
+              // should be able to immediately restart from within throwException.
+              var hasInvisibleChildContext = current === null && workInProgress.memoizedProps.unstable_avoidThisFallback !== true;
+
+              if (hasInvisibleChildContext || hasSuspenseContext(suspenseStackCursor.current, InvisibleParentSuspenseContext)) {
+                // If this was in an invisible tree or a new render, then showing
+                // this boundary is ok.
+                renderDidSuspend();
+              } else {
+                // Otherwise, we're going to have to hide content so we should
+                // suspend for longer if possible.
+                renderDidSuspendDelayIfPossible();
+              }
+            }
+          }
+
+          {
+            // TODO: Only schedule updates if these values are non equal, i.e. it changed.
+            if (nextDidTimeout || prevDidTimeout) {
+              // If this boundary just timed out, schedule an effect to attach a
+              // retry listener to the promise. This flag is also used to hide the
+              // primary children. In mutation mode, we also need the flag to
+              // *unhide* children that were previously hidden, so check if this
+              // is currently timed out, too.
+              workInProgress.effectTag |= Update;
+            }
+          }
+
+          return null;
+        }
+
+      case HostPortal:
+        popHostContainer(workInProgress);
+        updateHostContainer(workInProgress);
+        return null;
+
+      case ContextProvider:
+        // Pop provider fiber
+        popProvider(workInProgress);
+        return null;
+
+      case IncompleteClassComponent:
+        {
+          // Same as class component case. I put it down here so that the tags are
+          // sequential to ensure this switch is compiled to a jump table.
+          var _Component = workInProgress.type;
+
+          if (isContextProvider(_Component)) {
+            popContext(workInProgress);
+          }
+
+          return null;
+        }
+
+      case SuspenseListComponent:
+        {
+          popSuspenseContext(workInProgress);
+          var renderState = workInProgress.memoizedState;
+
+          if (renderState === null) {
+            // We're running in the default, "independent" mode.
+            // We don't do anything in this mode.
+            return null;
+          }
+
+          var didSuspendAlready = (workInProgress.effectTag & DidCapture) !== NoEffect;
+          var renderedTail = renderState.rendering;
+
+          if (renderedTail === null) {
+            // We just rendered the head.
+            if (!didSuspendAlready) {
+              // This is the first pass. We need to figure out if anything is still
+              // suspended in the rendered set.
+              // If new content unsuspended, but there's still some content that
+              // didn't. Then we need to do a second pass that forces everything
+              // to keep showing their fallbacks.
+              // We might be suspended if something in this render pass suspended, or
+              // something in the previous committed pass suspended. Otherwise,
+              // there's no chance so we can skip the expensive call to
+              // findFirstSuspended.
+              var cannotBeSuspended = renderHasNotSuspendedYet() && (current === null || (current.effectTag & DidCapture) === NoEffect);
+
+              if (!cannotBeSuspended) {
+                var row = workInProgress.child;
+
+                while (row !== null) {
+                  var suspended = findFirstSuspended(row);
+
+                  if (suspended !== null) {
+                    didSuspendAlready = true;
+                    workInProgress.effectTag |= DidCapture;
+                    cutOffTailIfNeeded(renderState, false); // If this is a newly suspended tree, it might not get committed as
+                    // part of the second pass. In that case nothing will subscribe to
+                    // its thennables. Instead, we'll transfer its thennables to the
+                    // SuspenseList so that it can retry if they resolve.
+                    // There might be multiple of these in the list but since we're
+                    // going to wait for all of them anyway, it doesn't really matter
+                    // which ones gets to ping. In theory we could get clever and keep
+                    // track of how many dependencies remain but it gets tricky because
+                    // in the meantime, we can add/remove/change items and dependencies.
+                    // We might bail out of the loop before finding any but that
+                    // doesn't matter since that means that the other boundaries that
+                    // we did find already has their listeners attached.
+
+                    var newThennables = suspended.updateQueue;
+
+                    if (newThennables !== null) {
+                      workInProgress.updateQueue = newThennables;
+                      workInProgress.effectTag |= Update;
+                    } // Rerender the whole list, but this time, we'll force fallbacks
+                    // to stay in place.
+                    // Reset the effect list before doing the second pass since that's now invalid.
+
+
+                    if (renderState.lastEffect === null) {
+                      workInProgress.firstEffect = null;
+                    }
+
+                    workInProgress.lastEffect = renderState.lastEffect; // Reset the child fibers to their original state.
+
+                    resetChildFibers(workInProgress, renderExpirationTime); // Set up the Suspense Context to force suspense and immediately
+                    // rerender the children.
+
+                    pushSuspenseContext(workInProgress, setShallowSuspenseContext(suspenseStackCursor.current, ForceSuspenseFallback));
+                    return workInProgress.child;
+                  }
+
+                  row = row.sibling;
+                }
+              }
+            } else {
+              cutOffTailIfNeeded(renderState, false);
+            } // Next we're going to render the tail.
+
+          } else {
+            // Append the rendered row to the child list.
+            if (!didSuspendAlready) {
+              var _suspended = findFirstSuspended(renderedTail);
+
+              if (_suspended !== null) {
+                workInProgress.effectTag |= DidCapture;
+                didSuspendAlready = true; // Ensure we transfer the update queue to the parent so that it doesn't
+                // get lost if this row ends up dropped during a second pass.
+
+                var _newThennables = _suspended.updateQueue;
+
+                if (_newThennables !== null) {
+                  workInProgress.updateQueue = _newThennables;
+                  workInProgress.effectTag |= Update;
+                }
+
+                cutOffTailIfNeeded(renderState, true); // This might have been modified.
+
+                if (renderState.tail === null && renderState.tailMode === 'hidden' && !renderedTail.alternate) {
+                  // We need to delete the row we just rendered.
+                  // Reset the effect list to what it was before we rendered this
+                  // child. The nested children have already appended themselves.
+                  var lastEffect = workInProgress.lastEffect = renderState.lastEffect; // Remove any effects that were appended after this point.
+
+                  if (lastEffect !== null) {
+                    lastEffect.nextEffect = null;
+                  } // We're done.
+
+
+                  return null;
+                }
+              } else if ( // The time it took to render last row is greater than time until
+              // the expiration.
+              now() * 2 - renderState.renderingStartTime > renderState.tailExpiration && renderExpirationTime > Never) {
+                // We have now passed our CPU deadline and we'll just give up further
+                // attempts to render the main content and only render fallbacks.
+                // The assumption is that this is usually faster.
+                workInProgress.effectTag |= DidCapture;
+                didSuspendAlready = true;
+                cutOffTailIfNeeded(renderState, false); // Since nothing actually suspended, there will nothing to ping this
+                // to get it started back up to attempt the next item. If we can show
+                // them, then they really have the same priority as this render.
+                // So we'll pick it back up the very next render pass once we've had
+                // an opportunity to yield for paint.
+
+                var nextPriority = renderExpirationTime - 1;
+                workInProgress.expirationTime = workInProgress.childExpirationTime = nextPriority;
+
+                {
+                  markSpawnedWork(nextPriority);
+                }
+              }
+            }
+
+            if (renderState.isBackwards) {
+              // The effect list of the backwards tail will have been added
+              // to the end. This breaks the guarantee that life-cycles fire in
+              // sibling order but that isn't a strong guarantee promised by React.
+              // Especially since these might also just pop in during future commits.
+              // Append to the beginning of the list.
+              renderedTail.sibling = workInProgress.child;
+              workInProgress.child = renderedTail;
+            } else {
+              var previousSibling = renderState.last;
+
+              if (previousSibling !== null) {
+                previousSibling.sibling = renderedTail;
+              } else {
+                workInProgress.child = renderedTail;
+              }
+
+              renderState.last = renderedTail;
+            }
+          }
+
+          if (renderState.tail !== null) {
+            // We still have tail rows to render.
+            if (renderState.tailExpiration === 0) {
+              // Heuristic for how long we're willing to spend rendering rows
+              // until we just give up and show what we have so far.
+              var TAIL_EXPIRATION_TIMEOUT_MS = 500;
+              renderState.tailExpiration = now() + TAIL_EXPIRATION_TIMEOUT_MS; // TODO: This is meant to mimic the train model or JND but this
+              // is a per component value. It should really be since the start
+              // of the total render or last commit. Consider using something like
+              // globalMostRecentFallbackTime. That doesn't account for being
+              // suspended for part of the time or when it's a new render.
+              // It should probably use a global start time value instead.
+            } // Pop a row.
+
+
+            var next = renderState.tail;
+            renderState.rendering = next;
+            renderState.tail = next.sibling;
+            renderState.lastEffect = workInProgress.lastEffect;
+            renderState.renderingStartTime = now();
+            next.sibling = null; // Restore the context.
+            // TODO: We can probably just avoid popping it instead and only
+            // setting it the first time we go from not suspended to suspended.
+
+            var suspenseContext = suspenseStackCursor.current;
+
+            if (didSuspendAlready) {
+              suspenseContext = setShallowSuspenseContext(suspenseContext, ForceSuspenseFallback);
+            } else {
+              suspenseContext = setDefaultShallowSuspenseContext(suspenseContext);
+            }
+
+            pushSuspenseContext(workInProgress, suspenseContext); // Do a pass over the next row.
+
+            return next;
+          }
+
+          return null;
+        }
+    }
+
+    {
+      {
+        throw Error( "Unknown unit of work tag (" + workInProgress.tag + "). This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function unwindWork(workInProgress, renderExpirationTime) {
+    switch (workInProgress.tag) {
+      case ClassComponent:
+        {
+          var Component = workInProgress.type;
+
+          if (isContextProvider(Component)) {
+            popContext(workInProgress);
+          }
+
+          var effectTag = workInProgress.effectTag;
+
+          if (effectTag & ShouldCapture) {
+            workInProgress.effectTag = effectTag & ~ShouldCapture | DidCapture;
+            return workInProgress;
+          }
+
+          return null;
+        }
+
+      case HostRoot:
+        {
+          popHostContainer(workInProgress);
+          popTopLevelContextObject(workInProgress);
+          var _effectTag = workInProgress.effectTag;
+
+          if (!((_effectTag & DidCapture) === NoEffect)) {
+            {
+              throw Error( "The root failed to unmount after an error. This is likely a bug in React. Please file an issue." );
+            }
+          }
+
+          workInProgress.effectTag = _effectTag & ~ShouldCapture | DidCapture;
+          return workInProgress;
+        }
+
+      case HostComponent:
+        {
+          // TODO: popHydrationState
+          popHostContext(workInProgress);
+          return null;
+        }
+
+      case SuspenseComponent:
+        {
+          popSuspenseContext(workInProgress);
+
+          var _effectTag2 = workInProgress.effectTag;
+
+          if (_effectTag2 & ShouldCapture) {
+            workInProgress.effectTag = _effectTag2 & ~ShouldCapture | DidCapture; // Captured a suspense effect. Re-render the boundary.
+
+            return workInProgress;
+          }
+
+          return null;
+        }
+
+      case SuspenseListComponent:
+        {
+          popSuspenseContext(workInProgress); // SuspenseList doesn't actually catch anything. It should've been
+          // caught by a nested boundary. If not, it should bubble through.
+
+          return null;
+        }
+
+      case HostPortal:
+        popHostContainer(workInProgress);
+        return null;
+
+      case ContextProvider:
+        popProvider(workInProgress);
+        return null;
+
+      default:
+        return null;
+    }
+  }
+
+  function unwindInterruptedWork(interruptedWork) {
+    switch (interruptedWork.tag) {
+      case ClassComponent:
+        {
+          var childContextTypes = interruptedWork.type.childContextTypes;
+
+          if (childContextTypes !== null && childContextTypes !== undefined) {
+            popContext(interruptedWork);
+          }
+
+          break;
+        }
+
+      case HostRoot:
+        {
+          popHostContainer(interruptedWork);
+          popTopLevelContextObject(interruptedWork);
+          break;
+        }
+
+      case HostComponent:
+        {
+          popHostContext(interruptedWork);
+          break;
+        }
+
+      case HostPortal:
+        popHostContainer(interruptedWork);
+        break;
+
+      case SuspenseComponent:
+        popSuspenseContext(interruptedWork);
+        break;
+
+      case SuspenseListComponent:
+        popSuspenseContext(interruptedWork);
+        break;
+
+      case ContextProvider:
+        popProvider(interruptedWork);
+        break;
+    }
+  }
+
+  function createCapturedValue(value, source) {
+    // If the value is an error, call this function immediately after it is thrown
+    // so the stack is accurate.
+    return {
+      value: value,
+      source: source,
+      stack: getStackByFiberInDevAndProd(source)
+    };
+  }
+
+  function logCapturedError(capturedError) {
+
+    var error = capturedError.error;
+
+    {
+      var componentName = capturedError.componentName,
+          componentStack = capturedError.componentStack,
+          errorBoundaryName = capturedError.errorBoundaryName,
+          errorBoundaryFound = capturedError.errorBoundaryFound,
+          willRetry = capturedError.willRetry; // Browsers support silencing uncaught errors by calling
+      // `preventDefault()` in window `error` handler.
+      // We record this information as an expando on the error.
+
+      if (error != null && error._suppressLogging) {
+        if (errorBoundaryFound && willRetry) {
+          // The error is recoverable and was silenced.
+          // Ignore it and don't print the stack addendum.
+          // This is handy for testing error boundaries without noise.
+          return;
+        } // The error is fatal. Since the silencing might have
+        // been accidental, we'll surface it anyway.
+        // However, the browser would have silenced the original error
+        // so we'll print it first, and then print the stack addendum.
+
+
+        console['error'](error); // Don't transform to our wrapper
+        // For a more detailed description of this block, see:
+        // https://github.com/facebook/react/pull/13384
+      }
+
+      var componentNameMessage = componentName ? "The above error occurred in the <" + componentName + "> component:" : 'The above error occurred in one of your React components:';
+      var errorBoundaryMessage; // errorBoundaryFound check is sufficient; errorBoundaryName check is to satisfy Flow.
+
+      if (errorBoundaryFound && errorBoundaryName) {
+        if (willRetry) {
+          errorBoundaryMessage = "React will try to recreate this component tree from scratch " + ("using the error boundary you provided, " + errorBoundaryName + ".");
+        } else {
+          errorBoundaryMessage = "This error was initially handled by the error boundary " + errorBoundaryName + ".\n" + "Recreating the tree from scratch failed so React will unmount the tree.";
+        }
+      } else {
+        errorBoundaryMessage = 'Consider adding an error boundary to your tree to customize error handling behavior.\n' + 'Visit https://fb.me/react-error-boundaries to learn more about error boundaries.';
+      }
+
+      var combinedMessage = "" + componentNameMessage + componentStack + "\n\n" + ("" + errorBoundaryMessage); // In development, we provide our own message with just the component stack.
+      // We don't include the original error message and JS stack because the browser
+      // has already printed it. Even if the application swallows the error, it is still
+      // displayed by the browser thanks to the DEV-only fake event trick in ReactErrorUtils.
+
+      console['error'](combinedMessage); // Don't transform to our wrapper
+    }
+  }
+
+  var didWarnAboutUndefinedSnapshotBeforeUpdate = null;
+
+  {
+    didWarnAboutUndefinedSnapshotBeforeUpdate = new Set();
+  }
+
+  var PossiblyWeakSet = typeof WeakSet === 'function' ? WeakSet : Set;
+  function logError(boundary, errorInfo) {
+    var source = errorInfo.source;
+    var stack = errorInfo.stack;
+
+    if (stack === null && source !== null) {
+      stack = getStackByFiberInDevAndProd(source);
+    }
+
+    var capturedError = {
+      componentName: source !== null ? getComponentName(source.type) : null,
+      componentStack: stack !== null ? stack : '',
+      error: errorInfo.value,
+      errorBoundary: null,
+      errorBoundaryName: null,
+      errorBoundaryFound: false,
+      willRetry: false
+    };
+
+    if (boundary !== null && boundary.tag === ClassComponent) {
+      capturedError.errorBoundary = boundary.stateNode;
+      capturedError.errorBoundaryName = getComponentName(boundary.type);
+      capturedError.errorBoundaryFound = true;
+      capturedError.willRetry = true;
+    }
+
+    try {
+      logCapturedError(capturedError);
+    } catch (e) {
+      // This method must not throw, or React internal state will get messed up.
+      // If console.error is overridden, or logCapturedError() shows a dialog that throws,
+      // we want to report this error outside of the normal stack as a last resort.
+      // https://github.com/facebook/react/issues/13188
+      setTimeout(function () {
+        throw e;
+      });
+    }
+  }
+
+  var callComponentWillUnmountWithTimer = function (current, instance) {
+    startPhaseTimer(current, 'componentWillUnmount');
+    instance.props = current.memoizedProps;
+    instance.state = current.memoizedState;
+    instance.componentWillUnmount();
+    stopPhaseTimer();
+  }; // Capture errors so they don't interrupt unmounting.
+
+
+  function safelyCallComponentWillUnmount(current, instance) {
+    {
+      invokeGuardedCallback(null, callComponentWillUnmountWithTimer, null, current, instance);
+
+      if (hasCaughtError()) {
+        var unmountError = clearCaughtError();
+        captureCommitPhaseError(current, unmountError);
+      }
+    }
+  }
+
+  function safelyDetachRef(current) {
+    var ref = current.ref;
+
+    if (ref !== null) {
+      if (typeof ref === 'function') {
+        {
+          invokeGuardedCallback(null, ref, null, null);
+
+          if (hasCaughtError()) {
+            var refError = clearCaughtError();
+            captureCommitPhaseError(current, refError);
+          }
+        }
+      } else {
+        ref.current = null;
+      }
+    }
+  }
+
+  function safelyCallDestroy(current, destroy) {
+    {
+      invokeGuardedCallback(null, destroy, null);
+
+      if (hasCaughtError()) {
+        var error = clearCaughtError();
+        captureCommitPhaseError(current, error);
+      }
+    }
+  }
+
+  function commitBeforeMutationLifeCycles(current, finishedWork) {
+    switch (finishedWork.tag) {
+      case FunctionComponent:
+      case ForwardRef:
+      case SimpleMemoComponent:
+      case Block:
+        {
+          return;
+        }
+
+      case ClassComponent:
+        {
+          if (finishedWork.effectTag & Snapshot) {
+            if (current !== null) {
+              var prevProps = current.memoizedProps;
+              var prevState = current.memoizedState;
+              startPhaseTimer(finishedWork, 'getSnapshotBeforeUpdate');
+              var instance = finishedWork.stateNode; // We could update instance props and state here,
+              // but instead we rely on them being set during last render.
+              // TODO: revisit this when we implement resuming.
+
+              {
+                if (finishedWork.type === finishedWork.elementType && !didWarnAboutReassigningProps) {
+                  if (instance.props !== finishedWork.memoizedProps) {
+                    error('Expected %s props to match memoized props before ' + 'getSnapshotBeforeUpdate. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+
+                  if (instance.state !== finishedWork.memoizedState) {
+                    error('Expected %s state to match memoized state before ' + 'getSnapshotBeforeUpdate. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+                }
+              }
+
+              var snapshot = instance.getSnapshotBeforeUpdate(finishedWork.elementType === finishedWork.type ? prevProps : resolveDefaultProps(finishedWork.type, prevProps), prevState);
+
+              {
+                var didWarnSet = didWarnAboutUndefinedSnapshotBeforeUpdate;
+
+                if (snapshot === undefined && !didWarnSet.has(finishedWork.type)) {
+                  didWarnSet.add(finishedWork.type);
+
+                  error('%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' + 'must be returned. You have returned undefined.', getComponentName(finishedWork.type));
+                }
+              }
+
+              instance.__reactInternalSnapshotBeforeUpdate = snapshot;
+              stopPhaseTimer();
+            }
+          }
+
+          return;
+        }
+
+      case HostRoot:
+      case HostComponent:
+      case HostText:
+      case HostPortal:
+      case IncompleteClassComponent:
+        // Nothing to do for these component types
+        return;
+    }
+
+    {
+      {
+        throw Error( "This unit of work tag should not have side-effects. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function commitHookEffectListUnmount(tag, finishedWork) {
+    var updateQueue = finishedWork.updateQueue;
+    var lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
+
+    if (lastEffect !== null) {
+      var firstEffect = lastEffect.next;
+      var effect = firstEffect;
+
+      do {
+        if ((effect.tag & tag) === tag) {
+          // Unmount
+          var destroy = effect.destroy;
+          effect.destroy = undefined;
+
+          if (destroy !== undefined) {
+            destroy();
+          }
+        }
+
+        effect = effect.next;
+      } while (effect !== firstEffect);
+    }
+  }
+
+  function commitHookEffectListMount(tag, finishedWork) {
+    var updateQueue = finishedWork.updateQueue;
+    var lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
+
+    if (lastEffect !== null) {
+      var firstEffect = lastEffect.next;
+      var effect = firstEffect;
+
+      do {
+        if ((effect.tag & tag) === tag) {
+          // Mount
+          var create = effect.create;
+          effect.destroy = create();
+
+          {
+            var destroy = effect.destroy;
+
+            if (destroy !== undefined && typeof destroy !== 'function') {
+              var addendum = void 0;
+
+              if (destroy === null) {
+                addendum = ' You returned null. If your effect does not require clean ' + 'up, return undefined (or nothing).';
+              } else if (typeof destroy.then === 'function') {
+                addendum = '\n\nIt looks like you wrote useEffect(async () => ...) or returned a Promise. ' + 'Instead, write the async function inside your effect ' + 'and call it immediately:\n\n' + 'useEffect(() => {\n' + '  async function fetchData() {\n' + '    // You can await here\n' + '    const response = await MyAPI.getData(someId);\n' + '    // ...\n' + '  }\n' + '  fetchData();\n' + "}, [someId]); // Or [] if effect doesn't need props or state\n\n" + 'Learn more about data fetching with Hooks: https://fb.me/react-hooks-data-fetching';
+              } else {
+                addendum = ' You returned: ' + destroy;
+              }
+
+              error('An effect function must not return anything besides a function, ' + 'which is used for clean-up.%s%s', addendum, getStackByFiberInDevAndProd(finishedWork));
+            }
+          }
+        }
+
+        effect = effect.next;
+      } while (effect !== firstEffect);
+    }
+  }
+
+  function commitPassiveHookEffects(finishedWork) {
+    if ((finishedWork.effectTag & Passive) !== NoEffect) {
+      switch (finishedWork.tag) {
+        case FunctionComponent:
+        case ForwardRef:
+        case SimpleMemoComponent:
+        case Block:
+          {
+            // TODO (#17945) We should call all passive destroy functions (for all fibers)
+            // before calling any create functions. The current approach only serializes
+            // these for a single fiber.
+            commitHookEffectListUnmount(Passive$1 | HasEffect, finishedWork);
+            commitHookEffectListMount(Passive$1 | HasEffect, finishedWork);
+            break;
+          }
+      }
+    }
+  }
+
+  function commitLifeCycles(finishedRoot, current, finishedWork, committedExpirationTime) {
+    switch (finishedWork.tag) {
+      case FunctionComponent:
+      case ForwardRef:
+      case SimpleMemoComponent:
+      case Block:
+        {
+          // At this point layout effects have already been destroyed (during mutation phase).
+          // This is done to prevent sibling component effects from interfering with each other,
+          // e.g. a destroy function in one component should never override a ref set
+          // by a create function in another component during the same commit.
+          commitHookEffectListMount(Layout | HasEffect, finishedWork);
+
+          return;
+        }
+
+      case ClassComponent:
+        {
+          var instance = finishedWork.stateNode;
+
+          if (finishedWork.effectTag & Update) {
+            if (current === null) {
+              startPhaseTimer(finishedWork, 'componentDidMount'); // We could update instance props and state here,
+              // but instead we rely on them being set during last render.
+              // TODO: revisit this when we implement resuming.
+
+              {
+                if (finishedWork.type === finishedWork.elementType && !didWarnAboutReassigningProps) {
+                  if (instance.props !== finishedWork.memoizedProps) {
+                    error('Expected %s props to match memoized props before ' + 'componentDidMount. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+
+                  if (instance.state !== finishedWork.memoizedState) {
+                    error('Expected %s state to match memoized state before ' + 'componentDidMount. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+                }
+              }
+
+              instance.componentDidMount();
+              stopPhaseTimer();
+            } else {
+              var prevProps = finishedWork.elementType === finishedWork.type ? current.memoizedProps : resolveDefaultProps(finishedWork.type, current.memoizedProps);
+              var prevState = current.memoizedState;
+              startPhaseTimer(finishedWork, 'componentDidUpdate'); // We could update instance props and state here,
+              // but instead we rely on them being set during last render.
+              // TODO: revisit this when we implement resuming.
+
+              {
+                if (finishedWork.type === finishedWork.elementType && !didWarnAboutReassigningProps) {
+                  if (instance.props !== finishedWork.memoizedProps) {
+                    error('Expected %s props to match memoized props before ' + 'componentDidUpdate. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+
+                  if (instance.state !== finishedWork.memoizedState) {
+                    error('Expected %s state to match memoized state before ' + 'componentDidUpdate. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+                }
+              }
+
+              instance.componentDidUpdate(prevProps, prevState, instance.__reactInternalSnapshotBeforeUpdate);
+              stopPhaseTimer();
+            }
+          }
+
+          var updateQueue = finishedWork.updateQueue;
+
+          if (updateQueue !== null) {
+            {
+              if (finishedWork.type === finishedWork.elementType && !didWarnAboutReassigningProps) {
+                if (instance.props !== finishedWork.memoizedProps) {
+                  error('Expected %s props to match memoized props before ' + 'processing the update queue. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                }
+
+                if (instance.state !== finishedWork.memoizedState) {
+                  error('Expected %s state to match memoized state before ' + 'processing the update queue. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                }
+              }
+            } // We could update instance props and state here,
+            // but instead we rely on them being set during last render.
+            // TODO: revisit this when we implement resuming.
+
+
+            commitUpdateQueue(finishedWork, updateQueue, instance);
+          }
+
+          return;
+        }
+
+      case HostRoot:
+        {
+          var _updateQueue = finishedWork.updateQueue;
+
+          if (_updateQueue !== null) {
+            var _instance = null;
+
+            if (finishedWork.child !== null) {
+              switch (finishedWork.child.tag) {
+                case HostComponent:
+                  _instance = getPublicInstance(finishedWork.child.stateNode);
+                  break;
+
+                case ClassComponent:
+                  _instance = finishedWork.child.stateNode;
+                  break;
+              }
+            }
+
+            commitUpdateQueue(finishedWork, _updateQueue, _instance);
+          }
+
+          return;
+        }
+
+      case HostComponent:
+        {
+          var _instance2 = finishedWork.stateNode; // Renderers may schedule work to be done after host components are mounted
+          // (eg DOM renderer may schedule auto-focus for inputs and form controls).
+          // These effects should only be committed when components are first mounted,
+          // aka when there is no current/alternate.
+
+          if (current === null && finishedWork.effectTag & Update) {
+            var type = finishedWork.type;
+            var props = finishedWork.memoizedProps;
+            commitMount(_instance2, type, props);
+          }
+
+          return;
+        }
+
+      case HostText:
+        {
+          // We have no life-cycles associated with text.
+          return;
+        }
+
+      case HostPortal:
+        {
+          // We have no life-cycles associated with portals.
+          return;
+        }
+
+      case Profiler:
+        {
+          {
+            var onRender = finishedWork.memoizedProps.onRender;
+
+            if (typeof onRender === 'function') {
+              {
+                onRender(finishedWork.memoizedProps.id, current === null ? 'mount' : 'update', finishedWork.actualDuration, finishedWork.treeBaseDuration, finishedWork.actualStartTime, getCommitTime(), finishedRoot.memoizedInteractions);
+              }
+            }
+          }
+
+          return;
+        }
+
+      case SuspenseComponent:
+        {
+          commitSuspenseHydrationCallbacks(finishedRoot, finishedWork);
+          return;
+        }
+
+      case SuspenseListComponent:
+      case IncompleteClassComponent:
+      case FundamentalComponent:
+      case ScopeComponent:
+        return;
+    }
+
+    {
+      {
+        throw Error( "This unit of work tag should not have side-effects. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function hideOrUnhideAllChildren(finishedWork, isHidden) {
+    {
+      // We only have the top Fiber that was inserted but we need to recurse down its
+      // children to find all the terminal nodes.
+      var node = finishedWork;
+
+      while (true) {
+        if (node.tag === HostComponent) {
+          var instance = node.stateNode;
+
+          if (isHidden) {
+            hideInstance(instance);
+          } else {
+            unhideInstance(node.stateNode, node.memoizedProps);
+          }
+        } else if (node.tag === HostText) {
+          var _instance3 = node.stateNode;
+
+          if (isHidden) {
+            hideTextInstance(_instance3);
+          } else {
+            unhideTextInstance(_instance3, node.memoizedProps);
+          }
+        } else if (node.tag === SuspenseComponent && node.memoizedState !== null && node.memoizedState.dehydrated === null) {
+          // Found a nested Suspense component that timed out. Skip over the
+          // primary child fragment, which should remain hidden.
+          var fallbackChildFragment = node.child.sibling;
+          fallbackChildFragment.return = node;
+          node = fallbackChildFragment;
+          continue;
+        } else if (node.child !== null) {
+          node.child.return = node;
+          node = node.child;
+          continue;
+        }
+
+        if (node === finishedWork) {
+          return;
+        }
+
+        while (node.sibling === null) {
+          if (node.return === null || node.return === finishedWork) {
+            return;
+          }
+
+          node = node.return;
+        }
+
+        node.sibling.return = node.return;
+        node = node.sibling;
+      }
+    }
+  }
+
+  function commitAttachRef(finishedWork) {
+    var ref = finishedWork.ref;
+
+    if (ref !== null) {
+      var instance = finishedWork.stateNode;
+      var instanceToUse;
+
+      switch (finishedWork.tag) {
+        case HostComponent:
+          instanceToUse = getPublicInstance(instance);
+          break;
+
+        default:
+          instanceToUse = instance;
+      } // Moved outside to ensure DCE works with this flag
+
+      if (typeof ref === 'function') {
+        ref(instanceToUse);
+      } else {
+        {
+          if (!ref.hasOwnProperty('current')) {
+            error('Unexpected ref object provided for %s. ' + 'Use either a ref-setter function or React.createRef().%s', getComponentName(finishedWork.type), getStackByFiberInDevAndProd(finishedWork));
+          }
+        }
+
+        ref.current = instanceToUse;
+      }
+    }
+  }
+
+  function commitDetachRef(current) {
+    var currentRef = current.ref;
+
+    if (currentRef !== null) {
+      if (typeof currentRef === 'function') {
+        currentRef(null);
+      } else {
+        currentRef.current = null;
+      }
+    }
+  } // User-originating errors (lifecycles and refs) should not interrupt
+  // deletion, so don't let them throw. Host-originating errors should
+  // interrupt deletion, so it's okay
+
+
+  function commitUnmount(finishedRoot, current, renderPriorityLevel) {
+    onCommitUnmount(current);
+
+    switch (current.tag) {
+      case FunctionComponent:
+      case ForwardRef:
+      case MemoComponent:
+      case SimpleMemoComponent:
+      case Block:
+        {
+          var updateQueue = current.updateQueue;
+
+          if (updateQueue !== null) {
+            var lastEffect = updateQueue.lastEffect;
+
+            if (lastEffect !== null) {
+              var firstEffect = lastEffect.next;
+
+              {
+                // When the owner fiber is deleted, the destroy function of a passive
+                // effect hook is called during the synchronous commit phase. This is
+                // a concession to implementation complexity. Calling it in the
+                // passive effect phase (like they usually are, when dependencies
+                // change during an update) would require either traversing the
+                // children of the deleted fiber again, or including unmount effects
+                // as part of the fiber effect list.
+                //
+                // Because this is during the sync commit phase, we need to change
+                // the priority.
+                //
+                // TODO: Reconsider this implementation trade off.
+                var priorityLevel = renderPriorityLevel > NormalPriority ? NormalPriority : renderPriorityLevel;
+                runWithPriority$1(priorityLevel, function () {
+                  var effect = firstEffect;
+
+                  do {
+                    var _destroy = effect.destroy;
+
+                    if (_destroy !== undefined) {
+                      safelyCallDestroy(current, _destroy);
+                    }
+
+                    effect = effect.next;
+                  } while (effect !== firstEffect);
+                });
+              }
+            }
+          }
+
+          return;
+        }
+
+      case ClassComponent:
+        {
+          safelyDetachRef(current);
+          var instance = current.stateNode;
+
+          if (typeof instance.componentWillUnmount === 'function') {
+            safelyCallComponentWillUnmount(current, instance);
+          }
+
+          return;
+        }
+
+      case HostComponent:
+        {
+
+          safelyDetachRef(current);
+          return;
+        }
+
+      case HostPortal:
+        {
+          // TODO: this is recursive.
+          // We are also not using this parent because
+          // the portal will get pushed immediately.
+          {
+            unmountHostComponents(finishedRoot, current, renderPriorityLevel);
+          }
+
+          return;
+        }
+
+      case FundamentalComponent:
+        {
+
+          return;
+        }
+
+      case DehydratedFragment:
+        {
+
+          return;
+        }
+
+      case ScopeComponent:
+        {
+
+          return;
+        }
+    }
+  }
+
+  function commitNestedUnmounts(finishedRoot, root, renderPriorityLevel) {
+    // While we're inside a removed host node we don't want to call
+    // removeChild on the inner nodes because they're removed by the top
+    // call anyway. We also want to call componentWillUnmount on all
+    // composites before this host node is removed from the tree. Therefore
+    // we do an inner loop while we're still inside the host node.
+    var node = root;
+
+    while (true) {
+      commitUnmount(finishedRoot, node, renderPriorityLevel); // Visit children because they may contain more composite or host nodes.
+      // Skip portals because commitUnmount() currently visits them recursively.
+
+      if (node.child !== null && ( // If we use mutation we drill down into portals using commitUnmount above.
+      // If we don't use mutation we drill down into portals here instead.
+       node.tag !== HostPortal)) {
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
+
+      if (node === root) {
+        return;
+      }
+
+      while (node.sibling === null) {
+        if (node.return === null || node.return === root) {
+          return;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    }
+  }
+
+  function detachFiber(current) {
+    var alternate = current.alternate; // Cut off the return pointers to disconnect it from the tree. Ideally, we
+    // should clear the child pointer of the parent alternate to let this
+    // get GC:ed but we don't know which for sure which parent is the current
+    // one so we'll settle for GC:ing the subtree of this child. This child
+    // itself will be GC:ed when the parent updates the next time.
+
+    current.return = null;
+    current.child = null;
+    current.memoizedState = null;
+    current.updateQueue = null;
+    current.dependencies = null;
+    current.alternate = null;
+    current.firstEffect = null;
+    current.lastEffect = null;
+    current.pendingProps = null;
+    current.memoizedProps = null;
+    current.stateNode = null;
+
+    if (alternate !== null) {
+      detachFiber(alternate);
+    }
+  }
+
+  function getHostParentFiber(fiber) {
+    var parent = fiber.return;
+
+    while (parent !== null) {
+      if (isHostParent(parent)) {
+        return parent;
+      }
+
+      parent = parent.return;
+    }
+
+    {
+      {
+        throw Error( "Expected to find a host parent. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function isHostParent(fiber) {
+    return fiber.tag === HostComponent || fiber.tag === HostRoot || fiber.tag === HostPortal;
+  }
+
+  function getHostSibling(fiber) {
+    // We're going to search forward into the tree until we find a sibling host
+    // node. Unfortunately, if multiple insertions are done in a row we have to
+    // search past them. This leads to exponential search for the next sibling.
+    // TODO: Find a more efficient way to do this.
+    var node = fiber;
+
+    siblings: while (true) {
+      // If we didn't find anything, let's try the next sibling.
+      while (node.sibling === null) {
+        if (node.return === null || isHostParent(node.return)) {
+          // If we pop out of the root or hit the parent the fiber we are the
+          // last sibling.
+          return null;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+
+      while (node.tag !== HostComponent && node.tag !== HostText && node.tag !== DehydratedFragment) {
+        // If it is not host node and, we might have a host node inside it.
+        // Try to search down until we find one.
+        if (node.effectTag & Placement) {
+          // If we don't have a child, try the siblings instead.
+          continue siblings;
+        } // If we don't have a child, try the siblings instead.
+        // We also skip portals because they are not part of this host tree.
+
+
+        if (node.child === null || node.tag === HostPortal) {
+          continue siblings;
+        } else {
+          node.child.return = node;
+          node = node.child;
+        }
+      } // Check if this host node is stable or about to be placed.
+
+
+      if (!(node.effectTag & Placement)) {
+        // Found it!
+        return node.stateNode;
+      }
+    }
+  }
+
+  function commitPlacement(finishedWork) {
+
+
+    var parentFiber = getHostParentFiber(finishedWork); // Note: these two variables *must* always be updated together.
+
+    var parent;
+    var isContainer;
+    var parentStateNode = parentFiber.stateNode;
+
+    switch (parentFiber.tag) {
+      case HostComponent:
+        parent = parentStateNode;
+        isContainer = false;
+        break;
+
+      case HostRoot:
+        parent = parentStateNode.containerInfo;
+        isContainer = true;
+        break;
+
+      case HostPortal:
+        parent = parentStateNode.containerInfo;
+        isContainer = true;
+        break;
+
+      case FundamentalComponent:
+
+      // eslint-disable-next-line-no-fallthrough
+
+      default:
+        {
+          {
+            throw Error( "Invalid host parent fiber. This error is likely caused by a bug in React. Please file an issue." );
+          }
+        }
+
+    }
+
+    if (parentFiber.effectTag & ContentReset) {
+      // Reset the text content of the parent before doing any insertions
+      resetTextContent(parent); // Clear ContentReset from the effect tag
+
+      parentFiber.effectTag &= ~ContentReset;
+    }
+
+    var before = getHostSibling(finishedWork); // We only have the top Fiber that was inserted but we need to recurse down its
+    // children to find all the terminal nodes.
+
+    if (isContainer) {
+      insertOrAppendPlacementNodeIntoContainer(finishedWork, before, parent);
+    } else {
+      insertOrAppendPlacementNode(finishedWork, before, parent);
+    }
+  }
+
+  function insertOrAppendPlacementNodeIntoContainer(node, before, parent) {
+    var tag = node.tag;
+    var isHost = tag === HostComponent || tag === HostText;
+
+    if (isHost || enableFundamentalAPI ) {
+      var stateNode = isHost ? node.stateNode : node.stateNode.instance;
+
+      if (before) {
+        insertInContainerBefore(parent, stateNode, before);
+      } else {
+        appendChildToContainer(parent, stateNode);
+      }
+    } else if (tag === HostPortal) ; else {
+      var child = node.child;
+
+      if (child !== null) {
+        insertOrAppendPlacementNodeIntoContainer(child, before, parent);
+        var sibling = child.sibling;
+
+        while (sibling !== null) {
+          insertOrAppendPlacementNodeIntoContainer(sibling, before, parent);
+          sibling = sibling.sibling;
+        }
+      }
+    }
+  }
+
+  function insertOrAppendPlacementNode(node, before, parent) {
+    var tag = node.tag;
+    var isHost = tag === HostComponent || tag === HostText;
+
+    if (isHost || enableFundamentalAPI ) {
+      var stateNode = isHost ? node.stateNode : node.stateNode.instance;
+
+      if (before) {
+        insertBefore(parent, stateNode, before);
+      } else {
+        appendChild(parent, stateNode);
+      }
+    } else if (tag === HostPortal) ; else {
+      var child = node.child;
+
+      if (child !== null) {
+        insertOrAppendPlacementNode(child, before, parent);
+        var sibling = child.sibling;
+
+        while (sibling !== null) {
+          insertOrAppendPlacementNode(sibling, before, parent);
+          sibling = sibling.sibling;
+        }
+      }
+    }
+  }
+
+  function unmountHostComponents(finishedRoot, current, renderPriorityLevel) {
+    // We only have the top Fiber that was deleted but we need to recurse down its
+    // children to find all the terminal nodes.
+    var node = current; // Each iteration, currentParent is populated with node's host parent if not
+    // currentParentIsValid.
+
+    var currentParentIsValid = false; // Note: these two variables *must* always be updated together.
+
+    var currentParent;
+    var currentParentIsContainer;
+
+    while (true) {
+      if (!currentParentIsValid) {
+        var parent = node.return;
+
+        findParent: while (true) {
+          if (!(parent !== null)) {
+            {
+              throw Error( "Expected to find a host parent. This error is likely caused by a bug in React. Please file an issue." );
+            }
+          }
+
+          var parentStateNode = parent.stateNode;
+
+          switch (parent.tag) {
+            case HostComponent:
+              currentParent = parentStateNode;
+              currentParentIsContainer = false;
+              break findParent;
+
+            case HostRoot:
+              currentParent = parentStateNode.containerInfo;
+              currentParentIsContainer = true;
+              break findParent;
+
+            case HostPortal:
+              currentParent = parentStateNode.containerInfo;
+              currentParentIsContainer = true;
+              break findParent;
+
+          }
+
+          parent = parent.return;
+        }
+
+        currentParentIsValid = true;
+      }
+
+      if (node.tag === HostComponent || node.tag === HostText) {
+        commitNestedUnmounts(finishedRoot, node, renderPriorityLevel); // After all the children have unmounted, it is now safe to remove the
+        // node from the tree.
+
+        if (currentParentIsContainer) {
+          removeChildFromContainer(currentParent, node.stateNode);
+        } else {
+          removeChild(currentParent, node.stateNode);
+        } // Don't visit children because we already visited them.
+
+      } else if (node.tag === HostPortal) {
+        if (node.child !== null) {
+          // When we go into a portal, it becomes the parent to remove from.
+          // We will reassign it back when we pop the portal on the way up.
+          currentParent = node.stateNode.containerInfo;
+          currentParentIsContainer = true; // Visit children because portals might contain host components.
+
+          node.child.return = node;
+          node = node.child;
+          continue;
+        }
+      } else {
+        commitUnmount(finishedRoot, node, renderPriorityLevel); // Visit children because we may find more host components below.
+
+        if (node.child !== null) {
+          node.child.return = node;
+          node = node.child;
+          continue;
+        }
+      }
+
+      if (node === current) {
+        return;
+      }
+
+      while (node.sibling === null) {
+        if (node.return === null || node.return === current) {
+          return;
+        }
+
+        node = node.return;
+
+        if (node.tag === HostPortal) {
+          // When we go out of the portal, we need to restore the parent.
+          // Since we don't keep a stack of them, we will search for it.
+          currentParentIsValid = false;
+        }
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    }
+  }
+
+  function commitDeletion(finishedRoot, current, renderPriorityLevel) {
+    {
+      // Recursively delete all host nodes from the parent.
+      // Detach refs and call componentWillUnmount() on the whole subtree.
+      unmountHostComponents(finishedRoot, current, renderPriorityLevel);
+    }
+
+    detachFiber(current);
+  }
+
+  function commitWork(current, finishedWork) {
+
+    switch (finishedWork.tag) {
+      case FunctionComponent:
+      case ForwardRef:
+      case MemoComponent:
+      case SimpleMemoComponent:
+      case Block:
+        {
+          // Layout effects are destroyed during the mutation phase so that all
+          // destroy functions for all fibers are called before any create functions.
+          // This prevents sibling component effects from interfering with each other,
+          // e.g. a destroy function in one component should never override a ref set
+          // by a create function in another component during the same commit.
+          commitHookEffectListUnmount(Layout | HasEffect, finishedWork);
+          return;
+        }
+
+      case ClassComponent:
+        {
+          return;
+        }
+
+      case HostComponent:
+        {
+          var instance = finishedWork.stateNode;
+
+          if (instance != null) {
+            // Commit the work prepared earlier.
+            var newProps = finishedWork.memoizedProps; // For hydration we reuse the update path but we treat the oldProps
+            // as the newProps. The updatePayload will contain the real change in
+            // this case.
+
+            var oldProps = current !== null ? current.memoizedProps : newProps;
+            var type = finishedWork.type; // TODO: Type the updateQueue to be specific to host components.
+
+            var updatePayload = finishedWork.updateQueue;
+            finishedWork.updateQueue = null;
+
+            if (updatePayload !== null) {
+              commitUpdate(instance, updatePayload, type, oldProps, newProps);
+            }
+          }
+
+          return;
+        }
+
+      case HostText:
+        {
+          if (!(finishedWork.stateNode !== null)) {
+            {
+              throw Error( "This should have a text node initialized. This error is likely caused by a bug in React. Please file an issue." );
+            }
+          }
+
+          var textInstance = finishedWork.stateNode;
+          var newText = finishedWork.memoizedProps; // For hydration we reuse the update path but we treat the oldProps
+          // as the newProps. The updatePayload will contain the real change in
+          // this case.
+
+          var oldText = current !== null ? current.memoizedProps : newText;
+          commitTextUpdate(textInstance, oldText, newText);
+          return;
+        }
+
+      case HostRoot:
+        {
+          {
+            var _root = finishedWork.stateNode;
+
+            if (_root.hydrate) {
+              // We've just hydrated. No need to hydrate again.
+              _root.hydrate = false;
+              commitHydratedContainer(_root.containerInfo);
+            }
+          }
+
+          return;
+        }
+
+      case Profiler:
+        {
+          return;
+        }
+
+      case SuspenseComponent:
+        {
+          commitSuspenseComponent(finishedWork);
+          attachSuspenseRetryListeners(finishedWork);
+          return;
+        }
+
+      case SuspenseListComponent:
+        {
+          attachSuspenseRetryListeners(finishedWork);
+          return;
+        }
+
+      case IncompleteClassComponent:
+        {
+          return;
+        }
+    }
+
+    {
+      {
+        throw Error( "This unit of work tag should not have side-effects. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function commitSuspenseComponent(finishedWork) {
+    var newState = finishedWork.memoizedState;
+    var newDidTimeout;
+    var primaryChildParent = finishedWork;
+
+    if (newState === null) {
+      newDidTimeout = false;
+    } else {
+      newDidTimeout = true;
+      primaryChildParent = finishedWork.child;
+      markCommitTimeOfFallback();
+    }
+
+    if ( primaryChildParent !== null) {
+      hideOrUnhideAllChildren(primaryChildParent, newDidTimeout);
+    }
+  }
+
+  function commitSuspenseHydrationCallbacks(finishedRoot, finishedWork) {
+
+    var newState = finishedWork.memoizedState;
+
+    if (newState === null) {
+      var current = finishedWork.alternate;
+
+      if (current !== null) {
+        var prevState = current.memoizedState;
+
+        if (prevState !== null) {
+          var suspenseInstance = prevState.dehydrated;
+
+          if (suspenseInstance !== null) {
+            commitHydratedSuspenseInstance(suspenseInstance);
+          }
+        }
+      }
+    }
+  }
+
+  function attachSuspenseRetryListeners(finishedWork) {
+    // If this boundary just timed out, then it will have a set of thenables.
+    // For each thenable, attach a listener so that when it resolves, React
+    // attempts to re-render the boundary in the primary (pre-timeout) state.
+    var thenables = finishedWork.updateQueue;
+
+    if (thenables !== null) {
+      finishedWork.updateQueue = null;
+      var retryCache = finishedWork.stateNode;
+
+      if (retryCache === null) {
+        retryCache = finishedWork.stateNode = new PossiblyWeakSet();
+      }
+
+      thenables.forEach(function (thenable) {
+        // Memoize using the boundary fiber to prevent redundant listeners.
+        var retry = resolveRetryThenable.bind(null, finishedWork, thenable);
+
+        if (!retryCache.has(thenable)) {
+          {
+            if (thenable.__reactDoNotTraceInteractions !== true) {
+              retry = unstable_wrap(retry);
+            }
+          }
+
+          retryCache.add(thenable);
+          thenable.then(retry, retry);
+        }
+      });
+    }
+  }
+
+  function commitResetTextContent(current) {
+
+    resetTextContent(current.stateNode);
+  }
+
+  var PossiblyWeakMap$1 = typeof WeakMap === 'function' ? WeakMap : Map;
+
+  function createRootErrorUpdate(fiber, errorInfo, expirationTime) {
+    var update = createUpdate(expirationTime, null); // Unmount the root by rendering null.
+
+    update.tag = CaptureUpdate; // Caution: React DevTools currently depends on this property
+    // being called "element".
+
+    update.payload = {
+      element: null
+    };
+    var error = errorInfo.value;
+
+    update.callback = function () {
+      onUncaughtError(error);
+      logError(fiber, errorInfo);
+    };
+
+    return update;
+  }
+
+  function createClassErrorUpdate(fiber, errorInfo, expirationTime) {
+    var update = createUpdate(expirationTime, null);
+    update.tag = CaptureUpdate;
+    var getDerivedStateFromError = fiber.type.getDerivedStateFromError;
+
+    if (typeof getDerivedStateFromError === 'function') {
+      var error$1 = errorInfo.value;
+
+      update.payload = function () {
+        logError(fiber, errorInfo);
+        return getDerivedStateFromError(error$1);
+      };
+    }
+
+    var inst = fiber.stateNode;
+
+    if (inst !== null && typeof inst.componentDidCatch === 'function') {
+      update.callback = function callback() {
+        {
+          markFailedErrorBoundaryForHotReloading(fiber);
+        }
+
+        if (typeof getDerivedStateFromError !== 'function') {
+          // To preserve the preexisting retry behavior of error boundaries,
+          // we keep track of which ones already failed during this batch.
+          // This gets reset before we yield back to the browser.
+          // TODO: Warn in strict mode if getDerivedStateFromError is
+          // not defined.
+          markLegacyErrorBoundaryAsFailed(this); // Only log here if componentDidCatch is the only error boundary method defined
+
+          logError(fiber, errorInfo);
+        }
+
+        var error$1 = errorInfo.value;
+        var stack = errorInfo.stack;
+        this.componentDidCatch(error$1, {
+          componentStack: stack !== null ? stack : ''
+        });
+
+        {
+          if (typeof getDerivedStateFromError !== 'function') {
+            // If componentDidCatch is the only error boundary method defined,
+            // then it needs to call setState to recover from errors.
+            // If no state update is scheduled then the boundary will swallow the error.
+            if (fiber.expirationTime !== Sync) {
+              error('%s: Error boundaries should implement getDerivedStateFromError(). ' + 'In that method, return a state update to display an error message or fallback UI.', getComponentName(fiber.type) || 'Unknown');
+            }
+          }
+        }
+      };
+    } else {
+      update.callback = function () {
+        markFailedErrorBoundaryForHotReloading(fiber);
+      };
+    }
+
+    return update;
+  }
+
+  function attachPingListener(root, renderExpirationTime, thenable) {
+    // Attach a listener to the promise to "ping" the root and retry. But
+    // only if one does not already exist for the current render expiration
+    // time (which acts like a "thread ID" here).
+    var pingCache = root.pingCache;
+    var threadIDs;
+
+    if (pingCache === null) {
+      pingCache = root.pingCache = new PossiblyWeakMap$1();
+      threadIDs = new Set();
+      pingCache.set(thenable, threadIDs);
+    } else {
+      threadIDs = pingCache.get(thenable);
+
+      if (threadIDs === undefined) {
+        threadIDs = new Set();
+        pingCache.set(thenable, threadIDs);
+      }
+    }
+
+    if (!threadIDs.has(renderExpirationTime)) {
+      // Memoize using the thread ID to prevent redundant listeners.
+      threadIDs.add(renderExpirationTime);
+      var ping = pingSuspendedRoot.bind(null, root, thenable, renderExpirationTime);
+      thenable.then(ping, ping);
+    }
+  }
+
+  function throwException(root, returnFiber, sourceFiber, value, renderExpirationTime) {
+    // The source fiber did not complete.
+    sourceFiber.effectTag |= Incomplete; // Its effect list is no longer valid.
+
+    sourceFiber.firstEffect = sourceFiber.lastEffect = null;
+
+    if (value !== null && typeof value === 'object' && typeof value.then === 'function') {
+      // This is a thenable.
+      var thenable = value;
+
+      if ((sourceFiber.mode & BlockingMode) === NoMode) {
+        // Reset the memoizedState to what it was before we attempted
+        // to render it.
+        var currentSource = sourceFiber.alternate;
+
+        if (currentSource) {
+          sourceFiber.updateQueue = currentSource.updateQueue;
+          sourceFiber.memoizedState = currentSource.memoizedState;
+          sourceFiber.expirationTime = currentSource.expirationTime;
+        } else {
+          sourceFiber.updateQueue = null;
+          sourceFiber.memoizedState = null;
+        }
+      }
+
+      var hasInvisibleParentBoundary = hasSuspenseContext(suspenseStackCursor.current, InvisibleParentSuspenseContext); // Schedule the nearest Suspense to re-render the timed out view.
+
+      var _workInProgress = returnFiber;
+
+      do {
+        if (_workInProgress.tag === SuspenseComponent && shouldCaptureSuspense(_workInProgress, hasInvisibleParentBoundary)) {
+          // Found the nearest boundary.
+          // Stash the promise on the boundary fiber. If the boundary times out, we'll
+          // attach another listener to flip the boundary back to its normal state.
+          var thenables = _workInProgress.updateQueue;
+
+          if (thenables === null) {
+            var updateQueue = new Set();
+            updateQueue.add(thenable);
+            _workInProgress.updateQueue = updateQueue;
+          } else {
+            thenables.add(thenable);
+          } // If the boundary is outside of blocking mode, we should *not*
+          // suspend the commit. Pretend as if the suspended component rendered
+          // null and keep rendering. In the commit phase, we'll schedule a
+          // subsequent synchronous update to re-render the Suspense.
+          //
+          // Note: It doesn't matter whether the component that suspended was
+          // inside a blocking mode tree. If the Suspense is outside of it, we
+          // should *not* suspend the commit.
+
+
+          if ((_workInProgress.mode & BlockingMode) === NoMode) {
+            _workInProgress.effectTag |= DidCapture; // We're going to commit this fiber even though it didn't complete.
+            // But we shouldn't call any lifecycle methods or callbacks. Remove
+            // all lifecycle effect tags.
+
+            sourceFiber.effectTag &= ~(LifecycleEffectMask | Incomplete);
+
+            if (sourceFiber.tag === ClassComponent) {
+              var currentSourceFiber = sourceFiber.alternate;
+
+              if (currentSourceFiber === null) {
+                // This is a new mount. Change the tag so it's not mistaken for a
+                // completed class component. For example, we should not call
+                // componentWillUnmount if it is deleted.
+                sourceFiber.tag = IncompleteClassComponent;
+              } else {
+                // When we try rendering again, we should not reuse the current fiber,
+                // since it's known to be in an inconsistent state. Use a force update to
+                // prevent a bail out.
+                var update = createUpdate(Sync, null);
+                update.tag = ForceUpdate;
+                enqueueUpdate(sourceFiber, update);
+              }
+            } // The source fiber did not complete. Mark it with Sync priority to
+            // indicate that it still has pending work.
+
+
+            sourceFiber.expirationTime = Sync; // Exit without suspending.
+
+            return;
+          } // Confirmed that the boundary is in a concurrent mode tree. Continue
+          // with the normal suspend path.
+          //
+          // After this we'll use a set of heuristics to determine whether this
+          // render pass will run to completion or restart or "suspend" the commit.
+          // The actual logic for this is spread out in different places.
+          //
+          // This first principle is that if we're going to suspend when we complete
+          // a root, then we should also restart if we get an update or ping that
+          // might unsuspend it, and vice versa. The only reason to suspend is
+          // because you think you might want to restart before committing. However,
+          // it doesn't make sense to restart only while in the period we're suspended.
+          //
+          // Restarting too aggressively is also not good because it starves out any
+          // intermediate loading state. So we use heuristics to determine when.
+          // Suspense Heuristics
+          //
+          // If nothing threw a Promise or all the same fallbacks are already showing,
+          // then don't suspend/restart.
+          //
+          // If this is an initial render of a new tree of Suspense boundaries and
+          // those trigger a fallback, then don't suspend/restart. We want to ensure
+          // that we can show the initial loading state as quickly as possible.
+          //
+          // If we hit a "Delayed" case, such as when we'd switch from content back into
+          // a fallback, then we should always suspend/restart. SuspenseConfig applies to
+          // this case. If none is defined, JND is used instead.
+          //
+          // If we're already showing a fallback and it gets "retried", allowing us to show
+          // another level, but there's still an inner boundary that would show a fallback,
+          // then we suspend/restart for 500ms since the last time we showed a fallback
+          // anywhere in the tree. This effectively throttles progressive loading into a
+          // consistent train of commits. This also gives us an opportunity to restart to
+          // get to the completed state slightly earlier.
+          //
+          // If there's ambiguity due to batching it's resolved in preference of:
+          // 1) "delayed", 2) "initial render", 3) "retry".
+          //
+          // We want to ensure that a "busy" state doesn't get force committed. We want to
+          // ensure that new initial loading states can commit as soon as possible.
+
+
+          attachPingListener(root, renderExpirationTime, thenable);
+          _workInProgress.effectTag |= ShouldCapture;
+          _workInProgress.expirationTime = renderExpirationTime;
+          return;
+        } // This boundary already captured during this render. Continue to the next
+        // boundary.
+
+
+        _workInProgress = _workInProgress.return;
+      } while (_workInProgress !== null); // No boundary was found. Fallthrough to error mode.
+      // TODO: Use invariant so the message is stripped in prod?
+
+
+      value = new Error((getComponentName(sourceFiber.type) || 'A React component') + ' suspended while rendering, but no fallback UI was specified.\n' + '\n' + 'Add a <Suspense fallback=...> component higher in the tree to ' + 'provide a loading indicator or placeholder to display.' + getStackByFiberInDevAndProd(sourceFiber));
+    } // We didn't find a boundary that could handle this type of exception. Start
+    // over and traverse parent path again, this time treating the exception
+    // as an error.
+
+
+    renderDidError();
+    value = createCapturedValue(value, sourceFiber);
+    var workInProgress = returnFiber;
+
+    do {
+      switch (workInProgress.tag) {
+        case HostRoot:
+          {
+            var _errorInfo = value;
+            workInProgress.effectTag |= ShouldCapture;
+            workInProgress.expirationTime = renderExpirationTime;
+
+            var _update = createRootErrorUpdate(workInProgress, _errorInfo, renderExpirationTime);
+
+            enqueueCapturedUpdate(workInProgress, _update);
+            return;
+          }
+
+        case ClassComponent:
+          // Capture and retry
+          var errorInfo = value;
+          var ctor = workInProgress.type;
+          var instance = workInProgress.stateNode;
+
+          if ((workInProgress.effectTag & DidCapture) === NoEffect && (typeof ctor.getDerivedStateFromError === 'function' || instance !== null && typeof instance.componentDidCatch === 'function' && !isAlreadyFailedLegacyErrorBoundary(instance))) {
+            workInProgress.effectTag |= ShouldCapture;
+            workInProgress.expirationTime = renderExpirationTime; // Schedule the error boundary to re-render using updated state
+
+            var _update2 = createClassErrorUpdate(workInProgress, errorInfo, renderExpirationTime);
+
+            enqueueCapturedUpdate(workInProgress, _update2);
+            return;
+          }
+
+          break;
+      }
+
+      workInProgress = workInProgress.return;
+    } while (workInProgress !== null);
+  }
+
+  var ceil = Math.ceil;
+  var ReactCurrentDispatcher$1 = ReactSharedInternals.ReactCurrentDispatcher,
+      ReactCurrentOwner$2 = ReactSharedInternals.ReactCurrentOwner,
+      IsSomeRendererActing = ReactSharedInternals.IsSomeRendererActing;
+  var NoContext =
+  /*                    */
+  0;
+  var BatchedContext =
+  /*               */
+  1;
+  var EventContext =
+  /*                 */
+  2;
+  var DiscreteEventContext =
+  /*         */
+  4;
+  var LegacyUnbatchedContext =
+  /*       */
+  8;
+  var RenderContext =
+  /*                */
+  16;
+  var CommitContext =
+  /*                */
+  32;
+  var RootIncomplete = 0;
+  var RootFatalErrored = 1;
+  var RootErrored = 2;
+  var RootSuspended = 3;
+  var RootSuspendedWithDelay = 4;
+  var RootCompleted = 5;
+  // Describes where we are in the React execution stack
+  var executionContext = NoContext; // The root we're working on
+
+  var workInProgressRoot = null; // The fiber we're working on
+
+  var workInProgress = null; // The expiration time we're rendering
+
+  var renderExpirationTime$1 = NoWork; // Whether to root completed, errored, suspended, etc.
+
+  var workInProgressRootExitStatus = RootIncomplete; // A fatal error, if one is thrown
+
+  var workInProgressRootFatalError = null; // Most recent event time among processed updates during this render.
+  // This is conceptually a time stamp but expressed in terms of an ExpirationTime
+  // because we deal mostly with expiration times in the hot path, so this avoids
+  // the conversion happening in the hot path.
+
+  var workInProgressRootLatestProcessedExpirationTime = Sync;
+  var workInProgressRootLatestSuspenseTimeout = Sync;
+  var workInProgressRootCanSuspendUsingConfig = null; // The work left over by components that were visited during this render. Only
+  // includes unprocessed updates, not work in bailed out children.
+
+  var workInProgressRootNextUnprocessedUpdateTime = NoWork; // If we're pinged while rendering we don't always restart immediately.
+  // This flag determines if it might be worthwhile to restart if an opportunity
+  // happens latere.
+
+  var workInProgressRootHasPendingPing = false; // The most recent time we committed a fallback. This lets us ensure a train
+  // model where we don't commit new loading states in too quick succession.
+
+  var globalMostRecentFallbackTime = 0;
+  var FALLBACK_THROTTLE_MS = 500;
+  var nextEffect = null;
+  var hasUncaughtError = false;
+  var firstUncaughtError = null;
+  var legacyErrorBoundariesThatAlreadyFailed = null;
+  var rootDoesHavePassiveEffects = false;
+  var rootWithPendingPassiveEffects = null;
+  var pendingPassiveEffectsRenderPriority = NoPriority;
+  var pendingPassiveEffectsExpirationTime = NoWork;
+  var rootsWithPendingDiscreteUpdates = null; // Use these to prevent an infinite loop of nested updates
+
+  var NESTED_UPDATE_LIMIT = 50;
+  var nestedUpdateCount = 0;
+  var rootWithNestedUpdates = null;
+  var NESTED_PASSIVE_UPDATE_LIMIT = 50;
+  var nestedPassiveUpdateCount = 0;
+  var interruptedBy = null; // Marks the need to reschedule pending interactions at these expiration times
+  // during the commit phase. This enables them to be traced across components
+  // that spawn new work during render. E.g. hidden boundaries, suspended SSR
+  // hydration or SuspenseList.
+
+  var spawnedWorkDuringRender = null; // Expiration times are computed by adding to the current time (the start
+  // time). However, if two updates are scheduled within the same event, we
+  // should treat their start times as simultaneous, even if the actual clock
+  // time has advanced between the first and second call.
+  // In other words, because expiration times determine how updates are batched,
+  // we want all updates of like priority that occur within the same event to
+  // receive the same expiration time. Otherwise we get tearing.
+
+  var currentEventTime = NoWork;
+  function requestCurrentTimeForUpdate() {
+    if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
+      // We're inside React, so it's fine to read the actual time.
+      return msToExpirationTime(now());
+    } // We're not inside React, so we may be in the middle of a browser event.
+
+
+    if (currentEventTime !== NoWork) {
+      // Use the same start time for all updates until we enter React again.
+      return currentEventTime;
+    } // This is the first update since React yielded. Compute a new start time.
+
+
+    currentEventTime = msToExpirationTime(now());
+    return currentEventTime;
+  }
+  function getCurrentTime() {
+    return msToExpirationTime(now());
+  }
+  function computeExpirationForFiber(currentTime, fiber, suspenseConfig) {
+    var mode = fiber.mode;
+
+    if ((mode & BlockingMode) === NoMode) {
+      return Sync;
+    }
+
+    var priorityLevel = getCurrentPriorityLevel();
+
+    if ((mode & ConcurrentMode) === NoMode) {
+      return priorityLevel === ImmediatePriority ? Sync : Batched;
+    }
+
+    if ((executionContext & RenderContext) !== NoContext) {
+      // Use whatever time we're already rendering
+      // TODO: Should there be a way to opt out, like with `runWithPriority`?
+      return renderExpirationTime$1;
+    }
+
+    var expirationTime;
+
+    if (suspenseConfig !== null) {
+      // Compute an expiration time based on the Suspense timeout.
+      expirationTime = computeSuspenseExpiration(currentTime, suspenseConfig.timeoutMs | 0 || LOW_PRIORITY_EXPIRATION);
+    } else {
+      // Compute an expiration time based on the Scheduler priority.
+      switch (priorityLevel) {
+        case ImmediatePriority:
+          expirationTime = Sync;
+          break;
+
+        case UserBlockingPriority$1:
+          // TODO: Rename this to computeUserBlockingExpiration
+          expirationTime = computeInteractiveExpiration(currentTime);
+          break;
+
+        case NormalPriority:
+        case LowPriority:
+          // TODO: Handle LowPriority
+          // TODO: Rename this to... something better.
+          expirationTime = computeAsyncExpiration(currentTime);
+          break;
+
+        case IdlePriority:
+          expirationTime = Idle;
+          break;
+
+        default:
+          {
+            {
+              throw Error( "Expected a valid priority level" );
+            }
+          }
+
+      }
+    } // If we're in the middle of rendering a tree, do not update at the same
+    // expiration time that is already rendering.
+    // TODO: We shouldn't have to do this if the update is on a different root.
+    // Refactor computeExpirationForFiber + scheduleUpdate so we have access to
+    // the root when we check for this condition.
+
+
+    if (workInProgressRoot !== null && expirationTime === renderExpirationTime$1) {
+      // This is a trick to move this update into a separate batch
+      expirationTime -= 1;
+    }
+
+    return expirationTime;
+  }
+  function scheduleUpdateOnFiber(fiber, expirationTime) {
+    checkForNestedUpdates();
+    warnAboutRenderPhaseUpdatesInDEV(fiber);
+    var root = markUpdateTimeFromFiberToRoot(fiber, expirationTime);
+
+    if (root === null) {
+      warnAboutUpdateOnUnmountedFiberInDEV(fiber);
+      return;
+    }
+
+    checkForInterruption(fiber, expirationTime);
+    recordScheduleUpdate(); // TODO: computeExpirationForFiber also reads the priority. Pass the
+    // priority as an argument to that function and this one.
+
+    var priorityLevel = getCurrentPriorityLevel();
+
+    if (expirationTime === Sync) {
+      if ( // Check if we're inside unbatchedUpdates
+      (executionContext & LegacyUnbatchedContext) !== NoContext && // Check if we're not already rendering
+      (executionContext & (RenderContext | CommitContext)) === NoContext) {
+        // Register pending interactions on the root to avoid losing traced interaction data.
+        schedulePendingInteractions(root, expirationTime); // This is a legacy edge case. The initial mount of a ReactDOM.render-ed
+        // root inside of batchedUpdates should be synchronous, but layout updates
+        // should be deferred until the end of the batch.
+
+        performSyncWorkOnRoot(root);
+      } else {
+        ensureRootIsScheduled(root);
+        schedulePendingInteractions(root, expirationTime);
+
+        if (executionContext === NoContext) {
+          // Flush the synchronous work now, unless we're already working or inside
+          // a batch. This is intentionally inside scheduleUpdateOnFiber instead of
+          // scheduleCallbackForFiber to preserve the ability to schedule a callback
+          // without immediately flushing it. We only do this for user-initiated
+          // updates, to preserve historical behavior of legacy mode.
+          flushSyncCallbackQueue();
+        }
+      }
+    } else {
+      ensureRootIsScheduled(root);
+      schedulePendingInteractions(root, expirationTime);
+    }
+
+    if ((executionContext & DiscreteEventContext) !== NoContext && ( // Only updates at user-blocking priority or greater are considered
+    // discrete, even inside a discrete event.
+    priorityLevel === UserBlockingPriority$1 || priorityLevel === ImmediatePriority)) {
+      // This is the result of a discrete event. Track the lowest priority
+      // discrete update per root so we can flush them early, if needed.
+      if (rootsWithPendingDiscreteUpdates === null) {
+        rootsWithPendingDiscreteUpdates = new Map([[root, expirationTime]]);
+      } else {
+        var lastDiscreteTime = rootsWithPendingDiscreteUpdates.get(root);
+
+        if (lastDiscreteTime === undefined || lastDiscreteTime > expirationTime) {
+          rootsWithPendingDiscreteUpdates.set(root, expirationTime);
+        }
+      }
+    }
+  }
+  var scheduleWork = scheduleUpdateOnFiber; // This is split into a separate function so we can mark a fiber with pending
+  // work without treating it as a typical update that originates from an event;
+  // e.g. retrying a Suspense boundary isn't an update, but it does schedule work
+  // on a fiber.
+
+  function markUpdateTimeFromFiberToRoot(fiber, expirationTime) {
+    // Update the source fiber's expiration time
+    if (fiber.expirationTime < expirationTime) {
+      fiber.expirationTime = expirationTime;
+    }
+
+    var alternate = fiber.alternate;
+
+    if (alternate !== null && alternate.expirationTime < expirationTime) {
+      alternate.expirationTime = expirationTime;
+    } // Walk the parent path to the root and update the child expiration time.
+
+
+    var node = fiber.return;
+    var root = null;
+
+    if (node === null && fiber.tag === HostRoot) {
+      root = fiber.stateNode;
+    } else {
+      while (node !== null) {
+        alternate = node.alternate;
+
+        if (node.childExpirationTime < expirationTime) {
+          node.childExpirationTime = expirationTime;
+
+          if (alternate !== null && alternate.childExpirationTime < expirationTime) {
+            alternate.childExpirationTime = expirationTime;
+          }
+        } else if (alternate !== null && alternate.childExpirationTime < expirationTime) {
+          alternate.childExpirationTime = expirationTime;
+        }
+
+        if (node.return === null && node.tag === HostRoot) {
+          root = node.stateNode;
+          break;
+        }
+
+        node = node.return;
+      }
+    }
+
+    if (root !== null) {
+      if (workInProgressRoot === root) {
+        // Received an update to a tree that's in the middle of rendering. Mark
+        // that's unprocessed work on this root.
+        markUnprocessedUpdateTime(expirationTime);
+
+        if (workInProgressRootExitStatus === RootSuspendedWithDelay) {
+          // The root already suspended with a delay, which means this render
+          // definitely won't finish. Since we have a new update, let's mark it as
+          // suspended now, right before marking the incoming update. This has the
+          // effect of interrupting the current render and switching to the update.
+          // TODO: This happens to work when receiving an update during the render
+          // phase, because of the trick inside computeExpirationForFiber to
+          // subtract 1 from `renderExpirationTime` to move it into a
+          // separate bucket. But we should probably model it with an exception,
+          // using the same mechanism we use to force hydration of a subtree.
+          // TODO: This does not account for low pri updates that were already
+          // scheduled before the root started rendering. Need to track the next
+          // pending expiration time (perhaps by backtracking the return path) and
+          // then trigger a restart in the `renderDidSuspendDelayIfPossible` path.
+          markRootSuspendedAtTime(root, renderExpirationTime$1);
+        }
+      } // Mark that the root has a pending update.
+
+
+      markRootUpdatedAtTime(root, expirationTime);
+    }
+
+    return root;
+  }
+
+  function getNextRootExpirationTimeToWorkOn(root) {
+    // Determines the next expiration time that the root should render, taking
+    // into account levels that may be suspended, or levels that may have
+    // received a ping.
+    var lastExpiredTime = root.lastExpiredTime;
+
+    if (lastExpiredTime !== NoWork) {
+      return lastExpiredTime;
+    } // "Pending" refers to any update that hasn't committed yet, including if it
+    // suspended. The "suspended" range is therefore a subset.
+
+
+    var firstPendingTime = root.firstPendingTime;
+
+    if (!isRootSuspendedAtTime(root, firstPendingTime)) {
+      // The highest priority pending time is not suspended. Let's work on that.
+      return firstPendingTime;
+    } // If the first pending time is suspended, check if there's a lower priority
+    // pending level that we know about. Or check if we received a ping. Work
+    // on whichever is higher priority.
+
+
+    var lastPingedTime = root.lastPingedTime;
+    var nextKnownPendingLevel = root.nextKnownPendingLevel;
+    var nextLevel = lastPingedTime > nextKnownPendingLevel ? lastPingedTime : nextKnownPendingLevel;
+
+    if ( nextLevel <= Idle && firstPendingTime !== nextLevel) {
+      // Don't work on Idle/Never priority unless everything else is committed.
+      return NoWork;
+    }
+
+    return nextLevel;
+  } // Use this function to schedule a task for a root. There's only one task per
+  // root; if a task was already scheduled, we'll check to make sure the
+  // expiration time of the existing task is the same as the expiration time of
+  // the next level that the root has work on. This function is called on every
+  // update, and right before exiting a task.
+
+
+  function ensureRootIsScheduled(root) {
+    var lastExpiredTime = root.lastExpiredTime;
+
+    if (lastExpiredTime !== NoWork) {
+      // Special case: Expired work should flush synchronously.
+      root.callbackExpirationTime = Sync;
+      root.callbackPriority = ImmediatePriority;
+      root.callbackNode = scheduleSyncCallback(performSyncWorkOnRoot.bind(null, root));
+      return;
+    }
+
+    var expirationTime = getNextRootExpirationTimeToWorkOn(root);
+    var existingCallbackNode = root.callbackNode;
+
+    if (expirationTime === NoWork) {
+      // There's nothing to work on.
+      if (existingCallbackNode !== null) {
+        root.callbackNode = null;
+        root.callbackExpirationTime = NoWork;
+        root.callbackPriority = NoPriority;
+      }
+
+      return;
+    } // TODO: If this is an update, we already read the current time. Pass the
+    // time as an argument.
+
+
+    var currentTime = requestCurrentTimeForUpdate();
+    var priorityLevel = inferPriorityFromExpirationTime(currentTime, expirationTime); // If there's an existing render task, confirm it has the correct priority and
+    // expiration time. Otherwise, we'll cancel it and schedule a new one.
+
+    if (existingCallbackNode !== null) {
+      var existingCallbackPriority = root.callbackPriority;
+      var existingCallbackExpirationTime = root.callbackExpirationTime;
+
+      if ( // Callback must have the exact same expiration time.
+      existingCallbackExpirationTime === expirationTime && // Callback must have greater or equal priority.
+      existingCallbackPriority >= priorityLevel) {
+        // Existing callback is sufficient.
+        return;
+      } // Need to schedule a new task.
+      // TODO: Instead of scheduling a new task, we should be able to change the
+      // priority of the existing one.
+
+
+      cancelCallback(existingCallbackNode);
+    }
+
+    root.callbackExpirationTime = expirationTime;
+    root.callbackPriority = priorityLevel;
+    var callbackNode;
+
+    if (expirationTime === Sync) {
+      // Sync React callbacks are scheduled on a special internal queue
+      callbackNode = scheduleSyncCallback(performSyncWorkOnRoot.bind(null, root));
+    } else {
+      callbackNode = scheduleCallback(priorityLevel, performConcurrentWorkOnRoot.bind(null, root), // Compute a task timeout based on the expiration time. This also affects
+      // ordering because tasks are processed in timeout order.
+      {
+        timeout: expirationTimeToMs(expirationTime) - now()
+      });
+    }
+
+    root.callbackNode = callbackNode;
+  } // This is the entry point for every concurrent task, i.e. anything that
+  // goes through Scheduler.
+
+
+  function performConcurrentWorkOnRoot(root, didTimeout) {
+    // Since we know we're in a React event, we can clear the current
+    // event time. The next update will compute a new event time.
+    currentEventTime = NoWork;
+
+    if (didTimeout) {
+      // The render task took too long to complete. Mark the current time as
+      // expired to synchronously render all expired work in a single batch.
+      var currentTime = requestCurrentTimeForUpdate();
+      markRootExpiredAtTime(root, currentTime); // This will schedule a synchronous callback.
+
+      ensureRootIsScheduled(root);
+      return null;
+    } // Determine the next expiration time to work on, using the fields stored
+    // on the root.
+
+
+    var expirationTime = getNextRootExpirationTimeToWorkOn(root);
+
+    if (expirationTime !== NoWork) {
+      var originalCallbackNode = root.callbackNode;
+
+      if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+        {
+          throw Error( "Should not already be working." );
+        }
+      }
+
+      flushPassiveEffects(); // If the root or expiration time have changed, throw out the existing stack
+      // and prepare a fresh one. Otherwise we'll continue where we left off.
+
+      if (root !== workInProgressRoot || expirationTime !== renderExpirationTime$1) {
+        prepareFreshStack(root, expirationTime);
+        startWorkOnPendingInteractions(root, expirationTime);
+      } // If we have a work-in-progress fiber, it means there's still work to do
+      // in this root.
+
+
+      if (workInProgress !== null) {
+        var prevExecutionContext = executionContext;
+        executionContext |= RenderContext;
+        var prevDispatcher = pushDispatcher();
+        var prevInteractions = pushInteractions(root);
+        startWorkLoopTimer(workInProgress);
+
+        do {
+          try {
+            workLoopConcurrent();
+            break;
+          } catch (thrownValue) {
+            handleError(root, thrownValue);
+          }
+        } while (true);
+
+        resetContextDependencies();
+        executionContext = prevExecutionContext;
+        popDispatcher(prevDispatcher);
+
+        {
+          popInteractions(prevInteractions);
+        }
+
+        if (workInProgressRootExitStatus === RootFatalErrored) {
+          var fatalError = workInProgressRootFatalError;
+          stopInterruptedWorkLoopTimer();
+          prepareFreshStack(root, expirationTime);
+          markRootSuspendedAtTime(root, expirationTime);
+          ensureRootIsScheduled(root);
+          throw fatalError;
+        }
+
+        if (workInProgress !== null) {
+          // There's still work left over. Exit without committing.
+          stopInterruptedWorkLoopTimer();
+        } else {
+          // We now have a consistent tree. The next step is either to commit it,
+          // or, if something suspended, wait to commit it after a timeout.
+          stopFinishedWorkLoopTimer();
+          var finishedWork = root.finishedWork = root.current.alternate;
+          root.finishedExpirationTime = expirationTime;
+          finishConcurrentRender(root, finishedWork, workInProgressRootExitStatus, expirationTime);
+        }
+
+        ensureRootIsScheduled(root);
+
+        if (root.callbackNode === originalCallbackNode) {
+          // The task node scheduled for this root is the same one that's
+          // currently executed. Need to return a continuation.
+          return performConcurrentWorkOnRoot.bind(null, root);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  function finishConcurrentRender(root, finishedWork, exitStatus, expirationTime) {
+    // Set this to null to indicate there's no in-progress render.
+    workInProgressRoot = null;
+
+    switch (exitStatus) {
+      case RootIncomplete:
+      case RootFatalErrored:
+        {
+          {
+            {
+              throw Error( "Root did not complete. This is a bug in React." );
+            }
+          }
+        }
+      // Flow knows about invariant, so it complains if I add a break
+      // statement, but eslint doesn't know about invariant, so it complains
+      // if I do. eslint-disable-next-line no-fallthrough
+
+      case RootErrored:
+        {
+          // If this was an async render, the error may have happened due to
+          // a mutation in a concurrent event. Try rendering one more time,
+          // synchronously, to see if the error goes away. If there are
+          // lower priority updates, let's include those, too, in case they
+          // fix the inconsistency. Render at Idle to include all updates.
+          // If it was Idle or Never or some not-yet-invented time, render
+          // at that time.
+          markRootExpiredAtTime(root, expirationTime > Idle ? Idle : expirationTime); // We assume that this second render pass will be synchronous
+          // and therefore not hit this path again.
+
+          break;
+        }
+
+      case RootSuspended:
+        {
+          markRootSuspendedAtTime(root, expirationTime);
+          var lastSuspendedTime = root.lastSuspendedTime;
+
+          if (expirationTime === lastSuspendedTime) {
+            root.nextKnownPendingLevel = getRemainingExpirationTime(finishedWork);
+          } // We have an acceptable loading state. We need to figure out if we
+          // should immediately commit it or wait a bit.
+          // If we have processed new updates during this render, we may now
+          // have a new loading state ready. We want to ensure that we commit
+          // that as soon as possible.
+
+
+          var hasNotProcessedNewUpdates = workInProgressRootLatestProcessedExpirationTime === Sync;
+
+          if (hasNotProcessedNewUpdates && // do not delay if we're inside an act() scope
+          !( IsThisRendererActing.current)) {
+            // If we have not processed any new updates during this pass, then
+            // this is either a retry of an existing fallback state or a
+            // hidden tree. Hidden trees shouldn't be batched with other work
+            // and after that's fixed it can only be a retry. We're going to
+            // throttle committing retries so that we don't show too many
+            // loading states too quickly.
+            var msUntilTimeout = globalMostRecentFallbackTime + FALLBACK_THROTTLE_MS - now(); // Don't bother with a very short suspense time.
+
+            if (msUntilTimeout > 10) {
+              if (workInProgressRootHasPendingPing) {
+                var lastPingedTime = root.lastPingedTime;
+
+                if (lastPingedTime === NoWork || lastPingedTime >= expirationTime) {
+                  // This render was pinged but we didn't get to restart
+                  // earlier so try restarting now instead.
+                  root.lastPingedTime = expirationTime;
+                  prepareFreshStack(root, expirationTime);
+                  break;
+                }
+              }
+
+              var nextTime = getNextRootExpirationTimeToWorkOn(root);
+
+              if (nextTime !== NoWork && nextTime !== expirationTime) {
+                // There's additional work on this root.
+                break;
+              }
+
+              if (lastSuspendedTime !== NoWork && lastSuspendedTime !== expirationTime) {
+                // We should prefer to render the fallback of at the last
+                // suspended level. Ping the last suspended level to try
+                // rendering it again.
+                root.lastPingedTime = lastSuspendedTime;
+                break;
+              } // The render is suspended, it hasn't timed out, and there's no
+              // lower priority work to do. Instead of committing the fallback
+              // immediately, wait for more data to arrive.
+
+
+              root.timeoutHandle = scheduleTimeout(commitRoot.bind(null, root), msUntilTimeout);
+              break;
+            }
+          } // The work expired. Commit immediately.
+
+
+          commitRoot(root);
+          break;
+        }
+
+      case RootSuspendedWithDelay:
+        {
+          markRootSuspendedAtTime(root, expirationTime);
+          var _lastSuspendedTime = root.lastSuspendedTime;
+
+          if (expirationTime === _lastSuspendedTime) {
+            root.nextKnownPendingLevel = getRemainingExpirationTime(finishedWork);
+          }
+
+          if ( // do not delay if we're inside an act() scope
+          !( IsThisRendererActing.current)) {
+            // We're suspended in a state that should be avoided. We'll try to
+            // avoid committing it for as long as the timeouts let us.
+            if (workInProgressRootHasPendingPing) {
+              var _lastPingedTime = root.lastPingedTime;
+
+              if (_lastPingedTime === NoWork || _lastPingedTime >= expirationTime) {
+                // This render was pinged but we didn't get to restart earlier
+                // so try restarting now instead.
+                root.lastPingedTime = expirationTime;
+                prepareFreshStack(root, expirationTime);
+                break;
+              }
+            }
+
+            var _nextTime = getNextRootExpirationTimeToWorkOn(root);
+
+            if (_nextTime !== NoWork && _nextTime !== expirationTime) {
+              // There's additional work on this root.
+              break;
+            }
+
+            if (_lastSuspendedTime !== NoWork && _lastSuspendedTime !== expirationTime) {
+              // We should prefer to render the fallback of at the last
+              // suspended level. Ping the last suspended level to try
+              // rendering it again.
+              root.lastPingedTime = _lastSuspendedTime;
+              break;
+            }
+
+            var _msUntilTimeout;
+
+            if (workInProgressRootLatestSuspenseTimeout !== Sync) {
+              // We have processed a suspense config whose expiration time we
+              // can use as the timeout.
+              _msUntilTimeout = expirationTimeToMs(workInProgressRootLatestSuspenseTimeout) - now();
+            } else if (workInProgressRootLatestProcessedExpirationTime === Sync) {
+              // This should never normally happen because only new updates
+              // cause delayed states, so we should have processed something.
+              // However, this could also happen in an offscreen tree.
+              _msUntilTimeout = 0;
+            } else {
+              // If we don't have a suspense config, we're going to use a
+              // heuristic to determine how long we can suspend.
+              var eventTimeMs = inferTimeFromExpirationTime(workInProgressRootLatestProcessedExpirationTime);
+              var currentTimeMs = now();
+              var timeUntilExpirationMs = expirationTimeToMs(expirationTime) - currentTimeMs;
+              var timeElapsed = currentTimeMs - eventTimeMs;
+
+              if (timeElapsed < 0) {
+                // We get this wrong some time since we estimate the time.
+                timeElapsed = 0;
+              }
+
+              _msUntilTimeout = jnd(timeElapsed) - timeElapsed; // Clamp the timeout to the expiration time. TODO: Once the
+              // event time is exact instead of inferred from expiration time
+              // we don't need this.
+
+              if (timeUntilExpirationMs < _msUntilTimeout) {
+                _msUntilTimeout = timeUntilExpirationMs;
+              }
+            } // Don't bother with a very short suspense time.
+
+
+            if (_msUntilTimeout > 10) {
+              // The render is suspended, it hasn't timed out, and there's no
+              // lower priority work to do. Instead of committing the fallback
+              // immediately, wait for more data to arrive.
+              root.timeoutHandle = scheduleTimeout(commitRoot.bind(null, root), _msUntilTimeout);
+              break;
+            }
+          } // The work expired. Commit immediately.
+
+
+          commitRoot(root);
+          break;
+        }
+
+      case RootCompleted:
+        {
+          // The work completed. Ready to commit.
+          if ( // do not delay if we're inside an act() scope
+          !( IsThisRendererActing.current) && workInProgressRootLatestProcessedExpirationTime !== Sync && workInProgressRootCanSuspendUsingConfig !== null) {
+            // If we have exceeded the minimum loading delay, which probably
+            // means we have shown a spinner already, we might have to suspend
+            // a bit longer to ensure that the spinner is shown for
+            // enough time.
+            var _msUntilTimeout2 = computeMsUntilSuspenseLoadingDelay(workInProgressRootLatestProcessedExpirationTime, expirationTime, workInProgressRootCanSuspendUsingConfig);
+
+            if (_msUntilTimeout2 > 10) {
+              markRootSuspendedAtTime(root, expirationTime);
+              root.timeoutHandle = scheduleTimeout(commitRoot.bind(null, root), _msUntilTimeout2);
+              break;
+            }
+          }
+
+          commitRoot(root);
+          break;
+        }
+
+      default:
+        {
+          {
+            {
+              throw Error( "Unknown root exit status." );
+            }
+          }
+        }
+    }
+  } // This is the entry point for synchronous tasks that don't go
+  // through Scheduler
+
+
+  function performSyncWorkOnRoot(root) {
+    // Check if there's expired work on this root. Otherwise, render at Sync.
+    var lastExpiredTime = root.lastExpiredTime;
+    var expirationTime = lastExpiredTime !== NoWork ? lastExpiredTime : Sync;
+
+    if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+      {
+        throw Error( "Should not already be working." );
+      }
+    }
+
+    flushPassiveEffects(); // If the root or expiration time have changed, throw out the existing stack
+    // and prepare a fresh one. Otherwise we'll continue where we left off.
+
+    if (root !== workInProgressRoot || expirationTime !== renderExpirationTime$1) {
+      prepareFreshStack(root, expirationTime);
+      startWorkOnPendingInteractions(root, expirationTime);
+    } // If we have a work-in-progress fiber, it means there's still work to do
+    // in this root.
+
+
+    if (workInProgress !== null) {
+      var prevExecutionContext = executionContext;
+      executionContext |= RenderContext;
+      var prevDispatcher = pushDispatcher();
+      var prevInteractions = pushInteractions(root);
+      startWorkLoopTimer(workInProgress);
+
+      do {
+        try {
+          workLoopSync();
+          break;
+        } catch (thrownValue) {
+          handleError(root, thrownValue);
+        }
+      } while (true);
+
+      resetContextDependencies();
+      executionContext = prevExecutionContext;
+      popDispatcher(prevDispatcher);
+
+      {
+        popInteractions(prevInteractions);
+      }
+
+      if (workInProgressRootExitStatus === RootFatalErrored) {
+        var fatalError = workInProgressRootFatalError;
+        stopInterruptedWorkLoopTimer();
+        prepareFreshStack(root, expirationTime);
+        markRootSuspendedAtTime(root, expirationTime);
+        ensureRootIsScheduled(root);
+        throw fatalError;
+      }
+
+      if (workInProgress !== null) {
+        // This is a sync render, so we should have finished the whole tree.
+        {
+          {
+            throw Error( "Cannot commit an incomplete root. This error is likely caused by a bug in React. Please file an issue." );
+          }
+        }
+      } else {
+        // We now have a consistent tree. Because this is a sync render, we
+        // will commit it even if something suspended.
+        stopFinishedWorkLoopTimer();
+        root.finishedWork = root.current.alternate;
+        root.finishedExpirationTime = expirationTime;
+        finishSyncRender(root);
+      } // Before exiting, make sure there's a callback scheduled for the next
+      // pending level.
+
+
+      ensureRootIsScheduled(root);
+    }
+
+    return null;
+  }
+
+  function finishSyncRender(root) {
+    // Set this to null to indicate there's no in-progress render.
+    workInProgressRoot = null;
+    commitRoot(root);
+  }
+  function flushDiscreteUpdates() {
+    // TODO: Should be able to flush inside batchedUpdates, but not inside `act`.
+    // However, `act` uses `batchedUpdates`, so there's no way to distinguish
+    // those two cases. Need to fix this before exposing flushDiscreteUpdates
+    // as a public API.
+    if ((executionContext & (BatchedContext | RenderContext | CommitContext)) !== NoContext) {
+      {
+        if ((executionContext & RenderContext) !== NoContext) {
+          error('unstable_flushDiscreteUpdates: Cannot flush updates when React is ' + 'already rendering.');
+        }
+      } // We're already rendering, so we can't synchronously flush pending work.
+      // This is probably a nested event dispatch triggered by a lifecycle/effect,
+      // like `el.focus()`. Exit.
+
+
+      return;
+    }
+
+    flushPendingDiscreteUpdates(); // If the discrete updates scheduled passive effects, flush them now so that
+    // they fire before the next serial event.
+
+    flushPassiveEffects();
+  }
+  function syncUpdates(fn, a, b, c) {
+    return runWithPriority$1(ImmediatePriority, fn.bind(null, a, b, c));
+  }
+
+  function flushPendingDiscreteUpdates() {
+    if (rootsWithPendingDiscreteUpdates !== null) {
+      // For each root with pending discrete updates, schedule a callback to
+      // immediately flush them.
+      var roots = rootsWithPendingDiscreteUpdates;
+      rootsWithPendingDiscreteUpdates = null;
+      roots.forEach(function (expirationTime, root) {
+        markRootExpiredAtTime(root, expirationTime);
+        ensureRootIsScheduled(root);
+      }); // Now flush the immediate queue.
+
+      flushSyncCallbackQueue();
+    }
+  }
+
+  function batchedUpdates$1(fn, a) {
+    var prevExecutionContext = executionContext;
+    executionContext |= BatchedContext;
+
+    try {
+      return fn(a);
+    } finally {
+      executionContext = prevExecutionContext;
+
+      if (executionContext === NoContext) {
+        // Flush the immediate callbacks that were scheduled during this batch
+        flushSyncCallbackQueue();
+      }
+    }
+  }
+  function batchedEventUpdates$1(fn, a) {
+    var prevExecutionContext = executionContext;
+    executionContext |= EventContext;
+
+    try {
+      return fn(a);
+    } finally {
+      executionContext = prevExecutionContext;
+
+      if (executionContext === NoContext) {
+        // Flush the immediate callbacks that were scheduled during this batch
+        flushSyncCallbackQueue();
+      }
+    }
+  }
+  function discreteUpdates$1(fn, a, b, c, d) {
+    var prevExecutionContext = executionContext;
+    executionContext |= DiscreteEventContext;
+
+    try {
+      // Should this
+      return runWithPriority$1(UserBlockingPriority$1, fn.bind(null, a, b, c, d));
+    } finally {
+      executionContext = prevExecutionContext;
+
+      if (executionContext === NoContext) {
+        // Flush the immediate callbacks that were scheduled during this batch
+        flushSyncCallbackQueue();
+      }
+    }
+  }
+  function unbatchedUpdates(fn, a) {
+    var prevExecutionContext = executionContext;
+    executionContext &= ~BatchedContext;
+    executionContext |= LegacyUnbatchedContext;
+
+    try {
+      return fn(a);
+    } finally {
+      executionContext = prevExecutionContext;
+
+      if (executionContext === NoContext) {
+        // Flush the immediate callbacks that were scheduled during this batch
+        flushSyncCallbackQueue();
+      }
+    }
+  }
+  function flushSync(fn, a) {
+    if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
+      {
+        {
+          throw Error( "flushSync was called from inside a lifecycle method. It cannot be called when React is already rendering." );
+        }
+      }
+    }
+
+    var prevExecutionContext = executionContext;
+    executionContext |= BatchedContext;
+
+    try {
+      return runWithPriority$1(ImmediatePriority, fn.bind(null, a));
+    } finally {
+      executionContext = prevExecutionContext; // Flush the immediate callbacks that were scheduled during this batch.
+      // Note that this will happen even if batchedUpdates is higher up
+      // the stack.
+
+      flushSyncCallbackQueue();
+    }
+  }
+
+  function prepareFreshStack(root, expirationTime) {
+    root.finishedWork = null;
+    root.finishedExpirationTime = NoWork;
+    var timeoutHandle = root.timeoutHandle;
+
+    if (timeoutHandle !== noTimeout) {
+      // The root previous suspended and scheduled a timeout to commit a fallback
+      // state. Now that we have additional work, cancel the timeout.
+      root.timeoutHandle = noTimeout; // $FlowFixMe Complains noTimeout is not a TimeoutID, despite the check above
+
+      cancelTimeout(timeoutHandle);
+    }
+
+    if (workInProgress !== null) {
+      var interruptedWork = workInProgress.return;
+
+      while (interruptedWork !== null) {
+        unwindInterruptedWork(interruptedWork);
+        interruptedWork = interruptedWork.return;
+      }
+    }
+
+    workInProgressRoot = root;
+    workInProgress = createWorkInProgress(root.current, null);
+    renderExpirationTime$1 = expirationTime;
+    workInProgressRootExitStatus = RootIncomplete;
+    workInProgressRootFatalError = null;
+    workInProgressRootLatestProcessedExpirationTime = Sync;
+    workInProgressRootLatestSuspenseTimeout = Sync;
+    workInProgressRootCanSuspendUsingConfig = null;
+    workInProgressRootNextUnprocessedUpdateTime = NoWork;
+    workInProgressRootHasPendingPing = false;
+
+    {
+      spawnedWorkDuringRender = null;
+    }
+
+    {
+      ReactStrictModeWarnings.discardPendingWarnings();
+    }
+  }
+
+  function handleError(root, thrownValue) {
+    do {
+      try {
+        // Reset module-level state that was set during the render phase.
+        resetContextDependencies();
+        resetHooksAfterThrow();
+        resetCurrentFiber();
+
+        if (workInProgress === null || workInProgress.return === null) {
+          // Expected to be working on a non-root fiber. This is a fatal error
+          // because there's no ancestor that can handle it; the root is
+          // supposed to capture all errors that weren't caught by an error
+          // boundary.
+          workInProgressRootExitStatus = RootFatalErrored;
+          workInProgressRootFatalError = thrownValue; // Set `workInProgress` to null. This represents advancing to the next
+          // sibling, or the parent if there are no siblings. But since the root
+          // has no siblings nor a parent, we set it to null. Usually this is
+          // handled by `completeUnitOfWork` or `unwindWork`, but since we're
+          // interntionally not calling those, we need set it here.
+          // TODO: Consider calling `unwindWork` to pop the contexts.
+
+          workInProgress = null;
+          return null;
+        }
+
+        if (enableProfilerTimer && workInProgress.mode & ProfileMode) {
+          // Record the time spent rendering before an error was thrown. This
+          // avoids inaccurate Profiler durations in the case of a
+          // suspended render.
+          stopProfilerTimerIfRunningAndRecordDelta(workInProgress, true);
+        }
+
+        throwException(root, workInProgress.return, workInProgress, thrownValue, renderExpirationTime$1);
+        workInProgress = completeUnitOfWork(workInProgress);
+      } catch (yetAnotherThrownValue) {
+        // Something in the return path also threw.
+        thrownValue = yetAnotherThrownValue;
+        continue;
+      } // Return to the normal work loop.
+
+
+      return;
+    } while (true);
+  }
+
+  function pushDispatcher(root) {
+    var prevDispatcher = ReactCurrentDispatcher$1.current;
+    ReactCurrentDispatcher$1.current = ContextOnlyDispatcher;
+
+    if (prevDispatcher === null) {
+      // The React isomorphic package does not include a default dispatcher.
+      // Instead the first renderer will lazily attach one, in order to give
+      // nicer error messages.
+      return ContextOnlyDispatcher;
+    } else {
+      return prevDispatcher;
+    }
+  }
+
+  function popDispatcher(prevDispatcher) {
+    ReactCurrentDispatcher$1.current = prevDispatcher;
+  }
+
+  function pushInteractions(root) {
+    {
+      var prevInteractions = __interactionsRef.current;
+      __interactionsRef.current = root.memoizedInteractions;
+      return prevInteractions;
+    }
+  }
+
+  function popInteractions(prevInteractions) {
+    {
+      __interactionsRef.current = prevInteractions;
+    }
+  }
+
+  function markCommitTimeOfFallback() {
+    globalMostRecentFallbackTime = now();
+  }
+  function markRenderEventTimeAndConfig(expirationTime, suspenseConfig) {
+    if (expirationTime < workInProgressRootLatestProcessedExpirationTime && expirationTime > Idle) {
+      workInProgressRootLatestProcessedExpirationTime = expirationTime;
+    }
+
+    if (suspenseConfig !== null) {
+      if (expirationTime < workInProgressRootLatestSuspenseTimeout && expirationTime > Idle) {
+        workInProgressRootLatestSuspenseTimeout = expirationTime; // Most of the time we only have one config and getting wrong is not bad.
+
+        workInProgressRootCanSuspendUsingConfig = suspenseConfig;
+      }
+    }
+  }
+  function markUnprocessedUpdateTime(expirationTime) {
+    if (expirationTime > workInProgressRootNextUnprocessedUpdateTime) {
+      workInProgressRootNextUnprocessedUpdateTime = expirationTime;
+    }
+  }
+  function renderDidSuspend() {
+    if (workInProgressRootExitStatus === RootIncomplete) {
+      workInProgressRootExitStatus = RootSuspended;
+    }
+  }
+  function renderDidSuspendDelayIfPossible() {
+    if (workInProgressRootExitStatus === RootIncomplete || workInProgressRootExitStatus === RootSuspended) {
+      workInProgressRootExitStatus = RootSuspendedWithDelay;
+    } // Check if there's a lower priority update somewhere else in the tree.
+
+
+    if (workInProgressRootNextUnprocessedUpdateTime !== NoWork && workInProgressRoot !== null) {
+      // Mark the current render as suspended, and then mark that there's a
+      // pending update.
+      // TODO: This should immediately interrupt the current render, instead
+      // of waiting until the next time we yield.
+      markRootSuspendedAtTime(workInProgressRoot, renderExpirationTime$1);
+      markRootUpdatedAtTime(workInProgressRoot, workInProgressRootNextUnprocessedUpdateTime);
+    }
+  }
+  function renderDidError() {
+    if (workInProgressRootExitStatus !== RootCompleted) {
+      workInProgressRootExitStatus = RootErrored;
+    }
+  } // Called during render to determine if anything has suspended.
+  // Returns false if we're not sure.
+
+  function renderHasNotSuspendedYet() {
+    // If something errored or completed, we can't really be sure,
+    // so those are false.
+    return workInProgressRootExitStatus === RootIncomplete;
+  }
+
+  function inferTimeFromExpirationTime(expirationTime) {
+    // We don't know exactly when the update was scheduled, but we can infer an
+    // approximate start time from the expiration time.
+    var earliestExpirationTimeMs = expirationTimeToMs(expirationTime);
+    return earliestExpirationTimeMs - LOW_PRIORITY_EXPIRATION;
+  }
+
+  function inferTimeFromExpirationTimeWithSuspenseConfig(expirationTime, suspenseConfig) {
+    // We don't know exactly when the update was scheduled, but we can infer an
+    // approximate start time from the expiration time by subtracting the timeout
+    // that was added to the event time.
+    var earliestExpirationTimeMs = expirationTimeToMs(expirationTime);
+    return earliestExpirationTimeMs - (suspenseConfig.timeoutMs | 0 || LOW_PRIORITY_EXPIRATION);
+  } // The work loop is an extremely hot path. Tell Closure not to inline it.
+
+  /** @noinline */
+
+
+  function workLoopSync() {
+    // Already timed out, so perform work without checking if we need to yield.
+    while (workInProgress !== null) {
+      workInProgress = performUnitOfWork(workInProgress);
+    }
+  }
+  /** @noinline */
+
+
+  function workLoopConcurrent() {
+    // Perform work until Scheduler asks us to yield
+    while (workInProgress !== null && !shouldYield()) {
+      workInProgress = performUnitOfWork(workInProgress);
+    }
+  }
+
+  function performUnitOfWork(unitOfWork) {
+    // The current, flushed, state of this fiber is the alternate. Ideally
+    // nothing should rely on this, but relying on it here means that we don't
+    // need an additional field on the work in progress.
+    var current = unitOfWork.alternate;
+    startWorkTimer(unitOfWork);
+    setCurrentFiber(unitOfWork);
+    var next;
+
+    if ( (unitOfWork.mode & ProfileMode) !== NoMode) {
+      startProfilerTimer(unitOfWork);
+      next = beginWork$1(current, unitOfWork, renderExpirationTime$1);
+      stopProfilerTimerIfRunningAndRecordDelta(unitOfWork, true);
+    } else {
+      next = beginWork$1(current, unitOfWork, renderExpirationTime$1);
+    }
+
+    resetCurrentFiber();
+    unitOfWork.memoizedProps = unitOfWork.pendingProps;
+
+    if (next === null) {
+      // If this doesn't spawn new work, complete the current work.
+      next = completeUnitOfWork(unitOfWork);
+    }
+
+    ReactCurrentOwner$2.current = null;
+    return next;
+  }
+
+  function completeUnitOfWork(unitOfWork) {
+    // Attempt to complete the current unit of work, then move to the next
+    // sibling. If there are no more siblings, return to the parent fiber.
+    workInProgress = unitOfWork;
+
+    do {
+      // The current, flushed, state of this fiber is the alternate. Ideally
+      // nothing should rely on this, but relying on it here means that we don't
+      // need an additional field on the work in progress.
+      var current = workInProgress.alternate;
+      var returnFiber = workInProgress.return; // Check if the work completed or if something threw.
+
+      if ((workInProgress.effectTag & Incomplete) === NoEffect) {
+        setCurrentFiber(workInProgress);
+        var next = void 0;
+
+        if ( (workInProgress.mode & ProfileMode) === NoMode) {
+          next = completeWork(current, workInProgress, renderExpirationTime$1);
+        } else {
+          startProfilerTimer(workInProgress);
+          next = completeWork(current, workInProgress, renderExpirationTime$1); // Update render duration assuming we didn't error.
+
+          stopProfilerTimerIfRunningAndRecordDelta(workInProgress, false);
+        }
+
+        stopWorkTimer(workInProgress);
+        resetCurrentFiber();
+        resetChildExpirationTime(workInProgress);
+
+        if (next !== null) {
+          // Completing this fiber spawned new work. Work on that next.
+          return next;
+        }
+
+        if (returnFiber !== null && // Do not append effects to parents if a sibling failed to complete
+        (returnFiber.effectTag & Incomplete) === NoEffect) {
+          // Append all the effects of the subtree and this fiber onto the effect
+          // list of the parent. The completion order of the children affects the
+          // side-effect order.
+          if (returnFiber.firstEffect === null) {
+            returnFiber.firstEffect = workInProgress.firstEffect;
+          }
+
+          if (workInProgress.lastEffect !== null) {
+            if (returnFiber.lastEffect !== null) {
+              returnFiber.lastEffect.nextEffect = workInProgress.firstEffect;
+            }
+
+            returnFiber.lastEffect = workInProgress.lastEffect;
+          } // If this fiber had side-effects, we append it AFTER the children's
+          // side-effects. We can perform certain side-effects earlier if needed,
+          // by doing multiple passes over the effect list. We don't want to
+          // schedule our own side-effect on our own list because if end up
+          // reusing children we'll schedule this effect onto itself since we're
+          // at the end.
+
+
+          var effectTag = workInProgress.effectTag; // Skip both NoWork and PerformedWork tags when creating the effect
+          // list. PerformedWork effect is read by React DevTools but shouldn't be
+          // committed.
+
+          if (effectTag > PerformedWork) {
+            if (returnFiber.lastEffect !== null) {
+              returnFiber.lastEffect.nextEffect = workInProgress;
+            } else {
+              returnFiber.firstEffect = workInProgress;
+            }
+
+            returnFiber.lastEffect = workInProgress;
+          }
+        }
+      } else {
+        // This fiber did not complete because something threw. Pop values off
+        // the stack without entering the complete phase. If this is a boundary,
+        // capture values if possible.
+        var _next = unwindWork(workInProgress); // Because this fiber did not complete, don't reset its expiration time.
+
+
+        if ( (workInProgress.mode & ProfileMode) !== NoMode) {
+          // Record the render duration for the fiber that errored.
+          stopProfilerTimerIfRunningAndRecordDelta(workInProgress, false); // Include the time spent working on failed children before continuing.
+
+          var actualDuration = workInProgress.actualDuration;
+          var child = workInProgress.child;
+
+          while (child !== null) {
+            actualDuration += child.actualDuration;
+            child = child.sibling;
+          }
+
+          workInProgress.actualDuration = actualDuration;
+        }
+
+        if (_next !== null) {
+          // If completing this work spawned new work, do that next. We'll come
+          // back here again.
+          // Since we're restarting, remove anything that is not a host effect
+          // from the effect tag.
+          // TODO: The name stopFailedWorkTimer is misleading because Suspense
+          // also captures and restarts.
+          stopFailedWorkTimer(workInProgress);
+          _next.effectTag &= HostEffectMask;
+          return _next;
+        }
+
+        stopWorkTimer(workInProgress);
+
+        if (returnFiber !== null) {
+          // Mark the parent fiber as incomplete and clear its effect list.
+          returnFiber.firstEffect = returnFiber.lastEffect = null;
+          returnFiber.effectTag |= Incomplete;
+        }
+      }
+
+      var siblingFiber = workInProgress.sibling;
+
+      if (siblingFiber !== null) {
+        // If there is more work to do in this returnFiber, do that next.
+        return siblingFiber;
+      } // Otherwise, return to the parent
+
+
+      workInProgress = returnFiber;
+    } while (workInProgress !== null); // We've reached the root.
+
+
+    if (workInProgressRootExitStatus === RootIncomplete) {
+      workInProgressRootExitStatus = RootCompleted;
+    }
+
+    return null;
+  }
+
+  function getRemainingExpirationTime(fiber) {
+    var updateExpirationTime = fiber.expirationTime;
+    var childExpirationTime = fiber.childExpirationTime;
+    return updateExpirationTime > childExpirationTime ? updateExpirationTime : childExpirationTime;
+  }
+
+  function resetChildExpirationTime(completedWork) {
+    if (renderExpirationTime$1 !== Never && completedWork.childExpirationTime === Never) {
+      // The children of this component are hidden. Don't bubble their
+      // expiration times.
+      return;
+    }
+
+    var newChildExpirationTime = NoWork; // Bubble up the earliest expiration time.
+
+    if ( (completedWork.mode & ProfileMode) !== NoMode) {
+      // In profiling mode, resetChildExpirationTime is also used to reset
+      // profiler durations.
+      var actualDuration = completedWork.actualDuration;
+      var treeBaseDuration = completedWork.selfBaseDuration; // When a fiber is cloned, its actualDuration is reset to 0. This value will
+      // only be updated if work is done on the fiber (i.e. it doesn't bailout).
+      // When work is done, it should bubble to the parent's actualDuration. If
+      // the fiber has not been cloned though, (meaning no work was done), then
+      // this value will reflect the amount of time spent working on a previous
+      // render. In that case it should not bubble. We determine whether it was
+      // cloned by comparing the child pointer.
+
+      var shouldBubbleActualDurations = completedWork.alternate === null || completedWork.child !== completedWork.alternate.child;
+      var child = completedWork.child;
+
+      while (child !== null) {
+        var childUpdateExpirationTime = child.expirationTime;
+        var childChildExpirationTime = child.childExpirationTime;
+
+        if (childUpdateExpirationTime > newChildExpirationTime) {
+          newChildExpirationTime = childUpdateExpirationTime;
+        }
+
+        if (childChildExpirationTime > newChildExpirationTime) {
+          newChildExpirationTime = childChildExpirationTime;
+        }
+
+        if (shouldBubbleActualDurations) {
+          actualDuration += child.actualDuration;
+        }
+
+        treeBaseDuration += child.treeBaseDuration;
+        child = child.sibling;
+      }
+
+      completedWork.actualDuration = actualDuration;
+      completedWork.treeBaseDuration = treeBaseDuration;
+    } else {
+      var _child = completedWork.child;
+
+      while (_child !== null) {
+        var _childUpdateExpirationTime = _child.expirationTime;
+        var _childChildExpirationTime = _child.childExpirationTime;
+
+        if (_childUpdateExpirationTime > newChildExpirationTime) {
+          newChildExpirationTime = _childUpdateExpirationTime;
+        }
+
+        if (_childChildExpirationTime > newChildExpirationTime) {
+          newChildExpirationTime = _childChildExpirationTime;
+        }
+
+        _child = _child.sibling;
+      }
+    }
+
+    completedWork.childExpirationTime = newChildExpirationTime;
+  }
+
+  function commitRoot(root) {
+    var renderPriorityLevel = getCurrentPriorityLevel();
+    runWithPriority$1(ImmediatePriority, commitRootImpl.bind(null, root, renderPriorityLevel));
+    return null;
+  }
+
+  function commitRootImpl(root, renderPriorityLevel) {
+    do {
+      // `flushPassiveEffects` will call `flushSyncUpdateQueue` at the end, which
+      // means `flushPassiveEffects` will sometimes result in additional
+      // passive effects. So we need to keep flushing in a loop until there are
+      // no more pending effects.
+      // TODO: Might be better if `flushPassiveEffects` did not automatically
+      // flush synchronous work at the end, to avoid factoring hazards like this.
+      flushPassiveEffects();
+    } while (rootWithPendingPassiveEffects !== null);
+
+    flushRenderPhaseStrictModeWarningsInDEV();
+
+    if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+      {
+        throw Error( "Should not already be working." );
+      }
+    }
+
+    var finishedWork = root.finishedWork;
+    var expirationTime = root.finishedExpirationTime;
+
+    if (finishedWork === null) {
+      return null;
+    }
+
+    root.finishedWork = null;
+    root.finishedExpirationTime = NoWork;
+
+    if (!(finishedWork !== root.current)) {
+      {
+        throw Error( "Cannot commit the same tree as before. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    } // commitRoot never returns a continuation; it always finishes synchronously.
+    // So we can clear these now to allow a new callback to be scheduled.
+
+
+    root.callbackNode = null;
+    root.callbackExpirationTime = NoWork;
+    root.callbackPriority = NoPriority;
+    root.nextKnownPendingLevel = NoWork;
+    startCommitTimer(); // Update the first and last pending times on this root. The new first
+    // pending time is whatever is left on the root fiber.
+
+    var remainingExpirationTimeBeforeCommit = getRemainingExpirationTime(finishedWork);
+    markRootFinishedAtTime(root, expirationTime, remainingExpirationTimeBeforeCommit);
+
+    if (root === workInProgressRoot) {
+      // We can reset these now that they are finished.
+      workInProgressRoot = null;
+      workInProgress = null;
+      renderExpirationTime$1 = NoWork;
+    } // This indicates that the last root we worked on is not the same one that
+    // we're committing now. This most commonly happens when a suspended root
+    // times out.
+    // Get the list of effects.
+
+
+    var firstEffect;
+
+    if (finishedWork.effectTag > PerformedWork) {
+      // A fiber's effect list consists only of its children, not itself. So if
+      // the root has an effect, we need to add it to the end of the list. The
+      // resulting list is the set that would belong to the root's parent, if it
+      // had one; that is, all the effects in the tree including the root.
+      if (finishedWork.lastEffect !== null) {
+        finishedWork.lastEffect.nextEffect = finishedWork;
+        firstEffect = finishedWork.firstEffect;
+      } else {
+        firstEffect = finishedWork;
+      }
+    } else {
+      // There is no effect on the root.
+      firstEffect = finishedWork.firstEffect;
+    }
+
+    if (firstEffect !== null) {
+      var prevExecutionContext = executionContext;
+      executionContext |= CommitContext;
+      var prevInteractions = pushInteractions(root); // Reset this to null before calling lifecycles
+
+      ReactCurrentOwner$2.current = null; // The commit phase is broken into several sub-phases. We do a separate pass
+      // of the effect list for each phase: all mutation effects come before all
+      // layout effects, and so on.
+      // The first phase a "before mutation" phase. We use this phase to read the
+      // state of the host tree right before we mutate it. This is where
+      // getSnapshotBeforeUpdate is called.
+
+      startCommitSnapshotEffectsTimer();
+      prepareForCommit(root.containerInfo);
+      nextEffect = firstEffect;
+
+      do {
+        {
+          invokeGuardedCallback(null, commitBeforeMutationEffects, null);
+
+          if (hasCaughtError()) {
+            if (!(nextEffect !== null)) {
+              {
+                throw Error( "Should be working on an effect." );
+              }
+            }
+
+            var error = clearCaughtError();
+            captureCommitPhaseError(nextEffect, error);
+            nextEffect = nextEffect.nextEffect;
+          }
+        }
+      } while (nextEffect !== null);
+
+      stopCommitSnapshotEffectsTimer();
+
+      {
+        // Mark the current commit time to be shared by all Profilers in this
+        // batch. This enables them to be grouped later.
+        recordCommitTime();
+      } // The next phase is the mutation phase, where we mutate the host tree.
+
+
+      startCommitHostEffectsTimer();
+      nextEffect = firstEffect;
+
+      do {
+        {
+          invokeGuardedCallback(null, commitMutationEffects, null, root, renderPriorityLevel);
+
+          if (hasCaughtError()) {
+            if (!(nextEffect !== null)) {
+              {
+                throw Error( "Should be working on an effect." );
+              }
+            }
+
+            var _error = clearCaughtError();
+
+            captureCommitPhaseError(nextEffect, _error);
+            nextEffect = nextEffect.nextEffect;
+          }
+        }
+      } while (nextEffect !== null);
+
+      stopCommitHostEffectsTimer();
+      resetAfterCommit(root.containerInfo); // The work-in-progress tree is now the current tree. This must come after
+      // the mutation phase, so that the previous tree is still current during
+      // componentWillUnmount, but before the layout phase, so that the finished
+      // work is current during componentDidMount/Update.
+
+      root.current = finishedWork; // The next phase is the layout phase, where we call effects that read
+      // the host tree after it's been mutated. The idiomatic use case for this is
+      // layout, but class component lifecycles also fire here for legacy reasons.
+
+      startCommitLifeCyclesTimer();
+      nextEffect = firstEffect;
+
+      do {
+        {
+          invokeGuardedCallback(null, commitLayoutEffects, null, root, expirationTime);
+
+          if (hasCaughtError()) {
+            if (!(nextEffect !== null)) {
+              {
+                throw Error( "Should be working on an effect." );
+              }
+            }
+
+            var _error2 = clearCaughtError();
+
+            captureCommitPhaseError(nextEffect, _error2);
+            nextEffect = nextEffect.nextEffect;
+          }
+        }
+      } while (nextEffect !== null);
+
+      stopCommitLifeCyclesTimer();
+      nextEffect = null; // Tell Scheduler to yield at the end of the frame, so the browser has an
+      // opportunity to paint.
+
+      requestPaint();
+
+      {
+        popInteractions(prevInteractions);
+      }
+
+      executionContext = prevExecutionContext;
+    } else {
+      // No effects.
+      root.current = finishedWork; // Measure these anyway so the flamegraph explicitly shows that there were
+      // no effects.
+      // TODO: Maybe there's a better way to report this.
+
+      startCommitSnapshotEffectsTimer();
+      stopCommitSnapshotEffectsTimer();
+
+      {
+        recordCommitTime();
+      }
+
+      startCommitHostEffectsTimer();
+      stopCommitHostEffectsTimer();
+      startCommitLifeCyclesTimer();
+      stopCommitLifeCyclesTimer();
+    }
+
+    stopCommitTimer();
+    var rootDidHavePassiveEffects = rootDoesHavePassiveEffects;
+
+    if (rootDoesHavePassiveEffects) {
+      // This commit has passive effects. Stash a reference to them. But don't
+      // schedule a callback until after flushing layout work.
+      rootDoesHavePassiveEffects = false;
+      rootWithPendingPassiveEffects = root;
+      pendingPassiveEffectsExpirationTime = expirationTime;
+      pendingPassiveEffectsRenderPriority = renderPriorityLevel;
+    } else {
+      // We are done with the effect chain at this point so let's clear the
+      // nextEffect pointers to assist with GC. If we have passive effects, we'll
+      // clear this in flushPassiveEffects.
+      nextEffect = firstEffect;
+
+      while (nextEffect !== null) {
+        var nextNextEffect = nextEffect.nextEffect;
+        nextEffect.nextEffect = null;
+        nextEffect = nextNextEffect;
+      }
+    } // Check if there's remaining work on this root
+
+
+    var remainingExpirationTime = root.firstPendingTime;
+
+    if (remainingExpirationTime !== NoWork) {
+      {
+        if (spawnedWorkDuringRender !== null) {
+          var expirationTimes = spawnedWorkDuringRender;
+          spawnedWorkDuringRender = null;
+
+          for (var i = 0; i < expirationTimes.length; i++) {
+            scheduleInteractions(root, expirationTimes[i], root.memoizedInteractions);
+          }
+        }
+
+        schedulePendingInteractions(root, remainingExpirationTime);
+      }
+    } else {
+      // If there's no remaining work, we can clear the set of already failed
+      // error boundaries.
+      legacyErrorBoundariesThatAlreadyFailed = null;
+    }
+
+    {
+      if (!rootDidHavePassiveEffects) {
+        // If there are no passive effects, then we can complete the pending interactions.
+        // Otherwise, we'll wait until after the passive effects are flushed.
+        // Wait to do this until after remaining work has been scheduled,
+        // so that we don't prematurely signal complete for interactions when there's e.g. hidden work.
+        finishPendingInteractions(root, expirationTime);
+      }
+    }
+
+    if (remainingExpirationTime === Sync) {
+      // Count the number of times the root synchronously re-renders without
+      // finishing. If there are too many, it indicates an infinite update loop.
+      if (root === rootWithNestedUpdates) {
+        nestedUpdateCount++;
+      } else {
+        nestedUpdateCount = 0;
+        rootWithNestedUpdates = root;
+      }
+    } else {
+      nestedUpdateCount = 0;
+    }
+
+    onCommitRoot(finishedWork.stateNode, expirationTime); // Always call this before exiting `commitRoot`, to ensure that any
+    // additional work on this root is scheduled.
+
+    ensureRootIsScheduled(root);
+
+    if (hasUncaughtError) {
+      hasUncaughtError = false;
+      var _error3 = firstUncaughtError;
+      firstUncaughtError = null;
+      throw _error3;
+    }
+
+    if ((executionContext & LegacyUnbatchedContext) !== NoContext) {
+      // This is a legacy edge case. We just committed the initial mount of
+      // a ReactDOM.render-ed root inside of batchedUpdates. The commit fired
+      // synchronously, but layout updates should be deferred until the end
+      // of the batch.
+      return null;
+    } // If layout work was scheduled, flush it now.
+
+
+    flushSyncCallbackQueue();
+    return null;
+  }
+
+  function commitBeforeMutationEffects() {
+    while (nextEffect !== null) {
+      var effectTag = nextEffect.effectTag;
+
+      if ((effectTag & Snapshot) !== NoEffect) {
+        setCurrentFiber(nextEffect);
+        recordEffect();
+        var current = nextEffect.alternate;
+        commitBeforeMutationLifeCycles(current, nextEffect);
+        resetCurrentFiber();
+      }
+
+      if ((effectTag & Passive) !== NoEffect) {
+        // If there are passive effects, schedule a callback to flush at
+        // the earliest opportunity.
+        if (!rootDoesHavePassiveEffects) {
+          rootDoesHavePassiveEffects = true;
+          scheduleCallback(NormalPriority, function () {
+            flushPassiveEffects();
+            return null;
+          });
+        }
+      }
+
+      nextEffect = nextEffect.nextEffect;
+    }
+  }
+
+  function commitMutationEffects(root, renderPriorityLevel) {
+    // TODO: Should probably move the bulk of this function to commitWork.
+    while (nextEffect !== null) {
+      setCurrentFiber(nextEffect);
+      var effectTag = nextEffect.effectTag;
+
+      if (effectTag & ContentReset) {
+        commitResetTextContent(nextEffect);
+      }
+
+      if (effectTag & Ref) {
+        var current = nextEffect.alternate;
+
+        if (current !== null) {
+          commitDetachRef(current);
+        }
+      } // The following switch statement is only concerned about placement,
+      // updates, and deletions. To avoid needing to add a case for every possible
+      // bitmap value, we remove the secondary effects from the effect tag and
+      // switch on that value.
+
+
+      var primaryEffectTag = effectTag & (Placement | Update | Deletion | Hydrating);
+
+      switch (primaryEffectTag) {
+        case Placement:
+          {
+            commitPlacement(nextEffect); // Clear the "placement" from effect tag so that we know that this is
+            // inserted, before any life-cycles like componentDidMount gets called.
+            // TODO: findDOMNode doesn't rely on this any more but isMounted does
+            // and isMounted is deprecated anyway so we should be able to kill this.
+
+            nextEffect.effectTag &= ~Placement;
+            break;
+          }
+
+        case PlacementAndUpdate:
+          {
+            // Placement
+            commitPlacement(nextEffect); // Clear the "placement" from effect tag so that we know that this is
+            // inserted, before any life-cycles like componentDidMount gets called.
+
+            nextEffect.effectTag &= ~Placement; // Update
+
+            var _current = nextEffect.alternate;
+            commitWork(_current, nextEffect);
+            break;
+          }
+
+        case Hydrating:
+          {
+            nextEffect.effectTag &= ~Hydrating;
+            break;
+          }
+
+        case HydratingAndUpdate:
+          {
+            nextEffect.effectTag &= ~Hydrating; // Update
+
+            var _current2 = nextEffect.alternate;
+            commitWork(_current2, nextEffect);
+            break;
+          }
+
+        case Update:
+          {
+            var _current3 = nextEffect.alternate;
+            commitWork(_current3, nextEffect);
+            break;
+          }
+
+        case Deletion:
+          {
+            commitDeletion(root, nextEffect, renderPriorityLevel);
+            break;
+          }
+      } // TODO: Only record a mutation effect if primaryEffectTag is non-zero.
+
+
+      recordEffect();
+      resetCurrentFiber();
+      nextEffect = nextEffect.nextEffect;
+    }
+  }
+
+  function commitLayoutEffects(root, committedExpirationTime) {
+    // TODO: Should probably move the bulk of this function to commitWork.
+    while (nextEffect !== null) {
+      setCurrentFiber(nextEffect);
+      var effectTag = nextEffect.effectTag;
+
+      if (effectTag & (Update | Callback)) {
+        recordEffect();
+        var current = nextEffect.alternate;
+        commitLifeCycles(root, current, nextEffect);
+      }
+
+      if (effectTag & Ref) {
+        recordEffect();
+        commitAttachRef(nextEffect);
+      }
+
+      resetCurrentFiber();
+      nextEffect = nextEffect.nextEffect;
+    }
+  }
+
+  function flushPassiveEffects() {
+    if (pendingPassiveEffectsRenderPriority !== NoPriority) {
+      var priorityLevel = pendingPassiveEffectsRenderPriority > NormalPriority ? NormalPriority : pendingPassiveEffectsRenderPriority;
+      pendingPassiveEffectsRenderPriority = NoPriority;
+      return runWithPriority$1(priorityLevel, flushPassiveEffectsImpl);
+    }
+  }
+
+  function flushPassiveEffectsImpl() {
+    if (rootWithPendingPassiveEffects === null) {
+      return false;
+    }
+
+    var root = rootWithPendingPassiveEffects;
+    var expirationTime = pendingPassiveEffectsExpirationTime;
+    rootWithPendingPassiveEffects = null;
+    pendingPassiveEffectsExpirationTime = NoWork;
+
+    if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+      {
+        throw Error( "Cannot flush passive effects while already rendering." );
+      }
+    }
+
+    var prevExecutionContext = executionContext;
+    executionContext |= CommitContext;
+    var prevInteractions = pushInteractions(root);
+
+    {
+      // Note: This currently assumes there are no passive effects on the root fiber
+      // because the root is not part of its own effect list.
+      // This could change in the future.
+      var _effect2 = root.current.firstEffect;
+
+      while (_effect2 !== null) {
+        {
+          setCurrentFiber(_effect2);
+          invokeGuardedCallback(null, commitPassiveHookEffects, null, _effect2);
+
+          if (hasCaughtError()) {
+            if (!(_effect2 !== null)) {
+              {
+                throw Error( "Should be working on an effect." );
+              }
+            }
+
+            var _error5 = clearCaughtError();
+
+            captureCommitPhaseError(_effect2, _error5);
+          }
+
+          resetCurrentFiber();
+        }
+
+        var nextNextEffect = _effect2.nextEffect; // Remove nextEffect pointer to assist GC
+
+        _effect2.nextEffect = null;
+        _effect2 = nextNextEffect;
+      }
+    }
+
+    {
+      popInteractions(prevInteractions);
+      finishPendingInteractions(root, expirationTime);
+    }
+
+    executionContext = prevExecutionContext;
+    flushSyncCallbackQueue(); // If additional passive effects were scheduled, increment a counter. If this
+    // exceeds the limit, we'll fire a warning.
+
+    nestedPassiveUpdateCount = rootWithPendingPassiveEffects === null ? 0 : nestedPassiveUpdateCount + 1;
+    return true;
+  }
+
+  function isAlreadyFailedLegacyErrorBoundary(instance) {
+    return legacyErrorBoundariesThatAlreadyFailed !== null && legacyErrorBoundariesThatAlreadyFailed.has(instance);
+  }
+  function markLegacyErrorBoundaryAsFailed(instance) {
+    if (legacyErrorBoundariesThatAlreadyFailed === null) {
+      legacyErrorBoundariesThatAlreadyFailed = new Set([instance]);
+    } else {
+      legacyErrorBoundariesThatAlreadyFailed.add(instance);
+    }
+  }
+
+  function prepareToThrowUncaughtError(error) {
+    if (!hasUncaughtError) {
+      hasUncaughtError = true;
+      firstUncaughtError = error;
+    }
+  }
+
+  var onUncaughtError = prepareToThrowUncaughtError;
+
+  function captureCommitPhaseErrorOnRoot(rootFiber, sourceFiber, error) {
+    var errorInfo = createCapturedValue(error, sourceFiber);
+    var update = createRootErrorUpdate(rootFiber, errorInfo, Sync);
+    enqueueUpdate(rootFiber, update);
+    var root = markUpdateTimeFromFiberToRoot(rootFiber, Sync);
+
+    if (root !== null) {
+      ensureRootIsScheduled(root);
+      schedulePendingInteractions(root, Sync);
+    }
+  }
+
+  function captureCommitPhaseError(sourceFiber, error) {
+    if (sourceFiber.tag === HostRoot) {
+      // Error was thrown at the root. There is no parent, so the root
+      // itself should capture it.
+      captureCommitPhaseErrorOnRoot(sourceFiber, sourceFiber, error);
+      return;
+    }
+
+    var fiber = sourceFiber.return;
+
+    while (fiber !== null) {
+      if (fiber.tag === HostRoot) {
+        captureCommitPhaseErrorOnRoot(fiber, sourceFiber, error);
+        return;
+      } else if (fiber.tag === ClassComponent) {
+        var ctor = fiber.type;
+        var instance = fiber.stateNode;
+
+        if (typeof ctor.getDerivedStateFromError === 'function' || typeof instance.componentDidCatch === 'function' && !isAlreadyFailedLegacyErrorBoundary(instance)) {
+          var errorInfo = createCapturedValue(error, sourceFiber);
+          var update = createClassErrorUpdate(fiber, errorInfo, // TODO: This is always sync
+          Sync);
+          enqueueUpdate(fiber, update);
+          var root = markUpdateTimeFromFiberToRoot(fiber, Sync);
+
+          if (root !== null) {
+            ensureRootIsScheduled(root);
+            schedulePendingInteractions(root, Sync);
+          }
+
+          return;
+        }
+      }
+
+      fiber = fiber.return;
+    }
+  }
+  function pingSuspendedRoot(root, thenable, suspendedTime) {
+    var pingCache = root.pingCache;
+
+    if (pingCache !== null) {
+      // The thenable resolved, so we no longer need to memoize, because it will
+      // never be thrown again.
+      pingCache.delete(thenable);
+    }
+
+    if (workInProgressRoot === root && renderExpirationTime$1 === suspendedTime) {
+      // Received a ping at the same priority level at which we're currently
+      // rendering. We might want to restart this render. This should mirror
+      // the logic of whether or not a root suspends once it completes.
+      // TODO: If we're rendering sync either due to Sync, Batched or expired,
+      // we should probably never restart.
+      // If we're suspended with delay, we'll always suspend so we can always
+      // restart. If we're suspended without any updates, it might be a retry.
+      // If it's early in the retry we can restart. We can't know for sure
+      // whether we'll eventually process an update during this render pass,
+      // but it's somewhat unlikely that we get to a ping before that, since
+      // getting to the root most update is usually very fast.
+      if (workInProgressRootExitStatus === RootSuspendedWithDelay || workInProgressRootExitStatus === RootSuspended && workInProgressRootLatestProcessedExpirationTime === Sync && now() - globalMostRecentFallbackTime < FALLBACK_THROTTLE_MS) {
+        // Restart from the root. Don't need to schedule a ping because
+        // we're already working on this tree.
+        prepareFreshStack(root, renderExpirationTime$1);
+      } else {
+        // Even though we can't restart right now, we might get an
+        // opportunity later. So we mark this render as having a ping.
+        workInProgressRootHasPendingPing = true;
+      }
+
+      return;
+    }
+
+    if (!isRootSuspendedAtTime(root, suspendedTime)) {
+      // The root is no longer suspended at this time.
+      return;
+    }
+
+    var lastPingedTime = root.lastPingedTime;
+
+    if (lastPingedTime !== NoWork && lastPingedTime < suspendedTime) {
+      // There's already a lower priority ping scheduled.
+      return;
+    } // Mark the time at which this ping was scheduled.
+
+
+    root.lastPingedTime = suspendedTime;
+
+    ensureRootIsScheduled(root);
+    schedulePendingInteractions(root, suspendedTime);
+  }
+
+  function retryTimedOutBoundary(boundaryFiber, retryTime) {
+    // The boundary fiber (a Suspense component or SuspenseList component)
+    // previously was rendered in its fallback state. One of the promises that
+    // suspended it has resolved, which means at least part of the tree was
+    // likely unblocked. Try rendering again, at a new expiration time.
+    if (retryTime === NoWork) {
+      var suspenseConfig = null; // Retries don't carry over the already committed update.
+
+      var currentTime = requestCurrentTimeForUpdate();
+      retryTime = computeExpirationForFiber(currentTime, boundaryFiber, suspenseConfig);
+    } // TODO: Special case idle priority?
+
+
+    var root = markUpdateTimeFromFiberToRoot(boundaryFiber, retryTime);
+
+    if (root !== null) {
+      ensureRootIsScheduled(root);
+      schedulePendingInteractions(root, retryTime);
+    }
+  }
+  function resolveRetryThenable(boundaryFiber, thenable) {
+    var retryTime = NoWork; // Default
+
+    var retryCache;
+
+    {
+      retryCache = boundaryFiber.stateNode;
+    }
+
+    if (retryCache !== null) {
+      // The thenable resolved, so we no longer need to memoize, because it will
+      // never be thrown again.
+      retryCache.delete(thenable);
+    }
+
+    retryTimedOutBoundary(boundaryFiber, retryTime);
+  } // Computes the next Just Noticeable Difference (JND) boundary.
+  // The theory is that a person can't tell the difference between small differences in time.
+  // Therefore, if we wait a bit longer than necessary that won't translate to a noticeable
+  // difference in the experience. However, waiting for longer might mean that we can avoid
+  // showing an intermediate loading state. The longer we have already waited, the harder it
+  // is to tell small differences in time. Therefore, the longer we've already waited,
+  // the longer we can wait additionally. At some point we have to give up though.
+  // We pick a train model where the next boundary commits at a consistent schedule.
+  // These particular numbers are vague estimates. We expect to adjust them based on research.
+
+  function jnd(timeElapsed) {
+    return timeElapsed < 120 ? 120 : timeElapsed < 480 ? 480 : timeElapsed < 1080 ? 1080 : timeElapsed < 1920 ? 1920 : timeElapsed < 3000 ? 3000 : timeElapsed < 4320 ? 4320 : ceil(timeElapsed / 1960) * 1960;
+  }
+
+  function computeMsUntilSuspenseLoadingDelay(mostRecentEventTime, committedExpirationTime, suspenseConfig) {
+    var busyMinDurationMs = suspenseConfig.busyMinDurationMs | 0;
+
+    if (busyMinDurationMs <= 0) {
+      return 0;
+    }
+
+    var busyDelayMs = suspenseConfig.busyDelayMs | 0; // Compute the time until this render pass would expire.
+
+    var currentTimeMs = now();
+    var eventTimeMs = inferTimeFromExpirationTimeWithSuspenseConfig(mostRecentEventTime, suspenseConfig);
+    var timeElapsed = currentTimeMs - eventTimeMs;
+
+    if (timeElapsed <= busyDelayMs) {
+      // If we haven't yet waited longer than the initial delay, we don't
+      // have to wait any additional time.
+      return 0;
+    }
+
+    var msUntilTimeout = busyDelayMs + busyMinDurationMs - timeElapsed; // This is the value that is passed to `setTimeout`.
+
+    return msUntilTimeout;
+  }
+
+  function checkForNestedUpdates() {
+    if (nestedUpdateCount > NESTED_UPDATE_LIMIT) {
+      nestedUpdateCount = 0;
+      rootWithNestedUpdates = null;
+
+      {
+        {
+          throw Error( "Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops." );
+        }
+      }
+    }
+
+    {
+      if (nestedPassiveUpdateCount > NESTED_PASSIVE_UPDATE_LIMIT) {
+        nestedPassiveUpdateCount = 0;
+
+        error('Maximum update depth exceeded. This can happen when a component ' + "calls setState inside useEffect, but useEffect either doesn't " + 'have a dependency array, or one of the dependencies changes on ' + 'every render.');
+      }
+    }
+  }
+
+  function flushRenderPhaseStrictModeWarningsInDEV() {
+    {
+      ReactStrictModeWarnings.flushLegacyContextWarning();
+
+      {
+        ReactStrictModeWarnings.flushPendingUnsafeLifecycleWarnings();
+      }
+    }
+  }
+
+  function stopFinishedWorkLoopTimer() {
+    var didCompleteRoot = true;
+    stopWorkLoopTimer(interruptedBy, didCompleteRoot);
+    interruptedBy = null;
+  }
+
+  function stopInterruptedWorkLoopTimer() {
+    // TODO: Track which fiber caused the interruption.
+    var didCompleteRoot = false;
+    stopWorkLoopTimer(interruptedBy, didCompleteRoot);
+    interruptedBy = null;
+  }
+
+  function checkForInterruption(fiberThatReceivedUpdate, updateExpirationTime) {
+    if ( workInProgressRoot !== null && updateExpirationTime > renderExpirationTime$1) {
+      interruptedBy = fiberThatReceivedUpdate;
+    }
+  }
+
+  var didWarnStateUpdateForUnmountedComponent = null;
+
+  function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
+    {
+      var tag = fiber.tag;
+
+      if (tag !== HostRoot && tag !== ClassComponent && tag !== FunctionComponent && tag !== ForwardRef && tag !== MemoComponent && tag !== SimpleMemoComponent && tag !== Block) {
+        // Only warn for user-defined components, not internal ones like Suspense.
+        return;
+      }
+      // the problematic code almost always lies inside that component.
+
+
+      var componentName = getComponentName(fiber.type) || 'ReactComponent';
+
+      if (didWarnStateUpdateForUnmountedComponent !== null) {
+        if (didWarnStateUpdateForUnmountedComponent.has(componentName)) {
+          return;
+        }
+
+        didWarnStateUpdateForUnmountedComponent.add(componentName);
+      } else {
+        didWarnStateUpdateForUnmountedComponent = new Set([componentName]);
+      }
+
+      error("Can't perform a React state update on an unmounted component. This " + 'is a no-op, but it indicates a memory leak in your application. To ' + 'fix, cancel all subscriptions and asynchronous tasks in %s.%s', tag === ClassComponent ? 'the componentWillUnmount method' : 'a useEffect cleanup function', getStackByFiberInDevAndProd(fiber));
+    }
+  }
+
+  var beginWork$1;
+
+  {
+    var dummyFiber = null;
+
+    beginWork$1 = function (current, unitOfWork, expirationTime) {
+      // If a component throws an error, we replay it again in a synchronously
+      // dispatched event, so that the debugger will treat it as an uncaught
+      // error See ReactErrorUtils for more information.
+      // Before entering the begin phase, copy the work-in-progress onto a dummy
+      // fiber. If beginWork throws, we'll use this to reset the state.
+      var originalWorkInProgressCopy = assignFiberPropertiesInDEV(dummyFiber, unitOfWork);
+
+      try {
+        return beginWork(current, unitOfWork, expirationTime);
+      } catch (originalError) {
+        if (originalError !== null && typeof originalError === 'object' && typeof originalError.then === 'function') {
+          // Don't replay promises. Treat everything else like an error.
+          throw originalError;
+        } // Keep this code in sync with handleError; any changes here must have
+        // corresponding changes there.
+
+
+        resetContextDependencies();
+        resetHooksAfterThrow(); // Don't reset current debug fiber, since we're about to work on the
+        // same fiber again.
+        // Unwind the failed stack frame
+
+        unwindInterruptedWork(unitOfWork); // Restore the original properties of the fiber.
+
+        assignFiberPropertiesInDEV(unitOfWork, originalWorkInProgressCopy);
+
+        if ( unitOfWork.mode & ProfileMode) {
+          // Reset the profiler timer.
+          startProfilerTimer(unitOfWork);
+        } // Run beginWork again.
+
+
+        invokeGuardedCallback(null, beginWork, null, current, unitOfWork, expirationTime);
+
+        if (hasCaughtError()) {
+          var replayError = clearCaughtError(); // `invokeGuardedCallback` sometimes sets an expando `_suppressLogging`.
+          // Rethrow this error instead of the original one.
+
+          throw replayError;
+        } else {
+          // This branch is reachable if the render phase is impure.
+          throw originalError;
+        }
+      }
+    };
+  }
+
+  var didWarnAboutUpdateInRender = false;
+  var didWarnAboutUpdateInRenderForAnotherComponent;
+
+  {
+    didWarnAboutUpdateInRenderForAnotherComponent = new Set();
+  }
+
+  function warnAboutRenderPhaseUpdatesInDEV(fiber) {
+    {
+      if (isRendering && (executionContext & RenderContext) !== NoContext) {
+        switch (fiber.tag) {
+          case FunctionComponent:
+          case ForwardRef:
+          case SimpleMemoComponent:
+            {
+              var renderingComponentName = workInProgress && getComponentName(workInProgress.type) || 'Unknown'; // Dedupe by the rendering component because it's the one that needs to be fixed.
+
+              var dedupeKey = renderingComponentName;
+
+              if (!didWarnAboutUpdateInRenderForAnotherComponent.has(dedupeKey)) {
+                didWarnAboutUpdateInRenderForAnotherComponent.add(dedupeKey);
+                var setStateComponentName = getComponentName(fiber.type) || 'Unknown';
+
+                error('Cannot update a component (`%s`) while rendering a ' + 'different component (`%s`). To locate the bad setState() call inside `%s`, ' + 'follow the stack trace as described in https://fb.me/setstate-in-render', setStateComponentName, renderingComponentName, renderingComponentName);
+              }
+
+              break;
+            }
+
+          case ClassComponent:
+            {
+              if (!didWarnAboutUpdateInRender) {
+                error('Cannot update during an existing state transition (such as ' + 'within `render`). Render methods should be a pure ' + 'function of props and state.');
+
+                didWarnAboutUpdateInRender = true;
+              }
+
+              break;
+            }
+        }
+      }
+    }
+  } // a 'shared' variable that changes when act() opens/closes in tests.
+
+
+  var IsThisRendererActing = {
+    current: false
+  };
+  function warnIfNotScopedWithMatchingAct(fiber) {
+    {
+      if ( IsSomeRendererActing.current === true && IsThisRendererActing.current !== true) {
+        error("It looks like you're using the wrong act() around your test interactions.\n" + 'Be sure to use the matching version of act() corresponding to your renderer:\n\n' + '// for react-dom:\n' + "import {act} from 'react-dom/test-utils';\n" + '// ...\n' + 'act(() => ...);\n\n' + '// for react-test-renderer:\n' + "import TestRenderer from 'react-test-renderer';\n" + 'const {act} = TestRenderer;\n' + '// ...\n' + 'act(() => ...);' + '%s', getStackByFiberInDevAndProd(fiber));
+      }
+    }
+  }
+  function warnIfNotCurrentlyActingEffectsInDEV(fiber) {
+    {
+      if ( (fiber.mode & StrictMode) !== NoMode && IsSomeRendererActing.current === false && IsThisRendererActing.current === false) {
+        error('An update to %s ran an effect, but was not wrapped in act(...).\n\n' + 'When testing, code that causes React state updates should be ' + 'wrapped into act(...):\n\n' + 'act(() => {\n' + '  /* fire events that update state */\n' + '});\n' + '/* assert on the output */\n\n' + "This ensures that you're testing the behavior the user would see " + 'in the browser.' + ' Learn more at https://fb.me/react-wrap-tests-with-act' + '%s', getComponentName(fiber.type), getStackByFiberInDevAndProd(fiber));
+      }
+    }
+  }
+
+  function warnIfNotCurrentlyActingUpdatesInDEV(fiber) {
+    {
+      if ( executionContext === NoContext && IsSomeRendererActing.current === false && IsThisRendererActing.current === false) {
+        error('An update to %s inside a test was not wrapped in act(...).\n\n' + 'When testing, code that causes React state updates should be ' + 'wrapped into act(...):\n\n' + 'act(() => {\n' + '  /* fire events that update state */\n' + '});\n' + '/* assert on the output */\n\n' + "This ensures that you're testing the behavior the user would see " + 'in the browser.' + ' Learn more at https://fb.me/react-wrap-tests-with-act' + '%s', getComponentName(fiber.type), getStackByFiberInDevAndProd(fiber));
+      }
+    }
+  }
+
+  var warnIfNotCurrentlyActingUpdatesInDev = warnIfNotCurrentlyActingUpdatesInDEV; // In tests, we want to enforce a mocked scheduler.
+
+  var didWarnAboutUnmockedScheduler = false; // TODO Before we release concurrent mode, revisit this and decide whether a mocked
+  // scheduler is the actual recommendation. The alternative could be a testing build,
+  // a new lib, or whatever; we dunno just yet. This message is for early adopters
+  // to get their tests right.
+
+  function warnIfUnmockedScheduler(fiber) {
+    {
+      if (didWarnAboutUnmockedScheduler === false && unstable_flushAllWithoutAsserting === undefined) {
+        if (fiber.mode & BlockingMode || fiber.mode & ConcurrentMode) {
+          didWarnAboutUnmockedScheduler = true;
+
+          error('In Concurrent or Sync modes, the "scheduler" module needs to be mocked ' + 'to guarantee consistent behaviour across tests and browsers. ' + 'For example, with jest: \n' + "jest.mock('scheduler', () => require('scheduler/unstable_mock'));\n\n" + 'For more info, visit https://fb.me/react-mock-scheduler');
+        }
+      }
+    }
+  }
+
+  function computeThreadID(root, expirationTime) {
+    // Interaction threads are unique per root and expiration time.
+    return expirationTime * 1000 + root.interactionThreadID;
+  }
+
+  function markSpawnedWork(expirationTime) {
+
+    if (spawnedWorkDuringRender === null) {
+      spawnedWorkDuringRender = [expirationTime];
+    } else {
+      spawnedWorkDuringRender.push(expirationTime);
+    }
+  }
+
+  function scheduleInteractions(root, expirationTime, interactions) {
+
+    if (interactions.size > 0) {
+      var pendingInteractionMap = root.pendingInteractionMap;
+      var pendingInteractions = pendingInteractionMap.get(expirationTime);
+
+      if (pendingInteractions != null) {
+        interactions.forEach(function (interaction) {
+          if (!pendingInteractions.has(interaction)) {
+            // Update the pending async work count for previously unscheduled interaction.
+            interaction.__count++;
+          }
+
+          pendingInteractions.add(interaction);
+        });
+      } else {
+        pendingInteractionMap.set(expirationTime, new Set(interactions)); // Update the pending async work count for the current interactions.
+
+        interactions.forEach(function (interaction) {
+          interaction.__count++;
+        });
+      }
+
+      var subscriber = __subscriberRef.current;
+
+      if (subscriber !== null) {
+        var threadID = computeThreadID(root, expirationTime);
+        subscriber.onWorkScheduled(interactions, threadID);
+      }
+    }
+  }
+
+  function schedulePendingInteractions(root, expirationTime) {
+
+    scheduleInteractions(root, expirationTime, __interactionsRef.current);
+  }
+
+  function startWorkOnPendingInteractions(root, expirationTime) {
+    // we can accurately attribute time spent working on it, And so that cascading
+    // work triggered during the render phase will be associated with it.
+
+
+    var interactions = new Set();
+    root.pendingInteractionMap.forEach(function (scheduledInteractions, scheduledExpirationTime) {
+      if (scheduledExpirationTime >= expirationTime) {
+        scheduledInteractions.forEach(function (interaction) {
+          return interactions.add(interaction);
+        });
+      }
+    }); // Store the current set of interactions on the FiberRoot for a few reasons:
+    // We can re-use it in hot functions like performConcurrentWorkOnRoot()
+    // without having to recalculate it. We will also use it in commitWork() to
+    // pass to any Profiler onRender() hooks. This also provides DevTools with a
+    // way to access it when the onCommitRoot() hook is called.
+
+    root.memoizedInteractions = interactions;
+
+    if (interactions.size > 0) {
+      var subscriber = __subscriberRef.current;
+
+      if (subscriber !== null) {
+        var threadID = computeThreadID(root, expirationTime);
+
+        try {
+          subscriber.onWorkStarted(interactions, threadID);
+        } catch (error) {
+          // If the subscriber throws, rethrow it in a separate task
+          scheduleCallback(ImmediatePriority, function () {
+            throw error;
+          });
+        }
+      }
+    }
+  }
+
+  function finishPendingInteractions(root, committedExpirationTime) {
+
+    var earliestRemainingTimeAfterCommit = root.firstPendingTime;
+    var subscriber;
+
+    try {
+      subscriber = __subscriberRef.current;
+
+      if (subscriber !== null && root.memoizedInteractions.size > 0) {
+        var threadID = computeThreadID(root, committedExpirationTime);
+        subscriber.onWorkStopped(root.memoizedInteractions, threadID);
+      }
+    } catch (error) {
+      // If the subscriber throws, rethrow it in a separate task
+      scheduleCallback(ImmediatePriority, function () {
+        throw error;
+      });
+    } finally {
+      // Clear completed interactions from the pending Map.
+      // Unless the render was suspended or cascading work was scheduled,
+      // In which case– leave pending interactions until the subsequent render.
+      var pendingInteractionMap = root.pendingInteractionMap;
+      pendingInteractionMap.forEach(function (scheduledInteractions, scheduledExpirationTime) {
+        // Only decrement the pending interaction count if we're done.
+        // If there's still work at the current priority,
+        // That indicates that we are waiting for suspense data.
+        if (scheduledExpirationTime > earliestRemainingTimeAfterCommit) {
+          pendingInteractionMap.delete(scheduledExpirationTime);
+          scheduledInteractions.forEach(function (interaction) {
+            interaction.__count--;
+
+            if (subscriber !== null && interaction.__count === 0) {
+              try {
+                subscriber.onInteractionScheduledWorkCompleted(interaction);
+              } catch (error) {
+                // If the subscriber throws, rethrow it in a separate task
+                scheduleCallback(ImmediatePriority, function () {
+                  throw error;
+                });
+              }
+            }
+          });
+        }
+      });
+    }
+  }
+
+  var onScheduleFiberRoot = null;
+  var onCommitFiberRoot = null;
+  var onCommitFiberUnmount = null;
+  var hasLoggedError = false;
+  var isDevToolsPresent = typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined';
+  function injectInternals(internals) {
+    if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+      // No DevTools
+      return false;
+    }
+
+    var hook = __REACT_DEVTOOLS_GLOBAL_HOOK__;
+
+    if (hook.isDisabled) {
+      // This isn't a real property on the hook, but it can be set to opt out
+      // of DevTools integration and associated warnings and logs.
+      // https://github.com/facebook/react/issues/3877
+      return true;
+    }
+
+    if (!hook.supportsFiber) {
+      {
+        error('The installed version of React DevTools is too old and will not work ' + 'with the current version of React. Please update React DevTools. ' + 'https://fb.me/react-devtools');
+      } // DevTools exists, even though it doesn't support Fiber.
+
+
+      return true;
+    }
+
+    try {
+      var rendererID = hook.inject(internals); // We have successfully injected, so now it is safe to set up hooks.
+
+      if (true) {
+        // Only used by Fast Refresh
+        if (typeof hook.onScheduleFiberRoot === 'function') {
+          onScheduleFiberRoot = function (root, children) {
+            try {
+              hook.onScheduleFiberRoot(rendererID, root, children);
+            } catch (err) {
+              if (true && !hasLoggedError) {
+                hasLoggedError = true;
+
+                error('React instrumentation encountered an error: %s', err);
+              }
+            }
+          };
+        }
+      }
+
+      onCommitFiberRoot = function (root, expirationTime) {
+        try {
+          var didError = (root.current.effectTag & DidCapture) === DidCapture;
+
+          if (enableProfilerTimer) {
+            var currentTime = getCurrentTime();
+            var priorityLevel = inferPriorityFromExpirationTime(currentTime, expirationTime);
+            hook.onCommitFiberRoot(rendererID, root, priorityLevel, didError);
+          } else {
+            hook.onCommitFiberRoot(rendererID, root, undefined, didError);
+          }
+        } catch (err) {
+          if (true) {
+            if (!hasLoggedError) {
+              hasLoggedError = true;
+
+              error('React instrumentation encountered an error: %s', err);
+            }
+          }
+        }
+      };
+
+      onCommitFiberUnmount = function (fiber) {
+        try {
+          hook.onCommitFiberUnmount(rendererID, fiber);
+        } catch (err) {
+          if (true) {
+            if (!hasLoggedError) {
+              hasLoggedError = true;
+
+              error('React instrumentation encountered an error: %s', err);
+            }
+          }
+        }
+      };
+    } catch (err) {
+      // Catch all errors because it is unsafe to throw during initialization.
+      {
+        error('React instrumentation encountered an error: %s.', err);
+      }
+    } // DevTools exists
+
+
+    return true;
+  }
+  function onScheduleRoot(root, children) {
+    if (typeof onScheduleFiberRoot === 'function') {
+      onScheduleFiberRoot(root, children);
+    }
+  }
+  function onCommitRoot(root, expirationTime) {
+    if (typeof onCommitFiberRoot === 'function') {
+      onCommitFiberRoot(root, expirationTime);
+    }
+  }
+  function onCommitUnmount(fiber) {
+    if (typeof onCommitFiberUnmount === 'function') {
+      onCommitFiberUnmount(fiber);
+    }
+  }
+
+  var hasBadMapPolyfill;
+
+  {
+    hasBadMapPolyfill = false;
+
+    try {
+      var nonExtensibleObject = Object.preventExtensions({});
+      var testMap = new Map([[nonExtensibleObject, null]]);
+      var testSet = new Set([nonExtensibleObject]); // This is necessary for Rollup to not consider these unused.
+      // https://github.com/rollup/rollup/issues/1771
+      // TODO: we can remove these if Rollup fixes the bug.
+
+      testMap.set(0, 0);
+      testSet.add(0);
+    } catch (e) {
+      // TODO: Consider warning about bad polyfills
+      hasBadMapPolyfill = true;
+    }
+  }
+
+  var debugCounter = 1;
+
+  function FiberNode(tag, pendingProps, key, mode) {
+    // Instance
+    this.tag = tag;
+    this.key = key;
+    this.elementType = null;
+    this.type = null;
+    this.stateNode = null; // Fiber
+
+    this.return = null;
+    this.child = null;
+    this.sibling = null;
+    this.index = 0;
+    this.ref = null;
+    this.pendingProps = pendingProps;
+    this.memoizedProps = null;
+    this.updateQueue = null;
+    this.memoizedState = null;
+    this.dependencies = null;
+    this.mode = mode; // Effects
+
+    this.effectTag = NoEffect;
+    this.nextEffect = null;
+    this.firstEffect = null;
+    this.lastEffect = null;
+    this.expirationTime = NoWork;
+    this.childExpirationTime = NoWork;
+    this.alternate = null;
+
+    {
+      // Note: The following is done to avoid a v8 performance cliff.
+      //
+      // Initializing the fields below to smis and later updating them with
+      // double values will cause Fibers to end up having separate shapes.
+      // This behavior/bug has something to do with Object.preventExtension().
+      // Fortunately this only impacts DEV builds.
+      // Unfortunately it makes React unusably slow for some applications.
+      // To work around this, initialize the fields below with doubles.
+      //
+      // Learn more about this here:
+      // https://github.com/facebook/react/issues/14365
+      // https://bugs.chromium.org/p/v8/issues/detail?id=8538
+      this.actualDuration = Number.NaN;
+      this.actualStartTime = Number.NaN;
+      this.selfBaseDuration = Number.NaN;
+      this.treeBaseDuration = Number.NaN; // It's okay to replace the initial doubles with smis after initialization.
+      // This won't trigger the performance cliff mentioned above,
+      // and it simplifies other profiler code (including DevTools).
+
+      this.actualDuration = 0;
+      this.actualStartTime = -1;
+      this.selfBaseDuration = 0;
+      this.treeBaseDuration = 0;
+    } // This is normally DEV-only except www when it adds listeners.
+    // TODO: remove the User Timing integration in favor of Root Events.
+
+
+    {
+      this._debugID = debugCounter++;
+      this._debugIsCurrentlyTiming = false;
+    }
+
+    {
+      this._debugSource = null;
+      this._debugOwner = null;
+      this._debugNeedsRemount = false;
+      this._debugHookTypes = null;
+
+      if (!hasBadMapPolyfill && typeof Object.preventExtensions === 'function') {
+        Object.preventExtensions(this);
+      }
+    }
+  } // This is a constructor function, rather than a POJO constructor, still
+  // please ensure we do the following:
+  // 1) Nobody should add any instance methods on this. Instance methods can be
+  //    more difficult to predict when they get optimized and they are almost
+  //    never inlined properly in static compilers.
+  // 2) Nobody should rely on `instanceof Fiber` for type testing. We should
+  //    always know when it is a fiber.
+  // 3) We might want to experiment with using numeric keys since they are easier
+  //    to optimize in a non-JIT environment.
+  // 4) We can easily go from a constructor to a createFiber object literal if that
+  //    is faster.
+  // 5) It should be easy to port this to a C struct and keep a C implementation
+  //    compatible.
+
+
+  var createFiber = function (tag, pendingProps, key, mode) {
+    // $FlowFixMe: the shapes are exact here but Flow doesn't like constructors
+    return new FiberNode(tag, pendingProps, key, mode);
+  };
+
+  function shouldConstruct(Component) {
+    var prototype = Component.prototype;
+    return !!(prototype && prototype.isReactComponent);
+  }
+
+  function isSimpleFunctionComponent(type) {
+    return typeof type === 'function' && !shouldConstruct(type) && type.defaultProps === undefined;
+  }
+  function resolveLazyComponentTag(Component) {
+    if (typeof Component === 'function') {
+      return shouldConstruct(Component) ? ClassComponent : FunctionComponent;
+    } else if (Component !== undefined && Component !== null) {
+      var $$typeof = Component.$$typeof;
+
+      if ($$typeof === REACT_FORWARD_REF_TYPE) {
+        return ForwardRef;
+      }
+
+      if ($$typeof === REACT_MEMO_TYPE) {
+        return MemoComponent;
+      }
+    }
+
+    return IndeterminateComponent;
+  } // This is used to create an alternate fiber to do work on.
+
+  function createWorkInProgress(current, pendingProps) {
+    var workInProgress = current.alternate;
+
+    if (workInProgress === null) {
+      // We use a double buffering pooling technique because we know that we'll
+      // only ever need at most two versions of a tree. We pool the "other" unused
+      // node that we're free to reuse. This is lazily created to avoid allocating
+      // extra objects for things that are never updated. It also allow us to
+      // reclaim the extra memory if needed.
+      workInProgress = createFiber(current.tag, pendingProps, current.key, current.mode);
+      workInProgress.elementType = current.elementType;
+      workInProgress.type = current.type;
+      workInProgress.stateNode = current.stateNode;
+
+      {
+        // DEV-only fields
+        {
+          workInProgress._debugID = current._debugID;
+        }
+
+        workInProgress._debugSource = current._debugSource;
+        workInProgress._debugOwner = current._debugOwner;
+        workInProgress._debugHookTypes = current._debugHookTypes;
+      }
+
+      workInProgress.alternate = current;
+      current.alternate = workInProgress;
+    } else {
+      workInProgress.pendingProps = pendingProps; // We already have an alternate.
+      // Reset the effect tag.
+
+      workInProgress.effectTag = NoEffect; // The effect list is no longer valid.
+
+      workInProgress.nextEffect = null;
+      workInProgress.firstEffect = null;
+      workInProgress.lastEffect = null;
+
+      {
+        // We intentionally reset, rather than copy, actualDuration & actualStartTime.
+        // This prevents time from endlessly accumulating in new commits.
+        // This has the downside of resetting values for different priority renders,
+        // But works for yielding (the common case) and should support resuming.
+        workInProgress.actualDuration = 0;
+        workInProgress.actualStartTime = -1;
+      }
+    }
+
+    workInProgress.childExpirationTime = current.childExpirationTime;
+    workInProgress.expirationTime = current.expirationTime;
+    workInProgress.child = current.child;
+    workInProgress.memoizedProps = current.memoizedProps;
+    workInProgress.memoizedState = current.memoizedState;
+    workInProgress.updateQueue = current.updateQueue; // Clone the dependencies object. This is mutated during the render phase, so
+    // it cannot be shared with the current fiber.
+
+    var currentDependencies = current.dependencies;
+    workInProgress.dependencies = currentDependencies === null ? null : {
+      expirationTime: currentDependencies.expirationTime,
+      firstContext: currentDependencies.firstContext,
+      responders: currentDependencies.responders
+    }; // These will be overridden during the parent's reconciliation
+
+    workInProgress.sibling = current.sibling;
+    workInProgress.index = current.index;
+    workInProgress.ref = current.ref;
+
+    {
+      workInProgress.selfBaseDuration = current.selfBaseDuration;
+      workInProgress.treeBaseDuration = current.treeBaseDuration;
+    }
+
+    {
+      workInProgress._debugNeedsRemount = current._debugNeedsRemount;
+
+      switch (workInProgress.tag) {
+        case IndeterminateComponent:
+        case FunctionComponent:
+        case SimpleMemoComponent:
+          workInProgress.type = resolveFunctionForHotReloading(current.type);
+          break;
+
+        case ClassComponent:
+          workInProgress.type = resolveClassForHotReloading(current.type);
+          break;
+
+        case ForwardRef:
+          workInProgress.type = resolveForwardRefForHotReloading(current.type);
+          break;
+      }
+    }
+
+    return workInProgress;
+  } // Used to reuse a Fiber for a second pass.
+
+  function resetWorkInProgress(workInProgress, renderExpirationTime) {
+    // This resets the Fiber to what createFiber or createWorkInProgress would
+    // have set the values to before during the first pass. Ideally this wouldn't
+    // be necessary but unfortunately many code paths reads from the workInProgress
+    // when they should be reading from current and writing to workInProgress.
+    // We assume pendingProps, index, key, ref, return are still untouched to
+    // avoid doing another reconciliation.
+    // Reset the effect tag but keep any Placement tags, since that's something
+    // that child fiber is setting, not the reconciliation.
+    workInProgress.effectTag &= Placement; // The effect list is no longer valid.
+
+    workInProgress.nextEffect = null;
+    workInProgress.firstEffect = null;
+    workInProgress.lastEffect = null;
+    var current = workInProgress.alternate;
+
+    if (current === null) {
+      // Reset to createFiber's initial values.
+      workInProgress.childExpirationTime = NoWork;
+      workInProgress.expirationTime = renderExpirationTime;
+      workInProgress.child = null;
+      workInProgress.memoizedProps = null;
+      workInProgress.memoizedState = null;
+      workInProgress.updateQueue = null;
+      workInProgress.dependencies = null;
+
+      {
+        // Note: We don't reset the actualTime counts. It's useful to accumulate
+        // actual time across multiple render passes.
+        workInProgress.selfBaseDuration = 0;
+        workInProgress.treeBaseDuration = 0;
+      }
+    } else {
+      // Reset to the cloned values that createWorkInProgress would've.
+      workInProgress.childExpirationTime = current.childExpirationTime;
+      workInProgress.expirationTime = current.expirationTime;
+      workInProgress.child = current.child;
+      workInProgress.memoizedProps = current.memoizedProps;
+      workInProgress.memoizedState = current.memoizedState;
+      workInProgress.updateQueue = current.updateQueue; // Clone the dependencies object. This is mutated during the render phase, so
+      // it cannot be shared with the current fiber.
+
+      var currentDependencies = current.dependencies;
+      workInProgress.dependencies = currentDependencies === null ? null : {
+        expirationTime: currentDependencies.expirationTime,
+        firstContext: currentDependencies.firstContext,
+        responders: currentDependencies.responders
+      };
+
+      {
+        // Note: We don't reset the actualTime counts. It's useful to accumulate
+        // actual time across multiple render passes.
+        workInProgress.selfBaseDuration = current.selfBaseDuration;
+        workInProgress.treeBaseDuration = current.treeBaseDuration;
+      }
+    }
+
+    return workInProgress;
+  }
+  function createHostRootFiber(tag) {
+    var mode;
+
+    if (tag === ConcurrentRoot) {
+      mode = ConcurrentMode | BlockingMode | StrictMode;
+    } else if (tag === BlockingRoot) {
+      mode = BlockingMode | StrictMode;
+    } else {
+      mode = NoMode;
+    }
+
+    if ( isDevToolsPresent) {
+      // Always collect profile timings when DevTools are present.
+      // This enables DevTools to start capturing timing at any point–
+      // Without some nodes in the tree having empty base times.
+      mode |= ProfileMode;
+    }
+
+    return createFiber(HostRoot, null, null, mode);
+  }
+  function createFiberFromTypeAndProps(type, // React$ElementType
+  key, pendingProps, owner, mode, expirationTime) {
+    var fiber;
+    var fiberTag = IndeterminateComponent; // The resolved type is set if we know what the final type will be. I.e. it's not lazy.
+
+    var resolvedType = type;
+
+    if (typeof type === 'function') {
+      if (shouldConstruct(type)) {
+        fiberTag = ClassComponent;
+
+        {
+          resolvedType = resolveClassForHotReloading(resolvedType);
+        }
+      } else {
+        {
+          resolvedType = resolveFunctionForHotReloading(resolvedType);
+        }
+      }
+    } else if (typeof type === 'string') {
+      fiberTag = HostComponent;
+    } else {
+      getTag: switch (type) {
+        case REACT_FRAGMENT_TYPE:
+          return createFiberFromFragment(pendingProps.children, mode, expirationTime, key);
+
+        case REACT_CONCURRENT_MODE_TYPE:
+          fiberTag = Mode;
+          mode |= ConcurrentMode | BlockingMode | StrictMode;
+          break;
+
+        case REACT_STRICT_MODE_TYPE:
+          fiberTag = Mode;
+          mode |= StrictMode;
+          break;
+
+        case REACT_PROFILER_TYPE:
+          return createFiberFromProfiler(pendingProps, mode, expirationTime, key);
+
+        case REACT_SUSPENSE_TYPE:
+          return createFiberFromSuspense(pendingProps, mode, expirationTime, key);
+
+        case REACT_SUSPENSE_LIST_TYPE:
+          return createFiberFromSuspenseList(pendingProps, mode, expirationTime, key);
+
+        default:
+          {
+            if (typeof type === 'object' && type !== null) {
+              switch (type.$$typeof) {
+                case REACT_PROVIDER_TYPE:
+                  fiberTag = ContextProvider;
+                  break getTag;
+
+                case REACT_CONTEXT_TYPE:
+                  // This is a consumer
+                  fiberTag = ContextConsumer;
+                  break getTag;
+
+                case REACT_FORWARD_REF_TYPE:
+                  fiberTag = ForwardRef;
+
+                  {
+                    resolvedType = resolveForwardRefForHotReloading(resolvedType);
+                  }
+
+                  break getTag;
+
+                case REACT_MEMO_TYPE:
+                  fiberTag = MemoComponent;
+                  break getTag;
+
+                case REACT_LAZY_TYPE:
+                  fiberTag = LazyComponent;
+                  resolvedType = null;
+                  break getTag;
+
+                case REACT_BLOCK_TYPE:
+                  fiberTag = Block;
+                  break getTag;
+
+              }
+            }
+
+            var info = '';
+
+            {
+              if (type === undefined || typeof type === 'object' && type !== null && Object.keys(type).length === 0) {
+                info += ' You likely forgot to export your component from the file ' + "it's defined in, or you might have mixed up default and " + 'named imports.';
+              }
+
+              var ownerName = owner ? getComponentName(owner.type) : null;
+
+              if (ownerName) {
+                info += '\n\nCheck the render method of `' + ownerName + '`.';
+              }
+            }
+
+            {
+              {
+                throw Error( "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: " + (type == null ? type : typeof type) + "." + info );
+              }
+            }
+          }
+      }
+    }
+
+    fiber = createFiber(fiberTag, pendingProps, key, mode);
+    fiber.elementType = type;
+    fiber.type = resolvedType;
+    fiber.expirationTime = expirationTime;
+    return fiber;
+  }
+  function createFiberFromElement(element, mode, expirationTime) {
+    var owner = null;
+
+    {
+      owner = element._owner;
+    }
+
+    var type = element.type;
+    var key = element.key;
+    var pendingProps = element.props;
+    var fiber = createFiberFromTypeAndProps(type, key, pendingProps, owner, mode, expirationTime);
+
+    {
+      fiber._debugSource = element._source;
+      fiber._debugOwner = element._owner;
+    }
+
+    return fiber;
+  }
+  function createFiberFromFragment(elements, mode, expirationTime, key) {
+    var fiber = createFiber(Fragment, elements, key, mode);
+    fiber.expirationTime = expirationTime;
+    return fiber;
+  }
+
+  function createFiberFromProfiler(pendingProps, mode, expirationTime, key) {
+    {
+      if (typeof pendingProps.id !== 'string' || typeof pendingProps.onRender !== 'function') {
+        error('Profiler must specify an "id" string and "onRender" function as props');
+      }
+    }
+
+    var fiber = createFiber(Profiler, pendingProps, key, mode | ProfileMode); // TODO: The Profiler fiber shouldn't have a type. It has a tag.
+
+    fiber.elementType = REACT_PROFILER_TYPE;
+    fiber.type = REACT_PROFILER_TYPE;
+    fiber.expirationTime = expirationTime;
+    return fiber;
+  }
+
+  function createFiberFromSuspense(pendingProps, mode, expirationTime, key) {
+    var fiber = createFiber(SuspenseComponent, pendingProps, key, mode); // TODO: The SuspenseComponent fiber shouldn't have a type. It has a tag.
+    // This needs to be fixed in getComponentName so that it relies on the tag
+    // instead.
+
+    fiber.type = REACT_SUSPENSE_TYPE;
+    fiber.elementType = REACT_SUSPENSE_TYPE;
+    fiber.expirationTime = expirationTime;
+    return fiber;
+  }
+  function createFiberFromSuspenseList(pendingProps, mode, expirationTime, key) {
+    var fiber = createFiber(SuspenseListComponent, pendingProps, key, mode);
+
+    {
+      // TODO: The SuspenseListComponent fiber shouldn't have a type. It has a tag.
+      // This needs to be fixed in getComponentName so that it relies on the tag
+      // instead.
+      fiber.type = REACT_SUSPENSE_LIST_TYPE;
+    }
+
+    fiber.elementType = REACT_SUSPENSE_LIST_TYPE;
+    fiber.expirationTime = expirationTime;
+    return fiber;
+  }
+  function createFiberFromText(content, mode, expirationTime) {
+    var fiber = createFiber(HostText, content, null, mode);
+    fiber.expirationTime = expirationTime;
+    return fiber;
+  }
+  function createFiberFromHostInstanceForDeletion() {
+    var fiber = createFiber(HostComponent, null, null, NoMode); // TODO: These should not need a type.
+
+    fiber.elementType = 'DELETED';
+    fiber.type = 'DELETED';
+    return fiber;
+  }
+  function createFiberFromPortal(portal, mode, expirationTime) {
+    var pendingProps = portal.children !== null ? portal.children : [];
+    var fiber = createFiber(HostPortal, pendingProps, portal.key, mode);
+    fiber.expirationTime = expirationTime;
+    fiber.stateNode = {
+      containerInfo: portal.containerInfo,
+      pendingChildren: null,
+      // Used by persistent updates
+      implementation: portal.implementation
+    };
+    return fiber;
+  } // Used for stashing WIP properties to replay failed work in DEV.
+
+  function assignFiberPropertiesInDEV(target, source) {
+    if (target === null) {
+      // This Fiber's initial properties will always be overwritten.
+      // We only use a Fiber to ensure the same hidden class so DEV isn't slow.
+      target = createFiber(IndeterminateComponent, null, null, NoMode);
+    } // This is intentionally written as a list of all properties.
+    // We tried to use Object.assign() instead but this is called in
+    // the hottest path, and Object.assign() was too slow:
+    // https://github.com/facebook/react/issues/12502
+    // This code is DEV-only so size is not a concern.
+
+
+    target.tag = source.tag;
+    target.key = source.key;
+    target.elementType = source.elementType;
+    target.type = source.type;
+    target.stateNode = source.stateNode;
+    target.return = source.return;
+    target.child = source.child;
+    target.sibling = source.sibling;
+    target.index = source.index;
+    target.ref = source.ref;
+    target.pendingProps = source.pendingProps;
+    target.memoizedProps = source.memoizedProps;
+    target.updateQueue = source.updateQueue;
+    target.memoizedState = source.memoizedState;
+    target.dependencies = source.dependencies;
+    target.mode = source.mode;
+    target.effectTag = source.effectTag;
+    target.nextEffect = source.nextEffect;
+    target.firstEffect = source.firstEffect;
+    target.lastEffect = source.lastEffect;
+    target.expirationTime = source.expirationTime;
+    target.childExpirationTime = source.childExpirationTime;
+    target.alternate = source.alternate;
+
+    {
+      target.actualDuration = source.actualDuration;
+      target.actualStartTime = source.actualStartTime;
+      target.selfBaseDuration = source.selfBaseDuration;
+      target.treeBaseDuration = source.treeBaseDuration;
+    }
+
+    {
+      target._debugID = source._debugID;
+    }
+
+    target._debugSource = source._debugSource;
+    target._debugOwner = source._debugOwner;
+    target._debugIsCurrentlyTiming = source._debugIsCurrentlyTiming;
+    target._debugNeedsRemount = source._debugNeedsRemount;
+    target._debugHookTypes = source._debugHookTypes;
+    return target;
+  }
+
+  function FiberRootNode(containerInfo, tag, hydrate) {
+    this.tag = tag;
+    this.current = null;
+    this.containerInfo = containerInfo;
+    this.pendingChildren = null;
+    this.pingCache = null;
+    this.finishedExpirationTime = NoWork;
+    this.finishedWork = null;
+    this.timeoutHandle = noTimeout;
+    this.context = null;
+    this.pendingContext = null;
+    this.hydrate = hydrate;
+    this.callbackNode = null;
+    this.callbackPriority = NoPriority;
+    this.firstPendingTime = NoWork;
+    this.firstSuspendedTime = NoWork;
+    this.lastSuspendedTime = NoWork;
+    this.nextKnownPendingLevel = NoWork;
+    this.lastPingedTime = NoWork;
+    this.lastExpiredTime = NoWork;
+
+    {
+      this.interactionThreadID = unstable_getThreadID();
+      this.memoizedInteractions = new Set();
+      this.pendingInteractionMap = new Map();
+    }
+  }
+
+  function createFiberRoot(containerInfo, tag, hydrate, hydrationCallbacks) {
+    var root = new FiberRootNode(containerInfo, tag, hydrate);
+    // stateNode is any.
+
+
+    var uninitializedFiber = createHostRootFiber(tag);
+    root.current = uninitializedFiber;
+    uninitializedFiber.stateNode = root;
+    initializeUpdateQueue(uninitializedFiber);
+    return root;
+  }
+  function isRootSuspendedAtTime(root, expirationTime) {
+    var firstSuspendedTime = root.firstSuspendedTime;
+    var lastSuspendedTime = root.lastSuspendedTime;
+    return firstSuspendedTime !== NoWork && firstSuspendedTime >= expirationTime && lastSuspendedTime <= expirationTime;
+  }
+  function markRootSuspendedAtTime(root, expirationTime) {
+    var firstSuspendedTime = root.firstSuspendedTime;
+    var lastSuspendedTime = root.lastSuspendedTime;
+
+    if (firstSuspendedTime < expirationTime) {
+      root.firstSuspendedTime = expirationTime;
+    }
+
+    if (lastSuspendedTime > expirationTime || firstSuspendedTime === NoWork) {
+      root.lastSuspendedTime = expirationTime;
+    }
+
+    if (expirationTime <= root.lastPingedTime) {
+      root.lastPingedTime = NoWork;
+    }
+
+    if (expirationTime <= root.lastExpiredTime) {
+      root.lastExpiredTime = NoWork;
+    }
+  }
+  function markRootUpdatedAtTime(root, expirationTime) {
+    // Update the range of pending times
+    var firstPendingTime = root.firstPendingTime;
+
+    if (expirationTime > firstPendingTime) {
+      root.firstPendingTime = expirationTime;
+    } // Update the range of suspended times. Treat everything lower priority or
+    // equal to this update as unsuspended.
+
+
+    var firstSuspendedTime = root.firstSuspendedTime;
+
+    if (firstSuspendedTime !== NoWork) {
+      if (expirationTime >= firstSuspendedTime) {
+        // The entire suspended range is now unsuspended.
+        root.firstSuspendedTime = root.lastSuspendedTime = root.nextKnownPendingLevel = NoWork;
+      } else if (expirationTime >= root.lastSuspendedTime) {
+        root.lastSuspendedTime = expirationTime + 1;
+      } // This is a pending level. Check if it's higher priority than the next
+      // known pending level.
+
+
+      if (expirationTime > root.nextKnownPendingLevel) {
+        root.nextKnownPendingLevel = expirationTime;
+      }
+    }
+  }
+  function markRootFinishedAtTime(root, finishedExpirationTime, remainingExpirationTime) {
+    // Update the range of pending times
+    root.firstPendingTime = remainingExpirationTime; // Update the range of suspended times. Treat everything higher priority or
+    // equal to this update as unsuspended.
+
+    if (finishedExpirationTime <= root.lastSuspendedTime) {
+      // The entire suspended range is now unsuspended.
+      root.firstSuspendedTime = root.lastSuspendedTime = root.nextKnownPendingLevel = NoWork;
+    } else if (finishedExpirationTime <= root.firstSuspendedTime) {
+      // Part of the suspended range is now unsuspended. Narrow the range to
+      // include everything between the unsuspended time (non-inclusive) and the
+      // last suspended time.
+      root.firstSuspendedTime = finishedExpirationTime - 1;
+    }
+
+    if (finishedExpirationTime <= root.lastPingedTime) {
+      // Clear the pinged time
+      root.lastPingedTime = NoWork;
+    }
+
+    if (finishedExpirationTime <= root.lastExpiredTime) {
+      // Clear the expired time
+      root.lastExpiredTime = NoWork;
+    }
+  }
+  function markRootExpiredAtTime(root, expirationTime) {
+    var lastExpiredTime = root.lastExpiredTime;
+
+    if (lastExpiredTime === NoWork || lastExpiredTime > expirationTime) {
+      root.lastExpiredTime = expirationTime;
+    }
+  }
+
+  var didWarnAboutNestedUpdates;
+  var didWarnAboutFindNodeInStrictMode;
+
+  {
+    didWarnAboutNestedUpdates = false;
+    didWarnAboutFindNodeInStrictMode = {};
+  }
+
+  function getContextForSubtree(parentComponent) {
+    if (!parentComponent) {
+      return emptyContextObject;
+    }
+
+    var fiber = get(parentComponent);
+    var parentContext = findCurrentUnmaskedContext(fiber);
+
+    if (fiber.tag === ClassComponent) {
+      var Component = fiber.type;
+
+      if (isContextProvider(Component)) {
+        return processChildContext(fiber, Component, parentContext);
+      }
+    }
+
+    return parentContext;
+  }
+
+  function findHostInstanceWithWarning(component, methodName) {
+    {
+      var fiber = get(component);
+
+      if (fiber === undefined) {
+        if (typeof component.render === 'function') {
+          {
+            {
+              throw Error( "Unable to find node on an unmounted component." );
+            }
+          }
+        } else {
+          {
+            {
+              throw Error( "Argument appears to not be a ReactComponent. Keys: " + Object.keys(component) );
+            }
+          }
+        }
+      }
+
+      var hostFiber = findCurrentHostFiber(fiber);
+
+      if (hostFiber === null) {
+        return null;
+      }
+
+      if (hostFiber.mode & StrictMode) {
+        var componentName = getComponentName(fiber.type) || 'Component';
+
+        if (!didWarnAboutFindNodeInStrictMode[componentName]) {
+          didWarnAboutFindNodeInStrictMode[componentName] = true;
+
+          if (fiber.mode & StrictMode) {
+            error('%s is deprecated in StrictMode. ' + '%s was passed an instance of %s which is inside StrictMode. ' + 'Instead, add a ref directly to the element you want to reference. ' + 'Learn more about using refs safely here: ' + 'https://fb.me/react-strict-mode-find-node%s', methodName, methodName, componentName, getStackByFiberInDevAndProd(hostFiber));
+          } else {
+            error('%s is deprecated in StrictMode. ' + '%s was passed an instance of %s which renders StrictMode children. ' + 'Instead, add a ref directly to the element you want to reference. ' + 'Learn more about using refs safely here: ' + 'https://fb.me/react-strict-mode-find-node%s', methodName, methodName, componentName, getStackByFiberInDevAndProd(hostFiber));
+          }
+        }
+      }
+
+      return hostFiber.stateNode;
+    }
+  }
+
+  function createContainer(containerInfo, tag, hydrate, hydrationCallbacks) {
+    return createFiberRoot(containerInfo, tag, hydrate);
+  }
+  function updateContainer(element, container, parentComponent, callback) {
+    {
+      onScheduleRoot(container, element);
+    }
+
+    var current$1 = container.current;
+    var currentTime = requestCurrentTimeForUpdate();
+
+    {
+      // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+      if ('undefined' !== typeof jest) {
+        warnIfUnmockedScheduler(current$1);
+        warnIfNotScopedWithMatchingAct(current$1);
+      }
+    }
+
+    var suspenseConfig = requestCurrentSuspenseConfig();
+    var expirationTime = computeExpirationForFiber(currentTime, current$1, suspenseConfig);
+    var context = getContextForSubtree(parentComponent);
+
+    if (container.context === null) {
+      container.context = context;
+    } else {
+      container.pendingContext = context;
+    }
+
+    {
+      if (isRendering && current !== null && !didWarnAboutNestedUpdates) {
+        didWarnAboutNestedUpdates = true;
+
+        error('Render methods should be a pure function of props and state; ' + 'triggering nested component updates from render is not allowed. ' + 'If necessary, trigger nested updates in componentDidUpdate.\n\n' + 'Check the render method of %s.', getComponentName(current.type) || 'Unknown');
+      }
+    }
+
+    var update = createUpdate(expirationTime, suspenseConfig); // Caution: React DevTools currently depends on this property
+    // being called "element".
+
+    update.payload = {
+      element: element
+    };
+    callback = callback === undefined ? null : callback;
+
+    if (callback !== null) {
+      {
+        if (typeof callback !== 'function') {
+          error('render(...): Expected the last optional `callback` argument to be a ' + 'function. Instead received: %s.', callback);
+        }
+      }
+
+      update.callback = callback;
+    }
+
+    enqueueUpdate(current$1, update);
+    scheduleWork(current$1, expirationTime);
+    return expirationTime;
+  }
+  function getPublicRootInstance(container) {
+    var containerFiber = container.current;
+
+    if (!containerFiber.child) {
+      return null;
+    }
+
+    switch (containerFiber.child.tag) {
+      case HostComponent:
+        return getPublicInstance(containerFiber.child.stateNode);
+
+      default:
+        return containerFiber.child.stateNode;
+    }
+  }
+
+  function markRetryTimeImpl(fiber, retryTime) {
+    var suspenseState = fiber.memoizedState;
+
+    if (suspenseState !== null && suspenseState.dehydrated !== null) {
+      if (suspenseState.retryTime < retryTime) {
+        suspenseState.retryTime = retryTime;
+      }
+    }
+  } // Increases the priority of thennables when they resolve within this boundary.
+
+
+  function markRetryTimeIfNotHydrated(fiber, retryTime) {
+    markRetryTimeImpl(fiber, retryTime);
+    var alternate = fiber.alternate;
+
+    if (alternate) {
+      markRetryTimeImpl(alternate, retryTime);
+    }
+  }
+
+  function attemptUserBlockingHydration$1(fiber) {
+    if (fiber.tag !== SuspenseComponent) {
+      // We ignore HostRoots here because we can't increase
+      // their priority and they should not suspend on I/O,
+      // since you have to wrap anything that might suspend in
+      // Suspense.
+      return;
+    }
+
+    var expTime = computeInteractiveExpiration(requestCurrentTimeForUpdate());
+    scheduleWork(fiber, expTime);
+    markRetryTimeIfNotHydrated(fiber, expTime);
+  }
+  function attemptContinuousHydration$1(fiber) {
+    if (fiber.tag !== SuspenseComponent) {
+      // We ignore HostRoots here because we can't increase
+      // their priority and they should not suspend on I/O,
+      // since you have to wrap anything that might suspend in
+      // Suspense.
+      return;
+    }
+
+    scheduleWork(fiber, ContinuousHydration);
+    markRetryTimeIfNotHydrated(fiber, ContinuousHydration);
+  }
+  function attemptHydrationAtCurrentPriority$1(fiber) {
+    if (fiber.tag !== SuspenseComponent) {
+      // We ignore HostRoots here because we can't increase
+      // their priority other than synchronously flush it.
+      return;
+    }
+
+    var currentTime = requestCurrentTimeForUpdate();
+    var expTime = computeExpirationForFiber(currentTime, fiber, null);
+    scheduleWork(fiber, expTime);
+    markRetryTimeIfNotHydrated(fiber, expTime);
+  }
+  function findHostInstanceWithNoPortals(fiber) {
+    var hostFiber = findCurrentHostFiberWithNoPortals(fiber);
+
+    if (hostFiber === null) {
+      return null;
+    }
+
+    if (hostFiber.tag === FundamentalComponent) {
+      return hostFiber.stateNode.instance;
+    }
+
+    return hostFiber.stateNode;
+  }
+
+  var shouldSuspendImpl = function (fiber) {
+    return false;
+  };
+
+  function shouldSuspend(fiber) {
+    return shouldSuspendImpl(fiber);
+  }
+  var overrideHookState = null;
+  var overrideProps = null;
+  var scheduleUpdate = null;
+  var setSuspenseHandler = null;
+
+  {
+    var copyWithSetImpl = function (obj, path, idx, value) {
+      if (idx >= path.length) {
+        return value;
+      }
+
+      var key = path[idx];
+      var updated = Array.isArray(obj) ? obj.slice() : _assign({}, obj); // $FlowFixMe number or string is fine here
+
+      updated[key] = copyWithSetImpl(obj[key], path, idx + 1, value);
+      return updated;
+    };
+
+    var copyWithSet = function (obj, path, value) {
+      return copyWithSetImpl(obj, path, 0, value);
+    }; // Support DevTools editable values for useState and useReducer.
+
+
+    overrideHookState = function (fiber, id, path, value) {
+      // For now, the "id" of stateful hooks is just the stateful hook index.
+      // This may change in the future with e.g. nested hooks.
+      var currentHook = fiber.memoizedState;
+
+      while (currentHook !== null && id > 0) {
+        currentHook = currentHook.next;
+        id--;
+      }
+
+      if (currentHook !== null) {
+        var newState = copyWithSet(currentHook.memoizedState, path, value);
+        currentHook.memoizedState = newState;
+        currentHook.baseState = newState; // We aren't actually adding an update to the queue,
+        // because there is no update we can add for useReducer hooks that won't trigger an error.
+        // (There's no appropriate action type for DevTools overrides.)
+        // As a result though, React will see the scheduled update as a noop and bailout.
+        // Shallow cloning props works as a workaround for now to bypass the bailout check.
+
+        fiber.memoizedProps = _assign({}, fiber.memoizedProps);
+        scheduleWork(fiber, Sync);
+      }
+    }; // Support DevTools props for function components, forwardRef, memo, host components, etc.
+
+
+    overrideProps = function (fiber, path, value) {
+      fiber.pendingProps = copyWithSet(fiber.memoizedProps, path, value);
+
+      if (fiber.alternate) {
+        fiber.alternate.pendingProps = fiber.pendingProps;
+      }
+
+      scheduleWork(fiber, Sync);
+    };
+
+    scheduleUpdate = function (fiber) {
+      scheduleWork(fiber, Sync);
+    };
+
+    setSuspenseHandler = function (newShouldSuspendImpl) {
+      shouldSuspendImpl = newShouldSuspendImpl;
+    };
+  }
+
+  function injectIntoDevTools(devToolsConfig) {
+    var findFiberByHostInstance = devToolsConfig.findFiberByHostInstance;
+    var ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
+    return injectInternals(_assign({}, devToolsConfig, {
+      overrideHookState: overrideHookState,
+      overrideProps: overrideProps,
+      setSuspenseHandler: setSuspenseHandler,
+      scheduleUpdate: scheduleUpdate,
+      currentDispatcherRef: ReactCurrentDispatcher,
+      findHostInstanceByFiber: function (fiber) {
+        var hostFiber = findCurrentHostFiber(fiber);
+
+        if (hostFiber === null) {
+          return null;
+        }
+
+        return hostFiber.stateNode;
+      },
+      findFiberByHostInstance: function (instance) {
+        if (!findFiberByHostInstance) {
+          // Might not be implemented by the renderer.
+          return null;
+        }
+
+        return findFiberByHostInstance(instance);
+      },
+      // React Refresh
+      findHostInstancesForRefresh:  findHostInstancesForRefresh ,
+      scheduleRefresh:  scheduleRefresh ,
+      scheduleRoot:  scheduleRoot ,
+      setRefreshHandler:  setRefreshHandler ,
+      // Enables DevTools to append owner stacks to error messages in DEV mode.
+      getCurrentFiber:  function () {
+        return current;
+      }
+    }));
+  }
+  var IsSomeRendererActing$1 = ReactSharedInternals.IsSomeRendererActing;
+
+  function ReactDOMRoot(container, options) {
+    this._internalRoot = createRootImpl(container, ConcurrentRoot, options);
+  }
+
+  function ReactDOMBlockingRoot(container, tag, options) {
+    this._internalRoot = createRootImpl(container, tag, options);
+  }
+
+  ReactDOMRoot.prototype.render = ReactDOMBlockingRoot.prototype.render = function (children) {
+    var root = this._internalRoot;
+
+    {
+      if (typeof arguments[1] === 'function') {
+        error('render(...): does not support the second callback argument. ' + 'To execute a side effect after rendering, declare it in a component body with useEffect().');
+      }
+
+      var container = root.containerInfo;
+
+      if (container.nodeType !== COMMENT_NODE) {
+        var hostInstance = findHostInstanceWithNoPortals(root.current);
+
+        if (hostInstance) {
+          if (hostInstance.parentNode !== container) {
+            error('render(...): It looks like the React-rendered content of the ' + 'root container was removed without using React. This is not ' + 'supported and will cause errors. Instead, call ' + "root.unmount() to empty a root's container.");
+          }
+        }
+      }
+    }
+
+    updateContainer(children, root, null, null);
+  };
+
+  ReactDOMRoot.prototype.unmount = ReactDOMBlockingRoot.prototype.unmount = function () {
+    {
+      if (typeof arguments[0] === 'function') {
+        error('unmount(...): does not support a callback argument. ' + 'To execute a side effect after rendering, declare it in a component body with useEffect().');
+      }
+    }
+
+    var root = this._internalRoot;
+    var container = root.containerInfo;
+    updateContainer(null, root, null, function () {
+      unmarkContainerAsRoot(container);
+    });
+  };
+
+  function createRootImpl(container, tag, options) {
+    // Tag is either LegacyRoot or Concurrent Root
+    var hydrate = options != null && options.hydrate === true;
+    var hydrationCallbacks = options != null && options.hydrationOptions || null;
+    var root = createContainer(container, tag, hydrate);
+    markContainerAsRoot(root.current, container);
+
+    if (hydrate && tag !== LegacyRoot) {
+      var doc = container.nodeType === DOCUMENT_NODE ? container : container.ownerDocument;
+      eagerlyTrapReplayableEvents(container, doc);
+    }
+
+    return root;
+  }
+  function createLegacyRoot(container, options) {
+    return new ReactDOMBlockingRoot(container, LegacyRoot, options);
+  }
+  function isValidContainer(node) {
+    return !!(node && (node.nodeType === ELEMENT_NODE || node.nodeType === DOCUMENT_NODE || node.nodeType === DOCUMENT_FRAGMENT_NODE || node.nodeType === COMMENT_NODE && node.nodeValue === ' react-mount-point-unstable '));
+  }
+
+  var ReactCurrentOwner$3 = ReactSharedInternals.ReactCurrentOwner;
+  var topLevelUpdateWarnings;
+  var warnedAboutHydrateAPI = false;
+
+  {
+    topLevelUpdateWarnings = function (container) {
+      if (container._reactRootContainer && container.nodeType !== COMMENT_NODE) {
+        var hostInstance = findHostInstanceWithNoPortals(container._reactRootContainer._internalRoot.current);
+
+        if (hostInstance) {
+          if (hostInstance.parentNode !== container) {
+            error('render(...): It looks like the React-rendered content of this ' + 'container was removed without using React. This is not ' + 'supported and will cause errors. Instead, call ' + 'ReactDOM.unmountComponentAtNode to empty a container.');
+          }
+        }
+      }
+
+      var isRootRenderedBySomeReact = !!container._reactRootContainer;
+      var rootEl = getReactRootElementInContainer(container);
+      var hasNonRootReactChild = !!(rootEl && getInstanceFromNode$1(rootEl));
+
+      if (hasNonRootReactChild && !isRootRenderedBySomeReact) {
+        error('render(...): Replacing React-rendered children with a new root ' + 'component. If you intended to update the children of this node, ' + 'you should instead have the existing children update their state ' + 'and render the new components instead of calling ReactDOM.render.');
+      }
+
+      if (container.nodeType === ELEMENT_NODE && container.tagName && container.tagName.toUpperCase() === 'BODY') {
+        error('render(): Rendering components directly into document.body is ' + 'discouraged, since its children are often manipulated by third-party ' + 'scripts and browser extensions. This may lead to subtle ' + 'reconciliation issues. Try rendering into a container element created ' + 'for your app.');
+      }
+    };
+  }
+
+  function getReactRootElementInContainer(container) {
+    if (!container) {
+      return null;
+    }
+
+    if (container.nodeType === DOCUMENT_NODE) {
+      return container.documentElement;
+    } else {
+      return container.firstChild;
+    }
+  }
+
+  function shouldHydrateDueToLegacyHeuristic(container) {
+    var rootElement = getReactRootElementInContainer(container);
+    return !!(rootElement && rootElement.nodeType === ELEMENT_NODE && rootElement.hasAttribute(ROOT_ATTRIBUTE_NAME));
+  }
+
+  function legacyCreateRootFromDOMContainer(container, forceHydrate) {
+    var shouldHydrate = forceHydrate || shouldHydrateDueToLegacyHeuristic(container); // First clear any existing content.
+
+    if (!shouldHydrate) {
+      var warned = false;
+      var rootSibling;
+
+      while (rootSibling = container.lastChild) {
+        {
+          if (!warned && rootSibling.nodeType === ELEMENT_NODE && rootSibling.hasAttribute(ROOT_ATTRIBUTE_NAME)) {
+            warned = true;
+
+            error('render(): Target node has markup rendered by React, but there ' + 'are unrelated nodes as well. This is most commonly caused by ' + 'white-space inserted around server-rendered markup.');
+          }
+        }
+
+        container.removeChild(rootSibling);
+      }
+    }
+
+    {
+      if (shouldHydrate && !forceHydrate && !warnedAboutHydrateAPI) {
+        warnedAboutHydrateAPI = true;
+
+        warn('render(): Calling ReactDOM.render() to hydrate server-rendered markup ' + 'will stop working in React v17. Replace the ReactDOM.render() call ' + 'with ReactDOM.hydrate() if you want React to attach to the server HTML.');
+      }
+    }
+
+    return createLegacyRoot(container, shouldHydrate ? {
+      hydrate: true
+    } : undefined);
+  }
+
+  function warnOnInvalidCallback$1(callback, callerName) {
+    {
+      if (callback !== null && typeof callback !== 'function') {
+        error('%s(...): Expected the last optional `callback` argument to be a ' + 'function. Instead received: %s.', callerName, callback);
+      }
+    }
+  }
+
+  function legacyRenderSubtreeIntoContainer(parentComponent, children, container, forceHydrate, callback) {
+    {
+      topLevelUpdateWarnings(container);
+      warnOnInvalidCallback$1(callback === undefined ? null : callback, 'render');
+    } // TODO: Without `any` type, Flow says "Property cannot be accessed on any
+    // member of intersection type." Whyyyyyy.
+
+
+    var root = container._reactRootContainer;
+    var fiberRoot;
+
+    if (!root) {
+      // Initial mount
+      root = container._reactRootContainer = legacyCreateRootFromDOMContainer(container, forceHydrate);
+      fiberRoot = root._internalRoot;
+
+      if (typeof callback === 'function') {
+        var originalCallback = callback;
+
+        callback = function () {
+          var instance = getPublicRootInstance(fiberRoot);
+          originalCallback.call(instance);
+        };
+      } // Initial mount should not be batched.
+
+
+      unbatchedUpdates(function () {
+        updateContainer(children, fiberRoot, parentComponent, callback);
+      });
+    } else {
+      fiberRoot = root._internalRoot;
+
+      if (typeof callback === 'function') {
+        var _originalCallback = callback;
+
+        callback = function () {
+          var instance = getPublicRootInstance(fiberRoot);
+
+          _originalCallback.call(instance);
+        };
+      } // Update
+
+
+      updateContainer(children, fiberRoot, parentComponent, callback);
+    }
+
+    return getPublicRootInstance(fiberRoot);
+  }
+
+  function findDOMNode(componentOrElement) {
+    {
+      var owner = ReactCurrentOwner$3.current;
+
+      if (owner !== null && owner.stateNode !== null) {
+        var warnedAboutRefsInRender = owner.stateNode._warnedAboutRefsInRender;
+
+        if (!warnedAboutRefsInRender) {
+          error('%s is accessing findDOMNode inside its render(). ' + 'render() should be a pure function of props and state. It should ' + 'never access something that requires stale data from the previous ' + 'render, such as refs. Move this logic to componentDidMount and ' + 'componentDidUpdate instead.', getComponentName(owner.type) || 'A component');
+        }
+
+        owner.stateNode._warnedAboutRefsInRender = true;
+      }
+    }
+
+    if (componentOrElement == null) {
+      return null;
+    }
+
+    if (componentOrElement.nodeType === ELEMENT_NODE) {
+      return componentOrElement;
+    }
+
+    {
+      return findHostInstanceWithWarning(componentOrElement, 'findDOMNode');
+    }
+  }
+  function hydrate(element, container, callback) {
+    if (!isValidContainer(container)) {
+      {
+        throw Error( "Target container is not a DOM element." );
+      }
+    }
+
+    {
+      var isModernRoot = isContainerMarkedAsRoot(container) && container._reactRootContainer === undefined;
+
+      if (isModernRoot) {
+        error('You are calling ReactDOM.hydrate() on a container that was previously ' + 'passed to ReactDOM.createRoot(). This is not supported. ' + 'Did you mean to call createRoot(container, {hydrate: true}).render(element)?');
+      }
+    } // TODO: throw or warn if we couldn't hydrate?
+
+
+    return legacyRenderSubtreeIntoContainer(null, element, container, true, callback);
+  }
+  function render(element, container, callback) {
+    if (!isValidContainer(container)) {
+      {
+        throw Error( "Target container is not a DOM element." );
+      }
+    }
+
+    {
+      var isModernRoot = isContainerMarkedAsRoot(container) && container._reactRootContainer === undefined;
+
+      if (isModernRoot) {
+        error('You are calling ReactDOM.render() on a container that was previously ' + 'passed to ReactDOM.createRoot(). This is not supported. ' + 'Did you mean to call root.render(element)?');
+      }
+    }
+
+    return legacyRenderSubtreeIntoContainer(null, element, container, false, callback);
+  }
+  function unstable_renderSubtreeIntoContainer(parentComponent, element, containerNode, callback) {
+    if (!isValidContainer(containerNode)) {
+      {
+        throw Error( "Target container is not a DOM element." );
+      }
+    }
+
+    if (!(parentComponent != null && has$1(parentComponent))) {
+      {
+        throw Error( "parentComponent must be a valid React Component" );
+      }
+    }
+
+    return legacyRenderSubtreeIntoContainer(parentComponent, element, containerNode, false, callback);
+  }
+  function unmountComponentAtNode(container) {
+    if (!isValidContainer(container)) {
+      {
+        throw Error( "unmountComponentAtNode(...): Target container is not a DOM element." );
+      }
+    }
+
+    {
+      var isModernRoot = isContainerMarkedAsRoot(container) && container._reactRootContainer === undefined;
+
+      if (isModernRoot) {
+        error('You are calling ReactDOM.unmountComponentAtNode() on a container that was previously ' + 'passed to ReactDOM.createRoot(). This is not supported. Did you mean to call root.unmount()?');
+      }
+    }
+
+    if (container._reactRootContainer) {
+      {
+        var rootEl = getReactRootElementInContainer(container);
+        var renderedByDifferentReact = rootEl && !getInstanceFromNode$1(rootEl);
+
+        if (renderedByDifferentReact) {
+          error("unmountComponentAtNode(): The node you're attempting to unmount " + 'was rendered by another copy of React.');
+        }
+      } // Unmount should not be batched.
+
+
+      unbatchedUpdates(function () {
+        legacyRenderSubtreeIntoContainer(null, null, container, false, function () {
+          // $FlowFixMe This should probably use `delete container._reactRootContainer`
+          container._reactRootContainer = null;
+          unmarkContainerAsRoot(container);
+        });
+      }); // If you call unmountComponentAtNode twice in quick succession, you'll
+      // get `true` twice. That's probably fine?
+
+      return true;
+    } else {
+      {
+        var _rootEl = getReactRootElementInContainer(container);
+
+        var hasNonRootReactChild = !!(_rootEl && getInstanceFromNode$1(_rootEl)); // Check if the container itself is a React root node.
+
+        var isContainerReactRoot = container.nodeType === ELEMENT_NODE && isValidContainer(container.parentNode) && !!container.parentNode._reactRootContainer;
+
+        if (hasNonRootReactChild) {
+          error("unmountComponentAtNode(): The node you're attempting to unmount " + 'was rendered by React and is not a top-level container. %s', isContainerReactRoot ? 'You may have accidentally passed in a React root node instead ' + 'of its container.' : 'Instead, have the parent component update its state and ' + 'rerender in order to remove this component.');
+        }
+      }
+
+      return false;
+    }
+  }
+
+  function createPortal(children, containerInfo, // TODO: figure out the API for cross-renderer implementation.
+  implementation) {
+    var key = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : null;
+    return {
+      // This tag allow us to uniquely identify this as a React Portal
+      $$typeof: REACT_PORTAL_TYPE,
+      key: key == null ? null : '' + key,
+      children: children,
+      containerInfo: containerInfo,
+      implementation: implementation
+    };
+  }
+
+  var ReactVersion = '16.14.0';
+
+  setAttemptUserBlockingHydration(attemptUserBlockingHydration$1);
+  setAttemptContinuousHydration(attemptContinuousHydration$1);
+  setAttemptHydrationAtCurrentPriority(attemptHydrationAtCurrentPriority$1);
+  var didWarnAboutUnstableCreatePortal = false;
+
+  {
+    if (typeof Map !== 'function' || // $FlowIssue Flow incorrectly thinks Map has no prototype
+    Map.prototype == null || typeof Map.prototype.forEach !== 'function' || typeof Set !== 'function' || // $FlowIssue Flow incorrectly thinks Set has no prototype
+    Set.prototype == null || typeof Set.prototype.clear !== 'function' || typeof Set.prototype.forEach !== 'function') {
+      error('React depends on Map and Set built-in types. Make sure that you load a ' + 'polyfill in older browsers. https://fb.me/react-polyfills');
+    }
+  }
+
+  setRestoreImplementation(restoreControlledState$3);
+  setBatchingImplementation(batchedUpdates$1, discreteUpdates$1, flushDiscreteUpdates, batchedEventUpdates$1);
+
+  function createPortal$1(children, container) {
+    var key = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
+
+    if (!isValidContainer(container)) {
+      {
+        throw Error( "Target container is not a DOM element." );
+      }
+    } // TODO: pass ReactDOM portal implementation as third argument
+    // $FlowFixMe The Flow type is opaque but there's no way to actually create it.
+
+
+    return createPortal(children, container, null, key);
+  }
+
+  function renderSubtreeIntoContainer(parentComponent, element, containerNode, callback) {
+
+    return unstable_renderSubtreeIntoContainer(parentComponent, element, containerNode, callback);
+  }
+
+  function unstable_createPortal(children, container) {
+    var key = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
+
+    {
+      if (!didWarnAboutUnstableCreatePortal) {
+        didWarnAboutUnstableCreatePortal = true;
+
+        warn('The ReactDOM.unstable_createPortal() alias has been deprecated, ' + 'and will be removed in React 17+. Update your code to use ' + 'ReactDOM.createPortal() instead. It has the exact same API, ' + 'but without the "unstable_" prefix.');
+      }
+    }
+
+    return createPortal$1(children, container, key);
+  }
+
+  var Internals = {
+    // Keep in sync with ReactDOMUnstableNativeDependencies.js
+    // ReactTestUtils.js, and ReactTestUtilsAct.js. This is an array for better minification.
+    Events: [getInstanceFromNode$1, getNodeFromInstance$1, getFiberCurrentPropsFromNode$1, injectEventPluginsByName, eventNameDispatchConfigs, accumulateTwoPhaseDispatches, accumulateDirectDispatches, enqueueStateRestore, restoreStateIfNeeded, dispatchEvent, runEventsInBatch, flushPassiveEffects, IsThisRendererActing]
+  };
+  var foundDevTools = injectIntoDevTools({
+    findFiberByHostInstance: getClosestInstanceFromNode,
+    bundleType:  1 ,
+    version: ReactVersion,
+    rendererPackageName: 'react-dom'
+  });
+
+  {
+    if (!foundDevTools && canUseDOM && window.top === window.self) {
+      // If we're in Chrome or Firefox, provide a download link if not installed.
+      if (navigator.userAgent.indexOf('Chrome') > -1 && navigator.userAgent.indexOf('Edge') === -1 || navigator.userAgent.indexOf('Firefox') > -1) {
+        var protocol = window.location.protocol; // Don't warn in exotic cases like chrome-extension://.
+
+        if (/^(https?|file):$/.test(protocol)) {
+          // eslint-disable-next-line react-internal/no-production-logging
+          console.info('%cDownload the React DevTools ' + 'for a better development experience: ' + 'https://fb.me/react-devtools' + (protocol === 'file:' ? '\nYou might need to use a local HTTP server (instead of file://): ' + 'https://fb.me/react-devtools-faq' : ''), 'font-weight:bold');
+        }
+      }
+    }
+  }
+
+  exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = Internals;
+  exports.createPortal = createPortal$1;
+  exports.findDOMNode = findDOMNode;
+  exports.flushSync = flushSync;
+  exports.hydrate = hydrate;
+  exports.render = render;
+  exports.unmountComponentAtNode = unmountComponentAtNode;
+  exports.unstable_batchedUpdates = batchedUpdates$1;
+  exports.unstable_createPortal = unstable_createPortal;
+  exports.unstable_renderSubtreeIntoContainer = renderSubtreeIntoContainer;
+  exports.version = ReactVersion;
+
+})));

--- a/tests/assets/reading-list/react-dom_17.0.2.js
+++ b/tests/assets/reading-list/react-dom_17.0.2.js
@@ -1,0 +1,26292 @@
+/** @license React v17.0.2
+ * react-dom.development.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('react')) :
+  typeof define === 'function' && define.amd ? define(['exports', 'react'], factory) :
+  (global = global || self, factory(global.ReactDOM = {}, global.React));
+}(this, (function (exports, React) { 'use strict';
+
+  var ReactSharedInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+  // by calls to these methods by a Babel plugin.
+  //
+  // In PROD (or in packages without access to React internals),
+  // they are left as they are instead.
+
+  function warn(format) {
+    {
+      for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      printWarning('warn', format, args);
+    }
+  }
+  function error(format) {
+    {
+      for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+        args[_key2 - 1] = arguments[_key2];
+      }
+
+      printWarning('error', format, args);
+    }
+  }
+
+  function printWarning(level, format, args) {
+    // When changing this logic, you might want to also
+    // update consoleWithStackDev.www.js as well.
+    {
+      var ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+      var stack = ReactDebugCurrentFrame.getStackAddendum();
+
+      if (stack !== '') {
+        format += '%s';
+        args = args.concat([stack]);
+      }
+
+      var argsWithFormat = args.map(function (item) {
+        return '' + item;
+      }); // Careful: RN currently depends on this prefix
+
+      argsWithFormat.unshift('Warning: ' + format); // We intentionally don't use spread (or .apply) directly because it
+      // breaks IE9: https://github.com/facebook/react/issues/13610
+      // eslint-disable-next-line react-internal/no-production-logging
+
+      Function.prototype.apply.call(console[level], console, argsWithFormat);
+    }
+  }
+
+  if (!React) {
+    {
+      throw Error( "ReactDOM was loaded before React. Make sure you load the React package before loading ReactDOM." );
+    }
+  }
+
+  var FunctionComponent = 0;
+  var ClassComponent = 1;
+  var IndeterminateComponent = 2; // Before we know whether it is function or class
+
+  var HostRoot = 3; // Root of a host tree. Could be nested inside another node.
+
+  var HostPortal = 4; // A subtree. Could be an entry point to a different renderer.
+
+  var HostComponent = 5;
+  var HostText = 6;
+  var Fragment = 7;
+  var Mode = 8;
+  var ContextConsumer = 9;
+  var ContextProvider = 10;
+  var ForwardRef = 11;
+  var Profiler = 12;
+  var SuspenseComponent = 13;
+  var MemoComponent = 14;
+  var SimpleMemoComponent = 15;
+  var LazyComponent = 16;
+  var IncompleteClassComponent = 17;
+  var DehydratedFragment = 18;
+  var SuspenseListComponent = 19;
+  var FundamentalComponent = 20;
+  var ScopeComponent = 21;
+  var Block = 22;
+  var OffscreenComponent = 23;
+  var LegacyHiddenComponent = 24;
+
+  // Filter certain DOM attributes (e.g. src, href) if their values are empty strings.
+
+  var enableProfilerTimer = true; // Record durations for commit and passive effects phases.
+
+  var enableFundamentalAPI = false; // Experimental Scope support.
+  var enableNewReconciler = false; // Errors that are thrown while unmounting (or after in the case of passive effects)
+  var warnAboutStringRefs = false;
+
+  var allNativeEvents = new Set();
+  /**
+   * Mapping from registration name to event name
+   */
+
+
+  var registrationNameDependencies = {};
+  /**
+   * Mapping from lowercase registration names to the properly cased version,
+   * used to warn in the case of missing event handlers. Available
+   * only in true.
+   * @type {Object}
+   */
+
+  var possibleRegistrationNames =  {} ; // Trust the developer to only use possibleRegistrationNames in true
+
+  function registerTwoPhaseEvent(registrationName, dependencies) {
+    registerDirectEvent(registrationName, dependencies);
+    registerDirectEvent(registrationName + 'Capture', dependencies);
+  }
+  function registerDirectEvent(registrationName, dependencies) {
+    {
+      if (registrationNameDependencies[registrationName]) {
+        error('EventRegistry: More than one plugin attempted to publish the same ' + 'registration name, `%s`.', registrationName);
+      }
+    }
+
+    registrationNameDependencies[registrationName] = dependencies;
+
+    {
+      var lowerCasedName = registrationName.toLowerCase();
+      possibleRegistrationNames[lowerCasedName] = registrationName;
+
+      if (registrationName === 'onDoubleClick') {
+        possibleRegistrationNames.ondblclick = registrationName;
+      }
+    }
+
+    for (var i = 0; i < dependencies.length; i++) {
+      allNativeEvents.add(dependencies[i]);
+    }
+  }
+
+  var canUseDOM = !!(typeof window !== 'undefined' && typeof window.document !== 'undefined' && typeof window.document.createElement !== 'undefined');
+
+  // A reserved attribute.
+  // It is handled by React separately and shouldn't be written to the DOM.
+  var RESERVED = 0; // A simple string attribute.
+  // Attributes that aren't in the filter are presumed to have this type.
+
+  var STRING = 1; // A string attribute that accepts booleans in React. In HTML, these are called
+  // "enumerated" attributes with "true" and "false" as possible values.
+  // When true, it should be set to a "true" string.
+  // When false, it should be set to a "false" string.
+
+  var BOOLEANISH_STRING = 2; // A real boolean attribute.
+  // When true, it should be present (set either to an empty string or its name).
+  // When false, it should be omitted.
+
+  var BOOLEAN = 3; // An attribute that can be used as a flag as well as with a value.
+  // When true, it should be present (set either to an empty string or its name).
+  // When false, it should be omitted.
+  // For any other value, should be present with that value.
+
+  var OVERLOADED_BOOLEAN = 4; // An attribute that must be numeric or parse as a numeric.
+  // When falsy, it should be removed.
+
+  var NUMERIC = 5; // An attribute that must be positive numeric or parse as a positive numeric.
+  // When falsy, it should be removed.
+
+  var POSITIVE_NUMERIC = 6;
+
+  /* eslint-disable max-len */
+  var ATTRIBUTE_NAME_START_CHAR = ":A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
+  /* eslint-enable max-len */
+
+  var ATTRIBUTE_NAME_CHAR = ATTRIBUTE_NAME_START_CHAR + "\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
+  var ROOT_ATTRIBUTE_NAME = 'data-reactroot';
+  var VALID_ATTRIBUTE_NAME_REGEX = new RegExp('^[' + ATTRIBUTE_NAME_START_CHAR + '][' + ATTRIBUTE_NAME_CHAR + ']*$');
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
+  var illegalAttributeNameCache = {};
+  var validatedAttributeNameCache = {};
+  function isAttributeNameSafe(attributeName) {
+    if (hasOwnProperty.call(validatedAttributeNameCache, attributeName)) {
+      return true;
+    }
+
+    if (hasOwnProperty.call(illegalAttributeNameCache, attributeName)) {
+      return false;
+    }
+
+    if (VALID_ATTRIBUTE_NAME_REGEX.test(attributeName)) {
+      validatedAttributeNameCache[attributeName] = true;
+      return true;
+    }
+
+    illegalAttributeNameCache[attributeName] = true;
+
+    {
+      error('Invalid attribute name: `%s`', attributeName);
+    }
+
+    return false;
+  }
+  function shouldIgnoreAttribute(name, propertyInfo, isCustomComponentTag) {
+    if (propertyInfo !== null) {
+      return propertyInfo.type === RESERVED;
+    }
+
+    if (isCustomComponentTag) {
+      return false;
+    }
+
+    if (name.length > 2 && (name[0] === 'o' || name[0] === 'O') && (name[1] === 'n' || name[1] === 'N')) {
+      return true;
+    }
+
+    return false;
+  }
+  function shouldRemoveAttributeWithWarning(name, value, propertyInfo, isCustomComponentTag) {
+    if (propertyInfo !== null && propertyInfo.type === RESERVED) {
+      return false;
+    }
+
+    switch (typeof value) {
+      case 'function': // $FlowIssue symbol is perfectly valid here
+
+      case 'symbol':
+        // eslint-disable-line
+        return true;
+
+      case 'boolean':
+        {
+          if (isCustomComponentTag) {
+            return false;
+          }
+
+          if (propertyInfo !== null) {
+            return !propertyInfo.acceptsBooleans;
+          } else {
+            var prefix = name.toLowerCase().slice(0, 5);
+            return prefix !== 'data-' && prefix !== 'aria-';
+          }
+        }
+
+      default:
+        return false;
+    }
+  }
+  function shouldRemoveAttribute(name, value, propertyInfo, isCustomComponentTag) {
+    if (value === null || typeof value === 'undefined') {
+      return true;
+    }
+
+    if (shouldRemoveAttributeWithWarning(name, value, propertyInfo, isCustomComponentTag)) {
+      return true;
+    }
+
+    if (isCustomComponentTag) {
+      return false;
+    }
+
+    if (propertyInfo !== null) {
+
+      switch (propertyInfo.type) {
+        case BOOLEAN:
+          return !value;
+
+        case OVERLOADED_BOOLEAN:
+          return value === false;
+
+        case NUMERIC:
+          return isNaN(value);
+
+        case POSITIVE_NUMERIC:
+          return isNaN(value) || value < 1;
+      }
+    }
+
+    return false;
+  }
+  function getPropertyInfo(name) {
+    return properties.hasOwnProperty(name) ? properties[name] : null;
+  }
+
+  function PropertyInfoRecord(name, type, mustUseProperty, attributeName, attributeNamespace, sanitizeURL, removeEmptyString) {
+    this.acceptsBooleans = type === BOOLEANISH_STRING || type === BOOLEAN || type === OVERLOADED_BOOLEAN;
+    this.attributeName = attributeName;
+    this.attributeNamespace = attributeNamespace;
+    this.mustUseProperty = mustUseProperty;
+    this.propertyName = name;
+    this.type = type;
+    this.sanitizeURL = sanitizeURL;
+    this.removeEmptyString = removeEmptyString;
+  } // When adding attributes to this list, be sure to also add them to
+  // the `possibleStandardNames` module to ensure casing and incorrect
+  // name warnings.
+
+
+  var properties = {}; // These props are reserved by React. They shouldn't be written to the DOM.
+
+  var reservedProps = ['children', 'dangerouslySetInnerHTML', // TODO: This prevents the assignment of defaultValue to regular
+  // elements (not just inputs). Now that ReactDOMInput assigns to the
+  // defaultValue property -- do we need this?
+  'defaultValue', 'defaultChecked', 'innerHTML', 'suppressContentEditableWarning', 'suppressHydrationWarning', 'style'];
+  reservedProps.forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, RESERVED, false, // mustUseProperty
+    name, // attributeName
+    null, // attributeNamespace
+    false, // sanitizeURL
+    false);
+  }); // A few React string attributes have a different name.
+  // This is a mapping from React prop names to the attribute names.
+
+  [['acceptCharset', 'accept-charset'], ['className', 'class'], ['htmlFor', 'for'], ['httpEquiv', 'http-equiv']].forEach(function (_ref) {
+    var name = _ref[0],
+        attributeName = _ref[1];
+    properties[name] = new PropertyInfoRecord(name, STRING, false, // mustUseProperty
+    attributeName, // attributeName
+    null, // attributeNamespace
+    false, // sanitizeURL
+    false);
+  }); // These are "enumerated" HTML attributes that accept "true" and "false".
+  // In React, we let users pass `true` and `false` even though technically
+  // these aren't boolean attributes (they are coerced to strings).
+
+  ['contentEditable', 'draggable', 'spellCheck', 'value'].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, BOOLEANISH_STRING, false, // mustUseProperty
+    name.toLowerCase(), // attributeName
+    null, // attributeNamespace
+    false, // sanitizeURL
+    false);
+  }); // These are "enumerated" SVG attributes that accept "true" and "false".
+  // In React, we let users pass `true` and `false` even though technically
+  // these aren't boolean attributes (they are coerced to strings).
+  // Since these are SVG attributes, their attribute names are case-sensitive.
+
+  ['autoReverse', 'externalResourcesRequired', 'focusable', 'preserveAlpha'].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, BOOLEANISH_STRING, false, // mustUseProperty
+    name, // attributeName
+    null, // attributeNamespace
+    false, // sanitizeURL
+    false);
+  }); // These are HTML boolean attributes.
+
+  ['allowFullScreen', 'async', // Note: there is a special case that prevents it from being written to the DOM
+  // on the client side because the browsers are inconsistent. Instead we call focus().
+  'autoFocus', 'autoPlay', 'controls', 'default', 'defer', 'disabled', 'disablePictureInPicture', 'disableRemotePlayback', 'formNoValidate', 'hidden', 'loop', 'noModule', 'noValidate', 'open', 'playsInline', 'readOnly', 'required', 'reversed', 'scoped', 'seamless', // Microdata
+  'itemScope'].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, BOOLEAN, false, // mustUseProperty
+    name.toLowerCase(), // attributeName
+    null, // attributeNamespace
+    false, // sanitizeURL
+    false);
+  }); // These are the few React props that we set as DOM properties
+  // rather than attributes. These are all booleans.
+
+  ['checked', // Note: `option.selected` is not updated if `select.multiple` is
+  // disabled with `removeAttribute`. We have special logic for handling this.
+  'multiple', 'muted', 'selected' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, BOOLEAN, true, // mustUseProperty
+    name, // attributeName
+    null, // attributeNamespace
+    false, // sanitizeURL
+    false);
+  }); // These are HTML attributes that are "overloaded booleans": they behave like
+  // booleans, but can also accept a string value.
+
+  ['capture', 'download' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, OVERLOADED_BOOLEAN, false, // mustUseProperty
+    name, // attributeName
+    null, // attributeNamespace
+    false, // sanitizeURL
+    false);
+  }); // These are HTML attributes that must be positive numbers.
+
+  ['cols', 'rows', 'size', 'span' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, POSITIVE_NUMERIC, false, // mustUseProperty
+    name, // attributeName
+    null, // attributeNamespace
+    false, // sanitizeURL
+    false);
+  }); // These are HTML attributes that must be numbers.
+
+  ['rowSpan', 'start'].forEach(function (name) {
+    properties[name] = new PropertyInfoRecord(name, NUMERIC, false, // mustUseProperty
+    name.toLowerCase(), // attributeName
+    null, // attributeNamespace
+    false, // sanitizeURL
+    false);
+  });
+  var CAMELIZE = /[\-\:]([a-z])/g;
+
+  var capitalize = function (token) {
+    return token[1].toUpperCase();
+  }; // This is a list of all SVG attributes that need special casing, namespacing,
+  // or boolean value assignment. Regular attributes that just accept strings
+  // and have the same names are omitted, just like in the HTML attribute filter.
+  // Some of these attributes can be hard to find. This list was created by
+  // scraping the MDN documentation.
+
+
+  ['accent-height', 'alignment-baseline', 'arabic-form', 'baseline-shift', 'cap-height', 'clip-path', 'clip-rule', 'color-interpolation', 'color-interpolation-filters', 'color-profile', 'color-rendering', 'dominant-baseline', 'enable-background', 'fill-opacity', 'fill-rule', 'flood-color', 'flood-opacity', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', 'font-weight', 'glyph-name', 'glyph-orientation-horizontal', 'glyph-orientation-vertical', 'horiz-adv-x', 'horiz-origin-x', 'image-rendering', 'letter-spacing', 'lighting-color', 'marker-end', 'marker-mid', 'marker-start', 'overline-position', 'overline-thickness', 'paint-order', 'panose-1', 'pointer-events', 'rendering-intent', 'shape-rendering', 'stop-color', 'stop-opacity', 'strikethrough-position', 'strikethrough-thickness', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'text-anchor', 'text-decoration', 'text-rendering', 'underline-position', 'underline-thickness', 'unicode-bidi', 'unicode-range', 'units-per-em', 'v-alphabetic', 'v-hanging', 'v-ideographic', 'v-mathematical', 'vector-effect', 'vert-adv-y', 'vert-origin-x', 'vert-origin-y', 'word-spacing', 'writing-mode', 'xmlns:xlink', 'x-height' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (attributeName) {
+    var name = attributeName.replace(CAMELIZE, capitalize);
+    properties[name] = new PropertyInfoRecord(name, STRING, false, // mustUseProperty
+    attributeName, null, // attributeNamespace
+    false, // sanitizeURL
+    false);
+  }); // String SVG attributes with the xlink namespace.
+
+  ['xlink:actuate', 'xlink:arcrole', 'xlink:role', 'xlink:show', 'xlink:title', 'xlink:type' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (attributeName) {
+    var name = attributeName.replace(CAMELIZE, capitalize);
+    properties[name] = new PropertyInfoRecord(name, STRING, false, // mustUseProperty
+    attributeName, 'http://www.w3.org/1999/xlink', false, // sanitizeURL
+    false);
+  }); // String SVG attributes with the xml namespace.
+
+  ['xml:base', 'xml:lang', 'xml:space' // NOTE: if you add a camelCased prop to this list,
+  // you'll need to set attributeName to name.toLowerCase()
+  // instead in the assignment below.
+  ].forEach(function (attributeName) {
+    var name = attributeName.replace(CAMELIZE, capitalize);
+    properties[name] = new PropertyInfoRecord(name, STRING, false, // mustUseProperty
+    attributeName, 'http://www.w3.org/XML/1998/namespace', false, // sanitizeURL
+    false);
+  }); // These attribute exists both in HTML and SVG.
+  // The attribute name is case-sensitive in SVG so we can't just use
+  // the React name like we do for attributes that exist only in HTML.
+
+  ['tabIndex', 'crossOrigin'].forEach(function (attributeName) {
+    properties[attributeName] = new PropertyInfoRecord(attributeName, STRING, false, // mustUseProperty
+    attributeName.toLowerCase(), // attributeName
+    null, // attributeNamespace
+    false, // sanitizeURL
+    false);
+  }); // These attributes accept URLs. These must not allow javascript: URLS.
+  // These will also need to accept Trusted Types object in the future.
+
+  var xlinkHref = 'xlinkHref';
+  properties[xlinkHref] = new PropertyInfoRecord('xlinkHref', STRING, false, // mustUseProperty
+  'xlink:href', 'http://www.w3.org/1999/xlink', true, // sanitizeURL
+  false);
+  ['src', 'href', 'action', 'formAction'].forEach(function (attributeName) {
+    properties[attributeName] = new PropertyInfoRecord(attributeName, STRING, false, // mustUseProperty
+    attributeName.toLowerCase(), // attributeName
+    null, // attributeNamespace
+    true, // sanitizeURL
+    true);
+  });
+
+  // and any newline or tab are filtered out as if they're not part of the URL.
+  // https://url.spec.whatwg.org/#url-parsing
+  // Tab or newline are defined as \r\n\t:
+  // https://infra.spec.whatwg.org/#ascii-tab-or-newline
+  // A C0 control is a code point in the range \u0000 NULL to \u001F
+  // INFORMATION SEPARATOR ONE, inclusive:
+  // https://infra.spec.whatwg.org/#c0-control-or-space
+
+  /* eslint-disable max-len */
+
+  var isJavaScriptProtocol = /^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*\:/i;
+  var didWarn = false;
+
+  function sanitizeURL(url) {
+    {
+      if (!didWarn && isJavaScriptProtocol.test(url)) {
+        didWarn = true;
+
+        error('A future version of React will block javascript: URLs as a security precaution. ' + 'Use event handlers instead if you can. If you need to generate unsafe HTML try ' + 'using dangerouslySetInnerHTML instead. React was passed %s.', JSON.stringify(url));
+      }
+    }
+  }
+
+  /**
+   * Get the value for a property on a node. Only used in DEV for SSR validation.
+   * The "expected" argument is used as a hint of what the expected value is.
+   * Some properties have multiple equivalent values.
+   */
+  function getValueForProperty(node, name, expected, propertyInfo) {
+    {
+      if (propertyInfo.mustUseProperty) {
+        var propertyName = propertyInfo.propertyName;
+        return node[propertyName];
+      } else {
+        if ( propertyInfo.sanitizeURL) {
+          // If we haven't fully disabled javascript: URLs, and if
+          // the hydration is successful of a javascript: URL, we
+          // still want to warn on the client.
+          sanitizeURL('' + expected);
+        }
+
+        var attributeName = propertyInfo.attributeName;
+        var stringValue = null;
+
+        if (propertyInfo.type === OVERLOADED_BOOLEAN) {
+          if (node.hasAttribute(attributeName)) {
+            var value = node.getAttribute(attributeName);
+
+            if (value === '') {
+              return true;
+            }
+
+            if (shouldRemoveAttribute(name, expected, propertyInfo, false)) {
+              return value;
+            }
+
+            if (value === '' + expected) {
+              return expected;
+            }
+
+            return value;
+          }
+        } else if (node.hasAttribute(attributeName)) {
+          if (shouldRemoveAttribute(name, expected, propertyInfo, false)) {
+            // We had an attribute but shouldn't have had one, so read it
+            // for the error message.
+            return node.getAttribute(attributeName);
+          }
+
+          if (propertyInfo.type === BOOLEAN) {
+            // If this was a boolean, it doesn't matter what the value is
+            // the fact that we have it is the same as the expected.
+            return expected;
+          } // Even if this property uses a namespace we use getAttribute
+          // because we assume its namespaced name is the same as our config.
+          // To use getAttributeNS we need the local name which we don't have
+          // in our config atm.
+
+
+          stringValue = node.getAttribute(attributeName);
+        }
+
+        if (shouldRemoveAttribute(name, expected, propertyInfo, false)) {
+          return stringValue === null ? expected : stringValue;
+        } else if (stringValue === '' + expected) {
+          return expected;
+        } else {
+          return stringValue;
+        }
+      }
+    }
+  }
+  /**
+   * Get the value for a attribute on a node. Only used in DEV for SSR validation.
+   * The third argument is used as a hint of what the expected value is. Some
+   * attributes have multiple equivalent values.
+   */
+
+  function getValueForAttribute(node, name, expected) {
+    {
+      if (!isAttributeNameSafe(name)) {
+        return;
+      } // If the object is an opaque reference ID, it's expected that
+      // the next prop is different than the server value, so just return
+      // expected
+
+
+      if (isOpaqueHydratingObject(expected)) {
+        return expected;
+      }
+
+      if (!node.hasAttribute(name)) {
+        return expected === undefined ? undefined : null;
+      }
+
+      var value = node.getAttribute(name);
+
+      if (value === '' + expected) {
+        return expected;
+      }
+
+      return value;
+    }
+  }
+  /**
+   * Sets the value for a property on a node.
+   *
+   * @param {DOMElement} node
+   * @param {string} name
+   * @param {*} value
+   */
+
+  function setValueForProperty(node, name, value, isCustomComponentTag) {
+    var propertyInfo = getPropertyInfo(name);
+
+    if (shouldIgnoreAttribute(name, propertyInfo, isCustomComponentTag)) {
+      return;
+    }
+
+    if (shouldRemoveAttribute(name, value, propertyInfo, isCustomComponentTag)) {
+      value = null;
+    } // If the prop isn't in the special list, treat it as a simple attribute.
+
+
+    if (isCustomComponentTag || propertyInfo === null) {
+      if (isAttributeNameSafe(name)) {
+        var _attributeName = name;
+
+        if (value === null) {
+          node.removeAttribute(_attributeName);
+        } else {
+          node.setAttribute(_attributeName,  '' + value);
+        }
+      }
+
+      return;
+    }
+
+    var mustUseProperty = propertyInfo.mustUseProperty;
+
+    if (mustUseProperty) {
+      var propertyName = propertyInfo.propertyName;
+
+      if (value === null) {
+        var type = propertyInfo.type;
+        node[propertyName] = type === BOOLEAN ? false : '';
+      } else {
+        // Contrary to `setAttribute`, object properties are properly
+        // `toString`ed by IE8/9.
+        node[propertyName] = value;
+      }
+
+      return;
+    } // The rest are treated as attributes with special cases.
+
+
+    var attributeName = propertyInfo.attributeName,
+        attributeNamespace = propertyInfo.attributeNamespace;
+
+    if (value === null) {
+      node.removeAttribute(attributeName);
+    } else {
+      var _type = propertyInfo.type;
+      var attributeValue;
+
+      if (_type === BOOLEAN || _type === OVERLOADED_BOOLEAN && value === true) {
+        // If attribute type is boolean, we know for sure it won't be an execution sink
+        // and we won't require Trusted Type here.
+        attributeValue = '';
+      } else {
+        // `setAttribute` with objects becomes only `[object]` in IE8/9,
+        // ('' + value) makes it output the correct toString()-value.
+        {
+          attributeValue = '' + value;
+        }
+
+        if (propertyInfo.sanitizeURL) {
+          sanitizeURL(attributeValue.toString());
+        }
+      }
+
+      if (attributeNamespace) {
+        node.setAttributeNS(attributeNamespace, attributeName, attributeValue);
+      } else {
+        node.setAttribute(attributeName, attributeValue);
+      }
+    }
+  }
+
+  var ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+  var _assign = ReactInternals.assign;
+
+  // ATTENTION
+  // When adding new symbols to this file,
+  // Please consider also adding to 'react-devtools-shared/src/backend/ReactSymbols'
+  // The Symbol used to tag the ReactElement-like types. If there is no native Symbol
+  // nor polyfill, then a plain number is used for performance.
+  var REACT_ELEMENT_TYPE = 0xeac7;
+  var REACT_PORTAL_TYPE = 0xeaca;
+  var REACT_FRAGMENT_TYPE = 0xeacb;
+  var REACT_STRICT_MODE_TYPE = 0xeacc;
+  var REACT_PROFILER_TYPE = 0xead2;
+  var REACT_PROVIDER_TYPE = 0xeacd;
+  var REACT_CONTEXT_TYPE = 0xeace;
+  var REACT_FORWARD_REF_TYPE = 0xead0;
+  var REACT_SUSPENSE_TYPE = 0xead1;
+  var REACT_SUSPENSE_LIST_TYPE = 0xead8;
+  var REACT_MEMO_TYPE = 0xead3;
+  var REACT_LAZY_TYPE = 0xead4;
+  var REACT_BLOCK_TYPE = 0xead9;
+  var REACT_SERVER_BLOCK_TYPE = 0xeada;
+  var REACT_FUNDAMENTAL_TYPE = 0xead5;
+  var REACT_SCOPE_TYPE = 0xead7;
+  var REACT_OPAQUE_ID_TYPE = 0xeae0;
+  var REACT_DEBUG_TRACING_MODE_TYPE = 0xeae1;
+  var REACT_OFFSCREEN_TYPE = 0xeae2;
+  var REACT_LEGACY_HIDDEN_TYPE = 0xeae3;
+
+  if (typeof Symbol === 'function' && Symbol.for) {
+    var symbolFor = Symbol.for;
+    REACT_ELEMENT_TYPE = symbolFor('react.element');
+    REACT_PORTAL_TYPE = symbolFor('react.portal');
+    REACT_FRAGMENT_TYPE = symbolFor('react.fragment');
+    REACT_STRICT_MODE_TYPE = symbolFor('react.strict_mode');
+    REACT_PROFILER_TYPE = symbolFor('react.profiler');
+    REACT_PROVIDER_TYPE = symbolFor('react.provider');
+    REACT_CONTEXT_TYPE = symbolFor('react.context');
+    REACT_FORWARD_REF_TYPE = symbolFor('react.forward_ref');
+    REACT_SUSPENSE_TYPE = symbolFor('react.suspense');
+    REACT_SUSPENSE_LIST_TYPE = symbolFor('react.suspense_list');
+    REACT_MEMO_TYPE = symbolFor('react.memo');
+    REACT_LAZY_TYPE = symbolFor('react.lazy');
+    REACT_BLOCK_TYPE = symbolFor('react.block');
+    REACT_SERVER_BLOCK_TYPE = symbolFor('react.server.block');
+    REACT_FUNDAMENTAL_TYPE = symbolFor('react.fundamental');
+    REACT_SCOPE_TYPE = symbolFor('react.scope');
+    REACT_OPAQUE_ID_TYPE = symbolFor('react.opaque.id');
+    REACT_DEBUG_TRACING_MODE_TYPE = symbolFor('react.debug_trace_mode');
+    REACT_OFFSCREEN_TYPE = symbolFor('react.offscreen');
+    REACT_LEGACY_HIDDEN_TYPE = symbolFor('react.legacy_hidden');
+  }
+
+  var MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+  var FAUX_ITERATOR_SYMBOL = '@@iterator';
+  function getIteratorFn(maybeIterable) {
+    if (maybeIterable === null || typeof maybeIterable !== 'object') {
+      return null;
+    }
+
+    var maybeIterator = MAYBE_ITERATOR_SYMBOL && maybeIterable[MAYBE_ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL];
+
+    if (typeof maybeIterator === 'function') {
+      return maybeIterator;
+    }
+
+    return null;
+  }
+
+  // Helpers to patch console.logs to avoid logging during side-effect free
+  // replaying on render function. This currently only patches the object
+  // lazily which won't cover if the log function was extracted eagerly.
+  // We could also eagerly patch the method.
+  var disabledDepth = 0;
+  var prevLog;
+  var prevInfo;
+  var prevWarn;
+  var prevError;
+  var prevGroup;
+  var prevGroupCollapsed;
+  var prevGroupEnd;
+
+  function disabledLog() {}
+
+  disabledLog.__reactDisabledLog = true;
+  function disableLogs() {
+    {
+      if (disabledDepth === 0) {
+        /* eslint-disable react-internal/no-production-logging */
+        prevLog = console.log;
+        prevInfo = console.info;
+        prevWarn = console.warn;
+        prevError = console.error;
+        prevGroup = console.group;
+        prevGroupCollapsed = console.groupCollapsed;
+        prevGroupEnd = console.groupEnd; // https://github.com/facebook/react/issues/19099
+
+        var props = {
+          configurable: true,
+          enumerable: true,
+          value: disabledLog,
+          writable: true
+        }; // $FlowFixMe Flow thinks console is immutable.
+
+        Object.defineProperties(console, {
+          info: props,
+          log: props,
+          warn: props,
+          error: props,
+          group: props,
+          groupCollapsed: props,
+          groupEnd: props
+        });
+        /* eslint-enable react-internal/no-production-logging */
+      }
+
+      disabledDepth++;
+    }
+  }
+  function reenableLogs() {
+    {
+      disabledDepth--;
+
+      if (disabledDepth === 0) {
+        /* eslint-disable react-internal/no-production-logging */
+        var props = {
+          configurable: true,
+          enumerable: true,
+          writable: true
+        }; // $FlowFixMe Flow thinks console is immutable.
+
+        Object.defineProperties(console, {
+          log: _assign({}, props, {
+            value: prevLog
+          }),
+          info: _assign({}, props, {
+            value: prevInfo
+          }),
+          warn: _assign({}, props, {
+            value: prevWarn
+          }),
+          error: _assign({}, props, {
+            value: prevError
+          }),
+          group: _assign({}, props, {
+            value: prevGroup
+          }),
+          groupCollapsed: _assign({}, props, {
+            value: prevGroupCollapsed
+          }),
+          groupEnd: _assign({}, props, {
+            value: prevGroupEnd
+          })
+        });
+        /* eslint-enable react-internal/no-production-logging */
+      }
+
+      if (disabledDepth < 0) {
+        error('disabledDepth fell below zero. ' + 'This is a bug in React. Please file an issue.');
+      }
+    }
+  }
+
+  var ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
+  var prefix;
+  function describeBuiltInComponentFrame(name, source, ownerFn) {
+    {
+      if (prefix === undefined) {
+        // Extract the VM specific prefix used by each line.
+        try {
+          throw Error();
+        } catch (x) {
+          var match = x.stack.trim().match(/\n( *(at )?)/);
+          prefix = match && match[1] || '';
+        }
+      } // We use the prefix to ensure our stacks line up with native stack frames.
+
+
+      return '\n' + prefix + name;
+    }
+  }
+  var reentry = false;
+  var componentFrameCache;
+
+  {
+    var PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
+    componentFrameCache = new PossiblyWeakMap();
+  }
+
+  function describeNativeComponentFrame(fn, construct) {
+    // If something asked for a stack inside a fake render, it should get ignored.
+    if (!fn || reentry) {
+      return '';
+    }
+
+    {
+      var frame = componentFrameCache.get(fn);
+
+      if (frame !== undefined) {
+        return frame;
+      }
+    }
+
+    var control;
+    reentry = true;
+    var previousPrepareStackTrace = Error.prepareStackTrace; // $FlowFixMe It does accept undefined.
+
+    Error.prepareStackTrace = undefined;
+    var previousDispatcher;
+
+    {
+      previousDispatcher = ReactCurrentDispatcher.current; // Set the dispatcher in DEV because this might be call in the render function
+      // for warnings.
+
+      ReactCurrentDispatcher.current = null;
+      disableLogs();
+    }
+
+    try {
+      // This should throw.
+      if (construct) {
+        // Something should be setting the props in the constructor.
+        var Fake = function () {
+          throw Error();
+        }; // $FlowFixMe
+
+
+        Object.defineProperty(Fake.prototype, 'props', {
+          set: function () {
+            // We use a throwing setter instead of frozen or non-writable props
+            // because that won't throw in a non-strict mode function.
+            throw Error();
+          }
+        });
+
+        if (typeof Reflect === 'object' && Reflect.construct) {
+          // We construct a different control for this case to include any extra
+          // frames added by the construct call.
+          try {
+            Reflect.construct(Fake, []);
+          } catch (x) {
+            control = x;
+          }
+
+          Reflect.construct(fn, [], Fake);
+        } else {
+          try {
+            Fake.call();
+          } catch (x) {
+            control = x;
+          }
+
+          fn.call(Fake.prototype);
+        }
+      } else {
+        try {
+          throw Error();
+        } catch (x) {
+          control = x;
+        }
+
+        fn();
+      }
+    } catch (sample) {
+      // This is inlined manually because closure doesn't do it for us.
+      if (sample && control && typeof sample.stack === 'string') {
+        // This extracts the first frame from the sample that isn't also in the control.
+        // Skipping one frame that we assume is the frame that calls the two.
+        var sampleLines = sample.stack.split('\n');
+        var controlLines = control.stack.split('\n');
+        var s = sampleLines.length - 1;
+        var c = controlLines.length - 1;
+
+        while (s >= 1 && c >= 0 && sampleLines[s] !== controlLines[c]) {
+          // We expect at least one stack frame to be shared.
+          // Typically this will be the root most one. However, stack frames may be
+          // cut off due to maximum stack limits. In this case, one maybe cut off
+          // earlier than the other. We assume that the sample is longer or the same
+          // and there for cut off earlier. So we should find the root most frame in
+          // the sample somewhere in the control.
+          c--;
+        }
+
+        for (; s >= 1 && c >= 0; s--, c--) {
+          // Next we find the first one that isn't the same which should be the
+          // frame that called our sample function and the control.
+          if (sampleLines[s] !== controlLines[c]) {
+            // In V8, the first line is describing the message but other VMs don't.
+            // If we're about to return the first line, and the control is also on the same
+            // line, that's a pretty good indicator that our sample threw at same line as
+            // the control. I.e. before we entered the sample frame. So we ignore this result.
+            // This can happen if you passed a class to function component, or non-function.
+            if (s !== 1 || c !== 1) {
+              do {
+                s--;
+                c--; // We may still have similar intermediate frames from the construct call.
+                // The next one that isn't the same should be our match though.
+
+                if (c < 0 || sampleLines[s] !== controlLines[c]) {
+                  // V8 adds a "new" prefix for native classes. Let's remove it to make it prettier.
+                  var _frame = '\n' + sampleLines[s].replace(' at new ', ' at ');
+
+                  {
+                    if (typeof fn === 'function') {
+                      componentFrameCache.set(fn, _frame);
+                    }
+                  } // Return the line we found.
+
+
+                  return _frame;
+                }
+              } while (s >= 1 && c >= 0);
+            }
+
+            break;
+          }
+        }
+      }
+    } finally {
+      reentry = false;
+
+      {
+        ReactCurrentDispatcher.current = previousDispatcher;
+        reenableLogs();
+      }
+
+      Error.prepareStackTrace = previousPrepareStackTrace;
+    } // Fallback to just using the name if we couldn't make it throw.
+
+
+    var name = fn ? fn.displayName || fn.name : '';
+    var syntheticFrame = name ? describeBuiltInComponentFrame(name) : '';
+
+    {
+      if (typeof fn === 'function') {
+        componentFrameCache.set(fn, syntheticFrame);
+      }
+    }
+
+    return syntheticFrame;
+  }
+
+  function describeClassComponentFrame(ctor, source, ownerFn) {
+    {
+      return describeNativeComponentFrame(ctor, true);
+    }
+  }
+  function describeFunctionComponentFrame(fn, source, ownerFn) {
+    {
+      return describeNativeComponentFrame(fn, false);
+    }
+  }
+
+  function shouldConstruct(Component) {
+    var prototype = Component.prototype;
+    return !!(prototype && prototype.isReactComponent);
+  }
+
+  function describeUnknownElementTypeFrameInDEV(type, source, ownerFn) {
+
+    if (type == null) {
+      return '';
+    }
+
+    if (typeof type === 'function') {
+      {
+        return describeNativeComponentFrame(type, shouldConstruct(type));
+      }
+    }
+
+    if (typeof type === 'string') {
+      return describeBuiltInComponentFrame(type);
+    }
+
+    switch (type) {
+      case REACT_SUSPENSE_TYPE:
+        return describeBuiltInComponentFrame('Suspense');
+
+      case REACT_SUSPENSE_LIST_TYPE:
+        return describeBuiltInComponentFrame('SuspenseList');
+    }
+
+    if (typeof type === 'object') {
+      switch (type.$$typeof) {
+        case REACT_FORWARD_REF_TYPE:
+          return describeFunctionComponentFrame(type.render);
+
+        case REACT_MEMO_TYPE:
+          // Memo may contain any component type so we recursively resolve it.
+          return describeUnknownElementTypeFrameInDEV(type.type, source, ownerFn);
+
+        case REACT_BLOCK_TYPE:
+          return describeFunctionComponentFrame(type._render);
+
+        case REACT_LAZY_TYPE:
+          {
+            var lazyComponent = type;
+            var payload = lazyComponent._payload;
+            var init = lazyComponent._init;
+
+            try {
+              // Lazy may contain any component type so we recursively resolve it.
+              return describeUnknownElementTypeFrameInDEV(init(payload), source, ownerFn);
+            } catch (x) {}
+          }
+      }
+    }
+
+    return '';
+  }
+
+  function describeFiber(fiber) {
+    var owner =  fiber._debugOwner ? fiber._debugOwner.type : null ;
+    var source =  fiber._debugSource ;
+
+    switch (fiber.tag) {
+      case HostComponent:
+        return describeBuiltInComponentFrame(fiber.type);
+
+      case LazyComponent:
+        return describeBuiltInComponentFrame('Lazy');
+
+      case SuspenseComponent:
+        return describeBuiltInComponentFrame('Suspense');
+
+      case SuspenseListComponent:
+        return describeBuiltInComponentFrame('SuspenseList');
+
+      case FunctionComponent:
+      case IndeterminateComponent:
+      case SimpleMemoComponent:
+        return describeFunctionComponentFrame(fiber.type);
+
+      case ForwardRef:
+        return describeFunctionComponentFrame(fiber.type.render);
+
+      case Block:
+        return describeFunctionComponentFrame(fiber.type._render);
+
+      case ClassComponent:
+        return describeClassComponentFrame(fiber.type);
+
+      default:
+        return '';
+    }
+  }
+
+  function getStackByFiberInDevAndProd(workInProgress) {
+    try {
+      var info = '';
+      var node = workInProgress;
+
+      do {
+        info += describeFiber(node);
+        node = node.return;
+      } while (node);
+
+      return info;
+    } catch (x) {
+      return '\nError generating stack: ' + x.message + '\n' + x.stack;
+    }
+  }
+
+  function getWrappedName(outerType, innerType, wrapperName) {
+    var functionName = innerType.displayName || innerType.name || '';
+    return outerType.displayName || (functionName !== '' ? wrapperName + "(" + functionName + ")" : wrapperName);
+  }
+
+  function getContextName(type) {
+    return type.displayName || 'Context';
+  }
+
+  function getComponentName(type) {
+    if (type == null) {
+      // Host root, text node or just invalid type.
+      return null;
+    }
+
+    {
+      if (typeof type.tag === 'number') {
+        error('Received an unexpected object in getComponentName(). ' + 'This is likely a bug in React. Please file an issue.');
+      }
+    }
+
+    if (typeof type === 'function') {
+      return type.displayName || type.name || null;
+    }
+
+    if (typeof type === 'string') {
+      return type;
+    }
+
+    switch (type) {
+      case REACT_FRAGMENT_TYPE:
+        return 'Fragment';
+
+      case REACT_PORTAL_TYPE:
+        return 'Portal';
+
+      case REACT_PROFILER_TYPE:
+        return 'Profiler';
+
+      case REACT_STRICT_MODE_TYPE:
+        return 'StrictMode';
+
+      case REACT_SUSPENSE_TYPE:
+        return 'Suspense';
+
+      case REACT_SUSPENSE_LIST_TYPE:
+        return 'SuspenseList';
+    }
+
+    if (typeof type === 'object') {
+      switch (type.$$typeof) {
+        case REACT_CONTEXT_TYPE:
+          var context = type;
+          return getContextName(context) + '.Consumer';
+
+        case REACT_PROVIDER_TYPE:
+          var provider = type;
+          return getContextName(provider._context) + '.Provider';
+
+        case REACT_FORWARD_REF_TYPE:
+          return getWrappedName(type, type.render, 'ForwardRef');
+
+        case REACT_MEMO_TYPE:
+          return getComponentName(type.type);
+
+        case REACT_BLOCK_TYPE:
+          return getComponentName(type._render);
+
+        case REACT_LAZY_TYPE:
+          {
+            var lazyComponent = type;
+            var payload = lazyComponent._payload;
+            var init = lazyComponent._init;
+
+            try {
+              return getComponentName(init(payload));
+            } catch (x) {
+              return null;
+            }
+          }
+      }
+    }
+
+    return null;
+  }
+
+  var ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+  var current = null;
+  var isRendering = false;
+  function getCurrentFiberOwnerNameInDevOrNull() {
+    {
+      if (current === null) {
+        return null;
+      }
+
+      var owner = current._debugOwner;
+
+      if (owner !== null && typeof owner !== 'undefined') {
+        return getComponentName(owner.type);
+      }
+    }
+
+    return null;
+  }
+
+  function getCurrentFiberStackInDev() {
+    {
+      if (current === null) {
+        return '';
+      } // Safe because if current fiber exists, we are reconciling,
+      // and it is guaranteed to be the work-in-progress version.
+
+
+      return getStackByFiberInDevAndProd(current);
+    }
+  }
+
+  function resetCurrentFiber() {
+    {
+      ReactDebugCurrentFrame.getCurrentStack = null;
+      current = null;
+      isRendering = false;
+    }
+  }
+  function setCurrentFiber(fiber) {
+    {
+      ReactDebugCurrentFrame.getCurrentStack = getCurrentFiberStackInDev;
+      current = fiber;
+      isRendering = false;
+    }
+  }
+  function setIsRendering(rendering) {
+    {
+      isRendering = rendering;
+    }
+  }
+  function getIsRendering() {
+    {
+      return isRendering;
+    }
+  }
+
+  // Flow does not allow string concatenation of most non-string types. To work
+  // around this limitation, we use an opaque type that can only be obtained by
+  // passing the value through getToStringValue first.
+  function toString(value) {
+    return '' + value;
+  }
+  function getToStringValue(value) {
+    switch (typeof value) {
+      case 'boolean':
+      case 'number':
+      case 'object':
+      case 'string':
+      case 'undefined':
+        return value;
+
+      default:
+        // function, symbol are assigned as empty strings
+        return '';
+    }
+  }
+
+  var hasReadOnlyValue = {
+    button: true,
+    checkbox: true,
+    image: true,
+    hidden: true,
+    radio: true,
+    reset: true,
+    submit: true
+  };
+  function checkControlledValueProps(tagName, props) {
+    {
+      if (!(hasReadOnlyValue[props.type] || props.onChange || props.onInput || props.readOnly || props.disabled || props.value == null)) {
+        error('You provided a `value` prop to a form field without an ' + '`onChange` handler. This will render a read-only field. If ' + 'the field should be mutable use `defaultValue`. Otherwise, ' + 'set either `onChange` or `readOnly`.');
+      }
+
+      if (!(props.onChange || props.readOnly || props.disabled || props.checked == null)) {
+        error('You provided a `checked` prop to a form field without an ' + '`onChange` handler. This will render a read-only field. If ' + 'the field should be mutable use `defaultChecked`. Otherwise, ' + 'set either `onChange` or `readOnly`.');
+      }
+    }
+  }
+
+  function isCheckable(elem) {
+    var type = elem.type;
+    var nodeName = elem.nodeName;
+    return nodeName && nodeName.toLowerCase() === 'input' && (type === 'checkbox' || type === 'radio');
+  }
+
+  function getTracker(node) {
+    return node._valueTracker;
+  }
+
+  function detachTracker(node) {
+    node._valueTracker = null;
+  }
+
+  function getValueFromNode(node) {
+    var value = '';
+
+    if (!node) {
+      return value;
+    }
+
+    if (isCheckable(node)) {
+      value = node.checked ? 'true' : 'false';
+    } else {
+      value = node.value;
+    }
+
+    return value;
+  }
+
+  function trackValueOnNode(node) {
+    var valueField = isCheckable(node) ? 'checked' : 'value';
+    var descriptor = Object.getOwnPropertyDescriptor(node.constructor.prototype, valueField);
+    var currentValue = '' + node[valueField]; // if someone has already defined a value or Safari, then bail
+    // and don't track value will cause over reporting of changes,
+    // but it's better then a hard failure
+    // (needed for certain tests that spyOn input values and Safari)
+
+    if (node.hasOwnProperty(valueField) || typeof descriptor === 'undefined' || typeof descriptor.get !== 'function' || typeof descriptor.set !== 'function') {
+      return;
+    }
+
+    var get = descriptor.get,
+        set = descriptor.set;
+    Object.defineProperty(node, valueField, {
+      configurable: true,
+      get: function () {
+        return get.call(this);
+      },
+      set: function (value) {
+        currentValue = '' + value;
+        set.call(this, value);
+      }
+    }); // We could've passed this the first time
+    // but it triggers a bug in IE11 and Edge 14/15.
+    // Calling defineProperty() again should be equivalent.
+    // https://github.com/facebook/react/issues/11768
+
+    Object.defineProperty(node, valueField, {
+      enumerable: descriptor.enumerable
+    });
+    var tracker = {
+      getValue: function () {
+        return currentValue;
+      },
+      setValue: function (value) {
+        currentValue = '' + value;
+      },
+      stopTracking: function () {
+        detachTracker(node);
+        delete node[valueField];
+      }
+    };
+    return tracker;
+  }
+
+  function track(node) {
+    if (getTracker(node)) {
+      return;
+    } // TODO: Once it's just Fiber we can move this to node._wrapperState
+
+
+    node._valueTracker = trackValueOnNode(node);
+  }
+  function updateValueIfChanged(node) {
+    if (!node) {
+      return false;
+    }
+
+    var tracker = getTracker(node); // if there is no tracker at this point it's unlikely
+    // that trying again will succeed
+
+    if (!tracker) {
+      return true;
+    }
+
+    var lastValue = tracker.getValue();
+    var nextValue = getValueFromNode(node);
+
+    if (nextValue !== lastValue) {
+      tracker.setValue(nextValue);
+      return true;
+    }
+
+    return false;
+  }
+
+  function getActiveElement(doc) {
+    doc = doc || (typeof document !== 'undefined' ? document : undefined);
+
+    if (typeof doc === 'undefined') {
+      return null;
+    }
+
+    try {
+      return doc.activeElement || doc.body;
+    } catch (e) {
+      return doc.body;
+    }
+  }
+
+  var didWarnValueDefaultValue = false;
+  var didWarnCheckedDefaultChecked = false;
+  var didWarnControlledToUncontrolled = false;
+  var didWarnUncontrolledToControlled = false;
+
+  function isControlled(props) {
+    var usesChecked = props.type === 'checkbox' || props.type === 'radio';
+    return usesChecked ? props.checked != null : props.value != null;
+  }
+  /**
+   * Implements an <input> host component that allows setting these optional
+   * props: `checked`, `value`, `defaultChecked`, and `defaultValue`.
+   *
+   * If `checked` or `value` are not supplied (or null/undefined), user actions
+   * that affect the checked state or value will trigger updates to the element.
+   *
+   * If they are supplied (and not null/undefined), the rendered element will not
+   * trigger updates to the element. Instead, the props must change in order for
+   * the rendered element to be updated.
+   *
+   * The rendered element will be initialized as unchecked (or `defaultChecked`)
+   * with an empty value (or `defaultValue`).
+   *
+   * See http://www.w3.org/TR/2012/WD-html5-20121025/the-input-element.html
+   */
+
+
+  function getHostProps(element, props) {
+    var node = element;
+    var checked = props.checked;
+
+    var hostProps = _assign({}, props, {
+      defaultChecked: undefined,
+      defaultValue: undefined,
+      value: undefined,
+      checked: checked != null ? checked : node._wrapperState.initialChecked
+    });
+
+    return hostProps;
+  }
+  function initWrapperState(element, props) {
+    {
+      checkControlledValueProps('input', props);
+
+      if (props.checked !== undefined && props.defaultChecked !== undefined && !didWarnCheckedDefaultChecked) {
+        error('%s contains an input of type %s with both checked and defaultChecked props. ' + 'Input elements must be either controlled or uncontrolled ' + '(specify either the checked prop, or the defaultChecked prop, but not ' + 'both). Decide between using a controlled or uncontrolled input ' + 'element and remove one of these props. More info: ' + 'https://reactjs.org/link/controlled-components', getCurrentFiberOwnerNameInDevOrNull() || 'A component', props.type);
+
+        didWarnCheckedDefaultChecked = true;
+      }
+
+      if (props.value !== undefined && props.defaultValue !== undefined && !didWarnValueDefaultValue) {
+        error('%s contains an input of type %s with both value and defaultValue props. ' + 'Input elements must be either controlled or uncontrolled ' + '(specify either the value prop, or the defaultValue prop, but not ' + 'both). Decide between using a controlled or uncontrolled input ' + 'element and remove one of these props. More info: ' + 'https://reactjs.org/link/controlled-components', getCurrentFiberOwnerNameInDevOrNull() || 'A component', props.type);
+
+        didWarnValueDefaultValue = true;
+      }
+    }
+
+    var node = element;
+    var defaultValue = props.defaultValue == null ? '' : props.defaultValue;
+    node._wrapperState = {
+      initialChecked: props.checked != null ? props.checked : props.defaultChecked,
+      initialValue: getToStringValue(props.value != null ? props.value : defaultValue),
+      controlled: isControlled(props)
+    };
+  }
+  function updateChecked(element, props) {
+    var node = element;
+    var checked = props.checked;
+
+    if (checked != null) {
+      setValueForProperty(node, 'checked', checked, false);
+    }
+  }
+  function updateWrapper(element, props) {
+    var node = element;
+
+    {
+      var controlled = isControlled(props);
+
+      if (!node._wrapperState.controlled && controlled && !didWarnUncontrolledToControlled) {
+        error('A component is changing an uncontrolled input to be controlled. ' + 'This is likely caused by the value changing from undefined to ' + 'a defined value, which should not happen. ' + 'Decide between using a controlled or uncontrolled input ' + 'element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components');
+
+        didWarnUncontrolledToControlled = true;
+      }
+
+      if (node._wrapperState.controlled && !controlled && !didWarnControlledToUncontrolled) {
+        error('A component is changing a controlled input to be uncontrolled. ' + 'This is likely caused by the value changing from a defined to ' + 'undefined, which should not happen. ' + 'Decide between using a controlled or uncontrolled input ' + 'element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components');
+
+        didWarnControlledToUncontrolled = true;
+      }
+    }
+
+    updateChecked(element, props);
+    var value = getToStringValue(props.value);
+    var type = props.type;
+
+    if (value != null) {
+      if (type === 'number') {
+        if (value === 0 && node.value === '' || // We explicitly want to coerce to number here if possible.
+        // eslint-disable-next-line
+        node.value != value) {
+          node.value = toString(value);
+        }
+      } else if (node.value !== toString(value)) {
+        node.value = toString(value);
+      }
+    } else if (type === 'submit' || type === 'reset') {
+      // Submit/reset inputs need the attribute removed completely to avoid
+      // blank-text buttons.
+      node.removeAttribute('value');
+      return;
+    }
+
+    {
+      // When syncing the value attribute, the value comes from a cascade of
+      // properties:
+      //  1. The value React property
+      //  2. The defaultValue React property
+      //  3. Otherwise there should be no change
+      if (props.hasOwnProperty('value')) {
+        setDefaultValue(node, props.type, value);
+      } else if (props.hasOwnProperty('defaultValue')) {
+        setDefaultValue(node, props.type, getToStringValue(props.defaultValue));
+      }
+    }
+
+    {
+      // When syncing the checked attribute, it only changes when it needs
+      // to be removed, such as transitioning from a checkbox into a text input
+      if (props.checked == null && props.defaultChecked != null) {
+        node.defaultChecked = !!props.defaultChecked;
+      }
+    }
+  }
+  function postMountWrapper(element, props, isHydrating) {
+    var node = element; // Do not assign value if it is already set. This prevents user text input
+    // from being lost during SSR hydration.
+
+    if (props.hasOwnProperty('value') || props.hasOwnProperty('defaultValue')) {
+      var type = props.type;
+      var isButton = type === 'submit' || type === 'reset'; // Avoid setting value attribute on submit/reset inputs as it overrides the
+      // default value provided by the browser. See: #12872
+
+      if (isButton && (props.value === undefined || props.value === null)) {
+        return;
+      }
+
+      var initialValue = toString(node._wrapperState.initialValue); // Do not assign value if it is already set. This prevents user text input
+      // from being lost during SSR hydration.
+
+      if (!isHydrating) {
+        {
+          // When syncing the value attribute, the value property should use
+          // the wrapperState._initialValue property. This uses:
+          //
+          //   1. The value React property when present
+          //   2. The defaultValue React property when present
+          //   3. An empty string
+          if (initialValue !== node.value) {
+            node.value = initialValue;
+          }
+        }
+      }
+
+      {
+        // Otherwise, the value attribute is synchronized to the property,
+        // so we assign defaultValue to the same thing as the value property
+        // assignment step above.
+        node.defaultValue = initialValue;
+      }
+    } // Normally, we'd just do `node.checked = node.checked` upon initial mount, less this bug
+    // this is needed to work around a chrome bug where setting defaultChecked
+    // will sometimes influence the value of checked (even after detachment).
+    // Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=608416
+    // We need to temporarily unset name to avoid disrupting radio button groups.
+
+
+    var name = node.name;
+
+    if (name !== '') {
+      node.name = '';
+    }
+
+    {
+      // When syncing the checked attribute, both the checked property and
+      // attribute are assigned at the same time using defaultChecked. This uses:
+      //
+      //   1. The checked React property when present
+      //   2. The defaultChecked React property when present
+      //   3. Otherwise, false
+      node.defaultChecked = !node.defaultChecked;
+      node.defaultChecked = !!node._wrapperState.initialChecked;
+    }
+
+    if (name !== '') {
+      node.name = name;
+    }
+  }
+  function restoreControlledState(element, props) {
+    var node = element;
+    updateWrapper(node, props);
+    updateNamedCousins(node, props);
+  }
+
+  function updateNamedCousins(rootNode, props) {
+    var name = props.name;
+
+    if (props.type === 'radio' && name != null) {
+      var queryRoot = rootNode;
+
+      while (queryRoot.parentNode) {
+        queryRoot = queryRoot.parentNode;
+      } // If `rootNode.form` was non-null, then we could try `form.elements`,
+      // but that sometimes behaves strangely in IE8. We could also try using
+      // `form.getElementsByName`, but that will only return direct children
+      // and won't include inputs that use the HTML5 `form=` attribute. Since
+      // the input might not even be in a form. It might not even be in the
+      // document. Let's just use the local `querySelectorAll` to ensure we don't
+      // miss anything.
+
+
+      var group = queryRoot.querySelectorAll('input[name=' + JSON.stringify('' + name) + '][type="radio"]');
+
+      for (var i = 0; i < group.length; i++) {
+        var otherNode = group[i];
+
+        if (otherNode === rootNode || otherNode.form !== rootNode.form) {
+          continue;
+        } // This will throw if radio buttons rendered by different copies of React
+        // and the same name are rendered into the same form (same as #1939).
+        // That's probably okay; we don't support it just as we don't support
+        // mixing React radio buttons with non-React ones.
+
+
+        var otherProps = getFiberCurrentPropsFromNode(otherNode);
+
+        if (!otherProps) {
+          {
+            throw Error( "ReactDOMInput: Mixing React and non-React radio inputs with the same `name` is not supported." );
+          }
+        } // We need update the tracked value on the named cousin since the value
+        // was changed but the input saw no event or value set
+
+
+        updateValueIfChanged(otherNode); // If this is a controlled radio button group, forcing the input that
+        // was previously checked to update will cause it to be come re-checked
+        // as appropriate.
+
+        updateWrapper(otherNode, otherProps);
+      }
+    }
+  } // In Chrome, assigning defaultValue to certain input types triggers input validation.
+  // For number inputs, the display value loses trailing decimal points. For email inputs,
+  // Chrome raises "The specified value <x> is not a valid email address".
+  //
+  // Here we check to see if the defaultValue has actually changed, avoiding these problems
+  // when the user is inputting text
+  //
+  // https://github.com/facebook/react/issues/7253
+
+
+  function setDefaultValue(node, type, value) {
+    if ( // Focused number inputs synchronize on blur. See ChangeEventPlugin.js
+    type !== 'number' || getActiveElement(node.ownerDocument) !== node) {
+      if (value == null) {
+        node.defaultValue = toString(node._wrapperState.initialValue);
+      } else if (node.defaultValue !== toString(value)) {
+        node.defaultValue = toString(value);
+      }
+    }
+  }
+
+  var didWarnSelectedSetOnOption = false;
+  var didWarnInvalidChild = false;
+
+  function flattenChildren(children) {
+    var content = ''; // Flatten children. We'll warn if they are invalid
+    // during validateProps() which runs for hydration too.
+    // Note that this would throw on non-element objects.
+    // Elements are stringified (which is normally irrelevant
+    // but matters for <fbt>).
+
+    React.Children.forEach(children, function (child) {
+      if (child == null) {
+        return;
+      }
+
+      content += child; // Note: we don't warn about invalid children here.
+      // Instead, this is done separately below so that
+      // it happens during the hydration code path too.
+    });
+    return content;
+  }
+  /**
+   * Implements an <option> host component that warns when `selected` is set.
+   */
+
+
+  function validateProps(element, props) {
+    {
+      // This mirrors the code path above, but runs for hydration too.
+      // Warn about invalid children here so that client and hydration are consistent.
+      // TODO: this seems like it could cause a DEV-only throw for hydration
+      // if children contains a non-element object. We should try to avoid that.
+      if (typeof props.children === 'object' && props.children !== null) {
+        React.Children.forEach(props.children, function (child) {
+          if (child == null) {
+            return;
+          }
+
+          if (typeof child === 'string' || typeof child === 'number') {
+            return;
+          }
+
+          if (typeof child.type !== 'string') {
+            return;
+          }
+
+          if (!didWarnInvalidChild) {
+            didWarnInvalidChild = true;
+
+            error('Only strings and numbers are supported as <option> children.');
+          }
+        });
+      } // TODO: Remove support for `selected` in <option>.
+
+
+      if (props.selected != null && !didWarnSelectedSetOnOption) {
+        error('Use the `defaultValue` or `value` props on <select> instead of ' + 'setting `selected` on <option>.');
+
+        didWarnSelectedSetOnOption = true;
+      }
+    }
+  }
+  function postMountWrapper$1(element, props) {
+    // value="" should make a value attribute (#6219)
+    if (props.value != null) {
+      element.setAttribute('value', toString(getToStringValue(props.value)));
+    }
+  }
+  function getHostProps$1(element, props) {
+    var hostProps = _assign({
+      children: undefined
+    }, props);
+
+    var content = flattenChildren(props.children);
+
+    if (content) {
+      hostProps.children = content;
+    }
+
+    return hostProps;
+  }
+
+  var didWarnValueDefaultValue$1;
+
+  {
+    didWarnValueDefaultValue$1 = false;
+  }
+
+  function getDeclarationErrorAddendum() {
+    var ownerName = getCurrentFiberOwnerNameInDevOrNull();
+
+    if (ownerName) {
+      return '\n\nCheck the render method of `' + ownerName + '`.';
+    }
+
+    return '';
+  }
+
+  var valuePropNames = ['value', 'defaultValue'];
+  /**
+   * Validation function for `value` and `defaultValue`.
+   */
+
+  function checkSelectPropTypes(props) {
+    {
+      checkControlledValueProps('select', props);
+
+      for (var i = 0; i < valuePropNames.length; i++) {
+        var propName = valuePropNames[i];
+
+        if (props[propName] == null) {
+          continue;
+        }
+
+        var isArray = Array.isArray(props[propName]);
+
+        if (props.multiple && !isArray) {
+          error('The `%s` prop supplied to <select> must be an array if ' + '`multiple` is true.%s', propName, getDeclarationErrorAddendum());
+        } else if (!props.multiple && isArray) {
+          error('The `%s` prop supplied to <select> must be a scalar ' + 'value if `multiple` is false.%s', propName, getDeclarationErrorAddendum());
+        }
+      }
+    }
+  }
+
+  function updateOptions(node, multiple, propValue, setDefaultSelected) {
+    var options = node.options;
+
+    if (multiple) {
+      var selectedValues = propValue;
+      var selectedValue = {};
+
+      for (var i = 0; i < selectedValues.length; i++) {
+        // Prefix to avoid chaos with special keys.
+        selectedValue['$' + selectedValues[i]] = true;
+      }
+
+      for (var _i = 0; _i < options.length; _i++) {
+        var selected = selectedValue.hasOwnProperty('$' + options[_i].value);
+
+        if (options[_i].selected !== selected) {
+          options[_i].selected = selected;
+        }
+
+        if (selected && setDefaultSelected) {
+          options[_i].defaultSelected = true;
+        }
+      }
+    } else {
+      // Do not set `select.value` as exact behavior isn't consistent across all
+      // browsers for all cases.
+      var _selectedValue = toString(getToStringValue(propValue));
+
+      var defaultSelected = null;
+
+      for (var _i2 = 0; _i2 < options.length; _i2++) {
+        if (options[_i2].value === _selectedValue) {
+          options[_i2].selected = true;
+
+          if (setDefaultSelected) {
+            options[_i2].defaultSelected = true;
+          }
+
+          return;
+        }
+
+        if (defaultSelected === null && !options[_i2].disabled) {
+          defaultSelected = options[_i2];
+        }
+      }
+
+      if (defaultSelected !== null) {
+        defaultSelected.selected = true;
+      }
+    }
+  }
+  /**
+   * Implements a <select> host component that allows optionally setting the
+   * props `value` and `defaultValue`. If `multiple` is false, the prop must be a
+   * stringable. If `multiple` is true, the prop must be an array of stringables.
+   *
+   * If `value` is not supplied (or null/undefined), user actions that change the
+   * selected option will trigger updates to the rendered options.
+   *
+   * If it is supplied (and not null/undefined), the rendered options will not
+   * update in response to user actions. Instead, the `value` prop must change in
+   * order for the rendered options to update.
+   *
+   * If `defaultValue` is provided, any options with the supplied values will be
+   * selected.
+   */
+
+
+  function getHostProps$2(element, props) {
+    return _assign({}, props, {
+      value: undefined
+    });
+  }
+  function initWrapperState$1(element, props) {
+    var node = element;
+
+    {
+      checkSelectPropTypes(props);
+    }
+
+    node._wrapperState = {
+      wasMultiple: !!props.multiple
+    };
+
+    {
+      if (props.value !== undefined && props.defaultValue !== undefined && !didWarnValueDefaultValue$1) {
+        error('Select elements must be either controlled or uncontrolled ' + '(specify either the value prop, or the defaultValue prop, but not ' + 'both). Decide between using a controlled or uncontrolled select ' + 'element and remove one of these props. More info: ' + 'https://reactjs.org/link/controlled-components');
+
+        didWarnValueDefaultValue$1 = true;
+      }
+    }
+  }
+  function postMountWrapper$2(element, props) {
+    var node = element;
+    node.multiple = !!props.multiple;
+    var value = props.value;
+
+    if (value != null) {
+      updateOptions(node, !!props.multiple, value, false);
+    } else if (props.defaultValue != null) {
+      updateOptions(node, !!props.multiple, props.defaultValue, true);
+    }
+  }
+  function postUpdateWrapper(element, props) {
+    var node = element;
+    var wasMultiple = node._wrapperState.wasMultiple;
+    node._wrapperState.wasMultiple = !!props.multiple;
+    var value = props.value;
+
+    if (value != null) {
+      updateOptions(node, !!props.multiple, value, false);
+    } else if (wasMultiple !== !!props.multiple) {
+      // For simplicity, reapply `defaultValue` if `multiple` is toggled.
+      if (props.defaultValue != null) {
+        updateOptions(node, !!props.multiple, props.defaultValue, true);
+      } else {
+        // Revert the select back to its default unselected state.
+        updateOptions(node, !!props.multiple, props.multiple ? [] : '', false);
+      }
+    }
+  }
+  function restoreControlledState$1(element, props) {
+    var node = element;
+    var value = props.value;
+
+    if (value != null) {
+      updateOptions(node, !!props.multiple, value, false);
+    }
+  }
+
+  var didWarnValDefaultVal = false;
+
+  /**
+   * Implements a <textarea> host component that allows setting `value`, and
+   * `defaultValue`. This differs from the traditional DOM API because value is
+   * usually set as PCDATA children.
+   *
+   * If `value` is not supplied (or null/undefined), user actions that affect the
+   * value will trigger updates to the element.
+   *
+   * If `value` is supplied (and not null/undefined), the rendered element will
+   * not trigger updates to the element. Instead, the `value` prop must change in
+   * order for the rendered element to be updated.
+   *
+   * The rendered element will be initialized with an empty value, the prop
+   * `defaultValue` if specified, or the children content (deprecated).
+   */
+  function getHostProps$3(element, props) {
+    var node = element;
+
+    if (!(props.dangerouslySetInnerHTML == null)) {
+      {
+        throw Error( "`dangerouslySetInnerHTML` does not make sense on <textarea>." );
+      }
+    } // Always set children to the same thing. In IE9, the selection range will
+    // get reset if `textContent` is mutated.  We could add a check in setTextContent
+    // to only set the value if/when the value differs from the node value (which would
+    // completely solve this IE9 bug), but Sebastian+Sophie seemed to like this
+    // solution. The value can be a boolean or object so that's why it's forced
+    // to be a string.
+
+
+    var hostProps = _assign({}, props, {
+      value: undefined,
+      defaultValue: undefined,
+      children: toString(node._wrapperState.initialValue)
+    });
+
+    return hostProps;
+  }
+  function initWrapperState$2(element, props) {
+    var node = element;
+
+    {
+      checkControlledValueProps('textarea', props);
+
+      if (props.value !== undefined && props.defaultValue !== undefined && !didWarnValDefaultVal) {
+        error('%s contains a textarea with both value and defaultValue props. ' + 'Textarea elements must be either controlled or uncontrolled ' + '(specify either the value prop, or the defaultValue prop, but not ' + 'both). Decide between using a controlled or uncontrolled textarea ' + 'and remove one of these props. More info: ' + 'https://reactjs.org/link/controlled-components', getCurrentFiberOwnerNameInDevOrNull() || 'A component');
+
+        didWarnValDefaultVal = true;
+      }
+    }
+
+    var initialValue = props.value; // Only bother fetching default value if we're going to use it
+
+    if (initialValue == null) {
+      var children = props.children,
+          defaultValue = props.defaultValue;
+
+      if (children != null) {
+        {
+          error('Use the `defaultValue` or `value` props instead of setting ' + 'children on <textarea>.');
+        }
+
+        {
+          if (!(defaultValue == null)) {
+            {
+              throw Error( "If you supply `defaultValue` on a <textarea>, do not pass children." );
+            }
+          }
+
+          if (Array.isArray(children)) {
+            if (!(children.length <= 1)) {
+              {
+                throw Error( "<textarea> can only have at most one child." );
+              }
+            }
+
+            children = children[0];
+          }
+
+          defaultValue = children;
+        }
+      }
+
+      if (defaultValue == null) {
+        defaultValue = '';
+      }
+
+      initialValue = defaultValue;
+    }
+
+    node._wrapperState = {
+      initialValue: getToStringValue(initialValue)
+    };
+  }
+  function updateWrapper$1(element, props) {
+    var node = element;
+    var value = getToStringValue(props.value);
+    var defaultValue = getToStringValue(props.defaultValue);
+
+    if (value != null) {
+      // Cast `value` to a string to ensure the value is set correctly. While
+      // browsers typically do this as necessary, jsdom doesn't.
+      var newValue = toString(value); // To avoid side effects (such as losing text selection), only set value if changed
+
+      if (newValue !== node.value) {
+        node.value = newValue;
+      }
+
+      if (props.defaultValue == null && node.defaultValue !== newValue) {
+        node.defaultValue = newValue;
+      }
+    }
+
+    if (defaultValue != null) {
+      node.defaultValue = toString(defaultValue);
+    }
+  }
+  function postMountWrapper$3(element, props) {
+    var node = element; // This is in postMount because we need access to the DOM node, which is not
+    // available until after the component has mounted.
+
+    var textContent = node.textContent; // Only set node.value if textContent is equal to the expected
+    // initial value. In IE10/IE11 there is a bug where the placeholder attribute
+    // will populate textContent as well.
+    // https://developer.microsoft.com/microsoft-edge/platform/issues/101525/
+
+    if (textContent === node._wrapperState.initialValue) {
+      if (textContent !== '' && textContent !== null) {
+        node.value = textContent;
+      }
+    }
+  }
+  function restoreControlledState$2(element, props) {
+    // DOM component is still mounted; update
+    updateWrapper$1(element, props);
+  }
+
+  var HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+  var MATH_NAMESPACE = 'http://www.w3.org/1998/Math/MathML';
+  var SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+  var Namespaces = {
+    html: HTML_NAMESPACE,
+    mathml: MATH_NAMESPACE,
+    svg: SVG_NAMESPACE
+  }; // Assumes there is no parent namespace.
+
+  function getIntrinsicNamespace(type) {
+    switch (type) {
+      case 'svg':
+        return SVG_NAMESPACE;
+
+      case 'math':
+        return MATH_NAMESPACE;
+
+      default:
+        return HTML_NAMESPACE;
+    }
+  }
+  function getChildNamespace(parentNamespace, type) {
+    if (parentNamespace == null || parentNamespace === HTML_NAMESPACE) {
+      // No (or default) parent namespace: potential entry point.
+      return getIntrinsicNamespace(type);
+    }
+
+    if (parentNamespace === SVG_NAMESPACE && type === 'foreignObject') {
+      // We're leaving SVG.
+      return HTML_NAMESPACE;
+    } // By default, pass namespace below.
+
+
+    return parentNamespace;
+  }
+
+  /* globals MSApp */
+
+  /**
+   * Create a function which has 'unsafe' privileges (required by windows8 apps)
+   */
+  var createMicrosoftUnsafeLocalFunction = function (func) {
+    if (typeof MSApp !== 'undefined' && MSApp.execUnsafeLocalFunction) {
+      return function (arg0, arg1, arg2, arg3) {
+        MSApp.execUnsafeLocalFunction(function () {
+          return func(arg0, arg1, arg2, arg3);
+        });
+      };
+    } else {
+      return func;
+    }
+  };
+
+  var reusableSVGContainer;
+  /**
+   * Set the innerHTML property of a node
+   *
+   * @param {DOMElement} node
+   * @param {string} html
+   * @internal
+   */
+
+  var setInnerHTML = createMicrosoftUnsafeLocalFunction(function (node, html) {
+    if (node.namespaceURI === Namespaces.svg) {
+
+      if (!('innerHTML' in node)) {
+        // IE does not have innerHTML for SVG nodes, so instead we inject the
+        // new markup in a temp node and then move the child nodes across into
+        // the target node
+        reusableSVGContainer = reusableSVGContainer || document.createElement('div');
+        reusableSVGContainer.innerHTML = '<svg>' + html.valueOf().toString() + '</svg>';
+        var svgNode = reusableSVGContainer.firstChild;
+
+        while (node.firstChild) {
+          node.removeChild(node.firstChild);
+        }
+
+        while (svgNode.firstChild) {
+          node.appendChild(svgNode.firstChild);
+        }
+
+        return;
+      }
+    }
+
+    node.innerHTML = html;
+  });
+
+  /**
+   * HTML nodeType values that represent the type of the node
+   */
+  var ELEMENT_NODE = 1;
+  var TEXT_NODE = 3;
+  var COMMENT_NODE = 8;
+  var DOCUMENT_NODE = 9;
+  var DOCUMENT_FRAGMENT_NODE = 11;
+
+  /**
+   * Set the textContent property of a node. For text updates, it's faster
+   * to set the `nodeValue` of the Text node directly instead of using
+   * `.textContent` which will remove the existing node and create a new one.
+   *
+   * @param {DOMElement} node
+   * @param {string} text
+   * @internal
+   */
+
+  var setTextContent = function (node, text) {
+    if (text) {
+      var firstChild = node.firstChild;
+
+      if (firstChild && firstChild === node.lastChild && firstChild.nodeType === TEXT_NODE) {
+        firstChild.nodeValue = text;
+        return;
+      }
+    }
+
+    node.textContent = text;
+  };
+
+  // List derived from Gecko source code:
+  // https://github.com/mozilla/gecko-dev/blob/4e638efc71/layout/style/test/property_database.js
+  var shorthandToLonghand = {
+    animation: ['animationDelay', 'animationDirection', 'animationDuration', 'animationFillMode', 'animationIterationCount', 'animationName', 'animationPlayState', 'animationTimingFunction'],
+    background: ['backgroundAttachment', 'backgroundClip', 'backgroundColor', 'backgroundImage', 'backgroundOrigin', 'backgroundPositionX', 'backgroundPositionY', 'backgroundRepeat', 'backgroundSize'],
+    backgroundPosition: ['backgroundPositionX', 'backgroundPositionY'],
+    border: ['borderBottomColor', 'borderBottomStyle', 'borderBottomWidth', 'borderImageOutset', 'borderImageRepeat', 'borderImageSlice', 'borderImageSource', 'borderImageWidth', 'borderLeftColor', 'borderLeftStyle', 'borderLeftWidth', 'borderRightColor', 'borderRightStyle', 'borderRightWidth', 'borderTopColor', 'borderTopStyle', 'borderTopWidth'],
+    borderBlockEnd: ['borderBlockEndColor', 'borderBlockEndStyle', 'borderBlockEndWidth'],
+    borderBlockStart: ['borderBlockStartColor', 'borderBlockStartStyle', 'borderBlockStartWidth'],
+    borderBottom: ['borderBottomColor', 'borderBottomStyle', 'borderBottomWidth'],
+    borderColor: ['borderBottomColor', 'borderLeftColor', 'borderRightColor', 'borderTopColor'],
+    borderImage: ['borderImageOutset', 'borderImageRepeat', 'borderImageSlice', 'borderImageSource', 'borderImageWidth'],
+    borderInlineEnd: ['borderInlineEndColor', 'borderInlineEndStyle', 'borderInlineEndWidth'],
+    borderInlineStart: ['borderInlineStartColor', 'borderInlineStartStyle', 'borderInlineStartWidth'],
+    borderLeft: ['borderLeftColor', 'borderLeftStyle', 'borderLeftWidth'],
+    borderRadius: ['borderBottomLeftRadius', 'borderBottomRightRadius', 'borderTopLeftRadius', 'borderTopRightRadius'],
+    borderRight: ['borderRightColor', 'borderRightStyle', 'borderRightWidth'],
+    borderStyle: ['borderBottomStyle', 'borderLeftStyle', 'borderRightStyle', 'borderTopStyle'],
+    borderTop: ['borderTopColor', 'borderTopStyle', 'borderTopWidth'],
+    borderWidth: ['borderBottomWidth', 'borderLeftWidth', 'borderRightWidth', 'borderTopWidth'],
+    columnRule: ['columnRuleColor', 'columnRuleStyle', 'columnRuleWidth'],
+    columns: ['columnCount', 'columnWidth'],
+    flex: ['flexBasis', 'flexGrow', 'flexShrink'],
+    flexFlow: ['flexDirection', 'flexWrap'],
+    font: ['fontFamily', 'fontFeatureSettings', 'fontKerning', 'fontLanguageOverride', 'fontSize', 'fontSizeAdjust', 'fontStretch', 'fontStyle', 'fontVariant', 'fontVariantAlternates', 'fontVariantCaps', 'fontVariantEastAsian', 'fontVariantLigatures', 'fontVariantNumeric', 'fontVariantPosition', 'fontWeight', 'lineHeight'],
+    fontVariant: ['fontVariantAlternates', 'fontVariantCaps', 'fontVariantEastAsian', 'fontVariantLigatures', 'fontVariantNumeric', 'fontVariantPosition'],
+    gap: ['columnGap', 'rowGap'],
+    grid: ['gridAutoColumns', 'gridAutoFlow', 'gridAutoRows', 'gridTemplateAreas', 'gridTemplateColumns', 'gridTemplateRows'],
+    gridArea: ['gridColumnEnd', 'gridColumnStart', 'gridRowEnd', 'gridRowStart'],
+    gridColumn: ['gridColumnEnd', 'gridColumnStart'],
+    gridColumnGap: ['columnGap'],
+    gridGap: ['columnGap', 'rowGap'],
+    gridRow: ['gridRowEnd', 'gridRowStart'],
+    gridRowGap: ['rowGap'],
+    gridTemplate: ['gridTemplateAreas', 'gridTemplateColumns', 'gridTemplateRows'],
+    listStyle: ['listStyleImage', 'listStylePosition', 'listStyleType'],
+    margin: ['marginBottom', 'marginLeft', 'marginRight', 'marginTop'],
+    marker: ['markerEnd', 'markerMid', 'markerStart'],
+    mask: ['maskClip', 'maskComposite', 'maskImage', 'maskMode', 'maskOrigin', 'maskPositionX', 'maskPositionY', 'maskRepeat', 'maskSize'],
+    maskPosition: ['maskPositionX', 'maskPositionY'],
+    outline: ['outlineColor', 'outlineStyle', 'outlineWidth'],
+    overflow: ['overflowX', 'overflowY'],
+    padding: ['paddingBottom', 'paddingLeft', 'paddingRight', 'paddingTop'],
+    placeContent: ['alignContent', 'justifyContent'],
+    placeItems: ['alignItems', 'justifyItems'],
+    placeSelf: ['alignSelf', 'justifySelf'],
+    textDecoration: ['textDecorationColor', 'textDecorationLine', 'textDecorationStyle'],
+    textEmphasis: ['textEmphasisColor', 'textEmphasisStyle'],
+    transition: ['transitionDelay', 'transitionDuration', 'transitionProperty', 'transitionTimingFunction'],
+    wordWrap: ['overflowWrap']
+  };
+
+  /**
+   * CSS properties which accept numbers but are not in units of "px".
+   */
+  var isUnitlessNumber = {
+    animationIterationCount: true,
+    borderImageOutset: true,
+    borderImageSlice: true,
+    borderImageWidth: true,
+    boxFlex: true,
+    boxFlexGroup: true,
+    boxOrdinalGroup: true,
+    columnCount: true,
+    columns: true,
+    flex: true,
+    flexGrow: true,
+    flexPositive: true,
+    flexShrink: true,
+    flexNegative: true,
+    flexOrder: true,
+    gridArea: true,
+    gridRow: true,
+    gridRowEnd: true,
+    gridRowSpan: true,
+    gridRowStart: true,
+    gridColumn: true,
+    gridColumnEnd: true,
+    gridColumnSpan: true,
+    gridColumnStart: true,
+    fontWeight: true,
+    lineClamp: true,
+    lineHeight: true,
+    opacity: true,
+    order: true,
+    orphans: true,
+    tabSize: true,
+    widows: true,
+    zIndex: true,
+    zoom: true,
+    // SVG-related properties
+    fillOpacity: true,
+    floodOpacity: true,
+    stopOpacity: true,
+    strokeDasharray: true,
+    strokeDashoffset: true,
+    strokeMiterlimit: true,
+    strokeOpacity: true,
+    strokeWidth: true
+  };
+  /**
+   * @param {string} prefix vendor-specific prefix, eg: Webkit
+   * @param {string} key style name, eg: transitionDuration
+   * @return {string} style name prefixed with `prefix`, properly camelCased, eg:
+   * WebkitTransitionDuration
+   */
+
+  function prefixKey(prefix, key) {
+    return prefix + key.charAt(0).toUpperCase() + key.substring(1);
+  }
+  /**
+   * Support style names that may come passed in prefixed by adding permutations
+   * of vendor prefixes.
+   */
+
+
+  var prefixes = ['Webkit', 'ms', 'Moz', 'O']; // Using Object.keys here, or else the vanilla for-in loop makes IE8 go into an
+  // infinite loop, because it iterates over the newly added props too.
+
+  Object.keys(isUnitlessNumber).forEach(function (prop) {
+    prefixes.forEach(function (prefix) {
+      isUnitlessNumber[prefixKey(prefix, prop)] = isUnitlessNumber[prop];
+    });
+  });
+
+  /**
+   * Convert a value into the proper css writable value. The style name `name`
+   * should be logical (no hyphens), as specified
+   * in `CSSProperty.isUnitlessNumber`.
+   *
+   * @param {string} name CSS property name such as `topMargin`.
+   * @param {*} value CSS property value such as `10px`.
+   * @return {string} Normalized style value with dimensions applied.
+   */
+
+  function dangerousStyleValue(name, value, isCustomProperty) {
+    // Note that we've removed escapeTextForBrowser() calls here since the
+    // whole string will be escaped when the attribute is injected into
+    // the markup. If you provide unsafe user data here they can inject
+    // arbitrary CSS which may be problematic (I couldn't repro this):
+    // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet
+    // http://www.thespanner.co.uk/2007/11/26/ultimate-xss-css-injection/
+    // This is not an XSS hole but instead a potential CSS injection issue
+    // which has lead to a greater discussion about how we're going to
+    // trust URLs moving forward. See #2115901
+    var isEmpty = value == null || typeof value === 'boolean' || value === '';
+
+    if (isEmpty) {
+      return '';
+    }
+
+    if (!isCustomProperty && typeof value === 'number' && value !== 0 && !(isUnitlessNumber.hasOwnProperty(name) && isUnitlessNumber[name])) {
+      return value + 'px'; // Presumes implicit 'px' suffix for unitless numbers
+    }
+
+    return ('' + value).trim();
+  }
+
+  var uppercasePattern = /([A-Z])/g;
+  var msPattern = /^ms-/;
+  /**
+   * Hyphenates a camelcased CSS property name, for example:
+   *
+   *   > hyphenateStyleName('backgroundColor')
+   *   < "background-color"
+   *   > hyphenateStyleName('MozTransition')
+   *   < "-moz-transition"
+   *   > hyphenateStyleName('msTransition')
+   *   < "-ms-transition"
+   *
+   * As Modernizr suggests (http://modernizr.com/docs/#prefixed), an `ms` prefix
+   * is converted to `-ms-`.
+   */
+
+  function hyphenateStyleName(name) {
+    return name.replace(uppercasePattern, '-$1').toLowerCase().replace(msPattern, '-ms-');
+  }
+
+  var warnValidStyle = function () {};
+
+  {
+    // 'msTransform' is correct, but the other prefixes should be capitalized
+    var badVendoredStyleNamePattern = /^(?:webkit|moz|o)[A-Z]/;
+    var msPattern$1 = /^-ms-/;
+    var hyphenPattern = /-(.)/g; // style values shouldn't contain a semicolon
+
+    var badStyleValueWithSemicolonPattern = /;\s*$/;
+    var warnedStyleNames = {};
+    var warnedStyleValues = {};
+    var warnedForNaNValue = false;
+    var warnedForInfinityValue = false;
+
+    var camelize = function (string) {
+      return string.replace(hyphenPattern, function (_, character) {
+        return character.toUpperCase();
+      });
+    };
+
+    var warnHyphenatedStyleName = function (name) {
+      if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
+        return;
+      }
+
+      warnedStyleNames[name] = true;
+
+      error('Unsupported style property %s. Did you mean %s?', name, // As Andi Smith suggests
+      // (http://www.andismith.com/blog/2012/02/modernizr-prefixed/), an `-ms` prefix
+      // is converted to lowercase `ms`.
+      camelize(name.replace(msPattern$1, 'ms-')));
+    };
+
+    var warnBadVendoredStyleName = function (name) {
+      if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
+        return;
+      }
+
+      warnedStyleNames[name] = true;
+
+      error('Unsupported vendor-prefixed style property %s. Did you mean %s?', name, name.charAt(0).toUpperCase() + name.slice(1));
+    };
+
+    var warnStyleValueWithSemicolon = function (name, value) {
+      if (warnedStyleValues.hasOwnProperty(value) && warnedStyleValues[value]) {
+        return;
+      }
+
+      warnedStyleValues[value] = true;
+
+      error("Style property values shouldn't contain a semicolon. " + 'Try "%s: %s" instead.', name, value.replace(badStyleValueWithSemicolonPattern, ''));
+    };
+
+    var warnStyleValueIsNaN = function (name, value) {
+      if (warnedForNaNValue) {
+        return;
+      }
+
+      warnedForNaNValue = true;
+
+      error('`NaN` is an invalid value for the `%s` css style property.', name);
+    };
+
+    var warnStyleValueIsInfinity = function (name, value) {
+      if (warnedForInfinityValue) {
+        return;
+      }
+
+      warnedForInfinityValue = true;
+
+      error('`Infinity` is an invalid value for the `%s` css style property.', name);
+    };
+
+    warnValidStyle = function (name, value) {
+      if (name.indexOf('-') > -1) {
+        warnHyphenatedStyleName(name);
+      } else if (badVendoredStyleNamePattern.test(name)) {
+        warnBadVendoredStyleName(name);
+      } else if (badStyleValueWithSemicolonPattern.test(value)) {
+        warnStyleValueWithSemicolon(name, value);
+      }
+
+      if (typeof value === 'number') {
+        if (isNaN(value)) {
+          warnStyleValueIsNaN(name, value);
+        } else if (!isFinite(value)) {
+          warnStyleValueIsInfinity(name, value);
+        }
+      }
+    };
+  }
+
+  var warnValidStyle$1 = warnValidStyle;
+
+  /**
+   * Operations for dealing with CSS properties.
+   */
+
+  /**
+   * This creates a string that is expected to be equivalent to the style
+   * attribute generated by server-side rendering. It by-passes warnings and
+   * security checks so it's not safe to use this value for anything other than
+   * comparison. It is only used in DEV for SSR validation.
+   */
+
+  function createDangerousStringForStyles(styles) {
+    {
+      var serialized = '';
+      var delimiter = '';
+
+      for (var styleName in styles) {
+        if (!styles.hasOwnProperty(styleName)) {
+          continue;
+        }
+
+        var styleValue = styles[styleName];
+
+        if (styleValue != null) {
+          var isCustomProperty = styleName.indexOf('--') === 0;
+          serialized += delimiter + (isCustomProperty ? styleName : hyphenateStyleName(styleName)) + ':';
+          serialized += dangerousStyleValue(styleName, styleValue, isCustomProperty);
+          delimiter = ';';
+        }
+      }
+
+      return serialized || null;
+    }
+  }
+  /**
+   * Sets the value for multiple styles on a node.  If a value is specified as
+   * '' (empty string), the corresponding style property will be unset.
+   *
+   * @param {DOMElement} node
+   * @param {object} styles
+   */
+
+  function setValueForStyles(node, styles) {
+    var style = node.style;
+
+    for (var styleName in styles) {
+      if (!styles.hasOwnProperty(styleName)) {
+        continue;
+      }
+
+      var isCustomProperty = styleName.indexOf('--') === 0;
+
+      {
+        if (!isCustomProperty) {
+          warnValidStyle$1(styleName, styles[styleName]);
+        }
+      }
+
+      var styleValue = dangerousStyleValue(styleName, styles[styleName], isCustomProperty);
+
+      if (styleName === 'float') {
+        styleName = 'cssFloat';
+      }
+
+      if (isCustomProperty) {
+        style.setProperty(styleName, styleValue);
+      } else {
+        style[styleName] = styleValue;
+      }
+    }
+  }
+
+  function isValueEmpty(value) {
+    return value == null || typeof value === 'boolean' || value === '';
+  }
+  /**
+   * Given {color: 'red', overflow: 'hidden'} returns {
+   *   color: 'color',
+   *   overflowX: 'overflow',
+   *   overflowY: 'overflow',
+   * }. This can be read as "the overflowY property was set by the overflow
+   * shorthand". That is, the values are the property that each was derived from.
+   */
+
+
+  function expandShorthandMap(styles) {
+    var expanded = {};
+
+    for (var key in styles) {
+      var longhands = shorthandToLonghand[key] || [key];
+
+      for (var i = 0; i < longhands.length; i++) {
+        expanded[longhands[i]] = key;
+      }
+    }
+
+    return expanded;
+  }
+  /**
+   * When mixing shorthand and longhand property names, we warn during updates if
+   * we expect an incorrect result to occur. In particular, we warn for:
+   *
+   * Updating a shorthand property (longhand gets overwritten):
+   *   {font: 'foo', fontVariant: 'bar'} -> {font: 'baz', fontVariant: 'bar'}
+   *   becomes .style.font = 'baz'
+   * Removing a shorthand property (longhand gets lost too):
+   *   {font: 'foo', fontVariant: 'bar'} -> {fontVariant: 'bar'}
+   *   becomes .style.font = ''
+   * Removing a longhand property (should revert to shorthand; doesn't):
+   *   {font: 'foo', fontVariant: 'bar'} -> {font: 'foo'}
+   *   becomes .style.fontVariant = ''
+   */
+
+
+  function validateShorthandPropertyCollisionInDev(styleUpdates, nextStyles) {
+    {
+      if (!nextStyles) {
+        return;
+      }
+
+      var expandedUpdates = expandShorthandMap(styleUpdates);
+      var expandedStyles = expandShorthandMap(nextStyles);
+      var warnedAbout = {};
+
+      for (var key in expandedUpdates) {
+        var originalKey = expandedUpdates[key];
+        var correctOriginalKey = expandedStyles[key];
+
+        if (correctOriginalKey && originalKey !== correctOriginalKey) {
+          var warningKey = originalKey + ',' + correctOriginalKey;
+
+          if (warnedAbout[warningKey]) {
+            continue;
+          }
+
+          warnedAbout[warningKey] = true;
+
+          error('%s a style property during rerender (%s) when a ' + 'conflicting property is set (%s) can lead to styling bugs. To ' + "avoid this, don't mix shorthand and non-shorthand properties " + 'for the same value; instead, replace the shorthand with ' + 'separate values.', isValueEmpty(styleUpdates[originalKey]) ? 'Removing' : 'Updating', originalKey, correctOriginalKey);
+        }
+      }
+    }
+  }
+
+  // For HTML, certain tags should omit their close tag. We keep a list for
+  // those special-case tags.
+  var omittedCloseTags = {
+    area: true,
+    base: true,
+    br: true,
+    col: true,
+    embed: true,
+    hr: true,
+    img: true,
+    input: true,
+    keygen: true,
+    link: true,
+    meta: true,
+    param: true,
+    source: true,
+    track: true,
+    wbr: true // NOTE: menuitem's close tag should be omitted, but that causes problems.
+
+  };
+
+  // `omittedCloseTags` except that `menuitem` should still have its closing tag.
+
+  var voidElementTags = _assign({
+    menuitem: true
+  }, omittedCloseTags);
+
+  var HTML = '__html';
+
+  function assertValidProps(tag, props) {
+    if (!props) {
+      return;
+    } // Note the use of `==` which checks for null or undefined.
+
+
+    if (voidElementTags[tag]) {
+      if (!(props.children == null && props.dangerouslySetInnerHTML == null)) {
+        {
+          throw Error( tag + " is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`." );
+        }
+      }
+    }
+
+    if (props.dangerouslySetInnerHTML != null) {
+      if (!(props.children == null)) {
+        {
+          throw Error( "Can only set one of `children` or `props.dangerouslySetInnerHTML`." );
+        }
+      }
+
+      if (!(typeof props.dangerouslySetInnerHTML === 'object' && HTML in props.dangerouslySetInnerHTML)) {
+        {
+          throw Error( "`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. Please visit https://reactjs.org/link/dangerously-set-inner-html for more information." );
+        }
+      }
+    }
+
+    {
+      if (!props.suppressContentEditableWarning && props.contentEditable && props.children != null) {
+        error('A component is `contentEditable` and contains `children` managed by ' + 'React. It is now your responsibility to guarantee that none of ' + 'those nodes are unexpectedly modified or duplicated. This is ' + 'probably not intentional.');
+      }
+    }
+
+    if (!(props.style == null || typeof props.style === 'object')) {
+      {
+        throw Error( "The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + 'em'}} when using JSX." );
+      }
+    }
+  }
+
+  function isCustomComponent(tagName, props) {
+    if (tagName.indexOf('-') === -1) {
+      return typeof props.is === 'string';
+    }
+
+    switch (tagName) {
+      // These are reserved SVG and MathML elements.
+      // We don't mind this list too much because we expect it to never grow.
+      // The alternative is to track the namespace in a few places which is convoluted.
+      // https://w3c.github.io/webcomponents/spec/custom/#custom-elements-core-concepts
+      case 'annotation-xml':
+      case 'color-profile':
+      case 'font-face':
+      case 'font-face-src':
+      case 'font-face-uri':
+      case 'font-face-format':
+      case 'font-face-name':
+      case 'missing-glyph':
+        return false;
+
+      default:
+        return true;
+    }
+  }
+
+  // When adding attributes to the HTML or SVG allowed attribute list, be sure to
+  // also add them to this module to ensure casing and incorrect name
+  // warnings.
+  var possibleStandardNames = {
+    // HTML
+    accept: 'accept',
+    acceptcharset: 'acceptCharset',
+    'accept-charset': 'acceptCharset',
+    accesskey: 'accessKey',
+    action: 'action',
+    allowfullscreen: 'allowFullScreen',
+    alt: 'alt',
+    as: 'as',
+    async: 'async',
+    autocapitalize: 'autoCapitalize',
+    autocomplete: 'autoComplete',
+    autocorrect: 'autoCorrect',
+    autofocus: 'autoFocus',
+    autoplay: 'autoPlay',
+    autosave: 'autoSave',
+    capture: 'capture',
+    cellpadding: 'cellPadding',
+    cellspacing: 'cellSpacing',
+    challenge: 'challenge',
+    charset: 'charSet',
+    checked: 'checked',
+    children: 'children',
+    cite: 'cite',
+    class: 'className',
+    classid: 'classID',
+    classname: 'className',
+    cols: 'cols',
+    colspan: 'colSpan',
+    content: 'content',
+    contenteditable: 'contentEditable',
+    contextmenu: 'contextMenu',
+    controls: 'controls',
+    controlslist: 'controlsList',
+    coords: 'coords',
+    crossorigin: 'crossOrigin',
+    dangerouslysetinnerhtml: 'dangerouslySetInnerHTML',
+    data: 'data',
+    datetime: 'dateTime',
+    default: 'default',
+    defaultchecked: 'defaultChecked',
+    defaultvalue: 'defaultValue',
+    defer: 'defer',
+    dir: 'dir',
+    disabled: 'disabled',
+    disablepictureinpicture: 'disablePictureInPicture',
+    disableremoteplayback: 'disableRemotePlayback',
+    download: 'download',
+    draggable: 'draggable',
+    enctype: 'encType',
+    enterkeyhint: 'enterKeyHint',
+    for: 'htmlFor',
+    form: 'form',
+    formmethod: 'formMethod',
+    formaction: 'formAction',
+    formenctype: 'formEncType',
+    formnovalidate: 'formNoValidate',
+    formtarget: 'formTarget',
+    frameborder: 'frameBorder',
+    headers: 'headers',
+    height: 'height',
+    hidden: 'hidden',
+    high: 'high',
+    href: 'href',
+    hreflang: 'hrefLang',
+    htmlfor: 'htmlFor',
+    httpequiv: 'httpEquiv',
+    'http-equiv': 'httpEquiv',
+    icon: 'icon',
+    id: 'id',
+    innerhtml: 'innerHTML',
+    inputmode: 'inputMode',
+    integrity: 'integrity',
+    is: 'is',
+    itemid: 'itemID',
+    itemprop: 'itemProp',
+    itemref: 'itemRef',
+    itemscope: 'itemScope',
+    itemtype: 'itemType',
+    keyparams: 'keyParams',
+    keytype: 'keyType',
+    kind: 'kind',
+    label: 'label',
+    lang: 'lang',
+    list: 'list',
+    loop: 'loop',
+    low: 'low',
+    manifest: 'manifest',
+    marginwidth: 'marginWidth',
+    marginheight: 'marginHeight',
+    max: 'max',
+    maxlength: 'maxLength',
+    media: 'media',
+    mediagroup: 'mediaGroup',
+    method: 'method',
+    min: 'min',
+    minlength: 'minLength',
+    multiple: 'multiple',
+    muted: 'muted',
+    name: 'name',
+    nomodule: 'noModule',
+    nonce: 'nonce',
+    novalidate: 'noValidate',
+    open: 'open',
+    optimum: 'optimum',
+    pattern: 'pattern',
+    placeholder: 'placeholder',
+    playsinline: 'playsInline',
+    poster: 'poster',
+    preload: 'preload',
+    profile: 'profile',
+    radiogroup: 'radioGroup',
+    readonly: 'readOnly',
+    referrerpolicy: 'referrerPolicy',
+    rel: 'rel',
+    required: 'required',
+    reversed: 'reversed',
+    role: 'role',
+    rows: 'rows',
+    rowspan: 'rowSpan',
+    sandbox: 'sandbox',
+    scope: 'scope',
+    scoped: 'scoped',
+    scrolling: 'scrolling',
+    seamless: 'seamless',
+    selected: 'selected',
+    shape: 'shape',
+    size: 'size',
+    sizes: 'sizes',
+    span: 'span',
+    spellcheck: 'spellCheck',
+    src: 'src',
+    srcdoc: 'srcDoc',
+    srclang: 'srcLang',
+    srcset: 'srcSet',
+    start: 'start',
+    step: 'step',
+    style: 'style',
+    summary: 'summary',
+    tabindex: 'tabIndex',
+    target: 'target',
+    title: 'title',
+    type: 'type',
+    usemap: 'useMap',
+    value: 'value',
+    width: 'width',
+    wmode: 'wmode',
+    wrap: 'wrap',
+    // SVG
+    about: 'about',
+    accentheight: 'accentHeight',
+    'accent-height': 'accentHeight',
+    accumulate: 'accumulate',
+    additive: 'additive',
+    alignmentbaseline: 'alignmentBaseline',
+    'alignment-baseline': 'alignmentBaseline',
+    allowreorder: 'allowReorder',
+    alphabetic: 'alphabetic',
+    amplitude: 'amplitude',
+    arabicform: 'arabicForm',
+    'arabic-form': 'arabicForm',
+    ascent: 'ascent',
+    attributename: 'attributeName',
+    attributetype: 'attributeType',
+    autoreverse: 'autoReverse',
+    azimuth: 'azimuth',
+    basefrequency: 'baseFrequency',
+    baselineshift: 'baselineShift',
+    'baseline-shift': 'baselineShift',
+    baseprofile: 'baseProfile',
+    bbox: 'bbox',
+    begin: 'begin',
+    bias: 'bias',
+    by: 'by',
+    calcmode: 'calcMode',
+    capheight: 'capHeight',
+    'cap-height': 'capHeight',
+    clip: 'clip',
+    clippath: 'clipPath',
+    'clip-path': 'clipPath',
+    clippathunits: 'clipPathUnits',
+    cliprule: 'clipRule',
+    'clip-rule': 'clipRule',
+    color: 'color',
+    colorinterpolation: 'colorInterpolation',
+    'color-interpolation': 'colorInterpolation',
+    colorinterpolationfilters: 'colorInterpolationFilters',
+    'color-interpolation-filters': 'colorInterpolationFilters',
+    colorprofile: 'colorProfile',
+    'color-profile': 'colorProfile',
+    colorrendering: 'colorRendering',
+    'color-rendering': 'colorRendering',
+    contentscripttype: 'contentScriptType',
+    contentstyletype: 'contentStyleType',
+    cursor: 'cursor',
+    cx: 'cx',
+    cy: 'cy',
+    d: 'd',
+    datatype: 'datatype',
+    decelerate: 'decelerate',
+    descent: 'descent',
+    diffuseconstant: 'diffuseConstant',
+    direction: 'direction',
+    display: 'display',
+    divisor: 'divisor',
+    dominantbaseline: 'dominantBaseline',
+    'dominant-baseline': 'dominantBaseline',
+    dur: 'dur',
+    dx: 'dx',
+    dy: 'dy',
+    edgemode: 'edgeMode',
+    elevation: 'elevation',
+    enablebackground: 'enableBackground',
+    'enable-background': 'enableBackground',
+    end: 'end',
+    exponent: 'exponent',
+    externalresourcesrequired: 'externalResourcesRequired',
+    fill: 'fill',
+    fillopacity: 'fillOpacity',
+    'fill-opacity': 'fillOpacity',
+    fillrule: 'fillRule',
+    'fill-rule': 'fillRule',
+    filter: 'filter',
+    filterres: 'filterRes',
+    filterunits: 'filterUnits',
+    floodopacity: 'floodOpacity',
+    'flood-opacity': 'floodOpacity',
+    floodcolor: 'floodColor',
+    'flood-color': 'floodColor',
+    focusable: 'focusable',
+    fontfamily: 'fontFamily',
+    'font-family': 'fontFamily',
+    fontsize: 'fontSize',
+    'font-size': 'fontSize',
+    fontsizeadjust: 'fontSizeAdjust',
+    'font-size-adjust': 'fontSizeAdjust',
+    fontstretch: 'fontStretch',
+    'font-stretch': 'fontStretch',
+    fontstyle: 'fontStyle',
+    'font-style': 'fontStyle',
+    fontvariant: 'fontVariant',
+    'font-variant': 'fontVariant',
+    fontweight: 'fontWeight',
+    'font-weight': 'fontWeight',
+    format: 'format',
+    from: 'from',
+    fx: 'fx',
+    fy: 'fy',
+    g1: 'g1',
+    g2: 'g2',
+    glyphname: 'glyphName',
+    'glyph-name': 'glyphName',
+    glyphorientationhorizontal: 'glyphOrientationHorizontal',
+    'glyph-orientation-horizontal': 'glyphOrientationHorizontal',
+    glyphorientationvertical: 'glyphOrientationVertical',
+    'glyph-orientation-vertical': 'glyphOrientationVertical',
+    glyphref: 'glyphRef',
+    gradienttransform: 'gradientTransform',
+    gradientunits: 'gradientUnits',
+    hanging: 'hanging',
+    horizadvx: 'horizAdvX',
+    'horiz-adv-x': 'horizAdvX',
+    horizoriginx: 'horizOriginX',
+    'horiz-origin-x': 'horizOriginX',
+    ideographic: 'ideographic',
+    imagerendering: 'imageRendering',
+    'image-rendering': 'imageRendering',
+    in2: 'in2',
+    in: 'in',
+    inlist: 'inlist',
+    intercept: 'intercept',
+    k1: 'k1',
+    k2: 'k2',
+    k3: 'k3',
+    k4: 'k4',
+    k: 'k',
+    kernelmatrix: 'kernelMatrix',
+    kernelunitlength: 'kernelUnitLength',
+    kerning: 'kerning',
+    keypoints: 'keyPoints',
+    keysplines: 'keySplines',
+    keytimes: 'keyTimes',
+    lengthadjust: 'lengthAdjust',
+    letterspacing: 'letterSpacing',
+    'letter-spacing': 'letterSpacing',
+    lightingcolor: 'lightingColor',
+    'lighting-color': 'lightingColor',
+    limitingconeangle: 'limitingConeAngle',
+    local: 'local',
+    markerend: 'markerEnd',
+    'marker-end': 'markerEnd',
+    markerheight: 'markerHeight',
+    markermid: 'markerMid',
+    'marker-mid': 'markerMid',
+    markerstart: 'markerStart',
+    'marker-start': 'markerStart',
+    markerunits: 'markerUnits',
+    markerwidth: 'markerWidth',
+    mask: 'mask',
+    maskcontentunits: 'maskContentUnits',
+    maskunits: 'maskUnits',
+    mathematical: 'mathematical',
+    mode: 'mode',
+    numoctaves: 'numOctaves',
+    offset: 'offset',
+    opacity: 'opacity',
+    operator: 'operator',
+    order: 'order',
+    orient: 'orient',
+    orientation: 'orientation',
+    origin: 'origin',
+    overflow: 'overflow',
+    overlineposition: 'overlinePosition',
+    'overline-position': 'overlinePosition',
+    overlinethickness: 'overlineThickness',
+    'overline-thickness': 'overlineThickness',
+    paintorder: 'paintOrder',
+    'paint-order': 'paintOrder',
+    panose1: 'panose1',
+    'panose-1': 'panose1',
+    pathlength: 'pathLength',
+    patterncontentunits: 'patternContentUnits',
+    patterntransform: 'patternTransform',
+    patternunits: 'patternUnits',
+    pointerevents: 'pointerEvents',
+    'pointer-events': 'pointerEvents',
+    points: 'points',
+    pointsatx: 'pointsAtX',
+    pointsaty: 'pointsAtY',
+    pointsatz: 'pointsAtZ',
+    prefix: 'prefix',
+    preservealpha: 'preserveAlpha',
+    preserveaspectratio: 'preserveAspectRatio',
+    primitiveunits: 'primitiveUnits',
+    property: 'property',
+    r: 'r',
+    radius: 'radius',
+    refx: 'refX',
+    refy: 'refY',
+    renderingintent: 'renderingIntent',
+    'rendering-intent': 'renderingIntent',
+    repeatcount: 'repeatCount',
+    repeatdur: 'repeatDur',
+    requiredextensions: 'requiredExtensions',
+    requiredfeatures: 'requiredFeatures',
+    resource: 'resource',
+    restart: 'restart',
+    result: 'result',
+    results: 'results',
+    rotate: 'rotate',
+    rx: 'rx',
+    ry: 'ry',
+    scale: 'scale',
+    security: 'security',
+    seed: 'seed',
+    shaperendering: 'shapeRendering',
+    'shape-rendering': 'shapeRendering',
+    slope: 'slope',
+    spacing: 'spacing',
+    specularconstant: 'specularConstant',
+    specularexponent: 'specularExponent',
+    speed: 'speed',
+    spreadmethod: 'spreadMethod',
+    startoffset: 'startOffset',
+    stddeviation: 'stdDeviation',
+    stemh: 'stemh',
+    stemv: 'stemv',
+    stitchtiles: 'stitchTiles',
+    stopcolor: 'stopColor',
+    'stop-color': 'stopColor',
+    stopopacity: 'stopOpacity',
+    'stop-opacity': 'stopOpacity',
+    strikethroughposition: 'strikethroughPosition',
+    'strikethrough-position': 'strikethroughPosition',
+    strikethroughthickness: 'strikethroughThickness',
+    'strikethrough-thickness': 'strikethroughThickness',
+    string: 'string',
+    stroke: 'stroke',
+    strokedasharray: 'strokeDasharray',
+    'stroke-dasharray': 'strokeDasharray',
+    strokedashoffset: 'strokeDashoffset',
+    'stroke-dashoffset': 'strokeDashoffset',
+    strokelinecap: 'strokeLinecap',
+    'stroke-linecap': 'strokeLinecap',
+    strokelinejoin: 'strokeLinejoin',
+    'stroke-linejoin': 'strokeLinejoin',
+    strokemiterlimit: 'strokeMiterlimit',
+    'stroke-miterlimit': 'strokeMiterlimit',
+    strokewidth: 'strokeWidth',
+    'stroke-width': 'strokeWidth',
+    strokeopacity: 'strokeOpacity',
+    'stroke-opacity': 'strokeOpacity',
+    suppresscontenteditablewarning: 'suppressContentEditableWarning',
+    suppresshydrationwarning: 'suppressHydrationWarning',
+    surfacescale: 'surfaceScale',
+    systemlanguage: 'systemLanguage',
+    tablevalues: 'tableValues',
+    targetx: 'targetX',
+    targety: 'targetY',
+    textanchor: 'textAnchor',
+    'text-anchor': 'textAnchor',
+    textdecoration: 'textDecoration',
+    'text-decoration': 'textDecoration',
+    textlength: 'textLength',
+    textrendering: 'textRendering',
+    'text-rendering': 'textRendering',
+    to: 'to',
+    transform: 'transform',
+    typeof: 'typeof',
+    u1: 'u1',
+    u2: 'u2',
+    underlineposition: 'underlinePosition',
+    'underline-position': 'underlinePosition',
+    underlinethickness: 'underlineThickness',
+    'underline-thickness': 'underlineThickness',
+    unicode: 'unicode',
+    unicodebidi: 'unicodeBidi',
+    'unicode-bidi': 'unicodeBidi',
+    unicoderange: 'unicodeRange',
+    'unicode-range': 'unicodeRange',
+    unitsperem: 'unitsPerEm',
+    'units-per-em': 'unitsPerEm',
+    unselectable: 'unselectable',
+    valphabetic: 'vAlphabetic',
+    'v-alphabetic': 'vAlphabetic',
+    values: 'values',
+    vectoreffect: 'vectorEffect',
+    'vector-effect': 'vectorEffect',
+    version: 'version',
+    vertadvy: 'vertAdvY',
+    'vert-adv-y': 'vertAdvY',
+    vertoriginx: 'vertOriginX',
+    'vert-origin-x': 'vertOriginX',
+    vertoriginy: 'vertOriginY',
+    'vert-origin-y': 'vertOriginY',
+    vhanging: 'vHanging',
+    'v-hanging': 'vHanging',
+    videographic: 'vIdeographic',
+    'v-ideographic': 'vIdeographic',
+    viewbox: 'viewBox',
+    viewtarget: 'viewTarget',
+    visibility: 'visibility',
+    vmathematical: 'vMathematical',
+    'v-mathematical': 'vMathematical',
+    vocab: 'vocab',
+    widths: 'widths',
+    wordspacing: 'wordSpacing',
+    'word-spacing': 'wordSpacing',
+    writingmode: 'writingMode',
+    'writing-mode': 'writingMode',
+    x1: 'x1',
+    x2: 'x2',
+    x: 'x',
+    xchannelselector: 'xChannelSelector',
+    xheight: 'xHeight',
+    'x-height': 'xHeight',
+    xlinkactuate: 'xlinkActuate',
+    'xlink:actuate': 'xlinkActuate',
+    xlinkarcrole: 'xlinkArcrole',
+    'xlink:arcrole': 'xlinkArcrole',
+    xlinkhref: 'xlinkHref',
+    'xlink:href': 'xlinkHref',
+    xlinkrole: 'xlinkRole',
+    'xlink:role': 'xlinkRole',
+    xlinkshow: 'xlinkShow',
+    'xlink:show': 'xlinkShow',
+    xlinktitle: 'xlinkTitle',
+    'xlink:title': 'xlinkTitle',
+    xlinktype: 'xlinkType',
+    'xlink:type': 'xlinkType',
+    xmlbase: 'xmlBase',
+    'xml:base': 'xmlBase',
+    xmllang: 'xmlLang',
+    'xml:lang': 'xmlLang',
+    xmlns: 'xmlns',
+    'xml:space': 'xmlSpace',
+    xmlnsxlink: 'xmlnsXlink',
+    'xmlns:xlink': 'xmlnsXlink',
+    xmlspace: 'xmlSpace',
+    y1: 'y1',
+    y2: 'y2',
+    y: 'y',
+    ychannelselector: 'yChannelSelector',
+    z: 'z',
+    zoomandpan: 'zoomAndPan'
+  };
+
+  var ariaProperties = {
+    'aria-current': 0,
+    // state
+    'aria-details': 0,
+    'aria-disabled': 0,
+    // state
+    'aria-hidden': 0,
+    // state
+    'aria-invalid': 0,
+    // state
+    'aria-keyshortcuts': 0,
+    'aria-label': 0,
+    'aria-roledescription': 0,
+    // Widget Attributes
+    'aria-autocomplete': 0,
+    'aria-checked': 0,
+    'aria-expanded': 0,
+    'aria-haspopup': 0,
+    'aria-level': 0,
+    'aria-modal': 0,
+    'aria-multiline': 0,
+    'aria-multiselectable': 0,
+    'aria-orientation': 0,
+    'aria-placeholder': 0,
+    'aria-pressed': 0,
+    'aria-readonly': 0,
+    'aria-required': 0,
+    'aria-selected': 0,
+    'aria-sort': 0,
+    'aria-valuemax': 0,
+    'aria-valuemin': 0,
+    'aria-valuenow': 0,
+    'aria-valuetext': 0,
+    // Live Region Attributes
+    'aria-atomic': 0,
+    'aria-busy': 0,
+    'aria-live': 0,
+    'aria-relevant': 0,
+    // Drag-and-Drop Attributes
+    'aria-dropeffect': 0,
+    'aria-grabbed': 0,
+    // Relationship Attributes
+    'aria-activedescendant': 0,
+    'aria-colcount': 0,
+    'aria-colindex': 0,
+    'aria-colspan': 0,
+    'aria-controls': 0,
+    'aria-describedby': 0,
+    'aria-errormessage': 0,
+    'aria-flowto': 0,
+    'aria-labelledby': 0,
+    'aria-owns': 0,
+    'aria-posinset': 0,
+    'aria-rowcount': 0,
+    'aria-rowindex': 0,
+    'aria-rowspan': 0,
+    'aria-setsize': 0
+  };
+
+  var warnedProperties = {};
+  var rARIA = new RegExp('^(aria)-[' + ATTRIBUTE_NAME_CHAR + ']*$');
+  var rARIACamel = new RegExp('^(aria)[A-Z][' + ATTRIBUTE_NAME_CHAR + ']*$');
+  var hasOwnProperty$1 = Object.prototype.hasOwnProperty;
+
+  function validateProperty(tagName, name) {
+    {
+      if (hasOwnProperty$1.call(warnedProperties, name) && warnedProperties[name]) {
+        return true;
+      }
+
+      if (rARIACamel.test(name)) {
+        var ariaName = 'aria-' + name.slice(4).toLowerCase();
+        var correctName = ariaProperties.hasOwnProperty(ariaName) ? ariaName : null; // If this is an aria-* attribute, but is not listed in the known DOM
+        // DOM properties, then it is an invalid aria-* attribute.
+
+        if (correctName == null) {
+          error('Invalid ARIA attribute `%s`. ARIA attributes follow the pattern aria-* and must be lowercase.', name);
+
+          warnedProperties[name] = true;
+          return true;
+        } // aria-* attributes should be lowercase; suggest the lowercase version.
+
+
+        if (name !== correctName) {
+          error('Invalid ARIA attribute `%s`. Did you mean `%s`?', name, correctName);
+
+          warnedProperties[name] = true;
+          return true;
+        }
+      }
+
+      if (rARIA.test(name)) {
+        var lowerCasedName = name.toLowerCase();
+        var standardName = ariaProperties.hasOwnProperty(lowerCasedName) ? lowerCasedName : null; // If this is an aria-* attribute, but is not listed in the known DOM
+        // DOM properties, then it is an invalid aria-* attribute.
+
+        if (standardName == null) {
+          warnedProperties[name] = true;
+          return false;
+        } // aria-* attributes should be lowercase; suggest the lowercase version.
+
+
+        if (name !== standardName) {
+          error('Unknown ARIA attribute `%s`. Did you mean `%s`?', name, standardName);
+
+          warnedProperties[name] = true;
+          return true;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  function warnInvalidARIAProps(type, props) {
+    {
+      var invalidProps = [];
+
+      for (var key in props) {
+        var isValid = validateProperty(type, key);
+
+        if (!isValid) {
+          invalidProps.push(key);
+        }
+      }
+
+      var unknownPropString = invalidProps.map(function (prop) {
+        return '`' + prop + '`';
+      }).join(', ');
+
+      if (invalidProps.length === 1) {
+        error('Invalid aria prop %s on <%s> tag. ' + 'For details, see https://reactjs.org/link/invalid-aria-props', unknownPropString, type);
+      } else if (invalidProps.length > 1) {
+        error('Invalid aria props %s on <%s> tag. ' + 'For details, see https://reactjs.org/link/invalid-aria-props', unknownPropString, type);
+      }
+    }
+  }
+
+  function validateProperties(type, props) {
+    if (isCustomComponent(type, props)) {
+      return;
+    }
+
+    warnInvalidARIAProps(type, props);
+  }
+
+  var didWarnValueNull = false;
+  function validateProperties$1(type, props) {
+    {
+      if (type !== 'input' && type !== 'textarea' && type !== 'select') {
+        return;
+      }
+
+      if (props != null && props.value === null && !didWarnValueNull) {
+        didWarnValueNull = true;
+
+        if (type === 'select' && props.multiple) {
+          error('`value` prop on `%s` should not be null. ' + 'Consider using an empty array when `multiple` is set to `true` ' + 'to clear the component or `undefined` for uncontrolled components.', type);
+        } else {
+          error('`value` prop on `%s` should not be null. ' + 'Consider using an empty string to clear the component or `undefined` ' + 'for uncontrolled components.', type);
+        }
+      }
+    }
+  }
+
+  var validateProperty$1 = function () {};
+
+  {
+    var warnedProperties$1 = {};
+    var _hasOwnProperty = Object.prototype.hasOwnProperty;
+    var EVENT_NAME_REGEX = /^on./;
+    var INVALID_EVENT_NAME_REGEX = /^on[^A-Z]/;
+    var rARIA$1 = new RegExp('^(aria)-[' + ATTRIBUTE_NAME_CHAR + ']*$');
+    var rARIACamel$1 = new RegExp('^(aria)[A-Z][' + ATTRIBUTE_NAME_CHAR + ']*$');
+
+    validateProperty$1 = function (tagName, name, value, eventRegistry) {
+      if (_hasOwnProperty.call(warnedProperties$1, name) && warnedProperties$1[name]) {
+        return true;
+      }
+
+      var lowerCasedName = name.toLowerCase();
+
+      if (lowerCasedName === 'onfocusin' || lowerCasedName === 'onfocusout') {
+        error('React uses onFocus and onBlur instead of onFocusIn and onFocusOut. ' + 'All React events are normalized to bubble, so onFocusIn and onFocusOut ' + 'are not needed/supported by React.');
+
+        warnedProperties$1[name] = true;
+        return true;
+      } // We can't rely on the event system being injected on the server.
+
+
+      if (eventRegistry != null) {
+        var registrationNameDependencies = eventRegistry.registrationNameDependencies,
+            possibleRegistrationNames = eventRegistry.possibleRegistrationNames;
+
+        if (registrationNameDependencies.hasOwnProperty(name)) {
+          return true;
+        }
+
+        var registrationName = possibleRegistrationNames.hasOwnProperty(lowerCasedName) ? possibleRegistrationNames[lowerCasedName] : null;
+
+        if (registrationName != null) {
+          error('Invalid event handler property `%s`. Did you mean `%s`?', name, registrationName);
+
+          warnedProperties$1[name] = true;
+          return true;
+        }
+
+        if (EVENT_NAME_REGEX.test(name)) {
+          error('Unknown event handler property `%s`. It will be ignored.', name);
+
+          warnedProperties$1[name] = true;
+          return true;
+        }
+      } else if (EVENT_NAME_REGEX.test(name)) {
+        // If no event plugins have been injected, we are in a server environment.
+        // So we can't tell if the event name is correct for sure, but we can filter
+        // out known bad ones like `onclick`. We can't suggest a specific replacement though.
+        if (INVALID_EVENT_NAME_REGEX.test(name)) {
+          error('Invalid event handler property `%s`. ' + 'React events use the camelCase naming convention, for example `onClick`.', name);
+        }
+
+        warnedProperties$1[name] = true;
+        return true;
+      } // Let the ARIA attribute hook validate ARIA attributes
+
+
+      if (rARIA$1.test(name) || rARIACamel$1.test(name)) {
+        return true;
+      }
+
+      if (lowerCasedName === 'innerhtml') {
+        error('Directly setting property `innerHTML` is not permitted. ' + 'For more information, lookup documentation on `dangerouslySetInnerHTML`.');
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      if (lowerCasedName === 'aria') {
+        error('The `aria` attribute is reserved for future use in React. ' + 'Pass individual `aria-` attributes instead.');
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      if (lowerCasedName === 'is' && value !== null && value !== undefined && typeof value !== 'string') {
+        error('Received a `%s` for a string attribute `is`. If this is expected, cast ' + 'the value to a string.', typeof value);
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      if (typeof value === 'number' && isNaN(value)) {
+        error('Received NaN for the `%s` attribute. If this is expected, cast ' + 'the value to a string.', name);
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      var propertyInfo = getPropertyInfo(name);
+      var isReserved = propertyInfo !== null && propertyInfo.type === RESERVED; // Known attributes should match the casing specified in the property config.
+
+      if (possibleStandardNames.hasOwnProperty(lowerCasedName)) {
+        var standardName = possibleStandardNames[lowerCasedName];
+
+        if (standardName !== name) {
+          error('Invalid DOM property `%s`. Did you mean `%s`?', name, standardName);
+
+          warnedProperties$1[name] = true;
+          return true;
+        }
+      } else if (!isReserved && name !== lowerCasedName) {
+        // Unknown attributes should have lowercase casing since that's how they
+        // will be cased anyway with server rendering.
+        error('React does not recognize the `%s` prop on a DOM element. If you ' + 'intentionally want it to appear in the DOM as a custom ' + 'attribute, spell it as lowercase `%s` instead. ' + 'If you accidentally passed it from a parent component, remove ' + 'it from the DOM element.', name, lowerCasedName);
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      if (typeof value === 'boolean' && shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)) {
+        if (value) {
+          error('Received `%s` for a non-boolean attribute `%s`.\n\n' + 'If you want to write it to the DOM, pass a string instead: ' + '%s="%s" or %s={value.toString()}.', value, name, name, value, name);
+        } else {
+          error('Received `%s` for a non-boolean attribute `%s`.\n\n' + 'If you want to write it to the DOM, pass a string instead: ' + '%s="%s" or %s={value.toString()}.\n\n' + 'If you used to conditionally omit it with %s={condition && value}, ' + 'pass %s={condition ? value : undefined} instead.', value, name, name, value, name, name, name);
+        }
+
+        warnedProperties$1[name] = true;
+        return true;
+      } // Now that we've validated casing, do not validate
+      // data types for reserved props
+
+
+      if (isReserved) {
+        return true;
+      } // Warn when a known attribute is a bad type
+
+
+      if (shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)) {
+        warnedProperties$1[name] = true;
+        return false;
+      } // Warn when passing the strings 'false' or 'true' into a boolean prop
+
+
+      if ((value === 'false' || value === 'true') && propertyInfo !== null && propertyInfo.type === BOOLEAN) {
+        error('Received the string `%s` for the boolean attribute `%s`. ' + '%s ' + 'Did you mean %s={%s}?', value, name, value === 'false' ? 'The browser will interpret it as a truthy value.' : 'Although this works, it will not work as expected if you pass the string "false".', name, value);
+
+        warnedProperties$1[name] = true;
+        return true;
+      }
+
+      return true;
+    };
+  }
+
+  var warnUnknownProperties = function (type, props, eventRegistry) {
+    {
+      var unknownProps = [];
+
+      for (var key in props) {
+        var isValid = validateProperty$1(type, key, props[key], eventRegistry);
+
+        if (!isValid) {
+          unknownProps.push(key);
+        }
+      }
+
+      var unknownPropString = unknownProps.map(function (prop) {
+        return '`' + prop + '`';
+      }).join(', ');
+
+      if (unknownProps.length === 1) {
+        error('Invalid value for prop %s on <%s> tag. Either remove it from the element, ' + 'or pass a string or number value to keep it in the DOM. ' + 'For details, see https://reactjs.org/link/attribute-behavior ', unknownPropString, type);
+      } else if (unknownProps.length > 1) {
+        error('Invalid values for props %s on <%s> tag. Either remove them from the element, ' + 'or pass a string or number value to keep them in the DOM. ' + 'For details, see https://reactjs.org/link/attribute-behavior ', unknownPropString, type);
+      }
+    }
+  };
+
+  function validateProperties$2(type, props, eventRegistry) {
+    if (isCustomComponent(type, props)) {
+      return;
+    }
+
+    warnUnknownProperties(type, props, eventRegistry);
+  }
+
+  var IS_EVENT_HANDLE_NON_MANAGED_NODE = 1;
+  var IS_NON_DELEGATED = 1 << 1;
+  var IS_CAPTURE_PHASE = 1 << 2;
+  var IS_REPLAYED = 1 << 4;
+  // set to LEGACY_FB_SUPPORT. LEGACY_FB_SUPPORT only gets set when
+  // we call willDeferLaterForLegacyFBSupport, thus not bailing out
+  // will result in endless cycles like an infinite loop.
+  // We also don't want to defer during event replaying.
+
+  var SHOULD_NOT_PROCESS_POLYFILL_EVENT_PLUGINS = IS_EVENT_HANDLE_NON_MANAGED_NODE | IS_NON_DELEGATED | IS_CAPTURE_PHASE;
+
+  /**
+   * Gets the target node from a native browser event by accounting for
+   * inconsistencies in browser DOM APIs.
+   *
+   * @param {object} nativeEvent Native browser event.
+   * @return {DOMEventTarget} Target node.
+   */
+
+  function getEventTarget(nativeEvent) {
+    // Fallback to nativeEvent.srcElement for IE9
+    // https://github.com/facebook/react/issues/12506
+    var target = nativeEvent.target || nativeEvent.srcElement || window; // Normalize SVG <use> element events #4963
+
+    if (target.correspondingUseElement) {
+      target = target.correspondingUseElement;
+    } // Safari may fire events on text nodes (Node.TEXT_NODE is 3).
+    // @see http://www.quirksmode.org/js/events_properties.html
+
+
+    return target.nodeType === TEXT_NODE ? target.parentNode : target;
+  }
+
+  var restoreImpl = null;
+  var restoreTarget = null;
+  var restoreQueue = null;
+
+  function restoreStateOfTarget(target) {
+    // We perform this translation at the end of the event loop so that we
+    // always receive the correct fiber here
+    var internalInstance = getInstanceFromNode(target);
+
+    if (!internalInstance) {
+      // Unmounted
+      return;
+    }
+
+    if (!(typeof restoreImpl === 'function')) {
+      {
+        throw Error( "setRestoreImplementation() needs to be called to handle a target for controlled events. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+
+    var stateNode = internalInstance.stateNode; // Guard against Fiber being unmounted.
+
+    if (stateNode) {
+      var _props = getFiberCurrentPropsFromNode(stateNode);
+
+      restoreImpl(internalInstance.stateNode, internalInstance.type, _props);
+    }
+  }
+
+  function setRestoreImplementation(impl) {
+    restoreImpl = impl;
+  }
+  function enqueueStateRestore(target) {
+    if (restoreTarget) {
+      if (restoreQueue) {
+        restoreQueue.push(target);
+      } else {
+        restoreQueue = [target];
+      }
+    } else {
+      restoreTarget = target;
+    }
+  }
+  function needsStateRestore() {
+    return restoreTarget !== null || restoreQueue !== null;
+  }
+  function restoreStateIfNeeded() {
+    if (!restoreTarget) {
+      return;
+    }
+
+    var target = restoreTarget;
+    var queuedTargets = restoreQueue;
+    restoreTarget = null;
+    restoreQueue = null;
+    restoreStateOfTarget(target);
+
+    if (queuedTargets) {
+      for (var i = 0; i < queuedTargets.length; i++) {
+        restoreStateOfTarget(queuedTargets[i]);
+      }
+    }
+  }
+
+  // the renderer. Such as when we're dispatching events or if third party
+  // libraries need to call batchedUpdates. Eventually, this API will go away when
+  // everything is batched by default. We'll then have a similar API to opt-out of
+  // scheduled work and instead do synchronous work.
+  // Defaults
+
+  var batchedUpdatesImpl = function (fn, bookkeeping) {
+    return fn(bookkeeping);
+  };
+
+  var discreteUpdatesImpl = function (fn, a, b, c, d) {
+    return fn(a, b, c, d);
+  };
+
+  var flushDiscreteUpdatesImpl = function () {};
+
+  var batchedEventUpdatesImpl = batchedUpdatesImpl;
+  var isInsideEventHandler = false;
+  var isBatchingEventUpdates = false;
+
+  function finishEventHandler() {
+    // Here we wait until all updates have propagated, which is important
+    // when using controlled components within layers:
+    // https://github.com/facebook/react/issues/1698
+    // Then we restore state of any controlled component.
+    var controlledComponentsHavePendingUpdates = needsStateRestore();
+
+    if (controlledComponentsHavePendingUpdates) {
+      // If a controlled event was fired, we may need to restore the state of
+      // the DOM node back to the controlled value. This is necessary when React
+      // bails out of the update without touching the DOM.
+      flushDiscreteUpdatesImpl();
+      restoreStateIfNeeded();
+    }
+  }
+
+  function batchedUpdates(fn, bookkeeping) {
+    if (isInsideEventHandler) {
+      // If we are currently inside another batch, we need to wait until it
+      // fully completes before restoring state.
+      return fn(bookkeeping);
+    }
+
+    isInsideEventHandler = true;
+
+    try {
+      return batchedUpdatesImpl(fn, bookkeeping);
+    } finally {
+      isInsideEventHandler = false;
+      finishEventHandler();
+    }
+  }
+  function batchedEventUpdates(fn, a, b) {
+    if (isBatchingEventUpdates) {
+      // If we are currently inside another batch, we need to wait until it
+      // fully completes before restoring state.
+      return fn(a, b);
+    }
+
+    isBatchingEventUpdates = true;
+
+    try {
+      return batchedEventUpdatesImpl(fn, a, b);
+    } finally {
+      isBatchingEventUpdates = false;
+      finishEventHandler();
+    }
+  }
+  function discreteUpdates(fn, a, b, c, d) {
+    var prevIsInsideEventHandler = isInsideEventHandler;
+    isInsideEventHandler = true;
+
+    try {
+      return discreteUpdatesImpl(fn, a, b, c, d);
+    } finally {
+      isInsideEventHandler = prevIsInsideEventHandler;
+
+      if (!isInsideEventHandler) {
+        finishEventHandler();
+      }
+    }
+  }
+  function flushDiscreteUpdatesIfNeeded(timeStamp) {
+    {
+      if (!isInsideEventHandler) {
+        flushDiscreteUpdatesImpl();
+      }
+    }
+  }
+  function setBatchingImplementation(_batchedUpdatesImpl, _discreteUpdatesImpl, _flushDiscreteUpdatesImpl, _batchedEventUpdatesImpl) {
+    batchedUpdatesImpl = _batchedUpdatesImpl;
+    discreteUpdatesImpl = _discreteUpdatesImpl;
+    flushDiscreteUpdatesImpl = _flushDiscreteUpdatesImpl;
+    batchedEventUpdatesImpl = _batchedEventUpdatesImpl;
+  }
+
+  function isInteractive(tag) {
+    return tag === 'button' || tag === 'input' || tag === 'select' || tag === 'textarea';
+  }
+
+  function shouldPreventMouseEvent(name, type, props) {
+    switch (name) {
+      case 'onClick':
+      case 'onClickCapture':
+      case 'onDoubleClick':
+      case 'onDoubleClickCapture':
+      case 'onMouseDown':
+      case 'onMouseDownCapture':
+      case 'onMouseMove':
+      case 'onMouseMoveCapture':
+      case 'onMouseUp':
+      case 'onMouseUpCapture':
+      case 'onMouseEnter':
+        return !!(props.disabled && isInteractive(type));
+
+      default:
+        return false;
+    }
+  }
+  /**
+   * @param {object} inst The instance, which is the source of events.
+   * @param {string} registrationName Name of listener (e.g. `onClick`).
+   * @return {?function} The stored callback.
+   */
+
+
+  function getListener(inst, registrationName) {
+    var stateNode = inst.stateNode;
+
+    if (stateNode === null) {
+      // Work in progress (ex: onload events in incremental mode).
+      return null;
+    }
+
+    var props = getFiberCurrentPropsFromNode(stateNode);
+
+    if (props === null) {
+      // Work in progress.
+      return null;
+    }
+
+    var listener = props[registrationName];
+
+    if (shouldPreventMouseEvent(registrationName, inst.type, props)) {
+      return null;
+    }
+
+    if (!(!listener || typeof listener === 'function')) {
+      {
+        throw Error( "Expected `" + registrationName + "` listener to be a function, instead got a value of `" + typeof listener + "` type." );
+      }
+    }
+
+    return listener;
+  }
+
+  var passiveBrowserEventsSupported = false; // Check if browser support events with passive listeners
+  // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Safely_detecting_option_support
+
+  if (canUseDOM) {
+    try {
+      var options = {}; // $FlowFixMe: Ignore Flow complaining about needing a value
+
+      Object.defineProperty(options, 'passive', {
+        get: function () {
+          passiveBrowserEventsSupported = true;
+        }
+      });
+      window.addEventListener('test', options, options);
+      window.removeEventListener('test', options, options);
+    } catch (e) {
+      passiveBrowserEventsSupported = false;
+    }
+  }
+
+  function invokeGuardedCallbackProd(name, func, context, a, b, c, d, e, f) {
+    var funcArgs = Array.prototype.slice.call(arguments, 3);
+
+    try {
+      func.apply(context, funcArgs);
+    } catch (error) {
+      this.onError(error);
+    }
+  }
+
+  var invokeGuardedCallbackImpl = invokeGuardedCallbackProd;
+
+  {
+    // In DEV mode, we swap out invokeGuardedCallback for a special version
+    // that plays more nicely with the browser's DevTools. The idea is to preserve
+    // "Pause on exceptions" behavior. Because React wraps all user-provided
+    // functions in invokeGuardedCallback, and the production version of
+    // invokeGuardedCallback uses a try-catch, all user exceptions are treated
+    // like caught exceptions, and the DevTools won't pause unless the developer
+    // takes the extra step of enabling pause on caught exceptions. This is
+    // unintuitive, though, because even though React has caught the error, from
+    // the developer's perspective, the error is uncaught.
+    //
+    // To preserve the expected "Pause on exceptions" behavior, we don't use a
+    // try-catch in DEV. Instead, we synchronously dispatch a fake event to a fake
+    // DOM node, and call the user-provided callback from inside an event handler
+    // for that fake event. If the callback throws, the error is "captured" using
+    // a global event handler. But because the error happens in a different
+    // event loop context, it does not interrupt the normal program flow.
+    // Effectively, this gives us try-catch behavior without actually using
+    // try-catch. Neat!
+    // Check that the browser supports the APIs we need to implement our special
+    // DEV version of invokeGuardedCallback
+    if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function' && typeof document !== 'undefined' && typeof document.createEvent === 'function') {
+      var fakeNode = document.createElement('react');
+
+      invokeGuardedCallbackImpl = function invokeGuardedCallbackDev(name, func, context, a, b, c, d, e, f) {
+        // If document doesn't exist we know for sure we will crash in this method
+        // when we call document.createEvent(). However this can cause confusing
+        // errors: https://github.com/facebookincubator/create-react-app/issues/3482
+        // So we preemptively throw with a better message instead.
+        if (!(typeof document !== 'undefined')) {
+          {
+            throw Error( "The `document` global was defined when React was initialized, but is not defined anymore. This can happen in a test environment if a component schedules an update from an asynchronous callback, but the test has already finished running. To solve this, you can either unmount the component at the end of your test (and ensure that any asynchronous operations get canceled in `componentWillUnmount`), or you can change the test itself to be asynchronous." );
+          }
+        }
+
+        var evt = document.createEvent('Event');
+        var didCall = false; // Keeps track of whether the user-provided callback threw an error. We
+        // set this to true at the beginning, then set it to false right after
+        // calling the function. If the function errors, `didError` will never be
+        // set to false. This strategy works even if the browser is flaky and
+        // fails to call our global error handler, because it doesn't rely on
+        // the error event at all.
+
+        var didError = true; // Keeps track of the value of window.event so that we can reset it
+        // during the callback to let user code access window.event in the
+        // browsers that support it.
+
+        var windowEvent = window.event; // Keeps track of the descriptor of window.event to restore it after event
+        // dispatching: https://github.com/facebook/react/issues/13688
+
+        var windowEventDescriptor = Object.getOwnPropertyDescriptor(window, 'event');
+
+        function restoreAfterDispatch() {
+          // We immediately remove the callback from event listeners so that
+          // nested `invokeGuardedCallback` calls do not clash. Otherwise, a
+          // nested call would trigger the fake event handlers of any call higher
+          // in the stack.
+          fakeNode.removeEventListener(evtType, callCallback, false); // We check for window.hasOwnProperty('event') to prevent the
+          // window.event assignment in both IE <= 10 as they throw an error
+          // "Member not found" in strict mode, and in Firefox which does not
+          // support window.event.
+
+          if (typeof window.event !== 'undefined' && window.hasOwnProperty('event')) {
+            window.event = windowEvent;
+          }
+        } // Create an event handler for our fake event. We will synchronously
+        // dispatch our fake event using `dispatchEvent`. Inside the handler, we
+        // call the user-provided callback.
+
+
+        var funcArgs = Array.prototype.slice.call(arguments, 3);
+
+        function callCallback() {
+          didCall = true;
+          restoreAfterDispatch();
+          func.apply(context, funcArgs);
+          didError = false;
+        } // Create a global error event handler. We use this to capture the value
+        // that was thrown. It's possible that this error handler will fire more
+        // than once; for example, if non-React code also calls `dispatchEvent`
+        // and a handler for that event throws. We should be resilient to most of
+        // those cases. Even if our error event handler fires more than once, the
+        // last error event is always used. If the callback actually does error,
+        // we know that the last error event is the correct one, because it's not
+        // possible for anything else to have happened in between our callback
+        // erroring and the code that follows the `dispatchEvent` call below. If
+        // the callback doesn't error, but the error event was fired, we know to
+        // ignore it because `didError` will be false, as described above.
+
+
+        var error; // Use this to track whether the error event is ever called.
+
+        var didSetError = false;
+        var isCrossOriginError = false;
+
+        function handleWindowError(event) {
+          error = event.error;
+          didSetError = true;
+
+          if (error === null && event.colno === 0 && event.lineno === 0) {
+            isCrossOriginError = true;
+          }
+
+          if (event.defaultPrevented) {
+            // Some other error handler has prevented default.
+            // Browsers silence the error report if this happens.
+            // We'll remember this to later decide whether to log it or not.
+            if (error != null && typeof error === 'object') {
+              try {
+                error._suppressLogging = true;
+              } catch (inner) {// Ignore.
+              }
+            }
+          }
+        } // Create a fake event type.
+
+
+        var evtType = "react-" + (name ? name : 'invokeguardedcallback'); // Attach our event handlers
+
+        window.addEventListener('error', handleWindowError);
+        fakeNode.addEventListener(evtType, callCallback, false); // Synchronously dispatch our fake event. If the user-provided function
+        // errors, it will trigger our global error handler.
+
+        evt.initEvent(evtType, false, false);
+        fakeNode.dispatchEvent(evt);
+
+        if (windowEventDescriptor) {
+          Object.defineProperty(window, 'event', windowEventDescriptor);
+        }
+
+        if (didCall && didError) {
+          if (!didSetError) {
+            // The callback errored, but the error event never fired.
+            error = new Error('An error was thrown inside one of your components, but React ' + "doesn't know what it was. This is likely due to browser " + 'flakiness. React does its best to preserve the "Pause on ' + 'exceptions" behavior of the DevTools, which requires some ' + "DEV-mode only tricks. It's possible that these don't work in " + 'your browser. Try triggering the error in production mode, ' + 'or switching to a modern browser. If you suspect that this is ' + 'actually an issue with React, please file an issue.');
+          } else if (isCrossOriginError) {
+            error = new Error("A cross-origin error was thrown. React doesn't have access to " + 'the actual error object in development. ' + 'See https://reactjs.org/link/crossorigin-error for more information.');
+          }
+
+          this.onError(error);
+        } // Remove our event listeners
+
+
+        window.removeEventListener('error', handleWindowError);
+
+        if (!didCall) {
+          // Something went really wrong, and our event was not dispatched.
+          // https://github.com/facebook/react/issues/16734
+          // https://github.com/facebook/react/issues/16585
+          // Fall back to the production implementation.
+          restoreAfterDispatch();
+          return invokeGuardedCallbackProd.apply(this, arguments);
+        }
+      };
+    }
+  }
+
+  var invokeGuardedCallbackImpl$1 = invokeGuardedCallbackImpl;
+
+  var hasError = false;
+  var caughtError = null; // Used by event system to capture/rethrow the first error.
+
+  var hasRethrowError = false;
+  var rethrowError = null;
+  var reporter = {
+    onError: function (error) {
+      hasError = true;
+      caughtError = error;
+    }
+  };
+  /**
+   * Call a function while guarding against errors that happens within it.
+   * Returns an error if it throws, otherwise null.
+   *
+   * In production, this is implemented using a try-catch. The reason we don't
+   * use a try-catch directly is so that we can swap out a different
+   * implementation in DEV mode.
+   *
+   * @param {String} name of the guard to use for logging or debugging
+   * @param {Function} func The function to invoke
+   * @param {*} context The context to use when calling the function
+   * @param {...*} args Arguments for function
+   */
+
+  function invokeGuardedCallback(name, func, context, a, b, c, d, e, f) {
+    hasError = false;
+    caughtError = null;
+    invokeGuardedCallbackImpl$1.apply(reporter, arguments);
+  }
+  /**
+   * Same as invokeGuardedCallback, but instead of returning an error, it stores
+   * it in a global so it can be rethrown by `rethrowCaughtError` later.
+   * TODO: See if caughtError and rethrowError can be unified.
+   *
+   * @param {String} name of the guard to use for logging or debugging
+   * @param {Function} func The function to invoke
+   * @param {*} context The context to use when calling the function
+   * @param {...*} args Arguments for function
+   */
+
+  function invokeGuardedCallbackAndCatchFirstError(name, func, context, a, b, c, d, e, f) {
+    invokeGuardedCallback.apply(this, arguments);
+
+    if (hasError) {
+      var error = clearCaughtError();
+
+      if (!hasRethrowError) {
+        hasRethrowError = true;
+        rethrowError = error;
+      }
+    }
+  }
+  /**
+   * During execution of guarded functions we will capture the first error which
+   * we will rethrow to be handled by the top level error handler.
+   */
+
+  function rethrowCaughtError() {
+    if (hasRethrowError) {
+      var error = rethrowError;
+      hasRethrowError = false;
+      rethrowError = null;
+      throw error;
+    }
+  }
+  function hasCaughtError() {
+    return hasError;
+  }
+  function clearCaughtError() {
+    if (hasError) {
+      var error = caughtError;
+      hasError = false;
+      caughtError = null;
+      return error;
+    } else {
+      {
+        {
+          throw Error( "clearCaughtError was called but no error was captured. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+    }
+  }
+
+  var ReactInternals$1 = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+  var _ReactInternals$Sched = ReactInternals$1.Scheduler,
+      unstable_cancelCallback = _ReactInternals$Sched.unstable_cancelCallback,
+      unstable_now = _ReactInternals$Sched.unstable_now,
+      unstable_scheduleCallback = _ReactInternals$Sched.unstable_scheduleCallback,
+      unstable_shouldYield = _ReactInternals$Sched.unstable_shouldYield,
+      unstable_requestPaint = _ReactInternals$Sched.unstable_requestPaint,
+      unstable_getFirstCallbackNode = _ReactInternals$Sched.unstable_getFirstCallbackNode,
+      unstable_runWithPriority = _ReactInternals$Sched.unstable_runWithPriority,
+      unstable_next = _ReactInternals$Sched.unstable_next,
+      unstable_continueExecution = _ReactInternals$Sched.unstable_continueExecution,
+      unstable_pauseExecution = _ReactInternals$Sched.unstable_pauseExecution,
+      unstable_getCurrentPriorityLevel = _ReactInternals$Sched.unstable_getCurrentPriorityLevel,
+      unstable_ImmediatePriority = _ReactInternals$Sched.unstable_ImmediatePriority,
+      unstable_UserBlockingPriority = _ReactInternals$Sched.unstable_UserBlockingPriority,
+      unstable_NormalPriority = _ReactInternals$Sched.unstable_NormalPriority,
+      unstable_LowPriority = _ReactInternals$Sched.unstable_LowPriority,
+      unstable_IdlePriority = _ReactInternals$Sched.unstable_IdlePriority,
+      unstable_forceFrameRate = _ReactInternals$Sched.unstable_forceFrameRate,
+      unstable_flushAllWithoutAsserting = _ReactInternals$Sched.unstable_flushAllWithoutAsserting;
+
+  /**
+   * `ReactInstanceMap` maintains a mapping from a public facing stateful
+   * instance (key) and the internal representation (value). This allows public
+   * methods to accept the user facing instance as an argument and map them back
+   * to internal methods.
+   *
+   * Note that this module is currently shared and assumed to be stateless.
+   * If this becomes an actual Map, that will break.
+   */
+  function get(key) {
+    return key._reactInternals;
+  }
+  function has(key) {
+    return key._reactInternals !== undefined;
+  }
+  function set(key, value) {
+    key._reactInternals = value;
+  }
+
+  // Don't change these two values. They're used by React Dev Tools.
+  var NoFlags =
+  /*                      */
+  0;
+  var PerformedWork =
+  /*                */
+  1; // You can change the rest (and add more).
+
+  var Placement =
+  /*                    */
+  2;
+  var Update =
+  /*                       */
+  4;
+  var PlacementAndUpdate =
+  /*           */
+  6;
+  var Deletion =
+  /*                     */
+  8;
+  var ContentReset =
+  /*                 */
+  16;
+  var Callback =
+  /*                     */
+  32;
+  var DidCapture =
+  /*                   */
+  64;
+  var Ref =
+  /*                          */
+  128;
+  var Snapshot =
+  /*                     */
+  256;
+  var Passive =
+  /*                      */
+  512; // TODO (effects) Remove this bit once the new reconciler is synced to the old.
+
+  var PassiveUnmountPendingDev =
+  /*     */
+  8192;
+  var Hydrating =
+  /*                    */
+  1024;
+  var HydratingAndUpdate =
+  /*           */
+  1028; // Passive & Update & Callback & Ref & Snapshot
+
+  var LifecycleEffectMask =
+  /*          */
+  932; // Union of all host effects
+
+  var HostEffectMask =
+  /*               */
+  2047; // These are not really side effects, but we still reuse this field.
+
+  var Incomplete =
+  /*                   */
+  2048;
+  var ShouldCapture =
+  /*                */
+  4096;
+  var ForceUpdateForLegacySuspense =
+  /* */
+  16384; // Static tags describe aspects of a fiber that are not specific to a render,
+
+  var ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
+  function getNearestMountedFiber(fiber) {
+    var node = fiber;
+    var nearestMounted = fiber;
+
+    if (!fiber.alternate) {
+      // If there is no alternate, this might be a new tree that isn't inserted
+      // yet. If it is, then it will have a pending insertion effect on it.
+      var nextNode = node;
+
+      do {
+        node = nextNode;
+
+        if ((node.flags & (Placement | Hydrating)) !== NoFlags) {
+          // This is an insertion or in-progress hydration. The nearest possible
+          // mounted fiber is the parent but we need to continue to figure out
+          // if that one is still mounted.
+          nearestMounted = node.return;
+        }
+
+        nextNode = node.return;
+      } while (nextNode);
+    } else {
+      while (node.return) {
+        node = node.return;
+      }
+    }
+
+    if (node.tag === HostRoot) {
+      // TODO: Check if this was a nested HostRoot when used with
+      // renderContainerIntoSubtree.
+      return nearestMounted;
+    } // If we didn't hit the root, that means that we're in an disconnected tree
+    // that has been unmounted.
+
+
+    return null;
+  }
+  function getSuspenseInstanceFromFiber(fiber) {
+    if (fiber.tag === SuspenseComponent) {
+      var suspenseState = fiber.memoizedState;
+
+      if (suspenseState === null) {
+        var current = fiber.alternate;
+
+        if (current !== null) {
+          suspenseState = current.memoizedState;
+        }
+      }
+
+      if (suspenseState !== null) {
+        return suspenseState.dehydrated;
+      }
+    }
+
+    return null;
+  }
+  function getContainerFromFiber(fiber) {
+    return fiber.tag === HostRoot ? fiber.stateNode.containerInfo : null;
+  }
+  function isFiberMounted(fiber) {
+    return getNearestMountedFiber(fiber) === fiber;
+  }
+  function isMounted(component) {
+    {
+      var owner = ReactCurrentOwner.current;
+
+      if (owner !== null && owner.tag === ClassComponent) {
+        var ownerFiber = owner;
+        var instance = ownerFiber.stateNode;
+
+        if (!instance._warnedAboutRefsInRender) {
+          error('%s is accessing isMounted inside its render() function. ' + 'render() should be a pure function of props and state. It should ' + 'never access something that requires stale data from the previous ' + 'render, such as refs. Move this logic to componentDidMount and ' + 'componentDidUpdate instead.', getComponentName(ownerFiber.type) || 'A component');
+        }
+
+        instance._warnedAboutRefsInRender = true;
+      }
+    }
+
+    var fiber = get(component);
+
+    if (!fiber) {
+      return false;
+    }
+
+    return getNearestMountedFiber(fiber) === fiber;
+  }
+
+  function assertIsMounted(fiber) {
+    if (!(getNearestMountedFiber(fiber) === fiber)) {
+      {
+        throw Error( "Unable to find node on an unmounted component." );
+      }
+    }
+  }
+
+  function findCurrentFiberUsingSlowPath(fiber) {
+    var alternate = fiber.alternate;
+
+    if (!alternate) {
+      // If there is no alternate, then we only need to check if it is mounted.
+      var nearestMounted = getNearestMountedFiber(fiber);
+
+      if (!(nearestMounted !== null)) {
+        {
+          throw Error( "Unable to find node on an unmounted component." );
+        }
+      }
+
+      if (nearestMounted !== fiber) {
+        return null;
+      }
+
+      return fiber;
+    } // If we have two possible branches, we'll walk backwards up to the root
+    // to see what path the root points to. On the way we may hit one of the
+    // special cases and we'll deal with them.
+
+
+    var a = fiber;
+    var b = alternate;
+
+    while (true) {
+      var parentA = a.return;
+
+      if (parentA === null) {
+        // We're at the root.
+        break;
+      }
+
+      var parentB = parentA.alternate;
+
+      if (parentB === null) {
+        // There is no alternate. This is an unusual case. Currently, it only
+        // happens when a Suspense component is hidden. An extra fragment fiber
+        // is inserted in between the Suspense fiber and its children. Skip
+        // over this extra fragment fiber and proceed to the next parent.
+        var nextParent = parentA.return;
+
+        if (nextParent !== null) {
+          a = b = nextParent;
+          continue;
+        } // If there's no parent, we're at the root.
+
+
+        break;
+      } // If both copies of the parent fiber point to the same child, we can
+      // assume that the child is current. This happens when we bailout on low
+      // priority: the bailed out fiber's child reuses the current child.
+
+
+      if (parentA.child === parentB.child) {
+        var child = parentA.child;
+
+        while (child) {
+          if (child === a) {
+            // We've determined that A is the current branch.
+            assertIsMounted(parentA);
+            return fiber;
+          }
+
+          if (child === b) {
+            // We've determined that B is the current branch.
+            assertIsMounted(parentA);
+            return alternate;
+          }
+
+          child = child.sibling;
+        } // We should never have an alternate for any mounting node. So the only
+        // way this could possibly happen is if this was unmounted, if at all.
+
+
+        {
+          {
+            throw Error( "Unable to find node on an unmounted component." );
+          }
+        }
+      }
+
+      if (a.return !== b.return) {
+        // The return pointer of A and the return pointer of B point to different
+        // fibers. We assume that return pointers never criss-cross, so A must
+        // belong to the child set of A.return, and B must belong to the child
+        // set of B.return.
+        a = parentA;
+        b = parentB;
+      } else {
+        // The return pointers point to the same fiber. We'll have to use the
+        // default, slow path: scan the child sets of each parent alternate to see
+        // which child belongs to which set.
+        //
+        // Search parent A's child set
+        var didFindChild = false;
+        var _child = parentA.child;
+
+        while (_child) {
+          if (_child === a) {
+            didFindChild = true;
+            a = parentA;
+            b = parentB;
+            break;
+          }
+
+          if (_child === b) {
+            didFindChild = true;
+            b = parentA;
+            a = parentB;
+            break;
+          }
+
+          _child = _child.sibling;
+        }
+
+        if (!didFindChild) {
+          // Search parent B's child set
+          _child = parentB.child;
+
+          while (_child) {
+            if (_child === a) {
+              didFindChild = true;
+              a = parentB;
+              b = parentA;
+              break;
+            }
+
+            if (_child === b) {
+              didFindChild = true;
+              b = parentB;
+              a = parentA;
+              break;
+            }
+
+            _child = _child.sibling;
+          }
+
+          if (!didFindChild) {
+            {
+              throw Error( "Child was not found in either parent set. This indicates a bug in React related to the return pointer. Please file an issue." );
+            }
+          }
+        }
+      }
+
+      if (!(a.alternate === b)) {
+        {
+          throw Error( "Return fibers should always be each others' alternates. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+    } // If the root is not a host container, we're in a disconnected tree. I.e.
+    // unmounted.
+
+
+    if (!(a.tag === HostRoot)) {
+      {
+        throw Error( "Unable to find node on an unmounted component." );
+      }
+    }
+
+    if (a.stateNode.current === a) {
+      // We've determined that A is the current branch.
+      return fiber;
+    } // Otherwise B has to be current branch.
+
+
+    return alternate;
+  }
+  function findCurrentHostFiber(parent) {
+    var currentParent = findCurrentFiberUsingSlowPath(parent);
+
+    if (!currentParent) {
+      return null;
+    } // Next we'll drill down this component to find the first HostComponent/Text.
+
+
+    var node = currentParent;
+
+    while (true) {
+      if (node.tag === HostComponent || node.tag === HostText) {
+        return node;
+      } else if (node.child) {
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
+
+      if (node === currentParent) {
+        return null;
+      }
+
+      while (!node.sibling) {
+        if (!node.return || node.return === currentParent) {
+          return null;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    } // Flow needs the return null here, but ESLint complains about it.
+    // eslint-disable-next-line no-unreachable
+
+
+    return null;
+  }
+  function findCurrentHostFiberWithNoPortals(parent) {
+    var currentParent = findCurrentFiberUsingSlowPath(parent);
+
+    if (!currentParent) {
+      return null;
+    } // Next we'll drill down this component to find the first HostComponent/Text.
+
+
+    var node = currentParent;
+
+    while (true) {
+      if (node.tag === HostComponent || node.tag === HostText || enableFundamentalAPI ) {
+        return node;
+      } else if (node.child && node.tag !== HostPortal) {
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
+
+      if (node === currentParent) {
+        return null;
+      }
+
+      while (!node.sibling) {
+        if (!node.return || node.return === currentParent) {
+          return null;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    } // Flow needs the return null here, but ESLint complains about it.
+    // eslint-disable-next-line no-unreachable
+
+
+    return null;
+  }
+  function doesFiberContain(parentFiber, childFiber) {
+    var node = childFiber;
+    var parentFiberAlternate = parentFiber.alternate;
+
+    while (node !== null) {
+      if (node === parentFiber || node === parentFiberAlternate) {
+        return true;
+      }
+
+      node = node.return;
+    }
+
+    return false;
+  }
+
+  var attemptUserBlockingHydration;
+  function setAttemptUserBlockingHydration(fn) {
+    attemptUserBlockingHydration = fn;
+  }
+  var attemptContinuousHydration;
+  function setAttemptContinuousHydration(fn) {
+    attemptContinuousHydration = fn;
+  }
+  var attemptHydrationAtCurrentPriority;
+  function setAttemptHydrationAtCurrentPriority(fn) {
+    attemptHydrationAtCurrentPriority = fn;
+  }
+  var attemptHydrationAtPriority;
+  function setAttemptHydrationAtPriority(fn) {
+    attemptHydrationAtPriority = fn;
+  } // TODO: Upgrade this definition once we're on a newer version of Flow that
+  var hasScheduledReplayAttempt = false; // The queue of discrete events to be replayed.
+
+  var queuedDiscreteEvents = []; // Indicates if any continuous event targets are non-null for early bailout.
+  // if the last target was dehydrated.
+
+  var queuedFocus = null;
+  var queuedDrag = null;
+  var queuedMouse = null; // For pointer events there can be one latest event per pointerId.
+
+  var queuedPointers = new Map();
+  var queuedPointerCaptures = new Map(); // We could consider replaying selectionchange and touchmoves too.
+
+  var queuedExplicitHydrationTargets = [];
+  function hasQueuedDiscreteEvents() {
+    return queuedDiscreteEvents.length > 0;
+  }
+  var discreteReplayableEvents = ['mousedown', 'mouseup', 'touchcancel', 'touchend', 'touchstart', 'auxclick', 'dblclick', 'pointercancel', 'pointerdown', 'pointerup', 'dragend', 'dragstart', 'drop', 'compositionend', 'compositionstart', 'keydown', 'keypress', 'keyup', 'input', 'textInput', // Intentionally camelCase
+  'copy', 'cut', 'paste', 'click', 'change', 'contextmenu', 'reset', 'submit'];
+  function isReplayableDiscreteEvent(eventType) {
+    return discreteReplayableEvents.indexOf(eventType) > -1;
+  }
+
+  function createQueuedReplayableEvent(blockedOn, domEventName, eventSystemFlags, targetContainer, nativeEvent) {
+    return {
+      blockedOn: blockedOn,
+      domEventName: domEventName,
+      eventSystemFlags: eventSystemFlags | IS_REPLAYED,
+      nativeEvent: nativeEvent,
+      targetContainers: [targetContainer]
+    };
+  }
+
+  function queueDiscreteEvent(blockedOn, domEventName, eventSystemFlags, targetContainer, nativeEvent) {
+    var queuedEvent = createQueuedReplayableEvent(blockedOn, domEventName, eventSystemFlags, targetContainer, nativeEvent);
+    queuedDiscreteEvents.push(queuedEvent);
+  } // Resets the replaying for this type of continuous event to no event.
+
+  function clearIfContinuousEvent(domEventName, nativeEvent) {
+    switch (domEventName) {
+      case 'focusin':
+      case 'focusout':
+        queuedFocus = null;
+        break;
+
+      case 'dragenter':
+      case 'dragleave':
+        queuedDrag = null;
+        break;
+
+      case 'mouseover':
+      case 'mouseout':
+        queuedMouse = null;
+        break;
+
+      case 'pointerover':
+      case 'pointerout':
+        {
+          var pointerId = nativeEvent.pointerId;
+          queuedPointers.delete(pointerId);
+          break;
+        }
+
+      case 'gotpointercapture':
+      case 'lostpointercapture':
+        {
+          var _pointerId = nativeEvent.pointerId;
+          queuedPointerCaptures.delete(_pointerId);
+          break;
+        }
+    }
+  }
+
+  function accumulateOrCreateContinuousQueuedReplayableEvent(existingQueuedEvent, blockedOn, domEventName, eventSystemFlags, targetContainer, nativeEvent) {
+    if (existingQueuedEvent === null || existingQueuedEvent.nativeEvent !== nativeEvent) {
+      var queuedEvent = createQueuedReplayableEvent(blockedOn, domEventName, eventSystemFlags, targetContainer, nativeEvent);
+
+      if (blockedOn !== null) {
+        var _fiber2 = getInstanceFromNode(blockedOn);
+
+        if (_fiber2 !== null) {
+          // Attempt to increase the priority of this target.
+          attemptContinuousHydration(_fiber2);
+        }
+      }
+
+      return queuedEvent;
+    } // If we have already queued this exact event, then it's because
+    // the different event systems have different DOM event listeners.
+    // We can accumulate the flags, and the targetContainers, and
+    // store a single event to be replayed.
+
+
+    existingQueuedEvent.eventSystemFlags |= eventSystemFlags;
+    var targetContainers = existingQueuedEvent.targetContainers;
+
+    if (targetContainer !== null && targetContainers.indexOf(targetContainer) === -1) {
+      targetContainers.push(targetContainer);
+    }
+
+    return existingQueuedEvent;
+  }
+
+  function queueIfContinuousEvent(blockedOn, domEventName, eventSystemFlags, targetContainer, nativeEvent) {
+    // These set relatedTarget to null because the replayed event will be treated as if we
+    // moved from outside the window (no target) onto the target once it hydrates.
+    // Instead of mutating we could clone the event.
+    switch (domEventName) {
+      case 'focusin':
+        {
+          var focusEvent = nativeEvent;
+          queuedFocus = accumulateOrCreateContinuousQueuedReplayableEvent(queuedFocus, blockedOn, domEventName, eventSystemFlags, targetContainer, focusEvent);
+          return true;
+        }
+
+      case 'dragenter':
+        {
+          var dragEvent = nativeEvent;
+          queuedDrag = accumulateOrCreateContinuousQueuedReplayableEvent(queuedDrag, blockedOn, domEventName, eventSystemFlags, targetContainer, dragEvent);
+          return true;
+        }
+
+      case 'mouseover':
+        {
+          var mouseEvent = nativeEvent;
+          queuedMouse = accumulateOrCreateContinuousQueuedReplayableEvent(queuedMouse, blockedOn, domEventName, eventSystemFlags, targetContainer, mouseEvent);
+          return true;
+        }
+
+      case 'pointerover':
+        {
+          var pointerEvent = nativeEvent;
+          var pointerId = pointerEvent.pointerId;
+          queuedPointers.set(pointerId, accumulateOrCreateContinuousQueuedReplayableEvent(queuedPointers.get(pointerId) || null, blockedOn, domEventName, eventSystemFlags, targetContainer, pointerEvent));
+          return true;
+        }
+
+      case 'gotpointercapture':
+        {
+          var _pointerEvent = nativeEvent;
+          var _pointerId2 = _pointerEvent.pointerId;
+          queuedPointerCaptures.set(_pointerId2, accumulateOrCreateContinuousQueuedReplayableEvent(queuedPointerCaptures.get(_pointerId2) || null, blockedOn, domEventName, eventSystemFlags, targetContainer, _pointerEvent));
+          return true;
+        }
+    }
+
+    return false;
+  } // Check if this target is unblocked. Returns true if it's unblocked.
+
+  function attemptExplicitHydrationTarget(queuedTarget) {
+    // TODO: This function shares a lot of logic with attemptToDispatchEvent.
+    // Try to unify them. It's a bit tricky since it would require two return
+    // values.
+    var targetInst = getClosestInstanceFromNode(queuedTarget.target);
+
+    if (targetInst !== null) {
+      var nearestMounted = getNearestMountedFiber(targetInst);
+
+      if (nearestMounted !== null) {
+        var tag = nearestMounted.tag;
+
+        if (tag === SuspenseComponent) {
+          var instance = getSuspenseInstanceFromFiber(nearestMounted);
+
+          if (instance !== null) {
+            // We're blocked on hydrating this boundary.
+            // Increase its priority.
+            queuedTarget.blockedOn = instance;
+            attemptHydrationAtPriority(queuedTarget.lanePriority, function () {
+              unstable_runWithPriority(queuedTarget.priority, function () {
+                attemptHydrationAtCurrentPriority(nearestMounted);
+              });
+            });
+            return;
+          }
+        } else if (tag === HostRoot) {
+          var root = nearestMounted.stateNode;
+
+          if (root.hydrate) {
+            queuedTarget.blockedOn = getContainerFromFiber(nearestMounted); // We don't currently have a way to increase the priority of
+            // a root other than sync.
+
+            return;
+          }
+        }
+      }
+    }
+
+    queuedTarget.blockedOn = null;
+  }
+
+  function attemptReplayContinuousQueuedEvent(queuedEvent) {
+    if (queuedEvent.blockedOn !== null) {
+      return false;
+    }
+
+    var targetContainers = queuedEvent.targetContainers;
+
+    while (targetContainers.length > 0) {
+      var targetContainer = targetContainers[0];
+      var nextBlockedOn = attemptToDispatchEvent(queuedEvent.domEventName, queuedEvent.eventSystemFlags, targetContainer, queuedEvent.nativeEvent);
+
+      if (nextBlockedOn !== null) {
+        // We're still blocked. Try again later.
+        var _fiber3 = getInstanceFromNode(nextBlockedOn);
+
+        if (_fiber3 !== null) {
+          attemptContinuousHydration(_fiber3);
+        }
+
+        queuedEvent.blockedOn = nextBlockedOn;
+        return false;
+      } // This target container was successfully dispatched. Try the next.
+
+
+      targetContainers.shift();
+    }
+
+    return true;
+  }
+
+  function attemptReplayContinuousQueuedEventInMap(queuedEvent, key, map) {
+    if (attemptReplayContinuousQueuedEvent(queuedEvent)) {
+      map.delete(key);
+    }
+  }
+
+  function replayUnblockedEvents() {
+    hasScheduledReplayAttempt = false; // First replay discrete events.
+
+    while (queuedDiscreteEvents.length > 0) {
+      var nextDiscreteEvent = queuedDiscreteEvents[0];
+
+      if (nextDiscreteEvent.blockedOn !== null) {
+        // We're still blocked.
+        // Increase the priority of this boundary to unblock
+        // the next discrete event.
+        var _fiber4 = getInstanceFromNode(nextDiscreteEvent.blockedOn);
+
+        if (_fiber4 !== null) {
+          attemptUserBlockingHydration(_fiber4);
+        }
+
+        break;
+      }
+
+      var targetContainers = nextDiscreteEvent.targetContainers;
+
+      while (targetContainers.length > 0) {
+        var targetContainer = targetContainers[0];
+        var nextBlockedOn = attemptToDispatchEvent(nextDiscreteEvent.domEventName, nextDiscreteEvent.eventSystemFlags, targetContainer, nextDiscreteEvent.nativeEvent);
+
+        if (nextBlockedOn !== null) {
+          // We're still blocked. Try again later.
+          nextDiscreteEvent.blockedOn = nextBlockedOn;
+          break;
+        } // This target container was successfully dispatched. Try the next.
+
+
+        targetContainers.shift();
+      }
+
+      if (nextDiscreteEvent.blockedOn === null) {
+        // We've successfully replayed the first event. Let's try the next one.
+        queuedDiscreteEvents.shift();
+      }
+    } // Next replay any continuous events.
+
+
+    if (queuedFocus !== null && attemptReplayContinuousQueuedEvent(queuedFocus)) {
+      queuedFocus = null;
+    }
+
+    if (queuedDrag !== null && attemptReplayContinuousQueuedEvent(queuedDrag)) {
+      queuedDrag = null;
+    }
+
+    if (queuedMouse !== null && attemptReplayContinuousQueuedEvent(queuedMouse)) {
+      queuedMouse = null;
+    }
+
+    queuedPointers.forEach(attemptReplayContinuousQueuedEventInMap);
+    queuedPointerCaptures.forEach(attemptReplayContinuousQueuedEventInMap);
+  }
+
+  function scheduleCallbackIfUnblocked(queuedEvent, unblocked) {
+    if (queuedEvent.blockedOn === unblocked) {
+      queuedEvent.blockedOn = null;
+
+      if (!hasScheduledReplayAttempt) {
+        hasScheduledReplayAttempt = true; // Schedule a callback to attempt replaying as many events as are
+        // now unblocked. This first might not actually be unblocked yet.
+        // We could check it early to avoid scheduling an unnecessary callback.
+
+        unstable_scheduleCallback(unstable_NormalPriority, replayUnblockedEvents);
+      }
+    }
+  }
+
+  function retryIfBlockedOn(unblocked) {
+    // Mark anything that was blocked on this as no longer blocked
+    // and eligible for a replay.
+    if (queuedDiscreteEvents.length > 0) {
+      scheduleCallbackIfUnblocked(queuedDiscreteEvents[0], unblocked); // This is a exponential search for each boundary that commits. I think it's
+      // worth it because we expect very few discrete events to queue up and once
+      // we are actually fully unblocked it will be fast to replay them.
+
+      for (var i = 1; i < queuedDiscreteEvents.length; i++) {
+        var queuedEvent = queuedDiscreteEvents[i];
+
+        if (queuedEvent.blockedOn === unblocked) {
+          queuedEvent.blockedOn = null;
+        }
+      }
+    }
+
+    if (queuedFocus !== null) {
+      scheduleCallbackIfUnblocked(queuedFocus, unblocked);
+    }
+
+    if (queuedDrag !== null) {
+      scheduleCallbackIfUnblocked(queuedDrag, unblocked);
+    }
+
+    if (queuedMouse !== null) {
+      scheduleCallbackIfUnblocked(queuedMouse, unblocked);
+    }
+
+    var unblock = function (queuedEvent) {
+      return scheduleCallbackIfUnblocked(queuedEvent, unblocked);
+    };
+
+    queuedPointers.forEach(unblock);
+    queuedPointerCaptures.forEach(unblock);
+
+    for (var _i = 0; _i < queuedExplicitHydrationTargets.length; _i++) {
+      var queuedTarget = queuedExplicitHydrationTargets[_i];
+
+      if (queuedTarget.blockedOn === unblocked) {
+        queuedTarget.blockedOn = null;
+      }
+    }
+
+    while (queuedExplicitHydrationTargets.length > 0) {
+      var nextExplicitTarget = queuedExplicitHydrationTargets[0];
+
+      if (nextExplicitTarget.blockedOn !== null) {
+        // We're still blocked.
+        break;
+      } else {
+        attemptExplicitHydrationTarget(nextExplicitTarget);
+
+        if (nextExplicitTarget.blockedOn === null) {
+          // We're unblocked.
+          queuedExplicitHydrationTargets.shift();
+        }
+      }
+    }
+  }
+
+  var DiscreteEvent = 0;
+  var UserBlockingEvent = 1;
+  var ContinuousEvent = 2;
+
+  /**
+   * Generate a mapping of standard vendor prefixes using the defined style property and event name.
+   *
+   * @param {string} styleProp
+   * @param {string} eventName
+   * @returns {object}
+   */
+
+  function makePrefixMap(styleProp, eventName) {
+    var prefixes = {};
+    prefixes[styleProp.toLowerCase()] = eventName.toLowerCase();
+    prefixes['Webkit' + styleProp] = 'webkit' + eventName;
+    prefixes['Moz' + styleProp] = 'moz' + eventName;
+    return prefixes;
+  }
+  /**
+   * A list of event names to a configurable list of vendor prefixes.
+   */
+
+
+  var vendorPrefixes = {
+    animationend: makePrefixMap('Animation', 'AnimationEnd'),
+    animationiteration: makePrefixMap('Animation', 'AnimationIteration'),
+    animationstart: makePrefixMap('Animation', 'AnimationStart'),
+    transitionend: makePrefixMap('Transition', 'TransitionEnd')
+  };
+  /**
+   * Event names that have already been detected and prefixed (if applicable).
+   */
+
+  var prefixedEventNames = {};
+  /**
+   * Element to check for prefixes on.
+   */
+
+  var style = {};
+  /**
+   * Bootstrap if a DOM exists.
+   */
+
+  if (canUseDOM) {
+    style = document.createElement('div').style; // On some platforms, in particular some releases of Android 4.x,
+    // the un-prefixed "animation" and "transition" properties are defined on the
+    // style object but the events that fire will still be prefixed, so we need
+    // to check if the un-prefixed events are usable, and if not remove them from the map.
+
+    if (!('AnimationEvent' in window)) {
+      delete vendorPrefixes.animationend.animation;
+      delete vendorPrefixes.animationiteration.animation;
+      delete vendorPrefixes.animationstart.animation;
+    } // Same as above
+
+
+    if (!('TransitionEvent' in window)) {
+      delete vendorPrefixes.transitionend.transition;
+    }
+  }
+  /**
+   * Attempts to determine the correct vendor prefixed event name.
+   *
+   * @param {string} eventName
+   * @returns {string}
+   */
+
+
+  function getVendorPrefixedEventName(eventName) {
+    if (prefixedEventNames[eventName]) {
+      return prefixedEventNames[eventName];
+    } else if (!vendorPrefixes[eventName]) {
+      return eventName;
+    }
+
+    var prefixMap = vendorPrefixes[eventName];
+
+    for (var styleProp in prefixMap) {
+      if (prefixMap.hasOwnProperty(styleProp) && styleProp in style) {
+        return prefixedEventNames[eventName] = prefixMap[styleProp];
+      }
+    }
+
+    return eventName;
+  }
+
+  var ANIMATION_END = getVendorPrefixedEventName('animationend');
+  var ANIMATION_ITERATION = getVendorPrefixedEventName('animationiteration');
+  var ANIMATION_START = getVendorPrefixedEventName('animationstart');
+  var TRANSITION_END = getVendorPrefixedEventName('transitionend');
+
+  var topLevelEventsToReactNames = new Map();
+  var eventPriorities = new Map(); // We store most of the events in this module in pairs of two strings so we can re-use
+  // the code required to apply the same logic for event prioritization and that of the
+  // SimpleEventPlugin. This complicates things slightly, but the aim is to reduce code
+  // duplication (for which there would be quite a bit). For the events that are not needed
+  // for the SimpleEventPlugin (otherDiscreteEvents) we process them separately as an
+  // array of top level events.
+  // Lastly, we ignore prettier so we can keep the formatting sane.
+  // prettier-ignore
+
+  var discreteEventPairsForSimpleEventPlugin = ['cancel', 'cancel', 'click', 'click', 'close', 'close', 'contextmenu', 'contextMenu', 'copy', 'copy', 'cut', 'cut', 'auxclick', 'auxClick', 'dblclick', 'doubleClick', // Careful!
+  'dragend', 'dragEnd', 'dragstart', 'dragStart', 'drop', 'drop', 'focusin', 'focus', // Careful!
+  'focusout', 'blur', // Careful!
+  'input', 'input', 'invalid', 'invalid', 'keydown', 'keyDown', 'keypress', 'keyPress', 'keyup', 'keyUp', 'mousedown', 'mouseDown', 'mouseup', 'mouseUp', 'paste', 'paste', 'pause', 'pause', 'play', 'play', 'pointercancel', 'pointerCancel', 'pointerdown', 'pointerDown', 'pointerup', 'pointerUp', 'ratechange', 'rateChange', 'reset', 'reset', 'seeked', 'seeked', 'submit', 'submit', 'touchcancel', 'touchCancel', 'touchend', 'touchEnd', 'touchstart', 'touchStart', 'volumechange', 'volumeChange'];
+  var otherDiscreteEvents = ['change', 'selectionchange', 'textInput', 'compositionstart', 'compositionend', 'compositionupdate'];
+
+
+  var userBlockingPairsForSimpleEventPlugin = ['drag', 'drag', 'dragenter', 'dragEnter', 'dragexit', 'dragExit', 'dragleave', 'dragLeave', 'dragover', 'dragOver', 'mousemove', 'mouseMove', 'mouseout', 'mouseOut', 'mouseover', 'mouseOver', 'pointermove', 'pointerMove', 'pointerout', 'pointerOut', 'pointerover', 'pointerOver', 'scroll', 'scroll', 'toggle', 'toggle', 'touchmove', 'touchMove', 'wheel', 'wheel']; // prettier-ignore
+
+  var continuousPairsForSimpleEventPlugin = ['abort', 'abort', ANIMATION_END, 'animationEnd', ANIMATION_ITERATION, 'animationIteration', ANIMATION_START, 'animationStart', 'canplay', 'canPlay', 'canplaythrough', 'canPlayThrough', 'durationchange', 'durationChange', 'emptied', 'emptied', 'encrypted', 'encrypted', 'ended', 'ended', 'error', 'error', 'gotpointercapture', 'gotPointerCapture', 'load', 'load', 'loadeddata', 'loadedData', 'loadedmetadata', 'loadedMetadata', 'loadstart', 'loadStart', 'lostpointercapture', 'lostPointerCapture', 'playing', 'playing', 'progress', 'progress', 'seeking', 'seeking', 'stalled', 'stalled', 'suspend', 'suspend', 'timeupdate', 'timeUpdate', TRANSITION_END, 'transitionEnd', 'waiting', 'waiting'];
+  /**
+   * Turns
+   * ['abort', ...]
+   *
+   * into
+   *
+   * topLevelEventsToReactNames = new Map([
+   *   ['abort', 'onAbort'],
+   * ]);
+   *
+   * and registers them.
+   */
+
+  function registerSimplePluginEventsAndSetTheirPriorities(eventTypes, priority) {
+    // As the event types are in pairs of two, we need to iterate
+    // through in twos. The events are in pairs of two to save code
+    // and improve init perf of processing this array, as it will
+    // result in far fewer object allocations and property accesses
+    // if we only use three arrays to process all the categories of
+    // instead of tuples.
+    for (var i = 0; i < eventTypes.length; i += 2) {
+      var topEvent = eventTypes[i];
+      var event = eventTypes[i + 1];
+      var capitalizedEvent = event[0].toUpperCase() + event.slice(1);
+      var reactName = 'on' + capitalizedEvent;
+      eventPriorities.set(topEvent, priority);
+      topLevelEventsToReactNames.set(topEvent, reactName);
+      registerTwoPhaseEvent(reactName, [topEvent]);
+    }
+  }
+
+  function setEventPriorities(eventTypes, priority) {
+    for (var i = 0; i < eventTypes.length; i++) {
+      eventPriorities.set(eventTypes[i], priority);
+    }
+  }
+
+  function getEventPriorityForPluginSystem(domEventName) {
+    var priority = eventPriorities.get(domEventName); // Default to a ContinuousEvent. Note: we might
+    // want to warn if we can't detect the priority
+    // for the event.
+
+    return priority === undefined ? ContinuousEvent : priority;
+  }
+  function registerSimpleEvents() {
+    registerSimplePluginEventsAndSetTheirPriorities(discreteEventPairsForSimpleEventPlugin, DiscreteEvent);
+    registerSimplePluginEventsAndSetTheirPriorities(userBlockingPairsForSimpleEventPlugin, UserBlockingEvent);
+    registerSimplePluginEventsAndSetTheirPriorities(continuousPairsForSimpleEventPlugin, ContinuousEvent);
+    setEventPriorities(otherDiscreteEvents, DiscreteEvent);
+  }
+
+  var ReactInternals$2 = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+  var _ReactInternals$Sched$1 = ReactInternals$2.SchedulerTracing,
+      __interactionsRef = _ReactInternals$Sched$1.__interactionsRef,
+      __subscriberRef = _ReactInternals$Sched$1.__subscriberRef,
+      unstable_clear = _ReactInternals$Sched$1.unstable_clear,
+      unstable_getCurrent = _ReactInternals$Sched$1.unstable_getCurrent,
+      unstable_getThreadID = _ReactInternals$Sched$1.unstable_getThreadID,
+      unstable_subscribe = _ReactInternals$Sched$1.unstable_subscribe,
+      unstable_trace = _ReactInternals$Sched$1.unstable_trace,
+      unstable_unsubscribe = _ReactInternals$Sched$1.unstable_unsubscribe,
+      unstable_wrap = _ReactInternals$Sched$1.unstable_wrap;
+
+  var Scheduler_now = unstable_now;
+
+  {
+    // Provide explicit error message when production+profiling bundle of e.g.
+    // react-dom is used with production (non-profiling) bundle of
+    // scheduler/tracing
+    if (!(__interactionsRef != null && __interactionsRef.current != null)) {
+      {
+        throw Error( "It is not supported to run the profiling version of a renderer (for example, `react-dom/profiling`) without also replacing the `scheduler/tracing` module with `scheduler/tracing-profiling`. Your bundler might have a setting for aliasing both modules. Learn more at https://reactjs.org/link/profiling" );
+      }
+    }
+  }
+  // ascending numbers so we can compare them like numbers. They start at 90 to
+  // avoid clashing with Scheduler's priorities.
+
+  var ImmediatePriority = 99;
+  var UserBlockingPriority = 98;
+  var NormalPriority = 97;
+  var LowPriority = 96;
+  var IdlePriority = 95; // NoPriority is the absence of priority. Also React-only.
+
+  var NoPriority = 90;
+  var initialTimeMs = Scheduler_now(); // If the initial timestamp is reasonably small, use Scheduler's `now` directly.
+
+  var SyncLanePriority = 15;
+  var SyncBatchedLanePriority = 14;
+  var InputDiscreteHydrationLanePriority = 13;
+  var InputDiscreteLanePriority = 12;
+  var InputContinuousHydrationLanePriority = 11;
+  var InputContinuousLanePriority = 10;
+  var DefaultHydrationLanePriority = 9;
+  var DefaultLanePriority = 8;
+  var TransitionHydrationPriority = 7;
+  var TransitionPriority = 6;
+  var RetryLanePriority = 5;
+  var SelectiveHydrationLanePriority = 4;
+  var IdleHydrationLanePriority = 3;
+  var IdleLanePriority = 2;
+  var OffscreenLanePriority = 1;
+  var NoLanePriority = 0;
+  var TotalLanes = 31;
+  var NoLanes =
+  /*                        */
+  0;
+  var NoLane =
+  /*                          */
+  0;
+  var SyncLane =
+  /*                        */
+  1;
+  var SyncBatchedLane =
+  /*                 */
+  2;
+  var InputDiscreteHydrationLane =
+  /*      */
+  4;
+  var InputDiscreteLanes =
+  /*                    */
+  24;
+  var InputContinuousHydrationLane =
+  /*           */
+  32;
+  var InputContinuousLanes =
+  /*                  */
+  192;
+  var DefaultHydrationLane =
+  /*            */
+  256;
+  var DefaultLanes =
+  /*                   */
+  3584;
+  var TransitionHydrationLane =
+  /*                */
+  4096;
+  var TransitionLanes =
+  /*                       */
+  4186112;
+  var RetryLanes =
+  /*                            */
+  62914560;
+  var SomeRetryLane =
+  /*                  */
+  33554432;
+  var SelectiveHydrationLane =
+  /*          */
+  67108864;
+  var NonIdleLanes =
+  /*                                 */
+  134217727;
+  var IdleHydrationLane =
+  /*               */
+  134217728;
+  var IdleLanes =
+  /*                             */
+  805306368;
+  var OffscreenLane =
+  /*                   */
+  1073741824;
+  var NoTimestamp = -1;
+  function setCurrentUpdateLanePriority(newLanePriority) {
+  } // "Registers" used to "return" multiple values
+  // Used by getHighestPriorityLanes and getNextLanes:
+
+  var return_highestLanePriority = DefaultLanePriority;
+
+  function getHighestPriorityLanes(lanes) {
+    if ((SyncLane & lanes) !== NoLanes) {
+      return_highestLanePriority = SyncLanePriority;
+      return SyncLane;
+    }
+
+    if ((SyncBatchedLane & lanes) !== NoLanes) {
+      return_highestLanePriority = SyncBatchedLanePriority;
+      return SyncBatchedLane;
+    }
+
+    if ((InputDiscreteHydrationLane & lanes) !== NoLanes) {
+      return_highestLanePriority = InputDiscreteHydrationLanePriority;
+      return InputDiscreteHydrationLane;
+    }
+
+    var inputDiscreteLanes = InputDiscreteLanes & lanes;
+
+    if (inputDiscreteLanes !== NoLanes) {
+      return_highestLanePriority = InputDiscreteLanePriority;
+      return inputDiscreteLanes;
+    }
+
+    if ((lanes & InputContinuousHydrationLane) !== NoLanes) {
+      return_highestLanePriority = InputContinuousHydrationLanePriority;
+      return InputContinuousHydrationLane;
+    }
+
+    var inputContinuousLanes = InputContinuousLanes & lanes;
+
+    if (inputContinuousLanes !== NoLanes) {
+      return_highestLanePriority = InputContinuousLanePriority;
+      return inputContinuousLanes;
+    }
+
+    if ((lanes & DefaultHydrationLane) !== NoLanes) {
+      return_highestLanePriority = DefaultHydrationLanePriority;
+      return DefaultHydrationLane;
+    }
+
+    var defaultLanes = DefaultLanes & lanes;
+
+    if (defaultLanes !== NoLanes) {
+      return_highestLanePriority = DefaultLanePriority;
+      return defaultLanes;
+    }
+
+    if ((lanes & TransitionHydrationLane) !== NoLanes) {
+      return_highestLanePriority = TransitionHydrationPriority;
+      return TransitionHydrationLane;
+    }
+
+    var transitionLanes = TransitionLanes & lanes;
+
+    if (transitionLanes !== NoLanes) {
+      return_highestLanePriority = TransitionPriority;
+      return transitionLanes;
+    }
+
+    var retryLanes = RetryLanes & lanes;
+
+    if (retryLanes !== NoLanes) {
+      return_highestLanePriority = RetryLanePriority;
+      return retryLanes;
+    }
+
+    if (lanes & SelectiveHydrationLane) {
+      return_highestLanePriority = SelectiveHydrationLanePriority;
+      return SelectiveHydrationLane;
+    }
+
+    if ((lanes & IdleHydrationLane) !== NoLanes) {
+      return_highestLanePriority = IdleHydrationLanePriority;
+      return IdleHydrationLane;
+    }
+
+    var idleLanes = IdleLanes & lanes;
+
+    if (idleLanes !== NoLanes) {
+      return_highestLanePriority = IdleLanePriority;
+      return idleLanes;
+    }
+
+    if ((OffscreenLane & lanes) !== NoLanes) {
+      return_highestLanePriority = OffscreenLanePriority;
+      return OffscreenLane;
+    }
+
+    {
+      error('Should have found matching lanes. This is a bug in React.');
+    } // This shouldn't be reachable, but as a fallback, return the entire bitmask.
+
+
+    return_highestLanePriority = DefaultLanePriority;
+    return lanes;
+  }
+
+  function schedulerPriorityToLanePriority(schedulerPriorityLevel) {
+    switch (schedulerPriorityLevel) {
+      case ImmediatePriority:
+        return SyncLanePriority;
+
+      case UserBlockingPriority:
+        return InputContinuousLanePriority;
+
+      case NormalPriority:
+      case LowPriority:
+        // TODO: Handle LowSchedulerPriority, somehow. Maybe the same lane as hydration.
+        return DefaultLanePriority;
+
+      case IdlePriority:
+        return IdleLanePriority;
+
+      default:
+        return NoLanePriority;
+    }
+  }
+  function lanePriorityToSchedulerPriority(lanePriority) {
+    switch (lanePriority) {
+      case SyncLanePriority:
+      case SyncBatchedLanePriority:
+        return ImmediatePriority;
+
+      case InputDiscreteHydrationLanePriority:
+      case InputDiscreteLanePriority:
+      case InputContinuousHydrationLanePriority:
+      case InputContinuousLanePriority:
+        return UserBlockingPriority;
+
+      case DefaultHydrationLanePriority:
+      case DefaultLanePriority:
+      case TransitionHydrationPriority:
+      case TransitionPriority:
+      case SelectiveHydrationLanePriority:
+      case RetryLanePriority:
+        return NormalPriority;
+
+      case IdleHydrationLanePriority:
+      case IdleLanePriority:
+      case OffscreenLanePriority:
+        return IdlePriority;
+
+      case NoLanePriority:
+        return NoPriority;
+
+      default:
+        {
+          {
+            throw Error( "Invalid update priority: " + lanePriority + ". This is a bug in React." );
+          }
+        }
+
+    }
+  }
+  function getNextLanes(root, wipLanes) {
+    // Early bailout if there's no pending work left.
+    var pendingLanes = root.pendingLanes;
+
+    if (pendingLanes === NoLanes) {
+      return_highestLanePriority = NoLanePriority;
+      return NoLanes;
+    }
+
+    var nextLanes = NoLanes;
+    var nextLanePriority = NoLanePriority;
+    var expiredLanes = root.expiredLanes;
+    var suspendedLanes = root.suspendedLanes;
+    var pingedLanes = root.pingedLanes; // Check if any work has expired.
+
+    if (expiredLanes !== NoLanes) {
+      nextLanes = expiredLanes;
+      nextLanePriority = return_highestLanePriority = SyncLanePriority;
+    } else {
+      // Do not work on any idle work until all the non-idle work has finished,
+      // even if the work is suspended.
+      var nonIdlePendingLanes = pendingLanes & NonIdleLanes;
+
+      if (nonIdlePendingLanes !== NoLanes) {
+        var nonIdleUnblockedLanes = nonIdlePendingLanes & ~suspendedLanes;
+
+        if (nonIdleUnblockedLanes !== NoLanes) {
+          nextLanes = getHighestPriorityLanes(nonIdleUnblockedLanes);
+          nextLanePriority = return_highestLanePriority;
+        } else {
+          var nonIdlePingedLanes = nonIdlePendingLanes & pingedLanes;
+
+          if (nonIdlePingedLanes !== NoLanes) {
+            nextLanes = getHighestPriorityLanes(nonIdlePingedLanes);
+            nextLanePriority = return_highestLanePriority;
+          }
+        }
+      } else {
+        // The only remaining work is Idle.
+        var unblockedLanes = pendingLanes & ~suspendedLanes;
+
+        if (unblockedLanes !== NoLanes) {
+          nextLanes = getHighestPriorityLanes(unblockedLanes);
+          nextLanePriority = return_highestLanePriority;
+        } else {
+          if (pingedLanes !== NoLanes) {
+            nextLanes = getHighestPriorityLanes(pingedLanes);
+            nextLanePriority = return_highestLanePriority;
+          }
+        }
+      }
+    }
+
+    if (nextLanes === NoLanes) {
+      // This should only be reachable if we're suspended
+      // TODO: Consider warning in this path if a fallback timer is not scheduled.
+      return NoLanes;
+    } // If there are higher priority lanes, we'll include them even if they
+    // are suspended.
+
+
+    nextLanes = pendingLanes & getEqualOrHigherPriorityLanes(nextLanes); // If we're already in the middle of a render, switching lanes will interrupt
+    // it and we'll lose our progress. We should only do this if the new lanes are
+    // higher priority.
+
+    if (wipLanes !== NoLanes && wipLanes !== nextLanes && // If we already suspended with a delay, then interrupting is fine. Don't
+    // bother waiting until the root is complete.
+    (wipLanes & suspendedLanes) === NoLanes) {
+      getHighestPriorityLanes(wipLanes);
+      var wipLanePriority = return_highestLanePriority;
+
+      if (nextLanePriority <= wipLanePriority) {
+        return wipLanes;
+      } else {
+        return_highestLanePriority = nextLanePriority;
+      }
+    } // Check for entangled lanes and add them to the batch.
+    //
+    // A lane is said to be entangled with another when it's not allowed to render
+    // in a batch that does not also include the other lane. Typically we do this
+    // when multiple updates have the same source, and we only want to respond to
+    // the most recent event from that source.
+    //
+    // Note that we apply entanglements *after* checking for partial work above.
+    // This means that if a lane is entangled during an interleaved event while
+    // it's already rendering, we won't interrupt it. This is intentional, since
+    // entanglement is usually "best effort": we'll try our best to render the
+    // lanes in the same batch, but it's not worth throwing out partially
+    // completed work in order to do it.
+    //
+    // For those exceptions where entanglement is semantically important, like
+    // useMutableSource, we should ensure that there is no partial work at the
+    // time we apply the entanglement.
+
+
+    var entangledLanes = root.entangledLanes;
+
+    if (entangledLanes !== NoLanes) {
+      var entanglements = root.entanglements;
+      var lanes = nextLanes & entangledLanes;
+
+      while (lanes > 0) {
+        var index = pickArbitraryLaneIndex(lanes);
+        var lane = 1 << index;
+        nextLanes |= entanglements[index];
+        lanes &= ~lane;
+      }
+    }
+
+    return nextLanes;
+  }
+  function getMostRecentEventTime(root, lanes) {
+    var eventTimes = root.eventTimes;
+    var mostRecentEventTime = NoTimestamp;
+
+    while (lanes > 0) {
+      var index = pickArbitraryLaneIndex(lanes);
+      var lane = 1 << index;
+      var eventTime = eventTimes[index];
+
+      if (eventTime > mostRecentEventTime) {
+        mostRecentEventTime = eventTime;
+      }
+
+      lanes &= ~lane;
+    }
+
+    return mostRecentEventTime;
+  }
+
+  function computeExpirationTime(lane, currentTime) {
+    // TODO: Expiration heuristic is constant per lane, so could use a map.
+    getHighestPriorityLanes(lane);
+    var priority = return_highestLanePriority;
+
+    if (priority >= InputContinuousLanePriority) {
+      // User interactions should expire slightly more quickly.
+      //
+      // NOTE: This is set to the corresponding constant as in Scheduler.js. When
+      // we made it larger, a product metric in www regressed, suggesting there's
+      // a user interaction that's being starved by a series of synchronous
+      // updates. If that theory is correct, the proper solution is to fix the
+      // starvation. However, this scenario supports the idea that expiration
+      // times are an important safeguard when starvation does happen.
+      //
+      // Also note that, in the case of user input specifically, this will soon no
+      // longer be an issue because we plan to make user input synchronous by
+      // default (until you enter `startTransition`, of course.)
+      //
+      // If weren't planning to make these updates synchronous soon anyway, I
+      // would probably make this number a configurable parameter.
+      return currentTime + 250;
+    } else if (priority >= TransitionPriority) {
+      return currentTime + 5000;
+    } else {
+      // Anything idle priority or lower should never expire.
+      return NoTimestamp;
+    }
+  }
+
+  function markStarvedLanesAsExpired(root, currentTime) {
+    // TODO: This gets called every time we yield. We can optimize by storing
+    // the earliest expiration time on the root. Then use that to quickly bail out
+    // of this function.
+    var pendingLanes = root.pendingLanes;
+    var suspendedLanes = root.suspendedLanes;
+    var pingedLanes = root.pingedLanes;
+    var expirationTimes = root.expirationTimes; // Iterate through the pending lanes and check if we've reached their
+    // expiration time. If so, we'll assume the update is being starved and mark
+    // it as expired to force it to finish.
+
+    var lanes = pendingLanes;
+
+    while (lanes > 0) {
+      var index = pickArbitraryLaneIndex(lanes);
+      var lane = 1 << index;
+      var expirationTime = expirationTimes[index];
+
+      if (expirationTime === NoTimestamp) {
+        // Found a pending lane with no expiration time. If it's not suspended, or
+        // if it's pinged, assume it's CPU-bound. Compute a new expiration time
+        // using the current time.
+        if ((lane & suspendedLanes) === NoLanes || (lane & pingedLanes) !== NoLanes) {
+          // Assumes timestamps are monotonically increasing.
+          expirationTimes[index] = computeExpirationTime(lane, currentTime);
+        }
+      } else if (expirationTime <= currentTime) {
+        // This lane expired
+        root.expiredLanes |= lane;
+      }
+
+      lanes &= ~lane;
+    }
+  } // This returns the highest priority pending lanes regardless of whether they
+  function getLanesToRetrySynchronouslyOnError(root) {
+    var everythingButOffscreen = root.pendingLanes & ~OffscreenLane;
+
+    if (everythingButOffscreen !== NoLanes) {
+      return everythingButOffscreen;
+    }
+
+    if (everythingButOffscreen & OffscreenLane) {
+      return OffscreenLane;
+    }
+
+    return NoLanes;
+  }
+  function returnNextLanesPriority() {
+    return return_highestLanePriority;
+  }
+  function includesNonIdleWork(lanes) {
+    return (lanes & NonIdleLanes) !== NoLanes;
+  }
+  function includesOnlyRetries(lanes) {
+    return (lanes & RetryLanes) === lanes;
+  }
+  function includesOnlyTransitions(lanes) {
+    return (lanes & TransitionLanes) === lanes;
+  } // To ensure consistency across multiple updates in the same event, this should
+  // be a pure function, so that it always returns the same lane for given inputs.
+
+  function findUpdateLane(lanePriority, wipLanes) {
+    switch (lanePriority) {
+      case NoLanePriority:
+        break;
+
+      case SyncLanePriority:
+        return SyncLane;
+
+      case SyncBatchedLanePriority:
+        return SyncBatchedLane;
+
+      case InputDiscreteLanePriority:
+        {
+          var _lane = pickArbitraryLane(InputDiscreteLanes & ~wipLanes);
+
+          if (_lane === NoLane) {
+            // Shift to the next priority level
+            return findUpdateLane(InputContinuousLanePriority, wipLanes);
+          }
+
+          return _lane;
+        }
+
+      case InputContinuousLanePriority:
+        {
+          var _lane2 = pickArbitraryLane(InputContinuousLanes & ~wipLanes);
+
+          if (_lane2 === NoLane) {
+            // Shift to the next priority level
+            return findUpdateLane(DefaultLanePriority, wipLanes);
+          }
+
+          return _lane2;
+        }
+
+      case DefaultLanePriority:
+        {
+          var _lane3 = pickArbitraryLane(DefaultLanes & ~wipLanes);
+
+          if (_lane3 === NoLane) {
+            // If all the default lanes are already being worked on, look for a
+            // lane in the transition range.
+            _lane3 = pickArbitraryLane(TransitionLanes & ~wipLanes);
+
+            if (_lane3 === NoLane) {
+              // All the transition lanes are taken, too. This should be very
+              // rare, but as a last resort, pick a default lane. This will have
+              // the effect of interrupting the current work-in-progress render.
+              _lane3 = pickArbitraryLane(DefaultLanes);
+            }
+          }
+
+          return _lane3;
+        }
+
+      case TransitionPriority: // Should be handled by findTransitionLane instead
+
+      case RetryLanePriority:
+        // Should be handled by findRetryLane instead
+        break;
+
+      case IdleLanePriority:
+        var lane = pickArbitraryLane(IdleLanes & ~wipLanes);
+
+        if (lane === NoLane) {
+          lane = pickArbitraryLane(IdleLanes);
+        }
+
+        return lane;
+    }
+
+    {
+      {
+        throw Error( "Invalid update priority: " + lanePriority + ". This is a bug in React." );
+      }
+    }
+  } // To ensure consistency across multiple updates in the same event, this should
+  // be pure function, so that it always returns the same lane for given inputs.
+
+  function findTransitionLane(wipLanes, pendingLanes) {
+    // First look for lanes that are completely unclaimed, i.e. have no
+    // pending work.
+    var lane = pickArbitraryLane(TransitionLanes & ~pendingLanes);
+
+    if (lane === NoLane) {
+      // If all lanes have pending work, look for a lane that isn't currently
+      // being worked on.
+      lane = pickArbitraryLane(TransitionLanes & ~wipLanes);
+
+      if (lane === NoLane) {
+        // If everything is being worked on, pick any lane. This has the
+        // effect of interrupting the current work-in-progress.
+        lane = pickArbitraryLane(TransitionLanes);
+      }
+    }
+
+    return lane;
+  } // To ensure consistency across multiple updates in the same event, this should
+  // be pure function, so that it always returns the same lane for given inputs.
+
+  function findRetryLane(wipLanes) {
+    // This is a fork of `findUpdateLane` designed specifically for Suspense
+    // "retries" — a special update that attempts to flip a Suspense boundary
+    // from its placeholder state to its primary/resolved state.
+    var lane = pickArbitraryLane(RetryLanes & ~wipLanes);
+
+    if (lane === NoLane) {
+      lane = pickArbitraryLane(RetryLanes);
+    }
+
+    return lane;
+  }
+
+  function getHighestPriorityLane(lanes) {
+    return lanes & -lanes;
+  }
+
+  function getLowestPriorityLane(lanes) {
+    // This finds the most significant non-zero bit.
+    var index = 31 - clz32(lanes);
+    return index < 0 ? NoLanes : 1 << index;
+  }
+
+  function getEqualOrHigherPriorityLanes(lanes) {
+    return (getLowestPriorityLane(lanes) << 1) - 1;
+  }
+
+  function pickArbitraryLane(lanes) {
+    // This wrapper function gets inlined. Only exists so to communicate that it
+    // doesn't matter which bit is selected; you can pick any bit without
+    // affecting the algorithms where its used. Here I'm using
+    // getHighestPriorityLane because it requires the fewest operations.
+    return getHighestPriorityLane(lanes);
+  }
+
+  function pickArbitraryLaneIndex(lanes) {
+    return 31 - clz32(lanes);
+  }
+
+  function laneToIndex(lane) {
+    return pickArbitraryLaneIndex(lane);
+  }
+
+  function includesSomeLane(a, b) {
+    return (a & b) !== NoLanes;
+  }
+  function isSubsetOfLanes(set, subset) {
+    return (set & subset) === subset;
+  }
+  function mergeLanes(a, b) {
+    return a | b;
+  }
+  function removeLanes(set, subset) {
+    return set & ~subset;
+  } // Seems redundant, but it changes the type from a single lane (used for
+  // updates) to a group of lanes (used for flushing work).
+
+  function laneToLanes(lane) {
+    return lane;
+  }
+  function higherPriorityLane(a, b) {
+    // This works because the bit ranges decrease in priority as you go left.
+    return a !== NoLane && a < b ? a : b;
+  }
+  function createLaneMap(initial) {
+    // Intentionally pushing one by one.
+    // https://v8.dev/blog/elements-kinds#avoid-creating-holes
+    var laneMap = [];
+
+    for (var i = 0; i < TotalLanes; i++) {
+      laneMap.push(initial);
+    }
+
+    return laneMap;
+  }
+  function markRootUpdated(root, updateLane, eventTime) {
+    root.pendingLanes |= updateLane; // TODO: Theoretically, any update to any lane can unblock any other lane. But
+    // it's not practical to try every single possible combination. We need a
+    // heuristic to decide which lanes to attempt to render, and in which batches.
+    // For now, we use the same heuristic as in the old ExpirationTimes model:
+    // retry any lane at equal or lower priority, but don't try updates at higher
+    // priority without also including the lower priority updates. This works well
+    // when considering updates across different priority levels, but isn't
+    // sufficient for updates within the same priority, since we want to treat
+    // those updates as parallel.
+    // Unsuspend any update at equal or lower priority.
+
+    var higherPriorityLanes = updateLane - 1; // Turns 0b1000 into 0b0111
+
+    root.suspendedLanes &= higherPriorityLanes;
+    root.pingedLanes &= higherPriorityLanes;
+    var eventTimes = root.eventTimes;
+    var index = laneToIndex(updateLane); // We can always overwrite an existing timestamp because we prefer the most
+    // recent event, and we assume time is monotonically increasing.
+
+    eventTimes[index] = eventTime;
+  }
+  function markRootSuspended(root, suspendedLanes) {
+    root.suspendedLanes |= suspendedLanes;
+    root.pingedLanes &= ~suspendedLanes; // The suspended lanes are no longer CPU-bound. Clear their expiration times.
+
+    var expirationTimes = root.expirationTimes;
+    var lanes = suspendedLanes;
+
+    while (lanes > 0) {
+      var index = pickArbitraryLaneIndex(lanes);
+      var lane = 1 << index;
+      expirationTimes[index] = NoTimestamp;
+      lanes &= ~lane;
+    }
+  }
+  function markRootPinged(root, pingedLanes, eventTime) {
+    root.pingedLanes |= root.suspendedLanes & pingedLanes;
+  }
+  function markDiscreteUpdatesExpired(root) {
+    root.expiredLanes |= InputDiscreteLanes & root.pendingLanes;
+  }
+  function hasDiscreteLanes(lanes) {
+    return (lanes & InputDiscreteLanes) !== NoLanes;
+  }
+  function markRootMutableRead(root, updateLane) {
+    root.mutableReadLanes |= updateLane & root.pendingLanes;
+  }
+  function markRootFinished(root, remainingLanes) {
+    var noLongerPendingLanes = root.pendingLanes & ~remainingLanes;
+    root.pendingLanes = remainingLanes; // Let's try everything again
+
+    root.suspendedLanes = 0;
+    root.pingedLanes = 0;
+    root.expiredLanes &= remainingLanes;
+    root.mutableReadLanes &= remainingLanes;
+    root.entangledLanes &= remainingLanes;
+    var entanglements = root.entanglements;
+    var eventTimes = root.eventTimes;
+    var expirationTimes = root.expirationTimes; // Clear the lanes that no longer have pending work
+
+    var lanes = noLongerPendingLanes;
+
+    while (lanes > 0) {
+      var index = pickArbitraryLaneIndex(lanes);
+      var lane = 1 << index;
+      entanglements[index] = NoLanes;
+      eventTimes[index] = NoTimestamp;
+      expirationTimes[index] = NoTimestamp;
+      lanes &= ~lane;
+    }
+  }
+  function markRootEntangled(root, entangledLanes) {
+    root.entangledLanes |= entangledLanes;
+    var entanglements = root.entanglements;
+    var lanes = entangledLanes;
+
+    while (lanes > 0) {
+      var index = pickArbitraryLaneIndex(lanes);
+      var lane = 1 << index;
+      entanglements[index] |= entangledLanes;
+      lanes &= ~lane;
+    }
+  }
+  var clz32 = Math.clz32 ? Math.clz32 : clz32Fallback; // Count leading zeros. Only used on lanes, so assume input is an integer.
+  // Based on:
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32
+
+  var log = Math.log;
+  var LN2 = Math.LN2;
+
+  function clz32Fallback(lanes) {
+    if (lanes === 0) {
+      return 32;
+    }
+
+    return 31 - (log(lanes) / LN2 | 0) | 0;
+  }
+
+  // Intentionally not named imports because Rollup would use dynamic dispatch for
+  var UserBlockingPriority$1 = unstable_UserBlockingPriority,
+      runWithPriority = unstable_runWithPriority; // TODO: can we stop exporting these?
+
+  var _enabled = true; // This is exported in FB builds for use by legacy FB layer infra.
+  // We'd like to remove this but it's not clear if this is safe.
+
+  function setEnabled(enabled) {
+    _enabled = !!enabled;
+  }
+  function isEnabled() {
+    return _enabled;
+  }
+  function createEventListenerWrapperWithPriority(targetContainer, domEventName, eventSystemFlags) {
+    var eventPriority = getEventPriorityForPluginSystem(domEventName);
+    var listenerWrapper;
+
+    switch (eventPriority) {
+      case DiscreteEvent:
+        listenerWrapper = dispatchDiscreteEvent;
+        break;
+
+      case UserBlockingEvent:
+        listenerWrapper = dispatchUserBlockingUpdate;
+        break;
+
+      case ContinuousEvent:
+      default:
+        listenerWrapper = dispatchEvent;
+        break;
+    }
+
+    return listenerWrapper.bind(null, domEventName, eventSystemFlags, targetContainer);
+  }
+
+  function dispatchDiscreteEvent(domEventName, eventSystemFlags, container, nativeEvent) {
+    {
+      flushDiscreteUpdatesIfNeeded(nativeEvent.timeStamp);
+    }
+
+    discreteUpdates(dispatchEvent, domEventName, eventSystemFlags, container, nativeEvent);
+  }
+
+  function dispatchUserBlockingUpdate(domEventName, eventSystemFlags, container, nativeEvent) {
+    {
+      runWithPriority(UserBlockingPriority$1, dispatchEvent.bind(null, domEventName, eventSystemFlags, container, nativeEvent));
+    }
+  }
+
+  function dispatchEvent(domEventName, eventSystemFlags, targetContainer, nativeEvent) {
+    if (!_enabled) {
+      return;
+    }
+
+    var allowReplay = true;
+
+    {
+      // TODO: replaying capture phase events is currently broken
+      // because we used to do it during top-level native bubble handlers
+      // but now we use different bubble and capture handlers.
+      // In eager mode, we attach capture listeners early, so we need
+      // to filter them out until we fix the logic to handle them correctly.
+      // This could've been outside the flag but I put it inside to reduce risk.
+      allowReplay = (eventSystemFlags & IS_CAPTURE_PHASE) === 0;
+    }
+
+    if (allowReplay && hasQueuedDiscreteEvents() && isReplayableDiscreteEvent(domEventName)) {
+      // If we already have a queue of discrete events, and this is another discrete
+      // event, then we can't dispatch it regardless of its target, since they
+      // need to dispatch in order.
+      queueDiscreteEvent(null, // Flags that we're not actually blocked on anything as far as we know.
+      domEventName, eventSystemFlags, targetContainer, nativeEvent);
+      return;
+    }
+
+    var blockedOn = attemptToDispatchEvent(domEventName, eventSystemFlags, targetContainer, nativeEvent);
+
+    if (blockedOn === null) {
+      // We successfully dispatched this event.
+      if (allowReplay) {
+        clearIfContinuousEvent(domEventName, nativeEvent);
+      }
+
+      return;
+    }
+
+    if (allowReplay) {
+      if (isReplayableDiscreteEvent(domEventName)) {
+        // This this to be replayed later once the target is available.
+        queueDiscreteEvent(blockedOn, domEventName, eventSystemFlags, targetContainer, nativeEvent);
+        return;
+      }
+
+      if (queueIfContinuousEvent(blockedOn, domEventName, eventSystemFlags, targetContainer, nativeEvent)) {
+        return;
+      } // We need to clear only if we didn't queue because
+      // queueing is accummulative.
+
+
+      clearIfContinuousEvent(domEventName, nativeEvent);
+    } // This is not replayable so we'll invoke it but without a target,
+    // in case the event system needs to trace it.
+
+
+    dispatchEventForPluginEventSystem(domEventName, eventSystemFlags, nativeEvent, null, targetContainer);
+  } // Attempt dispatching an event. Returns a SuspenseInstance or Container if it's blocked.
+
+  function attemptToDispatchEvent(domEventName, eventSystemFlags, targetContainer, nativeEvent) {
+    // TODO: Warn if _enabled is false.
+    var nativeEventTarget = getEventTarget(nativeEvent);
+    var targetInst = getClosestInstanceFromNode(nativeEventTarget);
+
+    if (targetInst !== null) {
+      var nearestMounted = getNearestMountedFiber(targetInst);
+
+      if (nearestMounted === null) {
+        // This tree has been unmounted already. Dispatch without a target.
+        targetInst = null;
+      } else {
+        var tag = nearestMounted.tag;
+
+        if (tag === SuspenseComponent) {
+          var instance = getSuspenseInstanceFromFiber(nearestMounted);
+
+          if (instance !== null) {
+            // Queue the event to be replayed later. Abort dispatching since we
+            // don't want this event dispatched twice through the event system.
+            // TODO: If this is the first discrete event in the queue. Schedule an increased
+            // priority for this boundary.
+            return instance;
+          } // This shouldn't happen, something went wrong but to avoid blocking
+          // the whole system, dispatch the event without a target.
+          // TODO: Warn.
+
+
+          targetInst = null;
+        } else if (tag === HostRoot) {
+          var root = nearestMounted.stateNode;
+
+          if (root.hydrate) {
+            // If this happens during a replay something went wrong and it might block
+            // the whole system.
+            return getContainerFromFiber(nearestMounted);
+          }
+
+          targetInst = null;
+        } else if (nearestMounted !== targetInst) {
+          // If we get an event (ex: img onload) before committing that
+          // component's mount, ignore it for now (that is, treat it as if it was an
+          // event on a non-React tree). We might also consider queueing events and
+          // dispatching them after the mount.
+          targetInst = null;
+        }
+      }
+    }
+
+    dispatchEventForPluginEventSystem(domEventName, eventSystemFlags, nativeEvent, targetInst, targetContainer); // We're not blocked on anything.
+
+    return null;
+  }
+
+  function addEventBubbleListener(target, eventType, listener) {
+    target.addEventListener(eventType, listener, false);
+    return listener;
+  }
+  function addEventCaptureListener(target, eventType, listener) {
+    target.addEventListener(eventType, listener, true);
+    return listener;
+  }
+  function addEventCaptureListenerWithPassiveFlag(target, eventType, listener, passive) {
+    target.addEventListener(eventType, listener, {
+      capture: true,
+      passive: passive
+    });
+    return listener;
+  }
+  function addEventBubbleListenerWithPassiveFlag(target, eventType, listener, passive) {
+    target.addEventListener(eventType, listener, {
+      passive: passive
+    });
+    return listener;
+  }
+
+  /**
+   * These variables store information about text content of a target node,
+   * allowing comparison of content before and after a given event.
+   *
+   * Identify the node where selection currently begins, then observe
+   * both its text content and its current position in the DOM. Since the
+   * browser may natively replace the target node during composition, we can
+   * use its position to find its replacement.
+   *
+   *
+   */
+  var root = null;
+  var startText = null;
+  var fallbackText = null;
+  function initialize(nativeEventTarget) {
+    root = nativeEventTarget;
+    startText = getText();
+    return true;
+  }
+  function reset() {
+    root = null;
+    startText = null;
+    fallbackText = null;
+  }
+  function getData() {
+    if (fallbackText) {
+      return fallbackText;
+    }
+
+    var start;
+    var startValue = startText;
+    var startLength = startValue.length;
+    var end;
+    var endValue = getText();
+    var endLength = endValue.length;
+
+    for (start = 0; start < startLength; start++) {
+      if (startValue[start] !== endValue[start]) {
+        break;
+      }
+    }
+
+    var minEnd = startLength - start;
+
+    for (end = 1; end <= minEnd; end++) {
+      if (startValue[startLength - end] !== endValue[endLength - end]) {
+        break;
+      }
+    }
+
+    var sliceTail = end > 1 ? 1 - end : undefined;
+    fallbackText = endValue.slice(start, sliceTail);
+    return fallbackText;
+  }
+  function getText() {
+    if ('value' in root) {
+      return root.value;
+    }
+
+    return root.textContent;
+  }
+
+  /**
+   * `charCode` represents the actual "character code" and is safe to use with
+   * `String.fromCharCode`. As such, only keys that correspond to printable
+   * characters produce a valid `charCode`, the only exception to this is Enter.
+   * The Tab-key is considered non-printable and does not have a `charCode`,
+   * presumably because it does not produce a tab-character in browsers.
+   *
+   * @param {object} nativeEvent Native browser event.
+   * @return {number} Normalized `charCode` property.
+   */
+  function getEventCharCode(nativeEvent) {
+    var charCode;
+    var keyCode = nativeEvent.keyCode;
+
+    if ('charCode' in nativeEvent) {
+      charCode = nativeEvent.charCode; // FF does not set `charCode` for the Enter-key, check against `keyCode`.
+
+      if (charCode === 0 && keyCode === 13) {
+        charCode = 13;
+      }
+    } else {
+      // IE8 does not implement `charCode`, but `keyCode` has the correct value.
+      charCode = keyCode;
+    } // IE and Edge (on Windows) and Chrome / Safari (on Windows and Linux)
+    // report Enter as charCode 10 when ctrl is pressed.
+
+
+    if (charCode === 10) {
+      charCode = 13;
+    } // Some non-printable keys are reported in `charCode`/`keyCode`, discard them.
+    // Must not discard the (non-)printable Enter-key.
+
+
+    if (charCode >= 32 || charCode === 13) {
+      return charCode;
+    }
+
+    return 0;
+  }
+
+  function functionThatReturnsTrue() {
+    return true;
+  }
+
+  function functionThatReturnsFalse() {
+    return false;
+  } // This is intentionally a factory so that we have different returned constructors.
+  // If we had a single constructor, it would be megamorphic and engines would deopt.
+
+
+  function createSyntheticEvent(Interface) {
+    /**
+     * Synthetic events are dispatched by event plugins, typically in response to a
+     * top-level event delegation handler.
+     *
+     * These systems should generally use pooling to reduce the frequency of garbage
+     * collection. The system should check `isPersistent` to determine whether the
+     * event should be released into the pool after being dispatched. Users that
+     * need a persisted event should invoke `persist`.
+     *
+     * Synthetic events (and subclasses) implement the DOM Level 3 Events API by
+     * normalizing browser quirks. Subclasses do not necessarily have to implement a
+     * DOM interface; custom application-specific events can also subclass this.
+     */
+    function SyntheticBaseEvent(reactName, reactEventType, targetInst, nativeEvent, nativeEventTarget) {
+      this._reactName = reactName;
+      this._targetInst = targetInst;
+      this.type = reactEventType;
+      this.nativeEvent = nativeEvent;
+      this.target = nativeEventTarget;
+      this.currentTarget = null;
+
+      for (var _propName in Interface) {
+        if (!Interface.hasOwnProperty(_propName)) {
+          continue;
+        }
+
+        var normalize = Interface[_propName];
+
+        if (normalize) {
+          this[_propName] = normalize(nativeEvent);
+        } else {
+          this[_propName] = nativeEvent[_propName];
+        }
+      }
+
+      var defaultPrevented = nativeEvent.defaultPrevented != null ? nativeEvent.defaultPrevented : nativeEvent.returnValue === false;
+
+      if (defaultPrevented) {
+        this.isDefaultPrevented = functionThatReturnsTrue;
+      } else {
+        this.isDefaultPrevented = functionThatReturnsFalse;
+      }
+
+      this.isPropagationStopped = functionThatReturnsFalse;
+      return this;
+    }
+
+    _assign(SyntheticBaseEvent.prototype, {
+      preventDefault: function () {
+        this.defaultPrevented = true;
+        var event = this.nativeEvent;
+
+        if (!event) {
+          return;
+        }
+
+        if (event.preventDefault) {
+          event.preventDefault(); // $FlowFixMe - flow is not aware of `unknown` in IE
+        } else if (typeof event.returnValue !== 'unknown') {
+          event.returnValue = false;
+        }
+
+        this.isDefaultPrevented = functionThatReturnsTrue;
+      },
+      stopPropagation: function () {
+        var event = this.nativeEvent;
+
+        if (!event) {
+          return;
+        }
+
+        if (event.stopPropagation) {
+          event.stopPropagation(); // $FlowFixMe - flow is not aware of `unknown` in IE
+        } else if (typeof event.cancelBubble !== 'unknown') {
+          // The ChangeEventPlugin registers a "propertychange" event for
+          // IE. This event does not support bubbling or cancelling, and
+          // any references to cancelBubble throw "Member not found".  A
+          // typeof check of "unknown" circumvents this issue (and is also
+          // IE specific).
+          event.cancelBubble = true;
+        }
+
+        this.isPropagationStopped = functionThatReturnsTrue;
+      },
+
+      /**
+       * We release all dispatched `SyntheticEvent`s after each event loop, adding
+       * them back into the pool. This allows a way to hold onto a reference that
+       * won't be added back into the pool.
+       */
+      persist: function () {// Modern event system doesn't use pooling.
+      },
+
+      /**
+       * Checks if this event should be released back into the pool.
+       *
+       * @return {boolean} True if this should not be released, false otherwise.
+       */
+      isPersistent: functionThatReturnsTrue
+    });
+
+    return SyntheticBaseEvent;
+  }
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+
+  var EventInterface = {
+    eventPhase: 0,
+    bubbles: 0,
+    cancelable: 0,
+    timeStamp: function (event) {
+      return event.timeStamp || Date.now();
+    },
+    defaultPrevented: 0,
+    isTrusted: 0
+  };
+  var SyntheticEvent = createSyntheticEvent(EventInterface);
+
+  var UIEventInterface = _assign({}, EventInterface, {
+    view: 0,
+    detail: 0
+  });
+
+  var SyntheticUIEvent = createSyntheticEvent(UIEventInterface);
+  var lastMovementX;
+  var lastMovementY;
+  var lastMouseEvent;
+
+  function updateMouseMovementPolyfillState(event) {
+    if (event !== lastMouseEvent) {
+      if (lastMouseEvent && event.type === 'mousemove') {
+        lastMovementX = event.screenX - lastMouseEvent.screenX;
+        lastMovementY = event.screenY - lastMouseEvent.screenY;
+      } else {
+        lastMovementX = 0;
+        lastMovementY = 0;
+      }
+
+      lastMouseEvent = event;
+    }
+  }
+  /**
+   * @interface MouseEvent
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+
+  var MouseEventInterface = _assign({}, UIEventInterface, {
+    screenX: 0,
+    screenY: 0,
+    clientX: 0,
+    clientY: 0,
+    pageX: 0,
+    pageY: 0,
+    ctrlKey: 0,
+    shiftKey: 0,
+    altKey: 0,
+    metaKey: 0,
+    getModifierState: getEventModifierState,
+    button: 0,
+    buttons: 0,
+    relatedTarget: function (event) {
+      if (event.relatedTarget === undefined) return event.fromElement === event.srcElement ? event.toElement : event.fromElement;
+      return event.relatedTarget;
+    },
+    movementX: function (event) {
+      if ('movementX' in event) {
+        return event.movementX;
+      }
+
+      updateMouseMovementPolyfillState(event);
+      return lastMovementX;
+    },
+    movementY: function (event) {
+      if ('movementY' in event) {
+        return event.movementY;
+      } // Don't need to call updateMouseMovementPolyfillState() here
+      // because it's guaranteed to have already run when movementX
+      // was copied.
+
+
+      return lastMovementY;
+    }
+  });
+
+  var SyntheticMouseEvent = createSyntheticEvent(MouseEventInterface);
+  /**
+   * @interface DragEvent
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+  var DragEventInterface = _assign({}, MouseEventInterface, {
+    dataTransfer: 0
+  });
+
+  var SyntheticDragEvent = createSyntheticEvent(DragEventInterface);
+  /**
+   * @interface FocusEvent
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+  var FocusEventInterface = _assign({}, UIEventInterface, {
+    relatedTarget: 0
+  });
+
+  var SyntheticFocusEvent = createSyntheticEvent(FocusEventInterface);
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/css3-animations/#AnimationEvent-interface
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/AnimationEvent
+   */
+
+  var AnimationEventInterface = _assign({}, EventInterface, {
+    animationName: 0,
+    elapsedTime: 0,
+    pseudoElement: 0
+  });
+
+  var SyntheticAnimationEvent = createSyntheticEvent(AnimationEventInterface);
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/clipboard-apis/
+   */
+
+  var ClipboardEventInterface = _assign({}, EventInterface, {
+    clipboardData: function (event) {
+      return 'clipboardData' in event ? event.clipboardData : window.clipboardData;
+    }
+  });
+
+  var SyntheticClipboardEvent = createSyntheticEvent(ClipboardEventInterface);
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/#events-compositionevents
+   */
+
+  var CompositionEventInterface = _assign({}, EventInterface, {
+    data: 0
+  });
+
+  var SyntheticCompositionEvent = createSyntheticEvent(CompositionEventInterface);
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/2013/WD-DOM-Level-3-Events-20131105
+   *      /#events-inputevents
+   */
+  // Happens to share the same list for now.
+
+  var SyntheticInputEvent = SyntheticCompositionEvent;
+  /**
+   * Normalization of deprecated HTML5 `key` values
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+   */
+
+  var normalizeKey = {
+    Esc: 'Escape',
+    Spacebar: ' ',
+    Left: 'ArrowLeft',
+    Up: 'ArrowUp',
+    Right: 'ArrowRight',
+    Down: 'ArrowDown',
+    Del: 'Delete',
+    Win: 'OS',
+    Menu: 'ContextMenu',
+    Apps: 'ContextMenu',
+    Scroll: 'ScrollLock',
+    MozPrintableKey: 'Unidentified'
+  };
+  /**
+   * Translation from legacy `keyCode` to HTML5 `key`
+   * Only special keys supported, all others depend on keyboard layout or browser
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+   */
+
+  var translateToKey = {
+    '8': 'Backspace',
+    '9': 'Tab',
+    '12': 'Clear',
+    '13': 'Enter',
+    '16': 'Shift',
+    '17': 'Control',
+    '18': 'Alt',
+    '19': 'Pause',
+    '20': 'CapsLock',
+    '27': 'Escape',
+    '32': ' ',
+    '33': 'PageUp',
+    '34': 'PageDown',
+    '35': 'End',
+    '36': 'Home',
+    '37': 'ArrowLeft',
+    '38': 'ArrowUp',
+    '39': 'ArrowRight',
+    '40': 'ArrowDown',
+    '45': 'Insert',
+    '46': 'Delete',
+    '112': 'F1',
+    '113': 'F2',
+    '114': 'F3',
+    '115': 'F4',
+    '116': 'F5',
+    '117': 'F6',
+    '118': 'F7',
+    '119': 'F8',
+    '120': 'F9',
+    '121': 'F10',
+    '122': 'F11',
+    '123': 'F12',
+    '144': 'NumLock',
+    '145': 'ScrollLock',
+    '224': 'Meta'
+  };
+  /**
+   * @param {object} nativeEvent Native browser event.
+   * @return {string} Normalized `key` property.
+   */
+
+  function getEventKey(nativeEvent) {
+    if (nativeEvent.key) {
+      // Normalize inconsistent values reported by browsers due to
+      // implementations of a working draft specification.
+      // FireFox implements `key` but returns `MozPrintableKey` for all
+      // printable characters (normalized to `Unidentified`), ignore it.
+      var key = normalizeKey[nativeEvent.key] || nativeEvent.key;
+
+      if (key !== 'Unidentified') {
+        return key;
+      }
+    } // Browser does not implement `key`, polyfill as much of it as we can.
+
+
+    if (nativeEvent.type === 'keypress') {
+      var charCode = getEventCharCode(nativeEvent); // The enter-key is technically both printable and non-printable and can
+      // thus be captured by `keypress`, no other non-printable key should.
+
+      return charCode === 13 ? 'Enter' : String.fromCharCode(charCode);
+    }
+
+    if (nativeEvent.type === 'keydown' || nativeEvent.type === 'keyup') {
+      // While user keyboard layout determines the actual meaning of each
+      // `keyCode` value, almost all function keys have a universal value.
+      return translateToKey[nativeEvent.keyCode] || 'Unidentified';
+    }
+
+    return '';
+  }
+  /**
+   * Translation from modifier key to the associated property in the event.
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/#keys-Modifiers
+   */
+
+
+  var modifierKeyToProp = {
+    Alt: 'altKey',
+    Control: 'ctrlKey',
+    Meta: 'metaKey',
+    Shift: 'shiftKey'
+  }; // Older browsers (Safari <= 10, iOS Safari <= 10.2) do not support
+  // getModifierState. If getModifierState is not supported, we map it to a set of
+  // modifier keys exposed by the event. In this case, Lock-keys are not supported.
+
+  function modifierStateGetter(keyArg) {
+    var syntheticEvent = this;
+    var nativeEvent = syntheticEvent.nativeEvent;
+
+    if (nativeEvent.getModifierState) {
+      return nativeEvent.getModifierState(keyArg);
+    }
+
+    var keyProp = modifierKeyToProp[keyArg];
+    return keyProp ? !!nativeEvent[keyProp] : false;
+  }
+
+  function getEventModifierState(nativeEvent) {
+    return modifierStateGetter;
+  }
+  /**
+   * @interface KeyboardEvent
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+
+  var KeyboardEventInterface = _assign({}, UIEventInterface, {
+    key: getEventKey,
+    code: 0,
+    location: 0,
+    ctrlKey: 0,
+    shiftKey: 0,
+    altKey: 0,
+    metaKey: 0,
+    repeat: 0,
+    locale: 0,
+    getModifierState: getEventModifierState,
+    // Legacy Interface
+    charCode: function (event) {
+      // `charCode` is the result of a KeyPress event and represents the value of
+      // the actual printable character.
+      // KeyPress is deprecated, but its replacement is not yet final and not
+      // implemented in any major browser. Only KeyPress has charCode.
+      if (event.type === 'keypress') {
+        return getEventCharCode(event);
+      }
+
+      return 0;
+    },
+    keyCode: function (event) {
+      // `keyCode` is the result of a KeyDown/Up event and represents the value of
+      // physical keyboard key.
+      // The actual meaning of the value depends on the users' keyboard layout
+      // which cannot be detected. Assuming that it is a US keyboard layout
+      // provides a surprisingly accurate mapping for US and European users.
+      // Due to this, it is left to the user to implement at this time.
+      if (event.type === 'keydown' || event.type === 'keyup') {
+        return event.keyCode;
+      }
+
+      return 0;
+    },
+    which: function (event) {
+      // `which` is an alias for either `keyCode` or `charCode` depending on the
+      // type of the event.
+      if (event.type === 'keypress') {
+        return getEventCharCode(event);
+      }
+
+      if (event.type === 'keydown' || event.type === 'keyup') {
+        return event.keyCode;
+      }
+
+      return 0;
+    }
+  });
+
+  var SyntheticKeyboardEvent = createSyntheticEvent(KeyboardEventInterface);
+  /**
+   * @interface PointerEvent
+   * @see http://www.w3.org/TR/pointerevents/
+   */
+
+  var PointerEventInterface = _assign({}, MouseEventInterface, {
+    pointerId: 0,
+    width: 0,
+    height: 0,
+    pressure: 0,
+    tangentialPressure: 0,
+    tiltX: 0,
+    tiltY: 0,
+    twist: 0,
+    pointerType: 0,
+    isPrimary: 0
+  });
+
+  var SyntheticPointerEvent = createSyntheticEvent(PointerEventInterface);
+  /**
+   * @interface TouchEvent
+   * @see http://www.w3.org/TR/touch-events/
+   */
+
+  var TouchEventInterface = _assign({}, UIEventInterface, {
+    touches: 0,
+    targetTouches: 0,
+    changedTouches: 0,
+    altKey: 0,
+    metaKey: 0,
+    ctrlKey: 0,
+    shiftKey: 0,
+    getModifierState: getEventModifierState
+  });
+
+  var SyntheticTouchEvent = createSyntheticEvent(TouchEventInterface);
+  /**
+   * @interface Event
+   * @see http://www.w3.org/TR/2009/WD-css3-transitions-20090320/#transition-events-
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent
+   */
+
+  var TransitionEventInterface = _assign({}, EventInterface, {
+    propertyName: 0,
+    elapsedTime: 0,
+    pseudoElement: 0
+  });
+
+  var SyntheticTransitionEvent = createSyntheticEvent(TransitionEventInterface);
+  /**
+   * @interface WheelEvent
+   * @see http://www.w3.org/TR/DOM-Level-3-Events/
+   */
+
+  var WheelEventInterface = _assign({}, MouseEventInterface, {
+    deltaX: function (event) {
+      return 'deltaX' in event ? event.deltaX : // Fallback to `wheelDeltaX` for Webkit and normalize (right is positive).
+      'wheelDeltaX' in event ? -event.wheelDeltaX : 0;
+    },
+    deltaY: function (event) {
+      return 'deltaY' in event ? event.deltaY : // Fallback to `wheelDeltaY` for Webkit and normalize (down is positive).
+      'wheelDeltaY' in event ? -event.wheelDeltaY : // Fallback to `wheelDelta` for IE<9 and normalize (down is positive).
+      'wheelDelta' in event ? -event.wheelDelta : 0;
+    },
+    deltaZ: 0,
+    // Browsers without "deltaMode" is reporting in raw wheel delta where one
+    // notch on the scroll is always +/- 120, roughly equivalent to pixels.
+    // A good approximation of DOM_DELTA_LINE (1) is 5% of viewport size or
+    // ~40 pixels, for DOM_DELTA_SCREEN (2) it is 87.5% of viewport size.
+    deltaMode: 0
+  });
+
+  var SyntheticWheelEvent = createSyntheticEvent(WheelEventInterface);
+
+  var END_KEYCODES = [9, 13, 27, 32]; // Tab, Return, Esc, Space
+
+  var START_KEYCODE = 229;
+  var canUseCompositionEvent = canUseDOM && 'CompositionEvent' in window;
+  var documentMode = null;
+
+  if (canUseDOM && 'documentMode' in document) {
+    documentMode = document.documentMode;
+  } // Webkit offers a very useful `textInput` event that can be used to
+  // directly represent `beforeInput`. The IE `textinput` event is not as
+  // useful, so we don't use it.
+
+
+  var canUseTextInputEvent = canUseDOM && 'TextEvent' in window && !documentMode; // In IE9+, we have access to composition events, but the data supplied
+  // by the native compositionend event may be incorrect. Japanese ideographic
+  // spaces, for instance (\u3000) are not recorded correctly.
+
+  var useFallbackCompositionData = canUseDOM && (!canUseCompositionEvent || documentMode && documentMode > 8 && documentMode <= 11);
+  var SPACEBAR_CODE = 32;
+  var SPACEBAR_CHAR = String.fromCharCode(SPACEBAR_CODE);
+
+  function registerEvents() {
+    registerTwoPhaseEvent('onBeforeInput', ['compositionend', 'keypress', 'textInput', 'paste']);
+    registerTwoPhaseEvent('onCompositionEnd', ['compositionend', 'focusout', 'keydown', 'keypress', 'keyup', 'mousedown']);
+    registerTwoPhaseEvent('onCompositionStart', ['compositionstart', 'focusout', 'keydown', 'keypress', 'keyup', 'mousedown']);
+    registerTwoPhaseEvent('onCompositionUpdate', ['compositionupdate', 'focusout', 'keydown', 'keypress', 'keyup', 'mousedown']);
+  } // Track whether we've ever handled a keypress on the space key.
+
+
+  var hasSpaceKeypress = false;
+  /**
+   * Return whether a native keypress event is assumed to be a command.
+   * This is required because Firefox fires `keypress` events for key commands
+   * (cut, copy, select-all, etc.) even though no character is inserted.
+   */
+
+  function isKeypressCommand(nativeEvent) {
+    return (nativeEvent.ctrlKey || nativeEvent.altKey || nativeEvent.metaKey) && // ctrlKey && altKey is equivalent to AltGr, and is not a command.
+    !(nativeEvent.ctrlKey && nativeEvent.altKey);
+  }
+  /**
+   * Translate native top level events into event types.
+   */
+
+
+  function getCompositionEventType(domEventName) {
+    switch (domEventName) {
+      case 'compositionstart':
+        return 'onCompositionStart';
+
+      case 'compositionend':
+        return 'onCompositionEnd';
+
+      case 'compositionupdate':
+        return 'onCompositionUpdate';
+    }
+  }
+  /**
+   * Does our fallback best-guess model think this event signifies that
+   * composition has begun?
+   */
+
+
+  function isFallbackCompositionStart(domEventName, nativeEvent) {
+    return domEventName === 'keydown' && nativeEvent.keyCode === START_KEYCODE;
+  }
+  /**
+   * Does our fallback mode think that this event is the end of composition?
+   */
+
+
+  function isFallbackCompositionEnd(domEventName, nativeEvent) {
+    switch (domEventName) {
+      case 'keyup':
+        // Command keys insert or clear IME input.
+        return END_KEYCODES.indexOf(nativeEvent.keyCode) !== -1;
+
+      case 'keydown':
+        // Expect IME keyCode on each keydown. If we get any other
+        // code we must have exited earlier.
+        return nativeEvent.keyCode !== START_KEYCODE;
+
+      case 'keypress':
+      case 'mousedown':
+      case 'focusout':
+        // Events are not possible without cancelling IME.
+        return true;
+
+      default:
+        return false;
+    }
+  }
+  /**
+   * Google Input Tools provides composition data via a CustomEvent,
+   * with the `data` property populated in the `detail` object. If this
+   * is available on the event object, use it. If not, this is a plain
+   * composition event and we have nothing special to extract.
+   *
+   * @param {object} nativeEvent
+   * @return {?string}
+   */
+
+
+  function getDataFromCustomEvent(nativeEvent) {
+    var detail = nativeEvent.detail;
+
+    if (typeof detail === 'object' && 'data' in detail) {
+      return detail.data;
+    }
+
+    return null;
+  }
+  /**
+   * Check if a composition event was triggered by Korean IME.
+   * Our fallback mode does not work well with IE's Korean IME,
+   * so just use native composition events when Korean IME is used.
+   * Although CompositionEvent.locale property is deprecated,
+   * it is available in IE, where our fallback mode is enabled.
+   *
+   * @param {object} nativeEvent
+   * @return {boolean}
+   */
+
+
+  function isUsingKoreanIME(nativeEvent) {
+    return nativeEvent.locale === 'ko';
+  } // Track the current IME composition status, if any.
+
+
+  var isComposing = false;
+  /**
+   * @return {?object} A SyntheticCompositionEvent.
+   */
+
+  function extractCompositionEvent(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget) {
+    var eventType;
+    var fallbackData;
+
+    if (canUseCompositionEvent) {
+      eventType = getCompositionEventType(domEventName);
+    } else if (!isComposing) {
+      if (isFallbackCompositionStart(domEventName, nativeEvent)) {
+        eventType = 'onCompositionStart';
+      }
+    } else if (isFallbackCompositionEnd(domEventName, nativeEvent)) {
+      eventType = 'onCompositionEnd';
+    }
+
+    if (!eventType) {
+      return null;
+    }
+
+    if (useFallbackCompositionData && !isUsingKoreanIME(nativeEvent)) {
+      // The current composition is stored statically and must not be
+      // overwritten while composition continues.
+      if (!isComposing && eventType === 'onCompositionStart') {
+        isComposing = initialize(nativeEventTarget);
+      } else if (eventType === 'onCompositionEnd') {
+        if (isComposing) {
+          fallbackData = getData();
+        }
+      }
+    }
+
+    var listeners = accumulateTwoPhaseListeners(targetInst, eventType);
+
+    if (listeners.length > 0) {
+      var event = new SyntheticCompositionEvent(eventType, domEventName, null, nativeEvent, nativeEventTarget);
+      dispatchQueue.push({
+        event: event,
+        listeners: listeners
+      });
+
+      if (fallbackData) {
+        // Inject data generated from fallback path into the synthetic event.
+        // This matches the property of native CompositionEventInterface.
+        event.data = fallbackData;
+      } else {
+        var customData = getDataFromCustomEvent(nativeEvent);
+
+        if (customData !== null) {
+          event.data = customData;
+        }
+      }
+    }
+  }
+
+  function getNativeBeforeInputChars(domEventName, nativeEvent) {
+    switch (domEventName) {
+      case 'compositionend':
+        return getDataFromCustomEvent(nativeEvent);
+
+      case 'keypress':
+        /**
+         * If native `textInput` events are available, our goal is to make
+         * use of them. However, there is a special case: the spacebar key.
+         * In Webkit, preventing default on a spacebar `textInput` event
+         * cancels character insertion, but it *also* causes the browser
+         * to fall back to its default spacebar behavior of scrolling the
+         * page.
+         *
+         * Tracking at:
+         * https://code.google.com/p/chromium/issues/detail?id=355103
+         *
+         * To avoid this issue, use the keypress event as if no `textInput`
+         * event is available.
+         */
+        var which = nativeEvent.which;
+
+        if (which !== SPACEBAR_CODE) {
+          return null;
+        }
+
+        hasSpaceKeypress = true;
+        return SPACEBAR_CHAR;
+
+      case 'textInput':
+        // Record the characters to be added to the DOM.
+        var chars = nativeEvent.data; // If it's a spacebar character, assume that we have already handled
+        // it at the keypress level and bail immediately. Android Chrome
+        // doesn't give us keycodes, so we need to ignore it.
+
+        if (chars === SPACEBAR_CHAR && hasSpaceKeypress) {
+          return null;
+        }
+
+        return chars;
+
+      default:
+        // For other native event types, do nothing.
+        return null;
+    }
+  }
+  /**
+   * For browsers that do not provide the `textInput` event, extract the
+   * appropriate string to use for SyntheticInputEvent.
+   */
+
+
+  function getFallbackBeforeInputChars(domEventName, nativeEvent) {
+    // If we are currently composing (IME) and using a fallback to do so,
+    // try to extract the composed characters from the fallback object.
+    // If composition event is available, we extract a string only at
+    // compositionevent, otherwise extract it at fallback events.
+    if (isComposing) {
+      if (domEventName === 'compositionend' || !canUseCompositionEvent && isFallbackCompositionEnd(domEventName, nativeEvent)) {
+        var chars = getData();
+        reset();
+        isComposing = false;
+        return chars;
+      }
+
+      return null;
+    }
+
+    switch (domEventName) {
+      case 'paste':
+        // If a paste event occurs after a keypress, throw out the input
+        // chars. Paste events should not lead to BeforeInput events.
+        return null;
+
+      case 'keypress':
+        /**
+         * As of v27, Firefox may fire keypress events even when no character
+         * will be inserted. A few possibilities:
+         *
+         * - `which` is `0`. Arrow keys, Esc key, etc.
+         *
+         * - `which` is the pressed key code, but no char is available.
+         *   Ex: 'AltGr + d` in Polish. There is no modified character for
+         *   this key combination and no character is inserted into the
+         *   document, but FF fires the keypress for char code `100` anyway.
+         *   No `input` event will occur.
+         *
+         * - `which` is the pressed key code, but a command combination is
+         *   being used. Ex: `Cmd+C`. No character is inserted, and no
+         *   `input` event will occur.
+         */
+        if (!isKeypressCommand(nativeEvent)) {
+          // IE fires the `keypress` event when a user types an emoji via
+          // Touch keyboard of Windows.  In such a case, the `char` property
+          // holds an emoji character like `\uD83D\uDE0A`.  Because its length
+          // is 2, the property `which` does not represent an emoji correctly.
+          // In such a case, we directly return the `char` property instead of
+          // using `which`.
+          if (nativeEvent.char && nativeEvent.char.length > 1) {
+            return nativeEvent.char;
+          } else if (nativeEvent.which) {
+            return String.fromCharCode(nativeEvent.which);
+          }
+        }
+
+        return null;
+
+      case 'compositionend':
+        return useFallbackCompositionData && !isUsingKoreanIME(nativeEvent) ? null : nativeEvent.data;
+
+      default:
+        return null;
+    }
+  }
+  /**
+   * Extract a SyntheticInputEvent for `beforeInput`, based on either native
+   * `textInput` or fallback behavior.
+   *
+   * @return {?object} A SyntheticInputEvent.
+   */
+
+
+  function extractBeforeInputEvent(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget) {
+    var chars;
+
+    if (canUseTextInputEvent) {
+      chars = getNativeBeforeInputChars(domEventName, nativeEvent);
+    } else {
+      chars = getFallbackBeforeInputChars(domEventName, nativeEvent);
+    } // If no characters are being inserted, no BeforeInput event should
+    // be fired.
+
+
+    if (!chars) {
+      return null;
+    }
+
+    var listeners = accumulateTwoPhaseListeners(targetInst, 'onBeforeInput');
+
+    if (listeners.length > 0) {
+      var event = new SyntheticInputEvent('onBeforeInput', 'beforeinput', null, nativeEvent, nativeEventTarget);
+      dispatchQueue.push({
+        event: event,
+        listeners: listeners
+      });
+      event.data = chars;
+    }
+  }
+  /**
+   * Create an `onBeforeInput` event to match
+   * http://www.w3.org/TR/2013/WD-DOM-Level-3-Events-20131105/#events-inputevents.
+   *
+   * This event plugin is based on the native `textInput` event
+   * available in Chrome, Safari, Opera, and IE. This event fires after
+   * `onKeyPress` and `onCompositionEnd`, but before `onInput`.
+   *
+   * `beforeInput` is spec'd but not implemented in any browsers, and
+   * the `input` event does not provide any useful information about what has
+   * actually been added, contrary to the spec. Thus, `textInput` is the best
+   * available event to identify the characters that have actually been inserted
+   * into the target node.
+   *
+   * This plugin is also responsible for emitting `composition` events, thus
+   * allowing us to share composition fallback code for both `beforeInput` and
+   * `composition` event types.
+   */
+
+
+  function extractEvents(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags, targetContainer) {
+    extractCompositionEvent(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget);
+    extractBeforeInputEvent(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget);
+  }
+
+  /**
+   * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html#input-type-attr-summary
+   */
+  var supportedInputTypes = {
+    color: true,
+    date: true,
+    datetime: true,
+    'datetime-local': true,
+    email: true,
+    month: true,
+    number: true,
+    password: true,
+    range: true,
+    search: true,
+    tel: true,
+    text: true,
+    time: true,
+    url: true,
+    week: true
+  };
+
+  function isTextInputElement(elem) {
+    var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+
+    if (nodeName === 'input') {
+      return !!supportedInputTypes[elem.type];
+    }
+
+    if (nodeName === 'textarea') {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Checks if an event is supported in the current execution environment.
+   *
+   * NOTE: This will not work correctly for non-generic events such as `change`,
+   * `reset`, `load`, `error`, and `select`.
+   *
+   * Borrows from Modernizr.
+   *
+   * @param {string} eventNameSuffix Event name, e.g. "click".
+   * @return {boolean} True if the event is supported.
+   * @internal
+   * @license Modernizr 3.0.0pre (Custom Build) | MIT
+   */
+
+  function isEventSupported(eventNameSuffix) {
+    if (!canUseDOM) {
+      return false;
+    }
+
+    var eventName = 'on' + eventNameSuffix;
+    var isSupported = (eventName in document);
+
+    if (!isSupported) {
+      var element = document.createElement('div');
+      element.setAttribute(eventName, 'return;');
+      isSupported = typeof element[eventName] === 'function';
+    }
+
+    return isSupported;
+  }
+
+  function registerEvents$1() {
+    registerTwoPhaseEvent('onChange', ['change', 'click', 'focusin', 'focusout', 'input', 'keydown', 'keyup', 'selectionchange']);
+  }
+
+  function createAndAccumulateChangeEvent(dispatchQueue, inst, nativeEvent, target) {
+    // Flag this event loop as needing state restore.
+    enqueueStateRestore(target);
+    var listeners = accumulateTwoPhaseListeners(inst, 'onChange');
+
+    if (listeners.length > 0) {
+      var event = new SyntheticEvent('onChange', 'change', null, nativeEvent, target);
+      dispatchQueue.push({
+        event: event,
+        listeners: listeners
+      });
+    }
+  }
+  /**
+   * For IE shims
+   */
+
+
+  var activeElement = null;
+  var activeElementInst = null;
+  /**
+   * SECTION: handle `change` event
+   */
+
+  function shouldUseChangeEvent(elem) {
+    var nodeName = elem.nodeName && elem.nodeName.toLowerCase();
+    return nodeName === 'select' || nodeName === 'input' && elem.type === 'file';
+  }
+
+  function manualDispatchChangeEvent(nativeEvent) {
+    var dispatchQueue = [];
+    createAndAccumulateChangeEvent(dispatchQueue, activeElementInst, nativeEvent, getEventTarget(nativeEvent)); // If change and propertychange bubbled, we'd just bind to it like all the
+    // other events and have it go through ReactBrowserEventEmitter. Since it
+    // doesn't, we manually listen for the events and so we have to enqueue and
+    // process the abstract event manually.
+    //
+    // Batching is necessary here in order to ensure that all event handlers run
+    // before the next rerender (including event handlers attached to ancestor
+    // elements instead of directly on the input). Without this, controlled
+    // components don't work properly in conjunction with event bubbling because
+    // the component is rerendered and the value reverted before all the event
+    // handlers can run. See https://github.com/facebook/react/issues/708.
+
+    batchedUpdates(runEventInBatch, dispatchQueue);
+  }
+
+  function runEventInBatch(dispatchQueue) {
+    processDispatchQueue(dispatchQueue, 0);
+  }
+
+  function getInstIfValueChanged(targetInst) {
+    var targetNode = getNodeFromInstance(targetInst);
+
+    if (updateValueIfChanged(targetNode)) {
+      return targetInst;
+    }
+  }
+
+  function getTargetInstForChangeEvent(domEventName, targetInst) {
+    if (domEventName === 'change') {
+      return targetInst;
+    }
+  }
+  /**
+   * SECTION: handle `input` event
+   */
+
+
+  var isInputEventSupported = false;
+
+  if (canUseDOM) {
+    // IE9 claims to support the input event but fails to trigger it when
+    // deleting text, so we ignore its input events.
+    isInputEventSupported = isEventSupported('input') && (!document.documentMode || document.documentMode > 9);
+  }
+  /**
+   * (For IE <=9) Starts tracking propertychange events on the passed-in element
+   * and override the value property so that we can distinguish user events from
+   * value changes in JS.
+   */
+
+
+  function startWatchingForValueChange(target, targetInst) {
+    activeElement = target;
+    activeElementInst = targetInst;
+    activeElement.attachEvent('onpropertychange', handlePropertyChange);
+  }
+  /**
+   * (For IE <=9) Removes the event listeners from the currently-tracked element,
+   * if any exists.
+   */
+
+
+  function stopWatchingForValueChange() {
+    if (!activeElement) {
+      return;
+    }
+
+    activeElement.detachEvent('onpropertychange', handlePropertyChange);
+    activeElement = null;
+    activeElementInst = null;
+  }
+  /**
+   * (For IE <=9) Handles a propertychange event, sending a `change` event if
+   * the value of the active element has changed.
+   */
+
+
+  function handlePropertyChange(nativeEvent) {
+    if (nativeEvent.propertyName !== 'value') {
+      return;
+    }
+
+    if (getInstIfValueChanged(activeElementInst)) {
+      manualDispatchChangeEvent(nativeEvent);
+    }
+  }
+
+  function handleEventsForInputEventPolyfill(domEventName, target, targetInst) {
+    if (domEventName === 'focusin') {
+      // In IE9, propertychange fires for most input events but is buggy and
+      // doesn't fire when text is deleted, but conveniently, selectionchange
+      // appears to fire in all of the remaining cases so we catch those and
+      // forward the event if the value has changed
+      // In either case, we don't want to call the event handler if the value
+      // is changed from JS so we redefine a setter for `.value` that updates
+      // our activeElementValue variable, allowing us to ignore those changes
+      //
+      // stopWatching() should be a noop here but we call it just in case we
+      // missed a blur event somehow.
+      stopWatchingForValueChange();
+      startWatchingForValueChange(target, targetInst);
+    } else if (domEventName === 'focusout') {
+      stopWatchingForValueChange();
+    }
+  } // For IE8 and IE9.
+
+
+  function getTargetInstForInputEventPolyfill(domEventName, targetInst) {
+    if (domEventName === 'selectionchange' || domEventName === 'keyup' || domEventName === 'keydown') {
+      // On the selectionchange event, the target is just document which isn't
+      // helpful for us so just check activeElement instead.
+      //
+      // 99% of the time, keydown and keyup aren't necessary. IE8 fails to fire
+      // propertychange on the first input event after setting `value` from a
+      // script and fires only keydown, keypress, keyup. Catching keyup usually
+      // gets it and catching keydown lets us fire an event for the first
+      // keystroke if user does a key repeat (it'll be a little delayed: right
+      // before the second keystroke). Other input methods (e.g., paste) seem to
+      // fire selectionchange normally.
+      return getInstIfValueChanged(activeElementInst);
+    }
+  }
+  /**
+   * SECTION: handle `click` event
+   */
+
+
+  function shouldUseClickEvent(elem) {
+    // Use the `click` event to detect changes to checkbox and radio inputs.
+    // This approach works across all browsers, whereas `change` does not fire
+    // until `blur` in IE8.
+    var nodeName = elem.nodeName;
+    return nodeName && nodeName.toLowerCase() === 'input' && (elem.type === 'checkbox' || elem.type === 'radio');
+  }
+
+  function getTargetInstForClickEvent(domEventName, targetInst) {
+    if (domEventName === 'click') {
+      return getInstIfValueChanged(targetInst);
+    }
+  }
+
+  function getTargetInstForInputOrChangeEvent(domEventName, targetInst) {
+    if (domEventName === 'input' || domEventName === 'change') {
+      return getInstIfValueChanged(targetInst);
+    }
+  }
+
+  function handleControlledInputBlur(node) {
+    var state = node._wrapperState;
+
+    if (!state || !state.controlled || node.type !== 'number') {
+      return;
+    }
+
+    {
+      // If controlled, assign the value attribute to the current value on blur
+      setDefaultValue(node, 'number', node.value);
+    }
+  }
+  /**
+   * This plugin creates an `onChange` event that normalizes change events
+   * across form elements. This event fires at a time when it's possible to
+   * change the element's value without seeing a flicker.
+   *
+   * Supported elements are:
+   * - input (see `isTextInputElement`)
+   * - textarea
+   * - select
+   */
+
+
+  function extractEvents$1(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags, targetContainer) {
+    var targetNode = targetInst ? getNodeFromInstance(targetInst) : window;
+    var getTargetInstFunc, handleEventFunc;
+
+    if (shouldUseChangeEvent(targetNode)) {
+      getTargetInstFunc = getTargetInstForChangeEvent;
+    } else if (isTextInputElement(targetNode)) {
+      if (isInputEventSupported) {
+        getTargetInstFunc = getTargetInstForInputOrChangeEvent;
+      } else {
+        getTargetInstFunc = getTargetInstForInputEventPolyfill;
+        handleEventFunc = handleEventsForInputEventPolyfill;
+      }
+    } else if (shouldUseClickEvent(targetNode)) {
+      getTargetInstFunc = getTargetInstForClickEvent;
+    }
+
+    if (getTargetInstFunc) {
+      var inst = getTargetInstFunc(domEventName, targetInst);
+
+      if (inst) {
+        createAndAccumulateChangeEvent(dispatchQueue, inst, nativeEvent, nativeEventTarget);
+        return;
+      }
+    }
+
+    if (handleEventFunc) {
+      handleEventFunc(domEventName, targetNode, targetInst);
+    } // When blurring, set the value attribute for number inputs
+
+
+    if (domEventName === 'focusout') {
+      handleControlledInputBlur(targetNode);
+    }
+  }
+
+  function registerEvents$2() {
+    registerDirectEvent('onMouseEnter', ['mouseout', 'mouseover']);
+    registerDirectEvent('onMouseLeave', ['mouseout', 'mouseover']);
+    registerDirectEvent('onPointerEnter', ['pointerout', 'pointerover']);
+    registerDirectEvent('onPointerLeave', ['pointerout', 'pointerover']);
+  }
+  /**
+   * For almost every interaction we care about, there will be both a top-level
+   * `mouseover` and `mouseout` event that occurs. Only use `mouseout` so that
+   * we do not extract duplicate events. However, moving the mouse into the
+   * browser from outside will not fire a `mouseout` event. In this case, we use
+   * the `mouseover` top-level event.
+   */
+
+
+  function extractEvents$2(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags, targetContainer) {
+    var isOverEvent = domEventName === 'mouseover' || domEventName === 'pointerover';
+    var isOutEvent = domEventName === 'mouseout' || domEventName === 'pointerout';
+
+    if (isOverEvent && (eventSystemFlags & IS_REPLAYED) === 0) {
+      // If this is an over event with a target, we might have already dispatched
+      // the event in the out event of the other target. If this is replayed,
+      // then it's because we couldn't dispatch against this target previously
+      // so we have to do it now instead.
+      var related = nativeEvent.relatedTarget || nativeEvent.fromElement;
+
+      if (related) {
+        // If the related node is managed by React, we can assume that we have
+        // already dispatched the corresponding events during its mouseout.
+        if (getClosestInstanceFromNode(related) || isContainerMarkedAsRoot(related)) {
+          return;
+        }
+      }
+    }
+
+    if (!isOutEvent && !isOverEvent) {
+      // Must not be a mouse or pointer in or out - ignoring.
+      return;
+    }
+
+    var win; // TODO: why is this nullable in the types but we read from it?
+
+    if (nativeEventTarget.window === nativeEventTarget) {
+      // `nativeEventTarget` is probably a window object.
+      win = nativeEventTarget;
+    } else {
+      // TODO: Figure out why `ownerDocument` is sometimes undefined in IE8.
+      var doc = nativeEventTarget.ownerDocument;
+
+      if (doc) {
+        win = doc.defaultView || doc.parentWindow;
+      } else {
+        win = window;
+      }
+    }
+
+    var from;
+    var to;
+
+    if (isOutEvent) {
+      var _related = nativeEvent.relatedTarget || nativeEvent.toElement;
+
+      from = targetInst;
+      to = _related ? getClosestInstanceFromNode(_related) : null;
+
+      if (to !== null) {
+        var nearestMounted = getNearestMountedFiber(to);
+
+        if (to !== nearestMounted || to.tag !== HostComponent && to.tag !== HostText) {
+          to = null;
+        }
+      }
+    } else {
+      // Moving to a node from outside the window.
+      from = null;
+      to = targetInst;
+    }
+
+    if (from === to) {
+      // Nothing pertains to our managed components.
+      return;
+    }
+
+    var SyntheticEventCtor = SyntheticMouseEvent;
+    var leaveEventType = 'onMouseLeave';
+    var enterEventType = 'onMouseEnter';
+    var eventTypePrefix = 'mouse';
+
+    if (domEventName === 'pointerout' || domEventName === 'pointerover') {
+      SyntheticEventCtor = SyntheticPointerEvent;
+      leaveEventType = 'onPointerLeave';
+      enterEventType = 'onPointerEnter';
+      eventTypePrefix = 'pointer';
+    }
+
+    var fromNode = from == null ? win : getNodeFromInstance(from);
+    var toNode = to == null ? win : getNodeFromInstance(to);
+    var leave = new SyntheticEventCtor(leaveEventType, eventTypePrefix + 'leave', from, nativeEvent, nativeEventTarget);
+    leave.target = fromNode;
+    leave.relatedTarget = toNode;
+    var enter = null; // We should only process this nativeEvent if we are processing
+    // the first ancestor. Next time, we will ignore the event.
+
+    var nativeTargetInst = getClosestInstanceFromNode(nativeEventTarget);
+
+    if (nativeTargetInst === targetInst) {
+      var enterEvent = new SyntheticEventCtor(enterEventType, eventTypePrefix + 'enter', to, nativeEvent, nativeEventTarget);
+      enterEvent.target = toNode;
+      enterEvent.relatedTarget = fromNode;
+      enter = enterEvent;
+    }
+
+    accumulateEnterLeaveTwoPhaseListeners(dispatchQueue, leave, enter, from, to);
+  }
+
+  /**
+   * inlined Object.is polyfill to avoid requiring consumers ship their own
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+   */
+  function is(x, y) {
+    return x === y && (x !== 0 || 1 / x === 1 / y) || x !== x && y !== y // eslint-disable-line no-self-compare
+    ;
+  }
+
+  var objectIs = typeof Object.is === 'function' ? Object.is : is;
+
+  var hasOwnProperty$2 = Object.prototype.hasOwnProperty;
+  /**
+   * Performs equality by iterating through keys on an object and returning false
+   * when any key has values which are not strictly equal between the arguments.
+   * Returns true when the values of all keys are strictly equal.
+   */
+
+  function shallowEqual(objA, objB) {
+    if (objectIs(objA, objB)) {
+      return true;
+    }
+
+    if (typeof objA !== 'object' || objA === null || typeof objB !== 'object' || objB === null) {
+      return false;
+    }
+
+    var keysA = Object.keys(objA);
+    var keysB = Object.keys(objB);
+
+    if (keysA.length !== keysB.length) {
+      return false;
+    } // Test for A's keys different from B.
+
+
+    for (var i = 0; i < keysA.length; i++) {
+      if (!hasOwnProperty$2.call(objB, keysA[i]) || !objectIs(objA[keysA[i]], objB[keysA[i]])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Given any node return the first leaf node without children.
+   *
+   * @param {DOMElement|DOMTextNode} node
+   * @return {DOMElement|DOMTextNode}
+   */
+
+  function getLeafNode(node) {
+    while (node && node.firstChild) {
+      node = node.firstChild;
+    }
+
+    return node;
+  }
+  /**
+   * Get the next sibling within a container. This will walk up the
+   * DOM if a node's siblings have been exhausted.
+   *
+   * @param {DOMElement|DOMTextNode} node
+   * @return {?DOMElement|DOMTextNode}
+   */
+
+
+  function getSiblingNode(node) {
+    while (node) {
+      if (node.nextSibling) {
+        return node.nextSibling;
+      }
+
+      node = node.parentNode;
+    }
+  }
+  /**
+   * Get object describing the nodes which contain characters at offset.
+   *
+   * @param {DOMElement|DOMTextNode} root
+   * @param {number} offset
+   * @return {?object}
+   */
+
+
+  function getNodeForCharacterOffset(root, offset) {
+    var node = getLeafNode(root);
+    var nodeStart = 0;
+    var nodeEnd = 0;
+
+    while (node) {
+      if (node.nodeType === TEXT_NODE) {
+        nodeEnd = nodeStart + node.textContent.length;
+
+        if (nodeStart <= offset && nodeEnd >= offset) {
+          return {
+            node: node,
+            offset: offset - nodeStart
+          };
+        }
+
+        nodeStart = nodeEnd;
+      }
+
+      node = getLeafNode(getSiblingNode(node));
+    }
+  }
+
+  /**
+   * @param {DOMElement} outerNode
+   * @return {?object}
+   */
+
+  function getOffsets(outerNode) {
+    var ownerDocument = outerNode.ownerDocument;
+    var win = ownerDocument && ownerDocument.defaultView || window;
+    var selection = win.getSelection && win.getSelection();
+
+    if (!selection || selection.rangeCount === 0) {
+      return null;
+    }
+
+    var anchorNode = selection.anchorNode,
+        anchorOffset = selection.anchorOffset,
+        focusNode = selection.focusNode,
+        focusOffset = selection.focusOffset; // In Firefox, anchorNode and focusNode can be "anonymous divs", e.g. the
+    // up/down buttons on an <input type="number">. Anonymous divs do not seem to
+    // expose properties, triggering a "Permission denied error" if any of its
+    // properties are accessed. The only seemingly possible way to avoid erroring
+    // is to access a property that typically works for non-anonymous divs and
+    // catch any error that may otherwise arise. See
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=208427
+
+    try {
+      /* eslint-disable no-unused-expressions */
+      anchorNode.nodeType;
+      focusNode.nodeType;
+      /* eslint-enable no-unused-expressions */
+    } catch (e) {
+      return null;
+    }
+
+    return getModernOffsetsFromPoints(outerNode, anchorNode, anchorOffset, focusNode, focusOffset);
+  }
+  /**
+   * Returns {start, end} where `start` is the character/codepoint index of
+   * (anchorNode, anchorOffset) within the textContent of `outerNode`, and
+   * `end` is the index of (focusNode, focusOffset).
+   *
+   * Returns null if you pass in garbage input but we should probably just crash.
+   *
+   * Exported only for testing.
+   */
+
+  function getModernOffsetsFromPoints(outerNode, anchorNode, anchorOffset, focusNode, focusOffset) {
+    var length = 0;
+    var start = -1;
+    var end = -1;
+    var indexWithinAnchor = 0;
+    var indexWithinFocus = 0;
+    var node = outerNode;
+    var parentNode = null;
+
+    outer: while (true) {
+      var next = null;
+
+      while (true) {
+        if (node === anchorNode && (anchorOffset === 0 || node.nodeType === TEXT_NODE)) {
+          start = length + anchorOffset;
+        }
+
+        if (node === focusNode && (focusOffset === 0 || node.nodeType === TEXT_NODE)) {
+          end = length + focusOffset;
+        }
+
+        if (node.nodeType === TEXT_NODE) {
+          length += node.nodeValue.length;
+        }
+
+        if ((next = node.firstChild) === null) {
+          break;
+        } // Moving from `node` to its first child `next`.
+
+
+        parentNode = node;
+        node = next;
+      }
+
+      while (true) {
+        if (node === outerNode) {
+          // If `outerNode` has children, this is always the second time visiting
+          // it. If it has no children, this is still the first loop, and the only
+          // valid selection is anchorNode and focusNode both equal to this node
+          // and both offsets 0, in which case we will have handled above.
+          break outer;
+        }
+
+        if (parentNode === anchorNode && ++indexWithinAnchor === anchorOffset) {
+          start = length;
+        }
+
+        if (parentNode === focusNode && ++indexWithinFocus === focusOffset) {
+          end = length;
+        }
+
+        if ((next = node.nextSibling) !== null) {
+          break;
+        }
+
+        node = parentNode;
+        parentNode = node.parentNode;
+      } // Moving from `node` to its next sibling `next`.
+
+
+      node = next;
+    }
+
+    if (start === -1 || end === -1) {
+      // This should never happen. (Would happen if the anchor/focus nodes aren't
+      // actually inside the passed-in node.)
+      return null;
+    }
+
+    return {
+      start: start,
+      end: end
+    };
+  }
+  /**
+   * In modern non-IE browsers, we can support both forward and backward
+   * selections.
+   *
+   * Note: IE10+ supports the Selection object, but it does not support
+   * the `extend` method, which means that even in modern IE, it's not possible
+   * to programmatically create a backward selection. Thus, for all IE
+   * versions, we use the old IE API to create our selections.
+   *
+   * @param {DOMElement|DOMTextNode} node
+   * @param {object} offsets
+   */
+
+  function setOffsets(node, offsets) {
+    var doc = node.ownerDocument || document;
+    var win = doc && doc.defaultView || window; // Edge fails with "Object expected" in some scenarios.
+    // (For instance: TinyMCE editor used in a list component that supports pasting to add more,
+    // fails when pasting 100+ items)
+
+    if (!win.getSelection) {
+      return;
+    }
+
+    var selection = win.getSelection();
+    var length = node.textContent.length;
+    var start = Math.min(offsets.start, length);
+    var end = offsets.end === undefined ? start : Math.min(offsets.end, length); // IE 11 uses modern selection, but doesn't support the extend method.
+    // Flip backward selections, so we can set with a single range.
+
+    if (!selection.extend && start > end) {
+      var temp = end;
+      end = start;
+      start = temp;
+    }
+
+    var startMarker = getNodeForCharacterOffset(node, start);
+    var endMarker = getNodeForCharacterOffset(node, end);
+
+    if (startMarker && endMarker) {
+      if (selection.rangeCount === 1 && selection.anchorNode === startMarker.node && selection.anchorOffset === startMarker.offset && selection.focusNode === endMarker.node && selection.focusOffset === endMarker.offset) {
+        return;
+      }
+
+      var range = doc.createRange();
+      range.setStart(startMarker.node, startMarker.offset);
+      selection.removeAllRanges();
+
+      if (start > end) {
+        selection.addRange(range);
+        selection.extend(endMarker.node, endMarker.offset);
+      } else {
+        range.setEnd(endMarker.node, endMarker.offset);
+        selection.addRange(range);
+      }
+    }
+  }
+
+  function isTextNode(node) {
+    return node && node.nodeType === TEXT_NODE;
+  }
+
+  function containsNode(outerNode, innerNode) {
+    if (!outerNode || !innerNode) {
+      return false;
+    } else if (outerNode === innerNode) {
+      return true;
+    } else if (isTextNode(outerNode)) {
+      return false;
+    } else if (isTextNode(innerNode)) {
+      return containsNode(outerNode, innerNode.parentNode);
+    } else if ('contains' in outerNode) {
+      return outerNode.contains(innerNode);
+    } else if (outerNode.compareDocumentPosition) {
+      return !!(outerNode.compareDocumentPosition(innerNode) & 16);
+    } else {
+      return false;
+    }
+  }
+
+  function isInDocument(node) {
+    return node && node.ownerDocument && containsNode(node.ownerDocument.documentElement, node);
+  }
+
+  function isSameOriginFrame(iframe) {
+    try {
+      // Accessing the contentDocument of a HTMLIframeElement can cause the browser
+      // to throw, e.g. if it has a cross-origin src attribute.
+      // Safari will show an error in the console when the access results in "Blocked a frame with origin". e.g:
+      // iframe.contentDocument.defaultView;
+      // A safety way is to access one of the cross origin properties: Window or Location
+      // Which might result in "SecurityError" DOM Exception and it is compatible to Safari.
+      // https://html.spec.whatwg.org/multipage/browsers.html#integration-with-idl
+      return typeof iframe.contentWindow.location.href === 'string';
+    } catch (err) {
+      return false;
+    }
+  }
+
+  function getActiveElementDeep() {
+    var win = window;
+    var element = getActiveElement();
+
+    while (element instanceof win.HTMLIFrameElement) {
+      if (isSameOriginFrame(element)) {
+        win = element.contentWindow;
+      } else {
+        return element;
+      }
+
+      element = getActiveElement(win.document);
+    }
+
+    return element;
+  }
+  /**
+   * @ReactInputSelection: React input selection module. Based on Selection.js,
+   * but modified to be suitable for react and has a couple of bug fixes (doesn't
+   * assume buttons have range selections allowed).
+   * Input selection module for React.
+   */
+
+  /**
+   * @hasSelectionCapabilities: we get the element types that support selection
+   * from https://html.spec.whatwg.org/#do-not-apply, looking at `selectionStart`
+   * and `selectionEnd` rows.
+   */
+
+
+  function hasSelectionCapabilities(elem) {
+    var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+    return nodeName && (nodeName === 'input' && (elem.type === 'text' || elem.type === 'search' || elem.type === 'tel' || elem.type === 'url' || elem.type === 'password') || nodeName === 'textarea' || elem.contentEditable === 'true');
+  }
+  function getSelectionInformation() {
+    var focusedElem = getActiveElementDeep();
+    return {
+      focusedElem: focusedElem,
+      selectionRange: hasSelectionCapabilities(focusedElem) ? getSelection(focusedElem) : null
+    };
+  }
+  /**
+   * @restoreSelection: If any selection information was potentially lost,
+   * restore it. This is useful when performing operations that could remove dom
+   * nodes and place them back in, resulting in focus being lost.
+   */
+
+  function restoreSelection(priorSelectionInformation) {
+    var curFocusedElem = getActiveElementDeep();
+    var priorFocusedElem = priorSelectionInformation.focusedElem;
+    var priorSelectionRange = priorSelectionInformation.selectionRange;
+
+    if (curFocusedElem !== priorFocusedElem && isInDocument(priorFocusedElem)) {
+      if (priorSelectionRange !== null && hasSelectionCapabilities(priorFocusedElem)) {
+        setSelection(priorFocusedElem, priorSelectionRange);
+      } // Focusing a node can change the scroll position, which is undesirable
+
+
+      var ancestors = [];
+      var ancestor = priorFocusedElem;
+
+      while (ancestor = ancestor.parentNode) {
+        if (ancestor.nodeType === ELEMENT_NODE) {
+          ancestors.push({
+            element: ancestor,
+            left: ancestor.scrollLeft,
+            top: ancestor.scrollTop
+          });
+        }
+      }
+
+      if (typeof priorFocusedElem.focus === 'function') {
+        priorFocusedElem.focus();
+      }
+
+      for (var i = 0; i < ancestors.length; i++) {
+        var info = ancestors[i];
+        info.element.scrollLeft = info.left;
+        info.element.scrollTop = info.top;
+      }
+    }
+  }
+  /**
+   * @getSelection: Gets the selection bounds of a focused textarea, input or
+   * contentEditable node.
+   * -@input: Look up selection bounds of this input
+   * -@return {start: selectionStart, end: selectionEnd}
+   */
+
+  function getSelection(input) {
+    var selection;
+
+    if ('selectionStart' in input) {
+      // Modern browser with input or textarea.
+      selection = {
+        start: input.selectionStart,
+        end: input.selectionEnd
+      };
+    } else {
+      // Content editable or old IE textarea.
+      selection = getOffsets(input);
+    }
+
+    return selection || {
+      start: 0,
+      end: 0
+    };
+  }
+  /**
+   * @setSelection: Sets the selection bounds of a textarea or input and focuses
+   * the input.
+   * -@input     Set selection bounds of this input or textarea
+   * -@offsets   Object of same form that is returned from get*
+   */
+
+  function setSelection(input, offsets) {
+    var start = offsets.start;
+    var end = offsets.end;
+
+    if (end === undefined) {
+      end = start;
+    }
+
+    if ('selectionStart' in input) {
+      input.selectionStart = start;
+      input.selectionEnd = Math.min(end, input.value.length);
+    } else {
+      setOffsets(input, offsets);
+    }
+  }
+
+  var skipSelectionChangeEvent = canUseDOM && 'documentMode' in document && document.documentMode <= 11;
+
+  function registerEvents$3() {
+    registerTwoPhaseEvent('onSelect', ['focusout', 'contextmenu', 'dragend', 'focusin', 'keydown', 'keyup', 'mousedown', 'mouseup', 'selectionchange']);
+  }
+
+  var activeElement$1 = null;
+  var activeElementInst$1 = null;
+  var lastSelection = null;
+  var mouseDown = false;
+  /**
+   * Get an object which is a unique representation of the current selection.
+   *
+   * The return value will not be consistent across nodes or browsers, but
+   * two identical selections on the same node will return identical objects.
+   */
+
+  function getSelection$1(node) {
+    if ('selectionStart' in node && hasSelectionCapabilities(node)) {
+      return {
+        start: node.selectionStart,
+        end: node.selectionEnd
+      };
+    } else {
+      var win = node.ownerDocument && node.ownerDocument.defaultView || window;
+      var selection = win.getSelection();
+      return {
+        anchorNode: selection.anchorNode,
+        anchorOffset: selection.anchorOffset,
+        focusNode: selection.focusNode,
+        focusOffset: selection.focusOffset
+      };
+    }
+  }
+  /**
+   * Get document associated with the event target.
+   */
+
+
+  function getEventTargetDocument(eventTarget) {
+    return eventTarget.window === eventTarget ? eventTarget.document : eventTarget.nodeType === DOCUMENT_NODE ? eventTarget : eventTarget.ownerDocument;
+  }
+  /**
+   * Poll selection to see whether it's changed.
+   *
+   * @param {object} nativeEvent
+   * @param {object} nativeEventTarget
+   * @return {?SyntheticEvent}
+   */
+
+
+  function constructSelectEvent(dispatchQueue, nativeEvent, nativeEventTarget) {
+    // Ensure we have the right element, and that the user is not dragging a
+    // selection (this matches native `select` event behavior). In HTML5, select
+    // fires only on input and textarea thus if there's no focused element we
+    // won't dispatch.
+    var doc = getEventTargetDocument(nativeEventTarget);
+
+    if (mouseDown || activeElement$1 == null || activeElement$1 !== getActiveElement(doc)) {
+      return;
+    } // Only fire when selection has actually changed.
+
+
+    var currentSelection = getSelection$1(activeElement$1);
+
+    if (!lastSelection || !shallowEqual(lastSelection, currentSelection)) {
+      lastSelection = currentSelection;
+      var listeners = accumulateTwoPhaseListeners(activeElementInst$1, 'onSelect');
+
+      if (listeners.length > 0) {
+        var event = new SyntheticEvent('onSelect', 'select', null, nativeEvent, nativeEventTarget);
+        dispatchQueue.push({
+          event: event,
+          listeners: listeners
+        });
+        event.target = activeElement$1;
+      }
+    }
+  }
+  /**
+   * This plugin creates an `onSelect` event that normalizes select events
+   * across form elements.
+   *
+   * Supported elements are:
+   * - input (see `isTextInputElement`)
+   * - textarea
+   * - contentEditable
+   *
+   * This differs from native browser implementations in the following ways:
+   * - Fires on contentEditable fields as well as inputs.
+   * - Fires for collapsed selection.
+   * - Fires after user input.
+   */
+
+
+  function extractEvents$3(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags, targetContainer) {
+
+    var targetNode = targetInst ? getNodeFromInstance(targetInst) : window;
+
+    switch (domEventName) {
+      // Track the input node that has focus.
+      case 'focusin':
+        if (isTextInputElement(targetNode) || targetNode.contentEditable === 'true') {
+          activeElement$1 = targetNode;
+          activeElementInst$1 = targetInst;
+          lastSelection = null;
+        }
+
+        break;
+
+      case 'focusout':
+        activeElement$1 = null;
+        activeElementInst$1 = null;
+        lastSelection = null;
+        break;
+      // Don't fire the event while the user is dragging. This matches the
+      // semantics of the native select event.
+
+      case 'mousedown':
+        mouseDown = true;
+        break;
+
+      case 'contextmenu':
+      case 'mouseup':
+      case 'dragend':
+        mouseDown = false;
+        constructSelectEvent(dispatchQueue, nativeEvent, nativeEventTarget);
+        break;
+      // Chrome and IE fire non-standard event when selection is changed (and
+      // sometimes when it hasn't). IE's event fires out of order with respect
+      // to key and input events on deletion, so we discard it.
+      //
+      // Firefox doesn't support selectionchange, so check selection status
+      // after each key entry. The selection changes after keydown and before
+      // keyup, but we check on keydown as well in the case of holding down a
+      // key, when multiple keydown events are fired but only one keyup is.
+      // This is also our approach for IE handling, for the reason above.
+
+      case 'selectionchange':
+        if (skipSelectionChangeEvent) {
+          break;
+        }
+
+      // falls through
+
+      case 'keydown':
+      case 'keyup':
+        constructSelectEvent(dispatchQueue, nativeEvent, nativeEventTarget);
+    }
+  }
+
+  function extractEvents$4(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags, targetContainer) {
+    var reactName = topLevelEventsToReactNames.get(domEventName);
+
+    if (reactName === undefined) {
+      return;
+    }
+
+    var SyntheticEventCtor = SyntheticEvent;
+    var reactEventType = domEventName;
+
+    switch (domEventName) {
+      case 'keypress':
+        // Firefox creates a keypress event for function keys too. This removes
+        // the unwanted keypress events. Enter is however both printable and
+        // non-printable. One would expect Tab to be as well (but it isn't).
+        if (getEventCharCode(nativeEvent) === 0) {
+          return;
+        }
+
+      /* falls through */
+
+      case 'keydown':
+      case 'keyup':
+        SyntheticEventCtor = SyntheticKeyboardEvent;
+        break;
+
+      case 'focusin':
+        reactEventType = 'focus';
+        SyntheticEventCtor = SyntheticFocusEvent;
+        break;
+
+      case 'focusout':
+        reactEventType = 'blur';
+        SyntheticEventCtor = SyntheticFocusEvent;
+        break;
+
+      case 'beforeblur':
+      case 'afterblur':
+        SyntheticEventCtor = SyntheticFocusEvent;
+        break;
+
+      case 'click':
+        // Firefox creates a click event on right mouse clicks. This removes the
+        // unwanted click events.
+        if (nativeEvent.button === 2) {
+          return;
+        }
+
+      /* falls through */
+
+      case 'auxclick':
+      case 'dblclick':
+      case 'mousedown':
+      case 'mousemove':
+      case 'mouseup': // TODO: Disabled elements should not respond to mouse events
+
+      /* falls through */
+
+      case 'mouseout':
+      case 'mouseover':
+      case 'contextmenu':
+        SyntheticEventCtor = SyntheticMouseEvent;
+        break;
+
+      case 'drag':
+      case 'dragend':
+      case 'dragenter':
+      case 'dragexit':
+      case 'dragleave':
+      case 'dragover':
+      case 'dragstart':
+      case 'drop':
+        SyntheticEventCtor = SyntheticDragEvent;
+        break;
+
+      case 'touchcancel':
+      case 'touchend':
+      case 'touchmove':
+      case 'touchstart':
+        SyntheticEventCtor = SyntheticTouchEvent;
+        break;
+
+      case ANIMATION_END:
+      case ANIMATION_ITERATION:
+      case ANIMATION_START:
+        SyntheticEventCtor = SyntheticAnimationEvent;
+        break;
+
+      case TRANSITION_END:
+        SyntheticEventCtor = SyntheticTransitionEvent;
+        break;
+
+      case 'scroll':
+        SyntheticEventCtor = SyntheticUIEvent;
+        break;
+
+      case 'wheel':
+        SyntheticEventCtor = SyntheticWheelEvent;
+        break;
+
+      case 'copy':
+      case 'cut':
+      case 'paste':
+        SyntheticEventCtor = SyntheticClipboardEvent;
+        break;
+
+      case 'gotpointercapture':
+      case 'lostpointercapture':
+      case 'pointercancel':
+      case 'pointerdown':
+      case 'pointermove':
+      case 'pointerout':
+      case 'pointerover':
+      case 'pointerup':
+        SyntheticEventCtor = SyntheticPointerEvent;
+        break;
+    }
+
+    var inCapturePhase = (eventSystemFlags & IS_CAPTURE_PHASE) !== 0;
+
+    {
+      // Some events don't bubble in the browser.
+      // In the past, React has always bubbled them, but this can be surprising.
+      // We're going to try aligning closer to the browser behavior by not bubbling
+      // them in React either. We'll start by not bubbling onScroll, and then expand.
+      var accumulateTargetOnly = !inCapturePhase && // TODO: ideally, we'd eventually add all events from
+      // nonDelegatedEvents list in DOMPluginEventSystem.
+      // Then we can remove this special list.
+      // This is a breaking change that can wait until React 18.
+      domEventName === 'scroll';
+
+      var _listeners = accumulateSinglePhaseListeners(targetInst, reactName, nativeEvent.type, inCapturePhase, accumulateTargetOnly);
+
+      if (_listeners.length > 0) {
+        // Intentionally create event lazily.
+        var _event = new SyntheticEventCtor(reactName, reactEventType, null, nativeEvent, nativeEventTarget);
+
+        dispatchQueue.push({
+          event: _event,
+          listeners: _listeners
+        });
+      }
+    }
+  }
+
+  // TODO: remove top-level side effect.
+  registerSimpleEvents();
+  registerEvents$2();
+  registerEvents$1();
+  registerEvents$3();
+  registerEvents();
+
+  function extractEvents$5(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags, targetContainer) {
+    // TODO: we should remove the concept of a "SimpleEventPlugin".
+    // This is the basic functionality of the event system. All
+    // the other plugins are essentially polyfills. So the plugin
+    // should probably be inlined somewhere and have its logic
+    // be core the to event system. This would potentially allow
+    // us to ship builds of React without the polyfilled plugins below.
+    extractEvents$4(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags);
+    var shouldProcessPolyfillPlugins = (eventSystemFlags & SHOULD_NOT_PROCESS_POLYFILL_EVENT_PLUGINS) === 0; // We don't process these events unless we are in the
+    // event's native "bubble" phase, which means that we're
+    // not in the capture phase. That's because we emulate
+    // the capture phase here still. This is a trade-off,
+    // because in an ideal world we would not emulate and use
+    // the phases properly, like we do with the SimpleEvent
+    // plugin. However, the plugins below either expect
+    // emulation (EnterLeave) or use state localized to that
+    // plugin (BeforeInput, Change, Select). The state in
+    // these modules complicates things, as you'll essentially
+    // get the case where the capture phase event might change
+    // state, only for the following bubble event to come in
+    // later and not trigger anything as the state now
+    // invalidates the heuristics of the event plugin. We
+    // could alter all these plugins to work in such ways, but
+    // that might cause other unknown side-effects that we
+    // can't forsee right now.
+
+    if (shouldProcessPolyfillPlugins) {
+      extractEvents$2(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags);
+      extractEvents$1(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget);
+      extractEvents$3(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget);
+      extractEvents(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget);
+    }
+  } // List of events that need to be individually attached to media elements.
+
+
+  var mediaEventTypes = ['abort', 'canplay', 'canplaythrough', 'durationchange', 'emptied', 'encrypted', 'ended', 'error', 'loadeddata', 'loadedmetadata', 'loadstart', 'pause', 'play', 'playing', 'progress', 'ratechange', 'seeked', 'seeking', 'stalled', 'suspend', 'timeupdate', 'volumechange', 'waiting']; // We should not delegate these events to the container, but rather
+  // set them on the actual target element itself. This is primarily
+  // because these events do not consistently bubble in the DOM.
+
+  var nonDelegatedEvents = new Set(['cancel', 'close', 'invalid', 'load', 'scroll', 'toggle'].concat(mediaEventTypes));
+
+  function executeDispatch(event, listener, currentTarget) {
+    var type = event.type || 'unknown-event';
+    event.currentTarget = currentTarget;
+    invokeGuardedCallbackAndCatchFirstError(type, listener, undefined, event);
+    event.currentTarget = null;
+  }
+
+  function processDispatchQueueItemsInOrder(event, dispatchListeners, inCapturePhase) {
+    var previousInstance;
+
+    if (inCapturePhase) {
+      for (var i = dispatchListeners.length - 1; i >= 0; i--) {
+        var _dispatchListeners$i = dispatchListeners[i],
+            instance = _dispatchListeners$i.instance,
+            currentTarget = _dispatchListeners$i.currentTarget,
+            listener = _dispatchListeners$i.listener;
+
+        if (instance !== previousInstance && event.isPropagationStopped()) {
+          return;
+        }
+
+        executeDispatch(event, listener, currentTarget);
+        previousInstance = instance;
+      }
+    } else {
+      for (var _i = 0; _i < dispatchListeners.length; _i++) {
+        var _dispatchListeners$_i = dispatchListeners[_i],
+            _instance = _dispatchListeners$_i.instance,
+            _currentTarget = _dispatchListeners$_i.currentTarget,
+            _listener = _dispatchListeners$_i.listener;
+
+        if (_instance !== previousInstance && event.isPropagationStopped()) {
+          return;
+        }
+
+        executeDispatch(event, _listener, _currentTarget);
+        previousInstance = _instance;
+      }
+    }
+  }
+
+  function processDispatchQueue(dispatchQueue, eventSystemFlags) {
+    var inCapturePhase = (eventSystemFlags & IS_CAPTURE_PHASE) !== 0;
+
+    for (var i = 0; i < dispatchQueue.length; i++) {
+      var _dispatchQueue$i = dispatchQueue[i],
+          event = _dispatchQueue$i.event,
+          listeners = _dispatchQueue$i.listeners;
+      processDispatchQueueItemsInOrder(event, listeners, inCapturePhase); //  event system doesn't use pooling.
+    } // This would be a good time to rethrow if any of the event handlers threw.
+
+
+    rethrowCaughtError();
+  }
+
+  function dispatchEventsForPlugins(domEventName, eventSystemFlags, nativeEvent, targetInst, targetContainer) {
+    var nativeEventTarget = getEventTarget(nativeEvent);
+    var dispatchQueue = [];
+    extractEvents$5(dispatchQueue, domEventName, targetInst, nativeEvent, nativeEventTarget, eventSystemFlags);
+    processDispatchQueue(dispatchQueue, eventSystemFlags);
+  }
+
+  function listenToNonDelegatedEvent(domEventName, targetElement) {
+    var isCapturePhaseListener = false;
+    var listenerSet = getEventListenerSet(targetElement);
+    var listenerSetKey = getListenerSetKey(domEventName, isCapturePhaseListener);
+
+    if (!listenerSet.has(listenerSetKey)) {
+      addTrappedEventListener(targetElement, domEventName, IS_NON_DELEGATED, isCapturePhaseListener);
+      listenerSet.add(listenerSetKey);
+    }
+  }
+  var listeningMarker = '_reactListening' + Math.random().toString(36).slice(2);
+  function listenToAllSupportedEvents(rootContainerElement) {
+    {
+      if (rootContainerElement[listeningMarker]) {
+        // Performance optimization: don't iterate through events
+        // for the same portal container or root node more than once.
+        // TODO: once we remove the flag, we may be able to also
+        // remove some of the bookkeeping maps used for laziness.
+        return;
+      }
+
+      rootContainerElement[listeningMarker] = true;
+      allNativeEvents.forEach(function (domEventName) {
+        if (!nonDelegatedEvents.has(domEventName)) {
+          listenToNativeEvent(domEventName, false, rootContainerElement, null);
+        }
+
+        listenToNativeEvent(domEventName, true, rootContainerElement, null);
+      });
+    }
+  }
+  function listenToNativeEvent(domEventName, isCapturePhaseListener, rootContainerElement, targetElement) {
+    var eventSystemFlags = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : 0;
+    var target = rootContainerElement; // selectionchange needs to be attached to the document
+    // otherwise it won't capture incoming events that are only
+    // triggered on the document directly.
+
+    if (domEventName === 'selectionchange' && rootContainerElement.nodeType !== DOCUMENT_NODE) {
+      target = rootContainerElement.ownerDocument;
+    } // If the event can be delegated (or is capture phase), we can
+    // register it to the root container. Otherwise, we should
+    // register the event to the target element and mark it as
+    // a non-delegated event.
+
+
+    if (targetElement !== null && !isCapturePhaseListener && nonDelegatedEvents.has(domEventName)) {
+      // For all non-delegated events, apart from scroll, we attach
+      // their event listeners to the respective elements that their
+      // events fire on. That means we can skip this step, as event
+      // listener has already been added previously. However, we
+      // special case the scroll event because the reality is that any
+      // element can scroll.
+      // TODO: ideally, we'd eventually apply the same logic to all
+      // events from the nonDelegatedEvents list. Then we can remove
+      // this special case and use the same logic for all events.
+      if (domEventName !== 'scroll') {
+        return;
+      }
+
+      eventSystemFlags |= IS_NON_DELEGATED;
+      target = targetElement;
+    }
+
+    var listenerSet = getEventListenerSet(target);
+    var listenerSetKey = getListenerSetKey(domEventName, isCapturePhaseListener); // If the listener entry is empty or we should upgrade, then
+    // we need to trap an event listener onto the target.
+
+    if (!listenerSet.has(listenerSetKey)) {
+      if (isCapturePhaseListener) {
+        eventSystemFlags |= IS_CAPTURE_PHASE;
+      }
+
+      addTrappedEventListener(target, domEventName, eventSystemFlags, isCapturePhaseListener);
+      listenerSet.add(listenerSetKey);
+    }
+  }
+
+  function addTrappedEventListener(targetContainer, domEventName, eventSystemFlags, isCapturePhaseListener, isDeferredListenerForLegacyFBSupport) {
+    var listener = createEventListenerWrapperWithPriority(targetContainer, domEventName, eventSystemFlags); // If passive option is not supported, then the event will be
+    // active and not passive.
+
+    var isPassiveListener = undefined;
+
+    if (passiveBrowserEventsSupported) {
+      // Browsers introduced an intervention, making these events
+      // passive by default on document. React doesn't bind them
+      // to document anymore, but changing this now would undo
+      // the performance wins from the change. So we emulate
+      // the existing behavior manually on the roots now.
+      // https://github.com/facebook/react/issues/19651
+      if (domEventName === 'touchstart' || domEventName === 'touchmove' || domEventName === 'wheel') {
+        isPassiveListener = true;
+      }
+    }
+
+    targetContainer =  targetContainer;
+    var unsubscribeListener; // When legacyFBSupport is enabled, it's for when we
+
+
+    if (isCapturePhaseListener) {
+      if (isPassiveListener !== undefined) {
+        unsubscribeListener = addEventCaptureListenerWithPassiveFlag(targetContainer, domEventName, listener, isPassiveListener);
+      } else {
+        unsubscribeListener = addEventCaptureListener(targetContainer, domEventName, listener);
+      }
+    } else {
+      if (isPassiveListener !== undefined) {
+        unsubscribeListener = addEventBubbleListenerWithPassiveFlag(targetContainer, domEventName, listener, isPassiveListener);
+      } else {
+        unsubscribeListener = addEventBubbleListener(targetContainer, domEventName, listener);
+      }
+    }
+  }
+
+  function isMatchingRootContainer(grandContainer, targetContainer) {
+    return grandContainer === targetContainer || grandContainer.nodeType === COMMENT_NODE && grandContainer.parentNode === targetContainer;
+  }
+
+  function dispatchEventForPluginEventSystem(domEventName, eventSystemFlags, nativeEvent, targetInst, targetContainer) {
+    var ancestorInst = targetInst;
+
+    if ((eventSystemFlags & IS_EVENT_HANDLE_NON_MANAGED_NODE) === 0 && (eventSystemFlags & IS_NON_DELEGATED) === 0) {
+      var targetContainerNode = targetContainer; // If we are using the legacy FB support flag, we
+
+      if (targetInst !== null) {
+        // The below logic attempts to work out if we need to change
+        // the target fiber to a different ancestor. We had similar logic
+        // in the legacy event system, except the big difference between
+        // systems is that the modern event system now has an event listener
+        // attached to each React Root and React Portal Root. Together,
+        // the DOM nodes representing these roots are the "rootContainer".
+        // To figure out which ancestor instance we should use, we traverse
+        // up the fiber tree from the target instance and attempt to find
+        // root boundaries that match that of our current "rootContainer".
+        // If we find that "rootContainer", we find the parent fiber
+        // sub-tree for that root and make that our ancestor instance.
+        var node = targetInst;
+
+        mainLoop: while (true) {
+          if (node === null) {
+            return;
+          }
+
+          var nodeTag = node.tag;
+
+          if (nodeTag === HostRoot || nodeTag === HostPortal) {
+            var container = node.stateNode.containerInfo;
+
+            if (isMatchingRootContainer(container, targetContainerNode)) {
+              break;
+            }
+
+            if (nodeTag === HostPortal) {
+              // The target is a portal, but it's not the rootContainer we're looking for.
+              // Normally portals handle their own events all the way down to the root.
+              // So we should be able to stop now. However, we don't know if this portal
+              // was part of *our* root.
+              var grandNode = node.return;
+
+              while (grandNode !== null) {
+                var grandTag = grandNode.tag;
+
+                if (grandTag === HostRoot || grandTag === HostPortal) {
+                  var grandContainer = grandNode.stateNode.containerInfo;
+
+                  if (isMatchingRootContainer(grandContainer, targetContainerNode)) {
+                    // This is the rootContainer we're looking for and we found it as
+                    // a parent of the Portal. That means we can ignore it because the
+                    // Portal will bubble through to us.
+                    return;
+                  }
+                }
+
+                grandNode = grandNode.return;
+              }
+            } // Now we need to find it's corresponding host fiber in the other
+            // tree. To do this we can use getClosestInstanceFromNode, but we
+            // need to validate that the fiber is a host instance, otherwise
+            // we need to traverse up through the DOM till we find the correct
+            // node that is from the other tree.
+
+
+            while (container !== null) {
+              var parentNode = getClosestInstanceFromNode(container);
+
+              if (parentNode === null) {
+                return;
+              }
+
+              var parentTag = parentNode.tag;
+
+              if (parentTag === HostComponent || parentTag === HostText) {
+                node = ancestorInst = parentNode;
+                continue mainLoop;
+              }
+
+              container = container.parentNode;
+            }
+          }
+
+          node = node.return;
+        }
+      }
+    }
+
+    batchedEventUpdates(function () {
+      return dispatchEventsForPlugins(domEventName, eventSystemFlags, nativeEvent, ancestorInst);
+    });
+  }
+
+  function createDispatchListener(instance, listener, currentTarget) {
+    return {
+      instance: instance,
+      listener: listener,
+      currentTarget: currentTarget
+    };
+  }
+
+  function accumulateSinglePhaseListeners(targetFiber, reactName, nativeEventType, inCapturePhase, accumulateTargetOnly) {
+    var captureName = reactName !== null ? reactName + 'Capture' : null;
+    var reactEventName = inCapturePhase ? captureName : reactName;
+    var listeners = [];
+    var instance = targetFiber;
+    var lastHostComponent = null; // Accumulate all instances and listeners via the target -> root path.
+
+    while (instance !== null) {
+      var _instance2 = instance,
+          stateNode = _instance2.stateNode,
+          tag = _instance2.tag; // Handle listeners that are on HostComponents (i.e. <div>)
+
+      if (tag === HostComponent && stateNode !== null) {
+        lastHostComponent = stateNode; // createEventHandle listeners
+
+
+        if (reactEventName !== null) {
+          var listener = getListener(instance, reactEventName);
+
+          if (listener != null) {
+            listeners.push(createDispatchListener(instance, listener, lastHostComponent));
+          }
+        }
+      } // If we are only accumulating events for the target, then we don't
+      // continue to propagate through the React fiber tree to find other
+      // listeners.
+
+
+      if (accumulateTargetOnly) {
+        break;
+      }
+
+      instance = instance.return;
+    }
+
+    return listeners;
+  } // We should only use this function for:
+  // - BeforeInputEventPlugin
+  // - ChangeEventPlugin
+  // - SelectEventPlugin
+  // This is because we only process these plugins
+  // in the bubble phase, so we need to accumulate two
+  // phase event listeners (via emulation).
+
+  function accumulateTwoPhaseListeners(targetFiber, reactName) {
+    var captureName = reactName + 'Capture';
+    var listeners = [];
+    var instance = targetFiber; // Accumulate all instances and listeners via the target -> root path.
+
+    while (instance !== null) {
+      var _instance3 = instance,
+          stateNode = _instance3.stateNode,
+          tag = _instance3.tag; // Handle listeners that are on HostComponents (i.e. <div>)
+
+      if (tag === HostComponent && stateNode !== null) {
+        var currentTarget = stateNode;
+        var captureListener = getListener(instance, captureName);
+
+        if (captureListener != null) {
+          listeners.unshift(createDispatchListener(instance, captureListener, currentTarget));
+        }
+
+        var bubbleListener = getListener(instance, reactName);
+
+        if (bubbleListener != null) {
+          listeners.push(createDispatchListener(instance, bubbleListener, currentTarget));
+        }
+      }
+
+      instance = instance.return;
+    }
+
+    return listeners;
+  }
+
+  function getParent(inst) {
+    if (inst === null) {
+      return null;
+    }
+
+    do {
+      inst = inst.return; // TODO: If this is a HostRoot we might want to bail out.
+      // That is depending on if we want nested subtrees (layers) to bubble
+      // events to their parent. We could also go through parentNode on the
+      // host node but that wouldn't work for React Native and doesn't let us
+      // do the portal feature.
+    } while (inst && inst.tag !== HostComponent);
+
+    if (inst) {
+      return inst;
+    }
+
+    return null;
+  }
+  /**
+   * Return the lowest common ancestor of A and B, or null if they are in
+   * different trees.
+   */
+
+
+  function getLowestCommonAncestor(instA, instB) {
+    var nodeA = instA;
+    var nodeB = instB;
+    var depthA = 0;
+
+    for (var tempA = nodeA; tempA; tempA = getParent(tempA)) {
+      depthA++;
+    }
+
+    var depthB = 0;
+
+    for (var tempB = nodeB; tempB; tempB = getParent(tempB)) {
+      depthB++;
+    } // If A is deeper, crawl up.
+
+
+    while (depthA - depthB > 0) {
+      nodeA = getParent(nodeA);
+      depthA--;
+    } // If B is deeper, crawl up.
+
+
+    while (depthB - depthA > 0) {
+      nodeB = getParent(nodeB);
+      depthB--;
+    } // Walk in lockstep until we find a match.
+
+
+    var depth = depthA;
+
+    while (depth--) {
+      if (nodeA === nodeB || nodeB !== null && nodeA === nodeB.alternate) {
+        return nodeA;
+      }
+
+      nodeA = getParent(nodeA);
+      nodeB = getParent(nodeB);
+    }
+
+    return null;
+  }
+
+  function accumulateEnterLeaveListenersForEvent(dispatchQueue, event, target, common, inCapturePhase) {
+    var registrationName = event._reactName;
+    var listeners = [];
+    var instance = target;
+
+    while (instance !== null) {
+      if (instance === common) {
+        break;
+      }
+
+      var _instance4 = instance,
+          alternate = _instance4.alternate,
+          stateNode = _instance4.stateNode,
+          tag = _instance4.tag;
+
+      if (alternate !== null && alternate === common) {
+        break;
+      }
+
+      if (tag === HostComponent && stateNode !== null) {
+        var currentTarget = stateNode;
+
+        if (inCapturePhase) {
+          var captureListener = getListener(instance, registrationName);
+
+          if (captureListener != null) {
+            listeners.unshift(createDispatchListener(instance, captureListener, currentTarget));
+          }
+        } else if (!inCapturePhase) {
+          var bubbleListener = getListener(instance, registrationName);
+
+          if (bubbleListener != null) {
+            listeners.push(createDispatchListener(instance, bubbleListener, currentTarget));
+          }
+        }
+      }
+
+      instance = instance.return;
+    }
+
+    if (listeners.length !== 0) {
+      dispatchQueue.push({
+        event: event,
+        listeners: listeners
+      });
+    }
+  } // We should only use this function for:
+  // - EnterLeaveEventPlugin
+  // This is because we only process this plugin
+  // in the bubble phase, so we need to accumulate two
+  // phase event listeners.
+
+
+  function accumulateEnterLeaveTwoPhaseListeners(dispatchQueue, leaveEvent, enterEvent, from, to) {
+    var common = from && to ? getLowestCommonAncestor(from, to) : null;
+
+    if (from !== null) {
+      accumulateEnterLeaveListenersForEvent(dispatchQueue, leaveEvent, from, common, false);
+    }
+
+    if (to !== null && enterEvent !== null) {
+      accumulateEnterLeaveListenersForEvent(dispatchQueue, enterEvent, to, common, true);
+    }
+  }
+  function getListenerSetKey(domEventName, capture) {
+    return domEventName + "__" + (capture ? 'capture' : 'bubble');
+  }
+
+  var didWarnInvalidHydration = false;
+  var DANGEROUSLY_SET_INNER_HTML = 'dangerouslySetInnerHTML';
+  var SUPPRESS_CONTENT_EDITABLE_WARNING = 'suppressContentEditableWarning';
+  var SUPPRESS_HYDRATION_WARNING = 'suppressHydrationWarning';
+  var AUTOFOCUS = 'autoFocus';
+  var CHILDREN = 'children';
+  var STYLE = 'style';
+  var HTML$1 = '__html';
+  var HTML_NAMESPACE$1 = Namespaces.html;
+  var warnedUnknownTags;
+  var suppressHydrationWarning;
+  var validatePropertiesInDevelopment;
+  var warnForTextDifference;
+  var warnForPropDifference;
+  var warnForExtraAttributes;
+  var warnForInvalidEventListener;
+  var canDiffStyleForHydrationWarning;
+  var normalizeMarkupForTextOrAttribute;
+  var normalizeHTML;
+
+  {
+    warnedUnknownTags = {
+      // There are working polyfills for <dialog>. Let people use it.
+      dialog: true,
+      // Electron ships a custom <webview> tag to display external web content in
+      // an isolated frame and process.
+      // This tag is not present in non Electron environments such as JSDom which
+      // is often used for testing purposes.
+      // @see https://electronjs.org/docs/api/webview-tag
+      webview: true
+    };
+
+    validatePropertiesInDevelopment = function (type, props) {
+      validateProperties(type, props);
+      validateProperties$1(type, props);
+      validateProperties$2(type, props, {
+        registrationNameDependencies: registrationNameDependencies,
+        possibleRegistrationNames: possibleRegistrationNames
+      });
+    }; // IE 11 parses & normalizes the style attribute as opposed to other
+    // browsers. It adds spaces and sorts the properties in some
+    // non-alphabetical order. Handling that would require sorting CSS
+    // properties in the client & server versions or applying
+    // `expectedStyle` to a temporary DOM node to read its `style` attribute
+    // normalized. Since it only affects IE, we're skipping style warnings
+    // in that browser completely in favor of doing all that work.
+    // See https://github.com/facebook/react/issues/11807
+
+
+    canDiffStyleForHydrationWarning = canUseDOM && !document.documentMode; // HTML parsing normalizes CR and CRLF to LF.
+    // It also can turn \u0000 into \uFFFD inside attributes.
+    // https://www.w3.org/TR/html5/single-page.html#preprocessing-the-input-stream
+    // If we have a mismatch, it might be caused by that.
+    // We will still patch up in this case but not fire the warning.
+
+    var NORMALIZE_NEWLINES_REGEX = /\r\n?/g;
+    var NORMALIZE_NULL_AND_REPLACEMENT_REGEX = /\u0000|\uFFFD/g;
+
+    normalizeMarkupForTextOrAttribute = function (markup) {
+      var markupString = typeof markup === 'string' ? markup : '' + markup;
+      return markupString.replace(NORMALIZE_NEWLINES_REGEX, '\n').replace(NORMALIZE_NULL_AND_REPLACEMENT_REGEX, '');
+    };
+
+    warnForTextDifference = function (serverText, clientText) {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      var normalizedClientText = normalizeMarkupForTextOrAttribute(clientText);
+      var normalizedServerText = normalizeMarkupForTextOrAttribute(serverText);
+
+      if (normalizedServerText === normalizedClientText) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Text content did not match. Server: "%s" Client: "%s"', normalizedServerText, normalizedClientText);
+    };
+
+    warnForPropDifference = function (propName, serverValue, clientValue) {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      var normalizedClientValue = normalizeMarkupForTextOrAttribute(clientValue);
+      var normalizedServerValue = normalizeMarkupForTextOrAttribute(serverValue);
+
+      if (normalizedServerValue === normalizedClientValue) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Prop `%s` did not match. Server: %s Client: %s', propName, JSON.stringify(normalizedServerValue), JSON.stringify(normalizedClientValue));
+    };
+
+    warnForExtraAttributes = function (attributeNames) {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+      var names = [];
+      attributeNames.forEach(function (name) {
+        names.push(name);
+      });
+
+      error('Extra attributes from the server: %s', names);
+    };
+
+    warnForInvalidEventListener = function (registrationName, listener) {
+      if (listener === false) {
+        error('Expected `%s` listener to be a function, instead got `false`.\n\n' + 'If you used to conditionally omit it with %s={condition && value}, ' + 'pass %s={condition ? value : undefined} instead.', registrationName, registrationName, registrationName);
+      } else {
+        error('Expected `%s` listener to be a function, instead got a value of `%s` type.', registrationName, typeof listener);
+      }
+    }; // Parse the HTML and read it back to normalize the HTML string so that it
+    // can be used for comparison.
+
+
+    normalizeHTML = function (parent, html) {
+      // We could have created a separate document here to avoid
+      // re-initializing custom elements if they exist. But this breaks
+      // how <noscript> is being handled. So we use the same document.
+      // See the discussion in https://github.com/facebook/react/pull/11157.
+      var testElement = parent.namespaceURI === HTML_NAMESPACE$1 ? parent.ownerDocument.createElement(parent.tagName) : parent.ownerDocument.createElementNS(parent.namespaceURI, parent.tagName);
+      testElement.innerHTML = html;
+      return testElement.innerHTML;
+    };
+  }
+
+  function getOwnerDocumentFromRootContainer(rootContainerElement) {
+    return rootContainerElement.nodeType === DOCUMENT_NODE ? rootContainerElement : rootContainerElement.ownerDocument;
+  }
+
+  function noop() {}
+
+  function trapClickOnNonInteractiveElement(node) {
+    // Mobile Safari does not fire properly bubble click events on
+    // non-interactive elements, which means delegated click listeners do not
+    // fire. The workaround for this bug involves attaching an empty click
+    // listener on the target node.
+    // https://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
+    // Just set it using the onclick property so that we don't have to manage any
+    // bookkeeping for it. Not sure if we need to clear it when the listener is
+    // removed.
+    // TODO: Only do this for the relevant Safaris maybe?
+    node.onclick = noop;
+  }
+
+  function setInitialDOMProperties(tag, domElement, rootContainerElement, nextProps, isCustomComponentTag) {
+    for (var propKey in nextProps) {
+      if (!nextProps.hasOwnProperty(propKey)) {
+        continue;
+      }
+
+      var nextProp = nextProps[propKey];
+
+      if (propKey === STYLE) {
+        {
+          if (nextProp) {
+            // Freeze the next style object so that we can assume it won't be
+            // mutated. We have already warned for this in the past.
+            Object.freeze(nextProp);
+          }
+        } // Relies on `updateStylesByID` not mutating `styleUpdates`.
+
+
+        setValueForStyles(domElement, nextProp);
+      } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
+        var nextHtml = nextProp ? nextProp[HTML$1] : undefined;
+
+        if (nextHtml != null) {
+          setInnerHTML(domElement, nextHtml);
+        }
+      } else if (propKey === CHILDREN) {
+        if (typeof nextProp === 'string') {
+          // Avoid setting initial textContent when the text is empty. In IE11 setting
+          // textContent on a <textarea> will cause the placeholder to not
+          // show within the <textarea> until it has been focused and blurred again.
+          // https://github.com/facebook/react/issues/6731#issuecomment-254874553
+          var canSetTextContent = tag !== 'textarea' || nextProp !== '';
+
+          if (canSetTextContent) {
+            setTextContent(domElement, nextProp);
+          }
+        } else if (typeof nextProp === 'number') {
+          setTextContent(domElement, '' + nextProp);
+        }
+      } else if (propKey === SUPPRESS_CONTENT_EDITABLE_WARNING || propKey === SUPPRESS_HYDRATION_WARNING) ; else if (propKey === AUTOFOCUS) ; else if (registrationNameDependencies.hasOwnProperty(propKey)) {
+        if (nextProp != null) {
+          if ( typeof nextProp !== 'function') {
+            warnForInvalidEventListener(propKey, nextProp);
+          }
+
+          if (propKey === 'onScroll') {
+            listenToNonDelegatedEvent('scroll', domElement);
+          }
+        }
+      } else if (nextProp != null) {
+        setValueForProperty(domElement, propKey, nextProp, isCustomComponentTag);
+      }
+    }
+  }
+
+  function updateDOMProperties(domElement, updatePayload, wasCustomComponentTag, isCustomComponentTag) {
+    // TODO: Handle wasCustomComponentTag
+    for (var i = 0; i < updatePayload.length; i += 2) {
+      var propKey = updatePayload[i];
+      var propValue = updatePayload[i + 1];
+
+      if (propKey === STYLE) {
+        setValueForStyles(domElement, propValue);
+      } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
+        setInnerHTML(domElement, propValue);
+      } else if (propKey === CHILDREN) {
+        setTextContent(domElement, propValue);
+      } else {
+        setValueForProperty(domElement, propKey, propValue, isCustomComponentTag);
+      }
+    }
+  }
+
+  function createElement(type, props, rootContainerElement, parentNamespace) {
+    var isCustomComponentTag; // We create tags in the namespace of their parent container, except HTML
+    // tags get no namespace.
+
+    var ownerDocument = getOwnerDocumentFromRootContainer(rootContainerElement);
+    var domElement;
+    var namespaceURI = parentNamespace;
+
+    if (namespaceURI === HTML_NAMESPACE$1) {
+      namespaceURI = getIntrinsicNamespace(type);
+    }
+
+    if (namespaceURI === HTML_NAMESPACE$1) {
+      {
+        isCustomComponentTag = isCustomComponent(type, props); // Should this check be gated by parent namespace? Not sure we want to
+        // allow <SVG> or <mATH>.
+
+        if (!isCustomComponentTag && type !== type.toLowerCase()) {
+          error('<%s /> is using incorrect casing. ' + 'Use PascalCase for React components, ' + 'or lowercase for HTML elements.', type);
+        }
+      }
+
+      if (type === 'script') {
+        // Create the script via .innerHTML so its "parser-inserted" flag is
+        // set to true and it does not execute
+        var div = ownerDocument.createElement('div');
+
+        div.innerHTML = '<script><' + '/script>'; // eslint-disable-line
+        // This is guaranteed to yield a script element.
+
+        var firstChild = div.firstChild;
+        domElement = div.removeChild(firstChild);
+      } else if (typeof props.is === 'string') {
+        // $FlowIssue `createElement` should be updated for Web Components
+        domElement = ownerDocument.createElement(type, {
+          is: props.is
+        });
+      } else {
+        // Separate else branch instead of using `props.is || undefined` above because of a Firefox bug.
+        // See discussion in https://github.com/facebook/react/pull/6896
+        // and discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1276240
+        domElement = ownerDocument.createElement(type); // Normally attributes are assigned in `setInitialDOMProperties`, however the `multiple` and `size`
+        // attributes on `select`s needs to be added before `option`s are inserted.
+        // This prevents:
+        // - a bug where the `select` does not scroll to the correct option because singular
+        //  `select` elements automatically pick the first item #13222
+        // - a bug where the `select` set the first item as selected despite the `size` attribute #14239
+        // See https://github.com/facebook/react/issues/13222
+        // and https://github.com/facebook/react/issues/14239
+
+        if (type === 'select') {
+          var node = domElement;
+
+          if (props.multiple) {
+            node.multiple = true;
+          } else if (props.size) {
+            // Setting a size greater than 1 causes a select to behave like `multiple=true`, where
+            // it is possible that no option is selected.
+            //
+            // This is only necessary when a select in "single selection mode".
+            node.size = props.size;
+          }
+        }
+      }
+    } else {
+      domElement = ownerDocument.createElementNS(namespaceURI, type);
+    }
+
+    {
+      if (namespaceURI === HTML_NAMESPACE$1) {
+        if (!isCustomComponentTag && Object.prototype.toString.call(domElement) === '[object HTMLUnknownElement]' && !Object.prototype.hasOwnProperty.call(warnedUnknownTags, type)) {
+          warnedUnknownTags[type] = true;
+
+          error('The tag <%s> is unrecognized in this browser. ' + 'If you meant to render a React component, start its name with ' + 'an uppercase letter.', type);
+        }
+      }
+    }
+
+    return domElement;
+  }
+  function createTextNode(text, rootContainerElement) {
+    return getOwnerDocumentFromRootContainer(rootContainerElement).createTextNode(text);
+  }
+  function setInitialProperties(domElement, tag, rawProps, rootContainerElement) {
+    var isCustomComponentTag = isCustomComponent(tag, rawProps);
+
+    {
+      validatePropertiesInDevelopment(tag, rawProps);
+    } // TODO: Make sure that we check isMounted before firing any of these events.
+
+
+    var props;
+
+    switch (tag) {
+      case 'dialog':
+        listenToNonDelegatedEvent('cancel', domElement);
+        listenToNonDelegatedEvent('close', domElement);
+        props = rawProps;
+        break;
+
+      case 'iframe':
+      case 'object':
+      case 'embed':
+        // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the load event.
+        listenToNonDelegatedEvent('load', domElement);
+        props = rawProps;
+        break;
+
+      case 'video':
+      case 'audio':
+        // We listen to these events in case to ensure emulated bubble
+        // listeners still fire for all the media events.
+        for (var i = 0; i < mediaEventTypes.length; i++) {
+          listenToNonDelegatedEvent(mediaEventTypes[i], domElement);
+        }
+
+        props = rawProps;
+        break;
+
+      case 'source':
+        // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the error event.
+        listenToNonDelegatedEvent('error', domElement);
+        props = rawProps;
+        break;
+
+      case 'img':
+      case 'image':
+      case 'link':
+        // We listen to these events in case to ensure emulated bubble
+        // listeners still fire for error and load events.
+        listenToNonDelegatedEvent('error', domElement);
+        listenToNonDelegatedEvent('load', domElement);
+        props = rawProps;
+        break;
+
+      case 'details':
+        // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the toggle event.
+        listenToNonDelegatedEvent('toggle', domElement);
+        props = rawProps;
+        break;
+
+      case 'input':
+        initWrapperState(domElement, rawProps);
+        props = getHostProps(domElement, rawProps); // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the invalid event.
+
+        listenToNonDelegatedEvent('invalid', domElement);
+
+        break;
+
+      case 'option':
+        validateProps(domElement, rawProps);
+        props = getHostProps$1(domElement, rawProps);
+        break;
+
+      case 'select':
+        initWrapperState$1(domElement, rawProps);
+        props = getHostProps$2(domElement, rawProps); // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the invalid event.
+
+        listenToNonDelegatedEvent('invalid', domElement);
+
+        break;
+
+      case 'textarea':
+        initWrapperState$2(domElement, rawProps);
+        props = getHostProps$3(domElement, rawProps); // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the invalid event.
+
+        listenToNonDelegatedEvent('invalid', domElement);
+
+        break;
+
+      default:
+        props = rawProps;
+    }
+
+    assertValidProps(tag, props);
+    setInitialDOMProperties(tag, domElement, rootContainerElement, props, isCustomComponentTag);
+
+    switch (tag) {
+      case 'input':
+        // TODO: Make sure we check if this is still unmounted or do any clean
+        // up necessary since we never stop tracking anymore.
+        track(domElement);
+        postMountWrapper(domElement, rawProps, false);
+        break;
+
+      case 'textarea':
+        // TODO: Make sure we check if this is still unmounted or do any clean
+        // up necessary since we never stop tracking anymore.
+        track(domElement);
+        postMountWrapper$3(domElement);
+        break;
+
+      case 'option':
+        postMountWrapper$1(domElement, rawProps);
+        break;
+
+      case 'select':
+        postMountWrapper$2(domElement, rawProps);
+        break;
+
+      default:
+        if (typeof props.onClick === 'function') {
+          // TODO: This cast may not be sound for SVG, MathML or custom elements.
+          trapClickOnNonInteractiveElement(domElement);
+        }
+
+        break;
+    }
+  } // Calculate the diff between the two objects.
+
+  function diffProperties(domElement, tag, lastRawProps, nextRawProps, rootContainerElement) {
+    {
+      validatePropertiesInDevelopment(tag, nextRawProps);
+    }
+
+    var updatePayload = null;
+    var lastProps;
+    var nextProps;
+
+    switch (tag) {
+      case 'input':
+        lastProps = getHostProps(domElement, lastRawProps);
+        nextProps = getHostProps(domElement, nextRawProps);
+        updatePayload = [];
+        break;
+
+      case 'option':
+        lastProps = getHostProps$1(domElement, lastRawProps);
+        nextProps = getHostProps$1(domElement, nextRawProps);
+        updatePayload = [];
+        break;
+
+      case 'select':
+        lastProps = getHostProps$2(domElement, lastRawProps);
+        nextProps = getHostProps$2(domElement, nextRawProps);
+        updatePayload = [];
+        break;
+
+      case 'textarea':
+        lastProps = getHostProps$3(domElement, lastRawProps);
+        nextProps = getHostProps$3(domElement, nextRawProps);
+        updatePayload = [];
+        break;
+
+      default:
+        lastProps = lastRawProps;
+        nextProps = nextRawProps;
+
+        if (typeof lastProps.onClick !== 'function' && typeof nextProps.onClick === 'function') {
+          // TODO: This cast may not be sound for SVG, MathML or custom elements.
+          trapClickOnNonInteractiveElement(domElement);
+        }
+
+        break;
+    }
+
+    assertValidProps(tag, nextProps);
+    var propKey;
+    var styleName;
+    var styleUpdates = null;
+
+    for (propKey in lastProps) {
+      if (nextProps.hasOwnProperty(propKey) || !lastProps.hasOwnProperty(propKey) || lastProps[propKey] == null) {
+        continue;
+      }
+
+      if (propKey === STYLE) {
+        var lastStyle = lastProps[propKey];
+
+        for (styleName in lastStyle) {
+          if (lastStyle.hasOwnProperty(styleName)) {
+            if (!styleUpdates) {
+              styleUpdates = {};
+            }
+
+            styleUpdates[styleName] = '';
+          }
+        }
+      } else if (propKey === DANGEROUSLY_SET_INNER_HTML || propKey === CHILDREN) ; else if (propKey === SUPPRESS_CONTENT_EDITABLE_WARNING || propKey === SUPPRESS_HYDRATION_WARNING) ; else if (propKey === AUTOFOCUS) ; else if (registrationNameDependencies.hasOwnProperty(propKey)) {
+        // This is a special case. If any listener updates we need to ensure
+        // that the "current" fiber pointer gets updated so we need a commit
+        // to update this element.
+        if (!updatePayload) {
+          updatePayload = [];
+        }
+      } else {
+        // For all other deleted properties we add it to the queue. We use
+        // the allowed property list in the commit phase instead.
+        (updatePayload = updatePayload || []).push(propKey, null);
+      }
+    }
+
+    for (propKey in nextProps) {
+      var nextProp = nextProps[propKey];
+      var lastProp = lastProps != null ? lastProps[propKey] : undefined;
+
+      if (!nextProps.hasOwnProperty(propKey) || nextProp === lastProp || nextProp == null && lastProp == null) {
+        continue;
+      }
+
+      if (propKey === STYLE) {
+        {
+          if (nextProp) {
+            // Freeze the next style object so that we can assume it won't be
+            // mutated. We have already warned for this in the past.
+            Object.freeze(nextProp);
+          }
+        }
+
+        if (lastProp) {
+          // Unset styles on `lastProp` but not on `nextProp`.
+          for (styleName in lastProp) {
+            if (lastProp.hasOwnProperty(styleName) && (!nextProp || !nextProp.hasOwnProperty(styleName))) {
+              if (!styleUpdates) {
+                styleUpdates = {};
+              }
+
+              styleUpdates[styleName] = '';
+            }
+          } // Update styles that changed since `lastProp`.
+
+
+          for (styleName in nextProp) {
+            if (nextProp.hasOwnProperty(styleName) && lastProp[styleName] !== nextProp[styleName]) {
+              if (!styleUpdates) {
+                styleUpdates = {};
+              }
+
+              styleUpdates[styleName] = nextProp[styleName];
+            }
+          }
+        } else {
+          // Relies on `updateStylesByID` not mutating `styleUpdates`.
+          if (!styleUpdates) {
+            if (!updatePayload) {
+              updatePayload = [];
+            }
+
+            updatePayload.push(propKey, styleUpdates);
+          }
+
+          styleUpdates = nextProp;
+        }
+      } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
+        var nextHtml = nextProp ? nextProp[HTML$1] : undefined;
+        var lastHtml = lastProp ? lastProp[HTML$1] : undefined;
+
+        if (nextHtml != null) {
+          if (lastHtml !== nextHtml) {
+            (updatePayload = updatePayload || []).push(propKey, nextHtml);
+          }
+        }
+      } else if (propKey === CHILDREN) {
+        if (typeof nextProp === 'string' || typeof nextProp === 'number') {
+          (updatePayload = updatePayload || []).push(propKey, '' + nextProp);
+        }
+      } else if (propKey === SUPPRESS_CONTENT_EDITABLE_WARNING || propKey === SUPPRESS_HYDRATION_WARNING) ; else if (registrationNameDependencies.hasOwnProperty(propKey)) {
+        if (nextProp != null) {
+          // We eagerly listen to this even though we haven't committed yet.
+          if ( typeof nextProp !== 'function') {
+            warnForInvalidEventListener(propKey, nextProp);
+          }
+
+          if (propKey === 'onScroll') {
+            listenToNonDelegatedEvent('scroll', domElement);
+          }
+        }
+
+        if (!updatePayload && lastProp !== nextProp) {
+          // This is a special case. If any listener updates we need to ensure
+          // that the "current" props pointer gets updated so we need a commit
+          // to update this element.
+          updatePayload = [];
+        }
+      } else if (typeof nextProp === 'object' && nextProp !== null && nextProp.$$typeof === REACT_OPAQUE_ID_TYPE) {
+        // If we encounter useOpaqueReference's opaque object, this means we are hydrating.
+        // In this case, call the opaque object's toString function which generates a new client
+        // ID so client and server IDs match and throws to rerender.
+        nextProp.toString();
+      } else {
+        // For any other property we always add it to the queue and then we
+        // filter it out using the allowed property list during the commit.
+        (updatePayload = updatePayload || []).push(propKey, nextProp);
+      }
+    }
+
+    if (styleUpdates) {
+      {
+        validateShorthandPropertyCollisionInDev(styleUpdates, nextProps[STYLE]);
+      }
+
+      (updatePayload = updatePayload || []).push(STYLE, styleUpdates);
+    }
+
+    return updatePayload;
+  } // Apply the diff.
+
+  function updateProperties(domElement, updatePayload, tag, lastRawProps, nextRawProps) {
+    // Update checked *before* name.
+    // In the middle of an update, it is possible to have multiple checked.
+    // When a checked radio tries to change name, browser makes another radio's checked false.
+    if (tag === 'input' && nextRawProps.type === 'radio' && nextRawProps.name != null) {
+      updateChecked(domElement, nextRawProps);
+    }
+
+    var wasCustomComponentTag = isCustomComponent(tag, lastRawProps);
+    var isCustomComponentTag = isCustomComponent(tag, nextRawProps); // Apply the diff.
+
+    updateDOMProperties(domElement, updatePayload, wasCustomComponentTag, isCustomComponentTag); // TODO: Ensure that an update gets scheduled if any of the special props
+    // changed.
+
+    switch (tag) {
+      case 'input':
+        // Update the wrapper around inputs *after* updating props. This has to
+        // happen after `updateDOMProperties`. Otherwise HTML5 input validations
+        // raise warnings and prevent the new value from being assigned.
+        updateWrapper(domElement, nextRawProps);
+        break;
+
+      case 'textarea':
+        updateWrapper$1(domElement, nextRawProps);
+        break;
+
+      case 'select':
+        // <select> value update needs to occur after <option> children
+        // reconciliation
+        postUpdateWrapper(domElement, nextRawProps);
+        break;
+    }
+  }
+
+  function getPossibleStandardName(propName) {
+    {
+      var lowerCasedName = propName.toLowerCase();
+
+      if (!possibleStandardNames.hasOwnProperty(lowerCasedName)) {
+        return null;
+      }
+
+      return possibleStandardNames[lowerCasedName] || null;
+    }
+  }
+
+  function diffHydratedProperties(domElement, tag, rawProps, parentNamespace, rootContainerElement) {
+    var isCustomComponentTag;
+    var extraAttributeNames;
+
+    {
+      suppressHydrationWarning = rawProps[SUPPRESS_HYDRATION_WARNING] === true;
+      isCustomComponentTag = isCustomComponent(tag, rawProps);
+      validatePropertiesInDevelopment(tag, rawProps);
+    } // TODO: Make sure that we check isMounted before firing any of these events.
+
+
+    switch (tag) {
+      case 'dialog':
+        listenToNonDelegatedEvent('cancel', domElement);
+        listenToNonDelegatedEvent('close', domElement);
+        break;
+
+      case 'iframe':
+      case 'object':
+      case 'embed':
+        // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the load event.
+        listenToNonDelegatedEvent('load', domElement);
+        break;
+
+      case 'video':
+      case 'audio':
+        // We listen to these events in case to ensure emulated bubble
+        // listeners still fire for all the media events.
+        for (var i = 0; i < mediaEventTypes.length; i++) {
+          listenToNonDelegatedEvent(mediaEventTypes[i], domElement);
+        }
+
+        break;
+
+      case 'source':
+        // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the error event.
+        listenToNonDelegatedEvent('error', domElement);
+        break;
+
+      case 'img':
+      case 'image':
+      case 'link':
+        // We listen to these events in case to ensure emulated bubble
+        // listeners still fire for error and load events.
+        listenToNonDelegatedEvent('error', domElement);
+        listenToNonDelegatedEvent('load', domElement);
+        break;
+
+      case 'details':
+        // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the toggle event.
+        listenToNonDelegatedEvent('toggle', domElement);
+        break;
+
+      case 'input':
+        initWrapperState(domElement, rawProps); // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the invalid event.
+
+        listenToNonDelegatedEvent('invalid', domElement);
+
+        break;
+
+      case 'option':
+        validateProps(domElement, rawProps);
+        break;
+
+      case 'select':
+        initWrapperState$1(domElement, rawProps); // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the invalid event.
+
+        listenToNonDelegatedEvent('invalid', domElement);
+
+        break;
+
+      case 'textarea':
+        initWrapperState$2(domElement, rawProps); // We listen to this event in case to ensure emulated bubble
+        // listeners still fire for the invalid event.
+
+        listenToNonDelegatedEvent('invalid', domElement);
+
+        break;
+    }
+
+    assertValidProps(tag, rawProps);
+
+    {
+      extraAttributeNames = new Set();
+      var attributes = domElement.attributes;
+
+      for (var _i = 0; _i < attributes.length; _i++) {
+        var name = attributes[_i].name.toLowerCase();
+
+        switch (name) {
+          // Built-in SSR attribute is allowed
+          case 'data-reactroot':
+            break;
+          // Controlled attributes are not validated
+          // TODO: Only ignore them on controlled tags.
+
+          case 'value':
+            break;
+
+          case 'checked':
+            break;
+
+          case 'selected':
+            break;
+
+          default:
+            // Intentionally use the original name.
+            // See discussion in https://github.com/facebook/react/pull/10676.
+            extraAttributeNames.add(attributes[_i].name);
+        }
+      }
+    }
+
+    var updatePayload = null;
+
+    for (var propKey in rawProps) {
+      if (!rawProps.hasOwnProperty(propKey)) {
+        continue;
+      }
+
+      var nextProp = rawProps[propKey];
+
+      if (propKey === CHILDREN) {
+        // For text content children we compare against textContent. This
+        // might match additional HTML that is hidden when we read it using
+        // textContent. E.g. "foo" will match "f<span>oo</span>" but that still
+        // satisfies our requirement. Our requirement is not to produce perfect
+        // HTML and attributes. Ideally we should preserve structure but it's
+        // ok not to if the visible content is still enough to indicate what
+        // even listeners these nodes might be wired up to.
+        // TODO: Warn if there is more than a single textNode as a child.
+        // TODO: Should we use domElement.firstChild.nodeValue to compare?
+        if (typeof nextProp === 'string') {
+          if (domElement.textContent !== nextProp) {
+            if ( !suppressHydrationWarning) {
+              warnForTextDifference(domElement.textContent, nextProp);
+            }
+
+            updatePayload = [CHILDREN, nextProp];
+          }
+        } else if (typeof nextProp === 'number') {
+          if (domElement.textContent !== '' + nextProp) {
+            if ( !suppressHydrationWarning) {
+              warnForTextDifference(domElement.textContent, nextProp);
+            }
+
+            updatePayload = [CHILDREN, '' + nextProp];
+          }
+        }
+      } else if (registrationNameDependencies.hasOwnProperty(propKey)) {
+        if (nextProp != null) {
+          if ( typeof nextProp !== 'function') {
+            warnForInvalidEventListener(propKey, nextProp);
+          }
+
+          if (propKey === 'onScroll') {
+            listenToNonDelegatedEvent('scroll', domElement);
+          }
+        }
+      } else if ( // Convince Flow we've calculated it (it's DEV-only in this method.)
+      typeof isCustomComponentTag === 'boolean') {
+        // Validate that the properties correspond to their expected values.
+        var serverValue = void 0;
+        var propertyInfo = getPropertyInfo(propKey);
+
+        if (suppressHydrationWarning) ; else if (propKey === SUPPRESS_CONTENT_EDITABLE_WARNING || propKey === SUPPRESS_HYDRATION_WARNING || // Controlled attributes are not validated
+        // TODO: Only ignore them on controlled tags.
+        propKey === 'value' || propKey === 'checked' || propKey === 'selected') ; else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
+          var serverHTML = domElement.innerHTML;
+          var nextHtml = nextProp ? nextProp[HTML$1] : undefined;
+
+          if (nextHtml != null) {
+            var expectedHTML = normalizeHTML(domElement, nextHtml);
+
+            if (expectedHTML !== serverHTML) {
+              warnForPropDifference(propKey, serverHTML, expectedHTML);
+            }
+          }
+        } else if (propKey === STYLE) {
+          // $FlowFixMe - Should be inferred as not undefined.
+          extraAttributeNames.delete(propKey);
+
+          if (canDiffStyleForHydrationWarning) {
+            var expectedStyle = createDangerousStringForStyles(nextProp);
+            serverValue = domElement.getAttribute('style');
+
+            if (expectedStyle !== serverValue) {
+              warnForPropDifference(propKey, serverValue, expectedStyle);
+            }
+          }
+        } else if (isCustomComponentTag) {
+          // $FlowFixMe - Should be inferred as not undefined.
+          extraAttributeNames.delete(propKey.toLowerCase());
+          serverValue = getValueForAttribute(domElement, propKey, nextProp);
+
+          if (nextProp !== serverValue) {
+            warnForPropDifference(propKey, serverValue, nextProp);
+          }
+        } else if (!shouldIgnoreAttribute(propKey, propertyInfo, isCustomComponentTag) && !shouldRemoveAttribute(propKey, nextProp, propertyInfo, isCustomComponentTag)) {
+          var isMismatchDueToBadCasing = false;
+
+          if (propertyInfo !== null) {
+            // $FlowFixMe - Should be inferred as not undefined.
+            extraAttributeNames.delete(propertyInfo.attributeName);
+            serverValue = getValueForProperty(domElement, propKey, nextProp, propertyInfo);
+          } else {
+            var ownNamespace = parentNamespace;
+
+            if (ownNamespace === HTML_NAMESPACE$1) {
+              ownNamespace = getIntrinsicNamespace(tag);
+            }
+
+            if (ownNamespace === HTML_NAMESPACE$1) {
+              // $FlowFixMe - Should be inferred as not undefined.
+              extraAttributeNames.delete(propKey.toLowerCase());
+            } else {
+              var standardName = getPossibleStandardName(propKey);
+
+              if (standardName !== null && standardName !== propKey) {
+                // If an SVG prop is supplied with bad casing, it will
+                // be successfully parsed from HTML, but will produce a mismatch
+                // (and would be incorrectly rendered on the client).
+                // However, we already warn about bad casing elsewhere.
+                // So we'll skip the misleading extra mismatch warning in this case.
+                isMismatchDueToBadCasing = true; // $FlowFixMe - Should be inferred as not undefined.
+
+                extraAttributeNames.delete(standardName);
+              } // $FlowFixMe - Should be inferred as not undefined.
+
+
+              extraAttributeNames.delete(propKey);
+            }
+
+            serverValue = getValueForAttribute(domElement, propKey, nextProp);
+          }
+
+          if (nextProp !== serverValue && !isMismatchDueToBadCasing) {
+            warnForPropDifference(propKey, serverValue, nextProp);
+          }
+        }
+      }
+    }
+
+    {
+      // $FlowFixMe - Should be inferred as not undefined.
+      if (extraAttributeNames.size > 0 && !suppressHydrationWarning) {
+        // $FlowFixMe - Should be inferred as not undefined.
+        warnForExtraAttributes(extraAttributeNames);
+      }
+    }
+
+    switch (tag) {
+      case 'input':
+        // TODO: Make sure we check if this is still unmounted or do any clean
+        // up necessary since we never stop tracking anymore.
+        track(domElement);
+        postMountWrapper(domElement, rawProps, true);
+        break;
+
+      case 'textarea':
+        // TODO: Make sure we check if this is still unmounted or do any clean
+        // up necessary since we never stop tracking anymore.
+        track(domElement);
+        postMountWrapper$3(domElement);
+        break;
+
+      case 'select':
+      case 'option':
+        // For input and textarea we current always set the value property at
+        // post mount to force it to diverge from attributes. However, for
+        // option and select we don't quite do the same thing and select
+        // is not resilient to the DOM state changing so we don't do that here.
+        // TODO: Consider not doing this for input and textarea.
+        break;
+
+      default:
+        if (typeof rawProps.onClick === 'function') {
+          // TODO: This cast may not be sound for SVG, MathML or custom elements.
+          trapClickOnNonInteractiveElement(domElement);
+        }
+
+        break;
+    }
+
+    return updatePayload;
+  }
+  function diffHydratedText(textNode, text) {
+    var isDifferent = textNode.nodeValue !== text;
+    return isDifferent;
+  }
+  function warnForUnmatchedText(textNode, text) {
+    {
+      warnForTextDifference(textNode.nodeValue, text);
+    }
+  }
+  function warnForDeletedHydratableElement(parentNode, child) {
+    {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Did not expect server HTML to contain a <%s> in <%s>.', child.nodeName.toLowerCase(), parentNode.nodeName.toLowerCase());
+    }
+  }
+  function warnForDeletedHydratableText(parentNode, child) {
+    {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Did not expect server HTML to contain the text node "%s" in <%s>.', child.nodeValue, parentNode.nodeName.toLowerCase());
+    }
+  }
+  function warnForInsertedHydratedElement(parentNode, tag, props) {
+    {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Expected server HTML to contain a matching <%s> in <%s>.', tag, parentNode.nodeName.toLowerCase());
+    }
+  }
+  function warnForInsertedHydratedText(parentNode, text) {
+    {
+      if (text === '') {
+        // We expect to insert empty text nodes since they're not represented in
+        // the HTML.
+        // TODO: Remove this special case if we can just avoid inserting empty
+        // text nodes.
+        return;
+      }
+
+      if (didWarnInvalidHydration) {
+        return;
+      }
+
+      didWarnInvalidHydration = true;
+
+      error('Expected server HTML to contain a matching text node for "%s" in <%s>.', text, parentNode.nodeName.toLowerCase());
+    }
+  }
+  function restoreControlledState$3(domElement, tag, props) {
+    switch (tag) {
+      case 'input':
+        restoreControlledState(domElement, props);
+        return;
+
+      case 'textarea':
+        restoreControlledState$2(domElement, props);
+        return;
+
+      case 'select':
+        restoreControlledState$1(domElement, props);
+        return;
+    }
+  }
+
+  var validateDOMNesting = function () {};
+
+  var updatedAncestorInfo = function () {};
+
+  {
+    // This validation code was written based on the HTML5 parsing spec:
+    // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-scope
+    //
+    // Note: this does not catch all invalid nesting, nor does it try to (as it's
+    // not clear what practical benefit doing so provides); instead, we warn only
+    // for cases where the parser will give a parse tree differing from what React
+    // intended. For example, <b><div></div></b> is invalid but we don't warn
+    // because it still parses correctly; we do warn for other cases like nested
+    // <p> tags where the beginning of the second element implicitly closes the
+    // first, causing a confusing mess.
+    // https://html.spec.whatwg.org/multipage/syntax.html#special
+    var specialTags = ['address', 'applet', 'area', 'article', 'aside', 'base', 'basefont', 'bgsound', 'blockquote', 'body', 'br', 'button', 'caption', 'center', 'col', 'colgroup', 'dd', 'details', 'dir', 'div', 'dl', 'dt', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'frame', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'iframe', 'img', 'input', 'isindex', 'li', 'link', 'listing', 'main', 'marquee', 'menu', 'menuitem', 'meta', 'nav', 'noembed', 'noframes', 'noscript', 'object', 'ol', 'p', 'param', 'plaintext', 'pre', 'script', 'section', 'select', 'source', 'style', 'summary', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'title', 'tr', 'track', 'ul', 'wbr', 'xmp']; // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-scope
+
+    var inScopeTags = ['applet', 'caption', 'html', 'table', 'td', 'th', 'marquee', 'object', 'template', // https://html.spec.whatwg.org/multipage/syntax.html#html-integration-point
+    // TODO: Distinguish by namespace here -- for <title>, including it here
+    // errs on the side of fewer warnings
+    'foreignObject', 'desc', 'title']; // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-button-scope
+
+    var buttonScopeTags = inScopeTags.concat(['button']); // https://html.spec.whatwg.org/multipage/syntax.html#generate-implied-end-tags
+
+    var impliedEndTags = ['dd', 'dt', 'li', 'option', 'optgroup', 'p', 'rp', 'rt'];
+    var emptyAncestorInfo = {
+      current: null,
+      formTag: null,
+      aTagInScope: null,
+      buttonTagInScope: null,
+      nobrTagInScope: null,
+      pTagInButtonScope: null,
+      listItemTagAutoclosing: null,
+      dlItemTagAutoclosing: null
+    };
+
+    updatedAncestorInfo = function (oldInfo, tag) {
+      var ancestorInfo = _assign({}, oldInfo || emptyAncestorInfo);
+
+      var info = {
+        tag: tag
+      };
+
+      if (inScopeTags.indexOf(tag) !== -1) {
+        ancestorInfo.aTagInScope = null;
+        ancestorInfo.buttonTagInScope = null;
+        ancestorInfo.nobrTagInScope = null;
+      }
+
+      if (buttonScopeTags.indexOf(tag) !== -1) {
+        ancestorInfo.pTagInButtonScope = null;
+      } // See rules for 'li', 'dd', 'dt' start tags in
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inbody
+
+
+      if (specialTags.indexOf(tag) !== -1 && tag !== 'address' && tag !== 'div' && tag !== 'p') {
+        ancestorInfo.listItemTagAutoclosing = null;
+        ancestorInfo.dlItemTagAutoclosing = null;
+      }
+
+      ancestorInfo.current = info;
+
+      if (tag === 'form') {
+        ancestorInfo.formTag = info;
+      }
+
+      if (tag === 'a') {
+        ancestorInfo.aTagInScope = info;
+      }
+
+      if (tag === 'button') {
+        ancestorInfo.buttonTagInScope = info;
+      }
+
+      if (tag === 'nobr') {
+        ancestorInfo.nobrTagInScope = info;
+      }
+
+      if (tag === 'p') {
+        ancestorInfo.pTagInButtonScope = info;
+      }
+
+      if (tag === 'li') {
+        ancestorInfo.listItemTagAutoclosing = info;
+      }
+
+      if (tag === 'dd' || tag === 'dt') {
+        ancestorInfo.dlItemTagAutoclosing = info;
+      }
+
+      return ancestorInfo;
+    };
+    /**
+     * Returns whether
+     */
+
+
+    var isTagValidWithParent = function (tag, parentTag) {
+      // First, let's check if we're in an unusual parsing mode...
+      switch (parentTag) {
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inselect
+        case 'select':
+          return tag === 'option' || tag === 'optgroup' || tag === '#text';
+
+        case 'optgroup':
+          return tag === 'option' || tag === '#text';
+        // Strictly speaking, seeing an <option> doesn't mean we're in a <select>
+        // but
+
+        case 'option':
+          return tag === '#text';
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intd
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-incaption
+        // No special behavior since these rules fall back to "in body" mode for
+        // all except special table nodes which cause bad parsing behavior anyway.
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intr
+
+        case 'tr':
+          return tag === 'th' || tag === 'td' || tag === 'style' || tag === 'script' || tag === 'template';
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intbody
+
+        case 'tbody':
+        case 'thead':
+        case 'tfoot':
+          return tag === 'tr' || tag === 'style' || tag === 'script' || tag === 'template';
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-incolgroup
+
+        case 'colgroup':
+          return tag === 'col' || tag === 'template';
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intable
+
+        case 'table':
+          return tag === 'caption' || tag === 'colgroup' || tag === 'tbody' || tag === 'tfoot' || tag === 'thead' || tag === 'style' || tag === 'script' || tag === 'template';
+        // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inhead
+
+        case 'head':
+          return tag === 'base' || tag === 'basefont' || tag === 'bgsound' || tag === 'link' || tag === 'meta' || tag === 'title' || tag === 'noscript' || tag === 'noframes' || tag === 'style' || tag === 'script' || tag === 'template';
+        // https://html.spec.whatwg.org/multipage/semantics.html#the-html-element
+
+        case 'html':
+          return tag === 'head' || tag === 'body' || tag === 'frameset';
+
+        case 'frameset':
+          return tag === 'frame';
+
+        case '#document':
+          return tag === 'html';
+      } // Probably in the "in body" parsing mode, so we outlaw only tag combos
+      // where the parsing rules cause implicit opens or closes to be added.
+      // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inbody
+
+
+      switch (tag) {
+        case 'h1':
+        case 'h2':
+        case 'h3':
+        case 'h4':
+        case 'h5':
+        case 'h6':
+          return parentTag !== 'h1' && parentTag !== 'h2' && parentTag !== 'h3' && parentTag !== 'h4' && parentTag !== 'h5' && parentTag !== 'h6';
+
+        case 'rp':
+        case 'rt':
+          return impliedEndTags.indexOf(parentTag) === -1;
+
+        case 'body':
+        case 'caption':
+        case 'col':
+        case 'colgroup':
+        case 'frameset':
+        case 'frame':
+        case 'head':
+        case 'html':
+        case 'tbody':
+        case 'td':
+        case 'tfoot':
+        case 'th':
+        case 'thead':
+        case 'tr':
+          // These tags are only valid with a few parents that have special child
+          // parsing rules -- if we're down here, then none of those matched and
+          // so we allow it only if we don't know what the parent is, as all other
+          // cases are invalid.
+          return parentTag == null;
+      }
+
+      return true;
+    };
+    /**
+     * Returns whether
+     */
+
+
+    var findInvalidAncestorForTag = function (tag, ancestorInfo) {
+      switch (tag) {
+        case 'address':
+        case 'article':
+        case 'aside':
+        case 'blockquote':
+        case 'center':
+        case 'details':
+        case 'dialog':
+        case 'dir':
+        case 'div':
+        case 'dl':
+        case 'fieldset':
+        case 'figcaption':
+        case 'figure':
+        case 'footer':
+        case 'header':
+        case 'hgroup':
+        case 'main':
+        case 'menu':
+        case 'nav':
+        case 'ol':
+        case 'p':
+        case 'section':
+        case 'summary':
+        case 'ul':
+        case 'pre':
+        case 'listing':
+        case 'table':
+        case 'hr':
+        case 'xmp':
+        case 'h1':
+        case 'h2':
+        case 'h3':
+        case 'h4':
+        case 'h5':
+        case 'h6':
+          return ancestorInfo.pTagInButtonScope;
+
+        case 'form':
+          return ancestorInfo.formTag || ancestorInfo.pTagInButtonScope;
+
+        case 'li':
+          return ancestorInfo.listItemTagAutoclosing;
+
+        case 'dd':
+        case 'dt':
+          return ancestorInfo.dlItemTagAutoclosing;
+
+        case 'button':
+          return ancestorInfo.buttonTagInScope;
+
+        case 'a':
+          // Spec says something about storing a list of markers, but it sounds
+          // equivalent to this check.
+          return ancestorInfo.aTagInScope;
+
+        case 'nobr':
+          return ancestorInfo.nobrTagInScope;
+      }
+
+      return null;
+    };
+
+    var didWarn$1 = {};
+
+    validateDOMNesting = function (childTag, childText, ancestorInfo) {
+      ancestorInfo = ancestorInfo || emptyAncestorInfo;
+      var parentInfo = ancestorInfo.current;
+      var parentTag = parentInfo && parentInfo.tag;
+
+      if (childText != null) {
+        if (childTag != null) {
+          error('validateDOMNesting: when childText is passed, childTag should be null');
+        }
+
+        childTag = '#text';
+      }
+
+      var invalidParent = isTagValidWithParent(childTag, parentTag) ? null : parentInfo;
+      var invalidAncestor = invalidParent ? null : findInvalidAncestorForTag(childTag, ancestorInfo);
+      var invalidParentOrAncestor = invalidParent || invalidAncestor;
+
+      if (!invalidParentOrAncestor) {
+        return;
+      }
+
+      var ancestorTag = invalidParentOrAncestor.tag;
+      var warnKey = !!invalidParent + '|' + childTag + '|' + ancestorTag;
+
+      if (didWarn$1[warnKey]) {
+        return;
+      }
+
+      didWarn$1[warnKey] = true;
+      var tagDisplayName = childTag;
+      var whitespaceInfo = '';
+
+      if (childTag === '#text') {
+        if (/\S/.test(childText)) {
+          tagDisplayName = 'Text nodes';
+        } else {
+          tagDisplayName = 'Whitespace text nodes';
+          whitespaceInfo = " Make sure you don't have any extra whitespace between tags on " + 'each line of your source code.';
+        }
+      } else {
+        tagDisplayName = '<' + childTag + '>';
+      }
+
+      if (invalidParent) {
+        var info = '';
+
+        if (ancestorTag === 'table' && childTag === 'tr') {
+          info += ' Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated by ' + 'the browser.';
+        }
+
+        error('validateDOMNesting(...): %s cannot appear as a child of <%s>.%s%s', tagDisplayName, ancestorTag, whitespaceInfo, info);
+      } else {
+        error('validateDOMNesting(...): %s cannot appear as a descendant of ' + '<%s>.', tagDisplayName, ancestorTag);
+      }
+    };
+  }
+
+  var SUPPRESS_HYDRATION_WARNING$1;
+
+  {
+    SUPPRESS_HYDRATION_WARNING$1 = 'suppressHydrationWarning';
+  }
+
+  var SUSPENSE_START_DATA = '$';
+  var SUSPENSE_END_DATA = '/$';
+  var SUSPENSE_PENDING_START_DATA = '$?';
+  var SUSPENSE_FALLBACK_START_DATA = '$!';
+  var STYLE$1 = 'style';
+  var eventsEnabled = null;
+  var selectionInformation = null;
+
+  function shouldAutoFocusHostComponent(type, props) {
+    switch (type) {
+      case 'button':
+      case 'input':
+      case 'select':
+      case 'textarea':
+        return !!props.autoFocus;
+    }
+
+    return false;
+  }
+  function getRootHostContext(rootContainerInstance) {
+    var type;
+    var namespace;
+    var nodeType = rootContainerInstance.nodeType;
+
+    switch (nodeType) {
+      case DOCUMENT_NODE:
+      case DOCUMENT_FRAGMENT_NODE:
+        {
+          type = nodeType === DOCUMENT_NODE ? '#document' : '#fragment';
+          var root = rootContainerInstance.documentElement;
+          namespace = root ? root.namespaceURI : getChildNamespace(null, '');
+          break;
+        }
+
+      default:
+        {
+          var container = nodeType === COMMENT_NODE ? rootContainerInstance.parentNode : rootContainerInstance;
+          var ownNamespace = container.namespaceURI || null;
+          type = container.tagName;
+          namespace = getChildNamespace(ownNamespace, type);
+          break;
+        }
+    }
+
+    {
+      var validatedTag = type.toLowerCase();
+      var ancestorInfo = updatedAncestorInfo(null, validatedTag);
+      return {
+        namespace: namespace,
+        ancestorInfo: ancestorInfo
+      };
+    }
+  }
+  function getChildHostContext(parentHostContext, type, rootContainerInstance) {
+    {
+      var parentHostContextDev = parentHostContext;
+      var namespace = getChildNamespace(parentHostContextDev.namespace, type);
+      var ancestorInfo = updatedAncestorInfo(parentHostContextDev.ancestorInfo, type);
+      return {
+        namespace: namespace,
+        ancestorInfo: ancestorInfo
+      };
+    }
+  }
+  function getPublicInstance(instance) {
+    return instance;
+  }
+  function prepareForCommit(containerInfo) {
+    eventsEnabled = isEnabled();
+    selectionInformation = getSelectionInformation();
+    var activeInstance = null;
+
+    setEnabled(false);
+    return activeInstance;
+  }
+  function resetAfterCommit(containerInfo) {
+    restoreSelection(selectionInformation);
+    setEnabled(eventsEnabled);
+    eventsEnabled = null;
+    selectionInformation = null;
+  }
+  function createInstance(type, props, rootContainerInstance, hostContext, internalInstanceHandle) {
+    var parentNamespace;
+
+    {
+      // TODO: take namespace into account when validating.
+      var hostContextDev = hostContext;
+      validateDOMNesting(type, null, hostContextDev.ancestorInfo);
+
+      if (typeof props.children === 'string' || typeof props.children === 'number') {
+        var string = '' + props.children;
+        var ownAncestorInfo = updatedAncestorInfo(hostContextDev.ancestorInfo, type);
+        validateDOMNesting(null, string, ownAncestorInfo);
+      }
+
+      parentNamespace = hostContextDev.namespace;
+    }
+
+    var domElement = createElement(type, props, rootContainerInstance, parentNamespace);
+    precacheFiberNode(internalInstanceHandle, domElement);
+    updateFiberProps(domElement, props);
+    return domElement;
+  }
+  function appendInitialChild(parentInstance, child) {
+    parentInstance.appendChild(child);
+  }
+  function finalizeInitialChildren(domElement, type, props, rootContainerInstance, hostContext) {
+    setInitialProperties(domElement, type, props, rootContainerInstance);
+    return shouldAutoFocusHostComponent(type, props);
+  }
+  function prepareUpdate(domElement, type, oldProps, newProps, rootContainerInstance, hostContext) {
+    {
+      var hostContextDev = hostContext;
+
+      if (typeof newProps.children !== typeof oldProps.children && (typeof newProps.children === 'string' || typeof newProps.children === 'number')) {
+        var string = '' + newProps.children;
+        var ownAncestorInfo = updatedAncestorInfo(hostContextDev.ancestorInfo, type);
+        validateDOMNesting(null, string, ownAncestorInfo);
+      }
+    }
+
+    return diffProperties(domElement, type, oldProps, newProps);
+  }
+  function shouldSetTextContent(type, props) {
+    return type === 'textarea' || type === 'option' || type === 'noscript' || typeof props.children === 'string' || typeof props.children === 'number' || typeof props.dangerouslySetInnerHTML === 'object' && props.dangerouslySetInnerHTML !== null && props.dangerouslySetInnerHTML.__html != null;
+  }
+  function createTextInstance(text, rootContainerInstance, hostContext, internalInstanceHandle) {
+    {
+      var hostContextDev = hostContext;
+      validateDOMNesting(null, text, hostContextDev.ancestorInfo);
+    }
+
+    var textNode = createTextNode(text, rootContainerInstance);
+    precacheFiberNode(internalInstanceHandle, textNode);
+    return textNode;
+  }
+  // if a component just imports ReactDOM (e.g. for findDOMNode).
+  // Some environments might not have setTimeout or clearTimeout.
+
+  var scheduleTimeout = typeof setTimeout === 'function' ? setTimeout : undefined;
+  var cancelTimeout = typeof clearTimeout === 'function' ? clearTimeout : undefined;
+  var noTimeout = -1; // -------------------
+  function commitMount(domElement, type, newProps, internalInstanceHandle) {
+    // Despite the naming that might imply otherwise, this method only
+    // fires if there is an `Update` effect scheduled during mounting.
+    // This happens if `finalizeInitialChildren` returns `true` (which it
+    // does to implement the `autoFocus` attribute on the client). But
+    // there are also other cases when this might happen (such as patching
+    // up text content during hydration mismatch). So we'll check this again.
+    if (shouldAutoFocusHostComponent(type, newProps)) {
+      domElement.focus();
+    }
+  }
+  function commitUpdate(domElement, updatePayload, type, oldProps, newProps, internalInstanceHandle) {
+    // Update the props handle so that we know which props are the ones with
+    // with current event handlers.
+    updateFiberProps(domElement, newProps); // Apply the diff to the DOM node.
+
+    updateProperties(domElement, updatePayload, type, oldProps, newProps);
+  }
+  function resetTextContent(domElement) {
+    setTextContent(domElement, '');
+  }
+  function commitTextUpdate(textInstance, oldText, newText) {
+    textInstance.nodeValue = newText;
+  }
+  function appendChild(parentInstance, child) {
+    parentInstance.appendChild(child);
+  }
+  function appendChildToContainer(container, child) {
+    var parentNode;
+
+    if (container.nodeType === COMMENT_NODE) {
+      parentNode = container.parentNode;
+      parentNode.insertBefore(child, container);
+    } else {
+      parentNode = container;
+      parentNode.appendChild(child);
+    } // This container might be used for a portal.
+    // If something inside a portal is clicked, that click should bubble
+    // through the React tree. However, on Mobile Safari the click would
+    // never bubble through the *DOM* tree unless an ancestor with onclick
+    // event exists. So we wouldn't see it and dispatch it.
+    // This is why we ensure that non React root containers have inline onclick
+    // defined.
+    // https://github.com/facebook/react/issues/11918
+
+
+    var reactRootContainer = container._reactRootContainer;
+
+    if ((reactRootContainer === null || reactRootContainer === undefined) && parentNode.onclick === null) {
+      // TODO: This cast may not be sound for SVG, MathML or custom elements.
+      trapClickOnNonInteractiveElement(parentNode);
+    }
+  }
+  function insertBefore(parentInstance, child, beforeChild) {
+    parentInstance.insertBefore(child, beforeChild);
+  }
+  function insertInContainerBefore(container, child, beforeChild) {
+    if (container.nodeType === COMMENT_NODE) {
+      container.parentNode.insertBefore(child, beforeChild);
+    } else {
+      container.insertBefore(child, beforeChild);
+    }
+  }
+
+  function removeChild(parentInstance, child) {
+    parentInstance.removeChild(child);
+  }
+  function removeChildFromContainer(container, child) {
+    if (container.nodeType === COMMENT_NODE) {
+      container.parentNode.removeChild(child);
+    } else {
+      container.removeChild(child);
+    }
+  }
+  function hideInstance(instance) {
+    // TODO: Does this work for all element types? What about MathML? Should we
+    // pass host context to this method?
+    instance = instance;
+    var style = instance.style;
+
+    if (typeof style.setProperty === 'function') {
+      style.setProperty('display', 'none', 'important');
+    } else {
+      style.display = 'none';
+    }
+  }
+  function hideTextInstance(textInstance) {
+    textInstance.nodeValue = '';
+  }
+  function unhideInstance(instance, props) {
+    instance = instance;
+    var styleProp = props[STYLE$1];
+    var display = styleProp !== undefined && styleProp !== null && styleProp.hasOwnProperty('display') ? styleProp.display : null;
+    instance.style.display = dangerousStyleValue('display', display);
+  }
+  function unhideTextInstance(textInstance, text) {
+    textInstance.nodeValue = text;
+  }
+  function clearContainer(container) {
+    if (container.nodeType === ELEMENT_NODE) {
+      container.textContent = '';
+    } else if (container.nodeType === DOCUMENT_NODE) {
+      var body = container.body;
+
+      if (body != null) {
+        body.textContent = '';
+      }
+    }
+  } // -------------------
+  function canHydrateInstance(instance, type, props) {
+    if (instance.nodeType !== ELEMENT_NODE || type.toLowerCase() !== instance.nodeName.toLowerCase()) {
+      return null;
+    } // This has now been refined to an element node.
+
+
+    return instance;
+  }
+  function canHydrateTextInstance(instance, text) {
+    if (text === '' || instance.nodeType !== TEXT_NODE) {
+      // Empty strings are not parsed by HTML so there won't be a correct match here.
+      return null;
+    } // This has now been refined to a text node.
+
+
+    return instance;
+  }
+  function isSuspenseInstancePending(instance) {
+    return instance.data === SUSPENSE_PENDING_START_DATA;
+  }
+  function isSuspenseInstanceFallback(instance) {
+    return instance.data === SUSPENSE_FALLBACK_START_DATA;
+  }
+
+  function getNextHydratable(node) {
+    // Skip non-hydratable nodes.
+    for (; node != null; node = node.nextSibling) {
+      var nodeType = node.nodeType;
+
+      if (nodeType === ELEMENT_NODE || nodeType === TEXT_NODE) {
+        break;
+      }
+    }
+
+    return node;
+  }
+
+  function getNextHydratableSibling(instance) {
+    return getNextHydratable(instance.nextSibling);
+  }
+  function getFirstHydratableChild(parentInstance) {
+    return getNextHydratable(parentInstance.firstChild);
+  }
+  function hydrateInstance(instance, type, props, rootContainerInstance, hostContext, internalInstanceHandle) {
+    precacheFiberNode(internalInstanceHandle, instance); // TODO: Possibly defer this until the commit phase where all the events
+    // get attached.
+
+    updateFiberProps(instance, props);
+    var parentNamespace;
+
+    {
+      var hostContextDev = hostContext;
+      parentNamespace = hostContextDev.namespace;
+    }
+
+    return diffHydratedProperties(instance, type, props, parentNamespace);
+  }
+  function hydrateTextInstance(textInstance, text, internalInstanceHandle) {
+    precacheFiberNode(internalInstanceHandle, textInstance);
+    return diffHydratedText(textInstance, text);
+  }
+  function getNextHydratableInstanceAfterSuspenseInstance(suspenseInstance) {
+    var node = suspenseInstance.nextSibling; // Skip past all nodes within this suspense boundary.
+    // There might be nested nodes so we need to keep track of how
+    // deep we are and only break out when we're back on top.
+
+    var depth = 0;
+
+    while (node) {
+      if (node.nodeType === COMMENT_NODE) {
+        var data = node.data;
+
+        if (data === SUSPENSE_END_DATA) {
+          if (depth === 0) {
+            return getNextHydratableSibling(node);
+          } else {
+            depth--;
+          }
+        } else if (data === SUSPENSE_START_DATA || data === SUSPENSE_FALLBACK_START_DATA || data === SUSPENSE_PENDING_START_DATA) {
+          depth++;
+        }
+      }
+
+      node = node.nextSibling;
+    } // TODO: Warn, we didn't find the end comment boundary.
+
+
+    return null;
+  } // Returns the SuspenseInstance if this node is a direct child of a
+  // SuspenseInstance. I.e. if its previous sibling is a Comment with
+  // SUSPENSE_x_START_DATA. Otherwise, null.
+
+  function getParentSuspenseInstance(targetInstance) {
+    var node = targetInstance.previousSibling; // Skip past all nodes within this suspense boundary.
+    // There might be nested nodes so we need to keep track of how
+    // deep we are and only break out when we're back on top.
+
+    var depth = 0;
+
+    while (node) {
+      if (node.nodeType === COMMENT_NODE) {
+        var data = node.data;
+
+        if (data === SUSPENSE_START_DATA || data === SUSPENSE_FALLBACK_START_DATA || data === SUSPENSE_PENDING_START_DATA) {
+          if (depth === 0) {
+            return node;
+          } else {
+            depth--;
+          }
+        } else if (data === SUSPENSE_END_DATA) {
+          depth++;
+        }
+      }
+
+      node = node.previousSibling;
+    }
+
+    return null;
+  }
+  function commitHydratedContainer(container) {
+    // Retry if any event replaying was blocked on this.
+    retryIfBlockedOn(container);
+  }
+  function commitHydratedSuspenseInstance(suspenseInstance) {
+    // Retry if any event replaying was blocked on this.
+    retryIfBlockedOn(suspenseInstance);
+  }
+  function didNotMatchHydratedContainerTextInstance(parentContainer, textInstance, text) {
+    {
+      warnForUnmatchedText(textInstance, text);
+    }
+  }
+  function didNotMatchHydratedTextInstance(parentType, parentProps, parentInstance, textInstance, text) {
+    if ( parentProps[SUPPRESS_HYDRATION_WARNING$1] !== true) {
+      warnForUnmatchedText(textInstance, text);
+    }
+  }
+  function didNotHydrateContainerInstance(parentContainer, instance) {
+    {
+      if (instance.nodeType === ELEMENT_NODE) {
+        warnForDeletedHydratableElement(parentContainer, instance);
+      } else if (instance.nodeType === COMMENT_NODE) ; else {
+        warnForDeletedHydratableText(parentContainer, instance);
+      }
+    }
+  }
+  function didNotHydrateInstance(parentType, parentProps, parentInstance, instance) {
+    if ( parentProps[SUPPRESS_HYDRATION_WARNING$1] !== true) {
+      if (instance.nodeType === ELEMENT_NODE) {
+        warnForDeletedHydratableElement(parentInstance, instance);
+      } else if (instance.nodeType === COMMENT_NODE) ; else {
+        warnForDeletedHydratableText(parentInstance, instance);
+      }
+    }
+  }
+  function didNotFindHydratableContainerInstance(parentContainer, type, props) {
+    {
+      warnForInsertedHydratedElement(parentContainer, type);
+    }
+  }
+  function didNotFindHydratableContainerTextInstance(parentContainer, text) {
+    {
+      warnForInsertedHydratedText(parentContainer, text);
+    }
+  }
+  function didNotFindHydratableInstance(parentType, parentProps, parentInstance, type, props) {
+    if ( parentProps[SUPPRESS_HYDRATION_WARNING$1] !== true) {
+      warnForInsertedHydratedElement(parentInstance, type);
+    }
+  }
+  function didNotFindHydratableTextInstance(parentType, parentProps, parentInstance, text) {
+    if ( parentProps[SUPPRESS_HYDRATION_WARNING$1] !== true) {
+      warnForInsertedHydratedText(parentInstance, text);
+    }
+  }
+  function didNotFindHydratableSuspenseInstance(parentType, parentProps, parentInstance) {
+    if ( parentProps[SUPPRESS_HYDRATION_WARNING$1] !== true) ;
+  }
+  var clientId = 0;
+  function makeClientIdInDEV(warnOnAccessInDEV) {
+    var id = 'r:' + (clientId++).toString(36);
+    return {
+      toString: function () {
+        warnOnAccessInDEV();
+        return id;
+      },
+      valueOf: function () {
+        warnOnAccessInDEV();
+        return id;
+      }
+    };
+  }
+  function isOpaqueHydratingObject(value) {
+    return value !== null && typeof value === 'object' && value.$$typeof === REACT_OPAQUE_ID_TYPE;
+  }
+  function makeOpaqueHydratingObject(attemptToReadValue) {
+    return {
+      $$typeof: REACT_OPAQUE_ID_TYPE,
+      toString: attemptToReadValue,
+      valueOf: attemptToReadValue
+    };
+  }
+  function preparePortalMount(portalInstance) {
+    {
+      listenToAllSupportedEvents(portalInstance);
+    }
+  }
+
+  var randomKey = Math.random().toString(36).slice(2);
+  var internalInstanceKey = '__reactFiber$' + randomKey;
+  var internalPropsKey = '__reactProps$' + randomKey;
+  var internalContainerInstanceKey = '__reactContainer$' + randomKey;
+  var internalEventHandlersKey = '__reactEvents$' + randomKey;
+  function precacheFiberNode(hostInst, node) {
+    node[internalInstanceKey] = hostInst;
+  }
+  function markContainerAsRoot(hostRoot, node) {
+    node[internalContainerInstanceKey] = hostRoot;
+  }
+  function unmarkContainerAsRoot(node) {
+    node[internalContainerInstanceKey] = null;
+  }
+  function isContainerMarkedAsRoot(node) {
+    return !!node[internalContainerInstanceKey];
+  } // Given a DOM node, return the closest HostComponent or HostText fiber ancestor.
+  // If the target node is part of a hydrated or not yet rendered subtree, then
+  // this may also return a SuspenseComponent or HostRoot to indicate that.
+  // Conceptually the HostRoot fiber is a child of the Container node. So if you
+  // pass the Container node as the targetNode, you will not actually get the
+  // HostRoot back. To get to the HostRoot, you need to pass a child of it.
+  // The same thing applies to Suspense boundaries.
+
+  function getClosestInstanceFromNode(targetNode) {
+    var targetInst = targetNode[internalInstanceKey];
+
+    if (targetInst) {
+      // Don't return HostRoot or SuspenseComponent here.
+      return targetInst;
+    } // If the direct event target isn't a React owned DOM node, we need to look
+    // to see if one of its parents is a React owned DOM node.
+
+
+    var parentNode = targetNode.parentNode;
+
+    while (parentNode) {
+      // We'll check if this is a container root that could include
+      // React nodes in the future. We need to check this first because
+      // if we're a child of a dehydrated container, we need to first
+      // find that inner container before moving on to finding the parent
+      // instance. Note that we don't check this field on  the targetNode
+      // itself because the fibers are conceptually between the container
+      // node and the first child. It isn't surrounding the container node.
+      // If it's not a container, we check if it's an instance.
+      targetInst = parentNode[internalContainerInstanceKey] || parentNode[internalInstanceKey];
+
+      if (targetInst) {
+        // Since this wasn't the direct target of the event, we might have
+        // stepped past dehydrated DOM nodes to get here. However they could
+        // also have been non-React nodes. We need to answer which one.
+        // If we the instance doesn't have any children, then there can't be
+        // a nested suspense boundary within it. So we can use this as a fast
+        // bailout. Most of the time, when people add non-React children to
+        // the tree, it is using a ref to a child-less DOM node.
+        // Normally we'd only need to check one of the fibers because if it
+        // has ever gone from having children to deleting them or vice versa
+        // it would have deleted the dehydrated boundary nested inside already.
+        // However, since the HostRoot starts out with an alternate it might
+        // have one on the alternate so we need to check in case this was a
+        // root.
+        var alternate = targetInst.alternate;
+
+        if (targetInst.child !== null || alternate !== null && alternate.child !== null) {
+          // Next we need to figure out if the node that skipped past is
+          // nested within a dehydrated boundary and if so, which one.
+          var suspenseInstance = getParentSuspenseInstance(targetNode);
+
+          while (suspenseInstance !== null) {
+            // We found a suspense instance. That means that we haven't
+            // hydrated it yet. Even though we leave the comments in the
+            // DOM after hydrating, and there are boundaries in the DOM
+            // that could already be hydrated, we wouldn't have found them
+            // through this pass since if the target is hydrated it would
+            // have had an internalInstanceKey on it.
+            // Let's get the fiber associated with the SuspenseComponent
+            // as the deepest instance.
+            var targetSuspenseInst = suspenseInstance[internalInstanceKey];
+
+            if (targetSuspenseInst) {
+              return targetSuspenseInst;
+            } // If we don't find a Fiber on the comment, it might be because
+            // we haven't gotten to hydrate it yet. There might still be a
+            // parent boundary that hasn't above this one so we need to find
+            // the outer most that is known.
+
+
+            suspenseInstance = getParentSuspenseInstance(suspenseInstance); // If we don't find one, then that should mean that the parent
+            // host component also hasn't hydrated yet. We can return it
+            // below since it will bail out on the isMounted check later.
+          }
+        }
+
+        return targetInst;
+      }
+
+      targetNode = parentNode;
+      parentNode = targetNode.parentNode;
+    }
+
+    return null;
+  }
+  /**
+   * Given a DOM node, return the ReactDOMComponent or ReactDOMTextComponent
+   * instance, or null if the node was not rendered by this React.
+   */
+
+  function getInstanceFromNode(node) {
+    var inst = node[internalInstanceKey] || node[internalContainerInstanceKey];
+
+    if (inst) {
+      if (inst.tag === HostComponent || inst.tag === HostText || inst.tag === SuspenseComponent || inst.tag === HostRoot) {
+        return inst;
+      } else {
+        return null;
+      }
+    }
+
+    return null;
+  }
+  /**
+   * Given a ReactDOMComponent or ReactDOMTextComponent, return the corresponding
+   * DOM node.
+   */
+
+  function getNodeFromInstance(inst) {
+    if (inst.tag === HostComponent || inst.tag === HostText) {
+      // In Fiber this, is just the state node right now. We assume it will be
+      // a host component or host text.
+      return inst.stateNode;
+    } // Without this first invariant, passing a non-DOM-component triggers the next
+    // invariant for a missing parent, which is super confusing.
+
+
+    {
+      {
+        throw Error( "getNodeFromInstance: Invalid argument." );
+      }
+    }
+  }
+  function getFiberCurrentPropsFromNode(node) {
+    return node[internalPropsKey] || null;
+  }
+  function updateFiberProps(node, props) {
+    node[internalPropsKey] = props;
+  }
+  function getEventListenerSet(node) {
+    var elementListenerSet = node[internalEventHandlersKey];
+
+    if (elementListenerSet === undefined) {
+      elementListenerSet = node[internalEventHandlersKey] = new Set();
+    }
+
+    return elementListenerSet;
+  }
+
+  var loggedTypeFailures = {};
+  var ReactDebugCurrentFrame$1 = ReactSharedInternals.ReactDebugCurrentFrame;
+
+  function setCurrentlyValidatingElement(element) {
+    {
+      if (element) {
+        var owner = element._owner;
+        var stack = describeUnknownElementTypeFrameInDEV(element.type, element._source, owner ? owner.type : null);
+        ReactDebugCurrentFrame$1.setExtraStackFrame(stack);
+      } else {
+        ReactDebugCurrentFrame$1.setExtraStackFrame(null);
+      }
+    }
+  }
+
+  function checkPropTypes(typeSpecs, values, location, componentName, element) {
+    {
+      // $FlowFixMe This is okay but Flow doesn't know it.
+      var has = Function.call.bind(Object.prototype.hasOwnProperty);
+
+      for (var typeSpecName in typeSpecs) {
+        if (has(typeSpecs, typeSpecName)) {
+          var error$1 = void 0; // Prop type validation may throw. In case they do, we don't want to
+          // fail the render phase where it didn't fail before. So we log it.
+          // After these have been cleaned up, we'll let them throw.
+
+          try {
+            // This is intentionally an invariant that gets caught. It's the same
+            // behavior as without this statement except with a better message.
+            if (typeof typeSpecs[typeSpecName] !== 'function') {
+              var err = Error((componentName || 'React class') + ': ' + location + ' type `' + typeSpecName + '` is invalid; ' + 'it must be a function, usually from the `prop-types` package, but received `' + typeof typeSpecs[typeSpecName] + '`.' + 'This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.');
+              err.name = 'Invariant Violation';
+              throw err;
+            }
+
+            error$1 = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED');
+          } catch (ex) {
+            error$1 = ex;
+          }
+
+          if (error$1 && !(error$1 instanceof Error)) {
+            setCurrentlyValidatingElement(element);
+
+            error('%s: type specification of %s' + ' `%s` is invalid; the type checker ' + 'function must return `null` or an `Error` but returned a %s. ' + 'You may have forgotten to pass an argument to the type checker ' + 'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' + 'shape all require an argument).', componentName || 'React class', location, typeSpecName, typeof error$1);
+
+            setCurrentlyValidatingElement(null);
+          }
+
+          if (error$1 instanceof Error && !(error$1.message in loggedTypeFailures)) {
+            // Only monitor this failure once because there tends to be a lot of the
+            // same error.
+            loggedTypeFailures[error$1.message] = true;
+            setCurrentlyValidatingElement(element);
+
+            error('Failed %s type: %s', location, error$1.message);
+
+            setCurrentlyValidatingElement(null);
+          }
+        }
+      }
+    }
+  }
+
+  var valueStack = [];
+  var fiberStack;
+
+  {
+    fiberStack = [];
+  }
+
+  var index = -1;
+
+  function createCursor(defaultValue) {
+    return {
+      current: defaultValue
+    };
+  }
+
+  function pop(cursor, fiber) {
+    if (index < 0) {
+      {
+        error('Unexpected pop.');
+      }
+
+      return;
+    }
+
+    {
+      if (fiber !== fiberStack[index]) {
+        error('Unexpected Fiber popped.');
+      }
+    }
+
+    cursor.current = valueStack[index];
+    valueStack[index] = null;
+
+    {
+      fiberStack[index] = null;
+    }
+
+    index--;
+  }
+
+  function push(cursor, value, fiber) {
+    index++;
+    valueStack[index] = cursor.current;
+
+    {
+      fiberStack[index] = fiber;
+    }
+
+    cursor.current = value;
+  }
+
+  var warnedAboutMissingGetChildContext;
+
+  {
+    warnedAboutMissingGetChildContext = {};
+  }
+
+  var emptyContextObject = {};
+
+  {
+    Object.freeze(emptyContextObject);
+  } // A cursor to the current merged context object on the stack.
+
+
+  var contextStackCursor = createCursor(emptyContextObject); // A cursor to a boolean indicating whether the context has changed.
+
+  var didPerformWorkStackCursor = createCursor(false); // Keep track of the previous context object that was on the stack.
+  // We use this to get access to the parent context after we have already
+  // pushed the next context provider, and now need to merge their contexts.
+
+  var previousContext = emptyContextObject;
+
+  function getUnmaskedContext(workInProgress, Component, didPushOwnContextIfProvider) {
+    {
+      if (didPushOwnContextIfProvider && isContextProvider(Component)) {
+        // If the fiber is a context provider itself, when we read its context
+        // we may have already pushed its own child context on the stack. A context
+        // provider should not "see" its own child context. Therefore we read the
+        // previous (parent) context instead for a context provider.
+        return previousContext;
+      }
+
+      return contextStackCursor.current;
+    }
+  }
+
+  function cacheContext(workInProgress, unmaskedContext, maskedContext) {
+    {
+      var instance = workInProgress.stateNode;
+      instance.__reactInternalMemoizedUnmaskedChildContext = unmaskedContext;
+      instance.__reactInternalMemoizedMaskedChildContext = maskedContext;
+    }
+  }
+
+  function getMaskedContext(workInProgress, unmaskedContext) {
+    {
+      var type = workInProgress.type;
+      var contextTypes = type.contextTypes;
+
+      if (!contextTypes) {
+        return emptyContextObject;
+      } // Avoid recreating masked context unless unmasked context has changed.
+      // Failing to do this will result in unnecessary calls to componentWillReceiveProps.
+      // This may trigger infinite loops if componentWillReceiveProps calls setState.
+
+
+      var instance = workInProgress.stateNode;
+
+      if (instance && instance.__reactInternalMemoizedUnmaskedChildContext === unmaskedContext) {
+        return instance.__reactInternalMemoizedMaskedChildContext;
+      }
+
+      var context = {};
+
+      for (var key in contextTypes) {
+        context[key] = unmaskedContext[key];
+      }
+
+      {
+        var name = getComponentName(type) || 'Unknown';
+        checkPropTypes(contextTypes, context, 'context', name);
+      } // Cache unmasked context so we can avoid recreating masked context unless necessary.
+      // Context is created before the class component is instantiated so check for instance.
+
+
+      if (instance) {
+        cacheContext(workInProgress, unmaskedContext, context);
+      }
+
+      return context;
+    }
+  }
+
+  function hasContextChanged() {
+    {
+      return didPerformWorkStackCursor.current;
+    }
+  }
+
+  function isContextProvider(type) {
+    {
+      var childContextTypes = type.childContextTypes;
+      return childContextTypes !== null && childContextTypes !== undefined;
+    }
+  }
+
+  function popContext(fiber) {
+    {
+      pop(didPerformWorkStackCursor, fiber);
+      pop(contextStackCursor, fiber);
+    }
+  }
+
+  function popTopLevelContextObject(fiber) {
+    {
+      pop(didPerformWorkStackCursor, fiber);
+      pop(contextStackCursor, fiber);
+    }
+  }
+
+  function pushTopLevelContextObject(fiber, context, didChange) {
+    {
+      if (!(contextStackCursor.current === emptyContextObject)) {
+        {
+          throw Error( "Unexpected context found on stack. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+
+      push(contextStackCursor, context, fiber);
+      push(didPerformWorkStackCursor, didChange, fiber);
+    }
+  }
+
+  function processChildContext(fiber, type, parentContext) {
+    {
+      var instance = fiber.stateNode;
+      var childContextTypes = type.childContextTypes; // TODO (bvaughn) Replace this behavior with an invariant() in the future.
+      // It has only been added in Fiber to match the (unintentional) behavior in Stack.
+
+      if (typeof instance.getChildContext !== 'function') {
+        {
+          var componentName = getComponentName(type) || 'Unknown';
+
+          if (!warnedAboutMissingGetChildContext[componentName]) {
+            warnedAboutMissingGetChildContext[componentName] = true;
+
+            error('%s.childContextTypes is specified but there is no getChildContext() method ' + 'on the instance. You can either define getChildContext() on %s or remove ' + 'childContextTypes from it.', componentName, componentName);
+          }
+        }
+
+        return parentContext;
+      }
+
+      var childContext = instance.getChildContext();
+
+      for (var contextKey in childContext) {
+        if (!(contextKey in childContextTypes)) {
+          {
+            throw Error( (getComponentName(type) || 'Unknown') + ".getChildContext(): key \"" + contextKey + "\" is not defined in childContextTypes." );
+          }
+        }
+      }
+
+      {
+        var name = getComponentName(type) || 'Unknown';
+        checkPropTypes(childContextTypes, childContext, 'child context', name);
+      }
+
+      return _assign({}, parentContext, childContext);
+    }
+  }
+
+  function pushContextProvider(workInProgress) {
+    {
+      var instance = workInProgress.stateNode; // We push the context as early as possible to ensure stack integrity.
+      // If the instance does not exist yet, we will push null at first,
+      // and replace it on the stack later when invalidating the context.
+
+      var memoizedMergedChildContext = instance && instance.__reactInternalMemoizedMergedChildContext || emptyContextObject; // Remember the parent context so we can merge with it later.
+      // Inherit the parent's did-perform-work value to avoid inadvertently blocking updates.
+
+      previousContext = contextStackCursor.current;
+      push(contextStackCursor, memoizedMergedChildContext, workInProgress);
+      push(didPerformWorkStackCursor, didPerformWorkStackCursor.current, workInProgress);
+      return true;
+    }
+  }
+
+  function invalidateContextProvider(workInProgress, type, didChange) {
+    {
+      var instance = workInProgress.stateNode;
+
+      if (!instance) {
+        {
+          throw Error( "Expected to have an instance by this point. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+
+      if (didChange) {
+        // Merge parent and own context.
+        // Skip this if we're not updating due to sCU.
+        // This avoids unnecessarily recomputing memoized values.
+        var mergedContext = processChildContext(workInProgress, type, previousContext);
+        instance.__reactInternalMemoizedMergedChildContext = mergedContext; // Replace the old (or empty) context with the new one.
+        // It is important to unwind the context in the reverse order.
+
+        pop(didPerformWorkStackCursor, workInProgress);
+        pop(contextStackCursor, workInProgress); // Now push the new context and mark that it has changed.
+
+        push(contextStackCursor, mergedContext, workInProgress);
+        push(didPerformWorkStackCursor, didChange, workInProgress);
+      } else {
+        pop(didPerformWorkStackCursor, workInProgress);
+        push(didPerformWorkStackCursor, didChange, workInProgress);
+      }
+    }
+  }
+
+  function findCurrentUnmaskedContext(fiber) {
+    {
+      // Currently this is only used with renderSubtreeIntoContainer; not sure if it
+      // makes sense elsewhere
+      if (!(isFiberMounted(fiber) && fiber.tag === ClassComponent)) {
+        {
+          throw Error( "Expected subtree parent to be a mounted class component. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+
+      var node = fiber;
+
+      do {
+        switch (node.tag) {
+          case HostRoot:
+            return node.stateNode.context;
+
+          case ClassComponent:
+            {
+              var Component = node.type;
+
+              if (isContextProvider(Component)) {
+                return node.stateNode.__reactInternalMemoizedMergedChildContext;
+              }
+
+              break;
+            }
+        }
+
+        node = node.return;
+      } while (node !== null);
+
+      {
+        {
+          throw Error( "Found unexpected detached subtree parent. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+    }
+  }
+
+  var LegacyRoot = 0;
+  var BlockingRoot = 1;
+  var ConcurrentRoot = 2;
+
+  var rendererID = null;
+  var injectedHook = null;
+  var hasLoggedError = false;
+  var isDevToolsPresent = typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined';
+  function injectInternals(internals) {
+    if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+      // No DevTools
+      return false;
+    }
+
+    var hook = __REACT_DEVTOOLS_GLOBAL_HOOK__;
+
+    if (hook.isDisabled) {
+      // This isn't a real property on the hook, but it can be set to opt out
+      // of DevTools integration and associated warnings and logs.
+      // https://github.com/facebook/react/issues/3877
+      return true;
+    }
+
+    if (!hook.supportsFiber) {
+      {
+        error('The installed version of React DevTools is too old and will not work ' + 'with the current version of React. Please update React DevTools. ' + 'https://reactjs.org/link/react-devtools');
+      } // DevTools exists, even though it doesn't support Fiber.
+
+
+      return true;
+    }
+
+    try {
+      rendererID = hook.inject(internals); // We have successfully injected, so now it is safe to set up hooks.
+
+      injectedHook = hook;
+    } catch (err) {
+      // Catch all errors because it is unsafe to throw during initialization.
+      {
+        error('React instrumentation encountered an error: %s.', err);
+      }
+    } // DevTools exists
+
+
+    return true;
+  }
+  function onScheduleRoot(root, children) {
+    {
+      if (injectedHook && typeof injectedHook.onScheduleFiberRoot === 'function') {
+        try {
+          injectedHook.onScheduleFiberRoot(rendererID, root, children);
+        } catch (err) {
+          if ( !hasLoggedError) {
+            hasLoggedError = true;
+
+            error('React instrumentation encountered an error: %s', err);
+          }
+        }
+      }
+    }
+  }
+  function onCommitRoot(root, priorityLevel) {
+    if (injectedHook && typeof injectedHook.onCommitFiberRoot === 'function') {
+      try {
+        var didError = (root.current.flags & DidCapture) === DidCapture;
+
+        if (enableProfilerTimer) {
+          injectedHook.onCommitFiberRoot(rendererID, root, priorityLevel, didError);
+        } else {
+          injectedHook.onCommitFiberRoot(rendererID, root, undefined, didError);
+        }
+      } catch (err) {
+        {
+          if (!hasLoggedError) {
+            hasLoggedError = true;
+
+            error('React instrumentation encountered an error: %s', err);
+          }
+        }
+      }
+    }
+  }
+  function onCommitUnmount(fiber) {
+    if (injectedHook && typeof injectedHook.onCommitFiberUnmount === 'function') {
+      try {
+        injectedHook.onCommitFiberUnmount(rendererID, fiber);
+      } catch (err) {
+        {
+          if (!hasLoggedError) {
+            hasLoggedError = true;
+
+            error('React instrumentation encountered an error: %s', err);
+          }
+        }
+      }
+    }
+  }
+
+  var Scheduler_runWithPriority = unstable_runWithPriority,
+      Scheduler_scheduleCallback = unstable_scheduleCallback,
+      Scheduler_cancelCallback = unstable_cancelCallback,
+      Scheduler_shouldYield = unstable_shouldYield,
+      Scheduler_requestPaint = unstable_requestPaint,
+      Scheduler_now$1 = unstable_now,
+      Scheduler_getCurrentPriorityLevel = unstable_getCurrentPriorityLevel,
+      Scheduler_ImmediatePriority = unstable_ImmediatePriority,
+      Scheduler_UserBlockingPriority = unstable_UserBlockingPriority,
+      Scheduler_NormalPriority = unstable_NormalPriority,
+      Scheduler_LowPriority = unstable_LowPriority,
+      Scheduler_IdlePriority = unstable_IdlePriority;
+
+  {
+    // Provide explicit error message when production+profiling bundle of e.g.
+    // react-dom is used with production (non-profiling) bundle of
+    // scheduler/tracing
+    if (!(__interactionsRef != null && __interactionsRef.current != null)) {
+      {
+        throw Error( "It is not supported to run the profiling version of a renderer (for example, `react-dom/profiling`) without also replacing the `scheduler/tracing` module with `scheduler/tracing-profiling`. Your bundler might have a setting for aliasing both modules. Learn more at https://reactjs.org/link/profiling" );
+      }
+    }
+  }
+
+  var fakeCallbackNode = {}; // Except for NoPriority, these correspond to Scheduler priorities. We use
+  // ascending numbers so we can compare them like numbers. They start at 90 to
+  // avoid clashing with Scheduler's priorities.
+
+  var ImmediatePriority$1 = 99;
+  var UserBlockingPriority$2 = 98;
+  var NormalPriority$1 = 97;
+  var LowPriority$1 = 96;
+  var IdlePriority$1 = 95; // NoPriority is the absence of priority. Also React-only.
+
+  var NoPriority$1 = 90;
+  var shouldYield = Scheduler_shouldYield;
+  var requestPaint = // Fall back gracefully if we're running an older version of Scheduler.
+  Scheduler_requestPaint !== undefined ? Scheduler_requestPaint : function () {};
+  var syncQueue = null;
+  var immediateQueueCallbackNode = null;
+  var isFlushingSyncQueue = false;
+  var initialTimeMs$1 = Scheduler_now$1(); // If the initial timestamp is reasonably small, use Scheduler's `now` directly.
+  // This will be the case for modern browsers that support `performance.now`. In
+  // older browsers, Scheduler falls back to `Date.now`, which returns a Unix
+  // timestamp. In that case, subtract the module initialization time to simulate
+  // the behavior of performance.now and keep our times small enough to fit
+  // within 32 bits.
+  // TODO: Consider lifting this into Scheduler.
+
+  var now = initialTimeMs$1 < 10000 ? Scheduler_now$1 : function () {
+    return Scheduler_now$1() - initialTimeMs$1;
+  };
+  function getCurrentPriorityLevel() {
+    switch (Scheduler_getCurrentPriorityLevel()) {
+      case Scheduler_ImmediatePriority:
+        return ImmediatePriority$1;
+
+      case Scheduler_UserBlockingPriority:
+        return UserBlockingPriority$2;
+
+      case Scheduler_NormalPriority:
+        return NormalPriority$1;
+
+      case Scheduler_LowPriority:
+        return LowPriority$1;
+
+      case Scheduler_IdlePriority:
+        return IdlePriority$1;
+
+      default:
+        {
+          {
+            throw Error( "Unknown priority level." );
+          }
+        }
+
+    }
+  }
+
+  function reactPriorityToSchedulerPriority(reactPriorityLevel) {
+    switch (reactPriorityLevel) {
+      case ImmediatePriority$1:
+        return Scheduler_ImmediatePriority;
+
+      case UserBlockingPriority$2:
+        return Scheduler_UserBlockingPriority;
+
+      case NormalPriority$1:
+        return Scheduler_NormalPriority;
+
+      case LowPriority$1:
+        return Scheduler_LowPriority;
+
+      case IdlePriority$1:
+        return Scheduler_IdlePriority;
+
+      default:
+        {
+          {
+            throw Error( "Unknown priority level." );
+          }
+        }
+
+    }
+  }
+
+  function runWithPriority$1(reactPriorityLevel, fn) {
+    var priorityLevel = reactPriorityToSchedulerPriority(reactPriorityLevel);
+    return Scheduler_runWithPriority(priorityLevel, fn);
+  }
+  function scheduleCallback(reactPriorityLevel, callback, options) {
+    var priorityLevel = reactPriorityToSchedulerPriority(reactPriorityLevel);
+    return Scheduler_scheduleCallback(priorityLevel, callback, options);
+  }
+  function scheduleSyncCallback(callback) {
+    // Push this callback into an internal queue. We'll flush these either in
+    // the next tick, or earlier if something calls `flushSyncCallbackQueue`.
+    if (syncQueue === null) {
+      syncQueue = [callback]; // Flush the queue in the next tick, at the earliest.
+
+      immediateQueueCallbackNode = Scheduler_scheduleCallback(Scheduler_ImmediatePriority, flushSyncCallbackQueueImpl);
+    } else {
+      // Push onto existing queue. Don't need to schedule a callback because
+      // we already scheduled one when we created the queue.
+      syncQueue.push(callback);
+    }
+
+    return fakeCallbackNode;
+  }
+  function cancelCallback(callbackNode) {
+    if (callbackNode !== fakeCallbackNode) {
+      Scheduler_cancelCallback(callbackNode);
+    }
+  }
+  function flushSyncCallbackQueue() {
+    if (immediateQueueCallbackNode !== null) {
+      var node = immediateQueueCallbackNode;
+      immediateQueueCallbackNode = null;
+      Scheduler_cancelCallback(node);
+    }
+
+    flushSyncCallbackQueueImpl();
+  }
+
+  function flushSyncCallbackQueueImpl() {
+    if (!isFlushingSyncQueue && syncQueue !== null) {
+      // Prevent re-entrancy.
+      isFlushingSyncQueue = true;
+      var i = 0;
+
+      {
+        try {
+          var _isSync2 = true;
+          var _queue = syncQueue;
+          runWithPriority$1(ImmediatePriority$1, function () {
+            for (; i < _queue.length; i++) {
+              var callback = _queue[i];
+
+              do {
+                callback = callback(_isSync2);
+              } while (callback !== null);
+            }
+          });
+          syncQueue = null;
+        } catch (error) {
+          // If something throws, leave the remaining callbacks on the queue.
+          if (syncQueue !== null) {
+            syncQueue = syncQueue.slice(i + 1);
+          } // Resume flushing in the next tick
+
+
+          Scheduler_scheduleCallback(Scheduler_ImmediatePriority, flushSyncCallbackQueue);
+          throw error;
+        } finally {
+          isFlushingSyncQueue = false;
+        }
+      }
+    }
+  }
+
+  // TODO: this is special because it gets imported during build.
+  var ReactVersion = '17.0.2';
+
+  var NoMode = 0;
+  var StrictMode = 1; // TODO: Remove BlockingMode and ConcurrentMode by reading from the root
+  // tag instead
+
+  var BlockingMode = 2;
+  var ConcurrentMode = 4;
+  var ProfileMode = 8;
+  var DebugTracingMode = 16;
+
+  var ReactCurrentBatchConfig = ReactSharedInternals.ReactCurrentBatchConfig;
+  var NoTransition = 0;
+  function requestCurrentTransition() {
+    return ReactCurrentBatchConfig.transition;
+  }
+
+  var ReactStrictModeWarnings = {
+    recordUnsafeLifecycleWarnings: function (fiber, instance) {},
+    flushPendingUnsafeLifecycleWarnings: function () {},
+    recordLegacyContextWarning: function (fiber, instance) {},
+    flushLegacyContextWarning: function () {},
+    discardPendingWarnings: function () {}
+  };
+
+  {
+    var findStrictRoot = function (fiber) {
+      var maybeStrictRoot = null;
+      var node = fiber;
+
+      while (node !== null) {
+        if (node.mode & StrictMode) {
+          maybeStrictRoot = node;
+        }
+
+        node = node.return;
+      }
+
+      return maybeStrictRoot;
+    };
+
+    var setToSortedString = function (set) {
+      var array = [];
+      set.forEach(function (value) {
+        array.push(value);
+      });
+      return array.sort().join(', ');
+    };
+
+    var pendingComponentWillMountWarnings = [];
+    var pendingUNSAFE_ComponentWillMountWarnings = [];
+    var pendingComponentWillReceivePropsWarnings = [];
+    var pendingUNSAFE_ComponentWillReceivePropsWarnings = [];
+    var pendingComponentWillUpdateWarnings = [];
+    var pendingUNSAFE_ComponentWillUpdateWarnings = []; // Tracks components we have already warned about.
+
+    var didWarnAboutUnsafeLifecycles = new Set();
+
+    ReactStrictModeWarnings.recordUnsafeLifecycleWarnings = function (fiber, instance) {
+      // Dedup strategy: Warn once per component.
+      if (didWarnAboutUnsafeLifecycles.has(fiber.type)) {
+        return;
+      }
+
+      if (typeof instance.componentWillMount === 'function' && // Don't warn about react-lifecycles-compat polyfilled components.
+      instance.componentWillMount.__suppressDeprecationWarning !== true) {
+        pendingComponentWillMountWarnings.push(fiber);
+      }
+
+      if (fiber.mode & StrictMode && typeof instance.UNSAFE_componentWillMount === 'function') {
+        pendingUNSAFE_ComponentWillMountWarnings.push(fiber);
+      }
+
+      if (typeof instance.componentWillReceiveProps === 'function' && instance.componentWillReceiveProps.__suppressDeprecationWarning !== true) {
+        pendingComponentWillReceivePropsWarnings.push(fiber);
+      }
+
+      if (fiber.mode & StrictMode && typeof instance.UNSAFE_componentWillReceiveProps === 'function') {
+        pendingUNSAFE_ComponentWillReceivePropsWarnings.push(fiber);
+      }
+
+      if (typeof instance.componentWillUpdate === 'function' && instance.componentWillUpdate.__suppressDeprecationWarning !== true) {
+        pendingComponentWillUpdateWarnings.push(fiber);
+      }
+
+      if (fiber.mode & StrictMode && typeof instance.UNSAFE_componentWillUpdate === 'function') {
+        pendingUNSAFE_ComponentWillUpdateWarnings.push(fiber);
+      }
+    };
+
+    ReactStrictModeWarnings.flushPendingUnsafeLifecycleWarnings = function () {
+      // We do an initial pass to gather component names
+      var componentWillMountUniqueNames = new Set();
+
+      if (pendingComponentWillMountWarnings.length > 0) {
+        pendingComponentWillMountWarnings.forEach(function (fiber) {
+          componentWillMountUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingComponentWillMountWarnings = [];
+      }
+
+      var UNSAFE_componentWillMountUniqueNames = new Set();
+
+      if (pendingUNSAFE_ComponentWillMountWarnings.length > 0) {
+        pendingUNSAFE_ComponentWillMountWarnings.forEach(function (fiber) {
+          UNSAFE_componentWillMountUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingUNSAFE_ComponentWillMountWarnings = [];
+      }
+
+      var componentWillReceivePropsUniqueNames = new Set();
+
+      if (pendingComponentWillReceivePropsWarnings.length > 0) {
+        pendingComponentWillReceivePropsWarnings.forEach(function (fiber) {
+          componentWillReceivePropsUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingComponentWillReceivePropsWarnings = [];
+      }
+
+      var UNSAFE_componentWillReceivePropsUniqueNames = new Set();
+
+      if (pendingUNSAFE_ComponentWillReceivePropsWarnings.length > 0) {
+        pendingUNSAFE_ComponentWillReceivePropsWarnings.forEach(function (fiber) {
+          UNSAFE_componentWillReceivePropsUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingUNSAFE_ComponentWillReceivePropsWarnings = [];
+      }
+
+      var componentWillUpdateUniqueNames = new Set();
+
+      if (pendingComponentWillUpdateWarnings.length > 0) {
+        pendingComponentWillUpdateWarnings.forEach(function (fiber) {
+          componentWillUpdateUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingComponentWillUpdateWarnings = [];
+      }
+
+      var UNSAFE_componentWillUpdateUniqueNames = new Set();
+
+      if (pendingUNSAFE_ComponentWillUpdateWarnings.length > 0) {
+        pendingUNSAFE_ComponentWillUpdateWarnings.forEach(function (fiber) {
+          UNSAFE_componentWillUpdateUniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutUnsafeLifecycles.add(fiber.type);
+        });
+        pendingUNSAFE_ComponentWillUpdateWarnings = [];
+      } // Finally, we flush all the warnings
+      // UNSAFE_ ones before the deprecated ones, since they'll be 'louder'
+
+
+      if (UNSAFE_componentWillMountUniqueNames.size > 0) {
+        var sortedNames = setToSortedString(UNSAFE_componentWillMountUniqueNames);
+
+        error('Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. ' + 'See https://reactjs.org/link/unsafe-component-lifecycles for details.\n\n' + '* Move code with side effects to componentDidMount, and set initial state in the constructor.\n' + '\nPlease update the following components: %s', sortedNames);
+      }
+
+      if (UNSAFE_componentWillReceivePropsUniqueNames.size > 0) {
+        var _sortedNames = setToSortedString(UNSAFE_componentWillReceivePropsUniqueNames);
+
+        error('Using UNSAFE_componentWillReceiveProps in strict mode is not recommended ' + 'and may indicate bugs in your code. ' + 'See https://reactjs.org/link/unsafe-component-lifecycles for details.\n\n' + '* Move data fetching code or side effects to componentDidUpdate.\n' + "* If you're updating state whenever props change, " + 'refactor your code to use memoization techniques or move it to ' + 'static getDerivedStateFromProps. Learn more at: https://reactjs.org/link/derived-state\n' + '\nPlease update the following components: %s', _sortedNames);
+      }
+
+      if (UNSAFE_componentWillUpdateUniqueNames.size > 0) {
+        var _sortedNames2 = setToSortedString(UNSAFE_componentWillUpdateUniqueNames);
+
+        error('Using UNSAFE_componentWillUpdate in strict mode is not recommended ' + 'and may indicate bugs in your code. ' + 'See https://reactjs.org/link/unsafe-component-lifecycles for details.\n\n' + '* Move data fetching code or side effects to componentDidUpdate.\n' + '\nPlease update the following components: %s', _sortedNames2);
+      }
+
+      if (componentWillMountUniqueNames.size > 0) {
+        var _sortedNames3 = setToSortedString(componentWillMountUniqueNames);
+
+        warn('componentWillMount has been renamed, and is not recommended for use. ' + 'See https://reactjs.org/link/unsafe-component-lifecycles for details.\n\n' + '* Move code with side effects to componentDidMount, and set initial state in the constructor.\n' + '* Rename componentWillMount to UNSAFE_componentWillMount to suppress ' + 'this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. ' + 'To rename all deprecated lifecycles to their new names, you can run ' + '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' + '\nPlease update the following components: %s', _sortedNames3);
+      }
+
+      if (componentWillReceivePropsUniqueNames.size > 0) {
+        var _sortedNames4 = setToSortedString(componentWillReceivePropsUniqueNames);
+
+        warn('componentWillReceiveProps has been renamed, and is not recommended for use. ' + 'See https://reactjs.org/link/unsafe-component-lifecycles for details.\n\n' + '* Move data fetching code or side effects to componentDidUpdate.\n' + "* If you're updating state whenever props change, refactor your " + 'code to use memoization techniques or move it to ' + 'static getDerivedStateFromProps. Learn more at: https://reactjs.org/link/derived-state\n' + '* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress ' + 'this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. ' + 'To rename all deprecated lifecycles to their new names, you can run ' + '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' + '\nPlease update the following components: %s', _sortedNames4);
+      }
+
+      if (componentWillUpdateUniqueNames.size > 0) {
+        var _sortedNames5 = setToSortedString(componentWillUpdateUniqueNames);
+
+        warn('componentWillUpdate has been renamed, and is not recommended for use. ' + 'See https://reactjs.org/link/unsafe-component-lifecycles for details.\n\n' + '* Move data fetching code or side effects to componentDidUpdate.\n' + '* Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress ' + 'this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. ' + 'To rename all deprecated lifecycles to their new names, you can run ' + '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' + '\nPlease update the following components: %s', _sortedNames5);
+      }
+    };
+
+    var pendingLegacyContextWarning = new Map(); // Tracks components we have already warned about.
+
+    var didWarnAboutLegacyContext = new Set();
+
+    ReactStrictModeWarnings.recordLegacyContextWarning = function (fiber, instance) {
+      var strictRoot = findStrictRoot(fiber);
+
+      if (strictRoot === null) {
+        error('Expected to find a StrictMode component in a strict mode tree. ' + 'This error is likely caused by a bug in React. Please file an issue.');
+
+        return;
+      } // Dedup strategy: Warn once per component.
+
+
+      if (didWarnAboutLegacyContext.has(fiber.type)) {
+        return;
+      }
+
+      var warningsForRoot = pendingLegacyContextWarning.get(strictRoot);
+
+      if (fiber.type.contextTypes != null || fiber.type.childContextTypes != null || instance !== null && typeof instance.getChildContext === 'function') {
+        if (warningsForRoot === undefined) {
+          warningsForRoot = [];
+          pendingLegacyContextWarning.set(strictRoot, warningsForRoot);
+        }
+
+        warningsForRoot.push(fiber);
+      }
+    };
+
+    ReactStrictModeWarnings.flushLegacyContextWarning = function () {
+      pendingLegacyContextWarning.forEach(function (fiberArray, strictRoot) {
+        if (fiberArray.length === 0) {
+          return;
+        }
+
+        var firstFiber = fiberArray[0];
+        var uniqueNames = new Set();
+        fiberArray.forEach(function (fiber) {
+          uniqueNames.add(getComponentName(fiber.type) || 'Component');
+          didWarnAboutLegacyContext.add(fiber.type);
+        });
+        var sortedNames = setToSortedString(uniqueNames);
+
+        try {
+          setCurrentFiber(firstFiber);
+
+          error('Legacy context API has been detected within a strict-mode tree.' + '\n\nThe old API will be supported in all 16.x releases, but applications ' + 'using it should migrate to the new version.' + '\n\nPlease update the following components: %s' + '\n\nLearn more about this warning here: https://reactjs.org/link/legacy-context', sortedNames);
+        } finally {
+          resetCurrentFiber();
+        }
+      });
+    };
+
+    ReactStrictModeWarnings.discardPendingWarnings = function () {
+      pendingComponentWillMountWarnings = [];
+      pendingUNSAFE_ComponentWillMountWarnings = [];
+      pendingComponentWillReceivePropsWarnings = [];
+      pendingUNSAFE_ComponentWillReceivePropsWarnings = [];
+      pendingComponentWillUpdateWarnings = [];
+      pendingUNSAFE_ComponentWillUpdateWarnings = [];
+      pendingLegacyContextWarning = new Map();
+    };
+  }
+
+  function resolveDefaultProps(Component, baseProps) {
+    if (Component && Component.defaultProps) {
+      // Resolve default props. Taken from ReactElement
+      var props = _assign({}, baseProps);
+
+      var defaultProps = Component.defaultProps;
+
+      for (var propName in defaultProps) {
+        if (props[propName] === undefined) {
+          props[propName] = defaultProps[propName];
+        }
+      }
+
+      return props;
+    }
+
+    return baseProps;
+  }
+
+  // Max 31 bit integer. The max integer size in V8 for 32-bit systems.
+  // Math.pow(2, 30) - 1
+  // 0b111111111111111111111111111111
+  var MAX_SIGNED_31_BIT_INT = 1073741823;
+
+  var valueCursor = createCursor(null);
+  var rendererSigil;
+
+  {
+    // Use this to detect multiple renderers using the same context
+    rendererSigil = {};
+  }
+
+  var currentlyRenderingFiber = null;
+  var lastContextDependency = null;
+  var lastContextWithAllBitsObserved = null;
+  var isDisallowedContextReadInDEV = false;
+  function resetContextDependencies() {
+    // This is called right before React yields execution, to ensure `readContext`
+    // cannot be called outside the render phase.
+    currentlyRenderingFiber = null;
+    lastContextDependency = null;
+    lastContextWithAllBitsObserved = null;
+
+    {
+      isDisallowedContextReadInDEV = false;
+    }
+  }
+  function enterDisallowedContextReadInDEV() {
+    {
+      isDisallowedContextReadInDEV = true;
+    }
+  }
+  function exitDisallowedContextReadInDEV() {
+    {
+      isDisallowedContextReadInDEV = false;
+    }
+  }
+  function pushProvider(providerFiber, nextValue) {
+    var context = providerFiber.type._context;
+
+    {
+      push(valueCursor, context._currentValue, providerFiber);
+      context._currentValue = nextValue;
+
+      {
+        if (context._currentRenderer !== undefined && context._currentRenderer !== null && context._currentRenderer !== rendererSigil) {
+          error('Detected multiple renderers concurrently rendering the ' + 'same context provider. This is currently unsupported.');
+        }
+
+        context._currentRenderer = rendererSigil;
+      }
+    }
+  }
+  function popProvider(providerFiber) {
+    var currentValue = valueCursor.current;
+    pop(valueCursor, providerFiber);
+    var context = providerFiber.type._context;
+
+    {
+      context._currentValue = currentValue;
+    }
+  }
+  function calculateChangedBits(context, newValue, oldValue) {
+    if (objectIs(oldValue, newValue)) {
+      // No change
+      return 0;
+    } else {
+      var changedBits = typeof context._calculateChangedBits === 'function' ? context._calculateChangedBits(oldValue, newValue) : MAX_SIGNED_31_BIT_INT;
+
+      {
+        if ((changedBits & MAX_SIGNED_31_BIT_INT) !== changedBits) {
+          error('calculateChangedBits: Expected the return value to be a ' + '31-bit integer. Instead received: %s', changedBits);
+        }
+      }
+
+      return changedBits | 0;
+    }
+  }
+  function scheduleWorkOnParentPath(parent, renderLanes) {
+    // Update the child lanes of all the ancestors, including the alternates.
+    var node = parent;
+
+    while (node !== null) {
+      var alternate = node.alternate;
+
+      if (!isSubsetOfLanes(node.childLanes, renderLanes)) {
+        node.childLanes = mergeLanes(node.childLanes, renderLanes);
+
+        if (alternate !== null) {
+          alternate.childLanes = mergeLanes(alternate.childLanes, renderLanes);
+        }
+      } else if (alternate !== null && !isSubsetOfLanes(alternate.childLanes, renderLanes)) {
+        alternate.childLanes = mergeLanes(alternate.childLanes, renderLanes);
+      } else {
+        // Neither alternate was updated, which means the rest of the
+        // ancestor path already has sufficient priority.
+        break;
+      }
+
+      node = node.return;
+    }
+  }
+  function propagateContextChange(workInProgress, context, changedBits, renderLanes) {
+    var fiber = workInProgress.child;
+
+    if (fiber !== null) {
+      // Set the return pointer of the child to the work-in-progress fiber.
+      fiber.return = workInProgress;
+    }
+
+    while (fiber !== null) {
+      var nextFiber = void 0; // Visit this fiber.
+
+      var list = fiber.dependencies;
+
+      if (list !== null) {
+        nextFiber = fiber.child;
+        var dependency = list.firstContext;
+
+        while (dependency !== null) {
+          // Check if the context matches.
+          if (dependency.context === context && (dependency.observedBits & changedBits) !== 0) {
+            // Match! Schedule an update on this fiber.
+            if (fiber.tag === ClassComponent) {
+              // Schedule a force update on the work-in-progress.
+              var update = createUpdate(NoTimestamp, pickArbitraryLane(renderLanes));
+              update.tag = ForceUpdate; // TODO: Because we don't have a work-in-progress, this will add the
+              // update to the current fiber, too, which means it will persist even if
+              // this render is thrown away. Since it's a race condition, not sure it's
+              // worth fixing.
+
+              enqueueUpdate(fiber, update);
+            }
+
+            fiber.lanes = mergeLanes(fiber.lanes, renderLanes);
+            var alternate = fiber.alternate;
+
+            if (alternate !== null) {
+              alternate.lanes = mergeLanes(alternate.lanes, renderLanes);
+            }
+
+            scheduleWorkOnParentPath(fiber.return, renderLanes); // Mark the updated lanes on the list, too.
+
+            list.lanes = mergeLanes(list.lanes, renderLanes); // Since we already found a match, we can stop traversing the
+            // dependency list.
+
+            break;
+          }
+
+          dependency = dependency.next;
+        }
+      } else if (fiber.tag === ContextProvider) {
+        // Don't scan deeper if this is a matching provider
+        nextFiber = fiber.type === workInProgress.type ? null : fiber.child;
+      } else {
+        // Traverse down.
+        nextFiber = fiber.child;
+      }
+
+      if (nextFiber !== null) {
+        // Set the return pointer of the child to the work-in-progress fiber.
+        nextFiber.return = fiber;
+      } else {
+        // No child. Traverse to next sibling.
+        nextFiber = fiber;
+
+        while (nextFiber !== null) {
+          if (nextFiber === workInProgress) {
+            // We're back to the root of this subtree. Exit.
+            nextFiber = null;
+            break;
+          }
+
+          var sibling = nextFiber.sibling;
+
+          if (sibling !== null) {
+            // Set the return pointer of the sibling to the work-in-progress fiber.
+            sibling.return = nextFiber.return;
+            nextFiber = sibling;
+            break;
+          } // No more siblings. Traverse up.
+
+
+          nextFiber = nextFiber.return;
+        }
+      }
+
+      fiber = nextFiber;
+    }
+  }
+  function prepareToReadContext(workInProgress, renderLanes) {
+    currentlyRenderingFiber = workInProgress;
+    lastContextDependency = null;
+    lastContextWithAllBitsObserved = null;
+    var dependencies = workInProgress.dependencies;
+
+    if (dependencies !== null) {
+      var firstContext = dependencies.firstContext;
+
+      if (firstContext !== null) {
+        if (includesSomeLane(dependencies.lanes, renderLanes)) {
+          // Context list has a pending update. Mark that this fiber performed work.
+          markWorkInProgressReceivedUpdate();
+        } // Reset the work-in-progress list
+
+
+        dependencies.firstContext = null;
+      }
+    }
+  }
+  function readContext(context, observedBits) {
+    {
+      // This warning would fire if you read context inside a Hook like useMemo.
+      // Unlike the class check below, it's not enforced in production for perf.
+      if (isDisallowedContextReadInDEV) {
+        error('Context can only be read while React is rendering. ' + 'In classes, you can read it in the render method or getDerivedStateFromProps. ' + 'In function components, you can read it directly in the function body, but not ' + 'inside Hooks like useReducer() or useMemo().');
+      }
+    }
+
+    if (lastContextWithAllBitsObserved === context) ; else if (observedBits === false || observedBits === 0) ; else {
+      var resolvedObservedBits; // Avoid deopting on observable arguments or heterogeneous types.
+
+      if (typeof observedBits !== 'number' || observedBits === MAX_SIGNED_31_BIT_INT) {
+        // Observe all updates.
+        lastContextWithAllBitsObserved = context;
+        resolvedObservedBits = MAX_SIGNED_31_BIT_INT;
+      } else {
+        resolvedObservedBits = observedBits;
+      }
+
+      var contextItem = {
+        context: context,
+        observedBits: resolvedObservedBits,
+        next: null
+      };
+
+      if (lastContextDependency === null) {
+        if (!(currentlyRenderingFiber !== null)) {
+          {
+            throw Error( "Context can only be read while React is rendering. In classes, you can read it in the render method or getDerivedStateFromProps. In function components, you can read it directly in the function body, but not inside Hooks like useReducer() or useMemo()." );
+          }
+        } // This is the first dependency for this component. Create a new list.
+
+
+        lastContextDependency = contextItem;
+        currentlyRenderingFiber.dependencies = {
+          lanes: NoLanes,
+          firstContext: contextItem,
+          responders: null
+        };
+      } else {
+        // Append a new context item.
+        lastContextDependency = lastContextDependency.next = contextItem;
+      }
+    }
+
+    return  context._currentValue ;
+  }
+
+  var UpdateState = 0;
+  var ReplaceState = 1;
+  var ForceUpdate = 2;
+  var CaptureUpdate = 3; // Global state that is reset at the beginning of calling `processUpdateQueue`.
+  // It should only be read right after calling `processUpdateQueue`, via
+  // `checkHasForceUpdateAfterProcessing`.
+
+  var hasForceUpdate = false;
+  var didWarnUpdateInsideUpdate;
+  var currentlyProcessingQueue;
+
+  {
+    didWarnUpdateInsideUpdate = false;
+    currentlyProcessingQueue = null;
+  }
+
+  function initializeUpdateQueue(fiber) {
+    var queue = {
+      baseState: fiber.memoizedState,
+      firstBaseUpdate: null,
+      lastBaseUpdate: null,
+      shared: {
+        pending: null
+      },
+      effects: null
+    };
+    fiber.updateQueue = queue;
+  }
+  function cloneUpdateQueue(current, workInProgress) {
+    // Clone the update queue from current. Unless it's already a clone.
+    var queue = workInProgress.updateQueue;
+    var currentQueue = current.updateQueue;
+
+    if (queue === currentQueue) {
+      var clone = {
+        baseState: currentQueue.baseState,
+        firstBaseUpdate: currentQueue.firstBaseUpdate,
+        lastBaseUpdate: currentQueue.lastBaseUpdate,
+        shared: currentQueue.shared,
+        effects: currentQueue.effects
+      };
+      workInProgress.updateQueue = clone;
+    }
+  }
+  function createUpdate(eventTime, lane) {
+    var update = {
+      eventTime: eventTime,
+      lane: lane,
+      tag: UpdateState,
+      payload: null,
+      callback: null,
+      next: null
+    };
+    return update;
+  }
+  function enqueueUpdate(fiber, update) {
+    var updateQueue = fiber.updateQueue;
+
+    if (updateQueue === null) {
+      // Only occurs if the fiber has been unmounted.
+      return;
+    }
+
+    var sharedQueue = updateQueue.shared;
+    var pending = sharedQueue.pending;
+
+    if (pending === null) {
+      // This is the first update. Create a circular list.
+      update.next = update;
+    } else {
+      update.next = pending.next;
+      pending.next = update;
+    }
+
+    sharedQueue.pending = update;
+
+    {
+      if (currentlyProcessingQueue === sharedQueue && !didWarnUpdateInsideUpdate) {
+        error('An update (setState, replaceState, or forceUpdate) was scheduled ' + 'from inside an update function. Update functions should be pure, ' + 'with zero side-effects. Consider using componentDidUpdate or a ' + 'callback.');
+
+        didWarnUpdateInsideUpdate = true;
+      }
+    }
+  }
+  function enqueueCapturedUpdate(workInProgress, capturedUpdate) {
+    // Captured updates are updates that are thrown by a child during the render
+    // phase. They should be discarded if the render is aborted. Therefore,
+    // we should only put them on the work-in-progress queue, not the current one.
+    var queue = workInProgress.updateQueue; // Check if the work-in-progress queue is a clone.
+
+    var current = workInProgress.alternate;
+
+    if (current !== null) {
+      var currentQueue = current.updateQueue;
+
+      if (queue === currentQueue) {
+        // The work-in-progress queue is the same as current. This happens when
+        // we bail out on a parent fiber that then captures an error thrown by
+        // a child. Since we want to append the update only to the work-in
+        // -progress queue, we need to clone the updates. We usually clone during
+        // processUpdateQueue, but that didn't happen in this case because we
+        // skipped over the parent when we bailed out.
+        var newFirst = null;
+        var newLast = null;
+        var firstBaseUpdate = queue.firstBaseUpdate;
+
+        if (firstBaseUpdate !== null) {
+          // Loop through the updates and clone them.
+          var update = firstBaseUpdate;
+
+          do {
+            var clone = {
+              eventTime: update.eventTime,
+              lane: update.lane,
+              tag: update.tag,
+              payload: update.payload,
+              callback: update.callback,
+              next: null
+            };
+
+            if (newLast === null) {
+              newFirst = newLast = clone;
+            } else {
+              newLast.next = clone;
+              newLast = clone;
+            }
+
+            update = update.next;
+          } while (update !== null); // Append the captured update the end of the cloned list.
+
+
+          if (newLast === null) {
+            newFirst = newLast = capturedUpdate;
+          } else {
+            newLast.next = capturedUpdate;
+            newLast = capturedUpdate;
+          }
+        } else {
+          // There are no base updates.
+          newFirst = newLast = capturedUpdate;
+        }
+
+        queue = {
+          baseState: currentQueue.baseState,
+          firstBaseUpdate: newFirst,
+          lastBaseUpdate: newLast,
+          shared: currentQueue.shared,
+          effects: currentQueue.effects
+        };
+        workInProgress.updateQueue = queue;
+        return;
+      }
+    } // Append the update to the end of the list.
+
+
+    var lastBaseUpdate = queue.lastBaseUpdate;
+
+    if (lastBaseUpdate === null) {
+      queue.firstBaseUpdate = capturedUpdate;
+    } else {
+      lastBaseUpdate.next = capturedUpdate;
+    }
+
+    queue.lastBaseUpdate = capturedUpdate;
+  }
+
+  function getStateFromUpdate(workInProgress, queue, update, prevState, nextProps, instance) {
+    switch (update.tag) {
+      case ReplaceState:
+        {
+          var payload = update.payload;
+
+          if (typeof payload === 'function') {
+            // Updater function
+            {
+              enterDisallowedContextReadInDEV();
+            }
+
+            var nextState = payload.call(instance, prevState, nextProps);
+
+            {
+              if ( workInProgress.mode & StrictMode) {
+                disableLogs();
+
+                try {
+                  payload.call(instance, prevState, nextProps);
+                } finally {
+                  reenableLogs();
+                }
+              }
+
+              exitDisallowedContextReadInDEV();
+            }
+
+            return nextState;
+          } // State object
+
+
+          return payload;
+        }
+
+      case CaptureUpdate:
+        {
+          workInProgress.flags = workInProgress.flags & ~ShouldCapture | DidCapture;
+        }
+      // Intentional fallthrough
+
+      case UpdateState:
+        {
+          var _payload = update.payload;
+          var partialState;
+
+          if (typeof _payload === 'function') {
+            // Updater function
+            {
+              enterDisallowedContextReadInDEV();
+            }
+
+            partialState = _payload.call(instance, prevState, nextProps);
+
+            {
+              if ( workInProgress.mode & StrictMode) {
+                disableLogs();
+
+                try {
+                  _payload.call(instance, prevState, nextProps);
+                } finally {
+                  reenableLogs();
+                }
+              }
+
+              exitDisallowedContextReadInDEV();
+            }
+          } else {
+            // Partial state object
+            partialState = _payload;
+          }
+
+          if (partialState === null || partialState === undefined) {
+            // Null and undefined are treated as no-ops.
+            return prevState;
+          } // Merge the partial state and the previous state.
+
+
+          return _assign({}, prevState, partialState);
+        }
+
+      case ForceUpdate:
+        {
+          hasForceUpdate = true;
+          return prevState;
+        }
+    }
+
+    return prevState;
+  }
+
+  function processUpdateQueue(workInProgress, props, instance, renderLanes) {
+    // This is always non-null on a ClassComponent or HostRoot
+    var queue = workInProgress.updateQueue;
+    hasForceUpdate = false;
+
+    {
+      currentlyProcessingQueue = queue.shared;
+    }
+
+    var firstBaseUpdate = queue.firstBaseUpdate;
+    var lastBaseUpdate = queue.lastBaseUpdate; // Check if there are pending updates. If so, transfer them to the base queue.
+
+    var pendingQueue = queue.shared.pending;
+
+    if (pendingQueue !== null) {
+      queue.shared.pending = null; // The pending queue is circular. Disconnect the pointer between first
+      // and last so that it's non-circular.
+
+      var lastPendingUpdate = pendingQueue;
+      var firstPendingUpdate = lastPendingUpdate.next;
+      lastPendingUpdate.next = null; // Append pending updates to base queue
+
+      if (lastBaseUpdate === null) {
+        firstBaseUpdate = firstPendingUpdate;
+      } else {
+        lastBaseUpdate.next = firstPendingUpdate;
+      }
+
+      lastBaseUpdate = lastPendingUpdate; // If there's a current queue, and it's different from the base queue, then
+      // we need to transfer the updates to that queue, too. Because the base
+      // queue is a singly-linked list with no cycles, we can append to both
+      // lists and take advantage of structural sharing.
+      // TODO: Pass `current` as argument
+
+      var current = workInProgress.alternate;
+
+      if (current !== null) {
+        // This is always non-null on a ClassComponent or HostRoot
+        var currentQueue = current.updateQueue;
+        var currentLastBaseUpdate = currentQueue.lastBaseUpdate;
+
+        if (currentLastBaseUpdate !== lastBaseUpdate) {
+          if (currentLastBaseUpdate === null) {
+            currentQueue.firstBaseUpdate = firstPendingUpdate;
+          } else {
+            currentLastBaseUpdate.next = firstPendingUpdate;
+          }
+
+          currentQueue.lastBaseUpdate = lastPendingUpdate;
+        }
+      }
+    } // These values may change as we process the queue.
+
+
+    if (firstBaseUpdate !== null) {
+      // Iterate through the list of updates to compute the result.
+      var newState = queue.baseState; // TODO: Don't need to accumulate this. Instead, we can remove renderLanes
+      // from the original lanes.
+
+      var newLanes = NoLanes;
+      var newBaseState = null;
+      var newFirstBaseUpdate = null;
+      var newLastBaseUpdate = null;
+      var update = firstBaseUpdate;
+
+      do {
+        var updateLane = update.lane;
+        var updateEventTime = update.eventTime;
+
+        if (!isSubsetOfLanes(renderLanes, updateLane)) {
+          // Priority is insufficient. Skip this update. If this is the first
+          // skipped update, the previous update/state is the new base
+          // update/state.
+          var clone = {
+            eventTime: updateEventTime,
+            lane: updateLane,
+            tag: update.tag,
+            payload: update.payload,
+            callback: update.callback,
+            next: null
+          };
+
+          if (newLastBaseUpdate === null) {
+            newFirstBaseUpdate = newLastBaseUpdate = clone;
+            newBaseState = newState;
+          } else {
+            newLastBaseUpdate = newLastBaseUpdate.next = clone;
+          } // Update the remaining priority in the queue.
+
+
+          newLanes = mergeLanes(newLanes, updateLane);
+        } else {
+          // This update does have sufficient priority.
+          if (newLastBaseUpdate !== null) {
+            var _clone = {
+              eventTime: updateEventTime,
+              // This update is going to be committed so we never want uncommit
+              // it. Using NoLane works because 0 is a subset of all bitmasks, so
+              // this will never be skipped by the check above.
+              lane: NoLane,
+              tag: update.tag,
+              payload: update.payload,
+              callback: update.callback,
+              next: null
+            };
+            newLastBaseUpdate = newLastBaseUpdate.next = _clone;
+          } // Process this update.
+
+
+          newState = getStateFromUpdate(workInProgress, queue, update, newState, props, instance);
+          var callback = update.callback;
+
+          if (callback !== null) {
+            workInProgress.flags |= Callback;
+            var effects = queue.effects;
+
+            if (effects === null) {
+              queue.effects = [update];
+            } else {
+              effects.push(update);
+            }
+          }
+        }
+
+        update = update.next;
+
+        if (update === null) {
+          pendingQueue = queue.shared.pending;
+
+          if (pendingQueue === null) {
+            break;
+          } else {
+            // An update was scheduled from inside a reducer. Add the new
+            // pending updates to the end of the list and keep processing.
+            var _lastPendingUpdate = pendingQueue; // Intentionally unsound. Pending updates form a circular list, but we
+            // unravel them when transferring them to the base queue.
+
+            var _firstPendingUpdate = _lastPendingUpdate.next;
+            _lastPendingUpdate.next = null;
+            update = _firstPendingUpdate;
+            queue.lastBaseUpdate = _lastPendingUpdate;
+            queue.shared.pending = null;
+          }
+        }
+      } while (true);
+
+      if (newLastBaseUpdate === null) {
+        newBaseState = newState;
+      }
+
+      queue.baseState = newBaseState;
+      queue.firstBaseUpdate = newFirstBaseUpdate;
+      queue.lastBaseUpdate = newLastBaseUpdate; // Set the remaining expiration time to be whatever is remaining in the queue.
+      // This should be fine because the only two other things that contribute to
+      // expiration time are props and context. We're already in the middle of the
+      // begin phase by the time we start processing the queue, so we've already
+      // dealt with the props. Context in components that specify
+      // shouldComponentUpdate is tricky; but we'll have to account for
+      // that regardless.
+
+      markSkippedUpdateLanes(newLanes);
+      workInProgress.lanes = newLanes;
+      workInProgress.memoizedState = newState;
+    }
+
+    {
+      currentlyProcessingQueue = null;
+    }
+  }
+
+  function callCallback(callback, context) {
+    if (!(typeof callback === 'function')) {
+      {
+        throw Error( "Invalid argument passed as callback. Expected a function. Instead received: " + callback );
+      }
+    }
+
+    callback.call(context);
+  }
+
+  function resetHasForceUpdateBeforeProcessing() {
+    hasForceUpdate = false;
+  }
+  function checkHasForceUpdateAfterProcessing() {
+    return hasForceUpdate;
+  }
+  function commitUpdateQueue(finishedWork, finishedQueue, instance) {
+    // Commit the effects
+    var effects = finishedQueue.effects;
+    finishedQueue.effects = null;
+
+    if (effects !== null) {
+      for (var i = 0; i < effects.length; i++) {
+        var effect = effects[i];
+        var callback = effect.callback;
+
+        if (callback !== null) {
+          effect.callback = null;
+          callCallback(callback, instance);
+        }
+      }
+    }
+  }
+
+  var fakeInternalInstance = {};
+  var isArray = Array.isArray; // React.Component uses a shared frozen object by default.
+  // We'll use it to determine whether we need to initialize legacy refs.
+
+  var emptyRefsObject = new React.Component().refs;
+  var didWarnAboutStateAssignmentForComponent;
+  var didWarnAboutUninitializedState;
+  var didWarnAboutGetSnapshotBeforeUpdateWithoutDidUpdate;
+  var didWarnAboutLegacyLifecyclesAndDerivedState;
+  var didWarnAboutUndefinedDerivedState;
+  var warnOnUndefinedDerivedState;
+  var warnOnInvalidCallback;
+  var didWarnAboutDirectlyAssigningPropsToState;
+  var didWarnAboutContextTypeAndContextTypes;
+  var didWarnAboutInvalidateContextType;
+
+  {
+    didWarnAboutStateAssignmentForComponent = new Set();
+    didWarnAboutUninitializedState = new Set();
+    didWarnAboutGetSnapshotBeforeUpdateWithoutDidUpdate = new Set();
+    didWarnAboutLegacyLifecyclesAndDerivedState = new Set();
+    didWarnAboutDirectlyAssigningPropsToState = new Set();
+    didWarnAboutUndefinedDerivedState = new Set();
+    didWarnAboutContextTypeAndContextTypes = new Set();
+    didWarnAboutInvalidateContextType = new Set();
+    var didWarnOnInvalidCallback = new Set();
+
+    warnOnInvalidCallback = function (callback, callerName) {
+      if (callback === null || typeof callback === 'function') {
+        return;
+      }
+
+      var key = callerName + '_' + callback;
+
+      if (!didWarnOnInvalidCallback.has(key)) {
+        didWarnOnInvalidCallback.add(key);
+
+        error('%s(...): Expected the last optional `callback` argument to be a ' + 'function. Instead received: %s.', callerName, callback);
+      }
+    };
+
+    warnOnUndefinedDerivedState = function (type, partialState) {
+      if (partialState === undefined) {
+        var componentName = getComponentName(type) || 'Component';
+
+        if (!didWarnAboutUndefinedDerivedState.has(componentName)) {
+          didWarnAboutUndefinedDerivedState.add(componentName);
+
+          error('%s.getDerivedStateFromProps(): A valid state object (or null) must be returned. ' + 'You have returned undefined.', componentName);
+        }
+      }
+    }; // This is so gross but it's at least non-critical and can be removed if
+    // it causes problems. This is meant to give a nicer error message for
+    // ReactDOM15.unstable_renderSubtreeIntoContainer(reactDOM16Component,
+    // ...)) which otherwise throws a "_processChildContext is not a function"
+    // exception.
+
+
+    Object.defineProperty(fakeInternalInstance, '_processChildContext', {
+      enumerable: false,
+      value: function () {
+        {
+          {
+            throw Error( "_processChildContext is not available in React 16+. This likely means you have multiple copies of React and are attempting to nest a React 15 tree inside a React 16 tree using unstable_renderSubtreeIntoContainer, which isn't supported. Try to make sure you have only one copy of React (and ideally, switch to ReactDOM.createPortal)." );
+          }
+        }
+      }
+    });
+    Object.freeze(fakeInternalInstance);
+  }
+
+  function applyDerivedStateFromProps(workInProgress, ctor, getDerivedStateFromProps, nextProps) {
+    var prevState = workInProgress.memoizedState;
+
+    {
+      if ( workInProgress.mode & StrictMode) {
+        disableLogs();
+
+        try {
+          // Invoke the function an extra time to help detect side-effects.
+          getDerivedStateFromProps(nextProps, prevState);
+        } finally {
+          reenableLogs();
+        }
+      }
+    }
+
+    var partialState = getDerivedStateFromProps(nextProps, prevState);
+
+    {
+      warnOnUndefinedDerivedState(ctor, partialState);
+    } // Merge the partial state and the previous state.
+
+
+    var memoizedState = partialState === null || partialState === undefined ? prevState : _assign({}, prevState, partialState);
+    workInProgress.memoizedState = memoizedState; // Once the update queue is empty, persist the derived state onto the
+    // base state.
+
+    if (workInProgress.lanes === NoLanes) {
+      // Queue is always non-null for classes
+      var updateQueue = workInProgress.updateQueue;
+      updateQueue.baseState = memoizedState;
+    }
+  }
+  var classComponentUpdater = {
+    isMounted: isMounted,
+    enqueueSetState: function (inst, payload, callback) {
+      var fiber = get(inst);
+      var eventTime = requestEventTime();
+      var lane = requestUpdateLane(fiber);
+      var update = createUpdate(eventTime, lane);
+      update.payload = payload;
+
+      if (callback !== undefined && callback !== null) {
+        {
+          warnOnInvalidCallback(callback, 'setState');
+        }
+
+        update.callback = callback;
+      }
+
+      enqueueUpdate(fiber, update);
+      scheduleUpdateOnFiber(fiber, lane, eventTime);
+    },
+    enqueueReplaceState: function (inst, payload, callback) {
+      var fiber = get(inst);
+      var eventTime = requestEventTime();
+      var lane = requestUpdateLane(fiber);
+      var update = createUpdate(eventTime, lane);
+      update.tag = ReplaceState;
+      update.payload = payload;
+
+      if (callback !== undefined && callback !== null) {
+        {
+          warnOnInvalidCallback(callback, 'replaceState');
+        }
+
+        update.callback = callback;
+      }
+
+      enqueueUpdate(fiber, update);
+      scheduleUpdateOnFiber(fiber, lane, eventTime);
+    },
+    enqueueForceUpdate: function (inst, callback) {
+      var fiber = get(inst);
+      var eventTime = requestEventTime();
+      var lane = requestUpdateLane(fiber);
+      var update = createUpdate(eventTime, lane);
+      update.tag = ForceUpdate;
+
+      if (callback !== undefined && callback !== null) {
+        {
+          warnOnInvalidCallback(callback, 'forceUpdate');
+        }
+
+        update.callback = callback;
+      }
+
+      enqueueUpdate(fiber, update);
+      scheduleUpdateOnFiber(fiber, lane, eventTime);
+    }
+  };
+
+  function checkShouldComponentUpdate(workInProgress, ctor, oldProps, newProps, oldState, newState, nextContext) {
+    var instance = workInProgress.stateNode;
+
+    if (typeof instance.shouldComponentUpdate === 'function') {
+      {
+        if ( workInProgress.mode & StrictMode) {
+          disableLogs();
+
+          try {
+            // Invoke the function an extra time to help detect side-effects.
+            instance.shouldComponentUpdate(newProps, newState, nextContext);
+          } finally {
+            reenableLogs();
+          }
+        }
+      }
+
+      var shouldUpdate = instance.shouldComponentUpdate(newProps, newState, nextContext);
+
+      {
+        if (shouldUpdate === undefined) {
+          error('%s.shouldComponentUpdate(): Returned undefined instead of a ' + 'boolean value. Make sure to return true or false.', getComponentName(ctor) || 'Component');
+        }
+      }
+
+      return shouldUpdate;
+    }
+
+    if (ctor.prototype && ctor.prototype.isPureReactComponent) {
+      return !shallowEqual(oldProps, newProps) || !shallowEqual(oldState, newState);
+    }
+
+    return true;
+  }
+
+  function checkClassInstance(workInProgress, ctor, newProps) {
+    var instance = workInProgress.stateNode;
+
+    {
+      var name = getComponentName(ctor) || 'Component';
+      var renderPresent = instance.render;
+
+      if (!renderPresent) {
+        if (ctor.prototype && typeof ctor.prototype.render === 'function') {
+          error('%s(...): No `render` method found on the returned component ' + 'instance: did you accidentally return an object from the constructor?', name);
+        } else {
+          error('%s(...): No `render` method found on the returned component ' + 'instance: you may have forgotten to define `render`.', name);
+        }
+      }
+
+      if (instance.getInitialState && !instance.getInitialState.isReactClassApproved && !instance.state) {
+        error('getInitialState was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Did you mean to define a state property instead?', name);
+      }
+
+      if (instance.getDefaultProps && !instance.getDefaultProps.isReactClassApproved) {
+        error('getDefaultProps was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Use a static property to define defaultProps instead.', name);
+      }
+
+      if (instance.propTypes) {
+        error('propTypes was defined as an instance property on %s. Use a static ' + 'property to define propTypes instead.', name);
+      }
+
+      if (instance.contextType) {
+        error('contextType was defined as an instance property on %s. Use a static ' + 'property to define contextType instead.', name);
+      }
+
+      {
+        if (instance.contextTypes) {
+          error('contextTypes was defined as an instance property on %s. Use a static ' + 'property to define contextTypes instead.', name);
+        }
+
+        if (ctor.contextType && ctor.contextTypes && !didWarnAboutContextTypeAndContextTypes.has(ctor)) {
+          didWarnAboutContextTypeAndContextTypes.add(ctor);
+
+          error('%s declares both contextTypes and contextType static properties. ' + 'The legacy contextTypes property will be ignored.', name);
+        }
+      }
+
+      if (typeof instance.componentShouldUpdate === 'function') {
+        error('%s has a method called ' + 'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' + 'The name is phrased as a question because the function is ' + 'expected to return a value.', name);
+      }
+
+      if (ctor.prototype && ctor.prototype.isPureReactComponent && typeof instance.shouldComponentUpdate !== 'undefined') {
+        error('%s has a method called shouldComponentUpdate(). ' + 'shouldComponentUpdate should not be used when extending React.PureComponent. ' + 'Please extend React.Component if shouldComponentUpdate is used.', getComponentName(ctor) || 'A pure component');
+      }
+
+      if (typeof instance.componentDidUnmount === 'function') {
+        error('%s has a method called ' + 'componentDidUnmount(). But there is no such lifecycle method. ' + 'Did you mean componentWillUnmount()?', name);
+      }
+
+      if (typeof instance.componentDidReceiveProps === 'function') {
+        error('%s has a method called ' + 'componentDidReceiveProps(). But there is no such lifecycle method. ' + 'If you meant to update the state in response to changing props, ' + 'use componentWillReceiveProps(). If you meant to fetch data or ' + 'run side-effects or mutations after React has updated the UI, use componentDidUpdate().', name);
+      }
+
+      if (typeof instance.componentWillRecieveProps === 'function') {
+        error('%s has a method called ' + 'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?', name);
+      }
+
+      if (typeof instance.UNSAFE_componentWillRecieveProps === 'function') {
+        error('%s has a method called ' + 'UNSAFE_componentWillRecieveProps(). Did you mean UNSAFE_componentWillReceiveProps()?', name);
+      }
+
+      var hasMutatedProps = instance.props !== newProps;
+
+      if (instance.props !== undefined && hasMutatedProps) {
+        error('%s(...): When calling super() in `%s`, make sure to pass ' + "up the same props that your component's constructor was passed.", name, name);
+      }
+
+      if (instance.defaultProps) {
+        error('Setting defaultProps as an instance property on %s is not supported and will be ignored.' + ' Instead, define defaultProps as a static property on %s.', name, name);
+      }
+
+      if (typeof instance.getSnapshotBeforeUpdate === 'function' && typeof instance.componentDidUpdate !== 'function' && !didWarnAboutGetSnapshotBeforeUpdateWithoutDidUpdate.has(ctor)) {
+        didWarnAboutGetSnapshotBeforeUpdateWithoutDidUpdate.add(ctor);
+
+        error('%s: getSnapshotBeforeUpdate() should be used with componentDidUpdate(). ' + 'This component defines getSnapshotBeforeUpdate() only.', getComponentName(ctor));
+      }
+
+      if (typeof instance.getDerivedStateFromProps === 'function') {
+        error('%s: getDerivedStateFromProps() is defined as an instance method ' + 'and will be ignored. Instead, declare it as a static method.', name);
+      }
+
+      if (typeof instance.getDerivedStateFromError === 'function') {
+        error('%s: getDerivedStateFromError() is defined as an instance method ' + 'and will be ignored. Instead, declare it as a static method.', name);
+      }
+
+      if (typeof ctor.getSnapshotBeforeUpdate === 'function') {
+        error('%s: getSnapshotBeforeUpdate() is defined as a static method ' + 'and will be ignored. Instead, declare it as an instance method.', name);
+      }
+
+      var _state = instance.state;
+
+      if (_state && (typeof _state !== 'object' || isArray(_state))) {
+        error('%s.state: must be set to an object or null', name);
+      }
+
+      if (typeof instance.getChildContext === 'function' && typeof ctor.childContextTypes !== 'object') {
+        error('%s.getChildContext(): childContextTypes must be defined in order to ' + 'use getChildContext().', name);
+      }
+    }
+  }
+
+  function adoptClassInstance(workInProgress, instance) {
+    instance.updater = classComponentUpdater;
+    workInProgress.stateNode = instance; // The instance needs access to the fiber so that it can schedule updates
+
+    set(instance, workInProgress);
+
+    {
+      instance._reactInternalInstance = fakeInternalInstance;
+    }
+  }
+
+  function constructClassInstance(workInProgress, ctor, props) {
+    var isLegacyContextConsumer = false;
+    var unmaskedContext = emptyContextObject;
+    var context = emptyContextObject;
+    var contextType = ctor.contextType;
+
+    {
+      if ('contextType' in ctor) {
+        var isValid = // Allow null for conditional declaration
+        contextType === null || contextType !== undefined && contextType.$$typeof === REACT_CONTEXT_TYPE && contextType._context === undefined; // Not a <Context.Consumer>
+
+        if (!isValid && !didWarnAboutInvalidateContextType.has(ctor)) {
+          didWarnAboutInvalidateContextType.add(ctor);
+          var addendum = '';
+
+          if (contextType === undefined) {
+            addendum = ' However, it is set to undefined. ' + 'This can be caused by a typo or by mixing up named and default imports. ' + 'This can also happen due to a circular dependency, so ' + 'try moving the createContext() call to a separate file.';
+          } else if (typeof contextType !== 'object') {
+            addendum = ' However, it is set to a ' + typeof contextType + '.';
+          } else if (contextType.$$typeof === REACT_PROVIDER_TYPE) {
+            addendum = ' Did you accidentally pass the Context.Provider instead?';
+          } else if (contextType._context !== undefined) {
+            // <Context.Consumer>
+            addendum = ' Did you accidentally pass the Context.Consumer instead?';
+          } else {
+            addendum = ' However, it is set to an object with keys {' + Object.keys(contextType).join(', ') + '}.';
+          }
+
+          error('%s defines an invalid contextType. ' + 'contextType should point to the Context object returned by React.createContext().%s', getComponentName(ctor) || 'Component', addendum);
+        }
+      }
+    }
+
+    if (typeof contextType === 'object' && contextType !== null) {
+      context = readContext(contextType);
+    } else {
+      unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
+      var contextTypes = ctor.contextTypes;
+      isLegacyContextConsumer = contextTypes !== null && contextTypes !== undefined;
+      context = isLegacyContextConsumer ? getMaskedContext(workInProgress, unmaskedContext) : emptyContextObject;
+    } // Instantiate twice to help detect side-effects.
+
+
+    {
+      if ( workInProgress.mode & StrictMode) {
+        disableLogs();
+
+        try {
+          new ctor(props, context); // eslint-disable-line no-new
+        } finally {
+          reenableLogs();
+        }
+      }
+    }
+
+    var instance = new ctor(props, context);
+    var state = workInProgress.memoizedState = instance.state !== null && instance.state !== undefined ? instance.state : null;
+    adoptClassInstance(workInProgress, instance);
+
+    {
+      if (typeof ctor.getDerivedStateFromProps === 'function' && state === null) {
+        var componentName = getComponentName(ctor) || 'Component';
+
+        if (!didWarnAboutUninitializedState.has(componentName)) {
+          didWarnAboutUninitializedState.add(componentName);
+
+          error('`%s` uses `getDerivedStateFromProps` but its initial state is ' + '%s. This is not recommended. Instead, define the initial state by ' + 'assigning an object to `this.state` in the constructor of `%s`. ' + 'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.', componentName, instance.state === null ? 'null' : 'undefined', componentName);
+        }
+      } // If new component APIs are defined, "unsafe" lifecycles won't be called.
+      // Warn about these lifecycles if they are present.
+      // Don't warn about react-lifecycles-compat polyfilled methods though.
+
+
+      if (typeof ctor.getDerivedStateFromProps === 'function' || typeof instance.getSnapshotBeforeUpdate === 'function') {
+        var foundWillMountName = null;
+        var foundWillReceivePropsName = null;
+        var foundWillUpdateName = null;
+
+        if (typeof instance.componentWillMount === 'function' && instance.componentWillMount.__suppressDeprecationWarning !== true) {
+          foundWillMountName = 'componentWillMount';
+        } else if (typeof instance.UNSAFE_componentWillMount === 'function') {
+          foundWillMountName = 'UNSAFE_componentWillMount';
+        }
+
+        if (typeof instance.componentWillReceiveProps === 'function' && instance.componentWillReceiveProps.__suppressDeprecationWarning !== true) {
+          foundWillReceivePropsName = 'componentWillReceiveProps';
+        } else if (typeof instance.UNSAFE_componentWillReceiveProps === 'function') {
+          foundWillReceivePropsName = 'UNSAFE_componentWillReceiveProps';
+        }
+
+        if (typeof instance.componentWillUpdate === 'function' && instance.componentWillUpdate.__suppressDeprecationWarning !== true) {
+          foundWillUpdateName = 'componentWillUpdate';
+        } else if (typeof instance.UNSAFE_componentWillUpdate === 'function') {
+          foundWillUpdateName = 'UNSAFE_componentWillUpdate';
+        }
+
+        if (foundWillMountName !== null || foundWillReceivePropsName !== null || foundWillUpdateName !== null) {
+          var _componentName = getComponentName(ctor) || 'Component';
+
+          var newApiName = typeof ctor.getDerivedStateFromProps === 'function' ? 'getDerivedStateFromProps()' : 'getSnapshotBeforeUpdate()';
+
+          if (!didWarnAboutLegacyLifecyclesAndDerivedState.has(_componentName)) {
+            didWarnAboutLegacyLifecyclesAndDerivedState.add(_componentName);
+
+            error('Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' + '%s uses %s but also contains the following legacy lifecycles:%s%s%s\n\n' + 'The above lifecycles should be removed. Learn more about this warning here:\n' + 'https://reactjs.org/link/unsafe-component-lifecycles', _componentName, newApiName, foundWillMountName !== null ? "\n  " + foundWillMountName : '', foundWillReceivePropsName !== null ? "\n  " + foundWillReceivePropsName : '', foundWillUpdateName !== null ? "\n  " + foundWillUpdateName : '');
+          }
+        }
+      }
+    } // Cache unmasked context so we can avoid recreating masked context unless necessary.
+    // ReactFiberContext usually updates this cache but can't for newly-created instances.
+
+
+    if (isLegacyContextConsumer) {
+      cacheContext(workInProgress, unmaskedContext, context);
+    }
+
+    return instance;
+  }
+
+  function callComponentWillMount(workInProgress, instance) {
+    var oldState = instance.state;
+
+    if (typeof instance.componentWillMount === 'function') {
+      instance.componentWillMount();
+    }
+
+    if (typeof instance.UNSAFE_componentWillMount === 'function') {
+      instance.UNSAFE_componentWillMount();
+    }
+
+    if (oldState !== instance.state) {
+      {
+        error('%s.componentWillMount(): Assigning directly to this.state is ' + "deprecated (except inside a component's " + 'constructor). Use setState instead.', getComponentName(workInProgress.type) || 'Component');
+      }
+
+      classComponentUpdater.enqueueReplaceState(instance, instance.state, null);
+    }
+  }
+
+  function callComponentWillReceiveProps(workInProgress, instance, newProps, nextContext) {
+    var oldState = instance.state;
+
+    if (typeof instance.componentWillReceiveProps === 'function') {
+      instance.componentWillReceiveProps(newProps, nextContext);
+    }
+
+    if (typeof instance.UNSAFE_componentWillReceiveProps === 'function') {
+      instance.UNSAFE_componentWillReceiveProps(newProps, nextContext);
+    }
+
+    if (instance.state !== oldState) {
+      {
+        var componentName = getComponentName(workInProgress.type) || 'Component';
+
+        if (!didWarnAboutStateAssignmentForComponent.has(componentName)) {
+          didWarnAboutStateAssignmentForComponent.add(componentName);
+
+          error('%s.componentWillReceiveProps(): Assigning directly to ' + "this.state is deprecated (except inside a component's " + 'constructor). Use setState instead.', componentName);
+        }
+      }
+
+      classComponentUpdater.enqueueReplaceState(instance, instance.state, null);
+    }
+  } // Invokes the mount life-cycles on a previously never rendered instance.
+
+
+  function mountClassInstance(workInProgress, ctor, newProps, renderLanes) {
+    {
+      checkClassInstance(workInProgress, ctor, newProps);
+    }
+
+    var instance = workInProgress.stateNode;
+    instance.props = newProps;
+    instance.state = workInProgress.memoizedState;
+    instance.refs = emptyRefsObject;
+    initializeUpdateQueue(workInProgress);
+    var contextType = ctor.contextType;
+
+    if (typeof contextType === 'object' && contextType !== null) {
+      instance.context = readContext(contextType);
+    } else {
+      var unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
+      instance.context = getMaskedContext(workInProgress, unmaskedContext);
+    }
+
+    {
+      if (instance.state === newProps) {
+        var componentName = getComponentName(ctor) || 'Component';
+
+        if (!didWarnAboutDirectlyAssigningPropsToState.has(componentName)) {
+          didWarnAboutDirectlyAssigningPropsToState.add(componentName);
+
+          error('%s: It is not recommended to assign props directly to state ' + "because updates to props won't be reflected in state. " + 'In most cases, it is better to use props directly.', componentName);
+        }
+      }
+
+      if (workInProgress.mode & StrictMode) {
+        ReactStrictModeWarnings.recordLegacyContextWarning(workInProgress, instance);
+      }
+
+      {
+        ReactStrictModeWarnings.recordUnsafeLifecycleWarnings(workInProgress, instance);
+      }
+    }
+
+    processUpdateQueue(workInProgress, newProps, instance, renderLanes);
+    instance.state = workInProgress.memoizedState;
+    var getDerivedStateFromProps = ctor.getDerivedStateFromProps;
+
+    if (typeof getDerivedStateFromProps === 'function') {
+      applyDerivedStateFromProps(workInProgress, ctor, getDerivedStateFromProps, newProps);
+      instance.state = workInProgress.memoizedState;
+    } // In order to support react-lifecycles-compat polyfilled components,
+    // Unsafe lifecycles should not be invoked for components using the new APIs.
+
+
+    if (typeof ctor.getDerivedStateFromProps !== 'function' && typeof instance.getSnapshotBeforeUpdate !== 'function' && (typeof instance.UNSAFE_componentWillMount === 'function' || typeof instance.componentWillMount === 'function')) {
+      callComponentWillMount(workInProgress, instance); // If we had additional state updates during this life-cycle, let's
+      // process them now.
+
+      processUpdateQueue(workInProgress, newProps, instance, renderLanes);
+      instance.state = workInProgress.memoizedState;
+    }
+
+    if (typeof instance.componentDidMount === 'function') {
+      workInProgress.flags |= Update;
+    }
+  }
+
+  function resumeMountClassInstance(workInProgress, ctor, newProps, renderLanes) {
+    var instance = workInProgress.stateNode;
+    var oldProps = workInProgress.memoizedProps;
+    instance.props = oldProps;
+    var oldContext = instance.context;
+    var contextType = ctor.contextType;
+    var nextContext = emptyContextObject;
+
+    if (typeof contextType === 'object' && contextType !== null) {
+      nextContext = readContext(contextType);
+    } else {
+      var nextLegacyUnmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
+      nextContext = getMaskedContext(workInProgress, nextLegacyUnmaskedContext);
+    }
+
+    var getDerivedStateFromProps = ctor.getDerivedStateFromProps;
+    var hasNewLifecycles = typeof getDerivedStateFromProps === 'function' || typeof instance.getSnapshotBeforeUpdate === 'function'; // Note: During these life-cycles, instance.props/instance.state are what
+    // ever the previously attempted to render - not the "current". However,
+    // during componentDidUpdate we pass the "current" props.
+    // In order to support react-lifecycles-compat polyfilled components,
+    // Unsafe lifecycles should not be invoked for components using the new APIs.
+
+    if (!hasNewLifecycles && (typeof instance.UNSAFE_componentWillReceiveProps === 'function' || typeof instance.componentWillReceiveProps === 'function')) {
+      if (oldProps !== newProps || oldContext !== nextContext) {
+        callComponentWillReceiveProps(workInProgress, instance, newProps, nextContext);
+      }
+    }
+
+    resetHasForceUpdateBeforeProcessing();
+    var oldState = workInProgress.memoizedState;
+    var newState = instance.state = oldState;
+    processUpdateQueue(workInProgress, newProps, instance, renderLanes);
+    newState = workInProgress.memoizedState;
+
+    if (oldProps === newProps && oldState === newState && !hasContextChanged() && !checkHasForceUpdateAfterProcessing()) {
+      // If an update was already in progress, we should schedule an Update
+      // effect even though we're bailing out, so that cWU/cDU are called.
+      if (typeof instance.componentDidMount === 'function') {
+        workInProgress.flags |= Update;
+      }
+
+      return false;
+    }
+
+    if (typeof getDerivedStateFromProps === 'function') {
+      applyDerivedStateFromProps(workInProgress, ctor, getDerivedStateFromProps, newProps);
+      newState = workInProgress.memoizedState;
+    }
+
+    var shouldUpdate = checkHasForceUpdateAfterProcessing() || checkShouldComponentUpdate(workInProgress, ctor, oldProps, newProps, oldState, newState, nextContext);
+
+    if (shouldUpdate) {
+      // In order to support react-lifecycles-compat polyfilled components,
+      // Unsafe lifecycles should not be invoked for components using the new APIs.
+      if (!hasNewLifecycles && (typeof instance.UNSAFE_componentWillMount === 'function' || typeof instance.componentWillMount === 'function')) {
+        if (typeof instance.componentWillMount === 'function') {
+          instance.componentWillMount();
+        }
+
+        if (typeof instance.UNSAFE_componentWillMount === 'function') {
+          instance.UNSAFE_componentWillMount();
+        }
+      }
+
+      if (typeof instance.componentDidMount === 'function') {
+        workInProgress.flags |= Update;
+      }
+    } else {
+      // If an update was already in progress, we should schedule an Update
+      // effect even though we're bailing out, so that cWU/cDU are called.
+      if (typeof instance.componentDidMount === 'function') {
+        workInProgress.flags |= Update;
+      } // If shouldComponentUpdate returned false, we should still update the
+      // memoized state to indicate that this work can be reused.
+
+
+      workInProgress.memoizedProps = newProps;
+      workInProgress.memoizedState = newState;
+    } // Update the existing instance's state, props, and context pointers even
+    // if shouldComponentUpdate returns false.
+
+
+    instance.props = newProps;
+    instance.state = newState;
+    instance.context = nextContext;
+    return shouldUpdate;
+  } // Invokes the update life-cycles and returns false if it shouldn't rerender.
+
+
+  function updateClassInstance(current, workInProgress, ctor, newProps, renderLanes) {
+    var instance = workInProgress.stateNode;
+    cloneUpdateQueue(current, workInProgress);
+    var unresolvedOldProps = workInProgress.memoizedProps;
+    var oldProps = workInProgress.type === workInProgress.elementType ? unresolvedOldProps : resolveDefaultProps(workInProgress.type, unresolvedOldProps);
+    instance.props = oldProps;
+    var unresolvedNewProps = workInProgress.pendingProps;
+    var oldContext = instance.context;
+    var contextType = ctor.contextType;
+    var nextContext = emptyContextObject;
+
+    if (typeof contextType === 'object' && contextType !== null) {
+      nextContext = readContext(contextType);
+    } else {
+      var nextUnmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
+      nextContext = getMaskedContext(workInProgress, nextUnmaskedContext);
+    }
+
+    var getDerivedStateFromProps = ctor.getDerivedStateFromProps;
+    var hasNewLifecycles = typeof getDerivedStateFromProps === 'function' || typeof instance.getSnapshotBeforeUpdate === 'function'; // Note: During these life-cycles, instance.props/instance.state are what
+    // ever the previously attempted to render - not the "current". However,
+    // during componentDidUpdate we pass the "current" props.
+    // In order to support react-lifecycles-compat polyfilled components,
+    // Unsafe lifecycles should not be invoked for components using the new APIs.
+
+    if (!hasNewLifecycles && (typeof instance.UNSAFE_componentWillReceiveProps === 'function' || typeof instance.componentWillReceiveProps === 'function')) {
+      if (unresolvedOldProps !== unresolvedNewProps || oldContext !== nextContext) {
+        callComponentWillReceiveProps(workInProgress, instance, newProps, nextContext);
+      }
+    }
+
+    resetHasForceUpdateBeforeProcessing();
+    var oldState = workInProgress.memoizedState;
+    var newState = instance.state = oldState;
+    processUpdateQueue(workInProgress, newProps, instance, renderLanes);
+    newState = workInProgress.memoizedState;
+
+    if (unresolvedOldProps === unresolvedNewProps && oldState === newState && !hasContextChanged() && !checkHasForceUpdateAfterProcessing()) {
+      // If an update was already in progress, we should schedule an Update
+      // effect even though we're bailing out, so that cWU/cDU are called.
+      if (typeof instance.componentDidUpdate === 'function') {
+        if (unresolvedOldProps !== current.memoizedProps || oldState !== current.memoizedState) {
+          workInProgress.flags |= Update;
+        }
+      }
+
+      if (typeof instance.getSnapshotBeforeUpdate === 'function') {
+        if (unresolvedOldProps !== current.memoizedProps || oldState !== current.memoizedState) {
+          workInProgress.flags |= Snapshot;
+        }
+      }
+
+      return false;
+    }
+
+    if (typeof getDerivedStateFromProps === 'function') {
+      applyDerivedStateFromProps(workInProgress, ctor, getDerivedStateFromProps, newProps);
+      newState = workInProgress.memoizedState;
+    }
+
+    var shouldUpdate = checkHasForceUpdateAfterProcessing() || checkShouldComponentUpdate(workInProgress, ctor, oldProps, newProps, oldState, newState, nextContext);
+
+    if (shouldUpdate) {
+      // In order to support react-lifecycles-compat polyfilled components,
+      // Unsafe lifecycles should not be invoked for components using the new APIs.
+      if (!hasNewLifecycles && (typeof instance.UNSAFE_componentWillUpdate === 'function' || typeof instance.componentWillUpdate === 'function')) {
+        if (typeof instance.componentWillUpdate === 'function') {
+          instance.componentWillUpdate(newProps, newState, nextContext);
+        }
+
+        if (typeof instance.UNSAFE_componentWillUpdate === 'function') {
+          instance.UNSAFE_componentWillUpdate(newProps, newState, nextContext);
+        }
+      }
+
+      if (typeof instance.componentDidUpdate === 'function') {
+        workInProgress.flags |= Update;
+      }
+
+      if (typeof instance.getSnapshotBeforeUpdate === 'function') {
+        workInProgress.flags |= Snapshot;
+      }
+    } else {
+      // If an update was already in progress, we should schedule an Update
+      // effect even though we're bailing out, so that cWU/cDU are called.
+      if (typeof instance.componentDidUpdate === 'function') {
+        if (unresolvedOldProps !== current.memoizedProps || oldState !== current.memoizedState) {
+          workInProgress.flags |= Update;
+        }
+      }
+
+      if (typeof instance.getSnapshotBeforeUpdate === 'function') {
+        if (unresolvedOldProps !== current.memoizedProps || oldState !== current.memoizedState) {
+          workInProgress.flags |= Snapshot;
+        }
+      } // If shouldComponentUpdate returned false, we should still update the
+      // memoized props/state to indicate that this work can be reused.
+
+
+      workInProgress.memoizedProps = newProps;
+      workInProgress.memoizedState = newState;
+    } // Update the existing instance's state, props, and context pointers even
+    // if shouldComponentUpdate returns false.
+
+
+    instance.props = newProps;
+    instance.state = newState;
+    instance.context = nextContext;
+    return shouldUpdate;
+  }
+
+  var didWarnAboutMaps;
+  var didWarnAboutGenerators;
+  var didWarnAboutStringRefs;
+  var ownerHasKeyUseWarning;
+  var ownerHasFunctionTypeWarning;
+
+  var warnForMissingKey = function (child, returnFiber) {};
+
+  {
+    didWarnAboutMaps = false;
+    didWarnAboutGenerators = false;
+    didWarnAboutStringRefs = {};
+    /**
+     * Warn if there's no key explicitly set on dynamic arrays of children or
+     * object keys are not valid. This allows us to keep track of children between
+     * updates.
+     */
+
+    ownerHasKeyUseWarning = {};
+    ownerHasFunctionTypeWarning = {};
+
+    warnForMissingKey = function (child, returnFiber) {
+      if (child === null || typeof child !== 'object') {
+        return;
+      }
+
+      if (!child._store || child._store.validated || child.key != null) {
+        return;
+      }
+
+      if (!(typeof child._store === 'object')) {
+        {
+          throw Error( "React Component in warnForMissingKey should have a _store. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+
+      child._store.validated = true;
+      var componentName = getComponentName(returnFiber.type) || 'Component';
+
+      if (ownerHasKeyUseWarning[componentName]) {
+        return;
+      }
+
+      ownerHasKeyUseWarning[componentName] = true;
+
+      error('Each child in a list should have a unique ' + '"key" prop. See https://reactjs.org/link/warning-keys for ' + 'more information.');
+    };
+  }
+
+  var isArray$1 = Array.isArray;
+
+  function coerceRef(returnFiber, current, element) {
+    var mixedRef = element.ref;
+
+    if (mixedRef !== null && typeof mixedRef !== 'function' && typeof mixedRef !== 'object') {
+      {
+        // TODO: Clean this up once we turn on the string ref warning for
+        // everyone, because the strict mode case will no longer be relevant
+        if ((returnFiber.mode & StrictMode || warnAboutStringRefs) && // We warn in ReactElement.js if owner and self are equal for string refs
+        // because these cannot be automatically converted to an arrow function
+        // using a codemod. Therefore, we don't have to warn about string refs again.
+        !(element._owner && element._self && element._owner.stateNode !== element._self)) {
+          var componentName = getComponentName(returnFiber.type) || 'Component';
+
+          if (!didWarnAboutStringRefs[componentName]) {
+            {
+              error('A string ref, "%s", has been found within a strict mode tree. ' + 'String refs are a source of potential bugs and should be avoided. ' + 'We recommend using useRef() or createRef() instead. ' + 'Learn more about using refs safely here: ' + 'https://reactjs.org/link/strict-mode-string-ref', mixedRef);
+            }
+
+            didWarnAboutStringRefs[componentName] = true;
+          }
+        }
+      }
+
+      if (element._owner) {
+        var owner = element._owner;
+        var inst;
+
+        if (owner) {
+          var ownerFiber = owner;
+
+          if (!(ownerFiber.tag === ClassComponent)) {
+            {
+              throw Error( "Function components cannot have string refs. We recommend using useRef() instead. Learn more about using refs safely here: https://reactjs.org/link/strict-mode-string-ref" );
+            }
+          }
+
+          inst = ownerFiber.stateNode;
+        }
+
+        if (!inst) {
+          {
+            throw Error( "Missing owner for string ref " + mixedRef + ". This error is likely caused by a bug in React. Please file an issue." );
+          }
+        }
+
+        var stringRef = '' + mixedRef; // Check if previous string ref matches new string ref
+
+        if (current !== null && current.ref !== null && typeof current.ref === 'function' && current.ref._stringRef === stringRef) {
+          return current.ref;
+        }
+
+        var ref = function (value) {
+          var refs = inst.refs;
+
+          if (refs === emptyRefsObject) {
+            // This is a lazy pooled frozen object, so we need to initialize.
+            refs = inst.refs = {};
+          }
+
+          if (value === null) {
+            delete refs[stringRef];
+          } else {
+            refs[stringRef] = value;
+          }
+        };
+
+        ref._stringRef = stringRef;
+        return ref;
+      } else {
+        if (!(typeof mixedRef === 'string')) {
+          {
+            throw Error( "Expected ref to be a function, a string, an object returned by React.createRef(), or null." );
+          }
+        }
+
+        if (!element._owner) {
+          {
+            throw Error( "Element ref was specified as a string (" + mixedRef + ") but no owner was set. This could happen for one of the following reasons:\n1. You may be adding a ref to a function component\n2. You may be adding a ref to a component that was not created inside a component's render method\n3. You have multiple copies of React loaded\nSee https://reactjs.org/link/refs-must-have-owner for more information." );
+          }
+        }
+      }
+    }
+
+    return mixedRef;
+  }
+
+  function throwOnInvalidObjectType(returnFiber, newChild) {
+    if (returnFiber.type !== 'textarea') {
+      {
+        {
+          throw Error( "Objects are not valid as a React child (found: " + (Object.prototype.toString.call(newChild) === '[object Object]' ? 'object with keys {' + Object.keys(newChild).join(', ') + '}' : newChild) + "). If you meant to render a collection of children, use an array instead." );
+        }
+      }
+    }
+  }
+
+  function warnOnFunctionType(returnFiber) {
+    {
+      var componentName = getComponentName(returnFiber.type) || 'Component';
+
+      if (ownerHasFunctionTypeWarning[componentName]) {
+        return;
+      }
+
+      ownerHasFunctionTypeWarning[componentName] = true;
+
+      error('Functions are not valid as a React child. This may happen if ' + 'you return a Component instead of <Component /> from render. ' + 'Or maybe you meant to call this function rather than return it.');
+    }
+  } // We avoid inlining this to avoid potential deopts from using try/catch.
+  // to be able to optimize each path individually by branching early. This needs
+  // a compiler or we can do it manually. Helpers that don't need this branching
+  // live outside of this function.
+
+
+  function ChildReconciler(shouldTrackSideEffects) {
+    function deleteChild(returnFiber, childToDelete) {
+      if (!shouldTrackSideEffects) {
+        // Noop.
+        return;
+      } // Deletions are added in reversed order so we add it to the front.
+      // At this point, the return fiber's effect list is empty except for
+      // deletions, so we can just append the deletion to the list. The remaining
+      // effects aren't added until the complete phase. Once we implement
+      // resuming, this may not be true.
+
+
+      var last = returnFiber.lastEffect;
+
+      if (last !== null) {
+        last.nextEffect = childToDelete;
+        returnFiber.lastEffect = childToDelete;
+      } else {
+        returnFiber.firstEffect = returnFiber.lastEffect = childToDelete;
+      }
+
+      childToDelete.nextEffect = null;
+      childToDelete.flags = Deletion;
+    }
+
+    function deleteRemainingChildren(returnFiber, currentFirstChild) {
+      if (!shouldTrackSideEffects) {
+        // Noop.
+        return null;
+      } // TODO: For the shouldClone case, this could be micro-optimized a bit by
+      // assuming that after the first child we've already added everything.
+
+
+      var childToDelete = currentFirstChild;
+
+      while (childToDelete !== null) {
+        deleteChild(returnFiber, childToDelete);
+        childToDelete = childToDelete.sibling;
+      }
+
+      return null;
+    }
+
+    function mapRemainingChildren(returnFiber, currentFirstChild) {
+      // Add the remaining children to a temporary map so that we can find them by
+      // keys quickly. Implicit (null) keys get added to this set with their index
+      // instead.
+      var existingChildren = new Map();
+      var existingChild = currentFirstChild;
+
+      while (existingChild !== null) {
+        if (existingChild.key !== null) {
+          existingChildren.set(existingChild.key, existingChild);
+        } else {
+          existingChildren.set(existingChild.index, existingChild);
+        }
+
+        existingChild = existingChild.sibling;
+      }
+
+      return existingChildren;
+    }
+
+    function useFiber(fiber, pendingProps) {
+      // We currently set sibling to null and index to 0 here because it is easy
+      // to forget to do before returning it. E.g. for the single child case.
+      var clone = createWorkInProgress(fiber, pendingProps);
+      clone.index = 0;
+      clone.sibling = null;
+      return clone;
+    }
+
+    function placeChild(newFiber, lastPlacedIndex, newIndex) {
+      newFiber.index = newIndex;
+
+      if (!shouldTrackSideEffects) {
+        // Noop.
+        return lastPlacedIndex;
+      }
+
+      var current = newFiber.alternate;
+
+      if (current !== null) {
+        var oldIndex = current.index;
+
+        if (oldIndex < lastPlacedIndex) {
+          // This is a move.
+          newFiber.flags = Placement;
+          return lastPlacedIndex;
+        } else {
+          // This item can stay in place.
+          return oldIndex;
+        }
+      } else {
+        // This is an insertion.
+        newFiber.flags = Placement;
+        return lastPlacedIndex;
+      }
+    }
+
+    function placeSingleChild(newFiber) {
+      // This is simpler for the single child case. We only need to do a
+      // placement for inserting new children.
+      if (shouldTrackSideEffects && newFiber.alternate === null) {
+        newFiber.flags = Placement;
+      }
+
+      return newFiber;
+    }
+
+    function updateTextNode(returnFiber, current, textContent, lanes) {
+      if (current === null || current.tag !== HostText) {
+        // Insert
+        var created = createFiberFromText(textContent, returnFiber.mode, lanes);
+        created.return = returnFiber;
+        return created;
+      } else {
+        // Update
+        var existing = useFiber(current, textContent);
+        existing.return = returnFiber;
+        return existing;
+      }
+    }
+
+    function updateElement(returnFiber, current, element, lanes) {
+      if (current !== null) {
+        if (current.elementType === element.type || ( // Keep this check inline so it only runs on the false path:
+         isCompatibleFamilyForHotReloading(current, element) )) {
+          // Move based on index
+          var existing = useFiber(current, element.props);
+          existing.ref = coerceRef(returnFiber, current, element);
+          existing.return = returnFiber;
+
+          {
+            existing._debugSource = element._source;
+            existing._debugOwner = element._owner;
+          }
+
+          return existing;
+        }
+      } // Insert
+
+
+      var created = createFiberFromElement(element, returnFiber.mode, lanes);
+      created.ref = coerceRef(returnFiber, current, element);
+      created.return = returnFiber;
+      return created;
+    }
+
+    function updatePortal(returnFiber, current, portal, lanes) {
+      if (current === null || current.tag !== HostPortal || current.stateNode.containerInfo !== portal.containerInfo || current.stateNode.implementation !== portal.implementation) {
+        // Insert
+        var created = createFiberFromPortal(portal, returnFiber.mode, lanes);
+        created.return = returnFiber;
+        return created;
+      } else {
+        // Update
+        var existing = useFiber(current, portal.children || []);
+        existing.return = returnFiber;
+        return existing;
+      }
+    }
+
+    function updateFragment(returnFiber, current, fragment, lanes, key) {
+      if (current === null || current.tag !== Fragment) {
+        // Insert
+        var created = createFiberFromFragment(fragment, returnFiber.mode, lanes, key);
+        created.return = returnFiber;
+        return created;
+      } else {
+        // Update
+        var existing = useFiber(current, fragment);
+        existing.return = returnFiber;
+        return existing;
+      }
+    }
+
+    function createChild(returnFiber, newChild, lanes) {
+      if (typeof newChild === 'string' || typeof newChild === 'number') {
+        // Text nodes don't have keys. If the previous node is implicitly keyed
+        // we can continue to replace it without aborting even if it is not a text
+        // node.
+        var created = createFiberFromText('' + newChild, returnFiber.mode, lanes);
+        created.return = returnFiber;
+        return created;
+      }
+
+      if (typeof newChild === 'object' && newChild !== null) {
+        switch (newChild.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+            {
+              var _created = createFiberFromElement(newChild, returnFiber.mode, lanes);
+
+              _created.ref = coerceRef(returnFiber, null, newChild);
+              _created.return = returnFiber;
+              return _created;
+            }
+
+          case REACT_PORTAL_TYPE:
+            {
+              var _created2 = createFiberFromPortal(newChild, returnFiber.mode, lanes);
+
+              _created2.return = returnFiber;
+              return _created2;
+            }
+        }
+
+        if (isArray$1(newChild) || getIteratorFn(newChild)) {
+          var _created3 = createFiberFromFragment(newChild, returnFiber.mode, lanes, null);
+
+          _created3.return = returnFiber;
+          return _created3;
+        }
+
+        throwOnInvalidObjectType(returnFiber, newChild);
+      }
+
+      {
+        if (typeof newChild === 'function') {
+          warnOnFunctionType(returnFiber);
+        }
+      }
+
+      return null;
+    }
+
+    function updateSlot(returnFiber, oldFiber, newChild, lanes) {
+      // Update the fiber if the keys match, otherwise return null.
+      var key = oldFiber !== null ? oldFiber.key : null;
+
+      if (typeof newChild === 'string' || typeof newChild === 'number') {
+        // Text nodes don't have keys. If the previous node is implicitly keyed
+        // we can continue to replace it without aborting even if it is not a text
+        // node.
+        if (key !== null) {
+          return null;
+        }
+
+        return updateTextNode(returnFiber, oldFiber, '' + newChild, lanes);
+      }
+
+      if (typeof newChild === 'object' && newChild !== null) {
+        switch (newChild.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+            {
+              if (newChild.key === key) {
+                if (newChild.type === REACT_FRAGMENT_TYPE) {
+                  return updateFragment(returnFiber, oldFiber, newChild.props.children, lanes, key);
+                }
+
+                return updateElement(returnFiber, oldFiber, newChild, lanes);
+              } else {
+                return null;
+              }
+            }
+
+          case REACT_PORTAL_TYPE:
+            {
+              if (newChild.key === key) {
+                return updatePortal(returnFiber, oldFiber, newChild, lanes);
+              } else {
+                return null;
+              }
+            }
+        }
+
+        if (isArray$1(newChild) || getIteratorFn(newChild)) {
+          if (key !== null) {
+            return null;
+          }
+
+          return updateFragment(returnFiber, oldFiber, newChild, lanes, null);
+        }
+
+        throwOnInvalidObjectType(returnFiber, newChild);
+      }
+
+      {
+        if (typeof newChild === 'function') {
+          warnOnFunctionType(returnFiber);
+        }
+      }
+
+      return null;
+    }
+
+    function updateFromMap(existingChildren, returnFiber, newIdx, newChild, lanes) {
+      if (typeof newChild === 'string' || typeof newChild === 'number') {
+        // Text nodes don't have keys, so we neither have to check the old nor
+        // new node for the key. If both are text nodes, they match.
+        var matchedFiber = existingChildren.get(newIdx) || null;
+        return updateTextNode(returnFiber, matchedFiber, '' + newChild, lanes);
+      }
+
+      if (typeof newChild === 'object' && newChild !== null) {
+        switch (newChild.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+            {
+              var _matchedFiber = existingChildren.get(newChild.key === null ? newIdx : newChild.key) || null;
+
+              if (newChild.type === REACT_FRAGMENT_TYPE) {
+                return updateFragment(returnFiber, _matchedFiber, newChild.props.children, lanes, newChild.key);
+              }
+
+              return updateElement(returnFiber, _matchedFiber, newChild, lanes);
+            }
+
+          case REACT_PORTAL_TYPE:
+            {
+              var _matchedFiber2 = existingChildren.get(newChild.key === null ? newIdx : newChild.key) || null;
+
+              return updatePortal(returnFiber, _matchedFiber2, newChild, lanes);
+            }
+
+        }
+
+        if (isArray$1(newChild) || getIteratorFn(newChild)) {
+          var _matchedFiber3 = existingChildren.get(newIdx) || null;
+
+          return updateFragment(returnFiber, _matchedFiber3, newChild, lanes, null);
+        }
+
+        throwOnInvalidObjectType(returnFiber, newChild);
+      }
+
+      {
+        if (typeof newChild === 'function') {
+          warnOnFunctionType(returnFiber);
+        }
+      }
+
+      return null;
+    }
+    /**
+     * Warns if there is a duplicate or missing key
+     */
+
+
+    function warnOnInvalidKey(child, knownKeys, returnFiber) {
+      {
+        if (typeof child !== 'object' || child === null) {
+          return knownKeys;
+        }
+
+        switch (child.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+          case REACT_PORTAL_TYPE:
+            warnForMissingKey(child, returnFiber);
+            var key = child.key;
+
+            if (typeof key !== 'string') {
+              break;
+            }
+
+            if (knownKeys === null) {
+              knownKeys = new Set();
+              knownKeys.add(key);
+              break;
+            }
+
+            if (!knownKeys.has(key)) {
+              knownKeys.add(key);
+              break;
+            }
+
+            error('Encountered two children with the same key, `%s`. ' + 'Keys should be unique so that components maintain their identity ' + 'across updates. Non-unique keys may cause children to be ' + 'duplicated and/or omitted — the behavior is unsupported and ' + 'could change in a future version.', key);
+
+            break;
+        }
+      }
+
+      return knownKeys;
+    }
+
+    function reconcileChildrenArray(returnFiber, currentFirstChild, newChildren, lanes) {
+      // This algorithm can't optimize by searching from both ends since we
+      // don't have backpointers on fibers. I'm trying to see how far we can get
+      // with that model. If it ends up not being worth the tradeoffs, we can
+      // add it later.
+      // Even with a two ended optimization, we'd want to optimize for the case
+      // where there are few changes and brute force the comparison instead of
+      // going for the Map. It'd like to explore hitting that path first in
+      // forward-only mode and only go for the Map once we notice that we need
+      // lots of look ahead. This doesn't handle reversal as well as two ended
+      // search but that's unusual. Besides, for the two ended optimization to
+      // work on Iterables, we'd need to copy the whole set.
+      // In this first iteration, we'll just live with hitting the bad case
+      // (adding everything to a Map) in for every insert/move.
+      // If you change this code, also update reconcileChildrenIterator() which
+      // uses the same algorithm.
+      {
+        // First, validate keys.
+        var knownKeys = null;
+
+        for (var i = 0; i < newChildren.length; i++) {
+          var child = newChildren[i];
+          knownKeys = warnOnInvalidKey(child, knownKeys, returnFiber);
+        }
+      }
+
+      var resultingFirstChild = null;
+      var previousNewFiber = null;
+      var oldFiber = currentFirstChild;
+      var lastPlacedIndex = 0;
+      var newIdx = 0;
+      var nextOldFiber = null;
+
+      for (; oldFiber !== null && newIdx < newChildren.length; newIdx++) {
+        if (oldFiber.index > newIdx) {
+          nextOldFiber = oldFiber;
+          oldFiber = null;
+        } else {
+          nextOldFiber = oldFiber.sibling;
+        }
+
+        var newFiber = updateSlot(returnFiber, oldFiber, newChildren[newIdx], lanes);
+
+        if (newFiber === null) {
+          // TODO: This breaks on empty slots like null children. That's
+          // unfortunate because it triggers the slow path all the time. We need
+          // a better way to communicate whether this was a miss or null,
+          // boolean, undefined, etc.
+          if (oldFiber === null) {
+            oldFiber = nextOldFiber;
+          }
+
+          break;
+        }
+
+        if (shouldTrackSideEffects) {
+          if (oldFiber && newFiber.alternate === null) {
+            // We matched the slot, but we didn't reuse the existing fiber, so we
+            // need to delete the existing child.
+            deleteChild(returnFiber, oldFiber);
+          }
+        }
+
+        lastPlacedIndex = placeChild(newFiber, lastPlacedIndex, newIdx);
+
+        if (previousNewFiber === null) {
+          // TODO: Move out of the loop. This only happens for the first run.
+          resultingFirstChild = newFiber;
+        } else {
+          // TODO: Defer siblings if we're not at the right index for this slot.
+          // I.e. if we had null values before, then we want to defer this
+          // for each null value. However, we also don't want to call updateSlot
+          // with the previous one.
+          previousNewFiber.sibling = newFiber;
+        }
+
+        previousNewFiber = newFiber;
+        oldFiber = nextOldFiber;
+      }
+
+      if (newIdx === newChildren.length) {
+        // We've reached the end of the new children. We can delete the rest.
+        deleteRemainingChildren(returnFiber, oldFiber);
+        return resultingFirstChild;
+      }
+
+      if (oldFiber === null) {
+        // If we don't have any more existing children we can choose a fast path
+        // since the rest will all be insertions.
+        for (; newIdx < newChildren.length; newIdx++) {
+          var _newFiber = createChild(returnFiber, newChildren[newIdx], lanes);
+
+          if (_newFiber === null) {
+            continue;
+          }
+
+          lastPlacedIndex = placeChild(_newFiber, lastPlacedIndex, newIdx);
+
+          if (previousNewFiber === null) {
+            // TODO: Move out of the loop. This only happens for the first run.
+            resultingFirstChild = _newFiber;
+          } else {
+            previousNewFiber.sibling = _newFiber;
+          }
+
+          previousNewFiber = _newFiber;
+        }
+
+        return resultingFirstChild;
+      } // Add all children to a key map for quick lookups.
+
+
+      var existingChildren = mapRemainingChildren(returnFiber, oldFiber); // Keep scanning and use the map to restore deleted items as moves.
+
+      for (; newIdx < newChildren.length; newIdx++) {
+        var _newFiber2 = updateFromMap(existingChildren, returnFiber, newIdx, newChildren[newIdx], lanes);
+
+        if (_newFiber2 !== null) {
+          if (shouldTrackSideEffects) {
+            if (_newFiber2.alternate !== null) {
+              // The new fiber is a work in progress, but if there exists a
+              // current, that means that we reused the fiber. We need to delete
+              // it from the child list so that we don't add it to the deletion
+              // list.
+              existingChildren.delete(_newFiber2.key === null ? newIdx : _newFiber2.key);
+            }
+          }
+
+          lastPlacedIndex = placeChild(_newFiber2, lastPlacedIndex, newIdx);
+
+          if (previousNewFiber === null) {
+            resultingFirstChild = _newFiber2;
+          } else {
+            previousNewFiber.sibling = _newFiber2;
+          }
+
+          previousNewFiber = _newFiber2;
+        }
+      }
+
+      if (shouldTrackSideEffects) {
+        // Any existing children that weren't consumed above were deleted. We need
+        // to add them to the deletion list.
+        existingChildren.forEach(function (child) {
+          return deleteChild(returnFiber, child);
+        });
+      }
+
+      return resultingFirstChild;
+    }
+
+    function reconcileChildrenIterator(returnFiber, currentFirstChild, newChildrenIterable, lanes) {
+      // This is the same implementation as reconcileChildrenArray(),
+      // but using the iterator instead.
+      var iteratorFn = getIteratorFn(newChildrenIterable);
+
+      if (!(typeof iteratorFn === 'function')) {
+        {
+          throw Error( "An object is not an iterable. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+
+      {
+        // We don't support rendering Generators because it's a mutation.
+        // See https://github.com/facebook/react/issues/12995
+        if (typeof Symbol === 'function' && // $FlowFixMe Flow doesn't know about toStringTag
+        newChildrenIterable[Symbol.toStringTag] === 'Generator') {
+          if (!didWarnAboutGenerators) {
+            error('Using Generators as children is unsupported and will likely yield ' + 'unexpected results because enumerating a generator mutates it. ' + 'You may convert it to an array with `Array.from()` or the ' + '`[...spread]` operator before rendering. Keep in mind ' + 'you might need to polyfill these features for older browsers.');
+          }
+
+          didWarnAboutGenerators = true;
+        } // Warn about using Maps as children
+
+
+        if (newChildrenIterable.entries === iteratorFn) {
+          if (!didWarnAboutMaps) {
+            error('Using Maps as children is not supported. ' + 'Use an array of keyed ReactElements instead.');
+          }
+
+          didWarnAboutMaps = true;
+        } // First, validate keys.
+        // We'll get a different iterator later for the main pass.
+
+
+        var _newChildren = iteratorFn.call(newChildrenIterable);
+
+        if (_newChildren) {
+          var knownKeys = null;
+
+          var _step = _newChildren.next();
+
+          for (; !_step.done; _step = _newChildren.next()) {
+            var child = _step.value;
+            knownKeys = warnOnInvalidKey(child, knownKeys, returnFiber);
+          }
+        }
+      }
+
+      var newChildren = iteratorFn.call(newChildrenIterable);
+
+      if (!(newChildren != null)) {
+        {
+          throw Error( "An iterable object provided no iterator." );
+        }
+      }
+
+      var resultingFirstChild = null;
+      var previousNewFiber = null;
+      var oldFiber = currentFirstChild;
+      var lastPlacedIndex = 0;
+      var newIdx = 0;
+      var nextOldFiber = null;
+      var step = newChildren.next();
+
+      for (; oldFiber !== null && !step.done; newIdx++, step = newChildren.next()) {
+        if (oldFiber.index > newIdx) {
+          nextOldFiber = oldFiber;
+          oldFiber = null;
+        } else {
+          nextOldFiber = oldFiber.sibling;
+        }
+
+        var newFiber = updateSlot(returnFiber, oldFiber, step.value, lanes);
+
+        if (newFiber === null) {
+          // TODO: This breaks on empty slots like null children. That's
+          // unfortunate because it triggers the slow path all the time. We need
+          // a better way to communicate whether this was a miss or null,
+          // boolean, undefined, etc.
+          if (oldFiber === null) {
+            oldFiber = nextOldFiber;
+          }
+
+          break;
+        }
+
+        if (shouldTrackSideEffects) {
+          if (oldFiber && newFiber.alternate === null) {
+            // We matched the slot, but we didn't reuse the existing fiber, so we
+            // need to delete the existing child.
+            deleteChild(returnFiber, oldFiber);
+          }
+        }
+
+        lastPlacedIndex = placeChild(newFiber, lastPlacedIndex, newIdx);
+
+        if (previousNewFiber === null) {
+          // TODO: Move out of the loop. This only happens for the first run.
+          resultingFirstChild = newFiber;
+        } else {
+          // TODO: Defer siblings if we're not at the right index for this slot.
+          // I.e. if we had null values before, then we want to defer this
+          // for each null value. However, we also don't want to call updateSlot
+          // with the previous one.
+          previousNewFiber.sibling = newFiber;
+        }
+
+        previousNewFiber = newFiber;
+        oldFiber = nextOldFiber;
+      }
+
+      if (step.done) {
+        // We've reached the end of the new children. We can delete the rest.
+        deleteRemainingChildren(returnFiber, oldFiber);
+        return resultingFirstChild;
+      }
+
+      if (oldFiber === null) {
+        // If we don't have any more existing children we can choose a fast path
+        // since the rest will all be insertions.
+        for (; !step.done; newIdx++, step = newChildren.next()) {
+          var _newFiber3 = createChild(returnFiber, step.value, lanes);
+
+          if (_newFiber3 === null) {
+            continue;
+          }
+
+          lastPlacedIndex = placeChild(_newFiber3, lastPlacedIndex, newIdx);
+
+          if (previousNewFiber === null) {
+            // TODO: Move out of the loop. This only happens for the first run.
+            resultingFirstChild = _newFiber3;
+          } else {
+            previousNewFiber.sibling = _newFiber3;
+          }
+
+          previousNewFiber = _newFiber3;
+        }
+
+        return resultingFirstChild;
+      } // Add all children to a key map for quick lookups.
+
+
+      var existingChildren = mapRemainingChildren(returnFiber, oldFiber); // Keep scanning and use the map to restore deleted items as moves.
+
+      for (; !step.done; newIdx++, step = newChildren.next()) {
+        var _newFiber4 = updateFromMap(existingChildren, returnFiber, newIdx, step.value, lanes);
+
+        if (_newFiber4 !== null) {
+          if (shouldTrackSideEffects) {
+            if (_newFiber4.alternate !== null) {
+              // The new fiber is a work in progress, but if there exists a
+              // current, that means that we reused the fiber. We need to delete
+              // it from the child list so that we don't add it to the deletion
+              // list.
+              existingChildren.delete(_newFiber4.key === null ? newIdx : _newFiber4.key);
+            }
+          }
+
+          lastPlacedIndex = placeChild(_newFiber4, lastPlacedIndex, newIdx);
+
+          if (previousNewFiber === null) {
+            resultingFirstChild = _newFiber4;
+          } else {
+            previousNewFiber.sibling = _newFiber4;
+          }
+
+          previousNewFiber = _newFiber4;
+        }
+      }
+
+      if (shouldTrackSideEffects) {
+        // Any existing children that weren't consumed above were deleted. We need
+        // to add them to the deletion list.
+        existingChildren.forEach(function (child) {
+          return deleteChild(returnFiber, child);
+        });
+      }
+
+      return resultingFirstChild;
+    }
+
+    function reconcileSingleTextNode(returnFiber, currentFirstChild, textContent, lanes) {
+      // There's no need to check for keys on text nodes since we don't have a
+      // way to define them.
+      if (currentFirstChild !== null && currentFirstChild.tag === HostText) {
+        // We already have an existing node so let's just update it and delete
+        // the rest.
+        deleteRemainingChildren(returnFiber, currentFirstChild.sibling);
+        var existing = useFiber(currentFirstChild, textContent);
+        existing.return = returnFiber;
+        return existing;
+      } // The existing first child is not a text node so we need to create one
+      // and delete the existing ones.
+
+
+      deleteRemainingChildren(returnFiber, currentFirstChild);
+      var created = createFiberFromText(textContent, returnFiber.mode, lanes);
+      created.return = returnFiber;
+      return created;
+    }
+
+    function reconcileSingleElement(returnFiber, currentFirstChild, element, lanes) {
+      var key = element.key;
+      var child = currentFirstChild;
+
+      while (child !== null) {
+        // TODO: If key === null and child.key === null, then this only applies to
+        // the first item in the list.
+        if (child.key === key) {
+          switch (child.tag) {
+            case Fragment:
+              {
+                if (element.type === REACT_FRAGMENT_TYPE) {
+                  deleteRemainingChildren(returnFiber, child.sibling);
+                  var existing = useFiber(child, element.props.children);
+                  existing.return = returnFiber;
+
+                  {
+                    existing._debugSource = element._source;
+                    existing._debugOwner = element._owner;
+                  }
+
+                  return existing;
+                }
+
+                break;
+              }
+
+            case Block:
+
+            // We intentionally fallthrough here if enableBlocksAPI is not on.
+            // eslint-disable-next-lined no-fallthrough
+
+            default:
+              {
+                if (child.elementType === element.type || ( // Keep this check inline so it only runs on the false path:
+                 isCompatibleFamilyForHotReloading(child, element) )) {
+                  deleteRemainingChildren(returnFiber, child.sibling);
+
+                  var _existing3 = useFiber(child, element.props);
+
+                  _existing3.ref = coerceRef(returnFiber, child, element);
+                  _existing3.return = returnFiber;
+
+                  {
+                    _existing3._debugSource = element._source;
+                    _existing3._debugOwner = element._owner;
+                  }
+
+                  return _existing3;
+                }
+
+                break;
+              }
+          } // Didn't match.
+
+
+          deleteRemainingChildren(returnFiber, child);
+          break;
+        } else {
+          deleteChild(returnFiber, child);
+        }
+
+        child = child.sibling;
+      }
+
+      if (element.type === REACT_FRAGMENT_TYPE) {
+        var created = createFiberFromFragment(element.props.children, returnFiber.mode, lanes, element.key);
+        created.return = returnFiber;
+        return created;
+      } else {
+        var _created4 = createFiberFromElement(element, returnFiber.mode, lanes);
+
+        _created4.ref = coerceRef(returnFiber, currentFirstChild, element);
+        _created4.return = returnFiber;
+        return _created4;
+      }
+    }
+
+    function reconcileSinglePortal(returnFiber, currentFirstChild, portal, lanes) {
+      var key = portal.key;
+      var child = currentFirstChild;
+
+      while (child !== null) {
+        // TODO: If key === null and child.key === null, then this only applies to
+        // the first item in the list.
+        if (child.key === key) {
+          if (child.tag === HostPortal && child.stateNode.containerInfo === portal.containerInfo && child.stateNode.implementation === portal.implementation) {
+            deleteRemainingChildren(returnFiber, child.sibling);
+            var existing = useFiber(child, portal.children || []);
+            existing.return = returnFiber;
+            return existing;
+          } else {
+            deleteRemainingChildren(returnFiber, child);
+            break;
+          }
+        } else {
+          deleteChild(returnFiber, child);
+        }
+
+        child = child.sibling;
+      }
+
+      var created = createFiberFromPortal(portal, returnFiber.mode, lanes);
+      created.return = returnFiber;
+      return created;
+    } // This API will tag the children with the side-effect of the reconciliation
+    // itself. They will be added to the side-effect list as we pass through the
+    // children and the parent.
+
+
+    function reconcileChildFibers(returnFiber, currentFirstChild, newChild, lanes) {
+      // This function is not recursive.
+      // If the top level item is an array, we treat it as a set of children,
+      // not as a fragment. Nested arrays on the other hand will be treated as
+      // fragment nodes. Recursion happens at the normal flow.
+      // Handle top level unkeyed fragments as if they were arrays.
+      // This leads to an ambiguity between <>{[...]}</> and <>...</>.
+      // We treat the ambiguous cases above the same.
+      var isUnkeyedTopLevelFragment = typeof newChild === 'object' && newChild !== null && newChild.type === REACT_FRAGMENT_TYPE && newChild.key === null;
+
+      if (isUnkeyedTopLevelFragment) {
+        newChild = newChild.props.children;
+      } // Handle object types
+
+
+      var isObject = typeof newChild === 'object' && newChild !== null;
+
+      if (isObject) {
+        switch (newChild.$$typeof) {
+          case REACT_ELEMENT_TYPE:
+            return placeSingleChild(reconcileSingleElement(returnFiber, currentFirstChild, newChild, lanes));
+
+          case REACT_PORTAL_TYPE:
+            return placeSingleChild(reconcileSinglePortal(returnFiber, currentFirstChild, newChild, lanes));
+
+        }
+      }
+
+      if (typeof newChild === 'string' || typeof newChild === 'number') {
+        return placeSingleChild(reconcileSingleTextNode(returnFiber, currentFirstChild, '' + newChild, lanes));
+      }
+
+      if (isArray$1(newChild)) {
+        return reconcileChildrenArray(returnFiber, currentFirstChild, newChild, lanes);
+      }
+
+      if (getIteratorFn(newChild)) {
+        return reconcileChildrenIterator(returnFiber, currentFirstChild, newChild, lanes);
+      }
+
+      if (isObject) {
+        throwOnInvalidObjectType(returnFiber, newChild);
+      }
+
+      {
+        if (typeof newChild === 'function') {
+          warnOnFunctionType(returnFiber);
+        }
+      }
+
+      if (typeof newChild === 'undefined' && !isUnkeyedTopLevelFragment) {
+        // If the new child is undefined, and the return fiber is a composite
+        // component, throw an error. If Fiber return types are disabled,
+        // we already threw above.
+        switch (returnFiber.tag) {
+          case ClassComponent:
+            {
+              {
+                var instance = returnFiber.stateNode;
+
+                if (instance.render._isMockFunction) {
+                  // We allow auto-mocks to proceed as if they're returning null.
+                  break;
+                }
+              }
+            }
+          // Intentionally fall through to the next case, which handles both
+          // functions and classes
+          // eslint-disable-next-lined no-fallthrough
+
+          case Block:
+          case FunctionComponent:
+          case ForwardRef:
+          case SimpleMemoComponent:
+            {
+              {
+                {
+                  throw Error( (getComponentName(returnFiber.type) || 'Component') + "(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null." );
+                }
+              }
+            }
+        }
+      } // Remaining cases are all treated as empty.
+
+
+      return deleteRemainingChildren(returnFiber, currentFirstChild);
+    }
+
+    return reconcileChildFibers;
+  }
+
+  var reconcileChildFibers = ChildReconciler(true);
+  var mountChildFibers = ChildReconciler(false);
+  function cloneChildFibers(current, workInProgress) {
+    if (!(current === null || workInProgress.child === current.child)) {
+      {
+        throw Error( "Resuming work not yet implemented." );
+      }
+    }
+
+    if (workInProgress.child === null) {
+      return;
+    }
+
+    var currentChild = workInProgress.child;
+    var newChild = createWorkInProgress(currentChild, currentChild.pendingProps);
+    workInProgress.child = newChild;
+    newChild.return = workInProgress;
+
+    while (currentChild.sibling !== null) {
+      currentChild = currentChild.sibling;
+      newChild = newChild.sibling = createWorkInProgress(currentChild, currentChild.pendingProps);
+      newChild.return = workInProgress;
+    }
+
+    newChild.sibling = null;
+  } // Reset a workInProgress child set to prepare it for a second pass.
+
+  function resetChildFibers(workInProgress, lanes) {
+    var child = workInProgress.child;
+
+    while (child !== null) {
+      resetWorkInProgress(child, lanes);
+      child = child.sibling;
+    }
+  }
+
+  var NO_CONTEXT = {};
+  var contextStackCursor$1 = createCursor(NO_CONTEXT);
+  var contextFiberStackCursor = createCursor(NO_CONTEXT);
+  var rootInstanceStackCursor = createCursor(NO_CONTEXT);
+
+  function requiredContext(c) {
+    if (!(c !== NO_CONTEXT)) {
+      {
+        throw Error( "Expected host context to exist. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+
+    return c;
+  }
+
+  function getRootHostContainer() {
+    var rootInstance = requiredContext(rootInstanceStackCursor.current);
+    return rootInstance;
+  }
+
+  function pushHostContainer(fiber, nextRootInstance) {
+    // Push current root instance onto the stack;
+    // This allows us to reset root when portals are popped.
+    push(rootInstanceStackCursor, nextRootInstance, fiber); // Track the context and the Fiber that provided it.
+    // This enables us to pop only Fibers that provide unique contexts.
+
+    push(contextFiberStackCursor, fiber, fiber); // Finally, we need to push the host context to the stack.
+    // However, we can't just call getRootHostContext() and push it because
+    // we'd have a different number of entries on the stack depending on
+    // whether getRootHostContext() throws somewhere in renderer code or not.
+    // So we push an empty value first. This lets us safely unwind on errors.
+
+    push(contextStackCursor$1, NO_CONTEXT, fiber);
+    var nextRootContext = getRootHostContext(nextRootInstance); // Now that we know this function doesn't throw, replace it.
+
+    pop(contextStackCursor$1, fiber);
+    push(contextStackCursor$1, nextRootContext, fiber);
+  }
+
+  function popHostContainer(fiber) {
+    pop(contextStackCursor$1, fiber);
+    pop(contextFiberStackCursor, fiber);
+    pop(rootInstanceStackCursor, fiber);
+  }
+
+  function getHostContext() {
+    var context = requiredContext(contextStackCursor$1.current);
+    return context;
+  }
+
+  function pushHostContext(fiber) {
+    var rootInstance = requiredContext(rootInstanceStackCursor.current);
+    var context = requiredContext(contextStackCursor$1.current);
+    var nextContext = getChildHostContext(context, fiber.type); // Don't push this Fiber's context unless it's unique.
+
+    if (context === nextContext) {
+      return;
+    } // Track the context and the Fiber that provided it.
+    // This enables us to pop only Fibers that provide unique contexts.
+
+
+    push(contextFiberStackCursor, fiber, fiber);
+    push(contextStackCursor$1, nextContext, fiber);
+  }
+
+  function popHostContext(fiber) {
+    // Do not pop unless this Fiber provided the current context.
+    // pushHostContext() only pushes Fibers that provide unique contexts.
+    if (contextFiberStackCursor.current !== fiber) {
+      return;
+    }
+
+    pop(contextStackCursor$1, fiber);
+    pop(contextFiberStackCursor, fiber);
+  }
+
+  var DefaultSuspenseContext = 0; // The Suspense Context is split into two parts. The lower bits is
+  // inherited deeply down the subtree. The upper bits only affect
+  // this immediate suspense boundary and gets reset each new
+  // boundary or suspense list.
+
+  var SubtreeSuspenseContextMask = 1; // Subtree Flags:
+  // InvisibleParentSuspenseContext indicates that one of our parent Suspense
+  // boundaries is not currently showing visible main content.
+  // Either because it is already showing a fallback or is not mounted at all.
+  // We can use this to determine if it is desirable to trigger a fallback at
+  // the parent. If not, then we might need to trigger undesirable boundaries
+  // and/or suspend the commit to avoid hiding the parent content.
+
+  var InvisibleParentSuspenseContext = 1; // Shallow Flags:
+  // ForceSuspenseFallback can be used by SuspenseList to force newly added
+  // items into their fallback state during one of the render passes.
+
+  var ForceSuspenseFallback = 2;
+  var suspenseStackCursor = createCursor(DefaultSuspenseContext);
+  function hasSuspenseContext(parentContext, flag) {
+    return (parentContext & flag) !== 0;
+  }
+  function setDefaultShallowSuspenseContext(parentContext) {
+    return parentContext & SubtreeSuspenseContextMask;
+  }
+  function setShallowSuspenseContext(parentContext, shallowContext) {
+    return parentContext & SubtreeSuspenseContextMask | shallowContext;
+  }
+  function addSubtreeSuspenseContext(parentContext, subtreeContext) {
+    return parentContext | subtreeContext;
+  }
+  function pushSuspenseContext(fiber, newContext) {
+    push(suspenseStackCursor, newContext, fiber);
+  }
+  function popSuspenseContext(fiber) {
+    pop(suspenseStackCursor, fiber);
+  }
+
+  function shouldCaptureSuspense(workInProgress, hasInvisibleParent) {
+    // If it was the primary children that just suspended, capture and render the
+    // fallback. Otherwise, don't capture and bubble to the next boundary.
+    var nextState = workInProgress.memoizedState;
+
+    if (nextState !== null) {
+      if (nextState.dehydrated !== null) {
+        // A dehydrated boundary always captures.
+        return true;
+      }
+
+      return false;
+    }
+
+    var props = workInProgress.memoizedProps; // In order to capture, the Suspense component must have a fallback prop.
+
+    if (props.fallback === undefined) {
+      return false;
+    } // Regular boundaries always capture.
+
+
+    if (props.unstable_avoidThisFallback !== true) {
+      return true;
+    } // If it's a boundary we should avoid, then we prefer to bubble up to the
+    // parent boundary if it is currently invisible.
+
+
+    if (hasInvisibleParent) {
+      return false;
+    } // If the parent is not able to handle it, we must handle it.
+
+
+    return true;
+  }
+  function findFirstSuspended(row) {
+    var node = row;
+
+    while (node !== null) {
+      if (node.tag === SuspenseComponent) {
+        var state = node.memoizedState;
+
+        if (state !== null) {
+          var dehydrated = state.dehydrated;
+
+          if (dehydrated === null || isSuspenseInstancePending(dehydrated) || isSuspenseInstanceFallback(dehydrated)) {
+            return node;
+          }
+        }
+      } else if (node.tag === SuspenseListComponent && // revealOrder undefined can't be trusted because it don't
+      // keep track of whether it suspended or not.
+      node.memoizedProps.revealOrder !== undefined) {
+        var didSuspend = (node.flags & DidCapture) !== NoFlags;
+
+        if (didSuspend) {
+          return node;
+        }
+      } else if (node.child !== null) {
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
+
+      if (node === row) {
+        return null;
+      }
+
+      while (node.sibling === null) {
+        if (node.return === null || node.return === row) {
+          return null;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    }
+
+    return null;
+  }
+
+  var NoFlags$1 =
+  /*  */
+  0; // Represents whether effect should fire.
+
+  var HasEffect =
+  /* */
+  1; // Represents the phase in which the effect (not the clean-up) fires.
+
+  var Layout =
+  /*    */
+  2;
+  var Passive$1 =
+  /*   */
+  4;
+
+  // This may have been an insertion or a hydration.
+
+  var hydrationParentFiber = null;
+  var nextHydratableInstance = null;
+  var isHydrating = false;
+
+  function enterHydrationState(fiber) {
+
+    var parentInstance = fiber.stateNode.containerInfo;
+    nextHydratableInstance = getFirstHydratableChild(parentInstance);
+    hydrationParentFiber = fiber;
+    isHydrating = true;
+    return true;
+  }
+
+  function deleteHydratableInstance(returnFiber, instance) {
+    {
+      switch (returnFiber.tag) {
+        case HostRoot:
+          didNotHydrateContainerInstance(returnFiber.stateNode.containerInfo, instance);
+          break;
+
+        case HostComponent:
+          didNotHydrateInstance(returnFiber.type, returnFiber.memoizedProps, returnFiber.stateNode, instance);
+          break;
+      }
+    }
+
+    var childToDelete = createFiberFromHostInstanceForDeletion();
+    childToDelete.stateNode = instance;
+    childToDelete.return = returnFiber;
+    childToDelete.flags = Deletion; // This might seem like it belongs on progressedFirstDeletion. However,
+    // these children are not part of the reconciliation list of children.
+    // Even if we abort and rereconcile the children, that will try to hydrate
+    // again and the nodes are still in the host tree so these will be
+    // recreated.
+
+    if (returnFiber.lastEffect !== null) {
+      returnFiber.lastEffect.nextEffect = childToDelete;
+      returnFiber.lastEffect = childToDelete;
+    } else {
+      returnFiber.firstEffect = returnFiber.lastEffect = childToDelete;
+    }
+  }
+
+  function insertNonHydratedInstance(returnFiber, fiber) {
+    fiber.flags = fiber.flags & ~Hydrating | Placement;
+
+    {
+      switch (returnFiber.tag) {
+        case HostRoot:
+          {
+            var parentContainer = returnFiber.stateNode.containerInfo;
+
+            switch (fiber.tag) {
+              case HostComponent:
+                var type = fiber.type;
+                var props = fiber.pendingProps;
+                didNotFindHydratableContainerInstance(parentContainer, type);
+                break;
+
+              case HostText:
+                var text = fiber.pendingProps;
+                didNotFindHydratableContainerTextInstance(parentContainer, text);
+                break;
+            }
+
+            break;
+          }
+
+        case HostComponent:
+          {
+            var parentType = returnFiber.type;
+            var parentProps = returnFiber.memoizedProps;
+            var parentInstance = returnFiber.stateNode;
+
+            switch (fiber.tag) {
+              case HostComponent:
+                var _type = fiber.type;
+                var _props = fiber.pendingProps;
+                didNotFindHydratableInstance(parentType, parentProps, parentInstance, _type);
+                break;
+
+              case HostText:
+                var _text = fiber.pendingProps;
+                didNotFindHydratableTextInstance(parentType, parentProps, parentInstance, _text);
+                break;
+
+              case SuspenseComponent:
+                didNotFindHydratableSuspenseInstance(parentType, parentProps);
+                break;
+            }
+
+            break;
+          }
+
+        default:
+          return;
+      }
+    }
+  }
+
+  function tryHydrate(fiber, nextInstance) {
+    switch (fiber.tag) {
+      case HostComponent:
+        {
+          var type = fiber.type;
+          var props = fiber.pendingProps;
+          var instance = canHydrateInstance(nextInstance, type);
+
+          if (instance !== null) {
+            fiber.stateNode = instance;
+            return true;
+          }
+
+          return false;
+        }
+
+      case HostText:
+        {
+          var text = fiber.pendingProps;
+          var textInstance = canHydrateTextInstance(nextInstance, text);
+
+          if (textInstance !== null) {
+            fiber.stateNode = textInstance;
+            return true;
+          }
+
+          return false;
+        }
+
+      case SuspenseComponent:
+        {
+
+          return false;
+        }
+
+      default:
+        return false;
+    }
+  }
+
+  function tryToClaimNextHydratableInstance(fiber) {
+    if (!isHydrating) {
+      return;
+    }
+
+    var nextInstance = nextHydratableInstance;
+
+    if (!nextInstance) {
+      // Nothing to hydrate. Make it an insertion.
+      insertNonHydratedInstance(hydrationParentFiber, fiber);
+      isHydrating = false;
+      hydrationParentFiber = fiber;
+      return;
+    }
+
+    var firstAttemptedInstance = nextInstance;
+
+    if (!tryHydrate(fiber, nextInstance)) {
+      // If we can't hydrate this instance let's try the next one.
+      // We use this as a heuristic. It's based on intuition and not data so it
+      // might be flawed or unnecessary.
+      nextInstance = getNextHydratableSibling(firstAttemptedInstance);
+
+      if (!nextInstance || !tryHydrate(fiber, nextInstance)) {
+        // Nothing to hydrate. Make it an insertion.
+        insertNonHydratedInstance(hydrationParentFiber, fiber);
+        isHydrating = false;
+        hydrationParentFiber = fiber;
+        return;
+      } // We matched the next one, we'll now assume that the first one was
+      // superfluous and we'll delete it. Since we can't eagerly delete it
+      // we'll have to schedule a deletion. To do that, this node needs a dummy
+      // fiber associated with it.
+
+
+      deleteHydratableInstance(hydrationParentFiber, firstAttemptedInstance);
+    }
+
+    hydrationParentFiber = fiber;
+    nextHydratableInstance = getFirstHydratableChild(nextInstance);
+  }
+
+  function prepareToHydrateHostInstance(fiber, rootContainerInstance, hostContext) {
+
+    var instance = fiber.stateNode;
+    var updatePayload = hydrateInstance(instance, fiber.type, fiber.memoizedProps, rootContainerInstance, hostContext, fiber); // TODO: Type this specific to this type of component.
+
+    fiber.updateQueue = updatePayload; // If the update payload indicates that there is a change or if there
+    // is a new ref we mark this as an update.
+
+    if (updatePayload !== null) {
+      return true;
+    }
+
+    return false;
+  }
+
+  function prepareToHydrateHostTextInstance(fiber) {
+
+    var textInstance = fiber.stateNode;
+    var textContent = fiber.memoizedProps;
+    var shouldUpdate = hydrateTextInstance(textInstance, textContent, fiber);
+
+    {
+      if (shouldUpdate) {
+        // We assume that prepareToHydrateHostTextInstance is called in a context where the
+        // hydration parent is the parent host component of this host text.
+        var returnFiber = hydrationParentFiber;
+
+        if (returnFiber !== null) {
+          switch (returnFiber.tag) {
+            case HostRoot:
+              {
+                var parentContainer = returnFiber.stateNode.containerInfo;
+                didNotMatchHydratedContainerTextInstance(parentContainer, textInstance, textContent);
+                break;
+              }
+
+            case HostComponent:
+              {
+                var parentType = returnFiber.type;
+                var parentProps = returnFiber.memoizedProps;
+                var parentInstance = returnFiber.stateNode;
+                didNotMatchHydratedTextInstance(parentType, parentProps, parentInstance, textInstance, textContent);
+                break;
+              }
+          }
+        }
+      }
+    }
+
+    return shouldUpdate;
+  }
+
+  function skipPastDehydratedSuspenseInstance(fiber) {
+
+    var suspenseState = fiber.memoizedState;
+    var suspenseInstance = suspenseState !== null ? suspenseState.dehydrated : null;
+
+    if (!suspenseInstance) {
+      {
+        throw Error( "Expected to have a hydrated suspense instance. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+
+    return getNextHydratableInstanceAfterSuspenseInstance(suspenseInstance);
+  }
+
+  function popToNextHostParent(fiber) {
+    var parent = fiber.return;
+
+    while (parent !== null && parent.tag !== HostComponent && parent.tag !== HostRoot && parent.tag !== SuspenseComponent) {
+      parent = parent.return;
+    }
+
+    hydrationParentFiber = parent;
+  }
+
+  function popHydrationState(fiber) {
+
+    if (fiber !== hydrationParentFiber) {
+      // We're deeper than the current hydration context, inside an inserted
+      // tree.
+      return false;
+    }
+
+    if (!isHydrating) {
+      // If we're not currently hydrating but we're in a hydration context, then
+      // we were an insertion and now need to pop up reenter hydration of our
+      // siblings.
+      popToNextHostParent(fiber);
+      isHydrating = true;
+      return false;
+    }
+
+    var type = fiber.type; // If we have any remaining hydratable nodes, we need to delete them now.
+    // We only do this deeper than head and body since they tend to have random
+    // other nodes in them. We also ignore components with pure text content in
+    // side of them.
+    // TODO: Better heuristic.
+
+    if (fiber.tag !== HostComponent || type !== 'head' && type !== 'body' && !shouldSetTextContent(type, fiber.memoizedProps)) {
+      var nextInstance = nextHydratableInstance;
+
+      while (nextInstance) {
+        deleteHydratableInstance(fiber, nextInstance);
+        nextInstance = getNextHydratableSibling(nextInstance);
+      }
+    }
+
+    popToNextHostParent(fiber);
+
+    if (fiber.tag === SuspenseComponent) {
+      nextHydratableInstance = skipPastDehydratedSuspenseInstance(fiber);
+    } else {
+      nextHydratableInstance = hydrationParentFiber ? getNextHydratableSibling(fiber.stateNode) : null;
+    }
+
+    return true;
+  }
+
+  function resetHydrationState() {
+
+    hydrationParentFiber = null;
+    nextHydratableInstance = null;
+    isHydrating = false;
+  }
+
+  function getIsHydrating() {
+    return isHydrating;
+  }
+
+  // and should be reset before starting a new render.
+  // This tracks which mutable sources need to be reset after a render.
+
+  var workInProgressSources = [];
+  var rendererSigil$1;
+
+  {
+    // Used to detect multiple renderers using the same mutable source.
+    rendererSigil$1 = {};
+  }
+
+  function markSourceAsDirty(mutableSource) {
+    workInProgressSources.push(mutableSource);
+  }
+  function resetWorkInProgressVersions() {
+    for (var i = 0; i < workInProgressSources.length; i++) {
+      var mutableSource = workInProgressSources[i];
+
+      {
+        mutableSource._workInProgressVersionPrimary = null;
+      }
+    }
+
+    workInProgressSources.length = 0;
+  }
+  function getWorkInProgressVersion(mutableSource) {
+    {
+      return mutableSource._workInProgressVersionPrimary;
+    }
+  }
+  function setWorkInProgressVersion(mutableSource, version) {
+    {
+      mutableSource._workInProgressVersionPrimary = version;
+    }
+
+    workInProgressSources.push(mutableSource);
+  }
+  function warnAboutMultipleRenderersDEV(mutableSource) {
+    {
+      {
+        if (mutableSource._currentPrimaryRenderer == null) {
+          mutableSource._currentPrimaryRenderer = rendererSigil$1;
+        } else if (mutableSource._currentPrimaryRenderer !== rendererSigil$1) {
+          error('Detected multiple renderers concurrently rendering the ' + 'same mutable source. This is currently unsupported.');
+        }
+      }
+    }
+  } // Eager reads the version of a mutable source and stores it on the root.
+
+  var ReactCurrentDispatcher$1 = ReactSharedInternals.ReactCurrentDispatcher,
+      ReactCurrentBatchConfig$1 = ReactSharedInternals.ReactCurrentBatchConfig;
+  var didWarnAboutMismatchedHooksForComponent;
+  var didWarnAboutUseOpaqueIdentifier;
+
+  {
+    didWarnAboutUseOpaqueIdentifier = {};
+    didWarnAboutMismatchedHooksForComponent = new Set();
+  }
+
+  // These are set right before calling the component.
+  var renderLanes = NoLanes; // The work-in-progress fiber. I've named it differently to distinguish it from
+  // the work-in-progress hook.
+
+  var currentlyRenderingFiber$1 = null; // Hooks are stored as a linked list on the fiber's memoizedState field. The
+  // current hook list is the list that belongs to the current fiber. The
+  // work-in-progress hook list is a new list that will be added to the
+  // work-in-progress fiber.
+
+  var currentHook = null;
+  var workInProgressHook = null; // Whether an update was scheduled at any point during the render phase. This
+  // does not get reset if we do another render pass; only when we're completely
+  // finished evaluating this component. This is an optimization so we know
+  // whether we need to clear render phase updates after a throw.
+
+  var didScheduleRenderPhaseUpdate = false; // Where an update was scheduled only during the current render pass. This
+  // gets reset after each attempt.
+  // TODO: Maybe there's some way to consolidate this with
+  // `didScheduleRenderPhaseUpdate`. Or with `numberOfReRenders`.
+
+  var didScheduleRenderPhaseUpdateDuringThisPass = false;
+  var RE_RENDER_LIMIT = 25; // In DEV, this is the name of the currently executing primitive hook
+
+  var currentHookNameInDev = null; // In DEV, this list ensures that hooks are called in the same order between renders.
+  // The list stores the order of hooks used during the initial render (mount).
+  // Subsequent renders (updates) reference this list.
+
+  var hookTypesDev = null;
+  var hookTypesUpdateIndexDev = -1; // In DEV, this tracks whether currently rendering component needs to ignore
+  // the dependencies for Hooks that need them (e.g. useEffect or useMemo).
+  // When true, such Hooks will always be "remounted". Only used during hot reload.
+
+  var ignorePreviousDependencies = false;
+
+  function mountHookTypesDev() {
+    {
+      var hookName = currentHookNameInDev;
+
+      if (hookTypesDev === null) {
+        hookTypesDev = [hookName];
+      } else {
+        hookTypesDev.push(hookName);
+      }
+    }
+  }
+
+  function updateHookTypesDev() {
+    {
+      var hookName = currentHookNameInDev;
+
+      if (hookTypesDev !== null) {
+        hookTypesUpdateIndexDev++;
+
+        if (hookTypesDev[hookTypesUpdateIndexDev] !== hookName) {
+          warnOnHookMismatchInDev(hookName);
+        }
+      }
+    }
+  }
+
+  function checkDepsAreArrayDev(deps) {
+    {
+      if (deps !== undefined && deps !== null && !Array.isArray(deps)) {
+        // Verify deps, but only on mount to avoid extra checks.
+        // It's unlikely their type would change as usually you define them inline.
+        error('%s received a final argument that is not an array (instead, received `%s`). When ' + 'specified, the final argument must be an array.', currentHookNameInDev, typeof deps);
+      }
+    }
+  }
+
+  function warnOnHookMismatchInDev(currentHookName) {
+    {
+      var componentName = getComponentName(currentlyRenderingFiber$1.type);
+
+      if (!didWarnAboutMismatchedHooksForComponent.has(componentName)) {
+        didWarnAboutMismatchedHooksForComponent.add(componentName);
+
+        if (hookTypesDev !== null) {
+          var table = '';
+          var secondColumnStart = 30;
+
+          for (var i = 0; i <= hookTypesUpdateIndexDev; i++) {
+            var oldHookName = hookTypesDev[i];
+            var newHookName = i === hookTypesUpdateIndexDev ? currentHookName : oldHookName;
+            var row = i + 1 + ". " + oldHookName; // Extra space so second column lines up
+            // lol @ IE not supporting String#repeat
+
+            while (row.length < secondColumnStart) {
+              row += ' ';
+            }
+
+            row += newHookName + '\n';
+            table += row;
+          }
+
+          error('React has detected a change in the order of Hooks called by %s. ' + 'This will lead to bugs and errors if not fixed. ' + 'For more information, read the Rules of Hooks: https://reactjs.org/link/rules-of-hooks\n\n' + '   Previous render            Next render\n' + '   ------------------------------------------------------\n' + '%s' + '   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n', componentName, table);
+        }
+      }
+    }
+  }
+
+  function throwInvalidHookError() {
+    {
+      {
+        throw Error( "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem." );
+      }
+    }
+  }
+
+  function areHookInputsEqual(nextDeps, prevDeps) {
+    {
+      if (ignorePreviousDependencies) {
+        // Only true when this component is being hot reloaded.
+        return false;
+      }
+    }
+
+    if (prevDeps === null) {
+      {
+        error('%s received a final argument during this render, but not during ' + 'the previous render. Even though the final argument is optional, ' + 'its type cannot change between renders.', currentHookNameInDev);
+      }
+
+      return false;
+    }
+
+    {
+      // Don't bother comparing lengths in prod because these arrays should be
+      // passed inline.
+      if (nextDeps.length !== prevDeps.length) {
+        error('The final argument passed to %s changed size between renders. The ' + 'order and size of this array must remain constant.\n\n' + 'Previous: %s\n' + 'Incoming: %s', currentHookNameInDev, "[" + prevDeps.join(', ') + "]", "[" + nextDeps.join(', ') + "]");
+      }
+    }
+
+    for (var i = 0; i < prevDeps.length && i < nextDeps.length; i++) {
+      if (objectIs(nextDeps[i], prevDeps[i])) {
+        continue;
+      }
+
+      return false;
+    }
+
+    return true;
+  }
+
+  function renderWithHooks(current, workInProgress, Component, props, secondArg, nextRenderLanes) {
+    renderLanes = nextRenderLanes;
+    currentlyRenderingFiber$1 = workInProgress;
+
+    {
+      hookTypesDev = current !== null ? current._debugHookTypes : null;
+      hookTypesUpdateIndexDev = -1; // Used for hot reloading:
+
+      ignorePreviousDependencies = current !== null && current.type !== workInProgress.type;
+    }
+
+    workInProgress.memoizedState = null;
+    workInProgress.updateQueue = null;
+    workInProgress.lanes = NoLanes; // The following should have already been reset
+    // currentHook = null;
+    // workInProgressHook = null;
+    // didScheduleRenderPhaseUpdate = false;
+    // TODO Warn if no hooks are used at all during mount, then some are used during update.
+    // Currently we will identify the update render as a mount because memoizedState === null.
+    // This is tricky because it's valid for certain types of components (e.g. React.lazy)
+    // Using memoizedState to differentiate between mount/update only works if at least one stateful hook is used.
+    // Non-stateful hooks (e.g. context) don't get added to memoizedState,
+    // so memoizedState would be null during updates and mounts.
+
+    {
+      if (current !== null && current.memoizedState !== null) {
+        ReactCurrentDispatcher$1.current = HooksDispatcherOnUpdateInDEV;
+      } else if (hookTypesDev !== null) {
+        // This dispatcher handles an edge case where a component is updating,
+        // but no stateful hooks have been used.
+        // We want to match the production code behavior (which will use HooksDispatcherOnMount),
+        // but with the extra DEV validation to ensure hooks ordering hasn't changed.
+        // This dispatcher does that.
+        ReactCurrentDispatcher$1.current = HooksDispatcherOnMountWithHookTypesInDEV;
+      } else {
+        ReactCurrentDispatcher$1.current = HooksDispatcherOnMountInDEV;
+      }
+    }
+
+    var children = Component(props, secondArg); // Check if there was a render phase update
+
+    if (didScheduleRenderPhaseUpdateDuringThisPass) {
+      // Keep rendering in a loop for as long as render phase updates continue to
+      // be scheduled. Use a counter to prevent infinite loops.
+      var numberOfReRenders = 0;
+
+      do {
+        didScheduleRenderPhaseUpdateDuringThisPass = false;
+
+        if (!(numberOfReRenders < RE_RENDER_LIMIT)) {
+          {
+            throw Error( "Too many re-renders. React limits the number of renders to prevent an infinite loop." );
+          }
+        }
+
+        numberOfReRenders += 1;
+
+        {
+          // Even when hot reloading, allow dependencies to stabilize
+          // after first render to prevent infinite render phase updates.
+          ignorePreviousDependencies = false;
+        } // Start over from the beginning of the list
+
+
+        currentHook = null;
+        workInProgressHook = null;
+        workInProgress.updateQueue = null;
+
+        {
+          // Also validate hook order for cascading updates.
+          hookTypesUpdateIndexDev = -1;
+        }
+
+        ReactCurrentDispatcher$1.current =  HooksDispatcherOnRerenderInDEV ;
+        children = Component(props, secondArg);
+      } while (didScheduleRenderPhaseUpdateDuringThisPass);
+    } // We can assume the previous dispatcher is always this one, since we set it
+    // at the beginning of the render phase and there's no re-entrancy.
+
+
+    ReactCurrentDispatcher$1.current = ContextOnlyDispatcher;
+
+    {
+      workInProgress._debugHookTypes = hookTypesDev;
+    } // This check uses currentHook so that it works the same in DEV and prod bundles.
+    // hookTypesDev could catch more cases (e.g. context) but only in DEV bundles.
+
+
+    var didRenderTooFewHooks = currentHook !== null && currentHook.next !== null;
+    renderLanes = NoLanes;
+    currentlyRenderingFiber$1 = null;
+    currentHook = null;
+    workInProgressHook = null;
+
+    {
+      currentHookNameInDev = null;
+      hookTypesDev = null;
+      hookTypesUpdateIndexDev = -1;
+    }
+
+    didScheduleRenderPhaseUpdate = false;
+
+    if (!!didRenderTooFewHooks) {
+      {
+        throw Error( "Rendered fewer hooks than expected. This may be caused by an accidental early return statement." );
+      }
+    }
+
+    return children;
+  }
+  function bailoutHooks(current, workInProgress, lanes) {
+    workInProgress.updateQueue = current.updateQueue;
+    workInProgress.flags &= ~(Passive | Update);
+    current.lanes = removeLanes(current.lanes, lanes);
+  }
+  function resetHooksAfterThrow() {
+    // We can assume the previous dispatcher is always this one, since we set it
+    // at the beginning of the render phase and there's no re-entrancy.
+    ReactCurrentDispatcher$1.current = ContextOnlyDispatcher;
+
+    if (didScheduleRenderPhaseUpdate) {
+      // There were render phase updates. These are only valid for this render
+      // phase, which we are now aborting. Remove the updates from the queues so
+      // they do not persist to the next render. Do not remove updates from hooks
+      // that weren't processed.
+      //
+      // Only reset the updates from the queue if it has a clone. If it does
+      // not have a clone, that means it wasn't processed, and the updates were
+      // scheduled before we entered the render phase.
+      var hook = currentlyRenderingFiber$1.memoizedState;
+
+      while (hook !== null) {
+        var queue = hook.queue;
+
+        if (queue !== null) {
+          queue.pending = null;
+        }
+
+        hook = hook.next;
+      }
+
+      didScheduleRenderPhaseUpdate = false;
+    }
+
+    renderLanes = NoLanes;
+    currentlyRenderingFiber$1 = null;
+    currentHook = null;
+    workInProgressHook = null;
+
+    {
+      hookTypesDev = null;
+      hookTypesUpdateIndexDev = -1;
+      currentHookNameInDev = null;
+      isUpdatingOpaqueValueInRenderPhase = false;
+    }
+
+    didScheduleRenderPhaseUpdateDuringThisPass = false;
+  }
+
+  function mountWorkInProgressHook() {
+    var hook = {
+      memoizedState: null,
+      baseState: null,
+      baseQueue: null,
+      queue: null,
+      next: null
+    };
+
+    if (workInProgressHook === null) {
+      // This is the first hook in the list
+      currentlyRenderingFiber$1.memoizedState = workInProgressHook = hook;
+    } else {
+      // Append to the end of the list
+      workInProgressHook = workInProgressHook.next = hook;
+    }
+
+    return workInProgressHook;
+  }
+
+  function updateWorkInProgressHook() {
+    // This function is used both for updates and for re-renders triggered by a
+    // render phase update. It assumes there is either a current hook we can
+    // clone, or a work-in-progress hook from a previous render pass that we can
+    // use as a base. When we reach the end of the base list, we must switch to
+    // the dispatcher used for mounts.
+    var nextCurrentHook;
+
+    if (currentHook === null) {
+      var current = currentlyRenderingFiber$1.alternate;
+
+      if (current !== null) {
+        nextCurrentHook = current.memoizedState;
+      } else {
+        nextCurrentHook = null;
+      }
+    } else {
+      nextCurrentHook = currentHook.next;
+    }
+
+    var nextWorkInProgressHook;
+
+    if (workInProgressHook === null) {
+      nextWorkInProgressHook = currentlyRenderingFiber$1.memoizedState;
+    } else {
+      nextWorkInProgressHook = workInProgressHook.next;
+    }
+
+    if (nextWorkInProgressHook !== null) {
+      // There's already a work-in-progress. Reuse it.
+      workInProgressHook = nextWorkInProgressHook;
+      nextWorkInProgressHook = workInProgressHook.next;
+      currentHook = nextCurrentHook;
+    } else {
+      // Clone from the current hook.
+      if (!(nextCurrentHook !== null)) {
+        {
+          throw Error( "Rendered more hooks than during the previous render." );
+        }
+      }
+
+      currentHook = nextCurrentHook;
+      var newHook = {
+        memoizedState: currentHook.memoizedState,
+        baseState: currentHook.baseState,
+        baseQueue: currentHook.baseQueue,
+        queue: currentHook.queue,
+        next: null
+      };
+
+      if (workInProgressHook === null) {
+        // This is the first hook in the list.
+        currentlyRenderingFiber$1.memoizedState = workInProgressHook = newHook;
+      } else {
+        // Append to the end of the list.
+        workInProgressHook = workInProgressHook.next = newHook;
+      }
+    }
+
+    return workInProgressHook;
+  }
+
+  function createFunctionComponentUpdateQueue() {
+    return {
+      lastEffect: null
+    };
+  }
+
+  function basicStateReducer(state, action) {
+    // $FlowFixMe: Flow doesn't like mixed types
+    return typeof action === 'function' ? action(state) : action;
+  }
+
+  function mountReducer(reducer, initialArg, init) {
+    var hook = mountWorkInProgressHook();
+    var initialState;
+
+    if (init !== undefined) {
+      initialState = init(initialArg);
+    } else {
+      initialState = initialArg;
+    }
+
+    hook.memoizedState = hook.baseState = initialState;
+    var queue = hook.queue = {
+      pending: null,
+      dispatch: null,
+      lastRenderedReducer: reducer,
+      lastRenderedState: initialState
+    };
+    var dispatch = queue.dispatch = dispatchAction.bind(null, currentlyRenderingFiber$1, queue);
+    return [hook.memoizedState, dispatch];
+  }
+
+  function updateReducer(reducer, initialArg, init) {
+    var hook = updateWorkInProgressHook();
+    var queue = hook.queue;
+
+    if (!(queue !== null)) {
+      {
+        throw Error( "Should have a queue. This is likely a bug in React. Please file an issue." );
+      }
+    }
+
+    queue.lastRenderedReducer = reducer;
+    var current = currentHook; // The last rebase update that is NOT part of the base state.
+
+    var baseQueue = current.baseQueue; // The last pending update that hasn't been processed yet.
+
+    var pendingQueue = queue.pending;
+
+    if (pendingQueue !== null) {
+      // We have new updates that haven't been processed yet.
+      // We'll add them to the base queue.
+      if (baseQueue !== null) {
+        // Merge the pending queue and the base queue.
+        var baseFirst = baseQueue.next;
+        var pendingFirst = pendingQueue.next;
+        baseQueue.next = pendingFirst;
+        pendingQueue.next = baseFirst;
+      }
+
+      {
+        if (current.baseQueue !== baseQueue) {
+          // Internal invariant that should never happen, but feasibly could in
+          // the future if we implement resuming, or some form of that.
+          error('Internal error: Expected work-in-progress queue to be a clone. ' + 'This is a bug in React.');
+        }
+      }
+
+      current.baseQueue = baseQueue = pendingQueue;
+      queue.pending = null;
+    }
+
+    if (baseQueue !== null) {
+      // We have a queue to process.
+      var first = baseQueue.next;
+      var newState = current.baseState;
+      var newBaseState = null;
+      var newBaseQueueFirst = null;
+      var newBaseQueueLast = null;
+      var update = first;
+
+      do {
+        var updateLane = update.lane;
+
+        if (!isSubsetOfLanes(renderLanes, updateLane)) {
+          // Priority is insufficient. Skip this update. If this is the first
+          // skipped update, the previous update/state is the new base
+          // update/state.
+          var clone = {
+            lane: updateLane,
+            action: update.action,
+            eagerReducer: update.eagerReducer,
+            eagerState: update.eagerState,
+            next: null
+          };
+
+          if (newBaseQueueLast === null) {
+            newBaseQueueFirst = newBaseQueueLast = clone;
+            newBaseState = newState;
+          } else {
+            newBaseQueueLast = newBaseQueueLast.next = clone;
+          } // Update the remaining priority in the queue.
+          // TODO: Don't need to accumulate this. Instead, we can remove
+          // renderLanes from the original lanes.
+
+
+          currentlyRenderingFiber$1.lanes = mergeLanes(currentlyRenderingFiber$1.lanes, updateLane);
+          markSkippedUpdateLanes(updateLane);
+        } else {
+          // This update does have sufficient priority.
+          if (newBaseQueueLast !== null) {
+            var _clone = {
+              // This update is going to be committed so we never want uncommit
+              // it. Using NoLane works because 0 is a subset of all bitmasks, so
+              // this will never be skipped by the check above.
+              lane: NoLane,
+              action: update.action,
+              eagerReducer: update.eagerReducer,
+              eagerState: update.eagerState,
+              next: null
+            };
+            newBaseQueueLast = newBaseQueueLast.next = _clone;
+          } // Process this update.
+
+
+          if (update.eagerReducer === reducer) {
+            // If this update was processed eagerly, and its reducer matches the
+            // current reducer, we can use the eagerly computed state.
+            newState = update.eagerState;
+          } else {
+            var action = update.action;
+            newState = reducer(newState, action);
+          }
+        }
+
+        update = update.next;
+      } while (update !== null && update !== first);
+
+      if (newBaseQueueLast === null) {
+        newBaseState = newState;
+      } else {
+        newBaseQueueLast.next = newBaseQueueFirst;
+      } // Mark that the fiber performed work, but only if the new state is
+      // different from the current state.
+
+
+      if (!objectIs(newState, hook.memoizedState)) {
+        markWorkInProgressReceivedUpdate();
+      }
+
+      hook.memoizedState = newState;
+      hook.baseState = newBaseState;
+      hook.baseQueue = newBaseQueueLast;
+      queue.lastRenderedState = newState;
+    }
+
+    var dispatch = queue.dispatch;
+    return [hook.memoizedState, dispatch];
+  }
+
+  function rerenderReducer(reducer, initialArg, init) {
+    var hook = updateWorkInProgressHook();
+    var queue = hook.queue;
+
+    if (!(queue !== null)) {
+      {
+        throw Error( "Should have a queue. This is likely a bug in React. Please file an issue." );
+      }
+    }
+
+    queue.lastRenderedReducer = reducer; // This is a re-render. Apply the new render phase updates to the previous
+    // work-in-progress hook.
+
+    var dispatch = queue.dispatch;
+    var lastRenderPhaseUpdate = queue.pending;
+    var newState = hook.memoizedState;
+
+    if (lastRenderPhaseUpdate !== null) {
+      // The queue doesn't persist past this render pass.
+      queue.pending = null;
+      var firstRenderPhaseUpdate = lastRenderPhaseUpdate.next;
+      var update = firstRenderPhaseUpdate;
+
+      do {
+        // Process this render phase update. We don't have to check the
+        // priority because it will always be the same as the current
+        // render's.
+        var action = update.action;
+        newState = reducer(newState, action);
+        update = update.next;
+      } while (update !== firstRenderPhaseUpdate); // Mark that the fiber performed work, but only if the new state is
+      // different from the current state.
+
+
+      if (!objectIs(newState, hook.memoizedState)) {
+        markWorkInProgressReceivedUpdate();
+      }
+
+      hook.memoizedState = newState; // Don't persist the state accumulated from the render phase updates to
+      // the base state unless the queue is empty.
+      // TODO: Not sure if this is the desired semantics, but it's what we
+      // do for gDSFP. I can't remember why.
+
+      if (hook.baseQueue === null) {
+        hook.baseState = newState;
+      }
+
+      queue.lastRenderedState = newState;
+    }
+
+    return [newState, dispatch];
+  }
+
+  function readFromUnsubcribedMutableSource(root, source, getSnapshot) {
+    {
+      warnAboutMultipleRenderersDEV(source);
+    }
+
+    var getVersion = source._getVersion;
+    var version = getVersion(source._source); // Is it safe for this component to read from this source during the current render?
+
+    var isSafeToReadFromSource = false; // Check the version first.
+    // If this render has already been started with a specific version,
+    // we can use it alone to determine if we can safely read from the source.
+
+    var currentRenderVersion = getWorkInProgressVersion(source);
+
+    if (currentRenderVersion !== null) {
+      // It's safe to read if the store hasn't been mutated since the last time
+      // we read something.
+      isSafeToReadFromSource = currentRenderVersion === version;
+    } else {
+      // If there's no version, then this is the first time we've read from the
+      // source during the current render pass, so we need to do a bit more work.
+      // What we need to determine is if there are any hooks that already
+      // subscribed to the source, and if so, whether there are any pending
+      // mutations that haven't been synchronized yet.
+      //
+      // If there are no pending mutations, then `root.mutableReadLanes` will be
+      // empty, and we know we can safely read.
+      //
+      // If there *are* pending mutations, we may still be able to safely read
+      // if the currently rendering lanes are inclusive of the pending mutation
+      // lanes, since that guarantees that the value we're about to read from
+      // the source is consistent with the values that we read during the most
+      // recent mutation.
+      isSafeToReadFromSource = isSubsetOfLanes(renderLanes, root.mutableReadLanes);
+
+      if (isSafeToReadFromSource) {
+        // If it's safe to read from this source during the current render,
+        // store the version in case other components read from it.
+        // A changed version number will let those components know to throw and restart the render.
+        setWorkInProgressVersion(source, version);
+      }
+    }
+
+    if (isSafeToReadFromSource) {
+      var snapshot = getSnapshot(source._source);
+
+      {
+        if (typeof snapshot === 'function') {
+          error('Mutable source should not return a function as the snapshot value. ' + 'Functions may close over mutable values and cause tearing.');
+        }
+      }
+
+      return snapshot;
+    } else {
+      // This handles the special case of a mutable source being shared between renderers.
+      // In that case, if the source is mutated between the first and second renderer,
+      // The second renderer don't know that it needs to reset the WIP version during unwind,
+      // (because the hook only marks sources as dirty if it's written to their WIP version).
+      // That would cause this tear check to throw again and eventually be visible to the user.
+      // We can avoid this infinite loop by explicitly marking the source as dirty.
+      //
+      // This can lead to tearing in the first renderer when it resumes,
+      // but there's nothing we can do about that (short of throwing here and refusing to continue the render).
+      markSourceAsDirty(source);
+
+      {
+        {
+          throw Error( "Cannot read from mutable source during the current render without tearing. This is a bug in React. Please file an issue." );
+        }
+      }
+    }
+  }
+
+  function useMutableSource(hook, source, getSnapshot, subscribe) {
+    var root = getWorkInProgressRoot();
+
+    if (!(root !== null)) {
+      {
+        throw Error( "Expected a work-in-progress root. This is a bug in React. Please file an issue." );
+      }
+    }
+
+    var getVersion = source._getVersion;
+    var version = getVersion(source._source);
+    var dispatcher = ReactCurrentDispatcher$1.current; // eslint-disable-next-line prefer-const
+
+    var _dispatcher$useState = dispatcher.useState(function () {
+      return readFromUnsubcribedMutableSource(root, source, getSnapshot);
+    }),
+        currentSnapshot = _dispatcher$useState[0],
+        setSnapshot = _dispatcher$useState[1];
+
+    var snapshot = currentSnapshot; // Grab a handle to the state hook as well.
+    // We use it to clear the pending update queue if we have a new source.
+
+    var stateHook = workInProgressHook;
+    var memoizedState = hook.memoizedState;
+    var refs = memoizedState.refs;
+    var prevGetSnapshot = refs.getSnapshot;
+    var prevSource = memoizedState.source;
+    var prevSubscribe = memoizedState.subscribe;
+    var fiber = currentlyRenderingFiber$1;
+    hook.memoizedState = {
+      refs: refs,
+      source: source,
+      subscribe: subscribe
+    }; // Sync the values needed by our subscription handler after each commit.
+
+    dispatcher.useEffect(function () {
+      refs.getSnapshot = getSnapshot; // Normally the dispatch function for a state hook never changes,
+      // but this hook recreates the queue in certain cases  to avoid updates from stale sources.
+      // handleChange() below needs to reference the dispatch function without re-subscribing,
+      // so we use a ref to ensure that it always has the latest version.
+
+      refs.setSnapshot = setSnapshot; // Check for a possible change between when we last rendered now.
+
+      var maybeNewVersion = getVersion(source._source);
+
+      if (!objectIs(version, maybeNewVersion)) {
+        var maybeNewSnapshot = getSnapshot(source._source);
+
+        {
+          if (typeof maybeNewSnapshot === 'function') {
+            error('Mutable source should not return a function as the snapshot value. ' + 'Functions may close over mutable values and cause tearing.');
+          }
+        }
+
+        if (!objectIs(snapshot, maybeNewSnapshot)) {
+          setSnapshot(maybeNewSnapshot);
+          var lane = requestUpdateLane(fiber);
+          markRootMutableRead(root, lane);
+        } // If the source mutated between render and now,
+        // there may be state updates already scheduled from the old source.
+        // Entangle the updates so that they render in the same batch.
+
+
+        markRootEntangled(root, root.mutableReadLanes);
+      }
+    }, [getSnapshot, source, subscribe]); // If we got a new source or subscribe function, re-subscribe in a passive effect.
+
+    dispatcher.useEffect(function () {
+      var handleChange = function () {
+        var latestGetSnapshot = refs.getSnapshot;
+        var latestSetSnapshot = refs.setSnapshot;
+
+        try {
+          latestSetSnapshot(latestGetSnapshot(source._source)); // Record a pending mutable source update with the same expiration time.
+
+          var lane = requestUpdateLane(fiber);
+          markRootMutableRead(root, lane);
+        } catch (error) {
+          // A selector might throw after a source mutation.
+          // e.g. it might try to read from a part of the store that no longer exists.
+          // In this case we should still schedule an update with React.
+          // Worst case the selector will throw again and then an error boundary will handle it.
+          latestSetSnapshot(function () {
+            throw error;
+          });
+        }
+      };
+
+      var unsubscribe = subscribe(source._source, handleChange);
+
+      {
+        if (typeof unsubscribe !== 'function') {
+          error('Mutable source subscribe function must return an unsubscribe function.');
+        }
+      }
+
+      return unsubscribe;
+    }, [source, subscribe]); // If any of the inputs to useMutableSource change, reading is potentially unsafe.
+    //
+    // If either the source or the subscription have changed we can't can't trust the update queue.
+    // Maybe the source changed in a way that the old subscription ignored but the new one depends on.
+    //
+    // If the getSnapshot function changed, we also shouldn't rely on the update queue.
+    // It's possible that the underlying source was mutated between the when the last "change" event fired,
+    // and when the current render (with the new getSnapshot function) is processed.
+    //
+    // In both cases, we need to throw away pending updates (since they are no longer relevant)
+    // and treat reading from the source as we do in the mount case.
+
+    if (!objectIs(prevGetSnapshot, getSnapshot) || !objectIs(prevSource, source) || !objectIs(prevSubscribe, subscribe)) {
+      // Create a new queue and setState method,
+      // So if there are interleaved updates, they get pushed to the older queue.
+      // When this becomes current, the previous queue and dispatch method will be discarded,
+      // including any interleaving updates that occur.
+      var newQueue = {
+        pending: null,
+        dispatch: null,
+        lastRenderedReducer: basicStateReducer,
+        lastRenderedState: snapshot
+      };
+      newQueue.dispatch = setSnapshot = dispatchAction.bind(null, currentlyRenderingFiber$1, newQueue);
+      stateHook.queue = newQueue;
+      stateHook.baseQueue = null;
+      snapshot = readFromUnsubcribedMutableSource(root, source, getSnapshot);
+      stateHook.memoizedState = stateHook.baseState = snapshot;
+    }
+
+    return snapshot;
+  }
+
+  function mountMutableSource(source, getSnapshot, subscribe) {
+    var hook = mountWorkInProgressHook();
+    hook.memoizedState = {
+      refs: {
+        getSnapshot: getSnapshot,
+        setSnapshot: null
+      },
+      source: source,
+      subscribe: subscribe
+    };
+    return useMutableSource(hook, source, getSnapshot, subscribe);
+  }
+
+  function updateMutableSource(source, getSnapshot, subscribe) {
+    var hook = updateWorkInProgressHook();
+    return useMutableSource(hook, source, getSnapshot, subscribe);
+  }
+
+  function mountState(initialState) {
+    var hook = mountWorkInProgressHook();
+
+    if (typeof initialState === 'function') {
+      // $FlowFixMe: Flow doesn't like mixed types
+      initialState = initialState();
+    }
+
+    hook.memoizedState = hook.baseState = initialState;
+    var queue = hook.queue = {
+      pending: null,
+      dispatch: null,
+      lastRenderedReducer: basicStateReducer,
+      lastRenderedState: initialState
+    };
+    var dispatch = queue.dispatch = dispatchAction.bind(null, currentlyRenderingFiber$1, queue);
+    return [hook.memoizedState, dispatch];
+  }
+
+  function updateState(initialState) {
+    return updateReducer(basicStateReducer);
+  }
+
+  function rerenderState(initialState) {
+    return rerenderReducer(basicStateReducer);
+  }
+
+  function pushEffect(tag, create, destroy, deps) {
+    var effect = {
+      tag: tag,
+      create: create,
+      destroy: destroy,
+      deps: deps,
+      // Circular
+      next: null
+    };
+    var componentUpdateQueue = currentlyRenderingFiber$1.updateQueue;
+
+    if (componentUpdateQueue === null) {
+      componentUpdateQueue = createFunctionComponentUpdateQueue();
+      currentlyRenderingFiber$1.updateQueue = componentUpdateQueue;
+      componentUpdateQueue.lastEffect = effect.next = effect;
+    } else {
+      var lastEffect = componentUpdateQueue.lastEffect;
+
+      if (lastEffect === null) {
+        componentUpdateQueue.lastEffect = effect.next = effect;
+      } else {
+        var firstEffect = lastEffect.next;
+        lastEffect.next = effect;
+        effect.next = firstEffect;
+        componentUpdateQueue.lastEffect = effect;
+      }
+    }
+
+    return effect;
+  }
+
+  function mountRef(initialValue) {
+    var hook = mountWorkInProgressHook();
+    var ref = {
+      current: initialValue
+    };
+
+    {
+      Object.seal(ref);
+    }
+
+    hook.memoizedState = ref;
+    return ref;
+  }
+
+  function updateRef(initialValue) {
+    var hook = updateWorkInProgressHook();
+    return hook.memoizedState;
+  }
+
+  function mountEffectImpl(fiberFlags, hookFlags, create, deps) {
+    var hook = mountWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    currentlyRenderingFiber$1.flags |= fiberFlags;
+    hook.memoizedState = pushEffect(HasEffect | hookFlags, create, undefined, nextDeps);
+  }
+
+  function updateEffectImpl(fiberFlags, hookFlags, create, deps) {
+    var hook = updateWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    var destroy = undefined;
+
+    if (currentHook !== null) {
+      var prevEffect = currentHook.memoizedState;
+      destroy = prevEffect.destroy;
+
+      if (nextDeps !== null) {
+        var prevDeps = prevEffect.deps;
+
+        if (areHookInputsEqual(nextDeps, prevDeps)) {
+          pushEffect(hookFlags, create, destroy, nextDeps);
+          return;
+        }
+      }
+    }
+
+    currentlyRenderingFiber$1.flags |= fiberFlags;
+    hook.memoizedState = pushEffect(HasEffect | hookFlags, create, destroy, nextDeps);
+  }
+
+  function mountEffect(create, deps) {
+    {
+      // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+      if ('undefined' !== typeof jest) {
+        warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber$1);
+      }
+    }
+
+    return mountEffectImpl(Update | Passive, Passive$1, create, deps);
+  }
+
+  function updateEffect(create, deps) {
+    {
+      // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+      if ('undefined' !== typeof jest) {
+        warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber$1);
+      }
+    }
+
+    return updateEffectImpl(Update | Passive, Passive$1, create, deps);
+  }
+
+  function mountLayoutEffect(create, deps) {
+    return mountEffectImpl(Update, Layout, create, deps);
+  }
+
+  function updateLayoutEffect(create, deps) {
+    return updateEffectImpl(Update, Layout, create, deps);
+  }
+
+  function imperativeHandleEffect(create, ref) {
+    if (typeof ref === 'function') {
+      var refCallback = ref;
+
+      var _inst = create();
+
+      refCallback(_inst);
+      return function () {
+        refCallback(null);
+      };
+    } else if (ref !== null && ref !== undefined) {
+      var refObject = ref;
+
+      {
+        if (!refObject.hasOwnProperty('current')) {
+          error('Expected useImperativeHandle() first argument to either be a ' + 'ref callback or React.createRef() object. Instead received: %s.', 'an object with keys {' + Object.keys(refObject).join(', ') + '}');
+        }
+      }
+
+      var _inst2 = create();
+
+      refObject.current = _inst2;
+      return function () {
+        refObject.current = null;
+      };
+    }
+  }
+
+  function mountImperativeHandle(ref, create, deps) {
+    {
+      if (typeof create !== 'function') {
+        error('Expected useImperativeHandle() second argument to be a function ' + 'that creates a handle. Instead received: %s.', create !== null ? typeof create : 'null');
+      }
+    } // TODO: If deps are provided, should we skip comparing the ref itself?
+
+
+    var effectDeps = deps !== null && deps !== undefined ? deps.concat([ref]) : null;
+    return mountEffectImpl(Update, Layout, imperativeHandleEffect.bind(null, create, ref), effectDeps);
+  }
+
+  function updateImperativeHandle(ref, create, deps) {
+    {
+      if (typeof create !== 'function') {
+        error('Expected useImperativeHandle() second argument to be a function ' + 'that creates a handle. Instead received: %s.', create !== null ? typeof create : 'null');
+      }
+    } // TODO: If deps are provided, should we skip comparing the ref itself?
+
+
+    var effectDeps = deps !== null && deps !== undefined ? deps.concat([ref]) : null;
+    return updateEffectImpl(Update, Layout, imperativeHandleEffect.bind(null, create, ref), effectDeps);
+  }
+
+  function mountDebugValue(value, formatterFn) {// This hook is normally a no-op.
+    // The react-debug-hooks package injects its own implementation
+    // so that e.g. DevTools can display custom hook values.
+  }
+
+  var updateDebugValue = mountDebugValue;
+
+  function mountCallback(callback, deps) {
+    var hook = mountWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    hook.memoizedState = [callback, nextDeps];
+    return callback;
+  }
+
+  function updateCallback(callback, deps) {
+    var hook = updateWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    var prevState = hook.memoizedState;
+
+    if (prevState !== null) {
+      if (nextDeps !== null) {
+        var prevDeps = prevState[1];
+
+        if (areHookInputsEqual(nextDeps, prevDeps)) {
+          return prevState[0];
+        }
+      }
+    }
+
+    hook.memoizedState = [callback, nextDeps];
+    return callback;
+  }
+
+  function mountMemo(nextCreate, deps) {
+    var hook = mountWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    var nextValue = nextCreate();
+    hook.memoizedState = [nextValue, nextDeps];
+    return nextValue;
+  }
+
+  function updateMemo(nextCreate, deps) {
+    var hook = updateWorkInProgressHook();
+    var nextDeps = deps === undefined ? null : deps;
+    var prevState = hook.memoizedState;
+
+    if (prevState !== null) {
+      // Assume these are defined. If they're not, areHookInputsEqual will warn.
+      if (nextDeps !== null) {
+        var prevDeps = prevState[1];
+
+        if (areHookInputsEqual(nextDeps, prevDeps)) {
+          return prevState[0];
+        }
+      }
+    }
+
+    var nextValue = nextCreate();
+    hook.memoizedState = [nextValue, nextDeps];
+    return nextValue;
+  }
+
+  function mountDeferredValue(value) {
+    var _mountState = mountState(value),
+        prevValue = _mountState[0],
+        setValue = _mountState[1];
+
+    mountEffect(function () {
+      var prevTransition = ReactCurrentBatchConfig$1.transition;
+      ReactCurrentBatchConfig$1.transition = 1;
+
+      try {
+        setValue(value);
+      } finally {
+        ReactCurrentBatchConfig$1.transition = prevTransition;
+      }
+    }, [value]);
+    return prevValue;
+  }
+
+  function updateDeferredValue(value) {
+    var _updateState = updateState(),
+        prevValue = _updateState[0],
+        setValue = _updateState[1];
+
+    updateEffect(function () {
+      var prevTransition = ReactCurrentBatchConfig$1.transition;
+      ReactCurrentBatchConfig$1.transition = 1;
+
+      try {
+        setValue(value);
+      } finally {
+        ReactCurrentBatchConfig$1.transition = prevTransition;
+      }
+    }, [value]);
+    return prevValue;
+  }
+
+  function rerenderDeferredValue(value) {
+    var _rerenderState = rerenderState(),
+        prevValue = _rerenderState[0],
+        setValue = _rerenderState[1];
+
+    updateEffect(function () {
+      var prevTransition = ReactCurrentBatchConfig$1.transition;
+      ReactCurrentBatchConfig$1.transition = 1;
+
+      try {
+        setValue(value);
+      } finally {
+        ReactCurrentBatchConfig$1.transition = prevTransition;
+      }
+    }, [value]);
+    return prevValue;
+  }
+
+  function startTransition(setPending, callback) {
+    var priorityLevel = getCurrentPriorityLevel();
+
+    {
+      runWithPriority$1(priorityLevel < UserBlockingPriority$2 ? UserBlockingPriority$2 : priorityLevel, function () {
+        setPending(true);
+      });
+      runWithPriority$1(priorityLevel > NormalPriority$1 ? NormalPriority$1 : priorityLevel, function () {
+        var prevTransition = ReactCurrentBatchConfig$1.transition;
+        ReactCurrentBatchConfig$1.transition = 1;
+
+        try {
+          setPending(false);
+          callback();
+        } finally {
+          ReactCurrentBatchConfig$1.transition = prevTransition;
+        }
+      });
+    }
+  }
+
+  function mountTransition() {
+    var _mountState2 = mountState(false),
+        isPending = _mountState2[0],
+        setPending = _mountState2[1]; // The `start` method can be stored on a ref, since `setPending`
+    // never changes.
+
+
+    var start = startTransition.bind(null, setPending);
+    mountRef(start);
+    return [start, isPending];
+  }
+
+  function updateTransition() {
+    var _updateState2 = updateState(),
+        isPending = _updateState2[0];
+
+    var startRef = updateRef();
+    var start = startRef.current;
+    return [start, isPending];
+  }
+
+  function rerenderTransition() {
+    var _rerenderState2 = rerenderState(),
+        isPending = _rerenderState2[0];
+
+    var startRef = updateRef();
+    var start = startRef.current;
+    return [start, isPending];
+  }
+
+  var isUpdatingOpaqueValueInRenderPhase = false;
+  function getIsUpdatingOpaqueValueInRenderPhaseInDEV() {
+    {
+      return isUpdatingOpaqueValueInRenderPhase;
+    }
+  }
+
+  function warnOnOpaqueIdentifierAccessInDEV(fiber) {
+    {
+      // TODO: Should warn in effects and callbacks, too
+      var name = getComponentName(fiber.type) || 'Unknown';
+
+      if (getIsRendering() && !didWarnAboutUseOpaqueIdentifier[name]) {
+        error('The object passed back from useOpaqueIdentifier is meant to be ' + 'passed through to attributes only. Do not read the ' + 'value directly.');
+
+        didWarnAboutUseOpaqueIdentifier[name] = true;
+      }
+    }
+  }
+
+  function mountOpaqueIdentifier() {
+    var makeId =  makeClientIdInDEV.bind(null, warnOnOpaqueIdentifierAccessInDEV.bind(null, currentlyRenderingFiber$1)) ;
+
+    if (getIsHydrating()) {
+      var didUpgrade = false;
+      var fiber = currentlyRenderingFiber$1;
+
+      var readValue = function () {
+        if (!didUpgrade) {
+          // Only upgrade once. This works even inside the render phase because
+          // the update is added to a shared queue, which outlasts the
+          // in-progress render.
+          didUpgrade = true;
+
+          {
+            isUpdatingOpaqueValueInRenderPhase = true;
+            setId(makeId());
+            isUpdatingOpaqueValueInRenderPhase = false;
+            warnOnOpaqueIdentifierAccessInDEV(fiber);
+          }
+        }
+
+        {
+          {
+            throw Error( "The object passed back from useOpaqueIdentifier is meant to be passed through to attributes only. Do not read the value directly." );
+          }
+        }
+      };
+
+      var id = makeOpaqueHydratingObject(readValue);
+      var setId = mountState(id)[1];
+
+      if ((currentlyRenderingFiber$1.mode & BlockingMode) === NoMode) {
+        currentlyRenderingFiber$1.flags |= Update | Passive;
+        pushEffect(HasEffect | Passive$1, function () {
+          setId(makeId());
+        }, undefined, null);
+      }
+
+      return id;
+    } else {
+      var _id = makeId();
+
+      mountState(_id);
+      return _id;
+    }
+  }
+
+  function updateOpaqueIdentifier() {
+    var id = updateState()[0];
+    return id;
+  }
+
+  function rerenderOpaqueIdentifier() {
+    var id = rerenderState()[0];
+    return id;
+  }
+
+  function dispatchAction(fiber, queue, action) {
+    {
+      if (typeof arguments[3] === 'function') {
+        error("State updates from the useState() and useReducer() Hooks don't support the " + 'second callback argument. To execute a side effect after ' + 'rendering, declare it in the component body with useEffect().');
+      }
+    }
+
+    var eventTime = requestEventTime();
+    var lane = requestUpdateLane(fiber);
+    var update = {
+      lane: lane,
+      action: action,
+      eagerReducer: null,
+      eagerState: null,
+      next: null
+    }; // Append the update to the end of the list.
+
+    var pending = queue.pending;
+
+    if (pending === null) {
+      // This is the first update. Create a circular list.
+      update.next = update;
+    } else {
+      update.next = pending.next;
+      pending.next = update;
+    }
+
+    queue.pending = update;
+    var alternate = fiber.alternate;
+
+    if (fiber === currentlyRenderingFiber$1 || alternate !== null && alternate === currentlyRenderingFiber$1) {
+      // This is a render phase update. Stash it in a lazily-created map of
+      // queue -> linked list of updates. After this render pass, we'll restart
+      // and apply the stashed updates on top of the work-in-progress hook.
+      didScheduleRenderPhaseUpdateDuringThisPass = didScheduleRenderPhaseUpdate = true;
+    } else {
+      if (fiber.lanes === NoLanes && (alternate === null || alternate.lanes === NoLanes)) {
+        // The queue is currently empty, which means we can eagerly compute the
+        // next state before entering the render phase. If the new state is the
+        // same as the current state, we may be able to bail out entirely.
+        var lastRenderedReducer = queue.lastRenderedReducer;
+
+        if (lastRenderedReducer !== null) {
+          var prevDispatcher;
+
+          {
+            prevDispatcher = ReactCurrentDispatcher$1.current;
+            ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+          }
+
+          try {
+            var currentState = queue.lastRenderedState;
+            var eagerState = lastRenderedReducer(currentState, action); // Stash the eagerly computed state, and the reducer used to compute
+            // it, on the update object. If the reducer hasn't changed by the
+            // time we enter the render phase, then the eager state can be used
+            // without calling the reducer again.
+
+            update.eagerReducer = lastRenderedReducer;
+            update.eagerState = eagerState;
+
+            if (objectIs(eagerState, currentState)) {
+              // Fast path. We can bail out without scheduling React to re-render.
+              // It's still possible that we'll need to rebase this update later,
+              // if the component re-renders for a different reason and by that
+              // time the reducer has changed.
+              return;
+            }
+          } catch (error) {// Suppress the error. It will throw again in the render phase.
+          } finally {
+            {
+              ReactCurrentDispatcher$1.current = prevDispatcher;
+            }
+          }
+        }
+      }
+
+      {
+        // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+        if ('undefined' !== typeof jest) {
+          warnIfNotScopedWithMatchingAct(fiber);
+          warnIfNotCurrentlyActingUpdatesInDev(fiber);
+        }
+      }
+
+      scheduleUpdateOnFiber(fiber, lane, eventTime);
+    }
+  }
+
+  var ContextOnlyDispatcher = {
+    readContext: readContext,
+    useCallback: throwInvalidHookError,
+    useContext: throwInvalidHookError,
+    useEffect: throwInvalidHookError,
+    useImperativeHandle: throwInvalidHookError,
+    useLayoutEffect: throwInvalidHookError,
+    useMemo: throwInvalidHookError,
+    useReducer: throwInvalidHookError,
+    useRef: throwInvalidHookError,
+    useState: throwInvalidHookError,
+    useDebugValue: throwInvalidHookError,
+    useDeferredValue: throwInvalidHookError,
+    useTransition: throwInvalidHookError,
+    useMutableSource: throwInvalidHookError,
+    useOpaqueIdentifier: throwInvalidHookError,
+    unstable_isNewReconciler: enableNewReconciler
+  };
+  var HooksDispatcherOnMountInDEV = null;
+  var HooksDispatcherOnMountWithHookTypesInDEV = null;
+  var HooksDispatcherOnUpdateInDEV = null;
+  var HooksDispatcherOnRerenderInDEV = null;
+  var InvalidNestedHooksDispatcherOnMountInDEV = null;
+  var InvalidNestedHooksDispatcherOnUpdateInDEV = null;
+  var InvalidNestedHooksDispatcherOnRerenderInDEV = null;
+
+  {
+    var warnInvalidContextAccess = function () {
+      error('Context can only be read while React is rendering. ' + 'In classes, you can read it in the render method or getDerivedStateFromProps. ' + 'In function components, you can read it directly in the function body, but not ' + 'inside Hooks like useReducer() or useMemo().');
+    };
+
+    var warnInvalidHookAccess = function () {
+      error('Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks. ' + 'You can only call Hooks at the top level of your React function. ' + 'For more information, see ' + 'https://reactjs.org/link/rules-of-hooks');
+    };
+
+    HooksDispatcherOnMountInDEV = {
+      readContext: function (context, observedBits) {
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        mountHookTypesDev();
+        checkDepsAreArrayDev(deps);
+        return mountCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        mountHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        mountHookTypesDev();
+        checkDepsAreArrayDev(deps);
+        return mountEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        mountHookTypesDev();
+        checkDepsAreArrayDev(deps);
+        return mountImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        mountHookTypesDev();
+        checkDepsAreArrayDev(deps);
+        return mountLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        mountHookTypesDev();
+        checkDepsAreArrayDev(deps);
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        mountHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        mountHookTypesDev();
+        return mountRef(initialValue);
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        mountHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountState(initialState);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        mountHookTypesDev();
+        return mountDebugValue();
+      },
+      useDeferredValue: function (value) {
+        currentHookNameInDev = 'useDeferredValue';
+        mountHookTypesDev();
+        return mountDeferredValue(value);
+      },
+      useTransition: function () {
+        currentHookNameInDev = 'useTransition';
+        mountHookTypesDev();
+        return mountTransition();
+      },
+      useMutableSource: function (source, getSnapshot, subscribe) {
+        currentHookNameInDev = 'useMutableSource';
+        mountHookTypesDev();
+        return mountMutableSource(source, getSnapshot, subscribe);
+      },
+      useOpaqueIdentifier: function () {
+        currentHookNameInDev = 'useOpaqueIdentifier';
+        mountHookTypesDev();
+        return mountOpaqueIdentifier();
+      },
+      unstable_isNewReconciler: enableNewReconciler
+    };
+    HooksDispatcherOnMountWithHookTypesInDEV = {
+      readContext: function (context, observedBits) {
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        updateHookTypesDev();
+        return mountCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        updateHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        updateHookTypesDev();
+        return mountEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        updateHookTypesDev();
+        return mountImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        updateHookTypesDev();
+        return mountLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        updateHookTypesDev();
+        return mountRef(initialValue);
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountState(initialState);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        updateHookTypesDev();
+        return mountDebugValue();
+      },
+      useDeferredValue: function (value) {
+        currentHookNameInDev = 'useDeferredValue';
+        updateHookTypesDev();
+        return mountDeferredValue(value);
+      },
+      useTransition: function () {
+        currentHookNameInDev = 'useTransition';
+        updateHookTypesDev();
+        return mountTransition();
+      },
+      useMutableSource: function (source, getSnapshot, subscribe) {
+        currentHookNameInDev = 'useMutableSource';
+        updateHookTypesDev();
+        return mountMutableSource(source, getSnapshot, subscribe);
+      },
+      useOpaqueIdentifier: function () {
+        currentHookNameInDev = 'useOpaqueIdentifier';
+        updateHookTypesDev();
+        return mountOpaqueIdentifier();
+      },
+      unstable_isNewReconciler: enableNewReconciler
+    };
+    HooksDispatcherOnUpdateInDEV = {
+      readContext: function (context, observedBits) {
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        updateHookTypesDev();
+        return updateCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        updateHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        updateHookTypesDev();
+        return updateEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        updateHookTypesDev();
+        return updateImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        updateHookTypesDev();
+        return updateLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        updateHookTypesDev();
+        return updateRef();
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateState(initialState);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        updateHookTypesDev();
+        return updateDebugValue();
+      },
+      useDeferredValue: function (value) {
+        currentHookNameInDev = 'useDeferredValue';
+        updateHookTypesDev();
+        return updateDeferredValue(value);
+      },
+      useTransition: function () {
+        currentHookNameInDev = 'useTransition';
+        updateHookTypesDev();
+        return updateTransition();
+      },
+      useMutableSource: function (source, getSnapshot, subscribe) {
+        currentHookNameInDev = 'useMutableSource';
+        updateHookTypesDev();
+        return updateMutableSource(source, getSnapshot, subscribe);
+      },
+      useOpaqueIdentifier: function () {
+        currentHookNameInDev = 'useOpaqueIdentifier';
+        updateHookTypesDev();
+        return updateOpaqueIdentifier();
+      },
+      unstable_isNewReconciler: enableNewReconciler
+    };
+    HooksDispatcherOnRerenderInDEV = {
+      readContext: function (context, observedBits) {
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        updateHookTypesDev();
+        return updateCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        updateHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        updateHookTypesDev();
+        return updateEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        updateHookTypesDev();
+        return updateImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        updateHookTypesDev();
+        return updateLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnRerenderInDEV;
+
+        try {
+          return updateMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnRerenderInDEV;
+
+        try {
+          return rerenderReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        updateHookTypesDev();
+        return updateRef();
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnRerenderInDEV;
+
+        try {
+          return rerenderState(initialState);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        updateHookTypesDev();
+        return updateDebugValue();
+      },
+      useDeferredValue: function (value) {
+        currentHookNameInDev = 'useDeferredValue';
+        updateHookTypesDev();
+        return rerenderDeferredValue(value);
+      },
+      useTransition: function () {
+        currentHookNameInDev = 'useTransition';
+        updateHookTypesDev();
+        return rerenderTransition();
+      },
+      useMutableSource: function (source, getSnapshot, subscribe) {
+        currentHookNameInDev = 'useMutableSource';
+        updateHookTypesDev();
+        return updateMutableSource(source, getSnapshot, subscribe);
+      },
+      useOpaqueIdentifier: function () {
+        currentHookNameInDev = 'useOpaqueIdentifier';
+        updateHookTypesDev();
+        return rerenderOpaqueIdentifier();
+      },
+      unstable_isNewReconciler: enableNewReconciler
+    };
+    InvalidNestedHooksDispatcherOnMountInDEV = {
+      readContext: function (context, observedBits) {
+        warnInvalidContextAccess();
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountRef(initialValue);
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnMountInDEV;
+
+        try {
+          return mountState(initialState);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountDebugValue();
+      },
+      useDeferredValue: function (value) {
+        currentHookNameInDev = 'useDeferredValue';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountDeferredValue(value);
+      },
+      useTransition: function () {
+        currentHookNameInDev = 'useTransition';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountTransition();
+      },
+      useMutableSource: function (source, getSnapshot, subscribe) {
+        currentHookNameInDev = 'useMutableSource';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountMutableSource(source, getSnapshot, subscribe);
+      },
+      useOpaqueIdentifier: function () {
+        currentHookNameInDev = 'useOpaqueIdentifier';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountOpaqueIdentifier();
+      },
+      unstable_isNewReconciler: enableNewReconciler
+    };
+    InvalidNestedHooksDispatcherOnUpdateInDEV = {
+      readContext: function (context, observedBits) {
+        warnInvalidContextAccess();
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateRef();
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateState(initialState);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateDebugValue();
+      },
+      useDeferredValue: function (value) {
+        currentHookNameInDev = 'useDeferredValue';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateDeferredValue(value);
+      },
+      useTransition: function () {
+        currentHookNameInDev = 'useTransition';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateTransition();
+      },
+      useMutableSource: function (source, getSnapshot, subscribe) {
+        currentHookNameInDev = 'useMutableSource';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateMutableSource(source, getSnapshot, subscribe);
+      },
+      useOpaqueIdentifier: function () {
+        currentHookNameInDev = 'useOpaqueIdentifier';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateOpaqueIdentifier();
+      },
+      unstable_isNewReconciler: enableNewReconciler
+    };
+    InvalidNestedHooksDispatcherOnRerenderInDEV = {
+      readContext: function (context, observedBits) {
+        warnInvalidContextAccess();
+        return readContext(context, observedBits);
+      },
+      useCallback: function (callback, deps) {
+        currentHookNameInDev = 'useCallback';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateCallback(callback, deps);
+      },
+      useContext: function (context, observedBits) {
+        currentHookNameInDev = 'useContext';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return readContext(context, observedBits);
+      },
+      useEffect: function (create, deps) {
+        currentHookNameInDev = 'useEffect';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateEffect(create, deps);
+      },
+      useImperativeHandle: function (ref, create, deps) {
+        currentHookNameInDev = 'useImperativeHandle';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateImperativeHandle(ref, create, deps);
+      },
+      useLayoutEffect: function (create, deps) {
+        currentHookNameInDev = 'useLayoutEffect';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateLayoutEffect(create, deps);
+      },
+      useMemo: function (create, deps) {
+        currentHookNameInDev = 'useMemo';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return updateMemo(create, deps);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useReducer: function (reducer, initialArg, init) {
+        currentHookNameInDev = 'useReducer';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return rerenderReducer(reducer, initialArg, init);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useRef: function (initialValue) {
+        currentHookNameInDev = 'useRef';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateRef();
+      },
+      useState: function (initialState) {
+        currentHookNameInDev = 'useState';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        var prevDispatcher = ReactCurrentDispatcher$1.current;
+        ReactCurrentDispatcher$1.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
+
+        try {
+          return rerenderState(initialState);
+        } finally {
+          ReactCurrentDispatcher$1.current = prevDispatcher;
+        }
+      },
+      useDebugValue: function (value, formatterFn) {
+        currentHookNameInDev = 'useDebugValue';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateDebugValue();
+      },
+      useDeferredValue: function (value) {
+        currentHookNameInDev = 'useDeferredValue';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return rerenderDeferredValue(value);
+      },
+      useTransition: function () {
+        currentHookNameInDev = 'useTransition';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return rerenderTransition();
+      },
+      useMutableSource: function (source, getSnapshot, subscribe) {
+        currentHookNameInDev = 'useMutableSource';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateMutableSource(source, getSnapshot, subscribe);
+      },
+      useOpaqueIdentifier: function () {
+        currentHookNameInDev = 'useOpaqueIdentifier';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return rerenderOpaqueIdentifier();
+      },
+      unstable_isNewReconciler: enableNewReconciler
+    };
+  }
+
+  var now$1 = unstable_now;
+  var commitTime = 0;
+  var profilerStartTime = -1;
+
+  function getCommitTime() {
+    return commitTime;
+  }
+
+  function recordCommitTime() {
+
+    commitTime = now$1();
+  }
+
+  function startProfilerTimer(fiber) {
+
+    profilerStartTime = now$1();
+
+    if (fiber.actualStartTime < 0) {
+      fiber.actualStartTime = now$1();
+    }
+  }
+
+  function stopProfilerTimerIfRunning(fiber) {
+
+    profilerStartTime = -1;
+  }
+
+  function stopProfilerTimerIfRunningAndRecordDelta(fiber, overrideBaseTime) {
+
+    if (profilerStartTime >= 0) {
+      var elapsedTime = now$1() - profilerStartTime;
+      fiber.actualDuration += elapsedTime;
+
+      if (overrideBaseTime) {
+        fiber.selfBaseDuration = elapsedTime;
+      }
+
+      profilerStartTime = -1;
+    }
+  }
+
+  function transferActualDuration(fiber) {
+    // Transfer time spent rendering these children so we don't lose it
+    // after we rerender. This is used as a helper in special cases
+    // where we should count the work of multiple passes.
+    var child = fiber.child;
+
+    while (child) {
+      fiber.actualDuration += child.actualDuration;
+      child = child.sibling;
+    }
+  }
+
+  var ReactCurrentOwner$1 = ReactSharedInternals.ReactCurrentOwner;
+  var didReceiveUpdate = false;
+  var didWarnAboutBadClass;
+  var didWarnAboutModulePatternComponent;
+  var didWarnAboutContextTypeOnFunctionComponent;
+  var didWarnAboutGetDerivedStateOnFunctionComponent;
+  var didWarnAboutFunctionRefs;
+  var didWarnAboutReassigningProps;
+  var didWarnAboutRevealOrder;
+  var didWarnAboutTailOptions;
+
+  {
+    didWarnAboutBadClass = {};
+    didWarnAboutModulePatternComponent = {};
+    didWarnAboutContextTypeOnFunctionComponent = {};
+    didWarnAboutGetDerivedStateOnFunctionComponent = {};
+    didWarnAboutFunctionRefs = {};
+    didWarnAboutReassigningProps = false;
+    didWarnAboutRevealOrder = {};
+    didWarnAboutTailOptions = {};
+  }
+
+  function reconcileChildren(current, workInProgress, nextChildren, renderLanes) {
+    if (current === null) {
+      // If this is a fresh new component that hasn't been rendered yet, we
+      // won't update its child set by applying minimal side-effects. Instead,
+      // we will add them all to the child before it gets rendered. That means
+      // we can optimize this reconciliation pass by not tracking side-effects.
+      workInProgress.child = mountChildFibers(workInProgress, null, nextChildren, renderLanes);
+    } else {
+      // If the current child is the same as the work in progress, it means that
+      // we haven't yet started any work on these children. Therefore, we use
+      // the clone algorithm to create a copy of all the current children.
+      // If we had any progressed work already, that is invalid at this point so
+      // let's throw it out.
+      workInProgress.child = reconcileChildFibers(workInProgress, current.child, nextChildren, renderLanes);
+    }
+  }
+
+  function forceUnmountCurrentAndReconcile(current, workInProgress, nextChildren, renderLanes) {
+    // This function is fork of reconcileChildren. It's used in cases where we
+    // want to reconcile without matching against the existing set. This has the
+    // effect of all current children being unmounted; even if the type and key
+    // are the same, the old child is unmounted and a new child is created.
+    //
+    // To do this, we're going to go through the reconcile algorithm twice. In
+    // the first pass, we schedule a deletion for all the current children by
+    // passing null.
+    workInProgress.child = reconcileChildFibers(workInProgress, current.child, null, renderLanes); // In the second pass, we mount the new children. The trick here is that we
+    // pass null in place of where we usually pass the current child set. This has
+    // the effect of remounting all children regardless of whether their
+    // identities match.
+
+    workInProgress.child = reconcileChildFibers(workInProgress, null, nextChildren, renderLanes);
+  }
+
+  function updateForwardRef(current, workInProgress, Component, nextProps, renderLanes) {
+    // TODO: current can be non-null here even if the component
+    // hasn't yet mounted. This happens after the first render suspends.
+    // We'll need to figure out if this is fine or can cause issues.
+    {
+      if (workInProgress.type !== workInProgress.elementType) {
+        // Lazy component props can't be validated in createElement
+        // because they're only guaranteed to be resolved here.
+        var innerPropTypes = Component.propTypes;
+
+        if (innerPropTypes) {
+          checkPropTypes(innerPropTypes, nextProps, // Resolved props
+          'prop', getComponentName(Component));
+        }
+      }
+    }
+
+    var render = Component.render;
+    var ref = workInProgress.ref; // The rest is a fork of updateFunctionComponent
+
+    var nextChildren;
+    prepareToReadContext(workInProgress, renderLanes);
+
+    {
+      ReactCurrentOwner$1.current = workInProgress;
+      setIsRendering(true);
+      nextChildren = renderWithHooks(current, workInProgress, render, nextProps, ref, renderLanes);
+
+      if ( workInProgress.mode & StrictMode) {
+        disableLogs();
+
+        try {
+          nextChildren = renderWithHooks(current, workInProgress, render, nextProps, ref, renderLanes);
+        } finally {
+          reenableLogs();
+        }
+      }
+
+      setIsRendering(false);
+    }
+
+    if (current !== null && !didReceiveUpdate) {
+      bailoutHooks(current, workInProgress, renderLanes);
+      return bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
+    } // React DevTools reads this flag.
+
+
+    workInProgress.flags |= PerformedWork;
+    reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+    return workInProgress.child;
+  }
+
+  function updateMemoComponent(current, workInProgress, Component, nextProps, updateLanes, renderLanes) {
+    if (current === null) {
+      var type = Component.type;
+
+      if (isSimpleFunctionComponent(type) && Component.compare === null && // SimpleMemoComponent codepath doesn't resolve outer props either.
+      Component.defaultProps === undefined) {
+        var resolvedType = type;
+
+        {
+          resolvedType = resolveFunctionForHotReloading(type);
+        } // If this is a plain function component without default props,
+        // and with only the default shallow comparison, we upgrade it
+        // to a SimpleMemoComponent to allow fast path updates.
+
+
+        workInProgress.tag = SimpleMemoComponent;
+        workInProgress.type = resolvedType;
+
+        {
+          validateFunctionComponentInDev(workInProgress, type);
+        }
+
+        return updateSimpleMemoComponent(current, workInProgress, resolvedType, nextProps, updateLanes, renderLanes);
+      }
+
+      {
+        var innerPropTypes = type.propTypes;
+
+        if (innerPropTypes) {
+          // Inner memo component props aren't currently validated in createElement.
+          // We could move it there, but we'd still need this for lazy code path.
+          checkPropTypes(innerPropTypes, nextProps, // Resolved props
+          'prop', getComponentName(type));
+        }
+      }
+
+      var child = createFiberFromTypeAndProps(Component.type, null, nextProps, workInProgress, workInProgress.mode, renderLanes);
+      child.ref = workInProgress.ref;
+      child.return = workInProgress;
+      workInProgress.child = child;
+      return child;
+    }
+
+    {
+      var _type = Component.type;
+      var _innerPropTypes = _type.propTypes;
+
+      if (_innerPropTypes) {
+        // Inner memo component props aren't currently validated in createElement.
+        // We could move it there, but we'd still need this for lazy code path.
+        checkPropTypes(_innerPropTypes, nextProps, // Resolved props
+        'prop', getComponentName(_type));
+      }
+    }
+
+    var currentChild = current.child; // This is always exactly one child
+
+    if (!includesSomeLane(updateLanes, renderLanes)) {
+      // This will be the props with resolved defaultProps,
+      // unlike current.memoizedProps which will be the unresolved ones.
+      var prevProps = currentChild.memoizedProps; // Default to shallow comparison
+
+      var compare = Component.compare;
+      compare = compare !== null ? compare : shallowEqual;
+
+      if (compare(prevProps, nextProps) && current.ref === workInProgress.ref) {
+        return bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
+      }
+    } // React DevTools reads this flag.
+
+
+    workInProgress.flags |= PerformedWork;
+    var newChild = createWorkInProgress(currentChild, nextProps);
+    newChild.ref = workInProgress.ref;
+    newChild.return = workInProgress;
+    workInProgress.child = newChild;
+    return newChild;
+  }
+
+  function updateSimpleMemoComponent(current, workInProgress, Component, nextProps, updateLanes, renderLanes) {
+    // TODO: current can be non-null here even if the component
+    // hasn't yet mounted. This happens when the inner render suspends.
+    // We'll need to figure out if this is fine or can cause issues.
+    {
+      if (workInProgress.type !== workInProgress.elementType) {
+        // Lazy component props can't be validated in createElement
+        // because they're only guaranteed to be resolved here.
+        var outerMemoType = workInProgress.elementType;
+
+        if (outerMemoType.$$typeof === REACT_LAZY_TYPE) {
+          // We warn when you define propTypes on lazy()
+          // so let's just skip over it to find memo() outer wrapper.
+          // Inner props for memo are validated later.
+          var lazyComponent = outerMemoType;
+          var payload = lazyComponent._payload;
+          var init = lazyComponent._init;
+
+          try {
+            outerMemoType = init(payload);
+          } catch (x) {
+            outerMemoType = null;
+          } // Inner propTypes will be validated in the function component path.
+
+
+          var outerPropTypes = outerMemoType && outerMemoType.propTypes;
+
+          if (outerPropTypes) {
+            checkPropTypes(outerPropTypes, nextProps, // Resolved (SimpleMemoComponent has no defaultProps)
+            'prop', getComponentName(outerMemoType));
+          }
+        }
+      }
+    }
+
+    if (current !== null) {
+      var prevProps = current.memoizedProps;
+
+      if (shallowEqual(prevProps, nextProps) && current.ref === workInProgress.ref && ( // Prevent bailout if the implementation changed due to hot reload.
+       workInProgress.type === current.type )) {
+        didReceiveUpdate = false;
+
+        if (!includesSomeLane(renderLanes, updateLanes)) {
+          // The pending lanes were cleared at the beginning of beginWork. We're
+          // about to bail out, but there might be other lanes that weren't
+          // included in the current render. Usually, the priority level of the
+          // remaining updates is accumlated during the evaluation of the
+          // component (i.e. when processing the update queue). But since since
+          // we're bailing out early *without* evaluating the component, we need
+          // to account for it here, too. Reset to the value of the current fiber.
+          // NOTE: This only applies to SimpleMemoComponent, not MemoComponent,
+          // because a MemoComponent fiber does not have hooks or an update queue;
+          // rather, it wraps around an inner component, which may or may not
+          // contains hooks.
+          // TODO: Move the reset at in beginWork out of the common path so that
+          // this is no longer necessary.
+          workInProgress.lanes = current.lanes;
+          return bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
+        } else if ((current.flags & ForceUpdateForLegacySuspense) !== NoFlags) {
+          // This is a special case that only exists for legacy mode.
+          // See https://github.com/facebook/react/pull/19216.
+          didReceiveUpdate = true;
+        }
+      }
+    }
+
+    return updateFunctionComponent(current, workInProgress, Component, nextProps, renderLanes);
+  }
+
+  function updateOffscreenComponent(current, workInProgress, renderLanes) {
+    var nextProps = workInProgress.pendingProps;
+    var nextChildren = nextProps.children;
+    var prevState = current !== null ? current.memoizedState : null;
+
+    if (nextProps.mode === 'hidden' || nextProps.mode === 'unstable-defer-without-hiding') {
+      if ((workInProgress.mode & ConcurrentMode) === NoMode) {
+        // In legacy sync mode, don't defer the subtree. Render it now.
+        // TODO: Figure out what we should do in Blocking mode.
+        var nextState = {
+          baseLanes: NoLanes
+        };
+        workInProgress.memoizedState = nextState;
+        pushRenderLanes(workInProgress, renderLanes);
+      } else if (!includesSomeLane(renderLanes, OffscreenLane)) {
+        var nextBaseLanes;
+
+        if (prevState !== null) {
+          var prevBaseLanes = prevState.baseLanes;
+          nextBaseLanes = mergeLanes(prevBaseLanes, renderLanes);
+        } else {
+          nextBaseLanes = renderLanes;
+        } // Schedule this fiber to re-render at offscreen priority. Then bailout.
+
+
+        {
+          markSpawnedWork(OffscreenLane);
+        }
+
+        workInProgress.lanes = workInProgress.childLanes = laneToLanes(OffscreenLane);
+        var _nextState = {
+          baseLanes: nextBaseLanes
+        };
+        workInProgress.memoizedState = _nextState; // We're about to bail out, but we need to push this to the stack anyway
+        // to avoid a push/pop misalignment.
+
+        pushRenderLanes(workInProgress, nextBaseLanes);
+        return null;
+      } else {
+        // Rendering at offscreen, so we can clear the base lanes.
+        var _nextState2 = {
+          baseLanes: NoLanes
+        };
+        workInProgress.memoizedState = _nextState2; // Push the lanes that were skipped when we bailed out.
+
+        var subtreeRenderLanes = prevState !== null ? prevState.baseLanes : renderLanes;
+        pushRenderLanes(workInProgress, subtreeRenderLanes);
+      }
+    } else {
+      var _subtreeRenderLanes;
+
+      if (prevState !== null) {
+        _subtreeRenderLanes = mergeLanes(prevState.baseLanes, renderLanes); // Since we're not hidden anymore, reset the state
+
+        workInProgress.memoizedState = null;
+      } else {
+        // We weren't previously hidden, and we still aren't, so there's nothing
+        // special to do. Need to push to the stack regardless, though, to avoid
+        // a push/pop misalignment.
+        _subtreeRenderLanes = renderLanes;
+      }
+
+      pushRenderLanes(workInProgress, _subtreeRenderLanes);
+    }
+
+    reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+    return workInProgress.child;
+  } // Note: These happen to have identical begin phases, for now. We shouldn't hold
+  // ourselves to this constraint, though. If the behavior diverges, we should
+  // fork the function.
+
+
+  var updateLegacyHiddenComponent = updateOffscreenComponent;
+
+  function updateFragment(current, workInProgress, renderLanes) {
+    var nextChildren = workInProgress.pendingProps;
+    reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+    return workInProgress.child;
+  }
+
+  function updateMode(current, workInProgress, renderLanes) {
+    var nextChildren = workInProgress.pendingProps.children;
+    reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+    return workInProgress.child;
+  }
+
+  function updateProfiler(current, workInProgress, renderLanes) {
+    {
+      workInProgress.flags |= Update; // Reset effect durations for the next eventual effect phase.
+      // These are reset during render to allow the DevTools commit hook a chance to read them,
+
+      var stateNode = workInProgress.stateNode;
+      stateNode.effectDuration = 0;
+      stateNode.passiveEffectDuration = 0;
+    }
+
+    var nextProps = workInProgress.pendingProps;
+    var nextChildren = nextProps.children;
+    reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+    return workInProgress.child;
+  }
+
+  function markRef(current, workInProgress) {
+    var ref = workInProgress.ref;
+
+    if (current === null && ref !== null || current !== null && current.ref !== ref) {
+      // Schedule a Ref effect
+      workInProgress.flags |= Ref;
+    }
+  }
+
+  function updateFunctionComponent(current, workInProgress, Component, nextProps, renderLanes) {
+    {
+      if (workInProgress.type !== workInProgress.elementType) {
+        // Lazy component props can't be validated in createElement
+        // because they're only guaranteed to be resolved here.
+        var innerPropTypes = Component.propTypes;
+
+        if (innerPropTypes) {
+          checkPropTypes(innerPropTypes, nextProps, // Resolved props
+          'prop', getComponentName(Component));
+        }
+      }
+    }
+
+    var context;
+
+    {
+      var unmaskedContext = getUnmaskedContext(workInProgress, Component, true);
+      context = getMaskedContext(workInProgress, unmaskedContext);
+    }
+
+    var nextChildren;
+    prepareToReadContext(workInProgress, renderLanes);
+
+    {
+      ReactCurrentOwner$1.current = workInProgress;
+      setIsRendering(true);
+      nextChildren = renderWithHooks(current, workInProgress, Component, nextProps, context, renderLanes);
+
+      if ( workInProgress.mode & StrictMode) {
+        disableLogs();
+
+        try {
+          nextChildren = renderWithHooks(current, workInProgress, Component, nextProps, context, renderLanes);
+        } finally {
+          reenableLogs();
+        }
+      }
+
+      setIsRendering(false);
+    }
+
+    if (current !== null && !didReceiveUpdate) {
+      bailoutHooks(current, workInProgress, renderLanes);
+      return bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
+    } // React DevTools reads this flag.
+
+
+    workInProgress.flags |= PerformedWork;
+    reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+    return workInProgress.child;
+  }
+
+  function updateClassComponent(current, workInProgress, Component, nextProps, renderLanes) {
+    {
+      if (workInProgress.type !== workInProgress.elementType) {
+        // Lazy component props can't be validated in createElement
+        // because they're only guaranteed to be resolved here.
+        var innerPropTypes = Component.propTypes;
+
+        if (innerPropTypes) {
+          checkPropTypes(innerPropTypes, nextProps, // Resolved props
+          'prop', getComponentName(Component));
+        }
+      }
+    } // Push context providers early to prevent context stack mismatches.
+    // During mounting we don't know the child context yet as the instance doesn't exist.
+    // We will invalidate the child context in finishClassComponent() right after rendering.
+
+
+    var hasContext;
+
+    if (isContextProvider(Component)) {
+      hasContext = true;
+      pushContextProvider(workInProgress);
+    } else {
+      hasContext = false;
+    }
+
+    prepareToReadContext(workInProgress, renderLanes);
+    var instance = workInProgress.stateNode;
+    var shouldUpdate;
+
+    if (instance === null) {
+      if (current !== null) {
+        // A class component without an instance only mounts if it suspended
+        // inside a non-concurrent tree, in an inconsistent state. We want to
+        // treat it like a new mount, even though an empty version of it already
+        // committed. Disconnect the alternate pointers.
+        current.alternate = null;
+        workInProgress.alternate = null; // Since this is conceptually a new fiber, schedule a Placement effect
+
+        workInProgress.flags |= Placement;
+      } // In the initial pass we might need to construct the instance.
+
+
+      constructClassInstance(workInProgress, Component, nextProps);
+      mountClassInstance(workInProgress, Component, nextProps, renderLanes);
+      shouldUpdate = true;
+    } else if (current === null) {
+      // In a resume, we'll already have an instance we can reuse.
+      shouldUpdate = resumeMountClassInstance(workInProgress, Component, nextProps, renderLanes);
+    } else {
+      shouldUpdate = updateClassInstance(current, workInProgress, Component, nextProps, renderLanes);
+    }
+
+    var nextUnitOfWork = finishClassComponent(current, workInProgress, Component, shouldUpdate, hasContext, renderLanes);
+
+    {
+      var inst = workInProgress.stateNode;
+
+      if (shouldUpdate && inst.props !== nextProps) {
+        if (!didWarnAboutReassigningProps) {
+          error('It looks like %s is reassigning its own `this.props` while rendering. ' + 'This is not supported and can lead to confusing bugs.', getComponentName(workInProgress.type) || 'a component');
+        }
+
+        didWarnAboutReassigningProps = true;
+      }
+    }
+
+    return nextUnitOfWork;
+  }
+
+  function finishClassComponent(current, workInProgress, Component, shouldUpdate, hasContext, renderLanes) {
+    // Refs should update even if shouldComponentUpdate returns false
+    markRef(current, workInProgress);
+    var didCaptureError = (workInProgress.flags & DidCapture) !== NoFlags;
+
+    if (!shouldUpdate && !didCaptureError) {
+      // Context providers should defer to sCU for rendering
+      if (hasContext) {
+        invalidateContextProvider(workInProgress, Component, false);
+      }
+
+      return bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
+    }
+
+    var instance = workInProgress.stateNode; // Rerender
+
+    ReactCurrentOwner$1.current = workInProgress;
+    var nextChildren;
+
+    if (didCaptureError && typeof Component.getDerivedStateFromError !== 'function') {
+      // If we captured an error, but getDerivedStateFromError is not defined,
+      // unmount all the children. componentDidCatch will schedule an update to
+      // re-render a fallback. This is temporary until we migrate everyone to
+      // the new API.
+      // TODO: Warn in a future release.
+      nextChildren = null;
+
+      {
+        stopProfilerTimerIfRunning();
+      }
+    } else {
+      {
+        setIsRendering(true);
+        nextChildren = instance.render();
+
+        if ( workInProgress.mode & StrictMode) {
+          disableLogs();
+
+          try {
+            instance.render();
+          } finally {
+            reenableLogs();
+          }
+        }
+
+        setIsRendering(false);
+      }
+    } // React DevTools reads this flag.
+
+
+    workInProgress.flags |= PerformedWork;
+
+    if (current !== null && didCaptureError) {
+      // If we're recovering from an error, reconcile without reusing any of
+      // the existing children. Conceptually, the normal children and the children
+      // that are shown on error are two different sets, so we shouldn't reuse
+      // normal children even if their identities match.
+      forceUnmountCurrentAndReconcile(current, workInProgress, nextChildren, renderLanes);
+    } else {
+      reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+    } // Memoize state using the values we just used to render.
+    // TODO: Restructure so we never read values from the instance.
+
+
+    workInProgress.memoizedState = instance.state; // The context might have changed so we need to recalculate it.
+
+    if (hasContext) {
+      invalidateContextProvider(workInProgress, Component, true);
+    }
+
+    return workInProgress.child;
+  }
+
+  function pushHostRootContext(workInProgress) {
+    var root = workInProgress.stateNode;
+
+    if (root.pendingContext) {
+      pushTopLevelContextObject(workInProgress, root.pendingContext, root.pendingContext !== root.context);
+    } else if (root.context) {
+      // Should always be set
+      pushTopLevelContextObject(workInProgress, root.context, false);
+    }
+
+    pushHostContainer(workInProgress, root.containerInfo);
+  }
+
+  function updateHostRoot(current, workInProgress, renderLanes) {
+    pushHostRootContext(workInProgress);
+    var updateQueue = workInProgress.updateQueue;
+
+    if (!(current !== null && updateQueue !== null)) {
+      {
+        throw Error( "If the root does not have an updateQueue, we should have already bailed out. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+
+    var nextProps = workInProgress.pendingProps;
+    var prevState = workInProgress.memoizedState;
+    var prevChildren = prevState !== null ? prevState.element : null;
+    cloneUpdateQueue(current, workInProgress);
+    processUpdateQueue(workInProgress, nextProps, null, renderLanes);
+    var nextState = workInProgress.memoizedState; // Caution: React DevTools currently depends on this property
+    // being called "element".
+
+    var nextChildren = nextState.element;
+
+    if (nextChildren === prevChildren) {
+      resetHydrationState();
+      return bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
+    }
+
+    var root = workInProgress.stateNode;
+
+    if (root.hydrate && enterHydrationState(workInProgress)) {
+      // If we don't have any current children this might be the first pass.
+      // We always try to hydrate. If this isn't a hydration pass there won't
+      // be any children to hydrate which is effectively the same thing as
+      // not hydrating.
+      {
+        var mutableSourceEagerHydrationData = root.mutableSourceEagerHydrationData;
+
+        if (mutableSourceEagerHydrationData != null) {
+          for (var i = 0; i < mutableSourceEagerHydrationData.length; i += 2) {
+            var mutableSource = mutableSourceEagerHydrationData[i];
+            var version = mutableSourceEagerHydrationData[i + 1];
+            setWorkInProgressVersion(mutableSource, version);
+          }
+        }
+      }
+
+      var child = mountChildFibers(workInProgress, null, nextChildren, renderLanes);
+      workInProgress.child = child;
+      var node = child;
+
+      while (node) {
+        // Mark each child as hydrating. This is a fast path to know whether this
+        // tree is part of a hydrating tree. This is used to determine if a child
+        // node has fully mounted yet, and for scheduling event replaying.
+        // Conceptually this is similar to Placement in that a new subtree is
+        // inserted into the React tree here. It just happens to not need DOM
+        // mutations because it already exists.
+        node.flags = node.flags & ~Placement | Hydrating;
+        node = node.sibling;
+      }
+    } else {
+      // Otherwise reset hydration state in case we aborted and resumed another
+      // root.
+      reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+      resetHydrationState();
+    }
+
+    return workInProgress.child;
+  }
+
+  function updateHostComponent(current, workInProgress, renderLanes) {
+    pushHostContext(workInProgress);
+
+    if (current === null) {
+      tryToClaimNextHydratableInstance(workInProgress);
+    }
+
+    var type = workInProgress.type;
+    var nextProps = workInProgress.pendingProps;
+    var prevProps = current !== null ? current.memoizedProps : null;
+    var nextChildren = nextProps.children;
+    var isDirectTextChild = shouldSetTextContent(type, nextProps);
+
+    if (isDirectTextChild) {
+      // We special case a direct text child of a host node. This is a common
+      // case. We won't handle it as a reified child. We will instead handle
+      // this in the host environment that also has access to this prop. That
+      // avoids allocating another HostText fiber and traversing it.
+      nextChildren = null;
+    } else if (prevProps !== null && shouldSetTextContent(type, prevProps)) {
+      // If we're switching from a direct text child to a normal child, or to
+      // empty, we need to schedule the text content to be reset.
+      workInProgress.flags |= ContentReset;
+    }
+
+    markRef(current, workInProgress);
+    reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+    return workInProgress.child;
+  }
+
+  function updateHostText(current, workInProgress) {
+    if (current === null) {
+      tryToClaimNextHydratableInstance(workInProgress);
+    } // Nothing to do here. This is terminal. We'll do the completion step
+    // immediately after.
+
+
+    return null;
+  }
+
+  function mountLazyComponent(_current, workInProgress, elementType, updateLanes, renderLanes) {
+    if (_current !== null) {
+      // A lazy component only mounts if it suspended inside a non-
+      // concurrent tree, in an inconsistent state. We want to treat it like
+      // a new mount, even though an empty version of it already committed.
+      // Disconnect the alternate pointers.
+      _current.alternate = null;
+      workInProgress.alternate = null; // Since this is conceptually a new fiber, schedule a Placement effect
+
+      workInProgress.flags |= Placement;
+    }
+
+    var props = workInProgress.pendingProps;
+    var lazyComponent = elementType;
+    var payload = lazyComponent._payload;
+    var init = lazyComponent._init;
+    var Component = init(payload); // Store the unwrapped component in the type.
+
+    workInProgress.type = Component;
+    var resolvedTag = workInProgress.tag = resolveLazyComponentTag(Component);
+    var resolvedProps = resolveDefaultProps(Component, props);
+    var child;
+
+    switch (resolvedTag) {
+      case FunctionComponent:
+        {
+          {
+            validateFunctionComponentInDev(workInProgress, Component);
+            workInProgress.type = Component = resolveFunctionForHotReloading(Component);
+          }
+
+          child = updateFunctionComponent(null, workInProgress, Component, resolvedProps, renderLanes);
+          return child;
+        }
+
+      case ClassComponent:
+        {
+          {
+            workInProgress.type = Component = resolveClassForHotReloading(Component);
+          }
+
+          child = updateClassComponent(null, workInProgress, Component, resolvedProps, renderLanes);
+          return child;
+        }
+
+      case ForwardRef:
+        {
+          {
+            workInProgress.type = Component = resolveForwardRefForHotReloading(Component);
+          }
+
+          child = updateForwardRef(null, workInProgress, Component, resolvedProps, renderLanes);
+          return child;
+        }
+
+      case MemoComponent:
+        {
+          {
+            if (workInProgress.type !== workInProgress.elementType) {
+              var outerPropTypes = Component.propTypes;
+
+              if (outerPropTypes) {
+                checkPropTypes(outerPropTypes, resolvedProps, // Resolved for outer only
+                'prop', getComponentName(Component));
+              }
+            }
+          }
+
+          child = updateMemoComponent(null, workInProgress, Component, resolveDefaultProps(Component.type, resolvedProps), // The inner type can have defaults too
+          updateLanes, renderLanes);
+          return child;
+        }
+    }
+
+    var hint = '';
+
+    {
+      if (Component !== null && typeof Component === 'object' && Component.$$typeof === REACT_LAZY_TYPE) {
+        hint = ' Did you wrap a component in React.lazy() more than once?';
+      }
+    } // This message intentionally doesn't mention ForwardRef or MemoComponent
+    // because the fact that it's a separate type of work is an
+    // implementation detail.
+
+
+    {
+      {
+        throw Error( "Element type is invalid. Received a promise that resolves to: " + Component + ". Lazy element type must resolve to a class or function." + hint );
+      }
+    }
+  }
+
+  function mountIncompleteClassComponent(_current, workInProgress, Component, nextProps, renderLanes) {
+    if (_current !== null) {
+      // An incomplete component only mounts if it suspended inside a non-
+      // concurrent tree, in an inconsistent state. We want to treat it like
+      // a new mount, even though an empty version of it already committed.
+      // Disconnect the alternate pointers.
+      _current.alternate = null;
+      workInProgress.alternate = null; // Since this is conceptually a new fiber, schedule a Placement effect
+
+      workInProgress.flags |= Placement;
+    } // Promote the fiber to a class and try rendering again.
+
+
+    workInProgress.tag = ClassComponent; // The rest of this function is a fork of `updateClassComponent`
+    // Push context providers early to prevent context stack mismatches.
+    // During mounting we don't know the child context yet as the instance doesn't exist.
+    // We will invalidate the child context in finishClassComponent() right after rendering.
+
+    var hasContext;
+
+    if (isContextProvider(Component)) {
+      hasContext = true;
+      pushContextProvider(workInProgress);
+    } else {
+      hasContext = false;
+    }
+
+    prepareToReadContext(workInProgress, renderLanes);
+    constructClassInstance(workInProgress, Component, nextProps);
+    mountClassInstance(workInProgress, Component, nextProps, renderLanes);
+    return finishClassComponent(null, workInProgress, Component, true, hasContext, renderLanes);
+  }
+
+  function mountIndeterminateComponent(_current, workInProgress, Component, renderLanes) {
+    if (_current !== null) {
+      // An indeterminate component only mounts if it suspended inside a non-
+      // concurrent tree, in an inconsistent state. We want to treat it like
+      // a new mount, even though an empty version of it already committed.
+      // Disconnect the alternate pointers.
+      _current.alternate = null;
+      workInProgress.alternate = null; // Since this is conceptually a new fiber, schedule a Placement effect
+
+      workInProgress.flags |= Placement;
+    }
+
+    var props = workInProgress.pendingProps;
+    var context;
+
+    {
+      var unmaskedContext = getUnmaskedContext(workInProgress, Component, false);
+      context = getMaskedContext(workInProgress, unmaskedContext);
+    }
+
+    prepareToReadContext(workInProgress, renderLanes);
+    var value;
+
+    {
+      if (Component.prototype && typeof Component.prototype.render === 'function') {
+        var componentName = getComponentName(Component) || 'Unknown';
+
+        if (!didWarnAboutBadClass[componentName]) {
+          error("The <%s /> component appears to have a render method, but doesn't extend React.Component. " + 'This is likely to cause errors. Change %s to extend React.Component instead.', componentName, componentName);
+
+          didWarnAboutBadClass[componentName] = true;
+        }
+      }
+
+      if (workInProgress.mode & StrictMode) {
+        ReactStrictModeWarnings.recordLegacyContextWarning(workInProgress, null);
+      }
+
+      setIsRendering(true);
+      ReactCurrentOwner$1.current = workInProgress;
+      value = renderWithHooks(null, workInProgress, Component, props, context, renderLanes);
+      setIsRendering(false);
+    } // React DevTools reads this flag.
+
+
+    workInProgress.flags |= PerformedWork;
+
+    {
+      // Support for module components is deprecated and is removed behind a flag.
+      // Whether or not it would crash later, we want to show a good message in DEV first.
+      if (typeof value === 'object' && value !== null && typeof value.render === 'function' && value.$$typeof === undefined) {
+        var _componentName = getComponentName(Component) || 'Unknown';
+
+        if (!didWarnAboutModulePatternComponent[_componentName]) {
+          error('The <%s /> component appears to be a function component that returns a class instance. ' + 'Change %s to a class that extends React.Component instead. ' + "If you can't use a class try assigning the prototype on the function as a workaround. " + "`%s.prototype = React.Component.prototype`. Don't use an arrow function since it " + 'cannot be called with `new` by React.', _componentName, _componentName, _componentName);
+
+          didWarnAboutModulePatternComponent[_componentName] = true;
+        }
+      }
+    }
+
+    if ( // Run these checks in production only if the flag is off.
+    // Eventually we'll delete this branch altogether.
+     typeof value === 'object' && value !== null && typeof value.render === 'function' && value.$$typeof === undefined) {
+      {
+        var _componentName2 = getComponentName(Component) || 'Unknown';
+
+        if (!didWarnAboutModulePatternComponent[_componentName2]) {
+          error('The <%s /> component appears to be a function component that returns a class instance. ' + 'Change %s to a class that extends React.Component instead. ' + "If you can't use a class try assigning the prototype on the function as a workaround. " + "`%s.prototype = React.Component.prototype`. Don't use an arrow function since it " + 'cannot be called with `new` by React.', _componentName2, _componentName2, _componentName2);
+
+          didWarnAboutModulePatternComponent[_componentName2] = true;
+        }
+      } // Proceed under the assumption that this is a class instance
+
+
+      workInProgress.tag = ClassComponent; // Throw out any hooks that were used.
+
+      workInProgress.memoizedState = null;
+      workInProgress.updateQueue = null; // Push context providers early to prevent context stack mismatches.
+      // During mounting we don't know the child context yet as the instance doesn't exist.
+      // We will invalidate the child context in finishClassComponent() right after rendering.
+
+      var hasContext = false;
+
+      if (isContextProvider(Component)) {
+        hasContext = true;
+        pushContextProvider(workInProgress);
+      } else {
+        hasContext = false;
+      }
+
+      workInProgress.memoizedState = value.state !== null && value.state !== undefined ? value.state : null;
+      initializeUpdateQueue(workInProgress);
+      var getDerivedStateFromProps = Component.getDerivedStateFromProps;
+
+      if (typeof getDerivedStateFromProps === 'function') {
+        applyDerivedStateFromProps(workInProgress, Component, getDerivedStateFromProps, props);
+      }
+
+      adoptClassInstance(workInProgress, value);
+      mountClassInstance(workInProgress, Component, props, renderLanes);
+      return finishClassComponent(null, workInProgress, Component, true, hasContext, renderLanes);
+    } else {
+      // Proceed under the assumption that this is a function component
+      workInProgress.tag = FunctionComponent;
+
+      {
+
+        if ( workInProgress.mode & StrictMode) {
+          disableLogs();
+
+          try {
+            value = renderWithHooks(null, workInProgress, Component, props, context, renderLanes);
+          } finally {
+            reenableLogs();
+          }
+        }
+      }
+
+      reconcileChildren(null, workInProgress, value, renderLanes);
+
+      {
+        validateFunctionComponentInDev(workInProgress, Component);
+      }
+
+      return workInProgress.child;
+    }
+  }
+
+  function validateFunctionComponentInDev(workInProgress, Component) {
+    {
+      if (Component) {
+        if (Component.childContextTypes) {
+          error('%s(...): childContextTypes cannot be defined on a function component.', Component.displayName || Component.name || 'Component');
+        }
+      }
+
+      if (workInProgress.ref !== null) {
+        var info = '';
+        var ownerName = getCurrentFiberOwnerNameInDevOrNull();
+
+        if (ownerName) {
+          info += '\n\nCheck the render method of `' + ownerName + '`.';
+        }
+
+        var warningKey = ownerName || workInProgress._debugID || '';
+        var debugSource = workInProgress._debugSource;
+
+        if (debugSource) {
+          warningKey = debugSource.fileName + ':' + debugSource.lineNumber;
+        }
+
+        if (!didWarnAboutFunctionRefs[warningKey]) {
+          didWarnAboutFunctionRefs[warningKey] = true;
+
+          error('Function components cannot be given refs. ' + 'Attempts to access this ref will fail. ' + 'Did you mean to use React.forwardRef()?%s', info);
+        }
+      }
+
+      if (typeof Component.getDerivedStateFromProps === 'function') {
+        var _componentName3 = getComponentName(Component) || 'Unknown';
+
+        if (!didWarnAboutGetDerivedStateOnFunctionComponent[_componentName3]) {
+          error('%s: Function components do not support getDerivedStateFromProps.', _componentName3);
+
+          didWarnAboutGetDerivedStateOnFunctionComponent[_componentName3] = true;
+        }
+      }
+
+      if (typeof Component.contextType === 'object' && Component.contextType !== null) {
+        var _componentName4 = getComponentName(Component) || 'Unknown';
+
+        if (!didWarnAboutContextTypeOnFunctionComponent[_componentName4]) {
+          error('%s: Function components do not support contextType.', _componentName4);
+
+          didWarnAboutContextTypeOnFunctionComponent[_componentName4] = true;
+        }
+      }
+    }
+  }
+
+  var SUSPENDED_MARKER = {
+    dehydrated: null,
+    retryLane: NoLane
+  };
+
+  function mountSuspenseOffscreenState(renderLanes) {
+    return {
+      baseLanes: renderLanes
+    };
+  }
+
+  function updateSuspenseOffscreenState(prevOffscreenState, renderLanes) {
+    return {
+      baseLanes: mergeLanes(prevOffscreenState.baseLanes, renderLanes)
+    };
+  } // TODO: Probably should inline this back
+
+
+  function shouldRemainOnFallback(suspenseContext, current, workInProgress, renderLanes) {
+    // If we're already showing a fallback, there are cases where we need to
+    // remain on that fallback regardless of whether the content has resolved.
+    // For example, SuspenseList coordinates when nested content appears.
+    if (current !== null) {
+      var suspenseState = current.memoizedState;
+
+      if (suspenseState === null) {
+        // Currently showing content. Don't hide it, even if ForceSuspenseFallack
+        // is true. More precise name might be "ForceRemainSuspenseFallback".
+        // Note: This is a factoring smell. Can't remain on a fallback if there's
+        // no fallback to remain on.
+        return false;
+      }
+    } // Not currently showing content. Consult the Suspense context.
+
+
+    return hasSuspenseContext(suspenseContext, ForceSuspenseFallback);
+  }
+
+  function getRemainingWorkInPrimaryTree(current, renderLanes) {
+    // TODO: Should not remove render lanes that were pinged during this render
+    return removeLanes(current.childLanes, renderLanes);
+  }
+
+  function updateSuspenseComponent(current, workInProgress, renderLanes) {
+    var nextProps = workInProgress.pendingProps; // This is used by DevTools to force a boundary to suspend.
+
+    {
+      if (shouldSuspend(workInProgress)) {
+        workInProgress.flags |= DidCapture;
+      }
+    }
+
+    var suspenseContext = suspenseStackCursor.current;
+    var showFallback = false;
+    var didSuspend = (workInProgress.flags & DidCapture) !== NoFlags;
+
+    if (didSuspend || shouldRemainOnFallback(suspenseContext, current)) {
+      // Something in this boundary's subtree already suspended. Switch to
+      // rendering the fallback children.
+      showFallback = true;
+      workInProgress.flags &= ~DidCapture;
+    } else {
+      // Attempting the main content
+      if (current === null || current.memoizedState !== null) {
+        // This is a new mount or this boundary is already showing a fallback state.
+        // Mark this subtree context as having at least one invisible parent that could
+        // handle the fallback state.
+        // Boundaries without fallbacks or should be avoided are not considered since
+        // they cannot handle preferred fallback states.
+        if (nextProps.fallback !== undefined && nextProps.unstable_avoidThisFallback !== true) {
+          suspenseContext = addSubtreeSuspenseContext(suspenseContext, InvisibleParentSuspenseContext);
+        }
+      }
+    }
+
+    suspenseContext = setDefaultShallowSuspenseContext(suspenseContext);
+    pushSuspenseContext(workInProgress, suspenseContext); // OK, the next part is confusing. We're about to reconcile the Suspense
+    // boundary's children. This involves some custom reconcilation logic. Two
+    // main reasons this is so complicated.
+    //
+    // First, Legacy Mode has different semantics for backwards compatibility. The
+    // primary tree will commit in an inconsistent state, so when we do the
+    // second pass to render the fallback, we do some exceedingly, uh, clever
+    // hacks to make that not totally break. Like transferring effects and
+    // deletions from hidden tree. In Concurrent Mode, it's much simpler,
+    // because we bailout on the primary tree completely and leave it in its old
+    // state, no effects. Same as what we do for Offscreen (except that
+    // Offscreen doesn't have the first render pass).
+    //
+    // Second is hydration. During hydration, the Suspense fiber has a slightly
+    // different layout, where the child points to a dehydrated fragment, which
+    // contains the DOM rendered by the server.
+    //
+    // Third, even if you set all that aside, Suspense is like error boundaries in
+    // that we first we try to render one tree, and if that fails, we render again
+    // and switch to a different tree. Like a try/catch block. So we have to track
+    // which branch we're currently rendering. Ideally we would model this using
+    // a stack.
+
+    if (current === null) {
+      // Initial mount
+      // If we're currently hydrating, try to hydrate this boundary.
+      // But only if this has a fallback.
+      if (nextProps.fallback !== undefined) {
+        tryToClaimNextHydratableInstance(workInProgress); // This could've been a dehydrated suspense component.
+      }
+
+      var nextPrimaryChildren = nextProps.children;
+      var nextFallbackChildren = nextProps.fallback;
+
+      if (showFallback) {
+        var fallbackFragment = mountSuspenseFallbackChildren(workInProgress, nextPrimaryChildren, nextFallbackChildren, renderLanes);
+        var primaryChildFragment = workInProgress.child;
+        primaryChildFragment.memoizedState = mountSuspenseOffscreenState(renderLanes);
+        workInProgress.memoizedState = SUSPENDED_MARKER;
+        return fallbackFragment;
+      } else if (typeof nextProps.unstable_expectedLoadTime === 'number') {
+        // This is a CPU-bound tree. Skip this tree and show a placeholder to
+        // unblock the surrounding content. Then immediately retry after the
+        // initial commit.
+        var _fallbackFragment = mountSuspenseFallbackChildren(workInProgress, nextPrimaryChildren, nextFallbackChildren, renderLanes);
+
+        var _primaryChildFragment = workInProgress.child;
+        _primaryChildFragment.memoizedState = mountSuspenseOffscreenState(renderLanes);
+        workInProgress.memoizedState = SUSPENDED_MARKER; // Since nothing actually suspended, there will nothing to ping this to
+        // get it started back up to attempt the next item. While in terms of
+        // priority this work has the same priority as this current render, it's
+        // not part of the same transition once the transition has committed. If
+        // it's sync, we still want to yield so that it can be painted.
+        // Conceptually, this is really the same as pinging. We can use any
+        // RetryLane even if it's the one currently rendering since we're leaving
+        // it behind on this node.
+
+        workInProgress.lanes = SomeRetryLane;
+
+        {
+          markSpawnedWork(SomeRetryLane);
+        }
+
+        return _fallbackFragment;
+      } else {
+        return mountSuspensePrimaryChildren(workInProgress, nextPrimaryChildren, renderLanes);
+      }
+    } else {
+      // This is an update.
+      // If the current fiber has a SuspenseState, that means it's already showing
+      // a fallback.
+      var prevState = current.memoizedState;
+
+      if (prevState !== null) {
+
+        if (showFallback) {
+          var _nextFallbackChildren2 = nextProps.fallback;
+          var _nextPrimaryChildren2 = nextProps.children;
+
+          var _fallbackChildFragment = updateSuspenseFallbackChildren(current, workInProgress, _nextPrimaryChildren2, _nextFallbackChildren2, renderLanes);
+
+          var _primaryChildFragment3 = workInProgress.child;
+          var prevOffscreenState = current.child.memoizedState;
+          _primaryChildFragment3.memoizedState = prevOffscreenState === null ? mountSuspenseOffscreenState(renderLanes) : updateSuspenseOffscreenState(prevOffscreenState, renderLanes);
+          _primaryChildFragment3.childLanes = getRemainingWorkInPrimaryTree(current, renderLanes);
+          workInProgress.memoizedState = SUSPENDED_MARKER;
+          return _fallbackChildFragment;
+        } else {
+          var _nextPrimaryChildren3 = nextProps.children;
+
+          var _primaryChildFragment4 = updateSuspensePrimaryChildren(current, workInProgress, _nextPrimaryChildren3, renderLanes);
+
+          workInProgress.memoizedState = null;
+          return _primaryChildFragment4;
+        }
+      } else {
+        // The current tree is not already showing a fallback.
+        if (showFallback) {
+          // Timed out.
+          var _nextFallbackChildren3 = nextProps.fallback;
+          var _nextPrimaryChildren4 = nextProps.children;
+
+          var _fallbackChildFragment2 = updateSuspenseFallbackChildren(current, workInProgress, _nextPrimaryChildren4, _nextFallbackChildren3, renderLanes);
+
+          var _primaryChildFragment5 = workInProgress.child;
+          var _prevOffscreenState = current.child.memoizedState;
+          _primaryChildFragment5.memoizedState = _prevOffscreenState === null ? mountSuspenseOffscreenState(renderLanes) : updateSuspenseOffscreenState(_prevOffscreenState, renderLanes);
+          _primaryChildFragment5.childLanes = getRemainingWorkInPrimaryTree(current, renderLanes); // Skip the primary children, and continue working on the
+          // fallback children.
+
+          workInProgress.memoizedState = SUSPENDED_MARKER;
+          return _fallbackChildFragment2;
+        } else {
+          // Still haven't timed out. Continue rendering the children, like we
+          // normally do.
+          var _nextPrimaryChildren5 = nextProps.children;
+
+          var _primaryChildFragment6 = updateSuspensePrimaryChildren(current, workInProgress, _nextPrimaryChildren5, renderLanes);
+
+          workInProgress.memoizedState = null;
+          return _primaryChildFragment6;
+        }
+      }
+    }
+  }
+
+  function mountSuspensePrimaryChildren(workInProgress, primaryChildren, renderLanes) {
+    var mode = workInProgress.mode;
+    var primaryChildProps = {
+      mode: 'visible',
+      children: primaryChildren
+    };
+    var primaryChildFragment = createFiberFromOffscreen(primaryChildProps, mode, renderLanes, null);
+    primaryChildFragment.return = workInProgress;
+    workInProgress.child = primaryChildFragment;
+    return primaryChildFragment;
+  }
+
+  function mountSuspenseFallbackChildren(workInProgress, primaryChildren, fallbackChildren, renderLanes) {
+    var mode = workInProgress.mode;
+    var progressedPrimaryFragment = workInProgress.child;
+    var primaryChildProps = {
+      mode: 'hidden',
+      children: primaryChildren
+    };
+    var primaryChildFragment;
+    var fallbackChildFragment;
+
+    if ((mode & BlockingMode) === NoMode && progressedPrimaryFragment !== null) {
+      // In legacy mode, we commit the primary tree as if it successfully
+      // completed, even though it's in an inconsistent state.
+      primaryChildFragment = progressedPrimaryFragment;
+      primaryChildFragment.childLanes = NoLanes;
+      primaryChildFragment.pendingProps = primaryChildProps;
+
+      if ( workInProgress.mode & ProfileMode) {
+        // Reset the durations from the first pass so they aren't included in the
+        // final amounts. This seems counterintuitive, since we're intentionally
+        // not measuring part of the render phase, but this makes it match what we
+        // do in Concurrent Mode.
+        primaryChildFragment.actualDuration = 0;
+        primaryChildFragment.actualStartTime = -1;
+        primaryChildFragment.selfBaseDuration = 0;
+        primaryChildFragment.treeBaseDuration = 0;
+      }
+
+      fallbackChildFragment = createFiberFromFragment(fallbackChildren, mode, renderLanes, null);
+    } else {
+      primaryChildFragment = createFiberFromOffscreen(primaryChildProps, mode, NoLanes, null);
+      fallbackChildFragment = createFiberFromFragment(fallbackChildren, mode, renderLanes, null);
+    }
+
+    primaryChildFragment.return = workInProgress;
+    fallbackChildFragment.return = workInProgress;
+    primaryChildFragment.sibling = fallbackChildFragment;
+    workInProgress.child = primaryChildFragment;
+    return fallbackChildFragment;
+  }
+
+  function createWorkInProgressOffscreenFiber(current, offscreenProps) {
+    // The props argument to `createWorkInProgress` is `any` typed, so we use this
+    // wrapper function to constrain it.
+    return createWorkInProgress(current, offscreenProps);
+  }
+
+  function updateSuspensePrimaryChildren(current, workInProgress, primaryChildren, renderLanes) {
+    var currentPrimaryChildFragment = current.child;
+    var currentFallbackChildFragment = currentPrimaryChildFragment.sibling;
+    var primaryChildFragment = createWorkInProgressOffscreenFiber(currentPrimaryChildFragment, {
+      mode: 'visible',
+      children: primaryChildren
+    });
+
+    if ((workInProgress.mode & BlockingMode) === NoMode) {
+      primaryChildFragment.lanes = renderLanes;
+    }
+
+    primaryChildFragment.return = workInProgress;
+    primaryChildFragment.sibling = null;
+
+    if (currentFallbackChildFragment !== null) {
+      // Delete the fallback child fragment
+      currentFallbackChildFragment.nextEffect = null;
+      currentFallbackChildFragment.flags = Deletion;
+      workInProgress.firstEffect = workInProgress.lastEffect = currentFallbackChildFragment;
+    }
+
+    workInProgress.child = primaryChildFragment;
+    return primaryChildFragment;
+  }
+
+  function updateSuspenseFallbackChildren(current, workInProgress, primaryChildren, fallbackChildren, renderLanes) {
+    var mode = workInProgress.mode;
+    var currentPrimaryChildFragment = current.child;
+    var currentFallbackChildFragment = currentPrimaryChildFragment.sibling;
+    var primaryChildProps = {
+      mode: 'hidden',
+      children: primaryChildren
+    };
+    var primaryChildFragment;
+
+    if ( // In legacy mode, we commit the primary tree as if it successfully
+    // completed, even though it's in an inconsistent state.
+    (mode & BlockingMode) === NoMode && // Make sure we're on the second pass, i.e. the primary child fragment was
+    // already cloned. In legacy mode, the only case where this isn't true is
+    // when DevTools forces us to display a fallback; we skip the first render
+    // pass entirely and go straight to rendering the fallback. (In Concurrent
+    // Mode, SuspenseList can also trigger this scenario, but this is a legacy-
+    // only codepath.)
+    workInProgress.child !== currentPrimaryChildFragment) {
+      var progressedPrimaryFragment = workInProgress.child;
+      primaryChildFragment = progressedPrimaryFragment;
+      primaryChildFragment.childLanes = NoLanes;
+      primaryChildFragment.pendingProps = primaryChildProps;
+
+      if ( workInProgress.mode & ProfileMode) {
+        // Reset the durations from the first pass so they aren't included in the
+        // final amounts. This seems counterintuitive, since we're intentionally
+        // not measuring part of the render phase, but this makes it match what we
+        // do in Concurrent Mode.
+        primaryChildFragment.actualDuration = 0;
+        primaryChildFragment.actualStartTime = -1;
+        primaryChildFragment.selfBaseDuration = currentPrimaryChildFragment.selfBaseDuration;
+        primaryChildFragment.treeBaseDuration = currentPrimaryChildFragment.treeBaseDuration;
+      } // The fallback fiber was added as a deletion effect during the first pass.
+      // However, since we're going to remain on the fallback, we no longer want
+      // to delete it. So we need to remove it from the list. Deletions are stored
+      // on the same list as effects. We want to keep the effects from the primary
+      // tree. So we copy the primary child fragment's effect list, which does not
+      // include the fallback deletion effect.
+
+
+      var progressedLastEffect = primaryChildFragment.lastEffect;
+
+      if (progressedLastEffect !== null) {
+        workInProgress.firstEffect = primaryChildFragment.firstEffect;
+        workInProgress.lastEffect = progressedLastEffect;
+        progressedLastEffect.nextEffect = null;
+      } else {
+        // TODO: Reset this somewhere else? Lol legacy mode is so weird.
+        workInProgress.firstEffect = workInProgress.lastEffect = null;
+      }
+    } else {
+      primaryChildFragment = createWorkInProgressOffscreenFiber(currentPrimaryChildFragment, primaryChildProps);
+    }
+
+    var fallbackChildFragment;
+
+    if (currentFallbackChildFragment !== null) {
+      fallbackChildFragment = createWorkInProgress(currentFallbackChildFragment, fallbackChildren);
+    } else {
+      fallbackChildFragment = createFiberFromFragment(fallbackChildren, mode, renderLanes, null); // Needs a placement effect because the parent (the Suspense boundary) already
+      // mounted but this is a new fiber.
+
+      fallbackChildFragment.flags |= Placement;
+    }
+
+    fallbackChildFragment.return = workInProgress;
+    primaryChildFragment.return = workInProgress;
+    primaryChildFragment.sibling = fallbackChildFragment;
+    workInProgress.child = primaryChildFragment;
+    return fallbackChildFragment;
+  }
+
+  function scheduleWorkOnFiber(fiber, renderLanes) {
+    fiber.lanes = mergeLanes(fiber.lanes, renderLanes);
+    var alternate = fiber.alternate;
+
+    if (alternate !== null) {
+      alternate.lanes = mergeLanes(alternate.lanes, renderLanes);
+    }
+
+    scheduleWorkOnParentPath(fiber.return, renderLanes);
+  }
+
+  function propagateSuspenseContextChange(workInProgress, firstChild, renderLanes) {
+    // Mark any Suspense boundaries with fallbacks as having work to do.
+    // If they were previously forced into fallbacks, they may now be able
+    // to unblock.
+    var node = firstChild;
+
+    while (node !== null) {
+      if (node.tag === SuspenseComponent) {
+        var state = node.memoizedState;
+
+        if (state !== null) {
+          scheduleWorkOnFiber(node, renderLanes);
+        }
+      } else if (node.tag === SuspenseListComponent) {
+        // If the tail is hidden there might not be an Suspense boundaries
+        // to schedule work on. In this case we have to schedule it on the
+        // list itself.
+        // We don't have to traverse to the children of the list since
+        // the list will propagate the change when it rerenders.
+        scheduleWorkOnFiber(node, renderLanes);
+      } else if (node.child !== null) {
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
+
+      if (node === workInProgress) {
+        return;
+      }
+
+      while (node.sibling === null) {
+        if (node.return === null || node.return === workInProgress) {
+          return;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    }
+  }
+
+  function findLastContentRow(firstChild) {
+    // This is going to find the last row among these children that is already
+    // showing content on the screen, as opposed to being in fallback state or
+    // new. If a row has multiple Suspense boundaries, any of them being in the
+    // fallback state, counts as the whole row being in a fallback state.
+    // Note that the "rows" will be workInProgress, but any nested children
+    // will still be current since we haven't rendered them yet. The mounted
+    // order may not be the same as the new order. We use the new order.
+    var row = firstChild;
+    var lastContentRow = null;
+
+    while (row !== null) {
+      var currentRow = row.alternate; // New rows can't be content rows.
+
+      if (currentRow !== null && findFirstSuspended(currentRow) === null) {
+        lastContentRow = row;
+      }
+
+      row = row.sibling;
+    }
+
+    return lastContentRow;
+  }
+
+  function validateRevealOrder(revealOrder) {
+    {
+      if (revealOrder !== undefined && revealOrder !== 'forwards' && revealOrder !== 'backwards' && revealOrder !== 'together' && !didWarnAboutRevealOrder[revealOrder]) {
+        didWarnAboutRevealOrder[revealOrder] = true;
+
+        if (typeof revealOrder === 'string') {
+          switch (revealOrder.toLowerCase()) {
+            case 'together':
+            case 'forwards':
+            case 'backwards':
+              {
+                error('"%s" is not a valid value for revealOrder on <SuspenseList />. ' + 'Use lowercase "%s" instead.', revealOrder, revealOrder.toLowerCase());
+
+                break;
+              }
+
+            case 'forward':
+            case 'backward':
+              {
+                error('"%s" is not a valid value for revealOrder on <SuspenseList />. ' + 'React uses the -s suffix in the spelling. Use "%ss" instead.', revealOrder, revealOrder.toLowerCase());
+
+                break;
+              }
+
+            default:
+              error('"%s" is not a supported revealOrder on <SuspenseList />. ' + 'Did you mean "together", "forwards" or "backwards"?', revealOrder);
+
+              break;
+          }
+        } else {
+          error('%s is not a supported value for revealOrder on <SuspenseList />. ' + 'Did you mean "together", "forwards" or "backwards"?', revealOrder);
+        }
+      }
+    }
+  }
+
+  function validateTailOptions(tailMode, revealOrder) {
+    {
+      if (tailMode !== undefined && !didWarnAboutTailOptions[tailMode]) {
+        if (tailMode !== 'collapsed' && tailMode !== 'hidden') {
+          didWarnAboutTailOptions[tailMode] = true;
+
+          error('"%s" is not a supported value for tail on <SuspenseList />. ' + 'Did you mean "collapsed" or "hidden"?', tailMode);
+        } else if (revealOrder !== 'forwards' && revealOrder !== 'backwards') {
+          didWarnAboutTailOptions[tailMode] = true;
+
+          error('<SuspenseList tail="%s" /> is only valid if revealOrder is ' + '"forwards" or "backwards". ' + 'Did you mean to specify revealOrder="forwards"?', tailMode);
+        }
+      }
+    }
+  }
+
+  function validateSuspenseListNestedChild(childSlot, index) {
+    {
+      var isArray = Array.isArray(childSlot);
+      var isIterable = !isArray && typeof getIteratorFn(childSlot) === 'function';
+
+      if (isArray || isIterable) {
+        var type = isArray ? 'array' : 'iterable';
+
+        error('A nested %s was passed to row #%s in <SuspenseList />. Wrap it in ' + 'an additional SuspenseList to configure its revealOrder: ' + '<SuspenseList revealOrder=...> ... ' + '<SuspenseList revealOrder=...>{%s}</SuspenseList> ... ' + '</SuspenseList>', type, index, type);
+
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  function validateSuspenseListChildren(children, revealOrder) {
+    {
+      if ((revealOrder === 'forwards' || revealOrder === 'backwards') && children !== undefined && children !== null && children !== false) {
+        if (Array.isArray(children)) {
+          for (var i = 0; i < children.length; i++) {
+            if (!validateSuspenseListNestedChild(children[i], i)) {
+              return;
+            }
+          }
+        } else {
+          var iteratorFn = getIteratorFn(children);
+
+          if (typeof iteratorFn === 'function') {
+            var childrenIterator = iteratorFn.call(children);
+
+            if (childrenIterator) {
+              var step = childrenIterator.next();
+              var _i = 0;
+
+              for (; !step.done; step = childrenIterator.next()) {
+                if (!validateSuspenseListNestedChild(step.value, _i)) {
+                  return;
+                }
+
+                _i++;
+              }
+            }
+          } else {
+            error('A single row was passed to a <SuspenseList revealOrder="%s" />. ' + 'This is not useful since it needs multiple rows. ' + 'Did you mean to pass multiple children or an array?', revealOrder);
+          }
+        }
+      }
+    }
+  }
+
+  function initSuspenseListRenderState(workInProgress, isBackwards, tail, lastContentRow, tailMode, lastEffectBeforeRendering) {
+    var renderState = workInProgress.memoizedState;
+
+    if (renderState === null) {
+      workInProgress.memoizedState = {
+        isBackwards: isBackwards,
+        rendering: null,
+        renderingStartTime: 0,
+        last: lastContentRow,
+        tail: tail,
+        tailMode: tailMode,
+        lastEffect: lastEffectBeforeRendering
+      };
+    } else {
+      // We can reuse the existing object from previous renders.
+      renderState.isBackwards = isBackwards;
+      renderState.rendering = null;
+      renderState.renderingStartTime = 0;
+      renderState.last = lastContentRow;
+      renderState.tail = tail;
+      renderState.tailMode = tailMode;
+      renderState.lastEffect = lastEffectBeforeRendering;
+    }
+  } // This can end up rendering this component multiple passes.
+  // The first pass splits the children fibers into two sets. A head and tail.
+  // We first render the head. If anything is in fallback state, we do another
+  // pass through beginWork to rerender all children (including the tail) with
+  // the force suspend context. If the first render didn't have anything in
+  // in fallback state. Then we render each row in the tail one-by-one.
+  // That happens in the completeWork phase without going back to beginWork.
+
+
+  function updateSuspenseListComponent(current, workInProgress, renderLanes) {
+    var nextProps = workInProgress.pendingProps;
+    var revealOrder = nextProps.revealOrder;
+    var tailMode = nextProps.tail;
+    var newChildren = nextProps.children;
+    validateRevealOrder(revealOrder);
+    validateTailOptions(tailMode, revealOrder);
+    validateSuspenseListChildren(newChildren, revealOrder);
+    reconcileChildren(current, workInProgress, newChildren, renderLanes);
+    var suspenseContext = suspenseStackCursor.current;
+    var shouldForceFallback = hasSuspenseContext(suspenseContext, ForceSuspenseFallback);
+
+    if (shouldForceFallback) {
+      suspenseContext = setShallowSuspenseContext(suspenseContext, ForceSuspenseFallback);
+      workInProgress.flags |= DidCapture;
+    } else {
+      var didSuspendBefore = current !== null && (current.flags & DidCapture) !== NoFlags;
+
+      if (didSuspendBefore) {
+        // If we previously forced a fallback, we need to schedule work
+        // on any nested boundaries to let them know to try to render
+        // again. This is the same as context updating.
+        propagateSuspenseContextChange(workInProgress, workInProgress.child, renderLanes);
+      }
+
+      suspenseContext = setDefaultShallowSuspenseContext(suspenseContext);
+    }
+
+    pushSuspenseContext(workInProgress, suspenseContext);
+
+    if ((workInProgress.mode & BlockingMode) === NoMode) {
+      // In legacy mode, SuspenseList doesn't work so we just
+      // use make it a noop by treating it as the default revealOrder.
+      workInProgress.memoizedState = null;
+    } else {
+      switch (revealOrder) {
+        case 'forwards':
+          {
+            var lastContentRow = findLastContentRow(workInProgress.child);
+            var tail;
+
+            if (lastContentRow === null) {
+              // The whole list is part of the tail.
+              // TODO: We could fast path by just rendering the tail now.
+              tail = workInProgress.child;
+              workInProgress.child = null;
+            } else {
+              // Disconnect the tail rows after the content row.
+              // We're going to render them separately later.
+              tail = lastContentRow.sibling;
+              lastContentRow.sibling = null;
+            }
+
+            initSuspenseListRenderState(workInProgress, false, // isBackwards
+            tail, lastContentRow, tailMode, workInProgress.lastEffect);
+            break;
+          }
+
+        case 'backwards':
+          {
+            // We're going to find the first row that has existing content.
+            // At the same time we're going to reverse the list of everything
+            // we pass in the meantime. That's going to be our tail in reverse
+            // order.
+            var _tail = null;
+            var row = workInProgress.child;
+            workInProgress.child = null;
+
+            while (row !== null) {
+              var currentRow = row.alternate; // New rows can't be content rows.
+
+              if (currentRow !== null && findFirstSuspended(currentRow) === null) {
+                // This is the beginning of the main content.
+                workInProgress.child = row;
+                break;
+              }
+
+              var nextRow = row.sibling;
+              row.sibling = _tail;
+              _tail = row;
+              row = nextRow;
+            } // TODO: If workInProgress.child is null, we can continue on the tail immediately.
+
+
+            initSuspenseListRenderState(workInProgress, true, // isBackwards
+            _tail, null, // last
+            tailMode, workInProgress.lastEffect);
+            break;
+          }
+
+        case 'together':
+          {
+            initSuspenseListRenderState(workInProgress, false, // isBackwards
+            null, // tail
+            null, // last
+            undefined, workInProgress.lastEffect);
+            break;
+          }
+
+        default:
+          {
+            // The default reveal order is the same as not having
+            // a boundary.
+            workInProgress.memoizedState = null;
+          }
+      }
+    }
+
+    return workInProgress.child;
+  }
+
+  function updatePortalComponent(current, workInProgress, renderLanes) {
+    pushHostContainer(workInProgress, workInProgress.stateNode.containerInfo);
+    var nextChildren = workInProgress.pendingProps;
+
+    if (current === null) {
+      // Portals are special because we don't append the children during mount
+      // but at commit. Therefore we need to track insertions which the normal
+      // flow doesn't do during mount. This doesn't happen at the root because
+      // the root always starts with a "current" with a null child.
+      // TODO: Consider unifying this with how the root works.
+      workInProgress.child = reconcileChildFibers(workInProgress, null, nextChildren, renderLanes);
+    } else {
+      reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+    }
+
+    return workInProgress.child;
+  }
+
+  var hasWarnedAboutUsingNoValuePropOnContextProvider = false;
+
+  function updateContextProvider(current, workInProgress, renderLanes) {
+    var providerType = workInProgress.type;
+    var context = providerType._context;
+    var newProps = workInProgress.pendingProps;
+    var oldProps = workInProgress.memoizedProps;
+    var newValue = newProps.value;
+
+    {
+      if (!('value' in newProps)) {
+        if (!hasWarnedAboutUsingNoValuePropOnContextProvider) {
+          hasWarnedAboutUsingNoValuePropOnContextProvider = true;
+
+          error('The `value` prop is required for the `<Context.Provider>`. Did you misspell it or forget to pass it?');
+        }
+      }
+
+      var providerPropTypes = workInProgress.type.propTypes;
+
+      if (providerPropTypes) {
+        checkPropTypes(providerPropTypes, newProps, 'prop', 'Context.Provider');
+      }
+    }
+
+    pushProvider(workInProgress, newValue);
+
+    if (oldProps !== null) {
+      var oldValue = oldProps.value;
+      var changedBits = calculateChangedBits(context, newValue, oldValue);
+
+      if (changedBits === 0) {
+        // No change. Bailout early if children are the same.
+        if (oldProps.children === newProps.children && !hasContextChanged()) {
+          return bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
+        }
+      } else {
+        // The context value changed. Search for matching consumers and schedule
+        // them to update.
+        propagateContextChange(workInProgress, context, changedBits, renderLanes);
+      }
+    }
+
+    var newChildren = newProps.children;
+    reconcileChildren(current, workInProgress, newChildren, renderLanes);
+    return workInProgress.child;
+  }
+
+  var hasWarnedAboutUsingContextAsConsumer = false;
+
+  function updateContextConsumer(current, workInProgress, renderLanes) {
+    var context = workInProgress.type; // The logic below for Context differs depending on PROD or DEV mode. In
+    // DEV mode, we create a separate object for Context.Consumer that acts
+    // like a proxy to Context. This proxy object adds unnecessary code in PROD
+    // so we use the old behaviour (Context.Consumer references Context) to
+    // reduce size and overhead. The separate object references context via
+    // a property called "_context", which also gives us the ability to check
+    // in DEV mode if this property exists or not and warn if it does not.
+
+    {
+      if (context._context === undefined) {
+        // This may be because it's a Context (rather than a Consumer).
+        // Or it may be because it's older React where they're the same thing.
+        // We only want to warn if we're sure it's a new React.
+        if (context !== context.Consumer) {
+          if (!hasWarnedAboutUsingContextAsConsumer) {
+            hasWarnedAboutUsingContextAsConsumer = true;
+
+            error('Rendering <Context> directly is not supported and will be removed in ' + 'a future major release. Did you mean to render <Context.Consumer> instead?');
+          }
+        }
+      } else {
+        context = context._context;
+      }
+    }
+
+    var newProps = workInProgress.pendingProps;
+    var render = newProps.children;
+
+    {
+      if (typeof render !== 'function') {
+        error('A context consumer was rendered with multiple children, or a child ' + "that isn't a function. A context consumer expects a single child " + 'that is a function. If you did pass a function, make sure there ' + 'is no trailing or leading whitespace around it.');
+      }
+    }
+
+    prepareToReadContext(workInProgress, renderLanes);
+    var newValue = readContext(context, newProps.unstable_observedBits);
+    var newChildren;
+
+    {
+      ReactCurrentOwner$1.current = workInProgress;
+      setIsRendering(true);
+      newChildren = render(newValue);
+      setIsRendering(false);
+    } // React DevTools reads this flag.
+
+
+    workInProgress.flags |= PerformedWork;
+    reconcileChildren(current, workInProgress, newChildren, renderLanes);
+    return workInProgress.child;
+  }
+
+  function markWorkInProgressReceivedUpdate() {
+    didReceiveUpdate = true;
+  }
+
+  function bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes) {
+    if (current !== null) {
+      // Reuse previous dependencies
+      workInProgress.dependencies = current.dependencies;
+    }
+
+    {
+      // Don't update "base" render times for bailouts.
+      stopProfilerTimerIfRunning();
+    }
+
+    markSkippedUpdateLanes(workInProgress.lanes); // Check if the children have any pending work.
+
+    if (!includesSomeLane(renderLanes, workInProgress.childLanes)) {
+      // The children don't have any work either. We can skip them.
+      // TODO: Once we add back resuming, we should check if the children are
+      // a work-in-progress set. If so, we need to transfer their effects.
+      return null;
+    } else {
+      // This fiber doesn't have work, but its subtree does. Clone the child
+      // fibers and continue.
+      cloneChildFibers(current, workInProgress);
+      return workInProgress.child;
+    }
+  }
+
+  function remountFiber(current, oldWorkInProgress, newWorkInProgress) {
+    {
+      var returnFiber = oldWorkInProgress.return;
+
+      if (returnFiber === null) {
+        throw new Error('Cannot swap the root fiber.');
+      } // Disconnect from the old current.
+      // It will get deleted.
+
+
+      current.alternate = null;
+      oldWorkInProgress.alternate = null; // Connect to the new tree.
+
+      newWorkInProgress.index = oldWorkInProgress.index;
+      newWorkInProgress.sibling = oldWorkInProgress.sibling;
+      newWorkInProgress.return = oldWorkInProgress.return;
+      newWorkInProgress.ref = oldWorkInProgress.ref; // Replace the child/sibling pointers above it.
+
+      if (oldWorkInProgress === returnFiber.child) {
+        returnFiber.child = newWorkInProgress;
+      } else {
+        var prevSibling = returnFiber.child;
+
+        if (prevSibling === null) {
+          throw new Error('Expected parent to have a child.');
+        }
+
+        while (prevSibling.sibling !== oldWorkInProgress) {
+          prevSibling = prevSibling.sibling;
+
+          if (prevSibling === null) {
+            throw new Error('Expected to find the previous sibling.');
+          }
+        }
+
+        prevSibling.sibling = newWorkInProgress;
+      } // Delete the old fiber and place the new one.
+      // Since the old fiber is disconnected, we have to schedule it manually.
+
+
+      var last = returnFiber.lastEffect;
+
+      if (last !== null) {
+        last.nextEffect = current;
+        returnFiber.lastEffect = current;
+      } else {
+        returnFiber.firstEffect = returnFiber.lastEffect = current;
+      }
+
+      current.nextEffect = null;
+      current.flags = Deletion;
+      newWorkInProgress.flags |= Placement; // Restart work from the new fiber.
+
+      return newWorkInProgress;
+    }
+  }
+
+  function beginWork(current, workInProgress, renderLanes) {
+    var updateLanes = workInProgress.lanes;
+
+    {
+      if (workInProgress._debugNeedsRemount && current !== null) {
+        // This will restart the begin phase with a new fiber.
+        return remountFiber(current, workInProgress, createFiberFromTypeAndProps(workInProgress.type, workInProgress.key, workInProgress.pendingProps, workInProgress._debugOwner || null, workInProgress.mode, workInProgress.lanes));
+      }
+    }
+
+    if (current !== null) {
+      var oldProps = current.memoizedProps;
+      var newProps = workInProgress.pendingProps;
+
+      if (oldProps !== newProps || hasContextChanged() || ( // Force a re-render if the implementation changed due to hot reload:
+       workInProgress.type !== current.type )) {
+        // If props or context changed, mark the fiber as having performed work.
+        // This may be unset if the props are determined to be equal later (memo).
+        didReceiveUpdate = true;
+      } else if (!includesSomeLane(renderLanes, updateLanes)) {
+        didReceiveUpdate = false; // This fiber does not have any pending work. Bailout without entering
+        // the begin phase. There's still some bookkeeping we that needs to be done
+        // in this optimized path, mostly pushing stuff onto the stack.
+
+        switch (workInProgress.tag) {
+          case HostRoot:
+            pushHostRootContext(workInProgress);
+            resetHydrationState();
+            break;
+
+          case HostComponent:
+            pushHostContext(workInProgress);
+            break;
+
+          case ClassComponent:
+            {
+              var Component = workInProgress.type;
+
+              if (isContextProvider(Component)) {
+                pushContextProvider(workInProgress);
+              }
+
+              break;
+            }
+
+          case HostPortal:
+            pushHostContainer(workInProgress, workInProgress.stateNode.containerInfo);
+            break;
+
+          case ContextProvider:
+            {
+              var newValue = workInProgress.memoizedProps.value;
+              pushProvider(workInProgress, newValue);
+              break;
+            }
+
+          case Profiler:
+            {
+              // Profiler should only call onRender when one of its descendants actually rendered.
+              var hasChildWork = includesSomeLane(renderLanes, workInProgress.childLanes);
+
+              if (hasChildWork) {
+                workInProgress.flags |= Update;
+              } // Reset effect durations for the next eventual effect phase.
+              // These are reset during render to allow the DevTools commit hook a chance to read them,
+
+
+              var stateNode = workInProgress.stateNode;
+              stateNode.effectDuration = 0;
+              stateNode.passiveEffectDuration = 0;
+            }
+
+            break;
+
+          case SuspenseComponent:
+            {
+              var state = workInProgress.memoizedState;
+
+              if (state !== null) {
+                // whether to retry the primary children, or to skip over it and
+                // go straight to the fallback. Check the priority of the primary
+                // child fragment.
+
+
+                var primaryChildFragment = workInProgress.child;
+                var primaryChildLanes = primaryChildFragment.childLanes;
+
+                if (includesSomeLane(renderLanes, primaryChildLanes)) {
+                  // The primary children have pending work. Use the normal path
+                  // to attempt to render the primary children again.
+                  return updateSuspenseComponent(current, workInProgress, renderLanes);
+                } else {
+                  // The primary child fragment does not have pending work marked
+                  // on it
+                  pushSuspenseContext(workInProgress, setDefaultShallowSuspenseContext(suspenseStackCursor.current)); // The primary children do not have pending work with sufficient
+                  // priority. Bailout.
+
+                  var child = bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
+
+                  if (child !== null) {
+                    // The fallback children have pending work. Skip over the
+                    // primary children and work on the fallback.
+                    return child.sibling;
+                  } else {
+                    return null;
+                  }
+                }
+              } else {
+                pushSuspenseContext(workInProgress, setDefaultShallowSuspenseContext(suspenseStackCursor.current));
+              }
+
+              break;
+            }
+
+          case SuspenseListComponent:
+            {
+              var didSuspendBefore = (current.flags & DidCapture) !== NoFlags;
+
+              var _hasChildWork = includesSomeLane(renderLanes, workInProgress.childLanes);
+
+              if (didSuspendBefore) {
+                if (_hasChildWork) {
+                  // If something was in fallback state last time, and we have all the
+                  // same children then we're still in progressive loading state.
+                  // Something might get unblocked by state updates or retries in the
+                  // tree which will affect the tail. So we need to use the normal
+                  // path to compute the correct tail.
+                  return updateSuspenseListComponent(current, workInProgress, renderLanes);
+                } // If none of the children had any work, that means that none of
+                // them got retried so they'll still be blocked in the same way
+                // as before. We can fast bail out.
+
+
+                workInProgress.flags |= DidCapture;
+              } // If nothing suspended before and we're rendering the same children,
+              // then the tail doesn't matter. Anything new that suspends will work
+              // in the "together" mode, so we can continue from the state we had.
+
+
+              var renderState = workInProgress.memoizedState;
+
+              if (renderState !== null) {
+                // Reset to the "together" mode in case we've started a different
+                // update in the past but didn't complete it.
+                renderState.rendering = null;
+                renderState.tail = null;
+                renderState.lastEffect = null;
+              }
+
+              pushSuspenseContext(workInProgress, suspenseStackCursor.current);
+
+              if (_hasChildWork) {
+                break;
+              } else {
+                // If none of the children had any work, that means that none of
+                // them got retried so they'll still be blocked in the same way
+                // as before. We can fast bail out.
+                return null;
+              }
+            }
+
+          case OffscreenComponent:
+          case LegacyHiddenComponent:
+            {
+              // Need to check if the tree still needs to be deferred. This is
+              // almost identical to the logic used in the normal update path,
+              // so we'll just enter that. The only difference is we'll bail out
+              // at the next level instead of this one, because the child props
+              // have not changed. Which is fine.
+              // TODO: Probably should refactor `beginWork` to split the bailout
+              // path from the normal path. I'm tempted to do a labeled break here
+              // but I won't :)
+              workInProgress.lanes = NoLanes;
+              return updateOffscreenComponent(current, workInProgress, renderLanes);
+            }
+        }
+
+        return bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
+      } else {
+        if ((current.flags & ForceUpdateForLegacySuspense) !== NoFlags) {
+          // This is a special case that only exists for legacy mode.
+          // See https://github.com/facebook/react/pull/19216.
+          didReceiveUpdate = true;
+        } else {
+          // An update was scheduled on this fiber, but there are no new props
+          // nor legacy context. Set this to false. If an update queue or context
+          // consumer produces a changed value, it will set this to true. Otherwise,
+          // the component will assume the children have not changed and bail out.
+          didReceiveUpdate = false;
+        }
+      }
+    } else {
+      didReceiveUpdate = false;
+    } // Before entering the begin phase, clear pending update priority.
+    // TODO: This assumes that we're about to evaluate the component and process
+    // the update queue. However, there's an exception: SimpleMemoComponent
+    // sometimes bails out later in the begin phase. This indicates that we should
+    // move this assignment out of the common path and into each branch.
+
+
+    workInProgress.lanes = NoLanes;
+
+    switch (workInProgress.tag) {
+      case IndeterminateComponent:
+        {
+          return mountIndeterminateComponent(current, workInProgress, workInProgress.type, renderLanes);
+        }
+
+      case LazyComponent:
+        {
+          var elementType = workInProgress.elementType;
+          return mountLazyComponent(current, workInProgress, elementType, updateLanes, renderLanes);
+        }
+
+      case FunctionComponent:
+        {
+          var _Component = workInProgress.type;
+          var unresolvedProps = workInProgress.pendingProps;
+          var resolvedProps = workInProgress.elementType === _Component ? unresolvedProps : resolveDefaultProps(_Component, unresolvedProps);
+          return updateFunctionComponent(current, workInProgress, _Component, resolvedProps, renderLanes);
+        }
+
+      case ClassComponent:
+        {
+          var _Component2 = workInProgress.type;
+          var _unresolvedProps = workInProgress.pendingProps;
+
+          var _resolvedProps = workInProgress.elementType === _Component2 ? _unresolvedProps : resolveDefaultProps(_Component2, _unresolvedProps);
+
+          return updateClassComponent(current, workInProgress, _Component2, _resolvedProps, renderLanes);
+        }
+
+      case HostRoot:
+        return updateHostRoot(current, workInProgress, renderLanes);
+
+      case HostComponent:
+        return updateHostComponent(current, workInProgress, renderLanes);
+
+      case HostText:
+        return updateHostText(current, workInProgress);
+
+      case SuspenseComponent:
+        return updateSuspenseComponent(current, workInProgress, renderLanes);
+
+      case HostPortal:
+        return updatePortalComponent(current, workInProgress, renderLanes);
+
+      case ForwardRef:
+        {
+          var type = workInProgress.type;
+          var _unresolvedProps2 = workInProgress.pendingProps;
+
+          var _resolvedProps2 = workInProgress.elementType === type ? _unresolvedProps2 : resolveDefaultProps(type, _unresolvedProps2);
+
+          return updateForwardRef(current, workInProgress, type, _resolvedProps2, renderLanes);
+        }
+
+      case Fragment:
+        return updateFragment(current, workInProgress, renderLanes);
+
+      case Mode:
+        return updateMode(current, workInProgress, renderLanes);
+
+      case Profiler:
+        return updateProfiler(current, workInProgress, renderLanes);
+
+      case ContextProvider:
+        return updateContextProvider(current, workInProgress, renderLanes);
+
+      case ContextConsumer:
+        return updateContextConsumer(current, workInProgress, renderLanes);
+
+      case MemoComponent:
+        {
+          var _type2 = workInProgress.type;
+          var _unresolvedProps3 = workInProgress.pendingProps; // Resolve outer props first, then resolve inner props.
+
+          var _resolvedProps3 = resolveDefaultProps(_type2, _unresolvedProps3);
+
+          {
+            if (workInProgress.type !== workInProgress.elementType) {
+              var outerPropTypes = _type2.propTypes;
+
+              if (outerPropTypes) {
+                checkPropTypes(outerPropTypes, _resolvedProps3, // Resolved for outer only
+                'prop', getComponentName(_type2));
+              }
+            }
+          }
+
+          _resolvedProps3 = resolveDefaultProps(_type2.type, _resolvedProps3);
+          return updateMemoComponent(current, workInProgress, _type2, _resolvedProps3, updateLanes, renderLanes);
+        }
+
+      case SimpleMemoComponent:
+        {
+          return updateSimpleMemoComponent(current, workInProgress, workInProgress.type, workInProgress.pendingProps, updateLanes, renderLanes);
+        }
+
+      case IncompleteClassComponent:
+        {
+          var _Component3 = workInProgress.type;
+          var _unresolvedProps4 = workInProgress.pendingProps;
+
+          var _resolvedProps4 = workInProgress.elementType === _Component3 ? _unresolvedProps4 : resolveDefaultProps(_Component3, _unresolvedProps4);
+
+          return mountIncompleteClassComponent(current, workInProgress, _Component3, _resolvedProps4, renderLanes);
+        }
+
+      case SuspenseListComponent:
+        {
+          return updateSuspenseListComponent(current, workInProgress, renderLanes);
+        }
+
+      case FundamentalComponent:
+        {
+
+          break;
+        }
+
+      case ScopeComponent:
+        {
+
+          break;
+        }
+
+      case Block:
+        {
+
+          break;
+        }
+
+      case OffscreenComponent:
+        {
+          return updateOffscreenComponent(current, workInProgress, renderLanes);
+        }
+
+      case LegacyHiddenComponent:
+        {
+          return updateLegacyHiddenComponent(current, workInProgress, renderLanes);
+        }
+    }
+
+    {
+      {
+        throw Error( "Unknown unit of work tag (" + workInProgress.tag + "). This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function markUpdate(workInProgress) {
+    // Tag the fiber with an update effect. This turns a Placement into
+    // a PlacementAndUpdate.
+    workInProgress.flags |= Update;
+  }
+
+  function markRef$1(workInProgress) {
+    workInProgress.flags |= Ref;
+  }
+
+  var appendAllChildren;
+  var updateHostContainer;
+  var updateHostComponent$1;
+  var updateHostText$1;
+
+  {
+    // Mutation mode
+    appendAllChildren = function (parent, workInProgress, needsVisibilityToggle, isHidden) {
+      // We only have the top Fiber that was created but we need recurse down its
+      // children to find all the terminal nodes.
+      var node = workInProgress.child;
+
+      while (node !== null) {
+        if (node.tag === HostComponent || node.tag === HostText) {
+          appendInitialChild(parent, node.stateNode);
+        } else if (node.tag === HostPortal) ; else if (node.child !== null) {
+          node.child.return = node;
+          node = node.child;
+          continue;
+        }
+
+        if (node === workInProgress) {
+          return;
+        }
+
+        while (node.sibling === null) {
+          if (node.return === null || node.return === workInProgress) {
+            return;
+          }
+
+          node = node.return;
+        }
+
+        node.sibling.return = node.return;
+        node = node.sibling;
+      }
+    };
+
+    updateHostContainer = function (workInProgress) {// Noop
+    };
+
+    updateHostComponent$1 = function (current, workInProgress, type, newProps, rootContainerInstance) {
+      // If we have an alternate, that means this is an update and we need to
+      // schedule a side-effect to do the updates.
+      var oldProps = current.memoizedProps;
+
+      if (oldProps === newProps) {
+        // In mutation mode, this is sufficient for a bailout because
+        // we won't touch this node even if children changed.
+        return;
+      } // If we get updated because one of our children updated, we don't
+      // have newProps so we'll have to reuse them.
+      // TODO: Split the update API as separate for the props vs. children.
+      // Even better would be if children weren't special cased at all tho.
+
+
+      var instance = workInProgress.stateNode;
+      var currentHostContext = getHostContext(); // TODO: Experiencing an error where oldProps is null. Suggests a host
+      // component is hitting the resume path. Figure out why. Possibly
+      // related to `hidden`.
+
+      var updatePayload = prepareUpdate(instance, type, oldProps, newProps, rootContainerInstance, currentHostContext); // TODO: Type this specific to this type of component.
+
+      workInProgress.updateQueue = updatePayload; // If the update payload indicates that there is a change or if there
+      // is a new ref we mark this as an update. All the work is done in commitWork.
+
+      if (updatePayload) {
+        markUpdate(workInProgress);
+      }
+    };
+
+    updateHostText$1 = function (current, workInProgress, oldText, newText) {
+      // If the text differs, mark it as an update. All the work in done in commitWork.
+      if (oldText !== newText) {
+        markUpdate(workInProgress);
+      }
+    };
+  }
+
+  function cutOffTailIfNeeded(renderState, hasRenderedATailFallback) {
+    if (getIsHydrating()) {
+      // If we're hydrating, we should consume as many items as we can
+      // so we don't leave any behind.
+      return;
+    }
+
+    switch (renderState.tailMode) {
+      case 'hidden':
+        {
+          // Any insertions at the end of the tail list after this point
+          // should be invisible. If there are already mounted boundaries
+          // anything before them are not considered for collapsing.
+          // Therefore we need to go through the whole tail to find if
+          // there are any.
+          var tailNode = renderState.tail;
+          var lastTailNode = null;
+
+          while (tailNode !== null) {
+            if (tailNode.alternate !== null) {
+              lastTailNode = tailNode;
+            }
+
+            tailNode = tailNode.sibling;
+          } // Next we're simply going to delete all insertions after the
+          // last rendered item.
+
+
+          if (lastTailNode === null) {
+            // All remaining items in the tail are insertions.
+            renderState.tail = null;
+          } else {
+            // Detach the insertion after the last node that was already
+            // inserted.
+            lastTailNode.sibling = null;
+          }
+
+          break;
+        }
+
+      case 'collapsed':
+        {
+          // Any insertions at the end of the tail list after this point
+          // should be invisible. If there are already mounted boundaries
+          // anything before them are not considered for collapsing.
+          // Therefore we need to go through the whole tail to find if
+          // there are any.
+          var _tailNode = renderState.tail;
+          var _lastTailNode = null;
+
+          while (_tailNode !== null) {
+            if (_tailNode.alternate !== null) {
+              _lastTailNode = _tailNode;
+            }
+
+            _tailNode = _tailNode.sibling;
+          } // Next we're simply going to delete all insertions after the
+          // last rendered item.
+
+
+          if (_lastTailNode === null) {
+            // All remaining items in the tail are insertions.
+            if (!hasRenderedATailFallback && renderState.tail !== null) {
+              // We suspended during the head. We want to show at least one
+              // row at the tail. So we'll keep on and cut off the rest.
+              renderState.tail.sibling = null;
+            } else {
+              renderState.tail = null;
+            }
+          } else {
+            // Detach the insertion after the last node that was already
+            // inserted.
+            _lastTailNode.sibling = null;
+          }
+
+          break;
+        }
+    }
+  }
+
+  function completeWork(current, workInProgress, renderLanes) {
+    var newProps = workInProgress.pendingProps;
+
+    switch (workInProgress.tag) {
+      case IndeterminateComponent:
+      case LazyComponent:
+      case SimpleMemoComponent:
+      case FunctionComponent:
+      case ForwardRef:
+      case Fragment:
+      case Mode:
+      case Profiler:
+      case ContextConsumer:
+      case MemoComponent:
+        return null;
+
+      case ClassComponent:
+        {
+          var Component = workInProgress.type;
+
+          if (isContextProvider(Component)) {
+            popContext(workInProgress);
+          }
+
+          return null;
+        }
+
+      case HostRoot:
+        {
+          popHostContainer(workInProgress);
+          popTopLevelContextObject(workInProgress);
+          resetWorkInProgressVersions();
+          var fiberRoot = workInProgress.stateNode;
+
+          if (fiberRoot.pendingContext) {
+            fiberRoot.context = fiberRoot.pendingContext;
+            fiberRoot.pendingContext = null;
+          }
+
+          if (current === null || current.child === null) {
+            // If we hydrated, pop so that we can delete any remaining children
+            // that weren't hydrated.
+            var wasHydrated = popHydrationState(workInProgress);
+
+            if (wasHydrated) {
+              // If we hydrated, then we'll need to schedule an update for
+              // the commit side-effects on the root.
+              markUpdate(workInProgress);
+            } else if (!fiberRoot.hydrate) {
+              // Schedule an effect to clear this container at the start of the next commit.
+              // This handles the case of React rendering into a container with previous children.
+              // It's also safe to do for updates too, because current.child would only be null
+              // if the previous render was null (so the the container would already be empty).
+              workInProgress.flags |= Snapshot;
+            }
+          }
+
+          updateHostContainer(workInProgress);
+          return null;
+        }
+
+      case HostComponent:
+        {
+          popHostContext(workInProgress);
+          var rootContainerInstance = getRootHostContainer();
+          var type = workInProgress.type;
+
+          if (current !== null && workInProgress.stateNode != null) {
+            updateHostComponent$1(current, workInProgress, type, newProps, rootContainerInstance);
+
+            if (current.ref !== workInProgress.ref) {
+              markRef$1(workInProgress);
+            }
+          } else {
+            if (!newProps) {
+              if (!(workInProgress.stateNode !== null)) {
+                {
+                  throw Error( "We must have new props for new mounts. This error is likely caused by a bug in React. Please file an issue." );
+                }
+              } // This can happen when we abort work.
+
+
+              return null;
+            }
+
+            var currentHostContext = getHostContext(); // TODO: Move createInstance to beginWork and keep it on a context
+            // "stack" as the parent. Then append children as we go in beginWork
+            // or completeWork depending on whether we want to add them top->down or
+            // bottom->up. Top->down is faster in IE11.
+
+            var _wasHydrated = popHydrationState(workInProgress);
+
+            if (_wasHydrated) {
+              // TODO: Move this and createInstance step into the beginPhase
+              // to consolidate.
+              if (prepareToHydrateHostInstance(workInProgress, rootContainerInstance, currentHostContext)) {
+                // If changes to the hydrated node need to be applied at the
+                // commit-phase we mark this as such.
+                markUpdate(workInProgress);
+              }
+            } else {
+              var instance = createInstance(type, newProps, rootContainerInstance, currentHostContext, workInProgress);
+              appendAllChildren(instance, workInProgress, false, false);
+              workInProgress.stateNode = instance; // Certain renderers require commit-time effects for initial mount.
+              // (eg DOM renderer supports auto-focus for certain elements).
+              // Make sure such renderers get scheduled for later work.
+
+              if (finalizeInitialChildren(instance, type, newProps, rootContainerInstance)) {
+                markUpdate(workInProgress);
+              }
+            }
+
+            if (workInProgress.ref !== null) {
+              // If there is a ref on a host node we need to schedule a callback
+              markRef$1(workInProgress);
+            }
+          }
+
+          return null;
+        }
+
+      case HostText:
+        {
+          var newText = newProps;
+
+          if (current && workInProgress.stateNode != null) {
+            var oldText = current.memoizedProps; // If we have an alternate, that means this is an update and we need
+            // to schedule a side-effect to do the updates.
+
+            updateHostText$1(current, workInProgress, oldText, newText);
+          } else {
+            if (typeof newText !== 'string') {
+              if (!(workInProgress.stateNode !== null)) {
+                {
+                  throw Error( "We must have new props for new mounts. This error is likely caused by a bug in React. Please file an issue." );
+                }
+              } // This can happen when we abort work.
+
+            }
+
+            var _rootContainerInstance = getRootHostContainer();
+
+            var _currentHostContext = getHostContext();
+
+            var _wasHydrated2 = popHydrationState(workInProgress);
+
+            if (_wasHydrated2) {
+              if (prepareToHydrateHostTextInstance(workInProgress)) {
+                markUpdate(workInProgress);
+              }
+            } else {
+              workInProgress.stateNode = createTextInstance(newText, _rootContainerInstance, _currentHostContext, workInProgress);
+            }
+          }
+
+          return null;
+        }
+
+      case SuspenseComponent:
+        {
+          popSuspenseContext(workInProgress);
+          var nextState = workInProgress.memoizedState;
+
+          if ((workInProgress.flags & DidCapture) !== NoFlags) {
+            // Something suspended. Re-render with the fallback children.
+            workInProgress.lanes = renderLanes; // Do not reset the effect list.
+
+            if ( (workInProgress.mode & ProfileMode) !== NoMode) {
+              transferActualDuration(workInProgress);
+            }
+
+            return workInProgress;
+          }
+
+          var nextDidTimeout = nextState !== null;
+          var prevDidTimeout = false;
+
+          if (current === null) {
+            if (workInProgress.memoizedProps.fallback !== undefined) {
+              popHydrationState(workInProgress);
+            }
+          } else {
+            var prevState = current.memoizedState;
+            prevDidTimeout = prevState !== null;
+          }
+
+          if (nextDidTimeout && !prevDidTimeout) {
+            // If this subtreee is running in blocking mode we can suspend,
+            // otherwise we won't suspend.
+            // TODO: This will still suspend a synchronous tree if anything
+            // in the concurrent tree already suspended during this render.
+            // This is a known bug.
+            if ((workInProgress.mode & BlockingMode) !== NoMode) {
+              // TODO: Move this back to throwException because this is too late
+              // if this is a large tree which is common for initial loads. We
+              // don't know if we should restart a render or not until we get
+              // this marker, and this is too late.
+              // If this render already had a ping or lower pri updates,
+              // and this is the first time we know we're going to suspend we
+              // should be able to immediately restart from within throwException.
+              var hasInvisibleChildContext = current === null && workInProgress.memoizedProps.unstable_avoidThisFallback !== true;
+
+              if (hasInvisibleChildContext || hasSuspenseContext(suspenseStackCursor.current, InvisibleParentSuspenseContext)) {
+                // If this was in an invisible tree or a new render, then showing
+                // this boundary is ok.
+                renderDidSuspend();
+              } else {
+                // Otherwise, we're going to have to hide content so we should
+                // suspend for longer if possible.
+                renderDidSuspendDelayIfPossible();
+              }
+            }
+          }
+
+          {
+            // TODO: Only schedule updates if these values are non equal, i.e. it changed.
+            if (nextDidTimeout || prevDidTimeout) {
+              // If this boundary just timed out, schedule an effect to attach a
+              // retry listener to the promise. This flag is also used to hide the
+              // primary children. In mutation mode, we also need the flag to
+              // *unhide* children that were previously hidden, so check if this
+              // is currently timed out, too.
+              workInProgress.flags |= Update;
+            }
+          }
+
+          return null;
+        }
+
+      case HostPortal:
+        popHostContainer(workInProgress);
+        updateHostContainer(workInProgress);
+
+        if (current === null) {
+          preparePortalMount(workInProgress.stateNode.containerInfo);
+        }
+
+        return null;
+
+      case ContextProvider:
+        // Pop provider fiber
+        popProvider(workInProgress);
+        return null;
+
+      case IncompleteClassComponent:
+        {
+          // Same as class component case. I put it down here so that the tags are
+          // sequential to ensure this switch is compiled to a jump table.
+          var _Component = workInProgress.type;
+
+          if (isContextProvider(_Component)) {
+            popContext(workInProgress);
+          }
+
+          return null;
+        }
+
+      case SuspenseListComponent:
+        {
+          popSuspenseContext(workInProgress);
+          var renderState = workInProgress.memoizedState;
+
+          if (renderState === null) {
+            // We're running in the default, "independent" mode.
+            // We don't do anything in this mode.
+            return null;
+          }
+
+          var didSuspendAlready = (workInProgress.flags & DidCapture) !== NoFlags;
+          var renderedTail = renderState.rendering;
+
+          if (renderedTail === null) {
+            // We just rendered the head.
+            if (!didSuspendAlready) {
+              // This is the first pass. We need to figure out if anything is still
+              // suspended in the rendered set.
+              // If new content unsuspended, but there's still some content that
+              // didn't. Then we need to do a second pass that forces everything
+              // to keep showing their fallbacks.
+              // We might be suspended if something in this render pass suspended, or
+              // something in the previous committed pass suspended. Otherwise,
+              // there's no chance so we can skip the expensive call to
+              // findFirstSuspended.
+              var cannotBeSuspended = renderHasNotSuspendedYet() && (current === null || (current.flags & DidCapture) === NoFlags);
+
+              if (!cannotBeSuspended) {
+                var row = workInProgress.child;
+
+                while (row !== null) {
+                  var suspended = findFirstSuspended(row);
+
+                  if (suspended !== null) {
+                    didSuspendAlready = true;
+                    workInProgress.flags |= DidCapture;
+                    cutOffTailIfNeeded(renderState, false); // If this is a newly suspended tree, it might not get committed as
+                    // part of the second pass. In that case nothing will subscribe to
+                    // its thennables. Instead, we'll transfer its thennables to the
+                    // SuspenseList so that it can retry if they resolve.
+                    // There might be multiple of these in the list but since we're
+                    // going to wait for all of them anyway, it doesn't really matter
+                    // which ones gets to ping. In theory we could get clever and keep
+                    // track of how many dependencies remain but it gets tricky because
+                    // in the meantime, we can add/remove/change items and dependencies.
+                    // We might bail out of the loop before finding any but that
+                    // doesn't matter since that means that the other boundaries that
+                    // we did find already has their listeners attached.
+
+                    var newThennables = suspended.updateQueue;
+
+                    if (newThennables !== null) {
+                      workInProgress.updateQueue = newThennables;
+                      workInProgress.flags |= Update;
+                    } // Rerender the whole list, but this time, we'll force fallbacks
+                    // to stay in place.
+                    // Reset the effect list before doing the second pass since that's now invalid.
+
+
+                    if (renderState.lastEffect === null) {
+                      workInProgress.firstEffect = null;
+                    }
+
+                    workInProgress.lastEffect = renderState.lastEffect; // Reset the child fibers to their original state.
+
+                    resetChildFibers(workInProgress, renderLanes); // Set up the Suspense Context to force suspense and immediately
+                    // rerender the children.
+
+                    pushSuspenseContext(workInProgress, setShallowSuspenseContext(suspenseStackCursor.current, ForceSuspenseFallback));
+                    return workInProgress.child;
+                  }
+
+                  row = row.sibling;
+                }
+              }
+
+              if (renderState.tail !== null && now() > getRenderTargetTime()) {
+                // We have already passed our CPU deadline but we still have rows
+                // left in the tail. We'll just give up further attempts to render
+                // the main content and only render fallbacks.
+                workInProgress.flags |= DidCapture;
+                didSuspendAlready = true;
+                cutOffTailIfNeeded(renderState, false); // Since nothing actually suspended, there will nothing to ping this
+                // to get it started back up to attempt the next item. While in terms
+                // of priority this work has the same priority as this current render,
+                // it's not part of the same transition once the transition has
+                // committed. If it's sync, we still want to yield so that it can be
+                // painted. Conceptually, this is really the same as pinging.
+                // We can use any RetryLane even if it's the one currently rendering
+                // since we're leaving it behind on this node.
+
+                workInProgress.lanes = SomeRetryLane;
+
+                {
+                  markSpawnedWork(SomeRetryLane);
+                }
+              }
+            } else {
+              cutOffTailIfNeeded(renderState, false);
+            } // Next we're going to render the tail.
+
+          } else {
+            // Append the rendered row to the child list.
+            if (!didSuspendAlready) {
+              var _suspended = findFirstSuspended(renderedTail);
+
+              if (_suspended !== null) {
+                workInProgress.flags |= DidCapture;
+                didSuspendAlready = true; // Ensure we transfer the update queue to the parent so that it doesn't
+                // get lost if this row ends up dropped during a second pass.
+
+                var _newThennables = _suspended.updateQueue;
+
+                if (_newThennables !== null) {
+                  workInProgress.updateQueue = _newThennables;
+                  workInProgress.flags |= Update;
+                }
+
+                cutOffTailIfNeeded(renderState, true); // This might have been modified.
+
+                if (renderState.tail === null && renderState.tailMode === 'hidden' && !renderedTail.alternate && !getIsHydrating() // We don't cut it if we're hydrating.
+                ) {
+                    // We need to delete the row we just rendered.
+                    // Reset the effect list to what it was before we rendered this
+                    // child. The nested children have already appended themselves.
+                    var lastEffect = workInProgress.lastEffect = renderState.lastEffect; // Remove any effects that were appended after this point.
+
+                    if (lastEffect !== null) {
+                      lastEffect.nextEffect = null;
+                    } // We're done.
+
+
+                    return null;
+                  }
+              } else if ( // The time it took to render last row is greater than the remaining
+              // time we have to render. So rendering one more row would likely
+              // exceed it.
+              now() * 2 - renderState.renderingStartTime > getRenderTargetTime() && renderLanes !== OffscreenLane) {
+                // We have now passed our CPU deadline and we'll just give up further
+                // attempts to render the main content and only render fallbacks.
+                // The assumption is that this is usually faster.
+                workInProgress.flags |= DidCapture;
+                didSuspendAlready = true;
+                cutOffTailIfNeeded(renderState, false); // Since nothing actually suspended, there will nothing to ping this
+                // to get it started back up to attempt the next item. While in terms
+                // of priority this work has the same priority as this current render,
+                // it's not part of the same transition once the transition has
+                // committed. If it's sync, we still want to yield so that it can be
+                // painted. Conceptually, this is really the same as pinging.
+                // We can use any RetryLane even if it's the one currently rendering
+                // since we're leaving it behind on this node.
+
+                workInProgress.lanes = SomeRetryLane;
+
+                {
+                  markSpawnedWork(SomeRetryLane);
+                }
+              }
+            }
+
+            if (renderState.isBackwards) {
+              // The effect list of the backwards tail will have been added
+              // to the end. This breaks the guarantee that life-cycles fire in
+              // sibling order but that isn't a strong guarantee promised by React.
+              // Especially since these might also just pop in during future commits.
+              // Append to the beginning of the list.
+              renderedTail.sibling = workInProgress.child;
+              workInProgress.child = renderedTail;
+            } else {
+              var previousSibling = renderState.last;
+
+              if (previousSibling !== null) {
+                previousSibling.sibling = renderedTail;
+              } else {
+                workInProgress.child = renderedTail;
+              }
+
+              renderState.last = renderedTail;
+            }
+          }
+
+          if (renderState.tail !== null) {
+            // We still have tail rows to render.
+            // Pop a row.
+            var next = renderState.tail;
+            renderState.rendering = next;
+            renderState.tail = next.sibling;
+            renderState.lastEffect = workInProgress.lastEffect;
+            renderState.renderingStartTime = now();
+            next.sibling = null; // Restore the context.
+            // TODO: We can probably just avoid popping it instead and only
+            // setting it the first time we go from not suspended to suspended.
+
+            var suspenseContext = suspenseStackCursor.current;
+
+            if (didSuspendAlready) {
+              suspenseContext = setShallowSuspenseContext(suspenseContext, ForceSuspenseFallback);
+            } else {
+              suspenseContext = setDefaultShallowSuspenseContext(suspenseContext);
+            }
+
+            pushSuspenseContext(workInProgress, suspenseContext); // Do a pass over the next row.
+
+            return next;
+          }
+
+          return null;
+        }
+
+      case FundamentalComponent:
+        {
+
+          break;
+        }
+
+      case ScopeComponent:
+        {
+
+          break;
+        }
+
+      case Block:
+
+        break;
+
+      case OffscreenComponent:
+      case LegacyHiddenComponent:
+        {
+          popRenderLanes(workInProgress);
+
+          if (current !== null) {
+            var _nextState = workInProgress.memoizedState;
+            var _prevState = current.memoizedState;
+            var prevIsHidden = _prevState !== null;
+            var nextIsHidden = _nextState !== null;
+
+            if (prevIsHidden !== nextIsHidden && newProps.mode !== 'unstable-defer-without-hiding') {
+              workInProgress.flags |= Update;
+            }
+          }
+
+          return null;
+        }
+    }
+
+    {
+      {
+        throw Error( "Unknown unit of work tag (" + workInProgress.tag + "). This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function unwindWork(workInProgress, renderLanes) {
+    switch (workInProgress.tag) {
+      case ClassComponent:
+        {
+          var Component = workInProgress.type;
+
+          if (isContextProvider(Component)) {
+            popContext(workInProgress);
+          }
+
+          var flags = workInProgress.flags;
+
+          if (flags & ShouldCapture) {
+            workInProgress.flags = flags & ~ShouldCapture | DidCapture;
+
+            if ( (workInProgress.mode & ProfileMode) !== NoMode) {
+              transferActualDuration(workInProgress);
+            }
+
+            return workInProgress;
+          }
+
+          return null;
+        }
+
+      case HostRoot:
+        {
+          popHostContainer(workInProgress);
+          popTopLevelContextObject(workInProgress);
+          resetWorkInProgressVersions();
+          var _flags = workInProgress.flags;
+
+          if (!((_flags & DidCapture) === NoFlags)) {
+            {
+              throw Error( "The root failed to unmount after an error. This is likely a bug in React. Please file an issue." );
+            }
+          }
+
+          workInProgress.flags = _flags & ~ShouldCapture | DidCapture;
+          return workInProgress;
+        }
+
+      case HostComponent:
+        {
+          // TODO: popHydrationState
+          popHostContext(workInProgress);
+          return null;
+        }
+
+      case SuspenseComponent:
+        {
+          popSuspenseContext(workInProgress);
+
+          var _flags2 = workInProgress.flags;
+
+          if (_flags2 & ShouldCapture) {
+            workInProgress.flags = _flags2 & ~ShouldCapture | DidCapture; // Captured a suspense effect. Re-render the boundary.
+
+            if ( (workInProgress.mode & ProfileMode) !== NoMode) {
+              transferActualDuration(workInProgress);
+            }
+
+            return workInProgress;
+          }
+
+          return null;
+        }
+
+      case SuspenseListComponent:
+        {
+          popSuspenseContext(workInProgress); // SuspenseList doesn't actually catch anything. It should've been
+          // caught by a nested boundary. If not, it should bubble through.
+
+          return null;
+        }
+
+      case HostPortal:
+        popHostContainer(workInProgress);
+        return null;
+
+      case ContextProvider:
+        popProvider(workInProgress);
+        return null;
+
+      case OffscreenComponent:
+      case LegacyHiddenComponent:
+        popRenderLanes(workInProgress);
+        return null;
+
+      default:
+        return null;
+    }
+  }
+
+  function unwindInterruptedWork(interruptedWork) {
+    switch (interruptedWork.tag) {
+      case ClassComponent:
+        {
+          var childContextTypes = interruptedWork.type.childContextTypes;
+
+          if (childContextTypes !== null && childContextTypes !== undefined) {
+            popContext(interruptedWork);
+          }
+
+          break;
+        }
+
+      case HostRoot:
+        {
+          popHostContainer(interruptedWork);
+          popTopLevelContextObject(interruptedWork);
+          resetWorkInProgressVersions();
+          break;
+        }
+
+      case HostComponent:
+        {
+          popHostContext(interruptedWork);
+          break;
+        }
+
+      case HostPortal:
+        popHostContainer(interruptedWork);
+        break;
+
+      case SuspenseComponent:
+        popSuspenseContext(interruptedWork);
+        break;
+
+      case SuspenseListComponent:
+        popSuspenseContext(interruptedWork);
+        break;
+
+      case ContextProvider:
+        popProvider(interruptedWork);
+        break;
+
+      case OffscreenComponent:
+      case LegacyHiddenComponent:
+        popRenderLanes(interruptedWork);
+        break;
+    }
+  }
+
+  function createCapturedValue(value, source) {
+    // If the value is an error, call this function immediately after it is thrown
+    // so the stack is accurate.
+    return {
+      value: value,
+      source: source,
+      stack: getStackByFiberInDevAndProd(source)
+    };
+  }
+
+  // This module is forked in different environments.
+  // By default, return `true` to log errors to the console.
+  // Forks can return `false` if this isn't desirable.
+  function showErrorDialog(boundary, errorInfo) {
+    return true;
+  }
+
+  function logCapturedError(boundary, errorInfo) {
+    try {
+      var logError = showErrorDialog(boundary, errorInfo); // Allow injected showErrorDialog() to prevent default console.error logging.
+      // This enables renderers like ReactNative to better manage redbox behavior.
+
+      if (logError === false) {
+        return;
+      }
+
+      var error = errorInfo.value;
+
+      if (true) {
+        var source = errorInfo.source;
+        var stack = errorInfo.stack;
+        var componentStack = stack !== null ? stack : ''; // Browsers support silencing uncaught errors by calling
+        // `preventDefault()` in window `error` handler.
+        // We record this information as an expando on the error.
+
+        if (error != null && error._suppressLogging) {
+          if (boundary.tag === ClassComponent) {
+            // The error is recoverable and was silenced.
+            // Ignore it and don't print the stack addendum.
+            // This is handy for testing error boundaries without noise.
+            return;
+          } // The error is fatal. Since the silencing might have
+          // been accidental, we'll surface it anyway.
+          // However, the browser would have silenced the original error
+          // so we'll print it first, and then print the stack addendum.
+
+
+          console['error'](error); // Don't transform to our wrapper
+          // For a more detailed description of this block, see:
+          // https://github.com/facebook/react/pull/13384
+        }
+
+        var componentName = source ? getComponentName(source.type) : null;
+        var componentNameMessage = componentName ? "The above error occurred in the <" + componentName + "> component:" : 'The above error occurred in one of your React components:';
+        var errorBoundaryMessage;
+        var errorBoundaryName = getComponentName(boundary.type);
+
+        if (errorBoundaryName) {
+          errorBoundaryMessage = "React will try to recreate this component tree from scratch " + ("using the error boundary you provided, " + errorBoundaryName + ".");
+        } else {
+          errorBoundaryMessage = 'Consider adding an error boundary to your tree to customize error handling behavior.\n' + 'Visit https://reactjs.org/link/error-boundaries to learn more about error boundaries.';
+        }
+
+        var combinedMessage = componentNameMessage + "\n" + componentStack + "\n\n" + ("" + errorBoundaryMessage); // In development, we provide our own message with just the component stack.
+        // We don't include the original error message and JS stack because the browser
+        // has already printed it. Even if the application swallows the error, it is still
+        // displayed by the browser thanks to the DEV-only fake event trick in ReactErrorUtils.
+
+        console['error'](combinedMessage); // Don't transform to our wrapper
+      } else {
+        // In production, we print the error directly.
+        // This will include the message, the JS stack, and anything the browser wants to show.
+        // We pass the error object instead of custom message so that the browser displays the error natively.
+        console['error'](error); // Don't transform to our wrapper
+      }
+    } catch (e) {
+      // This method must not throw, or React internal state will get messed up.
+      // If console.error is overridden, or logCapturedError() shows a dialog that throws,
+      // we want to report this error outside of the normal stack as a last resort.
+      // https://github.com/facebook/react/issues/13188
+      setTimeout(function () {
+        throw e;
+      });
+    }
+  }
+
+  var PossiblyWeakMap$1 = typeof WeakMap === 'function' ? WeakMap : Map;
+
+  function createRootErrorUpdate(fiber, errorInfo, lane) {
+    var update = createUpdate(NoTimestamp, lane); // Unmount the root by rendering null.
+
+    update.tag = CaptureUpdate; // Caution: React DevTools currently depends on this property
+    // being called "element".
+
+    update.payload = {
+      element: null
+    };
+    var error = errorInfo.value;
+
+    update.callback = function () {
+      onUncaughtError(error);
+      logCapturedError(fiber, errorInfo);
+    };
+
+    return update;
+  }
+
+  function createClassErrorUpdate(fiber, errorInfo, lane) {
+    var update = createUpdate(NoTimestamp, lane);
+    update.tag = CaptureUpdate;
+    var getDerivedStateFromError = fiber.type.getDerivedStateFromError;
+
+    if (typeof getDerivedStateFromError === 'function') {
+      var error$1 = errorInfo.value;
+
+      update.payload = function () {
+        logCapturedError(fiber, errorInfo);
+        return getDerivedStateFromError(error$1);
+      };
+    }
+
+    var inst = fiber.stateNode;
+
+    if (inst !== null && typeof inst.componentDidCatch === 'function') {
+      update.callback = function callback() {
+        {
+          markFailedErrorBoundaryForHotReloading(fiber);
+        }
+
+        if (typeof getDerivedStateFromError !== 'function') {
+          // To preserve the preexisting retry behavior of error boundaries,
+          // we keep track of which ones already failed during this batch.
+          // This gets reset before we yield back to the browser.
+          // TODO: Warn in strict mode if getDerivedStateFromError is
+          // not defined.
+          markLegacyErrorBoundaryAsFailed(this); // Only log here if componentDidCatch is the only error boundary method defined
+
+          logCapturedError(fiber, errorInfo);
+        }
+
+        var error$1 = errorInfo.value;
+        var stack = errorInfo.stack;
+        this.componentDidCatch(error$1, {
+          componentStack: stack !== null ? stack : ''
+        });
+
+        {
+          if (typeof getDerivedStateFromError !== 'function') {
+            // If componentDidCatch is the only error boundary method defined,
+            // then it needs to call setState to recover from errors.
+            // If no state update is scheduled then the boundary will swallow the error.
+            if (!includesSomeLane(fiber.lanes, SyncLane)) {
+              error('%s: Error boundaries should implement getDerivedStateFromError(). ' + 'In that method, return a state update to display an error message or fallback UI.', getComponentName(fiber.type) || 'Unknown');
+            }
+          }
+        }
+      };
+    } else {
+      update.callback = function () {
+        markFailedErrorBoundaryForHotReloading(fiber);
+      };
+    }
+
+    return update;
+  }
+
+  function attachPingListener(root, wakeable, lanes) {
+    // Attach a listener to the promise to "ping" the root and retry. But only if
+    // one does not already exist for the lanes we're currently rendering (which
+    // acts like a "thread ID" here).
+    var pingCache = root.pingCache;
+    var threadIDs;
+
+    if (pingCache === null) {
+      pingCache = root.pingCache = new PossiblyWeakMap$1();
+      threadIDs = new Set();
+      pingCache.set(wakeable, threadIDs);
+    } else {
+      threadIDs = pingCache.get(wakeable);
+
+      if (threadIDs === undefined) {
+        threadIDs = new Set();
+        pingCache.set(wakeable, threadIDs);
+      }
+    }
+
+    if (!threadIDs.has(lanes)) {
+      // Memoize using the thread ID to prevent redundant listeners.
+      threadIDs.add(lanes);
+      var ping = pingSuspendedRoot.bind(null, root, wakeable, lanes);
+      wakeable.then(ping, ping);
+    }
+  }
+
+  function throwException(root, returnFiber, sourceFiber, value, rootRenderLanes) {
+    // The source fiber did not complete.
+    sourceFiber.flags |= Incomplete; // Its effect list is no longer valid.
+
+    sourceFiber.firstEffect = sourceFiber.lastEffect = null;
+
+    if (value !== null && typeof value === 'object' && typeof value.then === 'function') {
+      // This is a wakeable.
+      var wakeable = value;
+
+      if ((sourceFiber.mode & BlockingMode) === NoMode) {
+        // Reset the memoizedState to what it was before we attempted
+        // to render it.
+        var currentSource = sourceFiber.alternate;
+
+        if (currentSource) {
+          sourceFiber.updateQueue = currentSource.updateQueue;
+          sourceFiber.memoizedState = currentSource.memoizedState;
+          sourceFiber.lanes = currentSource.lanes;
+        } else {
+          sourceFiber.updateQueue = null;
+          sourceFiber.memoizedState = null;
+        }
+      }
+
+      var hasInvisibleParentBoundary = hasSuspenseContext(suspenseStackCursor.current, InvisibleParentSuspenseContext); // Schedule the nearest Suspense to re-render the timed out view.
+
+      var _workInProgress = returnFiber;
+
+      do {
+        if (_workInProgress.tag === SuspenseComponent && shouldCaptureSuspense(_workInProgress, hasInvisibleParentBoundary)) {
+          // Found the nearest boundary.
+          // Stash the promise on the boundary fiber. If the boundary times out, we'll
+          // attach another listener to flip the boundary back to its normal state.
+          var wakeables = _workInProgress.updateQueue;
+
+          if (wakeables === null) {
+            var updateQueue = new Set();
+            updateQueue.add(wakeable);
+            _workInProgress.updateQueue = updateQueue;
+          } else {
+            wakeables.add(wakeable);
+          } // If the boundary is outside of blocking mode, we should *not*
+          // suspend the commit. Pretend as if the suspended component rendered
+          // null and keep rendering. In the commit phase, we'll schedule a
+          // subsequent synchronous update to re-render the Suspense.
+          //
+          // Note: It doesn't matter whether the component that suspended was
+          // inside a blocking mode tree. If the Suspense is outside of it, we
+          // should *not* suspend the commit.
+
+
+          if ((_workInProgress.mode & BlockingMode) === NoMode) {
+            _workInProgress.flags |= DidCapture;
+            sourceFiber.flags |= ForceUpdateForLegacySuspense; // We're going to commit this fiber even though it didn't complete.
+            // But we shouldn't call any lifecycle methods or callbacks. Remove
+            // all lifecycle effect tags.
+
+            sourceFiber.flags &= ~(LifecycleEffectMask | Incomplete);
+
+            if (sourceFiber.tag === ClassComponent) {
+              var currentSourceFiber = sourceFiber.alternate;
+
+              if (currentSourceFiber === null) {
+                // This is a new mount. Change the tag so it's not mistaken for a
+                // completed class component. For example, we should not call
+                // componentWillUnmount if it is deleted.
+                sourceFiber.tag = IncompleteClassComponent;
+              } else {
+                // When we try rendering again, we should not reuse the current fiber,
+                // since it's known to be in an inconsistent state. Use a force update to
+                // prevent a bail out.
+                var update = createUpdate(NoTimestamp, SyncLane);
+                update.tag = ForceUpdate;
+                enqueueUpdate(sourceFiber, update);
+              }
+            } // The source fiber did not complete. Mark it with Sync priority to
+            // indicate that it still has pending work.
+
+
+            sourceFiber.lanes = mergeLanes(sourceFiber.lanes, SyncLane); // Exit without suspending.
+
+            return;
+          } // Confirmed that the boundary is in a concurrent mode tree. Continue
+          // with the normal suspend path.
+          //
+          // After this we'll use a set of heuristics to determine whether this
+          // render pass will run to completion or restart or "suspend" the commit.
+          // The actual logic for this is spread out in different places.
+          //
+          // This first principle is that if we're going to suspend when we complete
+          // a root, then we should also restart if we get an update or ping that
+          // might unsuspend it, and vice versa. The only reason to suspend is
+          // because you think you might want to restart before committing. However,
+          // it doesn't make sense to restart only while in the period we're suspended.
+          //
+          // Restarting too aggressively is also not good because it starves out any
+          // intermediate loading state. So we use heuristics to determine when.
+          // Suspense Heuristics
+          //
+          // If nothing threw a Promise or all the same fallbacks are already showing,
+          // then don't suspend/restart.
+          //
+          // If this is an initial render of a new tree of Suspense boundaries and
+          // those trigger a fallback, then don't suspend/restart. We want to ensure
+          // that we can show the initial loading state as quickly as possible.
+          //
+          // If we hit a "Delayed" case, such as when we'd switch from content back into
+          // a fallback, then we should always suspend/restart. Transitions apply
+          // to this case. If none is defined, JND is used instead.
+          //
+          // If we're already showing a fallback and it gets "retried", allowing us to show
+          // another level, but there's still an inner boundary that would show a fallback,
+          // then we suspend/restart for 500ms since the last time we showed a fallback
+          // anywhere in the tree. This effectively throttles progressive loading into a
+          // consistent train of commits. This also gives us an opportunity to restart to
+          // get to the completed state slightly earlier.
+          //
+          // If there's ambiguity due to batching it's resolved in preference of:
+          // 1) "delayed", 2) "initial render", 3) "retry".
+          //
+          // We want to ensure that a "busy" state doesn't get force committed. We want to
+          // ensure that new initial loading states can commit as soon as possible.
+
+
+          attachPingListener(root, wakeable, rootRenderLanes);
+          _workInProgress.flags |= ShouldCapture;
+          _workInProgress.lanes = rootRenderLanes;
+          return;
+        } // This boundary already captured during this render. Continue to the next
+        // boundary.
+
+
+        _workInProgress = _workInProgress.return;
+      } while (_workInProgress !== null); // No boundary was found. Fallthrough to error mode.
+      // TODO: Use invariant so the message is stripped in prod?
+
+
+      value = new Error((getComponentName(sourceFiber.type) || 'A React component') + ' suspended while rendering, but no fallback UI was specified.\n' + '\n' + 'Add a <Suspense fallback=...> component higher in the tree to ' + 'provide a loading indicator or placeholder to display.');
+    } // We didn't find a boundary that could handle this type of exception. Start
+    // over and traverse parent path again, this time treating the exception
+    // as an error.
+
+
+    renderDidError();
+    value = createCapturedValue(value, sourceFiber);
+    var workInProgress = returnFiber;
+
+    do {
+      switch (workInProgress.tag) {
+        case HostRoot:
+          {
+            var _errorInfo = value;
+            workInProgress.flags |= ShouldCapture;
+            var lane = pickArbitraryLane(rootRenderLanes);
+            workInProgress.lanes = mergeLanes(workInProgress.lanes, lane);
+
+            var _update = createRootErrorUpdate(workInProgress, _errorInfo, lane);
+
+            enqueueCapturedUpdate(workInProgress, _update);
+            return;
+          }
+
+        case ClassComponent:
+          // Capture and retry
+          var errorInfo = value;
+          var ctor = workInProgress.type;
+          var instance = workInProgress.stateNode;
+
+          if ((workInProgress.flags & DidCapture) === NoFlags && (typeof ctor.getDerivedStateFromError === 'function' || instance !== null && typeof instance.componentDidCatch === 'function' && !isAlreadyFailedLegacyErrorBoundary(instance))) {
+            workInProgress.flags |= ShouldCapture;
+
+            var _lane = pickArbitraryLane(rootRenderLanes);
+
+            workInProgress.lanes = mergeLanes(workInProgress.lanes, _lane); // Schedule the error boundary to re-render using updated state
+
+            var _update2 = createClassErrorUpdate(workInProgress, errorInfo, _lane);
+
+            enqueueCapturedUpdate(workInProgress, _update2);
+            return;
+          }
+
+          break;
+      }
+
+      workInProgress = workInProgress.return;
+    } while (workInProgress !== null);
+  }
+
+  var didWarnAboutUndefinedSnapshotBeforeUpdate = null;
+
+  {
+    didWarnAboutUndefinedSnapshotBeforeUpdate = new Set();
+  }
+
+  var PossiblyWeakSet = typeof WeakSet === 'function' ? WeakSet : Set;
+
+  var callComponentWillUnmountWithTimer = function (current, instance) {
+    instance.props = current.memoizedProps;
+    instance.state = current.memoizedState;
+
+    {
+      instance.componentWillUnmount();
+    }
+  }; // Capture errors so they don't interrupt unmounting.
+
+
+  function safelyCallComponentWillUnmount(current, instance) {
+    {
+      invokeGuardedCallback(null, callComponentWillUnmountWithTimer, null, current, instance);
+
+      if (hasCaughtError()) {
+        var unmountError = clearCaughtError();
+        captureCommitPhaseError(current, unmountError);
+      }
+    }
+  }
+
+  function safelyDetachRef(current) {
+    var ref = current.ref;
+
+    if (ref !== null) {
+      if (typeof ref === 'function') {
+        {
+          invokeGuardedCallback(null, ref, null, null);
+
+          if (hasCaughtError()) {
+            var refError = clearCaughtError();
+            captureCommitPhaseError(current, refError);
+          }
+        }
+      } else {
+        ref.current = null;
+      }
+    }
+  }
+
+  function safelyCallDestroy(current, destroy) {
+    {
+      invokeGuardedCallback(null, destroy, null);
+
+      if (hasCaughtError()) {
+        var error = clearCaughtError();
+        captureCommitPhaseError(current, error);
+      }
+    }
+  }
+
+  function commitBeforeMutationLifeCycles(current, finishedWork) {
+    switch (finishedWork.tag) {
+      case FunctionComponent:
+      case ForwardRef:
+      case SimpleMemoComponent:
+      case Block:
+        {
+          return;
+        }
+
+      case ClassComponent:
+        {
+          if (finishedWork.flags & Snapshot) {
+            if (current !== null) {
+              var prevProps = current.memoizedProps;
+              var prevState = current.memoizedState;
+              var instance = finishedWork.stateNode; // We could update instance props and state here,
+              // but instead we rely on them being set during last render.
+              // TODO: revisit this when we implement resuming.
+
+              {
+                if (finishedWork.type === finishedWork.elementType && !didWarnAboutReassigningProps) {
+                  if (instance.props !== finishedWork.memoizedProps) {
+                    error('Expected %s props to match memoized props before ' + 'getSnapshotBeforeUpdate. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+
+                  if (instance.state !== finishedWork.memoizedState) {
+                    error('Expected %s state to match memoized state before ' + 'getSnapshotBeforeUpdate. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.state`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+                }
+              }
+
+              var snapshot = instance.getSnapshotBeforeUpdate(finishedWork.elementType === finishedWork.type ? prevProps : resolveDefaultProps(finishedWork.type, prevProps), prevState);
+
+              {
+                var didWarnSet = didWarnAboutUndefinedSnapshotBeforeUpdate;
+
+                if (snapshot === undefined && !didWarnSet.has(finishedWork.type)) {
+                  didWarnSet.add(finishedWork.type);
+
+                  error('%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' + 'must be returned. You have returned undefined.', getComponentName(finishedWork.type));
+                }
+              }
+
+              instance.__reactInternalSnapshotBeforeUpdate = snapshot;
+            }
+          }
+
+          return;
+        }
+
+      case HostRoot:
+        {
+          {
+            if (finishedWork.flags & Snapshot) {
+              var root = finishedWork.stateNode;
+              clearContainer(root.containerInfo);
+            }
+          }
+
+          return;
+        }
+
+      case HostComponent:
+      case HostText:
+      case HostPortal:
+      case IncompleteClassComponent:
+        // Nothing to do for these component types
+        return;
+    }
+
+    {
+      {
+        throw Error( "This unit of work tag should not have side-effects. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function commitHookEffectListUnmount(tag, finishedWork) {
+    var updateQueue = finishedWork.updateQueue;
+    var lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
+
+    if (lastEffect !== null) {
+      var firstEffect = lastEffect.next;
+      var effect = firstEffect;
+
+      do {
+        if ((effect.tag & tag) === tag) {
+          // Unmount
+          var destroy = effect.destroy;
+          effect.destroy = undefined;
+
+          if (destroy !== undefined) {
+            destroy();
+          }
+        }
+
+        effect = effect.next;
+      } while (effect !== firstEffect);
+    }
+  }
+
+  function commitHookEffectListMount(tag, finishedWork) {
+    var updateQueue = finishedWork.updateQueue;
+    var lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
+
+    if (lastEffect !== null) {
+      var firstEffect = lastEffect.next;
+      var effect = firstEffect;
+
+      do {
+        if ((effect.tag & tag) === tag) {
+          // Mount
+          var create = effect.create;
+          effect.destroy = create();
+
+          {
+            var destroy = effect.destroy;
+
+            if (destroy !== undefined && typeof destroy !== 'function') {
+              var addendum = void 0;
+
+              if (destroy === null) {
+                addendum = ' You returned null. If your effect does not require clean ' + 'up, return undefined (or nothing).';
+              } else if (typeof destroy.then === 'function') {
+                addendum = '\n\nIt looks like you wrote useEffect(async () => ...) or returned a Promise. ' + 'Instead, write the async function inside your effect ' + 'and call it immediately:\n\n' + 'useEffect(() => {\n' + '  async function fetchData() {\n' + '    // You can await here\n' + '    const response = await MyAPI.getData(someId);\n' + '    // ...\n' + '  }\n' + '  fetchData();\n' + "}, [someId]); // Or [] if effect doesn't need props or state\n\n" + 'Learn more about data fetching with Hooks: https://reactjs.org/link/hooks-data-fetching';
+              } else {
+                addendum = ' You returned: ' + destroy;
+              }
+
+              error('An effect function must not return anything besides a function, ' + 'which is used for clean-up.%s', addendum);
+            }
+          }
+        }
+
+        effect = effect.next;
+      } while (effect !== firstEffect);
+    }
+  }
+
+  function schedulePassiveEffects(finishedWork) {
+    var updateQueue = finishedWork.updateQueue;
+    var lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
+
+    if (lastEffect !== null) {
+      var firstEffect = lastEffect.next;
+      var effect = firstEffect;
+
+      do {
+        var _effect = effect,
+            next = _effect.next,
+            tag = _effect.tag;
+
+        if ((tag & Passive$1) !== NoFlags$1 && (tag & HasEffect) !== NoFlags$1) {
+          enqueuePendingPassiveHookEffectUnmount(finishedWork, effect);
+          enqueuePendingPassiveHookEffectMount(finishedWork, effect);
+        }
+
+        effect = next;
+      } while (effect !== firstEffect);
+    }
+  }
+
+  function commitLifeCycles(finishedRoot, current, finishedWork, committedLanes) {
+    switch (finishedWork.tag) {
+      case FunctionComponent:
+      case ForwardRef:
+      case SimpleMemoComponent:
+      case Block:
+        {
+          // At this point layout effects have already been destroyed (during mutation phase).
+          // This is done to prevent sibling component effects from interfering with each other,
+          // e.g. a destroy function in one component should never override a ref set
+          // by a create function in another component during the same commit.
+          {
+            commitHookEffectListMount(Layout | HasEffect, finishedWork);
+          }
+
+          schedulePassiveEffects(finishedWork);
+          return;
+        }
+
+      case ClassComponent:
+        {
+          var instance = finishedWork.stateNode;
+
+          if (finishedWork.flags & Update) {
+            if (current === null) {
+              // We could update instance props and state here,
+              // but instead we rely on them being set during last render.
+              // TODO: revisit this when we implement resuming.
+              {
+                if (finishedWork.type === finishedWork.elementType && !didWarnAboutReassigningProps) {
+                  if (instance.props !== finishedWork.memoizedProps) {
+                    error('Expected %s props to match memoized props before ' + 'componentDidMount. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+
+                  if (instance.state !== finishedWork.memoizedState) {
+                    error('Expected %s state to match memoized state before ' + 'componentDidMount. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.state`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+                }
+              }
+
+              {
+                instance.componentDidMount();
+              }
+            } else {
+              var prevProps = finishedWork.elementType === finishedWork.type ? current.memoizedProps : resolveDefaultProps(finishedWork.type, current.memoizedProps);
+              var prevState = current.memoizedState; // We could update instance props and state here,
+              // but instead we rely on them being set during last render.
+              // TODO: revisit this when we implement resuming.
+
+              {
+                if (finishedWork.type === finishedWork.elementType && !didWarnAboutReassigningProps) {
+                  if (instance.props !== finishedWork.memoizedProps) {
+                    error('Expected %s props to match memoized props before ' + 'componentDidUpdate. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+
+                  if (instance.state !== finishedWork.memoizedState) {
+                    error('Expected %s state to match memoized state before ' + 'componentDidUpdate. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.state`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                  }
+                }
+              }
+
+              {
+                instance.componentDidUpdate(prevProps, prevState, instance.__reactInternalSnapshotBeforeUpdate);
+              }
+            }
+          } // TODO: I think this is now always non-null by the time it reaches the
+          // commit phase. Consider removing the type check.
+
+
+          var updateQueue = finishedWork.updateQueue;
+
+          if (updateQueue !== null) {
+            {
+              if (finishedWork.type === finishedWork.elementType && !didWarnAboutReassigningProps) {
+                if (instance.props !== finishedWork.memoizedProps) {
+                  error('Expected %s props to match memoized props before ' + 'processing the update queue. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.props`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                }
+
+                if (instance.state !== finishedWork.memoizedState) {
+                  error('Expected %s state to match memoized state before ' + 'processing the update queue. ' + 'This might either be because of a bug in React, or because ' + 'a component reassigns its own `this.state`. ' + 'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                }
+              }
+            } // We could update instance props and state here,
+            // but instead we rely on them being set during last render.
+            // TODO: revisit this when we implement resuming.
+
+
+            commitUpdateQueue(finishedWork, updateQueue, instance);
+          }
+
+          return;
+        }
+
+      case HostRoot:
+        {
+          // TODO: I think this is now always non-null by the time it reaches the
+          // commit phase. Consider removing the type check.
+          var _updateQueue = finishedWork.updateQueue;
+
+          if (_updateQueue !== null) {
+            var _instance = null;
+
+            if (finishedWork.child !== null) {
+              switch (finishedWork.child.tag) {
+                case HostComponent:
+                  _instance = getPublicInstance(finishedWork.child.stateNode);
+                  break;
+
+                case ClassComponent:
+                  _instance = finishedWork.child.stateNode;
+                  break;
+              }
+            }
+
+            commitUpdateQueue(finishedWork, _updateQueue, _instance);
+          }
+
+          return;
+        }
+
+      case HostComponent:
+        {
+          var _instance2 = finishedWork.stateNode; // Renderers may schedule work to be done after host components are mounted
+          // (eg DOM renderer may schedule auto-focus for inputs and form controls).
+          // These effects should only be committed when components are first mounted,
+          // aka when there is no current/alternate.
+
+          if (current === null && finishedWork.flags & Update) {
+            var type = finishedWork.type;
+            var props = finishedWork.memoizedProps;
+            commitMount(_instance2, type, props);
+          }
+
+          return;
+        }
+
+      case HostText:
+        {
+          // We have no life-cycles associated with text.
+          return;
+        }
+
+      case HostPortal:
+        {
+          // We have no life-cycles associated with portals.
+          return;
+        }
+
+      case Profiler:
+        {
+          {
+            var _finishedWork$memoize2 = finishedWork.memoizedProps,
+                onCommit = _finishedWork$memoize2.onCommit,
+                onRender = _finishedWork$memoize2.onRender;
+            var effectDuration = finishedWork.stateNode.effectDuration;
+            var commitTime = getCommitTime();
+
+            if (typeof onRender === 'function') {
+              {
+                onRender(finishedWork.memoizedProps.id, current === null ? 'mount' : 'update', finishedWork.actualDuration, finishedWork.treeBaseDuration, finishedWork.actualStartTime, commitTime, finishedRoot.memoizedInteractions);
+              }
+            }
+          }
+
+          return;
+        }
+
+      case SuspenseComponent:
+        {
+          commitSuspenseHydrationCallbacks(finishedRoot, finishedWork);
+          return;
+        }
+
+      case SuspenseListComponent:
+      case IncompleteClassComponent:
+      case FundamentalComponent:
+      case ScopeComponent:
+      case OffscreenComponent:
+      case LegacyHiddenComponent:
+        return;
+    }
+
+    {
+      {
+        throw Error( "This unit of work tag should not have side-effects. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function hideOrUnhideAllChildren(finishedWork, isHidden) {
+    {
+      // We only have the top Fiber that was inserted but we need to recurse down its
+      // children to find all the terminal nodes.
+      var node = finishedWork;
+
+      while (true) {
+        if (node.tag === HostComponent) {
+          var instance = node.stateNode;
+
+          if (isHidden) {
+            hideInstance(instance);
+          } else {
+            unhideInstance(node.stateNode, node.memoizedProps);
+          }
+        } else if (node.tag === HostText) {
+          var _instance3 = node.stateNode;
+
+          if (isHidden) {
+            hideTextInstance(_instance3);
+          } else {
+            unhideTextInstance(_instance3, node.memoizedProps);
+          }
+        } else if ((node.tag === OffscreenComponent || node.tag === LegacyHiddenComponent) && node.memoizedState !== null && node !== finishedWork) ; else if (node.child !== null) {
+          node.child.return = node;
+          node = node.child;
+          continue;
+        }
+
+        if (node === finishedWork) {
+          return;
+        }
+
+        while (node.sibling === null) {
+          if (node.return === null || node.return === finishedWork) {
+            return;
+          }
+
+          node = node.return;
+        }
+
+        node.sibling.return = node.return;
+        node = node.sibling;
+      }
+    }
+  }
+
+  function commitAttachRef(finishedWork) {
+    var ref = finishedWork.ref;
+
+    if (ref !== null) {
+      var instance = finishedWork.stateNode;
+      var instanceToUse;
+
+      switch (finishedWork.tag) {
+        case HostComponent:
+          instanceToUse = getPublicInstance(instance);
+          break;
+
+        default:
+          instanceToUse = instance;
+      } // Moved outside to ensure DCE works with this flag
+
+      if (typeof ref === 'function') {
+        ref(instanceToUse);
+      } else {
+        {
+          if (!ref.hasOwnProperty('current')) {
+            error('Unexpected ref object provided for %s. ' + 'Use either a ref-setter function or React.createRef().', getComponentName(finishedWork.type));
+          }
+        }
+
+        ref.current = instanceToUse;
+      }
+    }
+  }
+
+  function commitDetachRef(current) {
+    var currentRef = current.ref;
+
+    if (currentRef !== null) {
+      if (typeof currentRef === 'function') {
+        currentRef(null);
+      } else {
+        currentRef.current = null;
+      }
+    }
+  } // User-originating errors (lifecycles and refs) should not interrupt
+  // deletion, so don't let them throw. Host-originating errors should
+  // interrupt deletion, so it's okay
+
+
+  function commitUnmount(finishedRoot, current, renderPriorityLevel) {
+    onCommitUnmount(current);
+
+    switch (current.tag) {
+      case FunctionComponent:
+      case ForwardRef:
+      case MemoComponent:
+      case SimpleMemoComponent:
+      case Block:
+        {
+          var updateQueue = current.updateQueue;
+
+          if (updateQueue !== null) {
+            var lastEffect = updateQueue.lastEffect;
+
+            if (lastEffect !== null) {
+              var firstEffect = lastEffect.next;
+              var effect = firstEffect;
+
+              do {
+                var _effect2 = effect,
+                    destroy = _effect2.destroy,
+                    tag = _effect2.tag;
+
+                if (destroy !== undefined) {
+                  if ((tag & Passive$1) !== NoFlags$1) {
+                    enqueuePendingPassiveHookEffectUnmount(current, effect);
+                  } else {
+                    {
+                      safelyCallDestroy(current, destroy);
+                    }
+                  }
+                }
+
+                effect = effect.next;
+              } while (effect !== firstEffect);
+            }
+          }
+
+          return;
+        }
+
+      case ClassComponent:
+        {
+          safelyDetachRef(current);
+          var instance = current.stateNode;
+
+          if (typeof instance.componentWillUnmount === 'function') {
+            safelyCallComponentWillUnmount(current, instance);
+          }
+
+          return;
+        }
+
+      case HostComponent:
+        {
+          safelyDetachRef(current);
+          return;
+        }
+
+      case HostPortal:
+        {
+          // TODO: this is recursive.
+          // We are also not using this parent because
+          // the portal will get pushed immediately.
+          {
+            unmountHostComponents(finishedRoot, current);
+          }
+
+          return;
+        }
+
+      case FundamentalComponent:
+        {
+
+          return;
+        }
+
+      case DehydratedFragment:
+        {
+
+          return;
+        }
+
+      case ScopeComponent:
+        {
+
+          return;
+        }
+    }
+  }
+
+  function commitNestedUnmounts(finishedRoot, root, renderPriorityLevel) {
+    // While we're inside a removed host node we don't want to call
+    // removeChild on the inner nodes because they're removed by the top
+    // call anyway. We also want to call componentWillUnmount on all
+    // composites before this host node is removed from the tree. Therefore
+    // we do an inner loop while we're still inside the host node.
+    var node = root;
+
+    while (true) {
+      commitUnmount(finishedRoot, node); // Visit children because they may contain more composite or host nodes.
+      // Skip portals because commitUnmount() currently visits them recursively.
+
+      if (node.child !== null && ( // If we use mutation we drill down into portals using commitUnmount above.
+      // If we don't use mutation we drill down into portals here instead.
+       node.tag !== HostPortal)) {
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
+
+      if (node === root) {
+        return;
+      }
+
+      while (node.sibling === null) {
+        if (node.return === null || node.return === root) {
+          return;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    }
+  }
+
+  function detachFiberMutation(fiber) {
+    // Cut off the return pointers to disconnect it from the tree. Ideally, we
+    // should clear the child pointer of the parent alternate to let this
+    // get GC:ed but we don't know which for sure which parent is the current
+    // one so we'll settle for GC:ing the subtree of this child. This child
+    // itself will be GC:ed when the parent updates the next time.
+    // Note: we cannot null out sibling here, otherwise it can cause issues
+    // with findDOMNode and how it requires the sibling field to carry out
+    // traversal in a later effect. See PR #16820. We now clear the sibling
+    // field after effects, see: detachFiberAfterEffects.
+    //
+    // Don't disconnect stateNode now; it will be detached in detachFiberAfterEffects.
+    // It may be required if the current component is an error boundary,
+    // and one of its descendants throws while unmounting a passive effect.
+    fiber.alternate = null;
+    fiber.child = null;
+    fiber.dependencies = null;
+    fiber.firstEffect = null;
+    fiber.lastEffect = null;
+    fiber.memoizedProps = null;
+    fiber.memoizedState = null;
+    fiber.pendingProps = null;
+    fiber.return = null;
+    fiber.updateQueue = null;
+
+    {
+      fiber._debugOwner = null;
+    }
+  }
+
+  function getHostParentFiber(fiber) {
+    var parent = fiber.return;
+
+    while (parent !== null) {
+      if (isHostParent(parent)) {
+        return parent;
+      }
+
+      parent = parent.return;
+    }
+
+    {
+      {
+        throw Error( "Expected to find a host parent. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function isHostParent(fiber) {
+    return fiber.tag === HostComponent || fiber.tag === HostRoot || fiber.tag === HostPortal;
+  }
+
+  function getHostSibling(fiber) {
+    // We're going to search forward into the tree until we find a sibling host
+    // node. Unfortunately, if multiple insertions are done in a row we have to
+    // search past them. This leads to exponential search for the next sibling.
+    // TODO: Find a more efficient way to do this.
+    var node = fiber;
+
+    siblings: while (true) {
+      // If we didn't find anything, let's try the next sibling.
+      while (node.sibling === null) {
+        if (node.return === null || isHostParent(node.return)) {
+          // If we pop out of the root or hit the parent the fiber we are the
+          // last sibling.
+          return null;
+        }
+
+        node = node.return;
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+
+      while (node.tag !== HostComponent && node.tag !== HostText && node.tag !== DehydratedFragment) {
+        // If it is not host node and, we might have a host node inside it.
+        // Try to search down until we find one.
+        if (node.flags & Placement) {
+          // If we don't have a child, try the siblings instead.
+          continue siblings;
+        } // If we don't have a child, try the siblings instead.
+        // We also skip portals because they are not part of this host tree.
+
+
+        if (node.child === null || node.tag === HostPortal) {
+          continue siblings;
+        } else {
+          node.child.return = node;
+          node = node.child;
+        }
+      } // Check if this host node is stable or about to be placed.
+
+
+      if (!(node.flags & Placement)) {
+        // Found it!
+        return node.stateNode;
+      }
+    }
+  }
+
+  function commitPlacement(finishedWork) {
+
+
+    var parentFiber = getHostParentFiber(finishedWork); // Note: these two variables *must* always be updated together.
+
+    var parent;
+    var isContainer;
+    var parentStateNode = parentFiber.stateNode;
+
+    switch (parentFiber.tag) {
+      case HostComponent:
+        parent = parentStateNode;
+        isContainer = false;
+        break;
+
+      case HostRoot:
+        parent = parentStateNode.containerInfo;
+        isContainer = true;
+        break;
+
+      case HostPortal:
+        parent = parentStateNode.containerInfo;
+        isContainer = true;
+        break;
+
+      case FundamentalComponent:
+
+      // eslint-disable-next-line-no-fallthrough
+
+      default:
+        {
+          {
+            throw Error( "Invalid host parent fiber. This error is likely caused by a bug in React. Please file an issue." );
+          }
+        }
+
+    }
+
+    if (parentFiber.flags & ContentReset) {
+      // Reset the text content of the parent before doing any insertions
+      resetTextContent(parent); // Clear ContentReset from the effect tag
+
+      parentFiber.flags &= ~ContentReset;
+    }
+
+    var before = getHostSibling(finishedWork); // We only have the top Fiber that was inserted but we need to recurse down its
+    // children to find all the terminal nodes.
+
+    if (isContainer) {
+      insertOrAppendPlacementNodeIntoContainer(finishedWork, before, parent);
+    } else {
+      insertOrAppendPlacementNode(finishedWork, before, parent);
+    }
+  }
+
+  function insertOrAppendPlacementNodeIntoContainer(node, before, parent) {
+    var tag = node.tag;
+    var isHost = tag === HostComponent || tag === HostText;
+
+    if (isHost || enableFundamentalAPI ) {
+      var stateNode = isHost ? node.stateNode : node.stateNode.instance;
+
+      if (before) {
+        insertInContainerBefore(parent, stateNode, before);
+      } else {
+        appendChildToContainer(parent, stateNode);
+      }
+    } else if (tag === HostPortal) ; else {
+      var child = node.child;
+
+      if (child !== null) {
+        insertOrAppendPlacementNodeIntoContainer(child, before, parent);
+        var sibling = child.sibling;
+
+        while (sibling !== null) {
+          insertOrAppendPlacementNodeIntoContainer(sibling, before, parent);
+          sibling = sibling.sibling;
+        }
+      }
+    }
+  }
+
+  function insertOrAppendPlacementNode(node, before, parent) {
+    var tag = node.tag;
+    var isHost = tag === HostComponent || tag === HostText;
+
+    if (isHost || enableFundamentalAPI ) {
+      var stateNode = isHost ? node.stateNode : node.stateNode.instance;
+
+      if (before) {
+        insertBefore(parent, stateNode, before);
+      } else {
+        appendChild(parent, stateNode);
+      }
+    } else if (tag === HostPortal) ; else {
+      var child = node.child;
+
+      if (child !== null) {
+        insertOrAppendPlacementNode(child, before, parent);
+        var sibling = child.sibling;
+
+        while (sibling !== null) {
+          insertOrAppendPlacementNode(sibling, before, parent);
+          sibling = sibling.sibling;
+        }
+      }
+    }
+  }
+
+  function unmountHostComponents(finishedRoot, current, renderPriorityLevel) {
+    // We only have the top Fiber that was deleted but we need to recurse down its
+    // children to find all the terminal nodes.
+    var node = current; // Each iteration, currentParent is populated with node's host parent if not
+    // currentParentIsValid.
+
+    var currentParentIsValid = false; // Note: these two variables *must* always be updated together.
+
+    var currentParent;
+    var currentParentIsContainer;
+
+    while (true) {
+      if (!currentParentIsValid) {
+        var parent = node.return;
+
+        findParent: while (true) {
+          if (!(parent !== null)) {
+            {
+              throw Error( "Expected to find a host parent. This error is likely caused by a bug in React. Please file an issue." );
+            }
+          }
+
+          var parentStateNode = parent.stateNode;
+
+          switch (parent.tag) {
+            case HostComponent:
+              currentParent = parentStateNode;
+              currentParentIsContainer = false;
+              break findParent;
+
+            case HostRoot:
+              currentParent = parentStateNode.containerInfo;
+              currentParentIsContainer = true;
+              break findParent;
+
+            case HostPortal:
+              currentParent = parentStateNode.containerInfo;
+              currentParentIsContainer = true;
+              break findParent;
+
+          }
+
+          parent = parent.return;
+        }
+
+        currentParentIsValid = true;
+      }
+
+      if (node.tag === HostComponent || node.tag === HostText) {
+        commitNestedUnmounts(finishedRoot, node); // After all the children have unmounted, it is now safe to remove the
+        // node from the tree.
+
+        if (currentParentIsContainer) {
+          removeChildFromContainer(currentParent, node.stateNode);
+        } else {
+          removeChild(currentParent, node.stateNode);
+        } // Don't visit children because we already visited them.
+
+      } else if (node.tag === HostPortal) {
+        if (node.child !== null) {
+          // When we go into a portal, it becomes the parent to remove from.
+          // We will reassign it back when we pop the portal on the way up.
+          currentParent = node.stateNode.containerInfo;
+          currentParentIsContainer = true; // Visit children because portals might contain host components.
+
+          node.child.return = node;
+          node = node.child;
+          continue;
+        }
+      } else {
+        commitUnmount(finishedRoot, node); // Visit children because we may find more host components below.
+
+        if (node.child !== null) {
+          node.child.return = node;
+          node = node.child;
+          continue;
+        }
+      }
+
+      if (node === current) {
+        return;
+      }
+
+      while (node.sibling === null) {
+        if (node.return === null || node.return === current) {
+          return;
+        }
+
+        node = node.return;
+
+        if (node.tag === HostPortal) {
+          // When we go out of the portal, we need to restore the parent.
+          // Since we don't keep a stack of them, we will search for it.
+          currentParentIsValid = false;
+        }
+      }
+
+      node.sibling.return = node.return;
+      node = node.sibling;
+    }
+  }
+
+  function commitDeletion(finishedRoot, current, renderPriorityLevel) {
+    {
+      // Recursively delete all host nodes from the parent.
+      // Detach refs and call componentWillUnmount() on the whole subtree.
+      unmountHostComponents(finishedRoot, current);
+    }
+
+    var alternate = current.alternate;
+    detachFiberMutation(current);
+
+    if (alternate !== null) {
+      detachFiberMutation(alternate);
+    }
+  }
+
+  function commitWork(current, finishedWork) {
+
+    switch (finishedWork.tag) {
+      case FunctionComponent:
+      case ForwardRef:
+      case MemoComponent:
+      case SimpleMemoComponent:
+      case Block:
+        {
+          // Layout effects are destroyed during the mutation phase so that all
+          // destroy functions for all fibers are called before any create functions.
+          // This prevents sibling component effects from interfering with each other,
+          // e.g. a destroy function in one component should never override a ref set
+          // by a create function in another component during the same commit.
+          {
+            commitHookEffectListUnmount(Layout | HasEffect, finishedWork);
+          }
+
+          return;
+        }
+
+      case ClassComponent:
+        {
+          return;
+        }
+
+      case HostComponent:
+        {
+          var instance = finishedWork.stateNode;
+
+          if (instance != null) {
+            // Commit the work prepared earlier.
+            var newProps = finishedWork.memoizedProps; // For hydration we reuse the update path but we treat the oldProps
+            // as the newProps. The updatePayload will contain the real change in
+            // this case.
+
+            var oldProps = current !== null ? current.memoizedProps : newProps;
+            var type = finishedWork.type; // TODO: Type the updateQueue to be specific to host components.
+
+            var updatePayload = finishedWork.updateQueue;
+            finishedWork.updateQueue = null;
+
+            if (updatePayload !== null) {
+              commitUpdate(instance, updatePayload, type, oldProps, newProps);
+            }
+          }
+
+          return;
+        }
+
+      case HostText:
+        {
+          if (!(finishedWork.stateNode !== null)) {
+            {
+              throw Error( "This should have a text node initialized. This error is likely caused by a bug in React. Please file an issue." );
+            }
+          }
+
+          var textInstance = finishedWork.stateNode;
+          var newText = finishedWork.memoizedProps; // For hydration we reuse the update path but we treat the oldProps
+          // as the newProps. The updatePayload will contain the real change in
+          // this case.
+
+          var oldText = current !== null ? current.memoizedProps : newText;
+          commitTextUpdate(textInstance, oldText, newText);
+          return;
+        }
+
+      case HostRoot:
+        {
+          {
+            var _root = finishedWork.stateNode;
+
+            if (_root.hydrate) {
+              // We've just hydrated. No need to hydrate again.
+              _root.hydrate = false;
+              commitHydratedContainer(_root.containerInfo);
+            }
+          }
+
+          return;
+        }
+
+      case Profiler:
+        {
+          return;
+        }
+
+      case SuspenseComponent:
+        {
+          commitSuspenseComponent(finishedWork);
+          attachSuspenseRetryListeners(finishedWork);
+          return;
+        }
+
+      case SuspenseListComponent:
+        {
+          attachSuspenseRetryListeners(finishedWork);
+          return;
+        }
+
+      case IncompleteClassComponent:
+        {
+          return;
+        }
+
+      case FundamentalComponent:
+        {
+
+          break;
+        }
+
+      case ScopeComponent:
+        {
+
+          break;
+        }
+
+      case OffscreenComponent:
+      case LegacyHiddenComponent:
+        {
+          var newState = finishedWork.memoizedState;
+          var isHidden = newState !== null;
+          hideOrUnhideAllChildren(finishedWork, isHidden);
+          return;
+        }
+    }
+
+    {
+      {
+        throw Error( "This unit of work tag should not have side-effects. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+
+  function commitSuspenseComponent(finishedWork) {
+    var newState = finishedWork.memoizedState;
+
+    if (newState !== null) {
+      markCommitTimeOfFallback();
+
+      {
+        // Hide the Offscreen component that contains the primary children. TODO:
+        // Ideally, this effect would have been scheduled on the Offscreen fiber
+        // itself. That's how unhiding works: the Offscreen component schedules an
+        // effect on itself. However, in this case, the component didn't complete,
+        // so the fiber was never added to the effect list in the normal path. We
+        // could have appended it to the effect list in the Suspense component's
+        // second pass, but doing it this way is less complicated. This would be
+        // simpler if we got rid of the effect list and traversed the tree, like
+        // we're planning to do.
+        var primaryChildParent = finishedWork.child;
+        hideOrUnhideAllChildren(primaryChildParent, true);
+      }
+    }
+  }
+
+  function commitSuspenseHydrationCallbacks(finishedRoot, finishedWork) {
+
+    var newState = finishedWork.memoizedState;
+
+    if (newState === null) {
+      var current = finishedWork.alternate;
+
+      if (current !== null) {
+        var prevState = current.memoizedState;
+
+        if (prevState !== null) {
+          var suspenseInstance = prevState.dehydrated;
+
+          if (suspenseInstance !== null) {
+            commitHydratedSuspenseInstance(suspenseInstance);
+          }
+        }
+      }
+    }
+  }
+
+  function attachSuspenseRetryListeners(finishedWork) {
+    // If this boundary just timed out, then it will have a set of wakeables.
+    // For each wakeable, attach a listener so that when it resolves, React
+    // attempts to re-render the boundary in the primary (pre-timeout) state.
+    var wakeables = finishedWork.updateQueue;
+
+    if (wakeables !== null) {
+      finishedWork.updateQueue = null;
+      var retryCache = finishedWork.stateNode;
+
+      if (retryCache === null) {
+        retryCache = finishedWork.stateNode = new PossiblyWeakSet();
+      }
+
+      wakeables.forEach(function (wakeable) {
+        // Memoize using the boundary fiber to prevent redundant listeners.
+        var retry = resolveRetryWakeable.bind(null, finishedWork, wakeable);
+
+        if (!retryCache.has(wakeable)) {
+          {
+            if (wakeable.__reactDoNotTraceInteractions !== true) {
+              retry = unstable_wrap(retry);
+            }
+          }
+
+          retryCache.add(wakeable);
+          wakeable.then(retry, retry);
+        }
+      });
+    }
+  } // This function detects when a Suspense boundary goes from visible to hidden.
+  // It returns false if the boundary is already hidden.
+  // TODO: Use an effect tag.
+
+
+  function isSuspenseBoundaryBeingHidden(current, finishedWork) {
+    if (current !== null) {
+      var oldState = current.memoizedState;
+
+      if (oldState === null || oldState.dehydrated !== null) {
+        var newState = finishedWork.memoizedState;
+        return newState !== null && newState.dehydrated === null;
+      }
+    }
+
+    return false;
+  }
+
+  function commitResetTextContent(current) {
+
+    resetTextContent(current.stateNode);
+  }
+
+  var COMPONENT_TYPE = 0;
+  var HAS_PSEUDO_CLASS_TYPE = 1;
+  var ROLE_TYPE = 2;
+  var TEST_NAME_TYPE = 3;
+  var TEXT_TYPE = 4;
+
+  if (typeof Symbol === 'function' && Symbol.for) {
+    var symbolFor$1 = Symbol.for;
+    COMPONENT_TYPE = symbolFor$1('selector.component');
+    HAS_PSEUDO_CLASS_TYPE = symbolFor$1('selector.has_pseudo_class');
+    ROLE_TYPE = symbolFor$1('selector.role');
+    TEST_NAME_TYPE = symbolFor$1('selector.test_id');
+    TEXT_TYPE = symbolFor$1('selector.text');
+  }
+  var commitHooks = [];
+  function onCommitRoot$1() {
+    {
+      commitHooks.forEach(function (commitHook) {
+        return commitHook();
+      });
+    }
+  }
+
+  var ceil = Math.ceil;
+  var ReactCurrentDispatcher$2 = ReactSharedInternals.ReactCurrentDispatcher,
+      ReactCurrentOwner$2 = ReactSharedInternals.ReactCurrentOwner,
+      IsSomeRendererActing = ReactSharedInternals.IsSomeRendererActing;
+  var NoContext =
+  /*             */
+  0;
+  var BatchedContext =
+  /*               */
+  1;
+  var EventContext =
+  /*                 */
+  2;
+  var DiscreteEventContext =
+  /*         */
+  4;
+  var LegacyUnbatchedContext =
+  /*       */
+  8;
+  var RenderContext =
+  /*                */
+  16;
+  var CommitContext =
+  /*                */
+  32;
+  var RetryAfterError =
+  /*       */
+  64;
+  var RootIncomplete = 0;
+  var RootFatalErrored = 1;
+  var RootErrored = 2;
+  var RootSuspended = 3;
+  var RootSuspendedWithDelay = 4;
+  var RootCompleted = 5; // Describes where we are in the React execution stack
+
+  var executionContext = NoContext; // The root we're working on
+
+  var workInProgressRoot = null; // The fiber we're working on
+
+  var workInProgress = null; // The lanes we're rendering
+
+  var workInProgressRootRenderLanes = NoLanes; // Stack that allows components to change the render lanes for its subtree
+  // This is a superset of the lanes we started working on at the root. The only
+  // case where it's different from `workInProgressRootRenderLanes` is when we
+  // enter a subtree that is hidden and needs to be unhidden: Suspense and
+  // Offscreen component.
+  //
+  // Most things in the work loop should deal with workInProgressRootRenderLanes.
+  // Most things in begin/complete phases should deal with subtreeRenderLanes.
+
+  var subtreeRenderLanes = NoLanes;
+  var subtreeRenderLanesCursor = createCursor(NoLanes); // Whether to root completed, errored, suspended, etc.
+
+  var workInProgressRootExitStatus = RootIncomplete; // A fatal error, if one is thrown
+
+  var workInProgressRootFatalError = null; // "Included" lanes refer to lanes that were worked on during this render. It's
+  // slightly different than `renderLanes` because `renderLanes` can change as you
+  // enter and exit an Offscreen tree. This value is the combination of all render
+  // lanes for the entire render phase.
+
+  var workInProgressRootIncludedLanes = NoLanes; // The work left over by components that were visited during this render. Only
+  // includes unprocessed updates, not work in bailed out children.
+
+  var workInProgressRootSkippedLanes = NoLanes; // Lanes that were updated (in an interleaved event) during this render.
+
+  var workInProgressRootUpdatedLanes = NoLanes; // Lanes that were pinged (in an interleaved event) during this render.
+
+  var workInProgressRootPingedLanes = NoLanes;
+  var mostRecentlyUpdatedRoot = null; // The most recent time we committed a fallback. This lets us ensure a train
+  // model where we don't commit new loading states in too quick succession.
+
+  var globalMostRecentFallbackTime = 0;
+  var FALLBACK_THROTTLE_MS = 500; // The absolute time for when we should start giving up on rendering
+  // more and prefer CPU suspense heuristics instead.
+
+  var workInProgressRootRenderTargetTime = Infinity; // How long a render is supposed to take before we start following CPU
+  // suspense heuristics and opt out of rendering more content.
+
+  var RENDER_TIMEOUT_MS = 500;
+
+  function resetRenderTimer() {
+    workInProgressRootRenderTargetTime = now() + RENDER_TIMEOUT_MS;
+  }
+
+  function getRenderTargetTime() {
+    return workInProgressRootRenderTargetTime;
+  }
+  var nextEffect = null;
+  var hasUncaughtError = false;
+  var firstUncaughtError = null;
+  var legacyErrorBoundariesThatAlreadyFailed = null;
+  var rootDoesHavePassiveEffects = false;
+  var rootWithPendingPassiveEffects = null;
+  var pendingPassiveEffectsRenderPriority = NoPriority$1;
+  var pendingPassiveEffectsLanes = NoLanes;
+  var pendingPassiveHookEffectsMount = [];
+  var pendingPassiveHookEffectsUnmount = [];
+  var rootsWithPendingDiscreteUpdates = null; // Use these to prevent an infinite loop of nested updates
+
+  var NESTED_UPDATE_LIMIT = 50;
+  var nestedUpdateCount = 0;
+  var rootWithNestedUpdates = null;
+  var NESTED_PASSIVE_UPDATE_LIMIT = 50;
+  var nestedPassiveUpdateCount = 0; // Marks the need to reschedule pending interactions at these lanes
+  // during the commit phase. This enables them to be traced across components
+  // that spawn new work during render. E.g. hidden boundaries, suspended SSR
+  // hydration or SuspenseList.
+  // TODO: Can use a bitmask instead of an array
+
+  var spawnedWorkDuringRender = null; // If two updates are scheduled within the same event, we should treat their
+  // event times as simultaneous, even if the actual clock time has advanced
+  // between the first and second call.
+
+  var currentEventTime = NoTimestamp;
+  var currentEventWipLanes = NoLanes;
+  var currentEventPendingLanes = NoLanes; // Dev only flag that tracks if passive effects are currently being flushed.
+  // We warn about state updates for unmounted components differently in this case.
+
+  var isFlushingPassiveEffects = false;
+  var focusedInstanceHandle = null;
+  var shouldFireAfterActiveInstanceBlur = false;
+  function getWorkInProgressRoot() {
+    return workInProgressRoot;
+  }
+  function requestEventTime() {
+    if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
+      // We're inside React, so it's fine to read the actual time.
+      return now();
+    } // We're not inside React, so we may be in the middle of a browser event.
+
+
+    if (currentEventTime !== NoTimestamp) {
+      // Use the same start time for all updates until we enter React again.
+      return currentEventTime;
+    } // This is the first update since React yielded. Compute a new start time.
+
+
+    currentEventTime = now();
+    return currentEventTime;
+  }
+  function requestUpdateLane(fiber) {
+    // Special cases
+    var mode = fiber.mode;
+
+    if ((mode & BlockingMode) === NoMode) {
+      return SyncLane;
+    } else if ((mode & ConcurrentMode) === NoMode) {
+      return getCurrentPriorityLevel() === ImmediatePriority$1 ? SyncLane : SyncBatchedLane;
+    } // The algorithm for assigning an update to a lane should be stable for all
+    // updates at the same priority within the same event. To do this, the inputs
+    // to the algorithm must be the same. For example, we use the `renderLanes`
+    // to avoid choosing a lane that is already in the middle of rendering.
+    //
+    // However, the "included" lanes could be mutated in between updates in the
+    // same event, like if you perform an update inside `flushSync`. Or any other
+    // code path that might call `prepareFreshStack`.
+    //
+    // The trick we use is to cache the first of each of these inputs within an
+    // event. Then reset the cached values once we can be sure the event is over.
+    // Our heuristic for that is whenever we enter a concurrent work loop.
+    //
+    // We'll do the same for `currentEventPendingLanes` below.
+
+
+    if (currentEventWipLanes === NoLanes) {
+      currentEventWipLanes = workInProgressRootIncludedLanes;
+    }
+
+    var isTransition = requestCurrentTransition() !== NoTransition;
+
+    if (isTransition) {
+      if (currentEventPendingLanes !== NoLanes) {
+        currentEventPendingLanes = mostRecentlyUpdatedRoot !== null ? mostRecentlyUpdatedRoot.pendingLanes : NoLanes;
+      }
+
+      return findTransitionLane(currentEventWipLanes, currentEventPendingLanes);
+    } // TODO: Remove this dependency on the Scheduler priority.
+    // To do that, we're replacing it with an update lane priority.
+
+
+    var schedulerPriority = getCurrentPriorityLevel(); // The old behavior was using the priority level of the Scheduler.
+    // This couples React to the Scheduler internals, so we're replacing it
+    // with the currentUpdateLanePriority above. As an example of how this
+    // could be problematic, if we're not inside `Scheduler.runWithPriority`,
+    // then we'll get the priority of the current running Scheduler task,
+    // which is probably not what we want.
+
+    var lane;
+
+    if ( // TODO: Temporary. We're removing the concept of discrete updates.
+    (executionContext & DiscreteEventContext) !== NoContext && schedulerPriority === UserBlockingPriority$2) {
+      lane = findUpdateLane(InputDiscreteLanePriority, currentEventWipLanes);
+    } else {
+      var schedulerLanePriority = schedulerPriorityToLanePriority(schedulerPriority);
+
+      lane = findUpdateLane(schedulerLanePriority, currentEventWipLanes);
+    }
+
+    return lane;
+  }
+
+  function requestRetryLane(fiber) {
+    // This is a fork of `requestUpdateLane` designed specifically for Suspense
+    // "retries" — a special update that attempts to flip a Suspense boundary
+    // from its placeholder state to its primary/resolved state.
+    // Special cases
+    var mode = fiber.mode;
+
+    if ((mode & BlockingMode) === NoMode) {
+      return SyncLane;
+    } else if ((mode & ConcurrentMode) === NoMode) {
+      return getCurrentPriorityLevel() === ImmediatePriority$1 ? SyncLane : SyncBatchedLane;
+    } // See `requestUpdateLane` for explanation of `currentEventWipLanes`
+
+
+    if (currentEventWipLanes === NoLanes) {
+      currentEventWipLanes = workInProgressRootIncludedLanes;
+    }
+
+    return findRetryLane(currentEventWipLanes);
+  }
+
+  function scheduleUpdateOnFiber(fiber, lane, eventTime) {
+    checkForNestedUpdates();
+    warnAboutRenderPhaseUpdatesInDEV(fiber);
+    var root = markUpdateLaneFromFiberToRoot(fiber, lane);
+
+    if (root === null) {
+      warnAboutUpdateOnUnmountedFiberInDEV(fiber);
+      return null;
+    } // Mark that the root has a pending update.
+
+
+    markRootUpdated(root, lane, eventTime);
+
+    if (root === workInProgressRoot) {
+      // Received an update to a tree that's in the middle of rendering. Mark
+      // that there was an interleaved update work on this root. Unless the
+      // `deferRenderPhaseUpdateToNextBatch` flag is off and this is a render
+      // phase update. In that case, we don't treat render phase updates as if
+      // they were interleaved, for backwards compat reasons.
+      {
+        workInProgressRootUpdatedLanes = mergeLanes(workInProgressRootUpdatedLanes, lane);
+      }
+
+      if (workInProgressRootExitStatus === RootSuspendedWithDelay) {
+        // The root already suspended with a delay, which means this render
+        // definitely won't finish. Since we have a new update, let's mark it as
+        // suspended now, right before marking the incoming update. This has the
+        // effect of interrupting the current render and switching to the update.
+        // TODO: Make sure this doesn't override pings that happen while we've
+        // already started rendering.
+        markRootSuspended$1(root, workInProgressRootRenderLanes);
+      }
+    } // TODO: requestUpdateLanePriority also reads the priority. Pass the
+    // priority as an argument to that function and this one.
+
+
+    var priorityLevel = getCurrentPriorityLevel();
+
+    if (lane === SyncLane) {
+      if ( // Check if we're inside unbatchedUpdates
+      (executionContext & LegacyUnbatchedContext) !== NoContext && // Check if we're not already rendering
+      (executionContext & (RenderContext | CommitContext)) === NoContext) {
+        // Register pending interactions on the root to avoid losing traced interaction data.
+        schedulePendingInteractions(root, lane); // This is a legacy edge case. The initial mount of a ReactDOM.render-ed
+        // root inside of batchedUpdates should be synchronous, but layout updates
+        // should be deferred until the end of the batch.
+
+        performSyncWorkOnRoot(root);
+      } else {
+        ensureRootIsScheduled(root, eventTime);
+        schedulePendingInteractions(root, lane);
+
+        if (executionContext === NoContext) {
+          // Flush the synchronous work now, unless we're already working or inside
+          // a batch. This is intentionally inside scheduleUpdateOnFiber instead of
+          // scheduleCallbackForFiber to preserve the ability to schedule a callback
+          // without immediately flushing it. We only do this for user-initiated
+          // updates, to preserve historical behavior of legacy mode.
+          resetRenderTimer();
+          flushSyncCallbackQueue();
+        }
+      }
+    } else {
+      // Schedule a discrete update but only if it's not Sync.
+      if ((executionContext & DiscreteEventContext) !== NoContext && ( // Only updates at user-blocking priority or greater are considered
+      // discrete, even inside a discrete event.
+      priorityLevel === UserBlockingPriority$2 || priorityLevel === ImmediatePriority$1)) {
+        // This is the result of a discrete event. Track the lowest priority
+        // discrete update per root so we can flush them early, if needed.
+        if (rootsWithPendingDiscreteUpdates === null) {
+          rootsWithPendingDiscreteUpdates = new Set([root]);
+        } else {
+          rootsWithPendingDiscreteUpdates.add(root);
+        }
+      } // Schedule other updates after in case the callback is sync.
+
+
+      ensureRootIsScheduled(root, eventTime);
+      schedulePendingInteractions(root, lane);
+    } // We use this when assigning a lane for a transition inside
+    // `requestUpdateLane`. We assume it's the same as the root being updated,
+    // since in the common case of a single root app it probably is. If it's not
+    // the same root, then it's not a huge deal, we just might batch more stuff
+    // together more than necessary.
+
+
+    mostRecentlyUpdatedRoot = root;
+  } // This is split into a separate function so we can mark a fiber with pending
+  // work without treating it as a typical update that originates from an event;
+  // e.g. retrying a Suspense boundary isn't an update, but it does schedule work
+  // on a fiber.
+
+  function markUpdateLaneFromFiberToRoot(sourceFiber, lane) {
+    // Update the source fiber's lanes
+    sourceFiber.lanes = mergeLanes(sourceFiber.lanes, lane);
+    var alternate = sourceFiber.alternate;
+
+    if (alternate !== null) {
+      alternate.lanes = mergeLanes(alternate.lanes, lane);
+    }
+
+    {
+      if (alternate === null && (sourceFiber.flags & (Placement | Hydrating)) !== NoFlags) {
+        warnAboutUpdateOnNotYetMountedFiberInDEV(sourceFiber);
+      }
+    } // Walk the parent path to the root and update the child expiration time.
+
+
+    var node = sourceFiber;
+    var parent = sourceFiber.return;
+
+    while (parent !== null) {
+      parent.childLanes = mergeLanes(parent.childLanes, lane);
+      alternate = parent.alternate;
+
+      if (alternate !== null) {
+        alternate.childLanes = mergeLanes(alternate.childLanes, lane);
+      } else {
+        {
+          if ((parent.flags & (Placement | Hydrating)) !== NoFlags) {
+            warnAboutUpdateOnNotYetMountedFiberInDEV(sourceFiber);
+          }
+        }
+      }
+
+      node = parent;
+      parent = parent.return;
+    }
+
+    if (node.tag === HostRoot) {
+      var root = node.stateNode;
+      return root;
+    } else {
+      return null;
+    }
+  } // Use this function to schedule a task for a root. There's only one task per
+  // root; if a task was already scheduled, we'll check to make sure the priority
+  // of the existing task is the same as the priority of the next level that the
+  // root has work on. This function is called on every update, and right before
+  // exiting a task.
+
+
+  function ensureRootIsScheduled(root, currentTime) {
+    var existingCallbackNode = root.callbackNode; // Check if any lanes are being starved by other work. If so, mark them as
+    // expired so we know to work on those next.
+
+    markStarvedLanesAsExpired(root, currentTime); // Determine the next lanes to work on, and their priority.
+
+    var nextLanes = getNextLanes(root, root === workInProgressRoot ? workInProgressRootRenderLanes : NoLanes); // This returns the priority level computed during the `getNextLanes` call.
+
+    var newCallbackPriority = returnNextLanesPriority();
+
+    if (nextLanes === NoLanes) {
+      // Special case: There's nothing to work on.
+      if (existingCallbackNode !== null) {
+        cancelCallback(existingCallbackNode);
+        root.callbackNode = null;
+        root.callbackPriority = NoLanePriority;
+      }
+
+      return;
+    } // Check if there's an existing task. We may be able to reuse it.
+
+
+    if (existingCallbackNode !== null) {
+      var existingCallbackPriority = root.callbackPriority;
+
+      if (existingCallbackPriority === newCallbackPriority) {
+        // The priority hasn't changed. We can reuse the existing task. Exit.
+        return;
+      } // The priority changed. Cancel the existing callback. We'll schedule a new
+      // one below.
+
+
+      cancelCallback(existingCallbackNode);
+    } // Schedule a new callback.
+
+
+    var newCallbackNode;
+
+    if (newCallbackPriority === SyncLanePriority) {
+      // Special case: Sync React callbacks are scheduled on a special
+      // internal queue
+      newCallbackNode = scheduleSyncCallback(performSyncWorkOnRoot.bind(null, root));
+    } else if (newCallbackPriority === SyncBatchedLanePriority) {
+      newCallbackNode = scheduleCallback(ImmediatePriority$1, performSyncWorkOnRoot.bind(null, root));
+    } else {
+      var schedulerPriorityLevel = lanePriorityToSchedulerPriority(newCallbackPriority);
+      newCallbackNode = scheduleCallback(schedulerPriorityLevel, performConcurrentWorkOnRoot.bind(null, root));
+    }
+
+    root.callbackPriority = newCallbackPriority;
+    root.callbackNode = newCallbackNode;
+  } // This is the entry point for every concurrent task, i.e. anything that
+  // goes through Scheduler.
+
+
+  function performConcurrentWorkOnRoot(root) {
+    // Since we know we're in a React event, we can clear the current
+    // event time. The next update will compute a new event time.
+    currentEventTime = NoTimestamp;
+    currentEventWipLanes = NoLanes;
+    currentEventPendingLanes = NoLanes;
+
+    if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+      {
+        throw Error( "Should not already be working." );
+      }
+    } // Flush any pending passive effects before deciding which lanes to work on,
+    // in case they schedule additional work.
+
+
+    var originalCallbackNode = root.callbackNode;
+    var didFlushPassiveEffects = flushPassiveEffects();
+
+    if (didFlushPassiveEffects) {
+      // Something in the passive effect phase may have canceled the current task.
+      // Check if the task node for this root was changed.
+      if (root.callbackNode !== originalCallbackNode) {
+        // The current task was canceled. Exit. We don't need to call
+        // `ensureRootIsScheduled` because the check above implies either that
+        // there's a new task, or that there's no remaining work on this root.
+        return null;
+      }
+    } // Determine the next expiration time to work on, using the fields stored
+    // on the root.
+
+
+    var lanes = getNextLanes(root, root === workInProgressRoot ? workInProgressRootRenderLanes : NoLanes);
+
+    if (lanes === NoLanes) {
+      // Defensive coding. This is never expected to happen.
+      return null;
+    }
+
+    var exitStatus = renderRootConcurrent(root, lanes);
+
+    if (includesSomeLane(workInProgressRootIncludedLanes, workInProgressRootUpdatedLanes)) {
+      // The render included lanes that were updated during the render phase.
+      // For example, when unhiding a hidden tree, we include all the lanes
+      // that were previously skipped when the tree was hidden. That set of
+      // lanes is a superset of the lanes we started rendering with.
+      //
+      // So we'll throw out the current work and restart.
+      prepareFreshStack(root, NoLanes);
+    } else if (exitStatus !== RootIncomplete) {
+      if (exitStatus === RootErrored) {
+        executionContext |= RetryAfterError; // If an error occurred during hydration,
+        // discard server response and fall back to client side render.
+
+        if (root.hydrate) {
+          root.hydrate = false;
+          clearContainer(root.containerInfo);
+        } // If something threw an error, try rendering one more time. We'll render
+        // synchronously to block concurrent data mutations, and we'll includes
+        // all pending updates are included. If it still fails after the second
+        // attempt, we'll give up and commit the resulting tree.
+
+
+        lanes = getLanesToRetrySynchronouslyOnError(root);
+
+        if (lanes !== NoLanes) {
+          exitStatus = renderRootSync(root, lanes);
+        }
+      }
+
+      if (exitStatus === RootFatalErrored) {
+        var fatalError = workInProgressRootFatalError;
+        prepareFreshStack(root, NoLanes);
+        markRootSuspended$1(root, lanes);
+        ensureRootIsScheduled(root, now());
+        throw fatalError;
+      } // We now have a consistent tree. The next step is either to commit it,
+      // or, if something suspended, wait to commit it after a timeout.
+
+
+      var finishedWork = root.current.alternate;
+      root.finishedWork = finishedWork;
+      root.finishedLanes = lanes;
+      finishConcurrentRender(root, exitStatus, lanes);
+    }
+
+    ensureRootIsScheduled(root, now());
+
+    if (root.callbackNode === originalCallbackNode) {
+      // The task node scheduled for this root is the same one that's
+      // currently executed. Need to return a continuation.
+      return performConcurrentWorkOnRoot.bind(null, root);
+    }
+
+    return null;
+  }
+
+  function finishConcurrentRender(root, exitStatus, lanes) {
+    switch (exitStatus) {
+      case RootIncomplete:
+      case RootFatalErrored:
+        {
+          {
+            {
+              throw Error( "Root did not complete. This is a bug in React." );
+            }
+          }
+        }
+      // Flow knows about invariant, so it complains if I add a break
+      // statement, but eslint doesn't know about invariant, so it complains
+      // if I do. eslint-disable-next-line no-fallthrough
+
+      case RootErrored:
+        {
+          // We should have already attempted to retry this tree. If we reached
+          // this point, it errored again. Commit it.
+          commitRoot(root);
+          break;
+        }
+
+      case RootSuspended:
+        {
+          markRootSuspended$1(root, lanes); // We have an acceptable loading state. We need to figure out if we
+          // should immediately commit it or wait a bit.
+
+          if (includesOnlyRetries(lanes) && // do not delay if we're inside an act() scope
+          !shouldForceFlushFallbacksInDEV()) {
+            // This render only included retries, no updates. Throttle committing
+            // retries so that we don't show too many loading states too quickly.
+            var msUntilTimeout = globalMostRecentFallbackTime + FALLBACK_THROTTLE_MS - now(); // Don't bother with a very short suspense time.
+
+            if (msUntilTimeout > 10) {
+              var nextLanes = getNextLanes(root, NoLanes);
+
+              if (nextLanes !== NoLanes) {
+                // There's additional work on this root.
+                break;
+              }
+
+              var suspendedLanes = root.suspendedLanes;
+
+              if (!isSubsetOfLanes(suspendedLanes, lanes)) {
+                // We should prefer to render the fallback of at the last
+                // suspended level. Ping the last suspended level to try
+                // rendering it again.
+                // FIXME: What if the suspended lanes are Idle? Should not restart.
+                var eventTime = requestEventTime();
+                markRootPinged(root, suspendedLanes);
+                break;
+              } // The render is suspended, it hasn't timed out, and there's no
+              // lower priority work to do. Instead of committing the fallback
+              // immediately, wait for more data to arrive.
+
+
+              root.timeoutHandle = scheduleTimeout(commitRoot.bind(null, root), msUntilTimeout);
+              break;
+            }
+          } // The work expired. Commit immediately.
+
+
+          commitRoot(root);
+          break;
+        }
+
+      case RootSuspendedWithDelay:
+        {
+          markRootSuspended$1(root, lanes);
+
+          if (includesOnlyTransitions(lanes)) {
+            // This is a transition, so we should exit without committing a
+            // placeholder and without scheduling a timeout. Delay indefinitely
+            // until we receive more data.
+            break;
+          }
+
+          if (!shouldForceFlushFallbacksInDEV()) {
+            // This is not a transition, but we did trigger an avoided state.
+            // Schedule a placeholder to display after a short delay, using the Just
+            // Noticeable Difference.
+            // TODO: Is the JND optimization worth the added complexity? If this is
+            // the only reason we track the event time, then probably not.
+            // Consider removing.
+            var mostRecentEventTime = getMostRecentEventTime(root, lanes);
+            var eventTimeMs = mostRecentEventTime;
+            var timeElapsedMs = now() - eventTimeMs;
+
+            var _msUntilTimeout = jnd(timeElapsedMs) - timeElapsedMs; // Don't bother with a very short suspense time.
+
+
+            if (_msUntilTimeout > 10) {
+              // Instead of committing the fallback immediately, wait for more data
+              // to arrive.
+              root.timeoutHandle = scheduleTimeout(commitRoot.bind(null, root), _msUntilTimeout);
+              break;
+            }
+          } // Commit the placeholder.
+
+
+          commitRoot(root);
+          break;
+        }
+
+      case RootCompleted:
+        {
+          // The work completed. Ready to commit.
+          commitRoot(root);
+          break;
+        }
+
+      default:
+        {
+          {
+            {
+              throw Error( "Unknown root exit status." );
+            }
+          }
+        }
+    }
+  }
+
+  function markRootSuspended$1(root, suspendedLanes) {
+    // When suspending, we should always exclude lanes that were pinged or (more
+    // rarely, since we try to avoid it) updated during the render phase.
+    // TODO: Lol maybe there's a better way to factor this besides this
+    // obnoxiously named function :)
+    suspendedLanes = removeLanes(suspendedLanes, workInProgressRootPingedLanes);
+    suspendedLanes = removeLanes(suspendedLanes, workInProgressRootUpdatedLanes);
+    markRootSuspended(root, suspendedLanes);
+  } // This is the entry point for synchronous tasks that don't go
+  // through Scheduler
+
+
+  function performSyncWorkOnRoot(root) {
+    if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+      {
+        throw Error( "Should not already be working." );
+      }
+    }
+
+    flushPassiveEffects();
+    var lanes;
+    var exitStatus;
+
+    if (root === workInProgressRoot && includesSomeLane(root.expiredLanes, workInProgressRootRenderLanes)) {
+      // There's a partial tree, and at least one of its lanes has expired. Finish
+      // rendering it before rendering the rest of the expired work.
+      lanes = workInProgressRootRenderLanes;
+      exitStatus = renderRootSync(root, lanes);
+
+      if (includesSomeLane(workInProgressRootIncludedLanes, workInProgressRootUpdatedLanes)) {
+        // The render included lanes that were updated during the render phase.
+        // For example, when unhiding a hidden tree, we include all the lanes
+        // that were previously skipped when the tree was hidden. That set of
+        // lanes is a superset of the lanes we started rendering with.
+        //
+        // Note that this only happens when part of the tree is rendered
+        // concurrently. If the whole tree is rendered synchronously, then there
+        // are no interleaved events.
+        lanes = getNextLanes(root, lanes);
+        exitStatus = renderRootSync(root, lanes);
+      }
+    } else {
+      lanes = getNextLanes(root, NoLanes);
+      exitStatus = renderRootSync(root, lanes);
+    }
+
+    if (root.tag !== LegacyRoot && exitStatus === RootErrored) {
+      executionContext |= RetryAfterError; // If an error occurred during hydration,
+      // discard server response and fall back to client side render.
+
+      if (root.hydrate) {
+        root.hydrate = false;
+        clearContainer(root.containerInfo);
+      } // If something threw an error, try rendering one more time. We'll render
+      // synchronously to block concurrent data mutations, and we'll includes
+      // all pending updates are included. If it still fails after the second
+      // attempt, we'll give up and commit the resulting tree.
+
+
+      lanes = getLanesToRetrySynchronouslyOnError(root);
+
+      if (lanes !== NoLanes) {
+        exitStatus = renderRootSync(root, lanes);
+      }
+    }
+
+    if (exitStatus === RootFatalErrored) {
+      var fatalError = workInProgressRootFatalError;
+      prepareFreshStack(root, NoLanes);
+      markRootSuspended$1(root, lanes);
+      ensureRootIsScheduled(root, now());
+      throw fatalError;
+    } // We now have a consistent tree. Because this is a sync render, we
+    // will commit it even if something suspended.
+
+
+    var finishedWork = root.current.alternate;
+    root.finishedWork = finishedWork;
+    root.finishedLanes = lanes;
+    commitRoot(root); // Before exiting, make sure there's a callback scheduled for the next
+    // pending level.
+
+    ensureRootIsScheduled(root, now());
+    return null;
+  }
+  function flushDiscreteUpdates() {
+    // TODO: Should be able to flush inside batchedUpdates, but not inside `act`.
+    // However, `act` uses `batchedUpdates`, so there's no way to distinguish
+    // those two cases. Need to fix this before exposing flushDiscreteUpdates
+    // as a public API.
+    if ((executionContext & (BatchedContext | RenderContext | CommitContext)) !== NoContext) {
+      {
+        if ((executionContext & RenderContext) !== NoContext) {
+          error('unstable_flushDiscreteUpdates: Cannot flush updates when React is ' + 'already rendering.');
+        }
+      } // We're already rendering, so we can't synchronously flush pending work.
+      // This is probably a nested event dispatch triggered by a lifecycle/effect,
+      // like `el.focus()`. Exit.
+
+
+      return;
+    }
+
+    flushPendingDiscreteUpdates(); // If the discrete updates scheduled passive effects, flush them now so that
+    // they fire before the next serial event.
+
+    flushPassiveEffects();
+  }
+
+  function flushPendingDiscreteUpdates() {
+    if (rootsWithPendingDiscreteUpdates !== null) {
+      // For each root with pending discrete updates, schedule a callback to
+      // immediately flush them.
+      var roots = rootsWithPendingDiscreteUpdates;
+      rootsWithPendingDiscreteUpdates = null;
+      roots.forEach(function (root) {
+        markDiscreteUpdatesExpired(root);
+        ensureRootIsScheduled(root, now());
+      });
+    } // Now flush the immediate queue.
+
+
+    flushSyncCallbackQueue();
+  }
+
+  function batchedUpdates$1(fn, a) {
+    var prevExecutionContext = executionContext;
+    executionContext |= BatchedContext;
+
+    try {
+      return fn(a);
+    } finally {
+      executionContext = prevExecutionContext;
+
+      if (executionContext === NoContext) {
+        // Flush the immediate callbacks that were scheduled during this batch
+        resetRenderTimer();
+        flushSyncCallbackQueue();
+      }
+    }
+  }
+  function batchedEventUpdates$1(fn, a) {
+    var prevExecutionContext = executionContext;
+    executionContext |= EventContext;
+
+    try {
+      return fn(a);
+    } finally {
+      executionContext = prevExecutionContext;
+
+      if (executionContext === NoContext) {
+        // Flush the immediate callbacks that were scheduled during this batch
+        resetRenderTimer();
+        flushSyncCallbackQueue();
+      }
+    }
+  }
+  function discreteUpdates$1(fn, a, b, c, d) {
+    var prevExecutionContext = executionContext;
+    executionContext |= DiscreteEventContext;
+
+    {
+      try {
+        return runWithPriority$1(UserBlockingPriority$2, fn.bind(null, a, b, c, d));
+      } finally {
+        executionContext = prevExecutionContext;
+
+        if (executionContext === NoContext) {
+          // Flush the immediate callbacks that were scheduled during this batch
+          resetRenderTimer();
+          flushSyncCallbackQueue();
+        }
+      }
+    }
+  }
+  function unbatchedUpdates(fn, a) {
+    var prevExecutionContext = executionContext;
+    executionContext &= ~BatchedContext;
+    executionContext |= LegacyUnbatchedContext;
+
+    try {
+      return fn(a);
+    } finally {
+      executionContext = prevExecutionContext;
+
+      if (executionContext === NoContext) {
+        // Flush the immediate callbacks that were scheduled during this batch
+        resetRenderTimer();
+        flushSyncCallbackQueue();
+      }
+    }
+  }
+  function flushSync(fn, a) {
+    var prevExecutionContext = executionContext;
+
+    if ((prevExecutionContext & (RenderContext | CommitContext)) !== NoContext) {
+      {
+        error('flushSync was called from inside a lifecycle method. React cannot ' + 'flush when React is already rendering. Consider moving this call to ' + 'a scheduler task or micro task.');
+      }
+
+      return fn(a);
+    }
+
+    executionContext |= BatchedContext;
+
+    {
+      try {
+        if (fn) {
+          return runWithPriority$1(ImmediatePriority$1, fn.bind(null, a));
+        } else {
+          return undefined;
+        }
+      } finally {
+        executionContext = prevExecutionContext; // Flush the immediate callbacks that were scheduled during this batch.
+        // Note that this will happen even if batchedUpdates is higher up
+        // the stack.
+
+        flushSyncCallbackQueue();
+      }
+    }
+  }
+  function pushRenderLanes(fiber, lanes) {
+    push(subtreeRenderLanesCursor, subtreeRenderLanes, fiber);
+    subtreeRenderLanes = mergeLanes(subtreeRenderLanes, lanes);
+    workInProgressRootIncludedLanes = mergeLanes(workInProgressRootIncludedLanes, lanes);
+  }
+  function popRenderLanes(fiber) {
+    subtreeRenderLanes = subtreeRenderLanesCursor.current;
+    pop(subtreeRenderLanesCursor, fiber);
+  }
+
+  function prepareFreshStack(root, lanes) {
+    root.finishedWork = null;
+    root.finishedLanes = NoLanes;
+    var timeoutHandle = root.timeoutHandle;
+
+    if (timeoutHandle !== noTimeout) {
+      // The root previous suspended and scheduled a timeout to commit a fallback
+      // state. Now that we have additional work, cancel the timeout.
+      root.timeoutHandle = noTimeout; // $FlowFixMe Complains noTimeout is not a TimeoutID, despite the check above
+
+      cancelTimeout(timeoutHandle);
+    }
+
+    if (workInProgress !== null) {
+      var interruptedWork = workInProgress.return;
+
+      while (interruptedWork !== null) {
+        unwindInterruptedWork(interruptedWork);
+        interruptedWork = interruptedWork.return;
+      }
+    }
+
+    workInProgressRoot = root;
+    workInProgress = createWorkInProgress(root.current, null);
+    workInProgressRootRenderLanes = subtreeRenderLanes = workInProgressRootIncludedLanes = lanes;
+    workInProgressRootExitStatus = RootIncomplete;
+    workInProgressRootFatalError = null;
+    workInProgressRootSkippedLanes = NoLanes;
+    workInProgressRootUpdatedLanes = NoLanes;
+    workInProgressRootPingedLanes = NoLanes;
+
+    {
+      spawnedWorkDuringRender = null;
+    }
+
+    {
+      ReactStrictModeWarnings.discardPendingWarnings();
+    }
+  }
+
+  function handleError(root, thrownValue) {
+    do {
+      var erroredWork = workInProgress;
+
+      try {
+        // Reset module-level state that was set during the render phase.
+        resetContextDependencies();
+        resetHooksAfterThrow();
+        resetCurrentFiber(); // TODO: I found and added this missing line while investigating a
+        // separate issue. Write a regression test using string refs.
+
+        ReactCurrentOwner$2.current = null;
+
+        if (erroredWork === null || erroredWork.return === null) {
+          // Expected to be working on a non-root fiber. This is a fatal error
+          // because there's no ancestor that can handle it; the root is
+          // supposed to capture all errors that weren't caught by an error
+          // boundary.
+          workInProgressRootExitStatus = RootFatalErrored;
+          workInProgressRootFatalError = thrownValue; // Set `workInProgress` to null. This represents advancing to the next
+          // sibling, or the parent if there are no siblings. But since the root
+          // has no siblings nor a parent, we set it to null. Usually this is
+          // handled by `completeUnitOfWork` or `unwindWork`, but since we're
+          // intentionally not calling those, we need set it here.
+          // TODO: Consider calling `unwindWork` to pop the contexts.
+
+          workInProgress = null;
+          return;
+        }
+
+        if (enableProfilerTimer && erroredWork.mode & ProfileMode) {
+          // Record the time spent rendering before an error was thrown. This
+          // avoids inaccurate Profiler durations in the case of a
+          // suspended render.
+          stopProfilerTimerIfRunningAndRecordDelta(erroredWork, true);
+        }
+
+        throwException(root, erroredWork.return, erroredWork, thrownValue, workInProgressRootRenderLanes);
+        completeUnitOfWork(erroredWork);
+      } catch (yetAnotherThrownValue) {
+        // Something in the return path also threw.
+        thrownValue = yetAnotherThrownValue;
+
+        if (workInProgress === erroredWork && erroredWork !== null) {
+          // If this boundary has already errored, then we had trouble processing
+          // the error. Bubble it to the next boundary.
+          erroredWork = erroredWork.return;
+          workInProgress = erroredWork;
+        } else {
+          erroredWork = workInProgress;
+        }
+
+        continue;
+      } // Return to the normal work loop.
+
+
+      return;
+    } while (true);
+  }
+
+  function pushDispatcher() {
+    var prevDispatcher = ReactCurrentDispatcher$2.current;
+    ReactCurrentDispatcher$2.current = ContextOnlyDispatcher;
+
+    if (prevDispatcher === null) {
+      // The React isomorphic package does not include a default dispatcher.
+      // Instead the first renderer will lazily attach one, in order to give
+      // nicer error messages.
+      return ContextOnlyDispatcher;
+    } else {
+      return prevDispatcher;
+    }
+  }
+
+  function popDispatcher(prevDispatcher) {
+    ReactCurrentDispatcher$2.current = prevDispatcher;
+  }
+
+  function pushInteractions(root) {
+    {
+      var prevInteractions = __interactionsRef.current;
+      __interactionsRef.current = root.memoizedInteractions;
+      return prevInteractions;
+    }
+  }
+
+  function popInteractions(prevInteractions) {
+    {
+      __interactionsRef.current = prevInteractions;
+    }
+  }
+
+  function markCommitTimeOfFallback() {
+    globalMostRecentFallbackTime = now();
+  }
+  function markSkippedUpdateLanes(lane) {
+    workInProgressRootSkippedLanes = mergeLanes(lane, workInProgressRootSkippedLanes);
+  }
+  function renderDidSuspend() {
+    if (workInProgressRootExitStatus === RootIncomplete) {
+      workInProgressRootExitStatus = RootSuspended;
+    }
+  }
+  function renderDidSuspendDelayIfPossible() {
+    if (workInProgressRootExitStatus === RootIncomplete || workInProgressRootExitStatus === RootSuspended) {
+      workInProgressRootExitStatus = RootSuspendedWithDelay;
+    } // Check if there are updates that we skipped tree that might have unblocked
+    // this render.
+
+
+    if (workInProgressRoot !== null && (includesNonIdleWork(workInProgressRootSkippedLanes) || includesNonIdleWork(workInProgressRootUpdatedLanes))) {
+      // Mark the current render as suspended so that we switch to working on
+      // the updates that were skipped. Usually we only suspend at the end of
+      // the render phase.
+      // TODO: We should probably always mark the root as suspended immediately
+      // (inside this function), since by suspending at the end of the render
+      // phase introduces a potential mistake where we suspend lanes that were
+      // pinged or updated while we were rendering.
+      markRootSuspended$1(workInProgressRoot, workInProgressRootRenderLanes);
+    }
+  }
+  function renderDidError() {
+    if (workInProgressRootExitStatus !== RootCompleted) {
+      workInProgressRootExitStatus = RootErrored;
+    }
+  } // Called during render to determine if anything has suspended.
+  // Returns false if we're not sure.
+
+  function renderHasNotSuspendedYet() {
+    // If something errored or completed, we can't really be sure,
+    // so those are false.
+    return workInProgressRootExitStatus === RootIncomplete;
+  }
+
+  function renderRootSync(root, lanes) {
+    var prevExecutionContext = executionContext;
+    executionContext |= RenderContext;
+    var prevDispatcher = pushDispatcher(); // If the root or lanes have changed, throw out the existing stack
+    // and prepare a fresh one. Otherwise we'll continue where we left off.
+
+    if (workInProgressRoot !== root || workInProgressRootRenderLanes !== lanes) {
+      prepareFreshStack(root, lanes);
+      startWorkOnPendingInteractions(root, lanes);
+    }
+
+    var prevInteractions = pushInteractions(root);
+
+    do {
+      try {
+        workLoopSync();
+        break;
+      } catch (thrownValue) {
+        handleError(root, thrownValue);
+      }
+    } while (true);
+
+    resetContextDependencies();
+
+    {
+      popInteractions(prevInteractions);
+    }
+
+    executionContext = prevExecutionContext;
+    popDispatcher(prevDispatcher);
+
+    if (workInProgress !== null) {
+      // This is a sync render, so we should have finished the whole tree.
+      {
+        {
+          throw Error( "Cannot commit an incomplete root. This error is likely caused by a bug in React. Please file an issue." );
+        }
+      }
+    }
+
+
+    workInProgressRoot = null;
+    workInProgressRootRenderLanes = NoLanes;
+    return workInProgressRootExitStatus;
+  } // The work loop is an extremely hot path. Tell Closure not to inline it.
+
+  /** @noinline */
+
+
+  function workLoopSync() {
+    // Already timed out, so perform work without checking if we need to yield.
+    while (workInProgress !== null) {
+      performUnitOfWork(workInProgress);
+    }
+  }
+
+  function renderRootConcurrent(root, lanes) {
+    var prevExecutionContext = executionContext;
+    executionContext |= RenderContext;
+    var prevDispatcher = pushDispatcher(); // If the root or lanes have changed, throw out the existing stack
+    // and prepare a fresh one. Otherwise we'll continue where we left off.
+
+    if (workInProgressRoot !== root || workInProgressRootRenderLanes !== lanes) {
+      resetRenderTimer();
+      prepareFreshStack(root, lanes);
+      startWorkOnPendingInteractions(root, lanes);
+    }
+
+    var prevInteractions = pushInteractions(root);
+
+    do {
+      try {
+        workLoopConcurrent();
+        break;
+      } catch (thrownValue) {
+        handleError(root, thrownValue);
+      }
+    } while (true);
+
+    resetContextDependencies();
+
+    {
+      popInteractions(prevInteractions);
+    }
+
+    popDispatcher(prevDispatcher);
+    executionContext = prevExecutionContext;
+
+
+    if (workInProgress !== null) {
+
+      return RootIncomplete;
+    } else {
+
+
+      workInProgressRoot = null;
+      workInProgressRootRenderLanes = NoLanes; // Return the final exit status.
+
+      return workInProgressRootExitStatus;
+    }
+  }
+  /** @noinline */
+
+
+  function workLoopConcurrent() {
+    // Perform work until Scheduler asks us to yield
+    while (workInProgress !== null && !shouldYield()) {
+      performUnitOfWork(workInProgress);
+    }
+  }
+
+  function performUnitOfWork(unitOfWork) {
+    // The current, flushed, state of this fiber is the alternate. Ideally
+    // nothing should rely on this, but relying on it here means that we don't
+    // need an additional field on the work in progress.
+    var current = unitOfWork.alternate;
+    setCurrentFiber(unitOfWork);
+    var next;
+
+    if ( (unitOfWork.mode & ProfileMode) !== NoMode) {
+      startProfilerTimer(unitOfWork);
+      next = beginWork$1(current, unitOfWork, subtreeRenderLanes);
+      stopProfilerTimerIfRunningAndRecordDelta(unitOfWork, true);
+    } else {
+      next = beginWork$1(current, unitOfWork, subtreeRenderLanes);
+    }
+
+    resetCurrentFiber();
+    unitOfWork.memoizedProps = unitOfWork.pendingProps;
+
+    if (next === null) {
+      // If this doesn't spawn new work, complete the current work.
+      completeUnitOfWork(unitOfWork);
+    } else {
+      workInProgress = next;
+    }
+
+    ReactCurrentOwner$2.current = null;
+  }
+
+  function completeUnitOfWork(unitOfWork) {
+    // Attempt to complete the current unit of work, then move to the next
+    // sibling. If there are no more siblings, return to the parent fiber.
+    var completedWork = unitOfWork;
+
+    do {
+      // The current, flushed, state of this fiber is the alternate. Ideally
+      // nothing should rely on this, but relying on it here means that we don't
+      // need an additional field on the work in progress.
+      var current = completedWork.alternate;
+      var returnFiber = completedWork.return; // Check if the work completed or if something threw.
+
+      if ((completedWork.flags & Incomplete) === NoFlags) {
+        setCurrentFiber(completedWork);
+        var next = void 0;
+
+        if ( (completedWork.mode & ProfileMode) === NoMode) {
+          next = completeWork(current, completedWork, subtreeRenderLanes);
+        } else {
+          startProfilerTimer(completedWork);
+          next = completeWork(current, completedWork, subtreeRenderLanes); // Update render duration assuming we didn't error.
+
+          stopProfilerTimerIfRunningAndRecordDelta(completedWork, false);
+        }
+
+        resetCurrentFiber();
+
+        if (next !== null) {
+          // Completing this fiber spawned new work. Work on that next.
+          workInProgress = next;
+          return;
+        }
+
+        resetChildLanes(completedWork);
+
+        if (returnFiber !== null && // Do not append effects to parents if a sibling failed to complete
+        (returnFiber.flags & Incomplete) === NoFlags) {
+          // Append all the effects of the subtree and this fiber onto the effect
+          // list of the parent. The completion order of the children affects the
+          // side-effect order.
+          if (returnFiber.firstEffect === null) {
+            returnFiber.firstEffect = completedWork.firstEffect;
+          }
+
+          if (completedWork.lastEffect !== null) {
+            if (returnFiber.lastEffect !== null) {
+              returnFiber.lastEffect.nextEffect = completedWork.firstEffect;
+            }
+
+            returnFiber.lastEffect = completedWork.lastEffect;
+          } // If this fiber had side-effects, we append it AFTER the children's
+          // side-effects. We can perform certain side-effects earlier if needed,
+          // by doing multiple passes over the effect list. We don't want to
+          // schedule our own side-effect on our own list because if end up
+          // reusing children we'll schedule this effect onto itself since we're
+          // at the end.
+
+
+          var flags = completedWork.flags; // Skip both NoWork and PerformedWork tags when creating the effect
+          // list. PerformedWork effect is read by React DevTools but shouldn't be
+          // committed.
+
+          if (flags > PerformedWork) {
+            if (returnFiber.lastEffect !== null) {
+              returnFiber.lastEffect.nextEffect = completedWork;
+            } else {
+              returnFiber.firstEffect = completedWork;
+            }
+
+            returnFiber.lastEffect = completedWork;
+          }
+        }
+      } else {
+        // This fiber did not complete because something threw. Pop values off
+        // the stack without entering the complete phase. If this is a boundary,
+        // capture values if possible.
+        var _next = unwindWork(completedWork); // Because this fiber did not complete, don't reset its expiration time.
+
+
+        if (_next !== null) {
+          // If completing this work spawned new work, do that next. We'll come
+          // back here again.
+          // Since we're restarting, remove anything that is not a host effect
+          // from the effect tag.
+          _next.flags &= HostEffectMask;
+          workInProgress = _next;
+          return;
+        }
+
+        if ( (completedWork.mode & ProfileMode) !== NoMode) {
+          // Record the render duration for the fiber that errored.
+          stopProfilerTimerIfRunningAndRecordDelta(completedWork, false); // Include the time spent working on failed children before continuing.
+
+          var actualDuration = completedWork.actualDuration;
+          var child = completedWork.child;
+
+          while (child !== null) {
+            actualDuration += child.actualDuration;
+            child = child.sibling;
+          }
+
+          completedWork.actualDuration = actualDuration;
+        }
+
+        if (returnFiber !== null) {
+          // Mark the parent fiber as incomplete and clear its effect list.
+          returnFiber.firstEffect = returnFiber.lastEffect = null;
+          returnFiber.flags |= Incomplete;
+        }
+      }
+
+      var siblingFiber = completedWork.sibling;
+
+      if (siblingFiber !== null) {
+        // If there is more work to do in this returnFiber, do that next.
+        workInProgress = siblingFiber;
+        return;
+      } // Otherwise, return to the parent
+
+
+      completedWork = returnFiber; // Update the next thing we're working on in case something throws.
+
+      workInProgress = completedWork;
+    } while (completedWork !== null); // We've reached the root.
+
+
+    if (workInProgressRootExitStatus === RootIncomplete) {
+      workInProgressRootExitStatus = RootCompleted;
+    }
+  }
+
+  function resetChildLanes(completedWork) {
+    if ( // TODO: Move this check out of the hot path by moving `resetChildLanes`
+    // to switch statement in `completeWork`.
+    (completedWork.tag === LegacyHiddenComponent || completedWork.tag === OffscreenComponent) && completedWork.memoizedState !== null && !includesSomeLane(subtreeRenderLanes, OffscreenLane) && (completedWork.mode & ConcurrentMode) !== NoLanes) {
+      // The children of this component are hidden. Don't bubble their
+      // expiration times.
+      return;
+    }
+
+    var newChildLanes = NoLanes; // Bubble up the earliest expiration time.
+
+    if ( (completedWork.mode & ProfileMode) !== NoMode) {
+      // In profiling mode, resetChildExpirationTime is also used to reset
+      // profiler durations.
+      var actualDuration = completedWork.actualDuration;
+      var treeBaseDuration = completedWork.selfBaseDuration; // When a fiber is cloned, its actualDuration is reset to 0. This value will
+      // only be updated if work is done on the fiber (i.e. it doesn't bailout).
+      // When work is done, it should bubble to the parent's actualDuration. If
+      // the fiber has not been cloned though, (meaning no work was done), then
+      // this value will reflect the amount of time spent working on a previous
+      // render. In that case it should not bubble. We determine whether it was
+      // cloned by comparing the child pointer.
+
+      var shouldBubbleActualDurations = completedWork.alternate === null || completedWork.child !== completedWork.alternate.child;
+      var child = completedWork.child;
+
+      while (child !== null) {
+        newChildLanes = mergeLanes(newChildLanes, mergeLanes(child.lanes, child.childLanes));
+
+        if (shouldBubbleActualDurations) {
+          actualDuration += child.actualDuration;
+        }
+
+        treeBaseDuration += child.treeBaseDuration;
+        child = child.sibling;
+      }
+
+      var isTimedOutSuspense = completedWork.tag === SuspenseComponent && completedWork.memoizedState !== null;
+
+      if (isTimedOutSuspense) {
+        // Don't count time spent in a timed out Suspense subtree as part of the base duration.
+        var primaryChildFragment = completedWork.child;
+
+        if (primaryChildFragment !== null) {
+          treeBaseDuration -= primaryChildFragment.treeBaseDuration;
+        }
+      }
+
+      completedWork.actualDuration = actualDuration;
+      completedWork.treeBaseDuration = treeBaseDuration;
+    } else {
+      var _child = completedWork.child;
+
+      while (_child !== null) {
+        newChildLanes = mergeLanes(newChildLanes, mergeLanes(_child.lanes, _child.childLanes));
+        _child = _child.sibling;
+      }
+    }
+
+    completedWork.childLanes = newChildLanes;
+  }
+
+  function commitRoot(root) {
+    var renderPriorityLevel = getCurrentPriorityLevel();
+    runWithPriority$1(ImmediatePriority$1, commitRootImpl.bind(null, root, renderPriorityLevel));
+    return null;
+  }
+
+  function commitRootImpl(root, renderPriorityLevel) {
+    do {
+      // `flushPassiveEffects` will call `flushSyncUpdateQueue` at the end, which
+      // means `flushPassiveEffects` will sometimes result in additional
+      // passive effects. So we need to keep flushing in a loop until there are
+      // no more pending effects.
+      // TODO: Might be better if `flushPassiveEffects` did not automatically
+      // flush synchronous work at the end, to avoid factoring hazards like this.
+      flushPassiveEffects();
+    } while (rootWithPendingPassiveEffects !== null);
+
+    flushRenderPhaseStrictModeWarningsInDEV();
+
+    if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+      {
+        throw Error( "Should not already be working." );
+      }
+    }
+
+    var finishedWork = root.finishedWork;
+    var lanes = root.finishedLanes;
+
+    if (finishedWork === null) {
+
+      return null;
+    }
+
+    root.finishedWork = null;
+    root.finishedLanes = NoLanes;
+
+    if (!(finishedWork !== root.current)) {
+      {
+        throw Error( "Cannot commit the same tree as before. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    } // commitRoot never returns a continuation; it always finishes synchronously.
+    // So we can clear these now to allow a new callback to be scheduled.
+
+
+    root.callbackNode = null; // Update the first and last pending times on this root. The new first
+    // pending time is whatever is left on the root fiber.
+
+    var remainingLanes = mergeLanes(finishedWork.lanes, finishedWork.childLanes);
+    markRootFinished(root, remainingLanes); // Clear already finished discrete updates in case that a later call of
+    // `flushDiscreteUpdates` starts a useless render pass which may cancels
+    // a scheduled timeout.
+
+    if (rootsWithPendingDiscreteUpdates !== null) {
+      if (!hasDiscreteLanes(remainingLanes) && rootsWithPendingDiscreteUpdates.has(root)) {
+        rootsWithPendingDiscreteUpdates.delete(root);
+      }
+    }
+
+    if (root === workInProgressRoot) {
+      // We can reset these now that they are finished.
+      workInProgressRoot = null;
+      workInProgress = null;
+      workInProgressRootRenderLanes = NoLanes;
+    } // Get the list of effects.
+
+
+    var firstEffect;
+
+    if (finishedWork.flags > PerformedWork) {
+      // A fiber's effect list consists only of its children, not itself. So if
+      // the root has an effect, we need to add it to the end of the list. The
+      // resulting list is the set that would belong to the root's parent, if it
+      // had one; that is, all the effects in the tree including the root.
+      if (finishedWork.lastEffect !== null) {
+        finishedWork.lastEffect.nextEffect = finishedWork;
+        firstEffect = finishedWork.firstEffect;
+      } else {
+        firstEffect = finishedWork;
+      }
+    } else {
+      // There is no effect on the root.
+      firstEffect = finishedWork.firstEffect;
+    }
+
+    if (firstEffect !== null) {
+
+      var prevExecutionContext = executionContext;
+      executionContext |= CommitContext;
+      var prevInteractions = pushInteractions(root); // Reset this to null before calling lifecycles
+
+      ReactCurrentOwner$2.current = null; // The commit phase is broken into several sub-phases. We do a separate pass
+      // of the effect list for each phase: all mutation effects come before all
+      // layout effects, and so on.
+      // The first phase a "before mutation" phase. We use this phase to read the
+      // state of the host tree right before we mutate it. This is where
+      // getSnapshotBeforeUpdate is called.
+
+      focusedInstanceHandle = prepareForCommit(root.containerInfo);
+      shouldFireAfterActiveInstanceBlur = false;
+      nextEffect = firstEffect;
+
+      do {
+        {
+          invokeGuardedCallback(null, commitBeforeMutationEffects, null);
+
+          if (hasCaughtError()) {
+            if (!(nextEffect !== null)) {
+              {
+                throw Error( "Should be working on an effect." );
+              }
+            }
+
+            var error = clearCaughtError();
+            captureCommitPhaseError(nextEffect, error);
+            nextEffect = nextEffect.nextEffect;
+          }
+        }
+      } while (nextEffect !== null); // We no longer need to track the active instance fiber
+
+
+      focusedInstanceHandle = null;
+
+      {
+        // Mark the current commit time to be shared by all Profilers in this
+        // batch. This enables them to be grouped later.
+        recordCommitTime();
+      } // The next phase is the mutation phase, where we mutate the host tree.
+
+
+      nextEffect = firstEffect;
+
+      do {
+        {
+          invokeGuardedCallback(null, commitMutationEffects, null, root, renderPriorityLevel);
+
+          if (hasCaughtError()) {
+            if (!(nextEffect !== null)) {
+              {
+                throw Error( "Should be working on an effect." );
+              }
+            }
+
+            var _error = clearCaughtError();
+
+            captureCommitPhaseError(nextEffect, _error);
+            nextEffect = nextEffect.nextEffect;
+          }
+        }
+      } while (nextEffect !== null);
+
+      resetAfterCommit(root.containerInfo); // The work-in-progress tree is now the current tree. This must come after
+      // the mutation phase, so that the previous tree is still current during
+      // componentWillUnmount, but before the layout phase, so that the finished
+      // work is current during componentDidMount/Update.
+
+      root.current = finishedWork; // The next phase is the layout phase, where we call effects that read
+      // the host tree after it's been mutated. The idiomatic use case for this is
+      // layout, but class component lifecycles also fire here for legacy reasons.
+
+      nextEffect = firstEffect;
+
+      do {
+        {
+          invokeGuardedCallback(null, commitLayoutEffects, null, root, lanes);
+
+          if (hasCaughtError()) {
+            if (!(nextEffect !== null)) {
+              {
+                throw Error( "Should be working on an effect." );
+              }
+            }
+
+            var _error2 = clearCaughtError();
+
+            captureCommitPhaseError(nextEffect, _error2);
+            nextEffect = nextEffect.nextEffect;
+          }
+        }
+      } while (nextEffect !== null);
+
+      nextEffect = null; // Tell Scheduler to yield at the end of the frame, so the browser has an
+      // opportunity to paint.
+
+      requestPaint();
+
+      {
+        popInteractions(prevInteractions);
+      }
+
+      executionContext = prevExecutionContext;
+    } else {
+      // No effects.
+      root.current = finishedWork; // Measure these anyway so the flamegraph explicitly shows that there were
+      // no effects.
+      // TODO: Maybe there's a better way to report this.
+
+      {
+        recordCommitTime();
+      }
+    }
+
+    var rootDidHavePassiveEffects = rootDoesHavePassiveEffects;
+
+    if (rootDoesHavePassiveEffects) {
+      // This commit has passive effects. Stash a reference to them. But don't
+      // schedule a callback until after flushing layout work.
+      rootDoesHavePassiveEffects = false;
+      rootWithPendingPassiveEffects = root;
+      pendingPassiveEffectsLanes = lanes;
+      pendingPassiveEffectsRenderPriority = renderPriorityLevel;
+    } else {
+      // We are done with the effect chain at this point so let's clear the
+      // nextEffect pointers to assist with GC. If we have passive effects, we'll
+      // clear this in flushPassiveEffects.
+      nextEffect = firstEffect;
+
+      while (nextEffect !== null) {
+        var nextNextEffect = nextEffect.nextEffect;
+        nextEffect.nextEffect = null;
+
+        if (nextEffect.flags & Deletion) {
+          detachFiberAfterEffects(nextEffect);
+        }
+
+        nextEffect = nextNextEffect;
+      }
+    } // Read this again, since an effect might have updated it
+
+
+    remainingLanes = root.pendingLanes; // Check if there's remaining work on this root
+
+    if (remainingLanes !== NoLanes) {
+      {
+        if (spawnedWorkDuringRender !== null) {
+          var expirationTimes = spawnedWorkDuringRender;
+          spawnedWorkDuringRender = null;
+
+          for (var i = 0; i < expirationTimes.length; i++) {
+            scheduleInteractions(root, expirationTimes[i], root.memoizedInteractions);
+          }
+        }
+
+        schedulePendingInteractions(root, remainingLanes);
+      }
+    } else {
+      // If there's no remaining work, we can clear the set of already failed
+      // error boundaries.
+      legacyErrorBoundariesThatAlreadyFailed = null;
+    }
+
+    {
+      if (!rootDidHavePassiveEffects) {
+        // If there are no passive effects, then we can complete the pending interactions.
+        // Otherwise, we'll wait until after the passive effects are flushed.
+        // Wait to do this until after remaining work has been scheduled,
+        // so that we don't prematurely signal complete for interactions when there's e.g. hidden work.
+        finishPendingInteractions(root, lanes);
+      }
+    }
+
+    if (remainingLanes === SyncLane) {
+      // Count the number of times the root synchronously re-renders without
+      // finishing. If there are too many, it indicates an infinite update loop.
+      if (root === rootWithNestedUpdates) {
+        nestedUpdateCount++;
+      } else {
+        nestedUpdateCount = 0;
+        rootWithNestedUpdates = root;
+      }
+    } else {
+      nestedUpdateCount = 0;
+    }
+
+    onCommitRoot(finishedWork.stateNode, renderPriorityLevel);
+
+    {
+      onCommitRoot$1();
+    } // Always call this before exiting `commitRoot`, to ensure that any
+    // additional work on this root is scheduled.
+
+
+    ensureRootIsScheduled(root, now());
+
+    if (hasUncaughtError) {
+      hasUncaughtError = false;
+      var _error3 = firstUncaughtError;
+      firstUncaughtError = null;
+      throw _error3;
+    }
+
+    if ((executionContext & LegacyUnbatchedContext) !== NoContext) {
+      // a ReactDOM.render-ed root inside of batchedUpdates. The commit fired
+      // synchronously, but layout updates should be deferred until the end
+      // of the batch.
+
+
+      return null;
+    } // If layout work was scheduled, flush it now.
+
+
+    flushSyncCallbackQueue();
+
+    return null;
+  }
+
+  function commitBeforeMutationEffects() {
+    while (nextEffect !== null) {
+      var current = nextEffect.alternate;
+
+      if (!shouldFireAfterActiveInstanceBlur && focusedInstanceHandle !== null) {
+        if ((nextEffect.flags & Deletion) !== NoFlags) {
+          if (doesFiberContain(nextEffect, focusedInstanceHandle)) {
+            shouldFireAfterActiveInstanceBlur = true;
+          }
+        } else {
+          // TODO: Move this out of the hot path using a dedicated effect tag.
+          if (nextEffect.tag === SuspenseComponent && isSuspenseBoundaryBeingHidden(current, nextEffect) && doesFiberContain(nextEffect, focusedInstanceHandle)) {
+            shouldFireAfterActiveInstanceBlur = true;
+          }
+        }
+      }
+
+      var flags = nextEffect.flags;
+
+      if ((flags & Snapshot) !== NoFlags) {
+        setCurrentFiber(nextEffect);
+        commitBeforeMutationLifeCycles(current, nextEffect);
+        resetCurrentFiber();
+      }
+
+      if ((flags & Passive) !== NoFlags) {
+        // If there are passive effects, schedule a callback to flush at
+        // the earliest opportunity.
+        if (!rootDoesHavePassiveEffects) {
+          rootDoesHavePassiveEffects = true;
+          scheduleCallback(NormalPriority$1, function () {
+            flushPassiveEffects();
+            return null;
+          });
+        }
+      }
+
+      nextEffect = nextEffect.nextEffect;
+    }
+  }
+
+  function commitMutationEffects(root, renderPriorityLevel) {
+    // TODO: Should probably move the bulk of this function to commitWork.
+    while (nextEffect !== null) {
+      setCurrentFiber(nextEffect);
+      var flags = nextEffect.flags;
+
+      if (flags & ContentReset) {
+        commitResetTextContent(nextEffect);
+      }
+
+      if (flags & Ref) {
+        var current = nextEffect.alternate;
+
+        if (current !== null) {
+          commitDetachRef(current);
+        }
+      } // The following switch statement is only concerned about placement,
+      // updates, and deletions. To avoid needing to add a case for every possible
+      // bitmap value, we remove the secondary effects from the effect tag and
+      // switch on that value.
+
+
+      var primaryFlags = flags & (Placement | Update | Deletion | Hydrating);
+
+      switch (primaryFlags) {
+        case Placement:
+          {
+            commitPlacement(nextEffect); // Clear the "placement" from effect tag so that we know that this is
+            // inserted, before any life-cycles like componentDidMount gets called.
+            // TODO: findDOMNode doesn't rely on this any more but isMounted does
+            // and isMounted is deprecated anyway so we should be able to kill this.
+
+            nextEffect.flags &= ~Placement;
+            break;
+          }
+
+        case PlacementAndUpdate:
+          {
+            // Placement
+            commitPlacement(nextEffect); // Clear the "placement" from effect tag so that we know that this is
+            // inserted, before any life-cycles like componentDidMount gets called.
+
+            nextEffect.flags &= ~Placement; // Update
+
+            var _current = nextEffect.alternate;
+            commitWork(_current, nextEffect);
+            break;
+          }
+
+        case Hydrating:
+          {
+            nextEffect.flags &= ~Hydrating;
+            break;
+          }
+
+        case HydratingAndUpdate:
+          {
+            nextEffect.flags &= ~Hydrating; // Update
+
+            var _current2 = nextEffect.alternate;
+            commitWork(_current2, nextEffect);
+            break;
+          }
+
+        case Update:
+          {
+            var _current3 = nextEffect.alternate;
+            commitWork(_current3, nextEffect);
+            break;
+          }
+
+        case Deletion:
+          {
+            commitDeletion(root, nextEffect);
+            break;
+          }
+      }
+
+      resetCurrentFiber();
+      nextEffect = nextEffect.nextEffect;
+    }
+  }
+
+  function commitLayoutEffects(root, committedLanes) {
+
+
+    while (nextEffect !== null) {
+      setCurrentFiber(nextEffect);
+      var flags = nextEffect.flags;
+
+      if (flags & (Update | Callback)) {
+        var current = nextEffect.alternate;
+        commitLifeCycles(root, current, nextEffect);
+      }
+
+      {
+        if (flags & Ref) {
+          commitAttachRef(nextEffect);
+        }
+      }
+
+      resetCurrentFiber();
+      nextEffect = nextEffect.nextEffect;
+    }
+  }
+
+  function flushPassiveEffects() {
+    // Returns whether passive effects were flushed.
+    if (pendingPassiveEffectsRenderPriority !== NoPriority$1) {
+      var priorityLevel = pendingPassiveEffectsRenderPriority > NormalPriority$1 ? NormalPriority$1 : pendingPassiveEffectsRenderPriority;
+      pendingPassiveEffectsRenderPriority = NoPriority$1;
+
+      {
+        return runWithPriority$1(priorityLevel, flushPassiveEffectsImpl);
+      }
+    }
+
+    return false;
+  }
+  function enqueuePendingPassiveHookEffectMount(fiber, effect) {
+    pendingPassiveHookEffectsMount.push(effect, fiber);
+
+    if (!rootDoesHavePassiveEffects) {
+      rootDoesHavePassiveEffects = true;
+      scheduleCallback(NormalPriority$1, function () {
+        flushPassiveEffects();
+        return null;
+      });
+    }
+  }
+  function enqueuePendingPassiveHookEffectUnmount(fiber, effect) {
+    pendingPassiveHookEffectsUnmount.push(effect, fiber);
+
+    {
+      fiber.flags |= PassiveUnmountPendingDev;
+      var alternate = fiber.alternate;
+
+      if (alternate !== null) {
+        alternate.flags |= PassiveUnmountPendingDev;
+      }
+    }
+
+    if (!rootDoesHavePassiveEffects) {
+      rootDoesHavePassiveEffects = true;
+      scheduleCallback(NormalPriority$1, function () {
+        flushPassiveEffects();
+        return null;
+      });
+    }
+  }
+
+  function invokePassiveEffectCreate(effect) {
+    var create = effect.create;
+    effect.destroy = create();
+  }
+
+  function flushPassiveEffectsImpl() {
+    if (rootWithPendingPassiveEffects === null) {
+      return false;
+    }
+
+    var root = rootWithPendingPassiveEffects;
+    var lanes = pendingPassiveEffectsLanes;
+    rootWithPendingPassiveEffects = null;
+    pendingPassiveEffectsLanes = NoLanes;
+
+    if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+      {
+        throw Error( "Cannot flush passive effects while already rendering." );
+      }
+    }
+
+    {
+      isFlushingPassiveEffects = true;
+    }
+
+    var prevExecutionContext = executionContext;
+    executionContext |= CommitContext;
+    var prevInteractions = pushInteractions(root); // It's important that ALL pending passive effect destroy functions are called
+    // before ANY passive effect create functions are called.
+    // Otherwise effects in sibling components might interfere with each other.
+    // e.g. a destroy function in one component may unintentionally override a ref
+    // value set by a create function in another component.
+    // Layout effects have the same constraint.
+    // First pass: Destroy stale passive effects.
+
+    var unmountEffects = pendingPassiveHookEffectsUnmount;
+    pendingPassiveHookEffectsUnmount = [];
+
+    for (var i = 0; i < unmountEffects.length; i += 2) {
+      var _effect = unmountEffects[i];
+      var fiber = unmountEffects[i + 1];
+      var destroy = _effect.destroy;
+      _effect.destroy = undefined;
+
+      {
+        fiber.flags &= ~PassiveUnmountPendingDev;
+        var alternate = fiber.alternate;
+
+        if (alternate !== null) {
+          alternate.flags &= ~PassiveUnmountPendingDev;
+        }
+      }
+
+      if (typeof destroy === 'function') {
+        {
+          setCurrentFiber(fiber);
+
+          {
+            invokeGuardedCallback(null, destroy, null);
+          }
+
+          if (hasCaughtError()) {
+            if (!(fiber !== null)) {
+              {
+                throw Error( "Should be working on an effect." );
+              }
+            }
+
+            var error = clearCaughtError();
+            captureCommitPhaseError(fiber, error);
+          }
+
+          resetCurrentFiber();
+        }
+      }
+    } // Second pass: Create new passive effects.
+
+
+    var mountEffects = pendingPassiveHookEffectsMount;
+    pendingPassiveHookEffectsMount = [];
+
+    for (var _i = 0; _i < mountEffects.length; _i += 2) {
+      var _effect2 = mountEffects[_i];
+      var _fiber = mountEffects[_i + 1];
+
+      {
+        setCurrentFiber(_fiber);
+
+        {
+          invokeGuardedCallback(null, invokePassiveEffectCreate, null, _effect2);
+        }
+
+        if (hasCaughtError()) {
+          if (!(_fiber !== null)) {
+            {
+              throw Error( "Should be working on an effect." );
+            }
+          }
+
+          var _error4 = clearCaughtError();
+
+          captureCommitPhaseError(_fiber, _error4);
+        }
+
+        resetCurrentFiber();
+      }
+    } // Note: This currently assumes there are no passive effects on the root fiber
+    // because the root is not part of its own effect list.
+    // This could change in the future.
+
+
+    var effect = root.current.firstEffect;
+
+    while (effect !== null) {
+      var nextNextEffect = effect.nextEffect; // Remove nextEffect pointer to assist GC
+
+      effect.nextEffect = null;
+
+      if (effect.flags & Deletion) {
+        detachFiberAfterEffects(effect);
+      }
+
+      effect = nextNextEffect;
+    }
+
+    {
+      popInteractions(prevInteractions);
+      finishPendingInteractions(root, lanes);
+    }
+
+    {
+      isFlushingPassiveEffects = false;
+    }
+
+    executionContext = prevExecutionContext;
+    flushSyncCallbackQueue(); // If additional passive effects were scheduled, increment a counter. If this
+    // exceeds the limit, we'll fire a warning.
+
+    nestedPassiveUpdateCount = rootWithPendingPassiveEffects === null ? 0 : nestedPassiveUpdateCount + 1;
+    return true;
+  }
+
+  function isAlreadyFailedLegacyErrorBoundary(instance) {
+    return legacyErrorBoundariesThatAlreadyFailed !== null && legacyErrorBoundariesThatAlreadyFailed.has(instance);
+  }
+  function markLegacyErrorBoundaryAsFailed(instance) {
+    if (legacyErrorBoundariesThatAlreadyFailed === null) {
+      legacyErrorBoundariesThatAlreadyFailed = new Set([instance]);
+    } else {
+      legacyErrorBoundariesThatAlreadyFailed.add(instance);
+    }
+  }
+
+  function prepareToThrowUncaughtError(error) {
+    if (!hasUncaughtError) {
+      hasUncaughtError = true;
+      firstUncaughtError = error;
+    }
+  }
+
+  var onUncaughtError = prepareToThrowUncaughtError;
+
+  function captureCommitPhaseErrorOnRoot(rootFiber, sourceFiber, error) {
+    var errorInfo = createCapturedValue(error, sourceFiber);
+    var update = createRootErrorUpdate(rootFiber, errorInfo, SyncLane);
+    enqueueUpdate(rootFiber, update);
+    var eventTime = requestEventTime();
+    var root = markUpdateLaneFromFiberToRoot(rootFiber, SyncLane);
+
+    if (root !== null) {
+      markRootUpdated(root, SyncLane, eventTime);
+      ensureRootIsScheduled(root, eventTime);
+      schedulePendingInteractions(root, SyncLane);
+    }
+  }
+
+  function captureCommitPhaseError(sourceFiber, error) {
+    if (sourceFiber.tag === HostRoot) {
+      // Error was thrown at the root. There is no parent, so the root
+      // itself should capture it.
+      captureCommitPhaseErrorOnRoot(sourceFiber, sourceFiber, error);
+      return;
+    }
+
+    var fiber = sourceFiber.return;
+
+    while (fiber !== null) {
+      if (fiber.tag === HostRoot) {
+        captureCommitPhaseErrorOnRoot(fiber, sourceFiber, error);
+        return;
+      } else if (fiber.tag === ClassComponent) {
+        var ctor = fiber.type;
+        var instance = fiber.stateNode;
+
+        if (typeof ctor.getDerivedStateFromError === 'function' || typeof instance.componentDidCatch === 'function' && !isAlreadyFailedLegacyErrorBoundary(instance)) {
+          var errorInfo = createCapturedValue(error, sourceFiber);
+          var update = createClassErrorUpdate(fiber, errorInfo, SyncLane);
+          enqueueUpdate(fiber, update);
+          var eventTime = requestEventTime();
+          var root = markUpdateLaneFromFiberToRoot(fiber, SyncLane);
+
+          if (root !== null) {
+            markRootUpdated(root, SyncLane, eventTime);
+            ensureRootIsScheduled(root, eventTime);
+            schedulePendingInteractions(root, SyncLane);
+          } else {
+            // This component has already been unmounted.
+            // We can't schedule any follow up work for the root because the fiber is already unmounted,
+            // but we can still call the log-only boundary so the error isn't swallowed.
+            //
+            // TODO This is only a temporary bandaid for the old reconciler fork.
+            // We can delete this special case once the new fork is merged.
+            if (typeof instance.componentDidCatch === 'function' && !isAlreadyFailedLegacyErrorBoundary(instance)) {
+              try {
+                instance.componentDidCatch(error, errorInfo);
+              } catch (errorToIgnore) {// TODO Ignore this error? Rethrow it?
+                // This is kind of an edge case.
+              }
+            }
+          }
+
+          return;
+        }
+      }
+
+      fiber = fiber.return;
+    }
+  }
+  function pingSuspendedRoot(root, wakeable, pingedLanes) {
+    var pingCache = root.pingCache;
+
+    if (pingCache !== null) {
+      // The wakeable resolved, so we no longer need to memoize, because it will
+      // never be thrown again.
+      pingCache.delete(wakeable);
+    }
+
+    var eventTime = requestEventTime();
+    markRootPinged(root, pingedLanes);
+
+    if (workInProgressRoot === root && isSubsetOfLanes(workInProgressRootRenderLanes, pingedLanes)) {
+      // Received a ping at the same priority level at which we're currently
+      // rendering. We might want to restart this render. This should mirror
+      // the logic of whether or not a root suspends once it completes.
+      // TODO: If we're rendering sync either due to Sync, Batched or expired,
+      // we should probably never restart.
+      // If we're suspended with delay, or if it's a retry, we'll always suspend
+      // so we can always restart.
+      if (workInProgressRootExitStatus === RootSuspendedWithDelay || workInProgressRootExitStatus === RootSuspended && includesOnlyRetries(workInProgressRootRenderLanes) && now() - globalMostRecentFallbackTime < FALLBACK_THROTTLE_MS) {
+        // Restart from the root.
+        prepareFreshStack(root, NoLanes);
+      } else {
+        // Even though we can't restart right now, we might get an
+        // opportunity later. So we mark this render as having a ping.
+        workInProgressRootPingedLanes = mergeLanes(workInProgressRootPingedLanes, pingedLanes);
+      }
+    }
+
+    ensureRootIsScheduled(root, eventTime);
+    schedulePendingInteractions(root, pingedLanes);
+  }
+
+  function retryTimedOutBoundary(boundaryFiber, retryLane) {
+    // The boundary fiber (a Suspense component or SuspenseList component)
+    // previously was rendered in its fallback state. One of the promises that
+    // suspended it has resolved, which means at least part of the tree was
+    // likely unblocked. Try rendering again, at a new expiration time.
+    if (retryLane === NoLane) {
+      retryLane = requestRetryLane(boundaryFiber);
+    } // TODO: Special case idle priority?
+
+
+    var eventTime = requestEventTime();
+    var root = markUpdateLaneFromFiberToRoot(boundaryFiber, retryLane);
+
+    if (root !== null) {
+      markRootUpdated(root, retryLane, eventTime);
+      ensureRootIsScheduled(root, eventTime);
+      schedulePendingInteractions(root, retryLane);
+    }
+  }
+  function resolveRetryWakeable(boundaryFiber, wakeable) {
+    var retryLane = NoLane; // Default
+
+    var retryCache;
+
+    {
+      retryCache = boundaryFiber.stateNode;
+    }
+
+    if (retryCache !== null) {
+      // The wakeable resolved, so we no longer need to memoize, because it will
+      // never be thrown again.
+      retryCache.delete(wakeable);
+    }
+
+    retryTimedOutBoundary(boundaryFiber, retryLane);
+  } // Computes the next Just Noticeable Difference (JND) boundary.
+  // The theory is that a person can't tell the difference between small differences in time.
+  // Therefore, if we wait a bit longer than necessary that won't translate to a noticeable
+  // difference in the experience. However, waiting for longer might mean that we can avoid
+  // showing an intermediate loading state. The longer we have already waited, the harder it
+  // is to tell small differences in time. Therefore, the longer we've already waited,
+  // the longer we can wait additionally. At some point we have to give up though.
+  // We pick a train model where the next boundary commits at a consistent schedule.
+  // These particular numbers are vague estimates. We expect to adjust them based on research.
+
+  function jnd(timeElapsed) {
+    return timeElapsed < 120 ? 120 : timeElapsed < 480 ? 480 : timeElapsed < 1080 ? 1080 : timeElapsed < 1920 ? 1920 : timeElapsed < 3000 ? 3000 : timeElapsed < 4320 ? 4320 : ceil(timeElapsed / 1960) * 1960;
+  }
+
+  function checkForNestedUpdates() {
+    if (nestedUpdateCount > NESTED_UPDATE_LIMIT) {
+      nestedUpdateCount = 0;
+      rootWithNestedUpdates = null;
+
+      {
+        {
+          throw Error( "Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops." );
+        }
+      }
+    }
+
+    {
+      if (nestedPassiveUpdateCount > NESTED_PASSIVE_UPDATE_LIMIT) {
+        nestedPassiveUpdateCount = 0;
+
+        error('Maximum update depth exceeded. This can happen when a component ' + "calls setState inside useEffect, but useEffect either doesn't " + 'have a dependency array, or one of the dependencies changes on ' + 'every render.');
+      }
+    }
+  }
+
+  function flushRenderPhaseStrictModeWarningsInDEV() {
+    {
+      ReactStrictModeWarnings.flushLegacyContextWarning();
+
+      {
+        ReactStrictModeWarnings.flushPendingUnsafeLifecycleWarnings();
+      }
+    }
+  }
+
+  var didWarnStateUpdateForNotYetMountedComponent = null;
+
+  function warnAboutUpdateOnNotYetMountedFiberInDEV(fiber) {
+    {
+      if ((executionContext & RenderContext) !== NoContext) {
+        // We let the other warning about render phase updates deal with this one.
+        return;
+      }
+
+      if (!(fiber.mode & (BlockingMode | ConcurrentMode))) {
+        return;
+      }
+
+      var tag = fiber.tag;
+
+      if (tag !== IndeterminateComponent && tag !== HostRoot && tag !== ClassComponent && tag !== FunctionComponent && tag !== ForwardRef && tag !== MemoComponent && tag !== SimpleMemoComponent && tag !== Block) {
+        // Only warn for user-defined components, not internal ones like Suspense.
+        return;
+      } // We show the whole stack but dedupe on the top component's name because
+      // the problematic code almost always lies inside that component.
+
+
+      var componentName = getComponentName(fiber.type) || 'ReactComponent';
+
+      if (didWarnStateUpdateForNotYetMountedComponent !== null) {
+        if (didWarnStateUpdateForNotYetMountedComponent.has(componentName)) {
+          return;
+        }
+
+        didWarnStateUpdateForNotYetMountedComponent.add(componentName);
+      } else {
+        didWarnStateUpdateForNotYetMountedComponent = new Set([componentName]);
+      }
+
+      var previousFiber = current;
+
+      try {
+        setCurrentFiber(fiber);
+
+        error("Can't perform a React state update on a component that hasn't mounted yet. " + 'This indicates that you have a side-effect in your render function that ' + 'asynchronously later calls tries to update the component. Move this work to ' + 'useEffect instead.');
+      } finally {
+        if (previousFiber) {
+          setCurrentFiber(fiber);
+        } else {
+          resetCurrentFiber();
+        }
+      }
+    }
+  }
+
+  var didWarnStateUpdateForUnmountedComponent = null;
+
+  function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
+    {
+      var tag = fiber.tag;
+
+      if (tag !== HostRoot && tag !== ClassComponent && tag !== FunctionComponent && tag !== ForwardRef && tag !== MemoComponent && tag !== SimpleMemoComponent && tag !== Block) {
+        // Only warn for user-defined components, not internal ones like Suspense.
+        return;
+      } // If there are pending passive effects unmounts for this Fiber,
+      // we can assume that they would have prevented this update.
+
+
+      if ((fiber.flags & PassiveUnmountPendingDev) !== NoFlags) {
+        return;
+      } // We show the whole stack but dedupe on the top component's name because
+      // the problematic code almost always lies inside that component.
+
+
+      var componentName = getComponentName(fiber.type) || 'ReactComponent';
+
+      if (didWarnStateUpdateForUnmountedComponent !== null) {
+        if (didWarnStateUpdateForUnmountedComponent.has(componentName)) {
+          return;
+        }
+
+        didWarnStateUpdateForUnmountedComponent.add(componentName);
+      } else {
+        didWarnStateUpdateForUnmountedComponent = new Set([componentName]);
+      }
+
+      if (isFlushingPassiveEffects) ; else {
+        var previousFiber = current;
+
+        try {
+          setCurrentFiber(fiber);
+
+          error("Can't perform a React state update on an unmounted component. This " + 'is a no-op, but it indicates a memory leak in your application. To ' + 'fix, cancel all subscriptions and asynchronous tasks in %s.', tag === ClassComponent ? 'the componentWillUnmount method' : 'a useEffect cleanup function');
+        } finally {
+          if (previousFiber) {
+            setCurrentFiber(fiber);
+          } else {
+            resetCurrentFiber();
+          }
+        }
+      }
+    }
+  }
+
+  var beginWork$1;
+
+  {
+    var dummyFiber = null;
+
+    beginWork$1 = function (current, unitOfWork, lanes) {
+      // If a component throws an error, we replay it again in a synchronously
+      // dispatched event, so that the debugger will treat it as an uncaught
+      // error See ReactErrorUtils for more information.
+      // Before entering the begin phase, copy the work-in-progress onto a dummy
+      // fiber. If beginWork throws, we'll use this to reset the state.
+      var originalWorkInProgressCopy = assignFiberPropertiesInDEV(dummyFiber, unitOfWork);
+
+      try {
+        return beginWork(current, unitOfWork, lanes);
+      } catch (originalError) {
+        if (originalError !== null && typeof originalError === 'object' && typeof originalError.then === 'function') {
+          // Don't replay promises. Treat everything else like an error.
+          throw originalError;
+        } // Keep this code in sync with handleError; any changes here must have
+        // corresponding changes there.
+
+
+        resetContextDependencies();
+        resetHooksAfterThrow(); // Don't reset current debug fiber, since we're about to work on the
+        // same fiber again.
+        // Unwind the failed stack frame
+
+        unwindInterruptedWork(unitOfWork); // Restore the original properties of the fiber.
+
+        assignFiberPropertiesInDEV(unitOfWork, originalWorkInProgressCopy);
+
+        if ( unitOfWork.mode & ProfileMode) {
+          // Reset the profiler timer.
+          startProfilerTimer(unitOfWork);
+        } // Run beginWork again.
+
+
+        invokeGuardedCallback(null, beginWork, null, current, unitOfWork, lanes);
+
+        if (hasCaughtError()) {
+          var replayError = clearCaughtError(); // `invokeGuardedCallback` sometimes sets an expando `_suppressLogging`.
+          // Rethrow this error instead of the original one.
+
+          throw replayError;
+        } else {
+          // This branch is reachable if the render phase is impure.
+          throw originalError;
+        }
+      }
+    };
+  }
+
+  var didWarnAboutUpdateInRender = false;
+  var didWarnAboutUpdateInRenderForAnotherComponent;
+
+  {
+    didWarnAboutUpdateInRenderForAnotherComponent = new Set();
+  }
+
+  function warnAboutRenderPhaseUpdatesInDEV(fiber) {
+    {
+      if (isRendering && (executionContext & RenderContext) !== NoContext && !getIsUpdatingOpaqueValueInRenderPhaseInDEV()) {
+        switch (fiber.tag) {
+          case FunctionComponent:
+          case ForwardRef:
+          case SimpleMemoComponent:
+            {
+              var renderingComponentName = workInProgress && getComponentName(workInProgress.type) || 'Unknown'; // Dedupe by the rendering component because it's the one that needs to be fixed.
+
+              var dedupeKey = renderingComponentName;
+
+              if (!didWarnAboutUpdateInRenderForAnotherComponent.has(dedupeKey)) {
+                didWarnAboutUpdateInRenderForAnotherComponent.add(dedupeKey);
+                var setStateComponentName = getComponentName(fiber.type) || 'Unknown';
+
+                error('Cannot update a component (`%s`) while rendering a ' + 'different component (`%s`). To locate the bad setState() call inside `%s`, ' + 'follow the stack trace as described in https://reactjs.org/link/setstate-in-render', setStateComponentName, renderingComponentName, renderingComponentName);
+              }
+
+              break;
+            }
+
+          case ClassComponent:
+            {
+              if (!didWarnAboutUpdateInRender) {
+                error('Cannot update during an existing state transition (such as ' + 'within `render`). Render methods should be a pure ' + 'function of props and state.');
+
+                didWarnAboutUpdateInRender = true;
+              }
+
+              break;
+            }
+        }
+      }
+    }
+  } // a 'shared' variable that changes when act() opens/closes in tests.
+
+
+  var IsThisRendererActing = {
+    current: false
+  };
+  function warnIfNotScopedWithMatchingAct(fiber) {
+    {
+      if ( IsSomeRendererActing.current === true && IsThisRendererActing.current !== true) {
+        var previousFiber = current;
+
+        try {
+          setCurrentFiber(fiber);
+
+          error("It looks like you're using the wrong act() around your test interactions.\n" + 'Be sure to use the matching version of act() corresponding to your renderer:\n\n' + '// for react-dom:\n' + // Break up imports to avoid accidentally parsing them as dependencies.
+          'import {act} fr' + "om 'react-dom/test-utils';\n" + '// ...\n' + 'act(() => ...);\n\n' + '// for react-test-renderer:\n' + // Break up imports to avoid accidentally parsing them as dependencies.
+          'import TestRenderer fr' + "om react-test-renderer';\n" + 'const {act} = TestRenderer;\n' + '// ...\n' + 'act(() => ...);');
+        } finally {
+          if (previousFiber) {
+            setCurrentFiber(fiber);
+          } else {
+            resetCurrentFiber();
+          }
+        }
+      }
+    }
+  }
+  function warnIfNotCurrentlyActingEffectsInDEV(fiber) {
+    {
+      if ( (fiber.mode & StrictMode) !== NoMode && IsSomeRendererActing.current === false && IsThisRendererActing.current === false) {
+        error('An update to %s ran an effect, but was not wrapped in act(...).\n\n' + 'When testing, code that causes React state updates should be ' + 'wrapped into act(...):\n\n' + 'act(() => {\n' + '  /* fire events that update state */\n' + '});\n' + '/* assert on the output */\n\n' + "This ensures that you're testing the behavior the user would see " + 'in the browser.' + ' Learn more at https://reactjs.org/link/wrap-tests-with-act', getComponentName(fiber.type));
+      }
+    }
+  }
+
+  function warnIfNotCurrentlyActingUpdatesInDEV(fiber) {
+    {
+      if ( executionContext === NoContext && IsSomeRendererActing.current === false && IsThisRendererActing.current === false) {
+        var previousFiber = current;
+
+        try {
+          setCurrentFiber(fiber);
+
+          error('An update to %s inside a test was not wrapped in act(...).\n\n' + 'When testing, code that causes React state updates should be ' + 'wrapped into act(...):\n\n' + 'act(() => {\n' + '  /* fire events that update state */\n' + '});\n' + '/* assert on the output */\n\n' + "This ensures that you're testing the behavior the user would see " + 'in the browser.' + ' Learn more at https://reactjs.org/link/wrap-tests-with-act', getComponentName(fiber.type));
+        } finally {
+          if (previousFiber) {
+            setCurrentFiber(fiber);
+          } else {
+            resetCurrentFiber();
+          }
+        }
+      }
+    }
+  }
+
+  var warnIfNotCurrentlyActingUpdatesInDev = warnIfNotCurrentlyActingUpdatesInDEV; // In tests, we want to enforce a mocked scheduler.
+
+  var didWarnAboutUnmockedScheduler = false; // TODO Before we release concurrent mode, revisit this and decide whether a mocked
+  // scheduler is the actual recommendation. The alternative could be a testing build,
+  // a new lib, or whatever; we dunno just yet. This message is for early adopters
+  // to get their tests right.
+
+  function warnIfUnmockedScheduler(fiber) {
+    {
+      if (didWarnAboutUnmockedScheduler === false && unstable_flushAllWithoutAsserting === undefined) {
+        if (fiber.mode & BlockingMode || fiber.mode & ConcurrentMode) {
+          didWarnAboutUnmockedScheduler = true;
+
+          error('In Concurrent or Sync modes, the "scheduler" module needs to be mocked ' + 'to guarantee consistent behaviour across tests and browsers. ' + 'For example, with jest: \n' + // Break up requires to avoid accidentally parsing them as dependencies.
+          "jest.mock('scheduler', () => require" + "('scheduler/unstable_mock'));\n\n" + 'For more info, visit https://reactjs.org/link/mock-scheduler');
+        }
+      }
+    }
+  }
+
+  function computeThreadID(root, lane) {
+    // Interaction threads are unique per root and expiration time.
+    // NOTE: Intentionally unsound cast. All that matters is that it's a number
+    // and it represents a batch of work. Could make a helper function instead,
+    // but meh this is fine for now.
+    return lane * 1000 + root.interactionThreadID;
+  }
+
+  function markSpawnedWork(lane) {
+
+    if (spawnedWorkDuringRender === null) {
+      spawnedWorkDuringRender = [lane];
+    } else {
+      spawnedWorkDuringRender.push(lane);
+    }
+  }
+
+  function scheduleInteractions(root, lane, interactions) {
+
+    if (interactions.size > 0) {
+      var pendingInteractionMap = root.pendingInteractionMap;
+      var pendingInteractions = pendingInteractionMap.get(lane);
+
+      if (pendingInteractions != null) {
+        interactions.forEach(function (interaction) {
+          if (!pendingInteractions.has(interaction)) {
+            // Update the pending async work count for previously unscheduled interaction.
+            interaction.__count++;
+          }
+
+          pendingInteractions.add(interaction);
+        });
+      } else {
+        pendingInteractionMap.set(lane, new Set(interactions)); // Update the pending async work count for the current interactions.
+
+        interactions.forEach(function (interaction) {
+          interaction.__count++;
+        });
+      }
+
+      var subscriber = __subscriberRef.current;
+
+      if (subscriber !== null) {
+        var threadID = computeThreadID(root, lane);
+        subscriber.onWorkScheduled(interactions, threadID);
+      }
+    }
+  }
+
+  function schedulePendingInteractions(root, lane) {
+
+    scheduleInteractions(root, lane, __interactionsRef.current);
+  }
+
+  function startWorkOnPendingInteractions(root, lanes) {
+    // we can accurately attribute time spent working on it, And so that cascading
+    // work triggered during the render phase will be associated with it.
+
+
+    var interactions = new Set();
+    root.pendingInteractionMap.forEach(function (scheduledInteractions, scheduledLane) {
+      if (includesSomeLane(lanes, scheduledLane)) {
+        scheduledInteractions.forEach(function (interaction) {
+          return interactions.add(interaction);
+        });
+      }
+    }); // Store the current set of interactions on the FiberRoot for a few reasons:
+    // We can re-use it in hot functions like performConcurrentWorkOnRoot()
+    // without having to recalculate it. We will also use it in commitWork() to
+    // pass to any Profiler onRender() hooks. This also provides DevTools with a
+    // way to access it when the onCommitRoot() hook is called.
+
+    root.memoizedInteractions = interactions;
+
+    if (interactions.size > 0) {
+      var subscriber = __subscriberRef.current;
+
+      if (subscriber !== null) {
+        var threadID = computeThreadID(root, lanes);
+
+        try {
+          subscriber.onWorkStarted(interactions, threadID);
+        } catch (error) {
+          // If the subscriber throws, rethrow it in a separate task
+          scheduleCallback(ImmediatePriority$1, function () {
+            throw error;
+          });
+        }
+      }
+    }
+  }
+
+  function finishPendingInteractions(root, committedLanes) {
+
+    var remainingLanesAfterCommit = root.pendingLanes;
+    var subscriber;
+
+    try {
+      subscriber = __subscriberRef.current;
+
+      if (subscriber !== null && root.memoizedInteractions.size > 0) {
+        // FIXME: More than one lane can finish in a single commit.
+        var threadID = computeThreadID(root, committedLanes);
+        subscriber.onWorkStopped(root.memoizedInteractions, threadID);
+      }
+    } catch (error) {
+      // If the subscriber throws, rethrow it in a separate task
+      scheduleCallback(ImmediatePriority$1, function () {
+        throw error;
+      });
+    } finally {
+      // Clear completed interactions from the pending Map.
+      // Unless the render was suspended or cascading work was scheduled,
+      // In which case– leave pending interactions until the subsequent render.
+      var pendingInteractionMap = root.pendingInteractionMap;
+      pendingInteractionMap.forEach(function (scheduledInteractions, lane) {
+        // Only decrement the pending interaction count if we're done.
+        // If there's still work at the current priority,
+        // That indicates that we are waiting for suspense data.
+        if (!includesSomeLane(remainingLanesAfterCommit, lane)) {
+          pendingInteractionMap.delete(lane);
+          scheduledInteractions.forEach(function (interaction) {
+            interaction.__count--;
+
+            if (subscriber !== null && interaction.__count === 0) {
+              try {
+                subscriber.onInteractionScheduledWorkCompleted(interaction);
+              } catch (error) {
+                // If the subscriber throws, rethrow it in a separate task
+                scheduleCallback(ImmediatePriority$1, function () {
+                  throw error;
+                });
+              }
+            }
+          });
+        }
+      });
+    }
+  } // `act` testing API
+
+  function shouldForceFlushFallbacksInDEV() {
+    // Never force flush in production. This function should get stripped out.
+    return  actingUpdatesScopeDepth > 0;
+  }
+  // so we can tell if any async act() calls try to run in parallel.
+
+
+  var actingUpdatesScopeDepth = 0;
+
+  function detachFiberAfterEffects(fiber) {
+    fiber.sibling = null;
+    fiber.stateNode = null;
+  }
+
+  var resolveFamily = null; // $FlowFixMe Flow gets confused by a WeakSet feature check below.
+
+  var failedBoundaries = null;
+  var setRefreshHandler = function (handler) {
+    {
+      resolveFamily = handler;
+    }
+  };
+  function resolveFunctionForHotReloading(type) {
+    {
+      if (resolveFamily === null) {
+        // Hot reloading is disabled.
+        return type;
+      }
+
+      var family = resolveFamily(type);
+
+      if (family === undefined) {
+        return type;
+      } // Use the latest known implementation.
+
+
+      return family.current;
+    }
+  }
+  function resolveClassForHotReloading(type) {
+    // No implementation differences.
+    return resolveFunctionForHotReloading(type);
+  }
+  function resolveForwardRefForHotReloading(type) {
+    {
+      if (resolveFamily === null) {
+        // Hot reloading is disabled.
+        return type;
+      }
+
+      var family = resolveFamily(type);
+
+      if (family === undefined) {
+        // Check if we're dealing with a real forwardRef. Don't want to crash early.
+        if (type !== null && type !== undefined && typeof type.render === 'function') {
+          // ForwardRef is special because its resolved .type is an object,
+          // but it's possible that we only have its inner render function in the map.
+          // If that inner render function is different, we'll build a new forwardRef type.
+          var currentRender = resolveFunctionForHotReloading(type.render);
+
+          if (type.render !== currentRender) {
+            var syntheticType = {
+              $$typeof: REACT_FORWARD_REF_TYPE,
+              render: currentRender
+            };
+
+            if (type.displayName !== undefined) {
+              syntheticType.displayName = type.displayName;
+            }
+
+            return syntheticType;
+          }
+        }
+
+        return type;
+      } // Use the latest known implementation.
+
+
+      return family.current;
+    }
+  }
+  function isCompatibleFamilyForHotReloading(fiber, element) {
+    {
+      if (resolveFamily === null) {
+        // Hot reloading is disabled.
+        return false;
+      }
+
+      var prevType = fiber.elementType;
+      var nextType = element.type; // If we got here, we know types aren't === equal.
+
+      var needsCompareFamilies = false;
+      var $$typeofNextType = typeof nextType === 'object' && nextType !== null ? nextType.$$typeof : null;
+
+      switch (fiber.tag) {
+        case ClassComponent:
+          {
+            if (typeof nextType === 'function') {
+              needsCompareFamilies = true;
+            }
+
+            break;
+          }
+
+        case FunctionComponent:
+          {
+            if (typeof nextType === 'function') {
+              needsCompareFamilies = true;
+            } else if ($$typeofNextType === REACT_LAZY_TYPE) {
+              // We don't know the inner type yet.
+              // We're going to assume that the lazy inner type is stable,
+              // and so it is sufficient to avoid reconciling it away.
+              // We're not going to unwrap or actually use the new lazy type.
+              needsCompareFamilies = true;
+            }
+
+            break;
+          }
+
+        case ForwardRef:
+          {
+            if ($$typeofNextType === REACT_FORWARD_REF_TYPE) {
+              needsCompareFamilies = true;
+            } else if ($$typeofNextType === REACT_LAZY_TYPE) {
+              needsCompareFamilies = true;
+            }
+
+            break;
+          }
+
+        case MemoComponent:
+        case SimpleMemoComponent:
+          {
+            if ($$typeofNextType === REACT_MEMO_TYPE) {
+              // TODO: if it was but can no longer be simple,
+              // we shouldn't set this.
+              needsCompareFamilies = true;
+            } else if ($$typeofNextType === REACT_LAZY_TYPE) {
+              needsCompareFamilies = true;
+            }
+
+            break;
+          }
+
+        default:
+          return false;
+      } // Check if both types have a family and it's the same one.
+
+
+      if (needsCompareFamilies) {
+        // Note: memo() and forwardRef() we'll compare outer rather than inner type.
+        // This means both of them need to be registered to preserve state.
+        // If we unwrapped and compared the inner types for wrappers instead,
+        // then we would risk falsely saying two separate memo(Foo)
+        // calls are equivalent because they wrap the same Foo function.
+        var prevFamily = resolveFamily(prevType);
+
+        if (prevFamily !== undefined && prevFamily === resolveFamily(nextType)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  }
+  function markFailedErrorBoundaryForHotReloading(fiber) {
+    {
+      if (resolveFamily === null) {
+        // Hot reloading is disabled.
+        return;
+      }
+
+      if (typeof WeakSet !== 'function') {
+        return;
+      }
+
+      if (failedBoundaries === null) {
+        failedBoundaries = new WeakSet();
+      }
+
+      failedBoundaries.add(fiber);
+    }
+  }
+  var scheduleRefresh = function (root, update) {
+    {
+      if (resolveFamily === null) {
+        // Hot reloading is disabled.
+        return;
+      }
+
+      var staleFamilies = update.staleFamilies,
+          updatedFamilies = update.updatedFamilies;
+      flushPassiveEffects();
+      flushSync(function () {
+        scheduleFibersWithFamiliesRecursively(root.current, updatedFamilies, staleFamilies);
+      });
+    }
+  };
+  var scheduleRoot = function (root, element) {
+    {
+      if (root.context !== emptyContextObject) {
+        // Super edge case: root has a legacy _renderSubtree context
+        // but we don't know the parentComponent so we can't pass it.
+        // Just ignore. We'll delete this with _renderSubtree code path later.
+        return;
+      }
+
+      flushPassiveEffects();
+      flushSync(function () {
+        updateContainer(element, root, null, null);
+      });
+    }
+  };
+
+  function scheduleFibersWithFamiliesRecursively(fiber, updatedFamilies, staleFamilies) {
+    {
+      var alternate = fiber.alternate,
+          child = fiber.child,
+          sibling = fiber.sibling,
+          tag = fiber.tag,
+          type = fiber.type;
+      var candidateType = null;
+
+      switch (tag) {
+        case FunctionComponent:
+        case SimpleMemoComponent:
+        case ClassComponent:
+          candidateType = type;
+          break;
+
+        case ForwardRef:
+          candidateType = type.render;
+          break;
+      }
+
+      if (resolveFamily === null) {
+        throw new Error('Expected resolveFamily to be set during hot reload.');
+      }
+
+      var needsRender = false;
+      var needsRemount = false;
+
+      if (candidateType !== null) {
+        var family = resolveFamily(candidateType);
+
+        if (family !== undefined) {
+          if (staleFamilies.has(family)) {
+            needsRemount = true;
+          } else if (updatedFamilies.has(family)) {
+            if (tag === ClassComponent) {
+              needsRemount = true;
+            } else {
+              needsRender = true;
+            }
+          }
+        }
+      }
+
+      if (failedBoundaries !== null) {
+        if (failedBoundaries.has(fiber) || alternate !== null && failedBoundaries.has(alternate)) {
+          needsRemount = true;
+        }
+      }
+
+      if (needsRemount) {
+        fiber._debugNeedsRemount = true;
+      }
+
+      if (needsRemount || needsRender) {
+        scheduleUpdateOnFiber(fiber, SyncLane, NoTimestamp);
+      }
+
+      if (child !== null && !needsRemount) {
+        scheduleFibersWithFamiliesRecursively(child, updatedFamilies, staleFamilies);
+      }
+
+      if (sibling !== null) {
+        scheduleFibersWithFamiliesRecursively(sibling, updatedFamilies, staleFamilies);
+      }
+    }
+  }
+
+  var findHostInstancesForRefresh = function (root, families) {
+    {
+      var hostInstances = new Set();
+      var types = new Set(families.map(function (family) {
+        return family.current;
+      }));
+      findHostInstancesForMatchingFibersRecursively(root.current, types, hostInstances);
+      return hostInstances;
+    }
+  };
+
+  function findHostInstancesForMatchingFibersRecursively(fiber, types, hostInstances) {
+    {
+      var child = fiber.child,
+          sibling = fiber.sibling,
+          tag = fiber.tag,
+          type = fiber.type;
+      var candidateType = null;
+
+      switch (tag) {
+        case FunctionComponent:
+        case SimpleMemoComponent:
+        case ClassComponent:
+          candidateType = type;
+          break;
+
+        case ForwardRef:
+          candidateType = type.render;
+          break;
+      }
+
+      var didMatch = false;
+
+      if (candidateType !== null) {
+        if (types.has(candidateType)) {
+          didMatch = true;
+        }
+      }
+
+      if (didMatch) {
+        // We have a match. This only drills down to the closest host components.
+        // There's no need to search deeper because for the purpose of giving
+        // visual feedback, "flashing" outermost parent rectangles is sufficient.
+        findHostInstancesForFiberShallowly(fiber, hostInstances);
+      } else {
+        // If there's no match, maybe there will be one further down in the child tree.
+        if (child !== null) {
+          findHostInstancesForMatchingFibersRecursively(child, types, hostInstances);
+        }
+      }
+
+      if (sibling !== null) {
+        findHostInstancesForMatchingFibersRecursively(sibling, types, hostInstances);
+      }
+    }
+  }
+
+  function findHostInstancesForFiberShallowly(fiber, hostInstances) {
+    {
+      var foundHostInstances = findChildHostInstancesForFiberShallowly(fiber, hostInstances);
+
+      if (foundHostInstances) {
+        return;
+      } // If we didn't find any host children, fallback to closest host parent.
+
+
+      var node = fiber;
+
+      while (true) {
+        switch (node.tag) {
+          case HostComponent:
+            hostInstances.add(node.stateNode);
+            return;
+
+          case HostPortal:
+            hostInstances.add(node.stateNode.containerInfo);
+            return;
+
+          case HostRoot:
+            hostInstances.add(node.stateNode.containerInfo);
+            return;
+        }
+
+        if (node.return === null) {
+          throw new Error('Expected to reach root first.');
+        }
+
+        node = node.return;
+      }
+    }
+  }
+
+  function findChildHostInstancesForFiberShallowly(fiber, hostInstances) {
+    {
+      var node = fiber;
+      var foundHostInstances = false;
+
+      while (true) {
+        if (node.tag === HostComponent) {
+          // We got a match.
+          foundHostInstances = true;
+          hostInstances.add(node.stateNode); // There may still be more, so keep searching.
+        } else if (node.child !== null) {
+          node.child.return = node;
+          node = node.child;
+          continue;
+        }
+
+        if (node === fiber) {
+          return foundHostInstances;
+        }
+
+        while (node.sibling === null) {
+          if (node.return === null || node.return === fiber) {
+            return foundHostInstances;
+          }
+
+          node = node.return;
+        }
+
+        node.sibling.return = node.return;
+        node = node.sibling;
+      }
+    }
+
+    return false;
+  }
+
+  var hasBadMapPolyfill;
+
+  {
+    hasBadMapPolyfill = false;
+
+    try {
+      var nonExtensibleObject = Object.preventExtensions({});
+      /* eslint-disable no-new */
+
+      new Map([[nonExtensibleObject, null]]);
+      new Set([nonExtensibleObject]);
+      /* eslint-enable no-new */
+    } catch (e) {
+      // TODO: Consider warning about bad polyfills
+      hasBadMapPolyfill = true;
+    }
+  }
+
+  var debugCounter = 1;
+
+  function FiberNode(tag, pendingProps, key, mode) {
+    // Instance
+    this.tag = tag;
+    this.key = key;
+    this.elementType = null;
+    this.type = null;
+    this.stateNode = null; // Fiber
+
+    this.return = null;
+    this.child = null;
+    this.sibling = null;
+    this.index = 0;
+    this.ref = null;
+    this.pendingProps = pendingProps;
+    this.memoizedProps = null;
+    this.updateQueue = null;
+    this.memoizedState = null;
+    this.dependencies = null;
+    this.mode = mode; // Effects
+
+    this.flags = NoFlags;
+    this.nextEffect = null;
+    this.firstEffect = null;
+    this.lastEffect = null;
+    this.lanes = NoLanes;
+    this.childLanes = NoLanes;
+    this.alternate = null;
+
+    {
+      // Note: The following is done to avoid a v8 performance cliff.
+      //
+      // Initializing the fields below to smis and later updating them with
+      // double values will cause Fibers to end up having separate shapes.
+      // This behavior/bug has something to do with Object.preventExtension().
+      // Fortunately this only impacts DEV builds.
+      // Unfortunately it makes React unusably slow for some applications.
+      // To work around this, initialize the fields below with doubles.
+      //
+      // Learn more about this here:
+      // https://github.com/facebook/react/issues/14365
+      // https://bugs.chromium.org/p/v8/issues/detail?id=8538
+      this.actualDuration = Number.NaN;
+      this.actualStartTime = Number.NaN;
+      this.selfBaseDuration = Number.NaN;
+      this.treeBaseDuration = Number.NaN; // It's okay to replace the initial doubles with smis after initialization.
+      // This won't trigger the performance cliff mentioned above,
+      // and it simplifies other profiler code (including DevTools).
+
+      this.actualDuration = 0;
+      this.actualStartTime = -1;
+      this.selfBaseDuration = 0;
+      this.treeBaseDuration = 0;
+    }
+
+    {
+      // This isn't directly used but is handy for debugging internals:
+      this._debugID = debugCounter++;
+      this._debugSource = null;
+      this._debugOwner = null;
+      this._debugNeedsRemount = false;
+      this._debugHookTypes = null;
+
+      if (!hasBadMapPolyfill && typeof Object.preventExtensions === 'function') {
+        Object.preventExtensions(this);
+      }
+    }
+  } // This is a constructor function, rather than a POJO constructor, still
+  // please ensure we do the following:
+  // 1) Nobody should add any instance methods on this. Instance methods can be
+  //    more difficult to predict when they get optimized and they are almost
+  //    never inlined properly in static compilers.
+  // 2) Nobody should rely on `instanceof Fiber` for type testing. We should
+  //    always know when it is a fiber.
+  // 3) We might want to experiment with using numeric keys since they are easier
+  //    to optimize in a non-JIT environment.
+  // 4) We can easily go from a constructor to a createFiber object literal if that
+  //    is faster.
+  // 5) It should be easy to port this to a C struct and keep a C implementation
+  //    compatible.
+
+
+  var createFiber = function (tag, pendingProps, key, mode) {
+    // $FlowFixMe: the shapes are exact here but Flow doesn't like constructors
+    return new FiberNode(tag, pendingProps, key, mode);
+  };
+
+  function shouldConstruct$1(Component) {
+    var prototype = Component.prototype;
+    return !!(prototype && prototype.isReactComponent);
+  }
+
+  function isSimpleFunctionComponent(type) {
+    return typeof type === 'function' && !shouldConstruct$1(type) && type.defaultProps === undefined;
+  }
+  function resolveLazyComponentTag(Component) {
+    if (typeof Component === 'function') {
+      return shouldConstruct$1(Component) ? ClassComponent : FunctionComponent;
+    } else if (Component !== undefined && Component !== null) {
+      var $$typeof = Component.$$typeof;
+
+      if ($$typeof === REACT_FORWARD_REF_TYPE) {
+        return ForwardRef;
+      }
+
+      if ($$typeof === REACT_MEMO_TYPE) {
+        return MemoComponent;
+      }
+    }
+
+    return IndeterminateComponent;
+  } // This is used to create an alternate fiber to do work on.
+
+  function createWorkInProgress(current, pendingProps) {
+    var workInProgress = current.alternate;
+
+    if (workInProgress === null) {
+      // We use a double buffering pooling technique because we know that we'll
+      // only ever need at most two versions of a tree. We pool the "other" unused
+      // node that we're free to reuse. This is lazily created to avoid allocating
+      // extra objects for things that are never updated. It also allow us to
+      // reclaim the extra memory if needed.
+      workInProgress = createFiber(current.tag, pendingProps, current.key, current.mode);
+      workInProgress.elementType = current.elementType;
+      workInProgress.type = current.type;
+      workInProgress.stateNode = current.stateNode;
+
+      {
+        // DEV-only fields
+        workInProgress._debugID = current._debugID;
+        workInProgress._debugSource = current._debugSource;
+        workInProgress._debugOwner = current._debugOwner;
+        workInProgress._debugHookTypes = current._debugHookTypes;
+      }
+
+      workInProgress.alternate = current;
+      current.alternate = workInProgress;
+    } else {
+      workInProgress.pendingProps = pendingProps; // Needed because Blocks store data on type.
+
+      workInProgress.type = current.type; // We already have an alternate.
+      // Reset the effect tag.
+
+      workInProgress.flags = NoFlags; // The effect list is no longer valid.
+
+      workInProgress.nextEffect = null;
+      workInProgress.firstEffect = null;
+      workInProgress.lastEffect = null;
+
+      {
+        // We intentionally reset, rather than copy, actualDuration & actualStartTime.
+        // This prevents time from endlessly accumulating in new commits.
+        // This has the downside of resetting values for different priority renders,
+        // But works for yielding (the common case) and should support resuming.
+        workInProgress.actualDuration = 0;
+        workInProgress.actualStartTime = -1;
+      }
+    }
+
+    workInProgress.childLanes = current.childLanes;
+    workInProgress.lanes = current.lanes;
+    workInProgress.child = current.child;
+    workInProgress.memoizedProps = current.memoizedProps;
+    workInProgress.memoizedState = current.memoizedState;
+    workInProgress.updateQueue = current.updateQueue; // Clone the dependencies object. This is mutated during the render phase, so
+    // it cannot be shared with the current fiber.
+
+    var currentDependencies = current.dependencies;
+    workInProgress.dependencies = currentDependencies === null ? null : {
+      lanes: currentDependencies.lanes,
+      firstContext: currentDependencies.firstContext
+    }; // These will be overridden during the parent's reconciliation
+
+    workInProgress.sibling = current.sibling;
+    workInProgress.index = current.index;
+    workInProgress.ref = current.ref;
+
+    {
+      workInProgress.selfBaseDuration = current.selfBaseDuration;
+      workInProgress.treeBaseDuration = current.treeBaseDuration;
+    }
+
+    {
+      workInProgress._debugNeedsRemount = current._debugNeedsRemount;
+
+      switch (workInProgress.tag) {
+        case IndeterminateComponent:
+        case FunctionComponent:
+        case SimpleMemoComponent:
+          workInProgress.type = resolveFunctionForHotReloading(current.type);
+          break;
+
+        case ClassComponent:
+          workInProgress.type = resolveClassForHotReloading(current.type);
+          break;
+
+        case ForwardRef:
+          workInProgress.type = resolveForwardRefForHotReloading(current.type);
+          break;
+      }
+    }
+
+    return workInProgress;
+  } // Used to reuse a Fiber for a second pass.
+
+  function resetWorkInProgress(workInProgress, renderLanes) {
+    // This resets the Fiber to what createFiber or createWorkInProgress would
+    // have set the values to before during the first pass. Ideally this wouldn't
+    // be necessary but unfortunately many code paths reads from the workInProgress
+    // when they should be reading from current and writing to workInProgress.
+    // We assume pendingProps, index, key, ref, return are still untouched to
+    // avoid doing another reconciliation.
+    // Reset the effect tag but keep any Placement tags, since that's something
+    // that child fiber is setting, not the reconciliation.
+    workInProgress.flags &= Placement; // The effect list is no longer valid.
+
+    workInProgress.nextEffect = null;
+    workInProgress.firstEffect = null;
+    workInProgress.lastEffect = null;
+    var current = workInProgress.alternate;
+
+    if (current === null) {
+      // Reset to createFiber's initial values.
+      workInProgress.childLanes = NoLanes;
+      workInProgress.lanes = renderLanes;
+      workInProgress.child = null;
+      workInProgress.memoizedProps = null;
+      workInProgress.memoizedState = null;
+      workInProgress.updateQueue = null;
+      workInProgress.dependencies = null;
+      workInProgress.stateNode = null;
+
+      {
+        // Note: We don't reset the actualTime counts. It's useful to accumulate
+        // actual time across multiple render passes.
+        workInProgress.selfBaseDuration = 0;
+        workInProgress.treeBaseDuration = 0;
+      }
+    } else {
+      // Reset to the cloned values that createWorkInProgress would've.
+      workInProgress.childLanes = current.childLanes;
+      workInProgress.lanes = current.lanes;
+      workInProgress.child = current.child;
+      workInProgress.memoizedProps = current.memoizedProps;
+      workInProgress.memoizedState = current.memoizedState;
+      workInProgress.updateQueue = current.updateQueue; // Needed because Blocks store data on type.
+
+      workInProgress.type = current.type; // Clone the dependencies object. This is mutated during the render phase, so
+      // it cannot be shared with the current fiber.
+
+      var currentDependencies = current.dependencies;
+      workInProgress.dependencies = currentDependencies === null ? null : {
+        lanes: currentDependencies.lanes,
+        firstContext: currentDependencies.firstContext
+      };
+
+      {
+        // Note: We don't reset the actualTime counts. It's useful to accumulate
+        // actual time across multiple render passes.
+        workInProgress.selfBaseDuration = current.selfBaseDuration;
+        workInProgress.treeBaseDuration = current.treeBaseDuration;
+      }
+    }
+
+    return workInProgress;
+  }
+  function createHostRootFiber(tag) {
+    var mode;
+
+    if (tag === ConcurrentRoot) {
+      mode = ConcurrentMode | BlockingMode | StrictMode;
+    } else if (tag === BlockingRoot) {
+      mode = BlockingMode | StrictMode;
+    } else {
+      mode = NoMode;
+    }
+
+    if ( isDevToolsPresent) {
+      // Always collect profile timings when DevTools are present.
+      // This enables DevTools to start capturing timing at any point–
+      // Without some nodes in the tree having empty base times.
+      mode |= ProfileMode;
+    }
+
+    return createFiber(HostRoot, null, null, mode);
+  }
+  function createFiberFromTypeAndProps(type, // React$ElementType
+  key, pendingProps, owner, mode, lanes) {
+    var fiberTag = IndeterminateComponent; // The resolved type is set if we know what the final type will be. I.e. it's not lazy.
+
+    var resolvedType = type;
+
+    if (typeof type === 'function') {
+      if (shouldConstruct$1(type)) {
+        fiberTag = ClassComponent;
+
+        {
+          resolvedType = resolveClassForHotReloading(resolvedType);
+        }
+      } else {
+        {
+          resolvedType = resolveFunctionForHotReloading(resolvedType);
+        }
+      }
+    } else if (typeof type === 'string') {
+      fiberTag = HostComponent;
+    } else {
+      getTag: switch (type) {
+        case REACT_FRAGMENT_TYPE:
+          return createFiberFromFragment(pendingProps.children, mode, lanes, key);
+
+        case REACT_DEBUG_TRACING_MODE_TYPE:
+          fiberTag = Mode;
+          mode |= DebugTracingMode;
+          break;
+
+        case REACT_STRICT_MODE_TYPE:
+          fiberTag = Mode;
+          mode |= StrictMode;
+          break;
+
+        case REACT_PROFILER_TYPE:
+          return createFiberFromProfiler(pendingProps, mode, lanes, key);
+
+        case REACT_SUSPENSE_TYPE:
+          return createFiberFromSuspense(pendingProps, mode, lanes, key);
+
+        case REACT_SUSPENSE_LIST_TYPE:
+          return createFiberFromSuspenseList(pendingProps, mode, lanes, key);
+
+        case REACT_OFFSCREEN_TYPE:
+          return createFiberFromOffscreen(pendingProps, mode, lanes, key);
+
+        case REACT_LEGACY_HIDDEN_TYPE:
+          return createFiberFromLegacyHidden(pendingProps, mode, lanes, key);
+
+        case REACT_SCOPE_TYPE:
+
+        // eslint-disable-next-line no-fallthrough
+
+        default:
+          {
+            if (typeof type === 'object' && type !== null) {
+              switch (type.$$typeof) {
+                case REACT_PROVIDER_TYPE:
+                  fiberTag = ContextProvider;
+                  break getTag;
+
+                case REACT_CONTEXT_TYPE:
+                  // This is a consumer
+                  fiberTag = ContextConsumer;
+                  break getTag;
+
+                case REACT_FORWARD_REF_TYPE:
+                  fiberTag = ForwardRef;
+
+                  {
+                    resolvedType = resolveForwardRefForHotReloading(resolvedType);
+                  }
+
+                  break getTag;
+
+                case REACT_MEMO_TYPE:
+                  fiberTag = MemoComponent;
+                  break getTag;
+
+                case REACT_LAZY_TYPE:
+                  fiberTag = LazyComponent;
+                  resolvedType = null;
+                  break getTag;
+
+                case REACT_BLOCK_TYPE:
+                  fiberTag = Block;
+                  break getTag;
+              }
+            }
+
+            var info = '';
+
+            {
+              if (type === undefined || typeof type === 'object' && type !== null && Object.keys(type).length === 0) {
+                info += ' You likely forgot to export your component from the file ' + "it's defined in, or you might have mixed up default and " + 'named imports.';
+              }
+
+              var ownerName = owner ? getComponentName(owner.type) : null;
+
+              if (ownerName) {
+                info += '\n\nCheck the render method of `' + ownerName + '`.';
+              }
+            }
+
+            {
+              {
+                throw Error( "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: " + (type == null ? type : typeof type) + "." + info );
+              }
+            }
+          }
+      }
+    }
+
+    var fiber = createFiber(fiberTag, pendingProps, key, mode);
+    fiber.elementType = type;
+    fiber.type = resolvedType;
+    fiber.lanes = lanes;
+
+    {
+      fiber._debugOwner = owner;
+    }
+
+    return fiber;
+  }
+  function createFiberFromElement(element, mode, lanes) {
+    var owner = null;
+
+    {
+      owner = element._owner;
+    }
+
+    var type = element.type;
+    var key = element.key;
+    var pendingProps = element.props;
+    var fiber = createFiberFromTypeAndProps(type, key, pendingProps, owner, mode, lanes);
+
+    {
+      fiber._debugSource = element._source;
+      fiber._debugOwner = element._owner;
+    }
+
+    return fiber;
+  }
+  function createFiberFromFragment(elements, mode, lanes, key) {
+    var fiber = createFiber(Fragment, elements, key, mode);
+    fiber.lanes = lanes;
+    return fiber;
+  }
+
+  function createFiberFromProfiler(pendingProps, mode, lanes, key) {
+    {
+      if (typeof pendingProps.id !== 'string') {
+        error('Profiler must specify an "id" as a prop');
+      }
+    }
+
+    var fiber = createFiber(Profiler, pendingProps, key, mode | ProfileMode); // TODO: The Profiler fiber shouldn't have a type. It has a tag.
+
+    fiber.elementType = REACT_PROFILER_TYPE;
+    fiber.type = REACT_PROFILER_TYPE;
+    fiber.lanes = lanes;
+
+    {
+      fiber.stateNode = {
+        effectDuration: 0,
+        passiveEffectDuration: 0
+      };
+    }
+
+    return fiber;
+  }
+
+  function createFiberFromSuspense(pendingProps, mode, lanes, key) {
+    var fiber = createFiber(SuspenseComponent, pendingProps, key, mode); // TODO: The SuspenseComponent fiber shouldn't have a type. It has a tag.
+    // This needs to be fixed in getComponentName so that it relies on the tag
+    // instead.
+
+    fiber.type = REACT_SUSPENSE_TYPE;
+    fiber.elementType = REACT_SUSPENSE_TYPE;
+    fiber.lanes = lanes;
+    return fiber;
+  }
+  function createFiberFromSuspenseList(pendingProps, mode, lanes, key) {
+    var fiber = createFiber(SuspenseListComponent, pendingProps, key, mode);
+
+    {
+      // TODO: The SuspenseListComponent fiber shouldn't have a type. It has a tag.
+      // This needs to be fixed in getComponentName so that it relies on the tag
+      // instead.
+      fiber.type = REACT_SUSPENSE_LIST_TYPE;
+    }
+
+    fiber.elementType = REACT_SUSPENSE_LIST_TYPE;
+    fiber.lanes = lanes;
+    return fiber;
+  }
+  function createFiberFromOffscreen(pendingProps, mode, lanes, key) {
+    var fiber = createFiber(OffscreenComponent, pendingProps, key, mode); // TODO: The OffscreenComponent fiber shouldn't have a type. It has a tag.
+    // This needs to be fixed in getComponentName so that it relies on the tag
+    // instead.
+
+    {
+      fiber.type = REACT_OFFSCREEN_TYPE;
+    }
+
+    fiber.elementType = REACT_OFFSCREEN_TYPE;
+    fiber.lanes = lanes;
+    return fiber;
+  }
+  function createFiberFromLegacyHidden(pendingProps, mode, lanes, key) {
+    var fiber = createFiber(LegacyHiddenComponent, pendingProps, key, mode); // TODO: The LegacyHidden fiber shouldn't have a type. It has a tag.
+    // This needs to be fixed in getComponentName so that it relies on the tag
+    // instead.
+
+    {
+      fiber.type = REACT_LEGACY_HIDDEN_TYPE;
+    }
+
+    fiber.elementType = REACT_LEGACY_HIDDEN_TYPE;
+    fiber.lanes = lanes;
+    return fiber;
+  }
+  function createFiberFromText(content, mode, lanes) {
+    var fiber = createFiber(HostText, content, null, mode);
+    fiber.lanes = lanes;
+    return fiber;
+  }
+  function createFiberFromHostInstanceForDeletion() {
+    var fiber = createFiber(HostComponent, null, null, NoMode); // TODO: These should not need a type.
+
+    fiber.elementType = 'DELETED';
+    fiber.type = 'DELETED';
+    return fiber;
+  }
+  function createFiberFromPortal(portal, mode, lanes) {
+    var pendingProps = portal.children !== null ? portal.children : [];
+    var fiber = createFiber(HostPortal, pendingProps, portal.key, mode);
+    fiber.lanes = lanes;
+    fiber.stateNode = {
+      containerInfo: portal.containerInfo,
+      pendingChildren: null,
+      // Used by persistent updates
+      implementation: portal.implementation
+    };
+    return fiber;
+  } // Used for stashing WIP properties to replay failed work in DEV.
+
+  function assignFiberPropertiesInDEV(target, source) {
+    if (target === null) {
+      // This Fiber's initial properties will always be overwritten.
+      // We only use a Fiber to ensure the same hidden class so DEV isn't slow.
+      target = createFiber(IndeterminateComponent, null, null, NoMode);
+    } // This is intentionally written as a list of all properties.
+    // We tried to use Object.assign() instead but this is called in
+    // the hottest path, and Object.assign() was too slow:
+    // https://github.com/facebook/react/issues/12502
+    // This code is DEV-only so size is not a concern.
+
+
+    target.tag = source.tag;
+    target.key = source.key;
+    target.elementType = source.elementType;
+    target.type = source.type;
+    target.stateNode = source.stateNode;
+    target.return = source.return;
+    target.child = source.child;
+    target.sibling = source.sibling;
+    target.index = source.index;
+    target.ref = source.ref;
+    target.pendingProps = source.pendingProps;
+    target.memoizedProps = source.memoizedProps;
+    target.updateQueue = source.updateQueue;
+    target.memoizedState = source.memoizedState;
+    target.dependencies = source.dependencies;
+    target.mode = source.mode;
+    target.flags = source.flags;
+    target.nextEffect = source.nextEffect;
+    target.firstEffect = source.firstEffect;
+    target.lastEffect = source.lastEffect;
+    target.lanes = source.lanes;
+    target.childLanes = source.childLanes;
+    target.alternate = source.alternate;
+
+    {
+      target.actualDuration = source.actualDuration;
+      target.actualStartTime = source.actualStartTime;
+      target.selfBaseDuration = source.selfBaseDuration;
+      target.treeBaseDuration = source.treeBaseDuration;
+    }
+
+    target._debugID = source._debugID;
+    target._debugSource = source._debugSource;
+    target._debugOwner = source._debugOwner;
+    target._debugNeedsRemount = source._debugNeedsRemount;
+    target._debugHookTypes = source._debugHookTypes;
+    return target;
+  }
+
+  function FiberRootNode(containerInfo, tag, hydrate) {
+    this.tag = tag;
+    this.containerInfo = containerInfo;
+    this.pendingChildren = null;
+    this.current = null;
+    this.pingCache = null;
+    this.finishedWork = null;
+    this.timeoutHandle = noTimeout;
+    this.context = null;
+    this.pendingContext = null;
+    this.hydrate = hydrate;
+    this.callbackNode = null;
+    this.callbackPriority = NoLanePriority;
+    this.eventTimes = createLaneMap(NoLanes);
+    this.expirationTimes = createLaneMap(NoTimestamp);
+    this.pendingLanes = NoLanes;
+    this.suspendedLanes = NoLanes;
+    this.pingedLanes = NoLanes;
+    this.expiredLanes = NoLanes;
+    this.mutableReadLanes = NoLanes;
+    this.finishedLanes = NoLanes;
+    this.entangledLanes = NoLanes;
+    this.entanglements = createLaneMap(NoLanes);
+
+    {
+      this.mutableSourceEagerHydrationData = null;
+    }
+
+    {
+      this.interactionThreadID = unstable_getThreadID();
+      this.memoizedInteractions = new Set();
+      this.pendingInteractionMap = new Map();
+    }
+
+    {
+      switch (tag) {
+        case BlockingRoot:
+          this._debugRootType = 'createBlockingRoot()';
+          break;
+
+        case ConcurrentRoot:
+          this._debugRootType = 'createRoot()';
+          break;
+
+        case LegacyRoot:
+          this._debugRootType = 'createLegacyRoot()';
+          break;
+      }
+    }
+  }
+
+  function createFiberRoot(containerInfo, tag, hydrate, hydrationCallbacks) {
+    var root = new FiberRootNode(containerInfo, tag, hydrate);
+    // stateNode is any.
+
+
+    var uninitializedFiber = createHostRootFiber(tag);
+    root.current = uninitializedFiber;
+    uninitializedFiber.stateNode = root;
+    initializeUpdateQueue(uninitializedFiber);
+    return root;
+  }
+
+  // This ensures that the version used for server rendering matches the one
+  // that is eventually read during hydration.
+  // If they don't match there's a potential tear and a full deopt render is required.
+
+  function registerMutableSourceForHydration(root, mutableSource) {
+    var getVersion = mutableSource._getVersion;
+    var version = getVersion(mutableSource._source); // TODO Clear this data once all pending hydration work is finished.
+    // Retaining it forever may interfere with GC.
+
+    if (root.mutableSourceEagerHydrationData == null) {
+      root.mutableSourceEagerHydrationData = [mutableSource, version];
+    } else {
+      root.mutableSourceEagerHydrationData.push(mutableSource, version);
+    }
+  }
+
+  function createPortal(children, containerInfo, // TODO: figure out the API for cross-renderer implementation.
+  implementation) {
+    var key = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : null;
+    return {
+      // This tag allow us to uniquely identify this as a React Portal
+      $$typeof: REACT_PORTAL_TYPE,
+      key: key == null ? null : '' + key,
+      children: children,
+      containerInfo: containerInfo,
+      implementation: implementation
+    };
+  }
+
+  var didWarnAboutNestedUpdates;
+  var didWarnAboutFindNodeInStrictMode;
+
+  {
+    didWarnAboutNestedUpdates = false;
+    didWarnAboutFindNodeInStrictMode = {};
+  }
+
+  function getContextForSubtree(parentComponent) {
+    if (!parentComponent) {
+      return emptyContextObject;
+    }
+
+    var fiber = get(parentComponent);
+    var parentContext = findCurrentUnmaskedContext(fiber);
+
+    if (fiber.tag === ClassComponent) {
+      var Component = fiber.type;
+
+      if (isContextProvider(Component)) {
+        return processChildContext(fiber, Component, parentContext);
+      }
+    }
+
+    return parentContext;
+  }
+
+  function findHostInstanceWithWarning(component, methodName) {
+    {
+      var fiber = get(component);
+
+      if (fiber === undefined) {
+        if (typeof component.render === 'function') {
+          {
+            {
+              throw Error( "Unable to find node on an unmounted component." );
+            }
+          }
+        } else {
+          {
+            {
+              throw Error( "Argument appears to not be a ReactComponent. Keys: " + Object.keys(component) );
+            }
+          }
+        }
+      }
+
+      var hostFiber = findCurrentHostFiber(fiber);
+
+      if (hostFiber === null) {
+        return null;
+      }
+
+      if (hostFiber.mode & StrictMode) {
+        var componentName = getComponentName(fiber.type) || 'Component';
+
+        if (!didWarnAboutFindNodeInStrictMode[componentName]) {
+          didWarnAboutFindNodeInStrictMode[componentName] = true;
+          var previousFiber = current;
+
+          try {
+            setCurrentFiber(hostFiber);
+
+            if (fiber.mode & StrictMode) {
+              error('%s is deprecated in StrictMode. ' + '%s was passed an instance of %s which is inside StrictMode. ' + 'Instead, add a ref directly to the element you want to reference. ' + 'Learn more about using refs safely here: ' + 'https://reactjs.org/link/strict-mode-find-node', methodName, methodName, componentName);
+            } else {
+              error('%s is deprecated in StrictMode. ' + '%s was passed an instance of %s which renders StrictMode children. ' + 'Instead, add a ref directly to the element you want to reference. ' + 'Learn more about using refs safely here: ' + 'https://reactjs.org/link/strict-mode-find-node', methodName, methodName, componentName);
+            }
+          } finally {
+            // Ideally this should reset to previous but this shouldn't be called in
+            // render and there's another warning for that anyway.
+            if (previousFiber) {
+              setCurrentFiber(previousFiber);
+            } else {
+              resetCurrentFiber();
+            }
+          }
+        }
+      }
+
+      return hostFiber.stateNode;
+    }
+  }
+
+  function createContainer(containerInfo, tag, hydrate, hydrationCallbacks) {
+    return createFiberRoot(containerInfo, tag, hydrate);
+  }
+  function updateContainer(element, container, parentComponent, callback) {
+    {
+      onScheduleRoot(container, element);
+    }
+
+    var current$1 = container.current;
+    var eventTime = requestEventTime();
+
+    {
+      // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+      if ('undefined' !== typeof jest) {
+        warnIfUnmockedScheduler(current$1);
+        warnIfNotScopedWithMatchingAct(current$1);
+      }
+    }
+
+    var lane = requestUpdateLane(current$1);
+
+    var context = getContextForSubtree(parentComponent);
+
+    if (container.context === null) {
+      container.context = context;
+    } else {
+      container.pendingContext = context;
+    }
+
+    {
+      if (isRendering && current !== null && !didWarnAboutNestedUpdates) {
+        didWarnAboutNestedUpdates = true;
+
+        error('Render methods should be a pure function of props and state; ' + 'triggering nested component updates from render is not allowed. ' + 'If necessary, trigger nested updates in componentDidUpdate.\n\n' + 'Check the render method of %s.', getComponentName(current.type) || 'Unknown');
+      }
+    }
+
+    var update = createUpdate(eventTime, lane); // Caution: React DevTools currently depends on this property
+    // being called "element".
+
+    update.payload = {
+      element: element
+    };
+    callback = callback === undefined ? null : callback;
+
+    if (callback !== null) {
+      {
+        if (typeof callback !== 'function') {
+          error('render(...): Expected the last optional `callback` argument to be a ' + 'function. Instead received: %s.', callback);
+        }
+      }
+
+      update.callback = callback;
+    }
+
+    enqueueUpdate(current$1, update);
+    scheduleUpdateOnFiber(current$1, lane, eventTime);
+    return lane;
+  }
+  function getPublicRootInstance(container) {
+    var containerFiber = container.current;
+
+    if (!containerFiber.child) {
+      return null;
+    }
+
+    switch (containerFiber.child.tag) {
+      case HostComponent:
+        return getPublicInstance(containerFiber.child.stateNode);
+
+      default:
+        return containerFiber.child.stateNode;
+    }
+  }
+
+  function markRetryLaneImpl(fiber, retryLane) {
+    var suspenseState = fiber.memoizedState;
+
+    if (suspenseState !== null && suspenseState.dehydrated !== null) {
+      suspenseState.retryLane = higherPriorityLane(suspenseState.retryLane, retryLane);
+    }
+  } // Increases the priority of thennables when they resolve within this boundary.
+
+
+  function markRetryLaneIfNotHydrated(fiber, retryLane) {
+    markRetryLaneImpl(fiber, retryLane);
+    var alternate = fiber.alternate;
+
+    if (alternate) {
+      markRetryLaneImpl(alternate, retryLane);
+    }
+  }
+
+  function attemptUserBlockingHydration$1(fiber) {
+    if (fiber.tag !== SuspenseComponent) {
+      // We ignore HostRoots here because we can't increase
+      // their priority and they should not suspend on I/O,
+      // since you have to wrap anything that might suspend in
+      // Suspense.
+      return;
+    }
+
+    var eventTime = requestEventTime();
+    var lane = InputDiscreteHydrationLane;
+    scheduleUpdateOnFiber(fiber, lane, eventTime);
+    markRetryLaneIfNotHydrated(fiber, lane);
+  }
+  function attemptContinuousHydration$1(fiber) {
+    if (fiber.tag !== SuspenseComponent) {
+      // We ignore HostRoots here because we can't increase
+      // their priority and they should not suspend on I/O,
+      // since you have to wrap anything that might suspend in
+      // Suspense.
+      return;
+    }
+
+    var eventTime = requestEventTime();
+    var lane = SelectiveHydrationLane;
+    scheduleUpdateOnFiber(fiber, lane, eventTime);
+    markRetryLaneIfNotHydrated(fiber, lane);
+  }
+  function attemptHydrationAtCurrentPriority$1(fiber) {
+    if (fiber.tag !== SuspenseComponent) {
+      // We ignore HostRoots here because we can't increase
+      // their priority other than synchronously flush it.
+      return;
+    }
+
+    var eventTime = requestEventTime();
+    var lane = requestUpdateLane(fiber);
+    scheduleUpdateOnFiber(fiber, lane, eventTime);
+    markRetryLaneIfNotHydrated(fiber, lane);
+  }
+  function runWithPriority$2(priority, fn) {
+
+    try {
+      setCurrentUpdateLanePriority(priority);
+      return fn();
+    } finally {
+    }
+  }
+  function findHostInstanceWithNoPortals(fiber) {
+    var hostFiber = findCurrentHostFiberWithNoPortals(fiber);
+
+    if (hostFiber === null) {
+      return null;
+    }
+
+    if (hostFiber.tag === FundamentalComponent) {
+      return hostFiber.stateNode.instance;
+    }
+
+    return hostFiber.stateNode;
+  }
+
+  var shouldSuspendImpl = function (fiber) {
+    return false;
+  };
+
+  function shouldSuspend(fiber) {
+    return shouldSuspendImpl(fiber);
+  }
+  var overrideHookState = null;
+  var overrideHookStateDeletePath = null;
+  var overrideHookStateRenamePath = null;
+  var overrideProps = null;
+  var overridePropsDeletePath = null;
+  var overridePropsRenamePath = null;
+  var scheduleUpdate = null;
+  var setSuspenseHandler = null;
+
+  {
+    var copyWithDeleteImpl = function (obj, path, index) {
+      var key = path[index];
+      var updated = Array.isArray(obj) ? obj.slice() : _assign({}, obj);
+
+      if (index + 1 === path.length) {
+        if (Array.isArray(updated)) {
+          updated.splice(key, 1);
+        } else {
+          delete updated[key];
+        }
+
+        return updated;
+      } // $FlowFixMe number or string is fine here
+
+
+      updated[key] = copyWithDeleteImpl(obj[key], path, index + 1);
+      return updated;
+    };
+
+    var copyWithDelete = function (obj, path) {
+      return copyWithDeleteImpl(obj, path, 0);
+    };
+
+    var copyWithRenameImpl = function (obj, oldPath, newPath, index) {
+      var oldKey = oldPath[index];
+      var updated = Array.isArray(obj) ? obj.slice() : _assign({}, obj);
+
+      if (index + 1 === oldPath.length) {
+        var newKey = newPath[index]; // $FlowFixMe number or string is fine here
+
+        updated[newKey] = updated[oldKey];
+
+        if (Array.isArray(updated)) {
+          updated.splice(oldKey, 1);
+        } else {
+          delete updated[oldKey];
+        }
+      } else {
+        // $FlowFixMe number or string is fine here
+        updated[oldKey] = copyWithRenameImpl( // $FlowFixMe number or string is fine here
+        obj[oldKey], oldPath, newPath, index + 1);
+      }
+
+      return updated;
+    };
+
+    var copyWithRename = function (obj, oldPath, newPath) {
+      if (oldPath.length !== newPath.length) {
+        warn('copyWithRename() expects paths of the same length');
+
+        return;
+      } else {
+        for (var i = 0; i < newPath.length - 1; i++) {
+          if (oldPath[i] !== newPath[i]) {
+            warn('copyWithRename() expects paths to be the same except for the deepest key');
+
+            return;
+          }
+        }
+      }
+
+      return copyWithRenameImpl(obj, oldPath, newPath, 0);
+    };
+
+    var copyWithSetImpl = function (obj, path, index, value) {
+      if (index >= path.length) {
+        return value;
+      }
+
+      var key = path[index];
+      var updated = Array.isArray(obj) ? obj.slice() : _assign({}, obj); // $FlowFixMe number or string is fine here
+
+      updated[key] = copyWithSetImpl(obj[key], path, index + 1, value);
+      return updated;
+    };
+
+    var copyWithSet = function (obj, path, value) {
+      return copyWithSetImpl(obj, path, 0, value);
+    };
+
+    var findHook = function (fiber, id) {
+      // For now, the "id" of stateful hooks is just the stateful hook index.
+      // This may change in the future with e.g. nested hooks.
+      var currentHook = fiber.memoizedState;
+
+      while (currentHook !== null && id > 0) {
+        currentHook = currentHook.next;
+        id--;
+      }
+
+      return currentHook;
+    }; // Support DevTools editable values for useState and useReducer.
+
+
+    overrideHookState = function (fiber, id, path, value) {
+      var hook = findHook(fiber, id);
+
+      if (hook !== null) {
+        var newState = copyWithSet(hook.memoizedState, path, value);
+        hook.memoizedState = newState;
+        hook.baseState = newState; // We aren't actually adding an update to the queue,
+        // because there is no update we can add for useReducer hooks that won't trigger an error.
+        // (There's no appropriate action type for DevTools overrides.)
+        // As a result though, React will see the scheduled update as a noop and bailout.
+        // Shallow cloning props works as a workaround for now to bypass the bailout check.
+
+        fiber.memoizedProps = _assign({}, fiber.memoizedProps);
+        scheduleUpdateOnFiber(fiber, SyncLane, NoTimestamp);
+      }
+    };
+
+    overrideHookStateDeletePath = function (fiber, id, path) {
+      var hook = findHook(fiber, id);
+
+      if (hook !== null) {
+        var newState = copyWithDelete(hook.memoizedState, path);
+        hook.memoizedState = newState;
+        hook.baseState = newState; // We aren't actually adding an update to the queue,
+        // because there is no update we can add for useReducer hooks that won't trigger an error.
+        // (There's no appropriate action type for DevTools overrides.)
+        // As a result though, React will see the scheduled update as a noop and bailout.
+        // Shallow cloning props works as a workaround for now to bypass the bailout check.
+
+        fiber.memoizedProps = _assign({}, fiber.memoizedProps);
+        scheduleUpdateOnFiber(fiber, SyncLane, NoTimestamp);
+      }
+    };
+
+    overrideHookStateRenamePath = function (fiber, id, oldPath, newPath) {
+      var hook = findHook(fiber, id);
+
+      if (hook !== null) {
+        var newState = copyWithRename(hook.memoizedState, oldPath, newPath);
+        hook.memoizedState = newState;
+        hook.baseState = newState; // We aren't actually adding an update to the queue,
+        // because there is no update we can add for useReducer hooks that won't trigger an error.
+        // (There's no appropriate action type for DevTools overrides.)
+        // As a result though, React will see the scheduled update as a noop and bailout.
+        // Shallow cloning props works as a workaround for now to bypass the bailout check.
+
+        fiber.memoizedProps = _assign({}, fiber.memoizedProps);
+        scheduleUpdateOnFiber(fiber, SyncLane, NoTimestamp);
+      }
+    }; // Support DevTools props for function components, forwardRef, memo, host components, etc.
+
+
+    overrideProps = function (fiber, path, value) {
+      fiber.pendingProps = copyWithSet(fiber.memoizedProps, path, value);
+
+      if (fiber.alternate) {
+        fiber.alternate.pendingProps = fiber.pendingProps;
+      }
+
+      scheduleUpdateOnFiber(fiber, SyncLane, NoTimestamp);
+    };
+
+    overridePropsDeletePath = function (fiber, path) {
+      fiber.pendingProps = copyWithDelete(fiber.memoizedProps, path);
+
+      if (fiber.alternate) {
+        fiber.alternate.pendingProps = fiber.pendingProps;
+      }
+
+      scheduleUpdateOnFiber(fiber, SyncLane, NoTimestamp);
+    };
+
+    overridePropsRenamePath = function (fiber, oldPath, newPath) {
+      fiber.pendingProps = copyWithRename(fiber.memoizedProps, oldPath, newPath);
+
+      if (fiber.alternate) {
+        fiber.alternate.pendingProps = fiber.pendingProps;
+      }
+
+      scheduleUpdateOnFiber(fiber, SyncLane, NoTimestamp);
+    };
+
+    scheduleUpdate = function (fiber) {
+      scheduleUpdateOnFiber(fiber, SyncLane, NoTimestamp);
+    };
+
+    setSuspenseHandler = function (newShouldSuspendImpl) {
+      shouldSuspendImpl = newShouldSuspendImpl;
+    };
+  }
+
+  function findHostInstanceByFiber(fiber) {
+    var hostFiber = findCurrentHostFiber(fiber);
+
+    if (hostFiber === null) {
+      return null;
+    }
+
+    return hostFiber.stateNode;
+  }
+
+  function emptyFindFiberByHostInstance(instance) {
+    return null;
+  }
+
+  function getCurrentFiberForDevTools() {
+    return current;
+  }
+
+  function injectIntoDevTools(devToolsConfig) {
+    var findFiberByHostInstance = devToolsConfig.findFiberByHostInstance;
+    var ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
+    return injectInternals({
+      bundleType: devToolsConfig.bundleType,
+      version: devToolsConfig.version,
+      rendererPackageName: devToolsConfig.rendererPackageName,
+      rendererConfig: devToolsConfig.rendererConfig,
+      overrideHookState: overrideHookState,
+      overrideHookStateDeletePath: overrideHookStateDeletePath,
+      overrideHookStateRenamePath: overrideHookStateRenamePath,
+      overrideProps: overrideProps,
+      overridePropsDeletePath: overridePropsDeletePath,
+      overridePropsRenamePath: overridePropsRenamePath,
+      setSuspenseHandler: setSuspenseHandler,
+      scheduleUpdate: scheduleUpdate,
+      currentDispatcherRef: ReactCurrentDispatcher,
+      findHostInstanceByFiber: findHostInstanceByFiber,
+      findFiberByHostInstance: findFiberByHostInstance || emptyFindFiberByHostInstance,
+      // React Refresh
+      findHostInstancesForRefresh:  findHostInstancesForRefresh ,
+      scheduleRefresh:  scheduleRefresh ,
+      scheduleRoot:  scheduleRoot ,
+      setRefreshHandler:  setRefreshHandler ,
+      // Enables DevTools to append owner stacks to error messages in DEV mode.
+      getCurrentFiber:  getCurrentFiberForDevTools 
+    });
+  }
+
+  function ReactDOMRoot(container, options) {
+    this._internalRoot = createRootImpl(container, ConcurrentRoot, options);
+  }
+
+  function ReactDOMBlockingRoot(container, tag, options) {
+    this._internalRoot = createRootImpl(container, tag, options);
+  }
+
+  ReactDOMRoot.prototype.render = ReactDOMBlockingRoot.prototype.render = function (children) {
+    var root = this._internalRoot;
+
+    {
+      if (typeof arguments[1] === 'function') {
+        error('render(...): does not support the second callback argument. ' + 'To execute a side effect after rendering, declare it in a component body with useEffect().');
+      }
+
+      var container = root.containerInfo;
+
+      if (container.nodeType !== COMMENT_NODE) {
+        var hostInstance = findHostInstanceWithNoPortals(root.current);
+
+        if (hostInstance) {
+          if (hostInstance.parentNode !== container) {
+            error('render(...): It looks like the React-rendered content of the ' + 'root container was removed without using React. This is not ' + 'supported and will cause errors. Instead, call ' + "root.unmount() to empty a root's container.");
+          }
+        }
+      }
+    }
+
+    updateContainer(children, root, null, null);
+  };
+
+  ReactDOMRoot.prototype.unmount = ReactDOMBlockingRoot.prototype.unmount = function () {
+    {
+      if (typeof arguments[0] === 'function') {
+        error('unmount(...): does not support a callback argument. ' + 'To execute a side effect after rendering, declare it in a component body with useEffect().');
+      }
+    }
+
+    var root = this._internalRoot;
+    var container = root.containerInfo;
+    updateContainer(null, root, null, function () {
+      unmarkContainerAsRoot(container);
+    });
+  };
+
+  function createRootImpl(container, tag, options) {
+    // Tag is either LegacyRoot or Concurrent Root
+    var hydrate = options != null && options.hydrate === true;
+    var hydrationCallbacks = options != null && options.hydrationOptions || null;
+    var mutableSources = options != null && options.hydrationOptions != null && options.hydrationOptions.mutableSources || null;
+    var root = createContainer(container, tag, hydrate);
+    markContainerAsRoot(root.current, container);
+    var containerNodeType = container.nodeType;
+
+    {
+      var rootContainerElement = container.nodeType === COMMENT_NODE ? container.parentNode : container;
+      listenToAllSupportedEvents(rootContainerElement);
+    }
+
+    if (mutableSources) {
+      for (var i = 0; i < mutableSources.length; i++) {
+        var mutableSource = mutableSources[i];
+        registerMutableSourceForHydration(root, mutableSource);
+      }
+    }
+
+    return root;
+  }
+  function createLegacyRoot(container, options) {
+    return new ReactDOMBlockingRoot(container, LegacyRoot, options);
+  }
+  function isValidContainer(node) {
+    return !!(node && (node.nodeType === ELEMENT_NODE || node.nodeType === DOCUMENT_NODE || node.nodeType === DOCUMENT_FRAGMENT_NODE || node.nodeType === COMMENT_NODE && node.nodeValue === ' react-mount-point-unstable '));
+  }
+
+  var ReactCurrentOwner$3 = ReactSharedInternals.ReactCurrentOwner;
+  var topLevelUpdateWarnings;
+  var warnedAboutHydrateAPI = false;
+
+  {
+    topLevelUpdateWarnings = function (container) {
+      if (container._reactRootContainer && container.nodeType !== COMMENT_NODE) {
+        var hostInstance = findHostInstanceWithNoPortals(container._reactRootContainer._internalRoot.current);
+
+        if (hostInstance) {
+          if (hostInstance.parentNode !== container) {
+            error('render(...): It looks like the React-rendered content of this ' + 'container was removed without using React. This is not ' + 'supported and will cause errors. Instead, call ' + 'ReactDOM.unmountComponentAtNode to empty a container.');
+          }
+        }
+      }
+
+      var isRootRenderedBySomeReact = !!container._reactRootContainer;
+      var rootEl = getReactRootElementInContainer(container);
+      var hasNonRootReactChild = !!(rootEl && getInstanceFromNode(rootEl));
+
+      if (hasNonRootReactChild && !isRootRenderedBySomeReact) {
+        error('render(...): Replacing React-rendered children with a new root ' + 'component. If you intended to update the children of this node, ' + 'you should instead have the existing children update their state ' + 'and render the new components instead of calling ReactDOM.render.');
+      }
+
+      if (container.nodeType === ELEMENT_NODE && container.tagName && container.tagName.toUpperCase() === 'BODY') {
+        error('render(): Rendering components directly into document.body is ' + 'discouraged, since its children are often manipulated by third-party ' + 'scripts and browser extensions. This may lead to subtle ' + 'reconciliation issues. Try rendering into a container element created ' + 'for your app.');
+      }
+    };
+  }
+
+  function getReactRootElementInContainer(container) {
+    if (!container) {
+      return null;
+    }
+
+    if (container.nodeType === DOCUMENT_NODE) {
+      return container.documentElement;
+    } else {
+      return container.firstChild;
+    }
+  }
+
+  function shouldHydrateDueToLegacyHeuristic(container) {
+    var rootElement = getReactRootElementInContainer(container);
+    return !!(rootElement && rootElement.nodeType === ELEMENT_NODE && rootElement.hasAttribute(ROOT_ATTRIBUTE_NAME));
+  }
+
+  function legacyCreateRootFromDOMContainer(container, forceHydrate) {
+    var shouldHydrate = forceHydrate || shouldHydrateDueToLegacyHeuristic(container); // First clear any existing content.
+
+    if (!shouldHydrate) {
+      var warned = false;
+      var rootSibling;
+
+      while (rootSibling = container.lastChild) {
+        {
+          if (!warned && rootSibling.nodeType === ELEMENT_NODE && rootSibling.hasAttribute(ROOT_ATTRIBUTE_NAME)) {
+            warned = true;
+
+            error('render(): Target node has markup rendered by React, but there ' + 'are unrelated nodes as well. This is most commonly caused by ' + 'white-space inserted around server-rendered markup.');
+          }
+        }
+
+        container.removeChild(rootSibling);
+      }
+    }
+
+    {
+      if (shouldHydrate && !forceHydrate && !warnedAboutHydrateAPI) {
+        warnedAboutHydrateAPI = true;
+
+        warn('render(): Calling ReactDOM.render() to hydrate server-rendered markup ' + 'will stop working in React v18. Replace the ReactDOM.render() call ' + 'with ReactDOM.hydrate() if you want React to attach to the server HTML.');
+      }
+    }
+
+    return createLegacyRoot(container, shouldHydrate ? {
+      hydrate: true
+    } : undefined);
+  }
+
+  function warnOnInvalidCallback$1(callback, callerName) {
+    {
+      if (callback !== null && typeof callback !== 'function') {
+        error('%s(...): Expected the last optional `callback` argument to be a ' + 'function. Instead received: %s.', callerName, callback);
+      }
+    }
+  }
+
+  function legacyRenderSubtreeIntoContainer(parentComponent, children, container, forceHydrate, callback) {
+    {
+      topLevelUpdateWarnings(container);
+      warnOnInvalidCallback$1(callback === undefined ? null : callback, 'render');
+    } // TODO: Without `any` type, Flow says "Property cannot be accessed on any
+    // member of intersection type." Whyyyyyy.
+
+
+    var root = container._reactRootContainer;
+    var fiberRoot;
+
+    if (!root) {
+      // Initial mount
+      root = container._reactRootContainer = legacyCreateRootFromDOMContainer(container, forceHydrate);
+      fiberRoot = root._internalRoot;
+
+      if (typeof callback === 'function') {
+        var originalCallback = callback;
+
+        callback = function () {
+          var instance = getPublicRootInstance(fiberRoot);
+          originalCallback.call(instance);
+        };
+      } // Initial mount should not be batched.
+
+
+      unbatchedUpdates(function () {
+        updateContainer(children, fiberRoot, parentComponent, callback);
+      });
+    } else {
+      fiberRoot = root._internalRoot;
+
+      if (typeof callback === 'function') {
+        var _originalCallback = callback;
+
+        callback = function () {
+          var instance = getPublicRootInstance(fiberRoot);
+
+          _originalCallback.call(instance);
+        };
+      } // Update
+
+
+      updateContainer(children, fiberRoot, parentComponent, callback);
+    }
+
+    return getPublicRootInstance(fiberRoot);
+  }
+
+  function findDOMNode(componentOrElement) {
+    {
+      var owner = ReactCurrentOwner$3.current;
+
+      if (owner !== null && owner.stateNode !== null) {
+        var warnedAboutRefsInRender = owner.stateNode._warnedAboutRefsInRender;
+
+        if (!warnedAboutRefsInRender) {
+          error('%s is accessing findDOMNode inside its render(). ' + 'render() should be a pure function of props and state. It should ' + 'never access something that requires stale data from the previous ' + 'render, such as refs. Move this logic to componentDidMount and ' + 'componentDidUpdate instead.', getComponentName(owner.type) || 'A component');
+        }
+
+        owner.stateNode._warnedAboutRefsInRender = true;
+      }
+    }
+
+    if (componentOrElement == null) {
+      return null;
+    }
+
+    if (componentOrElement.nodeType === ELEMENT_NODE) {
+      return componentOrElement;
+    }
+
+    {
+      return findHostInstanceWithWarning(componentOrElement, 'findDOMNode');
+    }
+  }
+  function hydrate(element, container, callback) {
+    if (!isValidContainer(container)) {
+      {
+        throw Error( "Target container is not a DOM element." );
+      }
+    }
+
+    {
+      var isModernRoot = isContainerMarkedAsRoot(container) && container._reactRootContainer === undefined;
+
+      if (isModernRoot) {
+        error('You are calling ReactDOM.hydrate() on a container that was previously ' + 'passed to ReactDOM.createRoot(). This is not supported. ' + 'Did you mean to call createRoot(container, {hydrate: true}).render(element)?');
+      }
+    } // TODO: throw or warn if we couldn't hydrate?
+
+
+    return legacyRenderSubtreeIntoContainer(null, element, container, true, callback);
+  }
+  function render(element, container, callback) {
+    if (!isValidContainer(container)) {
+      {
+        throw Error( "Target container is not a DOM element." );
+      }
+    }
+
+    {
+      var isModernRoot = isContainerMarkedAsRoot(container) && container._reactRootContainer === undefined;
+
+      if (isModernRoot) {
+        error('You are calling ReactDOM.render() on a container that was previously ' + 'passed to ReactDOM.createRoot(). This is not supported. ' + 'Did you mean to call root.render(element)?');
+      }
+    }
+
+    return legacyRenderSubtreeIntoContainer(null, element, container, false, callback);
+  }
+  function unstable_renderSubtreeIntoContainer(parentComponent, element, containerNode, callback) {
+    if (!isValidContainer(containerNode)) {
+      {
+        throw Error( "Target container is not a DOM element." );
+      }
+    }
+
+    if (!(parentComponent != null && has(parentComponent))) {
+      {
+        throw Error( "parentComponent must be a valid React Component" );
+      }
+    }
+
+    return legacyRenderSubtreeIntoContainer(parentComponent, element, containerNode, false, callback);
+  }
+  function unmountComponentAtNode(container) {
+    if (!isValidContainer(container)) {
+      {
+        throw Error( "unmountComponentAtNode(...): Target container is not a DOM element." );
+      }
+    }
+
+    {
+      var isModernRoot = isContainerMarkedAsRoot(container) && container._reactRootContainer === undefined;
+
+      if (isModernRoot) {
+        error('You are calling ReactDOM.unmountComponentAtNode() on a container that was previously ' + 'passed to ReactDOM.createRoot(). This is not supported. Did you mean to call root.unmount()?');
+      }
+    }
+
+    if (container._reactRootContainer) {
+      {
+        var rootEl = getReactRootElementInContainer(container);
+        var renderedByDifferentReact = rootEl && !getInstanceFromNode(rootEl);
+
+        if (renderedByDifferentReact) {
+          error("unmountComponentAtNode(): The node you're attempting to unmount " + 'was rendered by another copy of React.');
+        }
+      } // Unmount should not be batched.
+
+
+      unbatchedUpdates(function () {
+        legacyRenderSubtreeIntoContainer(null, null, container, false, function () {
+          // $FlowFixMe This should probably use `delete container._reactRootContainer`
+          container._reactRootContainer = null;
+          unmarkContainerAsRoot(container);
+        });
+      }); // If you call unmountComponentAtNode twice in quick succession, you'll
+      // get `true` twice. That's probably fine?
+
+      return true;
+    } else {
+      {
+        var _rootEl = getReactRootElementInContainer(container);
+
+        var hasNonRootReactChild = !!(_rootEl && getInstanceFromNode(_rootEl)); // Check if the container itself is a React root node.
+
+        var isContainerReactRoot = container.nodeType === ELEMENT_NODE && isValidContainer(container.parentNode) && !!container.parentNode._reactRootContainer;
+
+        if (hasNonRootReactChild) {
+          error("unmountComponentAtNode(): The node you're attempting to unmount " + 'was rendered by React and is not a top-level container. %s', isContainerReactRoot ? 'You may have accidentally passed in a React root node instead ' + 'of its container.' : 'Instead, have the parent component update its state and ' + 'rerender in order to remove this component.');
+        }
+      }
+
+      return false;
+    }
+  }
+
+  setAttemptUserBlockingHydration(attemptUserBlockingHydration$1);
+  setAttemptContinuousHydration(attemptContinuousHydration$1);
+  setAttemptHydrationAtCurrentPriority(attemptHydrationAtCurrentPriority$1);
+  setAttemptHydrationAtPriority(runWithPriority$2);
+  var didWarnAboutUnstableCreatePortal = false;
+
+  {
+    if (typeof Map !== 'function' || // $FlowIssue Flow incorrectly thinks Map has no prototype
+    Map.prototype == null || typeof Map.prototype.forEach !== 'function' || typeof Set !== 'function' || // $FlowIssue Flow incorrectly thinks Set has no prototype
+    Set.prototype == null || typeof Set.prototype.clear !== 'function' || typeof Set.prototype.forEach !== 'function') {
+      error('React depends on Map and Set built-in types. Make sure that you load a ' + 'polyfill in older browsers. https://reactjs.org/link/react-polyfills');
+    }
+  }
+
+  setRestoreImplementation(restoreControlledState$3);
+  setBatchingImplementation(batchedUpdates$1, discreteUpdates$1, flushDiscreteUpdates, batchedEventUpdates$1);
+
+  function createPortal$1(children, container) {
+    var key = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
+
+    if (!isValidContainer(container)) {
+      {
+        throw Error( "Target container is not a DOM element." );
+      }
+    } // TODO: pass ReactDOM portal implementation as third argument
+    // $FlowFixMe The Flow type is opaque but there's no way to actually create it.
+
+
+    return createPortal(children, container, null, key);
+  }
+
+  function renderSubtreeIntoContainer(parentComponent, element, containerNode, callback) {
+
+    return unstable_renderSubtreeIntoContainer(parentComponent, element, containerNode, callback);
+  }
+
+  function unstable_createPortal(children, container) {
+    var key = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
+
+    {
+      if (!didWarnAboutUnstableCreatePortal) {
+        didWarnAboutUnstableCreatePortal = true;
+
+        warn('The ReactDOM.unstable_createPortal() alias has been deprecated, ' + 'and will be removed in React 18+. Update your code to use ' + 'ReactDOM.createPortal() instead. It has the exact same API, ' + 'but without the "unstable_" prefix.');
+      }
+    }
+
+    return createPortal$1(children, container, key);
+  }
+
+  var Internals = {
+    // Keep in sync with ReactTestUtils.js, and ReactTestUtilsAct.js.
+    // This is an array for better minification.
+    Events: [getInstanceFromNode, getNodeFromInstance, getFiberCurrentPropsFromNode, enqueueStateRestore, restoreStateIfNeeded, flushPassiveEffects, // TODO: This is related to `act`, not events. Move to separate key?
+    IsThisRendererActing]
+  };
+  var foundDevTools = injectIntoDevTools({
+    findFiberByHostInstance: getClosestInstanceFromNode,
+    bundleType:  1 ,
+    version: ReactVersion,
+    rendererPackageName: 'react-dom'
+  });
+
+  {
+    if (!foundDevTools && canUseDOM && window.top === window.self) {
+      // If we're in Chrome or Firefox, provide a download link if not installed.
+      if (navigator.userAgent.indexOf('Chrome') > -1 && navigator.userAgent.indexOf('Edge') === -1 || navigator.userAgent.indexOf('Firefox') > -1) {
+        var protocol = window.location.protocol; // Don't warn in exotic cases like chrome-extension://.
+
+        if (/^(https?|file):$/.test(protocol)) {
+          // eslint-disable-next-line react-internal/no-production-logging
+          console.info('%cDownload the React DevTools ' + 'for a better development experience: ' + 'https://reactjs.org/link/react-devtools' + (protocol === 'file:' ? '\nYou might need to use a local HTTP server (instead of file://): ' + 'https://reactjs.org/link/react-devtools-faq' : ''), 'font-weight:bold');
+        }
+      }
+    }
+  }
+
+  exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = Internals;
+  exports.createPortal = createPortal$1;
+  exports.findDOMNode = findDOMNode;
+  exports.flushSync = flushSync;
+  exports.hydrate = hydrate;
+  exports.render = render;
+  exports.unmountComponentAtNode = unmountComponentAtNode;
+  exports.unstable_batchedUpdates = batchedUpdates$1;
+  exports.unstable_createPortal = unstable_createPortal;
+  exports.unstable_renderSubtreeIntoContainer = renderSubtreeIntoContainer;
+  exports.version = ReactVersion;
+
+})));

--- a/tests/assets/reading-list/react15.html
+++ b/tests/assets/reading-list/react15.html
@@ -1,0 +1,85 @@
+<link rel=stylesheet href='./style.css'>
+<script src="./react_15.7.0.js"></script>
+<script src="./react-dom_15.7.0.js"></script>
+
+<div id=root></div>
+
+<script>
+const e = React.createElement;
+
+class AppHeader extends React.Component {
+  render() {
+    return e('div', null,
+      e('h1', null, `reactjs@${React.version}`),
+      e('h3', null, `Reading List: ${this.props.bookCount}`),
+    );
+  }
+}
+
+class NewBook extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: '',
+    };
+  }
+
+  onInput(event) {
+    this.state.text = event.target.value;
+  }
+
+  render() {
+    return e('div', null,
+      e('input', {onInput: this.onInput.bind(this)}, null),
+      e('button', {
+        onClick: () => this.props.onNewBook(this.state.text),
+      }, `new book`),
+    );
+  }
+}
+
+class BookItem extends React.Component {
+  render() {
+    return e('div', null, this.props.name);
+  }
+}
+
+class BookList extends React.Component {
+  render() {
+    return e('ol', null, this.props.books.map(book => e('li', {key: book.name}, e(BookItem, { name: book.name }))));
+  }
+}
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      books: [
+        {name: 'Pride and Prejudice' },
+        {name: 'To Kill a Mockingbird' },
+        {name: 'The Great Gatsby' },
+      ],
+    };
+  }
+
+  render() {
+    return e('div', null,
+      e(AppHeader, {bookCount: this.state.books.length}, null),
+      e(NewBook, {onNewBook: bookName => this.onNewBook(bookName)}, null),
+      e(BookList, {books: this.state.books}, null),
+    );
+  }
+
+  onNewBook(bookName) {
+    this.setState({
+      books: [...this.state.books, {name: bookName}],
+    });
+  }
+}
+
+ReactDOM.render(
+  e(App, null, null),
+  document.getElementById('root'),
+);
+
+</script>

--- a/tests/assets/reading-list/react16.html
+++ b/tests/assets/reading-list/react16.html
@@ -1,0 +1,83 @@
+<link rel=stylesheet href='./style.css'>
+<script src="./react_16.14.0.js"></script>
+<script src="./react-dom_16.14.0.js"></script>
+
+<div id=root></div>
+
+<script>
+const e = React.createElement;
+
+class AppHeader extends React.Component {
+  render() {
+    return e(React.Fragment, null,
+      e('h1', null, `reactjs@${React.version}`),
+      e('h3', null, `Reading List: ${this.props.bookCount}`),
+    );
+  }
+}
+
+class NewBook extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = '';
+  }
+
+  onInput(event) {
+    this.state = event.target.value;
+  }
+
+  render() {
+    return e(React.Fragment, null, 
+      e('input', {onInput: this.onInput.bind(this)}, null),
+      e('button', {
+        onClick: () => this.props.onNewBook(this.state),
+      }, `new book`),
+    );
+  }
+}
+
+class BookItem extends React.Component {
+  render() {
+    return e('div', null, this.props.name);
+  }
+}
+
+class BookList extends React.Component {
+  render() {
+    return e('ol', null, this.props.books.map(book => e('li', {key: book.name}, e(BookItem, { name: book.name }))));
+  }
+}
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      books: [
+        {name: 'Pride and Prejudice' },
+        {name: 'To Kill a Mockingbird' },
+        {name: 'The Great Gatsby' },
+      ],
+    };
+  }
+
+  render() {
+    return e(React.Fragment, null, 
+      e(AppHeader, {bookCount: this.state.books.length}, null),
+      e(NewBook, {onNewBook: bookName => this.onNewBook(bookName)}, null),
+      e(BookList, {books: this.state.books}, null),
+    );
+  }
+
+  onNewBook(bookName) {
+    this.setState({
+      books: [...this.state.books, {name: bookName}],
+    });
+  }
+}
+
+ReactDOM.render(
+  e(App, null, null),
+  document.getElementById('root'),
+);
+
+</script>

--- a/tests/assets/reading-list/react17.html
+++ b/tests/assets/reading-list/react17.html
@@ -7,13 +7,11 @@
 <script>
 const e = React.createElement;
 
-class AppHeader extends React.Component {
-  render() {
-    return e(React.Fragment, null,
-      e('h1', null, `reactjs@${React.version}`),
-      e('h3', null, `Reading List: ${this.props.bookCount}`),
-    );
-  }
+function AppHeader(props) {
+  return e(React.Fragment, null,
+    e('h1', null, `reactjs@${React.version}`),
+    e('h3', null, `Reading List: ${props.bookCount}`),
+  );
 }
 
 class NewBook extends React.Component {

--- a/tests/assets/reading-list/react17.html
+++ b/tests/assets/reading-list/react17.html
@@ -1,0 +1,83 @@
+<link rel=stylesheet href='./style.css'>
+<script src="./react_17.0.2.js"></script>
+<script src="./react-dom_17.0.2.js"></script>
+
+<div id=root></div>
+
+<script>
+const e = React.createElement;
+
+class AppHeader extends React.Component {
+  render() {
+    return e(React.Fragment, null,
+      e('h1', null, `reactjs@${React.version}`),
+      e('h3', null, `Reading List: ${this.props.bookCount}`),
+    );
+  }
+}
+
+class NewBook extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = '';
+  }
+
+  onInput(event) {
+    this.state = event.target.value;
+  }
+
+  render() {
+    return e(React.Fragment, null,
+      e('input', {onInput: this.onInput.bind(this)}, null),
+      e('button', {
+        onClick: () => this.props.onNewBook(this.state),
+      }, `new book`),
+    );
+  }
+}
+
+class BookItem extends React.Component {
+  render() {
+    return e('div', null, this.props.name);
+  }
+}
+
+class BookList extends React.Component {
+  render() {
+    return e('ol', null, this.props.books.map(book => e('li', {key: book.name}, e(BookItem, { name: book.name }))));
+  }
+}
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      books: [
+        {name: 'Pride and Prejudice' },
+        {name: 'To Kill a Mockingbird' },
+        {name: 'The Great Gatsby' },
+      ],
+    };
+  }
+
+  render() {
+    return e(React.Fragment, null,
+      e(AppHeader, {bookCount: this.state.books.length}, null),
+      e(NewBook, {onNewBook: bookName => this.onNewBook(bookName)}, null),
+      e(BookList, {books: this.state.books}, null),
+    );
+  }
+
+  onNewBook(bookName) {
+    this.setState({
+      books: [...this.state.books, {name: bookName}],
+    });
+  }
+}
+
+ReactDOM.render(
+  e(App, null, null),
+  document.getElementById('root'),
+);
+
+</script>

--- a/tests/assets/reading-list/react_15.7.0.js
+++ b/tests/assets/reading-list/react_15.7.0.js
@@ -1,0 +1,4268 @@
+ /**
+  * React v15.7.0
+  */
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.React = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+/**
+ * Escape and wrap key so it is safe to use as a reactid
+ *
+ * @param {string} key to be escaped.
+ * @return {string} the escaped key.
+ */
+
+function escape(key) {
+  var escapeRegex = /[=:]/g;
+  var escaperLookup = {
+    '=': '=0',
+    ':': '=2'
+  };
+  var escapedString = ('' + key).replace(escapeRegex, function (match) {
+    return escaperLookup[match];
+  });
+
+  return '$' + escapedString;
+}
+
+/**
+ * Unescape and unwrap key for human-readable display
+ *
+ * @param {string} key to unescape.
+ * @return {string} the unescaped key.
+ */
+function unescape(key) {
+  var unescapeRegex = /(=0|=2)/g;
+  var unescaperLookup = {
+    '=0': '=',
+    '=2': ':'
+  };
+  var keySubstring = key[0] === '.' && key[1] === '$' ? key.substring(2) : key.substring(1);
+
+  return ('' + keySubstring).replace(unescapeRegex, function (match) {
+    return unescaperLookup[match];
+  });
+}
+
+var KeyEscapeUtils = {
+  escape: escape,
+  unescape: unescape
+};
+
+module.exports = KeyEscapeUtils;
+},{}],2:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(25);
+
+var invariant = _dereq_(30);
+
+/**
+ * Static poolers. Several custom versions for each potential number of
+ * arguments. A completely generic pooler is easy to implement, but would
+ * require accessing the `arguments` object. In each of these, `this` refers to
+ * the Class itself, not an instance. If any others are needed, simply add them
+ * here, or in their own files.
+ */
+var oneArgumentPooler = function (copyFieldsFrom) {
+  var Klass = this;
+  if (Klass.instancePool.length) {
+    var instance = Klass.instancePool.pop();
+    Klass.call(instance, copyFieldsFrom);
+    return instance;
+  } else {
+    return new Klass(copyFieldsFrom);
+  }
+};
+
+var twoArgumentPooler = function (a1, a2) {
+  var Klass = this;
+  if (Klass.instancePool.length) {
+    var instance = Klass.instancePool.pop();
+    Klass.call(instance, a1, a2);
+    return instance;
+  } else {
+    return new Klass(a1, a2);
+  }
+};
+
+var threeArgumentPooler = function (a1, a2, a3) {
+  var Klass = this;
+  if (Klass.instancePool.length) {
+    var instance = Klass.instancePool.pop();
+    Klass.call(instance, a1, a2, a3);
+    return instance;
+  } else {
+    return new Klass(a1, a2, a3);
+  }
+};
+
+var fourArgumentPooler = function (a1, a2, a3, a4) {
+  var Klass = this;
+  if (Klass.instancePool.length) {
+    var instance = Klass.instancePool.pop();
+    Klass.call(instance, a1, a2, a3, a4);
+    return instance;
+  } else {
+    return new Klass(a1, a2, a3, a4);
+  }
+};
+
+var standardReleaser = function (instance) {
+  var Klass = this;
+  !(instance instanceof Klass) ? "development" !== 'production' ? invariant(false, 'Trying to release an instance into a pool of a different type.') : _prodInvariant('25') : void 0;
+  instance.destructor();
+  if (Klass.instancePool.length < Klass.poolSize) {
+    Klass.instancePool.push(instance);
+  }
+};
+
+var DEFAULT_POOL_SIZE = 10;
+var DEFAULT_POOLER = oneArgumentPooler;
+
+/**
+ * Augments `CopyConstructor` to be a poolable class, augmenting only the class
+ * itself (statically) not adding any prototypical fields. Any CopyConstructor
+ * you give this may have a `poolSize` property, and will look for a
+ * prototypical `destructor` on instances.
+ *
+ * @param {Function} CopyConstructor Constructor that can be used to reset.
+ * @param {Function} pooler Customizable pooler.
+ */
+var addPoolingTo = function (CopyConstructor, pooler) {
+  // Casting as any so that flow ignores the actual implementation and trusts
+  // it to match the type we declared
+  var NewKlass = CopyConstructor;
+  NewKlass.instancePool = [];
+  NewKlass.getPooled = pooler || DEFAULT_POOLER;
+  if (!NewKlass.poolSize) {
+    NewKlass.poolSize = DEFAULT_POOL_SIZE;
+  }
+  NewKlass.release = standardReleaser;
+  return NewKlass;
+};
+
+var PooledClass = {
+  addPoolingTo: addPoolingTo,
+  oneArgumentPooler: oneArgumentPooler,
+  twoArgumentPooler: twoArgumentPooler,
+  threeArgumentPooler: threeArgumentPooler,
+  fourArgumentPooler: fourArgumentPooler
+};
+
+module.exports = PooledClass;
+},{"25":25,"30":30}],3:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(32);
+
+var ReactBaseClasses = _dereq_(4);
+var ReactChildren = _dereq_(5);
+var ReactDOMFactories = _dereq_(8);
+var ReactElement = _dereq_(9);
+var ReactPropTypes = _dereq_(14);
+var ReactVersion = _dereq_(17);
+
+var createReactClass = _dereq_(20);
+var onlyChild = _dereq_(24);
+
+var createElement = ReactElement.createElement;
+var createFactory = ReactElement.createFactory;
+var cloneElement = ReactElement.cloneElement;
+
+if ("development" !== 'production') {
+  var lowPriorityWarning = _dereq_(23);
+  var canDefineProperty = _dereq_(18);
+  var ReactElementValidator = _dereq_(11);
+  var didWarnPropTypesDeprecated = false;
+  createElement = ReactElementValidator.createElement;
+  createFactory = ReactElementValidator.createFactory;
+  cloneElement = ReactElementValidator.cloneElement;
+}
+
+var __spread = _assign;
+var createMixin = function (mixin) {
+  return mixin;
+};
+
+if ("development" !== 'production') {
+  var warnedForSpread = false;
+  var warnedForCreateMixin = false;
+  __spread = function () {
+    lowPriorityWarning(warnedForSpread, 'React.__spread is deprecated and should not be used. Use ' + 'Object.assign directly or another helper function with similar ' + 'semantics. You may be seeing this warning due to your compiler. ' + 'See https://fb.me/react-spread-deprecation for more details.');
+    warnedForSpread = true;
+    return _assign.apply(null, arguments);
+  };
+
+  createMixin = function (mixin) {
+    lowPriorityWarning(warnedForCreateMixin, 'React.createMixin is deprecated and should not be used. ' + 'In React v16.0, it will be removed. ' + 'You can use this mixin directly instead. ' + 'See https://fb.me/createmixin-was-never-implemented for more info.');
+    warnedForCreateMixin = true;
+    return mixin;
+  };
+}
+
+var React = {
+  // Modern
+
+  Children: {
+    map: ReactChildren.map,
+    forEach: ReactChildren.forEach,
+    count: ReactChildren.count,
+    toArray: ReactChildren.toArray,
+    only: onlyChild
+  },
+
+  Component: ReactBaseClasses.Component,
+  PureComponent: ReactBaseClasses.PureComponent,
+
+  createElement: createElement,
+  cloneElement: cloneElement,
+  isValidElement: ReactElement.isValidElement,
+
+  // Classic
+
+  PropTypes: ReactPropTypes,
+  createClass: createReactClass,
+  createFactory: createFactory,
+  createMixin: createMixin,
+
+  // This looks DOM specific but these are actually isomorphic helpers
+  // since they are just generating DOM strings.
+  DOM: ReactDOMFactories,
+
+  version: ReactVersion,
+
+  // Deprecated hook for JSX spread, don't use this for anything.
+  __spread: __spread
+};
+
+if ("development" !== 'production') {
+  var warnedForCreateClass = false;
+  if (canDefineProperty) {
+    Object.defineProperty(React, 'PropTypes', {
+      get: function () {
+        lowPriorityWarning(didWarnPropTypesDeprecated, 'Accessing PropTypes via the main React package is deprecated,' + ' and will be removed in  React v16.0.' + ' Use the latest available v15.* prop-types package from npm instead.' + ' For info on usage, compatibility, migration and more, see ' + 'https://fb.me/prop-types-docs');
+        didWarnPropTypesDeprecated = true;
+        return ReactPropTypes;
+      }
+    });
+
+    Object.defineProperty(React, 'createClass', {
+      get: function () {
+        lowPriorityWarning(warnedForCreateClass, 'Accessing createClass via the main React package is deprecated,' + ' and will be removed in React v16.0.' + " Use a plain JavaScript class instead. If you're not yet " + 'ready to migrate, create-react-class v15.* is available ' + 'on npm as a temporary, drop-in replacement. ' + 'For more info see https://fb.me/react-create-class');
+        warnedForCreateClass = true;
+        return createReactClass;
+      }
+    });
+  }
+
+  // React.DOM factories are deprecated. Wrap these methods so that
+  // invocations of the React.DOM namespace and alert users to switch
+  // to the `react-dom-factories` package.
+  React.DOM = {};
+  var warnedForFactories = false;
+  Object.keys(ReactDOMFactories).forEach(function (factory) {
+    React.DOM[factory] = function () {
+      if (!warnedForFactories) {
+        lowPriorityWarning(false, 'Accessing factories like React.DOM.%s has been deprecated ' + 'and will be removed in v16.0+. Use the ' + 'react-dom-factories package instead. ' + ' Version 1.0 provides a drop-in replacement.' + ' For more info, see https://fb.me/react-dom-factories', factory);
+        warnedForFactories = true;
+      }
+      return ReactDOMFactories[factory].apply(ReactDOMFactories, arguments);
+    };
+  });
+}
+
+module.exports = React;
+},{"11":11,"14":14,"17":17,"18":18,"20":20,"23":23,"24":24,"32":32,"4":4,"5":5,"8":8,"9":9}],4:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(25),
+    _assign = _dereq_(32);
+
+var ReactNoopUpdateQueue = _dereq_(12);
+
+var canDefineProperty = _dereq_(18);
+var emptyObject = _dereq_(29);
+var invariant = _dereq_(30);
+var lowPriorityWarning = _dereq_(23);
+
+/**
+ * Base class helpers for the updating state of a component.
+ */
+function ReactComponent(props, context, updater) {
+  this.props = props;
+  this.context = context;
+  this.refs = emptyObject;
+  // We initialize the default updater but the real one gets injected by the
+  // renderer.
+  this.updater = updater || ReactNoopUpdateQueue;
+}
+
+ReactComponent.prototype.isReactComponent = {};
+
+/**
+ * Sets a subset of the state. Always use this to mutate
+ * state. You should treat `this.state` as immutable.
+ *
+ * There is no guarantee that `this.state` will be immediately updated, so
+ * accessing `this.state` after calling this method may return the old value.
+ *
+ * There is no guarantee that calls to `setState` will run synchronously,
+ * as they may eventually be batched together.  You can provide an optional
+ * callback that will be executed when the call to setState is actually
+ * completed.
+ *
+ * When a function is provided to setState, it will be called at some point in
+ * the future (not synchronously). It will be called with the up to date
+ * component arguments (state, props, context). These values can be different
+ * from this.* because your function may be called after receiveProps but before
+ * shouldComponentUpdate, and this new state, props, and context will not yet be
+ * assigned to this.
+ *
+ * @param {object|function} partialState Next partial state or function to
+ *        produce next partial state to be merged with current state.
+ * @param {?function} callback Called after state is updated.
+ * @final
+ * @protected
+ */
+ReactComponent.prototype.setState = function (partialState, callback) {
+  !(typeof partialState === 'object' || typeof partialState === 'function' || partialState == null) ? "development" !== 'production' ? invariant(false, 'setState(...): takes an object of state variables to update or a function which returns an object of state variables.') : _prodInvariant('85') : void 0;
+  this.updater.enqueueSetState(this, partialState);
+  if (callback) {
+    this.updater.enqueueCallback(this, callback, 'setState');
+  }
+};
+
+/**
+ * Forces an update. This should only be invoked when it is known with
+ * certainty that we are **not** in a DOM transaction.
+ *
+ * You may want to call this when you know that some deeper aspect of the
+ * component's state has changed but `setState` was not called.
+ *
+ * This will not invoke `shouldComponentUpdate`, but it will invoke
+ * `componentWillUpdate` and `componentDidUpdate`.
+ *
+ * @param {?function} callback Called after update is complete.
+ * @final
+ * @protected
+ */
+ReactComponent.prototype.forceUpdate = function (callback) {
+  this.updater.enqueueForceUpdate(this);
+  if (callback) {
+    this.updater.enqueueCallback(this, callback, 'forceUpdate');
+  }
+};
+
+/**
+ * Deprecated APIs. These APIs used to exist on classic React classes but since
+ * we would like to deprecate them, we're not going to move them over to this
+ * modern base class. Instead, we define a getter that warns if it's accessed.
+ */
+if ("development" !== 'production') {
+  var deprecatedAPIs = {
+    isMounted: ['isMounted', 'Instead, make sure to clean up subscriptions and pending requests in ' + 'componentWillUnmount to prevent memory leaks.'],
+    replaceState: ['replaceState', 'Refactor your code to use setState instead (see ' + 'https://github.com/facebook/react/issues/3236).']
+  };
+  var defineDeprecationWarning = function (methodName, info) {
+    if (canDefineProperty) {
+      Object.defineProperty(ReactComponent.prototype, methodName, {
+        get: function () {
+          lowPriorityWarning(false, '%s(...) is deprecated in plain JavaScript React classes. %s', info[0], info[1]);
+          return undefined;
+        }
+      });
+    }
+  };
+  for (var fnName in deprecatedAPIs) {
+    if (deprecatedAPIs.hasOwnProperty(fnName)) {
+      defineDeprecationWarning(fnName, deprecatedAPIs[fnName]);
+    }
+  }
+}
+
+/**
+ * Base class helpers for the updating state of a component.
+ */
+function ReactPureComponent(props, context, updater) {
+  // Duplicated from ReactComponent.
+  this.props = props;
+  this.context = context;
+  this.refs = emptyObject;
+  // We initialize the default updater but the real one gets injected by the
+  // renderer.
+  this.updater = updater || ReactNoopUpdateQueue;
+}
+
+function ComponentDummy() {}
+ComponentDummy.prototype = ReactComponent.prototype;
+ReactPureComponent.prototype = new ComponentDummy();
+ReactPureComponent.prototype.constructor = ReactPureComponent;
+// Avoid an extra prototype jump for these methods.
+_assign(ReactPureComponent.prototype, ReactComponent.prototype);
+ReactPureComponent.prototype.isPureReactComponent = true;
+
+module.exports = {
+  Component: ReactComponent,
+  PureComponent: ReactPureComponent
+};
+},{"12":12,"18":18,"23":23,"25":25,"29":29,"30":30,"32":32}],5:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var PooledClass = _dereq_(2);
+var ReactElement = _dereq_(9);
+
+var emptyFunction = _dereq_(28);
+var traverseAllChildren = _dereq_(26);
+
+var twoArgumentPooler = PooledClass.twoArgumentPooler;
+var fourArgumentPooler = PooledClass.fourArgumentPooler;
+
+var userProvidedKeyEscapeRegex = /\/+/g;
+function escapeUserProvidedKey(text) {
+  return ('' + text).replace(userProvidedKeyEscapeRegex, '$&/');
+}
+
+/**
+ * PooledClass representing the bookkeeping associated with performing a child
+ * traversal. Allows avoiding binding callbacks.
+ *
+ * @constructor ForEachBookKeeping
+ * @param {!function} forEachFunction Function to perform traversal with.
+ * @param {?*} forEachContext Context to perform context with.
+ */
+function ForEachBookKeeping(forEachFunction, forEachContext) {
+  this.func = forEachFunction;
+  this.context = forEachContext;
+  this.count = 0;
+}
+ForEachBookKeeping.prototype.destructor = function () {
+  this.func = null;
+  this.context = null;
+  this.count = 0;
+};
+PooledClass.addPoolingTo(ForEachBookKeeping, twoArgumentPooler);
+
+function forEachSingleChild(bookKeeping, child, name) {
+  var func = bookKeeping.func,
+      context = bookKeeping.context;
+
+  func.call(context, child, bookKeeping.count++);
+}
+
+/**
+ * Iterates through children that are typically specified as `props.children`.
+ *
+ * See https://facebook.github.io/react/docs/top-level-api.html#react.children.foreach
+ *
+ * The provided forEachFunc(child, index) will be called for each
+ * leaf child.
+ *
+ * @param {?*} children Children tree container.
+ * @param {function(*, int)} forEachFunc
+ * @param {*} forEachContext Context for forEachContext.
+ */
+function forEachChildren(children, forEachFunc, forEachContext) {
+  if (children == null) {
+    return children;
+  }
+  var traverseContext = ForEachBookKeeping.getPooled(forEachFunc, forEachContext);
+  traverseAllChildren(children, forEachSingleChild, traverseContext);
+  ForEachBookKeeping.release(traverseContext);
+}
+
+/**
+ * PooledClass representing the bookkeeping associated with performing a child
+ * mapping. Allows avoiding binding callbacks.
+ *
+ * @constructor MapBookKeeping
+ * @param {!*} mapResult Object containing the ordered map of results.
+ * @param {!function} mapFunction Function to perform mapping with.
+ * @param {?*} mapContext Context to perform mapping with.
+ */
+function MapBookKeeping(mapResult, keyPrefix, mapFunction, mapContext) {
+  this.result = mapResult;
+  this.keyPrefix = keyPrefix;
+  this.func = mapFunction;
+  this.context = mapContext;
+  this.count = 0;
+}
+MapBookKeeping.prototype.destructor = function () {
+  this.result = null;
+  this.keyPrefix = null;
+  this.func = null;
+  this.context = null;
+  this.count = 0;
+};
+PooledClass.addPoolingTo(MapBookKeeping, fourArgumentPooler);
+
+function mapSingleChildIntoContext(bookKeeping, child, childKey) {
+  var result = bookKeeping.result,
+      keyPrefix = bookKeeping.keyPrefix,
+      func = bookKeeping.func,
+      context = bookKeeping.context;
+
+
+  var mappedChild = func.call(context, child, bookKeeping.count++);
+  if (Array.isArray(mappedChild)) {
+    mapIntoWithKeyPrefixInternal(mappedChild, result, childKey, emptyFunction.thatReturnsArgument);
+  } else if (mappedChild != null) {
+    if (ReactElement.isValidElement(mappedChild)) {
+      mappedChild = ReactElement.cloneAndReplaceKey(mappedChild,
+      // Keep both the (mapped) and old keys if they differ, just as
+      // traverseAllChildren used to do for objects as children
+      keyPrefix + (mappedChild.key && (!child || child.key !== mappedChild.key) ? escapeUserProvidedKey(mappedChild.key) + '/' : '') + childKey);
+    }
+    result.push(mappedChild);
+  }
+}
+
+function mapIntoWithKeyPrefixInternal(children, array, prefix, func, context) {
+  var escapedPrefix = '';
+  if (prefix != null) {
+    escapedPrefix = escapeUserProvidedKey(prefix) + '/';
+  }
+  var traverseContext = MapBookKeeping.getPooled(array, escapedPrefix, func, context);
+  traverseAllChildren(children, mapSingleChildIntoContext, traverseContext);
+  MapBookKeeping.release(traverseContext);
+}
+
+/**
+ * Maps children that are typically specified as `props.children`.
+ *
+ * See https://facebook.github.io/react/docs/top-level-api.html#react.children.map
+ *
+ * The provided mapFunction(child, key, index) will be called for each
+ * leaf child.
+ *
+ * @param {?*} children Children tree container.
+ * @param {function(*, int)} func The map function.
+ * @param {*} context Context for mapFunction.
+ * @return {object} Object containing the ordered map of results.
+ */
+function mapChildren(children, func, context) {
+  if (children == null) {
+    return children;
+  }
+  var result = [];
+  mapIntoWithKeyPrefixInternal(children, result, null, func, context);
+  return result;
+}
+
+function forEachSingleChildDummy(traverseContext, child, name) {
+  return null;
+}
+
+/**
+ * Count the number of children that are typically specified as
+ * `props.children`.
+ *
+ * See https://facebook.github.io/react/docs/top-level-api.html#react.children.count
+ *
+ * @param {?*} children Children tree container.
+ * @return {number} The number of children.
+ */
+function countChildren(children, context) {
+  return traverseAllChildren(children, forEachSingleChildDummy, null);
+}
+
+/**
+ * Flatten a children object (typically specified as `props.children`) and
+ * return an array with appropriately re-keyed children.
+ *
+ * See https://facebook.github.io/react/docs/top-level-api.html#react.children.toarray
+ */
+function toArray(children) {
+  var result = [];
+  mapIntoWithKeyPrefixInternal(children, result, null, emptyFunction.thatReturnsArgument);
+  return result;
+}
+
+var ReactChildren = {
+  forEach: forEachChildren,
+  map: mapChildren,
+  mapIntoWithKeyPrefixInternal: mapIntoWithKeyPrefixInternal,
+  count: countChildren,
+  toArray: toArray
+};
+
+module.exports = ReactChildren;
+},{"2":2,"26":26,"28":28,"9":9}],6:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(25);
+
+var ReactCurrentOwner = _dereq_(7);
+
+var invariant = _dereq_(30);
+var warning = _dereq_(31);
+
+function isNative(fn) {
+  // Based on isNative() from Lodash
+  var funcToString = Function.prototype.toString;
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
+  var reIsNative = RegExp('^' + funcToString
+  // Take an example native function source for comparison
+  .call(hasOwnProperty
+  // Strip regex characters so we can use it for regex
+  ).replace(/[\\^$.*+?()[\]{}|]/g, '\\$&'
+  // Remove hasOwnProperty from the template to make it generic
+  ).replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$');
+  try {
+    var source = funcToString.call(fn);
+    return reIsNative.test(source);
+  } catch (err) {
+    return false;
+  }
+}
+
+var canUseCollections =
+// Array.from
+typeof Array.from === 'function' &&
+// Map
+typeof Map === 'function' && isNative(Map) &&
+// Map.prototype.keys
+Map.prototype != null && typeof Map.prototype.keys === 'function' && isNative(Map.prototype.keys) &&
+// Set
+typeof Set === 'function' && isNative(Set) &&
+// Set.prototype.keys
+Set.prototype != null && typeof Set.prototype.keys === 'function' && isNative(Set.prototype.keys);
+
+var setItem;
+var getItem;
+var removeItem;
+var getItemIDs;
+var addRoot;
+var removeRoot;
+var getRootIDs;
+
+if (canUseCollections) {
+  var itemMap = new Map();
+  var rootIDSet = new Set();
+
+  setItem = function (id, item) {
+    itemMap.set(id, item);
+  };
+  getItem = function (id) {
+    return itemMap.get(id);
+  };
+  removeItem = function (id) {
+    itemMap['delete'](id);
+  };
+  getItemIDs = function () {
+    return Array.from(itemMap.keys());
+  };
+
+  addRoot = function (id) {
+    rootIDSet.add(id);
+  };
+  removeRoot = function (id) {
+    rootIDSet['delete'](id);
+  };
+  getRootIDs = function () {
+    return Array.from(rootIDSet.keys());
+  };
+} else {
+  var itemByKey = {};
+  var rootByKey = {};
+
+  // Use non-numeric keys to prevent V8 performance issues:
+  // https://github.com/facebook/react/pull/7232
+  var getKeyFromID = function (id) {
+    return '.' + id;
+  };
+  var getIDFromKey = function (key) {
+    return parseInt(key.substr(1), 10);
+  };
+
+  setItem = function (id, item) {
+    var key = getKeyFromID(id);
+    itemByKey[key] = item;
+  };
+  getItem = function (id) {
+    var key = getKeyFromID(id);
+    return itemByKey[key];
+  };
+  removeItem = function (id) {
+    var key = getKeyFromID(id);
+    delete itemByKey[key];
+  };
+  getItemIDs = function () {
+    return Object.keys(itemByKey).map(getIDFromKey);
+  };
+
+  addRoot = function (id) {
+    var key = getKeyFromID(id);
+    rootByKey[key] = true;
+  };
+  removeRoot = function (id) {
+    var key = getKeyFromID(id);
+    delete rootByKey[key];
+  };
+  getRootIDs = function () {
+    return Object.keys(rootByKey).map(getIDFromKey);
+  };
+}
+
+var unmountedIDs = [];
+
+function purgeDeep(id) {
+  var item = getItem(id);
+  if (item) {
+    var childIDs = item.childIDs;
+
+    removeItem(id);
+    childIDs.forEach(purgeDeep);
+  }
+}
+
+function describeComponentFrame(name, source, ownerName) {
+  return '\n    in ' + (name || 'Unknown') + (source ? ' (at ' + source.fileName.replace(/^.*[\\\/]/, '') + ':' + source.lineNumber + ')' : ownerName ? ' (created by ' + ownerName + ')' : '');
+}
+
+function getDisplayName(element) {
+  if (element == null) {
+    return '#empty';
+  } else if (typeof element === 'string' || typeof element === 'number') {
+    return '#text';
+  } else if (typeof element.type === 'string') {
+    return element.type;
+  } else {
+    return element.type.displayName || element.type.name || 'Unknown';
+  }
+}
+
+function describeID(id) {
+  var name = ReactComponentTreeHook.getDisplayName(id);
+  var element = ReactComponentTreeHook.getElement(id);
+  var ownerID = ReactComponentTreeHook.getOwnerID(id);
+  var ownerName;
+  if (ownerID) {
+    ownerName = ReactComponentTreeHook.getDisplayName(ownerID);
+  }
+  "development" !== 'production' ? warning(element, 'ReactComponentTreeHook: Missing React element for debugID %s when ' + 'building stack', id) : void 0;
+  return describeComponentFrame(name, element && element._source, ownerName);
+}
+
+var ReactComponentTreeHook = {
+  onSetChildren: function (id, nextChildIDs) {
+    var item = getItem(id);
+    !item ? "development" !== 'production' ? invariant(false, 'Item must have been set') : _prodInvariant('144') : void 0;
+    item.childIDs = nextChildIDs;
+
+    for (var i = 0; i < nextChildIDs.length; i++) {
+      var nextChildID = nextChildIDs[i];
+      var nextChild = getItem(nextChildID);
+      !nextChild ? "development" !== 'production' ? invariant(false, 'Expected hook events to fire for the child before its parent includes it in onSetChildren().') : _prodInvariant('140') : void 0;
+      !(nextChild.childIDs != null || typeof nextChild.element !== 'object' || nextChild.element == null) ? "development" !== 'production' ? invariant(false, 'Expected onSetChildren() to fire for a container child before its parent includes it in onSetChildren().') : _prodInvariant('141') : void 0;
+      !nextChild.isMounted ? "development" !== 'production' ? invariant(false, 'Expected onMountComponent() to fire for the child before its parent includes it in onSetChildren().') : _prodInvariant('71') : void 0;
+      if (nextChild.parentID == null) {
+        nextChild.parentID = id;
+        // TODO: This shouldn't be necessary but mounting a new root during in
+        // componentWillMount currently causes not-yet-mounted components to
+        // be purged from our tree data so their parent id is missing.
+      }
+      !(nextChild.parentID === id) ? "development" !== 'production' ? invariant(false, 'Expected onBeforeMountComponent() parent and onSetChildren() to be consistent (%s has parents %s and %s).', nextChildID, nextChild.parentID, id) : _prodInvariant('142', nextChildID, nextChild.parentID, id) : void 0;
+    }
+  },
+  onBeforeMountComponent: function (id, element, parentID) {
+    var item = {
+      element: element,
+      parentID: parentID,
+      text: null,
+      childIDs: [],
+      isMounted: false,
+      updateCount: 0
+    };
+    setItem(id, item);
+  },
+  onBeforeUpdateComponent: function (id, element) {
+    var item = getItem(id);
+    if (!item || !item.isMounted) {
+      // We may end up here as a result of setState() in componentWillUnmount().
+      // In this case, ignore the element.
+      return;
+    }
+    item.element = element;
+  },
+  onMountComponent: function (id) {
+    var item = getItem(id);
+    !item ? "development" !== 'production' ? invariant(false, 'Item must have been set') : _prodInvariant('144') : void 0;
+    item.isMounted = true;
+    var isRoot = item.parentID === 0;
+    if (isRoot) {
+      addRoot(id);
+    }
+  },
+  onUpdateComponent: function (id) {
+    var item = getItem(id);
+    if (!item || !item.isMounted) {
+      // We may end up here as a result of setState() in componentWillUnmount().
+      // In this case, ignore the element.
+      return;
+    }
+    item.updateCount++;
+  },
+  onUnmountComponent: function (id) {
+    var item = getItem(id);
+    if (item) {
+      // We need to check if it exists.
+      // `item` might not exist if it is inside an error boundary, and a sibling
+      // error boundary child threw while mounting. Then this instance never
+      // got a chance to mount, but it still gets an unmounting event during
+      // the error boundary cleanup.
+      item.isMounted = false;
+      var isRoot = item.parentID === 0;
+      if (isRoot) {
+        removeRoot(id);
+      }
+    }
+    unmountedIDs.push(id);
+  },
+  purgeUnmountedComponents: function () {
+    if (ReactComponentTreeHook._preventPurging) {
+      // Should only be used for testing.
+      return;
+    }
+
+    for (var i = 0; i < unmountedIDs.length; i++) {
+      var id = unmountedIDs[i];
+      purgeDeep(id);
+    }
+    unmountedIDs.length = 0;
+  },
+  isMounted: function (id) {
+    var item = getItem(id);
+    return item ? item.isMounted : false;
+  },
+  getCurrentStackAddendum: function (topElement) {
+    var info = '';
+    if (topElement) {
+      var name = getDisplayName(topElement);
+      var owner = topElement._owner;
+      info += describeComponentFrame(name, topElement._source, owner && owner.getName());
+    }
+
+    var currentOwner = ReactCurrentOwner.current;
+    var id = currentOwner && currentOwner._debugID;
+
+    info += ReactComponentTreeHook.getStackAddendumByID(id);
+    return info;
+  },
+  getStackAddendumByID: function (id) {
+    var info = '';
+    while (id) {
+      info += describeID(id);
+      id = ReactComponentTreeHook.getParentID(id);
+    }
+    return info;
+  },
+  getChildIDs: function (id) {
+    var item = getItem(id);
+    return item ? item.childIDs : [];
+  },
+  getDisplayName: function (id) {
+    var element = ReactComponentTreeHook.getElement(id);
+    if (!element) {
+      return null;
+    }
+    return getDisplayName(element);
+  },
+  getElement: function (id) {
+    var item = getItem(id);
+    return item ? item.element : null;
+  },
+  getOwnerID: function (id) {
+    var element = ReactComponentTreeHook.getElement(id);
+    if (!element || !element._owner) {
+      return null;
+    }
+    return element._owner._debugID;
+  },
+  getParentID: function (id) {
+    var item = getItem(id);
+    return item ? item.parentID : null;
+  },
+  getSource: function (id) {
+    var item = getItem(id);
+    var element = item ? item.element : null;
+    var source = element != null ? element._source : null;
+    return source;
+  },
+  getText: function (id) {
+    var element = ReactComponentTreeHook.getElement(id);
+    if (typeof element === 'string') {
+      return element;
+    } else if (typeof element === 'number') {
+      return '' + element;
+    } else {
+      return null;
+    }
+  },
+  getUpdateCount: function (id) {
+    var item = getItem(id);
+    return item ? item.updateCount : 0;
+  },
+
+
+  getRootIDs: getRootIDs,
+  getRegisteredIDs: getItemIDs,
+
+  pushNonStandardWarningStack: function (isCreatingElement, currentSource) {
+    if (typeof console.reactStack !== 'function') {
+      return;
+    }
+
+    var stack = [];
+    var currentOwner = ReactCurrentOwner.current;
+    var id = currentOwner && currentOwner._debugID;
+
+    try {
+      if (isCreatingElement) {
+        stack.push({
+          name: id ? ReactComponentTreeHook.getDisplayName(id) : null,
+          fileName: currentSource ? currentSource.fileName : null,
+          lineNumber: currentSource ? currentSource.lineNumber : null
+        });
+      }
+
+      while (id) {
+        var element = ReactComponentTreeHook.getElement(id);
+        var parentID = ReactComponentTreeHook.getParentID(id);
+        var ownerID = ReactComponentTreeHook.getOwnerID(id);
+        var ownerName = ownerID ? ReactComponentTreeHook.getDisplayName(ownerID) : null;
+        var source = element && element._source;
+        stack.push({
+          name: ownerName,
+          fileName: source ? source.fileName : null,
+          lineNumber: source ? source.lineNumber : null
+        });
+        id = parentID;
+      }
+    } catch (err) {
+      // Internal state is messed up.
+      // Stop building the stack (it's just a nice to have).
+    }
+
+    console.reactStack(stack);
+  },
+  popNonStandardWarningStack: function () {
+    if (typeof console.reactStackEnd !== 'function') {
+      return;
+    }
+    console.reactStackEnd();
+  }
+};
+
+module.exports = ReactComponentTreeHook;
+},{"25":25,"30":30,"31":31,"7":7}],7:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+/**
+ * Keeps track of the current owner.
+ *
+ * The current owner is the component who should own any components that are
+ * currently being constructed.
+ */
+var ReactCurrentOwner = {
+  /**
+   * @internal
+   * @type {ReactComponent}
+   */
+  current: null
+};
+
+module.exports = ReactCurrentOwner;
+},{}],8:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var ReactElement = _dereq_(9);
+
+/**
+ * Create a factory that creates HTML tag elements.
+ *
+ * @private
+ */
+var createDOMFactory = ReactElement.createFactory;
+if ("development" !== 'production') {
+  var ReactElementValidator = _dereq_(11);
+  createDOMFactory = ReactElementValidator.createFactory;
+}
+
+/**
+ * Creates a mapping from supported HTML tags to `ReactDOMComponent` classes.
+ *
+ * @public
+ */
+var ReactDOMFactories = {
+  a: createDOMFactory('a'),
+  abbr: createDOMFactory('abbr'),
+  address: createDOMFactory('address'),
+  area: createDOMFactory('area'),
+  article: createDOMFactory('article'),
+  aside: createDOMFactory('aside'),
+  audio: createDOMFactory('audio'),
+  b: createDOMFactory('b'),
+  base: createDOMFactory('base'),
+  bdi: createDOMFactory('bdi'),
+  bdo: createDOMFactory('bdo'),
+  big: createDOMFactory('big'),
+  blockquote: createDOMFactory('blockquote'),
+  body: createDOMFactory('body'),
+  br: createDOMFactory('br'),
+  button: createDOMFactory('button'),
+  canvas: createDOMFactory('canvas'),
+  caption: createDOMFactory('caption'),
+  cite: createDOMFactory('cite'),
+  code: createDOMFactory('code'),
+  col: createDOMFactory('col'),
+  colgroup: createDOMFactory('colgroup'),
+  data: createDOMFactory('data'),
+  datalist: createDOMFactory('datalist'),
+  dd: createDOMFactory('dd'),
+  del: createDOMFactory('del'),
+  details: createDOMFactory('details'),
+  dfn: createDOMFactory('dfn'),
+  dialog: createDOMFactory('dialog'),
+  div: createDOMFactory('div'),
+  dl: createDOMFactory('dl'),
+  dt: createDOMFactory('dt'),
+  em: createDOMFactory('em'),
+  embed: createDOMFactory('embed'),
+  fieldset: createDOMFactory('fieldset'),
+  figcaption: createDOMFactory('figcaption'),
+  figure: createDOMFactory('figure'),
+  footer: createDOMFactory('footer'),
+  form: createDOMFactory('form'),
+  h1: createDOMFactory('h1'),
+  h2: createDOMFactory('h2'),
+  h3: createDOMFactory('h3'),
+  h4: createDOMFactory('h4'),
+  h5: createDOMFactory('h5'),
+  h6: createDOMFactory('h6'),
+  head: createDOMFactory('head'),
+  header: createDOMFactory('header'),
+  hgroup: createDOMFactory('hgroup'),
+  hr: createDOMFactory('hr'),
+  html: createDOMFactory('html'),
+  i: createDOMFactory('i'),
+  iframe: createDOMFactory('iframe'),
+  img: createDOMFactory('img'),
+  input: createDOMFactory('input'),
+  ins: createDOMFactory('ins'),
+  kbd: createDOMFactory('kbd'),
+  keygen: createDOMFactory('keygen'),
+  label: createDOMFactory('label'),
+  legend: createDOMFactory('legend'),
+  li: createDOMFactory('li'),
+  link: createDOMFactory('link'),
+  main: createDOMFactory('main'),
+  map: createDOMFactory('map'),
+  mark: createDOMFactory('mark'),
+  menu: createDOMFactory('menu'),
+  menuitem: createDOMFactory('menuitem'),
+  meta: createDOMFactory('meta'),
+  meter: createDOMFactory('meter'),
+  nav: createDOMFactory('nav'),
+  noscript: createDOMFactory('noscript'),
+  object: createDOMFactory('object'),
+  ol: createDOMFactory('ol'),
+  optgroup: createDOMFactory('optgroup'),
+  option: createDOMFactory('option'),
+  output: createDOMFactory('output'),
+  p: createDOMFactory('p'),
+  param: createDOMFactory('param'),
+  picture: createDOMFactory('picture'),
+  pre: createDOMFactory('pre'),
+  progress: createDOMFactory('progress'),
+  q: createDOMFactory('q'),
+  rp: createDOMFactory('rp'),
+  rt: createDOMFactory('rt'),
+  ruby: createDOMFactory('ruby'),
+  s: createDOMFactory('s'),
+  samp: createDOMFactory('samp'),
+  script: createDOMFactory('script'),
+  section: createDOMFactory('section'),
+  select: createDOMFactory('select'),
+  small: createDOMFactory('small'),
+  source: createDOMFactory('source'),
+  span: createDOMFactory('span'),
+  strong: createDOMFactory('strong'),
+  style: createDOMFactory('style'),
+  sub: createDOMFactory('sub'),
+  summary: createDOMFactory('summary'),
+  sup: createDOMFactory('sup'),
+  table: createDOMFactory('table'),
+  tbody: createDOMFactory('tbody'),
+  td: createDOMFactory('td'),
+  textarea: createDOMFactory('textarea'),
+  tfoot: createDOMFactory('tfoot'),
+  th: createDOMFactory('th'),
+  thead: createDOMFactory('thead'),
+  time: createDOMFactory('time'),
+  title: createDOMFactory('title'),
+  tr: createDOMFactory('tr'),
+  track: createDOMFactory('track'),
+  u: createDOMFactory('u'),
+  ul: createDOMFactory('ul'),
+  'var': createDOMFactory('var'),
+  video: createDOMFactory('video'),
+  wbr: createDOMFactory('wbr'),
+
+  // SVG
+  circle: createDOMFactory('circle'),
+  clipPath: createDOMFactory('clipPath'),
+  defs: createDOMFactory('defs'),
+  ellipse: createDOMFactory('ellipse'),
+  g: createDOMFactory('g'),
+  image: createDOMFactory('image'),
+  line: createDOMFactory('line'),
+  linearGradient: createDOMFactory('linearGradient'),
+  mask: createDOMFactory('mask'),
+  path: createDOMFactory('path'),
+  pattern: createDOMFactory('pattern'),
+  polygon: createDOMFactory('polygon'),
+  polyline: createDOMFactory('polyline'),
+  radialGradient: createDOMFactory('radialGradient'),
+  rect: createDOMFactory('rect'),
+  stop: createDOMFactory('stop'),
+  svg: createDOMFactory('svg'),
+  text: createDOMFactory('text'),
+  tspan: createDOMFactory('tspan')
+};
+
+module.exports = ReactDOMFactories;
+},{"11":11,"9":9}],9:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(32);
+
+var ReactCurrentOwner = _dereq_(7);
+
+var warning = _dereq_(31);
+var canDefineProperty = _dereq_(18);
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
+var REACT_ELEMENT_TYPE = _dereq_(10);
+
+var RESERVED_PROPS = {
+  key: true,
+  ref: true,
+  __self: true,
+  __source: true
+};
+
+var specialPropKeyWarningShown, specialPropRefWarningShown;
+
+function hasValidRef(config) {
+  if ("development" !== 'production') {
+    if (hasOwnProperty.call(config, 'ref')) {
+      var getter = Object.getOwnPropertyDescriptor(config, 'ref').get;
+      if (getter && getter.isReactWarning) {
+        return false;
+      }
+    }
+  }
+  return config.ref !== undefined;
+}
+
+function hasValidKey(config) {
+  if ("development" !== 'production') {
+    if (hasOwnProperty.call(config, 'key')) {
+      var getter = Object.getOwnPropertyDescriptor(config, 'key').get;
+      if (getter && getter.isReactWarning) {
+        return false;
+      }
+    }
+  }
+  return config.key !== undefined;
+}
+
+function defineKeyPropWarningGetter(props, displayName) {
+  var warnAboutAccessingKey = function () {
+    if (!specialPropKeyWarningShown) {
+      specialPropKeyWarningShown = true;
+      "development" !== 'production' ? warning(false, '%s: `key` is not a prop. Trying to access it will result ' + 'in `undefined` being returned. If you need to access the same ' + 'value within the child component, you should pass it as a different ' + 'prop. (https://fb.me/react-special-props)', displayName) : void 0;
+    }
+  };
+  warnAboutAccessingKey.isReactWarning = true;
+  Object.defineProperty(props, 'key', {
+    get: warnAboutAccessingKey,
+    configurable: true
+  });
+}
+
+function defineRefPropWarningGetter(props, displayName) {
+  var warnAboutAccessingRef = function () {
+    if (!specialPropRefWarningShown) {
+      specialPropRefWarningShown = true;
+      "development" !== 'production' ? warning(false, '%s: `ref` is not a prop. Trying to access it will result ' + 'in `undefined` being returned. If you need to access the same ' + 'value within the child component, you should pass it as a different ' + 'prop. (https://fb.me/react-special-props)', displayName) : void 0;
+    }
+  };
+  warnAboutAccessingRef.isReactWarning = true;
+  Object.defineProperty(props, 'ref', {
+    get: warnAboutAccessingRef,
+    configurable: true
+  });
+}
+
+/**
+ * Factory method to create a new React element. This no longer adheres to
+ * the class pattern, so do not use new to call it. Also, no instanceof check
+ * will work. Instead test $$typeof field against Symbol.for('react.element') to check
+ * if something is a React Element.
+ *
+ * @param {*} type
+ * @param {*} key
+ * @param {string|object} ref
+ * @param {*} self A *temporary* helper to detect places where `this` is
+ * different from the `owner` when React.createElement is called, so that we
+ * can warn. We want to get rid of owner and replace string `ref`s with arrow
+ * functions, and as long as `this` and owner are the same, there will be no
+ * change in behavior.
+ * @param {*} source An annotation object (added by a transpiler or otherwise)
+ * indicating filename, line number, and/or other information.
+ * @param {*} owner
+ * @param {*} props
+ * @internal
+ */
+var ReactElement = function (type, key, ref, self, source, owner, props) {
+  var element = {
+    // This tag allow us to uniquely identify this as a React Element
+    $$typeof: REACT_ELEMENT_TYPE,
+
+    // Built-in properties that belong on the element
+    type: type,
+    key: key,
+    ref: ref,
+    props: props,
+
+    // Record the component responsible for creating this element.
+    _owner: owner
+  };
+
+  if ("development" !== 'production') {
+    // The validation flag is currently mutative. We put it on
+    // an external backing store so that we can freeze the whole object.
+    // This can be replaced with a WeakMap once they are implemented in
+    // commonly used development environments.
+    element._store = {};
+
+    // To make comparing ReactElements easier for testing purposes, we make
+    // the validation flag non-enumerable (where possible, which should
+    // include every environment we run tests in), so the test framework
+    // ignores it.
+    if (canDefineProperty) {
+      Object.defineProperty(element._store, 'validated', {
+        configurable: false,
+        enumerable: false,
+        writable: true,
+        value: false
+      });
+      // self and source are DEV only properties.
+      Object.defineProperty(element, '_self', {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: self
+      });
+      // Two elements created in two different places should be considered
+      // equal for testing purposes and therefore we hide it from enumeration.
+      Object.defineProperty(element, '_source', {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: source
+      });
+    } else {
+      element._store.validated = false;
+      element._self = self;
+      element._source = source;
+    }
+    if (Object.freeze) {
+      Object.freeze(element.props);
+      Object.freeze(element);
+    }
+  }
+
+  return element;
+};
+
+/**
+ * Create and return a new ReactElement of the given type.
+ * See https://facebook.github.io/react/docs/top-level-api.html#react.createelement
+ */
+ReactElement.createElement = function (type, config, children) {
+  var propName;
+
+  // Reserved names are extracted
+  var props = {};
+
+  var key = null;
+  var ref = null;
+  var self = null;
+  var source = null;
+
+  if (config != null) {
+    if (hasValidRef(config)) {
+      ref = config.ref;
+    }
+    if (hasValidKey(config)) {
+      key = '' + config.key;
+    }
+
+    self = config.__self === undefined ? null : config.__self;
+    source = config.__source === undefined ? null : config.__source;
+    // Remaining properties are added to a new props object
+    for (propName in config) {
+      if (hasOwnProperty.call(config, propName) && !RESERVED_PROPS.hasOwnProperty(propName)) {
+        props[propName] = config[propName];
+      }
+    }
+  }
+
+  // Children can be more than one argument, and those are transferred onto
+  // the newly allocated props object.
+  var childrenLength = arguments.length - 2;
+  if (childrenLength === 1) {
+    props.children = children;
+  } else if (childrenLength > 1) {
+    var childArray = Array(childrenLength);
+    for (var i = 0; i < childrenLength; i++) {
+      childArray[i] = arguments[i + 2];
+    }
+    if ("development" !== 'production') {
+      if (Object.freeze) {
+        Object.freeze(childArray);
+      }
+    }
+    props.children = childArray;
+  }
+
+  // Resolve default props
+  if (type && type.defaultProps) {
+    var defaultProps = type.defaultProps;
+    for (propName in defaultProps) {
+      if (props[propName] === undefined) {
+        props[propName] = defaultProps[propName];
+      }
+    }
+  }
+  if ("development" !== 'production') {
+    if (key || ref) {
+      if (typeof props.$$typeof === 'undefined' || props.$$typeof !== REACT_ELEMENT_TYPE) {
+        var displayName = typeof type === 'function' ? type.displayName || type.name || 'Unknown' : type;
+        if (key) {
+          defineKeyPropWarningGetter(props, displayName);
+        }
+        if (ref) {
+          defineRefPropWarningGetter(props, displayName);
+        }
+      }
+    }
+  }
+  return ReactElement(type, key, ref, self, source, ReactCurrentOwner.current, props);
+};
+
+/**
+ * Return a function that produces ReactElements of a given type.
+ * See https://facebook.github.io/react/docs/top-level-api.html#react.createfactory
+ */
+ReactElement.createFactory = function (type) {
+  var factory = ReactElement.createElement.bind(null, type);
+  // Expose the type on the factory and the prototype so that it can be
+  // easily accessed on elements. E.g. `<Foo />.type === Foo`.
+  // This should not be named `constructor` since this may not be the function
+  // that created the element, and it may not even be a constructor.
+  // Legacy hook TODO: Warn if this is accessed
+  factory.type = type;
+  return factory;
+};
+
+ReactElement.cloneAndReplaceKey = function (oldElement, newKey) {
+  var newElement = ReactElement(oldElement.type, newKey, oldElement.ref, oldElement._self, oldElement._source, oldElement._owner, oldElement.props);
+
+  return newElement;
+};
+
+/**
+ * Clone and return a new ReactElement using element as the starting point.
+ * See https://facebook.github.io/react/docs/top-level-api.html#react.cloneelement
+ */
+ReactElement.cloneElement = function (element, config, children) {
+  var propName;
+
+  // Original props are copied
+  var props = _assign({}, element.props);
+
+  // Reserved names are extracted
+  var key = element.key;
+  var ref = element.ref;
+  // Self is preserved since the owner is preserved.
+  var self = element._self;
+  // Source is preserved since cloneElement is unlikely to be targeted by a
+  // transpiler, and the original source is probably a better indicator of the
+  // true owner.
+  var source = element._source;
+
+  // Owner will be preserved, unless ref is overridden
+  var owner = element._owner;
+
+  if (config != null) {
+    if (hasValidRef(config)) {
+      // Silently steal the ref from the parent.
+      ref = config.ref;
+      owner = ReactCurrentOwner.current;
+    }
+    if (hasValidKey(config)) {
+      key = '' + config.key;
+    }
+
+    // Remaining properties override existing props
+    var defaultProps;
+    if (element.type && element.type.defaultProps) {
+      defaultProps = element.type.defaultProps;
+    }
+    for (propName in config) {
+      if (hasOwnProperty.call(config, propName) && !RESERVED_PROPS.hasOwnProperty(propName)) {
+        if (config[propName] === undefined && defaultProps !== undefined) {
+          // Resolve default props
+          props[propName] = defaultProps[propName];
+        } else {
+          props[propName] = config[propName];
+        }
+      }
+    }
+  }
+
+  // Children can be more than one argument, and those are transferred onto
+  // the newly allocated props object.
+  var childrenLength = arguments.length - 2;
+  if (childrenLength === 1) {
+    props.children = children;
+  } else if (childrenLength > 1) {
+    var childArray = Array(childrenLength);
+    for (var i = 0; i < childrenLength; i++) {
+      childArray[i] = arguments[i + 2];
+    }
+    props.children = childArray;
+  }
+
+  return ReactElement(element.type, key, ref, self, source, owner, props);
+};
+
+/**
+ * Verifies the object is a ReactElement.
+ * See https://facebook.github.io/react/docs/top-level-api.html#react.isvalidelement
+ * @param {?object} object
+ * @return {boolean} True if `object` is a valid component.
+ * @final
+ */
+ReactElement.isValidElement = function (object) {
+  return typeof object === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
+};
+
+module.exports = ReactElement;
+},{"10":10,"18":18,"31":31,"32":32,"7":7}],10:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+// The Symbol used to tag the ReactElement type. If there is no native Symbol
+// nor polyfill, then a plain number is used for performance.
+
+var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol['for'] && Symbol['for']('react.element') || 0xeac7;
+
+module.exports = REACT_ELEMENT_TYPE;
+},{}],11:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * ReactElementValidator provides a wrapper around a element factory
+ * which validates the props passed to the element. This is intended to be
+ * used only in DEV and could be replaced by a static type checker for languages
+ * that support it.
+ */
+
+'use strict';
+
+var ReactCurrentOwner = _dereq_(7);
+var ReactComponentTreeHook = _dereq_(6);
+var ReactElement = _dereq_(9);
+
+var checkReactTypeSpec = _dereq_(19);
+
+var canDefineProperty = _dereq_(18);
+var getIteratorFn = _dereq_(21);
+var warning = _dereq_(31);
+var lowPriorityWarning = _dereq_(23);
+
+function getDeclarationErrorAddendum() {
+  if (ReactCurrentOwner.current) {
+    var name = ReactCurrentOwner.current.getName();
+    if (name) {
+      return ' Check the render method of `' + name + '`.';
+    }
+  }
+  return '';
+}
+
+function getSourceInfoErrorAddendum(elementProps) {
+  if (elementProps !== null && elementProps !== undefined && elementProps.__source !== undefined) {
+    var source = elementProps.__source;
+    var fileName = source.fileName.replace(/^.*[\\\/]/, '');
+    var lineNumber = source.lineNumber;
+    return ' Check your code at ' + fileName + ':' + lineNumber + '.';
+  }
+  return '';
+}
+
+/**
+ * Warn if there's no key explicitly set on dynamic arrays of children or
+ * object keys are not valid. This allows us to keep track of children between
+ * updates.
+ */
+var ownerHasKeyUseWarning = {};
+
+function getCurrentComponentErrorInfo(parentType) {
+  var info = getDeclarationErrorAddendum();
+
+  if (!info) {
+    var parentName = typeof parentType === 'string' ? parentType : parentType.displayName || parentType.name;
+    if (parentName) {
+      info = ' Check the top-level render call using <' + parentName + '>.';
+    }
+  }
+  return info;
+}
+
+/**
+ * Warn if the element doesn't have an explicit key assigned to it.
+ * This element is in an array. The array could grow and shrink or be
+ * reordered. All children that haven't already been validated are required to
+ * have a "key" property assigned to it. Error statuses are cached so a warning
+ * will only be shown once.
+ *
+ * @internal
+ * @param {ReactElement} element Element that requires a key.
+ * @param {*} parentType element's parent's type.
+ */
+function validateExplicitKey(element, parentType) {
+  if (!element._store || element._store.validated || element.key != null) {
+    return;
+  }
+  element._store.validated = true;
+
+  var memoizer = ownerHasKeyUseWarning.uniqueKey || (ownerHasKeyUseWarning.uniqueKey = {});
+
+  var currentComponentErrorInfo = getCurrentComponentErrorInfo(parentType);
+  if (memoizer[currentComponentErrorInfo]) {
+    return;
+  }
+  memoizer[currentComponentErrorInfo] = true;
+
+  // Usually the current owner is the offender, but if it accepts children as a
+  // property, it may be the creator of the child that's responsible for
+  // assigning it a key.
+  var childOwner = '';
+  if (element && element._owner && element._owner !== ReactCurrentOwner.current) {
+    // Give the component that originally created this child.
+    childOwner = ' It was passed a child from ' + element._owner.getName() + '.';
+  }
+
+  "development" !== 'production' ? warning(false, 'Each child in an array or iterator should have a unique "key" prop.' + '%s%s See https://fb.me/react-warning-keys for more information.%s', currentComponentErrorInfo, childOwner, ReactComponentTreeHook.getCurrentStackAddendum(element)) : void 0;
+}
+
+/**
+ * Ensure that every element either is passed in a static location, in an
+ * array with an explicit keys property defined, or in an object literal
+ * with valid key property.
+ *
+ * @internal
+ * @param {ReactNode} node Statically passed child of any type.
+ * @param {*} parentType node's parent's type.
+ */
+function validateChildKeys(node, parentType) {
+  if (typeof node !== 'object') {
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (var i = 0; i < node.length; i++) {
+      var child = node[i];
+      if (ReactElement.isValidElement(child)) {
+        validateExplicitKey(child, parentType);
+      }
+    }
+  } else if (ReactElement.isValidElement(node)) {
+    // This element was passed in a valid location.
+    if (node._store) {
+      node._store.validated = true;
+    }
+  } else if (node) {
+    var iteratorFn = getIteratorFn(node);
+    // Entry iterators provide implicit keys.
+    if (iteratorFn) {
+      if (iteratorFn !== node.entries) {
+        var iterator = iteratorFn.call(node);
+        var step;
+        while (!(step = iterator.next()).done) {
+          if (ReactElement.isValidElement(step.value)) {
+            validateExplicitKey(step.value, parentType);
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Given an element, validate that its props follow the propTypes definition,
+ * provided by the type.
+ *
+ * @param {ReactElement} element
+ */
+function validatePropTypes(element) {
+  var componentClass = element.type;
+  if (typeof componentClass !== 'function') {
+    return;
+  }
+  var name = componentClass.displayName || componentClass.name;
+  if (componentClass.propTypes) {
+    checkReactTypeSpec(componentClass.propTypes, element.props, 'prop', name, element, null);
+  }
+  if (typeof componentClass.getDefaultProps === 'function') {
+    "development" !== 'production' ? warning(componentClass.getDefaultProps.isReactClassApproved, 'getDefaultProps is only used on classic React.createClass ' + 'definitions. Use a static property named `defaultProps` instead.') : void 0;
+  }
+}
+
+var ReactElementValidator = {
+  createElement: function (type, props, children) {
+    var validType = typeof type === 'string' || typeof type === 'function';
+    // We warn in this case but don't throw. We expect the element creation to
+    // succeed and there will likely be errors in render.
+    if (!validType) {
+      if (typeof type !== 'function' && typeof type !== 'string') {
+        var info = '';
+        if (type === undefined || typeof type === 'object' && type !== null && Object.keys(type).length === 0) {
+          info += ' You likely forgot to export your component from the file ' + "it's defined in.";
+        }
+
+        var sourceInfo = getSourceInfoErrorAddendum(props);
+        if (sourceInfo) {
+          info += sourceInfo;
+        } else {
+          info += getDeclarationErrorAddendum();
+        }
+
+        info += ReactComponentTreeHook.getCurrentStackAddendum();
+
+        var currentSource = props !== null && props !== undefined && props.__source !== undefined ? props.__source : null;
+        ReactComponentTreeHook.pushNonStandardWarningStack(true, currentSource);
+        "development" !== 'production' ? warning(false, 'React.createElement: type is invalid -- expected a string (for ' + 'built-in components) or a class/function (for composite ' + 'components) but got: %s.%s', type == null ? type : typeof type, info) : void 0;
+        ReactComponentTreeHook.popNonStandardWarningStack();
+      }
+    }
+
+    var element = ReactElement.createElement.apply(this, arguments);
+
+    // The result can be nullish if a mock or a custom function is used.
+    // TODO: Drop this when these are no longer allowed as the type argument.
+    if (element == null) {
+      return element;
+    }
+
+    // Skip key warning if the type isn't valid since our key validation logic
+    // doesn't expect a non-string/function type and can throw confusing errors.
+    // We don't want exception behavior to differ between dev and prod.
+    // (Rendering will throw with a helpful message and as soon as the type is
+    // fixed, the key warnings will appear.)
+    if (validType) {
+      for (var i = 2; i < arguments.length; i++) {
+        validateChildKeys(arguments[i], type);
+      }
+    }
+
+    validatePropTypes(element);
+
+    return element;
+  },
+
+  createFactory: function (type) {
+    var validatedFactory = ReactElementValidator.createElement.bind(null, type);
+    // Legacy hook TODO: Warn if this is accessed
+    validatedFactory.type = type;
+
+    if ("development" !== 'production') {
+      if (canDefineProperty) {
+        Object.defineProperty(validatedFactory, 'type', {
+          enumerable: false,
+          get: function () {
+            lowPriorityWarning(false, 'Factory.type is deprecated. Access the class directly ' + 'before passing it to createFactory.');
+            Object.defineProperty(this, 'type', {
+              value: type
+            });
+            return type;
+          }
+        });
+      }
+    }
+
+    return validatedFactory;
+  },
+
+  cloneElement: function (element, props, children) {
+    var newElement = ReactElement.cloneElement.apply(this, arguments);
+    for (var i = 2; i < arguments.length; i++) {
+      validateChildKeys(arguments[i], newElement.type);
+    }
+    validatePropTypes(newElement);
+    return newElement;
+  }
+};
+
+module.exports = ReactElementValidator;
+},{"18":18,"19":19,"21":21,"23":23,"31":31,"6":6,"7":7,"9":9}],12:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var warning = _dereq_(31);
+
+function warnNoop(publicInstance, callerName) {
+  if ("development" !== 'production') {
+    var constructor = publicInstance.constructor;
+    "development" !== 'production' ? warning(false, '%s(...): Can only update a mounted or mounting component. ' + 'This usually means you called %s() on an unmounted component. ' + 'This is a no-op. Please check the code for the %s component.', callerName, callerName, constructor && (constructor.displayName || constructor.name) || 'ReactClass') : void 0;
+  }
+}
+
+/**
+ * This is the abstract API for an update queue.
+ */
+var ReactNoopUpdateQueue = {
+  /**
+   * Checks whether or not this composite component is mounted.
+   * @param {ReactClass} publicInstance The instance we want to test.
+   * @return {boolean} True if mounted, false otherwise.
+   * @protected
+   * @final
+   */
+  isMounted: function (publicInstance) {
+    return false;
+  },
+
+  /**
+   * Enqueue a callback that will be executed after all the pending updates
+   * have processed.
+   *
+   * @param {ReactClass} publicInstance The instance to use as `this` context.
+   * @param {?function} callback Called after state is updated.
+   * @internal
+   */
+  enqueueCallback: function (publicInstance, callback) {},
+
+  /**
+   * Forces an update. This should only be invoked when it is known with
+   * certainty that we are **not** in a DOM transaction.
+   *
+   * You may want to call this when you know that some deeper aspect of the
+   * component's state has changed but `setState` was not called.
+   *
+   * This will not invoke `shouldComponentUpdate`, but it will invoke
+   * `componentWillUpdate` and `componentDidUpdate`.
+   *
+   * @param {ReactClass} publicInstance The instance that should rerender.
+   * @internal
+   */
+  enqueueForceUpdate: function (publicInstance) {
+    warnNoop(publicInstance, 'forceUpdate');
+  },
+
+  /**
+   * Replaces all of the state. Always use this or `setState` to mutate state.
+   * You should treat `this.state` as immutable.
+   *
+   * There is no guarantee that `this.state` will be immediately updated, so
+   * accessing `this.state` after calling this method may return the old value.
+   *
+   * @param {ReactClass} publicInstance The instance that should rerender.
+   * @param {object} completeState Next state.
+   * @internal
+   */
+  enqueueReplaceState: function (publicInstance, completeState) {
+    warnNoop(publicInstance, 'replaceState');
+  },
+
+  /**
+   * Sets a subset of the state. This only exists because _pendingState is
+   * internal. This provides a merging strategy that is not available to deep
+   * properties which is confusing. TODO: Expose pendingState or don't use it
+   * during the merge.
+   *
+   * @param {ReactClass} publicInstance The instance that should rerender.
+   * @param {object} partialState Next partial state to be merged with state.
+   * @internal
+   */
+  enqueueSetState: function (publicInstance, partialState) {
+    warnNoop(publicInstance, 'setState');
+  }
+};
+
+module.exports = ReactNoopUpdateQueue;
+},{"31":31}],13:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var ReactPropTypeLocationNames = {};
+
+if ("development" !== 'production') {
+  ReactPropTypeLocationNames = {
+    prop: 'prop',
+    context: 'context',
+    childContext: 'child context'
+  };
+}
+
+module.exports = ReactPropTypeLocationNames;
+},{}],14:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _require = _dereq_(9),
+    isValidElement = _require.isValidElement;
+
+var factory = _dereq_(34);
+
+module.exports = factory(isValidElement);
+},{"34":34,"9":9}],15:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+
+module.exports = ReactPropTypesSecret;
+},{}],16:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(32);
+
+var React = _dereq_(3);
+
+// `version` will be added here by the React module.
+var ReactUMDEntry = _assign(React, {
+  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
+    ReactCurrentOwner: _dereq_(7)
+  }
+});
+
+if ("development" !== 'production') {
+  _assign(ReactUMDEntry.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED, {
+    // ReactComponentTreeHook should not be included in production.
+    ReactComponentTreeHook: _dereq_(6),
+    getNextDebugID: _dereq_(22)
+  });
+}
+
+module.exports = ReactUMDEntry;
+},{"22":22,"3":3,"32":32,"6":6,"7":7}],17:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+module.exports = '15.7.0';
+},{}],18:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var canDefineProperty = false;
+if ("development" !== 'production') {
+  try {
+    // $FlowFixMe https://github.com/facebook/flow/issues/285
+    Object.defineProperty({}, 'x', { get: function () {} });
+    canDefineProperty = true;
+  } catch (x) {
+    // IE will fail on defineProperty
+  }
+}
+
+module.exports = canDefineProperty;
+},{}],19:[function(_dereq_,module,exports){
+(function (process){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(25);
+
+var ReactPropTypeLocationNames = _dereq_(13);
+var ReactPropTypesSecret = _dereq_(15);
+
+var invariant = _dereq_(30);
+var warning = _dereq_(31);
+
+var ReactComponentTreeHook;
+
+if (typeof process !== 'undefined' && process.env && "development" === 'test') {
+  // Temporary hack.
+  // Inline requires don't work well with Jest:
+  // https://github.com/facebook/react/issues/7240
+  // Remove the inline requires when we don't need them anymore:
+  // https://github.com/facebook/react/pull/7178
+  ReactComponentTreeHook = _dereq_(6);
+}
+
+var loggedTypeFailures = {};
+
+/**
+ * Assert that the values match with the type specs.
+ * Error messages are memorized and will only be shown once.
+ *
+ * @param {object} typeSpecs Map of name to a ReactPropType
+ * @param {object} values Runtime values that need to be type-checked
+ * @param {string} location e.g. "prop", "context", "child context"
+ * @param {string} componentName Name of the component for error messages.
+ * @param {?object} element The React element that is being type-checked
+ * @param {?number} debugID The React component instance that is being type-checked
+ * @private
+ */
+function checkReactTypeSpec(typeSpecs, values, location, componentName, element, debugID) {
+  for (var typeSpecName in typeSpecs) {
+    if (typeSpecs.hasOwnProperty(typeSpecName)) {
+      var error;
+      // Prop type validation may throw. In case they do, we don't want to
+      // fail the render phase where it didn't fail before. So we log it.
+      // After these have been cleaned up, we'll let them throw.
+      try {
+        // This is intentionally an invariant that gets caught. It's the same
+        // behavior as without this statement except with a better message.
+        !(typeof typeSpecs[typeSpecName] === 'function') ? "development" !== 'production' ? invariant(false, '%s: %s type `%s` is invalid; it must be a function, usually from React.PropTypes.', componentName || 'React class', ReactPropTypeLocationNames[location], typeSpecName) : _prodInvariant('84', componentName || 'React class', ReactPropTypeLocationNames[location], typeSpecName) : void 0;
+        error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
+      } catch (ex) {
+        error = ex;
+      }
+      "development" !== 'production' ? warning(!error || error instanceof Error, '%s: type specification of %s `%s` is invalid; the type checker ' + 'function must return `null` or an `Error` but returned a %s. ' + 'You may have forgotten to pass an argument to the type checker ' + 'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' + 'shape all require an argument).', componentName || 'React class', ReactPropTypeLocationNames[location], typeSpecName, typeof error) : void 0;
+      if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+        // Only monitor this failure once because there tends to be a lot of the
+        // same error.
+        loggedTypeFailures[error.message] = true;
+
+        var componentStackInfo = '';
+
+        if ("development" !== 'production') {
+          if (!ReactComponentTreeHook) {
+            ReactComponentTreeHook = _dereq_(6);
+          }
+          if (debugID !== null) {
+            componentStackInfo = ReactComponentTreeHook.getStackAddendumByID(debugID);
+          } else if (element !== null) {
+            componentStackInfo = ReactComponentTreeHook.getCurrentStackAddendum(element);
+          }
+        }
+
+        "development" !== 'production' ? warning(false, 'Failed %s type: %s%s', location, error.message, componentStackInfo) : void 0;
+      }
+    }
+  }
+}
+
+module.exports = checkReactTypeSpec;
+}).call(this,undefined)
+},{"13":13,"15":15,"25":25,"30":30,"31":31,"6":6}],20:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _require = _dereq_(4),
+    Component = _require.Component;
+
+var _require2 = _dereq_(9),
+    isValidElement = _require2.isValidElement;
+
+var ReactNoopUpdateQueue = _dereq_(12);
+var factory = _dereq_(27);
+
+module.exports = factory(Component, isValidElement, ReactNoopUpdateQueue);
+},{"12":12,"27":27,"4":4,"9":9}],21:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+/* global Symbol */
+
+var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+
+/**
+ * Returns the iterator method function contained on the iterable object.
+ *
+ * Be sure to invoke the function with the iterable as context:
+ *
+ *     var iteratorFn = getIteratorFn(myIterable);
+ *     if (iteratorFn) {
+ *       var iterator = iteratorFn.call(myIterable);
+ *       ...
+ *     }
+ *
+ * @param {?object} maybeIterable
+ * @return {?function}
+ */
+function getIteratorFn(maybeIterable) {
+  var iteratorFn = maybeIterable && (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL]);
+  if (typeof iteratorFn === 'function') {
+    return iteratorFn;
+  }
+}
+
+module.exports = getIteratorFn;
+},{}],22:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+var nextDebugID = 1;
+
+function getNextDebugID() {
+  return nextDebugID++;
+}
+
+module.exports = getNextDebugID;
+},{}],23:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+/**
+ * Forked from fbjs/warning:
+ * https://github.com/facebook/fbjs/blob/e66ba20ad5be433eb54423f2b097d829324d9de6/packages/fbjs/src/__forks__/warning.js
+ *
+ * Only change is we use console.warn instead of console.error,
+ * and do nothing when 'console' is not supported.
+ * This really simplifies the code.
+ * ---
+ * Similar to invariant but only logs a warning if the condition is not met.
+ * This can be used to log issues in development environments in critical
+ * paths. Removing the logging code for production environments will keep the
+ * same logic and follow the same code paths.
+ */
+
+var lowPriorityWarning = function () {};
+
+if ("development" !== 'production') {
+  var printWarning = function (format) {
+    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      args[_key - 1] = arguments[_key];
+    }
+
+    var argIndex = 0;
+    var message = 'Warning: ' + format.replace(/%s/g, function () {
+      return args[argIndex++];
+    });
+    if (typeof console !== 'undefined') {
+      console.warn(message);
+    }
+    try {
+      // --- Welcome to debugging React ---
+      // This error was thrown as a convenience so that you can use this stack
+      // to find the callsite that caused this warning to fire.
+      throw new Error(message);
+    } catch (x) {}
+  };
+
+  lowPriorityWarning = function (condition, format) {
+    if (format === undefined) {
+      throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
+    }
+    if (!condition) {
+      for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+        args[_key2 - 2] = arguments[_key2];
+      }
+
+      printWarning.apply(undefined, [format].concat(args));
+    }
+  };
+}
+
+module.exports = lowPriorityWarning;
+},{}],24:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+var _prodInvariant = _dereq_(25);
+
+var ReactElement = _dereq_(9);
+
+var invariant = _dereq_(30);
+
+/**
+ * Returns the first child in a collection of children and verifies that there
+ * is only one child in the collection.
+ *
+ * See https://facebook.github.io/react/docs/top-level-api.html#react.children.only
+ *
+ * The current implementation of this function assumes that a single child gets
+ * passed without a wrapper, but the purpose of this helper function is to
+ * abstract away the particular structure of children.
+ *
+ * @param {?object} children Child collection structure.
+ * @return {ReactElement} The first and only `ReactElement` contained in the
+ * structure.
+ */
+function onlyChild(children) {
+  !ReactElement.isValidElement(children) ? "development" !== 'production' ? invariant(false, 'React.Children.only expected to receive a single React element child.') : _prodInvariant('143') : void 0;
+  return children;
+}
+
+module.exports = onlyChild;
+},{"25":25,"30":30,"9":9}],25:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+'use strict';
+
+/**
+ * WARNING: DO NOT manually require this module.
+ * This is a replacement for `invariant(...)` used by the error code system
+ * and will _only_ be required by the corresponding babel pass.
+ * It always throws.
+ */
+
+function reactProdInvariant(code) {
+  var argCount = arguments.length - 1;
+
+  var message = 'Minified React error #' + code + '; visit ' + 'http://facebook.github.io/react/docs/error-decoder.html?invariant=' + code;
+
+  for (var argIdx = 0; argIdx < argCount; argIdx++) {
+    message += '&args[]=' + encodeURIComponent(arguments[argIdx + 1]);
+  }
+
+  message += ' for the full message or use the non-minified dev environment' + ' for full errors and additional helpful warnings.';
+
+  var error = new Error(message);
+  error.name = 'Invariant Violation';
+  error.framesToPop = 1; // we don't care about reactProdInvariant's own frame
+
+  throw error;
+}
+
+module.exports = reactProdInvariant;
+},{}],26:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+var _prodInvariant = _dereq_(25);
+
+var ReactCurrentOwner = _dereq_(7);
+var REACT_ELEMENT_TYPE = _dereq_(10);
+
+var getIteratorFn = _dereq_(21);
+var invariant = _dereq_(30);
+var KeyEscapeUtils = _dereq_(1);
+var warning = _dereq_(31);
+
+var SEPARATOR = '.';
+var SUBSEPARATOR = ':';
+
+/**
+ * This is inlined from ReactElement since this file is shared between
+ * isomorphic and renderers. We could extract this to a
+ *
+ */
+
+/**
+ * TODO: Test that a single child and an array with one item have the same key
+ * pattern.
+ */
+
+var didWarnAboutMaps = false;
+
+/**
+ * Generate a key string that identifies a component within a set.
+ *
+ * @param {*} component A component that could contain a manual key.
+ * @param {number} index Index that is used if a manual key is not provided.
+ * @return {string}
+ */
+function getComponentKey(component, index) {
+  // Do some typechecking here since we call this blindly. We want to ensure
+  // that we don't block potential future ES APIs.
+  if (component && typeof component === 'object' && component.key != null) {
+    // Explicit key
+    return KeyEscapeUtils.escape(component.key);
+  }
+  // Implicit key determined by the index in the set
+  return index.toString(36);
+}
+
+/**
+ * @param {?*} children Children tree container.
+ * @param {!string} nameSoFar Name of the key path so far.
+ * @param {!function} callback Callback to invoke with each child found.
+ * @param {?*} traverseContext Used to pass information throughout the traversal
+ * process.
+ * @return {!number} The number of children in this subtree.
+ */
+function traverseAllChildrenImpl(children, nameSoFar, callback, traverseContext) {
+  var type = typeof children;
+
+  if (type === 'undefined' || type === 'boolean') {
+    // All of the above are perceived as null.
+    children = null;
+  }
+
+  if (children === null || type === 'string' || type === 'number' ||
+  // The following is inlined from ReactElement. This means we can optimize
+  // some checks. React Fiber also inlines this logic for similar purposes.
+  type === 'object' && children.$$typeof === REACT_ELEMENT_TYPE) {
+    callback(traverseContext, children,
+    // If it's the only child, treat the name as if it was wrapped in an array
+    // so that it's consistent if the number of children grows.
+    nameSoFar === '' ? SEPARATOR + getComponentKey(children, 0) : nameSoFar);
+    return 1;
+  }
+
+  var child;
+  var nextName;
+  var subtreeCount = 0; // Count of children found in the current subtree.
+  var nextNamePrefix = nameSoFar === '' ? SEPARATOR : nameSoFar + SUBSEPARATOR;
+
+  if (Array.isArray(children)) {
+    for (var i = 0; i < children.length; i++) {
+      child = children[i];
+      nextName = nextNamePrefix + getComponentKey(child, i);
+      subtreeCount += traverseAllChildrenImpl(child, nextName, callback, traverseContext);
+    }
+  } else {
+    var iteratorFn = getIteratorFn(children);
+    if (iteratorFn) {
+      var iterator = iteratorFn.call(children);
+      var step;
+      if (iteratorFn !== children.entries) {
+        var ii = 0;
+        while (!(step = iterator.next()).done) {
+          child = step.value;
+          nextName = nextNamePrefix + getComponentKey(child, ii++);
+          subtreeCount += traverseAllChildrenImpl(child, nextName, callback, traverseContext);
+        }
+      } else {
+        if ("development" !== 'production') {
+          var mapsAsChildrenAddendum = '';
+          if (ReactCurrentOwner.current) {
+            var mapsAsChildrenOwnerName = ReactCurrentOwner.current.getName();
+            if (mapsAsChildrenOwnerName) {
+              mapsAsChildrenAddendum = ' Check the render method of `' + mapsAsChildrenOwnerName + '`.';
+            }
+          }
+          "development" !== 'production' ? warning(didWarnAboutMaps, 'Using Maps as children is not yet fully supported. It is an ' + 'experimental feature that might be removed. Convert it to a ' + 'sequence / iterable of keyed ReactElements instead.%s', mapsAsChildrenAddendum) : void 0;
+          didWarnAboutMaps = true;
+        }
+        // Iterator will provide entry [k,v] tuples rather than values.
+        while (!(step = iterator.next()).done) {
+          var entry = step.value;
+          if (entry) {
+            child = entry[1];
+            nextName = nextNamePrefix + KeyEscapeUtils.escape(entry[0]) + SUBSEPARATOR + getComponentKey(child, 0);
+            subtreeCount += traverseAllChildrenImpl(child, nextName, callback, traverseContext);
+          }
+        }
+      }
+    } else if (type === 'object') {
+      var addendum = '';
+      if ("development" !== 'production') {
+        addendum = ' If you meant to render a collection of children, use an array ' + 'instead or wrap the object using createFragment(object) from the ' + 'React add-ons.';
+        if (children._isReactElement) {
+          addendum = " It looks like you're using an element created by a different " + 'version of React. Make sure to use only one copy of React.';
+        }
+        if (ReactCurrentOwner.current) {
+          var name = ReactCurrentOwner.current.getName();
+          if (name) {
+            addendum += ' Check the render method of `' + name + '`.';
+          }
+        }
+      }
+      var childrenString = String(children);
+      !false ? "development" !== 'production' ? invariant(false, 'Objects are not valid as a React child (found: %s).%s', childrenString === '[object Object]' ? 'object with keys {' + Object.keys(children).join(', ') + '}' : childrenString, addendum) : _prodInvariant('31', childrenString === '[object Object]' ? 'object with keys {' + Object.keys(children).join(', ') + '}' : childrenString, addendum) : void 0;
+    }
+  }
+
+  return subtreeCount;
+}
+
+/**
+ * Traverses children that are typically specified as `props.children`, but
+ * might also be specified through attributes:
+ *
+ * - `traverseAllChildren(this.props.children, ...)`
+ * - `traverseAllChildren(this.props.leftPanelChildren, ...)`
+ *
+ * The `traverseContext` is an optional argument that is passed through the
+ * entire traversal. It can be used to store accumulations or anything else that
+ * the callback might find relevant.
+ *
+ * @param {?*} children Children tree object.
+ * @param {!function} callback To invoke upon traversing each child.
+ * @param {?*} traverseContext Context for traversal.
+ * @return {!number} The number of children in this subtree.
+ */
+function traverseAllChildren(children, callback, traverseContext) {
+  if (children == null) {
+    return 0;
+  }
+
+  return traverseAllChildrenImpl(children, '', callback, traverseContext);
+}
+
+module.exports = traverseAllChildren;
+},{"1":1,"10":10,"21":21,"25":25,"30":30,"31":31,"7":7}],27:[function(_dereq_,module,exports){
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+var _assign = _dereq_(32);
+
+var emptyObject = _dereq_(29);
+var _invariant = _dereq_(30);
+
+if ("development" !== 'production') {
+  var warning = _dereq_(31);
+}
+
+var MIXINS_KEY = 'mixins';
+
+// Helper function to allow the creation of anonymous functions which do not
+// have .name set to the name of the variable being assigned to.
+function identity(fn) {
+  return fn;
+}
+
+var ReactPropTypeLocationNames;
+if ("development" !== 'production') {
+  ReactPropTypeLocationNames = {
+    prop: 'prop',
+    context: 'context',
+    childContext: 'child context'
+  };
+} else {
+  ReactPropTypeLocationNames = {};
+}
+
+function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
+  /**
+   * Policies that describe methods in `ReactClassInterface`.
+   */
+
+  var injectedMixins = [];
+
+  /**
+   * Composite components are higher-level components that compose other composite
+   * or host components.
+   *
+   * To create a new type of `ReactClass`, pass a specification of
+   * your new class to `React.createClass`. The only requirement of your class
+   * specification is that you implement a `render` method.
+   *
+   *   var MyComponent = React.createClass({
+   *     render: function() {
+   *       return <div>Hello World</div>;
+   *     }
+   *   });
+   *
+   * The class specification supports a specific protocol of methods that have
+   * special meaning (e.g. `render`). See `ReactClassInterface` for
+   * more the comprehensive protocol. Any other properties and methods in the
+   * class specification will be available on the prototype.
+   *
+   * @interface ReactClassInterface
+   * @internal
+   */
+  var ReactClassInterface = {
+    /**
+     * An array of Mixin objects to include when defining your component.
+     *
+     * @type {array}
+     * @optional
+     */
+    mixins: 'DEFINE_MANY',
+
+    /**
+     * An object containing properties and methods that should be defined on
+     * the component's constructor instead of its prototype (static methods).
+     *
+     * @type {object}
+     * @optional
+     */
+    statics: 'DEFINE_MANY',
+
+    /**
+     * Definition of prop types for this component.
+     *
+     * @type {object}
+     * @optional
+     */
+    propTypes: 'DEFINE_MANY',
+
+    /**
+     * Definition of context types for this component.
+     *
+     * @type {object}
+     * @optional
+     */
+    contextTypes: 'DEFINE_MANY',
+
+    /**
+     * Definition of context types this component sets for its children.
+     *
+     * @type {object}
+     * @optional
+     */
+    childContextTypes: 'DEFINE_MANY',
+
+    // ==== Definition methods ====
+
+    /**
+     * Invoked when the component is mounted. Values in the mapping will be set on
+     * `this.props` if that prop is not specified (i.e. using an `in` check).
+     *
+     * This method is invoked before `getInitialState` and therefore cannot rely
+     * on `this.state` or use `this.setState`.
+     *
+     * @return {object}
+     * @optional
+     */
+    getDefaultProps: 'DEFINE_MANY_MERGED',
+
+    /**
+     * Invoked once before the component is mounted. The return value will be used
+     * as the initial value of `this.state`.
+     *
+     *   getInitialState: function() {
+     *     return {
+     *       isOn: false,
+     *       fooBaz: new BazFoo()
+     *     }
+     *   }
+     *
+     * @return {object}
+     * @optional
+     */
+    getInitialState: 'DEFINE_MANY_MERGED',
+
+    /**
+     * @return {object}
+     * @optional
+     */
+    getChildContext: 'DEFINE_MANY_MERGED',
+
+    /**
+     * Uses props from `this.props` and state from `this.state` to render the
+     * structure of the component.
+     *
+     * No guarantees are made about when or how often this method is invoked, so
+     * it must not have side effects.
+     *
+     *   render: function() {
+     *     var name = this.props.name;
+     *     return <div>Hello, {name}!</div>;
+     *   }
+     *
+     * @return {ReactComponent}
+     * @required
+     */
+    render: 'DEFINE_ONCE',
+
+    // ==== Delegate methods ====
+
+    /**
+     * Invoked when the component is initially created and about to be mounted.
+     * This may have side effects, but any external subscriptions or data created
+     * by this method must be cleaned up in `componentWillUnmount`.
+     *
+     * @optional
+     */
+    componentWillMount: 'DEFINE_MANY',
+
+    /**
+     * Invoked when the component has been mounted and has a DOM representation.
+     * However, there is no guarantee that the DOM node is in the document.
+     *
+     * Use this as an opportunity to operate on the DOM when the component has
+     * been mounted (initialized and rendered) for the first time.
+     *
+     * @param {DOMElement} rootNode DOM element representing the component.
+     * @optional
+     */
+    componentDidMount: 'DEFINE_MANY',
+
+    /**
+     * Invoked before the component receives new props.
+     *
+     * Use this as an opportunity to react to a prop transition by updating the
+     * state using `this.setState`. Current props are accessed via `this.props`.
+     *
+     *   componentWillReceiveProps: function(nextProps, nextContext) {
+     *     this.setState({
+     *       likesIncreasing: nextProps.likeCount > this.props.likeCount
+     *     });
+     *   }
+     *
+     * NOTE: There is no equivalent `componentWillReceiveState`. An incoming prop
+     * transition may cause a state change, but the opposite is not true. If you
+     * need it, you are probably looking for `componentWillUpdate`.
+     *
+     * @param {object} nextProps
+     * @optional
+     */
+    componentWillReceiveProps: 'DEFINE_MANY',
+
+    /**
+     * Invoked while deciding if the component should be updated as a result of
+     * receiving new props, state and/or context.
+     *
+     * Use this as an opportunity to `return false` when you're certain that the
+     * transition to the new props/state/context will not require a component
+     * update.
+     *
+     *   shouldComponentUpdate: function(nextProps, nextState, nextContext) {
+     *     return !equal(nextProps, this.props) ||
+     *       !equal(nextState, this.state) ||
+     *       !equal(nextContext, this.context);
+     *   }
+     *
+     * @param {object} nextProps
+     * @param {?object} nextState
+     * @param {?object} nextContext
+     * @return {boolean} True if the component should update.
+     * @optional
+     */
+    shouldComponentUpdate: 'DEFINE_ONCE',
+
+    /**
+     * Invoked when the component is about to update due to a transition from
+     * `this.props`, `this.state` and `this.context` to `nextProps`, `nextState`
+     * and `nextContext`.
+     *
+     * Use this as an opportunity to perform preparation before an update occurs.
+     *
+     * NOTE: You **cannot** use `this.setState()` in this method.
+     *
+     * @param {object} nextProps
+     * @param {?object} nextState
+     * @param {?object} nextContext
+     * @param {ReactReconcileTransaction} transaction
+     * @optional
+     */
+    componentWillUpdate: 'DEFINE_MANY',
+
+    /**
+     * Invoked when the component's DOM representation has been updated.
+     *
+     * Use this as an opportunity to operate on the DOM when the component has
+     * been updated.
+     *
+     * @param {object} prevProps
+     * @param {?object} prevState
+     * @param {?object} prevContext
+     * @param {DOMElement} rootNode DOM element representing the component.
+     * @optional
+     */
+    componentDidUpdate: 'DEFINE_MANY',
+
+    /**
+     * Invoked when the component is about to be removed from its parent and have
+     * its DOM representation destroyed.
+     *
+     * Use this as an opportunity to deallocate any external resources.
+     *
+     * NOTE: There is no `componentDidUnmount` since your component will have been
+     * destroyed by that point.
+     *
+     * @optional
+     */
+    componentWillUnmount: 'DEFINE_MANY',
+
+    // ==== Advanced methods ====
+
+    /**
+     * Updates the component's currently mounted DOM representation.
+     *
+     * By default, this implements React's rendering and reconciliation algorithm.
+     * Sophisticated clients may wish to override this.
+     *
+     * @param {ReactReconcileTransaction} transaction
+     * @internal
+     * @overridable
+     */
+    updateComponent: 'OVERRIDE_BASE'
+  };
+
+  /**
+   * Mapping from class specification keys to special processing functions.
+   *
+   * Although these are declared like instance properties in the specification
+   * when defining classes using `React.createClass`, they are actually static
+   * and are accessible on the constructor instead of the prototype. Despite
+   * being static, they must be defined outside of the "statics" key under
+   * which all other static methods are defined.
+   */
+  var RESERVED_SPEC_KEYS = {
+    displayName: function(Constructor, displayName) {
+      Constructor.displayName = displayName;
+    },
+    mixins: function(Constructor, mixins) {
+      if (mixins) {
+        for (var i = 0; i < mixins.length; i++) {
+          mixSpecIntoComponent(Constructor, mixins[i]);
+        }
+      }
+    },
+    childContextTypes: function(Constructor, childContextTypes) {
+      if ("development" !== 'production') {
+        validateTypeDef(Constructor, childContextTypes, 'childContext');
+      }
+      Constructor.childContextTypes = _assign(
+        {},
+        Constructor.childContextTypes,
+        childContextTypes
+      );
+    },
+    contextTypes: function(Constructor, contextTypes) {
+      if ("development" !== 'production') {
+        validateTypeDef(Constructor, contextTypes, 'context');
+      }
+      Constructor.contextTypes = _assign(
+        {},
+        Constructor.contextTypes,
+        contextTypes
+      );
+    },
+    /**
+     * Special case getDefaultProps which should move into statics but requires
+     * automatic merging.
+     */
+    getDefaultProps: function(Constructor, getDefaultProps) {
+      if (Constructor.getDefaultProps) {
+        Constructor.getDefaultProps = createMergedResultFunction(
+          Constructor.getDefaultProps,
+          getDefaultProps
+        );
+      } else {
+        Constructor.getDefaultProps = getDefaultProps;
+      }
+    },
+    propTypes: function(Constructor, propTypes) {
+      if ("development" !== 'production') {
+        validateTypeDef(Constructor, propTypes, 'prop');
+      }
+      Constructor.propTypes = _assign({}, Constructor.propTypes, propTypes);
+    },
+    statics: function(Constructor, statics) {
+      mixStaticSpecIntoComponent(Constructor, statics);
+    },
+    autobind: function() {}
+  };
+
+  function validateTypeDef(Constructor, typeDef, location) {
+    for (var propName in typeDef) {
+      if (typeDef.hasOwnProperty(propName)) {
+        // use a warning instead of an _invariant so components
+        // don't show up in prod but only in __DEV__
+        if ("development" !== 'production') {
+          warning(
+            typeof typeDef[propName] === 'function',
+            '%s: %s type `%s` is invalid; it must be a function, usually from ' +
+              'React.PropTypes.',
+            Constructor.displayName || 'ReactClass',
+            ReactPropTypeLocationNames[location],
+            propName
+          );
+        }
+      }
+    }
+  }
+
+  function validateMethodOverride(isAlreadyDefined, name) {
+    var specPolicy = ReactClassInterface.hasOwnProperty(name)
+      ? ReactClassInterface[name]
+      : null;
+
+    // Disallow overriding of base class methods unless explicitly allowed.
+    if (ReactClassMixin.hasOwnProperty(name)) {
+      _invariant(
+        specPolicy === 'OVERRIDE_BASE',
+        'ReactClassInterface: You are attempting to override ' +
+          '`%s` from your class specification. Ensure that your method names ' +
+          'do not overlap with React methods.',
+        name
+      );
+    }
+
+    // Disallow defining methods more than once unless explicitly allowed.
+    if (isAlreadyDefined) {
+      _invariant(
+        specPolicy === 'DEFINE_MANY' || specPolicy === 'DEFINE_MANY_MERGED',
+        'ReactClassInterface: You are attempting to define ' +
+          '`%s` on your component more than once. This conflict may be due ' +
+          'to a mixin.',
+        name
+      );
+    }
+  }
+
+  /**
+   * Mixin helper which handles policy validation and reserved
+   * specification keys when building React classes.
+   */
+  function mixSpecIntoComponent(Constructor, spec) {
+    if (!spec) {
+      if ("development" !== 'production') {
+        var typeofSpec = typeof spec;
+        var isMixinValid = typeofSpec === 'object' && spec !== null;
+
+        if ("development" !== 'production') {
+          warning(
+            isMixinValid,
+            "%s: You're attempting to include a mixin that is either null " +
+              'or not an object. Check the mixins included by the component, ' +
+              'as well as any mixins they include themselves. ' +
+              'Expected object but got %s.',
+            Constructor.displayName || 'ReactClass',
+            spec === null ? null : typeofSpec
+          );
+        }
+      }
+
+      return;
+    }
+
+    _invariant(
+      typeof spec !== 'function',
+      "ReactClass: You're attempting to " +
+        'use a component class or function as a mixin. Instead, just use a ' +
+        'regular object.'
+    );
+    _invariant(
+      !isValidElement(spec),
+      "ReactClass: You're attempting to " +
+        'use a component as a mixin. Instead, just use a regular object.'
+    );
+
+    var proto = Constructor.prototype;
+    var autoBindPairs = proto.__reactAutoBindPairs;
+
+    // By handling mixins before any other properties, we ensure the same
+    // chaining order is applied to methods with DEFINE_MANY policy, whether
+    // mixins are listed before or after these methods in the spec.
+    if (spec.hasOwnProperty(MIXINS_KEY)) {
+      RESERVED_SPEC_KEYS.mixins(Constructor, spec.mixins);
+    }
+
+    for (var name in spec) {
+      if (!spec.hasOwnProperty(name)) {
+        continue;
+      }
+
+      if (name === MIXINS_KEY) {
+        // We have already handled mixins in a special case above.
+        continue;
+      }
+
+      var property = spec[name];
+      var isAlreadyDefined = proto.hasOwnProperty(name);
+      validateMethodOverride(isAlreadyDefined, name);
+
+      if (RESERVED_SPEC_KEYS.hasOwnProperty(name)) {
+        RESERVED_SPEC_KEYS[name](Constructor, property);
+      } else {
+        // Setup methods on prototype:
+        // The following member methods should not be automatically bound:
+        // 1. Expected ReactClass methods (in the "interface").
+        // 2. Overridden methods (that were mixed in).
+        var isReactClassMethod = ReactClassInterface.hasOwnProperty(name);
+        var isFunction = typeof property === 'function';
+        var shouldAutoBind =
+          isFunction &&
+          !isReactClassMethod &&
+          !isAlreadyDefined &&
+          spec.autobind !== false;
+
+        if (shouldAutoBind) {
+          autoBindPairs.push(name, property);
+          proto[name] = property;
+        } else {
+          if (isAlreadyDefined) {
+            var specPolicy = ReactClassInterface[name];
+
+            // These cases should already be caught by validateMethodOverride.
+            _invariant(
+              isReactClassMethod &&
+                (specPolicy === 'DEFINE_MANY_MERGED' ||
+                  specPolicy === 'DEFINE_MANY'),
+              'ReactClass: Unexpected spec policy %s for key %s ' +
+                'when mixing in component specs.',
+              specPolicy,
+              name
+            );
+
+            // For methods which are defined more than once, call the existing
+            // methods before calling the new property, merging if appropriate.
+            if (specPolicy === 'DEFINE_MANY_MERGED') {
+              proto[name] = createMergedResultFunction(proto[name], property);
+            } else if (specPolicy === 'DEFINE_MANY') {
+              proto[name] = createChainedFunction(proto[name], property);
+            }
+          } else {
+            proto[name] = property;
+            if ("development" !== 'production') {
+              // Add verbose displayName to the function, which helps when looking
+              // at profiling tools.
+              if (typeof property === 'function' && spec.displayName) {
+                proto[name].displayName = spec.displayName + '_' + name;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  function mixStaticSpecIntoComponent(Constructor, statics) {
+    if (!statics) {
+      return;
+    }
+    for (var name in statics) {
+      var property = statics[name];
+      if (!statics.hasOwnProperty(name)) {
+        continue;
+      }
+
+      var isReserved = name in RESERVED_SPEC_KEYS;
+      _invariant(
+        !isReserved,
+        'ReactClass: You are attempting to define a reserved ' +
+          'property, `%s`, that shouldn\'t be on the "statics" key. Define it ' +
+          'as an instance property instead; it will still be accessible on the ' +
+          'constructor.',
+        name
+      );
+
+      var isInherited = name in Constructor;
+      _invariant(
+        !isInherited,
+        'ReactClass: You are attempting to define ' +
+          '`%s` on your component more than once. This conflict may be ' +
+          'due to a mixin.',
+        name
+      );
+      Constructor[name] = property;
+    }
+  }
+
+  /**
+   * Merge two objects, but throw if both contain the same key.
+   *
+   * @param {object} one The first object, which is mutated.
+   * @param {object} two The second object
+   * @return {object} one after it has been mutated to contain everything in two.
+   */
+  function mergeIntoWithNoDuplicateKeys(one, two) {
+    _invariant(
+      one && two && typeof one === 'object' && typeof two === 'object',
+      'mergeIntoWithNoDuplicateKeys(): Cannot merge non-objects.'
+    );
+
+    for (var key in two) {
+      if (two.hasOwnProperty(key)) {
+        _invariant(
+          one[key] === undefined,
+          'mergeIntoWithNoDuplicateKeys(): ' +
+            'Tried to merge two objects with the same key: `%s`. This conflict ' +
+            'may be due to a mixin; in particular, this may be caused by two ' +
+            'getInitialState() or getDefaultProps() methods returning objects ' +
+            'with clashing keys.',
+          key
+        );
+        one[key] = two[key];
+      }
+    }
+    return one;
+  }
+
+  /**
+   * Creates a function that invokes two functions and merges their return values.
+   *
+   * @param {function} one Function to invoke first.
+   * @param {function} two Function to invoke second.
+   * @return {function} Function that invokes the two argument functions.
+   * @private
+   */
+  function createMergedResultFunction(one, two) {
+    return function mergedResult() {
+      var a = one.apply(this, arguments);
+      var b = two.apply(this, arguments);
+      if (a == null) {
+        return b;
+      } else if (b == null) {
+        return a;
+      }
+      var c = {};
+      mergeIntoWithNoDuplicateKeys(c, a);
+      mergeIntoWithNoDuplicateKeys(c, b);
+      return c;
+    };
+  }
+
+  /**
+   * Creates a function that invokes two functions and ignores their return vales.
+   *
+   * @param {function} one Function to invoke first.
+   * @param {function} two Function to invoke second.
+   * @return {function} Function that invokes the two argument functions.
+   * @private
+   */
+  function createChainedFunction(one, two) {
+    return function chainedFunction() {
+      one.apply(this, arguments);
+      two.apply(this, arguments);
+    };
+  }
+
+  /**
+   * Binds a method to the component.
+   *
+   * @param {object} component Component whose method is going to be bound.
+   * @param {function} method Method to be bound.
+   * @return {function} The bound method.
+   */
+  function bindAutoBindMethod(component, method) {
+    var boundMethod = method.bind(component);
+    if ("development" !== 'production') {
+      boundMethod.__reactBoundContext = component;
+      boundMethod.__reactBoundMethod = method;
+      boundMethod.__reactBoundArguments = null;
+      var componentName = component.constructor.displayName;
+      var _bind = boundMethod.bind;
+      boundMethod.bind = function(newThis) {
+        for (
+          var _len = arguments.length,
+            args = Array(_len > 1 ? _len - 1 : 0),
+            _key = 1;
+          _key < _len;
+          _key++
+        ) {
+          args[_key - 1] = arguments[_key];
+        }
+
+        // User is trying to bind() an autobound method; we effectively will
+        // ignore the value of "this" that the user is trying to use, so
+        // let's warn.
+        if (newThis !== component && newThis !== null) {
+          if ("development" !== 'production') {
+            warning(
+              false,
+              'bind(): React component methods may only be bound to the ' +
+                'component instance. See %s',
+              componentName
+            );
+          }
+        } else if (!args.length) {
+          if ("development" !== 'production') {
+            warning(
+              false,
+              'bind(): You are binding a component method to the component. ' +
+                'React does this for you automatically in a high-performance ' +
+                'way, so you can safely remove this call. See %s',
+              componentName
+            );
+          }
+          return boundMethod;
+        }
+        var reboundMethod = _bind.apply(boundMethod, arguments);
+        reboundMethod.__reactBoundContext = component;
+        reboundMethod.__reactBoundMethod = method;
+        reboundMethod.__reactBoundArguments = args;
+        return reboundMethod;
+      };
+    }
+    return boundMethod;
+  }
+
+  /**
+   * Binds all auto-bound methods in a component.
+   *
+   * @param {object} component Component whose method is going to be bound.
+   */
+  function bindAutoBindMethods(component) {
+    var pairs = component.__reactAutoBindPairs;
+    for (var i = 0; i < pairs.length; i += 2) {
+      var autoBindKey = pairs[i];
+      var method = pairs[i + 1];
+      component[autoBindKey] = bindAutoBindMethod(component, method);
+    }
+  }
+
+  var IsMountedPreMixin = {
+    componentDidMount: function() {
+      this.__isMounted = true;
+    }
+  };
+
+  var IsMountedPostMixin = {
+    componentWillUnmount: function() {
+      this.__isMounted = false;
+    }
+  };
+
+  /**
+   * Add more to the ReactClass base class. These are all legacy features and
+   * therefore not already part of the modern ReactComponent.
+   */
+  var ReactClassMixin = {
+    /**
+     * TODO: This will be deprecated because state should always keep a consistent
+     * type signature and the only use case for this, is to avoid that.
+     */
+    replaceState: function(newState, callback) {
+      this.updater.enqueueReplaceState(this, newState, callback);
+    },
+
+    /**
+     * Checks whether or not this composite component is mounted.
+     * @return {boolean} True if mounted, false otherwise.
+     * @protected
+     * @final
+     */
+    isMounted: function() {
+      if ("development" !== 'production') {
+        warning(
+          this.__didWarnIsMounted,
+          '%s: isMounted is deprecated. Instead, make sure to clean up ' +
+            'subscriptions and pending requests in componentWillUnmount to ' +
+            'prevent memory leaks.',
+          (this.constructor && this.constructor.displayName) ||
+            this.name ||
+            'Component'
+        );
+        this.__didWarnIsMounted = true;
+      }
+      return !!this.__isMounted;
+    }
+  };
+
+  var ReactClassComponent = function() {};
+  _assign(
+    ReactClassComponent.prototype,
+    ReactComponent.prototype,
+    ReactClassMixin
+  );
+
+  /**
+   * Creates a composite component class given a class specification.
+   * See https://facebook.github.io/react/docs/top-level-api.html#react.createclass
+   *
+   * @param {object} spec Class specification (which must define `render`).
+   * @return {function} Component constructor function.
+   * @public
+   */
+  function createClass(spec) {
+    // To keep our warnings more understandable, we'll use a little hack here to
+    // ensure that Constructor.name !== 'Constructor'. This makes sure we don't
+    // unnecessarily identify a class without displayName as 'Constructor'.
+    var Constructor = identity(function(props, context, updater) {
+      // This constructor gets overridden by mocks. The argument is used
+      // by mocks to assert on what gets mounted.
+
+      if ("development" !== 'production') {
+        warning(
+          this instanceof Constructor,
+          'Something is calling a React component directly. Use a factory or ' +
+            'JSX instead. See: https://fb.me/react-legacyfactory'
+        );
+      }
+
+      // Wire up auto-binding
+      if (this.__reactAutoBindPairs.length) {
+        bindAutoBindMethods(this);
+      }
+
+      this.props = props;
+      this.context = context;
+      this.refs = emptyObject;
+      this.updater = updater || ReactNoopUpdateQueue;
+
+      this.state = null;
+
+      // ReactClasses doesn't have constructors. Instead, they use the
+      // getInitialState and componentWillMount methods for initialization.
+
+      var initialState = this.getInitialState ? this.getInitialState() : null;
+      if ("development" !== 'production') {
+        // We allow auto-mocks to proceed as if they're returning null.
+        if (
+          initialState === undefined &&
+          this.getInitialState._isMockFunction
+        ) {
+          // This is probably bad practice. Consider warning here and
+          // deprecating this convenience.
+          initialState = null;
+        }
+      }
+      _invariant(
+        typeof initialState === 'object' && !Array.isArray(initialState),
+        '%s.getInitialState(): must return an object or null',
+        Constructor.displayName || 'ReactCompositeComponent'
+      );
+
+      this.state = initialState;
+    });
+    Constructor.prototype = new ReactClassComponent();
+    Constructor.prototype.constructor = Constructor;
+    Constructor.prototype.__reactAutoBindPairs = [];
+
+    injectedMixins.forEach(mixSpecIntoComponent.bind(null, Constructor));
+
+    mixSpecIntoComponent(Constructor, IsMountedPreMixin);
+    mixSpecIntoComponent(Constructor, spec);
+    mixSpecIntoComponent(Constructor, IsMountedPostMixin);
+
+    // Initialize the defaultProps property after all mixins have been merged.
+    if (Constructor.getDefaultProps) {
+      Constructor.defaultProps = Constructor.getDefaultProps();
+    }
+
+    if ("development" !== 'production') {
+      // This is a tag to indicate that the use of these method names is ok,
+      // since it's used with createClass. If it's not, then it's likely a
+      // mistake so we'll warn you to use the static property, property
+      // initializer or constructor respectively.
+      if (Constructor.getDefaultProps) {
+        Constructor.getDefaultProps.isReactClassApproved = {};
+      }
+      if (Constructor.prototype.getInitialState) {
+        Constructor.prototype.getInitialState.isReactClassApproved = {};
+      }
+    }
+
+    _invariant(
+      Constructor.prototype.render,
+      'createClass(...): Class specification must implement a `render` method.'
+    );
+
+    if ("development" !== 'production') {
+      warning(
+        !Constructor.prototype.componentShouldUpdate,
+        '%s has a method called ' +
+          'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' +
+          'The name is phrased as a question because the function is ' +
+          'expected to return a value.',
+        spec.displayName || 'A component'
+      );
+      warning(
+        !Constructor.prototype.componentWillRecieveProps,
+        '%s has a method called ' +
+          'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
+        spec.displayName || 'A component'
+      );
+    }
+
+    // Reduce time spent doing lookups by setting these on the prototype.
+    for (var methodName in ReactClassInterface) {
+      if (!Constructor.prototype[methodName]) {
+        Constructor.prototype[methodName] = null;
+      }
+    }
+
+    return Constructor;
+  }
+
+  return createClass;
+}
+
+module.exports = factory;
+
+},{"29":29,"30":30,"31":31,"32":32}],28:[function(_dereq_,module,exports){
+"use strict";
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *
+ */
+
+function makeEmptyFunction(arg) {
+  return function () {
+    return arg;
+  };
+}
+
+/**
+ * This function accepts and discards inputs; it has no side effects. This is
+ * primarily useful idiomatically for overridable function endpoints which
+ * always need to be callable, since JS lacks a null-call idiom ala Cocoa.
+ */
+var emptyFunction = function emptyFunction() {};
+
+emptyFunction.thatReturns = makeEmptyFunction;
+emptyFunction.thatReturnsFalse = makeEmptyFunction(false);
+emptyFunction.thatReturnsTrue = makeEmptyFunction(true);
+emptyFunction.thatReturnsNull = makeEmptyFunction(null);
+emptyFunction.thatReturnsThis = function () {
+  return this;
+};
+emptyFunction.thatReturnsArgument = function (arg) {
+  return arg;
+};
+
+module.exports = emptyFunction;
+},{}],29:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+var emptyObject = {};
+
+if ("development" !== 'production') {
+  Object.freeze(emptyObject);
+}
+
+module.exports = emptyObject;
+},{}],30:[function(_dereq_,module,exports){
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+/**
+ * Use invariant() to assert state which your program assumes to be true.
+ *
+ * Provide sprintf-style format (only %s is supported) and arguments
+ * to provide information about what broke and what you were
+ * expecting.
+ *
+ * The invariant message will be stripped in production, but the invariant
+ * will remain to ensure logic does not differ in production.
+ */
+
+var validateFormat = function validateFormat(format) {};
+
+if ("development" !== 'production') {
+  validateFormat = function validateFormat(format) {
+    if (format === undefined) {
+      throw new Error('invariant requires an error message argument');
+    }
+  };
+}
+
+function invariant(condition, format, a, b, c, d, e, f) {
+  validateFormat(format);
+
+  if (!condition) {
+    var error;
+    if (format === undefined) {
+      error = new Error('Minified exception occurred; use the non-minified dev environment ' + 'for the full error message and additional helpful warnings.');
+    } else {
+      var args = [a, b, c, d, e, f];
+      var argIndex = 0;
+      error = new Error(format.replace(/%s/g, function () {
+        return args[argIndex++];
+      }));
+      error.name = 'Invariant Violation';
+    }
+
+    error.framesToPop = 1; // we don't care about invariant's own frame
+    throw error;
+  }
+}
+
+module.exports = invariant;
+},{}],31:[function(_dereq_,module,exports){
+/**
+ * Copyright 2014-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+var emptyFunction = _dereq_(28);
+
+/**
+ * Similar to invariant but only logs a warning if the condition is not met.
+ * This can be used to log issues in development environments in critical
+ * paths. Removing the logging code for production environments will keep the
+ * same logic and follow the same code paths.
+ */
+
+var warning = emptyFunction;
+
+if ("development" !== 'production') {
+  (function () {
+    var printWarning = function printWarning(format) {
+      for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      var argIndex = 0;
+      var message = 'Warning: ' + format.replace(/%s/g, function () {
+        return args[argIndex++];
+      });
+      if (typeof console !== 'undefined') {
+        console.error(message);
+      }
+      try {
+        // --- Welcome to debugging React ---
+        // This error was thrown as a convenience so that you can use this stack
+        // to find the callsite that caused this warning to fire.
+        throw new Error(message);
+      } catch (x) {}
+    };
+
+    warning = function warning(condition, format) {
+      if (format === undefined) {
+        throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
+      }
+
+      if (format.indexOf('Failed Composite propType: ') === 0) {
+        return; // Ignore CompositeComponent proptype check.
+      }
+
+      if (!condition) {
+        for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+          args[_key2 - 2] = arguments[_key2];
+        }
+
+        printWarning.apply(undefined, [format].concat(args));
+      }
+    };
+  })();
+}
+
+module.exports = warning;
+},{"28":28}],32:[function(_dereq_,module,exports){
+/*
+object-assign
+(c) Sindre Sorhus
+@license MIT
+*/
+
+'use strict';
+/* eslint-disable no-unused-vars */
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+function toObject(val) {
+	if (val === null || val === undefined) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+function shouldUseNative() {
+	try {
+		if (!Object.assign) {
+			return false;
+		}
+
+		// Detect buggy property enumeration order in older V8 versions.
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
+		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
+		test1[5] = 'de';
+		if (Object.getOwnPropertyNames(test1)[0] === '5') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test2 = {};
+		for (var i = 0; i < 10; i++) {
+			test2['_' + String.fromCharCode(i)] = i;
+		}
+		var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
+			return test2[n];
+		});
+		if (order2.join('') !== '0123456789') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test3 = {};
+		'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
+			test3[letter] = letter;
+		});
+		if (Object.keys(Object.assign({}, test3)).join('') !==
+				'abcdefghijklmnopqrst') {
+			return false;
+		}
+
+		return true;
+	} catch (err) {
+		// We don't expect any of the above to throw, but better to be safe.
+		return false;
+	}
+}
+
+module.exports = shouldUseNative() ? Object.assign : function (target, source) {
+	var from;
+	var to = toObject(target);
+	var symbols;
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = Object(arguments[s]);
+
+		for (var key in from) {
+			if (hasOwnProperty.call(from, key)) {
+				to[key] = from[key];
+			}
+		}
+
+		if (getOwnPropertySymbols) {
+			symbols = getOwnPropertySymbols(from);
+			for (var i = 0; i < symbols.length; i++) {
+				if (propIsEnumerable.call(from, symbols[i])) {
+					to[symbols[i]] = from[symbols[i]];
+				}
+			}
+		}
+	}
+
+	return to;
+};
+
+},{}],33:[function(_dereq_,module,exports){
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+if ("development" !== 'production') {
+  var invariant = _dereq_(30);
+  var warning = _dereq_(31);
+  var ReactPropTypesSecret = _dereq_(36);
+  var loggedTypeFailures = {};
+}
+
+/**
+ * Assert that the values match with the type specs.
+ * Error messages are memorized and will only be shown once.
+ *
+ * @param {object} typeSpecs Map of name to a ReactPropType
+ * @param {object} values Runtime values that need to be type-checked
+ * @param {string} location e.g. "prop", "context", "child context"
+ * @param {string} componentName Name of the component for error messages.
+ * @param {?Function} getStack Returns the component stack.
+ * @private
+ */
+function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
+  if ("development" !== 'production') {
+    for (var typeSpecName in typeSpecs) {
+      if (typeSpecs.hasOwnProperty(typeSpecName)) {
+        var error;
+        // Prop type validation may throw. In case they do, we don't want to
+        // fail the render phase where it didn't fail before. So we log it.
+        // After these have been cleaned up, we'll let them throw.
+        try {
+          // This is intentionally an invariant that gets caught. It's the same
+          // behavior as without this statement except with a better message.
+          invariant(typeof typeSpecs[typeSpecName] === 'function', '%s: %s type `%s` is invalid; it must be a function, usually from ' + 'React.PropTypes.', componentName || 'React class', location, typeSpecName);
+          error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
+        } catch (ex) {
+          error = ex;
+        }
+        warning(!error || error instanceof Error, '%s: type specification of %s `%s` is invalid; the type checker ' + 'function must return `null` or an `Error` but returned a %s. ' + 'You may have forgotten to pass an argument to the type checker ' + 'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' + 'shape all require an argument).', componentName || 'React class', location, typeSpecName, typeof error);
+        if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+          // Only monitor this failure once because there tends to be a lot of the
+          // same error.
+          loggedTypeFailures[error.message] = true;
+
+          var stack = getStack ? getStack() : '';
+
+          warning(false, 'Failed %s type: %s%s', location, error.message, stack != null ? stack : '');
+        }
+      }
+    }
+  }
+}
+
+module.exports = checkPropTypes;
+
+},{"30":30,"31":31,"36":36}],34:[function(_dereq_,module,exports){
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+// React 15.5 references this module, and assumes PropTypes are still callable in production.
+// Therefore we re-export development-only version with all the PropTypes checks here.
+// However if one is migrating to the `prop-types` npm library, they will go through the
+// `index.js` entry point, and it will branch depending on the environment.
+var factory = _dereq_(35);
+module.exports = function(isValidElement) {
+  // It is still allowed in 15.5.
+  var throwOnDirectAccess = false;
+  return factory(isValidElement, throwOnDirectAccess);
+};
+
+},{"35":35}],35:[function(_dereq_,module,exports){
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var emptyFunction = _dereq_(28);
+var invariant = _dereq_(30);
+var warning = _dereq_(31);
+
+var ReactPropTypesSecret = _dereq_(36);
+var checkPropTypes = _dereq_(33);
+
+module.exports = function(isValidElement, throwOnDirectAccess) {
+  /* global Symbol */
+  var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+  var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+
+  /**
+   * Returns the iterator method function contained on the iterable object.
+   *
+   * Be sure to invoke the function with the iterable as context:
+   *
+   *     var iteratorFn = getIteratorFn(myIterable);
+   *     if (iteratorFn) {
+   *       var iterator = iteratorFn.call(myIterable);
+   *       ...
+   *     }
+   *
+   * @param {?object} maybeIterable
+   * @return {?function}
+   */
+  function getIteratorFn(maybeIterable) {
+    var iteratorFn = maybeIterable && (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL]);
+    if (typeof iteratorFn === 'function') {
+      return iteratorFn;
+    }
+  }
+
+  /**
+   * Collection of methods that allow declaration and validation of props that are
+   * supplied to React components. Example usage:
+   *
+   *   var Props = require('ReactPropTypes');
+   *   var MyArticle = React.createClass({
+   *     propTypes: {
+   *       // An optional string prop named "description".
+   *       description: Props.string,
+   *
+   *       // A required enum prop named "category".
+   *       category: Props.oneOf(['News','Photos']).isRequired,
+   *
+   *       // A prop named "dialog" that requires an instance of Dialog.
+   *       dialog: Props.instanceOf(Dialog).isRequired
+   *     },
+   *     render: function() { ... }
+   *   });
+   *
+   * A more formal specification of how these methods are used:
+   *
+   *   type := array|bool|func|object|number|string|oneOf([...])|instanceOf(...)
+   *   decl := ReactPropTypes.{type}(.isRequired)?
+   *
+   * Each and every declaration produces a function with the same signature. This
+   * allows the creation of custom validation functions. For example:
+   *
+   *  var MyLink = React.createClass({
+   *    propTypes: {
+   *      // An optional string or URI prop named "href".
+   *      href: function(props, propName, componentName) {
+   *        var propValue = props[propName];
+   *        if (propValue != null && typeof propValue !== 'string' &&
+   *            !(propValue instanceof URI)) {
+   *          return new Error(
+   *            'Expected a string or an URI for ' + propName + ' in ' +
+   *            componentName
+   *          );
+   *        }
+   *      }
+   *    },
+   *    render: function() {...}
+   *  });
+   *
+   * @internal
+   */
+
+  var ANONYMOUS = '<<anonymous>>';
+
+  // Important!
+  // Keep this list in sync with production version in `./factoryWithThrowingShims.js`.
+  var ReactPropTypes = {
+    array: createPrimitiveTypeChecker('array'),
+    bool: createPrimitiveTypeChecker('boolean'),
+    func: createPrimitiveTypeChecker('function'),
+    number: createPrimitiveTypeChecker('number'),
+    object: createPrimitiveTypeChecker('object'),
+    string: createPrimitiveTypeChecker('string'),
+    symbol: createPrimitiveTypeChecker('symbol'),
+
+    any: createAnyTypeChecker(),
+    arrayOf: createArrayOfTypeChecker,
+    element: createElementTypeChecker(),
+    instanceOf: createInstanceTypeChecker,
+    node: createNodeChecker(),
+    objectOf: createObjectOfTypeChecker,
+    oneOf: createEnumTypeChecker,
+    oneOfType: createUnionTypeChecker,
+    shape: createShapeTypeChecker
+  };
+
+  /**
+   * inlined Object.is polyfill to avoid requiring consumers ship their own
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+   */
+  /*eslint-disable no-self-compare*/
+  function is(x, y) {
+    // SameValue algorithm
+    if (x === y) {
+      // Steps 1-5, 7-10
+      // Steps 6.b-6.e: +0 != -0
+      return x !== 0 || 1 / x === 1 / y;
+    } else {
+      // Step 6.a: NaN == NaN
+      return x !== x && y !== y;
+    }
+  }
+  /*eslint-enable no-self-compare*/
+
+  /**
+   * We use an Error-like object for backward compatibility as people may call
+   * PropTypes directly and inspect their output. However, we don't use real
+   * Errors anymore. We don't inspect their stack anyway, and creating them
+   * is prohibitively expensive if they are created too often, such as what
+   * happens in oneOfType() for any type before the one that matched.
+   */
+  function PropTypeError(message) {
+    this.message = message;
+    this.stack = '';
+  }
+  // Make `instanceof Error` still work for returned errors.
+  PropTypeError.prototype = Error.prototype;
+
+  function createChainableTypeChecker(validate) {
+    if ("development" !== 'production') {
+      var manualPropTypeCallCache = {};
+      var manualPropTypeWarningCount = 0;
+    }
+    function checkType(isRequired, props, propName, componentName, location, propFullName, secret) {
+      componentName = componentName || ANONYMOUS;
+      propFullName = propFullName || propName;
+
+      if (secret !== ReactPropTypesSecret) {
+        if (throwOnDirectAccess) {
+          // New behavior only for users of `prop-types` package
+          invariant(
+            false,
+            'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
+            'Use `PropTypes.checkPropTypes()` to call them. ' +
+            'Read more at http://fb.me/use-check-prop-types'
+          );
+        } else if ("development" !== 'production' && typeof console !== 'undefined') {
+          // Old behavior for people using React.PropTypes
+          var cacheKey = componentName + ':' + propName;
+          if (
+            !manualPropTypeCallCache[cacheKey] &&
+            // Avoid spamming the console because they are often not actionable except for lib authors
+            manualPropTypeWarningCount < 3
+          ) {
+            warning(
+              false,
+              'You are manually calling a React.PropTypes validation ' +
+              'function for the `%s` prop on `%s`. This is deprecated ' +
+              'and will throw in the standalone `prop-types` package. ' +
+              'You may be seeing this warning due to a third-party PropTypes ' +
+              'library. See https://fb.me/react-warning-dont-call-proptypes ' + 'for details.',
+              propFullName,
+              componentName
+            );
+            manualPropTypeCallCache[cacheKey] = true;
+            manualPropTypeWarningCount++;
+          }
+        }
+      }
+      if (props[propName] == null) {
+        if (isRequired) {
+          if (props[propName] === null) {
+            return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required ' + ('in `' + componentName + '`, but its value is `null`.'));
+          }
+          return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required in ' + ('`' + componentName + '`, but its value is `undefined`.'));
+        }
+        return null;
+      } else {
+        return validate(props, propName, componentName, location, propFullName);
+      }
+    }
+
+    var chainedCheckType = checkType.bind(null, false);
+    chainedCheckType.isRequired = checkType.bind(null, true);
+
+    return chainedCheckType;
+  }
+
+  function createPrimitiveTypeChecker(expectedType) {
+    function validate(props, propName, componentName, location, propFullName, secret) {
+      var propValue = props[propName];
+      var propType = getPropType(propValue);
+      if (propType !== expectedType) {
+        // `propValue` being instance of, say, date/regexp, pass the 'object'
+        // check, but we can offer a more precise error message here rather than
+        // 'of type `object`'.
+        var preciseType = getPreciseType(propValue);
+
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + preciseType + '` supplied to `' + componentName + '`, expected ') + ('`' + expectedType + '`.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createAnyTypeChecker() {
+    return createChainableTypeChecker(emptyFunction.thatReturnsNull);
+  }
+
+  function createArrayOfTypeChecker(typeChecker) {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (typeof typeChecker !== 'function') {
+        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside arrayOf.');
+      }
+      var propValue = props[propName];
+      if (!Array.isArray(propValue)) {
+        var propType = getPropType(propValue);
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an array.'));
+      }
+      for (var i = 0; i < propValue.length; i++) {
+        var error = typeChecker(propValue, i, componentName, location, propFullName + '[' + i + ']', ReactPropTypesSecret);
+        if (error instanceof Error) {
+          return error;
+        }
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createElementTypeChecker() {
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      if (!isValidElement(propValue)) {
+        var propType = getPropType(propValue);
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createInstanceTypeChecker(expectedClass) {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (!(props[propName] instanceof expectedClass)) {
+        var expectedClassName = expectedClass.name || ANONYMOUS;
+        var actualClassName = getClassName(props[propName]);
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + actualClassName + '` supplied to `' + componentName + '`, expected ') + ('instance of `' + expectedClassName + '`.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createEnumTypeChecker(expectedValues) {
+    if (!Array.isArray(expectedValues)) {
+      "development" !== 'production' ? warning(false, 'Invalid argument supplied to oneOf, expected an instance of array.') : void 0;
+      return emptyFunction.thatReturnsNull;
+    }
+
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      for (var i = 0; i < expectedValues.length; i++) {
+        if (is(propValue, expectedValues[i])) {
+          return null;
+        }
+      }
+
+      var valuesString = JSON.stringify(expectedValues);
+      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of value `' + propValue + '` ' + ('supplied to `' + componentName + '`, expected one of ' + valuesString + '.'));
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createObjectOfTypeChecker(typeChecker) {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (typeof typeChecker !== 'function') {
+        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside objectOf.');
+      }
+      var propValue = props[propName];
+      var propType = getPropType(propValue);
+      if (propType !== 'object') {
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an object.'));
+      }
+      for (var key in propValue) {
+        if (propValue.hasOwnProperty(key)) {
+          var error = typeChecker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+          if (error instanceof Error) {
+            return error;
+          }
+        }
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createUnionTypeChecker(arrayOfTypeCheckers) {
+    if (!Array.isArray(arrayOfTypeCheckers)) {
+      "development" !== 'production' ? warning(false, 'Invalid argument supplied to oneOfType, expected an instance of array.') : void 0;
+      return emptyFunction.thatReturnsNull;
+    }
+
+    for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+      var checker = arrayOfTypeCheckers[i];
+      if (typeof checker !== 'function') {
+        warning(
+          false,
+          'Invalid argument supplid to oneOfType. Expected an array of check functions, but ' +
+          'received %s at index %s.',
+          getPostfixForTypeWarning(checker),
+          i
+        );
+        return emptyFunction.thatReturnsNull;
+      }
+    }
+
+    function validate(props, propName, componentName, location, propFullName) {
+      for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+        var checker = arrayOfTypeCheckers[i];
+        if (checker(props, propName, componentName, location, propFullName, ReactPropTypesSecret) == null) {
+          return null;
+        }
+      }
+
+      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`.'));
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createNodeChecker() {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (!isNode(props[propName])) {
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`, expected a ReactNode.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createShapeTypeChecker(shapeTypes) {
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      var propType = getPropType(propValue);
+      if (propType !== 'object') {
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
+      }
+      for (var key in shapeTypes) {
+        var checker = shapeTypes[key];
+        if (!checker) {
+          continue;
+        }
+        var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+        if (error) {
+          return error;
+        }
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function isNode(propValue) {
+    switch (typeof propValue) {
+      case 'number':
+      case 'string':
+      case 'undefined':
+        return true;
+      case 'boolean':
+        return !propValue;
+      case 'object':
+        if (Array.isArray(propValue)) {
+          return propValue.every(isNode);
+        }
+        if (propValue === null || isValidElement(propValue)) {
+          return true;
+        }
+
+        var iteratorFn = getIteratorFn(propValue);
+        if (iteratorFn) {
+          var iterator = iteratorFn.call(propValue);
+          var step;
+          if (iteratorFn !== propValue.entries) {
+            while (!(step = iterator.next()).done) {
+              if (!isNode(step.value)) {
+                return false;
+              }
+            }
+          } else {
+            // Iterator will provide entry [k,v] tuples rather than values.
+            while (!(step = iterator.next()).done) {
+              var entry = step.value;
+              if (entry) {
+                if (!isNode(entry[1])) {
+                  return false;
+                }
+              }
+            }
+          }
+        } else {
+          return false;
+        }
+
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  function isSymbol(propType, propValue) {
+    // Native Symbol.
+    if (propType === 'symbol') {
+      return true;
+    }
+
+    // 19.4.3.5 Symbol.prototype[@@toStringTag] === 'Symbol'
+    if (propValue['@@toStringTag'] === 'Symbol') {
+      return true;
+    }
+
+    // Fallback for non-spec compliant Symbols which are polyfilled.
+    if (typeof Symbol === 'function' && propValue instanceof Symbol) {
+      return true;
+    }
+
+    return false;
+  }
+
+  // Equivalent of `typeof` but with special handling for array and regexp.
+  function getPropType(propValue) {
+    var propType = typeof propValue;
+    if (Array.isArray(propValue)) {
+      return 'array';
+    }
+    if (propValue instanceof RegExp) {
+      // Old webkits (at least until Android 4.0) return 'function' rather than
+      // 'object' for typeof a RegExp. We'll normalize this here so that /bla/
+      // passes PropTypes.object.
+      return 'object';
+    }
+    if (isSymbol(propType, propValue)) {
+      return 'symbol';
+    }
+    return propType;
+  }
+
+  // This handles more types than `getPropType`. Only used for error messages.
+  // See `createPrimitiveTypeChecker`.
+  function getPreciseType(propValue) {
+    if (typeof propValue === 'undefined' || propValue === null) {
+      return '' + propValue;
+    }
+    var propType = getPropType(propValue);
+    if (propType === 'object') {
+      if (propValue instanceof Date) {
+        return 'date';
+      } else if (propValue instanceof RegExp) {
+        return 'regexp';
+      }
+    }
+    return propType;
+  }
+
+  // Returns a string that is postfixed to a warning about an invalid type.
+  // For example, "undefined" or "of type array"
+  function getPostfixForTypeWarning(value) {
+    var type = getPreciseType(value);
+    switch (type) {
+      case 'array':
+      case 'object':
+        return 'an ' + type;
+      case 'boolean':
+      case 'date':
+      case 'regexp':
+        return 'a ' + type;
+      default:
+        return type;
+    }
+  }
+
+  // Returns class name of the object, if any.
+  function getClassName(propValue) {
+    if (!propValue.constructor || !propValue.constructor.name) {
+      return ANONYMOUS;
+    }
+    return propValue.constructor.name;
+  }
+
+  ReactPropTypes.checkPropTypes = checkPropTypes;
+  ReactPropTypes.PropTypes = ReactPropTypes;
+
+  return ReactPropTypes;
+};
+
+},{"28":28,"30":30,"31":31,"33":33,"36":36}],36:[function(_dereq_,module,exports){
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+
+module.exports = ReactPropTypesSecret;
+
+},{}]},{},[16])(16)
+});

--- a/tests/assets/reading-list/react_16.14.0.js
+++ b/tests/assets/reading-list/react_16.14.0.js
@@ -1,0 +1,3318 @@
+/** @license React v16.14.0
+ * react.development.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  (global = global || self, factory(global.React = {}));
+}(this, (function (exports) { 'use strict';
+
+  var ReactVersion = '16.14.0';
+
+  // The Symbol used to tag the ReactElement-like types. If there is no native Symbol
+  // nor polyfill, then a plain number is used for performance.
+  var hasSymbol = typeof Symbol === 'function' && Symbol.for;
+  var REACT_ELEMENT_TYPE = hasSymbol ? Symbol.for('react.element') : 0xeac7;
+  var REACT_PORTAL_TYPE = hasSymbol ? Symbol.for('react.portal') : 0xeaca;
+  var REACT_FRAGMENT_TYPE = hasSymbol ? Symbol.for('react.fragment') : 0xeacb;
+  var REACT_STRICT_MODE_TYPE = hasSymbol ? Symbol.for('react.strict_mode') : 0xeacc;
+  var REACT_PROFILER_TYPE = hasSymbol ? Symbol.for('react.profiler') : 0xead2;
+  var REACT_PROVIDER_TYPE = hasSymbol ? Symbol.for('react.provider') : 0xeacd;
+  var REACT_CONTEXT_TYPE = hasSymbol ? Symbol.for('react.context') : 0xeace; // TODO: We don't use AsyncMode or ConcurrentMode anymore. They were temporary
+  var REACT_CONCURRENT_MODE_TYPE = hasSymbol ? Symbol.for('react.concurrent_mode') : 0xeacf;
+  var REACT_FORWARD_REF_TYPE = hasSymbol ? Symbol.for('react.forward_ref') : 0xead0;
+  var REACT_SUSPENSE_TYPE = hasSymbol ? Symbol.for('react.suspense') : 0xead1;
+  var REACT_SUSPENSE_LIST_TYPE = hasSymbol ? Symbol.for('react.suspense_list') : 0xead8;
+  var REACT_MEMO_TYPE = hasSymbol ? Symbol.for('react.memo') : 0xead3;
+  var REACT_LAZY_TYPE = hasSymbol ? Symbol.for('react.lazy') : 0xead4;
+  var REACT_BLOCK_TYPE = hasSymbol ? Symbol.for('react.block') : 0xead9;
+  var REACT_FUNDAMENTAL_TYPE = hasSymbol ? Symbol.for('react.fundamental') : 0xead5;
+  var REACT_RESPONDER_TYPE = hasSymbol ? Symbol.for('react.responder') : 0xead6;
+  var REACT_SCOPE_TYPE = hasSymbol ? Symbol.for('react.scope') : 0xead7;
+  var MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+  var FAUX_ITERATOR_SYMBOL = '@@iterator';
+  function getIteratorFn(maybeIterable) {
+    if (maybeIterable === null || typeof maybeIterable !== 'object') {
+      return null;
+    }
+
+    var maybeIterator = MAYBE_ITERATOR_SYMBOL && maybeIterable[MAYBE_ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL];
+
+    if (typeof maybeIterator === 'function') {
+      return maybeIterator;
+    }
+
+    return null;
+  }
+
+  /*
+  object-assign
+  (c) Sindre Sorhus
+  @license MIT
+  */
+  /* eslint-disable no-unused-vars */
+  var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
+  var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+  function toObject(val) {
+  	if (val === null || val === undefined) {
+  		throw new TypeError('Object.assign cannot be called with null or undefined');
+  	}
+
+  	return Object(val);
+  }
+
+  function shouldUseNative() {
+  	try {
+  		if (!Object.assign) {
+  			return false;
+  		}
+
+  		// Detect buggy property enumeration order in older V8 versions.
+
+  		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
+  		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
+  		test1[5] = 'de';
+  		if (Object.getOwnPropertyNames(test1)[0] === '5') {
+  			return false;
+  		}
+
+  		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+  		var test2 = {};
+  		for (var i = 0; i < 10; i++) {
+  			test2['_' + String.fromCharCode(i)] = i;
+  		}
+  		var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
+  			return test2[n];
+  		});
+  		if (order2.join('') !== '0123456789') {
+  			return false;
+  		}
+
+  		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+  		var test3 = {};
+  		'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
+  			test3[letter] = letter;
+  		});
+  		if (Object.keys(Object.assign({}, test3)).join('') !==
+  				'abcdefghijklmnopqrst') {
+  			return false;
+  		}
+
+  		return true;
+  	} catch (err) {
+  		// We don't expect any of the above to throw, but better to be safe.
+  		return false;
+  	}
+  }
+
+  var objectAssign = shouldUseNative() ? Object.assign : function (target, source) {
+  	var from;
+  	var to = toObject(target);
+  	var symbols;
+
+  	for (var s = 1; s < arguments.length; s++) {
+  		from = Object(arguments[s]);
+
+  		for (var key in from) {
+  			if (hasOwnProperty.call(from, key)) {
+  				to[key] = from[key];
+  			}
+  		}
+
+  		if (getOwnPropertySymbols) {
+  			symbols = getOwnPropertySymbols(from);
+  			for (var i = 0; i < symbols.length; i++) {
+  				if (propIsEnumerable.call(from, symbols[i])) {
+  					to[symbols[i]] = from[symbols[i]];
+  				}
+  			}
+  		}
+  	}
+
+  	return to;
+  };
+
+  /**
+   * Keeps track of the current dispatcher.
+   */
+  var ReactCurrentDispatcher = {
+    /**
+     * @internal
+     * @type {ReactComponent}
+     */
+    current: null
+  };
+
+  /**
+   * Keeps track of the current batch's configuration such as how long an update
+   * should suspend for if it needs to.
+   */
+  var ReactCurrentBatchConfig = {
+    suspense: null
+  };
+
+  /**
+   * Keeps track of the current owner.
+   *
+   * The current owner is the component who should own any components that are
+   * currently being constructed.
+   */
+  var ReactCurrentOwner = {
+    /**
+     * @internal
+     * @type {ReactComponent}
+     */
+    current: null
+  };
+
+  var BEFORE_SLASH_RE = /^(.*)[\\\/]/;
+  function describeComponentFrame (name, source, ownerName) {
+    var sourceInfo = '';
+
+    if (source) {
+      var path = source.fileName;
+      var fileName = path.replace(BEFORE_SLASH_RE, '');
+
+      {
+        // In DEV, include code for a common special case:
+        // prefer "folder/index.js" instead of just "index.js".
+        if (/^index\./.test(fileName)) {
+          var match = path.match(BEFORE_SLASH_RE);
+
+          if (match) {
+            var pathBeforeSlash = match[1];
+
+            if (pathBeforeSlash) {
+              var folderName = pathBeforeSlash.replace(BEFORE_SLASH_RE, '');
+              fileName = folderName + '/' + fileName;
+            }
+          }
+        }
+      }
+
+      sourceInfo = ' (at ' + fileName + ':' + source.lineNumber + ')';
+    } else if (ownerName) {
+      sourceInfo = ' (created by ' + ownerName + ')';
+    }
+
+    return '\n    in ' + (name || 'Unknown') + sourceInfo;
+  }
+
+  var Resolved = 1;
+  function refineResolvedLazyComponent(lazyComponent) {
+    return lazyComponent._status === Resolved ? lazyComponent._result : null;
+  }
+
+  function getWrappedName(outerType, innerType, wrapperName) {
+    var functionName = innerType.displayName || innerType.name || '';
+    return outerType.displayName || (functionName !== '' ? wrapperName + "(" + functionName + ")" : wrapperName);
+  }
+
+  function getComponentName(type) {
+    if (type == null) {
+      // Host root, text node or just invalid type.
+      return null;
+    }
+
+    {
+      if (typeof type.tag === 'number') {
+        error('Received an unexpected object in getComponentName(). ' + 'This is likely a bug in React. Please file an issue.');
+      }
+    }
+
+    if (typeof type === 'function') {
+      return type.displayName || type.name || null;
+    }
+
+    if (typeof type === 'string') {
+      return type;
+    }
+
+    switch (type) {
+      case REACT_FRAGMENT_TYPE:
+        return 'Fragment';
+
+      case REACT_PORTAL_TYPE:
+        return 'Portal';
+
+      case REACT_PROFILER_TYPE:
+        return "Profiler";
+
+      case REACT_STRICT_MODE_TYPE:
+        return 'StrictMode';
+
+      case REACT_SUSPENSE_TYPE:
+        return 'Suspense';
+
+      case REACT_SUSPENSE_LIST_TYPE:
+        return 'SuspenseList';
+    }
+
+    if (typeof type === 'object') {
+      switch (type.$$typeof) {
+        case REACT_CONTEXT_TYPE:
+          return 'Context.Consumer';
+
+        case REACT_PROVIDER_TYPE:
+          return 'Context.Provider';
+
+        case REACT_FORWARD_REF_TYPE:
+          return getWrappedName(type, type.render, 'ForwardRef');
+
+        case REACT_MEMO_TYPE:
+          return getComponentName(type.type);
+
+        case REACT_BLOCK_TYPE:
+          return getComponentName(type.render);
+
+        case REACT_LAZY_TYPE:
+          {
+            var thenable = type;
+            var resolvedThenable = refineResolvedLazyComponent(thenable);
+
+            if (resolvedThenable) {
+              return getComponentName(resolvedThenable);
+            }
+
+            break;
+          }
+      }
+    }
+
+    return null;
+  }
+
+  var ReactDebugCurrentFrame = {};
+  var currentlyValidatingElement = null;
+  function setCurrentlyValidatingElement(element) {
+    {
+      currentlyValidatingElement = element;
+    }
+  }
+
+  {
+    // Stack implementation injected by the current renderer.
+    ReactDebugCurrentFrame.getCurrentStack = null;
+
+    ReactDebugCurrentFrame.getStackAddendum = function () {
+      var stack = ''; // Add an extra top frame while an element is being validated
+
+      if (currentlyValidatingElement) {
+        var name = getComponentName(currentlyValidatingElement.type);
+        var owner = currentlyValidatingElement._owner;
+        stack += describeComponentFrame(name, currentlyValidatingElement._source, owner && getComponentName(owner.type));
+      } // Delegate to the injected renderer-specific implementation
+
+
+      var impl = ReactDebugCurrentFrame.getCurrentStack;
+
+      if (impl) {
+        stack += impl() || '';
+      }
+
+      return stack;
+    };
+  }
+
+  /**
+   * Used by act() to track whether you're inside an act() scope.
+   */
+  var IsSomeRendererActing = {
+    current: false
+  };
+
+  var ReactSharedInternals = {
+    ReactCurrentDispatcher: ReactCurrentDispatcher,
+    ReactCurrentBatchConfig: ReactCurrentBatchConfig,
+    ReactCurrentOwner: ReactCurrentOwner,
+    IsSomeRendererActing: IsSomeRendererActing,
+    // Used by renderers to avoid bundling object-assign twice in UMD bundles:
+    assign: objectAssign
+  };
+
+  {
+    objectAssign(ReactSharedInternals, {
+      // These should not be included in production.
+      ReactDebugCurrentFrame: ReactDebugCurrentFrame,
+      // Shim for React DOM 16.0.0 which still destructured (but not used) this.
+      // TODO: remove in React 17.0.
+      ReactComponentTreeHook: {}
+    });
+  }
+
+  // by calls to these methods by a Babel plugin.
+  //
+  // In PROD (or in packages without access to React internals),
+  // they are left as they are instead.
+
+  function warn(format) {
+    {
+      for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      printWarning('warn', format, args);
+    }
+  }
+  function error(format) {
+    {
+      for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+        args[_key2 - 1] = arguments[_key2];
+      }
+
+      printWarning('error', format, args);
+    }
+  }
+
+  function printWarning(level, format, args) {
+    // When changing this logic, you might want to also
+    // update consoleWithStackDev.www.js as well.
+    {
+      var hasExistingStack = args.length > 0 && typeof args[args.length - 1] === 'string' && args[args.length - 1].indexOf('\n    in') === 0;
+
+      if (!hasExistingStack) {
+        var ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+        var stack = ReactDebugCurrentFrame.getStackAddendum();
+
+        if (stack !== '') {
+          format += '%s';
+          args = args.concat([stack]);
+        }
+      }
+
+      var argsWithFormat = args.map(function (item) {
+        return '' + item;
+      }); // Careful: RN currently depends on this prefix
+
+      argsWithFormat.unshift('Warning: ' + format); // We intentionally don't use spread (or .apply) directly because it
+      // breaks IE9: https://github.com/facebook/react/issues/13610
+      // eslint-disable-next-line react-internal/no-production-logging
+
+      Function.prototype.apply.call(console[level], console, argsWithFormat);
+
+      try {
+        // --- Welcome to debugging React ---
+        // This error was thrown as a convenience so that you can use this stack
+        // to find the callsite that caused this warning to fire.
+        var argIndex = 0;
+        var message = 'Warning: ' + format.replace(/%s/g, function () {
+          return args[argIndex++];
+        });
+        throw new Error(message);
+      } catch (x) {}
+    }
+  }
+
+  var didWarnStateUpdateForUnmountedComponent = {};
+
+  function warnNoop(publicInstance, callerName) {
+    {
+      var _constructor = publicInstance.constructor;
+      var componentName = _constructor && (_constructor.displayName || _constructor.name) || 'ReactClass';
+      var warningKey = componentName + "." + callerName;
+
+      if (didWarnStateUpdateForUnmountedComponent[warningKey]) {
+        return;
+      }
+
+      error("Can't call %s on a component that is not yet mounted. " + 'This is a no-op, but it might indicate a bug in your application. ' + 'Instead, assign to `this.state` directly or define a `state = {};` ' + 'class property with the desired state in the %s component.', callerName, componentName);
+
+      didWarnStateUpdateForUnmountedComponent[warningKey] = true;
+    }
+  }
+  /**
+   * This is the abstract API for an update queue.
+   */
+
+
+  var ReactNoopUpdateQueue = {
+    /**
+     * Checks whether or not this composite component is mounted.
+     * @param {ReactClass} publicInstance The instance we want to test.
+     * @return {boolean} True if mounted, false otherwise.
+     * @protected
+     * @final
+     */
+    isMounted: function (publicInstance) {
+      return false;
+    },
+
+    /**
+     * Forces an update. This should only be invoked when it is known with
+     * certainty that we are **not** in a DOM transaction.
+     *
+     * You may want to call this when you know that some deeper aspect of the
+     * component's state has changed but `setState` was not called.
+     *
+     * This will not invoke `shouldComponentUpdate`, but it will invoke
+     * `componentWillUpdate` and `componentDidUpdate`.
+     *
+     * @param {ReactClass} publicInstance The instance that should rerender.
+     * @param {?function} callback Called after component is updated.
+     * @param {?string} callerName name of the calling function in the public API.
+     * @internal
+     */
+    enqueueForceUpdate: function (publicInstance, callback, callerName) {
+      warnNoop(publicInstance, 'forceUpdate');
+    },
+
+    /**
+     * Replaces all of the state. Always use this or `setState` to mutate state.
+     * You should treat `this.state` as immutable.
+     *
+     * There is no guarantee that `this.state` will be immediately updated, so
+     * accessing `this.state` after calling this method may return the old value.
+     *
+     * @param {ReactClass} publicInstance The instance that should rerender.
+     * @param {object} completeState Next state.
+     * @param {?function} callback Called after component is updated.
+     * @param {?string} callerName name of the calling function in the public API.
+     * @internal
+     */
+    enqueueReplaceState: function (publicInstance, completeState, callback, callerName) {
+      warnNoop(publicInstance, 'replaceState');
+    },
+
+    /**
+     * Sets a subset of the state. This only exists because _pendingState is
+     * internal. This provides a merging strategy that is not available to deep
+     * properties which is confusing. TODO: Expose pendingState or don't use it
+     * during the merge.
+     *
+     * @param {ReactClass} publicInstance The instance that should rerender.
+     * @param {object} partialState Next partial state to be merged with state.
+     * @param {?function} callback Called after component is updated.
+     * @param {?string} Name of the calling function in the public API.
+     * @internal
+     */
+    enqueueSetState: function (publicInstance, partialState, callback, callerName) {
+      warnNoop(publicInstance, 'setState');
+    }
+  };
+
+  var emptyObject = {};
+
+  {
+    Object.freeze(emptyObject);
+  }
+  /**
+   * Base class helpers for the updating state of a component.
+   */
+
+
+  function Component(props, context, updater) {
+    this.props = props;
+    this.context = context; // If a component has string refs, we will assign a different object later.
+
+    this.refs = emptyObject; // We initialize the default updater but the real one gets injected by the
+    // renderer.
+
+    this.updater = updater || ReactNoopUpdateQueue;
+  }
+
+  Component.prototype.isReactComponent = {};
+  /**
+   * Sets a subset of the state. Always use this to mutate
+   * state. You should treat `this.state` as immutable.
+   *
+   * There is no guarantee that `this.state` will be immediately updated, so
+   * accessing `this.state` after calling this method may return the old value.
+   *
+   * There is no guarantee that calls to `setState` will run synchronously,
+   * as they may eventually be batched together.  You can provide an optional
+   * callback that will be executed when the call to setState is actually
+   * completed.
+   *
+   * When a function is provided to setState, it will be called at some point in
+   * the future (not synchronously). It will be called with the up to date
+   * component arguments (state, props, context). These values can be different
+   * from this.* because your function may be called after receiveProps but before
+   * shouldComponentUpdate, and this new state, props, and context will not yet be
+   * assigned to this.
+   *
+   * @param {object|function} partialState Next partial state or function to
+   *        produce next partial state to be merged with current state.
+   * @param {?function} callback Called after state is updated.
+   * @final
+   * @protected
+   */
+
+  Component.prototype.setState = function (partialState, callback) {
+    if (!(typeof partialState === 'object' || typeof partialState === 'function' || partialState == null)) {
+      {
+        throw Error( "setState(...): takes an object of state variables to update or a function which returns an object of state variables." );
+      }
+    }
+
+    this.updater.enqueueSetState(this, partialState, callback, 'setState');
+  };
+  /**
+   * Forces an update. This should only be invoked when it is known with
+   * certainty that we are **not** in a DOM transaction.
+   *
+   * You may want to call this when you know that some deeper aspect of the
+   * component's state has changed but `setState` was not called.
+   *
+   * This will not invoke `shouldComponentUpdate`, but it will invoke
+   * `componentWillUpdate` and `componentDidUpdate`.
+   *
+   * @param {?function} callback Called after update is complete.
+   * @final
+   * @protected
+   */
+
+
+  Component.prototype.forceUpdate = function (callback) {
+    this.updater.enqueueForceUpdate(this, callback, 'forceUpdate');
+  };
+  /**
+   * Deprecated APIs. These APIs used to exist on classic React classes but since
+   * we would like to deprecate them, we're not going to move them over to this
+   * modern base class. Instead, we define a getter that warns if it's accessed.
+   */
+
+
+  {
+    var deprecatedAPIs = {
+      isMounted: ['isMounted', 'Instead, make sure to clean up subscriptions and pending requests in ' + 'componentWillUnmount to prevent memory leaks.'],
+      replaceState: ['replaceState', 'Refactor your code to use setState instead (see ' + 'https://github.com/facebook/react/issues/3236).']
+    };
+
+    var defineDeprecationWarning = function (methodName, info) {
+      Object.defineProperty(Component.prototype, methodName, {
+        get: function () {
+          warn('%s(...) is deprecated in plain JavaScript React classes. %s', info[0], info[1]);
+
+          return undefined;
+        }
+      });
+    };
+
+    for (var fnName in deprecatedAPIs) {
+      if (deprecatedAPIs.hasOwnProperty(fnName)) {
+        defineDeprecationWarning(fnName, deprecatedAPIs[fnName]);
+      }
+    }
+  }
+
+  function ComponentDummy() {}
+
+  ComponentDummy.prototype = Component.prototype;
+  /**
+   * Convenience component with default shallow equality check for sCU.
+   */
+
+  function PureComponent(props, context, updater) {
+    this.props = props;
+    this.context = context; // If a component has string refs, we will assign a different object later.
+
+    this.refs = emptyObject;
+    this.updater = updater || ReactNoopUpdateQueue;
+  }
+
+  var pureComponentPrototype = PureComponent.prototype = new ComponentDummy();
+  pureComponentPrototype.constructor = PureComponent; // Avoid an extra prototype jump for these methods.
+
+  objectAssign(pureComponentPrototype, Component.prototype);
+
+  pureComponentPrototype.isPureReactComponent = true;
+
+  // an immutable object with a single mutable value
+  function createRef() {
+    var refObject = {
+      current: null
+    };
+
+    {
+      Object.seal(refObject);
+    }
+
+    return refObject;
+  }
+
+  var hasOwnProperty$1 = Object.prototype.hasOwnProperty;
+  var RESERVED_PROPS = {
+    key: true,
+    ref: true,
+    __self: true,
+    __source: true
+  };
+  var specialPropKeyWarningShown, specialPropRefWarningShown, didWarnAboutStringRefs;
+
+  {
+    didWarnAboutStringRefs = {};
+  }
+
+  function hasValidRef(config) {
+    {
+      if (hasOwnProperty$1.call(config, 'ref')) {
+        var getter = Object.getOwnPropertyDescriptor(config, 'ref').get;
+
+        if (getter && getter.isReactWarning) {
+          return false;
+        }
+      }
+    }
+
+    return config.ref !== undefined;
+  }
+
+  function hasValidKey(config) {
+    {
+      if (hasOwnProperty$1.call(config, 'key')) {
+        var getter = Object.getOwnPropertyDescriptor(config, 'key').get;
+
+        if (getter && getter.isReactWarning) {
+          return false;
+        }
+      }
+    }
+
+    return config.key !== undefined;
+  }
+
+  function defineKeyPropWarningGetter(props, displayName) {
+    var warnAboutAccessingKey = function () {
+      {
+        if (!specialPropKeyWarningShown) {
+          specialPropKeyWarningShown = true;
+
+          error('%s: `key` is not a prop. Trying to access it will result ' + 'in `undefined` being returned. If you need to access the same ' + 'value within the child component, you should pass it as a different ' + 'prop. (https://fb.me/react-special-props)', displayName);
+        }
+      }
+    };
+
+    warnAboutAccessingKey.isReactWarning = true;
+    Object.defineProperty(props, 'key', {
+      get: warnAboutAccessingKey,
+      configurable: true
+    });
+  }
+
+  function defineRefPropWarningGetter(props, displayName) {
+    var warnAboutAccessingRef = function () {
+      {
+        if (!specialPropRefWarningShown) {
+          specialPropRefWarningShown = true;
+
+          error('%s: `ref` is not a prop. Trying to access it will result ' + 'in `undefined` being returned. If you need to access the same ' + 'value within the child component, you should pass it as a different ' + 'prop. (https://fb.me/react-special-props)', displayName);
+        }
+      }
+    };
+
+    warnAboutAccessingRef.isReactWarning = true;
+    Object.defineProperty(props, 'ref', {
+      get: warnAboutAccessingRef,
+      configurable: true
+    });
+  }
+
+  function warnIfStringRefCannotBeAutoConverted(config) {
+    {
+      if (typeof config.ref === 'string' && ReactCurrentOwner.current && config.__self && ReactCurrentOwner.current.stateNode !== config.__self) {
+        var componentName = getComponentName(ReactCurrentOwner.current.type);
+
+        if (!didWarnAboutStringRefs[componentName]) {
+          error('Component "%s" contains the string ref "%s". ' + 'Support for string refs will be removed in a future major release. ' + 'This case cannot be automatically converted to an arrow function. ' + 'We ask you to manually fix this case by using useRef() or createRef() instead. ' + 'Learn more about using refs safely here: ' + 'https://fb.me/react-strict-mode-string-ref', getComponentName(ReactCurrentOwner.current.type), config.ref);
+
+          didWarnAboutStringRefs[componentName] = true;
+        }
+      }
+    }
+  }
+  /**
+   * Factory method to create a new React element. This no longer adheres to
+   * the class pattern, so do not use new to call it. Also, instanceof check
+   * will not work. Instead test $$typeof field against Symbol.for('react.element') to check
+   * if something is a React Element.
+   *
+   * @param {*} type
+   * @param {*} props
+   * @param {*} key
+   * @param {string|object} ref
+   * @param {*} owner
+   * @param {*} self A *temporary* helper to detect places where `this` is
+   * different from the `owner` when React.createElement is called, so that we
+   * can warn. We want to get rid of owner and replace string `ref`s with arrow
+   * functions, and as long as `this` and owner are the same, there will be no
+   * change in behavior.
+   * @param {*} source An annotation object (added by a transpiler or otherwise)
+   * indicating filename, line number, and/or other information.
+   * @internal
+   */
+
+
+  var ReactElement = function (type, key, ref, self, source, owner, props) {
+    var element = {
+      // This tag allows us to uniquely identify this as a React Element
+      $$typeof: REACT_ELEMENT_TYPE,
+      // Built-in properties that belong on the element
+      type: type,
+      key: key,
+      ref: ref,
+      props: props,
+      // Record the component responsible for creating this element.
+      _owner: owner
+    };
+
+    {
+      // The validation flag is currently mutative. We put it on
+      // an external backing store so that we can freeze the whole object.
+      // This can be replaced with a WeakMap once they are implemented in
+      // commonly used development environments.
+      element._store = {}; // To make comparing ReactElements easier for testing purposes, we make
+      // the validation flag non-enumerable (where possible, which should
+      // include every environment we run tests in), so the test framework
+      // ignores it.
+
+      Object.defineProperty(element._store, 'validated', {
+        configurable: false,
+        enumerable: false,
+        writable: true,
+        value: false
+      }); // self and source are DEV only properties.
+
+      Object.defineProperty(element, '_self', {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: self
+      }); // Two elements created in two different places should be considered
+      // equal for testing purposes and therefore we hide it from enumeration.
+
+      Object.defineProperty(element, '_source', {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: source
+      });
+
+      if (Object.freeze) {
+        Object.freeze(element.props);
+        Object.freeze(element);
+      }
+    }
+
+    return element;
+  };
+  /**
+   * Create and return a new ReactElement of the given type.
+   * See https://reactjs.org/docs/react-api.html#createelement
+   */
+
+  function createElement(type, config, children) {
+    var propName; // Reserved names are extracted
+
+    var props = {};
+    var key = null;
+    var ref = null;
+    var self = null;
+    var source = null;
+
+    if (config != null) {
+      if (hasValidRef(config)) {
+        ref = config.ref;
+
+        {
+          warnIfStringRefCannotBeAutoConverted(config);
+        }
+      }
+
+      if (hasValidKey(config)) {
+        key = '' + config.key;
+      }
+
+      self = config.__self === undefined ? null : config.__self;
+      source = config.__source === undefined ? null : config.__source; // Remaining properties are added to a new props object
+
+      for (propName in config) {
+        if (hasOwnProperty$1.call(config, propName) && !RESERVED_PROPS.hasOwnProperty(propName)) {
+          props[propName] = config[propName];
+        }
+      }
+    } // Children can be more than one argument, and those are transferred onto
+    // the newly allocated props object.
+
+
+    var childrenLength = arguments.length - 2;
+
+    if (childrenLength === 1) {
+      props.children = children;
+    } else if (childrenLength > 1) {
+      var childArray = Array(childrenLength);
+
+      for (var i = 0; i < childrenLength; i++) {
+        childArray[i] = arguments[i + 2];
+      }
+
+      {
+        if (Object.freeze) {
+          Object.freeze(childArray);
+        }
+      }
+
+      props.children = childArray;
+    } // Resolve default props
+
+
+    if (type && type.defaultProps) {
+      var defaultProps = type.defaultProps;
+
+      for (propName in defaultProps) {
+        if (props[propName] === undefined) {
+          props[propName] = defaultProps[propName];
+        }
+      }
+    }
+
+    {
+      if (key || ref) {
+        var displayName = typeof type === 'function' ? type.displayName || type.name || 'Unknown' : type;
+
+        if (key) {
+          defineKeyPropWarningGetter(props, displayName);
+        }
+
+        if (ref) {
+          defineRefPropWarningGetter(props, displayName);
+        }
+      }
+    }
+
+    return ReactElement(type, key, ref, self, source, ReactCurrentOwner.current, props);
+  }
+  function cloneAndReplaceKey(oldElement, newKey) {
+    var newElement = ReactElement(oldElement.type, newKey, oldElement.ref, oldElement._self, oldElement._source, oldElement._owner, oldElement.props);
+    return newElement;
+  }
+  /**
+   * Clone and return a new ReactElement using element as the starting point.
+   * See https://reactjs.org/docs/react-api.html#cloneelement
+   */
+
+  function cloneElement(element, config, children) {
+    if (!!(element === null || element === undefined)) {
+      {
+        throw Error( "React.cloneElement(...): The argument must be a React element, but you passed " + element + "." );
+      }
+    }
+
+    var propName; // Original props are copied
+
+    var props = objectAssign({}, element.props); // Reserved names are extracted
+
+
+    var key = element.key;
+    var ref = element.ref; // Self is preserved since the owner is preserved.
+
+    var self = element._self; // Source is preserved since cloneElement is unlikely to be targeted by a
+    // transpiler, and the original source is probably a better indicator of the
+    // true owner.
+
+    var source = element._source; // Owner will be preserved, unless ref is overridden
+
+    var owner = element._owner;
+
+    if (config != null) {
+      if (hasValidRef(config)) {
+        // Silently steal the ref from the parent.
+        ref = config.ref;
+        owner = ReactCurrentOwner.current;
+      }
+
+      if (hasValidKey(config)) {
+        key = '' + config.key;
+      } // Remaining properties override existing props
+
+
+      var defaultProps;
+
+      if (element.type && element.type.defaultProps) {
+        defaultProps = element.type.defaultProps;
+      }
+
+      for (propName in config) {
+        if (hasOwnProperty$1.call(config, propName) && !RESERVED_PROPS.hasOwnProperty(propName)) {
+          if (config[propName] === undefined && defaultProps !== undefined) {
+            // Resolve default props
+            props[propName] = defaultProps[propName];
+          } else {
+            props[propName] = config[propName];
+          }
+        }
+      }
+    } // Children can be more than one argument, and those are transferred onto
+    // the newly allocated props object.
+
+
+    var childrenLength = arguments.length - 2;
+
+    if (childrenLength === 1) {
+      props.children = children;
+    } else if (childrenLength > 1) {
+      var childArray = Array(childrenLength);
+
+      for (var i = 0; i < childrenLength; i++) {
+        childArray[i] = arguments[i + 2];
+      }
+
+      props.children = childArray;
+    }
+
+    return ReactElement(element.type, key, ref, self, source, owner, props);
+  }
+  /**
+   * Verifies the object is a ReactElement.
+   * See https://reactjs.org/docs/react-api.html#isvalidelement
+   * @param {?object} object
+   * @return {boolean} True if `object` is a ReactElement.
+   * @final
+   */
+
+  function isValidElement(object) {
+    return typeof object === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
+  }
+
+  var SEPARATOR = '.';
+  var SUBSEPARATOR = ':';
+  /**
+   * Escape and wrap key so it is safe to use as a reactid
+   *
+   * @param {string} key to be escaped.
+   * @return {string} the escaped key.
+   */
+
+  function escape(key) {
+    var escapeRegex = /[=:]/g;
+    var escaperLookup = {
+      '=': '=0',
+      ':': '=2'
+    };
+    var escapedString = ('' + key).replace(escapeRegex, function (match) {
+      return escaperLookup[match];
+    });
+    return '$' + escapedString;
+  }
+  /**
+   * TODO: Test that a single child and an array with one item have the same key
+   * pattern.
+   */
+
+
+  var didWarnAboutMaps = false;
+  var userProvidedKeyEscapeRegex = /\/+/g;
+
+  function escapeUserProvidedKey(text) {
+    return ('' + text).replace(userProvidedKeyEscapeRegex, '$&/');
+  }
+
+  var POOL_SIZE = 10;
+  var traverseContextPool = [];
+
+  function getPooledTraverseContext(mapResult, keyPrefix, mapFunction, mapContext) {
+    if (traverseContextPool.length) {
+      var traverseContext = traverseContextPool.pop();
+      traverseContext.result = mapResult;
+      traverseContext.keyPrefix = keyPrefix;
+      traverseContext.func = mapFunction;
+      traverseContext.context = mapContext;
+      traverseContext.count = 0;
+      return traverseContext;
+    } else {
+      return {
+        result: mapResult,
+        keyPrefix: keyPrefix,
+        func: mapFunction,
+        context: mapContext,
+        count: 0
+      };
+    }
+  }
+
+  function releaseTraverseContext(traverseContext) {
+    traverseContext.result = null;
+    traverseContext.keyPrefix = null;
+    traverseContext.func = null;
+    traverseContext.context = null;
+    traverseContext.count = 0;
+
+    if (traverseContextPool.length < POOL_SIZE) {
+      traverseContextPool.push(traverseContext);
+    }
+  }
+  /**
+   * @param {?*} children Children tree container.
+   * @param {!string} nameSoFar Name of the key path so far.
+   * @param {!function} callback Callback to invoke with each child found.
+   * @param {?*} traverseContext Used to pass information throughout the traversal
+   * process.
+   * @return {!number} The number of children in this subtree.
+   */
+
+
+  function traverseAllChildrenImpl(children, nameSoFar, callback, traverseContext) {
+    var type = typeof children;
+
+    if (type === 'undefined' || type === 'boolean') {
+      // All of the above are perceived as null.
+      children = null;
+    }
+
+    var invokeCallback = false;
+
+    if (children === null) {
+      invokeCallback = true;
+    } else {
+      switch (type) {
+        case 'string':
+        case 'number':
+          invokeCallback = true;
+          break;
+
+        case 'object':
+          switch (children.$$typeof) {
+            case REACT_ELEMENT_TYPE:
+            case REACT_PORTAL_TYPE:
+              invokeCallback = true;
+          }
+
+      }
+    }
+
+    if (invokeCallback) {
+      callback(traverseContext, children, // If it's the only child, treat the name as if it was wrapped in an array
+      // so that it's consistent if the number of children grows.
+      nameSoFar === '' ? SEPARATOR + getComponentKey(children, 0) : nameSoFar);
+      return 1;
+    }
+
+    var child;
+    var nextName;
+    var subtreeCount = 0; // Count of children found in the current subtree.
+
+    var nextNamePrefix = nameSoFar === '' ? SEPARATOR : nameSoFar + SUBSEPARATOR;
+
+    if (Array.isArray(children)) {
+      for (var i = 0; i < children.length; i++) {
+        child = children[i];
+        nextName = nextNamePrefix + getComponentKey(child, i);
+        subtreeCount += traverseAllChildrenImpl(child, nextName, callback, traverseContext);
+      }
+    } else {
+      var iteratorFn = getIteratorFn(children);
+
+      if (typeof iteratorFn === 'function') {
+
+        {
+          // Warn about using Maps as children
+          if (iteratorFn === children.entries) {
+            if (!didWarnAboutMaps) {
+              warn('Using Maps as children is deprecated and will be removed in ' + 'a future major release. Consider converting children to ' + 'an array of keyed ReactElements instead.');
+            }
+
+            didWarnAboutMaps = true;
+          }
+        }
+
+        var iterator = iteratorFn.call(children);
+        var step;
+        var ii = 0;
+
+        while (!(step = iterator.next()).done) {
+          child = step.value;
+          nextName = nextNamePrefix + getComponentKey(child, ii++);
+          subtreeCount += traverseAllChildrenImpl(child, nextName, callback, traverseContext);
+        }
+      } else if (type === 'object') {
+        var addendum = '';
+
+        {
+          addendum = ' If you meant to render a collection of children, use an array ' + 'instead.' + ReactDebugCurrentFrame.getStackAddendum();
+        }
+
+        var childrenString = '' + children;
+
+        {
+          {
+            throw Error( "Objects are not valid as a React child (found: " + (childrenString === '[object Object]' ? 'object with keys {' + Object.keys(children).join(', ') + '}' : childrenString) + ")." + addendum );
+          }
+        }
+      }
+    }
+
+    return subtreeCount;
+  }
+  /**
+   * Traverses children that are typically specified as `props.children`, but
+   * might also be specified through attributes:
+   *
+   * - `traverseAllChildren(this.props.children, ...)`
+   * - `traverseAllChildren(this.props.leftPanelChildren, ...)`
+   *
+   * The `traverseContext` is an optional argument that is passed through the
+   * entire traversal. It can be used to store accumulations or anything else that
+   * the callback might find relevant.
+   *
+   * @param {?*} children Children tree object.
+   * @param {!function} callback To invoke upon traversing each child.
+   * @param {?*} traverseContext Context for traversal.
+   * @return {!number} The number of children in this subtree.
+   */
+
+
+  function traverseAllChildren(children, callback, traverseContext) {
+    if (children == null) {
+      return 0;
+    }
+
+    return traverseAllChildrenImpl(children, '', callback, traverseContext);
+  }
+  /**
+   * Generate a key string that identifies a component within a set.
+   *
+   * @param {*} component A component that could contain a manual key.
+   * @param {number} index Index that is used if a manual key is not provided.
+   * @return {string}
+   */
+
+
+  function getComponentKey(component, index) {
+    // Do some typechecking here since we call this blindly. We want to ensure
+    // that we don't block potential future ES APIs.
+    if (typeof component === 'object' && component !== null && component.key != null) {
+      // Explicit key
+      return escape(component.key);
+    } // Implicit key determined by the index in the set
+
+
+    return index.toString(36);
+  }
+
+  function forEachSingleChild(bookKeeping, child, name) {
+    var func = bookKeeping.func,
+        context = bookKeeping.context;
+    func.call(context, child, bookKeeping.count++);
+  }
+  /**
+   * Iterates through children that are typically specified as `props.children`.
+   *
+   * See https://reactjs.org/docs/react-api.html#reactchildrenforeach
+   *
+   * The provided forEachFunc(child, index) will be called for each
+   * leaf child.
+   *
+   * @param {?*} children Children tree container.
+   * @param {function(*, int)} forEachFunc
+   * @param {*} forEachContext Context for forEachContext.
+   */
+
+
+  function forEachChildren(children, forEachFunc, forEachContext) {
+    if (children == null) {
+      return children;
+    }
+
+    var traverseContext = getPooledTraverseContext(null, null, forEachFunc, forEachContext);
+    traverseAllChildren(children, forEachSingleChild, traverseContext);
+    releaseTraverseContext(traverseContext);
+  }
+
+  function mapSingleChildIntoContext(bookKeeping, child, childKey) {
+    var result = bookKeeping.result,
+        keyPrefix = bookKeeping.keyPrefix,
+        func = bookKeeping.func,
+        context = bookKeeping.context;
+    var mappedChild = func.call(context, child, bookKeeping.count++);
+
+    if (Array.isArray(mappedChild)) {
+      mapIntoWithKeyPrefixInternal(mappedChild, result, childKey, function (c) {
+        return c;
+      });
+    } else if (mappedChild != null) {
+      if (isValidElement(mappedChild)) {
+        mappedChild = cloneAndReplaceKey(mappedChild, // Keep both the (mapped) and old keys if they differ, just as
+        // traverseAllChildren used to do for objects as children
+        keyPrefix + (mappedChild.key && (!child || child.key !== mappedChild.key) ? escapeUserProvidedKey(mappedChild.key) + '/' : '') + childKey);
+      }
+
+      result.push(mappedChild);
+    }
+  }
+
+  function mapIntoWithKeyPrefixInternal(children, array, prefix, func, context) {
+    var escapedPrefix = '';
+
+    if (prefix != null) {
+      escapedPrefix = escapeUserProvidedKey(prefix) + '/';
+    }
+
+    var traverseContext = getPooledTraverseContext(array, escapedPrefix, func, context);
+    traverseAllChildren(children, mapSingleChildIntoContext, traverseContext);
+    releaseTraverseContext(traverseContext);
+  }
+  /**
+   * Maps children that are typically specified as `props.children`.
+   *
+   * See https://reactjs.org/docs/react-api.html#reactchildrenmap
+   *
+   * The provided mapFunction(child, key, index) will be called for each
+   * leaf child.
+   *
+   * @param {?*} children Children tree container.
+   * @param {function(*, int)} func The map function.
+   * @param {*} context Context for mapFunction.
+   * @return {object} Object containing the ordered map of results.
+   */
+
+
+  function mapChildren(children, func, context) {
+    if (children == null) {
+      return children;
+    }
+
+    var result = [];
+    mapIntoWithKeyPrefixInternal(children, result, null, func, context);
+    return result;
+  }
+  /**
+   * Count the number of children that are typically specified as
+   * `props.children`.
+   *
+   * See https://reactjs.org/docs/react-api.html#reactchildrencount
+   *
+   * @param {?*} children Children tree container.
+   * @return {number} The number of children.
+   */
+
+
+  function countChildren(children) {
+    return traverseAllChildren(children, function () {
+      return null;
+    }, null);
+  }
+  /**
+   * Flatten a children object (typically specified as `props.children`) and
+   * return an array with appropriately re-keyed children.
+   *
+   * See https://reactjs.org/docs/react-api.html#reactchildrentoarray
+   */
+
+
+  function toArray(children) {
+    var result = [];
+    mapIntoWithKeyPrefixInternal(children, result, null, function (child) {
+      return child;
+    });
+    return result;
+  }
+  /**
+   * Returns the first child in a collection of children and verifies that there
+   * is only one child in the collection.
+   *
+   * See https://reactjs.org/docs/react-api.html#reactchildrenonly
+   *
+   * The current implementation of this function assumes that a single child gets
+   * passed without a wrapper, but the purpose of this helper function is to
+   * abstract away the particular structure of children.
+   *
+   * @param {?object} children Child collection structure.
+   * @return {ReactElement} The first and only `ReactElement` contained in the
+   * structure.
+   */
+
+
+  function onlyChild(children) {
+    if (!isValidElement(children)) {
+      {
+        throw Error( "React.Children.only expected to receive a single React element child." );
+      }
+    }
+
+    return children;
+  }
+
+  function createContext(defaultValue, calculateChangedBits) {
+    if (calculateChangedBits === undefined) {
+      calculateChangedBits = null;
+    } else {
+      {
+        if (calculateChangedBits !== null && typeof calculateChangedBits !== 'function') {
+          error('createContext: Expected the optional second argument to be a ' + 'function. Instead received: %s', calculateChangedBits);
+        }
+      }
+    }
+
+    var context = {
+      $$typeof: REACT_CONTEXT_TYPE,
+      _calculateChangedBits: calculateChangedBits,
+      // As a workaround to support multiple concurrent renderers, we categorize
+      // some renderers as primary and others as secondary. We only expect
+      // there to be two concurrent renderers at most: React Native (primary) and
+      // Fabric (secondary); React DOM (primary) and React ART (secondary).
+      // Secondary renderers store their context values on separate fields.
+      _currentValue: defaultValue,
+      _currentValue2: defaultValue,
+      // Used to track how many concurrent renderers this context currently
+      // supports within in a single renderer. Such as parallel server rendering.
+      _threadCount: 0,
+      // These are circular
+      Provider: null,
+      Consumer: null
+    };
+    context.Provider = {
+      $$typeof: REACT_PROVIDER_TYPE,
+      _context: context
+    };
+    var hasWarnedAboutUsingNestedContextConsumers = false;
+    var hasWarnedAboutUsingConsumerProvider = false;
+
+    {
+      // A separate object, but proxies back to the original context object for
+      // backwards compatibility. It has a different $$typeof, so we can properly
+      // warn for the incorrect usage of Context as a Consumer.
+      var Consumer = {
+        $$typeof: REACT_CONTEXT_TYPE,
+        _context: context,
+        _calculateChangedBits: context._calculateChangedBits
+      }; // $FlowFixMe: Flow complains about not setting a value, which is intentional here
+
+      Object.defineProperties(Consumer, {
+        Provider: {
+          get: function () {
+            if (!hasWarnedAboutUsingConsumerProvider) {
+              hasWarnedAboutUsingConsumerProvider = true;
+
+              error('Rendering <Context.Consumer.Provider> is not supported and will be removed in ' + 'a future major release. Did you mean to render <Context.Provider> instead?');
+            }
+
+            return context.Provider;
+          },
+          set: function (_Provider) {
+            context.Provider = _Provider;
+          }
+        },
+        _currentValue: {
+          get: function () {
+            return context._currentValue;
+          },
+          set: function (_currentValue) {
+            context._currentValue = _currentValue;
+          }
+        },
+        _currentValue2: {
+          get: function () {
+            return context._currentValue2;
+          },
+          set: function (_currentValue2) {
+            context._currentValue2 = _currentValue2;
+          }
+        },
+        _threadCount: {
+          get: function () {
+            return context._threadCount;
+          },
+          set: function (_threadCount) {
+            context._threadCount = _threadCount;
+          }
+        },
+        Consumer: {
+          get: function () {
+            if (!hasWarnedAboutUsingNestedContextConsumers) {
+              hasWarnedAboutUsingNestedContextConsumers = true;
+
+              error('Rendering <Context.Consumer.Consumer> is not supported and will be removed in ' + 'a future major release. Did you mean to render <Context.Consumer> instead?');
+            }
+
+            return context.Consumer;
+          }
+        }
+      }); // $FlowFixMe: Flow complains about missing properties because it doesn't understand defineProperty
+
+      context.Consumer = Consumer;
+    }
+
+    {
+      context._currentRenderer = null;
+      context._currentRenderer2 = null;
+    }
+
+    return context;
+  }
+
+  function lazy(ctor) {
+    var lazyType = {
+      $$typeof: REACT_LAZY_TYPE,
+      _ctor: ctor,
+      // React uses these fields to store the result.
+      _status: -1,
+      _result: null
+    };
+
+    {
+      // In production, this would just set it on the object.
+      var defaultProps;
+      var propTypes;
+      Object.defineProperties(lazyType, {
+        defaultProps: {
+          configurable: true,
+          get: function () {
+            return defaultProps;
+          },
+          set: function (newDefaultProps) {
+            error('React.lazy(...): It is not supported to assign `defaultProps` to ' + 'a lazy component import. Either specify them where the component ' + 'is defined, or create a wrapping component around it.');
+
+            defaultProps = newDefaultProps; // Match production behavior more closely:
+
+            Object.defineProperty(lazyType, 'defaultProps', {
+              enumerable: true
+            });
+          }
+        },
+        propTypes: {
+          configurable: true,
+          get: function () {
+            return propTypes;
+          },
+          set: function (newPropTypes) {
+            error('React.lazy(...): It is not supported to assign `propTypes` to ' + 'a lazy component import. Either specify them where the component ' + 'is defined, or create a wrapping component around it.');
+
+            propTypes = newPropTypes; // Match production behavior more closely:
+
+            Object.defineProperty(lazyType, 'propTypes', {
+              enumerable: true
+            });
+          }
+        }
+      });
+    }
+
+    return lazyType;
+  }
+
+  function forwardRef(render) {
+    {
+      if (render != null && render.$$typeof === REACT_MEMO_TYPE) {
+        error('forwardRef requires a render function but received a `memo` ' + 'component. Instead of forwardRef(memo(...)), use ' + 'memo(forwardRef(...)).');
+      } else if (typeof render !== 'function') {
+        error('forwardRef requires a render function but was given %s.', render === null ? 'null' : typeof render);
+      } else {
+        if (render.length !== 0 && render.length !== 2) {
+          error('forwardRef render functions accept exactly two parameters: props and ref. %s', render.length === 1 ? 'Did you forget to use the ref parameter?' : 'Any additional parameter will be undefined.');
+        }
+      }
+
+      if (render != null) {
+        if (render.defaultProps != null || render.propTypes != null) {
+          error('forwardRef render functions do not support propTypes or defaultProps. ' + 'Did you accidentally pass a React component?');
+        }
+      }
+    }
+
+    return {
+      $$typeof: REACT_FORWARD_REF_TYPE,
+      render: render
+    };
+  }
+
+  function isValidElementType(type) {
+    return typeof type === 'string' || typeof type === 'function' || // Note: its typeof might be other than 'symbol' or 'number' if it's a polyfill.
+    type === REACT_FRAGMENT_TYPE || type === REACT_CONCURRENT_MODE_TYPE || type === REACT_PROFILER_TYPE || type === REACT_STRICT_MODE_TYPE || type === REACT_SUSPENSE_TYPE || type === REACT_SUSPENSE_LIST_TYPE || typeof type === 'object' && type !== null && (type.$$typeof === REACT_LAZY_TYPE || type.$$typeof === REACT_MEMO_TYPE || type.$$typeof === REACT_PROVIDER_TYPE || type.$$typeof === REACT_CONTEXT_TYPE || type.$$typeof === REACT_FORWARD_REF_TYPE || type.$$typeof === REACT_FUNDAMENTAL_TYPE || type.$$typeof === REACT_RESPONDER_TYPE || type.$$typeof === REACT_SCOPE_TYPE || type.$$typeof === REACT_BLOCK_TYPE);
+  }
+
+  function memo(type, compare) {
+    {
+      if (!isValidElementType(type)) {
+        error('memo: The first argument must be a component. Instead ' + 'received: %s', type === null ? 'null' : typeof type);
+      }
+    }
+
+    return {
+      $$typeof: REACT_MEMO_TYPE,
+      type: type,
+      compare: compare === undefined ? null : compare
+    };
+  }
+
+  function resolveDispatcher() {
+    var dispatcher = ReactCurrentDispatcher.current;
+
+    if (!(dispatcher !== null)) {
+      {
+        throw Error( "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem." );
+      }
+    }
+
+    return dispatcher;
+  }
+
+  function useContext(Context, unstable_observedBits) {
+    var dispatcher = resolveDispatcher();
+
+    {
+      if (unstable_observedBits !== undefined) {
+        error('useContext() second argument is reserved for future ' + 'use in React. Passing it is not supported. ' + 'You passed: %s.%s', unstable_observedBits, typeof unstable_observedBits === 'number' && Array.isArray(arguments[2]) ? '\n\nDid you call array.map(useContext)? ' + 'Calling Hooks inside a loop is not supported. ' + 'Learn more at https://fb.me/rules-of-hooks' : '');
+      } // TODO: add a more generic warning for invalid values.
+
+
+      if (Context._context !== undefined) {
+        var realContext = Context._context; // Don't deduplicate because this legitimately causes bugs
+        // and nobody should be using this in existing code.
+
+        if (realContext.Consumer === Context) {
+          error('Calling useContext(Context.Consumer) is not supported, may cause bugs, and will be ' + 'removed in a future major release. Did you mean to call useContext(Context) instead?');
+        } else if (realContext.Provider === Context) {
+          error('Calling useContext(Context.Provider) is not supported. ' + 'Did you mean to call useContext(Context) instead?');
+        }
+      }
+    }
+
+    return dispatcher.useContext(Context, unstable_observedBits);
+  }
+  function useState(initialState) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useState(initialState);
+  }
+  function useReducer(reducer, initialArg, init) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useReducer(reducer, initialArg, init);
+  }
+  function useRef(initialValue) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useRef(initialValue);
+  }
+  function useEffect(create, deps) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useEffect(create, deps);
+  }
+  function useLayoutEffect(create, deps) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useLayoutEffect(create, deps);
+  }
+  function useCallback(callback, deps) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useCallback(callback, deps);
+  }
+  function useMemo(create, deps) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useMemo(create, deps);
+  }
+  function useImperativeHandle(ref, create, deps) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useImperativeHandle(ref, create, deps);
+  }
+  function useDebugValue(value, formatterFn) {
+    {
+      var dispatcher = resolveDispatcher();
+      return dispatcher.useDebugValue(value, formatterFn);
+    }
+  }
+
+  /**
+   * Copyright (c) 2013-present, Facebook, Inc.
+   *
+   * This source code is licensed under the MIT license found in the
+   * LICENSE file in the root directory of this source tree.
+   */
+
+  var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+
+  var ReactPropTypesSecret_1 = ReactPropTypesSecret;
+
+  var printWarning$1 = function() {};
+
+  {
+    var ReactPropTypesSecret$1 = ReactPropTypesSecret_1;
+    var loggedTypeFailures = {};
+    var has = Function.call.bind(Object.prototype.hasOwnProperty);
+
+    printWarning$1 = function(text) {
+      var message = 'Warning: ' + text;
+      if (typeof console !== 'undefined') {
+        console.error(message);
+      }
+      try {
+        // --- Welcome to debugging React ---
+        // This error was thrown as a convenience so that you can use this stack
+        // to find the callsite that caused this warning to fire.
+        throw new Error(message);
+      } catch (x) {}
+    };
+  }
+
+  /**
+   * Assert that the values match with the type specs.
+   * Error messages are memorized and will only be shown once.
+   *
+   * @param {object} typeSpecs Map of name to a ReactPropType
+   * @param {object} values Runtime values that need to be type-checked
+   * @param {string} location e.g. "prop", "context", "child context"
+   * @param {string} componentName Name of the component for error messages.
+   * @param {?Function} getStack Returns the component stack.
+   * @private
+   */
+  function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
+    {
+      for (var typeSpecName in typeSpecs) {
+        if (has(typeSpecs, typeSpecName)) {
+          var error;
+          // Prop type validation may throw. In case they do, we don't want to
+          // fail the render phase where it didn't fail before. So we log it.
+          // After these have been cleaned up, we'll let them throw.
+          try {
+            // This is intentionally an invariant that gets caught. It's the same
+            // behavior as without this statement except with a better message.
+            if (typeof typeSpecs[typeSpecName] !== 'function') {
+              var err = Error(
+                (componentName || 'React class') + ': ' + location + ' type `' + typeSpecName + '` is invalid; ' +
+                'it must be a function, usually from the `prop-types` package, but received `' + typeof typeSpecs[typeSpecName] + '`.'
+              );
+              err.name = 'Invariant Violation';
+              throw err;
+            }
+            error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret$1);
+          } catch (ex) {
+            error = ex;
+          }
+          if (error && !(error instanceof Error)) {
+            printWarning$1(
+              (componentName || 'React class') + ': type specification of ' +
+              location + ' `' + typeSpecName + '` is invalid; the type checker ' +
+              'function must return `null` or an `Error` but returned a ' + typeof error + '. ' +
+              'You may have forgotten to pass an argument to the type checker ' +
+              'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' +
+              'shape all require an argument).'
+            );
+          }
+          if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+            // Only monitor this failure once because there tends to be a lot of the
+            // same error.
+            loggedTypeFailures[error.message] = true;
+
+            var stack = getStack ? getStack() : '';
+
+            printWarning$1(
+              'Failed ' + location + ' type: ' + error.message + (stack != null ? stack : '')
+            );
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Resets warning cache when testing.
+   *
+   * @private
+   */
+  checkPropTypes.resetWarningCache = function() {
+    {
+      loggedTypeFailures = {};
+    }
+  };
+
+  var checkPropTypes_1 = checkPropTypes;
+
+  var propTypesMisspellWarningShown;
+
+  {
+    propTypesMisspellWarningShown = false;
+  }
+
+  function getDeclarationErrorAddendum() {
+    if (ReactCurrentOwner.current) {
+      var name = getComponentName(ReactCurrentOwner.current.type);
+
+      if (name) {
+        return '\n\nCheck the render method of `' + name + '`.';
+      }
+    }
+
+    return '';
+  }
+
+  function getSourceInfoErrorAddendum(source) {
+    if (source !== undefined) {
+      var fileName = source.fileName.replace(/^.*[\\\/]/, '');
+      var lineNumber = source.lineNumber;
+      return '\n\nCheck your code at ' + fileName + ':' + lineNumber + '.';
+    }
+
+    return '';
+  }
+
+  function getSourceInfoErrorAddendumForProps(elementProps) {
+    if (elementProps !== null && elementProps !== undefined) {
+      return getSourceInfoErrorAddendum(elementProps.__source);
+    }
+
+    return '';
+  }
+  /**
+   * Warn if there's no key explicitly set on dynamic arrays of children or
+   * object keys are not valid. This allows us to keep track of children between
+   * updates.
+   */
+
+
+  var ownerHasKeyUseWarning = {};
+
+  function getCurrentComponentErrorInfo(parentType) {
+    var info = getDeclarationErrorAddendum();
+
+    if (!info) {
+      var parentName = typeof parentType === 'string' ? parentType : parentType.displayName || parentType.name;
+
+      if (parentName) {
+        info = "\n\nCheck the top-level render call using <" + parentName + ">.";
+      }
+    }
+
+    return info;
+  }
+  /**
+   * Warn if the element doesn't have an explicit key assigned to it.
+   * This element is in an array. The array could grow and shrink or be
+   * reordered. All children that haven't already been validated are required to
+   * have a "key" property assigned to it. Error statuses are cached so a warning
+   * will only be shown once.
+   *
+   * @internal
+   * @param {ReactElement} element Element that requires a key.
+   * @param {*} parentType element's parent's type.
+   */
+
+
+  function validateExplicitKey(element, parentType) {
+    if (!element._store || element._store.validated || element.key != null) {
+      return;
+    }
+
+    element._store.validated = true;
+    var currentComponentErrorInfo = getCurrentComponentErrorInfo(parentType);
+
+    if (ownerHasKeyUseWarning[currentComponentErrorInfo]) {
+      return;
+    }
+
+    ownerHasKeyUseWarning[currentComponentErrorInfo] = true; // Usually the current owner is the offender, but if it accepts children as a
+    // property, it may be the creator of the child that's responsible for
+    // assigning it a key.
+
+    var childOwner = '';
+
+    if (element && element._owner && element._owner !== ReactCurrentOwner.current) {
+      // Give the component that originally created this child.
+      childOwner = " It was passed a child from " + getComponentName(element._owner.type) + ".";
+    }
+
+    setCurrentlyValidatingElement(element);
+
+    {
+      error('Each child in a list should have a unique "key" prop.' + '%s%s See https://fb.me/react-warning-keys for more information.', currentComponentErrorInfo, childOwner);
+    }
+
+    setCurrentlyValidatingElement(null);
+  }
+  /**
+   * Ensure that every element either is passed in a static location, in an
+   * array with an explicit keys property defined, or in an object literal
+   * with valid key property.
+   *
+   * @internal
+   * @param {ReactNode} node Statically passed child of any type.
+   * @param {*} parentType node's parent's type.
+   */
+
+
+  function validateChildKeys(node, parentType) {
+    if (typeof node !== 'object') {
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      for (var i = 0; i < node.length; i++) {
+        var child = node[i];
+
+        if (isValidElement(child)) {
+          validateExplicitKey(child, parentType);
+        }
+      }
+    } else if (isValidElement(node)) {
+      // This element was passed in a valid location.
+      if (node._store) {
+        node._store.validated = true;
+      }
+    } else if (node) {
+      var iteratorFn = getIteratorFn(node);
+
+      if (typeof iteratorFn === 'function') {
+        // Entry iterators used to provide implicit keys,
+        // but now we print a separate warning for them later.
+        if (iteratorFn !== node.entries) {
+          var iterator = iteratorFn.call(node);
+          var step;
+
+          while (!(step = iterator.next()).done) {
+            if (isValidElement(step.value)) {
+              validateExplicitKey(step.value, parentType);
+            }
+          }
+        }
+      }
+    }
+  }
+  /**
+   * Given an element, validate that its props follow the propTypes definition,
+   * provided by the type.
+   *
+   * @param {ReactElement} element
+   */
+
+
+  function validatePropTypes(element) {
+    {
+      var type = element.type;
+
+      if (type === null || type === undefined || typeof type === 'string') {
+        return;
+      }
+
+      var name = getComponentName(type);
+      var propTypes;
+
+      if (typeof type === 'function') {
+        propTypes = type.propTypes;
+      } else if (typeof type === 'object' && (type.$$typeof === REACT_FORWARD_REF_TYPE || // Note: Memo only checks outer props here.
+      // Inner props are checked in the reconciler.
+      type.$$typeof === REACT_MEMO_TYPE)) {
+        propTypes = type.propTypes;
+      } else {
+        return;
+      }
+
+      if (propTypes) {
+        setCurrentlyValidatingElement(element);
+        checkPropTypes_1(propTypes, element.props, 'prop', name, ReactDebugCurrentFrame.getStackAddendum);
+        setCurrentlyValidatingElement(null);
+      } else if (type.PropTypes !== undefined && !propTypesMisspellWarningShown) {
+        propTypesMisspellWarningShown = true;
+
+        error('Component %s declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment?', name || 'Unknown');
+      }
+
+      if (typeof type.getDefaultProps === 'function' && !type.getDefaultProps.isReactClassApproved) {
+        error('getDefaultProps is only used on classic React.createClass ' + 'definitions. Use a static property named `defaultProps` instead.');
+      }
+    }
+  }
+  /**
+   * Given a fragment, validate that it can only be provided with fragment props
+   * @param {ReactElement} fragment
+   */
+
+
+  function validateFragmentProps(fragment) {
+    {
+      setCurrentlyValidatingElement(fragment);
+      var keys = Object.keys(fragment.props);
+
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+
+        if (key !== 'children' && key !== 'key') {
+          error('Invalid prop `%s` supplied to `React.Fragment`. ' + 'React.Fragment can only have `key` and `children` props.', key);
+
+          break;
+        }
+      }
+
+      if (fragment.ref !== null) {
+        error('Invalid attribute `ref` supplied to `React.Fragment`.');
+      }
+
+      setCurrentlyValidatingElement(null);
+    }
+  }
+  function createElementWithValidation(type, props, children) {
+    var validType = isValidElementType(type); // We warn in this case but don't throw. We expect the element creation to
+    // succeed and there will likely be errors in render.
+
+    if (!validType) {
+      var info = '';
+
+      if (type === undefined || typeof type === 'object' && type !== null && Object.keys(type).length === 0) {
+        info += ' You likely forgot to export your component from the file ' + "it's defined in, or you might have mixed up default and named imports.";
+      }
+
+      var sourceInfo = getSourceInfoErrorAddendumForProps(props);
+
+      if (sourceInfo) {
+        info += sourceInfo;
+      } else {
+        info += getDeclarationErrorAddendum();
+      }
+
+      var typeString;
+
+      if (type === null) {
+        typeString = 'null';
+      } else if (Array.isArray(type)) {
+        typeString = 'array';
+      } else if (type !== undefined && type.$$typeof === REACT_ELEMENT_TYPE) {
+        typeString = "<" + (getComponentName(type.type) || 'Unknown') + " />";
+        info = ' Did you accidentally export a JSX literal instead of a component?';
+      } else {
+        typeString = typeof type;
+      }
+
+      {
+        error('React.createElement: type is invalid -- expected a string (for ' + 'built-in components) or a class/function (for composite ' + 'components) but got: %s.%s', typeString, info);
+      }
+    }
+
+    var element = createElement.apply(this, arguments); // The result can be nullish if a mock or a custom function is used.
+    // TODO: Drop this when these are no longer allowed as the type argument.
+
+    if (element == null) {
+      return element;
+    } // Skip key warning if the type isn't valid since our key validation logic
+    // doesn't expect a non-string/function type and can throw confusing errors.
+    // We don't want exception behavior to differ between dev and prod.
+    // (Rendering will throw with a helpful message and as soon as the type is
+    // fixed, the key warnings will appear.)
+
+
+    if (validType) {
+      for (var i = 2; i < arguments.length; i++) {
+        validateChildKeys(arguments[i], type);
+      }
+    }
+
+    if (type === REACT_FRAGMENT_TYPE) {
+      validateFragmentProps(element);
+    } else {
+      validatePropTypes(element);
+    }
+
+    return element;
+  }
+  var didWarnAboutDeprecatedCreateFactory = false;
+  function createFactoryWithValidation(type) {
+    var validatedFactory = createElementWithValidation.bind(null, type);
+    validatedFactory.type = type;
+
+    {
+      if (!didWarnAboutDeprecatedCreateFactory) {
+        didWarnAboutDeprecatedCreateFactory = true;
+
+        warn('React.createFactory() is deprecated and will be removed in ' + 'a future major release. Consider using JSX ' + 'or use React.createElement() directly instead.');
+      } // Legacy hook: remove it
+
+
+      Object.defineProperty(validatedFactory, 'type', {
+        enumerable: false,
+        get: function () {
+          warn('Factory.type is deprecated. Access the class directly ' + 'before passing it to createFactory.');
+
+          Object.defineProperty(this, 'type', {
+            value: type
+          });
+          return type;
+        }
+      });
+    }
+
+    return validatedFactory;
+  }
+  function cloneElementWithValidation(element, props, children) {
+    var newElement = cloneElement.apply(this, arguments);
+
+    for (var i = 2; i < arguments.length; i++) {
+      validateChildKeys(arguments[i], newElement.type);
+    }
+
+    validatePropTypes(newElement);
+    return newElement;
+  }
+
+  var enableSchedulerDebugging = false;
+  var enableProfiling = true;
+
+  var requestHostCallback;
+  var requestHostTimeout;
+  var cancelHostTimeout;
+  var shouldYieldToHost;
+  var requestPaint;
+  var getCurrentTime;
+  var forceFrameRate;
+
+  if ( // If Scheduler runs in a non-DOM environment, it falls back to a naive
+  // implementation using setTimeout.
+  typeof window === 'undefined' || // Check if MessageChannel is supported, too.
+  typeof MessageChannel !== 'function') {
+    // If this accidentally gets imported in a non-browser environment, e.g. JavaScriptCore,
+    // fallback to a naive implementation.
+    var _callback = null;
+    var _timeoutID = null;
+
+    var _flushCallback = function () {
+      if (_callback !== null) {
+        try {
+          var currentTime = getCurrentTime();
+          var hasRemainingTime = true;
+
+          _callback(hasRemainingTime, currentTime);
+
+          _callback = null;
+        } catch (e) {
+          setTimeout(_flushCallback, 0);
+          throw e;
+        }
+      }
+    };
+
+    var initialTime = Date.now();
+
+    getCurrentTime = function () {
+      return Date.now() - initialTime;
+    };
+
+    requestHostCallback = function (cb) {
+      if (_callback !== null) {
+        // Protect against re-entrancy.
+        setTimeout(requestHostCallback, 0, cb);
+      } else {
+        _callback = cb;
+        setTimeout(_flushCallback, 0);
+      }
+    };
+
+    requestHostTimeout = function (cb, ms) {
+      _timeoutID = setTimeout(cb, ms);
+    };
+
+    cancelHostTimeout = function () {
+      clearTimeout(_timeoutID);
+    };
+
+    shouldYieldToHost = function () {
+      return false;
+    };
+
+    requestPaint = forceFrameRate = function () {};
+  } else {
+    // Capture local references to native APIs, in case a polyfill overrides them.
+    var performance = window.performance;
+    var _Date = window.Date;
+    var _setTimeout = window.setTimeout;
+    var _clearTimeout = window.clearTimeout;
+
+    if (typeof console !== 'undefined') {
+      // TODO: Scheduler no longer requires these methods to be polyfilled. But
+      // maybe we want to continue warning if they don't exist, to preserve the
+      // option to rely on it in the future?
+      var requestAnimationFrame = window.requestAnimationFrame;
+      var cancelAnimationFrame = window.cancelAnimationFrame; // TODO: Remove fb.me link
+
+      if (typeof requestAnimationFrame !== 'function') {
+        // Using console['error'] to evade Babel and ESLint
+        console['error']("This browser doesn't support requestAnimationFrame. " + 'Make sure that you load a ' + 'polyfill in older browsers. https://fb.me/react-polyfills');
+      }
+
+      if (typeof cancelAnimationFrame !== 'function') {
+        // Using console['error'] to evade Babel and ESLint
+        console['error']("This browser doesn't support cancelAnimationFrame. " + 'Make sure that you load a ' + 'polyfill in older browsers. https://fb.me/react-polyfills');
+      }
+    }
+
+    if (typeof performance === 'object' && typeof performance.now === 'function') {
+      getCurrentTime = function () {
+        return performance.now();
+      };
+    } else {
+      var _initialTime = _Date.now();
+
+      getCurrentTime = function () {
+        return _Date.now() - _initialTime;
+      };
+    }
+
+    var isMessageLoopRunning = false;
+    var scheduledHostCallback = null;
+    var taskTimeoutID = -1; // Scheduler periodically yields in case there is other work on the main
+    // thread, like user events. By default, it yields multiple times per frame.
+    // It does not attempt to align with frame boundaries, since most tasks don't
+    // need to be frame aligned; for those that do, use requestAnimationFrame.
+
+    var yieldInterval = 5;
+    var deadline = 0; // TODO: Make this configurable
+
+    {
+      // `isInputPending` is not available. Since we have no way of knowing if
+      // there's pending input, always yield at the end of the frame.
+      shouldYieldToHost = function () {
+        return getCurrentTime() >= deadline;
+      }; // Since we yield every frame regardless, `requestPaint` has no effect.
+
+
+      requestPaint = function () {};
+    }
+
+    forceFrameRate = function (fps) {
+      if (fps < 0 || fps > 125) {
+        // Using console['error'] to evade Babel and ESLint
+        console['error']('forceFrameRate takes a positive int between 0 and 125, ' + 'forcing framerates higher than 125 fps is not unsupported');
+        return;
+      }
+
+      if (fps > 0) {
+        yieldInterval = Math.floor(1000 / fps);
+      } else {
+        // reset the framerate
+        yieldInterval = 5;
+      }
+    };
+
+    var performWorkUntilDeadline = function () {
+      if (scheduledHostCallback !== null) {
+        var currentTime = getCurrentTime(); // Yield after `yieldInterval` ms, regardless of where we are in the vsync
+        // cycle. This means there's always time remaining at the beginning of
+        // the message event.
+
+        deadline = currentTime + yieldInterval;
+        var hasTimeRemaining = true;
+
+        try {
+          var hasMoreWork = scheduledHostCallback(hasTimeRemaining, currentTime);
+
+          if (!hasMoreWork) {
+            isMessageLoopRunning = false;
+            scheduledHostCallback = null;
+          } else {
+            // If there's more work, schedule the next message event at the end
+            // of the preceding one.
+            port.postMessage(null);
+          }
+        } catch (error) {
+          // If a scheduler task throws, exit the current browser task so the
+          // error can be observed.
+          port.postMessage(null);
+          throw error;
+        }
+      } else {
+        isMessageLoopRunning = false;
+      } // Yielding to the browser will give it a chance to paint, so we can
+    };
+
+    var channel = new MessageChannel();
+    var port = channel.port2;
+    channel.port1.onmessage = performWorkUntilDeadline;
+
+    requestHostCallback = function (callback) {
+      scheduledHostCallback = callback;
+
+      if (!isMessageLoopRunning) {
+        isMessageLoopRunning = true;
+        port.postMessage(null);
+      }
+    };
+
+    requestHostTimeout = function (callback, ms) {
+      taskTimeoutID = _setTimeout(function () {
+        callback(getCurrentTime());
+      }, ms);
+    };
+
+    cancelHostTimeout = function () {
+      _clearTimeout(taskTimeoutID);
+
+      taskTimeoutID = -1;
+    };
+  }
+
+  function push(heap, node) {
+    var index = heap.length;
+    heap.push(node);
+    siftUp(heap, node, index);
+  }
+  function peek(heap) {
+    var first = heap[0];
+    return first === undefined ? null : first;
+  }
+  function pop(heap) {
+    var first = heap[0];
+
+    if (first !== undefined) {
+      var last = heap.pop();
+
+      if (last !== first) {
+        heap[0] = last;
+        siftDown(heap, last, 0);
+      }
+
+      return first;
+    } else {
+      return null;
+    }
+  }
+
+  function siftUp(heap, node, i) {
+    var index = i;
+
+    while (true) {
+      var parentIndex = index - 1 >>> 1;
+      var parent = heap[parentIndex];
+
+      if (parent !== undefined && compare(parent, node) > 0) {
+        // The parent is larger. Swap positions.
+        heap[parentIndex] = node;
+        heap[index] = parent;
+        index = parentIndex;
+      } else {
+        // The parent is smaller. Exit.
+        return;
+      }
+    }
+  }
+
+  function siftDown(heap, node, i) {
+    var index = i;
+    var length = heap.length;
+
+    while (index < length) {
+      var leftIndex = (index + 1) * 2 - 1;
+      var left = heap[leftIndex];
+      var rightIndex = leftIndex + 1;
+      var right = heap[rightIndex]; // If the left or right node is smaller, swap with the smaller of those.
+
+      if (left !== undefined && compare(left, node) < 0) {
+        if (right !== undefined && compare(right, left) < 0) {
+          heap[index] = right;
+          heap[rightIndex] = node;
+          index = rightIndex;
+        } else {
+          heap[index] = left;
+          heap[leftIndex] = node;
+          index = leftIndex;
+        }
+      } else if (right !== undefined && compare(right, node) < 0) {
+        heap[index] = right;
+        heap[rightIndex] = node;
+        index = rightIndex;
+      } else {
+        // Neither child is smaller. Exit.
+        return;
+      }
+    }
+  }
+
+  function compare(a, b) {
+    // Compare sort index first, then task id.
+    var diff = a.sortIndex - b.sortIndex;
+    return diff !== 0 ? diff : a.id - b.id;
+  }
+
+  // TODO: Use symbols?
+  var NoPriority = 0;
+  var ImmediatePriority = 1;
+  var UserBlockingPriority = 2;
+  var NormalPriority = 3;
+  var LowPriority = 4;
+  var IdlePriority = 5;
+
+  var runIdCounter = 0;
+  var mainThreadIdCounter = 0;
+  var profilingStateSize = 4;
+  var sharedProfilingBuffer =  // $FlowFixMe Flow doesn't know about SharedArrayBuffer
+  typeof SharedArrayBuffer === 'function' ? new SharedArrayBuffer(profilingStateSize * Int32Array.BYTES_PER_ELEMENT) : // $FlowFixMe Flow doesn't know about ArrayBuffer
+  typeof ArrayBuffer === 'function' ? new ArrayBuffer(profilingStateSize * Int32Array.BYTES_PER_ELEMENT) : null // Don't crash the init path on IE9
+  ;
+  var profilingState =  sharedProfilingBuffer !== null ? new Int32Array(sharedProfilingBuffer) : []; // We can't read this but it helps save bytes for null checks
+
+  var PRIORITY = 0;
+  var CURRENT_TASK_ID = 1;
+  var CURRENT_RUN_ID = 2;
+  var QUEUE_SIZE = 3;
+
+  {
+    profilingState[PRIORITY] = NoPriority; // This is maintained with a counter, because the size of the priority queue
+    // array might include canceled tasks.
+
+    profilingState[QUEUE_SIZE] = 0;
+    profilingState[CURRENT_TASK_ID] = 0;
+  } // Bytes per element is 4
+
+
+  var INITIAL_EVENT_LOG_SIZE = 131072;
+  var MAX_EVENT_LOG_SIZE = 524288; // Equivalent to 2 megabytes
+
+  var eventLogSize = 0;
+  var eventLogBuffer = null;
+  var eventLog = null;
+  var eventLogIndex = 0;
+  var TaskStartEvent = 1;
+  var TaskCompleteEvent = 2;
+  var TaskErrorEvent = 3;
+  var TaskCancelEvent = 4;
+  var TaskRunEvent = 5;
+  var TaskYieldEvent = 6;
+  var SchedulerSuspendEvent = 7;
+  var SchedulerResumeEvent = 8;
+
+  function logEvent(entries) {
+    if (eventLog !== null) {
+      var offset = eventLogIndex;
+      eventLogIndex += entries.length;
+
+      if (eventLogIndex + 1 > eventLogSize) {
+        eventLogSize *= 2;
+
+        if (eventLogSize > MAX_EVENT_LOG_SIZE) {
+          // Using console['error'] to evade Babel and ESLint
+          console['error']("Scheduler Profiling: Event log exceeded maximum size. Don't " + 'forget to call `stopLoggingProfilingEvents()`.');
+          stopLoggingProfilingEvents();
+          return;
+        }
+
+        var newEventLog = new Int32Array(eventLogSize * 4);
+        newEventLog.set(eventLog);
+        eventLogBuffer = newEventLog.buffer;
+        eventLog = newEventLog;
+      }
+
+      eventLog.set(entries, offset);
+    }
+  }
+
+  function startLoggingProfilingEvents() {
+    eventLogSize = INITIAL_EVENT_LOG_SIZE;
+    eventLogBuffer = new ArrayBuffer(eventLogSize * 4);
+    eventLog = new Int32Array(eventLogBuffer);
+    eventLogIndex = 0;
+  }
+  function stopLoggingProfilingEvents() {
+    var buffer = eventLogBuffer;
+    eventLogSize = 0;
+    eventLogBuffer = null;
+    eventLog = null;
+    eventLogIndex = 0;
+    return buffer;
+  }
+  function markTaskStart(task, ms) {
+    {
+      profilingState[QUEUE_SIZE]++;
+
+      if (eventLog !== null) {
+        // performance.now returns a float, representing milliseconds. When the
+        // event is logged, it's coerced to an int. Convert to microseconds to
+        // maintain extra degrees of precision.
+        logEvent([TaskStartEvent, ms * 1000, task.id, task.priorityLevel]);
+      }
+    }
+  }
+  function markTaskCompleted(task, ms) {
+    {
+      profilingState[PRIORITY] = NoPriority;
+      profilingState[CURRENT_TASK_ID] = 0;
+      profilingState[QUEUE_SIZE]--;
+
+      if (eventLog !== null) {
+        logEvent([TaskCompleteEvent, ms * 1000, task.id]);
+      }
+    }
+  }
+  function markTaskCanceled(task, ms) {
+    {
+      profilingState[QUEUE_SIZE]--;
+
+      if (eventLog !== null) {
+        logEvent([TaskCancelEvent, ms * 1000, task.id]);
+      }
+    }
+  }
+  function markTaskErrored(task, ms) {
+    {
+      profilingState[PRIORITY] = NoPriority;
+      profilingState[CURRENT_TASK_ID] = 0;
+      profilingState[QUEUE_SIZE]--;
+
+      if (eventLog !== null) {
+        logEvent([TaskErrorEvent, ms * 1000, task.id]);
+      }
+    }
+  }
+  function markTaskRun(task, ms) {
+    {
+      runIdCounter++;
+      profilingState[PRIORITY] = task.priorityLevel;
+      profilingState[CURRENT_TASK_ID] = task.id;
+      profilingState[CURRENT_RUN_ID] = runIdCounter;
+
+      if (eventLog !== null) {
+        logEvent([TaskRunEvent, ms * 1000, task.id, runIdCounter]);
+      }
+    }
+  }
+  function markTaskYield(task, ms) {
+    {
+      profilingState[PRIORITY] = NoPriority;
+      profilingState[CURRENT_TASK_ID] = 0;
+      profilingState[CURRENT_RUN_ID] = 0;
+
+      if (eventLog !== null) {
+        logEvent([TaskYieldEvent, ms * 1000, task.id, runIdCounter]);
+      }
+    }
+  }
+  function markSchedulerSuspended(ms) {
+    {
+      mainThreadIdCounter++;
+
+      if (eventLog !== null) {
+        logEvent([SchedulerSuspendEvent, ms * 1000, mainThreadIdCounter]);
+      }
+    }
+  }
+  function markSchedulerUnsuspended(ms) {
+    {
+      if (eventLog !== null) {
+        logEvent([SchedulerResumeEvent, ms * 1000, mainThreadIdCounter]);
+      }
+    }
+  }
+
+  /* eslint-disable no-var */
+  // Math.pow(2, 30) - 1
+  // 0b111111111111111111111111111111
+
+  var maxSigned31BitInt = 1073741823; // Times out immediately
+
+  var IMMEDIATE_PRIORITY_TIMEOUT = -1; // Eventually times out
+
+  var USER_BLOCKING_PRIORITY = 250;
+  var NORMAL_PRIORITY_TIMEOUT = 5000;
+  var LOW_PRIORITY_TIMEOUT = 10000; // Never times out
+
+  var IDLE_PRIORITY = maxSigned31BitInt; // Tasks are stored on a min heap
+
+  var taskQueue = [];
+  var timerQueue = []; // Incrementing id counter. Used to maintain insertion order.
+
+  var taskIdCounter = 1; // Pausing the scheduler is useful for debugging.
+  var currentTask = null;
+  var currentPriorityLevel = NormalPriority; // This is set while performing work, to prevent re-entrancy.
+
+  var isPerformingWork = false;
+  var isHostCallbackScheduled = false;
+  var isHostTimeoutScheduled = false;
+
+  function advanceTimers(currentTime) {
+    // Check for tasks that are no longer delayed and add them to the queue.
+    var timer = peek(timerQueue);
+
+    while (timer !== null) {
+      if (timer.callback === null) {
+        // Timer was cancelled.
+        pop(timerQueue);
+      } else if (timer.startTime <= currentTime) {
+        // Timer fired. Transfer to the task queue.
+        pop(timerQueue);
+        timer.sortIndex = timer.expirationTime;
+        push(taskQueue, timer);
+
+        {
+          markTaskStart(timer, currentTime);
+          timer.isQueued = true;
+        }
+      } else {
+        // Remaining timers are pending.
+        return;
+      }
+
+      timer = peek(timerQueue);
+    }
+  }
+
+  function handleTimeout(currentTime) {
+    isHostTimeoutScheduled = false;
+    advanceTimers(currentTime);
+
+    if (!isHostCallbackScheduled) {
+      if (peek(taskQueue) !== null) {
+        isHostCallbackScheduled = true;
+        requestHostCallback(flushWork);
+      } else {
+        var firstTimer = peek(timerQueue);
+
+        if (firstTimer !== null) {
+          requestHostTimeout(handleTimeout, firstTimer.startTime - currentTime);
+        }
+      }
+    }
+  }
+
+  function flushWork(hasTimeRemaining, initialTime) {
+    {
+      markSchedulerUnsuspended(initialTime);
+    } // We'll need a host callback the next time work is scheduled.
+
+
+    isHostCallbackScheduled = false;
+
+    if (isHostTimeoutScheduled) {
+      // We scheduled a timeout but it's no longer needed. Cancel it.
+      isHostTimeoutScheduled = false;
+      cancelHostTimeout();
+    }
+
+    isPerformingWork = true;
+    var previousPriorityLevel = currentPriorityLevel;
+
+    try {
+      if (enableProfiling) {
+        try {
+          return workLoop(hasTimeRemaining, initialTime);
+        } catch (error) {
+          if (currentTask !== null) {
+            var currentTime = getCurrentTime();
+            markTaskErrored(currentTask, currentTime);
+            currentTask.isQueued = false;
+          }
+
+          throw error;
+        }
+      } else {
+        // No catch in prod codepath.
+        return workLoop(hasTimeRemaining, initialTime);
+      }
+    } finally {
+      currentTask = null;
+      currentPriorityLevel = previousPriorityLevel;
+      isPerformingWork = false;
+
+      {
+        var _currentTime = getCurrentTime();
+
+        markSchedulerSuspended(_currentTime);
+      }
+    }
+  }
+
+  function workLoop(hasTimeRemaining, initialTime) {
+    var currentTime = initialTime;
+    advanceTimers(currentTime);
+    currentTask = peek(taskQueue);
+
+    while (currentTask !== null && !(enableSchedulerDebugging )) {
+      if (currentTask.expirationTime > currentTime && (!hasTimeRemaining || shouldYieldToHost())) {
+        // This currentTask hasn't expired, and we've reached the deadline.
+        break;
+      }
+
+      var callback = currentTask.callback;
+
+      if (callback !== null) {
+        currentTask.callback = null;
+        currentPriorityLevel = currentTask.priorityLevel;
+        var didUserCallbackTimeout = currentTask.expirationTime <= currentTime;
+        markTaskRun(currentTask, currentTime);
+        var continuationCallback = callback(didUserCallbackTimeout);
+        currentTime = getCurrentTime();
+
+        if (typeof continuationCallback === 'function') {
+          currentTask.callback = continuationCallback;
+          markTaskYield(currentTask, currentTime);
+        } else {
+          {
+            markTaskCompleted(currentTask, currentTime);
+            currentTask.isQueued = false;
+          }
+
+          if (currentTask === peek(taskQueue)) {
+            pop(taskQueue);
+          }
+        }
+
+        advanceTimers(currentTime);
+      } else {
+        pop(taskQueue);
+      }
+
+      currentTask = peek(taskQueue);
+    } // Return whether there's additional work
+
+
+    if (currentTask !== null) {
+      return true;
+    } else {
+      var firstTimer = peek(timerQueue);
+
+      if (firstTimer !== null) {
+        requestHostTimeout(handleTimeout, firstTimer.startTime - currentTime);
+      }
+
+      return false;
+    }
+  }
+
+  function unstable_runWithPriority(priorityLevel, eventHandler) {
+    switch (priorityLevel) {
+      case ImmediatePriority:
+      case UserBlockingPriority:
+      case NormalPriority:
+      case LowPriority:
+      case IdlePriority:
+        break;
+
+      default:
+        priorityLevel = NormalPriority;
+    }
+
+    var previousPriorityLevel = currentPriorityLevel;
+    currentPriorityLevel = priorityLevel;
+
+    try {
+      return eventHandler();
+    } finally {
+      currentPriorityLevel = previousPriorityLevel;
+    }
+  }
+
+  function unstable_next(eventHandler) {
+    var priorityLevel;
+
+    switch (currentPriorityLevel) {
+      case ImmediatePriority:
+      case UserBlockingPriority:
+      case NormalPriority:
+        // Shift down to normal priority
+        priorityLevel = NormalPriority;
+        break;
+
+      default:
+        // Anything lower than normal priority should remain at the current level.
+        priorityLevel = currentPriorityLevel;
+        break;
+    }
+
+    var previousPriorityLevel = currentPriorityLevel;
+    currentPriorityLevel = priorityLevel;
+
+    try {
+      return eventHandler();
+    } finally {
+      currentPriorityLevel = previousPriorityLevel;
+    }
+  }
+
+  function unstable_wrapCallback(callback) {
+    var parentPriorityLevel = currentPriorityLevel;
+    return function () {
+      // This is a fork of runWithPriority, inlined for performance.
+      var previousPriorityLevel = currentPriorityLevel;
+      currentPriorityLevel = parentPriorityLevel;
+
+      try {
+        return callback.apply(this, arguments);
+      } finally {
+        currentPriorityLevel = previousPriorityLevel;
+      }
+    };
+  }
+
+  function timeoutForPriorityLevel(priorityLevel) {
+    switch (priorityLevel) {
+      case ImmediatePriority:
+        return IMMEDIATE_PRIORITY_TIMEOUT;
+
+      case UserBlockingPriority:
+        return USER_BLOCKING_PRIORITY;
+
+      case IdlePriority:
+        return IDLE_PRIORITY;
+
+      case LowPriority:
+        return LOW_PRIORITY_TIMEOUT;
+
+      case NormalPriority:
+      default:
+        return NORMAL_PRIORITY_TIMEOUT;
+    }
+  }
+
+  function unstable_scheduleCallback(priorityLevel, callback, options) {
+    var currentTime = getCurrentTime();
+    var startTime;
+    var timeout;
+
+    if (typeof options === 'object' && options !== null) {
+      var delay = options.delay;
+
+      if (typeof delay === 'number' && delay > 0) {
+        startTime = currentTime + delay;
+      } else {
+        startTime = currentTime;
+      }
+
+      timeout = typeof options.timeout === 'number' ? options.timeout : timeoutForPriorityLevel(priorityLevel);
+    } else {
+      timeout = timeoutForPriorityLevel(priorityLevel);
+      startTime = currentTime;
+    }
+
+    var expirationTime = startTime + timeout;
+    var newTask = {
+      id: taskIdCounter++,
+      callback: callback,
+      priorityLevel: priorityLevel,
+      startTime: startTime,
+      expirationTime: expirationTime,
+      sortIndex: -1
+    };
+
+    {
+      newTask.isQueued = false;
+    }
+
+    if (startTime > currentTime) {
+      // This is a delayed task.
+      newTask.sortIndex = startTime;
+      push(timerQueue, newTask);
+
+      if (peek(taskQueue) === null && newTask === peek(timerQueue)) {
+        // All tasks are delayed, and this is the task with the earliest delay.
+        if (isHostTimeoutScheduled) {
+          // Cancel an existing timeout.
+          cancelHostTimeout();
+        } else {
+          isHostTimeoutScheduled = true;
+        } // Schedule a timeout.
+
+
+        requestHostTimeout(handleTimeout, startTime - currentTime);
+      }
+    } else {
+      newTask.sortIndex = expirationTime;
+      push(taskQueue, newTask);
+
+      {
+        markTaskStart(newTask, currentTime);
+        newTask.isQueued = true;
+      } // Schedule a host callback, if needed. If we're already performing work,
+      // wait until the next time we yield.
+
+
+      if (!isHostCallbackScheduled && !isPerformingWork) {
+        isHostCallbackScheduled = true;
+        requestHostCallback(flushWork);
+      }
+    }
+
+    return newTask;
+  }
+
+  function unstable_pauseExecution() {
+  }
+
+  function unstable_continueExecution() {
+
+    if (!isHostCallbackScheduled && !isPerformingWork) {
+      isHostCallbackScheduled = true;
+      requestHostCallback(flushWork);
+    }
+  }
+
+  function unstable_getFirstCallbackNode() {
+    return peek(taskQueue);
+  }
+
+  function unstable_cancelCallback(task) {
+    {
+      if (task.isQueued) {
+        var currentTime = getCurrentTime();
+        markTaskCanceled(task, currentTime);
+        task.isQueued = false;
+      }
+    } // Null out the callback to indicate the task has been canceled. (Can't
+    // remove from the queue because you can't remove arbitrary nodes from an
+    // array based heap, only the first one.)
+
+
+    task.callback = null;
+  }
+
+  function unstable_getCurrentPriorityLevel() {
+    return currentPriorityLevel;
+  }
+
+  function unstable_shouldYield() {
+    var currentTime = getCurrentTime();
+    advanceTimers(currentTime);
+    var firstTask = peek(taskQueue);
+    return firstTask !== currentTask && currentTask !== null && firstTask !== null && firstTask.callback !== null && firstTask.startTime <= currentTime && firstTask.expirationTime < currentTask.expirationTime || shouldYieldToHost();
+  }
+
+  var unstable_requestPaint = requestPaint;
+  var unstable_Profiling =  {
+    startLoggingProfilingEvents: startLoggingProfilingEvents,
+    stopLoggingProfilingEvents: stopLoggingProfilingEvents,
+    sharedProfilingBuffer: sharedProfilingBuffer
+  } ;
+
+
+
+  var Scheduler = /*#__PURE__*/Object.freeze({
+    __proto__: null,
+    unstable_ImmediatePriority: ImmediatePriority,
+    unstable_UserBlockingPriority: UserBlockingPriority,
+    unstable_NormalPriority: NormalPriority,
+    unstable_IdlePriority: IdlePriority,
+    unstable_LowPriority: LowPriority,
+    unstable_runWithPriority: unstable_runWithPriority,
+    unstable_next: unstable_next,
+    unstable_scheduleCallback: unstable_scheduleCallback,
+    unstable_cancelCallback: unstable_cancelCallback,
+    unstable_wrapCallback: unstable_wrapCallback,
+    unstable_getCurrentPriorityLevel: unstable_getCurrentPriorityLevel,
+    unstable_shouldYield: unstable_shouldYield,
+    unstable_requestPaint: unstable_requestPaint,
+    unstable_continueExecution: unstable_continueExecution,
+    unstable_pauseExecution: unstable_pauseExecution,
+    unstable_getFirstCallbackNode: unstable_getFirstCallbackNode,
+    get unstable_now () { return getCurrentTime; },
+    get unstable_forceFrameRate () { return forceFrameRate; },
+    unstable_Profiling: unstable_Profiling
+  });
+
+  var DEFAULT_THREAD_ID = 0; // Counters used to generate unique IDs.
+
+  var interactionIDCounter = 0;
+  var threadIDCounter = 0; // Set of currently traced interactions.
+  // Interactions "stack"–
+  // Meaning that newly traced interactions are appended to the previously active set.
+  // When an interaction goes out of scope, the previous set (if any) is restored.
+
+  var interactionsRef = null; // Listener(s) to notify when interactions begin and end.
+
+  var subscriberRef = null;
+
+  {
+    interactionsRef = {
+      current: new Set()
+    };
+    subscriberRef = {
+      current: null
+    };
+  }
+  function unstable_clear(callback) {
+
+    var prevInteractions = interactionsRef.current;
+    interactionsRef.current = new Set();
+
+    try {
+      return callback();
+    } finally {
+      interactionsRef.current = prevInteractions;
+    }
+  }
+  function unstable_getCurrent() {
+    {
+      return interactionsRef.current;
+    }
+  }
+  function unstable_getThreadID() {
+    return ++threadIDCounter;
+  }
+  function unstable_trace(name, timestamp, callback) {
+    var threadID = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : DEFAULT_THREAD_ID;
+
+    var interaction = {
+      __count: 1,
+      id: interactionIDCounter++,
+      name: name,
+      timestamp: timestamp
+    };
+    var prevInteractions = interactionsRef.current; // Traced interactions should stack/accumulate.
+    // To do that, clone the current interactions.
+    // The previous set will be restored upon completion.
+
+    var interactions = new Set(prevInteractions);
+    interactions.add(interaction);
+    interactionsRef.current = interactions;
+    var subscriber = subscriberRef.current;
+    var returnValue;
+
+    try {
+      if (subscriber !== null) {
+        subscriber.onInteractionTraced(interaction);
+      }
+    } finally {
+      try {
+        if (subscriber !== null) {
+          subscriber.onWorkStarted(interactions, threadID);
+        }
+      } finally {
+        try {
+          returnValue = callback();
+        } finally {
+          interactionsRef.current = prevInteractions;
+
+          try {
+            if (subscriber !== null) {
+              subscriber.onWorkStopped(interactions, threadID);
+            }
+          } finally {
+            interaction.__count--; // If no async work was scheduled for this interaction,
+            // Notify subscribers that it's completed.
+
+            if (subscriber !== null && interaction.__count === 0) {
+              subscriber.onInteractionScheduledWorkCompleted(interaction);
+            }
+          }
+        }
+      }
+    }
+
+    return returnValue;
+  }
+  function unstable_wrap(callback) {
+    var threadID = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : DEFAULT_THREAD_ID;
+
+    var wrappedInteractions = interactionsRef.current;
+    var subscriber = subscriberRef.current;
+
+    if (subscriber !== null) {
+      subscriber.onWorkScheduled(wrappedInteractions, threadID);
+    } // Update the pending async work count for the current interactions.
+    // Update after calling subscribers in case of error.
+
+
+    wrappedInteractions.forEach(function (interaction) {
+      interaction.__count++;
+    });
+    var hasRun = false;
+
+    function wrapped() {
+      var prevInteractions = interactionsRef.current;
+      interactionsRef.current = wrappedInteractions;
+      subscriber = subscriberRef.current;
+
+      try {
+        var returnValue;
+
+        try {
+          if (subscriber !== null) {
+            subscriber.onWorkStarted(wrappedInteractions, threadID);
+          }
+        } finally {
+          try {
+            returnValue = callback.apply(undefined, arguments);
+          } finally {
+            interactionsRef.current = prevInteractions;
+
+            if (subscriber !== null) {
+              subscriber.onWorkStopped(wrappedInteractions, threadID);
+            }
+          }
+        }
+
+        return returnValue;
+      } finally {
+        if (!hasRun) {
+          // We only expect a wrapped function to be executed once,
+          // But in the event that it's executed more than once–
+          // Only decrement the outstanding interaction counts once.
+          hasRun = true; // Update pending async counts for all wrapped interactions.
+          // If this was the last scheduled async work for any of them,
+          // Mark them as completed.
+
+          wrappedInteractions.forEach(function (interaction) {
+            interaction.__count--;
+
+            if (subscriber !== null && interaction.__count === 0) {
+              subscriber.onInteractionScheduledWorkCompleted(interaction);
+            }
+          });
+        }
+      }
+    }
+
+    wrapped.cancel = function cancel() {
+      subscriber = subscriberRef.current;
+
+      try {
+        if (subscriber !== null) {
+          subscriber.onWorkCanceled(wrappedInteractions, threadID);
+        }
+      } finally {
+        // Update pending async counts for all wrapped interactions.
+        // If this was the last scheduled async work for any of them,
+        // Mark them as completed.
+        wrappedInteractions.forEach(function (interaction) {
+          interaction.__count--;
+
+          if (subscriber && interaction.__count === 0) {
+            subscriber.onInteractionScheduledWorkCompleted(interaction);
+          }
+        });
+      }
+    };
+
+    return wrapped;
+  }
+
+  var subscribers = null;
+
+  {
+    subscribers = new Set();
+  }
+
+  function unstable_subscribe(subscriber) {
+    {
+      subscribers.add(subscriber);
+
+      if (subscribers.size === 1) {
+        subscriberRef.current = {
+          onInteractionScheduledWorkCompleted: onInteractionScheduledWorkCompleted,
+          onInteractionTraced: onInteractionTraced,
+          onWorkCanceled: onWorkCanceled,
+          onWorkScheduled: onWorkScheduled,
+          onWorkStarted: onWorkStarted,
+          onWorkStopped: onWorkStopped
+        };
+      }
+    }
+  }
+  function unstable_unsubscribe(subscriber) {
+    {
+      subscribers.delete(subscriber);
+
+      if (subscribers.size === 0) {
+        subscriberRef.current = null;
+      }
+    }
+  }
+
+  function onInteractionTraced(interaction) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onInteractionTraced(interaction);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+  function onInteractionScheduledWorkCompleted(interaction) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onInteractionScheduledWorkCompleted(interaction);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+  function onWorkScheduled(interactions, threadID) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onWorkScheduled(interactions, threadID);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+  function onWorkStarted(interactions, threadID) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onWorkStarted(interactions, threadID);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+  function onWorkStopped(interactions, threadID) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onWorkStopped(interactions, threadID);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+  function onWorkCanceled(interactions, threadID) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onWorkCanceled(interactions, threadID);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+
+
+  var SchedulerTracing = /*#__PURE__*/Object.freeze({
+    __proto__: null,
+    get __interactionsRef () { return interactionsRef; },
+    get __subscriberRef () { return subscriberRef; },
+    unstable_clear: unstable_clear,
+    unstable_getCurrent: unstable_getCurrent,
+    unstable_getThreadID: unstable_getThreadID,
+    unstable_trace: unstable_trace,
+    unstable_wrap: unstable_wrap,
+    unstable_subscribe: unstable_subscribe,
+    unstable_unsubscribe: unstable_unsubscribe
+  });
+
+  var ReactSharedInternals$1 = {
+    ReactCurrentDispatcher: ReactCurrentDispatcher,
+    ReactCurrentOwner: ReactCurrentOwner,
+    IsSomeRendererActing: IsSomeRendererActing,
+    // Used by renderers to avoid bundling object-assign twice in UMD bundles:
+    assign: objectAssign
+  };
+
+  {
+    objectAssign(ReactSharedInternals$1, {
+      // These should not be included in production.
+      ReactDebugCurrentFrame: ReactDebugCurrentFrame,
+      // Shim for React DOM 16.0.0 which still destructured (but not used) this.
+      // TODO: remove in React 17.0.
+      ReactComponentTreeHook: {}
+    });
+  } // Re-export the schedule API(s) for UMD bundles.
+  // This avoids introducing a dependency on a new UMD global in a minor update,
+  // Since that would be a breaking change (e.g. for all existing CodeSandboxes).
+  // This re-export is only required for UMD bundles;
+  // CJS bundles use the shared NPM package.
+
+
+  objectAssign(ReactSharedInternals$1, {
+    Scheduler: Scheduler,
+    SchedulerTracing: SchedulerTracing
+  });
+
+  {
+
+    try {
+      var frozenObject = Object.freeze({});
+      var testMap = new Map([[frozenObject, null]]);
+      var testSet = new Set([frozenObject]); // This is necessary for Rollup to not consider these unused.
+      // https://github.com/rollup/rollup/issues/1771
+      // TODO: we can remove these if Rollup fixes the bug.
+
+      testMap.set(0, 0);
+      testSet.add(0);
+    } catch (e) {
+    }
+  }
+
+  var createElement$1 =  createElementWithValidation ;
+  var cloneElement$1 =  cloneElementWithValidation ;
+  var createFactory =  createFactoryWithValidation ;
+  var Children = {
+    map: mapChildren,
+    forEach: forEachChildren,
+    count: countChildren,
+    toArray: toArray,
+    only: onlyChild
+  };
+
+  exports.Children = Children;
+  exports.Component = Component;
+  exports.Fragment = REACT_FRAGMENT_TYPE;
+  exports.Profiler = REACT_PROFILER_TYPE;
+  exports.PureComponent = PureComponent;
+  exports.StrictMode = REACT_STRICT_MODE_TYPE;
+  exports.Suspense = REACT_SUSPENSE_TYPE;
+  exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = ReactSharedInternals$1;
+  exports.cloneElement = cloneElement$1;
+  exports.createContext = createContext;
+  exports.createElement = createElement$1;
+  exports.createFactory = createFactory;
+  exports.createRef = createRef;
+  exports.forwardRef = forwardRef;
+  exports.isValidElement = isValidElement;
+  exports.lazy = lazy;
+  exports.memo = memo;
+  exports.useCallback = useCallback;
+  exports.useContext = useContext;
+  exports.useDebugValue = useDebugValue;
+  exports.useEffect = useEffect;
+  exports.useImperativeHandle = useImperativeHandle;
+  exports.useLayoutEffect = useLayoutEffect;
+  exports.useMemo = useMemo;
+  exports.useReducer = useReducer;
+  exports.useRef = useRef;
+  exports.useState = useState;
+  exports.version = ReactVersion;
+
+})));

--- a/tests/assets/reading-list/react_17.0.2.js
+++ b/tests/assets/reading-list/react_17.0.2.js
@@ -1,0 +1,3357 @@
+/** @license React v17.0.2
+ * react.development.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  (global = global || self, factory(global.React = {}));
+}(this, (function (exports) { 'use strict';
+
+  // TODO: this is special because it gets imported during build.
+  var ReactVersion = '17.0.2';
+
+  // ATTENTION
+  // When adding new symbols to this file,
+  // Please consider also adding to 'react-devtools-shared/src/backend/ReactSymbols'
+  // The Symbol used to tag the ReactElement-like types. If there is no native Symbol
+  // nor polyfill, then a plain number is used for performance.
+  var REACT_ELEMENT_TYPE = 0xeac7;
+  var REACT_PORTAL_TYPE = 0xeaca;
+  exports.Fragment = 0xeacb;
+  exports.StrictMode = 0xeacc;
+  exports.Profiler = 0xead2;
+  var REACT_PROVIDER_TYPE = 0xeacd;
+  var REACT_CONTEXT_TYPE = 0xeace;
+  var REACT_FORWARD_REF_TYPE = 0xead0;
+  exports.Suspense = 0xead1;
+  var REACT_SUSPENSE_LIST_TYPE = 0xead8;
+  var REACT_MEMO_TYPE = 0xead3;
+  var REACT_LAZY_TYPE = 0xead4;
+  var REACT_BLOCK_TYPE = 0xead9;
+  var REACT_SERVER_BLOCK_TYPE = 0xeada;
+  var REACT_FUNDAMENTAL_TYPE = 0xead5;
+  var REACT_SCOPE_TYPE = 0xead7;
+  var REACT_OPAQUE_ID_TYPE = 0xeae0;
+  var REACT_DEBUG_TRACING_MODE_TYPE = 0xeae1;
+  var REACT_OFFSCREEN_TYPE = 0xeae2;
+  var REACT_LEGACY_HIDDEN_TYPE = 0xeae3;
+
+  if (typeof Symbol === 'function' && Symbol.for) {
+    var symbolFor = Symbol.for;
+    REACT_ELEMENT_TYPE = symbolFor('react.element');
+    REACT_PORTAL_TYPE = symbolFor('react.portal');
+    exports.Fragment = symbolFor('react.fragment');
+    exports.StrictMode = symbolFor('react.strict_mode');
+    exports.Profiler = symbolFor('react.profiler');
+    REACT_PROVIDER_TYPE = symbolFor('react.provider');
+    REACT_CONTEXT_TYPE = symbolFor('react.context');
+    REACT_FORWARD_REF_TYPE = symbolFor('react.forward_ref');
+    exports.Suspense = symbolFor('react.suspense');
+    REACT_SUSPENSE_LIST_TYPE = symbolFor('react.suspense_list');
+    REACT_MEMO_TYPE = symbolFor('react.memo');
+    REACT_LAZY_TYPE = symbolFor('react.lazy');
+    REACT_BLOCK_TYPE = symbolFor('react.block');
+    REACT_SERVER_BLOCK_TYPE = symbolFor('react.server.block');
+    REACT_FUNDAMENTAL_TYPE = symbolFor('react.fundamental');
+    REACT_SCOPE_TYPE = symbolFor('react.scope');
+    REACT_OPAQUE_ID_TYPE = symbolFor('react.opaque.id');
+    REACT_DEBUG_TRACING_MODE_TYPE = symbolFor('react.debug_trace_mode');
+    REACT_OFFSCREEN_TYPE = symbolFor('react.offscreen');
+    REACT_LEGACY_HIDDEN_TYPE = symbolFor('react.legacy_hidden');
+  }
+
+  var MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+  var FAUX_ITERATOR_SYMBOL = '@@iterator';
+  function getIteratorFn(maybeIterable) {
+    if (maybeIterable === null || typeof maybeIterable !== 'object') {
+      return null;
+    }
+
+    var maybeIterator = MAYBE_ITERATOR_SYMBOL && maybeIterable[MAYBE_ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL];
+
+    if (typeof maybeIterator === 'function') {
+      return maybeIterator;
+    }
+
+    return null;
+  }
+
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
+
+  var _assign = function (to, from) {
+    for (var key in from) {
+      if (hasOwnProperty.call(from, key)) {
+        to[key] = from[key];
+      }
+    }
+  };
+
+  var assign = Object.assign || function (target, sources) {
+    if (target == null) {
+      throw new TypeError('Object.assign target cannot be null or undefined');
+    }
+
+    var to = Object(target);
+
+    for (var nextIndex = 1; nextIndex < arguments.length; nextIndex++) {
+      var nextSource = arguments[nextIndex];
+
+      if (nextSource != null) {
+        _assign(to, Object(nextSource));
+      }
+    }
+
+    return to;
+  };
+
+  /**
+   * Keeps track of the current dispatcher.
+   */
+  var ReactCurrentDispatcher = {
+    /**
+     * @internal
+     * @type {ReactComponent}
+     */
+    current: null
+  };
+
+  /**
+   * Keeps track of the current batch's configuration such as how long an update
+   * should suspend for if it needs to.
+   */
+  var ReactCurrentBatchConfig = {
+    transition: 0
+  };
+
+  /**
+   * Keeps track of the current owner.
+   *
+   * The current owner is the component who should own any components that are
+   * currently being constructed.
+   */
+  var ReactCurrentOwner = {
+    /**
+     * @internal
+     * @type {ReactComponent}
+     */
+    current: null
+  };
+
+  var ReactDebugCurrentFrame = {};
+  var currentExtraStackFrame = null;
+  function setExtraStackFrame(stack) {
+    {
+      currentExtraStackFrame = stack;
+    }
+  }
+
+  {
+    ReactDebugCurrentFrame.setExtraStackFrame = function (stack) {
+      {
+        currentExtraStackFrame = stack;
+      }
+    }; // Stack implementation injected by the current renderer.
+
+
+    ReactDebugCurrentFrame.getCurrentStack = null;
+
+    ReactDebugCurrentFrame.getStackAddendum = function () {
+      var stack = ''; // Add an extra top frame while an element is being validated
+
+      if (currentExtraStackFrame) {
+        stack += currentExtraStackFrame;
+      } // Delegate to the injected renderer-specific implementation
+
+
+      var impl = ReactDebugCurrentFrame.getCurrentStack;
+
+      if (impl) {
+        stack += impl() || '';
+      }
+
+      return stack;
+    };
+  }
+
+  /**
+   * Used by act() to track whether you're inside an act() scope.
+   */
+  var IsSomeRendererActing = {
+    current: false
+  };
+
+  var ReactSharedInternals = {
+    ReactCurrentDispatcher: ReactCurrentDispatcher,
+    ReactCurrentBatchConfig: ReactCurrentBatchConfig,
+    ReactCurrentOwner: ReactCurrentOwner,
+    IsSomeRendererActing: IsSomeRendererActing,
+    // Used by renderers to avoid bundling object-assign twice in UMD bundles:
+    assign: assign
+  };
+
+  {
+    ReactSharedInternals.ReactDebugCurrentFrame = ReactDebugCurrentFrame;
+  }
+
+  // by calls to these methods by a Babel plugin.
+  //
+  // In PROD (or in packages without access to React internals),
+  // they are left as they are instead.
+
+  function warn(format) {
+    {
+      for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      printWarning('warn', format, args);
+    }
+  }
+  function error(format) {
+    {
+      for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+        args[_key2 - 1] = arguments[_key2];
+      }
+
+      printWarning('error', format, args);
+    }
+  }
+
+  function printWarning(level, format, args) {
+    // When changing this logic, you might want to also
+    // update consoleWithStackDev.www.js as well.
+    {
+      var ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+      var stack = ReactDebugCurrentFrame.getStackAddendum();
+
+      if (stack !== '') {
+        format += '%s';
+        args = args.concat([stack]);
+      }
+
+      var argsWithFormat = args.map(function (item) {
+        return '' + item;
+      }); // Careful: RN currently depends on this prefix
+
+      argsWithFormat.unshift('Warning: ' + format); // We intentionally don't use spread (or .apply) directly because it
+      // breaks IE9: https://github.com/facebook/react/issues/13610
+      // eslint-disable-next-line react-internal/no-production-logging
+
+      Function.prototype.apply.call(console[level], console, argsWithFormat);
+    }
+  }
+
+  var didWarnStateUpdateForUnmountedComponent = {};
+
+  function warnNoop(publicInstance, callerName) {
+    {
+      var _constructor = publicInstance.constructor;
+      var componentName = _constructor && (_constructor.displayName || _constructor.name) || 'ReactClass';
+      var warningKey = componentName + "." + callerName;
+
+      if (didWarnStateUpdateForUnmountedComponent[warningKey]) {
+        return;
+      }
+
+      error("Can't call %s on a component that is not yet mounted. " + 'This is a no-op, but it might indicate a bug in your application. ' + 'Instead, assign to `this.state` directly or define a `state = {};` ' + 'class property with the desired state in the %s component.', callerName, componentName);
+
+      didWarnStateUpdateForUnmountedComponent[warningKey] = true;
+    }
+  }
+  /**
+   * This is the abstract API for an update queue.
+   */
+
+
+  var ReactNoopUpdateQueue = {
+    /**
+     * Checks whether or not this composite component is mounted.
+     * @param {ReactClass} publicInstance The instance we want to test.
+     * @return {boolean} True if mounted, false otherwise.
+     * @protected
+     * @final
+     */
+    isMounted: function (publicInstance) {
+      return false;
+    },
+
+    /**
+     * Forces an update. This should only be invoked when it is known with
+     * certainty that we are **not** in a DOM transaction.
+     *
+     * You may want to call this when you know that some deeper aspect of the
+     * component's state has changed but `setState` was not called.
+     *
+     * This will not invoke `shouldComponentUpdate`, but it will invoke
+     * `componentWillUpdate` and `componentDidUpdate`.
+     *
+     * @param {ReactClass} publicInstance The instance that should rerender.
+     * @param {?function} callback Called after component is updated.
+     * @param {?string} callerName name of the calling function in the public API.
+     * @internal
+     */
+    enqueueForceUpdate: function (publicInstance, callback, callerName) {
+      warnNoop(publicInstance, 'forceUpdate');
+    },
+
+    /**
+     * Replaces all of the state. Always use this or `setState` to mutate state.
+     * You should treat `this.state` as immutable.
+     *
+     * There is no guarantee that `this.state` will be immediately updated, so
+     * accessing `this.state` after calling this method may return the old value.
+     *
+     * @param {ReactClass} publicInstance The instance that should rerender.
+     * @param {object} completeState Next state.
+     * @param {?function} callback Called after component is updated.
+     * @param {?string} callerName name of the calling function in the public API.
+     * @internal
+     */
+    enqueueReplaceState: function (publicInstance, completeState, callback, callerName) {
+      warnNoop(publicInstance, 'replaceState');
+    },
+
+    /**
+     * Sets a subset of the state. This only exists because _pendingState is
+     * internal. This provides a merging strategy that is not available to deep
+     * properties which is confusing. TODO: Expose pendingState or don't use it
+     * during the merge.
+     *
+     * @param {ReactClass} publicInstance The instance that should rerender.
+     * @param {object} partialState Next partial state to be merged with state.
+     * @param {?function} callback Called after component is updated.
+     * @param {?string} Name of the calling function in the public API.
+     * @internal
+     */
+    enqueueSetState: function (publicInstance, partialState, callback, callerName) {
+      warnNoop(publicInstance, 'setState');
+    }
+  };
+
+  var emptyObject = {};
+
+  {
+    Object.freeze(emptyObject);
+  }
+  /**
+   * Base class helpers for the updating state of a component.
+   */
+
+
+  function Component(props, context, updater) {
+    this.props = props;
+    this.context = context; // If a component has string refs, we will assign a different object later.
+
+    this.refs = emptyObject; // We initialize the default updater but the real one gets injected by the
+    // renderer.
+
+    this.updater = updater || ReactNoopUpdateQueue;
+  }
+
+  Component.prototype.isReactComponent = {};
+  /**
+   * Sets a subset of the state. Always use this to mutate
+   * state. You should treat `this.state` as immutable.
+   *
+   * There is no guarantee that `this.state` will be immediately updated, so
+   * accessing `this.state` after calling this method may return the old value.
+   *
+   * There is no guarantee that calls to `setState` will run synchronously,
+   * as they may eventually be batched together.  You can provide an optional
+   * callback that will be executed when the call to setState is actually
+   * completed.
+   *
+   * When a function is provided to setState, it will be called at some point in
+   * the future (not synchronously). It will be called with the up to date
+   * component arguments (state, props, context). These values can be different
+   * from this.* because your function may be called after receiveProps but before
+   * shouldComponentUpdate, and this new state, props, and context will not yet be
+   * assigned to this.
+   *
+   * @param {object|function} partialState Next partial state or function to
+   *        produce next partial state to be merged with current state.
+   * @param {?function} callback Called after state is updated.
+   * @final
+   * @protected
+   */
+
+  Component.prototype.setState = function (partialState, callback) {
+    if (!(typeof partialState === 'object' || typeof partialState === 'function' || partialState == null)) {
+      {
+        throw Error( "setState(...): takes an object of state variables to update or a function which returns an object of state variables." );
+      }
+    }
+
+    this.updater.enqueueSetState(this, partialState, callback, 'setState');
+  };
+  /**
+   * Forces an update. This should only be invoked when it is known with
+   * certainty that we are **not** in a DOM transaction.
+   *
+   * You may want to call this when you know that some deeper aspect of the
+   * component's state has changed but `setState` was not called.
+   *
+   * This will not invoke `shouldComponentUpdate`, but it will invoke
+   * `componentWillUpdate` and `componentDidUpdate`.
+   *
+   * @param {?function} callback Called after update is complete.
+   * @final
+   * @protected
+   */
+
+
+  Component.prototype.forceUpdate = function (callback) {
+    this.updater.enqueueForceUpdate(this, callback, 'forceUpdate');
+  };
+  /**
+   * Deprecated APIs. These APIs used to exist on classic React classes but since
+   * we would like to deprecate them, we're not going to move them over to this
+   * modern base class. Instead, we define a getter that warns if it's accessed.
+   */
+
+
+  {
+    var deprecatedAPIs = {
+      isMounted: ['isMounted', 'Instead, make sure to clean up subscriptions and pending requests in ' + 'componentWillUnmount to prevent memory leaks.'],
+      replaceState: ['replaceState', 'Refactor your code to use setState instead (see ' + 'https://github.com/facebook/react/issues/3236).']
+    };
+
+    var defineDeprecationWarning = function (methodName, info) {
+      Object.defineProperty(Component.prototype, methodName, {
+        get: function () {
+          warn('%s(...) is deprecated in plain JavaScript React classes. %s', info[0], info[1]);
+
+          return undefined;
+        }
+      });
+    };
+
+    for (var fnName in deprecatedAPIs) {
+      if (deprecatedAPIs.hasOwnProperty(fnName)) {
+        defineDeprecationWarning(fnName, deprecatedAPIs[fnName]);
+      }
+    }
+  }
+
+  function ComponentDummy() {}
+
+  ComponentDummy.prototype = Component.prototype;
+  /**
+   * Convenience component with default shallow equality check for sCU.
+   */
+
+  function PureComponent(props, context, updater) {
+    this.props = props;
+    this.context = context; // If a component has string refs, we will assign a different object later.
+
+    this.refs = emptyObject;
+    this.updater = updater || ReactNoopUpdateQueue;
+  }
+
+  var pureComponentPrototype = PureComponent.prototype = new ComponentDummy();
+  pureComponentPrototype.constructor = PureComponent; // Avoid an extra prototype jump for these methods.
+
+  assign(pureComponentPrototype, Component.prototype);
+
+  pureComponentPrototype.isPureReactComponent = true;
+
+  // an immutable object with a single mutable value
+  function createRef() {
+    var refObject = {
+      current: null
+    };
+
+    {
+      Object.seal(refObject);
+    }
+
+    return refObject;
+  }
+
+  function getWrappedName(outerType, innerType, wrapperName) {
+    var functionName = innerType.displayName || innerType.name || '';
+    return outerType.displayName || (functionName !== '' ? wrapperName + "(" + functionName + ")" : wrapperName);
+  }
+
+  function getContextName(type) {
+    return type.displayName || 'Context';
+  }
+
+  function getComponentName(type) {
+    if (type == null) {
+      // Host root, text node or just invalid type.
+      return null;
+    }
+
+    {
+      if (typeof type.tag === 'number') {
+        error('Received an unexpected object in getComponentName(). ' + 'This is likely a bug in React. Please file an issue.');
+      }
+    }
+
+    if (typeof type === 'function') {
+      return type.displayName || type.name || null;
+    }
+
+    if (typeof type === 'string') {
+      return type;
+    }
+
+    switch (type) {
+      case exports.Fragment:
+        return 'Fragment';
+
+      case REACT_PORTAL_TYPE:
+        return 'Portal';
+
+      case exports.Profiler:
+        return 'Profiler';
+
+      case exports.StrictMode:
+        return 'StrictMode';
+
+      case exports.Suspense:
+        return 'Suspense';
+
+      case REACT_SUSPENSE_LIST_TYPE:
+        return 'SuspenseList';
+    }
+
+    if (typeof type === 'object') {
+      switch (type.$$typeof) {
+        case REACT_CONTEXT_TYPE:
+          var context = type;
+          return getContextName(context) + '.Consumer';
+
+        case REACT_PROVIDER_TYPE:
+          var provider = type;
+          return getContextName(provider._context) + '.Provider';
+
+        case REACT_FORWARD_REF_TYPE:
+          return getWrappedName(type, type.render, 'ForwardRef');
+
+        case REACT_MEMO_TYPE:
+          return getComponentName(type.type);
+
+        case REACT_BLOCK_TYPE:
+          return getComponentName(type._render);
+
+        case REACT_LAZY_TYPE:
+          {
+            var lazyComponent = type;
+            var payload = lazyComponent._payload;
+            var init = lazyComponent._init;
+
+            try {
+              return getComponentName(init(payload));
+            } catch (x) {
+              return null;
+            }
+          }
+      }
+    }
+
+    return null;
+  }
+
+  var hasOwnProperty$1 = Object.prototype.hasOwnProperty;
+  var RESERVED_PROPS = {
+    key: true,
+    ref: true,
+    __self: true,
+    __source: true
+  };
+  var specialPropKeyWarningShown, specialPropRefWarningShown, didWarnAboutStringRefs;
+
+  {
+    didWarnAboutStringRefs = {};
+  }
+
+  function hasValidRef(config) {
+    {
+      if (hasOwnProperty$1.call(config, 'ref')) {
+        var getter = Object.getOwnPropertyDescriptor(config, 'ref').get;
+
+        if (getter && getter.isReactWarning) {
+          return false;
+        }
+      }
+    }
+
+    return config.ref !== undefined;
+  }
+
+  function hasValidKey(config) {
+    {
+      if (hasOwnProperty$1.call(config, 'key')) {
+        var getter = Object.getOwnPropertyDescriptor(config, 'key').get;
+
+        if (getter && getter.isReactWarning) {
+          return false;
+        }
+      }
+    }
+
+    return config.key !== undefined;
+  }
+
+  function defineKeyPropWarningGetter(props, displayName) {
+    var warnAboutAccessingKey = function () {
+      {
+        if (!specialPropKeyWarningShown) {
+          specialPropKeyWarningShown = true;
+
+          error('%s: `key` is not a prop. Trying to access it will result ' + 'in `undefined` being returned. If you need to access the same ' + 'value within the child component, you should pass it as a different ' + 'prop. (https://reactjs.org/link/special-props)', displayName);
+        }
+      }
+    };
+
+    warnAboutAccessingKey.isReactWarning = true;
+    Object.defineProperty(props, 'key', {
+      get: warnAboutAccessingKey,
+      configurable: true
+    });
+  }
+
+  function defineRefPropWarningGetter(props, displayName) {
+    var warnAboutAccessingRef = function () {
+      {
+        if (!specialPropRefWarningShown) {
+          specialPropRefWarningShown = true;
+
+          error('%s: `ref` is not a prop. Trying to access it will result ' + 'in `undefined` being returned. If you need to access the same ' + 'value within the child component, you should pass it as a different ' + 'prop. (https://reactjs.org/link/special-props)', displayName);
+        }
+      }
+    };
+
+    warnAboutAccessingRef.isReactWarning = true;
+    Object.defineProperty(props, 'ref', {
+      get: warnAboutAccessingRef,
+      configurable: true
+    });
+  }
+
+  function warnIfStringRefCannotBeAutoConverted(config) {
+    {
+      if (typeof config.ref === 'string' && ReactCurrentOwner.current && config.__self && ReactCurrentOwner.current.stateNode !== config.__self) {
+        var componentName = getComponentName(ReactCurrentOwner.current.type);
+
+        if (!didWarnAboutStringRefs[componentName]) {
+          error('Component "%s" contains the string ref "%s". ' + 'Support for string refs will be removed in a future major release. ' + 'This case cannot be automatically converted to an arrow function. ' + 'We ask you to manually fix this case by using useRef() or createRef() instead. ' + 'Learn more about using refs safely here: ' + 'https://reactjs.org/link/strict-mode-string-ref', componentName, config.ref);
+
+          didWarnAboutStringRefs[componentName] = true;
+        }
+      }
+    }
+  }
+  /**
+   * Factory method to create a new React element. This no longer adheres to
+   * the class pattern, so do not use new to call it. Also, instanceof check
+   * will not work. Instead test $$typeof field against Symbol.for('react.element') to check
+   * if something is a React Element.
+   *
+   * @param {*} type
+   * @param {*} props
+   * @param {*} key
+   * @param {string|object} ref
+   * @param {*} owner
+   * @param {*} self A *temporary* helper to detect places where `this` is
+   * different from the `owner` when React.createElement is called, so that we
+   * can warn. We want to get rid of owner and replace string `ref`s with arrow
+   * functions, and as long as `this` and owner are the same, there will be no
+   * change in behavior.
+   * @param {*} source An annotation object (added by a transpiler or otherwise)
+   * indicating filename, line number, and/or other information.
+   * @internal
+   */
+
+
+  var ReactElement = function (type, key, ref, self, source, owner, props) {
+    var element = {
+      // This tag allows us to uniquely identify this as a React Element
+      $$typeof: REACT_ELEMENT_TYPE,
+      // Built-in properties that belong on the element
+      type: type,
+      key: key,
+      ref: ref,
+      props: props,
+      // Record the component responsible for creating this element.
+      _owner: owner
+    };
+
+    {
+      // The validation flag is currently mutative. We put it on
+      // an external backing store so that we can freeze the whole object.
+      // This can be replaced with a WeakMap once they are implemented in
+      // commonly used development environments.
+      element._store = {}; // To make comparing ReactElements easier for testing purposes, we make
+      // the validation flag non-enumerable (where possible, which should
+      // include every environment we run tests in), so the test framework
+      // ignores it.
+
+      Object.defineProperty(element._store, 'validated', {
+        configurable: false,
+        enumerable: false,
+        writable: true,
+        value: false
+      }); // self and source are DEV only properties.
+
+      Object.defineProperty(element, '_self', {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: self
+      }); // Two elements created in two different places should be considered
+      // equal for testing purposes and therefore we hide it from enumeration.
+
+      Object.defineProperty(element, '_source', {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: source
+      });
+
+      if (Object.freeze) {
+        Object.freeze(element.props);
+        Object.freeze(element);
+      }
+    }
+
+    return element;
+  };
+  /**
+   * Create and return a new ReactElement of the given type.
+   * See https://reactjs.org/docs/react-api.html#createelement
+   */
+
+  function createElement(type, config, children) {
+    var propName; // Reserved names are extracted
+
+    var props = {};
+    var key = null;
+    var ref = null;
+    var self = null;
+    var source = null;
+
+    if (config != null) {
+      if (hasValidRef(config)) {
+        ref = config.ref;
+
+        {
+          warnIfStringRefCannotBeAutoConverted(config);
+        }
+      }
+
+      if (hasValidKey(config)) {
+        key = '' + config.key;
+      }
+
+      self = config.__self === undefined ? null : config.__self;
+      source = config.__source === undefined ? null : config.__source; // Remaining properties are added to a new props object
+
+      for (propName in config) {
+        if (hasOwnProperty$1.call(config, propName) && !RESERVED_PROPS.hasOwnProperty(propName)) {
+          props[propName] = config[propName];
+        }
+      }
+    } // Children can be more than one argument, and those are transferred onto
+    // the newly allocated props object.
+
+
+    var childrenLength = arguments.length - 2;
+
+    if (childrenLength === 1) {
+      props.children = children;
+    } else if (childrenLength > 1) {
+      var childArray = Array(childrenLength);
+
+      for (var i = 0; i < childrenLength; i++) {
+        childArray[i] = arguments[i + 2];
+      }
+
+      {
+        if (Object.freeze) {
+          Object.freeze(childArray);
+        }
+      }
+
+      props.children = childArray;
+    } // Resolve default props
+
+
+    if (type && type.defaultProps) {
+      var defaultProps = type.defaultProps;
+
+      for (propName in defaultProps) {
+        if (props[propName] === undefined) {
+          props[propName] = defaultProps[propName];
+        }
+      }
+    }
+
+    {
+      if (key || ref) {
+        var displayName = typeof type === 'function' ? type.displayName || type.name || 'Unknown' : type;
+
+        if (key) {
+          defineKeyPropWarningGetter(props, displayName);
+        }
+
+        if (ref) {
+          defineRefPropWarningGetter(props, displayName);
+        }
+      }
+    }
+
+    return ReactElement(type, key, ref, self, source, ReactCurrentOwner.current, props);
+  }
+  function cloneAndReplaceKey(oldElement, newKey) {
+    var newElement = ReactElement(oldElement.type, newKey, oldElement.ref, oldElement._self, oldElement._source, oldElement._owner, oldElement.props);
+    return newElement;
+  }
+  /**
+   * Clone and return a new ReactElement using element as the starting point.
+   * See https://reactjs.org/docs/react-api.html#cloneelement
+   */
+
+  function cloneElement(element, config, children) {
+    if (!!(element === null || element === undefined)) {
+      {
+        throw Error( "React.cloneElement(...): The argument must be a React element, but you passed " + element + "." );
+      }
+    }
+
+    var propName; // Original props are copied
+
+    var props = assign({}, element.props); // Reserved names are extracted
+
+
+    var key = element.key;
+    var ref = element.ref; // Self is preserved since the owner is preserved.
+
+    var self = element._self; // Source is preserved since cloneElement is unlikely to be targeted by a
+    // transpiler, and the original source is probably a better indicator of the
+    // true owner.
+
+    var source = element._source; // Owner will be preserved, unless ref is overridden
+
+    var owner = element._owner;
+
+    if (config != null) {
+      if (hasValidRef(config)) {
+        // Silently steal the ref from the parent.
+        ref = config.ref;
+        owner = ReactCurrentOwner.current;
+      }
+
+      if (hasValidKey(config)) {
+        key = '' + config.key;
+      } // Remaining properties override existing props
+
+
+      var defaultProps;
+
+      if (element.type && element.type.defaultProps) {
+        defaultProps = element.type.defaultProps;
+      }
+
+      for (propName in config) {
+        if (hasOwnProperty$1.call(config, propName) && !RESERVED_PROPS.hasOwnProperty(propName)) {
+          if (config[propName] === undefined && defaultProps !== undefined) {
+            // Resolve default props
+            props[propName] = defaultProps[propName];
+          } else {
+            props[propName] = config[propName];
+          }
+        }
+      }
+    } // Children can be more than one argument, and those are transferred onto
+    // the newly allocated props object.
+
+
+    var childrenLength = arguments.length - 2;
+
+    if (childrenLength === 1) {
+      props.children = children;
+    } else if (childrenLength > 1) {
+      var childArray = Array(childrenLength);
+
+      for (var i = 0; i < childrenLength; i++) {
+        childArray[i] = arguments[i + 2];
+      }
+
+      props.children = childArray;
+    }
+
+    return ReactElement(element.type, key, ref, self, source, owner, props);
+  }
+  /**
+   * Verifies the object is a ReactElement.
+   * See https://reactjs.org/docs/react-api.html#isvalidelement
+   * @param {?object} object
+   * @return {boolean} True if `object` is a ReactElement.
+   * @final
+   */
+
+  function isValidElement(object) {
+    return typeof object === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
+  }
+
+  var SEPARATOR = '.';
+  var SUBSEPARATOR = ':';
+  /**
+   * Escape and wrap key so it is safe to use as a reactid
+   *
+   * @param {string} key to be escaped.
+   * @return {string} the escaped key.
+   */
+
+  function escape(key) {
+    var escapeRegex = /[=:]/g;
+    var escaperLookup = {
+      '=': '=0',
+      ':': '=2'
+    };
+    var escapedString = key.replace(escapeRegex, function (match) {
+      return escaperLookup[match];
+    });
+    return '$' + escapedString;
+  }
+  /**
+   * TODO: Test that a single child and an array with one item have the same key
+   * pattern.
+   */
+
+
+  var didWarnAboutMaps = false;
+  var userProvidedKeyEscapeRegex = /\/+/g;
+
+  function escapeUserProvidedKey(text) {
+    return text.replace(userProvidedKeyEscapeRegex, '$&/');
+  }
+  /**
+   * Generate a key string that identifies a element within a set.
+   *
+   * @param {*} element A element that could contain a manual key.
+   * @param {number} index Index that is used if a manual key is not provided.
+   * @return {string}
+   */
+
+
+  function getElementKey(element, index) {
+    // Do some typechecking here since we call this blindly. We want to ensure
+    // that we don't block potential future ES APIs.
+    if (typeof element === 'object' && element !== null && element.key != null) {
+      // Explicit key
+      return escape('' + element.key);
+    } // Implicit key determined by the index in the set
+
+
+    return index.toString(36);
+  }
+
+  function mapIntoArray(children, array, escapedPrefix, nameSoFar, callback) {
+    var type = typeof children;
+
+    if (type === 'undefined' || type === 'boolean') {
+      // All of the above are perceived as null.
+      children = null;
+    }
+
+    var invokeCallback = false;
+
+    if (children === null) {
+      invokeCallback = true;
+    } else {
+      switch (type) {
+        case 'string':
+        case 'number':
+          invokeCallback = true;
+          break;
+
+        case 'object':
+          switch (children.$$typeof) {
+            case REACT_ELEMENT_TYPE:
+            case REACT_PORTAL_TYPE:
+              invokeCallback = true;
+          }
+
+      }
+    }
+
+    if (invokeCallback) {
+      var _child = children;
+      var mappedChild = callback(_child); // If it's the only child, treat the name as if it was wrapped in an array
+      // so that it's consistent if the number of children grows:
+
+      var childKey = nameSoFar === '' ? SEPARATOR + getElementKey(_child, 0) : nameSoFar;
+
+      if (Array.isArray(mappedChild)) {
+        var escapedChildKey = '';
+
+        if (childKey != null) {
+          escapedChildKey = escapeUserProvidedKey(childKey) + '/';
+        }
+
+        mapIntoArray(mappedChild, array, escapedChildKey, '', function (c) {
+          return c;
+        });
+      } else if (mappedChild != null) {
+        if (isValidElement(mappedChild)) {
+          mappedChild = cloneAndReplaceKey(mappedChild, // Keep both the (mapped) and old keys if they differ, just as
+          // traverseAllChildren used to do for objects as children
+          escapedPrefix + ( // $FlowFixMe Flow incorrectly thinks React.Portal doesn't have a key
+          mappedChild.key && (!_child || _child.key !== mappedChild.key) ? // $FlowFixMe Flow incorrectly thinks existing element's key can be a number
+          escapeUserProvidedKey('' + mappedChild.key) + '/' : '') + childKey);
+        }
+
+        array.push(mappedChild);
+      }
+
+      return 1;
+    }
+
+    var child;
+    var nextName;
+    var subtreeCount = 0; // Count of children found in the current subtree.
+
+    var nextNamePrefix = nameSoFar === '' ? SEPARATOR : nameSoFar + SUBSEPARATOR;
+
+    if (Array.isArray(children)) {
+      for (var i = 0; i < children.length; i++) {
+        child = children[i];
+        nextName = nextNamePrefix + getElementKey(child, i);
+        subtreeCount += mapIntoArray(child, array, escapedPrefix, nextName, callback);
+      }
+    } else {
+      var iteratorFn = getIteratorFn(children);
+
+      if (typeof iteratorFn === 'function') {
+        var iterableChildren = children;
+
+        {
+          // Warn about using Maps as children
+          if (iteratorFn === iterableChildren.entries) {
+            if (!didWarnAboutMaps) {
+              warn('Using Maps as children is not supported. ' + 'Use an array of keyed ReactElements instead.');
+            }
+
+            didWarnAboutMaps = true;
+          }
+        }
+
+        var iterator = iteratorFn.call(iterableChildren);
+        var step;
+        var ii = 0;
+
+        while (!(step = iterator.next()).done) {
+          child = step.value;
+          nextName = nextNamePrefix + getElementKey(child, ii++);
+          subtreeCount += mapIntoArray(child, array, escapedPrefix, nextName, callback);
+        }
+      } else if (type === 'object') {
+        var childrenString = '' + children;
+
+        {
+          {
+            throw Error( "Objects are not valid as a React child (found: " + (childrenString === '[object Object]' ? 'object with keys {' + Object.keys(children).join(', ') + '}' : childrenString) + "). If you meant to render a collection of children, use an array instead." );
+          }
+        }
+      }
+    }
+
+    return subtreeCount;
+  }
+
+  /**
+   * Maps children that are typically specified as `props.children`.
+   *
+   * See https://reactjs.org/docs/react-api.html#reactchildrenmap
+   *
+   * The provided mapFunction(child, index) will be called for each
+   * leaf child.
+   *
+   * @param {?*} children Children tree container.
+   * @param {function(*, int)} func The map function.
+   * @param {*} context Context for mapFunction.
+   * @return {object} Object containing the ordered map of results.
+   */
+  function mapChildren(children, func, context) {
+    if (children == null) {
+      return children;
+    }
+
+    var result = [];
+    var count = 0;
+    mapIntoArray(children, result, '', '', function (child) {
+      return func.call(context, child, count++);
+    });
+    return result;
+  }
+  /**
+   * Count the number of children that are typically specified as
+   * `props.children`.
+   *
+   * See https://reactjs.org/docs/react-api.html#reactchildrencount
+   *
+   * @param {?*} children Children tree container.
+   * @return {number} The number of children.
+   */
+
+
+  function countChildren(children) {
+    var n = 0;
+    mapChildren(children, function () {
+      n++; // Don't return anything
+    });
+    return n;
+  }
+
+  /**
+   * Iterates through children that are typically specified as `props.children`.
+   *
+   * See https://reactjs.org/docs/react-api.html#reactchildrenforeach
+   *
+   * The provided forEachFunc(child, index) will be called for each
+   * leaf child.
+   *
+   * @param {?*} children Children tree container.
+   * @param {function(*, int)} forEachFunc
+   * @param {*} forEachContext Context for forEachContext.
+   */
+  function forEachChildren(children, forEachFunc, forEachContext) {
+    mapChildren(children, function () {
+      forEachFunc.apply(this, arguments); // Don't return anything.
+    }, forEachContext);
+  }
+  /**
+   * Flatten a children object (typically specified as `props.children`) and
+   * return an array with appropriately re-keyed children.
+   *
+   * See https://reactjs.org/docs/react-api.html#reactchildrentoarray
+   */
+
+
+  function toArray(children) {
+    return mapChildren(children, function (child) {
+      return child;
+    }) || [];
+  }
+  /**
+   * Returns the first child in a collection of children and verifies that there
+   * is only one child in the collection.
+   *
+   * See https://reactjs.org/docs/react-api.html#reactchildrenonly
+   *
+   * The current implementation of this function assumes that a single child gets
+   * passed without a wrapper, but the purpose of this helper function is to
+   * abstract away the particular structure of children.
+   *
+   * @param {?object} children Child collection structure.
+   * @return {ReactElement} The first and only `ReactElement` contained in the
+   * structure.
+   */
+
+
+  function onlyChild(children) {
+    if (!isValidElement(children)) {
+      {
+        throw Error( "React.Children.only expected to receive a single React element child." );
+      }
+    }
+
+    return children;
+  }
+
+  function createContext(defaultValue, calculateChangedBits) {
+    if (calculateChangedBits === undefined) {
+      calculateChangedBits = null;
+    } else {
+      {
+        if (calculateChangedBits !== null && typeof calculateChangedBits !== 'function') {
+          error('createContext: Expected the optional second argument to be a ' + 'function. Instead received: %s', calculateChangedBits);
+        }
+      }
+    }
+
+    var context = {
+      $$typeof: REACT_CONTEXT_TYPE,
+      _calculateChangedBits: calculateChangedBits,
+      // As a workaround to support multiple concurrent renderers, we categorize
+      // some renderers as primary and others as secondary. We only expect
+      // there to be two concurrent renderers at most: React Native (primary) and
+      // Fabric (secondary); React DOM (primary) and React ART (secondary).
+      // Secondary renderers store their context values on separate fields.
+      _currentValue: defaultValue,
+      _currentValue2: defaultValue,
+      // Used to track how many concurrent renderers this context currently
+      // supports within in a single renderer. Such as parallel server rendering.
+      _threadCount: 0,
+      // These are circular
+      Provider: null,
+      Consumer: null
+    };
+    context.Provider = {
+      $$typeof: REACT_PROVIDER_TYPE,
+      _context: context
+    };
+    var hasWarnedAboutUsingNestedContextConsumers = false;
+    var hasWarnedAboutUsingConsumerProvider = false;
+    var hasWarnedAboutDisplayNameOnConsumer = false;
+
+    {
+      // A separate object, but proxies back to the original context object for
+      // backwards compatibility. It has a different $$typeof, so we can properly
+      // warn for the incorrect usage of Context as a Consumer.
+      var Consumer = {
+        $$typeof: REACT_CONTEXT_TYPE,
+        _context: context,
+        _calculateChangedBits: context._calculateChangedBits
+      }; // $FlowFixMe: Flow complains about not setting a value, which is intentional here
+
+      Object.defineProperties(Consumer, {
+        Provider: {
+          get: function () {
+            if (!hasWarnedAboutUsingConsumerProvider) {
+              hasWarnedAboutUsingConsumerProvider = true;
+
+              error('Rendering <Context.Consumer.Provider> is not supported and will be removed in ' + 'a future major release. Did you mean to render <Context.Provider> instead?');
+            }
+
+            return context.Provider;
+          },
+          set: function (_Provider) {
+            context.Provider = _Provider;
+          }
+        },
+        _currentValue: {
+          get: function () {
+            return context._currentValue;
+          },
+          set: function (_currentValue) {
+            context._currentValue = _currentValue;
+          }
+        },
+        _currentValue2: {
+          get: function () {
+            return context._currentValue2;
+          },
+          set: function (_currentValue2) {
+            context._currentValue2 = _currentValue2;
+          }
+        },
+        _threadCount: {
+          get: function () {
+            return context._threadCount;
+          },
+          set: function (_threadCount) {
+            context._threadCount = _threadCount;
+          }
+        },
+        Consumer: {
+          get: function () {
+            if (!hasWarnedAboutUsingNestedContextConsumers) {
+              hasWarnedAboutUsingNestedContextConsumers = true;
+
+              error('Rendering <Context.Consumer.Consumer> is not supported and will be removed in ' + 'a future major release. Did you mean to render <Context.Consumer> instead?');
+            }
+
+            return context.Consumer;
+          }
+        },
+        displayName: {
+          get: function () {
+            return context.displayName;
+          },
+          set: function (displayName) {
+            if (!hasWarnedAboutDisplayNameOnConsumer) {
+              warn('Setting `displayName` on Context.Consumer has no effect. ' + "You should set it directly on the context with Context.displayName = '%s'.", displayName);
+
+              hasWarnedAboutDisplayNameOnConsumer = true;
+            }
+          }
+        }
+      }); // $FlowFixMe: Flow complains about missing properties because it doesn't understand defineProperty
+
+      context.Consumer = Consumer;
+    }
+
+    {
+      context._currentRenderer = null;
+      context._currentRenderer2 = null;
+    }
+
+    return context;
+  }
+
+  var Uninitialized = -1;
+  var Pending = 0;
+  var Resolved = 1;
+  var Rejected = 2;
+
+  function lazyInitializer(payload) {
+    if (payload._status === Uninitialized) {
+      var ctor = payload._result;
+      var thenable = ctor(); // Transition to the next state.
+
+      var pending = payload;
+      pending._status = Pending;
+      pending._result = thenable;
+      thenable.then(function (moduleObject) {
+        if (payload._status === Pending) {
+          var defaultExport = moduleObject.default;
+
+          {
+            if (defaultExport === undefined) {
+              error('lazy: Expected the result of a dynamic import() call. ' + 'Instead received: %s\n\nYour code should look like: \n  ' + // Break up imports to avoid accidentally parsing them as dependencies.
+              'const MyComponent = lazy(() => imp' + "ort('./MyComponent'))", moduleObject);
+            }
+          } // Transition to the next state.
+
+
+          var resolved = payload;
+          resolved._status = Resolved;
+          resolved._result = defaultExport;
+        }
+      }, function (error) {
+        if (payload._status === Pending) {
+          // Transition to the next state.
+          var rejected = payload;
+          rejected._status = Rejected;
+          rejected._result = error;
+        }
+      });
+    }
+
+    if (payload._status === Resolved) {
+      return payload._result;
+    } else {
+      throw payload._result;
+    }
+  }
+
+  function lazy(ctor) {
+    var payload = {
+      // We use these fields to store the result.
+      _status: -1,
+      _result: ctor
+    };
+    var lazyType = {
+      $$typeof: REACT_LAZY_TYPE,
+      _payload: payload,
+      _init: lazyInitializer
+    };
+
+    {
+      // In production, this would just set it on the object.
+      var defaultProps;
+      var propTypes; // $FlowFixMe
+
+      Object.defineProperties(lazyType, {
+        defaultProps: {
+          configurable: true,
+          get: function () {
+            return defaultProps;
+          },
+          set: function (newDefaultProps) {
+            error('React.lazy(...): It is not supported to assign `defaultProps` to ' + 'a lazy component import. Either specify them where the component ' + 'is defined, or create a wrapping component around it.');
+
+            defaultProps = newDefaultProps; // Match production behavior more closely:
+            // $FlowFixMe
+
+            Object.defineProperty(lazyType, 'defaultProps', {
+              enumerable: true
+            });
+          }
+        },
+        propTypes: {
+          configurable: true,
+          get: function () {
+            return propTypes;
+          },
+          set: function (newPropTypes) {
+            error('React.lazy(...): It is not supported to assign `propTypes` to ' + 'a lazy component import. Either specify them where the component ' + 'is defined, or create a wrapping component around it.');
+
+            propTypes = newPropTypes; // Match production behavior more closely:
+            // $FlowFixMe
+
+            Object.defineProperty(lazyType, 'propTypes', {
+              enumerable: true
+            });
+          }
+        }
+      });
+    }
+
+    return lazyType;
+  }
+
+  function forwardRef(render) {
+    {
+      if (render != null && render.$$typeof === REACT_MEMO_TYPE) {
+        error('forwardRef requires a render function but received a `memo` ' + 'component. Instead of forwardRef(memo(...)), use ' + 'memo(forwardRef(...)).');
+      } else if (typeof render !== 'function') {
+        error('forwardRef requires a render function but was given %s.', render === null ? 'null' : typeof render);
+      } else {
+        if (render.length !== 0 && render.length !== 2) {
+          error('forwardRef render functions accept exactly two parameters: props and ref. %s', render.length === 1 ? 'Did you forget to use the ref parameter?' : 'Any additional parameter will be undefined.');
+        }
+      }
+
+      if (render != null) {
+        if (render.defaultProps != null || render.propTypes != null) {
+          error('forwardRef render functions do not support propTypes or defaultProps. ' + 'Did you accidentally pass a React component?');
+        }
+      }
+    }
+
+    var elementType = {
+      $$typeof: REACT_FORWARD_REF_TYPE,
+      render: render
+    };
+
+    {
+      var ownName;
+      Object.defineProperty(elementType, 'displayName', {
+        enumerable: false,
+        configurable: true,
+        get: function () {
+          return ownName;
+        },
+        set: function (name) {
+          ownName = name;
+
+          if (render.displayName == null) {
+            render.displayName = name;
+          }
+        }
+      });
+    }
+
+    return elementType;
+  }
+
+  // Filter certain DOM attributes (e.g. src, href) if their values are empty strings.
+
+  var enableScopeAPI = false; // Experimental Create Event Handle API.
+
+  function isValidElementType(type) {
+    if (typeof type === 'string' || typeof type === 'function') {
+      return true;
+    } // Note: typeof might be other than 'symbol' or 'number' (e.g. if it's a polyfill).
+
+
+    if (type === exports.Fragment || type === exports.Profiler || type === REACT_DEBUG_TRACING_MODE_TYPE || type === exports.StrictMode || type === exports.Suspense || type === REACT_SUSPENSE_LIST_TYPE || type === REACT_LEGACY_HIDDEN_TYPE || enableScopeAPI ) {
+      return true;
+    }
+
+    if (typeof type === 'object' && type !== null) {
+      if (type.$$typeof === REACT_LAZY_TYPE || type.$$typeof === REACT_MEMO_TYPE || type.$$typeof === REACT_PROVIDER_TYPE || type.$$typeof === REACT_CONTEXT_TYPE || type.$$typeof === REACT_FORWARD_REF_TYPE || type.$$typeof === REACT_FUNDAMENTAL_TYPE || type.$$typeof === REACT_BLOCK_TYPE || type[0] === REACT_SERVER_BLOCK_TYPE) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function memo(type, compare) {
+    {
+      if (!isValidElementType(type)) {
+        error('memo: The first argument must be a component. Instead ' + 'received: %s', type === null ? 'null' : typeof type);
+      }
+    }
+
+    var elementType = {
+      $$typeof: REACT_MEMO_TYPE,
+      type: type,
+      compare: compare === undefined ? null : compare
+    };
+
+    {
+      var ownName;
+      Object.defineProperty(elementType, 'displayName', {
+        enumerable: false,
+        configurable: true,
+        get: function () {
+          return ownName;
+        },
+        set: function (name) {
+          ownName = name;
+
+          if (type.displayName == null) {
+            type.displayName = name;
+          }
+        }
+      });
+    }
+
+    return elementType;
+  }
+
+  function resolveDispatcher() {
+    var dispatcher = ReactCurrentDispatcher.current;
+
+    if (!(dispatcher !== null)) {
+      {
+        throw Error( "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem." );
+      }
+    }
+
+    return dispatcher;
+  }
+
+  function useContext(Context, unstable_observedBits) {
+    var dispatcher = resolveDispatcher();
+
+    {
+      if (unstable_observedBits !== undefined) {
+        error('useContext() second argument is reserved for future ' + 'use in React. Passing it is not supported. ' + 'You passed: %s.%s', unstable_observedBits, typeof unstable_observedBits === 'number' && Array.isArray(arguments[2]) ? '\n\nDid you call array.map(useContext)? ' + 'Calling Hooks inside a loop is not supported. ' + 'Learn more at https://reactjs.org/link/rules-of-hooks' : '');
+      } // TODO: add a more generic warning for invalid values.
+
+
+      if (Context._context !== undefined) {
+        var realContext = Context._context; // Don't deduplicate because this legitimately causes bugs
+        // and nobody should be using this in existing code.
+
+        if (realContext.Consumer === Context) {
+          error('Calling useContext(Context.Consumer) is not supported, may cause bugs, and will be ' + 'removed in a future major release. Did you mean to call useContext(Context) instead?');
+        } else if (realContext.Provider === Context) {
+          error('Calling useContext(Context.Provider) is not supported. ' + 'Did you mean to call useContext(Context) instead?');
+        }
+      }
+    }
+
+    return dispatcher.useContext(Context, unstable_observedBits);
+  }
+  function useState(initialState) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useState(initialState);
+  }
+  function useReducer(reducer, initialArg, init) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useReducer(reducer, initialArg, init);
+  }
+  function useRef(initialValue) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useRef(initialValue);
+  }
+  function useEffect(create, deps) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useEffect(create, deps);
+  }
+  function useLayoutEffect(create, deps) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useLayoutEffect(create, deps);
+  }
+  function useCallback(callback, deps) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useCallback(callback, deps);
+  }
+  function useMemo(create, deps) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useMemo(create, deps);
+  }
+  function useImperativeHandle(ref, create, deps) {
+    var dispatcher = resolveDispatcher();
+    return dispatcher.useImperativeHandle(ref, create, deps);
+  }
+  function useDebugValue(value, formatterFn) {
+    {
+      var dispatcher = resolveDispatcher();
+      return dispatcher.useDebugValue(value, formatterFn);
+    }
+  }
+
+  // Helpers to patch console.logs to avoid logging during side-effect free
+  // replaying on render function. This currently only patches the object
+  // lazily which won't cover if the log function was extracted eagerly.
+  // We could also eagerly patch the method.
+  var disabledDepth = 0;
+  var prevLog;
+  var prevInfo;
+  var prevWarn;
+  var prevError;
+  var prevGroup;
+  var prevGroupCollapsed;
+  var prevGroupEnd;
+
+  function disabledLog() {}
+
+  disabledLog.__reactDisabledLog = true;
+  function disableLogs() {
+    {
+      if (disabledDepth === 0) {
+        /* eslint-disable react-internal/no-production-logging */
+        prevLog = console.log;
+        prevInfo = console.info;
+        prevWarn = console.warn;
+        prevError = console.error;
+        prevGroup = console.group;
+        prevGroupCollapsed = console.groupCollapsed;
+        prevGroupEnd = console.groupEnd; // https://github.com/facebook/react/issues/19099
+
+        var props = {
+          configurable: true,
+          enumerable: true,
+          value: disabledLog,
+          writable: true
+        }; // $FlowFixMe Flow thinks console is immutable.
+
+        Object.defineProperties(console, {
+          info: props,
+          log: props,
+          warn: props,
+          error: props,
+          group: props,
+          groupCollapsed: props,
+          groupEnd: props
+        });
+        /* eslint-enable react-internal/no-production-logging */
+      }
+
+      disabledDepth++;
+    }
+  }
+  function reenableLogs() {
+    {
+      disabledDepth--;
+
+      if (disabledDepth === 0) {
+        /* eslint-disable react-internal/no-production-logging */
+        var props = {
+          configurable: true,
+          enumerable: true,
+          writable: true
+        }; // $FlowFixMe Flow thinks console is immutable.
+
+        Object.defineProperties(console, {
+          log: assign({}, props, {
+            value: prevLog
+          }),
+          info: assign({}, props, {
+            value: prevInfo
+          }),
+          warn: assign({}, props, {
+            value: prevWarn
+          }),
+          error: assign({}, props, {
+            value: prevError
+          }),
+          group: assign({}, props, {
+            value: prevGroup
+          }),
+          groupCollapsed: assign({}, props, {
+            value: prevGroupCollapsed
+          }),
+          groupEnd: assign({}, props, {
+            value: prevGroupEnd
+          })
+        });
+        /* eslint-enable react-internal/no-production-logging */
+      }
+
+      if (disabledDepth < 0) {
+        error('disabledDepth fell below zero. ' + 'This is a bug in React. Please file an issue.');
+      }
+    }
+  }
+
+  var ReactCurrentDispatcher$1 = ReactSharedInternals.ReactCurrentDispatcher;
+  var prefix;
+  function describeBuiltInComponentFrame(name, source, ownerFn) {
+    {
+      if (prefix === undefined) {
+        // Extract the VM specific prefix used by each line.
+        try {
+          throw Error();
+        } catch (x) {
+          var match = x.stack.trim().match(/\n( *(at )?)/);
+          prefix = match && match[1] || '';
+        }
+      } // We use the prefix to ensure our stacks line up with native stack frames.
+
+
+      return '\n' + prefix + name;
+    }
+  }
+  var reentry = false;
+  var componentFrameCache;
+
+  {
+    var PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
+    componentFrameCache = new PossiblyWeakMap();
+  }
+
+  function describeNativeComponentFrame(fn, construct) {
+    // If something asked for a stack inside a fake render, it should get ignored.
+    if (!fn || reentry) {
+      return '';
+    }
+
+    {
+      var frame = componentFrameCache.get(fn);
+
+      if (frame !== undefined) {
+        return frame;
+      }
+    }
+
+    var control;
+    reentry = true;
+    var previousPrepareStackTrace = Error.prepareStackTrace; // $FlowFixMe It does accept undefined.
+
+    Error.prepareStackTrace = undefined;
+    var previousDispatcher;
+
+    {
+      previousDispatcher = ReactCurrentDispatcher$1.current; // Set the dispatcher in DEV because this might be call in the render function
+      // for warnings.
+
+      ReactCurrentDispatcher$1.current = null;
+      disableLogs();
+    }
+
+    try {
+      // This should throw.
+      if (construct) {
+        // Something should be setting the props in the constructor.
+        var Fake = function () {
+          throw Error();
+        }; // $FlowFixMe
+
+
+        Object.defineProperty(Fake.prototype, 'props', {
+          set: function () {
+            // We use a throwing setter instead of frozen or non-writable props
+            // because that won't throw in a non-strict mode function.
+            throw Error();
+          }
+        });
+
+        if (typeof Reflect === 'object' && Reflect.construct) {
+          // We construct a different control for this case to include any extra
+          // frames added by the construct call.
+          try {
+            Reflect.construct(Fake, []);
+          } catch (x) {
+            control = x;
+          }
+
+          Reflect.construct(fn, [], Fake);
+        } else {
+          try {
+            Fake.call();
+          } catch (x) {
+            control = x;
+          }
+
+          fn.call(Fake.prototype);
+        }
+      } else {
+        try {
+          throw Error();
+        } catch (x) {
+          control = x;
+        }
+
+        fn();
+      }
+    } catch (sample) {
+      // This is inlined manually because closure doesn't do it for us.
+      if (sample && control && typeof sample.stack === 'string') {
+        // This extracts the first frame from the sample that isn't also in the control.
+        // Skipping one frame that we assume is the frame that calls the two.
+        var sampleLines = sample.stack.split('\n');
+        var controlLines = control.stack.split('\n');
+        var s = sampleLines.length - 1;
+        var c = controlLines.length - 1;
+
+        while (s >= 1 && c >= 0 && sampleLines[s] !== controlLines[c]) {
+          // We expect at least one stack frame to be shared.
+          // Typically this will be the root most one. However, stack frames may be
+          // cut off due to maximum stack limits. In this case, one maybe cut off
+          // earlier than the other. We assume that the sample is longer or the same
+          // and there for cut off earlier. So we should find the root most frame in
+          // the sample somewhere in the control.
+          c--;
+        }
+
+        for (; s >= 1 && c >= 0; s--, c--) {
+          // Next we find the first one that isn't the same which should be the
+          // frame that called our sample function and the control.
+          if (sampleLines[s] !== controlLines[c]) {
+            // In V8, the first line is describing the message but other VMs don't.
+            // If we're about to return the first line, and the control is also on the same
+            // line, that's a pretty good indicator that our sample threw at same line as
+            // the control. I.e. before we entered the sample frame. So we ignore this result.
+            // This can happen if you passed a class to function component, or non-function.
+            if (s !== 1 || c !== 1) {
+              do {
+                s--;
+                c--; // We may still have similar intermediate frames from the construct call.
+                // The next one that isn't the same should be our match though.
+
+                if (c < 0 || sampleLines[s] !== controlLines[c]) {
+                  // V8 adds a "new" prefix for native classes. Let's remove it to make it prettier.
+                  var _frame = '\n' + sampleLines[s].replace(' at new ', ' at ');
+
+                  {
+                    if (typeof fn === 'function') {
+                      componentFrameCache.set(fn, _frame);
+                    }
+                  } // Return the line we found.
+
+
+                  return _frame;
+                }
+              } while (s >= 1 && c >= 0);
+            }
+
+            break;
+          }
+        }
+      }
+    } finally {
+      reentry = false;
+
+      {
+        ReactCurrentDispatcher$1.current = previousDispatcher;
+        reenableLogs();
+      }
+
+      Error.prepareStackTrace = previousPrepareStackTrace;
+    } // Fallback to just using the name if we couldn't make it throw.
+
+
+    var name = fn ? fn.displayName || fn.name : '';
+    var syntheticFrame = name ? describeBuiltInComponentFrame(name) : '';
+
+    {
+      if (typeof fn === 'function') {
+        componentFrameCache.set(fn, syntheticFrame);
+      }
+    }
+
+    return syntheticFrame;
+  }
+  function describeFunctionComponentFrame(fn, source, ownerFn) {
+    {
+      return describeNativeComponentFrame(fn, false);
+    }
+  }
+
+  function shouldConstruct(Component) {
+    var prototype = Component.prototype;
+    return !!(prototype && prototype.isReactComponent);
+  }
+
+  function describeUnknownElementTypeFrameInDEV(type, source, ownerFn) {
+
+    if (type == null) {
+      return '';
+    }
+
+    if (typeof type === 'function') {
+      {
+        return describeNativeComponentFrame(type, shouldConstruct(type));
+      }
+    }
+
+    if (typeof type === 'string') {
+      return describeBuiltInComponentFrame(type);
+    }
+
+    switch (type) {
+      case exports.Suspense:
+        return describeBuiltInComponentFrame('Suspense');
+
+      case REACT_SUSPENSE_LIST_TYPE:
+        return describeBuiltInComponentFrame('SuspenseList');
+    }
+
+    if (typeof type === 'object') {
+      switch (type.$$typeof) {
+        case REACT_FORWARD_REF_TYPE:
+          return describeFunctionComponentFrame(type.render);
+
+        case REACT_MEMO_TYPE:
+          // Memo may contain any component type so we recursively resolve it.
+          return describeUnknownElementTypeFrameInDEV(type.type, source, ownerFn);
+
+        case REACT_BLOCK_TYPE:
+          return describeFunctionComponentFrame(type._render);
+
+        case REACT_LAZY_TYPE:
+          {
+            var lazyComponent = type;
+            var payload = lazyComponent._payload;
+            var init = lazyComponent._init;
+
+            try {
+              // Lazy may contain any component type so we recursively resolve it.
+              return describeUnknownElementTypeFrameInDEV(init(payload), source, ownerFn);
+            } catch (x) {}
+          }
+      }
+    }
+
+    return '';
+  }
+
+  var loggedTypeFailures = {};
+  var ReactDebugCurrentFrame$1 = ReactSharedInternals.ReactDebugCurrentFrame;
+
+  function setCurrentlyValidatingElement(element) {
+    {
+      if (element) {
+        var owner = element._owner;
+        var stack = describeUnknownElementTypeFrameInDEV(element.type, element._source, owner ? owner.type : null);
+        ReactDebugCurrentFrame$1.setExtraStackFrame(stack);
+      } else {
+        ReactDebugCurrentFrame$1.setExtraStackFrame(null);
+      }
+    }
+  }
+
+  function checkPropTypes(typeSpecs, values, location, componentName, element) {
+    {
+      // $FlowFixMe This is okay but Flow doesn't know it.
+      var has = Function.call.bind(Object.prototype.hasOwnProperty);
+
+      for (var typeSpecName in typeSpecs) {
+        if (has(typeSpecs, typeSpecName)) {
+          var error$1 = void 0; // Prop type validation may throw. In case they do, we don't want to
+          // fail the render phase where it didn't fail before. So we log it.
+          // After these have been cleaned up, we'll let them throw.
+
+          try {
+            // This is intentionally an invariant that gets caught. It's the same
+            // behavior as without this statement except with a better message.
+            if (typeof typeSpecs[typeSpecName] !== 'function') {
+              var err = Error((componentName || 'React class') + ': ' + location + ' type `' + typeSpecName + '` is invalid; ' + 'it must be a function, usually from the `prop-types` package, but received `' + typeof typeSpecs[typeSpecName] + '`.' + 'This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.');
+              err.name = 'Invariant Violation';
+              throw err;
+            }
+
+            error$1 = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED');
+          } catch (ex) {
+            error$1 = ex;
+          }
+
+          if (error$1 && !(error$1 instanceof Error)) {
+            setCurrentlyValidatingElement(element);
+
+            error('%s: type specification of %s' + ' `%s` is invalid; the type checker ' + 'function must return `null` or an `Error` but returned a %s. ' + 'You may have forgotten to pass an argument to the type checker ' + 'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' + 'shape all require an argument).', componentName || 'React class', location, typeSpecName, typeof error$1);
+
+            setCurrentlyValidatingElement(null);
+          }
+
+          if (error$1 instanceof Error && !(error$1.message in loggedTypeFailures)) {
+            // Only monitor this failure once because there tends to be a lot of the
+            // same error.
+            loggedTypeFailures[error$1.message] = true;
+            setCurrentlyValidatingElement(element);
+
+            error('Failed %s type: %s', location, error$1.message);
+
+            setCurrentlyValidatingElement(null);
+          }
+        }
+      }
+    }
+  }
+
+  function setCurrentlyValidatingElement$1(element) {
+    {
+      if (element) {
+        var owner = element._owner;
+        var stack = describeUnknownElementTypeFrameInDEV(element.type, element._source, owner ? owner.type : null);
+        setExtraStackFrame(stack);
+      } else {
+        setExtraStackFrame(null);
+      }
+    }
+  }
+
+  var propTypesMisspellWarningShown;
+
+  {
+    propTypesMisspellWarningShown = false;
+  }
+
+  function getDeclarationErrorAddendum() {
+    if (ReactCurrentOwner.current) {
+      var name = getComponentName(ReactCurrentOwner.current.type);
+
+      if (name) {
+        return '\n\nCheck the render method of `' + name + '`.';
+      }
+    }
+
+    return '';
+  }
+
+  function getSourceInfoErrorAddendum(source) {
+    if (source !== undefined) {
+      var fileName = source.fileName.replace(/^.*[\\\/]/, '');
+      var lineNumber = source.lineNumber;
+      return '\n\nCheck your code at ' + fileName + ':' + lineNumber + '.';
+    }
+
+    return '';
+  }
+
+  function getSourceInfoErrorAddendumForProps(elementProps) {
+    if (elementProps !== null && elementProps !== undefined) {
+      return getSourceInfoErrorAddendum(elementProps.__source);
+    }
+
+    return '';
+  }
+  /**
+   * Warn if there's no key explicitly set on dynamic arrays of children or
+   * object keys are not valid. This allows us to keep track of children between
+   * updates.
+   */
+
+
+  var ownerHasKeyUseWarning = {};
+
+  function getCurrentComponentErrorInfo(parentType) {
+    var info = getDeclarationErrorAddendum();
+
+    if (!info) {
+      var parentName = typeof parentType === 'string' ? parentType : parentType.displayName || parentType.name;
+
+      if (parentName) {
+        info = "\n\nCheck the top-level render call using <" + parentName + ">.";
+      }
+    }
+
+    return info;
+  }
+  /**
+   * Warn if the element doesn't have an explicit key assigned to it.
+   * This element is in an array. The array could grow and shrink or be
+   * reordered. All children that haven't already been validated are required to
+   * have a "key" property assigned to it. Error statuses are cached so a warning
+   * will only be shown once.
+   *
+   * @internal
+   * @param {ReactElement} element Element that requires a key.
+   * @param {*} parentType element's parent's type.
+   */
+
+
+  function validateExplicitKey(element, parentType) {
+    if (!element._store || element._store.validated || element.key != null) {
+      return;
+    }
+
+    element._store.validated = true;
+    var currentComponentErrorInfo = getCurrentComponentErrorInfo(parentType);
+
+    if (ownerHasKeyUseWarning[currentComponentErrorInfo]) {
+      return;
+    }
+
+    ownerHasKeyUseWarning[currentComponentErrorInfo] = true; // Usually the current owner is the offender, but if it accepts children as a
+    // property, it may be the creator of the child that's responsible for
+    // assigning it a key.
+
+    var childOwner = '';
+
+    if (element && element._owner && element._owner !== ReactCurrentOwner.current) {
+      // Give the component that originally created this child.
+      childOwner = " It was passed a child from " + getComponentName(element._owner.type) + ".";
+    }
+
+    {
+      setCurrentlyValidatingElement$1(element);
+
+      error('Each child in a list should have a unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
+
+      setCurrentlyValidatingElement$1(null);
+    }
+  }
+  /**
+   * Ensure that every element either is passed in a static location, in an
+   * array with an explicit keys property defined, or in an object literal
+   * with valid key property.
+   *
+   * @internal
+   * @param {ReactNode} node Statically passed child of any type.
+   * @param {*} parentType node's parent's type.
+   */
+
+
+  function validateChildKeys(node, parentType) {
+    if (typeof node !== 'object') {
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      for (var i = 0; i < node.length; i++) {
+        var child = node[i];
+
+        if (isValidElement(child)) {
+          validateExplicitKey(child, parentType);
+        }
+      }
+    } else if (isValidElement(node)) {
+      // This element was passed in a valid location.
+      if (node._store) {
+        node._store.validated = true;
+      }
+    } else if (node) {
+      var iteratorFn = getIteratorFn(node);
+
+      if (typeof iteratorFn === 'function') {
+        // Entry iterators used to provide implicit keys,
+        // but now we print a separate warning for them later.
+        if (iteratorFn !== node.entries) {
+          var iterator = iteratorFn.call(node);
+          var step;
+
+          while (!(step = iterator.next()).done) {
+            if (isValidElement(step.value)) {
+              validateExplicitKey(step.value, parentType);
+            }
+          }
+        }
+      }
+    }
+  }
+  /**
+   * Given an element, validate that its props follow the propTypes definition,
+   * provided by the type.
+   *
+   * @param {ReactElement} element
+   */
+
+
+  function validatePropTypes(element) {
+    {
+      var type = element.type;
+
+      if (type === null || type === undefined || typeof type === 'string') {
+        return;
+      }
+
+      var propTypes;
+
+      if (typeof type === 'function') {
+        propTypes = type.propTypes;
+      } else if (typeof type === 'object' && (type.$$typeof === REACT_FORWARD_REF_TYPE || // Note: Memo only checks outer props here.
+      // Inner props are checked in the reconciler.
+      type.$$typeof === REACT_MEMO_TYPE)) {
+        propTypes = type.propTypes;
+      } else {
+        return;
+      }
+
+      if (propTypes) {
+        // Intentionally inside to avoid triggering lazy initializers:
+        var name = getComponentName(type);
+        checkPropTypes(propTypes, element.props, 'prop', name, element);
+      } else if (type.PropTypes !== undefined && !propTypesMisspellWarningShown) {
+        propTypesMisspellWarningShown = true; // Intentionally inside to avoid triggering lazy initializers:
+
+        var _name = getComponentName(type);
+
+        error('Component %s declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment?', _name || 'Unknown');
+      }
+
+      if (typeof type.getDefaultProps === 'function' && !type.getDefaultProps.isReactClassApproved) {
+        error('getDefaultProps is only used on classic React.createClass ' + 'definitions. Use a static property named `defaultProps` instead.');
+      }
+    }
+  }
+  /**
+   * Given a fragment, validate that it can only be provided with fragment props
+   * @param {ReactElement} fragment
+   */
+
+
+  function validateFragmentProps(fragment) {
+    {
+      var keys = Object.keys(fragment.props);
+
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+
+        if (key !== 'children' && key !== 'key') {
+          setCurrentlyValidatingElement$1(fragment);
+
+          error('Invalid prop `%s` supplied to `React.Fragment`. ' + 'React.Fragment can only have `key` and `children` props.', key);
+
+          setCurrentlyValidatingElement$1(null);
+          break;
+        }
+      }
+
+      if (fragment.ref !== null) {
+        setCurrentlyValidatingElement$1(fragment);
+
+        error('Invalid attribute `ref` supplied to `React.Fragment`.');
+
+        setCurrentlyValidatingElement$1(null);
+      }
+    }
+  }
+  function createElementWithValidation(type, props, children) {
+    var validType = isValidElementType(type); // We warn in this case but don't throw. We expect the element creation to
+    // succeed and there will likely be errors in render.
+
+    if (!validType) {
+      var info = '';
+
+      if (type === undefined || typeof type === 'object' && type !== null && Object.keys(type).length === 0) {
+        info += ' You likely forgot to export your component from the file ' + "it's defined in, or you might have mixed up default and named imports.";
+      }
+
+      var sourceInfo = getSourceInfoErrorAddendumForProps(props);
+
+      if (sourceInfo) {
+        info += sourceInfo;
+      } else {
+        info += getDeclarationErrorAddendum();
+      }
+
+      var typeString;
+
+      if (type === null) {
+        typeString = 'null';
+      } else if (Array.isArray(type)) {
+        typeString = 'array';
+      } else if (type !== undefined && type.$$typeof === REACT_ELEMENT_TYPE) {
+        typeString = "<" + (getComponentName(type.type) || 'Unknown') + " />";
+        info = ' Did you accidentally export a JSX literal instead of a component?';
+      } else {
+        typeString = typeof type;
+      }
+
+      {
+        error('React.createElement: type is invalid -- expected a string (for ' + 'built-in components) or a class/function (for composite ' + 'components) but got: %s.%s', typeString, info);
+      }
+    }
+
+    var element = createElement.apply(this, arguments); // The result can be nullish if a mock or a custom function is used.
+    // TODO: Drop this when these are no longer allowed as the type argument.
+
+    if (element == null) {
+      return element;
+    } // Skip key warning if the type isn't valid since our key validation logic
+    // doesn't expect a non-string/function type and can throw confusing errors.
+    // We don't want exception behavior to differ between dev and prod.
+    // (Rendering will throw with a helpful message and as soon as the type is
+    // fixed, the key warnings will appear.)
+
+
+    if (validType) {
+      for (var i = 2; i < arguments.length; i++) {
+        validateChildKeys(arguments[i], type);
+      }
+    }
+
+    if (type === exports.Fragment) {
+      validateFragmentProps(element);
+    } else {
+      validatePropTypes(element);
+    }
+
+    return element;
+  }
+  var didWarnAboutDeprecatedCreateFactory = false;
+  function createFactoryWithValidation(type) {
+    var validatedFactory = createElementWithValidation.bind(null, type);
+    validatedFactory.type = type;
+
+    {
+      if (!didWarnAboutDeprecatedCreateFactory) {
+        didWarnAboutDeprecatedCreateFactory = true;
+
+        warn('React.createFactory() is deprecated and will be removed in ' + 'a future major release. Consider using JSX ' + 'or use React.createElement() directly instead.');
+      } // Legacy hook: remove it
+
+
+      Object.defineProperty(validatedFactory, 'type', {
+        enumerable: false,
+        get: function () {
+          warn('Factory.type is deprecated. Access the class directly ' + 'before passing it to createFactory.');
+
+          Object.defineProperty(this, 'type', {
+            value: type
+          });
+          return type;
+        }
+      });
+    }
+
+    return validatedFactory;
+  }
+  function cloneElementWithValidation(element, props, children) {
+    var newElement = cloneElement.apply(this, arguments);
+
+    for (var i = 2; i < arguments.length; i++) {
+      validateChildKeys(arguments[i], newElement.type);
+    }
+
+    validatePropTypes(newElement);
+    return newElement;
+  }
+
+  var enableSchedulerDebugging = false;
+  var enableProfiling = false;
+
+  var requestHostCallback;
+  var requestHostTimeout;
+  var cancelHostTimeout;
+  var shouldYieldToHost;
+  var requestPaint;
+  var getCurrentTime;
+  var forceFrameRate;
+  var hasPerformanceNow = typeof performance === 'object' && typeof performance.now === 'function';
+
+  if (hasPerformanceNow) {
+    var localPerformance = performance;
+
+    getCurrentTime = function () {
+      return localPerformance.now();
+    };
+  } else {
+    var localDate = Date;
+    var initialTime = localDate.now();
+
+    getCurrentTime = function () {
+      return localDate.now() - initialTime;
+    };
+  }
+
+  if ( // If Scheduler runs in a non-DOM environment, it falls back to a naive
+  // implementation using setTimeout.
+  typeof window === 'undefined' || // Check if MessageChannel is supported, too.
+  typeof MessageChannel !== 'function') {
+    // If this accidentally gets imported in a non-browser environment, e.g. JavaScriptCore,
+    // fallback to a naive implementation.
+    var _callback = null;
+    var _timeoutID = null;
+
+    var _flushCallback = function () {
+      if (_callback !== null) {
+        try {
+          var currentTime = getCurrentTime();
+          var hasRemainingTime = true;
+
+          _callback(hasRemainingTime, currentTime);
+
+          _callback = null;
+        } catch (e) {
+          setTimeout(_flushCallback, 0);
+          throw e;
+        }
+      }
+    };
+
+    requestHostCallback = function (cb) {
+      if (_callback !== null) {
+        // Protect against re-entrancy.
+        setTimeout(requestHostCallback, 0, cb);
+      } else {
+        _callback = cb;
+        setTimeout(_flushCallback, 0);
+      }
+    };
+
+    requestHostTimeout = function (cb, ms) {
+      _timeoutID = setTimeout(cb, ms);
+    };
+
+    cancelHostTimeout = function () {
+      clearTimeout(_timeoutID);
+    };
+
+    shouldYieldToHost = function () {
+      return false;
+    };
+
+    requestPaint = forceFrameRate = function () {};
+  } else {
+    // Capture local references to native APIs, in case a polyfill overrides them.
+    var _setTimeout = window.setTimeout;
+    var _clearTimeout = window.clearTimeout;
+
+    if (typeof console !== 'undefined') {
+      // TODO: Scheduler no longer requires these methods to be polyfilled. But
+      // maybe we want to continue warning if they don't exist, to preserve the
+      // option to rely on it in the future?
+      var requestAnimationFrame = window.requestAnimationFrame;
+      var cancelAnimationFrame = window.cancelAnimationFrame;
+
+      if (typeof requestAnimationFrame !== 'function') {
+        // Using console['error'] to evade Babel and ESLint
+        console['error']("This browser doesn't support requestAnimationFrame. " + 'Make sure that you load a ' + 'polyfill in older browsers. https://reactjs.org/link/react-polyfills');
+      }
+
+      if (typeof cancelAnimationFrame !== 'function') {
+        // Using console['error'] to evade Babel and ESLint
+        console['error']("This browser doesn't support cancelAnimationFrame. " + 'Make sure that you load a ' + 'polyfill in older browsers. https://reactjs.org/link/react-polyfills');
+      }
+    }
+
+    var isMessageLoopRunning = false;
+    var scheduledHostCallback = null;
+    var taskTimeoutID = -1; // Scheduler periodically yields in case there is other work on the main
+    // thread, like user events. By default, it yields multiple times per frame.
+    // It does not attempt to align with frame boundaries, since most tasks don't
+    // need to be frame aligned; for those that do, use requestAnimationFrame.
+
+    var yieldInterval = 5;
+    var deadline = 0; // TODO: Make this configurable
+
+    {
+      // `isInputPending` is not available. Since we have no way of knowing if
+      // there's pending input, always yield at the end of the frame.
+      shouldYieldToHost = function () {
+        return getCurrentTime() >= deadline;
+      }; // Since we yield every frame regardless, `requestPaint` has no effect.
+
+
+      requestPaint = function () {};
+    }
+
+    forceFrameRate = function (fps) {
+      if (fps < 0 || fps > 125) {
+        // Using console['error'] to evade Babel and ESLint
+        console['error']('forceFrameRate takes a positive int between 0 and 125, ' + 'forcing frame rates higher than 125 fps is not supported');
+        return;
+      }
+
+      if (fps > 0) {
+        yieldInterval = Math.floor(1000 / fps);
+      } else {
+        // reset the framerate
+        yieldInterval = 5;
+      }
+    };
+
+    var performWorkUntilDeadline = function () {
+      if (scheduledHostCallback !== null) {
+        var currentTime = getCurrentTime(); // Yield after `yieldInterval` ms, regardless of where we are in the vsync
+        // cycle. This means there's always time remaining at the beginning of
+        // the message event.
+
+        deadline = currentTime + yieldInterval;
+        var hasTimeRemaining = true;
+
+        try {
+          var hasMoreWork = scheduledHostCallback(hasTimeRemaining, currentTime);
+
+          if (!hasMoreWork) {
+            isMessageLoopRunning = false;
+            scheduledHostCallback = null;
+          } else {
+            // If there's more work, schedule the next message event at the end
+            // of the preceding one.
+            port.postMessage(null);
+          }
+        } catch (error) {
+          // If a scheduler task throws, exit the current browser task so the
+          // error can be observed.
+          port.postMessage(null);
+          throw error;
+        }
+      } else {
+        isMessageLoopRunning = false;
+      } // Yielding to the browser will give it a chance to paint, so we can
+    };
+
+    var channel = new MessageChannel();
+    var port = channel.port2;
+    channel.port1.onmessage = performWorkUntilDeadline;
+
+    requestHostCallback = function (callback) {
+      scheduledHostCallback = callback;
+
+      if (!isMessageLoopRunning) {
+        isMessageLoopRunning = true;
+        port.postMessage(null);
+      }
+    };
+
+    requestHostTimeout = function (callback, ms) {
+      taskTimeoutID = _setTimeout(function () {
+        callback(getCurrentTime());
+      }, ms);
+    };
+
+    cancelHostTimeout = function () {
+      _clearTimeout(taskTimeoutID);
+
+      taskTimeoutID = -1;
+    };
+  }
+
+  function push(heap, node) {
+    var index = heap.length;
+    heap.push(node);
+    siftUp(heap, node, index);
+  }
+  function peek(heap) {
+    var first = heap[0];
+    return first === undefined ? null : first;
+  }
+  function pop(heap) {
+    var first = heap[0];
+
+    if (first !== undefined) {
+      var last = heap.pop();
+
+      if (last !== first) {
+        heap[0] = last;
+        siftDown(heap, last, 0);
+      }
+
+      return first;
+    } else {
+      return null;
+    }
+  }
+
+  function siftUp(heap, node, i) {
+    var index = i;
+
+    while (true) {
+      var parentIndex = index - 1 >>> 1;
+      var parent = heap[parentIndex];
+
+      if (parent !== undefined && compare(parent, node) > 0) {
+        // The parent is larger. Swap positions.
+        heap[parentIndex] = node;
+        heap[index] = parent;
+        index = parentIndex;
+      } else {
+        // The parent is smaller. Exit.
+        return;
+      }
+    }
+  }
+
+  function siftDown(heap, node, i) {
+    var index = i;
+    var length = heap.length;
+
+    while (index < length) {
+      var leftIndex = (index + 1) * 2 - 1;
+      var left = heap[leftIndex];
+      var rightIndex = leftIndex + 1;
+      var right = heap[rightIndex]; // If the left or right node is smaller, swap with the smaller of those.
+
+      if (left !== undefined && compare(left, node) < 0) {
+        if (right !== undefined && compare(right, left) < 0) {
+          heap[index] = right;
+          heap[rightIndex] = node;
+          index = rightIndex;
+        } else {
+          heap[index] = left;
+          heap[leftIndex] = node;
+          index = leftIndex;
+        }
+      } else if (right !== undefined && compare(right, node) < 0) {
+        heap[index] = right;
+        heap[rightIndex] = node;
+        index = rightIndex;
+      } else {
+        // Neither child is smaller. Exit.
+        return;
+      }
+    }
+  }
+
+  function compare(a, b) {
+    // Compare sort index first, then task id.
+    var diff = a.sortIndex - b.sortIndex;
+    return diff !== 0 ? diff : a.id - b.id;
+  }
+
+  // TODO: Use symbols?
+  var ImmediatePriority = 1;
+  var UserBlockingPriority = 2;
+  var NormalPriority = 3;
+  var LowPriority = 4;
+  var IdlePriority = 5;
+
+  function markTaskErrored(task, ms) {
+  }
+
+  /* eslint-disable no-var */
+  // Math.pow(2, 30) - 1
+  // 0b111111111111111111111111111111
+
+  var maxSigned31BitInt = 1073741823; // Times out immediately
+
+  var IMMEDIATE_PRIORITY_TIMEOUT = -1; // Eventually times out
+
+  var USER_BLOCKING_PRIORITY_TIMEOUT = 250;
+  var NORMAL_PRIORITY_TIMEOUT = 5000;
+  var LOW_PRIORITY_TIMEOUT = 10000; // Never times out
+
+  var IDLE_PRIORITY_TIMEOUT = maxSigned31BitInt; // Tasks are stored on a min heap
+
+  var taskQueue = [];
+  var timerQueue = []; // Incrementing id counter. Used to maintain insertion order.
+
+  var taskIdCounter = 1; // Pausing the scheduler is useful for debugging.
+  var currentTask = null;
+  var currentPriorityLevel = NormalPriority; // This is set while performing work, to prevent re-entrancy.
+
+  var isPerformingWork = false;
+  var isHostCallbackScheduled = false;
+  var isHostTimeoutScheduled = false;
+
+  function advanceTimers(currentTime) {
+    // Check for tasks that are no longer delayed and add them to the queue.
+    var timer = peek(timerQueue);
+
+    while (timer !== null) {
+      if (timer.callback === null) {
+        // Timer was cancelled.
+        pop(timerQueue);
+      } else if (timer.startTime <= currentTime) {
+        // Timer fired. Transfer to the task queue.
+        pop(timerQueue);
+        timer.sortIndex = timer.expirationTime;
+        push(taskQueue, timer);
+      } else {
+        // Remaining timers are pending.
+        return;
+      }
+
+      timer = peek(timerQueue);
+    }
+  }
+
+  function handleTimeout(currentTime) {
+    isHostTimeoutScheduled = false;
+    advanceTimers(currentTime);
+
+    if (!isHostCallbackScheduled) {
+      if (peek(taskQueue) !== null) {
+        isHostCallbackScheduled = true;
+        requestHostCallback(flushWork);
+      } else {
+        var firstTimer = peek(timerQueue);
+
+        if (firstTimer !== null) {
+          requestHostTimeout(handleTimeout, firstTimer.startTime - currentTime);
+        }
+      }
+    }
+  }
+
+  function flushWork(hasTimeRemaining, initialTime) {
+
+
+    isHostCallbackScheduled = false;
+
+    if (isHostTimeoutScheduled) {
+      // We scheduled a timeout but it's no longer needed. Cancel it.
+      isHostTimeoutScheduled = false;
+      cancelHostTimeout();
+    }
+
+    isPerformingWork = true;
+    var previousPriorityLevel = currentPriorityLevel;
+
+    try {
+      if (enableProfiling) {
+        try {
+          return workLoop(hasTimeRemaining, initialTime);
+        } catch (error) {
+          if (currentTask !== null) {
+            var currentTime = getCurrentTime();
+            markTaskErrored(currentTask, currentTime);
+            currentTask.isQueued = false;
+          }
+
+          throw error;
+        }
+      } else {
+        // No catch in prod code path.
+        return workLoop(hasTimeRemaining, initialTime);
+      }
+    } finally {
+      currentTask = null;
+      currentPriorityLevel = previousPriorityLevel;
+      isPerformingWork = false;
+    }
+  }
+
+  function workLoop(hasTimeRemaining, initialTime) {
+    var currentTime = initialTime;
+    advanceTimers(currentTime);
+    currentTask = peek(taskQueue);
+
+    while (currentTask !== null && !(enableSchedulerDebugging )) {
+      if (currentTask.expirationTime > currentTime && (!hasTimeRemaining || shouldYieldToHost())) {
+        // This currentTask hasn't expired, and we've reached the deadline.
+        break;
+      }
+
+      var callback = currentTask.callback;
+
+      if (typeof callback === 'function') {
+        currentTask.callback = null;
+        currentPriorityLevel = currentTask.priorityLevel;
+        var didUserCallbackTimeout = currentTask.expirationTime <= currentTime;
+
+        var continuationCallback = callback(didUserCallbackTimeout);
+        currentTime = getCurrentTime();
+
+        if (typeof continuationCallback === 'function') {
+          currentTask.callback = continuationCallback;
+        } else {
+
+          if (currentTask === peek(taskQueue)) {
+            pop(taskQueue);
+          }
+        }
+
+        advanceTimers(currentTime);
+      } else {
+        pop(taskQueue);
+      }
+
+      currentTask = peek(taskQueue);
+    } // Return whether there's additional work
+
+
+    if (currentTask !== null) {
+      return true;
+    } else {
+      var firstTimer = peek(timerQueue);
+
+      if (firstTimer !== null) {
+        requestHostTimeout(handleTimeout, firstTimer.startTime - currentTime);
+      }
+
+      return false;
+    }
+  }
+
+  function unstable_runWithPriority(priorityLevel, eventHandler) {
+    switch (priorityLevel) {
+      case ImmediatePriority:
+      case UserBlockingPriority:
+      case NormalPriority:
+      case LowPriority:
+      case IdlePriority:
+        break;
+
+      default:
+        priorityLevel = NormalPriority;
+    }
+
+    var previousPriorityLevel = currentPriorityLevel;
+    currentPriorityLevel = priorityLevel;
+
+    try {
+      return eventHandler();
+    } finally {
+      currentPriorityLevel = previousPriorityLevel;
+    }
+  }
+
+  function unstable_next(eventHandler) {
+    var priorityLevel;
+
+    switch (currentPriorityLevel) {
+      case ImmediatePriority:
+      case UserBlockingPriority:
+      case NormalPriority:
+        // Shift down to normal priority
+        priorityLevel = NormalPriority;
+        break;
+
+      default:
+        // Anything lower than normal priority should remain at the current level.
+        priorityLevel = currentPriorityLevel;
+        break;
+    }
+
+    var previousPriorityLevel = currentPriorityLevel;
+    currentPriorityLevel = priorityLevel;
+
+    try {
+      return eventHandler();
+    } finally {
+      currentPriorityLevel = previousPriorityLevel;
+    }
+  }
+
+  function unstable_wrapCallback(callback) {
+    var parentPriorityLevel = currentPriorityLevel;
+    return function () {
+      // This is a fork of runWithPriority, inlined for performance.
+      var previousPriorityLevel = currentPriorityLevel;
+      currentPriorityLevel = parentPriorityLevel;
+
+      try {
+        return callback.apply(this, arguments);
+      } finally {
+        currentPriorityLevel = previousPriorityLevel;
+      }
+    };
+  }
+
+  function unstable_scheduleCallback(priorityLevel, callback, options) {
+    var currentTime = getCurrentTime();
+    var startTime;
+
+    if (typeof options === 'object' && options !== null) {
+      var delay = options.delay;
+
+      if (typeof delay === 'number' && delay > 0) {
+        startTime = currentTime + delay;
+      } else {
+        startTime = currentTime;
+      }
+    } else {
+      startTime = currentTime;
+    }
+
+    var timeout;
+
+    switch (priorityLevel) {
+      case ImmediatePriority:
+        timeout = IMMEDIATE_PRIORITY_TIMEOUT;
+        break;
+
+      case UserBlockingPriority:
+        timeout = USER_BLOCKING_PRIORITY_TIMEOUT;
+        break;
+
+      case IdlePriority:
+        timeout = IDLE_PRIORITY_TIMEOUT;
+        break;
+
+      case LowPriority:
+        timeout = LOW_PRIORITY_TIMEOUT;
+        break;
+
+      case NormalPriority:
+      default:
+        timeout = NORMAL_PRIORITY_TIMEOUT;
+        break;
+    }
+
+    var expirationTime = startTime + timeout;
+    var newTask = {
+      id: taskIdCounter++,
+      callback: callback,
+      priorityLevel: priorityLevel,
+      startTime: startTime,
+      expirationTime: expirationTime,
+      sortIndex: -1
+    };
+
+    if (startTime > currentTime) {
+      // This is a delayed task.
+      newTask.sortIndex = startTime;
+      push(timerQueue, newTask);
+
+      if (peek(taskQueue) === null && newTask === peek(timerQueue)) {
+        // All tasks are delayed, and this is the task with the earliest delay.
+        if (isHostTimeoutScheduled) {
+          // Cancel an existing timeout.
+          cancelHostTimeout();
+        } else {
+          isHostTimeoutScheduled = true;
+        } // Schedule a timeout.
+
+
+        requestHostTimeout(handleTimeout, startTime - currentTime);
+      }
+    } else {
+      newTask.sortIndex = expirationTime;
+      push(taskQueue, newTask);
+      // wait until the next time we yield.
+
+
+      if (!isHostCallbackScheduled && !isPerformingWork) {
+        isHostCallbackScheduled = true;
+        requestHostCallback(flushWork);
+      }
+    }
+
+    return newTask;
+  }
+
+  function unstable_pauseExecution() {
+  }
+
+  function unstable_continueExecution() {
+
+    if (!isHostCallbackScheduled && !isPerformingWork) {
+      isHostCallbackScheduled = true;
+      requestHostCallback(flushWork);
+    }
+  }
+
+  function unstable_getFirstCallbackNode() {
+    return peek(taskQueue);
+  }
+
+  function unstable_cancelCallback(task) {
+    // remove from the queue because you can't remove arbitrary nodes from an
+    // array based heap, only the first one.)
+
+
+    task.callback = null;
+  }
+
+  function unstable_getCurrentPriorityLevel() {
+    return currentPriorityLevel;
+  }
+
+  var unstable_requestPaint = requestPaint;
+  var unstable_Profiling =  null;
+
+
+
+  var Scheduler = /*#__PURE__*/Object.freeze({
+    __proto__: null,
+    unstable_ImmediatePriority: ImmediatePriority,
+    unstable_UserBlockingPriority: UserBlockingPriority,
+    unstable_NormalPriority: NormalPriority,
+    unstable_IdlePriority: IdlePriority,
+    unstable_LowPriority: LowPriority,
+    unstable_runWithPriority: unstable_runWithPriority,
+    unstable_next: unstable_next,
+    unstable_scheduleCallback: unstable_scheduleCallback,
+    unstable_cancelCallback: unstable_cancelCallback,
+    unstable_wrapCallback: unstable_wrapCallback,
+    unstable_getCurrentPriorityLevel: unstable_getCurrentPriorityLevel,
+    get unstable_shouldYield () { return shouldYieldToHost; },
+    unstable_requestPaint: unstable_requestPaint,
+    unstable_continueExecution: unstable_continueExecution,
+    unstable_pauseExecution: unstable_pauseExecution,
+    unstable_getFirstCallbackNode: unstable_getFirstCallbackNode,
+    get unstable_now () { return getCurrentTime; },
+    get unstable_forceFrameRate () { return forceFrameRate; },
+    unstable_Profiling: unstable_Profiling
+  });
+
+  var DEFAULT_THREAD_ID = 0; // Counters used to generate unique IDs.
+
+  var interactionIDCounter = 0;
+  var threadIDCounter = 0; // Set of currently traced interactions.
+  // Interactions "stack"–
+  // Meaning that newly traced interactions are appended to the previously active set.
+  // When an interaction goes out of scope, the previous set (if any) is restored.
+
+  var interactionsRef = null; // Listener(s) to notify when interactions begin and end.
+
+  var subscriberRef = null;
+
+  {
+    interactionsRef = {
+      current: new Set()
+    };
+    subscriberRef = {
+      current: null
+    };
+  }
+  function unstable_clear(callback) {
+
+    var prevInteractions = interactionsRef.current;
+    interactionsRef.current = new Set();
+
+    try {
+      return callback();
+    } finally {
+      interactionsRef.current = prevInteractions;
+    }
+  }
+  function unstable_getCurrent() {
+    {
+      return interactionsRef.current;
+    }
+  }
+  function unstable_getThreadID() {
+    return ++threadIDCounter;
+  }
+  function unstable_trace(name, timestamp, callback) {
+    var threadID = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : DEFAULT_THREAD_ID;
+
+    var interaction = {
+      __count: 1,
+      id: interactionIDCounter++,
+      name: name,
+      timestamp: timestamp
+    };
+    var prevInteractions = interactionsRef.current; // Traced interactions should stack/accumulate.
+    // To do that, clone the current interactions.
+    // The previous set will be restored upon completion.
+
+    var interactions = new Set(prevInteractions);
+    interactions.add(interaction);
+    interactionsRef.current = interactions;
+    var subscriber = subscriberRef.current;
+    var returnValue;
+
+    try {
+      if (subscriber !== null) {
+        subscriber.onInteractionTraced(interaction);
+      }
+    } finally {
+      try {
+        if (subscriber !== null) {
+          subscriber.onWorkStarted(interactions, threadID);
+        }
+      } finally {
+        try {
+          returnValue = callback();
+        } finally {
+          interactionsRef.current = prevInteractions;
+
+          try {
+            if (subscriber !== null) {
+              subscriber.onWorkStopped(interactions, threadID);
+            }
+          } finally {
+            interaction.__count--; // If no async work was scheduled for this interaction,
+            // Notify subscribers that it's completed.
+
+            if (subscriber !== null && interaction.__count === 0) {
+              subscriber.onInteractionScheduledWorkCompleted(interaction);
+            }
+          }
+        }
+      }
+    }
+
+    return returnValue;
+  }
+  function unstable_wrap(callback) {
+    var threadID = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : DEFAULT_THREAD_ID;
+
+    var wrappedInteractions = interactionsRef.current;
+    var subscriber = subscriberRef.current;
+
+    if (subscriber !== null) {
+      subscriber.onWorkScheduled(wrappedInteractions, threadID);
+    } // Update the pending async work count for the current interactions.
+    // Update after calling subscribers in case of error.
+
+
+    wrappedInteractions.forEach(function (interaction) {
+      interaction.__count++;
+    });
+    var hasRun = false;
+
+    function wrapped() {
+      var prevInteractions = interactionsRef.current;
+      interactionsRef.current = wrappedInteractions;
+      subscriber = subscriberRef.current;
+
+      try {
+        var returnValue;
+
+        try {
+          if (subscriber !== null) {
+            subscriber.onWorkStarted(wrappedInteractions, threadID);
+          }
+        } finally {
+          try {
+            returnValue = callback.apply(undefined, arguments);
+          } finally {
+            interactionsRef.current = prevInteractions;
+
+            if (subscriber !== null) {
+              subscriber.onWorkStopped(wrappedInteractions, threadID);
+            }
+          }
+        }
+
+        return returnValue;
+      } finally {
+        if (!hasRun) {
+          // We only expect a wrapped function to be executed once,
+          // But in the event that it's executed more than once–
+          // Only decrement the outstanding interaction counts once.
+          hasRun = true; // Update pending async counts for all wrapped interactions.
+          // If this was the last scheduled async work for any of them,
+          // Mark them as completed.
+
+          wrappedInteractions.forEach(function (interaction) {
+            interaction.__count--;
+
+            if (subscriber !== null && interaction.__count === 0) {
+              subscriber.onInteractionScheduledWorkCompleted(interaction);
+            }
+          });
+        }
+      }
+    }
+
+    wrapped.cancel = function cancel() {
+      subscriber = subscriberRef.current;
+
+      try {
+        if (subscriber !== null) {
+          subscriber.onWorkCanceled(wrappedInteractions, threadID);
+        }
+      } finally {
+        // Update pending async counts for all wrapped interactions.
+        // If this was the last scheduled async work for any of them,
+        // Mark them as completed.
+        wrappedInteractions.forEach(function (interaction) {
+          interaction.__count--;
+
+          if (subscriber && interaction.__count === 0) {
+            subscriber.onInteractionScheduledWorkCompleted(interaction);
+          }
+        });
+      }
+    };
+
+    return wrapped;
+  }
+
+  var subscribers = null;
+
+  {
+    subscribers = new Set();
+  }
+
+  function unstable_subscribe(subscriber) {
+    {
+      subscribers.add(subscriber);
+
+      if (subscribers.size === 1) {
+        subscriberRef.current = {
+          onInteractionScheduledWorkCompleted: onInteractionScheduledWorkCompleted,
+          onInteractionTraced: onInteractionTraced,
+          onWorkCanceled: onWorkCanceled,
+          onWorkScheduled: onWorkScheduled,
+          onWorkStarted: onWorkStarted,
+          onWorkStopped: onWorkStopped
+        };
+      }
+    }
+  }
+  function unstable_unsubscribe(subscriber) {
+    {
+      subscribers.delete(subscriber);
+
+      if (subscribers.size === 0) {
+        subscriberRef.current = null;
+      }
+    }
+  }
+
+  function onInteractionTraced(interaction) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onInteractionTraced(interaction);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+  function onInteractionScheduledWorkCompleted(interaction) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onInteractionScheduledWorkCompleted(interaction);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+  function onWorkScheduled(interactions, threadID) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onWorkScheduled(interactions, threadID);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+  function onWorkStarted(interactions, threadID) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onWorkStarted(interactions, threadID);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+  function onWorkStopped(interactions, threadID) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onWorkStopped(interactions, threadID);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+  function onWorkCanceled(interactions, threadID) {
+    var didCatchError = false;
+    var caughtError = null;
+    subscribers.forEach(function (subscriber) {
+      try {
+        subscriber.onWorkCanceled(interactions, threadID);
+      } catch (error) {
+        if (!didCatchError) {
+          didCatchError = true;
+          caughtError = error;
+        }
+      }
+    });
+
+    if (didCatchError) {
+      throw caughtError;
+    }
+  }
+
+
+
+  var SchedulerTracing = /*#__PURE__*/Object.freeze({
+    __proto__: null,
+    get __interactionsRef () { return interactionsRef; },
+    get __subscriberRef () { return subscriberRef; },
+    unstable_clear: unstable_clear,
+    unstable_getCurrent: unstable_getCurrent,
+    unstable_getThreadID: unstable_getThreadID,
+    unstable_trace: unstable_trace,
+    unstable_wrap: unstable_wrap,
+    unstable_subscribe: unstable_subscribe,
+    unstable_unsubscribe: unstable_unsubscribe
+  });
+
+  var ReactSharedInternals$1 = {
+    ReactCurrentDispatcher: ReactCurrentDispatcher,
+    ReactCurrentOwner: ReactCurrentOwner,
+    IsSomeRendererActing: IsSomeRendererActing,
+    ReactCurrentBatchConfig: ReactCurrentBatchConfig,
+    // Used by renderers to avoid bundling object-assign twice in UMD bundles:
+    assign: assign,
+    // Re-export the schedule API(s) for UMD bundles.
+    // This avoids introducing a dependency on a new UMD global in a minor update,
+    // Since that would be a breaking change (e.g. for all existing CodeSandboxes).
+    // This re-export is only required for UMD bundles;
+    // CJS bundles use the shared NPM package.
+    Scheduler: Scheduler,
+    SchedulerTracing: SchedulerTracing
+  };
+
+  {
+    ReactSharedInternals$1.ReactDebugCurrentFrame = ReactDebugCurrentFrame;
+  }
+
+  {
+
+    try {
+      var frozenObject = Object.freeze({});
+      /* eslint-disable no-new */
+
+      new Map([[frozenObject, null]]);
+      new Set([frozenObject]);
+      /* eslint-enable no-new */
+    } catch (e) {
+    }
+  }
+
+  var createElement$1 =  createElementWithValidation ;
+  var cloneElement$1 =  cloneElementWithValidation ;
+  var createFactory =  createFactoryWithValidation ;
+  var Children = {
+    map: mapChildren,
+    forEach: forEachChildren,
+    count: countChildren,
+    toArray: toArray,
+    only: onlyChild
+  };
+
+  exports.Children = Children;
+  exports.Component = Component;
+  exports.PureComponent = PureComponent;
+  exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = ReactSharedInternals$1;
+  exports.cloneElement = cloneElement$1;
+  exports.createContext = createContext;
+  exports.createElement = createElement$1;
+  exports.createFactory = createFactory;
+  exports.createRef = createRef;
+  exports.forwardRef = forwardRef;
+  exports.isValidElement = isValidElement;
+  exports.lazy = lazy;
+  exports.memo = memo;
+  exports.useCallback = useCallback;
+  exports.useContext = useContext;
+  exports.useDebugValue = useDebugValue;
+  exports.useEffect = useEffect;
+  exports.useImperativeHandle = useImperativeHandle;
+  exports.useLayoutEffect = useLayoutEffect;
+  exports.useMemo = useMemo;
+  exports.useReducer = useReducer;
+  exports.useRef = useRef;
+  exports.useState = useState;
+  exports.version = ReactVersion;
+
+})));

--- a/tests/assets/reading-list/style.css
+++ b/tests/assets/reading-list/style.css
@@ -1,0 +1,9 @@
+:root {
+  --non-monospace: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --monospace: Consolas, Menlo, monospace;
+  font-size: 14px;
+}
+
+body {
+  font-family: var(--non-monospace);
+}

--- a/tests/page/selectors-react.spec.ts
+++ b/tests/page/selectors-react.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ * Modifications copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test as it, expect } from './pageTest';
+
+const reacts = {
+  'react15': '/reading-list/react15.html',
+  'react16': '/reading-list/react16.html',
+  'react17': '/reading-list/react17.html',
+};
+
+for (const [name, url] of Object.entries(reacts)) {
+  it.describe(name, () => {
+    it.beforeEach(async ({page, server}) => {
+      await page.goto(server.PREFIX + url);
+    });
+
+    it('should work with single-root elements', async ({page}) => {
+      expect(await page.$$eval(`react=BookList`, els => els.length)).toBe(1);
+      expect(await page.$$eval(`react=BookItem`, els => els.length)).toBe(3);
+      expect(await page.$$eval(`react=BookList >> react=BookItem`, els => els.length)).toBe(3);
+      expect(await page.$$eval(`react=BookItem >> react=BookList`, els => els.length)).toBe(0);
+    });
+
+    it('should work with multi-root elements (fragments)', async ({page}) => {
+      it.skip(name === 'react15', 'React 15 does not support fragments');
+      // App is a fragment.
+      expect(await page.$$eval(`react=App`, els => els.length)).toBe(5);
+      // App is a fragment.
+      expect(await page.$$eval(`react=AppHeader`, els => els.length)).toBe(2);
+      // App is a fragment.
+      expect(await page.$$eval(`react=NewBook`, els => els.length)).toBe(2);
+    });
+
+    it('should not crash when there is no match', async ({page}) => {
+      expect(await page.$$eval(`react=Apps`, els => els.length)).toBe(0);
+      expect(await page.$$eval(`react=BookLi`, els => els.length)).toBe(0);
+    });
+  });
+}
+

--- a/tests/page/selectors-react.spec.ts
+++ b/tests/page/selectors-react.spec.ts
@@ -49,7 +49,7 @@ for (const [name, url] of Object.entries(reacts)) {
       expect(await page.$$eval(`react=BookLi`, els => els.length)).toBe(0);
     });
 
-    it('should compose', async({page}) => {
+    it('should compose', async ({page}) => {
       expect(await page.$eval(`react=NewBook >> react=button`, el => el.textContent)).toBe('new book');
       expect(await page.$eval(`react=NewBook >> react=input`, el => el.tagName)).toBe('INPUT');
       expect(await page.$eval(`react=BookItem >> text=Gatsby`, el => el.textContent)).toBe('The Great Gatsby');

--- a/tests/page/selectors-react.spec.ts
+++ b/tests/page/selectors-react.spec.ts
@@ -34,15 +34,13 @@ for (const [name, url] of Object.entries(reacts)) {
       expect(await page.$$eval(`react=BookItem`, els => els.length)).toBe(3);
       expect(await page.$$eval(`react=BookList >> react=BookItem`, els => els.length)).toBe(3);
       expect(await page.$$eval(`react=BookItem >> react=BookList`, els => els.length)).toBe(0);
+
     });
 
     it('should work with multi-root elements (fragments)', async ({page}) => {
       it.skip(name === 'react15', 'React 15 does not support fragments');
-      // App is a fragment.
       expect(await page.$$eval(`react=App`, els => els.length)).toBe(5);
-      // App is a fragment.
       expect(await page.$$eval(`react=AppHeader`, els => els.length)).toBe(2);
-      // App is a fragment.
       expect(await page.$$eval(`react=NewBook`, els => els.length)).toBe(2);
     });
 
@@ -50,6 +48,13 @@ for (const [name, url] of Object.entries(reacts)) {
       expect(await page.$$eval(`react=Apps`, els => els.length)).toBe(0);
       expect(await page.$$eval(`react=BookLi`, els => els.length)).toBe(0);
     });
+
+    it('should compose', async({page}) => {
+      expect(await page.$eval(`react=NewBook >> react=button`, el => el.textContent)).toBe('new book');
+      expect(await page.$eval(`react=NewBook >> react=input`, el => el.tagName)).toBe('INPUT');
+      expect(await page.$eval(`react=BookItem >> text=Gatsby`, el => el.textContent)).toBe('The Great Gatsby');
+    });
+
   });
 }
 


### PR DESCRIPTION
This patch adds support for the `react` selector engine that allows
selecting DOM elements based on the component name.

> **NOTE**: in case of multi-root components (React.Fragment), `react`
engine will select all root DOM elements.

> **NOTE**: `react` engine supports react v15+.

References #7189