### PR TITLE
feat(screenshots): Add `captureBeyondViewport` option to screenshot

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -642,6 +642,16 @@ The quality of the image, between 0-100. Not applicable to `png` images.
 Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
 Defaults to `false`.
 
+### option: ElementHandle.screenshot.captureBeyondViewport
+- `captureBeyondViewport` <[boolean]>
+
+In chromium, Playwright will temporarily resize the viewport when taking
+screenshots of content that is outside the current viewport. This can cause
+issues if you are using `vh` and `vw` units. By setting `captureBeyondViewport`
+to true, we avoid the viewport workaround and instead instructs chromium to use
+the experimental `captureBeyondViewport` option when capturing the screenshot.
+Default is `false`.
+
 ### option: ElementHandle.screenshot.timeout = %%-input-timeout-%%
 
 ## async method: ElementHandle.scrollIntoViewIfNeeded

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2686,6 +2686,16 @@ Defaults to `false`.
 
 ### option: Page.screenshot.timeout = %%-input-timeout-%%
 
+### option: Page.screenshot.captureBeyondViewport
+- `captureBeyondViewport` <[boolean]>
+
+In chromium, Playwright will temporarily resize the viewport when taking
+screenshots of content that is outside the current viewport. This can cause
+issues if you are using `vh` and `vw` units. By setting `captureBeyondViewport`
+to true, we avoid the viewport workaround and instead instructs chromium to use
+the experimental `captureBeyondViewport` option when capturing the screenshot.
+Default is `false`.
+
 ## async method: Page.selectOption
 - returns: <[Array]<[string]>>
 

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -1466,6 +1466,7 @@ export type PageScreenshotParams = {
   omitBackground?: boolean,
   fullPage?: boolean,
   clip?: Rect,
+  captureBeyondViewport?: boolean,
 };
 export type PageScreenshotOptions = {
   timeout?: number,
@@ -1474,6 +1475,7 @@ export type PageScreenshotOptions = {
   omitBackground?: boolean,
   fullPage?: boolean,
   clip?: Rect,
+  captureBeyondViewport?: boolean,
 };
 export type PageScreenshotResult = {
   binary: Binary,
@@ -2750,12 +2752,14 @@ export type ElementHandleScreenshotParams = {
   type?: 'png' | 'jpeg',
   quality?: number,
   omitBackground?: boolean,
+  captureBeyondViewport?: boolean,
 };
 export type ElementHandleScreenshotOptions = {
   timeout?: number,
   type?: 'png' | 'jpeg',
   quality?: number,
   omitBackground?: boolean,
+  captureBeyondViewport?: boolean,
 };
 export type ElementHandleScreenshotResult = {
   binary: Binary,

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -991,6 +991,7 @@ Page:
         omitBackground: boolean?
         fullPage: boolean?
         clip: Rect?
+        captureBeyondViewport: boolean?
       returns:
         binary: binary
 
@@ -2132,6 +2133,7 @@ ElementHandle:
           - jpeg
         quality: number?
         omitBackground: boolean?
+        captureBeyondViewport: boolean?
       returns:
         binary: binary
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -550,6 +550,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     omitBackground: tOptional(tBoolean),
     fullPage: tOptional(tBoolean),
     clip: tOptional(tType('Rect')),
+    captureBeyondViewport: tOptional(tBoolean),
   });
   scheme.PageSetExtraHTTPHeadersParams = tObject({
     headers: tArray(tType('NameValue')),
@@ -1033,6 +1034,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     type: tOptional(tEnum(['png', 'jpeg'])),
     quality: tOptional(tNumber),
     omitBackground: tOptional(tBoolean),
+    captureBeyondViewport: tOptional(tBoolean),
   });
   scheme.ElementHandleScrollIntoViewIfNeededParams = tObject({
     timeout: tOptional(tNumber),

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -252,7 +252,7 @@ export class CRPage implements PageDelegate {
     await this._mainFrameSession._client.send('Emulation.setDefaultBackgroundColorOverride', { color });
   }
 
-  async takeScreenshot(progress: Progress, format: 'png' | 'jpeg', documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined): Promise<Buffer> {
+  async takeScreenshot(progress: Progress, format: 'png' | 'jpeg', documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined, captureBeyondViewport: boolean | undefined): Promise<Buffer> {
     const { visualViewport } = await this._mainFrameSession._client.send('Page.getLayoutMetrics');
     if (!documentRect) {
       documentRect = {
@@ -268,7 +268,7 @@ export class CRPage implements PageDelegate {
     // ignore current page scale.
     const clip = { ...documentRect, scale: viewportRect ? visualViewport.scale : 1 };
     progress.throwIfAborted();
-    const result = await this._mainFrameSession._client.send('Page.captureScreenshot', { format, quality, clip });
+    const result = await this._mainFrameSession._client.send('Page.captureScreenshot', { format, quality, clip, captureBeyondViewport });
     return Buffer.from(result.data, 'base64');
   }
 

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -61,7 +61,7 @@ export interface PageDelegate {
   canScreenshotOutsideViewport(): boolean;
   resetViewport(): Promise<void>; // Only called if canScreenshotOutsideViewport() returns false.
   setBackgroundColor(color?: { r: number; g: number; b: number; a: number; }): Promise<void>;
-  takeScreenshot(progress: Progress, format: string, documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined): Promise<Buffer>;
+  takeScreenshot(progress: Progress, format: string, documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined, captureBeyondViewport: boolean | undefined): Promise<Buffer>;
 
   isElementHandle(remoteObject: any): boolean;
   adoptElementHandle<T extends Node>(handle: dom.ElementHandle<T>, to: dom.FrameExecutionContext): Promise<dom.ElementHandle<T>>;

--- a/packages/playwright-core/src/server/screenshotter.ts
+++ b/packages/playwright-core/src/server/screenshotter.ts
@@ -69,7 +69,7 @@ export class Screenshotter {
         let documentRect = { x: 0, y: 0, width: fullPageSize.width, height: fullPageSize.height };
         let overriddenViewportSize: types.Size | null = null;
         const fitsViewport = fullPageSize.width <= viewportSize.width && fullPageSize.height <= viewportSize.height;
-        if (!this._page._delegate.canScreenshotOutsideViewport() && !fitsViewport) {
+        if (!this._page._delegate.canScreenshotOutsideViewport() && !fitsViewport && !options.captureBeyondViewport) {
           overriddenViewportSize = fullPageSize;
           progress.throwIfAborted(); // Avoid side effects.
           await this._page.setViewportSize(overriddenViewportSize);
@@ -104,7 +104,7 @@ export class Screenshotter {
 
       let overriddenViewportSize: types.Size | null = null;
       const fitsViewport = boundingBox.width <= viewportSize.width && boundingBox.height <= viewportSize.height;
-      if (!this._page._delegate.canScreenshotOutsideViewport() && !fitsViewport) {
+      if (!this._page._delegate.canScreenshotOutsideViewport() && !fitsViewport && !options.captureBeyondViewport) {
         overriddenViewportSize = helper.enclosingIntSize({
           width: Math.max(viewportSize.width, boundingBox.width),
           height: Math.max(viewportSize.height, boundingBox.height),
@@ -144,7 +144,7 @@ export class Screenshotter {
       progress.cleanupWhenAborted(() => this._page._delegate.setBackgroundColor());
     }
     progress.throwIfAborted(); // Avoid extra work.
-    const buffer = await this._page._delegate.takeScreenshot(progress, format, documentRect, viewportRect, options.quality);
+    const buffer = await this._page._delegate.takeScreenshot(progress, format, documentRect, viewportRect, options.quality, options.captureBeyondViewport);
     progress.throwIfAborted(); // Avoid restoring after failure - should be done by cleanup.
     if (shouldSetDefaultBackground)
       await this._page._delegate.setBackgroundColor();

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -51,6 +51,7 @@ export type ElementScreenshotOptions = TimeoutOptions & {
   type?: 'png' | 'jpeg',
   quality?: number,
   omitBackground?: boolean,
+  captureBeyondViewport?: boolean,
 };
 
 export type ScreenshotOptions = ElementScreenshotOptions & {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8028,6 +8028,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
    */
   screenshot(options?: {
     /**
+     * In chromium, Playwright will temporarily resize the viewport when taking screenshots of content that is outside the
+     * current viewport. This can cause issues if you are using `vh` and `vw` units. By setting `captureBeyondViewport` to
+     * true, we avoid the viewport workaround and instead instructs chromium to use the experimental `captureBeyondViewport`
+     * option when capturing the screenshot. Default is `false`.
+     */
+    captureBeyondViewport?: boolean;
+
+    /**
      * Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
      * Defaults to `false`.
      */
@@ -15615,6 +15623,14 @@ interface PageWaitForFunctionOptions {
 }
 
 export interface PageScreenshotOptions {
+  /**
+   * In chromium, Playwright will temporarily resize the viewport when taking screenshots of content that is outside the
+   * current viewport. This can cause issues if you are using `vh` and `vw` units. By setting `captureBeyondViewport` to
+   * true, we avoid the viewport workaround and instead instructs chromium to use the experimental `captureBeyondViewport`
+   * option when capturing the screenshot. Default is `false`.
+   */
+  captureBeyondViewport?: boolean;
+
   /**
    * An object which specifies clipping of the resulting image. Should have the following fields:
    */


### PR DESCRIPTION
The default behavior for Playwright in chromium is to temporarily resize
the viewport before taking a screenshot. This happens both for
`page.screenshot({ fullPage: true })` and `elementHandle.screenshot()`.
Without it, screenshots would be cut at the viewport size. In general,
this behavior/workaround is okay. But when you start using CSS viewport
units like vh and vw, screenshots will look wrong. Consider the
following example:

<main style="min-height: 2000px">
  <div style="height: 50vh"></div>
</main>

For a viewport of size 800px, the div will render at 400px. But a
Playwright screenshot of a this page will show the div at 1000px. Of
course, one could argue that you should probably use vh heights together
with a fixed max-height or vmax or similar (with the reasoning usually
being something like "people shouldn't assume viewports are always
small") but the fact is that there are tons of websites out there that
use viewport units and they all sort of look wrong in Playwright
screenshots.

At happo.io, we've been using Puppeteer for an extended period of time,
and I've noticed that they don't have the same problem. Viewport units
work well even when content doesn't fit inside the viewport. After doing
some digging, I found that Puppeteer passes the `captureBeyondViewport`
flag in the call to `captureScreenshot()`.
https://github.com/puppeteer/puppeteer/blob/4d9dc8c0e613f22d4cdf237e8bd0b0da3c588edb/src/common/Page.ts#L2778
https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot

The `captureBeyondViewport` option is experiemental, so it's probably
best not to lock ourselves into the behavior by making it the default.
That's why this commit will add a new option to the screenshot methods
(page and elementHandle). That way, people can opt in to the
experimental behavior and people who are happy with the viewport resize
workaround can stay with the default.

This is a chromium only option. Other browsers won't be affected by this
change (they are also already doing "the right thing" for screenshots
with viewport units).