### PR TITLE
fix: do not show taskkill.exe output

### DIFF
--- a/packages/playwright-core/src/utils/processLauncher.ts
+++ b/packages/playwright-core/src/utils/processLauncher.ts
@@ -172,8 +172,12 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
       // Force kill the browser.
       try {
         if (process.platform === 'win32') {
-          const stdout = childProcess.execSync(`taskkill /pid ${spawnedProcess.pid} /T /F /FI "MEMUSAGE gt 0"`);
-          options.log(`[pid=${spawnedProcess.pid}] taskkill output: ${stdout.toString()}`);
+          const taskkillProcess = childProcess.spawnSync(`taskkill /pid ${spawnedProcess.pid} /T /F /FI "MEMUSAGE gt 0"`, { shell: true });
+          const [stderr, stdout] = [taskkillProcess.stdout.toString(), taskkillProcess.stderr.toString()];
+          if (stdout)
+            options.log(`[pid=${spawnedProcess.pid}] taskkill stdout: ${stdout}`);
+          if (stderr)
+            options.log(`[pid=${spawnedProcess.pid}] taskkill stderr: ${stderr}`);
         } else {
           process.kill(-spawnedProcess.pid, 'SIGKILL');
         }

--- a/tests/config/commonFixtures.ts
+++ b/tests/config/commonFixtures.ts
@@ -87,7 +87,7 @@ export class TestChildProcess {
       return;
     try {
       if (process.platform === 'win32')
-        execSync(`taskkill /pid ${this.process.pid} /T /F /FI "MEMUSAGE gt 0"`);
+        execSync(`taskkill /pid ${this.process.pid} /T /F /FI "MEMUSAGE gt 0"`, { stdio: 'ignore' });
       else
         process.kill(-this.process.pid, 'SIGKILL');
     } catch (e) {

--- a/tests/signals.spec.ts
+++ b/tests/signals.spec.ts
@@ -23,7 +23,7 @@ test.slow();
 test('should close the browser when the node process closes', async ({ startRemoteServer, isWindows, server }) => {
   const remoteServer = await startRemoteServer({ url: server.EMPTY_PAGE });
   if (isWindows)
-    execSync(`taskkill /pid ${remoteServer.child().pid} /T /F`);
+    execSync(`taskkill /pid ${remoteServer.child().pid} /T /F`, { stdio: 'ignore' });
   else
     process.kill(remoteServer.child().pid);
   // We might not get browser exitCode in time when killing the parent node process,


### PR DESCRIPTION
`execSync` by default does forward the `stderr` to the parent process. `taskkill.exe` prints to the stderr when there was no process found (already killed by the user) and this yielded to the users's terminal.

By using `spawnSync` this can be fixed, since we want to log the stderr / stdout to our logger infra.

Fixes #9738
