### PR TITLE
fix(html-reporter): teardown web server correctly

### DIFF
--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -41,6 +41,7 @@ export async function showTraceViewer(traceUrl: string, browserName: string, hea
     return server.serveFile(response, absolutePath);
   });
 
+  process.on('exit', () => server.stop().catch(() => { }));
   const urlPrefix = await server.start(port);
 
   const traceViewerPlaywright = createPlaywright('javascript', true);

--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -171,6 +171,7 @@ export async function showHTMLReport(reportFolder: string | undefined, testId?: 
     return;
   }
   const server = startHtmlReportServer(folder);
+  process.on('exit', () => server.stop().catch(() => { }));
   let url = await server.start(9323);
   console.log('');
   console.log(colors.cyan(`  Serving HTML report at ${url}. Press Ctrl+C to quit.`));


### PR DESCRIPTION
Thought also to put this magic piece into the httpServer.start directly so the httpServer users don't have to worry about it, but was unsure.

Fixes #10010