### PR TITLE
Feature: Addition of Tags to JSON Reporter Output

### DIFF
--- a/src/test/reporters/json.ts
+++ b/src/test/reporters/json.ts
@@ -202,7 +202,7 @@ class JSONReporter implements Reporter {
 
   private _serializeTestSpec(test: TestCase): JSONReportSpec {
 
-    let fixedTags: string[] = []
+    const fixedTags: string[] = [];
     const tagMatches: RegExpMatchArray| null = test.title.match(/@[\S]+/g);
 
     if (tagMatches) {

--- a/src/test/reporters/json.ts
+++ b/src/test/reporters/json.ts
@@ -44,6 +44,7 @@ export interface JSONReportSuite {
   suites?: JSONReportSuite[];
 }
 export interface JSONReportSpec {
+  tags: string[],
   title: string;
   ok: boolean;
   tests: JSONReportTest[];
@@ -200,9 +201,20 @@ class JSONReporter implements Reporter {
   }
 
   private _serializeTestSpec(test: TestCase): JSONReportSpec {
+
+    let fixedTags: string[] = []
+    const tagMatches: RegExpMatchArray| null = test.title.match(/@[\S]+/g);
+
+    if (tagMatches) {
+      tagMatches.forEach(function(tag){
+        fixedTags.push(tag.replace(/^@/,''));
+      });
+    }
+
     return {
       title: test.title,
       ok: test.ok(),
+      tags: fixedTags,
       tests: [ this._serializeTest(test) ],
       ...this._relativeLocation(test.location),
     };

--- a/src/test/reporters/json.ts
+++ b/src/test/reporters/json.ts
@@ -207,7 +207,7 @@ class JSONReporter implements Reporter {
 
     if (tagMatches) {
       tagMatches.forEach(function(tag){
-        fixedTags.push(tag.replace(/^@/,''));
+        fixedTags.push(tag.substring(1));
       });
     }
 

--- a/src/test/reporters/json.ts
+++ b/src/test/reporters/json.ts
@@ -201,20 +201,10 @@ class JSONReporter implements Reporter {
   }
 
   private _serializeTestSpec(test: TestCase): JSONReportSpec {
-
-    const fixedTags: string[] = [];
-    const tagMatches: RegExpMatchArray| null = test.title.match(/@[\S]+/g);
-
-    if (tagMatches) {
-      tagMatches.forEach(function(tag){
-        fixedTags.push(tag.substring(1));
-      });
-    }
-
     return {
       title: test.title,
       ok: test.ok(),
-      tags: fixedTags,
+      tags: (test.title.match(/@[\S]+/g) || []).map(t => t.substring(1)),
       tests: [ this._serializeTest(test) ],
       ...this._relativeLocation(test.location),
     };

--- a/tests/playwright-test/json-reporter.spec.ts
+++ b/tests/playwright-test/json-reporter.spec.ts
@@ -139,6 +139,36 @@ test('should show steps', async ({ runInlineTest }) => {
   expect(result.report.suites[0].specs[0].tests[0].results[0].steps[1].error).not.toBeUndefined();
 });
 
+test('should display tags separately from title', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test('math works! @USR-MATH-001 @USR-MATH-002', async ({}) => {
+        expect(1 + 1).toBe(2);
+        await test.step('math works in a step', async () => {
+          expect(2 + 2).toBe(4);
+          await test.step('nested step', async () => {
+            expect(2 + 2).toBe(4);
+            await test.step('deeply nested step', async () => {
+              expect(2 + 2).toBe(4);
+            });
+          })
+        })
+      });
+    `
+  });
+  
+  expect(result.exitCode).toBe(0);
+  expect(result.report.suites.length).toBe(1);
+  expect(result.report.suites[0].specs.length).toBe(1);
+  // Ensure the length is as expected
+  expect(result.report.suites[0].specs[0].tags.length).toBe(2);
+  console.log(result.report.suites[0].specs[0].tags)
+  // Ensure that the '@' value is stripped
+  expect(result.report.suites[0].specs[0].tags[0]).toBe('USR-MATH-001');
+  expect(result.report.suites[0].specs[0].tags[1]).toBe('USR-MATH-002');
+});
+
 test('should have relative always-posix paths', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `

--- a/tests/playwright-test/json-reporter.spec.ts
+++ b/tests/playwright-test/json-reporter.spec.ts
@@ -157,13 +157,12 @@ test('should display tags separately from title', async ({ runInlineTest }) => {
       });
     `
   });
-  
+
   expect(result.exitCode).toBe(0);
   expect(result.report.suites.length).toBe(1);
   expect(result.report.suites[0].specs.length).toBe(1);
   // Ensure the length is as expected
   expect(result.report.suites[0].specs[0].tags.length).toBe(2);
-  console.log(result.report.suites[0].specs[0].tags)
   // Ensure that the '@' value is stripped
   expect(result.report.suites[0].specs[0].tags[0]).toBe('USR-MATH-001');
   expect(result.report.suites[0].specs[0].tags[1]).toBe('USR-MATH-002');


### PR DESCRIPTION
# Background

I've used tools like Newman to do E2E testing for APIs, and have used their custom reporters and tagging to facilitate documentation / validation of a product in CI. While looking into doing something similar with Playwright, I realized the JSON reporter didn't expose the tags passed to a spec in the output (shy of still being in the title).

When going complex user acceptance testing, being able to map from User Story -> Requirement -> Test is important, and using tags to identify the tests for that purpose is extremely beneficial. While we can add tags with playwright, they're *absent* in the JSON reporter's output shy of being in the title of the spec itself. 

This pull request updates the reporter such that the spec serializer locates all tags by regex with word boundary, plops them into an array and then strips the preceding `@` since it's more of an identifier for a tag than the content of the tag. 
