### PR TITLE
fix: separate Selectors instance per Playwright object

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -27,6 +27,7 @@ import { assert, headersObjectToArray, getUserAgent, monotonicTime } from '../ut
 import * as api from '../../types/types';
 import { kBrowserClosedError } from '../utils/errors';
 import { raceAgainstDeadline } from '../utils/async';
+import type { Playwright } from './playwright';
 
 export interface BrowserServerLauncher {
   launchServer(options?: LaunchServerOptions): Promise<api.BrowserServer>;
@@ -43,6 +44,7 @@ export interface BrowserServer extends api.BrowserServer {
 export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, channels.BrowserTypeInitializer> implements api.BrowserType {
   _serverLauncher?: BrowserServerLauncher;
   _contexts = new Set<BrowserContext>();
+  _playwright!: Playwright;
 
   // Instrumentation.
   _defaultContextOptions: BrowserContextOptions = {};
@@ -52,10 +54,6 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, chann
 
   static from(browserType: channels.BrowserTypeChannel): BrowserType {
     return (browserType as any)._object;
-  }
-
-  constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.BrowserTypeInitializer) {
-    super(parent, type, guid, initializer);
   }
 
   executablePath(): string {
@@ -172,6 +170,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel, chann
             closePipe();
             return;
           }
+          playwright._setSelectors(this._playwright.selectors);
           browser = Browser.from(playwright._initializer.preLaunchedBrowser!);
           browser._logger = logger;
           browser._shouldCloseConnectionOnClose = true;

--- a/packages/playwright-core/src/client/selectors.ts
+++ b/packages/playwright-core/src/client/selectors.ts
@@ -50,5 +50,3 @@ export class SelectorsOwner extends ChannelOwner<channels.SelectorsChannel, chan
     return (browser as any)._object;
   }
 }
-
-export const sharedSelectors = new Selectors();


### PR DESCRIPTION
We used to share selectors for inprocess, remote and any internal playwright objects.