### PR TITLE
Fix typo: afterEach runs AFTER not before

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -72,7 +72,7 @@ Hook function that takes one or two arguments: an object with fixtures and optio
 
 ## method: Test.afterEach
 
-Declares an `afterEach` hook that is executed after each test. When called in the scope of a test file, runs before each test in the file. When called inside a [`method: Test.describe`] group, runs before each test in the group.
+Declares an `afterEach` hook that is executed after each test. When called in the scope of a test file, runs after each test in the file. When called inside a [`method: Test.describe`] group, runs after each test in the group.
 
 ### param: Test.afterEach.hookFunction
 - `hookFunction` <[function]\([Fixtures], [TestInfo]\)>

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -2173,9 +2173,9 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    */
   beforeEach(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   /**
-   * Declares an `afterEach` hook that is executed after each test. When called in the scope of a test file, runs before each
+   * Declares an `afterEach` hook that is executed after each test. When called in the scope of a test file, runs after each
    * test in the file. When called inside a
-   * [test.describe(title, callback)](https://playwright.dev/docs/api/class-test#test-describe) group, runs before each test
+   * [test.describe(title, callback)](https://playwright.dev/docs/api/class-test#test-describe) group, runs after each test
    * in the group.
    * @param hookFunction Hook function that takes one or two arguments: an object with fixtures and optional [TestInfo].
    */


### PR DESCRIPTION
This looks like a typo in the docs. I assume that afterEach runs after each test. If this is intentionally "before", then some docs to clarify that would be helpful instead.