### PR TITLE
feat(input): restore modified layout shift check

### DIFF
--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -407,7 +407,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const point = roundPoint(maybePoint);
     progress.metadata.point = point;
 
-    if (!process.env.PLAYWRIGHT_LAYOUT_SHIFT_CHECK)
+    if (process.env.PLAYWRIGHT_NO_LAYOUT_SHIFT_CHECK)
       return this._finishPointerAction(progress, actionName, point, options, action);
     else
       return this._finishPointerActionDetectLayoutShift(progress, actionName, point, options, action);

--- a/packages/playwright-core/src/server/firefox/ffInput.ts
+++ b/packages/playwright-core/src/server/firefox/ffInput.ts
@@ -108,7 +108,7 @@ export class RawMouseImpl implements input.RawMouse {
     this._client = client;
   }
 
-  async move(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>): Promise<void> {
+  async move(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void> {
     await this._client.send('Page.dispatchMouseEvent', {
       type: 'mousemove',
       button: 0,

--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -731,19 +731,17 @@ export class InjectedScript {
       if (!event.isTrusted)
         return;
 
-      // Element was detached during the action, for example in some event handler.
-      // If events before that were correctly pointing to it, consider this a valid scenario.
-      if (!element.isConnected)
-        return;
-
       // Determine the event point. Note that Firefox does not always have window.TouchEvent.
       const point = (!!window.TouchEvent && (event instanceof window.TouchEvent)) ? event.touches[0] : (event as MouseEvent | PointerEvent);
-      if (!!point && (result === undefined || result === 'done')) {
-        // Determine whether we hit the target element, unless we have already failed.
+
+      // Check that we hit the right element at the first event, and assume all
+      // subsequent events will be fine.
+      if (result === undefined && point) {
         const hitElement = this.deepElementFromPoint(document, point.clientX, point.clientY);
         result = this._expectHitTargetParent(hitElement, element);
       }
-      if (blockAllEvents || result !== 'done') {
+
+      if (blockAllEvents || (result !== 'done' && result !== undefined)) {
         event.preventDefault();
         event.stopPropagation();
         event.stopImmediatePropagation();

--- a/packages/playwright-core/src/server/webkit/wkInput.ts
+++ b/packages/playwright-core/src/server/webkit/wkInput.ts
@@ -113,7 +113,7 @@ export class RawMouseImpl implements input.RawMouse {
     this._session = session;
   }
 
-  async move(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>): Promise<void> {
+  async move(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void> {
     await this._pageProxySession.send('Input.dispatchMouseEvent', {
       type: 'move',
       button,

--- a/tests/tap.spec.ts
+++ b/tests/tap.spec.ts
@@ -48,7 +48,7 @@ it('trial run should not tap', async ({ page }) => {
   await page.tap('#a');
   const eventsHandle = await trackEvents(await page.$('#b'));
   await page.tap('#b', { trial: true });
-  const expected = !process.env.PLAYWRIGHT_LAYOUT_SHIFT_CHECK ? [] : ['pointerover', 'pointerenter', 'pointerout', 'pointerleave'];
+  const expected = !!process.env.PLAYWRIGHT_NO_LAYOUT_SHIFT_CHECK ? [] : ['pointerover', 'pointerenter', 'pointerout', 'pointerleave'];
   expect(await eventsHandle.jsonValue()).toEqual(expected);
 });
 


### PR DESCRIPTION
This changes previous layout shift attempt (see #9546) to account for more valid usecases:
- On the first event that is intercepted we enforce the hit target. This is similar to the current mode that checks hit target before the action, but is better timed.
- On subsequent events we assume that everything is fine. This covers more scenarios like react rerender, glass pane on mousedown, detach on mouseup.

This check is enabled by default, with `process.env.PLAYWRIGHT_NO_LAYOUT_SHIFT_CHECK` to opt out.

Fixes #6238.