### PR TITLE
fix(snapshot): render adoptedStyleSheets used in more than one node

### DIFF
--- a/src/server/snapshot/snapshotRenderer.ts
+++ b/src/server/snapshot/snapshotRenderer.ts
@@ -49,7 +49,7 @@ export class SnapshotRenderer {
         if (Array.isArray(n[0])) {
           // Node reference.
           const referenceIndex = snapshotIndex - n[0][0];
-          if (referenceIndex >= 0 && referenceIndex < snapshotIndex) {
+          if (referenceIndex >= 0 && referenceIndex <= snapshotIndex) {
             const nodes = snapshotNodes(this._snapshots[referenceIndex]);
             const nodeIndex = n[0][1];
             if (nodeIndex >= 0 && nodeIndex < nodes.length)

--- a/src/server/snapshot/snapshotterInjected.ts
+++ b/src/server/snapshot/snapshotterInjected.ts
@@ -91,6 +91,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string) {
       this._interceptNativeGetter(window.CSSStyleSheet.prototype, 'rules', (sheet: CSSStyleSheet) => this._invalidateStyleSheet(sheet));
       this._interceptNativeGetter(window.CSSStyleSheet.prototype, 'cssRules', (sheet: CSSStyleSheet) => this._invalidateStyleSheet(sheet));
       this._interceptNativeMethod(window.CSSStyleSheet.prototype, 'replaceSync', (sheet: CSSStyleSheet) => this._invalidateStyleSheet(sheet));
+      this._interceptNativeAsyncMethod(window.CSSStyleSheet.prototype, 'replace', (sheet: CSSStyleSheet) => this._invalidateStyleSheet(sheet));
 
       this._fakeBase = document.createElement('base');
 
@@ -105,6 +106,17 @@ export function frameSnapshotStreamer(snapshotStreamer: string) {
         return;
       obj[method] = function(...args: any[]) {
         const result = native.call(this, ...args);
+        cb(this, result);
+        return result;
+      };
+    }
+
+    private _interceptNativeAsyncMethod(obj: any, method: string, cb: (thisObj: any, result: any) => void) {
+      const native = obj[method] as Function;
+      if (!native)
+        return;
+      obj[method] = async function(...args: any[]) {
+        const result = await native.call(this, ...args);
         cb(this, result);
         return result;
       };

--- a/src/server/snapshot/snapshotterInjected.ts
+++ b/src/server/snapshot/snapshotterInjected.ts
@@ -90,6 +90,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string) {
       this._interceptNativeMethod(window.CSSStyleSheet.prototype, 'removeRule', (sheet: CSSStyleSheet) => this._invalidateStyleSheet(sheet));
       this._interceptNativeGetter(window.CSSStyleSheet.prototype, 'rules', (sheet: CSSStyleSheet) => this._invalidateStyleSheet(sheet));
       this._interceptNativeGetter(window.CSSStyleSheet.prototype, 'cssRules', (sheet: CSSStyleSheet) => this._invalidateStyleSheet(sheet));
+      this._interceptNativeMethod(window.CSSStyleSheet.prototype, 'replaceSync', (sheet: CSSStyleSheet) => this._invalidateStyleSheet(sheet));
 
       this._fakeBase = document.createElement('base');
 

--- a/tests/snapshotter.spec.ts
+++ b/tests/snapshotter.spec.ts
@@ -256,7 +256,7 @@ it.describe('snapshots', () => {
     expect(spanColor).toBe('rgb(0, 0, 255)');
   });
 
-  it('should work with adopted style sheets and replaceSync', async ({ page, toImpl, showSnapshot, snapshotter, browserName }) => {
+  it('should work with adopted style sheets and replace/replaceSync', async ({ page, toImpl, showSnapshot, snapshotter, browserName }) => {
     it.skip(browserName !== 'chromium', 'Constructed stylesheets are only in Chromium.');
     await page.setContent('<button>Hello</button>');
     await page.evaluate(() => {
@@ -270,6 +270,11 @@ it.describe('snapshots', () => {
       sheet.replaceSync(`button { color: blue }`);
     });
     const snapshot2 = await snapshotter.captureSnapshot(toImpl(page), 'snapshot2');
+    await page.evaluate(() => {
+      const [sheet] = (document as any).adoptedStyleSheets;
+      sheet.replace(`button { color: #0F0 }`);
+    });
+    const snapshot3 = await snapshotter.captureSnapshot(toImpl(page), 'snapshot3');
 
     {
       const frame = await showSnapshot(snapshot1);
@@ -286,6 +291,14 @@ it.describe('snapshots', () => {
         return window.getComputedStyle(button).color;
       });
       expect(buttonColor).toBe('rgb(0, 0, 255)');
+    }
+    {
+      const frame = await showSnapshot(snapshot3);
+      await frame.waitForSelector('button');
+      const buttonColor = await frame.$eval('button', button => {
+        return window.getComputedStyle(button).color;
+      });
+      expect(buttonColor).toBe('rgb(0, 255, 0)');
     }
   });
 

--- a/tests/snapshotter.spec.ts
+++ b/tests/snapshotter.spec.ts
@@ -226,15 +226,17 @@ it.describe('snapshots', () => {
       sheet.addRule('button', 'color: red');
       (document as any).adoptedStyleSheets = [sheet];
 
-      const div = document.createElement('div');
-      const root = div.attachShadow({
-        mode: 'open'
-      });
-      root.append('foo');
       const sheet2 = new CSSStyleSheet();
       sheet2.addRule(':host', 'color: blue');
-      (root as any).adoptedStyleSheets = [sheet2];
-      document.body.appendChild(div);
+
+      for (const element of [document.createElement('div'), document.createElement('span')]) {
+        const root = element.attachShadow({
+          mode: 'open'
+        });
+        root.append('foo');
+        (root as any).adoptedStyleSheets = [sheet2];
+        document.body.appendChild(element);
+      }
     });
     const snapshot1 = await snapshotter.captureSnapshot(toImpl(page), 'snapshot1');
 
@@ -248,6 +250,10 @@ it.describe('snapshots', () => {
       return window.getComputedStyle(div).color;
     });
     expect(divColor).toBe('rgb(0, 0, 255)');
+    const spanColor = await frame.$eval('span', span => {
+      return window.getComputedStyle(span).color;
+    });
+    expect(spanColor).toBe('rgb(0, 0, 255)');
   });
 
   it('should restore scroll positions', async ({ page, showSnapshot, toImpl, snapshotter, browserName }) => {


### PR DESCRIPTION
Sometimes adopted style sheets reference other style sheets in the same document.﻿

Fixes #7085.
