### PR TITLE
chore(codegen): use offsetX instead of clientX for positioned clicks

### DIFF
--- a/packages/playwright-core/src/server/supplements/injected/recorder.ts
+++ b/packages/playwright-core/src/server/supplements/injected/recorder.ts
@@ -572,10 +572,9 @@ function positionForEvent(event: MouseEvent): Point |undefined {
   const targetElement = (event.target as HTMLElement);
   if (targetElement.nodeName !== 'CANVAS')
     return;
-  const rect = targetElement.getBoundingClientRect();
   return {
-    x: event.clientX - rect.left,
-    y: event.clientY - rect.top,
+    x: event.offsetX,
+    y: event.offsetY,
   };
 }
 


### PR DESCRIPTION
Follow-up: #9503

Addressing https://github.com/microsoft/playwright/pull/9503#discussion_r729162057