### PR TITLE
fix(codegen): allow to set initial window position

### DIFF
--- a/src/server/supplements/recorder/recorderApp.ts
+++ b/src/server/supplements/recorder/recorderApp.ts
@@ -97,11 +97,12 @@ export class RecorderApp extends EventEmitter {
     const recorderPlaywright = require('../../playwright').createPlaywright(true) as import('../../playwright').Playwright;
     const args = [
       '--app=data:text/html,',
-      '--window-size=600,600',
-      '--window-position=1280,10',
+      '--window-size=600,600'
     ];
     if (process.env.PWTEST_RECORDER_PORT)
       args.push(`--remote-debugging-port=${process.env.PWTEST_RECORDER_PORT}`);
+    if (process.env.PWTEST_RECORDER_WINDOW_POSITION)
+      args.push(`--window-position=${process.env.PWTEST_RECORDER_WINDOW_POSITION}`);
     let channel: types.BrowserChannel | undefined;
     let executablePath: string | undefined;
     if (inspectedContext._browser.options.isChromium) {


### PR DESCRIPTION
This commit removes hardcoded position of the recorder (codegen) window
position, which made this entire core feature non usable on machines
withuot external additional display or when using HDPi or resolution different from the original environment on which that position was added as fixed, that could work in one, specific setup scenario.

If required, window position can be set as
`PWTEST_RECORDER_WINDOW_POSITION` environment variable, for example to
restore original, fixed location:

```powershell
$env:PWTEST_RECORDER_WINDOW_POSITION="1280,10"
npx playwright codegen wikipedia.org
```

Thanks!

Fixes #5696