### PR TITLE
devops: support arm drivers for Mac and Linux

### DIFF
--- a/utils/build/build-playwright-driver.sh
+++ b/utils/build/build-playwright-driver.sh
@@ -4,7 +4,7 @@ set -x
 
 trap "cd $(pwd -P)" EXIT
 SCRIPT_PATH="$(cd "$(dirname "$0")" ; pwd -P)"
-NODE_VERSION="14.17.6"
+NODE_VERSION="16.13.0"
 
 cd "$(dirname "$0")"
 PACKAGE_VERSION=$(node -p "require('../../package.json').version")
@@ -71,5 +71,7 @@ function build {
 }
 
 build "node-v${NODE_VERSION}-darwin-x64" "mac" "tar.gz" "run-driver-posix.sh"
+build "node-v${NODE_VERSION}-darwin-arm64" "mac-arm64" "tar.gz" "run-driver-posix.sh"
 build "node-v${NODE_VERSION}-linux-x64" "linux" "tar.gz" "run-driver-posix.sh"
+build "node-v${NODE_VERSION}-linux-arm64" "linux-arm64" "tar.gz" "run-driver-posix.sh"
 build "node-v${NODE_VERSION}-win-x64" "win32_x64" "zip" "run-driver-win.cmd"

--- a/utils/build/upload-playwright-driver.sh
+++ b/utils/build/upload-playwright-driver.sh
@@ -7,5 +7,7 @@ cd "$(dirname "$0")"
 
 PACKAGE_VERSION=$(node -p "require('../../package.json').version")
 az storage blob upload -c builds --account-key ${AZ_ACCOUNT_KEY} --account-name ${AZ_ACCOUNT_NAME} -f ./output/playwright-${PACKAGE_VERSION}-mac.zip -n "${AZ_UPLOAD_FOLDER}/playwright-${PACKAGE_VERSION}-mac.zip"
+az storage blob upload -c builds --account-key ${AZ_ACCOUNT_KEY} --account-name ${AZ_ACCOUNT_NAME} -f ./output/playwright-${PACKAGE_VERSION}-mac-arm64.zip -n "${AZ_UPLOAD_FOLDER}/playwright-${PACKAGE_VERSION}-mac-arm64.zip"
 az storage blob upload -c builds --account-key ${AZ_ACCOUNT_KEY} --account-name ${AZ_ACCOUNT_NAME} -f ./output/playwright-${PACKAGE_VERSION}-linux.zip -n "${AZ_UPLOAD_FOLDER}/playwright-${PACKAGE_VERSION}-linux.zip"
+az storage blob upload -c builds --account-key ${AZ_ACCOUNT_KEY} --account-name ${AZ_ACCOUNT_NAME} -f ./output/playwright-${PACKAGE_VERSION}-linux-arm64.zip -n "${AZ_UPLOAD_FOLDER}/playwright-${PACKAGE_VERSION}-linux-arm64.zip"
 az storage blob upload -c builds --account-key ${AZ_ACCOUNT_KEY} --account-name ${AZ_ACCOUNT_NAME} -f ./output/playwright-${PACKAGE_VERSION}-win32_x64.zip -n "${AZ_UPLOAD_FOLDER}/playwright-${PACKAGE_VERSION}-win32_x64.zip"


### PR DESCRIPTION
- Move to node 16 for driver (Node publishes Mac arm64 builds since Node 16)
- Publish Mac Arm64 driver
- Publish Linux Arm64 driver