### PR TITLE
chore(expect): simplify expect implementation

### DIFF
--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -221,7 +221,7 @@ export class Locator implements api.Locator {
     });
   }
 
-  async _expect(expression: string, options: FrameExpectOptions): Promise<{ pass: boolean, received?: any, log?: string[] }> {
+  async _expect(expression: string, options: FrameExpectOptions): Promise<{ matches: boolean, received?: any, log?: string[] }> {
     return this._frame._wrapApiCall(async (channel: channels.FrameChannel) => {
       const params: channels.FrameExpectParams = { selector: this._selector, expression, ...options, isNot: !!options.isNot };
       if (options.expectedValue)

--- a/packages/playwright-core/src/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/dispatchers/frameDispatcher.ts
@@ -232,7 +232,7 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameInitializer
     const result = await this._frame.expect(metadata, params.selector, { ...params, expectedValue });
     if (result.received !== undefined)
       result.received = serializeResult(result.received);
-    if (result.pass === !!params.isNot)
+    if (result.matches === params.isNot)
       metadata.error = { error: { name: 'Expect', message: 'Expect failed' } };
     return result;
   }

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -2233,7 +2233,7 @@ export type FrameExpectOptions = {
   timeout?: number,
 };
 export type FrameExpectResult = {
-  pass: boolean,
+  matches: boolean,
   received?: SerializedValue,
   log?: string[],
 };

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -1802,7 +1802,7 @@ Frame:
         isNot: boolean
         timeout: number?
       returns:
-        pass: boolean
+        matches: boolean
         received: SerializedValue?
         log:
           type: array?

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1176,7 +1176,14 @@ export class Frame extends SdkObject {
       if (!element)
         return { pass: !!options.isNot };
       // We have an element.
-      return progress.injectedScript.expect(progress, element!, options, elements, continuePolling);
+      const { matches, received } = progress.injectedScript.expect(progress, element!, options, elements);
+      if (matches === options.isNot) {
+        progress.setIntermediateResult(received);
+        if (!Array.isArray(received))
+          progress.log(`  unexpected value "${received}"`);
+        return continuePolling;
+      }
+      return { pass: !options.isNot, received };
     }, { omitAttached, ...options }, { strict: true, querySelectorAll, mainWorld, omitAttached, logScale: true, ...options }).catch(e => {
       if (js.isJavaScriptErrorInEvaluate(e))
         throw e;

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -70,7 +70,7 @@ export type NavigationEvent = {
 };
 
 export type SchedulableTask<T> = (injectedScript: js.JSHandle<InjectedScript>) => Promise<js.JSHandle<InjectedScriptPoll<T>>>;
-export type DomTaskBody<T, R, E> = (progress: InjectedScriptProgress, element: E, data: T, elements: Element[], continuePolling: any) => R;
+export type DomTaskBody<T, R, E> = (progress: InjectedScriptProgress, element: E, data: T, elements: Element[], continuePolling: symbol) => R | symbol;
 
 export class FrameManager {
   private _page: Page;
@@ -1161,20 +1161,22 @@ export class Frame extends SdkObject {
     });
   }
 
-  async expect(metadata: CallMetadata, selector: string, options: FrameExpectParams): Promise<{ pass: boolean, received?: any, log?: string[] }> {
+  async expect(metadata: CallMetadata, selector: string, options: FrameExpectParams): Promise<{ matches: boolean, received?: any, log?: string[] }> {
     const controller = new ProgressController(metadata, this);
     const isListMatcher = options.expression.endsWith('.array');
     const querySelectorAll = options.expression === 'to.have.count' || isListMatcher;
     const mainWorld = options.expression === 'to.have.property';
+    const missingElementShouldMatch = (!options.isNot && options.expression === 'to.be.hidden') || (options.isNot && options.expression === 'to.be.visible');
     const expectsEmptyList = options.expectedText?.length === 0;
-    const omitAttached = (isListMatcher && options.isNot !== expectsEmptyList) || (!options.isNot && options.expression === 'to.be.hidden') || (options.isNot && options.expression === 'to.be.visible');
+    const emptyListShouldMatch = isListMatcher && expectsEmptyList;
+    const omitAttached = (isListMatcher && options.isNot !== expectsEmptyList) || missingElementShouldMatch;
     return await this._scheduleRerunnableTaskWithController(controller, selector, (progress, element, options, elements, continuePolling) => {
-      // We don't have an element and we don't need an element => pass.
-      if (!element && options.omitAttached)
-        return { pass: !options.isNot };
-      // We don't have an element and we DO need an element => fail.
+      // We don't have an element and we don't need an element => matches.
+      if (!element && (options.emptyListShouldMatch || options.missingElementShouldMatch))
+        return { matches: true };
+      // We don't have an element and we DO need an element => does not match.
       if (!element)
-        return { pass: !!options.isNot };
+        return { matches: false };
       // We have an element.
       const { matches, received } = progress.injectedScript.expect(progress, element!, options, elements);
       if (matches === options.isNot) {
@@ -1183,11 +1185,11 @@ export class Frame extends SdkObject {
           progress.log(`  unexpected value "${received}"`);
         return continuePolling;
       }
-      return { pass: !options.isNot, received };
-    }, { omitAttached, ...options }, { strict: true, querySelectorAll, mainWorld, omitAttached, logScale: true, ...options }).catch(e => {
+      return { matches, received };
+    }, { emptyListShouldMatch, missingElementShouldMatch, ...options }, { strict: true, querySelectorAll, mainWorld, omitAttached, logScale: true, ...options }).catch(e => {
       if (js.isJavaScriptErrorInEvaluate(e))
         throw e;
-      return { received: controller.lastIntermediateResult(), pass: !!options.isNot, log: metadata.log };
+      return { received: controller.lastIntermediateResult(), matches: options.isNot, log: metadata.log };
     });
   }
 

--- a/packages/playwright-test/src/matchers/matchers.ts
+++ b/packages/playwright-test/src/matchers/matchers.ts
@@ -23,7 +23,7 @@ import { toEqual } from './toEqual';
 import { toExpectedTextValues, toMatchText } from './toMatchText';
 
 interface LocatorEx extends Locator {
-  _expect(expression: string, options: FrameExpectOptions): Promise<{ pass: boolean, received?: any, log?: string[] }>;
+  _expect(expression: string, options: FrameExpectOptions): Promise<{ matches: boolean, received?: any, log?: string[] }>;
 }
 
 export function toBeChecked(

--- a/packages/playwright-test/src/matchers/toBeTruthy.ts
+++ b/packages/playwright-test/src/matchers/toBeTruthy.ts
@@ -24,7 +24,7 @@ export async function toBeTruthy(
   matcherName: string,
   receiver: any,
   receiverType: string,
-  query: (isNot: boolean, timeout: number) => Promise<{ pass: boolean, log?: string[] }>,
+  query: (isNot: boolean, timeout: number) => Promise<{ matches: boolean, log?: string[] }>,
   options: { timeout?: number } = {},
 ) {
   const testInfo = currentTestInfo();
@@ -42,11 +42,11 @@ export async function toBeTruthy(
     defaultExpectTimeout = 5000;
   const timeout = options.timeout === 0 ? 0 : options.timeout || defaultExpectTimeout;
 
-  const { pass, log } = await query(this.isNot, timeout);
+  const { matches, log } = await query(this.isNot, timeout);
 
   const message = () => {
     return this.utils.matcherHint(matcherName, undefined, '', matcherOptions) + callLogText(log);
   };
 
-  return { message, pass };
+  return { message, pass: matches };
 }

--- a/packages/playwright-test/src/matchers/toEqual.ts
+++ b/packages/playwright-test/src/matchers/toEqual.ts
@@ -31,7 +31,7 @@ export async function toEqual<T>(
   matcherName: string,
   receiver: any,
   receiverType: string,
-  query: (isNot: boolean, timeout: number) => Promise<{ pass: boolean, received?: any, log?: string[] }>,
+  query: (isNot: boolean, timeout: number) => Promise<{ matches: boolean, received?: any, log?: string[] }>,
   expected: T,
   options: { timeout?: number, contains?: boolean } = {},
 ) {
@@ -51,7 +51,8 @@ export async function toEqual<T>(
     defaultExpectTimeout = 5000;
   const timeout = options.timeout === 0 ? 0 : options.timeout || defaultExpectTimeout;
 
-  const { pass, received, log } = await query(this.isNot, timeout);
+  const { matches, received, log } = await query(this.isNot, timeout);
+  const pass = matches;
 
   const message = pass
     ? () =>

--- a/packages/playwright-test/src/matchers/toEqual.ts
+++ b/packages/playwright-test/src/matchers/toEqual.ts
@@ -51,8 +51,7 @@ export async function toEqual<T>(
     defaultExpectTimeout = 5000;
   const timeout = options.timeout === 0 ? 0 : options.timeout || defaultExpectTimeout;
 
-  const { matches, received, log } = await query(this.isNot, timeout);
-  const pass = matches;
+  const { matches: pass, received, log } = await query(this.isNot, timeout);
 
   const message = pass
     ? () =>

--- a/packages/playwright-test/src/matchers/toMatchText.ts
+++ b/packages/playwright-test/src/matchers/toMatchText.ts
@@ -31,7 +31,7 @@ export async function toMatchText(
   matcherName: string,
   receiver: any,
   receiverType: string,
-  query: (isNot: boolean, timeout: number) => Promise<{ pass: boolean, received?: string, log?: string[] }>,
+  query: (isNot: boolean, timeout: number) => Promise<{ matches: boolean, received?: string, log?: string[] }>,
   expected: string | RegExp,
   options: { timeout?: number, matchSubstring?: boolean } = {},
 ) {
@@ -65,7 +65,8 @@ export async function toMatchText(
     defaultExpectTimeout = 5000;
   const timeout = options.timeout === 0 ? 0 : options.timeout || defaultExpectTimeout;
 
-  const { pass, received, log } = await query(this.isNot, timeout);
+  const { matches, received, log } = await query(this.isNot, timeout);
+  const pass = matches;
   const stringSubstring = options.matchSubstring ? 'substring' : 'string';
   const receivedString = received || '';
   const message = pass

--- a/packages/playwright-test/src/matchers/toMatchText.ts
+++ b/packages/playwright-test/src/matchers/toMatchText.ts
@@ -65,8 +65,7 @@ export async function toMatchText(
     defaultExpectTimeout = 5000;
   const timeout = options.timeout === 0 ? 0 : options.timeout || defaultExpectTimeout;
 
-  const { matches, received, log } = await query(this.isNot, timeout);
-  const pass = matches;
+  const { matches: pass, received, log } = await query(this.isNot, timeout);
   const stringSubstring = options.matchSubstring ? 'substring' : 'string';
   const receivedString = received || '';
   const message = pass

--- a/tests/playwright-test/playwright.expect.text.spec.ts
+++ b/tests/playwright-test/playwright.expect.text.spec.ts
@@ -184,6 +184,12 @@ test('should support toHaveText w/ array', async ({ runInlineTest }) => {
         await expect(locator).not.toHaveText(['Test']);
       });
 
+      test('fail on not+empty', async ({ page }) => {
+        await page.setContent('<div></div>');
+        const locator = page.locator('p');
+        await expect(locator).not.toHaveText([], { timeout: 1000 });
+      });
+
       test('pass eventually empty', async ({ page }) => {
         await page.setContent('<div id=div><p>Text</p></div>');
         const locator = page.locator('p');
@@ -207,7 +213,7 @@ test('should support toHaveText w/ array', async ({ runInlineTest }) => {
   expect(output).toContain('waiting for selector "div"');
   expect(output).toContain('selector resolved to 2 elements');
   expect(result.passed).toBe(6);
-  expect(result.failed).toBe(1);
+  expect(result.failed).toBe(2);
   expect(result.exitCode).toBe(1);
 });
 


### PR DESCRIPTION
- Extract `pass: !options.isNot` logic to a single place.
- Return `matches` instead of `pass` everywhere.
- Always pass `omitAttached` and explicitly handle special cases.
- Extra tests.