### PR TITLE
fix(selectors): nicer errors if the selector engine returns a bad value

### DIFF
--- a/src/server/injected/injectedScript.ts
+++ b/src/server/injected/injectedScript.ts
@@ -157,8 +157,11 @@ export class InjectedScript {
         queryResults[index] = all;
       }
 
-      for (const element of all)
+      for (const element of all) {
+        if (!('nodeName' in element))
+          throw new Error(`Expected a Node but got ${Object.prototype.toString.call(element)}`);
         result.push({ element, capture });
+      }
     }
     return this._querySelectorRecursively(result, selector, index + 1, queryCache);
   }

--- a/tests/selectors-register.spec.ts
+++ b/tests/selectors-register.spec.ts
@@ -134,7 +134,7 @@ it('should not rely on engines working from the root', async ({ playwright, brow
   expect(await page.$eval('input >> __value=value2', e => e.id)).toBe('input2');
 });
 
-it.only('should throw a nice error if the selector returns a bad value', async ({ playwright, browser }) => {
+it('should throw a nice error if the selector returns a bad value', async ({ playwright, browser }) => {
   const page = await browser.newPage();
   const createFakeEngine = () => ({
     query(root, selector) {

--- a/tests/selectors-register.spec.ts
+++ b/tests/selectors-register.spec.ts
@@ -133,3 +133,19 @@ it('should not rely on engines working from the root', async ({ playwright, brow
   await page.setContent(`<input id=input1 value=value1><input id=input2 value=value2>`);
   expect(await page.$eval('input >> __value=value2', e => e.id)).toBe('input2');
 });
+
+it.only('should throw a nice error if the selector returns a bad value', async ({ playwright, browser }) => {
+  const page = await browser.newPage();
+  const createFakeEngine = () => ({
+    query(root, selector) {
+      return [document.body];
+    },
+    queryAll(root, selector) {
+      return [[document.body]];
+    },
+  });
+
+  await playwright.selectors.register('__fake', createFakeEngine);
+  const error = await page.$('__fake=value2').catch(e => e);
+  expect(error.message).toContain('Expected a Node but got [object Array]');
+});


### PR DESCRIPTION
A selector engine returning something other than elements
would fail silently and return cryptic errors later on.﻿
