### PR TITLE
docs: use language-neutral references to page.goto

### DIFF
--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -777,19 +777,19 @@ Attribute name to get the value for.
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
 last redirect.
 
-`frame.goto` will throw an error if:
+The method will throw an error if:
 * there's an SSL error (e.g. in case of self-signed certificates).
 * target URL is invalid.
 * the [`option: timeout`] is exceeded during navigation.
 * the remote server does not respond or is unreachable.
 * the main resource failed to load.
 
-`frame.goto` will not throw an error when any valid HTTP status code is returned by the remote server, including 404
+The method will not throw an error when any valid HTTP status code is returned by the remote server, including 404
 "Not Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling
 [`method: Response.status`].
 
 :::note
-`frame.goto` either throws an error or returns a main resource response. The only exceptions are navigation to
+The method either throws an error or returns a main resource response. The only exceptions are navigation to
 `about:blank` or navigation to the same URL with a different hash, which would succeed and return `null`.
 :::
 

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1877,19 +1877,19 @@ Navigate to the next page in history.
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
 last redirect.
 
-`page.goto` will throw an error if:
+The method will throw an error if:
 * there's an SSL error (e.g. in case of self-signed certificates).
 * target URL is invalid.
 * the [`option: timeout`] is exceeded during navigation.
 * the remote server does not respond or is unreachable.
 * the main resource failed to load.
 
-`page.goto` will not throw an error when any valid HTTP status code is returned by the remote server, including 404 "Not
+The method will not throw an error when any valid HTTP status code is returned by the remote server, including 404 "Not
 Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling
 [`method: Response.status`].
 
 :::note
-`page.goto` either throws an error or returns a main resource response. The only exceptions are navigation to
+The method either throws an error or returns a main resource response. The only exceptions are navigation to
 `about:blank` or navigation to the same URL with a different hash, which would succeed and return `null`.
 :::
 

--- a/docs/src/navigations.md
+++ b/docs/src/navigations.md
@@ -34,7 +34,7 @@ Navigations can be initiated by changing the URL bar, reloading the page or goin
 ### Auto-wait
 
 Navigating to a URL auto-waits for the page to fire the `load` event. If the page does a client-side redirect before
-`load`, `page.goto` will auto-wait for the redirected page to fire the `load` event.
+`load`, [`method: Page.goto`] will auto-wait for the redirected page to fire the `load` event.
 
 ```js
 // Navigate the page

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1760,18 +1760,18 @@ export interface Page {
    * Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
    * last redirect.
    *
-   * `page.goto` will throw an error if:
+   * The method will throw an error if:
    * - there's an SSL error (e.g. in case of self-signed certificates).
    * - target URL is invalid.
    * - the `timeout` is exceeded during navigation.
    * - the remote server does not respond or is unreachable.
    * - the main resource failed to load.
    *
-   * `page.goto` will not throw an error when any valid HTTP status code is returned by the remote server, including 404 "Not
+   * The method will not throw an error when any valid HTTP status code is returned by the remote server, including 404 "Not
    * Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling
    * [response.status()](https://playwright.dev/docs/api/class-response#response-status).
    *
-   * > NOTE: `page.goto` either throws an error or returns a main resource response. The only exceptions are navigation to
+   * > NOTE: The method either throws an error or returns a main resource response. The only exceptions are navigation to
    * `about:blank` or navigation to the same URL with a different hash, which would succeed and return `null`.
    * > NOTE: Headless mode doesn't support navigation to a PDF document. See the
    * [upstream issue](https://bugs.chromium.org/p/chromium/issues/detail?id=761295).

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -4034,18 +4034,18 @@ export interface Frame {
    * Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
    * last redirect.
    *
-   * `frame.goto` will throw an error if:
+   * The method will throw an error if:
    * - there's an SSL error (e.g. in case of self-signed certificates).
    * - target URL is invalid.
    * - the `timeout` is exceeded during navigation.
    * - the remote server does not respond or is unreachable.
    * - the main resource failed to load.
    *
-   * `frame.goto` will not throw an error when any valid HTTP status code is returned by the remote server, including 404
-   * "Not Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling
+   * The method will not throw an error when any valid HTTP status code is returned by the remote server, including 404 "Not
+   * Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling
    * [response.status()](https://playwright.dev/docs/api/class-response#response-status).
    *
-   * > NOTE: `frame.goto` either throws an error or returns a main resource response. The only exceptions are navigation to
+   * > NOTE: The method either throws an error or returns a main resource response. The only exceptions are navigation to
    * `about:blank` or navigation to the same URL with a different hash, which would succeed and return `null`.
    * > NOTE: Headless mode doesn't support navigation to a PDF document. See the
    * [upstream issue](https://bugs.chromium.org/p/chromium/issues/detail?id=761295).


### PR DESCRIPTION
Refs: https://github.com/microsoft/playwright-java/issues/576