### PR TITLE
fix(fetch): smarter JSON.stringify for application/json requests

### DIFF
--- a/packages/playwright-core/src/client/fetch.ts
+++ b/packages/playwright-core/src/client/fetch.ts
@@ -309,7 +309,7 @@ async function readStreamToJson(stream: fs.ReadStream): Promise<ServerFilePayloa
 function isJsonContentType(headers?: HeadersArray): boolean {
   if (!headers)
     return false;
-  for (const {name, value} of headers) {
+  for (const { name, value } of headers) {
     if (name.toLocaleLowerCase() === 'content-type')
       return value === 'application/json';
   }

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -488,10 +488,24 @@ function parseCookie(header: string): types.NetworkCookie | null {
   return cookie;
 }
 
+function isJsonParsable(value: any) {
+  if (typeof value !== 'string')
+    return false;
+  try {
+    JSON.parse(value);
+    return true;
+  } catch(e) {
+    if (e instanceof SyntaxError)
+      return false;
+    else
+      throw e;
+  }
+}
+
 function serializePostData(params: channels.APIRequestContextFetchParams, headers: { [name: string]: string }): Buffer | undefined {
   assert((params.postData ? 1 : 0) + (params.jsonData ? 1 : 0) + (params.formData ? 1 : 0) + (params.multipartData ? 1 : 0) <= 1, `Only one of 'data', 'form' or 'multipart' can be specified`);
   if (params.jsonData) {
-    const json = JSON.stringify(params.jsonData);
+    const json = isJsonParsable(params.jsonData) ? params.jsonData : JSON.stringify(params.jsonData);
     headers['content-type'] ??= 'application/json';
     return Buffer.from(json, 'utf8');
   } else if (params.formData) {

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -494,7 +494,7 @@ function isJsonParsable(value: any) {
   try {
     JSON.parse(value);
     return true;
-  } catch(e) {
+  } catch (e) {
     if (e instanceof SyntaxError)
       return false;
     else

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -276,3 +276,20 @@ for (const [type, value] of serialization) {
     await request.dispose();
   });
 }
+
+it(`should accept already serialized data as Buffer when content-type is application/json`, async ({ playwright, server }) => {
+  const request = await playwright.request.newContext();
+  const value = JSON.stringify(JSON.stringify({'foo':'bar'}));
+  const [req] = await Promise.all([
+    server.waitForRequest('/empty.html'),
+    request.post(server.EMPTY_PAGE, {
+      headers: {
+        'content-type': 'application/json'
+      },
+      data: Buffer.from(value, 'utf8')
+    })
+  ]);
+  const body = await req.postBody;
+  expect(body.toString()).toEqual(value);
+  await request.dispose();
+});

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -237,7 +237,8 @@ it('should remove content-length from reidrected post requests', async ({ playwr
 
 
 const serialization = [
-  ['object', {'foo': 'bar'}],
+  ['object', { 'foo': 'bar' }],
+  ['array', ['foo', 'bar', 2021]],
   ['string', 'foo'],
   ['bool', true],
   ['number', 2021],
@@ -279,7 +280,7 @@ for (const [type, value] of serialization) {
 
 it(`should accept already serialized data as Buffer when content-type is application/json`, async ({ playwright, server }) => {
   const request = await playwright.request.newContext();
-  const value = JSON.stringify(JSON.stringify({'foo':'bar'}));
+  const value = JSON.stringify(JSON.stringify({ 'foo': 'bar' }));
   const [req] = await Promise.all([
     server.waitForRequest('/empty.html'),
     request.post(server.EMPTY_PAGE, {

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -234,3 +234,45 @@ it('should remove content-length from reidrected post requests', async ({ playwr
   expect(req2.headers['content-length']).toBe(undefined);
   await request.dispose();
 });
+
+
+const serialization = [
+  ['object', {'foo': 'bar'}],
+  ['string', 'foo'],
+  ['bool', true],
+  ['number', 2021],
+];
+for (const [type, value] of serialization) {
+  const stringifiedValue = JSON.stringify(value);
+  it(`should json stringify ${type} body when content-type is application/json`, async ({ playwright, server }) => {
+    const request = await playwright.request.newContext();
+    const [req] = await Promise.all([
+      server.waitForRequest('/empty.html'),
+      request.post(server.EMPTY_PAGE, {
+        headers: {
+          'content-type': 'application/json'
+        },
+        data: value
+      })
+    ]);
+    const body = await req.postBody;
+    expect(body.toString()).toEqual(stringifiedValue);
+    await request.dispose();
+  });
+
+  it(`should not double stringify ${type} body when content-type is application/json`, async ({ playwright, server }) => {
+    const request = await playwright.request.newContext();
+    const [req] = await Promise.all([
+      server.waitForRequest('/empty.html'),
+      request.post(server.EMPTY_PAGE, {
+        headers: {
+          'content-type': 'application/json'
+        },
+        data: stringifiedValue
+      })
+    ]);
+    const body = await req.postBody;
+    expect(body.toString()).toEqual(stringifiedValue);
+    await request.dispose();
+  });
+}


### PR DESCRIPTION
When `content-type` header is set to `applicagtion/json` the `data` will be serialized to json string. If the data is a string which is already parsable by `JSON.parse` it will be passed as is (this should address the use case from the discussion where we otherwise require both setting application/json header and to manually serialize string data). The latter behavior could be overridden by converting string data into a Buffer if needed.

#10222