### PR TITLE
docs(intro): fix optionally install browsers url

### DIFF
--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -47,7 +47,7 @@ npm i -D @playwright/test
 npx playwright install
 ```
 
-You can optionally install only selected browsers, see [installing browsers](./browsers.md#installing-browsers) for more details. Or you can install no browsers at all and use existing [browser channels](./browsers.md).
+You can optionally install only selected browsers, see [install browsers](./cli.md#install-browsers) for more details. Or you can install no browsers at all and use existing [browser channels](./browsers.md).
 
 ## First test
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please link to the issue this PR addresses.
-->
The Getting started section in docs (Node.js) mentions this
> You can optionally install only selected browsers, see installing browsers for more details.

However the [installing browsers](https://playwright.dev/docs/browsers#installing-browsers) section does not mention anything about optionally installing browsers.

This PR updates the url to [install browsers](https://playwright.dev/docs/cli#install-browsers) from Command line tools instead.

<!-- PR Checklist
- The issue has been triaged and positive signals were received from maintainers
- Existing tests pass
- New tests are added
- Relevant documentation is changed or added
-->
