### PR TITLE
fix: compute file field mime type on the server

### DIFF
--- a/packages/playwright-core/src/client/fetch.ts
+++ b/packages/playwright-core/src/client/fetch.ts
@@ -16,7 +16,6 @@
 
 import fs from 'fs';
 import path from 'path';
-import * as mime from 'mime';
 import * as util from 'util';
 import { Serializable } from '../../types/structs';
 import * as api from '../../types/types';
@@ -283,11 +282,7 @@ export class APIResponse implements api.APIResponse {
   }
 }
 
-type ServerFilePayload = {
-  name: string,
-  mimeType: string,
-  buffer: string,
-};
+type ServerFilePayload = NonNullable<channels.FormField['file']>;
 
 function filePayloadToJson(payload: FilePayload): ServerFilePayload {
   return {
@@ -307,7 +302,6 @@ async function readStreamToJson(stream: fs.ReadStream): Promise<ServerFilePayloa
   const streamPath: string = Buffer.isBuffer(stream.path) ? stream.path.toString('utf8') : stream.path;
   return {
     name: path.basename(streamPath),
-    mimeType: mime.getType(streamPath) || 'application/octet-stream',
     buffer: buffer.toString('base64'),
   };
 }

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -156,7 +156,7 @@ export type FormField = {
   value?: string,
   file?: {
     name: string,
-    mimeType: string,
+    mimeType?: string,
     buffer: Binary,
   },
 };

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -224,7 +224,7 @@ FormField:
       type: object?
       properties:
         name: string
-        mimeType: string
+        mimeType: string?
         buffer: binary
 
 APIRequestContext:

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -153,7 +153,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     value: tOptional(tString),
     file: tOptional(tObject({
       name: tString,
-      mimeType: tString,
+      mimeType: tOptional(tString),
       buffer: tBinary,
     })),
   });

--- a/packages/playwright-core/src/server/formData.ts
+++ b/packages/playwright-core/src/server/formData.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import * as types from './types';
+import mime from 'mime';
+import * as channels from '../protocol/channels';
 
 export class MultipartFormData {
   private readonly _boundary: string;
@@ -35,10 +36,10 @@ export class MultipartFormData {
     this._finishMultiPartField();
   }
 
-  addFileField(name: string, value: types.FilePayload) {
+  addFileField(name: string, value: NonNullable<channels.FormField['file']>) {
     this._beginMultiPartHeader(name);
     this._chunks.push(Buffer.from(`; filename="${value.name}"`));
-    this._chunks.push(Buffer.from(`\r\ncontent-type: ${value.mimeType || 'application/octet-stream'}`));
+    this._chunks.push(Buffer.from(`\r\ncontent-type: ${value.mimeType || mime.getType(value.name) || 'application/octet-stream'}`));
     this._finishMultiPartHeader();
     this._chunks.push(Buffer.from(value.buffer, 'base64'));
     this._finishMultiPartField();


### PR DESCRIPTION
This will unify mime type evaluation across language bindings.