### PR TITLE
chore: fix connectOverCDP on Windows when proxy is used

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -92,7 +92,11 @@ export class Chromium extends BrowserType {
       artifactsDir,
       downloadsPath: artifactsDir,
       tracesDir: artifactsDir,
-      // Chromium on Windows global proxy workaround
+      // On Windows context level proxies only work, if there isn't a global proxy
+      // set. This is currently a bug in the CR/Windows networking stack. By
+      // passing an arbitrary value we disable the check in PW land which warns
+      // users in normal (launch/launchServer) mode since otherwise connectOverCDP
+      // does not work at all with proxies on Windows.
       proxy: { server: 'per-context' },
     };
     progress.throwIfAborted();

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -91,7 +91,9 @@ export class Chromium extends BrowserType {
       browserLogsCollector: new RecentLogsCollector(),
       artifactsDir,
       downloadsPath: artifactsDir,
-      tracesDir: artifactsDir
+      tracesDir: artifactsDir,
+      // Chromium on Windows global proxy workaround
+      proxy: { server: 'per-context' },
     };
     progress.throwIfAborted();
     const browser = await CRBrowser.connect(chromeTransport, browserOptions);


### PR DESCRIPTION
Before this was throwing on Windows:

https://github.com/microsoft/playwright/blob/56ca3a18f56f4759da0e3f7e7a698e83948c3e4d/packages/playwright-core/src/server/browserContext.ts#L424-L426

Alternatively we could introduce again a connection mode e.g. on the browser and don't validate if connectOverCDP is used.

Fixes #10077