### PR TITLE
cherry-pick(release-1.14): add an overload for test.skip(title, fn)

### DIFF
--- a/tests/playwright-test/test-modifiers.spec.ts
+++ b/tests/playwright-test/test-modifiers.spec.ts
@@ -179,6 +179,10 @@ test('test modifiers should check types', async ({runTSC}) => {
         // @ts-expect-error
         test.skip(42);
       });
+      test.skip('skipped', async ({}) => {
+      });
+      // @ts-expect-error
+      test.skip('skipped', 'skipped');
     `,
   });
   expect(result.exitCode).toBe(0);

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -1626,6 +1626,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * skipped when the condition is `true`.
    * @param testFunctionOrDescription When used with `test.skip('test', () => {})` notation, second argument is a test function. Otherwise it is an optional description that will be reflected in a test report.
    */
+  skip(title: string, testFunction: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
   skip(): void;
   skip(condition: boolean): void;
   skip(condition: boolean, description: string): void;

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -227,6 +227,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
       only: SuiteFunction;
     };
   };
+  skip(title: string, testFunction: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
   skip(): void;
   skip(condition: boolean): void;
   skip(condition: boolean, description: string): void;


### PR DESCRIPTION
SHA1 a479cb6
PR #8454