### PR TITLE
fix(codegen): use new toHaveURL syntax

### DIFF
--- a/src/server/supplements/recorder/javascript.ts
+++ b/src/server/supplements/recorder/javascript.ts
@@ -95,7 +95,7 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
       formatter.add(`]);`);
     } else if (signals.assertNavigation) {
       if (this._isTest)
-        formatter.add(`  expect(${pageAlias}.url()).toBe(${quote(signals.assertNavigation.url)});`);
+        formatter.add(`  await expect(${pageAlias}).toHaveURL(${quote(signals.assertNavigation.url)});`);
       else
         formatter.add(`  // assert.equal(${pageAlias}.url(), ${quote(signals.assertNavigation.url)});`);
     }

--- a/tests/inspector/cli-codegen-1.spec.ts
+++ b/tests/inspector/cli-codegen-1.spec.ts
@@ -539,7 +539,7 @@ test.describe('cli codegen', () => {
     expect(sources.get('Playwright Test').text).toContain(`
   // Click text=link
   await page.click('text=link');
-  expect(page.url()).toBe('about:blank#foo');`);
+  await expect(page).toHaveURL('about:blank#foo');`);
 
     expect(sources.get('Java').text).toContain(`
       // Click text=link


### PR DESCRIPTION
Switches the code generation for the 'Playwright Test' target to use the new web-first assertion `expect(page).toHaveURL(url)`. Previously, the codegen used a `.toBe` assertion on a string which less reliable as it did not auto-wait in case of a failure.