### PR TITLE
fix(test runner): ensure we run after hooks after failures

### DIFF
--- a/src/test/types.ts
+++ b/src/test/types.ts
@@ -29,6 +29,5 @@ export type CompleteStepCallback = (error?: Error | TestError) => void;
 
 export interface TestInfoImpl extends TestInfo {
   _testFinished: Promise<void>;
-  _type: 'test' | 'beforeAll' | 'afterAll';
   _addStep: (category: string, title: string) => CompleteStepCallback;
 }

--- a/src/test/worker.ts
+++ b/src/test/worker.ts
@@ -97,7 +97,7 @@ async function gracefullyCloseAndExit() {
   // Meanwhile, try to gracefully shutdown.
   try {
     if (workerRunner) {
-      workerRunner.stop();
+      await workerRunner.stop();
       await workerRunner.cleanup();
     }
     if (workerIndex !== undefined)


### PR DESCRIPTION
Instead of checking `this._isStopped` everywhere in the code for an early exit, we now always run `WorkerRunner._run` until the end, only skipping entire suites and tests after stop was requested. This ensures we run all the hooks after a failure or user interrupt. We also "terminate" the current `DeadlineRunner` so that we do not have to wait for the whole test to finish.