### PR TITLE
test: add failing WebKit navigation test

### DIFF
--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -59,11 +59,11 @@ it('should work cross-process', async ({page, server}) => {
 });
 
 it('should work with Cross-Origin-Opener-Policy', async ({page, server, browserName}) => {
-  it.fail(browserName === 'webkit', 'Regressed in https://trac.webkit.org/changeset/281516/webkit')
+  it.fail(browserName === 'webkit', 'Regressed in https://trac.webkit.org/changeset/281516/webkit');
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
     res.end();
-  })
+  });
   await page.goto(server.EMPTY_PAGE);
   expect(page.url()).toBe(server.EMPTY_PAGE);
 });

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -58,6 +58,16 @@ it('should work cross-process', async ({page, server}) => {
   expect(response.url()).toBe(url);
 });
 
+it('should work with Cross-Origin-Opener-Policy', async ({page, server, browserName}) => {
+  it.fail(browserName === 'webkit', 'Regressed in https://trac.webkit.org/changeset/281516/webkit')
+  server.setRoute('/empty.html', (req, res) => {
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    res.end();
+  })
+  await page.goto(server.EMPTY_PAGE);
+  expect(page.url()).toBe(server.EMPTY_PAGE);
+});
+
 it('should capture iframe navigation request', async ({page, server}) => {
   await page.goto(server.EMPTY_PAGE);
   expect(page.url()).toBe(server.EMPTY_PAGE);


### PR DESCRIPTION
The test documents regression which was apparently introduced in [this commit](https://trac.webkit.org/changeset/281516/webkit) upstream.

Update:
Actually, it is https://trac.webkit.org/changeset/282007/webkit (Turn on support for Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy on WebKit2) that causes the problem.

#9065