### PR TITLE
docs: Assert.Equal -> Assert.AreEqual

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -591,7 +591,7 @@ await page.SetContentAsync("<script>\n" +
 await page.ClickAsync("div");
 // Note: it makes sense to await the result here, because otherwise, the context
 //  gets closed and the binding function will throw an exception.
-Assert.Equal("Click me", await result.Task);
+Assert.AreEqual("Click me", await result.Task);
 ```
 
 ### param: BrowserContext.exposeBinding.name

--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -377,8 +377,8 @@ assert tweet_handle.eval_on_selector(".retweets", "node => node.innerText") = "1
 
 ```csharp
 var tweetHandle = await page.QuerySelectorAsync(".tweet");
-Assert.Equals("100", await tweetHandle.EvalOnSelectorAsync(".like", "node => node.innerText"));
-Assert.Equals("10", await tweetHandle.EvalOnSelectorAsync(".retweets", "node => node.innerText"));
+Assert.AreEqual("100", await tweetHandle.EvalOnSelectorAsync(".like", "node => node.innerText"));
+Assert.AreEqual("10", await tweetHandle.EvalOnSelectorAsync(".retweets", "node => node.innerText"));
 ```
 
 ### param: ElementHandle.evalOnSelector.selector = %%-query-selector-%%
@@ -436,7 +436,7 @@ assert feed_handle.eval_on_selector_all(".tweet", "nodes => nodes.map(n => n.inn
 
 ```csharp
 var feedHandle = await page.QuerySelectorAsync(".feed");
-Assert.Equals(new [] { "Hello!", "Hi!" }, await feedHandle.EvalOnSelectorAllAsync<string[]>(".tweet", "nodes => nodes.map(n => n.innerText)"));
+Assert.AreEqual(new [] { "Hello!", "Hi!" }, await feedHandle.EvalOnSelectorAllAsync<string[]>(".tweet", "nodes => nodes.map(n => n.innerText)"));
 ```
 
 ### param: ElementHandle.evalOnSelectorAll.selector = %%-query-selector-%%

--- a/docs/src/api/class-jshandle.md
+++ b/docs/src/api/class-jshandle.md
@@ -77,7 +77,7 @@ assert tweet_handle.evaluate("node => node.innerText") == "10 retweets"
 
 ```csharp
 var tweetHandle = await page.QuerySelectorAsync(".tweet .retweets");
-Assert.Equals("10 retweets", await tweetHandle.EvaluateAsync("node => node.innerText"));
+Assert.AreEqual("10 retweets", await tweetHandle.EvaluateAsync("node => node.innerText"));
 ```
 
 ### param: JSHandle.evaluate.expression = %%-evaluate-expression-%%

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -288,7 +288,7 @@ assert tweets.evaluate("node => node.innerText") == "10 retweets"
 
 ```csharp
 var tweets = page.Locator(".tweet .retweets");
-Assert.Equals("10 retweets", await tweets.EvaluateAsync("node => node.innerText"));
+Assert.AreEqual("10 retweets", await tweets.EvaluateAsync("node => node.innerText"));
 ```
 
 ### param: Locator.evaluate.expression = %%-evaluate-expression-%%

--- a/docs/src/assertions.md
+++ b/docs/src/assertions.md
@@ -32,7 +32,7 @@ assert content == "home"
 
 ```csharp
 var content = await page.TextContentAsync("nav:first-child");
-Assert.Equals("home", content);
+Assert.AreEqual("home", content);
 ```
 
 ### API reference
@@ -63,7 +63,7 @@ assert text == "value"
 
 ```csharp
 var content = await page.InnerTextAsync(".selected");
-Assert.Equals("value", content);
+Assert.AreEqual("value", content);
 ```
 
 ### API reference
@@ -94,7 +94,7 @@ assert alt == "Text"
 
 ```csharp
 var value = await page.GetAttributeAsync("input", "alt");
-Assert.Equals("Text", value);
+Assert.AreEqual("Text", value);
 ```
 
 ## Checkbox state
@@ -152,7 +152,7 @@ assert content == "home"
 
 ```csharp
 var content = await page.locator("nav:first-child").TextContentAsync();
-Assert.Equals("home", content);
+Assert.AreEqual("home", content);
 ```
 
 ### API reference
@@ -183,7 +183,7 @@ assert html == "<p>Result</p>"
 
 ```csharp
 var html = await page.InnerHTMLAsync("div.result");
-Assert.Equals("<p>Result</p>", html);
+Assert.AreEqual("<p>Result</p>", html);
 ```
 
 ### API reference
@@ -337,13 +337,13 @@ Assert.NotNull(userId);
 
 // Assert value for input element
 var value = await page.Locator("#search").InputValueAsync();
-Assert.Equals("query", value);
+Assert.AreEqual("query", value);
 
 // Assert computed style
 var fontSize = await page.Locator("div").EvalOnSelectorAsync<string>("el => window.getComputedStyle(el).fontSize");
-Assert.Equals("16px", fontSize);
+Assert.AreEqual("16px", fontSize);
 
 // Assert list length
 var length = await page.Locator("li.selected").CountAsync();
-Assert.Equals(3, length);
+Assert.AreEqual(3, length);
 ```

--- a/docs/src/dialogs.md
+++ b/docs/src/dialogs.md
@@ -124,7 +124,7 @@ page.close(run_before_unload=True)
 ```csharp
 page.Dialog += (_, dialog) =>
 {
-    Assert.Equal("beforeunload", dialog.Type);
+    Assert.AreEqual("beforeunload", dialog.Type);
     dialog.DismissAsync();
 };
 await page.CloseAsync(runBeforeUnload: true);

--- a/docs/src/handles.md
+++ b/docs/src/handles.md
@@ -118,7 +118,7 @@ var elementHandle = jsHandle as ElementHandle;
 
 // Assert bounding box for the element
 var boundingBox = await elementHandle.BoundingBoxAsync();
-Assert.Equal(100, boundingBox.Width);
+Assert.AreEqual(100, boundingBox.Width);
 
 // Assert attribute for the element
 var classNames = await elementHandle.GetAttributeAsync("class");


### PR DESCRIPTION
See here https://stackoverflow.com/questions/11584429/nunits-assert-equals-throws-exception-assert-equals-should-not-be-used-for-ass

We use it / enforce it in .NET already. Assert.Equal does also not work with Nunit.