### PR TITLE
test: responseBodySize incorrect for 404 with content

### DIFF
--- a/tests/page/page-network-sizes.spec.ts
+++ b/tests/page/page-network-sizes.spec.ts
@@ -167,3 +167,31 @@ for (const statusCode of [200, 401, 404, 500]) {
     expect(sizes.responseBodySize).toBe(3);
   });
 }
+
+it('should have correct responseBodySize for 404 with content', async ({ page, server, browserName }) => {
+  it.fail(browserName === 'chromium');
+
+  server.setRoute('/broken-image.png', (req, resp) => {
+    resp.writeHead(404);
+    resp.end(`<p>this should have a non-negative size</p>`);
+  });
+  server.setRoute('/page-with-404-image.html', (req, resp) => {
+    resp.end(`
+    <!DOCTYPE html>
+    <html>
+      <head><title>Page with Broken Image</title></head>
+      <body>
+        <img src="/broken-image.png" />
+      </body>
+    </html>
+    `);
+  });
+
+  const [req] = await Promise.all([
+    page.waitForRequest(/broken-image\.png$/),
+    page.goto(server.PREFIX + '/page-with-404-image.html'),
+  ]);
+
+  const { responseBodySize } = await req.sizes();
+  expect(responseBodySize).toBeGreaterThanOrEqual(0);
+});


### PR DESCRIPTION
This test shows a chrome-only bug where the ResponseSize is negative if
a 404 contains content.

The size is also incorrect in the HAR.

NB: If you remove the following line, the test will pass in all
browsers, so the content is important:

```
    resp.end(`<p>this should have a non-negative size</p>`);
```