### PR TITLE
fix(types): allow specifying scope when overriding fixtures

### DIFF
--- a/tests/playwright-test/types.spec.ts
+++ b/tests/playwright-test/types.spec.ts
@@ -37,6 +37,16 @@ test('should check types of fixtures', async ({runTSC}) => {
       const good7 = test.extend<{ baz: boolean }>({
         baz: [ false, { auto: true } ],
       });
+      const good8 = test.extend<{ foo: string }>({
+        foo: [ async ({}, use) => {
+          await use('foo');
+        }, { scope: 'test' } ],
+      });
+      const good9 = test.extend<{}, {}>({
+        bar: [ async ({}, use) => {
+          await use(42);
+        }, { scope: 'worker' } ],
+      });
 
       // @ts-expect-error
       const fail1 = test.extend<{}>({ foo: 42 });
@@ -59,6 +69,18 @@ test('should check types of fixtures', async ({runTSC}) => {
       const fail8 = test.extend<{}, { baz: boolean }>({
         // @ts-expect-error
         baz: true,
+      });
+      const fail9 = test.extend<{ foo: string }>({
+        foo: [ async ({}, use) => {
+          await use('foo');
+        // @ts-expect-error
+        }, { scope: 'test', auto: true } ],
+      });
+      const fail10 = test.extend<{}, {}>({
+        bar: [ async ({}, use) => {
+          await use(42);
+        // @ts-expect-error
+        }, { scope: 'test' } ],
       });
     `,
     'playwright.config.ts': `

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -2142,9 +2142,9 @@ export type WorkerFixture<R, Args extends KeyValue> = (args: Args, use: (r: R) =
 type TestFixtureValue<R, Args> = R | TestFixture<R, Args>;
 type WorkerFixtureValue<R, Args> = R | WorkerFixture<R, Args>;
 export type Fixtures<T extends KeyValue = {}, W extends KeyValue = {}, PT extends KeyValue = {}, PW extends KeyValue = {}> = {
-  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW>;
+  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker' }];
 } & {
-  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW>;
+  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test' }];
 } & {
   [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean }];
 } & {

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -265,9 +265,9 @@ export type WorkerFixture<R, Args extends KeyValue> = (args: Args, use: (r: R) =
 type TestFixtureValue<R, Args> = R | TestFixture<R, Args>;
 type WorkerFixtureValue<R, Args> = R | WorkerFixture<R, Args>;
 export type Fixtures<T extends KeyValue = {}, W extends KeyValue = {}, PT extends KeyValue = {}, PW extends KeyValue = {}> = {
-  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW>;
+  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker' }];
 } & {
-  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW>;
+  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test' }];
 } & {
   [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean }];
 } & {


### PR DESCRIPTION
Otherwise it shows a confusing error.

References #7447.