### PR TITLE
feat(expect): toContainText(array)

### DIFF
--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -118,17 +118,25 @@ const locator = page.locator('.my-element');
 await expect(locator).toBeVisible();
 ```
 
-## expect(locator).toContainText(text, options?)
-- `text`: <[string]> Text to look for inside the element
+## expect(locator).toContainText(expected, options?)
+- `expected`: <[string] | [RegExp] | [Array]<[string]|[RegExp]>>
 - `options`
-  - `timeout`: <[number]> Time to wait for, defaults to `timeout` in [`property: TestProject.expect`].
+  - `timeout`: <[number]> Time to retry assertion for, defaults to `timeout` in [`property: TestProject.expect`].
   - `useInnerText`: <[boolean]> Whether to use `element.innerText` instead of `element.textContent` when retrieving DOM node text.
 
-Ensures [Locator] points to a selected option.
+Ensures [Locator] points to an element that contains the given text. You can use regular expressions for the value as well.
 
 ```js
 const locator = page.locator('.title');
 await expect(locator).toContainText('substring');
+await expect(locator).toContainText(/\d messages/);
+```
+
+Note that if array is passed as an expected value, entire lists can be asserted:
+
+```js
+const locator = page.locator('list > .list-item');
+await expect(locator).toContainText(['Text 1', 'Text 4', 'Text 5']);
 ```
 
 ## expect(locator).toHaveAttribute(name, value)
@@ -171,7 +179,7 @@ await expect(locator).toHaveClass(['component', 'component selected', 'component
 Ensures [Locator] resolves to an exact number of DOM nodes.
 
 ```js
-const list = page.locator('list > #component');
+const list = page.locator('list > .component');
 await expect(list).toHaveCount(3);
 ```
 
@@ -181,7 +189,7 @@ await expect(list).toHaveCount(3);
 - `options`
   - `timeout`: <[number]> Time to retry assertion for, defaults to `timeout` in [`property: TestProject.expect`].
 
-Ensures [Locator] resolves to an element with the given computed CSS style
+Ensures [Locator] resolves to an element with the given computed CSS style.
 
 ```js
 const locator = page.locator('button');
@@ -224,13 +232,14 @@ Ensures [Locator] points to an element with the given text. You can use regular 
 
 ```js
 const locator = page.locator('.title');
+await expect(locator).toHaveText(/Welcome, Test User/);
 await expect(locator).toHaveText(/Welcome, .*/);
 ```
 
 Note that if array is passed as an expected value, entire lists can be asserted:
 
 ```js
-const locator = page.locator('list > #component');
+const locator = page.locator('list > .component');
 await expect(locator).toHaveText(['Text 1', 'Text 2', 'Text 3']);
 ```
 

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -1256,6 +1256,7 @@ export class Frame extends SdkObject {
           return poller((progress, continuePolling) => {
             if (querySelectorAll) {
               const elements = injected.querySelectorAll(info.parsed, document);
+              progress.logRepeating(`  selector resolved to ${elements.length} element${elements.length === 1 ? '' : 's'}`);
               return callback(progress, elements[0], taskData as T, elements, continuePolling);
             }
 

--- a/src/test/matchers/matchers.ts
+++ b/src/test/matchers/matchers.ts
@@ -109,13 +109,20 @@ export function toBeVisible(
 export function toContainText(
   this: ReturnType<Expect['getState']>,
   locator: LocatorEx,
-  expected: string,
+  expected: string | RegExp | (string | RegExp)[],
   options?: { timeout?: number, useInnerText?: boolean },
 ) {
-  return toMatchText.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout) => {
-    const expectedText = toExpectedTextValues([expected], { matchSubstring: true, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options?.useInnerText, timeout });
-  }, expected, options);
+  if (Array.isArray(expected)) {
+    return toEqual.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout) => {
+      const expectedText = toExpectedTextValues(expected, { matchSubstring: true, normalizeWhiteSpace: true });
+      return await locator._expect('to.contain.text.array', { expectedText, isNot, useInnerText: options?.useInnerText, timeout });
+    }, expected, { ...options, contains: true });
+  } else {
+    return toMatchText.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout) => {
+      const expectedText = toExpectedTextValues([expected], { matchSubstring: true, normalizeWhiteSpace: true });
+      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options?.useInnerText, timeout });
+    }, expected, options);
+  }
 }
 
 export function toHaveAttribute(

--- a/src/test/matchers/toEqual.ts
+++ b/src/test/matchers/toEqual.ts
@@ -33,7 +33,7 @@ export async function toEqual<T>(
   receiverType: string,
   query: (isNot: boolean, timeout: number) => Promise<{ pass: boolean, received?: any, log?: string[] }>,
   expected: T,
-  options: { timeout?: number } = {},
+  options: { timeout?: number, contains?: boolean } = {},
 ) {
   const testInfo = currentTestInfo();
   if (!testInfo)
@@ -41,7 +41,7 @@ export async function toEqual<T>(
   expectType(receiver, receiverType, matcherName);
 
   const matcherOptions = {
-    comment: 'deep equality',
+    comment: options.contains ? '' : 'deep equality',
     isNot: this.isNot,
     promise: this.promise,
   };

--- a/tests/trace-viewer/trace-viewer.spec.ts
+++ b/tests/trace-viewer/trace-viewer.spec.ts
@@ -232,18 +232,16 @@ test('should have correct stack trace', async ({ showTraceViewer }) => {
 
   await traceViewer.selectAction('page.click');
   await traceViewer.showSourceTab();
-  const stack1 = (await traceViewer.stackFrames.allInnerTexts()).map(s => s.replace(/\s+/g, ' ').replace(/:[0-9]+/g, ':XXX'));
-  expect(stack1.slice(0, 2)).toEqual([
-    'doClick trace-viewer.spec.ts :XXX',
-    'recordTrace trace-viewer.spec.ts :XXX',
-  ]);
+  await expect(traceViewer.stackFrames).toContainText([
+    /doClick\s+trace-viewer.spec.ts\s+:\d+/,
+    /recordTrace\s+trace-viewer.spec.ts\s+:\d+/,
+  ], { useInnerText: true });
 
   await traceViewer.selectAction('page.hover');
   await traceViewer.showSourceTab();
-  const stack2 = (await traceViewer.stackFrames.allInnerTexts()).map(s => s.replace(/\s+/g, ' ').replace(/:[0-9]+/g, ':XXX'));
-  expect(stack2.slice(0, 1)).toEqual([
-    'BrowserType.browserType._onWillCloseContext trace-viewer.spec.ts :XXX',
-  ]);
+  await expect(traceViewer.stackFrames).toContainText([
+    /BrowserType.browserType._onWillCloseContext\s+trace-viewer.spec.ts\s+:\d+/,
+  ], { useInnerText: true });
 });
 
 test('should have network requests', async ({ showTraceViewer }) => {

--- a/types/testExpect.d.ts
+++ b/types/testExpect.d.ts
@@ -111,7 +111,7 @@ declare global {
       /**
        * Asserts element's text content matches given pattern or contains given substring.
        */
-      toContainText(expected: string, options?: { timeout?: number, useInnerText?: boolean }): Promise<R>;
+      toContainText(expected: string | RegExp | (string|RegExp)[], options?: { timeout?: number, useInnerText?: boolean }): Promise<R>;
 
       /**
        * Asserts element's attributes `name` matches expected value.


### PR DESCRIPTION
This matches when each expected item from the array is matched to one of the resolved elements, in order.
Note this performs both "sub-array" and "substring" matching.

Drive-by: documentation fixes.
Drive-by: added `selector resolved to 3 elements` log line when expecting arrays.

References #8869.