### PR TITLE
test: skip input type=color test on WebKit/Windows

### DIFF
--- a/tests/page/page-fill.spec.ts
+++ b/tests/page/page-fill.spec.ts
@@ -105,7 +105,8 @@ it('should fill color input', async ({ page }) => {
   expect(await page.$eval('input', input => input.value)).toBe('#aaaaaa');
 });
 
-it('should throw on incorrect color value', async ({ page }) => {
+it('should throw on incorrect color value', async ({ page, browserName, platform }) => {
+  it.skip(browserName === 'webkit' && platform === 'win32', 'WebKit option ENABLE_INPUT_TYPE_COLOR is off on Windows');
   await page.setContent('<input type=color value="#e66465">');
   const error1 = await page.fill('input', 'badvalue').catch(e => e);
   expect(error1.message).toContain('Malformed value');


### PR DESCRIPTION
Its disabled by default, see here (git blame says since 6 years):

https://github.com/WebKit/WebKit/blob/873d43643d869e63be122e17cea53a7b4141c778/Source/cmake/OptionsWin.cmake#L36

and failing by that: https://devops.aslushnikov.com/flakiness2.html#filter_spec=uld+throw+on+incorrect+color+val

Probably fine to just skip it.