### PR TITLE
chore: re-arrange firefox preferences

### DIFF
--- a/browser_patches/firefox-beta/preferences/playwright.cfg
+++ b/browser_patches/firefox-beta/preferences/playwright.cfg
@@ -1,11 +1,22 @@
 // Any comment. You must start the file with a comment!
 
-// Use light theme by default.
-pref("ui.systemUsesDarkTheme", 0);
+// =================================================================
+// THESE ARE THE PROPERTIES THAT MUST BE ENABLED FOR JUGGLER TO WORK
+// =================================================================
+
+pref("datareporting.policy.dataSubmissionEnabled", false);
+pref("datareporting.policy.dataSubmissionPolicyAccepted", false);
+pref("datareporting.policy.dataSubmissionPolicyBypassNotification", true);
 
 // @see https://github.com/microsoft/playwright/issues/4297
 pref("browser.tabs.remote.useCrossOriginEmbedderPolicy", false);
 pref("browser.tabs.remote.useCrossOriginOpenerPolicy", false);
+
+// =================================================================
+// =================================================================
+
+// Use light theme by default.
+pref("ui.systemUsesDarkTheme", 0);
 
 // Only allow the old modal dialogs. This should be removed when there is
 // support for the new modal UI (see Bug 1686743).
@@ -152,9 +163,6 @@ pref("datareporting.healthreport.logging.consoleEnabled", false);
 pref("datareporting.healthreport.service.enabled", false);
 pref("datareporting.healthreport.service.firstRun", false);
 pref("datareporting.healthreport.uploadEnabled", false);
-pref("datareporting.policy.dataSubmissionEnabled", false);
-pref("datareporting.policy.dataSubmissionPolicyAccepted", false);
-pref("datareporting.policy.dataSubmissionPolicyBypassNotification", true);
 
 // Automatically unload beforeunload alerts
 pref("dom.disable_beforeunload", false);

--- a/browser_patches/firefox/preferences/playwright.cfg
+++ b/browser_patches/firefox/preferences/playwright.cfg
@@ -1,11 +1,22 @@
 // Any comment. You must start the file with a comment!
 
-// Use light theme by default.
-pref("ui.systemUsesDarkTheme", 0);
+// =================================================================
+// THESE ARE THE PROPERTIES THAT MUST BE ENABLED FOR JUGGLER TO WORK
+// =================================================================
+
+pref("datareporting.policy.dataSubmissionEnabled", false);
+pref("datareporting.policy.dataSubmissionPolicyAccepted", false);
+pref("datareporting.policy.dataSubmissionPolicyBypassNotification", true);
 
 // @see https://github.com/microsoft/playwright/issues/4297
 pref("browser.tabs.remote.useCrossOriginEmbedderPolicy", false);
 pref("browser.tabs.remote.useCrossOriginOpenerPolicy", false);
+
+// =================================================================
+// =================================================================
+
+// Use light theme by default.
+pref("ui.systemUsesDarkTheme", 0);
 
 // Only allow the old modal dialogs. This should be removed when there is
 // support for the new modal UI (see Bug 1686743).
@@ -152,9 +163,6 @@ pref("datareporting.healthreport.logging.consoleEnabled", false);
 pref("datareporting.healthreport.service.enabled", false);
 pref("datareporting.healthreport.service.firstRun", false);
 pref("datareporting.healthreport.uploadEnabled", false);
-pref("datareporting.policy.dataSubmissionEnabled", false);
-pref("datareporting.policy.dataSubmissionPolicyAccepted", false);
-pref("datareporting.policy.dataSubmissionPolicyBypassNotification", true);
 
 // Automatically unload beforeunload alerts
 pref("dom.disable_beforeunload", false);


### PR DESCRIPTION
There's a set of preferenes that's absolutely critical for juggler
to work. Keep these on top and mark them as critical.