### PR TITLE
fix: fix proper-lock-file configuration

### DIFF
--- a/packages/playwright-core/src/utils/registry.ts
+++ b/packages/playwright-core/src/utils/registry.ts
@@ -550,10 +550,10 @@ export class Registry {
     try {
       releaseLock = await lockfile.lock(registryDirectory, {
         retries: {
-          retries: 10,
           // Retry 20 times during 10 minutes with
           // exponential back-off.
           // See documentation at: https://www.npmjs.com/package/retry#retrytimeoutsoptions
+          retries: 20,
           factor: 1.27579,
         },
         onCompromised: (err: Error) => {


### PR DESCRIPTION
Turns out we were using wrong formula; with the config we had in place,
proper-lock-file would give up to aquire lock after 49 seconds of
waiting.

With the proper configuration, we'll keep re-trying for 10 minutes.

Fixes #10354