### PR TITLE
chore: bump ff beta to 1275

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "firefox-beta",
-      "revision": "1274",
+      "revision": "1275",
       "installByDefault": false
     },
     {


### PR DESCRIPTION
Should fix failing Firefox Beta tests.