### PR TITLE
docs: fix wrongly annotated JS only paragraph

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -339,7 +339,7 @@ Developers can opt-in in this mode via exporting `PLAYWRIGHT_BROWSERS_PATH=$HOME
 :::
 
 ### Managing browser binaries
-* lang: js
+* langs: js
 
 You can opt into the hermetic install and place binaries in the local folder:
 


### PR DESCRIPTION
currently broken: https://playwright.dev/docs/browsers/#managing-browser-binaries-1

and the paragraph gets shown also on other languages.