### PR TITLE
browser(firefox): use pre-downloaded toolchains for release builds

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1310
-Changed: lushnikov@chromium.org Tue Dec 14 15:56:05 PST 2021
+1311
+Changed: lushnikov@chromium.org Tue Dec 14 23:27:53 PST 2021

--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -63,6 +63,8 @@ echo "ac_add_options --disable-backgroundtasks" >> .mozconfig
 if [[ -n $FF_DEBUG_BUILD ]]; then
   echo "ac_add_options --enable-debug" >> .mozconfig
   echo "ac_add_options --enable-debug-symbols" >> .mozconfig
+else
+  echo "ac_add_options --enable-release" >> .mozconfig
 fi
 
 if [[ "$(uname)" == MINGW* || "$(uname)" == "Darwin" ]]; then
@@ -86,7 +88,7 @@ if [[ $1 != "--juggler" ]]; then
   fi
 fi
 
-if [[ $1 == "--full" || $2 == "--full" ]]; then
+if [[ $1 == "--full" || $2 == "--full" || $1 == "--bootstrap" ]]; then
   echo "ac_add_options --enable-bootstrap" >> .mozconfig
   if [[ "$(uname)" == "Darwin" || "$(uname)" == "Linux" ]]; then
     SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser
@@ -103,13 +105,15 @@ fi
 
 if [[ $1 == "--juggler" ]]; then
   ./mach build faster
+elif [[ $1 == "--bootstrap" ]]; then
+  ./mach configure
 else
   ./mach build
+  if [[ "$(uname)" == "Darwin" ]]; then
+    node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/${OBJ_FOLDER}/dist
+  else
+    node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/${OBJ_FOLDER}/dist/bin
+  fi
 fi
 
-if [[ "$(uname)" == "Darwin" ]]; then
-  node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/${OBJ_FOLDER}/dist
-else
-  node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/${OBJ_FOLDER}/dist/bin
-fi
 

--- a/browser_patches/firefox-beta/patches/bootstrap.diff
+++ b/browser_patches/firefox-beta/patches/bootstrap.diff
@@ -1863,7 +1863,7 @@ index b32d426ba38045d14e6f1e79d17e8e6061e78227..df782034e79466fcc251e9a06e99d2e1
    }
  
 diff --git a/js/src/vm/DateTime.cpp b/js/src/vm/DateTime.cpp
