### PR TITLE
fix(test-runner): allow matching against source mapped files

### DIFF
--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -116,7 +116,7 @@ async function runTSC(baseDir: string): Promise<TSCResult> {
 
 async function runPlaywrightTest(baseDir: string, params: any, env: Env, options: RunOptions): Promise<RunResult> {
   const paramList = [];
-  let additionalArgs = '';
+  let additionalArgs: string[] = null;
   for (const key of Object.keys(params)) {
     if (key === 'args') {
       additionalArgs = params[key];

--- a/tests/playwright-test/test-ignore.spec.ts
+++ b/tests/playwright-test/test-ignore.spec.ts
@@ -390,3 +390,28 @@ test('should only match files with JS/TS file extensions', async ({ runInlineTes
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(2);
 });
+
+test('should work against a source mapped file', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'out/foo.spec.js': `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//@no-header
+const test_1 = require(${JSON.stringify(path.join(__dirname, 'entry'))});
+test_1.default('passes', async () => {
+});
+//# sourceMappingURL=foo.spec.js.map`,
+
+    'out/foo.spec.js.map': `{"version":3,"file":"foo.spec.js","sourceRoot":"","sources":["../src/foo.spec.ts"],"names":[],"mappings":";;AAAA,YAAY;AACZ,2CAAoC;AAEpC,cAAI,CAAC,QAAQ,EAAE,KAAK,IAAG,EAAE;AACzB,CAAC,CAAC,CAAC"}`,
+
+    'src/foo.test.ts': `//@no-header
+import test from '@playwright/test';
+
+test('passes', async() => {
+});
+`
+  }, {
+    args: ['-c', 'out', 'foo.spec.ts']
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});


### PR DESCRIPTION
References https://github.com/microsoft/playwright/issues/16975

This is half the battle, matching the filename against the source map. But we also need to convert the line number from the source file to a line
number in the compiled file.

Maybe the source map code should have a try-catch? I'm not sure what broken source maps on our tests would mean.
