### PR TITLE
feat(test runner): add `snapshotSuffix` config

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -295,6 +295,11 @@ The directory for each test can be accessed by [`property: TestInfo.snapshotDir`
 
 This path will serve as the base directory for each test file snapshot directory. Setting `snapshotDir` to `'snapshots'`, the [`property: TestInfo.snapshotDir`] would resolve to `snapshots/a.spec.js-snapshots`.
 
+## property: TestConfig.snapshotSuffix
+- type: <[string]>
+
+Suffix used to differentiate snapshots between multiple test configurations. For example, if snapshots depend on the platform, you can set `testInfo.snapshotSuffix` equal to `process.platform`. In this case `expect(value).toMatchSnapshot(snapshotName)` will use different snapshots depending on the platform. Learn more about [snapshots](./test-snapshots.md).
+
 ## property: TestConfig.preserveOutput
 - type: <[PreserveOutput]<"always"|"never"|"failures-only">>
 

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -133,6 +133,11 @@ The directory for each test can be accessed by [`property: TestInfo.snapshotDir`
 
 This path will serve as the base directory for each test file snapshot directory. Setting `snapshotDir` to `'snapshots'`, the [`property: TestInfo.snapshotDir`] would resolve to `snapshots/a.spec.js-snapshots`.
 
+## property: TestProject.snapshotSuffix
+- type: <[string]>
+
+Suffix used to differentiate snapshots between multiple test configurations. For example, if snapshots depend on the platform, you can set `testInfo.snapshotSuffix` equal to `process.platform`. In this case `expect(value).toMatchSnapshot(snapshotName)` will use different snapshots depending on the platform. Learn more about [snapshots](./test-snapshots.md).
+
 ## property: TestProject.outputDir
 - type: <[string]>
 

--- a/docs/src/test-snapshots-js.md
+++ b/docs/src/test-snapshots-js.md
@@ -41,6 +41,10 @@ drwxr-xr-x  3 user  group   96 Jun  4 11:46 example.spec.ts-snapshots
 
 Note the `chromium-darwin` in the generated snapshot file name - it contains the browser name and the platform. Screenshots differ between browsers and platforms due to different rendering, fonts and more, so you will need different snapshots for them. If you use multiple projects in your [configuration file](./test-configuration.md), project name will be used instead of `chromium`.
 
+:::note
+If you're snapshotting platform-independent data, like JSON or YAML from an API response, you can opt out of embedding the platform name (e.g. `linux`, `darwin`, etc.). See [Snapshot Suffix Overrides](#snapshot-suffix-overrides) for more details.
+:::
+
 If you are not on the same operating system as your CI system, you can use Docker to generate/update the screenshots:
 
 ```bash
@@ -125,3 +129,70 @@ test('example test', async ({ page }) => {
 ```
 
 Snapshots are stored next to the test file, in a separate directory. For example, `my.spec.ts` file will produce and store snapshots in the `my.spec.ts-snapshots` directory. You should commit this directory to your version control (e.g. `git`), and review any changes to it.
+
+
+## Snapshot Suffix Overrides
+
+By default, Playwright Test will embed the OS Platform in your snapshot files since Browser-based tests involving screenshots may be different depending on the platform.
+
+If you're snapshotting data that is platform-agnostic like JSON or YAML data from an API response, you can opt out of the default behavior.
+
+If you want to globally disable the behavior you can set `snapshotSuffix` to be empty (`''`):
+
+```js js-flavor=js
+// playwright.config.js
+// @ts-check
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  snapshotSuffix: '', // empty by default for all projects unless other overrides present
+
+  projects: [
+    {
+      name: 'API Tests',
+      snapshotSuffix: '', // override per-project
+    }
+  ]
+};
+
+module.exports = config;
+```
+
+```js js-flavor=ts
+// playwright.config.ts
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  snapshotSuffix: '', // empty by default for all projects unless other overrides present
+
+  projects: [
+    {
+      name: 'API Tests',
+      snapshotSuffix: '', // override per-project
+    }
+  ]
+};
+export default config;
+```
+
+You can also customize it per-test via [`property: TestInfo.snapshotSuffix`] directly in a test (see below), in a hook (like [`method: Test.beforeEach`]), or even in an `auto`-run fixture (see [Test Fixtures](./test-fixtures.md):
+
+```js js-flavor=js
+// example.spec.js
+const { test, expect } = require('@playwright/test');
+
+test('it works', async ({ api }, testInfo) => {
+  testInfo.snapshotSuffix = '';
+  expect(await api.getProducts()).toMatchSnapshot('products.json');
+});
+```
+
+```js js-flavor=ts
+// example.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('it works', async ({ api }, testInfo) => {
+  testInfo.snapshotSuffix = '';
+  expect(await api.getProducts()).toMatchSnapshot('products.json');
+});
+```

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -34,7 +34,6 @@ type WorkerFixtures = PlaywrightWorkerArgs & PlaywrightWorkerOptions & {
   _browserType: BrowserType;
   _browserOptions: LaunchOptions;
   _artifactsDir: () => string;
-  _snapshotSuffix: string;
 };
 
 export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
@@ -169,10 +168,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
     });
   },
 
