### PR TITLE
docs: projects simplify & crosslink

### DIFF
--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -364,7 +364,7 @@ test('test', async ({ page }) => {
 
 ## Projects
 
-Playwright Test supports running multiple test projects at the same time. This is useful for running the same tests in multiple configurations. For example, consider running tests against multiple versions of some REST backend.
+Playwright Test supports running multiple test projects at the same time. This is useful for running the same tests in multiple configurations. For example, consider running tests against multiple versions of some REST backend, or against different [emulated devices](./test-configuration.md#emulation).
 
 To make use of this feature, we will declare an "option fixture" for the backend version, and use it in the tests.
 

--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -170,22 +170,13 @@ const { devices } = require('@playwright/test');
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
   projects: [
-    // "Pixel 4" tests use Chromium browser.
     {
       name: 'Pixel 4',
-      use: {
-        browserName: 'chromium',
-        ...devices['Pixel 4'],
-      },
+      use: devices['Pixel 4'],
     },
-
-    // "iPhone 11" tests use WebKit browser.
     {
       name: 'iPhone 11',
-      use: {
-        browserName: 'webkit',
-        ...devices['iPhone 11'],
-      },
+      use: devices['iPhone 11'],
     },
   ],
 };
@@ -199,29 +190,20 @@ import { PlaywrightTestConfig, devices } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   projects: [
-    // "Pixel 4" tests use Chromium browser.
     {
       name: 'Pixel 4',
-      use: {
-        browserName: 'chromium',
-        ...devices['Pixel 4'],
-      },
+      use: devices['Pixel 4'],
     },
-
-    // "iPhone 11" tests use WebKit browser.
     {
       name: 'iPhone 11',
-      use: {
-        browserName: 'webkit',
-        ...devices['iPhone 11'],
-      },
+      use: devices['iPhone 11'],
     },
   ],
 };
 export default config;
 ```
 
-You can specify options separately instead of using predefined devices. There are also more options such as locale, geolocation, and timezone which can be configured.
+You can specify options separately instead of using [predefined devices](https://github.com/microsoft/playwright/blob/master/src/server/deviceDescriptorsSource.json). There are also more options such as locale, geolocation, and timezone which can be configured.
 
 - `colorScheme` - Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`.
 - `deviceScaleFactor` - Specify device scale factor (can be thought of as dpr). Defaults to `1`.


### PR DESCRIPTION
1. Remove extraneous bits from example code: This could mislead users into thinking they need to specify `browserName` when using `projects` for device emulation. If we want to demonstrate how to override some details, maybe we can find a more realistic example?
2. Link from [./test-advanced/#projects](https://playwright.dev/docs/test-advanced/#projects) to [./test-configuration/#emulation](https://playwright.dev/docs/test-configuration/#emulation).