### PR TITLE
fix(cleanup): use rimraf.sync on process exit

### DIFF
--- a/packages/playwright-core/src/utils/processLauncher.ts
+++ b/packages/playwright-core/src/utils/processLauncher.ts
@@ -19,6 +19,7 @@ import * as childProcess from 'child_process';
 import * as readline from 'readline';
 import { eventsHelper } from './eventsHelper';
 import { isUnderTest, removeFolders } from './utils';
+import rimraf from 'rimraf';
 
 export type Env = {[key: string]: string | number | boolean | undefined};
 
@@ -124,7 +125,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     cleanup().then(fulfillCleanup);
   });
 
-  const listeners = [ eventsHelper.addEventListener(process, 'exit', killProcess) ];
+  const listeners = [ eventsHelper.addEventListener(process, 'exit', killProcessAndCleanup) ];
   if (options.handleSIGINT) {
     listeners.push(eventsHelper.addEventListener(process, 'SIGINT', () => {
       gracefullyClose().then(() => {
@@ -183,7 +184,19 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     } else {
       options.log(`[pid=${spawnedProcess.pid}] <skipped force kill spawnedProcess.killed=${spawnedProcess.killed} processClosed=${processClosed}>`);
     }
-    cleanup();
+  }
+
+  function killProcessAndCleanup() {
+    killProcess();
+    options.log(`[pid=${spawnedProcess.pid || 'N/A'}] starting temporary directories cleanup`);
+    for (const dir of options.tempDirectories) {
+      try {
+        rimraf.sync(dir, { maxBusyTries: 10 });
+      } catch (e) {
+        options.log(`[pid=${spawnedProcess.pid || 'N/A'}] exception while removing ${dir}: ${e}`);
+      }
+    }
+    options.log(`[pid=${spawnedProcess.pid || 'N/A'}] finished temporary directories cleanup`);
   }
 
   function killAndWait() {


### PR DESCRIPTION
Currently we call async `removeFolders` from a synchronous `process.on('exit')` handler, which should not work.

References #9838.