### PR TITLE
feat(test runner): show stdio for failures in terminal reporters

### DIFF
--- a/src/test/reporters/dot.ts
+++ b/src/test/reporters/dot.ts
@@ -21,6 +21,18 @@ import { FullResult, TestCase, TestResult } from '../../../types/testReporter';
 class DotReporter extends BaseReporter {
   private _counter = 0;
 
+  onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+    super.onStdOut(chunk, test, result);
+    if (!this.config.quiet)
+      process.stdout.write(chunk);
+  }
+
+  onStdErr(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+    super.onStdErr(chunk, test, result);
+    if (!this.config.quiet)
+      process.stderr.write(chunk);
+  }
+
   onTestEnd(test: TestCase, result: TestResult) {
     super.onTestEnd(test, result);
     if (this._counter === 80) {

--- a/src/test/reporters/junit.ts
+++ b/src/test/reporters/junit.ts
@@ -18,7 +18,7 @@ import fs from 'fs';
 import path from 'path';
 import { FullConfig, FullResult, Reporter, Suite, TestCase } from '../../../types/testReporter';
 import { monotonicTime } from '../util';
-import { formatFailure, formatTestTitle, stripAscii } from './base';
+import { formatFailure, formatTestTitle, stripAnsiEscapes } from './base';
 
 class JUnitReporter implements Reporter {
   private config!: FullConfig;
@@ -142,7 +142,7 @@ class JUnitReporter implements Reporter {
           message: `${path.basename(test.location.file)}:${test.location.line}:${test.location.column} ${test.title}`,
           type: 'FAILURE',
         },
-        text: stripAscii(formatFailure(this.config, test))
+        text: stripAnsiEscapes(formatFailure(this.config, test))
       });
     }
     for (const result of test.results) {

--- a/src/test/reporters/line.ts
+++ b/src/test/reporters/line.ts
@@ -30,11 +30,13 @@ class LineReporter extends BaseReporter {
     console.log();
   }
 
-  onStdOut(chunk: string | Buffer, test?: TestCase) {
+  onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+    super.onStdOut(chunk, test, result);
     this._dumpToStdio(test, chunk, process.stdout);
   }
 
-  onStdErr(chunk: string | Buffer, test?: TestCase) {
+  onStdErr(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+    super.onStdErr(chunk, test, result);
     this._dumpToStdio(test, chunk, process.stderr);
   }
 

--- a/src/test/reporters/list.ts
+++ b/src/test/reporters/list.ts
@@ -27,7 +27,6 @@ const POSITIVE_STATUS_MARK = DOES_NOT_SUPPORT_UTF8_IN_TERMINAL ? 'ok' : '✓';
 const NEGATIVE_STATUS_MARK = DOES_NOT_SUPPORT_UTF8_IN_TERMINAL ? 'x' : '✘';
 
 class ListReporter extends BaseReporter {
-  private _failure = 0;
   private _lastRow = 0;
   private _testRows = new Map<TestCase, number>();
   private _needNewLine = false;
@@ -44,16 +43,18 @@ class ListReporter extends BaseReporter {
         process.stdout.write('\n');
         this._lastRow++;
       }
-      process.stdout.write('     ' + colors.gray(formatTestTitle(this.config, test) + ': ') + '\n');
+      process.stdout.write('     ' + colors.gray(formatTestTitle(this.config, test)) + '\n');
     }
     this._testRows.set(test, this._lastRow++);
   }
 
-  onStdOut(chunk: string | Buffer, test?: TestCase) {
+  onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+    super.onStdOut(chunk, test, result);
     this._dumpToStdio(test, chunk, process.stdout);
   }
 
-  onStdErr(chunk: string | Buffer, test?: TestCase) {
+  onStdErr(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+    super.onStdErr(chunk, test, result);
     this._dumpToStdio(test, chunk, process.stdout);
   }
 
@@ -76,13 +77,13 @@ class ListReporter extends BaseReporter {
     const title = formatTestTitle(this.config, test);
     let text = '';
     if (result.status === 'skipped') {
-      text = colors.green('  - ') + colors.cyan(title);
+      text = colors.green('  -  ') + colors.cyan(title);
     } else {
       const statusMark = ('  ' + (result.status === 'passed' ? POSITIVE_STATUS_MARK : NEGATIVE_STATUS_MARK)).padEnd(5);
       if (result.status === test.expectedStatus)
         text = '\u001b[2K\u001b[0G' + colors.green(statusMark) + colors.gray(title) + duration;
       else
-        text = '\u001b[2K\u001b[0G' + colors.red(`${statusMark}${++this._failure}) ` + title) + duration;
+        text = '\u001b[2K\u001b[0G' + colors.red(statusMark + title) + duration;
     }
 
     const testRow = this._testRows.get(test)!;

--- a/tests/playwright-test/base-reporter.spec.ts
+++ b/tests/playwright-test/base-reporter.spec.ts
@@ -16,6 +16,7 @@
 
 import { test, expect, stripAscii } from './playwright-test-fixtures';
 import * as path from 'path';
+import colors from 'colors/safe';
 
 test('handle long test names', async ({ runInlineTest }) => {
   const title = 'title'.repeat(30);
@@ -157,4 +158,26 @@ test('should not print slow tests', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(4);
   expect(stripAscii(result.output)).not.toContain('Slow test');
+});
+
+test('should print stdio for failures', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test('fails', async ({}) => {
+        console.log('my log 1');
+        console.error('my error');
+        console.log('my log 2');
+        expect(1).toBe(2);
+      });
+    `,
+  }, {}, { PWTEST_SKIP_TEST_OUTPUT: '' });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.output).toContain('Test output');
+  expect(result.output).toContain([
+    'my log 1\n',
+    colors.red('my error\n'),
+    'my log 2\n',
+  ].join(''));
 });

--- a/tests/playwright-test/list-reporter.spec.ts
+++ b/tests/playwright-test/list-reporter.spec.ts
@@ -32,14 +32,18 @@ test('render each test with project name', async ({ runInlineTest }) => {
       test('passes', async ({}) => {
         expect(0).toBe(0);
       });
+      test.skip('skipped', async () => {
+      });
     `,
   }, { reporter: 'list' });
   const text = stripAscii(result.output);
   const positiveStatusMarkPrefix = process.platform === 'win32' ? 'ok' : '✓ ';
   const negativateStatusMarkPrefix = process.platform === 'win32' ? 'x ' : '✘ ';
-  expect(text).toContain(`${negativateStatusMarkPrefix} 1) [foo] › a.test.ts:6:7 › fails`);
-  expect(text).toContain(`${negativateStatusMarkPrefix} 2) [bar] › a.test.ts:6:7 › fails`);
+  expect(text).toContain(`${negativateStatusMarkPrefix} [foo] › a.test.ts:6:7 › fails`);
+  expect(text).toContain(`${negativateStatusMarkPrefix} [bar] › a.test.ts:6:7 › fails`);
   expect(text).toContain(`${positiveStatusMarkPrefix} [foo] › a.test.ts:9:7 › passes`);
   expect(text).toContain(`${positiveStatusMarkPrefix} [bar] › a.test.ts:9:7 › passes`);
+  expect(text).toContain(`-  [foo] › a.test.ts:12:12 › skipped`);
+  expect(text).toContain(`-  [bar] › a.test.ts:12:12 › skipped`);
   expect(result.exitCode).toBe(1);
 });

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -145,10 +145,11 @@ async function runPlaywrightTest(baseDir: string, params: any, env: Env, options
   const testProcess = spawn('node', args, {
     env: {
       ...process.env,
-      ...env,
       PLAYWRIGHT_JSON_OUTPUT_NAME: reportFile,
       PWTEST_CACHE_DIR: cacheDir,
       PWTEST_CLI_ALLOW_TEST_COMMAND: '1',
+      PWTEST_SKIP_TEST_OUTPUT: '1',
+      ...env,
     },
     cwd: baseDir
   });


### PR DESCRIPTION
Shows stdio in a separate "Test output" section for failed test runs. 

Example output:
<img width="840" alt="Screen Shot 2021-08-11 at 12 59 01 PM" src="https://user-images.githubusercontent.com/9881434/129094916-3be9a7f0-5528-47b4-bbdd-09cee61b3b77.png">
