### PR TITLE
Fix locator not waiting until handle is disposed

### DIFF
--- a/src/client/locator.ts
+++ b/src/client/locator.ts
@@ -41,7 +41,7 @@ export class Locator implements api.Locator {
     try {
       return await task(handle, deadline ? deadline - monotonicTime() : 0);
     } finally {
-      handle.dispose();
+      await handle.dispose();
     }
   }
 


### PR DESCRIPTION
I'm using `locator` in my tests, and whenever I call `locator.evaluate` it throws an unhandled promise rejection warning when the test is finished.

```
(node:62883) UnhandledPromiseRejectionWarning: locator.evaluate: Browser has been closed
```

I did some digging and found out that the `ElementHandle` being used in `locator._withElement` is not fully disposed after finished. [`JSHandle.dispose`](https://playwright.dev/docs/api/class-jshandle#js-handle-dispose) should return a promise so we should `await` it.

