### PR TITLE
docs(selector): change Python textContent to text_content

### DIFF
--- a/docs/src/selectors.md
+++ b/docs/src/selectors.md
@@ -490,11 +490,11 @@ page.textContent("article:has(div.promo)");
 ```
 
 ```python async
-await page.textContent("article:has(div.promo)")
+await page.text_content("article:has(div.promo)")
 ```
 
 ```python sync
-page.textContent("article:has(div.promo)")
+page.text_content("article:has(div.promo)")
 ```
 
 ```csharp


### PR DESCRIPTION
Wrong method name in docs:

```
from playwright.sync_api import sync_playwright

with sync_playwright() as p:
    for browser_type in [p.chromium]:
        browser = browser_type.launch()
        page = browser.new_page()
        page.goto('http://whatsmyuseragent.org/')
        page.textContent("div")
        browser.close()
```

`AttributeError: 'Page' object has no attribute 'textContent'`

should be

`page.text_content()`


https://playwright.dev/python/docs/selectors#selecting-elements-that-contain-other-elements
