### PR TITLE
fix(test runner): report beforeAll timeout instead of hanging

### DIFF
--- a/src/test/reporters/base.ts
+++ b/src/test/reporters/base.ts
@@ -239,6 +239,9 @@ function formatError(error: TestError, file?: string) {
     }
     tokens.push('');
     tokens.push(colors.dim(preamble.length > 0 ? stack.substring(preamble.length + 1) : stack));
+  } else if (error.message) {
+    tokens.push('');
+    tokens.push(error.message);
   } else {
     tokens.push('');
     tokens.push(error.value);

--- a/src/test/workerRunner.ts
+++ b/src/test/workerRunner.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 import path from 'path';
 import rimraf from 'rimraf';
 import util from 'util';
+import colors from 'colors/safe';
 import { EventEmitter } from 'events';
 import { monotonicTime, DeadlineRunner, raceAgainstDeadline, serializeError, sanitizeForFilePath } from './util';
 import { TestBeginPayload, TestEndPayload, RunPayload, TestEntry, DonePayload, WorkerInitParams, StepBeginPayload, StepEndPayload } from './ipc';
@@ -375,10 +376,14 @@ export class WorkerRunner extends EventEmitter {
     setCurrentTestInfo(null);
 
     if (isFailure) {
-      if (test._type === 'test')
+      if (test._type === 'test') {
         this._failedTestId = testId;
-      else if (!this._fatalError)
-        this._fatalError = testInfo.error;
+      } else if (!this._fatalError) {
+        if (testInfo.status === 'timedOut')
+          this._fatalError = { message: colors.red(`Timeout of ${testInfo.timeout}ms exceeded in ${test._type} hook.`) };
+        else
+          this._fatalError = testInfo.error;
+      }
       this.stop();
     }
   }

--- a/tests/playwright-test/base-reporter.spec.ts
+++ b/tests/playwright-test/base-reporter.spec.ts
@@ -210,3 +210,19 @@ test('should print flaky timeouts', async ({ runInlineTest }) => {
   expect(result.flaky).toBe(1);
   expect(stripAscii(result.output)).toContain('Timeout of 1000ms exceeded.');
 });
+
+test('should print stack-less errors', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('foobar', async ({}) => {
+        const e = new Error('Hello');
+        delete e.stack;
+        throw e;
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.output).toContain('Hello');
+});


### PR DESCRIPTION
We used to not report fatal error and hang forever because worker did not run any tests but also did not report any errors.
Also properly show stack-less errors.
References #8428, #8427.