### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -15,19 +15,20 @@ jobs:
     name: "docs & lint"
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: npm run build
-    - run: npx playwright install-deps
-    - run: npm run lint
-    - name: Verify clean tree
-      run: |
-        if [[ -n $(git status -s) ]]; then
-          echo "ERROR: tree is dirty after npm run build:"
-          git diff
-          exit 1
-        fi
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+      - run: npm run build
+      - run: npx playwright install-deps
+      - run: npm run lint
+      - name: Verify clean tree
+        run: |
+          if [[ -n $(git status -s) ]]; then
+            echo "ERROR: tree is dirty after npm run build:"
+            git diff
+            exit 1
+          fi

--- a/.github/workflows/publish_canary_driver.yml
+++ b/.github/workflows/publish_canary_driver.yml
@@ -12,19 +12,20 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: npm run build
-    - run: npx playwright install-deps
-    - run: node utils/build/update_canary_version.js --commit-timestamp
-    - run: utils/build/build-playwright-driver.sh
-    - run: utils/build/upload-playwright-driver.sh
-      env:
-        AZ_UPLOAD_FOLDER: driver/next
-        AZ_ACCOUNT_KEY: ${{ secrets.AZ_ACCOUNT_KEY }}
-        AZ_ACCOUNT_NAME: ${{ secrets.AZ_ACCOUNT_NAME }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+      - run: npm run build
+      - run: npx playwright install-deps
+      - run: node utils/build/update_canary_version.js --commit-timestamp
+      - run: utils/build/build-playwright-driver.sh
+      - run: utils/build/upload-playwright-driver.sh
+        env:
+          AZ_UPLOAD_FOLDER: driver/next
+          AZ_ACCOUNT_KEY: ${{ secrets.AZ_ACCOUNT_KEY }}
+          AZ_ACCOUNT_NAME: ${{ secrets.AZ_ACCOUNT_NAME }}

--- a/.github/workflows/publish_canary_npm.yml
+++ b/.github/workflows/publish_canary_npm.yml
@@ -1,7 +1,7 @@
 name: "devrelease:npm"
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   schedule:
     - cron: "10 0 * * *"
   push:
@@ -14,20 +14,20 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: npm run build
-    - run: npx playwright install-deps
-    - run: node utils/build/update_canary_version.js --today-date
-      if: contains(github.ref, 'master') && github.event_name != 'workflow_dispatch'
-    - run: node utils/build/update_canary_version.js --commit-timestamp
-      if: contains(github.ref, 'release') || github.event_name == 'workflow_dispatch'
-    - run: utils/publish_all_packages.sh --tip-of-tree
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+      - run: npm run build
+      - run: npx playwright install-deps
+      - run: node utils/build/update_canary_version.js --today-date
+        if: contains(github.ref, 'master') && github.event_name != 'workflow_dispatch'
+      - run: node utils/build/update_canary_version.js --commit-timestamp
+        if: contains(github.ref, 'release') || github.event_name == 'workflow_dispatch'
+      - run: utils/publish_all_packages.sh --tip-of-tree
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -10,48 +10,50 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: npm run build
-    - run: npx playwright install-deps
-    - run: utils/publish_all_packages.sh --release
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+      - run: npm run build
+      - run: npx playwright install-deps
+      - run: utils/publish_all_packages.sh --release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-driver-release:
     name: "publish playwright driver to CDN"
     runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: npm run build
-    - run: npx playwright install-deps
-    - run: utils/build/build-playwright-driver.sh
-    - run: utils/build/upload-playwright-driver.sh
-      env:
-        AZ_UPLOAD_FOLDER: driver
-        AZ_ACCOUNT_KEY: ${{ secrets.AZ_ACCOUNT_KEY }}
-        AZ_ACCOUNT_NAME: ${{ secrets.AZ_ACCOUNT_NAME }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+      - run: npm run build
+      - run: npx playwright install-deps
+      - run: utils/build/build-playwright-driver.sh
+      - run: utils/build/upload-playwright-driver.sh
+        env:
+          AZ_UPLOAD_FOLDER: driver
+          AZ_ACCOUNT_KEY: ${{ secrets.AZ_ACCOUNT_KEY }}
+          AZ_ACCOUNT_NAME: ${{ secrets.AZ_ACCOUNT_NAME }}
 
   trigger-docker-build:
     name: "publish to DockerHub"
     runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
     steps:
-    - run: |
-        curl -X POST \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token ${{ secrets.REPOSITORY_DISPATCH_PERSONAL_ACCESS_TOKEN }}" \
-          --data "{\"event_type\": \"build_docker_production\", \"client_payload\": {\"ref\": \"${{ github.sha }}\"}}" \
-          https://api.github.com/repos/microsoft/playwright-internal/dispatches
+      - run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.REPOSITORY_DISPATCH_PERSONAL_ACCESS_TOKEN }}" \
+            --data "{\"event_type\": \"build_docker_production\", \"client_payload\": {\"ref\": \"${{ github.sha }}\"}}" \
+            https://api.github.com/repos/microsoft/playwright-internal/dispatches

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -8,39 +8,40 @@ jobs:
   roll:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 16
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: npm run build
-    - name: Install dependencies
-      run: npx playwright install-deps
-    - name: Roll to new revision
-      run: |
-        ./utils/roll_browser.js ${{ github.event.client_payload.browser }} ${{ github.event.client_payload.revision }}
-        npm run build
-    - name: Prepare branch
-      id: prepare-branch
-      run: |
-        BASE_POSITION="${{ steps.bump-chromium.outputs.BASE_POSITION }}"
-        BRANCH_NAME="roll-into-pw-${{ github.event.client_payload.browser }}/${{ github.event.client_payload.revision }}"
-        echo "::set-output name=BRANCH_NAME::$BRANCH_NAME"
-        git config --global user.name github-actions
-        git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git checkout -b "$BRANCH_NAME"
-        git add .
-        git commit -m "feat(${{ github.event.client_payload.browser }}): roll to r${{ github.event.client_payload.revision }}"
-        git push origin $BRANCH_NAME
-    - name: Create Pull Request
-      uses: actions/github-script@v4
-      with:
-        script: |
-          await github.pulls.create({
-            owner: 'microsoft',
-            repo: 'playwright',
-            head: 'microsoft:${{ steps.prepare-branch.outputs.BRANCH_NAME }}',
-            base: 'master',
-            title: 'feat(${{ github.event.client_payload.browser }}): roll to r${{ github.event.client_payload.revision }}',
-          });
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+      - run: npm run build
+      - name: Install dependencies
+        run: npx playwright install-deps
+      - name: Roll to new revision
+        run: |
+          ./utils/roll_browser.js ${{ github.event.client_payload.browser }} ${{ github.event.client_payload.revision }}
+          npm run build
+      - name: Prepare branch
+        id: prepare-branch
+        run: |
+          BASE_POSITION="${{ steps.bump-chromium.outputs.BASE_POSITION }}"
+          BRANCH_NAME="roll-into-pw-${{ github.event.client_payload.browser }}/${{ github.event.client_payload.revision }}"
+          echo "::set-output name=BRANCH_NAME::$BRANCH_NAME"
+          git config --global user.name github-actions
+          git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git checkout -b "$BRANCH_NAME"
+          git add .
+          git commit -m "feat(${{ github.event.client_payload.browser }}): roll to r${{ github.event.client_payload.revision }}"
+          git push origin $BRANCH_NAME
+      - name: Create Pull Request
+        uses: actions/github-script@v4
+        with:
+          script: |
+            await github.pulls.create({
+              owner: 'microsoft',
+              repo: 'playwright',
+              head: 'microsoft:${{ steps.prepare-branch.outputs.BRANCH_NAME }}',
+              base: 'master',
+              title: 'feat(${{ github.event.client_payload.browser }}): roll to r${{ github.event.client_payload.revision }}',
+            });

--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -6,16 +6,16 @@ on:
       - master
       - release-*
     paths:
-      - '.github/workflows/tests_docker.yml'
-      - '**/Dockerfile*'
-      - 'browsers.json'
-      - 'package.json'
+      - ".github/workflows/tests_docker.yml"
+      - "**/Dockerfile*"
+      - "browsers.json"
+      - "package.json"
   pull_request:
     paths:
-      - '.github/workflows/tests_docker.yml'
-      - '**/Dockerfile*'
-      - 'browsers.json'
-      - 'package.json'
+      - ".github/workflows/tests_docker.yml"
+      - "**/Dockerfile*"
+      - "browsers.json"
+      - "package.json"
     branches:
       - master
       - release-*
@@ -35,37 +35,37 @@ jobs:
         tag: [bionic, focal]
         user: [pwuser, root]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 14
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: npm run build
-    - name: Build
-      run: bash utils/docker/build.sh ${{ matrix.tag }} playwright:localbuild-${{ matrix.tag }}
-    - name: Clean & Prepare for Docker
-      run: |
-        npm run clean
-        rm -rf node_modules/
-        if [[ ${{ matrix.user }} == 'root' ]]; then
-          sudo chown -R 0 $(pwd)
-        else
-          sudo chown -R 1000 $(pwd)
-        fi
-    - name: Launch container
-      run: docker run --rm --user=${{ matrix.user }} -v $(pwd):/tmp/playwright --workdir /tmp/playwright/ --name playwright-docker-${{ matrix.tag }}-test -d -t playwright:localbuild-${{ matrix.tag }} /bin/bash
-    - name: Run "npm ci" inside docker
-      run: docker exec playwright-docker-${{ matrix.tag }}-test npm ci
-    - name: Run "npm run build" inside docker
-      run: docker exec playwright-docker-${{ matrix.tag }}-test npm run build
-    - name: Run "npm run test" inside docker
-      run: docker exec -e INSIDE_DOCKER=1 -e CI=1 playwright-docker-${{ matrix.tag }}-test xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run test
-    - run: sudo ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: docker-ubuntu-${{ matrix.tag }}-${{ matrix.user }}-test-results
-        path: test-results
-
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+      - run: npm run build
+      - name: Build
+        run: bash utils/docker/build.sh ${{ matrix.tag }} playwright:localbuild-${{ matrix.tag }}
+      - name: Clean & Prepare for Docker
+        run: |
+          npm run clean
+          rm -rf node_modules/
+          if [[ ${{ matrix.user }} == 'root' ]]; then
+            sudo chown -R 0 $(pwd)
+          else
+            sudo chown -R 1000 $(pwd)
+          fi
+      - name: Launch container
+        run: docker run --rm --user=${{ matrix.user }} -v $(pwd):/tmp/playwright --workdir /tmp/playwright/ --name playwright-docker-${{ matrix.tag }}-test -d -t playwright:localbuild-${{ matrix.tag }} /bin/bash
+      - name: Run "npm ci" inside docker
+        run: docker exec playwright-docker-${{ matrix.tag }}-test npm ci
+      - name: Run "npm run build" inside docker
+        run: docker exec playwright-docker-${{ matrix.tag }}-test npm run build
+      - name: Run "npm run test" inside docker
+        run: docker exec -e INSIDE_DOCKER=1 -e CI=1 playwright-docker-${{ matrix.tag }}-test xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run test
+      - run: sudo ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: docker-ubuntu-${{ matrix.tag }}-${{ matrix.user }}-test-results
+          path: test-results

--- a/.github/workflows/tests_fyi.yml
+++ b/.github/workflows/tests_fyi.yml
@@ -20,27 +20,28 @@ jobs:
         browser: [chromium, firefox, webkit]
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }}
-      env:
-        PWTEST_VIDEO: 1
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: video-${{ matrix.browser }}-linux-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          DEBUG: pw:install
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }}
+        env:
+          PWTEST_VIDEO: 1
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: video-${{ matrix.browser }}-linux-test-results
+          path: test-results
 
   test_android:
     name: Android Emulator (shard ${{ matrix.shard }})
