### PR TITLE
test: bump expect timeout

### DIFF
--- a/tests/config/default.config.ts
+++ b/tests/config/default.config.ts
@@ -41,6 +41,9 @@ const testDir = path.join(__dirname, '..');
 const config: Config<CoverageWorkerOptions & PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeWorkerFixtures> = {
   testDir,
   outputDir,
+  expect: {
+    timeout: 10000,
+  },
   timeout: video ? 60000 : 30000,
   globalTimeout: 5400000,
   workers: process.env.CI ? 1 : undefined,


### PR DESCRIPTION
This should make trace viewer tests less flaky.

References #10383