### PR TITLE
Create `userDataDir` if it does not exist

### DIFF
--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -146,7 +146,11 @@ export abstract class BrowserType extends SdkObject {
     const artifactsDir = await fs.promises.mkdtemp(ARTIFACTS_FOLDER);
     tempDirectories.push(artifactsDir);
 
-    if (!userDataDir) {
+    if (userDataDir) {
+      // Firefox bails if the profile directory does not exist, Chrome creates it. We ensure consistent behavior here.
+      if (!await existsAsync(userDataDir))
+        await fs.promises.mkdir(userDataDir, { recursive: true, mode: 0o700 });
+    } else {
       userDataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), `playwright_${this._name}dev_profile-`));
       tempDirectories.push(userDataDir);
     }

--- a/tests/defaultbrowsercontext-2.spec.ts
+++ b/tests/defaultbrowsercontext-2.spec.ts
@@ -17,6 +17,7 @@
 
 import { playwrightTest as it, expect } from './config/browserTest';
 import fs from 'fs';
+import path from 'path';
 
 it('should support hasTouch option', async ({ server, launchPersistent }) => {
   const { page } = await launchPersistent({ hasTouch: true });
@@ -117,6 +118,13 @@ it('should restore state from userDataDir', async ({ browserType, browserOptions
   await page3.goto(server.EMPTY_PAGE);
   expect(await page3.evaluate(() => localStorage.hey)).not.toBe('hello');
   await browserContext3.close();
+});
+
+it('should create userDataDir if it does not exist', async ({ createUserDataDir, browserType, browserOptions }) => {
+  const userDataDir = path.join(await createUserDataDir(), 'nonexisting');
+  const context = await browserType.launchPersistentContext(userDataDir, browserOptions);
+  await context.close();
+  expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
 });
 
 it('should restore cookies from userDataDir', async ({ browserType, browserOptions,  server, createUserDataDir, platform, channel }) => {


### PR DESCRIPTION
### Problem Description

While Chromium creates `userDataDir` itself if it does not exist, Firefox decides to instead hang on startup:

`repro.js`
```
const { firefox } = require("playwright");

(async () => {
    await firefox.launchPersistentContext("/tmp/nonexistent", {});
})();
```
```
$ node repro.js
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^

browserType.launchPersistentContext: Timeout 30000ms exceeded.
=========================== logs ===========================
<launching> /root/.cache/ms-playwright/firefox-1295/firefox/firefox -no-remote -headless -profile /tmp/nonexistent -juggler-pipe about:blank
<launched> pid=18379
[pid=18379][err] *** You are running in headless mode.
[pid=18379][out] Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: Unable to open a connection to the X server (t=0.083725) [GFX1-]: glxtest: Unable to open a connection to the X server
[pid=18379][out] Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: Unable to open a connection to the X server (t=0.083725) |[1][GFX1-]: glxtest: libEGL initialize failed (t=0.0838034) [GFX1-]: glxtest: libEGL initialize failed
[pid=18379][err] JavaScript error: resource://gre/modules/XULStore.jsm, line 66: Error: Can't find profile directory.
[pid=18379][err] JavaScript error: resource://gre/modules/XULStore.jsm, line 66: Error: Can't find profile directory.
[pid=18379][err] JavaScript error: resource://gre/modules/XULStore.jsm, line 66: Error: Can't find profile directory.
[pid=18379][err] JavaScript error: resource://gre/modules/XULStore.jsm, line 66: Error: Can't find profile directory.
[pid=18379][err] JavaScript error: resource://gre/modules/XULStore.jsm, line 66: Error: Can't find profile directory.
============================================================
```

I first suspected the missing X server to be an issue, which sent me down quite a rabbit hole as it looked similar to #7110. It turns out the problem was just the missing directory. Long story short, playwright should handle this consistently, so we want to create userDataDir if it does not exist. 🙃

At this point I'm wondering if #7110 is actually the same issue and libpci is a red herring as well, but I get a slightly different glxtest error so I can't say for sure. 😄 