### PR TITLE
fix(fetch): do not allow to call get/post with request

### DIFF
--- a/docs/src/api/class-fetchrequest.md
+++ b/docs/src/api/class-fetchrequest.md
@@ -64,7 +64,7 @@ Sends HTTP(S) GET request and returns its response. The method will populate fet
 context cookies from the response. The method will automatically follow redirects.
 
 ### param: FetchRequest.get.url
-- `urlOrRequest` <[string]>
+- `url` <[string]>
 
 Target URL.
 
@@ -98,7 +98,7 @@ Sends HTTP(S) fetch and returns its response. The method will populate fetch coo
 context cookies from the response. The method will automatically follow redirects.
 
 ### param: FetchRequest.post.url
-- `urlOrRequest` <[string]>
+- `url` <[string]>
 
 Target URL.
 

--- a/docs/src/api/class-fetchrequest.md
+++ b/docs/src/api/class-fetchrequest.md
@@ -63,10 +63,10 @@ for all status codes.
 Sends HTTP(S) GET request and returns its response. The method will populate fetch cookies from the context and update
 context cookies from the response. The method will automatically follow redirects.
 
-### param: FetchRequest.get.urlOrRequest
-- `urlOrRequest` <[string]|[Request]>
+### param: FetchRequest.get.url
+- `urlOrRequest` <[string]>
 
-Target URL or Request to get all fetch parameters from.
+Target URL.
 
 ### option: FetchRequest.get.params
 - `params` <[Object]<[string], [string]>>
@@ -97,10 +97,10 @@ for all status codes.
 Sends HTTP(S) fetch and returns its response. The method will populate fetch cookies from the context and update
 context cookies from the response. The method will automatically follow redirects.
 
-### param: FetchRequest.post.urlOrRequest
-- `urlOrRequest` <[string]|[Request]>
+### param: FetchRequest.post.url
+- `urlOrRequest` <[string]>
 
-Target URL or Request to get all fetch parameters from.
+Target URL.
 
 ### option: FetchRequest.post.params
 - `params` <[Object]<[string], [string]>>

