### PR TITLE
chore: ignore grid version checks

### DIFF
--- a/packages/playwright-core/src/grid/gridServer.ts
+++ b/packages/playwright-core/src/grid/gridServer.ts
@@ -238,7 +238,7 @@ export class GridServer {
     this._wsServer.on('connection', async (ws, request) => {
       if (request.url?.startsWith(this._securePath('/claimWorker'))) {
         const params = new URL('http://localhost/' + request.url).searchParams;
-        if (params.get('pwVersion') !== this._pwVersion) {
+        if (params.get('pwVersion') !== this._pwVersion && !process.env.PWTEST_UNSAFE_GRID_VERSION) {
           ws.close(WSErrors.CLIENT_PLAYWRIGHT_VERSION_MISMATCH.code, WSErrors.CLIENT_PLAYWRIGHT_VERSION_MISMATCH.reason);
           return;
         }


### PR DESCRIPTION
This is a preparation for docker dogfooding: since in our own repo,
we run tip-of-tree tests against stable @playwright/test, we have
different versions for Playwright and Grid.

In our case, these versions should always be close-enough, so we
can disregard safety version checks for our usecase.