### PR TITLE
browser(webkit): include GPU process in mac archive

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1529
-Changed: yurys@chromium.org Fri 06 Aug 2021 12:34:04 PM PDT
+1530
+Changed: dkolesa@igalia.com Wed Aug 11 01:40:23 AM CEST 2021

--- a/browser_patches/webkit/archive.sh
+++ b/browser_patches/webkit/archive.sh
@@ -116,6 +116,7 @@ createZipForMac() {
   local tmpdir=$(mktemp -d)
 
   # copy all relevant files
+  ditto {./WebKitBuild/Release,"$tmpdir"}/com.apple.WebKit.GPU.xpc
   ditto {./WebKitBuild/Release,"$tmpdir"}/com.apple.WebKit.Networking.xpc
   ditto {./WebKitBuild/Release,"$tmpdir"}/com.apple.WebKit.Plugin.64.xpc
   ditto {./WebKitBuild/Release,"$tmpdir"}/com.apple.WebKit.WebContent.xpc


### PR DESCRIPTION
As it turns out, the GPU process executable just wasn't included in the bundle (and I failed to notice that since the macOS names are different and when I considered this possibility I did not notice it while looking for it), thanks @yury-s for the hint.

Fixes Mac issues that started with https://github.com/microsoft/playwright/pull/7984.

Also closes https://github.com/microsoft/playwright/pull/8121.