### PR TITLE
chore(tracing): rework start/export chunks

### DIFF
--- a/src/server/trace/common/traceEvents.ts
+++ b/src/server/trace/common/traceEvents.ts
@@ -50,15 +50,9 @@ export type FrameSnapshotTraceEvent = {
   snapshot: FrameSnapshot,
 };
 
-export type MarkerTraceEvent = {
-  type: 'marker',
-  resetIndex?: number,
-};
-
 export type TraceEvent =
     ContextCreatedTraceEvent |
     ScreencastFrameTraceEvent |
     ActionTraceEvent |
     ResourceSnapshotTraceEvent |
-    FrameSnapshotTraceEvent |
-    MarkerTraceEvent;
+    FrameSnapshotTraceEvent;

--- a/tests/tracing.spec.ts
+++ b/tests/tracing.spec.ts
@@ -213,7 +213,7 @@ test('should reset to different options', async ({ context, page, server }, test
   expect(events.find(e => e.metadata?.apiName === 'page.click')).toBeTruthy();
 
   expect(events.some(e => e.type === 'frame-snapshot')).toBeFalsy();
-  expect(events.some(e => e.type === 'resource-snapshot')).toBeFalsy();
+  expect(events.some(e => e.type === 'resource-snapshot')).toBeTruthy();
 });
 
 test('should reset and export', async ({ context, page, server }, testInfo) => {
@@ -300,7 +300,15 @@ async function parseTrace(file: string): Promise<{ events: any[], resources: Map
   const resources = new Map<string, Buffer>();
   for (const { name, buffer } of await Promise.all(entries))
     resources.set(name, buffer);
-  const events = resources.get('trace.trace').toString().split('\n').map(line => line ? JSON.parse(line) : false).filter(Boolean);
+  const events = [];
+  for (const line of resources.get('trace.trace').toString().split('\n')) {
+    if (line)
+      events.push(JSON.parse(line));
+  }
+  for (const line of resources.get('trace.network').toString().split('\n')) {
+    if (line)
+      events.push(JSON.parse(line));
+  }
   return {
     events,
     resources,


### PR DESCRIPTION
Instead of filtering the whole trace file on export, we write into separate trace file for each chunk: `trace.trace`, `trace-1.trace`, etc. We also write a separate `trace.network` file with all resources, because it is reused between chunks.

This brings us towards `tracing.startFile()/stopFile()` api.