### PR TITLE
fix: support regexp flags with locator.withText()

### DIFF
--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -99,9 +99,9 @@ export class Locator implements api.Locator {
   }
 
   withText(text: string | RegExp): Locator {
-    const matcher = isRegExp(text) ? 'text-matches' : 'has-text';
-    const source = escapeWithQuotes(isRegExp(text) ? text.source : text, '"');
-    return new Locator(this._frame, this._selector + ` >> :scope:${matcher}(${source})`);
+    if (isRegExp(text))
+      return new Locator(this._frame, this._selector + ` >> :scope:text-matches(${escapeWithQuotes(text.source, '"')}, "${text.flags}")`);
+    return new Locator(this._frame, this._selector + ` >> :scope:has-text(${escapeWithQuotes(text, '"')})`);
   }
 
   frameLocator(selector: string): FrameLocator {

--- a/tests/page/locator-query.spec.ts
+++ b/tests/page/locator-query.spec.ts
@@ -84,3 +84,8 @@ it('should filter by regex with quotes', async ({ page }) => {
   await page.setContent(`<div>Hello "world"</div><div>Hello world</div>`);
   await expect(page.locator('div').withText(/Hello "world"/)).toHaveText('Hello "world"');
 });
+
+it('should filter by regex and regexp flags', async ({ page }) => {
+  await page.setContent(`<div>Hello "world"</div><div>Hello world</div>`);
+  await expect(page.locator('div').withText(/hElLo "world"/i)).toHaveText('Hello "world"');
+});


### PR DESCRIPTION
Seems simpler to understand when splitting it up with a if instead of 3 times checking if its a regexp.

Fixes #10773