### PR TITLE
Making testProject more clear

### DIFF
--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -13,7 +13,7 @@ Here is an example configuration that runs every test in Chromium, Firefox and W
 const { devices } = require('@playwright/test');
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
-const testProject = {
+const config = {
   // Options shared for all projects.
   timeout: 30000,
   use: {
@@ -54,14 +54,14 @@ const testProject = {
   ],
 };
 
-module.exports = testProject;
+module.exports = config;
 ```
 
 ```js js-flavor=ts
 // playwright.config.ts
 import { PlaywrightTestConfig, devices } from '@playwright/test';
 
-const testProject: PlaywrightTestConfig = {
+const config: PlaywrightTestConfig = {
   // Options shared for all projects.
   timeout: 30000,
   use: {
@@ -101,7 +101,7 @@ const testProject: PlaywrightTestConfig = {
     },
   ],
 };
-export default testProject;
+export default config;
 ```
 
 ## property: TestProject.expect
@@ -173,7 +173,7 @@ Each project can use a different directory. Here is an example that runs smoke t
 // @ts-check
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
-const testProject = {
+const config = {
   projects: [
     {
       name: 'Smoke Chromium',
@@ -207,14 +207,14 @@ const testProject = {
   ],
 };
 
-module.exports = testProject;
+module.exports = config;
 ```
 
 ```js js-flavor=ts
 // playwright.config.ts
 import { PlaywrightTestConfig } from '@playwright/test';
 
-const testProject: PlaywrightTestConfig = {
+const config: PlaywrightTestConfig = {
   projects: [
     {
       name: 'Smoke Chromium',
@@ -247,7 +247,7 @@ const testProject: PlaywrightTestConfig = {
     },
   ],
 };
-export default testProject;
+export default config;
 ```
 
 
@@ -284,7 +284,7 @@ Options for all tests in this project, for example [`property: TestOptions.brows
 // @ts-check
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
-const testProject = {
+const config = {
   projects: [
     {
       name: 'Chromium',
@@ -295,14 +295,14 @@ const testProject = {
   ],
 };
 
-module.exports = testProject;
+module.exports = config;
 ```
 
 ```js js-flavor=ts
 // playwright.config.ts
 import { PlaywrightTestConfig } from '@playwright/test';
 
-const testProject: PlaywrightTestConfig = {
+const config: PlaywrightTestConfig = {
   projects: [
     {
       name: 'Chromium',
@@ -312,5 +312,5 @@ const testProject: PlaywrightTestConfig = {
     },
   ],
 };
-export default testProject;
+export default config;
 ```

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -13,7 +13,7 @@ Here is an example configuration that runs every test in Chromium, Firefox and W
 const { devices } = require('@playwright/test');
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
-const config = {
+const testProject = {
   // Options shared for all projects.
   timeout: 30000,
   use: {
@@ -54,14 +54,14 @@ const config = {
   ],
 };
 
-module.exports = config;
+module.exports = testProject;
 ```
 
 ```js js-flavor=ts
 // playwright.config.ts
 import { PlaywrightTestConfig, devices } from '@playwright/test';
 
-const config: PlaywrightTestConfig = {
+const testProject: PlaywrightTestConfig = {
   // Options shared for all projects.
   timeout: 30000,
   use: {
@@ -101,7 +101,7 @@ const config: PlaywrightTestConfig = {
     },
   ],
 };
-export default config;
+export default testProject;
 ```
 
 ## property: TestProject.expect
@@ -173,7 +173,7 @@ Each project can use a different directory. Here is an example that runs smoke t
 // @ts-check
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
-const config = {
+const testProject = {
   projects: [
     {
       name: 'Smoke Chromium',
@@ -207,14 +207,14 @@ const config = {
   ],
 };
 
-module.exports = config;
+module.exports = testProject;
 ```
 
 ```js js-flavor=ts
 // playwright.config.ts
 import { PlaywrightTestConfig } from '@playwright/test';
 
-const config: PlaywrightTestConfig = {
+const testProject: PlaywrightTestConfig = {
   projects: [
     {
       name: 'Smoke Chromium',
@@ -247,7 +247,7 @@ const config: PlaywrightTestConfig = {
     },
   ],
 };
-export default config;
+export default testProject;
 ```
 
 
@@ -284,7 +284,7 @@ Options for all tests in this project, for example [`property: TestOptions.brows
 // @ts-check
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
-const config = {
+const testProject = {
   projects: [
     {
       name: 'Chromium',
@@ -295,14 +295,14 @@ const config = {
   ],
 };
 
-module.exports = config;
+module.exports = testProject;
 ```
 
 ```js js-flavor=ts
 // playwright.config.ts
 import { PlaywrightTestConfig } from '@playwright/test';
 
-const config: PlaywrightTestConfig = {
+const testProject: PlaywrightTestConfig = {
   projects: [
     {
       name: 'Chromium',
@@ -312,5 +312,5 @@ const config: PlaywrightTestConfig = {
     },
   ],
 };
-export default config;
+export default testProject;
 ```

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -3,7 +3,7 @@ id: test-assertions
 title: "Assertions"
 ---
 
-Playwright Test uses the [expect](https://jestjs.io/docs/expect) library for test assertions. This library provides
+Playwright Test uses [expect](https://jestjs.io/docs/expect) library for test assertions. This library provides
 a lot of matchers like `toEqual`, `toContain`, `toMatch`, `toMatchSnapshot` and many more:
 
 ```js
@@ -11,13 +11,7 @@ expect(success).toBeTruthy();
 ```
 
 Playwright also extends it with convenience async matchers that will wait until
-the expected condition is met. In general, we can expect the opposite to be true by adding a `.not` to the front
-of the matchers:
-
-```js
-expect(value).not.toEqual(0);
-expect(locator).not.toContainText("some text");
-```
+the expected condition is met.
 
 <!-- TOC -->
 

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -11,7 +11,13 @@ expect(success).toBeTruthy();
 ```
 
 Playwright also extends it with convenience async matchers that will wait until
-the expected condition is met.
+the expected condition is met. In general, we can expect the opposite to be true by adding a `.not` to the front
+of the matchers:
+
+```js
+expect(value).not.toEqual(0);
+expect(locator).not.toContainText("some text");
+```
 
 <!-- TOC -->
 

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -3,7 +3,7 @@ id: test-assertions
 title: "Assertions"
 ---
 
-Playwright Test uses [expect](https://jestjs.io/docs/expect) library for test assertions. This library provides
+Playwright Test uses the [expect](https://jestjs.io/docs/expect) library for test assertions. This library provides
 a lot of matchers like `toEqual`, `toContain`, `toMatch`, `toMatchSnapshot` and many more:
 
 ```js


### PR DESCRIPTION

as per https://github.com/microsoft/playwright/issues/9733#issuecomment-951428289
If it is testProject, why not name it `testProject`?  Why name it `config` to add an extra confusion?
