### PR TITLE
docs(page): Document Page.reload

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2411,6 +2411,7 @@ Shortcut for main frame's [`method: Frame.querySelectorAll`].
 ## async method: Page.reload
 - returns: <[null]|[Response]>
 
+This method reloads the current page, in the same way as if the user had triggered a browser refresh.
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
 last redirect.
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2730,8 +2730,8 @@ export interface Page {
   }): Promise<void>;
 
   /**
-   * Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
-   * last redirect.
+   * This method reloads the current page, in the same way as if the user had triggered a browser refresh. Returns the main
+   * resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
    * @param options
    */
   reload(options?: {


### PR DESCRIPTION
I found this question on Stack Overflow https://stackoverflow.com/questions/69792318/what-is-page-reloadoptions-in-playwright

Although it's quite obvious, I think it won't hurt to have some little explanation about what `reload` does.