### PR TITLE
browser(firefox): fix proxy auth redirect + resource redirect handling

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1307
-Changed: lushnikov@chromium.org Mon Dec  6 15:17:29 PST 2021
+1308
+Changed: lushnikov@chromium.org Fri Dec 10 02:42:14 PST 2021

--- a/browser_patches/firefox-beta/juggler/NetworkObserver.js
+++ b/browser_patches/firefox-beta/juggler/NetworkObserver.js
@@ -104,7 +104,6 @@ class NetworkRequest {
   constructor(networkObserver, httpChannel, redirectedFrom) {
     this._networkObserver = networkObserver;
     this.httpChannel = httpChannel;
-    this._networkObserver._channelToRequest.set(this.httpChannel, this);
 
     const loadInfo = this.httpChannel.loadInfo;
     let browsingContext = loadInfo?.frameBrowsingContext || loadInfo?.browsingContext;
@@ -133,6 +132,17 @@ class NetworkRequest {
       // use onStopRequest, but that will only happen after the last redirect has finished.
       redirectedFrom._sendOnRequestFinished();
     }
+    // In case of proxy auth, we get to requests with the same channel:
+    // - one is pre-auth
+    // - second is with auth header.
+    //
+    // In this case, we create this NetworkRequest object with a `redirectedFrom`
+    // object, and they both share the same httpChannel.
+    //
+    // Since we want to maintain _channelToRequest map without clashes,
+    // we must call `_sendOnRequestFinished` **before** we update it with a new object
+    // here.
+    this._networkObserver._channelToRequest.set(this.httpChannel, this);
 
     this._pageNetwork = redirectedFrom ? redirectedFrom._pageNetwork : networkObserver._findPageNetwork(httpChannel);
     this._expectingInterception = false;

--- a/browser_patches/firefox-beta/juggler/NetworkObserver.js
+++ b/browser_patches/firefox-beta/juggler/NetworkObserver.js
@@ -132,7 +132,7 @@ class NetworkRequest {
       // use onStopRequest, but that will only happen after the last redirect has finished.
       redirectedFrom._sendOnRequestFinished();
     }
-    // In case of proxy auth, we get to requests with the same channel:
+    // In case of proxy auth, we get two requests with the same channel:
     // - one is pre-auth
     // - second is with auth header.
     //
@@ -142,6 +142,8 @@ class NetworkRequest {
     // Since we want to maintain _channelToRequest map without clashes,
     // we must call `_sendOnRequestFinished` **before** we update it with a new object
     // here.
+    if (this._networkObserver._channelToRequest.has(this.httpChannel))
+      throw new Error(`Internal Error: invariant is broken for _channelToRequest map`);
     this._networkObserver._channelToRequest.set(this.httpChannel, this);
 
     this._pageNetwork = redirectedFrom ? redirectedFrom._pageNetwork : networkObserver._findPageNetwork(httpChannel);

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1308
-Changed: lushnikov@chromium.org Tue Dec  7 11:51:20 PST 2021
+1309
+Changed: lushnikov@chromium.org Fri Dec 10 02:42:14 PST 2021

--- a/browser_patches/firefox/juggler/NetworkObserver.js
+++ b/browser_patches/firefox/juggler/NetworkObserver.js
@@ -104,7 +104,6 @@ class NetworkRequest {
   constructor(networkObserver, httpChannel, redirectedFrom) {
     this._networkObserver = networkObserver;
     this.httpChannel = httpChannel;
-    this._networkObserver._channelToRequest.set(this.httpChannel, this);
 
     const loadInfo = this.httpChannel.loadInfo;
     let browsingContext = loadInfo?.frameBrowsingContext || loadInfo?.browsingContext;
@@ -133,6 +132,17 @@ class NetworkRequest {
       // use onStopRequest, but that will only happen after the last redirect has finished.
       redirectedFrom._sendOnRequestFinished();
     }
+    // In case of proxy auth, we get to requests with the same channel:
+    // - one is pre-auth
+    // - second is with auth header.
+    //
+    // In this case, we create this NetworkRequest object with a `redirectedFrom`
+    // object, and they both share the same httpChannel.
+    //
+    // Since we want to maintain _channelToRequest map without clashes,
+    // we must call `_sendOnRequestFinished` **before** we update it with a new object
+    // here.
+    this._networkObserver._channelToRequest.set(this.httpChannel, this);
 
     this._pageNetwork = redirectedFrom ? redirectedFrom._pageNetwork : networkObserver._findPageNetwork(httpChannel);
     this._expectingInterception = false;

--- a/browser_patches/firefox/juggler/NetworkObserver.js
+++ b/browser_patches/firefox/juggler/NetworkObserver.js
@@ -132,7 +132,7 @@ class NetworkRequest {
       // use onStopRequest, but that will only happen after the last redirect has finished.
       redirectedFrom._sendOnRequestFinished();
     }
-    // In case of proxy auth, we get to requests with the same channel:
+    // In case of proxy auth, we get two requests with the same channel:
     // - one is pre-auth
     // - second is with auth header.
     //
@@ -142,6 +142,8 @@ class NetworkRequest {
     // Since we want to maintain _channelToRequest map without clashes,
     // we must call `_sendOnRequestFinished` **before** we update it with a new object
     // here.
+    if (this._networkObserver._channelToRequest.has(this.httpChannel))
+      throw new Error(`Internal Error: invariant is broken for _channelToRequest map`);
     this._networkObserver._channelToRequest.set(this.httpChannel, this);
 
     this._pageNetwork = redirectedFrom ? redirectedFrom._pageNetwork : networkObserver._findPageNetwork(httpChannel);


### PR DESCRIPTION
This was breaking a vital invariant in our firefox network code - see
comments.

References #10095
