### PR TITLE
chore(expect): remove some dependencies on jest internals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "expect": "^26.4.2",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
-        "jest-matcher-utils": "^26.4.2",
         "jpeg-js": "^0.4.2",
         "mime": "^2.4.6",
         "minimatch": "^3.0.3",
@@ -6393,78 +6392,6 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/jest-matcher-utils": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
-      "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^26.4.2",
-        "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.4.2"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/jest-matcher-utils/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-message-util": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
@@ -8894,6 +8821,7 @@
     },
     "node_modules/socksv5/node_modules/ipv6": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/ipv6/-/ipv6-3.1.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8912,6 +8840,7 @@
     },
     "node_modules/socksv5/node_modules/ipv6/node_modules/sprintf": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.3.tgz",
       "dev": true,
       "inBundle": true,
       "engines": {
@@ -15824,62 +15753,6 @@
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
       "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
     },
-    "jest-matcher-utils": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
-      "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
-      "requires": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^26.4.2",
-        "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.4.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "jest-message-util": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
@@ -17858,6 +17731,7 @@
       "dependencies": {
         "ipv6": {
           "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/ipv6/-/ipv6-3.1.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17868,6 +17742,7 @@
           "dependencies": {
             "sprintf": {
               "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.3.tgz",
               "bundled": true,
               "dev": true
             }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "expect": "^26.4.2",
     "extract-zip": "^2.0.1",
     "https-proxy-agent": "^5.0.0",
-    "jest-matcher-utils": "^26.4.2",
     "jpeg-js": "^0.4.2",
     "mime": "^2.4.6",
     "minimatch": "^3.0.3",

--- a/src/test/matchers/toBeTruthy.ts
+++ b/src/test/matchers/toBeTruthy.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-import {
-  matcherHint,
-  MatcherHintOptions
-} from 'jest-matcher-utils';
 import { currentTestInfo } from '../globals';
 import type { Expect } from '../types';
 import { expectType, pollUntilDeadline } from '../util';
@@ -35,7 +31,7 @@ export async function toBeTruthy<T>(
     throw new Error(`${matcherName} must be called during the test`);
   expectType(receiver, receiverType, matcherName);
 
-  const matcherOptions: MatcherHintOptions = {
+  const matcherOptions = {
     isNot: this.isNot,
     promise: this.promise,
   };
@@ -50,7 +46,7 @@ export async function toBeTruthy<T>(
   }, options.timeout, testInfo._testFinished);
 
   const message = () => {
-    return matcherHint(matcherName, undefined, '', matcherOptions);
+    return this.utils.matcherHint(matcherName, undefined, '', matcherOptions);
   };
 
   return { message, pass };

--- a/src/test/matchers/toEqual.ts
+++ b/src/test/matchers/toEqual.ts
@@ -14,17 +14,9 @@
  * limitations under the License.
  */
 
-import { equals } from 'expect/build/jasmineUtils';
 import {
   iterableEquality
 } from 'expect/build/utils';
-import {
-  matcherHint, MatcherHintOptions,
-  printDiffOrStringify,
-  printExpected,
-  printReceived,
-  stringify
-} from 'jest-matcher-utils';
 import { currentTestInfo } from '../globals';
 import type { Expect } from '../types';
 import { expectType, pollUntilDeadline } from '../util';
@@ -57,7 +49,7 @@ export async function toEqual<T>(
     throw new Error(`${matcherName} must be called during the test`);
   expectType(receiver, receiverType, matcherName);
 
-  const matcherOptions: MatcherHintOptions = {
+  const matcherOptions = {
     comment: 'deep equality',
     isNot: this.isNot,
     promise: this.promise,
@@ -68,22 +60,22 @@ export async function toEqual<T>(
 
   await pollUntilDeadline(testInfo, async remainingTime => {
     received = await query(remainingTime);
-    pass = equals(received, expected, [iterableEquality, regExpTester]);
+    pass = this.equals(received, expected, [iterableEquality, regExpTester]);
     return pass === !matcherOptions.isNot;
   }, options.timeout, testInfo._testFinished);
 
   const message = pass
     ? () =>
-      matcherHint(matcherName, undefined, undefined, matcherOptions) +
+      this.utils.matcherHint(matcherName, undefined, undefined, matcherOptions) +
       '\n\n' +
-      `Expected: not ${printExpected(expected)}\n` +
-      (stringify(expected) !== stringify(received)
-        ? `Received:     ${printReceived(received)}`
+      `Expected: not ${this.utils.printExpected(expected)}\n` +
+      (this.utils.stringify(expected) !== this.utils.stringify(received)
+        ? `Received:     ${this.utils.printReceived(received)}`
         : '')
     : () =>
-      matcherHint(matcherName, undefined, undefined, matcherOptions) +
+      this.utils.matcherHint(matcherName, undefined, undefined, matcherOptions) +
       '\n\n' +
-      printDiffOrStringify(
+      this.utils.printDiffOrStringify(
           expected,
           received,
           EXPECTED_LABEL,

--- a/src/test/matchers/toMatchSnapshot.ts
+++ b/src/test/matchers/toMatchSnapshot.ts
@@ -17,7 +17,12 @@
 import type { Expect } from '../types';
 import { currentTestInfo } from '../globals';
 import { compare } from './golden';
-import { SyncExpectationResult } from 'expect/build/types';
+
+// from expect/build/types
+type SyncExpectationResult = {
+  pass: boolean;
+  message: () => string;
+};
 
 export function toMatchSnapshot(this: ReturnType<Expect['getState']>, received: Buffer | string, nameOrOptions: string | { name: string, threshold?: number }, optOptions: { threshold?: number } = {}): SyncExpectationResult {
   let options: { name: string, threshold?: number };

--- a/src/test/matchers/toMatchText.ts
+++ b/src/test/matchers/toMatchText.ts
@@ -19,14 +19,6 @@ import {
   printReceivedStringContainExpectedSubstring
 } from 'expect/build/print';
 
-import {
-  EXPECTED_COLOR,
-  matcherErrorMessage,
-  matcherHint, MatcherHintOptions,
-  printExpected,
-  printWithType,
-  printDiffOrStringify,
-} from 'jest-matcher-utils';
 import { currentTestInfo } from '../globals';
 import type { Expect } from '../types';
 import { expectType, pollUntilDeadline } from '../util';
@@ -45,7 +37,7 @@ export async function toMatchText(
     throw new Error(`${matcherName} must be called during the test`);
   expectType(receiver, receiverType, matcherName);
 
-  const matcherOptions: MatcherHintOptions = {
+  const matcherOptions = {
     isNot: this.isNot,
     promise: this.promise,
   };
@@ -55,12 +47,12 @@ export async function toMatchText(
     !(expected && typeof expected.test === 'function')
   ) {
     throw new Error(
-        matcherErrorMessage(
-            matcherHint(matcherName, undefined, undefined, matcherOptions),
-            `${EXPECTED_COLOR(
+        this.utils.matcherErrorMessage(
+            this.utils.matcherHint(matcherName, undefined, undefined, matcherOptions),
+            `${this.utils.EXPECTED_COLOR(
                 'expected',
             )} value must be a string or regular expression`,
-            printWithType('Expected', expected, printExpected),
+            this.utils.printWithType('Expected', expected, this.utils.printExpected),
         ),
     );
   }
@@ -84,17 +76,17 @@ export async function toMatchText(
   const message = pass
     ? () =>
       typeof expected === 'string'
-        ? matcherHint(matcherName, undefined, undefined, matcherOptions) +
+        ? this.utils.matcherHint(matcherName, undefined, undefined, matcherOptions) +
         '\n\n' +
-        `Expected ${stringSubstring}: not ${printExpected(expected)}\n` +
+        `Expected ${stringSubstring}: not ${this.utils.printExpected(expected)}\n` +
         `Received string:        ${printReceivedStringContainExpectedSubstring(
             received,
             received.indexOf(expected),
             expected.length,
         )}`
-        : matcherHint(matcherName, undefined, undefined, matcherOptions) +
+        : this.utils.matcherHint(matcherName, undefined, undefined, matcherOptions) +
         '\n\n' +
-        `Expected pattern: not ${printExpected(expected)}\n` +
+        `Expected pattern: not ${this.utils.printExpected(expected)}\n` +
         `Received string:      ${printReceivedStringContainExpectedResult(
             received,
             typeof expected.exec === 'function'
@@ -107,9 +99,9 @@ export async function toMatchText(
       const labelReceived = 'Received string';
 
       return (
-        matcherHint(matcherName, undefined, undefined, matcherOptions) +
+        this.utils.matcherHint(matcherName, undefined, undefined, matcherOptions) +
         '\n\n' +
-        printDiffOrStringify(
+        this.utils.printDiffOrStringify(
             expected,
             received,
             labelExpected,

--- a/types/testExpect.d.ts
+++ b/types/testExpect.d.ts
@@ -7,7 +7,6 @@
  */
 
 import type * as expect from 'expect';
-import type { ExpectedAssertionsErrors } from 'expect/build/types';
 
 export declare type AsymmetricMatcher = Record<string, any>;
 
@@ -17,7 +16,7 @@ export declare type Expect = {
   // Sourced from node_modules/expect/build/types.d.ts
   assertions(arg0: number): void;
   extend(arg0: any): void;
-  extractExpectedAssertionsErrors: () => ExpectedAssertionsErrors;
+  extractExpectedAssertionsErrors: typeof expect['extractExpectedAssertionsErrors'];
   getState(): expect.MatcherState;
   hasAssertions(): void;
   setState(state: Partial<expect.MatcherState>): void;


### PR DESCRIPTION
As Simen suggests in https://github.com/facebook/jest/pull/11816, we can remove the
dependency on `jest-matcher-utils` by using `this.utils` in our matchers. I cleaned
up some other places were we use internal types that are not needed.

We still are requiring two unexported files: `expect/build/matchers` and `expect/build/print`

﻿
