### PR TITLE
tests: skip Docker ipv6 tests

### DIFF
--- a/tests/browsercontext-proxy.spec.ts
+++ b/tests/browsercontext-proxy.spec.ts
@@ -88,7 +88,7 @@ it('should use proxy', async ({ contextFactory, server, proxyServer }) => {
 
 it('should use ipv6 proxy', async ({ contextFactory, server, proxyServer, browserName }) => {
   it.fail(browserName === 'firefox', 'page.goto: NS_ERROR_UNKNOWN_HOST');
-  it.fail(!!process.env.INSIDE_DOCKER, 'docker does not support IPv6 by deafult');
+  it.fail(!!process.env.INSIDE_DOCKER, 'docker does not support IPv6 by default');
   proxyServer.forwardTo(server.PORT);
   const context = await contextFactory({
     proxy: { server: `[0:0:0:0:0:0:0:1]:${proxyServer.PORT}` }

--- a/tests/browsercontext-proxy.spec.ts
+++ b/tests/browsercontext-proxy.spec.ts
@@ -88,6 +88,7 @@ it('should use proxy', async ({ contextFactory, server, proxyServer }) => {
 
 it('should use ipv6 proxy', async ({ contextFactory, server, proxyServer, browserName }) => {
   it.fail(browserName === 'firefox', 'page.goto: NS_ERROR_UNKNOWN_HOST');
+  it.fail(!!process.env.INSIDE_DOCKER, 'docker does not support IPv6 by deafult');
   proxyServer.forwardTo(server.PORT);
   const context = await contextFactory({
     proxy: { server: `[0:0:0:0:0:0:0:1]:${proxyServer.PORT}` }


### PR DESCRIPTION
Default docker configuratiton does not support ipv6.