### PR TITLE
fix: align default docker image download with the docker integration

### DIFF
--- a/packages/playwright-core/src/cli/cli.ts
+++ b/packages/playwright-core/src/cli/cli.ts
@@ -115,7 +115,7 @@ program
           const installDockerImage = args.some(arg => arg === 'docker-image');
           args = args.filter(arg => arg !== 'docker-image');
           if (installDockerImage) {
-            const imageName = `mcr.microsoft.com/playwright:v${getPlaywrightVersion()}`;
+            const imageName = `mcr.microsoft.com/playwright:v${getPlaywrightVersion()}-focal`;
             const { code } = await spawnAsync('docker', ['pull', imageName], { stdio: 'inherit' });
             if (code !== 0) {
               console.log('Failed to pull docker image');


### PR DESCRIPTION
The docker image that we download should match the one we expect
while running tests in docker.