### PR TITLE
docs: replace TestCase.suite with TestCase.parent

### DIFF
--- a/docs/src/test-reporter-api/class-testcase.md
+++ b/docs/src/test-reporter-api/class-testcase.md
@@ -41,6 +41,11 @@ Testing outcome for this test. Note that outcome is not the same as [`property: 
 * Test that is expected to fail and actually fails is `'expected'`.
 * Test that passes on a second retry is `'flaky'`.
 
+## property: TestCase.parent
+- type: <[Suite]>
+
+Suite this test case belongs to.
+
 ## property: TestCase.results
 - type: <[Array]<[TestResult]>>
 
@@ -52,11 +57,6 @@ Results for each run of this test.
 The maximum number of retries given to this test in the configuration.
 
 Learn more about [test retries](./test-retries.md#retries).
-
-## property: TestCase.suite
-- type: <[Suite]>
-
-Suite this test case belongs to.
 
 ## property: TestCase.timeout
 - type: <[float]>

--- a/packages/playwright-test/types/testReporter.d.ts
+++ b/packages/playwright-test/types/testReporter.d.ts
@@ -106,6 +106,9 @@ export interface Suite {
  * or repeated multiple times, it will have multiple `TestCase` objects in corresponding projects' suites.
  */
 export interface TestCase {
+  /**
+   * Suite this test case belongs to.
+   */
   parent: Suite;
   /**
    * Test title as passed to the [test.(call)(title, testFunction)](https://playwright.dev/docs/api/class-test#test-call)


### PR DESCRIPTION
It is there by mistake.

Fixes #10677.