### PR TITLE
chore: have correct version in driver

### DIFF
--- a/utils/build/update_canary_version.js
+++ b/utils/build/update_canary_version.js
@@ -31,19 +31,20 @@ if (process.argv[2] === '--alpha') {
   throw new Error('only --alpha or --beta prefixes are allowed');
 }
 
+let newVersion;
 if (process.argv[3] === '--today-date') {
   const date = new Date();
   const month = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'][date.getMonth()];
   const day = date.getDate();
   const year = date.getFullYear();
-  packageJSON.version = `${baseVersion}-${prefix}-${month}-${day}-${year}`;
+  newVersion = `${baseVersion}-${prefix}-${month}-${day}-${year}`;
 } else if (process.argv[3] === '--commit-timestamp') {
   const timestamp = execSync('git show -s --format=%ct HEAD', {
     stdio: ['ignore', 'pipe', 'ignore']
   }).toString('utf8').trim();
-  packageJSON.version = `${baseVersion}-${prefix}-${timestamp}000`;
+  newVersion = `${baseVersion}-${prefix}-${timestamp}000`;
 } else {
   throw new Error('This script must be run with either --commit-timestamp or --today-date parameter');
 }
-console.log('Setting version to ' + packageJSON.version);
-fs.writeFileSync(path.join(__dirname, '..', '..', 'package.json'), JSON.stringify(packageJSON, undefined, 2) + '\n');
+console.log('Setting version to ' + newVersion);
+execSync(`node utils/bump_package_versions.js ${newVersion}`, { stdio: 'inherit' });


### PR DESCRIPTION
Currently when we build the driver, we only execute `utils/build/update_canary_version.js` which won't propagate the new versions to all our sub-packages. This results that the driver keeps the next name in its version. (playwright --version is still `1.17.0-next`)

With this change we don't update the version manually anymore, we instead use the recently introduced `bump_package_versions.js` script which takes care of propagating the versions to all needed places.

Fixes https://github.com/mxschmitt/playwright-go/issues/236