### PR TITLE
fix(test runner): after hooks step should not be nested

### DIFF
--- a/src/test/dispatcher.ts
+++ b/src/test/dispatcher.ts
@@ -297,7 +297,7 @@ export class Dispatcher {
         return;
       }
       const { test, result, steps, stepStack } = this._testById.get(params.testId)!;
-      const parentStep = [...stepStack].pop();
+      const parentStep = params.forceNoParent ? undefined : [...stepStack].pop();
       const step: TestStep = {
         title: params.title,
         titlePath: () => {

--- a/src/test/expect.ts
+++ b/src/test/expect.ts
@@ -75,7 +75,12 @@ function wrap(matcherName: string, matcher: any) {
 
     const INTERNAL_STACK_LENGTH = 3;
     const stackLines = new Error().stack!.split('\n').slice(INTERNAL_STACK_LENGTH + 1);
-    const step = testInfo._addStep('expect', `expect${this.isNot ? '.not' : ''}.${matcherName}`, true);
+    const step = testInfo._addStep({
+      category: 'expect',
+      title: `expect${this.isNot ? '.not' : ''}.${matcherName}`,
+      canHaveChildren: true,
+      forceNoParent: false
+    });
 
     const reportStepEnd = (result: any) => {
       const success = result.pass !== this.isNot;

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -212,8 +212,12 @@ export const test = _baseTest.extend<TestFixtures, WorkerAndFileFixtures>({
       }
       (context as any)._csi = {
         onApiCallBegin: (apiCall: string) => {
-          const testInfoImpl = testInfo as any;
-          const step = testInfoImpl._addStep('pw:api', apiCall, false);
+          const step = (testInfo as any)._addStep({
+            category: 'pw:api',
+            title: apiCall,
+            canHaveChildren: false,
+            forceNoParent: false,
+          });
           return { userObject: step };
         },
         onApiCallEnd: (data: { userObject: any }, error?: Error) => {

--- a/src/test/ipc.ts
+++ b/src/test/ipc.ts
@@ -52,6 +52,7 @@ export type StepBeginPayload = {
   title: string;
   category: string;
   canHaveChildren: boolean;
+  forceNoParent: boolean;
   wallTime: number;  // milliseconds since unix epoch
 };
 

--- a/src/test/testType.ts
+++ b/src/test/testType.ts
@@ -186,7 +186,12 @@ export class TestTypeImpl {
     const testInfo = currentTestInfo();
     if (!testInfo)
       throw errorWithLocation(location, `test.step() can only be called from a test`);
-    const step = testInfo._addStep('test.step', title, true);
+    const step = testInfo._addStep({
+      category: 'test.step',
+      title,
+      canHaveChildren: true,
+      forceNoParent: false
+    });
     try {
       await body();
       step.complete();

--- a/src/test/types.ts
+++ b/src/test/types.ts
@@ -27,11 +27,13 @@ export type Annotations = { type: string, description?: string }[];
 
 export interface TestStepInternal {
   complete(error?: Error | TestError): void;
+  title: string;
   category: string;
   canHaveChildren: boolean;
+  forceNoParent: boolean;
 }
 
 export interface TestInfoImpl extends TestInfo {
   _testFinished: Promise<void>;
-  _addStep: (category: string, title: string, canHaveChildren: boolean) => TestStepInternal;
+  _addStep: (data: Omit<TestStepInternal, 'complete'>) => TestStepInternal;
 }

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -143,7 +143,12 @@ export const playwrightFixtures: Fixtures<PlaywrightTestOptions & PlaywrightTest
       (context as any)._csi = {
         onApiCallBegin: (apiCall: string) => {
           const testInfoImpl = testInfo as any;
-          const step = testInfoImpl._addStep('pw:api', apiCall, false);
+          const step = testInfoImpl._addStep({
+            category: 'pw:api',
+            title: apiCall,
+            canHaveChildren: false,
+            forceNoParent: false
+          });
           return { userObject: step };
         },
         onApiCallEnd: (data: { userObject: any }, error?: Error) => {


### PR DESCRIPTION
When we teardown after timeout, or some inbalanced `test.step` calls, "after hooks" is put to the last unfinished step.

Fixes #8921.