### PR TITLE
fix(fetch): remove content-length from redirected post requests

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -226,6 +226,7 @@ export abstract class FetchRequest extends SdkObject {
             postData = undefined;
             delete headers[`content-encoding`];
             delete headers[`content-language`];
+            delete headers[`content-length`];
             delete headers[`content-location`];
             delete headers[`content-type`];
           }


### PR DESCRIPTION
POST request is transformed to GET on redirect and the latter has no body, so content-length makes no sense there. Moreover, it makes redirected requests hang with some servers which wait for body.