### PR TITLE
docs(intro-java): bump Java to 1.17.1

### DIFF
--- a/docs/src/intro-java.md
+++ b/docs/src/intro-java.md
@@ -59,7 +59,7 @@ public class Example {
     <dependency>
       <groupId>com.microsoft.playwright</groupId>
       <artifactId>playwright</artifactId>
-      <version>1.16.0</version>
+      <version>1.17.1</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
We should cherry-pick it to the release branch when we regenerate the docs.