### PR TITLE
docs(python): move browser_context_args fixture back to session scope

### DIFF
--- a/docs/src/test-runners-python.md
+++ b/docs/src/test-runners-python.md
@@ -165,7 +165,7 @@ def test_visit_example(page):
 # conftest.py
 import pytest
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def browser_context_args(browser_context_args):
     return {
         **browser_context_args,
@@ -179,7 +179,7 @@ def browser_context_args(browser_context_args):
 # conftest.py
 import pytest
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def browser_context_args(browser_context_args):
     return {
         **browser_context_args,
@@ -196,7 +196,7 @@ def browser_context_args(browser_context_args):
 # conftest.py
 import pytest
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def browser_context_args(browser_context_args, playwright):
     iphone_11 = playwright.devices['iPhone 11 Pro']
     return {

--- a/docs/src/test-runners-python.md
+++ b/docs/src/test-runners-python.md
@@ -77,9 +77,11 @@ def test_my_app_is_working(fixture_name):
 
 **Session scope**: These fixtures are created when requested in a test function and destroyed when all tests end.
 
-- `browser`: Browser instance launched by Playwright.
+- `playwright`: [Playwright](https://playwright.dev/python/docs/api/class-playwright) instance.
+- `browser_type`: [BrowserType](https://playwright.dev/python/docs/api/class-browsertype) instance of the current browser.
+- `browser`: [Browser](https://playwright.dev/python/docs/api/class-browser) instance launched by Playwright.
 - `browser_name`: Browser name as string.
-- `browser_channel`: Browser Channel as string.
+- `browser_channel`: Browser channel as string.
 - `is_chromium`, `is_webkit`, `is_firefox`: Booleans for the respective browser types.
 
 **Customizing fixture options**: For `browser` and `context` fixtures, use the the following fixtures to define custom launch options.


### PR DESCRIPTION
This was accidentally changed to the wrong scope before.

Relates https://github.com/microsoft/playwright-pytest/issues/73