### PR TITLE
types(test-runner): fix access worker fixtures in test.skip

### DIFF
--- a/packages/playwright-core/types/test.d.ts
+++ b/packages/playwright-core/types/test.d.ts
@@ -1303,7 +1303,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * @param title Test title.
    * @param testFunction Test function that takes one or two arguments: an object with fixtures and optional [TestInfo].
    */
-  skip(title: string, testFunction: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  skip(title: string, testFunction: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
   /**
    * Unconditionally skip a test. Test is immediately aborted when you call
    * [test.skip()](https://playwright.dev/docs/api/class-test#test-skip-2).

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -232,7 +232,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
       only: SuiteFunction;
     };
   };
-  skip(title: string, testFunction: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  skip(title: string, testFunction: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
   skip(): void;
   skip(condition: boolean, description?: string): void;
   skip(callback: (args: TestArgs & WorkerArgs) => boolean, description?: string): void;


### PR DESCRIPTION
Before it was not possible. Example repro is: `tests/browsertype-launch-selenium.spec.ts:86` when you change `test` to `test.skip`.

