### PR TITLE
feat(test runner): introduce TestInfo.parallelIndex

### DIFF
--- a/docs/src/test-api/class-testinfo.md
+++ b/docs/src/test-api/class-testinfo.md
@@ -201,6 +201,13 @@ test('example test', async ({}, testInfo) => {
 
 Path segments to append at the end of the resulting path.
 
+## property: TestInfo.parallelIndex
+- type: <[int]>
+
+The index of the worker between `0` and `workers - 1`. It is guaranteed that workers running at the same time have a different `parallelIndex`. When a worker is restarted, for example after a failure, the new worker process has the same `parallelIndex`.
+
+Also available as `process.env.TEST_PARALLEL_INDEX`. Learn more about [parallelism and sharding](./test-parallel.md) with Playwright Test.
+
 ## property: TestInfo.project
 - type: <[TestProject]>
 
@@ -358,4 +365,6 @@ The title of the currently running test as passed to `test(title, testFunction)`
 ## property: TestInfo.workerIndex
 - type: <[int]>
 
-The unique index of the worker process that is running the test. Also available as `process.env.TEST_WORKER_INDEX`. Learn more about [parallelism and sharding](./test-parallel.md) with Playwright Test.
+The unique index of the worker process that is running the test. When a worker is restarted, for example after a failure, the new worker process gets a new unique `workerIndex`.
+
+Also available as `process.env.TEST_WORKER_INDEX`. Learn more about [parallelism and sharding](./test-parallel.md) with Playwright Test.

--- a/docs/src/test-api/class-workerinfo.md
+++ b/docs/src/test-api/class-workerinfo.md
@@ -25,6 +25,14 @@ test.beforeAll(async ({ browserName }, workerInfo) => {
 Processed configuration from the [configuration file](./test-configuration.md).
 
 
+## property: WorkerInfo.parallelIndex
+- type: <[int]>
+
+The index of the worker between `0` and `workers - 1`. It is guaranteed that workers running at the same time have a different `parallelIndex`. When a worker is restarted, for example after a failure, the new worker process has the same `parallelIndex`.
+
+Also available as `process.env.TEST_PARALLEL_INDEX`. Learn more about [parallelism and sharding](./test-parallel.md) with Playwright Test.
+
+
 ## property: WorkerInfo.project
 - type: <[TestProject]>
 
@@ -34,4 +42,6 @@ Processed project configuration from the [configuration file](./test-configurati
 ## property: WorkerInfo.workerIndex
 - type: <[int]>
 
-The unique index of the worker process that is running the test. Also available as `process.env.TEST_WORKER_INDEX`. Learn more about [parallelism and sharding](./test-parallel.md) with Playwright Test.
+The unique index of the worker process that is running the test. When a worker is restarted, for example after a failure, the new worker process gets a new unique `workerIndex`.
+
+Also available as `process.env.TEST_WORKER_INDEX`. Learn more about [parallelism and sharding](./test-parallel.md) with Playwright Test.

--- a/docs/src/test-parallel-js.md
+++ b/docs/src/test-parallel-js.md
@@ -135,6 +135,8 @@ const config: PlaywrightTestConfig = {
 export default config;
 ```
 
-## Worker index
+## Worker index and parallel index
 
-Each worker process is assigned a unique id (an index that starts with 1). You can read it from environment variable `process.env.TEST_WORKER_INDEX`, or access through [`property: TestInfo.workerIndex`].
+Each worker process is assigned two ids: a unique worker index that starts with 1, and a parallel index that is between `0` and `workers - 1`. When a worker is restarted, for example after a failure, the new worker process has the same `parallelIndex` and a new `workerIndex`.
+
+You can read an index from environment variables `process.env.TEST_WORKER_INDEX` and `process.env.TEST_PARALLEL_INDEX`, or access them through [`property: TestInfo.workerIndex`] and [`property: TestInfo.parallelIndex`].

--- a/packages/playwright-test/src/dispatcher.ts
+++ b/packages/playwright-test/src/dispatcher.ts
@@ -96,7 +96,7 @@ export class Dispatcher {
 
     // 2. Start the worker if it is down.
     if (!worker) {
-      worker = this._createWorker(job.workerHash);
+      worker = this._createWorker(job.workerHash, index);
       this._workerSlots[index].worker = worker;
       worker.on('exit', () => this._workerSlots[index].worker = undefined);
       await worker.init(job, this._loader.serialize());
@@ -337,8 +337,8 @@ export class Dispatcher {
     return result;
   }
 
-  _createWorker(hash: string) {
-    const worker = new Worker(hash);
+  _createWorker(hash: string, parallelIndex: number) {
+    const worker = new Worker(hash, parallelIndex);
     worker.on('stdOut', (params: TestOutputPayload) => {
       const chunk = chunkFromParams(params);
       if (worker.didFail()) {
@@ -404,15 +404,17 @@ let lastWorkerIndex = 0;
 class Worker extends EventEmitter {
   private process: child_process.ChildProcess;
   private _hash: string;
+  private parallelIndex: number;
   private workerIndex: number;
   private didSendStop = false;
   private _didFail = false;
   private didExit = false;
 
-  constructor(hash: string) {
+  constructor(hash: string, parallelIndex: number) {
     super();
     this.workerIndex = lastWorkerIndex++;
     this._hash = hash;
+    this.parallelIndex = parallelIndex;
 
     this.process = child_process.fork(path.join(__dirname, 'worker.js'), {
       detached: false,
@@ -420,6 +422,7 @@ class Worker extends EventEmitter {
         FORCE_COLOR: process.stdout.isTTY ? '1' : '0',
         DEBUG_COLORS: process.stdout.isTTY ? '1' : '0',
         TEST_WORKER_INDEX: String(this.workerIndex),
+        TEST_PARALLEL_INDEX: String(this.parallelIndex),
         ...process.env
       },
       // Can't pipe since piping slows down termination for some reason.
@@ -439,6 +442,7 @@ class Worker extends EventEmitter {
   async init(testGroup: TestGroup, loaderData: SerializedLoaderData) {
     const params: WorkerInitParams = {
       workerIndex: this.workerIndex,
+      parallelIndex: this.parallelIndex,
       repeatEachIndex: testGroup.repeatEachIndex,
       projectIndex: testGroup.projectIndex,
       loader: loaderData,

--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -24,6 +24,7 @@ export type SerializedLoaderData = {
 };
 export type WorkerInitParams = {
   workerIndex: number;
+  parallelIndex: number;
   repeatEachIndex: number;
   projectIndex: number;
   loader: SerializedLoaderData;

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -125,6 +125,7 @@ export class WorkerRunner extends EventEmitter {
 
     this._workerInfo = {
       workerIndex: this._params.workerIndex,
+      parallelIndex: this._params.parallelIndex,
       project: this._project.config,
       config: this._loader.fullConfig(),
     };
@@ -234,6 +235,7 @@ export class WorkerRunner extends EventEmitter {
     let lastStepId = 0;
     const testInfo: TestInfoImpl = {
       workerIndex: this._params.workerIndex,
+      parallelIndex: this._params.parallelIndex,
       project: this._project.config,
       config: this._loader.fullConfig(),
       title: test.title,

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -815,12 +815,24 @@ export interface WorkerInfo {
    */
   config: FullConfig;
   /**
+   * The index of the worker between `0` and `workers - 1`. It is guaranteed that workers running at the same time have a
+   * different `parallelIndex`. When a worker is restarted, for example after a failure, the new worker process has the same
+   * `parallelIndex`.
+   *
+   * Also available as `process.env.TEST_PARALLEL_INDEX`. Learn more about [parallelism and sharding](https://playwright.dev/docs/test-parallel)
+   * with Playwright Test.
+   */
+  parallelIndex: number;
+  /**
    * Processed project configuration from the [configuration file](https://playwright.dev/docs/test-configuration).
    */
   project: FullProject;
   /**
-   * The unique index of the worker process that is running the test. Also available as `process.env.TEST_WORKER_INDEX`.
-   * Learn more about [parallelism and sharding](https://playwright.dev/docs/test-parallel) with Playwright Test.
+   * The unique index of the worker process that is running the test. When a worker is restarted, for example after a
+   * failure, the new worker process gets a new unique `workerIndex`.
+   *
+   * Also available as `process.env.TEST_WORKER_INDEX`. Learn more about [parallelism and sharding](https://playwright.dev/docs/test-parallel) with
+   * Playwright Test.
    */
   workerIndex: number;
 }
@@ -848,12 +860,24 @@ export interface TestInfo {
    */
   config: FullConfig;
   /**
+   * The index of the worker between `0` and `workers - 1`. It is guaranteed that workers running at the same time have a
+   * different `parallelIndex`. When a worker is restarted, for example after a failure, the new worker process has the same
+   * `parallelIndex`.
+   *
+   * Also available as `process.env.TEST_PARALLEL_INDEX`. Learn more about [parallelism and sharding](https://playwright.dev/docs/test-parallel)
+   * with Playwright Test.
+   */
+  parallelIndex: number;
+  /**
    * Processed project configuration from the [configuration file](https://playwright.dev/docs/test-configuration).
    */
   project: FullProject;
   /**
-   * The unique index of the worker process that is running the test. Also available as `process.env.TEST_WORKER_INDEX`.
-   * Learn more about [parallelism and sharding](https://playwright.dev/docs/test-parallel) with Playwright Test.
+   * The unique index of the worker process that is running the test. When a worker is restarted, for example after a
+   * failure, the new worker process gets a new unique `workerIndex`.
+   *
+   * Also available as `process.env.TEST_WORKER_INDEX`. Learn more about [parallelism and sharding](https://playwright.dev/docs/test-parallel) with
+   * Playwright Test.
    */
   workerIndex: number;
 

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -165,12 +165,14 @@ export interface TestError {
 
 export interface WorkerInfo {
   config: FullConfig;
+  parallelIndex: number;
   project: FullProject;
   workerIndex: number;
 }
 
 export interface TestInfo {
   config: FullConfig;
+  parallelIndex: number;
   project: FullProject;
   workerIndex: number;
 


### PR DESCRIPTION
This is a worker number between `0` and `workers - 1` that does not change after worker process restart.

Fixes #9178.