### PR TITLE
fix(monorepo): support yarn2/pnp by specifying all deps and bins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8183,9 +8183,9 @@
       "dev": true
     },
     "node_modules/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -9314,6 +9314,9 @@
       "dependencies": {
         "playwright-core": "=1.16.0-next"
       },
+      "bin": {
+        "playwright": "cli.js"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -9324,6 +9327,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "=1.16.0-next"
+      },
+      "bin": {
+        "playwright": "cli.js"
       },
       "engines": {
         "node": ">=12"
@@ -9372,6 +9378,9 @@
       "dependencies": {
         "playwright-core": "=1.16.0-next"
       },
+      "bin": {
+        "playwright": "cli.js"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -9400,15 +9409,23 @@
         "@babel/preset-typescript": "^7.14.5",
         "colors": "^1.4.0",
         "commander": "^8.2.0",
+        "debug": "^4.1.1",
         "expect": "^27.2.5",
         "jest-matcher-utils": "^27.2.5",
+        "jpeg-js": "^0.4.2",
         "minimatch": "^3.0.3",
         "ms": "^2.1.2",
         "open": "^8.3.0",
         "pirates": "^4.0.1",
         "pixelmatch": "^5.2.1",
         "playwright-core": "=1.16.0-next",
-        "source-map-support": "^0.4.18"
+        "pngjs": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "source-map-support": "^0.4.18",
+        "stack-utils": "^2.0.3"
+      },
+      "bin": {
+        "playwright": "cli.js"
       },
       "engines": {
         "node": ">=12"
@@ -9420,6 +9437,14 @@
       "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "packages/playwright-test/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "engines": {
+        "node": ">=12.13.0"
       }
     },
     "packages/playwright-test/node_modules/source-map-support": {
@@ -9436,6 +9461,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "=1.16.0-next"
+      },
+      "bin": {
+        "playwright": "cli.js"
       },
       "engines": {
         "node": ">=12"
@@ -10186,21 +10214,30 @@
         "@babel/preset-typescript": "^7.14.5",
         "colors": "^1.4.0",
         "commander": "^8.2.0",
+        "debug": "^4.1.1",
         "expect": "^27.2.5",
         "jest-matcher-utils": "^27.2.5",
+        "jpeg-js": "^0.4.2",
         "minimatch": "^3.0.3",
         "ms": "^2.1.2",
         "open": "^8.3.0",
         "pirates": "^4.0.1",
         "pixelmatch": "^5.2.1",
         "playwright-core": "=1.16.0-next",
-        "source-map-support": "^0.4.18"
+        "pngjs": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "source-map-support": "^0.4.18",
+        "stack-utils": "^2.0.3"
       },
       "dependencies": {
         "commander": {
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
           "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA=="
+        },
+        "pngjs": {
+          "version": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+          "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
         },
         "source-map-support": {
           "version": "0.4.18",
@@ -15732,9 +15769,9 @@
       "dev": true
     },
     "stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "requires": {
         "escape-string-regexp": "^2.0.0"
       },

--- a/packages/playwright-chromium/cli.js
+++ b/packages/playwright-chromium/cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module.exports = require('playwright-core/cli');

--- a/packages/playwright-chromium/package.json
+++ b/packages/playwright-chromium/package.json
@@ -18,6 +18,9 @@
     },
     "./": "./"
   },
+  "bin": {
+    "playwright": "./cli.js"
+  },
   "scripts": {
     "install": "node install.js"
   },

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -19,6 +19,7 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
+    "./cli": "./cli.js",
     "./src/grid/gridClient": "./lib/grid/gridClient.js",
     "./src/utils/async": "./lib/utils/async.js",
     "./src/utils/httpServer": "./lib/utils/httpServer.js",

--- a/packages/playwright-firefox/cli.js
+++ b/packages/playwright-firefox/cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module.exports = require('playwright-core/cli');

--- a/packages/playwright-firefox/package.json
+++ b/packages/playwright-firefox/package.json
@@ -18,6 +18,9 @@
     },
     "./": "./"
   },
+  "bin": {
+    "playwright": "./cli.js"
+  },
   "scripts": {
     "install": "node install.js"
   },

--- a/packages/playwright-test/cli.js
+++ b/packages/playwright-test/cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module.exports = require('playwright-core/cli');

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -16,6 +16,9 @@
     "./src/*": "./lib/*.js",
     "./*": "./*.js"
   },
+  "bin": {
+    "playwright": "./cli.js"
+  },
   "author": {
     "name": "Microsoft Corporation"
   },
@@ -42,13 +45,17 @@
     "commander": "^8.2.0",
     "expect": "^27.2.5",
     "jest-matcher-utils": "^27.2.5",
+    "jpeg-js": "^0.4.2",
     "minimatch": "^3.0.3",
     "ms": "^2.1.2",
     "open": "^8.3.0",
     "pirates": "^4.0.1",
     "pixelmatch": "^5.2.1",
     "playwright-core": "=1.16.0-next",
+    "pngjs": "^5.0.0",
+    "rimraf": "^3.0.2",
     "source-map-support": "^0.4.18",
-    "stack-utils": "^2.0.3"
+    "stack-utils": "^2.0.3",
+    "debug": "^4.1.1"
   }
 }

--- a/packages/playwright-webkit/cli.js
+++ b/packages/playwright-webkit/cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module.exports = require('playwright-core/cli');

--- a/packages/playwright-webkit/package.json
+++ b/packages/playwright-webkit/package.json
@@ -18,6 +18,9 @@
     },
     "./": "./"
   },
+  "bin": {
+    "playwright": "./cli.js"
+  },
   "scripts": {
     "install": "node install.js"
   },

--- a/packages/playwright/cli.js
+++ b/packages/playwright/cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module.exports = require('playwright-core/cli');

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -17,6 +17,9 @@
       "require": "./index.js"
     }
   },
+  "bin": {
+    "playwright": "./cli.js"
+  },
   "scripts": {
     "install": "node install.js"
   },


### PR DESCRIPTION
`@playwright/test` was using some dependencies from `playwright-core` without explicitly depending on them itself. This doesn't work with yarn2 / pnp.

Also you can't use the `playwright` command with yarn2 unless you explictly depend on `playwright-core`. This is fixed by adding a `cli.js` file to each of our packages which forwards to the `playwright-core` `cli.js`.