### PR TITLE
fix(test runner): disallow use(workerFixture) in describes

### DIFF
--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -105,7 +105,7 @@ export class FixturePool {
   readonly digest: string;
   readonly registrations: Map<string, FixtureRegistration>;
 
-  constructor(fixturesList: FixturesWithLocation[], parentPool?: FixturePool) {
+  constructor(fixturesList: FixturesWithLocation[], parentPool?: FixturePool, disallowWorkerFixtures?: boolean) {
     this.registrations = new Map(parentPool ? parentPool.registrations : []);
 
     for (const { fixtures, location } of fixturesList) {
@@ -136,6 +136,8 @@ export class FixturePool {
 
         if (options.scope !== 'test' && options.scope !== 'worker')
           throw errorWithLocations(`Fixture "${name}" has unknown { scope: '${options.scope}' }.`, { location, name });
+        if (options.scope === 'worker' && disallowWorkerFixtures)
+          throw errorWithLocations(`Cannot use({ ${name} }) in a describe group, because it forces a new worker.\nMake it top-level in the test file or put in the configuration file.`, { location, name });
 
         const deps = fixtureParameterNames(fn, location);
         const registration: FixtureRegistration = { id: '', name, location, scope: options.scope, fn, auto: options.auto, deps, super: previous };

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -17,7 +17,7 @@
 import type { FixturePool } from './fixtures';
 import * as reporterTypes from '../../types/testReporter';
 import type { TestTypeImpl } from './testType';
-import { Annotations, Location } from './types';
+import { Annotations, FixturesWithLocation, Location } from './types';
 
 class Base {
   title: string;
@@ -48,7 +48,8 @@ export class Suite extends Base implements reporterTypes.Suite {
   suites: Suite[] = [];
   tests: TestCase[] = [];
   location?: Location;
-  _fixtureOverrides: any = {};
+  _use: FixturesWithLocation[] = [];
+  _isDescribe = false;
   _entries: (Suite | TestCase)[] = [];
   _allHooks: TestCase[] = [];
   _eachHooks: { type: 'beforeEach' | 'afterEach', fn: Function, location: Location }[] = [];
@@ -97,20 +98,17 @@ export class Suite extends Base implements reporterTypes.Suite {
     return items;
   }
 
-  _buildFixtureOverrides(): any {
-    return this.parent ? { ...this.parent._buildFixtureOverrides(), ...this._fixtureOverrides } : this._fixtureOverrides;
-  }
-
   _clone(): Suite {
     const suite = new Suite(this.title);
     suite._only = this._only;
     suite.location = this.location;
     suite._requireFile = this._requireFile;
-    suite._fixtureOverrides = this._fixtureOverrides;
+    suite._use = this._use.slice();
     suite._eachHooks = this._eachHooks.slice();
     suite._timeout = this._timeout;
     suite._annotations = this._annotations.slice();
     suite._modifiers = this._modifiers.slice();
+    suite._isDescribe = this._isDescribe;
     return suite;
   }
 }

--- a/src/test/testType.ts
+++ b/src/test/testType.ts
@@ -92,6 +92,7 @@ export class TestTypeImpl {
 
     const child = new Suite(title);
     child._requireFile = suite._requireFile;
+    child._isDescribe = true;
     child.location = location;
     suite._addSuite(child);
 
@@ -161,7 +162,7 @@ export class TestTypeImpl {
     const suite = currentlyLoadingFileSuite();
     if (!suite)
       throw errorWithLocation(location, `test.use() can only be called in a test file`);
-    suite._fixtureOverrides = { ...suite._fixtureOverrides, ...fixtures };
+    suite._use.push({ fixtures, location });
   }
 
   private async _step(location: Location, title: string, body: () => Promise<void>): Promise<void> {

--- a/tests/playwright-test/shard.spec.ts
+++ b/tests/playwright-test/shard.spec.ts
@@ -17,28 +17,28 @@
 import { test, expect } from './playwright-test-fixtures';
 
 const tests = {
+  'helper.ts': `
+    export const headlessTest = pwt.test.extend({ headless: false });
+    export const headedTest = pwt.test.extend({ headless: true });
+  `,
   'a.spec.ts': `
-    const test = pwt.test.extend({ foo: 'bar' });
-    test.use({ headless: false });
-    test('test1', async () => {
+    import { headlessTest, headedTest } from './helper';
+    headlessTest('test1', async () => {
       console.log('test1-done');
     });
-    test.describe('suite', () => {
-      test.use({ headless: true });
-      test('test2', async () => {
-        console.log('test2-done');
-      });
+    headedTest('test2', async () => {
+      console.log('test2-done');
     });
-    test('test3', async () => {
+    headlessTest('test3', async () => {
       console.log('test3-done');
     });
   `,
   'b.spec.ts': `
-    const test = pwt.test.extend({ bar: 'foo' });
-    test('test4', async () => {
+    import { headlessTest, headedTest } from './helper';
+    headlessTest('test4', async () => {
       console.log('test4-done');
     });
-    test('test5', async () => {
+    headedTest('test5', async () => {
       console.log('test5-done');
     });
   `,
@@ -51,7 +51,7 @@ test('should respect shard=1/2', async ({ runInlineTest }) => {
   expect(result.skipped).toBe(0);
   expect(result.output).toContain('test1-done');
   expect(result.output).toContain('test3-done');
-  expect(result.output).toContain('test2-done');
+  expect(result.output).toContain('test4-done');
 });
 
 test('should respect shard=2/2', async ({ runInlineTest }) => {
@@ -59,7 +59,7 @@ test('should respect shard=2/2', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(2);
   expect(result.skipped).toBe(0);
-  expect(result.output).toContain('test4-done');
+  expect(result.output).toContain('test2-done');
   expect(result.output).toContain('test5-done');
 });
 
@@ -75,5 +75,5 @@ test('should respect shard=1/2 in config', async ({ runInlineTest }) => {
   expect(result.skipped).toBe(0);
   expect(result.output).toContain('test1-done');
   expect(result.output).toContain('test3-done');
-  expect(result.output).toContain('test2-done');
+  expect(result.output).toContain('test4-done');
 });


### PR DESCRIPTION
Using a worker fixture forces a new worker. This might be unexpected when one part of a test file runs in one worker, and another runs in another worker. Top-level use of worker fixtures is still fine.