### PR TITLE
test: fix wss/https tests which were failing on transport mode

### DIFF
--- a/tests/browsertype-connect.spec.ts
+++ b/tests/browsertype-connect.spec.ts
@@ -23,7 +23,8 @@ import WebSocket from 'ws';
 
 test.slow(true, 'All connect tests are slow');
 
-test('should connect over wss', async ({browserType , startRemoteServer, httpsServer}) => {
+test('should connect over wss', async ({browserType , startRemoteServer, httpsServer, mode}) => {
+  test.skip(mode !== 'default'); // Out of process transport does not allow us to set env vars dynamically.
   const remoteServer = await startRemoteServer();
 
   const oldValue = process.env['NODE_TLS_REJECT_UNAUTHORIZED'];

--- a/tests/chromium/chromium.spec.ts
+++ b/tests/chromium/chromium.spec.ts
@@ -286,7 +286,8 @@ playwrightTest('should report all pages in an existing browser', async ({ browse
   }
 });
 
-playwrightTest('should connect via https', async ({ browserType, browserOptions, httpsServer }, testInfo) => {
+playwrightTest('should connect via https', async ({ browserType, browserOptions, httpsServer, mode }, testInfo) => {
+  test.skip(mode !== 'default'); // Out of process transport does not allow us to set env vars dynamically.
   const port = 9339 + testInfo.workerIndex;
   const browserServer = await browserType.launch({
     ...browserOptions,


### PR DESCRIPTION
https://devops.aslushnikov.com/flakiness2.html#timestamp=1630969104538&filter_spec=wss

They were failing because when using the custom transports out of process. Skipping them is the easiest for now. 