### PR TITLE
fix(test runner): make sure we always teardown all fixtures

### DIFF
--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -223,14 +223,23 @@ export class FixtureRunner {
   }
 
   async teardownScope(scope: FixtureScope) {
+    let error: Error | undefined;
     // Teardown fixtures in the reverse order.
     const fixtures = Array.from(this.instanceForId.values()).reverse();
     for (const fixture of fixtures) {
-      if (fixture.registration.scope === scope)
-        await fixture.teardown();
+      if (fixture.registration.scope === scope) {
+        try {
+          await fixture.teardown();
+        } catch (e) {
+          if (error === undefined)
+            error = e;
+        }
+      }
     }
     if (scope === 'test')
       this.testScopeClean = true;
+    if (error !== undefined)
+      throw error;
   }
 
   async resolveParametersAndRunHookOrTest(fn: Function, workerInfo: WorkerInfo, testInfo: TestInfo | undefined) {


### PR DESCRIPTION
Even if one of the fixtures throws, we should teardown all of them so that we can run afterAll hooks.