### PR TITLE
feat(tracing): support recording video through tracing

### DIFF
--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -136,8 +136,6 @@ Whether to record video for all pages.
 Alternatively, specifies the dimensions of the recorded video. Actual picture of each page will be scaled down if necessary to fit the specified size.
 
 ## async method: Tracing.stop
-- returns: <[Object]>
-  - `videoFiles` <[Array]<[string]>> The list of video files created next to the exported trace file.
 
 Stop tracing.
 
@@ -145,5 +143,3 @@ Stop tracing.
 - `path` <[path]>
 
 Export trace into the file with the given name.
-
-If started with the `video` option, a few additional video files will be exported next to the trace file.

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -3,7 +3,7 @@
 API for collecting and saving Playwright traces. Playwright traces can be opened using the Playwright CLI after
 Playwright script runs.
 
-Start with specifying the folder traces will be stored in:
+Start recording a trace, then perform actions, and later stop recording and export trace to a file.
 
 ```js
 const browser = await chromium.launch();
@@ -126,7 +126,18 @@ a timeline preview.
 
 Whether to capture DOM snapshot on every action.
 
+### option: Tracing.start.video
+- `video` <[boolean]|[Object]>
+  - `width` <[int]> Video frame width.
+  - `height` <[int]> Video frame height.
+
+Whether to record video for all pages.
+
+Alternatively, specifies the dimensions of the recorded video. Actual picture of each page will be scaled down if necessary to fit the specified size.
+
 ## async method: Tracing.stop
+- returns: <[Object]>
+  - `videoFiles` <[Array]<[string]>> The list of video files created next to the exported trace file.
 
 Stop tracing.
 
@@ -134,3 +145,5 @@ Stop tracing.
 - `path` <[path]>
 
 Export trace into the file with the given name.
+
+If started with the `video` option, a few additional video files will be exported next to the trace file.

--- a/src/dispatchers/browserContextDispatcher.ts
+++ b/src/dispatchers/browserContextDispatcher.ts
@@ -192,7 +192,10 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   }
 
   async tracingExport(params: channels.BrowserContextTracingExportParams): Promise<channels.BrowserContextTracingExportResult> {
-    const artifact = await this._context.tracing.export();
-    return { artifact: new ArtifactDispatcher(this._scope, artifact) };
+    const result = await this._context.tracing.export();
+    return {
+      trace: new ArtifactDispatcher(this._scope, result.trace),
+      video: result.video.map(artifact => new ArtifactDispatcher(this._scope, artifact)),
+    };
   }
 }

--- a/src/dispatchers/browserContextDispatcher.ts
+++ b/src/dispatchers/browserContextDispatcher.ts
@@ -192,10 +192,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   }
 
   async tracingExport(params: channels.BrowserContextTracingExportParams): Promise<channels.BrowserContextTracingExportResult> {
-    const result = await this._context.tracing.export();
-    return {
-      trace: new ArtifactDispatcher(this._scope, result.trace),
-      video: result.video.map(artifact => new ArtifactDispatcher(this._scope, artifact)),
-    };
+    const artifact = await this._context.tracing.export();
+    return { artifact: new ArtifactDispatcher(this._scope, artifact) };
   }
 }

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -859,11 +859,21 @@ export type BrowserContextTracingStartParams = {
   name?: string,
   snapshots?: boolean,
   screenshots?: boolean,
+  video?: boolean,
+  videoSize?: {
+    width: number,
+    height: number,
+  },
 };
 export type BrowserContextTracingStartOptions = {
   name?: string,
   snapshots?: boolean,
   screenshots?: boolean,
+  video?: boolean,
+  videoSize?: {
+    width: number,
+    height: number,
+  },
 };
 export type BrowserContextTracingStartResult = void;
 export type BrowserContextTracingStopParams = {};
@@ -872,7 +882,8 @@ export type BrowserContextTracingStopResult = void;
 export type BrowserContextTracingExportParams = {};
 export type BrowserContextTracingExportOptions = {};
 export type BrowserContextTracingExportResult = {
-  artifact: ArtifactChannel,
+  trace: ArtifactChannel,
+  video: ArtifactChannel[],
 };
 
 // ----------- Page -----------

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -882,8 +882,7 @@ export type BrowserContextTracingStopResult = void;
 export type BrowserContextTracingExportParams = {};
 export type BrowserContextTracingExportOptions = {};
 export type BrowserContextTracingExportResult = {
-  trace: ArtifactChannel,
-  video: ArtifactChannel[],
+  artifact: ArtifactChannel,
 };
 
 // ----------- Page -----------

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -650,10 +650,7 @@ BrowserContext:
 
     tracingExport:
       returns:
-        trace: Artifact
-        video:
-          type: array
-          items: Artifact
+        artifact: Artifact
 
   events:
 

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -639,12 +639,21 @@ BrowserContext:
         name: string?
         snapshots: boolean?
         screenshots: boolean?
+        video: boolean?
+        videoSize:
+          type: object?
+          properties:
+            width: number
+            height: number
 
     tracingStop:
 
     tracingExport:
       returns:
-        artifact: Artifact
+        trace: Artifact
+        video:
+          type: array
+          items: Artifact
 
   events:
 

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -413,6 +413,11 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     name: tOptional(tString),
     snapshots: tOptional(tBoolean),
     screenshots: tOptional(tBoolean),
+    video: tOptional(tBoolean),
+    videoSize: tOptional(tObject({
+      width: tNumber,
+      height: tNumber,
+    })),
   });
   scheme.BrowserContextTracingStopParams = tOptional(tObject({}));
   scheme.BrowserContextTracingExportParams = tOptional(tObject({}));

--- a/src/server/browser.ts
+++ b/src/server/browser.ts
@@ -101,6 +101,12 @@ export abstract class Browser extends SdkObject {
   _videoStarted(context: BrowserContext, videoId: string, path: string, pageOrError: Promise<Page | Error>) {
     const artifact = new Artifact(context, path);
     this._idToVideo.set(videoId, { context, artifact });
+    if (!context._options.recordVideo) {
+      // Videos started for custom startVideoRecording without recordVideo option
+      // should not be reported to the client.
+      context.emit(BrowserContext.Events.VideoStartedWithoutRecordVideoOption, artifact);
+      return;
+    }
     context.emit(BrowserContext.Events.VideoStarted, artifact);
     pageOrError.then(page => {
       if (page instanceof Page) {

--- a/src/server/chromium/videoRecorder.ts
+++ b/src/server/chromium/videoRecorder.ts
@@ -20,9 +20,14 @@ import { Page } from '../page';
 import { launchProcess } from '../../utils/processLauncher';
 import { Progress, ProgressController } from '../progress';
 import { internalCallMetadata } from '../instrumentation';
-import * as types from '../types';
 
 const fps = 25;
+
+export type VideoRecorderOptions = {
+  width: number,
+  height: number,
+  outputFile: string,
+};
 
 export class VideoRecorder {
   private _process: ChildProcess | null = null;
@@ -36,7 +41,7 @@ export class VideoRecorder {
   private _isStopped = false;
   private _ffmpegPath: string;
 
-  static async launch(page: Page, ffmpegPath: string, options: types.PageScreencastOptions): Promise<VideoRecorder> {
+  static async launch(page: Page, ffmpegPath: string, options: VideoRecorderOptions): Promise<VideoRecorder> {
     if (!options.outputFile.endsWith('.webm'))
       throw new Error('File must have .webm extension');
 
@@ -55,7 +60,7 @@ export class VideoRecorder {
     page.on(Page.Events.ScreencastFrame, frame => this.writeFrame(frame.buffer, frame.timestamp));
   }
 
-  private async _launch(options: types.PageScreencastOptions) {
+  private async _launch(options: VideoRecorderOptions) {
     // How to tune the codec:
     // 1. Read vp8 documentation to figure out the options.
     //   https://www.webmproject.org/docs/encoder-parameters/

--- a/src/server/firefox/ffBrowser.ts
+++ b/src/server/firefox/ffBrowser.ts
@@ -203,18 +203,6 @@ export class FFBrowserContext extends BrowserContext {
       browserContextId,
       reducedMotion: this._options.reducedMotion !== undefined  ? this._options.reducedMotion : 'no-preference',
     }));
-    if (this._options.recordVideo) {
-      promises.push(this._ensureVideosPath().then(() => {
-        return this._browser._connection.send('Browser.setVideoRecordingOptions', {
-          // validateBrowserContextOptions ensures correct video size.
-          options: {
-            ...this._options.recordVideo!.size!,
-            dir: this._options.recordVideo!.dir,
-          },
-          browserContextId: this._browserContextId
-        });
-      }));
-    }
     if (this._options.proxy) {
       promises.push(this._browser._connection.send('Browser.setContextProxy', {
         browserContextId: this._browserContextId,
@@ -334,6 +322,23 @@ export class FFBrowserContext extends BrowserContext {
 
   async _doCancelDownload(uuid: string) {
     await this._browser._connection.send('Browser.cancelDownload', { uuid });
+  }
+
+  async _doStartVideoRecording() {
+    await this._browser._connection.send('Browser.setVideoRecordingOptions', {
+      options: {
+        ...this._videoOptions!.size,
+        dir: this._videoOptions!.dir,
+      },
+      browserContextId: this._browserContextId,
+    });
+  }
+
+  async _doStopVideoRecording() {
+    await this._browser._connection.send('Browser.setVideoRecordingOptions', {
+      options: undefined,
+      browserContextId: this._browserContextId,
+    });
   }
 }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -58,12 +58,6 @@ export type ScreenshotOptions = ElementScreenshotOptions & {
   clip?: Rect,
 };
 
-export type PageScreencastOptions = {
-  width: number,
-  height: number,
-  outputFile: string,
-};
-
 export type Credentials = {
   username: string;
   password: string;
@@ -244,6 +238,7 @@ export type SetNetworkCookieParam = {
 
 export type EmulatedSize = { viewport: Size, screen: Size };
 
+export type VideoOptions = { dir: string, size: Size };
 export type BrowserContextOptions = {
   sdkLanguage: string,
   viewport?: Size,

--- a/src/server/webkit/wkBrowser.ts
+++ b/src/server/webkit/wkBrowser.ts
@@ -328,4 +328,12 @@ export class WKBrowserContext extends BrowserContext {
   async _doCancelDownload(uuid: string) {
     await this._browser._browserSession.send('Playwright.cancelDownload', { uuid });
   }
+
+  async _doStartVideoRecording() {
+    await Promise.all(this._wkPages().map(page => page._startVideo(this._videoOptions!)));
+  }
+
+  async _doStopVideoRecording() {
+    await Promise.all(this._wkPages().map(page => page._stopVideo()));
+  }
 }

--- a/src/test/matchers/golden.ts
+++ b/src/test/matchers/golden.ts
@@ -23,6 +23,7 @@ import jpeg from 'jpeg-js';
 import pixelmatch from 'pixelmatch';
 import { diff_match_patch, DIFF_INSERT, DIFF_DELETE, DIFF_EQUAL } from '../../third_party/diff_match_patch';
 import { UpdateSnapshots } from '../types';
+import { addSuffixToFilePath } from '../../utils/utils';
 
 // Note: we require the pngjs version of pixelmatch to avoid version mismatches.
 const { PNG } = require(require.resolve('pngjs', { paths: [require.resolve('pixelmatch')] }));
@@ -91,9 +92,9 @@ export function compare(
 ): { pass: boolean; message?: string; expectedPath?: string, actualPath?: string, diffPath?: string, mimeType?: string } {
   const snapshotFile = snapshotPath(name);
   const outputFile = outputPath(name);
-  const expectedPath = addSuffix(outputFile, '-expected');
-  const actualPath = addSuffix(outputFile, '-actual');
-  const diffPath = addSuffix(outputFile, '-diff');
+  const expectedPath = addSuffixToFilePath(outputFile, '-expected');
+  const actualPath = addSuffixToFilePath(outputFile, '-actual');
+  const diffPath = addSuffixToFilePath(outputFile, '-diff');
 
   if (!fs.existsSync(snapshotFile)) {
     const isWriteMissingMode = updateSnapshots === 'all' || updateSnapshots === 'missing';
@@ -189,13 +190,6 @@ export function compare(
 
 function indent(lines: string, tab: string) {
   return lines.replace(/^(?=.+$)/gm, tab);
-}
-
-function addSuffix(filePath: string, suffix: string, customExtension?: string): string {
-  const dirname = path.dirname(filePath);
-  const ext = path.extname(filePath);
-  const name = path.basename(filePath, ext);
-  return path.join(dirname, name + suffix + (customExtension || ext));
 }
 
 function diff_prettyTerminal(diffs: diff_match_patch.Diff[]) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -392,3 +392,10 @@ export function wrapInASCIIBox(text: string, padding = 0): string {
     '╚' + '═'.repeat(maxLength + padding * 2) + '╝',
   ].join('\n');
 }
+
+export function addSuffixToFilePath(filePath: string, suffix: string, customExtension?: string): string {
+  const dirname = path.dirname(filePath);
+  const ext = path.extname(filePath);
+  const name = path.basename(filePath, ext);
+  return path.join(dirname, name + suffix + (customExtension || ext));
+}

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -11970,7 +11970,7 @@ export interface Touchscreen {
  * API for collecting and saving Playwright traces. Playwright traces can be opened using the Playwright CLI after
  * Playwright script runs.
  *
- * Start with specifying the folder traces will be stored in:
+ * Start recording a trace, then perform actions, and later stop recording and export trace to a file.
  *
  * ```js
  * const browser = await chromium.launch();
