### PR TITLE
docs: update console event snippet

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -169,8 +169,10 @@ An example of handling `console` event:
 
 ```js
 page.on('console', async msg => {
-  for (let i = 0; i < msg.args().length; ++i)
-    console.log(`${i}: ${await msg.args()[i].jsonValue()}`);
+  const values = [];
+  for (const arg of msg.args())
+    values.push(await arg.jsonValue());
+  console.log(...values);
 });
 await page.evaluate(() => console.log('hello', 5, {foo: 'bar'}));
 ```
@@ -185,8 +187,10 @@ page.evaluate("() => console.log('hello', 5, {foo: 'bar'})");
 
 ```python async
 async def print_args(msg):
+    values = []
     for arg in msg.args:
-        print(await arg.json_value())
+        values.append(await arg.json_value())
+    print(values)
 
 page.on("console", print_args)
 await page.evaluate("console.log('hello', 5, {foo: 'bar'})")

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -794,8 +794,10 @@ export interface Page {
    *
    * ```js
    * page.on('console', async msg => {
-   *   for (let i = 0; i < msg.args().length; ++i)
-   *     console.log(`${i}: ${await msg.args()[i].jsonValue()}`);
+   *   const values = [];
+   *   for (const arg of msg.args())
+   *     values.push(await arg.jsonValue());
+   *   console.log(...values);
    * });
    * await page.evaluate(() => console.log('hello', 5, {foo: 'bar'}));
    * ```
@@ -1065,8 +1067,10 @@ export interface Page {
    *
    * ```js
    * page.on('console', async msg => {
-   *   for (let i = 0; i < msg.args().length; ++i)
-   *     console.log(`${i}: ${await msg.args()[i].jsonValue()}`);
+   *   const values = [];
+   *   for (const arg of msg.args())
+   *     values.push(await arg.jsonValue());
+   *   console.log(...values);
    * });
    * await page.evaluate(() => console.log('hello', 5, {foo: 'bar'}));
    * ```
@@ -3394,8 +3398,10 @@ export interface Page {
    *
    * ```js
    * page.on('console', async msg => {
-   *   for (let i = 0; i < msg.args().length; ++i)
-   *     console.log(`${i}: ${await msg.args()[i].jsonValue()}`);
+   *   const values = [];
+   *   for (const arg of msg.args())
+   *     values.push(await arg.jsonValue());
+   *   console.log(...values);
    * });
    * await page.evaluate(() => console.log('hello', 5, {foo: 'bar'}));
    * ```


### PR DESCRIPTION
This avoids the confusion where arguments are printed
asynchronously, interleaved with other console messages.

Fixes #9785.