### PR TITLE
chore(webpack): fix watch for webpack 5

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -129,7 +129,7 @@ const webPackFiles = [
 for (const file of webPackFiles) {
   steps.push({
     command: 'npx',
-    args: ['webpack', '--config', filePath(file), ...(watchMode ? ['--watch', '--silent'] : [])],
+    args: ['webpack', '--config', filePath(file), ...(watchMode ? ['--watch', '--stats', 'none'] : [])],
     shell: true,
     env: {
       NODE_ENV: watchMode ? 'development' : 'production'


### PR DESCRIPTION
Webpack 5 does not have a `--silent` option anymore.﻿
