### PR TITLE
fix(fetch): be compatible with a 0 timeout

### DIFF
--- a/src/server/fetch.ts
+++ b/src/server/fetch.ts
@@ -111,7 +111,7 @@ export abstract class FetchRequest extends SdkObject {
       }
 
       const timeout = defaults.timeoutSettings.timeout(params);
-      const deadline = monotonicTime() + timeout;
+      const deadline = timeout && (monotonicTime() + timeout);
 
       const options: https.RequestOptions & { maxRedirects: number, deadline: number } = {
         method,
@@ -279,16 +279,20 @@ export abstract class FetchRequest extends SdkObject {
         body.on('error',reject);
       });
       request.on('error', reject);
-      const rejectOnTimeout = () =>  {
-        reject(new Error(`Request timed out after ${options.timeout}ms`));
-        request.abort();
-      };
-      const remaining = options.deadline - monotonicTime();
-      if (remaining <= 0) {
-        rejectOnTimeout();
-        return;
+
+      if (options.deadline) {
+        const rejectOnTimeout = () =>  {
+          reject(new Error(`Request timed out after ${options.timeout}ms`));
+          request.abort();
+        };
+        const remaining = options.deadline - monotonicTime();
+        if (remaining <= 0) {
+          rejectOnTimeout();
+          return;
+        }
+        request.setTimeout(remaining, rejectOnTimeout);
       }
-      request.setTimeout(remaining, rejectOnTimeout);
+
       if (postData)
         request.write(postData);
       request.end();

--- a/tests/browsercontext-fetch.spec.ts
+++ b/tests/browsercontext-fetch.spec.ts
@@ -659,6 +659,23 @@ it('should support timeout option', async function({context, server}) {
   expect(error.message).toContain(`Request timed out after 10ms`);
 });
 
+it('should support a timeout of 0', async function({context, server}) {
+  server.setRoute('/slow', (req, res) => {
+    res.writeHead(200, {
+      'content-length': 4,
+      'content-type': 'text/html',
+    });
+    setTimeout(() => {
+      res.end('done');
+    }, 50);
+  });
+
+  const response = await context._request.get(server.PREFIX + '/slow', {
+    timeout: 0,
+  });
+  expect(await response.text()).toBe('done');
+});
+
 it('should respect timeout after redirects', async function({context, server}) {
   server.setRedirect('/redirect', '/slow');
   server.setRoute('/slow', (req, res) => {


### PR DESCRIPTION
When using e.g. `PWDEBUG=console` [a timeout of 0 gets used](https://github.com/microsoft/playwright/blob/ad731c1535a83953628a05c870185199b77f6ef0/src/utils/timeoutSettings.ts#L21). Also passing manually a timeout of 0 results also ends up in a timeout of 0.

Actual: This then results in a negative deadline and the request gets instantly rejected.
Expected: It does not timeout at all.