### PR TITLE
feat(junit): add custom properties to junit output

### DIFF
--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -389,6 +389,8 @@ const config: PlaywrightTestConfig = {
 export default config;
 ```
 
+You can add custom properties for a test case, by adding `@propert_name=property_value`, e.g. `@test_key=ABC` to the test name. 
+
 ### GitHub Actions annotations
 
 You can use the built in `github` reporter to get automatic failure annotations when running in GitHub actions.


### PR DESCRIPTION
Fixes #9348

In order to allow the output of the [XRay extended JUnit format](https://docs.getxray.app/display/XRAYCLOUD/Taking+advantage+of+JUnit+XML+reports#TakingadvantageofJUnitXMLreports-XrayextendedJUnitformatLinkingTestswithRequirements) i added a generic approach that adds tags from the issue description as properties of the test case

for example:
```js
test('Test login page @test_id=123", async ({ page }) => {
  // ...
});
```

becomes 
```xml
 <testcase classname="UNCHANGED" name="Test login page @test_id=123" time="123.345000">
    <properties>
        <property name="test_id" value="123" />
    </properties>
</testcase>
```