### PR TITLE
fix: omit page.route

### DIFF
--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -168,7 +168,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
   }
 
   private _onRoute(route: Route, request: Request) {
-    for (const routeHandler of this._routes) {
+    for (const routeHandler of [...this._routes]) {
       if (routeHandler.matches(request.url())) {
         if (routeHandler.handle(route, request)) {
           this._routes.splice(this._routes.indexOf(routeHandler), 1);


### PR DESCRIPTION
const routes = [1,2,3];
for(const v of routes){
    console.info(v);
    routes.splice(routes.indexOf(v),1)
}
got  1,3 but 2 has been omitted