### PR TITLE
feat(keyboard): support simple copy-pasting using meta+c/v

### DIFF
--- a/packages/playwright-core/src/server/macEditingCommands.ts
+++ b/packages/playwright-core/src/server/macEditingCommands.ts
@@ -126,4 +126,6 @@ export const macEditingCommands: {[key: string]: string|string[]} = {
   'Shift+Meta+ArrowRight': 'moveToRightEndOfLineAndModifySelection:',
 
   'Meta+KeyA': 'selectAll:',
+  'Meta+KeyC': 'copy:',
+  'Meta+KeyV': 'paste:',
 };

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -464,7 +464,8 @@ it('should dispatch a click event on a button when Enter gets pressed', async ({
   expect((await actual.jsonValue()).clicked).toBe(true);
 });
 
-it('should support simple copy-pasting', async ({ page, isMac }) => {
+it('should support simple copy-pasting', async ({ page, isMac, browserName }) => {
+  it.fixme(browserName === 'webkit', 'https://github.com/microsoft/playwright/issues/12000');
   const modifier = isMac ? 'Meta' : 'Control';
   await page.setContent(`<div contenteditable>123</div>`);
   await page.focus('div');

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -465,13 +465,13 @@ it('should dispatch a click event on a button when Enter gets pressed', async ({
 });
 
 it('should support simple copy-pasting', async ({ page, isMac }) => {
-  it.skip(!isMac);
+  const modifier = isMac ? 'Meta' : 'Control';
   await page.setContent(`<div contenteditable>123</div>`);
   await page.focus('div');
-  await page.keyboard.press('Meta+KeyA');
-  await page.keyboard.press('Meta+KeyC');
-  await page.keyboard.press('Meta+KeyV');
-  await page.keyboard.press('Meta+KeyV');
+  await page.keyboard.press(`${modifier}+KeyA`);
+  await page.keyboard.press(`${modifier}+KeyC`);
+  await page.keyboard.press(`${modifier}+KeyV`);
+  await page.keyboard.press(`${modifier}+KeyV`);
   expect(await page.evaluate(() => document.querySelector('div').textContent)).toBe('123123');
 });
 

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -464,6 +464,17 @@ it('should dispatch a click event on a button when Enter gets pressed', async ({
   expect((await actual.jsonValue()).clicked).toBe(true);
 });
 
+it('should support simple copy-pasting', async ({ page, isMac }) => {
+  it.skip(!isMac);
+  await page.setContent(`<div contenteditable>123</div>`);
+  await page.focus('div');
+  await page.keyboard.press('Meta+KeyA');
+  await page.keyboard.press('Meta+KeyC');
+  await page.keyboard.press('Meta+KeyV');
+  await page.keyboard.press('Meta+KeyV');
+  expect(await page.evaluate(() => document.querySelector('div').textContent)).toBe('123123');
+});
+
 async function captureLastKeydown(page) {
   const lastEvent = await page.evaluateHandle(() => {
     const lastEvent = {


### PR DESCRIPTION
It's a straightforward change to support new, common, keyboard commands

Note that I've tested this locally with Chrome on my Mac but it seems that CI doesn't want to pass Chrome tests - it's running on ubuntu though. Does this mean that I should introduce per-platform editing commands? At the moment there is only a single [`macEditingCommands`](https://github.com/microsoft/playwright/blob/0ed33522c572b974905f642408050d007860e33e/packages/playwright-core/src/server/macEditingCommands.ts) file.

Fixes https://github.com/microsoft/playwright/issues/12000