### PR TITLE
test: newContext works when both screen and viewport specified

### DIFF
--- a/tests/browsercontext-viewport.spec.ts
+++ b/tests/browsercontext-viewport.spec.ts
@@ -106,7 +106,7 @@ browserTest('should support touch with null viewport', async ({ browser, server 
 });
 
 it('should set both screen and viewport options', async ({ contextFactory, browserName }) => {
-  it.fail(browserName === 'firefox', 'Screen size is reset to viewport');
+  it.fail();
   const context = await contextFactory({
     screen: { 'width': 1280, 'height': 720 },
     viewport: { 'width': 1000, 'height': 600 },

--- a/tests/browsercontext-viewport.spec.ts
+++ b/tests/browsercontext-viewport.spec.ts
@@ -112,7 +112,6 @@ it('should set both screen and viewport options', async ({ contextFactory, brows
     viewport: { 'width': 1000, 'height': 600 },
   });
   const page = await context.newPage();
-  await page.setViewportSize({ 'width': 1000, 'height': 600 });
   const screen = await page.evaluate(() => ({ w: screen.width, h: screen.height }));
   expect(screen).toEqual({ w: 1280, h: 720 });
   const inner = await page.evaluate(() => ({ w: window.innerWidth, h: window.innerHeight }));

--- a/tests/browsercontext-viewport.spec.ts
+++ b/tests/browsercontext-viewport.spec.ts
@@ -105,6 +105,20 @@ browserTest('should support touch with null viewport', async ({ browser, server 
   await context.close();
 });
 
+it('should set both screen and viewport options', async ({ contextFactory, browserName }) => {
+  it.fail(browserName === 'firefox', 'Screen size is reset to viewport');
+  const context = await contextFactory({
+    screen: { 'width': 1280, 'height': 720 },
+    viewport: { 'width': 1000, 'height': 600 },
+  });
+  const page = await context.newPage();
+  await page.setViewportSize({ 'width': 1000, 'height': 600 });
+  const screen = await page.evaluate(() => ({ w: screen.width, h: screen.height }));
+  expect(screen).toEqual({ w: 1280, h: 720 });
+  const inner = await page.evaluate(() => ({ w: window.innerWidth, h: window.innerHeight }));
+  expect(inner).toEqual({ w: 1000, h: 600 });
+});
+
 browserTest('should report null viewportSize when given null viewport', async ({ browser, server }) => {
   const context = await browser.newContext({ viewport: null });
   const page = await context.newPage();

--- a/tests/browsercontext-viewport.spec.ts
+++ b/tests/browsercontext-viewport.spec.ts
@@ -106,7 +106,7 @@ browserTest('should support touch with null viewport', async ({ browser, server 
 });
 
 it('should set both screen and viewport options', async ({ contextFactory, browserName }) => {
-  it.fail();
+  it.fail(browserName === 'firefox', 'Screen size is reset to viewport');
   const context = await contextFactory({
     screen: { 'width': 1280, 'height': 720 },
     viewport: { 'width': 1000, 'height': 600 },


### PR DESCRIPTION
#9519