### PR TITLE
feat(proxy): unify local network proxy behavior

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -277,6 +277,8 @@ export class Chromium extends BrowserType {
         proxyBypassRules.push('<-loopback>');
       if (proxy.bypass)
         proxyBypassRules.push(...proxy.bypass.split(',').map(t => t.trim()).map(t => t.startsWith('.') ? '*' + t : t));
+      if (!process.env.PLAYWRIGHT_DISABLE_FORCED_CHROMIUM_PROXIED_LOOPBACK && !proxyBypassRules.includes('<-loopback>'))
+        proxyBypassRules.push('<-loopback>');
       if (proxyBypassRules.length > 0)
         chromeArguments.push(`--proxy-bypass-list=${proxyBypassRules.join(';')}`);
     }

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -90,10 +90,19 @@ export class CRBrowser extends Browser {
 
   async newContext(options: types.BrowserContextOptions): Promise<BrowserContext> {
     validateBrowserContextOptions(options, this.options);
+
+    let proxyBypassList = undefined;
+    if (options.proxy) {
+      if (process.env.PLAYWRIGHT_DISABLE_FORCED_CHROMIUM_PROXIED_LOOPBACK)
+        proxyBypassList = options.proxy.bypass;
+      else
+        proxyBypassList = '<-loopback>' + (options.proxy.bypass ? `,${options.proxy.bypass}` : '');
+    }
+
     const { browserContextId } = await this._session.send('Target.createBrowserContext', {
       disposeOnDetach: true,
       proxyServer: options.proxy ? options.proxy.server : undefined,
-      proxyBypassList: options.proxy ? options.proxy.bypass : undefined,
+      proxyBypassList,
     });
     const context = new CRBrowserContext(this, browserContextId, options);
     await context._initialize();

--- a/tests/browsercontext-proxy.spec.ts
+++ b/tests/browsercontext-proxy.spec.ts
@@ -91,93 +91,55 @@ it('should use proxy', async ({ contextFactory, server, proxyServer }) => {
   await context.close();
 });
 
-it.describe('should proxy local network requests', () => {
+it.describe.parallel('should proxy local network requests', () => {
   for (const additionalBypass of [false, true]) {
-    it.describe(additionalBypass ? 'with other bypasses' : 'by default', () => {
-      it('localhost', async ({ platform, browserName, contextFactory, server, proxyServer }) => {
-        it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass, 'WK fails to proxy localhost if additional bypasses are present');
+    it.describe.parallel(additionalBypass ? 'with other bypasses' : 'by default', () => {
+      for (const params of [
+        {
+          target: 'localhost',
+          description: 'localhost',
+        },
+        {
+          target: '127.0.0.1',
+          description: 'loopback address',
+        },
+        {
+          target: '169.254.3.4',
+          description: 'link-local'
+        }
+      ]) {
+        it(`${params.description}`, async ({ platform, browserName, contextFactory, server, proxyServer }) => {
+          it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
 
-        const path = `/target-${additionalBypass}-localhost.html`;
-        server.setRoute(path, async (req, res) => {
-          res.end('<html><title>Served by the proxy</title></html>');
+          const path = `/target-${additionalBypass}-${params.target}.html`;
+          server.setRoute(path, async (req, res) => {
+            res.end('<html><title>Served by the proxy</title></html>');
+          });
+
+          const url = `http://${params.target}:${server.PORT}${path}`;
+          proxyServer.forwardTo(server.PORT);
+          const context = await contextFactory({
+            proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
+          });
+
+          const page = await context.newPage();
+          await page.goto(url);
+          expect(proxyServer.requestUrls).toContain(url);
+          expect(await page.title()).toBe('Served by the proxy');
+
+          await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
+          if (additionalBypass)
+            expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
+          else
+            expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
+
+          await context.close();
         });
-
-        const url = `http://localhost:${server.PORT}${path}`;
-        proxyServer.forwardTo(server.PORT);
-        const context = await contextFactory({
-          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
-        });
-
-        const page = await context.newPage();
-        await page.goto(url);
-        expect(proxyServer.requestUrls).toContain(url);
-        expect(await page.title()).toBe('Served by the proxy');
-
-        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
-        if (additionalBypass)
-          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
-        else
-          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
-
-        await context.close();
-      });
-
-      it('loopback address', async ({ platform, browserName, contextFactory, server, proxyServer }) => {
-        it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass, 'WK fails to proxy 127.0.0.1 if additional bypasses are present');
-
-        const path = `/target-${additionalBypass}-127.0.0.1.html`;
-        server.setRoute(path, async (req, res) => {
-          res.end('<html><title>Served by the proxy</title></html>');
-        });
-
-        const url = `http://127.0.0.1:${server.PORT}${path}`;
-        proxyServer.forwardTo(server.PORT);
-        const context = await contextFactory({
-          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
-        });
-
-        const page = await context.newPage();
-        await page.goto(url);
-        expect(proxyServer.requestUrls).toContain(url);
-        expect(await page.title()).toBe('Served by the proxy');
-
-        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
-        if (additionalBypass)
-          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
-        else
-          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
-
-        await context.close();
-      });
-
-      it('link-local address', async ({ contextFactory, server, proxyServer }) => {
-        const path = `/target-${additionalBypass}-169.254.3.4.html`;
-        server.setRoute(path, async (req, res) => {
-          res.end('<html><title>Served by the proxy</title></html>');
-        });
-
-        const url = `http://169.254.3.4:${server.PORT}${path}`;
-        proxyServer.forwardTo(server.PORT);
-        const context = await contextFactory({
-          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
-        });
-
-        const page = await context.newPage();
-        await page.goto(url);
-        expect(proxyServer.requestUrls).toContain(url);
-        expect(await page.title()).toBe('Served by the proxy');
-
-        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
-        if (additionalBypass)
-          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
-        else
-          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
-
-        await context.close();
-      });
+      }
     });
   }
 });
+
 
 it('should use ipv6 proxy', async ({ contextFactory, server, proxyServer, browserName }) => {
   it.fail(browserName === 'firefox', 'page.goto: NS_ERROR_UNKNOWN_HOST');

--- a/tests/browsercontext-proxy.spec.ts
+++ b/tests/browsercontext-proxy.spec.ts
@@ -91,6 +91,42 @@ it('should use proxy', async ({ contextFactory, server, proxyServer }) => {
   await context.close();
 });
 
+it('should use proxy for localhost', async ({ contextFactory, server, proxyServer }) => {
+  proxyServer.forwardTo(server.PORT);
+  const context = await contextFactory({
+    proxy: { server: `localhost:${proxyServer.PORT}` }
+  });
+  const page = await context.newPage();
+  await page.goto(`http://localhost:${server.PORT}/target.html`);
+  expect(proxyServer.requestUrls).toContain(`http://localhost:${server.PORT}/target.html`);
+  expect(await page.title()).toBe('Served by the proxy');
+  await context.close();
+});
+
+it('should use proxy for loopback address', async ({ contextFactory, server, proxyServer }) => {
+  proxyServer.forwardTo(server.PORT);
+  const context = await contextFactory({
+    proxy: { server: `localhost:${proxyServer.PORT}` }
+  });
+  const page = await context.newPage();
+  await page.goto(`http://127.0.0.1:${server.PORT}/target.html`);
+  expect(proxyServer.requestUrls).toContain(`http://127.0.0.1:${server.PORT}/target.html`);
+  expect(await page.title()).toBe('Served by the proxy');
+  await context.close();
+});
+
+it('should use proxy for link-local address', async ({ contextFactory, server, proxyServer }) => {
+  proxyServer.forwardTo(server.PORT);
+  const context = await contextFactory({
+    proxy: { server: `localhost:${proxyServer.PORT}` }
+  });
+  const page = await context.newPage();
+  await page.goto(`http://169.254.3.4:4321/target.html`);
+  expect(proxyServer.requestUrls).toContain(`http://169.254.3.4:4321/target.html`);
+  expect(await page.title()).toBe('Served by the proxy');
+  await context.close();
+});
+
 it('should use ipv6 proxy', async ({ contextFactory, server, proxyServer, browserName }) => {
   it.fail(browserName === 'firefox', 'page.goto: NS_ERROR_UNKNOWN_HOST');
   it.fail(!!process.env.INSIDE_DOCKER, 'docker does not support IPv6 by default');

--- a/tests/browsercontext-proxy.spec.ts
+++ b/tests/browsercontext-proxy.spec.ts
@@ -91,9 +91,9 @@ it('should use proxy', async ({ contextFactory, server, proxyServer }) => {
   await context.close();
 });
 
-it.describe.parallel('should proxy local network requests', () => {
+it.describe('should proxy local network requests', () => {
   for (const additionalBypass of [false, true]) {
-    it.describe.parallel(additionalBypass ? 'with other bypasses' : 'by default', () => {
+    it.describe(additionalBypass ? 'with other bypasses' : 'by default', () => {
       for (const params of [
         {
           target: 'localhost',

--- a/tests/browsercontext-proxy.spec.ts
+++ b/tests/browsercontext-proxy.spec.ts
@@ -108,8 +108,8 @@ it.describe.parallel('should proxy local network requests', () => {
           description: 'link-local'
         }
       ]) {
-        it(`${params.description}`, async ({ browserName, contextFactory, server, proxyServer }) => {
-          it.fail(browserName === 'webkit' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
+        it(`${params.description}`, async ({ platform, browserName, contextFactory, server, proxyServer }) => {
+          it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
 
           const path = `/target-${additionalBypass}-${params.target}.html`;
           server.setRoute(path, async (req, res) => {

--- a/tests/browsercontext-proxy.spec.ts
+++ b/tests/browsercontext-proxy.spec.ts
@@ -91,55 +91,93 @@ it('should use proxy', async ({ contextFactory, server, proxyServer }) => {
   await context.close();
 });
 
-it.describe.parallel('should proxy local network requests', () => {
+it.describe('should proxy local network requests', () => {
   for (const additionalBypass of [false, true]) {
-    it.describe.parallel(additionalBypass ? 'with other bypasses' : 'by default', () => {
-      for (const params of [
-        {
-          target: 'localhost',
-          description: 'localhost',
-        },
-        {
-          target: '127.0.0.1',
-          description: 'loopback address',
-        },
-        {
-          target: '169.254.3.4',
-          description: 'link-local'
-        }
-      ]) {
-        it(`${params.description}`, async ({ platform, browserName, contextFactory, server, proxyServer }) => {
-          it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
+    it.describe(additionalBypass ? 'with other bypasses' : 'by default', () => {
+      it('localhost', async ({ platform, browserName, contextFactory, server, proxyServer }) => {
+        it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass, 'WK fails to proxy localhost if additional bypasses are present');
 
-          const path = `/target-${additionalBypass}-${params.target}.html`;
-          server.setRoute(path, async (req, res) => {
-            res.end('<html><title>Served by the proxy</title></html>');
-          });
-
-          const url = `http://${params.target}:${server.PORT}${path}`;
-          proxyServer.forwardTo(server.PORT);
-          const context = await contextFactory({
-            proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
-          });
-
-          const page = await context.newPage();
-          await page.goto(url);
-          expect(proxyServer.requestUrls).toContain(url);
-          expect(await page.title()).toBe('Served by the proxy');
-
-          await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
-          if (additionalBypass)
-            expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
-          else
-            expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
-
-          await context.close();
+        const path = `/target-${additionalBypass}-localhost.html`;
+        server.setRoute(path, async (req, res) => {
+          res.end('<html><title>Served by the proxy</title></html>');
         });
-      }
+
+        const url = `http://localhost:${server.PORT}${path}`;
+        proxyServer.forwardTo(server.PORT);
+        const context = await contextFactory({
+          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
+        });
+
+        const page = await context.newPage();
+        await page.goto(url);
+        expect(proxyServer.requestUrls).toContain(url);
+        expect(await page.title()).toBe('Served by the proxy');
+
+        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
+        if (additionalBypass)
+          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
+        else
+          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
+
+        await context.close();
+      });
+
+      it('loopback address', async ({ platform, browserName, contextFactory, server, proxyServer }) => {
+        it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass, 'WK fails to proxy 127.0.0.1 if additional bypasses are present');
+
+        const path = `/target-${additionalBypass}-127.0.0.1.html`;
+        server.setRoute(path, async (req, res) => {
+          res.end('<html><title>Served by the proxy</title></html>');
+        });
+
+        const url = `http://127.0.0.1:${server.PORT}${path}`;
+        proxyServer.forwardTo(server.PORT);
+        const context = await contextFactory({
+          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
+        });
+
+        const page = await context.newPage();
+        await page.goto(url);
+        expect(proxyServer.requestUrls).toContain(url);
+        expect(await page.title()).toBe('Served by the proxy');
+
+        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
+        if (additionalBypass)
+          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
+        else
+          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
+
+        await context.close();
+      });
+
+      it('link-local address', async ({ contextFactory, server, proxyServer }) => {
+        const path = `/target-${additionalBypass}-169.254.3.4.html`;
+        server.setRoute(path, async (req, res) => {
+          res.end('<html><title>Served by the proxy</title></html>');
+        });
+
+        const url = `http://169.254.3.4:${server.PORT}${path}`;
+        proxyServer.forwardTo(server.PORT);
+        const context = await contextFactory({
+          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
+        });
+
+        const page = await context.newPage();
+        await page.goto(url);
+        expect(proxyServer.requestUrls).toContain(url);
+        expect(await page.title()).toBe('Served by the proxy');
+
+        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
+        if (additionalBypass)
+          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
+        else
+          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
+
+        await context.close();
+      });
     });
   }
 });
-
 
 it('should use ipv6 proxy', async ({ contextFactory, server, proxyServer, browserName }) => {
   it.fail(browserName === 'firefox', 'page.goto: NS_ERROR_UNKNOWN_HOST');

--- a/tests/browsercontext-proxy.spec.ts
+++ b/tests/browsercontext-proxy.spec.ts
@@ -109,7 +109,7 @@ it.describe('should proxy local network requests', () => {
         }
       ]) {
         it(`${params.description}`, async ({ platform, browserName, contextFactory, server, proxyServer }) => {
-          it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
+          it.fail(browserName === 'webkit' && platform === 'darwin' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
 
           const path = `/target-${additionalBypass}-${params.target}.html`;
           server.setRoute(path, async (req, res) => {

--- a/tests/browsercontext-proxy.spec.ts
+++ b/tests/browsercontext-proxy.spec.ts
@@ -91,41 +91,55 @@ it('should use proxy', async ({ contextFactory, server, proxyServer }) => {
   await context.close();
 });
 
-it('should use proxy for localhost', async ({ contextFactory, server, proxyServer }) => {
-  proxyServer.forwardTo(server.PORT);
-  const context = await contextFactory({
-    proxy: { server: `localhost:${proxyServer.PORT}` }
-  });
-  const page = await context.newPage();
-  await page.goto(`http://localhost:${server.PORT}/target.html`);
-  expect(proxyServer.requestUrls).toContain(`http://localhost:${server.PORT}/target.html`);
-  expect(await page.title()).toBe('Served by the proxy');
-  await context.close();
+it.describe.parallel('should proxy local network requests', () => {
+  for (const additionalBypass of [false, true]) {
+    it.describe.parallel(additionalBypass ? 'with other bypasses' : 'by default', () => {
+      for (const params of [
+        {
+          target: 'localhost',
+          description: 'localhost',
+        },
+        {
+          target: '127.0.0.1',
+          description: 'loopback address',
+        },
+        {
+          target: '169.254.3.4',
+          description: 'link-local'
+        }
+      ]) {
+        it(`${params.description}`, async ({ browserName, contextFactory, server, proxyServer }) => {
+          it.fail(browserName === 'webkit' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
+
+          const path = `/target-${additionalBypass}-${params.target}.html`;
+          server.setRoute(path, async (req, res) => {
+            res.end('<html><title>Served by the proxy</title></html>');
+          });
+
+          const url = `http://${params.target}:${server.PORT}${path}`;
+          proxyServer.forwardTo(server.PORT);
+          const context = await contextFactory({
+            proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
+          });
+
+          const page = await context.newPage();
+          await page.goto(url);
+          expect(proxyServer.requestUrls).toContain(url);
+          expect(await page.title()).toBe('Served by the proxy');
+
+          await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
+          if (additionalBypass)
+            expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
+          else
+            expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
+
+          await context.close();
+        });
+      }
+    });
+  }
 });
 
-it('should use proxy for loopback address', async ({ contextFactory, server, proxyServer }) => {
-  proxyServer.forwardTo(server.PORT);
-  const context = await contextFactory({
-    proxy: { server: `localhost:${proxyServer.PORT}` }
-  });
-  const page = await context.newPage();
-  await page.goto(`http://127.0.0.1:${server.PORT}/target.html`);
-  expect(proxyServer.requestUrls).toContain(`http://127.0.0.1:${server.PORT}/target.html`);
-  expect(await page.title()).toBe('Served by the proxy');
-  await context.close();
-});
-
-it('should use proxy for link-local address', async ({ contextFactory, server, proxyServer }) => {
-  proxyServer.forwardTo(server.PORT);
-  const context = await contextFactory({
-    proxy: { server: `localhost:${proxyServer.PORT}` }
-  });
-  const page = await context.newPage();
-  await page.goto(`http://169.254.3.4:4321/target.html`);
-  expect(proxyServer.requestUrls).toContain(`http://169.254.3.4:4321/target.html`);
-  expect(await page.title()).toBe('Served by the proxy');
-  await context.close();
-});
 
 it('should use ipv6 proxy', async ({ contextFactory, server, proxyServer, browserName }) => {
   it.fail(browserName === 'firefox', 'page.goto: NS_ERROR_UNKNOWN_HOST');

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -59,6 +59,11 @@ export class TestProxy {
     });
     this._prependHandler('connect', (req: IncomingMessage) => {
       this.connectHosts.push(req.url);
+      // Relevant to FF only: skip re-writing this request since it requires
+      // better MITM'ing than the tests require. If you MITM this without setting
+      // up trusted certs, FF will crash on newPage() if using this Proxy Server.
+      if (req.url === 'contile.services.mozilla.com:443')
+        return;
       req.url = `localhost:${port}`;
     });
   }

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -73,9 +73,9 @@ it('should work with IP:PORT notion', async ({ browserType, server }) => {
   await browser.close();
 });
 
-it.describe.parallel('should proxy local network requests', () => {
+it.describe('should proxy local network requests', () => {
   for (const additionalBypass of [false, true]) {
-    it.describe.parallel(additionalBypass ? 'with other bypasses' : 'by default', () => {
+    it.describe(additionalBypass ? 'with other bypasses' : 'by default', () => {
       for (const params of [
         {
           target: 'localhost',

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -73,90 +73,51 @@ it('should work with IP:PORT notion', async ({ browserType, server }) => {
   await browser.close();
 });
 
-it.describe('should proxy local network requests', () => {
+it.describe.parallel('should proxy local network requests', () => {
   for (const additionalBypass of [false, true]) {
-    it.describe(additionalBypass ? 'with other bypasses' : 'by default', () => {
-      it('localhost', async ({ platform, browserName, browserType, server, proxyServer }) => {
-        it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass, 'WK fails to proxy localhost if additional bypasses are present');
+    it.describe.parallel(additionalBypass ? 'with other bypasses' : 'by default', () => {
+      for (const params of [
+        {
+          target: 'localhost',
+          description: 'localhost',
+        },
+        {
+          target: '127.0.0.1',
+          description: 'loopback address',
+        },
+        {
+          target: '169.254.3.4',
+          description: 'link-local'
+        }
+      ]) {
+        it(`${params.description}`, async ({ platform, browserName, browserType, server, proxyServer }) => {
+          it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
 
-        const path = `/target-${additionalBypass}-localhost.html`;
-        server.setRoute(path, async (req, res) => {
-          res.end('<html><title>Served by the proxy</title></html>');
+          const path = `/target-${additionalBypass}-${params.target}.html`;
+          server.setRoute(path, async (req, res) => {
+            res.end('<html><title>Served by the proxy</title></html>');
+          });
+
+          const url = `http://${params.target}:${server.PORT}${path}`;
+          proxyServer.forwardTo(server.PORT);
+          const browser = await browserType.launch({
+            proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
+          });
+
+          const page = await browser.newPage();
+          await page.goto(url);
+          expect(proxyServer.requestUrls).toContain(url);
+          expect(await page.title()).toBe('Served by the proxy');
+
+          await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
+          if (additionalBypass)
+            expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
+          else
+            expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
+
+          await browser.close();
         });
-
-        const url = `http://localhost:${server.PORT}${path}`;
-        proxyServer.forwardTo(server.PORT);
-        const browser = await browserType.launch({
-          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
-        });
-
-        const page = await browser.newPage();
-        await page.goto(url);
-        expect(proxyServer.requestUrls).toContain(url);
-        expect(await page.title()).toBe('Served by the proxy');
-
-        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
-        if (additionalBypass)
-          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
-        else
-          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
-
-        await browser.close();
-      });
-
-      it('loopback address', async ({ platform, browserName, browserType, server, proxyServer }) => {
-        it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass, 'WK fails to proxy 127.0.0.1 if additional bypasses are present');
-
-        const path = `/target-${additionalBypass}-127.0.0.1.html`;
-        server.setRoute(path, async (req, res) => {
-          res.end('<html><title>Served by the proxy</title></html>');
-        });
-
-        const url = `http://127.0.0.1:${server.PORT}${path}`;
-        proxyServer.forwardTo(server.PORT);
-        const browser = await browserType.launch({
-          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
-        });
-
-        const page = await browser.newPage();
-        await page.goto(url);
-        expect(proxyServer.requestUrls).toContain(url);
-        expect(await page.title()).toBe('Served by the proxy');
-
-        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
-        if (additionalBypass)
-          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
-        else
-          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
-
-        await browser.close();
-      });
-
-      it('link-local address', async ({ browserType, server, proxyServer }) => {
-        const path = `/target-${additionalBypass}-169.254.3.4.html`;
-        server.setRoute(path, async (req, res) => {
-          res.end('<html><title>Served by the proxy</title></html>');
-        });
-
-        const url = `http://169.254.3.4:${server.PORT}${path}`;
-        proxyServer.forwardTo(server.PORT);
-        const browser = await browserType.launch({
-          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
-        });
-
-        const page = await browser.newPage();
-        await page.goto(url);
-        expect(proxyServer.requestUrls).toContain(url);
-        expect(await page.title()).toBe('Served by the proxy');
-
-        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
-        if (additionalBypass)
-          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
-        else
-          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
-
-        await browser.close();
-      });
+      }
     });
   }
 });

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -73,51 +73,90 @@ it('should work with IP:PORT notion', async ({ browserType, server }) => {
   await browser.close();
 });
 
-it.describe.parallel('should proxy local network requests', () => {
+it.describe('should proxy local network requests', () => {
   for (const additionalBypass of [false, true]) {
-    it.describe.parallel(additionalBypass ? 'with other bypasses' : 'by default', () => {
-      for (const params of [
-        {
-          target: 'localhost',
-          description: 'localhost',
-        },
-        {
-          target: '127.0.0.1',
-          description: 'loopback address',
-        },
-        {
-          target: '169.254.3.4',
-          description: 'link-local'
-        }
-      ]) {
-        it(`${params.description}`, async ({ platform, browserName, browserType, server, proxyServer }) => {
-          it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
+    it.describe(additionalBypass ? 'with other bypasses' : 'by default', () => {
+      it('localhost', async ({ platform, browserName, browserType, server, proxyServer }) => {
+        it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass, 'WK fails to proxy localhost if additional bypasses are present');
 
-          const path = `/target-${additionalBypass}-${params.target}.html`;
-          server.setRoute(path, async (req, res) => {
-            res.end('<html><title>Served by the proxy</title></html>');
-          });
-
-          const url = `http://${params.target}:${server.PORT}${path}`;
-          proxyServer.forwardTo(server.PORT);
-          const browser = await browserType.launch({
-            proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
-          });
-
-          const page = await browser.newPage();
-          await page.goto(url);
-          expect(proxyServer.requestUrls).toContain(url);
-          expect(await page.title()).toBe('Served by the proxy');
-
-          await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
-          if (additionalBypass)
-            expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
-          else
-            expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
-
-          await browser.close();
+        const path = `/target-${additionalBypass}-localhost.html`;
+        server.setRoute(path, async (req, res) => {
+          res.end('<html><title>Served by the proxy</title></html>');
         });
-      }
+
+        const url = `http://localhost:${server.PORT}${path}`;
+        proxyServer.forwardTo(server.PORT);
+        const browser = await browserType.launch({
+          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
+        });
+
+        const page = await browser.newPage();
+        await page.goto(url);
+        expect(proxyServer.requestUrls).toContain(url);
+        expect(await page.title()).toBe('Served by the proxy');
+
+        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
+        if (additionalBypass)
+          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
+        else
+          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
+
+        await browser.close();
+      });
+
+      it('loopback address', async ({ platform, browserName, browserType, server, proxyServer }) => {
+        it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass, 'WK fails to proxy 127.0.0.1 if additional bypasses are present');
+
+        const path = `/target-${additionalBypass}-127.0.0.1.html`;
+        server.setRoute(path, async (req, res) => {
+          res.end('<html><title>Served by the proxy</title></html>');
+        });
+
+        const url = `http://127.0.0.1:${server.PORT}${path}`;
+        proxyServer.forwardTo(server.PORT);
+        const browser = await browserType.launch({
+          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
+        });
+
+        const page = await browser.newPage();
+        await page.goto(url);
+        expect(proxyServer.requestUrls).toContain(url);
+        expect(await page.title()).toBe('Served by the proxy');
+
+        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
+        if (additionalBypass)
+          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
+        else
+          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
+
+        await browser.close();
+      });
+
+      it('link-local address', async ({ browserType, server, proxyServer }) => {
+        const path = `/target-${additionalBypass}-169.254.3.4.html`;
+        server.setRoute(path, async (req, res) => {
+          res.end('<html><title>Served by the proxy</title></html>');
+        });
+
+        const url = `http://169.254.3.4:${server.PORT}${path}`;
+        proxyServer.forwardTo(server.PORT);
+        const browser = await browserType.launch({
+          proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
+        });
+
+        const page = await browser.newPage();
+        await page.goto(url);
+        expect(proxyServer.requestUrls).toContain(url);
+        expect(await page.title()).toBe('Served by the proxy');
+
+        await page.goto('http://1.non.existent.domain.for.the.test/foo.html').catch(() => {});
+        if (additionalBypass)
+          expect(proxyServer.requestUrls).not.toContain('http://1.non.existent.domain.for.the.test/foo.html');
+        else
+          expect(proxyServer.requestUrls).toContain('http://1.non.existent.domain.for.the.test/foo.html');
+
+        await browser.close();
+      });
     });
   }
 });

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -91,7 +91,7 @@ it.describe('should proxy local network requests', () => {
         }
       ]) {
         it(`${params.description}`, async ({ platform, browserName, browserType, server, proxyServer }) => {
-          it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
+          it.fail(browserName === 'webkit' && platform === 'darwin' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
 
           const path = `/target-${additionalBypass}-${params.target}.html`;
           server.setRoute(path, async (req, res) => {

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -90,8 +90,8 @@ it.describe.parallel('should proxy local network requests', () => {
           description: 'link-local'
         }
       ]) {
-        it(`${params.description}`, async ({ browserName, browserType, server, proxyServer }) => {
-          it.fail(browserName === 'webkit' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
+        it(`${params.description}`, async ({ platform, browserName, browserType, server, proxyServer }) => {
+          it.fail(platform !== 'linux' && browserName === 'webkit' && additionalBypass && ['localhost', '127.0.0.1'].includes(params.target), 'WK fails to proxy 127.0.0.1 and localhost if additional bypasses are present');
 
           const path = `/target-${additionalBypass}-${params.target}.html`;
           server.setRoute(path, async (req, res) => {

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -99,7 +99,7 @@ it.describe('should proxy local network requests', () => {
           });
 
           const url = `http://${params.target}:${server.PORT}${path}`;
-          proxyServer.forwardTo(server.PORT);
+          proxyServer.forwardTo(server.PORT, { skipConnectRequests: true });
           const browser = await browserType.launch({
             proxy: { server: `localhost:${proxyServer.PORT}`, bypass: additionalBypass ? '1.non.existent.domain.for.the.test' : undefined }
           });


### PR DESCRIPTION
When configuring a proxy, Chromium requires a magic tokens to get some
local network requests to go through the proxy. This has tripped up a
few users, so we make the behavior default to the expected: proxy
everything including the local requests. This matches the other vendors
as well.

NB: This can be disabled via
`PLAYWRIGHT_DISABLE_FORCED_CHROMIUM_PROXIED_LOOPBACK=1`

Supercedes: #8345
Fixes: #10631