### PR TITLE
feat: export tagged pdf by default

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -319,6 +319,7 @@ const DEFAULT_ARGS = [
   '--use-mock-keychain',
   // See https://chromium-review.googlesource.com/c/chromium/src/+/2436773
   '--no-service-autorun',
+  '--export-tagged-pdf'
 ];
 
 async function urlToWSEndpoint(progress: Progress, endpointURL: string) {


### PR DESCRIPTION
Since v85 Chrome does export pdf with accessibility tags [by default](https://blog.chromium.org/2020/07/using-chrome-to-generate-more.html). Enable this in Playwright too.

<!--
Thank you for your Pull Request. Please link to the issue this PR addresses.
-->
Fixes: https://github.com/microsoft/playwright-java/issues/745

<!-- PR Checklist
- The issue has been triaged and positive signals were received from maintainers
- Existing tests pass
- New tests are added
- Relevant documentation is changed or added
-->
