### PR TITLE
fix: support shadow DOM with Vue and React selectors

### DIFF
--- a/packages/playwright-core/src/server/common/componentUtils.ts
+++ b/packages/playwright-core/src/server/common/componentUtils.ts
@@ -200,3 +200,13 @@ export function parseComponentSelector(selector: string): ParsedComponentSelecto
     throw new Error(`Error while parsing selector \`${selector}\` - selector cannot be empty`);
   return result;
 }
+
+export function isInsideScope(scope: Node, node: Node): boolean {
+  while (node) {
+    if (scope.contains(node))
+      return true;
+    node = node.parentNode || (node as ShadowRoot).host;
+  }
+  return false;
+}
+

--- a/packages/playwright-core/src/server/common/componentUtils.ts
+++ b/packages/playwright-core/src/server/common/componentUtils.ts
@@ -200,4 +200,3 @@ export function parseComponentSelector(selector: string): ParsedComponentSelecto
     throw new Error(`Error while parsing selector \`${selector}\` - selector cannot be empty`);
   return result;
 }
-

--- a/packages/playwright-core/src/server/common/componentUtils.ts
+++ b/packages/playwright-core/src/server/common/componentUtils.ts
@@ -201,12 +201,3 @@ export function parseComponentSelector(selector: string): ParsedComponentSelecto
   return result;
 }
 
-export function isInsideScope(scope: Node, node: Node): boolean {
-  while (node) {
-    if (scope.contains(node))
-      return true;
-    node = node.parentNode || (node as ShadowRoot).host;
-  }
-  return false;
-}
-

--- a/packages/playwright-core/src/server/injected/reactSelectorEngine.ts
+++ b/packages/playwright-core/src/server/injected/reactSelectorEngine.ts
@@ -15,7 +15,8 @@
  */
 
 import { SelectorEngine, SelectorRoot } from './selectorEngine';
