### PR TITLE
browser(firefox): fix HTTP->HTTPS fallback for refused connection

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1311
-Changed: lushnikov@chromium.org Tue Dec 14 23:27:53 PST 2021
+1312
+Changed: lushnikov@chromium.org Tue Dec 28 13:12:02 MST 2021

--- a/browser_patches/firefox-beta/juggler/NetworkObserver.js
+++ b/browser_patches/firefox-beta/juggler/NetworkObserver.js
@@ -554,12 +554,18 @@ class NetworkRequest {
   _sendOnRequestFinished() {
     const pageNetwork = this._pageNetwork;
     if (pageNetwork) {
+      let protocolVersion = undefined;
+      try {
+        protocolVersion = this.httpChannel.protocolVersion;
+      } catch (e) {
+        // protocolVersion is unavailable in certain cases.
+      };
       pageNetwork.emit(PageNetwork.Events.RequestFinished, {
         requestId: this.requestId,
         responseEndTime: this.httpChannel.responseEndTime,
         transferSize: this.httpChannel.transferSize,
         encodedBodySize: this.httpChannel.encodedBodySize,
-        protocolVersion: this.httpChannel.protocolVersion,
+        protocolVersion,
       }, this._frameId);
     }
     this._networkObserver._channelToRequest.delete(this.httpChannel);

--- a/browser_patches/firefox-beta/juggler/protocol/Protocol.js
+++ b/browser_patches/firefox-beta/juggler/protocol/Protocol.js
@@ -503,7 +503,7 @@ const Network = {
       responseEndTime: t.Number,
       transferSize: t.Number,
       encodedBodySize: t.Number,
-      protocolVersion: t.String,
+      protocolVersion: t.Optional(t.String),
     },
     'requestFailed': {
       requestId: t.String,

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1311
-Changed: lushnikov@chromium.org Tue Dec 14 23:26:10 PST 2021
+1312
+Changed: lushnikov@chromium.org Tue Dec 28 13:12:02 MST 2021

--- a/browser_patches/firefox/juggler/NetworkObserver.js
+++ b/browser_patches/firefox/juggler/NetworkObserver.js
@@ -554,12 +554,18 @@ class NetworkRequest {
   _sendOnRequestFinished() {
     const pageNetwork = this._pageNetwork;
     if (pageNetwork) {
+      let protocolVersion = undefined;
+      try {
+        protocolVersion = this.httpChannel.protocolVersion;
+      } catch (e) {
+        // protocolVersion is unavailable in certain cases.
+      };
       pageNetwork.emit(PageNetwork.Events.RequestFinished, {
         requestId: this.requestId,
         responseEndTime: this.httpChannel.responseEndTime,
         transferSize: this.httpChannel.transferSize,
         encodedBodySize: this.httpChannel.encodedBodySize,
-        protocolVersion: this.httpChannel.protocolVersion,
+        protocolVersion,
       }, this._frameId);
     }
     this._networkObserver._channelToRequest.delete(this.httpChannel);

--- a/browser_patches/firefox/juggler/protocol/Protocol.js
+++ b/browser_patches/firefox/juggler/protocol/Protocol.js
@@ -503,7 +503,7 @@ const Network = {
       responseEndTime: t.Number,
       transferSize: t.Number,
       encodedBodySize: t.Number,
-      protocolVersion: t.String,
+      protocolVersion: t.Optional(t.String),
     },
     'requestFailed': {
       requestId: t.String,


### PR DESCRIPTION
In this case, there's no protocol version that we can extract for
nsIHttpChannel.

The code that does the redirect is here: https://github.com/mozilla/gecko-dev/blob/7f3d9fce4154e71ec1af78eb6bcded0db11af08d/docshell/base/nsDocShell.cpp#L6079-L6095

To trigger this codepath, we'd need to run test inside a special
docker container that has https server running on the 443 port. We lack
infrastructure for this kind of tests (but it'll be cool to have it).

References #11118
