### PR TITLE
feat(test runner): introduce config.reportFlakyFailures

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -207,6 +207,13 @@ const config: PlaywrightTestConfig = {
 export default config;
 ```
 
+## property: TestConfig.reportFlakyFailures
+- type: <[ReportFlakyFailures]<"all"|"none">>
+
+Whether to show failure details for flaky test runs. Defaults to `'none'`.
+* `'all'` - Show failure details for all flaky runs.
+* `'none'` - Do not show failure details for flaky runs.
+
 ## property: TestConfig.reportSlowTests
 - type: <[Object]>
   - `max` <[int]> The maximum number of slow tests to report. Defaults to `5`.

--- a/src/test/loader.ts
+++ b/src/test/loader.ts
@@ -95,6 +95,7 @@ export class Loader {
     this._fullConfig.maxFailures = takeFirst(this._configOverrides.maxFailures, this._config.maxFailures, baseFullConfig.maxFailures);
     this._fullConfig.preserveOutput = takeFirst<PreserveOutput>(this._configOverrides.preserveOutput, this._config.preserveOutput, baseFullConfig.preserveOutput);
     this._fullConfig.reporter = takeFirst(toReporters(this._configOverrides.reporter as any), resolveReporters(this._config.reporter, rootDir), baseFullConfig.reporter);
+    this._fullConfig.reportFlakyFailures = takeFirst(this._configOverrides.reportFlakyFailures, this._config.reportFlakyFailures, baseFullConfig.reportFlakyFailures);
     this._fullConfig.reportSlowTests = takeFirst(this._configOverrides.reportSlowTests, this._config.reportSlowTests, baseFullConfig.reportSlowTests);
     this._fullConfig.quiet = takeFirst(this._configOverrides.quiet, this._config.quiet, baseFullConfig.quiet);
     this._fullConfig.shard = takeFirst(this._configOverrides.shard, this._config.shard, baseFullConfig.shard);
@@ -420,6 +421,7 @@ const baseFullConfig: FullConfig = {
   preserveOutput: 'always',
   projects: [],
   reporter: [ ['list'] ],
+  reportFlakyFailures: 'none',
   reportSlowTests: null,
   rootDir: path.resolve(process.cwd()),
   quiet: false,

--- a/src/test/reporters/base.ts
+++ b/src/test/reporters/base.ts
@@ -110,9 +110,13 @@ export class BaseReporter implements Reporter  {
       }
     });
 
-    if (full && (unexpected.length || skippedWithError.length)) {
+    const failuresToPrint: TestCase[] = [...unexpected, ...skippedWithError];
+    if (this.config.reportFlakyFailures === 'all')
+      failuresToPrint.push(...flaky);
+
+    if (full && failuresToPrint.length) {
       console.log('');
-      this._printFailures([...unexpected, ...skippedWithError]);
+      this._printFailures(failuresToPrint);
     }
 
     this._printSlowTests();

--- a/tests/playwright-test/stdio.spec.ts
+++ b/tests/playwright-test/stdio.spec.ts
@@ -61,3 +61,18 @@ test('should get stdio from env afterAll', async ({runInlineTest}) => {
   ]);
 });
 
+test('should ignore stdio when quiet', async ({runInlineTest}) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { quiet: true };
+    `,
+    'a.spec.js': `
+      const { test } = pwt;
+      test('is a test', () => {
+        console.log('\\n%% stdout in a test');
+        console.error('\\n%% stderr in a test');
+      });
+    `
+  }, { reporter: 'list' }, { PWTEST_SKIP_TEST_OUTPUT: '' });
+  expect(result.output).not.toContain('%%');
+});

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -30,6 +30,7 @@ export type ReporterDescription =
   [string] | [string, any];
 
 export type Shard = { total: number, current: number } | null;
+export type ReportFlakyFailures = 'all' | 'none';
 export type ReportSlowTests = { max: number, threshold: number } | null;
 export type PreserveOutput = 'always' | 'never' | 'failures-only';
 export type UpdateSnapshots = 'all' | 'none' | 'missing';
@@ -672,6 +673,12 @@ interface TestConfig {
    */
   reporter?: LiteralUnion<'list'|'dot'|'line'|'json'|'junit'|'null', string> | ReporterDescription[];
   /**
+   * Whether to show failure details for flaky test runs. Defaults to `'none'`.
+   * - `'all'` - Show failure details for all flaky runs.
+   * - `'none'` - Do not show failure details for flaky runs.
+   */
+  reportFlakyFailures?: ReportFlakyFailures;
+  /**
    * Whether to report slow tests. Pass `null` to disable this feature.
    *
    * Tests that took more than `threshold` milliseconds are considered slow, and the slowest ones are reported, no more than
@@ -1017,6 +1024,12 @@ export interface FullConfig {
    *
    */
   reporter: ReporterDescription[];
+  /**
+   * Whether to show failure details for flaky test runs. Defaults to `'none'`.
+   * - `'all'` - Show failure details for all flaky runs.
+   * - `'none'` - Do not show failure details for flaky runs.
+   */
+  reportFlakyFailures: ReportFlakyFailures;
   /**
    * Whether to report slow tests. Pass `null` to disable this feature.
    *

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -29,6 +29,7 @@ export type ReporterDescription =
   [string] | [string, any];
 
 export type Shard = { total: number, current: number } | null;
+export type ReportFlakyFailures = 'all' | 'none';
 export type ReportSlowTests = { max: number, threshold: number } | null;
 export type PreserveOutput = 'always' | 'never' | 'failures-only';
 export type UpdateSnapshots = 'all' | 'none' | 'missing';
@@ -108,6 +109,7 @@ interface TestConfig {
   projects?: Project[];
   quiet?: boolean;
   reporter?: LiteralUnion<'list'|'dot'|'line'|'json'|'junit'|'null', string> | ReporterDescription[];
+  reportFlakyFailures?: ReportFlakyFailures;
   reportSlowTests?: ReportSlowTests;
   shard?: Shard;
   updateSnapshots?: UpdateSnapshots;
@@ -143,6 +145,7 @@ export interface FullConfig {
   preserveOutput: PreserveOutput;
   projects: FullProject[];
   reporter: ReporterDescription[];
+  reportFlakyFailures: ReportFlakyFailures;
   reportSlowTests: ReportSlowTests;
   rootDir: string;
   quiet: boolean;


### PR DESCRIPTION
This option shows errors for flaky test runs, while by default we just print that "foo.spec.ts > my test" was flaky.