### PR TITLE
chore: add --dry-run to install-deps CLI command

### DIFF
--- a/packages/playwright-core/src/cli/innerCli.ts
+++ b/packages/playwright-core/src/cli/innerCli.ts
@@ -107,7 +107,7 @@ program
         if (!args.length) {
           const executables = registry.defaultExecutables();
           if (options.withDeps)
-            await registry.installDeps(executables);
+            await registry.installDeps(executables, false);
           await registry.install(executables);
         } else {
           const installDockerImage = args.some(arg => arg === 'docker-image');
@@ -123,7 +123,7 @@ program
 
           const executables = checkBrowsersToInstall(args);
           if (options.withDeps)
-            await registry.installDeps(executables);
+            await registry.installDeps(executables, false);
           await registry.install(executables);
         }
       } catch (e) {
@@ -143,12 +143,13 @@ Examples:
 program
     .command('install-deps [browser...]')
     .description('install dependencies necessary to run browsers (will ask for sudo permissions)')
-    .action(async function(args: string[]) {
+    .option('--dry-run', 'Do not execute installation commands, only print them')
+    .action(async function(args: string[], options: { dryRun?: boolean }) {
       try {
         if (!args.length)
-          await registry.installDeps(registry.defaultExecutables());
+          await registry.installDeps(registry.defaultExecutables(), !!options.dryRun);
         else
-          await registry.installDeps(checkBrowsersToInstall(args));
+          await registry.installDeps(checkBrowsersToInstall(args), !!options.dryRun);
       } catch (e) {
         console.log(`Failed to install browser dependencies\n${e}`);
         process.exit(1);

--- a/packages/playwright-core/src/utils/registry.ts
+++ b/packages/playwright-core/src/utils/registry.ts
@@ -526,7 +526,7 @@ export class Registry {
       return await validateDependenciesWindows(windowsExeAndDllDirectories.map(d => path.join(browserDirectory, d)));
   }
 
-  async installDeps(executablesToInstallDeps: Executable[]) {
+  async installDeps(executablesToInstallDeps: Executable[], dryRun: boolean) {
     const executables = this._addRequirementsAndDedupe(executablesToInstallDeps);
     const targets = new Set<DependencyGroup>();
     for (const executable of executables) {
@@ -535,9 +535,9 @@ export class Registry {
     }
     targets.add('tools');
     if (os.platform() === 'win32')
-      return await installDependenciesWindows(targets);
+      return await installDependenciesWindows(targets, dryRun);
     if (os.platform() === 'linux')
-      return await installDependenciesLinux(targets);
+      return await installDependenciesLinux(targets, dryRun);
   }
 
   async install(executablesToInstall: Executable[]) {


### PR DESCRIPTION
This will print the command which gets executed before we combine it with && and add sudo/su. Seems to be the expected behaviour here instead of the sh -c -u root stuff.


Fixes https://github.com/microsoft/playwright/issues/10232
Re-landing partly: https://github.com/microsoft/playwright/pull/6901
Relates: https://github.com/playwright-community/heroku-playwright-buildpack/issues/14
