### PR TITLE
browser(firefox): fix a race between Browser.close and closing context

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1279
-Changed: yurys@chromium.org Fri 13 Aug 2021 07:00:48 PM PDT
+1280
+Changed: dgozman@gmail.com Wed Aug 18 14:34:33 PDT 2021

--- a/browser_patches/firefox-beta/juggler/protocol/BrowserHandler.js
+++ b/browser_patches/firefox-beta/juggler/protocol/BrowserHandler.js
@@ -305,7 +305,12 @@ async function waitForWindowClosed(browserWindow) {
   await new Promise((resolve => {
     const listener = {
       onCloseWindow: window => {
-        if (window === browserWindow) {
+        let domWindow;
+        if (window instanceof Ci.nsIAppWindow)
+          domWindow = window.QueryInterface(Ci.nsIInterfaceRequestor).getInterface(Ci.nsIDOMWindowInternal || Ci.nsIDOMWindow);
+        else
+          domWindow = window;
+        if (domWindow === browserWindow) {
           Services.wm.removeListener(listener);
           resolve();
         }

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1284
-Changed: yurys@chromium.org Fri 13 Aug 2021 07:00:24 PM PDT
+1285
+Changed: dgozman@gmail.com Wed Aug 18 14:34:33 PDT 2021

--- a/browser_patches/firefox/juggler/protocol/BrowserHandler.js
+++ b/browser_patches/firefox/juggler/protocol/BrowserHandler.js
@@ -305,7 +305,12 @@ async function waitForWindowClosed(browserWindow) {
   await new Promise((resolve => {
     const listener = {
       onCloseWindow: window => {
-        if (window === browserWindow) {
+        let domWindow;
+        if (window instanceof Ci.nsIAppWindow)
+          domWindow = window.QueryInterface(Ci.nsIInterfaceRequestor).getInterface(Ci.nsIDOMWindowInternal || Ci.nsIDOMWindow);
+        else
+          domWindow = window;
+        if (domWindow === browserWindow) {
           Services.wm.removeListener(listener);
           resolve();
         }


### PR DESCRIPTION
Consider the following scenario:
- `Browser.close` command comes, and we start waiting for the browser window to either finish initialization or close.
- `Browser.removeBrowserContext` command comes, and we close the last browser window.
- Last `CI.nsIAppWindow` is closed, but we get no notification about the `DOMWindow` being closed.
- `Browser.close` hangs forever.

To fix this, we cast `CI.nsIAppWindow` to its `DOMWindow`, as we already do in other places.