### PR TITLE
cherry-pick(#10743): devops: demand explicit arch when building docker

### DIFF
--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -38,7 +38,7 @@ jobs:
     - run: npm ci
     - run: npm run build
     - name: Build
-      run: bash utils/docker/build.sh --arm64 ${{ matrix.tag }} playwright:localbuild-${{ matrix.tag }}
+      run: bash utils/docker/build.sh --amd64 ${{ matrix.tag }} playwright:localbuild-${{ matrix.tag }}
     - name: Clean & Prepare for Docker
       run: |
         npm run clean

--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -38,7 +38,7 @@ jobs:
     - run: npm ci
     - run: npm run build
     - name: Build
-      run: bash utils/docker/build.sh ${{ matrix.tag }} playwright:localbuild-${{ matrix.tag }}
+      run: bash utils/docker/build.sh --arm64 ${{ matrix.tag }} playwright:localbuild-${{ matrix.tag }}
     - name: Clean & Prepare for Docker
       run: |
         npm run clean

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -3,7 +3,7 @@ set -e
 set +x
 
 if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
-  echo "usage: $(basename $0) {bionic,focal} playwright:localbuild-focal"
+  echo "usage: $(basename $0) {--arm64,--amd64} {bionic,focal} playwright:localbuild-focal"
   echo
   echo "Build Playwright docker image and tag it as 'playwright:localbuild-focal'."
   echo "Once image is built, you can run it with"
@@ -17,7 +17,7 @@ if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
 fi
 
 function cleanup() {
-  rm -f "playwright.tar.gz"
+  rm -f "playwright-core.tar.gz"
 }
 
 trap "cleanup; cd $(pwd -P)" EXIT
@@ -27,4 +27,14 @@ cd "$(dirname "$0")"
 # image.
 node ../../utils/pack_package.js playwright-core ./playwright-core.tar.gz
 
-docker build -t "$2" -f "Dockerfile.$1" .
+PLATFORM=""
+if [[ "$1" == "--arm64" ]]; then
+  PLATFORM="linux/arm64";
+elif [[ "$1" == "--amd64" ]]; then
+  PLATFORM="linux/amd64"
+else
+  echo "ERROR: unknown platform specifier - $1. Only --arm64 or --amd64 is supported"
+  exit 1
+fi
+
+docker build --platform "${PLATFORM}" -t "$3" -f "Dockerfile.$2" .


### PR DESCRIPTION
Currently, arch is inhereted from host. This patch explicitly
sets desired docker build arch.

References #10351, #11292
