### PR TITLE
devops: fix bumping chromium-with-symbols on bot

### DIFF
--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -432,7 +432,9 @@ if generate_and_upload_browser_build 2>&1 | ./sanitize_and_compress_log.js $LOG_
     done;
     LAST_COMMIT_MESSAGE=$(git log --format=%s -n 1 HEAD -- "./${BROWSER_NAME}/BUILD_NUMBER")
     send_telegram_message "<b>${BROWSER_DISPLAY_NAME} r${BUILD_NUMBER} COMPLETE! ✅</b> ${LAST_COMMIT_MESSAGE}"
-    create_roll_into_playwright_pr $BROWSER_NAME $BUILD_NUMBER
+    if [[ "${BROWSER_DISPLAY_NAME}" == "${BROWSER_NAME}" ]]; then
+      create_roll_into_playwright_pr $BROWSER_NAME $BUILD_NUMBER
+    fi
   )
 else
   RESULT_CODE="$?"

--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -432,7 +432,7 @@ if generate_and_upload_browser_build 2>&1 | ./sanitize_and_compress_log.js $LOG_
     done;
     LAST_COMMIT_MESSAGE=$(git log --format=%s -n 1 HEAD -- "./${BROWSER_NAME}/BUILD_NUMBER")
     send_telegram_message "<b>${BROWSER_DISPLAY_NAME} r${BUILD_NUMBER} COMPLETE! ✅</b> ${LAST_COMMIT_MESSAGE}"
-    if [[ "${BROWSER_DISPLAY_NAME}" == "${BROWSER_NAME}" ]]; then
+    if [[ "${BROWSER_DISPLAY_NAME}" != "chromium-with-symbols" ]]; then
       create_roll_into_playwright_pr $BROWSER_NAME $BUILD_NUMBER
     fi
   )


### PR DESCRIPTION
Previously we also triggered the bumping bot when the chromium with symbols bot was finished. Usually this bot finished before the chromium bot which lead to a PR without having the published browser binaries for it.

