### PR TITLE
fix: noncompliant Firefox User-Agents

### DIFF
--- a/packages/playwright-core/src/server/deviceDescriptorsSource.json
+++ b/packages/playwright-core/src/server/deviceDescriptorsSource.json
@@ -784,7 +784,7 @@
     "defaultBrowserType": "webkit"
   },
   "JioPhone 2": {
-    "userAgent": "Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-15-130718-i;Android; rv:89.0 Gecko/48.0 Firefox/94.0.1 KAIOS/2.5",
+    "userAgent": "Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-15-130718-i;Android; rv:94.0.1) Gecko/48.0 Firefox/94.0.1 KAIOS/2.5",
     "viewport": {
       "width": 240,
       "height": 320
@@ -795,7 +795,7 @@
     "defaultBrowserType": "firefox"
   },
   "JioPhone 2 landscape": {
-    "userAgent": "Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-15-130718-i;Android; rv:89.0 Gecko/48.0 Firefox/94.0.1 KAIOS/2.5",
+    "userAgent": "Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-15-130718-i;Android; rv:94.0.1) Gecko/48.0 Firefox/94.0.1 KAIOS/2.5",
     "viewport": {
       "width": 320,
       "height": 240
@@ -1292,7 +1292,7 @@
     "defaultBrowserType": "chromium"
   },
   "Desktop Firefox HiDPI": {
-    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:90.0 Gecko/20100101 Firefox/94.0.1",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0.1) Gecko/20100101 Firefox/94.0.1",
     "screen": {
       "width": 1792,
       "height": 1120
@@ -1352,7 +1352,7 @@
     "defaultBrowserType": "chromium"
   },
   "Desktop Firefox": {
-    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:90.0 Gecko/20100101 Firefox/94.0.1",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0.1) Gecko/20100101 Firefox/94.0.1",
     "screen": {
       "width": 1920,
       "height": 1080

--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -79,7 +79,7 @@ async function run() {
           devicesDescriptors[deviceName].userAgent = devicesDescriptors[deviceName].userAgent.replace(
             /^(.*Firefox\/)(.*?)( .*?)?$/,
             `$1${versions.firefox}$3`
-          ).replace(/(.*rv:)(.*)\)(.*?)/, `$1${versions.firefox}$3`)
+          ).replace(/^(.*rv:)(.*)(\).*?)$/, `$1${versions.firefox}$3`)
           break;
         case 'webkit':
           devicesDescriptors[deviceName].userAgent = devicesDescriptors[deviceName].userAgent.replace(


### PR DESCRIPTION
Before we were triggered by some WAFs because our User Agent was not parsable.

-> 1.17 RC candiate.