### PR TITLE
devops: try running Android tests on MacOS 11

### DIFF
--- a/.github/workflows/tests_fyi.yml
+++ b/.github/workflows/tests_fyi.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2]
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2


### PR DESCRIPTION
It crashes on MacOS 10 1/5 times, maybe MacOS 11 fixes it: https://github.com/microsoft/playwright/runs/3463870210#step:9:15