### PR TITLE
browser(webkit): roll to 25/11/21

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1579
-Changed: dpino@igalia.com Thu 18 Nov 2021 07:04:08 AM UTC
+1580
+Changed: dpino@igalia.com Thu Nov 25 14:22:44 HKT 2021

--- a/browser_patches/webkit/UPSTREAM_CONFIG.sh
+++ b/browser_patches/webkit/UPSTREAM_CONFIG.sh
@@ -1,3 +1,3 @@
 REMOTE_URL="https://github.com/WebKit/WebKit.git"
 BASE_BRANCH="main"
-BASE_REVISION="a8d27d2f68e72abd50ed4a142af0d05f9aef662c"
+BASE_REVISION="bed174a39a11c5fa8e1c3658dfffb46305ddf5f4"

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -1,5 +1,5 @@
 diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
-index f1a30e2f9552f1ca282f626a82c0a6fbe8b978a0..8085033676c04b5e5124e7f669a3ef0ae35ad749 100644
+index 08badc32775c2280a7a60dda6027eccc3343ef8d..1a34d0324feef99d9e497462b90299b8c0b2c4bd 100644
 --- a/Source/JavaScriptCore/CMakeLists.txt
 +++ b/Source/JavaScriptCore/CMakeLists.txt
 @@ -1353,22 +1353,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
@@ -31,10 +31,10 @@ index f1a30e2f9552f1ca282f626a82c0a6fbe8b978a0..8085033676c04b5e5124e7f669a3ef0a
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/ServiceWorker.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Target.json
 diff --git a/Source/JavaScriptCore/DerivedSources.make b/Source/JavaScriptCore/DerivedSources.make
-index 4ecae3f05981398cbf63a4679ee8dfcfeb4686fa..567535749077bfd9aefc7c58d699eb8741b7da4c 100644
+index dee7344e6b12635ba4f90dc1faa9c00be4682d72..15d7e73a0aa248625180fecca3cf5ae6876adab4 100644
 --- a/Source/JavaScriptCore/DerivedSources.make
 +++ b/Source/JavaScriptCore/DerivedSources.make
-@@ -286,22 +286,27 @@ INSPECTOR_DOMAINS := \
+@@ -290,22 +290,27 @@ INSPECTOR_DOMAINS := \
      $(JavaScriptCore)/inspector/protocol/CSS.json \
      $(JavaScriptCore)/inspector/protocol/Canvas.json \
      $(JavaScriptCore)/inspector/protocol/Console.json \
@@ -2249,7 +2249,7 @@ index 24cc44a5c88de5f78cd96404f23060ee514301ec..c922489288e827ebd0b249e64609459c
  
  #if !defined(ENABLE_TOUCH_ACTION_REGIONS)
 diff --git a/Source/WTF/wtf/PlatformEnableCocoa.h b/Source/WTF/wtf/PlatformEnableCocoa.h
-index 0d143bf5b31f01532fa4c2f86d9859ec1b055eca..27738a4dd54c8e6cd31972228ca798969bb9073a 100644
+index 7e807beda588a540b477e185e41e367f7a333702..9322d1e5b425c9bbafa89083a1df7eaada2bbe68 100644
 --- a/Source/WTF/wtf/PlatformEnableCocoa.h
 +++ b/Source/WTF/wtf/PlatformEnableCocoa.h
 @@ -224,7 +224,7 @@
@@ -2299,10 +2299,10 @@ index f8bedf1af5d20d9c93a96af565e416bfb0df6faa..a072e5e130822d3658cbab453aef8d16
  
  if (Journald_FOUND)
 diff --git a/Source/WebCore/DerivedSources.make b/Source/WebCore/DerivedSources.make
-index f88e639b9d74b9dd5448ced99181c0df0f528144..5cdd41bcc73e0266afebc93811df65121d05c760 100644
+index dde6444061d22332b41a0387191080ff6111be90..a30f29deff3646b36a2104fd3557992ec5313c95 100644
 --- a/Source/WebCore/DerivedSources.make
 +++ b/Source/WebCore/DerivedSources.make
-@@ -935,6 +935,10 @@ JS_BINDING_IDLS := \
+@@ -940,6 +940,10 @@ JS_BINDING_IDLS := \
      $(WebCore)/dom/Slotable.idl \
      $(WebCore)/dom/StaticRange.idl \
      $(WebCore)/dom/StringCallback.idl \
@@ -2313,7 +2313,7 @@ index f88e639b9d74b9dd5448ced99181c0df0f528144..5cdd41bcc73e0266afebc93811df6512
      $(WebCore)/dom/Text.idl \
      $(WebCore)/dom/TextDecoder.idl \
      $(WebCore)/dom/TextDecoderStream.idl \
-@@ -1475,9 +1479,6 @@ JS_BINDING_IDLS := \
+@@ -1480,9 +1484,6 @@ JS_BINDING_IDLS := \
  ADDITIONAL_BINDING_IDLS = \
      DocumentTouch.idl \
      GestureEvent.idl \
@@ -2400,10 +2400,10 @@ index cfbfe4f66dbc339e68179f4ceb48a02c3c122926..66050a7c29254f73d04273510b5e0642
  
  set(CSS_VALUE_PLATFORM_DEFINES "HAVE_OS_DARK_MODE_SUPPORT=1")
 diff --git a/Source/WebCore/SourcesCocoa.txt b/Source/WebCore/SourcesCocoa.txt
-index b287710cdf0da7084615f2f28a14722221a964a1..484d841b7cb4b621e0160c9207e4bf4f63cdb67c 100644
+index 1a46686f78cdcb238bad5f2ac32a72c5417463de..c625a5cba18006f1c2290712c1ccb54c1c513ced 100644
 --- a/Source/WebCore/SourcesCocoa.txt
 +++ b/Source/WebCore/SourcesCocoa.txt
-@@ -609,3 +609,9 @@ platform/graphics/angle/ANGLEUtilities.cpp @no-unify
+@@ -608,3 +608,9 @@ platform/graphics/angle/ANGLEUtilities.cpp @no-unify
  platform/graphics/angle/ExtensionsGLANGLE.cpp @no-unify
  platform/graphics/angle/GraphicsContextGLANGLE.cpp @no-unify
  platform/graphics/angle/TemporaryANGLESetting.cpp @no-unify
@@ -2414,10 +2414,10 @@ index b287710cdf0da7084615f2f28a14722221a964a1..484d841b7cb4b621e0160c9207e4bf4f
 +JSTouchList.cpp
 +// Playwright end
 diff --git a/Source/WebCore/SourcesGTK.txt b/Source/WebCore/SourcesGTK.txt
-index 6aa4060d8735712f463c35690689242f25d1d441..4bff6490fef065297df7834bdbb8a7029737d1d2 100644
+index 77a71256512d1728c86e378591685edcbcdcc569..7fb305a28a3d95d7c42845a176ae407b153f7385 100644
 --- a/Source/WebCore/SourcesGTK.txt
 +++ b/Source/WebCore/SourcesGTK.txt
-@@ -94,7 +94,7 @@ platform/graphics/egl/GLContextEGLLibWPE.cpp @no-unify
+@@ -100,7 +100,7 @@ platform/graphics/egl/GLContextEGLLibWPE.cpp @no-unify
  platform/graphics/egl/GLContextEGLWayland.cpp @no-unify
  platform/graphics/egl/GLContextEGLX11.cpp @no-unify
  
@@ -2465,10 +2465,10 @@ index 9f85e4986c53a1cc8d63b3394d3f7295832af387..1228fda7c688c5b24cecaf07e21437d3
  __ZN7WebCore14DocumentLoaderD2Ev
  __ZN7WebCore14DocumentLoader17clearMainResourceEv
 diff --git a/Source/WebCore/WebCore.xcodeproj/project.pbxproj b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d4390677a14774 100644
+index 0aca7c32c4568b43e4b901bdbd72c5f5a0bfcd3c..d1f134304639ae3dd9c862cf1f82b0254597714a 100644
 --- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 +++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-@@ -5421,6 +5421,14 @@
+@@ -5422,6 +5422,14 @@
  		EDE3A5000C7A430600956A37 /* ColorMac.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE3A4FF0C7A430600956A37 /* ColorMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		EDEC98030AED7E170059137F /* WebCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEC98020AED7E170059137F /* WebCorePrefix.h */; };
  		EFCC6C8F20FE914400A2321B /* CanvasActivityRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2483,7 +2483,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  		F12171F616A8CF0B000053CA /* WebVTTElement.h in Headers */ = {isa = PBXBuildFile; fileRef = F12171F416A8BC63000053CA /* WebVTTElement.h */; };
  		F32BDCD92363AACA0073B6AE /* UserGestureEmulationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F32BDCD72363AACA0073B6AE /* UserGestureEmulationScope.h */; };
  		F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
-@@ -17209,6 +17217,14 @@
+@@ -17252,6 +17260,14 @@
  		EDEC98020AED7E170059137F /* WebCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCorePrefix.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
  		EFB7287B2124C73D005C2558 /* CanvasActivityRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasActivityRecord.cpp; sourceTree = "<group>"; };
  		EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasActivityRecord.h; sourceTree = "<group>"; };
@@ -2498,7 +2498,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  		F12171F316A8BC63000053CA /* WebVTTElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebVTTElement.cpp; sourceTree = "<group>"; };
  		F12171F416A8BC63000053CA /* WebVTTElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebVTTElement.h; sourceTree = "<group>"; };
  		F32BDCD52363AAC90073B6AE /* UserGestureEmulationScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserGestureEmulationScope.cpp; sourceTree = "<group>"; };
-@@ -23160,7 +23176,12 @@
+@@ -23201,7 +23217,12 @@
  				93D6B7A62551D3ED0058DD3A /* DummySpeechRecognitionProvider.h */,
  				1AF326770D78B9440068F0C4 /* EditorClient.h */,
  				93C09A800B064F00005ABD4D /* EventHandler.cpp */,
@@ -2511,7 +2511,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  				E0FEF371B27C53EAC1C1FBEE /* EventSource.cpp */,
  				E0FEF371B17C53EAC1C1FBEE /* EventSource.h */,
  				E0FEF371B07C53EAC1C1FBEE /* EventSource.idl */,
-@@ -29055,6 +29076,8 @@
+@@ -29143,6 +29164,8 @@
  				29E4D8DF16B0940F00C84704 /* PlatformSpeechSynthesizer.h */,
  				1AD8F81A11CAB9E900E93E54 /* PlatformStrategies.cpp */,
  				1AD8F81911CAB9E900E93E54 /* PlatformStrategies.h */,
@@ -2520,7 +2520,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  				0FD7C21D23CE41E30096D102 /* PlatformWheelEvent.cpp */,
  				935C476A09AC4D4F00A6AAB4 /* PlatformWheelEvent.h */,
  				BCBB8AB513F1AFB000734DF0 /* PODInterval.h */,
-@@ -31309,6 +31332,7 @@
+@@ -31402,6 +31425,7 @@
  				BCCFBAE70B5152ED0001F1D7 /* DocumentParser.h */,
  				AD6E71AA1668899D00320C13 /* DocumentSharedObjectPool.cpp */,
  				AD6E71AB1668899D00320C13 /* DocumentSharedObjectPool.h */,
@@ -2528,7 +2528,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  				6BDB5DC1227BD3B800919770 /* DocumentStorageAccess.cpp */,
  				6BDB5DC0227BD3B800919770 /* DocumentStorageAccess.h */,
  				7CE7FA5B1EF882300060C9D6 /* DocumentTouch.cpp */,
-@@ -32326,6 +32350,7 @@
+@@ -32419,6 +32443,7 @@
  				93C4F6EB1108F9A50099D0DB /* AccessibilityScrollbar.h in Headers */,
  				29489FC712C00F0300D83F0F /* AccessibilityScrollView.h in Headers */,
  				0709FC4E1025DEE30059CDBA /* AccessibilitySlider.h in Headers */,
