### PR TITLE
docs(python): Specifying use of context element in multi-pages Python documentation

### DIFF
--- a/docs/src/multi-pages.md
+++ b/docs/src/multi-pages.md
@@ -189,7 +189,7 @@ System.out.println(newPage.title());
 
 ```python async
 # Get page after a specific action (e.g. clicking a link)
-async with context.expect_page() as new_page_info:
+async with page.context.expect_page() as new_page_info:
     await page.click('a[target="_blank"]') # Opens a new tab
 new_page = await new_page_info.value
 
@@ -199,7 +199,7 @@ print(await new_page.title())
 
 ```python sync
 # Get page after a specific action (e.g. clicking a link)
-with context.expect_page() as new_page_info:
+with page.context.expect_page() as new_page_info:
     page.click('a[target="_blank"]') # Opens a new tab
 new_page = new_page_info.value
 


### PR DESCRIPTION
Current documentation for multi-pages doesn't explain how to get the `context` element in example.

This PR replaces `context.expect_page()` by `page.context.expect_page()` for example to be immediately usable.