### PR TITLE
test: mark test as failing until next wk roll

### DIFF
--- a/tests/page/elementhandle-bounding-box.spec.ts
+++ b/tests/page/elementhandle-bounding-box.spec.ts
@@ -39,6 +39,7 @@ it('should handle nested frames', async ({ page, server }) => {
 });
 
 it('should get frame box', async ({ page, browserName }) => {
+  it.fail(browserName === 'webkit', 'https://github.com/microsoft/playwright/issues/10977');
   await page.setViewportSize({ width: 200, height: 200 });
   await page.setContent(`<style>
   body {


### PR DESCRIPTION
The test was inadvertently marked as passing in https://github.com/microsoft/playwright/pull/11105