### PR TITLE
chore: hide npx playwright debug command

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -67,7 +67,7 @@ commandWithOpenOptions('codegen [url]', 'open page and generate code for user ac
 });
 
 program
-    .command('debug <app> [args...]')
+    .command('debug <app> [args...]', { hidden: true })
     .description('run command in debug mode: disable timeout, open inspector')
     .allowUnknownOption(true)
     .action(function(app, args) {


### PR DESCRIPTION
It got introduced in #5679 but seems like its more confusing than it helps users. For folks who are using the test-runner, we advice `npx playwright test --debug` now, see here: #8938