### PR TITLE
chore: rename Fetch Request/Response internally to API

### DIFF
--- a/packages/playwright-core/src/client/api.ts
+++ b/packages/playwright-core/src/client/api.ts
@@ -34,7 +34,7 @@ export { Frame } from './frame';
 export { Keyboard, Mouse, Touchscreen } from './input';
 export { JSHandle } from './jsHandle';
 export { Request, Response, Route, WebSocket } from './network';
-export { Fetch as APIRequest, FetchRequest as APIRequestContext, FetchResponse as APIResponse } from './fetch';
+export { APIRequest, APIRequestContext, APIResponse } from './fetch';
 export { Page } from './page';
 export { Selectors } from './selectors';
 export { Tracing } from './tracing';

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -36,7 +36,7 @@ import { CDPSession } from './cdpSession';
 import { Tracing } from './tracing';
 import type { BrowserType } from './browserType';
 import { Artifact } from './artifact';
-import { FetchRequest } from './fetch';
+import { APIRequestContext } from './fetch';
 import { createInstrumentation } from './clientInstrumentation';
 
 export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel, channels.BrowserContextInitializer> implements api.BrowserContext {
@@ -50,7 +50,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel,
   private _closedPromise: Promise<void>;
   _options: channels.BrowserNewContextParams = { };
 
-  readonly request: FetchRequest;
+  readonly request: APIRequestContext;
   readonly tracing: Tracing;
   readonly _backgroundPages = new Set<Page>();
   readonly _serviceWorkers = new Set<Worker>();
@@ -70,7 +70,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel,
       this._browser = parent;
     this._isChromium = this._browser?._name === 'chromium';
     this.tracing = new Tracing(this);
-    this.request = FetchRequest.from(initializer.fetchRequest);
+    this.request = APIRequestContext.from(initializer.APIRequestContext);
 
     this._channel.on('bindingCall', ({ binding }) => this._onBinding(BindingCall.from(binding)));
     this._channel.on('close', () => this._onClose());

--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -39,7 +39,7 @@ import { ParsedStackTrace } from '../utils/stackTrace';
 import { Artifact } from './artifact';
 import { EventEmitter } from 'events';
 import { JsonPipe } from './jsonPipe';
-import { FetchRequest } from './fetch';
+import { APIRequestContext } from './fetch';
 
 class Root extends ChannelOwner<channels.RootChannel, {}> {
   constructor(connection: Connection) {
@@ -185,6 +185,9 @@ export class Connection extends EventEmitter {
       case 'AndroidDevice':
         result = new AndroidDevice(parent, type, guid, initializer);
         break;
+      case 'APIRequestContext':
+        result = new APIRequestContext(parent, type, guid, initializer);
+        break;
       case 'Artifact':
         result = new Artifact(parent, type, guid, initializer);
         break;
@@ -217,9 +220,6 @@ export class Connection extends EventEmitter {
         break;
       case 'ElementHandle':
         result = new ElementHandle(parent, type, guid, initializer);
-        break;
-      case 'FetchRequest':
-        result = new FetchRequest(parent, type, guid, initializer);
         break;
       case 'Frame':
         result = new Frame(parent, type, guid, initializer);

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -30,7 +30,7 @@ import * as api from '../../types/types';
 import { HeadersArray, URLMatch } from '../common/types';
 import { urlMatches } from './clientHelper';
 import { MultiMap } from '../utils/multimap';
-import { FetchResponse } from './fetch';
+import { APIResponse } from './fetch';
 
 export type NetworkCookie = {
   name: string,
@@ -241,8 +241,8 @@ export class Route extends ChannelOwner<channels.RouteChannel, channels.RouteIni
       if (options.response) {
         statusOption ||= options.response.status();
         headersOption ||= options.response.headers();
-        if (options.body === undefined && options.path === undefined && options.response instanceof FetchResponse)
-          fetchResponseUid = (options.response as FetchResponse)._fetchUid();
+        if (options.body === undefined && options.path === undefined && options.response instanceof APIResponse)
+          fetchResponseUid = (options.response as APIResponse)._fetchUid();
       }
 
       let isBase64 = false;

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -47,7 +47,7 @@ import { isString, isRegExp, isObject, mkdirIfNeeded, headersObjectToArray } fro
 import { isSafeCloseError } from '../utils/errors';
 import { Video } from './video';
 import { Artifact } from './artifact';
-import { FetchRequest } from './fetch';
+import { APIRequestContext } from './fetch';
 
 type PDFOptions = Omit<channels.PagePdfParams, 'width' | 'height' | 'margin'> & {
   width?: string | number,
@@ -78,7 +78,7 @@ export class Page extends ChannelOwner<channels.PageChannel, channels.PageInitia
   readonly coverage: Coverage;
   readonly keyboard: Keyboard;
   readonly mouse: Mouse;
-  readonly request: FetchRequest;
+  readonly request: APIRequestContext;
   readonly touchscreen: Touchscreen;
 
   readonly _bindings = new Map<string, (source: structs.BindingSource, ...args: any[]) => any>();

--- a/packages/playwright-core/src/client/playwright.ts
+++ b/packages/playwright-core/src/client/playwright.ts
@@ -24,7 +24,7 @@ import { Android } from './android';
 import { BrowserType } from './browserType';
 import { ChannelOwner } from './channelOwner';
 import { Electron } from './electron';
-import { Fetch } from './fetch';
+import { APIRequest } from './fetch';
 import { Selectors, SelectorsOwner } from './selectors';
 import { Size } from './types';
 const dnsLookupAsync = util.promisify(dns.lookup);
@@ -47,14 +47,14 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel, channel
   readonly webkit: BrowserType;
   readonly devices: Devices;
   selectors: Selectors;
-  readonly request: Fetch;
+  readonly request: APIRequest;
   readonly errors: { TimeoutError: typeof TimeoutError };
   private _sockets = new Map<string, net.Socket>();
   private _redirectPortForTest: number | undefined;
 
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.PlaywrightInitializer) {
     super(parent, type, guid, initializer);
-    this.request = new Fetch(this);
+    this.request = new APIRequest(this);
     this.chromium = BrowserType.from(initializer.chromium);
     this.chromium._playwright = this;
     this.firefox = BrowserType.from(initializer.firefox);

--- a/packages/playwright-core/src/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/dispatchers/browserContextDispatcher.ts
@@ -19,7 +19,7 @@ import { Dispatcher, DispatcherScope, lookupDispatcher } from './dispatcher';
 import { PageDispatcher, BindingCallDispatcher, WorkerDispatcher } from './pageDispatcher';
 import { FrameDispatcher } from './frameDispatcher';
 import * as channels from '../protocol/channels';
-import { RouteDispatcher, RequestDispatcher, ResponseDispatcher, FetchRequestDispatcher } from './networkDispatchers';
+import { RouteDispatcher, RequestDispatcher, ResponseDispatcher, APIRequestContextDispatcher } from './networkDispatchers';
 import { CRBrowserContext } from '../server/chromium/crBrowser';
 import { CDPSessionDispatcher } from './cdpSessionDispatcher';
 import { RecorderSupplement } from '../server/supplements/recorderSupplement';
@@ -34,7 +34,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   constructor(scope: DispatcherScope, context: BrowserContext) {
     super(scope, context, 'BrowserContext', {
       isChromium: context._browser.options.isChromium,
-      fetchRequest: FetchRequestDispatcher.from(scope, context.fetchRequest),
+      APIRequestContext: APIRequestContextDispatcher.from(scope, context.fetchRequest),
     }, true);
     this._context = context;
     // Note: when launching persistent context, dispatcher is created very late,

--- a/packages/playwright-core/src/dispatchers/networkDispatchers.ts
+++ b/packages/playwright-core/src/dispatchers/networkDispatchers.ts
@@ -15,7 +15,7 @@
  */
 
 import * as channels from '../protocol/channels';
-import { FetchRequest } from '../server/fetch';
+import { APIRequestContext } from '../server/fetch';
 import { CallMetadata } from '../server/instrumentation';
 import { Request, Response, Route, WebSocket } from '../server/network';
 import { Dispatcher, DispatcherScope, existingDispatcher, lookupNullableDispatcher } from './dispatcher';
@@ -143,33 +143,33 @@ export class WebSocketDispatcher extends Dispatcher<WebSocket, channels.WebSocke
   }
 }
 
-export class FetchRequestDispatcher extends Dispatcher<FetchRequest, channels.FetchRequestInitializer, channels.FetchRequestEvents> implements channels.FetchRequestChannel {
-  static from(scope: DispatcherScope, request: FetchRequest): FetchRequestDispatcher {
-    const result = existingDispatcher<FetchRequestDispatcher>(request);
-    return result || new FetchRequestDispatcher(scope, request);
+export class APIRequestContextDispatcher extends Dispatcher<APIRequestContext, channels.APIRequestContextInitializer, channels.APIRequestContextEvents> implements channels.APIRequestContextChannel {
+  static from(scope: DispatcherScope, request: APIRequestContext): APIRequestContextDispatcher {
+    const result = existingDispatcher<APIRequestContextDispatcher>(request);
+    return result || new APIRequestContextDispatcher(scope, request);
   }
 
-  static fromNullable(scope: DispatcherScope, request: FetchRequest | null): FetchRequestDispatcher | undefined {
-    return request ? FetchRequestDispatcher.from(scope, request) : undefined;
+  static fromNullable(scope: DispatcherScope, request: APIRequestContext | null): APIRequestContextDispatcher | undefined {
+    return request ? APIRequestContextDispatcher.from(scope, request) : undefined;
   }
 
-  private constructor(scope: DispatcherScope, request: FetchRequest) {
-    super(scope, request, 'FetchRequest', {}, true);
-    request.once(FetchRequest.Events.Dispose, () => {
+  private constructor(scope: DispatcherScope, request: APIRequestContext) {
+    super(scope, request, 'APIRequestContext', {}, true);
+    request.once(APIRequestContext.Events.Dispose, () => {
       if (!this._disposed)
         super._dispose();
     });
   }
 
-  async storageState(params?: channels.FetchRequestStorageStateParams): Promise<channels.FetchRequestStorageStateResult> {
+  async storageState(params?: channels.APIRequestContextStorageStateParams): Promise<channels.APIRequestContextStorageStateResult> {
     return this._object.storageState();
   }
 
-  async dispose(params?: channels.FetchRequestDisposeParams): Promise<void> {
+  async dispose(params?: channels.APIRequestContextDisposeParams): Promise<void> {
     this._object.dispose();
   }
 
-  async fetch(params: channels.FetchRequestFetchParams, metadata?: channels.Metadata): Promise<channels.FetchRequestFetchResult> {
+  async fetch(params: channels.APIRequestContextFetchParams, metadata?: channels.Metadata): Promise<channels.APIRequestContextFetchResult> {
     const { fetchResponse, error } = await this._object.fetch(params);
     let response;
     if (fetchResponse) {
@@ -184,12 +184,12 @@ export class FetchRequestDispatcher extends Dispatcher<FetchRequest, channels.Fe
     return { response, error };
   }
 
-  async fetchResponseBody(params: channels.FetchRequestFetchResponseBodyParams, metadata?: channels.Metadata): Promise<channels.FetchRequestFetchResponseBodyResult> {
+  async fetchResponseBody(params: channels.APIRequestContextFetchResponseBodyParams, metadata?: channels.Metadata): Promise<channels.APIRequestContextFetchResponseBodyResult> {
     const buffer = this._object.fetchResponses.get(params.fetchUid);
     return { binary: buffer ? buffer.toString('base64') : undefined };
   }
 
-  async disposeFetchResponse(params: channels.FetchRequestDisposeFetchResponseParams, metadata?: channels.Metadata): Promise<void> {
+  async disposeAPIResponse(params: channels.APIRequestContextDisposeAPIResponseParams, metadata?: channels.Metadata): Promise<void> {
     this._object.fetchResponses.delete(params.fetchUid);
   }
 }

--- a/packages/playwright-core/src/dispatchers/playwrightDispatcher.ts
+++ b/packages/playwright-core/src/dispatchers/playwrightDispatcher.ts
@@ -16,7 +16,7 @@
 
 import net, { AddressInfo } from 'net';
 import * as channels from '../protocol/channels';
-import { GlobalFetchRequest } from '../server/fetch';
+import { GlobalAPIRequestContext } from '../server/fetch';
 import { Playwright } from '../server/playwright';
 import * as types from '../server/types';
 import { debugLogger } from '../utils/debugLogger';
@@ -26,7 +26,7 @@ import { AndroidDispatcher } from './androidDispatcher';
 import { BrowserTypeDispatcher } from './browserTypeDispatcher';
 import { Dispatcher, DispatcherScope } from './dispatcher';
 import { ElectronDispatcher } from './electronDispatcher';
-import { FetchRequestDispatcher } from './networkDispatchers';
+import { APIRequestContextDispatcher } from './networkDispatchers';
 import { SelectorsDispatcher } from './selectorsDispatcher';
 
 export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.PlaywrightInitializer, channels.PlaywrightEvents> implements channels.PlaywrightChannel {
@@ -75,8 +75,8 @@ export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.Playwr
   }
 
   async newRequest(params: channels.PlaywrightNewRequestParams, metadata?: channels.Metadata): Promise<channels.PlaywrightNewRequestResult> {
-    const request = new GlobalFetchRequest(this._object, params);
-    return { request: FetchRequestDispatcher.from(this._scope, request) };
+    const request = new GlobalAPIRequestContext(this._object, params);
+    return { request: APIRequestContextDispatcher.from(this._scope, request) };
   }
 }
 

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -161,16 +161,16 @@ export type FormField = {
   },
 };
 
-// ----------- FetchRequest -----------
-export type FetchRequestInitializer = {};
-export interface FetchRequestChannel extends Channel {
-  fetch(params: FetchRequestFetchParams, metadata?: Metadata): Promise<FetchRequestFetchResult>;
-  fetchResponseBody(params: FetchRequestFetchResponseBodyParams, metadata?: Metadata): Promise<FetchRequestFetchResponseBodyResult>;
-  storageState(params?: FetchRequestStorageStateParams, metadata?: Metadata): Promise<FetchRequestStorageStateResult>;
-  disposeFetchResponse(params: FetchRequestDisposeFetchResponseParams, metadata?: Metadata): Promise<FetchRequestDisposeFetchResponseResult>;
-  dispose(params?: FetchRequestDisposeParams, metadata?: Metadata): Promise<FetchRequestDisposeResult>;
+// ----------- APIRequestContext -----------
+export type APIRequestContextInitializer = {};
+export interface APIRequestContextChannel extends Channel {
+  fetch(params: APIRequestContextFetchParams, metadata?: Metadata): Promise<APIRequestContextFetchResult>;
+  fetchResponseBody(params: APIRequestContextFetchResponseBodyParams, metadata?: Metadata): Promise<APIRequestContextFetchResponseBodyResult>;
+  storageState(params?: APIRequestContextStorageStateParams, metadata?: Metadata): Promise<APIRequestContextStorageStateResult>;
+  disposeAPIResponse(params: APIRequestContextDisposeAPIResponseParams, metadata?: Metadata): Promise<APIRequestContextDisposeAPIResponseResult>;
+  dispose(params?: APIRequestContextDisposeParams, metadata?: Metadata): Promise<APIRequestContextDisposeResult>;
 }
-export type FetchRequestFetchParams = {
+export type APIRequestContextFetchParams = {
   url: string,
   params?: NameValue[],
   method?: string,
@@ -183,7 +183,7 @@ export type FetchRequestFetchParams = {
   failOnStatusCode?: boolean,
   ignoreHTTPSErrors?: boolean,
 };
-export type FetchRequestFetchOptions = {
+export type APIRequestContextFetchOptions = {
   params?: NameValue[],
   method?: string,
   headers?: NameValue[],
@@ -195,40 +195,40 @@ export type FetchRequestFetchOptions = {
   failOnStatusCode?: boolean,
   ignoreHTTPSErrors?: boolean,
 };
-export type FetchRequestFetchResult = {
-  response?: FetchResponse,
+export type APIRequestContextFetchResult = {
+  response?: APIResponse,
   error?: string,
 };
-export type FetchRequestFetchResponseBodyParams = {
+export type APIRequestContextFetchResponseBodyParams = {
   fetchUid: string,
 };
-export type FetchRequestFetchResponseBodyOptions = {
+export type APIRequestContextFetchResponseBodyOptions = {
 
 };
-export type FetchRequestFetchResponseBodyResult = {
+export type APIRequestContextFetchResponseBodyResult = {
   binary?: Binary,
 };
-export type FetchRequestStorageStateParams = {};
-export type FetchRequestStorageStateOptions = {};
-export type FetchRequestStorageStateResult = {
+export type APIRequestContextStorageStateParams = {};
+export type APIRequestContextStorageStateOptions = {};
+export type APIRequestContextStorageStateResult = {
   cookies: NetworkCookie[],
   origins: OriginStorage[],
 };
-export type FetchRequestDisposeFetchResponseParams = {
+export type APIRequestContextDisposeAPIResponseParams = {
   fetchUid: string,
 };
-export type FetchRequestDisposeFetchResponseOptions = {
+export type APIRequestContextDisposeAPIResponseOptions = {
 
 };
-export type FetchRequestDisposeFetchResponseResult = void;
-export type FetchRequestDisposeParams = {};
-export type FetchRequestDisposeOptions = {};
-export type FetchRequestDisposeResult = void;
+export type APIRequestContextDisposeAPIResponseResult = void;
+export type APIRequestContextDisposeParams = {};
+export type APIRequestContextDisposeOptions = {};
+export type APIRequestContextDisposeResult = void;
 
-export interface FetchRequestEvents {
+export interface APIRequestContextEvents {
 }
 
-export type FetchResponse = {
+export type APIResponse = {
   fetchUid: string,
   url: string,
   status: number,
@@ -389,7 +389,7 @@ export type PlaywrightNewRequestOptions = {
   },
 };
 export type PlaywrightNewRequestResult = {
-  request: FetchRequestChannel,
+  request: APIRequestContextChannel,
 };
 
 export interface PlaywrightEvents {
@@ -854,7 +854,7 @@ export interface EventTargetEvents {
 // ----------- BrowserContext -----------
 export type BrowserContextInitializer = {
   isChromium: boolean,
-  fetchRequest: FetchRequestChannel,
+  APIRequestContext: APIRequestContextChannel,
 };
 export interface BrowserContextChannel extends EventTargetChannel {
   on(event: 'bindingCall', callback: (params: BrowserContextBindingCallEvent) => void): this;

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -227,7 +227,7 @@ FormField:
         mimeType: string
         buffer: binary
 
-FetchRequest:
+APIRequestContext:
   type: interface
 
   commands:
@@ -254,7 +254,7 @@ FetchRequest:
         failOnStatusCode: boolean?
         ignoreHTTPSErrors: boolean?
       returns:
-        response: FetchResponse?
+        response: APIResponse?
         error: string?
 
     fetchResponseBody:
@@ -272,14 +272,14 @@ FetchRequest:
           type: array
           items: OriginStorage
 
-    disposeFetchResponse:
+    disposeAPIResponse:
       parameters:
         fetchUid: string
 
     dispose:
 
 
-FetchResponse:
+APIResponse:
   type: object
   properties:
     fetchUid: string
@@ -520,7 +520,7 @@ Playwright:
               items: OriginStorage
 
       returns:
-        request: FetchRequest
+        request: APIRequestContext
 
   events:
     socksRequested:
@@ -684,7 +684,7 @@ BrowserContext:
 
   initializer:
     isChromium: boolean
-    fetchRequest: FetchRequest
+    APIRequestContext: APIRequestContext
 
   commands:
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -157,7 +157,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
       buffer: tBinary,
     })),
   });
-  scheme.FetchRequestFetchParams = tObject({
+  scheme.APIRequestContextFetchParams = tObject({
     url: tString,
     params: tOptional(tArray(tType('NameValue'))),
     method: tOptional(tString),
@@ -170,15 +170,15 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     failOnStatusCode: tOptional(tBoolean),
     ignoreHTTPSErrors: tOptional(tBoolean),
   });
-  scheme.FetchRequestFetchResponseBodyParams = tObject({
+  scheme.APIRequestContextFetchResponseBodyParams = tObject({
     fetchUid: tString,
   });
-  scheme.FetchRequestStorageStateParams = tOptional(tObject({}));
-  scheme.FetchRequestDisposeFetchResponseParams = tObject({
+  scheme.APIRequestContextStorageStateParams = tOptional(tObject({}));
+  scheme.APIRequestContextDisposeAPIResponseParams = tObject({
     fetchUid: tString,
   });
-  scheme.FetchRequestDisposeParams = tOptional(tObject({}));
-  scheme.FetchResponse = tObject({
+  scheme.APIRequestContextDisposeParams = tOptional(tObject({}));
+  scheme.APIResponse = tObject({
     fetchUid: tString,
     url: tString,
     status: tNumber,

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -34,7 +34,7 @@ import { Tracing } from './trace/recorder/tracing';
 import { HarRecorder } from './supplements/har/harRecorder';
 import { RecorderSupplement } from './supplements/recorderSupplement';
 import * as consoleApiSource from '../generated/consoleApiSource';
-import { BrowserContextFetchRequest } from './fetch';
+import { BrowserContextAPIRequestContext } from './fetch';
 
 export abstract class BrowserContext extends SdkObject {
   static Events = {
@@ -64,7 +64,7 @@ export abstract class BrowserContext extends SdkObject {
   private _origins = new Set<string>();
   readonly _harRecorder: HarRecorder | undefined;
   readonly tracing: Tracing;
-  readonly fetchRequest: BrowserContextFetchRequest;
+  readonly fetchRequest: BrowserContextAPIRequestContext;
 
   constructor(browser: Browser, options: types.BrowserContextOptions, browserContextId: string | undefined) {
     super(browser, 'browser-context');
@@ -82,7 +82,7 @@ export abstract class BrowserContext extends SdkObject {
       this._harRecorder = new HarRecorder(this, { ...this._options.recordHar, path: path.join(this._browser.options.artifactsDir, `${createGuid()}.har`) });
 
     this.tracing = new Tracing(this);
-    this.fetchRequest = new BrowserContextFetchRequest(this);
+    this.fetchRequest = new BrowserContextAPIRequestContext(this);
   }
 
   isPersistentContext(): boolean {

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -20,7 +20,7 @@ import { assert } from '../utils/utils';
 import { ManualPromise } from '../utils/async';
 import { SdkObject } from './instrumentation';
 import { NameValue } from '../common/types';
-import { FetchRequest } from './fetch';
+import { APIRequestContext } from './fetch';
 
 export function filterCookies(cookies: types.NetworkCookie[], urls: string[]): types.NetworkCookie[] {
   const parsedURLs = urls.map(s => new URL(s));
@@ -251,7 +251,7 @@ export class Route extends SdkObject {
     if (body === undefined) {
       if (overrides.fetchResponseUid) {
         const context = this._request.frame()._page._browserContext;
-        const buffer = context.fetchRequest.fetchResponses.get(overrides.fetchResponseUid) || FetchRequest.findResponseBody(overrides.fetchResponseUid);
+        const buffer = context.fetchRequest.fetchResponses.get(overrides.fetchResponseUid) || APIRequestContext.findResponseBody(overrides.fetchResponseUid);
         assert(buffer, 'Fetch response has been disposed');
         body = buffer.toString('base64');
         isBase64 = true;

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -370,7 +370,7 @@ export type SetStorageState = {
   origins?: OriginStorage[]
 };
 
-export type FetchResponse = {
+export type APIResponse = {
   url: string,
   status: number,
   statusText: string,


### PR DESCRIPTION
Before that we sometimes used both inconsistent which makes it confusing for language ports.

- Fetch → APIRequest
- FetchRequest → APIRequestContext
- FetchResponse → APIResponse