### PR TITLE
chore: enhance repack-juggler

### DIFF
--- a/browser_patches/firefox-beta/install-preferences.js
+++ b/browser_patches/firefox-beta/install-preferences.js
@@ -83,14 +83,18 @@ function copyFile({from, to}) {
   });
 }
 
-if (process.argv.length !== 3) {
-  console.log('ERROR: expected a path to the directory with browser build');
-  process.exit(1);
-  return;
-}
+module.exports = { installFirefoxPreferences };
 
-installFirefoxPreferences(process.argv[2]).catch(error => {
-  console.error('ERROR: failed to put preferences!');
-  console.error(error);
-  process.exit(1);
-});
+if (require.main === module) {
+  if (process.argv.length !== 3) {
+    console.log('ERROR: expected a path to the directory with browser build');
+    process.exit(1);
+    return;
+  }
+
+  installFirefoxPreferences(process.argv[2]).catch(error => {
+    console.error('ERROR: failed to put preferences!');
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/browser_patches/firefox/install-preferences.js
+++ b/browser_patches/firefox/install-preferences.js
@@ -83,14 +83,18 @@ function copyFile({from, to}) {
   });
 }
 
-if (process.argv.length !== 3) {
-  console.log('ERROR: expected a path to the directory with browser build');
-  process.exit(1);
-  return;
-}
+module.exports = { installFirefoxPreferences };
 
-installFirefoxPreferences(process.argv[2]).catch(error => {
-  console.error('ERROR: failed to put preferences!');
-  console.error(error);
-  process.exit(1);
-});
+if (require.main === module) {
+  if (process.argv.length !== 3) {
+    console.log('ERROR: expected a path to the directory with browser build');
+    process.exit(1);
+    return;
+  }
+
+  installFirefoxPreferences(process.argv[2]).catch(error => {
+    console.error('ERROR: failed to put preferences!');
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Instead of building firefox using `//browser_patches/buid.sh ff-beta`,
one can use `//browser_patches/repack-juggler.mjs ff-beta`.

The script will download the last Playwright build, and repack
Juggler and preferences there.
