### PR TITLE
fix(reporter api): explicit onHookBegin and onHookEnd

### DIFF
--- a/docs/src/test-reporter-api/class-reporter.md
+++ b/docs/src/test-reporter-api/class-reporter.md
@@ -132,6 +132,38 @@ Called on some global error, for example unhandled exception in the worker proce
 The error.
 
 
+
+## method: Reporter.onHookBegin
+
+Called after a `beforeAll` or `afterAll` hook has been started in the worker process. Note that `beforeEach` and `afterEach` hooks are reported as steps inside applicable tests.
+
+### param: Reporter.onHookBegin.hook
+- `hook` <[TestCase]>
+
+Hook that has been started.
+
+### param: Reporter.onHookBegin.result
+- `result` <[TestResult]>
+
+Result of the hook run, this object gets populated while the hook runs.
+
+
+## method: Reporter.onHookEnd
+
+Called after a `beforeAll` or `afterAll` hook has been finished in the worker process. Note that `beforeEach` and `afterEach` hooks are reported as steps inside applicable tests.
+
+### param: Reporter.onHookEnd.hook
+- `hook` <[TestCase]>
+
+Hook that has been finished.
+
+### param: Reporter.onHookEnd.result
+- `result` <[TestResult]>
+
+Result of the hook run.
+
+
+
 ## method: Reporter.onStdErr
 
 Called when something has been written to the standard error in the worker process.
@@ -144,12 +176,13 @@ Output chunk.
 ### param: Reporter.onStdErr.test
 - `test` <[void]|[TestCase]>
 
-Test that was running. Note that output may happen when no test is running, in which case this will be [void].
+Test or hook that was running. Note that output may happen when no test is running, in which case this will be [void].
 
 ### param: Reporter.onStdErr.result
 - `result` <[void]|[TestResult]>
 
-Result of the test run, this object gets populated while the test runs.
+Result of the test/hook run, this object gets populated while the test/hook runs.
+
 
 
 ## method: Reporter.onStdOut
@@ -164,12 +197,14 @@ Output chunk.
 ### param: Reporter.onStdOut.test
 - `test` <[void]|[TestCase]>
 
-Test that was running. Note that output may happen when no test is running, in which case this will be [void].
+Test or hook that was running. Note that output may happen when no test is running, in which case this will be [void].
 
 ### param: Reporter.onStdOut.result
 - `result` <[void]|[TestResult]>
 
-Result of the test run, this object gets populated while the test runs.
+Result of the test/hook run, this object gets populated while the test/hook runs.
+
+
 
 ## method: Reporter.onStepBegin
 
@@ -178,17 +213,19 @@ Called when a test step started in the worker process.
 ### param: Reporter.onStepBegin.test
 - `test` <[TestCase]>
 
-Test that the step belongs to.
+Test or hook that the step belongs to.
 
 ### param: Reporter.onStepBegin.result
 - `result` <[TestResult]>
 
-Result of the test run, this object gets populated while the test runs.
+Result of the test/hook run, this object gets populated while the test/hook runs.
 
 ### param: Reporter.onStepBegin.step
 - `step` <[TestStep]>
 
 Test step instance that has started.
+
+
 
 ## method: Reporter.onStepEnd
 
@@ -197,17 +234,19 @@ Called when a test step finished in the worker process.
 ### param: Reporter.onStepEnd.test
 - `test` <[TestCase]>
 
-Test that the step belongs to.
+Test or hook that the step belongs to.
 
 ### param: Reporter.onStepEnd.result
 - `result` <[TestResult]>
 
-Result of the test run.
+Result of the test/hook run.
 
 ### param: Reporter.onStepEnd.step
 - `step` <[TestStep]>
 
 Test step instance that has finished.
+
+
 
 ## method: Reporter.onTestBegin
 
@@ -222,6 +261,7 @@ Test that has been started.
 - `result` <[TestResult]>
 
 Result of the test run, this object gets populated while the test runs.
+
 
 
 ## method: Reporter.onTestEnd

--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -91,12 +91,25 @@ export class BaseReporter implements Reporter  {
     (result as any)[kOutputSymbol].push(output);
   }
 
