### PR TITLE
chore(trace-viewer): add drag hover animation and click to upload

### DIFF
--- a/packages/playwright-core/src/web/traceViewer/ui/workbench.css
+++ b/packages/playwright-core/src/web/traceViewer/ui/workbench.css
@@ -20,9 +20,21 @@
   justify-content: center;
   box-shadow: var(--box-shadow);
   flex: auto;
+  flex-direction: column;
   font-size: 24px;
   color: #666;
   font-weight: bold;
+  background-color: #fffb;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 100;
+}
+
+.drop-target input {
+  margin-top: 50px;
 }
 
 .progress {
@@ -78,7 +90,7 @@
   flex: auto;
 }
 
-tab-strip {
+.tab-strip {
   background-color: var(--light-background);
 }
 


### PR DESCRIPTION
This patch includes three changes:

a) there is now a light grey background when you hover with a file over the workbench
b) There was a CSS typo for the `tab-strip` element CSS selector, its now fixed but looks a bit different, see attachment(1) and attachment(2)
c) its now possible to click on the empty workbench area to upload a file, since not all users are used to drag'n drop especially when having small monitors

attachment(1) - after
![image](https://user-images.githubusercontent.com/17984549/138911668-18a44658-58cc-458c-bebe-d07d5b1decbc.png)

attachment(2) - before

![image](https://user-images.githubusercontent.com/17984549/138911758-13a7779f-8402-4f0e-9885-04192f73c787.png)
