### PR TITLE
chore: run docker tests on every commit

### DIFF
--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - master
       - release-*
-    paths:
-      - '.github/workflows/tests_docker.yml'
-      - '**/Dockerfile*'
-      - 'browsers.json'
-      - 'package.json'
   pull_request:
     paths:
       - '.github/workflows/tests_docker.yml'


### PR DESCRIPTION
Otherwise, we run docker tests very rarely, and their failures don't
show up on the flakiness dashboard.