### PR TITLE
chore(test runner): create TestResult instances lazily in dispatcher

### DIFF
--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -33,7 +33,6 @@ export type WorkerInitParams = {
 export type TestBeginPayload = {
   testId: string;
   startWallTime: number;  // milliseconds since unix epoch
-  workerIndex: number;
 };
 
 export type TestEndPayload = {

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -600,7 +600,6 @@ export class WorkerRunner extends EventEmitter {
 function buildTestBeginPayload(testId: string, testInfo: TestInfo, startWallTime: number): TestBeginPayload {
   return {
     testId,
-    workerIndex: testInfo.workerIndex,
     startWallTime,
   };
 }

--- a/tests/playwright-test/max-failures.spec.ts
+++ b/tests/playwright-test/max-failures.spec.ts
@@ -38,6 +38,8 @@ test('max-failures should work', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(8);
   expect(result.output.split('\n').filter(l => l.includes('expect(')).length).toBe(16);
+  expect(result.report.suites[0].specs.map(spec => spec.tests[0].results.length)).toEqual(new Array(10).fill(1));
+  expect(result.report.suites[1].specs.map(spec => spec.tests[0].results.length)).toEqual(new Array(10).fill(1));
 });
 
 test('-x should work', async ({ runInlineTest }) => {


### PR DESCRIPTION
This prepares for beforeAll/afterAll hooks to be handled in the same way. Since we do not know in advance whether a hook will run, we must create TestResults lazily.

Drive-by: fix an issue where steps from one test run will get into another test run.
