### PR TITLE
fix(recorder): improve rendering of multiline selectors

### DIFF
--- a/src/web/recorder/callLog.css
+++ b/src/web/recorder/callLog.css
@@ -79,6 +79,7 @@
 
 .call-log-selector {
   color: var(--orange);
+  white-space: normal;
 }
 
 .call-log-time {


### PR DESCRIPTION
Call me crazy, but I like to use multi-line CSS selectors similar to this one:

```javascript
await page.click(`
    .foo,
    .bar,
    .baz
`);
```

Those break the recorder styling a bit, so here's a fix! 😃 

| before | after |
|----|----|
![image](https://user-images.githubusercontent.com/1019198/131854138-a6e80c2d-564e-4812-aa12-793c5e772f18.png) | ![image](https://user-images.githubusercontent.com/1019198/131854160-9074709c-fbe7-4979-b051-0968a7c60699.png)
