### PR TITLE
chore: move setting PW User-Agent on connectOverCDP to the server side

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -23,7 +23,7 @@ import { Connection } from './connection';
 import { Events } from './events';
 import { ChildProcess } from 'child_process';
 import { envObjectToArray } from './clientHelper';
-import { assert, headersObjectToArray, getUserAgent, monotonicTime } from '../utils/utils';
+import { assert, headersObjectToArray, monotonicTime } from '../utils/utils';
 import * as api from '../../types/types';
 import { kBrowserClosedError } from '../utils/errors';
 import { raceAgainstDeadline } from '../utils/async';
@@ -205,9 +205,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
   async _connectOverCDP(endpointURL: string, params: api.ConnectOverCDPOptions = {}): Promise<Browser>  {
     if (this.name() !== 'chromium')
       throw new Error('Connecting over CDP is only supported in Chromium.');
-    const logger = params.logger;
-    const paramsHeaders = Object.assign({ 'User-Agent': getUserAgent() }, params.headers);
-    const headers = paramsHeaders ? headersObjectToArray(paramsHeaders) : undefined;
+    const headers = params.headers ? headersObjectToArray(params.headers) : undefined;
     const result = await this._channel.connectOverCDP({
       endpointURL,
       headers,
@@ -217,7 +215,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
     const browser = Browser.from(result.browser);
     if (result.defaultContext)
       browser._contexts.add(BrowserContext.from(result.defaultContext));
-    browser._logger = logger;
+    browser._logger = params.logger;
     browser._setBrowserType(this);
     browser._localUtils = this._playwright._utils;
     return browser;

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -27,7 +27,7 @@ import { ConnectionTransport, ProtocolRequest, WebSocketTransport } from '../tra
 import { CRDevTools } from './crDevTools';
 import { Browser, BrowserOptions, BrowserProcess, PlaywrightOptions } from '../browser';
 import * as types from '../types';
-import { debugMode, fetchData, headersArrayToObject, HTTPRequestParams, removeFolders, streamToString } from '../../utils/utils';
+import { debugMode, fetchData, getUserAgent, headersArrayToObject, HTTPRequestParams, removeFolders, streamToString } from '../../utils/utils';
 import { RecentLogsCollector } from '../../utils/debugLogger';
 import { Progress, ProgressController } from '../progress';
 import { TimeoutSettings } from '../../utils/timeoutSettings';
@@ -62,6 +62,11 @@ export class Chromium extends BrowserType {
     let headersMap: { [key: string]: string; } | undefined;
     if (options.headers)
       headersMap = headersArrayToObject(options.headers, false);
+
+    if (!headersMap)
+      headersMap = { 'User-Agent': getUserAgent() };
+    else if (headersMap && !Object.keys(headersMap).some(key => key.toLowerCase() === 'user-agent'))
+      headersMap['User-Agent'] = getUserAgent();
 
     const artifactsDir = await fs.promises.mkdtemp(ARTIFACTS_FOLDER);
 


### PR DESCRIPTION
This moves the default UA from the client to the server side. On the languages we didn't set the default UA yet, but we do it in Node.js. If there is a request in the future for adding the language name, then we can do it by using the env var.
