### PR TITLE
chore(create-playwright): UX follow-ups

### DIFF
--- a/packages/create-playwright/assets/playwright.config.js
+++ b/packages/create-playwright/assets/playwright.config.js
@@ -19,7 +19,7 @@ const config = {
 
   projects: [
     {
-      name: 'Desktop Chromium',
+      name: 'Desktop Chrome',
       use: {
         ...devices['Desktop Chrome'],
       },

--- a/packages/create-playwright/assets/playwright.config.js
+++ b/packages/create-playwright/assets/playwright.config.js
@@ -21,9 +21,7 @@ const config = {
     {
       name: 'Desktop Chromium',
       use: {
-        browserName: 'chromium',
-        // Test against Chrome Beta channel.
-        channel: 'chrome-beta',
+        ...devices['Desktop Chrome'],
       },
     },
     {

--- a/packages/create-playwright/assets/playwright.config.ts
+++ b/packages/create-playwright/assets/playwright.config.ts
@@ -17,9 +17,7 @@ const config: PlaywrightTestConfig = {
     {
       name: 'Chrome Stable',
       use: {
-        browserName: 'chromium',
-        // Test against Chrome Stable channel.
-        channel: 'chrome',
+        ...devices['Desktop Chrome'],
       },
     },
     {

--- a/packages/create-playwright/assets/playwright.config.ts
+++ b/packages/create-playwright/assets/playwright.config.ts
@@ -15,7 +15,7 @@ const config: PlaywrightTestConfig = {
 
   projects: [
     {
-      name: 'Chrome Stable',
+      name: 'Desktop Chrome',
       use: {
         ...devices['Desktop Chrome'],
       },

--- a/packages/create-playwright/package.json
+++ b/packages/create-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-playwright",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Getting started with writing end-to-end tests with Playwright.",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",

--- a/packages/create-playwright/src/index.ts
+++ b/packages/create-playwright/src/index.ts
@@ -135,7 +135,7 @@ class Generator {
     packageJSON.scripts['playwright-tests'] = `playwright test`;
 
     const files = new Map<string, string>();
-    files.set('package.json', JSON.stringify(packageJSON, null, 2));
+    files.set('package.json', JSON.stringify(packageJSON, null, 2) + '\n'); // NPM keeps a trailing new-line
     await createFiles(this.rootDir, files, true);
   }
 

--- a/packages/create-playwright/src/index.ts
+++ b/packages/create-playwright/src/index.ts
@@ -117,7 +117,7 @@ class Generator {
     let gitIgnore = '';
     if (fs.existsSync(path.join(this.rootDir, '.gitignore')))
       gitIgnore = fs.readFileSync(path.join(this.rootDir, '.gitignore'), 'utf-8').trimEnd() + '\n';
-    gitIgnore += 'test-results/';
+    gitIgnore += 'test-results/\n';
     files.set('.gitignore', gitIgnore);
 
     return { files, commands };

--- a/packages/create-playwright/src/index.ts
+++ b/packages/create-playwright/src/index.ts
@@ -99,7 +99,7 @@ class Generator {
 
     if (!fs.existsSync(path.join(this.rootDir, 'package.json'))) {
       commands.push({
-        name: 'Initializing NPM project',
+        name: `Initializing ${this.packageManager === 'yarn' ? 'Yarn' : 'NPM'} project`,
         command: this.packageManager === 'yarn' ? 'yarn init -y' : 'npm init -y',
       });
     }

--- a/packages/create-playwright/src/utils.ts
+++ b/packages/create-playwright/src/utils.ts
@@ -21,10 +21,14 @@ import path from 'path';
 import { prompt } from 'enquirer';
 import colors from 'ansi-colors';
 
+export type Command = {
+  command: string;
+  name: string;
+};
 
-export function executeCommands(cwd: string, commands: string[]) {
-  for (const command of commands) {
-    console.log('Running:', command);
+export function executeCommands(cwd: string, commands: Command[]) {
+  for (const { command, name } of commands) {
+    console.log(`${name} (${command})…`);
     execSync(command, {
       stdio: 'inherit',
       cwd,

--- a/packages/create-playwright/src/utils.ts
+++ b/packages/create-playwright/src/utils.ts
@@ -76,3 +76,7 @@ export function executeTemplate(input: string, args: Record<string, string>): st
     input = input.replace(`{{${key}}}`, args[key]);
   return input;
 }
+
+export function languagetoFileExtension(language: 'JavaScript' | 'TypeScript'): 'js' | 'ts' {
+  return language === 'JavaScript' ? 'js' : 'ts';
+}

--- a/packages/create-playwright/tests/integration.spec.ts
+++ b/packages/create-playwright/tests/integration.spec.ts
@@ -84,6 +84,7 @@ for (const packageManager of ['npm', 'yarn'] as ('npm'|'yarn')[]) {
       const playwrightConfigContent = fs.readFileSync(path.join(dir, 'playwright.config.ts'), 'utf8');
       expect(playwrightConfigContent).toContain('e2e');
       expect(fs.existsSync(path.join(dir, '.github/workflows/playwright.yml'))).toBeTruthy();
+      expect(fs.existsSync(path.join(dir, '.gitignore'))).toBeTruthy();
       if (packageManager === 'npm') {
         expect(stdout).toContain('Running: npm init -y');
         expect(stdout).toContain('Running: npm install --save-dev @playwright/test');

--- a/packages/create-playwright/tests/integration.spec.ts
+++ b/packages/create-playwright/tests/integration.spec.ts
@@ -86,13 +86,13 @@ for (const packageManager of ['npm', 'yarn'] as ('npm'|'yarn')[]) {
       expect(fs.existsSync(path.join(dir, '.github/workflows/playwright.yml'))).toBeTruthy();
       expect(fs.existsSync(path.join(dir, '.gitignore'))).toBeTruthy();
       if (packageManager === 'npm') {
-        expect(stdout).toContain('Running: npm init -y');
-        expect(stdout).toContain('Running: npm install --save-dev @playwright/test');
+        expect(stdout).toContain('Initializing NPM project (npm init -y)…');
+        expect(stdout).toContain('Installing Playwright Test (npm install --save-dev @playwright/test)…');
       } else {
-        expect(stdout).toContain('Running: yarn init -y');
-        expect(stdout).toContain('Running: yarn add --dev @playwright/test');
+        expect(stdout).toContain('Initializing Yarn project (yarn init -y)…');
+        expect(stdout).toContain('Installing Playwright Test (yarn add --dev @playwright/test)…');
       }
-      expect(stdout).toContain('Running: npx playwright install --with-deps');
+      expect(stdout).toContain('npx playwright install --with-deps');
     });
 
     test('should generate a project in a given directory', async ({ run }) => {


### PR DESCRIPTION
#8892

New outro is now in sync with what React & Next.js will print:

![image](https://user-images.githubusercontent.com/17984549/133239225-727679db-1424-4e49-80be-e48f40b1b398.png)

React:

```
Success! Created my-app at /Users/max/development/playwright/packages/create-playwright/my-app
Inside that directory, you can run several commands:

  npm run dev
    Starts the development server.

  npm run build
    Builds the app for production.

  npm start
    Runs the built app in production mode.

We suggest that you begin by typing:

  cd my-app
  npm run dev
```

Next.js:

```
✨  Done in 15.63s.

Success! Created test at /Users/max/development/playwright/packages/create-playwright/test
Inside that directory, you can run several commands:

  yarn start
    Starts the development server.

  yarn build
    Bundles the app into static files for production.

  yarn test
    Starts the test runner.

  yarn eject
    Removes this tool and copies build dependencies, configuration files
    and scripts into the app directory. If you do this, you can’t go back!

We suggest that you begin by typing:

  cd test
  yarn start

Happy hacking!
```