### PR TITLE
browser(webkit): roll to 23/12/21

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1588
-Changed: dpino@igalia.com Fri Dec 10 01:51:01 UTC 2021
+1589
+Changed: dpino@igalia.com Thu Dec 30 10:10:19 UTC 2021

--- a/browser_patches/webkit/UPSTREAM_CONFIG.sh
+++ b/browser_patches/webkit/UPSTREAM_CONFIG.sh
@@ -1,3 +1,3 @@
 REMOTE_URL="https://github.com/WebKit/WebKit.git"
 BASE_BRANCH="main"
-BASE_REVISION="cb640ac039a98d9c724461a40a37ebea9efe7bf9"
+BASE_REVISION="0e8b8397ffef0f1b9e6f67d02739ff3e50fc0f6f"

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -1,5 +1,5 @@
 diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
-index c01016d0c2bce085fc61f1ae5bc8015f5a3487f0..280b3c4018e1264c9ddee5aeb3d33d79b7096cae 100644
+index f48b7ac917f9bf8450494d5ac7a54852ba3a9bf3..15e637f563d165b51713d25df8a78c302308db6c 100644
 --- a/Source/JavaScriptCore/CMakeLists.txt
 +++ b/Source/JavaScriptCore/CMakeLists.txt
 @@ -1358,22 +1358,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
@@ -1295,10 +1295,10 @@ index db52479a72d459be23d4d8d080c0ed15ea9fc4c0..cf8c009d5591c4eac1a65e2c0de15533
  }
 diff --git a/Source/JavaScriptCore/inspector/protocol/Playwright.json b/Source/JavaScriptCore/inspector/protocol/Playwright.json
 new file mode 100644
-index 0000000000000000000000000000000000000000..3aebbe625682094d0e8ac2f14ac33321dd475142
+index 0000000000000000000000000000000000000000..b608b7e5c6007cfc0d47a5ea8d3cdefd2dda8f0e
 --- /dev/null
 +++ b/Source/JavaScriptCore/inspector/protocol/Playwright.json
-@@ -0,0 +1,289 @@
+@@ -0,0 +1,269 @@
 +{
 +    "domain": "Playwright",
 +    "availability": ["web"],
@@ -1469,26 +1469,6 @@ index 0000000000000000000000000000000000000000..3aebbe625682094d0e8ac2f14ac33321
 +            "async": true,
 +            "parameters": [
 +                { "name": "browserContextId", "$ref": "ContextID", "optional": true, "description": "Browser context id." }
-+            ]
-+        },
-+        {
-+            "name": "getLocalStorageData",
-+            "description": "Returns all local storage data in the given browser context.",
-+            "async": true,
-+            "parameters": [
-+                { "name": "browserContextId", "$ref": "ContextID", "optional": true, "description": "Browser context id." }
-+            ],
-+            "returns": [
-+                { "name": "origins", "type": "array", "items": { "$ref": "OriginStorage" }, "description": "Local storage data." }
-+            ]
-+        },
-+        {
-+            "name": "setLocalStorageData",
-+            "description": "Populates local storage data in the given browser context.",
-+            "async": true,
-+            "parameters": [
-+                { "name": "browserContextId", "$ref": "ContextID", "optional": true, "description": "Browser context id." },
-+                { "name": "origins", "type": "array", "items": { "$ref": "OriginStorage" }, "description": "Local storage data." }
 +            ]
 +        },
 +        {
@@ -1932,11 +1912,11 @@ index dfe8ba87c6bed689f7f044d388b7c21b19936518..3de753ce55f0626e98d19a71c31f81f2
 +_vpx_codec_version_str
 +_vpx_codec_vp8_cx
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
-index dd884b22250114627213c4827ca176c283ec2525..9927a937145f23d05e907083a01748dd8015eb98 100644
+index 09d2b903fbb47f0a1b995e9da970b394f4a74eef..6f59a25c1b8f1f69768bb2a8d4d12e91c6c2b34c 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
-@@ -43,7 +43,7 @@ DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_ = $(DYLIB_INSTALL_NAME_BASE);
- DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_YES = @loader_path/../../../;
+@@ -51,7 +51,7 @@ OUTPUT_ALTERNATE_ROOT_PATH = $(OUTPUT_ALTERNATE_ROOT_PATH_$(USE_SYSTEM_CONTENT_P
+ OUTPUT_ALTERNATE_ROOT_PATH_YES = $(DSTROOT)$(ALTERNATE_ROOT_PATH)/$(FULL_PRODUCT_NAME);
  
  GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 -HEADER_SEARCH_PATHS = Source Source/third_party/jsoncpp/source/include Source/third_party/libsrtp/crypto/include Source/third_party/libsrtp/include Source/third_party/boringssl/src/include Source/third_party/libyuv/include Source/third_party/usrsctp Source/third_party/usrsctp/usrsctplib Source/third_party/usrsctp/usrsctplib/usrsctplib Source/webrtc/sdk/objc/Framework/Headers Source/webrtc/common_audio/signal_processing/include Source/webrtc/modules/audio_coding/codecs/isac/main/include Source/third_party/opus/src/celt Source/third_party/opus/src/include Source/third_party/opus/src/src Source/webrtc/modules/audio_device/mac Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet Source/webrtc/modules/audio_device/ios Source/webrtc Source/webrtc/sdk/objc Source/webrtc/sdk/objc/base Source/webrtc/sdk/objc/Framework/Classes Source/third_party/libsrtp/config Source/webrtc/sdk/objc/Framework/Classes/Common Source/webrtc/sdk/objc/Framework/Classes/Video Source/webrtc/sdk/objc/Framework/Classes/PeerConnection Source/third_party/abseil-cpp Source/third_party/libvpx/source/libvpx Source/third_party/libwebm/webm_parser/include;
@@ -2027,10 +2007,10 @@ index a4eef414ab4e495956517320ae72235750e1c5d6..e8942e7e3b9cd57ae8b25e4854df37fe
  				41323A1D2665288B00B38623 /* packet_sequencer.cc in Sources */,
  				4131BF2D234B88200028A615 /* rtc_stats_collector.cc in Sources */,
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferences.yaml b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
-index 6475aa03dd643fbb8c57c933750e2e53469444d1..ab2f792bc27bc377031539c4ffc3df8f263f0edd 100644
+index feb5a80e0a27f12e5577582c3abdcf3c91932b1d..80392f95a6e39c4b8d314f48c4ac81ed8598afbb 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
-@@ -1042,7 +1042,7 @@ InspectorStartsAttached:
+@@ -1007,7 +1007,7 @@ InspectorStartsAttached:
    exposed: [ WebKit ]
    defaultValue:
      WebKit:
@@ -2039,7 +2019,7 @@ index 6475aa03dd643fbb8c57c933750e2e53469444d1..ab2f792bc27bc377031539c4ffc3df8f
  
  InspectorWindowFrame:
    type: String
-@@ -1782,6 +1782,17 @@ PluginsEnabled:
+@@ -1747,6 +1747,17 @@ PluginsEnabled:
      WebCore:
        default: false
  
@@ -2058,10 +2038,10 @@ index 6475aa03dd643fbb8c57c933750e2e53469444d1..ab2f792bc27bc377031539c4ffc3df8f
    type: bool
    humanReadableName: "Private Click Measurement"
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index be9acb429aa256d906c4a419c6f1c7fa451cf2e3..27cd55e2dfa1cc95ceb11f951f6a8b120470ca4b 100644
+index 48069370ebb2464f2e31162116cca29f59cc4667..0b165bc852fa468cbc0d6aa924d650daaf32a2f2 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-@@ -433,7 +433,7 @@ CrossOriginOpenerPolicyEnabled:
+@@ -457,7 +457,7 @@ CrossOriginOpenerPolicyEnabled:
      WebKitLegacy:
        default: false
      WebKit:
@@ -2070,7 +2050,7 @@ index be9acb429aa256d906c4a419c6f1c7fa451cf2e3..27cd55e2dfa1cc95ceb11f951f6a8b12
      WebCore:
        default: false
  
-@@ -812,9 +812,9 @@ MaskWebGLStringsEnabled:
+@@ -836,9 +836,9 @@ MaskWebGLStringsEnabled:
      WebKitLegacy:
        default: true
      WebKit:
@@ -2082,7 +2062,7 @@ index be9acb429aa256d906c4a419c6f1c7fa451cf2e3..27cd55e2dfa1cc95ceb11f951f6a8b12
  
  # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
  MediaCapabilitiesExtensionsEnabled:
-@@ -1292,7 +1292,7 @@ SpeechRecognitionEnabled:
+@@ -1316,7 +1316,7 @@ SpeechRecognitionEnabled:
      WebKitLegacy:
        default: false
      WebKit:
@@ -2211,7 +2191,7 @@ index ebd69a4c76cd7acb0a233be552071158ca2171ca..2ee388e94a56d3de9c9fb2506d2ddead
 +
  } // namespace WTF
 diff --git a/Source/WTF/wtf/DateMath.h b/Source/WTF/wtf/DateMath.h
-index 7bb27e9976fb14e06fa4ee48553617fca06d8d7b..79ac2c9e778c1efca4f588edd4271bf8d25b1aa6 100644
+index 07ddf3854633cb5e4ca9679359c048f13395e4ab..a0be72ba35e7afa09e8ea5976ebf600b9f35269a 100644
 --- a/Source/WTF/wtf/DateMath.h
 +++ b/Source/WTF/wtf/DateMath.h
 @@ -393,6 +393,10 @@ inline double timeToMS(double hour, double min, double sec, double ms)
@@ -2226,7 +2206,7 @@ index 7bb27e9976fb14e06fa4ee48553617fca06d8d7b..79ac2c9e778c1efca4f588edd4271bf8
  WTF_EXPORT_PRIVATE LocalTimeOffset calculateLocalTimeOffset(double utcInMilliseconds, TimeType = UTCTime);
  
 diff --git a/Source/WTF/wtf/PlatformEnable.h b/Source/WTF/wtf/PlatformEnable.h
-index b263ee464856665ce90f783d6ce7e0ded9aee067..1d29a03a2a5bf81b2b308bc3923b55002afc409c 100644
+index 0103e1324c129aba2e876ebe0739f2787f16503e..7faf8390719e6826c99ad5a467c60e3d62e47206 100644
 --- a/Source/WTF/wtf/PlatformEnable.h
 +++ b/Source/WTF/wtf/PlatformEnable.h
 @@ -412,7 +412,7 @@
@@ -2273,7 +2253,7 @@ index 3901bfb0f5479064f4e7b67c90621ff26d74b580..5b3615a871d0d7123822394c94d5ce10
  
  if (Journald_FOUND)
 diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
-index 3c3106cbec7fb2e255cab3acb1d41cac76941c04..dbf3e055eca007cd80976048465b52e4e77c6ccc 100644
+index db9bd84e7ed5c907bd34db09af6eb9dd0c72d058..eb996a09baa0c81d339c752bb355630c29954a3c 100644
 --- a/Source/WTF/wtf/PlatformHave.h
 +++ b/Source/WTF/wtf/PlatformHave.h
 @@ -384,7 +384,7 @@
@@ -2298,10 +2278,10 @@ index f8bedf1af5d20d9c93a96af565e416bfb0df6faa..a072e5e130822d3658cbab453aef8d16
  
  if (Journald_FOUND)
 diff --git a/Source/WebCore/DerivedSources.make b/Source/WebCore/DerivedSources.make
-index 6051405ada53f685bcd81120ba2697408f723868..70dcd353afc701e9468882c4558d38abe40fe942 100644
+index 49adbc24360b169eca1e3233602350964593ae62..93a727058dc3d4dd01f4890975be169894131b87 100644
 --- a/Source/WebCore/DerivedSources.make
 +++ b/Source/WebCore/DerivedSources.make
-@@ -953,6 +953,10 @@ JS_BINDING_IDLS := \
+@@ -957,6 +957,10 @@ JS_BINDING_IDLS := \
      $(WebCore)/dom/Slotable.idl \
      $(WebCore)/dom/StaticRange.idl \
      $(WebCore)/dom/StringCallback.idl \
@@ -2312,7 +2292,7 @@ index 6051405ada53f685bcd81120ba2697408f723868..70dcd353afc701e9468882c4558d38ab
      $(WebCore)/dom/Text.idl \
      $(WebCore)/dom/TextDecoder.idl \
      $(WebCore)/dom/TextDecoderStream.idl \
-@@ -1497,9 +1501,6 @@ JS_BINDING_IDLS := \
+@@ -1501,9 +1505,6 @@ JS_BINDING_IDLS := \
  ADDITIONAL_BINDING_IDLS = \
      DocumentTouch.idl \
      GestureEvent.idl \
@@ -2323,7 +2303,7 @@ index 6051405ada53f685bcd81120ba2697408f723868..70dcd353afc701e9468882c4558d38ab
  
  vpath %.in $(WEBKITADDITIONS_HEADER_SEARCH_PATHS)
 diff --git a/Source/WebCore/Modules/geolocation/Geolocation.cpp b/Source/WebCore/Modules/geolocation/Geolocation.cpp
-index e272ecdef2a7d066a121ec366a9906d4b8db14c7..f922d861134d44958c58e6332fb3d029da150921 100644
+index cd372f43691add4d7df0c9e52570eaffd2934037..55ee984ef83a06ba7cc47b0d3beee2540587575c 100644
 --- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
 +++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
 @@ -371,8 +371,9 @@ bool Geolocation::shouldBlockGeolocationRequests()
@@ -2399,10 +2379,10 @@ index cfbfe4f66dbc339e68179f4ceb48a02c3c122926..66050a7c29254f73d04273510b5e0642
  
  set(CSS_VALUE_PLATFORM_DEFINES "HAVE_OS_DARK_MODE_SUPPORT=1")
 diff --git a/Source/WebCore/SourcesCocoa.txt b/Source/WebCore/SourcesCocoa.txt
-index eafb0854821731b2d7c8ae572c44815598f41cca..d7681ec1662e9a45ff2fbb4fde458b01aa0f86f8 100644
+index cad11d30469e842ccd74e2fedbac1d983a3e25b8..2578c8aa423dae3ffccee22a1e9ba0518c19729b 100644
 --- a/Source/WebCore/SourcesCocoa.txt
 +++ b/Source/WebCore/SourcesCocoa.txt
-@@ -610,3 +610,9 @@ platform/graphics/angle/ANGLEUtilities.cpp @no-unify
+@@ -612,3 +612,9 @@ platform/graphics/angle/ANGLEUtilities.cpp @no-unify
  platform/graphics/angle/ExtensionsGLANGLE.cpp @no-unify
  platform/graphics/angle/GraphicsContextGLANGLE.cpp @no-unify
  platform/graphics/angle/TemporaryANGLESetting.cpp @no-unify
@@ -2452,7 +2432,7 @@ index fd058e8f614edba70fd0d104285864e768eceb5d..375547aee2755513950c253666eeb569
 +
 +platform/wpe/SelectionData.cpp
 diff --git a/Source/WebCore/WebCore.order b/Source/WebCore/WebCore.order
-index 9f85e4986c53a1cc8d63b3394d3f7295832af387..1228fda7c688c5b24cecaf07e21437d34f016042 100644
+index 33ac35df7d3d583c86d275654cadc1caf75b079a..2697718f3a9309df08493cdf78ef0abd0ceaf321 100644
 --- a/Source/WebCore/WebCore.order
 +++ b/Source/WebCore/WebCore.order
 @@ -3090,7 +3090,6 @@ __ZN7WebCore14DocumentLoader23stopLoadingSubresourcesEv
@@ -2464,10 +2444,10 @@ index 9f85e4986c53a1cc8d63b3394d3f7295832af387..1228fda7c688c5b24cecaf07e21437d3
  __ZN7WebCore14DocumentLoaderD2Ev
  __ZN7WebCore14DocumentLoader17clearMainResourceEv
 diff --git a/Source/WebCore/WebCore.xcodeproj/project.pbxproj b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901084b3850 100644
+index 823fd6743985d6337b5c97b7d5c9f47baffd61f2..27327a2585861d23026c7240cb460b576ee6ab54 100644
 --- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 +++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-@@ -5439,6 +5439,13 @@
+@@ -5462,6 +5462,13 @@
  		EDE3A5000C7A430600956A37 /* ColorMac.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE3A4FF0C7A430600956A37 /* ColorMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		EDEC98030AED7E170059137F /* WebCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEC98020AED7E170059137F /* WebCorePrefix.h */; };
  		EFCC6C8F20FE914400A2321B /* CanvasActivityRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2481,7 +2461,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  		F12171F616A8CF0B000053CA /* WebVTTElement.h in Headers */ = {isa = PBXBuildFile; fileRef = F12171F416A8BC63000053CA /* WebVTTElement.h */; };
  		F32BDCD92363AACA0073B6AE /* UserGestureEmulationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F32BDCD72363AACA0073B6AE /* UserGestureEmulationScope.h */; };
  		F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
-@@ -17584,6 +17591,14 @@
+@@ -17648,6 +17655,14 @@
  		EDEC98020AED7E170059137F /* WebCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCorePrefix.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
  		EFB7287B2124C73D005C2558 /* CanvasActivityRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasActivityRecord.cpp; sourceTree = "<group>"; };
  		EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasActivityRecord.h; sourceTree = "<group>"; };
@@ -2496,7 +2476,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  		F12171F316A8BC63000053CA /* WebVTTElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebVTTElement.cpp; sourceTree = "<group>"; };
  		F12171F416A8BC63000053CA /* WebVTTElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebVTTElement.h; sourceTree = "<group>"; };
  		F32BDCD52363AAC90073B6AE /* UserGestureEmulationScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserGestureEmulationScope.cpp; sourceTree = "<group>"; };
-@@ -23849,7 +23864,12 @@
+@@ -23939,7 +23954,12 @@
  				93D6B7A62551D3ED0058DD3A /* DummySpeechRecognitionProvider.h */,
  				1AF326770D78B9440068F0C4 /* EditorClient.h */,
  				93C09A800B064F00005ABD4D /* EventHandler.cpp */,
@@ -2509,7 +2489,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  				E0FEF371B27C53EAC1C1FBEE /* EventSource.cpp */,
  				E0FEF371B17C53EAC1C1FBEE /* EventSource.h */,
  				E0FEF371B07C53EAC1C1FBEE /* EventSource.idl */,
-@@ -29789,6 +29809,8 @@
+@@ -29887,6 +29907,8 @@
  				29E4D8DF16B0940F00C84704 /* PlatformSpeechSynthesizer.h */,
  				1AD8F81A11CAB9E900E93E54 /* PlatformStrategies.cpp */,
  				1AD8F81911CAB9E900E93E54 /* PlatformStrategies.h */,
@@ -2518,7 +2498,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  				0FD7C21D23CE41E30096D102 /* PlatformWheelEvent.cpp */,
  				935C476A09AC4D4F00A6AAB4 /* PlatformWheelEvent.h */,
  				BCBB8AB513F1AFB000734DF0 /* PODInterval.h */,
-@@ -32084,6 +32106,7 @@
+@@ -32197,6 +32219,7 @@
  				BCCFBAE70B5152ED0001F1D7 /* DocumentParser.h */,
  				AD6E71AA1668899D00320C13 /* DocumentSharedObjectPool.cpp */,
  				AD6E71AB1668899D00320C13 /* DocumentSharedObjectPool.h */,
@@ -2526,7 +2506,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  				6BDB5DC1227BD3B800919770 /* DocumentStorageAccess.cpp */,
  				6BDB5DC0227BD3B800919770 /* DocumentStorageAccess.h */,
  				7CE7FA5B1EF882300060C9D6 /* DocumentTouch.cpp */,
-@@ -33101,6 +33124,7 @@
+@@ -33215,6 +33238,7 @@
  				93C4F6EB1108F9A50099D0DB /* AccessibilityScrollbar.h in Headers */,
  				29489FC712C00F0300D83F0F /* AccessibilityScrollView.h in Headers */,
  				0709FC4E1025DEE30059CDBA /* AccessibilitySlider.h in Headers */,
@@ -2534,7 +2514,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  				29D7BCFA1444AF7D0070619C /* AccessibilitySpinButton.h in Headers */,
  				69A6CBAD1C6BE42C00B836E9 /* AccessibilitySVGElement.h in Headers */,
  				AAC08CF315F941FD00F1E188 /* AccessibilitySVGRoot.h in Headers */,
-@@ -35216,6 +35240,7 @@
+@@ -35338,6 +35362,7 @@
  				6E4ABCD5138EA0B70071D291 /* JSHTMLUnknownElement.h in Headers */,
  				E44614170CD6826900FADA75 /* JSHTMLVideoElement.h in Headers */,
  				81BE20D311F4BC3200915DFA /* JSIDBCursor.h in Headers */,
@@ -2542,7 +2522,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  				7C3D8EF01E0B21430023B084 /* JSIDBCursorDirection.h in Headers */,
  				C585A68311D4FB08004C3E4B /* JSIDBDatabase.h in Headers */,
  				C585A69711D4FB13004C3E4B /* JSIDBFactory.h in Headers */,
-@@ -36311,6 +36336,7 @@
+@@ -36442,6 +36467,7 @@
  				1AD8F81B11CAB9E900E93E54 /* PlatformStrategies.h in Headers */,
  				0F7D07331884C56C00B4AF86 /* PlatformTextTrack.h in Headers */,
  				074E82BB18A69F0E007EF54C /* PlatformTimeRanges.h in Headers */,
@@ -2550,7 +2530,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  				CD1F9B022700323D00617EB6 /* PlatformVideoColorPrimaries.h in Headers */,
  				CD1F9B01270020B700617EB6 /* PlatformVideoColorSpace.h in Headers */,
  				CD1F9B032700323D00617EB6 /* PlatformVideoMatrixCoefficients.h in Headers */,
-@@ -38315,6 +38341,7 @@
+@@ -38471,6 +38497,7 @@
  				1ABA76CA11D20E50004C201C /* CSSPropertyNames.cpp in Sources */,
  				2D22830323A8470700364B7E /* CursorMac.mm in Sources */,
  				5CBD59592280E926002B22AA /* CustomHeaderFields.cpp in Sources */,
@@ -2558,7 +2538,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  				6E72F54C229DCD0C00B3E151 /* ExtensionsGLANGLE.cpp in Sources */,
  				7CE6CBFD187F394900D46BF5 /* FormatConverter.cpp in Sources */,
  				5130F2F624AEA60A00E1D0A0 /* GameControllerSoftLink.mm in Sources */,
-@@ -38384,6 +38411,7 @@
+@@ -38541,6 +38568,7 @@
  				6E72F54F229DCD1300B3E151 /* TemporaryANGLESetting.cpp in Sources */,
  				CE88EE262414467B007F29C2 /* TextAlternativeWithRange.mm in Sources */,
  				51DF6D800B92A18E00C2DC85 /* ThreadCheck.mm in Sources */,
@@ -2566,7 +2546,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  				538EC8031F96AF81004D22A8 /* UnifiedSource1-mm.mm in Sources */,
  				538EC8021F96AF81004D22A8 /* UnifiedSource1.cpp in Sources */,
  				538EC8051F96AF81004D22A8 /* UnifiedSource2-mm.mm in Sources */,
-@@ -38432,6 +38460,7 @@
+@@ -38589,6 +38617,7 @@
  				538EC8881F993F9C004D22A8 /* UnifiedSource23.cpp in Sources */,
  				DE5F85801FA1ABF4006DB63A /* UnifiedSource24-mm.mm in Sources */,
  				538EC8891F993F9D004D22A8 /* UnifiedSource24.cpp in Sources */,
@@ -2574,7 +2554,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  				DE5F85811FA1ABF4006DB63A /* UnifiedSource25-mm.mm in Sources */,
  				538EC88A1F993F9D004D22A8 /* UnifiedSource25.cpp in Sources */,
  				DE5F85821FA1ABF4006DB63A /* UnifiedSource26-mm.mm in Sources */,
-@@ -38964,6 +38993,7 @@
+@@ -39121,6 +39150,7 @@
  				2D8B92F1203D13E1009C868F /* UnifiedSource516.cpp in Sources */,
  				2D8B92F2203D13E1009C868F /* UnifiedSource517.cpp in Sources */,
  				2D8B92F3203D13E1009C868F /* UnifiedSource518.cpp in Sources */,
@@ -2583,7 +2563,7 @@ index 26f9e950e52cc4d7daf8eddbe289d7014fe1ced0..fa881b8bbb2a282b5f759908b5527901
  				2D8B92F5203D13E1009C868F /* UnifiedSource520.cpp in Sources */,
  				2D8B92F6203D13E1009C868F /* UnifiedSource521.cpp in Sources */,
 diff --git a/Source/WebCore/accessibility/AccessibilityObject.cpp b/Source/WebCore/accessibility/AccessibilityObject.cpp
-index d649f1cd2cec7a8da6f04debe5524a770d09b9f5..707d7c1fedc1434b09f6fd66b7d5ebed43913bed 100644
+index 1dccd86aba239cd93d102e0fb492626e5fb49eb6..804dd8dde6ae557c8abcf7e290a50540c0f2013d 100644
 --- a/Source/WebCore/accessibility/AccessibilityObject.cpp
 +++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
 @@ -61,6 +61,7 @@
@@ -2594,7 +2574,7 @@ index d649f1cd2cec7a8da6f04debe5524a770d09b9f5..707d7c1fedc1434b09f6fd66b7d5ebed
  #include "LocalizedStrings.h"
  #include "MathMLNames.h"
  #include "NodeList.h"
-@@ -3542,10 +3543,15 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
+@@ -3540,10 +3541,15 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
      
      if (useParentData ? m_isIgnoredFromParentData.isPresentationalChildOfAriaRole : isPresentationalChildOfAriaRole())
          return AccessibilityObjectInclusion::IgnoreObject;
