### PR TITLE
docs(network): add notes, tests re: proxy loopback

### DIFF
--- a/docs/src/network.md
+++ b/docs/src/network.md
@@ -71,6 +71,19 @@ for the entire browser, or for each browser context individually.
 You can optionally specify username and password for HTTP(S) proxy, you can also specify hosts to
 bypass proxy for.
 
+:::note
+Chromium, unlike WebKit and Firefox, will **not** proxy localhost, link locals
+(i.e. 169.254/16), and loopback addresses by default (unless
+running in headful mode on Linux).
+
+If you need these requests (e.g. `page.goto("http://localhost:3030")`) to route
+through the configured proxy, add the special token `<-loopback>` to the `bypass`
+option.
+
+Do not pass `<-loopback>` to non-Chromium browsers as behavior will be undefined
+or broken.
+:::
+
 Here is an example of a global proxy:
 
 ```js


### PR DESCRIPTION
Chromium's behavior diverges from the other browsers regarding implicit
proxy bypass of some loopback and local addresses.

While debugging tests, I sometimes use an HTTP Proxy debugger and/or
external HAR capture and Chrome was not forwarding requests I expected
to end up at the proxy.

This change documents this behavior as well as the obscure (to me) work
around derived from [Chromium source code][src-code].

[src-code]: https://source.chromium.org/chromium/chromium/src/+/main:net/proxy_resolution/proxy_bypass_rules.cc