### PR TITLE
chore: dont throw errors about deviceDescriptors.js on first watch

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -46,13 +46,17 @@ function filePath(relative) {
   return path.join(ROOT, ...relative.split('/'));
 }
 
-function runWatch() {
-  function runOnChanges(paths, nodeFile) {
+async function runWatch() {
+  function runOnChanges(paths, mustExist = [], nodeFile) {
     nodeFile = filePath(nodeFile);
     function callback() {
+      for (const fileMustExist of mustExist) {
+        if (!fs.existsSync(filePath(fileMustExist)))
+          return;
+      }
       child_process.spawnSync('node', [nodeFile], { stdio: 'inherit' });
     }
-    chokidar.watch([...paths, nodeFile].map(filePath)).on('all', callback);
+    chokidar.watch([...paths, ...mustExist, nodeFile].map(filePath)).on('all', callback);
     callback();
   }
 
@@ -72,7 +76,7 @@ function runWatch() {
     }));
   process.on('exit', () => spawns.forEach(s => s.kill()));
   for (const onChange of onChanges)
-    runOnChanges(onChange.inputs, onChange.script);
+    runOnChanges(onChange.inputs, onChange.mustExist, onChange.script);
 }
 
 async function runBuild() {
@@ -165,6 +169,10 @@ onChanges.push({
     'utils/generate_types/overrides-testReporter.d.ts',
     'utils/generate_types/exported.json',
     'packages/playwright-core/src/server/chromium/protocol.d.ts',
+  ],
+  mustExist: [
+    'packages/playwright-core/lib/server/deviceDescriptors.js',
+    'packages/playwright-core/lib/server/deviceDescriptorsSource.json',
   ],
   script: 'utils/generate_types/index.js',
 });


### PR DESCRIPTION
All of the watch steps run in parallel, but some depend on eachother.

`generate_types` tries to require deviceDescriptors.js, which is the output
of a copy command. This patch has it wait to run until the file exists, as well
as watching for updates to it.