@@ -50,27 +51,27 @@ jobs:
         shard: [1, 2]
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 14
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-    - run: npm run build
-    - run: npx playwright install-deps
-    - name: Create Android Emulator
-      run: utils/avd_recreate.sh
-    - name: Start Android Emulator
-      run: utils/avd_start.sh
-    - name: Run tests
-      run: npm run atest -- --shard=${{ matrix.shard }}/2
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: android-test-results
-        path: test-results
-
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          DEBUG: pw:install
+      - run: npm run build
+      - run: npx playwright install-deps
+      - name: Create Android Emulator
+        run: utils/avd_recreate.sh
+      - name: Start Android Emulator
+        run: utils/avd_start.sh
+      - name: Run tests
+        run: npm run atest -- --shard=${{ matrix.shard }}/2
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: android-test-results
+          path: test-results

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -7,8 +7,8 @@ on:
       - release-*
   pull_request:
     paths-ignore:
-      - 'browser_patches/**'
-      - 'docs/**'
+      - "browser_patches/**"
+      - "docs/**"
     branches:
       - master
       - release-*
@@ -28,26 +28,27 @@ jobs:
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }}
-    - run: node tests/config/checkCoverage.js ${{ matrix.browser }}
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: always()
-      with:
-        name: ${{ matrix.browser }}-${{ matrix.os }}-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          DEBUG: pw:install
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }}
+      - run: node tests/config/checkCoverage.js ${{ matrix.browser }}
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: ${{ matrix.browser }}-${{ matrix.os }}-test-results
+          path: test-results
 
   test_test_runner:
     name: Test Runner
