### PR TITLE
chore: use Node.js 16 in Docker

### DIFF
--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -5,13 +5,10 @@ ARG TZ=America/Los_Angeles
 
 # === INSTALL Node.js ===
 
-# Install node14
+# Install node16
 RUN apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -y nodejs
-
-# Upgrade to NPM7 (see https://github.com/microsoft/playwright/pull/8915)
-RUN npm install -g npm@7
 
 # Feature-parity with node.js base images.
 RUN apt-get update && apt-get install -y --no-install-recommends git ssh && \

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -5,13 +5,10 @@ ARG TZ=America/Los_Angeles
 
 # === INSTALL Node.js ===
 
-# Install node14
+# Install node16
 RUN apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -y nodejs
-
-# Upgrade to NPM7 (see https://github.com/microsoft/playwright/pull/8915)
-RUN npm install -g npm@7
 
 # Feature-parity with node.js base images.
 RUN apt-get update && apt-get install -y --no-install-recommends git ssh && \


### PR DESCRIPTION
We ship the current LTS inside Docker, since version 16 is now LTS, lets switch to 16 and have NPM 8 by default: https://nodejs.org/en/about/releases/

Relates:

- #6498
- #7212