### PR TITLE
devops: fix docker tests

### DIFF
--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -31,11 +31,11 @@ jobs:
         include:
         - os_name: "Ubuntu 18.04"
           tag: bionic
-          user: pwuser
+          user: root
           arch: amd64
         - os_name: "Ubuntu 20.04"
           tag: focal
-          user: root
+          user: pwuser
           arch: arm64
     steps:
     - uses: actions/checkout@v2
@@ -85,12 +85,12 @@ jobs:
     # Chromium crashes  when run on x86_64 host machine with qemu emulating aarch64
     - name: '[amd64 only] Run "npm run ctest" inside docker'
       if: matrix.arch == 'amd64'
-      run: docker exec --workdir /home/pwuser/playwright docker-tests xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ctest -- --grep '#smoke' --output chromium-test-results
+      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ctest -- --grep '#smoke' --output chromium-test-results
     - name: Run "npm run ftest" inside docker
-      run: docker exec --workdir /home/pwuser/playwright docker-tests xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep '#smoke' --output firefox-test-results
+      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep '#smoke' --output firefox-test-results
       if: always()
     - name: Run "npm run wtest" inside docker
-      run: docker exec --workdir /home/pwuser/playwright docker-tests xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep '#smoke' --output webkit-test-results
+      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep '#smoke' --output webkit-test-results
       if: always()
     - name: Upload Flakiness dashboard
       if: always()

--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -85,12 +85,12 @@ jobs:
     # Chromium crashes  when run on x86_64 host machine with qemu emulating aarch64
     - name: '[amd64 only] Run "npm run ctest" inside docker'
       if: matrix.arch == 'amd64'
-      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ctest -- --grep '#smoke' --output chromium-test-results
+      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ctest -- --grep "#smoke" --output chromium-test-results
     - name: Run "npm run ftest" inside docker
-      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep '#smoke' --output firefox-test-results
+      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep "#smoke" --output firefox-test-results
       if: always()
     - name: Run "npm run wtest" inside docker
-      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep '#smoke' --output webkit-test-results
+      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep "#smoke" --output webkit-test-results
       if: always()
     - name: Upload Flakiness dashboard
       if: always()

--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -66,14 +66,13 @@ jobs:
           -d \
           -t \
           playwright:localbuild /bin/bash
-    - name: Clone inside docker
+    - name: Copy repository inside docker container
       run: |
-        docker exec docker-tests /bin/bash -c '
-          git clone ${{ github.repository }} playwright
-          cd playwright
-          git checkout ${{ github.sha }}
-          git show
-        '
+        # Note: we cannot do explicit `git clone` inside container because it requires some smarts to decide if github.sha or
+        # github.ref should be used for checkout.
+        # The actions/checkout action already handled this complexity for us, so we'll just copy checkout.
+        docker cp . docker-tests:/home/pwuser/playwright
+        docker exec --user root docker-tests chown -R ${{ matrix.user }} /home/pwuser/playwright
     - name: Run "npm ci" inside docker
       run: docker exec --workdir /home/pwuser/playwright docker-tests npm ci
     - name: Run "npm run build" inside docker

--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   test_linux_docker:
     name: "Docker ${{ matrix.os_name}} ${{ matrix.arch}} ${{ matrix.user }} Tests"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
     strategy:
       fail-fast: false
@@ -51,18 +51,6 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: ./utils/docker/build.sh --${{ matrix.arch }} ${{ matrix.tag }} playwright:localbuild
-    - name: Freeup Space
-      run: |
-        pwd
-        df -h
-        # Based on the official advice:
-        # https://github.com/actions/virtual-environments/issues/2840#issuecomment-790492173
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf "/usr/local/share/boost"
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-        df -h
-
     - name: Launch container
       run: |
         docker run \
@@ -91,11 +79,19 @@ jobs:
     # Test channel installation for root user.
     # Note #1: as of Dec 2021, pwuser would require manual password for root since we don't ship passwordless sudo (and any sudo, actually) in our containers.
     # Note #2: neither chrome nor msedge are shipped for arm64.
-    - name: Test installing Chrome & MSEdge
+    - name: '[amd64 only] Test installing Chrome & MSEdge'
       if: matrix.user == 'root' && matrix.arch == 'amd64'
       run: docker exec --workdir /home/pwuser/playwright docker-tests docker-tests -test npx playwright install chrome msedge
-    - name: Run "npm run test" inside docker
-      run: docker exec --workdir /home/pwuser/playwright docker-tests xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run test
+    # Chromium crashes  when run on x86_64 host machine with qemu emulating aarch64
+    - name: '[amd64 only] Run "npm run ctest" inside docker'
+      if: matrix.arch == 'amd64'
+      run: docker exec --workdir /home/pwuser/playwright docker-tests xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ctest -- --grep '#smoke' --output chromium-test-results
+    - name: Run "npm run ftest" inside docker
+      run: docker exec --workdir /home/pwuser/playwright docker-tests xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep '#smoke' --output firefox-test-results
+      if: always()
+    - name: Run "npm run wtest" inside docker
+      run: docker exec --workdir /home/pwuser/playwright docker-tests xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep '#smoke' --output webkit-test-results
+      if: always()
     - name: Upload Flakiness dashboard
       if: always()
       run: |
@@ -115,7 +111,11 @@ jobs:
             # Azure-CLI can only be installed via PIP3 inside ubuntu 20.04 arm64,
             # see https://github.com/Azure/azure-cli/issues/7368
             pip install azure-cli
-            ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+            if [[ -d ./chromium-test-results ]]; then
+              ./utils/upload_flakiness_dashboard.sh ./chromium-test-results/report.json
+            fi
+            ./utils/upload_flakiness_dashboard.sh ./firefox-test-results/report.json
+            ./utils/upload_flakiness_dashboard.sh ./webkit-test-results/report.json
           '
     - name: Copy test results from container
       if: always()

--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -69,9 +69,9 @@ jobs:
     - name: Clone inside docker
       run: |
         docker exec docker-tests /bin/bash -c '
-          git clone https://github.com/microsoft/playwright
+          git clone ${{ github.repository }} playwright
           cd playwright
-          git checkout ${{ env.GITHUB_SHA }}
+          git checkout ${{ github.sha }}
           git show
         '
     - name: Run "npm ci" inside docker

--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -48,6 +48,8 @@ jobs:
       with:
         platforms: arm64
     - run: npm i -g npm@8
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm ci
     - run: npm run build
     - run: ./utils/docker/build.sh --${{ matrix.arch }} ${{ matrix.tag }} playwright:localbuild
@@ -81,16 +83,16 @@ jobs:
     # Note #2: neither chrome nor msedge are shipped for arm64.
     - name: '[amd64 only] Test installing Chrome & MSEdge'
       if: matrix.user == 'root' && matrix.arch == 'amd64'