@@ -57,17 +58,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-    - run: npm run build
-    - run: npx playwright install --with-deps
-    - run: npm run ttest
-      if: matrix.os != 'ubuntu-latest'
-    - run: xvfb-run npm run ttest
-      if: matrix.os == 'ubuntu-latest'
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          DEBUG: pw:install
+      - run: npm run build
+      - run: npx playwright install --with-deps
+      - run: npm run ttest
+        if: matrix.os != 'ubuntu-latest'
+      - run: xvfb-run npm run ttest
+        if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -7,9 +7,9 @@ on:
       - release-*
   pull_request:
     paths-ignore:
-      - 'browser_patches/**'
-      - 'docs/**'
-    types: [ labeled ]
+      - "browser_patches/**"
+      - "docs/**"
+    types: [labeled]
     branches:
       - master
       - release-*
@@ -29,26 +29,27 @@ jobs:
         os: [ubuntu-18.04]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }}
-    - run: node tests/config/checkCoverage.js ${{ matrix.browser }}
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: always()
-      with:
-        name: ${{ matrix.browser }}-${{ matrix.os }}-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          DEBUG: pw:install
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }}
+      - run: node tests/config/checkCoverage.js ${{ matrix.browser }}
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: ${{ matrix.browser }}-${{ matrix.os }}-test-results
+          path: test-results
 
   test_mac:
     name: ${{ matrix.os }} (${{ matrix.browser }})
