### PR TITLE
browser(webkit): Reenable OS_DARK_MODE_SUPPORT

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1545
-Changed: pavel.feldman@gmail.com Thu 16 Sep 2021 01:11:19 PM PDT
+1546
+Changed: dpino@igalia.com Fri Sep 17 05:26:59 UTC 2021

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -2272,20 +2272,18 @@ index 4a12b5a4393fe2bbe39673e3fa547c9d6976abd7..678b777736019debbd25fcd72fd34f3d
  
  if (Systemd_FOUND)
 diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
-index b066e5fc131fc4e8b7fb956795379989f6a85bcc..2f45ae9c423aeba3c93eb24081ec4091beec57e7 100644
+index b066e5fc131fc4e8b7fb956795379989f6a85bcc..9008dfb7a119ecb2a391a76507afe3e041b41c70 100644
 --- a/Source/WTF/wtf/PlatformHave.h
 +++ b/Source/WTF/wtf/PlatformHave.h
-@@ -387,8 +387,8 @@
+@@ -387,7 +387,7 @@
  #define HAVE_NSHTTPCOOKIESTORAGE__INITWITHIDENTIFIER_WITH_INACCURATE_NULLABILITY 1
  #endif
  
 -#if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(GTK) || PLATFORM(WPE)
--#define HAVE_OS_DARK_MODE_SUPPORT 1
 +#if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
-+#define HAVE_OS_DARK_MODE_SUPPORT 0
+ #define HAVE_OS_DARK_MODE_SUPPORT 1
  #endif
  
- #if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 110000
 diff --git a/Source/WTF/wtf/PlatformWPE.cmake b/Source/WTF/wtf/PlatformWPE.cmake
 index 643ef0fcdf4f3ce4a1f27bc0cc6e179b7143bbd4..f6ee05b80ebc200d0db74fc7e975d96ce0dcd75f 100644
 --- a/Source/WTF/wtf/PlatformWPE.cmake
@@ -21725,7 +21723,7 @@ index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d
 +    LIBVPX_LIBRARIES
 +)
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index 5e8501a6000a30a192bbd603e7dab8a2d7714024..2ba5734d33d482c938cbbe206c52c5f243e5caee 100644
+index 5e8501a6000a30a192bbd603e7dab8a2d7714024..50b284f48a747829ff6a28a6416aecde323d4c28 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
 @@ -5,6 +5,7 @@ WEBKIT_OPTION_BEGIN()
@@ -21800,17 +21798,8 @@ index 5e8501a6000a30a192bbd603e7dab8a2d7714024..2ba5734d33d482c938cbbe206c52c5f2
  include(GStreamerDependencies)
  
  # Finalize the value for all options. Do not attempt to use an option before
-@@ -268,7 +283,7 @@ if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
- endif ()
- 
- SET_AND_EXPOSE_TO_BUILD(HAVE_GTK_UNIX_PRINTING ${GTK_UNIX_PRINT_FOUND})
--SET_AND_EXPOSE_TO_BUILD(HAVE_OS_DARK_MODE_SUPPORT 1)
-+SET_AND_EXPOSE_TO_BUILD(HAVE_OS_DARK_MODE_SUPPORT 0)
- 
- # GUri is available in GLib since version 2.66, but we only want to use it if version is >= 2.67.1.
- if (PC_GLIB_VERSION VERSION_GREATER "2.67.1" OR PC_GLIB_VERSION STREQUAL "2.67.1")
 diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
-index 0e23732209de52a342e8dc19eea5efbb7b85b97a..398b92a14e8273a929fc359ad821eccd9b48a06b 100644
+index 0e23732209de52a342e8dc19eea5efbb7b85b97a..2a7712cc155635d29a3bbfcedb8289bf597630a1 100644
 --- a/Source/cmake/OptionsWPE.cmake
 +++ b/Source/cmake/OptionsWPE.cmake
 @@ -3,6 +3,7 @@ include(VersioningUtils)
@@ -21868,15 +21857,6 @@ index 0e23732209de52a342e8dc19eea5efbb7b85b97a..398b92a14e8273a929fc359ad821eccd
  WEBKIT_OPTION_DEFINE(USE_SYSTEMD "Whether to enable journald logging" PUBLIC ON)
  WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." PUBLIC ON)
  
-@@ -284,7 +304,7 @@ SET_AND_EXPOSE_TO_BUILD(USE_TEXTURE_MAPPER_GL TRUE)
- SET_AND_EXPOSE_TO_BUILD(USE_TILED_BACKING_STORE TRUE)
- SET_AND_EXPOSE_TO_BUILD(USE_COORDINATED_GRAPHICS TRUE)
- SET_AND_EXPOSE_TO_BUILD(USE_NICOSIA TRUE)
--SET_AND_EXPOSE_TO_BUILD(HAVE_OS_DARK_MODE_SUPPORT 1)
-+SET_AND_EXPOSE_TO_BUILD(HAVE_OS_DARK_MODE_SUPPORT 0)
- 
- # GUri is available in GLib since version 2.66, but we only want to use it if version is >= 2.67.1.
- if (PC_GLIB_VERSION VERSION_GREATER "2.67.1" OR PC_GLIB_VERSION STREQUAL "2.67.1")
 diff --git a/Source/cmake/OptionsWin.cmake b/Source/cmake/OptionsWin.cmake
 index fb99a1e511986a6a0ea6a593d0c5a225bcc26fe3..5c31cd3f0529c81d932b3adc092ea8c1bab877e0 100644
 --- a/Source/cmake/OptionsWin.cmake


### PR DESCRIPTION
Disabling OS_DARK_MODE_SUPPORT caused regressions in several tests and it also broke WebKit compilation in Mac platforms.

https://github.com/microsoft/playwright/pull/8802
https://playwright.azureedge.net/builds/webkit/1544/webkit-mac-11.0-arm64.log.gz