### PR TITLE
test: wait for screenshots to get into trace before stopping

### DIFF
--- a/tests/tracing.spec.ts
+++ b/tests/tracing.spec.ts
@@ -139,6 +139,8 @@ test('should not include trace resources from the provious chunks', async ({ con
   await page.goto(server.EMPTY_PAGE);
   await page.setContent('<button>Click</button>');
   await page.click('"Click"');
+  // Give it enough time for both screenshots to get into the trace.
+  await new Promise(f => setTimeout(f, 1000));
   await context.tracing.stopChunk({ path: testInfo.outputPath('trace1.zip') });
 
   await context.tracing.startChunk();


### PR DESCRIPTION
The test has been flaky [recently](https://devops.aslushnikov.com/flakiness2.html#filter_spec=should+not+include+trace+resources+from+the+provious+chunks&timestamp=1639424793673).