### PR TITLE
browser(firefox): fix extra HTTP headers in request interception

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1313
-Changed: lushnikov@chromium.org Wed 29 Dec 2021 09:04:48 PM PST
+1314
+Changed: lushnikov@chromium.org Sat Jan  8 18:49:01 MSK 2022

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1312
-Changed: lushnikov@chromium.org Tue Dec 28 13:12:02 MST 2021
+1313
+Changed: lushnikov@chromium.org Sat Jan  8 18:49:01 MSK 2022


### PR DESCRIPTION
- `locale` override internally adds `accept-language` http header
- during internal redirects, this header is getting overwritten in
  `netwerk` subsystem in firefox
- thus we have to re-apply extra HTTP headers in request interception.

References #11264
