### PR TITLE
feat(fetch): set user-agent and other default headers

### DIFF
--- a/src/server/browser.ts
+++ b/src/server/browser.ts
@@ -78,6 +78,7 @@ export abstract class Browser extends SdkObject {
   abstract contexts(): BrowserContext[];
   abstract isConnected(): boolean;
   abstract version(): string;
+  abstract userAgent(): string;
 
   _downloadCreated(page: Page, uuid: string, url: string, suggestedFilename?: string) {
     const download = new Download(page, this.options.downloadsPath || '', uuid, url, suggestedFilename);

--- a/src/server/chromium/crBrowser.ts
+++ b/src/server/chromium/crBrowser.ts
@@ -45,6 +45,7 @@ export class CRBrowser extends Browser {
   private _tracingRecording = false;
   private _tracingPath: string | null = '';
   private _tracingClient: CRSession | undefined;
+  private _userAgent: string = '';
 
   static async connect(transport: ConnectionTransport, options: BrowserOptions, devtools?: CRDevTools): Promise<CRBrowser> {
     const connection = new CRConnection(transport, options.protocolLogger, options.browserLogsCollector);
@@ -57,6 +58,7 @@ export class CRBrowser extends Browser {
     const version = await session.send('Browser.getVersion');
     browser._isMac = version.userAgent.includes('Macintosh');
     browser._version = version.product.substring(version.product.indexOf('/') + 1);
+    browser._userAgent = version.userAgent;
     if (!options.persistent) {
       await session.send('Target.setAutoAttach', { autoAttach: true, waitForDebuggerOnStart: true, flatten: true });
       return browser;
@@ -105,6 +107,10 @@ export class CRBrowser extends Browser {
 
   version(): string {
     return this._version;
+  }
+
+  userAgent(): string {
+    return this._userAgent;
   }
 
   isClank(): boolean {

--- a/src/server/fetch.ts
+++ b/src/server/fetch.ts
@@ -28,9 +28,12 @@ export async function playwrightFetch(context: BrowserContext, params: types.Fet
       for (const [name, value] of Object.entries(params.headers))
         headers[name.toLowerCase()] = value;
     }
-    headers['user-agent'] ??= context._options.userAgent || context._browser.userAgent();
-    headers['accept'] ??= '*/*';
-    headers['accept-encoding'] ??= 'gzip,deflate';
+    if (headers['user-agent'] === undefined)
+      headers['user-agent'] = context._options.userAgent || context._browser.userAgent();
+    if (headers['accept'] === undefined)
+      headers['accept'] = '*/*';
+    if (headers['accept-encoding'] === undefined)
+      headers['accept-encoding'] = 'gzip,deflate';
 
     if (headers['cookie'] === undefined) {
       const cookies = await context.cookies(params.url);

--- a/src/server/firefox/ffBrowser.ts
+++ b/src/server/firefox/ffBrowser.ts
@@ -32,6 +32,7 @@ export class FFBrowser extends Browser {
   readonly _ffPages: Map<string, FFPage>;
   readonly _contexts: Map<string, FFBrowserContext>;
   private _version = '';
+  private _userAgent: string = '';
 
   static async connect(transport: ConnectionTransport, options: BrowserOptions): Promise<FFBrowser> {
     const connection = new FFConnection(transport, options.protocolLogger, options.browserLogsCollector);
@@ -68,6 +69,7 @@ export class FFBrowser extends Browser {
   async _initVersion() {
     const result = await this._connection.send('Browser.getInfo');
     this._version = result.version.substring(result.version.indexOf('/') + 1);
+    this._userAgent = result.userAgent;
   }
 
   isConnected(): boolean {
@@ -91,6 +93,10 @@ export class FFBrowser extends Browser {
 
   version(): string {
     return this._version;
+  }
+
+  userAgent(): string {
+    return this._userAgent;
   }
 
   _onDetachedFromTarget(payload: Protocol.Browser.detachedFromTargetPayload) {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -371,7 +371,7 @@ export type SetStorageState = {
 export type FetchOptions = {
   url: string,
   method?: string,
-  headers?:  { [name: string]: string },
+  headers?: { [name: string]: string },
   postData?: Buffer,
 };
 

--- a/src/server/webkit/wkBrowser.ts
+++ b/src/server/webkit/wkBrowser.ts
@@ -101,6 +101,10 @@ export class WKBrowser extends Browser {
     return BROWSER_VERSION;
   }
 
+  userAgent(): string {
+    return DEFAULT_USER_AGENT;
+  }
+
   _onDownloadCreated(payload: Protocol.Playwright.downloadCreatedPayload) {
     const page = this._wkPages.get(payload.pageProxyId);
     if (!page)


### PR DESCRIPTION
* Send following headers by default:
```
  "connection": "keep-alive",
  "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36",
  "accept": "*/*",
  "host": "localhost:8907",
  "accept-encoding": "gzip, deflate"
```
* If `cookie` header is passed as a parameter make it completely override cookie value passed to the server
* Lowercase all header names to simplify the code

#5999 