### PR TITLE
docs: fix colorized errors in GitLab CI

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -334,6 +334,8 @@ stages:
 tests:
   stage: test
   image: mcr.microsoft.com/playwright:focal
+  variables:
+    FORCE_COLOR: 1 # ensure pretty, colorized errors from `expect` (courtesy of https://www.npmjs.com/package/colors)
   script:
   ...
 ```

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -335,7 +335,7 @@ tests:
   stage: test
   image: mcr.microsoft.com/playwright:focal
   variables:
-    FORCE_COLOR: 1 # ensure pretty, colorized errors from `expect` (courtesy of https://www.npmjs.com/package/colors)
+    FORCE_COLOR: 1 # Ensure colorized errors appear in all reports like the HTML Reporter. (Follow https://github.com/microsoft/playwright/issues/11314 to be notified of when this is no longer necessary.)
   script:
   ...
 ```


### PR DESCRIPTION
Without this, HTML Reports (which we make available via S3 in Slack alerts) were missing the pretty green/red colorization on `expect` failures/errors that you can see here (e.g. the red `Snapshot comparison failed`):

<img width="591" alt="Screen Shot 2022-01-06 at 5 42 50 PM" src="https://user-images.githubusercontent.com/11915034/148478178-f32ed2fa-8dde-41ed-a26d-b864b5e34edc.png">

Turns out, the colors weren't being outputted in GitLab CI logs either. For the snapshot diffs, the colorization is critical as it shows what's added/removed.