@@ -12011,6 +12011,24 @@ export interface Tracing {
      * Whether to capture DOM snapshot on every action.
      */
     snapshots?: boolean;
+
+    /**
+     * Whether to record video for all pages.
+     *
+     * Alternatively, specifies the dimensions of the recorded video. Actual picture of each page will be scaled down if
+     * necessary to fit the specified size.
+     */
+    video?: boolean|{
+      /**
+       * Video frame width.
+       */
+      width: number;
+
+      /**
+       * Video frame height.
+       */
+      height: number;
+    };
   }): Promise<void>;
 
   /**
@@ -12020,9 +12038,16 @@ export interface Tracing {
   stop(options?: {
     /**
      * Export trace into the file with the given name.
+     *
+     * If started with the `video` option, a few additional video files will be exported next to the trace file.
      */
     path?: string;
-  }): Promise<void>;
+  }): Promise<{
+    /**
+     * The list of video files created next to the exported trace file.
+     */
+    videoFiles: Array<string>;
+  }>;
 }
 
 /**

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -12038,16 +12038,9 @@ export interface Tracing {
   stop(options?: {
     /**
      * Export trace into the file with the given name.
-     *
-     * If started with the `video` option, a few additional video files will be exported next to the trace file.
      */
     path?: string;
-  }): Promise<{
-    /**
-     * The list of video files created next to the exported trace file.
-     */
-    videoFiles: Array<string>;
-  }>;
+  }): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
- `tracing.start()` gets a `video` option.
- When exporting, we generate a few video files next to the trace file and return them as `{ videoFiles: string[] }`.
- Video is stopped on any trace export, until the next `tracing.start()` call.
- This includes the ability to start/stop videos on the live pages, implemented differently in all engines.
- Tracing video is mutually exclusive with `recordVideo` context option.