### PR TITLE
devops: do not build Chromium with symbols for every commit

### DIFF
--- a/.github/workflows/trigger_build_chromium_with_symbols.yml
+++ b/.github/workflows/trigger_build_chromium_with_symbols.yml
@@ -12,7 +12,6 @@ on:
     types: [published]
   push:
     branches:
-      - master
       - release-*
     paths:
       - browser_patches/chromium/BUILD_NUMBER


### PR DESCRIPTION
Wastes a lot of compute for the thing we barely use.