### PR TITLE
feat(test runner): replace declare/define with "options"

### DIFF
--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -374,10 +374,10 @@ To make use of this feature, we will declare an "option fixture" for the backend
 const base = require('@playwright/test');
 const { startBackend } = require('./my-backend');
 
-exports.test = base.test.extend({
+exports.test = base.test.declare({
   // Default value for the version.
   version: '1.0',
-
+}).extend({
   // Use version when starting the backend.
   backendURL: async ({ version }, use) => {
     const app = await startBackend(version);
@@ -392,15 +392,12 @@ exports.test = base.test.extend({
 import { test as base } from '@playwright/test';
 import { startBackend } from './my-backend';
 
-export type TestOptions = {
-  version: string;
-  backendURL: string;
-};
+export type TestOptions = { version: string };
 
-export const test = base.extend<TestOptions>({
+export const test = base.declare<TestOptions>({
   // Default value for the version.
   version: '1.0',
-
+}).extend<{ backendURL: string }>({
   // Use version when starting the backend.
   backendURL: async ({ version }, use) => {
     const app = await startBackend(version);

--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -141,16 +141,19 @@ test('hello world', ({ helloWorld }) => {
 
 It uses an option `hello` and a fixture `helloWorld` that are set up by the framework for each test run.
 
-Here is how test fixtures are declared and defined. Fixtures can use other fixtures and/or options - note how `helloWorld` uses `hello`.
+Here is how test fixtures are defined. Fixtures can use other fixtures and/or options - note how `helloWorld` uses `hello`.
 
 ```js js-flavor=js
 // hello.js
 const base = require('@playwright/test');
 
 // Extend base test with our options and fixtures.
-const test =  base.test.declare({
-  hello: 'Hello', // provide default value
-}).extend({
+const test =  base.test.extend({
+  // Define an option and provide a default value.
+  // We can later override it in the config.
+  hello: ['Hello', { option: true }],
+
+  // Define a fixture.
   helloWorld: async ({ hello }, use) => {
     // Set up the fixture.
     const value = hello + ', world!';
@@ -178,9 +181,12 @@ type TestFixtures = {
 };
 
 // Extend base test with our options and fixtures.
-const test = base.declare<TestOptions>({
-  hello: 'Hello', // provide default value
-}).extend<TestFixtures>({
+const test = base.extend<TestOptions & TestFixtures>({
+  // Define an option and provide a default value.
+  // We can later override it in the config.
+  hello: ['Hello', { option: true }],
+
+  // Define a fixture.
   helloWorld: async ({ hello }, use) => {
     // Set up the fixture.
     const value = hello + ', world!';

--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -82,7 +82,7 @@ test('should remove an item', async ({ todoPage }) => {
 import { test as base } from '@playwright/test';
 import { TodoPage } from './todo-page';
 
-// Extend basic test by providing a "table" fixture.
+// Extend basic test by providing a "todoPage" fixture.
 const test = base.extend<{ todoPage: TodoPage }>({
   todoPage: async ({ page }, use) => {
     const todoPage = new TodoPage(page);
@@ -139,21 +139,18 @@ test('hello world', ({ helloWorld }) => {
 });
 ```
 
-It uses fixtures `hello` and `helloWorld` that are set up by the framework for each test run.
+It uses an option `hello` and a fixture `helloWorld` that are set up by the framework for each test run.
 
-Here is how test fixtures are declared and defined. Fixtures can use other fixtures - note how `helloWorld` uses `hello`.
+Here is how test fixtures are declared and defined. Fixtures can use other fixtures and/or options - note how `helloWorld` uses `hello`.
 
 ```js js-flavor=js
 // hello.js
 const base = require('@playwright/test');
 
-// Extend base test with fixtures "hello" and "helloWorld".
-// This new "test" can be used in multiple test files, and each of them will get the fixtures.
-module.exports = base.test.extend({
-  // This fixture is a constant, so we can just provide the value.
-  hello: 'Hello',
-
-  // This fixture has some complex logic and is defined with a function.
+// Extend base test with our options and fixtures.
+const test =  base.test.declare({
+  hello: 'Hello', // provide default value
+}).extend({
   helloWorld: async ({ hello }, use) => {
     // Set up the fixture.
     const value = hello + ', world!';
@@ -164,24 +161,26 @@ module.exports = base.test.extend({
     // Clean up the fixture. Nothing to cleanup in this example.
   },
 });
+
+// This new "test" can be used in multiple test files, and each of them will get the fixtures.
+module.exports = test;
 ```
 
 ```js js-flavor=ts
 // hello.ts
 import { test as base } from '@playwright/test';
 
-// Define test fixtures "hello" and "helloWorld".
-type TestFixtures = {
+type TestOptions = {
   hello: string;
+};
+type TestFixtures = {
   helloWorld: string;
 };
 
-// Extend base test with our fixtures.
-const test = base.extend<TestFixtures>({
-  // This fixture is a constant, so we can just provide the value.
-  hello: 'Hello',
-
-  // This fixture has some complex logic and is defined with a function.
+// Extend base test with our options and fixtures.
+const test = base.declare<TestOptions>({
+  hello: 'Hello', // provide default value
+}).extend<TestFixtures>({
   helloWorld: async ({ hello }, use) => {
     // Set up the fixture.
     const value = hello + ', world!';

--- a/docs/src/test-parameterize-js.md
+++ b/docs/src/test-parameterize-js.md
@@ -33,17 +33,18 @@ for (const name of people) {
 
 ## Parametrized Projects
 
-Playwright Test supports running multiple test projects at the same time. In the following example, we'll run two projects with different parameters.
+Playwright Test supports running multiple test projects at the same time. In the following example, we'll run two projects with different options.
 
-We declare the parameter and set the value in the config. The first project runs with the value `Alice` and the second with the value `Bob`.
+We declare the option `person` and set the value in the config. The first project runs with the value `Alice` and the second with the value `Bob`.
 
 ```js js-flavor=js
 // my-test.js
 const base = require('@playwright/test');
 
-exports.test = base.test.declare({
-  // Default value - you can override it in the config.
-  person: 'John',
+exports.test = base.test.extend({
+  // Define an option and provide a default value.
+  // We can later override it in the config.
+  person: ['John', { option: true }],
 });
 ```
 
@@ -55,13 +56,14 @@ export type TestOptions = {
   person: string;
 };
 
-export const test = base.declare<TestOptions>({
-  // Default value - you can override it in the config.
-  person: 'John',
+export const test = base.extend<TestOptions>({
+  // Define an option and provide a default value.
+  // We can later override it in the config.
+  person: ['John', { option: true }],
 });
 ```
 
-We can use the parameter in the test.
+We can use this option in the test, similarly to [fixtures](./test-fixtures.md).
 
 ```js js-flavor=js
 // example.spec.js
@@ -128,16 +130,17 @@ const config: PlaywrightTestConfig<TestOptions> = {
 export default config;
 ```
 
-We can also use the parameter in a fixture. Learn more about [fixtures](./test-fixtures.md).
+We can also use the option in a fixture. Learn more about [fixtures](./test-fixtures.md).
 
 ```js js-flavor=js
 // my-test.js
 const base = require('@playwright/test');
 
-exports.test = base.test.declare({
-  // Default value - you can override it in the config.
-  person: 'John',
-}).extend({
+exports.test = base.test.extend({
+  // Define an option and provide a default value.
+  // We can later override it in the config.
+  person: ['John', { option: true }],
+
   // Override default "page" fixture.
   page: async ({ page, person }, use) => {
     await page.goto('/chat');
@@ -158,10 +161,11 @@ export type TestOptions = {
   person: string;
 };
 
-export const test = base.test.declare<TestOptions>({
-  // Default value - you can override it in the config.
-  person: 'John',
-}).extend({
+export const test = base.test.extend<TestOptions>({
+  // Define an option and provide a default value.
+  // We can later override it in the config.
+  person: ['John', { option: true }],
+
   // Override default "page" fixture.
   page: async ({ page, person }, use) => {
     await page.goto('/chat');

--- a/docs/src/test-parameterize-js.md
+++ b/docs/src/test-parameterize-js.md
@@ -1,9 +1,9 @@
 ---
 id: test-parameterize
-title: "Parameterize tests"
+title: "Parametrize tests"
 ---
 
-You can either parameterize tests on a test level or on a project level.
+You can either parametrize tests on a test level or on a project level.
 
 <!-- TOC -->
 
@@ -34,15 +34,16 @@ for (const name of people) {
 ## Parametrized Projects
 
 Playwright Test supports running multiple test projects at the same time. In the following example, we'll run two projects with different parameters.
-A parameter itself is represented as a [`fixture`](./api/class-fixtures), where the value gets set from the config. The first project runs with the value `Alice` and the second with the value `Bob`.
+
+We declare the parameter and set the value in the config. The first project runs with the value `Alice` and the second with the value `Bob`.
 
 ```js js-flavor=js
 // my-test.js
 const base = require('@playwright/test');
 
-exports.test = base.test.extend({
-  // Default value for person.
-  person: 'not-set',
+exports.test = base.test.declare({
+  // Default value - you can override it in the config.
+  person: 'John',
 });
 ```
 
@@ -54,13 +55,14 @@ export type TestOptions = {
   person: string;
 };
 
-export const test = base.extend<TestOptions>({
-  // Default value for the person.
-  person: 'not-set',
+export const test = base.declare<TestOptions>({
+  // Default value - you can override it in the config.
+  person: 'John',
 });
 ```
 
-We can use our fixtures in the test.
+We can use the parameter in the test.
+
 ```js js-flavor=js
 // example.spec.js
 const { test } = require('./my-test');
@@ -83,7 +85,8 @@ test('test 1', async ({ page, person }) => {
 });
 ```
 
-Now, we can run test in multiple configurations by using projects.
+Now, we can run tests in multiple configurations by using projects.
+
 ```js js-flavor=js
 // playwright.config.js
 // @ts-check
@@ -92,11 +95,11 @@ Now, we can run test in multiple configurations by using projects.
 const config = {
   projects: [
     {
-      name: 'Alice',
+      name: 'alice',
       use: { person: 'Alice' },
     },
     {
-      name: 'Bob',
+      name: 'bob',
       use: { person: 'Bob' },
     },
   ]
@@ -111,17 +114,62 @@ import { PlaywrightTestConfig } from '@playwright/test';
 import { TestOptions } from './my-test';
 
 const config: PlaywrightTestConfig<TestOptions> = {
-  timeout: 20000,
   projects: [
     {
       name: 'alice',
       use: { person: 'Alice' },
     },
     {
-      name: 'Bob',
+      name: 'bob',
       use: { person: 'Bob' },
     },
   ]
 };
 export default config;
+```
+
+We can also use the parameter in a fixture. Learn more about [fixtures](./test-fixtures.md).
+
+```js js-flavor=js
+// my-test.js
+const base = require('@playwright/test');
+
+exports.test = base.test.declare({
+  // Default value - you can override it in the config.
+  person: 'John',
+}).extend({
+  // Override default "page" fixture.
+  page: async ({ page, person }, use) => {
+    await page.goto('/chat');
+    // We use "person" parameter as a "name" for the chat room.
+    await page.locator('#name').fill(person);
+    await page.click('text=Enter chat room');
+    // Each test will get a "page" that already has the person name.
+    await use(page);
+  },
+});
+```
+
+```js js-flavor=ts
+// my-test.ts
+import { test as base } from '@playwright/test';
+
+export type TestOptions = {
+  person: string;
+};
+
+export const test = base.test.declare<TestOptions>({
+  // Default value - you can override it in the config.
+  person: 'John',
+}).extend({
+  // Override default "page" fixture.
+  page: async ({ page, person }, use) => {
+    await page.goto('/chat');
+    // We use "person" parameter as a "name" for the chat room.
+    await page.locator('#name').fill(person);
+    await page.click('text=Enter chat room');
+    // Each test will get a "page" that already has the person name.
+    await use(page);
+  },
+});
 ```

--- a/packages/playwright-test/src/fixtures.ts
+++ b/packages/playwright-test/src/fixtures.ts
@@ -103,8 +103,12 @@ class Fixture {
   }
 }
 
-export function isFixtureTuple(value: any): value is [any, any] {
-  return Array.isArray(value) && typeof value[1] === 'object' && ('scope' in value[1] || 'auto' in value[1]);
+function isFixtureTuple(value: any): value is [any, any] {
+  return Array.isArray(value) && typeof value[1] === 'object' && ('scope' in value[1] || 'auto' in value[1] || 'option' in value[1]);
+}
+
+export function isFixtureOption(value: any): value is [any, any] {
+  return isFixtureTuple(value) && !!value[1].option;
 }
 
 export class FixturePool {

--- a/packages/playwright-test/src/fixtures.ts
+++ b/packages/playwright-test/src/fixtures.ts
@@ -103,6 +103,10 @@ class Fixture {
   }
 }
 
+export function isFixtureTuple(value: any): value is [any, any] {
+  return Array.isArray(value) && typeof value[1] === 'object' && ('scope' in value[1] || 'auto' in value[1]);
+}
+
 export class FixturePool {
   readonly digest: string;
   readonly registrations: Map<string, FixtureRegistration>;
@@ -115,7 +119,7 @@ export class FixturePool {
         const name = entry[0];
         let value = entry[1];
         let options: { auto: boolean, scope: FixtureScope } | undefined;
-        if (Array.isArray(value) && typeof value[1] === 'object' && ('scope' in value[1] || 'auto' in value[1])) {
+        if (isFixtureTuple(value)) {
           options = {
             auto: !!value[1].auto,
             scope: value[1].scope || 'test'

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -25,54 +25,21 @@ import { Browser } from 'playwright-core';
 export { expect } from './expect';
 export const _baseTest: TestType<{}, {}> = rootTestType.test;
 
-type TestFixtures = PlaywrightTestArgs & {
+type TestFixtures = PlaywrightTestArgs & PlaywrightTestOptions & {
   _combinedContextOptions: BrowserContextOptions,
   _setupContextOptionsAndArtifacts: void;
   _contextFactory: (options?: BrowserContextOptions) => Promise<BrowserContext>;
 };
-type WorkerFixtures = PlaywrightWorkerArgs & {
+type WorkerFixtures = PlaywrightWorkerArgs & PlaywrightWorkerOptions & {
   _browserType: BrowserType;
   _browserOptions: LaunchOptions;
   _artifactsDir: () => string;
   _snapshotSuffix: string;
 };
 
-export const test = _baseTest.declare<PlaywrightTestOptions, PlaywrightWorkerOptions>({
-  defaultBrowserType: [ 'chromium', { scope: 'worker' } ],
-  browserName: [ ({ defaultBrowserType }, use) => use(defaultBrowserType), { scope: 'worker' } ],
-  headless: [ undefined, { scope: 'worker' } ],
-  channel: [ undefined, { scope: 'worker' } ],
-  launchOptions: [ {}, { scope: 'worker' } ],
-  screenshot: [ 'off', { scope: 'worker' } ],
-  video: [ 'off', { scope: 'worker' } ],
-  trace: [ 'off', { scope: 'worker' } ],
-
-  acceptDownloads: undefined,
-  bypassCSP: undefined,
-  colorScheme: undefined,
-  deviceScaleFactor: undefined,
-  extraHTTPHeaders: undefined,
-  geolocation: undefined,
-  hasTouch: undefined,
-  httpCredentials: undefined,
-  ignoreHTTPSErrors: undefined,
-  isMobile: undefined,
-  javaScriptEnabled: undefined,
-  locale: undefined,
-  offline: undefined,
-  permissions: undefined,
-  proxy: undefined,
-  storageState: undefined,
-  timezoneId: undefined,
-  userAgent: undefined,
-  viewport: undefined,
-  actionTimeout: undefined,
-  navigationTimeout: undefined,
-  baseURL: async ({ }, use) => {
-    await use(process.env.PLAYWRIGHT_TEST_BASE_URL);
-  },
-  contextOptions: {},
-}).extend<TestFixtures, WorkerFixtures>({
+export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
+  defaultBrowserType: [ 'chromium', { scope: 'worker', option: true } ],
+  browserName: [ ({ defaultBrowserType }, use) => use(defaultBrowserType), { scope: 'worker', option: true } ],
   playwright: [async ({}, use, workerInfo) => {
     if (process.env.PW_GRID) {
       const gridClient = await GridClient.connect(process.env.PW_GRID);
@@ -82,6 +49,12 @@ export const test = _baseTest.declare<PlaywrightTestOptions, PlaywrightWorkerOpt
       await use(require('playwright-core'));
     }
   }, { scope: 'worker' } ],
+  headless: [ undefined, { scope: 'worker', option: true } ],
+  channel: [ undefined, { scope: 'worker', option: true } ],
+  launchOptions: [ {}, { scope: 'worker', option: true } ],
+  screenshot: [ 'off', { scope: 'worker', option: true } ],
+  video: [ 'off', { scope: 'worker', option: true } ],
+  trace: [ 'off', { scope: 'worker', option: true } ],
 
   _artifactsDir: [async ({}, use, workerInfo) => {
     let dir: string | undefined;
@@ -99,6 +72,32 @@ export const test = _baseTest.declare<PlaywrightTestOptions, PlaywrightWorkerOpt
   _browserOptions: [browserOptionsWorkerFixture, { scope: 'worker' }],
   _browserType: [browserTypeWorkerFixture, { scope: 'worker' }],
   browser: [browserWorkerFixture, { scope: 'worker' } ],
+
+  acceptDownloads: [ undefined, { option: true } ],
+  bypassCSP: [ undefined, { option: true } ],
+  colorScheme: [ undefined, { option: true } ],
+  deviceScaleFactor: [ undefined, { option: true } ],
+  extraHTTPHeaders: [ undefined, { option: true } ],
+  geolocation: [ undefined, { option: true } ],
+  hasTouch: [ undefined, { option: true } ],
+  httpCredentials: [ undefined, { option: true } ],
+  ignoreHTTPSErrors: [ undefined, { option: true } ],
+  isMobile: [ undefined, { option: true } ],
+  javaScriptEnabled: [ undefined, { option: true } ],
+  locale: [ undefined, { option: true } ],
+  offline: [ undefined, { option: true } ],
+  permissions: [ undefined, { option: true } ],
+  proxy: [ undefined, { option: true } ],
+  storageState: [ undefined, { option: true } ],
+  timezoneId: [ undefined, { option: true } ],
+  userAgent: [ undefined, { option: true } ],
+  viewport: [ undefined, { option: true } ],
+  actionTimeout: [ undefined, { option: true } ],
+  navigationTimeout: [ undefined, { option: true } ],
+  baseURL: [ async ({ }, use) => {
+    await use(process.env.PLAYWRIGHT_TEST_BASE_URL);
+  }, { option: true } ],
+  contextOptions: [ {}, { option: true } ],
 
   _combinedContextOptions: async ({
     acceptDownloads,

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -173,7 +173,6 @@ export class Loader {
     if (!path.isAbsolute(snapshotDir))
       snapshotDir = path.resolve(configDir, snapshotDir);
     const fullProject: FullProject = {
-      define: takeFirst(this._configOverrides.define, projectConfig.define, this._config.define, []),
       expect: takeFirst(this._configOverrides.expect, projectConfig.expect, this._config.expect, undefined),
       outputDir,
       repeatEach: takeFirst(this._configOverrides.repeatEach, projectConfig.repeatEach, this._config.repeatEach, 1),
@@ -357,16 +356,6 @@ function validateProject(file: string, project: Project, title: string) {
   if (typeof project !== 'object' || !project)
     throw errorWithFile(file, `${title} must be an object`);
 
-  if ('define' in project && project.define !== undefined) {
-    if (Array.isArray(project.define)) {
-      project.define.forEach((item, index) => {
-        validateDefine(file, item, `${title}.define[${index}]`);
-      });
-    } else {
-      validateDefine(file, project.define, `${title}.define`);
-    }
-  }
-
   if ('name' in project && project.name !== undefined) {
     if (typeof project.name !== 'string')
       throw errorWithFile(file, `${title}.name must be a string`);
@@ -415,11 +404,6 @@ function validateProject(file: string, project: Project, title: string) {
     if (!project.use || typeof project.use !== 'object')
       throw errorWithFile(file, `${title}.use must be an object`);
   }
-}
-
-function validateDefine(file: string, define: any, title: string) {
-  if (!define || typeof define !== 'object' || !define.test || !define.fixtures)
-    throw errorWithFile(file, `${title} must be an object with "test" and "fixtures" properties`);
 }
 
 const baseFullConfig: FullConfig = {

--- a/packages/playwright-test/src/testType.ts
+++ b/packages/playwright-test/src/testType.ts
@@ -23,16 +23,13 @@ import { errorWithLocation, serializeError } from './util';
 
 const countByFile = new Map<string, number>();
 
-export class DeclaredFixtures {
-  testType!: TestTypeImpl;
-  location!: Location;
-}
+type TestTypeFixtures = FixturesWithLocation & { type: 'extend' | 'declare' };
 
 export class TestTypeImpl {
-  readonly fixtures: (FixturesWithLocation | DeclaredFixtures)[];
+  readonly fixtures: TestTypeFixtures[];
   readonly test: TestType<any, any>;
 
-  constructor(fixtures: (FixturesWithLocation | DeclaredFixtures)[]) {
+  constructor(fixtures: TestTypeFixtures[]) {
     this.fixtures = fixtures;
 
     const test: any = wrapFunctionWithLocation(this._createTest.bind(this, 'default'));
@@ -203,16 +200,13 @@ export class TestTypeImpl {
   }
 
   private _extend(location: Location, fixtures: Fixtures) {
-    const fixturesWithLocation = { fixtures, location };
+    const fixturesWithLocation: TestTypeFixtures = { fixtures, location, type: 'extend' };
     return new TestTypeImpl([...this.fixtures, fixturesWithLocation]).test;
   }
 
-  private _declare(location: Location) {
-    const declared = new DeclaredFixtures();
-    declared.location = location;
-    const child = new TestTypeImpl([...this.fixtures, declared]);
-    declared.testType = child;
-    return child.test;
+  private _declare(location: Location, fixtures: Fixtures) {
+    const fixturesWithLocation: TestTypeFixtures = { fixtures, location, type: 'declare' };
+    return new TestTypeImpl([...this.fixtures, fixturesWithLocation]).test;
   }
 }
 

--- a/packages/playwright-test/src/testType.ts
+++ b/packages/playwright-test/src/testType.ts
@@ -22,17 +22,17 @@ import { Fixtures, FixturesWithLocation, Location, TestType } from './types';
 import { errorWithLocation, serializeError } from './util';
 
 const countByFile = new Map<string, number>();
-
-type TestTypeFixtures = FixturesWithLocation & { type: 'extend' | 'declare' };
+const testTypeSymbol = Symbol('testType');
 
 export class TestTypeImpl {
-  readonly fixtures: TestTypeFixtures[];
+  readonly fixtures: FixturesWithLocation[];
   readonly test: TestType<any, any>;
 
-  constructor(fixtures: TestTypeFixtures[]) {
+  constructor(fixtures: FixturesWithLocation[]) {
     this.fixtures = fixtures;
 
     const test: any = wrapFunctionWithLocation(this._createTest.bind(this, 'default'));
+    test[testTypeSymbol] = this;
     test.expect = expect;
     test.only = wrapFunctionWithLocation(this._createTest.bind(this, 'only'));
     test.describe = wrapFunctionWithLocation(this._describe.bind(this, 'default'));
@@ -53,7 +53,7 @@ export class TestTypeImpl {
     test.step = wrapFunctionWithLocation(this._step.bind(this));
     test.use = wrapFunctionWithLocation(this._use.bind(this));
     test.extend = wrapFunctionWithLocation(this._extend.bind(this));
-    test.declare = wrapFunctionWithLocation(this._declare.bind(this));
+    test.extendTest = wrapFunctionWithLocation(this._extendTest.bind(this));
     this.test = test;
   }
 
@@ -200,13 +200,19 @@ export class TestTypeImpl {
   }
 
   private _extend(location: Location, fixtures: Fixtures) {
-    const fixturesWithLocation: TestTypeFixtures = { fixtures, location, type: 'extend' };
+    if ((fixtures as any)[testTypeSymbol])
+      throw new Error(`test.extend() accepts fixtures object, not a test object.\nDid you mean to call test.extendTest()?`);
+    const fixturesWithLocation: FixturesWithLocation = { fixtures, location };
     return new TestTypeImpl([...this.fixtures, fixturesWithLocation]).test;
   }
 
-  private _declare(location: Location, fixtures: Fixtures) {
-    const fixturesWithLocation: TestTypeFixtures = { fixtures, location, type: 'declare' };
-    return new TestTypeImpl([...this.fixtures, fixturesWithLocation]).test;
+  private _extendTest(location: Location, test: TestType<any, any>) {
+    const testTypeImpl = (test as any)[testTypeSymbol] as TestTypeImpl;
+    if (!testTypeImpl)
+      throw new Error(`test.extendTest() accepts a single "test" parameter.\nDid you mean to call test.extend() with fixtures instead?`);
+    // Filter out common ancestor fixtures.
+    const newFixtures = testTypeImpl.fixtures.filter(theirs => !this.fixtures.find(ours => ours.fixtures === theirs.fixtures));
+    return new TestTypeImpl([...this.fixtures, ...newFixtures]).test;
   }
 }
 

--- a/tests/config/baseTest.ts
+++ b/tests/config/baseTest.ts
@@ -16,22 +16,25 @@
 
 import { test } from '@playwright/test';
 import { commonFixtures, CommonFixtures } from './commonFixtures';
-import { serverFixtures, ServerFixtures, ServerWorkerOptions } from './serverFixtures';
-import { coverageFixtures, CoverageWorkerOptions } from './coverageFixtures';
+import { serverFixtures, ServerFixtures, serverOptions, ServerWorkerOptions } from './serverFixtures';
+import { coverageFixtures, coverageOptions, CoverageWorkerOptions } from './coverageFixtures';
 import { platformFixtures, PlatformWorkerFixtures } from './platformFixtures';
-import { testModeFixtures, TestModeWorkerFixtures } from './testModeFixtures';
+import { testModeFixtures, testModeOptions, TestModeWorkerOptions, TestModeWorkerFixtures } from './testModeFixtures';
 
 
-export type BaseTestWorkerFixtures = {
+type BaseTestWorkerParams = {
   _snapshotSuffix: string;
 };
 
 export const baseTest = test
-    .extend<{}, CoverageWorkerOptions>(coverageFixtures as any)
+    .declare<{}, CoverageWorkerOptions>(coverageOptions)
+    .extend(coverageFixtures)
     .extend<{}, PlatformWorkerFixtures>(platformFixtures)
+    .declare<{}, TestModeWorkerOptions>(testModeOptions)
     .extend<{}, TestModeWorkerFixtures>(testModeFixtures as any)
     .extend<CommonFixtures>(commonFixtures)
-    .extend<ServerFixtures, ServerWorkerOptions>(serverFixtures as any)
-    .extend<{}, BaseTestWorkerFixtures>({
+    .declare<{}, ServerWorkerOptions>(serverOptions)
+    .extend<ServerFixtures>(serverFixtures as any)
+    .declare<{}, BaseTestWorkerParams>({
       _snapshotSuffix: ['', { scope: 'worker' }],
     });

--- a/tests/config/baseTest.ts
+++ b/tests/config/baseTest.ts
@@ -16,25 +16,17 @@
 
 import { test } from '@playwright/test';
 import { commonFixtures, CommonFixtures } from './commonFixtures';
-import { serverFixtures, ServerFixtures, serverOptions, ServerWorkerOptions } from './serverFixtures';
-import { coverageFixtures, coverageOptions, CoverageWorkerOptions } from './coverageFixtures';
-import { platformFixtures, PlatformWorkerFixtures } from './platformFixtures';
-import { testModeFixtures, testModeOptions, TestModeWorkerOptions, TestModeWorkerFixtures } from './testModeFixtures';
-
-
-type BaseTestWorkerParams = {
-  _snapshotSuffix: string;
-};
+import { serverTest } from './serverFixtures';
+import { coverageTest } from './coverageFixtures';
+import { platformTest } from './platformFixtures';
+import { testModeTest } from './testModeFixtures';
 
 export const baseTest = test
-    .declare<{}, CoverageWorkerOptions>(coverageOptions)
-    .extend(coverageFixtures)
-    .extend<{}, PlatformWorkerFixtures>(platformFixtures)
-    .declare<{}, TestModeWorkerOptions>(testModeOptions)
-    .extend<{}, TestModeWorkerFixtures>(testModeFixtures as any)
+    .extendTest(coverageTest)
+    .extendTest(platformTest)
+    .extendTest(testModeTest)
     .extend<CommonFixtures>(commonFixtures)
-    .declare<{}, ServerWorkerOptions>(serverOptions)
-    .extend<ServerFixtures>(serverFixtures as any)
-    .declare<{}, BaseTestWorkerParams>({
+    .extendTest(serverTest)
+    .extend<{}, { _snapshotSuffix: string }>({
       _snapshotSuffix: ['', { scope: 'worker' }],
     });

--- a/tests/config/coverageFixtures.ts
+++ b/tests/config/coverageFixtures.ts
@@ -14,20 +14,17 @@
  * limitations under the License.
  */
 
-import { Fixtures } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { installCoverageHooks } from './coverage';
+import { test } from '@playwright/test';
 
 export type CoverageWorkerOptions = {
   coverageName?: string;
 };
 
-export const coverageOptions: Fixtures<{}, CoverageWorkerOptions> = {
-  coverageName: [ undefined, { scope: 'worker' } ],
-};
-
-export const coverageFixtures: Fixtures<{}, { __collectCoverage: void }, {}, CoverageWorkerOptions> = {
+export const coverageTest = test.extend<{}, { __collectCoverage: void } & CoverageWorkerOptions>({
+  coverageName: [ undefined, { scope: 'worker', option: true  } ],
   __collectCoverage: [ async ({ coverageName }, run, workerInfo) => {
     if (!coverageName) {
       await run();
@@ -42,4 +39,4 @@ export const coverageFixtures: Fixtures<{}, { __collectCoverage: void }, {}, Cov
     await fs.promises.mkdir(path.dirname(coveragePath), { recursive: true });
     await fs.promises.writeFile(coveragePath, JSON.stringify(coverageJSON, undefined, 2), 'utf8');
   }, { scope: 'worker', auto: true } ],
-};
+});

--- a/tests/config/coverageFixtures.ts
+++ b/tests/config/coverageFixtures.ts
@@ -23,9 +23,11 @@ export type CoverageWorkerOptions = {
   coverageName?: string;
 };
 
-export const coverageFixtures: Fixtures<{}, CoverageWorkerOptions & { __collectCoverage: void }> = {
+export const coverageOptions: Fixtures<{}, CoverageWorkerOptions> = {
   coverageName: [ undefined, { scope: 'worker' } ],
+};
 
+export const coverageFixtures: Fixtures<{}, { __collectCoverage: void }, {}, CoverageWorkerOptions> = {
   __collectCoverage: [ async ({ coverageName }, run, workerInfo) => {
     if (!coverageName) {
       await run();

--- a/tests/config/default.config.ts
+++ b/tests/config/default.config.ts
@@ -16,7 +16,7 @@
 
 import type { Config, PlaywrightTestOptions, PlaywrightWorkerOptions } from '@playwright/test';
 import * as path from 'path';
-import { TestModeWorkerFixtures } from './testModeFixtures';
+import { TestModeWorkerOptions } from './testModeFixtures';
 import { CoverageWorkerOptions } from './coverageFixtures';
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';
@@ -38,7 +38,7 @@ const trace = !!process.env.PWTEST_TRACE;
 
 const outputDir = path.join(__dirname, '..', '..', 'test-results');
 const testDir = path.join(__dirname, '..');
-const config: Config<CoverageWorkerOptions & PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeWorkerFixtures> = {
+const config: Config<CoverageWorkerOptions & PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeWorkerOptions> = {
   testDir,
   outputDir,
   timeout: video ? 60000 : 30000,

--- a/tests/config/platformFixtures.ts
+++ b/tests/config/platformFixtures.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Fixtures } from '@playwright/test';
+import { test } from '@playwright/test';
 
 export type PlatformWorkerFixtures = {
   platform: 'win32' | 'darwin' | 'linux';
@@ -23,9 +23,9 @@ export type PlatformWorkerFixtures = {
   isLinux: boolean;
 };
 
-export const platformFixtures: Fixtures<{}, PlatformWorkerFixtures> = {
+export const platformTest = test.extend<{}, PlatformWorkerFixtures>({
   platform: [ process.platform as 'win32' | 'darwin' | 'linux', { scope: 'worker' } ],
   isWindows: [ process.platform === 'win32', { scope: 'worker' } ],
   isMac: [ process.platform === 'darwin', { scope: 'worker' } ],
   isLinux: [ process.platform === 'linux', { scope: 'worker' } ],
-};
+});

--- a/tests/config/serverFixtures.ts
+++ b/tests/config/serverFixtures.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Fixtures } from '@playwright/test';
+import { test, Fixtures } from '@playwright/test';
 import path from 'path';
 import socks from 'socksv5';
 import { TestServer } from '../../utils/testserver';
@@ -33,11 +33,8 @@ export type ServerFixtures = {
 };
 
 export type ServersInternal = ServerFixtures & { socksServer: socks.SocksServer };
-export const serverOptions: Fixtures<{}, ServerWorkerOptions> = {
-  loopback: [ undefined, { scope: 'worker' } ],
-};
-
-export const serverFixtures: Fixtures<ServerFixtures, { __servers: ServersInternal }, {}, ServerWorkerOptions> = {
+export const serverFixtures: Fixtures<ServerFixtures, { __servers: ServersInternal } & ServerWorkerOptions> = {
+  loopback: [ undefined, { scope: 'worker', option: true } ],
   __servers: [ async ({ loopback }, run, workerInfo) => {
     const assetsPath = path.join(__dirname, '..', 'assets');
     const cachedPath = path.join(__dirname, '..', 'assets', 'cached');
@@ -113,3 +110,5 @@ export const serverFixtures: Fixtures<ServerFixtures, { __servers: ServersIntern
     await run(__servers.asset);
   },
 };
+
+export const serverTest = test.extend<ServerFixtures, ServerWorkerOptions & { __servers: ServersInternal }>(serverFixtures);

--- a/tests/config/serverFixtures.ts
+++ b/tests/config/serverFixtures.ts
@@ -33,8 +33,11 @@ export type ServerFixtures = {
 };
 
 export type ServersInternal = ServerFixtures & { socksServer: socks.SocksServer };
-export const serverFixtures: Fixtures<ServerFixtures, ServerWorkerOptions & { __servers: ServersInternal }> = {
+export const serverOptions: Fixtures<{}, ServerWorkerOptions> = {
   loopback: [ undefined, { scope: 'worker' } ],
+};
+
+export const serverFixtures: Fixtures<ServerFixtures, { __servers: ServersInternal }, {}, ServerWorkerOptions> = {
   __servers: [ async ({ loopback }, run, workerInfo) => {
     const assetsPath = path.join(__dirname, '..', 'assets');
     const cachedPath = path.join(__dirname, '..', 'assets', 'cached');

--- a/tests/config/testModeFixtures.ts
+++ b/tests/config/testModeFixtures.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Fixtures, PlaywrightWorkerArgs } from '@playwright/test';
+import { test } from '@playwright/test';
 import { DefaultTestMode, DriverTestMode, ServiceTestMode, TestModeName } from './testMode';
 
 export type TestModeWorkerOptions = {
@@ -26,11 +26,8 @@ export type TestModeWorkerFixtures = {
   toImpl: (rpcObject: any) => any;
 };
 
-export const testModeOptions: Fixtures<{}, TestModeWorkerOptions> = {
-  mode: [ 'default', { scope: 'worker' } ],
-};
-
-export const testModeFixtures: Fixtures<{}, TestModeWorkerFixtures, {}, TestModeWorkerOptions & PlaywrightWorkerArgs> = {
+export const testModeTest = test.extend<{}, TestModeWorkerOptions & TestModeWorkerFixtures>({
+  mode: [ 'default', { scope: 'worker', option: true } ],
   playwright: [ async ({ mode }, run) => {
     const testMode = {
       default: new DefaultTestMode(),
@@ -44,4 +41,4 @@ export const testModeFixtures: Fixtures<{}, TestModeWorkerFixtures, {}, TestMode
   }, { scope: 'worker' } ],
 
   toImpl: [ async ({ playwright }, run) => run((playwright as any)._toImpl), { scope: 'worker' } ],
-};
+});

--- a/tests/config/testModeFixtures.ts
+++ b/tests/config/testModeFixtures.ts
@@ -14,18 +14,23 @@
  * limitations under the License.
  */
 
-import type { Fixtures } from '@playwright/test';
+import type { Fixtures, PlaywrightWorkerArgs } from '@playwright/test';
 import { DefaultTestMode, DriverTestMode, ServiceTestMode, TestModeName } from './testMode';
 
-export type TestModeWorkerFixtures = {
+export type TestModeWorkerOptions = {
   mode: TestModeName;
-  playwright: typeof import('playwright-core');
+};
+
+export type TestModeWorkerFixtures = {
+  playwright: typeof import('@playwright/test');
   toImpl: (rpcObject: any) => any;
 };
 
-export const testModeFixtures: Fixtures<{}, TestModeWorkerFixtures> = {
+export const testModeOptions: Fixtures<{}, TestModeWorkerOptions> = {
   mode: [ 'default', { scope: 'worker' } ],
+};
 
+export const testModeFixtures: Fixtures<{}, TestModeWorkerFixtures, {}, TestModeWorkerOptions & PlaywrightWorkerArgs> = {
   playwright: [ async ({ mode }, run) => {
     const testMode = {
       default: new DefaultTestMode(),

--- a/tests/page/pageTest.ts
+++ b/tests/page/pageTest.ts
@@ -16,7 +16,7 @@
 
 import { TestType } from '@playwright/test';
 import { PlatformWorkerFixtures } from '../config/platformFixtures';
-import { TestModeWorkerFixtures } from '../config/testModeFixtures';
+import { TestModeWorkerFixtures, TestModeWorkerOptions } from '../config/testModeFixtures';
 import { androidTest } from '../android/androidTest';
 import { browserTest } from '../config/browserTest';
 import { electronTest } from '../electron/electronTest';
@@ -24,7 +24,7 @@ import { PageTestFixtures, PageWorkerFixtures } from './pageTestApi';
 import { ServerFixtures, ServerWorkerOptions } from '../config/serverFixtures';
 export { expect } from '@playwright/test';
 
-let impl: TestType<PageTestFixtures & ServerFixtures, PageWorkerFixtures & PlatformWorkerFixtures & TestModeWorkerFixtures & ServerWorkerOptions> = browserTest;
+let impl: TestType<PageTestFixtures & ServerFixtures, PageWorkerFixtures & PlatformWorkerFixtures & TestModeWorkerFixtures & TestModeWorkerOptions & ServerWorkerOptions> = browserTest;
 
 if (process.env.PWPAGE_IMPL === 'android')
   impl = androidTest;

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -361,7 +361,7 @@ test('should inerhit use options in projects', async ({ runInlineTest }) => {
       };
     `,
     'a.test.ts': `
-      const { test } = pwt;
+      const test = pwt.test.declare({ foo: '', bar: '' });
       test('pass', async ({ foo, bar  }, testInfo) => {
         test.expect(foo).toBe('config');
         test.expect(bar).toBe('project');

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -361,7 +361,7 @@ test('should inerhit use options in projects', async ({ runInlineTest }) => {
       };
     `,
     'a.test.ts': `
-      const test = pwt.test.declare({ foo: '', bar: '' });
+      const test = pwt.test.extend({ foo: ['', {option:true}], bar: ['', {option: true}] });
       test('pass', async ({ foo, bar  }, testInfo) => {
         test.expect(foo).toBe('config');
         test.expect(bar).toBe('project');

--- a/tests/playwright-test/fixtures.spec.ts
+++ b/tests/playwright-test/fixtures.spec.ts
@@ -491,8 +491,8 @@ test('should work with overrides calling base', async ({ runInlineTest }) => {
 test('should understand worker fixture params in overrides calling base', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      const test1 = pwt.test.declare({
-        param: [ 'param', { scope: 'worker' }],
+      const test1 = pwt.test.extend({
+        param: [ 'param', { scope: 'worker', option: true }],
       }).extend({
         foo: async ({}, test) => await test('foo'),
         bar: async ({foo}, test) => await test(foo + '-bar'),

--- a/tests/playwright-test/fixtures.spec.ts
+++ b/tests/playwright-test/fixtures.spec.ts
@@ -491,8 +491,9 @@ test('should work with overrides calling base', async ({ runInlineTest }) => {
 test('should understand worker fixture params in overrides calling base', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      const test1 = pwt.test.extend({
+      const test1 = pwt.test.declare({
         param: [ 'param', { scope: 'worker' }],
+      }).extend({
         foo: async ({}, test) => await test('foo'),
         bar: async ({foo}, test) => await test(foo + '-bar'),
       });

--- a/tests/playwright-test/test-use.spec.ts
+++ b/tests/playwright-test/test-use.spec.ts
@@ -138,8 +138,8 @@ test('should run tests with different worker options', async ({ runInlineTest })
 test('should use options from the config', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'helper.ts': `
-      export const test = pwt.test.declare({
-        foo: 'foo',
+      export const test = pwt.test.extend({
+        foo: [ 'foo', { option: true } ],
       });
     `,
     'playwright.config.ts': `

--- a/tests/playwright-test/test-use.spec.ts
+++ b/tests/playwright-test/test-use.spec.ts
@@ -138,7 +138,7 @@ test('should run tests with different worker options', async ({ runInlineTest })
 test('should use options from the config', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'helper.ts': `
-      export const test = pwt.test.extend({
+      export const test = pwt.test.declare({
         foo: 'foo',
       });
     `,

--- a/tests/playwright-test/types-2.spec.ts
+++ b/tests/playwright-test/types-2.spec.ts
@@ -63,13 +63,14 @@ test('can return anything from hooks', async ({ runTSC }) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('test.declare should check types', async ({ runTSC }) => {
+test('test.extend options should check types', async ({ runTSC }) => {
   const result = await runTSC({
     'helper.ts': `
       export type Params = { foo: string };
       export const test = pwt.test;
-      export const test1 = test.declare<Params>({ foo: 'foo' });
-      export const testerror = test.declare<{ foo: string }>({
+      export const test1 = test.extend<Params>({ foo: [ 'foo', { option: true } ] });
+      export const test1b = test.extend<{ bar: string }>({ bar: [ 'bar', { option: true } ] });
+      export const testerror = test.extend<{ foo: string }>({
         // @ts-expect-error
         foo: 123
       });
@@ -80,6 +81,7 @@ test('test.declare should check types', async ({ runTSC }) => {
         // @ts-expect-error
         bar: async ({ baz }, run) => { await run(42); }
       });
+      export const test4 = test1.extendTest(test1b);
     `,
     'playwright.config.ts': `
       import { Params } from './helper';
@@ -103,7 +105,7 @@ test('test.declare should check types', async ({ runTSC }) => {
       module.exports = configs;
     `,
     'a.spec.ts': `
-      import { test, test1, test2, test3 } from './helper';
+      import { test, test1, test2, test3, test4 } from './helper';
       // @ts-expect-error
       test('my test', async ({ foo }) => {});
       test1('my test', async ({ foo }) => {});
@@ -112,6 +114,7 @@ test('test.declare should check types', async ({ runTSC }) => {
       test2('my test', async ({ foo, bar }) => {});
       // @ts-expect-error
       test2('my test', async ({ foo, baz }) => {});
+      test4('my test', async ({ foo, bar }) => {});
     `
   });
   expect(result.exitCode).toBe(0);

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -264,8 +264,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
   use(fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs>): void;
   step(title: string, body: () => Promise<any>): Promise<any>;
   expect: Expect;
-  declare<T, W extends KeyValue = {}>(parameters: Fixtures<T, W, TestArgs, WorkerArgs>): TestType<TestArgs & T, WorkerArgs & W>;
   extend<T, W extends KeyValue = {}>(fixtures: Fixtures<T, W, TestArgs, WorkerArgs>): TestType<TestArgs & T, WorkerArgs & W>;
+  extendTest<T, W>(other: TestType<T, W>): TestType<TestArgs & T, WorkerArgs & W>;
 }
 
 type KeyValue = { [key: string]: any };
@@ -278,9 +278,9 @@ export type Fixtures<T extends KeyValue = {}, W extends KeyValue = {}, PT extend
 } & {
   [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test' }];
 } & {
-  [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean }];
+  [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean }];
 } & {
-  [K in keyof T]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean }];
+  [K in keyof T]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -35,7 +35,6 @@ export type ReportSlowTests = { max: number, threshold: number } | null;
 export type PreserveOutput = 'always' | 'never' | 'failures-only';
 export type UpdateSnapshots = 'all' | 'none' | 'missing';
 
-type FixtureDefine<TestArgs extends KeyValue = {}, WorkerArgs extends KeyValue = {}> = { test: TestType<TestArgs, WorkerArgs>, fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs> };
 type UseOptions<TestArgs, WorkerArgs> = { [K in keyof WorkerArgs]?: WorkerArgs[K] } & { [K in keyof TestArgs]?: TestArgs[K] };
 
 type ExpectSettings = {
@@ -62,7 +61,6 @@ interface TestProject {
 }
 
 export interface Project<TestArgs = {}, WorkerArgs = {}> extends TestProject {
-  define?: FixtureDefine | FixtureDefine[];
   use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
@@ -133,7 +131,6 @@ interface TestConfig {
 
 export interface Config<TestArgs = {}, WorkerArgs = {}> extends TestConfig {
   projects?: Project<TestArgs, WorkerArgs>[];
-  define?: FixtureDefine | FixtureDefine[];
   use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
@@ -267,7 +264,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
   use(fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs>): void;
   step(title: string, body: () => Promise<any>): Promise<any>;
   expect: Expect;
-  declare<T extends KeyValue = {}, W extends KeyValue = {}>(): TestType<TestArgs & T, WorkerArgs & W>;
+  declare<T, W extends KeyValue = {}>(parameters: Fixtures<T, W, TestArgs, WorkerArgs>): TestType<TestArgs & T, WorkerArgs & W>;
   extend<T, W extends KeyValue = {}>(fixtures: Fixtures<T, W, TestArgs, WorkerArgs>): TestType<TestArgs & T, WorkerArgs & W>;
 }
 


### PR DESCRIPTION
- Fixtures defined in `test.extend()` can now have `{ option: true }` configuration that makes them overridable in the config. Options support all other properties of fixtures - value/function, scope, auto.

  ```ts
  const test = base.extend<MyOptions>({
    foo: ['default', { option: true }],
  });
  ```

- `test.declare()` and `project.define` are removed.

- `project.use` applies overrides to default option values and nothing else. Any `test.extend()` and `test.use()` calls take priority over config options.

**Required user changes**: if someone used to define fixture options with `test.extend()`, overriding them in config will stop working. The solution is to add `{ option: true }`:

```js
// Old code
export const test = base.extend<{ myOption: number, myFixture: number }>({
  myOption: 123,
  myFixture: ({ myOption }, use) => use(2 * myOption),
});

// New code
export const test = base.extend<{ myOption: number, myFixture: number }>({
  myOption: [123, { option: true }],
  myFixture: ({ myOption }, use) => use(2 * myOption),
});
```