### PR TITLE
fix: add missing closing backquote

### DIFF
--- a/docs/src/selectors.md
+++ b/docs/src/selectors.md
@@ -869,7 +869,7 @@ Attribute selectors are not CSS selectors, so anything CSS-specific like `:enabl
 :::
 
 :::note
-Attribute selectors pierce shadow DOM. To opt-out from this behavior, use `:light` suffix after attribute, for example `page.click('data-test-id:light=submit')
+Attribute selectors pierce shadow DOM. To opt-out from this behavior, use `:light` suffix after attribute, for example `page.click('data-test-id:light=submit')`
 :::
 
 


### PR DESCRIPTION
While reading the documentation here https://playwright.dev/docs/selectors/#id-data-testid-data-test-id-data-test-selectors, I noticed not correctly formatted code.

![image](https://user-images.githubusercontent.com/13823215/144019892-ae7f5d31-38f9-491f-890d-9fb8c9c8236e.png)

This minor change fixes that problem.