### PR TITLE
cherry-pick(release-1.16): Revert "chore: print global errors when running html report"

### DIFF
--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -18,12 +18,11 @@ import colors from 'colors/safe';
 import fs from 'fs';
 import open from 'open';
 import path from 'path';
-import { FullConfig, Suite, TestError } from '../../types/testReporter';
+import { FullConfig, Suite } from '../../types/testReporter';
 import { HttpServer } from 'playwright-core/src/utils/httpServer';
 import { calculateSha1, removeFolders } from 'playwright-core/src/utils/utils';
 import RawReporter, { JsonReport, JsonSuite, JsonTestCase, JsonTestResult, JsonTestStep, JsonAttachment } from './raw';
 import assert from 'assert';
-import { formatError } from './base';
 
 export type Stats = {
   total: number;
@@ -140,10 +139,6 @@ class HtmlReporter {
 `));
       }
     }
-  }
-
-  onError(error: TestError) {
-    console.log(formatError(error, colors.enabled));
   }
 }
 


### PR DESCRIPTION
This reverts commit 68c9fce50772e3f75c5d80397b7ab9b1ceb7fd99.