-index e8f27fb69691aa6062c860a14ec94660fb9e5189..67715cbbc8257f11927564b45bbc8ee5384f809d 100644
+index e8f27fb69691aa6062c860a14ec94660fb9e5189..83cffc97f12072c24a7ea1bbd7b26ee37d856df3 100644
 --- a/js/src/vm/DateTime.cpp
 +++ b/js/src/vm/DateTime.cpp
 @@ -170,6 +170,11 @@ void js::DateTimeInfo::internalResetTimeZone(ResetTimeZoneMode mode) {
@@ -1903,13 +1903,16 @@ index e8f27fb69691aa6062c860a14ec94660fb9e5189..67715cbbc8257f11927564b45bbc8ee5
  #if JS_HAS_INTL_API
  #  if defined(XP_WIN)
  static bool IsOlsonCompatibleWindowsTimeZoneId(std::string_view tz) {
-@@ -719,9 +738,14 @@ void js::ResyncICUDefaultTimeZone() {
+@@ -719,9 +738,17 @@ void js::ResyncICUDefaultTimeZone() {
  
  void js::DateTimeInfo::internalResyncICUDefaultTimeZone() {
  #if JS_HAS_INTL_API
 +  if (!timeZoneOverride_.empty()) {
 +    mozilla::Span<const char> tzid = mozilla::Span(timeZoneOverride_.data(), timeZoneOverride_.length());
-+    mozilla::intl::TimeZone::SetDefaultTimeZone(tzid);
++    auto result = mozilla::intl::TimeZone::SetDefaultTimeZone(tzid);
++    if (result.isErr()) {
++      fprintf(stderr, "ERROR: failed to setup default time zone\n");
++    }
 +    return;
 +  }
 +

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1310
-Changed: lushnikov@chromium.org Mon 13 Dec 2021 07:00:27 PM PST
+1311
+Changed: lushnikov@chromium.org Tue Dec 14 23:26:10 PST 2021

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -104,8 +104,7 @@ fi
 if [[ "$(uname)" == "Darwin" ]]; then
   if [[ ! -d "$HOME/.mozbuild/clang" ]]; then
     echo "ERROR: build toolchains are not found, specifically \$HOME/.mozbuild/clang is not there!"
-    echo "Since December, 2021, release build toolchains cannot be downloaded automatically. See:"
-    echo "   https://bugzilla.mozilla.org/show_bug.cgi?id=1744197#c2"
+    echo "Since December, 2021, build toolchains have to be predownloaded (see https://github.com/microsoft/playwright/pull/10929)"
     echo
     echo "To bootstrap toolchains:"
     echo "    ./browser_patches/prepare_checkout.sh firefox-beta"

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -62,6 +62,9 @@ echo "ac_add_options --disable-backgroundtasks" >> .mozconfig
 
 if [[ -n $FF_DEBUG_BUILD ]]; then
   echo "ac_add_options --enable-debug" >> .mozconfig
+  echo "ac_add_options --enable-debug-symbols" >> .mozconfig
+else
+  echo "ac_add_options --enable-release" >> .mozconfig
 fi
 
 if [[ "$(uname)" == MINGW* || "$(uname)" == "Darwin" ]]; then
@@ -89,31 +92,29 @@ if [[ $1 == "--full" || $2 == "--full" ]]; then
   if [[ "$(uname)" == "Darwin" || "$(uname)" == "Linux" ]]; then
     SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser
   fi
-  if [[ "$(uname)" == "Darwin" ]]; then
-    HOMEBREW_LLVM="/opt/homebrew/opt/llvm/bin/clang";
-    if [[ ! -f "${HOMEBREW_LLVM}" || $($HOMEBREW_LLVM --version) != *"version 13"* ]]; then
-      echo "ERROR: as of Dec, 2021, building release firefox requires HomeBrew LLVM v13"
-      echo "Please run:"
-      echo
-      echo "    brew install llvm@13"
-      echo
-      exit 1
-    fi
-    echo "CC=${HOMEBREW_LLVM}" >> .mozconfig
-    echo "CXX=${HOMEBREW_LLVM}++" >> .mozconfig
-
-    # Download wasi toolchain if needed
-    if [[ ! -d "$HOME/.mozbuild/sysroot-wasm32-wasi" ]]; then
-      ./mach artifact toolchain --from-build toolchain-sysroot-wasm32-wasi
-      mv ./sysroot-wasm32-wasi ~/.mozbuild/
-    fi
-  elif [[ "$(uname)" == "Linux" ]]; then
+  if [[ "$(uname)" == "Linux" ]]; then
     echo "ac_add_options --enable-bootstrap" >> .mozconfig
   fi
   if [[ ! -z "${WIN32_REDIST_DIR}" ]]; then
     # Having this option in .mozconfig kills incremental compilation.
     echo "export WIN32_REDIST_DIR=\"$WIN32_REDIST_DIR\"" >> .mozconfig
   fi
+fi
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  if [[ ! -d "$HOME/.mozbuild/clang" ]]; then
+    echo "ERROR: build toolchains are not found, specifically \$HOME/.mozbuild/clang is not there!"
+    echo "Since December, 2021, release build toolchains cannot be downloaded automatically. See:"
+    echo "   https://bugzilla.mozilla.org/show_bug.cgi?id=1744197#c2"
+    echo
+    echo "To bootstrap toolchains:"
+    echo "    ./browser_patches/prepare_checkout.sh firefox-beta"
+    echo "    ./browser_patches/build.sh firefox-beta --bootstrap"
+    echo
+    exit 1
+  fi
+  export MOZ_AUTOMATION=1
+  export MOZ_FETCHES_DIR=$HOME/.mozbuild
 fi
 
 if ! [[ -f "$HOME/.mozbuild/_virtualenvs/mach/bin/python" ]]; then

--- a/browser_patches/firefox/patches/bootstrap.diff
+++ b/browser_patches/firefox/patches/bootstrap.diff
@@ -1871,7 +1871,7 @@ index b32d426ba38045d14e6f1e79d17e8e6061e78227..df782034e79466fcc251e9a06e99d2e1
    }
  
 diff --git a/js/src/vm/DateTime.cpp b/js/src/vm/DateTime.cpp
-index e8f27fb69691aa6062c860a14ec94660fb9e5189..67715cbbc8257f11927564b45bbc8ee5384f809d 100644
+index e8f27fb69691aa6062c860a14ec94660fb9e5189..83cffc97f12072c24a7ea1bbd7b26ee37d856df3 100644
 --- a/js/src/vm/DateTime.cpp
 +++ b/js/src/vm/DateTime.cpp
 @@ -170,6 +170,11 @@ void js::DateTimeInfo::internalResetTimeZone(ResetTimeZoneMode mode) {
@@ -1911,13 +1911,16 @@ index e8f27fb69691aa6062c860a14ec94660fb9e5189..67715cbbc8257f11927564b45bbc8ee5
  #if JS_HAS_INTL_API
  #  if defined(XP_WIN)
  static bool IsOlsonCompatibleWindowsTimeZoneId(std::string_view tz) {
-@@ -719,9 +738,14 @@ void js::ResyncICUDefaultTimeZone() {
+@@ -719,9 +738,17 @@ void js::ResyncICUDefaultTimeZone() {
  
  void js::DateTimeInfo::internalResyncICUDefaultTimeZone() {
  #if JS_HAS_INTL_API
 +  if (!timeZoneOverride_.empty()) {
 +    mozilla::Span<const char> tzid = mozilla::Span(timeZoneOverride_.data(), timeZoneOverride_.length());
-+    mozilla::intl::TimeZone::SetDefaultTimeZone(tzid);
++    auto result = mozilla::intl::TimeZone::SetDefaultTimeZone(tzid);
++    if (result.isErr()) {
++      fprintf(stderr, "ERROR: failed to setup default time zone\n");
++    }
 +    return;
 +  }
 +
@@ -2559,7 +2562,7 @@ diff --git a/widget/cocoa/NativeKeyBindings.mm b/widget/cocoa/NativeKeyBindings.
 index 2b11df66d9445080d4d8a19a915b3e00285c5d32..caef1b65bbcff899f45c3e3cddfe76e88479ec30 100644
 --- a/widget/cocoa/NativeKeyBindings.mm
 +++ b/widget/cocoa/NativeKeyBindings.mm
-@@ -491,6 +491,13 @@ void NativeKeyBindings::GetEditCommandsForTests(NativeKeyBindingsType aType,
+@@ -491,6 +491,13 @@
        break;
      case KEY_NAME_INDEX_ArrowLeft:
        if (aEvent.IsAlt()) {
@@ -2573,7 +2576,7 @@ index 2b11df66d9445080d4d8a19a915b3e00285c5d32..caef1b65bbcff899f45c3e3cddfe76e8
          break;
        }
        if (aEvent.IsMeta() || (aEvent.IsControl() && aEvent.IsShift())) {
-@@ -511,6 +518,13 @@ void NativeKeyBindings::GetEditCommandsForTests(NativeKeyBindingsType aType,
+@@ -511,6 +518,13 @@
        break;
      case KEY_NAME_INDEX_ArrowRight:
        if (aEvent.IsAlt()) {
@@ -2587,7 +2590,7 @@ index 2b11df66d9445080d4d8a19a915b3e00285c5d32..caef1b65bbcff899f45c3e3cddfe76e8
          break;
        }
        if (aEvent.IsMeta() || (aEvent.IsControl() && aEvent.IsShift())) {
-@@ -531,6 +545,10 @@ void NativeKeyBindings::GetEditCommandsForTests(NativeKeyBindingsType aType,
+@@ -531,6 +545,10 @@
        break;
      case KEY_NAME_INDEX_ArrowUp:
        if (aEvent.IsControl()) {
@@ -2598,7 +2601,7 @@ index 2b11df66d9445080d4d8a19a915b3e00285c5d32..caef1b65bbcff899f45c3e3cddfe76e8
          break;
        }
        if (aEvent.IsMeta()) {
-@@ -540,7 +558,7 @@ void NativeKeyBindings::GetEditCommandsForTests(NativeKeyBindingsType aType,
+@@ -540,7 +558,7 @@
          instance->AppendEditCommandsForSelector(
              !aEvent.IsShift()
                  ? ToObjcSelectorPtr(@selector(moveToBeginningOfDocument:))
@@ -2607,7 +2610,7 @@ index 2b11df66d9445080d4d8a19a915b3e00285c5d32..caef1b65bbcff899f45c3e3cddfe76e8
              aCommands);
          break;
        }
-@@ -563,6 +581,10 @@ void NativeKeyBindings::GetEditCommandsForTests(NativeKeyBindingsType aType,
+@@ -563,6 +581,10 @@
        break;
      case KEY_NAME_INDEX_ArrowDown:
        if (aEvent.IsControl()) {


### PR DESCRIPTION
Firefox requires a bunch of build tools (aka "toolchains") to be built.
Until recently, default MacOS clang (that comes with Xcode) was
sufficient to compile firefox.

However, Firefox 95 started to use WebAssembly: https://hacks.mozilla.org/2021/12/webassembly-and-back-again-fine-grained-sandboxing-in-firefox-95/

This yielded the following issues specific to MacOS (somehow builds complete successfully on other platforms):

- Default MacOS clang that comes with XCode doesn't support WebAssembly: https://github.com/WebAssembly/wasi-sdk/issues/172#issuecomment-772399153
- Clang that comes from Homebrew is missing `libclang_rt.builtins-wasm32.a`: https://github.com/jedisct1/libclang_rt.builtins-wasm32.a/blob/79b9b39f9be950110d3a7d6f91d86074349d8302/README.md
- Firefox also requires `wasi sysroot`

Now, depending on which branch firefox checkout comes from
(`mozilla-release` vs `mozilla-beta`), firefox build system **might** or
**might not** be able to download all the required toolchains in the
`$HOME/.mozbuild` folder:
- `mozilla-beta` branch supports toolchain auto-download
- `mozilla-release` **does not** support it yet: https://bugzilla.mozilla.org/show_bug.cgi?id=1744197#c2

The recommended solution is to download toolchains using non-release
firefox branch, and then re-use these toolchains to compile firefox from
release branch.

This patch does exactly this: relies on pre-downloaded toolchains for
release firefox compilation. To re-use pre-downloaded toolchains, we set a
combination of `MOZ_AUTOMATION` and `MOZ_FETCH_DIR` environment
variables - this is the same approach that is used on the official
Firefox CI (see `about:buildconfig` page in the stable firefox 95).

This almost works, but there's a catch: the `MOZ_AUTOMATION` environment
variable auto-adds ("implies") the `--enable-release` configuration
option: https://github.com/mozilla/gecko-dev/blob/9e1cd985485c0e01c5faa9b5072a405b344ebde7/moz.configure#L162

The `--enable-release` is supposed to yield a better binary, and we want
builds to be the same across platforms, so this patch adds this option
**unconditionally on all platforms**.

The `--enable-release` is also more picky about the source code: for
example, it complains about unused return values. Browser changes in
this patch are addressing these.

References #10759
