### PR TITLE
Use pixel buffer diff for 4x faster image diffng and reduced visual noise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6703,24 +6703,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/pixelmatch": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
-      "integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
-      "dependencies": {
-        "pngjs": "^4.0.1"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
-      }
-    },
-    "node_modules/pixelmatch/node_modules/pngjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
-      "integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
-      "engines": {
-        "node": ">=8.0.0"
-      }
+    "node_modules/pixel-buffer-diff": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pixel-buffer-diff/-/pixel-buffer-diff-1.1.1.tgz",
+      "integrity": "sha512-tUEy8Mgi6ei1J2G3PKlSK1P82MAuv4wGI/QTz8dCtPeg4nJVlXK9NmEZJUA86bCMFeaVXaJkjMBkdpXpxh2dsg=="
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -9160,7 +9146,7 @@
         "ms": "^2.1.2",
         "open": "^8.3.0",
         "pirates": "^4.0.1",
-        "pixelmatch": "^5.2.1",
+        "pixel-buffer-diff": "^1.1.1",
         "playwright-core": "=1.18.0-next",
         "pngjs": "^5.0.0",
         "rimraf": "^3.0.2",
@@ -9975,7 +9961,7 @@
         "ms": "^2.1.2",
         "open": "^8.3.0",
         "pirates": "^4.0.1",
-        "pixelmatch": "^5.2.1",
+        "pixel-buffer-diff": "^1.1.1",
         "playwright-core": "=1.18.0-next",
         "pngjs": "^5.0.0",
         "rimraf": "^3.0.2",
@@ -14325,20 +14311,10 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
-    "pixelmatch": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
-      "integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
-      "requires": {
-        "pngjs": "^4.0.1"
-      },
-      "dependencies": {
-        "pngjs": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
-          "integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg=="
-        }
-      }
+    "pixel-buffer-diff": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pixel-buffer-diff/-/pixel-buffer-diff-1.1.1.tgz",
+      "integrity": "sha512-tUEy8Mgi6ei1J2G3PKlSK1P82MAuv4wGI/QTz8dCtPeg4nJVlXK9NmEZJUA86bCMFeaVXaJkjMBkdpXpxh2dsg=="
     },
     "pkg-dir": {
       "version": "4.2.0",

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -57,7 +57,7 @@
     "ms": "^2.1.2",
     "open": "^8.3.0",
     "pirates": "^4.0.1",
-    "pixelmatch": "^5.2.1",
+    "pixel-buffer-diff": "^1.1.1",
     "playwright-core": "=1.18.0-next",
     "pngjs": "^5.0.0",
     "rimraf": "^3.0.2",

--- a/packages/playwright-test/src/matchers/golden.ts
+++ b/packages/playwright-test/src/matchers/golden.ts
@@ -20,13 +20,14 @@ import colors from 'colors/safe';
 import fs from 'fs';
 import path from 'path';
 import jpeg from 'jpeg-js';
-import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+import * as pbd from 'pixel-buffer-diff';
 import { diff_match_patch, DIFF_INSERT, DIFF_DELETE, DIFF_EQUAL } from '../third_party/diff_match_patch';
 import { TestInfoImpl, UpdateSnapshots } from '../types';
 import { addSuffixToFilePath } from '../util';
 
 // Note: we require the pngjs version of pixelmatch to avoid version mismatches.
-const { PNG } = require(require.resolve('pngjs', { paths: [require.resolve('pixelmatch')] })) as typeof import('pngjs');
+//const { PNG } = require(require.resolve('pngjs', { paths: [require.resolve('pixelmatch')] })) as typeof import('pngjs');
 
 const extensionToMimeType: { [key: string]: string } = {
   'dat': 'application/octet-string',
@@ -66,8 +67,8 @@ function compareImages(actualBuffer: Buffer | string, expectedBuffer: Buffer, mi
     };
   }
   const diff = new PNG({ width: expected.width, height: expected.height });
-  const count = pixelmatch(expected.data, actual.data, diff.data, expected.width, expected.height, { threshold: 0.2, ...options });
-  return count > 0 ? { diff: PNG.sync.write(diff) } : null;
+  const diffResult = pbd.diff(expected.data, actual.data, diff.data, expected.width, expected.height, { threshold: 0.2, ...options });
+  return diffResult.cumulatedDiff > 0 ? { diff: PNG.sync.write(diff) } : null;
 }
 
 function compareText(actual: Buffer | string, expectedBuffer: Buffer): { diff?: Buffer; errorMessage?: string; diffExtension?: string; } | null {

--- a/packages/playwright-test/src/matchers/golden.ts
+++ b/packages/playwright-test/src/matchers/golden.ts
@@ -26,9 +26,6 @@ import { diff_match_patch, DIFF_INSERT, DIFF_DELETE, DIFF_EQUAL } from '../third
 import { TestInfoImpl, UpdateSnapshots } from '../types';
 import { addSuffixToFilePath } from '../util';
 
-// Note: we require the pngjs version of pixelmatch to avoid version mismatches.
-//const { PNG } = require(require.resolve('pngjs', { paths: [require.resolve('pixelmatch')] })) as typeof import('pngjs');
-
 const extensionToMimeType: { [key: string]: string } = {
   'dat': 'application/octet-string',
   'jpeg': 'image/jpeg',


### PR DESCRIPTION
Pixel-buffer-diff uses the same image diffing technique as Pixelmatch, but does not stop at individual pixels. It take into account the cumulated differences to reduce false positive.