### PR TITLE
fix: Variable not of type string

### DIFF
--- a/packages/playwright-core/src/utils/utils.ts
+++ b/packages/playwright-core/src/utils/utils.ts
@@ -348,7 +348,7 @@ export function headersObjectToArray(headers: HeadersObject, separator?: string,
   const result: HeadersArray = [];
   for (const name in headers) {
     const values = headers[name];
-    if (separator) {
+    if (separator && typeof values === 'string') {
       const sep = name.toLowerCase() === 'set-cookie' ? setCookieSeparator : separator;
       for (const value of values.split(sep!))
         result.push({ name, value: value.trim() });


### PR DESCRIPTION
I ran into the case where the variable `values` in
headersObjectToArray is not a string.
Therefore, the call to the split function fails at runtime.

The trace for the error is

```sh
.../playwright-core/lib/utils/utils.js:417
      for (const value of values.split(sep)) result.push({
                                 ^
TypeError: values.split is not a function or its return value is not iterable
    at headersObjectToArray (.../playwright-core/lib/utils/utils.js:417:34)
    at ResponseExtraInfoTracker._patchHeaders (.../playwright-core/lib/server/chromium/crNetworkManager.js:717:111)
    at ResponseExtraInfoTracker.processResponse (.../playwright-core/lib/server/chromium/crNetworkManager.js:675:10)
    at CRNetworkManager._createResponse (.../playwright-core/lib/server/chromium/crNetworkManager.js:347:36)
    at CRNetworkManager._onResponseReceived (.../playwright-core/lib/server/chromium/crNetworkManager.js:378:27)
    at CRSession.emit (node:events:390:28)
    at CRSession.emit (node:domain:475:12)
    at .../playwright-core/lib/server/chromium/crConnection.js:225:14
```

This PR checks if the type of `values` is actually a string.
I'm not quite happy with the approach to fix this bug, but I'm just a
user of playwright and have no better idea how to fix this.

<!--
Thank you for your Pull Request. Please link to the issue this PR addresses.
-->
Fixes #

<!-- PR Checklist
- The issue has been triaged and positive signals were received from maintainers
- Existing tests pass
- New tests are added
- Relevant documentation is changed or added
-->