-  onTestEnd(test: TestCase, result: TestResult) {
+  private _appendToFileDuration(test: TestCase, result: TestResult) {
     const projectName = test.titlePath()[1];
     const relativePath = relativeTestPath(this.config, test);
     const fileAndProject = (projectName ? `[${projectName}] › ` : '') + relativePath;
     const duration = this.fileDurations.get(fileAndProject) || 0;
     this.fileDurations.set(fileAndProject, duration + result.duration);
+  }
+
+  onTestEnd(test: TestCase, result: TestResult) {
+    this._appendToFileDuration(test, result);
+    this.onTestOrHookEnd(test, result, false);
+  }
+
+  onHookEnd(hook: TestCase, result: TestResult) {
+    this._appendToFileDuration(hook, result);
+    this.onTestOrHookEnd(hook, result, true);
+  }
+
+  protected onTestOrHookEnd(test: TestCase, result: TestResult, isHook: boolean) {
   }
 
   onError(error: TestError) {

--- a/packages/playwright-test/src/reporters/dot.ts
+++ b/packages/playwright-test/src/reporters/dot.ts
@@ -42,8 +42,7 @@ class DotReporter extends BaseReporter {
       process.stderr.write(chunk);
   }
 
-  override onTestEnd(test: TestCase, result: TestResult) {
-    super.onTestEnd(test, result);
+  override onTestOrHookEnd(test: TestCase, result: TestResult, isHook: boolean) {
     if (this._counter === 80) {
       process.stdout.write('\n');
       this._counter = 0;

--- a/packages/playwright-test/src/reporters/line.ts
+++ b/packages/playwright-test/src/reporters/line.ts
@@ -59,9 +59,8 @@ class LineReporter extends BaseReporter {
     console.log();
   }
 
-  override onTestEnd(test: TestCase, result: TestResult) {
-    super.onTestEnd(test, result);
-    if (!test.title.startsWith('beforeAll') && !test.title.startsWith('afterAll'))
+  override onTestOrHookEnd(test: TestCase, result: TestResult, isHook: boolean) {
+    if (!isHook)
       ++this._current;
     const retriesSuffix = this.totalTestCount < this._current ? ` (retries)` : ``;
     const title = `[${this._current}/${this.totalTestCount}]${retriesSuffix} ${formatTestTitle(this.config, test)}`;

--- a/packages/playwright-test/src/reporters/list.ts
+++ b/packages/playwright-test/src/reporters/list.ts
@@ -98,9 +98,7 @@ class ListReporter extends BaseReporter {
     stream.write(chunk);
   }
 
-  override onTestEnd(test: TestCase, result: TestResult) {
-    super.onTestEnd(test, result);
-
+  override onTestOrHookEnd(test: TestCase, result: TestResult, isHook: boolean) {
     let duration = colors.dim(` (${milliseconds(result.duration)})`);
     const title = formatTestTitle(this.config, test);
     let text = '';

--- a/packages/playwright-test/src/reporters/multiplexer.ts
+++ b/packages/playwright-test/src/reporters/multiplexer.ts
@@ -71,4 +71,14 @@ export class Multiplexer implements Reporter {
     for (const reporter of this._reporters)
       (reporter as any).onStepEnd?.(test, result, step);
   }
+
+  onHookBegin(hook: TestCase, result: TestResult) {
+    for (const reporter of this._reporters)
+      reporter.onHookBegin?.(hook, result);
+  }
+
+  onHookEnd(hook: TestCase, result: TestResult) {
+    for (const reporter of this._reporters)
+      reporter.onHookEnd?.(hook, result);
+  }
 }

--- a/packages/playwright-test/types/testReporter.d.ts
+++ b/packages/playwright-test/types/testReporter.d.ts
@@ -389,15 +389,15 @@ export interface Reporter {
   /**
    * Called when something has been written to the standard output in the worker process.
    * @param chunk Output chunk.
-   * @param test Test that was running. Note that output may happen when no test is running, in which case this will be [void].
-   * @param result Result of the test run, this object gets populated while the test runs.
+   * @param test Test or hook that was running. Note that output may happen when no test is running, in which case this will be [void].
+   * @param result Result of the test/hook run, this object gets populated while the test/hook runs.
    */
   onStdOut?(chunk: string | Buffer, test?: TestCase, result?: TestResult): void;
   /**
    * Called when something has been written to the standard error in the worker process.
    * @param chunk Output chunk.
-   * @param test Test that was running. Note that output may happen when no test is running, in which case this will be [void].
-   * @param result Result of the test run, this object gets populated while the test runs.
+   * @param test Test or hook that was running. Note that output may happen when no test is running, in which case this will be [void].
+   * @param result Result of the test/hook run, this object gets populated while the test/hook runs.
    */
   onStdErr?(chunk: string | Buffer, test?: TestCase, result?: TestResult): void;
   /**
@@ -408,18 +408,32 @@ export interface Reporter {
   onTestEnd?(test: TestCase, result: TestResult): void;
   /**
    * Called when a test step started in the worker process.
-   * @param test Test that the step belongs to.
-   * @param result Result of the test run, this object gets populated while the test runs.
+   * @param test Test or hook that the step belongs to.
+   * @param result Result of the test/hook run, this object gets populated while the test/hook runs.
    * @param step Test step instance that has started.
    */
   onStepBegin?(test: TestCase, result: TestResult, step: TestStep): void;
   /**
    * Called when a test step finished in the worker process.
-   * @param test Test that the step belongs to.
-   * @param result Result of the test run.
+   * @param test Test or hook that the step belongs to.
+   * @param result Result of the test/hook run.
    * @param step Test step instance that has finished.
    */
   onStepEnd?(test: TestCase, result: TestResult, step: TestStep): void;
+  /**
+   * Called after a `beforeAll` or `afterAll` hook has been started in the worker process. Note that `beforeEach` and
+   * `afterEach` hooks are reported as steps inside applicable tests.
+   * @param hook Hook that has been started.
+   * @param result Result of the hook run, this object gets populated while the hook runs.
+   */
+  onHookBegin?(hook: TestCase, result: TestResult): void;
+  /**
+   * Called after a `beforeAll` or `afterAll` hook has been finished in the worker process. Note that `beforeEach` and
+   * `afterEach` hooks are reported as steps inside applicable tests.
+   * @param hook Hook that has been finished.
+   * @param result Result of the hook run.
+   */
+  onHookEnd?(hook: TestCase, result: TestResult): void;
   /**
    * Called on some global error, for example unhandled exception in the worker process.
    * @param error The error.

--- a/utils/generate_types/overrides-testReporter.d.ts
+++ b/utils/generate_types/overrides-testReporter.d.ts
@@ -99,6 +99,8 @@ export interface Reporter {
   onTestEnd?(test: TestCase, result: TestResult): void;
   onStepBegin?(test: TestCase, result: TestResult, step: TestStep): void;
   onStepEnd?(test: TestCase, result: TestResult, step: TestStep): void;
+  onHookBegin?(hook: TestCase, result: TestResult): void;
+  onHookEnd?(hook: TestCase, result: TestResult): void;
   onError?(error: TestError): void;
   onEnd?(result: FullResult): void | Promise<void>;
 }


### PR DESCRIPTION
To avoid confusion between tests and hooks.
