### PR TITLE
fix(test runner): show codeframe and location from the error top stack frame

### DIFF
--- a/packages/playwright-test/src/reporters/github.ts
+++ b/packages/playwright-test/src/reporters/github.ts
@@ -69,7 +69,7 @@ export class GitHubReporter extends BaseReporter {
   }
 
   override onError(error: TestError) {
-    const errorMessage = formatError(error, false).message;
+    const errorMessage = formatError(this.config, error, false).message;
     this.githubLogger.error(errorMessage);
   }
 
@@ -100,21 +100,19 @@ export class GitHubReporter extends BaseReporter {
 
   private _printFailureAnnotations(failures: TestCase[]) {
     failures.forEach((test, index) => {
-      const filePath = workspaceRelativePath(test.location.file);
       const { annotations } = formatFailure(this.config, test, {
-        filePath,
         index: index + 1,
         includeStdio: true,
         includeAttachments: false,
       });
-      annotations.forEach(({ filePath, title, message, position }) => {
+      annotations.forEach(({ location, title, message }) => {
         const options: GitHubLogOptions = {
-          file: filePath,
+          file: workspaceRelativePath(location?.file || test.location.file),
           title,
         };
-        if (position) {
-          options.line = position.line;
-          options.col = position.column;
+        if (location) {
+          options.line = location.line;
+          options.col = location.column;
         }
         this.githubLogger.error(message, options);
       });

--- a/packages/playwright-test/src/reporters/json.ts
+++ b/packages/playwright-test/src/reporters/json.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 import { FullConfig, TestCase, Suite, TestResult, TestError, TestStep, FullResult, TestStatus, Location, Reporter } from '../../types/testReporter';
-import { PositionInFile, prepareErrorStack } from './base';
+import { prepareErrorStack } from './base';
 
 export interface JSONReport {
   config: Omit<FullConfig, 'projects'> & {
@@ -77,7 +77,7 @@ export interface JSONReportTestResult {
     body?: string;
     contentType: string;
   }[];
-  errorLocation?: PositionInFile
+  errorLocation?: Location;
 }
 export interface JSONReportTestStep {
   title: string;
@@ -229,12 +229,12 @@ class JSONReporter implements Reporter {
       annotations: test.annotations,
       expectedStatus: test.expectedStatus,
       projectName: test.titlePath()[1],
-      results: test.results.map(r => this._serializeTestResult(r, test.location.file)),
+      results: test.results.map(r => this._serializeTestResult(r)),
       status: test.outcome(),
     };
   }
 
-  private _serializeTestResult(result: TestResult, file: string): JSONReportTestResult {
+  private _serializeTestResult(result: TestResult): JSONReportTestResult {
     const steps = result.steps.filter(s => s.category === 'test.step');
     const jsonResult: JSONReportTestResult = {
       workerIndex: result.workerIndex,
@@ -252,14 +252,8 @@ class JSONReporter implements Reporter {
         body: a.body?.toString('base64')
       })),
     };
-    if (result.error?.stack) {
-      const { position } = prepareErrorStack(
-          result.error.stack,
-          file
-      );
-      if (position)
-        jsonResult.errorLocation = position;
-    }
+    if (result.error?.stack)
+      jsonResult.errorLocation = prepareErrorStack(result.error.stack).location;
     return jsonResult;
   }
 

--- a/packages/playwright-test/src/reporters/raw.ts
+++ b/packages/playwright-test/src/reporters/raw.ts
@@ -219,7 +219,7 @@ class RawReporter {
       startTime: result.startTime.toISOString(),
       duration: result.duration,
       status: result.status,
-      error: formatResultFailure(test, result, '', true).tokens.join('').trim(),
+      error: formatResultFailure(this.config, test, result, '', true).tokens.join('').trim(),
       attachments: this._createAttachments(result),
       steps: dedupeSteps(result.steps.map(step => this._serializeStep(test, step)))
     };

--- a/tests/playwright-test/blink-diff.spec.ts
+++ b/tests/playwright-test/blink-diff.spec.ts
@@ -730,7 +730,6 @@ it.describe('Blink-Diff', () => {
 
       it('should crop image-a', async () => {
         instance._cropImageA = { width: 1, height: 2 };
-        console.log('A');
         const result = instance.runSync();
         expect(result.dimension).toBe(2);
       });


### PR DESCRIPTION
Previously, reporter would look for a stack frame directly in the test file.
Often times, that is not a top stack frame, especially when the test uses
some helper functions.

This changes error snippets and locations to use the top frame. When top
frame does not match the test file, we additionally show the location
to avoid confusion:

```
  1) a.spec.ts:7:7 › foobar ========================================================================

    Error: oh my

       at helper.ts:5

      3 |
      4 |       export function ohMy() {
    > 5 |         throw new Error('oh my');
        |               ^
      6 |       }
      7 |

        at ohMy (.../reporter-base-should-print-codeframe-from-a-helper/helper.ts:5:15)
        at .../reporter-base-should-print-codeframe-from-a-helper/a.spec.ts:8:9
        at FixtureRunner.resolveParametersAndRunHookOrTest (.../src/fixtures.ts:281:12)
```
