### PR TITLE
docs/test reporters: fix allure result path

### DIFF
--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -403,5 +403,5 @@ export default config;
   npx playwright test --reporter=line,allure-playwright
 
   # Generate report
-  allure generate ./allure-result --clean && allure open ./allure-report
+  allure generate ./allure-results --clean && allure open ./allure-report
   ```


### PR DESCRIPTION
By default, allure generates `allure-results` instead of `allure-result`