### PR TITLE
fix(devops): do not upload -win32.zip to Azure

### DIFF
--- a/utils/build/upload-playwright-driver.sh
+++ b/utils/build/upload-playwright-driver.sh
@@ -9,4 +9,3 @@ PACKAGE_VERSION=$(node -p "require('../../package.json').version")
 az storage blob upload -c builds --account-key ${AZ_ACCOUNT_KEY} --account-name ${AZ_ACCOUNT_NAME} -f ./output/playwright-${PACKAGE_VERSION}-mac.zip -n "${AZ_UPLOAD_FOLDER}/playwright-${PACKAGE_VERSION}-mac.zip"
 az storage blob upload -c builds --account-key ${AZ_ACCOUNT_KEY} --account-name ${AZ_ACCOUNT_NAME} -f ./output/playwright-${PACKAGE_VERSION}-linux.zip -n "${AZ_UPLOAD_FOLDER}/playwright-${PACKAGE_VERSION}-linux.zip"
 az storage blob upload -c builds --account-key ${AZ_ACCOUNT_KEY} --account-name ${AZ_ACCOUNT_NAME} -f ./output/playwright-${PACKAGE_VERSION}-win32_x64.zip -n "${AZ_UPLOAD_FOLDER}/playwright-${PACKAGE_VERSION}-win32_x64.zip"
-az storage blob upload -c builds --account-key ${AZ_ACCOUNT_KEY} --account-name ${AZ_ACCOUNT_NAME} -f ./output/playwright-${PACKAGE_VERSION}-win32.zip -n "${AZ_UPLOAD_FOLDER}/playwright-${PACKAGE_VERSION}-win32.zip"


### PR DESCRIPTION
Otherwise we get this:

ERROR: [Errno 2] No such file or directory: './output/playwright-1.17.0-next-1635521587000-win32.zip'
