### PR TITLE
chore(test-runner): make outputDir based on cwd instead of testDir

### DIFF
--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -104,7 +104,7 @@ export class Loader {
     this._fullConfig.webServer = takeFirst(this._configOverrides.webServer, this._config.webServer, baseFullConfig.webServer);
 
     for (const project of projects)
-      this._addProject(project, this._fullConfig.rootDir);
+      this._addProject(project, this._fullConfig.rootDir, rootDir);
     this._fullConfig.projects = this._projects.map(p => p.config);
   }
 
@@ -162,13 +162,13 @@ export class Loader {
     };
   }
 
-  private _addProject(projectConfig: Project, rootDir: string) {
+  private _addProject(projectConfig: Project, rootDir: string, configDir: string) {
     let testDir = takeFirst(projectConfig.testDir, rootDir);
     if (!path.isAbsolute(testDir))
-      testDir = path.resolve(rootDir, testDir);
+      testDir = path.resolve(configDir, testDir);
     let outputDir = takeFirst(this._configOverrides.outputDir, projectConfig.outputDir, this._config.outputDir, path.resolve(process.cwd(), 'test-results'));
     if (!path.isAbsolute(outputDir))
-      outputDir = path.resolve(process.cwd(), outputDir);
+      outputDir = path.resolve(configDir, outputDir);
     const fullProject: FullProject = {
       define: takeFirst(this._configOverrides.define, projectConfig.define, this._config.define, []),
       expect: takeFirst(this._configOverrides.expect, projectConfig.expect, this._config.expect, undefined),

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -168,7 +168,7 @@ export class Loader {
       testDir = path.resolve(rootDir, testDir);
     let outputDir = takeFirst(this._configOverrides.outputDir, projectConfig.outputDir, this._config.outputDir, path.resolve(process.cwd(), 'test-results'));
     if (!path.isAbsolute(outputDir))
-      outputDir = path.resolve(rootDir, outputDir);
+      outputDir = path.resolve(process.cwd(), outputDir);
     const fullProject: FullProject = {
       define: takeFirst(this._configOverrides.define, projectConfig.define, this._config.define, []),
       expect: takeFirst(this._configOverrides.expect, projectConfig.expect, this._config.expect, undefined),

--- a/tests/playwright-test/test-output-dir.spec.ts
+++ b/tests/playwright-test/test-output-dir.spec.ts
@@ -396,7 +396,6 @@ test('should accept a relative path for outputDir', async ({ runInlineTest }, te
 });
 
 test('should have output dir based on rootDir (cwd)', async ({ runInlineTest }, testInfo) => {
-  test.fixme(true, 'https://github.com/microsoft/playwright/issues/9380');
   const result = await runInlineTest({
     'playwright.config.js': `
       const path = require('path');


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/9380