### PR TITLE
fix(inspector): do not show internal calls

### DIFF
--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -167,12 +167,16 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
 
   setDefaultNavigationTimeout(timeout: number) {
     this._timeoutSettings.setDefaultNavigationTimeout(timeout);
-    this._channel.setDefaultNavigationTimeoutNoReply({ timeout });
+    this._wrapApiCall(async () => {
+      this._channel.setDefaultNavigationTimeoutNoReply({ timeout });
+    }, true);
   }
 
   setDefaultTimeout(timeout: number) {
     this._timeoutSettings.setDefaultTimeout(timeout);
-    this._channel.setDefaultTimeoutNoReply({ timeout });
+    this._wrapApiCall(async () => {
+      this._channel.setDefaultTimeoutNoReply({ timeout });
+    }, true);
   }
 
   browser(): Browser | null {

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -238,12 +238,16 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
 
   setDefaultNavigationTimeout(timeout: number) {
     this._timeoutSettings.setDefaultNavigationTimeout(timeout);
-    this._channel.setDefaultNavigationTimeoutNoReply({ timeout });
+    this._wrapApiCall(async () => {
+      this._channel.setDefaultNavigationTimeoutNoReply({ timeout });
+    }, true);
   }
 
   setDefaultTimeout(timeout: number) {
     this._timeoutSettings.setDefaultTimeout(timeout);
-    this._channel.setDefaultTimeoutNoReply({ timeout });
+    this._wrapApiCall(async () => {
+      this._channel.setDefaultTimeoutNoReply({ timeout });
+    }, true);
   }
 
   private _forceVideo(): Video {

--- a/packages/playwright-core/src/server/supplements/recorderSupplement.ts
+++ b/packages/playwright-core/src/server/supplements/recorderSupplement.ts
@@ -257,7 +257,7 @@ export class RecorderSupplement implements InstrumentationListener {
       return;
     const logs: CallLog[] = [];
     for (const metadata of metadatas) {
-      if (!metadata.method)
+      if (!metadata.method || metadata.internal)
         continue;
       let status: CallLogStatus = 'done';
       if (this._currentCallsMetadata.has(metadata))


### PR DESCRIPTION
Also mark setDefault{Navigation,}Timeout as always internal.
