### PR TITLE
fix: resolve ip using grid/api/testsession endpoint

### DIFF
--- a/packages/playwright-core/src/utils/utils.ts
+++ b/packages/playwright-core/src/utils/utils.ts
@@ -40,7 +40,7 @@ const ProxyAgent = require('https-proxy-agent');
 
 export const existsAsync = (path: string): Promise<boolean> => new Promise(resolve => fs.stat(path, err => resolve(!err)));
 
-type HTTPRequestParams = {
+export type HTTPRequestParams = {
   url: string,
   method?: string,
   headers?: http.OutgoingHttpHeaders,
@@ -97,11 +97,11 @@ function httpRequest(params: HTTPRequestParams, onResponse: (r: http.IncomingMes
   request.end(params.data);
 }
 
-export function fetchData(params: HTTPRequestParams, onError?: (response: http.IncomingMessage) => Promise<Error>): Promise<string> {
+export function fetchData(params: HTTPRequestParams, onError?: (params: HTTPRequestParams, response: http.IncomingMessage) => Promise<Error>): Promise<string> {
   return new Promise((resolve, reject) => {
     httpRequest(params, async response => {
       if (response.statusCode !== 200) {
-        const error = onError ? await onError(response) : new Error(`fetch failed: server returned code ${response.statusCode}. URL: ${params.url}`);
+        const error = onError ? await onError(params, response) : new Error(`fetch failed: server returned code ${response.statusCode}. URL: ${params.url}`);
         reject(error);
         return;
       }

--- a/tests/browsertype-launch-selenium.spec.ts
+++ b/tests/browsertype-launch-selenium.spec.ts
@@ -22,13 +22,13 @@ import { start } from '../packages/playwright-core/lib/outofprocess';
 
 const chromeDriver = require('chromedriver').path;
 const brokenDriver = path.join(__dirname, 'assets', 'selenium-grid', 'broken-selenium-driver.js');
-const seleniumConfigStandalone = path.join(__dirname, 'assets', 'selenium-grid', 'selenium-config-standalone.json');
 const standalone_3_141_59 = path.join(__dirname, 'assets', 'selenium-grid', 'selenium-server-standalone-3.141.59.jar');
 const selenium_4_0_0_rc1 = path.join(__dirname, 'assets', 'selenium-grid', 'selenium-server-4.0.0-rc-1.jar');
 
 function writeSeleniumConfig(testInfo: TestInfo, port: number) {
-  const content = fs.readFileSync(seleniumConfigStandalone, 'utf8').replace(/4444/g, String(port));
-  const file = testInfo.outputPath('selenium-config.json');
+  const template = path.join(__dirname, 'assets', 'selenium-grid', `selenium-config-standalone.json`);
+  const content = fs.readFileSync(template, 'utf8').replace(/4444/g, String(port));
+  const file = testInfo.outputPath(`selenium-config-standalone.json`);
   fs.writeFileSync(file, content, 'utf8');
   return file;
 }
@@ -60,6 +60,39 @@ test('selenium grid 3.141.59 standalone chromium', async ({ browserName, childPr
   await grid.waitForOutput('Removing session');
 });
 
+test('selenium grid 3.141.59 hub + node chromium', async ({ browserName, childProcess, waitForPort, browserType }, testInfo) => {
+  test.skip(browserName !== 'chromium');
+
+  const port = testInfo.workerIndex + 15123;
+  const hub = childProcess({
+    command: ['java', '-jar', standalone_3_141_59, '-role', 'hub', '-port', String(port)],
+    cwd: __dirname,
+  });
+  await waitForPort(port);
+
+  const node = childProcess({
+    command: ['java', `-Dwebdriver.chrome.driver=${chromeDriver}`, '-jar', standalone_3_141_59, '-role', 'node', '-host', '127.0.0.1', '-hub', `http://localhost:${port}/grid/register`],
+    cwd: __dirname,
+  });
+  await Promise.all([
+    node.waitForOutput('The node is registered to the hub and ready to use'),
+    hub.waitForOutput('Registered a node'),
+  ]);
+
+  const __testHookSeleniumRemoteURL = `http://localhost:${port}/wd/hub`;
+  const browser = await browserType.launch({ __testHookSeleniumRemoteURL } as any);
+  const page = await browser.newPage();
+  await page.setContent('<title>Hello world</title><div>Get Started</div>');
+  await page.click('text=Get Started');
+  await expect(page).toHaveTitle('Hello world');
+  await browser.close();
+
+  expect(hub.output).toContain('Got a request to create a new session');
+  expect(node.output).toContain('Starting ChromeDriver');
+  expect(node.output).toContain('Started new session');
+  await node.waitForOutput('Removing session');
+});
+
 test('selenium grid 4.0.0-rc-1 standalone chromium', async ({ browserName, childProcess, waitForPort, browserType }, testInfo) => {
   test.skip(browserName !== 'chromium');
 
@@ -83,6 +116,38 @@ test('selenium grid 4.0.0-rc-1 standalone chromium', async ({ browserName, child
   await grid.waitForOutput('Deleted session');
 });
 
+test('selenium grid 4.0.0-rc-1 hub + node chromium', async ({ browserName, childProcess, waitForPort, browserType }, testInfo) => {
+  test.skip(browserName !== 'chromium');
+
+  const port = testInfo.workerIndex + 15123;
+  const hub = childProcess({
+    command: ['java', '-jar', selenium_4_0_0_rc1, 'hub', '--port', String(port)],
+    cwd: __dirname,
+  });
+  await waitForPort(port);
+  const __testHookSeleniumRemoteURL = `http://localhost:${port}/wd/hub`;
+
+  const node = childProcess({
+    command: ['java', `-Dwebdriver.chrome.driver=${chromeDriver}`, '-jar', selenium_4_0_0_rc1, 'node', '--grid-url', `http://localhost:${port}`, '--port', String(port + 1)],
+    cwd: __dirname,
+  });
+  await Promise.all([
+    node.waitForOutput('Node has been added'),
+    hub.waitForOutput('from DOWN to UP'),
+  ]);
+
+  const browser = await browserType.launch({ __testHookSeleniumRemoteURL } as any);
+  const page = await browser.newPage();
+  await page.setContent('<title>Hello world</title><div>Get Started</div>');
+  await page.click('text=Get Started');
+  await expect(page).toHaveTitle('Hello world');
+  await browser.close();
+
+  expect(hub.output).toContain('Session request received by the distributor');
+  expect(node.output).toContain('Starting ChromeDriver');
+  await hub.waitForOutput('Deleted session');
+});
+
 test('selenium grid 4.0.0-rc-1 standalone chromium broken driver', async ({ browserName, childProcess, waitForPort, browserType }, testInfo) => {
   test.skip(browserName !== 'chromium');
 
@@ -95,7 +160,7 @@ test('selenium grid 4.0.0-rc-1 standalone chromium broken driver', async ({ brow
 
   const __testHookSeleniumRemoteURL = `http://localhost:${port}/wd/hub`;
   const error = await browserType.launch({ __testHookSeleniumRemoteURL } as any).catch(e => e);
-  expect(error.message).toContain(`Error connecting to Selenium at http://localhost:${port}/wd/hub/: Could not start a new session`);
+  expect(error.message).toContain(`Error connecting to Selenium at http://localhost:${port}/wd/hub/session: Could not start a new session`);
 
   expect(grid.output).not.toContain('Starting ChromeDriver');
 });
@@ -108,7 +173,7 @@ test('selenium grid 3.141.59 standalone non-chromium', async ({ browserName, bro
   expect(error.message).toContain('Connecting to SELENIUM_REMOTE_URL is only supported by Chromium');
 });
 
-test('selenium grid 3.141.59 standalone chromium through driver', async ({ browserName, childProcess, waitForPort }, testInfo) => {
+test('selenium grid 3.141.59 standalone chromium through run-driver', async ({ browserName, childProcess, waitForPort }, testInfo) => {
   test.skip(browserName !== 'chromium');
 
   const port = testInfo.workerIndex + 15123;


### PR DESCRIPTION
For v4, we use se:cdp ws proxy, pointing it to the hub url.
For v3, we use grid api to try and get the target node ip.