### PR TITLE
fix(har): rewrite sizes and make transferSize work in WK/Linux

### DIFF
--- a/src/server/chromium/crNetworkManager.ts
+++ b/src/server/chromium/crNetworkManager.ts
@@ -362,8 +362,8 @@ export class CRNetworkManager {
     // event from protocol. @see https://crbug.com/883475
     const response = request.request._existingResponse();
     if (response) {
-      request.request._transferSize = event.encodedDataLength;
-      request.request._responseBodySize = event.encodedDataLength - response?.headersSize();
+      request.request._sizes.transferSize = event.encodedDataLength;
+      request.request._sizes.responseBodySize = event.encodedDataLength - response?.headersSize();
       response._requestFinished(helper.secondsToRoundishMillis(event.timestamp - request._timestamp), undefined);
     }
     this._requestIdToRequest.delete(request._requestId);

--- a/src/server/chromium/crNetworkManager.ts
+++ b/src/server/chromium/crNetworkManager.ts
@@ -361,8 +361,11 @@ export class CRNetworkManager {
     // Under certain conditions we never get the Network.responseReceived
     // event from protocol. @see https://crbug.com/883475
     const response = request.request._existingResponse();
-    if (response)
-      response._requestFinished(helper.secondsToRoundishMillis(event.timestamp - request._timestamp), undefined, event.encodedDataLength);
+    if (response) {
+      request.request._transferSize = event.encodedDataLength;
+      request.request._responseBodySize = event.encodedDataLength - response?.headersSize();
+      response._requestFinished(helper.secondsToRoundishMillis(event.timestamp - request._timestamp), undefined);
+    }
     this._requestIdToRequest.delete(request._requestId);
     if (request._interceptionId)
       this._attemptedAuthentications.delete(request._interceptionId);

--- a/src/server/firefox/ffNetworkManager.ts
+++ b/src/server/firefox/ffNetworkManager.ts
@@ -116,13 +116,17 @@ export class FFNetworkManager {
     if (!request)
       return;
     const response = request.request._existingResponse()!;
+
+    request.request._transferSize = event.transferSize;
+    request.request._responseBodySize = event.transferSize - response.headersSize();
+
     // Keep redirected requests in the map for future reference as redirectedFrom.
     const isRedirected = response.status() >= 300 && response.status() <= 399;
     if (isRedirected) {
       response._requestFinished(this._relativeTiming(event.responseEndTime), 'Response body is unavailable for redirect responses');
     } else {
       this._requests.delete(request._id);
-      response._requestFinished(this._relativeTiming(event.responseEndTime), undefined, event.transferSize);
+      response._requestFinished(this._relativeTiming(event.responseEndTime), undefined);
     }
     this._page._frameManager.requestFinished(request.request);
   }

--- a/src/server/firefox/ffNetworkManager.ts
+++ b/src/server/firefox/ffNetworkManager.ts
@@ -117,8 +117,8 @@ export class FFNetworkManager {
       return;
     const response = request.request._existingResponse()!;
 
-    request.request._transferSize = event.transferSize;
-    request.request._responseBodySize = event.transferSize - response.headersSize();
+    request.request._sizes.transferSize = event.transferSize;
+    request.request._sizes.responseBodySize = event.transferSize - response.headersSize();
 
     // Keep redirected requests in the map for future reference as redirectedFrom.
     const isRedirected = response.status() >= 300 && response.status() <= 399;

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -78,6 +78,11 @@ export function stripFragmentFromUrl(url: string): string {
   return url.substring(0, url.indexOf('#'));
 }
 
+type RequestSizes = {
+  responseBodySize: number;
+  transferSize: number;
+};
+
 export class Request extends SdkObject {
   private _response: Response | null = null;
   private _redirectedFrom: Request | null;
@@ -95,8 +100,7 @@ export class Request extends SdkObject {
   private _waitForResponsePromise: Promise<Response | null>;
   private _waitForResponsePromiseCallback: (value: Response | null) => void = () => {};
   _responseEndTiming = -1;
-  _responseBodySize: number = 0;
-  _transferSize: number = 0;
+  _sizes: RequestSizes = { responseBodySize: 0, transferSize: 0 };
 
   constructor(frame: frames.Frame, redirectedFrom: Request | null, documentId: string | undefined,
     url: string, resourceType: string, method: string, postData: Buffer | null, headers: types.HeadersArray) {
@@ -197,10 +201,7 @@ export class Request extends SdkObject {
   }
 
   bodySize(): number {
-    const postData = this.postDataBuffer();
-    if (!postData)
-      return 0;
-    return postData.length;
+    return this.postDataBuffer()?.length || 0;
   }
 
   headersSize(): number {
@@ -422,11 +423,11 @@ export class Response extends SdkObject {
   }
 
   transferSize(): number | undefined {
-    return this._request._transferSize;
+    return this._request._sizes.transferSize;
   }
 
   bodySize(): number {
-    return this._request._responseBodySize;
+    return this._request._sizes.responseBodySize;
   }
 
   httpVersion(): string {

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -1050,7 +1050,7 @@ export class WKPage implements PageDelegate {
         validFrom: responseReceivedPayload?.response.security?.certificate?.validFrom,
         validTo: responseReceivedPayload?.response.security?.certificate?.validUntil,
       });
-      request.request._transferSize += response.headersSize();
+      request.request._sizes.transferSize += response.headersSize();
       if (event.metrics?.protocol)
         response._setHttpVersion(event.metrics.protocol);
       response._requestFinished(helper.secondsToRoundishMillis(event.timestamp - request._timestamp), undefined);
@@ -1085,8 +1085,8 @@ export class WKPage implements PageDelegate {
     const request = this._requestIdToRequest.get(event.requestId);
     if (!request)
       return;
-    request.request._responseBodySize += event.encodedDataLength === -1 ? event.dataLength : event.encodedDataLength;
-    request.request._transferSize += event.encodedDataLength === -1 ? event.dataLength : event.encodedDataLength;
+    request.request._sizes.responseBodySize += event.encodedDataLength === -1 ? event.dataLength : event.encodedDataLength;
+    request.request._sizes.transferSize += event.encodedDataLength === -1 ? event.dataLength : event.encodedDataLength;
   }
 
   async _grantPermissions(origin: string, permissions: string[]) {

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -380,6 +380,7 @@ export class WKPage implements PageDelegate {
       eventsHelper.addEventListener(this._session, 'Network.responseReceived', e => this._onResponseReceived(e)),
       eventsHelper.addEventListener(this._session, 'Network.loadingFinished', e => this._onLoadingFinished(e)),
       eventsHelper.addEventListener(this._session, 'Network.loadingFailed', e => this._onLoadingFailed(e)),
+      eventsHelper.addEventListener(this._session, 'Network.dataReceived', e => this._onDataReceived(e)),
       eventsHelper.addEventListener(this._session, 'Network.webSocketCreated', e => this._page._frameManager.onWebSocketCreated(e.requestId, e.url)),
       eventsHelper.addEventListener(this._session, 'Network.webSocketWillSendHandshakeRequest', e => this._page._frameManager.onWebSocketRequest(e.requestId)),
       eventsHelper.addEventListener(this._session, 'Network.webSocketHandshakeResponseReceived', e => this._page._frameManager.onWebSocketResponse(e.requestId, e.response.status, e.response.statusText)),
@@ -1049,11 +1050,10 @@ export class WKPage implements PageDelegate {
         validFrom: responseReceivedPayload?.response.security?.certificate?.validFrom,
         validTo: responseReceivedPayload?.response.security?.certificate?.validUntil,
       });
-      const { responseBodyBytesReceived, responseHeaderBytesReceived } = event.metrics || {};
-      const transferSize = responseBodyBytesReceived ? responseBodyBytesReceived + (responseHeaderBytesReceived || 0) : undefined;
+      request.request._transferSize += response.headersSize();
       if (event.metrics?.protocol)
         response._setHttpVersion(event.metrics.protocol);
-      response._requestFinished(helper.secondsToRoundishMillis(event.timestamp - request._timestamp), undefined, transferSize);
+      response._requestFinished(helper.secondsToRoundishMillis(event.timestamp - request._timestamp), undefined);
     }
 
     this._requestIdToResponseReceivedPayloadEvent.delete(request._requestId);
@@ -1079,6 +1079,14 @@ export class WKPage implements PageDelegate {
     this._requestIdToRequest.delete(request._requestId);
     request.request._setFailureText(event.errorText);
     this._page._frameManager.requestFailed(request.request, event.errorText.includes('cancelled'));
+  }
+
+  _onDataReceived(event: Protocol.Network.dataReceivedPayload) {
+    const request = this._requestIdToRequest.get(event.requestId);
+    if (!request)
+      return;
+    request.request._responseBodySize += event.encodedDataLength === -1 ? event.dataLength : event.encodedDataLength;
+    request.request._transferSize += event.encodedDataLength === -1 ? event.dataLength : event.encodedDataLength;
   }
 
   async _grantPermissions(origin: string, permissions: string[]) {

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -297,14 +297,14 @@ it('should calculate time', async ({ contextFactory, server }, testInfo) => {
   expect(log.entries[0].time).toBeGreaterThan(0);
 });
 
-it('should report the correct _transferSize with PNG files', async ({ contextFactory, server, browserName, platform }, testInfo) => {
+it('should report the correct _transferSize with PNG files', async ({ contextFactory, server, asset }, testInfo) => {
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`
     <img src="${server.PREFIX}/pptr.png" />
   `);
   const log = await getLog();
-  expect(log.entries[1].response._transferSize).toBe(6323);
+  expect(log.entries[1].response._transferSize).toBeGreaterThan(fs.statSync(asset('pptr.png')).size);
 });
 
 it('should have -1 _transferSize when its a failed request', async ({ contextFactory, server }, testInfo) => {
@@ -326,9 +326,9 @@ it('should report the correct request body size', async ({ contextFactory, serve
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
   await page.goto(server.EMPTY_PAGE);
   await Promise.all([
-    page.waitForResponse(server.PREFIX + '/api'),
+    page.waitForResponse(server.PREFIX + '/api1'),
     page.evaluate(() => {
-      fetch('/api', {
+      fetch('/api1', {
         method: 'POST',
         body: 'abc123'
       });
@@ -343,9 +343,9 @@ it('should report the correct request body size when the bodySize is 0', async (
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
   await page.goto(server.EMPTY_PAGE);
   await Promise.all([
-    page.waitForResponse(server.PREFIX + '/api'),
+    page.waitForResponse(server.PREFIX + '/api2'),
     page.evaluate(() => {
-      fetch('/api', {
+      fetch('/api2', {
         method: 'POST',
         body: ''
       });


### PR DESCRIPTION
- Extracted server side rewrite from #8234
- Migrated WK transferSize logic to `Network.dataReceived` event