### PR TITLE
fix(tracing): return early if no trace was produced

### DIFF
--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -65,6 +65,9 @@ export class Tracing implements api.Tracing {
       return;
     }
 
+    if (!result.artifact)
+      return;
+
     // Save trace to the final local file.
     const artifact = Artifact.from(result.artifact!);
     await artifact.saveAs(filePath);

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -65,11 +65,12 @@ export class Tracing implements api.Tracing {
       return;
     }
 
+    // The artifact may be missing if the browser closed while stopping tracing.
     if (!result.artifact)
       return;
 
     // Save trace to the final local file.
-    const artifact = Artifact.from(result.artifact!);
+    const artifact = Artifact.from(result.artifact);
     await artifact.saveAs(filePath);
     await artifact.delete();
 

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -840,6 +840,7 @@ BrowserContext:
           - compressTrace
           - compressTraceAndSources
       returns:
+        # The artifact may be missing if the browser closes while tracing is beeing stopped.
         artifact: Artifact?
         sourceEntries:
           type: array?


### PR DESCRIPTION
This fixes [page/page-set-input-files.spec.ts](https://devops.aslushnikov.com/flakiness2.html#filter_spec=page%2Fpage-set-input-files.spec.ts&commits=50&test_parameter_filters=%5B%5B%22browserName%22%2C%5B%5B%22electron%22%2C%22exclude%22%5D%5D%5D%2C%5B%22platform%22%2C%5B%5B%22Android%22%2C%22exclude%22%5D%5D%5D%2C%5B%22video%22%2C%5B%5Btrue%2C%22exclude%22%5D%5D%5D%2C%5B%22trace%22%2C%5B%5Btrue%2C%22include%22%5D%5D%5D%5D&timestamp=1639590204582) failures.

