### PR TITLE
devops: run docker test in headful mode too

### DIFF
--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         tag: [bionic, focal]
         user: [pwuser, root]
+        headless: ['headless', 'headful']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
@@ -59,7 +60,11 @@ jobs:
       if: matrix.user == 'root'
       run: docker exec playwright-docker-${{ matrix.tag }}-test npx playwright install chrome msedge
     - name: Run "npm run test" inside docker
+      if: matrix.headless == 'headless'
       run: docker exec -e INSIDE_DOCKER=1 -e CI=1 playwright-docker-${{ matrix.tag }}-test xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run test
+    - name: Run "HEADFUL=1 npm run test" inside docker
+      if: matrix.headless == 'headful'
+      run: docker exec -e HEADFUL=1 -e INSIDE_DOCKER=1 -e CI=1 playwright-docker-${{ matrix.tag }}-test xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run test
     - run: sudo chmod -R 777 . && ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   test_linux_docker:
-    name: "Docker Ubuntu-${{ matrix.tag }}-${{ matrix.user }} Tests"
+    name: "Docker Ubuntu-${{ matrix.tag }}-${{ matrix.user }}-${{ matrix.headless }} Tests"
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
Some test failures (like [this one](https://github.com/microsoft/playwright/pull/10741)) are reproducible in headful mode in docker while the same tests pass on GHA in headful mode.