### PR TITLE
fix(test runner): avoid internal error for step end without begin

### DIFF
--- a/src/test/workerRunner.ts
+++ b/src/test/workerRunner.ts
@@ -212,7 +212,6 @@ export class WorkerRunner extends EventEmitter {
     })();
 
     let testFinishedCallback = () => {};
-    let testFinished = false;
     let lastStepId = 0;
     const testInfo: TestInfoImpl = {
       workerIndex: this._params.workerIndex,
@@ -271,10 +270,7 @@ export class WorkerRunner extends EventEmitter {
           title,
           wallTime: Date.now()
         };
-        // Steps can begin/end after the test did timeout, but before the worker has been
-        // completely shutdown, because test code might still be running.
-        // Sending steps after 'testEnd' to the dispatcher confuses it, so we just drop them.
-        if (reportEvents && !testFinished)
+        if (reportEvents)
           this.emit('stepBegin', payload);
         let callbackHandled = false;
         return (error?: Error | TestError) => {
@@ -289,7 +285,7 @@ export class WorkerRunner extends EventEmitter {
             wallTime: Date.now(),
             error
           };
-          if (reportEvents && !testFinished)
+          if (reportEvents)
             this.emit('stepEnd', payload);
         };
       },
@@ -364,7 +360,6 @@ export class WorkerRunner extends EventEmitter {
 
     this._currentDeadlineRunner = undefined;
     testInfo.duration = monotonicTime() - startTime;
-    testFinished = true;
     if (reportEvents)
       this.emit('testEnd', buildTestEndPayload(testId, testInfo));
 


### PR DESCRIPTION
Consider the following scenario:
- Test finishes and starts tearing down fixtures.
- Fixture teardown starts a step `S` and then times out.
- We declare the test finished (with timeout).
- Dispatcher shuts down the worker and spins a new one for a retry. Additionally, it clears steps information for the test to be ready for the new retry. Step `S` information is lost.
- Meanwhile, during worker teardown, the step `S` does actually finish (usually with an error), and we send `stepEnd` for `S`.
- Dispatcher does not know what to do with step `S` end and prints an internal error.

The fix is to ignore certain messages from the shutting down worker that failed.