### PR TITLE
fix(monorepo): explicitly list package.json exports instead of using glob patterns

### DIFF
--- a/install-from-github.js
+++ b/install-from-github.js
@@ -31,7 +31,7 @@ try {
 }
 
 console.log(`Downloading browsers...`);
-const { installDefaultBrowsersForNpmInstall } = require('./packages/playwright-core/lib/utils/registry');
+const { installDefaultBrowsersForNpmInstall } = require('playwright-core/src/utils/registry');
 installDefaultBrowsersForNpmInstall().catch(e => {
   console.error(`Failed to install browsers, caused by\n${e.stack}`);
   process.exit(1);

--- a/installation-tests/driver-client.js
+++ b/installation-tests/driver-client.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const { start } = require('playwright-core/lib/outofprocess');
+const { start } = require('node_modules/playwright-core/lib/outofprocess');
 
 (async () => {
   const playwright = await start();

--- a/installation-tests/esm-playwright-chromium.mjs
+++ b/installation-tests/esm-playwright-chromium.mjs
@@ -16,7 +16,6 @@
 
 import { chromium, firefox, webkit, selectors, devices, errors } from 'playwright-chromium';
 import playwright from 'playwright-chromium';
-import errorsFile from 'playwright-core/lib/utils/errors';
 
 import testESM from './esm.mjs';
-testESM({ chromium, firefox, webkit, selectors, devices, errors, playwright, errorsFile }, [chromium]);
+testESM({ chromium, firefox, webkit, selectors, devices, errors, playwright }, [chromium]);

--- a/installation-tests/esm.mjs
+++ b/installation-tests/esm.mjs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export default async function testESM({ chromium, firefox, webkit, selectors, devices, errors, playwright, errorsFile }, browsers) {
+export default async function testESM({ chromium, firefox, webkit, selectors, devices, errors, playwright }, browsers) {
   if (playwright.chromium !== chromium)
     process.exit(1);
   if (playwright.firefox !== firefox)
@@ -22,8 +22,6 @@ export default async function testESM({ chromium, firefox, webkit, selectors, de
   if (playwright.webkit !== webkit)
     process.exit(1);
   if (playwright.errors !== errors)
-    process.exit(1);
-  if (errors.TimeoutError !== errorsFile.TimeoutError)
     process.exit(1);
 
   try {

--- a/installation-tests/sanity.js
+++ b/installation-tests/sanity.js
@@ -31,9 +31,6 @@ else if (process.argv[3])
 
 const playwright = require(requireName);
 
-// Requiring internals should work.
-const registry = require('playwright-core/src/utils/registry');
-
 (async () => {
   for (const browserType of success) {
     try {

--- a/installation-tests/sanity.js
+++ b/installation-tests/sanity.js
@@ -32,8 +32,7 @@ else if (process.argv[3])
 const playwright = require(requireName);
 
 // Requiring internals should work.
-const errors = require('playwright-core/lib/utils/errors');
-const registry = require('playwright-core/lib/utils/registry');
+const registry = require('playwright-core/src/utils/registry');
 
 (async () => {
   for (const browserType of success) {

--- a/packages/playwright-chromium/install.js
+++ b/packages/playwright-chromium/install.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-const { installBrowsersForNpmInstall } = require('playwright-core/lib/utils/registry');
+const { installBrowsersForNpmInstall } = require('playwright-core/src/utils/registry');
 
 installBrowsersForNpmInstall(['chromium', 'ffmpeg']);

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -19,8 +19,12 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./src/*": "./lib/*.js",
-    "./*": "./*.js"
+    "./src/grid/gridClient": "./lib/grid/gridClient.js",
+    "./src/utils/async": "./lib/utils/async.js",
+    "./src/utils/httpServer": "./lib/utils/httpServer.js",
+    "./src/utils/processLauncher": "./lib/utils/processLauncher.js",
+    "./src/utils/registry": "./lib/utils/registry.js",
+    "./src/utils/utils": "./lib/utils/utils.js"
   },
   "types": "types/types.d.ts",
   "bin": {

--- a/packages/playwright-firefox/install.js
+++ b/packages/playwright-firefox/install.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-const { installBrowsersForNpmInstall } = require('playwright-core/lib/utils/registry');
+const { installBrowsersForNpmInstall } = require('playwright-core/src/utils/registry');
 
 installBrowsersForNpmInstall(['firefox']);

--- a/packages/playwright-test/index.js
+++ b/packages/playwright-test/index.js
@@ -15,7 +15,7 @@
  */
 
 const pwt = require('./lib/index');
-const playwright = require('playwright-core/lib/inprocess');
+const playwright = require('playwright-core');
 const combinedExports = {
   ...playwright,
   ...pwt,

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -127,7 +127,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerAndFileFixtures>({
       await use(gridClient.playwright() as any);
       await gridClient.close();
     } else {
-      await use(require('playwright-core/lib/inprocess'));
+      await use(require('playwright-core'));
     }
   }, { scope: 'worker' } ],
   headless: [ undefined, { scope: 'worker' } ],

--- a/packages/playwright-webkit/install.js
+++ b/packages/playwright-webkit/install.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-const { installBrowsersForNpmInstall } = require('playwright-core/lib/utils/registry');
+const { installBrowsersForNpmInstall } = require('playwright-core/src/utils/registry');
 
 installBrowsersForNpmInstall(['webkit']);

--- a/packages/playwright/install.js
+++ b/packages/playwright/install.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-const { installDefaultBrowsersForNpmInstall } = require('playwright-core/lib/utils/registry');
+const { installDefaultBrowsersForNpmInstall } = require('playwright-core/src/utils/registry');
 
 installDefaultBrowsersForNpmInstall();

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -15,8 +15,7 @@
     ".": {
       "import": "./index.mjs",
       "require": "./index.js"
-    },
-    "./": "./"
+    }
   },
   "scripts": {
     "install": "node install.js"

--- a/tests/browsertype-connect.spec.ts
+++ b/tests/browsertype-connect.spec.ts
@@ -18,7 +18,7 @@
 import { playwrightTest as test, expect } from './config/browserTest';
 import fs from 'fs';
 import * as path from 'path';
-import { getUserAgent } from 'playwright-core/lib/utils/utils';
+import { getUserAgent } from 'playwright-core/src/utils/utils';
 import WebSocket from 'ws';
 import { suppressCertificateWarning } from './config/utils';
 

--- a/tests/browsertype-launch-selenium.spec.ts
+++ b/tests/browsertype-launch-selenium.spec.ts
@@ -18,7 +18,7 @@ import { playwrightTest as test, expect } from './config/browserTest';
 import type { TestInfo } from '@playwright/test';
 import path from 'path';
 import fs from 'fs';
-import { start } from 'playwright-core/lib/outofprocess';
+import { start } from '../packages/playwright-core/lib/outofprocess';
 
 const chromeDriver = require('chromedriver').path;
 const brokenDriver = path.join(__dirname, 'assets', 'selenium-grid', 'broken-selenium-driver.js');

--- a/tests/chromium/chromium.spec.ts
+++ b/tests/chromium/chromium.spec.ts
@@ -18,7 +18,7 @@
 import { contextTest as test, expect } from '../config/browserTest';
 import { playwrightTest } from '../config/browserTest';
 import http from 'http';
-import { getUserAgent } from 'playwright-core/lib/utils/utils';
+import { getUserAgent } from 'playwright-core/src/utils/utils';
 import { suppressCertificateWarning } from '../config/utils';
 
 test('should create a worker from a service worker', async ({ page, server }) => {

--- a/tests/component-parser.spec.ts
+++ b/tests/component-parser.spec.ts
@@ -15,7 +15,8 @@
  */
 
 import { playwrightTest as it, expect } from './config/browserTest';
-import { parseComponentSelector, ParsedComponentSelector } from 'playwright-core/lib/server/common/componentUtils';
+import type { ParsedComponentSelector } from '../packages/playwright-core/src/server/common/componentUtils';
+import { parseComponentSelector } from '../packages/playwright-core/lib/server/common/componentUtils';
 
 const parse = parseComponentSelector;
 const serialize = (parsed: ParsedComponentSelector) => {

--- a/tests/config/baseTest.ts
+++ b/tests/config/baseTest.ts
@@ -18,7 +18,7 @@ import { Fixtures, _baseTest } from '@playwright/test';
 import * as path from 'path';
 import * as fs from 'fs';
 import { installCoverageHooks } from './coverage';
-import { start } from 'playwright-core/lib/outofprocess';
+import { start } from '../../packages/playwright-core/lib/outofprocess';
 import { GridClient } from 'playwright-core/src/grid/gridClient';
 import type { LaunchOptions } from 'playwright-core';
 import { commonFixtures, CommonFixtures, serverFixtures, ServerFixtures, ServerOptions } from './commonFixtures';
@@ -91,7 +91,7 @@ const baseFixtures: Fixtures<{}, BaseOptions & BaseFixtures> = {
       service: new ServiceMode(),
       driver: new DriverMode(),
     }[mode];
-    require('playwright-core/lib/utils/utils').setUnderTest();
+    require('playwright-core/src/utils/utils').setUnderTest();
     const playwright = await modeImpl.setup(workerInfo.workerIndex);
     await run(playwright);
     await modeImpl.teardown();

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -24,7 +24,7 @@ import * as os from 'os';
 import { RemoteServer, RemoteServerOptions } from './remoteServer';
 import { baseTest, CommonWorkerFixtures } from './baseTest';
 import { CommonFixtures } from './commonFixtures';
-import { ParsedStackTrace } from 'playwright-core/src/utils/stackTrace';
+import type { ParsedStackTrace } from 'playwright-core/src/utils/stackTrace';
 
 type PlaywrightWorkerOptions = {
   executablePath: LaunchOptions['executablePath'];

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -16,7 +16,7 @@
 
 import type { Fixtures } from '@playwright/test';
 import type { Browser, BrowserContext, BrowserContextOptions, BrowserType, LaunchOptions, Page } from 'playwright-core';
-import { removeFolders } from 'playwright-core/lib/utils/utils';
+import { removeFolders } from 'playwright-core/src/utils/utils';
 import { ReuseBrowserContextStorage } from '@playwright/test/src/index';
 import * as path from 'path';
 import * as fs from 'fs';

--- a/tests/config/coverage.js
+++ b/tests/config/coverage.js
@@ -63,8 +63,8 @@ function traceAPICoverage(apiCoverage, api, events) {
  * @param {string} browserName
  */
 function apiForBrowser(browserName) {
-  const events = require('playwright-core/lib/client/events').Events;
-  const api = require('playwright-core/lib/client/api');
+  const events = require('../../packages/playwright-core/lib/client/events').Events;
+  const api = require('../../packages/playwright-core/lib/client/api');
   const otherBrowsers = ['chromium', 'webkit', 'firefox'].filter(name => name.toLowerCase() !== browserName.toLowerCase());
   const filteredKeys = Object.keys(api).filter(apiName => {
     if (apiName.toLowerCase().startsWith('android'))

--- a/tests/css-parser.spec.ts
+++ b/tests/css-parser.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { playwrightTest as it, expect } from './config/browserTest';
-import { parseCSS, serializeSelector as serialize } from 'playwright-core/lib/server/common/cssParser';
+import { parseCSS, serializeSelector as serialize } from '../packages/playwright-core/lib/server/common/cssParser';
 
 const parse = (selector: string) => {
   return parseCSS(selector, new Set(['text', 'not', 'has', 'react', 'scope', 'right-of', 'is'])).selector;

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import http from 'http';
-import { getPlaywrightVersion } from 'playwright-core/lib/utils/utils';
+import { getPlaywrightVersion } from 'playwright-core/src/utils/utils';
 import { expect, playwrightTest as it } from './config/browserTest';
 
 it.skip(({ mode }) => mode !== 'default');

--- a/tests/inspector/inspectorTest.ts
+++ b/tests/inspector/inspectorTest.ts
@@ -28,7 +28,7 @@ type CLITestArgs = {
   runCLI: (args: string[]) => CLIMock;
 };
 
-const playwrightToAutomateInspector = require('playwright-core/lib/inProcessFactory').createInProcessPlaywright();
+const playwrightToAutomateInspector = require('../../packages/playwright-core/lib/inProcessFactory').createInProcessPlaywright();
 
 export const test = contextTest.extend<CLITestArgs>({
   recorderPageGetter: async ({ context, toImpl, mode }, run, testInfo) => {

--- a/tests/launcher.spec.ts
+++ b/tests/launcher.spec.ts
@@ -17,15 +17,12 @@
 
 import { playwrightTest as it, expect } from './config/browserTest';
 
-it('should require top-level Errors', async ({}) => {
-  const Errors = require('playwright-core/lib/utils/errors');
-  expect(String(Errors.TimeoutError)).toContain('TimeoutError');
+it('should have an errors object', async ({ playwright }) => {
+  expect(String(playwright.errors.TimeoutError)).toContain('TimeoutError');
 });
 
-it('should require top-level DeviceDescriptors', async ({ playwright }) => {
-  const Devices = require('playwright-core/lib/server/deviceDescriptors');
-  expect(Devices['iPhone 6']).toBeTruthy();
-  expect(Devices['iPhone 6']).toEqual(playwright.devices['iPhone 6']);
+it('should have a devices object', async ({ playwright }) => {
+  expect(playwright.devices['iPhone 6']).toBeTruthy();
   expect(playwright.devices['iPhone 6'].defaultBrowserType).toBe('webkit');
 });
 

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { test as it, expect } from './pageTest';
-import { globToRegex } from 'playwright-core/lib/client/clientHelper';
+import { globToRegex } from '../../packages/playwright-core/lib/client/clientHelper';
 import vm from 'vm';
 
 it('should work with navigation', async ({ page, server }) => {

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -18,7 +18,7 @@ import { test, expect, stripAscii } from './playwright-test-fixtures';
 import fs from 'fs';
 import path from 'path';
 import { spawnSync } from 'child_process';
-import { registry } from 'playwright-core/lib/utils/registry';
+import { registry } from 'playwright-core/src/utils/registry';
 
 const ffmpeg = registry.findExecutable('ffmpeg')!.executablePath();
 

--- a/tests/port-forwarding-server.spec.ts
+++ b/tests/port-forwarding-server.spec.ts
@@ -20,7 +20,7 @@ import path from 'path';
 import net from 'net';
 
 import { contextTest, expect } from './config/browserTest';
-import { PlaywrightClient } from 'playwright-core/lib/remote/playwrightClient';
+import { PlaywrightClient } from '../packages/playwright-core/lib/remote/playwrightClient';
 import type { Page } from 'playwright-core';
 
 class OutOfProcessPlaywrightServer {

--- a/tests/snapshotter.spec.ts
+++ b/tests/snapshotter.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { contextTest, expect } from './config/browserTest';
-import { InMemorySnapshotter } from 'playwright-core/lib/web/traceViewer/inMemorySnapshotter';
+import { InMemorySnapshotter } from '../packages/playwright-core/lib/web/traceViewer/inMemorySnapshotter';
 
 const it = contextTest.extend<{ snapshotter: InMemorySnapshotter }>({
   snapshotter: async ({ mode, toImpl, context }, run, testInfo) => {

--- a/tests/trace-viewer/trace-viewer.spec.ts
+++ b/tests/trace-viewer/trace-viewer.spec.ts
@@ -16,7 +16,7 @@
 
 import path from 'path';
 import type { Browser, Frame, Locator, Page } from 'playwright-core';
-import { showTraceViewer } from 'playwright-core/lib/server/trace/viewer/traceViewer';
+import { showTraceViewer } from '../../packages/playwright-core/lib/server/trace/viewer/traceViewer';
 import { playwrightTest, expect } from '../config/browserTest';
 
 class TraceViewerPage {

--- a/tests/tracing.spec.ts
+++ b/tests/tracing.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { expect, contextTest as test, browserTest } from './config/browserTest';
-import { ZipFileSystem } from 'playwright-core/lib/utils/vfs';
+import { ZipFileSystem } from '../packages/playwright-core/lib/utils/vfs';
 import jpeg from 'jpeg-js';
 
 test.skip(({ trace }) => !!trace);

--- a/tests/video.spec.ts
+++ b/tests/video.spec.ts
@@ -19,7 +19,7 @@ import fs from 'fs';
 import path from 'path';
 import { spawnSync } from 'child_process';
 import { PNG } from 'pngjs';
-import { registry } from 'playwright-core/lib/utils/registry';
+import { registry } from 'playwright-core/src/utils/registry';
 
 const ffmpeg = registry.findExecutable('ffmpeg')!.executablePath();
 

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -18,7 +18,7 @@
 const path = require('path');
 const os = require('os');
 const toKebabCase = require('lodash/kebabCase')
-const devices = require('playwright-core/lib/server/deviceDescriptors');
+const devices = require('../../packages/playwright-core/lib/server/deviceDescriptors');
 const Documentation = require('../doclint/documentation');
 const PROJECT_DIR = path.join(__dirname, '..', '..');
 const fs = require('fs');

--- a/utils/linux-browser-dependencies/inside_docker/list_dependencies.js
+++ b/utils/linux-browser-dependencies/inside_docker/list_dependencies.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const util = require('util');
 const path = require('path');
 const {spawn} = require('child_process');
-const {registryDirectory} = require('playwright-core/lib/utils/registry.js');
+const {registryDirectory} = require('playwright-core/src/utils/registry.js');
 
 const readdirAsync = util.promisify(fs.readdir.bind(fs));
 const readFileAsync = util.promisify(fs.readFile.bind(fs));

--- a/utils/roll_browser.js
+++ b/utils/roll_browser.js
@@ -17,7 +17,7 @@
  */
 
 const path = require('path');
-const {Registry} = require('../packages/playwright-core/lib/utils/registry');
+const {Registry} = require('../packages/playwright-core/src/utils/registry');
 const fs = require('fs');
 const protocolGenerator = require('./protocol-types-generator');
 const {execSync} = require('child_process');


### PR DESCRIPTION
In new versions of node, using `"./": "./"` in the package.json field is deprecated.

In old versions of node 12, using `"./src/**/*": "./lib/**/*.js"` is unsupported. Technically
we don't support old node 12, only current LTS node 12, but enough people seem to be using it
that I'd rather not break.

This patch lists the files that `@playwright/test` and `playwright-webkit` require from playwright-core.
They are:
- ./lib/grid/gridClient.js
- ./lib/utils/async.js
- ./lib/utils/httpServer.js
- ./lib/utils/processLauncher.js
- ./lib/utils/registry.js
- ./lib/utils/utils.js

Other files that are required by tests instead require the file directly like `../packages/playwright-core/lib/foo/bar`.

We had some tests that were testing requiring `./lib/utils/errors` and `./lib/server/deviceDescriptors`. These have
not been supported apis since the Puppeteer days, so I modified the tests.
