### PR TITLE
fix(webkit): deduce response mime type from content-type

### DIFF
--- a/src/server/webkit/wkInterceptableRequest.ts
+++ b/src/server/webkit/wkInterceptableRequest.ts
@@ -130,7 +130,7 @@ export class WKRouteImpl implements network.RouteDelegate {
     // In certain cases, protocol will return error if the request was already canceled
     // or the page was closed. We should tolerate these errors.
     let mimeType = response.isBase64 ? 'application/octet-stream' : 'text/plain';
-    const headers = headersArrayToObject(response.headers, false /* lowerCase */);
+    const headers = headersArrayToObject(response.headers, true /* lowerCase */);
     const contentType = headers['content-type'];
     if (contentType)
       mimeType = contentType.split(';')[0].trim();

--- a/tests/page/page-request-fulfill.spec.ts
+++ b/tests/page/page-request-fulfill.spec.ts
@@ -225,7 +225,7 @@ it('should fulfill with fetch result and overrides', async ({ page, server, isEl
       response,
       status: 201,
       headers: {
-        ...response.headers(),
+        'Content-Type': 'application/json', // Case matters for the tested behavior
         'foo': 'bar'
       }
     });


### PR DESCRIPTION
This fixes following test failure:

```
1) [webkit] › page/page-request-fulfill.spec.ts:220:1 › should fulfill with fetch result and overrides 

    page.goto: Frame load interrupted
    =========================== logs ===========================
    navigating to "http://localhost:8915/empty.html", waiting until "load"
    ============================================================

      230 |     });
      231 |   });
    > 232 |   const response = await page.goto(server.EMPTY_PAGE);
          |                               ^
      233 |   expect(response.status()).toBe(201);
      234 |   expect((await response.allHeaders()).foo).toEqual('bar');
      235 |   expect(await response.json()).toEqual({ 'foo': 'bar' });

        at /home/runner/work/playwright/playwright/tests/page/page-request-fulfill.spec.ts:232:31
        at WorkerRunner._runTestWithBeforeHooks (/home/runner/work/playwright/playwright/lib/test/workerRunner.js:466:7)
    <inner error>
    Error: Frame load interrupted
    =========================== logs ===========================
    navigating to "http://localhost:8915/empty.html", waiting until "load"
    ============================================================
        at FrameManager.frameAbortedNavigation (/home/runner/work/playwright/playwright/lib/server/frames.js:249:14)
        at FrameManager.requestFailed (/home/runner/work/playwright/playwright/lib/server/frames.js:317:12)
        at WKPage._onLoadingFailed (/home/runner/work/playwright/playwright/lib/server/webkit/wkPage.js:1290:30)
        at WKSession.<anonymous> (/home/runner/work/playwright/playwright/lib/server/webkit/wkPage.js:472:2646)
        at WKSession.emit (events.js:314:20)
        at /home/runner/work/playwright/playwright/lib/server/webkit/wkConnection.js:204:41
        at runMicrotasks (<anonymous>)
        at runNextTicks (internal/process/task_queues.js:62:5)
        at processImmediate (internal/timers.js:434:9)
```