### PR TITLE
fix(types): remove `strict` param from Locator.setChecked

### DIFF
--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -834,7 +834,6 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Locator.setChecked.force = %%-input-force-%%
 ### option: Locator.setChecked.noWaitAfter = %%-input-no-wait-after-%%
 ### option: Locator.setChecked.position = %%-input-position-%%
-### option: Locator.setChecked.strict = %%-input-strict-%%
 ### option: Locator.setChecked.timeout = %%-input-timeout-%%
 ### option: Locator.setChecked.trial = %%-input-trial-%%
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -9287,12 +9287,6 @@ export interface Locator {
     };
 
     /**
-     * When true, the call requires selector to resolve to a single element. If given selector resolves to more then one
-     * element, the call throws an exception.
-     */
-    strict?: boolean;
-
-    /**
      * Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by
      * using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)


### PR DESCRIPTION
The API definition of `Locator#setChecked` has unused `strict` parameter.
Python client already have it and actually not used: https://github.com/microsoft/playwright-python/pull/879/files#diff-b080c6f27fac96dd688af70aaa7eeb919770d1f37777f9c6e9e1629965e51d28R448

This issue is very similar to #8653 where `ElementHandle#setChecked` is fixed.
I'm afraid I didn't find this issue when I report the issue above.