### PR TITLE
browser(webkit): fix windows build

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1573
-Changed: dpino@igalia.com Thu Nov  4 11:53:07 UTC 2021
+1574
+Changed: yurys@chromium.org Fri, Nov  5, 2021  5:41:09 PM

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -20378,6 +20378,19 @@ index 259449423855fed3aaaab414819f8951a3b8b7ff..6ba9678f50190492ef5140d0793582a8
          return;
      }
  
+diff --git a/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp b/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp
+index 5edd887612819d7d25ce86713434dd0bd4aff78c..1a9e2fbe665a408ba230313f220f948462212d0d 100644
+--- a/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp
++++ b/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp
+@@ -83,7 +83,7 @@ void NotificationPermissionRequestManager::startRequest(const SecurityOriginData
+ 
+     m_page->sendWithAsyncReply(Messages::WebPageProxy::RequestNotificationPermission(securityOrigin.toString()), [this, protectedThis = Ref { *this }, securityOrigin, permissionHandler = WTFMove(permissionHandler)](bool allowed) mutable {
+ 
+-        auto innerPermissionHandler = [this, protectedThis = Ref { *this }, securityOrigin, permissionHandler = WTFMove(permissionHandler)] (bool allowed) mutable {
++        auto innerPermissionHandler = [this, protectedThis, securityOrigin, permissionHandler = WTFMove(permissionHandler)] (bool allowed) mutable {
+             WebProcess::singleton().supplement<WebNotificationManager>()->didUpdateNotificationDecision(securityOrigin.toString(), allowed);
+ 
+             auto permissionHandlers = m_requestsPerOrigin.take(securityOrigin);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 index 0c8da665770bd473aeaabab3f16af60160b2750f..064cec74ddedea795f2ebf6d9d921cf7d0209562 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp


### PR DESCRIPTION
https://github.com/yury-s/WebKit/commit/bb2eeac8857554ca2bfa7db078da51f52e1f72f1

Fixes the following compilation error on Windows after the latest roll:

```
58>D:\webkit\WebKitBuild\Release\WTF\Headers\wtf/Ref.h(67,16): error C2039: 'ref': is not a member of 'WebKit::NotificationPermissionRequestManager::startRequest::<lambda_1>' (compiling source file D:\webkit\WebKitBuild\Release\WebKit\DerivedSources\unified-sources\UnifiedSource-54928a2b-14.cpp)
58>D:\webkit\Source\WebKit\WebProcess/Notifications/NotificationPermissionRequestManager.cpp(100): message : see declaration of 'WebKit::NotificationPermissionRequestManager::startRequest::<lambda_1>' (compiling source file D:\webkit\WebKitBuild\Release\WebKit\DerivedSources\unified-sources\UnifiedSource-54928a2b-14.cpp)
58>D:\webkit\WebKitBuild\Release\WTF\Headers\wtf/Ref.h(64): message : while compiling class template member function 'WTF::Ref<WebKit::NotificationPermissionRequestManager::startRequest::<lambda_1>,WTF::RawPtrTraits<T>>::Ref(T &)'
58>        with
58>        [
58>            T=WebKit::NotificationPermissionRequestManager::startRequest::<lambda_1>
58>        ] (compiling source file D:\webkit\WebKitBuild\Release\WebKit\DerivedSources\unified-sources\UnifiedSource-54928a2b-14.cpp)
58>D:\webkit\Source\WebKit\WebProcess/Notifications/NotificationPermissionRequestManager.cpp(86): message : see reference to function template instantiation 'WTF::Ref<WebKit::NotificationPermissionRequestManager::startRequest::<lambda_1>,WTF::RawPtrTraits<T>>::Ref(T &)' being compiled
58>        with
58>        [
58>            T=WebKit::NotificationPermissionRequestManager::startRequest::<lambda_1>
58>        ] (compiling source file D:\webkit\WebKitBuild\Release\WebKit\DerivedSources\unified-sources\UnifiedSource-54928a2b-14.cpp)
58>D:\webkit\Source\WebKit\WebProcess/Notifications/NotificationPermissionRequestManager.cpp(100): message : see reference to class template instantiation 'WTF::Ref<WebKit::NotificationPermissionRequestManager::startRequest::<lambda_1>,WTF::RawPtrTraits<T>>' being compiled
58>        with
58>        [
58>            T=WebKit::NotificationPermissionRequestManager::startRequest::<lambda_1>
58>        ] (compiling source file D:\webkit\WebKitBuild\Release\WebKit\DerivedSources\unified-sources\UnifiedSource-54928a2b-14.cpp)
58>WebPage.cpp
```