### PR TITLE
test: fix fixture teardown

### DIFF
--- a/tests/trace-viewer/trace-viewer.spec.ts
+++ b/tests/trace-viewer/trace-viewer.spec.ts
@@ -104,8 +104,8 @@ const test = playwrightTest.extend<{ showTraceViewer: (trace: string) => Promise
       browser = await playwright.chromium.connectOverCDP({ endpointURL: contextImpl._browser.options.wsEndpoint });
       return new TraceViewerPage(browser.contexts()[0].pages()[0]);
     });
-    await browser.close();
-    await contextImpl._browser.close();
+    await browser?.close();
+    await contextImpl?._browser.close();
   },
 
   runAndTrace: async ({ context, showTraceViewer }, use, testInfo) => {


### PR DESCRIPTION
In case a fixture was initialized, but never used, (e.g. a test was
skipped), both of the objects are undefined.