### PR TITLE
browser(firefox): enable SharedArrayBuffer in Firefox builds

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1286
-Changed: lushnikov@chromium.org Mon 30 Aug 2021 04:15:30 AM PDT
+1287
+Changed: lushnikov@chromium.org Wed 01 Sep 2021 03:05:22 AM PDT

--- a/browser_patches/firefox-beta/patches/bootstrap.diff
+++ b/browser_patches/firefox-beta/patches/bootstrap.diff
@@ -2015,6 +2015,21 @@ index f2723e654098ff27542e1eb16a536c11ad0af617..b0b480551ff7d895dfdeb5a980087485
  /* #undef MEM_SRCDST_SUPPORTED */
  
  /* Use accelerated SIMD routines. */
+diff --git a/modules/libpref/init/all.js b/modules/libpref/init/all.js
+index 5c9cb809bf119dc57afbb85e12b2e9fd76051f40..c4d42838db79101434b44f911c3f1fa34a2a081b 100644
+--- a/modules/libpref/init/all.js
++++ b/modules/libpref/init/all.js
+@@ -4567,7 +4567,9 @@ pref("devtools.experiment.f12.shortcut_disabled", false);
+ // doesn't provide a way to lock the pref
+ pref("dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled", false);
+ #else
+-pref("dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled", false, locked);
++// Playwright: DO NOT make preference locked so that we can overwrite it
++// later in our playwright.cfg file.
++pref("dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled", false);
+ #endif
+ 
+ // Whether to start the private browsing mode at application startup
 diff --git a/netwerk/base/nsINetworkInterceptController.idl b/netwerk/base/nsINetworkInterceptController.idl
 index c1ee73acde26b1a77a3e32b7132ce687d48e3347..0ce45a1d7b10eef91164e517522c4ea11487bf26 100644
 --- a/netwerk/base/nsINetworkInterceptController.idl

--- a/browser_patches/firefox-beta/preferences/playwright.cfg
+++ b/browser_patches/firefox-beta/preferences/playwright.cfg
@@ -15,6 +15,9 @@ pref("browser.tabs.remote.useCrossOriginOpenerPolicy", false);
 // =================================================================
 // =================================================================
 
+// @see https://github.com/microsoft/playwright/issues/8178
+pref("dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled", true);
+
 // Use light theme by default.
 pref("ui.systemUsesDarkTheme", 0);
 

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1289
-Changed: lushnikov@chromium.org Fri 27 Aug 2021 09:23:19 AM PDT
+1290
+Changed: lushnikov@chromium.org Wed 01 Sep 2021 03:10:46 AM PDT

--- a/browser_patches/firefox/patches/bootstrap.diff
+++ b/browser_patches/firefox/patches/bootstrap.diff
@@ -2015,6 +2015,21 @@ index f2723e654098ff27542e1eb16a536c11ad0af617..b0b480551ff7d895dfdeb5a980087485
  /* #undef MEM_SRCDST_SUPPORTED */
  
  /* Use accelerated SIMD routines. */
+diff --git a/modules/libpref/init/all.js b/modules/libpref/init/all.js
+index aba5106ecfc19ba03d4e4bddcecadf74a3c0efb1..df7f1d086976fc81d0a58202821e201dc3e744b6 100644
+--- a/modules/libpref/init/all.js
++++ b/modules/libpref/init/all.js
+@@ -4562,7 +4562,9 @@ pref("devtools.experiment.f12.shortcut_disabled", false);
+ // doesn't provide a way to lock the pref
+ pref("dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled", false);
+ #else
+-pref("dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled", false, locked);
++// Playwright: DO NOT make preference locked so that we can overwrite it
++// later in our playwright.cfg file.
++pref("dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled", false);
+ #endif
+ 
+ // Whether to start the private browsing mode at application startup
 diff --git a/netwerk/base/nsINetworkInterceptController.idl b/netwerk/base/nsINetworkInterceptController.idl
 index c1ee73acde26b1a77a3e32b7132ce687d48e3347..0ce45a1d7b10eef91164e517522c4ea11487bf26 100644
 --- a/netwerk/base/nsINetworkInterceptController.idl

--- a/browser_patches/firefox/preferences/playwright.cfg
+++ b/browser_patches/firefox/preferences/playwright.cfg
@@ -15,6 +15,9 @@ pref("browser.tabs.remote.useCrossOriginOpenerPolicy", false);
 // =================================================================
 // =================================================================
 
+// @see https://github.com/microsoft/playwright/issues/8178
+pref("dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled", true);
+
 // Use light theme by default.
 pref("ui.systemUsesDarkTheme", 0);
 

--- a/tests/capabilities.spec.ts
+++ b/tests/capabilities.spec.ts
@@ -28,8 +28,6 @@ it('SharedArrayBuffer should work', async function({contextFactory, httpsServer,
     res.end();
   });
   await page.goto(httpsServer.PREFIX + '/sharedarraybuffer');
-  // await page.goto(httpsServer.PREFIX + '/empty.html');
-  // await page.goto(server.PREFIX + '/empty.html');
   expect(await page.evaluate(() => typeof SharedArrayBuffer)).toBe('function');
 });
 

--- a/tests/capabilities.spec.ts
+++ b/tests/capabilities.spec.ts
@@ -18,6 +18,21 @@ import os from 'os';
 import url from 'url';
 import { contextTest as it, expect } from './config/browserTest';
 
+it('SharedArrayBuffer should work', async function({contextFactory, httpsServer, browserName}) {
+  it.fail(browserName === 'webkit', 'no shared array buffer on webkit');
+  const context = await contextFactory({ ignoreHTTPSErrors: true });
+  const page = await context.newPage();
+  httpsServer.setRoute('/sharedarraybuffer', (req, res) => {
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+    res.end();
+  });
+  await page.goto(httpsServer.PREFIX + '/sharedarraybuffer');
+  // await page.goto(httpsServer.PREFIX + '/empty.html');
+  // await page.goto(server.PREFIX + '/empty.html');
+  expect(await page.evaluate(() => typeof SharedArrayBuffer)).toBe('function');
+});
+
 it('Web Assembly should work', async function({page, server, browserName, platform}) {
   it.fail(browserName === 'webkit' && platform === 'win32');
 


### PR DESCRIPTION
SharedArrayBuffer was disabled since we disable cross-process
navigation.

References #8178