### PR TITLE
test: skip fill tests for android

### DIFF
--- a/tests/page/page-fill.spec.ts
+++ b/tests/page/page-fill.spec.ts
@@ -17,6 +17,8 @@
 
 import { test as it, expect } from './pageTest';
 
+it.skip(({ isAndroid }) => isAndroid);
+
 async function giveItAChanceToFill(page) {
   for (let i = 0; i < 5; i++)
     await page.evaluate(() => new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f))));


### PR DESCRIPTION
All page-fill tests are timing-out on android bots, probably due to inputs
rendered differently. 39 tests * 120s timeout * 2 (1 retry + 1 run) = 2.6 hours of CPU time wasted on waiting.