### PR TITLE
fix(test): make `use` in config accept option values only

### DIFF
--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -193,11 +193,11 @@ async function globalSetup(config: FullConfig) {
   const { baseURL, storageState } = config.projects[0].use;
   const browser = await chromium.launch();
   const page = await browser.newPage();
-  await page.goto(baseURL);
+  await page.goto(baseURL!);
   await page.fill('input[name="user"]', 'user');
   await page.fill('input[name="password"]', 'password');
   await page.click('text=Sign in');
-  await page.context().storageState({ path: storageState });
+  await page.context().storageState({ path: storageState as string });
   await browser.close();
 }
 

--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -301,11 +301,11 @@ async function globalSetup(config: FullConfig) {
   const { baseURL, storageState } = config.projects[0].use;
   const browser = await chromium.launch();
   const page = await browser.newPage();
-  await page.goto(baseURL);
+  await page.goto(baseURL!);
   await page.fill('input[name="user"]', 'user');
   await page.fill('input[name="password"]', 'password');
   await page.click('text=Sign in');
-  await page.context().storageState({ path: storageState });
+  await page.context().storageState({ path: storageState as string });
   await browser.close();
 }
 

--- a/src/test/matchers/matchers.ts
+++ b/src/test/matchers/matchers.ts
@@ -15,7 +15,6 @@
  */
 
 import { Locator, Page } from '../../..';
-import { PlaywrightTestOptions} from '../../../types/test';
 import { constructURLBasedOnBaseURL } from '../../utils/utils';
 import { currentTestInfo } from '../globals';
 import type { Expect } from '../types';
@@ -240,7 +239,7 @@ export function toHaveURL(
   const testInfo = currentTestInfo();
   if (!testInfo)
     throw new Error(`toHaveURL must be called during the test`);
-  const baseURL = (testInfo.project.use as PlaywrightTestOptions)?.baseURL;
+  const baseURL = testInfo.project.use.baseURL;
 
   return toMatchText.call(this, 'toHaveURL', page, 'Page', async () => {
     return page.url();

--- a/tests/playwright-test/entry/index.d.ts
+++ b/tests/playwright-test/entry/index.d.ts
@@ -15,3 +15,5 @@
  */
 
 export * from '../../../types/test';
+export * from '../../../types/types';
+export { default } from '../../../types/test';

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -35,6 +35,7 @@ export type PreserveOutput = 'always' | 'never' | 'failures-only';
 export type UpdateSnapshots = 'all' | 'none' | 'missing';
 
 type FixtureDefine<TestArgs extends KeyValue = {}, WorkerArgs extends KeyValue = {}> = { test: TestType<TestArgs, WorkerArgs>, fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs> };
+type UseOptions<TestArgs, WorkerArgs> = { [K in keyof WorkerArgs]?: WorkerArgs[K] } & { [K in keyof TestArgs]?: TestArgs[K] };
 
 type ExpectSettings = {
   // Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
@@ -305,10 +306,10 @@ export interface Project<TestArgs = {}, WorkerArgs = {}> extends TestProject {
    * ```
    *
    */
-  use?: Fixtures<{}, {}, TestArgs, WorkerArgs>;
+  use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
-export type FullProject<TestArgs = {}, WorkerArgs = {}> = Required<Project<TestArgs, WorkerArgs>>;
+export type FullProject<TestArgs = {}, WorkerArgs = {}> = Required<Project<PlaywrightTestOptions & TestArgs, PlaywrightWorkerOptions & WorkerArgs>>;
 
 export type WebServerConfig = {
   /**
@@ -611,7 +612,7 @@ export interface Config<TestArgs = {}, WorkerArgs = {}> extends TestConfig {
    * ```
    *
    */
-  use?: Fixtures<{}, {}, TestArgs, WorkerArgs>;
+  use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
 /**
@@ -636,7 +637,7 @@ export interface Config<TestArgs = {}, WorkerArgs = {}> extends TestConfig {
  * ```
  *
  */
-export interface FullConfig {
+export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
   /**
    * Whether to exit with an error if any tests or groups are marked as
    * [test.only(title, testFunction)](https://playwright.dev/docs/api/class-test#test-only) or
@@ -706,7 +707,7 @@ export interface FullConfig {
   /**
    * Playwright Test supports running multiple test projects at the same time. See [TestProject] for more information.
    */
-  projects: FullProject[];
+  projects: FullProject<TestArgs, WorkerArgs>[];
   /**
    * The list of reporters to use. Each reporter can be:
    * - A builtin reporter name like `'list'` or `'json'`.

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -34,6 +34,7 @@ export type PreserveOutput = 'always' | 'never' | 'failures-only';
 export type UpdateSnapshots = 'all' | 'none' | 'missing';
 
 type FixtureDefine<TestArgs extends KeyValue = {}, WorkerArgs extends KeyValue = {}> = { test: TestType<TestArgs, WorkerArgs>, fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs> };
+type UseOptions<TestArgs, WorkerArgs> = { [K in keyof WorkerArgs]?: WorkerArgs[K] } & { [K in keyof TestArgs]?: TestArgs[K] };
 
 type ExpectSettings = {
   // Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
@@ -59,10 +60,10 @@ interface TestProject {
 
 export interface Project<TestArgs = {}, WorkerArgs = {}> extends TestProject {
   define?: FixtureDefine | FixtureDefine[];
-  use?: Fixtures<{}, {}, TestArgs, WorkerArgs>;
+  use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
-export type FullProject<TestArgs = {}, WorkerArgs = {}> = Required<Project<TestArgs, WorkerArgs>>;
+export type FullProject<TestArgs = {}, WorkerArgs = {}> = Required<Project<PlaywrightTestOptions & TestArgs, PlaywrightWorkerOptions & WorkerArgs>>;
 
 export type WebServerConfig = {
   /**
@@ -129,10 +130,10 @@ interface TestConfig {
 export interface Config<TestArgs = {}, WorkerArgs = {}> extends TestConfig {
   projects?: Project<TestArgs, WorkerArgs>[];
   define?: FixtureDefine | FixtureDefine[];
-  use?: Fixtures<{}, {}, TestArgs, WorkerArgs>;
+  use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
-export interface FullConfig {
+export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
   forbidOnly: boolean;
   globalSetup: string | null;
   globalTeardown: string | null;
@@ -141,7 +142,7 @@ export interface FullConfig {
   grepInvert: RegExp | RegExp[] | null;
   maxFailures: number;
   preserveOutput: PreserveOutput;
-  projects: FullProject[];
+  projects: FullProject<TestArgs, WorkerArgs>[];
   reporter: ReporterDescription[];
   reportSlowTests: ReportSlowTests;
   rootDir: string;


### PR DESCRIPTION
Also include default options in FullConfig/FullProject.
Also make examples compile and add a test.

Fixes #8814.