### PR TITLE
fix(test runner): do not reuse worker that did not teardown scopes

### DIFF
--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -90,7 +90,17 @@ export class WorkerRunner extends EventEmitter {
   }
 
   unhandledError(error: Error | any) {
-    if (this._currentTest && this._currentTest.type === 'test') {
+    // Usually, we do not differentiate between errors in the control flow
+    // and unhandled errors - both lead to the test failing. This is good for regular tests,
+    // so that you can, e.g. expect() from inside an event handler. The test fails,
+    // and we restart the worker.
+    //
+    // However, for tests marked with test.fail(), this is a problem. Unhandled error
+    // could come either from the user test code (legit failure), or from a fixture or
+    // a test runner. In the latter case, the worker state could be messed up,
+    // and continuing to run tests in the same worker is problematic. Therefore,
+    // we turn this into a fatal error and restart the worker anyway.
+    if (this._currentTest && this._currentTest.type === 'test' && this._currentTest.testInfo.expectedStatus !== 'failed') {
       if (!this._currentTest.testInfo.error) {
         this._currentTest.testInfo.status = 'failed';
         this._currentTest.testInfo.error = serializeError(error);

--- a/tests/page/page-request-intercept.spec.ts
+++ b/tests/page/page-request-intercept.spec.ts
@@ -221,10 +221,9 @@ it('should give access to the intercepted response status text', async ({ page, 
   // @ts-expect-error
   const response = await route._continueToResponse();
 
+  await Promise.all([route.fulfill({ response }), evalPromise]);
   expect(response.statusText()).toBe('You are awesome');
   expect(response.url()).toBe(server.PREFIX + '/title.html');
-
-  await Promise.all([route.fulfill({ response }), evalPromise]);
 });
 
 it('should give access to the intercepted response body', async ({ page, server }) => {


### PR DESCRIPTION
Two bug fixes:
- Do not use the worker that is being shutdown for a new job.
- Report unhandled errors during "expected to fail" tests as fatal errors.

Fixes #9854.