### PR TITLE
[Docs] [Core concepts/Browser contexts] Fix C# code example

### DIFF
--- a/docs/src/api/class-playwright.md
+++ b/docs/src/api/class-playwright.md
@@ -163,7 +163,7 @@ class PlaywrightExample
     {
         using var playwright = await Playwright.CreateAsync();
         await using var browser = await playwright.Webkit.LaunchAsync();
-        await using var context = await browser.NewContextAsync(Playwright.Devices["iPhone 6"]);
+        await using var context = await browser.NewContextAsync(playwright.Devices["iPhone 6"]);
 
         var page = await context.NewPageAsync();
         await page.GotoAsync("https://www.theverge.com");

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -214,7 +214,7 @@ class PlaywrightExample
     {
         using var playwright = await Playwright.CreateAsync();
         await using var browser = await playwright.Webkit.LaunchAsync();
-        var options = new BrowserContextNewOptions(Playwright.Devices["iPhone 11 Pro"])
+        var options = new BrowserNewContextOptions(playwright.Devices["iPhone 11 Pro"])
         {
             Geolocation = new() { Longitude = 12.492507f, Latitude = 41.889938f },
             Permissions = new[] { "geolocation" },


### PR DESCRIPTION
Example contains
```cs
var options = new BrowserContextNewOptions(Playwright.Devices["iPhone 11 Pro"])
```
which cause compile errors because

1. correct name is `BrowserNewContextOptions`, not `BrowserContextNewOptions`
2. `Devices ` is instance field, not static