### PR TITLE
chore: use curl instead of wget when installing stable channels

### DIFF
--- a/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
@@ -19,13 +19,13 @@ if dpkg --get-selections | grep -q "^google-chrome-beta[[:space:]]*install$" >/d
   $maybesudo apt-get remove -y google-chrome-beta
 fi
 
-if ! command -v wget >/dev/null; then
-  $maybesudo apt-get install -y wget
+if ! command -v curl >/dev/null; then
+  $maybesudo apt-get install -y curl
 fi
 
 # 2. download chrome beta from dl.google.com and install it.
 cd /tmp
-wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
+curl -O https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
 $maybesudo apt-get install -y ./google-chrome-beta_current_amd64.deb
 rm -rf ./google-chrome-beta_current_amd64.deb
 cd -

--- a/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
@@ -20,13 +20,13 @@ if dpkg --get-selections | grep -q "^google-chrome[[:space:]]*install$" >/dev/nu
   $maybesudo apt-get remove -y google-chrome
 fi
 
-if ! command -v wget >/dev/null; then
-  $maybesudo apt-get install -y wget
+if ! command -v curl >/dev/null; then
+  $maybesudo apt-get install -y curl
 fi
 
 # 2. download chrome stable from dl.google.com and install it.
 cd /tmp
-wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 $maybesudo apt-get install -y ./google-chrome-stable_current_amd64.deb
 rm -rf ./google-chrome-stable_current_amd64.deb
 cd -


### PR DESCRIPTION
0936ce2bbd23dc998ad44fd83ad1134cf298f6b9 was for fixing the previous users who are using the `:focal` tag, since 1.16.X and 1.15.X still uses wget. This got manually repushed already.

This PR is the first PR for simplifying the install process by using `cURL` instead of `wget`, since we use `cURL` in other places already and it's more common. 

Relates #10615