### PR TITLE
browser(firefox-beta): remove use of `mach create-mach-environment`

### DIFF
--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -97,10 +97,6 @@ if [[ $1 == "--full" || $2 == "--full" ]]; then
   fi
 fi
 
-if ! [[ -f "$HOME/.mozbuild/_virtualenvs/mach/bin/python" ]]; then
-  ./mach create-mach-environment
-fi
-
 if [[ $1 == "--juggler" ]]; then
   ./mach build faster
 else


### PR DESCRIPTION
This command has been removed and is no longer needed: https://github.com/mozilla/gecko-dev/commit/abeedf3bbdabc32f17e0bee074c4b81eded853f6#diff-080f2a5f770785d46fa3a2404de9430136a5a6c5a4739dab3c47cfbd7421ce79

