### PR TITLE
chore: bail out stable installation when running on Linux Arm64

### DIFF
--- a/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
@@ -2,6 +2,11 @@
 set -e
 set -x
 
+if [[ $(arch) == "aarch64" ]]; then
+  echo "ERROR: not supported on Linux Arm64"
+  exit 1
+fi
+
 is_user_root () { [ "${EUID:-$(id -u)}" -eq 0 ]; }
 if is_user_root; then
   maybesudo=""

--- a/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
@@ -2,6 +2,11 @@
 set -e
 set -x
 
+if [[ $(arch) == "aarch64" ]]; then
+  echo "ERROR: not supported on Linux Arm64"
+  exit 1
+fi
+
 is_user_root () { [ "${EUID:-$(id -u)}" -eq 0 ]; }
 if is_user_root; then
   maybesudo=""

--- a/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
@@ -3,6 +3,11 @@
 set -e
 set -x
 
+if [[ $(arch) == "aarch64" ]]; then
+  echo "ERROR: not supported on Linux Arm64"
+  exit 1
+fi
+
 is_user_root () { [ "${EUID:-$(id -u)}" -eq 0 ]; }
 if is_user_root; then
   maybesudo=""

--- a/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
@@ -3,6 +3,11 @@
 set -e
 set -x
 
+if [[ $(arch) == "aarch64" ]]; then
+  echo "ERROR: not supported on Linux Arm64"
+  exit 1
+fi
+
 is_user_root () { [ "${EUID:-$(id -u)}" -eq 0 ]; }
 if is_user_root; then
   maybesudo=""

--- a/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
@@ -3,6 +3,11 @@
 set -e
 set -x
 
+if [[ $(arch) == "aarch64" ]]; then
+  echo "ERROR: not supported on Linux Arm64"
+  exit 1
+fi
+
 is_user_root () { [ "${EUID:-$(id -u)}" -eq 0 ]; }
 if is_user_root; then
   maybesudo=""


### PR DESCRIPTION
Stable browser channels are only shipped on x86