### PR TITLE
docs: reference only focal base image in docs

### DIFF
--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -21,14 +21,14 @@ docker pull mcr.microsoft.com/playwright:focal
 docker pull mcr.microsoft.com/playwright/java:focal
 ```
 
-or pinned to a specific Playwright version (recommended). Replace 1.10.0 with your Playwright version:
+or pinned to a specific Playwright version (recommended). Replace 1.15.0 with your Playwright version:
 
 ```bash js python csharp
-docker pull mcr.microsoft.com/playwright:v1.10.0-focal
+docker pull mcr.microsoft.com/playwright:v1.15.0-focal
 ```
 
 ```bash java
-docker pull mcr.microsoft.com/playwright/java:v1.10.0-focal
+docker pull mcr.microsoft.com/playwright/java:v1.15.0-focal
 ```
 
 ### Run the image
@@ -92,15 +92,12 @@ See our [Continuous Integration guides](./ci.md) for sample configs.
 See [all available image tags].
 
 Docker images are published automatically by GitHub Actions. We currently publish images with the
-following tags (`v1.10.0` in this case is an example:):
-- `:next` - tip-of-tree image version based on Ubuntu 20.04 LTS.
-- `:next-focal` - tip-of-tree image version based on Ubuntu 20.04 LTS.
-- `:next-bionic` - tip-of-tree image version based on Ubuntu 18.04 LTS.
-- `:bionic` - last Playwright release docker image based on Ubuntu 18.04 LTS.
+following tags (`v1.15.0` in this case is an example:):
+- `:next` - tip-of-tree image version based on Ubuntu 20.04 LTS (Focal Fossa).
+- `:next-focal` - tip-of-tree image version based on Ubuntu 20.04 LTS (Focal Fossa).
 - `:focal` - last Playwright release docker image based on Ubuntu 20.04 LTS (Focal Fossa).
-- `:v1.10.0` - Playwright v1.10.0 release docker image based on Ubuntu 20.04 LTS (Focal Fossa).
-- `:v1.10.0-focal` - Playwright v1.10.0 release docker image based on Ubuntu 20.04 LTS (Focal Fossa).
-- `:v1.10.0-bionic` - Playwright v1.10.0 release docker image based on Ubuntu 18.04 LTS (Bionic Beaver).
+- `:v1.15.0` - Playwright v1.15.0 release docker image based on Ubuntu 20.04 LTS (Focal Fossa).
+- `:v1.15.0-focal` - Playwright v1.15.0 release docker image based on Ubuntu 20.04 LTS (Focal Fossa).
 - `:sha-XXXXXXX` - docker image for every commit that changed
   docker files or browsers, marked with a [short sha](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#Short-SHA-1) (first 7 digits of the SHA commit).
 
@@ -110,7 +107,7 @@ Status of push to MCR can be [verified here](https://mcrflow-status-ui.azurewebs
 
 We currently publish images based on the following [Ubuntu](https://hub.docker.com/_/ubuntu) versions:
 - **Ubuntu 20.04 LTS** (Focal Fossa), image tags include `focal`
-- **Ubuntu 18.04 LTS** (Bionic Beaver), image tags include `bionic`
+- **Ubuntu 18.04 LTS** (Bionic Beaver), image tags include `bionic` (not published for Java)
 
 #### Alpine
 


### PR DESCRIPTION
Bionic image is not published for playwright java and previous wording was misleading (see the bug).

Fixes https://github.com/microsoft/playwright-java/issues/641