### PR TITLE
feat(playwright-test): introduce first-party docker integration

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -32,6 +32,7 @@ import { BrowserType } from '../client/browserType';
 import { BrowserContextOptions, LaunchOptions } from '../client/types';
 import { spawn } from 'child_process';
 import { registry, Executable } from '../utils/registry';
+import { launchGridAgent } from '../grid/gridAgent';
 
 const packageJSON = require('../../package.json');
 
@@ -202,6 +203,14 @@ commandWithOpenOptions('pdf <url> <filename>', 'save page as pdf',
   console.log('');
   console.log('  $ pdf https://example.com example.pdf');
 });
+
+program
+    .command('experimental-grid-agent', { hidden: true })
+    .requiredOption('--agentId <agentId>', 'agent ID')
+    .requiredOption('--gridURL <gridURL>', 'grid URL')
+    .action(function(options) {
+      launchGridAgent(options.agentId, options.gridURL);
+    });
 
 program
     .command('show-trace [trace]')

--- a/src/grid/docker.ts
+++ b/src/grid/docker.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import http from 'http';
+import os from 'os';
+
+export async function launchAgent(agentId: string, gridPort: number) {
+  const images = await getJSON('/images/json');
+  let imageName = process.env.PW_IMAGE_NAME;
+  if (!imageName) {
+    const packageJson = require('../../package.json');
+    imageName = `mcr.microsoft.com/playwright:v${packageJson.version}-focal`;
+  }
+  const pwImage = images.find((image: any) => image.RepoTags.includes(imageName));
+  if (!pwImage) {
+    //TODO: instructions how to pull given image.
+    throw new Error(`Failed to find ${imageName} docker image.`);
+  }
+  const container = await postJSON('/containers/create', {
+    Env: [
+      'PW_SOCKS_PROXY_PORT=1', // Enable port forwarding over PlaywrightClient
+    ],
+    WorkingDir: '/ms-playwright-agent',
+    Cmd: [ 'bash', 'start_agent.sh', agentId, `http://host.docker.internal:${gridPort}` ],
+    AttachStdout: true,
+    AttachStderr: true,
+    Image: pwImage.Id,
+    HostConfig: {
+      Init: true,
+      AutoRemove: true,
+      ShmSize: 2 * 1024 * 1024 * 1024,
+      ExtraHosts: process.platform === 'linux' ? [
+        'host.docker.internal:host-gateway', // Enable host.docker.internal on Linux.
+      ] : [],
+    },
+  });
+  await postJSON(`/containers/${container.Id}/start`);
+}
+
+async function getJSON(url: string): Promise<any> {
+  const result = await callDockerAPI('get', url);
+  if (!result)
+    return result;
+  return JSON.parse(result);
+}
+
+async function postJSON(url: string, json: any = undefined) {
+  const result = await callDockerAPI('post', url, json ? JSON.stringify(json) : undefined);
+  if (!result)
+    return result;
+  return JSON.parse(result);
+}
+
+function callDockerAPI(method: 'post'|'get', url: string, body: Buffer|string|undefined = undefined): Promise<string|null> {
+  const dockerSocket = os.platform() === 'win32' ? '\\\\.\\pipe\\docker_engine' : '/var/run/docker.sock';
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      socketPath: dockerSocket,
+      path: url,
+      method,
+    }, (response: http.IncomingMessage) => {
+      let body = '';
+      response.on('data', function(chunk){
+        body += chunk;
+      });
+      response.on('end', function(){
+        if (!response.statusCode || response.statusCode < 200 || response.statusCode >= 300) {
+          console.error(`ERROR ${method} ${url}`, response.statusCode, body);
+          resolve(null);
+        } else {
+          resolve(body);
+        }
+      });
+    });
+    request.on('error', function(e){
+      console.error('Error fetching json: ' + e);
+      resolve(null);
+    });
+    if (body) {
+      request.setHeader('Content-Type', 'application/json');
+      request.setHeader('Content-Length', body.length);
+      request.write(body);
+    }
+    request.end();
+  });
+}

