### PR TITLE
chore: move "service" mode tests to experimental grid

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -182,7 +182,6 @@ jobs:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
     - run: npx playwright install --with-deps chromium
-    - run: npx playwright experimental-grid-server &
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
       env:
         PWTEST_MODE: ${{ matrix.mode }}

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -182,6 +182,7 @@ jobs:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
     - run: npx playwright install --with-deps chromium
+    - run: npx playwright experimental-grid-server &
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
       env:
         PWTEST_MODE: ${{ matrix.mode }}

--- a/tests/config/default.config.ts
+++ b/tests/config/default.config.ts
@@ -60,6 +60,11 @@ const config: Config<CommonOptions & PlaywrightOptions> = {
     [ 'json', { outputFile: path.join(outputDir, 'report.json') } ],
   ] : 'line',
   projects: [],
+  webServer: mode === 'service' ? {
+    command: 'npx playwright experimental-grid-server',
+    port: 3333,
+    reuseExistingServer: true,
+  } : undefined,
 };
 
 const browserNames = ['chromium', 'webkit', 'firefox'] as BrowserName[];

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -23,6 +23,8 @@ import type { BrowserContext, BrowserContextOptions } from 'playwright-core';
 import type { AddressInfo } from 'net';
 import type { Log } from 'playwright-core/src/server/supplements/har/har';
 
+it.skip(({ mode }) => mode === 'service');
+
 async function pageWithHar(contextFactory: (options?: BrowserContextOptions) => Promise<BrowserContext>, testInfo: any, outputPath: string = 'test.har') {
   const harPath = testInfo.outputPath(outputPath);
   const context = await contextFactory({ recordHar: { path: harPath }, ignoreHTTPSErrors: true });

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -289,10 +289,12 @@ it('should throw if networkidle2 is passed as an option', async ({ page, server 
   expect(error.message).toContain(`waitUntil: expected one of (load|domcontentloaded|networkidle)`);
 });
 
-it('should fail when main resources failed to load', async ({ page, browserName, isWindows }) => {
+it('should fail when main resources failed to load', async ({ page, browserName, isWindows, mode }) => {
   let error = null;
   await page.goto('http://localhost:44123/non-existing-url').catch(e => error = e);
-  if (browserName === 'chromium')
+  if (mode === 'service')
+    expect(error.message).toContain('net::ERR_SOCKS_CONNECTION_FAILED');
+  else if (browserName === 'chromium')
     expect(error.message).toContain('net::ERR_CONNECTION_REFUSED');
   else if (browserName === 'webkit' && isWindows)
     expect(error.message).toContain(`Couldn\'t connect to server`);

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -18,6 +18,8 @@ import { playwrightTest as it, expect } from './config/browserTest';
 import socks from 'socksv5';
 import net from 'net';
 
+it.skip(({ mode }) => mode === 'service');
+
 it('should throw for bad server value', async ({ browserType, browserOptions }) => {
   const error = await browserType.launch({
     ...browserOptions,


### PR DESCRIPTION
This patch moves "service" mode tests to experimental
grid.
