### PR TITLE
Add sanity check for frames before removing it.

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -319,8 +319,11 @@ export class FrameManager {
   }
 
   removeChildFramesRecursively(frame: Frame) {
-    for (const child of frame.childFrames())
-      this._removeFramesRecursively(child);
+    if(frame){
+      for (const child of frame.childFrames()){
+        this._removeFramesRecursively(child);
+      }
+    }
   }
 
   private _removeFramesRecursively(frame: Frame) {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -319,10 +319,9 @@ export class FrameManager {
   }
 
   removeChildFramesRecursively(frame: Frame) {
-    if(frame){
-      for (const child of frame.childFrames()){
+    if (frame){
+      for (const child of frame.childFrames())
         this._removeFramesRecursively(child);
-      }
     }
   }
 


### PR DESCRIPTION
Sometimes frame doesn't exist for various reasons. We add
some sanity check before removing the frame recursively.