### PR TITLE
chore: verify supported Node.js version during runtime

### DIFF
--- a/packages/playwright-core/src/utils/verifyNodeJsVersion.ts
+++ b/packages/playwright-core/src/utils/verifyNodeJsVersion.ts
@@ -14,5 +14,17 @@
  * limitations under the License.
  */
 
-require('./lib/utils/verifyNodeJsVersion');
-module.exports = require('./lib/inprocess');
+const currentNodeVersion = process.versions.node;
+const semver = currentNodeVersion.split('.');
+const [major] = [+semver[0]];
+
+if (major < 12) {
+  console.error(
+      'You are running Node.js ' +
+      currentNodeVersion +
+      '.\n' +
+      'Playwright requires Node.js 12 or higher. \n' +
+      'Please update your version of Node.js.'
+  );
+  process.exit(1);
+}

--- a/packages/playwright-core/src/utils/verifyNodeJsVersion.ts
+++ b/packages/playwright-core/src/utils/verifyNodeJsVersion.ts
@@ -28,3 +28,5 @@ if (major < 12) {
   );
   process.exit(1);
 }
+
+export {};


### PR DESCRIPTION
We support now also 12.0 so no need to warn users there I guess: https://github.com/microsoft/playwright/pull/9804

Fixes https://github.com/microsoft/playwright/issues/10387