### PR TITLE
fix: fulfill intercepted response with empty body

### DIFF
--- a/src/client/network.ts
+++ b/src/client/network.ts
@@ -265,7 +265,7 @@ export class Route extends ChannelOwner<channels.RouteChannel, channels.RouteIni
 
   async fulfill(options: { status?: number, headers?: Headers, contentType?: string, body?: string | Buffer, path?: string } = {}) {
     return this._wrapApiCall(async (channel: channels.RouteChannel) => {
-      let body = '';
+      let body = undefined;
       let isBase64 = false;
       let length = 0;
       if (options.path) {

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -222,9 +222,9 @@ export class Route extends SdkObject {
     this._handled = true;
     let body = overrides.body;
     let isBase64 = overrides.isBase64 || false;
-    if (!body) {
+    if (body === undefined) {
       if (this._response) {
-        body = (await this._delegate.responseBody(true)).toString('utf8');
+        body = (await this._delegate.responseBody()).toString('utf8');
         isBase64 = false;
       } else {
         body = '';
@@ -254,7 +254,7 @@ export class Route extends SdkObject {
 
   async responseBody(): Promise<Buffer> {
     assert(!this._handled, 'Route is already handled!');
-    return this._delegate.responseBody(false);
+    return this._delegate.responseBody();
   }
 }
 
@@ -474,7 +474,7 @@ export interface RouteDelegate {
   abort(errorCode: string): Promise<void>;
   fulfill(response: types.NormalizedFulfillResponse): Promise<void>;
   continue(request: Request, overrides: types.NormalizedContinueOverrides): Promise<InterceptedResponse|null>;
-  responseBody(forFulfill: boolean): Promise<Buffer>;
+  responseBody(): Promise<Buffer>;
 }
 
 // List taken from https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml with extra 306 and 418 codes.

--- a/tests/page/page-request-intercept.spec.ts
+++ b/tests/page/page-request-intercept.spec.ts
@@ -40,6 +40,21 @@ it('should fulfill intercepted response', async ({page, server, browserName}) =>
   expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
 });
 
+it('should fulfill response with empty body', async ({page, server, browserName}) => {
+  it.fail(browserName === 'firefox');
+  await page.route('**/*', async route => {
+    // @ts-expect-error
+    await route._intercept({});
+    await route.fulfill({
+      status: 201,
+      body: ''
+    });
+  });
+  const response = await page.goto(server.PREFIX + '/title.html');
+  expect(response.status()).toBe(201);
+  expect(await response.text()).toBe('');
+});
+
 it('should throw on continue after intercept', async ({page, server, browserName}) => {
   let routeCallback;
   const routePromise = new Promise<Route>(f => routeCallback = f);


### PR DESCRIPTION
When fulfilling intercepted response and the client didn't provide overridden body we now fetch original body in all browsers including firefox and pass it to the fulfill.

#1774