### PR TITLE
Adding no reuseWorkers config option

### DIFF
--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -41,6 +41,7 @@ const defaultConfig: Config = {
   timeout: defaultTimeout,
   updateSnapshots: 'missing',
   workers: Math.ceil(require('os').cpus().length / 2),
+  reuseWorkers: true,
 };
 
 export function addTestCommand(program: Command) {
@@ -56,6 +57,7 @@ export function addTestCommand(program: Command) {
   command.option('--global-timeout <timeout>', `Maximum time this test suite can run in milliseconds (default: unlimited)`);
   command.option('-j, --workers <workers>', `Number of concurrent workers, use 1 to run in a single worker (default: number of CPU cores / 2)`);
   command.option('--list', `Collect all the tests and report them, but do not run`);
+  command.option('--no-reuse-workers', `Respawn workers for each spec (default: reuse enabled)`);
   command.option('--max-failures <N>', `Stop after the first N failures`);
   command.option('--output <dir>', `Folder for output artifacts (default: "test-results")`);
   command.option('--quiet', `Suppress stdio`);
@@ -222,6 +224,7 @@ function overridesFromOptions(options: { [key: string]: any }): Config {
     timeout: isDebuggerAttached ? 0 : (options.timeout ? parseInt(options.timeout, 10) : undefined),
     updateSnapshots: options.updateSnapshots ? 'all' as const : undefined,
     workers: options.workers ? parseInt(options.workers, 10) : undefined,
+    reuseWorkers: options.reuseWorkers === false ? false : undefined,
   };
 }
 

--- a/packages/playwright-test/src/dispatcher.ts
+++ b/packages/playwright-test/src/dispatcher.ts
@@ -231,7 +231,7 @@ export class Dispatcher {
       // - there are no remaining
       // - we are here not because something failed
       // - no unrecoverable worker error
-      if (!remaining.length && !failedTestIds.size && !params.fatalError) {
+      if (!remaining.length && !failedTestIds.size && !params.fatalError && this._loader.fullConfig().reuseWorkers) {
         doneWithJob();
         return;
       }

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -102,6 +102,7 @@ export class Loader {
     this._fullConfig.shard = takeFirst(this._configOverrides.shard, this._config.shard, baseFullConfig.shard);
     this._fullConfig.updateSnapshots = takeFirst(this._configOverrides.updateSnapshots, this._config.updateSnapshots, baseFullConfig.updateSnapshots);
     this._fullConfig.workers = takeFirst(this._configOverrides.workers, this._config.workers, baseFullConfig.workers);
+    this._fullConfig.reuseWorkers = takeFirst(this._configOverrides.reuseWorkers, this._config.reuseWorkers, baseFullConfig.reuseWorkers);
     this._fullConfig.webServer = takeFirst(this._configOverrides.webServer, this._config.webServer, baseFullConfig.webServer);
 
     for (const project of projects)
@@ -442,6 +443,7 @@ const baseFullConfig: FullConfig = {
   updateSnapshots: 'missing',
   version: require('../package.json').version,
   workers: 1,
+  reuseWorkers: true,
   webServer: null,
 };
 

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -589,6 +589,7 @@ interface TestConfig {
    *
    */
   workers?: number;
+  reuseWorkers?: boolean;
 
   /**
    * Configuration for the `expect` assertion library. Learn more about [various timeouts](https://playwright.dev/docs/test-timeouts).

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -1013,6 +1013,7 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
    *
    */
   workers: number;
+  reuseWorkers: boolean;
   webServer: WebServerConfig | null;
 }
 

--- a/tests/playwright-test/worker-index.spec.ts
+++ b/tests/playwright-test/worker-index.spec.ts
@@ -233,7 +233,7 @@ test('should not reuse workers when reuseWorkers used as false', async ({ runInl
       test('succeeds 1', async ({}, testInfo) => {
         expect(testInfo.workerIndex).toBe(1);
       });`
-  }, { workers: 1}, {}, { additionalArgs: ["--no-reuse-workers"] });
+  }, { workers: 1 }, {}, { additionalArgs: ['--no-reuse-workers'] });
   expect(result.passed).toBe(2);
   expect(result.failed).toBe(0);
   expect(result.exitCode).toBe(0);

--- a/tests/playwright-test/worker-index.spec.ts
+++ b/tests/playwright-test/worker-index.spec.ts
@@ -219,3 +219,22 @@ test('parallelIndex should be in 0..workers-1', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(20);
 });
+
+test('should not reuse workers when reuseWorkers used as false', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    '1.test.js': `
+      const { test } = pwt;
+      test('succeeds 1', async ({}, testInfo) => {
+        expect(testInfo.workerIndex).toBe(0);
+      });
+    `,
+    '2.spec.ts': `
+      const { test } = pwt;
+      test('succeeds 1', async ({}, testInfo) => {
+        expect(testInfo.workerIndex).toBe(1);
+      });`
+  }, { workers: 1}, {}, { additionalArgs: ["--no-reuse-workers"] });
+  expect(result.passed).toBe(2);
+  expect(result.failed).toBe(0);
+  expect(result.exitCode).toBe(0);
+});

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -115,6 +115,7 @@ interface TestConfig {
   updateSnapshots?: UpdateSnapshots;
   webServer?: WebServerConfig;
   workers?: number;
+  reuseWorkers?: boolean;
 
   expect?: ExpectSettings;
   metadata?: any;
@@ -152,6 +153,7 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
   shard: Shard;
   updateSnapshots: UpdateSnapshots;
   workers: number;
+  reuseWorkers: boolean;
   webServer: WebServerConfig | null;
 }
 


### PR DESCRIPTION
Changes to support creating a new worker per spec on cloud providers. Keeping this configurable - default is current behavior of reusing workers.