### PR TITLE
docs: clarify download lifetime when downloadsPath is specified

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -659,7 +659,8 @@ Enable Chromium sandboxing. Defaults to `false`.
 - `downloadsPath` <[path]>
 
 If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and is
-deleted when browser is closed.
+deleted when browser is closed. In either case, the downloads are deleted when the browser context they were created in
+is closed.
 
 ## browser-option-executablepath
 - `executablePath` <[path]>

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -8280,7 +8280,8 @@ export interface BrowserType<Unused = {}> {
 
     /**
      * If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and is
-     * deleted when browser is closed.
+     * deleted when browser is closed. In either case, the downloads are deleted when the browser context they were created in
+     * is closed.
      */
     downloadsPath?: string;
 
@@ -8610,7 +8611,8 @@ export interface BrowserType<Unused = {}> {
 
     /**
      * If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and is
-     * deleted when browser is closed.
+     * deleted when browser is closed. In either case, the downloads are deleted when the browser context they were created in
+     * is closed.
      */
     downloadsPath?: string;
 
@@ -12628,7 +12630,8 @@ export interface LaunchOptions {
 
   /**
    * If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and is
-   * deleted when browser is closed.
+   * deleted when browser is closed. In either case, the downloads are deleted when the browser context they were created in
+   * is closed.
    */
   downloadsPath?: string;
 


### PR DESCRIPTION
Fixes #8205