### PR TITLE
fix(protocol): remove unnused strict in QSA and add it to waitForSelector docs

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -974,3 +974,5 @@ This method does not work across navigations, use [`method: Page.waitForSelector
 ### option: ElementHandle.waitForSelector.state = %%-wait-for-selector-state-%%
 
 ### option: ElementHandle.waitForSelector.timeout = %%-input-timeout-%%
+
+### option: ElementHandle.waitForSelector.strict = %%-input-strict-%%

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -1804,10 +1804,9 @@ export type FrameQuerySelectorResult = {
 };
 export type FrameQuerySelectorAllParams = {
   selector: string,
-  strict?: boolean,
 };
 export type FrameQuerySelectorAllOptions = {
-  strict?: boolean,
+
 };
 export type FrameQuerySelectorAllResult = {
   elements: ElementHandleChannel[],

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -1463,7 +1463,6 @@ Frame:
     querySelectorAll:
       parameters:
         selector: string
-        strict: boolean?
       returns:
         elements:
           type: array

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -741,7 +741,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   });
   scheme.FrameQuerySelectorAllParams = tObject({
     selector: tString,
-    strict: tOptional(tBoolean),
   });
   scheme.FrameSelectOptionParams = tObject({
     selector: tString,

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -12876,6 +12876,12 @@ interface ElementHandleWaitForSelectorOptions {
   state?: "attached"|"detached"|"visible"|"hidden";
 
   /**
+   * When true, the call requires selector to resolve to a single element. If given selector resolves to more then one
+   * element, the call throws an exception.
+   */
+  strict?: boolean;
+
+  /**
    * Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by
    * using the
    * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)


### PR DESCRIPTION
Strict doesn't make sense in querySelectorAll, but it was in the protocol.

And we had a strict option in ElementHandle.waitForSelector but it
was not surfaced in the docs/api.