@@ -59,25 +60,26 @@ jobs:
         browser: [chromium, firefox, webkit]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
-    - run: npm run test -- --project=${{ matrix.browser }}
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: ${{ matrix.browser }}-${{ matrix.os }}-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          DEBUG: pw:install
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
+      - run: npm run test -- --project=${{ matrix.browser }}
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: ${{ matrix.browser }}-${{ matrix.os }}-test-results
+          path: test-results
 
   test_win:
     name: "Windows"
@@ -87,27 +89,28 @@ jobs:
         browser: [chromium, firefox, webkit]
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
-    - run: npm run test -- --project=${{ matrix.browser }}
-      shell: bash
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-      shell: bash
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: ${{ matrix.browser }}-win-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          DEBUG: pw:install
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
+      - run: npm run test -- --project=${{ matrix.browser }}
+        shell: bash
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+        shell: bash
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: ${{ matrix.browser }}-win-test-results
+          path: test-results
 
   test-package-installations:
     runs-on: ubuntu-20.04
@@ -115,22 +118,23 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
-        - "^12.0.0"
-        - "^14.1.0"  # pre 14.1, zip extraction was broken (https://github.com/microsoft/playwright/issues/1988)
-        - "^16.0.0"
+          - "^12.0.0"
+          - "^14.1.0" # pre 14.1, zip extraction was broken (https://github.com/microsoft/playwright/issues/1988)
+          - "^16.0.0"
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node_version }}
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-    - run: npm run build
-    - run: npx playwright install-deps
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash installation-tests/installation-tests.sh
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          DEBUG: pw:install
+      - run: npm run build
+      - run: npx playwright install-deps
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash installation-tests/installation-tests.sh
 
   headful_linux:
     name: "Headful Linux"
@@ -140,28 +144,29 @@ jobs:
         browser: [chromium, firefox, webkit]
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }}
-      if: ${{ always() }}
-      env:
-        HEADFUL: 1
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: headful-${{ matrix.browser }}-linux-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          DEBUG: pw:install
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }}
+        if: ${{ always() }}
+        env:
+          HEADFUL: 1
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: headful-${{ matrix.browser }}-linux-test-results
+          path: test-results
 
   transport_linux:
     name: "Transport"
