### PR TITLE
Update documentation to include pre-release install information

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,14 @@ const { webkit } = require('playwright');
 * [Community showcase](https://playwright.dev/docs/showcase/)
 * [Contribution guide](CONTRIBUTING.md)
 * [Changelog](https://github.com/microsoft/playwright/releases)
+
+## Pre-release versions
+
+To use the latest unreleased version and associated binaries, use:
+
+```
+npm i -D playwright@next
+```
+
+For a complete list of versions, see the [npm releases page](https://www.npmjs.com/package/playwright)
+


### PR DESCRIPTION
A questions surrounding pre-release versions came up in slack recently. 

I've updated the readme to include basic instructions on how to install the latest development version or other pre-release versions.