### PR TITLE
[Draft] Check accessible name when calculating enabled/disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3222,6 +3222,11 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g=="
+    },
     "node_modules/dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -9084,6 +9089,7 @@
       "dependencies": {
         "commander": "^8.2.0",
         "debug": "^4.1.1",
+        "dom-accessibility-api": "^0.5.10",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
         "jpeg-js": "^0.4.2",
@@ -11684,6 +11690,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g=="
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -14420,6 +14431,7 @@
       "requires": {
         "commander": "^8.2.0",
         "debug": "^4.1.1",
+        "dom-accessibility-api": "^0.5.10",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
         "jpeg-js": "^0.4.2",

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "commander": "^8.2.0",
     "debug": "^4.1.1",
+    "dom-accessibility-api": "^0.5.10",
     "extract-zip": "^2.0.1",
     "https-proxy-agent": "^5.0.0",
     "jpeg-js": "^0.4.2",

--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -23,6 +23,7 @@ import { SelectorEvaluatorImpl, isVisible, parentElementOrShadowHost, elementMat
 import { CSSComplexSelectorList } from '../common/cssParser';
 import { generateSelector } from './selectorGenerator';
 import type * as channels from '../../protocol/channels';
+import { computeAccessibleName } from 'dom-accessibility-api';
 
 type Predicate<T> = (progress: InjectedScriptProgress) => T | symbol;
 
@@ -1190,6 +1191,10 @@ function deepEquals(a: any, b: any): boolean {
 
 function isElementDisabled(element: Element): boolean {
   const isRealFormControl = ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'].includes(element.nodeName);
+  const name = computeAccessibleName(element);
+
+  if (isRealFormControl && (!name || name.length === 0))
+    return true;
   if (isRealFormControl && element.hasAttribute('disabled'))
     return true;
   if (isRealFormControl && hasDisabledFieldSet(element))

--- a/tests/page/elementhandle-convenience.spec.ts
+++ b/tests/page/elementhandle-convenience.spec.ts
@@ -183,6 +183,36 @@ it('getAttribute should be atomic', async ({ playwright, page }) => {
   expect(await page.evaluate(() => document.querySelector('div').getAttribute('foo'))).toBe('modified');
 });
 
+it('is not visible if missing an accessible name', async ({ page }) => {
+  await page.setContent(`
+  <input placeholder='My Input' id='unlabelled' type='text' />
+  <label>My Input <input id='labelled-wrapped' type='text' />
+  <label for='labelled-id-ref'>My Input</label><input id='labelled-id-ref' type='text' />
+  <input placeholder='My Input' aria-label='My Input' id='labelled-aria' type='text' />
+  <input placeholder='My Input' aria-hidden='true' id='ignored-aria-hidden' type='text' />
+  `);
+
+  const unlabelled = await page.$('input#unlabelled');
+  expect(await unlabelled.isEnabled()).toBe(false);
+  expect(await page.isEnabled('input#unlabelled')).toBe(false);
+
+  const labelledWrapped = await page.$('input#labelled-wrapped');
+  expect(await labelledWrapped.isEnabled()).toBe(true);
+  expect(await page.isEnabled('input#labelled-wrapped')).toBe(true);
+
+  const labelledIdRef = await page.$('input#labelled-id-ref');
+  expect(await labelledIdRef.isEnabled()).toBe(true);
+  expect(await page.isEnabled('input#labelled-id-ref')).toBe(true);
+
+  const labelledAria = await page.$('input#labelled-aria');
+  expect(await labelledAria.isEnabled()).toBe(true);
+  expect(await page.isEnabled('input#labelled-aria')).toBe(true);
+
+  const ignoredHidden = await page.$('input#ignored-aria-hidden');
+  expect(await ignoredHidden.isEnabled()).toBe(false);
+  expect(await page.isEnabled('input#ignored-aria-hidden')).toBe(false);
+});
+
 it('isVisible and isHidden should work', async ({ page }) => {
   await page.setContent(`<div>Hi</div><span></span>`);
 

--- a/tests/playwright-test/playwright.expect.text.spec.ts
+++ b/tests/playwright-test/playwright.expect.text.spec.ts
@@ -336,7 +336,7 @@ test('should support toHaveValue', async ({ runInlineTest }) => {
       const { test } = pwt;
 
       test('pass', async ({ page }) => {
-        await page.setContent('<input id=node></input>');
+        await page.setContent('<input aria-label="my input" id=node></input>');
         const locator = page.locator('#node');
         await locator.fill('Text content');
         await expect(locator).toHaveValue('Text content');

--- a/tests/playwright-test/playwright.expect.true.spec.ts
+++ b/tests/playwright-test/playwright.expect.true.spec.ts
@@ -109,7 +109,7 @@ test('should support toBeEditable, toBeEnabled, toBeDisabled, toBeEmpty', async 
       const { test } = pwt;
 
       test('editable', async ({ page }) => {
-        await page.setContent('<input></input>');
+        await page.setContent('<input aria-label="my input"></input>');
         const locator = page.locator('input');
         await expect(locator).toBeEditable();
       });


### PR DESCRIPTION
- When a control is missing an accessible name, it is effectively missing for assistive technology and therefore in-actionable.
- Developers can use `force` to override.
- Draft / PoC pending issue triage


Fixes #10562 

<!-- PR Checklist
- The issue has been triaged and positive signals were received from maintainers
- Existing tests pass
- New tests are added
- Relevant documentation is changed or added
-->
