### PR TITLE
docs: expand "Strictness" examples

### DIFF
--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -153,7 +153,7 @@ await page.Locator("button").ClickAsync();
 await page.Locator("button").First.ClickAsync();
 
 // Works because Count knows what to do with multiple matches:
-await page.Locator("button").Count();
+await page.Locator("button").CountAsync();
 ```
 
 ## async method: Locator.allInnerTexts

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -107,6 +107,9 @@ await page.locator('button').click();
 
 // Works because we explicitly tell locator to pick the first element:
 await page.locator('button').first().click();
+
+// Works because count knows what to do with multiple matches:
+await page.locator('button').count();
 ```
 
 ```python async
@@ -115,6 +118,9 @@ await page.locator('button').click()
 
 # Works because we explicitly tell locator to pick the first element:
 await page.locator('button').first.click()
+
+# Works because count knows what to do with multiple matches:
+await page.locator('button').count()
 ```
 
 ```python sync
@@ -123,21 +129,31 @@ page.locator('button').click()
 
 # Works because we explicitly tell locator to pick the first element:
 page.locator('button').first.click()
+
+# Works because count knows what to do with multiple matches:
+page.locator('button').count()
 ```
 
 ```java
 // Throws if there are several buttons in DOM:
 page.locator("button").click();
 
-// Works because you explicitly tell locator to pick the first element:
+// Works because we explicitly tell locator to pick the first element:
 page.locator("button").first().click();
+
+// Works because count knows what to do with multiple matches:
+page.locator("button").count();
 ```
 
 ```csharp
 // Throws if there are several buttons in DOM:
 await page.Locator("button").ClickAsync();
-// Works because you explicitly tell locator to pick the first element:
+
+// Works because we explicitly tell locator to pick the first element:
 await page.Locator("button").First.ClickAsync();
+
+// Works because Count knows what to do with multiple matches:
+await page.Locator("button").Count();
 ```
 
 ## async method: Locator.allInnerTexts

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -7062,6 +7062,9 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
  *
  * // Works because we explicitly tell locator to pick the first element:
  * await page.locator('button').first().click();
+ *
+ * // Works because count knows what to do with multiple matches:
+ * await page.locator('button').count();
  * ```
  *
  */


### PR DESCRIPTION
Add a third example showing a case where "strictness" doesn't apply.

This may be unnecessary, but I thought it might be useful to some.

Also tempted to change this phrase:
>operations on locators that imply some target DOM element

To:
>operations on locators that expect a single target DOM element

Or:
>operations on locators that expect a single DOM element

Or:
>operations on locators that expect a single match

PS: also changed two instances of "you" to "we" for consistency.