### PR TITLE
feat(mouse): set `.buttons` correctly for basic mouse commands in Chrome

### DIFF
--- a/packages/playwright-core/src/server/chromium/crInput.ts
+++ b/packages/playwright-core/src/server/chromium/crInput.ts
@@ -22,7 +22,7 @@ import { macEditingCommands } from '../macEditingCommands';
 import { isString } from '../../utils/utils';
 import { DragManager } from './crDragDrop';
 import { CRPage } from './crPage';
-import { toModifiersMask } from './crProtocolHelper';
+import { toButtonsMask, toModifiersMask } from './crProtocolHelper';
 
 export class RawKeyboardImpl implements input.RawKeyboard {
   constructor(
@@ -101,6 +101,7 @@ export class RawMouseImpl implements input.RawMouse {
       await this._client.send('Input.dispatchMouseEvent', {
         type: 'mouseMoved',
         button,
+        buttons: toButtonsMask(buttons),
         x,
         y,
         modifiers: toModifiersMask(modifiers)
@@ -120,6 +121,7 @@ export class RawMouseImpl implements input.RawMouse {
     await this._client.send('Input.dispatchMouseEvent', {
       type: 'mousePressed',
       button,
+      buttons: toButtonsMask(buttons),
       x,
       y,
       modifiers: toModifiersMask(modifiers),
@@ -135,6 +137,7 @@ export class RawMouseImpl implements input.RawMouse {
     await this._client.send('Input.dispatchMouseEvent', {
       type: 'mouseReleased',
       button,
+      buttons: toButtonsMask(buttons),
       x,
       y,
       modifiers: toModifiersMask(modifiers),

--- a/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
+++ b/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
@@ -102,3 +102,14 @@ export function toModifiersMask(modifiers: Set<types.KeyboardModifier>): number 
     mask |= 8;
   return mask;
 }
+
+export function toButtonsMask(buttons: Set<types.MouseButton>): number {
+  let mask = 0;
+  if (buttons.has('left'))
+    mask |= 1;
+  if (buttons.has('right'))
+    mask |= 2;
+  if (buttons.has('middle'))
+    mask |= 4;
+  return mask;
+}

--- a/tests/page/page-mouse.spec.ts
+++ b/tests/page/page-mouse.spec.ts
@@ -110,6 +110,44 @@ it('should pointerdown the div with a custom button', async ({ page, server, bro
   expect(event.pointerId).toBe(browserName === 'firefox' ? 0 : 1);
 });
 
+it('should mousedown the div with extra buttons', async ({ page, server }) => {
+  await page.setContent(
+      `<div style='width: 100px; height: 100px;'>Click me</div>`
+  );
+  await page.evaluate(() => {
+    window['mousedownPromise'] = new Promise(resolve => {
+      document.querySelector('div').addEventListener('mousedown', event => {
+        if (event.button !== 1 /* wheel button */) return;
+
+        resolve({
+          type: event.type,
+          detail: event.detail,
+          clientX: event.clientX,
+          clientY: event.clientY,
+          isTrusted: event.isTrusted,
+          button: event.button,
+          buttons: event.buttons,
+        });
+      });
+    });
+  });
+  await page.mouse.move(50, 60);
+  await page.mouse.down({
+    button: 'right',
+  });
+  await page.mouse.down({
+    button: 'middle',
+  });
+  const event = await page.evaluate(() => window['mousedownPromise']);
+  expect(event.type).toBe('mousedown');
+  expect(event.detail).toBe(1);
+  expect(event.clientX).toBe(50);
+  expect(event.clientY).toBe(60);
+  expect(event.isTrusted).toBe(true);
+  expect(event.button).toBe(1); // wheel button
+  expect(event.buttons).toBe(6); // right + middle button
+});
+
 it('should select the text with mouse', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.focus('textarea');

--- a/tests/page/page-mouse.spec.ts
+++ b/tests/page/page-mouse.spec.ts
@@ -118,7 +118,7 @@ it('should report correct buttons property', async ({ page }) => {
         type: event.type,
         button: event.button,
         buttons: event.buttons,
-      })
+      });
     };
     window.addEventListener('mousedown', handler, false);
     window.addEventListener('mouseup', handler, false);


### PR DESCRIPTION
While working on https://github.com/microsoft/playwright/pull/10697 I've noticed that this is not handled correctly in `crInput` because the `buttons` argument was completely ignored. I've figured out that I will just add this since the change is trivial and might spare somebody doing an investigation why this doesn't work in the future 😉 