### PR TITLE
fix: increase recent logs buffer

### DIFF
--- a/src/utils/debugLogger.ts
+++ b/src/utils/debugLogger.ts
@@ -64,7 +64,7 @@ class DebugLogger {
 
 export const debugLogger = new DebugLogger();
 
-const kLogCount = 50;
+const kLogCount = 500;
 export class RecentLogsCollector {
   private _logs: string[] = [];
 

--- a/src/utils/debugLogger.ts
+++ b/src/utils/debugLogger.ts
@@ -64,7 +64,7 @@ class DebugLogger {
 
 export const debugLogger = new DebugLogger();
 
-const kLogCount = 500;
+const kLogCount = 150;
 export class RecentLogsCollector {
   private _logs: string[] = [];
 


### PR DESCRIPTION
Sometimes top part of the stack is trimmed in the log, like [here](https://github.com/microsoft/playwright/pull/9119/checks?check_run_id=3694112473)