### PR TITLE
chore: fix installing of branded browsers under non-root

### DIFF
--- a/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
@@ -7,26 +7,23 @@ if [[ $(arch) == "aarch64" ]]; then
   exit 1
 fi
 
-is_user_root () { [ "${EUID:-$(id -u)}" -eq 0 ]; }
-if is_user_root; then
-  maybesudo=""
-else
-  maybesudo="sudo"
-fi
-
 # 1. make sure to remove old beta if any.
 if dpkg --get-selections | grep -q "^google-chrome-beta[[:space:]]*install$" >/dev/null; then
-  $maybesudo apt-get remove -y google-chrome-beta
+  apt-get remove -y google-chrome-beta
 fi
 
+# 2. Update apt lists (needed to install curl and chrome dependencies)
+apt-get update
+
+# 3. Install curl to download chrome
 if ! command -v curl >/dev/null; then
-  $maybesudo apt-get install -y curl
+  apt-get install -y curl
 fi
 
-# 2. download chrome beta from dl.google.com and install it.
+# 4. download chrome beta from dl.google.com and install it.
 cd /tmp
 curl -O https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
-$maybesudo apt-get install -y ./google-chrome-beta_current_amd64.deb
+apt-get install -y ./google-chrome-beta_current_amd64.deb
 rm -rf ./google-chrome-beta_current_amd64.deb
 cd -
 google-chrome-beta --version

--- a/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
@@ -7,27 +7,23 @@ if [[ $(arch) == "aarch64" ]]; then
   exit 1
 fi
 
-is_user_root () { [ "${EUID:-$(id -u)}" -eq 0 ]; }
-if is_user_root; then
-  maybesudo=""
-else
-  maybesudo="sudo"
-fi
-
-
 # 1. make sure to remove old stable if any.
 if dpkg --get-selections | grep -q "^google-chrome[[:space:]]*install$" >/dev/null; then
-  $maybesudo apt-get remove -y google-chrome
+  apt-get remove -y google-chrome
 fi
 
+# 2. Update apt lists (needed to install curl and chrome dependencies)
+apt-get update
+
+# 3. Install curl to download chrome
 if ! command -v curl >/dev/null; then
-  $maybesudo apt-get install -y curl
+  apt-get install -y curl
 fi
 
-# 2. download chrome stable from dl.google.com and install it.
+# 4. download chrome stable from dl.google.com and install it.
 cd /tmp
 curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-$maybesudo apt-get install -y ./google-chrome-stable_current_amd64.deb
+apt-get install -y ./google-chrome-stable_current_amd64.deb
 rm -rf ./google-chrome-stable_current_amd64.deb
 cd -
 google-chrome --version

--- a/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
@@ -8,25 +8,22 @@ if [[ $(arch) == "aarch64" ]]; then
   exit 1
 fi
 
-is_user_root () { [ "${EUID:-$(id -u)}" -eq 0 ]; }
-if is_user_root; then
-  maybesudo=""
-else
-  maybesudo="sudo"
-fi
-
+# 1. make sure to remove old beta if any.
 if dpkg --get-selections | grep -q "^microsoft-edge-beta[[:space:]]*install$" >/dev/null; then
-  $maybesudo apt-get remove -y microsoft-edge-beta
+  apt-get remove -y microsoft-edge-beta
 fi
 
+# 2. Install curl to download Microsoft gpg key
 if ! command -v curl >/dev/null; then
-  $maybesudo apt-get install -y curl
+  apt-get update
+  apt-get install -y curl
 fi
 
+# 3. Add the GPG key, the apt repo, update the apt cache, and install the package
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
-$maybesudo install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
-$maybesudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'
+install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
+sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'
 rm /tmp/microsoft.gpg
-$maybesudo apt-get update && $maybesudo apt-get install -y microsoft-edge-beta
+apt-get update && apt-get install -y microsoft-edge-beta
 
 microsoft-edge-beta --version

--- a/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
@@ -8,25 +8,22 @@ if [[ $(arch) == "aarch64" ]]; then
   exit 1
 fi
 
-is_user_root () { [ "${EUID:-$(id -u)}" -eq 0 ]; }
-if is_user_root; then
-  maybesudo=""
-else
-  maybesudo="sudo"
-fi
-
+# 1. make sure to remove old dev if any.
 if dpkg --get-selections | grep -q "^microsoft-edge-dev[[:space:]]*install$" >/dev/null; then
-  $maybesudo apt-get remove -y microsoft-edge-dev
+  apt-get remove -y microsoft-edge-dev
 fi
 
+# 2. Install curl to download Microsoft gpg key
 if ! command -v curl >/dev/null; then
-  $maybesudo apt-get install -y curl
+  apt-get update
+  apt-get install -y curl
 fi
 
+# 3. Add the GPG key, the apt repo, update the apt cache, and install the package
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
-$maybesudo install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
-$maybesudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'
+install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
+sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'
 rm /tmp/microsoft.gpg
-$maybesudo apt-get update && $maybesudo apt-get install -y microsoft-edge-dev
+apt-get update && apt-get install -y microsoft-edge-dev
 
 microsoft-edge-dev --version

--- a/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
@@ -8,25 +8,22 @@ if [[ $(arch) == "aarch64" ]]; then
   exit 1
 fi
 
-is_user_root () { [ "${EUID:-$(id -u)}" -eq 0 ]; }
-if is_user_root; then
-  maybesudo=""
-else
-  maybesudo="sudo"
-fi
-
+# 1. make sure to remove old stable if any.
 if dpkg --get-selections | grep -q "^microsoft-edge-stable[[:space:]]*install$" >/dev/null; then
-  $maybesudo apt-get remove -y microsoft-edge-stable
+  apt-get remove -y microsoft-edge-stable
 fi
 
+# 2. Install curl to download Microsoft gpg key
 if ! command -v curl >/dev/null; then
-  $maybesudo apt-get install -y curl
+  apt-get update
+  apt-get install -y curl
 fi
 
+# 3. Add the GPG key, the apt repo, update the apt cache, and install the package
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
-$maybesudo install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
-$maybesudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-stable.list'
+install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
+sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-stable.list'
 rm /tmp/microsoft.gpg
-$maybesudo apt-get update && $maybesudo apt-get install -y microsoft-edge-stable
+apt-get update && apt-get install -y microsoft-edge-stable
 
 microsoft-edge-stable --version


### PR DESCRIPTION
Before the determination, if we should run a certain command under `root` or not was done in multiple places. Inside the channel install scripts, we had a fallback to `sudo` when we were not under root, but there is not always sudo. For example inside our Docker image, we don't have sudo.

This change does centralise this check, so that the actual install.sh script runs already with elevated permissions, since we always modify the system and removes the manual `maybesudo` checks inside the scripts.

Tested under the following scenarios:

1. root user
2. non-root which has sudo available
3. non-root which has no sudo available

Fixes #10615
Should fix the broken CI in https://github.com/microsoft/playwright/pull/10617 as well