### PR TITLE
fix: default to en-US locale in all browsers

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -415,8 +415,6 @@ export function validateBrowserContextOptions(options: types.BrowserContextOptio
     throw new Error(`"isMobile" option is not supported with null "viewport"`);
   if (options.acceptDownloads === undefined)
     options.acceptDownloads = true;
-  if (options.locale === undefined)
-    options.locale = 'en-US';
   if (!options.viewport && !options.noDefaultViewport)
     options.viewport = { width: 1280, height: 720 };
   if (options.recordVideo) {

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -415,6 +415,8 @@ export function validateBrowserContextOptions(options: types.BrowserContextOptio
     throw new Error(`"isMobile" option is not supported with null "viewport"`);
   if (options.acceptDownloads === undefined)
     options.acceptDownloads = true;
+  if (options.locale === undefined)
+    options.locale = 'en-US';
   if (!options.viewport && !options.noDefaultViewport)
     options.viewport = { width: 1280, height: 720 };
   if (options.recordVideo) {

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -96,7 +96,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
   ignoreHTTPSErrors: [ undefined, { option: true } ],
   isMobile: [ undefined, { option: true } ],
   javaScriptEnabled: [ undefined, { option: true } ],
-  locale: [ undefined, { option: true } ],
+  locale: [ 'en-US', { option: true } ],
   offline: [ undefined, { option: true } ],
   permissions: [ undefined, { option: true } ],
   proxy: [ undefined, { option: true } ],

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -82,8 +82,11 @@ it('should have pages in persistent context', async ({ launchPersistent }, testI
   await page.waitForLoadState('domcontentloaded');
   await context.close();
   const log = JSON.parse(fs.readFileSync(harPath).toString())['log'];
-  expect(log.pages.length).toBe(1);
-  const pageEntry = log.pages[0];
+  // Explicit locale emulation forces a new page creation when
+  // doing a new context.
+  // See https://github.com/microsoft/playwright/blob/13dd41c2e36a63f35ddef5dc5dec322052d670c6/packages/playwright-core/src/server/browserContext.ts#L232-L242
+  expect(log.pages.length).toBe(2);
+  const pageEntry = log.pages[1];
   expect(pageEntry.id).toBeTruthy();
   expect(pageEntry.title).toBe('Hello');
 });


### PR DESCRIPTION
It makes sense to default to en-US by default across all our browsers.

Fixes #11127
