### PR TITLE
feat: roll FFMPEG to 1006

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "ffmpeg",
-      "revision": "1005",
+      "revision": "1006",
       "installByDefault": true
     }
   ]


### PR DESCRIPTION
The new version of FFMPEG is built with a new macos buildbot.