### PR TITLE
feat(test runner): global fixtures

### DIFF
--- a/packages/playwright-test/src/globalFixtures.ts
+++ b/packages/playwright-test/src/globalFixtures.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EventEmitter } from 'events';
+import { ManualPromise } from 'playwright-core/lib/utils/async';
+import { FullConfig, WorkerInfo, TestError, FullProject } from './types';
+import { FixturePool, FixtureRegistration, FixtureRunner } from './fixtures';
+import { GlobalFixtureSetupRequest, GlobalFixtureSetupResponse, GlobalFixtureTeardownRequest } from './ipc';
+import { prependToTestError, serializeError } from './util';
+
+function globalFixtureId(registration: FixtureRegistration): string {
+  return registration.name + '@' + registration.location.file + ':' + registration.location.line + ':' + registration.location.column;
+}
+
+type GlobalFixtureData = {
+  originalName: string;
+  registration: FixtureRegistration;
+  value?: Promise<{ stringifiedValue?: string, error?: TestError }>;
+};
+
+export class GlobalFixtureRunner {
+  private _pool: FixturePool;
+  private _runner: FixtureRunner;
+  private _idToFixture = new Map<string, GlobalFixtureData>();
+  private _config: FullConfig;
+
+  constructor(config: FullConfig) {
+    this._config = config;
+    this._pool = new FixturePool([]);
+    this._runner = new FixtureRunner();
+    this._runner.setPool(this._pool);
+  }
+
+  registerPool(pool: FixturePool) {
+    for (const registration of pool.registrations.values()) {
+      if (registration.scope === 'global')
+        this.registerFixture(pool, registration);
+    }
+  }
+
+  registerFixture(pool: FixturePool, registration: FixtureRegistration): FixtureRegistration {
+    const parent = registration.super ? this.registerFixture(pool, registration.super) : undefined;
+    const id = globalFixtureId(registration);
+    const data = this._idToFixture.get(id);
+    if (data)
+      return data.registration;
+    const newRegistration: FixtureRegistration = {
+      ...registration,
+      super: parent,
+      name: id,
+      deps: registration.deps.map(dep => {
+        const oldDep = pool.resolveDependency(registration, dep)!;
+        const newDep = this.registerFixture(pool, oldDep);
+        return newDep.name;
+      }),
+    };
+    this._pool.registrations.set(id, newRegistration);
+    this._idToFixture.set(id, { originalName: registration.name, registration: newRegistration });
+    return newRegistration;
+  }
+
+  async globalFixtureSetupRequest(payload: GlobalFixtureSetupRequest): Promise<GlobalFixtureSetupResponse> {
+    const data = this._idToFixture.get(payload.id);
+    if (!data) {
+      return {
+        id: payload.id,
+        error: { message: `Unable to resolve global fixture` },
+      };
+    }
+
+    if (!data.value) {
+      const workerInfo: WorkerInfo = {
+        config: this._config,
+        project: dummyProject,
+        parallelIndex: -1,
+        workerIndex: -1,
+      };
+      data.value = this._runner.setupFixtureForRegistration(data.registration, workerInfo, undefined).then(fixture => {
+        try {
+          const stringifiedValue = JSON.stringify(fixture.value);
+          if (stringifiedValue === undefined)
+            return { error: { message: `The value of the global fixture "${data.originalName}" cannot be serialized.` } };
+          return { stringifiedValue };
+        } catch (e) {
+          const error = prependToTestError(serializeError(e), `The value of the global fixture "${data.originalName}" cannot be serialized:\n`);
+          return { error };
+        }
+      }).catch(e => {
+        return { error: serializeError(e) };
+      });
+    }
+
+    const result = await data.value;
+    return {
+      id: payload.id,
+      error: result.error,
+      stringifiedValue: result.stringifiedValue,
+    };
+  }
+
+  globalFixtureTeardownRequest(payload: GlobalFixtureTeardownRequest) {
+    // TODO: implement something smart?
+    // For now, we teardown all global fixtures at the very end.
+  }
+
+  async teardown() {
+    // TODO: handle timeout here.
+    await this._runner.teardownScope('global');
+  }
+}
+
+export class GlobalFixtureResolver extends EventEmitter {
+  private _setupPromises = new Map<string, ManualPromise<any>>();
+
+  async resolve(registration: FixtureRegistration, use: (value: any) => Promise<unknown>): Promise<any> {
+    const id = globalFixtureId(registration);
+    const setupPromise = new ManualPromise<any>();
+    this._setupPromises.set(id, setupPromise);
+    const setupRequest: GlobalFixtureSetupRequest = { id };
+    this.emit('globalFixtureSetupRequest', setupRequest);
+    const value = await setupPromise;
+    this._setupPromises.delete(id);
+    await use(value);
+    const teardownRequest: GlobalFixtureTeardownRequest = { id };
+    this.emit('globalFixtureTeardownRequest', teardownRequest);
+  }
+
+  globalFixtureSetupResponse(response: GlobalFixtureSetupResponse) {
+    const promise = this._setupPromises.get(response.id);
+    if (!promise)
+      return;
+    if (response.error) {
+      if ('value' in response.error) {
+        promise.reject(response.error.value as any);
+      } else {
+        const e = new Error(response.error.message || '');
+        e.stack = response.error.stack;
+        promise.reject(e);
+      }
+    } else {
+      promise.resolve(JSON.parse(response.stringifiedValue!));
+    }
+  }
+}
+
+const dummyProject: FullProject = {
+  expect: {},
+  outputDir: '',
+  repeatEach: 1,
+  retries: 0,
+  metadata: undefined,
+  name: '',
+  testDir: '',
+  snapshotDir: '',
+  testIgnore: [],
+  testMatch: '',
+  timeout: 0,
+  use: {},
+};

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -38,8 +38,8 @@ type WorkerFixtures = PlaywrightWorkerArgs & PlaywrightWorkerOptions & {
 };
 
 export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
