### PR TITLE
feat(reporters): show retry #x when running a test

### DIFF
--- a/packages/playwright-test/src/reporters/line.ts
+++ b/packages/playwright-test/src/reporters/line.ts
@@ -15,7 +15,7 @@
  */
 
 import colors from 'colors/safe';
-import { BaseReporter, formatFailure, formatTestTitle } from './base';
+import { BaseReporter, fitToScreen, formatFailure, formatTestTitle } from './base';
 import { FullConfig, TestCase, Suite, TestResult, FullResult } from '../../types/testReporter';
 
 class LineReporter extends BaseReporter {
@@ -50,7 +50,8 @@ class LineReporter extends BaseReporter {
       stream.write(`\u001B[1A\u001B[2K`);
     if (test && this._lastTest !== test) {
       // Write new header for the output.
-      stream.write(colors.gray(formatTestTitle(this.config, test) + `\n`));
+      const title = colors.gray(formatTestTitle(this.config, test));
+      stream.write(fitToScreen(title, this.ttyWidth()) + `\n`);
       this._lastTest = test;
     }
 
@@ -60,15 +61,15 @@ class LineReporter extends BaseReporter {
 
   override onTestEnd(test: TestCase, result: TestResult) {
     super.onTestEnd(test, result);
-    const width = process.env.PWTEST_SKIP_TEST_OUTPUT ? 79 : process.stdout.columns! - 1;
     if (!test.title.startsWith('beforeAll') && !test.title.startsWith('afterAll'))
       ++this._current;
     const retriesSuffix = this.totalTestCount < this._current ? ` (retries)` : ``;
-    const title = `[${this._current}/${this.totalTestCount}]${retriesSuffix} ${formatTestTitle(this.config, test)}`.substring(0, width);
+    const title = `[${this._current}/${this.totalTestCount}]${retriesSuffix} ${formatTestTitle(this.config, test)}`;
+    const suffix = result.retry ? ` (retry #${result.retry})` : '';
     if (process.env.PWTEST_SKIP_TEST_OUTPUT)
-      process.stdout.write(`${title}\n`);
+      process.stdout.write(`${title + suffix}\n`);
     else
-      process.stdout.write(`\u001B[1A\u001B[2K${title}\n`);
+      process.stdout.write(`\u001B[1A\u001B[2K${fitToScreen(title, this.ttyWidth(), suffix) + colors.yellow(suffix)}\n`);
 
     if (!this.willRetry(test) && (test.outcome() === 'flaky' || test.outcome() === 'unexpected')) {
       if (!process.env.PWTEST_SKIP_TEST_OUTPUT)

--- a/tests/playwright-test/reporter-line.spec.ts
+++ b/tests/playwright-test/reporter-line.spec.ts
@@ -27,15 +27,15 @@ test('render unexpected after retry', async ({ runInlineTest }) => {
   }, { retries: 3, reporter: 'line' });
   const text = stripAscii(result.output);
   expect(text).toContain('[1/1] a.test.js:6:7 › one');
-  expect(text).toContain('[2/1] (retries) a.test.js:6:7 › one');
-  expect(text).toContain('[3/1] (retries) a.test.js:6:7 › one');
-  expect(text).toContain('[4/1] (retries) a.test.js:6:7 › one');
+  expect(text).toContain('[2/1] (retries) a.test.js:6:7 › one (retry #1)');
+  expect(text).toContain('[3/1] (retries) a.test.js:6:7 › one (retry #2)');
+  expect(text).toContain('[4/1] (retries) a.test.js:6:7 › one (retry #3)');
   expect(text).toContain('1 failed');
   expect(text).toContain('1) a.test');
   expect(text).not.toContain('2) a.test');
-  expect(text).toContain('Retry #1');
-  expect(text).toContain('Retry #2');
-  expect(text).toContain('Retry #3');
+  expect(text).toContain('Retry #1 ----');
+  expect(text).toContain('Retry #2 ----');
+  expect(text).toContain('Retry #3 ----');
   expect(result.exitCode).toBe(1);
 });
 


### PR DESCRIPTION
Here is an example:

```bash
  ✘  [chromium] › page/page-click.spec.ts:26:4 › should click the button button button button button button  (768ms)
  ✓  [chromium] › page/page-click.spec.ts:26:4 › should click the button button button button but (retry #1) (727ms)
```

Drive-by:
- moved common `fitToScreen` into base;
- fixed an issue with `fitToScreen` by resetting the `regex.lastIndex` to zero.

Fixes #10888.