@@ -2536,7 +2536,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  				29D7BCFA1444AF7D0070619C /* AccessibilitySpinButton.h in Headers */,
  				69A6CBAD1C6BE42C00B836E9 /* AccessibilitySVGElement.h in Headers */,
  				AAC08CF315F941FD00F1E188 /* AccessibilitySVGRoot.h in Headers */,
-@@ -34423,6 +34448,7 @@
+@@ -34517,6 +34542,7 @@
  				6E4ABCD5138EA0B70071D291 /* JSHTMLUnknownElement.h in Headers */,
  				E44614170CD6826900FADA75 /* JSHTMLVideoElement.h in Headers */,
  				81BE20D311F4BC3200915DFA /* JSIDBCursor.h in Headers */,
@@ -2544,7 +2544,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  				7C3D8EF01E0B21430023B084 /* JSIDBCursorDirection.h in Headers */,
  				C585A68311D4FB08004C3E4B /* JSIDBDatabase.h in Headers */,
  				C585A69711D4FB13004C3E4B /* JSIDBFactory.h in Headers */,
-@@ -36555,9 +36581,11 @@
+@@ -36648,9 +36674,11 @@
  				B2C3DA3A0D006C1D00EF6F26 /* TextCodec.h in Headers */,
  				26E98A10130A9FCA008EB7B2 /* TextCodecASCIIFastPath.h in Headers */,
  				DF95B14A24FDAFD300B1F4D7 /* TextCodecCJK.h in Headers */,
@@ -2556,7 +2556,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  				B2C3DA400D006C1D00EF6F26 /* TextCodecUserDefined.h in Headers */,
  				B2C3DA420D006C1D00EF6F26 /* TextCodecUTF16.h in Headers */,
  				9343CB8212F25E510033C5EE /* TextCodecUTF8.h in Headers */,
-@@ -37518,6 +37546,7 @@
+@@ -37613,6 +37641,7 @@
  				1ABA76CA11D20E50004C201C /* CSSPropertyNames.cpp in Sources */,
  				2D22830323A8470700364B7E /* CursorMac.mm in Sources */,
  				5CBD59592280E926002B22AA /* CustomHeaderFields.cpp in Sources */,
@@ -2564,7 +2564,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  				6E72F54C229DCD0C00B3E151 /* ExtensionsGLANGLE.cpp in Sources */,
  				7CE6CBFD187F394900D46BF5 /* FormatConverter.cpp in Sources */,
  				5130F2F624AEA60A00E1D0A0 /* GameControllerSoftLink.mm in Sources */,
-@@ -37587,6 +37616,7 @@
+@@ -37682,6 +37711,7 @@
  				6E72F54F229DCD1300B3E151 /* TemporaryANGLESetting.cpp in Sources */,
  				CE88EE262414467B007F29C2 /* TextAlternativeWithRange.mm in Sources */,
  				51DF6D800B92A18E00C2DC85 /* ThreadCheck.mm in Sources */,
@@ -2572,7 +2572,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  				538EC8031F96AF81004D22A8 /* UnifiedSource1-mm.mm in Sources */,
  				538EC8021F96AF81004D22A8 /* UnifiedSource1.cpp in Sources */,
  				538EC8051F96AF81004D22A8 /* UnifiedSource2-mm.mm in Sources */,
-@@ -37635,6 +37665,7 @@
+@@ -37730,6 +37760,7 @@
  				538EC8881F993F9C004D22A8 /* UnifiedSource23.cpp in Sources */,
  				DE5F85801FA1ABF4006DB63A /* UnifiedSource24-mm.mm in Sources */,
  				538EC8891F993F9D004D22A8 /* UnifiedSource24.cpp in Sources */,
@@ -2580,7 +2580,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  				DE5F85811FA1ABF4006DB63A /* UnifiedSource25-mm.mm in Sources */,
  				538EC88A1F993F9D004D22A8 /* UnifiedSource25.cpp in Sources */,
  				DE5F85821FA1ABF4006DB63A /* UnifiedSource26-mm.mm in Sources */,
-@@ -38167,6 +38198,7 @@
+@@ -38262,6 +38293,7 @@
  				2D8B92F1203D13E1009C868F /* UnifiedSource516.cpp in Sources */,
  				2D8B92F2203D13E1009C868F /* UnifiedSource517.cpp in Sources */,
  				2D8B92F3203D13E1009C868F /* UnifiedSource518.cpp in Sources */,
@@ -2589,7 +2589,7 @@ index 9104f545b2a00b03c27cf71a1691a92808af9ada..dbbc87d407b39c02c102739fb1d43906
  				2D8B92F5203D13E1009C868F /* UnifiedSource520.cpp in Sources */,
  				2D8B92F6203D13E1009C868F /* UnifiedSource521.cpp in Sources */,
 diff --git a/Source/WebCore/accessibility/AccessibilityObject.cpp b/Source/WebCore/accessibility/AccessibilityObject.cpp
-index 93848e1cab76d7987638db8f3daa638f9990fe09..c8f7c9fa69fd10981f3d63007c9624ff8abb0522 100644
+index 10ba9f976d3cdf26c9cca2b7d08b2b24c341782b..e11d39157f67c35f843ba5e485f3d51ee0e2e66b 100644
 --- a/Source/WebCore/accessibility/AccessibilityObject.cpp
 +++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
 @@ -60,6 +60,7 @@
@@ -2600,7 +2600,7 @@ index 93848e1cab76d7987638db8f3daa638f9990fe09..c8f7c9fa69fd10981f3d63007c9624ff
  #include "LocalizedStrings.h"
  #include "MathMLNames.h"
  #include "NodeList.h"
-@@ -3476,10 +3477,15 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
+@@ -3530,10 +3531,15 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
      
      if (useParentData ? m_isIgnoredFromParentData.isPresentationalChildOfAriaRole : isPresentationalChildOfAriaRole())
          return AccessibilityObjectInclusion::IgnoreObject;
