### PR TITLE
feat(har): add _requestref

### DIFF
--- a/src/server/supplements/har/har.ts
+++ b/src/server/supplements/har/har.ts
@@ -55,6 +55,7 @@ export type Entry = {
   timings: Timings;
   serverIPAddress?: string;
   connection?: string;
+  _requestref: string;
   _frameref: string;
   _monotonicTime: number;
   _serverPort?: number;

--- a/src/server/supplements/har/harTracer.ts
+++ b/src/server/supplements/har/harTracer.ts
@@ -141,6 +141,7 @@ export class HarTracer {
     const pageEntry = this._ensurePageEntry(page);
     const harEntry: har.Entry = {
       pageref: pageEntry.id,
+      _requestref: request.guid,
       _frameref: request.frame().guid,
       _monotonicTime: monotonicTime(),
       startedDateTime: new Date(),

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -589,3 +589,42 @@ it('should have different hars for concurrent contexts', async ({ contextFactory
     expect(pageEntry.title).toBe('One');
   }
 });
+
+it('should include _requestref', async ({ contextFactory, server }, testInfo) => {
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo);
+  const resp = await page.goto(server.EMPTY_PAGE);
+  const log = await getLog();
+  expect(log.entries.length).toBe(1);
+  const entry = log.entries[0];
+  expect(entry._requestref).toMatch(/^request@[a-f0-9]{32}$/);
+  expect(entry._requestref).toBe((resp.request() as any)._guid);
+});
+
+it('should include _requestref for redirects', async ({ contextFactory, server }, testInfo) => {
+  server.setRedirect('/start', '/one-more');
+  server.setRedirect('/one-more', server.EMPTY_PAGE);
+
+  const { page, getLog, context } = await pageWithHar(contextFactory, testInfo);
+
+  const requests = new Map<string, string>();
+  context.on('request', request => {
+    requests.set(request.url(), (request as any)._guid);
+  });
+
+  await page.goto(server.PREFIX + '/start');
+
+  const log = await getLog();
+  expect(log.entries.length).toBe(3);
+
+  const entryStart = log.entries[0];
+  expect(entryStart.request.url).toBe(server.PREFIX + '/start');
+  expect(entryStart._requestref).toBe(requests.get(entryStart.request.url));
+
+  const entryOneMore = log.entries[1];
+  expect(entryOneMore.request.url).toBe(server.PREFIX + '/one-more');
+  expect(entryOneMore._requestref).toBe(requests.get(entryOneMore.request.url));
+
+  const entryEmptyPage = log.entries[2];
+  expect(entryEmptyPage.request.url).toBe(server.EMPTY_PAGE);
+  expect(entryEmptyPage._requestref).toBe(requests.get(entryEmptyPage.request.url));
+});


### PR DESCRIPTION
This will be used by our traceviewer-like (userland) debug tools
that require correlating logging emitted from Playwright-dependent code
and the requests that end up in the HAR file after the run.

This can be utilized by Playwright’s own traceviewer some day, too. For
example, it can be used to link back code that transformed a request to
the actual request that ended up getting recorded in the HAR file.