### PR TITLE
test(mouse): add a test for pointerdown event with custom button

### DIFF
--- a/packages/playwright-core/src/server/webkit/wkInput.ts
+++ b/packages/playwright-core/src/server/webkit/wkInput.ts
@@ -40,9 +40,9 @@ function toButtonsMask(buttons: Set<types.MouseButton>): number {
   let mask = 0;
   if (buttons.has('left'))
     mask |= 1;
-  if (buttons.has('middle'))
-    mask |= 2;
   if (buttons.has('right'))
+    mask |= 2;
+  if (buttons.has('middle'))
     mask |= 4;
   return mask;
 }

--- a/tests/page/page-mouse.spec.ts
+++ b/tests/page/page-mouse.spec.ts
@@ -78,6 +78,38 @@ it('should dblclick the div', async ({ page, server }) => {
   expect(event.button).toBe(0);
 });
 
+it('should pointerdown the div with a custom button', async ({ page, server, browserName }) => {
+  await page.setContent(`<div style='width: 100px; height: 100px;'>Click me</div>`);
+  await page.evaluate(() => {
+    window['pointerdownPromise'] = new Promise(resolve => {
+      document.querySelector('div').addEventListener('pointerdown', event => {
+        resolve({
+          type: event.type,
+          detail: event.detail,
+          clientX: event.clientX,
+          clientY: event.clientY,
+          isTrusted: event.isTrusted,
+          button: event.button,
+          buttons: event.buttons,
+          pointerId: event.pointerId,
+        });
+      });
+    });
+  });
+  await page.mouse.click(50, 60, {
+    button: 'middle'
+  });
+  const event = await page.evaluate(() => window['pointerdownPromise']);
+  expect(event.type).toBe('pointerdown');
+  expect(event.detail).toBe(browserName === 'webkit' ? 1 : 0);
+  expect(event.clientX).toBe(50);
+  expect(event.clientY).toBe(60);
+  expect(event.isTrusted).toBe(true);
+  expect(event.button).toBe(1);
+  expect(event.buttons).toBe(4);
+  expect(event.pointerId).toBe(browserName === 'firefox' ? 0 : 1);
+});
+
 it('should select the text with mouse', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.focus('textarea');


### PR DESCRIPTION
I was comparing my adjustments to [`cypress-real-events`](https://github.com/dmtrKovalenko/cypress-real-events/) with the code in Playwright. My code was not working correctly so I've gone here to check if the same thing works with Playwright - I've written this test and verified that it works in Playwright. This has allowed me to finally find a silly, silly mistake in my code.

I've noticed that there was no `button: "someType"` test in this file and since I've already added that as part of my own investigation I've figured out that it's best to just submit it as a PR.