-      run: docker exec --workdir /home/pwuser/playwright docker-tests docker-tests -test npx playwright install chrome msedge
+      run: docker exec --workdir /home/pwuser/playwright docker-tests npx playwright install chrome msedge
     # Chromium crashes  when run on x86_64 host machine with qemu emulating aarch64
     - name: '[amd64 only] Run "npm run ctest" inside docker'
       if: matrix.arch == 'amd64'
-      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ctest -- --grep "#smoke" --output chromium-test-results
+      run: docker exec --workdir /home/pwuser/playwright docker-tests xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ctest -- --grep "#smoke" --output chromium-test-results
     - name: Run "npm run ftest" inside docker
-      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep "#smoke" --output firefox-test-results
+      run: docker exec --workdir /home/pwuser/playwright docker-tests xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep "#smoke" --output firefox-test-results
       if: always()
     - name: Run "npm run wtest" inside docker
-      run: docker exec --workdir /home/pwuser/playwright docker-tests -- xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep "#smoke" --output webkit-test-results
+      run: docker exec --workdir /home/pwuser/playwright docker-tests xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run ftest -- --grep "#smoke" --output webkit-test-results
       if: always()
     - name: Upload Flakiness dashboard
       if: always()
@@ -102,6 +104,7 @@ jobs:
           --env GITHUB_REPOSITORY \
           --env GITHUB_REF \
           --env GITHUB_RUN_ID \
+          --user root \
           --workdir /home/pwuser/playwright docker-tests /bin/bash -c '
             if ! command -v pip3 >/dev/null; then
               apt-get update
@@ -111,21 +114,33 @@ jobs:
             # Azure-CLI can only be installed via PIP3 inside ubuntu 20.04 arm64,
             # see https://github.com/Azure/azure-cli/issues/7368
             pip install azure-cli
-            if [[ -d ./chromium-test-results ]]; then
-              ./utils/upload_flakiness_dashboard.sh ./chromium-test-results/report.json
-            fi
-            ./utils/upload_flakiness_dashboard.sh ./firefox-test-results/report.json
-            ./utils/upload_flakiness_dashboard.sh ./webkit-test-results/report.json
+
+            function upload_report() {
+              if [[ -d "./$1" ]]; then
+                ./utils/upload_flakiness_dashboard.sh "./$1/report.json"
+              fi
+            }
+            upload_report "chromium-test-results"
+            upload_report "firefox-test-results"
+            upload_report "webkit-test-results"
           '
     - name: Copy test results from container
       if: always()
-      run: docker cp docker-tests:/home/pwuser/playwright/test-results ./test-results
+      run: |
+        function copy_from_docker() {
+          if docker exec -it docker-tests /bin/bash -c "test -d /home/pwuser/playwright/$1"; then
+            docker cp "docker-tests:/home/pwuser/playwright/$1" "./$1"
+          fi
+        }
+        copy_from_docker "chromium-test-results"
+        copy_from_docker "firefox-test-results"
+        copy_from_docker "webkit-test-results"
     - name: Upload Github Artifacts
       if: ${{ always() }}
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: docker-ubuntu-${{ matrix.tag }}-${{ matrix.arch }}-${{ matrix.user }}-test-results
-        path: test-results
+        path: '*-test-results'
     - name: Stop container
       if: always()
       run: docker kill docker-tests

--- a/tests/beforeunload.spec.ts
+++ b/tests/beforeunload.spec.ts
@@ -52,7 +52,7 @@ it('should close page with beforeunload listener', async ({ context, server }) =
   await newPage.close();
 });
 
