### PR TITLE
test(downloads): enable test for downloads in a persistent context

### DIFF
--- a/tests/defaultbrowsercontext-1.spec.ts
+++ b/tests/defaultbrowsercontext-1.spec.ts
@@ -172,8 +172,6 @@ it('should support offline option', async ({ server, launchPersistent }) => {
 });
 
 it('should support acceptDownloads option', async ({ server, launchPersistent }) => {
-  it.skip(true, 'Unskip once we support downloads in persistent context.');
-
   const { page } = await launchPersistent({ acceptDownloads: true });
   server.setRoute('/download', (req, res) => {
     res.setHeader('Content-Type', 'application/octet-stream');


### PR DESCRIPTION
I am not sure why this test was disabled. Looks related to #9364, but the test passed for me on Linux and Mac. Let's see what the bots say.