### PR TITLE
feat(route): silent catch route methods

### DIFF
--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -152,7 +152,6 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel,
         return;
       }
     }
-    // it can race with BrowserContext.close() which then throws since its closed
     route._internalContinue();
   }
 

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -230,7 +230,8 @@ export class Route extends ChannelOwner<channels.RouteChannel, channels.RouteIni
 
   async abort(errorCode?: string) {
     return this._wrapApiCall(async (channel: channels.RouteChannel) => {
-      await channel.abort({ errorCode });
+      // Route often happens concurrently to page close, so we catch.
+      await channel.abort({ errorCode }).catch(() => {});
     });
   }
 
@@ -277,7 +278,7 @@ export class Route extends ChannelOwner<channels.RouteChannel, channels.RouteIni
         body,
         isBase64,
         fetchResponseUid
-      });
+      }).catch(() => {}); // Route often happens concurrently to page close, so we catch.
     });
   }
 
@@ -286,7 +287,7 @@ export class Route extends ChannelOwner<channels.RouteChannel, channels.RouteIni
   }
 
   async _internalContinue(options: { url?: string, method?: string, headers?: Headers, postData?: string | Buffer } = {}) {
-    await this._continue(options, true).catch(() => {});
+    await this._continue(options, true);
   }
 
   private async _continue(options: { url?: string, method?: string, headers?: Headers, postData?: string | Buffer }, isInternal?: boolean) {
@@ -297,7 +298,7 @@ export class Route extends ChannelOwner<channels.RouteChannel, channels.RouteIni
         method: options.method,
         headers: options.headers ? headersObjectToArray(options.headers) : undefined,
         postData: postDataBuffer ? postDataBuffer.toString('base64') : undefined,
-      });
+      }).catch(() => {}); // Route often happens concurrently to page close, so we catch.
     }, undefined, isInternal);
   }
 }

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -270,12 +270,6 @@ export class Route extends SdkObject {
 
   async continue(overrides: types.NormalizedContinueOverrides = {}) {
     assert(!this._handled, 'Route is already handled!');
-    if (overrides.url) {
-      const newUrl = new URL(overrides.url);
-      const oldUrl = new URL(this._request.url());
-      if (oldUrl.protocol !== newUrl.protocol)
-        throw new Error('New URL must have same protocol as overridden URL');
-    }
     await this._delegate.continue(this._request, overrides);
   }
 }


### PR DESCRIPTION
Methods `route.abort()`, `route.continue()` and `route.fulfill()` are often
called outside of the control flow, and could happen while the page is closing
or already closed.

In this case, it is usually fine to just forget about the route error.