### PR TITLE
conda activation

### DIFF
--- a/docs/src/intro-python.md
+++ b/docs/src/intro-python.md
@@ -29,6 +29,7 @@ playwright install
 conda config --add channels conda-forge
 conda config --add channels microsoft
 conda install playwright
+conda activate (if not already done)
 playwright install
 ```
 


### PR DESCRIPTION
I had to do it on Ubuntu 21.04 as it's not activated on system startup.