### PR TITLE
fix: make APIRequest tracing work on node 16

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -248,9 +248,11 @@ export abstract class APIRequestContext extends SdkObject {
         const notifyRequestFinished = (body?: Buffer) => {
           const requestFinishedEvent: APIRequestFinishedEvent = {
             requestEvent,
-            statusCode: -1,
-            statusMessage: '',
-            ...response,
+            httpVersion: response.httpVersion,
+            statusCode: response.statusCode || 0,
+            statusMessage: response.statusMessage || '',
+            headers: response.headers,
+            rawHeaders: response.rawHeaders,
             cookies,
             body
           };


### PR DESCRIPTION
Starting with v15.1.0  'message.headers is now lazily computed using an accessor property on the prototype.' and spread operator on the response doesn't copy headers to the event which leads to the following error on Node 16 (see [this run](https://github.com/microsoft/playwright/runs/4411628246?check_suite_focus=true)):

```
    TypeError: Cannot read properties of undefined (reading 'location')

        at HarTracer._onAPIRequestFinished (/tmp/playwright/packages/playwright-core/lib/server/supplements/har/harTracer.js:163:51)
```

Copy all fields explicitly instead.