-  _snapshotSuffix: [process.env.PLAYWRIGHT_DOCKER ? 'docker' : process.platform, { scope: 'worker' }],
-
-  _setupContextOptionsAndArtifacts: [async ({ playwright, _snapshotSuffix, _combinedContextOptions, _artifactsDir, trace, screenshot, actionTimeout, navigationTimeout }, use, testInfo) => {
-    testInfo.snapshotSuffix = _snapshotSuffix;
+  _setupContextOptionsAndArtifacts: [async ({ playwright, _combinedContextOptions, _artifactsDir, trace, screenshot, actionTimeout, navigationTimeout }, use, testInfo) => {
     if (process.env.PWDEBUG)
       testInfo.setTimeout(0);
 

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -184,6 +184,7 @@ export class Loader {
       name: takeFirst(this._configOverrides.name, projectConfig.name, this._config.name, ''),
       testDir,
       snapshotDir,
+      snapshotSuffix: takeFirst(this._configOverrides.snapshotSuffix, projectConfig.snapshotSuffix, this._config.snapshotSuffix, process.env.PLAYWRIGHT_DOCKER ? 'docker' : process.platform),
       testIgnore: takeFirst(this._configOverrides.testIgnore, projectConfig.testIgnore, this._config.testIgnore, []),
       testMatch: takeFirst(this._configOverrides.testMatch, projectConfig.testMatch, this._config.testMatch, '**/?(*.)@(spec|test).*'),
       timeout: takeFirst(this._configOverrides.timeout, projectConfig.timeout, this._config.timeout, 10000),

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -303,7 +303,7 @@ export class WorkerRunner extends EventEmitter {
       stdout: [],
       stderr: [],
       timeout: this._project.config.timeout,
-      snapshotSuffix: '',
+      snapshotSuffix: this._project.config.snapshotSuffix,
       outputDir: baseOutputDir,
       snapshotDir,
       outputPath: (...pathSegments: string[]): string => {

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -136,6 +136,13 @@ interface TestProject {
    */
   snapshotDir?: string;
   /**
+   * Suffix used to differentiate snapshots between multiple test configurations. For example, if snapshots depend on the
+   * platform, you can set `testInfo.snapshotSuffix` equal to `process.platform`. In this case
+   * `expect(value).toMatchSnapshot(snapshotName)` will use different snapshots depending on the platform. Learn more about
+   * [snapshots](https://playwright.dev/docs/test-snapshots).
+   */
+  snapshotSuffix?: string;
+  /**
    * The output directory for files created during test execution. Defaults to `test-results`.
    *
    * This directory is cleaned at the start. When running a test, a unique subdirectory inside the
@@ -671,6 +678,13 @@ interface TestConfig {
    * resolve to `snapshots/a.spec.js-snapshots`.
    */
   snapshotDir?: string;
+  /**
+   * Suffix used to differentiate snapshots between multiple test configurations. For example, if snapshots depend on the
+   * platform, you can set `testInfo.snapshotSuffix` equal to `process.platform`. In this case
+   * `expect(value).toMatchSnapshot(snapshotName)` will use different snapshots depending on the platform. Learn more about
+   * [snapshots](https://playwright.dev/docs/test-snapshots).
+   */
+  snapshotSuffix?: string;
   /**
    * The output directory for files created during test execution. Defaults to `test-results`.
    *

--- a/tests/config/baseTest.ts
+++ b/tests/config/baseTest.ts
@@ -27,6 +27,9 @@ export const baseTest = test
     .extendTest(testModeTest)
     .extend<CommonFixtures>(commonFixtures)
     .extendTest(serverTest)
-    .extend<{}, { _snapshotSuffix: string }>({
-      _snapshotSuffix: ['', { scope: 'worker' }],
+    .extend<{ autoRemoveSnapshotSuffix: void }>({
+      autoRemoveSnapshotSuffix: [ async ({}, use, testInfo) => {
+        testInfo.snapshotSuffix = '';
+        await use();
+      }, { auto: true } ]
     });

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -51,6 +51,7 @@ interface TestProject {
   metadata?: any;
   name?: string;
   snapshotDir?: string;
+  snapshotSuffix?: string;
   outputDir?: string;
   repeatEach?: number;
   retries?: number;
@@ -120,6 +121,7 @@ interface TestConfig {
   metadata?: any;
   name?: string;
   snapshotDir?: string;
+  snapshotSuffix?: string;
   outputDir?: string;
   repeatEach?: number;
   retries?: number;


### PR DESCRIPTION
Adds `snapshotSuffix` to be configured in `playwright.config.ts` overall and per-project. Also adds test cases for currently documented but untested behavior (like platform and/or project being present in snapshot names).

**Context**:

We're using Playwright Test for API testing. Under this use case, all of our snapshots are textual (normalized JSON, YAML, etc.), so the default behavior of having the platform embedded in the snapshot name does not make sense. I went to disable it in the config, but realized there does not exist an option currently, although there does exist a top-level option for `snapshotDir`.

We worked around this with a `beforeEach` hook, then a more robust `auto` fixture; however, it felt awkward compared to a top-level config like there are for related behavior/configs (`snapshotDir`).

Resolves #11134
Relates #8912
Relates #11115
