### PR TITLE
test: request.sizes() sometimes hangs in CR

### DIFF
--- a/tests/page/page-network-sizes.spec.ts
+++ b/tests/page/page-network-sizes.spec.ts
@@ -195,3 +195,29 @@ it('should have correct responseBodySize for 404 with content', async ({ page, s
   const { responseBodySize } = await req.sizes();
   expect(responseBodySize).toBeGreaterThanOrEqual(0);
 });
+
+
+it('should return sizes without hanging', async ({ page, server, browserName }) => {
+  it.fixme(browserName === 'chromium');
+
+  server.setRoute('/has-abandoned-fetch', (req, resp) => {
+    resp.end(`
+    <!DOCTYPE html>
+    <html>
+      <head><title>t</title></head>
+      <body>
+        <script>
+          fetch("./404");
+        </script>
+      </body>
+    </html>
+    `);
+  });
+
+  const [req] = await Promise.all([
+    page.waitForRequest(/404$/),
+    page.goto(server.PREFIX + '/has-abandoned-fetch')
+  ]);
+
+  await req.sizes();
+});


### PR DESCRIPTION
We've started using the new `request.sizes()` API but noticed it hangs
sometimes (including on some third-party request code that cannot be
changed to "behave").

This likley relates to #6666