### PR TITLE
fix(page.content): throw a nice error when navigation intervenes

### DIFF
--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -769,15 +769,21 @@ export class Frame extends SdkObject {
   }
 
   async content(): Promise<string> {
-    const context = await this._utilityContext();
-    return context.evaluate(() => {
-      let retVal = '';
-      if (document.doctype)
-        retVal = new XMLSerializer().serializeToString(document.doctype);
-      if (document.documentElement)
-        retVal += document.documentElement.outerHTML;
-      return retVal;
-    });
+    try {
+      const context = await this._utilityContext();
+      return await context.evaluate(() => {
+        let retVal = '';
+        if (document.doctype)
+          retVal = new XMLSerializer().serializeToString(document.doctype);
+        if (document.documentElement)
+          retVal += document.documentElement.outerHTML;
+        return retVal;
+      });
+    } catch (e) {
+      if (js.isJavaScriptErrorInEvaluate(e) || isSessionClosedError(e))
+        throw e;
+      throw new Error(`Unable to retrieve content because the page is navigating and changing the content.`);
+    }
   }
 
   async setContent(metadata: CallMetadata, html: string, options: types.NavigateOptions = {}): Promise<void> {

--- a/tests/page/page-set-content.spec.ts
+++ b/tests/page/page-set-content.spec.ts
@@ -101,3 +101,18 @@ it('should work with newline', async ({page, server}) => {
   await page.setContent('<div>\n</div>');
   expect(await page.$eval('div', div => div.textContent)).toBe('\n');
 });
+
+it('content() should throw nice error during navigation', async ({page, server}) => {
+  for (let timeout = 0; timeout < 200; timeout += 20) {
+    await page.setContent('<div>hello</div>');
+    const promise = page.goto(server.EMPTY_PAGE);
+    await page.waitForTimeout(timeout);
+    const [contentOrError] = await Promise.all([
+      page.content().catch(e => e),
+      promise,
+    ]);
+    const emptyOutput = '<html><head></head><body></body></html>';
+    if (contentOrError !== expectedOutput && contentOrError !== emptyOutput)
+      expect(contentOrError?.message).toContain('Unable to retrieve content because the page is navigating and changing the content.');
+  }
+});


### PR DESCRIPTION
Fixes #8958.