### PR TITLE
devops: attempt to use ubuntu 18.04 for docker tests

### DIFF
--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   test_linux_docker:
     name: "Docker ${{ matrix.os_name}} ${{ matrix.arch}} ${{ matrix.user }} Tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     if: github.repository == 'microsoft/playwright'
     strategy:
       fail-fast: false


### PR DESCRIPTION
Folks on the internet claim 18.04 never runs out of disk space for them
for github actions.

