### PR TITLE
chore: do not publish driver on every commit

### DIFF
--- a/.github/workflows/publish_canary_driver.yml
+++ b/.github/workflows/publish_canary_driver.yml
@@ -1,9 +1,11 @@
 name: "devrelease:driver"
 
 on:
+  workflow_dispatch:
+  schedule:
+    - cron: "10 0 * * *"
   push:
     branches:
-      - master
       - release-*
 
 jobs:


### PR DESCRIPTION
With this patch:
- one can trigger driver publish manually
- driver will be published once a day for master branch
- driver will be published for every commit of release branch