-import { checkComponentAttribute, parseComponentSelector, isInsideScope } from '../common/componentUtils';
+import { isInsideScope } from './selectorEvaluator';
+import { checkComponentAttribute, parseComponentSelector } from '../common/componentUtils';
 
 type ComponentNode = {
   name: string,

--- a/packages/playwright-core/src/server/injected/reactSelectorEngine.ts
+++ b/packages/playwright-core/src/server/injected/reactSelectorEngine.ts
@@ -15,7 +15,7 @@
  */
 
 import { SelectorEngine, SelectorRoot } from './selectorEngine';
-import { checkComponentAttribute, parseComponentSelector } from '../common/componentUtils';
+import { checkComponentAttribute, parseComponentSelector, isInsideScope } from '../common/componentUtils';
 
 type ComponentNode = {
   name: string,
@@ -132,24 +132,28 @@ function filterComponentsTree(treeNode: ComponentNode, searchFn: (node: Componen
   return result;
 }
 
-function findReactRoots(): ReactVNode[] {
-  const roots: ReactVNode[] = [];
-  const walker = document.createTreeWalker(document, NodeFilter.SHOW_ELEMENT);
-  while (walker.nextNode()) {
+function findReactRoots(root: Document | ShadowRoot, roots: ReactVNode[] = []): ReactVNode[] {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+  do {
     const node = walker.currentNode;
     // @see https://github.com/baruchvlz/resq/blob/5c15a5e04d3f7174087248f5a158c3d6dcc1ec72/src/utils.js#L329
     if (node.hasOwnProperty('_reactRootContainer'))
       roots.push((node as any)._reactRootContainer._internalRoot.current);
-  }
-  // Pre-react 16: query dom for `data-reactroot`
-  // @see https://github.com/facebook/react/issues/10971
-  for (const node of document.querySelectorAll('[data-reactroot]')) {
-    for (const key of Object.keys(node)) {
-      // @see https://github.com/baruchvlz/resq/blob/5c15a5e04d3f7174087248f5a158c3d6dcc1ec72/src/utils.js#L334
-      if (key.startsWith('__reactInternalInstance') || key.startsWith('__reactFiber'))
-        roots.push((node as any)[key]);
+
+    // Pre-react 16: rely on `data-reactroot`
+    // @see https://github.com/facebook/react/issues/10971
+    if ((node instanceof Element) && node.hasAttribute('data-reactroot')) {
+      for (const key of Object.keys(node)) {
+        // @see https://github.com/baruchvlz/resq/blob/5c15a5e04d3f7174087248f5a158c3d6dcc1ec72/src/utils.js#L334
+        if (key.startsWith('__reactInternalInstance') || key.startsWith('__reactFiber'))
+          roots.push((node as any)[key]);
+      }
     }
-  }
+
+    const shadowRoot = node instanceof Element ? node.shadowRoot : null;
+    if (shadowRoot)
+      findReactRoots(shadowRoot, roots);
+  } while (walker.nextNode());
   return roots;
 }
 
@@ -157,12 +161,12 @@ export const ReactEngine: SelectorEngine = {
   queryAll(scope: SelectorRoot, selector: string): Element[] {
     const { name, attributes } = parseComponentSelector(selector);
 
-    const reactRoots = findReactRoots();
+    const reactRoots = findReactRoots(document);
     const trees = reactRoots.map(reactRoot => buildComponentsTree(reactRoot));
     const treeNodes = trees.map(tree => filterComponentsTree(tree, treeNode => {
       if (name && treeNode.name !== name)
         return false;
-      if (treeNode.rootElements.some(domNode => !scope.contains(domNode)))
+      if (treeNode.rootElements.some(domNode => !isInsideScope(scope, domNode)))
         return false;
       for (const attr of attributes) {
         if (!checkComponentAttribute(treeNode.props, attr))

--- a/packages/playwright-core/src/server/injected/selectorEvaluator.ts
+++ b/packages/playwright-core/src/server/injected/selectorEvaluator.ts
@@ -619,6 +619,15 @@ const nthMatchEngine: SelectorEngine = {
   },
 };
 
+export function isInsideScope(scope: Node, element: Element | undefined): boolean {
+  while (element) {
+    if (scope.contains(element))
+      return true;
+    element = parentElementOrShadowHost(element);
+  }
+  return false;
+}
+
 export function parentElementOrShadowHost(element: Element): Element | undefined {
   if (element.parentElement)
     return element.parentElement;

--- a/packages/playwright-core/src/server/injected/selectorEvaluator.ts
+++ b/packages/playwright-core/src/server/injected/selectorEvaluator.ts
@@ -623,6 +623,8 @@ export function isInsideScope(scope: Node, element: Element | undefined): boolea
   while (element) {
     if (scope.contains(element))
       return true;
+    while (element.parentElement)
+      element = element.parentElement;
     element = parentElementOrShadowHost(element);
   }
   return false;

--- a/packages/playwright-core/src/server/injected/vueSelectorEngine.ts
+++ b/packages/playwright-core/src/server/injected/vueSelectorEngine.ts
@@ -15,7 +15,8 @@
  */
 
 import { SelectorEngine, SelectorRoot } from './selectorEngine';
-import { checkComponentAttribute, parseComponentSelector, isInsideScope } from '../common/componentUtils';
+import { isInsideScope } from './selectorEvaluator';
+import { checkComponentAttribute, parseComponentSelector } from '../common/componentUtils';
 
 type ComponentNode = {
   name: string,

--- a/tests/page/selectors-react.spec.ts
+++ b/tests/page/selectors-react.spec.ts
@@ -140,7 +140,7 @@ for (const [name, url] of Object.entries(reacts)) {
       await page.evaluate(() => {
         const anotherRoot = document.createElement('div');
         document.body.append(anotherRoot);
-        const shadowRoot = anotherRoot.attachShadow({mode: 'open'});
+        const shadowRoot = anotherRoot.attachShadow({ mode: 'open' });
         // @ts-ignore
         window.mountApp(shadowRoot);
       });

--- a/tests/page/selectors-react.spec.ts
+++ b/tests/page/selectors-react.spec.ts
@@ -134,6 +134,18 @@ for (const [name, url] of Object.entries(reacts)) {
         await expect(page.locator('css=#root2 >> _react=BookItem')).toHaveCount(4);
       });
     });
+
+    it('should work with multiroot react inside shadow DOM', async ({ page }) => {
+      await expect(page.locator(`_react=BookItem`)).toHaveCount(3);
+      await page.evaluate(() => {
+        const anotherRoot = document.createElement('div');
+        document.body.append(anotherRoot);
+        const shadowRoot = anotherRoot.attachShadow({mode: 'open'});
+        // @ts-ignore
+        window.mountApp(shadowRoot);
+      });
+      await expect(page.locator(`_react=BookItem`)).toHaveCount(6);
+    });
   });
 }
 

--- a/tests/page/selectors-vue.spec.ts
+++ b/tests/page/selectors-vue.spec.ts
@@ -138,7 +138,7 @@ for (const [name, url] of Object.entries(vues)) {
       await page.evaluate(vueName => {
         const anotherRoot = document.createElement('div');
         document.body.append(anotherRoot);
-        const shadowRoot = anotherRoot.attachShadow({mode: 'open'});
+        const shadowRoot = anotherRoot.attachShadow({ mode: 'open' });
         if (vueName === 'vue2') {
           // Vue2 cannot be mounted in shadow root directly.
           const div = document.createElement('div');

--- a/tests/page/selectors-vue.spec.ts
+++ b/tests/page/selectors-vue.spec.ts
@@ -143,6 +143,7 @@ for (const [name, url] of Object.entries(vues)) {
           // Vue2 cannot be mounted in shadow root directly.
           const div = document.createElement('div');
           shadowRoot.append(div);
+          // @ts-ignore
           window.mountApp(div);
         } else {
           // @ts-ignore

--- a/tests/page/selectors-vue.spec.ts
+++ b/tests/page/selectors-vue.spec.ts
@@ -132,6 +132,25 @@ for (const [name, url] of Object.entries(vues)) {
         await expect(page.locator('css=#root2 >> _vue=book-item')).toHaveCount(4);
       });
     });
+
+    it('should work with multiroot vue inside shadow DOM', async ({ page }) => {
+      await expect(page.locator(`_vue=book-item`)).toHaveCount(3);
+      await page.evaluate(vueName => {
+        const anotherRoot = document.createElement('div');
+        document.body.append(anotherRoot);
+        const shadowRoot = anotherRoot.attachShadow({mode: 'open'});
+        if (vueName === 'vue2') {
+          // Vue2 cannot be mounted in shadow root directly.
+          const div = document.createElement('div');
+          shadowRoot.append(div);
+          window.mountApp(div);
+        } else {
+          // @ts-ignore
+          window.mountApp(shadowRoot);
+        }
+      }, name);
+      await expect(page.locator(`_vue=book-item`)).toHaveCount(6);
+    });
   });
 }
 


### PR DESCRIPTION
There were two issues:
- we did not find VDom roots inside shadow DOM
- we incorrectly relied on DOM's `contain` method to determine if
  VDom's rendered node belongs to requested scope.

Fixes #10123