### PR TITLE
fix(codegen): generate Asssert.AreEqual instead of Equals for csharp

### DIFF
--- a/src/server/supplements/recorder/csharp.ts
+++ b/src/server/supplements/recorder/csharp.ts
@@ -84,7 +84,7 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
       formatter.add(line);
 
     if (signals.assertNavigation)
-      formatter.add(`  // Assert.Equal(${quote(signals.assertNavigation.url)}, ${pageAlias}.Url);`);
+      formatter.add(`  // Assert.AreEqual(${quote(signals.assertNavigation.url)}, ${pageAlias}.Url);`);
     return formatter.format();
   }
 


### PR DESCRIPTION
Using `Assert.Equals` throws an Exception in NUnit, which is our default.