### PR TITLE
fix(test runner): do not write missing snapshot until the last retry

### DIFF
--- a/src/test/matchers/toMatchSnapshot.ts
+++ b/src/test/matchers/toMatchSnapshot.ts
@@ -46,7 +46,7 @@ export function toMatchSnapshot(this: ReturnType<Expect['getState']>, received: 
       options.name,
       testInfo.snapshotPath,
       testInfo.outputPath,
-      testInfo.config.updateSnapshots,
+      testInfo.retry < testInfo.project.retries ? 'none' : testInfo.config.updateSnapshots,
       withNegateComparison,
       options
   );


### PR DESCRIPTION
This prevents future retries from passing because of the actual snapshot being written.

In theory, we can avoid running the retry since it should fail anyway. However, this brings problems: for example running a test in `describe.serial` mode has some global side effects and so it should not be skipped. Since running a test without a snapshot is rare, it should be fine to retry it.

Fixes #9219.