### PR TITLE
test: fix flaky 'should not fire events for favicon' test

### DIFF
--- a/tests/browsercontext-network-event.spec.ts
+++ b/tests/browsercontext-network-event.spec.ts
@@ -17,8 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('BrowserContext.Events.Request', async ({browser, server}) => {
-  const context = await browser.newContext();
+it('BrowserContext.Events.Request', async ({context, server}) => {
   const page = await context.newPage();
   const requests = [];
   context.on('request', request => requests.push(request));
@@ -37,8 +36,7 @@ it('BrowserContext.Events.Request', async ({browser, server}) => {
   ]);
 });
 
-it('BrowserContext.Events.Response', async ({browser, server}) => {
-  const context = await browser.newContext();
+it('BrowserContext.Events.Response', async ({context, server}) => {
   const page = await context.newPage();
   const responses = [];
   context.on('response', response => responses.push(response));
@@ -57,12 +55,11 @@ it('BrowserContext.Events.Response', async ({browser, server}) => {
   ]);
 });
 
-it('BrowserContext.Events.RequestFailed', async ({browser, server}) => {
+it('BrowserContext.Events.RequestFailed', async ({context, server}) => {
   server.setRoute('/one-style.css', (_, res) => {
     res.setHeader('Content-Type', 'text/css');
     res.connection.destroy();
   });
-  const context = await browser.newContext();
   const page = await context.newPage();
   const failedRequests = [];
   context.on('requestfailed', request => failedRequests.push(request));
@@ -75,8 +72,7 @@ it('BrowserContext.Events.RequestFailed', async ({browser, server}) => {
 });
 
 
-it('BrowserContext.Events.RequestFinished', async ({browser, server}) => {
-  const context = await browser.newContext();
+it('BrowserContext.Events.RequestFinished', async ({context, server}) => {
   const page = await context.newPage();
   const [response] = await Promise.all([
     page.goto(server.EMPTY_PAGE),
@@ -90,8 +86,7 @@ it('BrowserContext.Events.RequestFinished', async ({browser, server}) => {
   expect(request.failure()).toBe(null);
 });
 
-it('should fire events in proper order', async ({browser, server}) => {
-  const context = await browser.newContext();
+it('should fire events in proper order', async ({context, server}) => {
   const page = await context.newPage();
   const events = [];
   context.on('request', () => events.push('request'));
@@ -108,12 +103,10 @@ it('should fire events in proper order', async ({browser, server}) => {
   ]);
 });
 
-it('should not fire events for favicon or favicon redirects', async ({browser, server, browserName, channel, headless}) => {
+it('should not fire events for favicon or favicon redirects', async ({context, page, server, browserName, channel, headless}) => {
   it.skip(headless && browserName !== 'firefox', 'headless browsers, except firefox, do not request favicons');
   it.skip(!headless && browserName === 'webkit' && !channel, 'headed webkit does not have a favicon feature');
-  const context = await browser.newContext();
-  const page = await context.newPage();
-  const favicon = `/favicon.ico`;
+  const favicon = `/no-cache/favicon.ico`;
   const hashedFaviconUrl = `/favicon-hashed.ico`;
   const imagePath = `/fakeimage.png`;
   const pagePath = `/page.html`;

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -465,6 +465,7 @@ it.describe('download event', () => {
     ]);
     expect(downloadPath).toBe(null);
     expect(saveError.message).toContain('File deleted upon browser context closure.');
+    await browser.close();
   });
 
   it('should download large binary.zip', async ({browser, server, browserName}, testInfo) => {

--- a/tests/selectors-register.spec.ts
+++ b/tests/selectors-register.spec.ts
@@ -56,6 +56,7 @@ it('should work with path', async ({playwright, browser, asset}) => {
   await playwright.selectors.register('foo', { path: asset('sectionselectorengine.js') });
   await page.setContent('<section></section>');
   expect(await page.$eval('foo=whatever', e => e.nodeName)).toBe('SECTION');
+  await page.close();
 });
 
 it('should work in main and isolated world', async ({playwright, browser}) => {
@@ -88,6 +89,7 @@ it('should work in main and isolated world', async ({playwright, browser}) => {
   expect(await page.$eval('isolated=ignored >> main=ignored', e => e.nodeName)).toBe('SPAN');
   // Can be chained to css.
   expect(await page.$eval('main=ignored >> css=section', e => e.nodeName)).toBe('SECTION');
+  await page.close();
 });
 
 it('should handle errors', async ({playwright, browser}) => {
@@ -116,6 +118,7 @@ it('should handle errors', async ({playwright, browser}) => {
 
   error = await playwright.selectors.register('css', createDummySelector).catch(e => e);
   expect(error.message).toBe('"css" is a predefined selector engine');
+  await page.close();
 });
 
 it('should not rely on engines working from the root', async ({ playwright, browser }) => {
@@ -132,6 +135,7 @@ it('should not rely on engines working from the root', async ({ playwright, brow
   await playwright.selectors.register('__value', createValueEngine);
   await page.setContent(`<input id=input1 value=value1><input id=input2 value=value2>`);
   expect(await page.$eval('input >> __value=value2', e => e.id)).toBe('input2');
+  await page.close();
 });
 
 it('should throw a nice error if the selector returns a bad value', async ({ playwright, browser }) => {
@@ -148,4 +152,5 @@ it('should throw a nice error if the selector returns a bad value', async ({ pla
   await playwright.selectors.register('__fake', createFakeEngine);
   const error = await page.$('__fake=value2').catch(e => e);
   expect(error.message).toContain('Expected a Node but got [object Array]');
+  await page.close();
 });


### PR DESCRIPTION
Was failing in Chromium Headed since it got introduced in #8176. The reason for it is that Chromium headed has a favicon cache in place.

Drive-by: Fixed leaking browser context instances.