### PR TITLE
devops: fix --full command in FF which installs deps

### DIFF
--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -102,7 +102,6 @@ if [[ $1 != "--juggler" ]]; then
     echo "-- Using cbindgen v${CBINDGEN_VERSION}"
     cargo install cbindgen --version "${CBINDGEN_VERSION}"
   fi
-  ./mach build
 fi
 
 if [[ $1 == "--full" || $2 == "--full" ]]; then
@@ -121,6 +120,8 @@ fi
 
 if [[ $1 == "--juggler" ]]; then
   ./mach build faster
+else
+  ./mach build
 fi
 
 if [[ "$(uname)" == "Darwin" ]]; then

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -102,7 +102,6 @@ if [[ $1 != "--juggler" ]]; then
     echo "-- Using cbindgen v${CBINDGEN_VERSION}"
     cargo install cbindgen --version "${CBINDGEN_VERSION}"
   fi
-  ./mach build
 fi
 
 if [[ $1 == "--full" || $2 == "--full" ]]; then
@@ -121,6 +120,8 @@ fi
 
 if [[ $1 == "--juggler" ]]; then
   ./mach build faster
+else
+  ./mach build
 fi
 
 if [[ "$(uname)" == "Darwin" ]]; then


### PR DESCRIPTION
Broken since https://github.com/microsoft/playwright/pull/8049

Previously when doing `build.sh --full` it was installing deps + building. Currently when passing `--full` it does not install the deps before, since it tries to compile before.