@@ -2620,7 +2620,7 @@ index 93848e1cab76d7987638db8f3daa638f9990fe09..c8f7c9fa69fd10981f3d63007c9624ff
  {
      AXComputedObjectAttributeCache* attributeCache = nullptr;
 diff --git a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
-index 261d89346ffb43466fda3e1551d262ef96a69eb8..777edd5e48943ffcbb8414a70835993cef78d4ca 100644
+index eb43545d9b501810cb1db2bdff05f4c6fc1432dc..57a61dcee5a7b580ca5d31d392b24c006715359c 100644
 --- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
 +++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
 @@ -109,6 +109,8 @@ namespace WebCore {
@@ -2633,10 +2633,10 @@ index 261d89346ffb43466fda3e1551d262ef96a69eb8..777edd5e48943ffcbb8414a70835993c
      macro(EnterPictureInPictureEvent) \
      macro(ExtendableEvent) \
 diff --git a/Source/WebCore/css/MediaQueryEvaluator.cpp b/Source/WebCore/css/MediaQueryEvaluator.cpp
-index 856ec46ac0f8f6079bf3668823734749d242dda7..1dd61f7227c3887a8780b0fed2e2f1324ce6a015 100644
+index 9c00886958d5ae32edd5f76f76843d0bdfaffe70..63e99946a89893f39465e7858be329498e68cb0f 100644
 --- a/Source/WebCore/css/MediaQueryEvaluator.cpp
 +++ b/Source/WebCore/css/MediaQueryEvaluator.cpp
-@@ -846,7 +846,11 @@ static bool prefersContrastEvaluate(CSSValue* value, const CSSToLengthConversion
+@@ -847,7 +847,11 @@ static bool prefersContrastEvaluate(CSSValue* value, const CSSToLengthConversion
  static bool prefersReducedMotionEvaluate(CSSValue* value, const CSSToLengthConversionData&, Frame& frame, MediaFeaturePrefix)
  {
      bool userPrefersReducedMotion = false;
@@ -2649,7 +2649,7 @@ index 856ec46ac0f8f6079bf3668823734749d242dda7..1dd61f7227c3887a8780b0fed2e2f132
      switch (frame.settings().forcedPrefersReducedMotionAccessibilityValue()) {
      case ForcedAccessibilityValue::On:
          userPrefersReducedMotion = true;
-@@ -859,6 +863,7 @@ static bool prefersReducedMotionEvaluate(CSSValue* value, const CSSToLengthConve
+@@ -860,6 +864,7 @@ static bool prefersReducedMotionEvaluate(CSSValue* value, const CSSToLengthConve
  #endif
          break;
      }
@@ -5342,7 +5342,7 @@ index 16edb3bc689b8e2dde17597b642b706c1343e1f5..f363b2ca2410f22cff8d6ad908a88527
  
  private:
 diff --git a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
-index aef157ed20bd14aa57087c54d8d1c48266a2aac9..4405adbd414c039149f83a90460ad8afdbb5bde4 100644
+index 74c38ea363a9d0090e1dbda9740ef680d0052d49..432d939c41f3d6fbf673e79b95df5d225174101d 100644
 --- a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
 +++ b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
 @@ -277,7 +277,7 @@ void LineLayout::updateFormattingRootGeometryAndInvalidate()
@@ -5377,10 +5377,10 @@ index 982691dd2dfe2f65201370a12302b5086703c126..4af72beb3b1405ffac78e89e7fbb2b14
  protected:
      static SameSiteInfo sameSiteInfo(const Document&, IsForDOMCookieAccess = IsForDOMCookieAccess::No);
 diff --git a/Source/WebCore/loader/DocumentLoader.cpp b/Source/WebCore/loader/DocumentLoader.cpp
-index 39ce5fd41d6699928d8b900cb4f58c9627a695de..189da4e9d4dc65740d140c817ab1cd4f3a028685 100644
+index c3d8450f71c2c373d2af1cccfb215ad81bf80d0b..fe236968bb014fb055b45ad61ba221c7d8110148 100644
 --- a/Source/WebCore/loader/DocumentLoader.cpp
 +++ b/Source/WebCore/loader/DocumentLoader.cpp
-@@ -1467,8 +1467,6 @@ void DocumentLoader::detachFromFrame()
+@@ -1471,8 +1471,6 @@ void DocumentLoader::detachFromFrame()
      if (!m_frame)
          return;
  
@@ -5390,10 +5390,10 @@ index 39ce5fd41d6699928d8b900cb4f58c9627a695de..189da4e9d4dc65740d140c817ab1cd4f
  }
  
 diff --git a/Source/WebCore/loader/DocumentLoader.h b/Source/WebCore/loader/DocumentLoader.h
-index 4fbfd7120199d27cfa87bdd596737106bce08db0..4f769e266eb4d33ca9c8fa553a4d763a549681be 100644
+index fbf545c460e4e489d87b25c0e85eccca4cbf3c87..89e3cbe6a430d019a5acf59899551a9a80d827ab 100644
 --- a/Source/WebCore/loader/DocumentLoader.h
 +++ b/Source/WebCore/loader/DocumentLoader.h
-@@ -168,9 +168,13 @@ public:
+@@ -169,9 +169,13 @@ public:
  
      WEBCORE_EXPORT virtual void detachFromFrame();
  
@@ -5576,7 +5576,7 @@ index fa84c366c63175f9fb4730eb85c4677fc3d6368f..ecf5b8dc97e35910baf493424e673155
  
  void ProgressTracker::incrementProgress(ResourceLoaderIdentifier identifier, const ResourceResponse& response)
 diff --git a/Source/WebCore/page/ChromeClient.h b/Source/WebCore/page/ChromeClient.h
-index e13e387d19168ac5fd359b2e616d43dd3f175022..1c6b14b83d4bea3acbff3bbc402474f05b7cebdc 100644
+index f239145706d0b1905410ad8e66cfe9900cdc76ee..c1fbeb8ce16a31c756f2f85babcdd58497b64140 100644
 --- a/Source/WebCore/page/ChromeClient.h
 +++ b/Source/WebCore/page/ChromeClient.h
 @@ -307,7 +307,7 @@ public:
@@ -5589,7 +5589,7 @@ index e13e387d19168ac5fd359b2e616d43dd3f175022..1c6b14b83d4bea3acbff3bbc402474f0
  
  #if ENABLE(INPUT_TYPE_COLOR)
 diff --git a/Source/WebCore/page/EventHandler.cpp b/Source/WebCore/page/EventHandler.cpp
-index 7c349b7082741df76cf71bcfdb90daa098bbb0a3..83130f06f39846b5850581f21377b0c516aca032 100644
+index ec3e420e79bb1b5dcf701355d1ace69bf8864151..7ba5d7e5db457bb3eb0f4ecef6d95b8ae70540dc 100644
 --- a/Source/WebCore/page/EventHandler.cpp
 +++ b/Source/WebCore/page/EventHandler.cpp
 @@ -139,6 +139,7 @@
@@ -5687,7 +5687,7 @@ index 7c349b7082741df76cf71bcfdb90daa098bbb0a3..83130f06f39846b5850581f21377b0c5
  
      return swallowEvent;
  }
-@@ -4101,7 +4101,14 @@ bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDr
+@@ -4108,7 +4108,14 @@ bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDr
      if (!m_frame.document())
          return false;
  
@@ -5703,7 +5703,7 @@ index 7c349b7082741df76cf71bcfdb90daa098bbb0a3..83130f06f39846b5850581f21377b0c5
      auto hasNonDefaultPasteboardData = HasNonDefaultPasteboardData::No;
      
      if (dragState().shouldDispatchEvents) {
-@@ -4512,7 +4519,8 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
+@@ -4515,7 +4522,8 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
              allTouchReleased = false;
      }
  
@@ -5713,7 +5713,7 @@ index 7c349b7082741df76cf71bcfdb90daa098bbb0a3..83130f06f39846b5850581f21377b0c5
          PlatformTouchPoint::State pointState = point.state();
          LayoutPoint pagePoint = documentPointForWindowPoint(m_frame, point.pos());
  
-@@ -4639,6 +4647,9 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
+@@ -4642,6 +4650,9 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
              changedTouches[pointState].m_touches->append(WTFMove(touch));
              changedTouches[pointState].m_targets.add(touchTarget);
          }
@@ -5724,7 +5724,7 @@ index 7c349b7082741df76cf71bcfdb90daa098bbb0a3..83130f06f39846b5850581f21377b0c5
      m_touchPressed = touches->length() > 0;
      if (allTouchReleased)
 diff --git a/Source/WebCore/page/EventHandler.h b/Source/WebCore/page/EventHandler.h
-index 36c80230d2b2e761a0b666c943061f9b62f547b3..78df0795a1add4fe962e64457a640959bb06cdfd 100644
+index eac1d5f340086c3636bff6109651dec9f4eb30fe..6da03d6a69a9ac5d0eb50ddc90ac77f6fa85b659 100644
 --- a/Source/WebCore/page/EventHandler.h
 +++ b/Source/WebCore/page/EventHandler.h
 @@ -135,9 +135,7 @@ public:
@@ -5737,7 +5737,7 @@ index 36c80230d2b2e761a0b666c943061f9b62f547b3..78df0795a1add4fe962e64457a640959
  
  #if ENABLE(PAN_SCROLLING)
      void didPanScrollStart();
-@@ -383,10 +381,8 @@ private:
+@@ -385,10 +383,8 @@ private:
      bool startKeyboardScrolling(KeyboardEvent&);
      void stopKeyboardScrolling();
  
@@ -5748,7 +5748,7 @@ index 36c80230d2b2e761a0b666c943061f9b62f547b3..78df0795a1add4fe962e64457a640959
  
      WEBCORE_EXPORT bool handleMouseReleaseEvent(const MouseEventWithHitTestResults&);
  
-@@ -486,10 +482,8 @@ private:
+@@ -488,10 +484,8 @@ private:
      void defaultTabEventHandler(KeyboardEvent&);
      void defaultArrowEventHandler(FocusDirection, KeyboardEvent&);
  
@@ -5759,7 +5759,7 @@ index 36c80230d2b2e761a0b666c943061f9b62f547b3..78df0795a1add4fe962e64457a640959
  
      // The following are called at the beginning of handleMouseUp and handleDrag.  
      // If they return true it indicates that they have consumed the event.
-@@ -497,9 +491,10 @@ private:
+@@ -499,9 +493,10 @@ private:
  
  #if ENABLE(DRAG_SUPPORT)
      bool eventLoopHandleMouseDragged(const MouseEventWithHitTestResults&);
@@ -5771,7 +5771,7 @@ index 36c80230d2b2e761a0b666c943061f9b62f547b3..78df0795a1add4fe962e64457a640959
      enum class SetOrClearLastScrollbar { Clear, Set };
      void updateLastScrollbarUnderMouse(Scrollbar*, SetOrClearLastScrollbar);
      
-@@ -591,8 +586,8 @@ private:
+@@ -593,8 +588,8 @@ private:
      Timer m_autoHideCursorTimer;
  #endif
  
@@ -6604,7 +6604,7 @@ index 3bec0aef174336939838fb1069fffbcb9f3d5604..566ef3806be3c5ccf1bb951251c2a90d
  
  RefPtr<ThreadableWebSocketChannel> SocketProvider::createWebSocketChannel(Document&, WebSocketChannelClient&)
 diff --git a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
-index b2de5ffdbfa97ec1d6dca9fdd428c97607d17bdb..06dee0ec352e206d82d6137b128d692c63dd9e3c 100644
+index f15302bf8396b40ff1578c0cad124581a7736445..4a5271a0f7ece6baeef4e9e0c3f1f8df80c25be6 100644
 --- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
 +++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
 @@ -293,6 +293,8 @@ bool ContentSecurityPolicy::protocolMatchesSelf(const URL& url) const
@@ -6921,7 +6921,7 @@ index d47d193e8bee85c2d2a35e218decdd84b7212dc1..a1cd2f3b8f025436b596d1b1081357d9
  #endif
  
 diff --git a/Source/WebCore/platform/ScrollableArea.h b/Source/WebCore/platform/ScrollableArea.h
-index 7a7d30ecd60131dc1c2f61b48efb68ee9a91eb66..3b9e78d794754c03481542961c129ff96cd226b6 100644
+index ab745c4bba9f23e18aba3cf136e3e915310b9051..b97ce7699e3bd705016cb1d209ba90f507ba394a 100644
 --- a/Source/WebCore/platform/ScrollableArea.h
 +++ b/Source/WebCore/platform/ScrollableArea.h
 @@ -103,7 +103,7 @@ public:
@@ -7145,6 +7145,33 @@ index 8677d106bf2d0f53044b47fba0e6736efcd3aeb6..9b28f9d917536d2c2699f613adf296bb
  Vector<uint8_t> data(const PixelBuffer&, const String& mimeType, std::optional<double> quality);
  
  WEBCORE_EXPORT String dataURL(CGImageRef, CFStringRef destinationUTI, const String& mimeType, std::optional<double> quality);
+diff --git a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.h b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.h
+index 5e321c7193b9cad45721460c7eb438e0b70042b7..69ced7fa6ee71248a38a1b50d5dce4b56f1d906a 100644
+--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.h
++++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.h
+@@ -23,6 +23,7 @@
+ #pragma once
+ 
+ #include "FilterEffectApplier.h"
++#include "PixelBuffer.h"
+ 
+ namespace WebCore {
+ 
+diff --git a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
+index 24d6c08da79c177cad8717af8c9d2229c2defe81..17f49c8074df6d2b55ee5710b15117fe7c37b6b8 100644
+--- a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
++++ b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
+@@ -24,7 +24,10 @@
+ #pragma once
+ 
+ #include "FilterEffectApplier.h"
++#include "IntPoint.h"
++#include "IntSize.h"
+ #include <wtf/Vector.h>
++#include <JavaScriptCore/Uint8ClampedArray.h>
+ 
+ namespace WebCore {
+ 
 diff --git a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
 index 2e46b61536c835dfcacf9f79e10e6d59ae7a3836..fa0c72d80d83c58a8407e78988de010fe97d7c38 100644
 --- a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
@@ -8850,7 +8877,7 @@ index 694008e0451edc5770142a0a6d9eed52b04ded80..ec93869f9486bdf7bd3bb56478c62469
      
  WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollAlignment::Behavior);
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
-index 9f72d8dc62b90b7e64437c5870e7944d81460630..54c56855f86077bdb984527f61774dfb121bcbf1 100644
+index 291cc9892e81027d9caed1d9db7061d73e674170..82250607745fb5b7f7148b0b2381f626a746de7d 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 @@ -76,6 +76,11 @@
@@ -8881,7 +8908,7 @@ index 9f72d8dc62b90b7e64437c5870e7944d81460630..54c56855f86077bdb984527f61774dfb
  void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier frameID, PageIdentifier pageID)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
-index d1bbfdb0090a8fcf8c8fa8d1e0a6d55bc2bf956f..2e72b6aed762434d14c0e4b76dbcf142df6c89d2 100644
+index e817b7b62d249787dc4ab19edebb0c4f68512f2e..b3b923d1a0508d1bc8d8238fc5526437a62fcca1 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 @@ -289,6 +289,8 @@ private:
@@ -8894,7 +8921,7 @@ index d1bbfdb0090a8fcf8c8fa8d1e0a6d55bc2bf956f..2e72b6aed762434d14c0e4b76dbcf142
      void removeStorageAccessForFrame(WebCore::FrameIdentifier, WebCore::PageIdentifier);
  
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
-index daeba5d84582c506391b2eca143710d23a17de12..cd68dd1d1b7e7d952040e6546a66fbbbe990068b 100644
+index 005f632ef577c9c16a7dd7c1e6c67c911b42676c..53d84bccb064cc99f998b10519a3993ee29b613e 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 @@ -66,6 +66,8 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
@@ -8907,7 +8934,7 @@ index daeba5d84582c506391b2eca143710d23a17de12..cd68dd1d1b7e7d952040e6546a66fbbb
      RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
      LogUserInteraction(WebCore::RegistrableDomain domain)
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.cpp b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
-index be00066ba03350ce965795c58bafa412bc495907..7cc58fc49c933597f012c4c35bd63b6a21fd25a3 100644
+index 666bcc1b21b95d0892b2f23fdc129fbae61fe321..1d4bd1ad2a05d1a1b831d083d85363edb641c13e 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 @@ -26,7 +26,6 @@
@@ -8979,7 +9006,7 @@ index be00066ba03350ce965795c58bafa412bc495907..7cc58fc49c933597f012c4c35bd63b6a
  void NetworkProcess::dumpResourceLoadStatistics(PAL::SessionID sessionID, CompletionHandler<void(String)>&& completionHandler)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.h b/Source/WebKit/NetworkProcess/NetworkProcess.h
-index 57799ac04368746487dd2536a195951e5c08d760..4b7d77358ab101e63a7c7585d40d1cdee53498b1 100644
+index 9d32d57973a0ebac1d07175c6df879d466ce68a8..0769edae24c8b22f69cb2b088bf7bb1c812ea4ed 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
 @@ -35,6 +35,7 @@
@@ -8998,7 +9025,7 @@ index 57799ac04368746487dd2536a195951e5c08d760..4b7d77358ab101e63a7c7585d40d1cde
  class CurlProxySettings;
  class ProtectionSpace;
  class StorageQuotaManager;
-@@ -212,6 +214,14 @@ public:
+@@ -211,6 +213,14 @@ public:
  
      void addWebsiteDataStore(WebsiteDataStoreParameters&&);
  
@@ -9653,7 +9680,7 @@ index 87fa6e1bd9e5f8dbdef854021f7d8579591629b5..a0e9545900928f005110e83ef1248fa1
      Cairo::Cairo
      Freetype::Freetype
 diff --git a/Source/WebKit/PlatformWin.cmake b/Source/WebKit/PlatformWin.cmake
-index 9bea022e3891a56368f3f1cd02d79e265170d194..4ed61a3efe288c12f61bd3a795dd38e716614e31 100644
+index 350fdd497eaaab711059c54b5075015b19379368..bf5cd7221e1a131dd880d11e968b132782359937 100644
 --- a/Source/WebKit/PlatformWin.cmake
 +++ b/Source/WebKit/PlatformWin.cmake
 @@ -75,8 +75,12 @@ list(APPEND WebKit_SOURCES
@@ -9669,7 +9696,7 @@ index 9bea022e3891a56368f3f1cd02d79e265170d194..4ed61a3efe288c12f61bd3a795dd38e7
      UIProcess/win/WebPageProxyWin.cpp
      UIProcess/win/WebPopupMenuProxyWin.cpp
      UIProcess/win/WebProcessPoolWin.cpp
-@@ -93,6 +97,7 @@ list(APPEND WebKit_SOURCES
+@@ -94,6 +98,7 @@ list(APPEND WebKit_SOURCES
      WebProcess/MediaCache/WebMediaKeyStorageManager.cpp
  
      WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
@@ -9677,7 +9704,7 @@ index 9bea022e3891a56368f3f1cd02d79e265170d194..4ed61a3efe288c12f61bd3a795dd38e7
  
      WebProcess/WebPage/AcceleratedSurface.cpp
  
-@@ -148,6 +153,72 @@ list(APPEND WebKit_MESSAGES_IN_FILES
+@@ -149,6 +154,72 @@ list(APPEND WebKit_MESSAGES_IN_FILES
      WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy
  )
  
@@ -9750,7 +9777,7 @@ index 9bea022e3891a56368f3f1cd02d79e265170d194..4ed61a3efe288c12f61bd3a795dd38e7
  set(WebKitCommonIncludeDirectories ${WebKit_INCLUDE_DIRECTORIES})
  set(WebKitCommonSystemIncludeDirectories ${WebKit_SYSTEM_INCLUDE_DIRECTORIES})
  
-@@ -200,6 +271,7 @@ if (${WTF_PLATFORM_WIN_CAIRO})
+@@ -201,6 +272,7 @@ if (${WTF_PLATFORM_WIN_CAIRO})
          OpenSSL::SSL
          mfuuid.lib
          strmiids.lib
@@ -9849,7 +9876,7 @@ index f2f3979fcac9dfd97d0e0ead600fe35eb8defd40..ac91412e1a96bdf521b1890a66e465dc
      NSEvent* nativeEvent() const { return m_nativeEvent.get(); }
  #elif PLATFORM(GTK)
 diff --git a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
-index 39cd73ceec97a6a26952c8684c605cef82c711e7..3ff657e419f0543eec268bead3b3df41c019ab0d 100644
+index c0b6ef3fa3a2e1204c677ecf86aecbd19bb64d7b..e0f690d3714eb07aa204fcf66d095a289f3e9336 100644
 --- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 +++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 @@ -119,6 +119,10 @@
@@ -10434,10 +10461,10 @@ index 85d6f74114f4e7f82d9502d1b99d69098d6a49b6..6896c9756edb233dda46c7031e1af699
      return WebTouchEvent();
  }
 diff --git a/Source/WebKit/Sources.txt b/Source/WebKit/Sources.txt
-index 676daddac883196c6a344a9fb1a6d4cd41af8cbb..d3848e32efdd415145d1533e0071cf9c8c265f81 100644
+index dc2dbd526d5b8aa4e911901b720467f0e23d3295..56c8588e3e193fc5056087afbe2851d05ddfd3d4 100644
 --- a/Source/WebKit/Sources.txt
 +++ b/Source/WebKit/Sources.txt
-@@ -299,11 +299,14 @@ Shared/XR/XRDeviceProxy.cpp
+@@ -386,11 +386,14 @@ Shared/XR/XRDeviceProxy.cpp
  
  UIProcess/AuxiliaryProcessProxy.cpp
  UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -10452,7 +10479,7 @@ index 676daddac883196c6a344a9fb1a6d4cd41af8cbb..d3848e32efdd415145d1533e0071cf9c
  UIProcess/LegacyGlobalSettings.cpp
  UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
  UIProcess/MediaKeySystemPermissionRequestProxy.cpp
-@@ -312,6 +315,7 @@ UIProcess/PageLoadState.cpp
+@@ -399,6 +402,7 @@ UIProcess/PageLoadState.cpp
  UIProcess/ProcessAssertion.cpp
  UIProcess/ProcessThrottler.cpp
  UIProcess/ProvisionalPageProxy.cpp
@@ -10460,7 +10487,7 @@ index 676daddac883196c6a344a9fb1a6d4cd41af8cbb..d3848e32efdd415145d1533e0071cf9c
  UIProcess/ResponsivenessTimer.cpp
  UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
  UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
-@@ -352,6 +356,8 @@ UIProcess/WebOpenPanelResultListenerProxy.cpp
+@@ -439,6 +443,8 @@ UIProcess/WebOpenPanelResultListenerProxy.cpp
  UIProcess/WebPageDiagnosticLoggingClient.cpp
  UIProcess/WebPageGroup.cpp
  UIProcess/WebPageInjectedBundleClient.cpp
@@ -10469,7 +10496,7 @@ index 676daddac883196c6a344a9fb1a6d4cd41af8cbb..d3848e32efdd415145d1533e0071cf9c
  UIProcess/WebPageProxy.cpp
  UIProcess/WebPasteboardProxy.cpp
  UIProcess/WebPreferences.cpp
-@@ -473,7 +479,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
+@@ -560,7 +566,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
  UIProcess/Inspector/WebPageDebuggable.cpp
  UIProcess/Inspector/WebPageInspectorController.cpp
  
@@ -10699,7 +10726,7 @@ index 026121d114c5fcad84c1396be8d692625beaa3bd..edd6e5cae033124c589959a42522fde0
  }
  #endif
 diff --git a/Source/WebKit/UIProcess/API/C/WKPage.cpp b/Source/WebKit/UIProcess/API/C/WKPage.cpp
-index d72cc5b353d34fb0ce233ddfc8ed4a14599e8585..d9b6886ca181c532b74248d186b8014593b7f118 100644
+index 92ffd2147089216b00fe371cdbc3adf787defce7..c588d60634701ad4c1cec974cfb680806ea7e096 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
 +++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
 @@ -1775,6 +1775,13 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
@@ -17157,7 +17184,7 @@ index 0000000000000000000000000000000000000000..48c9ccc420c1b4ae3259e1d5ba17fd8f
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd36f061863 100644
+index f6ab809dc8c4b936f8147fb992b40e02a2f2d9a0..fe49db5f5ab80e09f5585962b6f3e6aeaeacb904 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
 @@ -245,6 +245,9 @@
@@ -17503,7 +17530,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
  }
  
  void WebPageProxy::decidePolicyForNavigationActionAsyncShared(Ref<WebProcessProxy>&& process, PageIdentifier webPageID, FrameIdentifier frameID, FrameInfoData&& frameInfo,
-@@ -5794,6 +5956,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -5796,6 +5958,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
      auto* originatingPage = m_process->webPage(originatingPageID);
      auto originatingFrameInfo = API::FrameInfo::create(WTFMove(originatingFrameInfoData), originatingPage);
      auto mainFrameURL = m_mainFrame ? m_mainFrame->url() : URL();
@@ -17511,7 +17538,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
      auto completionHandler = [this, protectedThis = Ref { *this }, mainFrameURL, request, reply = WTFMove(reply), privateClickMeasurement = navigationActionData.privateClickMeasurement] (RefPtr<WebPageProxy> newPage) mutable {
          if (!newPage) {
              reply(std::nullopt, std::nullopt);
-@@ -5837,6 +6000,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -5839,6 +6002,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
  void WebPageProxy::showPage()
  {
      m_uiClient->showPage(this);
@@ -17519,7 +17546,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
  }
  
  void WebPageProxy::exitFullscreenImmediately()
-@@ -5872,6 +6036,10 @@ void WebPageProxy::closePage()
+@@ -5874,6 +6038,10 @@ void WebPageProxy::closePage()
      if (isClosed())
          return;
  
@@ -17530,7 +17557,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
      WEBPAGEPROXY_RELEASE_LOG(Process, "closePage:");
      pageClient().clearAllEditCommands();
      m_uiClient->close(this);
-@@ -5908,6 +6076,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
+@@ -5910,6 +6078,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
      }
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
@@ -17539,7 +17566,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
          page.m_uiClient->runJavaScriptAlert(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)]() mutable {
              reply();
              completion();
-@@ -5929,6 +6099,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
+@@ -5931,6 +6101,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17548,7 +17575,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptConfirm(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](bool result) mutable {
-@@ -5952,6 +6124,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
+@@ -5954,6 +6126,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17557,7 +17584,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply), defaultValue](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptPrompt(page, message, defaultValue, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](auto& result) mutable {
-@@ -6079,6 +6253,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
+@@ -6081,6 +6255,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
              return;
          }
      }
@@ -17566,7 +17593,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
  
      // Since runBeforeUnloadConfirmPanel() can spin a nested run loop we need to turn off the responsiveness timer and the tryClose timer.
      m_process->stopResponsivenessTimer();
-@@ -7310,6 +7486,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7312,6 +7488,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->mouseEventsFlushedForPage(*this);
              didFinishProcessingAllPendingMouseEvents();
@@ -17575,7 +17602,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
          }
          break;
      }
-@@ -7324,10 +7502,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7326,10 +7504,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              pageClient().wheelEventWasNotHandledByWebCore(oldestProcessedEvent);
          }
  
@@ -17592,7 +17619,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
          break;
      }
  
-@@ -7336,7 +7517,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7338,7 +7519,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
      case WebEvent::RawKeyDown:
      case WebEvent::Char: {
          LOG(KeyHandling, "WebPageProxy::didReceiveEvent: %s (queue empty %d)", webKeyboardEventTypeString(type), m_keyEventQueue.isEmpty());
@@ -17600,7 +17627,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
          MESSAGE_CHECK(m_process, !m_keyEventQueue.isEmpty());
          auto event = m_keyEventQueue.takeFirst();
          MESSAGE_CHECK(m_process, type == event.type());
-@@ -7355,7 +7535,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7357,7 +7537,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          // The call to doneWithKeyEvent may close this WebPage.
          // Protect against this being destroyed.
          Ref<WebPageProxy> protect(*this);
@@ -17608,7 +17635,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
          pageClient().doneWithKeyEvent(event, handled);
          if (!handled)
              m_uiClient->didNotHandleKeyEvent(this, event);
-@@ -7364,6 +7543,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7366,6 +7545,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          if (!canProcessMoreKeyEvents) {
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->keyboardEventsFlushedForPage(*this);
@@ -17616,7 +17643,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
          }
          break;
      }
-@@ -7718,7 +7898,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
+@@ -7720,7 +7900,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
  {
      WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "dispatchProcessDidTerminate: reason=%{public}s", processTerminationReasonToString(reason));
  
@@ -17628,7 +17655,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
      if (m_loaderClient)
          handledByClient = reason != ProcessTerminationReason::RequestedByClient && m_loaderClient->processDidCrash(*this);
      else
-@@ -8102,6 +8285,7 @@ static const Vector<ASCIILiteral>& mediaRelatedIOKitClasses()
+@@ -8104,6 +8287,7 @@ static const Vector<ASCIILiteral>& mediaRelatedIOKitClasses()
  
  WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& process, DrawingAreaProxy& drawingArea, RefPtr<API::WebsitePolicies>&& websitePolicies)
  {
@@ -17636,7 +17663,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
      WebPageCreationParameters parameters;
  
      parameters.processDisplayName = configuration().processDisplayName();
-@@ -8297,6 +8481,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
+@@ -8299,6 +8483,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
      parameters.shouldRelaxThirdPartyCookieBlocking = m_configuration->shouldRelaxThirdPartyCookieBlocking();
      parameters.canUseCredentialStorage = m_canUseCredentialStorage;
  
@@ -17645,7 +17672,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
  #if PLATFORM(GTK)
      parameters.gtkSettings = GtkSettingsManager::singleton().settingsState();
  #endif
-@@ -8378,6 +8564,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
+@@ -8380,6 +8566,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
  
  void WebPageProxy::didReceiveAuthenticationChallengeProxy(Ref<AuthenticationChallengeProxy>&& authenticationChallenge, NegotiatedLegacyTLS negotiatedLegacyTLS)
  {
@@ -17660,7 +17687,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
      if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes) {
          m_navigationClient->shouldAllowLegacyTLS(*this, authenticationChallenge.get(), [this, protectedThis = Ref { *this }, authenticationChallenge] (bool shouldAllowLegacyTLS) {
              if (shouldAllowLegacyTLS)
-@@ -8471,6 +8665,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
+@@ -8473,6 +8667,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
              request->deny();
      };
  
@@ -17677,7 +17704,7 @@ index 42ade6d8b9d156d86e4c61e03d8b98e2aba99ce8..6f8727b8ae3822ca165c3c8aabe69dd3
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e309cd135f 100644
+index 53bb6d5dd10cb6353aaef9358e03b040032f9677..28ecb282d295baacb454bef96609aaa099dcb7a4 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -39,6 +39,7 @@
@@ -17715,7 +17742,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
  #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
  #include <WebCore/MediaPlaybackTargetPicker.h>
  #include <WebCore/WebMediaSessionManagerClient.h>
-@@ -249,6 +261,7 @@ class AuthenticationChallenge;
+@@ -250,6 +262,7 @@ class AuthenticationChallenge;
  class CertificateInfo;
  class Cursor;
  class DragData;
@@ -17723,7 +17750,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
  class FloatRect;
  class FontAttributeChanges;
  class FontChanges;
-@@ -256,7 +269,6 @@ class GraphicsLayer;
+@@ -257,7 +270,6 @@ class GraphicsLayer;
  class IntSize;
  class ProtectionSpace;
  class RunLoopObserver;
@@ -17731,7 +17758,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
  class SharedBuffer;
  class SpeechRecognitionRequest;
  class TextIndicator;
-@@ -538,6 +550,8 @@ public:
+@@ -539,6 +551,8 @@ public:
      void setControlledByAutomation(bool);
  
      WebPageInspectorController& inspectorController() { return *m_inspectorController; }
@@ -17740,7 +17767,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
  
  #if PLATFORM(IOS_FAMILY)
      void showInspectorIndication();
-@@ -626,6 +640,11 @@ public:
+@@ -642,6 +656,11 @@ public:
  
      void setPageLoadStateObserver(std::unique_ptr<PageLoadState::Observer>&&);
  
@@ -17752,7 +17779,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
      void initializeWebPage();
      void setDrawingArea(std::unique_ptr<DrawingAreaProxy>&&);
  
-@@ -653,6 +672,7 @@ public:
+@@ -669,6 +688,7 @@ public:
      void closePage();
  
      void addPlatformLoadParameters(WebProcessProxy&, LoadParameters&);
@@ -17760,7 +17787,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
      RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadData(const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
-@@ -1174,6 +1194,7 @@ public:
+@@ -1190,6 +1210,7 @@ public:
  #endif
  
      void pageScaleFactorDidChange(double);
@@ -17768,7 +17795,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
      void pluginScaleFactorDidChange(double);
      void pluginZoomFactorDidChange(double);
  
-@@ -1248,14 +1269,20 @@ public:
+@@ -1264,14 +1285,20 @@ public:
      void didStartDrag();
      void dragCancelled();
      void setDragCaretRect(const WebCore::IntRect&);
@@ -17790,7 +17817,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
  #endif
  
      void processDidBecomeUnresponsive();
-@@ -1499,6 +1526,8 @@ public:
+@@ -1515,6 +1542,8 @@ public:
  
  #if PLATFORM(COCOA) || PLATFORM(GTK)
      RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
@@ -17799,7 +17826,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
  #endif
  
  #if ENABLE(WEB_CRYPTO)
-@@ -2615,6 +2644,7 @@ private:
+@@ -2633,6 +2662,7 @@ private:
      String m_overrideContentSecurityPolicy;
  
      RefPtr<WebInspectorUIProxy> m_inspector;
@@ -17807,7 +17834,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
  
  #if PLATFORM(COCOA)
      WeakObjCPtr<WKWebView> m_cocoaView;
-@@ -2879,6 +2909,20 @@ private:
+@@ -2897,6 +2927,20 @@ private:
      unsigned m_currentDragNumberOfFilesToBeAccepted { 0 };
      WebCore::IntRect m_currentDragCaretRect;
      WebCore::IntRect m_currentDragCaretEditableElementRect;
@@ -17828,7 +17855,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
  #endif
  
      PageLoadState m_pageLoadState;
-@@ -3091,6 +3135,9 @@ private:
+@@ -3109,6 +3153,9 @@ private:
          RefPtr<API::Object> messageBody;
      };
      Vector<InjectedBundleMessage> m_pendingInjectedBundleMessages;
@@ -17839,7 +17866,7 @@ index 5999ce9821552a9d66806608c04fa41a29503a93..b3d54ea7e9af81b6ca633875a27460e3
  #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
      std::unique_ptr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.messages.in b/Source/WebKit/UIProcess/WebPageProxy.messages.in
-index 7590bd8e51deec8cbc998141d18b2c702129f398..057cb51bf39880d56f1e4ddac9ee326a7edc0da4 100644
+index 62aeb587f7c87b1d6c4d2a7bc03fcb65fb98d04a..82334cf71934b68b32382e2c5f6bebfb462e9ed7 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
 +++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
 @@ -29,6 +29,7 @@ messages -> WebPageProxy {
@@ -17874,10 +17901,10 @@ index 7590bd8e51deec8cbc998141d18b2c702129f398..057cb51bf39880d56f1e4ddac9ee326a
      DidPerformDragOperation(bool handled)
  #endif
 diff --git a/Source/WebKit/UIProcess/WebProcessPool.cpp b/Source/WebKit/UIProcess/WebProcessPool.cpp
-index 3c3befc2a674c0d82bea64ebe354940ac3cfa980..09ab6031f32524ebcd95465766a705837c907860 100644
+index 7424f08e5eefbe336176985edb0c03feca1f529f..ae3750f509539c1199638feb45f5f4683cf27a85 100644
 --- a/Source/WebKit/UIProcess/WebProcessPool.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
-@@ -522,6 +522,14 @@ void WebProcessPool::establishWorkerContextConnectionToNetworkProcess(NetworkPro
+@@ -523,6 +523,14 @@ void WebProcessPool::establishWorkerContextConnectionToNetworkProcess(NetworkPro
  
      // Arbitrarily choose the first process pool to host the service worker process.
      auto* processPool = processPools()[0];
@@ -17892,7 +17919,7 @@ index 3c3befc2a674c0d82bea64ebe354940ac3cfa980..09ab6031f32524ebcd95465766a70583
      ASSERT(processPool);
  
      WebProcessProxy* serviceWorkerProcessProxy { nullptr };
-@@ -793,8 +801,12 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
+@@ -794,8 +802,12 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
  #endif
  
      parameters.cacheModel = LegacyGlobalSettings::singleton().cacheModel();
@@ -17908,7 +17935,7 @@ index 3c3befc2a674c0d82bea64ebe354940ac3cfa980..09ab6031f32524ebcd95465766a70583
      parameters.urlSchemesRegisteredAsEmptyDocument = copyToVector(m_schemesToRegisterAsEmptyDocument);
      parameters.urlSchemesRegisteredAsSecure = copyToVector(LegacyGlobalSettings::singleton().schemesToRegisterAsSecure());
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.cpp b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-index 9c00c47b7c5cd0264f270302ea7bf6354580b7cf..9beba394871c99e3f946d75aced3383b2c86f1a1 100644
+index 028c8d8ef0714c82eb904c94e7e2971d85baeb13..f0733d5e34c786fc665bae196a5f1aae535eae70 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
 @@ -143,6 +143,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
@@ -17924,7 +17951,7 @@ index 9c00c47b7c5cd0264f270302ea7bf6354580b7cf..9beba394871c99e3f946d75aced3383b
  {
      return allProcesses().get(identifier);
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.h b/Source/WebKit/UIProcess/WebProcessProxy.h
-index 429c3c10631f34beab57297e64cf9393a83fda09..315dd55978cb6272bc6a22e948176dcc7dd8593b 100644
+index c99e8c20bce6f0b5b35ab76ce958de7f8308224b..99a63dd89caf923a87a72e0cda558470a31ef379 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.h
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.h
 @@ -142,6 +142,7 @@ public:
@@ -19992,10 +20019,10 @@ index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705e
 + 
 +} // namespace WebKit
 diff --git a/Source/WebKit/WebKit.xcodeproj/project.pbxproj b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df58317763 100644
+index 6540eb0bcf6c6b131d17844feda35c070cd1ca0e..66b29710c9c922f5993a498339391da6c9946658 100644
 --- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 +++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-@@ -1910,6 +1910,18 @@
+@@ -1925,6 +1925,18 @@
  		DF0C5F28252ECB8E00D921DB /* WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F24252ECB8D00D921DB /* WKDownload.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2A252ECB8E00D921DB /* WKDownloadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2B252ED44000D921DB /* WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */; };
@@ -20014,17 +20041,17 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  		DF462E0F23F22F5500EFF35F /* WKHTTPCookieStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */; };
-@@ -1966,6 +1978,9 @@
+@@ -1983,6 +1995,9 @@
  		E5CB07DC20E1678F0022C183 /* WKFormColorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */; };
  		E5DEFA6826F8F42600AB68DB /* PhotosUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E5DEFA6726F8F42600AB68DB /* PhotosUISPI.h */; };
  		ED82A7F2128C6FAF004477B3 /* WKBundlePageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22F0FF1289FCD90085E74F /* WKBundlePageOverlay.h */; settings = {ATTRIBUTES = (Private, ); }; };
 +		F303B849249A8D640031DE5C /* ScreencastEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = F303B848249A8D3A0031DE5C /* ScreencastEncoder.h */; };
 +		F33C7AC7249AD79C0018BE41 /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F33C7AC6249AD79C0018BE41 /* libwebrtc.dylib */; };
 +		F3867F0A24607D4E008F0F31 /* InspectorScreencastAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = F3867F0424607D2B008F0F31 /* InspectorScreencastAgent.h */; };
