### PR TITLE
devops: start using Xcode 13 to compile Firefox

### DIFF
--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -26,9 +26,9 @@ rm -rf .mozconfig
 
 if [[ "$(uname)" == "Darwin" ]]; then
   CURRENT_HOST_OS_VERSION=$(getMacVersion)
-  # As of Oct 2021, building Firefox requires XCode 12.2
+  # As of Oct 2021, building Firefox requires XCode 13
   if [[ "${CURRENT_HOST_OS_VERSION}" == "11."* ]]; then
-    selectXcodeVersionOrDie "12.2"
+    selectXcodeVersionOrDie "13"
   else
     echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"
     exit 1

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -26,9 +26,9 @@ rm -rf .mozconfig
 
 if [[ "$(uname)" == "Darwin" ]]; then
   CURRENT_HOST_OS_VERSION=$(getMacVersion)
-  # As of Oct 2021, building Firefox requires XCode 12.2
+  # As of Oct 2021, building Firefox requires XCode 13
   if [[ "${CURRENT_HOST_OS_VERSION}" == "11."* ]]; then
-    selectXcodeVersionOrDie "12.2"
+    selectXcodeVersionOrDie "13"
   else
     echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"
     exit 1


### PR DESCRIPTION
It didn't compile withh Xcode 12.2, but does compile with Xcode 13
locally for me.

Moving on to Xcode 13 then.