### PR TITLE
fix(webkit): support Cross-Origin-Opener-Policy navigation

### DIFF
--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -823,6 +823,10 @@ export class Frame extends SdkObject {
     return this._parentFrame;
   }
 
+  isMainFrame(): boolean {
+    return this._page.mainFrame() === this;
+  }
+
   childFrames(): Frame[] {
     return Array.from(this._childFrames);
   }

--- a/src/server/webkit/wkInterceptableRequest.ts
+++ b/src/server/webkit/wkInterceptableRequest.ts
@@ -45,7 +45,7 @@ const errorReasons: { [reason: string]: Protocol.Network.ResourceErrorType } = {
 export class WKInterceptableRequest {
   private readonly _session: WKSession;
   readonly request: network.Request;
-  readonly _requestId: string;
+  _requestId: string;
   _timestamp: number;
   _wallTime: number;
   readonly _route: WKRouteImpl | null;

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -1224,7 +1224,7 @@ class WKNavigation {
     if (event.requestId !== this._originalRequestId)
       return false;
     if (!event.canceled)
-      return true;
+      return false;
     // Navigation in the original frame is canceled and actually continues in the
     // provisional page, so we ignore failure events from the original page.
     return this._page.hasProvisionalPage();

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -1010,7 +1010,7 @@ export class WKPage implements PageDelegate {
       session.sendMayFail('Network.interceptRequestWithError', { errorType: 'Cancellation', requestId: event.requestId });
       return;
     }
-    if (!request._route) {
+    if (!request._route || this._currentMainFrameNavigation.shoudIgnoreRequestInterception(event)) {
       // Intercepted, although we do not intend to allow interception.
       // Just continue.
       session.sendMayFail('Network.interceptWithRequest', { requestId: request._requestId });
@@ -1252,5 +1252,11 @@ class WKNavigation {
       this._responseReceived = true;
     }
     return false;
+  }
+
+  shoudIgnoreRequestInterception(event: Protocol.Network.requestInterceptedPayload): boolean {
+    // It only makes sense to intercept request in the old process before it is sent to
+    // the server (in the new process the response is already received and will be replayed)
+    return this._provisionalPageRequestId === event.requestId;
   }
 }

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -944,7 +944,7 @@ export class WKPage implements PageDelegate {
   }
 
   _onRequestWillBeSentProvisional(session: WKSession, event: Protocol.Network.requestWillBeSentPayload) {
-    if (!this._currentMainFrameNavigation?.checkIfSameNavigationInNewProcess(event)) {
+    if (!this._currentMainFrameNavigation?.isSameNavigationInNewProcess(event)) {
       this._onRequestWillBeSent(session, event);
       return;
     }
@@ -1204,7 +1204,6 @@ class WKNavigation {
   readonly _originalRequestId: Protocol.Network.RequestId;
   private readonly _frameId: string;
   private _responseReceived: boolean = false;
-  private _newProcessRequestId: Protocol.Network.RequestId;
 
   constructor(page: WKPage, event: Protocol.Network.requestWillBeSentPayload) {
     this._page = page;
@@ -1231,12 +1230,8 @@ class WKNavigation {
     return this._page.hasProvisionalPage();
   }
 
-  checkIfSameNavigationInNewProcess(event: Protocol.Network.requestWillBeSentPayload) {
-    if (event.loaderId === this._loaderId) {
-      this._newProcessRequestId = event.requestId;
-      return true;
-    }
-    return false;
+  isSameNavigationInNewProcess(event: Protocol.Network.requestWillBeSentPayload) {
+    return event.loaderId === this._loaderId;
   }
 
   checkIfDuplicateResponseEvent(event: Protocol.Network.responseReceivedPayload) {

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -1010,7 +1010,7 @@ export class WKPage implements PageDelegate {
       session.sendMayFail('Network.interceptRequestWithError', { errorType: 'Cancellation', requestId: event.requestId });
       return;
     }
-    if (!request._route || this._currentMainFrameNavigation.shoudIgnoreRequestInterception(event)) {
+    if (!request._route || this._currentMainFrameNavigation?.shoudIgnoreRequestInterception(event)) {
       // Intercepted, although we do not intend to allow interception.
       // Just continue.
       session.sendMayFail('Network.interceptWithRequest', { requestId: request._requestId });

--- a/src/server/webkit/wkProvisionalPage.ts
+++ b/src/server/webkit/wkProvisionalPage.ts
@@ -42,12 +42,12 @@ export class WKProvisionalPage {
     const wkPage = this._wkPage;
 
     this._sessionListeners = [
-      eventsHelper.addEventListener(session, 'Network.requestWillBeSent', overrideFrameId(e => wkPage._onRequestWillBeSent(session, e))),
+      eventsHelper.addEventListener(session, 'Network.requestWillBeSent', overrideFrameId(e => wkPage._onRequestWillBeSentProvisional(session, e))),
       eventsHelper.addEventListener(session, 'Network.requestIntercepted', overrideFrameId(e => wkPage._onRequestIntercepted(session, e))),
       eventsHelper.addEventListener(session, 'Network.responseIntercepted', overrideFrameId(e => wkPage._onResponseIntercepted(session, e))),
       eventsHelper.addEventListener(session, 'Network.responseReceived', overrideFrameId(e => wkPage._onResponseReceived(e))),
       eventsHelper.addEventListener(session, 'Network.loadingFinished', overrideFrameId(e => wkPage._onLoadingFinished(e))),
-      eventsHelper.addEventListener(session, 'Network.loadingFailed', overrideFrameId(e => wkPage._onLoadingFailed(e))),
+      eventsHelper.addEventListener(session, 'Network.loadingFailed', overrideFrameId(e => wkPage._onLoadingFailedShared(e))),
     ];
 
     this.initializationPromise = this._wkPage._initializeSession(session, true, ({ frameTree }) => this._handleFrameTree(frameTree));

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -39,6 +39,12 @@ it.describe('download event', () => {
       res.write('foo');
       res.uncork();
     });
+    server.setRoute('/downloadWithCOOP', (req, res) => {
+      res.setHeader('Content-Type', 'application/octet-stream');
+      res.setHeader('Content-Disposition', 'attachment');
+      res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+      res.end(`Hello world`);
+    });
   });
 
   it('should report download when navigation turns into download', async ({ browser, server, browserName }) => {
@@ -49,6 +55,32 @@ it.describe('download event', () => {
     ]);
     expect(download.page()).toBe(page);
     expect(download.url()).toBe(`${server.PREFIX}/download`);
+    const path = await download.path();
+    expect(fs.existsSync(path)).toBeTruthy();
+    expect(fs.readFileSync(path).toString()).toBe('Hello world');
+    if (browserName === 'chromium') {
+      expect(responseOrError instanceof Error).toBeTruthy();
+      expect(responseOrError.message).toContain('net::ERR_ABORTED');
+      expect(page.url()).toBe('about:blank');
+    } else if (browserName === 'webkit') {
+      expect(responseOrError instanceof Error).toBeTruthy();
+      expect(responseOrError.message).toContain('Download is starting');
+      expect(page.url()).toBe('about:blank');
+    } else {
+      expect(responseOrError.status()).toBe(200);
+      expect(page.url()).toBe(server.PREFIX + '/download');
+    }
+    await page.close();
+  });
+
+  it('should work with Cross-Origin-Opener-Policy', async ({ browser, server, browserName }) => {
+    const page = await browser.newPage({ acceptDownloads: true });
+    const [ download, responseOrError ] = await Promise.all([
+      page.waitForEvent('download'),
+      page.goto(server.PREFIX + '/downloadWithCOOP').catch(e => e)
+    ]);
+    expect(download.page()).toBe(page);
+    expect(download.url()).toBe(`${server.PREFIX}/downloadWithCOOP`);
     const path = await download.path();
     expect(fs.existsSync(path)).toBeTruthy();
     expect(fs.readFileSync(path).toString()).toBe('Hello world');

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -58,6 +58,21 @@ it('should work cross-process', async ({ page, server }) => {
   expect(response.url()).toBe(url);
 });
 
+it('should work with cross-process that fails before committing', async ({ page, server, browserName }) => {
+  server.setRoute('/empty.html', (req, res) => {
+    req.socket.destroy();
+  });
+  const response1 = await page.goto(server.CROSS_PROCESS_PREFIX + '/title.html');
+  await response1.finished();
+  const error = await page.goto(server.EMPTY_PAGE).catch(e => e);
+  if (browserName === 'chromium')
+    expect(error.message).toContain('net::ERR_EMPTY_RESPONSE');
+  if (browserName === 'webkit')
+    expect(error.message).toContain('Message Corrupt');
+  if (browserName === 'firefox')
+    expect(error.message).toContain('NS_ERROR_NET_RESET');
+});
+
 it('should work with Cross-Origin-Opener-Policy', async ({ page, server }) => {
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -113,8 +113,6 @@ it('should work with Cross-Origin-Opener-Policy after redirect', async ({ page, 
     events.push('response');
     requests.add(r.request());
   });
-  console.log('\n\n\n\n');
-  // const response = await page.goto(server.EMPTY_PAGE);
   const response = await page.goto(server.PREFIX + '/redirect');
   expect(page.url()).toBe(server.EMPTY_PAGE);
   await response.finished();

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -168,7 +168,7 @@ it.describe('', () => {
   });
 });
 
-it('should work with Cross-Origin-Opener-Policy', async ({ page, server }) => {
+it('should work with Cross-Origin-Opener-Policy', async ({ page, server, browserName }) => {
   let serverHeaders;
   const serverRequests = [];
   server.setRoute('/empty.html', (req, res) => {
@@ -208,7 +208,10 @@ it('should work with Cross-Origin-Opener-Policy', async ({ page, server }) => {
   const response = await page.goto(server.EMPTY_PAGE);
   expect(intercepted).toEqual([server.EMPTY_PAGE]);
   // There should be only one request to the server.
-  expect(serverRequests).toEqual(['/empty.html']);
+  if (browserName === 'webkit')
+    expect(serverRequests).toEqual(['/empty.html', '/empty.html']);
+  else
+    expect(serverRequests).toEqual(['/empty.html']);
   expect(serverHeaders['foo']).toBe('bar');
   expect(page.url()).toBe(server.EMPTY_PAGE);
   await response.finished();


### PR DESCRIPTION
WebKit recently [enabled](https://trac.webkit.org/changeset/282007/webkit) support for  Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy and decision about whether navigation should happen in a new process now made twice:
* navigation policy decision
* response policy decision

In the latter case the requestWillBeSent and responseReceivedEvents are fired in the original process and then (if process should be swapped) fired again in the new process (with new request id but same loaderId). Moreover, after the response policy decision the old process will send Page.frameStoppedLoading and Network.loadingFailed(canceled) events. We now ignore those events if there is ongoing navigation in a provisional page.

Fixes #9065