### PR TITLE
devops: fix clobbering of firefox builds

### DIFF
--- a/browser_patches/firefox-beta/clean.sh
+++ b/browser_patches/firefox-beta/clean.sh
@@ -16,5 +16,5 @@ if [[ -d $OBJ_FOLDER ]]; then
 fi
 
 if [[ -f "mach" ]]; then
-  ./mach clobber
+  ./mach clobber || true
 fi

--- a/browser_patches/firefox/clean.sh
+++ b/browser_patches/firefox/clean.sh
@@ -16,5 +16,5 @@ if [[ -d $OBJ_FOLDER ]]; then
 fi
 
 if [[ -f "mach" ]]; then
-  ./mach clobber
+  ./mach clobber || true
 fi


### PR DESCRIPTION
Turns out `mach clobber` works reliably only with a bootstrapped
checkout and fails otherwise.

Ignore failure if there's been no bootstrap since clobberring won't
change anything.
