### PR TITLE
fix(test runner): make sure options, trace and screenshot apply to all contexts

### DIFF
--- a/src/client/browser.ts
+++ b/src/client/browser.ts
@@ -23,12 +23,14 @@ import { BrowserContextOptions } from './types';
 import { isSafeCloseError } from '../utils/errors';
 import * as api from '../../types/types';
 import { CDPSession } from './cdpSession';
+import type { BrowserType } from './browserType';
 
 export class Browser extends ChannelOwner<channels.BrowserChannel, channels.BrowserInitializer> implements api.Browser {
   readonly _contexts = new Set<BrowserContext>();
   private _isConnected = true;
   private _closedPromise: Promise<void>;
   _remoteType: 'owns-connection' | 'uses-connection' | null = null;
+  private _browserType!: BrowserType;
   readonly _name: string;
 
   static from(browser: channels.BrowserChannel): Browser {
@@ -46,13 +48,22 @@ export class Browser extends ChannelOwner<channels.BrowserChannel, channels.Brow
     this._closedPromise = new Promise(f => this.once(Events.Browser.Disconnected, f));
   }
 
+  _setBrowserType(browserType: BrowserType) {
+    this._browserType = browserType;
+    for (const context of this._contexts)
+      context._setBrowserType(browserType);
+  }
+
   async newContext(options: BrowserContextOptions = {}): Promise<BrowserContext> {
     return this._wrapApiCall(async (channel: channels.BrowserChannel) => {
+      options = { ...this._browserType._defaultContextOptions, ...options };
       const contextOptions = await prepareBrowserContextParams(options);
       const context = BrowserContext.from((await channel.newContext(contextOptions)).context);
       context._options = contextOptions;
       this._contexts.add(context);
       context._logger = options.logger || this._logger;
+      context._setBrowserType(this._browserType);
+      await this._browserType._onDidCreateContext?.(context);
       return context;
     });
   }

--- a/src/client/browserType.ts
+++ b/src/client/browserType.ts
@@ -18,7 +18,7 @@ import * as channels from '../protocol/channels';
 import { Browser } from './browser';
 import { BrowserContext, prepareBrowserContextParams } from './browserContext';
 import { ChannelOwner } from './channelOwner';
-import { LaunchOptions, LaunchServerOptions, ConnectOptions, LaunchPersistentContextOptions } from './types';
+import { LaunchOptions, LaunchServerOptions, ConnectOptions, LaunchPersistentContextOptions, BrowserContextOptions } from './types';
 import WebSocket from 'ws';
 import { Connection } from './connection';
 import { Events } from './events';
@@ -45,6 +45,13 @@ export interface BrowserServer extends api.BrowserServer {
 export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, channels.BrowserTypeInitializer> implements api.BrowserType {
   private _timeoutSettings = new TimeoutSettings();
   _serverLauncher?: BrowserServerLauncher;
+  _contexts = new Set<BrowserContext>();
+
+  // Instrumentation.
+  _defaultContextOptions: BrowserContextOptions = {};
+  _defaultLaunchOptions: LaunchOptions = {};
+  _onDidCreateContext?: (context: BrowserContext) => Promise<void>;
+  _onWillCloseContext?: (context: BrowserContext) => Promise<void>;
 
   static from(browserType: channels.BrowserTypeChannel): BrowserType {
     return (browserType as any)._object;
@@ -69,6 +76,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, chann
     return this._wrapApiCall(async (channel: channels.BrowserTypeChannel) => {
       assert(!(options as any).userDataDir, 'userDataDir option is not supported in `browserType.launch`. Use `browserType.launchPersistentContext` instead');
       assert(!(options as any).port, 'Cannot specify a port without launching as a server.');
+      options = { ...this._defaultLaunchOptions, ...options };
       const launchOptions: channels.BrowserTypeLaunchParams = {
         ...options,
         ignoreDefaultArgs: Array.isArray(options.ignoreDefaultArgs) ? options.ignoreDefaultArgs : undefined,
@@ -77,6 +85,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, chann
       };
       const browser = Browser.from((await channel.launch(launchOptions)).browser);
       browser._logger = logger;
+      browser._setBrowserType(this);
       return browser;
     }, logger);
   }
@@ -90,6 +99,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, chann
   async launchPersistentContext(userDataDir: string, options: LaunchPersistentContextOptions = {}): Promise<BrowserContext> {
     return this._wrapApiCall(async (channel: channels.BrowserTypeChannel) => {
       assert(!(options as any).port, 'Cannot specify a port without launching as a server.');
+      options = { ...this._defaultLaunchOptions, ...this._defaultContextOptions, ...options };
       const contextParams = await prepareBrowserContextParams(options);
       const persistentParams: channels.BrowserTypeLaunchPersistentContextParams = {
         ...contextParams,
@@ -103,6 +113,8 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, chann
       const context = BrowserContext.from(result.context);
       context._options = contextParams;
       context._logger = options.logger;
+      context._setBrowserType(this);
+      await this._onDidCreateContext?.(context);
       return context;
     }, options.logger);
   }
@@ -181,6 +193,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, chann
           const browser = Browser.from(playwright._initializer.preLaunchedBrowser!);
           browser._logger = logger;
           browser._remoteType = 'owns-connection';
+          browser._setBrowserType((playwright as any)[browser._name]);
           const closeListener = () => {
             // Emulate all pages, contexts and the browser closing upon disconnect.
             for (const context of browser.contexts()) {
@@ -252,6 +265,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, chann
         browser._contexts.add(BrowserContext.from(result.defaultContext));
       browser._remoteType = 'uses-connection';
       browser._logger = logger;
+      browser._setBrowserType(this);
       return browser;
     }, logger);
   }

--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -487,9 +487,10 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
   async close(options: { runBeforeUnload?: boolean } = {runBeforeUnload: undefined}) {
     try {
       await this._wrapApiCall(async (channel: channels.PageChannel) => {
-        await channel.close(options);
         if (this._ownedContext)
           await this._ownedContext.close();
+        else
+          await channel.close(options);
       });
     } catch (e) {
       if (isSafeCloseError(e))

--- a/tests/playwright-test/playwright.artifacts.spec.ts
+++ b/tests/playwright-test/playwright.artifacts.spec.ts
@@ -1,0 +1,280 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './playwright-test-fixtures';
+import fs from 'fs';
+import path from 'path';
+
+function listFiles(dir: string): string[] {
+  const result: string[] = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    result.push(entry.name);
+    if (entry.isDirectory())
+      result.push(...listFiles(path.join(dir, entry.name)).map(x => '  ' + x));
+  }
+  return result;
+}
+
+const testFiles = {
+  'artifacts.spec.ts': `
+    import fs from 'fs';
+    import os from 'os';
+    import path from 'path';
+    import rimraf from 'rimraf';
+
+    const { test } = pwt;
+
+    test.describe('shared', () => {
+      let page;
+      test.beforeAll(async ({ browser }) => {
+        page = await browser.newPage({});
+        await page.setContent('<button>Click me</button><button>And me</button>');
+      });
+
+      test.afterAll(async () => {
+        await page.close();
+      });
+
+      test('shared passing', async ({ }) => {
+        await page.click('text=Click me');
+      });
+
+      test('shared  failing', async ({ }) => {
+        await page.click('text=And me');
+        expect(1).toBe(2);
+      });
+    });
+
+    test('passing', async ({ page }) => {
+      await page.setContent('I am the page');
+    });
+
+    test('two contexts', async ({ page, createContext }) => {
+      await page.setContent('I am the page');
+
+      const context2 = await createContext();
+      const page2 = await context2.newPage();
+      await page2.setContent('I am the page');
+    });
+
+    test('failing', async ({ page }) => {
+      await page.setContent('I am the page');
+      expect(1).toBe(2);
+    });
+
+    test('two contexts failing', async ({ page, createContext }) => {
+      await page.setContent('I am the page');
+
+      const context2 = await createContext();
+      const page2 = await context2.newPage();
+      await page2.setContent('I am the page');
+
+      expect(1).toBe(2);
+    });
+
+    test('own context passing', async ({ browser }) => {
+      const page = await browser.newPage();
+      await page.setContent('<button>Click me</button><button>And me</button>');
+      await page.click('text=Click me');
+      await page.close();
+    });
+
+    test('own context failing', async ({ browser }) => {
+      const page = await browser.newPage();
+      await page.setContent('<button>Click me</button><button>And me</button>');
+      await page.click('text=Click me');
+      await page.close();
+      expect(1).toBe(2);
+    });
+
+    const testPersistent = test.extend({
+      page: async ({ playwright, browserName }, use) => {
+        const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'user-data-dir-'));
+        const context = await playwright[browserName].launchPersistentContext(dir);
+        await use(context.pages()[0]);
+        await context.close();
+        rimraf.sync(dir);
+      },
+    });
+
+    testPersistent('persistent passing', async ({ page }) => {
+      await page.setContent('<button>Click me</button><button>And me</button>');
+    });
+
+    testPersistent('persistent failing', async ({ page }) => {
+      await page.setContent('<button>Click me</button><button>And me</button>');
+      expect(1).toBe(2);
+    });
+  `,
+};
+
+test('should work with screenshot: on', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...testFiles,
+    'playwright.config.ts': `
+      module.exports = { use: { screenshot: 'on' } };
+    `,
+  }, { workers: 1 });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(5);
+  expect(result.failed).toBe(5);
+  expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
+    'artifacts-failing',
+    '  test-failed-1.png',
+    'artifacts-own-context-failing',
+    '  test-failed-1.png',
+    'artifacts-own-context-passing',
+    '  test-finished-1.png',
+    'artifacts-passing',
+    '  test-finished-1.png',
+    'artifacts-persistent-failing',
+    '  test-failed-1.png',
+    'artifacts-persistent-passing',
+    '  test-finished-1.png',
+    'artifacts-shared-failing',
+    '  test-failed-1.png',
+    'artifacts-shared-passing',
+    '  test-finished-1.png',
+    'artifacts-two-contexts',
+    '  test-finished-1.png',
+    '  test-finished-2.png',
+    'artifacts-two-contexts-failing',
+    '  test-failed-1.png',
+    '  test-failed-2.png',
+    'report.json',
+  ]);
+});
+
+test('should work with screenshot: only-on-failure', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...testFiles,
+    'playwright.config.ts': `
+      module.exports = { use: { screenshot: 'only-on-failure' } };
+    `,
+  }, { workers: 1 });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(5);
+  expect(result.failed).toBe(5);
+  expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
+    'artifacts-failing',
+    '  test-failed-1.png',
+    'artifacts-own-context-failing',
+    '  test-failed-1.png',
+    'artifacts-persistent-failing',
+    '  test-failed-1.png',
+    'artifacts-shared-failing',
+    '  test-failed-1.png',
+    'artifacts-two-contexts-failing',
+    '  test-failed-1.png',
+    '  test-failed-2.png',
+    'report.json',
+  ]);
+});
+
+test('should work with trace: on', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...testFiles,
+    'playwright.config.ts': `
+      module.exports = { use: { trace: 'on' } };
+    `,
+  }, { workers: 1 });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(5);
+  expect(result.failed).toBe(5);
+  expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
+    'artifacts-failing',
+    '  trace.zip',
+    'artifacts-own-context-failing',
+    '  trace.zip',
+    'artifacts-own-context-passing',
+    '  trace.zip',
+    'artifacts-passing',
+    '  trace.zip',
+    'artifacts-persistent-failing',
+    '  trace.zip',
+    'artifacts-persistent-passing',
+    '  trace.zip',
+    'artifacts-shared-failing',
+    '  trace.zip',
+    'artifacts-shared-passing',
+    '  trace.zip',
+    'artifacts-two-contexts',
+    '  trace-1.zip',
+    '  trace.zip',
+    'artifacts-two-contexts-failing',
+    '  trace-1.zip',
+    '  trace.zip',
+    'report.json',
+  ]);
+});
+
+test('should work with trace: retain-on-failure', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...testFiles,
+    'playwright.config.ts': `
+      module.exports = { use: { trace: 'retain-on-failure' } };
+    `,
+  }, { workers: 1 });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(5);
+  expect(result.failed).toBe(5);
+  expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
+    'artifacts-failing',
+    '  trace.zip',
+    'artifacts-own-context-failing',
+    '  trace.zip',
+    'artifacts-persistent-failing',
+    '  trace.zip',
+    'artifacts-shared-failing',
+    '  trace.zip',
+    'artifacts-two-contexts-failing',
+    '  trace-1.zip',
+    '  trace.zip',
+    'report.json',
+  ]);
+});
+
+test('should work with trace: on-first-retry', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...testFiles,
+    'playwright.config.ts': `
+      module.exports = { use: { trace: 'on-first-retry' } };
+    `,
+  }, { workers: 1, retries: 1 });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(5);
+  expect(result.failed).toBe(5);
+  expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
+    'artifacts-failing-retry1',
+    '  trace.zip',
+    'artifacts-own-context-failing-retry1',
+    '  trace.zip',
+    'artifacts-persistent-failing-retry1',
+    '  trace.zip',
+    'artifacts-shared-failing-retry1',
+    '  trace.zip',
+    'artifacts-two-contexts-failing-retry1',
+    '  trace-1.zip',
+    '  trace.zip',
+    'report.json',
+  ]);
+});

