### PR TITLE
chore: enable object-curly-spacing in ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
          * Enforced rules
          */
         // syntax preferences
+        "object-curly-spacing": ["error", "always"],
         "quotes": [2, "single", {
             "avoidEscape": true,
             "allowTemplateLiterals": true

--- a/packages/create-playwright/tests/integration.spec.ts
+++ b/packages/create-playwright/tests/integration.spec.ts
@@ -67,9 +67,9 @@ const test = base.extend<TestFixtures>({
   },
 });
 
-for (const packageManager of ['npm', 'yarn'] as ('npm'|'yarn')[]) {
+for (const packageManager of ['npm', 'yarn'] as ('npm' | 'yarn')[]) {
   test.describe(`Package manager: ${packageManager}`, () => {
-    test.use({packageManager});
+    test.use({ packageManager });
 
     test('should generate a project in the current directory', async ({ run }) => {
       const { exitCode, dir, stdout } = await run([], { installGitHubActions: true, testDir: 'e2e', language: 'TypeScript' });

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -167,7 +167,7 @@ const browsers = [
   { alias: 'wk', name: 'WebKit', type: 'webkit' },
 ];
 
-for (const {alias, name, type} of browsers) {
+for (const { alias, name, type } of browsers) {
   commandWithOpenOptions(`${alias} [url]`, `open page in ${name}`, [])
       .action(function(url, command) {
         open({ ...command, browser: type }, url, command.target).catch(logErrorAndExit);

--- a/src/client/android.ts
+++ b/src/client/android.ts
@@ -360,7 +360,7 @@ function toSelectorChannel(selector: api.AndroidSelector): channels.AndroidSelec
     focusable,
     focused,
     hasChild: hasChild ? { selector: toSelectorChannel(hasChild.selector) } : undefined,
-    hasDescendant: hasDescendant ? { selector: toSelectorChannel(hasDescendant.selector), maxDepth: hasDescendant.maxDepth} : undefined,
+    hasDescendant: hasDescendant ? { selector: toSelectorChannel(hasDescendant.selector), maxDepth: hasDescendant.maxDepth } : undefined,
     longClickable,
     scrollable,
     selected,

--- a/src/client/browserContext.ts
+++ b/src/client/browserContext.ts
@@ -71,16 +71,16 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel,
     this.tracing = new Tracing(this);
     this._request = FetchRequest.from(initializer.fetchRequest);
 
-    this._channel.on('bindingCall', ({binding}) => this._onBinding(BindingCall.from(binding)));
+    this._channel.on('bindingCall', ({ binding }) => this._onBinding(BindingCall.from(binding)));
     this._channel.on('close', () => this._onClose());
-    this._channel.on('page', ({page}) => this._onPage(Page.from(page)));
+    this._channel.on('page', ({ page }) => this._onPage(Page.from(page)));
     this._channel.on('route', ({ route, request }) => this._onRoute(network.Route.from(route), network.Request.from(request)));
     this._channel.on('backgroundPage', ({ page }) => {
       const backgroundPage = Page.from(page);
       this._backgroundPages.add(backgroundPage);
       this.emit(Events.BrowserContext.BackgroundPage, backgroundPage);
     });
-    this._channel.on('serviceWorker', ({worker}) => {
+    this._channel.on('serviceWorker', ({ worker }) => {
       const serviceWorker = Worker.from(worker);
       serviceWorker._context = this;
       this._serviceWorkers.add(serviceWorker);

--- a/src/client/browserType.ts
+++ b/src/client/browserType.ts
@@ -210,7 +210,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, chann
       throw new Error('Connecting over CDP is only supported in Chromium.');
     const logger = params.logger;
     return this._wrapApiCall(async (channel: channels.BrowserTypeChannel) => {
-      const paramsHeaders = Object.assign({'User-Agent': getUserAgent()}, params.headers);
+      const paramsHeaders = Object.assign({ 'User-Agent': getUserAgent() }, params.headers);
       const headers = paramsHeaders ? headersObjectToArray(paramsHeaders) : undefined;
       const result = await channel.connectOverCDP({
         endpointURL,

--- a/src/client/input.ts
+++ b/src/client/input.ts
@@ -108,7 +108,7 @@ export class Touchscreen implements api.Touchscreen {
 
   async tap(x: number, y: number) {
     await this._page._wrapApiCall(async channel => {
-      await channel.touchscreenTap({x, y});
+      await channel.touchscreenTap({ x, y });
     });
   }
 }

--- a/src/client/jsHandle.ts
+++ b/src/client/jsHandle.ts
@@ -30,7 +30,7 @@ export class JSHandle<T = any> extends ChannelOwner<channels.JSHandleChannel, ch
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.JSHandleInitializer) {
     super(parent, type, guid, initializer);
     this._preview = this._initializer.preview;
-    this._channel.on('previewUpdated', ({preview}) => this._preview = preview);
+    this._channel.on('previewUpdated', ({ preview }) => this._preview = preview);
   }
 
   async evaluate<R, Arg>(pageFunction: structs.PageFunctionOn<T, Arg, R>, arg?: Arg): Promise<R> {

--- a/src/client/page.ts
+++ b/src/client/page.ts
@@ -491,7 +491,7 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
     });
   }
 
-  async close(options: { runBeforeUnload?: boolean } = {runBeforeUnload: undefined}) {
+  async close(options: { runBeforeUnload?: boolean } = { runBeforeUnload: undefined }) {
     try {
       await this._wrapApiCall(async (channel: channels.PageChannel) => {
         if (this._ownedContext)

--- a/src/dispatchers/browserContextDispatcher.ts
+++ b/src/dispatchers/browserContextDispatcher.ts
@@ -65,7 +65,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
         this._dispatchEvent('backgroundPage', { page: new PageDispatcher(this._scope, page) });
       context.on(CRBrowserContext.CREvents.BackgroundPage, page => this._dispatchEvent('backgroundPage', { page: new PageDispatcher(this._scope, page) }));
       for (const serviceWorker of (context as CRBrowserContext).serviceWorkers())
-        this._dispatchEvent('serviceWorker', { worker: new WorkerDispatcher(this._scope, serviceWorker)});
+        this._dispatchEvent('serviceWorker', { worker: new WorkerDispatcher(this._scope, serviceWorker) });
       context.on(CRBrowserContext.CREvents.ServiceWorker, serviceWorker => this._dispatchEvent('serviceWorker', { worker: new WorkerDispatcher(this._scope, serviceWorker) }));
     }
     context.on(BrowserContext.Events.Request, (request: Request) =>  {
@@ -84,7 +84,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
       responseEndTiming: request._responseEndTiming,
       page: PageDispatcher.fromNullable(this._scope, request.frame()._page.initializedOrUndefined())
     }));
-    context.on(BrowserContext.Events.RequestFinished, ({ request, response}: { request: Request, response: Response | null }) => this._dispatchEvent('requestFinished', {
+    context.on(BrowserContext.Events.RequestFinished, ({ request, response }: { request: Request, response: Response | null }) => this._dispatchEvent('requestFinished', {
       request: RequestDispatcher.from(scope, request),
       response: ResponseDispatcher.fromNullable(scope, response),
       responseEndTiming: request._responseEndTiming,

--- a/src/dispatchers/browserTypeDispatcher.ts
+++ b/src/dispatchers/browserTypeDispatcher.ts
@@ -56,7 +56,7 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.Brow
     const waitForNextTask = params.slowMo
       ? (cb: () => any) => setTimeout(cb, params.slowMo)
       : makeWaitForNextTask();
-    const paramsHeaders = Object.assign({'User-Agent': getUserAgent()}, params.headers || {});
+    const paramsHeaders = Object.assign({ 'User-Agent': getUserAgent() }, params.headers || {});
     const ws = new WebSocket(params.wsEndpoint, [], {
       perMessageDeflate: false,
       maxPayload: 256 * 1024 * 1024, // 256Mb,

--- a/src/server/accessibility.ts
+++ b/src/server/accessibility.ts
@@ -40,7 +40,7 @@ export class Accessibility {
       interestingOnly = true,
       root = null,
     } = options;
-    const {tree, needle} = await this._getAXTree(root || undefined);
+    const { tree, needle } = await this._getAXTree(root || undefined);
     if (!interestingOnly) {
       if (root)
         return needle && serializeTree(needle)[0];

--- a/src/server/browserContext.ts
+++ b/src/server/browserContext.ts
@@ -76,7 +76,7 @@ export abstract class BrowserContext extends SdkObject {
     this._closePromise = new Promise(fulfill => this._closePromiseFulfill = fulfill);
 
     if (this._options.recordHar)
-      this._harRecorder = new HarRecorder(this, {...this._options.recordHar, path: path.join(this._browser.options.artifactsDir, `${createGuid()}.har`)});
+      this._harRecorder = new HarRecorder(this, { ...this._options.recordHar, path: path.join(this._browser.options.artifactsDir, `${createGuid()}.har`) });
 
     this.tracing = new Tracing(this);
     this.fetchRequest = new BrowserContextFetchRequest(this);

--- a/src/server/chromium/chromium.ts
+++ b/src/server/chromium/chromium.ts
@@ -54,7 +54,7 @@ export class Chromium extends BrowserType {
     controller.setLogName('browser');
     return controller.run(async progress => {
       return await this._connectOverCDPInternal(progress, endpointURL, options);
-    }, TimeoutSettings.timeout({timeout}));
+    }, TimeoutSettings.timeout({ timeout }));
   }
 
   async _connectOverCDPInternal(progress: Progress, endpointURL: string, options: { slowMo?: number, headers?: types.HeadersArray }, onClose?: () => Promise<void>) {

--- a/src/server/chromium/crAccessibility.ts
+++ b/src/server/chromium/crAccessibility.ts
@@ -22,7 +22,7 @@ import * as accessibility from '../accessibility';
 import * as types from '../types';
 
 export async function getAccessibilityTree(client: CRSession, needle?: dom.ElementHandle): Promise<{tree: accessibility.AXNode, needle: accessibility.AXNode | null}> {
-  const {nodes} = await client.send('Accessibility.getFullAXTree');
+  const { nodes } = await client.send('Accessibility.getFullAXTree');
   const tree = CRAXNode.createTree(client, nodes);
   return {
     tree,
@@ -97,7 +97,7 @@ class CRAXNode implements accessibility.AXNode {
 
   async _findElement(element: dom.ElementHandle): Promise<CRAXNode | null> {
     const objectId = element._objectId;
-    const {node: {backendNodeId}} = await this._client.send('DOM.describeNode', { objectId });
+    const { node: { backendNodeId } } = await this._client.send('DOM.describeNode', { objectId });
     const needle = this.find(node => node._payload.backendDOMNodeId === backendNodeId);
     return needle || null;
   }

--- a/src/server/chromium/crBrowser.ts
+++ b/src/server/chromium/crBrowser.ts
@@ -121,7 +121,7 @@ export class CRBrowser extends Browser {
     await Promise.all([...this._crPages.values()].map(page => page.pageOrError()));
   }
 
-  _onAttachedToTarget({targetInfo, sessionId, waitingForDebugger}: Protocol.Target.attachedToTargetPayload) {
+  _onAttachedToTarget({ targetInfo, sessionId, waitingForDebugger }: Protocol.Target.attachedToTargetPayload) {
     if (targetInfo.type === 'browser')
       return;
     const session = this._connection.session(sessionId)!;

--- a/src/server/chromium/crConnection.ts
+++ b/src/server/chromium/crConnection.ts
@@ -172,7 +172,7 @@ export class CRSession extends EventEmitter {
       throw new ProtocolError(true, `Target closed`);
     const id = this._connection._rawSend(this._sessionId, method, params);
     return new Promise((resolve, reject) => {
-      this._callbacks.set(id, {resolve, reject, error: new ProtocolError(false), method});
+      this._callbacks.set(id, { resolve, reject, error: new ProtocolError(false), method });
     });
   }
 

--- a/src/server/chromium/crCoverage.ts
+++ b/src/server/chromium/crCoverage.ts
@@ -85,7 +85,7 @@ class JSCoverage {
       this._client.send('Profiler.enable'),
       this._client.send('Profiler.startPreciseCoverage', { callCount: true, detailed: true }),
       this._client.send('Debugger.enable'),
-      this._client.send('Debugger.setSkipAllPauses', {skip: true})
+      this._client.send('Debugger.setSkipAllPauses', { skip: true })
     ]);
   }
 
@@ -106,7 +106,7 @@ class JSCoverage {
     if (!event.url && !this._reportAnonymousScripts)
       return;
     // This might fail if the page has already navigated away.
-    const response = await this._client._sendMayFail('Debugger.getScriptSource', {scriptId: event.scriptId});
+    const response = await this._client._sendMayFail('Debugger.getScriptSource', { scriptId: event.scriptId });
     if (response)
       this._scriptSources.set(event.scriptId, response.scriptSource);
   }
@@ -130,7 +130,7 @@ class JSCoverage {
         continue;
       const source = this._scriptSources.get(entry.scriptId);
       if (source)
-        coverage.push({...entry, source});
+        coverage.push({ ...entry, source });
       else
         coverage.push(entry);
     }
@@ -157,7 +157,7 @@ class CSSCoverage {
 
   async start(options: types.CSSCoverageOptions = {}) {
     assert(!this._enabled, 'CSSCoverage is already enabled');
-    const {resetOnNavigation = true} = options;
+    const { resetOnNavigation = true } = options;
     this._resetOnNavigation = resetOnNavigation;
     this._enabled = true;
     this._stylesheetURLs.clear();
@@ -186,7 +186,7 @@ class CSSCoverage {
     if (!header.sourceURL)
       return;
     // This might fail if the page has already navigated away.
-    const response = await this._client._sendMayFail('CSS.getStyleSheetText', {styleSheetId: header.styleSheetId});
+    const response = await this._client._sendMayFail('CSS.getStyleSheetText', { styleSheetId: header.styleSheetId });
     if (response) {
       this._stylesheetURLs.set(header.styleSheetId, header.sourceURL);
       this._stylesheetSources.set(header.styleSheetId, response.text);
@@ -266,7 +266,7 @@ function convertToDisjointRanges(nestedRanges: {
       if (lastResult && lastResult.end === lastOffset)
         lastResult.end = point.offset;
       else
-        results.push({start: lastOffset, end: point.offset});
+        results.push({ start: lastOffset, end: point.offset });
     }
     lastOffset = point.offset;
     if (point.type === 0)

--- a/src/server/chromium/crDragDrop.ts
+++ b/src/server/chromium/crDragDrop.ts
@@ -28,7 +28,7 @@ declare global {
 export class DragManager {
   private _crPage: CRPage;
   private _dragState: Protocol.Input.DragData | null = null;
-  private _lastPosition = {x: 0, y: 0};
+  private _lastPosition = { x: 0, y: 0 };
   constructor(page: CRPage) {
     this._crPage = page;
   }
@@ -50,7 +50,7 @@ export class DragManager {
   }
 
   async interceptDragCausedByMove(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, moveCallback: () => Promise<void>): Promise<void> {
-    this._lastPosition = {x, y};
+    this._lastPosition = { x, y };
     if (this._dragState) {
       await this._crPage._mainFrameSession._client.send('Input.dispatchDragEvent', {
         type: 'dragOver',
@@ -75,15 +75,15 @@ export class DragManager {
         const dragListener = (event: Event) => dragEvent = event;
         const mouseListener = () => {
           didStartDrag = new Promise<boolean>(callback => {
-            window.addEventListener('dragstart', dragListener, {once: true, capture: true});
+            window.addEventListener('dragstart', dragListener, { once: true, capture: true });
             setTimeout(() => callback(dragEvent ? !dragEvent.defaultPrevented : false), 0);
           });
         };
-        window.addEventListener('mousemove', mouseListener, {once: true, capture: true});
+        window.addEventListener('mousemove', mouseListener, { once: true, capture: true });
         window.__cleanupDrag = async () => {
           const val = await didStartDrag;
-          window.removeEventListener('mousemove', mouseListener, {capture: true});
-          window.removeEventListener('dragstart', dragListener, {capture: true});
+          window.removeEventListener('mousemove', mouseListener, { capture: true });
+          window.removeEventListener('dragstart', dragListener, { capture: true });
           return val;
         };
       }).toString(), true, 'utility').catch(() => {});
@@ -91,7 +91,7 @@ export class DragManager {
 
     client.on('Input.dragIntercepted', onDragIntercepted!);
     try {
-      await client.send('Input.setInterceptDrags', {enabled: true});
+      await client.send('Input.setInterceptDrags', { enabled: true });
     } catch {
       // If Input.setInterceptDrags is not supported, just do a regular move.
       // This can be removed once we stop supporting old Electron.
@@ -105,7 +105,7 @@ export class DragManager {
     }))).some(x => x);
     this._dragState = expectingDrag ? (await dragInterceptedPromise).data : null;
     client.off('Input.dragIntercepted', onDragIntercepted!);
-    await client.send('Input.setInterceptDrags', {enabled: false});
+    await client.send('Input.setInterceptDrags', { enabled: false });
 
 
     if (this._dragState) {

--- a/src/server/chromium/crExecutionContext.ts
+++ b/src/server/chromium/crExecutionContext.ts
@@ -106,9 +106,9 @@ export class CRExecutionContext implements js.ExecutionContextDelegate {
 
 function rewriteError(error: Error): Protocol.Runtime.evaluateReturnValue {
   if (error.message.includes('Object reference chain is too long'))
-    return {result: {type: 'undefined'}};
+    return { result: { type: 'undefined' } };
   if (error.message.includes('Object couldn\'t be returned by value'))
-    return {result: {type: 'undefined'}};
+    return { result: { type: 'undefined' } };
 
   if (error instanceof TypeError && error.message.startsWith('Converting circular structure to JSON'))
     rewriteErrorMessage(error, error.message + ' Are you passing a nested JSHandle?');

--- a/src/server/chromium/crNetworkManager.ts
+++ b/src/server/chromium/crNetworkManager.ts
@@ -105,7 +105,7 @@ export class CRNetworkManager {
         this._client.send('Network.setCacheDisabled', { cacheDisabled: true }),
         this._client.send('Fetch.enable', {
           handleAuthRequests: true,
-          patterns: [{urlPattern: '*', requestStage: 'Request'}, {urlPattern: '*', requestStage: 'Response'}],
+          patterns: [{ urlPattern: '*', requestStage: 'Request' }, { urlPattern: '*', requestStage: 'Response' }],
         }),
       ]);
     } else {
@@ -146,7 +146,7 @@ export class CRNetworkManager {
       response = 'ProvideCredentials';
       this._attemptedAuthentications.add(event.requestId);
     }
-    const {username, password} = this._credentials || {username: undefined, password: undefined};
+    const { username, password } = this._credentials || { username: undefined, password: undefined };
     this._client._sendMayFail('Fetch.continueWithAuth', {
       requestId: event.requestId,
       authChallengeResponse: { response, username, password },

--- a/src/server/chromium/crPage.ts
+++ b/src/server/chromium/crPage.ts
@@ -460,7 +460,7 @@ class FrameSession {
     this._addBrowserListeners();
     const promises: Promise<any>[] = [
       this._client.send('Page.enable'),
-      this._client.send('Page.getFrameTree').then(({frameTree}) => {
+      this._client.send('Page.getFrameTree').then(({ frameTree }) => {
         if (this._isMainFrame()) {
           this._handleFrameTree(frameTree);
           this._addRendererListeners();
@@ -815,7 +815,7 @@ class FrameSession {
   }
 
   _onLogEntryAdded(event: Protocol.Log.entryAddedPayload) {
-    const {level, text, args, source, url, lineNumber} = event.entry;
+    const { level, text, args, source, url, lineNumber } = event.entry;
     if (args)
       args.map(arg => releaseObject(this._client, arg.objectId!));
     if (source !== 'worker') {
@@ -853,7 +853,7 @@ class FrameSession {
   }
 
   _onScreencastFrame(payload: Protocol.Page.screencastFramePayload) {
-    this._client.send('Page.screencastFrameAck', {sessionId: payload.sessionId}).catch(() => {});
+    this._client.send('Page.screencastFrameAck', { sessionId: payload.sessionId }).catch(() => {});
     const buffer = Buffer.from(payload.data, 'base64');
     this._page.emit(Page.Events.ScreencastFrame, {
       buffer,

--- a/src/server/chromium/crPdf.ts
+++ b/src/server/chromium/crPdf.ts
@@ -21,17 +21,17 @@ import { CRSession } from './crConnection';
 import { readProtocolStream } from './crProtocolHelper';
 
 const PagePaperFormats: { [key: string]: { width: number, height: number }} = {
-  letter: {width: 8.5, height: 11},
-  legal: {width: 8.5, height: 14},
-  tabloid: {width: 11, height: 17},
-  ledger: {width: 17, height: 11},
-  a0: {width: 33.1, height: 46.8 },
-  a1: {width: 23.4, height: 33.1 },
-  a2: {width: 16.54, height: 23.4 },
-  a3: {width: 11.7, height: 16.54 },
-  a4: {width: 8.27, height: 11.7 },
-  a5: {width: 5.83, height: 8.27 },
-  a6: {width: 4.13, height: 5.83 },
+  letter: { width: 8.5, height: 11 },
+  legal: { width: 8.5, height: 14 },
+  tabloid: { width: 11, height: 17 },
+  ledger: { width: 17, height: 11 },
+  a0: { width: 33.1, height: 46.8 },
+  a1: { width: 23.4, height: 33.1 },
+  a2: { width: 16.54, height: 23.4 },
+  a3: { width: 11.7, height: 16.54 },
+  a4: { width: 8.27, height: 11.7 },
+  a5: { width: 5.83, height: 8.27 },
+  a6: { width: 4.13, height: 5.83 },
 };
 
 const unitToPixels: { [key: string]: number } = {

--- a/src/server/chromium/crProtocolHelper.ts
+++ b/src/server/chromium/crProtocolHelper.ts
@@ -49,7 +49,7 @@ export async function readProtocolStream(client: CRSession, handle: string, path
   }
   const bufs = [];
   while (!eof) {
-    const response = await client.send('IO.read', {handle});
+    const response = await client.send('IO.read', { handle });
     eof = response.eof;
     const buf = Buffer.from(response.data, response.base64Encoded ? 'base64' : undefined);
     bufs.push(buf);
@@ -58,7 +58,7 @@ export async function readProtocolStream(client: CRSession, handle: string, path
   }
   if (fd)
     await fd.close();
-  await client.send('IO.close', {handle});
+  await client.send('IO.close', { handle });
   return Buffer.concat(bufs);
 }
 
@@ -82,7 +82,7 @@ export function exceptionToError(exceptionDetails: Protocol.Runtime.ExceptionDet
     messageWithName = lines.slice(0, firstStackTraceLine).join('\n');
     stack = messageWithStack;
   }
-  const {name, message} = splitErrorMessage(messageWithName);
+  const { name, message } = splitErrorMessage(messageWithName);
 
   const err = new Error(message);
   err.stack = stack;

--- a/src/server/common/componentUtils.ts
+++ b/src/server/common/componentUtils.ts
@@ -142,7 +142,7 @@ export function parseComponentSelector(selector: string): ParsedComponentSelecto
     // check property is truthy: [enabled]
     if (next() === ']') {
       eat1();
-      return {jsonPath, op: '<truthy>', value: null, caseSensetive: false};
+      return { jsonPath, op: '<truthy>', value: null, caseSensetive: false };
     }
 
     const operator = readOperator();
@@ -181,7 +181,7 @@ export function parseComponentSelector(selector: string): ParsedComponentSelecto
     eat1();
     if (operator !== '=' && typeof value !== 'string')
       throw new Error(`Error while parsing selector \`${selector}\` - cannot use ${operator} in attribute with non-string matching value - ${value}`);
-    return {jsonPath, op: operator, value, caseSensetive};
+    return { jsonPath, op: operator, value, caseSensetive };
   }
 
   const result: ParsedComponentSelector = {

--- a/src/server/dom.ts
+++ b/src/server/dom.ts
@@ -277,7 +277,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
     const [quads, metrics] = await Promise.all([
       this._page._delegate.getContentQuads(this),
-      this._page.mainFrame()._utilityContext().then(utility => utility.evaluate(() => ({width: innerWidth, height: innerHeight}))),
+      this._page.mainFrame()._utilityContext().then(utility => utility.evaluate(() => ({ width: innerWidth, height: innerHeight }))),
     ] as const);
     if (!quads || !quads.length)
       return 'error:notvisible';

--- a/src/server/electron/electron.ts
+++ b/src/server/electron/electron.ts
@@ -26,7 +26,7 @@ import { TimeoutSettings } from '../../utils/timeoutSettings';
 import { WebSocketTransport } from '../transport';
 import { launchProcess, envArrayToObject } from '../../utils/processLauncher';
 import { BrowserContext } from '../browserContext';
-import type {BrowserWindow} from 'electron';
+import type { BrowserWindow } from 'electron';
 import { Progress, ProgressController } from '../progress';
 import { helper } from '../helper';
 import { eventsHelper } from '../../utils/eventsHelper';

--- a/src/server/fetch.ts
+++ b/src/server/fetch.ts
@@ -91,7 +91,7 @@ export abstract class FetchRequest extends SdkObject {
       headers['accept-encoding'] = 'gzip,deflate,br';
 
       if (defaults.extraHTTPHeaders) {
-        for (const {name, value} of defaults.extraHTTPHeaders)
+        for (const { name, value } of defaults.extraHTTPHeaders)
           headers[name.toLowerCase()] = value;
       }
 
@@ -235,7 +235,7 @@ export abstract class FetchRequest extends SdkObject {
           const auth = response.headers['www-authenticate'];
           const credentials = this._defaultOptions().httpCredentials;
           if (auth?.trim().startsWith('Basic ') && credentials) {
-            const {username, password} = credentials;
+            const { username, password } = credentials;
             const encoded = Buffer.from(`${username || ''}:${password || ''}`).toString('base64');
             options.headers!['authorization'] = `Basic ${encoded}`;
             fulfill(this._sendRequest(url, options, postData));

--- a/src/server/firefox/ffBrowser.ts
+++ b/src/server/firefox/ffBrowser.ts
@@ -106,7 +106,7 @@ export class FFBrowser extends Browser {
   }
 
   _onAttachedToTarget(payload: Protocol.Browser.attachedToTargetPayload) {
-    const {targetId, browserContextId, openerId, type} = payload.targetInfo;
+    const { targetId, browserContextId, openerId, type } = payload.targetInfo;
     assert(type === 'page');
     const context = browserContextId ? this._contexts.get(browserContextId)! : this._defaultContext as FFBrowserContext;
     assert(context, `Unknown context id:${browserContextId}, _defaultContext: ${this._defaultContext}`);
@@ -290,7 +290,7 @@ export class FFBrowserContext extends BrowserContext {
         throw new Error('Unknown permission: ' + permission);
       return protocolPermission;
     });
-    await this._browser._connection.send('Browser.grantPermissions', { origin: origin, browserContextId: this._browserContextId, permissions: filtered});
+    await this._browser._connection.send('Browser.grantPermissions', { origin: origin, browserContextId: this._browserContextId, permissions: filtered });
   }
 
   async _doClearPermissions() {

--- a/src/server/firefox/ffConnection.ts
+++ b/src/server/firefox/ffConnection.ts
@@ -75,9 +75,9 @@ export class FFConnection extends EventEmitter {
   ): Promise<Protocol.CommandReturnValues[T]> {
     this._checkClosed(method);
     const id = this.nextMessageId();
-    this._rawSend({id, method, params});
+    this._rawSend({ id, method, params });
     return new Promise((resolve, reject) => {
-      this._callbacks.set(id, {resolve, reject, error: new ProtocolError(false), method});
+      this._callbacks.set(id, { resolve, reject, error: new ProtocolError(false), method });
     });
   }
 
@@ -141,7 +141,7 @@ export class FFConnection extends EventEmitter {
   }
 
   createSession(sessionId: string): FFSession {
-    const session = new FFSession(this, sessionId, message => this._rawSend({...message, sessionId}));
+    const session = new FFSession(this, sessionId, message => this._rawSend({ ...message, sessionId }));
     this._sessions.set(sessionId, session);
     return session;
   }
@@ -193,9 +193,9 @@ export class FFSession extends EventEmitter {
     if (this._disposed)
       throw new ProtocolError(true, 'Target closed');
     const id = this._connection.nextMessageId();
-    this._rawSend({method, params, id});
+    this._rawSend({ method, params, id });
     return new Promise((resolve, reject) => {
-      this._callbacks.set(id, {resolve, reject, error: new ProtocolError(false), method});
+      this._callbacks.set(id, { resolve, reject, error: new ProtocolError(false), method });
     });
   }
 

--- a/src/server/firefox/ffExecutionContext.ts
+++ b/src/server/firefox/ffExecutionContext.ts
@@ -111,7 +111,7 @@ function checkException(exceptionDetails?: Protocol.Runtime.ExceptionDetails) {
 
 function rewriteError(error: Error): (Protocol.Runtime.evaluateReturnValue | Protocol.Runtime.callFunctionReturnValue) {
   if (error.message.includes('cyclic object value') || error.message.includes('Object is not serializable'))
-    return {result: {type: 'undefined', value: undefined}};
+    return { result: { type: 'undefined', value: undefined } };
   if (error instanceof TypeError && error.message.startsWith('Converting circular structure to JSON'))
     rewriteErrorMessage(error, error.message + ' Are you passing a nested JSHandle?');
   if (!js.isJavaScriptErrorInEvaluate(error) && !isSessionClosedError(error))

--- a/src/server/firefox/ffNetworkManager.ts
+++ b/src/server/firefox/ffNetworkManager.ts
@@ -50,7 +50,7 @@ export class FFNetworkManager {
   }
 
   async setRequestInterception(enabled: boolean) {
-    await this._session.send('Network.setRequestInterception', {enabled});
+    await this._session.send('Network.setRequestInterception', { enabled });
   }
 
   _onRequestWillBeSent(event: Protocol.Network.requestWillBeSentPayload) {

--- a/src/server/firefox/ffPage.ts
+++ b/src/server/firefox/ffPage.ts
@@ -152,7 +152,7 @@ export class FFPage implements PageDelegate {
   }
 
   _onExecutionContextCreated(payload: Protocol.Runtime.executionContextCreatedPayload) {
-    const {executionContextId, auxData} = payload;
+    const { executionContextId, auxData } = payload;
     const frame = this._page._frameManager.frame(auxData.frameId!);
     if (!frame)
       return;
@@ -169,7 +169,7 @@ export class FFPage implements PageDelegate {
   }
 
   _onExecutionContextDestroyed(payload: Protocol.Runtime.executionContextDestroyedPayload) {
-    const {executionContextId} = payload;
+    const { executionContextId } = payload;
     const context = this._contextIdToContext.get(executionContextId);
     if (!context)
       return;
@@ -220,7 +220,7 @@ export class FFPage implements PageDelegate {
   }
 
   _onEventFired(payload: Protocol.Page.eventFiredPayload) {
-    const {frameId, name} = payload;
+    const { frameId, name } = payload;
     if (name === 'load')
       this._page._frameManager.frameLifecycleEvent(frameId, 'load');
     if (name === 'DOMContentLoaded')
@@ -236,7 +236,7 @@ export class FFPage implements PageDelegate {
   }
 
   _onConsole(payload: Protocol.Runtime.consolePayload) {
-    const {type, args, executionContextId, location} = payload;
+    const { type, args, executionContextId, location } = payload;
     const context = this._contextIdToContext.get(executionContextId)!;
     this._page._addConsoleMessage(type, args.map(arg => context.createHandle(arg)), location);
   }
@@ -260,7 +260,7 @@ export class FFPage implements PageDelegate {
   }
 
   async _onFileChooserOpened(payload: Protocol.Page.fileChooserOpenedPayload) {
-    const {executionContextId, element} = payload;
+    const { executionContextId, element } = payload;
     const context = this._contextIdToContext.get(executionContextId)!;
     const handle = context.createHandle(element).asElement()!;
     await this._page._onFileChooserOpened(handle);
@@ -284,7 +284,7 @@ export class FFPage implements PageDelegate {
       worker._createExecutionContext(new FFExecutionContext(workerSession, event.executionContextId));
     });
     workerSession.on('Runtime.console', event => {
-      const {type, args, location} = event;
+      const { type, args, location } = event;
       const context = worker._existingExecutionContext!;
       this._page._addConsoleMessage(type, args.map(arg => context.createHandle(arg)), location);
     });

--- a/src/server/frames.ts
+++ b/src/server/frames.ts
@@ -1336,7 +1336,7 @@ export class Frame extends SdkObject {
   async extendInjectedScript(source: string, arg?: any): Promise<js.JSHandle> {
     const context = await this._context('main');
     const injectedScriptHandle = await context.injectedScript();
-    return injectedScriptHandle.evaluateHandle((injectedScript, {source, arg}) => {
+    return injectedScriptHandle.evaluateHandle((injectedScript, { source, arg }) => {
       return injectedScript.extend(source, arg);
     }, { source, arg });
   }

--- a/src/server/injected/reactSelectorEngine.ts
+++ b/src/server/injected/reactSelectorEngine.ts
@@ -155,7 +155,7 @@ function findReactRoots(): ReactVNode[] {
 
 export const ReactEngine: SelectorEngine = {
   queryAll(scope: SelectorRoot, selector: string): Element[] {
-    const {name, attributes} = parseComponentSelector(selector);
+    const { name, attributes } = parseComponentSelector(selector);
 
     const reactRoots = findReactRoots();
     const trees = reactRoots.map(reactRoot => buildComponentsTree(reactRoot));

--- a/src/server/injected/vueSelectorEngine.ts
+++ b/src/server/injected/vueSelectorEngine.ts
@@ -210,7 +210,7 @@ function findVueRoots(): VueRoot[] {
   // Vue3 roots are marked with [data-v-app] attribute
   for (const node of document.querySelectorAll('[data-v-app]')) {
     if ((node as any)._vnode && (node as any)._vnode.component)
-      roots.push({root: (node as any)._vnode.component, version: 3});
+      roots.push({ root: (node as any)._vnode.component, version: 3 });
   }
   // Vue2 roots are referred to from elements.
   const walker = document.createTreeWalker(document, NodeFilter.SHOW_ELEMENT);
@@ -231,7 +231,7 @@ function findVueRoots(): VueRoot[] {
 
 export const VueEngine: SelectorEngine = {
   queryAll(scope: SelectorRoot, selector: string): Element[] {
-    const {name, attributes} = parseComponentSelector(selector);
+    const { name, attributes } = parseComponentSelector(selector);
     const vueRoots = findVueRoots();
     const trees = vueRoots.map(vueRoot => vueRoot.version === 3 ? buildComponentsTreeVue3(vueRoot.root) : buildComponentsTreeVue2(vueRoot.root));
     const treeNodes = trees.map(tree => filterComponentsTree(tree, treeNode => {

--- a/src/server/javascript.ts
+++ b/src/server/javascript.ts
@@ -132,7 +132,7 @@ export class JSHandle<T = any> extends SdkObject {
 
   async getProperty(propertyName: string): Promise<JSHandle> {
     const objectHandle = await this.evaluateHandle((object: any, propertyName) => {
-      const result: any = {__proto__: null};
+      const result: any = { __proto__: null };
       result[propertyName] = object[propertyName];
       return result;
     }, propertyName);

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -54,7 +54,7 @@ export function rewriteCookies(cookies: types.SetNetworkCookieParam[]): types.Se
     assert(c.url || (c.domain && c.path), 'Cookie should have a url or a domain/path pair');
     assert(!(c.url && c.domain), 'Cookie should have either url or domain');
     assert(!(c.url && c.path), 'Cookie should have either url or path');
-    const copy = {...c};
+    const copy = { ...c };
     if (copy.url) {
       assert(copy.url !== 'about:blank', `Blank page can not have cookie "${c.name}"`);
       assert(!copy.url.startsWith('data:'), `Data URL page can not have cookie "${c.name}"`);

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -556,7 +556,7 @@ export class PageBinding {
   }
 
   static async dispatch(page: Page, payload: string, context: dom.FrameExecutionContext) {
-    const {name, seq, args} = JSON.parse(payload);
+    const { name, seq, args } = JSON.parse(payload);
     try {
       assert(context.world);
       const binding = page.getBinding(name)!;
@@ -620,12 +620,12 @@ function addPageBinding(bindingName: string, needsHandle: boolean) {
       handles = new Map();
       me['handles'] = handles;
     }
-    const promise = new Promise((resolve, reject) => callbacks.set(seq, {resolve, reject}));
+    const promise = new Promise((resolve, reject) => callbacks.set(seq, { resolve, reject }));
     if (needsHandle) {
       handles.set(seq, args[0]);
-      binding(JSON.stringify({name: bindingName, seq}));
+      binding(JSON.stringify({ name: bindingName, seq }));
     } else {
-      binding(JSON.stringify({name: bindingName, seq, args}));
+      binding(JSON.stringify({ name: bindingName, seq, args }));
     }
     return promise;
   };

--- a/src/server/screenshotter.ts
+++ b/src/server/screenshotter.ts
@@ -140,7 +140,7 @@ export class Screenshotter {
     progress.throwIfAborted(); // Screenshotting is expensive - avoid extra work.
     const shouldSetDefaultBackground = options.omitBackground && format === 'png';
     if (shouldSetDefaultBackground) {
-      await this._page._delegate.setBackgroundColor({ r: 0, g: 0, b: 0, a: 0});
+      await this._page._delegate.setBackgroundColor({ r: 0, g: 0, b: 0, a: 0 });
       progress.cleanupWhenAborted(() => this._page._delegate.setBackgroundColor());
     }
     progress.throwIfAborted(); // Avoid extra work.

--- a/src/server/webkit/webkit.ts
+++ b/src/server/webkit/webkit.ts
@@ -42,7 +42,7 @@ export class WebKit extends BrowserType {
   }
 
   _attemptToGracefullyCloseBrowser(transport: ConnectionTransport): void {
-    transport.send({method: 'Playwright.close', params: {}, id: kBrowserCloseMessageId});
+    transport.send({ method: 'Playwright.close', params: {}, id: kBrowserCloseMessageId });
   }
 
   _defaultArgs(options: types.LaunchOptions, isPersistent: boolean, userDataDir: string): string[] {

--- a/src/server/webkit/wkAccessibility.ts
+++ b/src/server/webkit/wkAccessibility.ts
@@ -21,7 +21,7 @@ import * as types from '../types';
 
 export async function getAccessibilityTree(session: WKSession, needle?: dom.ElementHandle) {
   const objectId = needle ? needle._objectId : undefined;
-  const {axNode} = await session.send('Page.accessibilitySnapshot', { objectId });
+  const { axNode } = await session.send('Page.accessibilitySnapshot', { objectId });
   const tree = new WKAXNode(axNode);
   return {
     tree,
@@ -127,7 +127,7 @@ class WKAXNode implements accessibility.AXNode {
     }
 
     isInteresting(insideControl: boolean): boolean {
-      const {role, focusable} = this._payload;
+      const { role, focusable } = this._payload;
       const name = this._name();
       if (role === 'ScrollArea')
         return false;

--- a/src/server/webkit/wkConnection.ts
+++ b/src/server/webkit/wkConnection.ts
@@ -138,7 +138,7 @@ export class WKSession extends EventEmitter {
     const messageObj = { id, method, params };
     this._rawSend(messageObj);
     return new Promise<Protocol.CommandReturnValues[T]>((resolve, reject) => {
-      this._callbacks.set(id, {resolve, reject, error: new ProtocolError(false), method});
+      this._callbacks.set(id, { resolve, reject, error: new ProtocolError(false), method });
     });
   }
 

--- a/src/server/webkit/wkPage.ts
+++ b/src/server/webkit/wkPage.ts
@@ -308,7 +308,7 @@ export class WKPage implements PageDelegate {
         this._setSession(session);
         await Promise.all([
           this._initializePageProxySession(),
-          this._initializeSession(session, false, ({frameTree}) => this._handleFrameTree(frameTree)),
+          this._initializeSession(session, false, ({ frameTree }) => this._handleFrameTree(frameTree)),
         ]);
         pageOrError = this._page;
       } catch (e) {
@@ -552,7 +552,7 @@ export class WKPage implements PageDelegate {
         columnNumber: (columnNumber || 1) - 1,
       }
     };
-    this._onConsoleRepeatCountUpdated({ count: 1});
+    this._onConsoleRepeatCountUpdated({ count: 1 });
   }
 
   _onConsoleRepeatCountUpdated(event: Protocol.Console.messageRepeatCountUpdatedPayload) {
@@ -983,7 +983,7 @@ export class WKPage implements PageDelegate {
   _onRequestIntercepted(session: WKSession, event: Protocol.Network.requestInterceptedPayload) {
     const request = this._requestIdToRequest.get(event.requestId);
     if (!request) {
-      session.sendMayFail('Network.interceptRequestWithError', {errorType: 'Cancellation', requestId: event.requestId});
+      session.sendMayFail('Network.interceptRequestWithError', { errorType: 'Cancellation', requestId: event.requestId });
       return;
     }
     if (!request._route) {

--- a/src/server/webkit/wkProvisionalPage.ts
+++ b/src/server/webkit/wkProvisionalPage.ts
@@ -50,7 +50,7 @@ export class WKProvisionalPage {
       eventsHelper.addEventListener(session, 'Network.loadingFailed', overrideFrameId(e => wkPage._onLoadingFailed(e))),
     ];
 
-    this.initializationPromise = this._wkPage._initializeSession(session, true, ({frameTree}) => this._handleFrameTree(frameTree));
+    this.initializationPromise = this._wkPage._initializeSession(session, true, ({ frameTree }) => this._handleFrameTree(frameTree));
   }
 
   dispose() {

--- a/src/test/dispatcher.ts
+++ b/src/test/dispatcher.ts
@@ -364,7 +364,7 @@ export class Dispatcher {
         pair.result.stderr.push(chunk);
       this._reporter.onStdErr?.(chunk, pair?.test, pair?.result);
     });
-    worker.on('teardownError', ({error}) => {
+    worker.on('teardownError', ({ error }) => {
       this._hasWorkerErrors = true;
       this._reporter.onError?.(error);
     });

--- a/src/test/reporters/base.ts
+++ b/src/test/reporters/base.ts
@@ -285,7 +285,7 @@ function positionInFile(stackLines: string[], file: string): { column: number; l
     if (!parsed || !parsed.file)
       continue;
     if (path.resolve(process.cwd(), parsed.file) === file)
-      return {column: parsed.column || 0, line: parsed.line || 0};
+      return { column: parsed.column || 0, line: parsed.line || 0 };
   }
 }
 

--- a/src/test/reporters/junit.ts
+++ b/src/test/reporters/junit.ts
@@ -131,7 +131,7 @@ class JUnitReporter implements Reporter {
     entries.push(entry);
 
     if (test.outcome() === 'skipped') {
-      entry.children.push({ name: 'skipped'});
+      entry.children.push({ name: 'skipped' });
       return;
     }
 

--- a/src/test/runner.ts
+++ b/src/test/runner.ts
@@ -338,7 +338,7 @@ function filterOnly(suite: Suite) {
 }
 
 function filterByFocusedLine(suite: Suite, focusedTestFileLines: FilePatternFilter[]) {
-  const testFileLineMatches = (testFileName: string, testLine: number) => focusedTestFileLines.some(({re, line}) => {
+  const testFileLineMatches = (testFileName: string, testLine: number) => focusedTestFileLines.some(({ re, line }) => {
     re.lastIndex = 0;
     return re.test(testFileName) && (line === testLine || line === null);
   });

--- a/src/test/transform.ts
+++ b/src/test/transform.ts
@@ -92,7 +92,7 @@ export function installTransform(): () => void {
       sourceMaps: 'both',
     } as babel.TransformOptions)!;
     if (result.code) {
-      fs.mkdirSync(path.dirname(cachePath), {recursive: true});
+      fs.mkdirSync(path.dirname(cachePath), { recursive: true });
       if (result.map)
         fs.writeFileSync(sourceMapPath, JSON.stringify(result.map), 'utf8');
       fs.writeFileSync(codePath, result.code, 'utf8');

--- a/src/utils/browserFetcher.ts
+++ b/src/utils/browserFetcher.ts
@@ -55,7 +55,7 @@ export async function downloadBrowserWithProgressBar(title: string, browserDirec
   try {
     for (let attempt = 1, N = 3; attempt <= N; ++attempt) {
       debugLogger.log('install', `downloading ${progressBarName} - attempt #${attempt}`);
-      const {error} = await downloadFile(url, zipPath, {progressCallback: progress, log: debugLogger.log.bind(debugLogger, 'install')});
+      const { error } = await downloadFile(url, zipPath, { progressCallback: progress, log: debugLogger.log.bind(debugLogger, 'install') });
       if (!error) {
         debugLogger.log('install', `SUCCESS downloading ${progressBarName}`);
         break;
@@ -74,7 +74,7 @@ export async function downloadBrowserWithProgressBar(title: string, browserDirec
     debugLogger.log('install', `extracting archive`);
     debugLogger.log('install', `-- zip: ${zipPath}`);
     debugLogger.log('install', `-- location: ${browserDirectory}`);
-    await extract(zipPath, { dir: browserDirectory});
+    await extract(zipPath, { dir: browserDirectory });
     debugLogger.log('install', `fixing permissions at ${executablePath}`);
     await fs.promises.chmod(executablePath, 0o755);
   } catch (e) {

--- a/src/utils/dependencies.ts
+++ b/src/utils/dependencies.ts
@@ -39,7 +39,7 @@ export type DependencyGroup = 'chromium' | 'firefox' | 'webkit' | 'tools';
 
 export async function installDependenciesWindows(targets: Set<DependencyGroup>) {
   if (targets.has('chromium')) {
-    const {code} = await utils.spawnAsync('powershell.exe', [path.join(BIN_DIRECTORY, 'install_media_pack.ps1')], { cwd: BIN_DIRECTORY, stdio: 'inherit' });
+    const { code } = await utils.spawnAsync('powershell.exe', [path.join(BIN_DIRECTORY, 'install_media_pack.ps1')], { cwd: BIN_DIRECTORY, stdio: 'inherit' });
     if (code !== 0)
       throw new Error('Failed to install windows dependencies!');
   }
@@ -255,7 +255,7 @@ async function executablesOrSharedLibraries(directoryPath: string): Promise<stri
 async function missingFileDependenciesWindows(filePath: string): Promise<Array<string>> {
   const executable = path.join(__dirname, '..', '..', 'bin', 'PrintDeps.exe');
   const dirname = path.dirname(filePath);
-  const {stdout, code} = await utils.spawnAsync(executable, [filePath], {
+  const { stdout, code } = await utils.spawnAsync(executable, [filePath], {
     cwd: dirname,
     env: {
       ...process.env,
@@ -273,7 +273,7 @@ async function missingFileDependencies(filePath: string, extraLDPaths: string[])
   let LD_LIBRARY_PATH = extraLDPaths.join(':');
   if (process.env.LD_LIBRARY_PATH)
     LD_LIBRARY_PATH = `${process.env.LD_LIBRARY_PATH}:${LD_LIBRARY_PATH}`;
-  const {stdout, code} = await utils.spawnAsync('ldd', [filePath], {
+  const { stdout, code } = await utils.spawnAsync('ldd', [filePath], {
     cwd: dirname,
     env: {
       ...process.env,
@@ -292,7 +292,7 @@ async function missingDLOPENLibraries(libraries: string[]): Promise<string[]> {
   // NOTE: Using full-qualified path to `ldconfig` since `/sbin` is not part of the
   // default PATH in CRON.
   // @see https://github.com/microsoft/playwright/issues/3397
-  const {stdout, code, error} = await utils.spawnAsync('/sbin/ldconfig', ['-p'], {});
+  const { stdout, code, error } = await utils.spawnAsync('/sbin/ldconfig', ['-p'], {});
   if (code !== 0 || error)
     return [];
   const isLibraryAvailable = (library: string) => stdout.toLowerCase().includes(library.toLowerCase());

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -615,8 +615,8 @@ export class Registry {
       }[channel];
       const product = products.find((product: any) => product.Product === productName);
       const searchConfig = ({
-        darwin: {platform: 'MacOS', arch: 'universal', artifact: 'pkg'},
-        win32: {platform: 'Windows', arch: os.arch() === 'x64' ? 'x64' : 'x86', artifact: 'msi'},
+        darwin: { platform: 'MacOS', arch: 'universal', artifact: 'pkg' },
+        win32: { platform: 'Windows', arch: os.arch() === 'x64' ? 'x64' : 'x86', artifact: 'msi' },
       } as any)[process.platform];
       const release = searchConfig ? product.Releases.find((release: any) => release.Platform === searchConfig.platform && release.Architecture === searchConfig.arch) : null;
       const artifact = release ? release.Artifacts.find((artifact: any) => artifact.ArtifactName === searchConfig.artifact) : null;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -123,7 +123,7 @@ export function downloadFile(url: string, destinationPath: string, options: {pro
   log(`running download:`);
   log(`-- from url: ${url}`);
   log(`-- to location: ${destinationPath}`);
-  let fulfill: ({error}: {error: any}) => void = ({error}) => {};
+  let fulfill: ({ error }: {error: any}) => void = ({ error }) => {};
   let downloadedBytes = 0;
   let totalBytes = 0;
 
@@ -135,18 +135,18 @@ export function downloadFile(url: string, destinationPath: string, options: {pro
       const error = new Error(`Download failed: server returned code ${response.statusCode}. URL: ${url}`);
       // consume response data to free up memory
       response.resume();
-      fulfill({error});
+      fulfill({ error });
       return;
     }
     const file = fs.createWriteStream(destinationPath);
-    file.on('finish', () => fulfill({error: null}));
-    file.on('error', error => fulfill({error}));
+    file.on('finish', () => fulfill({ error: null }));
+    file.on('error', error => fulfill({ error }));
     response.pipe(file);
     totalBytes = parseInt(response.headers['content-length'] || '0', 10);
     log(`-- total bytes: ${totalBytes}`);
     if (progressCallback)
       response.on('data', onData);
-  }, (error: any) => fulfill({error}));
+  }, (error: any) => fulfill({ error }));
   return promise;
 
   function onData(chunk: string) {
@@ -165,8 +165,8 @@ export function spawnAsync(cmd: string, args: string[], options?: SpawnOptions):
       process.stdout.on('data', data => stdout += data);
     if (process.stderr)
       process.stderr.on('data', data => stderr += data);
-    process.on('close', code => resolve({stdout, stderr, code}));
-    process.on('error', error => resolve({stdout, stderr, code: 0, error}));
+    process.on('close', code => resolve({ stdout, stderr, code }));
+    process.on('error', error => resolve({ stdout, stderr, code: 0, error }));
   });
 }
 
@@ -265,7 +265,7 @@ export function getAsBooleanFromENV(name: string): boolean {
 
 export async function mkdirIfNeeded(filePath: string) {
   // This will harmlessly throw on windows if the dirname is the root directory.
-  await fs.promises.mkdir(path.dirname(filePath), {recursive: true}).catch(() => {});
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true }).catch(() => {});
 }
 
 type HeadersArray = { name: string, value: string }[];
@@ -326,7 +326,7 @@ export function arrayToObject(array?: NameValue[]): { [key: string]: string } | 
   if (!array)
     return undefined;
   const result: { [key: string]: string } = {};
-  for (const {name, value} of array)
+  for (const { name, value } of array)
     result[name] = value;
   return result;
 }

--- a/src/web/components/expandable.tsx
+++ b/src/web/components/expandable.tsx
@@ -27,7 +27,7 @@ export const Expandable: React.FunctionComponent<{
     <div className='expandable-title' style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', whiteSpace: 'nowrap' }}>
       <div
         className={'codicon codicon-' + (expanded ? 'chevron-down' : 'chevron-right')}
-        style={{ cursor: 'pointer', color: 'var(--color)', marginRight: '4px'}}
+        style={{ cursor: 'pointer', color: 'var(--color)', marginRight: '4px' }}
         onClick={() => setExpanded(!expanded)} />
       {title}
     </div>

--- a/src/web/components/splitView.tsx
+++ b/src/web/components/splitView.tsx
@@ -53,7 +53,7 @@ export const SplitView: React.FC<SplitViewProps> = ({
 
   return <div className={'split-view ' + orientation + (sidebarIsFirst ? ' sidebar-first' : '') }>
     <div className='split-view-main'>{childrenArray[0]}</div>
-    { !sidebarHidden && <div style={{flexBasis: size}} className='split-view-sidebar'>{childrenArray[1]}</div> }
+    { !sidebarHidden && <div style={{ flexBasis: size }} className='split-view-sidebar'>{childrenArray[1]}</div> }
     { !sidebarHidden && <div
       style={resizerStyle}
       className='split-view-resizer'

--- a/src/web/htmlReport/htmlReport.tsx
+++ b/src/web/htmlReport/htmlReport.tsx
@@ -233,7 +233,7 @@ const StepTreeItem: React.FC<{
 const StatsView: React.FC<{
   stats: Stats
 }> = ({ stats }) => {
-  return <div className='hbox' style={{flex: 'none'}}>
+  return <div className='hbox' style={{ flex: 'none' }}>
     {!!stats.expected && <div className='stats expected' title='Passed'>{stats.expected}</div>}
     {!!stats.unexpected && <div className='stats unexpected' title='Failed'>{stats.unexpected}</div>}
     {!!stats.flaky && <div className='stats flaky' title='Flaky'>{stats.flaky}</div>}

--- a/src/web/recorder/callLog.tsx
+++ b/src/web/recorder/callLog.tsx
@@ -32,7 +32,7 @@ export const CallLogView: React.FC<CallLogProps> = ({
     if (log.find(callLog => callLog.reveal))
       messagesEndRef.current?.scrollIntoView({ block: 'center', inline: 'nearest' });
   }, [messagesEndRef, log]);
-  return <div className='call-log' style={{flex: 'auto'}}>
+  return <div className='call-log' style={{ flex: 'auto' }}>
     {log.map(callLog => {
       const expandOverride = expandOverrides.get(callLog.id);
       const isExpanded = typeof expandOverride === 'boolean' ? expandOverride : callLog.status !== 'done';

--- a/src/web/recorder/recorder.tsx
+++ b/src/web/recorder/recorder.tsx
@@ -81,7 +81,7 @@ export const Recorder: React.FC<RecorderProps> = ({
   return <div className='recorder'>
     <Toolbar>
       <ToolbarButton icon='record' title='Record' toggled={mode === 'recording'} onClick={() => {
-        window.dispatch({ event: 'setMode', params: { mode: mode === 'recording' ? 'none' : 'recording' }});
+        window.dispatch({ event: 'setMode', params: { mode: mode === 'recording' ? 'none' : 'recording' } });
       }}>Record</ToolbarButton>
       <ToolbarButton icon='files' title='Copy' disabled={!source || !source.text} onClick={() => {
         copy(source.text);
@@ -95,7 +95,7 @@ export const Recorder: React.FC<RecorderProps> = ({
       <ToolbarButton icon='debug-step-over' title='Step over' disabled={!paused} onClick={() => {
         window.dispatch({ event: 'step' });
       }}></ToolbarButton>
-      <div style={{flex: 'auto'}}></div>
+      <div style={{ flex: 'auto' }}></div>
       <div>Target:</div>
       <select className='recorder-chooser' hidden={!sources.length} value={file} onChange={event => {
         setFile(event.target.selectedOptions[0].value);
@@ -115,7 +115,7 @@ export const Recorder: React.FC<RecorderProps> = ({
       <div className='vbox'>
         <Toolbar>
           <ToolbarButton icon='microscope' title='Explore' toggled={mode === 'inspecting'} onClick={() => {
-            window.dispatch({ event: 'setMode', params: { mode: mode === 'inspecting' ? 'none' : 'inspecting' }}).catch(() => { });
+            window.dispatch({ event: 'setMode', params: { mode: mode === 'inspecting' ? 'none' : 'inspecting' } }).catch(() => { });
           }}>Explore</ToolbarButton>
           <input ref={selectorInputRef} className='selector-input' placeholder='Playwright Selector' value={selector} disabled={mode !== 'none'} onChange={event => {
             setSelector(event.target.value);

--- a/tests/android/browser.spec.ts
+++ b/tests/android/browser.spec.ts
@@ -52,6 +52,6 @@ test('should be able to send CDP messages', async ({ androidDevice }) => {
   const [page] = context.pages();
   const client = await context.newCDPSession(page);
   await client.send('Runtime.enable');
-  const evalResponse = await client.send('Runtime.evaluate', {expression: '1 + 2', returnByValue: true});
+  const evalResponse = await client.send('Runtime.evaluate', { expression: '1 + 2', returnByValue: true });
   expect(evalResponse.result.value).toBe(3);
 });

--- a/tests/android/device.spec.ts
+++ b/tests/android/device.spec.ts
@@ -38,7 +38,7 @@ test('androidDevice.screenshot', async function({ androidDevice }, testInfo) {
   const result = await androidDevice.screenshot({ path });
   const buffer = fs.readFileSync(path);
   expect(result.length).toBe(buffer.length);
-  const { width, height} = PNG.sync.read(result);
+  const { width, height } = PNG.sync.read(result);
   expect(width).toBe(1080);
   expect(height).toBe(1920);
 });

--- a/tests/beforeunload.spec.ts
+++ b/tests/beforeunload.spec.ts
@@ -17,7 +17,7 @@
 
 import { contextTest as it, expect } from './config/browserTest';
 
-it('should close browser with beforeunload page', async ({server, browserType, browserOptions }) => {
+it('should close browser with beforeunload page', async ({ server, browserType, browserOptions }) => {
   const browser = await browserType.launch(browserOptions);
   const page = await browser.newPage();
   await page.goto(server.PREFIX + '/beforeunload.html');
@@ -27,7 +27,7 @@ it('should close browser with beforeunload page', async ({server, browserType, b
   await browser.close();
 });
 
-it('should close browsercontext with beforeunload page', async ({server, page, context }) => {
+it('should close browsercontext with beforeunload page', async ({ server, page, context }) => {
   await page.goto(server.PREFIX + '/beforeunload.html');
   // We have to interact with a page so that 'beforeunload' handlers
   // fire.
@@ -35,7 +35,7 @@ it('should close browsercontext with beforeunload page', async ({server, page, c
   await context.close();
 });
 
-it('should be able to navigate away from page with beforeunload', async ({server, page, context }) => {
+it('should be able to navigate away from page with beforeunload', async ({ server, page, context }) => {
   await page.goto(server.PREFIX + '/beforeunload.html');
   // We have to interact with a page so that 'beforeunload' handlers
   // fire.
@@ -43,7 +43,7 @@ it('should be able to navigate away from page with beforeunload', async ({server
   await page.goto(server.EMPTY_PAGE);
 });
 
-it('should close page with beforeunload listener', async ({context, server}) => {
+it('should close page with beforeunload listener', async ({ context, server }) => {
   const newPage = await context.newPage();
   await newPage.goto(server.PREFIX + '/beforeunload.html');
   // We have to interact with a page so that 'beforeunload' handlers
@@ -52,7 +52,7 @@ it('should close page with beforeunload listener', async ({context, server}) => 
   await newPage.close();
 });
 
-it('should run beforeunload if asked for', async ({context, server, browserName}) => {
+it('should run beforeunload if asked for', async ({ context, server, browserName }) => {
   const newPage = await context.newPage();
   await newPage.goto(server.PREFIX + '/beforeunload.html');
   // We have to interact with a page so that 'beforeunload' handlers
@@ -76,7 +76,7 @@ it('should run beforeunload if asked for', async ({context, server, browserName}
   ]);
 });
 
-it('should access page after beforeunload', async ({page, server}) => {
+it('should access page after beforeunload', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/beforeunload.html');
   // We have to interact with a page so that 'beforeunload' handlers
   // fire.

--- a/tests/browser.spec.ts
+++ b/tests/browser.spec.ts
@@ -16,7 +16,7 @@
 
 import { browserTest as test, expect } from './config/browserTest';
 
-test('should create new page', async function({browser}) {
+test('should create new page', async function({ browser }) {
   const page1 = await browser.newPage();
   expect(browser.contexts().length).toBe(1);
 
@@ -30,7 +30,7 @@ test('should create new page', async function({browser}) {
   expect(browser.contexts().length).toBe(0);
 });
 
-test('should throw upon second create new page', async function({browser}) {
+test('should throw upon second create new page', async function({ browser }) {
   const page = await browser.newPage();
   let error;
   await page.context().newPage().catch(e => error = e);
@@ -38,7 +38,7 @@ test('should throw upon second create new page', async function({browser}) {
   expect(error.message).toContain('Please use browser.newContext()');
 });
 
-test('version should work', async function({browser, browserName}) {
+test('version should work', async function({ browser, browserName }) {
   const version = browser.version();
   if (browserName === 'chromium')
     expect(version.match(/^\d+\.\d+\.\d+\.\d+$/)).toBeTruthy();

--- a/tests/browsercontext-add-cookies.spec.ts
+++ b/tests/browsercontext-add-cookies.spec.ts
@@ -17,7 +17,7 @@
 
 import { contextTest as it, playwrightTest, expect } from './config/browserTest';
 
-it('should work', async ({context, page, server}) => {
+it('should work', async ({ context, page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await context.addCookies([{
     url: server.EMPTY_PAGE,
@@ -27,7 +27,7 @@ it('should work', async ({context, page, server}) => {
   expect(await page.evaluate(() => document.cookie)).toEqual('password=123456');
 });
 
-it('should work with expires=-1', async ({context, page}) => {
+it('should work with expires=-1', async ({ context, page }) => {
   await context.addCookies([{
     name: 'username',
     value: 'John Doe',
@@ -45,7 +45,7 @@ it('should work with expires=-1', async ({context, page}) => {
   expect(await page.evaluate(() => document.cookie)).toEqual('username=John Doe');
 });
 
-it('should roundtrip cookie', async ({context, page, server}) => {
+it('should roundtrip cookie', async ({ context, page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   // @see https://en.wikipedia.org/wiki/Year_2038_problem
   const date = +(new Date('1/1/2038'));
@@ -62,22 +62,22 @@ it('should roundtrip cookie', async ({context, page, server}) => {
   expect(await context.cookies()).toEqual(cookies);
 });
 
-it('should send cookie header', async ({server, context}) => {
+it('should send cookie header', async ({ server, context }) => {
   let cookie = '';
   server.setRoute('/empty.html', (req, res) => {
     cookie = req.headers.cookie;
     res.end();
   });
-  await context.addCookies([{url: server.EMPTY_PAGE, name: 'cookie', value: 'value'}]);
+  await context.addCookies([{ url: server.EMPTY_PAGE, name: 'cookie', value: 'value' }]);
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
   expect(cookie).toBe('cookie=value');
 });
 
-it('should isolate cookies in browser contexts', async ({context, server, browser}) => {
+it('should isolate cookies in browser contexts', async ({ context, server, browser }) => {
   const anotherContext = await browser.newContext();
-  await context.addCookies([{url: server.EMPTY_PAGE, name: 'isolatecookie', value: 'page1value'}]);
-  await anotherContext.addCookies([{url: server.EMPTY_PAGE, name: 'isolatecookie', value: 'page2value'}]);
+  await context.addCookies([{ url: server.EMPTY_PAGE, name: 'isolatecookie', value: 'page1value' }]);
+  await anotherContext.addCookies([{ url: server.EMPTY_PAGE, name: 'isolatecookie', value: 'page2value' }]);
 
   const cookies1 = await context.cookies();
   const cookies2 = await anotherContext.cookies();
@@ -90,7 +90,7 @@ it('should isolate cookies in browser contexts', async ({context, server, browse
   await anotherContext.close();
 });
 
-it('should isolate session cookies', async ({context, server, browser}) => {
+it('should isolate session cookies', async ({ context, server, browser }) => {
   server.setRoute('/setcookie.html', (req, res) => {
     res.setHeader('Set-Cookie', 'session=value');
     res.end();
@@ -116,7 +116,7 @@ it('should isolate session cookies', async ({context, server, browser}) => {
   }
 });
 
-it('should isolate persistent cookies', async ({context, server, browser}) => {
+it('should isolate persistent cookies', async ({ context, server, browser }) => {
   server.setRoute('/setcookie.html', (req, res) => {
     res.setHeader('Set-Cookie', 'persistent=persistent-value; max-age=3600');
     res.end();
@@ -136,13 +136,13 @@ it('should isolate persistent cookies', async ({context, server, browser}) => {
   await context2.close();
 });
 
-it('should isolate send cookie header', async ({server, context, browser}) => {
+it('should isolate send cookie header', async ({ server, context, browser }) => {
   let cookie = '';
   server.setRoute('/empty.html', (req, res) => {
     cookie = req.headers.cookie || '';
     res.end();
   });
-  await context.addCookies([{url: server.EMPTY_PAGE, name: 'sendcookie', value: 'value'}]);
+  await context.addCookies([{ url: server.EMPTY_PAGE, name: 'sendcookie', value: 'value' }]);
   {
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
@@ -157,12 +157,12 @@ it('should isolate send cookie header', async ({server, context, browser}) => {
   }
 });
 
-playwrightTest('should isolate cookies between launches', async ({browserType, server, browserOptions}) => {
+playwrightTest('should isolate cookies between launches', async ({ browserType, server, browserOptions }) => {
   playwrightTest.slow();
 
   const browser1 = await browserType.launch(browserOptions);
   const context1 = await browser1.newContext();
-  await context1.addCookies([{url: server.EMPTY_PAGE, name: 'cookie-in-context-1', value: 'value', expires: Date.now() / 1000 + 10000}]);
+  await context1.addCookies([{ url: server.EMPTY_PAGE, name: 'cookie-in-context-1', value: 'value', expires: Date.now() / 1000 + 10000 }]);
   await browser1.close();
 
   const browser2 = await browserType.launch(browserOptions);
@@ -172,7 +172,7 @@ playwrightTest('should isolate cookies between launches', async ({browserType, s
   await browser2.close();
 });
 
-it('should set multiple cookies', async ({context, page, server}) => {
+it('should set multiple cookies', async ({ context, page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await context.addCookies([{
     url: server.EMPTY_PAGE,
@@ -192,7 +192,7 @@ it('should set multiple cookies', async ({context, page, server}) => {
   ]);
 });
 
-it('should have |expires| set to |-1| for session cookies', async ({context, server}) => {
+it('should have |expires| set to |-1| for session cookies', async ({ context, server }) => {
   await context.addCookies([{
     url: server.EMPTY_PAGE,
     name: 'expires',
@@ -202,7 +202,7 @@ it('should have |expires| set to |-1| for session cookies', async ({context, ser
   expect(cookies[0].expires).toBe(-1);
 });
 
-it('should set cookie with reasonable defaults', async ({context, server, browserName}) => {
+it('should set cookie with reasonable defaults', async ({ context, server, browserName }) => {
   await context.addCookies([{
     url: server.EMPTY_PAGE,
     name: 'defaults',
@@ -221,7 +221,7 @@ it('should set cookie with reasonable defaults', async ({context, server, browse
   }]);
 });
 
-it('should set a cookie with a path', async ({context, page, server, browserName, isWindows}) => {
+it('should set a cookie with a path', async ({ context, page, server, browserName, isWindows }) => {
   await page.goto(server.PREFIX + '/grid.html');
   await context.addCookies([{
     domain: 'localhost',
@@ -247,12 +247,12 @@ it('should set a cookie with a path', async ({context, page, server, browserName
   expect(await page.evaluate('document.cookie')).toBe('gridcookie=GRID');
 });
 
-it('should not set a cookie with blank page URL', async function({context, server}) {
+it('should not set a cookie with blank page URL', async function({ context, server }) {
   let error = null;
   try {
     await context.addCookies([
-      {url: server.EMPTY_PAGE, name: 'example-cookie', value: 'best'},
-      {url: 'about:blank', name: 'example-cookie-blank', value: 'best'}
+      { url: server.EMPTY_PAGE, name: 'example-cookie', value: 'best' },
+      { url: 'about:blank', name: 'example-cookie-blank', value: 'best' }
     ]);
   } catch (e) {
     error = e;
@@ -262,17 +262,17 @@ it('should not set a cookie with blank page URL', async function({context, serve
   );
 });
 
-it('should not set a cookie on a data URL page', async function({context}) {
+it('should not set a cookie on a data URL page', async function({ context }) {
   let error = null;
   try {
-    await context.addCookies([{url: 'data:,Hello%2C%20World!', name: 'example-cookie', value: 'best'}]);
+    await context.addCookies([{ url: 'data:,Hello%2C%20World!', name: 'example-cookie', value: 'best' }]);
   } catch (e) {
     error = e;
   }
   expect(error.message).toContain('Data URL page can not have cookie "example-cookie"');
 });
 
-it('should default to setting secure cookie for HTTPS websites', async ({context, page, server}) => {
+it('should default to setting secure cookie for HTTPS websites', async ({ context, page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const SECURE_URL = 'https://example.com';
   await context.addCookies([{
@@ -284,7 +284,7 @@ it('should default to setting secure cookie for HTTPS websites', async ({context
   expect(cookie.secure).toBe(true);
 });
 
-it('should be able to set unsecure cookie for HTTP website', async ({context, page, server}) => {
+it('should be able to set unsecure cookie for HTTP website', async ({ context, page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const HTTP_URL = 'http://example.com';
   await context.addCookies([{
@@ -296,7 +296,7 @@ it('should be able to set unsecure cookie for HTTP website', async ({context, pa
   expect(cookie.secure).toBe(false);
 });
 
-it('should set a cookie on a different domain', async ({context, page, server, browserName, isWindows}) => {
+it('should set a cookie on a different domain', async ({ context, page, server, browserName, isWindows }) => {
   await page.goto(server.EMPTY_PAGE);
   await context.addCookies([{
     url: 'https://www.example.com',
@@ -317,10 +317,10 @@ it('should set a cookie on a different domain', async ({context, page, server, b
   }]);
 });
 
-it('should set cookies for a frame', async ({context, page, server}) => {
+it('should set cookies for a frame', async ({ context, page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await context.addCookies([
-    {url: server.PREFIX, name: 'frame-cookie', value: 'value'}
+    { url: server.PREFIX, name: 'frame-cookie', value: 'value' }
   ]);
   await page.evaluate(src => {
     let fulfill;
@@ -335,7 +335,7 @@ it('should set cookies for a frame', async ({context, page, server}) => {
   expect(await page.frames()[1].evaluate('document.cookie')).toBe('frame-cookie=value');
 });
 
-it('should(not) block third party cookies', async ({context, page, server, browserName}) => {
+it('should(not) block third party cookies', async ({ context, page, server, browserName }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(src => {
     let fulfill;

--- a/tests/browsercontext-base-url.spec.ts
+++ b/tests/browsercontext-base-url.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should construct a new URL when a baseURL in browser.newContext is passed to page.goto', async function({browser, server}) {
+it('should construct a new URL when a baseURL in browser.newContext is passed to page.goto', async function({ browser, server }) {
   const context = await browser.newContext({
     baseURL: server.PREFIX,
   });
@@ -26,7 +26,7 @@ it('should construct a new URL when a baseURL in browser.newContext is passed to
   await context.close();
 });
 
-it('should construct a new URL when a baseURL in browser.newPage is passed to page.goto', async function({browser, server}) {
+it('should construct a new URL when a baseURL in browser.newPage is passed to page.goto', async function({ browser, server }) {
   const page = await browser.newPage({
     baseURL: server.PREFIX,
   });
@@ -34,7 +34,7 @@ it('should construct a new URL when a baseURL in browser.newPage is passed to pa
   await page.close();
 });
 
-it('should construct a new URL when a baseURL in browserType.launchPersistentContext is passed to page.goto', async function({browserType, server, createUserDataDir, browserOptions}) {
+it('should construct a new URL when a baseURL in browserType.launchPersistentContext is passed to page.goto', async function({ browserType, server, createUserDataDir, browserOptions }) {
   const userDataDir = await createUserDataDir();
   const context = await browserType.launchPersistentContext(userDataDir, {
     ...browserOptions,
@@ -45,7 +45,7 @@ it('should construct a new URL when a baseURL in browserType.launchPersistentCon
   await context.close();
 });
 
-it('should construct the URLs correctly when a baseURL without a trailing slash in browser.newPage is passed to page.goto', async function({browser, server}) {
+it('should construct the URLs correctly when a baseURL without a trailing slash in browser.newPage is passed to page.goto', async function({ browser, server }) {
   const page = await browser.newPage({
     baseURL: server.PREFIX + '/url-construction',
   });
@@ -55,7 +55,7 @@ it('should construct the URLs correctly when a baseURL without a trailing slash 
   await page.close();
 });
 
-it('should construct the URLs correctly when a baseURL with a trailing slash in browser.newPage is passed to page.goto', async function({browser, server}) {
+it('should construct the URLs correctly when a baseURL with a trailing slash in browser.newPage is passed to page.goto', async function({ browser, server }) {
   const page = await browser.newPage({
     baseURL: server.PREFIX + '/url-construction/',
   });
@@ -67,7 +67,7 @@ it('should construct the URLs correctly when a baseURL with a trailing slash in 
   await page.close();
 });
 
-it('should not construct a new URL when valid URLs are passed', async function({browser, server}) {
+it('should not construct a new URL when valid URLs are passed', async function({ browser, server }) {
   const page = await browser.newPage({
     baseURL: 'http://microsoft.com',
   });
@@ -81,7 +81,7 @@ it('should not construct a new URL when valid URLs are passed', async function({
   await page.close();
 });
 
-it('should be able to match a URL relative to its given URL with urlMatcher', async function({browser, server}) {
+it('should be able to match a URL relative to its given URL with urlMatcher', async function({ browser, server }) {
   const page = await browser.newPage({
     baseURL: server.PREFIX + '/foobar/',
   });
@@ -103,7 +103,7 @@ it('should be able to match a URL relative to its given URL with urlMatcher', as
   await page.close();
 });
 
-it('should not construct a new URL with baseURL when a glob was used', async function({browser, server}) {
+it('should not construct a new URL with baseURL when a glob was used', async function({ browser, server }) {
   const page = await browser.newPage({
     baseURL: server.PREFIX + '/foobar/',
   });

--- a/tests/browsercontext-basic.spec.ts
+++ b/tests/browsercontext-basic.spec.ts
@@ -18,7 +18,7 @@
 import { browserTest as it, expect } from './config/browserTest';
 import { attachFrame, verifyViewport } from './config/utils';
 
-it('should create new context', async function({browser}) {
+it('should create new context', async function({ browser }) {
   expect(browser.contexts().length).toBe(0);
   const context = await browser.newContext();
   expect(browser.contexts().length).toBe(1);
@@ -29,7 +29,7 @@ it('should create new context', async function({browser}) {
   expect(browser).toBe(context.browser());
 });
 
-it('window.open should use parent tab context', async function({browser, server}) {
+it('window.open should use parent tab context', async function({ browser, server }) {
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -41,7 +41,7 @@ it('window.open should use parent tab context', async function({browser, server}
   await context.close();
 });
 
-it('should isolate localStorage and cookies', async function({browser, server}) {
+it('should isolate localStorage and cookies', async function({ browser, server }) {
   // Create two incognito contexts.
   const context1 = await browser.newContext();
   const context2 = await browser.newContext();
@@ -132,7 +132,7 @@ it('close() should abort waitForEvent', async ({ browser }) => {
   expect(error.message).toContain('Context closed');
 });
 
-it('close() should be callable twice', async ({browser}) => {
+it('close() should be callable twice', async ({ browser }) => {
   const context = await browser.newContext();
   await Promise.all([
     context.close(),
@@ -141,7 +141,7 @@ it('close() should be callable twice', async ({browser}) => {
   await context.close();
 });
 
-it('should pass self to close event', async ({browser}) => {
+it('should pass self to close event', async ({ browser }) => {
   const newContext = await browser.newContext();
   const [closedContext] = await Promise.all([
     newContext.waitForEvent('close'),
@@ -150,7 +150,7 @@ it('should pass self to close event', async ({browser}) => {
   expect(closedContext).toBe(newContext);
 });
 
-it('should not report frameless pages on error', async ({browser, server}) => {
+it('should not report frameless pages on error', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   server.setRoute('/empty.html', (req, res) => {
@@ -168,7 +168,7 @@ it('should not report frameless pages on error', async ({browser, server}) => {
   }
 });
 
-it('should return all of the pages', async ({browser, server}) => {
+it('should return all of the pages', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   const second = await context.newPage();
@@ -179,7 +179,7 @@ it('should return all of the pages', async ({browser, server}) => {
   await context.close();
 });
 
-it('should close all belonging pages once closing context', async function({browser}) {
+it('should close all belonging pages once closing context', async function({ browser }) {
   const context = await browser.newContext();
   await context.newPage();
   expect(context.pages().length).toBe(1);
@@ -188,7 +188,7 @@ it('should close all belonging pages once closing context', async function({brow
   expect(context.pages().length).toBe(0);
 });
 
-it('should disable javascript', async ({browser, browserName}) => {
+it('should disable javascript', async ({ browser, browserName }) => {
   {
     const context = await browser.newContext({ javaScriptEnabled: false });
     const page = await context.newPage();
@@ -211,15 +211,15 @@ it('should disable javascript', async ({browser, browserName}) => {
   }
 });
 
-it('should be able to navigate after disabling javascript', async ({browser, server}) => {
+it('should be able to navigate after disabling javascript', async ({ browser, server }) => {
   const context = await browser.newContext({ javaScriptEnabled: false });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
   await context.close();
 });
 
-it('should work with offline option', async ({browser, server}) => {
-  const context = await browser.newContext({offline: true});
+it('should work with offline option', async ({ browser, server }) => {
+  const context = await browser.newContext({ offline: true });
   const page = await context.newPage();
   let error = null;
   await page.goto(server.EMPTY_PAGE).catch(e => error = e);
@@ -230,7 +230,7 @@ it('should work with offline option', async ({browser, server}) => {
   await context.close();
 });
 
-it('should emulate navigator.onLine', async ({browser, server}) => {
+it('should emulate navigator.onLine', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   expect(await page.evaluate(() => window.navigator.onLine)).toBe(true);
@@ -241,7 +241,7 @@ it('should emulate navigator.onLine', async ({browser, server}) => {
   await context.close();
 });
 
-it('should emulate media in popup', async ({browser, server}) => {
+it('should emulate media in popup', async ({ browser, server }) => {
   {
     const context = await browser.newContext({ colorScheme: 'dark' });
     const page = await context.newPage();
@@ -267,7 +267,7 @@ it('should emulate media in popup', async ({browser, server}) => {
   }
 });
 
-it('should emulate media in cross-process iframe', async ({browser, server}) => {
+it('should emulate media in cross-process iframe', async ({ browser, server }) => {
   const page = await browser.newPage({ colorScheme: 'dark' });
   await page.goto(server.EMPTY_PAGE);
   await attachFrame(page, 'frame1', server.CROSS_PROCESS_PREFIX + '/empty.html');

--- a/tests/browsercontext-clearcookies.spec.ts
+++ b/tests/browsercontext-clearcookies.spec.ts
@@ -17,7 +17,7 @@
 
 import { contextTest as it, expect } from './config/browserTest';
 
-it('should clear cookies', async ({context, page, server}) => {
+it('should clear cookies', async ({ context, page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await context.addCookies([{
     url: server.EMPTY_PAGE,
@@ -31,10 +31,10 @@ it('should clear cookies', async ({context, page, server}) => {
   expect(await page.evaluate('document.cookie')).toBe('');
 });
 
-it('should isolate cookies when clearing', async ({context, server, browser}) => {
+it('should isolate cookies when clearing', async ({ context, server, browser }) => {
   const anotherContext = await browser.newContext();
-  await context.addCookies([{url: server.EMPTY_PAGE, name: 'page1cookie', value: 'page1value'}]);
-  await anotherContext.addCookies([{url: server.EMPTY_PAGE, name: 'page2cookie', value: 'page2value'}]);
+  await context.addCookies([{ url: server.EMPTY_PAGE, name: 'page1cookie', value: 'page1value' }]);
+  await anotherContext.addCookies([{ url: server.EMPTY_PAGE, name: 'page2cookie', value: 'page2value' }]);
 
   expect((await context.cookies()).length).toBe(1);
   expect((await anotherContext.cookies()).length).toBe(1);

--- a/tests/browsercontext-cookies.spec.ts
+++ b/tests/browsercontext-cookies.spec.ts
@@ -17,11 +17,11 @@
 
 import { contextTest as it, expect } from './config/browserTest';
 
-it('should return no cookies in pristine browser context', async ({context, page, server}) => {
+it('should return no cookies in pristine browser context', async ({ context, page, server }) => {
   expect(await context.cookies()).toEqual([]);
 });
 
-it('should get a cookie', async ({context, page, server, browserName}) => {
+it('should get a cookie', async ({ context, page, server, browserName }) => {
   await page.goto(server.EMPTY_PAGE);
   const documentCookie = await page.evaluate(() => {
     document.cookie = 'username=John Doe';
@@ -40,7 +40,7 @@ it('should get a cookie', async ({context, page, server, browserName}) => {
   }]);
 });
 
-it('should get a non-session cookie', async ({context, page, server, browserName}) => {
+it('should get a non-session cookie', async ({ context, page, server, browserName }) => {
   await page.goto(server.EMPTY_PAGE);
   // @see https://en.wikipedia.org/wiki/Year_2038_problem
   const date = +(new Date('1/1/2038'));
@@ -62,7 +62,7 @@ it('should get a non-session cookie', async ({context, page, server, browserName
   }]);
 });
 
-it('should properly report httpOnly cookie', async ({context, page, server}) => {
+it('should properly report httpOnly cookie', async ({ context, page, server }) => {
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('Set-Cookie', 'name=value;HttpOnly; Path=/');
     res.end();
@@ -73,7 +73,7 @@ it('should properly report httpOnly cookie', async ({context, page, server}) => 
   expect(cookies[0].httpOnly).toBe(true);
 });
 
-it('should properly report "Strict" sameSite cookie', async ({context, page, server, browserName, platform}) => {
+it('should properly report "Strict" sameSite cookie', async ({ context, page, server, browserName, platform }) => {
   it.fail(browserName === 'webkit' && platform === 'win32');
 
   server.setRoute('/empty.html', (req, res) => {
@@ -86,7 +86,7 @@ it('should properly report "Strict" sameSite cookie', async ({context, page, ser
   expect(cookies[0].sameSite).toBe('Strict');
 });
 
-it('should properly report "Lax" sameSite cookie', async ({context, page, server, browserName, platform}) => {
+it('should properly report "Lax" sameSite cookie', async ({ context, page, server, browserName, platform }) => {
   it.fail(browserName === 'webkit' && platform === 'win32');
 
   server.setRoute('/empty.html', (req, res) => {
@@ -99,7 +99,7 @@ it('should properly report "Lax" sameSite cookie', async ({context, page, server
   expect(cookies[0].sameSite).toBe('Lax');
 });
 
-it('should get multiple cookies', async ({context, page, server, browserName}) => {
+it('should get multiple cookies', async ({ context, page, server, browserName }) => {
   await page.goto(server.EMPTY_PAGE);
   const documentCookie = await page.evaluate(() => {
     document.cookie = 'username=John Doe';
@@ -132,7 +132,7 @@ it('should get multiple cookies', async ({context, page, server, browserName}) =
   ]));
 });
 
-it('should get cookies from multiple urls', async ({context, browserName, isWindows}) => {
+it('should get cookies from multiple urls', async ({ context, browserName, isWindows }) => {
   await context.addCookies([{
     url: 'https://foo.com',
     name: 'doggo',
@@ -171,7 +171,7 @@ it('should get cookies from multiple urls', async ({context, browserName, isWind
   }]));
 });
 
-it('should work with subdomain cookie', async ({context, browserName, isWindows}) => {
+it('should work with subdomain cookie', async ({ context, browserName, isWindows }) => {
   await context.addCookies([{
     domain: '.foo.com',
     path: '/',
@@ -202,7 +202,7 @@ it('should work with subdomain cookie', async ({context, browserName, isWindows}
   }]);
 });
 
-it('should not return cookies with empty value', async ({context, page, server}) => {
+it('should not return cookies with empty value', async ({ context, page, server }) => {
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('Set-Cookie', 'name=;Path=/');
     res.end();
@@ -212,7 +212,7 @@ it('should not return cookies with empty value', async ({context, page, server})
   expect(cookies.length).toBe(0);
 });
 
-it('should return secure cookies based on HTTP(S) protocol', async ({context, browserName, isWindows}) => {
+it('should return secure cookies based on HTTP(S) protocol', async ({ context, browserName, isWindows }) => {
   await context.addCookies([{
     url: 'https://foo.com',
     name: 'doggo',

--- a/tests/browsercontext-credentials.spec.ts
+++ b/tests/browsercontext-credentials.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should fail without credentials', async ({browser, server, browserName, headless}) => {
+it('should fail without credentials', async ({ browser, server, browserName, headless }) => {
   it.fail(browserName === 'chromium' && !headless);
 
   server.setAuth('/empty.html', 'user', 'pass');
@@ -28,7 +28,7 @@ it('should fail without credentials', async ({browser, server, browserName, head
   await context.close();
 });
 
-it('should work with setHTTPCredentials', async ({browser, server, browserName, headless}) => {
+it('should work with setHTTPCredentials', async ({ browser, server, browserName, headless }) => {
   it.fail(browserName === 'chromium' && !headless);
 
   server.setAuth('/empty.html', 'user', 'pass');
@@ -42,7 +42,7 @@ it('should work with setHTTPCredentials', async ({browser, server, browserName, 
   await context.close();
 });
 
-it('should work with correct credentials', async ({browser, server}) => {
+it('should work with correct credentials', async ({ browser, server }) => {
   server.setAuth('/empty.html', 'user', 'pass');
   const context = await browser.newContext({
     httpCredentials: { username: 'user', password: 'pass' }
@@ -53,7 +53,7 @@ it('should work with correct credentials', async ({browser, server}) => {
   await context.close();
 });
 
-it('should fail with wrong credentials', async ({browser, server}) => {
+it('should fail with wrong credentials', async ({ browser, server }) => {
   server.setAuth('/empty.html', 'user', 'pass');
   const context = await browser.newContext({
     httpCredentials: { username: 'foo', password: 'bar' }
@@ -64,7 +64,7 @@ it('should fail with wrong credentials', async ({browser, server}) => {
   await context.close();
 });
 
-it('should return resource body', async ({browser, server}) => {
+it('should return resource body', async ({ browser, server }) => {
   server.setAuth('/playground.html', 'user', 'pass');
   const context = await browser.newContext({
     httpCredentials: { username: 'user', password: 'pass' }

--- a/tests/browsercontext-csp.spec.ts
+++ b/tests/browsercontext-csp.spec.ts
@@ -18,13 +18,13 @@
 import { browserTest as it, expect } from './config/browserTest';
 import { attachFrame } from './config/utils';
 
-it('should bypass CSP meta tag', async ({browser, server}) => {
+it('should bypass CSP meta tag', async ({ browser, server }) => {
   // Make sure CSP prohibits addScriptTag.
   {
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/csp.html');
-    await page.addScriptTag({content: 'window["__injected"] = 42;'}).catch(e => void e);
+    await page.addScriptTag({ content: 'window["__injected"] = 42;' }).catch(e => void e);
     expect(await page.evaluate('window["__injected"]')).toBe(undefined);
     await context.close();
   }
@@ -34,13 +34,13 @@ it('should bypass CSP meta tag', async ({browser, server}) => {
     const context = await browser.newContext({ bypassCSP: true });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/csp.html');
-    await page.addScriptTag({content: 'window["__injected"] = 42;'});
+    await page.addScriptTag({ content: 'window["__injected"] = 42;' });
     expect(await page.evaluate('window["__injected"]')).toBe(42);
     await context.close();
   }
 });
 
-it('should bypass CSP header', async ({browser, server}) => {
+it('should bypass CSP header', async ({ browser, server }) => {
   // Make sure CSP prohibits addScriptTag.
   server.setCSP('/empty.html', 'default-src "self"');
 
@@ -48,7 +48,7 @@ it('should bypass CSP header', async ({browser, server}) => {
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
-    await page.addScriptTag({content: 'window["__injected"] = 42;'}).catch(e => void e);
+    await page.addScriptTag({ content: 'window["__injected"] = 42;' }).catch(e => void e);
     expect(await page.evaluate('window["__injected"]')).toBe(undefined);
     await context.close();
   }
@@ -58,33 +58,33 @@ it('should bypass CSP header', async ({browser, server}) => {
     const context = await browser.newContext({ bypassCSP: true });
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
-    await page.addScriptTag({content: 'window["__injected"] = 42;'});
+    await page.addScriptTag({ content: 'window["__injected"] = 42;' });
     expect(await page.evaluate('window["__injected"]')).toBe(42);
     await context.close();
   }
 });
 
-it('should bypass after cross-process navigation', async ({browser, server}) => {
+it('should bypass after cross-process navigation', async ({ browser, server }) => {
   const context = await browser.newContext({ bypassCSP: true });
   const page = await context.newPage();
   await page.goto(server.PREFIX + '/csp.html');
-  await page.addScriptTag({content: 'window["__injected"] = 42;'});
+  await page.addScriptTag({ content: 'window["__injected"] = 42;' });
   expect(await page.evaluate('window["__injected"]')).toBe(42);
 
   await page.goto(server.CROSS_PROCESS_PREFIX + '/csp.html');
-  await page.addScriptTag({content: 'window["__injected"] = 42;'});
+  await page.addScriptTag({ content: 'window["__injected"] = 42;' });
   expect(await page.evaluate('window["__injected"]')).toBe(42);
   await context.close();
 });
 
-it('should bypass CSP in iframes as well', async ({browser, server}) => {
+it('should bypass CSP in iframes as well', async ({ browser, server }) => {
   // Make sure CSP prohibits addScriptTag in an iframe.
   {
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
     const frame = await attachFrame(page, 'frame1', server.PREFIX + '/csp.html');
-    await frame.addScriptTag({content: 'window["__injected"] = 42;'}).catch(e => void e);
+    await frame.addScriptTag({ content: 'window["__injected"] = 42;' }).catch(e => void e);
     expect(await frame.evaluate('window["__injected"]')).toBe(undefined);
     await context.close();
   }
@@ -95,7 +95,7 @@ it('should bypass CSP in iframes as well', async ({browser, server}) => {
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
     const frame = await attachFrame(page, 'frame1', server.PREFIX + '/csp.html');
-    await frame.addScriptTag({content: 'window["__injected"] = 42;'}).catch(e => void e);
+    await frame.addScriptTag({ content: 'window["__injected"] = 42;' }).catch(e => void e);
     expect(await frame.evaluate('window["__injected"]')).toBe(42);
     await context.close();
   }

--- a/tests/browsercontext-device.spec.ts
+++ b/tests/browsercontext-device.spec.ts
@@ -20,7 +20,7 @@ import { browserTest as it, expect } from './config/browserTest';
 it.describe('device', () => {
   it.skip(({ browserName }) => browserName === 'firefox');
 
-  it('should work', async ({playwright, browser, server}) => {
+  it('should work', async ({ playwright, browser, server }) => {
     const iPhone = playwright.devices['iPhone 6'];
     const context = await browser.newContext({ ...iPhone });
     const page = await context.newPage();
@@ -30,7 +30,7 @@ it.describe('device', () => {
     await context.close();
   });
 
-  it('should support clicking', async ({playwright, browser, server}) => {
+  it('should support clicking', async ({ playwright, browser, server }) => {
     const iPhone = playwright.devices['iPhone 6'];
     const context = await browser.newContext({ ...iPhone });
     const page = await context.newPage();
@@ -42,7 +42,7 @@ it.describe('device', () => {
     await context.close();
   });
 
-  it('should scroll to click', async ({browser, server, contextOptions}) => {
+  it('should scroll to click', async ({ browser, server, contextOptions }) => {
     const context = await browser.newContext({
       ...contextOptions,
       viewport: {
@@ -60,7 +60,7 @@ it.describe('device', () => {
     await context.close();
   });
 
-  it('should scroll twice when emulated', async ({server, contextFactory, playwright}) => {
+  it('should scroll twice when emulated', async ({ server, contextFactory, playwright }) => {
     const device = playwright.devices['iPhone 6'];
     const context = await contextFactory(device);
     const page = await context.newPage();
@@ -78,7 +78,7 @@ it.describe('device', () => {
     await context.close();
   });
 
-  it('should reset scroll top after a navigation', async ({server, contextFactory, playwright, browserName}) => {
+  it('should reset scroll top after a navigation', async ({ server, contextFactory, playwright, browserName }) => {
     it.skip(browserName === 'webkit');
 
     const device = playwright.devices['iPhone 6'];
@@ -92,7 +92,7 @@ it.describe('device', () => {
     await context.close();
   });
 
-  it('should scroll to a precise position with mobile scale', async ({server, contextFactory, playwright, browserName}) => {
+  it('should scroll to a precise position with mobile scale', async ({ server, contextFactory, playwright, browserName }) => {
     it.skip(browserName === 'webkit');
 
     const device = playwright.devices['iPhone 6'];
@@ -105,7 +105,7 @@ it.describe('device', () => {
     await context.close();
   });
 
-  it('should emulate viewport and screen size', async ({server, contextFactory, playwright}) => {
+  it('should emulate viewport and screen size', async ({ server, contextFactory, playwright }) => {
     const device = playwright.devices['iPhone 12'];
     const context = await contextFactory(device);
     const page = await context.newPage();
@@ -124,7 +124,7 @@ it.describe('device', () => {
     await context.close();
   });
 
-  it('should emulate viewport without screen size', async ({server, contextFactory, playwright}) => {
+  it('should emulate viewport without screen size', async ({ server, contextFactory, playwright }) => {
     const device = playwright.devices['iPhone 6'];
     const context = await contextFactory(device);
     const page = await context.newPage();

--- a/tests/browsercontext-dsf.spec.ts
+++ b/tests/browsercontext-dsf.spec.ts
@@ -16,7 +16,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should fetch lodpi assets', async ({ contextFactory, server}) => {
+it('should fetch lodpi assets', async ({ contextFactory, server }) => {
   const context = await contextFactory({
     deviceScaleFactor: 1
   });

--- a/tests/browsercontext-expose-function.spec.ts
+++ b/tests/browsercontext-expose-function.spec.ts
@@ -17,7 +17,7 @@
 
 import { contextTest as it, expect } from './config/browserTest';
 
-it('expose binding should work', async ({context}) => {
+it('expose binding should work', async ({ context }) => {
   let bindingSource;
   await context.exposeBinding('add', (source, a, b) => {
     bindingSource = source;
@@ -31,7 +31,7 @@ it('expose binding should work', async ({context}) => {
   expect(result).toEqual(11);
 });
 
-it('should work', async ({context, server}) => {
+it('should work', async ({ context, server }) => {
   await context.exposeFunction('add', (a, b) => a + b);
   const page = await context.newPage();
   await page.exposeFunction('mul', (a, b) => a * b);
@@ -44,7 +44,7 @@ it('should work', async ({context, server}) => {
   expect(result).toEqual({ mul: 36, add: 13, sub: 5, addHandle: 11 });
 });
 
-it('should throw for duplicate registrations', async ({context, server}) => {
+it('should throw for duplicate registrations', async ({ context, server }) => {
   await context.exposeFunction('foo', () => {});
   await context.exposeFunction('bar', () => {});
   let error = await context.exposeFunction('foo', () => {}).catch(e => e);
@@ -57,7 +57,7 @@ it('should throw for duplicate registrations', async ({context, server}) => {
   expect(error.message).toContain('Function "baz" has been already registered in one of the pages');
 });
 
-it('should be callable from-inside addInitScript', async ({context, server}) => {
+it('should be callable from-inside addInitScript', async ({ context, server }) => {
   let args = [];
   await context.exposeFunction('woof', function(arg) {
     args.push(arg);
@@ -72,7 +72,7 @@ it('should be callable from-inside addInitScript', async ({context, server}) => 
   expect(args).toEqual(['context', 'page']);
 });
 
-it('exposeBindingHandle should work', async ({context}) => {
+it('exposeBindingHandle should work', async ({ context }) => {
   let target;
   await context.exposeBinding('logme', (source, t) => {
     target = t;

--- a/tests/browsercontext-fetch.spec.ts
+++ b/tests/browsercontext-fetch.spec.ts
@@ -42,7 +42,7 @@ it.afterAll(() => {
   http.globalAgent = prevAgent;
 });
 
-it('get should work', async ({context, server}) => {
+it('get should work', async ({ context, server }) => {
   const response = await context._request.get(server.PREFIX + '/simple.json');
   expect(response.url()).toBe(server.PREFIX + '/simple.json');
   expect(response.status()).toBe(200);
@@ -54,7 +54,7 @@ it('get should work', async ({context, server}) => {
   expect(await response.text()).toBe('{"foo": "bar"}\n');
 });
 
-it('fetch should work', async ({context, server}) => {
+it('fetch should work', async ({ context, server }) => {
   const response = await context._request.fetch(server.PREFIX + '/simple.json');
   expect(response.url()).toBe(server.PREFIX + '/simple.json');
   expect(response.status()).toBe(200);
@@ -66,7 +66,7 @@ it('fetch should work', async ({context, server}) => {
   expect(await response.text()).toBe('{"foo": "bar"}\n');
 });
 
-it('should throw on network error', async ({context, server}) => {
+it('should throw on network error', async ({ context, server }) => {
   server.setRoute('/test', (req, res) => {
     req.socket.destroy();
   });
@@ -74,7 +74,7 @@ it('should throw on network error', async ({context, server}) => {
   expect(error.message).toContain('socket hang up');
 });
 
-it('should throw on network error after redirect', async ({context, server}) => {
+it('should throw on network error after redirect', async ({ context, server }) => {
   server.setRedirect('/redirect', '/test');
   server.setRoute('/test', (req, res) => {
     req.socket.destroy();
@@ -83,7 +83,7 @@ it('should throw on network error after redirect', async ({context, server}) => 
   expect(error.message).toContain('socket hang up');
 });
 
-it('should throw on network error when sending body', async ({context, server}) => {
+it('should throw on network error when sending body', async ({ context, server }) => {
   server.setRoute('/test', (req, res) => {
     res.writeHead(200, {
       'content-length': 4096,
@@ -97,7 +97,7 @@ it('should throw on network error when sending body', async ({context, server}) 
   expect(error.message).toContain('Error: aborted');
 });
 
-it('should throw on network error when sending body after redirect', async ({context, server}) => {
+it('should throw on network error when sending body after redirect', async ({ context, server }) => {
   server.setRedirect('/redirect', '/test');
   server.setRoute('/test', (req, res) => {
     res.writeHead(200, {
@@ -112,7 +112,7 @@ it('should throw on network error when sending body after redirect', async ({con
   expect(error.message).toContain('Error: aborted');
 });
 
-it('should add session cookies to request', async ({context, server}) => {
+it('should add session cookies to request', async ({ context, server }) => {
   await context.addCookies([{
     name: 'username',
     value: 'John Doe',
@@ -131,7 +131,7 @@ it('should add session cookies to request', async ({context, server}) => {
 });
 
 for (const method of ['get', 'post', 'fetch']) {
-  it(`${method} should support queryParams`, async ({context, server}) => {
+  it(`${method} should support queryParams`, async ({ context, server }) => {
     let request;
     const url = new URL(server.EMPTY_PAGE);
     url.searchParams.set('p1', 'v1');
@@ -151,7 +151,7 @@ for (const method of ['get', 'post', 'fetch']) {
     expect(params.get('парам2')).toEqual('знач2');
   });
 
-  it(`${method} should support failOnStatusCode`, async ({context, server}) => {
+  it(`${method} should support failOnStatusCode`, async ({ context, server }) => {
     const error = await context._request[method](server.PREFIX + '/does-not-exist.html', {
       failOnStatusCode: true
     }).catch(e => e);
@@ -159,7 +159,7 @@ for (const method of ['get', 'post', 'fetch']) {
   });
 }
 
-it('should not add context cookie if cookie header passed as a parameter', async ({context, server}) => {
+it('should not add context cookie if cookie header passed as a parameter', async ({ context, server }) => {
   await context.addCookies([{
     name: 'username',
     value: 'John Doe',
@@ -181,7 +181,7 @@ it('should not add context cookie if cookie header passed as a parameter', async
   expect(req.headers.cookie).toEqual('foo=bar');
 });
 
-it('should follow redirects', async ({context, server}) => {
+it('should follow redirects', async ({ context, server }) => {
   server.setRedirect('/redirect1', '/redirect2');
   server.setRedirect('/redirect2', '/simple.json');
   await context.addCookies([{
@@ -200,10 +200,10 @@ it('should follow redirects', async ({context, server}) => {
   ]);
   expect(req.headers.cookie).toEqual('username=John Doe');
   expect(response.url()).toBe(`http://www.my.playwright.dev:${server.PORT}/simple.json`);
-  expect(await response.json()).toEqual({foo: 'bar'});
+  expect(await response.json()).toEqual({ foo: 'bar' });
 });
 
-it('should add cookies from Set-Cookie header', async ({context, page, server}) => {
+it('should add cookies from Set-Cookie header', async ({ context, page, server }) => {
   server.setRoute('/setcookie.html', (req, res) => {
     res.setHeader('Set-Cookie', ['session=value', 'foo=bar; max-age=3600']);
     res.end();
@@ -224,7 +224,7 @@ it('should add cookies from Set-Cookie header', async ({context, page, server}) 
   expect((await page.evaluate(() => document.cookie)).split(';').map(s => s.trim()).sort()).toEqual(['foo=bar', 'session=value']);
 });
 
-it('should not lose body while handling Set-Cookie header', async ({context, server}) => {
+it('should not lose body while handling Set-Cookie header', async ({ context, server }) => {
   server.setRoute('/setcookie.html', (req, res) => {
     res.setHeader('Set-Cookie', ['session=value', 'foo=bar; max-age=3600']);
     res.end('text content');
@@ -233,7 +233,7 @@ it('should not lose body while handling Set-Cookie header', async ({context, ser
   expect(await response.text()).toBe('text content');
 });
 
-it('should handle cookies on redirects', async ({context, server, browserName, isWindows}) => {
+it('should handle cookies on redirects', async ({ context, server, browserName, isWindows }) => {
   server.setRoute('/redirect1', (req, res) => {
     res.setHeader('Set-Cookie', 'r1=v1;SameSite=Lax');
     res.writeHead(301, { location: '/a/b/redirect2' });
@@ -291,7 +291,7 @@ it('should handle cookies on redirects', async ({context, server, browserName, i
   ]));
 });
 
-it('should return raw headers', async ({context, page, server}) => {
+it('should return raw headers', async ({ context, page, server }) => {
   server.setRoute('/headers', (req, res) => {
     // Headers array is only supported since Node v14.14.0 so we write directly to the socket.
     // res.writeHead(200, ['name-a', 'v1','name-b', 'v4','Name-a', 'v2', 'name-A', 'v3']);
@@ -314,7 +314,7 @@ it('should return raw headers', async ({context, page, server}) => {
   expect(response.headers()['name-b']).toBe('v4');
 });
 
-it('should work with context level proxy', async ({browserOptions, browserType, contextOptions, server, proxyServer}) => {
+it('should work with context level proxy', async ({ browserOptions, browserType, contextOptions, server, proxyServer }) => {
   server.setRoute('/target.html', async (req, res) => {
     res.end('<title>Served by the proxy</title>');
   });
@@ -342,7 +342,7 @@ it('should work with context level proxy', async ({browserOptions, browserType, 
   }
 });
 
-it('should pass proxy credentials', async ({browserType, browserOptions, server, proxyServer}) => {
+it('should pass proxy credentials', async ({ browserType, browserOptions, server, proxyServer }) => {
   proxyServer.forwardTo(server.PORT);
   let auth;
   proxyServer.setAuthHandler(req => {
@@ -357,11 +357,11 @@ it('should pass proxy credentials', async ({browserType, browserOptions, server,
   const response = await context._request.get('http://non-existent.com/simple.json');
   expect(proxyServer.connectHosts).toContain('non-existent.com:80');
   expect(auth).toBe('Basic ' + Buffer.from('user:secret').toString('base64'));
-  expect(await response.json()).toEqual({foo: 'bar'});
+  expect(await response.json()).toEqual({ foo: 'bar' });
   await browser.close();
 });
 
-it('should work with http credentials', async ({context, server}) => {
+it('should work with http credentials', async ({ context, server }) => {
   server.setAuth('/empty.html', 'user', 'pass');
 
   const [request, response] = await Promise.all([
@@ -376,7 +376,7 @@ it('should work with http credentials', async ({context, server}) => {
   expect(request.url).toBe('/empty.html');
 });
 
-it('should work with setHTTPCredentials', async ({context, server}) => {
+it('should work with setHTTPCredentials', async ({ context, server }) => {
   server.setAuth('/empty.html', 'user', 'pass');
   const response1 = await context._request.get(server.EMPTY_PAGE);
   expect(response1.status()).toBe(401);
@@ -386,14 +386,14 @@ it('should work with setHTTPCredentials', async ({context, server}) => {
   expect(response2.status()).toBe(200);
 });
 
-it('should return error with wrong credentials', async ({context, server}) => {
+it('should return error with wrong credentials', async ({ context, server }) => {
   server.setAuth('/empty.html', 'user', 'pass');
   await context.setHTTPCredentials({ username: 'user', password: 'wrong' });
   const response2 = await context._request.get(server.EMPTY_PAGE);
   expect(response2.status()).toBe(401);
 });
 
-it('should support post data', async ({context, server}) => {
+it('should support post data', async ({ context, server }) => {
   const [request, response] = await Promise.all([
     server.waitForRequest('/simple.json'),
     context._request.post(`${server.PREFIX}/simple.json`, {
@@ -406,7 +406,7 @@ it('should support post data', async ({context, server}) => {
   expect(request.url).toBe('/simple.json');
 });
 
-it('should add default headers', async ({context, server, page}) => {
+it('should add default headers', async ({ context, server, page }) => {
   const [request] = await Promise.all([
     server.waitForRequest('/empty.html'),
     context._request.get(server.EMPTY_PAGE)
@@ -417,7 +417,7 @@ it('should add default headers', async ({context, server, page}) => {
   expect(request.headers['accept-encoding']).toBe('gzip,deflate,br');
 });
 
-it('should send content-length', async function({context, asset, server}) {
+it('should send content-length', async function({ context, asset, server }) {
   const bytes = [];
   for (let i = 0; i < 256; i++)
     bytes.push(i);
@@ -431,7 +431,7 @@ it('should send content-length', async function({context, asset, server}) {
   expect(request.headers['content-type']).toBe('application/octet-stream');
 });
 
-it('should add default headers to redirects', async ({context, server, page}) => {
+it('should add default headers to redirects', async ({ context, server, page }) => {
   server.setRedirect('/redirect', '/empty.html');
   const [request] = await Promise.all([
     server.waitForRequest('/empty.html'),
@@ -443,7 +443,7 @@ it('should add default headers to redirects', async ({context, server, page}) =>
   expect(request.headers['accept-encoding']).toBe('gzip,deflate,br');
 });
 
-it('should allow to override default headers', async ({context, server, page}) => {
+it('should allow to override default headers', async ({ context, server, page }) => {
   const [request] = await Promise.all([
     server.waitForRequest('/empty.html'),
     context._request.get(server.EMPTY_PAGE, {
@@ -459,21 +459,21 @@ it('should allow to override default headers', async ({context, server, page}) =
   expect(request.headers['accept-encoding']).toBe('br');
 });
 
-it('should propagate custom headers with redirects', async ({context, server}) => {
+it('should propagate custom headers with redirects', async ({ context, server }) => {
   server.setRedirect('/a/redirect1', '/b/c/redirect2');
   server.setRedirect('/b/c/redirect2', '/simple.json');
   const [req1, req2, req3] = await Promise.all([
     server.waitForRequest('/a/redirect1'),
     server.waitForRequest('/b/c/redirect2'),
     server.waitForRequest('/simple.json'),
-    context._request.get(`${server.PREFIX}/a/redirect1`, {headers: {'foo': 'bar'}}),
+    context._request.get(`${server.PREFIX}/a/redirect1`, { headers: { 'foo': 'bar' } }),
   ]);
   expect(req1.headers['foo']).toBe('bar');
   expect(req2.headers['foo']).toBe('bar');
   expect(req3.headers['foo']).toBe('bar');
 });
 
-it('should propagate extra http headers with redirects', async ({context, server}) => {
+it('should propagate extra http headers with redirects', async ({ context, server }) => {
   server.setRedirect('/a/redirect1', '/b/c/redirect2');
   server.setRedirect('/b/c/redirect2', '/simple.json');
   await context.setExtraHTTPHeaders({ 'My-Secret': 'Value' });
@@ -488,7 +488,7 @@ it('should propagate extra http headers with redirects', async ({context, server
   expect(req3.headers['my-secret']).toBe('Value');
 });
 
-it('should throw on invalid header value', async ({context, server}) => {
+it('should throw on invalid header value', async ({ context, server }) => {
   const error = await context._request.get(`${server.PREFIX}/a/redirect1`, {
     headers: {
       'foo': 'недопустимое значение',
@@ -497,14 +497,14 @@ it('should throw on invalid header value', async ({context, server}) => {
   expect(error.message).toContain('Invalid character in header content');
 });
 
-it('should throw on non-http(s) protocol', async ({context}) => {
+it('should throw on non-http(s) protocol', async ({ context }) => {
   const error1 = await context._request.get(`data:text/plain,test`).catch(e => e);
   expect(error1.message).toContain('Protocol "data:" not supported');
   const error2 = await context._request.get(`file:///tmp/foo`).catch(e => e);
   expect(error2.message).toContain('Protocol "file:" not supported');
 });
 
-it('should support https', async ({context, httpsServer}) => {
+it('should support https', async ({ context, httpsServer }) => {
   const oldValue = process.env['NODE_TLS_REJECT_UNAUTHORIZED'];
   // https://stackoverflow.com/a/21961005/552185
   process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
@@ -517,13 +517,13 @@ it('should support https', async ({context, httpsServer}) => {
   }
 });
 
-it('should support ignoreHTTPSErrors', async ({contextFactory, contextOptions, httpsServer}) => {
+it('should support ignoreHTTPSErrors', async ({ contextFactory, contextOptions, httpsServer }) => {
   const context = await contextFactory({ ...contextOptions, ignoreHTTPSErrors: true });
   const response = await context._request.get(httpsServer.EMPTY_PAGE);
   expect(response.status()).toBe(200);
 });
 
-it('should resolve url relative to baseURL', async function({server, contextFactory, contextOptions}) {
+it('should resolve url relative to baseURL', async function({ server, contextFactory, contextOptions }) {
   const context = await contextFactory({
     ...contextOptions,
     baseURL: server.PREFIX,
@@ -532,7 +532,7 @@ it('should resolve url relative to baseURL', async function({server, contextFact
   expect(response.url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should support gzip compression', async function({context, server}) {
+it('should support gzip compression', async function({ context, server }) {
   server.setRoute('/compressed', (req, res) => {
     res.writeHead(200, {
       'Content-Encoding': 'gzip',
@@ -552,7 +552,7 @@ it('should support gzip compression', async function({context, server}) {
   expect(await response.text()).toBe('Hello, world!');
 });
 
-it('should throw informatibe error on corrupted gzip body', async function({context, server}) {
+it('should throw informatibe error on corrupted gzip body', async function({ context, server }) {
   server.setRoute('/corrupted', (req, res) => {
     res.writeHead(200, {
       'Content-Encoding': 'gzip',
@@ -566,7 +566,7 @@ it('should throw informatibe error on corrupted gzip body', async function({cont
   expect(error.message).toContain(`failed to decompress 'gzip' encoding`);
 });
 
-it('should support brotli compression', async function({context, server}) {
+it('should support brotli compression', async function({ context, server }) {
   server.setRoute('/compressed', (req, res) => {
     res.writeHead(200, {
       'Content-Encoding': 'br',
@@ -586,7 +586,7 @@ it('should support brotli compression', async function({context, server}) {
   expect(await response.text()).toBe('Hello, world!');
 });
 
-it('should throw informatibe error on corrupted brotli body', async function({context, server}) {
+it('should throw informatibe error on corrupted brotli body', async function({ context, server }) {
   server.setRoute('/corrupted', (req, res) => {
     res.writeHead(200, {
       'Content-Encoding': 'br',
@@ -600,7 +600,7 @@ it('should throw informatibe error on corrupted brotli body', async function({co
   expect(error.message).toContain(`failed to decompress 'br' encoding`);
 });
 
-it('should support deflate compression', async function({context, server}) {
+it('should support deflate compression', async function({ context, server }) {
   server.setRoute('/compressed', (req, res) => {
     res.writeHead(200, {
       'Content-Encoding': 'deflate',
@@ -620,7 +620,7 @@ it('should support deflate compression', async function({context, server}) {
   expect(await response.text()).toBe('Hello, world!');
 });
 
-it('should throw informatibe error on corrupted deflate body', async function({context, server}) {
+it('should throw informatibe error on corrupted deflate body', async function({ context, server }) {
   server.setRoute('/corrupted', (req, res) => {
     res.writeHead(200, {
       'Content-Encoding': 'deflate',
@@ -634,7 +634,7 @@ it('should throw informatibe error on corrupted deflate body', async function({c
   expect(error.message).toContain(`failed to decompress 'deflate' encoding`);
 });
 
-it('should support timeout option', async function({context, server}) {
+it('should support timeout option', async function({ context, server }) {
   server.setRoute('/slow', (req, res) => {
     res.writeHead(200, {
       'content-length': 4096,
@@ -646,7 +646,7 @@ it('should support timeout option', async function({context, server}) {
   expect(error.message).toContain(`Request timed out after 10ms`);
 });
 
-it('should support a timeout of 0', async function({context, server}) {
+it('should support a timeout of 0', async function({ context, server }) {
   server.setRoute('/slow', (req, res) => {
     res.writeHead(200, {
       'content-length': 4,
@@ -663,7 +663,7 @@ it('should support a timeout of 0', async function({context, server}) {
   expect(await response.text()).toBe('done');
 });
 
-it('should respect timeout after redirects', async function({context, server}) {
+it('should respect timeout after redirects', async function({ context, server }) {
   server.setRedirect('/redirect', '/slow');
   server.setRoute('/slow', (req, res) => {
     res.writeHead(200, {
@@ -677,7 +677,7 @@ it('should respect timeout after redirects', async function({context, server}) {
   expect(error.message).toContain(`Request timed out after 100ms`);
 });
 
-it('should dispose', async function({context, server}) {
+it('should dispose', async function({ context, server }) {
   const response = await context._request.get(server.PREFIX + '/simple.json');
   expect(await response.json()).toEqual({ foo: 'bar' });
   await response.dispose();
@@ -685,7 +685,7 @@ it('should dispose', async function({context, server}) {
   expect(error.message).toContain('Response has been disposed');
 });
 
-it('should dispose when context closes', async function({context, server}) {
+it('should dispose when context closes', async function({ context, server }) {
   const response = await context._request.get(server.PREFIX + '/simple.json');
   expect(await response.json()).toEqual({ foo: 'bar' });
   await context.close();
@@ -693,12 +693,12 @@ it('should dispose when context closes', async function({context, server}) {
   expect(error.message).toContain('Response has been disposed');
 });
 
-it('should throw on invalid first argument', async function({context}) {
+it('should throw on invalid first argument', async function({ context }) {
   const error = await context._request.get({} as any).catch(e => e);
   expect(error.message).toContain('First argument must be either URL string or Request');
 });
 
-it('should override request parameters', async function({context, page, server}) {
+it('should override request parameters', async function({ context, page, server }) {
   const [pageReq] = await Promise.all([
     page.waitForRequest('**/*'),
     page.goto(server.EMPTY_PAGE)
@@ -717,7 +717,7 @@ it('should override request parameters', async function({context, page, server})
   expect((await req.postBody).toString('utf8')).toBe('data');
 });
 
-it('should support application/x-www-form-urlencoded', async function({context, page, server}) {
+it('should support application/x-www-form-urlencoded', async function({ context, page, server }) {
   const [req] = await Promise.all([
     server.waitForRequest('/empty.html'),
     context._request.post(server.EMPTY_PAGE, {
@@ -741,7 +741,7 @@ it('should support application/x-www-form-urlencoded', async function({context, 
   expect(params.get('file')).toBe('f.js');
 });
 
-it('should encode to application/json by default', async function({context, page, server}) {
+it('should encode to application/json by default', async function({ context, page, server }) {
   const data = {
     firstName: 'John',
     lastName: 'Doe',
@@ -760,13 +760,13 @@ it('should encode to application/json by default', async function({context, page
   expect(json).toEqual(data);
 });
 
-it('should support multipart/form-data', async function({context, page, server}) {
+it('should support multipart/form-data', async function({ context, page, server }) {
   const formReceived = new Promise<any>(resolve => {
     server.setRoute('/empty.html', async (serverRequest, res) => {
       const form = new formidable.IncomingForm();
       form.parse(serverRequest, (error, fields, files) => {
         server.serveFile(serverRequest, res);
-        resolve({error, fields, files, serverRequest });
+        resolve({ error, fields, files, serverRequest });
       });
     });
   });
@@ -776,7 +776,7 @@ it('should support multipart/form-data', async function({context, page, server})
     mimeType: 'text/javascript',
     buffer: Buffer.from('var x = 10;\r\n;console.log(x);')
   };
-  const [{error, fields, files, serverRequest}, response] = await Promise.all([
+  const [{ error, fields, files, serverRequest }, response] = await Promise.all([
     formReceived,
     context._request.post(server.EMPTY_PAGE, {
       headers: {
@@ -800,18 +800,18 @@ it('should support multipart/form-data', async function({context, page, server})
   expect(response.status()).toBe(200);
 });
 
-it('should support multipart/form-data with ReadSream values', async function({context, page, asset, server}) {
+it('should support multipart/form-data with ReadSream values', async function({ context, page, asset, server }) {
   const formReceived = new Promise<any>(resolve => {
     server.setRoute('/empty.html', async (serverRequest, res) => {
       const form = new formidable.IncomingForm();
       form.parse(serverRequest, (error, fields, files) => {
         server.serveFile(serverRequest, res);
-        resolve({error, fields, files, serverRequest });
+        resolve({ error, fields, files, serverRequest });
       });
     });
   });
   const readStream = fs.createReadStream(asset('simplezip.json'));
-  const [{error, fields, files, serverRequest}, response] = await Promise.all([
+  const [{ error, fields, files, serverRequest }, response] = await Promise.all([
     formReceived,
     context._request.post(server.EMPTY_PAGE, {
       headers: {
@@ -836,7 +836,7 @@ it('should support multipart/form-data with ReadSream values', async function({c
   expect(response.status()).toBe(200);
 });
 
-it('should throw nice error on unsupported encoding', async function({context, server}) {
+it('should throw nice error on unsupported encoding', async function({ context, server }) {
   const error = await context._request.post(server.EMPTY_PAGE, {
     headers: {
       'content-type': 'unknown'
@@ -849,7 +849,7 @@ it('should throw nice error on unsupported encoding', async function({context, s
   expect(error.message).toContain('Cannot serialize data using content type: unknown');
 });
 
-it('should throw nice error on unsupported data type', async function({context, server}) {
+it('should throw nice error on unsupported data type', async function({ context, server }) {
   const error = await context._request.post(server.EMPTY_PAGE, {
     headers: {
       'content-type': 'application/json'
@@ -859,7 +859,7 @@ it('should throw nice error on unsupported data type', async function({context, 
   expect(error.message).toContain(`Unexpected 'data' type`);
 });
 
-it('should throw when data passed for unsupported request', async function({context, server}) {
+it('should throw when data passed for unsupported request', async function({ context, server }) {
   const error = await context._request.fetch(server.EMPTY_PAGE, {
     method: 'GET',
     headers: {

--- a/tests/browsercontext-locale.spec.ts
+++ b/tests/browsercontext-locale.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should affect accept-language header', async ({browser, server}) => {
+it('should affect accept-language header', async ({ browser, server }) => {
   const context = await browser.newContext({ locale: 'fr-CH' });
   const page = await context.newPage();
   const [request] = await Promise.all([
@@ -28,14 +28,14 @@ it('should affect accept-language header', async ({browser, server}) => {
   await context.close();
 });
 
-it('should affect navigator.language', async ({browser, server}) => {
+it('should affect navigator.language', async ({ browser, server }) => {
   const context = await browser.newContext({ locale: 'fr-CH' });
   const page = await context.newPage();
   expect(await page.evaluate(() => navigator.language)).toBe('fr-CH');
   await context.close();
 });
 
-it('should format number', async ({browser, server}) => {
+it('should format number', async ({ browser, server }) => {
   {
     const context = await browser.newContext({ locale: 'en-US' });
     const page = await context.newPage();
@@ -52,7 +52,7 @@ it('should format number', async ({browser, server}) => {
   }
 });
 
-it('should format date', async ({browser, server, browserName}) => {
+it('should format date', async ({ browser, server, browserName }) => {
   {
     const context = await browser.newContext({ locale: 'en-US', timezoneId: 'America/Los_Angeles' });
     const page = await context.newPage();
@@ -71,7 +71,7 @@ it('should format date', async ({browser, server, browserName}) => {
   }
 });
 
-it('should format number in popups', async ({browser, server}) => {
+it('should format number in popups', async ({ browser, server }) => {
   const context = await browser.newContext({ locale: 'fr-CH' });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -86,7 +86,7 @@ it('should format number in popups', async ({browser, server}) => {
   await context.close();
 });
 
-it('should affect navigator.language in popups', async ({browser, server}) => {
+it('should affect navigator.language in popups', async ({ browser, server }) => {
   const context = await browser.newContext({ locale: 'fr-CH' });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -100,7 +100,7 @@ it('should affect navigator.language in popups', async ({browser, server}) => {
   await context.close();
 });
 
-it('should work for multiple pages sharing same process', async ({browser, server}) => {
+it('should work for multiple pages sharing same process', async ({ browser, server }) => {
   const context = await browser.newContext({ locale: 'ru-RU' });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -115,7 +115,7 @@ it('should work for multiple pages sharing same process', async ({browser, serve
   await context.close();
 });
 
-it('should be isolated between contexts', async ({browser, server}) => {
+it('should be isolated between contexts', async ({ browser, server }) => {
   const context1 = await browser.newContext({ locale: 'en-US' });
   const promises = [];
   // By default firefox limits number of child web processes to 8.
@@ -138,7 +138,7 @@ it('should be isolated between contexts', async ({browser, server}) => {
   ]);
 });
 
-it('should not change default locale in another context', async ({browser, server}) => {
+it('should not change default locale in another context', async ({ browser, server }) => {
   async function getContextLocale(context) {
     const page = await context.newPage();
     return await page.evaluate(() => (new Intl.NumberFormat()).resolvedOptions().locale);
@@ -152,7 +152,7 @@ it('should not change default locale in another context', async ({browser, serve
   }
   const localeOverride = defaultLocale === 'ru-RU' ? 'de-DE' : 'ru-RU';
   {
-    const context = await browser.newContext({ locale: localeOverride});
+    const context = await browser.newContext({ locale: localeOverride });
     expect(await getContextLocale(context)).toBe(localeOverride);
     await context.close();
   }
@@ -163,13 +163,13 @@ it('should not change default locale in another context', async ({browser, serve
   }
 });
 
-it('should format number in workers', async ({browser, server}) => {
+it('should format number in workers', async ({ browser, server }) => {
   const context = await browser.newContext({ locale: 'ru-RU' });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
   const [worker] = await Promise.all([
     page.waitForEvent('worker'),
-    page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))),
+    page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], { type: 'application/javascript' })))),
   ]);
   expect(await worker.evaluate(() => (10000.20).toLocaleString())).toBe('10\u00A0000,2');
   await context.close();

--- a/tests/browsercontext-network-event.spec.ts
+++ b/tests/browsercontext-network-event.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('BrowserContext.Events.Request', async ({context, server}) => {
+it('BrowserContext.Events.Request', async ({ context, server }) => {
   const page = await context.newPage();
   const requests = [];
   context.on('request', request => requests.push(request));
@@ -36,7 +36,7 @@ it('BrowserContext.Events.Request', async ({context, server}) => {
   ]);
 });
 
-it('BrowserContext.Events.Response', async ({context, server}) => {
+it('BrowserContext.Events.Response', async ({ context, server }) => {
   const page = await context.newPage();
   const responses = [];
   context.on('response', response => responses.push(response));
@@ -55,7 +55,7 @@ it('BrowserContext.Events.Response', async ({context, server}) => {
   ]);
 });
 
-it('BrowserContext.Events.RequestFailed', async ({context, server}) => {
+it('BrowserContext.Events.RequestFailed', async ({ context, server }) => {
   server.setRoute('/one-style.css', (_, res) => {
     res.setHeader('Content-Type', 'text/css');
     res.connection.destroy();
@@ -72,7 +72,7 @@ it('BrowserContext.Events.RequestFailed', async ({context, server}) => {
 });
 
 
-it('BrowserContext.Events.RequestFinished', async ({context, server}) => {
+it('BrowserContext.Events.RequestFinished', async ({ context, server }) => {
   const page = await context.newPage();
   const [response] = await Promise.all([
     page.goto(server.EMPTY_PAGE),
@@ -86,7 +86,7 @@ it('BrowserContext.Events.RequestFinished', async ({context, server}) => {
   expect(request.failure()).toBe(null);
 });
 
-it('should fire events in proper order', async ({context, server}) => {
+it('should fire events in proper order', async ({ context, server }) => {
   const page = await context.newPage();
   const events = [];
   context.on('request', () => events.push('request'));
@@ -103,7 +103,7 @@ it('should fire events in proper order', async ({context, server}) => {
   ]);
 });
 
-it('should not fire events for favicon or favicon redirects', async ({context, page, server, browserName, channel, headless}) => {
+it('should not fire events for favicon or favicon redirects', async ({ context, page, server, browserName, channel, headless }) => {
   it.skip(headless && browserName !== 'firefox', 'headless browsers, except firefox, do not request favicons');
   it.skip(!headless && browserName === 'webkit' && !channel, 'headed webkit does not have a favicon feature');
   const favicon = `/no-cache/favicon.ico`;

--- a/tests/browsercontext-page-event.spec.ts
+++ b/tests/browsercontext-page-event.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should have url', async ({browser, server}) => {
+it('should have url', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   const [otherPage] = await Promise.all([
@@ -28,7 +28,7 @@ it('should have url', async ({browser, server}) => {
   await context.close();
 });
 
-it('should have url after domcontentloaded', async ({browser, server}) => {
+it('should have url after domcontentloaded', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   const [otherPage] = await Promise.all([
@@ -40,7 +40,7 @@ it('should have url after domcontentloaded', async ({browser, server}) => {
   await context.close();
 });
 
-it('should have about:blank url with domcontentloaded', async ({browser, server}) => {
+it('should have about:blank url with domcontentloaded', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   const [otherPage] = await Promise.all([
@@ -52,7 +52,7 @@ it('should have about:blank url with domcontentloaded', async ({browser, server}
   await context.close();
 });
 
-it('should have about:blank for empty url with domcontentloaded', async ({browser, server}) => {
+it('should have about:blank for empty url with domcontentloaded', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   const [otherPage] = await Promise.all([
@@ -64,7 +64,7 @@ it('should have about:blank for empty url with domcontentloaded', async ({browse
   await context.close();
 });
 
-it('should report when a new page is created and closed', async ({browser, server}) => {
+it('should report when a new page is created and closed', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   const [otherPage] = await Promise.all([
@@ -91,7 +91,7 @@ it('should report when a new page is created and closed', async ({browser, serve
   await context.close();
 });
 
-it('should report initialized pages', async ({browser, server}) => {
+it('should report initialized pages', async ({ browser, server }) => {
   const context = await browser.newContext();
   const pagePromise = context.waitForEvent('page');
   context.newPage();
@@ -106,7 +106,7 @@ it('should report initialized pages', async ({browser, server}) => {
   await context.close();
 });
 
-it('should not crash while redirecting of original request was missed', async ({browser, server}) => {
+it('should not crash while redirecting of original request was missed', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   let serverResponse = null;
@@ -126,7 +126,7 @@ it('should not crash while redirecting of original request was missed', async ({
   await context.close();
 });
 
-it('should have an opener', async ({browser, server}) => {
+it('should have an opener', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -140,7 +140,7 @@ it('should have an opener', async ({browser, server}) => {
   await context.close();
 });
 
-it('should fire page lifecycle events', async function({browser, server}) {
+it('should fire page lifecycle events', async function({ browser, server }) {
   const context = await browser.newContext();
   const events = [];
   context.on('page', async page => {
@@ -157,7 +157,7 @@ it('should fire page lifecycle events', async function({browser, server}) {
   await context.close();
 });
 
-it('should work with Shift-clicking', async ({browser, server, browserName}) => {
+it('should work with Shift-clicking', async ({ browser, server, browserName }) => {
   it.fixme(browserName === 'webkit', 'WebKit: Shift+Click does not open a new window.');
 
   const context = await browser.newContext();
@@ -172,7 +172,7 @@ it('should work with Shift-clicking', async ({browser, server, browserName}) => 
   await context.close();
 });
 
-it('should work with Ctrl-clicking', async ({browser, server, isMac, browserName}) => {
+it('should work with Ctrl-clicking', async ({ browser, server, isMac, browserName }) => {
   it.fixme(browserName === 'webkit', 'Ctrl+Click does not open a new tab.');
   it.fixme(browserName === 'firefox', 'Reports an opener in this case.');
 

--- a/tests/browsercontext-pages.spec.ts
+++ b/tests/browsercontext-pages.spec.ts
@@ -18,7 +18,7 @@
 import { browserTest as it, expect } from './config/browserTest';
 import { attachFrame, chromiumVersionLessThan } from './config/utils';
 
-it('should not be visible in context.pages', async ({contextFactory}) => {
+it('should not be visible in context.pages', async ({ contextFactory }) => {
   const context = await contextFactory();
   const page = await context.newPage();
   expect(context.pages()).toContain(page);
@@ -26,7 +26,7 @@ it('should not be visible in context.pages', async ({contextFactory}) => {
   expect(context.pages()).not.toContain(page);
 });
 
-it('page.context should return the correct instance', async function({contextFactory}) {
+it('page.context should return the correct instance', async function({ contextFactory }) {
   const context = await contextFactory();
   const page = await context.newPage();
   expect(page.context()).toBe(context);
@@ -43,7 +43,7 @@ it('frame.focus should work multiple times', async ({ contextFactory }) => {
   }
 });
 
-it('should click with disabled javascript', async ({browser, server}) => {
+it('should click with disabled javascript', async ({ browser, server }) => {
   const context = await browser.newContext({ javaScriptEnabled: false });
   const page = await context.newPage();
   await page.goto(server.PREFIX + '/wrappedlink.html');
@@ -55,7 +55,7 @@ it('should click with disabled javascript', async ({browser, server}) => {
   await context.close();
 });
 
-it('should not hang with touch-enabled viewports', async ({browser, playwright}) => {
+it('should not hang with touch-enabled viewports', async ({ browser, playwright }) => {
   // @see https://github.com/GoogleChrome/puppeteer/issues/161
   const { viewport, hasTouch } = playwright.devices['iPhone 6'];
   const context = await browser.newContext({ viewport, hasTouch });
@@ -66,7 +66,7 @@ it('should not hang with touch-enabled viewports', async ({browser, playwright})
   await context.close();
 });
 
-it('should click the button with deviceScaleFactor set', async ({browser, server}) => {
+it('should click the button with deviceScaleFactor set', async ({ browser, server }) => {
   const context = await browser.newContext({ viewport: { width: 400, height: 400 }, deviceScaleFactor: 5 });
   const page = await context.newPage();
   expect(await page.evaluate(() => window.devicePixelRatio)).toBe(5);
@@ -79,7 +79,7 @@ it('should click the button with deviceScaleFactor set', async ({browser, server
   await context.close();
 });
 
-it('should click the button with offset with page scale', async ({browser, server, headless, browserName, browserVersion}) => {
+it('should click the button with offset with page scale', async ({ browser, server, headless, browserName, browserVersion }) => {
   it.skip(browserName === 'firefox');
 
   const context = await browser.newContext({ viewport: { width: 400, height: 400 }, isMobile: true });
@@ -131,7 +131,7 @@ it('should return bounding box with page scale', async ({ browser, server, brows
   await context.close();
 });
 
-it('should not leak listeners during navigation of 20 pages', async ({contextFactory, server}) => {
+it('should not leak listeners during navigation of 20 pages', async ({ contextFactory, server }) => {
   it.slow(true, 'We open 20 pages here!');
 
   const context = await contextFactory();

--- a/tests/browsercontext-proxy.spec.ts
+++ b/tests/browsercontext-proxy.spec.ts
@@ -40,7 +40,7 @@ it('should throw for missing global proxy on Chromium Windows', async ({ browser
   }
 });
 
-it('should work when passing the proxy only on the context level', async ({browserName, platform, browserType, browserOptions, contextOptions, server, proxyServer}) => {
+it('should work when passing the proxy only on the context level', async ({ browserName, platform, browserType, browserOptions, contextOptions, server, proxyServer }) => {
   // Currently an upstream bug in the network stack of Chromium which leads that
   // the wrong proxy gets used in the BrowserContext.
   it.fixme(browserName === 'chromium' && platform === 'win32');
@@ -100,7 +100,7 @@ it('should use proxy twice', async ({ contextFactory, server, proxyServer }) => 
   await context.close();
 });
 
-it('should use proxy for second page', async ({contextFactory, server, proxyServer}) => {
+it('should use proxy for second page', async ({ contextFactory, server, proxyServer }) => {
   proxyServer.forwardTo(server.PORT);
   const context = await contextFactory({
     proxy: { server: `localhost:${proxyServer.PORT}` }
@@ -136,7 +136,7 @@ it('should use proxy for https urls', async ({ contextFactory, server, httpsServ
   await context.close();
 });
 
-it('should work with IP:PORT notion', async ({contextFactory, server, proxyServer}) => {
+it('should work with IP:PORT notion', async ({ contextFactory, server, proxyServer }) => {
   proxyServer.forwardTo(server.PORT);
   const context = await contextFactory({
     proxy: { server: `127.0.0.1:${proxyServer.PORT}` }
@@ -148,21 +148,21 @@ it('should work with IP:PORT notion', async ({contextFactory, server, proxyServe
   await context.close();
 });
 
-it('should throw for socks5 authentication', async ({contextFactory}) => {
+it('should throw for socks5 authentication', async ({ contextFactory }) => {
   const error = await contextFactory({
     proxy: { server: `socks5://localhost:1234`, username: 'user', password: 'secret' }
   }).catch(e => e);
   expect(error.message).toContain('Browser does not support socks5 proxy authentication');
 });
 
-it('should throw for socks4 authentication', async ({contextFactory}) => {
+it('should throw for socks4 authentication', async ({ contextFactory }) => {
   const error = await contextFactory({
     proxy: { server: `socks4://localhost:1234`, username: 'user', password: 'secret' }
   }).catch(e => e);
   expect(error.message).toContain('Socks4 proxy protocol does not support authentication');
 });
 
-it('should authenticate', async ({contextFactory, server, proxyServer}) => {
+it('should authenticate', async ({ contextFactory, server, proxyServer }) => {
   proxyServer.forwardTo(server.PORT);
   let auth;
   proxyServer.setAuthHandler(req => {
@@ -180,7 +180,7 @@ it('should authenticate', async ({contextFactory, server, proxyServer}) => {
   await context.close();
 });
 
-it('should authenticate with empty password', async ({contextFactory, server, proxyServer}) => {
+it('should authenticate with empty password', async ({ contextFactory, server, proxyServer }) => {
   proxyServer.forwardTo(server.PORT);
   let auth;
   proxyServer.setAuthHandler(req => {
@@ -197,7 +197,7 @@ it('should authenticate with empty password', async ({contextFactory, server, pr
   await context.close();
 });
 
-it('should isolate proxy credentials between contexts', async ({contextFactory, server, browserName, proxyServer}) => {
+it('should isolate proxy credentials between contexts', async ({ contextFactory, server, browserName, proxyServer }) => {
   it.fixme(browserName === 'firefox', 'Credentials from the first context stick around');
 
   proxyServer.forwardTo(server.PORT);
@@ -229,7 +229,7 @@ it('should isolate proxy credentials between contexts', async ({contextFactory, 
   }
 });
 
-it('should exclude patterns', async ({contextFactory, server, browserName, headless, proxyServer}) => {
+it('should exclude patterns', async ({ contextFactory, server, browserName, headless, proxyServer }) => {
   it.fixme(browserName === 'chromium' && !headless, 'Chromium headed crashes with CHECK(!in_frame_tree_) in RenderFrameImpl::OnDeleteFrame.');
 
   proxyServer.forwardTo(server.PORT);

--- a/tests/browsercontext-route.spec.ts
+++ b/tests/browsercontext-route.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should intercept', async ({browser, server}) => {
+it('should intercept', async ({ browser, server }) => {
   const context = await browser.newContext();
   let intercepted = false;
   await context.route('**/empty.html', route => {
@@ -40,7 +40,7 @@ it('should intercept', async ({browser, server}) => {
   await context.close();
 });
 
-it('should unroute', async ({browser, server}) => {
+it('should unroute', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
 
@@ -78,7 +78,7 @@ it('should unroute', async ({browser, server}) => {
   await context.close();
 });
 
-it('should yield to page.route', async ({browser, server}) => {
+it('should yield to page.route', async ({ browser, server }) => {
   const context = await browser.newContext();
   await context.route('**/empty.html', route => {
     route.fulfill({ status: 200, body: 'context' });
@@ -93,7 +93,7 @@ it('should yield to page.route', async ({browser, server}) => {
   await context.close();
 });
 
-it('should fall back to context.route', async ({browser, server}) => {
+it('should fall back to context.route', async ({ browser, server }) => {
   const context = await browser.newContext();
   await context.route('**/empty.html', route => {
     route.fulfill({ status: 200, body: 'context' });
@@ -108,7 +108,7 @@ it('should fall back to context.route', async ({browser, server}) => {
   await context.close();
 });
 
-it('should support Set-Cookie header', async ({contextFactory, server, browserName}) => {
+it('should support Set-Cookie header', async ({ contextFactory, server, browserName }) => {
   it.fixme(browserName === 'webkit');
 
   const context = await contextFactory();
@@ -135,7 +135,7 @@ it('should support Set-Cookie header', async ({contextFactory, server, browserNa
   }]);
 });
 
-it('should ignore secure Set-Cookie header for insecure requests', async ({contextFactory, server, browserName}) => {
+it('should ignore secure Set-Cookie header for insecure requests', async ({ contextFactory, server, browserName }) => {
   it.fixme(browserName === 'webkit');
 
   const context = await contextFactory();
@@ -153,7 +153,7 @@ it('should ignore secure Set-Cookie header for insecure requests', async ({conte
   expect(await context.cookies()).toEqual([]);
 });
 
-it('should use Set-Cookie header in future requests', async ({contextFactory, server, browserName}) => {
+it('should use Set-Cookie header in future requests', async ({ contextFactory, server, browserName }) => {
   it.fixme(browserName === 'webkit');
 
   const context = await contextFactory();
@@ -189,7 +189,7 @@ it('should use Set-Cookie header in future requests', async ({contextFactory, se
   expect(cookie).toBe('name=value');
 });
 
-it('should work with ignoreHTTPSErrors', async ({browser, httpsServer}) => {
+it('should work with ignoreHTTPSErrors', async ({ browser, httpsServer }) => {
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
 
@@ -199,12 +199,12 @@ it('should work with ignoreHTTPSErrors', async ({browser, httpsServer}) => {
   await context.close();
 });
 
-it('should support the times parameter with route matching', async ({context, page, server}) => {
+it('should support the times parameter with route matching', async ({ context, page, server }) => {
   const intercepted = [];
   await context.route('**/empty.html', route => {
     intercepted.push(1);
     route.continue();
-  }, { times: 1});
+  }, { times: 1 });
   await page.goto(server.EMPTY_PAGE);
   await page.goto(server.EMPTY_PAGE);
   await page.goto(server.EMPTY_PAGE);

--- a/tests/browsercontext-set-extra-http-headers.spec.ts
+++ b/tests/browsercontext-set-extra-http-headers.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should override extra headers from browser context', async ({browser, server}) => {
+it('should override extra headers from browser context', async ({ browser, server }) => {
   const context = await browser.newContext({
     extraHTTPHeaders: { 'fOo': 'bAr', 'baR': 'foO' },
   });
@@ -34,7 +34,7 @@ it('should override extra headers from browser context', async ({browser, server
   expect(request.headers['bar']).toBe('foO');
 });
 
-it('should throw for non-string header values', async ({browser}) => {
+it('should throw for non-string header values', async ({ browser }) => {
   const error3 = await browser.newContext({ extraHTTPHeaders: { 'foo': null } }).catch(e => e);
   expect(error3.message).toContain('Expected value of header "foo" to be String, but "object" is found.');
 });

--- a/tests/browsercontext-timezone-id.spec.ts
+++ b/tests/browsercontext-timezone-id.spec.ts
@@ -45,7 +45,7 @@ it('should work', async ({ browser, browserName }) => {
   }
 });
 
-it('should throw for invalid timezone IDs when creating pages', async ({browser}) => {
+it('should throw for invalid timezone IDs when creating pages', async ({ browser }) => {
   for (const timezoneId of ['Foo/Bar', 'Baz/Qux']) {
     let error = null;
     const context = await browser.newContext({ timezoneId });
@@ -55,7 +55,7 @@ it('should throw for invalid timezone IDs when creating pages', async ({browser}
   }
 });
 
-it('should work for multiple pages sharing same process', async ({browser, server}) => {
+it('should work for multiple pages sharing same process', async ({ browser, server }) => {
   const context = await browser.newContext({ timezoneId: 'Europe/Moscow' });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -70,7 +70,7 @@ it('should work for multiple pages sharing same process', async ({browser, serve
   await context.close();
 });
 
-it('should not change default timezone in another context', async ({browser, server}) => {
+it('should not change default timezone in another context', async ({ browser, server }) => {
   async function getContextTimezone(context) {
     const page = await context.newPage();
     return await page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone);
@@ -84,7 +84,7 @@ it('should not change default timezone in another context', async ({browser, ser
   }
   const timezoneOverride = defaultTimezone === 'Europe/Moscow' ? 'America/Los_Angeles' : 'Europe/Moscow';
   {
-    const context = await browser.newContext({ timezoneId: timezoneOverride});
+    const context = await browser.newContext({ timezoneId: timezoneOverride });
     expect(await getContextTimezone(context)).toBe(timezoneOverride);
     await context.close();
   }

--- a/tests/browsercontext-user-agent.spec.ts
+++ b/tests/browsercontext-user-agent.spec.ts
@@ -18,7 +18,7 @@
 import { browserTest as it, expect } from './config/browserTest';
 import { attachFrame } from './config/utils';
 
-it('should work', async ({browser, server}) => {
+it('should work', async ({ browser, server }) => {
   {
     const context = await browser.newContext();
     const page = await context.newPage();
@@ -37,7 +37,7 @@ it('should work', async ({browser, server}) => {
   }
 });
 
-it('should work for subframes', async ({browser, server}) => {
+it('should work for subframes', async ({ browser, server }) => {
   {
     const context = await browser.newContext();
     const page = await context.newPage();
@@ -56,7 +56,7 @@ it('should work for subframes', async ({browser, server}) => {
   }
 });
 
-it('should emulate device user-agent', async ({browser, server, playwright}) => {
+it('should emulate device user-agent', async ({ browser, server, playwright }) => {
   {
     const context = await browser.newContext();
     const page = await context.newPage();
@@ -73,7 +73,7 @@ it('should emulate device user-agent', async ({browser, server, playwright}) => 
   }
 });
 
-it('should make a copy of default options', async ({browser, server}) => {
+it('should make a copy of default options', async ({ browser, server }) => {
   const options = { userAgent: 'foobar' };
   const context = await browser.newContext(options);
   options.userAgent = 'wrong';

--- a/tests/browsercontext-viewport-mobile.spec.ts
+++ b/tests/browsercontext-viewport-mobile.spec.ts
@@ -20,18 +20,18 @@ import { browserTest as it, expect } from './config/browserTest';
 it.describe('mobile viewport', () => {
   it.skip(({ browserName }) => browserName === 'firefox');
 
-  it('should support mobile emulation', async ({playwright, browser, server}) => {
+  it('should support mobile emulation', async ({ playwright, browser, server }) => {
     const iPhone = playwright.devices['iPhone 6'];
     const context = await browser.newContext({ ...iPhone });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/mobile.html');
     expect(await page.evaluate(() => window.innerWidth)).toBe(375);
-    await page.setViewportSize({width: 400, height: 300});
+    await page.setViewportSize({ width: 400, height: 300 });
     expect(await page.evaluate(() => window.innerWidth)).toBe(400);
     await context.close();
   });
 
-  it('should support touch emulation', async ({playwright, browser, server}) => {
+  it('should support touch emulation', async ({ playwright, browser, server }) => {
     const iPhone = playwright.devices['iPhone 6'];
     const context = await browser.newContext({ ...iPhone });
     const page = await context.newPage();
@@ -54,7 +54,7 @@ it.describe('mobile viewport', () => {
     }
   });
 
-  it('should be detectable by Modernizr', async ({playwright, browser, server}) => {
+  it('should be detectable by Modernizr', async ({ playwright, browser, server }) => {
     const iPhone = playwright.devices['iPhone 6'];
     const context = await browser.newContext({ ...iPhone });
     const page = await context.newPage();
@@ -63,16 +63,16 @@ it.describe('mobile viewport', () => {
     await context.close();
   });
 
-  it('should detect touch when applying viewport with touches', async ({browser, server}) => {
+  it('should detect touch when applying viewport with touches', async ({ browser, server }) => {
     const context = await browser.newContext({ viewport: { width: 800, height: 600 }, hasTouch: true });
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
-    await page.addScriptTag({url: server.PREFIX + '/modernizr.js'});
+    await page.addScriptTag({ url: server.PREFIX + '/modernizr.js' });
     expect(await page.evaluate(() => window['Modernizr'].touchevents)).toBe(true);
     await context.close();
   });
 
-  it('should support landscape emulation', async ({playwright, browser, server}) => {
+  it('should support landscape emulation', async ({ playwright, browser, server }) => {
     const iPhone = playwright.devices['iPhone 6'];
     const iPhoneLandscape = playwright.devices['iPhone 6 landscape'];
     const context1 = await browser.newContext({ ...iPhone });
@@ -86,17 +86,17 @@ it.describe('mobile viewport', () => {
     await context2.close();
   });
 
-  it('should support window.orientation emulation', async ({browser, server}) => {
+  it('should support window.orientation emulation', async ({ browser, server }) => {
     const context = await browser.newContext({ viewport: { width: 300, height: 400 }, isMobile: true });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/mobile.html');
     expect(await page.evaluate(() => window.orientation)).toBe(0);
-    await page.setViewportSize({width: 400, height: 300});
+    await page.setViewportSize({ width: 400, height: 300 });
     expect(await page.evaluate(() => window.orientation)).toBe(90);
     await context.close();
   });
 
-  it('should fire orientationchange event', async ({browser, server}) => {
+  it('should fire orientationchange event', async ({ browser, server }) => {
     const context = await browser.newContext({ viewport: { width: 300, height: 400 }, isMobile: true });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/mobile.html');
@@ -106,32 +106,32 @@ it.describe('mobile viewport', () => {
     });
 
     const event1 = page.waitForEvent('console');
-    await page.setViewportSize({width: 400, height: 300});
+    await page.setViewportSize({ width: 400, height: 300 });
     expect((await event1).text()).toBe('1');
 
     const event2 = page.waitForEvent('console');
-    await page.setViewportSize({width: 300, height: 400});
+    await page.setViewportSize({ width: 300, height: 400 });
     expect((await event2).text()).toBe('2');
     await context.close();
   });
 
-  it('default mobile viewports to 980 width', async ({browser, server}) => {
-    const context = await browser.newContext({ viewport: {width: 320, height: 480 }, isMobile: true });
+  it('default mobile viewports to 980 width', async ({ browser, server }) => {
+    const context = await browser.newContext({ viewport: { width: 320, height: 480 }, isMobile: true });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/empty.html');
     expect(await page.evaluate(() => window.innerWidth)).toBe(980);
     await context.close();
   });
 
-  it('respect meta viewport tag', async ({browser, server}) => {
-    const context = await browser.newContext({ viewport: {width: 320, height: 480 }, isMobile: true });
+  it('respect meta viewport tag', async ({ browser, server }) => {
+    const context = await browser.newContext({ viewport: { width: 320, height: 480 }, isMobile: true });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/mobile.html');
     expect(await page.evaluate(() => window.innerWidth)).toBe(320);
     await context.close();
   });
 
-  it('should emulate the hover media feature', async ({playwright, browser}) => {
+  it('should emulate the hover media feature', async ({ playwright, browser }) => {
     const iPhone = playwright.devices['iPhone 6'];
     const mobilepage = await browser.newPage({ ...iPhone });
     expect(await mobilepage.evaluate(() => matchMedia('(hover: hover)').matches)).toBe(false);
@@ -156,21 +156,21 @@ it.describe('mobile viewport', () => {
     await desktopPage.close();
   });
 
-  it('mouse should work with mobile viewports and cross process navigations', async ({browser, server, browserName}) => {
+  it('mouse should work with mobile viewports and cross process navigations', async ({ browser, server, browserName }) => {
     // @see https://crbug.com/929806
-    const context = await browser.newContext({ viewport: {width: 360, height: 640}, isMobile: true });
+    const context = await browser.newContext({ viewport: { width: 360, height: 640 }, isMobile: true });
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
     await page.goto(server.CROSS_PROCESS_PREFIX + '/mobile.html');
     await page.evaluate(() => {
       document.addEventListener('click', event => {
-        window['result'] = {x: event.clientX, y: event.clientY};
+        window['result'] = { x: event.clientX, y: event.clientY };
       });
     });
 
     await page.mouse.click(30, 40);
 
-    expect(await page.evaluate('result')).toEqual({x: 30, y: 40});
+    expect(await page.evaluate('result')).toEqual({ x: 30, y: 40 });
     await context.close();
   });
 });

--- a/tests/browsercontext-viewport.spec.ts
+++ b/tests/browsercontext-viewport.spec.ts
@@ -19,17 +19,17 @@ import { contextTest as it, expect } from './config/browserTest';
 import { browserTest } from './config/browserTest';
 import { verifyViewport } from './config/utils';
 
-it('should get the proper default viewport size', async ({page, server}) => {
+it('should get the proper default viewport size', async ({ page, server }) => {
   await verifyViewport(page, 1280, 720);
 });
 
-it('should set the proper viewport size', async ({page, server}) => {
+it('should set the proper viewport size', async ({ page, server }) => {
   await verifyViewport(page, 1280, 720);
-  await page.setViewportSize({width: 123, height: 456});
+  await page.setViewportSize({ width: 123, height: 456 });
   await verifyViewport(page, 123, 456);
 });
 
-it('should return correct outerWidth and outerHeight', async ({page}) => {
+it('should return correct outerWidth and outerHeight', async ({ page }) => {
   const size = await page.evaluate(() => {
     return {
       innerWidth: window.innerWidth,
@@ -44,9 +44,9 @@ it('should return correct outerWidth and outerHeight', async ({page}) => {
   expect(size.outerHeight >= size.innerHeight).toBeTruthy();
 });
 
-it('should emulate device width', async ({page, server}) => {
-  expect(page.viewportSize()).toEqual({width: 1280, height: 720});
-  await page.setViewportSize({width: 200, height: 200});
+it('should emulate device width', async ({ page, server }) => {
+  expect(page.viewportSize()).toEqual({ width: 1280, height: 720 });
+  await page.setViewportSize({ width: 200, height: 200 });
   expect(await page.evaluate(() => window.screen.width)).toBe(200);
   expect(await page.evaluate(() => matchMedia('(min-device-width: 100px)').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('(min-device-width: 300px)').matches)).toBe(false);
@@ -54,7 +54,7 @@ it('should emulate device width', async ({page, server}) => {
   expect(await page.evaluate(() => matchMedia('(max-device-width: 300px)').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('(device-width: 500px)').matches)).toBe(false);
   expect(await page.evaluate(() => matchMedia('(device-width: 200px)').matches)).toBe(true);
-  await page.setViewportSize({width: 500, height: 500});
+  await page.setViewportSize({ width: 500, height: 500 });
   expect(await page.evaluate(() => window.screen.width)).toBe(500);
   expect(await page.evaluate(() => matchMedia('(min-device-width: 400px)').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('(min-device-width: 600px)').matches)).toBe(false);
@@ -64,9 +64,9 @@ it('should emulate device width', async ({page, server}) => {
   expect(await page.evaluate(() => matchMedia('(device-width: 500px)').matches)).toBe(true);
 });
 
-it('should emulate device height', async ({page, server}) => {
-  expect(page.viewportSize()).toEqual({width: 1280, height: 720});
-  await page.setViewportSize({width: 200, height: 200});
+it('should emulate device height', async ({ page, server }) => {
+  expect(page.viewportSize()).toEqual({ width: 1280, height: 720 });
+  await page.setViewportSize({ width: 200, height: 200 });
   expect(await page.evaluate(() => window.screen.height)).toBe(200);
   expect(await page.evaluate(() => matchMedia('(min-device-height: 100px)').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('(min-device-height: 300px)').matches)).toBe(false);
@@ -74,7 +74,7 @@ it('should emulate device height', async ({page, server}) => {
   expect(await page.evaluate(() => matchMedia('(max-device-height: 300px)').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('(device-height: 500px)').matches)).toBe(false);
   expect(await page.evaluate(() => matchMedia('(device-height: 200px)').matches)).toBe(true);
-  await page.setViewportSize({width: 500, height: 500});
+  await page.setViewportSize({ width: 500, height: 500 });
   expect(await page.evaluate(() => window.screen.height)).toBe(500);
   expect(await page.evaluate(() => matchMedia('(min-device-height: 400px)').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('(min-device-height: 600px)').matches)).toBe(false);
@@ -84,20 +84,20 @@ it('should emulate device height', async ({page, server}) => {
   expect(await page.evaluate(() => matchMedia('(device-height: 500px)').matches)).toBe(true);
 });
 
-it('should emulate availWidth and availHeight', async ({page}) => {
-  await page.setViewportSize({width: 500, height: 600});
+it('should emulate availWidth and availHeight', async ({ page }) => {
+  await page.setViewportSize({ width: 500, height: 600 });
   expect(await page.evaluate(() => window.screen.availWidth)).toBe(500);
   expect(await page.evaluate(() => window.screen.availHeight)).toBe(600);
 });
 
-it('should not have touch by default', async ({page, server}) => {
+it('should not have touch by default', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/mobile.html');
   expect(await page.evaluate(() => 'ontouchstart' in window)).toBe(false);
   await page.goto(server.PREFIX + '/detect-touch.html');
   expect(await page.evaluate(() => document.body.textContent.trim())).toBe('NO');
 });
 
-browserTest('should support touch with null viewport', async ({browser, server}) => {
+browserTest('should support touch with null viewport', async ({ browser, server }) => {
   const context = await browser.newContext({ viewport: null, hasTouch: true });
   const page = await context.newPage();
   await page.goto(server.PREFIX + '/mobile.html');
@@ -105,14 +105,14 @@ browserTest('should support touch with null viewport', async ({browser, server})
   await context.close();
 });
 
-browserTest('should report null viewportSize when given null viewport', async ({browser, server}) => {
+browserTest('should report null viewportSize when given null viewport', async ({ browser, server }) => {
   const context = await browser.newContext({ viewport: null });
   const page = await context.newPage();
   expect(page.viewportSize()).toBe(null);
   await context.close();
 });
 
-browserTest('should drag with high dpi', async ({ browser, server}) => {
+browserTest('should drag with high dpi', async ({ browser, server }) => {
   const page = await browser.newPage({ deviceScaleFactor: 2 });
   await page.goto(server.PREFIX + '/drag-n-drop.html');
   await page.hover('#source');

--- a/tests/browsertype-basic.spec.ts
+++ b/tests/browsertype-basic.spec.ts
@@ -26,13 +26,13 @@ test('browserType.executablePath should work', async ({ browserType, channel, br
   expect(fs.existsSync(executablePath)).toBe(true);
 });
 
-test('browserType.name should work', async ({browserType, browserName}) => {
+test('browserType.name should work', async ({ browserType, browserName }) => {
   expect(browserType.name()).toBe(browserName);
 });
 
 test('should throw when trying to connect with not-chromium', async ({ browserType, browserName }) => {
   test.skip(browserName === 'chromium');
 
-  const error = await browserType.connectOverCDP({endpointURL: 'ws://foo'}).catch(e => e);
+  const error = await browserType.connectOverCDP({ endpointURL: 'ws://foo' }).catch(e => e);
   expect(error.message).toBe('Connecting over CDP is only supported in Chromium.');
 });

--- a/tests/browsertype-connect.spec.ts
+++ b/tests/browsertype-connect.spec.ts
@@ -24,7 +24,7 @@ import { suppressCertificateWarning } from './config/utils';
 
 test.slow(true, 'All connect tests are slow');
 
-test('should connect over wss', async ({browserType , startRemoteServer, httpsServer, mode}) => {
+test('should connect over wss', async ({ browserType , startRemoteServer, httpsServer, mode }) => {
   test.skip(mode !== 'default'); // Out of process transport does not allow us to set env vars dynamically.
   const remoteServer = await startRemoteServer();
 
@@ -60,7 +60,7 @@ test('should connect over wss', async ({browserType , startRemoteServer, httpsSe
   }
 });
 
-test('should be able to reconnect to a browser', async ({browserType, startRemoteServer, server}) => {
+test('should be able to reconnect to a browser', async ({ browserType, startRemoteServer, server }) => {
   const remoteServer = await startRemoteServer();
   {
     const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
@@ -80,7 +80,7 @@ test('should be able to reconnect to a browser', async ({browserType, startRemot
   }
 });
 
-test('should be able to connect two browsers at the same time', async ({browserType, startRemoteServer}) => {
+test('should be able to connect two browsers at the same time', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
 
   const browser1 = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
@@ -102,7 +102,7 @@ test('should be able to connect two browsers at the same time', async ({browserT
   await browser2.close();
 });
 
-test('should timeout in socket while connecting', async ({browserType, startRemoteServer, server}) => {
+test('should timeout in socket while connecting', async ({ browserType, startRemoteServer, server }) => {
   const e = await browserType.connect({
     wsEndpoint: `ws://localhost:${server.PORT}/ws-slow`,
     timeout: 1000,
@@ -110,7 +110,7 @@ test('should timeout in socket while connecting', async ({browserType, startRemo
   expect(e.message).toContain('browserType.connect: Opening handshake has timed out');
 });
 
-test('should timeout in connect while connecting', async ({browserType, startRemoteServer, server}) => {
+test('should timeout in connect while connecting', async ({ browserType, startRemoteServer, server }) => {
   const e = await browserType.connect({
     wsEndpoint: `ws://localhost:${server.PORT}/ws`,
     timeout: 100,
@@ -118,7 +118,7 @@ test('should timeout in connect while connecting', async ({browserType, startRem
   expect(e.message).toContain('browserType.connect: Timeout 100ms exceeded');
 });
 
-test('should send extra headers with connect request', async ({browserType, startRemoteServer, server}) => {
+test('should send extra headers with connect request', async ({ browserType, startRemoteServer, server }) => {
   const [request] = await Promise.all([
     server.waitForWebSocketConnectionRequest(),
     browserType.connect({
@@ -134,7 +134,7 @@ test('should send extra headers with connect request', async ({browserType, star
   expect(request.headers['foo']).toBe('bar');
 });
 
-test('should send default User-Agent header with connect request', async ({browserType, startRemoteServer, server}) => {
+test('should send default User-Agent header with connect request', async ({ browserType, startRemoteServer, server }) => {
   const [request] = await Promise.all([
     server.waitForWebSocketConnectionRequest(),
     browserType.connect({
@@ -149,7 +149,7 @@ test('should send default User-Agent header with connect request', async ({brows
   expect(request.headers['foo']).toBe('bar');
 });
 
-test('should support slowmo option', async ({browserType, startRemoteServer}) => {
+test('should support slowmo option', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
 
   const browser1 = await browserType.connect(remoteServer.wsEndpoint(), { slowMo: 200 });
@@ -159,7 +159,7 @@ test('should support slowmo option', async ({browserType, startRemoteServer}) =>
   expect(Date.now() - start).toBeGreaterThan(199);
 });
 
-test('disconnected event should be emitted when browser is closed or server is closed', async ({browserType, startRemoteServer}) => {
+test('disconnected event should be emitted when browser is closed or server is closed', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
 
   const browser1 = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
@@ -188,7 +188,7 @@ test('disconnected event should be emitted when browser is closed or server is c
   expect(disconnected2).toBe(1);
 });
 
-test('disconnected event should have browser as argument', async ({browserType, startRemoteServer}) => {
+test('disconnected event should have browser as argument', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const [disconnected] = await Promise.all([
@@ -198,7 +198,7 @@ test('disconnected event should have browser as argument', async ({browserType, 
   expect(disconnected).toBe(browser);
 });
 
-test('should handle exceptions during connect', async ({browserType, startRemoteServer, mode}) => {
+test('should handle exceptions during connect', async ({ browserType, startRemoteServer, mode }) => {
   test.skip(mode !== 'default');
 
   const remoteServer = await startRemoteServer();
@@ -207,7 +207,7 @@ test('should handle exceptions during connect', async ({browserType, startRemote
   expect(error.message).toContain('Dummy');
 });
 
-test('should set the browser connected state', async ({browserType, startRemoteServer}) => {
+test('should set the browser connected state', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
   const remote = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   expect(remote.isConnected()).toBe(true);
@@ -215,7 +215,7 @@ test('should set the browser connected state', async ({browserType, startRemoteS
   expect(remote.isConnected()).toBe(false);
 });
 
-test('should throw when used after isConnected returns false', async ({browserType, startRemoteServer}) => {
+test('should throw when used after isConnected returns false', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const page = await browser.newPage();
@@ -228,7 +228,7 @@ test('should throw when used after isConnected returns false', async ({browserTy
   expect(error.message).toContain('has been closed');
 });
 
-test('should throw when calling waitForNavigation after disconnect', async ({browserType, startRemoteServer}) => {
+test('should throw when calling waitForNavigation after disconnect', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const page = await browser.newPage();
@@ -241,19 +241,19 @@ test('should throw when calling waitForNavigation after disconnect', async ({bro
   expect(error.message).toContain('Navigation failed because page was closed');
 });
 
-test('should reject navigation when browser closes', async ({browserType, startRemoteServer, server}) => {
+test('should reject navigation when browser closes', async ({ browserType, startRemoteServer, server }) => {
   const remoteServer = await startRemoteServer();
   server.setRoute('/one-style.css', () => {});
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const page = await browser.newPage();
-  const navigationPromise = page.goto(server.PREFIX + '/one-style.html', {timeout: 60000}).catch(e => e);
+  const navigationPromise = page.goto(server.PREFIX + '/one-style.html', { timeout: 60000 }).catch(e => e);
   await server.waitForRequest('/one-style.css');
   await browser.close();
   const error = await navigationPromise;
   expect(error.message).toContain('has been closed');
 });
 
-test('should reject waitForSelector when browser closes', async ({browserType, startRemoteServer, server}) => {
+test('should reject waitForSelector when browser closes', async ({ browserType, startRemoteServer, server }) => {
   const remoteServer = await startRemoteServer();
   server.setRoute('/empty.html', () => {});
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
@@ -268,7 +268,7 @@ test('should reject waitForSelector when browser closes', async ({browserType, s
   expect(error.message).toContain('has been closed');
 });
 
-test('should emit close events on pages and contexts', async ({browserType, startRemoteServer}) => {
+test('should emit close events on pages and contexts', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const context = await browser.newContext();
@@ -282,7 +282,7 @@ test('should emit close events on pages and contexts', async ({browserType, star
   expect(pageClosed).toBeTruthy();
 });
 
-test('should terminate network waiters', async ({browserType, startRemoteServer, server}) => {
+test('should terminate network waiters', async ({ browserType, startRemoteServer, server }) => {
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const newPage = await browser.newPage();
@@ -339,7 +339,7 @@ test('should respect selectors', async ({ playwright, browserType, startRemoteSe
   await browser1.close();
 });
 
-test('should not throw on close after disconnect', async ({browserType, startRemoteServer}) => {
+test('should not throw on close after disconnect', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   await browser.newPage();
@@ -350,7 +350,7 @@ test('should not throw on close after disconnect', async ({browserType, startRem
   await browser.close();
 });
 
-test('should not throw on context.close after disconnect', async ({browserType, startRemoteServer}) => {
+test('should not throw on context.close after disconnect', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const context = await browser.newContext();
@@ -362,7 +362,7 @@ test('should not throw on context.close after disconnect', async ({browserType, 
   await context.close();
 });
 
-test('should not throw on page.close after disconnect', async ({browserType, startRemoteServer}) => {
+test('should not throw on page.close after disconnect', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const page = await browser.newPage();
@@ -373,7 +373,7 @@ test('should not throw on page.close after disconnect', async ({browserType, sta
   await page.close();
 });
 
-test('should saveAs videos from remote browser', async ({browserType, startRemoteServer}, testInfo) => {
+test('should saveAs videos from remote browser', async ({ browserType, startRemoteServer }, testInfo) => {
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const videosPath = testInfo.outputPath();
@@ -392,7 +392,7 @@ test('should saveAs videos from remote browser', async ({browserType, startRemot
   expect(error.message).toContain('Path is not available when using browserType.connect(). Use saveAs() to save a local copy.');
 });
 
-test('should be able to connect 20 times to a single server without warnings', async ({browserType, startRemoteServer}) => {
+test('should be able to connect 20 times to a single server without warnings', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
 
   let warning = null;
@@ -408,7 +408,7 @@ test('should be able to connect 20 times to a single server without warnings', a
   expect(warning).toBe(null);
 });
 
-test('should save download', async ({server, browserType, startRemoteServer}, testInfo) => {
+test('should save download', async ({ server, browserType, startRemoteServer }, testInfo) => {
   server.setRoute('/download', (req, res) => {
     res.setHeader('Content-Type', 'application/octet-stream');
     res.setHeader('Content-Disposition', 'attachment');
@@ -432,7 +432,7 @@ test('should save download', async ({server, browserType, startRemoteServer}, te
   await browser.close();
 });
 
-test('should error when saving download after deletion', async ({server, browserType, startRemoteServer}, testInfo) => {
+test('should error when saving download after deletion', async ({ server, browserType, startRemoteServer }, testInfo) => {
   server.setRoute('/download', (req, res) => {
     res.setHeader('Content-Type', 'application/octet-stream');
     res.setHeader('Content-Disposition', 'attachment');
@@ -454,19 +454,19 @@ test('should error when saving download after deletion', async ({server, browser
   await browser.close();
 });
 
-test('should work with cluster', async ({browserType, startRemoteServer}) => {
+test('should work with cluster', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer({ inCluster: true });
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const page = await browser.newPage();
   expect(await page.evaluate('1 + 2')).toBe(3);
 });
 
-test('should properly disconnect when connection closes from the client side', async ({browserType, startRemoteServer, server}) => {
+test('should properly disconnect when connection closes from the client side', async ({ browserType, startRemoteServer, server }) => {
   server.setRoute('/one-style.css', () => {});
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const page = await browser.newPage();
-  const navigationPromise = page.goto(server.PREFIX + '/one-style.html', {timeout: 60000}).catch(e => e);
+  const navigationPromise = page.goto(server.PREFIX + '/one-style.html', { timeout: 60000 }).catch(e => e);
   const waitForNavigationPromise = page.waitForNavigation().catch(e => e);
 
   const disconnectedPromise = new Promise(f => browser.once('disconnected', f));
@@ -481,14 +481,14 @@ test('should properly disconnect when connection closes from the client side', a
   expect((await page.waitForNavigation().catch(e => e)).message).toContain('Navigation failed because page was closed');
 });
 
-test('should properly disconnect when connection closes from the server side', async ({browserType, startRemoteServer, server, platform}) => {
+test('should properly disconnect when connection closes from the server side', async ({ browserType, startRemoteServer, server, platform }) => {
   test.skip(platform === 'win32', 'Cannot send signals');
 
   server.setRoute('/one-style.css', () => {});
   const remoteServer = await startRemoteServer({ disconnectOnSIGHUP: true });
   const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
   const page = await browser.newPage();
-  const navigationPromise = page.goto(server.PREFIX + '/one-style.html', {timeout: 60000}).catch(e => e);
+  const navigationPromise = page.goto(server.PREFIX + '/one-style.html', { timeout: 60000 }).catch(e => e);
   const waitForNavigationPromise = page.waitForNavigation().catch(e => e);
 
   const disconnectedPromise = new Promise(f => browser.once('disconnected', f));
@@ -503,7 +503,7 @@ test('should properly disconnect when connection closes from the server side', a
   expect((await page.waitForNavigation().catch(e => e)).message).toContain('Navigation failed because page was closed');
 });
 
-test('should be able to connect when the wsEndpont is passed as the first argument', async ({browserType, startRemoteServer}) => {
+test('should be able to connect when the wsEndpont is passed as the first argument', async ({ browserType, startRemoteServer }) => {
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect(remoteServer.wsEndpoint());
   const page = await browser.newPage();
@@ -511,7 +511,7 @@ test('should be able to connect when the wsEndpont is passed as the first argume
   await browser.close();
 });
 
-test('should save har', async ({browserType, startRemoteServer, server}, testInfo) => {
+test('should save har', async ({ browserType, startRemoteServer, server }, testInfo) => {
   const remoteServer = await startRemoteServer();
   const browser = await browserType.connect(remoteServer.wsEndpoint());
   const harPath = testInfo.outputPath('test.har');

--- a/tests/browsertype-launch-server.spec.ts
+++ b/tests/browsertype-launch-server.spec.ts
@@ -18,49 +18,49 @@
 import { playwrightTest as it, expect } from './config/browserTest';
 
 it.describe('launch server', () => {
-  it.skip(({ mode}) => mode !== 'default');
+  it.skip(({ mode }) => mode !== 'default');
 
-  it('should work', async ({browserType, browserOptions}) => {
+  it('should work', async ({ browserType, browserOptions }) => {
     const browserServer = await browserType.launchServer(browserOptions);
     expect(browserServer.wsEndpoint()).not.toBe(null);
     await browserServer.close();
   });
 
-  it('should work with port', async ({browserType, browserOptions}, testInfo) => {
+  it('should work with port', async ({ browserType, browserOptions }, testInfo) => {
     const port = 8800 + testInfo.workerIndex;
     const browserServer = await browserType.launchServer({ ...browserOptions, port });
     expect(browserServer.wsEndpoint()).toContain(String(port));
     await browserServer.close();
   });
 
-  it('should work with wsPath', async ({browserType, browserOptions}) => {
+  it('should work with wsPath', async ({ browserType, browserOptions }) => {
     const wsPath = '/unguessable-token';
     const browserServer = await browserType.launchServer({ ...browserOptions, wsPath });
     expect(browserServer.wsEndpoint()).toMatch(/:\d+\/unguessable-token$/);
     await browserServer.close();
   });
 
-  it('should work when wsPath is missing leading slash', async ({browserType, browserOptions}) => {
+  it('should work when wsPath is missing leading slash', async ({ browserType, browserOptions }) => {
     const wsPath = 'unguessable-token';
     const browserServer = await browserType.launchServer({ ...browserOptions, wsPath });
     expect(browserServer.wsEndpoint()).toMatch(/:\d+\/unguessable-token$/);
     await browserServer.close();
   });
 
-  it('should default to random wsPath', async ({browserType, browserOptions}) => {
+  it('should default to random wsPath', async ({ browserType, browserOptions }) => {
     const browserServer = await browserType.launchServer({ ...browserOptions });
     expect(browserServer.wsEndpoint()).toMatch(/:\d+\/[a-f\d]{32}$/);
     await browserServer.close();
   });
 
-  it('should provide an error when ws endpoint is incorrect', async ({browserType, browserOptions}) => {
+  it('should provide an error when ws endpoint is incorrect', async ({ browserType, browserOptions }) => {
     const browserServer = await browserType.launchServer(browserOptions);
     const error = await browserType.connect({ wsEndpoint: browserServer.wsEndpoint() + '-foo' }).catch(e => e);
     await browserServer.close();
     expect(error.message).toContain('Unexpected server response: 400');
   });
 
-  it('should fire "close" event during kill', async ({browserType, browserOptions}) => {
+  it('should fire "close" event during kill', async ({ browserType, browserOptions }) => {
     const order = [];
     const browserServer = await browserType.launchServer(browserOptions);
     const closedPromise = new Promise<void>(f => browserServer.on('close', () => {
@@ -74,13 +74,13 @@ it.describe('launch server', () => {
     expect(order).toEqual(['closed', 'killed']);
   });
 
-  it('should return child_process instance', async ({browserType, browserOptions}) => {
+  it('should return child_process instance', async ({ browserType, browserOptions }) => {
     const browserServer = await browserType.launchServer(browserOptions);
     expect(browserServer.process().pid).toBeGreaterThan(0);
     await browserServer.close();
   });
 
-  it('should fire close event', async ({browserType, browserOptions}) => {
+  it('should fire close event', async ({ browserType, browserOptions }) => {
     const browserServer = await browserType.launchServer(browserOptions);
     const [result] = await Promise.all([
       // @ts-expect-error The signal parameter is not documented.
@@ -91,7 +91,7 @@ it.describe('launch server', () => {
     expect(result['signal']).toBe(null);
   });
 
-  it('should log protocol', async ({browserType, browserOptions}) => {
+  it('should log protocol', async ({ browserType, browserOptions }) => {
     const logs: string[] = [];
     const logger = {
       isEnabled(name: string) {

--- a/tests/browsertype-launch.spec.ts
+++ b/tests/browsertype-launch.spec.ts
@@ -17,7 +17,7 @@
 
 import { playwrightTest as it, expect } from './config/browserTest';
 
-it('should reject all promises when browser is closed', async ({browserType, browserOptions}) => {
+it('should reject all promises when browser is closed', async ({ browserType, browserOptions }) => {
   const browser = await browserType.launch(browserOptions);
   const page = await (await browser.newContext()).newPage();
   let error = null;
@@ -29,33 +29,33 @@ it('should reject all promises when browser is closed', async ({browserType, bro
   expect(error.message).toContain(' closed');
 });
 
-it('should throw if userDataDir option is passed', async ({browserType, browserOptions}) => {
+it('should throw if userDataDir option is passed', async ({ browserType, browserOptions }) => {
   let waitError = null;
-  const options = Object.assign({}, browserOptions, {userDataDir: 'random-path'});
+  const options = Object.assign({}, browserOptions, { userDataDir: 'random-path' });
   await browserType.launch(options).catch(e => waitError = e);
   expect(waitError.message).toContain('userDataDir option is not supported in `browserType.launch`. Use `browserType.launchPersistentContext` instead');
 });
 
-it('should throw if userDataDir is passed as an argument', async ({browserType, browserOptions}) => {
+it('should throw if userDataDir is passed as an argument', async ({ browserType, browserOptions }) => {
   let waitError = null;
-  const options = Object.assign({}, browserOptions, {args: ['--user-data-dir=random-path', '--profile=random-path']});
+  const options = Object.assign({}, browserOptions, { args: ['--user-data-dir=random-path', '--profile=random-path'] });
   await browserType.launch(options).catch(e => waitError = e);
   expect(waitError.message).toContain('Pass userDataDir parameter to `browserType.launchPersistentContext');
 });
 
-it('should throw if port option is passed', async ({browserType, browserOptions}) => {
-  const options = Object.assign({}, browserOptions, {port: 1234});
+it('should throw if port option is passed', async ({ browserType, browserOptions }) => {
+  const options = Object.assign({}, browserOptions, { port: 1234 });
   const error = await browserType.launch(options).catch(e => e);
   expect(error.message).toContain('Cannot specify a port without launching as a server.');
 });
 
-it('should throw if port option is passed for persistent context', async ({browserType, browserOptions}) => {
-  const options = Object.assign({}, browserOptions, {port: 1234});
+it('should throw if port option is passed for persistent context', async ({ browserType, browserOptions }) => {
+  const options = Object.assign({}, browserOptions, { port: 1234 });
   const error = await browserType.launchPersistentContext('foo', options).catch(e => e);
   expect(error.message).toContain('Cannot specify a port without launching as a server.');
 });
 
-it('should throw if page argument is passed', async ({browserType, browserOptions, browserName}) => {
+it('should throw if page argument is passed', async ({ browserType, browserOptions, browserName }) => {
   it.skip(browserName === 'firefox');
 
   let waitError = null;
@@ -64,21 +64,21 @@ it('should throw if page argument is passed', async ({browserType, browserOption
   expect(waitError.message).toContain('can not specify page');
 });
 
-it('should reject if launched browser fails immediately', async ({browserType, browserOptions, asset}) => {
-  const options = Object.assign({}, browserOptions, {executablePath: asset('dummy_bad_browser_executable.js')});
+it('should reject if launched browser fails immediately', async ({ browserType, browserOptions, asset }) => {
+  const options = Object.assign({}, browserOptions, { executablePath: asset('dummy_bad_browser_executable.js') });
   let waitError = null;
   await browserType.launch(options).catch(e => waitError = e);
   expect(waitError.message).toContain('== logs ==');
 });
 
-it('should reject if executable path is invalid', async ({browserType, browserOptions}) => {
+it('should reject if executable path is invalid', async ({ browserType, browserOptions }) => {
   let waitError = null;
-  const options = Object.assign({}, browserOptions, {executablePath: 'random-invalid-path'});
+  const options = Object.assign({}, browserOptions, { executablePath: 'random-invalid-path' });
   await browserType.launch(options).catch(e => waitError = e);
   expect(waitError.message).toContain('Failed to launch');
 });
 
-it('should handle timeout', async ({browserType, browserOptions, mode}) => {
+it('should handle timeout', async ({ browserType, browserOptions, mode }) => {
   it.skip(mode !== 'default');
 
   const options = { ...browserOptions, timeout: 5000, __testHookBeforeCreateBrowser: () => new Promise(f => setTimeout(f, 6000)) };
@@ -88,7 +88,7 @@ it('should handle timeout', async ({browserType, browserOptions, mode}) => {
   expect(error.message).toContain(`<launched> pid=`);
 });
 
-it('should handle exception', async ({browserType, browserOptions, mode}) => {
+it('should handle exception', async ({ browserType, browserOptions, mode }) => {
   it.skip(mode !== 'default');
 
   const e = new Error('Dummy');
@@ -97,7 +97,7 @@ it('should handle exception', async ({browserType, browserOptions, mode}) => {
   expect(error.message).toContain('Dummy');
 });
 
-it('should report launch log', async ({browserType, browserOptions, mode}) => {
+it('should report launch log', async ({ browserType, browserOptions, mode }) => {
   it.skip(mode !== 'default');
 
   const e = new Error('Dummy');
@@ -106,13 +106,13 @@ it('should report launch log', async ({browserType, browserOptions, mode}) => {
   expect(error.message).toContain('<launching>');
 });
 
-it('should accept objects as options', async ({browserType, browserOptions}) => {
+it('should accept objects as options', async ({ browserType, browserOptions }) => {
   // @ts-expect-error process is not a real option.
   const browser = await browserType.launch({ ...browserOptions, process });
   await browser.close();
 });
 
-it('should fire close event for all contexts', async ({browserType, browserOptions}) => {
+it('should fire close event for all contexts', async ({ browserType, browserOptions }) => {
   const browser = await browserType.launch(browserOptions);
   const context = await browser.newContext();
   let closed = false;
@@ -121,7 +121,7 @@ it('should fire close event for all contexts', async ({browserType, browserOptio
   expect(closed).toBe(true);
 });
 
-it('should be callable twice', async ({browserType, browserOptions}) => {
+it('should be callable twice', async ({ browserType, browserOptions }) => {
   const browser = await browserType.launch(browserOptions);
   await Promise.all([
     browser.close(),

--- a/tests/capabilities.spec.ts
+++ b/tests/capabilities.spec.ts
@@ -18,7 +18,7 @@ import os from 'os';
 import url from 'url';
 import { contextTest as it, expect } from './config/browserTest';
 
-it('SharedArrayBuffer should work', async function({contextFactory, httpsServer, browserName}) {
+it('SharedArrayBuffer should work', async function({ contextFactory, httpsServer, browserName }) {
   it.fail(browserName === 'webkit', 'no shared array buffer on webkit');
   const context = await contextFactory({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
@@ -31,14 +31,14 @@ it('SharedArrayBuffer should work', async function({contextFactory, httpsServer,
   expect(await page.evaluate(() => typeof SharedArrayBuffer)).toBe('function');
 });
 
-it('Web Assembly should work', async function({page, server, browserName, platform}) {
+it('Web Assembly should work', async function({ page, server, browserName, platform }) {
   it.fail(browserName === 'webkit' && platform === 'win32');
 
   await page.goto(server.PREFIX + '/wasm/table2.html');
   expect(await page.evaluate('loadTable()')).toBe('42, 83');
 });
 
-it('WebSocket should work', async ({page, server}) => {
+it('WebSocket should work', async ({ page, server }) => {
   server.sendOnWebSocketConnection('incoming');
   const value = await page.evaluate(port => {
     let cb;
@@ -51,7 +51,7 @@ it('WebSocket should work', async ({page, server}) => {
   expect(value).toBe('incoming');
 });
 
-it('should respect CSP', async ({page, server}) => {
+it('should respect CSP', async ({ page, server }) => {
   server.setRoute('/empty.html', async (req, res) => {
     res.setHeader('Content-Security-Policy', `script-src 'unsafe-inline';`);
     res.end(`
@@ -65,7 +65,7 @@ it('should respect CSP', async ({page, server}) => {
   expect(await page.evaluate(() => window['testStatus'])).toBe('SUCCESS');
 });
 
-it('should play video', async ({page, asset, browserName, platform}) => {
+it('should play video', async ({ page, asset, browserName, platform }) => {
   // TODO: the test passes on Windows locally but fails on GitHub Action bot,
   // apparently due to a Media Pack issue in the Windows Server.
   // Also the test is very flaky on Linux WebKit.
@@ -82,7 +82,7 @@ it('should play video', async ({page, asset, browserName, platform}) => {
   await page.$eval('video', v => v.pause());
 });
 
-it('should support webgl', async ({page, browserName, headless}) => {
+it('should support webgl', async ({ page, browserName, headless }) => {
   it.fixme(browserName === 'firefox' && headless);
 
   const hasWebGL = await page.evaluate(() => {
@@ -92,7 +92,7 @@ it('should support webgl', async ({page, browserName, headless}) => {
   expect(hasWebGL).toBe(true);
 });
 
-it('should support webgl 2', async ({page, browserName, headless}) => {
+it('should support webgl 2', async ({ page, browserName, headless }) => {
   it.skip(browserName === 'webkit', 'WebKit doesn\'t have webgl2 enabled yet upstream.');
   it.fixme(browserName === 'firefox' && headless);
   it.fixme(browserName === 'chromium' && !headless, 'chromium doesn\'t like webgl2 when running under xvfb');

--- a/tests/channels.spec.ts
+++ b/tests/channels.spec.ts
@@ -22,7 +22,7 @@ import { playwrightTest as it, expect } from './config/browserTest';
 // Otherwise, a browser launched for other tests in this worker will affect the expectations.
 it.use({ args: [] });
 
-it('should scope context handles', async ({browserType, browserOptions, server}) => {
+it('should scope context handles', async ({ browserType, browserOptions, server }) => {
   const browser = await browserType.launch(browserOptions);
   const GOLDEN_PRECONDITION = {
     _guid: '',
@@ -53,10 +53,10 @@ it('should scope context handles', async ({browserType, browserOptions, server})
         { _guid: 'browser', objects: [
           { _guid: 'browser-context', objects: [
             { _guid: 'frame', objects: [] },
-            { _guid: 'page', objects: []},
+            { _guid: 'page', objects: [] },
             { _guid: 'request', objects: [] },
             { _guid: 'response', objects: [] },
-          ]},
+          ] },
           { _guid: 'fetchRequest', objects: [] }
         ] },
       ] },
@@ -71,7 +71,7 @@ it('should scope context handles', async ({browserType, browserOptions, server})
   await browser.close();
 });
 
-it('should scope CDPSession handles', async ({browserType, browserOptions, browserName}) => {
+it('should scope CDPSession handles', async ({ browserType, browserOptions, browserName }) => {
   it.skip(browserName !== 'chromium');
 
   const browser = await browserType.launch(browserOptions);
@@ -115,7 +115,7 @@ it('should scope CDPSession handles', async ({browserType, browserOptions, brows
   await browser.close();
 });
 
-it('should scope browser handles', async ({browserType, browserOptions}) => {
+it('should scope browser handles', async ({ browserType, browserOptions }) => {
   const GOLDEN_PRECONDITION = {
     _guid: '',
     objects: [

--- a/tests/chromium/chromium.spec.ts
+++ b/tests/chromium/chromium.spec.ts
@@ -21,7 +21,7 @@ import http from 'http';
 import { getUserAgent } from '../../lib/utils/utils';
 import { suppressCertificateWarning } from '../config/utils';
 
-test('should create a worker from a service worker', async ({page, server}) => {
+test('should create a worker from a service worker', async ({ page, server }) => {
   const [worker] = await Promise.all([
     page.context().waitForEvent('serviceworker'),
     page.goto(server.PREFIX + '/serviceworkers/empty/sw.html')
@@ -29,7 +29,7 @@ test('should create a worker from a service worker', async ({page, server}) => {
   expect(await worker.evaluate(() => self.toString())).toBe('[object ServiceWorkerGlobalScope]');
 });
 
-test('serviceWorkers() should return current workers', async ({page, server}) => {
+test('serviceWorkers() should return current workers', async ({ page, server }) => {
   const context = page.context();
   const [worker1] = await Promise.all([
     context.waitForEvent('serviceworker'),
@@ -48,7 +48,7 @@ test('serviceWorkers() should return current workers', async ({page, server}) =>
   expect(workers).toContain(worker2);
 });
 
-test('should not create a worker from a shared worker', async ({page, server}) => {
+test('should not create a worker from a shared worker', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let serviceWorkerCreated;
   page.context().once('serviceworker', () => serviceWorkerCreated = true);
@@ -58,7 +58,7 @@ test('should not create a worker from a shared worker', async ({page, server}) =
   expect(serviceWorkerCreated).not.toBeTruthy();
 });
 
-test('Page.route should work with intervention headers', async ({server, page}) => {
+test('Page.route should work with intervention headers', async ({ server, page }) => {
   server.setRoute('/intervention', (req, res) => res.end(`
     <script>
       document.write('<script src="${server.CROSS_PROCESS_PREFIX}/intervention.js">' + '</scr' + 'ipt>');
@@ -78,7 +78,7 @@ test('Page.route should work with intervention headers', async ({server, page}) 
   expect(serverRequest.headers.intervention).toContain('feature/5718547946799104');
 });
 
-playwrightTest('should close service worker together with the context', async ({browserType, browserOptions, server}) => {
+playwrightTest('should close service worker together with the context', async ({ browserType, browserOptions, server }) => {
   const browser = await browserType.launch(browserOptions);
   const context = await browser.newContext();
   const page = await context.newPage();
@@ -169,7 +169,7 @@ playwrightTest('should connect to existing page with iframe and navigate', async
   }
 });
 
-playwrightTest('should connect to existing service workers', async ({browserType, browserOptions, server}, testInfo) => {
+playwrightTest('should connect to existing service workers', async ({ browserType, browserOptions, server }, testInfo) => {
   const port = 9339 + testInfo.workerIndex;
   const browserServer = await browserType.launch({
     ...browserOptions,
@@ -199,7 +199,7 @@ playwrightTest('should connect to existing service workers', async ({browserType
   }
 });
 
-playwrightTest('should connect over a ws endpoint', async ({browserType, browserOptions, server}, testInfo) => {
+playwrightTest('should connect over a ws endpoint', async ({ browserType, browserOptions, server }, testInfo) => {
   const port = 9339 + testInfo.workerIndex;
   const browserServer = await browserType.launch({
     ...browserOptions,
@@ -232,7 +232,7 @@ playwrightTest('should connect over a ws endpoint', async ({browserType, browser
   }
 });
 
-playwrightTest('should send extra headers with connect request', async ({browserType, browserOptions, server}, testInfo) => {
+playwrightTest('should send extra headers with connect request', async ({ browserType, browserOptions, server }, testInfo) => {
   {
     const [request] = await Promise.all([
       server.waitForWebSocketConnectionRequest(),
@@ -265,7 +265,7 @@ playwrightTest('should send extra headers with connect request', async ({browser
   }
 });
 
-playwrightTest('should send default User-Agent header with connect request', async ({browserType, browserOptions, server}, testInfo) => {
+playwrightTest('should send default User-Agent header with connect request', async ({ browserType, browserOptions, server }, testInfo) => {
   {
     const [request] = await Promise.all([
       server.waitForWebSocketConnectionRequest(),

--- a/tests/chromium/css-coverage.spec.ts
+++ b/tests/chromium/css-coverage.spec.ts
@@ -16,20 +16,20 @@
 
 import { contextTest as it, expect } from '../config/browserTest';
 
-it('should work', async function({page, server}) {
+it('should work', async function({ page, server }) {
   await page.coverage.startCSSCoverage();
   await page.goto(server.PREFIX + '/csscoverage/simple.html');
   const coverage = await page.coverage.stopCSSCoverage();
   expect(coverage.length).toBe(1);
   expect(coverage[0].url).toContain('/csscoverage/simple.html');
   expect(coverage[0].ranges).toEqual([
-    {start: 1, end: 22}
+    { start: 1, end: 22 }
   ]);
   const range = coverage[0].ranges[0];
   expect(coverage[0].text.substring(range.start, range.end)).toBe('div { color: green; }');
 });
 
-it('should report sourceURLs', async function({page, server}) {
+it('should report sourceURLs', async function({ page, server }) {
   await page.coverage.startCSSCoverage();
   await page.goto(server.PREFIX + '/csscoverage/sourceurl.html');
   const coverage = await page.coverage.stopCSSCoverage();
@@ -37,7 +37,7 @@ it('should report sourceURLs', async function({page, server}) {
   expect(coverage[0].url).toBe('nicename.css');
 });
 
-it('should report multiple stylesheets', async function({page, server}) {
+it('should report multiple stylesheets', async function({ page, server }) {
   await page.coverage.startCSSCoverage();
   await page.goto(server.PREFIX + '/csscoverage/multiple.html');
   const coverage = await page.coverage.stopCSSCoverage();
@@ -47,7 +47,7 @@ it('should report multiple stylesheets', async function({page, server}) {
   expect(coverage[1].url).toContain('/csscoverage/stylesheet2.css');
 });
 
-it('should report stylesheets that have no coverage', async function({page, server}) {
+it('should report stylesheets that have no coverage', async function({ page, server }) {
   await page.coverage.startCSSCoverage();
   await page.goto(server.PREFIX + '/csscoverage/unused.html');
   const coverage = await page.coverage.stopCSSCoverage();
@@ -56,18 +56,18 @@ it('should report stylesheets that have no coverage', async function({page, serv
   expect(coverage[0].ranges.length).toBe(0);
 });
 
-it('should work with media queries', async function({page, server}) {
+it('should work with media queries', async function({ page, server }) {
   await page.coverage.startCSSCoverage();
   await page.goto(server.PREFIX + '/csscoverage/media.html');
   const coverage = await page.coverage.stopCSSCoverage();
   expect(coverage.length).toBe(1);
   expect(coverage[0].url).toContain('/csscoverage/media.html');
   expect(coverage[0].ranges).toEqual([
-    {start: 17, end: 38}
+    { start: 17, end: 38 }
   ]);
 });
 
-it('should work with complicated usecases', async function({page, server}) {
+it('should work with complicated usecases', async function({ page, server }) {
   await page.coverage.startCSSCoverage();
   await page.goto(server.PREFIX + '/csscoverage/involved.html');
   const coverage: any = await page.coverage.stopCSSCoverage();
@@ -91,9 +91,9 @@ it('should work with complicated usecases', async function({page, server}) {
   );
 });
 
-it('should ignore injected stylesheets', async function({page, server}) {
+it('should ignore injected stylesheets', async function({ page, server }) {
   await page.coverage.startCSSCoverage();
-  await page.addStyleTag({content: 'body { margin: 10px;}'});
+  await page.addStyleTag({ content: 'body { margin: 10px;}' });
   // trigger style recalc
   const margin = await page.evaluate(() => window.getComputedStyle(document.body).margin);
   expect(margin).toBe('10px');
@@ -101,15 +101,15 @@ it('should ignore injected stylesheets', async function({page, server}) {
   expect(coverage.length).toBe(0);
 });
 
-it('should report stylesheets across navigations', async function({page, server}) {
-  await page.coverage.startCSSCoverage({resetOnNavigation: false});
+it('should report stylesheets across navigations', async function({ page, server }) {
+  await page.coverage.startCSSCoverage({ resetOnNavigation: false });
   await page.goto(server.PREFIX + '/csscoverage/multiple.html');
   await page.goto(server.EMPTY_PAGE);
   const coverage = await page.coverage.stopCSSCoverage();
   expect(coverage.length).toBe(2);
 });
 
-it('should NOT report scripts across navigations', async function({page, server}) {
+it('should NOT report scripts across navigations', async function({ page, server }) {
   await page.coverage.startCSSCoverage(); // Enabled by default.
   await page.goto(server.PREFIX + '/csscoverage/multiple.html');
   await page.goto(server.EMPTY_PAGE);
@@ -117,7 +117,7 @@ it('should NOT report scripts across navigations', async function({page, server}
   expect(coverage.length).toBe(0);
 });
 
-it('should work with a recently loaded stylesheet', async function({page, server}) {
+it('should work with a recently loaded stylesheet', async function({ page, server }) {
   await page.coverage.startCSSCoverage();
   await page.evaluate(async url => {
     document.body.textContent = 'hello, world';

--- a/tests/chromium/js-coverage.spec.ts
+++ b/tests/chromium/js-coverage.spec.ts
@@ -18,7 +18,7 @@ import { contextTest as it, expect } from '../config/browserTest';
 
 it.skip(({ trace }) => !!trace);
 
-it('should work', async function({page, server}) {
+it('should work', async function({ page, server }) {
   await page.coverage.startJSCoverage();
   await page.goto(server.PREFIX + '/jscoverage/simple.html', { waitUntil: 'load' });
   const coverage = await page.coverage.stopJSCoverage();
@@ -27,7 +27,7 @@ it('should work', async function({page, server}) {
   expect(coverage[0].functions.find(f => f.functionName === 'foo').ranges[0].count).toEqual(1);
 });
 
-it('should report sourceURLs', async function({page, server}) {
+it('should report sourceURLs', async function({ page, server }) {
   await page.coverage.startJSCoverage();
   await page.goto(server.PREFIX + '/jscoverage/sourceurl.html');
   const coverage = await page.coverage.stopJSCoverage();
@@ -35,22 +35,22 @@ it('should report sourceURLs', async function({page, server}) {
   expect(coverage[0].url).toBe('nicename.js');
 });
 
-it('should ignore eval() scripts by default', async function({page, server}) {
+it('should ignore eval() scripts by default', async function({ page, server }) {
   await page.coverage.startJSCoverage();
   await page.goto(server.PREFIX + '/jscoverage/eval.html');
   const coverage = await page.coverage.stopJSCoverage();
   expect(coverage.length).toBe(1);
 });
 
-it('shouldn\'t ignore eval() scripts if reportAnonymousScripts is true', async function({page, server}) {
-  await page.coverage.startJSCoverage({reportAnonymousScripts: true});
+it('shouldn\'t ignore eval() scripts if reportAnonymousScripts is true', async function({ page, server }) {
+  await page.coverage.startJSCoverage({ reportAnonymousScripts: true });
   await page.goto(server.PREFIX + '/jscoverage/eval.html');
   const coverage = await page.coverage.stopJSCoverage();
   expect(coverage.find(entry => entry.url === '').source).toBe('console.log("foo")');
   expect(coverage.length).toBe(2);
 });
 
-it('should report multiple scripts', async function({page, server}) {
+it('should report multiple scripts', async function({ page, server }) {
   await page.coverage.startJSCoverage();
   await page.goto(server.PREFIX + '/jscoverage/multiple.html');
   const coverage = await page.coverage.stopJSCoverage();
@@ -60,15 +60,15 @@ it('should report multiple scripts', async function({page, server}) {
   expect(coverage[1].url).toContain('/jscoverage/script2.js');
 });
 
-it('should report scripts across navigations when disabled', async function({page, server}) {
-  await page.coverage.startJSCoverage({resetOnNavigation: false});
+it('should report scripts across navigations when disabled', async function({ page, server }) {
+  await page.coverage.startJSCoverage({ resetOnNavigation: false });
   await page.goto(server.PREFIX + '/jscoverage/multiple.html');
   await page.goto(server.EMPTY_PAGE);
   const coverage = await page.coverage.stopJSCoverage();
   expect(coverage.length).toBe(2);
 });
 
-it('should NOT report scripts across navigations when enabled', async function({page, server}) {
+it('should NOT report scripts across navigations when enabled', async function({ page, server }) {
   await page.coverage.startJSCoverage(); // Enabled by default.
   await page.goto(server.PREFIX + '/jscoverage/multiple.html');
   await page.goto(server.EMPTY_PAGE);
@@ -76,7 +76,7 @@ it('should NOT report scripts across navigations when enabled', async function({
   expect(coverage.length).toBe(0);
 });
 
-it('should not hang when there is a debugger statement', async function({page, server}) {
+it('should not hang when there is a debugger statement', async function({ page, server }) {
   await page.coverage.startJSCoverage();
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => {

--- a/tests/chromium/launcher.spec.ts
+++ b/tests/chromium/launcher.spec.ts
@@ -16,7 +16,7 @@
 
 import { playwrightTest as it, expect } from '../config/browserTest';
 
-it('should throw with remote-debugging-pipe argument', async ({browserType, browserOptions, mode}) => {
+it('should throw with remote-debugging-pipe argument', async ({ browserType, browserOptions, mode }) => {
   it.skip(mode !== 'default');
 
   const options = Object.assign({}, browserOptions);
@@ -25,7 +25,7 @@ it('should throw with remote-debugging-pipe argument', async ({browserType, brow
   expect(error.message).toContain('Playwright manages remote debugging connection itself');
 });
 
-it('should not throw with remote-debugging-port argument', async ({browserType, browserOptions, mode}) => {
+it('should not throw with remote-debugging-port argument', async ({ browserType, browserOptions, mode }) => {
   it.skip(mode !== 'default');
 
   const options = Object.assign({}, browserOptions);
@@ -34,7 +34,7 @@ it('should not throw with remote-debugging-port argument', async ({browserType, 
   await browser.close();
 });
 
-it('should open devtools when "devtools: true" option is given', async ({browserType, browserOptions, mode, platform, channel}) => {
+it('should open devtools when "devtools: true" option is given', async ({ browserType, browserOptions, mode, platform, channel }) => {
   it.skip(mode !== 'default' || platform === 'win32' || !!channel);
 
   let devtoolsCallback;
@@ -43,7 +43,7 @@ it('should open devtools when "devtools: true" option is given', async ({browser
     if (parsed.method === 'getPreferences')
       devtoolsCallback();
   };
-  const browser = await browserType.launch({...browserOptions, headless: false, devtools: true, __testHookForDevTools} as any);
+  const browser = await browserType.launch({ ...browserOptions, headless: false, devtools: true, __testHookForDevTools } as any);
   const context = await browser.newContext();
   await Promise.all([
     devtoolsPromise,
@@ -52,10 +52,10 @@ it('should open devtools when "devtools: true" option is given', async ({browser
   await browser.close();
 });
 
-it('should return background pages', async ({browserType, browserOptions, createUserDataDir, asset}) => {
+it('should return background pages', async ({ browserType, browserOptions, createUserDataDir, asset }) => {
   const userDataDir = await createUserDataDir();
   const extensionPath = asset('simple-extension');
-  const extensionOptions = {...browserOptions,
+  const extensionOptions = { ...browserOptions,
     headless: false,
     args: [
       `--disable-extensions-except=${extensionPath}`,
@@ -75,10 +75,10 @@ it('should return background pages', async ({browserType, browserOptions, create
   expect(context.backgroundPages().length).toBe(0);
 });
 
-it('should return background pages when recording video', async ({browserType, browserOptions, createUserDataDir, asset}, testInfo) => {
+it('should return background pages when recording video', async ({ browserType, browserOptions, createUserDataDir, asset }, testInfo) => {
   const userDataDir = await createUserDataDir();
   const extensionPath = asset('simple-extension');
-  const extensionOptions = {...browserOptions,
+  const extensionOptions = { ...browserOptions,
     headless: false,
     args: [
       `--disable-extensions-except=${extensionPath}`,
@@ -99,11 +99,11 @@ it('should return background pages when recording video', async ({browserType, b
   await context.close();
 });
 
-it('should not create pages automatically', async ({browserType, browserOptions}) => {
+it('should not create pages automatically', async ({ browserType, browserOptions }) => {
   const browser = await browserType.launch(browserOptions);
   const browserSession = await browser.newBrowserCDPSession();
   const targets = [];
-  browserSession.on('Target.targetCreated', async ({targetInfo}) => {
+  browserSession.on('Target.targetCreated', async ({ targetInfo }) => {
     if (targetInfo.type !== 'browser')
       targets.push(targetInfo);
   });

--- a/tests/chromium/oopif.spec.ts
+++ b/tests/chromium/oopif.spec.ts
@@ -18,14 +18,14 @@ import { contextTest as it, expect } from '../config/browserTest';
 
 it.use({ args: ['--site-per-process'] });
 
-it('should report oopif frames', async function({page, browser, server}) {
+it('should report oopif frames', async function({ page, browser, server }) {
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   expect(await countOOPIFs(browser)).toBe(1);
   expect(page.frames().length).toBe(2);
   expect(await page.frames()[1].evaluate(() => '' + location.href)).toBe(server.CROSS_PROCESS_PREFIX + '/grid.html');
 });
 
-it('should handle oopif detach', async function({page, browser, server}) {
+it('should handle oopif detach', async function({ page, browser, server }) {
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   expect(await countOOPIFs(browser)).toBe(1);
   expect(page.frames().length).toBe(2);
@@ -38,7 +38,7 @@ it('should handle oopif detach', async function({page, browser, server}) {
   expect(detachedFrame).toBe(frame);
 });
 
-it('should handle remote -> local -> remote transitions', async function({page, browser, server}) {
+it('should handle remote -> local -> remote transitions', async function({ page, browser, server }) {
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   expect(page.frames().length).toBe(2);
   expect(await countOOPIFs(browser)).toBe(1);
@@ -57,10 +57,10 @@ it('should handle remote -> local -> remote transitions', async function({page, 
   expect(await countOOPIFs(browser)).toBe(1);
 });
 
-it('should get the proper viewport', async ({page, browser, server}) => {
+it('should get the proper viewport', async ({ page, browser, server }) => {
   it.fixme();
 
-  expect(page.viewportSize()).toEqual({width: 1280, height: 720});
+  expect(page.viewportSize()).toEqual({ width: 1280, height: 720 });
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   expect(page.frames().length).toBe(2);
   expect(await countOOPIFs(browser)).toBe(1);
@@ -70,7 +70,7 @@ it('should get the proper viewport', async ({page, browser, server}) => {
   expect(await oopif.evaluate(() => matchMedia('(device-width: 1280px)').matches)).toBe(true);
   expect(await oopif.evaluate(() => matchMedia('(device-height: 720px)').matches)).toBe(true);
   expect(await oopif.evaluate(() => 'ontouchstart' in window)).toBe(false);
-  await page.setViewportSize({width: 123, height: 456});
+  await page.setViewportSize({ width: 123, height: 456 });
   expect(await oopif.evaluate(() => screen.width)).toBe(123);
   expect(await oopif.evaluate(() => screen.height)).toBe(456);
   expect(await oopif.evaluate(() => matchMedia('(device-width: 123px)').matches)).toBe(true);
@@ -78,7 +78,7 @@ it('should get the proper viewport', async ({page, browser, server}) => {
   expect(await oopif.evaluate(() => 'ontouchstart' in window)).toBe(false);
 });
 
-it('should expose function', async ({page, browser, server}) => {
+it('should expose function', async ({ page, browser, server }) => {
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   expect(page.frames().length).toBe(2);
   expect(await countOOPIFs(browser)).toBe(1);
@@ -90,7 +90,7 @@ it('should expose function', async ({page, browser, server}) => {
   expect(result).toBe(36);
 });
 
-it('should emulate media', async ({page, browser, server}) => {
+it('should emulate media', async ({ page, browser, server }) => {
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   expect(page.frames().length).toBe(2);
   expect(await countOOPIFs(browser)).toBe(1);
@@ -100,7 +100,7 @@ it('should emulate media', async ({page, browser, server}) => {
   expect(await oopif.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches)).toBe(true);
 });
 
-it('should emulate offline', async ({page, browser, server}) => {
+it('should emulate offline', async ({ page, browser, server }) => {
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   expect(page.frames().length).toBe(2);
   expect(await countOOPIFs(browser)).toBe(1);
@@ -110,7 +110,7 @@ it('should emulate offline', async ({page, browser, server}) => {
   expect(await oopif.evaluate(() => navigator.onLine)).toBe(false);
 });
 
-it('should support context options', async ({browser, server, playwright}) => {
+it('should support context options', async ({ browser, server, playwright }) => {
   const iPhone = playwright.devices['iPhone 6'];
   const context = await browser.newContext({ ...iPhone, timezoneId: 'America/Jamaica', locale: 'fr-CH', userAgent: 'UA' });
   const page = await context.newPage();
@@ -132,7 +132,7 @@ it('should support context options', async ({browser, server, playwright}) => {
   await context.close();
 });
 
-it('should respect route', async ({page, browser, server}) => {
+it('should respect route', async ({ page, browser, server }) => {
   let intercepted = false;
   await page.route('**/digits/0.png', route => {
     intercepted = true;
@@ -144,21 +144,21 @@ it('should respect route', async ({page, browser, server}) => {
   expect(intercepted).toBe(true);
 });
 
-it('should take screenshot', async ({page, browser, server}) => {
-  await page.setViewportSize({width: 500, height: 500});
+it('should take screenshot', async ({ page, browser, server }) => {
+  await page.setViewportSize({ width: 500, height: 500 });
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   expect(page.frames().length).toBe(2);
   expect(await countOOPIFs(browser)).toBe(1);
   expect(await page.screenshot()).toMatchSnapshot('screenshot-oopif.png', { threshold: 0.3 });
 });
 
-it('should load oopif iframes with subresources and route', async function({page, browser, server}) {
+it('should load oopif iframes with subresources and route', async function({ page, browser, server }) {
   await page.route('**/*', route => route.continue());
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   expect(await countOOPIFs(browser)).toBe(1);
 });
 
-it('should report main requests', async function({page, browser, server}) {
+it('should report main requests', async function({ page, browser, server }) {
   const requestFrames = [];
   page.on('request', r => requestFrames.push(r.frame()));
   const finishedFrames = [];
@@ -196,7 +196,7 @@ it('should report main requests', async function({page, browser, server}) {
   expect(finishedFrames[2]).toBe(grandChild);
 });
 
-it('should support exposeFunction', async function({page, browser, server}) {
+it('should support exposeFunction', async function({ page, browser, server }) {
   await page.context().exposeFunction('dec', a => a - 1);
   await page.exposeFunction('inc', a => a + 1);
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
@@ -208,7 +208,7 @@ it('should support exposeFunction', async function({page, browser, server}) {
   expect(await page.frames()[1].evaluate(() => window['dec'](4))).toBe(3);
 });
 
-it('should support addInitScript', async function({page, browser, server}) {
+it('should support addInitScript', async function({ page, browser, server }) {
   await page.context().addInitScript(() => window['bar'] = 17);
   await page.addInitScript(() => window['foo'] = 42);
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
@@ -220,21 +220,21 @@ it('should support addInitScript', async function({page, browser, server}) {
   expect(await page.frames()[1].evaluate(() => window['bar'])).toBe(17);
 });
 // @see https://github.com/microsoft/playwright/issues/1240
-it('should click a button when it overlays oopif', async function({page, browser, server}) {
+it('should click a button when it overlays oopif', async function({ page, browser, server }) {
   await page.goto(server.PREFIX + '/button-overlay-oopif.html');
   expect(await countOOPIFs(browser)).toBe(1);
   await page.click('button');
   expect(await page.evaluate(() => window['BUTTON_CLICKED'])).toBe(true);
 });
 
-it('should report google.com frame with headed', async ({browserType, browserOptions, server}) => {
+it('should report google.com frame with headed', async ({ browserType, browserOptions, server }) => {
   // @see https://github.com/GoogleChrome/puppeteer/issues/2548
   // https://google.com is isolated by default in Chromium embedder.
-  const browser = await browserType.launch({...browserOptions, headless: false});
+  const browser = await browserType.launch({ ...browserOptions, headless: false });
   const page = await browser.newPage();
   await page.goto(server.EMPTY_PAGE);
   await page.route('**/*', route => {
-    route.fulfill({body: 'YO, GOOGLE.COM'});
+    route.fulfill({ body: 'YO, GOOGLE.COM' });
   });
   await page.evaluate(() => {
     const frame = document.createElement('iframe');
@@ -252,7 +252,7 @@ it('should report google.com frame with headed', async ({browserType, browserOpt
   await browser.close();
 });
 
-it('ElementHandle.boundingBox() should work', async function({page, browser, server}) {
+it('ElementHandle.boundingBox() should work', async function({ page, browser, server }) {
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   await page.$eval('iframe', iframe => {
     iframe.style.width = '500px';
@@ -275,7 +275,7 @@ it('ElementHandle.boundingBox() should work', async function({page, browser, ser
   expect(await handle2.boundingBox()).toEqual({ x: 100 + 42, y: 50 + 17, width: 50, height: 50 });
 });
 
-it('should click', async function({page, browser, server}) {
+it('should click', async function({ page, browser, server }) {
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   await page.$eval('iframe', iframe => {
     iframe.style.width = '500px';
@@ -292,7 +292,7 @@ it('should click', async function({page, browser, server}) {
   expect(await handle1.evaluate(() => window['_clicked'])).toBe(true);
 });
 
-it('should allow cdp sessions on oopifs', async function({page, browser, server}) {
+it('should allow cdp sessions on oopifs', async function({ page, browser, server }) {
   await page.goto(server.PREFIX + '/dynamic-oopif.html');
   expect(await countOOPIFs(browser)).toBe(1);
   expect(page.frames().length).toBe(2);
@@ -303,14 +303,14 @@ it('should allow cdp sessions on oopifs', async function({page, browser, server}
   expect(JSON.stringify(parent)).not.toContain('./digits/1.png');
 
   const oopifCDP = await page.context().newCDPSession(page.frames()[1]);
-  const oopif = await oopifCDP.send('DOM.getDocument', { pierce: true, depth: -1});
+  const oopif = await oopifCDP.send('DOM.getDocument', { pierce: true, depth: -1 });
   expect(JSON.stringify(oopif)).toContain('./digits/1.png');
 });
 
 async function countOOPIFs(browser) {
   const browserSession = await browser.newBrowserCDPSession();
   const oopifs = [];
-  browserSession.on('Target.targetCreated', async ({targetInfo}) => {
+  browserSession.on('Target.targetCreated', async ({ targetInfo }) => {
     if (targetInfo.type === 'iframe')
       oopifs.push(targetInfo);
   });

--- a/tests/chromium/session.spec.ts
+++ b/tests/chromium/session.spec.ts
@@ -17,7 +17,7 @@
 import { contextTest as it, expect } from '../config/browserTest';
 import { browserTest } from '../config/browserTest';
 
-it('should work', async function({page}) {
+it('should work', async function({ page }) {
   const client = await page.context().newCDPSession(page);
 
   await Promise.all([
@@ -28,7 +28,7 @@ it('should work', async function({page}) {
   expect(foo).toBe('bar');
 });
 
-it('should send events', async function({page, server}) {
+it('should send events', async function({ page, server }) {
   const client = await page.context().newCDPSession(page);
   await client.send('Network.enable');
   const events = [];
@@ -37,7 +37,7 @@ it('should send events', async function({page, server}) {
   expect(events.length).toBe(1);
 });
 
-it('should only accept a page or frame', async function({page}) {
+it('should only accept a page or frame', async function({ page }) {
   // @ts-expect-error newCDPSession expects a Page or Frame
   const error = await page.context().newCDPSession(page.context()).catch(e => e);
   expect(error.message).toContain('page: expected Page or Frame');
@@ -48,7 +48,7 @@ it('should only accept a page or frame', async function({page}) {
   expect(errorAlt.message).toContain('page: expected Page or Frame');
 });
 
-it('should enable and disable domains independently', async function({page}) {
+it('should enable and disable domains independently', async function({ page }) {
   const client = await page.context().newCDPSession(page);
   await client.send('Runtime.enable');
   await client.send('Debugger.enable');
@@ -66,22 +66,22 @@ it('should enable and disable domains independently', async function({page}) {
   ]);
 });
 
-it('should be able to detach session', async function({page}) {
+it('should be able to detach session', async function({ page }) {
   const client = await page.context().newCDPSession(page);
   await client.send('Runtime.enable');
-  const evalResponse = await client.send('Runtime.evaluate', {expression: '1 + 2', returnByValue: true});
+  const evalResponse = await client.send('Runtime.evaluate', { expression: '1 + 2', returnByValue: true });
   expect(evalResponse.result.value).toBe(3);
   await client.detach();
   let error = null;
   try {
-    await client.send('Runtime.evaluate', {expression: '3 + 1', returnByValue: true});
+    await client.send('Runtime.evaluate', { expression: '3 + 1', returnByValue: true });
   } catch (e) {
     error = e;
   }
   expect(error.message).toContain('Target page, context or browser has been closed');
 });
 
-it('should throw nice errors', async function({page}) {
+it('should throw nice errors', async function({ page }) {
   const client = await page.context().newCDPSession(page);
   const error = await theSourceOfTheProblems().catch(error => error);
   expect(error.stack).toContain('theSourceOfTheProblems');
@@ -93,7 +93,7 @@ it('should throw nice errors', async function({page}) {
   }
 });
 
-it('should work with main frame', async function({page}) {
+it('should work with main frame', async function({ page }) {
   const client = await page.context().newCDPSession(page.mainFrame());
 
   await Promise.all([
@@ -104,7 +104,7 @@ it('should work with main frame', async function({page}) {
   expect(foo).toBe('bar');
 });
 
-it('should throw if target is part of main', async function({server, page}){
+it('should throw if target is part of main', async function({ server, page }){
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(page.frames()[0].url()).toContain('/frames/one-frame.html');
   expect(page.frames()[1].url()).toContain('/frames/frame.html');
@@ -113,7 +113,7 @@ it('should throw if target is part of main', async function({server, page}){
   expect(error.message).toContain(`This frame does not have a separate CDP session, it is a part of the parent frame's session`);
 });
 
-browserTest('should not break page.close()', async function({browser}) {
+browserTest('should not break page.close()', async function({ browser }) {
   const context = await browser.newContext();
   const page = await context.newPage();
   const session = await page.context().newCDPSession(page);
@@ -122,7 +122,7 @@ browserTest('should not break page.close()', async function({browser}) {
   await context.close();
 });
 
-browserTest('should detach when page closes', async function({browser}) {
+browserTest('should detach when page closes', async function({ browser }) {
   const context = await browser.newContext();
   const page = await context.newPage();
   const session = await context.newCDPSession(page);
@@ -133,7 +133,7 @@ browserTest('should detach when page closes', async function({browser}) {
   await context.close();
 });
 
-browserTest('should work with newBrowserCDPSession', async function({browser}) {
+browserTest('should work with newBrowserCDPSession', async function({ browser }) {
   const session = await browser.newBrowserCDPSession();
 
   const version = await session.send('Browser.getVersion');

--- a/tests/chromium/tracing.spec.ts
+++ b/tests/chromium/tracing.spec.ts
@@ -18,30 +18,30 @@ import { browserTest as it, expect } from '../config/browserTest';
 import fs from 'fs';
 import path from 'path';
 
-it('should output a trace', async ({browser, server}, testInfo) => {
+it('should output a trace', async ({ browser, server }, testInfo) => {
   const page = await browser.newPage();
   const outputTraceFile = testInfo.outputPath(path.join(`trace.json`));
-  await browser.startTracing(page, {screenshots: true, path: outputTraceFile});
+  await browser.startTracing(page, { screenshots: true, path: outputTraceFile });
   await page.goto(server.PREFIX + '/grid.html');
   await browser.stopTracing();
   expect(fs.existsSync(outputTraceFile)).toBe(true);
   await page.close();
 });
 
-it('should create directories as needed', async ({browser, server}, testInfo) => {
+it('should create directories as needed', async ({ browser, server }, testInfo) => {
   const page = await browser.newPage();
   const filePath = testInfo.outputPath(path.join('these', 'are', 'directories', 'trace.json'));
-  await browser.startTracing(page, {screenshots: true, path: filePath});
+  await browser.startTracing(page, { screenshots: true, path: filePath });
   await page.goto(server.PREFIX + '/grid.html');
   await browser.stopTracing();
   expect(fs.existsSync(filePath)).toBe(true);
   await page.close();
 });
 
-it('should run with custom categories if provided', async ({browser}, testInfo) => {
+it('should run with custom categories if provided', async ({ browser }, testInfo) => {
   const page = await browser.newPage();
   const outputTraceFile = testInfo.outputPath(path.join(`trace.json`));
-  await browser.startTracing(page, {path: outputTraceFile, categories: ['disabled-by-default-v8.cpu_profiler.hires']});
+  await browser.startTracing(page, { path: outputTraceFile, categories: ['disabled-by-default-v8.cpu_profiler.hires'] });
   await browser.stopTracing();
 
   const traceJson = JSON.parse(fs.readFileSync(outputTraceFile).toString());
@@ -49,23 +49,23 @@ it('should run with custom categories if provided', async ({browser}, testInfo) 
   await page.close();
 });
 
-it('should throw if tracing on two pages', async ({browser}, testInfo) => {
+it('should throw if tracing on two pages', async ({ browser }, testInfo) => {
   const page = await browser.newPage();
   const outputTraceFile = testInfo.outputPath(path.join(`trace.json`));
-  await browser.startTracing(page, {path: outputTraceFile});
+  await browser.startTracing(page, { path: outputTraceFile });
   const newPage = await browser.newPage();
   let error = null;
-  await browser.startTracing(newPage, {path: outputTraceFile}).catch(e => error = e);
+  await browser.startTracing(newPage, { path: outputTraceFile }).catch(e => error = e);
   await newPage.close();
   expect(error).toBeTruthy();
   await browser.stopTracing();
   await page.close();
 });
 
-it('should return a buffer', async ({browser, server}, testInfo) => {
+it('should return a buffer', async ({ browser, server }, testInfo) => {
   const page = await browser.newPage();
   const outputTraceFile = testInfo.outputPath(path.join(`trace.json`));
-  await browser.startTracing(page, {screenshots: true, path: outputTraceFile});
+  await browser.startTracing(page, { screenshots: true, path: outputTraceFile });
   await page.goto(server.PREFIX + '/grid.html');
   const trace = await browser.stopTracing();
   const buf = fs.readFileSync(outputTraceFile);
@@ -73,7 +73,7 @@ it('should return a buffer', async ({browser, server}, testInfo) => {
   await page.close();
 });
 
-it('should work without options', async ({browser, server}) => {
+it('should work without options', async ({ browser, server }) => {
   const page = await browser.newPage();
   await browser.startTracing(page);
   await page.goto(server.PREFIX + '/grid.html');
@@ -82,9 +82,9 @@ it('should work without options', async ({browser, server}) => {
   await page.close();
 });
 
-it('should support a buffer without a path', async ({browser, server}) => {
+it('should support a buffer without a path', async ({ browser, server }) => {
   const page = await browser.newPage();
-  await browser.startTracing(page, {screenshots: true});
+  await browser.startTracing(page, { screenshots: true });
   await page.goto(server.PREFIX + '/grid.html');
   const trace = await browser.stopTracing();
   expect(trace.toString()).toContain('screenshot');

--- a/tests/config/baseTest.ts
+++ b/tests/config/baseTest.ts
@@ -76,7 +76,7 @@ class ServiceMode {
       });
     });
     this._serviceProcess.on('exit', this._onExit);
-    this._client = await PlaywrightClient.connect({wsEndpoint: `ws://localhost:${port}/ws`});
+    this._client = await PlaywrightClient.connect({ wsEndpoint: `ws://localhost:${port}/ws` });
     return this._client.playwright();
   }
 

--- a/tests/defaultbrowsercontext-1.spec.ts
+++ b/tests/defaultbrowsercontext-1.spec.ts
@@ -19,8 +19,8 @@ import { playwrightTest as it, expect } from './config/browserTest';
 import { verifyViewport } from './config/utils';
 import fs from 'fs';
 
-it('context.cookies() should work', async ({server, launchPersistent, browserName}) => {
-  const {page} = await launchPersistent();
+it('context.cookies() should work', async ({ server, launchPersistent, browserName }) => {
+  const { page } = await launchPersistent();
   await page.goto(server.EMPTY_PAGE);
   const documentCookie = await page.evaluate(() => {
     document.cookie = 'username=John Doe';
@@ -39,8 +39,8 @@ it('context.cookies() should work', async ({server, launchPersistent, browserNam
   }]);
 });
 
-it('context.addCookies() should work', async ({server, launchPersistent, browserName, isWindows}) => {
-  const {page} = await launchPersistent();
+it('context.addCookies() should work', async ({ server, launchPersistent, browserName, isWindows }) => {
+  const { page } = await launchPersistent();
   await page.goto(server.EMPTY_PAGE);
   await page.context().addCookies([{
     url: server.EMPTY_PAGE,
@@ -61,8 +61,8 @@ it('context.addCookies() should work', async ({server, launchPersistent, browser
   }]);
 });
 
-it('context.clearCookies() should work', async ({server, launchPersistent}) => {
-  const {page} = await launchPersistent();
+it('context.clearCookies() should work', async ({ server, launchPersistent }) => {
+  const { page } = await launchPersistent();
   await page.goto(server.EMPTY_PAGE);
   await page.context().addCookies([{
     url: server.EMPTY_PAGE,
@@ -80,8 +80,8 @@ it('context.clearCookies() should work', async ({server, launchPersistent}) => {
   expect(await page.evaluate('document.cookie')).toBe('');
 });
 
-it('should(not) block third party cookies', async ({server, launchPersistent, browserName}) => {
-  const {page, context} = await launchPersistent();
+it('should(not) block third party cookies', async ({ server, launchPersistent, browserName }) => {
+  const { page, context } = await launchPersistent();
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(src => {
     let fulfill;
@@ -118,20 +118,20 @@ it('should(not) block third party cookies', async ({server, launchPersistent, br
   }
 });
 
-it('should support viewport option', async ({launchPersistent}) => {
-  const {page, context} = await launchPersistent({viewport: { width: 456, height: 789 }});
+it('should support viewport option', async ({ launchPersistent }) => {
+  const { page, context } = await launchPersistent({ viewport: { width: 456, height: 789 } });
   await verifyViewport(page, 456, 789);
   const page2 = await context.newPage();
   await verifyViewport(page2, 456, 789);
 });
 
-it('should support deviceScaleFactor option', async ({launchPersistent}) => {
-  const {page} = await launchPersistent({deviceScaleFactor: 3});
+it('should support deviceScaleFactor option', async ({ launchPersistent }) => {
+  const { page } = await launchPersistent({ deviceScaleFactor: 3 });
   expect(await page.evaluate('window.devicePixelRatio')).toBe(3);
 });
 
-it('should support userAgent option', async ({server, launchPersistent}) => {
-  const {page} = await launchPersistent({userAgent: 'foobar'});
+it('should support userAgent option', async ({ server, launchPersistent }) => {
+  const { page } = await launchPersistent({ userAgent: 'foobar' });
   expect(await page.evaluate(() => navigator.userAgent)).toBe('foobar');
   const [request] = await Promise.all([
     server.waitForRequest('/empty.html'),
@@ -140,15 +140,15 @@ it('should support userAgent option', async ({server, launchPersistent}) => {
   expect(request.headers['user-agent']).toBe('foobar');
 });
 
-it('should support bypassCSP option', async ({server, launchPersistent}) => {
-  const {page} = await launchPersistent({bypassCSP: true});
+it('should support bypassCSP option', async ({ server, launchPersistent }) => {
+  const { page } = await launchPersistent({ bypassCSP: true });
   await page.goto(server.PREFIX + '/csp.html');
-  await page.addScriptTag({content: 'window["__injected"] = 42;'});
+  await page.addScriptTag({ content: 'window["__injected"] = 42;' });
   expect(await page.evaluate('__injected')).toBe(42);
 });
 
-it('should support javascriptEnabled option', async ({launchPersistent, browserName}) => {
-  const {page} = await launchPersistent({javaScriptEnabled: false});
+it('should support javascriptEnabled option', async ({ launchPersistent, browserName }) => {
+  const { page } = await launchPersistent({ javaScriptEnabled: false });
   await page.goto('data:text/html, <script>var something = "forbidden"</script>');
   let error = null;
   await page.evaluate('something').catch(e => error = e);
@@ -158,23 +158,23 @@ it('should support javascriptEnabled option', async ({launchPersistent, browserN
     expect(error.message).toContain('something is not defined');
 });
 
-it('should support httpCredentials option', async ({server, launchPersistent}) => {
-  const {page} = await launchPersistent({httpCredentials: { username: 'user', password: 'pass' }});
+it('should support httpCredentials option', async ({ server, launchPersistent }) => {
+  const { page } = await launchPersistent({ httpCredentials: { username: 'user', password: 'pass' } });
   server.setAuth('/playground.html', 'user', 'pass');
   const response = await page.goto(server.PREFIX + '/playground.html');
   expect(response.status()).toBe(200);
 });
 
-it('should support offline option', async ({server, launchPersistent}) => {
-  const {page} = await launchPersistent({offline: true});
+it('should support offline option', async ({ server, launchPersistent }) => {
+  const { page } = await launchPersistent({ offline: true });
   const error = await page.goto(server.EMPTY_PAGE).catch(e => e);
   expect(error).toBeTruthy();
 });
 
-it('should support acceptDownloads option', async ({server, launchPersistent}) => {
+it('should support acceptDownloads option', async ({ server, launchPersistent }) => {
   it.skip(true, 'Unskip once we support downloads in persistent context.');
 
-  const {page} = await launchPersistent({acceptDownloads: true});
+  const { page } = await launchPersistent({ acceptDownloads: true });
   server.setRoute('/download', (req, res) => {
     res.setHeader('Content-Type', 'application/octet-stream');
     res.setHeader('Content-Disposition', 'attachment');

--- a/tests/defaultbrowsercontext-2.spec.ts
+++ b/tests/defaultbrowsercontext-2.spec.ts
@@ -18,68 +18,68 @@
 import { playwrightTest as it, expect } from './config/browserTest';
 import fs from 'fs';
 
-it('should support hasTouch option', async ({server, launchPersistent}) => {
-  const {page} = await launchPersistent({hasTouch: true});
+it('should support hasTouch option', async ({ server, launchPersistent }) => {
+  const { page } = await launchPersistent({ hasTouch: true });
   await page.goto(server.PREFIX + '/mobile.html');
   expect(await page.evaluate(() => 'ontouchstart' in window)).toBe(true);
 });
 
-it('should work in persistent context', async ({server, launchPersistent, browserName}) => {
+it('should work in persistent context', async ({ server, launchPersistent, browserName }) => {
   it.skip(browserName === 'firefox', 'Firefox does not support mobile');
 
-  const {page} = await launchPersistent({viewport: {width: 320, height: 480}, isMobile: true});
+  const { page } = await launchPersistent({ viewport: { width: 320, height: 480 }, isMobile: true });
   await page.goto(server.PREFIX + '/empty.html');
   expect(await page.evaluate(() => window.innerWidth)).toBe(980);
 });
 
-it('should support colorScheme option', async ({launchPersistent}) => {
-  const {page} = await launchPersistent({colorScheme: 'dark'});
+it('should support colorScheme option', async ({ launchPersistent }) => {
+  const { page } = await launchPersistent({ colorScheme: 'dark' });
   expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: light)').matches)).toBe(false);
   expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches)).toBe(true);
 });
 
-it('should support reducedMotion option', async ({launchPersistent}) => {
-  const {page} = await launchPersistent({reducedMotion: 'reduce'});
+it('should support reducedMotion option', async ({ launchPersistent }) => {
+  const { page } = await launchPersistent({ reducedMotion: 'reduce' });
   expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: no-preference)').matches)).toBe(false);
 });
 
-it('should support forcedColors option', async ({launchPersistent, browserName}) => {
+it('should support forcedColors option', async ({ launchPersistent, browserName }) => {
   it.skip(browserName === 'webkit', 'https://bugs.webkit.org/show_bug.cgi?id=225281');
-  const {page} = await launchPersistent({forcedColors: 'active'});
+  const { page } = await launchPersistent({ forcedColors: 'active' });
   expect(await page.evaluate(() => matchMedia('(forced-colors: active)').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('(forced-colors: none)').matches)).toBe(false);
 });
 
-it('should support timezoneId option', async ({launchPersistent, browserName}) => {
-  const {page} = await launchPersistent({locale: 'en-US', timezoneId: 'America/Jamaica'});
+it('should support timezoneId option', async ({ launchPersistent, browserName }) => {
+  const { page } = await launchPersistent({ locale: 'en-US', timezoneId: 'America/Jamaica' });
   expect(await page.evaluate(() => new Date(1479579154987).toString())).toBe('Sat Nov 19 2016 13:12:34 GMT-0500 (Eastern Standard Time)');
 });
 
-it('should support locale option', async ({launchPersistent}) => {
-  const {page} = await launchPersistent({locale: 'fr-CH'});
+it('should support locale option', async ({ launchPersistent }) => {
+  const { page } = await launchPersistent({ locale: 'fr-CH' });
   expect(await page.evaluate(() => navigator.language)).toBe('fr-CH');
 });
 
-it('should support geolocation and permissions options', async ({server, launchPersistent}) => {
-  const {page} = await launchPersistent({geolocation: {longitude: 10, latitude: 10}, permissions: ['geolocation']});
+it('should support geolocation and permissions options', async ({ server, launchPersistent }) => {
+  const { page } = await launchPersistent({ geolocation: { longitude: 10, latitude: 10 }, permissions: ['geolocation'] });
   await page.goto(server.EMPTY_PAGE);
   const geolocation = await page.evaluate(() => new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {
-    resolve({latitude: position.coords.latitude, longitude: position.coords.longitude});
+    resolve({ latitude: position.coords.latitude, longitude: position.coords.longitude });
   })));
-  expect(geolocation).toEqual({latitude: 10, longitude: 10});
+  expect(geolocation).toEqual({ latitude: 10, longitude: 10 });
 });
 
-it('should support ignoreHTTPSErrors option', async ({httpsServer, launchPersistent}) => {
-  const {page} = await launchPersistent({ignoreHTTPSErrors: true});
+it('should support ignoreHTTPSErrors option', async ({ httpsServer, launchPersistent }) => {
+  const { page } = await launchPersistent({ ignoreHTTPSErrors: true });
   let error = null;
   const response = await page.goto(httpsServer.EMPTY_PAGE).catch(e => error = e);
   expect(error).toBe(null);
   expect(response.ok()).toBe(true);
 });
 
-it('should support extraHTTPHeaders option', async ({server, launchPersistent}) => {
-  const {page} = await launchPersistent({extraHTTPHeaders: { foo: 'bar' }});
+it('should support extraHTTPHeaders option', async ({ server, launchPersistent }) => {
+  const { page } = await launchPersistent({ extraHTTPHeaders: { foo: 'bar' } });
   const [request] = await Promise.all([
     server.waitForRequest('/empty.html'),
     page.goto(server.EMPTY_PAGE),
@@ -87,7 +87,7 @@ it('should support extraHTTPHeaders option', async ({server, launchPersistent}) 
   expect(request.headers['foo']).toBe('bar');
 });
 
-it('should accept userDataDir', async ({createUserDataDir, browserType, browserOptions}) => {
+it('should accept userDataDir', async ({ createUserDataDir, browserType, browserOptions }) => {
   const userDataDir = await createUserDataDir();
   const context = await browserType.launchPersistentContext(userDataDir, browserOptions);
   expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
@@ -95,7 +95,7 @@ it('should accept userDataDir', async ({createUserDataDir, browserType, browserO
   expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
 });
 
-it('should restore state from userDataDir', async ({browserType, browserOptions, server, createUserDataDir}) => {
+it('should restore state from userDataDir', async ({ browserType, browserOptions, server, createUserDataDir }) => {
   it.slow();
 
   const userDataDir = await createUserDataDir();
@@ -119,7 +119,7 @@ it('should restore state from userDataDir', async ({browserType, browserOptions,
   await browserContext3.close();
 });
 
-it('should restore cookies from userDataDir', async ({browserType, browserOptions,  server, createUserDataDir, platform, channel}) => {
+it('should restore cookies from userDataDir', async ({ browserType, browserOptions,  server, createUserDataDir, platform, channel }) => {
   it.fixme(platform === 'win32' && channel === 'chrome');
   it.slow();
 
@@ -148,21 +148,21 @@ it('should restore cookies from userDataDir', async ({browserType, browserOption
   await browserContext3.close();
 });
 
-it('should have default URL when launching browser', async ({launchPersistent}) => {
-  const {context} = await launchPersistent();
+it('should have default URL when launching browser', async ({ launchPersistent }) => {
+  const { context } = await launchPersistent();
   const urls = context.pages().map(page => page.url());
   expect(urls).toEqual(['about:blank']);
 });
 
-it('should throw if page argument is passed', async ({browserType, browserOptions, server, createUserDataDir, browserName}) => {
+it('should throw if page argument is passed', async ({ browserType, browserOptions, server, createUserDataDir, browserName }) => {
   it.skip(browserName === 'firefox');
 
-  const options = {...browserOptions, args: [server.EMPTY_PAGE] };
+  const options = { ...browserOptions, args: [server.EMPTY_PAGE] };
   const error = await browserType.launchPersistentContext(await createUserDataDir(), options).catch(e => e);
   expect(error.message).toContain('can not specify page');
 });
 
-it('should have passed URL when launching with ignoreDefaultArgs: true', async ({browserType, browserOptions, server, createUserDataDir, toImpl, mode, browserName}) => {
+it('should have passed URL when launching with ignoreDefaultArgs: true', async ({ browserType, browserOptions, server, createUserDataDir, toImpl, mode, browserName }) => {
   it.skip(mode !== 'default');
 
   const userDataDir = await createUserDataDir();
@@ -181,7 +181,7 @@ it('should have passed URL when launching with ignoreDefaultArgs: true', async (
   await browserContext.close();
 });
 
-it('should handle timeout', async ({browserType, browserOptions, createUserDataDir, mode}) => {
+it('should handle timeout', async ({ browserType, browserOptions, createUserDataDir, mode }) => {
   it.skip(mode !== 'default');
 
   const options = { ...browserOptions, timeout: 5000, __testHookBeforeCreateBrowser: () => new Promise(f => setTimeout(f, 6000)) };
@@ -189,7 +189,7 @@ it('should handle timeout', async ({browserType, browserOptions, createUserDataD
   expect(error.message).toContain(`browserType.launchPersistentContext: Timeout 5000ms exceeded.`);
 });
 
-it('should handle exception', async ({browserType, browserOptions, createUserDataDir, mode}) => {
+it('should handle exception', async ({ browserType, browserOptions, createUserDataDir, mode }) => {
   it.skip(mode !== 'default');
 
   const e = new Error('Dummy');
@@ -198,18 +198,18 @@ it('should handle exception', async ({browserType, browserOptions, createUserDat
   expect(error.message).toContain('Dummy');
 });
 
-it('should fire close event for a persistent context', async ({launchPersistent}) => {
-  const {context} = await launchPersistent();
+it('should fire close event for a persistent context', async ({ launchPersistent }) => {
+  const { context } = await launchPersistent();
   let closed = false;
   context.on('close', () => closed = true);
   await context.close();
   expect(closed).toBe(true);
 });
 
-it('coverage should work', async ({server, launchPersistent, browserName}) => {
+it('coverage should work', async ({ server, launchPersistent, browserName }) => {
   it.skip(browserName !== 'chromium');
 
-  const {page} = await launchPersistent();
+  const { page } = await launchPersistent();
   await page.coverage.startJSCoverage();
   await page.goto(server.PREFIX + '/jscoverage/simple.html', { waitUntil: 'load' });
   const coverage = await page.coverage.stopJSCoverage();
@@ -218,8 +218,8 @@ it('coverage should work', async ({server, launchPersistent, browserName}) => {
   expect(coverage[0].functions.find(f => f.functionName === 'foo').ranges[0].count).toEqual(1);
 });
 
-it('should respect selectors', async ({playwright, launchPersistent}) => {
-  const {page} = await launchPersistent();
+it('should respect selectors', async ({ playwright, launchPersistent }) => {
+  const { page } = await launchPersistent();
 
   const defaultContextCSS = () => ({
     query(root, selector) {
@@ -236,7 +236,7 @@ it('should respect selectors', async ({playwright, launchPersistent}) => {
   expect(await page.innerHTML('defaultContextCSS=div')).toBe('hello');
 });
 
-it('should connect to a browser with the default page', async ({browserType, browserOptions, createUserDataDir, mode}) => {
+it('should connect to a browser with the default page', async ({ browserType, browserOptions, createUserDataDir, mode }) => {
   it.skip(mode !== 'default');
 
   const options = { ...browserOptions, __testHookOnConnectToBrowser: () => new Promise(f => setTimeout(f, 3000)) };

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -20,7 +20,7 @@ import path from 'path';
 import crypto from 'crypto';
 
 it.describe('download event', () => {
-  it.beforeEach(async ({server}) => {
+  it.beforeEach(async ({ server }) => {
     server.setRoute('/download', (req, res) => {
       res.setHeader('Content-Type', 'application/octet-stream');
       res.setHeader('Content-Disposition', 'attachment');
@@ -41,7 +41,7 @@ it.describe('download event', () => {
     });
   });
 
-  it('should report download when navigation turns into download', async ({browser, server, browserName}) => {
+  it('should report download when navigation turns into download', async ({ browser, server, browserName }) => {
     const page = await browser.newPage({ acceptDownloads: true });
     const [ download, responseOrError ] = await Promise.all([
       page.waitForEvent('download'),
@@ -67,7 +67,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should report downloads with acceptDownloads: false', async ({browser, server}) => {
+  it('should report downloads with acceptDownloads: false', async ({ browser, server }) => {
     const page = await browser.newPage();
     await page.setContent(`<a href="${server.PREFIX}/downloadWithFilename">download</a>`);
     const [ download ] = await Promise.all([
@@ -84,7 +84,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should report downloads with acceptDownloads: true', async ({browser, server}) => {
+  it('should report downloads with acceptDownloads: true', async ({ browser, server }) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -97,7 +97,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should report proper download url when download is from download attribute', async ({browser, server, browserName}) => {
+  it('should report proper download url when download is from download attribute', async ({ browser, server, browserName }) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.goto(server.PREFIX + '/empty.html');
     await page.setContent(`<a href="${server.PREFIX}/chromium-linux.zip" download="foo.zip">download</a>`);
@@ -109,7 +109,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should report downloads for download attribute', async ({browser, server}) => {
+  it('should report downloads for download attribute', async ({ browser, server }) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.goto(server.PREFIX + '/empty.html');
     await page.setContent(`<a href="${server.PREFIX}/chromium-linux.zip" download="foo.zip">download</a>`);
@@ -123,7 +123,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should save to user-specified path', async ({browser, server}, testInfo) => {
+  it('should save to user-specified path', async ({ browser, server }, testInfo) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -137,7 +137,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should save to user-specified path without updating original path', async ({browser, server}, testInfo) => {
+  it('should save to user-specified path without updating original path', async ({ browser, server }, testInfo) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -155,7 +155,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should save to two different paths with multiple saveAs calls', async ({browser, server}, testInfo) => {
+  it('should save to two different paths with multiple saveAs calls', async ({ browser, server }, testInfo) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -174,7 +174,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should save to overwritten filepath', async ({browser, server}, testInfo) => {
+  it('should save to overwritten filepath', async ({ browser, server }, testInfo) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -192,7 +192,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should create subdirectories when saving to non-existent user-specified path', async ({browser, server}, testInfo) => {
+  it('should create subdirectories when saving to non-existent user-specified path', async ({ browser, server }, testInfo) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -206,7 +206,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should error when saving with downloads disabled', async ({browser, server}, testInfo) => {
+  it('should error when saving with downloads disabled', async ({ browser, server }, testInfo) => {
     const page = await browser.newPage({ acceptDownloads: false });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -219,7 +219,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should error when saving after deletion', async ({browser, server}, testInfo) => {
+  it('should error when saving after deletion', async ({ browser, server }, testInfo) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -233,7 +233,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should report non-navigation downloads', async ({browser, server}) => {
+  it('should report non-navigation downloads', async ({ browser, server }) => {
     // Mac WebKit embedder does not download in this case, although Safari does.
     server.setRoute('/download', (req, res) => {
       res.setHeader('Content-Type', 'application/octet-stream');
@@ -254,7 +254,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it(`should report download path within page.on('download', …) handler for Files`, async ({browser, server}) => {
+  it(`should report download path within page.on('download', …) handler for Files`, async ({ browser, server }) => {
     const page = await browser.newPage({ acceptDownloads: true });
     const onDownloadPath = new Promise<string>(res => {
       page.on('download', dl => {
@@ -268,7 +268,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it(`should report download path within page.on('download', …) handler for Blobs`, async ({browser, server}) => {
+  it(`should report download path within page.on('download', …) handler for Blobs`, async ({ browser, server }) => {
     const page = await browser.newPage({ acceptDownloads: true });
     const onDownloadPath = new Promise<string>(res => {
       page.on('download', dl => {
@@ -282,7 +282,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should report alt-click downloads', async ({browser, server, browserName}) => {
+  it('should report alt-click downloads', async ({ browser, server, browserName }) => {
     it.fixme(browserName === 'firefox' || browserName === 'webkit');
 
     // Firefox does not download on alt-click by default.
@@ -297,7 +297,7 @@ it.describe('download event', () => {
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
       page.waitForEvent('download'),
-      page.click('a', { modifiers: ['Alt']})
+      page.click('a', { modifiers: ['Alt'] })
     ]);
     const path = await download.path();
     expect(fs.existsSync(path)).toBeTruthy();
@@ -305,7 +305,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should report new window downloads', async ({browser, server}) => {
+  it('should report new window downloads', async ({ browser, server }) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a target=_blank href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -317,7 +317,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should delete file', async ({browser, server}) => {
+  it('should delete file', async ({ browser, server }) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -331,7 +331,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should expose stream', async ({browser, server}) => {
+  it('should expose stream', async ({ browser, server }) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -346,7 +346,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should delete downloads on context destruction', async ({browser, server}) => {
+  it('should delete downloads on context destruction', async ({ browser, server }) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download1 ] = await Promise.all([
@@ -388,7 +388,7 @@ it.describe('download event', () => {
     expect(fs.existsSync(path.join(path1, '..'))).toBeFalsy();
   });
 
-  it('should close the context without awaiting the failed download', async ({browser, server, httpsServer, browserName, headless}, testInfo) => {
+  it('should close the context without awaiting the failed download', async ({ browser, server, httpsServer, browserName, headless }, testInfo) => {
     it.skip(browserName !== 'chromium', 'Only Chromium downloads on alt-click');
 
     const page = await browser.newPage({ acceptDownloads: true });
@@ -398,7 +398,7 @@ it.describe('download event', () => {
       page.waitForEvent('download'),
       // Use alt-click to force the download. Otherwise browsers might try to navigate first,
       // probably because of http -> https link.
-      page.click('a', { modifiers: ['Alt']})
+      page.click('a', { modifiers: ['Alt'] })
     ]);
     const [downloadPath, saveError] = await Promise.all([
       download.path(),
@@ -412,7 +412,7 @@ it.describe('download event', () => {
     ]).toContain(saveError.message);
   });
 
-  it('should close the context without awaiting the download', async ({browser, server, browserName, platform}, testInfo) => {
+  it('should close the context without awaiting the download', async ({ browser, server, browserName, platform }, testInfo) => {
     it.skip(browserName === 'webkit' && platform === 'linux', 'WebKit on linux does not convert to the download immediately upon receiving headers');
 
     server.setRoute('/downloadStall', (req, res) => {
@@ -444,7 +444,7 @@ it.describe('download event', () => {
     ]).toContain(saveError.message);
   });
 
-  it('should throw if browser dies', async ({ server, browserType, browserName, browserOptions, platform}, testInfo) => {
+  it('should throw if browser dies', async ({ server, browserType, browserName, browserOptions, platform }, testInfo) => {
     it.skip(browserName === 'webkit' && platform === 'linux', 'WebKit on linux does not convert to the download immediately upon receiving headers');
     server.setRoute('/downloadStall', (req, res) => {
       res.setHeader('Content-Type', 'application/octet-stream');
@@ -471,7 +471,7 @@ it.describe('download event', () => {
     await browser.close();
   });
 
-  it('should download large binary.zip', async ({browser, server, browserName}, testInfo) => {
+  it('should download large binary.zip', async ({ browser, server, browserName }, testInfo) => {
     const zipFile = testInfo.outputPath('binary.zip');
     const content = crypto.randomBytes(1 << 20);
     fs.writeFileSync(zipFile, content);
@@ -501,7 +501,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should be able to cancel pending downloads', async ({browser, server, browserName, browserVersion}) => {
+  it('should be able to cancel pending downloads', async ({ browser, server, browserName, browserVersion }) => {
     // The exact upstream change is in b449b5c, which still does not appear in the first few 91.* tags until 91.0.4437.0.
     it.fixme(browserName === 'chromium' && Number(browserVersion.split('.')[0]) < 91, 'The upstream Browser.cancelDownload command is not available before Chrome 91');
     const page = await browser.newPage({ acceptDownloads: true });
@@ -516,7 +516,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should not fail explicitly to cancel a download even if that is already finished', async ({browser, server, browserName, browserVersion}) => {
+  it('should not fail explicitly to cancel a download even if that is already finished', async ({ browser, server, browserName, browserVersion }) => {
     // The exact upstream change is in b449b5c, which still does not appear in the first few 91.* tags until 91.0.4437.0.
     it.fixme(browserName === 'chromium' && Number(browserVersion.split('.')[0]) < 91, 'The upstream Browser.cancelDownload command is not available before Chrome 91');
     const page = await browser.newPage({ acceptDownloads: true });
@@ -534,7 +534,7 @@ it.describe('download event', () => {
     await page.close();
   });
 
-  it('should report downloads with interception', async ({browser, server}) => {
+  it('should report downloads with interception', async ({ browser, server }) => {
     const page = await browser.newPage({ acceptDownloads: true });
     await page.route(/.*/, r => r.continue());
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);

--- a/tests/downloads-path.spec.ts
+++ b/tests/downloads-path.spec.ts
@@ -19,7 +19,7 @@ import fs from 'fs';
 import path from 'path';
 
 it.describe('downloads path', () => {
-  it.beforeEach(async ({server}) => {
+  it.beforeEach(async ({ server }) => {
     server.setRoute('/download', (req, res) => {
       res.setHeader('Content-Type', 'application/octet-stream');
       res.setHeader('Content-Disposition', 'attachment; filename=file.txt');
@@ -27,7 +27,7 @@ it.describe('downloads path', () => {
     });
   });
 
-  it('should keep downloadsPath folder', async ({browserType, browserOptions, server}, testInfo)  => {
+  it('should keep downloadsPath folder', async ({ browserType, browserOptions, server }, testInfo)  => {
     const downloadsBrowser = await browserType.launch({ ...browserOptions, downloadsPath: testInfo.outputPath('') });
     const page = await downloadsBrowser.newPage();
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
@@ -43,7 +43,7 @@ it.describe('downloads path', () => {
     expect(fs.existsSync(testInfo.outputPath(''))).toBeTruthy();
   });
 
-  it('should delete downloads when context closes', async ({browserType, browserOptions, server}, testInfo) => {
+  it('should delete downloads when context closes', async ({ browserType, browserOptions, server }, testInfo) => {
     const downloadsBrowser = await browserType.launch({ ...browserOptions, downloadsPath: testInfo.outputPath('') });
     const page = await downloadsBrowser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
@@ -58,7 +58,7 @@ it.describe('downloads path', () => {
     await downloadsBrowser.close();
   });
 
-  it('should report downloads in downloadsPath folder', async ({browserType, browserOptions, server}, testInfo) => {
+  it('should report downloads in downloadsPath folder', async ({ browserType, browserOptions, server }, testInfo) => {
     const downloadsBrowser = await browserType.launch({ ...browserOptions, downloadsPath: testInfo.outputPath('') });
     const page = await downloadsBrowser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
@@ -72,7 +72,7 @@ it.describe('downloads path', () => {
     await downloadsBrowser.close();
   });
 
-  it('should report downloads in downloadsPath folder with a relative path', async ({browserType, browserOptions, server}, testInfo) => {
+  it('should report downloads in downloadsPath folder with a relative path', async ({ browserType, browserOptions, server }, testInfo) => {
     const downloadsBrowser = await browserType.launch({ ...browserOptions, downloadsPath: path.relative(process.cwd(), testInfo.outputPath('')) });
     const page = await downloadsBrowser.newPage({ acceptDownloads: true });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
@@ -86,7 +86,7 @@ it.describe('downloads path', () => {
     await downloadsBrowser.close();
   });
 
-  it('should accept downloads in persistent context', async ({launchPersistent, server}, testInfo)  => {
+  it('should accept downloads in persistent context', async ({ launchPersistent, server }, testInfo)  => {
     const { context, page } = await launchPersistent({ acceptDownloads: true, downloadsPath: testInfo.outputPath('') });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([
@@ -100,7 +100,7 @@ it.describe('downloads path', () => {
     await context.close();
   });
 
-  it('should delete downloads when persistent context closes', async ({launchPersistent, server}, testInfo) => {
+  it('should delete downloads when persistent context closes', async ({ launchPersistent, server }, testInfo) => {
     const { context, page } = await launchPersistent({ acceptDownloads: true, downloadsPath: testInfo.outputPath('') });
     await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
     const [ download ] = await Promise.all([

--- a/tests/electron/electron-app.spec.ts
+++ b/tests/electron/electron-app.spec.ts
@@ -86,8 +86,8 @@ test('should wait for first window', async ({ electronApp }) => {
 
 test('should have a clipboard instance', async ({ electronApp }) => {
   const clipboardContentToWrite = 'Hello from Playwright';
-  await electronApp.evaluate(async ({clipboard}, text) => clipboard.writeText(text), clipboardContentToWrite);
-  const clipboardContentRead = await electronApp.evaluate(async ({clipboard}) => clipboard.readText());
+  await electronApp.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), clipboardContentToWrite);
+  const clipboardContentRead = await electronApp.evaluate(async ({ clipboard }) => clipboard.readText());
   expect(clipboardContentRead).toEqual(clipboardContentToWrite);
 });
 
@@ -108,7 +108,7 @@ test('should return browser window', async ({ playwright }) => {
   await electronApp.close();
 });
 
-test('should bypass csp', async ({playwright, server}) => {
+test('should bypass csp', async ({ playwright, server }) => {
   const app = await playwright._electron.launch({
     args: [require('path').join(__dirname, 'electron-app.js')],
     bypassCSP: true,
@@ -122,7 +122,7 @@ test('should bypass csp', async ({playwright, server}) => {
   });
   const page = await app.firstWindow();
   await page.goto(server.PREFIX + '/csp.html');
-  await page.addScriptTag({content: 'window["__injected"] = 42;'});
+  await page.addScriptTag({ content: 'window["__injected"] = 42;' });
   expect(await page.evaluate('window["__injected"]')).toBe(42);
   await app.close();
 });

--- a/tests/electron/electron-window.spec.ts
+++ b/tests/electron/electron-window.spec.ts
@@ -16,28 +16,28 @@
 
 import { electronTest as test, expect } from './electronTest';
 
-test('should click the button', async ({newWindow, server}) => {
+test('should click the button', async ({ newWindow, server }) => {
   const window = await newWindow();
   await window.goto(server.PREFIX + '/input/button.html');
   await window.click('button');
   expect(await window.evaluate('result')).toBe('Clicked');
 });
 
-test('should check the box', async ({newWindow}) => {
+test('should check the box', async ({ newWindow }) => {
   const window = await newWindow();
   await window.setContent(`<input id='checkbox' type='checkbox'></input>`);
   await window.check('input');
   expect(await window.evaluate('checkbox.checked')).toBe(true);
 });
 
-test('should not check the checked box', async ({newWindow}) => {
+test('should not check the checked box', async ({ newWindow }) => {
   const window = await newWindow();
   await window.setContent(`<input id='checkbox' type='checkbox' checked></input>`);
   await window.check('input');
   expect(await window.evaluate('checkbox.checked')).toBe(true);
 });
 
-test('should type into a textarea', async ({newWindow}) => {
+test('should type into a textarea', async ({ newWindow }) => {
   const window = await newWindow();
   await window.evaluate(() => {
     const textarea = document.createElement('textarea');

--- a/tests/emulation-focus.spec.ts
+++ b/tests/emulation-focus.spec.ts
@@ -18,18 +18,18 @@
 import { contextTest as it, browserTest, expect } from './config/browserTest';
 import { attachFrame } from './config/utils';
 
-it('should think that it is focused by default', async ({page}) => {
+it('should think that it is focused by default', async ({ page }) => {
   expect(await page.evaluate('document.hasFocus()')).toBe(true);
 });
 
-it('should think that all pages are focused', async ({page}) => {
+it('should think that all pages are focused', async ({ page }) => {
   const page2 = await page.context().newPage();
   expect(await page.evaluate('document.hasFocus()')).toBe(true);
   expect(await page2.evaluate('document.hasFocus()')).toBe(true);
   await page2.close();
 });
 
-it('should focus popups by default', async ({page, server}) => {
+it('should focus popups by default', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
@@ -39,7 +39,7 @@ it('should focus popups by default', async ({page, server}) => {
   expect(await page.evaluate('document.hasFocus()')).toBe(true);
 });
 
-it('should provide target for keyboard events', async ({page, server}) => {
+it('should provide target for keyboard events', async ({ page, server }) => {
   const page2 = await page.context().newPage();
   await Promise.all([
     page.goto(server.PREFIX + '/input/textarea.html'),
@@ -62,7 +62,7 @@ it('should provide target for keyboard events', async ({page, server}) => {
   expect(results).toEqual([text, text2]);
 });
 
-it('should not affect mouse event target page', async ({page, server}) => {
+it('should not affect mouse event target page', async ({ page, server }) => {
   const page2 = await page.context().newPage();
   function clickCounter() {
     document.onclick = () => window['clickCount']  = (window['clickCount'] || 0) + 1;
@@ -84,7 +84,7 @@ it('should not affect mouse event target page', async ({page, server}) => {
   expect(counters).toEqual([1,1]);
 });
 
-it('should change document.activeElement', async ({page, server}) => {
+it('should change document.activeElement', async ({ page, server }) => {
   const page2 = await page.context().newPage();
   await Promise.all([
     page.goto(server.PREFIX + '/input/textarea.html'),
@@ -101,14 +101,14 @@ it('should change document.activeElement', async ({page, server}) => {
   expect(active).toEqual(['INPUT', 'TEXTAREA']);
 });
 
-it('should not affect screenshots', async ({page, server, browserName, headless}) => {
+it('should not affect screenshots', async ({ page, server, browserName, headless }) => {
   it.skip(browserName === 'firefox' && !headless, 'Firefox headede produces a different image');
 
   const page2 = await page.context().newPage();
   await Promise.all([
-    page.setViewportSize({width: 500, height: 500}),
+    page.setViewportSize({ width: 500, height: 500 }),
     page.goto(server.PREFIX + '/grid.html'),
-    page2.setViewportSize({width: 50, height: 50}),
+    page2.setViewportSize({ width: 50, height: 50 }),
     page2.goto(server.PREFIX + '/grid.html'),
   ]);
   await Promise.all([
@@ -123,7 +123,7 @@ it('should not affect screenshots', async ({page, server, browserName, headless}
   expect(screenshots[1]).toMatchSnapshot('grid-cell-0.png');
 });
 
-it('should change focused iframe', async ({page, server}) => {
+it('should change focused iframe', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [frame1, frame2] = await Promise.all([
     attachFrame(page, 'frame1', server.PREFIX + '/input/textarea.html'),
@@ -172,7 +172,7 @@ it('should change focused iframe', async ({page, server}) => {
 });
 
 // @see https://github.com/microsoft/playwright/issues/3476
-browserTest('should focus with more than one page/context', async ({contextFactory}) => {
+browserTest('should focus with more than one page/context', async ({ contextFactory }) => {
   const page1 = await (await contextFactory()).newPage();
   const page2 = await (await contextFactory()).newPage();
   await page1.setContent(`<button id="foo" onfocus="window.gotFocus=true">foo</button>`);

--- a/tests/favicon.spec.ts
+++ b/tests/favicon.spec.ts
@@ -17,7 +17,7 @@
 
 import { contextTest as it } from './config/browserTest';
 
-it('should load svg favicon with prefer-color-scheme', async ({page, server, browserName, channel, headless, asset}) => {
+it('should load svg favicon with prefer-color-scheme', async ({ page, server, browserName, channel, headless, asset }) => {
   it.skip(headless && browserName !== 'firefox', 'headless browsers, except firefox, do not request favicons');
   it.skip(!headless && browserName === 'webkit' && !channel, 'headed webkit does not have a favicon feature');
 

--- a/tests/firefox/launcher.spec.ts
+++ b/tests/firefox/launcher.spec.ts
@@ -16,7 +16,7 @@
 
 import { playwrightTest as it, expect } from '../config/browserTest';
 
-it('should pass firefox user preferences', async ({browserType, browserOptions, browserName}) => {
+it('should pass firefox user preferences', async ({ browserType, browserOptions, browserName }) => {
   const browser = await browserType.launch({
     ...browserOptions,
     firefoxUserPrefs: {

--- a/tests/geolocation.spec.ts
+++ b/tests/geolocation.spec.ts
@@ -17,14 +17,14 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should work', async ({server, contextFactory}) => {
+it('should work', async ({ server, contextFactory }) => {
   const context = await contextFactory();
   const page = await context.newPage();
   await context.grantPermissions(['geolocation']);
   await page.goto(server.EMPTY_PAGE);
-  await context.setGeolocation({longitude: 10, latitude: 10});
+  await context.setGeolocation({ longitude: 10, latitude: 10 });
   const geolocation = await page.evaluate(() => new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {
-    resolve({latitude: position.coords.latitude, longitude: position.coords.longitude});
+    resolve({ latitude: position.coords.latitude, longitude: position.coords.longitude });
   })));
   expect(geolocation).toEqual({
     latitude: 10,
@@ -32,33 +32,33 @@ it('should work', async ({server, contextFactory}) => {
   });
 });
 
-it('should throw when invalid longitude', async ({contextFactory}) => {
+it('should throw when invalid longitude', async ({ contextFactory }) => {
   const context = await contextFactory();
   let error = null;
   try {
-    await context.setGeolocation({longitude: 200, latitude: 10});
+    await context.setGeolocation({ longitude: 200, latitude: 10 });
   } catch (e) {
     error = e;
   }
   expect(error.message).toContain('geolocation.longitude: precondition -180 <= LONGITUDE <= 180 failed.');
 });
 
-it('should isolate contexts', async ({server, contextFactory, browser}) => {
+it('should isolate contexts', async ({ server, contextFactory, browser }) => {
   const context = await contextFactory();
   const page = await context.newPage();
   await context.grantPermissions(['geolocation']);
-  await context.setGeolocation({longitude: 10, latitude: 10});
+  await context.setGeolocation({ longitude: 10, latitude: 10 });
   await page.goto(server.EMPTY_PAGE);
 
   const context2 = await browser.newContext({
     permissions: ['geolocation'],
-    geolocation: {longitude: 20, latitude: 20}
+    geolocation: { longitude: 20, latitude: 20 }
   });
   const page2 = await context2.newPage();
   await page2.goto(server.EMPTY_PAGE);
 
   const geolocation = await page.evaluate(() => new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {
-    resolve({latitude: position.coords.latitude, longitude: position.coords.longitude});
+    resolve({ latitude: position.coords.latitude, longitude: position.coords.longitude });
   })));
   expect(geolocation).toEqual({
     latitude: 10,
@@ -66,7 +66,7 @@ it('should isolate contexts', async ({server, contextFactory, browser}) => {
   });
 
   const geolocation2 = await page2.evaluate(() => new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {
-    resolve({latitude: position.coords.latitude, longitude: position.coords.longitude});
+    resolve({ latitude: position.coords.latitude, longitude: position.coords.longitude });
   })));
   expect(geolocation2).toEqual({
     latitude: 20,
@@ -76,19 +76,19 @@ it('should isolate contexts', async ({server, contextFactory, browser}) => {
   await context2.close();
 });
 
-it('should throw with missing latitude', async ({contextFactory}) => {
+it('should throw with missing latitude', async ({ contextFactory }) => {
   const context = await contextFactory();
   let error = null;
   try {
     // @ts-expect-error setGeolocation must have latitude
-    await context.setGeolocation({longitude: 10});
+    await context.setGeolocation({ longitude: 10 });
   } catch (e) {
     error = e;
   }
   expect(error.message).toContain('geolocation.latitude: expected number, got undefined');
 });
 
-it('should not modify passed default options object', async ({browser}) => {
+it('should not modify passed default options object', async ({ browser }) => {
   const geolocation = { longitude: 10, latitude: 10 };
   const options = { geolocation };
   const context = await browser.newContext(options);
@@ -97,11 +97,11 @@ it('should not modify passed default options object', async ({browser}) => {
   await context.close();
 });
 
-it('should throw with missing longitude in default options', async ({browser}) => {
+it('should throw with missing longitude in default options', async ({ browser }) => {
   let error = null;
   try {
     // @ts-expect-error geolocation must have longitude
-    const context = await browser.newContext({ geolocation: {latitude: 10} });
+    const context = await browser.newContext({ geolocation: { latitude: 10 } });
     await context.close();
   } catch (e) {
     error = e;
@@ -109,14 +109,14 @@ it('should throw with missing longitude in default options', async ({browser}) =
   expect(error.message).toContain('geolocation.longitude: expected number, got undefined');
 });
 
-it('should use context options', async ({browser, server}) => {
+it('should use context options', async ({ browser, server }) => {
   const options = { geolocation: { longitude: 10, latitude: 10 }, permissions: ['geolocation'] };
   const context = await browser.newContext(options);
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
 
   const geolocation = await page.evaluate(() => new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {
-    resolve({latitude: position.coords.latitude, longitude: position.coords.longitude});
+    resolve({ latitude: position.coords.latitude, longitude: position.coords.longitude });
   })));
   expect(geolocation).toEqual({
     latitude: 10,
@@ -125,7 +125,7 @@ it('should use context options', async ({browser, server}) => {
   await context.close();
 });
 
-it('watchPosition should be notified', async ({server, contextFactory}) => {
+it('watchPosition should be notified', async ({ server, contextFactory }) => {
   const context = await contextFactory();
   const page = await context.newPage();
   await context.grantPermissions(['geolocation']);
@@ -133,18 +133,18 @@ it('watchPosition should be notified', async ({server, contextFactory}) => {
   const messages = [];
   page.on('console', message => messages.push(message.text()));
 
-  await context.setGeolocation({latitude: 0, longitude: 0});
+  await context.setGeolocation({ latitude: 0, longitude: 0 });
   await page.evaluate(() => {
     navigator.geolocation.watchPosition(pos => {
       const coords = pos.coords;
       console.log(`lat=${coords.latitude} lng=${coords.longitude}`);
     }, err => {});
   });
-  await context.setGeolocation({latitude: 0, longitude: 10});
+  await context.setGeolocation({ latitude: 0, longitude: 10 });
   await page.waitForEvent('console', message => message.text().includes('lat=0 lng=10'));
-  await context.setGeolocation({latitude: 20, longitude: 30});
+  await context.setGeolocation({ latitude: 20, longitude: 30 });
   await page.waitForEvent('console', message => message.text().includes('lat=20 lng=30'));
-  await context.setGeolocation({latitude: 40, longitude: 50});
+  await context.setGeolocation({ latitude: 40, longitude: 50 });
   await page.waitForEvent('console', message => message.text().includes('lat=40 lng=50'));
 
   const allMessages = messages.join('|');
@@ -153,7 +153,7 @@ it('watchPosition should be notified', async ({server, contextFactory}) => {
   expect(allMessages).toContain('lat=40 lng=50');
 });
 
-it('should use context options for popup', async ({contextFactory, server}) => {
+it('should use context options for popup', async ({ contextFactory, server }) => {
   const context = await contextFactory();
   const page = await context.newPage();
   await context.grantPermissions(['geolocation']);

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -38,7 +38,7 @@ it.afterAll(() => {
 });
 
 for (const method of ['get', 'post', 'fetch']) {
-  it(`${method} should work`, async ({playwright, server}) => {
+  it(`${method} should work`, async ({ playwright, server }) => {
     const request = await playwright._newRequest();
     const response = await request[method](server.PREFIX + '/simple.json');
     expect(response.url()).toBe(server.PREFIX + '/simple.json');
@@ -51,7 +51,7 @@ for (const method of ['get', 'post', 'fetch']) {
     expect(await response.text()).toBe('{"foo": "bar"}\n');
   });
 
-  it(`should dispose global ${method} request`, async function({playwright, context, server}) {
+  it(`should dispose global ${method} request`, async function({ playwright, context, server }) {
     const request = await playwright._newRequest();
     const response = await request.get(server.PREFIX + '/simple.json');
     expect(await response.json()).toEqual({ foo: 'bar' });
@@ -61,8 +61,8 @@ for (const method of ['get', 'post', 'fetch']) {
   });
 }
 
-it('should support global userAgent option', async ({playwright, server}) => {
-  const request = await playwright._newRequest({ userAgent: 'My Agent'});
+it('should support global userAgent option', async ({ playwright, server }) => {
+  const request = await playwright._newRequest({ userAgent: 'My Agent' });
   const [serverRequest, response] = await Promise.all([
     server.waitForRequest('/empty.html'),
     request.get(server.EMPTY_PAGE)
@@ -72,17 +72,17 @@ it('should support global userAgent option', async ({playwright, server}) => {
   expect(serverRequest.headers['user-agent']).toBe('My Agent');
 });
 
-it('should support global timeout option', async ({playwright, server}) => {
-  const request = await playwright._newRequest({ timeout: 1});
+it('should support global timeout option', async ({ playwright, server }) => {
+  const request = await playwright._newRequest({ timeout: 1 });
   server.setRoute('/empty.html', (req, res) => {});
   const error = await request.get(server.EMPTY_PAGE).catch(e => e);
   expect(error.message).toContain('Request timed out after 1ms');
 });
 
-it('should propagate extra http headers with redirects', async ({playwright, server}) => {
+it('should propagate extra http headers with redirects', async ({ playwright, server }) => {
   server.setRedirect('/a/redirect1', '/b/c/redirect2');
   server.setRedirect('/b/c/redirect2', '/simple.json');
-  const request = await playwright._newRequest({ extraHTTPHeaders: { 'My-Secret': 'Value' }});
+  const request = await playwright._newRequest({ extraHTTPHeaders: { 'My-Secret': 'Value' } });
   const [req1, req2, req3] = await Promise.all([
     server.waitForRequest('/a/redirect1'),
     server.waitForRequest('/b/c/redirect2'),
@@ -94,27 +94,27 @@ it('should propagate extra http headers with redirects', async ({playwright, ser
   expect(req3.headers['my-secret']).toBe('Value');
 });
 
-it('should support global httpCredentials option', async ({playwright, server}) => {
+it('should support global httpCredentials option', async ({ playwright, server }) => {
   server.setAuth('/empty.html', 'user', 'pass');
   const request1 = await playwright._newRequest();
   const response1 = await request1.get(server.EMPTY_PAGE);
   expect(response1.status()).toBe(401);
   await request1.dispose();
 
-  const request2 = await playwright._newRequest({ httpCredentials: { username: 'user', password: 'pass' }});
+  const request2 = await playwright._newRequest({ httpCredentials: { username: 'user', password: 'pass' } });
   const response2 = await request2.get(server.EMPTY_PAGE);
   expect(response2.status()).toBe(200);
   await request2.dispose();
 });
 
-it('should return error with wrong credentials', async ({playwright, server}) => {
+it('should return error with wrong credentials', async ({ playwright, server }) => {
   server.setAuth('/empty.html', 'user', 'pass');
-  const request = await playwright._newRequest({ httpCredentials: { username: 'user', password: 'wrong' }});
+  const request = await playwright._newRequest({ httpCredentials: { username: 'user', password: 'wrong' } });
   const response2 = await request.get(server.EMPTY_PAGE);
   expect(response2.status()).toBe(401);
 });
 
-it('should pass proxy credentials', async ({playwright, server, proxyServer}) => {
+it('should pass proxy credentials', async ({ playwright, server, proxyServer }) => {
   proxyServer.forwardTo(server.PORT);
   let auth;
   proxyServer.setAuthHandler(req => {
@@ -127,17 +127,17 @@ it('should pass proxy credentials', async ({playwright, server, proxyServer}) =>
   const response = await request.get('http://non-existent.com/simple.json');
   expect(proxyServer.connectHosts).toContain('non-existent.com:80');
   expect(auth).toBe('Basic ' + Buffer.from('user:secret').toString('base64'));
-  expect(await response.json()).toEqual({foo: 'bar'});
+  expect(await response.json()).toEqual({ foo: 'bar' });
   await request.dispose();
 });
 
-it('should support global ignoreHTTPSErrors option', async ({playwright, httpsServer}) => {
+it('should support global ignoreHTTPSErrors option', async ({ playwright, httpsServer }) => {
   const request = await playwright._newRequest({ ignoreHTTPSErrors: true });
   const response = await request.get(httpsServer.EMPTY_PAGE);
   expect(response.status()).toBe(200);
 });
 
-it('should resolve url relative to gobal baseURL option', async ({playwright, server}) => {
+it('should resolve url relative to gobal baseURL option', async ({ playwright, server }) => {
   const request = await playwright._newRequest({ baseURL: server.PREFIX });
   const response = await request.get('/empty.html');
   expect(response.url()).toBe(server.EMPTY_PAGE);

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -423,9 +423,9 @@ it('should have security details', async ({ contextFactory, httpsServer, browser
   expect(serverIPAddress).toMatch(/^127\.0\.0\.1|\[::1\]/);
   expect(port).toBe(httpsServer.PORT);
   if (browserName === 'webkit' && platform === 'darwin')
-    expect(securityDetails).toEqual({protocol: 'TLS 1.3', subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: 33086084863});
+    expect(securityDetails).toEqual({ protocol: 'TLS 1.3', subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: 33086084863 });
   else
-    expect(securityDetails).toEqual({issuer: 'puppeteer-tests', protocol: 'TLS 1.3', subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: 33086084863});
+    expect(securityDetails).toEqual({ issuer: 'puppeteer-tests', protocol: 'TLS 1.3', subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: 33086084863 });
 });
 
 it('should have connection details for redirects', async ({ contextFactory, server, browserName }, testInfo) => {
@@ -479,11 +479,11 @@ it('should return security details directly from response', async ({ contextFact
   const response = await page.goto(httpsServer.EMPTY_PAGE);
   const securityDetails = await response.securityDetails();
   if (browserName === 'webkit' && platform === 'win32')
-    expect(securityDetails).toEqual({subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: -1});
+    expect(securityDetails).toEqual({ subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: -1 });
   else if (browserName === 'webkit')
-    expect(securityDetails).toEqual({protocol: 'TLS 1.3', subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: 33086084863});
+    expect(securityDetails).toEqual({ protocol: 'TLS 1.3', subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: 33086084863 });
   else
-    expect(securityDetails).toEqual({issuer: 'puppeteer-tests', protocol: 'TLS 1.3', subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: 33086084863});
+    expect(securityDetails).toEqual({ issuer: 'puppeteer-tests', protocol: 'TLS 1.3', subjectName: 'puppeteer-tests', validFrom: 1550084863, validTo: 33086084863 });
 });
 
 it('should contain http2 for http2 requests', async ({ contextFactory, browserName, platform }, testInfo) => {
@@ -512,7 +512,7 @@ it('should contain http2 for http2 requests', async ({ contextFactory, browserNa
   server.close();
 });
 
-it('should filter favicon and favicon redirects', async ({server, browserName, channel, headless, asset, contextFactory}, testInfo) => {
+it('should filter favicon and favicon redirects', async ({ server, browserName, channel, headless, asset, contextFactory }, testInfo) => {
   it.skip(headless && browserName !== 'firefox', 'headless browsers, except firefox, do not request favicons');
   it.skip(!headless && browserName === 'webkit' && !channel, 'headed webkit does not have a favicon feature');
 

--- a/tests/headful.spec.ts
+++ b/tests/headful.spec.ts
@@ -16,17 +16,17 @@
 
 import { playwrightTest as it, expect } from './config/browserTest';
 
-it('should have default url when launching browser', async ({browserType, browserOptions, createUserDataDir}) => {
-  const browserContext = await browserType.launchPersistentContext(await createUserDataDir(), {...browserOptions, headless: false });
+it('should have default url when launching browser', async ({ browserType, browserOptions, createUserDataDir }) => {
+  const browserContext = await browserType.launchPersistentContext(await createUserDataDir(), { ...browserOptions, headless: false });
   const urls = browserContext.pages().map(page => page.url());
   expect(urls).toEqual(['about:blank']);
   await browserContext.close();
 });
 
-it('should close browser with beforeunload page', async ({browserType, browserOptions, server, createUserDataDir}) => {
+it('should close browser with beforeunload page', async ({ browserType, browserOptions, server, createUserDataDir }) => {
   it.slow();
 
-  const browserContext = await browserType.launchPersistentContext(await createUserDataDir(), {...browserOptions, headless: false});
+  const browserContext = await browserType.launchPersistentContext(await createUserDataDir(), { ...browserOptions, headless: false });
   const page = await browserContext.newPage();
   await page.goto(server.PREFIX + '/beforeunload.html');
   // We have to interact with a page so that 'beforeunload' handlers
@@ -35,8 +35,8 @@ it('should close browser with beforeunload page', async ({browserType, browserOp
   await browserContext.close();
 });
 
-it('should not crash when creating second context', async ({browserType, browserOptions}) => {
-  const browser = await browserType.launch({...browserOptions, headless: false });
+it('should not crash when creating second context', async ({ browserType, browserOptions }) => {
+  const browser = await browserType.launch({ ...browserOptions, headless: false });
   {
     const browserContext = await browser.newContext();
     await browserContext.newPage();
@@ -50,8 +50,8 @@ it('should not crash when creating second context', async ({browserType, browser
   await browser.close();
 });
 
-it('should click background tab', async ({browserType, browserOptions, server}) => {
-  const browser = await browserType.launch({...browserOptions, headless: false });
+it('should click background tab', async ({ browserType, browserOptions, server }) => {
+  const browser = await browserType.launch({ ...browserOptions, headless: false });
   const page = await browser.newPage();
   await page.setContent(`<button>Hello</button><a target=_blank href="${server.EMPTY_PAGE}">empty.html</a>`);
   await page.click('a');
@@ -59,16 +59,16 @@ it('should click background tab', async ({browserType, browserOptions, server}) 
   await browser.close();
 });
 
-it('should close browser after context menu was triggered', async ({browserType, browserOptions, server}) => {
-  const browser = await browserType.launch({...browserOptions, headless: false });
+it('should close browser after context menu was triggered', async ({ browserType, browserOptions, server }) => {
+  const browser = await browserType.launch({ ...browserOptions, headless: false });
   const page = await browser.newPage();
   await page.goto(server.PREFIX + '/grid.html');
-  await page.click('body', {button: 'right'});
+  await page.click('body', { button: 'right' });
   await browser.close();
 });
 
-it('should(not) block third party cookies', async ({browserType, browserOptions, server, browserName}) => {
-  const browser = await browserType.launch({...browserOptions, headless: false });
+it('should(not) block third party cookies', async ({ browserType, browserOptions, server, browserName }) => {
+  const browser = await browserType.launch({ ...browserOptions, headless: false });
   const page = await browser.newPage();
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(src => {
@@ -107,11 +107,11 @@ it('should(not) block third party cookies', async ({browserType, browserOptions,
   await browser.close();
 });
 
-it('should not override viewport size when passed null', async function({browserType, browserOptions, server, browserName}) {
+it('should not override viewport size when passed null', async function({ browserType, browserOptions, server, browserName }) {
   it.fixme(browserName === 'webkit');
 
   // Our WebKit embedder does not respect window features.
-  const browser = await browserType.launch({...browserOptions, headless: false });
+  const browser = await browserType.launch({ ...browserOptions, headless: false });
   const context = await browser.newContext({ viewport: null });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -128,8 +128,8 @@ it('should not override viewport size when passed null', async function({browser
   await browser.close();
 });
 
-it('Page.bringToFront should work', async ({browserType, browserOptions}) => {
-  const browser = await browserType.launch({...browserOptions, headless: false });
+it('Page.bringToFront should work', async ({ browserType, browserOptions }) => {
+  const browser = await browserType.launch({ ...browserOptions, headless: false });
   const page1 = await browser.newPage();
   await page1.setContent('Page1');
   const page2 = await browser.newPage();

--- a/tests/ignorehttpserrors.spec.ts
+++ b/tests/ignorehttpserrors.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should work', async ({browser, httpsServer}) => {
+it('should work', async ({ browser, httpsServer }) => {
   let error = null;
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
@@ -27,7 +27,7 @@ it('should work', async ({browser, httpsServer}) => {
   await context.close();
 });
 
-it('should isolate contexts', async ({browser, httpsServer}) => {
+it('should isolate contexts', async ({ browser, httpsServer }) => {
   {
     let error = null;
     const context = await browser.newContext({ ignoreHTTPSErrors: true });
@@ -47,13 +47,13 @@ it('should isolate contexts', async ({browser, httpsServer}) => {
   }
 });
 
-it('should work with mixed content', async ({browser, server, httpsServer}) => {
+it('should work with mixed content', async ({ browser, server, httpsServer }) => {
   httpsServer.setRoute('/mixedcontent.html', (req, res) => {
     res.end(`<iframe src=${server.EMPTY_PAGE}></iframe>`);
   });
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
-  await page.goto(httpsServer.PREFIX + '/mixedcontent.html', {waitUntil: 'domcontentloaded'});
+  await page.goto(httpsServer.PREFIX + '/mixedcontent.html', { waitUntil: 'domcontentloaded' });
   expect(page.frames().length).toBe(2);
   // Make sure blocked iframe has functional execution context
   // @see https://github.com/GoogleChrome/puppeteer/issues/2709
@@ -62,7 +62,7 @@ it('should work with mixed content', async ({browser, server, httpsServer}) => {
   await context.close();
 });
 
-it('should work with WebSocket', async ({browser, httpsServer}) => {
+it('should work with WebSocket', async ({ browser, httpsServer }) => {
   httpsServer.sendOnWebSocketConnection('incoming');
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
@@ -78,7 +78,7 @@ it('should work with WebSocket', async ({browser, httpsServer}) => {
   await context.close();
 });
 
-it('should fail with WebSocket if not ignored', async ({browser, httpsServer}) => {
+it('should fail with WebSocket if not ignored', async ({ browser, httpsServer }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   const value = await page.evaluate(endpoint => {

--- a/tests/inspector/pause.spec.ts
+++ b/tests/inspector/pause.spec.ts
@@ -18,7 +18,7 @@ import { Page } from '../../index';
 import { test as it, expect } from './inspectorTest';
 
 
-it('should resume when closing inspector', async ({page, recorderPageGetter, closeRecorder, mode}) => {
+it('should resume when closing inspector', async ({ page, recorderPageGetter, closeRecorder, mode }) => {
   it.skip(mode !== 'default');
 
   const scriptPromise = (async () => {
@@ -50,7 +50,7 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should resume from console', async ({page}) => {
+  it('should resume from console', async ({ page }) => {
     const scriptPromise = (async () => {
       await page.pause();
     })();
@@ -62,7 +62,7 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should pause after a navigation', async ({page, server, recorderPageGetter}) => {
+  it('should pause after a navigation', async ({ page, server, recorderPageGetter }) => {
     const scriptPromise = (async () => {
       await page.goto(server.EMPTY_PAGE);
       await page.pause();
@@ -72,7 +72,7 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should show source', async ({page, recorderPageGetter}) => {
+  it('should show source', async ({ page, recorderPageGetter }) => {
     const scriptPromise = (async () => {
       await page.pause();
     })();
@@ -83,7 +83,7 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should pause on next pause', async ({page, recorderPageGetter}) => {
+  it('should pause on next pause', async ({ page, recorderPageGetter }) => {
     const scriptPromise = (async () => {
       await page.pause();  // 1
       await page.pause();  // 2
@@ -97,7 +97,7 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should step', async ({page, recorderPageGetter}) => {
+  it('should step', async ({ page, recorderPageGetter }) => {
     await page.setContent('<button>Submit</button>');
     const scriptPromise = (async () => {
       await page.pause();
@@ -114,7 +114,7 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should highlight pointer', async ({page, recorderPageGetter}) => {
+  it('should highlight pointer', async ({ page, recorderPageGetter }) => {
     await page.setContent('<button>Submit</button>');
     const scriptPromise = (async () => {
       await page.pause();
@@ -140,7 +140,7 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should skip input when resuming', async ({page, recorderPageGetter}) => {
+  it('should skip input when resuming', async ({ page, recorderPageGetter }) => {
     await page.setContent('<button>Submit</button>');
     const scriptPromise = (async () => {
       await page.pause();
@@ -154,7 +154,7 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should populate log', async ({page, recorderPageGetter}) => {
+  it('should populate log', async ({ page, recorderPageGetter }) => {
     await page.setContent('<button>Submit</button>');
     const scriptPromise = (async () => {
       await page.pause();
@@ -173,7 +173,7 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should highlight waitForEvent', async ({page, recorderPageGetter}) => {
+  it('should highlight waitForEvent', async ({ page, recorderPageGetter }) => {
     await page.setContent('<button onclick="console.log(1)">Submit</button>');
     const scriptPromise = (async () => {
       await page.pause();
@@ -190,7 +190,7 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should populate log with waitForEvent', async ({page, recorderPageGetter}) => {
+  it('should populate log with waitForEvent', async ({ page, recorderPageGetter }) => {
     await page.setContent('<button onclick="console.log(1)">Submit</button>');
     const scriptPromise = (async () => {
       await page.pause();
@@ -213,7 +213,7 @@ it.describe('pause', () => {
     await scriptPromise;
   });
 
-  it('should populate log with error', async ({page, recorderPageGetter}) => {
+  it('should populate log with error', async ({ page, recorderPageGetter }) => {
     await page.setContent('<button onclick="console.log(1)">Submit</button>');
     const scriptPromise = (async () => {
       await page.pause();
@@ -233,7 +233,7 @@ it.describe('pause', () => {
     expect(error.message).toContain('Not a checkbox or radio button');
   });
 
-  it('should populate log with error in waitForEvent', async ({page, recorderPageGetter}) => {
+  it('should populate log with error in waitForEvent', async ({ page, recorderPageGetter }) => {
     await page.setContent('<button>Submit</button>');
     const scriptPromise = (async () => {
       await page.pause();

--- a/tests/launcher.spec.ts
+++ b/tests/launcher.spec.ts
@@ -22,14 +22,14 @@ it('should require top-level Errors', async ({}) => {
   expect(String(Errors.TimeoutError)).toContain('TimeoutError');
 });
 
-it('should require top-level DeviceDescriptors', async ({playwright}) => {
+it('should require top-level DeviceDescriptors', async ({ playwright }) => {
   const Devices = require('../lib/server/deviceDescriptors.js');
   expect(Devices['iPhone 6']).toBeTruthy();
   expect(Devices['iPhone 6']).toEqual(playwright.devices['iPhone 6']);
   expect(playwright.devices['iPhone 6'].defaultBrowserType).toBe('webkit');
 });
 
-it('should kill browser process on timeout after close', async ({browserType, browserOptions, mode}) => {
+it('should kill browser process on timeout after close', async ({ browserType, browserOptions, mode }) => {
   it.skip(mode !== 'default', 'Test passes server hooks via options');
 
   const launchOptions = { ...browserOptions };

--- a/tests/logger.spec.ts
+++ b/tests/logger.spec.ts
@@ -16,12 +16,12 @@
 
 import { playwrightTest as it, expect } from './config/browserTest';
 
-it('should log', async ({browserType, browserOptions}) => {
+it('should log', async ({ browserType, browserOptions }) => {
   const log = [];
-  const browser = await browserType.launch({...browserOptions, logger: {
-    log: (name, severity, message) => log.push({name, severity, message}),
+  const browser = await browserType.launch({ ...browserOptions, logger: {
+    log: (name, severity, message) => log.push({ name, severity, message }),
     isEnabled: (name, severity) => severity !== 'verbose'
-  }});
+  } });
   await browser.newContext();
   await browser.close();
   expect(log.length > 0).toBeTruthy();
@@ -30,12 +30,12 @@ it('should log', async ({browserType, browserOptions}) => {
   expect(log.filter(item => item.message.includes('browserType.launch succeeded')).length > 0).toBeTruthy();
 });
 
-it('should log context-level', async ({browserType, browserOptions}) => {
+it('should log context-level', async ({ browserType, browserOptions }) => {
   const log = [];
   const browser = await browserType.launch(browserOptions);
   const context = await browser.newContext({
     logger: {
-      log: (name, severity, message) => log.push({name, severity, message}),
+      log: (name, severity, message) => log.push({ name, severity, message }),
       isEnabled: (name, severity) => severity !== 'verbose'
     }
   });

--- a/tests/page/elementhandle-convenience.spec.ts
+++ b/tests/page/elementhandle-convenience.spec.ts
@@ -195,7 +195,7 @@ it('isVisible and isHidden should work', async ({ page }) => {
   expect(await page.isHidden('no-such-element')).toBe(true);
 });
 
-it('element state checks should work for label with zero-sized input', async ({page, server}) => {
+it('element state checks should work for label with zero-sized input', async ({ page, server }) => {
   await page.setContent(`
     <label>
       Click me
@@ -211,7 +211,7 @@ it('element state checks should work for label with zero-sized input', async ({p
   expect(await page.isDisabled('text=Click me')).toBe(true);
 });
 
-it('isVisible should not throw when the DOM element is not connected', async ({page}) => {
+it('isVisible should not throw when the DOM element is not connected', async ({ page }) => {
   await page.setContent(`<div id="root"></div>`);
   await page.evaluate(() => {
     function insert() {
@@ -267,7 +267,7 @@ it('isEditable should work', async ({ page }) => {
   expect(await page.isEditable('textarea')).toBe(false);
 });
 
-it('isChecked should work', async ({page}) => {
+it('isChecked should work', async ({ page }) => {
   await page.setContent(`<input type='checkbox' checked><div>Not a checkbox</div>`);
   const handle = await page.$('input');
   expect(await handle.isChecked()).toBe(true);

--- a/tests/page/elementhandle-eval-on-selector.spec.ts
+++ b/tests/page/elementhandle-eval-on-selector.spec.ts
@@ -17,14 +17,14 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.setContent('<html><body><div class="tweet"><div class="like">100</div><div class="retweets">10</div></div></body></html>');
   const tweet = await page.$('.tweet');
   const content = await tweet.$eval('.like', node => (node as HTMLElement).innerText);
   expect(content).toBe('100');
 });
 
-it('should retrieve content from subtree', async ({page, server}) => {
+it('should retrieve content from subtree', async ({ page, server }) => {
   const htmlContent = '<div class="a">not-a-child-div</div><div id="myId"><div class="a">a-child-div</div></div>';
   await page.setContent(htmlContent);
   const elementHandle = await page.$('#myId');
@@ -32,7 +32,7 @@ it('should retrieve content from subtree', async ({page, server}) => {
   expect(content).toBe('a-child-div');
 });
 
-it('should throw in case of missing selector', async ({page, server}) => {
+it('should throw in case of missing selector', async ({ page, server }) => {
   const htmlContent = '<div class="a">not-a-child-div</div><div id="myId"></div>';
   await page.setContent(htmlContent);
   const elementHandle = await page.$('#myId');
@@ -40,14 +40,14 @@ it('should throw in case of missing selector', async ({page, server}) => {
   expect(errorMessage).toContain(`Error: failed to find element matching selector ".a"`);
 });
 
-it('should work for all', async ({page, server}) => {
+it('should work for all', async ({ page, server }) => {
   await page.setContent('<html><body><div class="tweet"><div class="like">100</div><div class="like">10</div></div></body></html>');
   const tweet = await page.$('.tweet');
   const content = await tweet.$$eval('.like', nodes => nodes.map(n => (n as HTMLElement).innerText));
   expect(content).toEqual(['100', '10']);
 });
 
-it('should retrieve content from subtree for all', async ({page, server}) => {
+it('should retrieve content from subtree for all', async ({ page, server }) => {
   const htmlContent = '<div class="a">not-a-child-div</div><div id="myId"><div class="a">a1-child-div</div><div class="a">a2-child-div</div></div>';
   await page.setContent(htmlContent);
   const elementHandle = await page.$('#myId');
@@ -55,7 +55,7 @@ it('should retrieve content from subtree for all', async ({page, server}) => {
   expect(content).toEqual(['a1-child-div', 'a2-child-div']);
 });
 
-it('should not throw in case of missing selector for all', async ({page, server}) => {
+it('should not throw in case of missing selector for all', async ({ page, server }) => {
   const htmlContent = '<div class="a">not-a-child-div</div><div id="myId"></div>';
   await page.setContent(htmlContent);
   const elementHandle = await page.$('#myId');

--- a/tests/page/elementhandle-query-selector.spec.ts
+++ b/tests/page/elementhandle-query-selector.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should query existing element', async ({page, server}) => {
+it('should query existing element', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/playground.html');
   await page.setContent('<html><body><div class="second"><div class="inner">A</div></div></body></html>');
   const html = await page.$('html');
@@ -27,14 +27,14 @@ it('should query existing element', async ({page, server}) => {
   expect(content).toBe('A');
 });
 
-it('should return null for non-existing element', async ({page, server}) => {
+it('should return null for non-existing element', async ({ page, server }) => {
   await page.setContent('<html><body><div class="second"><div class="inner">B</div></div></body></html>');
   const html = await page.$('html');
   const second = await html.$('.third');
   expect(second).toBe(null);
 });
 
-it('should work for adopted elements', async ({page, server, isElectron}) => {
+it('should work for adopted elements', async ({ page, server, isElectron }) => {
   it.fixme(isElectron);
 
   await page.goto(server.EMPTY_PAGE);
@@ -62,7 +62,7 @@ it('should work for adopted elements', async ({page, server, isElectron}) => {
   expect(await divHandle.$eval('span', e => e.textContent)).toBe('hello');
 });
 
-it('should query existing elements', async ({page, server}) => {
+it('should query existing elements', async ({ page, server }) => {
   await page.setContent('<html><body><div>A</div><br/><div>B</div></body></html>');
   const html = await page.$('html');
   const elements = await html.$$('div');
@@ -71,7 +71,7 @@ it('should query existing elements', async ({page, server}) => {
   expect(await Promise.all(promises)).toEqual(['A', 'B']);
 });
 
-it('should return empty array for non-existing elements', async ({page, server}) => {
+it('should return empty array for non-existing elements', async ({ page, server }) => {
   await page.setContent('<html><body><span>A</span><br/><span>B</span></body></html>');
   const html = await page.$('html');
   const elements = await html.$$('div');
@@ -79,7 +79,7 @@ it('should return empty array for non-existing elements', async ({page, server})
 });
 
 
-it('xpath should query existing element', async ({page, server}) => {
+it('xpath should query existing element', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/playground.html');
   await page.setContent('<html><body><div class="second"><div class="inner">A</div></div></body></html>');
   const html = await page.$('html');
@@ -89,7 +89,7 @@ it('xpath should query existing element', async ({page, server}) => {
   expect(content).toBe('A');
 });
 
-it('xpath should return null for non-existing element', async ({page, server}) => {
+it('xpath should return null for non-existing element', async ({ page, server }) => {
   await page.setContent('<html><body><div class="second"><div class="inner">B</div></div></body></html>');
   const html = await page.$('html');
   const second = await html.$$(`xpath=/div[contains(@class, 'third')]`);

--- a/tests/page/elementhandle-screenshot.spec.ts
+++ b/tests/page/elementhandle-screenshot.spec.ts
@@ -24,8 +24,8 @@ it.describe('element screenshot', () => {
   it.skip(({ browserName, headless }) => browserName === 'firefox' && !headless);
   it.skip(({ isAndroid }) => isAndroid, 'Different dpr. Remove after using 1x scale for screenshots.');
 
-  it('should work', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should work', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     await page.evaluate(() => window.scrollBy(50, 100));
     const elementHandle = await page.$('.box:nth-of-type(3)');
@@ -33,8 +33,8 @@ it.describe('element screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-element-bounding-box.png');
   });
 
-  it('should take into account padding and border', async ({page}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should take into account padding and border', async ({ page }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.setContent(`
       <div style="height: 14px">oooo</div>
       <style>div {
@@ -51,8 +51,8 @@ it.describe('element screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-element-padding-border.png');
   });
 
-  it('should capture full element when larger than viewport in parallel', async ({page}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should capture full element when larger than viewport in parallel', async ({ page }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
 
     await page.setContent(`
       <div style="height: 14px">oooo</div>
@@ -79,8 +79,8 @@ it.describe('element screenshot', () => {
     await verifyViewport(page, 500, 500);
   });
 
-  it('should capture full element when larger than viewport', async ({page}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should capture full element when larger than viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
 
     await page.setContent(`
       <div style="height: 14px">oooo</div>
@@ -106,8 +106,8 @@ it.describe('element screenshot', () => {
     await verifyViewport(page, 500, 500);
   });
 
-  it('should scroll element into view', async ({page}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should scroll element into view', async ({ page }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.setContent(`
       <div style="height: 14px">oooo</div>
       <style>div.above {
@@ -130,8 +130,8 @@ it.describe('element screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-element-scrolled-into-view.png');
   });
 
-  it('should scroll 15000px into view', async ({page}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should scroll 15000px into view', async ({ page }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.setContent(`
       <div style="height: 14px">oooo</div>
       <style>div.above {
@@ -154,8 +154,8 @@ it.describe('element screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-element-scrolled-into-view.png');
   });
 
-  it('should work with a rotated element', async ({page}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should work with a rotated element', async ({ page }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.setContent(`<div style="position:absolute;
                                       top: 100px;
                                       left: 100px;
@@ -168,7 +168,7 @@ it.describe('element screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-element-rotate.png');
   });
 
-  it('should fail to screenshot a detached element', async ({page, server}) => {
+  it('should fail to screenshot a detached element', async ({ page, server }) => {
     await page.setContent('<h1>remove this</h1>');
     const elementHandle = await page.$('h1');
     await page.evaluate(element => element.remove(), elementHandle);
@@ -176,7 +176,7 @@ it.describe('element screenshot', () => {
     expect(screenshotError.message).toContain('Element is not attached to the DOM');
   });
 
-  it('should timeout waiting for visible', async ({page, server}) => {
+  it('should timeout waiting for visible', async ({ page, server }) => {
     await page.setContent('<div style="width: 50px; height: 0"></div>');
     const div = await page.$('div');
     const error = await div.screenshot({ timeout: 3000 }).catch(e => e);
@@ -184,8 +184,8 @@ it.describe('element screenshot', () => {
     expect(error.message).toContain('element is not visible');
   });
 
-  it('should wait for visible', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should wait for visible', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     await page.evaluate(() => window.scrollBy(50, 100));
     const elementHandle = await page.$('.box:nth-of-type(3)');
@@ -203,7 +203,7 @@ it.describe('element screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-element-bounding-box.png');
   });
 
-  it('should work for an element with fractional dimensions', async ({page, isElectron}) => {
+  it('should work for an element with fractional dimensions', async ({ page, isElectron }) => {
     it.fixme(isElectron, 'Scale is wrong');
 
     await page.setContent('<div style="width:48.51px;height:19.8px;border:1px solid black;"></div>');
@@ -212,7 +212,7 @@ it.describe('element screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-element-fractional.png');
   });
 
-  it('should work for an element with an offset', async ({page, isElectron}) => {
+  it('should work for an element with an offset', async ({ page, isElectron }) => {
     it.fixme(isElectron, 'Scale is wrong');
 
     await page.setContent('<div style="position:absolute; top: 10.3px; left: 20.4px;width:50.3px;height:20.2px;border:1px solid black;"></div>');
@@ -233,7 +233,7 @@ it.describe('element screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-element-bounding-box.png');
   });
 
-  it('should take screenshot of disabled button', async ({page}) => {
+  it('should take screenshot of disabled button', async ({ page }) => {
     await page.setViewportSize({ width: 500, height: 500 });
     await page.setContent(`<button disabled>Click me</button>`);
     const button = await page.$('button');
@@ -241,18 +241,18 @@ it.describe('element screenshot', () => {
     expect(screenshot).toBeInstanceOf(Buffer);
   });
 
-  it('path option should create subdirectories', async ({page, server}, testInfo) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('path option should create subdirectories', async ({ page, server }, testInfo) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     await page.evaluate(() => window.scrollBy(50, 100));
     const elementHandle = await page.$('.box:nth-of-type(3)');
     const outputPath = testInfo.outputPath(path.join('these', 'are', 'directories', 'screenshot.png'));
-    await elementHandle.screenshot({path: outputPath});
+    await elementHandle.screenshot({ path: outputPath });
     expect(await fs.promises.readFile(outputPath)).toMatchSnapshot('screenshot-element-bounding-box.png');
   });
 
-  it('should prefer type over extension', async ({page, server}, testInfo) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should prefer type over extension', async ({ page, server }, testInfo) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     await page.evaluate(() => window.scrollBy(50, 100));
     const elementHandle = await page.$('.box:nth-of-type(3)');
@@ -261,7 +261,7 @@ it.describe('element screenshot', () => {
     expect([buffer[0], buffer[1], buffer[2]]).toEqual([0xFF, 0xD8, 0xFF]);
   });
 
-  it('should not issue resize event', async ({page, server}) => {
+  it('should not issue resize event', async ({ page, server }) => {
     await page.goto(server.PREFIX + '/grid.html');
     let resizeTriggered = false;
     await page.exposeFunction('resize', () => {

--- a/tests/page/elementhandle-wait-for-element-state.spec.ts
+++ b/tests/page/elementhandle-wait-for-element-state.spec.ts
@@ -83,7 +83,7 @@ it('should wait for hidden when detached', async ({ page }) => {
   await promise;
 });
 
-it('should wait for enabled button', async ({page, server}) => {
+it('should wait for enabled button', async ({ page, server }) => {
   await page.setContent('<button disabled><span>Target</span></button>');
   const span = await page.$('text=Target');
   let done = false;
@@ -103,7 +103,7 @@ it('should throw waiting for enabled when detached', async ({ page }) => {
   expect(error.message).toContain('Element is not attached to the DOM');
 });
 
-it('should wait for disabled button', async ({page}) => {
+it('should wait for disabled button', async ({ page }) => {
   await page.setContent('<button><span>Target</span></button>');
   const span = await page.$('text=Target');
   let done = false;
@@ -114,7 +114,7 @@ it('should wait for disabled button', async ({page}) => {
   await promise;
 });
 
-it('should wait for stable position', async ({page, server, browserName, platform}) => {
+it('should wait for stable position', async ({ page, server, browserName, platform }) => {
   it.fixme(browserName === 'firefox' && platform === 'linux');
 
   await page.goto(server.PREFIX + '/input/button.html');
@@ -131,7 +131,7 @@ it('should wait for stable position', async ({page, server, browserName, platfor
   await promise;
 });
 
-it('should wait for editable input', async ({page, server}) => {
+it('should wait for editable input', async ({ page, server }) => {
   await page.setContent('<input readonly>');
   const input = await page.$('input');
   let done = false;

--- a/tests/page/eval-on-selector-all.spec.ts
+++ b/tests/page/eval-on-selector-all.spec.ts
@@ -17,37 +17,37 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work with css selector', async ({page, server}) => {
+it('should work with css selector', async ({ page, server }) => {
   await page.setContent('<div>hello</div><div>beautiful</div><div>world!</div>');
   const divsCount = await page.$$eval('css=div', divs => divs.length);
   expect(divsCount).toBe(3);
 });
 
-it('should work with text selector', async ({page, server}) => {
+it('should work with text selector', async ({ page, server }) => {
   await page.setContent('<div>hello</div><div>beautiful</div><div>beautiful</div><div>world!</div>');
   const divsCount = await page.$$eval('text="beautiful"', divs => divs.length);
   expect(divsCount).toBe(2);
 });
 
-it('should work with xpath selector', async ({page, server}) => {
+it('should work with xpath selector', async ({ page, server }) => {
   await page.setContent('<div>hello</div><div>beautiful</div><div>world!</div>');
   const divsCount = await page.$$eval('xpath=/html/body/div', divs => divs.length);
   expect(divsCount).toBe(3);
 });
 
-it('should auto-detect css selector', async ({page, server}) => {
+it('should auto-detect css selector', async ({ page, server }) => {
   await page.setContent('<div>hello</div><div>beautiful</div><div>world!</div>');
   const divsCount = await page.$$eval('div', divs => divs.length);
   expect(divsCount).toBe(3);
 });
 
-it('should support >> syntax', async ({page, server}) => {
+it('should support >> syntax', async ({ page, server }) => {
   await page.setContent('<div><span>hello</span></div><div>beautiful</div><div><span>wo</span><span>rld!</span></div><span>Not this one</span>');
   const spansCount = await page.$$eval('css=div >> css=span', spans => spans.length);
   expect(spansCount).toBe(3);
 });
 
-it('should support * capture', async ({page, server}) => {
+it('should support * capture', async ({ page, server }) => {
   await page.setContent('<section><div><span>a</span></div></section><section><div><span>b</span></div></section>');
   expect(await page.$$eval('*css=div >> "b"', els => els.length)).toBe(1);
   expect(await page.$$eval('section >> *css=div >> "b"', els => els.length)).toBe(1);
@@ -62,20 +62,20 @@ it('should support * capture', async ({page, server}) => {
   expect(await page.$$eval('section >> *css=div >> "a"', els => els.length)).toBe(1);
 });
 
-it('should support * capture when multiple paths match', async ({page, server}) => {
+it('should support * capture when multiple paths match', async ({ page, server }) => {
   await page.setContent('<div><div><span></span></div></div><div></div>');
   expect(await page.$$eval('*css=div >> span', els => els.length)).toBe(2);
   await page.setContent('<div><div><span></span></div><span></span><span></span></div><div></div>');
   expect(await page.$$eval('*css=div >> span', els => els.length)).toBe(2);
 });
 
-it('should return complex values', async ({page, server}) => {
+it('should return complex values', async ({ page, server }) => {
   await page.setContent('<div>hello</div><div>beautiful</div><div>world!</div>');
   const texts = await page.$$eval('css=div', divs => divs.map(div => div.textContent));
   expect(texts).toEqual(['hello', 'beautiful', 'world!']);
 });
 
-it('should work with bogus Array.from', async ({page, server}) => {
+it('should work with bogus Array.from', async ({ page, server }) => {
   await page.setContent('<div>hello</div><div>beautiful</div><div>world!</div>');
   await page.evaluate(() => {
     Array.from = () => [];

--- a/tests/page/eval-on-selector.spec.ts
+++ b/tests/page/eval-on-selector.spec.ts
@@ -17,116 +17,116 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work with css selector', async ({page, server}) => {
+it('should work with css selector', async ({ page, server }) => {
   await page.setContent('<section id="testAttribute">43543</section>');
   const idAttribute = await page.$eval('css=section', e => e.id);
   expect(idAttribute).toBe('testAttribute');
 });
 
-it('should work with id selector', async ({page, server}) => {
+it('should work with id selector', async ({ page, server }) => {
   await page.setContent('<section id="testAttribute">43543</section>');
   const idAttribute = await page.$eval('id=testAttribute', e => e.id);
   expect(idAttribute).toBe('testAttribute');
 });
 
-it('should work with data-test selector', async ({page, server}) => {
+it('should work with data-test selector', async ({ page, server }) => {
   await page.setContent('<section data-test=foo id="testAttribute">43543</section>');
   const idAttribute = await page.$eval('data-test=foo', e => e.id);
   expect(idAttribute).toBe('testAttribute');
 });
 
-it('should work with data-testid selector', async ({page, server}) => {
+it('should work with data-testid selector', async ({ page, server }) => {
   await page.setContent('<section data-testid=foo id="testAttribute">43543</section>');
   const idAttribute = await page.$eval('data-testid=foo', e => e.id);
   expect(idAttribute).toBe('testAttribute');
 });
 
-it('should work with data-test-id selector', async ({page, server}) => {
+it('should work with data-test-id selector', async ({ page, server }) => {
   await page.setContent('<section data-test-id=foo id="testAttribute">43543</section>');
   const idAttribute = await page.$eval('data-test-id=foo', e => e.id);
   expect(idAttribute).toBe('testAttribute');
 });
 
-it('should work with text selector in quotes', async ({page, server}) => {
+it('should work with text selector in quotes', async ({ page, server }) => {
   await page.setContent('<section id="testAttribute">43543</section>');
   const idAttribute = await page.$eval('text="43543"', e => e.id);
   expect(idAttribute).toBe('testAttribute');
 });
 
-it('should work with xpath selector', async ({page, server}) => {
+it('should work with xpath selector', async ({ page, server }) => {
   await page.setContent('<section id="testAttribute">43543</section>');
   const idAttribute = await page.$eval('xpath=/html/body/section', e => e.id);
   expect(idAttribute).toBe('testAttribute');
 });
 
-it('should work with text selector', async ({page, server}) => {
+it('should work with text selector', async ({ page, server }) => {
   await page.setContent('<section id="testAttribute">43543</section>');
   const idAttribute = await page.$eval('text=43543', e => e.id);
   expect(idAttribute).toBe('testAttribute');
 });
 
-it('should auto-detect css selector', async ({page, server}) => {
+it('should auto-detect css selector', async ({ page, server }) => {
   await page.setContent('<section id="testAttribute">43543</section>');
   const idAttribute = await page.$eval('section', e => e.id);
   expect(idAttribute).toBe('testAttribute');
 });
 
-it('should auto-detect css selector with attributes', async ({page, server}) => {
+it('should auto-detect css selector with attributes', async ({ page, server }) => {
   await page.setContent('<section id="testAttribute">43543</section>');
   const idAttribute = await page.$eval('section[id="testAttribute"]', e => e.id);
   expect(idAttribute).toBe('testAttribute');
 });
 
-it('should auto-detect nested selectors', async ({page, server}) => {
+it('should auto-detect nested selectors', async ({ page, server }) => {
   await page.setContent('<div foo=bar><section>43543<span>Hello<div id=target></div></span></section></div>');
   const idAttribute = await page.$eval('div[foo=bar] > section >> "Hello" >> div', e => e.id);
   expect(idAttribute).toBe('target');
 });
 
-it('should accept arguments', async ({page, server}) => {
+it('should accept arguments', async ({ page, server }) => {
   await page.setContent('<section>hello</section>');
   const text = await page.$eval('section', (e, suffix) => e.textContent + suffix, ' world!');
   expect(text).toBe('hello world!');
 });
 
-it('should accept ElementHandles as arguments', async ({page, server}) => {
+it('should accept ElementHandles as arguments', async ({ page, server }) => {
   await page.setContent('<section>hello</section><div> world</div>');
   const divHandle = await page.$('div');
   const text = await page.$eval('section', (e, div) => e.textContent + div.textContent, divHandle);
   expect(text).toBe('hello world');
 });
 
-it('should throw error if no element is found', async ({page, server}) => {
+it('should throw error if no element is found', async ({ page, server }) => {
   let error = null;
   await page.$eval('section', e => e.id).catch(e => error = e);
   expect(error.message).toContain('failed to find element matching selector "section"');
 });
 
-it('should support >> syntax', async ({page, server}) => {
+it('should support >> syntax', async ({ page, server }) => {
   await page.setContent('<section><div>hello</div></section>');
   const text = await page.$eval('css=section >> css=div', (e, suffix) => e.textContent + suffix, ' world!');
   expect(text).toBe('hello world!');
 });
 
-it('should support >> syntax with different engines', async ({page, server}) => {
+it('should support >> syntax with different engines', async ({ page, server }) => {
   await page.setContent('<section><div><span>hello</span></div></section>');
   const text = await page.$eval('xpath=/html/body/section >> css=div >> text="hello"', (e, suffix) => e.textContent + suffix, ' world!');
   expect(text).toBe('hello world!');
 });
 
-it('should support spaces with >> syntax', async ({page, server}) => {
+it('should support spaces with >> syntax', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
   const text = await page.$eval(' css = div >>css=div>>css   = span  ', e => e.textContent);
   expect(text).toBe('Hello from root2');
 });
 
-it('should not stop at first failure with >> syntax', async ({page, server}) => {
+it('should not stop at first failure with >> syntax', async ({ page, server }) => {
   await page.setContent('<div><span>Next</span><button>Previous</button><button>Next</button></div>');
   const html = await page.$eval('button >> "Next"', e => e.outerHTML);
   expect(html).toBe('<button>Next</button>');
 });
 
-it('should support * capture', async ({page, server}) => {
+it('should support * capture', async ({ page, server }) => {
   await page.setContent('<section><div><span>a</span></div></section><section><div><span>b</span></div></section>');
   expect(await page.$eval('*css=div >> "b"', e => e.outerHTML)).toBe('<div><span>b</span></div>');
   expect(await page.$eval('section >> *css=div >> "b"', e => e.outerHTML)).toBe('<div><span>b</span></div>');
@@ -134,17 +134,17 @@ it('should support * capture', async ({page, server}) => {
   expect(await page.$('*')).toBeTruthy();
 });
 
-it('should throw on multiple * captures', async ({page, server}) => {
+it('should throw on multiple * captures', async ({ page, server }) => {
   const error = await page.$eval('*css=div >> *css=span', e => e.outerHTML).catch(e => e);
   expect(error.message).toContain('Only one of the selectors can capture using * modifier');
 });
 
-it('should throw on malformed * capture', async ({page, server}) => {
+it('should throw on malformed * capture', async ({ page, server }) => {
   const error = await page.$eval('*=div', e => e.outerHTML).catch(e => e);
   expect(error.message).toContain('Unknown engine "" while parsing selector *=div');
 });
 
-it('should work with spaces in css attributes', async ({page, server}) => {
+it('should work with spaces in css attributes', async ({ page, server }) => {
   await page.setContent('<div><input placeholder="Select date"></div>');
   expect(await page.waitForSelector(`[placeholder="Select date"]`)).toBeTruthy();
   expect(await page.waitForSelector(`[placeholder='Select date']`)).toBeTruthy();
@@ -166,7 +166,7 @@ it('should work with spaces in css attributes', async ({page, server}) => {
   expect(await page.$eval(`div >> [placeholder='Select date']`, e => e.outerHTML)).toBe('<input placeholder="Select date">');
 });
 
-it('should work with quotes in css attributes', async ({page, server}) => {
+it('should work with quotes in css attributes', async ({ page, server }) => {
   await page.setContent('<div><input placeholder="Select&quot;date"></div>');
   expect(await page.$(`[placeholder="Select\\"date"]`)).toBeTruthy();
   expect(await page.$(`[placeholder='Select"date']`)).toBeTruthy();
@@ -181,21 +181,21 @@ it('should work with quotes in css attributes', async ({page, server}) => {
   expect(await page.$(`[placeholder='Select \\' date']`)).toBeTruthy();
 });
 
-it('should work with spaces in css attributes when missing', async ({page, server}) => {
+it('should work with spaces in css attributes when missing', async ({ page, server }) => {
   const inputPromise = page.waitForSelector(`[placeholder="Select date"]`);
   expect(await page.$(`[placeholder="Select date"]`)).toBe(null);
   await page.setContent('<div><input placeholder="Select date"></div>');
   await inputPromise;
 });
 
-it('should work with quotes in css attributes when missing', async ({page, server}) => {
+it('should work with quotes in css attributes when missing', async ({ page, server }) => {
   const inputPromise = page.waitForSelector(`[placeholder="Select\\"date"]`);
   expect(await page.$(`[placeholder="Select\\"date"]`)).toBe(null);
   await page.setContent('<div><input placeholder="Select&quot;date"></div>');
   await inputPromise;
 });
 
-it('should return complex values', async ({page, server}) => {
+it('should return complex values', async ({ page, server }) => {
   await page.setContent('<section id="testAttribute">43543</section>');
   const idAttribute = await page.$eval('css=section', e => [{ id: e.id }]);
   expect(idAttribute).toEqual([{ id: 'testAttribute' }]);

--- a/tests/page/frame-evaluate.spec.ts
+++ b/tests/page/frame-evaluate.spec.ts
@@ -106,7 +106,7 @@ it('should not allow cross-frame element handles when frames do not script each 
   expect(error.message).toContain('Unable to adopt element handle from a different document');
 });
 
-it('should throw for detached frames', async ({page, server}) => {
+it('should throw for detached frames', async ({ page, server }) => {
   const frame1 = await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   await detachFrame(page, 'frame1');
   let error = null;
@@ -114,7 +114,7 @@ it('should throw for detached frames', async ({page, server}) => {
   expect(error.message).toContain('Execution Context is not available in detached frame');
 });
 
-it('should be isolated between frames', async ({page, server}) => {
+it('should be isolated between frames', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   expect(page.frames().length).toBe(2);
@@ -133,7 +133,7 @@ it('should be isolated between frames', async ({page, server}) => {
   expect(a2).toBe(2);
 });
 
-it('should work in iframes that failed initial navigation', async ({page, browserName}) => {
+it('should work in iframes that failed initial navigation', async ({ page, browserName }) => {
   it.fail(browserName === 'chromium');
   it.fixme(browserName === 'firefox');
 
@@ -157,7 +157,7 @@ it('should work in iframes that failed initial navigation', async ({page, browse
   expect(await page.frames()[1].$('div')).toBeTruthy();
 });
 
-it('should work in iframes that interrupted initial javascript url navigation', async ({page, server, browserName}) => {
+it('should work in iframes that interrupted initial javascript url navigation', async ({ page, server, browserName }) => {
   it.fixme(browserName === 'chromium');
 
   // Chromium does not report isolated world for the iframe.
@@ -176,7 +176,7 @@ it('should work in iframes that interrupted initial javascript url navigation', 
   expect(await page.frames()[1].$('div')).toBeTruthy();
 });
 
-it('evaluateHandle should work', async ({page, server}) => {
+it('evaluateHandle should work', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const mainFrame = page.mainFrame();
   const windowHandle = await mainFrame.evaluateHandle(() => window);

--- a/tests/page/frame-frame-element.spec.ts
+++ b/tests/page/frame-frame-element.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import { attachFrame } from '../config/utils';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const frame1 = await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   await attachFrame(page, 'frame2', server.EMPTY_PAGE);
@@ -32,7 +32,7 @@ it('should work', async ({page, server}) => {
   expect(await frame1handle1.evaluate((a, b) => a === b, frame3handle1)).toBe(false);
 });
 
-it('should work with contentFrame', async ({page, server}) => {
+it('should work with contentFrame', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const frame = await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   const handle = await frame.frameElement();
@@ -40,7 +40,7 @@ it('should work with contentFrame', async ({page, server}) => {
   expect(contentFrame).toBe(frame);
 });
 
-it('should work with frameset', async ({page, server}) => {
+it('should work with frameset', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/frameset.html');
   const frameElement1 = await page.$('frame');
   const frame = await frameElement1.contentFrame();
@@ -48,7 +48,7 @@ it('should work with frameset', async ({page, server}) => {
   expect(await frameElement1.evaluate((a, b) => a === b, frameElement2)).toBe(true);
 });
 
-it('should throw when detached', async ({page, server}) => {
+it('should throw when detached', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const frame1 = await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   await page.$eval('#frame1', e => e.remove());

--- a/tests/page/frame-goto.spec.ts
+++ b/tests/page/frame-goto.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import { attachFrame } from '../config/utils';
 
-it('should navigate subframes', async ({page, server}) => {
+it('should navigate subframes', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(page.frames()[0].url()).toContain('/frames/one-frame.html');
   expect(page.frames()[1].url()).toContain('/frames/frame.html');
@@ -28,7 +28,7 @@ it('should navigate subframes', async ({page, server}) => {
   expect(response.frame()).toBe(page.frames()[1]);
 });
 
-it('should reject when frame detaches', async ({page, server}) => {
+it('should reject when frame detaches', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
 
   server.setRoute('/empty.html', () => {});
@@ -40,7 +40,7 @@ it('should reject when frame detaches', async ({page, server}) => {
   expect(error.message).toContain('frame was detached');
 });
 
-it('should continue after client redirect', async ({page, server, isAndroid}) => {
+it('should continue after client redirect', async ({ page, server, isAndroid }) => {
   it.fixme(isAndroid);
 
   server.setRoute('/frames/script.js', () => {});
@@ -50,7 +50,7 @@ it('should continue after client redirect', async ({page, server, isAndroid}) =>
   expect(error.message).toContain(`navigating to "${url}", waiting until "networkidle"`);
 });
 
-it('should return matching responses', async ({page, server}) => {
+it('should return matching responses', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   // Attach three frames.
   const frames = [

--- a/tests/page/frame-hierarchy.spec.ts
+++ b/tests/page/frame-hierarchy.spec.ts
@@ -35,7 +35,7 @@ function dumpFrames(frame: Frame, indentation: string = ''): string[] {
   return result;
 }
 
-it('should handle nested frames', async ({page, server, isAndroid}) => {
+it('should handle nested frames', async ({ page, server, isAndroid }) => {
   it.skip(isAndroid, 'No cross-process on Android');
 
   await page.goto(server.PREFIX + '/frames/nested-frames.html');
@@ -48,7 +48,7 @@ it('should handle nested frames', async ({page, server, isAndroid}) => {
   ]);
 });
 
-it('should send events when frames are manipulated dynamically', async ({page, server}) => {
+it('should send events when frames are manipulated dynamically', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   // validate frameattached events
   const attachedFrames = [];
@@ -76,7 +76,7 @@ it('should send events when frames are manipulated dynamically', async ({page, s
   expect(detachedFrames[0].isDetached()).toBe(true);
 });
 
-it('should send "framenavigated" when navigating on anchor URLs', async ({page, server}) => {
+it('should send "framenavigated" when navigating on anchor URLs', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await Promise.all([
     page.goto(server.EMPTY_PAGE + '#foo'),
@@ -85,14 +85,14 @@ it('should send "framenavigated" when navigating on anchor URLs', async ({page, 
   expect(page.url()).toBe(server.EMPTY_PAGE + '#foo');
 });
 
-it('should persist mainFrame on cross-process navigation', async ({page, server}) => {
+it('should persist mainFrame on cross-process navigation', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const mainFrame = page.mainFrame();
   await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
   expect(page.mainFrame() === mainFrame).toBeTruthy();
 });
 
-it('should not send attach/detach events for main frame', async ({page, server}) => {
+it('should not send attach/detach events for main frame', async ({ page, server }) => {
   let hasEvents = false;
   page.on('frameattached', frame => hasEvents = true);
   page.on('framedetached', frame => hasEvents = true);
@@ -100,7 +100,7 @@ it('should not send attach/detach events for main frame', async ({page, server})
   expect(hasEvents).toBe(false);
 });
 
-it('should detach child frames on navigation', async ({page, server}) => {
+it('should detach child frames on navigation', async ({ page, server }) => {
   let attachedFrames = [];
   let detachedFrames = [];
   let navigatedFrames = [];
@@ -121,7 +121,7 @@ it('should detach child frames on navigation', async ({page, server}) => {
   expect(navigatedFrames.length).toBe(1);
 });
 
-it('should support framesets', async ({page, server}) => {
+it('should support framesets', async ({ page, server }) => {
   let attachedFrames = [];
   let detachedFrames = [];
   let navigatedFrames = [];
@@ -142,7 +142,7 @@ it('should support framesets', async ({page, server}) => {
   expect(navigatedFrames.length).toBe(1);
 });
 
-it('should report frame from-inside shadow DOM', async ({page, server}) => {
+it('should report frame from-inside shadow DOM', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/shadow.html');
   await page.evaluate(async url => {
     const frame = document.createElement('iframe');
@@ -154,7 +154,7 @@ it('should report frame from-inside shadow DOM', async ({page, server}) => {
   expect(page.frames()[1].url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should report frame.name()', async ({page, server, isElectron}) => {
+it('should report frame.name()', async ({ page, server, isElectron }) => {
   it.fixme(isElectron);
 
   await attachFrame(page, 'theFrameId', server.EMPTY_PAGE);
@@ -170,7 +170,7 @@ it('should report frame.name()', async ({page, server, isElectron}) => {
   expect(page.frames()[2].name()).toBe('theFrameName');
 });
 
-it('should report frame.parent()', async ({page, server}) => {
+it('should report frame.parent()', async ({ page, server }) => {
   await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   await attachFrame(page, 'frame2', server.EMPTY_PAGE);
   expect(page.frames()[0].parentFrame()).toBe(null);
@@ -178,7 +178,7 @@ it('should report frame.parent()', async ({page, server}) => {
   expect(page.frames()[2].parentFrame()).toBe(page.mainFrame());
 });
 
-it('should report different frame instance when frame re-attaches', async ({page, server, isElectron}) => {
+it('should report different frame instance when frame re-attaches', async ({ page, server, isElectron }) => {
   it.fixme(isElectron);
 
   const frame1 = await attachFrame(page, 'frame1', server.EMPTY_PAGE);
@@ -195,7 +195,7 @@ it('should report different frame instance when frame re-attaches', async ({page
   expect(frame1).not.toBe(frame2);
 });
 
-it('should refuse to display x-frame-options:deny iframe', async ({page, server, browserName}) => {
+it('should refuse to display x-frame-options:deny iframe', async ({ page, server, browserName }) => {
   it.fixme(browserName === 'firefox');
 
   server.setRoute('/x-frame-options-deny.html', async (req, res) => {
@@ -214,7 +214,7 @@ it('should refuse to display x-frame-options:deny iframe', async ({page, server,
   expect(await refusalText).toMatch(/Refused to display .* in a frame because it set 'X-Frame-Options' to 'deny'./i);
 });
 
-it('should return frame.page()', async ({page, server}) => {
+it('should return frame.page()', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(page.mainFrame().page()).toBe(page);
   expect(page.mainFrame().childFrames()[0].page()).toBe(page);

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -19,7 +19,7 @@ import { test as it, expect } from './pageTest';
 import { globToRegex } from '../../lib/client/clientHelper';
 import vm from 'vm';
 
-it('should work with navigation', async ({page, server}) => {
+it('should work with navigation', async ({ page, server }) => {
   const requests = new Map();
   await page.route('**/*', route => {
     requests.set(route.request().url().split('/').pop(), route.request());
@@ -33,7 +33,7 @@ it('should work with navigation', async ({page, server}) => {
   expect(requests.get('style.css').isNavigationRequest()).toBe(false);
 });
 
-it('should intercept after a service worker', async ({page, server, isAndroid}) => {
+it('should intercept after a service worker', async ({ page, server, isAndroid }) => {
   it.skip(isAndroid);
 
   await page.goto(server.PREFIX + '/serviceworkers/fetchdummy/sw.html');
@@ -83,7 +83,7 @@ it('should work with glob', async () => {
   expect(globToRegex('http://localhost:3000/signin-oidc*').test('http://localhost:3000/signin-oidcnice')).toBeTruthy();
 });
 
-it('should intercept network activity from worker', async function({page, server, isAndroid}) {
+it('should intercept network activity from worker', async function({ page, server, isAndroid }) {
   it.skip(isAndroid);
 
   await page.goto(server.EMPTY_PAGE);
@@ -99,12 +99,12 @@ it('should intercept network activity from worker', async function({page, server
     page.waitForEvent('console'),
     page.evaluate(url => new Worker(URL.createObjectURL(new Blob([`
       fetch("${url}").then(response => response.text()).then(console.log);
-    `], {type: 'application/javascript'}))), url),
+    `], { type: 'application/javascript' }))), url),
   ]);
   expect(msg.text()).toBe('intercepted');
 });
 
-it('should intercept network activity from worker 2', async function({page, server, isElectron, isAndroid}) {
+it('should intercept network activity from worker 2', async function({ page, server, isElectron, isAndroid }) {
   it.skip(isAndroid);
   it.fixme(isElectron);
 
@@ -123,7 +123,7 @@ it('should intercept network activity from worker 2', async function({page, serv
   expect(msg.text()).toBe('intercepted');
 });
 
-it('should work with regular expression passed from a different context', async ({page, server, isElectron}) => {
+it('should work with regular expression passed from a different context', async ({ page, server, isElectron }) => {
   it.skip(isElectron);
 
   const ctx = vm.createContext();

--- a/tests/page/jshandle-as-element.spec.ts
+++ b/tests/page/jshandle-as-element.spec.ts
@@ -17,19 +17,19 @@
 
 import { test, expect } from './pageTest';
 
-test('should work', async ({page}) => {
+test('should work', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => document.body);
   const element = aHandle.asElement();
   expect(element).toBeTruthy();
 });
 
-test('should return null for non-elements', async ({page}) => {
+test('should return null for non-elements', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => 2);
   const element = aHandle.asElement();
   expect(element).toBeFalsy();
 });
 
-test('should return ElementHandle for TextNodes', async ({page}) => {
+test('should return ElementHandle for TextNodes', async ({ page }) => {
   await page.setContent('<div>ee!</div>');
   const aHandle = await page.evaluateHandle(() => document.querySelector('div').firstChild);
   const element = aHandle.asElement();
@@ -37,7 +37,7 @@ test('should return ElementHandle for TextNodes', async ({page}) => {
   expect(await page.evaluate(e => e.nodeType === Node.TEXT_NODE, element)).toBeTruthy();
 });
 
-test('should work with nullified Node', async ({page}) => {
+test('should work with nullified Node', async ({ page }) => {
   await page.setContent('<section>test</section>');
   await page.evaluate('delete Node');
   const handle = await page.evaluateHandle(() => document.querySelector('section'));

--- a/tests/page/jshandle-evaluate.spec.ts
+++ b/tests/page/jshandle-evaluate.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work with function', async ({page}) => {
+it('should work with function', async ({ page }) => {
   const windowHandle = await page.evaluateHandle(() => {
     window['foo'] = [1, 2];
     return window;
@@ -25,7 +25,7 @@ it('should work with function', async ({page}) => {
   expect(await windowHandle.evaluate(w => w['foo'])).toEqual([1, 2]);
 });
 
-it('should work with expression', async ({page}) => {
+it('should work with expression', async ({ page }) => {
   const windowHandle = await page.evaluateHandle(() => {
     window['foo'] = [1, 2];
     return window;

--- a/tests/page/jshandle-json-value.spec.ts
+++ b/tests/page/jshandle-json-value.spec.ts
@@ -17,19 +17,19 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({page}) => {
-  const aHandle = await page.evaluateHandle(() => ({foo: 'bar'}));
+it('should work', async ({ page }) => {
+  const aHandle = await page.evaluateHandle(() => ({ foo: 'bar' }));
   const json = await aHandle.jsonValue();
-  expect(json).toEqual({foo: 'bar'});
+  expect(json).toEqual({ foo: 'bar' });
 });
 
-it('should work with dates', async ({page}) => {
+it('should work with dates', async ({ page }) => {
   const dateHandle = await page.evaluateHandle(() => new Date('2017-09-26T00:00:00.000Z'));
   const date = await dateHandle.jsonValue();
   expect(date.toJSON()).toBe('2017-09-26T00:00:00.000Z');
 });
 
-it('should throw for circular objects', async ({page}) => {
+it('should throw for circular objects', async ({ page }) => {
   const windowHandle = await page.evaluateHandle('window');
   let error = null;
   await windowHandle.jsonValue().catch(e => error = e);

--- a/tests/page/jshandle-properties.spec.ts
+++ b/tests/page/jshandle-properties.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import type { ElementHandle } from '../../index';
 
-it('should work', async ({page}) => {
+it('should work', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => ({
     one: 1,
     two: 2,
@@ -28,7 +28,7 @@ it('should work', async ({page}) => {
   expect(await twoHandle.jsonValue()).toEqual(2);
 });
 
-it('should work with undefined, null, and empty', async ({page}) => {
+it('should work with undefined, null, and empty', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => ({
     undefined: undefined,
     null: null,
@@ -41,7 +41,7 @@ it('should work with undefined, null, and empty', async ({page}) => {
   expect(String(await emptyhandle.jsonValue())).toEqual('undefined');
 });
 
-it('should work with unserializable values', async ({page}) => {
+it('should work with unserializable values', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => ({
     infinity: Infinity,
     nInfinity: -Infinity,
@@ -58,7 +58,7 @@ it('should work with unserializable values', async ({page}) => {
   expect(await nzeroHandle.jsonValue()).toEqual(-0);
 });
 
-it('getProperties should work', async ({page}) => {
+it('getProperties should work', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => ({
     foo: 'bar'
   }));
@@ -68,13 +68,13 @@ it('getProperties should work', async ({page}) => {
   expect(await foo.jsonValue()).toBe('bar');
 });
 
-it('getProperties should return empty map for non-objects', async ({page}) => {
+it('getProperties should return empty map for non-objects', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => 123);
   const properties = await aHandle.getProperties();
   expect(properties.size).toBe(0);
 });
 
-it('getProperties should return even non-own properties', async ({page}) => {
+it('getProperties should return even non-own properties', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => {
     class A {
       a: string;
@@ -96,7 +96,7 @@ it('getProperties should return even non-own properties', async ({page}) => {
   expect(await properties.get('b').jsonValue()).toBe('2');
 });
 
-it('getProperties should work with elements', async ({page}) => {
+it('getProperties should work with elements', async ({ page }) => {
   await page.setContent(`<div>Hello</div>`);
   const handle = await page.evaluateHandle(() => ({ body: document.body }));
   const properties = await handle.getProperties();

--- a/tests/page/jshandle-to-string.spec.ts
+++ b/tests/page/jshandle-to-string.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work for primitives', async ({page}) => {
+it('should work for primitives', async ({ page }) => {
   const numberHandle = await page.evaluateHandle(() => 2);
   expect(numberHandle.toString()).toBe('2');
   const stringHandle = await page.evaluateHandle(() => 'a');
@@ -34,7 +34,7 @@ it('should work for complicated objects', async ({ page, browserName }) => {
 
 it('should work for promises', async ({ page }) => {
   // wrap the promise in an object, otherwise we will await.
-  const wrapperHandle = await page.evaluateHandle(() => ({b: Promise.resolve(123)}));
+  const wrapperHandle = await page.evaluateHandle(() => ({ b: Promise.resolve(123) }));
   const bHandle = await wrapperHandle.getProperty('b');
   expect(bHandle.toString()).toBe('Promise');
 });

--- a/tests/page/locator-convenience.spec.ts
+++ b/tests/page/locator-convenience.spec.ts
@@ -151,7 +151,7 @@ it('isEditable should work', async ({ page }) => {
   expect(await page.isEditable('textarea')).toBe(false);
 });
 
-it('isChecked should work', async ({page}) => {
+it('isChecked should work', async ({ page }) => {
   await page.setContent(`<input type='checkbox' checked><div>Not a checkbox</div>`);
   const element = page.locator('input');
   expect(await element.isChecked()).toBe(true);
@@ -163,12 +163,12 @@ it('isChecked should work', async ({page}) => {
   expect(error.message).toContain('Not a checkbox or radio button');
 });
 
-it('allTextContents should work', async ({page}) => {
+it('allTextContents should work', async ({ page }) => {
   await page.setContent(`<div>A</div><div>B</div><div>C</div>`);
   expect(await page.locator('div').allTextContents()).toEqual(['A', 'B', 'C']);
 });
 
-it('allInnerTexts should work', async ({page}) => {
+it('allInnerTexts should work', async ({ page }) => {
   await page.setContent(`<div>A</div><div>B</div><div>C</div>`);
   expect(await page.locator('div').allInnerTexts()).toEqual(['A', 'B', 'C']);
 });

--- a/tests/page/locator-element-handle.spec.ts
+++ b/tests/page/locator-element-handle.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should query existing element', async ({page, server}) => {
+it('should query existing element', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/playground.html');
   await page.setContent('<html><body><div class="second"><div class="inner">A</div></div></body></html>');
   const html = page.locator('html');
@@ -27,7 +27,7 @@ it('should query existing element', async ({page, server}) => {
   expect(content).toBe('A');
 });
 
-it('should query existing elements', async ({page, server}) => {
+it('should query existing elements', async ({ page, server }) => {
   await page.setContent('<html><body><div>A</div><br/><div>B</div></body></html>');
   const html = page.locator('html');
   const elements = await html.locator('div').elementHandles();
@@ -36,7 +36,7 @@ it('should query existing elements', async ({page, server}) => {
   expect(await Promise.all(promises)).toEqual(['A', 'B']);
 });
 
-it('should return empty array for non-existing elements', async ({page, server}) => {
+it('should return empty array for non-existing elements', async ({ page, server }) => {
   await page.setContent('<html><body><span>A</span><br/><span>B</span></body></html>');
   const html = page.locator('html');
   const elements = await html.locator('div').elementHandles();
@@ -44,7 +44,7 @@ it('should return empty array for non-existing elements', async ({page, server})
 });
 
 
-it('xpath should query existing element', async ({page, server}) => {
+it('xpath should query existing element', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/playground.html');
   await page.setContent('<html><body><div class="second"><div class="inner">A</div></div></body></html>');
   const html = page.locator('html');
@@ -54,7 +54,7 @@ it('xpath should query existing element', async ({page, server}) => {
   expect(content).toBe('A');
 });
 
-it('xpath should return null for non-existing element', async ({page, server}) => {
+it('xpath should return null for non-existing element', async ({ page, server }) => {
   await page.setContent('<html><body><div class="second"><div class="inner">B</div></div></body></html>');
   const html = page.locator('html');
   const second = await html.locator(`xpath=/div[contains(@class, 'third')]`).elementHandles();

--- a/tests/page/locator-evaluate.spec.ts
+++ b/tests/page/locator-evaluate.spec.ts
@@ -17,14 +17,14 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.setContent('<html><body><div class="tweet"><div class="like">100</div><div class="retweets">10</div></div></body></html>');
   const tweet = page.locator('.tweet .like');
   const content = await tweet.evaluate(node => (node as HTMLElement).innerText);
   expect(content).toBe('100');
 });
 
-it('should retrieve content from subtree', async ({page, server}) => {
+it('should retrieve content from subtree', async ({ page, server }) => {
   const htmlContent = '<div class="a">not-a-child-div</div><div id="myId"><div class="a">a-child-div</div></div>';
   await page.setContent(htmlContent);
   const elementHandle = page.locator('#myId .a');
@@ -32,14 +32,14 @@ it('should retrieve content from subtree', async ({page, server}) => {
   expect(content).toBe('a-child-div');
 });
 
-it('should work for all', async ({page, server}) => {
+it('should work for all', async ({ page, server }) => {
   await page.setContent('<html><body><div class="tweet"><div class="like">100</div><div class="like">10</div></div></body></html>');
   const tweet = page.locator('.tweet .like');
   const content = await tweet.evaluateAll(nodes => nodes.map(n => (n as HTMLElement).innerText));
   expect(content).toEqual(['100', '10']);
 });
 
-it('should retrieve content from subtree for all', async ({page, server}) => {
+it('should retrieve content from subtree for all', async ({ page, server }) => {
   const htmlContent = '<div class="a">not-a-child-div</div><div id="myId"><div class="a">a1-child-div</div><div class="a">a2-child-div</div></div>';
   await page.setContent(htmlContent);
   const element = page.locator('#myId .a');
@@ -47,7 +47,7 @@ it('should retrieve content from subtree for all', async ({page, server}) => {
   expect(content).toEqual(['a1-child-div', 'a2-child-div']);
 });
 
-it('should not throw in case of missing selector for all', async ({page, server}) => {
+it('should not throw in case of missing selector for all', async ({ page, server }) => {
   const htmlContent = '<div class="a">not-a-child-div</div><div id="myId"></div>';
   await page.setContent(htmlContent);
   const element = page.locator('#myId .a');

--- a/tests/page/locator-misc-1.spec.ts
+++ b/tests/page/locator-misc-1.spec.ts
@@ -87,14 +87,14 @@ it('should focus a button', async ({ page, server }) => {
   expect(await button.evaluate(button => document.activeElement === button)).toBe(true);
 });
 
-it('should dispatch click event via ElementHandles', async ({page, server}) => {
+it('should dispatch click event via ElementHandles', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   const button = page.locator('button');
   await button.dispatchEvent('click');
   expect(await page.evaluate(() => window['result'])).toBe('Clicked');
 });
 
-it('should upload the file', async ({page, server, asset}) => {
+it('should upload the file', async ({ page, server, asset }) => {
   await page.goto(server.PREFIX + '/input/fileupload.html');
   const filePath = path.relative(process.cwd(), asset('file-to-upload.txt'));
   const input = page.locator('input[type=file]');

--- a/tests/page/locator-misc-2.spec.ts
+++ b/tests/page/locator-misc-2.spec.ts
@@ -64,7 +64,7 @@ it('should type', async ({ page }) => {
 it('should take screenshot', async ({ page, server, browserName, headless, isAndroid }) => {
   it.skip(browserName === 'firefox' && !headless);
   it.skip(isAndroid, 'Different dpr. Remove after using 1x scale for screenshots.');
-  await page.setViewportSize({width: 500, height: 500});
+  await page.setViewportSize({ width: 500, height: 500 });
   await page.goto(server.PREFIX + '/grid.html');
   await page.evaluate(() => window.scrollBy(50, 100));
   const element = page.locator('.box:nth-of-type(3)');

--- a/tests/page/locator-query.spec.ts
+++ b/tests/page/locator-query.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should respect first() and last()', async ({page}) => {
+it('should respect first() and last()', async ({ page }) => {
   await page.setContent(`
   <section>
     <div><p>A</p></div>
@@ -30,7 +30,7 @@ it('should respect first() and last()', async ({page}) => {
   expect(await page.locator('div').last().locator('p').count()).toBe(3);
 });
 
-it('should respect nth()', async ({page}) => {
+it('should respect nth()', async ({ page }) => {
   await page.setContent(`
   <section>
     <div><p>A</p></div>
@@ -42,19 +42,19 @@ it('should respect nth()', async ({page}) => {
   expect(await page.locator('div').nth(2).locator('p').count()).toBe(3);
 });
 
-it('should throw on capture w/ nth()', async ({page}) => {
+it('should throw on capture w/ nth()', async ({ page }) => {
   await page.setContent(`<section><div><p>A</p></div></section>`);
   const e = await page.locator('*css=div >> p').nth(1).click().catch(e => e);
   expect(e.message).toContain(`Can't query n-th element`);
 });
 
-it('should throw on due to strictness', async ({page}) => {
+it('should throw on due to strictness', async ({ page }) => {
   await page.setContent(`<div>A</div><div>B</div>`);
   const e = await page.locator('div').isVisible().catch(e => e);
   expect(e.message).toContain(`strict mode violation`);
 });
 
-it('should throw on due to strictness 2', async ({page}) => {
+it('should throw on due to strictness 2', async ({ page }) => {
   await page.setContent(`<select><option>One</option><option>Two</option></select>`);
   const e = await page.locator('option').evaluate(e => {}).catch(e => e);
   expect(e.message).toContain(`strict mode violation`);

--- a/tests/page/network-post-data.spec.ts
+++ b/tests/page/network-post-data.spec.ts
@@ -18,51 +18,51 @@ import { test as it, expect } from './pageTest';
 
 it.fixme(({ isAndroid }) => isAndroid, 'Post data  does not work');
 
-it('should return correct postData buffer for utf-8 body', async ({page, server}) => {
+it('should return correct postData buffer for utf-8 body', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const value = 'baẞ';
   const [request] = await Promise.all([
     page.waitForRequest('**'),
-    page.evaluate(({url, value}) => {
+    page.evaluate(({ url, value }) => {
       const request = new Request(url, {
         method: 'POST',
         body: JSON.stringify(value),
       });
       request.headers.set('content-type', 'application/json;charset=UTF-8');
       return fetch(request);
-    }, {url: server.PREFIX + '/title.html', value})
+    }, { url: server.PREFIX + '/title.html', value })
   ]);
   expect(request.postDataBuffer().equals(Buffer.from(JSON.stringify(value), 'utf-8'))).toBe(true);
   expect(request.postDataJSON()).toBe(value);
 });
 
-it('should return post data w/o content-type', async ({page, server}) => {
+it('should return post data w/o content-type', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     page.waitForRequest('**'),
-    page.evaluate(({url}) => {
+    page.evaluate(({ url }) => {
       const request = new Request(url, {
         method: 'POST',
         body: JSON.stringify({ value: 42 }),
       });
       request.headers.set('content-type', '');
       return fetch(request);
-    }, {url: server.PREFIX + '/title.html'})
+    }, { url: server.PREFIX + '/title.html' })
   ]);
   expect(request.postDataJSON()).toEqual({ value: 42 });
 });
 
-it('should throw on invalid JSON in post data', async ({page, server}) => {
+it('should throw on invalid JSON in post data', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     page.waitForRequest('**'),
-    page.evaluate(({url}) => {
+    page.evaluate(({ url }) => {
       const request = new Request(url, {
         method: 'POST',
         body: '<not a json>',
       });
       return fetch(request);
-    }, {url: server.PREFIX + '/title.html'})
+    }, { url: server.PREFIX + '/title.html' })
   ]);
   let error;
   try {
@@ -73,22 +73,22 @@ it('should throw on invalid JSON in post data', async ({page, server}) => {
   expect(error.message).toContain('POST data is not a valid JSON object: <not a json>');
 });
 
-it('should return post data for PUT requests', async ({page, server}) => {
+it('should return post data for PUT requests', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     page.waitForRequest('**'),
-    page.evaluate(({url}) => {
+    page.evaluate(({ url }) => {
       const request = new Request(url, {
         method: 'PUT',
         body: JSON.stringify({ value: 42 }),
       });
       return fetch(request);
-    }, {url: server.PREFIX + '/title.html'})
+    }, { url: server.PREFIX + '/title.html' })
   ]);
   expect(request.postDataJSON()).toEqual({ value: 42 });
 });
 
-it('should get post data for file/blob', async ({page, server, browserName}) => {
+it('should get post data for file/blob', async ({ page, server, browserName }) => {
   it.fail(browserName === 'webkit' || browserName === 'chromium');
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([

--- a/tests/page/page-accessibility.spec.ts
+++ b/tests/page/page-accessibility.spec.ts
@@ -40,46 +40,46 @@ it('should work', async ({ page, browserName }) => {
     role: 'document',
     name: 'Accessibility Test',
     children: [
-      {role: 'heading', name: 'Inputs', level: 1},
-      {role: 'textbox', name: 'Empty input', focused: true},
-      {role: 'textbox', name: 'readonly input', readonly: true},
-      {role: 'textbox', name: 'disabled input', disabled: true},
-      {role: 'textbox', name: 'Input with whitespace', value: '  '},
-      {role: 'textbox', name: '', value: 'value only'},
-      {role: 'textbox', name: '', value: 'and a value'}, // firefox doesn't use aria-placeholder for the name
-      {role: 'textbox', name: '', value: 'and a value', description: 'This is a description!'}, // and here
+      { role: 'heading', name: 'Inputs', level: 1 },
+      { role: 'textbox', name: 'Empty input', focused: true },
+      { role: 'textbox', name: 'readonly input', readonly: true },
+      { role: 'textbox', name: 'disabled input', disabled: true },
+      { role: 'textbox', name: 'Input with whitespace', value: '  ' },
+      { role: 'textbox', name: '', value: 'value only' },
+      { role: 'textbox', name: '', value: 'and a value' }, // firefox doesn't use aria-placeholder for the name
+      { role: 'textbox', name: '', value: 'and a value', description: 'This is a description!' }, // and here
     ]
   } : (browserName === 'chromium') ? {
     role: 'WebArea',
     name: 'Accessibility Test',
     children: [
-      {role: 'heading', name: 'Inputs', level: 1},
-      {role: 'textbox', name: 'Empty input', focused: true},
-      {role: 'textbox', name: 'readonly input', readonly: true},
-      {role: 'textbox', name: 'disabled input', disabled: true},
-      {role: 'textbox', name: 'Input with whitespace', value: '  '},
-      {role: 'textbox', name: '', value: 'value only'},
-      {role: 'textbox', name: 'placeholder', value: 'and a value'},
-      {role: 'textbox', name: 'placeholder', value: 'and a value', description: 'This is a description!'},
+      { role: 'heading', name: 'Inputs', level: 1 },
+      { role: 'textbox', name: 'Empty input', focused: true },
+      { role: 'textbox', name: 'readonly input', readonly: true },
+      { role: 'textbox', name: 'disabled input', disabled: true },
+      { role: 'textbox', name: 'Input with whitespace', value: '  ' },
+      { role: 'textbox', name: '', value: 'value only' },
+      { role: 'textbox', name: 'placeholder', value: 'and a value' },
+      { role: 'textbox', name: 'placeholder', value: 'and a value', description: 'This is a description!' },
     ]
   } : {
     role: 'WebArea',
     name: 'Accessibility Test',
     children: [
-      {role: 'heading', name: 'Inputs', level: 1},
-      {role: 'textbox', name: 'Empty input', focused: true},
-      {role: 'textbox', name: 'readonly input', readonly: true},
-      {role: 'textbox', name: 'disabled input', disabled: true},
-      {role: 'textbox', name: 'Input with whitespace', value: '  ' },
-      {role: 'textbox', name: '', value: 'value only' },
-      {role: 'textbox', name: 'placeholder', value: 'and a value'},
-      {role: 'textbox', name: 'This is a description!',value: 'and a value'}, // webkit uses the description over placeholder for the name
+      { role: 'heading', name: 'Inputs', level: 1 },
+      { role: 'textbox', name: 'Empty input', focused: true },
+      { role: 'textbox', name: 'readonly input', readonly: true },
+      { role: 'textbox', name: 'disabled input', disabled: true },
+      { role: 'textbox', name: 'Input with whitespace', value: '  ' },
+      { role: 'textbox', name: '', value: 'value only' },
+      { role: 'textbox', name: 'placeholder', value: 'and a value' },
+      { role: 'textbox', name: 'This is a description!',value: 'and a value' }, // webkit uses the description over placeholder for the name
     ]
   };
   expect(await page.accessibility.snapshot()).toEqual(golden);
 });
 
-it('should work with regular text', async ({page, browserName}) => {
+it('should work with regular text', async ({ page, browserName }) => {
   await page.setContent(`<div>Hello World</div>`);
   const snapshot = await page.accessibility.snapshot();
   expect(snapshot.children[0]).toEqual({
@@ -88,37 +88,37 @@ it('should work with regular text', async ({page, browserName}) => {
   });
 });
 
-it('roledescription', async ({page}) => {
+it('roledescription', async ({ page }) => {
   await page.setContent('<p tabIndex=-1 aria-roledescription="foo">Hi</p>');
   const snapshot = await page.accessibility.snapshot();
   expect(snapshot.children[0].roledescription).toEqual('foo');
 });
 
-it('orientation', async ({page}) => {
+it('orientation', async ({ page }) => {
   await page.setContent('<a href="" role="slider" aria-orientation="vertical">11</a>');
   const snapshot = await page.accessibility.snapshot();
   expect(snapshot.children[0].orientation).toEqual('vertical');
 });
 
-it('autocomplete', async ({page}) => {
+it('autocomplete', async ({ page }) => {
   await page.setContent('<div role="textbox" aria-autocomplete="list">hi</div>');
   const snapshot = await page.accessibility.snapshot();
   expect(snapshot.children[0].autocomplete).toEqual('list');
 });
 
-it('multiselectable', async ({page}) => {
+it('multiselectable', async ({ page }) => {
   await page.setContent('<div role="grid" tabIndex=-1 aria-multiselectable=true>hey</div>');
   const snapshot = await page.accessibility.snapshot();
   expect(snapshot.children[0].multiselectable).toEqual(true);
 });
 
-it('keyshortcuts', async ({page}) => {
+it('keyshortcuts', async ({ page }) => {
   await page.setContent('<div role="grid" tabIndex=-1 aria-keyshortcuts="foo">hey</div>');
   const snapshot = await page.accessibility.snapshot();
   expect(snapshot.children[0].keyshortcuts).toEqual('foo');
 });
 
-it('should not report text nodes inside controls', async function({page, browserName}) {
+it('should not report text nodes inside controls', async function({ page, browserName }) {
   await page.setContent(`
   <div role="tablist">
     <div role="tab" aria-selected="true"><b>Tab1</b></div>
@@ -139,7 +139,7 @@ it('should not report text nodes inside controls', async function({page, browser
   expect(await page.accessibility.snapshot()).toEqual(golden);
 });
 
-it('rich text editable fields should have children', async function({page, browserName}) {
+it('rich text editable fields should have children', async function({ page, browserName }) {
   it.skip(browserName === 'webkit', 'WebKit rich text accessibility is iffy');
 
   await page.setContent(`
@@ -172,7 +172,7 @@ it('rich text editable fields should have children', async function({page, brows
   expect(snapshot.children[0]).toEqual(golden);
 });
 
-it('rich text editable fields with role should have children', async function({page, browserName, browserMajorVersion}) {
+it('rich text editable fields with role should have children', async function({ page, browserName, browserMajorVersion }) {
   it.skip(browserName === 'webkit', 'WebKit rich text accessibility is iffy');
 
   await page.setContent(`
@@ -204,7 +204,7 @@ it('rich text editable fields with role should have children', async function({p
   expect(snapshot.children[0]).toEqual(golden);
 });
 
-it('non editable textbox with role and tabIndex and label should not have children', async function({page, browserName}) {
+it('non editable textbox with role and tabIndex and label should not have children', async function({ page, browserName }) {
   await page.setContent(`
   <div role="textbox" tabIndex=0 aria-checked="true" aria-label="my favorite textbox">
     this is the inner content
@@ -227,7 +227,7 @@ it('non editable textbox with role and tabIndex and label should not have childr
   expect(snapshot.children[0]).toEqual(golden);
 });
 
-it('checkbox with and tabIndex and label should not have children', async function({page}) {
+it('checkbox with and tabIndex and label should not have children', async function({ page }) {
   await page.setContent(`
   <div role="checkbox" tabIndex=0 aria-checked="true" aria-label="my favorite checkbox">
     this is the inner content
@@ -242,7 +242,7 @@ it('checkbox with and tabIndex and label should not have children', async functi
   expect(snapshot.children[0]).toEqual(golden);
 });
 
-it('checkbox without label should not have children', async ({page, browserName}) => {
+it('checkbox without label should not have children', async ({ page, browserName }) => {
   await page.setContent(`
   <div role="checkbox" aria-checked="true">
     this is the inner content
@@ -261,28 +261,28 @@ it('checkbox without label should not have children', async ({page, browserName}
   expect(snapshot.children[0]).toEqual(golden);
 });
 
-it('should work a button', async ({page}) => {
+it('should work a button', async ({ page }) => {
   await page.setContent(`<button>My Button</button>`);
 
   const button = await page.$('button');
-  expect(await page.accessibility.snapshot({root: button})).toEqual({
+  expect(await page.accessibility.snapshot({ root: button })).toEqual({
     role: 'button',
     name: 'My Button'
   });
 });
 
-it('should work an input', async ({page}) => {
+it('should work an input', async ({ page }) => {
   await page.setContent(`<input title="My Input" value="My Value">`);
 
   const input = await page.$('input');
-  expect(await page.accessibility.snapshot({root: input})).toEqual({
+  expect(await page.accessibility.snapshot({ root: input })).toEqual({
     role: 'textbox',
     name: 'My Input',
     value: 'My Value'
   });
 });
 
-it('should work on a menu', async ({page, browserName}) => {
+it('should work on a menu', async ({ page, browserName }) => {
   await page.setContent(`
     <div role="menu" title="My Menu">
       <div role="menuitem">First Item</div>
@@ -292,7 +292,7 @@ it('should work on a menu', async ({page, browserName}) => {
   `);
 
   const menu = await page.$('div[role="menu"]');
-  expect(await page.accessibility.snapshot({root: menu})).toEqual({
+  expect(await page.accessibility.snapshot({ root: menu })).toEqual({
     role: 'menu',
     name: 'My Menu',
     children:
@@ -303,14 +303,14 @@ it('should work on a menu', async ({page, browserName}) => {
   });
 });
 
-it('should return null when the element is no longer in DOM', async ({page}) => {
+it('should return null when the element is no longer in DOM', async ({ page }) => {
   await page.setContent(`<button>My Button</button>`);
   const button = await page.$('button');
   await page.$eval('button', button => button.remove());
-  expect(await page.accessibility.snapshot({root: button})).toEqual(null);
+  expect(await page.accessibility.snapshot({ root: button })).toEqual(null);
 });
 
-it('should show uninteresting nodes', async ({page}) => {
+it('should show uninteresting nodes', async ({ page }) => {
   await page.setContent(`
     <div id="root" role="textbox">
       <div>
@@ -323,14 +323,14 @@ it('should show uninteresting nodes', async ({page}) => {
   `);
 
   const root = await page.$('#root');
-  const snapshot = await page.accessibility.snapshot({root, interestingOnly: false});
+  const snapshot = await page.accessibility.snapshot({ root, interestingOnly: false });
   expect(snapshot.role).toBe('textbox');
   expect(snapshot.value).toContain('hello');
   expect(snapshot.value).toContain('world');
   expect(!!snapshot.children).toBe(true);
 });
 
-it('should work when there is a title ', async ({page}) => {
+it('should work when there is a title ', async ({ page }) => {
   await page.setContent(`
     <title>This is the title</title>
     <div>This is the content</div>

--- a/tests/page/page-add-script-tag.spec.ts
+++ b/tests/page/page-add-script-tag.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import path from 'path';
 
-it('should throw an error if no options are provided', async ({page, server}) => {
+it('should throw an error if no options are provided', async ({ page, server }) => {
   let error = null;
   try {
     // @ts-ignore
@@ -29,34 +29,34 @@ it('should throw an error if no options are provided', async ({page, server}) =>
   expect(error.message).toContain('Provide an object with a `url`, `path` or `content` property');
 });
 
-it('should work with a url', async ({page, server}) => {
+it('should work with a url', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const scriptHandle = await page.addScriptTag({ url: '/injectedfile.js' });
   expect(scriptHandle.asElement()).not.toBeNull();
   expect(await page.evaluate(() => window['__injected'])).toBe(42);
 });
 
-it('should work with a url and type=module', async ({page, server}) => {
+it('should work with a url and type=module', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.addScriptTag({ url: '/es6/es6import.js', type: 'module' });
   expect(await page.evaluate(() => window['__es6injected'])).toBe(42);
 });
 
-it('should work with a path and type=module', async ({page, server, asset}) => {
+it('should work with a path and type=module', async ({ page, server, asset }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.addScriptTag({ path: asset('es6/es6pathimport.js'), type: 'module' });
   await page.waitForFunction('window.__es6injected');
   expect(await page.evaluate(() => window['__es6injected'])).toBe(42);
 });
 
-it('should work with a content and type=module', async ({page, server}) => {
+it('should work with a content and type=module', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.addScriptTag({ content: `import num from '/es6/es6module.js';window.__es6injected = num;`, type: 'module' });
   await page.waitForFunction('window.__es6injected');
   expect(await page.evaluate(() => window['__es6injected'])).toBe(42);
 });
 
-it('should throw an error if loading from url fail', async ({page, server}) => {
+it('should throw an error if loading from url fail', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let error = null;
   try {
@@ -67,14 +67,14 @@ it('should throw an error if loading from url fail', async ({page, server}) => {
   expect(error).not.toBe(null);
 });
 
-it('should work with a path', async ({page, server, asset}) => {
+it('should work with a path', async ({ page, server, asset }) => {
   await page.goto(server.EMPTY_PAGE);
   const scriptHandle = await page.addScriptTag({ path: asset('injectedfile.js') });
   expect(scriptHandle.asElement()).not.toBeNull();
   expect(await page.evaluate(() => window['__injected'])).toBe(42);
 });
 
-it('should include sourceURL when path is provided', async ({page, server, browserName, asset}) => {
+it('should include sourceURL when path is provided', async ({ page, server, browserName, asset }) => {
   it.skip(browserName === 'webkit');
 
   await page.goto(server.EMPTY_PAGE);
@@ -83,14 +83,14 @@ it('should include sourceURL when path is provided', async ({page, server, brows
   expect(result).toContain(path.join('assets', 'injectedfile.js'));
 });
 
-it('should work with content', async ({page, server}) => {
+it('should work with content', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const scriptHandle = await page.addScriptTag({ content: 'window["__injected"] = 35;' });
   expect(scriptHandle.asElement()).not.toBeNull();
   expect(await page.evaluate(() => window['__injected'])).toBe(35);
 });
 
-it('should throw when added with content to the CSP page', async ({page, server}) => {
+it('should throw when added with content to the CSP page', async ({ page, server }) => {
   // Firefox fires onload for blocked script before it issues the CSP console error.
   await page.goto(server.PREFIX + '/csp.html');
   let error = null;
@@ -98,7 +98,7 @@ it('should throw when added with content to the CSP page', async ({page, server}
   expect(error).toBeTruthy();
 });
 
-it('should throw when added with URL to the CSP page', async ({page, server, isAndroid}) => {
+it('should throw when added with URL to the CSP page', async ({ page, server, isAndroid }) => {
   it.skip(isAndroid, 'No cross-process on Android');
 
   await page.goto(server.PREFIX + '/csp.html');
@@ -107,9 +107,9 @@ it('should throw when added with URL to the CSP page', async ({page, server, isA
   expect(error).toBeTruthy();
 });
 
-it('should throw a nice error when the request fails', async ({page, server}) => {
+it('should throw a nice error when the request fails', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const url = server.PREFIX + '/this_does_not_exist.js';
-  const error = await page.addScriptTag({url}).catch(e => e);
+  const error = await page.addScriptTag({ url }).catch(e => e);
   expect(error.message).toContain(url);
 });

--- a/tests/page/page-add-style-tag.spec.ts
+++ b/tests/page/page-add-style-tag.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import path from 'path';
 
-it('should throw an error if no options are provided', async ({page, server}) => {
+it('should throw an error if no options are provided', async ({ page, server }) => {
   let error = null;
   try {
     // @ts-ignore
@@ -29,14 +29,14 @@ it('should throw an error if no options are provided', async ({page, server}) =>
   expect(error.message).toContain('Provide an object with a `url`, `path` or `content` property');
 });
 
-it('should work with a url', async ({page, server}) => {
+it('should work with a url', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const styleHandle = await page.addStyleTag({ url: '/injectedstyle.css' });
   expect(styleHandle.asElement()).not.toBeNull();
   expect(await page.evaluate(`window.getComputedStyle(document.querySelector('body')).getPropertyValue('background-color')`)).toBe('rgb(255, 0, 0)');
 });
 
-it('should throw an error if loading from url fail', async ({page, server}) => {
+it('should throw an error if loading from url fail', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let error = null;
   try {
@@ -47,14 +47,14 @@ it('should throw an error if loading from url fail', async ({page, server}) => {
   expect(error).not.toBe(null);
 });
 
-it('should work with a path', async ({page, server, asset}) => {
+it('should work with a path', async ({ page, server, asset }) => {
   await page.goto(server.EMPTY_PAGE);
   const styleHandle = await page.addStyleTag({ path: asset('injectedstyle.css') });
   expect(styleHandle.asElement()).not.toBeNull();
   expect(await page.evaluate(`window.getComputedStyle(document.querySelector('body')).getPropertyValue('background-color')`)).toBe('rgb(255, 0, 0)');
 });
 
-it('should include sourceURL when path is provided', async ({page, server, asset}) => {
+it('should include sourceURL when path is provided', async ({ page, server, asset }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.addStyleTag({ path: asset('injectedstyle.css') });
   const styleHandle = await page.$('style');
@@ -62,21 +62,21 @@ it('should include sourceURL when path is provided', async ({page, server, asset
   expect(styleContent).toContain(path.join('assets', 'injectedstyle.css'));
 });
 
-it('should work with content', async ({page, server}) => {
+it('should work with content', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const styleHandle = await page.addStyleTag({ content: 'body { background-color: green; }' });
   expect(styleHandle.asElement()).not.toBeNull();
   expect(await page.evaluate(`window.getComputedStyle(document.querySelector('body')).getPropertyValue('background-color')`)).toBe('rgb(0, 128, 0)');
 });
 
-it('should throw when added with content to the CSP page', async ({page, server}) => {
+it('should throw when added with content to the CSP page', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/csp.html');
   let error = null;
   await page.addStyleTag({ content: 'body { background-color: green; }' }).catch(e => error = e);
   expect(error).toBeTruthy();
 });
 
-it('should throw when added with URL to the CSP page', async ({page, server, isAndroid}) => {
+it('should throw when added with URL to the CSP page', async ({ page, server, isAndroid }) => {
   it.skip(isAndroid, 'No cross-process on Android');
 
   await page.goto(server.PREFIX + '/csp.html');

--- a/tests/page/page-autowaiting-basic.spec.ts
+++ b/tests/page/page-autowaiting-basic.spec.ts
@@ -30,7 +30,7 @@ function initServer(server: TestServer): string[] {
 
 it.skip(({ isAndroid }) => isAndroid, 'Too flaky on Android');
 
-it('should await navigation when clicking anchor', async ({page, server}) => {
+it('should await navigation when clicking anchor', async ({ page, server }) => {
   const messages = initServer(server);
   await page.setContent(`<a id="anchor" href="${server.EMPTY_PAGE}">empty.html</a>`);
   await Promise.all([
@@ -40,7 +40,7 @@ it('should await navigation when clicking anchor', async ({page, server}) => {
   expect(messages.join('|')).toBe('route|navigated|click');
 });
 
-it('should await navigation when clicking anchor programmatically', async ({page, server}) => {
+it('should await navigation when clicking anchor programmatically', async ({ page, server }) => {
   const messages = initServer(server);
   await page.setContent(`<a id="anchor" href="${server.EMPTY_PAGE}">empty.html</a>`);
   await Promise.all([
@@ -50,7 +50,7 @@ it('should await navigation when clicking anchor programmatically', async ({page
   expect(messages.join('|')).toBe('route|navigated|click');
 });
 
-it('should await navigation when clicking anchor via $eval', async ({page, server}) => {
+it('should await navigation when clicking anchor via $eval', async ({ page, server }) => {
   const messages = initServer(server);
   await page.setContent(`<a id="anchor" href="${server.EMPTY_PAGE}">empty.html</a>`);
   await Promise.all([
@@ -60,7 +60,7 @@ it('should await navigation when clicking anchor via $eval', async ({page, serve
   expect(messages.join('|')).toBe('route|navigated|click');
 });
 
-it('should await navigation when clicking anchor via handle.eval', async ({page, server}) => {
+it('should await navigation when clicking anchor via handle.eval', async ({ page, server }) => {
   const messages = initServer(server);
   await page.setContent(`<a id="anchor" href="${server.EMPTY_PAGE}">empty.html</a>`);
   const handle = await page.evaluateHandle('document');
@@ -71,7 +71,7 @@ it('should await navigation when clicking anchor via handle.eval', async ({page,
   expect(messages.join('|')).toBe('route|navigated|click');
 });
 
-it('should await navigation when clicking anchor via handle.$eval', async ({page, server}) => {
+it('should await navigation when clicking anchor via handle.$eval', async ({ page, server }) => {
   const messages = initServer(server);
   await page.setContent(`<a id="anchor" href="${server.EMPTY_PAGE}">empty.html</a>`);
   const handle = await page.$('body');
@@ -82,7 +82,7 @@ it('should await navigation when clicking anchor via handle.$eval', async ({page
   expect(messages.join('|')).toBe('route|navigated|click');
 });
 
-it('should await cross-process navigation when clicking anchor', async ({page, server}) => {
+it('should await cross-process navigation when clicking anchor', async ({ page, server }) => {
   const messages = initServer(server);
   await page.setContent(`<a href="${server.CROSS_PROCESS_PREFIX + '/empty.html'}">empty.html</a>`);
 
@@ -93,7 +93,7 @@ it('should await cross-process navigation when clicking anchor', async ({page, s
   expect(messages.join('|')).toBe('route|navigated|click');
 });
 
-it('should await cross-process navigation when clicking anchor programatically', async ({page, server}) => {
+it('should await cross-process navigation when clicking anchor programatically', async ({ page, server }) => {
   const messages = initServer(server);
   await page.setContent(`<a id="anchor" href="${server.CROSS_PROCESS_PREFIX + '/empty.html'}">empty.html</a>`);
 
@@ -104,7 +104,7 @@ it('should await cross-process navigation when clicking anchor programatically',
   expect(messages.join('|')).toBe('route|navigated|click');
 });
 
-it('should await form-get on click', async ({page, server}) => {
+it('should await form-get on click', async ({ page, server }) => {
   const messages = [];
   server.setRoute('/empty.html?foo=bar', async (req, res) => {
     messages.push('route');
@@ -125,7 +125,7 @@ it('should await form-get on click', async ({page, server}) => {
   expect(messages.join('|')).toBe('route|navigated|click');
 });
 
-it('should await form-post on click', async ({page, server}) => {
+it('should await form-post on click', async ({ page, server }) => {
   const messages = initServer(server);
   await page.setContent(`
     <form action="${server.EMPTY_PAGE}" method="post">
@@ -140,7 +140,7 @@ it('should await form-post on click', async ({page, server}) => {
   expect(messages.join('|')).toBe('route|navigated|click');
 });
 
-it('should await navigation when assigning location', async ({page, server}) => {
+it('should await navigation when assigning location', async ({ page, server }) => {
   const messages = initServer(server);
   await Promise.all([
     page.evaluate(`window.location.href = "${server.EMPTY_PAGE}"`).then(() => messages.push('evaluate')),
@@ -149,7 +149,7 @@ it('should await navigation when assigning location', async ({page, server}) => 
   expect(messages.join('|')).toBe('route|navigated|evaluate');
 });
 
-it('should await navigation when assigning location twice', async ({page, server}) => {
+it('should await navigation when assigning location twice', async ({ page, server }) => {
   const messages = [];
   server.setRoute('/empty.html?cancel', async (req, res) => { res.end('done'); });
   server.setRoute('/empty.html?override', async (req, res) => { messages.push('routeoverride'); res.end('done'); });
@@ -161,7 +161,7 @@ it('should await navigation when assigning location twice', async ({page, server
   expect(messages.join('|')).toBe('routeoverride|evaluate');
 });
 
-it('should await navigation when evaluating reload', async ({page, server}) => {
+it('should await navigation when evaluating reload', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const messages = initServer(server);
   await Promise.all([
@@ -171,19 +171,19 @@ it('should await navigation when evaluating reload', async ({page, server}) => {
   expect(messages.join('|')).toBe('route|navigated|evaluate');
 });
 
-it('should work with noWaitAfter: true', async ({page, server}) => {
+it('should work with noWaitAfter: true', async ({ page, server }) => {
   server.setRoute('/empty.html', async () => {});
   await page.setContent(`<a id="anchor" href="${server.EMPTY_PAGE}">empty.html</a>`);
   await page.click('a', { noWaitAfter: true });
 });
 
-it('should work with dblclick noWaitAfter: true', async ({page, server}) => {
+it('should work with dblclick noWaitAfter: true', async ({ page, server }) => {
   server.setRoute('/empty.html', async () => {});
   await page.setContent(`<a id="anchor" href="${server.EMPTY_PAGE}">empty.html</a>`);
   await page.dblclick('a', { noWaitAfter: true });
 });
 
-it('should work with waitForLoadState(load)', async ({page, server}) => {
+it('should work with waitForLoadState(load)', async ({ page, server }) => {
   const messages = initServer(server);
   await page.setContent(`<a id="anchor" href="${server.EMPTY_PAGE}">empty.html</a>`);
   await Promise.all([
@@ -193,7 +193,7 @@ it('should work with waitForLoadState(load)', async ({page, server}) => {
   expect(messages.join('|')).toBe('route|domcontentloaded|clickload');
 });
 
-it('should work with goto following click', async ({page, server}) => {
+it('should work with goto following click', async ({ page, server }) => {
   server.setRoute('/login.html', async (req, res) => {
     res.setHeader('Content-Type', 'text/html');
     res.end(`You are logged in`);
@@ -210,7 +210,7 @@ it('should work with goto following click', async ({page, server}) => {
   await page.goto(server.EMPTY_PAGE);
 });
 
-it('should report navigation in the log when clicking anchor', async ({page, server, mode}) => {
+it('should report navigation in the log when clicking anchor', async ({ page, server, mode }) => {
   it.skip(mode !== 'default');
 
   await page.setContent(`<a href="${server.PREFIX + '/frames/one-frame.html'}">click me</a>`);

--- a/tests/page/page-autowaiting-no-hang.spec.ts
+++ b/tests/page/page-autowaiting-no-hang.spec.ts
@@ -17,13 +17,13 @@
 
 import { test as it } from './pageTest';
 
-it('clicking on links which do not commit navigation', async ({page, server, httpsServer}) => {
+it('clicking on links which do not commit navigation', async ({ page, server, httpsServer }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<a href='${httpsServer.EMPTY_PAGE}'>foobar</a>`);
   await page.click('a');
 });
 
-it('calling window.stop async', async ({page, server, isElectron}) => {
+it('calling window.stop async', async ({ page, server, isElectron }) => {
   it.fixme(isElectron);
   server.setRoute('/empty.html', async (req, res) => {});
   await page.evaluate(url => {
@@ -32,26 +32,26 @@ it('calling window.stop async', async ({page, server, isElectron}) => {
   }, server.EMPTY_PAGE);
 });
 
-it('calling window.stop sync', async ({page, server}) => {
+it('calling window.stop sync', async ({ page, server }) => {
   await page.evaluate(url => {
     window.location.href = url;
     window.stop();
   }, server.EMPTY_PAGE);
 });
 
-it('assigning location to about:blank', async ({page, server}) => {
+it('assigning location to about:blank', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(`window.location.href = "about:blank";`);
 });
 
-it('assigning location to about:blank after non-about:blank', async ({page, server}) => {
+it('assigning location to about:blank after non-about:blank', async ({ page, server }) => {
   server.setRoute('/empty.html', async (req, res) => {});
   await page.evaluate(`
       window.location.href = "${server.EMPTY_PAGE}";
       window.location.href = "about:blank";`);
 });
 
-it('calling window.open and window.close', async function({page, server}) {
+it('calling window.open and window.close', async function({ page, server }) {
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => {
     const popup = window.open(window.location.href);
@@ -59,7 +59,7 @@ it('calling window.open and window.close', async function({page, server}) {
   });
 });
 
-it('opening a popup', async function({page, server}) {
+it('opening a popup', async function({ page, server }) {
   await page.goto(server.EMPTY_PAGE);
   await Promise.all([
     page.waitForEvent('popup'),

--- a/tests/page/page-basic.spec.ts
+++ b/tests/page/page-basic.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should reject all promises when page is closed', async ({page}) => {
+it('should reject all promises when page is closed', async ({ page }) => {
   let error = null;
   await Promise.all([
     page.evaluate(() => new Promise(r => {})).catch(e => error = e),
@@ -26,13 +26,13 @@ it('should reject all promises when page is closed', async ({page}) => {
   expect(error.message).toContain('Target closed');
 });
 
-it('should set the page close state', async ({page}) => {
+it('should set the page close state', async ({ page }) => {
   expect(page.isClosed()).toBe(false);
   await page.close();
   expect(page.isClosed()).toBe(true);
 });
 
-it('should pass page to close event', async ({page, isAndroid}) => {
+it('should pass page to close event', async ({ page, isAndroid }) => {
   it.fixme(isAndroid);
 
   const [closedPage] = await Promise.all([
@@ -42,7 +42,7 @@ it('should pass page to close event', async ({page, isAndroid}) => {
   expect(closedPage).toBe(page);
 });
 
-it('should terminate network waiters', async ({page, server, isAndroid}) => {
+it('should terminate network waiters', async ({ page, server, isAndroid }) => {
   it.fixme(isAndroid);
   const results = await Promise.all([
     page.waitForRequest(server.EMPTY_PAGE).catch(e => e),
@@ -56,7 +56,7 @@ it('should terminate network waiters', async ({page, server, isAndroid}) => {
   }
 });
 
-it('should be callable twice', async ({page}) => {
+it('should be callable twice', async ({ page }) => {
   await Promise.all([
     page.close(),
     page.close(),
@@ -64,14 +64,14 @@ it('should be callable twice', async ({page}) => {
   await page.close();
 });
 
-it('should fire load when expected', async ({page}) => {
+it('should fire load when expected', async ({ page }) => {
   await Promise.all([
     page.goto('about:blank'),
     page.waitForEvent('load'),
   ]);
 });
 
-it('async stacks should work', async ({page, server}) => {
+it('async stacks should work', async ({ page, server }) => {
   server.setRoute('/empty.html', (req, res) => {
     req.socket.end();
   });
@@ -81,7 +81,7 @@ it('async stacks should work', async ({page, server}) => {
   expect(error.stack).toContain(__filename);
 });
 
-it('should provide access to the opener page', async ({page}) => {
+it('should provide access to the opener page', async ({ page }) => {
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => window.open('about:blank')),
@@ -90,7 +90,7 @@ it('should provide access to the opener page', async ({page}) => {
   expect(opener).toBe(page);
 });
 
-it('should return null if parent page has been closed', async ({page}) => {
+it('should return null if parent page has been closed', async ({ page }) => {
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => window.open('about:blank')),
@@ -100,13 +100,13 @@ it('should return null if parent page has been closed', async ({page}) => {
   expect(opener).toBe(null);
 });
 
-it('should fire domcontentloaded when expected', async ({page}) => {
+it('should fire domcontentloaded when expected', async ({ page }) => {
   const navigatedPromise = page.goto('about:blank');
   await page.waitForEvent('domcontentloaded');
   await navigatedPromise;
 });
 
-it('should pass self as argument to domcontentloaded event', async ({page}) => {
+it('should pass self as argument to domcontentloaded event', async ({ page }) => {
   const [eventArg] = await Promise.all([
     new Promise(f => page.on('domcontentloaded', f)),
     page.goto('about:blank')
@@ -114,7 +114,7 @@ it('should pass self as argument to domcontentloaded event', async ({page}) => {
   expect(eventArg).toBe(page);
 });
 
-it('should pass self as argument to load event', async ({page}) => {
+it('should pass self as argument to load event', async ({ page }) => {
   const [eventArg] = await Promise.all([
     new Promise(f => page.on('load', f)),
     page.goto('about:blank')
@@ -122,7 +122,7 @@ it('should pass self as argument to load event', async ({page}) => {
   expect(eventArg).toBe(page);
 });
 
-it('should fail with error upon disconnect', async ({page, isAndroid}) => {
+it('should fail with error upon disconnect', async ({ page, isAndroid }) => {
   it.fixme(isAndroid);
 
   let error;
@@ -132,7 +132,7 @@ it('should fail with error upon disconnect', async ({page, isAndroid}) => {
   expect(error.message).toContain('Page closed');
 });
 
-it('page.url should work', async ({page, server, isElectron}) => {
+it('page.url should work', async ({ page, server, isElectron }) => {
   it.fixme(isElectron);
 
   expect(page.url()).toBe('about:blank');
@@ -140,7 +140,7 @@ it('page.url should work', async ({page, server, isElectron}) => {
   expect(page.url()).toBe(server.EMPTY_PAGE);
 });
 
-it('page.url should include hashes', async ({page, server}) => {
+it('page.url should include hashes', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE + '#hash');
   expect(page.url()).toBe(server.EMPTY_PAGE + '#hash');
   await page.evaluate(() => {
@@ -149,7 +149,7 @@ it('page.url should include hashes', async ({page, server}) => {
   expect(page.url()).toBe(server.EMPTY_PAGE + '#dynamic');
 });
 
-it('page.title should return the page title', async ({page, server}) => {
+it('page.title should return the page title', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/title.html');
   expect(await page.title()).toBe('Woof-Woof');
 });
@@ -169,7 +169,7 @@ it('page.close should work with page.close', async function({ page }) {
   await closedPromise;
 });
 
-it('page.frame should respect name', async function({page}) {
+it('page.frame should respect name', async function({ page }) {
   await page.setContent(`<iframe name=target></iframe>`);
   expect(page.frame({ name: 'bogus' })).toBe(null);
   const frame = page.frame({ name: 'target' });
@@ -177,13 +177,13 @@ it('page.frame should respect name', async function({page}) {
   expect(frame === page.mainFrame().childFrames()[0]).toBeTruthy();
 });
 
-it('page.frame should respect url', async function({page, server}) {
+it('page.frame should respect url', async function({ page, server }) {
   await page.setContent(`<iframe src="${server.EMPTY_PAGE}"></iframe>`);
   expect(page.frame({ url: /bogus/ })).toBe(null);
   expect(page.frame({ url: /empty/ }).url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should have sane user agent', async ({page, browserName, isElectron, isAndroid}) => {
+it('should have sane user agent', async ({ page, browserName, isElectron, isAndroid }) => {
   it.skip(isAndroid);
   it.skip(isElectron);
 
@@ -220,13 +220,13 @@ it('should have sane user agent', async ({page, browserName, isElectron, isAndro
     expect(engine.startsWith('Version/')).toBe(true);
 });
 
-it('page.press should work', async ({page, server}) => {
+it('page.press should work', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.press('textarea', 'a');
   expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('a');
 });
 
-it('page.press should work for Enter', async ({page}) => {
+it('page.press should work for Enter', async ({ page }) => {
   await page.setContent(`<input onkeypress="console.log('press')"></input>`);
   const messages = [];
   page.on('console', message => messages.push(message));
@@ -234,7 +234,7 @@ it('page.press should work for Enter', async ({page}) => {
   expect(messages[0].text()).toBe('press');
 });
 
-it('frame.press should work', async ({page, server}) => {
+it('frame.press should work', async ({ page, server }) => {
   await page.setContent(`<iframe name=inner src="${server.PREFIX}/input/textarea.html"></iframe>`);
   const frame = page.frame('inner');
   await frame.press('textarea', 'a');

--- a/tests/page/page-check.spec.ts
+++ b/tests/page/page-check.spec.ts
@@ -17,49 +17,49 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should check the box', async ({page}) => {
+it('should check the box', async ({ page }) => {
   await page.setContent(`<input id='checkbox' type='checkbox'></input>`);
   await page.check('input');
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);
 });
 
-it('should not check the checked box', async ({page}) => {
+it('should not check the checked box', async ({ page }) => {
   await page.setContent(`<input id='checkbox' type='checkbox' checked></input>`);
   await page.check('input');
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);
 });
 
-it('should uncheck the box', async ({page}) => {
+it('should uncheck the box', async ({ page }) => {
   await page.setContent(`<input id='checkbox' type='checkbox' checked></input>`);
   await page.uncheck('input');
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(false);
 });
 
-it('should not uncheck the unchecked box', async ({page}) => {
+it('should not uncheck the unchecked box', async ({ page }) => {
   await page.setContent(`<input id='checkbox' type='checkbox'></input>`);
   await page.uncheck('input');
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(false);
 });
 
-it('should check the box by label', async ({page}) => {
+it('should check the box by label', async ({ page }) => {
   await page.setContent(`<label for='checkbox'><input id='checkbox' type='checkbox'></input></label>`);
   await page.check('label');
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);
 });
 
-it('should check the box outside label', async ({page}) => {
+it('should check the box outside label', async ({ page }) => {
   await page.setContent(`<label for='checkbox'>Text</label><div><input id='checkbox' type='checkbox'></input></div>`);
   await page.check('label');
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);
 });
 
-it('should check the box inside label w/o id', async ({page}) => {
+it('should check the box inside label w/o id', async ({ page }) => {
   await page.setContent(`<label>Text<span><input id='checkbox' type='checkbox'></input></span></label>`);
   await page.check('label');
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);
 });
 
-it('should check the box outside shadow dom label', async ({page}) => {
+it('should check the box outside shadow dom label', async ({ page }) => {
   await page.setContent('<div></div>');
   await page.$eval('div', div => {
     const root = div.attachShadow({ mode: 'open' });
@@ -76,7 +76,7 @@ it('should check the box outside shadow dom label', async ({page}) => {
   expect(await page.$eval('input', input => input.checked)).toBe(true);
 });
 
-it('should check radio', async ({page}) => {
+it('should check radio', async ({ page }) => {
   await page.setContent(`
     <input type='radio'>one</input>
     <input id='two' type='radio'>two</input>
@@ -85,7 +85,7 @@ it('should check radio', async ({page}) => {
   expect(await page.evaluate(() => window['two'].checked)).toBe(true);
 });
 
-it('should check radio by aria role', async ({page}) => {
+it('should check radio by aria role', async ({ page }) => {
   await page.setContent(`<div role='radio' id='checkbox'>CHECKBOX</div>
     <script>
       checkbox.addEventListener('click', () => checkbox.setAttribute('aria-checked', 'true'));
@@ -94,7 +94,7 @@ it('should check radio by aria role', async ({page}) => {
   expect(await page.evaluate(() => window['checkbox'].getAttribute('aria-checked'))).toBe('true');
 });
 
-it('should uncheck radio by aria role', async ({page}) => {
+it('should uncheck radio by aria role', async ({ page }) => {
   await page.setContent(`<div role='radio' id='checkbox' aria-checked="true">CHECKBOX</div>
     <script>
       checkbox.addEventListener('click', () => checkbox.setAttribute('aria-checked', 'false'));
@@ -103,7 +103,7 @@ it('should uncheck radio by aria role', async ({page}) => {
   expect(await page.evaluate(() => window['checkbox'].getAttribute('aria-checked'))).toBe('false');
 });
 
-it('should check the box by aria role', async ({page}) => {
+it('should check the box by aria role', async ({ page }) => {
   await page.setContent(`<div role='checkbox' id='checkbox'>CHECKBOX</div>
     <script>
       checkbox.addEventListener('click', () => checkbox.setAttribute('aria-checked', 'true'));
@@ -112,7 +112,7 @@ it('should check the box by aria role', async ({page}) => {
   expect(await page.evaluate(() => window['checkbox'].getAttribute('aria-checked'))).toBe('true');
 });
 
-it('should uncheck the box by aria role', async ({page}) => {
+it('should uncheck the box by aria role', async ({ page }) => {
   await page.setContent(`<div role='checkbox' id='checkbox' aria-checked="true">CHECKBOX</div>
     <script>
       checkbox.addEventListener('click', () => checkbox.setAttribute('aria-checked', 'false'));
@@ -121,13 +121,13 @@ it('should uncheck the box by aria role', async ({page}) => {
   expect(await page.evaluate(() => window['checkbox'].getAttribute('aria-checked'))).toBe('false');
 });
 
-it('should throw when not a checkbox', async ({page}) => {
+it('should throw when not a checkbox', async ({ page }) => {
   await page.setContent(`<div>Check me</div>`);
   const error = await page.check('div').catch(e => e);
   expect(error.message).toContain('Not a checkbox or radio button');
 });
 
-it('should check the box inside a button', async ({page}) => {
+it('should check the box inside a button', async ({ page }) => {
   await page.setContent(`<div role='button'><input type='checkbox'></div>`);
   await page.check('input');
   expect(await page.$eval('input', input => input.checked)).toBe(true);
@@ -135,7 +135,7 @@ it('should check the box inside a button', async ({page}) => {
   expect(await (await page.$('input')).isChecked()).toBe(true);
 });
 
-it('should check the label with position', async ({page, server}) => {
+it('should check the label with position', async ({ page, server }) => {
   await page.setContent(`
     <input id='checkbox' type='checkbox' style='width: 5px; height: 5px;'>
     <label for='checkbox'>
@@ -147,19 +147,19 @@ it('should check the label with position', async ({page, server}) => {
   expect(await page.$eval('input', input => input.checked)).toBe(true);
 });
 
-it('trial run should not check', async ({page}) => {
+it('trial run should not check', async ({ page }) => {
   await page.setContent(`<input id='checkbox' type='checkbox'></input>`);
   await page.check('input', { trial: true });
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(false);
 });
 
-it('trial run should not uncheck', async ({page}) => {
+it('trial run should not uncheck', async ({ page }) => {
   await page.setContent(`<input id='checkbox' type='checkbox' checked></input>`);
   await page.uncheck('input', { trial: true });
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);
 });
 
-it('should check the box using setChecked', async ({page}) => {
+it('should check the box using setChecked', async ({ page }) => {
   await page.setContent(`<input id='checkbox' type='checkbox'></input>`);
   await page.setChecked('input', true);
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);

--- a/tests/page/page-click-react.spec.ts
+++ b/tests/page/page-click-react.spec.ts
@@ -21,7 +21,7 @@ declare const renderComponent;
 declare const e;
 declare const MyButton;
 
-it('should report that selector does not match anymore', async ({page, server}) => {
+it('should report that selector does not match anymore', async ({ page, server }) => {
   it.fixme();
 
   await page.goto(server.PREFIX + '/react.html');
@@ -42,7 +42,7 @@ it('should report that selector does not match anymore', async ({page, server}) 
   expect(error.message).toContain('element does not match the selector anymore');
 });
 
-it('should not retarget the handle when element is recycled', async ({page, server}) => {
+it('should not retarget the handle when element is recycled', async ({ page, server }) => {
   it.fixme();
 
   await page.goto(server.PREFIX + '/react.html');
@@ -62,7 +62,7 @@ it('should not retarget the handle when element is recycled', async ({page, serv
   expect(error.message).toContain('element is disabled - waiting');
 });
 
-it('should timeout when click opens alert', async ({page, server}) => {
+it('should timeout when click opens alert', async ({ page, server }) => {
   const dialogPromise = page.waitForEvent('dialog');
   await page.setContent(`<div onclick='window.alert(123)'>Click me</div>`);
   const error = await page.click('div', { timeout: 3000 }).catch(e => e);
@@ -71,7 +71,7 @@ it('should timeout when click opens alert', async ({page, server}) => {
   await dialog.dismiss();
 });
 
-it('should retarget when element is recycled during hit testing', async ({page, server}) => {
+it('should retarget when element is recycled during hit testing', async ({ page, server }) => {
   it.fixme();
 
   await page.goto(server.PREFIX + '/react.html');
@@ -88,7 +88,7 @@ it('should retarget when element is recycled during hit testing', async ({page, 
   expect(await page.evaluate('window.button2')).toBe(undefined);
 });
 
-it('should retarget when element is recycled before enabled check', async ({page, server}) => {
+it('should retarget when element is recycled before enabled check', async ({ page, server }) => {
   it.fixme();
 
   await page.goto(server.PREFIX + '/react.html');
@@ -105,7 +105,7 @@ it('should retarget when element is recycled before enabled check', async ({page
   expect(await page.evaluate('window.button2')).toBe(undefined);
 });
 
-it('should not retarget when element changes on hover', async ({page, server}) => {
+it('should not retarget when element changes on hover', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/react.html');
   await page.evaluate(() => {
     renderComponent(e('div', {}, [e(MyButton, { name: 'button1', renameOnHover: true }), e(MyButton, { name: 'button2' })]));
@@ -115,7 +115,7 @@ it('should not retarget when element changes on hover', async ({page, server}) =
   expect(await page.evaluate('window.button2')).toBe(undefined);
 });
 
-it('should not retarget when element is recycled on hover', async ({page, server}) => {
+it('should not retarget when element is recycled on hover', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/react.html');
   await page.evaluate(() => {
     function shuffle() {

--- a/tests/page/page-click-scroll.spec.ts
+++ b/tests/page/page-click-scroll.spec.ts
@@ -16,7 +16,7 @@
 
 import { test as it } from './pageTest';
 
-it('should not hit scroll bar', async ({page, isAndroid, browserName, platform, headless}) => {
+it('should not hit scroll bar', async ({ page, isAndroid, browserName, platform, headless }) => {
   it.fixme(browserName === 'webkit' && platform === 'darwin');
   it.fixme(browserName === 'webkit' && platform === 'linux' && headless);
   it.skip(isAndroid);

--- a/tests/page/page-click-timeout-1.spec.ts
+++ b/tests/page/page-click-timeout-1.spec.ts
@@ -17,17 +17,17 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should avoid side effects after timeout', async ({page, server, mode}) => {
+it('should avoid side effects after timeout', async ({ page, server, mode }) => {
   it.skip(mode !== 'default');
 
   await page.goto(server.PREFIX + '/input/button.html');
-  const error = await page.click('button', { timeout: 2000, __testHookBeforePointerAction: () => new Promise(f => setTimeout(f, 2500))} as any).catch(e => e);
+  const error = await page.click('button', { timeout: 2000, __testHookBeforePointerAction: () => new Promise(f => setTimeout(f, 2500)) } as any).catch(e => e);
   await page.waitForTimeout(5000);  // Give it some time to click after the test hook is done waiting.
   expect(await page.evaluate('result')).toBe('Was not clicked');
   expect(error.message).toContain('page.click: Timeout 2000ms exceeded.');
 });
 
-it('should timeout waiting for button to be enabled', async ({page}) => {
+it('should timeout waiting for button to be enabled', async ({ page }) => {
   await page.setContent('<button onclick="javascript:window.__CLICKED=true;" disabled><span>Click target</span></button>');
   const error = await page.click('text=Click target', { timeout: 3000 }).catch(e => e);
   expect(await page.evaluate('window.__CLICKED')).toBe(undefined);

--- a/tests/page/page-click-timeout-2.spec.ts
+++ b/tests/page/page-click-timeout-2.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should timeout waiting for display:none to be gone', async ({page, server}) => {
+it('should timeout waiting for display:none to be gone', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', b => b.style.display = 'none');
   const error = await page.click('button', { timeout: 5000 }).catch(e => e);
@@ -26,7 +26,7 @@ it('should timeout waiting for display:none to be gone', async ({page, server}) 
   expect(error.message).toContain('element is not visible - waiting');
 });
 
-it('should timeout waiting for visbility:hidden to be gone', async ({page, server}) => {
+it('should timeout waiting for visbility:hidden to be gone', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', b => b.style.visibility = 'hidden');
   const error = await page.click('button', { timeout: 5000 }).catch(e => e);

--- a/tests/page/page-click-timeout-3.spec.ts
+++ b/tests/page/page-click-timeout-3.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should fail when element jumps during hit testing', async ({page, mode}) => {
+it('should fail when element jumps during hit testing', async ({ page, mode }) => {
   it.skip(mode !== 'default');
 
   await page.setContent('<button>Click me</button>');
@@ -36,7 +36,7 @@ it('should fail when element jumps during hit testing', async ({page, mode}) => 
   expect(error.message).toContain('retrying click action');
 });
 
-it('should timeout waiting for hit target', async ({page, server}) => {
+it('should timeout waiting for hit target', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   const button = await page.$('button');
   await page.evaluate(() => {
@@ -57,7 +57,7 @@ it('should timeout waiting for hit target', async ({page, server}) => {
   expect(error.message).toContain('waiting 500ms');
 });
 
-it('should report wrong hit target subtree', async ({page, server}) => {
+it('should report wrong hit target subtree', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   const button = await page.$('button');
   await page.evaluate(() => {

--- a/tests/page/page-click-timeout-4.spec.ts
+++ b/tests/page/page-click-timeout-4.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should timeout waiting for stable position', async ({page, server}) => {
+it('should timeout waiting for stable position', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   const button = await page.$('button');
   await button.evaluate(button => {

--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -23,13 +23,13 @@ async function giveItAChanceToClick(page) {
     await page.evaluate(() => new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f))));
 }
 
-it('should click the button', async ({page, server}) => {
+it('should click the button', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.click('button');
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-it('should click button inside frameset', async ({page, server}) => {
+it('should click button inside frameset', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/frameset.html');
   const frameElement = await page.$('frame');
   await frameElement.evaluate(frame => frame.src = '/input/button.html');
@@ -39,7 +39,7 @@ it('should click button inside frameset', async ({page, server}) => {
 });
 
 
-it('should click svg', async ({page}) => {
+it('should click svg', async ({ page }) => {
   await page.setContent(`
     <svg height="100" width="100">
       <circle onclick="javascript:window.__CLICKED=42" cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
@@ -49,7 +49,7 @@ it('should click svg', async ({page}) => {
   expect(await page.evaluate('__CLICKED')).toBe(42);
 });
 
-it('should click the button if window.Node is removed', async ({page, server}) => {
+it('should click the button if window.Node is removed', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.evaluate(() => delete window.Node);
   await page.click('button');
@@ -57,7 +57,7 @@ it('should click the button if window.Node is removed', async ({page, server}) =
 });
 
 // @see https://github.com/GoogleChrome/puppeteer/issues/4281
-it('should click on a span with an inline element inside', async ({page}) => {
+it('should click on a span with an inline element inside', async ({ page }) => {
   await page.setContent(`
     <style>
     span::before {
@@ -70,20 +70,20 @@ it('should click on a span with an inline element inside', async ({page}) => {
   expect(await page.evaluate('CLICKED')).toBe(42);
 });
 
-it('should not throw UnhandledPromiseRejection when page closes', async ({page}) => {
+it('should not throw UnhandledPromiseRejection when page closes', async ({ page }) => {
   await Promise.all([
     page.close(),
     page.mouse.click(1, 2),
   ]).catch(e => {});
 });
 
-it('should click the 1x1 div', async ({page}) => {
+it('should click the 1x1 div', async ({ page }) => {
   await page.setContent(`<div style="width: 1px; height: 1px;" onclick="window.__clicked = true"></div>`);
   await page.click('div');
   expect(await page.evaluate('window.__clicked')).toBe(true);
 });
 
-it('should click the button after navigation ', async ({page, server}) => {
+it('should click the button after navigation ', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.click('button');
   await page.goto(server.PREFIX + '/input/button.html');
@@ -91,7 +91,7 @@ it('should click the button after navigation ', async ({page, server}) => {
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-it('should click the button after a cross origin navigation ', async ({page, server}) => {
+it('should click the button after a cross origin navigation ', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.click('button');
   await page.goto(server.CROSS_PROCESS_PREFIX + '/input/button.html');
@@ -99,7 +99,7 @@ it('should click the button after a cross origin navigation ', async ({page, ser
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-it('should click when one of inline box children is outside of viewport', async ({page}) => {
+it('should click when one of inline box children is outside of viewport', async ({ page }) => {
   await page.setContent(`
     <style>
     i {
@@ -113,7 +113,7 @@ it('should click when one of inline box children is outside of viewport', async 
   expect(await page.evaluate('CLICKED')).toBe(42);
 });
 
-it('should select the text by triple clicking', async ({page, server}) => {
+it('should select the text by triple clicking', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   const text = 'This is the text that we are going to try to select. Let\'s see how it goes.';
   await page.fill('textarea', text);
@@ -124,7 +124,7 @@ it('should select the text by triple clicking', async ({page, server}) => {
   })).toBe(text);
 });
 
-it('should click offscreen buttons', async ({page, server}) => {
+it('should click offscreen buttons', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/offscreenbuttons.html');
   const messages = [];
   page.on('console', msg => messages.push(msg.text()));
@@ -148,13 +148,13 @@ it('should click offscreen buttons', async ({page, server}) => {
   ]);
 });
 
-it('should waitFor visible when already visible', async ({page, server}) => {
+it('should waitFor visible when already visible', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.click('button');
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-it('should not wait with force', async ({page, server}) => {
+it('should not wait with force', async ({ page, server }) => {
   let error = null;
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', b => b.style.display = 'none');
@@ -163,7 +163,7 @@ it('should not wait with force', async ({page, server}) => {
   expect(await page.evaluate('result')).toBe('Was not clicked');
 });
 
-it('should waitFor display:none to be gone', async ({page, server}) => {
+it('should waitFor display:none to be gone', async ({ page, server }) => {
   let done = false;
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', b => b.style.display = 'none');
@@ -177,7 +177,7 @@ it('should waitFor display:none to be gone', async ({page, server}) => {
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-it('should waitFor visibility:hidden to be gone', async ({page, server}) => {
+it('should waitFor visibility:hidden to be gone', async ({ page, server }) => {
   let done = false;
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', b => b.style.visibility = 'hidden');
@@ -191,7 +191,7 @@ it('should waitFor visibility:hidden to be gone', async ({page, server}) => {
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-it('should waitFor visible when parent is hidden', async ({page, server}) => {
+it('should waitFor visible when parent is hidden', async ({ page, server }) => {
   let done = false;
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', b => b.parentElement.style.display = 'none');
@@ -204,13 +204,13 @@ it('should waitFor visible when parent is hidden', async ({page, server}) => {
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-it('should click wrapped links', async ({page, server}) => {
+it('should click wrapped links', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/wrappedlink.html');
   await page.click('a');
   expect(await page.evaluate('__clicked')).toBe(true);
 });
 
-it('should click on checkbox input and toggle', async ({page, server}) => {
+it('should click on checkbox input and toggle', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/checkbox.html');
   expect(await page.evaluate(() => window['result'].check)).toBe(null);
   await page.click('input#agree');
@@ -229,7 +229,7 @@ it('should click on checkbox input and toggle', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'].check)).toBe(false);
 });
 
-it('should click on checkbox label and toggle', async ({page, server}) => {
+it('should click on checkbox label and toggle', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/checkbox.html');
   expect(await page.evaluate(() => window['result'].check)).toBe(null);
   await page.click('label[for="agree"]');
@@ -243,7 +243,7 @@ it('should click on checkbox label and toggle', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'].check)).toBe(false);
 });
 
-it('should scroll and click the button', async ({page, server}) => {
+it('should scroll and click the button', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
   await page.click('#button-5');
   expect(await page.evaluate(() => document.querySelector('#button-5').textContent)).toBe('clicked');
@@ -251,7 +251,7 @@ it('should scroll and click the button', async ({page, server}) => {
   expect(await page.evaluate(() => document.querySelector('#button-80').textContent)).toBe('clicked');
 });
 
-it('should double click the button', async ({page, server}) => {
+it('should double click the button', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.evaluate(() => {
     window['double'] = false;
@@ -265,7 +265,7 @@ it('should double click the button', async ({page, server}) => {
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-it('should click a partially obscured button', async ({page, server}) => {
+it('should click a partially obscured button', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.evaluate(() => {
     const button = document.querySelector('button');
@@ -277,26 +277,26 @@ it('should click a partially obscured button', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'])).toBe('Clicked');
 });
 
-it('should click a rotated button', async ({page, server}) => {
+it('should click a rotated button', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/rotatedButton.html');
   await page.click('button');
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-it('should fire contextmenu event on right click', async ({page, server}) => {
+it('should fire contextmenu event on right click', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
-  await page.click('#button-8', {button: 'right'});
+  await page.click('#button-8', { button: 'right' });
   expect(await page.evaluate(() => document.querySelector('#button-8').textContent)).toBe('context menu');
 });
 
-it('should click links which cause navigation', async ({page, server}) => {
+it('should click links which cause navigation', async ({ page, server }) => {
   // @see https://github.com/GoogleChrome/puppeteer/issues/206
   await page.setContent(`<a href="${server.EMPTY_PAGE}">empty.html</a>`);
   // This await should not hang.
   await page.click('a');
 });
 
-it('should click the button inside an iframe', async ({page, server}) => {
+it('should click the button inside an iframe', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent('<div style="width:100px;height:100px">spacer</div>');
   await attachFrame(page, 'button-test', server.PREFIX + '/input/button.html');
@@ -306,14 +306,14 @@ it('should click the button inside an iframe', async ({page, server}) => {
   expect(await frame.evaluate(() => window['result'])).toBe('Clicked');
 });
 
-it('should click the button with fixed position inside an iframe', async ({page, server, browserName}) => {
+it('should click the button with fixed position inside an iframe', async ({ page, server, browserName }) => {
   it.fixme(browserName === 'chromium' || browserName === 'webkit');
 
   // @see https://github.com/GoogleChrome/puppeteer/issues/4110
   // @see https://bugs.chromium.org/p/chromium/issues/detail?id=986390
   // @see https://chromium-review.googlesource.com/c/chromium/src/+/1742784
   await page.goto(server.EMPTY_PAGE);
-  await page.setViewportSize({width: 500, height: 500});
+  await page.setViewportSize({ width: 500, height: 500 });
   await page.setContent('<div style="width:100px;height:2000px">spacer</div>');
   await attachFrame(page, 'button-test', server.CROSS_PROCESS_PREFIX + '/input/button.html');
   const frame = page.frames()[1];
@@ -322,7 +322,7 @@ it('should click the button with fixed position inside an iframe', async ({page,
   expect(await frame.evaluate(() => window['result'])).toBe('Clicked');
 });
 
-it('should click the button behind sticky header', async ({page}) => {
+it('should click the button behind sticky header', async ({ page }) => {
   await page.setViewportSize({ width: 500, height: 240 });
   await page.setContent(`
     <style>
@@ -359,7 +359,7 @@ it('should click the button behind sticky header', async ({page}) => {
   expect(await page.evaluate(() => window['__clicked'])).toBe(true);
 });
 
-it('should click the button with px border with offset', async ({page, server, browserName}) => {
+it('should click the button with px border with offset', async ({ page, server, browserName }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', button => button.style.borderWidth = '8px');
   await page.click('button', { position: { x: 20, y: 10 } });
@@ -369,7 +369,7 @@ it('should click the button with px border with offset', async ({page, server, b
   expect(await page.evaluate('offsetY')).toBe(browserName === 'webkit' ? 10 + 8 : 10);
 });
 
-it('should click the button with em border with offset', async ({page, server, browserName}) => {
+it('should click the button with em border with offset', async ({ page, server, browserName }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', button => button.style.borderWidth = '2em');
   await page.$eval('button', button => button.style.fontSize = '12px');
@@ -380,7 +380,7 @@ it('should click the button with em border with offset', async ({page, server, b
   expect(await page.evaluate('offsetY')).toBe(browserName === 'webkit' ? 12 * 2 + 10 : 10);
 });
 
-it('should click a very large button with offset', async ({page, server, browserName, isAndroid}) => {
+it('should click a very large button with offset', async ({ page, server, browserName, isAndroid }) => {
   it.fixme(isAndroid);
 
   await page.goto(server.PREFIX + '/input/button.html');
@@ -393,7 +393,7 @@ it('should click a very large button with offset', async ({page, server, browser
   expect(await page.evaluate('offsetY')).toBe(browserName === 'webkit' ? 1910 + 8 : 1910);
 });
 
-it('should click a button in scrolling container with offset', async ({page, server, browserName, isAndroid}) => {
+it('should click a button in scrolling container with offset', async ({ page, server, browserName, isAndroid }) => {
   it.fixme(isAndroid);
 
   await page.goto(server.PREFIX + '/input/button.html');
@@ -415,7 +415,7 @@ it('should click a button in scrolling container with offset', async ({page, ser
   expect(await page.evaluate('offsetY')).toBe(browserName === 'webkit' ? 1910 + 8 : 1910);
 });
 
-it('should wait for stable position', async ({page, server}) => {
+it('should wait for stable position', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', button => {
     button.style.transition = 'margin 500ms linear 0s';
@@ -434,7 +434,7 @@ it('should wait for stable position', async ({page, server}) => {
   expect(await page.evaluate('pageY')).toBe(10);
 });
 
-it('should wait for becoming hit target', async ({page, server}) => {
+it('should wait for becoming hit target', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', button => {
     button.style.borderWidth = '0';
@@ -466,7 +466,7 @@ it('should wait for becoming hit target', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'])).toBe('Clicked');
 });
 
-it('should wait for becoming hit target with trial run', async ({page, server}) => {
+it('should wait for becoming hit target with trial run', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', button => {
     button.style.borderWidth = '0';
@@ -500,7 +500,7 @@ it('should wait for becoming hit target with trial run', async ({page, server}) 
   expect(await page.evaluate(() => window['result'])).toBe('Was not clicked');
 });
 
-it('trial run should work with short timeout', async ({page, server}) => {
+it('trial run should work with short timeout', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.$eval('button', button => button.disabled = true);
   const error = await page.click('button', { trial: true, timeout: 500 }).catch(e => e);
@@ -508,13 +508,13 @@ it('trial run should work with short timeout', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'])).toBe('Was not clicked');
 });
 
-it('trial run should not click', async ({page, server}) => {
+it('trial run should not click', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.click('button', { trial: true });
   expect(await page.evaluate(() => window['result'])).toBe('Was not clicked');
 });
 
-it('trial run should not double click', async ({page, server}) => {
+it('trial run should not double click', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.evaluate(() => {
     window['double'] = false;
@@ -528,7 +528,7 @@ it('trial run should not double click', async ({page, server}) => {
   expect(await page.evaluate('result')).toBe('Was not clicked');
 });
 
-it('should fail when obscured and not waiting for hit target', async ({page, server}) => {
+it('should fail when obscured and not waiting for hit target', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   const button = await page.$('button');
   await page.evaluate(() => {
@@ -545,7 +545,7 @@ it('should fail when obscured and not waiting for hit target', async ({page, ser
   expect(await page.evaluate(() => window['result'])).toBe('Was not clicked');
 });
 
-it('should wait for button to be enabled', async ({page}) => {
+it('should wait for button to be enabled', async ({ page }) => {
   await page.setContent('<button onclick="javascript:window.__CLICKED=true;" disabled><span>Click target</span></button>');
   let done = false;
   const clickPromise = page.click('text=Click target').then(() => done = true);
@@ -557,7 +557,7 @@ it('should wait for button to be enabled', async ({page}) => {
   expect(await page.evaluate('__CLICKED')).toBe(true);
 });
 
-it('should wait for input to be enabled', async ({page}) => {
+it('should wait for input to be enabled', async ({ page }) => {
   await page.setContent('<input onclick="javascript:window.__CLICKED=true;" disabled>');
   let done = false;
   const clickPromise = page.click('input').then(() => done = true);
@@ -569,7 +569,7 @@ it('should wait for input to be enabled', async ({page}) => {
   expect(await page.evaluate('__CLICKED')).toBe(true);
 });
 
-it('should wait for select to be enabled', async ({page}) => {
+it('should wait for select to be enabled', async ({ page }) => {
   await page.setContent('<select onclick="javascript:window.__CLICKED=true;" disabled><option selected>Hello</option></select>');
   let done = false;
   const clickPromise = page.click('select').then(() => done = true);
@@ -581,25 +581,25 @@ it('should wait for select to be enabled', async ({page}) => {
   expect(await page.evaluate('__CLICKED')).toBe(true);
 });
 
-it('should click disabled div', async ({page}) => {
+it('should click disabled div', async ({ page }) => {
   await page.setContent('<div onclick="javascript:window.__CLICKED=true;" disabled>Click target</div>');
   await page.click('text=Click target');
   expect(await page.evaluate('__CLICKED')).toBe(true);
 });
 
-it('should climb dom for inner label with pointer-events:none', async ({page}) => {
+it('should climb dom for inner label with pointer-events:none', async ({ page }) => {
   await page.setContent('<button onclick="javascript:window.__CLICKED=true;"><label style="pointer-events:none">Click target</label></button>');
   await page.click('text=Click target');
   expect(await page.evaluate('__CLICKED')).toBe(true);
 });
 
-it('should climb up to [role=button]', async ({page}) => {
+it('should climb up to [role=button]', async ({ page }) => {
   await page.setContent('<div role=button onclick="javascript:window.__CLICKED=true;"><div style="pointer-events:none"><span><div>Click target</div></span></div>');
   await page.click('text=Click target');
   expect(await page.evaluate('__CLICKED')).toBe(true);
 });
 
-it('should wait for BUTTON to be clickable when it has pointer-events:none', async ({page}) => {
+it('should wait for BUTTON to be clickable when it has pointer-events:none', async ({ page }) => {
   await page.setContent('<button onclick="javascript:window.__CLICKED=true;" style="pointer-events:none"><span>Click target</span></button>');
   let done = false;
   const clickPromise = page.click('text=Click target').then(() => done = true);
@@ -611,7 +611,7 @@ it('should wait for BUTTON to be clickable when it has pointer-events:none', asy
   expect(await page.evaluate('__CLICKED')).toBe(true);
 });
 
-it('should wait for LABEL to be clickable when it has pointer-events:none', async ({page}) => {
+it('should wait for LABEL to be clickable when it has pointer-events:none', async ({ page }) => {
   await page.setContent('<label onclick="javascript:window.__CLICKED=true;" style="pointer-events:none"><span>Click target</span></label>');
   const clickPromise = page.click('text=Click target');
   // Do a few roundtrips to the page.
@@ -623,7 +623,7 @@ it('should wait for LABEL to be clickable when it has pointer-events:none', asyn
   expect(await page.evaluate('__CLICKED')).toBe(true);
 });
 
-it('should update modifiers correctly', async ({page, server}) => {
+it('should update modifiers correctly', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.click('button', { modifiers: ['Shift'] });
   expect(await page.evaluate('shiftKey')).toBe(true);
@@ -640,7 +640,7 @@ it('should update modifiers correctly', async ({page, server}) => {
   expect(await page.evaluate('shiftKey')).toBe(false);
 });
 
-it('should click an offscreen element when scroll-behavior is smooth', async ({page}) => {
+it('should click an offscreen element when scroll-behavior is smooth', async ({ page }) => {
   await page.setContent(`
     <div style="border: 1px solid black; height: 500px; overflow: auto; width: 500px; scroll-behavior: smooth">
     <button style="margin-top: 2000px" onClick="window.clicked = true">hi</button>
@@ -650,7 +650,7 @@ it('should click an offscreen element when scroll-behavior is smooth', async ({p
   expect(await page.evaluate('window.clicked')).toBe(true);
 });
 
-it('should report nice error when element is detached and force-clicked', async ({page, server}) => {
+it('should report nice error when element is detached and force-clicked', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/animating-button.html');
   await page.evaluate('addButton()');
   const handle = await page.$('button');
@@ -661,7 +661,7 @@ it('should report nice error when element is detached and force-clicked', async 
   expect(error.message).toContain('Element is not attached to the DOM');
 });
 
-it('should fail when element detaches after animation', async ({page, server}) => {
+it('should fail when element detaches after animation', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/animating-button.html');
   await page.evaluate('addButton()');
   const handle = await page.$('button');
@@ -672,7 +672,7 @@ it('should fail when element detaches after animation', async ({page, server}) =
   expect(error.message).toContain('Element is not attached to the DOM');
 });
 
-it('should retry when element detaches after animation', async ({page, server}) => {
+it('should retry when element detaches after animation', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/animating-button.html');
   await page.evaluate('addButton()');
   let clicked = false;
@@ -693,7 +693,7 @@ it('should retry when element detaches after animation', async ({page, server}) 
   expect(await page.evaluate('clicked')).toBe(true);
 });
 
-it('should retry when element is animating from outside the viewport', async ({page}) => {
+it('should retry when element is animating from outside the viewport', async ({ page }) => {
   await page.setContent(`<style>
     @keyframes move {
       from { left: -300px; }
@@ -721,7 +721,7 @@ it('should retry when element is animating from outside the viewport', async ({p
   expect(await page.evaluate('clicked')).toBe(true);
 });
 
-it('should fail when element is animating from outside the viewport with force', async ({page}) => {
+it('should fail when element is animating from outside the viewport with force', async ({ page }) => {
   await page.setContent(`<style>
     @keyframes move {
       from { left: -300px; }
@@ -750,7 +750,7 @@ it('should fail when element is animating from outside the viewport with force',
   expect(error.message).toContain('Element is outside of the viewport');
 });
 
-it('should dispatch microtasks in order', async ({page}) => {
+it('should dispatch microtasks in order', async ({ page }) => {
   await page.setContent(`
     <button id=button>Click me</button>
     <script>
@@ -773,14 +773,14 @@ it('should dispatch microtasks in order', async ({page}) => {
   expect(await page.evaluate(() => window['result'])).toBe(1);
 });
 
-it('should click the button when window.innerWidth is corrupted', async ({page, server}) => {
+it('should click the button when window.innerWidth is corrupted', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
-  await page.evaluate(() => Object.defineProperty(window, 'innerWidth', {value: 0}));
+  await page.evaluate(() => Object.defineProperty(window, 'innerWidth', { value: 0 }));
   await page.click('button');
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-it('should click zero-sized input by label', async ({page}) => {
+it('should click zero-sized input by label', async ({ page }) => {
   await page.setContent(`
     <label>
       Click me
@@ -791,7 +791,7 @@ it('should click zero-sized input by label', async ({page}) => {
   expect(await page.evaluate('window.__clicked')).toBe(true);
 });
 
-it('should not throw protocol error when navigating during the click', async ({page, server, mode}) => {
+it('should not throw protocol error when navigating during the click', async ({ page, server, mode }) => {
   it.skip(mode !== 'default');
 
   await page.goto(server.PREFIX + '/input/button.html');
@@ -806,7 +806,7 @@ it('should not throw protocol error when navigating during the click', async ({p
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-it('should retry when navigating during the click', async ({page, server, mode}) => {
+it('should retry when navigating during the click', async ({ page, server, mode }) => {
   it.skip(mode !== 'default');
 
   await page.goto(server.PREFIX + '/input/button.html');

--- a/tests/page/page-close.spec.ts
+++ b/tests/page/page-close.spec.ts
@@ -17,14 +17,14 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should close page with active dialog', async ({page}) => {
+it('should close page with active dialog', async ({ page }) => {
   await page.setContent(`<button onclick="setTimeout(() => alert(1))">alert</button>`);
   page.click('button');
   await page.waitForEvent('dialog');
   await page.close();
 });
 
-it('should not accept after close', async ({page}) => {
+it('should not accept after close', async ({ page }) => {
   page.evaluate(() => alert()).catch(() => {});
   const dialog = await page.waitForEvent('dialog');
   await page.close();

--- a/tests/page/page-dialog.spec.ts
+++ b/tests/page/page-dialog.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should fire', async ({page, server}) => {
+it('should fire', async ({ page, server }) => {
   page.on('dialog', dialog => {
     expect(dialog.type()).toBe('alert');
     expect(dialog.defaultValue()).toBe('');
@@ -27,7 +27,7 @@ it('should fire', async ({page, server}) => {
   await page.evaluate(() => alert('yo'));
 });
 
-it('should allow accepting prompts', async ({page, isElectron}) => {
+it('should allow accepting prompts', async ({ page, isElectron }) => {
   it.skip(isElectron, 'prompt() is not a thing in electron');
 
   page.on('dialog', dialog => {
@@ -40,7 +40,7 @@ it('should allow accepting prompts', async ({page, isElectron}) => {
   expect(result).toBe('answer!');
 });
 
-it('should dismiss the prompt', async ({page, isElectron}) => {
+it('should dismiss the prompt', async ({ page, isElectron }) => {
   it.skip(isElectron, 'prompt() is not a thing in electron');
 
   page.on('dialog', dialog => {
@@ -50,7 +50,7 @@ it('should dismiss the prompt', async ({page, isElectron}) => {
   expect(result).toBe(null);
 });
 
-it('should accept the confirm prompt', async ({page}) => {
+it('should accept the confirm prompt', async ({ page }) => {
   page.on('dialog', dialog => {
     dialog.accept();
   });
@@ -58,7 +58,7 @@ it('should accept the confirm prompt', async ({page}) => {
   expect(result).toBe(true);
 });
 
-it('should dismiss the confirm prompt', async ({page}) => {
+it('should dismiss the confirm prompt', async ({ page }) => {
   page.on('dialog', dialog => {
     dialog.dismiss();
   });
@@ -66,7 +66,7 @@ it('should dismiss the confirm prompt', async ({page}) => {
   expect(result).toBe(false);
 });
 
-it('should be able to close context with open alert', async ({page, trace}) => {
+it('should be able to close context with open alert', async ({ page, trace }) => {
   const alertPromise = page.waitForEvent('dialog');
   await page.evaluate(() => {
     setTimeout(() => alert('hello'), 0);
@@ -74,7 +74,7 @@ it('should be able to close context with open alert', async ({page, trace}) => {
   await alertPromise;
 });
 
-it('should handle multiple alerts', async ({page}) => {
+it('should handle multiple alerts', async ({ page }) => {
   page.on('dialog', dialog => {
     dialog.accept().catch(e => {});
   });
@@ -89,7 +89,7 @@ it('should handle multiple alerts', async ({page}) => {
   expect(await page.textContent('p')).toBe('Hello World');
 });
 
-it('should handle multiple confirms', async ({page}) => {
+it('should handle multiple confirms', async ({ page }) => {
   page.on('dialog', dialog => {
     dialog.accept().catch(e => {});
   });
@@ -104,14 +104,14 @@ it('should handle multiple confirms', async ({page}) => {
   expect(await page.textContent('p')).toBe('Hello World');
 });
 
-it('should auto-dismiss the prompt without listeners', async ({page, isElectron}) => {
+it('should auto-dismiss the prompt without listeners', async ({ page, isElectron }) => {
   it.skip(isElectron, 'prompt() is not a thing in electron');
 
   const result = await page.evaluate(() => prompt('question?'));
   expect(result).toBe(null);
 });
 
-it('should auto-dismiss the alert without listeners', async ({page}) => {
+it('should auto-dismiss the alert without listeners', async ({ page }) => {
   await page.setContent(`<div onclick="window.alert(123); window._clicked=true">Click me</div>`);
   await page.click('div');
   expect(await page.evaluate('window._clicked')).toBe(true);

--- a/tests/page/page-dispatchevent.spec.ts
+++ b/tests/page/page-dispatchevent.spec.ts
@@ -16,13 +16,13 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should dispatch click event', async ({page, server}) => {
+it('should dispatch click event', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.dispatchEvent('button', 'click');
   expect(await page.evaluate(() => window['result'])).toBe('Clicked');
 });
 
-it('should dispatch click event properties', async ({page, server}) => {
+it('should dispatch click event properties', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.dispatchEvent('button', 'click');
   expect(await page.evaluate('bubbles')).toBeTruthy();
@@ -30,7 +30,7 @@ it('should dispatch click event properties', async ({page, server}) => {
   expect(await page.evaluate('composed')).toBeTruthy();
 });
 
-it('should dispatch click svg', async ({page}) => {
+it('should dispatch click svg', async ({ page }) => {
   await page.setContent(`
     <svg height="100" width="100">
       <circle onclick="javascript:window.__CLICKED=42" cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
@@ -40,7 +40,7 @@ it('should dispatch click svg', async ({page}) => {
   expect(await page.evaluate(() => window['__CLICKED'])).toBe(42);
 });
 
-it('should dispatch click on a span with an inline element inside', async ({page}) => {
+it('should dispatch click on a span with an inline element inside', async ({ page }) => {
   await page.setContent(`
     <style>
     span::before {
@@ -53,7 +53,7 @@ it('should dispatch click on a span with an inline element inside', async ({page
   expect(await page.evaluate(() => window['CLICKED'])).toBe(42);
 });
 
-it('should dispatch click after navigation ', async ({page, server}) => {
+it('should dispatch click after navigation ', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.dispatchEvent('button', 'click');
   await page.goto(server.PREFIX + '/input/button.html');
@@ -61,7 +61,7 @@ it('should dispatch click after navigation ', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'])).toBe('Clicked');
 });
 
-it('should dispatch click after a cross origin navigation ', async ({page, server}) => {
+it('should dispatch click after a cross origin navigation ', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.dispatchEvent('button', 'click');
   await page.goto(server.CROSS_PROCESS_PREFIX + '/input/button.html');
@@ -69,7 +69,7 @@ it('should dispatch click after a cross origin navigation ', async ({page, serve
   expect(await page.evaluate(() => window['result'])).toBe('Clicked');
 });
 
-it('should not fail when element is blocked on hover', async ({page}) => {
+it('should not fail when element is blocked on hover', async ({ page }) => {
   await page.setContent(`<style>
     container { display: block; position: relative; width: 200px; height: 50px; }
     div, button { position: absolute; left: 0; top: 0; bottom: 0; right: 0; }
@@ -84,12 +84,12 @@ it('should not fail when element is blocked on hover', async ({page}) => {
   expect(await page.evaluate(() => window['clicked'])).toBeTruthy();
 });
 
-it('should dispatch click when node is added in shadow dom', async ({page, server}) => {
+it('should dispatch click when node is added in shadow dom', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const watchdog = page.dispatchEvent('span', 'click');
   await page.evaluate(() => {
     const div = document.createElement('div');
-    div.attachShadow({mode: 'open'});
+    div.attachShadow({ mode: 'open' });
     document.body.appendChild(div);
   });
   await page.evaluate(() => new Promise(f => setTimeout(f, 100)));
@@ -103,7 +103,7 @@ it('should dispatch click when node is added in shadow dom', async ({page, serve
   expect(await page.evaluate(() => window['clicked'])).toBe(true);
 });
 
-it('should be atomic', async ({playwright, page}) => {
+it('should be atomic', async ({ playwright, page }) => {
   const createDummySelector = () => ({
     query(root, selector) {
       const result = root.querySelector(selector);
@@ -124,31 +124,31 @@ it('should be atomic', async ({playwright, page}) => {
   expect(await page.evaluate(() => window['_clicked'])).toBe(true);
 });
 
-it('should dispatch drag drop events', async ({page, server}) => {
+it('should dispatch drag drop events', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/drag-n-drop.html');
   const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
   await page.dispatchEvent('#source', 'dragstart', { dataTransfer });
   await page.dispatchEvent('#target', 'drop', { dataTransfer });
   const source = await page.$('#source');
   const target = await page.$('#target');
-  expect(await page.evaluate(({source, target}) => {
+  expect(await page.evaluate(({ source, target }) => {
     return source.parentElement === target;
-  }, {source, target})).toBeTruthy();
+  }, { source, target })).toBeTruthy();
 });
 
-it('should dispatch drag drop events via ElementHandles', async ({page, server}) => {
+it('should dispatch drag drop events via ElementHandles', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/drag-n-drop.html');
   const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
   const source = await page.$('#source');
   await source.dispatchEvent('dragstart', { dataTransfer });
   const target = await page.$('#target');
   await target.dispatchEvent('drop', { dataTransfer });
-  expect(await page.evaluate(({source, target}) => {
+  expect(await page.evaluate(({ source, target }) => {
     return source.parentElement === target;
-  }, {source, target})).toBeTruthy();
+  }, { source, target })).toBeTruthy();
 });
 
-it('should dispatch click event via ElementHandles', async ({page, server}) => {
+it('should dispatch click event via ElementHandles', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   const button = await page.$('button');
   await button.dispatchEvent('click');

--- a/tests/page/page-drag.spec.ts
+++ b/tests/page/page-drag.spec.ts
@@ -19,10 +19,10 @@ import { test as it, expect } from './pageTest';
 import { attachFrame } from '../config/utils';
 
 it.describe('Drag and drop', () => {
-  it.skip(({isAndroid}) => isAndroid);
-  it.skip(({browserName, browserMajorVersion}) => browserName === 'chromium' && browserMajorVersion < 91);
+  it.skip(({ isAndroid }) => isAndroid);
+  it.skip(({ browserName, browserMajorVersion }) => browserName === 'chromium' && browserMajorVersion < 91);
 
-  it('should work', async ({page, server}) => {
+  it('should work', async ({ page, server }) => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');
     await page.hover('#source');
     await page.mouse.down();
@@ -31,7 +31,7 @@ it.describe('Drag and drop', () => {
     expect(await page.$eval('#target', target => target.contains(document.querySelector('#source')))).toBe(true); // could not find source in target
   });
 
-  it('should send the right events', async ({server, page, browserName}) => {
+  it('should send the right events', async ({ server, page, browserName }) => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');
     const events = await trackEvents(await page.$('body'));
     await page.hover('#source');
@@ -50,7 +50,7 @@ it.describe('Drag and drop', () => {
     ]);
   });
 
-  it('should cancel on escape', async ({server, page, browserName}) => {
+  it('should cancel on escape', async ({ server, page, browserName }) => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');
     const events = await trackEvents(await page.$('body'));
     await page.hover('#source');
@@ -74,7 +74,7 @@ it.describe('Drag and drop', () => {
   it.describe('iframe', () => {
     it.fixme(true, 'implement dragging with iframes');
 
-    it('should drag into an iframe', async ({server, page, browserName}) => {
+    it('should drag into an iframe', async ({ server, page, browserName }) => {
       await page.goto(server.PREFIX + '/drag-n-drop.html');
       const frame = await attachFrame(page, 'oopif',server.PREFIX + '/drag-n-drop.html');
       const pageEvents = await trackEvents(await page.$('body'));
@@ -98,7 +98,7 @@ it.describe('Drag and drop', () => {
       ]);
     });
 
-    it('should drag out of an iframe', async ({server, page}) => {
+    it('should drag out of an iframe', async ({ server, page }) => {
       await page.goto(server.PREFIX + '/drag-n-drop.html');
       const frame = await attachFrame(page, 'oopif',server.PREFIX + '/drag-n-drop.html');
       const pageEvents = await trackEvents(await page.$('body'));
@@ -121,7 +121,7 @@ it.describe('Drag and drop', () => {
     });
   });
 
-  it('should respect the drop effect', async ({page, browserName, platform, trace}) => {
+  it('should respect the drop effect', async ({ page, browserName, platform, trace }) => {
     it.fixme(browserName === 'webkit' && platform !== 'linux', 'WebKit doesn\'t handle the drop effect correctly outside of linux.');
     it.fixme(browserName === 'firefox');
     it.slow(!!trace);
@@ -150,7 +150,7 @@ it.describe('Drag and drop', () => {
         <div draggable="true">drag target</div>
         <drop-target>this is the drop target</drop-target>
       `);
-      await page.evaluate(({effectAllowed, dropEffect}) => {
+      await page.evaluate(({ effectAllowed, dropEffect }) => {
         window['dropped'] = false;
 
         document.querySelector('div').addEventListener('dragstart', event => {
@@ -166,7 +166,7 @@ it.describe('Drag and drop', () => {
         dropTarget.addEventListener('drop', event => {
           window['dropped'] = true;
         });
-      }, {effectAllowed, dropEffect});
+      }, { effectAllowed, dropEffect });
       await page.hover('div');
       await page.mouse.down();
       await page.hover('drop-target');
@@ -174,7 +174,7 @@ it.describe('Drag and drop', () => {
       return await page.evaluate('dropped');
     }
   });
-  it('should work if the drag is canceled', async ({page, server}) => {
+  it('should work if the drag is canceled', async ({ page, server }) => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');
     await page.evaluate(() => {
       document.body.addEventListener('dragstart', event => {
@@ -188,7 +188,7 @@ it.describe('Drag and drop', () => {
     expect(await page.$eval('#target', target => target.contains(document.querySelector('#source')))).toBe(false);
   });
 
-  it('should work if the drag event is captured but not canceled', async ({page, server}) => {
+  it('should work if the drag event is captured but not canceled', async ({ page, server }) => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');
     await page.evaluate(() => {
       document.body.addEventListener('dragstart', event => {
@@ -202,7 +202,7 @@ it.describe('Drag and drop', () => {
     expect(await page.$eval('#target', target => target.contains(document.querySelector('#source')))).toBe(true);
   });
 
-  it('should be able to drag the mouse in a frame', async ({page, server}) => {
+  it('should be able to drag the mouse in a frame', async ({ page, server }) => {
     await page.goto(server.PREFIX + '/frames/one-frame.html');
     const eventsHandle = await trackEvents(await page.frames()[1].$('html'));
     await page.mouse.move(30, 30);
@@ -212,7 +212,7 @@ it.describe('Drag and drop', () => {
     expect(await eventsHandle.jsonValue()).toEqual(['mousemove', 'mousedown', 'mousemove', 'mouseup']);
   });
 
-  it('should work if a frame is stalled', async ({page, server, toImpl}) => {
+  it('should work if a frame is stalled', async ({ page, server, toImpl }) => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');
     let madeRequest;
     const routePromise = new Promise<Route>(x => madeRequest = x);
@@ -229,13 +229,13 @@ it.describe('Drag and drop', () => {
     expect(await page.$eval('#target', target => target.contains(document.querySelector('#source')))).toBe(true); // could not find source in target
   });
 
-  it('should work with the helper method', async ({page, server}) => {
+  it('should work with the helper method', async ({ page, server }) => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');
     await page.dragAndDrop('#source', '#target');
     expect(await page.$eval('#target', target => target.contains(document.querySelector('#source')))).toBe(true); // could not find source in target
   });
 
-  it('should allow specifying the position', async ({page, server}) => {
+  it('should allow specifying the position', async ({ page, server }) => {
     await page.setContent(`
       <div style="width:100px;height:100px;background:red;" id="red">
       </div>
@@ -261,12 +261,12 @@ it.describe('Drag and drop', () => {
       return events;
     });
     await page.dragAndDrop('#red', '#blue', {
-      sourcePosition: {x: 34, y: 7},
-      targetPosition: {x: 10, y: 20},
+      sourcePosition: { x: 34, y: 7 },
+      targetPosition: { x: 10, y: 20 },
     });
     expect(await eventsHandle.jsonValue()).toEqual([
-      {type: 'mousedown', x: 34, y: 7},
-      {type: 'mouseup', x: 10, y: 20},
+      { type: 'mousedown', x: 34, y: 7 },
+      { type: 'mouseup', x: 10, y: 20 },
     ]);
   });
 
@@ -285,7 +285,7 @@ it.describe('Drag and drop', () => {
   }
 });
 
-it('should work if not doing a drag', async ({page}) => {
+it('should work if not doing a drag', async ({ page }) => {
   const eventsHandle = await trackEvents(await page.$('html'));
   await page.mouse.move(50, 50);
   await page.mouse.down();
@@ -294,7 +294,7 @@ it('should work if not doing a drag', async ({page}) => {
   expect(await eventsHandle.jsonValue()).toEqual(['mousemove', 'mousedown', 'mousemove', 'mouseup']);
 });
 
-it('should report event.buttons', async ({page, browserName}) => {
+it('should report event.buttons', async ({ page, browserName }) => {
   const logsHandle = await page.evaluateHandle(async () => {
     const div = document.createElement('div');
     document.body.appendChild(div);

--- a/tests/page/page-emulate-media.spec.ts
+++ b/tests/page/page-emulate-media.spec.ts
@@ -19,7 +19,7 @@ import { test as it, expect } from './pageTest';
 
 it.skip(({ isAndroid }) => isAndroid);
 
-it('should emulate type', async ({page}) => {
+it('should emulate type', async ({ page }) => {
   expect(await page.evaluate(() => matchMedia('screen').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('print').matches)).toBe(false);
   await page.emulateMedia({ media: 'print' });
@@ -33,14 +33,14 @@ it('should emulate type', async ({page}) => {
   expect(await page.evaluate(() => matchMedia('print').matches)).toBe(false);
 });
 
-it('should throw in case of bad media argument', async ({page}) => {
+it('should throw in case of bad media argument', async ({ page }) => {
   let error = null;
   // @ts-expect-error 'bad' is not a valid media type
-  await page.emulateMedia({ media: 'bad'}).catch(e => error = e);
+  await page.emulateMedia({ media: 'bad' }).catch(e => error = e);
   expect(error.message).toContain('media: expected one of (screen|print|null)');
 });
 
-it('should emulate colorScheme should work', async ({page}) => {
+it('should emulate colorScheme should work', async ({ page }) => {
   await page.emulateMedia({ colorScheme: 'light' });
   expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: light)').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches)).toBe(false);
@@ -49,7 +49,7 @@ it('should emulate colorScheme should work', async ({page}) => {
   expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: light)').matches)).toBe(false);
 });
 
-it('should default to light', async ({page}) => {
+it('should default to light', async ({ page }) => {
   expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: light)').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches)).toBe(false);
 
@@ -62,14 +62,14 @@ it('should default to light', async ({page}) => {
   expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: light)').matches)).toBe(true);
 });
 
-it('should throw in case of bad colorScheme argument', async ({page}) => {
+it('should throw in case of bad colorScheme argument', async ({ page }) => {
   let error = null;
   // @ts-expect-error 'bad' is not a valid media type
   await page.emulateMedia({ colorScheme: 'bad' }).catch(e => error = e);
   expect(error.message).toContain('colorScheme: expected one of (dark|light|no-preference|null)');
 });
 
-it('should work during navigation', async ({page, server}) => {
+it('should work during navigation', async ({ page, server }) => {
   await page.emulateMedia({ colorScheme: 'light' });
   const navigated = page.goto(server.EMPTY_PAGE);
   for (let i = 0; i < 9; i++) {
@@ -82,7 +82,7 @@ it('should work during navigation', async ({page, server}) => {
   expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches)).toBe(true);
 });
 
-it('should change the actual colors in css', async ({page}) => {
+it('should change the actual colors in css', async ({ page }) => {
   await page.setContent(`
     <style>
       @media (prefers-color-scheme: dark) {
@@ -115,7 +115,7 @@ it('should change the actual colors in css', async ({page}) => {
   expect(await getBackgroundColor()).toBe('rgb(255, 255, 255)');
 });
 
-it('should emulate reduced motion', async ({page}) => {
+it('should emulate reduced motion', async ({ page }) => {
   expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: no-preference)').matches)).toBe(true);
   await page.emulateMedia({ reducedMotion: 'reduce' });
   expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(true);
@@ -126,7 +126,7 @@ it('should emulate reduced motion', async ({page}) => {
   await page.emulateMedia({ reducedMotion: null });
 });
 
-it('should emulate forcedColors ', async ({page, browserName, isElectron}) => {
+it('should emulate forcedColors ', async ({ page, browserName, isElectron }) => {
   it.skip(browserName === 'webkit', 'https://bugs.webkit.org/show_bug.cgi?id=225281');
   it.fixme(isElectron);
   expect(await page.evaluate(() => matchMedia('(forced-colors: none)').matches)).toBe(true);

--- a/tests/page/page-evaluate-handle.spec.ts
+++ b/tests/page/page-evaluate-handle.spec.ts
@@ -17,24 +17,24 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({page}) => {
+it('should work', async ({ page }) => {
   const windowHandle = await page.evaluateHandle(() => window);
   expect(windowHandle).toBeTruthy();
 });
 
-it('should accept object handle as an argument', async ({page}) => {
+it('should accept object handle as an argument', async ({ page }) => {
   const navigatorHandle = await page.evaluateHandle(() => navigator);
   const text = await page.evaluate(e => e.userAgent, navigatorHandle);
   expect(text).toContain('Mozilla');
 });
 
-it('should accept object handle to primitive types', async ({page}) => {
+it('should accept object handle to primitive types', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => 5);
   const isFive = await page.evaluate(e => Object.is(e, 5), aHandle);
   expect(isFive).toBeTruthy();
 });
 
-it('should accept nested handle', async ({page}) => {
+it('should accept nested handle', async ({ page }) => {
   const foo = await page.evaluateHandle(() => ({ x: 1, y: 'foo' }));
   const result = await page.evaluate(({ foo }) => {
     return foo;
@@ -42,7 +42,7 @@ it('should accept nested handle', async ({page}) => {
   expect(result).toEqual({ x: 1, y: 'foo' });
 });
 
-it('should accept nested window handle', async ({page}) => {
+it('should accept nested window handle', async ({ page }) => {
   const foo = await page.evaluateHandle(() => window);
   const result = await page.evaluate(({ foo }) => {
     return foo === window;
@@ -50,7 +50,7 @@ it('should accept nested window handle', async ({page}) => {
   expect(result).toBe(true);
 });
 
-it('should accept multiple nested handles', async ({page}) => {
+it('should accept multiple nested handles', async ({ page }) => {
   const foo = await page.evaluateHandle(() => ({ x: 1, y: 'foo' }));
   const bar = await page.evaluateHandle(() => 5);
   const baz = await page.evaluateHandle(() => (['baz']));
@@ -63,29 +63,29 @@ it('should accept multiple nested handles', async ({page}) => {
   });
 });
 
-it('should throw for circular objects', async ({page}) => {
+it('should throw for circular objects', async ({ page }) => {
   const a = { x: 1 };
   a['y'] = a;
   const error = await page.evaluate(x => x, a).catch(e => e);
   expect(error.message).toContain('Argument is a circular structure');
 });
 
-it('should accept same handle multiple times', async ({page}) => {
+it('should accept same handle multiple times', async ({ page }) => {
   const foo = await page.evaluateHandle(() => 1);
-  expect(await page.evaluate(x => x, { foo, bar: [foo], baz: { foo }})).toEqual({ foo: 1, bar: [1], baz: { foo: 1 } });
+  expect(await page.evaluate(x => x, { foo, bar: [foo], baz: { foo } })).toEqual({ foo: 1, bar: [1], baz: { foo: 1 } });
 });
 
-it('should accept same nested object multiple times', async ({page}) => {
+it('should accept same nested object multiple times', async ({ page }) => {
   const foo = { x: 1 };
-  expect(await page.evaluate(x => x, { foo, bar: [foo], baz: { foo }})).toEqual({ foo: { x: 1 }, bar: [{ x: 1 }], baz: { foo: { x: 1 } } });
+  expect(await page.evaluate(x => x, { foo, bar: [foo], baz: { foo } })).toEqual({ foo: { x: 1 }, bar: [{ x: 1 }], baz: { foo: { x: 1 } } });
 });
 
-it('should accept object handle to unserializable value', async ({page}) => {
+it('should accept object handle to unserializable value', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => Infinity);
   expect(await page.evaluate(e => Object.is(e, Infinity), aHandle)).toBe(true);
 });
 
-it('should pass configurable args', async ({page}) => {
+it('should pass configurable args', async ({ page }) => {
   const result = await page.evaluate(arg => {
     if (arg.foo !== 42)
       throw new Error('Not a 42');
@@ -100,7 +100,7 @@ it('should pass configurable args', async ({page}) => {
   expect(result).toEqual({});
 });
 
-it('should work with primitives', async ({page}) => {
+it('should work with primitives', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => {
     window['FOO'] = 123;
     return window;

--- a/tests/page/page-evaluate-no-stall.spec.ts
+++ b/tests/page/page-evaluate-no-stall.spec.ts
@@ -17,15 +17,15 @@
 import { test, expect } from './pageTest';
 
 test.describe('non-stalling evaluate', () => {
-  test.skip(({mode}) => mode !== 'default');
+  test.skip(({ mode }) => mode !== 'default');
 
-  test('should work', async ({page, server, toImpl}) => {
+  test('should work', async ({ page, server, toImpl }) => {
     await page.goto(server.EMPTY_PAGE);
     const result = await toImpl(page.mainFrame()).nonStallingRawEvaluateInExistingMainContext('2+2');
     expect(result).toBe(4);
   });
 
-  test('should throw while pending navigation', async ({page, server, toImpl}) => {
+  test('should throw while pending navigation', async ({ page, server, toImpl }) => {
     await page.goto(server.EMPTY_PAGE);
     await page.evaluate(() => document.body.textContent = 'HELLO WORLD');
     let error;
@@ -37,7 +37,7 @@ test.describe('non-stalling evaluate', () => {
     expect(error.message).toContain('Frame is currently attempting a navigation');
   });
 
-  test('should throw when no main execution context', async ({page, toImpl}) => {
+  test('should throw when no main execution context', async ({ page, toImpl }) => {
     let errorPromise;
     page.on('frameattached', frame => {
       errorPromise = toImpl(frame).nonStallingRawEvaluateInExistingMainContext('2+2').catch(e => e);

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -18,11 +18,11 @@
 import { test as it, expect } from './pageTest';
 import util from 'util';
 
-it('should work', async ({page, browserName}) => {
+it('should work', async ({ page, browserName }) => {
   let message = null;
   page.once('console', m => message = m);
   await Promise.all([
-    page.evaluate(() => console.log('hello', 5, {foo: 'bar'})),
+    page.evaluate(() => console.log('hello', 5, { foo: 'bar' })),
     page.waitForEvent('console')
   ]);
   if (browserName !== 'firefox')
@@ -32,17 +32,17 @@ it('should work', async ({page, browserName}) => {
   expect(message.type()).toEqual('log');
   expect(await message.args()[0].jsonValue()).toEqual('hello');
   expect(await message.args()[1].jsonValue()).toEqual(5);
-  expect(await message.args()[2].jsonValue()).toEqual({foo: 'bar'});
+  expect(await message.args()[2].jsonValue()).toEqual({ foo: 'bar' });
 });
 
-it('should emit same log twice', async ({page}) => {
+it('should emit same log twice', async ({ page }) => {
   const messages = [];
   page.on('console', m => messages.push(m.text()));
   await page.evaluate(() => { for (let i = 0; i < 2; ++i) console.log('hello'); });
   expect(messages).toEqual(['hello', 'hello']);
 });
 
-it('should use text() for inspection', async ({page}) => {
+it('should use text() for inspection', async ({ page }) => {
   let text;
   const inspect = value => {
     text = util.inspect(value);
@@ -52,7 +52,7 @@ it('should use text() for inspection', async ({page}) => {
   expect(text).toEqual('Hello world');
 });
 
-it('should work for different console API calls', async ({page}) => {
+it('should work for different console API calls', async ({ page }) => {
   const messages = [];
   page.on('console', msg => messages.push(msg));
   // All console events will be reported before `page.evaluate` is finished.
@@ -92,7 +92,7 @@ it('should not fail for window object', async ({ page, browserName }) => {
     expect(message.text()).toEqual('JSHandle@object');
 });
 
-it('should trigger correct Log', async ({page, server, browserName, isWindows}) => {
+it('should trigger correct Log', async ({ page, server, browserName, isWindows }) => {
   it.skip(browserName === 'webkit' && isWindows, 'Upstream issue https://bugs.webkit.org/show_bug.cgi?id=229515');
   await page.goto('about:blank');
   const [message] = await Promise.all([
@@ -103,7 +103,7 @@ it('should trigger correct Log', async ({page, server, browserName, isWindows}) 
   expect(message.type()).toEqual('error');
 });
 
-it('should have location for console API calls', async ({page, server}) => {
+it('should have location for console API calls', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [message] = await Promise.all([
     page.waitForEvent('console', m => m.text() === 'yellow'),
@@ -119,7 +119,7 @@ it('should have location for console API calls', async ({page, server}) => {
   });
 });
 
-it('should not throw when there are console messages in detached iframes', async ({page, server}) => {
+it('should not throw when there are console messages in detached iframes', async ({ page, server }) => {
   // @see https://github.com/GoogleChrome/puppeteer/issues/3865
   await page.goto(server.EMPTY_PAGE);
   const [popup] = await Promise.all([
@@ -143,12 +143,12 @@ it('should not throw when there are console messages in detached iframes', async
   expect(await popup.evaluate('1 + 1')).toBe(2);
 });
 
-it('should use object previews for arrays and objects', async ({page, browserName}) => {
+it('should use object previews for arrays and objects', async ({ page, browserName }) => {
   let text: string;
   page.on('console', message => {
     text = message.text();
   });
-  await page.evaluate(() => console.log([1, 2, 3], {a: 1}, window));
+  await page.evaluate(() => console.log([1, 2, 3], { a: 1 }, window));
 
   if (browserName !== 'firefox')
     expect(text).toEqual('[1,2,3] {a: 1} Window');
@@ -156,7 +156,7 @@ it('should use object previews for arrays and objects', async ({page, browserNam
     expect(text).toEqual('Array JSHandle@object JSHandle@object');
 });
 
-it('should use object previews for errors', async ({page, browserName}) => {
+it('should use object previews for errors', async ({ page, browserName }) => {
   let text: string;
   page.on('console', message => {
     text = message.text();

--- a/tests/page/page-event-network.spec.ts
+++ b/tests/page/page-event-network.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('Page.Events.Request', async ({page, server}) => {
+it('Page.Events.Request', async ({ page, server }) => {
   const requests = [];
   page.on('request', request => requests.push(request));
   await page.goto(server.EMPTY_PAGE);
@@ -30,7 +30,7 @@ it('Page.Events.Request', async ({page, server}) => {
   expect(requests[0].frame().url()).toBe(server.EMPTY_PAGE);
 });
 
-it('Page.Events.Response', async ({page, server}) => {
+it('Page.Events.Response', async ({ page, server }) => {
   const responses = [];
   page.on('response', response => responses.push(response));
   await page.goto(server.EMPTY_PAGE);
@@ -41,7 +41,7 @@ it('Page.Events.Response', async ({page, server}) => {
   expect(responses[0].request()).toBeTruthy();
 });
 
-it('Page.Events.RequestFailed', async ({page, server, browserName, isMac, isWindows}) => {
+it('Page.Events.RequestFailed', async ({ page, server, browserName, isMac, isWindows }) => {
   server.setRoute('/one-style.css', (req, res) => {
     res.setHeader('Content-Type', 'text/css');
     res.connection.destroy();
@@ -68,7 +68,7 @@ it('Page.Events.RequestFailed', async ({page, server, browserName, isMac, isWind
   expect(failedRequests[0].frame()).toBeTruthy();
 });
 
-it('Page.Events.RequestFinished', async ({page, server}) => {
+it('Page.Events.RequestFinished', async ({ page, server }) => {
   const [response] = await Promise.all([
     page.goto(server.EMPTY_PAGE),
     page.waitForEvent('requestfinished')
@@ -81,7 +81,7 @@ it('Page.Events.RequestFinished', async ({page, server}) => {
   expect(request.failure()).toBe(null);
 });
 
-it('should fire events in proper order', async ({page, server}) => {
+it('should fire events in proper order', async ({ page, server }) => {
   const events = [];
   page.on('request', request => events.push('request'));
   page.on('response', response => events.push('response'));
@@ -91,7 +91,7 @@ it('should fire events in proper order', async ({page, server}) => {
   expect(events).toEqual(['request', 'response', 'requestfinished']);
 });
 
-it('should support redirects', async ({page, server}) => {
+it('should support redirects', async ({ page, server }) => {
   const FOO_URL = server.PREFIX + '/foo.html';
   const events = {};
   events[server.EMPTY_PAGE] = [];

--- a/tests/page/page-event-pageerror.spec.ts
+++ b/tests/page/page-event-pageerror.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should fire', async ({page, server, browserName}) => {
+it('should fire', async ({ page, server, browserName }) => {
   const url = server.PREFIX + '/error.html';
   const [error] = await Promise.all([
     page.waitForEvent('pageerror'),
@@ -57,7 +57,7 @@ it('should not receive console message for pageError', async ({ page, server, br
   expect(messages.length).toBe(1);
 });
 
-it('should contain sourceURL', async ({page, server, browserName}) => {
+it('should contain sourceURL', async ({ page, server, browserName }) => {
   it.fail(browserName === 'webkit');
 
   const [error] = await Promise.all([
@@ -97,7 +97,7 @@ it('should support an empty Error.name property', async ({ page }) => {
   expect(error.message).toBe('my-message');
 });
 
-it('should handle odd values', async ({page}) => {
+it('should handle odd values', async ({ page }) => {
   const cases = [
     [null, 'null'],
     [undefined, 'undefined'],
@@ -113,7 +113,7 @@ it('should handle odd values', async ({page}) => {
   }
 });
 
-it('should handle object', async ({page, browserName}) => {
+it('should handle object', async ({ page, browserName }) => {
   const [error] = await Promise.all([
     page.waitForEvent('pageerror'),
     page.evaluate(() => setTimeout(() => { throw {}; }, 0)),
@@ -121,7 +121,7 @@ it('should handle object', async ({page, browserName}) => {
   expect(error.message).toBe(browserName === 'chromium' ? 'Object' : '[object Object]');
 });
 
-it('should handle window', async ({page, browserName, isElectron}) => {
+it('should handle window', async ({ page, browserName, isElectron }) => {
   it.skip(isElectron);
   const [error] = await Promise.all([
     page.waitForEvent('pageerror'),

--- a/tests/page/page-event-popup.spec.ts
+++ b/tests/page/page-event-popup.spec.ts
@@ -16,7 +16,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({page}) => {
+it('should work', async ({ page }) => {
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => window['__popup'] = window.open('about:blank')),
@@ -25,7 +25,7 @@ it('should work', async ({page}) => {
   expect(await popup.evaluate(() => !!window.opener)).toBe(true);
 });
 
-it('should work with window features', async ({page, server}) => {
+it('should work with window features', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
@@ -35,7 +35,7 @@ it('should work with window features', async ({page, server}) => {
   expect(await popup.evaluate(() => !!window.opener)).toBe(true);
 });
 
-it('should emit for immediately closed popups', async ({page}) => {
+it('should emit for immediately closed popups', async ({ page }) => {
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => {
@@ -46,7 +46,7 @@ it('should emit for immediately closed popups', async ({page}) => {
   expect(popup).toBeTruthy();
 });
 
-it('should emit for immediately closed popups 2', async ({page, server, browserName, video}) => {
+it('should emit for immediately closed popups 2', async ({ page, server, browserName, video }) => {
   it.fixme(browserName === 'firefox' && video);
 
   await page.goto(server.EMPTY_PAGE);
@@ -60,7 +60,7 @@ it('should emit for immediately closed popups 2', async ({page, server, browserN
   expect(popup).toBeTruthy();
 });
 
-it('should be able to capture alert', async ({page}) => {
+it('should be able to capture alert', async ({ page }) => {
   const evaluatePromise = page.evaluate(() => {
     const win = window.open('');
     win.alert('hello');
@@ -72,7 +72,7 @@ it('should be able to capture alert', async ({page}) => {
   await evaluatePromise;
 });
 
-it('should work with empty url', async ({page}) => {
+it('should work with empty url', async ({ page }) => {
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => window['__popup'] = window.open('')),
@@ -81,7 +81,7 @@ it('should work with empty url', async ({page}) => {
   expect(await popup.evaluate(() => !!window.opener)).toBe(true);
 });
 
-it('should work with noopener and no url', async ({page}) => {
+it('should work with noopener and no url', async ({ page }) => {
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => window['__popup'] = window.open(undefined, null, 'noopener')),
@@ -92,7 +92,7 @@ it('should work with noopener and no url', async ({page}) => {
   expect(await popup.evaluate(() => !!window.opener)).toBe(false);
 });
 
-it('should work with noopener and about:blank', async ({page}) => {
+it('should work with noopener and about:blank', async ({ page }) => {
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => window['__popup'] = window.open('about:blank', null, 'noopener')),
@@ -101,7 +101,7 @@ it('should work with noopener and about:blank', async ({page}) => {
   expect(await popup.evaluate(() => !!window.opener)).toBe(false);
 });
 
-it('should work with noopener and url', async ({page, server}) => {
+it('should work with noopener and url', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
@@ -111,7 +111,7 @@ it('should work with noopener and url', async ({page, server}) => {
   expect(await popup.evaluate(() => !!window.opener)).toBe(false);
 });
 
-it('should work with clicking target=_blank', async ({page, server}) => {
+it('should work with clicking target=_blank', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent('<a target=_blank rel="opener" href="/one-style.html">yo</a>');
   const [popup] = await Promise.all([
@@ -122,7 +122,7 @@ it('should work with clicking target=_blank', async ({page, server}) => {
   expect(await popup.evaluate(() => !!window.opener)).toBe(true);
 });
 
-it('should work with fake-clicking target=_blank and rel=noopener', async ({page, server}) => {
+it('should work with fake-clicking target=_blank and rel=noopener', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent('<a target=_blank rel=noopener href="/one-style.html">yo</a>');
   const [popup] = await Promise.all([
@@ -133,7 +133,7 @@ it('should work with fake-clicking target=_blank and rel=noopener', async ({page
   expect(await popup.evaluate(() => !!window.opener)).toBe(false);
 });
 
-it('should work with clicking target=_blank and rel=noopener', async ({page, server}) => {
+it('should work with clicking target=_blank and rel=noopener', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent('<a target=_blank rel=noopener href="/one-style.html">yo</a>');
   const [popup] = await Promise.all([
@@ -144,7 +144,7 @@ it('should work with clicking target=_blank and rel=noopener', async ({page, ser
   expect(await popup.evaluate(() => !!window.opener)).toBe(false);
 });
 
-it('should not treat navigations as new popups', async ({page, server}) => {
+it('should not treat navigations as new popups', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent('<a target=_blank rel=noopener href="/one-style.html">yo</a>');
   const [popup] = await Promise.all([

--- a/tests/page/page-event-request.spec.ts
+++ b/tests/page/page-event-request.spec.ts
@@ -18,14 +18,14 @@
 import { test as it, expect } from './pageTest';
 import { attachFrame } from '../config/utils';
 
-it('should fire for navigation requests', async ({page, server}) => {
+it('should fire for navigation requests', async ({ page, server }) => {
   const requests = [];
   page.on('request', request => requests.push(request));
   await page.goto(server.EMPTY_PAGE);
   expect(requests.length).toBe(1);
 });
 
-it('should fire for iframes', async ({page, server}) => {
+it('should fire for iframes', async ({ page, server }) => {
   const requests = [];
   page.on('request', request => requests.push(request));
   await page.goto(server.EMPTY_PAGE);
@@ -33,7 +33,7 @@ it('should fire for iframes', async ({page, server}) => {
   expect(requests.length).toBe(2);
 });
 
-it('should fire for fetches', async ({page, server}) => {
+it('should fire for fetches', async ({ page, server }) => {
   const requests = [];
   page.on('request', request => requests.push(request));
   await page.goto(server.EMPTY_PAGE);
@@ -41,7 +41,7 @@ it('should fire for fetches', async ({page, server}) => {
   expect(requests.length).toBe(2);
 });
 
-it('should report requests and responses handled by service worker', async ({page, server, isAndroid}) => {
+it('should report requests and responses handled by service worker', async ({ page, server, isAndroid }) => {
   it.fixme(isAndroid);
 
   await page.goto(server.PREFIX + '/serviceworkers/fetchdummy/sw.html');

--- a/tests/page/page-expose-function.spec.ts
+++ b/tests/page/page-expose-function.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import type { ElementHandle } from '../../index';
 
-it('exposeBinding should work', async ({page}) => {
+it('exposeBinding should work', async ({ page }) => {
   let bindingSource;
   await page.exposeBinding('add', (source, a, b) => {
     bindingSource = source;
@@ -33,7 +33,7 @@ it('exposeBinding should work', async ({page}) => {
   expect(result).toEqual(11);
 });
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.exposeFunction('compute', function(a, b) {
     return a * b;
   });
@@ -43,7 +43,7 @@ it('should work', async ({page, server}) => {
   expect(result).toBe(36);
 });
 
-it('should work with handles and complex objects', async ({page, server}) => {
+it('should work with handles and complex objects', async ({ page, server }) => {
   const fooHandle = await page.evaluateHandle(() => {
     window['fooValue'] = { bar: 2 };
     return window['fooValue'];
@@ -59,22 +59,22 @@ it('should work with handles and complex objects', async ({page, server}) => {
   expect(equals).toBe(true);
 });
 
-it('should throw exception in page context', async ({page, server}) => {
+it('should throw exception in page context', async ({ page, server }) => {
   await page.exposeFunction('woof', function() {
     throw new Error('WOOF WOOF');
   });
-  const {message, stack} = await page.evaluate(async () => {
+  const { message, stack } = await page.evaluate(async () => {
     try {
       await window['woof']();
     } catch (e) {
-      return {message: e.message, stack: e.stack};
+      return { message: e.message, stack: e.stack };
     }
   });
   expect(message).toBe('WOOF WOOF');
   expect(stack).toContain(__filename);
 });
 
-it('should support throwing "null"', async ({page, server}) => {
+it('should support throwing "null"', async ({ page, server }) => {
   await page.exposeFunction('woof', function() {
     throw null;
   });
@@ -88,7 +88,7 @@ it('should support throwing "null"', async ({page, server}) => {
   expect(thrown).toBe(null);
 });
 
-it('should be callable from-inside addInitScript', async ({page, server}) => {
+it('should be callable from-inside addInitScript', async ({ page, server }) => {
   let called = false;
   await page.exposeFunction('woof', function() {
     called = true;
@@ -98,7 +98,7 @@ it('should be callable from-inside addInitScript', async ({page, server}) => {
   expect(called).toBe(true);
 });
 
-it('should survive navigation', async ({page, server}) => {
+it('should survive navigation', async ({ page, server }) => {
   await page.exposeFunction('compute', function(a, b) {
     return a * b;
   });
@@ -110,7 +110,7 @@ it('should survive navigation', async ({page, server}) => {
   expect(result).toBe(36);
 });
 
-it('should await returned promise', async ({page, server}) => {
+it('should await returned promise', async ({ page, server }) => {
   await page.exposeFunction('compute', function(a, b) {
     return Promise.resolve(a * b);
   });
@@ -121,7 +121,7 @@ it('should await returned promise', async ({page, server}) => {
   expect(result).toBe(15);
 });
 
-it('should work on frames', async ({page, server}) => {
+it('should work on frames', async ({ page, server }) => {
   await page.exposeFunction('compute', function(a, b) {
     return Promise.resolve(a * b);
   });
@@ -134,7 +134,7 @@ it('should work on frames', async ({page, server}) => {
   expect(result).toBe(15);
 });
 
-it('should work on frames before navigation', async ({page, server}) => {
+it('should work on frames before navigation', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/nested-frames.html');
   await page.exposeFunction('compute', function(a, b) {
     return Promise.resolve(a * b);
@@ -147,7 +147,7 @@ it('should work on frames before navigation', async ({page, server}) => {
   expect(result).toBe(15);
 });
 
-it('should work after cross origin navigation', async ({page, server}) => {
+it('should work after cross origin navigation', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.exposeFunction('compute', function(a, b) {
     return a * b;
@@ -160,15 +160,15 @@ it('should work after cross origin navigation', async ({page, server}) => {
   expect(result).toBe(36);
 });
 
-it('should work with complex objects', async ({page, server}) => {
+it('should work with complex objects', async ({ page, server }) => {
   await page.exposeFunction('complexObject', function(a, b) {
-    return {x: a.x + b.x};
+    return { x: a.x + b.x };
   });
-  const result = await page.evaluate(async () => window['complexObject']({x: 5}, {x: 2}));
+  const result = await page.evaluate(async () => window['complexObject']({ x: 5 }, { x: 2 }));
   expect(result.x).toBe(7);
 });
 
-it('exposeBindingHandle should work', async ({page}) => {
+it('exposeBindingHandle should work', async ({ page }) => {
   let target;
   await page.exposeBinding('logme', (source, t) => {
     target = t;
@@ -181,7 +181,7 @@ it('exposeBindingHandle should work', async ({page}) => {
   expect(result).toEqual(17);
 });
 
-it('exposeBindingHandle should not throw during navigation', async ({page, server}) => {
+it('exposeBindingHandle should not throw during navigation', async ({ page, server }) => {
   await page.exposeBinding('logme', (source, t) => {
     return 17;
   }, { handle: true });
@@ -195,13 +195,13 @@ it('exposeBindingHandle should not throw during navigation', async ({page, serve
   ]);
 });
 
-it('should throw for duplicate registrations', async ({page}) => {
+it('should throw for duplicate registrations', async ({ page }) => {
   await page.exposeFunction('foo', () => {});
   const error = await page.exposeFunction('foo', () => {}).catch(e => e);
   expect(error.message).toContain('page.exposeFunction: Function "foo" has been already registered');
 });
 
-it('exposeBindingHandle should throw for multiple arguments', async ({page}) => {
+it('exposeBindingHandle should throw for multiple arguments', async ({ page }) => {
   await page.exposeBinding('logme', (source, t) => {
     return 17;
   }, { handle: true });
@@ -221,7 +221,7 @@ it('exposeBindingHandle should throw for multiple arguments', async ({page}) => 
   expect(error.message).toContain('exposeBindingHandle supports a single argument, 2 received');
 });
 
-it('should not result in unhandled rejection', async ({page, isAndroid}) => {
+it('should not result in unhandled rejection', async ({ page, isAndroid }) => {
   it.fixme(isAndroid);
 
   const closedPromise = page.waitForEvent('close');
@@ -237,7 +237,7 @@ it('should not result in unhandled rejection', async ({page, isAndroid}) => {
   expect(await page.evaluate('1 + 1').catch(e => e)).toBeInstanceOf(Error);
 });
 
-it('exposeBinding(handle) should work with element handles', async ({ page}) => {
+it('exposeBinding(handle) should work with element handles', async ({ page }) => {
   let cb;
   const promise = new Promise(f => cb = f);
   await page.exposeBinding('clicked', async (source, element: ElementHandle) => {
@@ -254,7 +254,7 @@ it('exposeBinding(handle) should work with element handles', async ({ page}) => 
   expect(await promise).toBe('Click me');
 });
 
-it('should work with setContent', async ({page, server}) => {
+it('should work with setContent', async ({ page, server }) => {
   await page.exposeFunction('compute', function(a, b) {
     return Promise.resolve(a * b);
   });

--- a/tests/page/page-fill.spec.ts
+++ b/tests/page/page-fill.spec.ts
@@ -22,49 +22,49 @@ async function giveItAChanceToFill(page) {
     await page.evaluate(() => new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f))));
 }
 
-it('should fill textarea', async ({page, server}) => {
+it('should fill textarea', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.fill('textarea', 'some value');
   expect(await page.evaluate(() => window['result'])).toBe('some value');
 });
 
-it('should fill input', async ({page, server}) => {
+it('should fill input', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.fill('input', 'some value');
   expect(await page.evaluate(() => window['result'])).toBe('some value');
 });
 
-it('should fill input with label', async ({page}) => {
+it('should fill input with label', async ({ page }) => {
   await page.setContent(`<label for=target>Fill me</label><input id=target>`);
   await page.fill('text=Fill me', 'some value');
   expect(await page.$eval('input', input => input.value)).toBe('some value');
 });
 
-it('should fill input with label 2', async ({page}) => {
+it('should fill input with label 2', async ({ page }) => {
   await page.setContent(`<label>Fill me<input id=target></label>`);
   await page.fill('text=Fill me', 'some value');
   expect(await page.$eval('input', input => input.value)).toBe('some value');
 });
 
-it('should fill input with span inside the label', async ({page}) => {
+it('should fill input with span inside the label', async ({ page }) => {
   await page.setContent(`<label for=target><span>Fill me</span></label><input id=target>`);
   await page.fill('text=Fill me', 'some value');
   expect(await page.$eval('input', input => input.value)).toBe('some value');
 });
 
-it('should fill input inside the label', async ({page}) => {
+it('should fill input inside the label', async ({ page }) => {
   await page.setContent(`<label><input id=target></label>`);
   await page.fill('input', 'some value');
   expect(await page.$eval('input', input => input.value)).toBe('some value');
 });
 
-it('should fill textarea with label', async ({page}) => {
+it('should fill textarea with label', async ({ page }) => {
   await page.setContent(`<label for=target>Fill me</label><textarea id=target>hey</textarea>`);
   await page.fill('text=Fill me', 'some value');
   expect(await page.$eval('textarea', textarea => textarea.value)).toBe('some value');
 });
 
-it('should throw on unsupported inputs', async ({page, server}) => {
+it('should throw on unsupported inputs', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   for (const type of ['button', 'checkbox', 'file', 'image', 'radio', 'range', 'reset', 'submit']) {
     await page.$eval('input', (input, type) => input.setAttribute('type', type), type);
@@ -74,7 +74,7 @@ it('should throw on unsupported inputs', async ({page, server}) => {
   }
 });
 
-it('should fill different input types', async ({page, server}) => {
+it('should fill different input types', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   for (const type of ['password', 'search', 'tel', 'text', 'url', 'invalid-type']) {
     await page.$eval('input', (input, type) => input.setAttribute('type', type), type);
@@ -83,14 +83,14 @@ it('should fill different input types', async ({page, server}) => {
   }
 });
 
-it('should fill date input after clicking', async ({page, server}) => {
+it('should fill date input after clicking', async ({ page, server }) => {
   await page.setContent('<input type=date>');
   await page.click('input');
   await page.fill('input', '2020-03-02');
   expect(await page.$eval('input', input => input.value)).toBe('2020-03-02');
 });
 
-it('should throw on incorrect date', async ({page, browserName}) => {
+it('should throw on incorrect date', async ({ page, browserName }) => {
   it.skip(browserName === 'webkit', 'WebKit does not support date inputs');
 
   await page.setContent('<input type=date>');
@@ -98,19 +98,19 @@ it('should throw on incorrect date', async ({page, browserName}) => {
   expect(error.message).toContain('Malformed value');
 });
 
-it('should fill time input', async ({page}) => {
+it('should fill time input', async ({ page }) => {
   await page.setContent('<input type=time>');
   await page.fill('input', '13:15');
   expect(await page.$eval('input', input => input.value)).toBe('13:15');
 });
 
-it('should fill month input', async ({page}) => {
+it('should fill month input', async ({ page }) => {
   await page.setContent('<input type=month>');
   await page.fill('input', '2020-07');
   expect(await page.$eval('input', input => input.value)).toBe('2020-07');
 });
 
-it('should throw on incorrect month', async ({page, browserName}) => {
+it('should throw on incorrect month', async ({ page, browserName }) => {
   it.skip(browserName !== 'chromium', 'Only Chromium supports month inputs');
 
   await page.setContent('<input type=month>');
@@ -118,13 +118,13 @@ it('should throw on incorrect month', async ({page, browserName}) => {
   expect(error.message).toContain('Malformed value');
 });
 
-it('should fill week input', async ({page}) => {
+it('should fill week input', async ({ page }) => {
   await page.setContent('<input type=week>');
   await page.fill('input', '2020-W50');
   expect(await page.$eval('input', input => input.value)).toBe('2020-W50');
 });
 
-it('should throw on incorrect week', async ({page, browserName}) => {
+it('should throw on incorrect week', async ({ page, browserName }) => {
   it.skip(browserName !== 'chromium', 'Only Chromium supports week inputs');
 
   await page.setContent('<input type=week>');
@@ -132,7 +132,7 @@ it('should throw on incorrect week', async ({page, browserName}) => {
   expect(error.message).toContain('Malformed value');
 });
 
-it('should throw on incorrect time', async ({page, browserName}) => {
+it('should throw on incorrect time', async ({ page, browserName }) => {
   it.skip(browserName === 'webkit', 'WebKit does not support time inputs');
 
   await page.setContent('<input type=time>');
@@ -140,13 +140,13 @@ it('should throw on incorrect time', async ({page, browserName}) => {
   expect(error.message).toContain('Malformed value');
 });
 
-it('should fill datetime-local input', async ({page, server}) => {
+it('should fill datetime-local input', async ({ page, server }) => {
   await page.setContent('<input type=datetime-local>');
   await page.fill('input', '2020-03-02T05:15');
   expect(await page.$eval('input', input => input.value)).toBe('2020-03-02T05:15');
 });
 
-it('should throw on incorrect datetime-local', async ({page, server, browserName}) => {
+it('should throw on incorrect datetime-local', async ({ page, server, browserName }) => {
   it.skip(browserName !== 'chromium', 'Only Chromium supports datetime-local inputs');
 
   await page.setContent('<input type=datetime-local>');
@@ -154,13 +154,13 @@ it('should throw on incorrect datetime-local', async ({page, server, browserName
   expect(error.message).toContain('Malformed value');
 });
 
-it('should fill contenteditable', async ({page, server}) => {
+it('should fill contenteditable', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.fill('div[contenteditable]', 'some value');
   expect(await page.$eval('div[contenteditable]', div => div.textContent)).toBe('some value');
 });
 
-it('should fill elements with existing value and selection', async ({page, server}) => {
+it('should fill elements with existing value and selection', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
 
   await page.$eval('input', input => input.value = 'value one');
@@ -186,14 +186,14 @@ it('should fill elements with existing value and selection', async ({page, serve
   expect(await page.$eval('div[contenteditable]', div => div.textContent)).toBe('replace with this');
 });
 
-it('should throw nice error without injected script stack when element is not an <input>', async ({page, server}) => {
+it('should throw nice error without injected script stack when element is not an <input>', async ({ page, server }) => {
   let error = null;
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.fill('body', '').catch(e => error = e);
   expect(error.message).toContain('page.fill: Error: Element is not an <input>, <textarea> or [contenteditable] element\n=========================== logs');
 });
 
-it('should throw if passed a non-string value', async ({page, server}) => {
+it('should throw if passed a non-string value', async ({ page, server }) => {
   let error = null;
   await page.goto(server.PREFIX + '/input/textarea.html');
   // @ts-expect-error fill only accepts string values
@@ -201,7 +201,7 @@ it('should throw if passed a non-string value', async ({page, server}) => {
   expect(error.message).toContain('value: expected string, got number');
 });
 
-it('should retry on disabled element', async ({page, server}) => {
+it('should retry on disabled element', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.$eval('input', i => i.disabled = true);
   let done = false;
@@ -216,7 +216,7 @@ it('should retry on disabled element', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'])).toBe('some value');
 });
 
-it('should retry on readonly element', async ({page, server}) => {
+it('should retry on readonly element', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.$eval('textarea', i => i.readOnly = true);
   let done = false;
@@ -231,7 +231,7 @@ it('should retry on readonly element', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'])).toBe('some value');
 });
 
-it('should retry on invisible element', async ({page, server}) => {
+it('should retry on invisible element', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.$eval('input', i => i.style.display = 'none');
   let done = false;
@@ -246,19 +246,19 @@ it('should retry on invisible element', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'])).toBe('some value');
 });
 
-it('should be able to fill the body', async ({page}) => {
+it('should be able to fill the body', async ({ page }) => {
   await page.setContent(`<body contentEditable="true"></body>`);
   await page.fill('body', 'some value');
   expect(await page.evaluate(() => document.body.textContent)).toBe('some value');
 });
 
-it('should fill fixed position input', async ({page}) => {
+it('should fill fixed position input', async ({ page }) => {
   await page.setContent(`<input style='position: fixed;' />`);
   await page.fill('input', 'some value');
   expect(await page.evaluate(() => document.querySelector('input').value)).toBe('some value');
 });
 
-it('should be able to fill when focus is in the wrong frame', async ({page}) => {
+it('should be able to fill when focus is in the wrong frame', async ({ page }) => {
   await page.setContent(`
     <div contentEditable="true"></div>
     <iframe></iframe>
@@ -268,32 +268,32 @@ it('should be able to fill when focus is in the wrong frame', async ({page}) => 
   expect(await page.$eval('div', d => d.textContent)).toBe('some value');
 });
 
-it('should be able to fill the input[type=number]', async ({page}) => {
+it('should be able to fill the input[type=number]', async ({ page }) => {
   await page.setContent(`<input id="input" type="number"></input>`);
   await page.fill('input', '42');
   expect(await page.evaluate(() => window['input'].value)).toBe('42');
 });
 
-it('should be able to fill exponent into the input[type=number]', async ({page}) => {
+it('should be able to fill exponent into the input[type=number]', async ({ page }) => {
   await page.setContent(`<input id="input" type="number"></input>`);
   await page.fill('input', '-10e5');
   expect(await page.evaluate(() => window['input'].value)).toBe('-10e5');
 });
 
-it('should be able to fill input[type=number] with empty string', async ({page}) => {
+it('should be able to fill input[type=number] with empty string', async ({ page }) => {
   await page.setContent(`<input id="input" type="number" value="123"></input>`);
   await page.fill('input', '');
   expect(await page.evaluate(() => window['input'].value)).toBe('');
 });
 
-it('should not be able to fill text into the input[type=number]', async ({page}) => {
+it('should not be able to fill text into the input[type=number]', async ({ page }) => {
   await page.setContent(`<input id="input" type="number"></input>`);
   let error = null;
   await page.fill('input', 'abc').catch(e => error = e);
   expect(error.message).toContain('Cannot type text into input[type=number]');
 });
 
-it('should be able to clear', async ({page, server}) => {
+it('should be able to clear', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.fill('input', 'some value');
   expect(await page.evaluate(() => window['result'])).toBe('some value');
@@ -301,7 +301,7 @@ it('should be able to clear', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'])).toBe('');
 });
 
-it('should not throw when fill causes navigation', async ({page, server}) => {
+it('should not throw when fill causes navigation', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.setContent('<input type=date>');
   await page.$eval('input', select => select.addEventListener('input', () => window.location.href = '/empty.html'));

--- a/tests/page/page-focus.spec.ts
+++ b/tests/page/page-focus.spec.ts
@@ -16,7 +16,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async function({page, browserName}) {
+it('should work', async function({ page, browserName }) {
   it.skip(browserName === 'firefox');
 
   await page.setContent(`<div id=d1 tabIndex=0></div>`);
@@ -25,7 +25,7 @@ it('should work', async function({page, browserName}) {
   expect(await page.evaluate(() => document.activeElement.id)).toBe('d1');
 });
 
-it('should emit focus event', async function({page}) {
+it('should emit focus event', async function({ page }) {
   await page.setContent(`<div id=d1 tabIndex=0></div>`);
   let focused = false;
   await page.exposeFunction('focusEvent', () => focused = true);
@@ -34,7 +34,7 @@ it('should emit focus event', async function({page}) {
   expect(focused).toBe(true);
 });
 
-it('should emit blur event', async function({page}) {
+it('should emit blur event', async function({ page }) {
   await page.setContent(`<div id=d1 tabIndex=0>DIV1</div><div id=d2 tabIndex=0>DIV2</div>`);
   await page.focus('#d1');
   let focused = false;
@@ -48,7 +48,7 @@ it('should emit blur event', async function({page}) {
   expect(blurred).toBe(true);
 });
 
-it('should traverse focus', async function({page}) {
+it('should traverse focus', async function({ page }) {
   await page.setContent(`<input id="i1"><input id="i2">`);
   let focused = false;
   await page.exposeFunction('focusEvent', () => focused = true);
@@ -64,7 +64,7 @@ it('should traverse focus', async function({page}) {
   expect(await page.$eval('#i2', e => (e as HTMLInputElement).value)).toBe('Last');
 });
 
-it('should traverse focus in all directions', async function({page}) {
+it('should traverse focus in all directions', async function({ page }) {
   await page.setContent(`<input value="1"><input value="2"><input value="3">`);
   await page.keyboard.press('Tab');
   expect(await page.evaluate(() => (document.activeElement as HTMLInputElement).value)).toBe('1');
@@ -78,7 +78,7 @@ it('should traverse focus in all directions', async function({page}) {
   expect(await page.evaluate(() => (document.activeElement as HTMLInputElement).value)).toBe('1');
 });
 
-it('should traverse only form elements', async function({page, browserName, platform}) {
+it('should traverse only form elements', async function({ page, browserName, platform }) {
   it.skip(platform !== 'darwin' || browserName !== 'webkit',
       'Chromium and WebKit both have settings for tab traversing all links, but it is only on by default in WebKit.');
 

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -20,12 +20,12 @@ import os from 'os';
 import { test as it, expect } from './pageTest';
 import { expectedSSLError } from '../config/utils';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   expect(page.url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should work with file URL', async ({page, asset, isAndroid}) => {
+it('should work with file URL', async ({ page, asset, isAndroid }) => {
   it.skip(isAndroid, 'No files on Android');
 
   const fileurl = url.pathToFileURL(asset('frames/two-frames.html')).href;
@@ -34,14 +34,14 @@ it('should work with file URL', async ({page, asset, isAndroid}) => {
   expect(page.frames().length).toBe(3);
 });
 
-it('should use http for no protocol', async ({page, server, isAndroid}) => {
+it('should use http for no protocol', async ({ page, server, isAndroid }) => {
   it.skip(isAndroid);
 
   await page.goto(server.EMPTY_PAGE.substring('http://'.length));
   expect(page.url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should work cross-process', async ({page, server}) => {
+it('should work cross-process', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   expect(page.url()).toBe(server.EMPTY_PAGE);
 
@@ -58,7 +58,7 @@ it('should work cross-process', async ({page, server}) => {
   expect(response.url()).toBe(url);
 });
 
-it('should work with Cross-Origin-Opener-Policy', async ({page, server, browserName}) => {
+it('should work with Cross-Origin-Opener-Policy', async ({ page, server, browserName }) => {
   it.fail(browserName === 'webkit', 'Regressed in https://trac.webkit.org/changeset/281516/webkit');
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
@@ -68,7 +68,7 @@ it('should work with Cross-Origin-Opener-Policy', async ({page, server, browserN
   expect(page.url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should capture iframe navigation request', async ({page, server}) => {
+it('should capture iframe navigation request', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   expect(page.url()).toBe(server.EMPTY_PAGE);
 
@@ -86,7 +86,7 @@ it('should capture iframe navigation request', async ({page, server}) => {
   expect(requestFrame).toBe(page.frames()[1]);
 });
 
-it('should capture cross-process iframe navigation request', async ({page, server}) => {
+it('should capture cross-process iframe navigation request', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   expect(page.url()).toBe(server.EMPTY_PAGE);
 
@@ -104,7 +104,7 @@ it('should capture cross-process iframe navigation request', async ({page, serve
   expect(requestFrame).toBe(page.frames()[1]);
 });
 
-it('should work with anchor navigation', async ({page, server}) => {
+it('should work with anchor navigation', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   expect(page.url()).toBe(server.EMPTY_PAGE);
   await page.goto(server.EMPTY_PAGE + '#foo');
@@ -113,7 +113,7 @@ it('should work with anchor navigation', async ({page, server}) => {
   expect(page.url()).toBe(server.EMPTY_PAGE + '#bar');
 });
 
-it('should work with redirects', async ({page, server}) => {
+it('should work with redirects', async ({ page, server }) => {
   server.setRedirect('/redirect/1.html', '/redirect/2.html');
   server.setRedirect('/redirect/2.html', '/empty.html');
   const response = await page.goto(server.PREFIX + '/redirect/1.html');
@@ -121,17 +121,17 @@ it('should work with redirects', async ({page, server}) => {
   expect(page.url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should navigate to about:blank', async ({page, server}) => {
+it('should navigate to about:blank', async ({ page, server }) => {
   const response = await page.goto('about:blank');
   expect(response).toBe(null);
 });
 
-it('should return response when page changes its URL after load', async ({page, server}) => {
+it('should return response when page changes its URL after load', async ({ page, server }) => {
   const response = await page.goto(server.PREFIX + '/historyapi.html');
   expect(response.status()).toBe(200);
 });
 
-it('should work with subframes return 204', async ({page, server}) => {
+it('should work with subframes return 204', async ({ page, server }) => {
   server.setRoute('/frames/frame.html', (req, res) => {
     res.statusCode = 204;
     res.end();
@@ -139,7 +139,7 @@ it('should work with subframes return 204', async ({page, server}) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
 });
 
-it('should work with subframes return 204 with domcontentloaded', async ({page, server}) => {
+it('should work with subframes return 204 with domcontentloaded', async ({ page, server }) => {
   server.setRoute('/frames/frame.html', (req, res) => {
     res.statusCode = 204;
     res.end();
@@ -147,7 +147,7 @@ it('should work with subframes return 204 with domcontentloaded', async ({page, 
   await page.goto(server.PREFIX + '/frames/one-frame.html', { waitUntil: 'domcontentloaded' });
 });
 
-it('should fail when server returns 204', async ({page, server, browserName}) => {
+it('should fail when server returns 204', async ({ page, server, browserName }) => {
   // WebKit just loads an empty page.
   server.setRoute('/empty.html', (req, res) => {
     res.statusCode = 204;
@@ -164,12 +164,12 @@ it('should fail when server returns 204', async ({page, server, browserName}) =>
     expect(error.message).toContain('NS_BINDING_ABORTED');
 });
 
-it('should navigate to empty page with domcontentloaded', async ({page, server}) => {
-  const response = await page.goto(server.EMPTY_PAGE, {waitUntil: 'domcontentloaded'});
+it('should navigate to empty page with domcontentloaded', async ({ page, server }) => {
+  const response = await page.goto(server.EMPTY_PAGE, { waitUntil: 'domcontentloaded' });
   expect(response.status()).toBe(200);
 });
 
-it('should work when page calls history API in beforeunload', async ({page, server}) => {
+it('should work when page calls history API in beforeunload', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => {
     window.addEventListener('beforeunload', () => history.replaceState(null, 'initial', window.location.href), false);
@@ -178,7 +178,7 @@ it('should work when page calls history API in beforeunload', async ({page, serv
   expect(response.status()).toBe(200);
 });
 
-it('should fail when navigating to bad url', async ({page, browserName}) => {
+it('should fail when navigating to bad url', async ({ page, browserName }) => {
   let error = null;
   await page.goto('asdfasdf').catch(e => error = e);
   if (browserName === 'chromium' || browserName === 'webkit')
@@ -187,7 +187,7 @@ it('should fail when navigating to bad url', async ({page, browserName}) => {
     expect(error.message).toContain('Invalid url');
 });
 
-it('should fail when navigating to bad SSL', async ({page, browserName, httpsServer}) => {
+it('should fail when navigating to bad SSL', async ({ page, browserName, httpsServer }) => {
   // Make sure that network events do not emit 'undefined'.
   // @see https://crbug.com/750469
   page.on('request', request => expect(request).toBeTruthy());
@@ -198,7 +198,7 @@ it('should fail when navigating to bad SSL', async ({page, browserName, httpsSer
   expect(error.message).toContain(expectedSSLError(browserName));
 });
 
-it('should fail when navigating to bad SSL after redirects', async ({page, browserName, server, httpsServer}) => {
+it('should fail when navigating to bad SSL after redirects', async ({ page, browserName, server, httpsServer }) => {
   server.setRedirect('/redirect/1.html', '/redirect/2.html');
   server.setRedirect('/redirect/2.html', '/empty.html');
   let error = null;
@@ -206,24 +206,24 @@ it('should fail when navigating to bad SSL after redirects', async ({page, brows
   expect(error.message).toContain(expectedSSLError(browserName));
 });
 
-it('should not crash when navigating to bad SSL after a cross origin navigation', async ({page, server, httpsServer}) => {
+it('should not crash when navigating to bad SSL after a cross origin navigation', async ({ page, server, httpsServer }) => {
   await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
   await page.goto(httpsServer.EMPTY_PAGE).catch(e => void 0);
 });
 
-it('should not throw if networkidle0 is passed as an option', async ({page, server}) => {
+it('should not throw if networkidle0 is passed as an option', async ({ page, server }) => {
   // @ts-expect-error networkidle0 is undocumented
-  await page.goto(server.EMPTY_PAGE, {waitUntil: 'networkidle0'});
+  await page.goto(server.EMPTY_PAGE, { waitUntil: 'networkidle0' });
 });
 
-it('should throw if networkidle2 is passed as an option', async ({page, server}) => {
+it('should throw if networkidle2 is passed as an option', async ({ page, server }) => {
   let error = null;
   // @ts-expect-error networkidle2 is not allowed
-  await page.goto(server.EMPTY_PAGE, {waitUntil: 'networkidle2'}).catch(err => error = err);
+  await page.goto(server.EMPTY_PAGE, { waitUntil: 'networkidle2' }).catch(err => error = err);
   expect(error.message).toContain(`waitUntil: expected one of (load|domcontentloaded|networkidle)`);
 });
 
-it('should fail when main resources failed to load', async ({page, browserName, isWindows}) => {
+it('should fail when main resources failed to load', async ({ page, browserName, isWindows }) => {
   let error = null;
   await page.goto('http://localhost:44123/non-existing-url').catch(e => error = e);
   if (browserName === 'chromium')
@@ -236,17 +236,17 @@ it('should fail when main resources failed to load', async ({page, browserName, 
     expect(error.message).toContain('NS_ERROR_CONNECTION_REFUSED');
 });
 
-it('should fail when exceeding maximum navigation timeout', async ({page, server, playwright}) => {
+it('should fail when exceeding maximum navigation timeout', async ({ page, server, playwright }) => {
   // Hang for request to the empty.html
   server.setRoute('/empty.html', (req, res) => { });
   let error = null;
-  await page.goto(server.PREFIX + '/empty.html', {timeout: 1}).catch(e => error = e);
+  await page.goto(server.PREFIX + '/empty.html', { timeout: 1 }).catch(e => error = e);
   expect(error.message).toContain('page.goto: Timeout 1ms exceeded.');
   expect(error.message).toContain(server.PREFIX + '/empty.html');
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should fail when exceeding default maximum navigation timeout', async ({page, server, playwright, isAndroid}) => {
+it('should fail when exceeding default maximum navigation timeout', async ({ page, server, playwright, isAndroid }) => {
   it.skip(isAndroid, 'No context per test');
 
   // Hang for request to the empty.html
@@ -260,7 +260,7 @@ it('should fail when exceeding default maximum navigation timeout', async ({page
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should fail when exceeding browser context navigation timeout', async ({page, server, playwright, isAndroid}) => {
+it('should fail when exceeding browser context navigation timeout', async ({ page, server, playwright, isAndroid }) => {
   it.skip(isAndroid, 'No context per test');
 
   // Hang for request to the empty.html
@@ -273,7 +273,7 @@ it('should fail when exceeding browser context navigation timeout', async ({page
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should fail when exceeding default maximum timeout', async ({page, server, playwright, isAndroid}) => {
+it('should fail when exceeding default maximum timeout', async ({ page, server, playwright, isAndroid }) => {
   it.skip(isAndroid, 'No context per test');
 
   // Hang for request to the empty.html
@@ -287,7 +287,7 @@ it('should fail when exceeding default maximum timeout', async ({page, server, p
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should fail when exceeding browser context timeout', async ({page, server, playwright, isAndroid}) => {
+it('should fail when exceeding browser context timeout', async ({ page, server, playwright, isAndroid }) => {
   it.skip(isAndroid, 'No context per test');
 
   // Hang for request to the empty.html
@@ -300,7 +300,7 @@ it('should fail when exceeding browser context timeout', async ({page, server, p
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should prioritize default navigation timeout over default timeout', async ({page, server, playwright}) => {
+it('should prioritize default navigation timeout over default timeout', async ({ page, server, playwright }) => {
   // Hang for request to the empty.html
   server.setRoute('/empty.html', (req, res) => { });
   let error = null;
@@ -312,16 +312,16 @@ it('should prioritize default navigation timeout over default timeout', async ({
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should disable timeout when its set to 0', async ({page, server}) => {
+it('should disable timeout when its set to 0', async ({ page, server }) => {
   let error = null;
   let loaded = false;
   page.once('load', () => loaded = true);
-  await page.goto(server.PREFIX + '/grid.html', {timeout: 0, waitUntil: 'load'}).catch(e => error = e);
+  await page.goto(server.PREFIX + '/grid.html', { timeout: 0, waitUntil: 'load' }).catch(e => error = e);
   expect(error).toBe(null);
   expect(loaded).toBe(true);
 });
 
-it('should fail when replaced by another navigation', async ({page, server, browserName}) => {
+it('should fail when replaced by another navigation', async ({ page, server, browserName }) => {
   let anotherPromise;
   server.setRoute('/empty.html', (req, res) => {
     anotherPromise = page.goto(server.PREFIX + '/one-style.html');
@@ -337,23 +337,23 @@ it('should fail when replaced by another navigation', async ({page, server, brow
     expect(error.message).toContain('NS_BINDING_ABORTED');
 });
 
-it('should work when navigating to valid url', async ({page, server}) => {
+it('should work when navigating to valid url', async ({ page, server }) => {
   const response = await page.goto(server.EMPTY_PAGE);
   expect(response.ok()).toBe(true);
 });
 
-it('should work when navigating to data url', async ({page, server}) => {
+it('should work when navigating to data url', async ({ page, server }) => {
   const response = await page.goto('data:text/html,hello');
   expect(response).toBe(null);
 });
 
-it('should work when navigating to 404', async ({page, server}) => {
+it('should work when navigating to 404', async ({ page, server }) => {
   const response = await page.goto(server.PREFIX + '/not-found');
   expect(response.ok()).toBe(false);
   expect(response.status()).toBe(404);
 });
 
-it('should return last response in redirect chain', async ({page, server}) => {
+it('should return last response in redirect chain', async ({ page, server }) => {
   server.setRedirect('/redirect/1.html', '/redirect/2.html');
   server.setRedirect('/redirect/2.html', '/redirect/3.html');
   server.setRedirect('/redirect/3.html', server.EMPTY_PAGE);
@@ -362,7 +362,7 @@ it('should return last response in redirect chain', async ({page, server}) => {
   expect(response.url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should not leak listeners during navigation', async ({page, server}) => {
+it('should not leak listeners during navigation', async ({ page, server }) => {
   let warning = null;
   const warningHandler = w => warning = w;
   process.on('warning', warningHandler);
@@ -372,7 +372,7 @@ it('should not leak listeners during navigation', async ({page, server}) => {
   expect(warning).toBe(null);
 });
 
-it('should not leak listeners during bad navigation', async ({page, server}) => {
+it('should not leak listeners during bad navigation', async ({ page, server }) => {
   let warning = null;
   const warningHandler = w => warning = w;
   process.on('warning', warningHandler);
@@ -382,7 +382,7 @@ it('should not leak listeners during bad navigation', async ({page, server}) => 
   expect(warning).toBe(null);
 });
 
-it('should not leak listeners during 20 waitForNavigation', async ({page, server}) => {
+it('should not leak listeners during 20 waitForNavigation', async ({ page, server }) => {
   let warning = null;
   const warningHandler = w => warning = w;
   process.on('warning', warningHandler);
@@ -393,7 +393,7 @@ it('should not leak listeners during 20 waitForNavigation', async ({page, server
   expect(warning).toBe(null);
 });
 
-it('should navigate to dataURL and not fire dataURL requests', async ({page, server}) => {
+it('should navigate to dataURL and not fire dataURL requests', async ({ page, server }) => {
   const requests = [];
   page.on('request', request => requests.push(request));
   const dataURL = 'data:text/html,<div>yo</div>';
@@ -402,7 +402,7 @@ it('should navigate to dataURL and not fire dataURL requests', async ({page, ser
   expect(requests.length).toBe(0);
 });
 
-it('should navigate to URL with hash and fire requests without hash', async ({page, server}) => {
+it('should navigate to URL with hash and fire requests without hash', async ({ page, server }) => {
   const requests = [];
   page.on('request', request => requests.push(request));
   const response = await page.goto(server.EMPTY_PAGE + '#hash');
@@ -412,13 +412,13 @@ it('should navigate to URL with hash and fire requests without hash', async ({pa
   expect(requests[0].url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should work with self requesting page', async ({page, server}) => {
+it('should work with self requesting page', async ({ page, server }) => {
   const response = await page.goto(server.PREFIX + '/self-request.html');
   expect(response.status()).toBe(200);
   expect(response.url()).toContain('self-request.html');
 });
 
-it('should fail when navigating and show the url at the error message', async function({page, server, httpsServer}) {
+it('should fail when navigating and show the url at the error message', async function({ page, server, httpsServer }) {
   const url = httpsServer.PREFIX + '/redirect/1.html';
   let error = null;
   try {
@@ -429,13 +429,13 @@ it('should fail when navigating and show the url at the error message', async fu
   expect(error.message).toContain(url);
 });
 
-it('should be able to navigate to a page controlled by service worker', async ({page, server}) => {
+it('should be able to navigate to a page controlled by service worker', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/serviceworkers/fetch/sw.html');
   await page.evaluate(() => window['activationPromise']);
   await page.goto(server.PREFIX + '/serviceworkers/fetch/sw.html');
 });
 
-it('should send referer', async ({page, server}) => {
+it('should send referer', async ({ page, server }) => {
   const [request1, request2] = await Promise.all([
     server.waitForRequest('/grid.html'),
     server.waitForRequest('/digits/1.png'),
@@ -449,7 +449,7 @@ it('should send referer', async ({page, server}) => {
   expect(page.url()).toBe(server.PREFIX + '/grid.html');
 });
 
-it('should reject referer option when setExtraHTTPHeaders provides referer', async ({page, server}) => {
+it('should reject referer option when setExtraHTTPHeaders provides referer', async ({ page, server }) => {
   await page.setExtraHTTPHeaders({ 'referer': 'http://microsoft.com/' });
   let error;
   await page.goto(server.PREFIX + '/grid.html', {
@@ -459,7 +459,7 @@ it('should reject referer option when setExtraHTTPHeaders provides referer', asy
   expect(error.message).toContain(server.PREFIX + '/grid.html');
 });
 
-it('should override referrer-policy', async ({page, server}) => {
+it('should override referrer-policy', async ({ page, server }) => {
   server.setRoute('/grid.html', (req, res) => {
     res.setHeader('Referrer-Policy', 'no-referrer');
     server.serveFile(req, res);
@@ -477,7 +477,7 @@ it('should override referrer-policy', async ({page, server}) => {
   expect(page.url()).toBe(server.PREFIX + '/grid.html');
 });
 
-it('should fail when canceled by another navigation', async ({page, server}) => {
+it('should fail when canceled by another navigation', async ({ page, server }) => {
   server.setRoute('/one-style.html', (req, res) => {});
   const failed = page.goto(server.PREFIX + '/one-style.html').catch(e => e);
   await server.waitForRequest('/one-style.html');
@@ -486,7 +486,7 @@ it('should fail when canceled by another navigation', async ({page, server}) => 
   expect(error.message).toBeTruthy();
 });
 
-it('should work with lazy loading iframes', async ({page, server, isElectron, isAndroid}) => {
+it('should work with lazy loading iframes', async ({ page, server, isElectron, isAndroid }) => {
   it.fixme(isElectron);
   it.fixme(isAndroid);
 
@@ -494,7 +494,7 @@ it('should work with lazy loading iframes', async ({page, server, isElectron, is
   expect(page.frames().length).toBe(2);
 });
 
-it('should report raw buffer for main resource', async ({page, server, browserName, platform}) => {
+it('should report raw buffer for main resource', async ({ page, server, browserName, platform }) => {
   it.fail(browserName === 'chromium', 'Chromium sends main resource as text');
   it.fail(browserName === 'webkit' && platform === 'win32', 'Same here');
 
@@ -507,7 +507,7 @@ it('should report raw buffer for main resource', async ({page, server, browserNa
   expect(body.toString()).toBe('Ü (lowercase ü)');
 });
 
-it('should not throw unhandled rejections on invalid url', async ({page, server}) => {
+it('should not throw unhandled rejections on invalid url', async ({ page, server }) => {
   const e = await page.goto('https://www.youtube Panel Title.com/').catch(e => e);
   expect(e.toString()).toContain('Panel Title');
 });
@@ -537,11 +537,11 @@ it('should not crash when RTCPeerConnection is used', async ({ page, server, bro
   });
 });
 
-it('should properly wait for load', async ({page, server, browserName}) => {
+it('should properly wait for load', async ({ page, server, browserName }) => {
   it.fixme(browserName === 'webkit', 'WebKit has a bug where Page.frameStoppedLoading is sent too early.');
   server.setRoute('/slow.js', async (req, res) => {
     await new Promise(x => setTimeout(x, 100));
-    res.writeHead(200, {'Content-Type': 'application/javascript'});
+    res.writeHead(200, { 'Content-Type': 'application/javascript' });
     res.end(`window.results.push('slow module');export const foo = 'slow';`);
   });
   await page.goto(server.PREFIX + '/load-event/load-event.html');

--- a/tests/page/page-history.spec.ts
+++ b/tests/page/page-history.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import url from 'url';
 
-it('page.goBack should work', async ({page, server}) => {
+it('page.goBack should work', async ({ page, server }) => {
   expect(await page.goBack()).toBe(null);
 
   await page.goto(server.EMPTY_PAGE);
@@ -36,7 +36,7 @@ it('page.goBack should work', async ({page, server}) => {
   expect(response).toBe(null);
 });
 
-it('page.goBack should work with HistoryAPI', async ({page, server}) => {
+it('page.goBack should work with HistoryAPI', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => {
     history.pushState({}, '', '/first.html');
@@ -52,7 +52,7 @@ it('page.goBack should work with HistoryAPI', async ({page, server}) => {
   expect(page.url()).toBe(server.PREFIX + '/first.html');
 });
 
-it('page.goBack should work for file urls', async ({page, server, asset, browserName, platform, isAndroid}) => {
+it('page.goBack should work for file urls', async ({ page, server, asset, browserName, platform, isAndroid }) => {
   it.fail(browserName === 'webkit' && platform === 'darwin');
   it.skip(isAndroid, 'No files on Android');
 
@@ -80,21 +80,21 @@ it('page.goBack should work for file urls', async ({page, server, asset, browser
   await page.screenshot();
 });
 
-it('page.reload should work', async ({page, server}) => {
+it('page.reload should work', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => window['_foo'] = 10);
   await page.reload();
   expect(await page.evaluate(() => window['_foo'])).toBe(undefined);
 });
 
-it('page.reload should work with data url', async ({page, server}) => {
+it('page.reload should work with data url', async ({ page, server }) => {
   await page.goto('data:text/html,hello');
   expect(await page.content()).toContain('hello');
   expect(await page.reload()).toBe(null);
   expect(await page.content()).toContain('hello');
 });
 
-it('page.reload during renderer-initiated navigation', async ({page, server}) => {
+it('page.reload during renderer-initiated navigation', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/one-style.html');
   await page.setContent(`<form method='POST' action='/post'>Form is here<input type='submit'></form>`);
   server.setRoute('/post', (req, res) => {});
@@ -114,7 +114,7 @@ it('page.reload during renderer-initiated navigation', async ({page, server}) =>
   await page.waitForSelector('text=hello');
 });
 
-it('page.goBack during renderer-initiated navigation', async ({page, server}) => {
+it('page.goBack during renderer-initiated navigation', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/one-style.html');
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<form method='POST' action='/post'>Form is here<input type='submit'></form>`);
@@ -135,7 +135,7 @@ it('page.goBack during renderer-initiated navigation', async ({page, server}) =>
   await page.waitForSelector('text=hello');
 });
 
-it('page.goForward during renderer-initiated navigation', async ({page, server}) => {
+it('page.goForward during renderer-initiated navigation', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.goto(server.PREFIX + '/one-style.html');
   await page.goBack();

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -20,7 +20,7 @@ import { attachFrame } from '../config/utils';
 
 it.skip(({ isAndroid }) => isAndroid);
 
-it('should type into a textarea', async ({page}) => {
+it('should type into a textarea', async ({ page }) => {
   await page.evaluate(() => {
     const textarea = document.createElement('textarea');
     document.body.appendChild(textarea);
@@ -31,7 +31,7 @@ it('should type into a textarea', async ({page}) => {
   expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe(text);
 });
 
-it('should move with the arrow keys', async ({page, server}) => {
+it('should move with the arrow keys', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.type('textarea', 'Hello World!');
   expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('Hello World!');
@@ -47,7 +47,7 @@ it('should move with the arrow keys', async ({page, server}) => {
   expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('Hello World!');
 });
 
-it('should send a character with ElementHandle.press', async ({page, server}) => {
+it('should send a character with ElementHandle.press', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   const textarea = await page.$('textarea');
   await textarea.press('a');
@@ -59,7 +59,7 @@ it('should send a character with ElementHandle.press', async ({page, server}) =>
   expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('a');
 });
 
-it('should send a character with insertText', async ({page, server}) => {
+it('should send a character with insertText', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.focus('textarea');
   await page.keyboard.insertText('嗨');
@@ -69,7 +69,7 @@ it('should send a character with insertText', async ({page, server}) => {
   expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('嗨a');
 });
 
-it('insertText should only emit input event', async ({page, server}) => {
+it('insertText should only emit input event', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.focus('textarea');
   page.on('console', m => console.log(m.text()));
@@ -85,12 +85,12 @@ it('insertText should only emit input event', async ({page, server}) => {
   expect(await events.jsonValue()).toEqual(['input']);
 });
 
-it('should report shiftKey', async ({page, server, browserName, platform}) => {
+it('should report shiftKey', async ({ page, server, browserName, platform }) => {
   it.fail(browserName === 'firefox' && platform === 'darwin');
 
   await page.goto(server.PREFIX + '/input/keyboard.html');
   const keyboard = page.keyboard;
-  const codeForKey = {'Shift': 16, 'Alt': 18, 'Control': 17};
+  const codeForKey = { 'Shift': 16, 'Alt': 18, 'Control': 17 };
   for (const modifierKey in codeForKey) {
     await keyboard.down(modifierKey);
     expect(await page.evaluate('getResult()')).toBe('Keydown: ' + modifierKey + ' ' + modifierKey + 'Left ' + codeForKey[modifierKey] + ' [' + modifierKey + ']');
@@ -108,7 +108,7 @@ it('should report shiftKey', async ({page, server, browserName, platform}) => {
   }
 });
 
-it('should report multiple modifiers', async ({page, server}) => {
+it('should report multiple modifiers', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/keyboard.html');
   const keyboard = page.keyboard;
   await keyboard.down('Control');
@@ -125,7 +125,7 @@ it('should report multiple modifiers', async ({page, server}) => {
   expect(await page.evaluate('getResult()')).toBe('Keyup: Alt AltLeft 18 []');
 });
 
-it('should send proper codes while typing', async ({page, server}) => {
+it('should send proper codes while typing', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/keyboard.html');
   await page.keyboard.type('!');
   expect(await page.evaluate('getResult()')).toBe(
@@ -139,7 +139,7 @@ it('should send proper codes while typing', async ({page, server}) => {
         'Keyup: ^ Digit6 54 []'].join('\n'));
 });
 
-it('should send proper codes while typing with shift', async ({page, server}) => {
+it('should send proper codes while typing with shift', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/keyboard.html');
   const keyboard = page.keyboard;
   await keyboard.down('Shift');
@@ -152,7 +152,7 @@ it('should send proper codes while typing with shift', async ({page, server}) =>
   await keyboard.up('Shift');
 });
 
-it('should not type canceled events', async ({page, server}) => {
+it('should not type canceled events', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.focus('textarea');
   await page.evaluate(() => {
@@ -169,7 +169,7 @@ it('should not type canceled events', async ({page, server}) => {
   expect(await page.$eval('textarea', textarea => textarea.value)).toBe('He Wrd!');
 });
 
-it('should press plus', async ({page, server}) => {
+it('should press plus', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/keyboard.html');
   await page.keyboard.press('+');
   expect(await page.evaluate('getResult()')).toBe(
@@ -178,7 +178,7 @@ it('should press plus', async ({page, server}) => {
         'Keyup: + Equal 187 []'].join('\n'));
 });
 
-it('should press shift plus', async ({page, server}) => {
+it('should press shift plus', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/keyboard.html');
   await page.keyboard.press('Shift++');
   expect(await page.evaluate('getResult()')).toBe(
@@ -189,7 +189,7 @@ it('should press shift plus', async ({page, server}) => {
         'Keyup: Shift ShiftLeft 16 []'].join('\n'));
 });
 
-it('should support plus-separated modifiers', async ({page, server}) => {
+it('should support plus-separated modifiers', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/keyboard.html');
   await page.keyboard.press('Shift+~');
   expect(await page.evaluate('getResult()')).toBe(
@@ -200,7 +200,7 @@ it('should support plus-separated modifiers', async ({page, server}) => {
         'Keyup: Shift ShiftLeft 16 []'].join('\n'));
 });
 
-it('should support multiple plus-separated modifiers', async ({page, server}) => {
+it('should support multiple plus-separated modifiers', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/keyboard.html');
   await page.keyboard.press('Control+Shift+~');
   expect(await page.evaluate('getResult()')).toBe(
@@ -212,7 +212,7 @@ it('should support multiple plus-separated modifiers', async ({page, server}) =>
         'Keyup: Control ControlLeft 17 []'].join('\n'));
 });
 
-it('should shift raw codes', async ({page, server}) => {
+it('should shift raw codes', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/keyboard.html');
   await page.keyboard.press('Shift+Digit3');
   expect(await page.evaluate('getResult()')).toBe(
@@ -223,7 +223,7 @@ it('should shift raw codes', async ({page, server}) => {
         'Keyup: Shift ShiftLeft 16 []'].join('\n'));
 });
 
-it('should specify repeat property', async ({page, server}) => {
+it('should specify repeat property', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.focus('textarea');
   const lastEvent = await captureLastKeydown(page);
@@ -242,7 +242,7 @@ it('should specify repeat property', async ({page, server}) => {
   expect(await lastEvent.evaluate(e => e.repeat)).toBe(false);
 });
 
-it('should type all kinds of characters', async ({page, server}) => {
+it('should type all kinds of characters', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.focus('textarea');
   const text = 'This text goes onto two lines.\nThis character is 嗨.';
@@ -250,7 +250,7 @@ it('should type all kinds of characters', async ({page, server}) => {
   expect(await page.$eval('textarea', t => t.value)).toBe(text);
 });
 
-it('should specify location', async ({page, server}) => {
+it('should specify location', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   const lastEvent = await captureLastKeydown(page);
   const textarea = await page.$('textarea');
@@ -268,7 +268,7 @@ it('should specify location', async ({page, server}) => {
   expect(await lastEvent.evaluate(e => e.location)).toBe(3);
 });
 
-it('should press Enter', async ({page, server}) => {
+it('should press Enter', async ({ page, server }) => {
   await page.setContent('<textarea></textarea>');
   await page.focus('textarea');
   const lastEventHandle = await captureLastKeydown(page);
@@ -288,7 +288,7 @@ it('should press Enter', async ({page, server}) => {
   }
 });
 
-it('should throw on unknown keys', async ({page, server}) => {
+it('should throw on unknown keys', async ({ page, server }) => {
   let error = await page.keyboard.press('NotARealKey').catch(e => e);
   expect(error.message).toContain('Unknown key: "NotARealKey"');
 
@@ -299,13 +299,13 @@ it('should throw on unknown keys', async ({page, server}) => {
   expect(error && error.message).toContain('Unknown key: "😊"');
 });
 
-it('should type emoji', async ({page, server}) => {
+it('should type emoji', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.type('textarea', '👹 Tokyo street Japan 🇯🇵');
   expect(await page.$eval('textarea', textarea => textarea.value)).toBe('👹 Tokyo street Japan 🇯🇵');
 });
 
-it('should type emoji into an iframe', async ({page, server}) => {
+it('should type emoji into an iframe', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await attachFrame(page, 'emoji-test', server.PREFIX + '/input/textarea.html');
   const frame = page.frames()[1];
@@ -314,7 +314,7 @@ it('should type emoji into an iframe', async ({page, server}) => {
   expect(await frame.$eval('textarea', textarea => textarea.value)).toBe('👹 Tokyo street Japan 🇯🇵');
 });
 
-it('should handle selectAll', async ({page, server, isMac}) => {
+it('should handle selectAll', async ({ page, server, isMac }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   const textarea = await page.$('textarea');
   await textarea.type('some text');
@@ -326,7 +326,7 @@ it('should handle selectAll', async ({page, server, isMac}) => {
   expect(await page.$eval('textarea', textarea => textarea.value)).toBe('');
 });
 
-it('should be able to prevent selectAll', async ({page, server, isMac}) => {
+it('should be able to prevent selectAll', async ({ page, server, isMac }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   const textarea = await page.$('textarea');
   await textarea.type('some text');
@@ -344,7 +344,7 @@ it('should be able to prevent selectAll', async ({page, server, isMac}) => {
   expect(await page.$eval('textarea', textarea => textarea.value)).toBe('some tex');
 });
 
-it('should support MacOS shortcuts', async ({page, server, platform, browserName}) => {
+it('should support MacOS shortcuts', async ({ page, server, platform, browserName }) => {
   it.skip(platform !== 'darwin');
   // @see https://github.com/microsoft/playwright/issues/5721
   it.fixme(browserName === 'firefox' && platform === 'darwin');
@@ -358,10 +358,10 @@ it('should support MacOS shortcuts', async ({page, server, platform, browserName
   expect(await page.$eval('textarea', textarea => textarea.value)).toBe('some ');
 });
 
-it('should press the meta key', async ({page, browserName, isMac}) => {
+it('should press the meta key', async ({ page, browserName, isMac }) => {
   const lastEvent = await captureLastKeydown(page);
   await page.keyboard.press('Meta');
-  const {key, code, metaKey} = await lastEvent.jsonValue();
+  const { key, code, metaKey } = await lastEvent.jsonValue();
   if (browserName === 'firefox' && !isMac)
     expect(key).toBe('OS');
   else
@@ -379,7 +379,7 @@ it('should press the meta key', async ({page, browserName, isMac}) => {
 
 });
 
-it('should work after a cross origin navigation', async ({page, server}) => {
+it('should work after a cross origin navigation', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/empty.html');
   await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
   const lastEvent = await captureLastKeydown(page);
@@ -387,7 +387,7 @@ it('should work after a cross origin navigation', async ({page, server}) => {
   expect(await lastEvent.evaluate(l => l.key)).toBe('a');
 });
 
-it('should expose keyIdentifier in webkit', async ({page, browserName}) => {
+it('should expose keyIdentifier in webkit', async ({ page, browserName }) => {
   it.skip(browserName !== 'webkit', 'event.keyIdentifier has been removed from all browsers except WebKit');
 
   const lastEvent = await captureLastKeydown(page);
@@ -409,7 +409,7 @@ it('should expose keyIdentifier in webkit', async ({page, browserName}) => {
   }
 });
 
-it('should scroll with PageDown', async ({page, server}) => {
+it('should scroll with PageDown', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
   // A click is required for WebKit to send the event into the body.
   await page.click('body');
@@ -418,7 +418,7 @@ it('should scroll with PageDown', async ({page, server}) => {
   await page.waitForFunction(() => scrollY > 0);
 });
 
-it('should move around the selection in a contenteditable', async ({page, isMac}) => {
+it('should move around the selection in a contenteditable', async ({ page, isMac }) => {
   await page.setContent(`<div contenteditable></div>`);
   await page.focus('div');
   const modifier = isMac ? 'Alt' : 'Control';
@@ -431,7 +431,7 @@ it('should move around the selection in a contenteditable', async ({page, isMac}
   expect(await page.evaluate(() => window.getSelection().toString())).toBe('World');
 });
 
-it('should move to the start of the document', async ({page, isMac}) => {
+it('should move to the start of the document', async ({ page, isMac }) => {
   it.skip(!isMac);
   await page.setContent(`<div contenteditable></div>`);
   await page.focus('div');

--- a/tests/page/page-mouse.spec.ts
+++ b/tests/page/page-mouse.spec.ts
@@ -27,7 +27,7 @@ function dimensions() {
   };
 }
 
-it('should click the document', async ({page, server}) => {
+it('should click the document', async ({ page, server }) => {
   await page.evaluate(() => {
     window['clickPromise'] = new Promise(resolve => {
       document.addEventListener('click', event => {
@@ -52,7 +52,7 @@ it('should click the document', async ({page, server}) => {
   expect(event.button).toBe(0);
 });
 
-it('should dblclick the div', async ({page, server}) => {
+it('should dblclick the div', async ({ page, server }) => {
   await page.setContent(`<div style='width: 100px; height: 100px;'>Click me</div>`);
   await page.evaluate(() => {
     window['dblclickPromise'] = new Promise(resolve => {
@@ -78,7 +78,7 @@ it('should dblclick the div', async ({page, server}) => {
   expect(event.button).toBe(0);
 });
 
-it('should select the text with mouse', async ({page, server}) => {
+it('should select the text with mouse', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.focus('textarea');
   const text = 'This is the text that we are going to try to select. Let\'s see how it goes.';
@@ -86,7 +86,7 @@ it('should select the text with mouse', async ({page, server}) => {
   // Firefox needs an extra frame here after typing or it will fail to set the scrollTop
   await page.evaluate(() => new Promise(requestAnimationFrame));
   await page.evaluate(() => document.querySelector('textarea').scrollTop = 0);
-  const {x, y} = await page.evaluate(dimensions);
+  const { x, y } = await page.evaluate(dimensions);
   await page.mouse.move(x + 2,y + 2);
   await page.mouse.down();
   await page.mouse.move(200,200);
@@ -97,7 +97,7 @@ it('should select the text with mouse', async ({page, server}) => {
   })).toBe(text);
 });
 
-it('should trigger hover state', async ({page, server}) => {
+it('should trigger hover state', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
   await page.hover('#button-6');
   expect(await page.evaluate(() => document.querySelector('button:hover').id)).toBe('button-6');
@@ -107,24 +107,24 @@ it('should trigger hover state', async ({page, server}) => {
   expect(await page.evaluate(() => document.querySelector('button:hover').id)).toBe('button-91');
 });
 
-it('should trigger hover state on disabled button', async ({page, server}) => {
+it('should trigger hover state on disabled button', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
   await page.$eval('#button-6', (button: HTMLButtonElement) => button.disabled = true);
   await page.hover('#button-6', { timeout: 5000 });
   expect(await page.evaluate(() => document.querySelector('button:hover').id)).toBe('button-6');
 });
 
-it('should trigger hover state with removed window.Node', async ({page, server}) => {
+it('should trigger hover state with removed window.Node', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
   await page.evaluate(() => delete window.Node);
   await page.hover('#button-6');
   expect(await page.evaluate(() => document.querySelector('button:hover').id)).toBe('button-6');
 });
 
-it('should set modifier keys on click', async ({page, server, browserName, isMac}) => {
+it('should set modifier keys on click', async ({ page, server, browserName, isMac }) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
   await page.evaluate(() => document.querySelector('#button-3').addEventListener('mousedown', e => window['lastEvent'] = e, true));
-  const modifiers = {'Shift': 'shiftKey', 'Control': 'ctrlKey', 'Alt': 'altKey', 'Meta': 'metaKey'};
+  const modifiers = { 'Shift': 'shiftKey', 'Control': 'ctrlKey', 'Alt': 'altKey', 'Meta': 'metaKey' };
   // In Firefox, the Meta modifier only exists on Mac
   if (browserName === 'firefox' && !isMac)
     delete modifiers['Meta'];
@@ -142,7 +142,7 @@ it('should set modifier keys on click', async ({page, server, browserName, isMac
   }
 });
 
-it('should tween mouse movement', async ({page, browserName, isAndroid}) => {
+it('should tween mouse movement', async ({ page, browserName, isAndroid }) => {
   it.skip(isAndroid, 'Bad rounding');
 
   // The test becomes flaky on WebKit without next line.
@@ -155,7 +155,7 @@ it('should tween mouse movement', async ({page, browserName, isAndroid}) => {
       window['result'].push([event.clientX, event.clientY]);
     });
   });
-  await page.mouse.move(200, 300, {steps: 5});
+  await page.mouse.move(200, 300, { steps: 5 });
   expect(await page.evaluate('result')).toEqual([
     [120, 140],
     [140, 180],

--- a/tests/page/page-navigation.spec.ts
+++ b/tests/page/page-navigation.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it } from './pageTest';
 
-it('should work with _blank target', async ({page, server}) => {
+it('should work with _blank target', async ({ page, server }) => {
   server.setRoute('/empty.html', (req, res) => {
     res.end(`<a href="${server.EMPTY_PAGE}" target="_blank">Click me</a>`);
   });
@@ -25,7 +25,7 @@ it('should work with _blank target', async ({page, server}) => {
   await page.click('"Click me"');
 });
 
-it('should work with cross-process _blank target', async ({page, server}) => {
+it('should work with cross-process _blank target', async ({ page, server }) => {
   server.setRoute('/empty.html', (req, res) => {
     res.end(`<a href="${server.CROSS_PROCESS_PREFIX}/empty.html" target="_blank">Click me</a>`);
   });

--- a/tests/page/page-network-idle.spec.ts
+++ b/tests/page/page-network-idle.spec.ts
@@ -19,7 +19,7 @@ import { test as it, expect } from './pageTest';
 import type { Frame } from '../../index';
 import { TestServer } from '../../utils/testserver';
 
-it('should navigate to empty page with networkidle', async ({page, server}) => {
+it('should navigate to empty page with networkidle', async ({ page, server }) => {
   const response = await page.goto(server.EMPTY_PAGE, { waitUntil: 'networkidle' });
   expect(response.status()).toBe(200);
 });
@@ -80,13 +80,13 @@ async function networkIdleTest(frame: Frame, server: TestServer, action: () => P
     expect(response.ok()).toBe(true);
 }
 
-it('should wait for networkidle to succeed navigation', async ({page, server}) => {
+it('should wait for networkidle to succeed navigation', async ({ page, server }) => {
   await networkIdleTest(page.mainFrame(), server, () => {
     return page.goto(server.PREFIX + '/networkidle.html', { waitUntil: 'networkidle' });
   });
 });
 
-it('should wait for networkidle to succeed navigation with request from previous navigation', async ({page, server}) => {
+it('should wait for networkidle to succeed navigation with request from previous navigation', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   server.setRoute('/foo.js', () => {});
   await page.setContent(`<script>fetch('foo.js');</script>`);
@@ -95,7 +95,7 @@ it('should wait for networkidle to succeed navigation with request from previous
   });
 });
 
-it('should wait for networkidle in waitForNavigation', async ({page, server}) => {
+it('should wait for networkidle in waitForNavigation', async ({ page, server }) => {
   await networkIdleTest(page.mainFrame(), server, () => {
     const promise = page.waitForNavigation({ waitUntil: 'networkidle' });
     page.goto(server.PREFIX + '/networkidle.html');
@@ -103,14 +103,14 @@ it('should wait for networkidle in waitForNavigation', async ({page, server}) =>
   });
 });
 
-it('should wait for networkidle in setContent', async ({page, server}) => {
+it('should wait for networkidle in setContent', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await networkIdleTest(page.mainFrame(), server, () => {
     return page.setContent(`<script src='networkidle.js'></script>`, { waitUntil: 'networkidle' });
   }, true);
 });
 
-it('should wait for networkidle in setContent with request from previous navigation', async ({page, server}) => {
+it('should wait for networkidle in setContent with request from previous navigation', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   server.setRoute('/foo.js', () => {});
   await page.setContent(`<script>fetch('foo.js');</script>`);
@@ -119,26 +119,26 @@ it('should wait for networkidle in setContent with request from previous navigat
   }, true);
 });
 
-it('should wait for networkidle when navigating iframe', async ({page, server}) => {
+it('should wait for networkidle when navigating iframe', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   const frame = page.mainFrame().childFrames()[0];
   await networkIdleTest(frame, server, () => frame.goto(server.PREFIX + '/networkidle.html', { waitUntil: 'networkidle' }));
 });
 
-it('should wait for networkidle in setContent from the child frame', async ({page, server}) => {
+it('should wait for networkidle in setContent from the child frame', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await networkIdleTest(page.mainFrame(), server, () => {
     return page.setContent(`<iframe src='networkidle.html'></iframe>`, { waitUntil: 'networkidle' });
   }, true);
 });
 
-it('should wait for networkidle from the child frame', async ({page, server}) => {
+it('should wait for networkidle from the child frame', async ({ page, server }) => {
   await networkIdleTest(page.mainFrame(), server, () => {
     return page.goto(server.PREFIX + '/networkidle-frame.html', { waitUntil: 'networkidle' });
   });
 });
 
-it('should wait for networkidle from the popup', async ({page, server, isAndroid}) => {
+it('should wait for networkidle from the popup', async ({ page, server, isAndroid }) => {
   it.skip(isAndroid, 'Too slow');
 
   await page.goto(server.EMPTY_PAGE);

--- a/tests/page/page-network-request.spec.ts
+++ b/tests/page/page-network-request.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import { attachFrame } from '../config/utils';
 
-it('should work for main frame navigation request', async ({page, server}) => {
+it('should work for main frame navigation request', async ({ page, server }) => {
   const requests = [];
   page.on('request', request => requests.push(request));
   await page.goto(server.EMPTY_PAGE);
@@ -26,7 +26,7 @@ it('should work for main frame navigation request', async ({page, server}) => {
   expect(requests[0].frame()).toBe(page.mainFrame());
 });
 
-it('should work for subframe navigation request', async ({page, server}) => {
+it('should work for subframe navigation request', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const requests = [];
   page.on('request', request => requests.push(request));
@@ -35,7 +35,7 @@ it('should work for subframe navigation request', async ({page, server}) => {
   expect(requests[0].frame()).toBe(page.frames()[1]);
 });
 
-it('should work for fetch requests', async ({page, server}) => {
+it('should work for fetch requests', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const requests = [];
   page.on('request', request => requests.push(request));
@@ -44,7 +44,7 @@ it('should work for fetch requests', async ({page, server}) => {
   expect(requests[0].frame()).toBe(page.mainFrame());
 });
 
-it('should work for a redirect', async ({page, server}) => {
+it('should work for a redirect', async ({ page, server }) => {
   server.setRedirect('/foo.html', '/empty.html');
   const requests = [];
   page.on('request', request => requests.push(request));
@@ -56,7 +56,7 @@ it('should work for a redirect', async ({page, server}) => {
 });
 
 // https://github.com/microsoft/playwright/issues/3993
-it('should not work for a redirect and interception', async ({page, server}) => {
+it('should not work for a redirect and interception', async ({ page, server }) => {
   server.setRedirect('/foo.html', '/empty.html');
   const requests = [];
   await page.route('**', route => {
@@ -71,7 +71,7 @@ it('should not work for a redirect and interception', async ({page, server}) => 
   expect(requests[0].url()).toBe(server.PREFIX + '/foo.html');
 });
 
-it('should return headers', async ({page, server, browserName}) => {
+it('should return headers', async ({ page, server, browserName }) => {
   const response = await page.goto(server.EMPTY_PAGE);
   if (browserName === 'chromium')
     expect(response.request().headers()['user-agent']).toContain('Chrome');
@@ -93,7 +93,7 @@ it('should get the same headers as the server', async ({ page, server, browserNa
   expect(headers).toEqual(serverRequest.headers);
 });
 
-it('should get the same headers as the server CORS', async ({page, server, browserName, platform}) => {
+it('should get the same headers as the server CORS', async ({ page, server, browserName, platform }) => {
   it.fail(browserName === 'webkit' && platform === 'win32', 'Curl does not show accept-encoding and accept-language');
 
   await page.goto(server.PREFIX + '/empty.html');
@@ -114,19 +114,19 @@ it('should get the same headers as the server CORS', async ({page, server, brows
   expect(headers).toEqual(serverRequest.headers);
 });
 
-it('should return postData', async ({page, server, isAndroid}) => {
+it('should return postData', async ({ page, server, isAndroid }) => {
   it.fixme(isAndroid, 'Post data does not work');
 
   await page.goto(server.EMPTY_PAGE);
   server.setRoute('/post', (req, res) => res.end());
   let request = null;
   page.on('request', r => request = r);
-  await page.evaluate(() => fetch('./post', { method: 'POST', body: JSON.stringify({foo: 'bar'})}));
+  await page.evaluate(() => fetch('./post', { method: 'POST', body: JSON.stringify({ foo: 'bar' }) }));
   expect(request).toBeTruthy();
   expect(request.postData()).toBe('{"foo":"bar"}');
 });
 
-it('should work with binary post data', async ({page, server, isAndroid}) => {
+it('should work with binary post data', async ({ page, server, isAndroid }) => {
   it.fixme(isAndroid, 'Post data does not work');
 
   await page.goto(server.EMPTY_PAGE);
@@ -143,7 +143,7 @@ it('should work with binary post data', async ({page, server, isAndroid}) => {
     expect(buffer[i]).toBe(i);
 });
 
-it('should work with binary post data and interception', async ({page, server, isAndroid}) => {
+it('should work with binary post data and interception', async ({ page, server, isAndroid }) => {
   it.fixme(isAndroid, 'Post data does not work');
 
   await page.goto(server.EMPTY_PAGE);
@@ -161,7 +161,7 @@ it('should work with binary post data and interception', async ({page, server, i
     expect(buffer[i]).toBe(i);
 });
 
-it('should override post data content type', async ({page, server, isAndroid}) => {
+it('should override post data content type', async ({ page, server, isAndroid }) => {
   it.fixme(isAndroid, 'Post data does not work');
 
   await page.goto(server.EMPTY_PAGE);
@@ -185,7 +185,7 @@ it('should override post data content type', async ({page, server, isAndroid}) =
   expect(request.headers['content-type']).toBe('application/x-www-form-urlencoded; charset=UTF-8');
 });
 
-it('should get |undefined| with postData() when there is no post data', async ({page, server, isAndroid}) => {
+it('should get |undefined| with postData() when there is no post data', async ({ page, server, isAndroid }) => {
   it.fixme(isAndroid, 'Post data does not work');
 
   const response = await page.goto(server.EMPTY_PAGE);
@@ -204,7 +204,7 @@ it('should parse the json post data', async ({ page, server, isAndroid }) => {
   expect(request.postDataJSON()).toEqual({ 'foo': 'bar' });
 });
 
-it('should parse the data if content-type is application/x-www-form-urlencoded', async ({page, server, isAndroid}) => {
+it('should parse the data if content-type is application/x-www-form-urlencoded', async ({ page, server, isAndroid }) => {
   it.fixme(isAndroid, 'Post data does not work');
 
   await page.goto(server.EMPTY_PAGE);
@@ -214,7 +214,7 @@ it('should parse the data if content-type is application/x-www-form-urlencoded',
   await page.setContent(`<form method='POST' action='/post'><input type='text' name='foo' value='bar'><input type='number' name='baz' value='123'><input type='submit'></form>`);
   await page.click('input[type=submit]');
   expect(request).toBeTruthy();
-  expect(request.postDataJSON()).toEqual({'foo': 'bar','baz': '123'});
+  expect(request.postDataJSON()).toEqual({ 'foo': 'bar','baz': '123' });
 });
 
 it('should get |undefined| with postDataJSON() when there is no post data', async ({ page, server }) => {
@@ -222,8 +222,8 @@ it('should get |undefined| with postDataJSON() when there is no post data', asyn
   expect(response.request().postDataJSON()).toBe(null);
 });
 
-it('should return event source', async ({page, server}) => {
-  const SSE_MESSAGE = {foo: 'bar'};
+it('should return event source', async ({ page, server }) => {
+  const SSE_MESSAGE = { foo: 'bar' };
   // 1. Setup server-sent events on server that immediately sends a message to the client.
   server.setRoute('/sse', (req, res) => {
     res.writeHead(200, {
@@ -247,7 +247,7 @@ it('should return event source', async ({page, server}) => {
   expect(requests[0].resourceType()).toBe('eventsource');
 });
 
-it('should return navigation bit', async ({page, server}) => {
+it('should return navigation bit', async ({ page, server }) => {
   const requests = new Map();
   page.on('request', request => requests.set(request.url().split('/').pop(), request));
   server.setRedirect('/rrredirect', '/frames/one-frame.html');
@@ -259,7 +259,7 @@ it('should return navigation bit', async ({page, server}) => {
   expect(requests.get('style.css').isNavigationRequest()).toBe(false);
 });
 
-it('should return navigation bit when navigating to image', async ({page, server}) => {
+it('should return navigation bit when navigating to image', async ({ page, server }) => {
   const requests = [];
   page.on('request', request => requests.push(request));
   await page.goto(server.PREFIX + '/pptr.png');

--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import fs from 'fs';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('foo', 'bar');
     res.setHeader('BaZ', 'bAz');
@@ -30,7 +30,7 @@ it('should work', async ({page, server}) => {
   expect((await response.allHeaders())['BaZ']).toBe(undefined);
 });
 
-it('should return multiple header value', async ({page, server, browserName, platform}) => {
+it('should return multiple header value', async ({ page, server, browserName, platform }) => {
   it.fixme(browserName === 'webkit' && platform === 'win32', 'libcurl does not support non-set-cookie multivalue headers');
   server.setRoute('/headers', (req, res) => {
     // Headers array is only supported since Node v14.14.0 so we write directly to the socket.
@@ -49,19 +49,19 @@ it('should return multiple header value', async ({page, server, browserName, pla
   expect(response.headers()['name-a']).toBe('v1, v2, v3');
 });
 
-it('should return text', async ({page, server}) => {
+it('should return text', async ({ page, server }) => {
   const response = await page.goto(server.PREFIX + '/simple.json');
   expect(await response.text()).toBe('{"foo": "bar"}\n');
 });
 
-it('should return uncompressed text', async ({page, server}) => {
+it('should return uncompressed text', async ({ page, server }) => {
   server.enableGzip('/simple.json');
   const response = await page.goto(server.PREFIX + '/simple.json');
   expect(response.headers()['content-encoding']).toBe('gzip');
   expect(await response.text()).toBe('{"foo": "bar"}\n');
 });
 
-it('should throw when requesting body of redirected response', async ({page, server}) => {
+it('should throw when requesting body of redirected response', async ({ page, server }) => {
   server.setRedirect('/foo.html', '/empty.html');
   const response = await page.goto(server.PREFIX + '/foo.html');
   const redirectedFrom = response.request().redirectedFrom();
@@ -73,7 +73,7 @@ it('should throw when requesting body of redirected response', async ({page, ser
   expect(error.message).toContain('Response body is unavailable for redirect responses');
 });
 
-it('should wait until response completes', async ({page, server}) => {
+it('should wait until response completes', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   // Setup server to trap request.
   let serverResponse = null;
@@ -90,7 +90,7 @@ it('should wait until response completes', async ({page, server}) => {
   // send request and wait for server response
   const [pageResponse] = await Promise.all([
     page.waitForEvent('response'),
-    page.evaluate(() => fetch('./get', { method: 'GET'})),
+    page.evaluate(() => fetch('./get', { method: 'GET' })),
     server.waitForRequest('/get'),
   ]);
 
@@ -107,7 +107,7 @@ it('should wait until response completes', async ({page, server}) => {
   expect(await responseText).toBe('hello world!');
 });
 
-it('should reject response.finished if page closes', async ({page, server}) => {
+it('should reject response.finished if page closes', async ({ page, server }) => {
   it.fixme();
   await page.goto(server.EMPTY_PAGE);
   server.setRoute('/get', (req, res) => {
@@ -119,7 +119,7 @@ it('should reject response.finished if page closes', async ({page, server}) => {
   // send request and wait for server response
   const [pageResponse] = await Promise.all([
     page.waitForEvent('response'),
-    page.evaluate(() => fetch('./get', { method: 'GET'})),
+    page.evaluate(() => fetch('./get', { method: 'GET' })),
   ]);
 
   const finishPromise = pageResponse.finished().catch(e => e);
@@ -128,7 +128,7 @@ it('should reject response.finished if page closes', async ({page, server}) => {
   expect(error.message).toContain('closed');
 });
 
-it('should reject response.finished if context closes', async ({page, server}) => {
+it('should reject response.finished if context closes', async ({ page, server }) => {
   it.fixme();
   await page.goto(server.EMPTY_PAGE);
   server.setRoute('/get', (req, res) => {
@@ -140,7 +140,7 @@ it('should reject response.finished if context closes', async ({page, server}) =
   // send request and wait for server response
   const [pageResponse] = await Promise.all([
     page.waitForEvent('response'),
-    page.evaluate(() => fetch('./get', { method: 'GET'})),
+    page.evaluate(() => fetch('./get', { method: 'GET' })),
   ]);
 
   const finishPromise = pageResponse.finished().catch(e => e);
@@ -149,19 +149,19 @@ it('should reject response.finished if context closes', async ({page, server}) =
   expect(error.message).toContain('closed');
 });
 
-it('should return json', async ({page, server}) => {
+it('should return json', async ({ page, server }) => {
   const response = await page.goto(server.PREFIX + '/simple.json');
-  expect(await response.json()).toEqual({foo: 'bar'});
+  expect(await response.json()).toEqual({ foo: 'bar' });
 });
 
-it('should return body', async ({page, server, asset}) => {
+it('should return body', async ({ page, server, asset }) => {
   const response = await page.goto(server.PREFIX + '/pptr.png');
   const imageBuffer = fs.readFileSync(asset('pptr.png'));
   const responseBuffer = await response.body();
   expect(responseBuffer.equals(imageBuffer)).toBe(true);
 });
 
-it('should return body with compression', async ({page, server, asset}) => {
+it('should return body with compression', async ({ page, server, asset }) => {
   server.enableGzip('/pptr.png');
   const response = await page.goto(server.PREFIX + '/pptr.png');
   const imageBuffer = fs.readFileSync(asset('pptr.png'));
@@ -169,7 +169,7 @@ it('should return body with compression', async ({page, server, asset}) => {
   expect(responseBuffer.equals(imageBuffer)).toBe(true);
 });
 
-it('should return status text', async ({page, server}) => {
+it('should return status text', async ({ page, server }) => {
   server.setRoute('/cool', (req, res) => {
     res.writeHead(200, 'cool!');
     res.end();

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -17,12 +17,12 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.route('**/*', route => route.continue());
   await page.goto(server.EMPTY_PAGE);
 });
 
-it('should amend HTTP headers', async ({page, server}) => {
+it('should amend HTTP headers', async ({ page, server }) => {
   await page.route('**/*', route => {
     const headers = Object.assign({}, route.request().headers());
     headers['FOO'] = 'bar';
@@ -36,7 +36,7 @@ it('should amend HTTP headers', async ({page, server}) => {
   expect(request.headers['foo']).toBe('bar');
 });
 
-it('should amend method', async ({page, server}) => {
+it('should amend method', async ({ page, server }) => {
   const sRequest = server.waitForRequest('/sleep.zzz');
   await page.goto(server.EMPTY_PAGE);
   await page.route('**/*', route => route.continue({ method: 'POST' }));
@@ -48,7 +48,7 @@ it('should amend method', async ({page, server}) => {
   expect((await sRequest).method).toBe('POST');
 });
 
-it('should override request url', async ({page, server}) => {
+it('should override request url', async ({ page, server }) => {
   const request = server.waitForRequest('/global-var.html');
   await page.route('**/foo', route => {
     route.continue({ url: server.PREFIX + '/global-var.html' });
@@ -62,7 +62,7 @@ it('should override request url', async ({page, server}) => {
   expect((await request).method).toBe('GET');
 });
 
-it('should not allow changing protocol when overriding url', async ({page, server}) => {
+it('should not allow changing protocol when overriding url', async ({ page, server }) => {
   let error: Error | undefined;
   await page.route('**/*', async route => {
     try {
@@ -77,7 +77,7 @@ it('should not allow changing protocol when overriding url', async ({page, serve
   expect(error.message).toContain('New URL must have same protocol as overridden URL');
 });
 
-it('should override method along with url', async ({page, server}) => {
+it('should override method along with url', async ({ page, server }) => {
   const request = server.waitForRequest('/empty.html');
   await page.route('**/foo', route => {
     route.continue({
@@ -89,7 +89,7 @@ it('should override method along with url', async ({page, server}) => {
   expect((await request).method).toBe('POST');
 });
 
-it('should amend method on main request', async ({page, server}) => {
+it('should amend method on main request', async ({ page, server }) => {
   const request = server.waitForRequest('/empty.html');
   await page.route('**/*', route => route.continue({ method: 'POST' }));
   await page.goto(server.EMPTY_PAGE);
@@ -99,7 +99,7 @@ it('should amend method on main request', async ({page, server}) => {
 it.describe('', () => {
   it.fixme(({ isAndroid }) => isAndroid, 'Post data does not work');
 
-  it('should amend post data', async ({page, server}) => {
+  it('should amend post data', async ({ page, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await page.route('**/*', route => {
       route.continue({ postData: 'doggo' });
@@ -111,7 +111,7 @@ it.describe('', () => {
     expect((await serverRequest.postBody).toString('utf8')).toBe('doggo');
   });
 
-  it('should amend method and post data', async ({page, server}) => {
+  it('should amend method and post data', async ({ page, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await page.route('**/*', route => {
       route.continue({ method: 'POST', postData: 'doggo' });
@@ -124,7 +124,7 @@ it.describe('', () => {
     expect((await serverRequest.postBody).toString('utf8')).toBe('doggo');
   });
 
-  it('should amend utf8 post data', async ({page, server}) => {
+  it('should amend utf8 post data', async ({ page, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await page.route('**/*', route => {
       route.continue({ postData: 'пушкин' });
@@ -137,7 +137,7 @@ it.describe('', () => {
     expect((await serverRequest.postBody).toString('utf8')).toBe('пушкин');
   });
 
-  it('should amend longer post data', async ({page, server}) => {
+  it('should amend longer post data', async ({ page, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await page.route('**/*', route => {
       route.continue({ postData: 'doggo-is-longer-than-birdy' });
@@ -150,7 +150,7 @@ it.describe('', () => {
     expect((await serverRequest.postBody).toString('utf8')).toBe('doggo-is-longer-than-birdy');
   });
 
-  it('should amend binary post data', async ({page, server}) => {
+  it('should amend binary post data', async ({ page, server }) => {
     await page.goto(server.EMPTY_PAGE);
     const arr = Array.from(Array(256).keys());
     await page.route('**/*', route => {

--- a/tests/page/page-request-fulfill.spec.ts
+++ b/tests/page/page-request-fulfill.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import fs from 'fs';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.route('**/*', route => {
     route.fulfill({
       status: 201,
@@ -35,7 +35,7 @@ it('should work', async ({page, server}) => {
   expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
 });
 
-it('should work with buffer as body', async ({page, server, browserName, isLinux}) => {
+it('should work with buffer as body', async ({ page, server, browserName, isLinux }) => {
   it.fail(browserName === 'webkit' && isLinux, 'Loading of application/octet-stream resource fails');
   await page.route('**/*', route => {
     route.fulfill({
@@ -48,7 +48,7 @@ it('should work with buffer as body', async ({page, server, browserName, isLinux
   expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
 });
 
-it('should work with status code 422', async ({page, server}) => {
+it('should work with status code 422', async ({ page, server }) => {
   await page.route('**/*', route => {
     route.fulfill({
       status: 422,
@@ -61,7 +61,7 @@ it('should work with status code 422', async ({page, server}) => {
   expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
 });
 
-it('should allow mocking binary responses', async ({page, server, browserName, headless, asset, isAndroid}) => {
+it('should allow mocking binary responses', async ({ page, server, browserName, headless, asset, isAndroid }) => {
   it.skip(browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
   it.skip(isAndroid);
 
@@ -82,7 +82,7 @@ it('should allow mocking binary responses', async ({page, server, browserName, h
   expect(await img.screenshot()).toMatchSnapshot('mock-binary-response.png');
 });
 
-it('should allow mocking svg with charset', async ({page, server, browserName, headless, isAndroid}) => {
+it('should allow mocking svg with charset', async ({ page, server, browserName, headless, isAndroid }) => {
   it.skip(browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
   it.skip(isAndroid);
 
@@ -102,7 +102,7 @@ it('should allow mocking svg with charset', async ({page, server, browserName, h
   expect(await img.screenshot()).toMatchSnapshot('mock-svg.png');
 });
 
-it('should work with file path', async ({page, server, asset, isAndroid}) => {
+it('should work with file path', async ({ page, server, asset, isAndroid }) => {
   it.skip(isAndroid);
 
   await page.route('**/*', route => route.fulfill({ contentType: 'shouldBeIgnored', path: asset('pptr.png') }));
@@ -116,7 +116,7 @@ it('should work with file path', async ({page, server, asset, isAndroid}) => {
   expect(await img.screenshot()).toMatchSnapshot('mock-binary-response.png');
 });
 
-it('should stringify intercepted request response headers', async ({page, server}) => {
+it('should stringify intercepted request response headers', async ({ page, server }) => {
   await page.route('**/*', route => {
     route.fulfill({
       status: 200,
@@ -133,7 +133,7 @@ it('should stringify intercepted request response headers', async ({page, server
   expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
 });
 
-it('should not modify the headers sent to the server', async ({page, server}) => {
+it('should not modify the headers sent to the server', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/empty.html');
   const interceptedRequests = [];
 
@@ -170,7 +170,7 @@ it('should not modify the headers sent to the server', async ({page, server}) =>
   expect(interceptedRequests[1].headers).toEqual(interceptedRequests[0].headers);
 });
 
-it('should include the origin header', async ({page, server, isAndroid}) => {
+it('should include the origin header', async ({ page, server, isAndroid }) => {
   it.skip(isAndroid, 'No cross-process on Android');
 
   await page.goto(server.PREFIX + '/empty.html');
@@ -194,7 +194,7 @@ it('should include the origin header', async ({page, server, isAndroid}) => {
   expect(interceptedRequest.headers()['origin']).toEqual(server.PREFIX);
 });
 
-it('should fulfill with global fetch result', async ({playwright, page, server, isElectron}) => {
+it('should fulfill with global fetch result', async ({ playwright, page, server, isElectron }) => {
   it.fixme(isElectron, 'error: Browser context management is not supported.');
   await page.route('**/*', async route => {
     const request = await playwright._newRequest();
@@ -203,10 +203,10 @@ it('should fulfill with global fetch result', async ({playwright, page, server, 
   });
   const response = await page.goto(server.EMPTY_PAGE);
   expect(response.status()).toBe(200);
-  expect(await response.json()).toEqual({'foo': 'bar'});
+  expect(await response.json()).toEqual({ 'foo': 'bar' });
 });
 
-it('should fulfill with fetch result', async ({page, server, isElectron}) => {
+it('should fulfill with fetch result', async ({ page, server, isElectron }) => {
   it.fixme(isElectron, 'error: Browser context management is not supported.');
   await page.route('**/*', async route => {
     const response = await page._request.get(server.PREFIX + '/simple.json');
@@ -214,10 +214,10 @@ it('should fulfill with fetch result', async ({page, server, isElectron}) => {
   });
   const response = await page.goto(server.EMPTY_PAGE);
   expect(response.status()).toBe(200);
-  expect(await response.json()).toEqual({'foo': 'bar'});
+  expect(await response.json()).toEqual({ 'foo': 'bar' });
 });
 
-it('should fulfill with fetch result and overrides', async ({page, server, isElectron}) => {
+it('should fulfill with fetch result and overrides', async ({ page, server, isElectron }) => {
   it.fixme(isElectron, 'error: Browser context management is not supported.');
   await page.route('**/*', async route => {
     const response = await page._request.get(server.PREFIX + '/simple.json');
@@ -232,10 +232,10 @@ it('should fulfill with fetch result and overrides', async ({page, server, isEle
   const response = await page.goto(server.EMPTY_PAGE);
   expect(response.status()).toBe(201);
   expect((await response.allHeaders()).foo).toEqual('bar');
-  expect(await response.json()).toEqual({'foo': 'bar'});
+  expect(await response.json()).toEqual({ 'foo': 'bar' });
 });
 
-it('should fetch original request and fulfill', async ({page, server, isElectron}) => {
+it('should fetch original request and fulfill', async ({ page, server, isElectron }) => {
   it.fixme(isElectron, 'error: Browser context management is not supported.');
   await page.route('**/*', async route => {
     const response = await page._request.get(route.request());

--- a/tests/page/page-request-intercept.spec.ts
+++ b/tests/page/page-request-intercept.spec.ts
@@ -20,7 +20,7 @@ import os from 'os';
 import type { Route, Response } from '../../index';
 import { expect, test as it } from './pageTest';
 
-it('should fulfill intercepted response', async ({page, server, browserName}) => {
+it('should fulfill intercepted response', async ({ page, server, browserName }) => {
   await page.route('**/*', async route => {
     // @ts-expect-error
     await route._continueToResponse({});
@@ -40,7 +40,7 @@ it('should fulfill intercepted response', async ({page, server, browserName}) =>
   expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
 });
 
-it('should fulfill response with empty body', async ({page, server, browserName, browserMajorVersion}) => {
+it('should fulfill response with empty body', async ({ page, server, browserName, browserMajorVersion }) => {
   it.skip(browserName === 'chromium' && browserMajorVersion <= 91, 'Fails in Electron that uses old Chromium');
   await page.route('**/*', async route => {
     // @ts-expect-error
@@ -56,7 +56,7 @@ it('should fulfill response with empty body', async ({page, server, browserName,
   expect(await response.text()).toBe('');
 });
 
-it('should override with defaults when intercepted response not provided', async ({page, server, browserName, browserMajorVersion}) => {
+it('should override with defaults when intercepted response not provided', async ({ page, server, browserName, browserMajorVersion }) => {
   it.skip(browserName === 'chromium' && browserMajorVersion <= 91, 'Fails in Electron that uses old Chromium');
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('foo', 'bar');
@@ -73,12 +73,12 @@ it('should override with defaults when intercepted response not provided', async
   expect(response.status()).toBe(201);
   expect(await response.text()).toBe('');
   if (browserName === 'webkit')
-    expect(response.headers()).toEqual({'content-type': 'text/plain'});
+    expect(response.headers()).toEqual({ 'content-type': 'text/plain' });
   else
     expect(response.headers()).toEqual({ });
 });
 
-it('should fulfill with any response', async ({page, server, browserName, browserMajorVersion, isLinux}) => {
+it('should fulfill with any response', async ({ page, server, browserName, browserMajorVersion, isLinux }) => {
   it.skip(browserName === 'chromium' && browserMajorVersion <= 91, 'Fails in Electron that uses old Chromium');
 
   server.setRoute('/sample', (req, res) => {
@@ -104,7 +104,7 @@ it('should fulfill with any response', async ({page, server, browserName, browse
   expect(response.headers()['foo']).toBe('bar');
 });
 
-it('should throw on continue after intercept', async ({page, server, browserName}) => {
+it('should throw on continue after intercept', async ({ page, server, browserName }) => {
   let routeCallback;
   const routePromise = new Promise<Route>(f => routeCallback = f);
   await page.route('**', routeCallback);
@@ -121,7 +121,7 @@ it('should throw on continue after intercept', async ({page, server, browserName
   }
 });
 
-it('should support fulfill after intercept', async ({page, server}) => {
+it('should support fulfill after intercept', async ({ page, server }) => {
   const requestPromise = server.waitForRequest('/title.html');
   await page.route('**', async route => {
     // @ts-expect-error
@@ -134,7 +134,7 @@ it('should support fulfill after intercept', async ({page, server}) => {
   expect(await response.text()).toBe('<title>Woof-Woof</title>' + os.EOL);
 });
 
-it('should intercept failures', async ({page, browserName, browserMajorVersion, server}) => {
+it('should intercept failures', async ({ page, browserName, browserMajorVersion, server }) => {
   it.skip(browserName === 'chromium' && browserMajorVersion <= 91, 'Fails in Electron that uses old Chromium');
   server.setRoute('/title.html', (req, res) => {
     req.destroy();
@@ -159,7 +159,7 @@ it('should intercept failures', async ({page, browserName, browserMajorVersion, 
   expect(request.url).toBe('/title.html');
 });
 
-it('should support request overrides', async ({page, server, browserName, browserMajorVersion}) => {
+it('should support request overrides', async ({ page, server, browserName, browserMajorVersion }) => {
   it.skip(browserName === 'chromium' && browserMajorVersion <= 91, 'Fails in Electron that uses old Chromium');
   const requestPromise = server.waitForRequest('/empty.html');
   await page.route('**/foo', async route => {
@@ -167,7 +167,7 @@ it('should support request overrides', async ({page, server, browserName, browse
     const response = await route._continueToResponse({
       url: server.EMPTY_PAGE,
       method: 'POST',
-      headers: {'foo': 'bar'},
+      headers: { 'foo': 'bar' },
       postData: 'my data',
     });
     await route.fulfill({ response });
@@ -180,7 +180,7 @@ it('should support request overrides', async ({page, server, browserName, browse
   expect((await request.postBody).toString('utf8')).toBe('my data');
 });
 
-it('should give access to the intercepted response', async ({page, server}) => {
+it('should give access to the intercepted response', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
 
   let routeCallback;
@@ -204,7 +204,7 @@ it('should give access to the intercepted response', async ({page, server}) => {
   await Promise.all([route.fulfill({ response }), evalPromise]);
 });
 
-it('should give access to the intercepted response status text', async ({page, server, browserName}) => {
+it('should give access to the intercepted response status text', async ({ page, server, browserName }) => {
   it.fail(browserName === 'chromium', 'Status line is not reported for intercepted responses');
   await page.goto(server.EMPTY_PAGE);
   server.setRoute('/title.html', (req, res) => {
@@ -227,7 +227,7 @@ it('should give access to the intercepted response status text', async ({page, s
   await Promise.all([route.fulfill({ response }), evalPromise]);
 });
 
-it('should give access to the intercepted response body', async ({page, server}) => {
+it('should give access to the intercepted response body', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
 
   let routeCallback;
@@ -245,7 +245,7 @@ it('should give access to the intercepted response body', async ({page, server})
   await Promise.all([route.fulfill({ response }), evalPromise]);
 });
 
-it('should be abortable after interception', async ({page, server, browserName}) => {
+it('should be abortable after interception', async ({ page, server, browserName }) => {
   await page.route(/\.css$/, async route => {
     // @ts-expect-error
     await route._continueToResponse();
@@ -262,7 +262,7 @@ it('should be abortable after interception', async ({page, server, browserName})
   expect(failed).toBe(true);
 });
 
-it('should fulfill after redirects', async ({page, server, browserName}) => {
+it('should fulfill after redirects', async ({ page, server, browserName }) => {
   server.setRedirect('/redirect/1.html', '/redirect/2.html');
   server.setRedirect('/redirect/2.html', '/empty.html');
   const expectedUrls = ['/redirect/1.html', '/redirect/2.html', '/empty.html'].map(s => server.PREFIX + s);
@@ -304,7 +304,7 @@ it('should fulfill after redirects', async ({page, server, browserName}) => {
   expect(await response.text()).toBe('Yo, page!');
 });
 
-it('should fulfill original response after redirects', async ({page, browserName, server}) => {
+it('should fulfill original response after redirects', async ({ page, browserName, server }) => {
   server.setRedirect('/redirect/1.html', '/redirect/2.html');
   server.setRedirect('/redirect/2.html', '/title.html');
   const expectedUrls = ['/redirect/1.html', '/redirect/2.html', '/title.html'].map(s => server.PREFIX + s);
@@ -337,7 +337,7 @@ it('should fulfill original response after redirects', async ({page, browserName
   expect(await response.text()).toBe('<title>Woof-Woof</title>' + os.EOL);
 });
 
-it('should abort after redirects', async ({page, browserName, server}) => {
+it('should abort after redirects', async ({ page, browserName, server }) => {
   server.setRedirect('/redirect/1.html', '/redirect/2.html');
   server.setRedirect('/redirect/2.html', '/title.html');
   const expectedUrls = ['/redirect/1.html', '/redirect/2.html', '/title.html'].map(s => server.PREFIX + s);

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should intercept', async ({page, server}) => {
+it('should intercept', async ({ page, server }) => {
   let intercepted = false;
   await page.route('**/empty.html', (route, request) => {
     expect(route.request()).toBe(request);
@@ -37,7 +37,7 @@ it('should intercept', async ({page, server}) => {
   expect(intercepted).toBe(true);
 });
 
-it('should unroute', async ({page, server}) => {
+it('should unroute', async ({ page, server }) => {
   let intercepted = [];
   await page.route('**/*', route => {
     intercepted.push(1);
@@ -70,7 +70,7 @@ it('should unroute', async ({page, server}) => {
   expect(intercepted).toEqual([1]);
 });
 
-it('should work when POST is redirected with 302', async ({page, server}) => {
+it('should work when POST is redirected with 302', async ({ page, server }) => {
   server.setRedirect('/rredirect', '/empty.html');
   await page.goto(server.EMPTY_PAGE);
   await page.route('**/*', route => route.continue());
@@ -85,7 +85,7 @@ it('should work when POST is redirected with 302', async ({page, server}) => {
   ]);
 });
 // @see https://github.com/GoogleChrome/puppeteer/issues/3973
-it('should work when header manipulation headers with redirect', async ({page, server}) => {
+it('should work when header manipulation headers with redirect', async ({ page, server }) => {
   server.setRedirect('/rrredirect', '/empty.html');
   await page.route('**/*', route => {
     const headers = Object.assign({}, route.request().headers(), {
@@ -96,7 +96,7 @@ it('should work when header manipulation headers with redirect', async ({page, s
   await page.goto(server.PREFIX + '/rrredirect');
 });
 // @see https://github.com/GoogleChrome/puppeteer/issues/4743
-it('should be able to remove headers', async ({page, server}) => {
+it('should be able to remove headers', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.route('**/*', async route => {
     const headers = { ...route.request().headers() };
@@ -106,12 +106,12 @@ it('should be able to remove headers', async ({page, server}) => {
 
   const [serverRequest] = await Promise.all([
     server.waitForRequest('/title.html'),
-    page.evaluate(url => fetch(url, { headers: {foo: 'bar'} }), server.PREFIX + '/title.html')
+    page.evaluate(url => fetch(url, { headers: { foo: 'bar' } }), server.PREFIX + '/title.html')
   ]);
   expect(serverRequest.headers.foo).toBe(undefined);
 });
 
-it('should contain referer header', async ({page, server}) => {
+it('should contain referer header', async ({ page, server }) => {
   const requests = [];
   await page.route('**/*', route => {
     requests.push(route.request());
@@ -122,13 +122,13 @@ it('should contain referer header', async ({page, server}) => {
   expect(requests[1].headers().referer).toContain('/one-style.html');
 });
 
-it('should properly return navigation response when URL has cookies', async ({page, server, isElectron, isAndroid}) => {
+it('should properly return navigation response when URL has cookies', async ({ page, server, isElectron, isAndroid }) => {
   it.skip(isAndroid, 'No isolated context');
   it.fixme(isElectron, 'error: Browser context management is not supported.');
 
   // Setup cookie.
   await page.goto(server.EMPTY_PAGE);
-  await page.context().addCookies([{ url: server.EMPTY_PAGE, name: 'foo', value: 'bar'}]);
+  await page.context().addCookies([{ url: server.EMPTY_PAGE, name: 'foo', value: 'bar' }]);
 
   // Setup request interception.
   await page.route('**/*', route => route.continue());
@@ -136,7 +136,7 @@ it('should properly return navigation response when URL has cookies', async ({pa
   expect(response.status()).toBe(200);
 });
 
-it('should show custom HTTP headers', async ({page, server}) => {
+it('should show custom HTTP headers', async ({ page, server }) => {
   await page.setExtraHTTPHeaders({
     foo: 'bar'
   });
@@ -148,7 +148,7 @@ it('should show custom HTTP headers', async ({page, server}) => {
   expect(response.ok()).toBe(true);
 });
 // @see https://github.com/GoogleChrome/puppeteer/issues/4337
-it('should work with redirect inside sync XHR', async ({page, server}) => {
+it('should work with redirect inside sync XHR', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   server.setRedirect('/logo.png', '/pptr.png');
   await page.route('**/*', route => route.continue());
@@ -161,7 +161,7 @@ it('should work with redirect inside sync XHR', async ({page, server}) => {
   expect(status).toBe(200);
 });
 
-it('should pause intercepted XHR until continue', async ({page, server, browserName}) => {
+it('should pause intercepted XHR until continue', async ({ page, server, browserName }) => {
   it.fixme(browserName === 'webkit', 'Redirected request is not paused in WebKit');
 
   await page.goto(server.EMPTY_PAGE);
@@ -189,7 +189,7 @@ it('should pause intercepted XHR until continue', async ({page, server, browserN
   expect(status).toBe(200);
 });
 
-it('should pause intercepted fetch request until continue', async ({page, server}) => {
+it('should pause intercepted fetch request until continue', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let resolveRoute;
   const routePromise = new Promise(r => resolveRoute = r);
@@ -213,7 +213,7 @@ it('should pause intercepted fetch request until continue', async ({page, server
   expect(status).toBe(200);
 });
 
-it('should work with custom referer headers', async ({page, server, browserName}) => {
+it('should work with custom referer headers', async ({ page, server, browserName }) => {
   await page.setExtraHTTPHeaders({ 'referer': server.EMPTY_PAGE });
   await page.route('**/*', route => {
     // See https://github.com/microsoft/playwright/issues/8999
@@ -227,7 +227,7 @@ it('should work with custom referer headers', async ({page, server, browserName}
   expect(response.ok()).toBe(true);
 });
 
-it('should be abortable', async ({page, server}) => {
+it('should be abortable', async ({ page, server }) => {
   await page.route(/\.css$/, route => route.abort());
   let failed = false;
   page.on('requestfailed', request => {
@@ -240,7 +240,7 @@ it('should be abortable', async ({page, server}) => {
   expect(failed).toBe(true);
 });
 
-it('should be abortable with custom error codes', async ({page, server, browserName}) => {
+it('should be abortable with custom error codes', async ({ page, server, browserName }) => {
   await page.route('**/*', route => route.abort('internetdisconnected'));
   let failedRequest = null;
   page.on('requestfailed', request => failedRequest = request);
@@ -254,7 +254,7 @@ it('should be abortable with custom error codes', async ({page, server, browserN
     expect(failedRequest.failure().errorText).toBe('net::ERR_INTERNET_DISCONNECTED');
 });
 
-it('should send referer', async ({page, server}) => {
+it('should send referer', async ({ page, server }) => {
   await page.setExtraHTTPHeaders({
     referer: 'http://google.com/'
   });
@@ -266,7 +266,7 @@ it('should send referer', async ({page, server}) => {
   expect(request.headers['referer']).toBe('http://google.com/');
 });
 
-it('should fail navigation when aborting main resource', async ({page, server, browserName}) => {
+it('should fail navigation when aborting main resource', async ({ page, server, browserName }) => {
   await page.route('**/*', route => route.abort());
   let error = null;
   await page.goto(server.EMPTY_PAGE).catch(e => error = e);
@@ -279,7 +279,7 @@ it('should fail navigation when aborting main resource', async ({page, server, b
     expect(error.message).toContain('net::ERR_FAILED');
 });
 
-it('should not work with redirects', async ({page, server}) => {
+it('should not work with redirects', async ({ page, server }) => {
   const intercepted = [];
   await page.route('**/*', route => {
     route.continue();
@@ -314,7 +314,7 @@ it('should not work with redirects', async ({page, server}) => {
     expect(chain[i].redirectedTo()).toBe(i ? chain[i - 1] : null);
 });
 
-it('should work with redirects for subresources', async ({page, server}) => {
+it('should work with redirects for subresources', async ({ page, server }) => {
   const intercepted = [];
   await page.route('**/*', route => {
     route.continue();
@@ -342,7 +342,7 @@ it('should work with redirects for subresources', async ({page, server}) => {
   expect(r).toBe(null);
 });
 
-it('should work with equal requests', async ({page, server}) => {
+it('should work with equal requests', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let responseCount = 1;
   server.setRoute('/zzz', (req, res) => res.end((responseCount++) * 11 + ''));
@@ -359,7 +359,7 @@ it('should work with equal requests', async ({page, server}) => {
   expect(results).toEqual(['11', 'FAILED', '22']);
 });
 
-it('should navigate to dataURL and not fire dataURL requests', async ({page, server}) => {
+it('should navigate to dataURL and not fire dataURL requests', async ({ page, server }) => {
   const requests = [];
   await page.route('**/*', route => {
     requests.push(route.request());
@@ -371,7 +371,7 @@ it('should navigate to dataURL and not fire dataURL requests', async ({page, ser
   expect(requests.length).toBe(0);
 });
 
-it('should be able to fetch dataURL and not fire dataURL requests', async ({page, server}) => {
+it('should be able to fetch dataURL and not fire dataURL requests', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const requests = [];
   await page.route('**/*', route => {
@@ -384,7 +384,7 @@ it('should be able to fetch dataURL and not fire dataURL requests', async ({page
   expect(requests.length).toBe(0);
 });
 
-it('should navigate to URL with hash and and fire requests without hash', async ({page, server}) => {
+it('should navigate to URL with hash and and fire requests without hash', async ({ page, server }) => {
   const requests = [];
   await page.route('**/*', route => {
     requests.push(route.request());
@@ -397,7 +397,7 @@ it('should navigate to URL with hash and and fire requests without hash', async 
   expect(requests[0].url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should work with encoded server', async ({page, server}) => {
+it('should work with encoded server', async ({ page, server }) => {
   // The requestWillBeSent will report encoded URL, whereas interception will
   // report URL as-is. @see crbug.com/759388
   await page.route('**/*', route => route.continue());
@@ -405,14 +405,14 @@ it('should work with encoded server', async ({page, server}) => {
   expect(response.status()).toBe(404);
 });
 
-it('should work with badly encoded server', async ({page, server}) => {
+it('should work with badly encoded server', async ({ page, server }) => {
   server.setRoute('/malformed?rnd=%911', (req, res) => res.end());
   await page.route('**/*', route => route.continue());
   const response = await page.goto(server.PREFIX + '/malformed?rnd=%911');
   expect(response.status()).toBe(200);
 });
 
-it('should work with encoded server - 2', async ({page, server}) => {
+it('should work with encoded server - 2', async ({ page, server }) => {
   // The requestWillBeSent will report URL as-is, whereas interception will
   // report encoded URL for stylesheet. @see crbug.com/759388
   const requests = [];
@@ -426,7 +426,7 @@ it('should work with encoded server - 2', async ({page, server}) => {
   expect((await requests[0].response()).status()).toBe(404);
 });
 
-it('should not throw "Invalid Interception Id" if the request was cancelled', async ({page, server}) => {
+it('should not throw "Invalid Interception Id" if the request was cancelled', async ({ page, server }) => {
   await page.setContent('<iframe></iframe>');
   let route = null;
   await page.route('**/*', async r => route = r);
@@ -440,7 +440,7 @@ it('should not throw "Invalid Interception Id" if the request was cancelled', as
   expect(error).toBe(null);
 });
 
-it('should intercept main resource during cross-process navigation', async ({page, server}) => {
+it('should intercept main resource during cross-process navigation', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let intercepted = false;
   await page.route(server.CROSS_PROCESS_PREFIX + '/empty.html', route => {
@@ -452,7 +452,7 @@ it('should intercept main resource during cross-process navigation', async ({pag
   expect(intercepted).toBe(true);
 });
 
-it('should fulfill with redirect status', async ({page, server, browserName}) => {
+it('should fulfill with redirect status', async ({ page, server, browserName }) => {
   it.fixme(browserName === 'webkit', 'in WebKit the redirects are handled by the network stack and we intercept before');
 
   await page.goto(server.PREFIX + '/title.html');
@@ -475,7 +475,7 @@ it('should fulfill with redirect status', async ({page, server, browserName}) =>
   expect(text).toBe('foo');
 });
 
-it('should not fulfill with redirect status', async ({page, server, browserName}) => {
+it('should not fulfill with redirect status', async ({ page, server, browserName }) => {
   it.skip(browserName !== 'webkit', 'we should support fulfill with redirect in webkit and delete this test');
 
   await page.goto(server.PREFIX + '/empty.html');
@@ -509,7 +509,7 @@ it('should not fulfill with redirect status', async ({page, server, browserName}
   }
 });
 
-it('should support cors with GET', async ({page, server, browserName}) => {
+it('should support cors with GET', async ({ page, server, browserName }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.route('**/cars*', async (route, request) => {
     const headers = request.url().endsWith('allow') ? { 'access-control-allow-origin': '*' } : {};
@@ -543,7 +543,7 @@ it('should support cors with GET', async ({page, server, browserName}) => {
   }
 });
 
-it('should support cors with POST', async ({page, server}) => {
+it('should support cors with POST', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.route('**/cars', async route => {
     await route.fulfill({
@@ -565,7 +565,7 @@ it('should support cors with POST', async ({page, server}) => {
   expect(resp).toEqual(['electric', 'gas']);
 });
 
-it('should support cors with credentials', async ({page, server}) => {
+it('should support cors with credentials', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.route('**/cars', async route => {
     await route.fulfill({
@@ -591,7 +591,7 @@ it('should support cors with credentials', async ({page, server}) => {
   expect(resp).toEqual(['electric', 'gas']);
 });
 
-it('should reject cors with disallowed credentials', async ({page, server}) => {
+it('should reject cors with disallowed credentials', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.route('**/cars', async route => {
     await route.fulfill({
@@ -623,7 +623,7 @@ it('should reject cors with disallowed credentials', async ({page, server}) => {
   expect(error).toBeTruthy();
 });
 
-it('should support cors for different methods', async ({page, server}) => {
+it('should support cors for different methods', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.route('**/cars', async (route, request) => {
     await route.fulfill({
@@ -661,12 +661,12 @@ it('should support cors for different methods', async ({page, server}) => {
   }
 });
 
-it('should support the times parameter with route matching', async ({page, server}) => {
+it('should support the times parameter with route matching', async ({ page, server }) => {
   const intercepted = [];
   await page.route('**/empty.html', route => {
     intercepted.push(1);
     route.continue();
-  }, { times: 1});
+  }, { times: 1 });
   await page.goto(server.EMPTY_PAGE);
   await page.goto(server.EMPTY_PAGE);
   await page.goto(server.EMPTY_PAGE);

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -24,15 +24,15 @@ it.describe('page screenshot', () => {
   it.skip(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
   it.skip(({ isAndroid }) => isAndroid, 'Different viewport');
 
-  it('should work', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should work', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const screenshot = await page.screenshot();
     expect(screenshot).toMatchSnapshot('screenshot-sanity.png');
   });
 
-  it('should clip rect', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should clip rect', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const screenshot = await page.screenshot({
       clip: {
@@ -45,8 +45,8 @@ it.describe('page screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-clip-rect.png');
   });
 
-  it('should clip rect with fullPage', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should clip rect with fullPage', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     await page.evaluate(() => window.scrollBy(150, 200));
     const screenshot = await page.screenshot({
@@ -61,8 +61,8 @@ it.describe('page screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-clip-rect.png');
   });
 
-  it('should clip elements to the viewport', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should clip elements to the viewport', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const screenshot = await page.screenshot({
       clip: {
@@ -75,8 +75,8 @@ it.describe('page screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-offscreen-clip.png');
   });
 
-  it('should throw on clip outside the viewport', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should throw on clip outside the viewport', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const screenshotError = await page.screenshot({
       clip: {
@@ -89,8 +89,8 @@ it.describe('page screenshot', () => {
     expect(screenshotError.message).toContain('Clipped area is either empty or outside the resulting image');
   });
 
-  it('should run in parallel', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should run in parallel', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const promises = [];
     for (let i = 0; i < 3; ++i) {
@@ -107,8 +107,8 @@ it.describe('page screenshot', () => {
     expect(screenshots[1]).toMatchSnapshot('grid-cell-1.png');
   });
 
-  it('should take fullPage screenshots', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should take fullPage screenshots', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const screenshot = await page.screenshot({
       fullPage: true
@@ -116,15 +116,15 @@ it.describe('page screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-grid-fullpage.png');
   });
 
-  it('should restore viewport after fullPage screenshot', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should restore viewport after fullPage screenshot', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const screenshot = await page.screenshot({ fullPage: true });
     expect(screenshot).toBeInstanceOf(Buffer);
     await verifyViewport(page, 500, 500);
   });
 
-  it('should allow transparency', async ({page, browserName}) => {
+  it('should allow transparency', async ({ page, browserName }) => {
     it.fail(browserName === 'firefox');
 
     await page.setViewportSize({ width: 50, height: 150 });
@@ -137,20 +137,20 @@ it.describe('page screenshot', () => {
       <div style="background:white"></div>
       <div style="background:transparent"></div>
     `);
-    const screenshot = await page.screenshot({omitBackground: true});
+    const screenshot = await page.screenshot({ omitBackground: true });
     expect(screenshot).toMatchSnapshot('transparent.png');
   });
 
-  it('should render white background on jpeg file', async ({page, server, isElectron}) => {
+  it('should render white background on jpeg file', async ({ page, server, isElectron }) => {
     it.fixme(isElectron, 'omitBackground with jpeg does not work');
 
     await page.setViewportSize({ width: 100, height: 100 });
     await page.goto(server.EMPTY_PAGE);
-    const screenshot = await page.screenshot({omitBackground: true, type: 'jpeg'});
+    const screenshot = await page.screenshot({ omitBackground: true, type: 'jpeg' });
     expect(screenshot).toMatchSnapshot('white.jpg');
   });
 
-  it('should work with odd clip size on Retina displays', async ({page, isElectron}) => {
+  it('should work with odd clip size on Retina displays', async ({ page, isElectron }) => {
     it.fixme(isElectron, 'Scale is wrong');
 
     const screenshot = await page.screenshot({
@@ -164,31 +164,31 @@ it.describe('page screenshot', () => {
     expect(screenshot).toMatchSnapshot('screenshot-clip-odd-size.png');
   });
 
-  it('should work for canvas', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should work for canvas', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/screenshots/canvas.html');
     const screenshot = await page.screenshot();
     expect(screenshot).toMatchSnapshot('screenshot-canvas.png', { threshold: 0.4 });
   });
 
-  it('should work for webgl', async ({page, server, browserName}) => {
+  it('should work for webgl', async ({ page, server, browserName }) => {
     it.fixme(browserName === 'firefox' || browserName === 'webkit');
 
-    await page.setViewportSize({width: 640, height: 480});
+    await page.setViewportSize({ width: 640, height: 480 });
     await page.goto(server.PREFIX + '/screenshots/webgl.html');
     const screenshot = await page.screenshot();
     expect(screenshot).toMatchSnapshot('screenshot-webgl.png');
   });
 
-  it('should work for translateZ', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should work for translateZ', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/screenshots/translateZ.html');
     const screenshot = await page.screenshot();
     expect(screenshot).toMatchSnapshot('screenshot-translateZ.png');
   });
 
-  it('should work while navigating', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should work while navigating', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/redirectloop1.html');
     for (let i = 0; i < 10; i++) {
       const screenshot = await page.screenshot({ fullPage: true }).catch(e => {
@@ -200,61 +200,61 @@ it.describe('page screenshot', () => {
     }
   });
 
-  it('should work with iframe in shadow', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should work with iframe in shadow', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid-iframe-in-shadow.html');
     expect(await page.screenshot()).toMatchSnapshot('screenshot-iframe.png');
   });
 
-  it('path option should work', async ({page, server}, testInfo) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('path option should work', async ({ page, server }, testInfo) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const outputPath = testInfo.outputPath('screenshot.png');
-    await page.screenshot({path: outputPath});
+    await page.screenshot({ path: outputPath });
     expect(await fs.promises.readFile(outputPath)).toMatchSnapshot('screenshot-sanity.png');
   });
 
-  it('path option should create subdirectories', async ({page, server}, testInfo) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('path option should create subdirectories', async ({ page, server }, testInfo) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const outputPath = testInfo.outputPath(path.join('these', 'are', 'directories', 'screenshot.png'));
-    await page.screenshot({path: outputPath});
+    await page.screenshot({ path: outputPath });
     expect(await fs.promises.readFile(outputPath)).toMatchSnapshot('screenshot-sanity.png');
   });
 
-  it('path option should detect jpeg', async ({page, server, isElectron}, testInfo) => {
+  it('path option should detect jpeg', async ({ page, server, isElectron }, testInfo) => {
     it.fixme(isElectron, 'omitBackground with jpeg does not work');
 
     await page.setViewportSize({ width: 100, height: 100 });
     await page.goto(server.EMPTY_PAGE);
     const outputPath = testInfo.outputPath('screenshot.jpg');
-    const screenshot = await page.screenshot({omitBackground: true, path: outputPath});
+    const screenshot = await page.screenshot({ omitBackground: true, path: outputPath });
     expect(await fs.promises.readFile(outputPath)).toMatchSnapshot('white.jpg');
     expect(screenshot).toMatchSnapshot('white.jpg');
   });
 
-  it('path option should throw for unsupported mime type', async ({page}) => {
+  it('path option should throw for unsupported mime type', async ({ page }) => {
     const error = await page.screenshot({ path: 'file.txt' }).catch(e => e);
     expect(error.message).toContain('path: unsupported mime type "text/plain"');
   });
 
-  it('quality option should throw for png', async ({page}) => {
+  it('quality option should throw for png', async ({ page }) => {
     const error = await page.screenshot({ quality: 10 }).catch(e => e);
     expect(error.message).toContain('options.quality is unsupported for the png');
   });
 
-  it('zero quality option should throw for png', async ({page}) => {
+  it('zero quality option should throw for png', async ({ page }) => {
     const error = await page.screenshot({ quality: 0, type: 'png' }).catch(e => e);
     expect(error.message).toContain('options.quality is unsupported for the png');
   });
 
-  it('should prefer type over extension', async ({page}, testInfo) => {
+  it('should prefer type over extension', async ({ page }, testInfo) => {
     const outputPath = testInfo.outputPath('file.png');
     const buffer = await page.screenshot({ path: outputPath, type: 'jpeg' });
     expect([buffer[0], buffer[1], buffer[2]]).toEqual([0xFF, 0xD8, 0xFF]);
   });
 
-  it('should not issue resize event', async ({page, server}) => {
+  it('should not issue resize event', async ({ page, server }) => {
     await page.goto(server.PREFIX + '/grid.html');
     let resizeTriggered = false;
     await page.exposeFunction('resize', () => {
@@ -267,16 +267,16 @@ it.describe('page screenshot', () => {
     expect(resizeTriggered).toBeFalsy();
   });
 
-  it('should work with Array deleted', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should work with Array deleted', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     await page.evaluate(() => delete window.Array);
     const screenshot = await page.screenshot({ fullPage: true });
     expect(screenshot).toMatchSnapshot('screenshot-grid-fullpage.png');
   });
 
-  it('should take fullPage screenshots during navigation', async ({page, server}) => {
-    await page.setViewportSize({width: 500, height: 500});
+  it('should take fullPage screenshots during navigation', async ({ page, server }) => {
+    await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const reloadSeveralTimes = async () => {
       for (let i = 0; i < 5; ++i)

--- a/tests/page/page-select-option.spec.ts
+++ b/tests/page/page-select-option.spec.ts
@@ -22,67 +22,67 @@ async function giveItAChanceToResolve(page) {
     await page.evaluate(() => new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f))));
 }
 
-it('should select single option', async ({page, server}) => {
+it('should select single option', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('select', 'blue');
   expect(await page.evaluate(() => window['result'].onInput)).toEqual(['blue']);
   expect(await page.evaluate(() => window['result'].onChange)).toEqual(['blue']);
 });
 
-it('should select single option by value', async ({page, server}) => {
+it('should select single option by value', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('select', { value: 'blue' });
   expect(await page.evaluate(() => window['result'].onInput)).toEqual(['blue']);
   expect(await page.evaluate(() => window['result'].onChange)).toEqual(['blue']);
 });
 
-it('should select single option by label', async ({page, server}) => {
+it('should select single option by label', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('select', { label: 'Indigo' });
   expect(await page.evaluate(() => window['result'].onInput)).toEqual(['indigo']);
   expect(await page.evaluate(() => window['result'].onChange)).toEqual(['indigo']);
 });
 
-it('should select single option by handle', async ({page, server}) => {
+it('should select single option by handle', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('select', await page.$('[id=whiteOption]'));
   expect(await page.evaluate(() => window['result'].onInput)).toEqual(['white']);
   expect(await page.evaluate(() => window['result'].onChange)).toEqual(['white']);
 });
 
-it('should select single option by index', async ({page, server}) => {
+it('should select single option by index', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('select', { index: 2 });
   expect(await page.evaluate(() => window['result'].onInput)).toEqual(['brown']);
   expect(await page.evaluate(() => window['result'].onChange)).toEqual(['brown']);
 });
 
-it('should select single option by multiple attributes', async ({page, server}) => {
+it('should select single option by multiple attributes', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('select', { value: 'green', label: 'Green' });
   expect(await page.evaluate(() => window['result'].onInput)).toEqual(['green']);
   expect(await page.evaluate(() => window['result'].onChange)).toEqual(['green']);
 });
 
-it('should not select single option when some attributes do not match', async ({page, server}) => {
+it('should not select single option when some attributes do not match', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.$eval('select', s => s.value = undefined);
   try {
-    await page.selectOption('select', { value: 'green', label: 'Brown' }, {timeout: 300});
+    await page.selectOption('select', { value: 'green', label: 'Brown' }, { timeout: 300 });
   } catch (e) {
     expect(e.message).toContain('Timeout');
   }
   expect(await page.evaluate(() => document.querySelector('select').value)).toEqual('');
 });
 
-it('should select only first option', async ({page, server}) => {
+it('should select only first option', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('select', ['blue', 'green', 'red']);
   expect(await page.evaluate(() => window['result'].onInput)).toEqual(['blue']);
   expect(await page.evaluate(() => window['result'].onChange)).toEqual(['blue']);
 });
 
-it('should not throw when select causes navigation', async ({page, server}) => {
+it('should not throw when select causes navigation', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.$eval('select', select => select.addEventListener('input', () => window.location.href = '/empty.html'));
   await Promise.all([
@@ -92,7 +92,7 @@ it('should not throw when select causes navigation', async ({page, server}) => {
   expect(page.url()).toContain('empty.html');
 });
 
-it('should select multiple options', async ({page, server}) => {
+it('should select multiple options', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.evaluate(() => window['makeMultiple']());
   await page.selectOption('select', ['blue', 'green', 'red']);
@@ -100,7 +100,7 @@ it('should select multiple options', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'].onChange)).toEqual(['blue', 'green', 'red']);
 });
 
-it('should select multiple options with attributes', async ({page, server}) => {
+it('should select multiple options with attributes', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.evaluate(() => window['makeMultiple']());
   await page.selectOption('select', [{ value: 'blue' }, { label: 'Green' }, { index: 4 }]);
@@ -108,7 +108,7 @@ it('should select multiple options with attributes', async ({page, server}) => {
   expect(await page.evaluate(() => window['result'].onChange)).toEqual(['blue', 'gray', 'green']);
 });
 
-it('should select options with sibling label', async ({page, server}) => {
+it('should select options with sibling label', async ({ page, server }) => {
   await page.setContent(`<label for=pet-select>Choose a pet</label>
     <select id='pet-select'>
       <option value='dog'>Dog</option>
@@ -118,7 +118,7 @@ it('should select options with sibling label', async ({page, server}) => {
   expect(await page.$eval('select', select => select.options[select.selectedIndex].text)).toEqual('Cat');
 });
 
-it('should select options with outer label', async ({page, server}) => {
+it('should select options with outer label', async ({ page, server }) => {
   await page.setContent(`<label for=pet-select>Choose a pet
     <select id='pet-select'>
       <option value='dog'>Dog</option>
@@ -128,46 +128,46 @@ it('should select options with outer label', async ({page, server}) => {
   expect(await page.$eval('select', select => select.options[select.selectedIndex].text)).toEqual('Cat');
 });
 
-it('should respect event bubbling', async ({page, server}) => {
+it('should respect event bubbling', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('select', 'blue');
   expect(await page.evaluate(() => window['result'].onBubblingInput)).toEqual(['blue']);
   expect(await page.evaluate(() => window['result'].onBubblingChange)).toEqual(['blue']);
 });
 
-it('should throw when element is not a <select>', async ({page, server}) => {
+it('should throw when element is not a <select>', async ({ page, server }) => {
   let error = null;
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('body', '').catch(e => error = e);
   expect(error.message).toContain('Element is not a <select> element');
 });
 
-it('should return [] on no matched values', async ({page, server}) => {
+it('should return [] on no matched values', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   const result = await page.selectOption('select', []);
   expect(result).toEqual([]);
 });
 
-it('should return an array of matched values', async ({page, server}) => {
+it('should return an array of matched values', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.evaluate(() => window['makeMultiple']());
   const result = await page.selectOption('select', ['blue','black','magenta']);
   expect(result.reduce((accumulator,current) => ['blue', 'black', 'magenta'].includes(current) && accumulator, true)).toEqual(true);
 });
 
-it('should return an array of one element when multiple is not set', async ({page, server}) => {
+it('should return an array of one element when multiple is not set', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   const result = await page.selectOption('select',['42','blue','black','magenta']);
   expect(result.length).toEqual(1);
 });
 
-it('should return [] on no values',async ({page, server}) => {
+it('should return [] on no values',async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   const result = await page.selectOption('select', []);
   expect(result).toEqual([]);
 });
 
-it('should not allow null items',async ({page, server}) => {
+it('should not allow null items',async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.evaluate(() => window['makeMultiple']());
   let error = null;
@@ -175,7 +175,7 @@ it('should not allow null items',async ({page, server}) => {
   expect(error.message).toContain('options[1]: expected object, got null');
 });
 
-it('should unselect with null',async ({page, server}) => {
+it('should unselect with null',async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.evaluate(() => window['makeMultiple']());
   const result = await page.selectOption('select', ['blue', 'black','magenta']);
@@ -184,7 +184,7 @@ it('should unselect with null',async ({page, server}) => {
   expect(await page.$eval('select', select => Array.from(select.options).every(option => !option.selected))).toEqual(true);
 });
 
-it('should deselect all options when passed no values for a multiple select',async ({page, server}) => {
+it('should deselect all options when passed no values for a multiple select',async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.evaluate(() => window['makeMultiple']());
   await page.selectOption('select', ['blue','black','magenta']);
@@ -192,14 +192,14 @@ it('should deselect all options when passed no values for a multiple select',asy
   expect(await page.$eval('select', select => Array.from(select.options).every(option => !option.selected))).toEqual(true);
 });
 
-it('should deselect all options when passed no values for a select without multiple',async ({page, server}) => {
+it('should deselect all options when passed no values for a select without multiple',async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('select', ['blue','black','magenta']);
   await page.selectOption('select', []);
   expect(await page.$eval('select', select => Array.from(select.options).every(option => !option.selected))).toEqual(true);
 });
 
-it('should throw if passed wrong types', async ({page, server}) => {
+it('should throw if passed wrong types', async ({ page, server }) => {
   let error;
   await page.setContent('<select><option value="12"/></select>');
 
@@ -240,7 +240,7 @@ it('should throw if passed wrong types', async ({page, server}) => {
   expect(error.message).toContain('options[0].index: expected number, got string');
 });
 // @see https://github.com/GoogleChrome/puppeteer/issues/3327
-it('should work when re-defining top-level Event class', async ({page, server}) => {
+it('should work when re-defining top-level Event class', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.evaluate(() => window.Event = null);
   await page.selectOption('select', 'blue');
@@ -248,7 +248,7 @@ it('should work when re-defining top-level Event class', async ({page, server}) 
   expect(await page.evaluate(() => window['result'].onChange)).toEqual(['blue']);
 });
 
-it('should wait for option to be present',async ({page, server}) => {
+it('should wait for option to be present',async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   const selectPromise  = page.selectOption('select', 'scarlet');
   let didSelect = false;
@@ -265,10 +265,10 @@ it('should wait for option to be present',async ({page, server}) => {
   expect(items).toStrictEqual(['scarlet']);
 });
 
-it('should wait for option index to be present',async ({page, server}) => {
+it('should wait for option index to be present',async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   const len = await page.$eval('select', select => select.options.length);
-  const selectPromise  = page.selectOption('select', {index: len});
+  const selectPromise  = page.selectOption('select', { index: len });
   let didSelect = false;
   selectPromise.then(() => didSelect = true);
   await giveItAChanceToResolve(page);
@@ -283,7 +283,7 @@ it('should wait for option index to be present',async ({page, server}) => {
   expect(items).toStrictEqual(['scarlet']);
 });
 
-it('should wait for multiple options to be present',async ({page, server}) => {
+it('should wait for multiple options to be present',async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.evaluate(() => window['makeMultiple']());
   const selectPromise  = page.selectOption('select', ['green', 'scarlet']);

--- a/tests/page/page-set-content.spec.ts
+++ b/tests/page/page-set-content.spec.ts
@@ -19,26 +19,26 @@ import { test as it, expect } from './pageTest';
 
 const expectedOutput = '<html><head></head><body><div>hello</div></body></html>';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.setContent('<div>hello</div>');
   const result = await page.content();
   expect(result).toBe(expectedOutput);
 });
 
-it('should work with domcontentloaded', async ({page, server}) => {
+it('should work with domcontentloaded', async ({ page, server }) => {
   await page.setContent('<div>hello</div>', { waitUntil: 'domcontentloaded' });
   const result = await page.content();
   expect(result).toBe(expectedOutput);
 });
 
-it('should work with doctype', async ({page, server}) => {
+it('should work with doctype', async ({ page, server }) => {
   const doctype = '<!DOCTYPE html>';
   await page.setContent(`${doctype}<div>hello</div>`);
   const result = await page.content();
   expect(result).toBe(`${doctype}${expectedOutput}`);
 });
 
-it('should work with HTML 4 doctype', async ({page, server}) => {
+it('should work with HTML 4 doctype', async ({ page, server }) => {
   const doctype = '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" ' +
     '"http://www.w3.org/TR/html4/strict.dtd">';
   await page.setContent(`${doctype}<div>hello</div>`);
@@ -46,16 +46,16 @@ it('should work with HTML 4 doctype', async ({page, server}) => {
   expect(result).toBe(`${doctype}${expectedOutput}`);
 });
 
-it('should respect timeout', async ({page, server, playwright}) => {
+it('should respect timeout', async ({ page, server, playwright }) => {
   const imgPath = '/img.png';
   // stall for image
   server.setRoute(imgPath, (req, res) => {});
   let error = null;
-  await page.setContent(`<img src="${server.PREFIX + imgPath}"></img>`, {timeout: 1}).catch(e => error = e);
+  await page.setContent(`<img src="${server.PREFIX + imgPath}"></img>`, { timeout: 1 }).catch(e => error = e);
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should respect default navigation timeout', async ({page, server, playwright}) => {
+it('should respect default navigation timeout', async ({ page, server, playwright }) => {
   page.setDefaultNavigationTimeout(1);
   const imgPath = '/img.png';
   // stall for image
@@ -65,7 +65,7 @@ it('should respect default navigation timeout', async ({page, server, playwright
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should await resources to load', async ({page, server}) => {
+it('should await resources to load', async ({ page, server }) => {
   const imgPath = '/img.png';
   let imgResponse = null;
   server.setRoute(imgPath, (req, res) => imgResponse = res);
@@ -77,32 +77,32 @@ it('should await resources to load', async ({page, server}) => {
   await contentPromise;
 });
 
-it('should work fast enough', async ({page, server}) => {
+it('should work fast enough', async ({ page, server }) => {
   for (let i = 0; i < 20; ++i)
     await page.setContent('<div>yo</div>');
 });
 
-it('should work with tricky content', async ({page, server}) => {
+it('should work with tricky content', async ({ page, server }) => {
   await page.setContent('<div>hello world</div>' + '\x7F');
   expect(await page.$eval('div', div => div.textContent)).toBe('hello world');
 });
 
-it('should work with accents', async ({page, server}) => {
+it('should work with accents', async ({ page, server }) => {
   await page.setContent('<div>aberración</div>');
   expect(await page.$eval('div', div => div.textContent)).toBe('aberración');
 });
 
-it('should work with emojis', async ({page, server}) => {
+it('should work with emojis', async ({ page, server }) => {
   await page.setContent('<div>🐥</div>');
   expect(await page.$eval('div', div => div.textContent)).toBe('🐥');
 });
 
-it('should work with newline', async ({page, server}) => {
+it('should work with newline', async ({ page, server }) => {
   await page.setContent('<div>\n</div>');
   expect(await page.$eval('div', div => div.textContent)).toBe('\n');
 });
 
-it('content() should throw nice error during navigation', async ({page, server}) => {
+it('content() should throw nice error during navigation', async ({ page, server }) => {
   for (let timeout = 0; timeout < 200; timeout += 20) {
     await page.setContent('<div>hello</div>');
     const promise = page.goto(server.EMPTY_PAGE);

--- a/tests/page/page-set-extra-http-headers.spec.ts
+++ b/tests/page/page-set-extra-http-headers.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.setExtraHTTPHeaders({
     foo: 'bar',
   });
@@ -29,7 +29,7 @@ it('should work', async ({page, server}) => {
   expect(request.headers['baz']).toBe(undefined);
 });
 
-it('should work with redirects', async ({page, server}) => {
+it('should work with redirects', async ({ page, server }) => {
   server.setRedirect('/foo.html', '/empty.html');
   await page.setExtraHTTPHeaders({
     foo: 'bar'
@@ -41,7 +41,7 @@ it('should work with redirects', async ({page, server}) => {
   expect(request.headers['foo']).toBe('bar');
 });
 
-it('should work with extra headers from browser context', async ({page, server}) => {
+it('should work with extra headers from browser context', async ({ page, server }) => {
   await page.context().setExtraHTTPHeaders({
     'foo': 'bar',
   });
@@ -52,7 +52,7 @@ it('should work with extra headers from browser context', async ({page, server})
   expect(request.headers['foo']).toBe('bar');
 });
 
-it('should throw for non-string header values', async ({page}) => {
+it('should throw for non-string header values', async ({ page }) => {
   // @ts-expect-error headers must be strings
   const error1 = await page.setExtraHTTPHeaders({ 'foo': 1 }).catch(e => e);
   expect(error1.message).toContain('Expected value of header "foo" to be String, but "number" is found.');
@@ -61,7 +61,7 @@ it('should throw for non-string header values', async ({page}) => {
   expect(error2.message).toContain('Expected value of header "foo" to be String, but "boolean" is found.');
 });
 
-it('should not duplicate referer header', async ({page, server, browserName}) => {
+it('should not duplicate referer header', async ({ page, server, browserName }) => {
   it.fail(browserName === 'chromium', 'Request has referer and Referer');
   await page.setExtraHTTPHeaders({ 'referer': server.EMPTY_PAGE });
   const response = await page.goto(server.EMPTY_PAGE);

--- a/tests/page/page-set-input-files.spec.ts
+++ b/tests/page/page-set-input-files.spec.ts
@@ -22,7 +22,7 @@ import path from 'path';
 import fs from 'fs';
 import formidable from 'formidable';
 
-it('should upload the file', async ({page, server, asset}) => {
+it('should upload the file', async ({ page, server, asset }) => {
   await page.goto(server.PREFIX + '/input/fileupload.html');
   const filePath = path.relative(process.cwd(), asset('file-to-upload.txt'));
   const input = await page.$('input');
@@ -36,21 +36,21 @@ it('should upload the file', async ({page, server, asset}) => {
   }, input)).toBe('contents of the file');
 });
 
-it('should work', async ({page, asset}) => {
+it('should work', async ({ page, asset }) => {
   await page.setContent(`<input type=file>`);
   await page.setInputFiles('input', asset('file-to-upload.txt'));
   expect(await page.$eval('input', input => input.files.length)).toBe(1);
   expect(await page.$eval('input', input => input.files[0].name)).toBe('file-to-upload.txt');
 });
 
-it('should work with label', async ({page, asset}) => {
+it('should work with label', async ({ page, asset }) => {
   await page.setContent(`<label for=target>Choose a file</label><input id=target type=file>`);
   await page.setInputFiles('text=Choose a file', asset('file-to-upload.txt'));
   expect(await page.$eval('input', input => input.files.length)).toBe(1);
   expect(await page.$eval('input', input => input.files[0].name)).toBe('file-to-upload.txt');
 });
 
-it('should set from memory', async ({page}) => {
+it('should set from memory', async ({ page }) => {
   await page.setContent(`<input type=file>`);
   await page.setInputFiles('input', {
     name: 'test.txt',
@@ -61,7 +61,7 @@ it('should set from memory', async ({page}) => {
   expect(await page.$eval('input', input => input.files[0].name)).toBe('test.txt');
 });
 
-it('should emit event once', async ({page, server}) => {
+it('should emit event once', async ({ page, server }) => {
   await page.setContent(`<input type=file>`);
   const [chooser] = await Promise.all([
     new Promise(f => page.once('filechooser', f)),
@@ -70,7 +70,7 @@ it('should emit event once', async ({page, server}) => {
   expect(chooser).toBeTruthy();
 });
 
-it('should emit event for iframe', async ({page, server, browserName}) => {
+it('should emit event for iframe', async ({ page, server, browserName }) => {
   it.skip(browserName === 'firefox');
   const frame = await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   await frame.setContent(`<input type=file>`);
@@ -81,7 +81,7 @@ it('should emit event for iframe', async ({page, server, browserName}) => {
   expect(chooser).toBeTruthy();
 });
 
-it('should emit event on/off', async ({page, server}) => {
+it('should emit event on/off', async ({ page, server }) => {
   await page.setContent(`<input type=file>`);
   const [chooser] = await Promise.all([
     new Promise(f => {
@@ -96,7 +96,7 @@ it('should emit event on/off', async ({page, server}) => {
   expect(chooser).toBeTruthy();
 });
 
-it('should emit event addListener/removeListener', async ({page, server}) => {
+it('should emit event addListener/removeListener', async ({ page, server }) => {
   await page.setContent(`<input type=file>`);
   const [chooser] = await Promise.all([
     new Promise(f => {
@@ -111,7 +111,7 @@ it('should emit event addListener/removeListener', async ({page, server}) => {
   expect(chooser).toBeTruthy();
 });
 
-it('should work when file input is attached to DOM', async ({page, server}) => {
+it('should work when file input is attached to DOM', async ({ page, server }) => {
   await page.setContent(`<input type=file>`);
   const [chooser] = await Promise.all([
     page.waitForEvent('filechooser'),
@@ -120,7 +120,7 @@ it('should work when file input is attached to DOM', async ({page, server}) => {
   expect(chooser).toBeTruthy();
 });
 
-it('should work when file input is not attached to DOM', async ({page, asset}) => {
+it('should work when file input is not attached to DOM', async ({ page, asset }) => {
   const [,content] = await Promise.all([
     page.waitForEvent('filechooser').then(chooser => chooser.setFiles(asset('file-to-upload.txt'))),
     page.evaluate(async () => {
@@ -137,7 +137,7 @@ it('should work when file input is not attached to DOM', async ({page, asset}) =
   expect(content).toBe('contents of the file');
 });
 
-it('should not throw when filechooser belongs to iframe', async ({page, server, browserName}) => {
+it('should not throw when filechooser belongs to iframe', async ({ page, server, browserName }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   const frame = page.mainFrame().childFrames()[0];
   await frame.setContent(`
@@ -158,7 +158,7 @@ it('should not throw when filechooser belongs to iframe', async ({page, server, 
   await page.waitForFunction(() => (window as any).__done);
 });
 
-it('should not throw when frame is detached immediately', async ({page, server}) => {
+it('should not throw when frame is detached immediately', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   const frame = page.mainFrame().childFrames()[0];
   await frame.setContent(`
@@ -179,7 +179,7 @@ it('should not throw when frame is detached immediately', async ({page, server})
   await page.waitForFunction(() => (window as any).__done);
 });
 
-it('should work with CSP', async ({page, server, asset}) => {
+it('should work with CSP', async ({ page, server, asset }) => {
   server.setCSP('/empty.html', 'default-src "none"');
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<input type=file>`);
@@ -188,29 +188,29 @@ it('should work with CSP', async ({page, server, asset}) => {
   expect(await page.$eval('input', input => input.files[0].name)).toBe('file-to-upload.txt');
 });
 
-it('should respect timeout', async ({page, playwright}) => {
+it('should respect timeout', async ({ page, playwright }) => {
   let error = null;
-  await page.waitForEvent('filechooser', {timeout: 1}).catch(e => error = e);
+  await page.waitForEvent('filechooser', { timeout: 1 }).catch(e => error = e);
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should respect default timeout when there is no custom timeout', async ({page, playwright}) => {
+it('should respect default timeout when there is no custom timeout', async ({ page, playwright }) => {
   page.setDefaultTimeout(1);
   let error = null;
   await page.waitForEvent('filechooser').catch(e => error = e);
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should prioritize exact timeout over default timeout', async ({page, playwright}) => {
+it('should prioritize exact timeout over default timeout', async ({ page, playwright }) => {
   page.setDefaultTimeout(0);
   let error = null;
-  await page.waitForEvent('filechooser', {timeout: 1}).catch(e => error = e);
+  await page.waitForEvent('filechooser', { timeout: 1 }).catch(e => error = e);
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should work with no timeout', async ({page, server}) => {
+it('should work with no timeout', async ({ page, server }) => {
   const [chooser] = await Promise.all([
-    page.waitForEvent('filechooser', {timeout: 0}),
+    page.waitForEvent('filechooser', { timeout: 0 }),
     page.evaluate(() => setTimeout(() => {
       const el = document.createElement('input');
       el.type = 'file';
@@ -220,7 +220,7 @@ it('should work with no timeout', async ({page, server}) => {
   expect(chooser).toBeTruthy();
 });
 
-it('should return the same file chooser when there are many watchdogs simultaneously', async ({page, server}) => {
+it('should return the same file chooser when there are many watchdogs simultaneously', async ({ page, server }) => {
   await page.setContent(`<input type=file>`);
   const [fileChooser1, fileChooser2] = await Promise.all([
     page.waitForEvent('filechooser'),
@@ -230,7 +230,7 @@ it('should return the same file chooser when there are many watchdogs simultaneo
   expect(fileChooser1 === fileChooser2).toBe(true);
 });
 
-it('should accept single file', async ({page, asset}) => {
+it('should accept single file', async ({ page, asset }) => {
   await page.setContent(`<input type=file oninput='javascript:console.timeStamp()'>`);
   const [fileChooser] = await Promise.all([
     page.waitForEvent('filechooser'),
@@ -243,7 +243,7 @@ it('should accept single file', async ({page, asset}) => {
   expect(await page.$eval('input', input => input.files[0].name)).toBe('file-to-upload.txt');
 });
 
-it('should detect mime type', async ({page, server, asset, isAndroid}) => {
+it('should detect mime type', async ({ page, server, asset, isAndroid }) => {
   it.fixme(isAndroid);
 
   let files;
@@ -279,7 +279,7 @@ it('should detect mime type', async ({page, server, asset, isAndroid}) => {
 });
 
 // @see https://github.com/microsoft/playwright/issues/4704
-it('should not trim big uploaded files', async ({page, server, asset, isAndroid}) => {
+it('should not trim big uploaded files', async ({ page, server, asset, isAndroid }) => {
   it.fixme(isAndroid);
 
   let files;
@@ -304,7 +304,7 @@ it('should not trim big uploaded files', async ({page, server, asset, isAndroid}
   expect(files.file.size).toBe(DATA_SIZE);
 });
 
-it('should be able to read selected file', async ({page, asset}) => {
+it('should be able to read selected file', async ({ page, asset }) => {
   await page.setContent(`<input type=file>`);
   const [, content] = await Promise.all([
     page.waitForEvent('filechooser').then(fileChooser => fileChooser.setFiles(asset('file-to-upload.txt'))),
@@ -320,7 +320,7 @@ it('should be able to read selected file', async ({page, asset}) => {
   expect(content).toBe('contents of the file');
 });
 
-it('should be able to reset selected files with empty file list', async ({page, asset}) => {
+it('should be able to reset selected files with empty file list', async ({ page, asset }) => {
   await page.setContent(`<input type=file>`);
   const [, fileLength1] = await Promise.all([
     page.waitForEvent('filechooser').then(fileChooser => fileChooser.setFiles(asset('file-to-upload.txt'))),
@@ -342,7 +342,7 @@ it('should be able to reset selected files with empty file list', async ({page, 
   expect(fileLength2).toBe(0);
 });
 
-it('should not accept multiple files for single-file input', async ({page, asset}) => {
+it('should not accept multiple files for single-file input', async ({ page, asset }) => {
   await page.setContent(`<input type=file>`);
   const [fileChooser] = await Promise.all([
     page.waitForEvent('filechooser'),
@@ -356,7 +356,7 @@ it('should not accept multiple files for single-file input', async ({page, asset
   expect(error).not.toBe(null);
 });
 
-it('should emit input and change events', async ({page, asset}) => {
+it('should emit input and change events', async ({ page, asset }) => {
   const events = [];
   await page.exposeFunction('eventHandled', e => events.push(e));
   await page.setContent(`
@@ -371,7 +371,7 @@ it('should emit input and change events', async ({page, asset}) => {
   expect(events[1].type).toBe('change');
 });
 
-it('should work for single file pick', async ({page, server}) => {
+it('should work for single file pick', async ({ page, server }) => {
   await page.setContent(`<input type=file>`);
   const [fileChooser] = await Promise.all([
     page.waitForEvent('filechooser'),
@@ -380,7 +380,7 @@ it('should work for single file pick', async ({page, server}) => {
   expect(fileChooser.isMultiple()).toBe(false);
 });
 
-it('should work for "multiple"', async ({page, server}) => {
+it('should work for "multiple"', async ({ page, server }) => {
   await page.setContent(`<input multiple type=file>`);
   const [fileChooser] = await Promise.all([
     page.waitForEvent('filechooser'),
@@ -389,7 +389,7 @@ it('should work for "multiple"', async ({page, server}) => {
   expect(fileChooser.isMultiple()).toBe(true);
 });
 
-it('should work for "webkitdirectory"', async ({page, server}) => {
+it('should work for "webkitdirectory"', async ({ page, server }) => {
   await page.setContent(`<input multiple webkitdirectory type=file>`);
   const [fileChooser] = await Promise.all([
     page.waitForEvent('filechooser'),

--- a/tests/page/page-wait-for-function.spec.ts
+++ b/tests/page/page-wait-for-function.spec.ts
@@ -17,20 +17,20 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should timeout', async ({page}) => {
+it('should timeout', async ({ page }) => {
   const startTime = Date.now();
   const timeout = 42;
   await page.waitForTimeout(timeout);
   expect(Date.now() - startTime).not.toBeLessThan(timeout / 2);
 });
 
-it('should accept a string', async ({page}) => {
+it('should accept a string', async ({ page }) => {
   const watchdog = page.waitForFunction('window.__FOO === 1');
   await page.evaluate(() => window['__FOO'] = 1);
   await watchdog;
 });
 
-it('should work when resolved right before execution context disposal', async ({page}) => {
+it('should work when resolved right before execution context disposal', async ({ page }) => {
   await page.addInitScript(() => window['__RELOADED'] = true);
   await page.waitForFunction(() => {
     if (!window['__RELOADED'])
@@ -39,7 +39,7 @@ it('should work when resolved right before execution context disposal', async ({
   });
 });
 
-it('should poll on interval', async ({page, server}) => {
+it('should poll on interval', async ({ page, server }) => {
   const polling = 100;
   const timeDelta = await page.waitForFunction(() => {
     if (!window['__startTime']) {
@@ -47,11 +47,11 @@ it('should poll on interval', async ({page, server}) => {
       return false;
     }
     return Date.now() - window['__startTime'];
-  }, {}, {polling});
+  }, {}, { polling });
   expect(await timeDelta.jsonValue()).not.toBeLessThan(polling);
 });
 
-it('should avoid side effects after timeout', async ({page}) => {
+it('should avoid side effects after timeout', async ({ page }) => {
   let counter = 0;
   page.on('console', () => ++counter);
 
@@ -67,24 +67,24 @@ it('should avoid side effects after timeout', async ({page}) => {
   expect(counter).toBe(savedCounter);
 });
 
-it('should throw on polling:mutation', async ({page}) => {
+it('should throw on polling:mutation', async ({ page }) => {
   // @ts-expect-error mutation is not a valid polling strategy
-  const error = await page.waitForFunction(() => true, {}, {polling: 'mutation'}).catch(e => e);
+  const error = await page.waitForFunction(() => true, {}, { polling: 'mutation' }).catch(e => e);
   expect(error.message).toContain('Unknown polling option: mutation');
 });
 
-it('should poll on raf', async ({page}) => {
-  const watchdog = page.waitForFunction(() => window['__FOO'] === 'hit', {}, {polling: 'raf'});
+it('should poll on raf', async ({ page }) => {
+  const watchdog = page.waitForFunction(() => window['__FOO'] === 'hit', {}, { polling: 'raf' });
   await page.evaluate(() => window['__FOO'] = 'hit');
   await watchdog;
 });
 
-it('should fail with predicate throwing on first call', async ({page}) => {
+it('should fail with predicate throwing on first call', async ({ page }) => {
   const error = await page.waitForFunction(() => { throw new Error('oh my'); }).catch(e => e);
   expect(error.message).toContain('oh my');
 });
 
-it('should fail with predicate throwing sometimes', async ({page}) => {
+it('should fail with predicate throwing sometimes', async ({ page }) => {
   const error = await page.waitForFunction(() => {
     window['counter'] = (window['counter'] || 0) + 1;
     if (window['counter'] === 3)
@@ -94,28 +94,28 @@ it('should fail with predicate throwing sometimes', async ({page}) => {
   expect(error.message).toContain('Bad counter!');
 });
 
-it('should fail with ReferenceError on wrong page', async ({page}) => {
+it('should fail with ReferenceError on wrong page', async ({ page }) => {
   // @ts-ignore
   const error = await page.waitForFunction(() => globalVar === 123).catch(e => e);
   expect(error.message).toContain('globalVar');
 });
 
-it('should work with strict CSP policy', async ({page, server}) => {
+it('should work with strict CSP policy', async ({ page, server }) => {
   server.setCSP('/empty.html', 'script-src ' + server.PREFIX);
   await page.goto(server.EMPTY_PAGE);
   let error = null;
   await Promise.all([
-    page.waitForFunction(() => window['__FOO'] === 'hit', {}, {polling: 'raf'}).catch(e => error = e),
+    page.waitForFunction(() => window['__FOO'] === 'hit', {}, { polling: 'raf' }).catch(e => error = e),
     page.evaluate(() => window['__FOO'] = 'hit')
   ]);
   expect(error).toBe(null);
 });
 
-it('should throw on bad polling value', async ({page}) => {
+it('should throw on bad polling value', async ({ page }) => {
   let error = null;
   try {
     // @ts-expect-error 'unknown' is not a valid polling strategy
-    await page.waitForFunction(() => !!document.body, {}, {polling: 'unknown'});
+    await page.waitForFunction(() => !!document.body, {}, { polling: 'unknown' });
   } catch (e) {
     error = e;
   }
@@ -123,10 +123,10 @@ it('should throw on bad polling value', async ({page}) => {
   expect(error.message).toContain('polling');
 });
 
-it('should throw negative polling interval', async ({page}) => {
+it('should throw negative polling interval', async ({ page }) => {
   let error = null;
   try {
-    await page.waitForFunction(() => !!document.body, {}, {polling: -10});
+    await page.waitForFunction(() => !!document.body, {}, { polling: -10 });
   } catch (e) {
     error = e;
   }
@@ -134,7 +134,7 @@ it('should throw negative polling interval', async ({page}) => {
   expect(error.message).toContain('Cannot poll with non-positive interval');
 });
 
-it('should return the success value as a JSHandle', async ({page}) => {
+it('should return the success value as a JSHandle', async ({ page }) => {
   expect(await (await page.waitForFunction(() => 5)).jsonValue()).toBe(5);
 });
 
@@ -142,7 +142,7 @@ it('should return the window as a success value', async ({ page }) => {
   expect(await page.waitForFunction(() => window)).toBeTruthy();
 });
 
-it('should accept ElementHandle arguments', async ({page}) => {
+it('should accept ElementHandle arguments', async ({ page }) => {
   await page.setContent('<div></div>');
   const div = await page.$('div');
   let resolved = false;
@@ -152,15 +152,15 @@ it('should accept ElementHandle arguments', async ({page}) => {
   await waitForFunction;
 });
 
-it('should respect timeout', async ({page, playwright}) => {
+it('should respect timeout', async ({ page, playwright }) => {
   let error = null;
-  await page.waitForFunction('false', {}, {timeout: 10}).catch(e => error = e);
+  await page.waitForFunction('false', {}, { timeout: 10 }).catch(e => error = e);
   expect(error).toBeTruthy();
   expect(error.message).toContain('page.waitForFunction: Timeout 10ms exceeded');
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should respect default timeout', async ({page, playwright}) => {
+it('should respect default timeout', async ({ page, playwright }) => {
   page.setDefaultTimeout(1);
   let error = null;
   await page.waitForFunction('false').catch(e => error = e);
@@ -168,17 +168,17 @@ it('should respect default timeout', async ({page, playwright}) => {
   expect(error.message).toContain('page.waitForFunction: Timeout 1ms exceeded');
 });
 
-it('should disable timeout when its set to 0', async ({page}) => {
+it('should disable timeout when its set to 0', async ({ page }) => {
   const watchdog = page.waitForFunction(() => {
     window['__counter'] = (window['__counter'] || 0) + 1;
     return window['__injected'];
-  }, {}, {timeout: 0, polling: 10});
+  }, {}, { timeout: 0, polling: 10 });
   await page.waitForFunction(() => window['__counter'] > 10);
   await page.evaluate(() => window['__injected'] = true);
   await watchdog;
 });
 
-it('should survive cross-process navigation', async ({page, server}) => {
+it('should survive cross-process navigation', async ({ page, server }) => {
   let fooFound = false;
   const waitForFunction = page.waitForFunction('window.__FOO === 1').then(() => fooFound = true);
   await page.goto(server.EMPTY_PAGE);
@@ -192,7 +192,7 @@ it('should survive cross-process navigation', async ({page, server}) => {
   expect(fooFound).toBe(true);
 });
 
-it('should survive navigations', async ({page, server}) => {
+it('should survive navigations', async ({ page, server }) => {
   const watchdog = page.waitForFunction(() => window['__done']);
   await page.goto(server.EMPTY_PAGE);
   await page.goto(server.PREFIX + '/consolelog.html');
@@ -200,18 +200,18 @@ it('should survive navigations', async ({page, server}) => {
   await watchdog;
 });
 
-it('should work with multiline body', async ({page}) => {
+it('should work with multiline body', async ({ page }) => {
   const result = await page.waitForFunction(`
     (() => true)()
   `);
   expect(await result.jsonValue()).toBe(true);
 });
 
-it('should wait for predicate with arguments', async ({page}) => {
-  await page.waitForFunction(({arg1, arg2}) => arg1 + arg2 === 3, { arg1: 1, arg2: 2});
+it('should wait for predicate with arguments', async ({ page }) => {
+  await page.waitForFunction(({ arg1, arg2 }) => arg1 + arg2 === 3, { arg1: 1, arg2: 2 });
 });
 
-it('should not be called after finishing successfully', async ({page, server}) => {
+it('should not be called after finishing successfully', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
 
   const messages = [];
@@ -238,7 +238,7 @@ it('should not be called after finishing successfully', async ({page, server}) =
   expect(messages.join('|')).toBe('waitForFunction1|waitForFunction2|waitForFunction3');
 });
 
-it('should not be called after finishing unsuccessfully', async ({page, server}) => {
+it('should not be called after finishing unsuccessfully', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
 
   const messages = [];

--- a/tests/page/page-wait-for-load-state.spec.ts
+++ b/tests/page/page-wait-for-load-state.spec.ts
@@ -18,12 +18,12 @@
 import { test as it, expect } from './pageTest';
 import type { Route } from '../../index';
 
-it('should pick up ongoing navigation', async ({page, server}) => {
+it('should pick up ongoing navigation', async ({ page, server }) => {
   let response = null;
   server.setRoute('/one-style.css', (req, res) => response = res);
   await Promise.all([
     server.waitForRequest('/one-style.css'),
-    page.goto(server.PREFIX + '/one-style.html', {waitUntil: 'domcontentloaded'}),
+    page.goto(server.PREFIX + '/one-style.html', { waitUntil: 'domcontentloaded' }),
   ]);
   const waitPromise = page.waitForLoadState();
   response.statusCode = 404;
@@ -31,34 +31,34 @@ it('should pick up ongoing navigation', async ({page, server}) => {
   await waitPromise;
 });
 
-it('should respect timeout', async ({page, server}) => {
+it('should respect timeout', async ({ page, server }) => {
   server.setRoute('/one-style.css', (req, res) => void 0);
-  await page.goto(server.PREFIX + '/one-style.html', {waitUntil: 'domcontentloaded'});
+  await page.goto(server.PREFIX + '/one-style.html', { waitUntil: 'domcontentloaded' });
   const error = await page.waitForLoadState('load', { timeout: 1 }).catch(e => e);
   expect(error.message).toContain('page.waitForLoadState: Timeout 1ms exceeded.');
   expect(error.stack.split('\n')[1]).toContain(__filename);
 });
 
-it('should resolve immediately if loaded', async ({page, server}) => {
+it('should resolve immediately if loaded', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/one-style.html');
   await page.waitForLoadState();
 });
 
-it('should throw for bad state', async ({page, server}) => {
+it('should throw for bad state', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/one-style.html');
   // @ts-expect-error 'bad' is not a valid load state
   const error = await page.waitForLoadState('bad').catch(e => e);
   expect(error.message).toContain(`state: expected one of (load|domcontentloaded|networkidle)`);
 });
 
-it('should resolve immediately if load state matches', async ({page, server}) => {
+it('should resolve immediately if load state matches', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   server.setRoute('/one-style.css', (req, res) => void 0);
-  await page.goto(server.PREFIX + '/one-style.html', {waitUntil: 'domcontentloaded'});
+  await page.goto(server.PREFIX + '/one-style.html', { waitUntil: 'domcontentloaded' });
   await page.waitForLoadState('domcontentloaded');
 });
 
-it('should work with pages that have loaded before being connected to', async ({page, server}) => {
+it('should work with pages that have loaded before being connected to', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
@@ -70,7 +70,7 @@ it('should work with pages that have loaded before being connected to', async ({
   expect(popup.url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should wait for load state of empty url popup', async ({page, browserName}) => {
+it('should wait for load state of empty url popup', async ({ page, browserName }) => {
   const [popup, readyState] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => {
@@ -83,7 +83,7 @@ it('should wait for load state of empty url popup', async ({page, browserName}) 
   expect(await popup.evaluate(() => document.readyState)).toBe(browserName === 'firefox' ? 'uninitialized' : 'complete');
 });
 
-it('should wait for load state of about:blank popup ', async ({page}) => {
+it('should wait for load state of about:blank popup ', async ({ page }) => {
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => window.open('about:blank') && 1),
@@ -92,7 +92,7 @@ it('should wait for load state of about:blank popup ', async ({page}) => {
   expect(await popup.evaluate(() => document.readyState)).toBe('complete');
 });
 
-it('should wait for load state of about:blank popup with noopener ', async ({page}) => {
+it('should wait for load state of about:blank popup with noopener ', async ({ page }) => {
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => window.open('about:blank', null, 'noopener') && 1),
@@ -101,7 +101,7 @@ it('should wait for load state of about:blank popup with noopener ', async ({pag
   expect(await popup.evaluate(() => document.readyState)).toBe('complete');
 });
 
-it('should wait for load state of popup with network url ', async ({page, server}) => {
+it('should wait for load state of popup with network url ', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
@@ -111,7 +111,7 @@ it('should wait for load state of popup with network url ', async ({page, server
   expect(await popup.evaluate(() => document.readyState)).toBe('complete');
 });
 
-it('should wait for load state of popup with network url and noopener ', async ({page, server}) => {
+it('should wait for load state of popup with network url and noopener ', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
@@ -121,7 +121,7 @@ it('should wait for load state of popup with network url and noopener ', async (
   expect(await popup.evaluate(() => document.readyState)).toBe('complete');
 });
 
-it('should work with clicking target=_blank', async ({page, server}) => {
+it('should work with clicking target=_blank', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent('<a target=_blank rel="opener" href="/one-style.html">yo</a>');
   const [popup] = await Promise.all([
@@ -132,7 +132,7 @@ it('should work with clicking target=_blank', async ({page, server}) => {
   expect(await popup.evaluate(() => document.readyState)).toBe('complete');
 });
 
-it('should wait for load state of newPage', async ({page, server, isElectron}) => {
+it('should wait for load state of newPage', async ({ page, server, isElectron }) => {
   it.fixme(isElectron, 'BrowserContext.newPage does not work in Electron');
 
   const [newPage] = await Promise.all([
@@ -143,7 +143,7 @@ it('should wait for load state of newPage', async ({page, server, isElectron}) =
   expect(await newPage.evaluate(() => document.readyState)).toBe('complete');
 });
 
-it('should resolve after popup load', async ({page, server}) => {
+it('should resolve after popup load', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   // Stall the 'load' by delaying css.
   let cssResponse;
@@ -165,12 +165,12 @@ it('should resolve after popup load', async ({page, server}) => {
   expect(popup.url()).toBe(server.PREFIX + '/one-style.html');
 });
 
-it('should work for frame', async ({page, server}) => {
+it('should work for frame', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   const frame = page.frames()[1];
 
   const requestPromise = new Promise<Route>(resolve => page.route(server.PREFIX + '/one-style.css',resolve));
-  await frame.goto(server.PREFIX + '/one-style.html', {waitUntil: 'domcontentloaded'});
+  await frame.goto(server.PREFIX + '/one-style.html', { waitUntil: 'domcontentloaded' });
   const request = await requestPromise;
   let resolved = false;
   const loadPromise = frame.waitForLoadState().then(() => resolved = true);

--- a/tests/page/page-wait-for-navigation.spec.ts
+++ b/tests/page/page-wait-for-navigation.spec.ts
@@ -19,7 +19,7 @@ import { test as it, expect } from './pageTest';
 import type { Frame } from '../../index';
 import { expectedSSLError } from '../config/utils';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [response] = await Promise.all([
     page.waitForNavigation(),
@@ -29,7 +29,7 @@ it('should work', async ({page, server}) => {
   expect(response.url()).toContain('grid.html');
 });
 
-it('should respect timeout', async ({page, server}) => {
+it('should respect timeout', async ({ page, server }) => {
   const promise = page.waitForNavigation({ url: '**/frame.html', timeout: 5000 });
   await page.goto(server.EMPTY_PAGE);
   const error = await promise.catch(e => e);
@@ -38,7 +38,7 @@ it('should respect timeout', async ({page, server}) => {
   expect(error.message).toContain(`navigated to "${server.EMPTY_PAGE}"`);
 });
 
-it('should work with both domcontentloaded and load', async ({page, server}) => {
+it('should work with both domcontentloaded and load', async ({ page, server }) => {
   let response = null;
   server.setRoute('/one-style.css', (req, res) => response = res);
   const navigationPromise = page.goto(server.PREFIX + '/one-style.html');
@@ -60,7 +60,7 @@ it('should work with both domcontentloaded and load', async ({page, server}) => 
   await navigationPromise;
 });
 
-it('should work with clicking on anchor links', async ({page, server}) => {
+it('should work with clicking on anchor links', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<a href='#foobar'>foobar</a>`);
   const [response] = await Promise.all([
@@ -71,7 +71,7 @@ it('should work with clicking on anchor links', async ({page, server}) => {
   expect(page.url()).toBe(server.EMPTY_PAGE + '#foobar');
 });
 
-it('should work with clicking on links which do not commit navigation', async ({page, server, httpsServer, browserName}) => {
+it('should work with clicking on links which do not commit navigation', async ({ page, server, httpsServer, browserName }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<a href='${httpsServer.EMPTY_PAGE}'>foobar</a>`);
   const [error] = await Promise.all([
@@ -81,7 +81,7 @@ it('should work with clicking on links which do not commit navigation', async ({
   expect(error.message).toContain(expectedSSLError(browserName));
 });
 
-it('should work with history.pushState()', async ({page, server}) => {
+it('should work with history.pushState()', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`
     <a onclick='javascript:pushState()'>SPA</a>
@@ -97,7 +97,7 @@ it('should work with history.pushState()', async ({page, server}) => {
   expect(page.url()).toBe(server.PREFIX + '/wow.html');
 });
 
-it('should work with history.replaceState()', async ({page, server}) => {
+it('should work with history.replaceState()', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`
     <a onclick='javascript:replaceState()'>SPA</a>
@@ -113,7 +113,7 @@ it('should work with history.replaceState()', async ({page, server}) => {
   expect(page.url()).toBe(server.PREFIX + '/replaced.html');
 });
 
-it('should work with DOM history.back()/history.forward()', async ({page, server}) => {
+it('should work with DOM history.back()/history.forward()', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`
     <a id=back onclick='javascript:goBack()'>back</a>
@@ -140,7 +140,7 @@ it('should work with DOM history.back()/history.forward()', async ({page, server
   expect(page.url()).toBe(server.PREFIX + '/second.html');
 });
 
-it('should work when subframe issues window.stop()', async ({page, server}) => {
+it('should work when subframe issues window.stop()', async ({ page, server }) => {
   server.setRoute('/frames/style.css', (req, res) => {});
   const navigationPromise = page.goto(server.PREFIX + '/frames/one-frame.html');
   const frame = await new Promise<Frame>(f => page.once('frameattached', f));
@@ -154,7 +154,7 @@ it('should work when subframe issues window.stop()', async ({page, server}) => {
   ]);
 });
 
-it('should work with url match', async ({page, server}) => {
+it('should work with url match', async ({ page, server }) => {
   let response1 = null;
   const response1Promise = page.waitForNavigation({ url: /one-style\.html/ }).then(response => response1 = response);
   let response2 = null;
@@ -189,7 +189,7 @@ it('should work with url match', async ({page, server}) => {
   expect(response3.url()).toBe(server.PREFIX + '/frame.html?foo=bar');
 });
 
-it('should work with url match for same document navigations', async ({page, server}) => {
+it('should work with url match for same document navigations', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let resolved = false;
   const waitPromise = page.waitForNavigation({ url: /third\.html/ }).then(() => resolved = true);
@@ -209,9 +209,9 @@ it('should work with url match for same document navigations', async ({page, ser
   expect(resolved).toBe(true);
 });
 
-it('should work for cross-process navigations', async ({page, server}) => {
+it('should work for cross-process navigations', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
-  const waitPromise = page.waitForNavigation({waitUntil: 'domcontentloaded'});
+  const waitPromise = page.waitForNavigation({ waitUntil: 'domcontentloaded' });
   const url = server.CROSS_PROCESS_PREFIX + '/empty.html';
   const gotoPromise = page.goto(url);
   const response = await waitPromise;
@@ -221,7 +221,7 @@ it('should work for cross-process navigations', async ({page, server}) => {
   await gotoPromise;
 });
 
-it('should work on frame', async ({page, server}) => {
+it('should work on frame', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   const frame = page.frames()[1];
   const [response] = await Promise.all([
@@ -234,7 +234,7 @@ it('should work on frame', async ({page, server}) => {
   expect(page.url()).toContain('/frames/one-frame.html');
 });
 
-it('should fail when frame detaches', async ({page, server}) => {
+it('should fail when frame detaches', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   const frame = page.frames()[1];
   server.setRoute('/empty.html', () => {});

--- a/tests/page/page-wait-for-request.spec.ts
+++ b/tests/page/page-wait-for-request.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import vm from 'vm';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     page.waitForRequest(server.PREFIX + '/digits/2.png'),
@@ -31,7 +31,7 @@ it('should work', async ({page, server}) => {
   expect(request.url()).toBe(server.PREFIX + '/digits/2.png');
 });
 
-it('should work with predicate', async ({page, server}) => {
+it('should work with predicate', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     page.waitForEvent('request', request => request.url() === server.PREFIX + '/digits/2.png'),
@@ -44,28 +44,28 @@ it('should work with predicate', async ({page, server}) => {
   expect(request.url()).toBe(server.PREFIX + '/digits/2.png');
 });
 
-it('should respect timeout', async ({page, playwright}) => {
+it('should respect timeout', async ({ page, playwright }) => {
   let error = null;
   await page.waitForEvent('request', { predicate: () => false, timeout: 1 }).catch(e => error = e);
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should respect default timeout', async ({page, playwright}) => {
+it('should respect default timeout', async ({ page, playwright }) => {
   let error = null;
   page.setDefaultTimeout(1);
   await page.waitForEvent('request', () => false).catch(e => error = e);
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should log the url', async ({page}) => {
+it('should log the url', async ({ page }) => {
   const error = await page.waitForRequest('long-long-long-long-long-long-long-long-long-long-long-long-long-long.css', { timeout: 100 }).catch(e => e);
   expect(error.message).toContain('waiting for request "long-long-long-long-long-long-long-long-long-long-…"');
 });
 
-it('should work with no timeout', async ({page, server}) => {
+it('should work with no timeout', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
-    page.waitForRequest(server.PREFIX + '/digits/2.png', {timeout: 0}),
+    page.waitForRequest(server.PREFIX + '/digits/2.png', { timeout: 0 }),
     page.evaluate(() => setTimeout(() => {
       fetch('/digits/1.png');
       fetch('/digits/2.png');
@@ -75,7 +75,7 @@ it('should work with no timeout', async ({page, server}) => {
   expect(request.url()).toBe(server.PREFIX + '/digits/2.png');
 });
 
-it('should work with url match', async ({page, server}) => {
+it('should work with url match', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     page.waitForRequest(/digits\/\d\.png/),
@@ -86,7 +86,7 @@ it('should work with url match', async ({page, server}) => {
   expect(request.url()).toBe(server.PREFIX + '/digits/1.png');
 });
 
-it('should work with url match regular expression from a different context', async ({page, server}) => {
+it('should work with url match regular expression from a different context', async ({ page, server }) => {
   const ctx = vm.createContext();
   const regexp = vm.runInContext('new RegExp(/digits\\/\\d\\.png/)', ctx);
 

--- a/tests/page/page-wait-for-response.spec.ts
+++ b/tests/page/page-wait-for-response.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [response] = await Promise.all([
     page.waitForResponse(server.PREFIX + '/digits/2.png'),
@@ -30,27 +30,27 @@ it('should work', async ({page, server}) => {
   expect(response.url()).toBe(server.PREFIX + '/digits/2.png');
 });
 
-it('should respect timeout', async ({page, playwright}) => {
+it('should respect timeout', async ({ page, playwright }) => {
   let error = null;
   await page.waitForEvent('response', { predicate: () => false, timeout: 1 }).catch(e => error = e);
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should respect default timeout', async ({page, playwright}) => {
+it('should respect default timeout', async ({ page, playwright }) => {
   let error = null;
   page.setDefaultTimeout(1);
   await page.waitForEvent('response', () => false).catch(e => error = e);
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should log the url', async ({page}) => {
+it('should log the url', async ({ page }) => {
   const error1 = await page.waitForResponse('foo.css', { timeout: 100 }).catch(e => e);
   expect(error1.message).toContain('waiting for response "foo.css"');
   const error2 = await page.waitForResponse(/foo.css/i, { timeout: 100 }).catch(e => e);
   expect(error2.message).toContain('waiting for response /foo.css/i');
 });
 
-it('should work with predicate', async ({page, server}) => {
+it('should work with predicate', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [response] = await Promise.all([
     page.waitForEvent('response', response => response.url() === server.PREFIX + '/digits/2.png'),
@@ -63,7 +63,7 @@ it('should work with predicate', async ({page, server}) => {
   expect(response.url()).toBe(server.PREFIX + '/digits/2.png');
 });
 
-it('should work with async predicate', async ({page, server}) => {
+it('should work with async predicate', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [response1, response2] = await Promise.all([
     page.waitForEvent('response', async response => {
@@ -83,7 +83,7 @@ it('should work with async predicate', async ({page, server}) => {
   expect(response2.url()).toBe(server.PREFIX + '/simple.json');
 });
 
-it('sync predicate should be only called once', async ({page, server}) => {
+it('sync predicate should be only called once', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let counter = 0;
   const [response] = await Promise.all([
@@ -101,7 +101,7 @@ it('sync predicate should be only called once', async ({page, server}) => {
   expect(counter).toBe(1);
 });
 
-it('should work with no timeout', async ({page, server}) => {
+it('should work with no timeout', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [response] = await Promise.all([
     page.waitForResponse(server.PREFIX + '/digits/2.png', { timeout: 0 }),

--- a/tests/page/page-wait-for-selector-1.spec.ts
+++ b/tests/page/page-wait-for-selector-1.spec.ts
@@ -25,7 +25,7 @@ async function giveItTimeToLog(frame) {
 
 const addElement = tag => document.body.appendChild(document.createElement(tag));
 
-it('should throw on waitFor', async ({page, server}) => {
+it('should throw on waitFor', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let error;
   // @ts-expect-error waitFor is undocumented
@@ -33,7 +33,7 @@ it('should throw on waitFor', async ({page, server}) => {
   expect(error.message).toContain('options.waitFor is not supported, did you mean options.state?');
 });
 
-it('should tolerate waitFor=visible', async ({page, server}) => {
+it('should tolerate waitFor=visible', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let error = false;
   // @ts-expect-error waitFor is undocumented
@@ -41,22 +41,22 @@ it('should tolerate waitFor=visible', async ({page, server}) => {
   expect(error).toBe(false);
 });
 
-it('should immediately resolve promise if node exists', async ({page, server}) => {
+it('should immediately resolve promise if node exists', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const frame = page.mainFrame();
   await frame.waitForSelector('*');
   await frame.evaluate(addElement, 'div');
-  await frame.waitForSelector('div', { state: 'attached'});
+  await frame.waitForSelector('div', { state: 'attached' });
 });
 
-it('elementHandle.waitForSelector should immediately resolve if node exists', async ({page}) => {
+it('elementHandle.waitForSelector should immediately resolve if node exists', async ({ page }) => {
   await page.setContent(`<span>extra</span><div><span>target</span></div>`);
   const div = await page.$('div');
   const span = await div.waitForSelector('span', { state: 'attached' });
   expect(await span.evaluate(e => e.textContent)).toBe('target');
 });
 
-it('elementHandle.waitForSelector should wait', async ({page}) => {
+it('elementHandle.waitForSelector should wait', async ({ page }) => {
   await page.setContent(`<div></div>`);
   const div = await page.$('div');
   const promise = div.waitForSelector('span', { state: 'attached' });
@@ -65,14 +65,14 @@ it('elementHandle.waitForSelector should wait', async ({page}) => {
   expect(await span.evaluate(e => e.textContent)).toBe('target');
 });
 
-it('elementHandle.waitForSelector should timeout', async ({page}) => {
+it('elementHandle.waitForSelector should timeout', async ({ page }) => {
   await page.setContent(`<div></div>`);
   const div = await page.$('div');
   const error = await div.waitForSelector('span', { timeout: 100 }).catch(e => e);
   expect(error.message).toContain('Timeout 100ms exceeded.');
 });
 
-it('elementHandle.waitForSelector should throw on navigation', async ({page, server}) => {
+it('elementHandle.waitForSelector should throw on navigation', async ({ page, server }) => {
   await page.setContent(`<div></div>`);
   const div = await page.$('div');
   const promise = div.waitForSelector('span').catch(e => e);
@@ -84,7 +84,7 @@ it('elementHandle.waitForSelector should throw on navigation', async ({page, ser
   expect(error.message).toContain('Execution context was destroyed, most likely because of a navigation');
 });
 
-it('should work with removed MutationObserver', async ({page, server}) => {
+it('should work with removed MutationObserver', async ({ page, server }) => {
   await page.evaluate(() => delete window.MutationObserver);
   const [handle] = await Promise.all([
     page.waitForSelector('.zombo'),
@@ -93,7 +93,7 @@ it('should work with removed MutationObserver', async ({page, server}) => {
   expect(await page.evaluate(x => x.textContent, handle)).toBe('anything');
 });
 
-it('should resolve promise when node is added', async ({page, server}) => {
+it('should resolve promise when node is added', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const frame = page.mainFrame();
   const watchdog = frame.waitForSelector('div', { state: 'attached' });
@@ -104,7 +104,7 @@ it('should resolve promise when node is added', async ({page, server}) => {
   expect(tagName).toBe('DIV');
 });
 
-it('should report logs while waiting for visible', async ({page, server}) => {
+it('should report logs while waiting for visible', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const frame = page.mainFrame();
   const watchdog = frame.waitForSelector('div', { timeout: 5000 });
@@ -139,7 +139,7 @@ it('should report logs while waiting for visible', async ({page, server}) => {
   expect(error.message).toContain(`selector resolved to hidden <div class="another"></div>`);
 });
 
-it('should report logs while waiting for hidden', async ({page, server}) => {
+it('should report logs while waiting for hidden', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const frame = page.mainFrame();
   await frame.evaluate(() => {
@@ -169,7 +169,7 @@ it('should report logs while waiting for hidden', async ({page, server}) => {
   expect(error.message).toContain(`selector resolved to visible <div class="another">hello</div>`);
 });
 
-it('should report logs when the selector resolves to multiple elements', async ({page, server}) => {
+it('should report logs when the selector resolves to multiple elements', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`
     <button style="display: none; position: absolute; top: 0px; left: 0px; width: 100%;">
@@ -185,12 +185,12 @@ it('should report logs when the selector resolves to multiple elements', async (
   expect(error.toString()).toContain('selector resolved to 2 elements. Proceeding with the first one.');
 });
 
-it('should resolve promise when node is added in shadow dom', async ({page, server}) => {
+it('should resolve promise when node is added in shadow dom', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const watchdog = page.waitForSelector('span');
   await page.evaluate(() => {
     const div = document.createElement('div');
-    div.attachShadow({mode: 'open'});
+    div.attachShadow({ mode: 'open' });
     document.body.appendChild(div);
   });
   await page.evaluate(() => new Promise(f => setTimeout(f, 100)));
@@ -203,15 +203,15 @@ it('should resolve promise when node is added in shadow dom', async ({page, serv
   expect(await handle.evaluate(e => e.textContent)).toBe('Hello from shadow');
 });
 
-it('should work when node is added through innerHTML', async ({page, server}) => {
+it('should work when node is added through innerHTML', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
-  const watchdog = page.waitForSelector('h3 div', { state: 'attached'});
+  const watchdog = page.waitForSelector('h3 div', { state: 'attached' });
   await page.evaluate(addElement, 'span');
   await page.evaluate(() => document.querySelector('span').innerHTML = '<h3><div></div></h3>');
   await watchdog;
 });
 
-it('page.waitForSelector is shortcut for main frame', async ({page, server}) => {
+it('page.waitForSelector is shortcut for main frame', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   const otherFrame = page.frames()[1];
@@ -222,7 +222,7 @@ it('page.waitForSelector is shortcut for main frame', async ({page, server}) => 
   expect(await eHandle.ownerFrame()).toBe(page.mainFrame());
 });
 
-it('should run in specified frame', async ({page, server}) => {
+it('should run in specified frame', async ({ page, server }) => {
   await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   await attachFrame(page, 'frame2', server.EMPTY_PAGE);
   const frame1 = page.frames()[1];
@@ -234,7 +234,7 @@ it('should run in specified frame', async ({page, server}) => {
   expect(await eHandle.ownerFrame()).toBe(frame2);
 });
 
-it('should throw when frame is detached', async ({page, server}) => {
+it('should throw when frame is detached', async ({ page, server }) => {
   await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   const frame = page.frames()[1];
   let waitError = null;

--- a/tests/page/page-wait-for-selector-2.spec.ts
+++ b/tests/page/page-wait-for-selector-2.spec.ts
@@ -20,7 +20,7 @@ import { attachFrame, detachFrame } from '../config/utils';
 
 const addElement = tag => document.body.appendChild(document.createElement(tag));
 
-it('should survive cross-process navigation', async ({page, server}) => {
+it('should survive cross-process navigation', async ({ page, server }) => {
   let boxFound = false;
   const waitForSelector = page.waitForSelector('.box').then(() => boxFound = true);
   await page.goto(server.EMPTY_PAGE);
@@ -32,7 +32,7 @@ it('should survive cross-process navigation', async ({page, server}) => {
   expect(boxFound).toBe(true);
 });
 
-it('should wait for visible', async ({page, server}) => {
+it('should wait for visible', async ({ page, server }) => {
   let divFound = false;
   const waitForSelector = page.waitForSelector('div').then(() => divFound = true);
   await page.setContent(`<div style='display: none; visibility: hidden;'>1</div>`);
@@ -44,7 +44,7 @@ it('should wait for visible', async ({page, server}) => {
   expect(divFound).toBe(true);
 });
 
-it('should not consider visible when zero-sized', async ({page, server}) => {
+it('should not consider visible when zero-sized', async ({ page, server }) => {
   await page.setContent(`<div style='width: 0; height: 0;'>1</div>`);
   let error = await page.waitForSelector('div', { timeout: 1000 }).catch(e => e);
   expect(error.message).toContain('page.waitForSelector: Timeout 1000ms exceeded');
@@ -55,7 +55,7 @@ it('should not consider visible when zero-sized', async ({page, server}) => {
   expect(await page.waitForSelector('div', { timeout: 1000 })).toBeTruthy();
 });
 
-it('should wait for visible recursively', async ({page, server}) => {
+it('should wait for visible recursively', async ({ page, server }) => {
   let divVisible = false;
   const waitForSelector = page.waitForSelector('div#inner').then(() => divVisible = true);
   await page.setContent(`<div style='display: none; visibility: hidden;'><div id="inner">hi</div></div>`);
@@ -67,7 +67,7 @@ it('should wait for visible recursively', async ({page, server}) => {
   expect(divVisible).toBe(true);
 });
 
-it('hidden should wait for hidden', async ({page, server}) => {
+it('hidden should wait for hidden', async ({ page, server }) => {
   let divHidden = false;
   await page.setContent(`<div style='display: block;'>content</div>`);
   const waitForSelector = page.waitForSelector('div', { state: 'hidden' }).then(() => divHidden = true);
@@ -78,7 +78,7 @@ it('hidden should wait for hidden', async ({page, server}) => {
   expect(divHidden).toBe(true);
 });
 
-it('hidden should wait for display: none', async ({page, server}) => {
+it('hidden should wait for display: none', async ({ page, server }) => {
   let divHidden = false;
   await page.setContent(`<div style='display: block;'>content</div>`);
   const waitForSelector = page.waitForSelector('div', { state: 'hidden' }).then(() => divHidden = true);
@@ -89,7 +89,7 @@ it('hidden should wait for display: none', async ({page, server}) => {
   expect(divHidden).toBe(true);
 });
 
-it('hidden should wait for removal', async ({page, server}) => {
+it('hidden should wait for removal', async ({ page, server }) => {
   await page.setContent(`<div>content</div>`);
   let divRemoved = false;
   const waitForSelector = page.waitForSelector('div', { state: 'hidden' }).then(() => divRemoved = true);
@@ -100,12 +100,12 @@ it('hidden should wait for removal', async ({page, server}) => {
   expect(divRemoved).toBe(true);
 });
 
-it('should return null if waiting to hide non-existing element', async ({page, server}) => {
+it('should return null if waiting to hide non-existing element', async ({ page, server }) => {
   const handle = await page.waitForSelector('non-existing', { state: 'hidden' });
   expect(handle).toBe(null);
 });
 
-it('should respect timeout', async ({page, playwright}) => {
+it('should respect timeout', async ({ page, playwright }) => {
   let error = null;
   await page.waitForSelector('div', { timeout: 3000, state: 'attached' }).catch(e => error = e);
   expect(error).toBeTruthy();
@@ -114,7 +114,7 @@ it('should respect timeout', async ({page, playwright}) => {
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should have an error message specifically for awaiting an element to be hidden', async ({page, server}) => {
+it('should have an error message specifically for awaiting an element to be hidden', async ({ page, server }) => {
   await page.setContent(`<div>content</div>`);
   let error = null;
   await page.waitForSelector('div', { state: 'hidden', timeout: 1000 }).catch(e => error = e);
@@ -123,59 +123,59 @@ it('should have an error message specifically for awaiting an element to be hidd
   expect(error.message).toContain('waiting for selector "div" to be hidden');
 });
 
-it('should respond to node attribute mutation', async ({page, server}) => {
+it('should respond to node attribute mutation', async ({ page, server }) => {
   let divFound = false;
-  const waitForSelector = page.waitForSelector('.zombo', { state: 'attached'}).then(() => divFound = true);
+  const waitForSelector = page.waitForSelector('.zombo', { state: 'attached' }).then(() => divFound = true);
   await page.setContent(`<div class='notZombo'></div>`);
   expect(divFound).toBe(false);
   await page.evaluate(() => document.querySelector('div').className = 'zombo');
   expect(await waitForSelector).toBe(true);
 });
 
-it('should return the element handle', async ({page, server}) => {
+it('should return the element handle', async ({ page, server }) => {
   const waitForSelector = page.waitForSelector('.zombo');
   await page.setContent(`<div class='zombo'>anything</div>`);
   expect(await page.evaluate(x => x.textContent, await waitForSelector)).toBe('anything');
 });
 
-it('should have correct stack trace for timeout', async ({page, server}) => {
+it('should have correct stack trace for timeout', async ({ page, server }) => {
   let error;
   await page.waitForSelector('.zombo', { timeout: 10 }).catch(e => error = e);
   expect(error.stack).toContain('wait-for-selector');
 });
 
-it('should throw for unknown state option', async ({page, server}) => {
+it('should throw for unknown state option', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   // @ts-expect-error state is not an option of waitForSelector
-  const error = await page.waitForSelector('section', { state: 'foo'}).catch(e => e);
+  const error = await page.waitForSelector('section', { state: 'foo' }).catch(e => e);
   expect(error.message).toContain('state: expected one of (attached|detached|visible|hidden)');
 });
 
-it('should throw for visibility option', async ({page, server}) => {
+it('should throw for visibility option', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   // @ts-expect-error visibility is not an option of waitForSelector
   const error = await page.waitForSelector('section', { visibility: 'hidden' }).catch(e => e);
   expect(error.message).toContain('options.visibility is not supported, did you mean options.state?');
 });
 
-it('should throw for true state option', async ({page, server}) => {
+it('should throw for true state option', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   // @ts-expect-error state is not an option of waitForSelector
   const error = await page.waitForSelector('section', { state: true }).catch(e => e);
   expect(error.message).toContain('state: expected one of (attached|detached|visible|hidden)');
 });
 
-it('should throw for false state option', async ({page, server}) => {
+it('should throw for false state option', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   // @ts-expect-error state is not an option of waitForSelector
   const error = await page.waitForSelector('section', { state: false }).catch(e => e);
   expect(error.message).toContain('state: expected one of (attached|detached|visible|hidden)');
 });
 
-it('should support >> selector syntax', async ({page, server}) => {
+it('should support >> selector syntax', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const frame = page.mainFrame();
-  const watchdog = frame.waitForSelector('css=div >> css=span', { state: 'attached'});
+  const watchdog = frame.waitForSelector('css=div >> css=span', { state: 'attached' });
   await frame.evaluate(addElement, 'br');
   await frame.evaluate(addElement, 'div');
   await frame.evaluate(() => document.querySelector('div').appendChild(document.createElement('span')));
@@ -184,15 +184,15 @@ it('should support >> selector syntax', async ({page, server}) => {
   expect(tagName).toBe('SPAN');
 });
 
-it('should wait for detached if already detached', async ({page, server}) => {
+it('should wait for detached if already detached', async ({ page, server }) => {
   await page.setContent('<section id="testAttribute">43543</section>');
-  expect(await page.waitForSelector('css=div', { state: 'detached'})).toBe(null);
+  expect(await page.waitForSelector('css=div', { state: 'detached' })).toBe(null);
 });
 
-it('should wait for detached', async ({page, server}) => {
+it('should wait for detached', async ({ page, server }) => {
   await page.setContent('<section id="testAttribute"><div>43543</div></section>');
   let done = false;
-  const waitFor = page.waitForSelector('css=div', { state: 'detached'}).then(() => done = true);
+  const waitFor = page.waitForSelector('css=div', { state: 'detached' }).then(() => done = true);
   expect(done).toBe(false);
   await page.waitForSelector('css=section');
   expect(done).toBe(false);
@@ -201,13 +201,13 @@ it('should wait for detached', async ({page, server}) => {
   expect(done).toBe(true);
 });
 
-it('should support some fancy xpath', async ({page, server}) => {
+it('should support some fancy xpath', async ({ page, server }) => {
   await page.setContent(`<p>red herring</p><p>hello  world  </p>`);
   const waitForXPath = page.waitForSelector('//p[normalize-space(.)="hello world"]');
   expect(await page.evaluate(x => x.textContent, await waitForXPath)).toBe('hello  world  ');
 });
 
-it('should respect timeout xpath', async ({page, playwright}) => {
+it('should respect timeout xpath', async ({ page, playwright }) => {
   let error = null;
   await page.waitForSelector('//div', { state: 'attached', timeout: 3000 }).catch(e => error = e);
   expect(error).toBeTruthy();
@@ -216,7 +216,7 @@ it('should respect timeout xpath', async ({page, playwright}) => {
   expect(error).toBeInstanceOf(playwright.errors.TimeoutError);
 });
 
-it('should run in specified frame xpath', async ({page, server}) => {
+it('should run in specified frame xpath', async ({ page, server }) => {
   await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   await attachFrame(page, 'frame2', server.EMPTY_PAGE);
   const frame1 = page.frames()[1];
@@ -228,7 +228,7 @@ it('should run in specified frame xpath', async ({page, server}) => {
   expect(await eHandle.ownerFrame()).toBe(frame2);
 });
 
-it('should throw when frame is detached xpath', async ({page, server}) => {
+it('should throw when frame is detached xpath', async ({ page, server }) => {
   await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   const frame = page.frames()[1];
   let waitError = null;
@@ -239,19 +239,19 @@ it('should throw when frame is detached xpath', async ({page, server}) => {
   expect(waitError.message).toContain('waitForFunction failed: frame got detached.');
 });
 
-it('should return the element handle xpath', async ({page, server}) => {
+it('should return the element handle xpath', async ({ page, server }) => {
   const waitForXPath = page.waitForSelector('//*[@class="zombo"]');
   await page.setContent(`<div class='zombo'>anything</div>`);
   expect(await page.evaluate(x => x.textContent, await waitForXPath)).toBe('anything');
 });
 
-it('should allow you to select an element with single slash xpath', async ({page, server}) => {
+it('should allow you to select an element with single slash xpath', async ({ page, server }) => {
   await page.setContent(`<div>some text</div>`);
   const waitForXPath = page.waitForSelector('//html/body/div');
   expect(await page.evaluate(x => x.textContent, await waitForXPath)).toBe('some text');
 });
 
-it('should correctly handle hidden shadow host', async ({page, server}) => {
+it('should correctly handle hidden shadow host', async ({ page, server }) => {
   await page.setContent(`
     <x-host hidden></x-host>
     <script>
@@ -269,7 +269,7 @@ it('should correctly handle hidden shadow host', async ({page, server}) => {
   await page.waitForSelector('div', { state: 'hidden' });
 });
 
-it('should work when navigating before node adoption', async ({page, mode, server}) => {
+it('should work when navigating before node adoption', async ({ page, mode, server }) => {
   it.skip(mode !== 'default');
 
   await page.goto(server.EMPTY_PAGE);

--- a/tests/page/page-wait-for-url.spec.ts
+++ b/tests/page/page-wait-for-url.spec.ts
@@ -17,20 +17,20 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({page, server}) => {
+it('should work', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(url => window.location.href = url, server.PREFIX + '/grid.html');
   await page.waitForURL('**/grid.html');
 });
 
-it('should respect timeout', async ({page, server}) => {
+it('should respect timeout', async ({ page, server }) => {
   const promise = page.waitForURL('**/frame.html', { timeout: 2500 }).catch(e => e);
   await page.goto(server.EMPTY_PAGE);
   const error = await promise;
   expect(error.message).toContain('page.waitForURL: Timeout 2500ms exceeded.');
 });
 
-it('should work with both domcontentloaded and load', async ({page, server}) => {
+it('should work with both domcontentloaded and load', async ({ page, server }) => {
   let response = null;
   server.setRoute('/one-style.css', (req, res) => response = res);
   const navigationPromise = page.goto(server.PREFIX + '/one-style.html');
@@ -49,14 +49,14 @@ it('should work with both domcontentloaded and load', async ({page, server}) => 
   await navigationPromise;
 });
 
-it('should work with clicking on anchor links', async ({page, server}) => {
+it('should work with clicking on anchor links', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<a href='#foobar'>foobar</a>`);
   await page.click('a');
   await page.waitForURL('**/*#foobar');
 });
 
-it('should work with history.pushState()', async ({page, server}) => {
+it('should work with history.pushState()', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`
     <a onclick='javascript:pushState()'>SPA</a>
@@ -69,7 +69,7 @@ it('should work with history.pushState()', async ({page, server}) => {
   expect(page.url()).toBe(server.PREFIX + '/wow.html');
 });
 
-it('should work with history.replaceState()', async ({page, server}) => {
+it('should work with history.replaceState()', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`
     <a onclick='javascript:replaceState()'>SPA</a>
@@ -82,7 +82,7 @@ it('should work with history.replaceState()', async ({page, server}) => {
   expect(page.url()).toBe(server.PREFIX + '/replaced.html');
 });
 
-it('should work with DOM history.back()/history.forward()', async ({page, server}) => {
+it('should work with DOM history.back()/history.forward()', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`
     <a id=back onclick='javascript:goBack()'>back</a>
@@ -105,7 +105,7 @@ it('should work with DOM history.back()/history.forward()', async ({page, server
   expect(page.url()).toBe(server.PREFIX + '/second.html');
 });
 
-it('should work with url match for same document navigations', async ({page, server}) => {
+it('should work with url match for same document navigations', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let resolved = false;
   const waitPromise = page.waitForURL(/third\.html/).then(() => resolved = true);
@@ -125,7 +125,7 @@ it('should work with url match for same document navigations', async ({page, ser
   expect(resolved).toBe(true);
 });
 
-it('should work on frame', async ({page, server}) => {
+it('should work on frame', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   const frame = page.frames()[1];
   await frame.evaluate(url => window.location.href = url, server.PREFIX + '/grid.html');

--- a/tests/page/queryselector.spec.ts
+++ b/tests/page/queryselector.spec.ts
@@ -17,47 +17,47 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should throw for non-string selector', async ({page}) => {
+it('should throw for non-string selector', async ({ page }) => {
   const error = await page.$(null).catch(e => e);
   expect(error.message).toContain('selector: expected string, got object');
 });
 
-it('should query existing element with css selector', async ({page, server}) => {
+it('should query existing element with css selector', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   const element = await page.$('css=section');
   expect(element).toBeTruthy();
 });
 
-it('should query existing element with text selector', async ({page, server}) => {
+it('should query existing element with text selector', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   const element = await page.$('text="test"');
   expect(element).toBeTruthy();
 });
 
-it('should query existing element with xpath selector', async ({page, server}) => {
+it('should query existing element with xpath selector', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   const element = await page.$('xpath=/html/body/section');
   expect(element).toBeTruthy();
 });
 
-it('should return null for non-existing element', async ({page, server}) => {
+it('should return null for non-existing element', async ({ page, server }) => {
   const element = await page.$('non-existing-element');
   expect(element).toBe(null);
 });
 
-it('should auto-detect xpath selector', async ({page, server}) => {
+it('should auto-detect xpath selector', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   const element = await page.$('//html/body/section');
   expect(element).toBeTruthy();
 });
 
-it('should auto-detect xpath selector with starting parenthesis', async ({page, server}) => {
+it('should auto-detect xpath selector with starting parenthesis', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   const element = await page.$('(//section)[1]');
   expect(element).toBeTruthy();
 });
 
-it('should auto-detect xpath selector starting with ..', async ({page, server}) => {
+it('should auto-detect xpath selector starting with ..', async ({ page, server }) => {
   await page.setContent('<div><section>test</section><span></span></div>');
   const span = await page.$('"test" >> ../span');
   expect(await span.evaluate(e => e.nodeName)).toBe('SPAN');
@@ -65,25 +65,25 @@ it('should auto-detect xpath selector starting with ..', async ({page, server}) 
   expect(await div.evaluate(e => e.nodeName)).toBe('DIV');
 });
 
-it('should auto-detect text selector', async ({page, server}) => {
+it('should auto-detect text selector', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   const element = await page.$('"test"');
   expect(element).toBeTruthy();
 });
 
-it('should auto-detect css selector', async ({page, server}) => {
+it('should auto-detect css selector', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   const element = await page.$('section');
   expect(element).toBeTruthy();
 });
 
-it('should support >> syntax', async ({page, server}) => {
+it('should support >> syntax', async ({ page, server }) => {
   await page.setContent('<section><div>test</div></section>');
   const element = await page.$('css=section >> css=div');
   expect(element).toBeTruthy();
 });
 
-it('should query existing elements', async ({page, server}) => {
+it('should query existing elements', async ({ page, server }) => {
   await page.setContent('<div>A</div><br/><div>B</div>');
   const elements = await page.$$('div');
   expect(elements.length).toBe(2);
@@ -91,31 +91,31 @@ it('should query existing elements', async ({page, server}) => {
   expect(await Promise.all(promises)).toEqual(['A', 'B']);
 });
 
-it('should return empty array if nothing is found', async ({page, server}) => {
+it('should return empty array if nothing is found', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const elements = await page.$$('div');
   expect(elements.length).toBe(0);
 });
 
-it('xpath should query existing element', async ({page, server}) => {
+it('xpath should query existing element', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   const elements = await page.$$('xpath=/html/body/section');
   expect(elements[0]).toBeTruthy();
   expect(elements.length).toBe(1);
 });
 
-it('xpath should return empty array for non-existing element', async ({page, server}) => {
+it('xpath should return empty array for non-existing element', async ({ page, server }) => {
   const element = await page.$$('//html/body/non-existing-element');
   expect(element).toEqual([]);
 });
 
-it('xpath should return multiple elements', async ({page, server}) => {
+it('xpath should return multiple elements', async ({ page, server }) => {
   await page.setContent('<div></div><div></div>');
   const elements = await page.$$('xpath=/html/body/div');
   expect(elements.length).toBe(2);
 });
 
-it('$$ should work with bogus Array.from', async ({page, server}) => {
+it('$$ should work with bogus Array.from', async ({ page, server }) => {
   await page.setContent('<div>hello</div><div></div>');
   const div1 = await page.evaluateHandle(() => {
     Array.from = () => [];

--- a/tests/page/selectors-css.spec.ts
+++ b/tests/page/selectors-css.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work with large DOM', async ({page, server}) => {
+it('should work with large DOM', async ({ page, server }) => {
   await page.evaluate(() => {
     let id = 0;
     const next = (tag: string) => {
@@ -73,7 +73,7 @@ it('should work with large DOM', async ({page, server}) => {
   }
 });
 
-it('should work for open shadow roots', async ({page, server}) => {
+it('should work for open shadow roots', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$eval(`css=span`, e => e.textContent)).toBe('Hello from root1');
   expect(await page.$eval(`css=[attr="value\\ space"]`, e => e.textContent)).toBe('Hello from root3 #2');
@@ -101,7 +101,7 @@ it('should work for open shadow roots', async ({page, server}) => {
   expect(await root3.$(`css:light=[attr*="value"]`)).toBe(null);
 });
 
-it('should work with > combinator and spaces', async ({page, server}) => {
+it('should work with > combinator and spaces', async ({ page, server }) => {
   await page.setContent(`<div foo="bar" bar="baz"><span></span></div>`);
   expect(await page.$eval(`div[foo="bar"] > span`, e => e.outerHTML)).toBe(`<span></span>`);
   expect(await page.$eval(`div[foo="bar"]> span`, e => e.outerHTML)).toBe(`<span></span>`);
@@ -119,7 +119,7 @@ it('should work with > combinator and spaces', async ({page, server}) => {
   expect(await page.$eval(`div[foo="bar"][bar="baz"]     >span`, e => e.outerHTML)).toBe(`<span></span>`);
 });
 
-it('should work with comma separated list', async ({page, server}) => {
+it('should work with comma separated list', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$$eval(`css=span,section #root1`, els => els.length)).toBe(5);
   expect(await page.$$eval(`css=section #root1, div span`, els => els.length)).toBe(5);
@@ -132,7 +132,7 @@ it('should work with comma separated list', async ({page, server}) => {
   expect(await page.$$eval(`css=#target,[data-testid="foo"],[attr="value\\ space"],span`, els => els.length)).toBe(4);
 });
 
-it('should keep dom order with comma separated list', async ({page}) => {
+it('should keep dom order with comma separated list', async ({ page }) => {
   await page.setContent(`<section><span><div><x></x><y></y></div></span></section>`);
   expect(await page.$$eval(`css=span,div`, els => els.map(e => e.nodeName).join(','))).toBe('SPAN,DIV');
   expect(await page.$$eval(`css=div,span`, els => els.map(e => e.nodeName).join(','))).toBe('SPAN,DIV');
@@ -143,17 +143,17 @@ it('should keep dom order with comma separated list', async ({page}) => {
   expect(await page.$$eval(`css=section >> *css=div,span >> css=y`, els => els.map(e => e.nodeName).join(','))).toBe('SPAN,DIV');
 });
 
-it('should return multiple captures for the same node', async ({page}) => {
+it('should return multiple captures for the same node', async ({ page }) => {
   await page.setContent(`<div><div><div><span></span></div></div></div>`);
   expect(await page.$$eval(`*css=div >> span`, els => els.map(e => e.nodeName).join(','))).toBe('DIV,DIV,DIV');
 });
 
-it('should return multiple captures when going up the hierarchy', async ({page}) => {
+it('should return multiple captures when going up the hierarchy', async ({ page }) => {
   await page.setContent(`<section>Hello<ul><li></li><li></li></ul></section>`);
   expect(await page.$$eval(`*css=li >> ../.. >> text=Hello`, els => els.map(e => e.nodeName).join(','))).toBe('LI,LI');
 });
 
-it('should work with comma separated list in various positions', async ({page}) => {
+it('should work with comma separated list in various positions', async ({ page }) => {
   await page.setContent(`<section><span><div><x></x><y></y></div></span></section>`);
   expect(await page.$$eval(`css=span,div >> css=x,y`, els => els.map(e => e.nodeName).join(','))).toBe('X,Y');
   expect(await page.$$eval(`css=span,div >> css=x`, els => els.map(e => e.nodeName).join(','))).toBe('X');
@@ -167,7 +167,7 @@ it('should work with comma separated list in various positions', async ({page}) 
   expect(await page.$$eval(`css=section >> css=span >> css=x,y`, els => els.map(e => e.nodeName).join(','))).toBe('X,Y');
 });
 
-it('should work with comma inside text', async ({page}) => {
+it('should work with comma inside text', async ({ page }) => {
   await page.setContent(`<span></span><div attr="hello,world!"></div>`);
   expect(await page.$eval(`css=div[attr="hello,world!"]`, e => e.outerHTML)).toBe('<div attr="hello,world!"></div>');
   expect(await page.$eval(`css=[attr="hello,world!"]`, e => e.outerHTML)).toBe('<div attr="hello,world!"></div>');
@@ -176,7 +176,7 @@ it('should work with comma inside text', async ({page}) => {
   expect(await page.$eval(`css=div[attr="hello,world!"],span`, e => e.outerHTML)).toBe('<span></span>');
 });
 
-it('should work with attribute selectors', async ({page}) => {
+it('should work with attribute selectors', async ({ page }) => {
   await page.setContent(`<div attr="hello world" attr2="hello-''>>foo=bar[]" attr3="] span"><span></span></div>`);
   await page.evaluate(() => window['div'] = document.querySelector('div'));
   const selectors = [
@@ -200,19 +200,19 @@ it('should work with attribute selectors', async ({page}) => {
   expect(await page.$eval(`[attr3="] span"] >> span`, e => e.parentNode === window['div'])).toBe(true);
 });
 
-it('should not match root after >>', async ({page, server}) => {
+it('should not match root after >>', async ({ page, server }) => {
   await page.setContent('<section><div>test</div></section>');
   const element = await page.$('css=section >> css=section');
   expect(element).toBe(null);
 });
 
-it('should work with numerical id', async ({page, server}) => {
+it('should work with numerical id', async ({ page, server }) => {
   await page.setContent('<section id="123"></section>');
   const element = await page.$('#\\31\\32\\33');
   expect(element).toBeTruthy();
 });
 
-it('should work with wrong-case id', async ({page}) => {
+it('should work with wrong-case id', async ({ page }) => {
   await page.setContent('<section id="Hello"></section>');
   expect(await page.$eval('#Hello', e => e.tagName)).toBe('SECTION');
   expect(await page.$eval('#hello', e => e.tagName)).toBe('SECTION');
@@ -220,7 +220,7 @@ it('should work with wrong-case id', async ({page}) => {
   expect(await page.$eval('#helLO', e => e.tagName)).toBe('SECTION');
 });
 
-it('should work with *', async ({page}) => {
+it('should work with *', async ({ page }) => {
   await page.setContent('<div id=div1></div><div id=div2><span><span></span></span></div>');
   // Includes html, head and body.
   expect(await page.$$eval('*', els => els.length)).toBe(7);
@@ -259,7 +259,7 @@ it('should work with *', async ({page}) => {
   expect(await body.$$eval('* *:not(span)', els => els.length)).toBe(0);
 });
 
-it('should work with :nth-child', async ({page, server}) => {
+it('should work with :nth-child', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$$eval(`css=span:nth-child(odd)`, els => els.length)).toBe(3);
   expect(await page.$$eval(`css=span:nth-child(even)`, els => els.length)).toBe(1);
@@ -273,14 +273,14 @@ it('should work with :nth-child', async ({page, server}) => {
   expect(await page.$$eval(`css=span:nth-child(23n+2)`, els => els.length)).toBe(1);
 });
 
-it('should work with :not', async ({page, server}) => {
+it('should work with :not', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$$eval(`css=div:not(#root1)`, els => els.length)).toBe(2);
   expect(await page.$$eval(`css=body :not(span)`, els => els.length)).toBe(4);
   expect(await page.$$eval(`css=div > :not(span):not(div)`, els => els.length)).toBe(0);
 });
 
-it('should work with ~', async ({page}) => {
+it('should work with ~', async ({ page }) => {
   await page.setContent(`
     <div id=div1></div>
     <div id=div2></div>
@@ -298,7 +298,7 @@ it('should work with ~', async ({page}) => {
   expect(await page.$$eval(`css=#div3 ~ #div4 ~ #div5`, els => els.length)).toBe(1);
 });
 
-it('should work with +', async ({page}) => {
+it('should work with +', async ({ page }) => {
   await page.setContent(`
     <section>
       <div id=div1></div>
@@ -325,7 +325,7 @@ it('should work with +', async ({page}) => {
   // expect(await page.$eval(`css=div:has(:scope + #div5)`, e => e.id)).toBe('div4');
 });
 
-it('should work with spaces in :nth-child and :not', async ({page, server}) => {
+it('should work with spaces in :nth-child and :not', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$$eval(`css=span:nth-child(23n +2)`, els => els.length)).toBe(1);
   expect(await page.$$eval(`css=span:nth-child(23n+ 2)`, els => els.length)).toBe(1);
@@ -339,7 +339,7 @@ it('should work with spaces in :nth-child and :not', async ({page, server}) => {
   expect(await page.$$eval(`span:nth-child(23n+ 2) >> xpath=.`, els => els.length)).toBe(1);
 });
 
-it('should work with :is', async ({page, server}) => {
+it('should work with :is', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$$eval(`css=div:is(#root1)`, els => els.length)).toBe(1);
   expect(await page.$$eval(`css=div:is(#root1, #target)`, els => els.length)).toBe(1);
@@ -353,7 +353,7 @@ it('should work with :is', async ({page, server}) => {
   expect(await page.$$eval(`css=#root1:has(:is(:scope, #root1))`, els => els.length)).toBe(1);
 });
 
-it('should work with :has', async ({page, server}) => {
+it('should work with :has', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$$eval(`css=div:has(#target)`, els => els.length)).toBe(2);
   expect(await page.$$eval(`css=div:has([data-testid=foo])`, els => els.length)).toBe(3);
@@ -367,7 +367,7 @@ it('should work with :has', async ({page, server}) => {
   expect(await page.$$eval(`section:has(span, br, div)`, els => els.length)).toBe(2);
 });
 
-it('should work with :scope', async ({page, server}) => {
+it('should work with :scope', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
   // 'is' does not change the scope, so it remains 'html'.
   expect(await page.$$eval(`css=div:is(:scope#root1)`, els => els.length)).toBe(0);
@@ -385,7 +385,7 @@ it('should work with :scope', async ({page, server}) => {
   }
 });
 
-it('should absolutize relative selectors', async ({page, server}) => {
+it('should absolutize relative selectors', async ({ page, server }) => {
   await page.setContent(`<div><span>Hi</span></div>`);
   expect(await page.$eval('div >> >span', e => e.textContent)).toBe('Hi');
   expect(await page.locator('div').locator('>span').textContent()).toBe('Hi');

--- a/tests/page/selectors-misc.spec.ts
+++ b/tests/page/selectors-misc.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work for open shadow roots', async ({page, server}) => {
+it('should work for open shadow roots', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$eval(`id=target`, e => e.textContent)).toBe('Hello from root2');
   expect(await page.$eval(`data-testid=foo`, e => e.textContent)).toBe('Hello from root1');
@@ -27,7 +27,7 @@ it('should work for open shadow roots', async ({page, server}) => {
   expect(await page.$$(`data-testid:light=foo`)).toEqual([]);
 });
 
-it('should click on links in shadow dom', async ({page, server, browserName, browserMajorVersion, isElectron, isAndroid}) => {
+it('should click on links in shadow dom', async ({ page, server, browserName, browserMajorVersion, isElectron, isAndroid }) => {
   it.fixme(browserName === 'chromium' && browserMajorVersion < 91, 'Remove when crrev.com/864024 gets to the stable channel');
   it.fixme(isAndroid);
   it.fixme(isElectron);
@@ -38,7 +38,7 @@ it('should click on links in shadow dom', async ({page, server, browserName, bro
   expect(await page.evaluate(() => (window as any).clickCount)).toBe(1);
 });
 
-it('should work with :visible', async ({page}) => {
+it('should work with :visible', async ({ page }) => {
   await page.setContent(`
     <section>
       <div id=target1></div>
@@ -58,7 +58,7 @@ it('should work with :visible', async ({page}) => {
   expect(await page.$eval('div:visible', div => div.id)).toBe('target2');
 });
 
-it('should work with >> visible=', async ({page}) => {
+it('should work with >> visible=', async ({ page }) => {
   await page.setContent(`
     <section>
       <div id=target1></div>
@@ -78,7 +78,7 @@ it('should work with >> visible=', async ({page}) => {
   expect(await page.$eval('div >> visible=true', div => div.id)).toBe('target2');
 });
 
-it('should work with :nth-match', async ({page}) => {
+it('should work with :nth-match', async ({ page }) => {
   await page.setContent(`
     <section>
       <div id=target1></div>
@@ -113,7 +113,7 @@ it('should work with :nth-match', async ({page}) => {
   expect(await element.evaluate(e => e.id)).toBe('target3');
 });
 
-it('should work with nth=', async ({page}) => {
+it('should work with nth=', async ({ page }) => {
   await page.setContent(`
     <section>
       <div id=target1></div>
@@ -137,7 +137,7 @@ it('should work with nth=', async ({page}) => {
   expect(await element.evaluate(e => e.id)).toBe('target3');
 });
 
-it('should work with position selectors', async ({page}) => {
+it('should work with position selectors', async ({ page }) => {
   /*
 
        +--+  +--+

--- a/tests/page/selectors-react.spec.ts
+++ b/tests/page/selectors-react.spec.ts
@@ -25,11 +25,11 @@ const reacts = {
 
 for (const [name, url] of Object.entries(reacts)) {
   it.describe(name, () => {
-    it.beforeEach(async ({page, server}) => {
+    it.beforeEach(async ({ page, server }) => {
       await page.goto(server.PREFIX + url);
     });
 
-    it('should work with single-root elements', async ({page}) => {
+    it('should work with single-root elements', async ({ page }) => {
       expect(await page.$$eval(`_react=BookList`, els => els.length)).toBe(1);
       expect(await page.$$eval(`_react=BookItem`, els => els.length)).toBe(3);
       expect(await page.$$eval(`_react=BookList >> _react=BookItem`, els => els.length)).toBe(3);
@@ -37,25 +37,25 @@ for (const [name, url] of Object.entries(reacts)) {
 
     });
 
-    it('should work with multi-root elements (fragments)', async ({page}) => {
+    it('should work with multi-root elements (fragments)', async ({ page }) => {
       it.skip(name === 'react15', 'React 15 does not support fragments');
       expect(await page.$$eval(`_react=App`, els => els.length)).toBe(15);
       expect(await page.$$eval(`_react=AppHeader`, els => els.length)).toBe(2);
       expect(await page.$$eval(`_react=NewBook`, els => els.length)).toBe(2);
     });
 
-    it('should not crash when there is no match', async ({page}) => {
+    it('should not crash when there is no match', async ({ page }) => {
       expect(await page.$$eval(`_react=Apps`, els => els.length)).toBe(0);
       expect(await page.$$eval(`_react=BookLi`, els => els.length)).toBe(0);
     });
 
-    it('should compose', async ({page}) => {
+    it('should compose', async ({ page }) => {
       expect(await page.$eval(`_react=NewBook >> _react=button`, el => el.textContent)).toBe('new book');
       expect(await page.$eval(`_react=NewBook >> _react=input`, el => el.tagName)).toBe('INPUT');
       expect(await page.$eval(`_react=BookItem >> text=Gatsby`, el => el.textContent)).toBe('The Great Gatsby');
     });
 
-    it('should query by props combinations', async ({page}) => {
+    it('should query by props combinations', async ({ page }) => {
       expect(await page.$$eval(`_react=BookItem[name="The Great Gatsby"]`, els => els.length)).toBe(1);
       expect(await page.$$eval(`_react=BookItem[name="the great gatsby" i]`, els => els.length)).toBe(1);
       expect(await page.$$eval(`_react=ColorButton[nested.index = 0]`, els => els.length)).toBe(1);
@@ -69,7 +69,7 @@ for (const [name, url] of Object.entries(reacts)) {
       expect(await page.$$eval(`_react=ColorButton[enabled = true][color = "red"i][nested.index =  6]`, els => els.length)).toBe(1);
     });
 
-    it('should exact match by props', async ({page}) => {
+    it('should exact match by props', async ({ page }) => {
       expect(await page.$eval(`_react=BookItem[name = "The Great Gatsby"]`, el => el.textContent)).toBe('The Great Gatsby');
       expect(await page.$$eval(`_react=BookItem[name = "The Great Gatsby"]`, els => els.length)).toBe(1);
       // case sensetive by default
@@ -82,7 +82,7 @@ for (const [name, url] of Object.entries(reacts)) {
       expect(await page.$$eval(`_react=BookItem[name = "  The Great Gatsby  "]`, els => els.length)).toBe(0);
     });
 
-    it('should partially match by props', async ({page}) => {
+    it('should partially match by props', async ({ page }) => {
       // Check partial matching
       expect(await page.$eval(`_react=BookItem[name *= "Gatsby"]`, el => el.textContent)).toBe('The Great Gatsby');
       expect(await page.$$eval(`_react=BookItem[name *= "Gatsby"]`, els => els.length)).toBe(1);
@@ -91,7 +91,7 @@ for (const [name, url] of Object.entries(reacts)) {
       expect(await page.$$eval(`_react=BookItem[name = "Gatsby"]`, els => els.length)).toBe(0);
     });
 
-    it('should support all string operators', async ({page}) => {
+    it('should support all string operators', async ({ page }) => {
       expect(await page.$$eval(`_react=ColorButton[color = "red"]`, els => els.length)).toBe(3);
       expect(await page.$$eval(`_react=ColorButton[color |= "red"]`, els => els.length)).toBe(3);
       expect(await page.$$eval(`_react=ColorButton[color $= "ed"]`, els => els.length)).toBe(3);
@@ -101,11 +101,11 @@ for (const [name, url] of Object.entries(reacts)) {
       expect(await page.$$eval(`_react=BookItem[name *= " gatsby" i]`, els => els.length)).toBe(1);
     });
 
-    it('should support truthy querying', async ({page}) => {
+    it('should support truthy querying', async ({ page }) => {
       expect(await page.$$eval(`_react=ColorButton[enabled]`, els => els.length)).toBe(5);
     });
 
-    it('should support nested react trees', async ({page}) => {
+    it('should support nested react trees', async ({ page }) => {
       await expect(page.locator(`_react=BookItem`)).toHaveCount(3);
       await page.evaluate(() => {
         // @ts-ignore
@@ -114,7 +114,7 @@ for (const [name, url] of Object.entries(reacts)) {
       await expect(page.locator(`_react=BookItem`)).toHaveCount(6);
     });
 
-    it('should work with multiroot react', async ({page}) => {
+    it('should work with multiroot react', async ({ page }) => {
       await it.step('mount second root', async () => {
         await expect(page.locator(`_react=BookItem`)).toHaveCount(3);
         await page.evaluate(() => {

--- a/tests/page/selectors-text.spec.ts
+++ b/tests/page/selectors-text.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({page}) => {
+it('should work', async ({ page }) => {
   await page.setContent(`<div>yo</div><div>ya</div><div>\nye  </div>`);
   expect(await page.$eval(`text=ya`, e => e.outerHTML)).toBe('<div>ya</div>');
   expect(await page.$eval(`text="ya"`, e => e.outerHTML)).toBe('<div>ya</div>');
@@ -108,7 +108,7 @@ it('should work', async ({page}) => {
   expect((await page.$$(`text="lo \nwo"`)).length).toBe(0);
 });
 
-it('should work with :text', async ({page}) => {
+it('should work with :text', async ({ page }) => {
   await page.setContent(`<div>yo</div><div>ya</div><div>\nHELLO   \n world  </div>`);
   expect(await page.$eval(`:text("ya")`, e => e.outerHTML)).toBe('<div>ya</div>');
   expect(await page.$eval(`:text-is("ya")`, e => e.outerHTML)).toBe('<div>ya</div>');
@@ -129,7 +129,7 @@ it('should work with :text', async ({page}) => {
   expect(error2.message).toContain(`"text" engine expects a single string`);
 });
 
-it('should work across nodes', async ({page}) => {
+it('should work across nodes', async ({ page }) => {
   await page.setContent(`<div id=target1>Hello<i>,</i> <span id=target2>world</span><b>!</b></div>`);
 
   expect(await page.$eval(`:text("Hello, world!")`, e => e.id)).toBe('target1');
@@ -162,7 +162,7 @@ it('should work across nodes', async ({page}) => {
   expect(await page.$$eval(`text=/world/`, els => els.length)).toBe(1);
 });
 
-it('should work with text nodes in quoted mode', async ({page}) => {
+it('should work with text nodes in quoted mode', async ({ page }) => {
   await page.setContent(`<div id=target1>Hello<span id=target2>wo  rld  </span>  Hi again  </div>`);
   expect(await page.$eval(`text="Hello"`, e => e.id)).toBe('target1');
   expect(await page.$eval(`text="Hi again"`, e => e.id)).toBe('target1');
@@ -176,7 +176,7 @@ it('should work with text nodes in quoted mode', async ({page}) => {
   expect(await page.$eval(`text=hi again`, e => e.id)).toBe('target1');
 });
 
-it('should clear caches', async ({page}) => {
+it('should clear caches', async ({ page }) => {
   await page.setContent(`<div id=target1>text</div><div id=target2>text</div>`);
   const div = await page.$('#target1');
 
@@ -201,7 +201,7 @@ it('should clear caches', async ({page}) => {
   expect(await page.$$eval(`:text("text")`, els => els.length)).toBe(1);
 });
 
-it('should work with :has-text', async ({page}) => {
+it('should work with :has-text', async ({ page }) => {
   await page.setContent(`
     <input id=input2>
     <div id=div1>
@@ -228,7 +228,7 @@ it('should work with :has-text', async ({page}) => {
   expect(error2.message).toContain(`"has-text" engine expects a single string`);
 });
 
-it('should work with large DOM', async ({page}) => {
+it('should work with large DOM', async ({ page }) => {
   await page.evaluate(() => {
     let id = 0;
     const next = (tag: string) => {
@@ -285,19 +285,19 @@ it('should work with large DOM', async ({page}) => {
   }
 });
 
-it('should be case sensitive if quotes are specified', async ({page}) => {
+it('should be case sensitive if quotes are specified', async ({ page }) => {
   await page.setContent(`<div>yo</div><div>ya</div><div>\nye  </div>`);
   expect(await page.$eval(`text=yA`, e => e.outerHTML)).toBe('<div>ya</div>');
   expect(await page.$(`text="yA"`)).toBe(null);
 });
 
-it('should search for a substring without quotes', async ({page}) => {
+it('should search for a substring without quotes', async ({ page }) => {
   await page.setContent(`<div>textwithsubstring</div>`);
   expect(await page.$eval(`text=with`, e => e.outerHTML)).toBe('<div>textwithsubstring</div>');
   expect(await page.$(`text="with"`)).toBe(null);
 });
 
-it('should skip head, script and style', async ({page}) => {
+it('should skip head, script and style', async ({ page }) => {
   await page.setContent(`
     <head>
       <title>title</title>
@@ -323,13 +323,13 @@ it('should skip head, script and style', async ({page}) => {
   }
 });
 
-it('should match input[type=button|submit]', async ({page}) => {
+it('should match input[type=button|submit]', async ({ page }) => {
   await page.setContent(`<input type="submit" value="hello"><input type="button" value="world">`);
   expect(await page.$eval(`text=hello`, e => e.outerHTML)).toBe('<input type="submit" value="hello">');
   expect(await page.$eval(`text=world`, e => e.outerHTML)).toBe('<input type="button" value="world">');
 });
 
-it('should work for open shadow roots', async ({page, server}) => {
+it('should work for open shadow roots', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/deep-shadow.html');
   expect(await page.$eval(`text=root1`, e => e.textContent)).toBe('Hello from root1');
   expect(await page.$eval(`text=root2`, e => e.textContent)).toBe('Hello from root2');
@@ -341,7 +341,7 @@ it('should work for open shadow roots', async ({page, server}) => {
   expect(await page.$(`text:light=root3`)).toBe(null);
 });
 
-it('should prioritize light dom over shadow dom in the same parent', async ({page, server}) => {
+it('should prioritize light dom over shadow dom in the same parent', async ({ page, server }) => {
   await page.evaluate(() => {
     const div = document.createElement('div');
     document.body.appendChild(div);
@@ -358,7 +358,7 @@ it('should prioritize light dom over shadow dom in the same parent', async ({pag
   expect(await page.$eval(`div >> text=Hello`, e => e.textContent)).toBe('Hello from light');
 });
 
-it('should waitForSelector with distributed elements', async ({page, server}) => {
+it('should waitForSelector with distributed elements', async ({ page, server }) => {
   const promise = page.waitForSelector(`div >> text=Hello`);
   await page.evaluate(() => {
     const div = document.createElement('div');
@@ -378,7 +378,7 @@ it('should waitForSelector with distributed elements', async ({page, server}) =>
   expect(await handle.textContent()).toBe('Hello from light');
 });
 
-it('should match root after >>', async ({page, server}) => {
+it('should match root after >>', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   const element = await page.$('css=section >> text=test');
   expect(element).toBeTruthy();

--- a/tests/page/selectors-vue.spec.ts
+++ b/tests/page/selectors-vue.spec.ts
@@ -24,11 +24,11 @@ const vues = {
 
 for (const [name, url] of Object.entries(vues)) {
   it.describe(name, () => {
-    it.beforeEach(async ({page, server}) => {
+    it.beforeEach(async ({ page, server }) => {
       await page.goto(server.PREFIX + url);
     });
 
-    it('should work with single-root elements', async ({page}) => {
+    it('should work with single-root elements', async ({ page }) => {
       expect(await page.$$eval(`_vue=book-list`, els => els.length)).toBe(1);
       expect(await page.$$eval(`_vue=book-item`, els => els.length)).toBe(3);
       expect(await page.$$eval(`_vue=book-list >> _vue=book-item`, els => els.length)).toBe(3);
@@ -36,23 +36,23 @@ for (const [name, url] of Object.entries(vues)) {
 
     });
 
-    it('should work with multi-root elements (fragments)', async ({page}) => {
+    it('should work with multi-root elements (fragments)', async ({ page }) => {
       it.skip(name === 'vue2', 'vue2 does not support fragments');
       expect(await page.$$eval(`_vue=Root`, els => els.length)).toBe(15);
       expect(await page.$$eval(`_vue=app-header`, els => els.length)).toBe(2);
       expect(await page.$$eval(`_vue=new-book`, els => els.length)).toBe(2);
     });
 
-    it('should not crash when there is no match', async ({page}) => {
+    it('should not crash when there is no match', async ({ page }) => {
       expect(await page.$$eval(`_vue=apps`, els => els.length)).toBe(0);
       expect(await page.$$eval(`_vue=book-li`, els => els.length)).toBe(0);
     });
 
-    it('should compose', async ({page}) => {
+    it('should compose', async ({ page }) => {
       expect(await page.$eval(`_vue=book-item >> text=Gatsby`, el => el.textContent.trim())).toBe('The Great Gatsby');
     });
 
-    it('should query by props combinations', async ({page}) => {
+    it('should query by props combinations', async ({ page }) => {
       expect(await page.$$eval(`_vue=book-item[name="The Great Gatsby"]`, els => els.length)).toBe(1);
       expect(await page.$$eval(`_vue=book-item[name="the great gatsby" i]`, els => els.length)).toBe(1);
       expect(await page.$$eval(`_vue=color-button[nested.index = 0]`, els => els.length)).toBe(1);
@@ -66,7 +66,7 @@ for (const [name, url] of Object.entries(vues)) {
       expect(await page.$$eval(`_vue=color-button[enabled = true][color = "red"i][nested.index =  6]`, els => els.length)).toBe(1);
     });
 
-    it('should exact match by props', async ({page}) => {
+    it('should exact match by props', async ({ page }) => {
       expect(await page.$eval(`_vue=book-item[name = "The Great Gatsby"]`, el => el.textContent)).toBe('The Great Gatsby');
       expect(await page.$$eval(`_vue=book-item[name = "The Great Gatsby"]`, els => els.length)).toBe(1);
       // case sensetive by default
@@ -79,7 +79,7 @@ for (const [name, url] of Object.entries(vues)) {
       expect(await page.$$eval(`_vue=book-item[name = "  The Great Gatsby  "]`, els => els.length)).toBe(0);
     });
 
-    it('should partially match by props', async ({page}) => {
+    it('should partially match by props', async ({ page }) => {
       // Check partial matching
       expect(await page.$eval(`_vue=book-item[name *= "Gatsby"]`, el => el.textContent)).toBe('The Great Gatsby');
       expect(await page.$$eval(`_vue=book-item[name *= "Gatsby"]`, els => els.length)).toBe(1);
@@ -88,7 +88,7 @@ for (const [name, url] of Object.entries(vues)) {
       expect(await page.$$eval(`_vue=book-item[name = "Gatsby"]`, els => els.length)).toBe(0);
     });
 
-    it('should support all string operators', async ({page}) => {
+    it('should support all string operators', async ({ page }) => {
       expect(await page.$$eval(`_vue=color-button[color = "red"]`, els => els.length)).toBe(3);
       expect(await page.$$eval(`_vue=color-button[color |= "red"]`, els => els.length)).toBe(3);
       expect(await page.$$eval(`_vue=color-button[color $= "ed"]`, els => els.length)).toBe(3);
@@ -98,11 +98,11 @@ for (const [name, url] of Object.entries(vues)) {
       expect(await page.$$eval(`_vue=book-item[name *= " gatsby" i]`, els => els.length)).toBe(1);
     });
 
-    it('should support truthy querying', async ({page}) => {
+    it('should support truthy querying', async ({ page }) => {
       expect(await page.$$eval(`_vue=color-button[enabled]`, els => els.length)).toBe(5);
     });
 
-    it('should support nested vue trees', async ({page}) => {
+    it('should support nested vue trees', async ({ page }) => {
       await expect(page.locator(`_vue=book-item`)).toHaveCount(3);
       await page.evaluate(() => {
         // @ts-ignore
@@ -111,7 +111,7 @@ for (const [name, url] of Object.entries(vues)) {
       await expect(page.locator(`_vue=book-item`)).toHaveCount(6);
     });
 
-    it('should work with multiroot react', async ({page}) => {
+    it('should work with multiroot react', async ({ page }) => {
       await it.step('mount second root', async () => {
         await expect(page.locator(`_vue=book-item`)).toHaveCount(3);
         await page.evaluate(() => {

--- a/tests/page/wheel.spec.ts
+++ b/tests/page/wheel.spec.ts
@@ -15,11 +15,11 @@
  */
 import type { Page } from '../../';
 import { test as it, expect } from './pageTest';
-it.skip(({isElectron, browserMajorVersion}) => {
+it.skip(({ isElectron, browserMajorVersion }) => {
   // Old Electron has flaky wheel events.
   return isElectron && browserMajorVersion <= 11;
 });
-it('should dispatch wheel events', async ({page, server}) => {
+it('should dispatch wheel events', async ({ page, server }) => {
   await page.setContent(`<div style="width: 5000px; height: 5000px;"></div>`);
   await page.mouse.move(50, 60);
   await listenForWheelEvents(page, 'div');
@@ -38,14 +38,14 @@ it('should dispatch wheel events', async ({page, server}) => {
   await page.waitForFunction('window.scrollY === 100');
 });
 
-it('should scroll when nobody is listening', async ({page, server}) => {
+it('should scroll when nobody is listening', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
   await page.mouse.move(50, 60);
   await page.mouse.wheel(0, 100);
   await page.waitForFunction('window.scrollY === 100');
 });
 
-it('should set the modifiers', async ({page}) => {
+it('should set the modifiers', async ({ page }) => {
   await page.setContent(`<div style="width: 5000px; height: 5000px;"></div>`);
   await page.mouse.move(50, 60);
   await listenForWheelEvents(page, 'div');
@@ -64,7 +64,7 @@ it('should set the modifiers', async ({page}) => {
   });
 });
 
-it('should scroll horizontally', async ({page}) => {
+it('should scroll horizontally', async ({ page }) => {
   await page.setContent(`<div style="width: 5000px; height: 5000px;"></div>`);
   await page.mouse.move(50, 60);
   await listenForWheelEvents(page, 'div');
@@ -83,7 +83,7 @@ it('should scroll horizontally', async ({page}) => {
   await page.waitForFunction('window.scrollX === 100');
 });
 
-it('should work when the event is canceled', async ({page}) => {
+it('should work when the event is canceled', async ({ page }) => {
   await page.setContent(`<div style="width: 5000px; height: 5000px;"></div>`);
   await page.mouse.move(50, 60);
   await listenForWheelEvents(page, 'div');

--- a/tests/page/workers.spec.ts
+++ b/tests/page/workers.spec.ts
@@ -19,7 +19,7 @@ import { test as it, expect } from './pageTest';
 import { attachFrame } from '../config/utils';
 import type { ConsoleMessage } from '../../index';
 
-it('Page.workers', async function({page, server}) {
+it('Page.workers', async function({ page, server }) {
   await Promise.all([
     page.waitForEvent('worker'),
     page.goto(server.PREFIX + '/worker/worker.html')]);
@@ -32,9 +32,9 @@ it('Page.workers', async function({page, server}) {
   expect(page.workers().length).toBe(0);
 });
 
-it('should emit created and destroyed events', async function({page}) {
+it('should emit created and destroyed events', async function({ page }) {
   const workerCreatedPromise = page.waitForEvent('worker');
-  const workerObj = await page.evaluateHandle(() => new Worker(URL.createObjectURL(new Blob(['1'], {type: 'application/javascript'}))));
+  const workerObj = await page.evaluateHandle(() => new Worker(URL.createObjectURL(new Blob(['1'], { type: 'application/javascript' }))));
   const worker = await workerCreatedPromise;
   const workerThisObj = await worker.evaluateHandle(() => this);
   const workerDestroyedPromise = new Promise(x => worker.once('close', x));
@@ -44,21 +44,21 @@ it('should emit created and destroyed events', async function({page}) {
   expect(error.message).toContain('Target closed');
 });
 
-it('should report console logs', async function({page}) {
+it('should report console logs', async function({ page }) {
   const [message] = await Promise.all([
     page.waitForEvent('console'),
-    page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))),
+    page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], { type: 'application/javascript' })))),
   ]);
   expect(message.text()).toBe('1');
   // Firefox's juggler had an issue that reported worker blob urls as frame urls.
   expect(page.url()).not.toContain('blob');
 });
 
-it('should not report console logs from workers twice', async function({page}) {
+it('should not report console logs from workers twice', async function({ page }) {
   const messages = [];
   page.on('console', msg => messages.push(msg.text()));
   await Promise.all([
-    page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1); console.log(2);'], {type: 'application/javascript'})))),
+    page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1); console.log(2);'], { type: 'application/javascript' })))),
     page.waitForEvent('console', msg => msg.text() === '1'),
     page.waitForEvent('console', msg => msg.text() === '2'),
   ]);
@@ -69,7 +69,7 @@ it('should not report console logs from workers twice', async function({page}) {
 
 it('should have JSHandles for console logs', async function({ page, browserName }) {
   const logPromise = new Promise<ConsoleMessage>(x => page.on('console', x));
-  await page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1,2,3,this)'], {type: 'application/javascript'}))));
+  await page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1,2,3,this)'], { type: 'application/javascript' }))));
   const log = await logPromise;
   if (browserName !== 'firefox')
     expect(log.text()).toBe('1 2 3 DedicatedWorkerGlobalScope');
@@ -79,14 +79,14 @@ it('should have JSHandles for console logs', async function({ page, browserName 
   expect(await (await log.args()[3].getProperty('origin')).jsonValue()).toBe('null');
 });
 
-it('should evaluate', async function({page}) {
+it('should evaluate', async function({ page }) {
   const workerCreatedPromise = page.waitForEvent('worker');
-  await page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'}))));
+  await page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], { type: 'application/javascript' }))));
   const worker = await workerCreatedPromise;
   expect(await worker.evaluate('1+1')).toBe(2);
 });
 
-it('should report errors', async function({page}) {
+it('should report errors', async function({ page }) {
   const errorPromise = new Promise<Error>(x => page.on('pageerror', x));
   await page.evaluate(() => new Worker(URL.createObjectURL(new Blob([`
     setTimeout(() => {
@@ -94,15 +94,15 @@ it('should report errors', async function({page}) {
       console.log('hey');
       throw new Error('this is my error');
     })
-  `], {type: 'application/javascript'}))));
+  `], { type: 'application/javascript' }))));
   const errorLog = await errorPromise;
   expect(errorLog.message).toContain('this is my error');
 });
 
-it('should clear upon navigation', async function({server, page}) {
+it('should clear upon navigation', async function({ server, page }) {
   await page.goto(server.EMPTY_PAGE);
   const workerCreatedPromise = page.waitForEvent('worker');
-  await page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'}))));
+  await page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], { type: 'application/javascript' }))));
   const worker = await workerCreatedPromise;
   expect(page.workers().length).toBe(1);
   let destroyed = false;
@@ -112,10 +112,10 @@ it('should clear upon navigation', async function({server, page}) {
   expect(page.workers().length).toBe(0);
 });
 
-it('should clear upon cross-process navigation', async function({server, page}) {
+it('should clear upon cross-process navigation', async function({ server, page }) {
   await page.goto(server.EMPTY_PAGE);
   const workerCreatedPromise = page.waitForEvent('worker');
-  await page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'}))));
+  await page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], { type: 'application/javascript' }))));
   const worker = await workerCreatedPromise;
   expect(page.workers().length).toBe(1);
   let destroyed = false;
@@ -125,7 +125,7 @@ it('should clear upon cross-process navigation', async function({server, page}) 
   expect(page.workers().length).toBe(0);
 });
 
-it('should attribute network activity for worker inside iframe to the iframe', async function({page, server, browserName}) {
+it('should attribute network activity for worker inside iframe to the iframe', async function({ page, server, browserName }) {
   it.fixme(browserName === 'firefox' || browserName === 'chromium');
 
   await page.goto(server.PREFIX + '/empty.html');
@@ -142,7 +142,7 @@ it('should attribute network activity for worker inside iframe to the iframe', a
   expect(request.frame()).toBe(frame);
 });
 
-it('should report network activity', async function({page, server}) {
+it('should report network activity', async function({ page, server }) {
   const [worker] = await Promise.all([
     page.waitForEvent('worker'),
     page.goto(server.PREFIX + '/worker/worker.html'),
@@ -158,7 +158,7 @@ it('should report network activity', async function({page, server}) {
   expect(response.ok()).toBe(true);
 });
 
-it('should report network activity on worker creation', async function({page, server}) {
+it('should report network activity on worker creation', async function({ page, server }) {
   // Chromium needs waitForDebugger enabled for this one.
   await page.goto(server.EMPTY_PAGE);
   const url = server.PREFIX + '/one-style.css';
@@ -166,7 +166,7 @@ it('should report network activity on worker creation', async function({page, se
   const responsePromise = page.waitForResponse(url);
   await page.evaluate(url => new Worker(URL.createObjectURL(new Blob([`
     fetch("${url}").then(response => response.text()).then(console.log);
-  `], {type: 'application/javascript'}))), url);
+  `], { type: 'application/javascript' }))), url);
   const request = await requestPromise;
   const response = await responsePromise;
   expect(request.url()).toBe(url);

--- a/tests/pdf.spec.ts
+++ b/tests/pdf.spec.ts
@@ -17,12 +17,12 @@
 import { browserTest as it, expect } from './config/browserTest';
 import fs from 'fs';
 
-it('should be able to save file', async ({contextFactory, headless, browserName}, testInfo) => {
+it('should be able to save file', async ({ contextFactory, headless, browserName }, testInfo) => {
   it.skip(!headless || browserName !== 'chromium', 'Printing to pdf is currently only supported in headless chromium.');
 
   const context = await contextFactory();
   const page = await context.newPage();
   const outputFile = testInfo.outputPath('output.pdf');
-  await page.pdf({path: outputFile});
+  await page.pdf({ path: outputFile });
   expect(fs.readFileSync(outputFile).byteLength).toBeGreaterThan(0);
 });

--- a/tests/permissions.spec.ts
+++ b/tests/permissions.spec.ts
@@ -18,50 +18,50 @@
 import { contextTest as it, expect } from './config/browserTest';
 
 function getPermission(page, name) {
-  return page.evaluate(name => navigator.permissions.query({name}).then(result => result.state), name);
+  return page.evaluate(name => navigator.permissions.query({ name }).then(result => result.state), name);
 }
 
 it.describe('permissions', () => {
   it.skip(({ browserName }) => browserName === 'webkit', 'Permissions API is not implemented in WebKit (see https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API)');
 
-  it('should be prompt by default', async ({page, server}) => {
+  it('should be prompt by default', async ({ page, server }) => {
     await page.goto(server.EMPTY_PAGE);
     expect(await getPermission(page, 'geolocation')).toBe('prompt');
   });
 
-  it('should deny permission when not listed', async ({page, context, server}) => {
+  it('should deny permission when not listed', async ({ page, context, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions([], { origin: server.EMPTY_PAGE });
     expect(await getPermission(page, 'geolocation')).toBe('denied');
   });
 
-  it('should fail when bad permission is given', async ({page, context, server}) => {
+  it('should fail when bad permission is given', async ({ page, context, server }) => {
     await page.goto(server.EMPTY_PAGE);
     let error: Error;
     await context.grantPermissions(['foo'], { origin: server.EMPTY_PAGE }).catch(e => error = e);
     expect(error.message).toContain('Unknown permission: foo');
   });
 
-  it('should grant geolocation permission when origin is listed', async ({page, context, server}) => {
+  it('should grant geolocation permission when origin is listed', async ({ page, context, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions(['geolocation'], { origin: server.EMPTY_PAGE });
     expect(await getPermission(page, 'geolocation')).toBe('granted');
   });
 
-  it('should prompt for geolocation permission when origin is not listed', async ({page, context, server}) => {
+  it('should prompt for geolocation permission when origin is not listed', async ({ page, context, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions(['geolocation'], { origin: server.EMPTY_PAGE });
     await page.goto(server.EMPTY_PAGE.replace('localhost', '127.0.0.1'));
     expect(await getPermission(page, 'geolocation')).toBe('prompt');
   });
 
-  it('should grant notifications permission when listed', async ({page, context, server}) => {
+  it('should grant notifications permission when listed', async ({ page, context, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions(['notifications'], { origin: server.EMPTY_PAGE });
     expect(await getPermission(page, 'notifications')).toBe('granted');
   });
 
-  it('should accumulate when adding', async ({page, context, server}) => {
+  it('should accumulate when adding', async ({ page, context, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions(['geolocation']);
     await context.grantPermissions(['notifications']);
@@ -69,7 +69,7 @@ it.describe('permissions', () => {
     expect(await getPermission(page, 'notifications')).toBe('granted');
   });
 
-  it('should clear permissions', async ({page, context, server}) => {
+  it('should clear permissions', async ({ page, context, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions(['geolocation']);
     await context.clearPermissions();
@@ -78,13 +78,13 @@ it.describe('permissions', () => {
     expect(await getPermission(page, 'notifications')).toBe('granted');
   });
 
-  it('should grant permission when listed for all domains', async ({page, context, server}) => {
+  it('should grant permission when listed for all domains', async ({ page, context, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions(['geolocation']);
     expect(await getPermission(page, 'geolocation')).toBe('granted');
   });
 
-  it('should grant permission when creating context', async ({server, browser}) => {
+  it('should grant permission when creating context', async ({ server, browser }) => {
     const context = await browser.newContext({ permissions: ['geolocation'] });
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
@@ -92,7 +92,7 @@ it.describe('permissions', () => {
     await context.close();
   });
 
-  it('should reset permissions', async ({page, context, server}) => {
+  it('should reset permissions', async ({ page, context, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions(['geolocation'], { origin: server.EMPTY_PAGE });
     expect(await getPermission(page, 'geolocation')).toBe('granted');
@@ -100,14 +100,14 @@ it.describe('permissions', () => {
     expect(await getPermission(page, 'geolocation')).toBe('prompt');
   });
 
-  it('should trigger permission onchange', async ({page, context, server, browserName, headless}) => {
+  it('should trigger permission onchange', async ({ page, context, server, browserName, headless }) => {
     it.fail(browserName === 'webkit');
     it.fail(browserName === 'chromium' && !headless);
 
     await page.goto(server.EMPTY_PAGE);
     await page.evaluate(() => {
       window['events'] = [];
-      return navigator.permissions.query({name: 'geolocation'}).then(function(result) {
+      return navigator.permissions.query({ name: 'geolocation' }).then(function(result) {
         window['events'].push(result.state);
         result.onchange = function() {
           window['events'].push(result.state);
@@ -123,7 +123,7 @@ it.describe('permissions', () => {
     expect(await page.evaluate(() => window['events'])).toEqual(['prompt', 'denied', 'granted', 'prompt']);
   });
 
-  it('should isolate permissions between browser contexts', async ({server, browser}) => {
+  it('should isolate permissions between browser contexts', async ({ server, browser }) => {
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
@@ -145,7 +145,7 @@ it.describe('permissions', () => {
     await context.close();
   });
 
-  it('should support clipboard read', async ({page, context, server, browserName, headless}) => {
+  it('should support clipboard read', async ({ page, context, server, browserName, headless }) => {
     it.fail(browserName === 'webkit');
     it.fail(browserName === 'firefox', 'No such permissions (requires flag) in Firefox');
     it.fixme(browserName === 'chromium' && !headless);

--- a/tests/playwright-test/exit-code.spec.ts
+++ b/tests/playwright-test/exit-code.spec.ts
@@ -40,7 +40,7 @@ test('should collect stdio', async ({ runInlineTest }) => {
   expect(stderr).toEqual([{ text: 'stderr text' }, { buffer: Buffer.from('stderr buffer').toString('base64') }]);
 });
 
-test('should work with not defined errors', async ({runInlineTest}) => {
+test('should work with not defined errors', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'is-not-defined-error.spec.ts': `
       foo();
@@ -134,7 +134,7 @@ test('should respect global timeout', async ({ runInlineTest }) => {
   expect(monotonicTime() - now).toBeGreaterThan(2900);
 });
 
-test('should exit with code 1 if the specified folder does not exist', async ({runInlineTest}) => {
+test('should exit with code 1 if the specified folder does not exist', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
       module.exports = { testDir: '111111111111.js' };
@@ -144,7 +144,7 @@ test('should exit with code 1 if the specified folder does not exist', async ({r
   expect(result.output).toContain(`111111111111.js does not exist`);
 });
 
-test('should exit with code 1 if passed a file name', async ({runInlineTest}) => {
+test('should exit with code 1 if passed a file name', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
       module.exports = { testDir: 'test.spec.js' };
@@ -156,8 +156,8 @@ test('should exit with code 1 if passed a file name', async ({runInlineTest}) =>
   expect(result.output).toContain(`test.spec.js is not a directory`);
 });
 
-test('should exit with code 1 when config is not found', async ({runInlineTest}) => {
-  const result = await runInlineTest({'my.config.js': ''}, { 'config': 'foo.config.js' });
+test('should exit with code 1 when config is not found', async ({ runInlineTest }) => {
+  const result = await runInlineTest({ 'my.config.js': '' }, { 'config': 'foo.config.js' });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain(`foo.config.js does not exist`);
 });

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -50,7 +50,7 @@ test('should be able to call expect.extend in config', async ({ runInlineTest })
   expect(result.passed).toBe(1);
 });
 
-test('should work with default expect prototype functions', async ({runTSC}) => {
+test('should work with default expect prototype functions', async ({ runTSC }) => {
   const result = await runTSC({
     'a.spec.ts': `
       const { test } = pwt;
@@ -63,7 +63,7 @@ test('should work with default expect prototype functions', async ({runTSC}) => 
   expect(result.exitCode).toBe(0);
 });
 
-test('should work with default expect matchers', async ({runTSC}) => {
+test('should work with default expect matchers', async ({ runTSC }) => {
   const result = await runTSC({
     'a.spec.ts': `
       const { test } = pwt;
@@ -73,7 +73,7 @@ test('should work with default expect matchers', async ({runTSC}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should work with default expect matchers and esModuleInterop=false', async ({runTSC}) => {
+test('should work with default expect matchers and esModuleInterop=false', async ({ runTSC }) => {
   const result = await runTSC({
     'a.spec.ts': `
       const { test } = pwt;
@@ -98,7 +98,7 @@ test('should work with default expect matchers and esModuleInterop=false', async
   expect(result.exitCode).toBe(0);
 });
 
-test('should work with custom PlaywrightTest namespace', async ({runTSC}) => {
+test('should work with custom PlaywrightTest namespace', async ({ runTSC }) => {
   const result = await runTSC({
     'global.d.ts': `
       // Extracted example from their typings.
@@ -126,7 +126,7 @@ test('should work with custom PlaywrightTest namespace', async ({runTSC}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should not expand huge arrays', async ({runInlineTest}) => {
+test('should not expand huge arrays', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'expect-test.spec.ts': `
       const { test } = pwt;

--- a/tests/playwright-test/gitignore.spec.ts
+++ b/tests/playwright-test/gitignore.spec.ts
@@ -16,7 +16,7 @@
 
 import { test, expect } from './playwright-test-fixtures';
 
-test('should respect .gitignore', async ({runInlineTest}) => {
+test('should respect .gitignore', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     '.gitignore': `a.spec.js`,
     'a.spec.js': `
@@ -32,7 +32,7 @@ test('should respect .gitignore', async ({runInlineTest}) => {
   expect(result.passed).toBe(1);
 });
 
-test('should respect nested .gitignore', async ({runInlineTest}) => {
+test('should respect nested .gitignore', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a/.gitignore': `a.spec.js`,
     'a/a.spec.js': `
@@ -48,7 +48,7 @@ test('should respect nested .gitignore', async ({runInlineTest}) => {
   expect(result.passed).toBe(1);
 });
 
-test('should respect enclosing .gitignore', async ({runInlineTest}) => {
+test('should respect enclosing .gitignore', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     '.gitignore': `a/a.spec.js`,
     'a/a.spec.js': `
@@ -64,7 +64,7 @@ test('should respect enclosing .gitignore', async ({runInlineTest}) => {
   expect(result.passed).toBe(1);
 });
 
-test('should respect negations and comments in .gitignore', async ({runInlineTest}) => {
+test('should respect negations and comments in .gitignore', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     '.gitignore': `
       # A comment

--- a/tests/playwright-test/global-setup.spec.ts
+++ b/tests/playwright-test/global-setup.spec.ts
@@ -285,7 +285,7 @@ test('globalSetup should work for auth', async ({ runInlineTest }) => {
   expect(result.passed).toBe(1);
 });
 
-test('globalSetup auth should compile', async ({runTSC}) => {
+test('globalSetup auth should compile', async ({ runTSC }) => {
   const result = await runTSC(authFiles);
   expect(result.exitCode).toBe(0);
 });

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -30,7 +30,7 @@ const files = {
   `
 };
 
-test('should support golden', async ({runInlineTest}) => {
+test('should support golden', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot.txt': `Hello world`,
@@ -44,7 +44,7 @@ test('should support golden', async ({runInlineTest}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should fail on wrong golden', async ({runInlineTest}) => {
+test('should fail on wrong golden', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot.txt': `Line1
@@ -78,7 +78,7 @@ Line7`,
   expect(result.output).toContain('Line7');
 });
 
-test('should write detailed failure result to an output folder', async ({runInlineTest}, testInfo) => {
+test('should write detailed failure result to an output folder', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot.txt': `Hello world`,
@@ -101,7 +101,7 @@ test('should write detailed failure result to an output folder', async ({runInli
   expect(fs.existsSync(actualSnapshotArtifactPath)).toBe(true);
 });
 
-test("doesn\'t create comparison artifacts in an output folder for passed negated snapshot matcher", async ({runInlineTest}, testInfo) => {
+test("doesn\'t create comparison artifacts in an output folder for passed negated snapshot matcher", async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot.txt': `Hello world`,
@@ -123,7 +123,7 @@ test("doesn\'t create comparison artifacts in an output folder for passed negate
   expect(fs.existsSync(actualSnapshotArtifactPath)).toBe(false);
 });
 
-test('should pass on different snapshots with negate matcher', async ({runInlineTest}) => {
+test('should pass on different snapshots with negate matcher', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot.txt': `Hello world`,
@@ -138,7 +138,7 @@ test('should pass on different snapshots with negate matcher', async ({runInline
   expect(result.exitCode).toBe(0);
 });
 
-test('should fail on same snapshots with negate matcher', async ({runInlineTest}) => {
+test('should fail on same snapshots with negate matcher', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot.txt': `Hello world`,
@@ -155,7 +155,7 @@ test('should fail on same snapshots with negate matcher', async ({runInlineTest}
   expect(result.output).toContain('Expected result should be different from the actual one.');
 });
 
-test('should write missing expectations locally', async ({runInlineTest}, testInfo) => {
+test('should write missing expectations locally', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js': `
@@ -173,7 +173,7 @@ test('should write missing expectations locally', async ({runInlineTest}, testIn
   expect(data.toString()).toBe('Hello world');
 });
 
-test('shouldn\'t write missing expectations locally for negated matcher', async ({runInlineTest}, testInfo) => {
+test('shouldn\'t write missing expectations locally for negated matcher', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js': `
@@ -190,7 +190,7 @@ test('shouldn\'t write missing expectations locally for negated matcher', async 
   expect(fs.existsSync(snapshotOutputPath)).toBe(false);
 });
 
-test('should update snapshot with the update-snapshots flag', async ({runInlineTest}, testInfo) => {
+test('should update snapshot with the update-snapshots flag', async ({ runInlineTest }, testInfo) => {
   const EXPECTED_SNAPSHOT = 'Hello world';
   const ACTUAL_SNAPSHOT = 'Hello world updated';
   const result = await runInlineTest({
@@ -211,7 +211,7 @@ test('should update snapshot with the update-snapshots flag', async ({runInlineT
   expect(data.toString()).toBe(ACTUAL_SNAPSHOT);
 });
 
-test('shouldn\'t update snapshot with the update-snapshots flag for negated matcher', async ({runInlineTest}, testInfo) => {
+test('shouldn\'t update snapshot with the update-snapshots flag for negated matcher', async ({ runInlineTest }, testInfo) => {
   const EXPECTED_SNAPSHOT = 'Hello world';
   const ACTUAL_SNAPSHOT = 'Hello world updated';
   const result = await runInlineTest({
@@ -231,7 +231,7 @@ test('shouldn\'t update snapshot with the update-snapshots flag for negated matc
   expect(data.toString()).toBe(EXPECTED_SNAPSHOT);
 });
 
-test('should silently write missing expectations locally with the update-snapshots flag', async ({runInlineTest}, testInfo) => {
+test('should silently write missing expectations locally with the update-snapshots flag', async ({ runInlineTest }, testInfo) => {
   const ACTUAL_SNAPSHOT = 'Hello world new';
   const result = await runInlineTest({
     ...files,
@@ -250,7 +250,7 @@ test('should silently write missing expectations locally with the update-snapsho
   expect(data.toString()).toBe(ACTUAL_SNAPSHOT);
 });
 
-test('should silently write missing expectations locally with the update-snapshots flag for negated matcher', async ({runInlineTest}, testInfo) => {
+test('should silently write missing expectations locally with the update-snapshots flag for negated matcher', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js': `
@@ -267,7 +267,7 @@ test('should silently write missing expectations locally with the update-snapsho
   expect(fs.existsSync(snapshotOutputPath)).toBe(false);
 });
 
-test('should match multiple snapshots', async ({runInlineTest}) => {
+test('should match multiple snapshots', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot1.txt': `Snapshot1`,
@@ -285,7 +285,7 @@ test('should match multiple snapshots', async ({runInlineTest}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should match snapshots from multiple projects', async ({runInlineTest}) => {
+test('should match snapshots from multiple projects', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
     'playwright.config.ts': `
@@ -313,7 +313,7 @@ test('should match snapshots from multiple projects', async ({runInlineTest}) =>
   expect(result.exitCode).toBe(0);
 });
 
-test('should use provided name', async ({runInlineTest}) => {
+test('should use provided name', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/provided.txt': `Hello world`,
@@ -327,7 +327,7 @@ test('should use provided name', async ({runInlineTest}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should throw without a name', async ({runInlineTest}) => {
+test('should throw without a name', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js': `
@@ -341,7 +341,7 @@ test('should throw without a name', async ({runInlineTest}) => {
   expect(result.output).toContain('toMatchSnapshot() requires a "name" parameter');
 });
 
-test('should use provided name via options', async ({runInlineTest}) => {
+test('should use provided name via options', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/provided.txt': `Hello world`,
@@ -355,10 +355,10 @@ test('should use provided name via options', async ({runInlineTest}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should compare binary', async ({runInlineTest}) => {
+test('should compare binary', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
-    'a.spec.js-snapshots/snapshot.dat': Buffer.from([1,2,3,4]),
+    'a.spec.js-snapshots/snapshot.dat': Buffer.from([1, 2, 3, 4]),
     'a.spec.js': `
       const { test } = require('./helper');
       test('is a test', ({}) => {
@@ -369,11 +369,11 @@ test('should compare binary', async ({runInlineTest}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should compare PNG images', async ({runInlineTest}) => {
+test('should compare PNG images', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot.png':
-        Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==', 'base64'),
+      Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==', 'base64'),
     'a.spec.js': `
       const { test } = require('./helper');
       test('is a test', ({}) => {
@@ -384,11 +384,11 @@ test('should compare PNG images', async ({runInlineTest}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should compare different PNG images', async ({runInlineTest}, testInfo) => {
+test('should compare different PNG images', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot.png':
-        Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==', 'base64'),
+      Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==', 'base64'),
     'a.spec.js': `
       const { test } = require('./helper');
       test('is a test', ({}) => {
@@ -411,7 +411,7 @@ test('should compare different PNG images', async ({runInlineTest}, testInfo) =>
   expect(fs.existsSync(diffSnapshotArtifactPath)).toBe(true);
 });
 
-test('should respect threshold', async ({runInlineTest}) => {
+test('should respect threshold', async ({ runInlineTest }) => {
   const expected = fs.readFileSync(path.join(__dirname, 'assets/screenshot-canvas-expected.png'));
   const actual = fs.readFileSync(path.join(__dirname, 'assets/screenshot-canvas-actual.png'));
   const result = await runInlineTest({
@@ -431,7 +431,7 @@ test('should respect threshold', async ({runInlineTest}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should respect project threshold', async ({runInlineTest}) => {
+test('should respect project threshold', async ({ runInlineTest }) => {
   const expected = fs.readFileSync(path.join(__dirname, 'assets/screenshot-canvas-expected.png'));
   const actual = fs.readFileSync(path.join(__dirname, 'assets/screenshot-canvas-actual.png'));
   const result = await runInlineTest({
@@ -456,7 +456,7 @@ test('should respect project threshold', async ({runInlineTest}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should sanitize snapshot name', async ({runInlineTest}) => {
+test('should sanitize snapshot name', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/-snapshot-.txt': `Hello world`,
@@ -470,7 +470,7 @@ test('should sanitize snapshot name', async ({runInlineTest}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should write missing expectations with sanitized snapshot name', async ({runInlineTest}, testInfo) => {
+test('should write missing expectations with sanitized snapshot name', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js': `
@@ -488,11 +488,11 @@ test('should write missing expectations with sanitized snapshot name', async ({r
   expect(data.toString()).toBe('Hello world');
 });
 
-test('should attach expected/actual/diff', async ({runInlineTest}, testInfo) => {
+test('should attach expected/actual/diff', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot.png':
-        Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==', 'base64'),
+      Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==', 'base64'),
     'a.spec.js': `
       const { test } = require('./helper');
       test.afterEach(async ({}, testInfo) => {
@@ -527,11 +527,11 @@ test('should attach expected/actual/diff', async ({runInlineTest}, testInfo) => 
   ]);
 });
 
-test('should attach expected/actual and no diff', async ({runInlineTest}, testInfo) => {
+test('should attach expected/actual and no diff', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot.png':
-        Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEklEQVR42mP8z8AARAwMjDAGACwBA/9IB8FMAAAAAElFTkSuQmCC', 'base64'),
+      Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEklEQVR42mP8z8AARAwMjDAGACwBA/9IB8FMAAAAAElFTkSuQmCC', 'base64'),
     'a.spec.js': `
       const { test } = require('./helper');
       test.afterEach(async ({}, testInfo) => {

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -184,7 +184,7 @@ test('should load esm when package.json has type module', async ({ runInlineTest
       import * as fs from 'fs';
       export default { projects: [{name: 'foo'}] };
     `,
-    'package.json': JSON.stringify({type: 'module'}),
+    'package.json': JSON.stringify({ type: 'module' }),
     'a.test.ts': `
       const { test } = pwt;
       test('check project name', ({}, testInfo) => {

--- a/tests/playwright-test/repeat-each.spec.ts
+++ b/tests/playwright-test/repeat-each.spec.ts
@@ -16,7 +16,7 @@
 
 import { test, expect } from './playwright-test-fixtures';
 
-test('should repeat from command line', async ({runInlineTest}) => {
+test('should repeat from command line', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.js': `
       const { test } = pwt;

--- a/tests/playwright-test/stdio.spec.ts
+++ b/tests/playwright-test/stdio.spec.ts
@@ -16,7 +16,7 @@
 
 import { test, expect } from './playwright-test-fixtures';
 
-test('should get top level stdio', async ({runInlineTest}) => {
+test('should get top level stdio', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.js': `
       const { test } = pwt;
@@ -39,7 +39,7 @@ test('should get top level stdio', async ({runInlineTest}) => {
   ]);
 });
 
-test('should get stdio from env afterAll', async ({runInlineTest}) => {
+test('should get stdio from env afterAll', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'helper.ts': `
       export const test = pwt.test.extend({
@@ -61,7 +61,7 @@ test('should get stdio from env afterAll', async ({runInlineTest}) => {
   ]);
 });
 
-test('should ignore stdio when quiet', async ({runInlineTest}) => {
+test('should ignore stdio when quiet', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
       module.exports = { quiet: true };

--- a/tests/playwright-test/test-modifiers.spec.ts
+++ b/tests/playwright-test/test-modifiers.spec.ts
@@ -130,7 +130,7 @@ test('test modifiers should work', async ({ runInlineTest }) => {
   expect(result.skipped).toBe(9);
 });
 
-test('test modifiers should check types', async ({runTSC}) => {
+test('test modifiers should check types', async ({ runTSC }) => {
   const result = await runTSC({
     'helper.ts': `
       export const test = pwt.test.extend<{ foo: boolean }>({

--- a/tests/playwright-test/test-output-dir.spec.ts
+++ b/tests/playwright-test/test-output-dir.spec.ts
@@ -67,7 +67,7 @@ test('should work and remove non-failures', async ({ runInlineTest }, testInfo) 
   expect(fs.existsSync(testInfo.outputPath('test-results', 'my-test-test-1-chromium-retry2'))).toBe(false);
 });
 
-test('should include repeat token', async ({runInlineTest}) => {
+test('should include repeat token', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.js': `
       const { test } = pwt;
@@ -83,7 +83,7 @@ test('should include repeat token', async ({runInlineTest}) => {
   expect(result.passed).toBe(3);
 });
 
-test('should be unique for beforeAll and afterAll hooks', async ({runInlineTest}, testInfo) => {
+test('should be unique for beforeAll and afterAll hooks', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'a.spec.js': `
       const { test } = pwt;
@@ -216,7 +216,7 @@ test('should include the project name', async ({ runInlineTest }) => {
   expect(result.output).toContain('my-test.spec.js-snapshots/bar-Bar-space--suffix.txt');
 });
 
-test('should remove output dirs for projects run', async ({runInlineTest}, testInfo) => {
+test('should remove output dirs for projects run', async ({ runInlineTest }, testInfo) => {
   const paths: string[] = [];
   const files: string[] = [];
 

--- a/tests/playwright-test/types-2.spec.ts
+++ b/tests/playwright-test/types-2.spec.ts
@@ -16,7 +16,7 @@
 
 import { test, expect } from './playwright-test-fixtures';
 
-test('basics should work', async ({runTSC}) => {
+test('basics should work', async ({ runTSC }) => {
   const result = await runTSC({
     'a.spec.ts': `
       const { test } = pwt;
@@ -34,7 +34,7 @@ test('basics should work', async ({runTSC}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('can pass sync functions everywhere', async ({runTSC}) => {
+test('can pass sync functions everywhere', async ({ runTSC }) => {
   const result = await runTSC({
     'a.spec.ts': `
       const test = pwt.test.extend<{ foo: string }>({
@@ -50,7 +50,7 @@ test('can pass sync functions everywhere', async ({runTSC}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('can return anything from hooks', async ({runTSC}) => {
+test('can return anything from hooks', async ({ runTSC }) => {
   const result = await runTSC({
     'a.spec.ts': `
       const { test } = pwt;
@@ -63,7 +63,7 @@ test('can return anything from hooks', async ({runTSC}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('test.declare should check types', async ({runTSC}) => {
+test('test.declare should check types', async ({ runTSC }) => {
   const result = await runTSC({
     'helper.ts': `
       export const test = pwt.test;

--- a/tests/playwright-test/types.spec.ts
+++ b/tests/playwright-test/types.spec.ts
@@ -16,7 +16,7 @@
 
 import { test, expect } from './playwright-test-fixtures';
 
-test('should check types of fixtures', async ({runTSC}) => {
+test('should check types of fixtures', async ({ runTSC }) => {
   const result = await runTSC({
     'helper.ts': `
       export type MyOptions = { foo: string, bar: number };
@@ -165,7 +165,7 @@ test('should check types of fixtures', async ({runTSC}) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('config should allow void/empty options', async ({runTSC}) => {
+test('config should allow void/empty options', async ({ runTSC }) => {
   const result = await runTSC({
     'playwright.config.ts': `
       const configs: pwt.Config[] = [];

--- a/tests/popup.spec.ts
+++ b/tests/popup.spec.ts
@@ -16,7 +16,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should inherit user agent from browser context', async function({browser, server}) {
+it('should inherit user agent from browser context', async function({ browser, server }) {
   const context = await browser.newContext({
     userAgent: 'hey'
   });
@@ -36,7 +36,7 @@ it('should inherit user agent from browser context', async function({browser, se
   expect(request.headers['user-agent']).toBe('hey');
 });
 
-it('should respect routes from browser context', async function({browser, server}) {
+it('should respect routes from browser context', async function({ browser, server }) {
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -54,7 +54,7 @@ it('should respect routes from browser context', async function({browser, server
   expect(intercepted).toBe(true);
 });
 
-it('should inherit extra headers from browser context', async function({browser, server}) {
+it('should inherit extra headers from browser context', async function({ browser, server }) {
   const context = await browser.newContext({
     extraHTTPHeaders: { 'foo': 'bar' },
   });
@@ -67,7 +67,7 @@ it('should inherit extra headers from browser context', async function({browser,
   expect(request.headers['foo']).toBe('bar');
 });
 
-it('should inherit offline from browser context', async function({browser, server}) {
+it('should inherit offline from browser context', async function({ browser, server }) {
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -80,7 +80,7 @@ it('should inherit offline from browser context', async function({browser, serve
   expect(online).toBe(false);
 });
 
-it('should inherit http credentials from browser context', async function({browser, server}) {
+it('should inherit http credentials from browser context', async function({ browser, server }) {
   server.setAuth('/title.html', 'user', 'pass');
   const context = await browser.newContext({
     httpCredentials: { username: 'user', password: 'pass' }
@@ -96,7 +96,7 @@ it('should inherit http credentials from browser context', async function({brows
   await context.close();
 });
 
-it('should inherit touch support from browser context', async function({browser, server}) {
+it('should inherit touch support from browser context', async function({ browser, server }) {
   const context = await browser.newContext({
     viewport: { width: 400, height: 500 },
     hasTouch: true
@@ -111,7 +111,7 @@ it('should inherit touch support from browser context', async function({browser,
   expect(hasTouch).toBe(true);
 });
 
-it('should inherit viewport size from browser context', async function({browser, server}) {
+it('should inherit viewport size from browser context', async function({ browser, server }) {
   const context = await browser.newContext({
     viewport: { width: 400, height: 500 }
   });
@@ -122,10 +122,10 @@ it('should inherit viewport size from browser context', async function({browser,
     return { width: win.innerWidth, height: win.innerHeight };
   });
   await context.close();
-  expect(size).toEqual({width: 400, height: 500});
+  expect(size).toEqual({ width: 400, height: 500 });
 });
 
-it('should use viewport size from window features', async function({browser, server}) {
+it('should use viewport size from window features', async function({ browser, server }) {
   const context = await browser.newContext({
     viewport: { width: 700, height: 700 }
   });
@@ -142,11 +142,11 @@ it('should use viewport size from window features', async function({browser, ser
   await popup.waitForLoadState();
   const resized = await popup.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
   await context.close();
-  expect(size).toEqual({width: 600, height: 300});
-  expect(resized).toEqual({width: 500, height: 400});
+  expect(size).toEqual({ width: 600, height: 300 });
+  expect(resized).toEqual({ width: 500, height: 400 });
 });
 
-it('should respect routes from browser context when using window.open', async function({browser, server}) {
+it('should respect routes from browser context when using window.open', async function({ browser, server }) {
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -163,7 +163,7 @@ it('should respect routes from browser context when using window.open', async fu
   await context.close();
 });
 
-it('BrowserContext.addInitScript should apply to an in-process popup', async function({browser, server}) {
+it('BrowserContext.addInitScript should apply to an in-process popup', async function({ browser, server }) {
   const context = await browser.newContext();
   await context.addInitScript(() => window['injected'] = 123);
   const page = await context.newPage();
@@ -176,7 +176,7 @@ it('BrowserContext.addInitScript should apply to an in-process popup', async fun
   expect(injected).toBe(123);
 });
 
-it('BrowserContext.addInitScript should apply to a cross-process popup', async function({browser, server}) {
+it('BrowserContext.addInitScript should apply to a cross-process popup', async function({ browser, server }) {
   const context = await browser.newContext();
   await context.addInitScript(() => window['injected'] = 123);
   const page = await context.newPage();
@@ -191,7 +191,7 @@ it('BrowserContext.addInitScript should apply to a cross-process popup', async f
   await context.close();
 });
 
-it('should expose function from browser context', async function({browser, server}) {
+it('should expose function from browser context', async function({ browser, server }) {
   const context = await browser.newContext();
   const messages = [];
   await context.exposeFunction('add', (a, b) => {
@@ -210,7 +210,7 @@ it('should expose function from browser context', async function({browser, serve
   expect(messages.join('|')).toBe('page|binding');
 });
 
-it('should not dispatch binding on a closed page', async function({browser, server, browserName}) {
+it('should not dispatch binding on a closed page', async function({ browser, server, browserName }) {
   const context = await browser.newContext();
   const messages = [];
   await context.exposeFunction('add', (a, b) => {

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -18,7 +18,7 @@ import { playwrightTest as it, expect } from './config/browserTest';
 import socks from 'socksv5';
 import net from 'net';
 
-it('should throw for bad server value', async ({browserType, browserOptions}) => {
+it('should throw for bad server value', async ({ browserType, browserOptions }) => {
   const error = await browserType.launch({
     ...browserOptions,
     // @ts-expect-error server must be a string
@@ -27,7 +27,7 @@ it('should throw for bad server value', async ({browserType, browserOptions}) =>
   expect(error.message).toContain('proxy.server: expected string, got number');
 });
 
-it('should use proxy', async ({browserType, browserOptions, server}) => {
+it('should use proxy', async ({ browserType, browserOptions, server }) => {
   server.setRoute('/target.html', async (req, res) => {
     res.end('<html><title>Served by the proxy</title></html>');
   });
@@ -41,7 +41,7 @@ it('should use proxy', async ({browserType, browserOptions, server}) => {
   await browser.close();
 });
 
-it('should use proxy for second page', async ({browserType, browserOptions, server}) => {
+it('should use proxy for second page', async ({ browserType, browserOptions, server }) => {
   server.setRoute('/target.html', async (req, res) => {
     res.end('<html><title>Served by the proxy</title></html>');
   });
@@ -61,7 +61,7 @@ it('should use proxy for second page', async ({browserType, browserOptions, serv
   await browser.close();
 });
 
-it('should work with IP:PORT notion', async ({browserType, browserOptions, server}) => {
+it('should work with IP:PORT notion', async ({ browserType, browserOptions, server }) => {
   server.setRoute('/target.html', async (req, res) => {
     res.end('<html><title>Served by the proxy</title></html>');
   });
@@ -75,7 +75,7 @@ it('should work with IP:PORT notion', async ({browserType, browserOptions, serve
   await browser.close();
 });
 
-it('should authenticate', async ({browserType, browserOptions, server}) => {
+it('should authenticate', async ({ browserType, browserOptions, server }) => {
   server.setRoute('/target.html', async (req, res) => {
     const auth = req.headers['proxy-authorization'];
     if (!auth) {
@@ -97,7 +97,7 @@ it('should authenticate', async ({browserType, browserOptions, server}) => {
   await browser.close();
 });
 
-it('should exclude patterns', async ({browserType, browserOptions, server, browserName, headless}) => {
+it('should exclude patterns', async ({ browserType, browserOptions, server, browserName, headless }) => {
   it.fixme(browserName === 'chromium' && !headless, 'Chromium headed crashes with CHECK(!in_frame_tree_) in RenderFrameImpl::OnDeleteFrame.');
 
   server.setRoute('/target.html', async (req, res) => {
@@ -229,9 +229,9 @@ async function setupSocksForwardingServer(port: number, forwardPort: number){
   };
 }
 
-it('should use SOCKS proxy for websocket requests', async ({browserName, platform, browserType, browserOptions, server}, testInfo) => {
+it('should use SOCKS proxy for websocket requests', async ({ browserName, platform, browserType, browserOptions, server }, testInfo) => {
   it.fixme(browserName === 'webkit' && platform !== 'linux');
-  const {proxyServerAddr, closeProxyServer} = await setupSocksForwardingServer(testInfo.workerIndex + 2048 + 2, server.PORT);
+  const { proxyServerAddr, closeProxyServer } = await setupSocksForwardingServer(testInfo.workerIndex + 2048 + 2, server.PORT);
   const browser = await browserType.launch({
     ...browserOptions,
     proxy: {

--- a/tests/screenshot.spec.ts
+++ b/tests/screenshot.spec.ts
@@ -22,7 +22,7 @@ import { verifyViewport } from './config/utils';
 browserTest.describe('page screenshot', () => {
   browserTest.skip(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
 
-  browserTest('should run in parallel in multiple pages', async ({server, contextFactory}) => {
+  browserTest('should run in parallel in multiple pages', async ({ server, contextFactory }) => {
     const context = await contextFactory();
     const N = 5;
     const pages = await Promise.all(Array(N).fill(0).map(async () => {
@@ -39,7 +39,7 @@ browserTest.describe('page screenshot', () => {
     await Promise.all(pages.map(page => page.close()));
   });
 
-  browserTest('should work with a mobile viewport', async ({browser, server, browserName}) => {
+  browserTest('should work with a mobile viewport', async ({ browser, server, browserName }) => {
     browserTest.skip(browserName === 'firefox');
     browserTest.fixme(browserName === 'chromium');
 
@@ -51,11 +51,11 @@ browserTest.describe('page screenshot', () => {
     await context.close();
   });
 
-  browserTest('should work with a mobile viewport and clip', async ({browser, server, browserName, channel}) => {
+  browserTest('should work with a mobile viewport and clip', async ({ browser, server, browserName, channel }) => {
     browserTest.skip(browserName === 'firefox');
     browserTest.skip(!!channel, 'Different result in stable/beta');
 
-    const context = await browser.newContext({viewport: { width: 320, height: 480 }, isMobile: true});
+    const context = await browser.newContext({ viewport: { width: 320, height: 480 }, isMobile: true });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/overflow.html');
     const screenshot = await page.screenshot({ clip: { x: 10, y: 10, width: 100, height: 150 } });
@@ -63,10 +63,10 @@ browserTest.describe('page screenshot', () => {
     await context.close();
   });
 
-  browserTest('should work with a mobile viewport and fullPage', async ({browser, server, browserName}) => {
+  browserTest('should work with a mobile viewport and fullPage', async ({ browser, server, browserName }) => {
     browserTest.skip(browserName === 'firefox');
 
-    const context = await browser.newContext({viewport: { width: 320, height: 480 }, isMobile: true});
+    const context = await browser.newContext({ viewport: { width: 320, height: 480 }, isMobile: true });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/overflow-large.html');
     const screenshot = await page.screenshot({ fullPage: true });
@@ -74,7 +74,7 @@ browserTest.describe('page screenshot', () => {
     await context.close();
   });
 
-  browserTest('should work with device scale factor', async ({browser, server}) => {
+  browserTest('should work with device scale factor', async ({ browser, server }) => {
     const context = await browser.newContext({ viewport: { width: 320, height: 480 }, deviceScaleFactor: 2 });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/grid.html');
@@ -122,10 +122,10 @@ browserTest.describe('page screenshot', () => {
 browserTest.describe('element sceenshot', () => {
   browserTest.skip(({ browserName, headless }) => browserName === 'firefox' && !headless);
 
-  browserTest('element screenshot should work with a mobile viewport', async ({browser, server, browserName}) => {
+  browserTest('element screenshot should work with a mobile viewport', async ({ browser, server, browserName }) => {
     browserTest.skip(browserName === 'firefox');
 
-    const context = await browser.newContext({viewport: { width: 320, height: 480 }, isMobile: true});
+    const context = await browser.newContext({ viewport: { width: 320, height: 480 }, isMobile: true });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/grid.html');
     await page.evaluate(() => window.scrollBy(50, 100));
@@ -135,7 +135,7 @@ browserTest.describe('element sceenshot', () => {
     await context.close();
   });
 
-  browserTest('element screenshot should work with device scale factor', async ({browser, server, browserName}) => {
+  browserTest('element screenshot should work with device scale factor', async ({ browser, server, browserName }) => {
     browserTest.skip(browserName === 'firefox');
 
     const context = await browser.newContext({ viewport: { width: 320, height: 480 }, deviceScaleFactor: 2 });
@@ -148,7 +148,7 @@ browserTest.describe('element sceenshot', () => {
     await context.close();
   });
 
-  browserTest('should take screenshots when default viewport is null', async ({server, browser}) => {
+  browserTest('should take screenshots when default viewport is null', async ({ server, browser }) => {
     const context = await browser.newContext({ viewport: null });
     const page = await context.newPage();
     await page.setContent(`<div style='height: 10000px; background: red'></div>`);
@@ -167,7 +167,7 @@ browserTest.describe('element sceenshot', () => {
     await context.close();
   });
 
-  browserTest('should take fullPage screenshots when default viewport is null', async ({server, browser}) => {
+  browserTest('should take fullPage screenshots when default viewport is null', async ({ server, browser }) => {
     const context = await browser.newContext({ viewport: null });
     const page = await context.newPage();
     await page.goto(server.PREFIX + '/grid.html');
@@ -222,8 +222,8 @@ browserTest.describe('element sceenshot', () => {
     await context.close();
   });
 
-  browserTest('should take element screenshot when default viewport is null and restore back', async ({server, browser}) => {
-    const context = await browser.newContext({viewport: null});
+  browserTest('should take element screenshot when default viewport is null and restore back', async ({ server, browser }) => {
+    const context = await browser.newContext({ viewport: null });
     const page = await context.newPage();
     await page.setContent(`
       <div style="height: 14px">oooo</div>
@@ -252,7 +252,7 @@ browserTest.describe('element sceenshot', () => {
     await context.close();
   });
 
-  browserTest('should restore viewport after element screenshot and exception', async ({browser, mode}) => {
+  browserTest('should restore viewport after element screenshot and exception', async ({ browser, mode }) => {
     browserTest.skip(mode !== 'default');
 
     const context = await browser.newContext({ viewport: { width: 350, height: 360 } });

--- a/tests/selector-generator.spec.ts
+++ b/tests/selector-generator.spec.ts
@@ -277,7 +277,7 @@ it.describe('selector generator', () => {
     }
   });
 
-  it('should work with tricky ids', async ({page}) => {
+  it('should work with tricky ids', async ({ page }) => {
     await page.setContent(`<button id="this:is-my-tricky.id"><span></span></button>`);
     expect(await generate(page, 'button')).toBe('[id="this:is-my-tricky.id"]');
   });

--- a/tests/selectors-register.spec.ts
+++ b/tests/selectors-register.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should work', async ({playwright, browser}) => {
+it('should work', async ({ playwright, browser }) => {
   const createTagSelector = () => ({
     query(root, selector) {
       return root.querySelector(selector);
@@ -51,7 +51,7 @@ it('should work', async ({playwright, browser}) => {
   await context.close();
 });
 
-it('should work with path', async ({playwright, browser, asset}) => {
+it('should work with path', async ({ playwright, browser, asset }) => {
   const page = await browser.newPage();
   await playwright.selectors.register('foo', { path: asset('sectionselectorengine.js') });
   await page.setContent('<section></section>');
@@ -59,7 +59,7 @@ it('should work with path', async ({playwright, browser, asset}) => {
   await page.close();
 });
 
-it('should work in main and isolated world', async ({playwright, browser}) => {
+it('should work in main and isolated world', async ({ playwright, browser }) => {
   const page = await browser.newPage();
   const createDummySelector = () => ({
     query(root, selector) {
@@ -92,7 +92,7 @@ it('should work in main and isolated world', async ({playwright, browser}) => {
   await page.close();
 });
 
-it('should handle errors', async ({playwright, browser}) => {
+it('should handle errors', async ({ playwright, browser }) => {
   const page = await browser.newPage();
   let error = await page.$('neverregister=ignored').catch(e => e);
   expect(error.message).toContain('Unknown engine "neverregister" while parsing selector neverregister=ignored');

--- a/tests/signals.spec.ts
+++ b/tests/signals.spec.ts
@@ -20,7 +20,7 @@ import { execSync } from 'child_process';
 
 test.slow();
 
-test('should close the browser when the node process closes', async ({startRemoteServer, isWindows, server}) => {
+test('should close the browser when the node process closes', async ({ startRemoteServer, isWindows, server }) => {
   const remoteServer = await startRemoteServer({ url: server.EMPTY_PAGE });
   if (isWindows)
     execSync(`taskkill /pid ${remoteServer.child().pid} /T /F`);
@@ -32,9 +32,9 @@ test('should close the browser when the node process closes', async ({startRemot
 });
 
 test.describe('signals', () => {
-  test.skip(({platform, headless}) => platform === 'win32' || !headless);
+  test.skip(({ platform, headless }) => platform === 'win32' || !headless);
 
-  test('should report browser close signal', async ({startRemoteServer, server}) => {
+  test('should report browser close signal', async ({ startRemoteServer, server }) => {
     const remoteServer = await startRemoteServer({ url: server.EMPTY_PAGE });
     const pid = await remoteServer.out('pid');
     process.kill(-pid, 'SIGTERM');
@@ -44,7 +44,7 @@ test.describe('signals', () => {
     await remoteServer.childExitCode();
   });
 
-  test('should report browser close signal 2', async ({startRemoteServer, server}) => {
+  test('should report browser close signal 2', async ({ startRemoteServer, server }) => {
     const remoteServer = await startRemoteServer({ url: server.EMPTY_PAGE });
     const pid = await remoteServer.out('pid');
     process.kill(-pid, 'SIGKILL');
@@ -54,7 +54,7 @@ test.describe('signals', () => {
     await remoteServer.childExitCode();
   });
 
-  test('should close the browser on SIGINT', async ({startRemoteServer, server}) => {
+  test('should close the browser on SIGINT', async ({ startRemoteServer, server }) => {
     const remoteServer = await startRemoteServer({ url: server.EMPTY_PAGE });
     process.kill(remoteServer.child().pid, 'SIGINT');
     expect(await remoteServer.out('exitCode')).toBe('0');
@@ -62,7 +62,7 @@ test.describe('signals', () => {
     expect(await remoteServer.childExitCode()).toBe(130);
   });
 
-  test('should close the browser on SIGTERM', async ({startRemoteServer, server}) => {
+  test('should close the browser on SIGTERM', async ({ startRemoteServer, server }) => {
     const remoteServer = await startRemoteServer({ url: server.EMPTY_PAGE });
     process.kill(remoteServer.child().pid, 'SIGTERM');
     expect(await remoteServer.out('exitCode')).toBe('0');
@@ -70,7 +70,7 @@ test.describe('signals', () => {
     expect(await remoteServer.childExitCode()).toBe(0);
   });
 
-  test('should close the browser on SIGHUP', async ({startRemoteServer, server}) => {
+  test('should close the browser on SIGHUP', async ({ startRemoteServer, server }) => {
     const remoteServer = await startRemoteServer({ url: server.EMPTY_PAGE });
     process.kill(remoteServer.child().pid, 'SIGHUP');
     expect(await remoteServer.out('exitCode')).toBe('0');
@@ -78,7 +78,7 @@ test.describe('signals', () => {
     expect(await remoteServer.childExitCode()).toBe(0);
   });
 
-  test('should kill the browser on double SIGINT', async ({startRemoteServer, server}) => {
+  test('should kill the browser on double SIGINT', async ({ startRemoteServer, server }) => {
     const remoteServer = await startRemoteServer({ stallOnClose: true, url: server.EMPTY_PAGE });
     process.kill(remoteServer.child().pid, 'SIGINT');
     await remoteServer.out('stalled');
@@ -88,7 +88,7 @@ test.describe('signals', () => {
     expect(await remoteServer.childExitCode()).toBe(130);
   });
 
-  test('should kill the browser on SIGINT + SIGTERM', async ({startRemoteServer, server}) => {
+  test('should kill the browser on SIGINT + SIGTERM', async ({ startRemoteServer, server }) => {
     const remoteServer = await startRemoteServer({ stallOnClose: true, url: server.EMPTY_PAGE });
     process.kill(remoteServer.child().pid, 'SIGINT');
     await remoteServer.out('stalled');
@@ -98,7 +98,7 @@ test.describe('signals', () => {
     expect(await remoteServer.childExitCode()).toBe(0);
   });
 
-  test('should kill the browser on SIGTERM + SIGINT', async ({startRemoteServer, server}) => {
+  test('should kill the browser on SIGTERM + SIGINT', async ({ startRemoteServer, server }) => {
     const remoteServer = await startRemoteServer({ stallOnClose: true, url: server.EMPTY_PAGE });
     process.kill(remoteServer.child().pid, 'SIGTERM');
     await remoteServer.out('stalled');

--- a/tests/slowmo.spec.ts
+++ b/tests/slowmo.spec.ts
@@ -48,169 +48,169 @@ async function checkPageSlowMo(toImpl, page, task) {
 it.describe('slowMo', () => {
   it.skip(({ mode }) => mode !== 'default');
 
-  it('Page SlowMo $$eval', async ({page, toImpl}) => {
+  it('Page SlowMo $$eval', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.$$eval('button', () => void 0));
   });
-  it('Page SlowMo $eval', async ({page, toImpl}) => {
+  it('Page SlowMo $eval', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.$eval('button', () => void 0));
   });
-  it('Page SlowMo check', async ({page, toImpl}) => {
+  it('Page SlowMo check', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.check('.check'));
   });
-  it('Page SlowMo click', async ({page, toImpl}) => {
+  it('Page SlowMo click', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.click('button'));
   });
-  it('Page SlowMo dblclick', async ({page, toImpl}) => {
+  it('Page SlowMo dblclick', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.dblclick('button'));
   });
-  it('Page SlowMo dispatchEvent', async ({page, toImpl}) => {
+  it('Page SlowMo dispatchEvent', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.dispatchEvent('button', 'click'));
   });
-  it('Page SlowMo emulateMedia', async ({page, toImpl}) => {
-    await checkPageSlowMo(toImpl, page, () => page.emulateMedia({media: 'print'}));
+  it('Page SlowMo emulateMedia', async ({ page, toImpl }) => {
+    await checkPageSlowMo(toImpl, page, () => page.emulateMedia({ media: 'print' }));
   });
-  it('Page SlowMo evaluate', async ({page, toImpl}) => {
+  it('Page SlowMo evaluate', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.evaluate(() => void 0));
   });
-  it('Page SlowMo evaluateHandle', async ({page, toImpl}) => {
+  it('Page SlowMo evaluateHandle', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.evaluateHandle(() => window));
   });
-  it('Page SlowMo fill', async ({page, toImpl}) => {
+  it('Page SlowMo fill', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.fill('.fill', 'foo'));
   });
-  it('Page SlowMo focus', async ({page, toImpl}) => {
+  it('Page SlowMo focus', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.focus('button'));
   });
-  it('Page SlowMo goto', async ({page, toImpl}) => {
+  it('Page SlowMo goto', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.goto('about:blank'));
   });
-  it('Page SlowMo hover', async ({page, toImpl}) => {
+  it('Page SlowMo hover', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.hover('button'));
   });
-  it('Page SlowMo press', async ({page, toImpl}) => {
+  it('Page SlowMo press', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.press('button', 'Enter'));
   });
-  it('Page SlowMo reload', async ({page, toImpl}) => {
+  it('Page SlowMo reload', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.reload());
   });
-  it('Page SlowMo setContent', async ({page, toImpl}) => {
+  it('Page SlowMo setContent', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.setContent('hello world'));
   });
-  it('Page SlowMo selectOption', async ({page, toImpl}) => {
+  it('Page SlowMo selectOption', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.selectOption('select', 'foo'));
   });
-  it('Page SlowMo setInputFiles', async ({page, toImpl}) => {
+  it('Page SlowMo setInputFiles', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.setInputFiles('.file', []));
   });
-  it('Page SlowMo setViewportSize', async ({page, toImpl}) => {
-    await checkPageSlowMo(toImpl, page, () => page.setViewportSize({height: 400, width: 400}));
+  it('Page SlowMo setViewportSize', async ({ page, toImpl }) => {
+    await checkPageSlowMo(toImpl, page, () => page.setViewportSize({ height: 400, width: 400 }));
   });
-  it('Page SlowMo type', async ({page, toImpl}) => {
+  it('Page SlowMo type', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.type('.fill', 'a'));
   });
-  it('Page SlowMo uncheck', async ({page, toImpl}) => {
+  it('Page SlowMo uncheck', async ({ page, toImpl }) => {
     await checkPageSlowMo(toImpl, page, () => page.uncheck('.uncheck'));
   });
-  it('Frame SlowMo $$eval', async ({page, server, toImpl}) => {
+  it('Frame SlowMo $$eval', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.$$eval('button', () => void 0));
   });
-  it('Frame SlowMo $eval', async ({page, server, toImpl}) => {
+  it('Frame SlowMo $eval', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.$eval('button', () => void 0));
   });
-  it('Frame SlowMo check', async ({page, server, toImpl}) => {
+  it('Frame SlowMo check', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.check('.check'));
   });
-  it('Frame SlowMo click', async ({page, server, toImpl}) => {
+  it('Frame SlowMo click', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.click('button'));
   });
-  it('Frame SlowMo dblclick', async ({page, server, toImpl}) => {
+  it('Frame SlowMo dblclick', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.dblclick('button'));
   });
-  it('Frame SlowMo dispatchEvent', async ({page, server, toImpl}) => {
+  it('Frame SlowMo dispatchEvent', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.dispatchEvent('button', 'click'));
   });
-  it('Frame SlowMo evaluate', async ({page, server, toImpl}) => {
+  it('Frame SlowMo evaluate', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.evaluate(() => void 0));
   });
-  it('Frame SlowMo evaluateHandle', async ({page, server, toImpl}) => {
+  it('Frame SlowMo evaluateHandle', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.evaluateHandle(() => window));
   });
-  it('Frame SlowMo fill', async ({page, server, toImpl}) => {
+  it('Frame SlowMo fill', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.fill('.fill', 'foo'));
   });
-  it('Frame SlowMo focus', async ({page, server, toImpl}) => {
+  it('Frame SlowMo focus', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.focus('button'));
   });
-  it('Frame SlowMo goto', async ({page, server, toImpl}) => {
+  it('Frame SlowMo goto', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.goto('about:blank'));
   });
-  it('Frame SlowMo hover', async ({page, server, toImpl}) => {
+  it('Frame SlowMo hover', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.hover('button'));
   });
-  it('Frame SlowMo press', async ({page, server, toImpl}) => {
+  it('Frame SlowMo press', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.press('button', 'Enter'));
   });
-  it('Frame SlowMo setContent', async ({page, server, toImpl}) => {
+  it('Frame SlowMo setContent', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.setContent('hello world'));
   });
-  it('Frame SlowMo selectOption', async ({page, server, toImpl}) => {
+  it('Frame SlowMo selectOption', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.selectOption('select', 'foo'));
   });
-  it('Frame SlowMo setInputFiles', async ({page, server, toImpl}) => {
+  it('Frame SlowMo setInputFiles', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.setInputFiles('.file', []));
   });
-  it('Frame SlowMo type', async ({page, server, toImpl}) => {
+  it('Frame SlowMo type', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.type('.fill', 'a'));
   });
-  it('Frame SlowMo uncheck', async ({page, server, toImpl}) => {
+  it('Frame SlowMo uncheck', async ({ page, server, toImpl }) => {
     await checkFrameSlowMo(toImpl, page, server, frame => frame.uncheck('.uncheck'));
   });
-  it('ElementHandle SlowMo $$eval', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo $$eval', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, 'body', element => element.$$eval('button', () => void 0));
   });
-  it('ElementHandle SlowMo $eval', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo $eval', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, 'body', element => element.$eval('button', () => void 0));
   });
-  it('ElementHandle SlowMo check', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo check', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, '.check', element => element.check());
   });
-  it('ElementHandle SlowMo click', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo click', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, 'button', element => element.click());
   });
-  it('ElementHandle SlowMo dblclick', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo dblclick', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, 'button', element => element.dblclick());
   });
-  it('ElementHandle SlowMo dispatchEvent', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo dispatchEvent', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, 'button', element => element.dispatchEvent('click'));
   });
-  it('ElementHandle SlowMo evaluate', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo evaluate', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, 'button', element => element.evaluate(() => void 0));
   });
-  it('ElementHandle SlowMo evaluateHandle', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo evaluateHandle', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, 'button', element => element.evaluateHandle(() => void 0));
   });
-  it('ElementHandle SlowMo fill', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo fill', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, '.fill', element => element.fill('foo'));
   });
-  it('ElementHandle SlowMo focus', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo focus', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, 'button', element => element.focus());
   });
-  it('ElementHandle SlowMo hover', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo hover', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, 'button', element => element.hover());
   });
-  it('ElementHandle SlowMo press', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo press', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, 'button', element => element.press('Enter'));
   });
-  it('ElementHandle SlowMo selectOption', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo selectOption', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, 'select', element => element.selectOption('foo'));
   });
-  it('ElementHandle SlowMo setInputFiles', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo setInputFiles', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, '.file', element => element.setInputFiles([]));
   });
-  it('ElementHandle SlowMo type', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo type', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, '.fill', element => element.type('a'));
   });
-  it('ElementHandle SlowMo uncheck', async ({page, toImpl}) => {
+  it('ElementHandle SlowMo uncheck', async ({ page, toImpl }) => {
     await checkElementSlowMo(toImpl, page, '.uncheck', element => element.uncheck());
   });
 });

--- a/tests/snapshotter.spec.ts
+++ b/tests/snapshotter.spec.ts
@@ -125,7 +125,7 @@ it.describe('snapshots', () => {
     expect(distillSnapshot(snapshot2)).toBe('<DIV id=\"div\" attr1=\"1\"></DIV>');
   });
 
-  it('should have a custom doctype', async ({page, server, toImpl, snapshotter}) => {
+  it('should have a custom doctype', async ({ page, server, toImpl, snapshotter }) => {
     await page.goto(server.EMPTY_PAGE);
     await page.setContent('<!DOCTYPE foo><body>hi</body>');
 

--- a/tests/tap.spec.ts
+++ b/tests/tap.spec.ts
@@ -55,7 +55,7 @@ it('should not send mouse events touchstart is canceled', async ({ page }) => {
   await page.setContent(`<div style="width: 50px; height: 50px; background: red">`);
   await page.evaluate(() => {
     // touchstart is not cancelable unless passive is false
-    document.addEventListener('touchstart', t => t.preventDefault(), {passive: false});
+    document.addEventListener('touchstart', t => t.preventDefault(), { passive: false });
   });
   const eventsHandle = await trackEvents(await page.$('div'));
   await page.tap('div');
@@ -82,7 +82,7 @@ it('should not send mouse events when touchend is canceled', async ({ page }) =>
   ]);
 });
 
-it('should wait for a navigation caused by a tap', async ({page, server}) => {
+it('should wait for a navigation caused by a tap', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`
   <a href="/intercept-this.html">link</a>;
@@ -110,7 +110,7 @@ it('should work with modifiers', async ({ page  }) => {
   const altKeyPromise = page.evaluate(() => new Promise(resolve => {
     document.addEventListener('touchstart', event => {
       resolve(event.altKey);
-    }, {passive: false});
+    }, { passive: false });
   }));
   // make sure the evals hit the page
   await page.evaluate(() => void 0);

--- a/tests/tracing.spec.ts
+++ b/tests/tracing.spec.ts
@@ -159,7 +159,7 @@ for (const params of [
     const previewWidth = params.width * scale;
     const previewHeight = params.height * scale;
 
-    const context = await contextFactory({ viewport: { width: params.width, height: params.height }});
+    const context = await contextFactory({ viewport: { width: params.width, height: params.height } });
     await context.tracing.start({ screenshots: true, snapshots: true });
     const page = await context.newPage();
     // Make sure we have a chance to paint.

--- a/tests/video.spec.ts
+++ b/tests/video.spec.ts
@@ -153,12 +153,12 @@ function expectRedFrames(videoFile: string, size: { width: number, height: numbe
 it.describe('screencast', () => {
   it.slow();
 
-  it('videoSize should require videosPath', async ({browser}) => {
+  it('videoSize should require videosPath', async ({ browser }) => {
     const error = await browser.newContext({ videoSize: { width: 100, height: 100 } }).catch(e => e);
     expect(error.message).toContain('"videoSize" option requires "videosPath" to be specified');
   });
 
-  it('should work with old options', async ({browser}, testInfo) => {
+  it('should work with old options', async ({ browser }, testInfo) => {
     const videosPath = testInfo.outputPath('');
     const size = { width: 450, height: 240 };
     const context = await browser.newContext({
@@ -181,7 +181,7 @@ it.describe('screencast', () => {
     expect(error.message).toContain('recordVideo.dir: expected string, got undefined');
   });
 
-  it('should capture static page', async ({browser}, testInfo) => {
+  it('should capture static page', async ({ browser }, testInfo) => {
     const size = { width: 450, height: 240 };
     const context = await browser.newContext({
       recordVideo: {
@@ -200,7 +200,7 @@ it.describe('screencast', () => {
     expectRedFrames(videoFile, size);
   });
 
-  it('should expose video path', async ({browser}, testInfo) => {
+  it('should expose video path', async ({ browser }, testInfo) => {
     const videosPath = testInfo.outputPath('');
     const size = { width: 320, height: 240 };
     const context = await browser.newContext({
@@ -218,7 +218,7 @@ it.describe('screencast', () => {
     expect(fs.existsSync(path)).toBeTruthy();
   });
 
-  it('should saveAs video', async ({browser}, testInfo) => {
+  it('should saveAs video', async ({ browser }, testInfo) => {
     const videosPath = testInfo.outputPath('');
     const size = { width: 320, height: 240 };
     const context = await browser.newContext({
@@ -238,7 +238,7 @@ it.describe('screencast', () => {
     expect(fs.existsSync(saveAsPath)).toBeTruthy();
   });
 
-  it('saveAs should throw when no video frames', async ({browser, browserName}, testInfo) => {
+  it('saveAs should throw when no video frames', async ({ browser, browserName }, testInfo) => {
     const videosPath = testInfo.outputPath('');
     const size = { width: 320, height: 240 };
     const context = await browser.newContext({
@@ -267,7 +267,7 @@ it.describe('screencast', () => {
       expect(error.message).toContain('Page did not produce any video frames');
   });
 
-  it('should delete video', async ({browser}, testInfo) => {
+  it('should delete video', async ({ browser }, testInfo) => {
     const videosPath = testInfo.outputPath('');
     const size = { width: 320, height: 240 };
     const context = await browser.newContext({
@@ -288,7 +288,7 @@ it.describe('screencast', () => {
     expect(fs.existsSync(videoPath)).toBeFalsy();
   });
 
-  it('should expose video path blank page', async ({browser}, testInfo) => {
+  it('should expose video path blank page', async ({ browser }, testInfo) => {
     const videosPath = testInfo.outputPath('');
     const size = { width: 320, height: 240 };
     const context = await browser.newContext({
@@ -305,7 +305,7 @@ it.describe('screencast', () => {
     expect(fs.existsSync(path)).toBeTruthy();
   });
 
-  it('should expose video path blank popup', async ({browser}, testInfo) => {
+  it('should expose video path blank popup', async ({ browser }, testInfo) => {
     const videosPath = testInfo.outputPath('');
     const size = { width: 320, height: 240 };
     const context = await browser.newContext({
@@ -326,7 +326,7 @@ it.describe('screencast', () => {
     expect(fs.existsSync(path)).toBeTruthy();
   });
 
-  it('should capture navigation', async ({browser, server}, testInfo) => {
+  it('should capture navigation', async ({ browser, server }, testInfo) => {
     const context = await browser.newContext({
       recordVideo: {
         dir: testInfo.outputPath(''),
@@ -357,7 +357,7 @@ it.describe('screencast', () => {
     }
   });
 
-  it('should capture css transformation', async ({browser, server, headless, browserName, platform}, testInfo) => {
+  it('should capture css transformation', async ({ browser, server, headless, browserName, platform }, testInfo) => {
     it.fixme(!headless, 'Fails on headed');
     it.fixme(browserName === 'webkit' && platform === 'win32');
 
@@ -387,7 +387,7 @@ it.describe('screencast', () => {
     }
   });
 
-  it('should work for popups', async ({browser, server}, testInfo) => {
+  it('should work for popups', async ({ browser, server }, testInfo) => {
     const videosPath = testInfo.outputPath('');
     const size = { width: 450, height: 240 };
     const context = await browser.newContext({
@@ -417,7 +417,7 @@ it.describe('screencast', () => {
     expect(videoFiles.length).toBe(2);
   });
 
-  it('should scale frames down to the requested size ', async ({browser, server, headless}, testInfo) => {
+  it('should scale frames down to the requested size ', async ({ browser, server, headless }, testInfo) => {
     it.fixme(!headless, 'Fails on headed');
 
     const context = await browser.newContext({
@@ -426,7 +426,7 @@ it.describe('screencast', () => {
         // Set size to 1/2 of the viewport.
         size: { width: 320, height: 240 },
       },
-      viewport: {width: 640, height: 480},
+      viewport: { width: 640, height: 480 },
     });
     const page = await context.newPage();
 
@@ -448,25 +448,25 @@ it.describe('screencast', () => {
     expect(duration).toBeGreaterThan(0);
 
     {
-      const pixels = videoPlayer.seekLastFrame({x: 0, y: 0}).data;
+      const pixels = videoPlayer.seekLastFrame({ x: 0, y: 0 }).data;
       expectAll(pixels, almostRed);
     }
     {
-      const pixels = videoPlayer.seekLastFrame({x: 300, y: 0}).data;
+      const pixels = videoPlayer.seekLastFrame({ x: 300, y: 0 }).data;
       expectAll(pixels, almostGray);
     }
     {
-      const pixels = videoPlayer.seekLastFrame({x: 0, y: 200}).data;
+      const pixels = videoPlayer.seekLastFrame({ x: 0, y: 200 }).data;
       expectAll(pixels, almostGray);
     }
     {
-      const pixels = videoPlayer.seekLastFrame({x: 300, y: 200}).data;
+      const pixels = videoPlayer.seekLastFrame({ x: 300, y: 200 }).data;
       expectAll(pixels, almostRed);
     }
   });
 
-  it('should use viewport scaled down to fit into 800x800 as default size', async ({browser}, testInfo) => {
-    const size = {width: 1600, height: 1200};
+  it('should use viewport scaled down to fit into 800x800 as default size', async ({ browser }, testInfo) => {
+    const size = { width: 1600, height: 1200 };
     const context = await browser.newContext({
       recordVideo: {
         dir: testInfo.outputPath(''),
@@ -521,7 +521,7 @@ it.describe('screencast', () => {
     expect(videoPlayer.videoHeight).toBe(600);
   });
 
-  it('should capture static page in persistent context', async ({launchPersistent}, testInfo) => {
+  it('should capture static page in persistent context', async ({ launchPersistent }, testInfo) => {
     const size = { width: 320, height: 240 };
     const { context, page } = await launchPersistent({
       recordVideo: {
@@ -549,7 +549,7 @@ it.describe('screencast', () => {
     }
   });
 
-  it('should emulate an iphone', async ({contextFactory, playwright, contextOptions, browserName}, testInfo) => {
+  it('should emulate an iphone', async ({ contextFactory, playwright, contextOptions, browserName }, testInfo) => {
     it.skip(browserName === 'firefox', 'isMobile is not supported in Firefox');
 
     const device = playwright.devices['iPhone 6'];
@@ -571,7 +571,7 @@ it.describe('screencast', () => {
     expect(videoPlayer.videoHeight).toBe(666);
   });
 
-  it('should throw on browser close', async ({browserType, browserOptions, contextOptions}, testInfo) => {
+  it('should throw on browser close', async ({ browserType, browserOptions, contextOptions }, testInfo) => {
     const size = { width: 320, height: 240 };
     const browser = await browserType.launch(browserOptions);
     const context = await browser.newContext({
@@ -592,7 +592,7 @@ it.describe('screencast', () => {
     expect(saveResult.message).toContain('browser has been closed');
   });
 
-  it('should throw if browser dies', async ({browserType, browserOptions, contextOptions}, testInfo) => {
+  it('should throw if browser dies', async ({ browserType, browserOptions, contextOptions }, testInfo) => {
     const size = { width: 320, height: 240 };
     const browser = await browserType.launch(browserOptions);
 
@@ -614,7 +614,7 @@ it.describe('screencast', () => {
     expect(saveResult.message).toContain('rowser has been closed');
   });
 
-  it('should wait for video to finish if page was closed', async ({browserType, browserOptions, contextOptions}, testInfo) => {
+  it('should wait for video to finish if page was closed', async ({ browserType, browserOptions, contextOptions }, testInfo) => {
     const size = { width: 320, height: 240 };
     const browser = await browserType.launch(browserOptions);
 
@@ -641,7 +641,7 @@ it.describe('screencast', () => {
     expect(videoPlayer.videoHeight).toBe(240);
   });
 
-  it('should not create video for internal pages', async ({browser, browserName, contextOptions, server}, testInfo) => {
+  it('should not create video for internal pages', async ({ browser, browserName, contextOptions, server }, testInfo) => {
     it.fixme(true, 'https://github.com/microsoft/playwright/issues/6743');
     server.setRoute('/empty.html', (req, res) => {
       res.setHeader('Set-Cookie', 'name=value');

--- a/tests/web-socket.spec.ts
+++ b/tests/web-socket.spec.ts
@@ -136,7 +136,7 @@ it('should emit binary frame events', async ({ page, server }) => {
     expect(sent[1][i]).toBe(i);
 });
 
-it('should emit error', async ({page, server, browserName}) => {
+it('should emit error', async ({ page, server, browserName }) => {
   let callback;
   const result = new Promise(f => callback = f);
   page.on('websocket', ws => ws.on('socketerror', callback));
@@ -150,7 +150,7 @@ it('should emit error', async ({page, server, browserName}) => {
     expect(message).toContain(': 400');
 });
 
-it('should not have stray error events', async ({page, server}) => {
+it('should not have stray error events', async ({ page, server }) => {
   server.sendOnWebSocketConnection('incoming');
   let error;
   page.on('websocket', ws => ws.on('socketerror', e => error = e));
@@ -167,7 +167,7 @@ it('should not have stray error events', async ({page, server}) => {
   expect(error).toBeFalsy();
 });
 
-it('should reject waitForEvent on socket close', async ({page, server}) => {
+it('should reject waitForEvent on socket close', async ({ page, server }) => {
   server.sendOnWebSocketConnection('incoming');
   const [ws] = await Promise.all([
     page.waitForEvent('websocket').then(async ws => {
@@ -183,7 +183,7 @@ it('should reject waitForEvent on socket close', async ({page, server}) => {
   expect((await error).message).toContain('Socket closed');
 });
 
-it('should reject waitForEvent on page close', async ({page, server}) => {
+it('should reject waitForEvent on page close', async ({ page, server }) => {
   server.sendOnWebSocketConnection('incoming');
   const [ws] = await Promise.all([
     page.waitForEvent('websocket').then(async ws => {
@@ -199,7 +199,7 @@ it('should reject waitForEvent on page close', async ({page, server}) => {
   expect((await error).message).toContain('Page closed');
 });
 
-it('should turn off when offline', async ({page}) => {
+it('should turn off when offline', async ({ page }) => {
   it.fixme();
 
   const webSocketServer = new WebSocketServer();


### PR DESCRIPTION
Visual Studio Code does automatically do this when formatting code. In our source-code we have a big mixture between with spaces, without spaces, or sometimes even a mix out of both. When people format it with VSC this leads to fix then other's source-code pieces and so a weird diff gets created.