### PR TITLE
docs(python): fix incorrect syntax

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3629,7 +3629,7 @@ response = response_info.value
 return response.ok
 
 # or with a lambda
-async with page.expect_response(lambda response: response.url == "https://example.com" and response.status === 200) as response_info:
+async with page.expect_response(lambda response: response.url == "https://example.com" and response.status == 200) as response_info:
     await page.click("input")
 response = response_info.value
 return response.ok


### PR DESCRIPTION
In python, the equality operator is ==, rather than ===.