- 		F4094CBD2553053D003D73E3 /* DisplayListReaderHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = F4094CBB255304AF003D73E3 /* DisplayListReaderHandle.h */; };
- 		F4094CBE25530540003D73E3 /* DisplayListWriterHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = F4094CB92553047E003D73E3 /* DisplayListWriterHandle.h */; };
  		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
-@@ -5912,6 +5927,19 @@
+ 		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
+ 		F42D634122A0EFDF00D2FB3A /* WebAutocorrectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */; };
+@@ -6078,6 +6093,19 @@
  		DF0C5F24252ECB8D00D921DB /* WKDownload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownload.h; sourceTree = "<group>"; };
  		DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadInternal.h; sourceTree = "<group>"; };
  		DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadDelegate.h; sourceTree = "<group>"; };
@@ -20044,7 +20071,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  		DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHTTPCookieStorePrivate.h; sourceTree = "<group>"; };
  		DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKContentWorldPrivate.h; sourceTree = "<group>"; };
  		DF58C6311371AC5800F9A37C /* NativeWebWheelEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeWebWheelEvent.h; sourceTree = "<group>"; };
-@@ -6031,6 +6059,14 @@
+@@ -6199,6 +6227,14 @@
  		ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtraPrivateSymbolsForTAPI.h; sourceTree = "<group>"; };
  		ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExtraPublicSymbolsForTAPI.h; sourceTree = "<group>"; };
  		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
@@ -20056,10 +20083,10 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
 +		F3867F0324607D2B008F0F31 /* InspectorScreencastAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorScreencastAgent.cpp; sourceTree = "<group>"; };
 +		F3867F0424607D2B008F0F31 /* InspectorScreencastAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorScreencastAgent.h; sourceTree = "<group>"; };
 +		F3970344249BD4CE003E1A22 /* ScreencastEncoderMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScreencastEncoderMac.mm; sourceTree = "<group>"; };
- 		F4094CB92553047E003D73E3 /* DisplayListWriterHandle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisplayListWriterHandle.h; sourceTree = "<group>"; };
- 		F4094CBA2553047E003D73E3 /* DisplayListWriterHandle.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DisplayListWriterHandle.cpp; sourceTree = "<group>"; };
- 		F4094CBB255304AF003D73E3 /* DisplayListReaderHandle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisplayListReaderHandle.h; sourceTree = "<group>"; };
-@@ -6163,6 +6199,7 @@
+ 		F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDragDestinationAction.h; sourceTree = "<group>"; };
+ 		F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionContext.h; path = ios/WebAutocorrectionContext.h; sourceTree = "<group>"; };
+ 		F41056612130699A0092281D /* APIAttachmentCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = APIAttachmentCocoa.mm; sourceTree = "<group>"; };
+@@ -6325,6 +6361,7 @@
  				3766F9EF189A1244003CF19B /* QuartzCore.framework in Frameworks */,
  				37694525184FC6B600CDE21F /* Security.framework in Frameworks */,
  				37BEC4DD1948FC6A008B4286 /* WebCore.framework in Frameworks */,
