### PR TITLE
Revert "chore: print global errors when running html report"

### DIFF
--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -18,12 +18,11 @@ import colors from 'colors/safe';
 import fs from 'fs';
 import open from 'open';
 import path from 'path';
-import { FullConfig, Suite, TestError } from '../../types/testReporter';
+import { FullConfig, Suite } from '../../types/testReporter';
 import { HttpServer } from 'playwright-core/src/utils/httpServer';
 import { calculateSha1, removeFolders } from 'playwright-core/src/utils/utils';
 import RawReporter, { JsonReport, JsonSuite, JsonTestCase, JsonTestResult, JsonTestStep, JsonAttachment } from './raw';
 import assert from 'assert';
-import { formatError } from './base';
 
 export type Stats = {
   total: number;
@@ -140,10 +139,6 @@ class HtmlReporter {
 `));
       }
     }
-  }
-
-  onError(error: TestError) {
-    console.log(formatError(error, colors.enabled));
   }
 }
 


### PR DESCRIPTION
Reverts microsoft/playwright#9657

We'll eventually get a better fix. As long as html reporter runs with line/dot, we already print it.