### PR TITLE
test: proxy server fixture, new test for https via http proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
         "html-webpack-plugin": "^4.4.1",
         "ncp": "^2.0.0",
         "node-stream-zip": "^1.11.3",
+        "proxy": "^1.0.2",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "socksv5": "0.0.6",
@@ -2224,6 +2225,21 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "node_modules/args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2584,6 +2600,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "node_modules/basic-auth-parser": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/basic-auth-parser/-/basic-auth-parser-0.0.2.tgz",
+      "integrity": "sha1-zp5xp38jwSee7NJlmypGJEwVbkE=",
       "dev": true
     },
     "node_modules/big.js": {
@@ -2947,6 +2969,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
       "dev": true
+    },
+    "node_modules/camelcase": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001246",
@@ -6351,6 +6382,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -6753,6 +6793,15 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -7587,6 +7636,20 @@
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true,
       "optional": true
+    },
+    "node_modules/proxy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/proxy/-/proxy-1.0.2.tgz",
+      "integrity": "sha512-KNac2ueWRpjbUh77OAFPZuNdfEqNynm9DD4xHT14CccGpW8wKZwEkN0yjlb7X9G9Z9F55N0Q+1z+WfgAhwYdzQ==",
+      "dev": true,
+      "dependencies": {
+        "args": "5.0.1",
+        "basic-auth-parser": "0.0.2",
+        "debug": "^4.1.1"
+      },
+      "bin": {
+        "proxy": "bin/proxy.js"
+      }
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -11906,6 +11969,18 @@
         }
       }
     },
+    "args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -12189,6 +12264,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "basic-auth-parser": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/basic-auth-parser/-/basic-auth-parser-0.0.2.tgz",
+      "integrity": "sha1-zp5xp38jwSee7NJlmypGJEwVbkE=",
       "dev": true
     },
     "big.js": {
@@ -12520,6 +12601,12 @@
           "dev": true
         }
       }
+    },
+    "camelcase": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+      "dev": true
     },
     "caniuse-lite": {
       "version": "1.0.30001246",
@@ -15307,6 +15394,12 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -15641,6 +15734,12 @@
           }
         }
       }
+    },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -16314,6 +16413,17 @@
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true,
       "optional": true
+    },
+    "proxy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/proxy/-/proxy-1.0.2.tgz",
+      "integrity": "sha512-KNac2ueWRpjbUh77OAFPZuNdfEqNynm9DD4xHT14CccGpW8wKZwEkN0yjlb7X9G9Z9F55N0Q+1z+WfgAhwYdzQ==",
+      "dev": true,
+      "requires": {
+        "args": "5.0.1",
+        "basic-auth-parser": "0.0.2",
+        "debug": "^4.1.1"
+      }
     },
     "proxy-from-env": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "html-webpack-plugin": "^4.4.1",
     "ncp": "^2.0.0",
     "node-stream-zip": "^1.11.3",
+    "proxy": "^1.0.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "socksv5": "0.0.6",

--- a/tests/config/baseTest.ts
+++ b/tests/config/baseTest.ts
@@ -24,6 +24,7 @@ import * as childProcess from 'child_process';
 import { start } from '../../lib/outofprocess';
 import { PlaywrightClient } from '../../lib/remote/playwrightClient';
 import type { LaunchOptions } from '../../index';
+import { TestProxy } from './proxy';
 
 export type BrowserName = 'chromium' | 'firefox' | 'webkit';
 type Mode = 'default' | 'driver' | 'service';
@@ -130,6 +131,7 @@ type ServerFixtures = {
   server: TestServer;
   httpsServer: TestServer;
   socksPort: number;
+  proxyServer: TestProxy;
   asset: (p: string) => string;
 };
 
@@ -140,7 +142,7 @@ const serverFixtures: Fixtures<ServerFixtures, ServerOptions & { __servers: Serv
     const assetsPath = path.join(__dirname, '..', 'assets');
     const cachedPath = path.join(__dirname, '..', 'assets', 'cached');
 
-    const port = 8907 + workerInfo.workerIndex * 3;
+    const port = 8907 + workerInfo.workerIndex * 4;
     const server = await TestServer.create(assetsPath, port, loopback);
     server.enableHTTPCache(cachedPath);
 
@@ -168,11 +170,15 @@ const serverFixtures: Fixtures<ServerFixtures, ServerOptions & { __servers: Serv
     socksServer.listen(socksPort, 'localhost');
     socksServer.useAuth(socks.auth.None());
 
+    const proxyPort = port + 3;
+    const proxyServer = await TestProxy.create(proxyPort);
+
     await run({
       asset: (p: string) => path.join(__dirname, '..', 'assets', ...p.split('/')),
       server,
       httpsServer,
       socksPort,
+      proxyServer,
       socksServer,
     });
 
@@ -180,6 +186,7 @@ const serverFixtures: Fixtures<ServerFixtures, ServerOptions & { __servers: Serv
       server.stop(),
       httpsServer.stop(),
       socksServer.close(),
+      proxyServer.stop(),
     ]);
   }, { scope: 'worker' } ],
 
@@ -195,6 +202,11 @@ const serverFixtures: Fixtures<ServerFixtures, ServerOptions & { __servers: Serv
 
   socksPort: async ({ __servers }, run) => {
     await run(__servers.socksPort);
+  },
+
+  proxyServer: async ({ __servers }, run) => {
+    __servers.proxyServer.reset();
+    await run(__servers.proxyServer);
   },
 
   asset: async ({ __servers }, run) => {

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IncomingMessage, Server } from 'http';
+import { Socket } from 'net';
+import createProxy from 'proxy';
+
+export class TestProxy {
+  readonly PORT: number;
+  readonly URL: string;
+  readonly server: Server;
+
+  private readonly _sockets = new Set<Socket>();
+  private _connectHandlers = [];
+
+  static async create(port: number): Promise<TestProxy> {
+    const proxy = new TestProxy(port);
+    await new Promise(f => proxy.server.listen(port, f));
+    return proxy;
+  }
+
+  private constructor(port: number) {
+    this.PORT = port;
+    this.URL = `http://localhost:${port}`;
+    this.server = createProxy();
+    this.server.on('connection', socket => this._onSocket(socket));
+  }
+
+  async stop(): Promise<void> {
+    this.reset();
+    for (const socket of this._sockets)
+      socket.destroy();
+    this._sockets.clear();
+    await new Promise(x => this.server.close(x));
+  }
+
+  onConnect(handler: (req: IncomingMessage) => void) {
+    this._connectHandlers.push(handler);
+    this.server.prependListener('connect', handler);
+  }
+
+  reset() {
+    for (const handler of this._connectHandlers)
+      this.server.removeListener('connect', handler);
+    this._connectHandlers = [];
+  }
+
+  private _onSocket(socket: Socket) {
+    this._sockets.add(socket);
+    // ECONNRESET and HPE_INVALID_EOF_STATE are legit errors given
+    // that tab closing aborts outgoing connections to the server.
+    socket.on('error', (error: any) => {
+      if (error.code !== 'ECONNRESET' && error.code !== 'HPE_INVALID_EOF_STATE')
+        throw error;
+    });
+    socket.once('close', () => this._sockets.delete(socket));
+  }
+
+}


### PR DESCRIPTION
Existing proxy tests relied on the browser to send HTTP requests to the proxy as regular GET requests, whereas HTTPS via HTTP proxy requires handling CONNECT request first to establish connection to the target server. The new test executes that path. The proxy server is also going to be used to test new proxy support for the new `BrowserContext.fetch()` method.