### PR TITLE
fix(html reporter): skip img bits with non-images

### DIFF
--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -49,6 +49,7 @@ export const TestResultView: React.FC<{
   const expected = attachmentsMap.get('expected');
   const actual = attachmentsMap.get('actual');
   const diff = attachmentsMap.get('diff');
+  const hasImages = [actual?.contentType, expected?.contentType, diff?.contentType].some(v => v && /^image\//i.test(v));
   return <div className='test-result'>
     {result.error && <AutoChip header='Errors'>
       <ErrorMessage key='test-result-error-message' error={result.error}></ErrorMessage>
@@ -57,8 +58,8 @@ export const TestResultView: React.FC<{
       {result.steps.map((step, i) => <StepTreeItem key={`step-${i}`} step={step} depth={0}></StepTreeItem>)}
     </AutoChip>}
 
-    {expected && actual && <AutoChip header='Image mismatch'>
-      <ImageDiff actual={actual} expected={expected} diff={diff}></ImageDiff>
+    {expected && actual && <AutoChip header={`${hasImages ? 'Image' : 'Snapshot'} mismatch`}>
+      {hasImages && <ImageDiff actual={actual} expected={expected} diff={diff}></ImageDiff>}
       <AttachmentLink key={`expected`} attachment={expected}></AttachmentLink>
       <AttachmentLink key={`actual`} attachment={actual}></AttachmentLink>
       {diff && <AttachmentLink key={`diff`} attachment={diff}></AttachmentLink>}


### PR DESCRIPTION
Regarding backwards compatibility: The image block will no longer show
up in cases where no extension is used (see test case), but I think this
is OK since you would have never hit the actual image comparison in the
test if you omitted an extension: https://github.com/microsoft/playwright/blob/328f3e265efe9c431ebae1ed3d7fd47dcd547b29/packages/playwright-test/src/matchers/golden.ts#L44 before.

Depending on how Visual Testing evolves, a follow up PR is due to clean
up references to images.

Fixes #11183
