### PR TITLE
fix: do not wait for async navigation started before eval

### DIFF
--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -69,12 +69,22 @@ export class FrameExecutionContext extends js.ExecutionContext {
   }
 
   async evaluateExpressionAndWaitForSignals(expression: string, isFunction: boolean | undefined, arg?: any): Promise<any> {
+    // Make sure utility script is initialized before we start tracking signals to reduce the number of
+    // protocol commands we send to the browser, otherwise we may be mistakingly tracking asynchronous
+    // navigation started between utility script initialization and actual eval.
+    // See https://github.com/microsoft/playwright/issues/8570
+    await this.utilityScript();
     return await this.frame._page._frameManager.waitForSignalsCreatedBy(null, false /* noWaitFor */, async () => {
       return this.evaluateExpression(expression, isFunction, arg);
     });
   }
 
   async evaluateExpressionHandleAndWaitForSignals(expression: string, isFunction: boolean | undefined, arg: any): Promise<any> {
+    // Make sure utility script is initialized before we start tracking signals to reduce the number of
+    // protocol commands we send to the browser, otherwise we may be mistakingly tracking asynchronous
+    // navigation started between utility script initialization and actual eval.
+    // See https://github.com/microsoft/playwright/issues/8570
+    await this.utilityScript();
     return await this.frame._page._frameManager.waitForSignalsCreatedBy(null, false /* noWaitFor */, async () => {
       return js.evaluateExpression(this, false /* returnByValue */, expression, isFunction, arg);
     });


### PR DESCRIPTION
This is a hack that mitigates the problem described in #8570. In case of arguments coming from other contexts the 
evaluation still consists of several protocol commands and the same problem may happen.

#8570