### PR TITLE
fix(test runner): revert error location from top frame

### DIFF
--- a/packages/playwright-test/src/reporters/json.ts
+++ b/packages/playwright-test/src/reporters/json.ts
@@ -229,12 +229,12 @@ class JSONReporter implements Reporter {
       annotations: test.annotations,
       expectedStatus: test.expectedStatus,
       projectName: test.titlePath()[1],
-      results: test.results.map(r => this._serializeTestResult(r)),
+      results: test.results.map(r => this._serializeTestResult(r, test)),
       status: test.outcome(),
     };
   }
 
-  private _serializeTestResult(result: TestResult): JSONReportTestResult {
+  private _serializeTestResult(result: TestResult, test: TestCase): JSONReportTestResult {
     const steps = result.steps.filter(s => s.category === 'test.step');
     const jsonResult: JSONReportTestResult = {
       workerIndex: result.workerIndex,
@@ -253,7 +253,7 @@ class JSONReporter implements Reporter {
       })),
     };
     if (result.error?.stack)
-      jsonResult.errorLocation = prepareErrorStack(result.error.stack).location;
+      jsonResult.errorLocation = prepareErrorStack(result.error.stack, test.location.file).location;
     return jsonResult;
   }
 

--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -86,7 +86,7 @@ test('should print an error in a codeframe', async ({ runInlineTest }) => {
   expect(result.output).toContain(`>  7 |         const error = new Error('my-message');`);
 });
 
-test('should print codeframe from a helper', async ({ runInlineTest }) => {
+test('should not print codeframe from a helper', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'helper.ts': `
       export function ohMy() {
@@ -106,10 +106,9 @@ test('should print codeframe from a helper', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
   expect(result.output).toContain('Error: oh my');
-  expect(result.output).toContain(`   at helper.ts:5`);
-  expect(result.output).toContain(`  4 |       export function ohMy() {`);
-  expect(result.output).toContain(`> 5 |         throw new Error('oh my');`);
-  expect(result.output).toContain(`    |               ^`);
+  expect(result.output).toContain(`   7 |       test('foobar', async ({}) => {`);
+  expect(result.output).toContain(`>  8 |         ohMy();`);
+  expect(result.output).toContain(`     |         ^`);
 });
 
 test('should print slow tests', async ({ runInlineTest }) => {


### PR DESCRIPTION
This does not play nicely with some internal Playwright errors, so it needs more tweaks.
