### PR TITLE
fix(trace-viewer): show warning when opening an empty trace

### DIFF
--- a/packages/playwright-core/src/web/traceViewer/ui/actionList.css
+++ b/packages/playwright-core/src/web/traceViewer/ui/actionList.css
@@ -122,3 +122,15 @@
 .action-entry .codicon-warning {
   color: darkorange;
 }
+
+.no-actions-entry {
+  height: 400px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+}
+
+.no-actions-entry-text {
+  font-weight: bold;
+  font-size: 1.3rem;
+}

--- a/packages/playwright-core/src/web/traceViewer/ui/actionList.tsx
+++ b/packages/playwright-core/src/web/traceViewer/ui/actionList.tsx
@@ -45,7 +45,7 @@ export const ActionList: React.FC<ActionListProps> = ({
   }, [selectedAction, actionListRef]);
 
   return <div className='action-list vbox'>
-    <div className='.action-list-title tab-strip'>
+    <div className='action-list-title tab-strip'>
       <div className='tab-element'>
         <div className='tab-label'>Actions</div>
       </div>
@@ -72,6 +72,16 @@ export const ActionList: React.FC<ActionListProps> = ({
       }}
       ref={actionListRef}
     >
+      {actions.length === 0 && <div className='no-actions-entry'>
+        <div>
+          <div className='no-actions-entry-text'>
+            No actions recorded
+          </div>
+          <div>
+            Make sure that the right context was used when recording the trace.
+          </div>
+        </div>
+      </div>}
       {actions.map(action => {
         const { metadata } = action;
         const selectedSuffix = action === selectedAction ? ' selected' : '';


### PR DESCRIPTION
Customers were confused and didn't know what to do next. With this change they know at least that they are opening an empty trace file.

Before: 

![image](https://user-images.githubusercontent.com/17984549/136976942-43f38f23-035f-4b3d-8549-de9aad7507d4.png)


After:

![image](https://user-images.githubusercontent.com/17984549/136976853-96a79c74-3909-4ac8-b0a8-6d8bd2fdc532.png)
