### PR TITLE
docs: connect example with non-deprecated API

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -268,7 +268,7 @@ const { chromium } = require('playwright');  // Or 'webkit' or 'firefox'.
   const browserServer = await chromium.launchServer();
   const wsEndpoint = browserServer.wsEndpoint();
   // Use web socket endpoint later to establish a connection.
-  const browser = await chromium.connect({ wsEndpoint });
+  const browser = await chromium.connect(wsEndpoint);
   // Close browser instance.
   await browserServer.close();
 })();

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -8614,7 +8614,7 @@ export interface BrowserType<Unused = {}> {
    *   const browserServer = await chromium.launchServer();
    *   const wsEndpoint = browserServer.wsEndpoint();
    *   // Use web socket endpoint later to establish a connection.
-   *   const browser = await chromium.connect({ wsEndpoint });
+   *   const browser = await chromium.connect(wsEndpoint);
    *   // Close browser instance.
    *   await browserServer.close();
    * })();


### PR DESCRIPTION
See existing [deprecation notice](https://github.com/microsoft/playwright/blob/c627927bf57af81d2a33aea00954800654c4e064/types/types.d.ts#L8205).