### PR TITLE
devops: stop using MacOS 10.12 SDK when building Firefox

### DIFF
--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -33,22 +33,6 @@ if [[ "$(uname)" == "Darwin" ]]; then
     echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"
     exit 1
   fi
-
-  # Firefox on Mac Intel requires SDK for 10.12 to work on old versions of MacOS.
-  # Mac on Apple Silicon doesn't exist on old versions of MacOS, so this is not needed.
-  if [[ "$(uname -m)" == "x86_64" ]]; then
-    if ! [[ -d $HOME/SDK-archive/MacOSX${MACOS_SDK_VERSION}.sdk ]]; then
-      echo "As of Dec 2020, Firefox does not build on Mac ${CURRENT_HOST_OS_VERSION} without ${MACOS_SDK_VERSION} SDK."
-      echo "Download XCode ${XCODE_VERSION_WITH_REQUIRED_SDK_VERSION} from https://developer.apple.com/download/more/ and"
-      echo "extract SDK to $HOME/SDK-archive/MacOSX${MACOS_SDK_VERSION}.sdk"
-      echo ""
-      echo "More info: https://firefox-source-docs.mozilla.org/setup/macos_build.html"
-      exit 1
-    else
-      echo "-- configuting .mozconfig with ${MACOS_SDK_VERSION} SDK path"
-      echo "ac_add_options --with-macos-sdk=$HOME/SDK-archive/MacOSX${MACOS_SDK_VERSION}.sdk/" >> .mozconfig
-    fi
-  fi
   echo "-- building on Mac"
 elif [[ "$(uname)" == "Linux" ]]; then
   echo "-- building on Linux"


### PR DESCRIPTION
devops: stop using MacOS 10.12 SDK when building Firefox

An investigation has shown, that:
- Official Firefox builds actually cross-compile from Linux to MacOS,
  and for this reason use the old MacOS 10.12 SDK.
- We should be able to build with 11+ SDK just fine; read [primer on
   MacOS SDKs] for details.
- A random `symbol '___darwin_check_fd_set_overflow' not supported`
  error seems to be an [apple bug]. We can fix it using
  `LDFLAGS="-Wl,-U,___darwin_check_fd_set_overflow"`
  flag, similarly to [haskell compiler fix].

[primer on MacOS SDKs]: https://firefox-source-docs.mozilla.org/widget/cocoa/sdks.html
[apple bug]: https://openradar.appspot.com/FB7647406
[haskell compiler fix]: https://gitlab.haskell.org/ghc/ghc/-/commit/77456387025ca74299ecc70621cbdb62b1b6ffc9