### PR TITLE
docs(test-fixtures): Replace comment for "table"

### DIFF
--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -82,7 +82,7 @@ test('should remove an item', async ({ todoPage }) => {
 import { test as base } from '@playwright/test';
 import { TodoPage } from './todo-page';
 
-// Extend basic test by providing a "table" fixture.
+// Extend basic test by providing a "todoPage" fixture.
 const test = base.extend<{ todoPage: TodoPage }>({
   todoPage: async ({ page }, use) => {
     const todoPage = new TodoPage(page);


### PR DESCRIPTION
This change will replace the comment describing a fixture as "table" with its actual example, which is a "todoPage" fixture.