### PR TITLE
fix(test runner): make sure tracing is not running on non-retries

### DIFF
--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -194,6 +194,8 @@ export const test = _baseTest.extend<TestFixtures, WorkerAndFileFixtures>({
       context.setDefaultNavigationTimeout(navigationTimeout || actionTimeout || 0);
       if (captureTrace)
         await context.tracing.start({ screenshots: true, snapshots: true });
+      else
+        await context.tracing.stop();
       (context as any)._csi = {
         onApiCall: (name: string) => {
           return (testInfo as any)._addStep('pw:api', name);


### PR DESCRIPTION
When sharing a context between tests and using `'on-first-retry'` we could end up with tracing still running in non-retried tests. That's extra overhead without a reason.