### PR TITLE
devops: setup Docker Qemu for arm64 docker builds

### DIFF
--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -57,6 +57,10 @@ jobs:
         login-server: playwright.azurecr.io
         username: playwright
         password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Set up Docker QEMU for arm64 docker builds
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: arm64
     - name: publish docker canary
       run: ./utils/docker/publish_docker.sh canary
 

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -64,6 +64,10 @@ jobs:
         login-server: playwright.azurecr.io
         username: playwright
         password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Set up Docker QEMU for arm64 docker builds
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: arm64
     - run: npm i -g npm@8
     - run: npm ci
     - run: npm run build


### PR DESCRIPTION
We might also need to install docker buildx if this is not enough.

References #10351