### PR TITLE
docs: update global setup docs

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -48,7 +48,7 @@ Whether to exit with an error if any tests or groups are marked as [`method: Tes
 ## property: TestConfig.globalSetup
 - type: <[string]>
 
-Path to the global setup file. This file will be required and run before all the tests. It must export a single function.
+Path to the global setup file. This file will be required and run before all the tests. It must export a single function that takes a [`TestConfig`] argument.
 
 Learn more about [global setup and teardown](./test-advanced.md#global-setup-and-teardown).
 

--- a/tests/playwright-test/entry/index.js
+++ b/tests/playwright-test/entry/index.js
@@ -14,4 +14,11 @@
  * limitations under the License.
  */
 
-module.exports = require('../../../lib/test/index');
+const pwt = require('../../../lib/test/index');
+const playwright = require('../../../lib/inprocess');
+const combinedExports = {
+  ...playwright,
+  ...pwt,
+};
+Object.defineProperty(combinedExports, '__esModule', { value: true });
+module.exports = combinedExports;

--- a/tests/playwright-test/global-setup.spec.ts
+++ b/tests/playwright-test/global-setup.spec.ts
@@ -237,3 +237,46 @@ test('globalSetup should allow requiring a package from node_modules', async ({ 
   });
   expect(results[0].status).toBe('passed');
 });
+
+test('globalSetup should work for auth', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = {
+        globalSetup: require.resolve('./auth.js'),
+        use: {
+          baseURL: 'https://www.example.com',
+          storageState: 'state.json',
+        },
+      };
+    `,
+    'auth.js': `
+      module.exports = async config => {
+        const { baseURL, storageState } = config.projects[0].use;
+        const browser = await pwt.chromium.launch();
+        const page = await browser.newPage();
+        await page.route('**/*', route => {
+          route.fulfill({ body: '<html></html>' }).catch(() => {});
+        });
+        await page.goto(baseURL);
+        await page.evaluate(() => {
+          localStorage['name'] = 'value';
+        });
+        await page.context().storageState({ path: storageState });
+        await browser.close();
+      };
+    `,
+    'a.test.js': `
+      const { test } = pwt;
+      test('should have storage state', async ({ page }) => {
+        await page.route('**/*', route => {
+          route.fulfill({ body: '<html></html>' }).catch(() => {});
+        });
+        await page.goto('/');
+        const value = await page.evaluate(() => localStorage['name']);
+        expect(value).toBe('value');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -558,8 +558,8 @@ interface TestConfig {
    */
   forbidOnly?: boolean;
   /**
-   * Path to the global setup file. This file will be required and run before all the tests. It must export a single
-   * function.
+   * Path to the global setup file. This file will be required and run before all the tests. It must export a single function
+   * that takes a [`TestConfig`] argument.
    *
    * Learn more about [global setup and teardown](https://playwright.dev/docs/test-advanced#global-setup-and-teardown).
    *
@@ -908,8 +908,8 @@ export interface FullConfig {
    */
   forbidOnly: boolean;
   /**
-   * Path to the global setup file. This file will be required and run before all the tests. It must export a single
-   * function.
+   * Path to the global setup file. This file will be required and run before all the tests. It must export a single function
+   * that takes a [`TestConfig`] argument.
    *
    * Learn more about [global setup and teardown](https://playwright.dev/docs/test-advanced#global-setup-and-teardown).
    *


### PR DESCRIPTION
- Changing example to "authenticate once".
- Similarly updating the auth doc.
- Adding a test with the same auth setup.

References #8490.