### PR TITLE
test(keyboard): add tests for click events being dispatched when Space/Enter gets pressed while focus is on a button

### DIFF
--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -440,6 +440,30 @@ it('should move to the start of the document', async ({ page, isMac }) => {
   expect(await page.evaluate(() => window.getSelection().toString())).toBe('1\n2\n3\n');
 });
 
+it('should dispatch a click event on a button when Space gets pressed', async ({ page }) => {
+  await page.setContent(`<button type="button">a11y</button>`);
+  const actual = await page.evaluateHandle(() => {
+    const actual = { clicked: false };
+    document.querySelector('button').addEventListener('click', () => (actual.clicked = true));
+    return actual;
+  });
+  await page.focus('button');
+  await page.keyboard.press('Space');
+  expect((await actual.jsonValue()).clicked).toBe(true);
+});
+
+it('should dispatch a click event on a button when Enter gets pressed', async ({ page }) => {
+  await page.setContent(`<button type="button">a11y</button>`);
+  const actual = await page.evaluateHandle(() => {
+    const actual = { clicked: false };
+    document.querySelector('button').addEventListener('click', () => (actual.clicked = true));
+    return actual;
+  });
+  await page.focus('button');
+  await page.keyboard.press('Enter');
+  expect((await actual.jsonValue()).clicked).toBe(true);
+});
+
 async function captureLastKeydown(page) {
   const lastEvent = await page.evaluateHandle(() => {
     const lastEvent = {


### PR DESCRIPTION
Just a test for something that already works. I was looking into this because I'd like to simplify the logic introduced in `cypress-real-events` [here](https://github.com/dmtrKovalenko/cypress-real-events/commit/5978a6e3efa92b63e8d1ac31eac907d092aaebd3#). So I just went here to see if your logic handles this OK - and it does :wink: 