### PR TITLE
browser(firefox): response interception after redirects

### DIFF
--- a/browser_patches/firefox/juggler/protocol/PageHandler.js
+++ b/browser_patches/firefox/juggler/protocol/PageHandler.js
@@ -72,7 +72,7 @@ class PageHandler {
     this._workers = new Map();
 
     this._pageTarget = target;
-    this._pageNetwork = NetworkObserver.instance().pageNetworkForTarget(target);
+    this._pageNetwork = PageNetwork.forPageTarget(target);
 
     const emitProtocolEvent = eventName => {
       return (...args) => this._session.emitEvent(eventName, ...args);


### PR DESCRIPTION
When intercepting response we clone original HttpChannel and send another request to get original response. This may lead to a sequence of redirects before the final response is received. Such redirects should be reported to the client as usual without intercepting them (we don't support redirect interception). ResponseInterceptor class is used to keep track of the activities while response interception is in progress, it fiddles with HttpChannels depending on which request in the chain is handled and whether it is before or after the original response is received.

#1774 