### PR TITLE
docs(js): fix syntax errors at intro page examples

### DIFF
--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -103,7 +103,7 @@ test('my test', async ({ page }) => {
   await expect(page).toHaveTitle('Playwright');
 
   // Expect an attribute "to be strictly equal" to the value.
-  await expect(page.locator('text=Get Started').toHaveAttribute('href', '/docs/intro');
+  await expect(page.locator('text=Get Started')).toHaveAttribute('href', '/docs/intro');
 
   // Expect an element "to be visible".
   await expect(page.locator('text=Learn more')).toBeVisible();
@@ -128,7 +128,7 @@ test('my test', async ({ page }) => {
   await expect(page).toHaveTitle('Playwright');
 
   // Expect an attribute "to be strictly equal" to the value.
-  await expect(page.locator('text=Get Started').toHaveAttribute('href', '/docs/intro');
+  await expect(page.locator('text=Get Started')).toHaveAttribute('href', '/docs/intro');
 
   // Expect an element "to be visible".
   await expect(page.locator('text=Learn more')).toBeVisible();


### PR DESCRIPTION
## What Changed?
- Examples (Both JS and TS) at Getting Started page were not compiling after a copy/paste since the JavaScript syntax is false due to missing closing parentheses at attribution selectors. They added.