### PR TITLE
browser(firefox): fix input composition when TIP is stolen by user

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1303
-Changed: yurys@chromium.org Thu 04 Nov 2021 12:26:04 PM PDT
+1304
+Changed: aslushnikov@gmail.com Wed Nov 10 21:36:03 HST 2021

--- a/browser_patches/firefox-beta/juggler/content/FrameTree.js
+++ b/browser_patches/firefox-beta/juggler/content/FrameTree.js
@@ -522,8 +522,8 @@ class Frame {
   textInputProcessor() {
     if (!this._textInputProcessor) {
       this._textInputProcessor = Cc["@mozilla.org/text-input-processor;1"].createInstance(Ci.nsITextInputProcessor);
-      this._textInputProcessor.beginInputTransactionForTests(this._docShell.DOMWindow);
     }
+    this._textInputProcessor.beginInputTransactionForTests(this._docShell.DOMWindow);
     return this._textInputProcessor;
   }
 

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
 1304
-Changed: lushnikov@chromium.org Fri Nov  5 12:27:32 HST 2021
+Changed: lushnikov@chromium.org Wed Nov 10 21:36:03 HST 2021

--- a/browser_patches/firefox/juggler/content/FrameTree.js
+++ b/browser_patches/firefox/juggler/content/FrameTree.js
@@ -522,8 +522,8 @@ class Frame {
   textInputProcessor() {
     if (!this._textInputProcessor) {
       this._textInputProcessor = Cc["@mozilla.org/text-input-processor;1"].createInstance(Ci.nsITextInputProcessor);
-      this._textInputProcessor.beginInputTransactionForTests(this._docShell.DOMWindow);
     }
+    this._textInputProcessor.beginInputTransactionForTests(this._docShell.DOMWindow);
     return this._textInputProcessor;
   }
 


### PR DESCRIPTION
When firefox is automated + interacted with manually, input composition
might get stolen from Text Input Processor.

Re-requiring TIP every time seems to fix this.

References #5460