### PR TITLE
allow to return values from inside test.step

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -975,6 +975,32 @@ test('test', async ({ page }) => {
 });
 ```
 
+The `test.step` promise resolves to the value returned in the `body`:
+
+```js js-flavor=js
+const { test, expect } = require('@playwright/test');
+
+test('test', async ({ page }) => {
+  const result = await test.step('Log in', async () => {
+    // ...
+    return { a: true }
+  });
+  // result is { a: true }
+});
+```
+
+```js js-flavor=ts
+import { test, expect } from '@playwright/test';
+
+test('test', async ({ page }) => {
+  const result = await test.step('Log in', async () => {
+    // ...
+    return { a: true }
+  });
+  // result is { a: true }
+});
+```
+
 ### param: Test.step.title
 - `title` <[string]>
 

--- a/packages/playwright-test/src/testType.ts
+++ b/packages/playwright-test/src/testType.ts
@@ -182,7 +182,7 @@ export class TestTypeImpl {
     suite._use.push({ fixtures, location });
   }
 
-  private async _step(location: Location, title: string, body: () => Promise<void>): Promise<void> {
+  private async _step<T extends any = any>(location: Location, title: string, body: () => Promise<T>): Promise<T> {
     const testInfo = currentTestInfo();
     if (!testInfo)
       throw errorWithLocation(location, `test.step() can only be called from a test`);
@@ -194,8 +194,9 @@ export class TestTypeImpl {
       forceNoParent: false
     });
     try {
-      await body();
+      const result = await body();
       step.complete();
+      return result;
     } catch (e) {
       step.complete(serializeError(e));
       throw e;

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -2290,10 +2290,24 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * });
    * ```
    *
+   * The `test.step` promise resolves to the value returned in the `body`:
+   *
+   * ```ts
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('test', async ({ page }) => {
+   *   const result = await test.step('Log in', async () => {
+   *     // ...
+   *     return { a: true }
+   *   });
+   *   // result is { a: true }
+   * });
+   * ```
+   *
    * @param title Step name.
    * @param body Step body.
    */
-  step(title: string, body: () => Promise<any>): Promise<any>;
+  step<T extends any = any>(title: string, body: () => Promise<T>): Promise<T>;
   /**
    * `expect` function can be used to create test assertions. Read
    * [expect library documentation](https://jestjs.io/docs/expect) for more details.

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -321,3 +321,26 @@ test('should report expect step locations', async ({ runInlineTest }) => {
     },
   ]);
 });
+
+test('should return the value returned from inside the step', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      const { test } = pwt;
+      test('value', async ({ page }) => {
+        const randomValue = Math.random();
+        const valueFromStep = await test.step('return value is correct', async () => {
+          return randomValue;
+        });
+        expect(valueFromStep).toBe(randomValue);
+      });
+      test('void', async ({ page }) => {
+        const valueFromStep = await test.step('return value is correct', async () => {});
+        expect(valueFromStep).toBe(undefined);
+      });
+    `
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+});
+

--- a/tests/playwright-test/types-2.spec.ts
+++ b/tests/playwright-test/types-2.spec.ts
@@ -107,3 +107,26 @@ test('test.declare should check types', async ({ runTSC }) => {
   });
   expect(result.exitCode).toBe(0);
 });
+
+test('test.step should have as return type the exact type resolved in the step', async ({ runTSC }) => {
+  const result = await runTSC({
+    'a.spec.ts': `
+      type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
+      type IsAny<T> = IfAny<T, true, false>;
+      const { test } = pwt;
+      test('pass', async () => {
+        const shouldBeVoid = await test.step('should return void', async () => {});
+        const shouldBeVoidAnyCheck: IsAny<typeof shouldBeVoid> = false;
+        const shouldBeVoidCheck: typeof shouldBeVoid = void 0;
+        
+        type T = { a: number };
+        const shouldBeT = await test.step('should return void', async () => {
+          return { a: 1 } as T;
+        });
+        const shouldBeTAnyCheck: IsAny<typeof shouldBeT> = false;
+        const shouldBeTCheck: typeof shouldBeT = {  a: 1 } as T;
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+});

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -258,7 +258,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
   beforeAll(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   afterAll(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   use(fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs>): void;
-  step(title: string, body: () => Promise<any>): Promise<any>;
+  step<T extends any = any>(title: string, body: () => Promise<T>): Promise<T>;
   expect: Expect;
   declare<T extends KeyValue = {}, W extends KeyValue = {}>(): TestType<TestArgs & T, WorkerArgs & W>;
   extend<T, W extends KeyValue = {}>(fixtures: Fixtures<T, W, TestArgs, WorkerArgs>): TestType<TestArgs & T, WorkerArgs & W>;


### PR DESCRIPTION
Closes #9742

The test.step signature has been changed from:

```ts
step(title: string, body: () => Promise<any>): Promise<any>;
```

to:

```ts
step<T extends any = any>(title: string, body: () => Promise<T>): Promise<T>;
```

This is a backward-compatible change.

It allows the developer to use the return value from the `test.step` if they want to. This improves the DX in case you want to return some values from a `test.step` to use it again inside the current test.