### PR TITLE
fix: pin `colors` to `1.4.0`

### DIFF
--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -46,7 +46,7 @@
     "@babel/plugin-transform-react-jsx": "^7.14.5",
     "@babel/preset-typescript": "^7.14.5",
     "babel-plugin-module-resolver": "^4.1.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "commander": "^8.2.0",
     "debug": "^4.1.1",
     "expect": "=27.2.5",


### PR DESCRIPTION
https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what

---

Ref: #11272 

Closes #11273