### PR TITLE
fix(route): catch all Route methods when page closes

### DIFF
--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -77,6 +77,30 @@ it('should not allow changing protocol when overriding url', async ({ page, serv
   expect(error.message).toContain('New URL must have same protocol as overridden URL');
 });
 
+it('should not throw when continuing while page is closing', async ({ page, server }) => {
+  let done;
+  await page.route('**/*', async route => {
+    done = Promise.all([
+      route.continue(),
+      page.close(),
+    ]);
+  });
+  const error = await page.goto(server.EMPTY_PAGE).catch(e => e);
+  await done;
+  expect(error).toBeInstanceOf(Error);
+});
+
+it('should not throw when continuing after page is closed', async ({ page, server }) => {
+  let done;
+  await page.route('**/*', async route => {
+    await page.close();
+    done = route.continue();
+  });
+  const error = await page.goto(server.EMPTY_PAGE).catch(e => e);
+  await done;
+  expect(error).toBeInstanceOf(Error);
+});
+
 it('should override method along with url', async ({ page, server }) => {
   const request = server.waitForRequest('/empty.html');
   await page.route('**/foo', route => {


### PR DESCRIPTION
This fixes a common scenario where you setup a route,
and the page closes (e.g. test ends) while we are aborting/continuing
some requests that are not instrumental to the test itself.