### PR TITLE
browser(webkit): fix WebKit compilation on MacOS 12

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1586
-Changed: yurys@chromium.org Tue 07 Dec 2021 12:22:45 PM PST
+1587
+Changed: lushnikov@chromium.org Thu Dec  9 16:44:57 PST 2021

--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -49,6 +49,8 @@ if [[ "$(uname)" == "Darwin" ]]; then
     selectXcodeVersionOrDie "11.7"
   elif [[ "${CURRENT_HOST_OS_VERSION}" == "11."* ]]; then
     selectXcodeVersionOrDie "12.2"
+  elif [[ "${CURRENT_HOST_OS_VERSION}" == "12."* ]]; then
+    selectXcodeVersionOrDie "13.2"
   else
     echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"
     exit 1

--- a/browser_patches/webkit/embedder/Playwright/mac/BrowserWindowController.m
+++ b/browser_patches/webkit/embedder/Playwright/mac/BrowserWindowController.m
@@ -911,7 +911,10 @@ static NSSet *dataTypes()
 - (IBAction)saveAsPDF:(id)sender
 {
     NSSavePanel *panel = [NSSavePanel savePanel];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     panel.allowedFileTypes = @[ @"pdf" ];
+#pragma clang diagnostic pop
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
         if (result == NSModalResponseOK) {
             [_webView createPDFWithConfiguration:nil completionHandler:^(NSData *pdfSnapshotData, NSError *error) {
@@ -924,7 +927,10 @@ static NSSet *dataTypes()
 - (IBAction)saveAsWebArchive:(id)sender
 {
     NSSavePanel *panel = [NSSavePanel savePanel];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     panel.allowedFileTypes = @[ @"webarchive" ];
+#pragma clang diagnostic pop
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
         if (result == NSModalResponseOK) {
             [_webView createWebArchiveDataWithCompletionHandler:^(NSData *archiveData, NSError *error) {


### PR DESCRIPTION
This is not yet necessary for us, but I happen to use MacOS 12
now.

