### PR TITLE
devops: use `mach clobber` for clearing ff builds

### DIFF
--- a/browser_patches/firefox-beta/clean.sh
+++ b/browser_patches/firefox-beta/clean.sh
@@ -7,7 +7,6 @@ if [[ ! -z "${FF_CHECKOUT_PATH}" ]]; then
   cd "${FF_CHECKOUT_PATH}"
   echo "WARNING: checkout path from FF_CHECKOUT_PATH env: ${FF_CHECKOUT_PATH}"
 else
-  cd "$(dirname "$0")"
   cd "$HOME/firefox"
 fi
 
@@ -16,3 +15,6 @@ if [[ -d $OBJ_FOLDER ]]; then
   rm -rf $OBJ_FOLDER
 fi
 
+if [[ -f "mach" ]]; then
+  ./mach clobber
+fi

--- a/browser_patches/firefox/clean.sh
+++ b/browser_patches/firefox/clean.sh
@@ -15,3 +15,6 @@ if [[ -d $OBJ_FOLDER ]]; then
   rm -rf $OBJ_FOLDER
 fi
 
+if [[ -f "mach" ]]; then
+  ./mach clobber
+fi


### PR DESCRIPTION
Clobbering is required when switching between native intel compilation
and firefox arm cross-compilation.