### PR TITLE
devops: use Ubuntu 20.04 for Chromium Linux Arm64 build

### DIFF
--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -108,7 +108,7 @@ elif [[ "$BUILD_FLAVOR" == "chromium-linux-arm64" ]]; then
   EXTRA_BUILD_ARGS="--compile-linux-arm64"
   EXTRA_ARCHIVE_ARGS="--compile-linux-arm64"
   EXPECTED_HOST_OS="Ubuntu"
-  EXPECTED_HOST_OS_VERSION="18.04"
+  EXPECTED_HOST_OS_VERSION="20.04"
   BUILD_BLOB_NAME="chromium-linux-arm64.zip"
 
 # ===========================


### PR DESCRIPTION
This was we can better distribute load on our build bots.