### PR TITLE
fix(waitForEventInfo): reply from the server side

### DIFF
--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -237,17 +237,19 @@ export class DispatcherConnection {
     };
 
     if (sdkObject && params?.info?.waitId) {
-      // Process logs for waitForNavigation/waitForLoadState
+      // Process logs for waitForNavigation/waitForLoadState/etc.
       const info = params.info;
       switch (info.phase) {
         case 'before': {
           this._waitOperations.set(info.waitId, callMetadata);
           await sdkObject.instrumentation.onBeforeCall(sdkObject, callMetadata);
+          this.onmessage({ id });
           return;
         } case 'log': {
           const originalMetadata = this._waitOperations.get(info.waitId)!;
           originalMetadata.log.push(info.message);
           sdkObject.instrumentation.onCallLog('api', info.message, sdkObject, originalMetadata);
+          this.onmessage({ id });
           return;
         } case 'after': {
           const originalMetadata = this._waitOperations.get(info.waitId)!;
@@ -255,6 +257,7 @@ export class DispatcherConnection {
           originalMetadata.error = info.error ? { error: { name: 'Error', message: info.error } } : undefined;
           this._waitOperations.delete(info.waitId);
           await sdkObject.instrumentation.onAfterCall(sdkObject, originalMetadata);
+          this.onmessage({ id });
           return;
         }
       }

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -272,6 +272,26 @@ test('should report error and pending operations on timeout', async ({ runInline
   expect(stripAscii(result.output)).toContain(`10 |           page.textContent('text=More missing'),`);
 });
 
+test('should not report waitForEventInfo as pending', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      const { test } = pwt;
+      test('timedout', async ({ page }) => {
+        await page.setContent('<div>Click me</div>');
+        await page.waitForLoadState('networkidle');
+        await page.click('text=Missing');
+      });
+    `,
+  }, { workers: 1, timeout: 2000 });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(0);
+  expect(result.failed).toBe(1);
+  expect(result.output).toContain('Pending operations:');
+  expect(result.output).toContain('- page.click at a.test.ts:9:20');
+  expect(result.output).not.toContain('- page.waitForLoadState');
+});
+
 test('should throw when using page in beforeAll', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'a.test.ts': `


### PR DESCRIPTION
Otherwise, client thinks that `waitForEventInfo` is a pending operation.