### PR TITLE
Chromium video duration fix

### DIFF
--- a/packages/playwright-core/src/server/chromium/videoRecorder.ts
+++ b/packages/playwright-core/src/server/chromium/videoRecorder.ts
@@ -141,10 +141,12 @@ export class VideoRecorder {
       for (let i = 0; i < repeatCount; ++i)
         this._frameQueue.push(this._lastFrameBuffer);
       this._lastWritePromise = this._lastWritePromise.then(() => this._sendFrames());
+      this._lastFrameTimestamp += repeatCount / fps;
+    } else {
+      this._lastFrameTimestamp = timestamp;
     }
 
     this._lastFrameBuffer = frame;
-    this._lastFrameTimestamp = timestamp;
     this._lastWriteTimestamp = monotonicTime();
   }
 

--- a/packages/playwright-core/src/server/chromium/videoRecorder.ts
+++ b/packages/playwright-core/src/server/chromium/videoRecorder.ts
@@ -27,6 +27,7 @@ const fps = 25;
 export class VideoRecorder {
   private _process: ChildProcess | null = null;
   private _gracefullyClose: (() => Promise<void>) | null = null;
+  private _launchTimestamp: number = 0;
   private _lastWritePromise: Promise<void> = Promise.resolve();
   private _lastFrameTimestamp: number = 0;
   private _lastFrameBuffer: Buffer | null = null;
@@ -123,6 +124,7 @@ export class VideoRecorder {
     });
     this._process = launchedProcess;
     this._gracefullyClose = gracefullyClose;
+    this._launchTimestamp = monotonicTime();
   }
 
   writeFrame(frame: Buffer, timestamp: number) {
@@ -143,7 +145,7 @@ export class VideoRecorder {
       this._lastWritePromise = this._lastWritePromise.then(() => this._sendFrames());
       this._lastFrameTimestamp += repeatCount / fps;
     } else {
-      this._lastFrameTimestamp = timestamp;
+      this._lastFrameTimestamp = timestamp - (monotonicTime() - this._launchTimestamp) / 1000;
     }
 
     this._lastFrameBuffer = frame;

--- a/packages/playwright-core/src/server/chromium/videoRecorder.ts
+++ b/packages/playwright-core/src/server/chromium/videoRecorder.ts
@@ -129,6 +129,10 @@ export class VideoRecorder {
     assert(this._process);
     if (this._isStopped)
       return;
+    if (timestamp - this._lastFrameTimestamp < 1 / fps) {
+      this._lastFrameBuffer = frame;
+      return;
+    }
     this._progress.log(`writing frame ` + timestamp);
 
     if (this._lastFrameBuffer) {


### PR DESCRIPTION
Videos recorded with playwright using chromium engine are longer than what could be expected by measuring execution time. It is caused by more than one problem:
- chromium can generate frames faster than what is expected by playwright which uses hardcoded 25 fps,
- timestamp of last added frame is taken from timestamp reported by browser which is not in 1/fps intervals,
- the first screencast frame is send by browser with slight delay from the start of screencast.

Fixes #9611