### PR TITLE
fix(build): don't compile our web files twice with babel

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -12,7 +12,6 @@
     "@babel/plugin-transform-modules-commonjs"
   ],
   "ignore": [
-    "**/*.d.ts",
-    "packages/playwright-core/src/injected/**/*"
+    "**/*.d.ts"
   ]
 }

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -138,7 +138,13 @@ for (const packageDir of packages) {
     continue;
   steps.push({
     command: 'npx',
-    args: ['babel', ...(watchMode ? ['-w', '--source-maps'] : []), '--extensions', '.ts', '--out-dir', path.join(packageDir, 'lib'), path.join(packageDir, 'src')],
+    args: [
+      'babel',
+      ...(watchMode ? ['-w', '--source-maps'] : []),
+      '--extensions', '.ts',
+      '--out-dir', path.join(packageDir, 'lib'),
+      '--ignore', 'packages/playwright-core/src/server/injected/**/*,packages/playwright-core/src/web/**/*',
+      path.join(packageDir, 'src')],
     shell: true,
   });
 }


### PR DESCRIPTION
The files that go into our webpack bundle were not properly ignored by the babel.config,
and so they were showing up twice in our package. Once as a bundle, and once as
separate files run through babel. Ignoring them in the config actually causes
webpack to ignore them as well, so I added them to the ignore inside build.js﻿
