### PR TITLE
chore: validate client/server version match for remote connections

### DIFF
--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -40,6 +40,7 @@ import { Artifact } from './artifact';
 import { EventEmitter } from 'events';
 import { JsonPipe } from './jsonPipe';
 import { APIRequestContext } from './fetch';
+import { getPlaywrightVersion } from '../utils/utils';
 
 class Root extends ChannelOwner<channels.RootChannel> {
   constructor(connection: Connection) {
@@ -49,6 +50,7 @@ class Root extends ChannelOwner<channels.RootChannel> {
   async initialize(): Promise<Playwright> {
     return Playwright.from((await this._channel.initialize({
       sdkLanguage: 'javascript',
+      version: getPlaywrightVersion(),
     })).playwright);
   }
 }

--- a/packages/playwright-core/src/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/dispatchers/dispatcher.ts
@@ -18,7 +18,7 @@ import { EventEmitter } from 'events';
 import * as channels from '../protocol/channels';
 import { serializeError } from '../protocol/serializers';
 import { createScheme, Validator, ValidationError } from '../protocol/validator';
-import { assert, debugAssert, isUnderTest, monotonicTime } from '../utils/utils';
+import { assert, debugAssert, getPlaywrightVersion, isUnderTest, monotonicTime } from '../utils/utils';
 import { tOptional } from '../protocol/validatorPrimitives';
 import { kBrowserOrContextClosedError } from '../utils/errors';
 import { CallMetadata, SdkObject } from '../server/instrumentation';
@@ -132,6 +132,8 @@ export class Root extends Dispatcher<{ guid: '' }, any> {
   async initialize(params: channels.RootInitializeParams): Promise<channels.RootInitializeResult> {
     assert(this.createPlaywright);
     assert(!this._initialized);
+    const expectedPlaywrightVersion = getPlaywrightVersion();
+    assert(params.version === expectedPlaywrightVersion, `Server (${expectedPlaywrightVersion}) does not match with client version (${params.version}).`);
     this._initialized = true;
     return {
       playwright: await this.createPlaywright(this, params),

--- a/packages/playwright-core/src/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/dispatchers/dispatcher.ts
@@ -132,8 +132,7 @@ export class Root extends Dispatcher<{ guid: '' }, any> {
   async initialize(params: channels.RootInitializeParams): Promise<channels.RootInitializeResult> {
     assert(this.createPlaywright);
     assert(!this._initialized);
-    const expectedPlaywrightVersion = getPlaywrightVersion();
-    assert(params.version === expectedPlaywrightVersion, `Server (${expectedPlaywrightVersion}) does not match with client version (${params.version}).`);
+    assertPlaywrightVersion(params.version);
     this._initialized = true;
     return {
       playwright: await this.createPlaywright(this, params),
@@ -322,3 +321,10 @@ function formatLogRecording(log: string[]): string {
 }
 
 let lastEventId = 0;
+
+function assertPlaywrightVersion(givenVersion: string): void {
+  const expectedVersion = getPlaywrightVersion();
+  const givenParts = givenVersion.split('.');
+  const expectedParts = givenVersion.split('.');
+  assert(givenParts.slice(0, 2).join('.') === expectedParts.slice(0, 2).join('.'), `${expectedVersion} does not match the client version ${givenVersion}.`);
+}

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -346,6 +346,7 @@ export interface RootChannel extends RootEventTarget, Channel {
 }
 export type RootInitializeParams = {
   sdkLanguage: string,
+  version: string,
 };
 export type RootInitializeOptions = {
 

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -415,6 +415,7 @@ Root:
     initialize:
       parameters:
         sdkLanguage: string
+        version: string
       returns:
         playwright: Playwright
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -188,6 +188,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   scheme.LifecycleEvent = tEnum(['load', 'domcontentloaded', 'networkidle', 'commit']);
   scheme.RootInitializeParams = tObject({
     sdkLanguage: tString,
+    version: tString,
   });
   scheme.PlaywrightSocksConnectedParams = tObject({
     uid: tString,


### PR DESCRIPTION
- Keep the validation on the server side? Makes sense I guess
- Enforce it? I would probably, so the reported compatibility issues get resolved automatically. Maybe we can add an environment variable to opt-out of it. e.g. `Set the PLAYWRIGHT_DO_NOT_EXIT_ON_INCOMPATIBILITY to skip the validation`
- Tested with connect/and PlaywrightClient/PlaywrightServer

Related work: The language bindings need to implement it.