### PR TITLE
browser(webkit): disable COOP again

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1565
-Changed: dpino@igalia.com Thu Oct 21 16:32:56 UTC 2021
+1566
+Changed: yurys@chromium.org Wed 27 Oct 2021 09:04:43 AM PDT

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -2081,10 +2081,10 @@ index b929c9d72addb6500e98e1b0ad535bd018c547cc..8141987b4c4100f00a5db487c6ce83f7
    type: bool
    humanReadableName: "Private Click Measurement"
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index 2c176ae23d5aae49471a340c7b2dc456c9142165..83768668fee38ffded232d0759ab35ba70f6f8ad 100644
+index 2c176ae23d5aae49471a340c7b2dc456c9142165..65c454e382400a1849c4633558fd4f06ffc6e8f3 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-@@ -417,7 +417,7 @@ CrossOriginEmbedderPolicyEnabled:
+@@ -429,7 +429,7 @@ CrossOriginOpenerPolicyEnabled:
      WebKitLegacy:
        default: false
      WebKit:


### PR DESCRIPTION
It got inadvertently overwritten in the rececnt roll (https://github.com/microsoft/playwright/commit/8d05cdacbc808be4e7c78ef1668baa5c6abdb591)

~https://github.com/yury-s/WebKit/commit/ed37c0bf5855f1026a3c6cdb2e1f89090ed9e738~
https://github.com/yury-s/WebKit/commit/765525c20107f38e9a1bd1b28ca6a398e7c3b375