### PR TITLE
feat(test runner): improve fixture typings for function fixtures

### DIFF
--- a/tests/playwright-test/types.spec.ts
+++ b/tests/playwright-test/types.spec.ts
@@ -82,6 +82,18 @@ test('should check types of fixtures', async ({runTSC}) => {
         // @ts-expect-error
         }, { scope: 'test' } ],
       });
+
+      type AssertNotAny<S> = {notRealProperty: number} extends S ? false : true;
+      type AssertType<T, S> = S extends T ? AssertNotAny<S> : false;
+      const funcTest = pwt.test.extend<{ foo: (x: number, y: string) => Promise<string> }>({
+        foo: async ({}, use) => {
+          await use(async (x, y) => {
+            const assertionX: AssertType<number, typeof x> = true;
+            const assertionY: AssertType<string, typeof y> = true;
+            return y;
+          });
+        },
+      })
     `,
     'playwright.config.ts': `
       import { MyOptions } from './helper';

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -2282,8 +2282,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
 type KeyValue = { [key: string]: any };
 export type TestFixture<R, Args extends KeyValue> = (args: Args, use: (r: R) => Promise<void>, testInfo: TestInfo) => any;
 export type WorkerFixture<R, Args extends KeyValue> = (args: Args, use: (r: R) => Promise<void>, workerInfo: WorkerInfo) => any;
-type TestFixtureValue<R, Args> = R | TestFixture<R, Args>;
-type WorkerFixtureValue<R, Args> = R | WorkerFixture<R, Args>;
+type TestFixtureValue<R, Args> = Exclude<R, Function> | TestFixture<R, Args>;
+type WorkerFixtureValue<R, Args> = Exclude<R, Function> | WorkerFixture<R, Args>;
 export type Fixtures<T extends KeyValue = {}, W extends KeyValue = {}, PT extends KeyValue = {}, PW extends KeyValue = {}> = {
   [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker' }];
 } & {

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -265,8 +265,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
 type KeyValue = { [key: string]: any };
 export type TestFixture<R, Args extends KeyValue> = (args: Args, use: (r: R) => Promise<void>, testInfo: TestInfo) => any;
 export type WorkerFixture<R, Args extends KeyValue> = (args: Args, use: (r: R) => Promise<void>, workerInfo: WorkerInfo) => any;
-type TestFixtureValue<R, Args> = R | TestFixture<R, Args>;
-type WorkerFixtureValue<R, Args> = R | WorkerFixture<R, Args>;
+type TestFixtureValue<R, Args> = Exclude<R, Function> | TestFixture<R, Args>;
+type WorkerFixtureValue<R, Args> = Exclude<R, Function> | WorkerFixture<R, Args>;
 export type Fixtures<T extends KeyValue = {}, W extends KeyValue = {}, PT extends KeyValue = {}, PW extends KeyValue = {}> = {
   [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker' }];
 } & {


### PR DESCRIPTION
When fixture value `R` is a function, TypeScript sometimes confuses function `R` and function `async ({}, use) => {}`. This leads to `any` types in the latter because it could be either of the functions as TS thinks.

The solution is to only accept the second syntax, assuming that noone passes fixture value that is a function as is:

```js
// This will stop working.
test.extend<{ foo: (x: number) => number }>({
  foo: x => 2 * x,
});

// This will get inferred types and autocomplete.
test.extend<{ foo: (x: number) => number }>({
  foo: async ({}, use) => {
    await use(x => 2 * x);
  },
});
```

Fixes #9116.