### PR TITLE
feat(webkit): bump to 1534

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "webkit",
-      "revision": "1531",
+      "revision": "1534",
       "installByDefault": true,
       "revisionOverrides": {
         "mac10.14": "1446"

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -93,7 +93,7 @@ it('should not fail for window object', async ({ page, browserName }) => {
 });
 
 it('should trigger correct Log', async ({page, server, browserName, isWindows}) => {
-  it.fail(browserName === 'webkit' && isWindows, 'Regressed in https://trac.webkit.org/changeset/281158/webkit');
+  it.skip(browserName === 'webkit' && isWindows, 'Upstream issue https://bugs.webkit.org/show_bug.cgi?id=229515');
   await page.goto('about:blank');
   const [message] = await Promise.all([
     page.waitForEvent('console'),

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -92,7 +92,8 @@ it('should not fail for window object', async ({ page, browserName }) => {
     expect(message.text()).toEqual('JSHandle@object');
 });
 
-it('should trigger correct Log', async ({page, server}) => {
+it('should trigger correct Log', async ({page, server, browserName, isWindows}) => {
+  it.fail(browserName === 'webkit' && isWindows, 'Regressed in https://trac.webkit.org/changeset/281158/webkit');
   await page.goto('about:blank');
   const [message] = await Promise.all([
     page.waitForEvent('console'),


### PR DESCRIPTION
The console test is timing out on Windows most likely because of https://trac.webkit.org/changeset/281158/webkit as the load request now fails with `canceled: true` and no console error is generated.