### PR TITLE
feat(har): Remotely accessible HAR file

### DIFF
--- a/src/client/browserContext.ts
+++ b/src/client/browserContext.ts
@@ -344,6 +344,10 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel,
     try {
       await this._wrapApiCall(async (channel: channels.BrowserContextChannel) => {
         await this._browserType?._onWillCloseContext?.(this);
+        if (this._options.recordHar)  {
+          const har = await this._channel.harExport();
+          await har.artifact.saveAs({ path: this._options.recordHar.path });
+        }
         await channel.close();
         await this._closedPromise;
       });

--- a/src/dispatchers/browserContextDispatcher.ts
+++ b/src/dispatchers/browserContextDispatcher.ts
@@ -217,4 +217,11 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     const artifact = await this._context.tracing.export();
     return { artifact: new ArtifactDispatcher(this._scope, artifact) };
   }
+
+  async harExport(params: channels.BrowserContextHarExportParams): Promise<channels.BrowserContextHarExportResult> {
+    const artifact = await this._context._harRecorder?.export();
+    if (!artifact)
+      throw new Error('No HAR artifact. Ensure record.harPath is set.');
+    return { artifact: new ArtifactDispatcher(this._scope, artifact) };
+  }
 }

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -731,6 +731,7 @@ export interface BrowserContextChannel extends EventTargetChannel {
   tracingStart(params: BrowserContextTracingStartParams, metadata?: Metadata): Promise<BrowserContextTracingStartResult>;
   tracingStop(params?: BrowserContextTracingStopParams, metadata?: Metadata): Promise<BrowserContextTracingStopResult>;
   tracingExport(params?: BrowserContextTracingExportParams, metadata?: Metadata): Promise<BrowserContextTracingExportResult>;
+  harExport(params?: BrowserContextHarExportParams, metadata?: Metadata): Promise<BrowserContextHarExportResult>;
 }
 export type BrowserContextBindingCallEvent = {
   binding: BindingCallChannel,
@@ -960,6 +961,11 @@ export type BrowserContextTracingStopResult = void;
 export type BrowserContextTracingExportParams = {};
 export type BrowserContextTracingExportOptions = {};
 export type BrowserContextTracingExportResult = {
+  artifact: ArtifactChannel,
+};
+export type BrowserContextHarExportParams = {};
+export type BrowserContextHarExportOptions = {};
+export type BrowserContextHarExportResult = {
   artifact: ArtifactChannel,
 };
 

--- a/src/protocol/protocol.yml
+++ b/src/protocol/protocol.yml
@@ -707,6 +707,10 @@ BrowserContext:
       returns:
         artifact: Artifact
 
+    harExport:
+      returns:
+        artifact: Artifact
+
   events:
 
     bindingCall:

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -448,6 +448,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   });
   scheme.BrowserContextTracingStopParams = tOptional(tObject({}));
   scheme.BrowserContextTracingExportParams = tOptional(tObject({}));
+  scheme.BrowserContextHarExportParams = tOptional(tObject({}));
   scheme.PageSetDefaultNavigationTimeoutNoReplyParams = tObject({
     timeout: tNumber,
   });

--- a/src/server/browserContext.ts
+++ b/src/server/browserContext.ts
@@ -61,7 +61,7 @@ export abstract class BrowserContext extends SdkObject {
   readonly _browserContextId: string | undefined;
   private _selectors?: Selectors;
   private _origins = new Set<string>();
-  private _harRecorder: HarRecorder | undefined;
+  readonly _harRecorder: HarRecorder | undefined;
   readonly tracing: Tracing;
 
   constructor(browser: Browser, options: types.BrowserContextOptions, browserContextId: string | undefined) {
@@ -74,7 +74,8 @@ export abstract class BrowserContext extends SdkObject {
     this._closePromise = new Promise(fulfill => this._closePromiseFulfill = fulfill);
 
     if (this._options.recordHar)
-      this._harRecorder = new HarRecorder(this, this._options.recordHar);
+      this._harRecorder = new HarRecorder(this, {...this._options.recordHar, path: path.join(this._browser.options.artifactsDir, `${createGuid()}.har`)});
+
     this.tracing = new Tracing(this);
   }
 


### PR DESCRIPTION
This change ensure's the HAR file is saved at `recordHar.path` on the
client instead of the server.

NB: The goal was to make this change transparent to the user and NOT
introduce any new APIs. Namely, I want to leave the API open for
potential `context.har.start()` and `context.har.stop()`.

This does BREAK servers that expect the HAR to be at the `recordHar.path`
on the server, but I think that's OK since there haven't been reports
of missing HAR on client making me think not many users are getting
HAR with client and server on different hosts anyways.

Closes #8355