### PR TITLE
devops: add workflow to roll new browser into PW

### DIFF
--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -1,0 +1,42 @@
+name: Roll Browser into Playwright
+
+on:
+  repository_dispatch:
+    types: [roll_into_pw]
+
+jobs:
+  roll:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 14
+    - run: npm ci
+    - run: npm run build
+    - name: Roll to new revision
+      run: |
+        ./utils/roll_browser.js ${{ github.event.client_payload.browser }} ${{ github.event.client_payload.revision }}
+    - name: Prepare branch
+      id: prepare-branch
+      run: |
+        BASE_POSITION="${{ steps.bump-chromium.outputs.BASE_POSITION }}"
+        BRANCH_NAME="roll-${{ github.event.client_payload.browser }}/${{ github.event.client_payload.revision }}"
+        echo "::set-output name=BRANCH_NAME::$BRANCH_NAME"
+        git config --global user.name github-actions
+        git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
+        git checkout -b "$BRANCH_NAME"
+        git add .
+        git commit -m "feat(${{ github.event.client_payload.browser }}): roll to r${{ github.event.client_payload.revision }}"
+        git push origin $BRANCH_NAME
+    - name: Create Pull Request
+      uses: actions/github-script@v4
+      with:
+        script: |
+          await github.pulls.create({
+            owner: 'microsoft',
+            repo: 'playwright',
+            head: 'microsoft:${{ steps.prepare-branch.outputs.BRANCH_NAME }}',
+            base: 'master',
+            title: 'feat(${{ github.event.client_payload.browser }}): roll to r${{ github.event.client_payload.revison }}',
+          });

--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -403,6 +403,14 @@ function generate_and_upload_browser_build {
   return 0
 }
 
+function create_roll_into_playwright_pr {
+  curl -X POST \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Authorization: token ${GH_TOKEN}" \
+  --data '{"event_type": "roll_into_pw", "client_payload": {"browser": "'"$1"'", "revision": "'"$1"'"}}' \
+  https://api.github.com/repos/microsoft/playwright/dispatches
+}
+
 source ./send_telegram_message.sh
 BUILD_ALIAS="$BUILD_FLAVOR r$BUILD_NUMBER"
 send_telegram_message "$BUILD_ALIAS -- started"
@@ -427,6 +435,7 @@ if generate_and_upload_browser_build 2>&1 | ./sanitize_and_compress_log.js $LOG_
     done;
     LAST_COMMIT_MESSAGE=$(git log --format=%s -n 1 HEAD -- "./${BROWSER_NAME}/BUILD_NUMBER")
     send_telegram_message "<b>${BROWSER_DISPLAY_NAME} r${BUILD_NUMBER} COMPLETE! ✅</b> ${LAST_COMMIT_MESSAGE}"
+    create_roll_into_playwright_pr $BROWSER_NAME $BUILD_NUMBER
   )
 else
   RESULT_CODE="$?"


### PR DESCRIPTION
The idea is the following:

1. `browser_patches/checkout_build_archive_upload.sh` detects when all browser builds are completed - this logic is already in place
2. It then triggers a `workflow_dispatch` event which contains the browser name and the new revision
3. This GitHub Action from this PR gets triggered, calls the `roll_browser.js` script, and creates a Pull Request

Why a new workflow which does the roll? Because doing it via JS (GitHub JS) is easier and via bash we would need to ensure that our repo state is fresh etc.