### PR TITLE
chore(channels): generate dispatcher event types

### DIFF
--- a/src/browserServerImpl.ts
+++ b/src/browserServerImpl.ts
@@ -100,7 +100,7 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
 }
 
 // This class implements multiplexing browser dispatchers over a single Browser instance.
-class ConnectedBrowserDispatcher extends Dispatcher<Browser, channels.BrowserInitializer> implements channels.BrowserChannel {
+class ConnectedBrowserDispatcher extends Dispatcher<Browser, channels.BrowserInitializer, channels.BrowserEvents> implements channels.BrowserChannel {
   private _contexts = new Set<BrowserContext>();
   private _selectors: Selectors;
 

--- a/src/dispatchers/androidDispatcher.ts
+++ b/src/dispatchers/androidDispatcher.ts
@@ -20,7 +20,7 @@ import * as channels from '../protocol/channels';
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 import { CallMetadata } from '../server/instrumentation';
 
-export class AndroidDispatcher extends Dispatcher<Android, channels.AndroidInitializer> implements channels.AndroidChannel {
+export class AndroidDispatcher extends Dispatcher<Android, channels.AndroidInitializer, channels.AndroidEvents> implements channels.AndroidChannel {
   constructor(scope: DispatcherScope, android: Android) {
     super(scope, android, 'Android', {}, true);
   }
@@ -37,7 +37,7 @@ export class AndroidDispatcher extends Dispatcher<Android, channels.AndroidIniti
   }
 }
 
-export class AndroidDeviceDispatcher extends Dispatcher<AndroidDevice, channels.AndroidDeviceInitializer> implements channels.AndroidDeviceChannel {
+export class AndroidDeviceDispatcher extends Dispatcher<AndroidDevice, channels.AndroidDeviceInitializer, channels.AndroidDeviceEvents> implements channels.AndroidDeviceChannel {
 
   static from(scope: DispatcherScope, device: AndroidDevice): AndroidDeviceDispatcher {
     const result = existingDispatcher<AndroidDeviceDispatcher>(device);
@@ -169,7 +169,7 @@ export class AndroidDeviceDispatcher extends Dispatcher<AndroidDevice, channels.
   }
 }
 
-export class AndroidSocketDispatcher extends Dispatcher<SocketBackend, channels.AndroidSocketInitializer> implements channels.AndroidSocketChannel {
+export class AndroidSocketDispatcher extends Dispatcher<SocketBackend, channels.AndroidSocketInitializer, channels.AndroidSocketEvents> implements channels.AndroidSocketChannel {
   constructor(scope: DispatcherScope, socket: SocketBackend) {
     super(scope, socket, 'AndroidSocket', {}, true);
     socket.on('data', (data: Buffer) => this._dispatchEvent('data', { data: data.toString('base64') }));

--- a/src/dispatchers/artifactDispatcher.ts
+++ b/src/dispatchers/artifactDispatcher.ts
@@ -21,7 +21,7 @@ import fs from 'fs';
 import { mkdirIfNeeded } from '../utils/utils';
 import { Artifact } from '../server/artifact';
 
-export class ArtifactDispatcher extends Dispatcher<Artifact, channels.ArtifactInitializer> implements channels.ArtifactChannel {
+export class ArtifactDispatcher extends Dispatcher<Artifact, channels.ArtifactInitializer, channels.ArtifactEvents> implements channels.ArtifactChannel {
   constructor(scope: DispatcherScope, artifact: Artifact) {
     super(scope, artifact, 'Artifact', {
       absolutePath: artifact.localPath(),

--- a/src/dispatchers/browserContextDispatcher.ts
+++ b/src/dispatchers/browserContextDispatcher.ts
@@ -30,7 +30,7 @@ import { Artifact } from '../server/artifact';
 import { Request, Response } from '../server/network';
 import { headersArrayToObject } from '../utils/utils';
 
-export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channels.BrowserContextInitializer> implements channels.BrowserContextChannel {
+export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channels.BrowserContextInitializer, channels.BrowserContextEvents> implements channels.BrowserContextChannel {
   private _context: BrowserContext;
 
   constructor(scope: DispatcherScope, context: BrowserContext) {
@@ -79,7 +79,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     }));
     context.on(BrowserContext.Events.RequestFailed, (request: Request) => this._dispatchEvent('requestFailed', {
       request: RequestDispatcher.from(this._scope, request),
-      failureText: request._failureText,
+      failureText: request._failureText || undefined,
       responseEndTiming: request._responseEndTiming,
       page: PageDispatcher.fromNullable(this._scope, request.frame()._page.initializedOrUndefined())
     }));

--- a/src/dispatchers/browserDispatcher.ts
+++ b/src/dispatchers/browserDispatcher.ts
@@ -23,7 +23,7 @@ import { CRBrowser } from '../server/chromium/crBrowser';
 import { PageDispatcher } from './pageDispatcher';
 import { CallMetadata } from '../server/instrumentation';
 
-export class BrowserDispatcher extends Dispatcher<Browser, channels.BrowserInitializer> implements channels.BrowserChannel {
+export class BrowserDispatcher extends Dispatcher<Browser, channels.BrowserInitializer, channels.BrowserEvents> implements channels.BrowserChannel {
   constructor(scope: DispatcherScope, browser: Browser) {
     super(scope, browser, 'Browser', { version: browser.version(), name: browser.options.name }, true);
     browser.on(Browser.Events.Disconnected, () => this._didClose());

--- a/src/dispatchers/browserTypeDispatcher.ts
+++ b/src/dispatchers/browserTypeDispatcher.ts
@@ -21,7 +21,7 @@ import { Dispatcher, DispatcherScope } from './dispatcher';
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 import { CallMetadata } from '../server/instrumentation';
 
-export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.BrowserTypeInitializer> implements channels.BrowserTypeChannel {
+export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.BrowserTypeInitializer, channels.BrowserTypeEvents> implements channels.BrowserTypeChannel {
   constructor(scope: DispatcherScope, browserType: BrowserType) {
     super(scope, browserType, 'BrowserType', {
       executablePath: browserType.executablePath(),

--- a/src/dispatchers/cdpSessionDispatcher.ts
+++ b/src/dispatchers/cdpSessionDispatcher.ts
@@ -18,7 +18,7 @@ import { CRSession, CRSessionEvents } from '../server/chromium/crConnection';
 import * as channels from '../protocol/channels';
 import { Dispatcher, DispatcherScope } from './dispatcher';
 
-export class CDPSessionDispatcher extends Dispatcher<CRSession, channels.CDPSessionInitializer> implements channels.CDPSessionChannel {
+export class CDPSessionDispatcher extends Dispatcher<CRSession, channels.CDPSessionInitializer, channels.CDPSessionEvents> implements channels.CDPSessionChannel {
   constructor(scope: DispatcherScope, crSession: CRSession) {
     super(scope, crSession, 'CDPSession', {}, true);
     crSession._eventListener = (method, params) => {

--- a/src/dispatchers/consoleMessageDispatcher.ts
+++ b/src/dispatchers/consoleMessageDispatcher.ts
@@ -19,7 +19,7 @@ import * as channels from '../protocol/channels';
 import { Dispatcher, DispatcherScope } from './dispatcher';
 import { ElementHandleDispatcher } from './elementHandlerDispatcher';
 
-export class ConsoleMessageDispatcher extends Dispatcher<ConsoleMessage, channels.ConsoleMessageInitializer> implements channels.ConsoleMessageChannel {
+export class ConsoleMessageDispatcher extends Dispatcher<ConsoleMessage, channels.ConsoleMessageInitializer, channels.ConsoleMessageEvents> implements channels.ConsoleMessageChannel {
   constructor(scope: DispatcherScope, message: ConsoleMessage) {
     super(scope, message, 'ConsoleMessage', {
       type: message.type(),

--- a/src/dispatchers/dialogDispatcher.ts
+++ b/src/dispatchers/dialogDispatcher.ts
@@ -18,7 +18,7 @@ import { Dialog } from '../server/dialog';
 import * as channels from '../protocol/channels';
 import { Dispatcher, DispatcherScope } from './dispatcher';
 
-export class DialogDispatcher extends Dispatcher<Dialog, channels.DialogInitializer> implements channels.DialogChannel {
+export class DialogDispatcher extends Dispatcher<Dialog, channels.DialogInitializer, channels.DialogEvents> implements channels.DialogChannel {
   constructor(scope: DispatcherScope, dialog: Dialog) {
     super(scope, dialog, 'Dialog', {
       type: dialog.type(),

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -41,21 +41,21 @@ export function lookupNullableDispatcher<DispatcherType>(object: any | null): Di
   return object ? lookupDispatcher(object) : undefined;
 }
 
-export class Dispatcher<Type extends { guid: string }, Initializer> extends EventEmitter implements channels.Channel {
+export class Dispatcher<Type extends { guid: string }, Initializer, Events> extends EventEmitter implements channels.Channel {
   private _connection: DispatcherConnection;
   private _isScope: boolean;
   // Parent is always "isScope".
-  private _parent: Dispatcher<any, any> | undefined;
+  private _parent: Dispatcher<any, any, {}> | undefined;
   // Only "isScope" channel owners have registered dispatchers inside.
-  private _dispatchers = new Map<string, Dispatcher<any, any>>();
+  private _dispatchers = new Map<string, Dispatcher<any, any, {}>>();
   private _disposed = false;
 
   readonly _guid: string;
   readonly _type: string;
-  readonly _scope: Dispatcher<any, any>;
+  readonly _scope: Dispatcher<any, any, {}>;
   _object: Type;
 
-  constructor(parent: Dispatcher<any, any> | DispatcherConnection, object: Type, type: string, initializer: Initializer, isScope?: boolean) {
+  constructor(parent: Dispatcher<any, any, {}> | DispatcherConnection, object: Type, type: string, initializer: Initializer, isScope?: boolean) {
     super();
 
     this._connection = parent instanceof DispatcherConnection ? parent : parent._connection;
@@ -80,7 +80,7 @@ export class Dispatcher<Type extends { guid: string }, Initializer> extends Even
       this._connection.sendMessageToClient(this._parent._guid, type, '__create__', { type, initializer, guid }, this._parent._object);
   }
 
-  _dispatchEvent(method: string, params: Dispatcher<any, any> | any = {}) {
+  _dispatchEvent<T extends keyof Events>(method: T, params?: Events[T]) {
     if (this._disposed) {
       if (isUnderTest())
         throw new Error(`${this._guid} is sending "${method}" event after being disposed`);
@@ -88,7 +88,7 @@ export class Dispatcher<Type extends { guid: string }, Initializer> extends Even
       return;
     }
     const sdkObject = this._object instanceof SdkObject ? this._object : undefined;
-    this._connection.sendMessageToClient(this._guid, this._type, method, params, sdkObject);
+    this._connection.sendMessageToClient(this._guid, this._type, method as string, params, sdkObject);
   }
 
   _dispose() {
@@ -121,8 +121,8 @@ export class Dispatcher<Type extends { guid: string }, Initializer> extends Even
   }
 }
 
-export type DispatcherScope = Dispatcher<any, any>;
-export class Root extends Dispatcher<{ guid: '' }, {}> {
+export type DispatcherScope = Dispatcher<any, any, {}>;
+export class Root extends Dispatcher<{ guid: '' }, {}, {}> {
   private _initialized = false;
 
   constructor(connection: DispatcherConnection, private readonly createPlaywright?: (scope: DispatcherScope, options: channels.RootInitializeParams) => Promise<PlaywrightDispatcher>) {
@@ -140,7 +140,7 @@ export class Root extends Dispatcher<{ guid: '' }, {}> {
 }
 
 export class DispatcherConnection {
-  readonly _dispatchers = new Map<string, Dispatcher<any, any>>();
+  readonly _dispatchers = new Map<string, Dispatcher<any, any, {}>>();
   onmessage = (message: object) => {};
   private _validateParams: (type: string, method: string, params: any) => any;
   private _validateMetadata: (metadata: any) => { stack?: channels.StackFrame[] };

--- a/src/dispatchers/electronDispatcher.ts
+++ b/src/dispatchers/electronDispatcher.ts
@@ -22,7 +22,7 @@ import { PageDispatcher } from './pageDispatcher';
 import { parseArgument, serializeResult } from './jsHandleDispatcher';
 import { ElementHandleDispatcher } from './elementHandlerDispatcher';
 
-export class ElectronDispatcher extends Dispatcher<Electron, channels.ElectronInitializer> implements channels.ElectronChannel {
+export class ElectronDispatcher extends Dispatcher<Electron, channels.ElectronInitializer, channels.ElectronEvents> implements channels.ElectronChannel {
   constructor(scope: DispatcherScope, electron: Electron) {
     super(scope, electron, 'Electron', {}, true);
   }
@@ -33,7 +33,7 @@ export class ElectronDispatcher extends Dispatcher<Electron, channels.ElectronIn
   }
 }
 
-export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplication, channels.ElectronApplicationInitializer> implements channels.ElectronApplicationChannel {
+export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplication, channels.ElectronApplicationInitializer, channels.ElectronApplicationEvents> implements channels.ElectronApplicationChannel {
   constructor(scope: DispatcherScope, electronApplication: ElectronApplication) {
     super(scope, electronApplication, 'ElectronApplication', {
       context: new BrowserContextDispatcher(scope, electronApplication.context())

--- a/src/dispatchers/frameDispatcher.ts
+++ b/src/dispatchers/frameDispatcher.ts
@@ -22,7 +22,7 @@ import { parseArgument, serializeResult } from './jsHandleDispatcher';
 import { ResponseDispatcher, RequestDispatcher } from './networkDispatchers';
 import { CallMetadata } from '../server/instrumentation';
 
-export class FrameDispatcher extends Dispatcher<Frame, channels.FrameInitializer> implements channels.FrameChannel {
+export class FrameDispatcher extends Dispatcher<Frame, channels.FrameInitializer, channels.FrameEvents> implements channels.FrameChannel {
   private _frame: Frame;
 
   static from(scope: DispatcherScope, frame: Frame): FrameDispatcher {

--- a/src/dispatchers/jsHandleDispatcher.ts
+++ b/src/dispatchers/jsHandleDispatcher.ts
@@ -20,7 +20,7 @@ import { Dispatcher, DispatcherScope } from './dispatcher';
 import { ElementHandleDispatcher } from './elementHandlerDispatcher';
 import { parseSerializedValue, serializeValue } from '../protocol/serializers';
 
-export class JSHandleDispatcher extends Dispatcher<js.JSHandle, channels.JSHandleInitializer> implements channels.JSHandleChannel {
+export class JSHandleDispatcher extends Dispatcher<js.JSHandle, channels.JSHandleInitializer, channels.JSHandleEvents> implements channels.JSHandleChannel {
 
   protected constructor(scope: DispatcherScope, jsHandle: js.JSHandle) {
     // Do not call this directly, use createHandle() instead.

--- a/src/dispatchers/networkDispatchers.ts
+++ b/src/dispatchers/networkDispatchers.ts
@@ -19,7 +19,7 @@ import * as channels from '../protocol/channels';
 import { Dispatcher, DispatcherScope, lookupNullableDispatcher, existingDispatcher } from './dispatcher';
 import { FrameDispatcher } from './frameDispatcher';
 
-export class RequestDispatcher extends Dispatcher<Request, channels.RequestInitializer> implements channels.RequestChannel {
+export class RequestDispatcher extends Dispatcher<Request, channels.RequestInitializer, channels.RequestEvents> implements channels.RequestChannel {
 
   static from(scope: DispatcherScope, request: Request): RequestDispatcher {
     const result = existingDispatcher<RequestDispatcher>(request);
@@ -49,7 +49,7 @@ export class RequestDispatcher extends Dispatcher<Request, channels.RequestIniti
   }
 }
 
-export class ResponseDispatcher extends Dispatcher<Response, channels.ResponseInitializer> implements channels.ResponseChannel {
+export class ResponseDispatcher extends Dispatcher<Response, channels.ResponseInitializer, channels.ResponseEvents> implements channels.ResponseChannel {
 
   static from(scope: DispatcherScope, response: Response): ResponseDispatcher {
     const result = existingDispatcher<ResponseDispatcher>(response);
@@ -90,7 +90,7 @@ export class ResponseDispatcher extends Dispatcher<Response, channels.ResponseIn
   }
 }
 
-export class RouteDispatcher extends Dispatcher<Route, channels.RouteInitializer> implements channels.RouteChannel {
+export class RouteDispatcher extends Dispatcher<Route, channels.RouteInitializer, channels.RouteEvents> implements channels.RouteChannel {
 
   static from(scope: DispatcherScope, route: Route): RouteDispatcher {
     const result = existingDispatcher<RouteDispatcher>(route);
@@ -137,7 +137,7 @@ export class RouteDispatcher extends Dispatcher<Route, channels.RouteInitializer
   }
 }
 
-export class WebSocketDispatcher extends Dispatcher<WebSocket, channels.WebSocketInitializer> implements channels.WebSocketChannel {
+export class WebSocketDispatcher extends Dispatcher<WebSocket, channels.WebSocketInitializer, channels.WebSocketEvents> implements channels.WebSocketChannel {
   constructor(scope: DispatcherScope, webSocket: WebSocket) {
     super(scope, webSocket, 'WebSocket', {
       url: webSocket.url(),

--- a/src/dispatchers/pageDispatcher.ts
+++ b/src/dispatchers/pageDispatcher.ts
@@ -35,7 +35,7 @@ import { ArtifactDispatcher } from './artifactDispatcher';
 import { Download } from '../server/download';
 import { createGuid } from '../utils/utils';
 
-export class PageDispatcher extends Dispatcher<Page, channels.PageInitializer> implements channels.PageChannel {
+export class PageDispatcher extends Dispatcher<Page, channels.PageInitializer, channels.PageEvents> implements channels.PageChannel {
   private _page: Page;
 
   static fromNullable(scope: DispatcherScope, page: Page | undefined): PageDispatcher | undefined {
@@ -244,7 +244,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageInitializer> i
 }
 
 
-export class WorkerDispatcher extends Dispatcher<Worker, channels.WorkerInitializer> implements channels.WorkerChannel {
+export class WorkerDispatcher extends Dispatcher<Worker, channels.WorkerInitializer, channels.WorkerEvents> implements channels.WorkerChannel {
   constructor(scope: DispatcherScope, worker: Worker) {
     super(scope, worker, 'Worker', {
       url: worker.url()
@@ -261,7 +261,7 @@ export class WorkerDispatcher extends Dispatcher<Worker, channels.WorkerInitiali
   }
 }
 
-export class BindingCallDispatcher extends Dispatcher<{ guid: string }, channels.BindingCallInitializer> implements channels.BindingCallChannel {
+export class BindingCallDispatcher extends Dispatcher<{ guid: string }, channels.BindingCallInitializer, channels.BindingCallEvents> implements channels.BindingCallChannel {
   private _resolve: ((arg: any) => void) | undefined;
   private _reject: ((error: any) => void) | undefined;
   private _promise: Promise<any>;

--- a/src/dispatchers/playwrightDispatcher.ts
+++ b/src/dispatchers/playwrightDispatcher.ts
@@ -27,7 +27,7 @@ import { SocksConnection, SocksConnectionClient } from '../utils/socksProxy';
 import { createGuid } from '../utils/utils';
 import { debugLogger } from '../utils/debugLogger';
 
-export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.PlaywrightInitializer> implements channels.PlaywrightChannel {
+export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.PlaywrightInitializer, channels.PlaywrightEvents> implements channels.PlaywrightChannel {
   private _socksProxy: SocksProxy | undefined;
 
   constructor(scope: DispatcherScope, playwright: Playwright, customSelectors?: channels.SelectorsChannel, preLaunchedBrowser?: channels.BrowserChannel) {

--- a/src/dispatchers/selectorsDispatcher.ts
+++ b/src/dispatchers/selectorsDispatcher.ts
@@ -18,7 +18,7 @@ import { Dispatcher, DispatcherScope } from './dispatcher';
 import * as channels from '../protocol/channels';
 import { Selectors } from '../server/selectors';
 
-export class SelectorsDispatcher extends Dispatcher<Selectors, channels.SelectorsInitializer> implements channels.SelectorsChannel {
+export class SelectorsDispatcher extends Dispatcher<Selectors, channels.SelectorsInitializer, channels.SelectorsEvents> implements channels.SelectorsChannel {
   constructor(scope: DispatcherScope, selectors: Selectors) {
     super(scope, selectors, 'Selectors', {});
   }

--- a/src/dispatchers/streamDispatcher.ts
+++ b/src/dispatchers/streamDispatcher.ts
@@ -19,7 +19,7 @@ import { Dispatcher, DispatcherScope } from './dispatcher';
 import * as stream from 'stream';
 import { createGuid } from '../utils/utils';
 
-export class StreamDispatcher extends Dispatcher<{ guid: string, stream: stream.Readable }, channels.StreamInitializer> implements channels.StreamChannel {
+export class StreamDispatcher extends Dispatcher<{ guid: string, stream: stream.Readable }, channels.StreamInitializer, channels.StreamEvents> implements channels.StreamChannel {
   private _ended: boolean = false;
   constructor(scope: DispatcherScope, stream: stream.Readable) {
     super(scope, { guid: createGuid(), stream }, 'Stream', {});

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -175,6 +175,9 @@ export type RootInitializeResult = {
   playwright: PlaywrightChannel,
 };
 
+export interface RootEvents {
+}
+
 // ----------- Playwright -----------
 export type PlaywrightInitializer = {
   chromium: BrowserTypeChannel,
@@ -266,6 +269,12 @@ export type PlaywrightSocksEndOptions = {
 };
 export type PlaywrightSocksEndResult = void;
 
+export interface PlaywrightEvents {
+  'socksRequested': PlaywrightSocksRequestedEvent;
+  'socksData': PlaywrightSocksDataEvent;
+  'socksClosed': PlaywrightSocksClosedEvent;
+}
+
 // ----------- Selectors -----------
 export type SelectorsInitializer = {};
 export interface SelectorsChannel extends Channel {
@@ -280,6 +289,9 @@ export type SelectorsRegisterOptions = {
   contentScript?: boolean,
 };
 export type SelectorsRegisterResult = void;
+
+export interface SelectorsEvents {
+}
 
 // ----------- BrowserType -----------
 export type BrowserTypeInitializer = {
@@ -506,6 +518,9 @@ export type BrowserTypeConnectOverCDPResult = {
   defaultContext?: BrowserContextChannel,
 };
 
+export interface BrowserTypeEvents {
+}
+
 // ----------- Browser -----------
 export type BrowserInitializer = {
   version: string,
@@ -672,6 +687,10 @@ export type BrowserStopTracingResult = {
   binary: Binary,
 };
 
+export interface BrowserEvents {
+  'close': BrowserCloseEvent;
+}
+
 // ----------- EventTarget -----------
 export type EventTargetInitializer = {};
 export interface EventTargetChannel extends Channel {
@@ -690,6 +709,9 @@ export type EventTargetWaitForEventInfoOptions = {
 
 };
 export type EventTargetWaitForEventInfoResult = void;
+
+export interface EventTargetEvents {
+}
 
 // ----------- BrowserContext -----------
 export type BrowserContextInitializer = {
@@ -969,6 +991,20 @@ export type BrowserContextHarExportOptions = {};
 export type BrowserContextHarExportResult = {
   artifact: ArtifactChannel,
 };
+
+export interface BrowserContextEvents {
+  'bindingCall': BrowserContextBindingCallEvent;
+  'close': BrowserContextCloseEvent;
+  'page': BrowserContextPageEvent;
+  'route': BrowserContextRouteEvent;
+  'video': BrowserContextVideoEvent;
+  'backgroundPage': BrowserContextBackgroundPageEvent;
+  'serviceWorker': BrowserContextServiceWorkerEvent;
+  'request': BrowserContextRequestEvent;
+  'requestFailed': BrowserContextRequestFailedEvent;
+  'requestFinished': BrowserContextRequestFinishedEvent;
+  'response': BrowserContextResponseEvent;
+}
 
 // ----------- Page -----------
 export type PageInitializer = {
@@ -1389,6 +1425,25 @@ export type PageStopCSSCoverageResult = {
 export type PageBringToFrontParams = {};
 export type PageBringToFrontOptions = {};
 export type PageBringToFrontResult = void;
+
+export interface PageEvents {
+  'bindingCall': PageBindingCallEvent;
+  'close': PageCloseEvent;
+  'console': PageConsoleEvent;
+  'crash': PageCrashEvent;
+  'dialog': PageDialogEvent;
+  'download': PageDownloadEvent;
+  'domcontentloaded': PageDomcontentloadedEvent;
+  'fileChooser': PageFileChooserEvent;
+  'frameAttached': PageFrameAttachedEvent;
+  'frameDetached': PageFrameDetachedEvent;
+  'load': PageLoadEvent;
+  'pageError': PagePageErrorEvent;
+  'route': PageRouteEvent;
+  'video': PageVideoEvent;
+  'webSocket': PageWebSocketEvent;
+  'worker': PageWorkerEvent;
+}
 
 // ----------- Frame -----------
 export type FrameInitializer = {
@@ -1997,6 +2052,11 @@ export type FrameWaitForSelectorResult = {
   element?: ElementHandleChannel,
 };
 
+export interface FrameEvents {
+  'loadstate': FrameLoadstateEvent;
+  'navigated': FrameNavigatedEvent;
+}
+
 // ----------- Worker -----------
 export type WorkerInitializer = {
   url: string,
@@ -2029,6 +2089,10 @@ export type WorkerEvaluateExpressionHandleOptions = {
 export type WorkerEvaluateExpressionHandleResult = {
   handle: JSHandleChannel,
 };
+
+export interface WorkerEvents {
+  'close': WorkerCloseEvent;
+}
 
 // ----------- JSHandle -----------
 export type JSHandleInitializer = {
@@ -2093,6 +2157,10 @@ export type JSHandleJsonValueOptions = {};
 export type JSHandleJsonValueResult = {
   value: SerializedValue,
 };
+
+export interface JSHandleEvents {
+  'previewUpdated': JSHandlePreviewUpdatedEvent;
+}
 
 // ----------- ElementHandle -----------
 export type ElementHandleInitializer = {};
@@ -2499,6 +2567,9 @@ export type ElementHandleWaitForSelectorResult = {
   element?: ElementHandleChannel,
 };
 
+export interface ElementHandleEvents {
+}
+
 // ----------- Request -----------
 export type RequestInitializer = {
   frame: FrameChannel,
@@ -2521,6 +2592,9 @@ export type RequestResponseOptions = {};
 export type RequestResponseResult = {
   response?: ResponseChannel,
 };
+
+export interface RequestEvents {
+}
 
 // ----------- Route -----------
 export type RouteInitializer = {
@@ -2577,6 +2651,9 @@ export type RouteResponseBodyResult = {
   binary: Binary,
 };
 
+export interface RouteEvents {
+}
+
 export type ResourceTiming = {
   startTime: number,
   domainLookupStart: number,
@@ -2631,6 +2708,9 @@ export type ResponseServerAddrResult = {
   value?: RemoteAddr,
 };
 
+export interface ResponseEvents {
+}
+
 export type SecurityDetails = {
   issuer?: string,
   protocol?: string,
@@ -2677,6 +2757,14 @@ export type WebSocketSocketErrorEvent = {
 };
 export type WebSocketCloseEvent = {};
 
+export interface WebSocketEvents {
+  'open': WebSocketOpenEvent;
+  'frameSent': WebSocketFrameSentEvent;
+  'frameReceived': WebSocketFrameReceivedEvent;
+  'socketError': WebSocketSocketErrorEvent;
+  'close': WebSocketCloseEvent;
+}
+
 // ----------- ConsoleMessage -----------
 export type ConsoleMessageInitializer = {
   type: string,
@@ -2689,6 +2777,9 @@ export type ConsoleMessageInitializer = {
   },
 };
 export interface ConsoleMessageChannel extends Channel {
+}
+
+export interface ConsoleMessageEvents {
 }
 
 // ----------- BindingCall -----------
@@ -2717,6 +2808,9 @@ export type BindingCallResolveOptions = {
 };
 export type BindingCallResolveResult = void;
 
+export interface BindingCallEvents {
+}
+
 // ----------- Dialog -----------
 export type DialogInitializer = {
   type: string,
@@ -2737,6 +2831,9 @@ export type DialogAcceptResult = void;
 export type DialogDismissParams = {};
 export type DialogDismissOptions = {};
 export type DialogDismissResult = void;
+
+export interface DialogEvents {
+}
 
 // ----------- Artifact -----------
 export type ArtifactInitializer = {
@@ -2785,6 +2882,9 @@ export type ArtifactDeleteParams = {};
 export type ArtifactDeleteOptions = {};
 export type ArtifactDeleteResult = void;
 
+export interface ArtifactEvents {
+}
+
 // ----------- Stream -----------
 export type StreamInitializer = {};
 export interface StreamChannel extends Channel {
@@ -2803,6 +2903,9 @@ export type StreamReadResult = {
 export type StreamCloseParams = {};
 export type StreamCloseOptions = {};
 export type StreamCloseResult = void;
+
+export interface StreamEvents {
+}
 
 // ----------- CDPSession -----------
 export type CDPSessionInitializer = {};
@@ -2828,6 +2931,10 @@ export type CDPSessionSendResult = {
 export type CDPSessionDetachParams = {};
 export type CDPSessionDetachOptions = {};
 export type CDPSessionDetachResult = void;
+
+export interface CDPSessionEvents {
+  'event': CDPSessionEventEvent;
+}
 
 // ----------- Electron -----------
 export type ElectronInitializer = {};
@@ -2910,6 +3017,9 @@ export type ElectronLaunchResult = {
   electronApplication: ElectronApplicationChannel,
 };
 
+export interface ElectronEvents {
+}
+
 // ----------- ElectronApplication -----------
 export type ElectronApplicationInitializer = {
   context: BrowserContextChannel,
@@ -2957,6 +3067,10 @@ export type ElectronApplicationCloseParams = {};
 export type ElectronApplicationCloseOptions = {};
 export type ElectronApplicationCloseResult = void;
 
+export interface ElectronApplicationEvents {
+  'close': ElectronApplicationCloseEvent;
+}
+
 // ----------- Android -----------
 export type AndroidInitializer = {};
 export interface AndroidChannel extends Channel {
@@ -2975,6 +3089,9 @@ export type AndroidSetDefaultTimeoutNoReplyOptions = {
 
 };
 export type AndroidSetDefaultTimeoutNoReplyResult = void;
+
+export interface AndroidEvents {
+}
 
 // ----------- AndroidSocket -----------
 export type AndroidSocketInitializer = {};
@@ -2998,6 +3115,11 @@ export type AndroidSocketWriteResult = void;
 export type AndroidSocketCloseParams = {};
 export type AndroidSocketCloseOptions = {};
 export type AndroidSocketCloseResult = void;
+
+export interface AndroidSocketEvents {
+  'data': AndroidSocketDataEvent;
+  'close': AndroidSocketCloseEvent;
+}
 
 // ----------- AndroidDevice -----------
 export type AndroidDeviceInitializer = {
@@ -3345,6 +3467,11 @@ export type AndroidDeviceConnectToWebViewResult = {
 export type AndroidDeviceCloseParams = {};
 export type AndroidDeviceCloseOptions = {};
 export type AndroidDeviceCloseResult = void;
+
+export interface AndroidDeviceEvents {
+  'webViewAdded': AndroidDeviceWebViewAddedEvent;
+  'webViewRemoved': AndroidDeviceWebViewRemovedEvent;
+}
 
 export type AndroidWebView = {
   pid: number,


### PR DESCRIPTION
not sure if it's worth landing was more an experiment. This makes `this._dispatchEvent` easier to use in the dispatchers by having auto-completion and TS checks in it.