### PR TITLE
fix(test runner): allow multiple missing snapshots per test

### DIFF
--- a/packages/playwright-test/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright-test/src/matchers/toMatchSnapshot.ts
@@ -51,8 +51,7 @@ export function toMatchSnapshot(this: ReturnType<Expect['getState']>, received: 
   const { pass, message, expectedPath, actualPath, diffPath, mimeType } = compare(
       received,
       pathSegments,
-      testInfo.snapshotPath,
-      testInfo.outputPath,
+      testInfo,
       updateSnapshots,
       withNegateComparison,
       options


### PR DESCRIPTION
Instead of failing right away, continue test execution but mark the test as failed.

Fixes #10536.