### PR TITLE
docs: minor change for readability

### DIFF
--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -3,7 +3,7 @@ id: intro
 title: "Getting started"
 ---
 
-Playwright can either be used as a part of the Playwright Test (this guide), or as a [Playwright Library](./library.md).
+Playwright can either be used as a part of the Playwright Test test runner (this guide), or as a [Playwright Library](./library.md).
 
 Playwright Test was created specifically to accommodate the needs of the end-to-end testing. It does everything you would expect from the regular test runner, and more. Playwright test allows to:
 


### PR DESCRIPTION
Alternate fix is to remove the word "the" from:
>the Playwright Test (this guide)

We could also do one of the following (to make it clear how to parse this line):

the _Playwright Test_ test runner (this guide)

the **Playwright Test** test runner (this guide)

the "Playwright Test" test runner (this guide)

the 'Playwright Test' test runner (this guide)

... But I don't think that's necessary, I think the capitalization will do the trick -- along with continuing to read and seeing how the phrase "Playwright Test" is being used.