### PR TITLE
devops: cross-compile firefox for Ubuntu 20.04 Arm64

### DIFF
--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -207,6 +207,13 @@ elif [[ "$BUILD_FLAVOR" == "firefox-ubuntu-20.04" ]]; then
   EXPECTED_HOST_OS="Ubuntu"
   EXPECTED_HOST_OS_VERSION="20.04"
   BUILD_BLOB_NAME="firefox-ubuntu-20.04.zip"
+elif [[ "$BUILD_FLAVOR" == "firefox-ubuntu-20.04-arm64" ]]; then
+  BROWSER_NAME="firefox"
+  EXTRA_BUILD_ARGS="--full --linux-arm64"
+  EXTRA_ARCHIVE_ARGS="--linux-arm64"
+  EXPECTED_HOST_OS="Ubuntu"
+  EXPECTED_HOST_OS_VERSION="20.04"
+  BUILD_BLOB_NAME="firefox-ubuntu-20.04-arm64.zip"
 elif [[ "$BUILD_FLAVOR" == "firefox-mac-11" ]]; then
   BROWSER_NAME="firefox"
   EXTRA_BUILD_ARGS="--full"

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1302
-Changed: yurys@chromium.org Thu 04 Nov 2021 12:24:04 PM PDT
+1303
+Changed: lushnikov@chromium.org Fri Nov  5 07:27:32 HST 2021

--- a/browser_patches/firefox/EXPECTED_BUILDS
+++ b/browser_patches/firefox/EXPECTED_BUILDS
@@ -2,4 +2,5 @@ firefox-mac-11.zip
 firefox-mac-11-arm64.zip
 firefox-ubuntu-18.04.zip
 firefox-ubuntu-20.04.zip
+firefox-ubuntu-20.04-arm64.zip
 firefox-win64.zip

--- a/browser_patches/firefox/archive.sh
+++ b/browser_patches/firefox/archive.sh
@@ -41,7 +41,11 @@ fi
 
 OBJ_FOLDER="obj-build-playwright"
 
-./mach package
+if [[ "$2" == "--linux-arm64" ]]; then
+  CMD_STRIP=/usr/bin/aarch64-linux-gnu-strip ./mach package
+else
+  ./mach package
+fi
 node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/$OBJ_FOLDER/dist/firefox
 
 if ! [[ -d $OBJ_FOLDER/dist/firefox ]]; then

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -51,6 +51,10 @@ else
   exit 1;
 fi
 
+if [[ $1 == "--linux-arm64" || $2 == "--linux-arm64" ]]; then
+  echo "ac_add_options --target=aarch64-linux-gnu" >> .mozconfig
+fi
+
 OBJ_FOLDER="obj-build-playwright"
 echo "mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/${OBJ_FOLDER}" >> .mozconfig
 echo "ac_add_options --disable-crashreporter" >> .mozconfig
@@ -82,6 +86,7 @@ if [[ $1 != "--juggler" ]]; then
 fi
 
 if [[ $1 == "--full" || $2 == "--full" ]]; then
+  echo "ac_add_options --enable-bootstrap" >> .mozconfig
   if [[ "$(uname)" == "Darwin" || "$(uname)" == "Linux" ]]; then
     SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser
   fi

--- a/browser_patches/firefox/patches/bootstrap.diff
+++ b/browser_patches/firefox/patches/bootstrap.diff
@@ -2123,6 +2123,19 @@ index 35526ca3a37327b324166dd42e450d108667a643..a2c70b2b432b2a714a928a1c08f520b0
    nsresult rv = NS_OK;
    nsCOMPtr<nsIContentSecurityPolicy> preloadCsp = mDocument->GetPreloadCsp();
    if (!preloadCsp) {
+diff --git a/python/mozbuild/mozpack/executables.py b/python/mozbuild/mozpack/executables.py
+index 0130e089e5ea3fd59b76b7ca6151460d0ea8aded..d8f04e345957bc5d02f2cfe1c80aa30ad052ae58 100644
+--- a/python/mozbuild/mozpack/executables.py
++++ b/python/mozbuild/mozpack/executables.py
+@@ -101,7 +101,7 @@ def strip(path):
+     """
+     from buildconfig import substs
+ 
+-    strip = substs["STRIP"]
++    strip = os.getenv("CMD_STRIP") or substs["STRIP"]
+     flags = substs.get("STRIP_FLAGS", [])
+     cmd = [strip] + flags + [path]
+     if subprocess.call(cmd) != 0:
 diff --git a/security/manager/ssl/nsCertOverrideService.cpp b/security/manager/ssl/nsCertOverrideService.cpp
 index e108f50ef6d3e9b7b2fd6dbdf5742bcba2e65571..6d34e51fc2f63626014ec8c13ff85c5f63e4cdd1 100644
 --- a/security/manager/ssl/nsCertOverrideService.cpp


### PR DESCRIPTION
This patch adds Firefox cross-compilation from x86_64 Ubuntu 20.04 to
arm64 Ubuntu 20.04.

This patch also fixes packaging logic for Firefox to use a STRIP
command from the aarch64 toolchain.

References #7723