--- a/tests/playwright-test/retry.spec.ts
+++ b/tests/playwright-test/retry.spec.ts
@@ -68,7 +68,7 @@ test('should retry timeout', async ({ runInlineTest }) => {
         await new Promise(f => setTimeout(f, 10000));
       });
     `
-  }, { timeout: 100, retries: 2 });
+  }, { timeout: 1000, retries: 2 });
   expect(exitCode).toBe(1);
   expect(passed).toBe(0);
   expect(failed).toBe(1);

--- a/tests/playwright-test/test-output-dir.spec.ts
+++ b/tests/playwright-test/test-output-dir.spec.ts
@@ -88,6 +88,7 @@ test('should include the project name', async ({ runInlineTest }) => {
     'helper.ts': `
       export const test = pwt.test.extend({
         auto: [ async ({}, run, testInfo) => {
+          testInfo.snapshotSuffix = '';
           await run();
         }, { auto: true } ]
       });

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -2297,6 +2297,35 @@ export interface PlaywrightWorkerOptions {
    * [fixtures.channel](https://playwright.dev/docs/api/class-fixtures#fixtures-channel) take priority over this.
    */
   launchOptions: LaunchOptions;
+  /**
+   * Whether to automatically capture a screenshot after each test. Defaults to `'off'`.
+   * - `'off'`: Do not capture screenshots.
+   * - `'on'`: Capture screenshot after each test.
+   * - `'only-on-failure'`: Capture screenshot after each test failure.
+   *
+   * Learn more about [automatic screenshots](https://playwright.dev/docs/test-configuration#automatic-screenshots).
+   */
+  screenshot: 'off' | 'on' | 'only-on-failure';
+  /**
+   * Whether to record a trace for each test. Defaults to `'off'`.
+   * - `'off'`: Do not record a trace.
+   * - `'on'`: Record a trace for each test.
+   * - `'retain-on-failure'`: Record a trace for each test, but remove it from successful test runs.
+   * - `'on-first-retry'`: Record a trace only when retrying a test for the first time.
+   *
+   * Learn more about [recording trace](https://playwright.dev/docs/test-configuration#record-test-trace).
+   */
+  trace: 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | /** deprecated */ 'retry-with-trace';
+  /**
+   * Whether to record video for each test. Defaults to `'off'`.
+   * - `'off'`: Do not record video.
+   * - `'on'`: Record video for each test.
+   * - `'retain-on-failure'`: Record video for each test, but remove all videos from successful test runs.
+   * - `'on-first-retry'`: Record video only when retrying a test for the first time.
+   *
+   * Learn more about [recording video](https://playwright.dev/docs/test-configuration#record-video).
+   */
+  video: VideoMode | { mode: VideoMode, size: ViewportSize };
 }
 
 export type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | /** deprecated */ 'retry-with-video';
@@ -2390,35 +2419,6 @@ export type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 
  *
  */
 export interface PlaywrightTestOptions {
-  /**
-   * Whether to automatically capture a screenshot after each test. Defaults to `'off'`.
-   * - `'off'`: Do not capture screenshots.
-   * - `'on'`: Capture screenshot after each test.
-   * - `'only-on-failure'`: Capture screenshot after each test failure.
-   *
-   * Learn more about [automatic screenshots](https://playwright.dev/docs/test-configuration#automatic-screenshots).
-   */
-  screenshot: 'off' | 'on' | 'only-on-failure';
-  /**
-   * Whether to record a trace for each test. Defaults to `'off'`.
-   * - `'off'`: Do not record a trace.
-   * - `'on'`: Record a trace for each test.
-   * - `'retain-on-failure'`: Record a trace for each test, but remove it from successful test runs.
-   * - `'on-first-retry'`: Record a trace only when retrying a test for the first time.
-   *
-   * Learn more about [recording trace](https://playwright.dev/docs/test-configuration#record-test-trace).
-   */
-  trace: 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | /** deprecated */ 'retry-with-trace';
-  /**
-   * Whether to record video for each test. Defaults to `'off'`.
-   * - `'off'`: Do not record video.
-   * - `'on'`: Record video for each test.
-   * - `'retain-on-failure'`: Record video for each test, but remove all videos from successful test runs.
-   * - `'on-first-retry'`: Record video only when retrying a test for the first time.
-   *
-   * Learn more about [recording video](https://playwright.dev/docs/test-configuration#record-video).
-   */
-  video: VideoMode | { mode: VideoMode, size: ViewportSize };
   /**
    * Whether to automatically download all the attachments. Defaults to `false` where all the downloads are canceled.
    */

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -284,14 +284,14 @@ export interface PlaywrightWorkerOptions {
   headless: boolean | undefined;
   channel: BrowserChannel | undefined;
   launchOptions: LaunchOptions;
+  screenshot: 'off' | 'on' | 'only-on-failure';
+  trace: 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | /** deprecated */ 'retry-with-trace';
+  video: VideoMode | { mode: VideoMode, size: ViewportSize };
 }
 
 export type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | /** deprecated */ 'retry-with-video';
 
 export interface PlaywrightTestOptions {
-  screenshot: 'off' | 'on' | 'only-on-failure';
-  trace: 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | /** deprecated */ 'retry-with-trace';
-  video: VideoMode | { mode: VideoMode, size: ViewportSize };
   acceptDownloads: boolean | undefined;
   bypassCSP: boolean | undefined;
   colorScheme: ColorScheme | undefined;


### PR DESCRIPTION
- Plumb around `BrowserType` to be accessible from `Browser` and `BrowserContext`.
- Use some auto fixtures to set default options and context instrumentation on `BrowserType`.
- Move `screenshot`, `trace` and `video` to worker-scoped fixtures.
- Throw in `page`/`context` when used from `beforeAll`/`afterAll`.
