### PR TITLE
feat(test runner): support test fixtures in beforeAll/afterAll

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -64,9 +64,9 @@ Test function that takes one or two arguments: an object with fixtures and optio
 Declares an `afterAll` hook that is executed once after all tests. When called in the scope of a test file, runs after all tests in the file. When called inside a [`method: Test.describe`] group, runs after all tests in the group.
 
 ### param: Test.afterAll.hookFunction
-- `hookFunction` <[function]\([Fixtures], [WorkerInfo]\)>
+- `hookFunction` <[function]\([Fixtures], [TestInfo]\)>
 
-Hook function that takes one or two arguments: an object with fixtures and optional [WorkerInfo].
+Hook function that takes one or two arguments: an object with fixtures and optional [TestInfo].
 
 
 
@@ -121,9 +121,9 @@ test('my test', async ({ page }) => {
 You can use [`method: Test.afterAll`] to teardown any resources set up in `beforeAll`.
 
 ### param: Test.beforeAll.hookFunction
-- `hookFunction` <[function]\([Fixtures], [WorkerInfo]\)>
+- `hookFunction` <[function]\([Fixtures], [TestInfo]\)>
 
-Hook function that takes one or two arguments: an object with fixtures and optional [WorkerInfo].
+Hook function that takes one or two arguments: an object with fixtures and optional [TestInfo].
 
 
 

--- a/src/test/project.ts
+++ b/src/test/project.ts
@@ -67,18 +67,27 @@ export class ProjectImpl {
       }
       this.testPools.set(test, pool);
 
-      pool.validateFunction(test.fn, 'Test', true, test.location);
+      pool.validateFunction(test.fn, 'Test', test.location);
       for (let parent = test.parent; parent; parent = parent.parent) {
-        for (const hook of parent._hooks)
-          pool.validateFunction(hook.fn, hook.type + ' hook', hook.type === 'beforeEach' || hook.type === 'afterEach', hook.location);
+        for (const hook of parent._eachHooks)
+          pool.validateFunction(hook.fn, hook.type + ' hook', hook.location);
+        for (const hook of parent._allHooks)
+          pool.validateFunction(hook.fn, hook._type + ' hook', hook.location);
         for (const modifier of parent._modifiers)
-          pool.validateFunction(modifier.fn, modifier.type + ' modifier', true, modifier.location);
+          pool.validateFunction(modifier.fn, modifier.type + ' modifier', modifier.location);
       }
     }
     return this.testPools.get(test)!;
   }
 
   private _cloneEntries(from: Suite, to: Suite, repeatEachIndex: number, filter: (test: TestCase) => boolean): boolean {
+    for (const hook of from._allHooks) {
+      const clone = hook._clone();
+      clone.projectName = this.config.name;
+      clone._pool = this.buildPool(hook);
+      clone._projectIndex = this.index;
+      to._addAllHook(clone);
+    }
     for (const entry of from._entries) {
       if (entry instanceof Suite) {
         const suite = entry._clone();

--- a/src/test/testType.ts
+++ b/src/test/testType.ts
@@ -65,7 +65,7 @@ export class TestTypeImpl {
     const ordinalInFile = countByFile.get(suite._requireFile) || 0;
     countByFile.set(suite._requireFile, ordinalInFile + 1);
 
-    const test = new TestCase(title, fn, ordinalInFile, this, location);
+    const test = new TestCase('test', title, fn, ordinalInFile, this, location);
     test._requireFile = suite._requireFile;
     suite._addTest(test);
 
@@ -107,7 +107,13 @@ export class TestTypeImpl {
     const suite = currentlyLoadingFileSuite();
     if (!suite)
       throw errorWithLocation(location, `${name} hook can only be called in a test file`);
-    suite._hooks.push({ type: name, fn, location });
+    if (name === 'beforeAll' || name === 'afterAll') {
+      const hook = new TestCase(name, name, fn, 0, this, location);
+      hook._requireFile = suite._requireFile;
+      suite._addAllHook(hook);
+    } else {
+      suite._eachHooks.push({ type: name, fn, location });
+    }
   }
 
   private _modifier(type: 'skip' | 'fail' | 'fixme' | 'slow', location: Location, ...modifierArgs: [arg?: any | Function, description?: string]) {

--- a/src/test/types.ts
+++ b/src/test/types.ts
@@ -29,5 +29,6 @@ export type CompleteStepCallback = (error?: Error | TestError) => void;
 
 export interface TestInfoImpl extends TestInfo {
   _testFinished: Promise<void>;
+  _type: 'test' | 'beforeAll' | 'afterAll';
   _addStep: (category: string, title: string) => CompleteStepCallback;
 }

--- a/tests/playwright-test/fixture-errors.spec.ts
+++ b/tests/playwright-test/fixture-errors.spec.ts
@@ -179,44 +179,6 @@ test('should throw when worker fixture depends on a test fixture', async ({ runI
   expect(result.exitCode).toBe(1);
 });
 
-test('should throw when beforeAll hook depends on a test fixture', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'f.spec.ts': `
-      const test = pwt.test.extend({
-        foo: [async ({}, runTest) => {
-          await runTest();
-        }, { scope: 'test' }],
-      });
-
-      test.beforeAll(async ({ foo }) => {});
-      test('works', async ({ foo }) => {});
-    `,
-  });
-  expect(result.output).toContain('beforeAll hook cannot depend on a test fixture "foo".');
-  expect(result.output).toContain(`f.spec.ts:11:12`);
-  expect(result.output).toContain(`f.spec.ts:5:29`);
-  expect(result.exitCode).toBe(1);
-});
-
-test('should throw when afterAll hook depends on a test fixture', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'f.spec.ts': `
-      const test = pwt.test.extend({
-        foo: [async ({}, runTest) => {
-          await runTest();
-        }, { scope: 'test' }],
-      });
-
-      test.afterAll(async ({ foo }) => {});
-      test('works', async ({ foo }) => {});
-    `,
-  });
-  expect(result.output).toContain('afterAll hook cannot depend on a test fixture "foo".');
-  expect(result.output).toContain(`f.spec.ts:11:12`);
-  expect(result.output).toContain(`f.spec.ts:5:29`);
-  expect(result.exitCode).toBe(1);
-});
-
 test('should define the same fixture in two files', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.ts': `

--- a/tests/playwright-test/fixtures.spec.ts
+++ b/tests/playwright-test/fixtures.spec.ts
@@ -312,32 +312,61 @@ test('automatic fixtures should work', async ({ runInlineTest }) => {
       });
       test.beforeAll(async ({}) => {
         expect(counterWorker).toBe(1);
-        expect(counterTest).toBe(0);
+        expect(counterTest).toBe(1);
       });
       test.beforeEach(async ({}) => {
         expect(counterWorker).toBe(1);
-        expect(counterTest === 1 || counterTest === 2).toBe(true);
+        expect(counterTest === 2 || counterTest === 3).toBe(true);
       });
       test('test 1', async ({}) => {
         expect(counterWorker).toBe(1);
-        expect(counterTest).toBe(1);
+        expect(counterTest).toBe(2);
       });
       test('test 2', async ({}) => {
         expect(counterWorker).toBe(1);
-        expect(counterTest).toBe(2);
+        expect(counterTest).toBe(3);
       });
       test.afterEach(async ({}) => {
         expect(counterWorker).toBe(1);
-        expect(counterTest === 1 || counterTest === 2).toBe(true);
+        expect(counterTest === 2 || counterTest === 3).toBe(true);
       });
       test.afterAll(async ({}) => {
         expect(counterWorker).toBe(1);
-        expect(counterTest).toBe(2);
+        expect(counterTest).toBe(4);
       });
     `
   });
   expect(result.exitCode).toBe(0);
   expect(result.results.map(r => r.status)).toEqual(['passed', 'passed']);
+});
+
+test('automatic fixture should start before regular fixture and teardown after', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const test = pwt.test;
+      test.use({
+        auto: [ async ({}, runTest) => {
+          console.log('\\n%%auto-setup');
+          await runTest();
+          console.log('\\n%%auto-teardown');
+        }, { auto: true } ],
+        foo: async ({}, runTest) => {
+          console.log('\\n%%foo-setup');
+          await runTest();
+          console.log('\\n%%foo-teardown');
+        },
+      });
+      test('test 1', async ({ foo }) => {
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.output.split('\n').filter(line => line.startsWith('%%'))).toEqual([
+    '%%auto-setup',
+    '%%foo-setup',
+    '%%foo-teardown',
+    '%%auto-teardown',
+  ]);
 });
 
 test('automatic fixtures should keep workerInfo after conditional skip', async ({ runInlineTest }) => {
@@ -627,4 +656,25 @@ test('should run tests in order', async ({ runInlineTest }) => {
     '%%afterEach',
     '%%test3',
   ]);
+});
+
+test('worker fixture should not receive TestInfo', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const test = pwt.test;
+      test.use({
+        worker: [async ({}, use, info) => {
+          expect(info.title).toBe(undefined);
+          await use();
+        }, { scope: 'worker' }],
+        test: async ({ worker }, use, info) => {
+          expect(info.title).not.toBe(undefined);
+          await use();
+        },
+      });
+      test('test 1', async ({ test }) => {
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
 });

--- a/tests/playwright-test/types-2.spec.ts
+++ b/tests/playwright-test/types-2.spec.ts
@@ -27,6 +27,8 @@ test('basics should work', async ({runTSC}) => {
           testInfo.annotations[0].type;
         });
       });
+      // @ts-expect-error
+      test.foo();
     `
   });
   expect(result.exitCode).toBe(0);

