### PR TITLE
feat(test runner): add some fixture debugging

### DIFF
--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { formatLocation, wrapInPromise } from './util';
+import { formatLocation, wrapInPromise, debugTest } from './util';
 import * as crypto from 'crypto';
 import { FixturesWithLocation, Location, WorkerInfo, TestInfo, TestStepInternal } from './types';
 
@@ -67,6 +67,7 @@ class Fixture {
     let called = false;
     const setupFence = new Promise<void>((f, r) => { setupFenceFulfill = f; setupFenceReject = r; });
     const teardownFence = new Promise(f => this._teardownFenceCallback = f);
+    debugTest(`setup ${this.registration.name}`);
     this._tearDownComplete = wrapInPromise(this.registration.fn(params, async (value: any) => {
       if (called)
         throw new Error(`Cannot provide fixture value for the second time`);
@@ -94,6 +95,7 @@ class Fixture {
       await fixture.teardown();
     this.usages.clear();
     if (this._setup) {
+      debugTest(`teardown ${this.registration.name}`);
       this._teardownFenceCallback();
       await this._tearDownComplete;
     }

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -20,6 +20,7 @@ import path from 'path';
 import type { TestError, Location } from './types';
 import { default as minimatch } from 'minimatch';
 import { errors } from '../..';
+import debug from 'debug';
 
 export async function pollUntilDeadline(testInfo: TestInfoImpl, func: (remainingTime: number) => Promise<boolean>, pollTime: number | undefined, deadlinePromise: Promise<void>): Promise<void> {
   let defaultExpectTimeout = testInfo.project.expect?.timeout;
@@ -167,3 +168,5 @@ export function expectType(receiver: any, type: string, matcherName: string) {
 export function sanitizeForFilePath(s: string) {
   return s.replace(/[\x00-\x2F\x3A-\x40\x5B-\x60\x7B-\x7F]+/g, '-');
 }
+
+export const debugTest = debug('pw:test');


### PR DESCRIPTION
While debugging some test runner slowness, I needed some extra debug info. I figure we can add more as needed.﻿
