### PR TITLE
browser(webkit): fix build with shallow checkouts

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1532
-Changed: dpino@igalia.com Wed Aug 18 15:40:40 UTC 2021
+1533
+Changed: dkolesa@igalia.com Wed Aug 18 10:38:54 PM CEST 2021

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -22395,6 +22395,25 @@ index 296c902f375b1189f45ee56bb3ffd4d826dd26f6..45d8ca4bdd18e2467b26b0c6998b4dc5
 +
 +
  } // namespace WTR
+diff --git a/Tools/glib/apply-build-revision-to-files.py b/Tools/glib/apply-build-revision-to-files.py
+index a40c717362536ff5117160cd1a2d5f9f25594e3b..d20cd71927194c1d0966cc2e29673e72ef6912d3 100644
+--- a/Tools/glib/apply-build-revision-to-files.py
++++ b/Tools/glib/apply-build-revision-to-files.py
+@@ -37,7 +37,13 @@ def get_build_revision():
+                     revision = "r%s" % contents.decode('utf-8').strip()
+                     break
+         elif os.path.isdir('.git'):
+-            commit_message = subprocess.check_output(("git", "log", "-1", "--pretty=%B", "origin/HEAD"), stderr=devnull)
++            try:
++                commit_message = subprocess.check_output(("git", "log", "-1", "--pretty=%B", "origin/HEAD"), stderr=devnull)
++            except subprocess.CalledProcessError:
++                # This may happen with shallow checkouts whose HEAD has been
++                # modified; there is no origin reference anymore, and git
++                # will fail - let's pretend that this is not a repo at all
++                commit_message = ""
+             # Commit messages tend to be huge and the metadata we're looking
+             # for is at the very end. Also a spoofed 'Canonical link' mention
+             # could appear early on. So make sure we get the right metadata by
 diff --git a/Tools/glib/dependencies/apt b/Tools/glib/dependencies/apt
 index 02fa9bff0ab4bd094fd9498b042e06f35c25e7fc..f33f29a9a26d1219aa5780b1860792353a70f4ee 100644
 --- a/Tools/glib/dependencies/apt


### PR DESCRIPTION
https://github.com/WebKit/WebKit/commit/79d0e78bb1237a3a2727a20faf10a37de601172c

The above commit does not account for the git repository possibly being a shallow clone with modified HEAD - adding a local commit on top of a clone like this results in the origin reference being erased, which results in something like this:

fatal: ambiguous argument 'origin/HEAD': unknown revision or path not in the working tree.

Since we have no reference point there, let's just give up and pretend as if the repository wasn't a git clone at all.