### PR TITLE
fix(snapshot): remove CSP meta from snapshot

### DIFF
--- a/src/server/snapshot/snapshotterInjected.ts
+++ b/src/server/snapshot/snapshotterInjected.ts
@@ -253,6 +253,8 @@ export function frameSnapshotStreamer(snapshotStreamer: string) {
           return;
         if (this._removeNoScript && nodeName === 'NOSCRIPT')
           return;
+        if (nodeName === 'META' && (node as HTMLMetaElement).httpEquiv.toLowerCase() === 'content-security-policy')
+          return;
 
         const data = ensureCachedData(node);
         const values: any[] = [];


### PR DESCRIPTION
CSP prevents us from including scripts/styles to render snapshot properly.

Fixes #8644.