--- a/src/grid/docker.ts
+++ b/src/grid/docker.ts
@@ -26,7 +26,7 @@ export async function launchAgent(agentId: string, gridPort: number) {
   }
   const pwImage = images.find((image: any) => image.RepoTags.includes(imageName));
   if (!pwImage) {
-    //TODO: instructions how to pull given image.
+    // TODO: instructions how to pull given image.
     throw new Error(`Failed to find ${imageName} docker image.`);
   }
   const container = await postJSON('/containers/create', {

--- a/src/grid/gridAgent.ts
+++ b/src/grid/gridAgent.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import debug from 'debug';
+import WebSocket from 'ws';
+import { fork } from 'child_process';
+
+export function launchGridAgent(agentId: string, gridURL: string) {
+  const log = debug(`[agent ${agentId}]`);
+  log('created');
+  const ws = new WebSocket(gridURL + `/registerAgent?agentId=${agentId}`);
+  ws.on('message', (workerId: string) => {
+    log('Worker requested ' + workerId);
+    fork(require.resolve('./gridWorker.js'), [gridURL, agentId, workerId], { detached: true });
+  });
+  ws.on('close', () => process.exit(0));
+}

--- a/src/grid/gridServer.ts
+++ b/src/grid/gridServer.ts
@@ -1,0 +1,318 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import debug from 'debug';
+import { EventEmitter } from 'events';
+import { URL } from 'url';
+import WebSocket, { Server as WebSocketServer } from 'ws';
+import { Connection } from '../client/connection';
+import { Playwright } from '../client/playwright';
+import { HttpServer } from '../utils/httpServer';
+import { createGuid } from '../utils/utils';
+import * as docker from './docker';
+
+class GridWorker extends EventEmitter {
+  readonly workerId = createGuid();
+  private _workerSocket: WebSocket | undefined;
+  private _clientSocket: WebSocket;
+  private _log: debug.Debugger;
+
+  constructor(clientSocket: WebSocket) {
+    super();
+    this._log = debug(`[worker ${this.workerId}]`);
+    this._clientSocket = clientSocket;
+    clientSocket.on('close', () => this.closeWorker('client socket closed'));
+    clientSocket.on('error', () => this.closeWorker('client socket error'));
+  }
+
+  workerConnected(workerSocket: WebSocket) {
+    this._log('connected');
+    this._workerSocket = workerSocket;
+    workerSocket.on('close', () => this.closeWorker('worker socket closed'));
+    workerSocket.on('error', () => this.closeWorker('worker socket error'));
+    this._clientSocket.on('message', data => workerSocket!.send(data));
+    workerSocket.on('message', data => this._clientSocket!.send(data));
+    this._clientSocket.send('run');
+  }
+
+  closeWorker(reason = '<unknown>') {
+    this._log('close' + ' reason = ' + reason);
+    this._workerSocket?.close();
+    this._clientSocket.close();
+    this.emit('close');
+  }
+
+  debugInfo() {
+    return { worker: !!this._workerSocket, client: !!this._clientSocket };
+  }
+}
+
+type AgentStatus = 'none' | 'created' | 'connected' | 'retiring';
+
+class GridAgent extends EventEmitter {
+  private _capacity: number;
+  readonly agentId = createGuid();
+  private _ws: WebSocket | undefined;
+  readonly _workers = new Map<string, GridWorker>();
+  private _status: AgentStatus = 'none';
+  private _workersWaitingForAgentConnected: GridWorker[] = [];
+  private _retireTimeout: NodeJS.Timeout | undefined;
+  private _log: debug.Debugger;
+  private _tenantId: string;
+  private _agentCreationTimeout: NodeJS.Timeout;
+
+  constructor(tenantId: string, capacity: number) {
+    super();
+    this._tenantId = tenantId;
+    this._capacity = capacity;
+    this._log = debug(`[agent ${this.agentId}]`);
+    this.setStatus('created');
+    this._agentCreationTimeout = setTimeout(() => {
+      // This will close the first socket, which is the creator of the agent.
+      for (const worker of this._workersWaitingForAgentConnected)
+        worker.closeWorker('timeout');
+      this.close();
+    }, 5 * 60_000);
+  }
+
+  public status(): AgentStatus {
+    return this._status;
+  }
+
+  setStatus(status: AgentStatus) {
+    this._log(`status ${this._status} => ${status}`);
+    this._status = status;
+  }
+
+  agentConnected(ws: WebSocket) {
+    clearTimeout(this._agentCreationTimeout);
+    this.setStatus('connected');
+    this._ws = ws;
+    for (const worker of this._workersWaitingForAgentConnected) {
+      this._log(`send worker id: ${worker.workerId}`);
+      ws.send(worker.workerId);
+    }
+    this._workersWaitingForAgentConnected = [];
+  }
+
+  canCreateWorker(tenantId: string) {
+    return this._workers.size < this._capacity && tenantId === this._tenantId;
+  }
+
+  async createWorker(clientSocket: WebSocket) {
+    if (this._retireTimeout)
+      clearTimeout(this._retireTimeout);
+    if (this._ws)
+      this.setStatus('connected');
+    const worker = new GridWorker(clientSocket);
+    this._log(`create worker: ${worker.workerId}`);
+    this._workers.set(worker.workerId, worker);
+    worker.on('close', () => {
+      this._workers.delete(worker.workerId);
+      if (!this._workers.size) {
+        this.setStatus('retiring');
+        if (this._retireTimeout)
+          clearTimeout(this._retireTimeout);
+        this._retireTimeout = setTimeout(() => this.close(), 30000);
+      }
+    });
+    if (this._ws) {
+      this._log(`send worker id: ${worker.workerId}`);
+      this._ws.send(worker.workerId);
+    } else {
+      this._workersWaitingForAgentConnected.push(worker);
+    }
+  }
+
+  workerConnected(workerId: string, ws: WebSocket) {
+    this._log(`worker connected: ${workerId}`);
+    const worker = this._workers.get(workerId)!;
+    worker.workerConnected(ws);
+  }
+
+  close() {
+    this._log('close');
+    this._ws?.close();
+    this.emit('close');
+  }
+}
+
+export class GridServer {
+  private _server: HttpServer;
+  private _wsServer: WebSocketServer;
+  private _agents = new Map<string, GridAgent>();
+  private _log: debug.Debugger;
+
+  constructor() {
+    this._log = debug(`[grid]`);
+    this._server = new HttpServer();
+
+    this._server.routePath('/', (request, response) => {
+      response.statusCode = 200;
+      response.setHeader('Content-Type', 'text/plain');
+      response.end(this._state());
+      return true;
+    });
+
+    this._wsServer = this._server.createWebSocketServer();
+
+    this._wsServer.shouldHandle = request => {
+      this._log(request.url);
+      if (request.url!.startsWith('/claimWorker')) {
+        // shouldHandle claims it accepts promise, except it doesn't.
+        return true;
+      }
+
+      if (request.url!.startsWith('/registerAgent') || request.url!.startsWith('/registerWorker')) {
+        const params = new URL('http://localhost/' + request.url).searchParams;
+        const agentId = params.get('agentId');
+        return !!agentId && this._agents.has(agentId);
+      }
+
+      return false;
+    };
+
+    this._wsServer.on('connection', async (ws, request) => {
+      if (request.url?.startsWith('/claimWorker')) {
+        const params = new URL('http://localhost/' + request.url).searchParams;
+        const tenantId = params.get('tenantId');
+        if (!tenantId) {
+          ws.close();
+          return;
+        }
+        const agent = [...this._agents.values()].find(w => w.canCreateWorker(tenantId)) || this._createAgent(tenantId);
+        if (!agent) {
+          ws.close();
+          return;
+        }
+
+        agent.createWorker(ws);
+        return;
+      }
+
+      if (request.url?.startsWith('/registerAgent')) {
+        const params = new URL('http://localhost/' + request.url).searchParams;
+        const agentId = params.get('agentId')!;
+        const agent = this._agents.get(agentId);
+        if (!agent) {
+          ws.close();
+          return;
+        }
+
+        agent.agentConnected(ws);
+        return;
+      }
+
+      if (request.url?.startsWith('/registerWorker')) {
+        const params = new URL('http://localhost/' + request.url).searchParams;
+        const agentId = params.get('agentId')!;
+        const workerId = params.get('workerId')!;
+        const agent = this._agents.get(agentId);
+        if (!agent || agent.status() !== 'connected') {
+          ws.close();
+          return;
+        }
+        agent.workerConnected(workerId, ws);
+        return;
+      }
+    });
+  }
+
+  private _createAgent(tenantId: string): GridAgent {
+    this._log('create agent for', tenantId);
+    const agent = new GridAgent(tenantId, Infinity);
+    this._agents.set(agent.agentId, agent);
+    agent.on('close', () => {
+      this._agents.delete(agent.agentId);
+    });
+    createAgent(agent.agentId, this._server.port()).then(success => {
+      if (success)
+        this._log('created');
+      else
+        agent.close();
+    });
+    return agent;
+  }
+
+  private _state(): string {
+    const lines = [this._agents.size + ' Agents(s)'];
+    for (const [agentId, agent] of this._agents) {
+      lines.push(`  agent ${mangle(agentId)}}: ${agent.status()}`);
+      for (const [workerId, worker] of agent._workers)
+        lines.push(`    ${mangle(workerId)} - ${JSON.stringify(worker.debugInfo())}`);
+    }
+    return lines.join('\n');
+  }
+
+  async start(port = 3000) {
+    return await this._server.start(port);
+  }
+
+  port(): number {
+    return this._server.port();
+  }
+
+  async stop() {
+    for (const agent of this._agents.values())
+      agent.close();
+    this._agents.clear();
+    await this._server.stop();
+  }
+}
+
+export class GridServerClient {
+  private _ws: WebSocket;
+  private _playwright: Playwright;
+
+  static async create(gridURL: string) {
+    const ws = new WebSocket(`${gridURL}/claimWorker?tenantId=docker`);
+    await new Promise(f => ws.once('message', f));
+    const connection = new Connection();
+    connection.onmessage = (message: Object) => ws.send(JSON.stringify(message));
+    ws.on('message', message => connection.dispatch(JSON.parse(message.toString())));
+    const playwright = await connection.initializePlaywright();
+    playwright._enablePortForwarding();
+    return new GridServerClient(ws, playwright);
+  }
+
+  constructor(ws: WebSocket, playwright: Playwright) {
+    this._ws = ws;
+    this._playwright = playwright;
+  }
+
+  playwright(): Playwright {
+    return this._playwright;
+  }
+
+  close() {
+    this._ws.close();
+  }
+}
+
+function mangle(sessionId: string) {
+  return sessionId.replace(/\w{28}/, 'x'.repeat(28));
+}
+
+async function createAgent(agentId: string, gridPort: number): Promise<boolean> {
+  try {
+    await docker.launchAgent(agentId, gridPort);
+    return true;
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
+}
+

--- a/src/grid/gridWorker.ts
+++ b/src/grid/gridWorker.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import WebSocket from 'ws';
+import debug from 'debug';
+import { DispatcherConnection, Root } from '../dispatchers/dispatcher';
+import { PlaywrightDispatcher } from '../dispatchers/playwrightDispatcher';
+import { createPlaywright } from '../server/playwright';
+import { gracefullyCloseAll } from '../utils/processLauncher';
+
+function launchGridWorker(gridURL: string, agentId: string, workerId: string) {
+  const log = debug(`[worker ${workerId}]`);
+  log('created');
+  const ws = new WebSocket(gridURL + `/registerWorker?agentId=${agentId}&workerId=${workerId}`);
+  const dispatcherConnection = new DispatcherConnection();
+  dispatcherConnection.onmessage = message => ws.send(JSON.stringify(message));
+  ws.once('open', () => {
+    new Root(dispatcherConnection, async rootScope => {
+      const playwright = createPlaywright('javascript');
+      const dispatcher = new PlaywrightDispatcher(rootScope, playwright);
+      dispatcher.enableSocksProxy();
+      return dispatcher;
+    });
+  });
+  ws.on('message', message => dispatcherConnection.dispatch(JSON.parse(message.toString())));
+  ws.on('close', async () => {
+    // Drop any messages during shutdown on the floor.
+    dispatcherConnection.onmessage = () => {};
+    setTimeout(() => process.exit(0), 30000);
+    // Meanwhile, try to gracefully close all browsers.
+    await gracefullyCloseAll();
+    process.exit(0);
+  });
+}
+
+launchGridWorker(process.argv[2], process.argv[3], process.argv[4]);

--- a/utils/check_deps.js
+++ b/utils/check_deps.js
@@ -181,7 +181,7 @@ DEPS['src/web/traceViewer/ui/'] = ['src/common/', 'src/protocol/', 'src/web/trac
 DEPS['src/remote/'] = ['src/client/', 'src/debug/', 'src/dispatchers/', 'src/server/', 'src/server/supplements/', 'src/server/electron/', 'src/server/trace/', 'src/utils/**'];
 
 // CLI should only use client-side features.
-DEPS['src/cli/'] = ['src/cli/**', 'src/client/**', 'src/generated/', 'src/server/injected/', 'src/debug/injected/', 'src/server/trace/**', 'src/utils/**'];
+DEPS['src/cli/'] = ['src/cli/**', 'src/client/**', 'src/generated/', 'src/server/injected/', 'src/debug/injected/', 'src/server/trace/**', 'src/utils/**', 'src/grid/**'];
 
 DEPS['src/server/supplements/recorder/recorderApp.ts'] = ['src/common/', 'src/utils/', 'src/server/', 'src/server/chromium/'];
 DEPS['src/server/supplements/recorderSupplement.ts'] = ['src/server/snapshot/', ...DEPS['src/server/']];
@@ -191,12 +191,16 @@ DEPS['src/utils/'] = ['src/common/', 'src/protocol/'];
 DEPS['src/server/trace/common/'] = ['src/server/snapshot/', ...DEPS['src/server/']];
 DEPS['src/server/trace/recorder/'] = ['src/server/trace/common/', ...DEPS['src/server/trace/common/']];
 DEPS['src/server/trace/viewer/'] = ['src/server/trace/common/', 'src/server/trace/recorder/', 'src/server/chromium/', ...DEPS['src/server/trace/common/']];
-DEPS['src/test/'] = ['src/test/**', 'src/utils/utils.ts', 'src/utils/**'];
+
+// Playwright Test
+DEPS['src/test/'] = ['src/test/**', 'src/utils/utils.ts', 'src/utils/**', 'src/grid/**'];
 
 // HTML report
 DEPS['src/web/htmlReport/'] = ['src/test/**', 'src/web/'];
 DEPS['src/web/htmlReport2/'] = ['src/test/**', 'src/web/'];
 
+// Grid
+DEPS['src/grid/'] = ['src/utils/**', 'src/dispatchers/**', 'src/server/', 'src/client/'];
 
 checkDeps().catch(e => {
   console.error(e && e.stack ? e.stack : e);

--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -1,5 +1,8 @@
 FROM ubuntu:bionic
 
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=America/Los_Angeles
+
 # === INSTALL Node.js ===
 
 # Install node14
@@ -21,10 +24,28 @@ RUN apt-get update && apt-get install -y python3.8 python3-pip && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 
+# Install VNC & noVNC
+
+ARG NOVNC_REF="1.2.0"
+ARG WEBSOCKIFY_REF="0.10.0"
+ENV DISPLAY_NUM=99
+ENV DISPLAY=":${DISPLAY_NUM}"
+
+RUN mkdir -p /opt/bin && chmod +x /dev/shm \
+  && apt-get update && apt-get install -y unzip fluxbox x11vnc \
+  && curl -L -o noVNC.zip "https://github.com/novnc/noVNC/archive/v${NOVNC_REF}.zip" \
+  && unzip -x noVNC.zip \
+  && mv noVNC-${NOVNC_REF} /opt/bin/noVNC \
+  && cp /opt/bin/noVNC/vnc.html /opt/bin/noVNC/index.html \
+  && rm noVNC.zip \
+  && curl -L -o websockify.zip "https://github.com/novnc/websockify/archive/v${WEBSOCKIFY_REF}.zip" \
+  && unzip -x websockify.zip \
+  && rm websockify.zip \
+  && mv websockify-${WEBSOCKIFY_REF} /opt/bin/noVNC/utils/websockify
+
 # === BAKE BROWSERS INTO IMAGE ===
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-ENV DEBIAN_FRONTEND=noninteractive
 
 # 1. Add tip-of-tree Playwright package to install its browsers.
 #    The package should be built beforehand from tip-of-tree Playwright.
@@ -35,8 +56,11 @@ COPY ./playwright.tar.gz /tmp/playwright.tar.gz
 #    Note: make sure to set 777 to the registry so that any user can access
 #    registry.
 RUN mkdir /ms-playwright && \
-    mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
+    mkdir /ms-playwright-agent && \
+    cd /ms-playwright-agent && npm init -y && \
     npm i /tmp/playwright.tar.gz && \
-    DEBIAN_FRONTEND=noninteractive npx playwright install-deps && \
-    rm -rf /tmp/pw && rm /tmp/playwright.tar.gz && \
+    npx playwright install-deps && \
+    rm /tmp/playwright.tar.gz && \
     chmod -R 777 /ms-playwright
+
+COPY start_agent.sh /ms-playwright-agent/start_agent.sh

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -1,5 +1,8 @@
 FROM ubuntu:focal
 
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=America/Los_Angeles
+
 # === INSTALL Node.js ===
 
 # Install node14
@@ -21,6 +24,25 @@ RUN apt-get update && apt-get install -y python3.8 python3-pip && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 
+# Install VNC & noVNC
+
+ARG NOVNC_REF="1.2.0"
+ARG WEBSOCKIFY_REF="0.10.0"
+ENV DISPLAY_NUM=99
+ENV DISPLAY=":${DISPLAY_NUM}"
+
+RUN mkdir -p /opt/bin && chmod +x /dev/shm \
+  && apt-get update && apt-get install -y unzip fluxbox x11vnc \
+  && curl -L -o noVNC.zip "https://github.com/novnc/noVNC/archive/v${NOVNC_REF}.zip" \
+  && unzip -x noVNC.zip \
+  && mv noVNC-${NOVNC_REF} /opt/bin/noVNC \
+  && cp /opt/bin/noVNC/vnc.html /opt/bin/noVNC/index.html \
+  && rm noVNC.zip \
+  && curl -L -o websockify.zip "https://github.com/novnc/websockify/archive/v${WEBSOCKIFY_REF}.zip" \
+  && unzip -x websockify.zip \
+  && rm websockify.zip \
+  && mv websockify-${WEBSOCKIFY_REF} /opt/bin/noVNC/utils/websockify
+
 # === BAKE BROWSERS INTO IMAGE ===
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
@@ -34,8 +56,11 @@ COPY ./playwright.tar.gz /tmp/playwright.tar.gz
 #    Note: make sure to set 777 to the registry so that any user can access
 #    registry.
 RUN mkdir /ms-playwright && \
-    mkdir /tmp/pw && cd /tmp/pw && npm init -y && \
+    mkdir /ms-playwright-agent && \
+    cd /ms-playwright-agent && npm init -y && \
     npm i /tmp/playwright.tar.gz && \
-    DEBIAN_FRONTEND=noninteractive npx playwright install-deps && \
-    rm -rf /tmp/pw && rm /tmp/playwright.tar.gz && \
+    npx playwright install-deps && \
+    rm /tmp/playwright.tar.gz && \
     chmod -R 777 /ms-playwright
+
+COPY start_agent.sh /ms-playwright-agent/start_agent.sh

--- a/utils/docker/start_agent.sh
+++ b/utils/docker/start_agent.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+set +x
+
+SCREEN_WIDTH=1360
+SCREEN_HEIGHT=1020
+SCREEN_DEPTH=24
+SCREEN_DPI=96
+GEOMETRY="${SCREEN_WIDTH}""x""${SCREEN_HEIGHT}""x""${SCREEN_DEPTH}"
+
+nohup /usr/bin/xvfb-run --server-num=${DISPLAY_NUM} \
+     --listen-tcp \
+     --server-args="-screen 0 ${GEOMETRY} -fbdir /var/tmp -dpi ${SCREEN_DPI} -listen tcp -noreset -ac +extension RANDR" \
+     /usr/bin/fluxbox -display ${DISPLAY} >/dev/null 2>&1 &
+
+for i in $(seq 1 50)
+  do
+    if xdpyinfo -display ${DISPLAY} >/dev/null 2>&1; then
+      break
+    fi
+    echo "Waiting for Xvfb..."
+    sleep 0.2
+  done
+
+nohup x11vnc -forever -shared -rfbport 5900 -rfbportv6 5900 -display ${DISPLAY} >/dev/null 2>&1 &
+nohup /opt/bin/noVNC/utils/launch.sh --listen 7900 --vnc localhost:5900 >/dev/null 2>&1 &
+
+npx playwright experimental-grid-agent --agentId "$1" --gridURL "$2"


### PR DESCRIPTION
This patch adds an experimental capability to run Playwright Test
browsers in Docker container.

To do so, run tests with the `PW_GRID=docker npx playwright test`
command.