### PR TITLE
fix(chromium): query touch state instead of relying on context options

### DIFF
--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -53,6 +53,7 @@ export class FFPage implements PageDelegate {
   private _eventListeners: RegisteredListener[];
   private _workers = new Map<string, { frameId: string, session: FFSession }>();
   private _screencastId: string | undefined;
+  public hasTouch: boolean;
 
   constructor(session: FFSession, browserContext: FFBrowserContext, opener: FFPage | null) {
     this._session = session;
@@ -62,6 +63,7 @@ export class FFPage implements PageDelegate {
     this.rawTouchscreen = new RawTouchscreenImpl(session);
     this._contextIdToContext = new Map();
     this._browserContext = browserContext;
+    this.hasTouch = !!browserContext._options.hasTouch;
     this._page = new Page(this, browserContext);
     this.rawMouse.setPage(this._page);
     this._networkManager = new FFNetworkManager(session, this._page);

--- a/packages/playwright-core/src/server/input.ts
+++ b/packages/playwright-core/src/server/input.ts
@@ -314,7 +314,7 @@ export class Touchscreen {
   }
 
   async tap(x: number, y: number) {
-    if (!this._page._browserContext._options.hasTouch)
+    if (!this._page.hasTouch())
       throw new Error('hasTouch must be enabled on the browser context before using the touchscreen.');
     await this._raw.tap(x, y, this._page.keyboard._modifiers());
     await this._page._doSlowMo();

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -39,6 +39,7 @@ export interface PageDelegate {
   readonly rawMouse: input.RawMouse;
   readonly rawKeyboard: input.RawKeyboard;
   readonly rawTouchscreen: input.RawTouchscreen;
+  hasTouch: boolean;
 
   reload(): Promise<void>;
   goBack(): Promise<boolean>;
@@ -504,6 +505,10 @@ export class Page extends SdkObject {
   parseSelector(selector: string, options?: types.StrictOptions): SelectorInfo {
     const strict = typeof options?.strict === 'boolean' ? options.strict : !!this.context()._options.strictSelectors;
     return this.selectors.parseSelector(selector, strict);
+  }
+
+  hasTouch() {
+    return this._delegate.hasTouch;
   }
 }
 

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -77,6 +77,8 @@ export class WKPage implements PageDelegate {
   private _recordingVideoFile: string | null = null;
   private _screencastGeneration: number = 0;
 
+  public hasTouch: boolean;
+
   constructor(browserContext: WKBrowserContext, pageProxySession: WKSession, opener: WKPage | null) {
     this._pageProxySession = pageProxySession;
     this._opener = opener;
@@ -89,6 +91,7 @@ export class WKPage implements PageDelegate {
     this._workers = new WKWorkers(this._page);
     this._session = undefined as any as WKSession;
     this._browserContext = browserContext;
+    this.hasTouch = !!browserContext._options.hasTouch;
     this._page.on(Page.Events.FrameDetached, (frame: frames.Frame) => this._removeContextsForFrame(frame, false));
     this._eventListeners = [
       eventsHelper.addEventListener(this._pageProxySession, 'Target.targetCreated', this._onTargetCreated.bind(this)),


### PR DESCRIPTION
Needs tests, but maybe the whole concept is flawed?

Right now we assume that a page does not have
touch enabled unless the context options have
hasTouch = true. But this fails when we run
chromium on a computer/phone with a touch screen or
when connecting over CDP to a browser with its own emulation.

#9238
