### PR TITLE
feat(test): annotate tests with browser version

### DIFF
--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -188,6 +188,9 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
     const createdContexts = new Set<BrowserContext>();
 
     const onDidCreateContext = async (context: BrowserContext) => {
+      const browser = context.browser();
+      if (browser && !testInfo.annotations.find(a => a.type === 'browserVersion'))
+        testInfo.annotations.push({ type: 'browserVersion', description: browser.version() });
       createdContexts.add(context);
       context.setDefaultTimeout(testInfo.timeout === 0 ? 0 : (actionTimeout || 0));
       context.setDefaultNavigationTimeout(testInfo.timeout === 0 ? 0 : (navigationTimeout || actionTimeout || 0));

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -292,7 +292,10 @@ test('should render annotations', async ({ runInlineTest, page, showReport }) =>
 
   await showReport();
   await page.click('text=skipped test');
-  await expect(page.locator('.test-case-annotation')).toHaveText('skip: I am not interested in this test');
+  await expect(page.locator('.test-case-annotation')).toHaveText([
+    /browserVersion: [\d.]+/,
+    'skip: I am not interested in this test',
+  ]);
 });
 
 test('should render beforeAll/afterAll hooks', async ({ runInlineTest, page, showReport }) => {


### PR DESCRIPTION
Example:

<img width="996" alt="Screen Shot 2022-01-03 at 3 54 39 PM" src="https://user-images.githubusercontent.com/9881434/147992685-487c6fa5-3279-42f7-aa90-d1b24dcd2e52.png">

References #9217.
