### PR TITLE
docs: update showcase.md (add lariat library)

### DIFF
--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -31,8 +31,8 @@ title: "Community Showcase"
 * [CodeceptJS](https://github.com/Codeception/CodeceptJS): Write scenario-driven Playwright tests with synchronous code
 * [dom-to-playwright](https://github.com/Xiphe/dom-to-playwright) to copy a JSDOM snapshot into a Playwright page.
 * [expected-condition-playwright](https://github.com/elaichenkov/expected-condition-playwright): Supplies a set of common expected conditions that can wait for certain states and conditions
-* [expect-playwright](https://github.com/playwright-community/expect-playwright): Matcher functions to simplify expect statements for the usage with the Playwright test runner or Jest Playwright.
 * [Headless Testing](https://headlesstesting.com/support/start/playwright.html): Run Playwright tests on browsers in the cloud
+* [Lariat](https://github.com/Widen/lariat): Simplify page object construction for your Playwright tests
 * [Lumberjack](https://github.com/JakePartusch/lumberjack): Automated accessibility scanner to run checks on your entire website
 * [mockiavelli](https://github.com/HLTech/mockiavelli) Request mocking library for Playwright to test SPA in isolation from backend APIs.
 * [Moon](https://github.com/aerokube/moon): Run Playwright tests in parallel in Kubernetes cluster (free up to 4 parallel sessions)
@@ -48,7 +48,6 @@ title: "Community Showcase"
 
 ## Frameworks
 
-* [jest-playwright](https://github.com/mmarkelov/jest-playwright): Jest preset to run Playwright tests with Jest
 * [query-selector-shadow-dom](https://github.com/Georgegriff/query-selector-shadow-dom): Custom selector engine to pierce shadow DOM roots
 * [playwright-fluent](https://github.com/hdorgeval/playwright-fluent): Fluent API around Playwright
 * [robotframework-browser](https://robotframework-browser.org/) Robotframework library that uses Playwright to achieve good development ergonomics.

--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -48,6 +48,7 @@ title: "Community Showcase"
 
 ## Frameworks
 
+* [karma-playwright-launcher](https://github.com/Onslip/karma-playwright-launcher): Playwright powered browser support for Karma
 * [query-selector-shadow-dom](https://github.com/Georgegriff/query-selector-shadow-dom): Custom selector engine to pierce shadow DOM roots
 * [playwright-fluent](https://github.com/hdorgeval/playwright-fluent): Fluent API around Playwright
 * [robotframework-browser](https://robotframework-browser.org/) Robotframework library that uses Playwright to achieve good development ergonomics.


### PR DESCRIPTION
Two main changes here:

1. Removes expect-playwright and jest-playwright from the list.  These projects both officially recommend using the built-in Playwright test runner so it probably doesn't make sense to keep them in the showcase.
1. Adds Lariat to the list.  Lariat is a library I've developed at my company to simplify page object construction with support for nesting, nth based matching, portals, and more.

Also fixes #8337