### PR TITLE
feat(fetch): send Playwright as default user-agent for global fetch

### DIFF
--- a/src/server/fetch.ts
+++ b/src/server/fetch.ts
@@ -23,7 +23,7 @@ import zlib from 'zlib';
 import { HTTPCredentials } from '../../types/types';
 import { NameValue, NewRequestOptions } from '../common/types';
 import { TimeoutSettings } from '../utils/timeoutSettings';
-import { createGuid, isFilePayload, monotonicTime } from '../utils/utils';
+import { createGuid, getPlaywrightVersion, isFilePayload, monotonicTime } from '../utils/utils';
 import { BrowserContext } from './browserContext';
 import { MultipartFormData } from './formData';
 import { SdkObject } from './instrumentation';
@@ -352,7 +352,7 @@ export class GlobalFetchRequest extends FetchRequest {
     }
     this._options = {
       baseURL: options.baseURL,
-      userAgent: options.userAgent || 'Playwright',
+      userAgent: options.userAgent || `Playwright/${getPlaywrightVersion()}`,
       extraHTTPHeaders: options.extraHTTPHeaders,
       ignoreHTTPSErrors: !!options.ignoreHTTPSErrors,
       httpCredentials: options.httpCredentials,

--- a/src/server/fetch.ts
+++ b/src/server/fetch.ts
@@ -352,7 +352,7 @@ export class GlobalFetchRequest extends FetchRequest {
     }
     this._options = {
       baseURL: options.baseURL,
-      userAgent: options.userAgent || '',
+      userAgent: options.userAgent || 'Playwright',
       extraHTTPHeaders: options.extraHTTPHeaders,
       ignoreHTTPSErrors: !!options.ignoreHTTPSErrors,
       httpCredentials: options.httpCredentials,

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import http from 'http';
+import { getPlaywrightVersion } from '../lib/utils/utils';
 import { expect, playwrightTest as it } from './config/browserTest';
 
 it.skip(({ mode }) => mode !== 'default');
@@ -149,5 +150,5 @@ it('should set playwright as user-agent', async ({ playwright, server }) => {
     server.waitForRequest('/empty.html'),
     request.get(server.EMPTY_PAGE)
   ]);
-  expect(serverRequest.headers['user-agent']).toBe('Playwright');
+  expect(serverRequest.headers['user-agent']).toBe('Playwright/' + getPlaywrightVersion());
 });

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -143,3 +143,11 @@ it('should resolve url relative to gobal baseURL option', async ({ playwright, s
   expect(response.url()).toBe(server.EMPTY_PAGE);
 });
 
+it('should set playwright as user-agent', async ({ playwright, server }) => {
+  const request = await playwright._newRequest();
+  const [serverRequest] = await Promise.all([
+    server.waitForRequest('/empty.html'),
+    request.get(server.EMPTY_PAGE)
+  ]);
+  expect(serverRequest.headers['user-agent']).toBe('Playwright');
+});


### PR DESCRIPTION
By default use 'Playwright' as user-agent in global fetch instead of empty string. I didn't make it `Playwright/1.16.0-next (x64/linux/5.11.0-34-generic)` which is what we use in our browserType.connect as there were no requests for that and we don't necessarily want to expose that much data.

#5999 