### PR TITLE
fix(expect): do not rely on displayName

### DIFF
--- a/installation-tests/failing.spec.js
+++ b/installation-tests/failing.spec.js
@@ -1,0 +1,6 @@
+const { test, expect } = require('@playwright/test');
+
+test('failing test', async ({ page }) => {
+  await page.setContent(`<div>hello</div><span>world</span>`);
+  await expect(page.locator('span')).toHaveText('hello', { timeout: 1000 });
+});

--- a/packages/playwright-test/src/expect.ts
+++ b/packages/playwright-test/src/expect.ts
@@ -156,7 +156,7 @@ function wrap(matcherName: string, matcher: any) {
       reportStepError(e);
     }
   };
-  result.displayName = '__PWTRAP__[expect.' + matcherName + ']';
+  Object.defineProperty(result, 'name', { value: '__PWTRAP__[expect.' + matcherName + ']' });
   return result;
 }
 


### PR DESCRIPTION
Support for displayName was removed in Node 16. Switching to Function.name instead.

Added installation test to cover all node versions we care about.

Relevant V8 change: https://chromium-review.googlesource.com/c/v8/v8/+/2692189