### PR TITLE
(feat): Composition support for keyboard.imeSetComposition

### DIFF
--- a/docs/src/api/class-keyboard.md
+++ b/docs/src/api/class-keyboard.md
@@ -172,6 +172,71 @@ Modifier keys DO influence `keyboard.down`. Holding down `Shift` will type the t
 
 Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
 
+## async method: Keyboard.imeSetComposition
+
+If there is an active composition, it will update the composition. Otherwise it will start a new one. It will dispatch either
+a `compositionstart` or a `compositionupdate`. In order to cancel a composition: `keyboard.insertText('')`, and in order to commit/end a composition:
+`keyboard.insertText(<text to insert>)`.
+
+### param: Keyboard.imeSetComposition.text
+- `text` <[string]>
+
+Sets the text in the active composition
+
+### param: Keyboard.imeSetComposition.selectionStart
+- `selectionStart` <[int]>
+
+Sets the selection start of the focused element after the composition text is inserted. This is relatvie to the active composition,
+so if the text in the focused element is `abcd` but only `d` is part of the active composition, a selection start of `1` will set the
+selection start to be after `d`, which is absolute position `4`.
+
+### param: Keyboard.imeSetComposition.selectionEnd
+- `selectionEnd` <[int]>
+
+Sets the selection end of the focused element after the composition text is inserted. This is relatvie to the active composition,
+so if the text in the focused element is `abcd` but only `d` is part of the active composition, a selection end of `1` will set the
+selection end to be after `d`, which is absolute position `4`.
+
+### option: Keyboard.imeSetComposition.replacementStart
+- `replacementStart` <[int]>
+
+Sets the start position of the absolute range that is to be replaced with the composition text.
+
+
+### option: Keyboard.imeSetComposition.replacementEnd
+- `replacementEnd` <[int]>
+
+Sets the end position of the absolute range that is to be replaced with the composition text.
+
+
+```js
+const page = await browser.newPage();
+await page.goto('https://w3c.github.io/uievents/tools/key-event-viewer-ce.html');
+await page.focus('#input');
+await page.keyboard.imeSetComposition('ｓ', 1, 1);
+await page.keyboard.imeSetComposition('す', 1, 1);
+await browser.close();
+```
+
+
+```python async
+page = await browser.new_page()
+await page.goto("https://w3c.github.io/uievents/tools/key-event-viewer-ce.html")
+await page.focus("#input");
+await page.keyboard.imeSetComposition("ｓ", 1, 1)
+await page.keyboard.imeSetComposition("す", 1, 1)
+await browser.close()
+```
+
+```python sync
+page = browser.new_page()
+page.goto("https://w3c.github.io/uievents/tools/key-event-viewer-ce.html")
+page.focus("#input");
+page.keyboard.imeSetComposition("ｓ", 1, 1)
+page.keyboard.imeSetComposition("す", 1, 1)
+browser.close()
+```
+
 ## async method: Keyboard.insertText
 
 Dispatches only `input` event, does not emit the `keydown`, `keyup` or `keypress` events.