@@ -20067,7 +20094,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -8046,6 +8083,7 @@
+@@ -8364,6 +8401,7 @@
  		37C4C08318149C2A003688B9 /* Cocoa */ = {
  			isa = PBXGroup;
  			children = (
@@ -20075,15 +20102,15 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				1A43E826188F38E2009E4D30 /* Deprecated */,
  				37A5E01218BBF937000A081E /* _WKActivatedElementInfo.h */,
  				37A5E01118BBF937000A081E /* _WKActivatedElementInfo.mm */,
-@@ -9173,6 +9211,7 @@
+@@ -9489,6 +9527,7 @@
  			isa = PBXGroup;
  			children = (
  				57A9FF15252C6AEF006A2040 /* libWTF.a */,
 +				F33C7AC6249AD79C0018BE41 /* libwebrtc.dylib */,
  				5750F32A2032D4E500389347 /* LocalAuthentication.framework */,
  				570DAAB0230273D200E8FC04 /* NearField.framework */,
- 			);
-@@ -9666,6 +9705,12 @@
+ 				51F7BB7E274564A100C45A72 /* Security.framework */,
+@@ -9985,6 +10024,12 @@
  			children = (
  				9197940423DBC4BB00257892 /* InspectorBrowserAgent.cpp */,
  				9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */,
@@ -20096,7 +20123,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  			);
  			path = Agents;
  			sourceTree = "<group>";
-@@ -9674,6 +9719,7 @@
+@@ -9993,6 +10038,7 @@
  			isa = PBXGroup;
  			children = (
  				A5D3504D1D78F0D2005124A9 /* RemoteWebInspectorUIProxyMac.mm */,
@@ -20104,7 +20131,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */,
  				99A7ACE326012919006D57FD /* WKInspectorResourceURLSchemeHandler.h */,
  				99A7ACE42601291A006D57FD /* WKInspectorResourceURLSchemeHandler.mm */,
-@@ -10196,6 +10242,12 @@
+@@ -10515,6 +10561,12 @@
  		BC032DC310F438260058C15A /* UIProcess */ = {
  			isa = PBXGroup;
  			children = (
@@ -20117,7 +20144,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				BC032DC410F4387C0058C15A /* API */,
  				512F588D12A8836F00629530 /* Authentication */,
  				9955A6E81C79809000EB6A93 /* Automation */,
-@@ -10497,6 +10549,7 @@
+@@ -10816,6 +10868,7 @@
  		BC0C376610F807660076D7CB /* C */ = {
  			isa = PBXGroup;
  			children = (
@@ -20125,7 +20152,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				5123CF18133D25E60056F800 /* cg */,
  				6EE849C41368D9040038D481 /* mac */,
  				BCB63477116BF10600603215 /* WebKit2_C.h */,
-@@ -11084,6 +11137,11 @@
+@@ -11403,6 +11456,11 @@
  		BCCF085C113F3B7500C650C5 /* mac */ = {
  			isa = PBXGroup;
  			children = (
@@ -20137,7 +20164,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				B878B613133428DC006888E9 /* CorrectionPanel.h */,
  				B878B614133428DC006888E9 /* CorrectionPanel.mm */,
  				C1817362205844A900DFDA65 /* DisplayLink.cpp */,
-@@ -11936,6 +11994,7 @@
+@@ -12256,6 +12314,7 @@
  				99788ACB1F421DDA00C08000 /* _WKAutomationSessionConfiguration.h in Headers */,
  				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
  				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
@@ -20145,7 +20172,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
  				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
  				1A5704F81BE01FF400874AF1 /* _WKContextMenuElementInfo.h in Headers */,
-@@ -12243,6 +12302,7 @@
+@@ -12562,6 +12621,7 @@
  				1A14F8E21D74C834006CBEC6 /* FrameInfoData.h in Headers */,
  				1AE00D611831792100087DD7 /* FrameLoadState.h in Headers */,
  				5C121E842410208D00486F9B /* FrameTreeNodeData.h in Headers */,
@@ -20153,15 +20180,15 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				2D4AF0892044C3C4006C8817 /* FrontBoardServicesSPI.h in Headers */,
  				CD78E1151DB7D7ED0014A2DE /* FullscreenClient.h in Headers */,
  				CD19D2EA2046406F0017074A /* FullscreenTouchSecheuristic.h in Headers */,
-@@ -12259,6 +12319,7 @@
+@@ -12577,6 +12637,7 @@
+ 				410F0D4C2701EFF900F96DFC /* GPUProcessConnectionInitializationParameters.h in Headers */,
  				4614F13225DED875007006E7 /* GPUProcessConnectionParameters.h in Headers */,
- 				F40BBB41257FF46E0067463A /* GPUProcessWakeupMessageArguments.h in Headers */,
  				2DA049B8180CCD0A00AAFA9E /* GraphicsLayerCARemote.h in Headers */,
 +				D71A94342370E07A002C4D9E /* InspectorPlaywrightAgentClient.h in Headers */,
  				C0CE72AD1247E78D00BC0EC4 /* HandleMessage.h in Headers */,
  				1AC75A1B1B3368270056745B /* HangDetectionDisabler.h in Headers */,
  				57AC8F50217FEED90055438C /* HidConnection.h in Headers */,
-@@ -12401,6 +12462,7 @@
+@@ -12719,6 +12780,7 @@
  				413075AC1DE85F370039EC69 /* NetworkRTCMonitor.h in Headers */,
  				41DC45961E3D6E2200B11F51 /* NetworkRTCProvider.h in Headers */,
  				5C20CBA01BB1ECD800895BB1 /* NetworkSession.h in Headers */,
@@ -20169,7 +20196,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				532159551DBAE7290054AA3C /* NetworkSessionCocoa.h in Headers */,
  				417915B92257046F00D6F97E /* NetworkSocketChannel.h in Headers */,
  				93085DE026E5BCFD000EC6A7 /* NetworkStorageManager.h in Headers */,
-@@ -12466,6 +12528,7 @@
+@@ -12784,6 +12846,7 @@
  				BC1A7C581136E19C00FB7167 /* ProcessLauncher.h in Headers */,
  				463FD4821EB94EC000A2982C /* ProcessTerminationReason.h in Headers */,
  				86E67A251910B9D100004AB7 /* ProcessThrottler.h in Headers */,
@@ -20177,7 +20204,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				83048AE61ACA45DC0082C832 /* ProcessThrottlerClient.h in Headers */,
  				2D279E1926955768004B3EEB /* PrototypeToolsSPI.h in Headers */,
  				A1E688701F6E2BAB007006A6 /* QuarantineSPI.h in Headers */,
-@@ -12488,6 +12551,7 @@
+@@ -12806,6 +12869,7 @@
  				CDAC20CA23FC2F750021DEE3 /* RemoteCDMInstanceSession.h in Headers */,
  				CDAC20C923FC2F750021DEE3 /* RemoteCDMInstanceSessionIdentifier.h in Headers */,
  				F451C0FE2703B263002BA03B /* RemoteDisplayListRecorderProxy.h in Headers */,
@@ -20185,7 +20212,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				2D47B56D1810714E003A3AEE /* RemoteLayerBackingStore.h in Headers */,
  				2DDF731518E95060004F5A66 /* RemoteLayerBackingStoreCollection.h in Headers */,
  				1AB16AEA164B3A8800290D62 /* RemoteLayerTreeContext.h in Headers */,
-@@ -12815,6 +12879,7 @@
+@@ -13131,6 +13195,7 @@
  				A543E30D215C8A9000279CD9 /* WebPageInspectorTargetController.h in Headers */,
  				A543E307215AD13700279CD9 /* WebPageInspectorTargetFrontendChannel.h in Headers */,
  				C0CE72A11247E71D00BC0EC4 /* WebPageMessages.h in Headers */,
@@ -20193,7 +20220,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				2D5C9D0619C81D8F00B3C5C1 /* WebPageOverlay.h in Headers */,
  				46C392292316EC4D008EED9B /* WebPageProxyIdentifier.h in Headers */,
  				BCBD3915125BB1A800D2C29F /* WebPageProxyMessages.h in Headers */,
-@@ -12947,6 +13012,7 @@
+@@ -13263,6 +13328,7 @@
  				BCD25F1711D6BDE100169B0E /* WKBundleFrame.h in Headers */,
  				BCF049E611FE20F600F86A58 /* WKBundleFramePrivate.h in Headers */,
  				BC49862F124D18C100D834E1 /* WKBundleHitTestResult.h in Headers */,
@@ -20201,7 +20228,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				BC204EF211C83EC8008F3375 /* WKBundleInitialize.h in Headers */,
  				65B86F1E12F11DE300B7DD8A /* WKBundleInspector.h in Headers */,
  				1A8B66B41BC45B010082DF77 /* WKBundleMac.h in Headers */,
-@@ -13000,6 +13066,7 @@
+@@ -13316,6 +13382,7 @@
  				5C795D71229F3757003FF1C4 /* WKContextMenuElementInfoPrivate.h in Headers */,
  				51A555F6128C6C47009ABCEC /* WKContextMenuItem.h in Headers */,
  				51A55601128C6D92009ABCEC /* WKContextMenuItemTypes.h in Headers */,
@@ -20209,7 +20236,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				A1EA02381DABFF7E0096021F /* WKContextMenuListener.h in Headers */,
  				BCC938E11180DE440085E5FE /* WKContextPrivate.h in Headers */,
  				9FB5F395169E6A80002C25BF /* WKContextPrivateMac.h in Headers */,
-@@ -13156,6 +13223,7 @@
+@@ -13472,6 +13539,7 @@
  				1AB8A1F818400BB800E9AE69 /* WKPageContextMenuClient.h in Headers */,
  				8372DB251A674C8F00C697C5 /* WKPageDiagnosticLoggingClient.h in Headers */,
  				1AB8A1F418400B8F00E9AE69 /* WKPageFindClient.h in Headers */,
@@ -20217,7 +20244,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				1AB8A1F618400B9D00E9AE69 /* WKPageFindMatchesClient.h in Headers */,
  				1AB8A1F018400B0000E9AE69 /* WKPageFormClient.h in Headers */,
  				BC7B633712A45ABA00D174A4 /* WKPageGroup.h in Headers */,
-@@ -14440,6 +14508,8 @@
+@@ -14774,6 +14842,8 @@
  				C1A152D724E5A29A00978C8B /* HandleXPCEndpointMessages.mm in Sources */,
  				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
  				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
@@ -20226,7 +20253,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				9BF5EC642541145600984E77 /* JSIPCBinding.cpp in Sources */,
  				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
  				C1710CF724AA643200D7C112 /* LaunchServicesDatabaseObserver.mm in Sources */,
-@@ -14457,6 +14527,7 @@
+@@ -14791,6 +14861,7 @@
  				2D92A781212B6A7100F493FD /* MessageReceiverMap.cpp in Sources */,
  				2D92A782212B6A7100F493FD /* MessageSender.cpp in Sources */,
  				2D92A77A212B6A6100F493FD /* Module.cpp in Sources */,
@@ -20234,7 +20261,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				57B826452304F14000B72EB0 /* NearFieldSoftLink.mm in Sources */,
  				C1C1B30F2540F50D00D9100B /* NetworkConnectionToWebProcessMac.mm in Sources */,
  				51DD9F2816367DA2001578E9 /* NetworkConnectionToWebProcessMessageReceiver.cpp in Sources */,
-@@ -14764,6 +14835,7 @@
+@@ -15109,6 +15180,7 @@
  				2D92A78C212B6AB100F493FD /* WebMouseEvent.cpp in Sources */,
  				31BA924D148831260062EDB5 /* WebNotificationManagerMessageReceiver.cpp in Sources */,
  				2DF6FE52212E110900469030 /* WebPage.cpp in Sources */,
@@ -20243,7 +20270,7 @@ index 7da6574f8d643843d9042d314465369dc1858d7b..b518014a2b2b08eccf453122d48083df
  				BCBD3914125BB1A800D2C29F /* WebPageProxyMessageReceiver.cpp in Sources */,
  				7CE9CE101FA0767A000177DE /* WebPageUpdatePreferences.cpp in Sources */,
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
-index d671d0581071148b42e607ab598486e90a7035e0..64c50006752e596ad0e17e107c9ea4645ca9a820 100644
+index c63577929b5e02423e3522b00739e303f7fd8b90..5197e90f5123ab6ddc3c6e9a1277183266104e36 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 @@ -232,6 +232,11 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
@@ -20422,7 +20449,7 @@ index e00c722c2be5d505243d45f46001839d4eb8a977..33c0832cde6c292230397a13e70d90fb
  
              auto permissionHandlers = m_requestsPerOrigin.take(securityOrigin);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
-index fc7bc3323ab4f9c6bcc9929fa6ec8b5f0f082304..da74fd533ca76384c1aa33d008572d01e543f864 100644
+index 436a5a52035a0657589c0e90b0842c4336581e3d..5b71355701aec64db7ddd4d4351748c7ba6e7b9f 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 @@ -407,6 +407,8 @@ void WebChromeClient::setResizable(bool resizable)
@@ -20494,7 +20521,7 @@ index 4bdbbccd3fbc620e0754105cea09eddf05120b6b..f2f2c6eddfc6791647fcd19724719763
  
  void WebFrameLoaderClient::didRestoreFromBackForwardCache()
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
-index 8086318e989c479c3eebdb13a33b0891e0fbf4aa..2be4279c7c3f783d0a8e00eebcbb5a58a5b38c92 100644
+index a64c6a8b3c695e173364336bcb0f68dbdd9c2d21..041f428b297d492163b99b1ed1418879a17d13b5 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 @@ -127,7 +127,8 @@ static WebCore::CachedImage* cachedImage(Element& element)
@@ -20856,7 +20883,7 @@ index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4
      uint64_t m_navigationID;
  };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986affc1b3cf20 100644
+index 1ca9c23d677f03a29c60f5b2a8bac680d6b5c843..31c758b38a18311b67ab744e95013f0a8ebd148f 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 @@ -902,6 +902,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
@@ -20869,7 +20896,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
      updateThrottleState();
  }
  
-@@ -1668,6 +1671,22 @@ void WebPage::platformDidReceiveLoadParameters(const LoadParameters& loadParamet
+@@ -1670,6 +1673,22 @@ void WebPage::platformDidReceiveLoadParameters(const LoadParameters& loadParamet
  }
  #endif
  
@@ -20892,7 +20919,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
  void WebPage::loadRequest(LoadParameters&& loadParameters)
  {
      setLastNavigationWasAppInitiated(loadParameters.request.isAppInitiated());
-@@ -1924,17 +1943,13 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
+@@ -1926,17 +1945,13 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
      view->resize(viewSize);
      m_drawingArea->setNeedsDisplay();
  
@@ -20911,7 +20938,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
  
      // Viewport properties have no impact on zero sized fixed viewports.
      if (m_viewSize.isEmpty())
-@@ -1951,20 +1966,18 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
+@@ -1953,20 +1968,18 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
  
      ViewportAttributes attr = computeViewportAttributes(viewportArguments, minimumLayoutFallbackWidth, deviceWidth, deviceHeight, 1, m_viewSize);
  
@@ -20939,7 +20966,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
  
  #if USE(COORDINATED_GRAPHICS)
      m_drawingArea->didChangeViewportAttributes(WTFMove(attr));
-@@ -1972,7 +1985,6 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
+@@ -1974,7 +1987,6 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
      send(Messages::WebPageProxy::DidChangeViewportProperties(attr));
  #endif
  }
@@ -20947,7 +20974,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
  
  void WebPage::scrollMainFrameIfNotAtMaxScrollPosition(const IntSize& scrollOffset)
  {
-@@ -2267,6 +2279,7 @@ void WebPage::scaleView(double scale)
+@@ -2269,6 +2281,7 @@ void WebPage::scaleView(double scale)
      }
  
      m_page->setViewScaleFactor(scale);
@@ -20955,7 +20982,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
      scalePage(pageScale, scrollPositionAtNewScale);
  }
  
-@@ -2371,17 +2384,13 @@ void WebPage::viewportPropertiesDidChange(const ViewportArguments& viewportArgum
+@@ -2373,17 +2386,13 @@ void WebPage::viewportPropertiesDidChange(const ViewportArguments& viewportArgum
          viewportConfigurationChanged();
  #endif
  
@@ -20974,7 +21001,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
  }
  
  void WebPage::listenForLayoutMilestones(OptionSet<WebCore::LayoutMilestone> milestones)
-@@ -3268,6 +3277,104 @@ void WebPage::touchEvent(const WebTouchEvent& touchEvent)
+@@ -3270,6 +3279,104 @@ void WebPage::touchEvent(const WebTouchEvent& touchEvent)
  
      send(Messages::WebPageProxy::DidReceiveEvent(static_cast<uint32_t>(touchEvent.type()), handled));
  }
@@ -21079,7 +21106,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
  #endif
  
  void WebPage::cancelPointer(WebCore::PointerID pointerId, const WebCore::IntPoint& documentPoint)
-@@ -3344,6 +3451,11 @@ void WebPage::sendMessageToTargetBackend(const String& targetId, const String& m
+@@ -3346,6 +3453,11 @@ void WebPage::sendMessageToTargetBackend(const String& targetId, const String& m
      m_inspectorTargetController->sendMessageToTargetBackend(targetId, message);
  }
  
@@ -21091,7 +21118,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
  void WebPage::insertNewlineInQuotedContent()
  {
      Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-@@ -3582,6 +3694,7 @@ void WebPage::didCompletePageTransition()
+@@ -3584,6 +3696,7 @@ void WebPage::didCompletePageTransition()
  void WebPage::show()
  {
      send(Messages::WebPageProxy::ShowPage());
@@ -21099,7 +21126,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
  }
  
  void WebPage::setIsTakingSnapshotsForApplicationSuspension(bool isTakingSnapshotsForApplicationSuspension)
-@@ -4427,7 +4540,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
+@@ -4429,7 +4542,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
  
  #if ENABLE(DRAG_SUPPORT)
  
@@ -21108,7 +21135,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
  void WebPage::performDragControllerAction(DragControllerAction action, const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation> draggingSourceOperationMask, SelectionData&& selectionData, OptionSet<DragApplicationFlags> flags)
  {
      if (!m_page) {
-@@ -6742,6 +6855,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
+@@ -6744,6 +6857,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
              WebsitePoliciesData::applyToDocumentLoader(WTFMove(*m_pendingWebsitePolicies), documentLoader);
              m_pendingWebsitePolicies = std::nullopt;
          }
@@ -21119,7 +21146,7 @@ index b18d7f72e67acad4ab546d4d408edaa14ac69cab..df97f13e125603339cceedd9af986aff
  
      return documentLoader;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.h b/Source/WebKit/WebProcess/WebPage/WebPage.h
-index 41e26039ab814b4424c2e22a6c4ef2ca3ea1bf7e..33c9078d798077b2566512b4a28036ed6cde0af1 100644
+index 7403f77d50acd1fd500bdef9e4baa2e57f82845a..241c395dc762b4bb1d285b2990bb991a391a4db3 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
 @@ -121,6 +121,10 @@ typedef struct _AtkObject AtkObject;
@@ -21165,7 +21192,7 @@ index 41e26039ab814b4424c2e22a6c4ef2ca3ea1bf7e..33c9078d798077b2566512b4a28036ed
  
      void insertNewlineInQuotedContent();
  
-@@ -1604,6 +1612,7 @@ private:
+@@ -1600,6 +1608,7 @@ private:
      // Actions
      void tryClose(CompletionHandler<void(bool)>&&);
      void platformDidReceiveLoadParameters(const LoadParameters&);
@@ -21173,7 +21200,7 @@ index 41e26039ab814b4424c2e22a6c4ef2ca3ea1bf7e..33c9078d798077b2566512b4a28036ed
      void loadRequest(LoadParameters&&);
      NO_RETURN void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
      void loadData(LoadParameters&&);
-@@ -1641,6 +1650,7 @@ private:
+@@ -1637,6 +1646,7 @@ private:
      void updatePotentialTapSecurityOrigin(const WebTouchEvent&, bool wasHandled);
  #elif ENABLE(TOUCH_EVENTS)
      void touchEvent(const WebTouchEvent&);
@@ -21181,7 +21208,7 @@ index 41e26039ab814b4424c2e22a6c4ef2ca3ea1bf7e..33c9078d798077b2566512b4a28036ed
  #endif
  
      void cancelPointer(WebCore::PointerID, const WebCore::IntPoint&);
-@@ -1764,9 +1774,7 @@ private:
+@@ -1760,9 +1770,7 @@ private:
      void countStringMatches(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount);
      void replaceMatches(const Vector<uint32_t>& matchIndices, const String& replacementText, bool selectionOnly, CompletionHandler<void(uint64_t)>&&);
  
@@ -21191,7 +21218,7 @@ index 41e26039ab814b4424c2e22a6c4ef2ca3ea1bf7e..33c9078d798077b2566512b4a28036ed
  
      void didChangeSelectedIndexForActivePopupMenu(int32_t newIndex);
      void setTextForActivePopupMenu(int32_t index);
-@@ -2302,6 +2310,7 @@ private:
+@@ -2298,6 +2306,7 @@ private:
      UserActivity m_userActivity;
  
      uint64_t m_pendingNavigationID { 0 };
@@ -21252,7 +21279,7 @@ index 3771590efd2b6c5ed409d2f3c9f51e515d5736ff..623016d096c28856218c1c393dd529ec
      RequestDragStart(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
      RequestAdditionalItemsForDragSession(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
 diff --git a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
-index 5d974dcbc289c4be5a707a48e9c83053606d7ce2..bc2aee4b4bd4202e404a5ad65fc2883230686319 100644
+index d41282fc5dc63c317e54b8260c57e344ca36e309..dfafcc34c3ee42b94453c45e5a3dd3b647f1573b 100644
 --- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
 +++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
 @@ -837,21 +837,37 @@ String WebPage::platformUserAgent(const URL&) const
@@ -21344,7 +21371,7 @@ index afad4f9b13ab16b092525a84baaed34933c8e51c..c432676686dae42905ef45dfd4957f95
  }
  
 diff --git a/Source/WebKit/WebProcess/WebProcess.cpp b/Source/WebKit/WebProcess/WebProcess.cpp
-index 572f36dd073eda635867e15fe884d8b8747c2ecc..2a9e42782100431e8abd55ab308e247a170d8646 100644
+index 94304b711fd4faea3b20e739c996a47b8c72ad34..43541ed19fa23b9fb9449ec1a7e0a38d2dcf9864 100644
 --- a/Source/WebKit/WebProcess/WebProcess.cpp
 +++ b/Source/WebKit/WebProcess/WebProcess.cpp
 @@ -88,6 +88,7 @@
@@ -21446,7 +21473,7 @@ index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d
 +    LIBVPX_LIBRARIES
 +)
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index 27cca989c87cf3c0a704edd807363908043d9436..50cab168ad65cd728a86ddf473b0c915f36c1b29 100644
+index 21f6744e581d882f3e5a49e3a7f7756720c871b0..e3367a02e9a6c51f8ceefa4067820edbc7934054 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
 @@ -5,6 +5,7 @@ WEBKIT_OPTION_BEGIN()
@@ -21468,16 +21495,18 @@ index 27cca989c87cf3c0a704edd807363908043d9436..50cab168ad65cd728a86ddf473b0c915
  include(GStreamerDefinitions)
  
  SET_AND_EXPOSE_TO_BUILD(USE_CAIRO TRUE)
-@@ -60,7 +65,7 @@ WEBKIT_OPTION_DEFINE(ENABLE_JOURNALD_LOG "Whether to enable journald logging" PU
+@@ -60,16 +65,16 @@ WEBKIT_OPTION_DEFINE(ENABLE_JOURNALD_LOG "Whether to enable journald logging" PU
  WEBKIT_OPTION_DEFINE(ENABLE_QUARTZ_TARGET "Whether to enable support for the Quartz windowing target." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(ENABLE_WAYLAND_TARGET "Whether to enable support for the Wayland windowing target." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(ENABLE_X11_TARGET "Whether to enable support for the X11 windowing target." PUBLIC ON)
 -WEBKIT_OPTION_DEFINE(USE_AVIF "Whether to enable support for AVIF images." PUBLIC ${ENABLE_EXPERIMENTAL_FEATURES})
 +WEBKIT_OPTION_DEFINE(USE_AVIF "Whether to enable support for AVIF images." PUBLIC OFF)
  WEBKIT_OPTION_DEFINE(USE_GTK4 "Whether to enable usage of GTK4 instead of GTK3." PUBLIC OFF)
+-WEBKIT_OPTION_DEFINE(USE_JPEGXL "Whether to enable support for JPEG-XL images." PUBLIC ${ENABLE_EXPERIMENTAL_FEATURES})
++WEBKIT_OPTION_DEFINE(USE_JPEGXL "Whether to enable support for JPEG-XL images." PUBLIC OFF)
  WEBKIT_OPTION_DEFINE(USE_LCMS "Whether to enable support for image color management using libcms2." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(USE_LIBHYPHEN "Whether to enable the default automatic hyphenation implementation." PUBLIC ON)
-@@ -68,7 +73,7 @@ WEBKIT_OPTION_DEFINE(USE_LIBNOTIFY "Whether to enable the default web notificati
+ WEBKIT_OPTION_DEFINE(USE_LIBNOTIFY "Whether to enable the default web notification implementation." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(USE_LIBSECRET "Whether to enable the persistent credential storage using libsecret." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(USE_OPENGL_OR_ES "Whether to use OpenGL or ES." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(USE_OPENJPEG "Whether to enable support for JPEG2000 images." PUBLIC ON)
@@ -21486,7 +21515,7 @@ index 27cca989c87cf3c0a704edd807363908043d9436..50cab168ad65cd728a86ddf473b0c915
  WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(USE_WPE_RENDERER "Whether to enable WPE rendering" PUBLIC ON)
  
-@@ -119,7 +124,7 @@ endif ()
+@@ -120,7 +125,7 @@ endif ()
  # without approval from a GTK reviewer. There must be strong reason to support
  # changing the value of the option.
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_DRAG_SUPPORT PUBLIC ON)
@@ -21495,7 +21524,7 @@ index 27cca989c87cf3c0a704edd807363908043d9436..50cab168ad65cd728a86ddf473b0c915
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SPELLCHECK PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_TOUCH_EVENTS PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_CRYPTO PUBLIC ON)
-@@ -152,7 +157,7 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_INTELLIGENT_TRACKING_PREVENTION PRIVATE
+@@ -153,7 +158,7 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_INTELLIGENT_TRACKING_PREVENTION PRIVATE
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_LAYOUT_FORMATTING_CONTEXT PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MEDIA_SESSION PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MEDIA_SESSION_PLAYLIST PRIVATE OFF)
@@ -21504,7 +21533,7 @@ index 27cca989c87cf3c0a704edd807363908043d9436..50cab168ad65cd728a86ddf473b0c915
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MHTML PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MOUSE_CURSOR_SCALE PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETSCAPE_PLUGIN_API PRIVATE OFF)
-@@ -168,6 +173,16 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SHAREABLE_RESOURCE PRIVATE ON)
+@@ -169,6 +174,16 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SHAREABLE_RESOURCE PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_API_STATISTICS PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_RTC PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
  
@@ -21522,7 +21551,7 @@ index 27cca989c87cf3c0a704edd807363908043d9436..50cab168ad65cd728a86ddf473b0c915
  
  # Finalize the value for all options. Do not attempt to use an option before
 diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
-index bfaebdecc600f5538258b26b6b1879662343b16a..a0bfa778441052a7d251d1c15b14326849a1e694 100644
+index 1d0cd2b01891343864b5f67d03856c4fa5efa787..6f401a33832e4e8f43184fe745a21748e67a5a02 100644
 --- a/Source/cmake/OptionsWPE.cmake
 +++ b/Source/cmake/OptionsWPE.cmake
 @@ -3,6 +3,7 @@ include(VersioningUtils)
@@ -21542,7 +21571,7 @@ index bfaebdecc600f5538258b26b6b1879662343b16a..a0bfa778441052a7d251d1c15b143268
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MHTML PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETSCAPE_PLUGIN_API PRIVATE OFF)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NOTIFICATIONS PRIVATE ON)
-@@ -69,16 +70,35 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEBGL2 PRIVATE OFF)
+@@ -69,17 +70,36 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEBGL2 PRIVATE OFF)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_RTC PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEBXR PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
  
@@ -21572,8 +21601,10 @@ index bfaebdecc600f5538258b26b6b1879662343b16a..a0bfa778441052a7d251d1c15b143268
  WEBKIT_OPTION_DEFINE(ENABLE_JOURNALD_LOG "Whether to enable journald logging" PUBLIC ON)
 -WEBKIT_OPTION_DEFINE(ENABLE_WPE_QT_API "Whether to enable support for the Qt5/QML plugin" PUBLIC ${ENABLE_DEVELOPER_MODE})
 -WEBKIT_OPTION_DEFINE(USE_AVIF "Whether to enable support for AVIF images." PUBLIC ${ENABLE_EXPERIMENTAL_FEATURES})
+-WEBKIT_OPTION_DEFINE(USE_JPEGXL "Whether to enable support for JPEG-XL images." PUBLIC ${ENABLE_EXPERIMENTAL_FEATURES})
 +WEBKIT_OPTION_DEFINE(ENABLE_WPE_QT_API "Whether to enable support for the Qt5/QML plugin" PUBLIC OFF)
 +WEBKIT_OPTION_DEFINE(USE_AVIF "Whether to enable support for AVIF images." PUBLIC OFF)
++WEBKIT_OPTION_DEFINE(USE_JPEGXL "Whether to enable support for JPEG-XL images." PUBLIC OFF)
  WEBKIT_OPTION_DEFINE(USE_LCMS "Whether to enable support for image color management using libcms2." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(USE_OPENJPEG "Whether to enable support for JPEG2000 images." PUBLIC ON)
 -WEBKIT_OPTION_DEFINE(USE_SOUP2 "Whether to enable usage of Soup 2 instead of Soup 3." PUBLIC OFF)
@@ -21635,10 +21666,10 @@ index fb99a1e511986a6a0ea6a593d0c5a225bcc26fe3..5c31cd3f0529c81d932b3adc092ea8c1
      WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETSCAPE_PLUGIN_API PRIVATE OFF)
  else ()
 diff --git a/Source/cmake/OptionsWinCairo.cmake b/Source/cmake/OptionsWinCairo.cmake
-index 19f5127e6717f5f7729066f5d5b79c804a995763..ad52470cc76f32ef895acef4e060ea6b5c8e65b6 100644
+index 54dc095d9f98cf0116a704e99e88333f1108c8a0..23216d79747d514c53e965618d5bf7ade8beb659 100644
 --- a/Source/cmake/OptionsWinCairo.cmake
 +++ b/Source/cmake/OptionsWinCairo.cmake
-@@ -32,15 +32,36 @@ if (OpenJPEG_FOUND)
+@@ -37,15 +37,36 @@ if (OpenJPEG_FOUND)
  endif ()
  
  find_package(WOFF2 1.0.2 COMPONENTS dec)
@@ -21713,7 +21744,7 @@ index 1c84f30b2ea96dd0c168918f9d63773b8e2548a3..55603437900a65de7bef70563c9ec039
  }
  
 diff --git a/Tools/MiniBrowser/gtk/BrowserWindow.c b/Tools/MiniBrowser/gtk/BrowserWindow.c
-index 29a09ddafe4dbd50f8a2c461a91c63fbeede003a..cfd12b5abc88c7e257af82ff54ea8e258605bb95 100644
+index 881609c9fe8f2b5ed6158a5972438c14fd650cf5..4a032f5cc0808087405f2f9dd9614b5cbf85252a 100644
 --- a/Tools/MiniBrowser/gtk/BrowserWindow.c
 +++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
 @@ -70,7 +70,7 @@ struct _BrowserWindowClass {
@@ -22192,7 +22223,7 @@ index b0f26645ea360cc7e55afbfbe2ceb4e5791a0fb7..e5401df8302bb7b1950d1c92caf9ae58
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
 diff --git a/Tools/WebKitTestRunner/TestController.cpp b/Tools/WebKitTestRunner/TestController.cpp
-index b090bbd31ff486d19d379ac40828df3edd0b2df6..ed0b92061bdb14d321787a7aa1153a15b4a9035b 100644
+index ed2802fb1e766dc5de67c44d157661632c3931a3..3f1a19a33531ee5546eec0e9615bdffe0c040700 100644
 --- a/Tools/WebKitTestRunner/TestController.cpp
 +++ b/Tools/WebKitTestRunner/TestController.cpp
 @@ -805,6 +805,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)


### PR DESCRIPTION
Rebase `bootstrap.diff` to [r286156](https://trac.webkit.org/changeset/286156/webkit)

  * 3way diff: https://github.com/dpino/WebKit/commit/edcbad68714cd0be7a937d78e955b3709af5dceb
  * Resolve conflicts: https://github.com/dpino/WebKit/commit/b847914da4950e32f8c8b3e5e0ccf745e2515da6
  * Build fixes: https://github.com/dpino/WebKit/commit/69802e7a2183a3c7955afc0c2cefc5b8441a9ad8

The build fixes set USE_JPEGXL to false for WebKitGTK/WPE ports. This feature was enabled for WebKitGTK/WPE ports in [r286131](https://trac.webkit.org/changeset/286131/webkit).

The other build fixes solve several compilation issues that are currently happening on unified source files. I will push these fixes upstream.