### PR TITLE
chore(tracing): collect source names on server

### DIFF
--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -16,30 +16,17 @@
 
 import * as api from '../../types/types';
 import * as channels from '../protocol/channels';
-import { ParsedStackTrace } from '../utils/stackTrace';
-import { calculateSha1 } from '../utils/utils';
 import { Artifact } from './artifact';
 import { BrowserContext } from './browserContext';
-import { ClientInstrumentationListener } from './clientInstrumentation';
 
 export class Tracing implements api.Tracing {
   private _context: BrowserContext;
-  private _sources = new Set<string>();
-  private _instrumentationListener: ClientInstrumentationListener;
 
   constructor(channel: BrowserContext) {
     this._context = channel;
-    this._instrumentationListener = {
-      onApiCallBegin: (apiCall: string, stackTrace: ParsedStackTrace | null) => {
-        for (const frame of stackTrace?.frames || [])
-          this._sources.add(frame.file);
-      }
-    };
   }
 
   async start(options: { name?: string, title?: string, snapshots?: boolean, screenshots?: boolean, sources?: boolean } = {}) {
-    if (options.sources)
-      this._context._instrumentation!.addListener(this._instrumentationListener);
     await this._context._wrapApiCall(async () => {
       await this._context._channel.tracingStart(options);
       await this._context._channel.tracingStartChunk({ title: options.title });
@@ -47,7 +34,6 @@ export class Tracing implements api.Tracing {
   }
 
   async startChunk(options: { title?: string } = {}) {
-    this._sources = new Set();
     await this._context._channel.tracingStartChunk(options);
   }
 
@@ -63,9 +49,6 @@ export class Tracing implements api.Tracing {
   }
 
   private async _doStopChunk(channel: channels.BrowserContextChannel, filePath: string | undefined) {
-    const sources = this._sources;
-    this._sources = new Set();
-    this._context._instrumentation!.removeListener(this._instrumentationListener);
     const isLocal = !this._context._connection.isRemote();
 
     const result = await channel.tracingStopChunk({ save: !!filePath, skipCompress: isLocal });
@@ -74,10 +57,6 @@ export class Tracing implements api.Tracing {
       return;
     }
 
-    const sourceEntries: channels.NameValue[] = [];
-    for (const value of sources)
-      sourceEntries.push({ name: 'resources/src@' + calculateSha1(value) + '.txt', value });
-
     if (!isLocal) {
       // We run against remote Playwright, compress on remote side.
       const artifact = Artifact.from(result.artifact!);
@@ -85,7 +64,7 @@ export class Tracing implements api.Tracing {
       await artifact.delete();
     }
 
-    if (isLocal || sourceEntries)
-      await this._context._localUtils.zip(filePath, sourceEntries.concat(result.entries));
+    if (isLocal || result.sourceEntries.length)
+      await this._context._localUtils.zip(filePath, result.sourceEntries.concat(result.entries));
   }
 }

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
 import * as api from '../../types/types';
 import * as channels from '../protocol/channels';
 import { Artifact } from './artifact';
@@ -56,6 +57,9 @@ export class Tracing implements api.Tracing {
       // Not interested in artifacts.
       return;
     }
+
+    if (filePath && fs.existsSync(filePath))
+      await fs.promises.unlink(filePath);
 
     if (!isLocal) {
       // We run against remote Playwright, compress on remote side.

--- a/packages/playwright-core/src/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/dispatchers/browserContextDispatcher.ts
@@ -198,8 +198,8 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   }
 
   async tracingStopChunk(params: channels.BrowserContextTracingStopChunkParams): Promise<channels.BrowserContextTracingStopChunkResult> {
-    const { artifact, entries } = await this._context.tracing.stopChunk(params.save, params.skipCompress);
-    return { artifact: artifact ? new ArtifactDispatcher(this._scope, artifact) : undefined, entries };
+    const { artifact, entries, sourceEntries } = await this._context.tracing.stopChunk(params.save, params.skipCompress);
+    return { artifact: artifact ? new ArtifactDispatcher(this._scope, artifact) : undefined, entries, sourceEntries };
   }
 
   async tracingStop(params: channels.BrowserContextTracingStopParams): Promise<channels.BrowserContextTracingStopResult> {

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -1249,11 +1249,13 @@ export type BrowserContextTracingStartParams = {
   name?: string,
   snapshots?: boolean,
   screenshots?: boolean,
+  sources?: boolean,
 };
 export type BrowserContextTracingStartOptions = {
   name?: string,
   snapshots?: boolean,
   screenshots?: boolean,
+  sources?: boolean,
 };
 export type BrowserContextTracingStartResult = void;
 export type BrowserContextTracingStartChunkParams = {
@@ -1273,6 +1275,7 @@ export type BrowserContextTracingStopChunkOptions = {
 export type BrowserContextTracingStopChunkResult = {
   artifact?: ArtifactChannel,
   entries: NameValue[],
+  sourceEntries: NameValue[],
 };
 export type BrowserContextTracingStopParams = {};
 export type BrowserContextTracingStopOptions = {};

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -825,6 +825,7 @@ BrowserContext:
         name: string?
         snapshots: boolean?
         screenshots: boolean?
+        sources: boolean?
 
     tracingStartChunk:
       parameters:
@@ -837,6 +838,9 @@ BrowserContext:
       returns:
         artifact: Artifact?
         entries:
+          type: array
+          items: NameValue
+        sourceEntries:
           type: array
           items: NameValue
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -503,6 +503,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     name: tOptional(tString),
     snapshots: tOptional(tBoolean),
     screenshots: tOptional(tBoolean),
+    sources: tOptional(tBoolean),
   });
   scheme.BrowserContextTracingStartChunkParams = tObject({
     title: tOptional(tString),

--- a/tests/tracing.spec.ts
+++ b/tests/tracing.spec.ts
@@ -132,6 +132,35 @@ test('should collect two traces', async ({ context, page, server }, testInfo) =>
   }
 });
 
+test('should not include resources from the provious chunks', async ({ context, page, server }, testInfo) => {
+  await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+  await page.goto(server.EMPTY_PAGE);
+  await page.setContent('<button>Click</button>');
+  await page.click('"Click"');
+  await context.tracing.stop({ path: testInfo.outputPath('trace1.zip') });
+
+  await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+  await context.tracing.stop({ path: testInfo.outputPath('trace2.zip') });
+
+  {
+    const { resources } = await parseTrace(testInfo.outputPath('trace1.zip'));
+    const names = Array.from(resources.keys());
+    expect(names.filter(n => n.endsWith('.html')).length).toBe(1);
+    expect(names.filter(n => n.endsWith('.jpeg')).length).toBe(3);
+    // 1 source file for the test.
+    expect(names.filter(n => n.endsWith('.txt')).length).toBe(1);
+  }
+
+  {
+    const { resources } = await parseTrace(testInfo.outputPath('trace2.zip'));
+    const names = Array.from(resources.keys());
+    expect(names.filter(n => n.endsWith('.html')).length).toBe(0);
+    expect(names.filter(n => n.endsWith('.jpeg')).length).toBe(0);
+    // 1 source file for the test.
+    expect(names.filter(n => n.endsWith('.txt')).length).toBe(1);
+  }
+});
+
 test('should collect sources', async ({ context, page, server }, testInfo) => {
   await context.tracing.start({ sources: true });
   await page.goto(server.EMPTY_PAGE);

--- a/tests/tracing.spec.ts
+++ b/tests/tracing.spec.ts
@@ -148,7 +148,7 @@ test('should not include trace resources from the provious chunks', async ({ con
     const { resources } = await parseTrace(testInfo.outputPath('trace1.zip'));
     const names = Array.from(resources.keys());
     expect(names.filter(n => n.endsWith('.html')).length).toBe(1);
-    expect(names.filter(n => n.endsWith('.jpeg')).length).toBe(3);
+    expect(names.filter(n => n.endsWith('.jpeg')).length).toBeGreaterThan(1);
     // 1 source file for the test.
     expect(names.filter(n => n.endsWith('.txt')).length).toBe(1);
   }
@@ -161,6 +161,31 @@ test('should not include trace resources from the provious chunks', async ({ con
     expect(names.filter(n => n.endsWith('.jpeg')).length).toBe(0);
     // 1 source file for the test.
     expect(names.filter(n => n.endsWith('.txt')).length).toBe(1);
+  }
+});
+
+test('should overwrite existing file', async ({ context, page, server }, testInfo) => {
+  await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+  await page.goto(server.EMPTY_PAGE);
+  await page.setContent('<button>Click</button>');
+  await page.click('"Click"');
+  const path = testInfo.outputPath('trace1.zip');
+  await context.tracing.stop({ path });
+  {
+    const { resources } = await parseTrace(path);
+    const names = Array.from(resources.keys());
+    expect(names.filter(n => n.endsWith('.html')).length).toBe(1);
+    expect(names.filter(n => n.endsWith('.jpeg')).length).toBeGreaterThan(1);
+  }
+
+  await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+  await context.tracing.stop({ path });
+
+  {
+    const { resources } = await parseTrace(path);
+    const names = Array.from(resources.keys());
+    expect(names.filter(n => n.endsWith('.html')).length).toBe(0);
+    expect(names.filter(n => n.endsWith('.jpeg')).length).toBe(0);
   }
 });
 


### PR DESCRIPTION
When source files collection is enabled in tracing the paths to sources files (per context) are now collected on the server end and returned to the client when chunk is finished so that the client could add them to `trace.zip`. This allows sharing between the language ports the logic how file names are attributed to the contexts.

Drive-by: reset sha1 collection when trace chunk is finished.