### PR TITLE
chore(registry): refactor logic of what browsers to download to top level

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -113,9 +113,10 @@ program
     .action(async function(args: string[], command: program.Command) {
       try {
         if (!args.length) {
+          const executables = registry.defaultExecutables();
           if (command.opts().withDeps)
-            await registry.installDeps();
-          await registry.install();
+            await registry.installDeps(executables);
+          await registry.install(executables);
         } else {
           const executables = checkBrowsersToInstall(args);
           if (command.opts().withDeps)
@@ -143,7 +144,7 @@ program
     .action(async function(args: string[]) {
       try {
         if (!args.length)
-          await registry.installDeps();
+          await registry.installDeps(registry.defaultExecutables());
         else
           await registry.installDeps(checkBrowsersToInstall(args));
       } catch (e) {


### PR DESCRIPTION
Part of the monorepo refactoring.

Today each of our packages has a browsers.json that sets some executables as download by default.

When packages depend on core, there is only one browsers.json. So there needs to be a method to
download only a few browsers by name. While tracing the code I refactored it to remove optional
methods so that default browsers aren't downloaded by accident.