-  defaultBrowserType: [ 'chromium', { scope: 'worker', option: true } ],
-  browserName: [ ({ defaultBrowserType }, use) => use(defaultBrowserType), { scope: 'worker', option: true } ],
+  defaultBrowserType: [ 'chromium', { scope: 'global' as any, option: true } ],
+  browserName: [ ({ defaultBrowserType }, use) => use(defaultBrowserType), { scope: 'global' as any, option: true } ],
   playwright: [async ({}, use, workerInfo) => {
     if (process.env.PW_GRID) {
       const gridClient = await GridClient.connect(process.env.PW_GRID);

--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -95,6 +95,3 @@ export type GlobalFixtureSetupResponse = {
   stringifiedValue?: string;
 };
 
-export type GlobalFixtureTeardownRequest = {
-  id: string;
-};

--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -84,3 +84,17 @@ export type TestOutputPayload = {
   text?: string;
   buffer?: string;
 };
+
+export type GlobalFixtureSetupRequest = {
+  id: string;
+};
+
+export type GlobalFixtureSetupResponse = {
+  id: string;
+  error?: TestError;
+  stringifiedValue?: string;
+};
+
+export type GlobalFixtureTeardownRequest = {
+  id: string;
+};

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -174,7 +174,7 @@ export class Loader {
     if (!path.isAbsolute(snapshotDir))
       snapshotDir = path.resolve(configDir, snapshotDir);
     const fullProject: FullProject = {
-      expect: takeFirst(this._configOverrides.expect, projectConfig.expect, this._config.expect, undefined),
+      expect: takeFirst(this._configOverrides.expect, projectConfig.expect, this._config.expect, {}),
       outputDir,
       repeatEach: takeFirst(this._configOverrides.repeatEach, projectConfig.repeatEach, this._config.repeatEach, 1),
       retries: takeFirst(this._configOverrides.retries, projectConfig.retries, this._config.retries, 0),

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -45,7 +45,6 @@ export class WorkerRunner extends EventEmitter {
   private _projectNamePathSegment = '';
   private _uniqueProjectNamePathSegment = '';
   private _fixtureRunner: FixtureRunner;
-  readonly globalFixtureResolver: GlobalFixtureResolver;
 
   private _failedTest: TestData | undefined;
   private _fatalError: TestError | undefined;
@@ -55,12 +54,11 @@ export class WorkerRunner extends EventEmitter {
   private _currentDeadlineRunner: DeadlineRunner<any> | undefined;
   _currentTest: TestData | null = null;
 
-  constructor(params: WorkerInitParams) {
+  constructor(params: WorkerInitParams, globalFixtureResolver: GlobalFixtureResolver) {
     super();
     this._params = params;
     this._fixtureRunner = new FixtureRunner();
-    this.globalFixtureResolver = new GlobalFixtureResolver();
-    this._fixtureRunner.globalFixtureResolver = (registration, use) => this.globalFixtureResolver.resolve(registration, use);
+    this._fixtureRunner.globalFixtureSetup = globalFixtureResolver.setup.bind(globalFixtureResolver);
   }
 
   stop(): Promise<void> {

--- a/tests/playwright-test/fixture-errors.spec.ts
+++ b/tests/playwright-test/fixture-errors.spec.ts
@@ -194,7 +194,7 @@ test('should throw when worker fixture depends on a test fixture', async ({ runI
       test('works', async ({bar}) => {});
     `,
   });
-  expect(result.output).toContain('Worker fixture "bar" cannot depend on a test fixture "foo".');
+  expect(result.output).toContain('worker fixture "bar" cannot depend on a test fixture "foo".');
   expect(result.output).toContain(`f.spec.ts:5`);
   expect(result.exitCode).toBe(1);
 });
@@ -302,7 +302,7 @@ test('should throw when overridden worker fixture depends on a test fixture', as
       test2('works', async ({bar}) => {});
     `,
   });
-  expect(result.output).toContain('Worker fixture "bar" cannot depend on a test fixture "foo".');
+  expect(result.output).toContain('worker fixture "bar" cannot depend on a test fixture "foo".');
   expect(result.exitCode).toBe(1);
 });
 

--- a/tests/playwright-test/global-fixtures.spec.ts
+++ b/tests/playwright-test/global-fixtures.spec.ts
@@ -1,0 +1,437 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './playwright-test-fixtures';
+
+test('global fixtures should work', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'helper.js': `
+      const { test } = pwt;
+
+      const base = test.extend({
+        globalBase: [ async ({}, use) => {
+          console.log('\\n%%globalBase setup');
+          await use('globalBase');
+          console.log('\\n%%globalBase teardown');
+        }, { scope: 'global' }],
+      });
+
+      const test1 = base.extend({
+        global1: [ async ({ globalBase }, use) => {
+          console.log('\\n%%global1 setup');
+          await use(globalBase + '-global1');
+          console.log('\\n%%global1 teardown');
+        }, { scope: 'global' }],
+
+        global2: [ async ({ global1 }, use) => {
+          console.log('\\n%%global2 setup');
+          await use(global1 + '-global2');
+          console.log('\\n%%global2 teardown');
+        }, { scope: 'global' }],
+      }).extend({
+        global1: async ({ global1 }, use) => {
+          console.log('\\n%%global1 override setup');
+          await use(global1 + '-override1');
+          console.log('\\n%%global1 override teardown');
+        },
+      });
+
+      const test2 = base.extend({
+        global1: [ async ({ globalBase }, use) => {
+          console.log('\\n%%anotherglobal1 setup');
+          await use(globalBase + '-another1');
+          console.log('\\n%%anotherglobal1 teardown');
+        }, { scope: 'global' }],
+
+        global2: [ async ({ global1 }, use) => {
+          console.log('\\n%%anotherglobal2 setup');
+          await use(global1 + '-another2');
+          console.log('\\n%%anotherglobal2 teardown');
+        }, { scope: 'global' }],
+      }).extend({
+        global1: async ({ global1 }, use) => {
+          console.log('\\n%%anotherglobal1 override setup');
+          await use(global1 + '-anotheroverride1');
+          console.log('\\n%%anotherglobal1 override teardown');
+        },
+      });
+
+      module.exports = { test1, test2 };
+    `,
+    'a.test.ts': `
+      import { test1, test2 } from './helper';
+
+      test1('test1a', async ({ global1, global2 }) => {
+        console.log('\\n%%test1a;' + global1 + ';' + global2);
+      });
+      test1('test2a', async ({ global2, global1 }) => {
+        console.log('\\n%%test2a;' + global1 + ';' + global2);
+      });
+      test2('test3a', async ({ global1, global2 }) => {
+        console.log('\\n%%test3a;' + global1 + ';' + global2);
+      });
+    `,
+    'b.test.ts': `
+      import { test1, test2 } from './helper';
+
+      test1('test1b', async ({ global1, global2 }) => {
+        console.log('\\n%%test1b;' + global1 + ';' + global2);
+      });
+      test1('test2b', async ({ global2, global1 }) => {
+        console.log('\\n%%test2b;' + global1 + ';' + global2);
+      });
+      test2('test3b', async ({ global1, global2 }) => {
+        console.log('\\n%%test3b;' + global1 + ';' + global2);
+      });
+    `,
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.output.split('\n').filter(line => line.startsWith('%%'))).toEqual([
+    '%%globalBase setup',
+    '%%global1 setup',
+    '%%global1 override setup',
+    '%%global2 setup',
+    '%%test1a;globalBase-global1-override1;globalBase-global1-override1-global2',
+    '%%test2a;globalBase-global1-override1;globalBase-global1-override1-global2',
+    '%%test1b;globalBase-global1-override1;globalBase-global1-override1-global2',
+    '%%test2b;globalBase-global1-override1;globalBase-global1-override1-global2',
+    '%%anotherglobal1 setup',
+    '%%anotherglobal1 override setup',
+    '%%anotherglobal2 setup',
+    '%%test3a;globalBase-another1-anotheroverride1;globalBase-another1-anotheroverride1-another2',
+    '%%test3b;globalBase-another1-anotheroverride1;globalBase-another1-anotheroverride1-another2',
+    '%%anotherglobal2 teardown',
+    '%%anotherglobal1 override teardown',
+    '%%anotherglobal1 teardown',
+    '%%global2 teardown',
+    '%%global1 override teardown',
+    '%%global1 teardown',
+    '%%globalBase teardown',
+  ]);
+});
+
+test('global fixture teardown error should fail test run', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const test = pwt.test.extend({
+        globalBase: [ async ({}, use) => {
+          console.log('\\n%%globalBase setup');
+          await use('globalBase');
+          console.log('\\n%%globalBase teardown');
+          throw new Error('oh my');
+        }, { scope: 'global' }],
+      });
+
+      test('test', async ({ globalBase }) => {
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Error: oh my');
+});
+
+test('global fixture should be shared between projects and provide dummy workerInfo', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.js': `
+      module.exports = {
+        projects: [
+          { name: 'foo' },
+          { name: 'bar' },
+        ],
+      };
+    `,
+    'a.spec.js': `
+      const test = pwt.test.extend({
+        globalBase: [ async ({}, use, workerInfo) => {
+          console.log('\\n%%globalBase setup in project=' + workerInfo.project.name + ' wi=' + workerInfo.workerIndex + ' pi=' + workerInfo.parallelIndex);
+          await use('globalBase');
+        }, { scope: 'global' }],
+      });
+
+      test('test', async ({ globalBase }, testInfo) => {
+        console.log('\\n%%test: ' + globalBase + ' in project=' + testInfo.project.name);
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.output.split('\n').filter(line => line.startsWith('%%'))).toEqual([
+    '%%globalBase setup in project= wi=-1 pi=-1',
+    '%%test: globalBase in project=foo',
+    '%%test: globalBase in project=bar',
+  ]);
+});
+
+test('global option is not allowed', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const test = pwt.test.extend({
+        opt: [ 'opt', { scope: 'global', option: true }],
+      });
+
+      test('test', async ({ opt }, testInfo) => {
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toMatch(/Error: Global options are not supported.\n\s+"opt" defined at a.spec.js:5:29/);
+});
+
+test('global fixture cannot depend on worker fixture', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const test = pwt.test.extend({
+        worker: [ 'worker', { scope: 'worker' }],
+        global: [ async ({ worker }, use) => {
+          await use(worker);
+        }, { scope: 'global' }],
+      });
+
+      test('test', async ({ global }) => {
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Error: global fixture "global" cannot depend on a worker fixture "worker".');
+});
+
+test('global fixture cannot depend on test fixture', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const test = pwt.test.extend({
+        test: [ 'test', { scope: 'test' }],
+        global: [ async ({ test }, use) => {
+          await use(test);
+        }, { scope: 'global' }],
+      });
+
+      test('test', async ({ global }) => {
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Error: global fixture "global" cannot depend on a test fixture "test".');
+});
+
+test('test and worker fixtures can depend on global fixture', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const test = pwt.test.extend({
+        global: [ 'global', { scope: 'global' }],
+        test: [ ({ global }, use) => use(global + '-test'), { scope: 'test' }],
+        worker: [ ({ global }, use) => use(global + '-worker'), { scope: 'worker' }],
+      });
+
+      test('my test', async ({ global, test, worker }) => {
+        expect(global).toBe('global');
+        expect(test).toBe('global-test');
+        expect(worker).toBe('global-worker');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+});
+
+test('can use global fixture in skips', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const test = pwt.test.extend({
+        global: [ true, { scope: 'global' }],
+      });
+
+      test.skip(({ global }) => !!global);
+
+      test('skipped', async ({ global }) => {
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.skipped).toBe(1);
+});
+
+test('cannot test.use a global fixture inside describe', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const test = pwt.test.extend({
+        global: [ 'global', { scope: 'global' } ],
+      });
+
+      test.describe('suite', () => {
+        test.use({ global: 'foo' });
+
+        test('my test', async ({ global }) => {
+        });
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Error: Cannot use({ global }) in a describe group, because it forces a new worker.');
+});
+
+test('global fixture throw gets into the worker', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'helper.js': `
+      module.exports = pwt.test.extend({
+        global: [ () => {
+          console.log('global fixture setup');
+          throw new Error('Oh my!');
+        }, { scope: 'global' } ],
+      });
+    `,
+    'a.spec.js': `
+      const test = require('./helper');
+      test('test1', async ({ global }) => {
+        console.log('running test1');
+      });
+    `,
+    'b.spec.js': `
+      const test = require('./helper');
+      test('passed', async () => {
+        await new Promise(f => setTimeout(f, 1000));
+        console.log('finished passed');
+      });
+      test('test2', async ({ global }) => {
+        console.log('running test2');
+      });
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(2);
+  expect(result.output).toContain('global fixture setup');
+  expect(result.output).toContain('finished passed');
+  expect(result.output).toContain('Error: Oh my!');
+});
+
+test('should throw for non-stringifiable values', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const test = pwt.test.extend({
+        global: [ ({}, use) => use(process), { scope: 'global' } ],
+      });
+
+      test('my test', async ({ global }) => {
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toMatch(/The value of the global fixture "global" cannot be serialized:\n\s+TypeError: Converting circular structure to JSON/);
+});
+
+test('should throw for function values', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const test = pwt.test.extend({
+        global: [ ({}, use) => use(process.addListener), { scope: 'global' } ],
+      });
+
+      test('my test', async ({ global }) => {
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('The value of the global fixture "global" cannot be serialized.');
+});
+
+test('can use global fixture in hook but not test', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      const test = pwt.test.extend({
+        global: [ 'foo', { scope: 'global' }],
+      });
+
+      test.beforeAll(({ global }) => {
+        console.log('beforeAll ' + global);
+      });
+
+      test('my test', async () => {
+        console.log('my test');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.output).toContain('beforeAll foo');
+  expect(result.output).toContain('my test');
+});
+
+test('auto global fixtures run for filtered tests only', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      pwt.test.extend({
+        global: [ ({}, use) => {
+          console.log('global1 setup');
+          use('global1');
+        }, { scope: 'global' }],
+        auto: [ ({}, use) => {
+          console.log('auto1 setup');
+          use('auto1');
+        }, { scope: 'global', auto: true }],
+      })('test1', ({ global }) => {
+        console.log('test1-' + global);
+      });
+
+      pwt.test.extend({
+        global: [ ({}, use) => {
+          console.log('global2 setup');
+          use('global2');
+        }, { scope: 'global' }],
+        auto: [ ({}, use) => {
+          console.log('auto2 setup');
+          use('auto2');
+        }, { scope: 'global', auto: true }],
+      }).only('test2', ({ global }) => {
+        console.log('test2-' + global);
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.output).toContain('auto2 setup');
+  expect(result.output).toContain('global2 setup');
+  expect(result.output).toContain('test2-global2');
+});
+
+test('global fixtures should work concurrently', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'helper.js': `
+      module.exports = pwt.test.extend({
+        global: [ async ({}, use) => {
+          console.log('\\n%%global fixture setup');
+          await new Promise(f => setTimeout(f, 3000));
+          console.log('\\n%%global fixture setup done');
+          use('value');
+        }, { scope: 'global' } ],
+      });
+    `,
+    'a.spec.js': `
+      const test = require('./helper');
+      test('test1', async ({ global }) => {
+        console.log('running test1');
+      });
+    `,
+    'b.spec.js': `
+      const test = require('./helper');
+      test('test2', async ({ global }) => {
+        console.log('running test2');
+      });
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+  expect(result.output).toContain('global fixture setup');
+  expect(result.output).toContain('global fixture setup done');
+  expect(result.output).toContain('running test1');
+  expect(result.output).toContain('running test2');
+});


### PR DESCRIPTION
Global fixtures have a `'global'` scope:
- Run in the runner process, resulting value is serialized to worker processes.
- Set up lazily, upon the first use.
- Torn down at the end.
- Everything else is similar to other fixtures.

This change contains implementation, no types or documentation yet.