### PR TITLE
fix(test runner): disable expect, action and navigation timeouts on debug

### DIFF
--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -189,8 +189,8 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
 
     const onDidCreateContext = async (context: BrowserContext) => {
       createdContexts.add(context);
-      context.setDefaultTimeout(actionTimeout || 0);
-      context.setDefaultNavigationTimeout(navigationTimeout || actionTimeout || 0);
+      context.setDefaultTimeout(testInfo.timeout === 0 ? 0 : (actionTimeout || 0));
+      context.setDefaultNavigationTimeout(testInfo.timeout === 0 ? 0 : (navigationTimeout || actionTimeout || 0));
       if (captureTrace) {
         const title = [path.relative(testInfo.project.testDir, testInfo.file) + ':' + testInfo.line, ...testInfo.titlePath.slice(1)].join(' › ');
         if (!(context.tracing as any)[kTracingStarted]) {
@@ -207,8 +207,11 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
         onApiCallBegin: (apiCall: string, stackTrace: ParsedStackTrace | null, userData: any) => {
           if (apiCall.startsWith('expect.'))
             return { userObject: null };
-          if (apiCall === 'page.pause')
+          if (apiCall === 'page.pause') {
             testInfo.setTimeout(0);
+            context.setDefaultNavigationTimeout(0);
+            context.setDefaultTimeout(0);
+          }
           const testInfoImpl = testInfo as any;
           const step = testInfoImpl._addStep({
             location: stackTrace?.frames[0],

--- a/packages/playwright-test/src/matchers/toBeTruthy.ts
+++ b/packages/playwright-test/src/matchers/toBeTruthy.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { currentTestInfo } from '../globals';
 import type { Expect } from '../types';
 import { expectType } from '../util';
-import { callLogText } from './toMatchText';
+import { callLogText, currentExpectTimeout } from './toMatchText';
 
 export async function toBeTruthy(
   this: ReturnType<Expect['getState']>,
@@ -34,11 +33,7 @@ export async function toBeTruthy(
     promise: this.promise,
   };
 
-  const testInfo = currentTestInfo();
-  let defaultExpectTimeout = testInfo?.project.expect?.timeout;
-  if (typeof defaultExpectTimeout === 'undefined')
-    defaultExpectTimeout = 5000;
-  const timeout = options.timeout === 0 ? 0 : options.timeout || defaultExpectTimeout;
+  const timeout = currentExpectTimeout(options);
 
   const { matches, log } = await query(this.isNot, timeout);
 

--- a/packages/playwright-test/src/matchers/toEqual.ts
+++ b/packages/playwright-test/src/matchers/toEqual.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { currentTestInfo } from '../globals';
 import type { Expect } from '../types';
 import { expectType } from '../util';
-import { callLogText } from './toMatchText';
+import { callLogText, currentExpectTimeout } from './toMatchText';
 
 // Omit colon and one or more spaces, so can call getLabelPrinter.
 const EXPECTED_LABEL = 'Expected';
@@ -43,11 +42,7 @@ export async function toEqual<T>(
     promise: this.promise,
   };
 
-  const testInfo = currentTestInfo();
-  let defaultExpectTimeout = testInfo?.project.expect?.timeout;
-  if (typeof defaultExpectTimeout === 'undefined')
-    defaultExpectTimeout = 5000;
-  const timeout = options.timeout === 0 ? 0 : options.timeout || defaultExpectTimeout;
+  const timeout = currentExpectTimeout(options);
 
   const { matches: pass, received, log } = await query(this.isNot, timeout);
 

--- a/packages/playwright-test/src/matchers/toMatchText.ts
+++ b/packages/playwright-test/src/matchers/toMatchText.ts
@@ -57,11 +57,7 @@ export async function toMatchText(
     );
   }
 
-  const testInfo = currentTestInfo();
-  let defaultExpectTimeout = testInfo?.project.expect?.timeout;
-  if (typeof defaultExpectTimeout === 'undefined')
-    defaultExpectTimeout = 5000;
-  const timeout = options.timeout === 0 ? 0 : options.timeout || defaultExpectTimeout;
+  const timeout = currentExpectTimeout(options);
 
   const { matches: pass, received, log } = await query(this.isNot, timeout);
   const stringSubstring = options.matchSubstring ? 'substring' : 'string';
@@ -123,4 +119,16 @@ export function callLogText(log: string[] | undefined): string {
 Call log:
   ${colors.dim('- ' + (log || []).join('\n  - '))}
 `;
+}
+
+export function currentExpectTimeout(options: { timeout?: number }) {
+  const testInfo = currentTestInfo();
+  if (testInfo && !testInfo.timeout)
+    return 0;
+  if (options.timeout !== undefined)
+    return options.timeout;
+  let defaultExpectTimeout = testInfo?.project.expect?.timeout;
+  if (typeof defaultExpectTimeout === 'undefined')
+    defaultExpectTimeout = 5000;
+  return defaultExpectTimeout;
 }


### PR DESCRIPTION
We disable these timeouts when test timeout is set to zero.
This covers PWDEBUG=1, --debug and manual `test.setTimeout(0)` scenarios.

Fixes #10416.