### PR TITLE
devops(docker): upgrade Bionic to GCC-8

### DIFF
--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -21,6 +21,11 @@ RUN apt-get update && apt-get install -y python3.8 python3-pip && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 
+# Install GCC-8.
+RUN apt-get update && apt-get install -y gcc-8 g++-8 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 --slave /usr/bin/g++ g++ /usr/bin/g++-7 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
+
 # === BAKE BROWSERS INTO IMAGE ===
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright


### PR DESCRIPTION
This is necessary to build WebKit successfully in Ubuntu 18.04. GCC-8 is featured in Ubuntu 18.04.