### PR TITLE
browser(firefox): resolve socks DNS on server side

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1288
-Changed: max@schmitt.mx Fri  3 Sep 2021 16:41:51 CEST
+1289
+Changed: max@schmitt.mx Mon  6 Sep 2021 16:30:50 CEST

--- a/browser_patches/firefox-beta/juggler/NetworkObserver.js
+++ b/browser_patches/firefox-beta/juggler/NetworkObserver.js
@@ -766,7 +766,7 @@ class NetworkObserver {
             proxy.port,
             '', /* aProxyAuthorizationHeader */
             '', /* aConnectionIsolationKey */
-            0, /* aFlags */
+            Ci.nsIProxyInfo.TRANSPARENT_PROXY_RESOLVES_HOST, /* aFlags */
             UINT32_MAX, /* aFailoverTimeout */
             null, /* failover proxy */
         ));

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1291
-Changed: max@schmitt.mx Fri  3 Sep 2021 16:40:48 CEST
+1292
+Changed: max@schmitt.mx Mon  6 Sep 2021 16:30:50 CEST

--- a/browser_patches/firefox/juggler/NetworkObserver.js
+++ b/browser_patches/firefox/juggler/NetworkObserver.js
@@ -766,7 +766,7 @@ class NetworkObserver {
             proxy.port,
             '', /* aProxyAuthorizationHeader */
             '', /* aConnectionIsolationKey */
-            0, /* aFlags */
+            Ci.nsIProxyInfo.TRANSPARENT_PROXY_RESOLVES_HOST, /* aFlags */
             UINT32_MAX, /* aFailoverTimeout */
             null, /* failover proxy */
         ));


### PR DESCRIPTION
Fixes:

https://github.com/microsoft/playwright/blob/31c76a086db79824e40806428ae2acd8c64b95d0/tests/port-forwarding-server.spec.ts

With this change `playwright.local` will work on every OS & browser.

Docs: https://github.com/mozilla/gecko-dev/blob/781375a23ca0b6aa79b43d23d6e93295d4897472/netwerk/base/nsIProxyInfo.idl#L94-L106