### PR TITLE
docs(test-runner): worker fixtures only in before/after-All

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -66,7 +66,7 @@ Declares an `afterAll` hook that is executed once after all tests. When called i
 ### param: Test.afterAll.hookFunction
 - `hookFunction` <[function]\([Fixtures], [TestInfo]\)>
 
-Hook function that takes one or two arguments: an object with fixtures and optional [TestInfo].
+Hook function that takes one or two arguments: an object with worker fixtures and optional [TestInfo].
 
 
 
@@ -157,7 +157,7 @@ You can use [`method: Test.afterAll`] to teardown any resources set up in `befor
 ### param: Test.beforeAll.hookFunction
 - `hookFunction` <[function]\([Fixtures], [TestInfo]\)>
 
-Hook function that takes one or two arguments: an object with fixtures and optional [TestInfo].
+Hook function that takes one or two arguments: an object with worker fixtures and optional [TestInfo].
 
 
 

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -2473,7 +2473,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    *
    * You can use [test.afterAll(hookFunction)](https://playwright.dev/docs/api/class-test#test-after-all) to teardown any
    * resources set up in `beforeAll`.
-   * @param hookFunction Hook function that takes one or two arguments: an object with fixtures and optional [TestInfo].
+   * @param hookFunction Hook function that takes one or two arguments: an object with worker fixtures and optional [TestInfo].
    */
   beforeAll(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   /**
@@ -2481,7 +2481,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * all tests in the file. When called inside a
    * [test.describe(title, callback)](https://playwright.dev/docs/api/class-test#test-describe) group, runs after all tests
    * in the group.
-   * @param hookFunction Hook function that takes one or two arguments: an object with fixtures and optional [TestInfo].
+   * @param hookFunction Hook function that takes one or two arguments: an object with worker fixtures and optional [TestInfo].
    */
   afterAll(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   /**


### PR DESCRIPTION
https://github.com/microsoft/playwright/issues/9948