### PR TITLE
devops: fix Firefox builds on MacOS 12

### DIFF
--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -23,7 +23,7 @@ rm -rf .mozconfig
 if [[ "$(uname)" == "Darwin" ]]; then
   CURRENT_HOST_OS_VERSION=$(getMacVersion)
   # As of Oct 2021, building Firefox requires XCode 13
-  if [[ "${CURRENT_HOST_OS_VERSION}" == "11."* ]]; then
+  if [[ "${CURRENT_HOST_OS_VERSION}" != "10."* ]]; then
     selectXcodeVersionOrDie "13"
   else
     echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -23,7 +23,7 @@ rm -rf .mozconfig
 if [[ "$(uname)" == "Darwin" ]]; then
   CURRENT_HOST_OS_VERSION=$(getMacVersion)
   # As of Oct 2021, building Firefox requires XCode 13
-  if [[ "${CURRENT_HOST_OS_VERSION}" == "11."* ]]; then
+  if [[ "${CURRENT_HOST_OS_VERSION}" != "10."* ]]; then
     selectXcodeVersionOrDie "13"
   else
     echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"


### PR DESCRIPTION
We don't need this yet for our build bots, but I happen to run MacOS 12
now.

