### PR TITLE
fix(test runner): test.setTimeout should not break debugging

### DIFF
--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -329,6 +329,8 @@ export class WorkerRunner extends EventEmitter {
       fail: (...args: [arg?: any, description?: string]) => modifier(testInfo, 'fail', args),
       slow: (...args: [arg?: any, description?: string]) => modifier(testInfo, 'slow', args),
       setTimeout: (timeout: number) => {
+        if (!testInfo.timeout)
+          return; // Zero timeout means some debug mode - do not set a timeout.
         testInfo.timeout = timeout;
         if (deadlineRunner)
           deadlineRunner.updateDeadline(deadline());

--- a/tests/playwright-test/timeout.spec.ts
+++ b/tests/playwright-test/timeout.spec.ts
@@ -140,3 +140,17 @@ test('should respect test.slow', async ({ runInlineTest }) => {
   expect(result.passed).toBe(2);
   expect(result.output).toContain('Timeout of 1000ms exceeded');
 });
+
+test('should ignore test.setTimeout when debugging', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('my test', async ({}) => {
+        test.setTimeout(1000);
+        await new Promise(f => setTimeout(f, 2000));
+      });
+    `
+  }, { timeout: 0 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});


### PR DESCRIPTION
We ignore test.setTimeout() when timeout is already zero for debugging.
