### PR TITLE
Revert "chore: validate client/server version match for remote connections (#10542)

### DIFF
--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -40,7 +40,6 @@ import { Artifact } from './artifact';
 import { EventEmitter } from 'events';
 import { JsonPipe } from './jsonPipe';
 import { APIRequestContext } from './fetch';
-import { getPlaywrightVersion } from '../utils/utils';
 
 class Root extends ChannelOwner<channels.RootChannel> {
   constructor(connection: Connection) {
@@ -50,7 +49,6 @@ class Root extends ChannelOwner<channels.RootChannel> {
   async initialize(): Promise<Playwright> {
     return Playwright.from((await this._channel.initialize({
       sdkLanguage: 'javascript',
-      version: getPlaywrightVersion(),
     })).playwright);
   }
 }

--- a/packages/playwright-core/src/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/dispatchers/dispatcher.ts
@@ -18,7 +18,7 @@ import { EventEmitter } from 'events';
 import * as channels from '../protocol/channels';
 import { serializeError } from '../protocol/serializers';
 import { createScheme, Validator, ValidationError } from '../protocol/validator';
-import { assert, debugAssert, getPlaywrightVersion, isUnderTest, monotonicTime } from '../utils/utils';
+import { assert, debugAssert, isUnderTest, monotonicTime } from '../utils/utils';
 import { tOptional } from '../protocol/validatorPrimitives';
 import { kBrowserOrContextClosedError } from '../utils/errors';
 import { CallMetadata, SdkObject } from '../server/instrumentation';
@@ -132,7 +132,6 @@ export class Root extends Dispatcher<{ guid: '' }, any> {
   async initialize(params: channels.RootInitializeParams): Promise<channels.RootInitializeResult> {
     assert(this.createPlaywright);
     assert(!this._initialized);
-    assertPlaywrightVersion(params.version);
     this._initialized = true;
     return {
       playwright: await this.createPlaywright(this, params),
@@ -321,10 +320,3 @@ function formatLogRecording(log: string[]): string {
 }
 
 let lastEventId = 0;
-
-function assertPlaywrightVersion(givenVersion: string): void {
-  const expectedVersion = getPlaywrightVersion();
-  const givenParts = givenVersion.split('.');
-  const expectedParts = givenVersion.split('.');
-  assert(givenParts.slice(0, 2).join('.') === expectedParts.slice(0, 2).join('.'), `${expectedVersion} does not match the client version ${givenVersion}.`);
-}

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -356,7 +356,6 @@ export interface RootChannel extends RootEventTarget, Channel {
 }
 export type RootInitializeParams = {
   sdkLanguage: string,
-  version: string,
 };
 export type RootInitializeOptions = {
 

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -423,7 +423,6 @@ Root:
     initialize:
       parameters:
         sdkLanguage: string
-        version: string
       returns:
         playwright: Playwright
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -191,7 +191,6 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   scheme.LifecycleEvent = tEnum(['load', 'domcontentloaded', 'networkidle', 'commit']);
   scheme.RootInitializeParams = tObject({
     sdkLanguage: tString,
-    version: tString,
   });
   scheme.PlaywrightSocksConnectedParams = tObject({
     uid: tString,


### PR DESCRIPTION
This reverts commit 41070a2f555a12bda6ac2589ca72cf0d886f989c.

Relates #10761