### PR TITLE
fix: make sure `page.goto` navigates away from pages with beforeunload

### DIFF
--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -114,8 +114,13 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     this._channel.on('console', ({ message }) => this.emit(Events.Page.Console, ConsoleMessage.from(message)));
     this._channel.on('crash', () => this._onCrash());
     this._channel.on('dialog', ({ dialog }) => {
-      if (!this.emit(Events.Page.Dialog, Dialog.from(dialog)))
-        dialog.dismiss().catch(() => {});
+      const dialogObj = Dialog.from(dialog);
+      if (!this.emit(Events.Page.Dialog, dialogObj)) {
+        if (dialogObj.type() === 'beforeunload')
+          dialog.accept({}).catch(() => {});
+        else
+          dialog.dismiss().catch(() => {});
+      }
     });
     this._channel.on('domcontentloaded', () => this.emit(Events.Page.DOMContentLoaded, this));
     this._channel.on('download', ({ url, suggestedFilename, artifact }) => {

--- a/tests/beforeunload.spec.ts
+++ b/tests/beforeunload.spec.ts
@@ -35,6 +35,14 @@ it('should close browsercontext with beforeunload page', async ({server, page, c
   await context.close();
 });
 
+it('should be able to navigate away from page with beforeunload', async ({server, page, context }) => {
+  await page.goto(server.PREFIX + '/beforeunload.html');
+  // We have to interact with a page so that 'beforeunload' handlers
+  // fire.
+  await page.click('body');
+  await page.goto(server.EMPTY_PAGE);
+});
+
 it('should close page with beforeunload listener', async ({context, server}) => {
   const newPage = await context.newPage();
   await newPage.goto(server.PREFIX + '/beforeunload.html');


### PR DESCRIPTION
As of today, we can't navigate away from a page with beforeunload unless
we have an explicit `beforeunload` handler.

This patch updates our dialog auto-closing logic so that it auto-accepts
all beforeunload dialogs.

Fixes #8144