--- a/tests/playwright-test/types.spec.ts
+++ b/tests/playwright-test/types.spec.ts
@@ -16,17 +16,6 @@
 
 import { test, expect } from './playwright-test-fixtures';
 
-test('sanity', async ({runTSC}) => {
-  const result = await runTSC({
-    'a.spec.ts': `
-      const { test } = pwt;
-      // @ts-expect-error
-      test.foo();
-    `
-  });
-  expect(result.exitCode).toBe(0);
-});
-
 test('should check types of fixtures', async ({runTSC}) => {
   const result = await runTSC({
     'helper.ts': `
@@ -125,9 +114,7 @@ test('should check types of fixtures', async ({runTSC}) => {
 
       // @ts-expect-error
       test.beforeAll(async ({ a }) => {});
-      // @ts-expect-error
       test.beforeAll(async ({ foo, bar }) => {});
-      test.beforeAll(async ({ bar }) => {});
       test.beforeAll(() => {});
 
       // @ts-expect-error
@@ -137,9 +124,7 @@ test('should check types of fixtures', async ({runTSC}) => {
 
       // @ts-expect-error
       test.afterAll(async ({ a }) => {});
-      // @ts-expect-error
       test.afterAll(async ({ foo, bar }) => {});
-      test.afterAll(async ({ bar }) => {});
       test.afterAll(() => {});
     `
   });

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -2024,17 +2024,17 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    *
    * You can use [test.afterAll(hookFunction)](https://playwright.dev/docs/api/class-test#test-after-all) to teardown any
    * resources set up in `beforeAll`.
-   * @param hookFunction Hook function that takes one or two arguments: an object with fixtures and optional [WorkerInfo].
+   * @param hookFunction Hook function that takes one or two arguments: an object with fixtures and optional [TestInfo].
    */
-  beforeAll(inner: (args: WorkerArgs, workerInfo: WorkerInfo) => Promise<any> | any): void;
+  beforeAll(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   /**
    * Declares an `afterAll` hook that is executed once after all tests. When called in the scope of a test file, runs after
    * all tests in the file. When called inside a
    * [test.describe(title, callback)](https://playwright.dev/docs/api/class-test#test-describe) group, runs after all tests
    * in the group.
-   * @param hookFunction Hook function that takes one or two arguments: an object with fixtures and optional [WorkerInfo].
+   * @param hookFunction Hook function that takes one or two arguments: an object with fixtures and optional [TestInfo].
    */
-  afterAll(inner: (args: WorkerArgs, workerInfo: WorkerInfo) => Promise<any> | any): void;
+  afterAll(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   /**
    * Specifies parameters or fixtures to use in a single test file or a
    * [test.describe(title, callback)](https://playwright.dev/docs/api/class-test#test-describe) group. Most useful to

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -247,8 +247,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
   setTimeout(timeout: number): void;
   beforeEach(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   afterEach(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
-  beforeAll(inner: (args: WorkerArgs, workerInfo: WorkerInfo) => Promise<any> | any): void;
-  afterAll(inner: (args: WorkerArgs, workerInfo: WorkerInfo) => Promise<any> | any): void;
+  beforeAll(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
+  afterAll(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   use(fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs>): void;
   step(title: string, body: () => Promise<any>): Promise<any>;
   expect: Expect;


### PR DESCRIPTION
This is useful for option fixtures like `viewport`, to get access to your options in `beforeAll`.
This is less useful for object fixtures like `page`, although one can use a page in `beforeAll` to save storage state before running tests.

Technically, each `beforeAll`/`afterAll` hook gets its own test scope and tears down all test fixtures, like a test does. Implemented by creating a fake `TestCase` for the hook.