### PR TITLE
fix(test-runner): allow underscore as fixture name

### DIFF
--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -309,6 +309,8 @@ function innerFixtureParameterNames(fn: Function, location: Location): string[] 
   if (!trimmedParams)
     return [];
   const [firstParam] = splitByComma(trimmedParams);
+  if (firstParam === '_')
+    return [];
   if (firstParam[0] !== '{' || firstParam[firstParam.length - 1] !== '}')
     throw errorWithLocations('First argument must use the object destructuring pattern: '  + firstParam, { location });
   const props = splitByComma(firstParam.substring(1, firstParam.length - 1)).map(prop => {

--- a/tests/playwright-test/fixtures.spec.ts
+++ b/tests/playwright-test/fixtures.spec.ts
@@ -171,6 +171,18 @@ test('should fail if parameters are not destructured', async ({ runInlineTest })
   expect(result.results.length).toBe(0);
 });
 
+test('should not fail if parameters is an underscore', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      pwt.test('should pass', function (_) {
+        expect(_).toStrictEqual({});
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.results.length).toBe(1);
+});
+
 test('should fail with an unknown fixture', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `


### PR DESCRIPTION
It came up a few times in the past, since ESLint does not like [empty object patterns](https://eslint.org/docs/rules/no-empty-pattern), we want to give users a better experience by allowing the underscore for them.

Fixes #8798