### PR TITLE
fix: use HTTP/2.0 instead of h2 as Response.httpVersion

### DIFF
--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -434,6 +434,8 @@ export class Response extends SdkObject {
       return 'HTTP/1.1';
     if (this._httpVersion === 'http/1.1')
       return 'HTTP/1.1';
+    if (this._httpVersion === 'h2')
+      return 'HTTP/2.0';
     return this._httpVersion;
   }
 

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -512,8 +512,8 @@ it('should contain http2 for http2 requests', async ({ contextFactory, browserNa
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
   await page.goto(`https://localhost:${(server.address() as AddressInfo).port}`);
   const log = await getLog();
-  expect(log.entries[0].request.httpVersion).toBe('h2');
-  expect(log.entries[0].response.httpVersion).toBe('h2');
+  expect(log.entries[0].request.httpVersion).toBe('HTTP/2.0');
+  expect(log.entries[0].response.httpVersion).toBe('HTTP/2.0');
   expect(Buffer.from(log.entries[0].response.content.text, 'base64').toString()).toBe('<h1>Hello World</h1>');
   server.close();
 });


### PR DESCRIPTION
Fixes #10751