### PR TITLE
chore(chromium): Capture off-screen content without resizing viewport

### DIFF
--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -401,10 +401,6 @@ export class FFPage implements PageDelegate {
     await this._session.send('Page.close', { runBeforeUnload });
   }
 
-  canScreenshotOutsideViewport(): boolean {
-    return true;
-  }
-
   async setBackgroundColor(color?: { r: number; g: number; b: number; a: number; }): Promise<void> {
     if (color)
       throw new Error('Not implemented');
@@ -428,10 +424,6 @@ export class FFPage implements PageDelegate {
       clip: documentRect,
     });
     return Buffer.from(data, 'base64');
-  }
-
-  async resetViewport(): Promise<void> {
-    assert(false, 'Should not be called');
   }
 
   async getContentFrame(handle: dom.ElementHandle): Promise<frames.Frame | null> {

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -58,10 +58,8 @@ export interface PageDelegate {
   setFileChooserIntercepted(enabled: boolean): Promise<void>;
   bringToFront(): Promise<void>;
 
-  canScreenshotOutsideViewport(): boolean;
-  resetViewport(): Promise<void>; // Only called if canScreenshotOutsideViewport() returns false.
   setBackgroundColor(color?: { r: number; g: number; b: number; a: number; }): Promise<void>;
-  takeScreenshot(progress: Progress, format: string, documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined): Promise<Buffer>;
+  takeScreenshot(progress: Progress, format: string, documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined, fitsViewport: boolean | undefined): Promise<Buffer>;
 
   isElementHandle(remoteObject: any): boolean;
   adoptElementHandle<T extends Node>(handle: dom.ElementHandle<T>, to: dom.FrameExecutionContext): Promise<dom.ElementHandle<T>>;

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -747,10 +747,6 @@ export class WKPage implements PageDelegate {
     });
   }
 
-  canScreenshotOutsideViewport(): boolean {
-    return true;
-  }
-
   async setBackgroundColor(color?: { r: number; g: number; b: number; a: number; }): Promise<void> {
     await this._session.send('Page.setDefaultBackgroundColorOverride', { color });
   }
@@ -788,10 +784,6 @@ export class WKPage implements PageDelegate {
     if (format === 'jpeg')
       buffer = jpeg.encode(png.PNG.sync.read(buffer), quality).data;
     return buffer;
-  }
-
-  async resetViewport(): Promise<void> {
-    assert(false, 'Should not be called');
   }
 
   async getContentFrame(handle: dom.ElementHandle): Promise<frames.Frame | null> {

--- a/tests/screenshot.spec.ts
+++ b/tests/screenshot.spec.ts
@@ -117,6 +117,38 @@ browserTest.describe('page screenshot', () => {
     expect(pixel(0, 8339).r).toBeLessThan(128);
     expect(pixel(0, 8339).b).toBeGreaterThan(128);
   });
+
+  browserTest('should handle vh units ', async ({ contextFactory }) => {
+    const context = await contextFactory();
+    const page = await context.newPage();
+
+    await page.setViewportSize({ width: 800, height: 500 });
+    await page.evaluate(() => {
+      document.body.style.margin = '0';
+      document.body.style.padding = '0';
+      document.documentElement.style.margin = '0';
+      document.documentElement.style.padding = '0';
+      const div = document.createElement('div');
+      div.style.width = '100%';
+      div.style.borderTop = '100vh solid red';
+      div.style.borderBottom = '100vh solid blue';
+      document.body.appendChild(div);
+    });
+    const buffer = await page.screenshot({ fullPage: true });
+    const decoded = PNG.sync.read(buffer);
+
+    const pixel = (x: number, y: number) => {
+      const dst = new PNG({ width: 1, height: 1 });
+      PNG.bitblt(decoded, dst, x, y, 1, 1);
+      const pixels = dst.data;
+      return { r: pixels[0], g: pixels[1], b: pixels[2], a: pixels[3] };
+    };
+
+    expect(pixel(0, 0).r).toBeGreaterThan(128);
+    expect(pixel(0, 0).b).toBeLessThan(128);
+    expect(pixel(0, 999).r).toBeLessThan(128);
+    expect(pixel(0, 999).b).toBeGreaterThan(128);
+  });
 });
 
 browserTest.describe('element screenshot', () => {
@@ -264,6 +296,35 @@ browserTest.describe('element screenshot', () => {
     expect(error.message).toContain('oh my');
     await verifyViewport(page, 350, 360);
     await context.close();
+  });
+
+  browserTest('element screenshots should handle vh units ', async ({ contextFactory }) => {
+    const context = await contextFactory();
+    const page = await context.newPage();
+
+    await page.setViewportSize({ width: 800, height: 500 });
+    await page.evaluate(() => {
+      const div = document.createElement('div');
+      div.style.width = '100%';
+      div.style.borderTop = '100vh solid red';
+      div.style.borderBottom = '100vh solid blue';
+      document.body.appendChild(div);
+    });
+    const elementHandle = await page.$('div');
+    const buffer = await elementHandle.screenshot();
+    const decoded = PNG.sync.read(buffer);
+
+    const pixel = (x: number, y: number) => {
+      const dst = new PNG({ width: 1, height: 1 });
+      PNG.bitblt(decoded, dst, x, y, 1, 1);
+      const pixels = dst.data;
+      return { r: pixels[0], g: pixels[1], b: pixels[2], a: pixels[3] };
+    };
+
+    expect(pixel(0, 0).r).toBeGreaterThan(128);
+    expect(pixel(0, 0).b).toBeLessThan(128);
+    expect(pixel(0, 999).r).toBeLessThan(128);
+    expect(pixel(0, 999).b).toBeGreaterThan(128);
   });
 
   browserTest('should work if the main resource hangs', async ({ browser, browserName, mode, server }) => {


### PR DESCRIPTION
The default behavior for Playwright in chromium is to temporarily resize
the viewport before taking a screenshot. This happens both for
page.screenshot({ fullPage: true }) and elementHandle.screenshot().
Without it, screenshots would be cut at the viewport size. In general,
this behavior/workaround is okay. But when you start using CSS viewport
units like vh and vw, screenshots will look wrong. Consider the
following example:

For a viewport of size 800px, the div will render at 400px. But a
Playwright screenshot of a this page will show the div at 1000px. Of
course, one could argue that you should probably use vh heights together
with a fixed max-height or vmax or similar (with the reasoning usually
being something like "people shouldn't assume viewports are always
small") but the fact is that there are tons of websites out there that
use viewport units and they all sort of look wrong in Playwright
screenshots.

At happo.io, we've been using Puppeteer for an extended period of time,
and I've noticed that they don't have the same problem. Viewport units
work well even when content doesn't fit inside the viewport. After doing
some digging, I found that Puppeteer passes the captureBeyondViewport
flag in the call to captureScreenshot().
https://github.com/puppeteer/puppeteer/blob/4d9dc8c0e613f22d4cdf237e8bd0b0da3c588edb/src/common/Page.ts#L2778
https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot

In this commit, I'm making use of `captureBeyondViewport` so that we no
longer have to resize the viewport. I first worked on making this
opt-in, but after having things reviewed by @pavelfeldman we decided
it's safe to rely on this flag whenever content doesn't fit inside the
viewport.

This is a chromium only option. Other browsers won't be affected by this
change (they are also already doing "the right thing" for screenshots
with viewport units).