@@ -2614,7 +2594,7 @@ index d649f1cd2cec7a8da6f04debe5524a770d09b9f5..707d7c1fedc1434b09f6fd66b7d5ebed
  {
      AXComputedObjectAttributeCache* attributeCache = nullptr;
 diff --git a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
-index fa35e1bd8c44c86cc260eadf66e29f205c1efcd7..ec9947a51374ec042333dcde3e7d8df4c92b8cee 100644
+index 233a8cafe3433b99c165792fc01fd9a3708ff2c8..341526d174b4e99cb48016d40bd3a7f01b1a2f02 100644
 --- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
 +++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
 @@ -110,6 +110,8 @@ namespace WebCore {
@@ -2627,10 +2607,10 @@ index fa35e1bd8c44c86cc260eadf66e29f205c1efcd7..ec9947a51374ec042333dcde3e7d8df4
      macro(EnterPictureInPictureEvent) \
      macro(ExtendableEvent) \
 diff --git a/Source/WebCore/css/MediaQueryEvaluator.cpp b/Source/WebCore/css/MediaQueryEvaluator.cpp
-index 9c00886958d5ae32edd5f76f76843d0bdfaffe70..63e99946a89893f39465e7858be329498e68cb0f 100644
+index a7945e6d29b66a6c1ff863db93de98e31c4ffc93..a5d67259eba510457cf4f5018c4eb0dcda107077 100644
 --- a/Source/WebCore/css/MediaQueryEvaluator.cpp
 +++ b/Source/WebCore/css/MediaQueryEvaluator.cpp
-@@ -847,7 +847,11 @@ static bool prefersContrastEvaluate(CSSValue* value, const CSSToLengthConversion
+@@ -856,7 +856,11 @@ static bool prefersContrastEvaluate(CSSValue* value, const CSSToLengthConversion
  static bool prefersReducedMotionEvaluate(CSSValue* value, const CSSToLengthConversionData&, Frame& frame, MediaFeaturePrefix)
  {
      bool userPrefersReducedMotion = false;
@@ -2643,7 +2623,7 @@ index 9c00886958d5ae32edd5f76f76843d0bdfaffe70..63e99946a89893f39465e7858be32949
      switch (frame.settings().forcedPrefersReducedMotionAccessibilityValue()) {
      case ForcedAccessibilityValue::On:
          userPrefersReducedMotion = true;
-@@ -860,6 +864,7 @@ static bool prefersReducedMotionEvaluate(CSSValue* value, const CSSToLengthConve
+@@ -869,6 +873,7 @@ static bool prefersReducedMotionEvaluate(CSSValue* value, const CSSToLengthConve
  #endif
          break;
      }
@@ -2842,7 +2822,7 @@ index 9d60b85152f378566118574663701c25b001df3d..9811ce9aa6f066c57acf65f629d2ab81
  #endif
  
 diff --git a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
-index 9dd41d6366512fd385937a7608bd3fc9b5b90f60..d6bb529fb891a65c8f6dcc6cff1e718c7a40b8dd 100644
+index 8595ed1ddf389711422e453988dbbc3de5de8703..8e5f3aef9846a4b82a95ef0081d588b6878b3f78 100644
 --- a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
 +++ b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
 @@ -33,6 +33,7 @@
@@ -2853,8 +2833,8 @@ index 9dd41d6366512fd385937a7608bd3fc9b5b90f60..d6bb529fb891a65c8f6dcc6cff1e718c
  #include "markup.h"
  
  namespace WebCore {
-@@ -91,6 +92,14 @@ void Editor::pasteWithPasteboard(Pasteboard* pasteboard, OptionSet<PasteOption>
-         pasteAsFragment(*fragment, canSmartReplaceWithPasteboard(*pasteboard), chosePlainText, options.contains(PasteOption::IgnoreMailBlockquote) ? MailBlockquoteHandling::IgnoreBlockquote : MailBlockquoteHandling::RespectBlockquote);
+@@ -99,6 +100,14 @@ void Editor::platformPasteFont()
+ {
  }
  
 +RefPtr<DocumentFragment> Editor::webContentFromPasteboard(Pasteboard& pasteboard, const SimpleRange& context, bool allowPlainText, bool& chosePlainText)
@@ -2956,10 +2936,10 @@ index f6fec7cfbcbd2d7fba30bdd3138e0edfb3f69054..519786c307944a5ca4ba468513ba257b
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/InspectorInstrumentation.cpp b/Source/WebCore/inspector/InspectorInstrumentation.cpp
-index a7ca7162d791ed7fba8cc91c21a2cf3af6e69a7e..f43705d3dcb96c2f6fa7a359b5a3fd10a6c18e30 100644
+index 5c5bb2aea839918b069775881ce3a369a428e5b9..7ca973a49f21318f13d9d13d6be5cdd5e02c3785 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
 +++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
-@@ -569,6 +569,13 @@ void InspectorInstrumentation::applyUserAgentOverrideImpl(InstrumentingAgents& i
+@@ -572,6 +572,13 @@ void InspectorInstrumentation::applyUserAgentOverrideImpl(InstrumentingAgents& i
          pageAgent->applyUserAgentOverride(userAgent);
  }
  
@@ -2973,7 +2953,7 @@ index a7ca7162d791ed7fba8cc91c21a2cf3af6e69a7e..f43705d3dcb96c2f6fa7a359b5a3fd10
  void InspectorInstrumentation::applyEmulatedMediaImpl(InstrumentingAgents& instrumentingAgents, String& media)
  {
      if (auto* pageAgent = instrumentingAgents.enabledPageAgent())
-@@ -636,6 +643,12 @@ void InspectorInstrumentation::didFailLoadingImpl(InstrumentingAgents& instrumen
+@@ -639,6 +646,12 @@ void InspectorInstrumentation::didFailLoadingImpl(InstrumentingAgents& instrumen
          consoleAgent->didFailLoading(identifier, error); // This should come AFTER resource notification, front-end relies on this.
  }
  
@@ -2986,7 +2966,7 @@ index a7ca7162d791ed7fba8cc91c21a2cf3af6e69a7e..f43705d3dcb96c2f6fa7a359b5a3fd10
  void InspectorInstrumentation::willLoadXHRSynchronouslyImpl(InstrumentingAgents& instrumentingAgents)
  {
      if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
-@@ -668,20 +681,17 @@ void InspectorInstrumentation::didReceiveScriptResponseImpl(InstrumentingAgents&
+@@ -671,20 +684,17 @@ void InspectorInstrumentation::didReceiveScriptResponseImpl(InstrumentingAgents&
  
  void InspectorInstrumentation::domContentLoadedEventFiredImpl(InstrumentingAgents& instrumentingAgents, Frame& frame)
  {
@@ -3010,7 +2990,7 @@ index a7ca7162d791ed7fba8cc91c21a2cf3af6e69a7e..f43705d3dcb96c2f6fa7a359b5a3fd10
  }
  
  void InspectorInstrumentation::frameDetachedFromParentImpl(InstrumentingAgents& instrumentingAgents, Frame& frame)
-@@ -762,12 +772,6 @@ void InspectorInstrumentation::frameDocumentUpdatedImpl(InstrumentingAgents& ins
+@@ -765,12 +775,6 @@ void InspectorInstrumentation::frameDocumentUpdatedImpl(InstrumentingAgents& ins
          pageDOMDebuggerAgent->frameDocumentUpdated(frame);
  }
  
@@ -3023,7 +3003,7 @@ index a7ca7162d791ed7fba8cc91c21a2cf3af6e69a7e..f43705d3dcb96c2f6fa7a359b5a3fd10
  void InspectorInstrumentation::frameStartedLoadingImpl(InstrumentingAgents& instrumentingAgents, Frame& frame)
  {
      if (frame.isMainFrame()) {
-@@ -804,6 +808,12 @@ void InspectorInstrumentation::frameClearedScheduledNavigationImpl(Instrumenting
+@@ -807,6 +811,12 @@ void InspectorInstrumentation::frameClearedScheduledNavigationImpl(Instrumenting
          inspectorPageAgent->frameClearedScheduledNavigation(frame);
  }
  
@@ -3036,7 +3016,7 @@ index a7ca7162d791ed7fba8cc91c21a2cf3af6e69a7e..f43705d3dcb96c2f6fa7a359b5a3fd10
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
  void InspectorInstrumentation::defaultAppearanceDidChangeImpl(InstrumentingAgents& instrumentingAgents, bool useDarkAppearance)
  {
-@@ -1286,6 +1296,36 @@ void InspectorInstrumentation::renderLayerDestroyedImpl(InstrumentingAgents& ins
+@@ -1289,6 +1299,36 @@ void InspectorInstrumentation::renderLayerDestroyedImpl(InstrumentingAgents& ins
          layerTreeAgent->renderLayerDestroyed(renderLayer);
  }
  
@@ -3073,7 +3053,7 @@ index a7ca7162d791ed7fba8cc91c21a2cf3af6e69a7e..f43705d3dcb96c2f6fa7a359b5a3fd10
  InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(WorkerOrWorkletGlobalScope& globalScope)
  {
      return globalScope.inspectorController().m_instrumentingAgents;
-@@ -1297,6 +1337,13 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
+@@ -1300,6 +1340,13 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
      return page.inspectorController().m_instrumentingAgents.get();
  }
  
@@ -3088,7 +3068,7 @@ index a7ca7162d791ed7fba8cc91c21a2cf3af6e69a7e..f43705d3dcb96c2f6fa7a359b5a3fd10
  {
      if (is<Document>(context))
 diff --git a/Source/WebCore/inspector/InspectorInstrumentation.h b/Source/WebCore/inspector/InspectorInstrumentation.h
-index 8e65c4eb10233521f48c7f4b120ad2c8909a07ba..089f6520bfec96d96d54f7916d7db41887e1b591 100644
+index d2957810d8382c9351d5a93f144aed1493bcc651..8669933013d7972e355eacc358646d65f43e223f 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentation.h
 +++ b/Source/WebCore/inspector/InspectorInstrumentation.h
 @@ -31,6 +31,7 @@
@@ -3317,7 +3297,7 @@ index 8e65c4eb10233521f48c7f4b120ad2c8909a07ba..089f6520bfec96d96d54f7916d7db418
  {
      return context ? instrumentingAgents(*context) : nullptr;
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
-index 3805f84245f6cb73c45844364d54f822b6beb26d..a6c62b3bcceaa054095cb9edb853de606cc53d0f 100644
+index 7a790bb23c8f37af57e4284b367cad9d679a434f..e1c81580f7756c722e0ba6caaff2307321822619 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 @@ -62,12 +62,16 @@
@@ -3337,7 +3317,7 @@ index 3805f84245f6cb73c45844364d54f822b6beb26d..a6c62b3bcceaa054095cb9edb853de60
  #include "HTMLMediaElement.h"
  #include "HTMLNames.h"
  #include "HTMLParserIdioms.h"
-@@ -94,11 +98,14 @@
+@@ -95,11 +99,14 @@
  #include "Pasteboard.h"
  #include "PseudoElement.h"
  #include "RenderGrid.h"
@@ -3345,14 +3325,14 @@ index 3805f84245f6cb73c45844364d54f822b6beb26d..a6c62b3bcceaa054095cb9edb853de60
 +#include "RenderObject.h"
  #include "RenderStyle.h"
  #include "RenderStyleConstants.h"
- #include "ScriptState.h"
+ #include "ScriptController.h"
  #include "SelectorChecker.h"
  #include "ShadowRoot.h"
 +#include "SharedBuffer.h"
  #include "StaticNodeList.h"
  #include "StyleProperties.h"
  #include "StyleResolver.h"
-@@ -131,7 +138,8 @@ using namespace HTMLNames;
+@@ -132,7 +139,8 @@ using namespace HTMLNames;
  static const size_t maxTextSize = 10000;
  static const UChar ellipsisUChar[] = { 0x2026, 0 };
  
@@ -3362,7 +3342,7 @@ index 3805f84245f6cb73c45844364d54f822b6beb26d..a6c62b3bcceaa054095cb9edb853de60
  {
      if (!colorObject)
          return std::nullopt;
-@@ -150,7 +158,7 @@ static std::optional<Color> parseColor(RefPtr<JSON::Object>&& colorObject)
+@@ -151,7 +159,7 @@ static std::optional<Color> parseColor(RefPtr<JSON::Object>&& colorObject)
  
  static Color parseConfigColor(const String& fieldName, JSON::Object& configObject)
  {
@@ -3371,7 +3351,7 @@ index 3805f84245f6cb73c45844364d54f822b6beb26d..a6c62b3bcceaa054095cb9edb853de60
  }
  
  static bool parseQuad(Ref<JSON::Array>&& quadArray, FloatQuad* quad)
-@@ -431,6 +439,20 @@ Node* InspectorDOMAgent::assertNode(Protocol::ErrorString& errorString, Protocol
+@@ -432,6 +440,20 @@ Node* InspectorDOMAgent::assertNode(Protocol::ErrorString& errorString, Protocol
      return node;
  }
  
@@ -3392,7 +3372,7 @@ index 3805f84245f6cb73c45844364d54f822b6beb26d..a6c62b3bcceaa054095cb9edb853de60
  Document* InspectorDOMAgent::assertDocument(Protocol::ErrorString& errorString, Protocol::DOM::NodeId nodeId)
  {
      Node* node = assertNode(errorString, nodeId);
-@@ -1384,16 +1406,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(Ref<JSON::Obj
+@@ -1382,16 +1404,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(Ref<JSON::Obj
  Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNode(Ref<JSON::Object>&& highlightInspectorObject, std::optional<Protocol::DOM::NodeId>&& nodeId, const Protocol::Runtime::RemoteObjectId& objectId)
  {
      Protocol::ErrorString errorString;
@@ -3410,7 +3390,7 @@ index 3805f84245f6cb73c45844364d54f822b6beb26d..a6c62b3bcceaa054095cb9edb853de60
      if (!node)
          return makeUnexpected(errorString);
  
-@@ -1595,15 +1608,136 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Protocol::DOM:
+@@ -1593,15 +1606,136 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Protocol::DOM:
      return { };
  }
  
@@ -3551,7 +3531,7 @@ index 3805f84245f6cb73c45844364d54f822b6beb26d..a6c62b3bcceaa054095cb9edb853de60
      if (!object)
          return makeUnexpected("Missing injected script for given nodeId"_s);
  
-@@ -2837,7 +2971,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPath
+@@ -2839,7 +2973,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPath
      return makeUnexpected("Missing node for given path"_s);
  }
  
@@ -3560,27 +3540,28 @@ index 3805f84245f6cb73c45844364d54f822b6beb26d..a6c62b3bcceaa054095cb9edb853de60
  {
      Document* document = &node->document();
      if (auto* templateHost = document->templateDocumentHost())
-@@ -2846,12 +2980,16 @@ RefPtr<Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* nod
+@@ -2848,12 +2982,17 @@ RefPtr<Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* nod
      if (!frame)
          return nullptr;
  
--    auto& state = *mainWorldExecState(frame);
--    auto injectedScript = m_injectedScriptManager.injectedScriptFor(&state);
+-    auto& globalObject = mainWorldGlobalObject(*frame);
+-    auto injectedScript = m_injectedScriptManager.injectedScriptFor(&globalObject);
 +    InjectedScript injectedScript;
 +    if (contextId) {
 +        injectedScript = m_injectedScriptManager.injectedScriptForId(*contextId);
 +    } else {
-+        injectedScript = m_injectedScriptManager.injectedScriptFor(mainWorldExecState(frame));
++        auto& globalObject = mainWorldGlobalObject(*frame);
++        injectedScript = m_injectedScriptManager.injectedScriptFor(&globalObject);
 +    }
      if (injectedScript.hasNoValue())
          return nullptr;
  
--    return injectedScript.wrapObject(nodeAsScriptValue(state, node), objectGroup);
+-    return injectedScript.wrapObject(nodeAsScriptValue(globalObject, node), objectGroup);
 +    return injectedScript.wrapObject(nodeAsScriptValue(*injectedScript.globalObject(), node), objectGroup);
  }
  
  Node* InspectorDOMAgent::scriptValueAsNode(JSC::JSValue value)
-@@ -2874,4 +3012,42 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowT
+@@ -2876,4 +3015,42 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowT
      return { };
  }
  
@@ -3709,7 +3690,7 @@ index 3386cb879f1178c1b9635775c9a0e864f5b94c52..d2350182f5f061855e8ca172779ad60e
  class Page;
  class SecurityOrigin;
 diff --git a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
-index 4e3daf1ade47318795babaf852c2362b39949bdd..e84dc843dcd71b21cf27b50272c0051deb777d1f 100644
+index 3ceb4b47f1068a0afeaf00f179c2800c476bd6b1..b32967718d63a9c39826eefc98c28978b183e8d9 100644
 --- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
 @@ -45,6 +45,7 @@
@@ -3720,7 +3701,7 @@ index 4e3daf1ade47318795babaf852c2362b39949bdd..e84dc843dcd71b21cf27b50272c0051d
  #include "FrameLoader.h"
  #include "HTTPHeaderMap.h"
  #include "HTTPHeaderNames.h"
-@@ -57,6 +58,7 @@
+@@ -58,6 +59,7 @@
  #include "MIMETypeRegistry.h"
  #include "MemoryCache.h"
  #include "NetworkResourcesData.h"
@@ -3831,7 +3812,7 @@ index 4e3daf1ade47318795babaf852c2362b39949bdd..e84dc843dcd71b21cf27b50272c0051d
  {
      ASSERT(result);
 diff --git a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
-index 8f6fbcc293aebf8b9d5c945d2829a1527b74bc7f..22a97f735adb973b0aef74e54a897d15eb0591b3 100644
+index 6bcd87ddcd8b0441308d1d01eca6b0e6da1413d4..a855687249c48266331e7a2db61cc08d0a3d6601 100644
 --- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
 @@ -34,6 +34,8 @@
@@ -3860,7 +3841,7 @@ index 8f6fbcc293aebf8b9d5c945d2829a1527b74bc7f..22a97f735adb973b0aef74e54a897d15
      // InspectorInstrumentation
      void willRecalculateStyle();
 diff --git a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
-index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c616c25de 100644
+index a4ffd1361cdde5ab7d973cd00d19a910ae9ed29f..21efdf28e98c3209e294eba34e01f91f4495b502 100644
 --- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
 @@ -32,20 +32,28 @@
@@ -3892,7 +3873,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  #include "HTMLNames.h"
  #include "ImageBuffer.h"
  #include "InspectorClient.h"
-@@ -56,19 +64,30 @@
+@@ -56,19 +64,29 @@
  #include "MIMETypeRegistry.h"
  #include "MemoryCache.h"
  #include "Page.h"
@@ -3903,7 +3884,6 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
 +#include "SimpleRange.h"
  #include "ScriptController.h"
  #include "ScriptSourceCode.h"
-+#include "ScriptState.h"
  #include "SecurityOrigin.h"
  #include "Settings.h"
  #include "StyleScope.h"
@@ -3923,7 +3903,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  #include <wtf/Stopwatch.h>
  #include <wtf/text/Base64.h>
  #include <wtf/text/StringBuilder.h>
-@@ -81,11 +100,15 @@
+@@ -81,11 +99,15 @@
  #include "LegacyWebArchive.h"
  #endif
  
@@ -3940,7 +3920,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  static bool decodeBuffer(const uint8_t* buffer, unsigned size, const String& textEncodingName, String* result)
  {
      if (buffer) {
-@@ -235,6 +258,8 @@ Protocol::Page::ResourceType InspectorPageAgent::resourceTypeJSON(InspectorPageA
+@@ -235,6 +257,8 @@ Protocol::Page::ResourceType InspectorPageAgent::resourceTypeJSON(InspectorPageA
          return Protocol::Page::ResourceType::Beacon;
      case WebSocketResource:
          return Protocol::Page::ResourceType::WebSocket;
@@ -3949,7 +3929,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
      case OtherResource:
          return Protocol::Page::ResourceType::Other;
  #if ENABLE(APPLICATION_MANIFEST)
-@@ -322,6 +347,7 @@ InspectorPageAgent::InspectorPageAgent(PageAgentContext& context, InspectorClien
+@@ -322,6 +346,7 @@ InspectorPageAgent::InspectorPageAgent(PageAgentContext& context, InspectorClien
      , m_frontendDispatcher(makeUnique<Inspector::PageFrontendDispatcher>(context.frontendRouter))
      , m_backendDispatcher(Inspector::PageBackendDispatcher::create(context.backendDispatcher, this))
      , m_inspectedPage(context.inspectedPage)
@@ -3957,7 +3937,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
      , m_client(client)
      , m_overlay(overlay)
  {
-@@ -353,12 +379,20 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
+@@ -353,12 +378,20 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
      defaultAppearanceDidChange(m_inspectedPage.defaultUseDarkAppearance());
  #endif
  
@@ -3978,7 +3958,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  
      setShowPaintRects(false);
  #if !PLATFORM(IOS_FAMILY)
-@@ -407,6 +441,22 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::reload(std::optional<bool>&& i
+@@ -407,6 +440,22 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::reload(std::optional<bool>&& i
      return { };
  }
  
@@ -4001,7 +3981,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  Protocol::ErrorStringOr<void> InspectorPageAgent::navigate(const String& url)
  {
      UserGestureIndicator indicator { ProcessingUserGesture };
-@@ -427,6 +477,13 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::overrideUserAgent(const String
+@@ -427,6 +476,13 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::overrideUserAgent(const String
      return { };
  }
  
@@ -4015,7 +3995,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Protocol::Page::Setting setting, std::optional<bool>&& value)
  {
      auto& inspectedPageSettings = m_inspectedPage.settings();
-@@ -440,6 +497,12 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Protocol::Page
+@@ -440,6 +496,12 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Protocol::Page
          inspectedPageSettings.setAuthorAndUserStylesEnabledInspectorOverride(value);
          return { };
  
@@ -4028,7 +4008,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
      case Protocol::Page::Setting::ICECandidateFilteringEnabled:
          inspectedPageSettings.setICECandidateFilteringEnabledInspectorOverride(value);
          return { };
-@@ -465,6 +528,36 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Protocol::Page
+@@ -465,6 +527,36 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Protocol::Page
          inspectedPageSettings.setNeedsSiteSpecificQuirksInspectorOverride(value);
          return { };
  
@@ -4065,7 +4045,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
      case Protocol::Page::Setting::ScriptEnabled:
          inspectedPageSettings.setScriptEnabledInspectorOverride(value);
          return { };
-@@ -477,6 +570,12 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Protocol::Page
+@@ -477,6 +569,12 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Protocol::Page
          inspectedPageSettings.setShowRepaintCounterInspectorOverride(value);
          return { };
  
@@ -4078,7 +4058,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
      case Protocol::Page::Setting::WebRTCEncryptionEnabled:
          inspectedPageSettings.setWebRTCEncryptionEnabledInspectorOverride(value);
          return { };
-@@ -697,9 +796,13 @@ Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorP
+@@ -697,9 +795,13 @@ Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorP
      return { { content, base64Encoded } };
  }
  
@@ -4094,7 +4074,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  
      return { };
  }
-@@ -802,15 +905,16 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::setShowPaintRects(bool show)
+@@ -802,15 +904,16 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::setShowPaintRects(bool show)
      return { };
  }
  
@@ -4116,7 +4096,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  }
  
  void InspectorPageAgent::frameNavigated(Frame& frame)
-@@ -818,13 +922,23 @@ void InspectorPageAgent::frameNavigated(Frame& frame)
+@@ -818,13 +921,23 @@ void InspectorPageAgent::frameNavigated(Frame& frame)
      m_frontendDispatcher->frameNavigated(buildObjectForFrame(&frame));
  }
  
@@ -4143,7 +4123,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  }
  
  Frame* InspectorPageAgent::frameForId(const Protocol::Network::FrameId& frameId)
-@@ -836,20 +950,18 @@ String InspectorPageAgent::frameId(Frame* frame)
+@@ -836,20 +949,18 @@ String InspectorPageAgent::frameId(Frame* frame)
  {
      if (!frame)
          return emptyString();
@@ -4170,7 +4150,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  }
  
  Frame* InspectorPageAgent::assertFrame(Protocol::ErrorString& errorString, const Protocol::Network::FrameId& frameId)
-@@ -860,11 +972,6 @@ Frame* InspectorPageAgent::assertFrame(Protocol::ErrorString& errorString, const
+@@ -860,11 +971,6 @@ Frame* InspectorPageAgent::assertFrame(Protocol::ErrorString& errorString, const
      return frame;
  }
  
@@ -4182,7 +4162,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  void InspectorPageAgent::frameStartedLoading(Frame& frame)
  {
      m_frontendDispatcher->frameStartedLoading(frameId(&frame));
-@@ -885,6 +992,12 @@ void InspectorPageAgent::frameClearedScheduledNavigation(Frame& frame)
+@@ -885,6 +991,12 @@ void InspectorPageAgent::frameClearedScheduledNavigation(Frame& frame)
      m_frontendDispatcher->frameClearedScheduledNavigation(frameId(&frame));
  }
  
@@ -4195,7 +4175,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
  void InspectorPageAgent::defaultAppearanceDidChange(bool useDarkAppearance)
  {
-@@ -894,13 +1007,22 @@ void InspectorPageAgent::defaultAppearanceDidChange(bool useDarkAppearance)
+@@ -894,13 +1006,22 @@ void InspectorPageAgent::defaultAppearanceDidChange(bool useDarkAppearance)
  
  void InspectorPageAgent::didClearWindowObjectInWorld(Frame& frame, DOMWrapperWorld& world)
  {
@@ -4221,7 +4201,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  }
  
  void InspectorPageAgent::didPaint(RenderObject& renderer, const LayoutRect& rect)
-@@ -944,6 +1066,52 @@ void InspectorPageAgent::didRecalculateStyle()
+@@ -944,6 +1065,52 @@ void InspectorPageAgent::didRecalculateStyle()
      m_overlay->update();
  }
  
@@ -4237,12 +4217,12 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
 +    if (!frame)
 +        return;
 +
-+    auto& state = *mainWorldExecState(frame);
-+    auto injectedScript = m_injectedScriptManager.injectedScriptFor(&state);
++    auto& globalObject = mainWorldGlobalObject(*frame);
++    auto injectedScript = m_injectedScriptManager.injectedScriptFor(&globalObject);
 +    if (injectedScript.hasNoValue())
 +        return;
 +
-+    auto object = injectedScript.wrapObject(InspectorDOMAgent::nodeAsScriptValue(state, element), WTF::String());
++    auto object = injectedScript.wrapObject(InspectorDOMAgent::nodeAsScriptValue(globalObject, element), WTF::String());
 +    if (!object)
 +        return;
 +
@@ -4274,7 +4254,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  Ref<Protocol::Page::Frame> InspectorPageAgent::buildObjectForFrame(Frame* frame)
  {
      ASSERT_ARG(frame, frame);
-@@ -1057,6 +1225,12 @@ void InspectorPageAgent::applyUserAgentOverride(String& userAgent)
+@@ -1057,6 +1224,12 @@ void InspectorPageAgent::applyUserAgentOverride(String& userAgent)
          userAgent = m_userAgentOverride;
  }
  
@@ -4287,7 +4267,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  void InspectorPageAgent::applyEmulatedMedia(String& media)
  {
      if (!m_emulatedMedia.isEmpty())
-@@ -1080,11 +1254,13 @@ Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotNode(Protocol::DOM::
+@@ -1080,11 +1253,13 @@ Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotNode(Protocol::DOM::
      return snapshot->toDataURL("image/png"_s, std::nullopt, PreserveResolution::Yes);
  }
  
@@ -4302,7 +4282,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  
      IntRect rectangle(x, y, width, height);
      auto snapshot = snapshotFrameRect(m_inspectedPage.mainFrame(), rectangle, WTFMove(options));
-@@ -1095,6 +1271,47 @@ Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotRect(int x, int y, i
+@@ -1095,6 +1270,47 @@ Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotRect(int x, int y, i
      return snapshot->toDataURL("image/png"_s, std::nullopt, PreserveResolution::Yes);
  }
  
@@ -4350,7 +4330,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  #if ENABLE(WEB_ARCHIVE) && USE(CF)
  Protocol::ErrorStringOr<String> InspectorPageAgent::archive()
  {
-@@ -1107,7 +1324,6 @@ Protocol::ErrorStringOr<String> InspectorPageAgent::archive()
+@@ -1107,7 +1323,6 @@ Protocol::ErrorStringOr<String> InspectorPageAgent::archive()
  }
  #endif
  
@@ -4358,7 +4338,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  Protocol::ErrorStringOr<void> InspectorPageAgent::setScreenSizeOverride(std::optional<int>&& width, std::optional<int>&& height)
  {
      if (width.has_value() != height.has_value())
-@@ -1122,6 +1338,630 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::setScreenSizeOverride(std::opt
+@@ -1122,6 +1337,630 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::setScreenSizeOverride(std::opt
      m_inspectedPage.mainFrame().setOverrideScreenSize(FloatSize(width.value_or(0), height.value_or(0)));
      return { };
  }
@@ -4990,7 +4970,7 @@ index 9b5cad959a8e6f2c2bf70e1aee14287459d06612..340468e16678ffd65256f29a0126692c
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorPageAgent.h b/Source/WebCore/inspector/agents/InspectorPageAgent.h
-index b51addb1bd8f2cce69560799cd1d952d2de42838..ab460cc0c30020ab6ae53d15e8f231913cb59703 100644
+index 3d5e566dbe0c5ec11d9e8df67fcf0a70988a2f8f..48c39d5217f09c4a2cec26308deeb6bac063e538 100644
 --- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
 @@ -34,17 +34,23 @@
@@ -5029,7 +5009,7 @@ index b51addb1bd8f2cce69560799cd1d952d2de42838..ab460cc0c30020ab6ae53d15e8f23191
      };
  
 +    WEBCORE_EXPORT static String makeFrameID(ProcessIdentifier processID,  FrameIdentifier frameID);
-     static bool sharedBufferContent(RefPtr<SharedBuffer>&&, const String& textEncodingName, bool withBase64Encode, String* result);
+     static bool sharedBufferContent(RefPtr<FragmentedSharedBuffer>&&, const String& textEncodingName, bool withBase64Encode, String* result);
      static Vector<CachedResource*> cachedResourcesForFrame(Frame*);
      static void resourceContent(Inspector::Protocol::ErrorString&, Frame*, const URL&, String* result, bool* base64Encoded);
 @@ -95,15 +103,18 @@ public:
@@ -5165,7 +5145,7 @@ index c13374b161eebbf67860a0009bec14a35c53299f..aed9a5566b52b56cf93d660872b54e20
  
  void InspectorWorkerAgent::disconnectFromWorkerInspectorProxy(WorkerInspectorProxy& proxy)
 diff --git a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
-index 55d9518494195b96df165a94c1c2963adceb8395..98035b606587337e5fdacd31459a196fa7c28702 100644
+index 82b5d244b62964615fc4c123723514f2681b3915..2b871d024fbd99515b45d08235f81dde20df918e 100644
 --- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
 +++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
 @@ -38,6 +38,7 @@
@@ -5173,9 +5153,9 @@ index 55d9518494195b96df165a94c1c2963adceb8395..98035b606587337e5fdacd31459a196f
  #include "InspectorPageAgent.h"
  #include "InstrumentingAgents.h"
 +#include "JSDOMWindowBase.h"
+ #include "JSDOMWindowCustom.h"
  #include "Page.h"
  #include "PageConsoleClient.h"
- #include "PageDebugger.h"
 @@ -69,7 +70,11 @@ bool PageDebuggerAgent::enabled() const
  
  Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> PageDebuggerAgent::evaluateOnCallFrame(const Protocol::Debugger::CallFrameId& callFrameId, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture)
@@ -5201,7 +5181,7 @@ index 55d9518494195b96df165a94c1c2963adceb8395..98035b606587337e5fdacd31459a196f
  
  void PageDebuggerAgent::debuggerDidEvaluate(JSC::Debugger&, const JSC::Breakpoint::Action& action)
 diff --git a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
-index b32f3f699c2d2a377289760b245ac81784102458..48f0fab7f07bfc2b2408764e9adec252cc380705 100644
+index de5689aa33452afd95a3292ab1808aa95e1f6b1c..c8a04181e1295b16e41d5c77055e4ec2a6b3f67b 100644
 --- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
 +++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
 @@ -35,12 +35,14 @@
@@ -5211,15 +5191,15 @@ index b32f3f699c2d2a377289760b245ac81784102458..48f0fab7f07bfc2b2408764e9adec252
 +#include "FrameLoader.h"
  #include "InspectorPageAgent.h"
  #include "InstrumentingAgents.h"
- #include "JSDOMWindowBase.h"
+ #include "JSDOMWindowCustom.h"
  #include "Page.h"
  #include "PageConsoleClient.h"
  #include "ScriptController.h"
 +#include "ScriptSourceCode.h"
- #include "ScriptState.h"
  #include "SecurityOrigin.h"
  #include "UserGestureEmulationScope.h"
-@@ -103,6 +105,15 @@ void PageRuntimeAgent::didClearWindowObjectInWorld(Frame& frame, DOMWrapperWorld
+ #include <JavaScriptCore/InjectedScript.h>
+@@ -102,6 +104,15 @@ void PageRuntimeAgent::didClearWindowObjectInWorld(Frame& frame, DOMWrapperWorld
      notifyContextCreated(pageAgent->frameId(&frame), frame.script().globalObject(world), world);
  }
  
@@ -5228,14 +5208,14 @@ index b32f3f699c2d2a377289760b245ac81784102458..48f0fab7f07bfc2b2408764e9adec252
 +    if (frame.loader().stateMachine().isDisplayingInitialEmptyDocument()) {
 +        // Ensure execution context is created for the empty docment to make
 +        // it usable in case loading failed.
-+        mainWorldExecState(&frame);
++        mainWorldGlobalObject(frame);
 +    }
 +}
 +
  InjectedScript PageRuntimeAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
  {
      if (!executionContextId) {
-@@ -191,14 +202,24 @@ void PageRuntimeAgent::notifyContextCreated(const Protocol::Network::FrameId& fr
+@@ -189,14 +200,24 @@ void PageRuntimeAgent::notifyContextCreated(const Protocol::Network::FrameId& fr
  
  Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> PageRuntimeAgent::evaluate(const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture)
  {
@@ -5338,10 +5318,10 @@ index 16edb3bc689b8e2dde17597b642b706c1343e1f5..f363b2ca2410f22cff8d6ad908a88527
  
  private:
 diff --git a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
-index 74c38ea363a9d0090e1dbda9740ef680d0052d49..432d939c41f3d6fbf673e79b95df5d225174101d 100644
+index 657c7e038706cc3181acf2fd0fd1137d5b7c42d7..c641675dad3fa7319526865facc97b3a1c041a86 100644
 --- a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
 +++ b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
-@@ -277,7 +277,7 @@ void LineLayout::updateFormattingRootGeometryAndInvalidate()
+@@ -307,7 +307,7 @@ void LineLayout::updateFormattingRootGeometryAndInvalidate()
  
      auto updateGeometry = [&](auto& root) {
          root.setContentBoxWidth(flow.contentLogicalWidth());
@@ -5373,10 +5353,10 @@ index 982691dd2dfe2f65201370a12302b5086703c126..4af72beb3b1405ffac78e89e7fbb2b14
  protected:
      static SameSiteInfo sameSiteInfo(const Document&, IsForDOMCookieAccess = IsForDOMCookieAccess::No);
 diff --git a/Source/WebCore/loader/DocumentLoader.cpp b/Source/WebCore/loader/DocumentLoader.cpp
-index cf6ccf2bd089250c603fd04b74c3ec8c0e49c4f1..36cee6b7de987d793c763dce71ec141116a4ded0 100644
+index 6bf3ac297ec6b263a078640bcf3ad5779db0fedb..bca7ac699a84d8eb0e76e57081b39a5edc9bbbec 100644
 --- a/Source/WebCore/loader/DocumentLoader.cpp
 +++ b/Source/WebCore/loader/DocumentLoader.cpp
-@@ -1468,8 +1468,6 @@ void DocumentLoader::detachFromFrame()
+@@ -1473,8 +1473,6 @@ void DocumentLoader::detachFromFrame()
      if (!m_frame)
          return;
  
@@ -5386,10 +5366,10 @@ index cf6ccf2bd089250c603fd04b74c3ec8c0e49c4f1..36cee6b7de987d793c763dce71ec1411
  }
  
 diff --git a/Source/WebCore/loader/DocumentLoader.h b/Source/WebCore/loader/DocumentLoader.h
-index f7f3f3844f18447be8dd7b82d3a4435002216762..b445c8c291b1ffb7b05d0a1e348d42cdff54734c 100644
+index b46981d750b25c1fd307f16fda74b7ee306a4c39..a48ccb58b7fb1be21b601646ffdf7a7596a7a115 100644
 --- a/Source/WebCore/loader/DocumentLoader.h
 +++ b/Source/WebCore/loader/DocumentLoader.h
-@@ -169,9 +169,13 @@ public:
+@@ -178,9 +178,13 @@ public:
  
      WEBCORE_EXPORT virtual void detachFromFrame();
  
@@ -5397,14 +5377,14 @@ index f7f3f3844f18447be8dd7b82d3a4435002216762..b445c8c291b1ffb7b05d0a1e348d42cd
 +
      WEBCORE_EXPORT FrameLoader* frameLoader() const;
      WEBCORE_EXPORT SubresourceLoader* mainResourceLoader() const;
-     WEBCORE_EXPORT RefPtr<SharedBuffer> mainResourceData() const;
+     WEBCORE_EXPORT RefPtr<FragmentedSharedBuffer> mainResourceData() const;
 +
 +    virtual uint64_t loaderIDForInspector() { return 0; }
      
      DocumentWriter& writer() const { return m_writer; }
  
 diff --git a/Source/WebCore/loader/FrameLoader.cpp b/Source/WebCore/loader/FrameLoader.cpp
-index 6c5ee3a9b31ae8b84db920b66ebf214f26ec9ad6..a9b3e56a72d68ebe3a5dc73a2082c8b0b0f9bb06 100644
+index fdc97dc462c87526aa188f7968d60a0c83d680d9..4413aeac2541a73a32045479ca1d067c51e0961b 100644
 --- a/Source/WebCore/loader/FrameLoader.cpp
 +++ b/Source/WebCore/loader/FrameLoader.cpp
 @@ -1154,6 +1154,7 @@ void FrameLoader::loadInSameDocument(const URL& url, SerializedScriptValue* stat
@@ -5432,7 +5412,7 @@ index 6c5ee3a9b31ae8b84db920b66ebf214f26ec9ad6..a9b3e56a72d68ebe3a5dc73a2082c8b0
          RefPtr<DocumentLoader> oldDocumentLoader = m_documentLoader;
          NavigationAction action { *m_frame.document(), loader->request(), InitiatedByMainFrame::Unknown, policyChecker().loadType(), isFormSubmission };
  
-@@ -2792,12 +2796,17 @@ String FrameLoader::userAgent(const URL& url) const
+@@ -2796,12 +2800,17 @@ String FrameLoader::userAgent(const URL& url) const
  
  String FrameLoader::navigatorPlatform() const
  {
@@ -5452,7 +5432,7 @@ index 6c5ee3a9b31ae8b84db920b66ebf214f26ec9ad6..a9b3e56a72d68ebe3a5dc73a2082c8b0
  }
  
  void FrameLoader::dispatchOnloadEvents()
-@@ -3200,6 +3209,8 @@ void FrameLoader::receivedMainResourceError(const ResourceError& error)
+@@ -3206,6 +3215,8 @@ void FrameLoader::receivedMainResourceError(const ResourceError& error)
      checkCompleted();
      if (m_frame.page())
          checkLoadComplete();
@@ -5461,7 +5441,7 @@ index 6c5ee3a9b31ae8b84db920b66ebf214f26ec9ad6..a9b3e56a72d68ebe3a5dc73a2082c8b0
  }
  
  void FrameLoader::continueFragmentScrollAfterNavigationPolicy(const ResourceRequest& request, bool shouldContinue)
-@@ -3967,9 +3978,6 @@ String FrameLoader::referrer() const
+@@ -3973,9 +3984,6 @@ String FrameLoader::referrer() const
  
  void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
  {
@@ -5471,7 +5451,7 @@ index 6c5ee3a9b31ae8b84db920b66ebf214f26ec9ad6..a9b3e56a72d68ebe3a5dc73a2082c8b0
      Vector<Ref<DOMWrapperWorld>> worlds;
      ScriptController::getAllWorlds(worlds);
      for (auto& world : worlds)
-@@ -3978,13 +3986,13 @@ void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
+@@ -3984,13 +3992,13 @@ void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
  
  void FrameLoader::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld& world)
  {
@@ -5492,7 +5472,7 @@ index 6c5ee3a9b31ae8b84db920b66ebf214f26ec9ad6..a9b3e56a72d68ebe3a5dc73a2082c8b0
      InspectorInstrumentation::didClearWindowObjectInWorld(m_frame, world);
  }
 diff --git a/Source/WebCore/loader/LoaderStrategy.h b/Source/WebCore/loader/LoaderStrategy.h
-index aef668bd63ed5fcd45e61e9d1f107cfb6aef264b..16bf309b93be78f4a0e8ee89e5a6afcfa755530a 100644
+index 29d2e3f46140aaa51160e6a28562f370e371eb21..676ddc9369050c19454fbf5faffac2b27e0fad41 100644
 --- a/Source/WebCore/loader/LoaderStrategy.h
 +++ b/Source/WebCore/loader/LoaderStrategy.h
 @@ -86,6 +86,7 @@ public:
@@ -5572,10 +5552,10 @@ index fa84c366c63175f9fb4730eb85c4677fc3d6368f..ecf5b8dc97e35910baf493424e673155
  
  void ProgressTracker::incrementProgress(ResourceLoaderIdentifier identifier, const ResourceResponse& response)
 diff --git a/Source/WebCore/page/ChromeClient.h b/Source/WebCore/page/ChromeClient.h
-index 7d6ce2a54539f9b23eca243f0922de41ade8c189..2badd22f830ab475b2a3ca69f8b170e143232f3e 100644
+index 352e03f0c416b63800e71429e8c28ae3cdc26093..db1391b66afcfbc2299eefbdee22848e6b78b241 100644
 --- a/Source/WebCore/page/ChromeClient.h
 +++ b/Source/WebCore/page/ChromeClient.h
-@@ -314,7 +314,7 @@ public:
+@@ -316,7 +316,7 @@ public:
  #endif
  
  #if ENABLE(ORIENTATION_EVENTS)
@@ -5585,7 +5565,7 @@ index 7d6ce2a54539f9b23eca243f0922de41ade8c189..2badd22f830ab475b2a3ca69f8b170e1
  
  #if ENABLE(INPUT_TYPE_COLOR)
 diff --git a/Source/WebCore/page/EventHandler.cpp b/Source/WebCore/page/EventHandler.cpp
-index 659e3d260b9d34525881e64fe22e83b8584ab8cf..47dbdcab030cb5be500db44ebd3ba6aef1a6c16d 100644
+index 8e4e100a46e3985ac3ace014328ee8a8b0a9b152..f3fbe03a72ecb6b5b921ceb5e3d7d979de3a85b7 100644
 --- a/Source/WebCore/page/EventHandler.cpp
 +++ b/Source/WebCore/page/EventHandler.cpp
 @@ -140,6 +140,7 @@
@@ -5683,7 +5663,7 @@ index 659e3d260b9d34525881e64fe22e83b8584ab8cf..47dbdcab030cb5be500db44ebd3ba6ae
  
      return swallowEvent;
  }
-@@ -4111,7 +4111,14 @@ bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDr
+@@ -4117,7 +4117,14 @@ bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDr
      if (!m_frame.document())
          return false;
  
@@ -5699,7 +5679,7 @@ index 659e3d260b9d34525881e64fe22e83b8584ab8cf..47dbdcab030cb5be500db44ebd3ba6ae
      auto hasNonDefaultPasteboardData = HasNonDefaultPasteboardData::No;
      
      if (dragState().shouldDispatchEvents) {
-@@ -4518,7 +4525,8 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
+@@ -4506,7 +4513,8 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
              allTouchReleased = false;
      }
  
@@ -5709,7 +5689,7 @@ index 659e3d260b9d34525881e64fe22e83b8584ab8cf..47dbdcab030cb5be500db44ebd3ba6ae
          PlatformTouchPoint::State pointState = point.state();
          LayoutPoint pagePoint = documentPointForWindowPoint(m_frame, point.pos());
  
-@@ -4645,6 +4653,9 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
+@@ -4633,6 +4641,9 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
              changedTouches[pointState].m_touches->append(WTFMove(touch));
              changedTouches[pointState].m_targets.add(touchTarget);
          }
@@ -5720,7 +5700,7 @@ index 659e3d260b9d34525881e64fe22e83b8584ab8cf..47dbdcab030cb5be500db44ebd3ba6ae
      m_touchPressed = touches->length() > 0;
      if (allTouchReleased)
 diff --git a/Source/WebCore/page/EventHandler.h b/Source/WebCore/page/EventHandler.h
-index eac1d5f340086c3636bff6109651dec9f4eb30fe..6da03d6a69a9ac5d0eb50ddc90ac77f6fa85b659 100644
+index 6b359e7556a2d6a1485e04e8c20fa5f470c5a04a..4eda11b09ed371ff7bafd6d6f37a96b58f5c2075 100644
 --- a/Source/WebCore/page/EventHandler.h
 +++ b/Source/WebCore/page/EventHandler.h
 @@ -135,9 +135,7 @@ public:
@@ -5733,7 +5713,7 @@ index eac1d5f340086c3636bff6109651dec9f4eb30fe..6da03d6a69a9ac5d0eb50ddc90ac77f6
  
  #if ENABLE(PAN_SCROLLING)
      void didPanScrollStart();
-@@ -385,10 +383,8 @@ private:
+@@ -384,10 +382,8 @@ private:
      bool startKeyboardScrolling(KeyboardEvent&);
      void stopKeyboardScrolling();
  
@@ -5744,7 +5724,7 @@ index eac1d5f340086c3636bff6109651dec9f4eb30fe..6da03d6a69a9ac5d0eb50ddc90ac77f6
  
      WEBCORE_EXPORT bool handleMouseReleaseEvent(const MouseEventWithHitTestResults&);
  
-@@ -488,10 +484,8 @@ private:
+@@ -487,10 +483,8 @@ private:
      void defaultTabEventHandler(KeyboardEvent&);
      void defaultArrowEventHandler(FocusDirection, KeyboardEvent&);
  
@@ -5755,7 +5735,7 @@ index eac1d5f340086c3636bff6109651dec9f4eb30fe..6da03d6a69a9ac5d0eb50ddc90ac77f6
  
      // The following are called at the beginning of handleMouseUp and handleDrag.  
      // If they return true it indicates that they have consumed the event.
-@@ -499,9 +493,10 @@ private:
+@@ -498,9 +492,10 @@ private:
  
  #if ENABLE(DRAG_SUPPORT)
      bool eventLoopHandleMouseDragged(const MouseEventWithHitTestResults&);
@@ -5767,7 +5747,7 @@ index eac1d5f340086c3636bff6109651dec9f4eb30fe..6da03d6a69a9ac5d0eb50ddc90ac77f6
      enum class SetOrClearLastScrollbar { Clear, Set };
      void updateLastScrollbarUnderMouse(Scrollbar*, SetOrClearLastScrollbar);
      
-@@ -593,8 +588,8 @@ private:
+@@ -592,8 +587,8 @@ private:
      Timer m_autoHideCursorTimer;
  #endif
  
@@ -5798,7 +5778,7 @@ index 602631bb7cd10860b1a3121043c97d8efe44761d..867320c576201d35124a186ac60c2927
      request.setHTTPHeaderField(HTTPHeaderName::Accept, "text/event-stream");
      request.setHTTPHeaderField(HTTPHeaderName::CacheControl, "no-cache");
 diff --git a/Source/WebCore/page/Frame.cpp b/Source/WebCore/page/Frame.cpp
-index 7788ee5755febf003f929b6df5de094fd7a9338f..227640e9a941afe56dc2d80512e48d195de9aef9 100644
+index 86f9a7be3eba0dbf2b275c751cc843ddaa74a5c1..15551d2f74b3871470324253b755a35cf437a53c 100644
 --- a/Source/WebCore/page/Frame.cpp
 +++ b/Source/WebCore/page/Frame.cpp
 @@ -39,6 +39,7 @@
@@ -5825,7 +5805,7 @@ index 7788ee5755febf003f929b6df5de094fd7a9338f..227640e9a941afe56dc2d80512e48d19
  }
  
  Ref<Frame> Frame::create(Page* page, HTMLFrameOwnerElement* ownerElement, UniqueRef<FrameLoaderClient>&& client)
-@@ -376,7 +379,7 @@ void Frame::orientationChanged()
+@@ -370,7 +373,7 @@ void Frame::orientationChanged()
  int Frame::orientation() const
  {
      if (m_page)
@@ -5834,7 +5814,7 @@ index 7788ee5755febf003f929b6df5de094fd7a9338f..227640e9a941afe56dc2d80512e48d19
      return 0;
  }
  #endif // ENABLE(ORIENTATION_EVENTS)
-@@ -1169,6 +1172,362 @@ DataDetectionResultsStorage& Frame::dataDetectionResults()
+@@ -1163,6 +1166,362 @@ DataDetectionResultsStorage& Frame::dataDetectionResults()
  
  #endif
  
@@ -6198,7 +6178,7 @@ index 7788ee5755febf003f929b6df5de094fd7a9338f..227640e9a941afe56dc2d80512e48d19
  
  #undef FRAME_RELEASE_LOG_ERROR
 diff --git a/Source/WebCore/page/Frame.h b/Source/WebCore/page/Frame.h
-index 124df1885f71dcd7d65e01d69fd79b104a07e672..51f87cd8710add1be6b6e3b99d9dc5bd5bbd264e 100644
+index 53644eb195e17cd2fd7fc41b142ad1b76e4b6ccd..05915f61ef809c19ad4a4c9b0bdd64144e6495bc 100644
 --- a/Source/WebCore/page/Frame.h
 +++ b/Source/WebCore/page/Frame.h
 @@ -112,8 +112,8 @@ enum {
@@ -6328,7 +6308,7 @@ index 28d1fc3242174a680711027877d4153923790220..058b5309eed081fcc1e4158f66e80642
      if (stateObjectType == StateObjectType::Push) {
          frame->loader().history().pushState(WTFMove(data), title, fullURL.string());
 diff --git a/Source/WebCore/page/Page.cpp b/Source/WebCore/page/Page.cpp
-index 2cd19a110b2b86923f4631299da355063c8bb511..82c438e2772198c19584d56de64be61162453a31 100644
+index 3fb2b67cf2b549d24a8379f81842629399b1afb1..ecd4557ae4f50e335ee42de68972a693110f75a7 100644
 --- a/Source/WebCore/page/Page.cpp
 +++ b/Source/WebCore/page/Page.cpp
 @@ -472,6 +472,37 @@ void Page::setOverrideViewportArguments(const std::optional<ViewportArguments>&
@@ -6369,7 +6349,7 @@ index 2cd19a110b2b86923f4631299da355063c8bb511..82c438e2772198c19584d56de64be611
  ScrollingCoordinator* Page::scrollingCoordinator()
  {
      if (!m_scrollingCoordinator && m_settings->scrollingCoordinatorEnabled()) {
-@@ -1308,10 +1339,6 @@ void Page::didCommitLoad()
+@@ -1307,10 +1338,6 @@ void Page::didCommitLoad()
      m_isEditableRegionEnabled = false;
  #endif
  
@@ -6380,7 +6360,7 @@ index 2cd19a110b2b86923f4631299da355063c8bb511..82c438e2772198c19584d56de64be611
      resetSeenPlugins();
      resetSeenMediaEngines();
  
-@@ -3315,6 +3342,16 @@ void Page::setUseDarkAppearanceOverride(std::optional<bool> valueOverride)
+@@ -3326,6 +3353,16 @@ void Page::setUseDarkAppearanceOverride(std::optional<bool> valueOverride)
  #endif
  }
  
@@ -6398,7 +6378,7 @@ index 2cd19a110b2b86923f4631299da355063c8bb511..82c438e2772198c19584d56de64be611
  {
      if (insets == m_fullscreenInsets)
 diff --git a/Source/WebCore/page/Page.h b/Source/WebCore/page/Page.h
-index d09ae215184558929a31388a8ff0b2ba4fdbd4c8..6381b441ad76417f0df14cbb14dcca4f76191f8d 100644
+index d6d5ae2c56644e253898a04a0f9cb3ccaa536af2..a192815caa8bf7bab29877be1b5305724ff1658f 100644
 --- a/Source/WebCore/page/Page.h
 +++ b/Source/WebCore/page/Page.h
 @@ -272,6 +272,9 @@ public:
@@ -6431,7 +6411,7 @@ index d09ae215184558929a31388a8ff0b2ba4fdbd4c8..6381b441ad76417f0df14cbb14dcca4f
  
  #if ENABLE(TEXT_AUTOSIZING)
      float textAutosizingWidth() const { return m_textAutosizingWidth; }
-@@ -881,6 +890,11 @@ public:
+@@ -886,6 +895,11 @@ public:
  
      WEBCORE_EXPORT Vector<Ref<Element>> editableElementsInRect(const FloatRect&) const;
  
@@ -6443,7 +6423,7 @@ index d09ae215184558929a31388a8ff0b2ba4fdbd4c8..6381b441ad76417f0df14cbb14dcca4f
  #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
      DeviceOrientationUpdateProvider* deviceOrientationUpdateProvider() const { return m_deviceOrientationUpdateProvider.get(); }
  #endif
-@@ -979,6 +993,9 @@ private:
+@@ -986,6 +1000,9 @@ private:
  
  #if ENABLE(DRAG_SUPPORT)
      const std::unique_ptr<DragController> m_dragController;
@@ -6453,7 +6433,7 @@ index d09ae215184558929a31388a8ff0b2ba4fdbd4c8..6381b441ad76417f0df14cbb14dcca4f
  #endif
      const std::unique_ptr<FocusController> m_focusController;
  #if ENABLE(CONTEXT_MENUS)
-@@ -1058,6 +1075,7 @@ private:
+@@ -1065,6 +1082,7 @@ private:
      bool m_useElevatedUserInterfaceLevel { false };
      bool m_useDarkAppearance { false };
      std::optional<bool> m_useDarkAppearanceOverride;
@@ -6461,7 +6441,7 @@ index d09ae215184558929a31388a8ff0b2ba4fdbd4c8..6381b441ad76417f0df14cbb14dcca4f
  
  #if ENABLE(TEXT_AUTOSIZING)
      float m_textAutosizingWidth { 0 };
-@@ -1232,6 +1250,11 @@ private:
+@@ -1239,6 +1257,11 @@ private:
  #endif
  
      std::optional<ViewportArguments> m_overrideViewportArguments;
@@ -6535,10 +6515,10 @@ index 04fff21a26adbc73d8b74dbf55acc8e9824f35da..cd7346fe3b4701724431bc1617e13d2e
  #endif
  
 diff --git a/Source/WebCore/page/RuntimeEnabledFeatures.h b/Source/WebCore/page/RuntimeEnabledFeatures.h
-index 6258c0167d1f2c9f7811f7606787a2ef7f76a2f4..8a2b0d132553c30924f5747406d9040d63544dae 100644
+index 33cf308e7c61b23b2ec5283115e02de3abd0fedb..bcf0b9ca671eb2bcb91e46462a4893e73706eb71 100644
 --- a/Source/WebCore/page/RuntimeEnabledFeatures.h
 +++ b/Source/WebCore/page/RuntimeEnabledFeatures.h
-@@ -191,6 +191,7 @@ public:
+@@ -188,6 +188,7 @@ public:
      void setMouseEventsSimulationEnabled(bool isEnabled) { m_mouseEventsSimulationEnabled = isEnabled; }
      bool touchEventsEnabled() const;
      void setTouchEventsEnabled(bool isEnabled) { m_touchEventsEnabled = isEnabled; }
@@ -6600,10 +6580,10 @@ index 3bec0aef174336939838fb1069fffbcb9f3d5604..566ef3806be3c5ccf1bb951251c2a90d
  
  RefPtr<ThreadableWebSocketChannel> SocketProvider::createWebSocketChannel(Document&, WebSocketChannelClient&)
 diff --git a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
-index bb780481e89cb19c16789fb14b422e70afcd5197..191cf3a48d951292ba582458d2f17a1c49edbb6d 100644
+index e4209bca7749d9b0c2f95afbdd2a9f28387dd371..1501490f77da0eefd409f7f38f33630516560a6b 100644
 --- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
 +++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
-@@ -293,6 +293,8 @@ bool ContentSecurityPolicy::protocolMatchesSelf(const URL& url) const
+@@ -294,6 +294,8 @@ bool ContentSecurityPolicy::protocolMatchesSelf(const URL& url) const
  template<typename Predicate, typename... Args>
  typename std::enable_if<!std::is_convertible<Predicate, ContentSecurityPolicy::ViolatedDirectiveCallback>::value, bool>::type ContentSecurityPolicy::allPoliciesWithDispositionAllow(Disposition disposition, Predicate&& predicate, Args&&... args) const
  {
@@ -6612,7 +6592,7 @@ index bb780481e89cb19c16789fb14b422e70afcd5197..191cf3a48d951292ba582458d2f17a1c
      bool isReportOnly = disposition == ContentSecurityPolicy::Disposition::ReportOnly;
      for (auto& policy : m_policies) {
          if (policy->isReportOnly() != isReportOnly)
-@@ -306,6 +308,8 @@ typename std::enable_if<!std::is_convertible<Predicate, ContentSecurityPolicy::V
+@@ -307,6 +309,8 @@ typename std::enable_if<!std::is_convertible<Predicate, ContentSecurityPolicy::V
  template<typename Predicate, typename... Args>
  bool ContentSecurityPolicy::allPoliciesWithDispositionAllow(Disposition disposition, ViolatedDirectiveCallback&& callback, Predicate&& predicate, Args&&... args) const
  {
@@ -6621,7 +6601,7 @@ index bb780481e89cb19c16789fb14b422e70afcd5197..191cf3a48d951292ba582458d2f17a1c
      bool isReportOnly = disposition == ContentSecurityPolicy::Disposition::ReportOnly;
      bool isAllowed = true;
      for (auto& policy : m_policies) {
-@@ -322,6 +326,8 @@ bool ContentSecurityPolicy::allPoliciesWithDispositionAllow(Disposition disposit
+@@ -323,6 +327,8 @@ bool ContentSecurityPolicy::allPoliciesWithDispositionAllow(Disposition disposit
  template<typename Predicate, typename... Args>
  bool ContentSecurityPolicy::allPoliciesAllow(ViolatedDirectiveCallback&& callback, Predicate&& predicate, Args&&... args) const
  {
@@ -6754,7 +6734,7 @@ index 6dfe0dd3ea4da3a1f5f0f6c79d6d1a3bf00c3159..683c1bdb2cb33538af14dcc5dab89d07
  IntSize dragImageSize(DragImageRef)
  {
 diff --git a/Source/WebCore/platform/Pasteboard.h b/Source/WebCore/platform/Pasteboard.h
-index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e578fb03d 100644
+index f2eb972019a402eb88ceff8f47c3e863fe3402c6..1ba4a5a92fb81364d9b27eff315dbddc93034598 100644
 --- a/Source/WebCore/platform/Pasteboard.h
 +++ b/Source/WebCore/platform/Pasteboard.h
 @@ -44,7 +44,7 @@ OBJC_CLASS NSString;
@@ -6766,7 +6746,7 @@ index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e
  #include "SelectionData.h"
  #endif
  
-@@ -91,16 +91,12 @@ struct PasteboardWebContent {
+@@ -92,16 +92,12 @@ struct PasteboardWebContent {
      Vector<String> clientTypes;
      Vector<RefPtr<SharedBuffer>> clientData;
  #endif
@@ -6784,7 +6764,7 @@ index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e
  };
  
  struct PasteboardURL {
-@@ -109,7 +105,7 @@ struct PasteboardURL {
+@@ -110,7 +106,7 @@ struct PasteboardURL {
  #if PLATFORM(MAC)
      String userVisibleForm;
  #endif
@@ -6793,7 +6773,7 @@ index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e
      String markup;
  #endif
  };
-@@ -188,6 +184,11 @@ public:
+@@ -200,6 +196,11 @@ public:
  #endif
  #endif
  
@@ -6805,7 +6785,7 @@ index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e
  #if PLATFORM(WIN)
      explicit Pasteboard(std::unique_ptr<PasteboardContext>&&, IDataObject*);
      explicit Pasteboard(std::unique_ptr<PasteboardContext>&&, WCDataObject*);
-@@ -253,6 +254,12 @@ public:
+@@ -266,6 +267,12 @@ public:
      static std::unique_ptr<Pasteboard> createForGlobalSelection(std::unique_ptr<PasteboardContext>&&);
  #endif
  
@@ -6818,7 +6798,7 @@ index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e
  #if PLATFORM(IOS_FAMILY)
      explicit Pasteboard(std::unique_ptr<PasteboardContext>&&, int64_t changeCount);
      explicit Pasteboard(std::unique_ptr<PasteboardContext>&&, const String& pasteboardName);
-@@ -287,6 +294,7 @@ public:
+@@ -300,6 +307,7 @@ public:
      COMPtr<IDataObject> dataObject() const { return m_dataObject; }
      void setExternalDataObject(IDataObject*);
      const DragDataMap& dragDataMap() const { return m_dragDataMap; }
@@ -6826,7 +6806,7 @@ index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e
      void writeURLToWritableDataObject(const URL&, const String&);
      COMPtr<WCDataObject> writableDataObject() const { return m_writableDataObject; }
      void writeImageToDataObject(Element&, const URL&); // FIXME: Layering violation.
-@@ -338,6 +346,10 @@ private:
+@@ -351,6 +359,10 @@ private:
      String m_name;
  #endif
  
@@ -6837,7 +6817,7 @@ index 7d247dcd1a16f342c1754c45c4a73529bf8f71b2..6903f0a0ab250526f533bcc69e1af11e
  #if PLATFORM(COCOA)
      String m_pasteboardName;
      int64_t m_changeCount;
-@@ -353,6 +365,7 @@ private:
+@@ -366,6 +378,7 @@ private:
      COMPtr<IDataObject> m_dataObject;
      COMPtr<WCDataObject> m_writableDataObject;
      DragDataMap m_dragDataMap;
@@ -6895,7 +6875,7 @@ index ba50b688ab6d0bae5d199fa0bac4b7e2004baf81..0b83a798b00835635a95a0db22173de0
 +} // namespace WebCore
 +#endif
 diff --git a/Source/WebCore/platform/PlatformScreen.h b/Source/WebCore/platform/PlatformScreen.h
-index d47d193e8bee85c2d2a35e218decdd84b7212dc1..a1cd2f3b8f025436b596d1b1081357d9290763ea 100644
+index be373f080140728d3e0bfc1e7db9f163ed3aedc8..12f49cdf02ec892acef95e524e72929c12c3b8d3 100644
 --- a/Source/WebCore/platform/PlatformScreen.h
 +++ b/Source/WebCore/platform/PlatformScreen.h
 @@ -155,12 +155,14 @@ WEBCORE_EXPORT float screenScaleFactor(UIScreen * = nullptr);
@@ -6917,7 +6897,7 @@ index d47d193e8bee85c2d2a35e218decdd84b7212dc1..a1cd2f3b8f025436b596d1b1081357d9
  #endif
  
 diff --git a/Source/WebCore/platform/ScrollableArea.h b/Source/WebCore/platform/ScrollableArea.h
-index ab745c4bba9f23e18aba3cf136e3e915310b9051..b97ce7699e3bd705016cb1d209ba90f507ba394a 100644
+index 1acdf55bbef3d3fa5942a4efa6bdcbfb3cfaab08..6c9d2ef0691ea6eb6d86dc0d5aceb53881410481 100644
 --- a/Source/WebCore/platform/ScrollableArea.h
 +++ b/Source/WebCore/platform/ScrollableArea.h
 @@ -103,7 +103,7 @@ public:
@@ -7016,7 +6996,7 @@ index 0000000000000000000000000000000000000000..f0c3a183e5bc44bdfa4201e0db2067b4
 +
 +#endif // ENABLE(SPEECH_SYNTHESIS)
 diff --git a/Source/WebCore/platform/graphics/FontCascade.h b/Source/WebCore/platform/graphics/FontCascade.h
-index 6af5812d8a722b8fdbd39381bd64832769e4fa3a..02b9400c438c630f43c6a2e7301db4ac3311dcdc 100644
+index c34568017fcde983e6f5ac70ee1783a9f73e9053..3b35fed927fbcc4c48d727e0d3acf811a9a32235 100644
 --- a/Source/WebCore/platform/graphics/FontCascade.h
 +++ b/Source/WebCore/platform/graphics/FontCascade.h
 @@ -291,7 +291,8 @@ private:
@@ -7498,7 +7478,7 @@ index 80958ba565a877224d0ed37e4e4057b4be0dde24..eca42bf5181bc4a95efca9c9c3f5ce0f
      auto* display = gdk_display_get_default();
      if (!display)
 diff --git a/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp b/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
-index f4c905dc15a2183629b0e9817dc24135e0ff7fe5..e9925e7a9fc3cbf5fefffaf38f409fbeec189cb0 100644
+index 1887d8c6f2471444eed3cf06f345a3893c9e6e73..a6ea2832ec1faf627cc3a77537c479ede2785f4a 100644
 --- a/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
 +++ b/Source/WebCore/platform/libwpe/PasteboardLibWPE.cpp
 @@ -32,6 +32,10 @@
@@ -7559,7 +7539,7 @@ index f4c905dc15a2183629b0e9817dc24135e0ff7fe5..e9925e7a9fc3cbf5fefffaf38f409fbe
  }
  
  void Pasteboard::writeTrustworthyWebURLsPboardType(const PasteboardURL&)
-@@ -119,13 +147,28 @@ void Pasteboard::writeTrustworthyWebURLsPboardType(const PasteboardURL&)
+@@ -119,8 +147,16 @@ void Pasteboard::writeTrustworthyWebURLsPboardType(const PasteboardURL&)
      notImplemented();
  }
  
@@ -7576,6 +7556,9 @@ index f4c905dc15a2183629b0e9817dc24135e0ff7fe5..e9925e7a9fc3cbf5fefffaf38f409fbe
 +    }
  }
  
+ void Pasteboard::write(const PasteboardBuffer&)
+@@ -129,7 +165,14 @@ void Pasteboard::write(const PasteboardBuffer&)
+ 
  void Pasteboard::write(const PasteboardWebContent& content)
  {
 -    platformStrategies()->pasteboardStrategy()->writeToPasteboard(content);
@@ -7590,7 +7573,7 @@ index f4c905dc15a2183629b0e9817dc24135e0ff7fe5..e9925e7a9fc3cbf5fefffaf38f409fbe
  }
  
  Pasteboard::FileContentState Pasteboard::fileContentState()
-@@ -156,6 +199,35 @@ void Pasteboard::write(const Color&)
+@@ -160,6 +203,35 @@ void Pasteboard::write(const Color&)
  {
  }
  
@@ -7906,7 +7889,7 @@ index 39cb560e54bf9efd2dad6e1fb60dd0f609daf6bf..91c132460d4b466f61a8c579f70329fd
          m_commonHeaders.append(CommonHeader { name, value });
  }
 diff --git a/Source/WebCore/platform/network/NetworkStorageSession.h b/Source/WebCore/platform/network/NetworkStorageSession.h
-index 3cbe3f9473d4ef35b0577847bcb9f0c70355fc27..86dc55f9d09a2c9a92e1ed535a6f3888b078cae3 100644
+index 31bc15743684309822fdd8ce3873d74757b2c484..91052a0cabf088b30717247e9919510f7574694d 100644
 --- a/Source/WebCore/platform/network/NetworkStorageSession.h
 +++ b/Source/WebCore/platform/network/NetworkStorageSession.h
 @@ -154,6 +154,8 @@ public:
@@ -7983,7 +7966,7 @@ index 7330aa933924791f1292c0847921e3b367493d96..a5238a748d1fb4bfa5b3e0882fe62f40
      StreamBuffer<uint8_t, 1024 * 1024> m_buffer;
      static const unsigned maxBufferSize = 100 * 1024 * 1024;
 diff --git a/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp b/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
-index 311aef2d80fe7336cd8e5113c39d950db8f4394c..995545c175a9b22145f82c7efa8ef539cec4279b 100644
+index 6961e7983067a1865b4afbe3fa7ac5ce695a4d35..a834a02100c32c2eb0799e9b4fd07777d5f069d2 100644
 --- a/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
 +++ b/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
 @@ -96,7 +96,7 @@ static inline auto callbacksRunLoopMode()
@@ -8133,10 +8116,10 @@ index 0c39c90aac884fca48849388acc1b42bad16d620..dd8e50686c348b46d5ae92fd67a31eb0
      void send(CurlStreamID, UniqueArray<uint8_t>&&, size_t);
  
 diff --git a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
-index 5249bfb4a5ba52981e1f4cbe43048e27507b033a..52b8d0703ebb2fb0737b73bc7ebcf3abe3d7ed9e 100644
+index e7b8ebce073536c148eafaca9d751ec8fb244232..2212618a8980afdd9237669f946a1a8cdc9c92c4 100644
 --- a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
 +++ b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
-@@ -116,6 +116,12 @@ void NetworkStorageSession::setCookieAcceptPolicy(CookieAcceptPolicy policy) con
+@@ -118,6 +118,12 @@ void NetworkStorageSession::setCookieAcceptPolicy(CookieAcceptPolicy policy) con
      cookieDatabase().setAcceptPolicy(policy);
  }
  
@@ -8194,7 +8177,7 @@ index 4b9491c11543f2b60f12d36e9e6a0cbaae34a72e..e907fc00a2a426384ce1e471847911c9
  
  SocketStreamHandleImpl::~SocketStreamHandleImpl()
 diff --git a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
-index 5b32534e2bcaf1701331e9541013b8a5c38c4d36..2e8c12c871ba10d5769c400ec31d4fca6641aaca 100644
+index fcfa4e995212ae926f6339d37dbbb3d1051e0fc3..b2341ee77f6b1c2c0b4ebecc6e861f36522e2a7f 100644
 --- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
 +++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
 @@ -408,6 +408,30 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
@@ -8314,10 +8297,10 @@ index aae6c99dd052985a43718846b68536454050c234..7e2e5d0c1de90f1454f7fdb71a40ab71
  
  bool PlatformKeyboardEvent::currentCapsLockState()
 diff --git a/Source/WebCore/platform/win/PasteboardWin.cpp b/Source/WebCore/platform/win/PasteboardWin.cpp
-index 2b31285870303d09b0245365d61ab891111daab5..36e2efa8b05c21c003607e9143a213eb089ebfbb 100644
+index 85f96d85d2b372cfc2171a83411d528692073cd4..3350eb913cfb24273030bd8cf86a124c6851db01 100644
 --- a/Source/WebCore/platform/win/PasteboardWin.cpp
 +++ b/Source/WebCore/platform/win/PasteboardWin.cpp
-@@ -1126,7 +1126,21 @@ void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
+@@ -1130,7 +1130,21 @@ void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
      }
  
      clear();
@@ -8339,7 +8322,7 @@ index 2b31285870303d09b0245365d61ab891111daab5..36e2efa8b05c21c003607e9143a213eb
      if (::OpenClipboard(m_owner)) {
          const auto& customData = data.first();
          customData.forEachPlatformStringOrBuffer([](auto& type, auto& stringOrBuffer) {
-@@ -1165,4 +1179,25 @@ void Pasteboard::write(const Color&)
+@@ -1169,4 +1183,25 @@ void Pasteboard::write(const Color&)
  {
  }
  
@@ -8799,10 +8782,10 @@ index 0000000000000000000000000000000000000000..cf2b51f6f02837a1106f4d999f2f130e
 +
 +} // namespace WebCore
 diff --git a/Source/WebCore/rendering/RenderLayer.cpp b/Source/WebCore/rendering/RenderLayer.cpp
-index fbef46090d074e2fb6fa2c475c1e59f741cca2c2..caf0d9ebf5b7f4ef735a16213f0bd951df067fe3 100644
+index 6509f5bfe532ec09b8f3d8c452e8b69af41ce8bb..5f7b482cef1619599255ed56c634aa13ca64d203 100644
 --- a/Source/WebCore/rendering/RenderLayer.cpp
 +++ b/Source/WebCore/rendering/RenderLayer.cpp
-@@ -2618,7 +2618,7 @@ LayoutRect RenderLayer::getRectToExpose(const LayoutRect& visibleRect, const Lay
+@@ -2605,7 +2605,7 @@ LayoutRect RenderLayer::getRectToExpose(const LayoutRect& visibleRect, const Lay
      ScrollAlignment::Behavior scrollX;
      LayoutRect exposeRectX(exposeRect.x(), visibleRect.y(), exposeRect.width(), visibleRect.height());
      LayoutUnit intersectWidth = intersection(visibleRect, exposeRectX).width();
@@ -8858,10 +8841,10 @@ index 694008e0451edc5770142a0a6d9eed52b04ded80..ec93869f9486bdf7bd3bb56478c62469
      
  WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollAlignment::Behavior);
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
-index 291cc9892e81027d9caed1d9db7061d73e674170..82250607745fb5b7f7148b0b2381f626a746de7d 100644
+index 9c6dd8ce4d8f06a203b640aa22a025e997f31036..8dd790fbfc10c000a61a477e3178b474a7d8c126 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
-@@ -76,6 +76,11 @@
+@@ -77,6 +77,11 @@
  #include <WebCore/SameSiteInfo.h>
  #include <WebCore/SecurityPolicy.h>
  
@@ -8873,7 +8856,7 @@ index 291cc9892e81027d9caed1d9db7061d73e674170..82250607745fb5b7f7148b0b2381f626
  #if ENABLE(APPLE_PAY_REMOTE_UI)
  #include "WebPaymentCoordinatorProxyMessages.h"
  #endif
-@@ -964,6 +969,14 @@ void NetworkConnectionToWebProcess::clearPageSpecificData(PageIdentifier pageID)
+@@ -969,6 +974,14 @@ void NetworkConnectionToWebProcess::clearPageSpecificData(PageIdentifier pageID)
  #endif
  }
  
@@ -8889,10 +8872,10 @@ index 291cc9892e81027d9caed1d9db7061d73e674170..82250607745fb5b7f7148b0b2381f626
  void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier frameID, PageIdentifier pageID)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
-index e817b7b62d249787dc4ab19edebb0c4f68512f2e..b3b923d1a0508d1bc8d8238fc5526437a62fcca1 100644
+index b85bd65fcc011127c4fc2df590d218828646b531..77df8f91895b2ab046403c90a4f0e9cae0ac968b 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
-@@ -289,6 +289,8 @@ private:
+@@ -290,6 +290,8 @@ private:
  
      void clearPageSpecificData(WebCore::PageIdentifier);
  
@@ -8902,7 +8885,7 @@ index e817b7b62d249787dc4ab19edebb0c4f68512f2e..b3b923d1a0508d1bc8d8238fc5526437
      void removeStorageAccessForFrame(WebCore::FrameIdentifier, WebCore::PageIdentifier);
  
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
-index 005f632ef577c9c16a7dd7c1e6c67c911b42676c..53d84bccb064cc99f998b10519a3993ee29b613e 100644
+index e2847fc0a4c44d2ef2384fe8561c4ba34dc5ddc9..c0b90629e0dfe4b01a98abc44b03f133d1be2caa 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 @@ -66,6 +66,8 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
@@ -8915,7 +8898,7 @@ index 005f632ef577c9c16a7dd7c1e6c67c911b42676c..53d84bccb064cc99f998b10519a3993e
      RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
      LogUserInteraction(WebCore::RegistrableDomain domain)
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.cpp b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
-index 43f5bbe7b1abe09dd774c92b5c0e4f42dce1ddb7..5e44be4f1bbee607b24d33ef12f18987e815162c 100644
+index 26bd1071994b3f827bd7d5974539af149c1622ca..5c4ae23e0ffc43d68b192806377d5d7586fb75d8 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 @@ -26,7 +26,6 @@
@@ -8926,8 +8909,8 @@ index 43f5bbe7b1abe09dd774c92b5c0e4f42dce1ddb7..5e44be4f1bbee607b24d33ef12f18987
  #include "ArgumentCoders.h"
  #include "Attachment.h"
  #include "AuthenticationManager.h"
-@@ -580,6 +579,59 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID)
-     removeStorageManagerForSession(sessionID);
+@@ -535,6 +534,41 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID)
+     m_sessionsControlledByAutomation.remove(sessionID);
  }
  
 +void NetworkProcess::getAllCookies(PAL::SessionID sessionID, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
@@ -8959,24 +8942,6 @@ index 43f5bbe7b1abe09dd774c92b5c0e4f42dce1ddb7..5e44be4f1bbee607b24d33ef12f18987
 +    completionHandler(false);
 +}
 +
-+void NetworkProcess::getLocalStorageData(PAL::SessionID sessionID, CompletionHandler<void(Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>>&&)>&& completionHandler)
-+{
-+    if (m_storageManagerSet->contains(sessionID)) {
-+        m_storageManagerSet->getLocalStorageData(sessionID, WTFMove(completionHandler));
-+        return;
-+    }
-+    completionHandler(Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>>());
-+}
-+
-+void NetworkProcess::setLocalStorageData(PAL::SessionID sessionID, WebKit::StorageNamespaceIdentifier storageNamespaceID, Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>>&& origins, CompletionHandler<void(String)>&& completionHandler)
-+{
-+    if (m_storageManagerSet->contains(sessionID)) {
-+        m_storageManagerSet->setLocalStorageData(sessionID, storageNamespaceID, WTFMove(origins), WTFMove(completionHandler));
-+        return;
-+    }
-+    completionHandler("Cannot find storage manager for given session id");
-+}
-+
 +void NetworkProcess::setIgnoreCertificateErrors(PAL::SessionID sessionID, bool ignore)
 +{
 +    if (auto* networkSession = this->networkSession(sessionID))
@@ -8987,7 +8952,7 @@ index 43f5bbe7b1abe09dd774c92b5c0e4f42dce1ddb7..5e44be4f1bbee607b24d33ef12f18987
  void NetworkProcess::dumpResourceLoadStatistics(PAL::SessionID sessionID, CompletionHandler<void(String)>&& completionHandler)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.h b/Source/WebKit/NetworkProcess/NetworkProcess.h
-index 9bc57ee37eb609c397ed7e3d22f55e064d02e017..4d507c781525e582f869364b223cd50f4535e444 100644
+index 7877927a17c5596eb03bd4acf4d58e418ac8ba23..901fb80d71c8cac0eb0414153184ad928ff498ad 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
 @@ -35,6 +35,7 @@
@@ -8995,18 +8960,18 @@ index 9bc57ee37eb609c397ed7e3d22f55e064d02e017..4d507c781525e582f869364b223cd50f
  #include "RTCDataChannelRemoteManagerProxy.h"
  #include "SandboxExtension.h"
 +#include "StorageNamespaceIdentifier.h"
- #include "WebIDBServer.h"
  #include "WebPageProxyIdentifier.h"
  #include "WebResourceLoadStatisticsStore.h"
-@@ -80,6 +81,7 @@ class SessionID;
+ #include "WebsiteData.h"
+@@ -79,6 +80,7 @@ class SessionID;
  
  namespace WebCore {
  class CertificateInfo;
 +struct Cookie;
  class CurlProxySettings;
  class ProtectionSpace;
- class StorageQuotaManager;
-@@ -211,6 +213,14 @@ public:
+ class NetworkStorageSession;
+@@ -201,6 +203,11 @@ public:
  
      void addWebsiteDataStore(WebsiteDataStoreParameters&&);
  
@@ -9015,17 +8980,14 @@ index 9bc57ee37eb609c397ed7e3d22f55e064d02e017..4d507c781525e582f869364b223cd50f
 +    void deleteAllCookies(PAL::SessionID, CompletionHandler<void(bool)>&&);
 +    void setIgnoreCertificateErrors(PAL::SessionID, bool);
 +
-+    void getLocalStorageData(PAL::SessionID sessionID, CompletionHandler<void(Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>>&&)>&&);
-+    void setLocalStorageData(PAL::SessionID sessionID, WebKit::StorageNamespaceIdentifier storageNamespaceID, Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>>&& origins, CompletionHandler<void(String)>&&);
-+
  #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)
      void clearPrevalentResource(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
      void clearUserInteraction(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
-index 8d34e713966c7e90ab435b1bfdd3e3d3b6c2083c..4ebdca94755a7b9404f7d7885708cc1dbc83187b 100644
+index 637e159f186393bec5cc05ab5bd5780be8c6fce4..8032679d6f8a585441d4c5984f3cc7cdeb929e34 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
-@@ -78,6 +78,14 @@ messages -> NetworkProcess LegacyReceiver {
+@@ -78,6 +78,11 @@ messages -> NetworkProcess LegacyReceiver {
  
      PreconnectTo(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier webPageID, URL url, String userAgent, enum:uint8_t WebCore::StoredCredentialsPolicy storedCredentialsPolicy, enum:bool std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, enum:bool WebKit::LastNavigationWasAppInitiated lastNavigationWasAppInitiated);
  
@@ -9034,19 +8996,16 @@ index 8d34e713966c7e90ab435b1bfdd3e3d3b6c2083c..4ebdca94755a7b9404f7d7885708cc1d
 +    DeleteAllCookies(PAL::SessionID sessionID) -> (bool success) Async
 +    SetIgnoreCertificateErrors(PAL::SessionID sessionID, bool ignoreTLSErrors)
 +
-+    GetLocalStorageData(PAL::SessionID sessionID) -> (Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>> origins) Async
-+    SetLocalStorageData(PAL::SessionID sessionID, WebKit::StorageNamespaceIdentifier storageNamespaceID, Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>> origins) -> (String error) Async
-+
  #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)
      ClearPrevalentResource(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> () Async
      ClearUserInteraction(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> () Async
 diff --git a/Source/WebKit/NetworkProcess/NetworkSession.h b/Source/WebKit/NetworkProcess/NetworkSession.h
-index f8511ff158bc55f97adbe205d781ab2c66400ef0..cdd9a336faea14b6c818ae3fa040e56815d363a0 100644
+index c2de1dc53562c9026e88b1ec8e2c99c5fdd4dfed..0f7b2144b4b22aa89715decaafbb7fedef734ead 100644
 --- a/Source/WebKit/NetworkProcess/NetworkSession.h
 +++ b/Source/WebKit/NetworkProcess/NetworkSession.h
-@@ -175,6 +175,9 @@ public:
+@@ -191,6 +191,9 @@ public:
  
-     bool isStaleWhileRevalidateEnabled() const { return m_isStaleWhileRevalidateEnabled; }
+     void lowMemoryHandler(WTF::Critical);
  
 +    void setIgnoreCertificateErrors(bool ignore) { m_ignoreCertificateErrors = ignore; }
 +    bool ignoreCertificateErrors() { return m_ignoreCertificateErrors; }
@@ -9054,7 +9013,7 @@ index f8511ff158bc55f97adbe205d781ab2c66400ef0..cdd9a336faea14b6c818ae3fa040e568
  #if ENABLE(SERVICE_WORKER)
      void addSoftUpdateLoader(std::unique_ptr<ServiceWorkerSoftUpdateLoader>&& loader) { m_softUpdateLoaders.add(WTFMove(loader)); }
      void removeSoftUpdateLoader(ServiceWorkerSoftUpdateLoader* loader) { m_softUpdateLoaders.remove(loader); }
-@@ -235,6 +238,7 @@ protected:
+@@ -274,6 +277,7 @@ protected:
      bool m_privateClickMeasurementDebugModeEnabled { false };
      std::optional<WebCore::PrivateClickMeasurement> m_ephemeralMeasurement;
      bool m_isRunningEphemeralMeasurementTest { false };
@@ -9156,120 +9115,8 @@ index f57a72b6bdc3382469d69adb1b1201c7a9f07a84..c501211b094312ca44f0bf92de5d6ebc
      HashMap<String, String> items() const;
      void clear();
  
-diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
-index cb901b6c58b1859ae8be2ad9da9002d822b80612..1759668c2bd0fe375cbe12728a964317f66edb69 100644
---- a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
-+++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.cpp
-@@ -148,6 +148,19 @@ HashSet<SecurityOriginData> StorageManager::getLocalStorageOriginsCrossThreadCop
-     return origins;
- }
- 
-+Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>> StorageManager::getLocalStorageDataCrossThreadCopy() const
-+{
-+    ASSERT(!RunLoop::isMain());
-+
-+    Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>> result;
-+    for (const auto& localStorageNameSpace : m_localStorageNamespaces.values()) {
-+        localStorageNameSpace->forEachStorageArea([&] (const StorageArea& area) {
-+            result.append({ area.securityOrigin().isolatedCopy(), area.items() });
-+        });
-+    }
-+    return result;
-+}
-+
- Vector<LocalStorageDatabaseTracker::OriginDetails> StorageManager::getLocalStorageOriginDetailsCrossThreadCopy() const
- {
-     ASSERT(!RunLoop::isMain());
-diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
-index 47c84e483fa93672815651b3d2196a2b56cb02ab..bc5603f78e5a4d8499bd2795d2da6ed6c28d7210 100644
---- a/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
-+++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManager.h
-@@ -66,6 +66,7 @@ public:
-     void deleteSessionStorageEntriesForOrigins(const Vector<WebCore::SecurityOriginData>&);
- 
-     HashSet<WebCore::SecurityOriginData> getLocalStorageOriginsCrossThreadCopy() const;
-+    Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>> getLocalStorageDataCrossThreadCopy() const;
-     void deleteLocalStorageOriginsModifiedSince(WallTime);
-     void deleteLocalStorageEntriesForOrigins(const Vector<WebCore::SecurityOriginData>&);
-     Vector<LocalStorageDatabaseTracker::OriginDetails> getLocalStorageOriginDetailsCrossThreadCopy() const;
-diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
-index 3feedcd688f112417104518ab452259dd995ab12..05a530ccba65a5a6708e00e0e2c1826186474c61 100644
---- a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
-+++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.cpp
-@@ -245,6 +245,50 @@ void StorageManagerSet::getLocalStorageOrigins(PAL::SessionID sessionID, GetOrig
-     });
- }
- 
-+void StorageManagerSet::getLocalStorageData(PAL::SessionID sessionID, GetLocalStorageDataCallback&& completionHandler)
-+{
-+    ASSERT(RunLoop::isMain());
-+
-+    m_queue->dispatch([this, protectedThis = Ref { *this }, sessionID, completionHandler = WTFMove(completionHandler)]() mutable {
-+        auto* storageManager = m_storageManagers.get(sessionID);
-+        ASSERT(storageManager);
-+
-+        auto origins = storageManager->getLocalStorageDataCrossThreadCopy();
-+        RunLoop::main().dispatch([completionHandler = WTFMove(completionHandler), origins = WTFMove(origins)]() mutable {
-+            completionHandler(WTFMove(origins));
-+        });
-+    });
-+}
-+
-+void StorageManagerSet::setLocalStorageData(PAL::SessionID sessionID, WebKit::StorageNamespaceIdentifier storageNamespaceID, Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>>&& origins, CompletionHandler<void(String)>&& completionHandler)
-+{
-+    ASSERT(RunLoop::isMain());
-+
-+    m_queue->dispatch([this, protectedThis = Ref { *this }, sessionID, storageNamespaceID, origins = WTFMove(origins), completionHandler = WTFMove(completionHandler)]() mutable {
-+        auto* storageManager = m_storageManagers.get(sessionID);
-+        ASSERT(storageManager);
-+
-+        String error;
-+        for (const auto& originData : origins) {
-+            auto* storageArea = storageManager->createLocalStorageArea(storageNamespaceID, originData.first.isolatedCopy(), m_queue.copyRef());
-+            if (!storageArea) {
-+                error = "Cannot create storage area";
-+                break;
-+            }
-+            bool quotaException = false;
-+            storageArea->setItems(originData.second, quotaException);
-+            if (quotaException) {
-+                error = "Storage quota exceeded";
-+                break;
-+            }
-+        }
-+
-+        RunLoop::main().dispatch([completionHandler = WTFMove(completionHandler), error = WTFMove(error)]() mutable {
-+            completionHandler(error);
-+        });
-+    });
-+}
-+
- void StorageManagerSet::deleteLocalStorageModifiedSince(PAL::SessionID sessionID, WallTime time, DeleteCallback&& completionHandler)
- {
-     ASSERT(RunLoop::isMain());
-diff --git a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
-index d602a5f90999fc7f440e2468d40332625ed37083..577b76728f762e7f5aa509531a65eaabba205da6 100644
---- a/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
-+++ b/Source/WebKit/NetworkProcess/WebStorage/StorageManagerSet.h
-@@ -46,6 +46,7 @@ using ConnectToStorageAreaCallback = CompletionHandler<void(const std::optional<
- using GetValuesCallback = CompletionHandler<void(const HashMap<String, String>&)>;
- using GetOriginsCallback = CompletionHandler<void(HashSet<WebCore::SecurityOriginData>&&)>;
- using GetOriginDetailsCallback = CompletionHandler<void(Vector<LocalStorageDatabaseTracker::OriginDetails>&&)>;
-+using GetLocalStorageDataCallback = CompletionHandler<void(Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>>&&)>;
- using DeleteCallback = CompletionHandler<void()>;
- 
- class StorageManagerSet : public IPC::Connection::WorkQueueMessageReceiver {
-@@ -73,6 +74,8 @@ public:
-     void deleteLocalStorageModifiedSince(PAL::SessionID, WallTime, DeleteCallback&&);
-     void deleteLocalStorageForOrigins(PAL::SessionID, const Vector<WebCore::SecurityOriginData>&, DeleteCallback&&);
-     void getLocalStorageOriginDetails(PAL::SessionID, GetOriginDetailsCallback&&);
-+    void getLocalStorageData(PAL::SessionID, GetLocalStorageDataCallback&&);
-+    void setLocalStorageData(PAL::SessionID sessionID, WebKit::StorageNamespaceIdentifier storageNamespaceID, Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>>&& origins, CompletionHandler<void(String)>&&);
-     void renameOrigin(PAL::SessionID, const URL&, const URL&, CompletionHandler<void()>&&);
- 
-     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-index eae005b37aa2e6130dd0dd4b5780f171735268c4..37464a459932a4cd01d89bf749ae9742f51eb548 100644
+index 6a53b5d70a0544b8b02b349aff1b4bc60eade208..aeb2f1fbec86cbc95888db2b107b6d3d24595767 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 @@ -735,7 +735,7 @@ void NetworkSessionCocoa::setClientAuditToken(const WebCore::AuthenticationChall
@@ -9296,7 +9143,7 @@ index eae005b37aa2e6130dd0dd4b5780f171735268c4..37464a459932a4cd01d89bf749ae9742
  #if !LOG_DISABLED
              LOG(NetworkSession, "%llu didReceiveResponse completionHandler (%d)", taskIdentifier, policyAction);
 diff --git a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
-index 677c61da1a1894c1f59656d92709eb71d591a553..87831278a49f08a141c3899f369907b4637e0706 100644
+index 84669e209d77bf52a36afe2a7dab252a6900dcf7..1a0e7803464ea64e7ed2fe78e2c587a0b35bc899 100644
 --- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
 +++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
 @@ -26,9 +26,13 @@
@@ -9323,7 +9170,7 @@ index 677c61da1a1894c1f59656d92709eb71d591a553..87831278a49f08a141c3899f369907b4
  
 @@ -77,6 +82,8 @@ NetworkDataTaskCurl::NetworkDataTaskCurl(NetworkSession& session, NetworkDataTas
          m_curlRequest->setUserPass(m_initialCredential.user(), m_initialCredential.password());
-         m_curlRequest->setAuthenticationScheme(ProtectionSpaceAuthenticationSchemeHTTPBasic);
+         m_curlRequest->setAuthenticationScheme(ProtectionSpace::AuthenticationScheme::HTTPBasic);
      }
 +    if (m_session->ignoreCertificateErrors())
 +        m_curlRequest->disableServerTrustEvaluation();
@@ -9348,7 +9195,7 @@ index 677c61da1a1894c1f59656d92709eb71d591a553..87831278a49f08a141c3899f369907b4
  
      handleCookieHeaders(request.resourceRequest(), receivedResponse);
  
-@@ -177,7 +188,10 @@ void NetworkDataTaskCurl::curlDidReceiveBuffer(CurlRequest&, Ref<SharedBuffer>&&
+@@ -177,7 +188,10 @@ void NetworkDataTaskCurl::curlDidReceiveBuffer(CurlRequest&, Ref<FragmentedShare
      Ref protectedThis { *this };
      if (state() == State::Canceling || state() == State::Completed || (!m_client && !isDownload()))
          return;
@@ -9424,7 +9271,7 @@ index 677c61da1a1894c1f59656d92709eb71d591a553..87831278a49f08a141c3899f369907b4
              break;
 @@ -315,6 +367,8 @@ void NetworkDataTaskCurl::willPerformHTTPRedirection()
              m_curlRequest->setUserPass(m_initialCredential.user(), m_initialCredential.password());
-             m_curlRequest->setAuthenticationScheme(ProtectionSpaceAuthenticationSchemeHTTPBasic);
+             m_curlRequest->setAuthenticationScheme(ProtectionSpace::AuthenticationScheme::HTTPBasic);
          }
 +        if (m_session->ignoreCertificateErrors())
 +            m_curlRequest->disableServerTrustEvaluation();
@@ -9432,7 +9279,7 @@ index 677c61da1a1894c1f59656d92709eb71d591a553..87831278a49f08a141c3899f369907b4
  
          if (m_state != State::Suspended) {
 diff --git a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
-index 1c427ddb78d6953fe8960c5692afde4f4f0eee85..cf33ff6076dd95ffe564f1dde89c177acd27b02c 100644
+index 45be5ce184325271d5c080dd34f1ee4a16642a1f..4e2f05c6f882d60e21b05616249d0435274da408 100644
 --- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
 +++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
 @@ -32,6 +32,7 @@
@@ -9469,7 +9316,7 @@ index 1c427ddb78d6953fe8960c5692afde4f4f0eee85..cf33ff6076dd95ffe564f1dde89c177a
  
      WebCore::ShouldRelaxThirdPartyCookieBlocking m_shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
 diff --git a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
-index e67e05ba8478a581830e397068b32fb08d91b7ed..898f4f228753ef2cee226a9f486556b84fd7bf62 100644
+index 60a49c6d404c52563d87fc2cd1cb22444671d1cd..6184a79c62057390aa6fa7473a4117e8428bc597 100644
 --- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 +++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 @@ -493,6 +493,8 @@ void NetworkDataTaskSoup::didSendRequest(GRefPtr<GInputStream>&& inputStream)
@@ -9525,7 +9372,7 @@ index e67e05ba8478a581830e397068b32fb08d91b7ed..898f4f228753ef2cee226a9f486556b8
      }
  
 diff --git a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
-index 9873026a091fdf2974be1a1e734e6f5b30a7d7c5..17f2905841f190ab2e18862c5df477c4994bde5f 100644
+index 2bc74b941b23e0df0a6efc84257ac1bb880bc3ef..a0579fabb264c378238c6bd92a61c991d198cd08 100644
 --- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
 +++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
 @@ -109,6 +109,11 @@ static gboolean webSocketAcceptCertificateCallback(GTlsConnection* connection, G
@@ -9661,10 +9508,10 @@ index 529644655e0120d862ee8e886e67ac9f12692037..dc3cf7b3bafe259d44b04a16b6903b3b
      Cairo::Cairo
      Freetype::Freetype
 diff --git a/Source/WebKit/PlatformWin.cmake b/Source/WebKit/PlatformWin.cmake
-index 350fdd497eaaab711059c54b5075015b19379368..bf5cd7221e1a131dd880d11e968b132782359937 100644
+index 3676c3514564eb1f1bcd697e37aadcd0424ae704..baf72a6eda3b574c588cf299a56cac9334e29743 100644
 --- a/Source/WebKit/PlatformWin.cmake
 +++ b/Source/WebKit/PlatformWin.cmake
-@@ -75,8 +75,12 @@ list(APPEND WebKit_SOURCES
+@@ -76,8 +76,12 @@ list(APPEND WebKit_SOURCES
  
      UIProcess/wc/DrawingAreaProxyWC.cpp
  
@@ -9677,7 +9524,7 @@ index 350fdd497eaaab711059c54b5075015b19379368..bf5cd7221e1a131dd880d11e968b1327
      UIProcess/win/WebPageProxyWin.cpp
      UIProcess/win/WebPopupMenuProxyWin.cpp
      UIProcess/win/WebProcessPoolWin.cpp
-@@ -94,6 +98,7 @@ list(APPEND WebKit_SOURCES
+@@ -95,6 +99,7 @@ list(APPEND WebKit_SOURCES
      WebProcess/MediaCache/WebMediaKeyStorageManager.cpp
  
      WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
@@ -9685,7 +9532,7 @@ index 350fdd497eaaab711059c54b5075015b19379368..bf5cd7221e1a131dd880d11e968b1327
  
      WebProcess/WebPage/AcceleratedSurface.cpp
  
-@@ -149,6 +154,72 @@ list(APPEND WebKit_MESSAGES_IN_FILES
+@@ -151,6 +156,72 @@ list(APPEND WebKit_MESSAGES_IN_FILES
      WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy
  )
  
@@ -9758,7 +9605,7 @@ index 350fdd497eaaab711059c54b5075015b19379368..bf5cd7221e1a131dd880d11e968b1327
  set(WebKitCommonIncludeDirectories ${WebKit_INCLUDE_DIRECTORIES})
  set(WebKitCommonSystemIncludeDirectories ${WebKit_SYSTEM_INCLUDE_DIRECTORIES})
  
-@@ -201,6 +272,7 @@ if (${WTF_PLATFORM_WIN_CAIRO})
+@@ -203,6 +274,7 @@ if (${WTF_PLATFORM_WIN_CAIRO})
          OpenSSL::SSL
          mfuuid.lib
          strmiids.lib
@@ -9767,15 +9614,15 @@ index 350fdd497eaaab711059c54b5075015b19379368..bf5cd7221e1a131dd880d11e968b1327
  endif ()
  
 diff --git a/Source/WebKit/Scripts/generate-unified-sources.sh b/Source/WebKit/Scripts/generate-unified-sources.sh
-index b6d40ad9e9547bd40de85c9c85a35c1e25cdf191..4f1ac83cb3a226eccd07839837923cbc44bab923 100755
+index 2a3d6b5eeb241401c80ea3bed82382d035652364..5bed122a3e6a8a33419f211f5804c1062fb51a2c 100755
 --- a/Source/WebKit/Scripts/generate-unified-sources.sh
 +++ b/Source/WebKit/Scripts/generate-unified-sources.sh
 @@ -14,7 +14,7 @@ if [ -z "${BUILD_SCRIPTS_DIR}" ]; then
      fi
  fi
  
--UnifiedSourceCppFileCount=111
-+UnifiedSourceCppFileCount=112
+-UnifiedSourceCppFileCount=115
++UnifiedSourceCppFileCount=116
  UnifiedSourceMmFileCount=80
  
  if [ $# -eq 0 ]; then
@@ -9870,7 +9717,7 @@ index f2f3979fcac9dfd97d0e0ead600fe35eb8defd40..ac91412e1a96bdf521b1890a66e465dc
      NSEvent* nativeEvent() const { return m_nativeEvent.get(); }
  #elif PLATFORM(GTK)
 diff --git a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
-index 64982bc48102a4adb20a7e60e21bd492d653374c..bae76818c6260b9bf93fc2e4a601b5b6581a2716 100644
+index c898687b226cce4b4f3b8b1a85cbec7958b67ab6..821916c717bd1d19fe1d3ed6494932f56a558c76 100644
 --- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 +++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 @@ -119,6 +119,10 @@
@@ -10128,7 +9975,7 @@ index ebd51f5461fd35aa408fcde6927a16186374f6a9..fc2274d0f5b03f5ff3eb5b20060b24c4
      GtkSettingsState gtkSettings;
  #endif
 diff --git a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
-index 2d1c6dc88b16b7be6b9b14e8806d758ca176a7a8..c226107217233063822cb4d0c356f6333edabd2a 100644
+index be054e9c7e807a67a33d28406238fe8e5692eec3..9a958c55d9cb87efb4c1f4880740fedda9d9c9ae 100644
 --- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
 +++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
 @@ -162,7 +162,9 @@ bool defaultOfflineWebApplicationCacheEnabled()
@@ -10455,10 +10302,10 @@ index 85d6f74114f4e7f82d9502d1b99d69098d6a49b6..6896c9756edb233dda46c7031e1af699
      return WebTouchEvent();
  }
 diff --git a/Source/WebKit/Sources.txt b/Source/WebKit/Sources.txt
-index 05a85b0196042016ab685f20d4bef73c46265607..605962d551e56959656ffe39b031cd8731e61ac7 100644
+index 67963789fa347bf8ad564f95d3af1c9b9a7fc397..833ede887c6bf0ad0b2ab8156eec47a4996cab6f 100644
 --- a/Source/WebKit/Sources.txt
 +++ b/Source/WebKit/Sources.txt
-@@ -388,11 +388,14 @@ Shared/XR/XRDeviceProxy.cpp
+@@ -391,11 +391,14 @@ Shared/XR/XRDeviceProxy.cpp
  
  UIProcess/AuxiliaryProcessProxy.cpp
  UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -10473,7 +10320,7 @@ index 05a85b0196042016ab685f20d4bef73c46265607..605962d551e56959656ffe39b031cd87
  UIProcess/LegacyGlobalSettings.cpp
  UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
  UIProcess/MediaKeySystemPermissionRequestProxy.cpp
-@@ -401,6 +404,7 @@ UIProcess/PageLoadState.cpp
+@@ -404,6 +407,7 @@ UIProcess/PageLoadState.cpp
  UIProcess/ProcessAssertion.cpp
  UIProcess/ProcessThrottler.cpp
  UIProcess/ProvisionalPageProxy.cpp
@@ -10481,7 +10328,7 @@ index 05a85b0196042016ab685f20d4bef73c46265607..605962d551e56959656ffe39b031cd87
  UIProcess/ResponsivenessTimer.cpp
  UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
  UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
-@@ -442,6 +446,8 @@ UIProcess/WebOpenPanelResultListenerProxy.cpp
+@@ -445,6 +449,8 @@ UIProcess/WebOpenPanelResultListenerProxy.cpp
  UIProcess/WebPageDiagnosticLoggingClient.cpp
  UIProcess/WebPageGroup.cpp
  UIProcess/WebPageInjectedBundleClient.cpp
@@ -10490,7 +10337,7 @@ index 05a85b0196042016ab685f20d4bef73c46265607..605962d551e56959656ffe39b031cd87
  UIProcess/WebPageProxy.cpp
  UIProcess/WebPasteboardProxy.cpp
  UIProcess/WebPreferences.cpp
-@@ -563,7 +569,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
+@@ -566,7 +572,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
  UIProcess/Inspector/WebPageDebuggable.cpp
  UIProcess/Inspector/WebPageInspectorController.cpp
  
@@ -10503,7 +10350,7 @@ index 05a85b0196042016ab685f20d4bef73c46265607..605962d551e56959656ffe39b031cd87
  UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
  UIProcess/Media/MediaUsageManager.cpp
 diff --git a/Source/WebKit/SourcesCocoa.txt b/Source/WebKit/SourcesCocoa.txt
-index c8be55869276e50620bd335c00e666df2c454a94..cd3ba1872ae0406bd183de4b53854794de17a093 100644
+index 11f0c2405ac9474be8f8e805feebc8f1bb696002..8c9b418e4c26456fe968d0dd9ce02d5b67a97301 100644
 --- a/Source/WebKit/SourcesCocoa.txt
 +++ b/Source/WebKit/SourcesCocoa.txt
 @@ -270,6 +270,7 @@ UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -10514,7 +10361,7 @@ index c8be55869276e50620bd335c00e666df2c454a94..cd3ba1872ae0406bd183de4b53854794
  UIProcess/API/Cocoa/_WKContentRuleListAction.mm
  UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
  UIProcess/API/Cocoa/_WKCustomHeaderFields.mm @no-unify
-@@ -442,6 +443,7 @@ UIProcess/Inspector/ios/WKInspectorHighlightView.mm
+@@ -444,6 +445,7 @@ UIProcess/Inspector/ios/WKInspectorHighlightView.mm
  UIProcess/Inspector/ios/WKInspectorNodeSearchGestureRecognizer.mm
  
  UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -10665,10 +10512,10 @@ index cc642c51ba663e843df54d14cfccb6d4ef81726c..229ae1a7df1e418f9b09bf9c3c3bb1ed
      bool m_shouldTakeUIBackgroundAssertion { true };
      bool m_shouldCaptureDisplayInUIProcess { DEFAULT_CAPTURE_DISPLAY_IN_UI_PROCESS };
 diff --git a/Source/WebKit/UIProcess/API/APIUIClient.h b/Source/WebKit/UIProcess/API/APIUIClient.h
-index 2016cb48dd38e195271578c86103f4cbcc651429..469878cbbcafe4c6033068ce385fc9f8fbe14d58 100644
+index 9685054929cfdc35e98a15f054f7839e1df4ae08..6b79a387dacef4ef2a3e015fe078c19a80a664e4 100644
 --- a/Source/WebKit/UIProcess/API/APIUIClient.h
 +++ b/Source/WebKit/UIProcess/API/APIUIClient.h
-@@ -103,6 +103,7 @@ public:
+@@ -104,6 +104,7 @@ public:
      virtual void runJavaScriptAlert(WebKit::WebPageProxy&, const WTF::String&, WebKit::WebFrameProxy*, WebKit::FrameInfoData&&, Function<void()>&& completionHandler) { completionHandler(); }
      virtual void runJavaScriptConfirm(WebKit::WebPageProxy&, const WTF::String&, WebKit::WebFrameProxy*, WebKit::FrameInfoData&&, Function<void(bool)>&& completionHandler) { completionHandler(false); }
      virtual void runJavaScriptPrompt(WebKit::WebPageProxy&, const WTF::String&, const WTF::String&, WebKit::WebFrameProxy*, WebKit::FrameInfoData&&, Function<void(const WTF::String&)>&& completionHandler) { completionHandler(WTF::String()); }
@@ -10720,7 +10567,7 @@ index 026121d114c5fcad84c1396be8d692625beaa3bd..edd6e5cae033124c589959a42522fde0
  }
  #endif
 diff --git a/Source/WebKit/UIProcess/API/C/WKPage.cpp b/Source/WebKit/UIProcess/API/C/WKPage.cpp
-index 92ffd2147089216b00fe371cdbc3adf787defce7..c588d60634701ad4c1cec974cfb680806ea7e096 100644
+index 5b2b2b148c2a3d8bbe9c36be478c74c36ff4db7b..f9c9b8116f2eb0459ad6a3e65ce7e0e6e97535a8 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
 +++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
 @@ -1775,6 +1775,13 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
@@ -10747,7 +10594,7 @@ index 92ffd2147089216b00fe371cdbc3adf787defce7..c588d60634701ad4c1cec974cfb68080
          }
  
 diff --git a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
-index ed980be17cdf9faec3f7af1bdc7cfd640bab8fc2..ca3c0ff1ec6d30173ae15e786f30ef1bad0e5bb6 100644
+index 66fa7f948bdc35669fa7db5a01535333befa55ec..c7c4910916dc72f6c0efa7aac6678e9f867686a5 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
 +++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
 @@ -90,6 +90,7 @@ typedef void (*WKPageRunBeforeUnloadConfirmPanelCallback)(WKPageRef page, WKStri
@@ -10758,7 +10605,7 @@ index ed980be17cdf9faec3f7af1bdc7cfd640bab8fc2..ca3c0ff1ec6d30173ae15e786f30ef1b
  typedef void (*WKPageRequestStorageAccessConfirmCallback)(WKPageRef page, WKFrameRef frame, WKStringRef requestingDomain, WKStringRef currentDomain, WKPageRequestStorageAccessConfirmResultListenerRef listener, const void *clientInfo);
  typedef void (*WKPageTakeFocusCallback)(WKPageRef page, WKFocusDirection direction, const void *clientInfo);
  typedef void (*WKPageFocusCallback)(WKPageRef page, const void *clientInfo);
-@@ -1354,6 +1355,7 @@ typedef struct WKPageUIClientV14 {
+@@ -1355,6 +1356,7 @@ typedef struct WKPageUIClientV14 {
  
      // Version 14.
      WKPageRunWebAuthenticationPanelCallback                             runWebAuthenticationPanel;
@@ -10766,7 +10613,7 @@ index ed980be17cdf9faec3f7af1bdc7cfd640bab8fc2..ca3c0ff1ec6d30173ae15e786f30ef1b
  } WKPageUIClientV14;
  
  typedef struct WKPageUIClientV15 {
-@@ -1461,6 +1463,7 @@ typedef struct WKPageUIClientV15 {
+@@ -1462,6 +1464,7 @@ typedef struct WKPageUIClientV15 {
  
      // Version 14.
      WKPageRunWebAuthenticationPanelCallback                             runWebAuthenticationPanel;
@@ -10774,7 +10621,15 @@ index ed980be17cdf9faec3f7af1bdc7cfd640bab8fc2..ca3c0ff1ec6d30173ae15e786f30ef1b
  
      // Version 15.
      WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
-@@ -1572,6 +1575,7 @@ typedef struct WKPageUIClientV16 {
+@@ -1573,6 +1576,7 @@ typedef struct WKPageUIClientV16 {
+ 
+     // Version 14.
+     WKPageRunWebAuthenticationPanelCallback                             runWebAuthenticationPanel;
++    WKPageHandleJavaScriptDialogCallback                                handleJavaScriptDialog;
+ 
+     // Version 15.
+     WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
+@@ -1687,6 +1691,7 @@ typedef struct WKPageUIClientV17 {
  
      // Version 14.
      WKPageRunWebAuthenticationPanelCallback                             runWebAuthenticationPanel;
@@ -10821,10 +10676,10 @@ index afa925f36c29db9c23921298dead9cce737500d6..42d396342acdb6d39830f611df0ee40e
  
  NS_ASSUME_NONNULL_END
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
-index 7ef06950ab07d3e1a7616cbcb58bd25785359ec7..fa1320d8842b593c3ff2907a9daf2cc25ec1ef39 100644
+index f656d261655b73eba04b50aaa9892faae5f31859..8496ea19296ee4e1fee9a064231adac40ba3fce9 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
-@@ -44,6 +44,7 @@
+@@ -45,6 +45,7 @@
  #import "_WKResourceLoadStatisticsThirdPartyInternal.h"
  #import "_WKWebsiteDataStoreConfigurationInternal.h"
  #import "_WKWebsiteDataStoreDelegate.h"
@@ -10832,7 +10687,7 @@ index 7ef06950ab07d3e1a7616cbcb58bd25785359ec7..fa1320d8842b593c3ff2907a9daf2cc2
  #import <WebCore/Credential.h>
  #import <WebCore/RegistrationDatabase.h>
  #import <WebCore/VersionChecks.h>
-@@ -205,6 +206,11 @@ static WallTime toSystemClockTime(NSDate *date)
+@@ -206,6 +207,11 @@ static WallTime toSystemClockTime(NSDate *date)
      });
  }
  
@@ -11536,7 +11391,7 @@ index fbab1afe9ca09f5e6a6793f5065f08fc76bfedaf..23f66f4da6229d88271e4b732414088b
  bool webkitWebViewIsScriptDialogRunning(WebKitWebView*, WebKitScriptDialog*);
  String webkitWebViewGetCurrentScriptDialogMessage(WebKitWebView*);
 diff --git a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
-index 9204440b028fd175af6f0feb1c780ea7cb938dd8..8d6b56f2f7a92b12a7e7b13ba6bdbc6de0df31c2 100644
+index 1a91c7d787f7d3b88a2f0fcbd48eb72fe6bf532c..c59e4875ba4eb3883269985998c076db2505f078 100644
 --- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
 +++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
 @@ -250,6 +250,8 @@ void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool
@@ -11682,7 +11537,7 @@ index 5cd9524252a97d4ea64dfeb22e5a47b55f36c887..45da62b4ffe54d5cfd680dd40cabd6f4
  #include <webkit2/WebKitContextMenu.h>
  #include <webkit2/WebKitContextMenuActions.h>
 diff --git a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
-index 6c3e1c955042055b3016e04e4bc9c400c5a5c905..4371a9da51f6b55be180c86c9e9518894fd8728f 100644
+index 806993ca73a9cce37753d805a9ab9f4cb6bd1a7b..349a21bbc00c419da7c7e65671c2a6b424b9bcdb 100644
 --- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
 +++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
 @@ -32,8 +32,11 @@
@@ -11731,10 +11586,10 @@ index 6c3e1c955042055b3016e04e4bc9c400c5a5c905..4371a9da51f6b55be180c86c9e951889
 +
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
-index ca30000e1a06b85886716c8d991ef485963fd635..e178dc92338312823553719495ea7b67f4b853d7 100644
+index 7c08a13e10c75677452b74f52be2b447a5edaa13..56cf11581d453e8234f0957828083ee7c9bce8a6 100644
 --- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
 +++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
-@@ -166,6 +166,17 @@ private:
+@@ -167,6 +167,17 @@ private:
  
      void selectionDidChange() override;
  
@@ -12296,7 +12151,7 @@ index 8a95a3f8036bb0c664954c23ba3ecf72058ae711..dd10e28e2499cd84be2d072dc7567050
  namespace WebKit {
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
-index fdaaa1eb7130fd68da1fa8740343426b451cd288..74ce6bcd445822d69286a96f4d62aeadbf891805 100644
+index 9a033db5e7184f23054f8c2dacd4be0630a79ba6..69e036901b7bd20b27a19d03d5e112a0f83d321e 100644
 --- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
 +++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
 @@ -95,6 +95,7 @@ private:
@@ -12307,7 +12162,7 @@ index fdaaa1eb7130fd68da1fa8740343426b451cd288..74ce6bcd445822d69286a96f4d62aead
          void presentStorageAccessConfirmDialog(const WTF::String& requestingDomain, const WTF::String& currentDomain, CompletionHandler<void(bool)>&&);
          void requestStorageAccessConfirm(WebPageProxy&, WebFrameProxy*, const WebCore::RegistrableDomain& requestingDomain, const WebCore::RegistrableDomain& currentDomain, CompletionHandler<void(bool)>&&) final;
          void decidePolicyForGeolocationPermissionRequest(WebPageProxy&, WebFrameProxy&, const FrameInfoData&, Function<void(bool)>&) final;
-@@ -190,6 +191,7 @@ private:
+@@ -192,6 +193,7 @@ private:
          bool webViewRunJavaScriptAlertPanelWithMessageInitiatedByFrameCompletionHandler : 1;
          bool webViewRunJavaScriptConfirmPanelWithMessageInitiatedByFrameCompletionHandler : 1;
          bool webViewRunJavaScriptTextInputPanelWithPromptDefaultTextInitiatedByFrameCompletionHandler : 1;
@@ -12316,10 +12171,10 @@ index fdaaa1eb7130fd68da1fa8740343426b451cd288..74ce6bcd445822d69286a96f4d62aead
          bool webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler : 1;
          bool webViewRequestGeolocationPermissionForFrameDecisionHandler : 1;
 diff --git a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
-index 6d59a8f6416a225a3981099fbf1e6cf6a93732be..c0a9dbe0c7afa3a526194ff6022bf4d000e6fc28 100644
+index ddfc67d695731931eca4eb39926fb5b6e874a5a6..bf4d9f9b5caa1c93ae7d7ce650b3f9c90af7e57e 100644
 --- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
-@@ -109,6 +109,7 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
+@@ -110,6 +110,7 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
      m_delegateMethods.webViewRunJavaScriptAlertPanelWithMessageInitiatedByFrameCompletionHandler = [delegate respondsToSelector:@selector(webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:)];
      m_delegateMethods.webViewRunJavaScriptConfirmPanelWithMessageInitiatedByFrameCompletionHandler = [delegate respondsToSelector:@selector(webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:)];
      m_delegateMethods.webViewRunJavaScriptTextInputPanelWithPromptDefaultTextInitiatedByFrameCompletionHandler = [delegate respondsToSelector:@selector(webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:)];
@@ -12327,7 +12182,7 @@ index 6d59a8f6416a225a3981099fbf1e6cf6a93732be..c0a9dbe0c7afa3a526194ff6022bf4d0
      m_delegateMethods.webViewRequestStorageAccessPanelUnderFirstPartyCompletionHandler = [delegate respondsToSelector:@selector(_webView:requestStorageAccessPanelForDomain:underCurrentDomain:completionHandler:)];
      m_delegateMethods.webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler = [delegate respondsToSelector:@selector(_webView:runBeforeUnloadConfirmPanelWithMessage:initiatedByFrame:completionHandler:)];
      m_delegateMethods.webViewRequestGeolocationPermissionForOriginDecisionHandler = [delegate respondsToSelector:@selector(_webView:requestGeolocationPermissionForOrigin:initiatedByFrame:decisionHandler:)];
-@@ -381,6 +382,15 @@ void UIDelegate::UIClient::runJavaScriptPrompt(WebPageProxy& page, const WTF::St
+@@ -384,6 +385,15 @@ void UIDelegate::UIClient::runJavaScriptPrompt(WebPageProxy& page, const WTF::St
      }).get()];
  }
  
@@ -12344,18 +12199,18 @@ index 6d59a8f6416a225a3981099fbf1e6cf6a93732be..c0a9dbe0c7afa3a526194ff6022bf4d0
  {
      if (!m_uiDelegate)
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
-index 6a50a08103395865839ffa780e835b758335fabe..f2dd42fde3a21cc83f176613c671debe1f877e7a 100644
+index 29f91774596cf004cd0d57b5ea386b5cb233b30a..fd1b24fb32fddd65ccb5358a6add81ca865ffb7c 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
-@@ -36,6 +36,7 @@
- #import "InsertTextOptions.h"
+@@ -37,6 +37,7 @@
  #import "LoadParameters.h"
+ #import "ModalContainerControlClassifier.h"
  #import "PageClient.h"
 +#import "PasteboardTypes.h"
  #import "QuarantineSPI.h"
  #import "QuickLookThumbnailLoader.h"
  #import "SafeBrowsingSPI.h"
-@@ -236,9 +237,66 @@ bool WebPageProxy::scrollingUpdatesDisabledForTesting()
+@@ -237,9 +238,66 @@ bool WebPageProxy::scrollingUpdatesDisabledForTesting()
  
  void WebPageProxy::startDrag(const DragItem& dragItem, const ShareableBitmap::Handle& dragImageHandle)
  {
@@ -12423,10 +12278,10 @@ index 6a50a08103395865839ffa780e835b758335fabe..f2dd42fde3a21cc83f176613c671debe
  #if PLATFORM(IOS_FAMILY)
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-index 159c7222e270a2f589158e1aab8c2aaa146ba292..0649e6611d6f1b3e1ec949d0fe974b0dfc8501bb 100644
+index 4925e35329e814fc89ce4a83bfa576ae9898c4c5..3f46b6a9666aa0617aef227d77442c3655baa0b3 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-@@ -411,7 +411,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
+@@ -397,7 +397,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
      auto screenProperties = WebCore::collectScreenProperties();
      parameters.screenProperties = WTFMove(screenProperties);
  #if PLATFORM(MAC)
@@ -12435,7 +12290,7 @@ index 159c7222e270a2f589158e1aab8c2aaa146ba292..0649e6611d6f1b3e1ec949d0fe974b0d
  #endif
      
  #if PLATFORM(IOS)
-@@ -716,8 +716,8 @@ void WebProcessPool::registerNotificationObservers()
+@@ -697,8 +697,8 @@ void WebProcessPool::registerNotificationObservers()
      }];
  
      m_scrollerStyleNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSPreferredScrollerStyleDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
@@ -12447,10 +12302,10 @@ index 159c7222e270a2f589158e1aab8c2aaa146ba292..0649e6611d6f1b3e1ec949d0fe974b0d
  
      m_activationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidBecomeActiveNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
-index 3f6dd1f242e7a115ecf798390f34b635c6e8d6f9..9eb27efc6b344b4937a3aa693d0a62c8ab143bee 100644
+index e851cab82c7429f5b946e9aba7d2d88005965620..ce66175b9cdf1e866454834cfe4eaf3f87840989 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
-@@ -511,6 +511,9 @@ public:
+@@ -503,6 +503,9 @@ public:
      void provideDataForPasteboard(NSPasteboard *, NSString *type);
      NSArray *namesOfPromisedFilesDroppedAtDestination(NSURL *dropDestination);
  
@@ -12461,10 +12316,10 @@ index 3f6dd1f242e7a115ecf798390f34b635c6e8d6f9..9eb27efc6b344b4937a3aa693d0a62c8
      void saveBackForwardSnapshotForCurrentItem();
      void saveBackForwardSnapshotForItem(WebBackForwardListItem&);
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
-index 3d9e877b0cb75654b6391639557f52b60392cac9..7cb2c03f05520eca9ba9d98351b5918db925a73b 100644
+index 29026329364d84c3ddc1982f3a4093d100244308..fe310f0d9b89dd0f2333cff11cec603c95a936d6 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
-@@ -2623,6 +2623,11 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
+@@ -2653,6 +2653,11 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
          if (!m_colorSpace)
              m_colorSpace = [NSColorSpace sRGBColorSpace];
      }
@@ -12476,7 +12331,7 @@ index 3d9e877b0cb75654b6391639557f52b60392cac9..7cb2c03f05520eca9ba9d98351b5918d
  
      ASSERT(m_colorSpace);
      return WebCore::DestinationColorSpace { [m_colorSpace CGColorSpace] };
-@@ -4633,6 +4638,18 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
+@@ -4645,6 +4650,18 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
      return adoptCF(CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
  }
  
@@ -12652,7 +12507,7 @@ index b23a45ff7d313317d8ba64fb430ebba3b6adef71..8419b69c5e278cf88a3ab6b98c335edd
  
  } // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
-index eb0cfc3757cee17105bc4373a0877d86c89859d3..21fda5454cf8218ffedac88aa1a7b4627d9d5fa0 100644
+index e990b1d0c445ca7b3424a53d37a88e4b65be96db..ecb9528bcfbbaa6f14c3e8fc035887a5ee746091 100644
 --- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
 +++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
 @@ -42,8 +42,10 @@
@@ -14883,10 +14738,10 @@ index 0000000000000000000000000000000000000000..d0e11ed81a6257c011df23d5870da740
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..a07142981fbfb5d304fc8a485fb5cb4177509412
+index 0000000000000000000000000000000000000000..653b372feb40867fd68f3934f38072d071b4d371
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
-@@ -0,0 +1,1010 @@
+@@ -0,0 +1,905 @@
 +/*
 + * Copyright (C) 2019 Microsoft Corporation.
 + *
@@ -15450,111 +15305,6 @@ index 0000000000000000000000000000000000000000..a07142981fbfb5d304fc8a485fb5cb41
 +    m_client->deleteBrowserContext(errorString, sessionID);
 +}
 +
-+void InspectorPlaywrightAgent::getLocalStorageData(const String& browserContextID, Ref<GetLocalStorageDataCallback>&& callback)
-+{
-+    String errorString;
-+    BrowserContext* browserContext = lookupBrowserContext(errorString, browserContextID);
-+    if (!lookupBrowserContext(errorString, browserContextID)) {
-+        callback->sendFailure(errorString);
-+        return;
-+    }
-+    PAL::SessionID sessionID = browserContext->dataStore->sessionID();
-+    NetworkProcessProxy& networkProcess = browserContext->dataStore->networkProcess();
-+    networkProcess.sendWithAsyncReply(Messages::NetworkProcess::GetLocalStorageData(sessionID),
-+        [callback = WTFMove(callback)](Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>>&& data) {
-+            if (!callback->isActive())
-+                return;
-+            auto origins = JSON::ArrayOf<Inspector::Protocol::Playwright::OriginStorage>::create();
-+            for (const auto& originData : data) {
-+                auto items = JSON::ArrayOf<Inspector::Protocol::Playwright::NameValue>::create();
-+                for (const auto& entry : originData.second) {
-+                    items->addItem(Inspector::Protocol::Playwright::NameValue::create()
-+                        .setName(entry.key)
-+                        .setValue(entry.value)
-+                        .release());
-+                }
-+                origins->addItem(Inspector::Protocol::Playwright::OriginStorage::create()
-+                    .setOrigin(originData.first.toString())
-+                    .setItems(WTFMove(items))
-+                    .release());
-+            }
-+            callback->sendSuccess(WTFMove(origins));
-+        }, 0);
-+}
-+
-+void InspectorPlaywrightAgent::setLocalStorageData(const String& browserContextID, Ref<JSON::Array>&& origins, Ref<SetLocalStorageDataCallback>&& callback)
-+{
-+    String errorString;
-+    BrowserContext* browserContext = lookupBrowserContext(errorString, browserContextID);
-+    if (!lookupBrowserContext(errorString, browserContextID)) {
-+        callback->sendFailure(errorString);
-+        return;
-+    }
-+
-+    PAL::SessionID sessionID = browserContext->dataStore->sessionID();
-+    NetworkProcessProxy& networkProcess = browserContext->dataStore->networkProcess();
-+    if (!networkProcess.hasConnection()) {
-+       callback->sendFailure("No connection to the nework process");
-+       return;
-+    }
-+
-+    WebKit::PageGroupIdentifier pageGroupID = browserContext->processPool->defaultPageGroup().pageGroupID();
-+    auto storageNamespaceID = makeObjectIdentifier<StorageNamespaceIdentifierType>(pageGroupID.toUInt64());
-+
-+    Vector<std::pair<WebCore::SecurityOriginData, HashMap<String, String>>> data;
-+    for (const auto& value : origins.get()) {
-+        auto obj = value->asObject();
-+        if (!obj) {
-+            callback->sendFailure("Invalid OriginStorage format"_s);
-+            return;
-+        }
-+
-+        String origin = obj->getString("origin");
-+        if (origin.isEmpty()) {
-+            callback->sendFailure("Empty origin"_s);
-+            return;
-+        }
-+
-+        auto url = URL(URL(), origin);
-+        if (!url.isValid()) {
-+            callback->sendFailure("Invalid origin URL"_s);
-+            return;
-+        }
-+
-+        auto items = obj->getArray("items");
-+        if (!items) {
-+            callback->sendFailure("Invalid item array format"_s);
-+            return;
-+        }
-+
-+        HashMap<String, String> map;
-+        for (const auto& item : *items) {
-+            auto itemObj = item->asObject();
-+            if (!itemObj) {
-+                callback->sendFailure("Invalid item format"_s);
-+                return;
-+            }
-+
-+            String name = itemObj->getString("name");
-+            String value = itemObj->getString("value");;
-+            if (name.isEmpty()) {
-+                callback->sendFailure("Item name cannot be empty"_s);
-+                return;
-+            }
-+
-+            map.set(name, value);
-+        }
-+        data.append({ WebCore::SecurityOriginData::fromURL(url), WTFMove(map) });
-+    }
-+
-+    networkProcess.sendWithAsyncReply(Messages::NetworkProcess::SetLocalStorageData(sessionID, storageNamespaceID, data), [callback = WTFMove(callback)] (const String& error) {
-+        if (error.isEmpty())
-+            callback->sendSuccess();
-+        else
-+            callback->sendFailure(error);
-+    });
-+}
-+
 +Inspector::Protocol::ErrorStringOr<String /* pageProxyID */> InspectorPlaywrightAgent::createPage(const String& browserContextID)
 +{
 +    String errorString;
@@ -15899,10 +15649,10 @@ index 0000000000000000000000000000000000000000..a07142981fbfb5d304fc8a485fb5cb41
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..1d1f360f01740c001507acac6b1ba90598934917
+index 0000000000000000000000000000000000000000..27e1bf3c7fd32d676a09605604936fa505c6ad05
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.h
-@@ -0,0 +1,129 @@
+@@ -0,0 +1,126 @@
 +/*
 + * Copyright (C) 2019 Microsoft Corporation.
 + *
@@ -15996,9 +15746,6 @@ index 0000000000000000000000000000000000000000..1d1f360f01740c001507acac6b1ba905
 +    void getAllCookies(const String& browserContextID, Ref<GetAllCookiesCallback>&&) override;
 +    void setCookies(const String& browserContextID, Ref<JSON::Array>&& in_cookies, Ref<SetCookiesCallback>&&) override;
 +    void deleteAllCookies(const String& browserContextID, Ref<DeleteAllCookiesCallback>&&) override;
-+
-+    void getLocalStorageData(const String& browserContextID, Ref<GetLocalStorageDataCallback>&&) override;
-+    void setLocalStorageData(const String& browserContextID, Ref<JSON::Array>&& origins, Ref<SetLocalStorageDataCallback>&&) override;
 +
 +    Inspector::Protocol::ErrorStringOr<void> setGeolocationOverride(const String& browserContextID, RefPtr<JSON::Object>&& geolocation) override;
 +    Inspector::Protocol::ErrorStringOr<void> setLanguages(Ref<JSON::Array>&& languages, const String& browserContextID) override;
@@ -16122,10 +15869,10 @@ index 7a14cfba15c103a2d4fe263fa49d25af3c396ec2..3ee0e154349661632799057c71f1d1f1
      BOOL result = ::CreateProcess(0, commandLine.data(), 0, 0, true, 0, 0, 0, &startupInfo, &processInformation);
  
 diff --git a/Source/WebKit/UIProcess/PageClient.h b/Source/WebKit/UIProcess/PageClient.h
-index c485c7fc313ea0833fc606267169d692a8240928..fc378501a80d01d597c904be6258ba7fa4fc91fb 100644
+index 5b529ffd8c22d6de032cc89ea709b12c378b1340..8ac4ae4b5f69fa5c22a5889f78526c4fc8179f4b 100644
 --- a/Source/WebKit/UIProcess/PageClient.h
 +++ b/Source/WebKit/UIProcess/PageClient.h
-@@ -323,6 +323,11 @@ public:
+@@ -324,6 +324,11 @@ public:
      virtual void selectionDidChange() = 0;
  #endif
  
@@ -16138,10 +15885,10 @@ index c485c7fc313ea0833fc606267169d692a8240928..fc378501a80d01d597c904be6258ba7f
      virtual RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) = 0;
  #endif
 diff --git a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
-index f7ca4d2bc236d99d0fc512e8f51d20ba3b83a3e9..08f13a1e37adac5589f2559f983bd17eb25d9a8b 100644
+index 2e06addf7e87566323448e1fd3d89998731a4db4..f3d3e7d12fb318c8c60b6f86f8b97cf3104bd0e7 100644
 --- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
-@@ -645,3 +645,5 @@ bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Option
+@@ -644,3 +644,5 @@ bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Option
  }
  
  } // namespace WebKit
@@ -17169,10 +16916,10 @@ index 0000000000000000000000000000000000000000..48c9ccc420c1b4ae3259e1d5ba17fd8f
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecde056b542 100644
+index baa4387bf0e0875fa6e270f6c363ee13e3844132..93db01ad2cbcb041142b1cac06182ceac460719c 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
-@@ -245,6 +245,9 @@
+@@ -246,6 +246,9 @@
  
  #if PLATFORM(GTK)
  #include "GtkSettingsManager.h"
@@ -17182,7 +16929,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  #include <WebCore/SelectionData.h>
  #endif
  
-@@ -618,6 +621,10 @@ WebPageProxy::~WebPageProxy()
+@@ -616,6 +619,10 @@ WebPageProxy::~WebPageProxy()
      if (m_preferences->mediaSessionCoordinatorEnabled())
          GroupActivitiesSessionNotifier::sharedNotifier().removeWebPage(*this);
  #endif
@@ -17193,7 +16940,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  }
  
  void WebPageProxy::addAllMessageReceivers()
-@@ -1018,6 +1025,7 @@ void WebPageProxy::finishAttachingToWebProcess(ProcessLaunchReason reason)
+@@ -1017,6 +1024,7 @@ void WebPageProxy::finishAttachingToWebProcess(ProcessLaunchReason reason)
      m_pageLoadState.didSwapWebProcesses();
      if (reason != ProcessLaunchReason::InitialProcess)
          m_drawingArea->waitForBackingStoreUpdateOnNextPaint();
@@ -17201,7 +16948,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  }
  
  void WebPageProxy::didAttachToRunningProcess()
-@@ -1371,6 +1379,21 @@ WebProcessProxy& WebPageProxy::ensureRunningProcess()
+@@ -1370,6 +1378,21 @@ WebProcessProxy& WebPageProxy::ensureRunningProcess()
      return m_process;
  }
  
@@ -17223,7 +16970,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  RefPtr<API::Navigation> WebPageProxy::loadRequest(ResourceRequest&& request, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, API::Object* userData)
  {
      if (m_isClosed)
-@@ -1919,6 +1942,31 @@ void WebPageProxy::setControlledByAutomation(bool controlled)
+@@ -1918,6 +1941,31 @@ void WebPageProxy::setControlledByAutomation(bool controlled)
      websiteDataStore().networkProcess().send(Messages::NetworkProcess::SetSessionIsControlledByAutomation(m_websiteDataStore->sessionID(), m_controlledByAutomation), 0);
  }
  
@@ -17255,7 +17002,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  void WebPageProxy::createInspectorTarget(const String& targetId, Inspector::InspectorTargetType type)
  {
      MESSAGE_CHECK(m_process, !targetId.isEmpty());
-@@ -2109,6 +2157,25 @@ void WebPageProxy::updateActivityState(OptionSet<ActivityState::Flag> flagsToUpd
+@@ -2108,6 +2156,25 @@ void WebPageProxy::updateActivityState(OptionSet<ActivityState::Flag> flagsToUpd
  {
      bool wasVisible = isViewVisible();
      m_activityState.remove(flagsToUpdate);
@@ -17281,7 +17028,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
      if (flagsToUpdate & ActivityState::IsFocused && pageClient().isViewFocused())
          m_activityState.add(ActivityState::IsFocused);
      if (flagsToUpdate & ActivityState::WindowIsActive && pageClient().isViewWindowActive())
-@@ -2681,6 +2748,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
+@@ -2686,6 +2753,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
  {
      if (!hasRunningProcess())
          return;
@@ -17290,7 +17037,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  #if PLATFORM(GTK)
      UNUSED_PARAM(dragStorageName);
      UNUSED_PARAM(sandboxExtensionHandle);
-@@ -2691,6 +2760,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
+@@ -2696,6 +2765,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
          m_process->assumeReadAccessToBaseURL(*this, url);
  
      ASSERT(dragData.platformData());
@@ -17299,7 +17046,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
      send(Messages::WebPage::PerformDragControllerAction(action, dragData.clientPosition(), dragData.globalPosition(), dragData.draggingSourceOperationMask(), *dragData.platformData(), dragData.flags()));
  #else
      send(Messages::WebPage::PerformDragControllerAction(action, dragData, sandboxExtensionHandle, sandboxExtensionsForUpload));
-@@ -2706,18 +2777,41 @@ void WebPageProxy::didPerformDragControllerAction(std::optional<WebCore::DragOpe
+@@ -2711,18 +2782,41 @@ void WebPageProxy::didPerformDragControllerAction(std::optional<WebCore::DragOpe
      m_currentDragCaretEditableElementRect = editableElementRect;
      setDragCaretRect(insertionRect);
      pageClient().didPerformDragControllerAction();
@@ -17344,7 +17091,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<WebCore::DragOperation> dragOperationMask)
  {
      if (!hasRunningProcess())
-@@ -2726,6 +2820,24 @@ void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& glo
+@@ -2731,6 +2825,24 @@ void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& glo
      setDragCaretRect({ });
  }
  
@@ -17369,7 +17116,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  void WebPageProxy::didPerformDragOperation(bool handled)
  {
      pageClient().didPerformDragOperation(handled);
-@@ -2738,8 +2850,18 @@ void WebPageProxy::didStartDrag()
+@@ -2743,8 +2855,18 @@ void WebPageProxy::didStartDrag()
  
      discardQueuedMouseEvents();
      send(Messages::WebPage::DidStartDrag());
@@ -17389,7 +17136,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  void WebPageProxy::dragCancelled()
  {
      if (hasRunningProcess())
-@@ -2844,16 +2966,38 @@ void WebPageProxy::processNextQueuedMouseEvent()
+@@ -2849,16 +2971,38 @@ void WebPageProxy::processNextQueuedMouseEvent()
          m_process->startResponsivenessTimer();
      }
  
@@ -17435,7 +17182,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  }
  
  void WebPageProxy::doAfterProcessingAllPendingMouseEvents(WTF::Function<void ()>&& action)
-@@ -3017,7 +3161,7 @@ static TrackingType mergeTrackingTypes(TrackingType a, TrackingType b)
+@@ -3022,7 +3166,7 @@ static TrackingType mergeTrackingTypes(TrackingType a, TrackingType b)
  
  void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent)
  {
@@ -17444,7 +17191,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
      const EventNames& names = eventNames();
      for (auto& touchPoint : touchStartEvent.touchPoints()) {
          IntPoint location = touchPoint.location();
-@@ -3050,7 +3194,7 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
+@@ -3055,7 +3199,7 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
      m_touchAndPointerEventTracking.touchStartTracking = TrackingType::Synchronous;
      m_touchAndPointerEventTracking.touchMoveTracking = TrackingType::Synchronous;
      m_touchAndPointerEventTracking.touchEndTracking = TrackingType::Synchronous;
@@ -17453,7 +17200,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  }
  
  TrackingType WebPageProxy::touchEventTrackingType(const WebTouchEvent& touchStartEvent) const
-@@ -3439,6 +3583,8 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
+@@ -3444,6 +3588,8 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
          policyAction = PolicyAction::Download;
  
      if (policyAction != PolicyAction::Use || !frame.isMainFrame() || !navigation) {
@@ -17462,7 +17209,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
          receivedPolicyDecision(policyAction, navigation, WTFMove(policies), WTFMove(navigationAction), WTFMove(sender));
          return;
      }
-@@ -3507,6 +3653,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
+@@ -3512,6 +3658,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
  
  void WebPageProxy::receivedPolicyDecision(PolicyAction action, API::Navigation* navigation, RefPtr<API::WebsitePolicies>&& websitePolicies, std::variant<Ref<API::NavigationResponse>, Ref<API::NavigationAction>>&& navigationActionOrResponse, Ref<PolicyDecisionSender>&& sender, std::optional<SandboxExtension::Handle> sandboxExtensionHandle, WillContinueLoadInNewProcess willContinueLoadInNewProcess)
  {
@@ -17470,7 +17217,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
      if (!hasRunningProcess()) {
          sender->send(PolicyDecision { sender->identifier(), isNavigatingToAppBoundDomain(), PolicyAction::Ignore, 0, std::nullopt, std::nullopt });
          return;
-@@ -4243,6 +4390,11 @@ void WebPageProxy::pageScaleFactorDidChange(double scaleFactor)
+@@ -4248,6 +4395,11 @@ void WebPageProxy::pageScaleFactorDidChange(double scaleFactor)
      m_pageScaleFactor = scaleFactor;
  }
  
@@ -17482,7 +17229,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  void WebPageProxy::pluginScaleFactorDidChange(double pluginScaleFactor)
  {
      m_pluginScaleFactor = pluginScaleFactor;
-@@ -4586,6 +4738,7 @@ void WebPageProxy::didDestroyNavigation(uint64_t navigationID)
+@@ -4591,6 +4743,7 @@ void WebPageProxy::didDestroyNavigation(uint64_t navigationID)
          return;
  
      m_navigationState->didDestroyNavigation(navigationID);
@@ -17490,7 +17237,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  }
  
  void WebPageProxy::didStartProvisionalLoadForFrame(FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, uint64_t navigationID, URL&& url, URL&& unreachableURL, const UserData& userData)
-@@ -4810,6 +4963,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
+@@ -4815,6 +4968,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
  
      m_failingProvisionalLoadURL = { };
  
@@ -17499,7 +17246,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
      // If the provisional page's load fails then we destroy the provisional page.
      if (m_provisionalPage && m_provisionalPage->mainFrame() == &frame && willContinueLoading == WillContinueLoading::No)
          m_provisionalPage = nullptr;
-@@ -5278,7 +5433,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
+@@ -5283,7 +5438,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
      NavigationActionData&& navigationActionData, FrameInfoData&& originatingFrameInfo, std::optional<WebPageProxyIdentifier> originatingPageID, const WebCore::ResourceRequest& originalRequest, WebCore::ResourceRequest&& request,
      IPC::FormDataReference&& requestBody, WebCore::ResourceResponse&& redirectResponse, const UserData& userData, uint64_t listenerID)
  {
@@ -17515,15 +17262,15 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  }
  
  void WebPageProxy::decidePolicyForNavigationActionAsyncShared(Ref<WebProcessProxy>&& process, PageIdentifier webPageID, FrameIdentifier frameID, FrameInfoData&& frameInfo,
-@@ -5839,6 +6001,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
-     auto* originatingPage = m_process->webPage(originatingPageID);
-     auto originatingFrameInfo = API::FrameInfo::create(WTFMove(originatingFrameInfoData), originatingPage);
-     auto mainFrameURL = m_mainFrame ? m_mainFrame->url() : URL();
+@@ -5849,6 +6011,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+     if (originatingPage)
+         openerAppInitiatedState = originatingPage->lastNavigationWasAppInitiated();
+ 
 +    m_inspectorController->willCreateNewPage(windowFeatures, request.url());
-     auto completionHandler = [this, protectedThis = Ref { *this }, mainFrameURL, request, reply = WTFMove(reply), privateClickMeasurement = navigationActionData.privateClickMeasurement] (RefPtr<WebPageProxy> newPage) mutable {
+     auto completionHandler = [this, protectedThis = Ref { *this }, mainFrameURL, request, reply = WTFMove(reply), privateClickMeasurement = navigationActionData.privateClickMeasurement, openerAppInitiatedState = WTFMove(openerAppInitiatedState)] (RefPtr<WebPageProxy> newPage) mutable {
          if (!newPage) {
              reply(std::nullopt, std::nullopt);
-@@ -5882,6 +6045,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -5895,6 +6058,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
  void WebPageProxy::showPage()
  {
      m_uiClient->showPage(this);
@@ -17531,7 +17278,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  }
  
  void WebPageProxy::exitFullscreenImmediately()
-@@ -5917,6 +6081,10 @@ void WebPageProxy::closePage()
+@@ -5930,6 +6094,10 @@ void WebPageProxy::closePage()
      if (isClosed())
          return;
  
@@ -17542,7 +17289,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
      WEBPAGEPROXY_RELEASE_LOG(Process, "closePage:");
      pageClient().clearAllEditCommands();
      m_uiClient->close(this);
-@@ -5953,6 +6121,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
+@@ -5966,6 +6134,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
      }
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
@@ -17551,7 +17298,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
          page.m_uiClient->runJavaScriptAlert(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)]() mutable {
              reply();
              completion();
-@@ -5974,6 +6144,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
+@@ -5987,6 +6157,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17560,7 +17307,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptConfirm(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](bool result) mutable {
-@@ -5997,6 +6169,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
+@@ -6010,6 +6182,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17569,7 +17316,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply), defaultValue](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptPrompt(page, message, defaultValue, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](auto& result) mutable {
-@@ -6124,6 +6298,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
+@@ -6137,6 +6311,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
              return;
          }
      }
@@ -17578,7 +17325,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  
      // Since runBeforeUnloadConfirmPanel() can spin a nested run loop we need to turn off the responsiveness timer and the tryClose timer.
      m_process->stopResponsivenessTimer();
-@@ -7363,6 +7539,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7376,6 +7552,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->mouseEventsFlushedForPage(*this);
              didFinishProcessingAllPendingMouseEvents();
@@ -17587,7 +17334,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
          }
          break;
      }
-@@ -7377,10 +7555,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7390,10 +7568,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              pageClient().wheelEventWasNotHandledByWebCore(oldestProcessedEvent);
          }
  
@@ -17604,7 +17351,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
          break;
      }
  
-@@ -7389,7 +7570,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7402,7 +7583,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
      case WebEvent::RawKeyDown:
      case WebEvent::Char: {
          LOG(KeyHandling, "WebPageProxy::didReceiveEvent: %s (queue empty %d)", webKeyboardEventTypeString(type), m_keyEventQueue.isEmpty());
@@ -17612,7 +17359,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
          MESSAGE_CHECK(m_process, !m_keyEventQueue.isEmpty());
          auto event = m_keyEventQueue.takeFirst();
          MESSAGE_CHECK(m_process, type == event.type());
-@@ -7408,7 +7588,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7421,7 +7601,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          // The call to doneWithKeyEvent may close this WebPage.
          // Protect against this being destroyed.
          Ref<WebPageProxy> protect(*this);
@@ -17620,7 +17367,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
          pageClient().doneWithKeyEvent(event, handled);
          if (!handled)
              m_uiClient->didNotHandleKeyEvent(this, event);
-@@ -7417,6 +7596,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7430,6 +7609,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          if (!canProcessMoreKeyEvents) {
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->keyboardEventsFlushedForPage(*this);
@@ -17628,7 +17375,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
          }
          break;
      }
-@@ -7771,7 +7951,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
+@@ -7784,7 +7964,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
  {
      WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "dispatchProcessDidTerminate: reason=%{public}s", processTerminationReasonToString(reason));
  
@@ -17640,7 +17387,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
      if (m_loaderClient)
          handledByClient = reason != ProcessTerminationReason::RequestedByClient && m_loaderClient->processDidCrash(*this);
      else
-@@ -8158,6 +8341,7 @@ static const Vector<ASCIILiteral>& mediaRelatedIOKitClasses()
+@@ -8176,6 +8359,7 @@ static Span<const ASCIILiteral> mediaRelatedIOKitClasses()
  
  WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& process, DrawingAreaProxy& drawingArea, RefPtr<API::WebsitePolicies>&& websitePolicies)
  {
@@ -17648,7 +17395,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
      WebPageCreationParameters parameters;
  
      parameters.processDisplayName = configuration().processDisplayName();
-@@ -8353,6 +8537,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
+@@ -8371,6 +8555,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
      parameters.shouldRelaxThirdPartyCookieBlocking = m_configuration->shouldRelaxThirdPartyCookieBlocking();
      parameters.canUseCredentialStorage = m_canUseCredentialStorage;
  
@@ -17657,7 +17404,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
  #if PLATFORM(GTK)
      parameters.gtkSettings = GtkSettingsManager::singleton().settingsState();
  #endif
-@@ -8434,6 +8620,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
+@@ -8452,6 +8638,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
  
  void WebPageProxy::didReceiveAuthenticationChallengeProxy(Ref<AuthenticationChallengeProxy>&& authenticationChallenge, NegotiatedLegacyTLS negotiatedLegacyTLS)
  {
@@ -17672,7 +17419,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
      if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes) {
          m_navigationClient->shouldAllowLegacyTLS(*this, authenticationChallenge.get(), [this, protectedThis = Ref { *this }, authenticationChallenge] (bool shouldAllowLegacyTLS) {
              if (shouldAllowLegacyTLS)
-@@ -8527,6 +8721,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
+@@ -8545,6 +8739,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
              request->deny();
      };
  
@@ -17689,7 +17436,7 @@ index 9ca6815eeaafecb6fb01b345edb594391877eadd..6726ed4c9f8dc3122d419db692450ecd
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index 9a816fdb3183a19b679e87703a0f440e5ab90903..41caa2fd63a4ad7dc756be17d26b4a7f4f3ef1bb 100644
+index 8de9f824c4e1794a6b0459cbfb64390f881d4309..f97ca1c101065f6ce1a4858046b9fd3fb04e65a3 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -39,6 +39,7 @@
@@ -17743,7 +17490,7 @@ index 9a816fdb3183a19b679e87703a0f440e5ab90903..41caa2fd63a4ad7dc756be17d26b4a7f
  class SharedBuffer;
  class SpeechRecognitionRequest;
  class TextIndicator;
-@@ -542,6 +554,8 @@ public:
+@@ -545,6 +557,8 @@ public:
      void setControlledByAutomation(bool);
  
      WebPageInspectorController& inspectorController() { return *m_inspectorController; }
@@ -17752,7 +17499,7 @@ index 9a816fdb3183a19b679e87703a0f440e5ab90903..41caa2fd63a4ad7dc756be17d26b4a7f
  
  #if PLATFORM(IOS_FAMILY)
      void showInspectorIndication();
-@@ -645,6 +659,11 @@ public:
+@@ -648,6 +662,11 @@ public:
  
      void setPageLoadStateObserver(std::unique_ptr<PageLoadState::Observer>&&);
  
@@ -17764,7 +17511,7 @@ index 9a816fdb3183a19b679e87703a0f440e5ab90903..41caa2fd63a4ad7dc756be17d26b4a7f
      void initializeWebPage();
      void setDrawingArea(std::unique_ptr<DrawingAreaProxy>&&);
  
-@@ -672,6 +691,7 @@ public:
+@@ -675,6 +694,7 @@ public:
      void closePage();
  
      void addPlatformLoadParameters(WebProcessProxy&, LoadParameters&);
@@ -17772,7 +17519,7 @@ index 9a816fdb3183a19b679e87703a0f440e5ab90903..41caa2fd63a4ad7dc756be17d26b4a7f
      RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadData(const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
-@@ -1193,6 +1213,7 @@ public:
+@@ -1195,6 +1215,7 @@ public:
  #endif
  
      void pageScaleFactorDidChange(double);
@@ -17780,7 +17527,7 @@ index 9a816fdb3183a19b679e87703a0f440e5ab90903..41caa2fd63a4ad7dc756be17d26b4a7f
      void pluginScaleFactorDidChange(double);
      void pluginZoomFactorDidChange(double);
  
-@@ -1269,14 +1290,20 @@ public:
+@@ -1271,14 +1292,20 @@ public:
      void didStartDrag();
      void dragCancelled();
      void setDragCaretRect(const WebCore::IntRect&);
@@ -17802,7 +17549,7 @@ index 9a816fdb3183a19b679e87703a0f440e5ab90903..41caa2fd63a4ad7dc756be17d26b4a7f
  #endif
  
      void processDidBecomeUnresponsive();
-@@ -1523,6 +1550,8 @@ public:
+@@ -1525,6 +1552,8 @@ public:
  
  #if PLATFORM(COCOA) || PLATFORM(GTK)
      RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
@@ -17851,7 +17598,7 @@ index 9a816fdb3183a19b679e87703a0f440e5ab90903..41caa2fd63a4ad7dc756be17d26b4a7f
  #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
      std::unique_ptr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.messages.in b/Source/WebKit/UIProcess/WebPageProxy.messages.in
-index d5636a3a62c7af84d72d498afdae1f32b8f4b554..bad5a699c6f0d3ab74d3da88cfbfc5140b6af27c 100644
+index 942c93dd2f926925dc843fda796844d487129005..44486ce1ff4247d282396dd2634b35dbe5048fff 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
 +++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
 @@ -29,6 +29,7 @@ messages -> WebPageProxy {
@@ -17920,10 +17667,10 @@ index 0961367a61e89647c40c03962a4ba3d0ea6b1ab9..fd2b1c6e37a933ffb8b9e4467c7eca8f
      parameters.urlSchemesRegisteredAsEmptyDocument = copyToVector(m_schemesToRegisterAsEmptyDocument);
      parameters.urlSchemesRegisteredAsSecure = copyToVector(LegacyGlobalSettings::singleton().schemesToRegisterAsSecure());
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.cpp b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-index 6656e2dddd3b42cc707e8a28b5da9ada708099fb..89b9538d8d0076052509996cc915c5679c0ac6d2 100644
+index fdfd48ca1ebc0a74772f58bf90f5b8a4e79b3aad..f14e10ce82025ce22767e9b4497effd3e7796153 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-@@ -144,6 +144,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
+@@ -143,6 +143,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
      return map;
  }
  
@@ -17936,7 +17683,7 @@ index 6656e2dddd3b42cc707e8a28b5da9ada708099fb..89b9538d8d0076052509996cc915c567
  {
      return allProcesses().get(identifier);
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.h b/Source/WebKit/UIProcess/WebProcessProxy.h
-index f74480ffa7cc9f1806521e5bb0551f4466be57e4..4a27ca15723c90f046b3a63c55fcd5538995103d 100644
+index edc5090ecf29c032d3c2d78558f669a36f0d3dbb..0b5ee06e4f3e2b4f10b8f51687f68a0bbc537541 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.h
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.h
 @@ -143,6 +143,7 @@ public:
@@ -17948,10 +17695,10 @@ index f74480ffa7cc9f1806521e5bb0551f4466be57e4..4a27ca15723c90f046b3a63c55fcd553
      WebConnection* webConnection() const { return m_webConnection.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-index 909793e37568c042b1002a26aa0274784a91e4ca..d46ee8c3aa5835b2789a6566a040c7b4612b26a4 100644
+index 71cf9207efd9ca295ab890d676e2d39d492d6658..48a161acba75caec0c79ffe4bae493e69ad4903b 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-@@ -2035,6 +2035,17 @@ void WebsiteDataStore::renameOriginInWebsiteData(URL&& oldName, URL&& newName, O
+@@ -2038,6 +2038,17 @@ void WebsiteDataStore::renameOriginInWebsiteData(URL&& oldName, URL&& newName, O
      networkProcess().renameOriginInWebsiteData(m_sessionID, oldName, newName, dataTypes, WTFMove(completionHandler));
  }
  
@@ -17970,7 +17717,7 @@ index 909793e37568c042b1002a26aa0274784a91e4ca..d46ee8c3aa5835b2789a6566a040c7b4
  void WebsiteDataStore::hasAppBoundSession(CompletionHandler<void(bool)>&& completionHandler) const
  {
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
-index 1de25a66057f2d66c6299e5ebbb8146bee9b81e3..126b238365b8f9113028636ead95091186888826 100644
+index 6db82c1e03f5975571955c9e5b7b606e3bf42c03..870482803cb36223dd57dcce493c059ece645e72 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
 @@ -88,6 +88,7 @@ class SecKeyProxyStore;
@@ -18679,7 +18426,7 @@ index 0000000000000000000000000000000000000000..d0f9827544994e450e24e3f7a427c35e
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
-index 32d1f89c058b9b40a18e8f67bc7be9f0a102508b..5d9184da8c5f5a172fa71d31b31010840f273031 100644
+index fac9e7fb78bee0f62945672e3bb74b9e0520e30f..9b2a0d4acaa90efb00aa4d8dd981890c085cedaf 100644
 --- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 +++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 @@ -437,6 +437,8 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
@@ -18880,7 +18627,7 @@ index 0000000000000000000000000000000000000000..721826c8c98fc85b68a4f45deaee69c1
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/mac/PageClientImplMac.h b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
-index d2238fdc9d16f77f8c3d302ca9976fe83f1b3f37..0be14a01d922cb3b705433f9d1a7c5ceff337827 100644
+index aa57ea0f6cf5be671ece493898621b2a4cef53db..e2a32cb82db0f2bba7977865de1867c14d7bf63c 100644
 --- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
 +++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
 @@ -53,6 +53,8 @@ class PageClientImpl final : public PageClientImplCocoa
@@ -18902,7 +18649,7 @@ index d2238fdc9d16f77f8c3d302ca9976fe83f1b3f37..0be14a01d922cb3b705433f9d1a7c5ce
      RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) override;
      void wheelEventWasNotHandledByWebCore(const NativeWebWheelEvent&) override;
  #if ENABLE(MAC_GESTURE_EVENTS)
-@@ -218,6 +223,10 @@ private:
+@@ -216,6 +221,10 @@ private:
      void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
  #endif
  
@@ -18914,7 +18661,7 @@ index d2238fdc9d16f77f8c3d302ca9976fe83f1b3f37..0be14a01d922cb3b705433f9d1a7c5ce
      void navigationGestureWillEnd(bool willNavigate, WebBackForwardListItem&) override;
      void navigationGestureDidEnd(bool willNavigate, WebBackForwardListItem&) override;
 diff --git a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
-index a4112135f2ef19015a52f1e1b03ae30a1f223d2a..3cc260a1ed20e5f010639651260bd97987e66139 100644
+index 756184af6cd9946a5f947df90dd9e6bfb44e0e56..8f55df003e3bc7c19eafdbb966ae669d3a2341ac 100644
 --- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
 +++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
 @@ -81,6 +81,7 @@
@@ -19010,7 +18757,7 @@ index a4112135f2ef19015a52f1e1b03ae30a1f223d2a..3cc260a1ed20e5f010639651260bd979
  RefPtr<ViewSnapshot> PageClientImpl::takeViewSnapshot(std::optional<WebCore::IntRect>&&)
  {
      return m_impl->takeViewSnapshot();
-@@ -798,6 +826,13 @@ void PageClientImpl::beganExitFullScreen(const IntRect& initialFrame, const IntR
+@@ -793,6 +821,13 @@ void PageClientImpl::beganExitFullScreen(const IntRect& initialFrame, const IntR
  
  #endif // ENABLE(FULLSCREEN_API)
  
@@ -19024,7 +18771,7 @@ index a4112135f2ef19015a52f1e1b03ae30a1f223d2a..3cc260a1ed20e5f010639651260bd979
  void PageClientImpl::navigationGestureDidBegin()
  {
      m_impl->dismissContentRelativeChildWindowsWithAnimation(true);
-@@ -975,6 +1010,9 @@ void PageClientImpl::requestScrollToRect(const WebCore::FloatRect& targetRect, c
+@@ -970,6 +1005,9 @@ void PageClientImpl::requestScrollToRect(const WebCore::FloatRect& targetRect, c
  
  bool PageClientImpl::windowIsFrontWindowUnderMouse(const NativeWebMouseEvent& event)
  {
@@ -19047,10 +18794,10 @@ index 34e2d00746ebb079719becbe781f5bc6cea1d480..bf496a6327b962f8f40c207c9e2023d2
      void getContextMenuItem(const WebContextMenuItemData&, CompletionHandler<void(NSMenuItem *)>&&);
      void getContextMenuFromItems(const Vector<WebContextMenuItemData>&, CompletionHandler<void(NSMenu *)>&&);
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-index 049753f867d959f5db176c48824e2f551c646026..633136c091bea0566e03d7997a38af8ca7a2253b 100644
+index d59fcb12f2d2a0adc227b0fdc256f5cafea9384c..d0c7fed1aa604741edf72b4249e67c3271f0f86e 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-@@ -363,6 +363,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
+@@ -370,6 +370,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
  }
  #endif
  
@@ -20004,30 +19751,30 @@ index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705e
 + 
 +} // namespace WebKit
 diff --git a/Source/WebKit/UnifiedSources-output.xcfilelist b/Source/WebKit/UnifiedSources-output.xcfilelist
-index 50898e4630173194ae4ef7cce43ae8eb4673a86b..2ad79645d6ef683dad4eb076f5dd72472bf860b8 100644
+index 1b9d97c38c412a7cc8d3ffc4a52ca5ce656755f2..11541664ef8af36f43cee3cc1d2d8f4a7586e651 100644
 --- a/Source/WebKit/UnifiedSources-output.xcfilelist
 +++ b/Source/WebKit/UnifiedSources-output.xcfilelist
-@@ -17,6 +17,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource11-mm.m
- $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource11.cpp
- $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource110.cpp
- $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource111.cpp
-+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource112.cpp
+@@ -21,6 +21,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource112.cpp
+ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource113.cpp
+ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource114.cpp
+ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource115.cpp
++$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource116.cpp
  $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource12-mm.mm
  $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource12.cpp
  $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource13-mm.mm
 diff --git a/Source/WebKit/WebKit.xcodeproj/project.pbxproj b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83d338a94a 100644
+index 22894ab8f47fa46a7fb3c8aba5e0af512fc39af5..842f08cad6eb7d374f285b584e25ad0dca0075ee 100644
 --- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 +++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-@@ -395,6 +395,7 @@
- 		1CA8B946127C882A00576C2B /* WebInspectorUIProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CA8B944127C882A00576C2B /* WebInspectorUIProxyMessages.h */; };
- 		1CAECB6527465AE400AB78D0 /* UnifiedSource109.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CAECB5D27465AE300AB78D0 /* UnifiedSource109.cpp */; };
- 		1CAECB6627465AE400AB78D0 /* UnifiedSource111.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CAECB5E27465AE300AB78D0 /* UnifiedSource111.cpp */; };
-+		BF2C49ED7AD83CB7BC93CC92 /* UnifiedSource112.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1D7178FBC4EDB168CDB0B04D /* UnifiedSource112.cpp */; };
- 		1CAECB6727465AE400AB78D0 /* UnifiedSource108.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CAECB5F27465AE300AB78D0 /* UnifiedSource108.cpp */; };
- 		1CAECB6827465AE400AB78D0 /* UnifiedSource110.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CAECB6027465AE300AB78D0 /* UnifiedSource110.cpp */; };
- 		1CAECB6927465AE400AB78D0 /* UnifiedSource104.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CAECB6127465AE300AB78D0 /* UnifiedSource104.cpp */; };
-@@ -1953,6 +1954,18 @@
+@@ -1236,6 +1236,7 @@
+ 		5CABDC8722C40FED001EDE8E /* APIMessageListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CABDC8322C40FA7001EDE8E /* APIMessageListener.h */; };
+ 		5CADDE05215046BD0067D309 /* WKWebProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C74300E21500492004BFA17 /* WKWebProcess.h */; settings = {ATTRIBUTES = (Private, ); }; };
+ 		5CAECB6627465AE400AB78D0 /* UnifiedSource115.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */; };
++		BF2C49ED7AD83CB7BC93CC92 /* UnifiedSource116.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1D7178FBC4EDB168CDB0B04D /* UnifiedSource116.cpp */; };
+ 		5CAF7AA726F93AB00003F19E /* adattributiond.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAF7AA526F93A950003F19E /* adattributiond.cpp */; };
+ 		5CAFDE452130846300B1F7E1 /* _WKInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE422130843500B1F7E1 /* _WKInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
+ 		5CAFDE472130846A00B1F7E1 /* _WKInspectorInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE442130843600B1F7E1 /* _WKInspectorInternal.h */; };
+@@ -1925,6 +1926,18 @@
  		DF0C5F28252ECB8E00D921DB /* WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F24252ECB8D00D921DB /* WKDownload.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2A252ECB8E00D921DB /* WKDownloadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2B252ED44000D921DB /* WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */; };
@@ -20046,7 +19793,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  		DF462E0F23F22F5500EFF35F /* WKHTTPCookieStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */; };
-@@ -2009,6 +2022,9 @@
+@@ -1981,6 +1994,9 @@
  		E5CB07DC20E1678F0022C183 /* WKFormColorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */; };
  		E5DEFA6826F8F42600AB68DB /* PhotosUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E5DEFA6726F8F42600AB68DB /* PhotosUISPI.h */; };
  		ED82A7F2128C6FAF004477B3 /* WKBundlePageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22F0FF1289FCD90085E74F /* WKBundlePageOverlay.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -20056,15 +19803,15 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
  		F42D634122A0EFDF00D2FB3A /* WebAutocorrectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */; };
-@@ -3195,6 +3211,7 @@
- 		1CAECB6227465AE400AB78D0 /* UnifiedSource105.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource105.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource105.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
- 		1CAECB6327465AE400AB78D0 /* UnifiedSource106.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource106.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource106.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
- 		1CAECB6427465AE400AB78D0 /* UnifiedSource107.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource107.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource107.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
-+		1D7178FBC4EDB168CDB0B04D /* UnifiedSource112.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource112.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource112.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
- 		1CB7461A27436EE400F19874 /* RemoteTextureViewProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteTextureViewProxy.h; sourceTree = "<group>"; };
- 		1CB7461B27436EE400F19874 /* RemoteBindGroupLayoutProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteBindGroupLayoutProxy.h; sourceTree = "<group>"; };
- 		1CB7461C27436EE500F19874 /* RemoteCommandBufferProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteCommandBufferProxy.cpp; sourceTree = "<group>"; };
-@@ -6257,6 +6274,19 @@
+@@ -4858,6 +4874,7 @@
+ 		5CABDC8522C40FCC001EDE8E /* WKMessageListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKMessageListener.h; sourceTree = "<group>"; };
+ 		5CADDE0D2151AA010067D309 /* AuthenticationChallengeDisposition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthenticationChallengeDisposition.h; sourceTree = "<group>"; };
+ 		5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource115.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource115.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
++		1D7178FBC4EDB168CDB0B04D /* UnifiedSource116.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource116.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource116.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
+ 		5CAF7AA426F93A750003F19E /* adattributiond */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = adattributiond; sourceTree = BUILT_PRODUCTS_DIR; };
+ 		5CAF7AA526F93A950003F19E /* adattributiond.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = adattributiond.cpp; sourceTree = "<group>"; };
+ 		5CAF7AA626F93AA50003F19E /* adattributiond.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = adattributiond.xcconfig; sourceTree = "<group>"; };
+@@ -6262,6 +6279,19 @@
  		DF0C5F24252ECB8D00D921DB /* WKDownload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownload.h; sourceTree = "<group>"; };
  		DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadInternal.h; sourceTree = "<group>"; };
  		DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadDelegate.h; sourceTree = "<group>"; };
@@ -20084,7 +19831,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  		DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHTTPCookieStorePrivate.h; sourceTree = "<group>"; };
  		DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKContentWorldPrivate.h; sourceTree = "<group>"; };
  		DF58C6311371AC5800F9A37C /* NativeWebWheelEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeWebWheelEvent.h; sourceTree = "<group>"; };
-@@ -6378,6 +6408,14 @@
+@@ -6383,6 +6413,14 @@
  		ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtraPrivateSymbolsForTAPI.h; sourceTree = "<group>"; };
  		ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExtraPublicSymbolsForTAPI.h; sourceTree = "<group>"; };
  		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
@@ -20099,7 +19846,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  		F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDragDestinationAction.h; sourceTree = "<group>"; };
  		F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionContext.h; path = ios/WebAutocorrectionContext.h; sourceTree = "<group>"; };
  		F41056612130699A0092281D /* APIAttachmentCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = APIAttachmentCocoa.mm; sourceTree = "<group>"; };
-@@ -6520,6 +6558,7 @@
+@@ -6529,6 +6567,7 @@
  				3766F9EF189A1244003CF19B /* QuartzCore.framework in Frameworks */,
  				37694525184FC6B600CDE21F /* Security.framework in Frameworks */,
  				37BEC4DD1948FC6A008B4286 /* WebCore.framework in Frameworks */,
@@ -20107,15 +19854,15 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -8209,6 +8248,7 @@
- 				1CAECB5D27465AE300AB78D0 /* UnifiedSource109.cpp */,
- 				1CAECB6027465AE300AB78D0 /* UnifiedSource110.cpp */,
- 				1CAECB5E27465AE300AB78D0 /* UnifiedSource111.cpp */,
-+				1D7178FBC4EDB168CDB0B04D /* UnifiedSource112.cpp */,
+@@ -8223,6 +8262,7 @@
+ 				3CAECB5E27465AE300AB78D0 /* UnifiedSource113.cpp */,
+ 				4CAECB5E27465AE300AB78D0 /* UnifiedSource114.cpp */,
+ 				5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */,
++				1D7178FBC4EDB168CDB0B04D /* UnifiedSource116.cpp */,
  			);
  			name = "unified-sources";
  			path = "DerivedSources/WebKit/unified-sources";
-@@ -8569,6 +8609,7 @@
+@@ -8583,6 +8623,7 @@
  		37C4C08318149C2A003688B9 /* Cocoa */ = {
  			isa = PBXGroup;
  			children = (
@@ -20123,7 +19870,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				1A43E826188F38E2009E4D30 /* Deprecated */,
  				37A5E01218BBF937000A081E /* _WKActivatedElementInfo.h */,
  				37A5E01118BBF937000A081E /* _WKActivatedElementInfo.mm */,
-@@ -9701,6 +9742,7 @@
+@@ -9719,6 +9760,7 @@
  			isa = PBXGroup;
  			children = (
  				57A9FF15252C6AEF006A2040 /* libWTF.a */,
@@ -20131,7 +19878,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				5750F32A2032D4E500389347 /* LocalAuthentication.framework */,
  				570DAAB0230273D200E8FC04 /* NearField.framework */,
  				51F7BB7E274564A100C45A72 /* Security.framework */,
-@@ -10209,6 +10251,12 @@
+@@ -10227,6 +10269,12 @@
  			children = (
  				9197940423DBC4BB00257892 /* InspectorBrowserAgent.cpp */,
  				9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */,
@@ -20144,7 +19891,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  			);
  			path = Agents;
  			sourceTree = "<group>";
-@@ -10217,6 +10265,7 @@
+@@ -10235,6 +10283,7 @@
  			isa = PBXGroup;
  			children = (
  				A5D3504D1D78F0D2005124A9 /* RemoteWebInspectorUIProxyMac.mm */,
@@ -20152,7 +19899,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */,
  				99A7ACE326012919006D57FD /* WKInspectorResourceURLSchemeHandler.h */,
  				99A7ACE42601291A006D57FD /* WKInspectorResourceURLSchemeHandler.mm */,
-@@ -10748,6 +10797,12 @@
+@@ -10781,6 +10830,12 @@
  		BC032DC310F438260058C15A /* UIProcess */ = {
  			isa = PBXGroup;
  			children = (
@@ -20165,7 +19912,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				BC032DC410F4387C0058C15A /* API */,
  				512F588D12A8836F00629530 /* Authentication */,
  				9955A6E81C79809000EB6A93 /* Automation */,
-@@ -11053,6 +11108,7 @@
+@@ -11086,6 +11141,7 @@
  		BC0C376610F807660076D7CB /* C */ = {
  			isa = PBXGroup;
  			children = (
@@ -20173,7 +19920,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				5123CF18133D25E60056F800 /* cg */,
  				6EE849C41368D9040038D481 /* mac */,
  				BCB63477116BF10600603215 /* WebKit2_C.h */,
-@@ -11641,6 +11697,11 @@
+@@ -11674,6 +11730,11 @@
  		BCCF085C113F3B7500C650C5 /* mac */ = {
  			isa = PBXGroup;
  			children = (
@@ -20185,7 +19932,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				B878B613133428DC006888E9 /* CorrectionPanel.h */,
  				B878B614133428DC006888E9 /* CorrectionPanel.mm */,
  				C1817362205844A900DFDA65 /* DisplayLink.cpp */,
-@@ -12565,6 +12626,7 @@
+@@ -12594,6 +12655,7 @@
  				99788ACB1F421DDA00C08000 /* _WKAutomationSessionConfiguration.h in Headers */,
  				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
  				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
@@ -20193,7 +19940,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
  				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
  				1A5704F81BE01FF400874AF1 /* _WKContextMenuElementInfo.h in Headers */,
-@@ -12872,6 +12934,7 @@
+@@ -12903,6 +12965,7 @@
  				1A14F8E21D74C834006CBEC6 /* FrameInfoData.h in Headers */,
  				1AE00D611831792100087DD7 /* FrameLoadState.h in Headers */,
  				5C121E842410208D00486F9B /* FrameTreeNodeData.h in Headers */,
@@ -20201,7 +19948,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				2D4AF0892044C3C4006C8817 /* FrontBoardServicesSPI.h in Headers */,
  				CD78E1151DB7D7ED0014A2DE /* FullscreenClient.h in Headers */,
  				CD19D2EA2046406F0017074A /* FullscreenTouchSecheuristic.h in Headers */,
-@@ -12887,6 +12950,7 @@
+@@ -12918,6 +12981,7 @@
  				410F0D4C2701EFF900F96DFC /* GPUProcessConnectionInitializationParameters.h in Headers */,
  				4614F13225DED875007006E7 /* GPUProcessConnectionParameters.h in Headers */,
  				2DA049B8180CCD0A00AAFA9E /* GraphicsLayerCARemote.h in Headers */,
@@ -20209,7 +19956,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				C0CE72AD1247E78D00BC0EC4 /* HandleMessage.h in Headers */,
  				1AC75A1B1B3368270056745B /* HangDetectionDisabler.h in Headers */,
  				57AC8F50217FEED90055438C /* HidConnection.h in Headers */,
-@@ -13031,6 +13095,7 @@
+@@ -13064,6 +13128,7 @@
  				413075AC1DE85F370039EC69 /* NetworkRTCMonitor.h in Headers */,
  				41DC45961E3D6E2200B11F51 /* NetworkRTCProvider.h in Headers */,
  				5C20CBA01BB1ECD800895BB1 /* NetworkSession.h in Headers */,
@@ -20217,7 +19964,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				532159551DBAE7290054AA3C /* NetworkSessionCocoa.h in Headers */,
  				417915B92257046F00D6F97E /* NetworkSocketChannel.h in Headers */,
  				93085DE026E5BCFD000EC6A7 /* NetworkStorageManager.h in Headers */,
-@@ -13096,6 +13161,7 @@
+@@ -13129,6 +13194,7 @@
  				BC1A7C581136E19C00FB7167 /* ProcessLauncher.h in Headers */,
  				463FD4821EB94EC000A2982C /* ProcessTerminationReason.h in Headers */,
  				86E67A251910B9D100004AB7 /* ProcessThrottler.h in Headers */,
@@ -20225,7 +19972,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				83048AE61ACA45DC0082C832 /* ProcessThrottlerClient.h in Headers */,
  				2D279E1926955768004B3EEB /* PrototypeToolsSPI.h in Headers */,
  				517B5F81275E97B6002DC22D /* PushAppBundle.h in Headers */,
-@@ -13120,6 +13186,7 @@
+@@ -13154,6 +13220,7 @@
  				CDAC20CA23FC2F750021DEE3 /* RemoteCDMInstanceSession.h in Headers */,
  				CDAC20C923FC2F750021DEE3 /* RemoteCDMInstanceSessionIdentifier.h in Headers */,
  				F451C0FE2703B263002BA03B /* RemoteDisplayListRecorderProxy.h in Headers */,
@@ -20233,7 +19980,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				2D47B56D1810714E003A3AEE /* RemoteLayerBackingStore.h in Headers */,
  				2DDF731518E95060004F5A66 /* RemoteLayerBackingStoreCollection.h in Headers */,
  				1AB16AEA164B3A8800290D62 /* RemoteLayerTreeContext.h in Headers */,
-@@ -13448,6 +13515,7 @@
+@@ -13486,6 +13553,7 @@
  				A543E30D215C8A9000279CD9 /* WebPageInspectorTargetController.h in Headers */,
  				A543E307215AD13700279CD9 /* WebPageInspectorTargetFrontendChannel.h in Headers */,
  				C0CE72A11247E71D00BC0EC4 /* WebPageMessages.h in Headers */,
@@ -20241,7 +19988,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				2D5C9D0619C81D8F00B3C5C1 /* WebPageOverlay.h in Headers */,
  				46C392292316EC4D008EED9B /* WebPageProxyIdentifier.h in Headers */,
  				BCBD3915125BB1A800D2C29F /* WebPageProxyMessages.h in Headers */,
-@@ -13583,6 +13651,7 @@
+@@ -13622,6 +13690,7 @@
  				BCD25F1711D6BDE100169B0E /* WKBundleFrame.h in Headers */,
  				BCF049E611FE20F600F86A58 /* WKBundleFramePrivate.h in Headers */,
  				BC49862F124D18C100D834E1 /* WKBundleHitTestResult.h in Headers */,
@@ -20249,7 +19996,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				BC204EF211C83EC8008F3375 /* WKBundleInitialize.h in Headers */,
  				65B86F1E12F11DE300B7DD8A /* WKBundleInspector.h in Headers */,
  				1A8B66B41BC45B010082DF77 /* WKBundleMac.h in Headers */,
-@@ -13636,6 +13705,7 @@
+@@ -13675,6 +13744,7 @@
  				5C795D71229F3757003FF1C4 /* WKContextMenuElementInfoPrivate.h in Headers */,
  				51A555F6128C6C47009ABCEC /* WKContextMenuItem.h in Headers */,
  				51A55601128C6D92009ABCEC /* WKContextMenuItemTypes.h in Headers */,
@@ -20257,7 +20004,7 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				A1EA02381DABFF7E0096021F /* WKContextMenuListener.h in Headers */,
  				BCC938E11180DE440085E5FE /* WKContextPrivate.h in Headers */,
  				9FB5F395169E6A80002C25BF /* WKContextPrivateMac.h in Headers */,
-@@ -13792,6 +13862,7 @@
+@@ -13831,6 +13901,7 @@
  				1AB8A1F818400BB800E9AE69 /* WKPageContextMenuClient.h in Headers */,
  				8372DB251A674C8F00C697C5 /* WKPageDiagnosticLoggingClient.h in Headers */,
  				1AB8A1F418400B8F00E9AE69 /* WKPageFindClient.h in Headers */,
@@ -20265,41 +20012,34 @@ index fbf4879e8cc363ace8aadb131758e171bf544b7a..cab8962206072d4d747cca16c50ade83
  				1AB8A1F618400B9D00E9AE69 /* WKPageFindMatchesClient.h in Headers */,
  				1AB8A1F018400B0000E9AE69 /* WKPageFormClient.h in Headers */,
  				BC7B633712A45ABA00D174A4 /* WKPageGroup.h in Headers */,
-@@ -15182,6 +15253,8 @@
+@@ -15431,6 +15502,8 @@
  				C1A152D724E5A29A00978C8B /* HandleXPCEndpointMessages.mm in Sources */,
  				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
  				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
 +				D7EB04E72372A73B00F744CE /* InspectorPlaywrightAgentClientMac.mm in Sources */,
 +				D79902B2236E9404005D6F7E /* InspectorTargetProxyMac.mm in Sources */,
- 				9BF5EC642541145600984E77 /* JSIPCBinding.cpp in Sources */,
  				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
  				C1710CF724AA643200D7C112 /* LaunchServicesDatabaseObserver.mm in Sources */,
-@@ -15201,6 +15274,7 @@
- 				517B5F84275E97B6002DC22D /* MockAppBundleForTesting.mm in Sources */,
- 				517B5F86275E97B6002DC22D /* MockAppBundleRegistry.mm in Sources */,
- 				2D92A77A212B6A6100F493FD /* Module.cpp in Sources */,
-+				D79902B1236E9404005D6F7E /* WebPageInspectorEmulationAgentMac.mm in Sources */,
- 				57B826452304F14000B72EB0 /* NearFieldSoftLink.mm in Sources */,
- 				C1C1B30F2540F50D00D9100B /* NetworkConnectionToWebProcessMac.mm in Sources */,
- 				51DD9F2816367DA2001578E9 /* NetworkConnectionToWebProcessMessageReceiver.cpp in Sources */,
-@@ -15469,6 +15543,7 @@
- 				1CAECB6527465AE400AB78D0 /* UnifiedSource109.cpp in Sources */,
- 				1CAECB6827465AE400AB78D0 /* UnifiedSource110.cpp in Sources */,
- 				1CAECB6627465AE400AB78D0 /* UnifiedSource111.cpp in Sources */,
-+				BF2C49ED7AD83CB7BC93CC92 /* UnifiedSource112.cpp in Sources */,
+ 				2984F588164BA095004BC0C6 /* LegacyCustomProtocolManagerMessageReceiver.cpp in Sources */,
+@@ -15704,6 +15777,7 @@
+ 				3CAECB6627465AE400AB78D0 /* UnifiedSource113.cpp in Sources */,
+ 				4CAECB6627465AE400AB78D0 /* UnifiedSource114.cpp in Sources */,
+ 				5CAECB6627465AE400AB78D0 /* UnifiedSource115.cpp in Sources */,
++				BF2C49ED7AD83CB7BC93CC92 /* UnifiedSource116.cpp in Sources */,
  				E38A1FC023A551BF00D2374F /* UserInterfaceIdiom.mm in Sources */,
  				CD491B0D1E732E4D00009066 /* UserMediaCaptureManagerMessageReceiver.cpp in Sources */,
  				CD491B171E73525500009066 /* UserMediaCaptureManagerProxyMessageReceiver.cpp in Sources */,
-@@ -15522,6 +15597,7 @@
- 				2D92A78C212B6AB100F493FD /* WebMouseEvent.cpp in Sources */,
+@@ -15752,6 +15826,8 @@
+ 				51F060E11654318500F3282F /* WebMDNSRegisterMessageReceiver.cpp in Sources */,
  				31BA924D148831260062EDB5 /* WebNotificationManagerMessageReceiver.cpp in Sources */,
  				2DF6FE52212E110900469030 /* WebPage.cpp in Sources */,
++				D79902B1236E9404005D6F7E /* WebPageInspectorEmulationAgentMac.mm in Sources */,
 +				D79902B3236E9404005D6F7E /* WebPageInspectorInputAgentMac.mm in Sources */,
  				C0CE72A01247E71D00BC0EC4 /* WebPageMessageReceiver.cpp in Sources */,
  				BCBD3914125BB1A800D2C29F /* WebPageProxyMessageReceiver.cpp in Sources */,
  				7CE9CE101FA0767A000177DE /* WebPageUpdatePreferences.cpp in Sources */,
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
-index ec06a52d082fb54c3a128c202cf9fa4bc1f5b393..984702339cc8af73d77058b542a079a7bc4279af 100644
+index c3df153e0e6a27fb670417003a34d30b81c55c29..e7088b465d73f9846393d640d49b457d8348c57b 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 @@ -232,6 +232,11 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
@@ -20332,7 +20072,7 @@ index ec06a52d082fb54c3a128c202cf9fa4bc1f5b393..984702339cc8af73d77058b542a079a7
      loadParameters.identifier = identifier;
      loadParameters.webPageProxyID = trackingParameters.webPageProxyID;
      loadParameters.webPageID = trackingParameters.pageID;
-@@ -391,14 +396,11 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -392,14 +397,11 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
  
      if (loadParameters.options.mode != FetchOptions::Mode::Navigate) {
          ASSERT(loadParameters.sourceOrigin);
@@ -20350,7 +20090,7 @@ index ec06a52d082fb54c3a128c202cf9fa4bc1f5b393..984702339cc8af73d77058b542a079a7
  
      loadParameters.isMainFrameNavigation = resourceLoader.frame() && resourceLoader.frame()->isMainFrame() && resourceLoader.options().mode == FetchOptions::Mode::Navigate;
      if (loadParameters.isMainFrameNavigation && document)
-@@ -430,6 +432,17 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -431,6 +433,17 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
      }
  
      ASSERT((loadParameters.webPageID && loadParameters.webFrameID) || loadParameters.clientCredentialPolicy == ClientCredentialPolicy::CannotAskClientForCredentials);
@@ -20368,7 +20108,7 @@ index ec06a52d082fb54c3a128c202cf9fa4bc1f5b393..984702339cc8af73d77058b542a079a7
  
      std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
      if (loadParameters.isMainFrameNavigation)
-@@ -444,7 +457,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -445,7 +458,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
      }
  
      auto loader = WebResourceLoader::create(resourceLoader, trackingParameters);
@@ -20377,7 +20117,7 @@ index ec06a52d082fb54c3a128c202cf9fa4bc1f5b393..984702339cc8af73d77058b542a079a7
  }
  
  void WebLoaderStrategy::scheduleInternallyFailedLoad(WebCore::ResourceLoader& resourceLoader)
-@@ -850,7 +863,7 @@ void WebLoaderStrategy::didFinishPreconnection(WebCore::ResourceLoaderIdentifier
+@@ -852,7 +865,7 @@ void WebLoaderStrategy::didFinishPreconnection(WebCore::ResourceLoaderIdentifier
  
  bool WebLoaderStrategy::isOnLine() const
  {
@@ -20386,7 +20126,7 @@ index ec06a52d082fb54c3a128c202cf9fa4bc1f5b393..984702339cc8af73d77058b542a079a7
  }
  
  void WebLoaderStrategy::addOnlineStateChangeListener(Function<void(bool)>&& listener)
-@@ -870,6 +883,11 @@ void WebLoaderStrategy::isResourceLoadFinished(CachedResource& resource, Complet
+@@ -872,6 +885,11 @@ void WebLoaderStrategy::isResourceLoadFinished(CachedResource& resource, Complet
  
  void WebLoaderStrategy::setOnLineState(bool isOnLine)
  {
@@ -20398,7 +20138,7 @@ index ec06a52d082fb54c3a128c202cf9fa4bc1f5b393..984702339cc8af73d77058b542a079a7
      if (m_isOnLine == isOnLine)
          return;
  
-@@ -878,6 +896,12 @@ void WebLoaderStrategy::setOnLineState(bool isOnLine)
+@@ -880,6 +898,12 @@ void WebLoaderStrategy::setOnLineState(bool isOnLine)
          listener(isOnLine);
  }
  
@@ -20442,7 +20182,7 @@ index 2290d987c36f68245b08fb2b86319d4d5a68e4a3..f22b3a7c855918b11582dd1ea9be00b2
  
  } // namespace WebKit
 diff --git a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
-index 259449423855fed3aaaab414819f8951a3b8b7ff..6ba9678f50190492ef5140d0793582a8017d97fc 100644
+index 310fca7875c32c3cd7478db64f59ac2cf5016392..726e42d3bbf42c1df366cda2b69294da16d29fee 100644
 --- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
 @@ -163,9 +163,6 @@ void WebResourceLoader::didReceiveResponse(const ResourceResponse& response, boo
@@ -20478,7 +20218,7 @@ index e00c722c2be5d505243d45f46001839d4eb8a977..33c0832cde6c292230397a13e70d90fb
  
              auto permissionHandlers = m_requestsPerOrigin.take(securityOrigin);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
-index 0b635ef5a182002773308de20fcf1714201cc30b..3466dbe5e3e7e5bb27b018e803fdcc0f840b85f2 100644
+index c7cf5875c943b79192aebd28623b2b1bc747dcc5..c25c8eaeade583234d2e5853f6f67482f7a7c792 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 @@ -417,6 +417,8 @@ void WebChromeClient::setResizable(bool resizable)
@@ -20532,7 +20272,7 @@ index 2eb0886f13ed035a53b8eaa60605de4dfe53fbe3..c46393209cb4f80704bbc9268fad4371
  {
  }
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
-index 4bdbbccd3fbc620e0754105cea09eddf05120b6b..f2f2c6eddfc6791647fcd197247197633f59a9dc 100644
+index 14a083ca207a9063cf80b1e7e9670a487cf4d399..bac00a81f00ebef2461e040cc6b3e9c06a03fa37 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 @@ -1574,13 +1574,6 @@ void WebFrameLoaderClient::transitionToCommittedForNewPage()
@@ -20550,7 +20290,7 @@ index 4bdbbccd3fbc620e0754105cea09eddf05120b6b..f2f2c6eddfc6791647fcd19724719763
  
  void WebFrameLoaderClient::didRestoreFromBackForwardCache()
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
-index a64c6a8b3c695e173364336bcb0f68dbdd9c2d21..041f428b297d492163b99b1ed1418879a17d13b5 100644
+index e1e0e6112a2dedc3b8bb63098535376ef43ad514..66986b22a739669ff5075e26e7958ebb2b93ed41 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 @@ -127,7 +127,8 @@ static WebCore::CachedImage* cachedImage(Element& element)
@@ -20912,7 +20652,7 @@ index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4
      uint64_t m_navigationID;
  };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index 4ad677a3d06b2bc1309eb95ef645d8b6fb567bfe..f33c2b733545410500c4baa570f409fda89d1bfb 100644
+index 942edc623a4e653bb188aee050644a3f4a032e89..1c9c32505d7c23b7e2754366b4ad49aa153af9a7 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 @@ -920,6 +920,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
@@ -21155,7 +20895,7 @@ index 4ad677a3d06b2bc1309eb95ef645d8b6fb567bfe..f33c2b733545410500c4baa570f409fd
  }
  
  void WebPage::setIsTakingSnapshotsForApplicationSuspension(bool isTakingSnapshotsForApplicationSuspension)
-@@ -4453,7 +4566,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
+@@ -4464,7 +4577,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
  
  #if ENABLE(DRAG_SUPPORT)
  
@@ -21164,7 +20904,7 @@ index 4ad677a3d06b2bc1309eb95ef645d8b6fb567bfe..f33c2b733545410500c4baa570f409fd
  void WebPage::performDragControllerAction(DragControllerAction action, const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation> draggingSourceOperationMask, SelectionData&& selectionData, OptionSet<DragApplicationFlags> flags)
  {
      if (!m_page) {
-@@ -6778,6 +6891,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
+@@ -6789,6 +6902,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
              WebsitePoliciesData::applyToDocumentLoader(WTFMove(*m_pendingWebsitePolicies), documentLoader);
              m_pendingWebsitePolicies = std::nullopt;
          }
@@ -21175,7 +20915,7 @@ index 4ad677a3d06b2bc1309eb95ef645d8b6fb567bfe..f33c2b733545410500c4baa570f409fd
  
      return documentLoader;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.h b/Source/WebKit/WebProcess/WebPage/WebPage.h
-index a5c42b32cd892fdf586f85e291643f4e71976190..d3065707ecbe78679556f035f5486c2611032fad 100644
+index a94b5b9d7fe32f24a86daaad44842b0cdd0aeb2f..e67aa04b6ed080ac0c07f12f78f9eed49cf05cac 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
 @@ -122,6 +122,10 @@ typedef struct _AtkObject AtkObject;
@@ -21189,7 +20929,7 @@ index a5c42b32cd892fdf586f85e291643f4e71976190..d3065707ecbe78679556f035f5486c26
  #if PLATFORM(GTK) || PLATFORM(WPE)
  #include "InputMethodState.h"
  #endif
-@@ -982,11 +986,11 @@ public:
+@@ -986,11 +990,11 @@ public:
      void clearSelection();
      void restoreSelectionInFocusedEditableElement();
  
@@ -21203,7 +20943,7 @@ index a5c42b32cd892fdf586f85e291643f4e71976190..d3065707ecbe78679556f035f5486c26
      void performDragControllerAction(DragControllerAction, const WebCore::DragData&, SandboxExtension::Handle&&, Vector<SandboxExtension::Handle>&&);
  #endif
  
-@@ -1000,6 +1004,9 @@ public:
+@@ -1004,6 +1008,9 @@ public:
      void didStartDrag();
      void dragCancelled();
      OptionSet<WebCore::DragSourceAction> allowedDragSourceActions() const { return m_allowedDragSourceActions; }
@@ -21213,7 +20953,7 @@ index a5c42b32cd892fdf586f85e291643f4e71976190..d3065707ecbe78679556f035f5486c26
  #endif
  
      void beginPrinting(WebCore::FrameIdentifier, const PrintInfo&);
-@@ -1243,6 +1250,7 @@ public:
+@@ -1240,6 +1247,7 @@ public:
      void connectInspector(const String& targetId, Inspector::FrontendChannel::ConnectionType);
      void disconnectInspector(const String& targetId);
      void sendMessageToTargetBackend(const String& targetId, const String& message);
@@ -21221,7 +20961,7 @@ index a5c42b32cd892fdf586f85e291643f4e71976190..d3065707ecbe78679556f035f5486c26
  
      void insertNewlineInQuotedContent();
  
-@@ -1601,6 +1609,7 @@ private:
+@@ -1598,6 +1606,7 @@ private:
      // Actions
      void tryClose(CompletionHandler<void(bool)>&&);
      void platformDidReceiveLoadParameters(const LoadParameters&);
@@ -21229,7 +20969,7 @@ index a5c42b32cd892fdf586f85e291643f4e71976190..d3065707ecbe78679556f035f5486c26
      void loadRequest(LoadParameters&&);
      NO_RETURN void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
      void loadData(LoadParameters&&);
-@@ -1638,6 +1647,7 @@ private:
+@@ -1635,6 +1644,7 @@ private:
      void updatePotentialTapSecurityOrigin(const WebTouchEvent&, bool wasHandled);
  #elif ENABLE(TOUCH_EVENTS)
      void touchEvent(const WebTouchEvent&);
@@ -21237,7 +20977,7 @@ index a5c42b32cd892fdf586f85e291643f4e71976190..d3065707ecbe78679556f035f5486c26
  #endif
  
      void cancelPointer(WebCore::PointerID, const WebCore::IntPoint&);
-@@ -1762,9 +1772,7 @@ private:
+@@ -1759,9 +1769,7 @@ private:
      void findRectsForStringMatches(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount, CompletionHandler<void(Vector<WebCore::FloatRect>&&)>&&);
      void hideFindIndicator();
  
@@ -21247,7 +20987,7 @@ index a5c42b32cd892fdf586f85e291643f4e71976190..d3065707ecbe78679556f035f5486c26
  
      void didChangeSelectedIndexForActivePopupMenu(int32_t newIndex);
      void setTextForActivePopupMenu(int32_t index);
-@@ -2300,6 +2308,7 @@ private:
+@@ -2294,6 +2302,7 @@ private:
      UserActivity m_userActivity;
  
      uint64_t m_pendingNavigationID { 0 };
@@ -21256,7 +20996,7 @@ index a5c42b32cd892fdf586f85e291643f4e71976190..d3065707ecbe78679556f035f5486c26
  
      bool m_mainFrameProgressCompleted { false };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-index 68f91cd0426eb4c0259fb7cd75f3f5b8fe971593..d1bc0befd4a7be9f3839991b519be6582204f469 100644
+index b27229471eae86ee5981983dd57b5e7a8291cd4b..6eba477486aa9289d8ac9ae0e918ff46104fd888 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 @@ -137,6 +137,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
@@ -21308,10 +21048,10 @@ index 68f91cd0426eb4c0259fb7cd75f3f5b8fe971593..d1bc0befd4a7be9f3839991b519be658
      RequestDragStart(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
      RequestAdditionalItemsForDragSession(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
 diff --git a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
-index 60f84a45c38035f2dce925cbee2c31992e64032f..102ab944141a6b6c2685d50aa56dc555fbc1bca4 100644
+index b1ee013e8b0f53b0d7c5d8e117093cbd01adb5a9..335e0802554a1391faba3a5846d2110e13b9e910 100644
 --- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
 +++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
-@@ -842,21 +842,37 @@ String WebPage::platformUserAgent(const URL&) const
+@@ -834,21 +834,37 @@ String WebPage::platformUserAgent(const URL&) const
  
  bool WebPage::hoverSupportedByPrimaryPointingDevice() const
  {
@@ -21400,10 +21140,10 @@ index afad4f9b13ab16b092525a84baaed34933c8e51c..c432676686dae42905ef45dfd4957f95
  }
  
 diff --git a/Source/WebKit/WebProcess/WebProcess.cpp b/Source/WebKit/WebProcess/WebProcess.cpp
-index 105bc6ff8a245ffc10fd487139316c48acf2b005..81de336cb0ee6407f78c3eb2fbdc77baea2ccee0 100644
+index fa993287cfb6d0834de919d18ddde8902ba9466c..9ae38122ec35b93b093302fb8f130b7a96b0b574 100644
 --- a/Source/WebKit/WebProcess/WebProcess.cpp
 +++ b/Source/WebKit/WebProcess/WebProcess.cpp
-@@ -89,6 +89,7 @@
+@@ -88,6 +88,7 @@
  #include "WebsiteData.h"
  #include "WebsiteDataStoreParameters.h"
  #include "WebsiteDataType.h"
@@ -21411,7 +21151,7 @@ index 105bc6ff8a245ffc10fd487139316c48acf2b005..81de336cb0ee6407f78c3eb2fbdc77ba
  #include <JavaScriptCore/JSLock.h>
  #include <JavaScriptCore/MemoryStatistics.h>
  #include <JavaScriptCore/WasmFaultSignalHandler.h>
-@@ -352,6 +353,8 @@ void WebProcess::initializeProcess(const AuxiliaryProcessInitializationParameter
+@@ -351,6 +352,8 @@ void WebProcess::initializeProcess(const AuxiliaryProcessInitializationParameter
      
      platformInitializeProcess(parameters);
      updateCPULimit();
@@ -21436,7 +21176,7 @@ index 8987c3964a9308f2454759de7f8972215a3ae416..bcac0afeb94ed8123d1f9fb0b932c849
              SetProcessDPIAware();
          return true;
 diff --git a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-index 838e413381a8075a3d62459455267a5bbb55a991..e179a07490cc8fd579f219ff7ebb0ed5684e1353 100644
+index 28d875929ccacdb9a1388a826b2fd5ecf46eccd9..ada055ddcc2c659ba96efbe2739e1c9d8f43ab9f 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 @@ -4168,7 +4168,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
@@ -21449,10 +21189,10 @@ index 838e413381a8075a3d62459455267a5bbb55a991..e179a07490cc8fd579f219ff7ebb0ed5
  - (void)touch:(WebEvent *)event
  {
 diff --git a/Source/WebKitLegacy/mac/WebView/WebView.mm b/Source/WebKitLegacy/mac/WebView/WebView.mm
-index 56642c222d6bc543af9e759b63932aa6ed838684..bfab1bc05b34ca5a2ddc283098c16229a279a679 100644
+index 2baab1a34c19b6a2f14371f633d0350084985c0d..ac0a51a3fde5d91510364df122861ccf611d85d4 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
-@@ -4058,7 +4058,7 @@ IGNORE_WARNINGS_END
+@@ -4057,7 +4057,7 @@ IGNORE_WARNINGS_END
  }
  #endif // PLATFORM(IOS_FAMILY)
  
@@ -21461,7 +21201,7 @@ index 56642c222d6bc543af9e759b63932aa6ed838684..bfab1bc05b34ca5a2ddc283098c16229
  
  - (NSArray *)_touchEventRegions
  {
-@@ -4100,7 +4100,7 @@ IGNORE_WARNINGS_END
+@@ -4099,7 +4099,7 @@ IGNORE_WARNINGS_END
      }).autorelease();
  }
  
@@ -21995,7 +21735,7 @@ index 9e7863b61b3e9db76e04e14f45116684dae44e37..fb47d231744d578bcbef125df9011a80
  
      return exitAfterLoad && webProcessCrashed ? 1 : 0;
 diff --git a/Tools/MiniBrowser/wpe/main.cpp b/Tools/MiniBrowser/wpe/main.cpp
-index e01baba8002a4f6478e681f15aadaa1880e0214b..87fab30d048a6209ccc9b1c0f4fbd3f04f8a2d36 100644
+index 9af64b2e601d8e77a8c036ab409dcacdf4e99eee..34a0e76b728e70bd582a90cb8297996a4ddda678 100644
 --- a/Tools/MiniBrowser/wpe/main.cpp
 +++ b/Tools/MiniBrowser/wpe/main.cpp
 @@ -41,6 +41,9 @@ static gboolean headlessMode;
@@ -22258,22 +21998,22 @@ index 6d570521e0952e78ccf73eb01a15f7937a013a78..3b5013eb982a68741ef2be52842b56ef
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
 diff --git a/Tools/WebKitTestRunner/PlatformWPE.cmake b/Tools/WebKitTestRunner/PlatformWPE.cmake
-index b0f26645ea360cc7e55afbfbe2ceb4e5791a0fb7..e5401df8302bb7b1950d1c92caf9ae5851d9c8a4 100644
+index 6d2fa822376c3c230afcd04ce86e26033c5c2e80..47693c2373e8953a02512a4db8cbf23b7eac91f0 100644
 --- a/Tools/WebKitTestRunner/PlatformWPE.cmake
 +++ b/Tools/WebKitTestRunner/PlatformWPE.cmake
-@@ -31,6 +31,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
+@@ -30,6 +30,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
      ${WPEBACKEND_FDO_LIBRARIES}
      Cairo::Cairo
-     WPEToolingBackends
+     WebKit::WPEToolingBackends
 +    stdc++fs
  )
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
 diff --git a/Tools/WebKitTestRunner/TestController.cpp b/Tools/WebKitTestRunner/TestController.cpp
-index ed2802fb1e766dc5de67c44d157661632c3931a3..3f1a19a33531ee5546eec0e9615bdffe0c040700 100644
+index 21a4736d9b4614ff81d4466c2bf2fc51e75c8b15..ca4e89105880a3dcda53f15a1039d3de55b1cbf4 100644
 --- a/Tools/WebKitTestRunner/TestController.cpp
 +++ b/Tools/WebKitTestRunner/TestController.cpp
-@@ -805,6 +805,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
+@@ -808,6 +808,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
          0, // requestStorageAccessConfirm
          shouldAllowDeviceOrientationAndMotionAccess,
          runWebAuthenticationPanel,

--- a/tests/page/elementhandle-bounding-box.spec.ts
+++ b/tests/page/elementhandle-bounding-box.spec.ts
@@ -39,7 +39,6 @@ it('should handle nested frames', async ({ page, server }) => {
 });
 
 it('should get frame box', async ({ page, browserName }) => {
-  it.fail(browserName === 'webkit', 'https://github.com/microsoft/playwright/issues/10977');
   await page.setViewportSize({ width: 200, height: 200 });
   await page.setContent(`<style>
   body {


### PR DESCRIPTION
Rebase `browser_patches/webkit/patches/bootstrap.diff` to [r287382](https://trac.webkit.org/changeset/287382/webkit)

  * [3-way diff](https://github.com/dpino/WebKit/commit/6eb48579cc4fcc8a3a1704ba26508ac44ba51c6e)
  * [Resolve conflicts](https://github.com/dpino/WebKit/commit/71e92ec446b0daf7099bebd7c6b04f6b0765fc22)
  * [Fix compilation errors](https://github.com/dpino/WebKit/commit/9b9f08508d41757a52f85cb694325a82aa4aa707)
  * [Remove methods 'InspectorPlaywrightAgent::getLocalStorageData' and 'InspectorPlaywrightAgent::setLocalStorageData' as they're not being used](https://github.com/dpino/WebKit/commit/e9588d4938a1d5c24f89667e9c675d72802b9fc0)

After [r286936](https://trac.webkit.org/changeset/286936/webkit), there was a compilation error in methods `NetworkProcess::getLocalStorageData` and `NetworkProcess::setLocalStorageData`. These methods needed to be reimplemented. However, I obvserved these methods are not actually used in the codebase neither in any test, so I opted for removing them.