--- a/packages/playwright-core/src/client/input.ts
+++ b/packages/playwright-core/src/client/input.ts
@@ -40,9 +40,7 @@ export class Keyboard implements api.Keyboard {
 
   async imeSetComposition(text: string, selectionStart: number, selectionEnd: number,
     options: channels.PageKeyboardImeSetCompositionOptions) {
-    await this._page._wrapApiCall(async channel => {
-      await channel.keyboardImeSetComposition({ text, selectionStart, selectionEnd, ...options });
-    });
+    await this._page._channel.keyboardImeSetComposition({ text, selectionStart, selectionEnd, ...options });
   }
 
   async type(text: string, options: channels.PageKeyboardTypeOptions = {}) {

--- a/packages/playwright-core/src/client/input.ts
+++ b/packages/playwright-core/src/client/input.ts
@@ -38,6 +38,13 @@ export class Keyboard implements api.Keyboard {
     await this._page._channel.keyboardInsertText({ text });
   }
 
+  async imeSetComposition(text: string, selectionStart: number, selectionEnd: number,
+    options: channels.PageKeyboardImeSetCompositionOptions) {
+    await this._page._wrapApiCall(async channel => {
+      await channel.keyboardImeSetComposition({ text, selectionStart, selectionEnd, ...options });
+    });
+  }
+
   async type(text: string, options: channels.PageKeyboardTypeOptions = {}) {
     await this._page._channel.keyboardType({ text, ...options });
   }

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -1364,6 +1364,7 @@ export interface PageChannel extends PageEventTarget, EventTargetChannel {
   keyboardUp(params: PageKeyboardUpParams, metadata?: Metadata): Promise<PageKeyboardUpResult>;
   keyboardInsertText(params: PageKeyboardInsertTextParams, metadata?: Metadata): Promise<PageKeyboardInsertTextResult>;
   keyboardType(params: PageKeyboardTypeParams, metadata?: Metadata): Promise<PageKeyboardTypeResult>;
+  keyboardImeSetComposition(params: PageKeyboardImeSetCompositionParams, metadata?: Metadata): Promise<PageKeyboardImeSetCompositionResult>;
   keyboardPress(params: PageKeyboardPressParams, metadata?: Metadata): Promise<PageKeyboardPressResult>;
   mouseMove(params: PageMouseMoveParams, metadata?: Metadata): Promise<PageMouseMoveResult>;
   mouseDown(params: PageMouseDownParams, metadata?: Metadata): Promise<PageMouseDownResult>;
@@ -1662,6 +1663,18 @@ export type PageKeyboardTypeOptions = {
   delay?: number,
 };
 export type PageKeyboardTypeResult = void;
+export type PageKeyboardImeSetCompositionParams = {
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+  replacementStart?: number,
+  replacementEnd?: number,
+};
+export type PageKeyboardImeSetCompositionOptions = {
+  replacementStart?: number,
+  replacementEnd?: number,
+};
+export type PageKeyboardImeSetCompositionResult = void;
 export type PageKeyboardPressParams = {
   key: string,
   delay?: number,

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -1129,6 +1129,14 @@ Page:
       tracing:
         snapshot: true
 
+    keyboardImeSetComposition:
+      parameters:
+        text: string
+        selectionStart: number
+        selectionEnd: number
+        replacementStart: number?
+        replacementEnd: number?
+
     keyboardPress:
       parameters:
         key: string

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -617,6 +617,13 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     text: tString,
     delay: tOptional(tNumber),
   });
+  scheme.PageKeyboardImeSetCompositionParams = tObject({
+    text: tString,
+    selectionStart: tNumber,
+    selectionEnd: tNumber,
+    replacementStart: tOptional(tNumber),
+    replacementEnd: tOptional(tNumber),
+  });
   scheme.PageKeyboardPressParams = tObject({
     key: tString,
     delay: tOptional(tNumber),

--- a/packages/playwright-core/src/server/chromium/crInput.ts
+++ b/packages/playwright-core/src/server/chromium/crInput.ts
@@ -83,6 +83,13 @@ export class RawKeyboardImpl implements input.RawKeyboard {
   async sendText(text: string): Promise<void> {
     await this._client.send('Input.insertText', { text });
   }
+
+  async imeSetComposition(text: string, selectionStart: number, selectionEnd: number, replacementStart: number | -1, replacementEnd: number | -1): Promise<void> {
+    if (replacementStart === -1 && replacementEnd === -1)
+      await this._client.send('Input.imeSetComposition', { text, selectionStart, selectionEnd });
+    else
+      await this._client.send('Input.imeSetComposition', { text, selectionStart, selectionEnd, replacementStart, replacementEnd });
+  }
 }
 
 export class RawMouseImpl implements input.RawMouse {

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -212,6 +212,10 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel> imple
     await this._page.keyboard.up(params.key);
   }
 
+  async keyboardImeSetComposition(params: channels.PageKeyboardImeSetCompositionParams, metadata: CallMetadata): Promise<void> {
+    await this._page.keyboard.imeSetComposition(params.text, params.selectionStart, params.selectionEnd, params);
+  }
+
   async keyboardInsertText(params: channels.PageKeyboardInsertTextParams, metadata: CallMetadata): Promise<void> {
     await this._page.keyboard.insertText(params.text);
   }

--- a/packages/playwright-core/src/server/firefox/ffInput.ts
+++ b/packages/playwright-core/src/server/firefox/ffInput.ts
@@ -98,6 +98,13 @@ export class RawKeyboardImpl implements input.RawKeyboard {
   async sendText(text: string): Promise<void> {
     await this._client.send('Page.insertText', { text });
   }
+
+  async imeSetComposition(text: string, selectionStart: number, selectionEnd: number, replacementStart: number | -1, replacementEnd: number | -1): Promise<void> {
+    if (replacementStart === -1 && replacementEnd === -1)
+      await this._client.send('Page.setComposition', { text, selectionStart, selectionEnd });
+    else
+      await this._client.send('Page.setComposition', { text, selectionStart, selectionEnd, replacementStart, replacementEnd });
+  }
 }
 
 export class RawMouseImpl implements input.RawMouse {

--- a/packages/playwright-core/src/server/firefox/protocol.d.ts
+++ b/packages/playwright-core/src/server/firefox/protocol.d.ts
@@ -672,6 +672,30 @@ export module Protocol {
       text: string;
     };
     export type insertTextReturnValue = void;
+    export type setCompositionParameters = {
+      /**
+       * The text to insert
+       */
+      text: string;
+      /**
+       * selection start
+       */
+      selectionStart: number;
+      /**
+       * selection end
+       */
+      selectionEnd: number;
+      /**
+       * replacement start
+       */
+      replacementStart?: number;
+      /**
+       * replacement end
+       */
+      replacementEnd?: number;
+    }
+    export type setCompositionReturnValue = {
+    }
     export type crashParameters = {
     };
     export type crashReturnValue = void;
@@ -1131,6 +1155,7 @@ export module Protocol {
     "Page.dispatchMouseEvent": Page.dispatchMouseEventParameters;
     "Page.dispatchWheelEvent": Page.dispatchWheelEventParameters;
     "Page.insertText": Page.insertTextParameters;
+    "Page.setComposition": Page.setCompositionParameters;
     "Page.crash": Page.crashParameters;
     "Page.handleDialog": Page.handleDialogParameters;
     "Page.setInterceptFileChooserDialog": Page.setInterceptFileChooserDialogParameters;
@@ -1210,6 +1235,7 @@ export module Protocol {
     "Page.dispatchMouseEvent": Page.dispatchMouseEventReturnValue;
     "Page.dispatchWheelEvent": Page.dispatchWheelEventReturnValue;
     "Page.insertText": Page.insertTextReturnValue;
+    "Page.setComposition": Page.setCompositionReturnValue;
     "Page.crash": Page.crashReturnValue;
     "Page.handleDialog": Page.handleDialogReturnValue;
     "Page.setInterceptFileChooserDialog": Page.setInterceptFileChooserDialogReturnValue;

--- a/packages/playwright-core/src/server/input.ts
+++ b/packages/playwright-core/src/server/input.ts
@@ -37,6 +37,7 @@ export interface RawKeyboard {
   keydown(modifiers: Set<types.KeyboardModifier>, code: string, keyCode: number, keyCodeWithoutLocation: number, key: string, location: number, autoRepeat: boolean, text: string | undefined): Promise<void>;
   keyup(modifiers: Set<types.KeyboardModifier>, code: string, keyCode: number, keyCodeWithoutLocation: number, key: string, location: number): Promise<void>;
   sendText(text: string): Promise<void>;
+  imeSetComposition(text: string, selectionStart: number, selectionEnd: number, replacementStart: number | -1, replacementEnd: number | -1): Promise<void>;
 }
 
 export class Keyboard {
@@ -84,6 +85,17 @@ export class Keyboard {
 
   async insertText(text: string) {
     await this._raw.sendText(text);
+    await this._page._doSlowMo();
+  }
+
+  async imeSetComposition(text: string, selectionStart: number, selectionEnd: number, options?: { replacementStart?: number, replacementEnd?: number}) {
+    let replacementStart = -1;
+    let replacementEnd = -1;
+    if (options && options.replacementStart !== undefined)
+      replacementStart = options.replacementStart;
+    if (options && options.replacementEnd !== undefined)
+      replacementEnd = options.replacementEnd;
+    await this._raw.imeSetComposition(text, selectionStart, selectionEnd, replacementStart, replacementEnd);
     await this._page._doSlowMo();
   }
 

--- a/packages/playwright-core/src/server/webkit/protocol.d.ts
+++ b/packages/playwright-core/src/server/webkit/protocol.d.ts
@@ -6873,6 +6873,8 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     }
     export type insertTextReturnValue = {
     }
+    export type setCompositionReturnValue = {
+    }
     /**
      * Set the current IME composition.
      */
@@ -6882,8 +6884,6 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
       selectionLength: number;
       replacementStart?: number;
       replacementLength?: number;
-    }
-    export type setCompositionReturnValue = {
     }
     /**
      * Serializes and returns all of the accessibility nodes of the page.

--- a/packages/playwright-core/src/server/webkit/wkInput.ts
+++ b/packages/playwright-core/src/server/webkit/wkInput.ts
@@ -98,6 +98,16 @@ export class RawKeyboardImpl implements input.RawKeyboard {
   async sendText(text: string): Promise<void> {
     await this._session!.send('Page.insertText', { text });
   }
+
+  async imeSetComposition(text: string, selectionStart: number, selectionEnd: number, replacementStart: number | -1, replacementEnd: number | -1): Promise<void> {
+    const selectionLength = selectionEnd - selectionStart;
+    if (replacementStart === -1 && replacementEnd === -1) {
+      await this._session!.send('Page.setComposition', { text, selectionStart, selectionLength });
+    } else {
+      const replacementLength = replacementEnd - replacementStart;
+      await this._session!.send('Page.setComposition', { text, selectionStart, selectionLength, replacementStart, replacementLength });
+    }
+  }
 }
 
 export class RawMouseImpl implements input.RawMouse {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14028,6 +14028,39 @@ export interface Keyboard {
   down(key: string): Promise<void>;
 
   /**
+   * If there is an active composition, it will update the composition. Otherwise it will start a new one. It will dispatch
+   * either a `compositionstart` or a `compositionupdate`. In order to cancel a composition: `keyboard.insertText('')`, and
+   * in order to commit/end a composition: `keyboard.insertText(<text to insert>)`.
+   * @param text Sets the text in the active composition
+   * @param selectionStart Sets the selection start of the focused element after the composition text is inserted. This is relatvie to the active composition, so if the text in the focused element is `abcd` but only `d` is part of the active composition, a selection
+   * start of `1` will set the selection start to be after `d`, which is absolute position `4`.
+   * @param selectionEnd Sets the selection end of the focused element after the composition text is inserted. This is relatvie to the active composition, so if the text in the focused element is `abcd` but only `d` is part of the active composition, a selection
+   * end of `1` will set the selection end to be after `d`, which is absolute position `4`.
+   * @param options
+   */
+  imeSetComposition(text: string, selectionStart: number, selectionEnd: number, options?: {
+    /**
+     * Sets the end position of the absolute range that is to be replaced with the composition text.
+     *
+     * ```js
+     * const page = await browser.newPage();
+     * await page.goto('https://w3c.github.io/uievents/tools/key-event-viewer-ce.html');
+     * await page.focus('#input');
+     * await page.keyboard.imeSetComposition('ｓ', 1, 1);
+     * await page.keyboard.imeSetComposition('す', 1, 1);
+     * await browser.close();
+     * ```
+     *
+     */
+    replacementEnd?: number;
+
+    /**
+     * Sets the start position of the absolute range that is to be replaced with the composition text.
+     */
+    replacementStart?: number;
+  }): Promise<void>;
+
+  /**
    * Dispatches only `input` event, does not emit the `keydown`, `keyup` or `keypress` events.
    *
    * ```js

--- a/tests/config/experimental.d.ts
+++ b/tests/config/experimental.d.ts
@@ -14030,6 +14030,39 @@ export interface Keyboard {
   down(key: string): Promise<void>;
 
   /**
+   * If there is an active composition, it will update the composition. Otherwise it will start a new one. It will dispatch
+   * either a `compositionstart` or a `compositionupdate`. In order to cancel a composition: `keyboard.insertText('')`, and
+   * in order to commit/end a composition: `keyboard.insertText(<text to insert>)`.
+   * @param text Sets the text in the active composition
+   * @param selectionStart Sets the selection start of the focused element after the composition text is inserted. This is relatvie to the active composition, so if the text in the focused element is `abcd` but only `d` is part of the active composition, a selection
+   * start of `1` will set the selection start to be after `d`, which is absolute position `4`.
+   * @param selectionEnd Sets the selection end of the focused element after the composition text is inserted. This is relatvie to the active composition, so if the text in the focused element is `abcd` but only `d` is part of the active composition, a selection
+   * end of `1` will set the selection end to be after `d`, which is absolute position `4`.
+   * @param options
+   */
+  imeSetComposition(text: string, selectionStart: number, selectionEnd: number, options?: {
+    /**
+     * Sets the end position of the absolute range that is to be replaced with the composition text.
+     *
+     * ```js
+     * const page = await browser.newPage();
+     * await page.goto('https://w3c.github.io/uievents/tools/key-event-viewer-ce.html');
+     * await page.focus('#input');
+     * await page.keyboard.imeSetComposition('ｓ', 1, 1);
+     * await page.keyboard.imeSetComposition('す', 1, 1);
+     * await browser.close();
+     * ```
+     *
+     */
+    replacementEnd?: number;
+
+    /**
+     * Sets the start position of the absolute range that is to be replaced with the composition text.
+     */
+    replacementStart?: number;
+  }): Promise<void>;
+
+  /**
    * Dispatches only `input` event, does not emit the `keydown`, `keyup` or `keypress` events.
    *
    * ```js


### PR DESCRIPTION
Notes:
- Based off the work from https://github.com/microsoft/playwright/pull/7487. 
- Related feature thread: #5777
- Chromium changes have already been merged: https://chromium-review.googlesource.com/c/chromium/src/+/3009937

This PR implements the keyboard composition API `keyboard.imeSetComposition`. This makes it possible to test low-level IME related composition interactions.

Example:

```js
  await page.focus('textarea');
  await page.keyboard.imeSetComposition('ｓ', 1, 1);
  await page.keyboard.imeSetComposition('す', 1, 1);
  await page.keyboard.imeSetComposition('すｓ', 2, 2);
  await page.keyboard.imeSetComposition('すｓｈ', 3, 3);
  await page.keyboard.imeSetComposition('すし', 2, 2);
  await page.keyboard.insertText('すし');
```

You might be wondering what, what about triggering of keyboard events such as `keyboard.up`, `keyboard.press`, `keyboard.down` etc, Rather than couple this PR with other discussions (see https://github.com/microsoft/playwright/pull/7659) I think this can be worked on separately. Having `imeSetComposition` available sooner will be invaluable right now and help inform us of the discussions around how key events should work, and what their API should be.