### PR TITLE
fix(reporters): move more terminal output to terminal reporters

### DIFF
--- a/packages/playwright-test/src/reporters/line.ts
+++ b/packages/playwright-test/src/reporters/line.ts
@@ -16,19 +16,12 @@
 
 import colors from 'colors/safe';
 import { BaseReporter, formatFailure, formatTestTitle } from './base';
-import { FullConfig, TestCase, Suite, TestResult, FullResult } from '../../types/testReporter';
+import { TestCase, TestResult, FullResult } from '../../types/testReporter';
 
 class LineReporter extends BaseReporter {
-  private _total = 0;
   private _current = 0;
   private _failures = 0;
   private _lastTest: TestCase | undefined;
-
-  override onBegin(config: FullConfig, suite: Suite) {
-    super.onBegin(config, suite);
-    this._total = suite.allTests().length;
-    console.log();
-  }
 
   override onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
     super.onStdOut(chunk, test, result);
@@ -57,7 +50,7 @@ class LineReporter extends BaseReporter {
   override onTestEnd(test: TestCase, result: TestResult) {
     super.onTestEnd(test, result);
     const width = process.stdout.columns! - 1;
-    const title = `[${++this._current}/${this._total}] ${formatTestTitle(this.config, test)}`.substring(0, width);
+    const title = `[${++this._current}/${this.totalTestCount}] ${formatTestTitle(this.config, test)}`.substring(0, width);
     process.stdout.write(`\u001B[1A\u001B[2K${title}\n`);
 
     if (!this._omitFailures && !this.willRetry(test) && (test.outcome() === 'flaky' || test.outcome() === 'unexpected')) {

--- a/packages/playwright-test/src/reporters/list.ts
+++ b/packages/playwright-test/src/reporters/list.ts
@@ -18,7 +18,7 @@
 import colors from 'colors/safe';
 import milliseconds from 'ms';
 import { BaseReporter, formatTestTitle } from './base';
-import { FullConfig, FullResult, Suite, TestCase, TestResult, TestStep } from '../../types/testReporter';
+import { FullResult, TestCase, TestResult, TestStep } from '../../types/testReporter';
 
 // Allow it in the Visual Studio Code Terminal and the new Windows Terminal
 const DOES_NOT_SUPPORT_UTF8_IN_TERMINAL = process.platform === 'win32' && process.env.TERM_PROGRAM !== 'vscode' && !process.env.WT_SESSION;
@@ -36,11 +36,6 @@ class ListReporter extends BaseReporter {
     super(options);
     this._ttyWidthForTest = parseInt(process.env.PWTEST_TTY_WIDTH || '', 10);
     this._liveTerminal = process.stdout.isTTY || process.env.PWTEST_SKIP_TEST_OUTPUT || !!this._ttyWidthForTest;
-  }
-
-  override onBegin(config: FullConfig, suite: Suite) {
-    super.onBegin(config, suite);
-    console.log();
   }
 
   onTestBegin(test: TestCase) {

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -294,13 +294,7 @@ export class Runner {
         filterSuite(rootSuite, () => false, test => shardTests.has(test));
         total = rootSuite.allTests().length;
       }
-
-      if (process.stdout.isTTY) {
-        console.log();
-        const jobs = Math.min(config.workers, testGroups.length);
-        const shardDetails = shard ? `, shard ${shard.current} of ${shard.total}` : '';
-        console.log(`Running ${total} test${total > 1 ? 's' : ''} using ${jobs} worker${jobs > 1 ? 's' : ''}${shardDetails}`);
-      }
+      (config as any).__testGroupsCount = testGroups.length;
 
       let sigint = false;
       let sigintCallback: () => void;

--- a/tests/playwright-test/reporter-github.spec.ts
+++ b/tests/playwright-test/reporter-github.spec.ts
@@ -54,23 +54,3 @@ test('print GitHub annotations for failed tests', async ({ runInlineTest }, test
   expect(text).toContain(`::error file=${testPath},title=a.test.js:6:7 › example,line=7,col=23::  1) a.test.js:6:7 › example =======================================================================%0A%0A    Retry #3`);
   expect(result.exitCode).toBe(1);
 });
-
-test('print GitHub annotations for slow tests', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'playwright.config.ts': `
-      module.exports = {
-        reportSlowTests: { max: 0, threshold: 100 }
-      };
-    `,
-    'a.test.js': `
-      const { test } = pwt;
-      test('slow test', async ({}) => {
-        await new Promise(f => setTimeout(f, 200));
-      });
-    `
-  }, { retries: 3, reporter: 'github' }, { GITHUB_WORKSPACE: '' });
-  const text = stripAscii(result.output);
-  expect(text).toContain('::warning title=Slow Test,file=a.test.js::a.test.js took');
-  expect(text).toContain('::notice title=🎭 Playwright Run Summary::  1 passed');
-  expect(result.exitCode).toBe(0);
-});

--- a/tests/playwright-test/retry.spec.ts
+++ b/tests/playwright-test/retry.spec.ts
@@ -72,7 +72,7 @@ test('should retry timeout', async ({ runInlineTest }) => {
   expect(exitCode).toBe(1);
   expect(passed).toBe(0);
   expect(failed).toBe(1);
-  expect(stripAscii(output).split('\n')[0]).toBe('××T');
+  expect(stripAscii(output).split('\n')[3]).toBe('××T');
 });
 
 test('should fail on unexpected pass with retries', async ({ runInlineTest }) => {
@@ -103,7 +103,7 @@ test('should retry unexpected pass', async ({ runInlineTest }) => {
   expect(exitCode).toBe(1);
   expect(passed).toBe(0);
   expect(failed).toBe(1);
-  expect(stripAscii(output).split('\n')[0]).toBe('××F');
+  expect(stripAscii(output).split('\n')[3]).toBe('××F');
 });
 
 test('should not retry expected failure', async ({ runInlineTest }) => {
@@ -123,7 +123,7 @@ test('should not retry expected failure', async ({ runInlineTest }) => {
   expect(exitCode).toBe(0);
   expect(passed).toBe(2);
   expect(failed).toBe(0);
-  expect(stripAscii(output).split('\n')[0]).toBe('··');
+  expect(stripAscii(output).split('\n')[3]).toBe('··');
 });
 
 test('should retry unhandled rejection', async ({ runInlineTest }) => {
@@ -141,7 +141,7 @@ test('should retry unhandled rejection', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);
-  expect(stripAscii(result.output).split('\n')[0]).toBe('××F');
+  expect(stripAscii(result.output).split('\n')[3]).toBe('××F');
   expect(result.output).toContain('Unhandled rejection');
 });
 
@@ -162,7 +162,7 @@ test('should retry beforeAll failure', async ({ runInlineTest }) => {
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);
   expect(result.skipped).toBe(1);
-  expect(stripAscii(result.output).split('\n')[0]).toBe('×°×°F°');
+  expect(stripAscii(result.output).split('\n')[3]).toBe('×°×°F°');
   expect(result.output).toContain('BeforeAll is bugged!');
 });
 
@@ -184,6 +184,6 @@ test('should retry worker fixture setup failure', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);
-  expect(stripAscii(result.output).split('\n')[0]).toBe('××F');
+  expect(stripAscii(result.output).split('\n')[3]).toBe('××F');
   expect(result.output).toContain('worker setup is bugged!');
 });


### PR DESCRIPTION
This makes 'Running X tests using Y workers' visible on CI as long as you specify terminal reporter, and generally makes the code cleaner.

Drive-by: refactor github repoter to not inherit from base, since it is not a terminal reporter.

Note: `base.ts` is just a code except for the `onBegin` method.
Note: tests changed because we now print 'Running X tests' in the tests no matter the `stdout.isTTY`.

References #9847.