@@ -171,27 +176,28 @@ jobs:
         mode: [driver, service]
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps chromium
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
-      env:
-        PWTEST_MODE: ${{ matrix.mode }}
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: mode-${{ matrix.mode }}-linux-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          DEBUG: pw:install
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps chromium
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
+        env:
+          PWTEST_MODE: ${{ matrix.mode }}
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: mode-${{ matrix.mode }}-linux-test-results
+          path: test-results
 
   tracing_linux:
     name: "Tracing"
@@ -201,487 +207,506 @@ jobs:
         browser: [chromium, firefox, webkit]
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }}
-      env:
-        PWTEST_TRACE: 1
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          DEBUG: pw:install
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }}
+        env:
+          PWTEST_TRACE: 1
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
 
   chrome_stable_linux:
     name: "Chrome Stable (Linux)"
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps chrome
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
-      env:
-        PWTEST_CHANNEL: chrome
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: chrome-stable-linux-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps chrome
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
+        env:
+          PWTEST_CHANNEL: chrome
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: chrome-stable-linux-test-results
+          path: test-results
 
   chrome_stable_win:
     name: "Chrome Stable (Win)"
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps chrome
-    - run: npm run ctest
-      shell: bash
-      env:
-        PWTEST_CHANNEL: chrome
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-      shell: bash
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: chrome-stable-win-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps chrome
+      - run: npm run ctest
+        shell: bash
+        env:
+          PWTEST_CHANNEL: chrome
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+        shell: bash
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: chrome-stable-win-test-results
+          path: test-results
 
   chrome_stable_mac:
     name: "Chrome Stable (Mac)"
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps chrome
-    - run: npm run ctest
-      env:
-        PWTEST_CHANNEL: chrome
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: chrome-stable-mac-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps chrome
+      - run: npm run ctest
+        env:
+          PWTEST_CHANNEL: chrome
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: chrome-stable-mac-test-results
+          path: test-results
 
   firefox_beta_linux:
     name: "Firefox Beta (Linux)"
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps firefox-beta chromium
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ftest
-      env:
-        PWTEST_CHANNEL: firefox-beta
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: firefox-beta-linux-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps firefox-beta chromium
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ftest
+        env:
+          PWTEST_CHANNEL: firefox-beta
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: firefox-beta-linux-test-results
+          path: test-results
 
   firefox_beta_win:
     name: "Firefox Beta (Win)"
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps firefox-beta chromium
-    - run: npm run ftest
-      shell: bash
-      env:
-        PWTEST_CHANNEL: firefox-beta
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-      shell: bash
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: firefox-beta-win-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps firefox-beta chromium
+      - run: npm run ftest
+        shell: bash
+        env:
+          PWTEST_CHANNEL: firefox-beta
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+        shell: bash
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: firefox-beta-win-test-results
+          path: test-results
 
   firefox_beta_mac:
     name: "Firefox Beta (Mac)"
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps firefox-beta chromium
-    - run: npm run ftest
-      env:
-        PWTEST_CHANNEL: firefox-beta
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: firefox-beta-mac-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps firefox-beta chromium
+      - run: npm run ftest
+        env:
+          PWTEST_CHANNEL: firefox-beta
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: firefox-beta-mac-test-results
+          path: test-results
 
   edge_stable_mac:
     name: "Edge Stable (Mac)"
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps msedge
-    - run: npm run ctest
-      env:
-        PWTEST_CHANNEL: msedge
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: msedge-stable-mac-test-results
-        path: test-results
-
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps msedge
+      - run: npm run ctest
+        env:
+          PWTEST_CHANNEL: msedge
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: msedge-stable-mac-test-results
+          path: test-results
 
   edge_stable_win:
     name: "Edge Stable (Win)"
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps msedge
-    - run: npm run ctest
-      shell: bash
-      env:
-        PWTEST_CHANNEL: msedge
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: edge-stable-win-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps msedge
+      - run: npm run ctest
+        shell: bash
+        env:
+          PWTEST_CHANNEL: msedge
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: edge-stable-win-test-results
+          path: test-results
 
   edge_beta_mac:
     name: "Edge Beta (Mac)"
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps msedge-beta
-    - run: npm run ctest
-      env:
-        PWTEST_CHANNEL: msedge-beta
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: msedge-beta-mac-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps msedge-beta
+      - run: npm run ctest
+        env:
+          PWTEST_CHANNEL: msedge-beta
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: msedge-beta-mac-test-results
+          path: test-results
 
   edge_beta_win:
     name: "Edge Beta (Win)"
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps msedge-beta
-    - run: npm run ctest
-      shell: bash
-      env:
-        PWTEST_CHANNEL: msedge-beta
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: edge-beta-win-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps msedge-beta
+      - run: npm run ctest
+        shell: bash
+        env:
+          PWTEST_CHANNEL: msedge-beta
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: edge-beta-win-test-results
+          path: test-results
 
   edge_beta_linux:
     name: "Edge Beta (Linux)"
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps msedge-beta
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
-      env:
-        PWTEST_CHANNEL: msedge-beta
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: edge-beta-linux-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps msedge-beta
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
+        env:
+          PWTEST_CHANNEL: msedge-beta
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: edge-beta-linux-test-results
+          path: test-results
 
   edge_dev_mac:
     name: "Edge Dev (Mac)"
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps msedge-dev
-    - run: npm run ctest
-      env:
-        PWTEST_CHANNEL: msedge-dev
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: msedge-dev-mac-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps msedge-dev
+      - run: npm run ctest
+        env:
+          PWTEST_CHANNEL: msedge-dev
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: msedge-dev-mac-test-results
+          path: test-results
 
   edge_dev_win:
     name: "Edge Dev (Win)"
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps msedge-dev
-    - run: npm run ctest
-      shell: bash
-      env:
-        PWTEST_CHANNEL: msedge-dev
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: edge-dev-win-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps msedge-dev
+      - run: npm run ctest
+        shell: bash
+        env:
+          PWTEST_CHANNEL: msedge-dev
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: edge-dev-win-test-results
+          path: test-results
 
   edge_dev_linux:
     name: "Edge Dev (Linux)"
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps msedge-dev
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
-      env:
-        PWTEST_CHANNEL: msedge-dev
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: edge-dev-linux-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps msedge-dev
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
+        env:
+          PWTEST_CHANNEL: msedge-dev
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: edge-dev-linux-test-results
+          path: test-results
 
   chrome_beta_linux:
     name: "Chrome Beta (Linux)"
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps chrome-beta
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
-      env:
-        PWTEST_CHANNEL: chrome-beta
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: chrome-beta-linux-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps chrome-beta
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
+        env:
+          PWTEST_CHANNEL: chrome-beta
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: chrome-beta-linux-test-results
+          path: test-results
 
   chrome_beta_win:
     name: "Chrome Beta (Win)"
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps chrome-beta
-    - run: npm run ctest
-      shell: bash
-      env:
-        PWTEST_CHANNEL: chrome-beta
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-      shell: bash
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: chrome-beta-win-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps chrome-beta
+      - run: npm run ctest
+        shell: bash
+        env:
+          PWTEST_CHANNEL: chrome-beta
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+        shell: bash
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: chrome-beta-win-test-results
+          path: test-results
 
   chrome_beta_mac:
     name: "Chrome Beta (Mac)"
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps chrome-beta
-    - run: npm run ctest
-      env:
-        PWTEST_CHANNEL: chrome-beta
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: chrome-beta-mac-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps chrome-beta
+      - run: npm run ctest
+        env:
+          PWTEST_CHANNEL: chrome-beta
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: chrome-beta-mac-test-results
+          path: test-results
 
   test_electron:
     name: "Electron Linux"
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    - run: npm run build
-    - run: npx playwright install --with-deps chromium
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run etest
-    - run: node tests/config/checkCoverage.js electron
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-      if: always()
-    - uses: actions/upload-artifact@v1
-      if: ${{ always() }}
-      with:
-        name: electron-linux-test-results
-        path: test-results
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - run: npm run build
+      - run: npx playwright install --with-deps chromium
+      - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run etest
+      - run: node tests/config/checkCoverage.js electron
+      - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        if: always()
+      - uses: actions/upload-artifact@v1
+        if: ${{ always() }}
+        with:
+          name: electron-linux-test-results
+          path: test-results
 
   build-playwright-driver:
     name: "build-playwright-driver"
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: npm run build
-    - run: npx playwright install-deps
-    - run: node utils/build/update_canary_version.js --today-date
-    - run: utils/build/build-playwright-driver.sh
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+      - run: npm run build
+      - run: npx playwright install-deps
+      - run: node utils/build/update_canary_version.js --today-date
+      - run: utils/build/build-playwright-driver.sh


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
