### PR TITLE
devops: fix chromium linux arm64 bit build

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -156,4 +156,4 @@ mirror_chromium() {
   unzip chromium-upstream.zip
 }
 
-main "$1"
+main "$1" "$2" "$3"


### PR DESCRIPTION
Drive-By: this should also fix chromium-with-symbols build to actually
have symbols!