### PR TITLE
devops: fix firefox packaging for Ubuntu 20.04 arm64

### DIFF
--- a/browser_patches/firefox-beta/patches/bootstrap.diff
+++ b/browser_patches/firefox-beta/patches/bootstrap.diff
@@ -2069,6 +2069,19 @@ index 35526ca3a37327b324166dd42e450d108667a643..a2c70b2b432b2a714a928a1c08f520b0
    nsresult rv = NS_OK;
    nsCOMPtr<nsIContentSecurityPolicy> preloadCsp = mDocument->GetPreloadCsp();
    if (!preloadCsp) {
+diff --git a/python/mozbuild/mozpack/executables.py b/python/mozbuild/mozpack/executables.py
+index ce1f7dab4bc943f7de5e2f18655475e254699200..817c091fbb94abe3fbffebd3e10ff45be14eca62 100644
+--- a/python/mozbuild/mozpack/executables.py
++++ b/python/mozbuild/mozpack/executables.py
+@@ -107,7 +107,7 @@ def strip(path):
+     """
+     from buildconfig import substs
+ 
+-    strip = substs["STRIP"]
++    strip = os.getenv("CMD_STRIP") or substs["STRIP"]
+     flags = substs.get("STRIP_FLAGS", [])
+     cmd = [strip] + flags + [path]
+     if subprocess.call(cmd) != 0:
 diff --git a/security/manager/ssl/nsCertOverrideService.cpp b/security/manager/ssl/nsCertOverrideService.cpp
 index 03e2907b34448eef0843902e4fbe3e03ae0db720..0e24ebe3bddbf76fdc7fb6a02a20edb81a12db18 100644
 --- a/security/manager/ssl/nsCertOverrideService.cpp

--- a/browser_patches/firefox/patches/bootstrap.diff
+++ b/browser_patches/firefox/patches/bootstrap.diff
@@ -2077,6 +2077,19 @@ index 35526ca3a37327b324166dd42e450d108667a643..a2c70b2b432b2a714a928a1c08f520b0
    nsresult rv = NS_OK;
    nsCOMPtr<nsIContentSecurityPolicy> preloadCsp = mDocument->GetPreloadCsp();
    if (!preloadCsp) {
+diff --git a/python/mozbuild/mozpack/executables.py b/python/mozbuild/mozpack/executables.py
+index ce1f7dab4bc943f7de5e2f18655475e254699200..817c091fbb94abe3fbffebd3e10ff45be14eca62 100644
+--- a/python/mozbuild/mozpack/executables.py
++++ b/python/mozbuild/mozpack/executables.py
+@@ -107,7 +107,7 @@ def strip(path):
+     """
+     from buildconfig import substs
+ 
+-    strip = substs["STRIP"]
++    strip = os.getenv("CMD_STRIP") or substs["STRIP"]
+     flags = substs.get("STRIP_FLAGS", [])
+     cmd = [strip] + flags + [path]
+     if subprocess.call(cmd) != 0:
 diff --git a/security/manager/ssl/nsCertOverrideService.cpp b/security/manager/ssl/nsCertOverrideService.cpp
 index 36e7ff2d6985e9210371a74cc8a010ded7fadda6..d606982aa6a33dedd7878d13f4032dacf9de59a6 100644
 --- a/security/manager/ssl/nsCertOverrideService.cpp


### PR DESCRIPTION
This was originally landed in
https://github.com/microsoft/playwright/pull/10091 but got accidentally
reverted by https://github.com/microsoft/playwright/pull/10760

NOTE: since this is a build system change, `BUILD_NUMBER` bump is not necessary.

References #10759