--- a/src/client/fetch.ts
+++ b/src/client/fetch.ts
@@ -56,7 +56,7 @@ export class FetchRequest extends ChannelOwner<channels.FetchRequestChannel, cha
   }
 
   async get(
-    urlOrRequest: string | api.Request,
+    url: string,
     options?: {
       params?: { [key: string]: string; };
       headers?: { [key: string]: string; };
@@ -64,14 +64,14 @@ export class FetchRequest extends ChannelOwner<channels.FetchRequestChannel, cha
       failOnStatusCode?: boolean;
       ignoreHTTPSErrors?: boolean,
     }): Promise<FetchResponse> {
-    return this.fetch(urlOrRequest, {
+    return this.fetch(url, {
       ...options,
       method: 'GET',
     });
   }
 
-  async post(urlOrRequest: string | api.Request, options?: Omit<FetchOptions, 'method'>): Promise<FetchResponse> {
-    return this.fetch(urlOrRequest, {
+  async post(url: string, options?: Omit<FetchOptions, 'method'>): Promise<FetchResponse> {
+    return this.fetch(url, {
       ...options,
       method: 'POST',
     });

--- a/tests/browsercontext-fetch.spec.ts
+++ b/tests/browsercontext-fetch.spec.ts
@@ -710,7 +710,8 @@ it('should override request parameters', async function({ context, page, server 
   ]);
   const [req] = await Promise.all([
     server.waitForRequest('/empty.html'),
-    context.request.post(pageReq, {
+    context.request.fetch(pageReq, {
+      method: 'POST',
       headers: {
         'foo': 'bar'
       },

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -601,7 +601,7 @@ it('should be able to download a inline PDF file', async ({ browser, server, ass
   const page = await browser.newPage({ acceptDownloads: true });
   await page.goto(server.EMPTY_PAGE);
   await page.route('**/empty.pdf', async route => {
-    const response = await page.context().request.get(route.request());
+    const response = await page.context().request.fetch(route.request());
     await route.fulfill({
       response,
       headers: {

--- a/tests/page/page-request-fulfill.spec.ts
+++ b/tests/page/page-request-fulfill.spec.ts
@@ -239,7 +239,7 @@ it('should fulfill with fetch result and overrides', async ({ page, server, isEl
 it('should fetch original request and fulfill', async ({ page, server, isElectron }) => {
   it.fixme(isElectron, 'error: Browser context management is not supported.');
   await page.route('**/*', async route => {
-    const response = await page.request.get(route.request());
+    const response = await page.request.fetch(route.request());
     route.fulfill({
       response,
     });

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -12665,9 +12665,9 @@ export interface FetchRequest {
   /**
    * All responses received through
    * [fetchRequest.fetch(urlOrRequest[, options])](https://playwright.dev/docs/api/class-fetchrequest#fetch-request-fetch),
-   * [fetchRequest.get(urlOrRequest[, options])](https://playwright.dev/docs/api/class-fetchrequest#fetch-request-get),
-   * [fetchRequest.post(urlOrRequest[, options])](https://playwright.dev/docs/api/class-fetchrequest#fetch-request-post) and
-   * other methods are stored in the memory, so that you can later call
+   * [fetchRequest.get(url[, options])](https://playwright.dev/docs/api/class-fetchrequest#fetch-request-get),
+   * [fetchRequest.post(url[, options])](https://playwright.dev/docs/api/class-fetchrequest#fetch-request-post) and other
+   * methods are stored in the memory, so that you can later call
    * [fetchResponse.body()](https://playwright.dev/docs/api/class-fetchresponse#fetch-response-body). This method discards
    * all stored responses, and makes
    * [fetchResponse.body()](https://playwright.dev/docs/api/class-fetchresponse#fetch-response-body) throw "Response
@@ -12753,10 +12753,10 @@ export interface FetchRequest {
   /**
    * Sends HTTP(S) GET request and returns its response. The method will populate fetch cookies from the context and update
    * context cookies from the response. The method will automatically follow redirects.
-   * @param urlOrRequest Target URL.
+   * @param url Target URL.
    * @param options
    */
-  get(urlOrRequest: string, options?: {
+  get(url: string, options?: {
     /**
      * Whether to throw on response codes other than 2xx and 3xx. By default response object is returned for all status codes.
      */
@@ -12786,10 +12786,10 @@ export interface FetchRequest {
   /**
    * Sends HTTP(S) fetch and returns its response. The method will populate fetch cookies from the context and update context
    * cookies from the response. The method will automatically follow redirects.
-   * @param urlOrRequest Target URL.
+   * @param url Target URL.
    * @param options
    */
-  post(urlOrRequest: string, options?: {
+  post(url: string, options?: {
     /**
      * Allows to set post data of the request. If the data parameter is an object, it will be serialized to json string and
      * `content-type` header will be set to `application/json` if not explicitly set. Otherwise the `content-type` header will
@@ -13387,9 +13387,8 @@ export const firefox: BrowserType;
  */
 export const newRequest: (options?: {
   /**
-   * When using
-   * [fetchRequest.get(urlOrRequest[, options])](https://playwright.dev/docs/api/class-fetchrequest#fetch-request-get),
-   * [fetchRequest.post(urlOrRequest[, options])](https://playwright.dev/docs/api/class-fetchrequest#fetch-request-post),
+   * When using [fetchRequest.get(url[, options])](https://playwright.dev/docs/api/class-fetchrequest#fetch-request-get),
+   * [fetchRequest.post(url[, options])](https://playwright.dev/docs/api/class-fetchrequest#fetch-request-post),
    * [fetchRequest.fetch(urlOrRequest[, options])](https://playwright.dev/docs/api/class-fetchrequest#fetch-request-fetch) it
    * takes the base URL in consideration by using the [`URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)
    * constructor for building the corresponding URL. Examples:

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -12753,10 +12753,10 @@ export interface FetchRequest {
   /**
    * Sends HTTP(S) GET request and returns its response. The method will populate fetch cookies from the context and update
    * context cookies from the response. The method will automatically follow redirects.
-   * @param urlOrRequest Target URL or Request to get all fetch parameters from.
+   * @param urlOrRequest Target URL.
    * @param options
    */
-  get(urlOrRequest: string|Request, options?: {
+  get(urlOrRequest: string, options?: {
     /**
      * Whether to throw on response codes other than 2xx and 3xx. By default response object is returned for all status codes.
      */
@@ -12786,10 +12786,10 @@ export interface FetchRequest {
   /**
    * Sends HTTP(S) fetch and returns its response. The method will populate fetch cookies from the context and update context
    * cookies from the response. The method will automatically follow redirects.
-   * @param urlOrRequest Target URL or Request to get all fetch parameters from.
+   * @param urlOrRequest Target URL.
    * @param options
    */
-  post(urlOrRequest: string|Request, options?: {
+  post(urlOrRequest: string, options?: {
     /**
      * Allows to set post data of the request. If the data parameter is an object, it will be serialized to json string and
      * `content-type` header will be set to `application/json` if not explicitly set. Otherwise the `content-type` header will


### PR DESCRIPTION
Otherwise the client may pass `post` request into `get` which will cause an error because get request can't have body.

#5999 