### PR TITLE
feat(test-runner): add --debug CLI flag

### DIFF
--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -285,16 +285,7 @@ Following are the usual command line patterns. Learn more about the [command lin
 
 - Run in debug mode with [Playwright Inspector](./inspector.md)
   ```bash
-  # Linux/macOS
-  PWDEBUG=1 npx playwright test
-
-  # Windows with cmd.exe
-  set PWDEBUG=1
-  npx playwright test
-
-  # Windows with PowerShell
-  $env:PWDEBUG=1
-  npx playwright test
+  npx playwright test --debug
   ```
 
 - Ask for help

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -61,16 +61,7 @@ Here are the most common options available in the command line.
 
 - Run in debug mode with [Playwright Inspector](./inspector.md)
   ```bash
-  # Linux/macOS
-  PWDEBUG=1 npx playwright test
-
-  # Windows with cmd.exe
-  set PWDEBUG=1
-  npx playwright test
-
-  # Windows with PowerShell
-  $env:PWDEBUG=1
-  npx playwright test
+  npx playwright test --debug
   ```
 
 - Ask for help
@@ -86,7 +77,7 @@ Complete set of Playwright Test options is available in the [configuration file]
 
 - `--browser`: Run test in a specific browser. Available options are  `"chromium"`, `"firefox"`, `"webkit"` or `"all"` to run tests in all three browsers at the same time.
 
-- `--debug`: Run tests in debug mode. Shortcut for timeout=0, maxFailures=1, PWDEBUG=1, headed=true, workers=1
+- `--debug`: Run tests with Playwright Inspector. Shortcut for `PWDEBUG=1` environment variable and `--timeout=0 --maxFailures=1 --headed --workers=1` options
 
 - `-c <file>` or `--config <file>`: Configuration file. If not passed, defaults to `playwright.config.ts` or `playwright.config.js` in the current directory.
 

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -86,6 +86,8 @@ Complete set of Playwright Test options is available in the [configuration file]
 
 - `--browser`: Run test in a specific browser. Available options are  `"chromium"`, `"firefox"`, `"webkit"` or `"all"` to run tests in all three browsers at the same time.
 
+- `--debug`: Run tests in debug mode. Shortcut for timeout=0, maxFailures=1, PWDEBUG=1, headed=true, workers=1
+
 - `-c <file>` or `--config <file>`: Configuration file. If not passed, defaults to `playwright.config.ts` or `playwright.config.js` in the current directory.
 
 - `-c <dir>` or `--config <dir>`: Directory with the tests to run without configuration file.

--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -44,6 +44,7 @@ export function addTestCommand(program: commander.CommanderStatic) {
   command.description('Run tests with Playwright Test');
   command.option('--browser <browser>', `Browser to use for tests, one of "all", "chromium", "firefox" or "webkit" (default: "chromium")`);
   command.option('--headed', `Run tests in headed browsers (default: headless)`);
+  command.option('--debug', `Run tests in debug mode. Shortcut for timeout=0, maxFailures=1, PWDEBUG=1, headed=true, workers=1`);
   command.option('-c, --config <file>', `Configuration file, or a test directory with optional "${tsConfig}"/"${jsConfig}"`);
   command.option('--forbid-only', `Fail if test.only is called (default: false)`);
   command.option('-g, --grep <grep>', `Only run tests matching this regular expression (default: ".*")`);
@@ -97,8 +98,14 @@ async function createLoader(opts: { [key: string]: any }): Promise<Loader> {
   }
 
   const overrides = overridesFromOptions(opts);
-  if (opts.headed)
+  if (opts.headed || opts.debug)
     overrides.use = { headless: false };
+  if (opts.debug) {
+    overrides.maxFailures = 1;
+    overrides.timeout = 0;
+    overrides.workers = 1;
+    process.env.PWDEBUG = '1';
+  }
   const loader = new Loader(defaultConfig, overrides);
 
   async function loadConfig(configFile: string) {

--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -44,7 +44,7 @@ export function addTestCommand(program: commander.CommanderStatic) {
   command.description('Run tests with Playwright Test');
   command.option('--browser <browser>', `Browser to use for tests, one of "all", "chromium", "firefox" or "webkit" (default: "chromium")`);
   command.option('--headed', `Run tests in headed browsers (default: headless)`);
-  command.option('--debug', `Run tests in debug mode. Shortcut for timeout=0, maxFailures=1, PWDEBUG=1, headed=true, workers=1`);
+  command.option('--debug', `Run tests with Playwright Inspector. Shortcut for "PWDEBUG=1" environment variable and "--timeout=0 --maxFailures=1 --headed --workers=1" options`);
   command.option('-c, --config <file>', `Configuration file, or a test directory with optional "${tsConfig}"/"${jsConfig}"`);
   command.option('--forbid-only', `Fail if test.only is called (default: false)`);
   command.option('-g, --grep <grep>', `Only run tests matching this regular expression (default: ".*")`);


### PR DESCRIPTION
We could also add the `debug` property inside the config. CLI only is enough from my understanding.

#8892