### PR TITLE
[experimental] feat(reporter): verbose codeframe stacks 

### DIFF
--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -670,4 +670,3 @@ it('should include API request', async ({ contextFactory, server }, testInfo) =>
   expect(entry.response.content.size).toBe(15);
   expect(entry.response.content.text).toBe(responseBody.toString('base64'));
 });
-


### PR DESCRIPTION
This is a WIP experiment to try to get more complete stack traces and code previews into the HTML Report. We use helpers and parameterized tests and find that sometimes the report does not provide enough context to quickly understand where exactly the code failed.

We run smoketests via Playwright Test, so it's important for us to quickly triage directly from the report without opening the source code.

Given the following code:

`base.ts`:
```ts
import { test as _test, expect } from "@playwright/test";

export const test = _test.extend<{ run: () => void }>({
  run: async ({}, use) => {
    const run = () => expect(1).toBe(2);
    await use(run);
  },
});
```

`example.spec.ts`:
```ts
import { test } from "./base";

test("a", async ({ run }) => {
  run();
});
```

**v1.17.1** will output:

<img width="999" alt="Screen Shot 2022-01-06 at 10 00 56 PM" src="https://user-images.githubusercontent.com/11915034/148499380-896e3506-d3de-4d52-8bd7-391df5198878.png">

It shows which `test` (of potentially many) in a file failed, but the codeframe doesn't show us which `expect` call site failed (of which there can be many).

**v1.18.0-alpha-jan-7-2022** will outputs something a bit different (which we just picked up in a staging environment today):

<img width="1003" alt="Screen Shot 2022-01-06 at 10 03 21 PM" src="https://user-images.githubusercontent.com/11915034/148499606-41d43a6b-41d4-4f9f-9755-6cdd18952674.png">

While the codeframe shows which specific `expect` call site failed, we no longer see which `test` context it was called in.

Neither paint a complete picture, so the PR is an experiment with a verbose stack codeframe where we get codeframes for each line item on the stack. I think this provides the best of both worlds 😄 

Here's the sample output for the placeholder test examples checked into this MR:

`base.ts`:
```ts
const { test: _test, expect } = pwt;
export const test = _test.extend<{
  helpers: {
    runParameterizedTest: (v: number) => Promise<void>;
    exampleFixtureThatThrows: (v: number) => Promise<void>;
  };
}>({
  helpers: async ({}, use) => {
    const helpers = {
      runParameterizedTest: async (v: number) => {
        expect(v).toBe(2);
      },
      exampleFixtureThatThrows: async (v: number) => {
        throw new Error("oops! this is a def broken fixture helper!");
      },
    };
    await use(helpers);
  },
});

export const parameterizeTest = async (v: number) => {
  await test.step("a", () => expect(1).toBe(3));
};
```

`a.spec.ts`:
```ts
import { test, parameterizeTest } from "./base.ts";

test("basic expect example", () => {
  expect(1).toBe(2);
});

test("parameterized test helper fixture expect error", async ({ helpers }) => {
  await helpers.runParameterizedTest(5);
});

test("example fixture that throws", async ({ helpers }) => {
  await helpers.exampleFixtureThatThrows(5);
});

test("non-fixture parameterizer example", async () => {
  await parameterizeTest(47);
});
```
**Before** this change:
<img width="731" alt="Screen Shot 2022-01-06 at 10 17 29 PM" src="https://user-images.githubusercontent.com/11915034/148500797-e8c13cd6-60e2-49d6-877c-4615bafd41df.png">


**After** this change:
<img width="788" alt="Screen Shot 2022-01-06 at 10 15 25 PM" src="https://user-images.githubusercontent.com/11915034/148500631-ea1d8026-9884-4ffa-84d2-5721b2815828.png">
<img width="787" alt="Screen Shot 2022-01-06 at 10 15 42 PM" src="https://user-images.githubusercontent.com/11915034/148500646-cb891319-cfd0-4a4b-8ca4-22d3eb612607.png">

The last screenshots, while verbose, provide us with all the context we need even if there are errors/expects triggered in any helper functions that out test consumes.

Perhaps to find a happy balance between details vs. conciseness, there is an option for the reporter that controls whether just the top stack line gets a code frame or all of them within the stack do (like this experiment proposes). If it doesn't make sense to amend the built in reporter, this could also be a supplemental, non-default official (or user-land reporter). 