### PR TITLE
Update intro-python-python README

### DIFF
--- a/docs/src/intro-python.md
+++ b/docs/src/intro-python.md
@@ -16,6 +16,7 @@ See [system requirements](#system-requirements).
 [![PyPI version](https://badge.fury.io/py/playwright.svg)](https://pypi.python.org/pypi/playwright/)
 
 ```bash
+pip install --upgrade pip
 pip install playwright
 playwright install
 ```


### PR DESCRIPTION
### Description

-  I recently had an [issue ](https://github.com/microsoft/playwright-python/issues/848)while installing playwright for python 
-  After posting my issue as a question, I got it resolved and it turned out that my pip version had was the root cause
- TL;DR was that the PIP version which you were using did not support the package file naming which we use to distribute. After upgrading PIP it works as expected.
- Hence, I asked and confirmed with **Max Schmitt** about creating this PR and adding `pip install --upgrade pip` before `pip install playwright` command 

### Type of Change
-  README update
- Non-Breaking change

### Checklist

- Followed all the steps as mentioned in the [contributing guide ](https://github.com/microsoft/playwright/blob/master/CONTRIBUTING.md#code-reviews)

### Note:

- [Comment](https://github.com/microsoft/playwright-python/issues/848#issuecomment-899752457) about creating this PR 
