### PR TITLE
feat(serial): better errors from beforeAll

### DIFF
--- a/packages/playwright-test/src/util.ts
+++ b/packages/playwright-test/src/util.ts
@@ -162,3 +162,20 @@ export function getContainedPath(parentPath: string, subPath: string = ''): stri
 }
 
 export const debugTest = debug('pw:test');
+
+export function prependToTestError(testError: TestError | undefined, message: string | undefined) {
+  if (!message)
+    return testError;
+  if (!testError)
+    return { value: message };
+  if (testError.message) {
+    const stack = testError.stack ? message + testError.stack : testError.stack;
+    message = message + testError.message;
+    return {
+      value: testError.value,
+      message,
+      stack,
+    };
+  }
+  return testError;
+}


### PR DESCRIPTION
When beforeAll hook times out or fails with an exception, we now close the context and show a nice error.

```
    Timeout of 2000ms exceeded in beforeAll hook.
    Pending operations:
      - page.click at a.test.ts:10:16
      - page.textContent at a.test.ts:11:16

    page.click: Target closed
    =========================== logs ===========================
    waiting for selector "text=Missing"
    ============================================================
```

Fixes #10402.