### PR TITLE
ci(workflows): add 'npm' cache for actions/setup-node in .github/workflows

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
     - run: npm run build

--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         node-version: 12
         registry-url: 'https://registry.npmjs.org'
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
     - run: npm run build

--- a/.github/workflows/publish_canary_driver.yml
+++ b/.github/workflows/publish_canary_driver.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         node-version: 12
         registry-url: 'https://registry.npmjs.org'
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
     - run: npm run build

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -15,6 +15,7 @@ jobs:
       with:
         node-version: 12
         registry-url: 'https://registry.npmjs.org'
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
     - run: npm run build
@@ -33,6 +34,7 @@ jobs:
       with:
         node-version: 12
         registry-url: 'https://registry.npmjs.org'
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
     - run: npm run build

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 16
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
     - run: npm run build

--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -34,6 +34,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 14
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
     - run: npm run build

--- a/.github/workflows/tests_fyi.yml
+++ b/.github/workflows/tests_fyi.yml
@@ -24,6 +24,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -54,6 +55,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 14
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -32,6 +32,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -61,6 +62,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -80,6 +82,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -33,6 +33,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -63,6 +64,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -91,6 +93,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -125,6 +128,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node_version }}
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -145,6 +149,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -176,6 +181,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -206,6 +212,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -227,6 +234,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -252,6 +260,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -279,6 +288,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -304,6 +314,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -329,6 +340,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -356,6 +368,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -381,6 +394,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -407,6 +421,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -431,6 +446,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -456,6 +472,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -481,6 +498,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -505,6 +523,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -530,6 +549,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -555,6 +575,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -579,6 +600,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -604,6 +626,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -629,6 +652,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -656,6 +680,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -681,6 +706,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
       env:
@@ -705,6 +731,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - run: npm i -g npm@7
     - run: npm ci
     - run: npm run build

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -49,6 +49,7 @@ steps:
   - uses: actions/setup-node@v2
     with:
       node-version: '14'
+      cache: npm
   - name: Install operating system dependencies
     run: npx playwright install-deps
   - name: Run your tests
@@ -95,6 +96,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '14.x'
+        cache: npm
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright

--- a/packages/create-playwright/assets/github-actions.yml
+++ b/packages/create-playwright/assets/github-actions.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '14.x'
+        cache: npm
     - name: Install dependencies
       run: {{installDepsCommand}}
     - name: Install Playwright


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

### How much better it is with caching?
It depends on
- The amount of dependencies the project has ([you can see a summarized table in this ADR](https://github.com/actions/setup-node/issues/271#issuecomment-871408337))
- The size of these dependencies ([if it exceeds the limit of 5GB, the cache starts to overwrite old entries](https://github.com/actions/cache#cache-limits))
- How often does these pipelines run? ([GitHub will remove cache entries not accessed in the last 7 days](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy))
---

Context: 
* https://github.com/microsoft/playwright/pull/9451
* https://github.com/microsoft/playwright/pull/9451#issuecomment-948770133
