### PR TITLE
feat(cli): add yarn to buildPlaywrightCLICommand

### DIFF
--- a/packages/playwright-core/src/utils/registry.ts
+++ b/packages/playwright-core/src/utils/registry.ts
@@ -21,7 +21,7 @@ import * as util from 'util';
 import * as fs from 'fs';
 import lockfile from 'proper-lockfile';
 import { getUbuntuVersion } from './ubuntuVersion';
-import { getFromENV, getAsBooleanFromENV, calculateSha1, removeFolders, existsAsync, hostPlatform, canAccessFile, spawnAsync, fetchData, wrapInASCIIBox } from './utils';
+import { getFromENV, getAsBooleanFromENV, calculateSha1, removeFolders, existsAsync, hostPlatform, canAccessFile, spawnAsync, fetchData, wrapInASCIIBox, determinePackageManager } from './utils';
 import { DependencyGroup, installDependenciesLinux, installDependenciesWindows, validateDependenciesLinux, validateDependenciesWindows } from './dependencies';
 import { downloadBrowserWithProgressBar, logPolitely } from './browserFetcher';
 
@@ -718,7 +718,10 @@ export function buildPlaywrightCLICommand(sdkLanguage: string, parameters: strin
     case 'csharp':
       return `playwright ${parameters}`;
     default:
-      return `npx playwright ${parameters}`;
+      if (determinePackageManager(process.cwd()) === 'yarn')
+        return `yarn playwright ${parameters}`;
+      else
+        return `npx playwright ${parameters}`;
   }
 }
 

--- a/packages/playwright-core/src/utils/utils.ts
+++ b/packages/playwright-core/src/utils/utils.ts
@@ -520,3 +520,11 @@ export function streamToString(stream: stream.Readable): Promise<string> {
     stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
   });
 }
+
+export function determinePackageManager(rootDir: string): 'yarn' | 'npm' {
+  if (fs.existsSync(path.join(rootDir, 'yarn.lock')))
+    return 'yarn';
+  if (process.env.npm_config_user_agent)
+    return process.env.npm_config_user_agent.includes('yarn') ? 'yarn' : 'npm';
+  return 'npm';
+}


### PR DESCRIPTION
Modify messages like this to say `yarn` instead of `npx` when applicable:
<img width="538" alt="Screen Shot 2021-11-24 at 2 48 28 PM" src="https://user-images.githubusercontent.com/669326/143322451-609e4b3b-f94c-43eb-ab3b-e08be31b72b8.png">

`determinePackageManager` was copied from [packages/create-playwright/src/utils.ts](https://github.com/microsoft/playwright/blob/master/packages/create-playwright/src/utils.ts#L58-L64).

Prior to running across `determinePackageManager`, I was planning to use something a bit more conservative (in the sense of "more likely to default to npm"):
```js
if (!fs.existsSync(path.join(rootDir, 'package-lock.json')) && fs.existsSync(path.join(rootDir, 'yarn.lock')))
```