### PR TITLE
test: mark "fill color input" test as dailing on wk windows

### DIFF
--- a/tests/page/page-fill.spec.ts
+++ b/tests/page/page-fill.spec.ts
@@ -105,7 +105,8 @@ it('should fill color input', async ({ page }) => {
   expect(await page.$eval('input', input => input.value)).toBe('#aaaaaa');
 });
 
-it('should throw on incorrect color value', async ({ page }) => {
+it('should throw on incorrect color value', async ({ page, browserName, isWindows }) => {
+  it.fail(browserName === 'webkit' && isWindows, 'Error is undefined');
   await page.setContent('<input type=color value="#e66465">');
   const error1 = await page.fill('input', 'badvalue').catch(e => e);
   expect(error1.message).toContain('Malformed value');

--- a/tests/page/page-fill.spec.ts
+++ b/tests/page/page-fill.spec.ts
@@ -106,7 +106,7 @@ it('should fill color input', async ({ page }) => {
 });
 
 it('should throw on incorrect color value', async ({ page, browserName, isWindows }) => {
-  it.fail(browserName === 'webkit' && isWindows, 'Error is undefined');
+  it.skip(browserName === 'webkit' && isWindows, 'WebKit win does not support color inputs');
   await page.setContent('<input type=color value="#e66465">');
   const error1 = await page.fill('input', 'badvalue').catch(e => e);
   expect(error1.message).toContain('Malformed value');


### PR DESCRIPTION
It has been failing from the very beginning: https://devops.aslushnikov.com/flakiness2.html#filter_spec=should+throw+on+incorrect+color+value&branch=main&timestamp=1638978656357