### PR TITLE
chore: pretend world is win64

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -379,7 +379,7 @@ export const hostPlatform = ((): HostPlatform => {
     return 'ubuntu20.04';
   }
   if (platform === 'win32')
-    return os.arch() === 'x64' ? 'win64' : 'win32';
+    return 'win64';
   return platform as HostPlatform;
 })();
 


### PR DESCRIPTION
It looks like we have a very small share of users on 32-bit windows.
This is a tiny change that stops Playwright from using 32-bit windows
binaries.

References #8045
