### PR TITLE
devops: fix chromium checkout

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -46,7 +46,7 @@ compile_chromium() {
     # As of Jan, 2021 Chromium mac compilation requires Xcode12.2
     selectXcodeVersionOrDie "12.2"
     # As of Jan, 2021 Chromium mac compilation is only possible on Intel macbooks.
-    # See https://chromium.googlesource.com/chromium/src.git/+/master/docs/mac_arm64.md
+    # See https://chromium.googlesource.com/chromium/src.git/+/main/docs/mac_arm64.md
     if [[ $1 == "--compile-mac-arm64" && $(uname -m) != "x86_64" ]]; then
       echo "ERROR: chromium mac arm64 compilation is (ironically) only supported on Intel Macbooks"
       exit 1

--- a/browser_patches/ffmpeg/build-linux.sh
+++ b/browser_patches/ffmpeg/build-linux.sh
@@ -51,7 +51,7 @@ function build_libvpx {
   cd libvpx
   git checkout "${LIBVPX_VERSION}"
   # Cross-compiling libvpx according to the docs:
-  # - https://chromium.googlesource.com/webm/libvpx/+/master/README
+  # - https://chromium.googlesource.com/webm/libvpx/+/main/README
   ./configure --prefix="${PREFIX}" ${LIBVPX_CONFIG}
   make && make install
 }

--- a/browser_patches/ffmpeg/build-mac.sh
+++ b/browser_patches/ffmpeg/build-mac.sh
@@ -57,7 +57,7 @@ function build_libvpx {
   cd libvpx
   git checkout "${LIBVPX_VERSION}"
   # Compile libvpx according to the docs:
-  # - https://chromium.googlesource.com/webm/libvpx/+/master/README
+  # - https://chromium.googlesource.com/webm/libvpx/+/main/README
   ./configure --prefix="${PREFIX}" ${LIBVPX_CONFIG}
   make && make install
 }

--- a/browser_patches/ffmpeg/crosscompile-from-linux.sh
+++ b/browser_patches/ffmpeg/crosscompile-from-linux.sh
@@ -78,7 +78,7 @@ function build_libvpx {
   cd libvpx
   git checkout "${LIBVPX_VERSION}"
   # Cross-compiling libvpx according to the docs:
-  # - https://chromium.googlesource.com/webm/libvpx/+/master/README
+  # - https://chromium.googlesource.com/webm/libvpx/+/main/README
   local target=""
   if [[ $arch == "win64" ]]; then
     target="x86_64-win64-gcc";

--- a/browser_patches/prepare_checkout.sh
+++ b/browser_patches/prepare_checkout.sh
@@ -44,7 +44,7 @@ function prepare_chromium_checkout {
 
   # Update Chromium checkout.
   #
-  # This is based on https://chromium.googlesource.com/chromium/src/+/master/docs/linux/build_instructions.md#get-the-code
+  # This is based on https://chromium.googlesource.com/chromium/src/+/main/docs/linux/build_instructions.md#get-the-code
   if [[ ! -d "${CR_CHECKOUT_PATH}" ]]; then
     rm -rf "${CR_CHECKOUT_PATH}"
     mkdir -p "${CR_CHECKOUT_PATH}"
@@ -62,8 +62,8 @@ function prepare_chromium_checkout {
   fi
 
   cd "${CR_CHECKOUT_PATH}/src"
-  git checkout master
-  git pull origin master
+  git checkout main
+  git pull origin main
   git checkout "${CRSHA}"
   gclient sync -D
 }


### PR DESCRIPTION
Use `main` branch for all chromium-related projects.