### PR TITLE
fix: do not send Fetch.continueRequest twice for auth requests

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -161,11 +161,6 @@ export class CRNetworkManager {
         this._responseExtraInfoTracker.requestPaused(request.request, event);
     }
 
-    if (!this._userRequestInterceptionEnabled && this._protocolRequestInterceptionEnabled) {
-      this._client._sendMayFail('Fetch.continueRequest', {
-        requestId: event.requestId
-      });
-    }
     if (!event.networkId) {
       // Fetch without networkId means that request was not recongnized by inspector, and
       // it will never receive Network.requestWillBeSent. Most likely, this is an internal request
@@ -249,7 +244,7 @@ export class CRNetworkManager {
     let route = null;
     if (requestPausedEvent) {
       // We do not support intercepting redirects.
-      if (redirectedFrom)
+      if (redirectedFrom || (!this._userRequestInterceptionEnabled && this._protocolRequestInterceptionEnabled))
         this._client._sendMayFail('Fetch.continueRequest', { requestId: requestPausedEvent.requestId });
       else
         route = new RouteImpl(this._client, requestPausedEvent.requestId);


### PR DESCRIPTION
Previously for 401 responses `Fetch.continueRequest` command would be sent twice over CDP and when the context has http credentials that lead to a race which could have two outcomes:

Lucky:
```
Error:  2021-11-17T17:42:41.594Z pw:protocol ◀ RECV {"method":"Fetch.requestPaused","params":{"requestId":"interception-job-2.0","request":{"url":"http://localhost:9000/empty.html","method":"GET","headers":{"Upgrade-Insecure-Requests":"1","User-Agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/98.0.4695.0 Safari/537.36","Accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"},"initialPriority":"VeryHigh","referrerPolicy":"strict-origin-when-cross-origin"},"frameId":"701BD1EE5F130D8F44CFD579B3778F91","resourceType":"Document","networkId":"FCC66AC9AC0AC5BAF96490F13F62714B"},"sessionId":"5310C11CEAB4B0753F6539FF7FE81C7E"}
Error:  2021-11-17T17:42:41.594Z pw:protocol SEND ► {"id":89,"method":"Fetch.continueRequest","params":{"requestId":"interception-job-2.0"},"sessionId":"5310C11CEAB4B0753F6539FF7FE81C7E"}
Error:  2021-11-17T17:42:41.595Z pw:protocol SEND ► {"id":90,"method":"Fetch.continueRequest","params":{"requestId":"interception-job-2.0"},"sessionId":"5310C11CEAB4B0753F6539FF7FE81C7E"}
Error:  2021-11-17T17:42:41.601Z pw:protocol ◀ RECV {"id":89,"result":{},"sessionId":"5310C11CEAB4B0753F6539FF7FE81C7E"}
Error:  2021-11-17T17:42:41.602Z pw:protocol ◀ RECV {"method":"Network.requestWillBeSentExtraInfo","params":{"requestId":"FCC66AC9AC0AC5BAF96490F13F62714B","associatedCookies":[],"headers":{"Host":"localhost:9000","Connection":"keep-alive","Pragma":"no-cache","Cache-Control":"no-cache","Upgrade-Insecure-Requests":"1","User-Agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/98.0.4695.0 Safari/537.36","Accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9","Sec-Fetch-Site":"none","Sec-Fetch-Mode":"navigate","Sec-Fetch-User":"?1","Sec-Fetch-Dest":"document","Accept-Encoding":"gzip, deflate, br"},"connectTiming":{"requestTime":301.048118}},"sessionId":"5310C11CEAB4B0753F6539FF7FE81C7E"}
Error:  2021-11-17T17:42:41.602Z pw:protocol ◀ RECV {"id":90,"error":{"code":-32000,"message":"Invalid state for continueInterceptedRequest"},"sessionId":"5310C11CEAB4B0753F6539FF7FE81C7E"}
Error:  2021-11-17T17:42:41.603Z pw:protocol ◀ RECV {"method":"Fetch.authRequired","params":{"requestId":"interception-job-2.0","request":{"url":"http://localhost:9000/empty.html","method":"GET","headers":{"Upgrade-Insecure-Requests":"1","User-Agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/98.0.4695.0 Safari/537.36","Accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"},"initialPriority":"VeryHigh","referrerPolicy":"strict-origin-when-cross-origin"},"frameId":"701BD1EE5F130D8F44CFD579B3778F91","resourceType":"Document","authChallenge":{"source":"Server","origin":"http://localhost:9000","scheme":"basic","realm":"Secure Area"}},"sessionId":"5310C11CEAB4B0753F6539FF7FE81C7E"}
Error:  2021-11-17T17:42:41.603Z pw:protocol SEND ► {"id":91,"method":"Fetch.continueWithAuth","params":{"requestId":"interception-job-2.0","authChallengeResponse":{"response":"ProvideCredentials","username":"user","password":"pass"}},"sessionId":"5310C11CEAB4B0753F6539FF7FE81C7E"}
Error:  2021-11-17T17:42:41.603Z pw:protocol ◀ RECV {"id":91,"result":{},"sessionId":"5310C11CEAB4B0753F6539FF7FE81C7E"}
```
Unlucky:
```
Error:  2021-11-17T17:42:11.773Z pw:protocol ◀ RECV {"method":"Fetch.requestPaused","params":{"requestId":"interception-job-2.0","request":{"url":"http://localhost:9000/empty.html","method":"GET","headers":{"Upgrade-Insecure-Requests":"1","User-Agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/95.0.4638.69 Safari/537.36","Accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"},"initialPriority":"VeryHigh","referrerPolicy":"strict-origin-when-cross-origin"},"frameId":"4E4294377E7E3FBE9A51CD1A3BA6D859","resourceType":"Document","networkId":"C67F8950E06654DBF5CA370492CE16BF"},"sessionId":"9113944BFBC181B8250FECB981E47673"}
Error:  2021-11-17T17:42:11.773Z pw:protocol SEND ► {"id":89,"method":"Fetch.continueRequest","params":{"requestId":"interception-job-2.0"},"sessionId":"9113944BFBC181B8250FECB981E47673"}
Error:  2021-11-17T17:42:11.776Z pw:protocol SEND ► {"id":90,"method":"Fetch.continueRequest","params":{"requestId":"interception-job-2.0"},"sessionId":"9113944BFBC181B8250FECB981E47673"}
Error:  2021-11-17T17:42:11.776Z pw:protocol ◀ RECV {"id":89,"result":{},"sessionId":"9113944BFBC181B8250FECB981E47673"}
Error:  2021-11-17T17:42:11.779Z pw:protocol ◀ RECV {"method":"Network.requestWillBeSentExtraInfo","params":{"requestId":"C67F8950E06654DBF5CA370492CE16BF","associatedCookies":[],"headers":{"Host":"localhost:9000","Connection":"keep-alive","Pragma":"no-cache","Cache-Control":"no-cache","Upgrade-Insecure-Requests":"1","User-Agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/95.0.4638.69 Safari/537.36","Accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9","Sec-Fetch-Site":"none","Sec-Fetch-Mode":"navigate","Sec-Fetch-User":"?1","Sec-Fetch-Dest":"document","Accept-Encoding":"gzip, deflate, br"},"connectTiming":{"requestTime":142.367302}},"sessionId":"9113944BFBC181B8250FECB981E47673"}
Error:  2021-11-17T17:42:11.780Z pw:protocol ◀ RECV {"method":"Fetch.authRequired","params":{"requestId":"interception-job-2.0","request":{"url":"http://localhost:9000/empty.html","method":"GET","headers":{"Upgrade-Insecure-Requests":"1","User-Agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/95.0.4638.69 Safari/537.36","Accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"},"initialPriority":"VeryHigh","referrerPolicy":"strict-origin-when-cross-origin"},"frameId":"4E4294377E7E3FBE9A51CD1A3BA6D859","resourceType":"Document","authChallenge":{"source":"Server","origin":"http://localhost:9000","scheme":"basic","realm":"Secure Area"}},"sessionId":"9113944BFBC181B8250FECB981E47673"}
Error:  2021-11-17T17:42:11.782Z pw:protocol SEND ► {"id":91,"method":"Fetch.continueWithAuth","params":{"requestId":"interception-job-2.0","authChallengeResponse":{"response":"ProvideCredentials","username":"user","password":"pass"}},"sessionId":"9113944BFBC181B8250FECB981E47673"}
Error:  2021-11-17T17:42:11.782Z pw:protocol ◀ RECV {"id":90,"error":{"code":-32602,"message":"authChallengeResponse required."},"sessionId":"9113944BFBC181B8250FECB981E47673"}
Error:  2021-11-17T17:42:11.783Z pw:protocol ◀ RECV {"id":91,"error":{"code":-32000,"message":"Invalid state for continueInterceptedRequest"},"sessionId":"9113944BFBC181B8250FECB981E47673"}
```
In the latter case the request would hang and the test would timeout. It manifested itself a lot on GHA in Java, here is an example run with enabled protocol traces: https://github.com/microsoft/playwright-java/runs/4241641179?check_suite_focus=true