### PR TITLE
fix(test-runner): webServer port detection on Node.js 17

### DIFF
--- a/packages/playwright-test/src/webServer.ts
+++ b/packages/playwright-test/src/webServer.ts
@@ -105,9 +105,9 @@ export class WebServer {
 }
 
 async function isPortUsed(port: number): Promise<boolean> {
-  return new Promise<boolean>(resolve => {
+  const innerIsPortUsed = (host: string) => new Promise<boolean>(resolve => {
     const conn = net
-        .connect(port)
+        .connect(port, host)
         .on('error', () => {
           resolve(false);
         })
@@ -116,6 +116,7 @@ async function isPortUsed(port: number): Promise<boolean> {
           resolve(true);
         });
   });
+  return await innerIsPortUsed('127.0.0.1') || await innerIsPortUsed('::1');
 }
 
 async function waitForSocket(port: number, delay: number, cancellationToken: { canceled: boolean }) {


### PR DESCRIPTION
Node.js >= 17 does return the ipv6 address (`::1`) when resolving localhost. Before it did return ipv4 as expected (`127.0.0.1`). With this change we verify now ipv4 and ipv6 localhost availability.

Fixes #10346