### PR TITLE
fix(matchers): make isNot required in protocol

### DIFF
--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -21,9 +21,8 @@ import * as util from 'util';
 import { monotonicTime } from '../utils/utils';
 import { ElementHandle } from './elementHandle';
 import { Frame } from './frame';
-import { FilePayload, Rect, SelectOption, SelectOptionOptions, TimeoutOptions } from './types';
+import { FilePayload, FrameExpectOptions, Rect, SelectOption, SelectOptionOptions, TimeoutOptions } from './types';
 import { parseResult, serializeArgument } from './jsHandle';
-import { FrameExpectOptions } from '../server/types';
 
 export class Locator implements api.Locator {
   private _frame: Frame;

--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -23,6 +23,7 @@ import { ElementHandle } from './elementHandle';
 import { Frame } from './frame';
 import { FilePayload, Rect, SelectOption, SelectOptionOptions, TimeoutOptions } from './types';
 import { parseResult, serializeArgument } from './jsHandle';
+import { FrameExpectOptions } from '../server/types';
 
 export class Locator implements api.Locator {
   private _frame: Frame;
@@ -221,9 +222,9 @@ export class Locator implements api.Locator {
     });
   }
 
-  async _expect(expression: string, options: channels.FrameExpectOptions): Promise<{ pass: boolean, received?: any, log?: string[] }> {
+  async _expect(expression: string, options: FrameExpectOptions): Promise<{ pass: boolean, received?: any, log?: string[] }> {
     return this._frame._wrapApiCall(async (channel: channels.FrameChannel) => {
-      const params: any = { selector: this._selector, expression, ...options };
+      const params: channels.FrameExpectParams = { selector: this._selector, expression, ...options, isNot: !!options.isNot };
       if (options.expectedValue)
         params.expectedValue = serializeArgument(options.expectedValue);
       const result = (await channel.expect(params));

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -118,3 +118,5 @@ export type SelectorEngine = {
 
 export type RemoteAddr = channels.RemoteAddr;
 export type SecurityDetails = channels.SecurityDetails;
+
+export type FrameExpectOptions = channels.FrameExpectOptions & { isNot?: boolean };

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -2221,7 +2221,7 @@ export type FrameExpectParams = {
   expectedNumber?: number,
   expectedValue?: SerializedArgument,
   useInnerText?: boolean,
-  isNot?: boolean,
+  isNot: boolean,
   timeout?: number,
 };
 export type FrameExpectOptions = {
@@ -2230,7 +2230,6 @@ export type FrameExpectOptions = {
   expectedNumber?: number,
   expectedValue?: SerializedArgument,
   useInnerText?: boolean,
-  isNot?: boolean,
   timeout?: number,
 };
 export type FrameExpectResult = {

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -1799,7 +1799,7 @@ Frame:
         expectedNumber: number?
         expectedValue: SerializedArgument?
         useInnerText: boolean?
-        isNot: boolean?
+        isNot: boolean
         timeout: number?
       returns:
         pass: boolean

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -908,7 +908,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     expectedNumber: tOptional(tNumber),
     expectedValue: tOptional(tType('SerializedArgument')),
     useInnerText: tOptional(tBoolean),
-    isNot: tOptional(tBoolean),
+    isNot: tBoolean,
     timeout: tOptional(tNumber),
   });
   scheme.WorkerEvaluateExpressionParams = tObject({

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -17,7 +17,6 @@
 
 import { Size, Point, Rect, TimeoutOptions } from '../common/types';
 export { Size, Point, Rect, Quad, URLMatch, TimeoutOptions } from '../common/types';
-import * as channels from '../protocol/channels';
 
 export type StrictOptions = {
   strict?: boolean,
@@ -380,5 +379,3 @@ export type FetchResponse = {
   headers: HeadersArray,
   body: Buffer,
 };
-
-export type FrameExpectOptions = channels.FrameExpectOptions & { isNot?: boolean };

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -17,6 +17,7 @@
 
 import { Size, Point, Rect, TimeoutOptions } from '../common/types';
 export { Size, Point, Rect, Quad, URLMatch, TimeoutOptions } from '../common/types';
+import * as channels from '../protocol/channels';
 
 export type StrictOptions = {
   strict?: boolean,
@@ -379,3 +380,5 @@ export type FetchResponse = {
   headers: HeadersArray,
   body: Buffer,
 };
+
+export type FrameExpectOptions = channels.FrameExpectOptions & { isNot?: boolean };

--- a/packages/playwright-test/src/matchers/matchers.ts
+++ b/packages/playwright-test/src/matchers/matchers.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as channels from 'playwright-core/src/protocol/channels';
 import { Locator, Page } from 'playwright-core';
+import { FrameExpectOptions } from 'playwright-core/src/server/types';
 import { constructURLBasedOnBaseURL } from 'playwright-core/src/utils/utils';
 import type { Expect } from '../types';
 import { toBeTruthy } from './toBeTruthy';
@@ -23,7 +23,7 @@ import { toEqual } from './toEqual';
 import { toExpectedTextValues, toMatchText } from './toMatchText';
 
 interface LocatorEx extends Locator {
-  _expect(expression: string, options: channels.FrameExpectOptions): Promise<{ pass: boolean, received?: any, log?: string[] }>;
+  _expect(expression: string, options: FrameExpectOptions): Promise<{ pass: boolean, received?: any, log?: string[] }>;
 }
 
 export function toBeChecked(

--- a/packages/playwright-test/src/matchers/matchers.ts
+++ b/packages/playwright-test/src/matchers/matchers.ts
@@ -15,7 +15,7 @@
  */
 
 import { Locator, Page } from 'playwright-core';
-import { FrameExpectOptions } from 'playwright-core/src/server/types';
+import { FrameExpectOptions } from 'playwright-core/src/client/types';
 import { constructURLBasedOnBaseURL } from 'playwright-core/src/utils/utils';
 import type { Expect } from '../types';
 import { toBeTruthy } from './toBeTruthy';


### PR DESCRIPTION
Otherwise if the field is options all strict checks in [injectedScript](https://github.com/microsoft/playwright/blob/8ae926efbf4349de21cd76e907eefe7fb7cd25f4/packages/playwright-core/src/server/injected/injectedScript.ts#L839) may fail silently.