### PR TITLE
browser(webkit): disable COOP support

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1549
-Changed: max@schmitt.mx Thu 23 Sep 2021 21:05:36 CEST
+1550
+Changed: yurys@chromium.org Mon 27 Sep 2021 04:11:39 PM PDT

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -2081,9 +2081,18 @@ index 25afb2508e8cd45df55044d61e62a84a16336bea..c2ed115fa695ba072f9913bfc11ca956
    type: bool
    humanReadableName: "Private Click Measurement"
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index febcd6ef091269394803f9736bb564933a85580a..2a11ce3e5e00d9174931e7f793a85076e49117bc 100644
+index febcd6ef091269394803f9736bb564933a85580a..c01621d37add6e06204b57f37c41936105078a76 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+@@ -365,7 +365,7 @@ CrossOriginOpenerPolicyEnabled:
+     WebKitLegacy:
+       default: false
+     WebKit:
+-      default: true
++      default: false
+     WebCore:
+       default: false
+ 
 @@ -731,9 +731,9 @@ MaskWebGLStringsEnabled:
      WebKitLegacy:
        default: true


### PR DESCRIPTION
This reverts a part of https://github.com/WebKit/WebKit/commit/c43c58d83c79da9d08d5bffa2085df7f81736bff which recently enabled experimental support of Cross-Origin-Opener-Policy header by default. There are some open questions about the implementation which may significantly affect the way it is working. This is an alternative to landing https://github.com/microsoft/playwright/pull/9120 at this point as the latter looks quite brittle.

 #9065