### PR TITLE
fix: do not show the "accept incoming network connections" dialog

### DIFF
--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -197,7 +197,7 @@ const DEFAULT_ARGS = [
   '--disable-default-apps',
   '--disable-dev-shm-usage',
   '--disable-extensions',
-  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose',
+  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter',
   '--allow-pre-commit-input',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',


### PR DESCRIPTION
The dialog is provoked by a [MediaRouter chromium component](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/mac_build_instructions.md#avoiding-the-incoming-network-connections-dialog)

In general, this is a very narrow functionality that should be safe
to disable to not affect majority of users on MacOS.

Fixes #7937