-it('should run beforeunload if asked for', async ({ context, server, browserName }) => {
+it('should run beforeunload if asked for #smoke', async ({ context, server, browserName }) => {
   const newPage = await context.newPage();
   await newPage.goto(server.PREFIX + '/beforeunload.html');
   // We have to interact with a page so that 'beforeunload' handlers

--- a/tests/browser.spec.ts
+++ b/tests/browser.spec.ts
@@ -16,7 +16,7 @@
 
 import { browserTest as test, expect } from './config/browserTest';
 
-test('should create new page', async function({ browser }) {
+test('should create new page #smoke', async function({ browser }) {
   const page1 = await browser.newPage();
   expect(browser.contexts().length).toBe(1);
 

--- a/tests/browsercontext-add-cookies.spec.ts
+++ b/tests/browsercontext-add-cookies.spec.ts
@@ -17,7 +17,7 @@
 
 import { contextTest as it, playwrightTest, expect } from './config/browserTest';
 
-it('should work', async ({ context, page, server }) => {
+it('should work #smoke', async ({ context, page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await context.addCookies([{
     url: server.EMPTY_PAGE,

--- a/tests/browsercontext-add-init-script.spec.ts
+++ b/tests/browsercontext-add-init-script.spec.ts
@@ -17,7 +17,7 @@
 
 import { contextTest as it, expect } from './config/browserTest';
 
-it('should work with browser context scripts', async ({ context, server }) => {
+it('should work with browser context scripts #smoke', async ({ context, server }) => {
   await context.addInitScript(() => window['temp'] = 123);
   const page = await context.newPage();
   await page.addInitScript(() => window['injected'] = window['temp']);

--- a/tests/browsercontext-base-url.spec.ts
+++ b/tests/browsercontext-base-url.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should construct a new URL when a baseURL in browser.newContext is passed to page.goto', async function({ browser, server }) {
+it('should construct a new URL when a baseURL in browser.newContext is passed to page.goto #smoke', async function({ browser, server }) {
   const context = await browser.newContext({
     baseURL: server.PREFIX,
   });

--- a/tests/browsercontext-basic.spec.ts
+++ b/tests/browsercontext-basic.spec.ts
@@ -18,7 +18,7 @@
 import { browserTest as it, expect } from './config/browserTest';
 import { attachFrame, verifyViewport } from './config/utils';
 
-it('should create new context', async function({ browser }) {
+it('should create new context #smoke', async function({ browser }) {
   expect(browser.contexts().length).toBe(0);
   const context = await browser.newContext();
   expect(browser.contexts().length).toBe(1);
@@ -41,7 +41,7 @@ it('window.open should use parent tab context', async function({ browser, server
   await context.close();
 });
 
-it('should isolate localStorage and cookies', async function({ browser, server }) {
+it('should isolate localStorage and cookies #smoke', async function({ browser, server }) {
   // Create two incognito contexts.
   const context1 = await browser.newContext();
   const context2 = await browser.newContext();

--- a/tests/browsercontext-cookies.spec.ts
+++ b/tests/browsercontext-cookies.spec.ts
@@ -21,7 +21,7 @@ it('should return no cookies in pristine browser context', async ({ context, pag
   expect(await context.cookies()).toEqual([]);
 });
 
-it('should get a cookie', async ({ context, page, server, browserName, browserMajorVersion }) => {
+it('should get a cookie #smoke', async ({ context, page, server, browserName, browserMajorVersion }) => {
   await page.goto(server.EMPTY_PAGE);
   const documentCookie = await page.evaluate(() => {
     document.cookie = 'username=John Doe';

--- a/tests/browsercontext-credentials.spec.ts
+++ b/tests/browsercontext-credentials.spec.ts
@@ -42,7 +42,7 @@ it('should work with setHTTPCredentials', async ({ browser, server, browserName,
   await context.close();
 });
 
-it('should work with correct credentials', async ({ browser, server }) => {
+it('should work with correct credentials #smoke', async ({ browser, server }) => {
   server.setAuth('/empty.html', 'user', 'pass');
   const context = await browser.newContext({
     httpCredentials: { username: 'user', password: 'pass' }

--- a/tests/browsercontext-csp.spec.ts
+++ b/tests/browsercontext-csp.spec.ts
@@ -18,7 +18,7 @@
 import { browserTest as it, expect } from './config/browserTest';
 import { attachFrame } from './config/utils';
 
-it('should bypass CSP meta tag', async ({ browser, server }) => {
+it('should bypass CSP meta tag #smoke', async ({ browser, server }) => {
   // Make sure CSP prohibits addScriptTag.
   {
     const context = await browser.newContext();

--- a/tests/browsercontext-device.spec.ts
+++ b/tests/browsercontext-device.spec.ts
@@ -20,7 +20,7 @@ import { browserTest as it, expect } from './config/browserTest';
 it.describe('device', () => {
   it.skip(({ browserName }) => browserName === 'firefox');
 
-  it('should work', async ({ playwright, browser, server }) => {
+  it('should work #smoke', async ({ playwright, browser, server }) => {
     const iPhone = playwright.devices['iPhone 6'];
     const context = await browser.newContext({ ...iPhone });
     const page = await context.newPage();

--- a/tests/browsercontext-dsf.spec.ts
+++ b/tests/browsercontext-dsf.spec.ts
@@ -16,7 +16,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should fetch lodpi assets', async ({ contextFactory, server }) => {
+it('should fetch lodpi assets #smoke', async ({ contextFactory, server }) => {
   const context = await contextFactory({
     deviceScaleFactor: 1
   });

--- a/tests/browsercontext-fetch.spec.ts
+++ b/tests/browsercontext-fetch.spec.ts
@@ -42,7 +42,7 @@ it.afterAll(() => {
   http.globalAgent = prevAgent;
 });
 
-it('get should work', async ({ context, server }) => {
+it('get should work #smoke', async ({ context, server }) => {
   const response = await context.request.get(server.PREFIX + '/simple.json');
   expect(response.url()).toBe(server.PREFIX + '/simple.json');
   expect(response.status()).toBe(200);

--- a/tests/browsercontext-locale.spec.ts
+++ b/tests/browsercontext-locale.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should affect accept-language header', async ({ browser, server }) => {
+it('should affect accept-language header #smoke', async ({ browser, server }) => {
   const context = await browser.newContext({ locale: 'fr-CH' });
   const page = await context.newPage();
   const [request] = await Promise.all([

--- a/tests/browsercontext-timezone-id.spec.ts
+++ b/tests/browsercontext-timezone-id.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should work', async ({ browser, browserName }) => {
+it('should work #smoke', async ({ browser, browserName }) => {
   const func = () => new Date(1479579154987).toString();
   {
     const context = await browser.newContext({ locale: 'en-US', timezoneId: 'America/Jamaica' });

--- a/tests/capabilities.spec.ts
+++ b/tests/capabilities.spec.ts
@@ -18,7 +18,7 @@ import os from 'os';
 import url from 'url';
 import { contextTest as it, expect } from './config/browserTest';
 
-it('SharedArrayBuffer should work', async function({ contextFactory, httpsServer, browserName }) {
+it('SharedArrayBuffer should work #smoke', async function({ contextFactory, httpsServer, browserName }) {
   it.fail(browserName === 'webkit', 'no shared array buffer on webkit');
   const context = await contextFactory({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
@@ -31,14 +31,14 @@ it('SharedArrayBuffer should work', async function({ contextFactory, httpsServer
   expect(await page.evaluate(() => typeof SharedArrayBuffer)).toBe('function');
 });
 
-it('Web Assembly should work', async function({ page, server, browserName, platform }) {
+it('Web Assembly should work #smoke', async function({ page, server, browserName, platform }) {
   it.fail(browserName === 'webkit' && platform === 'win32');
 
   await page.goto(server.PREFIX + '/wasm/table2.html');
   expect(await page.evaluate('loadTable()')).toBe('42, 83');
 });
 
-it('WebSocket should work', async ({ page, server }) => {
+it('WebSocket should work #smoke', async ({ page, server }) => {
   server.sendOnWebSocketConnection('incoming');
   const value = await page.evaluate(port => {
     let cb;
@@ -51,7 +51,7 @@ it('WebSocket should work', async ({ page, server }) => {
   expect(value).toBe('incoming');
 });
 
-it('should respect CSP', async ({ page, server }) => {
+it('should respect CSP #smoke', async ({ page, server }) => {
   server.setRoute('/empty.html', async (req, res) => {
     res.setHeader('Content-Security-Policy', `script-src 'unsafe-inline';`);
     res.end(`
@@ -65,7 +65,7 @@ it('should respect CSP', async ({ page, server }) => {
   expect(await page.evaluate(() => window['testStatus'])).toBe('SUCCESS');
 });
 
-it('should play video', async ({ page, asset, browserName, platform }) => {
+it('should play video #smoke', async ({ page, asset, browserName, platform }) => {
   // TODO: the test passes on Windows locally but fails on GitHub Action bot,
   // apparently due to a Media Pack issue in the Windows Server.
   // Also the test is very flaky on Linux WebKit.
@@ -83,7 +83,7 @@ it('should play video', async ({ page, asset, browserName, platform }) => {
   await page.$eval('video', v => v.pause());
 });
 
-it('should play audio', async ({ page, server, browserName, platform }) => {
+it('should play audio #smoke', async ({ page, server, browserName, platform }) => {
   it.fixme(browserName === 'firefox' && platform === 'win32', 'https://github.com/microsoft/playwright/issues/10887');
   it.fixme(browserName === 'firefox' && platform === 'linux', 'https://github.com/microsoft/playwright/issues/10887');
   it.fixme(browserName === 'webkit' && platform === 'win32', 'https://github.com/microsoft/playwright/issues/10892');
@@ -96,7 +96,7 @@ it('should play audio', async ({ page, server, browserName, platform }) => {
   expect(await page.$eval('audio', e => e.currentTime)).toBeGreaterThan(0.5);
 });
 
-it('should support webgl', async ({ page, browserName, headless }) => {
+it('should support webgl #smoke', async ({ page, browserName, headless }) => {
   it.fixme(browserName === 'firefox' && headless);
 
   const hasWebGL = await page.evaluate(() => {
@@ -106,7 +106,7 @@ it('should support webgl', async ({ page, browserName, headless }) => {
   expect(hasWebGL).toBe(true);
 });
 
-it('should support webgl 2', async ({ page, browserName, headless }) => {
+it('should support webgl 2 #smoke', async ({ page, browserName, headless }) => {
   it.skip(browserName === 'webkit', 'WebKit doesn\'t have webgl2 enabled yet upstream.');
   it.fixme(browserName === 'firefox' && headless);
   it.fixme(browserName === 'chromium' && !headless, 'chromium doesn\'t like webgl2 when running under xvfb');
@@ -118,7 +118,7 @@ it('should support webgl 2', async ({ page, browserName, headless }) => {
   expect(hasWebGL2).toBe(true);
 });
 
-it('should not crash on page with mp4', async ({ page, server, platform, browserName }) => {
+it('should not crash on page with mp4 #smoke', async ({ page, server, platform, browserName }) => {
   it.fixme(browserName === 'webkit' && platform === 'win32', 'https://github.com/microsoft/playwright/issues/11009, times out in setContent');
   it.fail(browserName === 'webkit' && platform === 'darwin' && parseInt(os.release(), 10) >= 21, 'https://github.com/microsoft/playwright/issues/11009');
   await page.setContent(`<video><source src="${server.PREFIX}/movie.mp4"/></video>`);

--- a/tests/defaultbrowsercontext-1.spec.ts
+++ b/tests/defaultbrowsercontext-1.spec.ts
@@ -19,7 +19,7 @@ import { playwrightTest as it, expect } from './config/browserTest';
 import { verifyViewport } from './config/utils';
 import fs from 'fs';
 
-it('context.cookies() should work', async ({ server, launchPersistent, browserName, browserMajorVersion }) => {
+it('context.cookies() should work #smoke', async ({ server, launchPersistent, browserName, browserMajorVersion }) => {
   const { page } = await launchPersistent();
   await page.goto(server.EMPTY_PAGE);
   const documentCookie = await page.evaluate(() => {

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -50,7 +50,7 @@ it.describe('download event', () => {
     });
   });
 
-  it('should report download when navigation turns into download', async ({ browser, server, browserName }) => {
+  it('should report download when navigation turns into download #smoke', async ({ browser, server, browserName }) => {
     const page = await browser.newPage();
     const [ download, responseOrError ] = await Promise.all([
       page.waitForEvent('download'),

--- a/tests/emulation-focus.spec.ts
+++ b/tests/emulation-focus.spec.ts
@@ -22,7 +22,7 @@ it('should think that it is focused by default', async ({ page }) => {
   expect(await page.evaluate('document.hasFocus()')).toBe(true);
 });
 
-it('should think that all pages are focused', async ({ page }) => {
+it('should think that all pages are focused #smoke', async ({ page }) => {
   const page2 = await page.context().newPage();
   expect(await page.evaluate('document.hasFocus()')).toBe(true);
   expect(await page2.evaluate('document.hasFocus()')).toBe(true);

--- a/tests/geolocation.spec.ts
+++ b/tests/geolocation.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should work', async ({ server, contextFactory }) => {
+it('should work #smoke', async ({ server, contextFactory }) => {
   const context = await contextFactory();
   const page = await context.newPage();
   await context.grantPermissions(['geolocation']);

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -40,7 +40,7 @@ it.afterAll(() => {
 });
 
 for (const method of ['fetch', 'delete', 'get', 'head', 'patch', 'post', 'put'] as const) {
-  it(`${method} should work`, async ({ playwright, server }) => {
+  it(`${method} should work #smoke`, async ({ playwright, server }) => {
     const request = await playwright.request.newContext();
     const response = await request[method](server.PREFIX + '/simple.json');
     expect(response.url()).toBe(server.PREFIX + '/simple.json');

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -242,7 +242,7 @@ it('should include secure set-cookies', async ({ contextFactory, httpsServer }, 
   expect(cookies[0]).toEqual({ name: 'name1', value: 'value1', secure: true });
 });
 
-it('should include content', async ({ contextFactory, server }, testInfo) => {
+it('should include content #smoke', async ({ contextFactory, server }, testInfo) => {
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
   await page.goto(server.PREFIX + '/har.html');
   const log = await getLog();

--- a/tests/headful.spec.ts
+++ b/tests/headful.spec.ts
@@ -16,7 +16,7 @@
 
 import { playwrightTest as it, expect } from './config/browserTest';
 
-it('should have default url when launching browser', async ({ browserType, createUserDataDir }) => {
+it('should have default url when launching browser #smoke', async ({ browserType, createUserDataDir }) => {
   const browserContext = await browserType.launchPersistentContext(await createUserDataDir(), { headless: false });
   const urls = browserContext.pages().map(page => page.url());
   expect(urls).toEqual(['about:blank']);

--- a/tests/ignorehttpserrors.spec.ts
+++ b/tests/ignorehttpserrors.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should work', async ({ browser, httpsServer }) => {
+it('should work #smoke', async ({ browser, httpsServer }) => {
   let error = null;
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();

--- a/tests/logger.spec.ts
+++ b/tests/logger.spec.ts
@@ -16,7 +16,7 @@
 
 import { playwrightTest as it, expect } from './config/browserTest';
 
-it('should log', async ({ browserType }) => {
+it('should log #smoke', async ({ browserType }) => {
   const log = [];
   const browser = await browserType.launch({ logger: {
     log: (name, severity, message) => log.push({ name, severity, message }),

--- a/tests/page/elementhandle-click.spec.ts
+++ b/tests/page/elementhandle-click.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({ page, server }) => {
+it('should work #smoke', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   const button = await page.$('button');
   await button.click();

--- a/tests/page/elementhandle-scroll-into-view.spec.ts
+++ b/tests/page/elementhandle-scroll-into-view.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({ page, server, isAndroid }) => {
+it('should work #smoke', async ({ page, server, isAndroid }) => {
   it.fixme(isAndroid);
 
   await page.goto(server.PREFIX + '/offscreenbuttons.html');

--- a/tests/page/frame-evaluate.spec.ts
+++ b/tests/page/frame-evaluate.spec.ts
@@ -28,7 +28,7 @@ it('should have different execution contexts', async ({ page, server }) => {
   expect(await page.frames()[1].evaluate(() => window['FOO'])).toBe('bar');
 });
 
-it('should have correct execution contexts', async ({ page, server }) => {
+it('should have correct execution contexts #smoke', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(page.frames().length).toBe(2);
   expect(await page.frames()[0].evaluate(() => document.body.textContent.trim())).toBe('');

--- a/tests/page/frame-frame-element.spec.ts
+++ b/tests/page/frame-frame-element.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import { attachFrame } from '../config/utils';
 
-it('should work', async ({ page, server }) => {
+it('should work #smoke', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const frame1 = await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   await attachFrame(page, 'frame2', server.EMPTY_PAGE);

--- a/tests/page/frame-goto.spec.ts
+++ b/tests/page/frame-goto.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import { attachFrame } from '../config/utils';
 
-it('should navigate subframes', async ({ page, server }) => {
+it('should navigate subframes #smoke', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(page.frames()[0].url()).toContain('/frames/one-frame.html');
   expect(page.frames()[1].url()).toContain('/frames/frame.html');

--- a/tests/page/frame-hierarchy.spec.ts
+++ b/tests/page/frame-hierarchy.spec.ts
@@ -35,7 +35,7 @@ function dumpFrames(frame: Frame, indentation: string = ''): string[] {
   return result;
 }
 
-it('should handle nested frames', async ({ page, server, isAndroid }) => {
+it('should handle nested frames #smoke', async ({ page, server, isAndroid }) => {
   it.skip(isAndroid, 'No cross-process on Android');
 
   await page.goto(server.PREFIX + '/frames/nested-frames.html');

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -19,7 +19,7 @@ import { test as it, expect } from './pageTest';
 import { globToRegex } from '../../packages/playwright-core/lib/client/clientHelper';
 import vm from 'vm';
 
-it('should work with navigation', async ({ page, server }) => {
+it('should work with navigation #smoke', async ({ page, server }) => {
   const requests = new Map();
   await page.route('**/*', route => {
     requests.set(route.request().url().split('/').pop(), route.request());

--- a/tests/page/jshandle-as-element.spec.ts
+++ b/tests/page/jshandle-as-element.spec.ts
@@ -17,7 +17,7 @@
 
 import { test, expect } from './pageTest';
 
-test('should work', async ({ page }) => {
+test('should work #smoke', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => document.body);
   const element = aHandle.asElement();
   expect(element).toBeTruthy();

--- a/tests/page/jshandle-evaluate.spec.ts
+++ b/tests/page/jshandle-evaluate.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work with function', async ({ page }) => {
+it('should work with function #smoke', async ({ page }) => {
   const windowHandle = await page.evaluateHandle(() => {
     window['foo'] = [1, 2];
     return window;

--- a/tests/page/jshandle-json-value.spec.ts
+++ b/tests/page/jshandle-json-value.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({ page }) => {
+it('should work #smoke', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => ({ foo: 'bar' }));
   const json = await aHandle.jsonValue();
   expect(json).toEqual({ foo: 'bar' });

--- a/tests/page/jshandle-properties.spec.ts
+++ b/tests/page/jshandle-properties.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import type { ElementHandle } from 'playwright-core';
 
-it('should work', async ({ page }) => {
+it('should work #smoke', async ({ page }) => {
   const aHandle = await page.evaluateHandle(() => ({
     one: 1,
     two: 2,

--- a/tests/page/jshandle-to-string.spec.ts
+++ b/tests/page/jshandle-to-string.spec.ts
@@ -39,7 +39,7 @@ it('should work for promises', async ({ page }) => {
   expect(bHandle.toString()).toBe('Promise');
 });
 
-it('should work with different subtypes', async ({ page, browserName }) => {
+it('should work with different subtypes #smoke', async ({ page, browserName }) => {
   expect((await page.evaluateHandle('(function(){})')).toString()).toContain('function');
   expect((await page.evaluateHandle('12')).toString()).toBe('12');
   expect((await page.evaluateHandle('true')).toString()).toBe('true');

--- a/tests/page/locator-click.spec.ts
+++ b/tests/page/locator-click.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({ page, server }) => {
+it('should work #smoke', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   const button = page.locator('button');
   await button.click();

--- a/tests/page/locator-element-handle.spec.ts
+++ b/tests/page/locator-element-handle.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should query existing element', async ({ page, server }) => {
+it('should query existing element #smoke', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/playground.html');
   await page.setContent('<html><body><div class="second"><div class="inner">A</div></div></body></html>');
   const html = page.locator('html');

--- a/tests/page/locator-evaluate.spec.ts
+++ b/tests/page/locator-evaluate.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({ page, server }) => {
+it('should work #smoke', async ({ page, server }) => {
   await page.setContent('<html><body><div class="tweet"><div class="like">100</div><div class="retweets">10</div></div></body></html>');
   const tweet = page.locator('.tweet .like');
   const content = await tweet.evaluate(node => (node as HTMLElement).innerText);

--- a/tests/page/locator-frame.spec.ts
+++ b/tests/page/locator-frame.spec.ts
@@ -65,7 +65,7 @@ async function routeAmbiguous(page: Page) {
   });
 }
 
-it('should work for iframe', async ({ page, server }) => {
+it('should work for iframe #smoke', async ({ page, server }) => {
   await routeIframe(page);
   await page.goto(server.EMPTY_PAGE);
   const button = page.frameLocator('iframe').locator('button');

--- a/tests/page/locator-misc-1.spec.ts
+++ b/tests/page/locator-misc-1.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import path from 'path';
 
-it('should hover', async ({ page, server }) => {
+it('should hover #smoke', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/scrollable.html');
   const button = page.locator('#button-6');
   await button.hover();

--- a/tests/page/locator-misc-2.spec.ts
+++ b/tests/page/locator-misc-2.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should press', async ({ page }) => {
+it('should press #smoke', async ({ page }) => {
   await page.setContent(`<input type='text' />`);
   await page.locator('input').press('h');
   expect(await page.$eval('input', input => input.value)).toBe('h');

--- a/tests/page/locator-query.spec.ts
+++ b/tests/page/locator-query.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should respect first() and last()', async ({ page }) => {
+it('should respect first() and last() #smoke', async ({ page }) => {
   await page.setContent(`
   <section>
     <div><p>A</p></div>

--- a/tests/page/network-post-data.spec.ts
+++ b/tests/page/network-post-data.spec.ts
@@ -36,7 +36,7 @@ it('should return correct postData buffer for utf-8 body', async ({ page, server
   expect(request.postDataJSON()).toBe(value);
 });
 
-it('should return post data w/o content-type', async ({ page, server }) => {
+it('should return post data w/o content-type #smoke', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     page.waitForRequest('**'),

--- a/tests/page/page-accessibility.spec.ts
+++ b/tests/page/page-accessibility.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import { chromiumVersionLessThan } from '../config/utils';
 
-it('should work', async ({ page, browserName }) => {
+it('should work #smoke', async ({ page, browserName }) => {
   await page.setContent(`
   <head>
     <title>Accessibility Test</title>

--- a/tests/page/page-add-init-script.spec.ts
+++ b/tests/page/page-add-init-script.spec.ts
@@ -31,7 +31,7 @@ it('should work with a path', async ({ page, server, asset }) => {
   expect(await page.evaluate(() => window['result'])).toBe(123);
 });
 
-it('should work with content', async ({ page, server }) => {
+it('should work with content #smoke', async ({ page, server }) => {
   await page.addInitScript({ content: 'window["injected"] = 123' });
   await page.goto(server.PREFIX + '/tamperable.html');
   expect(await page.evaluate(() => window['result'])).toBe(123);

--- a/tests/page/page-add-style-tag.spec.ts
+++ b/tests/page/page-add-style-tag.spec.ts
@@ -29,7 +29,7 @@ it('should throw an error if no options are provided', async ({ page, server }) 
   expect(error.message).toContain('Provide an object with a `url`, `path` or `content` property');
 });
 
-it('should work with a url', async ({ page, server }) => {
+it('should work with a url #smoke', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const styleHandle = await page.addStyleTag({ url: '/injectedstyle.css' });
   expect(styleHandle.asElement()).not.toBeNull();

--- a/tests/page/page-check.spec.ts
+++ b/tests/page/page-check.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should check the box', async ({ page }) => {
+it('should check the box #smoke', async ({ page }) => {
   await page.setContent(`<input id='checkbox' type='checkbox'></input>`);
   await page.check('input');
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);

--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -23,7 +23,7 @@ async function giveItAChanceToClick(page) {
     await page.evaluate(() => new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f))));
 }
 
-it('should click the button', async ({ page, server }) => {
+it('should click the button #smoke', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.click('button');
   expect(await page.evaluate('result')).toBe('Clicked');

--- a/tests/page/page-dialog.spec.ts
+++ b/tests/page/page-dialog.spec.ts
@@ -27,7 +27,7 @@ it('should fire', async ({ page, server }) => {
   await page.evaluate(() => alert('yo'));
 });
 
-it('should allow accepting prompts', async ({ page, isElectron }) => {
+it('should allow accepting prompts #smoke', async ({ page, isElectron }) => {
   it.skip(isElectron, 'prompt() is not a thing in electron');
 
   page.on('dialog', dialog => {

--- a/tests/page/page-dispatchevent.spec.ts
+++ b/tests/page/page-dispatchevent.spec.ts
@@ -16,7 +16,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should dispatch click event', async ({ page, server }) => {
+it('should dispatch click event #smoke', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/button.html');
   await page.dispatchEvent('button', 'click');
   expect(await page.evaluate(() => window['result'])).toBe('Clicked');

--- a/tests/page/page-drag.spec.ts
+++ b/tests/page/page-drag.spec.ts
@@ -22,7 +22,7 @@ it.describe('Drag and drop', () => {
   it.skip(({ isAndroid }) => isAndroid);
   it.skip(({ browserName, browserMajorVersion }) => browserName === 'chromium' && browserMajorVersion < 91);
 
-  it('should work', async ({ page, server }) => {
+  it('should work #smoke', async ({ page, server }) => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');
     await page.hover('#source');
     await page.mouse.down();

--- a/tests/page/page-emulate-media.spec.ts
+++ b/tests/page/page-emulate-media.spec.ts
@@ -19,7 +19,7 @@ import { test as it, expect } from './pageTest';
 
 it.skip(({ isAndroid }) => isAndroid);
 
-it('should emulate type', async ({ page }) => {
+it('should emulate type #smoke', async ({ page }) => {
   expect(await page.evaluate(() => matchMedia('screen').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('print').matches)).toBe(false);
   await page.emulateMedia({ media: 'print' });
@@ -40,7 +40,7 @@ it('should throw in case of bad media argument', async ({ page }) => {
   expect(error.message).toContain('media: expected one of (screen|print|null)');
 });
 
-it('should emulate colorScheme should work', async ({ page }) => {
+it('should emulate colorScheme should work #smoke', async ({ page }) => {
   await page.emulateMedia({ colorScheme: 'light' });
   expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: light)').matches)).toBe(true);
   expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches)).toBe(false);

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -18,7 +18,7 @@
 import { attachFrame, detachFrame } from '../config/utils';
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({ page }) => {
+it('should work #smoke', async ({ page }) => {
   const result = await page.evaluate(() => 7 * 3);
   expect(result).toBe(21);
 });

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import util from 'util';
 
-it('should work', async ({ page, browserName }) => {
+it('should work #smoke', async ({ page, browserName }) => {
   let message = null;
   page.once('console', m => message = m);
   await Promise.all([

--- a/tests/page/page-event-network.spec.ts
+++ b/tests/page/page-event-network.spec.ts
@@ -18,7 +18,7 @@
 import type { ServerResponse } from '../../utils/testserver';
 import { test as it, expect } from './pageTest';
 
-it('Page.Events.Request', async ({ page, server }) => {
+it('Page.Events.Request #smoke', async ({ page, server }) => {
   const requests = [];
   page.on('request', request => requests.push(request));
   await page.goto(server.EMPTY_PAGE);
@@ -31,7 +31,7 @@ it('Page.Events.Request', async ({ page, server }) => {
   expect(requests[0].frame().url()).toBe(server.EMPTY_PAGE);
 });
 
-it('Page.Events.Response', async ({ page, server }) => {
+it('Page.Events.Response #smoke', async ({ page, server }) => {
   const responses = [];
   page.on('response', response => responses.push(response));
   await page.goto(server.EMPTY_PAGE);
@@ -42,7 +42,7 @@ it('Page.Events.Response', async ({ page, server }) => {
   expect(responses[0].request()).toBeTruthy();
 });
 
-it('Page.Events.RequestFailed', async ({ page, server, browserName, isMac, isWindows }) => {
+it('Page.Events.RequestFailed #smoke', async ({ page, server, browserName, isMac, isWindows }) => {
   server.setRoute('/one-style.css', (req, res) => {
     res.setHeader('Content-Type', 'text/css');
     res.connection.destroy();
@@ -69,7 +69,7 @@ it('Page.Events.RequestFailed', async ({ page, server, browserName, isMac, isWin
   expect(failedRequests[0].frame()).toBeTruthy();
 });
 
-it('Page.Events.RequestFinished', async ({ page, server }) => {
+it('Page.Events.RequestFinished #smoke', async ({ page, server }) => {
   const [response] = await Promise.all([
     page.goto(server.EMPTY_PAGE),
     page.waitForEvent('requestfinished')

--- a/tests/page/page-event-popup.spec.ts
+++ b/tests/page/page-event-popup.spec.ts
@@ -16,7 +16,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({ page }) => {
+it('should work #smoke', async ({ page }) => {
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => window['__popup'] = window.open('about:blank')),

--- a/tests/page/page-expose-function.spec.ts
+++ b/tests/page/page-expose-function.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import type { ElementHandle } from 'playwright-core';
 
-it('exposeBinding should work', async ({ page }) => {
+it('exposeBinding should work #smoke', async ({ page }) => {
   let bindingSource;
   await page.exposeBinding('add', (source, a, b) => {
     bindingSource = source;

--- a/tests/page/page-fill.spec.ts
+++ b/tests/page/page-fill.spec.ts
@@ -22,7 +22,7 @@ async function giveItAChanceToFill(page) {
     await page.evaluate(() => new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f))));
 }
 
-it('should fill textarea', async ({ page, server }) => {
+it('should fill textarea #smoke', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.fill('textarea', 'some value');
   expect(await page.evaluate(() => window['result'])).toBe('some value');

--- a/tests/page/page-focus.spec.ts
+++ b/tests/page/page-focus.spec.ts
@@ -16,7 +16,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async function({ page, browserName }) {
+it('should work #smoke', async function({ page, browserName }) {
   it.skip(browserName === 'firefox');
 
   await page.setContent(`<div id=d1 tabIndex=0></div>`);

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -20,7 +20,7 @@ import os from 'os';
 import { test as it, expect } from './pageTest';
 import { expectedSSLError } from '../config/utils';
 
-it('should work', async ({ page, server }) => {
+it('should work #smoke', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   expect(page.url()).toBe(server.EMPTY_PAGE);
 });

--- a/tests/page/page-history.spec.ts
+++ b/tests/page/page-history.spec.ts
@@ -18,7 +18,7 @@
 import { test as it, expect } from './pageTest';
 import url from 'url';
 
-it('page.goBack should work', async ({ page, server }) => {
+it('page.goBack should work #smoke', async ({ page, server }) => {
   expect(await page.goBack()).toBe(null);
 
   await page.goto(server.EMPTY_PAGE);

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -20,7 +20,7 @@ import { attachFrame } from '../config/utils';
 
 it.skip(({ isAndroid }) => isAndroid);
 
-it('should type into a textarea', async ({ page }) => {
+it('should type into a textarea #smoke', async ({ page }) => {
   await page.evaluate(() => {
     const textarea = document.createElement('textarea');
     document.body.appendChild(textarea);

--- a/tests/page/page-mouse.spec.ts
+++ b/tests/page/page-mouse.spec.ts
@@ -27,7 +27,7 @@ function dimensions() {
   };
 }
 
-it('should click the document', async ({ page, server }) => {
+it('should click the document #smoke', async ({ page, server }) => {
   await page.evaluate(() => {
     window['clickPromise'] = new Promise(resolve => {
       document.addEventListener('click', event => {

--- a/tests/page/page-network-request.spec.ts
+++ b/tests/page/page-network-request.spec.ts
@@ -35,7 +35,7 @@ it('should work for subframe navigation request', async ({ page, server }) => {
   expect(requests[0].frame()).toBe(page.frames()[1]);
 });
 
-it('should work for fetch requests', async ({ page, server }) => {
+it('should work for fetch requests #smoke', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const requests = [];
   page.on('request', request => requests.push(request));

--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -19,7 +19,7 @@ import url from 'url';
 import { test as it, expect } from './pageTest';
 import fs from 'fs';
 
-it('should work', async ({ page, server }) => {
+it('should work #smoke', async ({ page, server }) => {
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('foo', 'bar');
     res.setHeader('BaZ', 'bAz');

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should intercept', async ({ page, server }) => {
+it('should intercept #smoke', async ({ page, server }) => {
   let intercepted = false;
   await page.route('**/empty.html', (route, request) => {
     expect(route.request()).toBe(request);

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -24,7 +24,7 @@ it.describe('page screenshot', () => {
   it.skip(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
   it.skip(({ isAndroid }) => isAndroid, 'Different viewport');
 
-  it('should work', async ({ page, server }) => {
+  it('should work #smoke', async ({ page, server }) => {
     await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/grid.html');
     const screenshot = await page.screenshot();

--- a/tests/page/page-select-option.spec.ts
+++ b/tests/page/page-select-option.spec.ts
@@ -22,7 +22,7 @@ async function giveItAChanceToResolve(page) {
     await page.evaluate(() => new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f))));
 }
 
-it('should select single option', async ({ page, server }) => {
+it('should select single option #smoke', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('select', 'blue');
   expect(await page.evaluate(() => window['result'].onInput)).toEqual(['blue']);

--- a/tests/page/page-set-content.spec.ts
+++ b/tests/page/page-set-content.spec.ts
@@ -19,7 +19,7 @@ import { test as it, expect } from './pageTest';
 
 const expectedOutput = '<html><head></head><body><div>hello</div></body></html>';
 
-it('should work', async ({ page, server }) => {
+it('should work #smoke', async ({ page, server }) => {
   await page.setContent('<div>hello</div>');
   const result = await page.content();
   expect(result).toBe(expectedOutput);

--- a/tests/page/page-set-extra-http-headers.spec.ts
+++ b/tests/page/page-set-extra-http-headers.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({ page, server }) => {
+it('should work #smoke', async ({ page, server }) => {
   await page.setExtraHTTPHeaders({
     foo: 'bar',
   });

--- a/tests/page/page-set-input-files.spec.ts
+++ b/tests/page/page-set-input-files.spec.ts
@@ -36,7 +36,7 @@ it('should upload the file', async ({ page, server, asset }) => {
   }, input)).toBe('contents of the file');
 });
 
-it('should work', async ({ page, asset }) => {
+it('should work #smoke', async ({ page, asset }) => {
   await page.setContent(`<input type=file>`);
   await page.setInputFiles('input', asset('file-to-upload.txt'));
   expect(await page.$eval('input', input => input.files.length)).toBe(1);

--- a/tests/page/queryselector.spec.ts
+++ b/tests/page/queryselector.spec.ts
@@ -22,7 +22,7 @@ it('should throw for non-string selector', async ({ page }) => {
   expect(error.message).toContain('selector: expected string, got object');
 });
 
-it('should query existing element with css selector', async ({ page, server }) => {
+it('should query existing element with css selector #smoke', async ({ page, server }) => {
   await page.setContent('<section>test</section>');
   const element = await page.$('css=section');
   expect(element).toBeTruthy();

--- a/tests/page/selectors-css.spec.ts
+++ b/tests/page/selectors-css.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work with large DOM', async ({ page, server }) => {
+it('should work with large DOM #smoke', async ({ page, server }) => {
   await page.evaluate(() => {
     let id = 0;
     const next = (tag: string) => {

--- a/tests/page/selectors-frame.spec.ts
+++ b/tests/page/selectors-frame.spec.ts
@@ -46,7 +46,7 @@ async function routeIframe(page: Page) {
   });
 }
 
-it('should work for iframe', async ({ page, server }) => {
+it('should work for iframe #smoke', async ({ page, server }) => {
   await routeIframe(page);
   await page.goto(server.EMPTY_PAGE);
   const button = page.locator('iframe >> control=enter-frame >> button');

--- a/tests/page/selectors-react.spec.ts
+++ b/tests/page/selectors-react.spec.ts
@@ -29,7 +29,7 @@ for (const [name, url] of Object.entries(reacts)) {
       await page.goto(server.PREFIX + url);
     });
 
-    it('should work with single-root elements', async ({ page }) => {
+    it('should work with single-root elements #smoke', async ({ page }) => {
       expect(await page.$$eval(`_react=BookList`, els => els.length)).toBe(1);
       expect(await page.$$eval(`_react=BookItem`, els => els.length)).toBe(3);
       expect(await page.$$eval(`_react=BookList >> _react=BookItem`, els => els.length)).toBe(3);

--- a/tests/page/selectors-text.spec.ts
+++ b/tests/page/selectors-text.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async ({ page }) => {
+it('should work #smoke', async ({ page }) => {
   await page.setContent(`<div>yo</div><div>ya</div><div>\nye  </div>`);
   expect(await page.$eval(`text=ya`, e => e.outerHTML)).toBe('<div>ya</div>');
   expect(await page.$eval(`text="ya"`, e => e.outerHTML)).toBe('<div>ya</div>');

--- a/tests/page/selectors-vue.spec.ts
+++ b/tests/page/selectors-vue.spec.ts
@@ -28,7 +28,7 @@ for (const [name, url] of Object.entries(vues)) {
       await page.goto(server.PREFIX + url);
     });
 
-    it('should work with single-root elements', async ({ page }) => {
+    it('should work with single-root elements #smoke', async ({ page }) => {
       expect(await page.$$eval(`_vue=book-list`, els => els.length)).toBe(1);
       expect(await page.$$eval(`_vue=book-item`, els => els.length)).toBe(3);
       expect(await page.$$eval(`_vue=book-list >> _vue=book-item`, els => els.length)).toBe(3);

--- a/tests/page/wheel.spec.ts
+++ b/tests/page/wheel.spec.ts
@@ -21,7 +21,7 @@ it.skip(({ isElectron, browserMajorVersion }) => {
   // Old Electron has flaky wheel events.
   return isElectron && browserMajorVersion <= 11;
 });
-it('should dispatch wheel events', async ({ page, server }) => {
+it('should dispatch wheel events #smoke', async ({ page, server }) => {
   await page.setContent(`<div style="width: 5000px; height: 5000px;"></div>`);
   await page.mouse.move(50, 60);
   await listenForWheelEvents(page, 'div');

--- a/tests/page/workers.spec.ts
+++ b/tests/page/workers.spec.ts
@@ -19,7 +19,7 @@ import { test as it, expect } from './pageTest';
 import { attachFrame } from '../config/utils';
 import type { ConsoleMessage } from 'playwright-core';
 
-it('Page.workers', async function({ page, server }) {
+it('Page.workers #smoke', async function({ page, server }) {
   await Promise.all([
     page.waitForEvent('worker'),
     page.goto(server.PREFIX + '/worker/worker.html')]);

--- a/tests/popup.spec.ts
+++ b/tests/popup.spec.ts
@@ -16,7 +16,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should inherit user agent from browser context', async function({ browser, server }) {
+it('should inherit user agent from browser context #smoke', async function({ browser, server }) {
   const context = await browser.newContext({
     userAgent: 'hey'
   });

--- a/tests/port-forwarding-server.spec.ts
+++ b/tests/port-forwarding-server.spec.ts
@@ -105,7 +105,7 @@ it('should forward non-forwarded requests', async ({ pageFactory, server }) => {
   expect(reachedOriginalTarget).toBe(true);
 });
 
-it('should proxy localhost requests', async ({ pageFactory, server, browserName, platform }, workerInfo) => {
+it('should proxy localhost requests #smoke', async ({ pageFactory, server, browserName, platform }, workerInfo) => {
   it.skip(browserName === 'webkit' && platform === 'darwin');
   const { testServerPort, stopTestServer } = await startTestServer();
   let reachedOriginalTarget = false;

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -28,7 +28,7 @@ it('should throw for bad server value', async ({ browserType }) => {
   expect(error.message).toContain('proxy.server: expected string, got number');
 });
 
-it('should use proxy', async ({ browserType, server }) => {
+it('should use proxy #smoke', async ({ browserType, server }) => {
   server.setRoute('/target.html', async (req, res) => {
     res.end('<html><title>Served by the proxy</title></html>');
   });

--- a/tests/resource-timing.spec.ts
+++ b/tests/resource-timing.spec.ts
@@ -17,7 +17,7 @@
 
 import { browserTest as it, expect } from './config/browserTest';
 
-it('should work', async ({ contextFactory, server }) => {
+it('should work #smoke', async ({ contextFactory, server }) => {
   const context = await contextFactory();
   const page = await context.newPage();
   const [request] = await Promise.all([

--- a/tests/tap.spec.ts
+++ b/tests/tap.spec.ts
@@ -20,7 +20,7 @@ import type { ServerResponse } from 'http';
 
 it.use({ hasTouch: true });
 
-it('should send all of the correct events', async ({ page }) => {
+it('should send all of the correct events #smoke', async ({ page }) => {
   await page.setContent(`
   <div id="a" style="background: lightblue; width: 50px; height: 50px">a</div>
   <div id="b" style="background: pink; width: 50px; height: 50px">b</div>

--- a/tests/video.spec.ts
+++ b/tests/video.spec.ts
@@ -508,7 +508,7 @@ it.describe('screencast', () => {
     expect(videoPlayer.videoHeight).toBe(600);
   });
 
-  it('should capture static page in persistent context', async ({ launchPersistent, browserName }, testInfo) => {
+  it('should capture static page in persistent context #smoke', async ({ launchPersistent, browserName }, testInfo) => {
     it.fixme(browserName === 'firefox' && !!process.env.PWTEST_TRACE, 'https://github.com/microsoft/playwright/issues/10060');
     const size = { width: 320, height: 240 };
     const { context, page } = await launchPersistent({

--- a/tests/web-socket.spec.ts
+++ b/tests/web-socket.spec.ts
@@ -18,7 +18,7 @@
 import { contextTest as it, expect } from './config/browserTest';
 import { Server as WebSocketServer } from 'ws';
 
-it('should work', async ({ page, server }) => {
+it('should work #smoke', async ({ page, server }) => {
   server.sendOnWebSocketConnection('incoming');
   const value = await page.evaluate(port => {
     let cb;


### PR DESCRIPTION
This patch:
- introduces 109 "#smoke" tests - a subset of tests that makes sure that
  basic Playwright functionality works. This set is loosely defined;
  feel free to add/remove tests to the set. The only goal is to keep
  this set minimal & fast to run. I tried to pick tests so that various parts of
  Playwright functionality are exercised.
- starts running only smoke tests inside our docker containers. This
  should reduce docker tests run from hours to ~15-20 minutes, with most
  time spent building containers.
- stops running Chromium tests inside aarch64 docker container due to
  Chrome disliking QEMU emulation.

References #11112

