### PR TITLE
fix(test runner): hide beforeAll/afterAll hooks from the reporter api

### DIFF
--- a/docs/src/test-reporter-api/class-suite.md
+++ b/docs/src/test-reporter-api/class-suite.md
@@ -24,11 +24,6 @@ Reporter is given a root suite in the [`method: Reporter.onBegin`] method.
 
 Returns the list of all test cases in this suite and its descendants, as opposite to [`property: Suite.tests`].
 
-## property: Suite.hooks
-- type: <[Array]<[TestCase]>>
-
-`beforeAll` and `afterAll` hooks in the suite. Note that other hooks such as `beforeEach` and `afterEach` are reported as the steps within the test.
-
 ## property: Suite.location
 - type: <[void]|[Location]>
 

--- a/packages/playwright-test/src/reporters/json.ts
+++ b/packages/playwright-test/src/reporters/json.ts
@@ -42,7 +42,6 @@ export interface JSONReportSuite {
   column: number;
   line: number;
   specs: JSONReportSpec[];
-  hooks: JSONReportSpec[];
   suites?: JSONReportSuite[];
 }
 export interface JSONReportSpec {
@@ -208,7 +207,6 @@ class JSONReporter implements Reporter {
       title: suite.title,
       ...this._relativeLocation(suite.location),
       specs: suite.tests.map(test => this._serializeTestSpec(test)),
-      hooks: suite.hooks.map(test => this._serializeTestSpec(test)),
       suites: suites.length ? suites : undefined,
     };
   }

--- a/packages/playwright-test/src/reporters/raw.ts
+++ b/packages/playwright-test/src/reporters/raw.ts
@@ -190,7 +190,7 @@ class RawReporter {
       location,
       suites: suite.suites.map(s => this._serializeSuite(s)),
       tests: suite.tests.map(t => this._serializeTest(t, fileId)),
-      hooks: suite.hooks.map(t => this._serializeTest(t, fileId)),
+      hooks: [],
     };
   }
 

--- a/packages/playwright-test/types/testReporter.d.ts
+++ b/packages/playwright-test/types/testReporter.d.ts
@@ -85,11 +85,6 @@ export interface Suite {
    */
   tests: TestCase[];
   /**
-   * `beforeAll` and `afterAll` hooks in the suite. Note that other hooks such as `beforeEach` and `afterEach` are reported
-   * as the steps within the test.
-   */
-  hooks: TestCase[];
-  /**
    * Returns a list of titles from the root down to this suite.
    */
   titlePath(): string[];

--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -587,28 +587,3 @@ test('should not hang and report results when worker process suddenly exits duri
   expect(stripAscii(result.output)).toContain('[1/1] a.spec.js:6:7 › passed');
   expect(stripAscii(result.output)).toContain('[1/1] a.spec.js:7:12 › afterAll');
 });
-
-test('same beforeAll running in parallel should be reported correctly', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'a.spec.js': `
-      const { test } = pwt;
-      test.describe.parallel('', () => {
-        test.beforeAll(async () => {
-          await new Promise(f => setTimeout(f, 3000));
-        });
-        test('test1', () => {});
-        test('test2', () => {});
-      });
-    `
-  });
-  expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(2);
-  const hook = result.report.suites[0].suites[0].hooks[0];
-  expect(hook.title).toBe('beforeAll');
-  expect(hook.tests.length).toBe(1);
-  expect(hook.tests[0].results.length).toBe(2);
-  expect(hook.tests[0].results[0].status).toBe('passed');
-  expect(hook.tests[0].results[1].status).toBe('passed');
-  const workers = [hook.tests[0].results[0].workerIndex, hook.tests[0].results[1].workerIndex];
-  expect(workers.sort()).toEqual([0, 1]);
-});

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -325,45 +325,6 @@ test('should render annotations', async ({ runInlineTest, page, showReport }) =>
   await expect(page.locator('.test-case-annotation')).toHaveText('skip: I am not interested in this test');
 });
 
-test('should render beforeAll/afterAll hooks', async ({ runInlineTest, page, showReport }) => {
-  const result = await runInlineTest({
-    'a.test.js': `
-      const { test } = pwt;
-      test.use({ trace: 'on' });
-      test.beforeAll(async () => {
-      });
-      test.afterAll(async ({ browser }) => {
-        const page = await browser.newPage();
-        await page.close();
-        await test.step('after step', () => {
-          throw new Error('oh!');
-        });
-      });
-      test('test', async ({}) => {
-      });
-    `,
-  }, { reporter: 'dot,html' });
-  expect(result.exitCode).toBe(1);
-  expect(result.passed).toBe(1);
-
-  await showReport();
-  await expect(page.locator('.subnav-item:has-text("All") .counter')).toHaveText('1');
-  await expect(page.locator('.subnav-item:has-text("Passed") .counter')).toHaveText('1');
-  await expect(page.locator('.subnav-item:has-text("Failed") .counter')).toHaveText('0');
-  await expect(page.locator('.subnav-item:has-text("Flaky") .counter')).toHaveText('0');
-  await expect(page.locator('.subnav-item:has-text("Skipped") .counter')).toHaveText('0');
-
-  await expect(page.locator('text=beforeAll')).toBeVisible();
-  await expect(page.locator('.test-file-test:has-text("beforeAll") svg.color-icon-success')).toHaveCount(1);
-
-  await expect(page.locator('text=afterAll')).toBeVisible();
-  await expect(page.locator('.test-file-test:has-text("afterAll") svg.color-text-danger')).toHaveCount(1);
-
-  await page.click('text=afterAll');
-  await expect(page.locator('.tree-item:has-text("after step") svg.color-text-danger')).toHaveCount(1);
-  await expect(page.locator('img')).toBeVisible();
-});
-
 test('should render text attachments as text', async ({ runInlineTest, page, showReport }) => {
   const result = await runInlineTest({
     'a.test.js': `

--- a/tests/playwright-test/retry.spec.ts
+++ b/tests/playwright-test/retry.spec.ts
@@ -162,7 +162,7 @@ test('should retry beforeAll failure', async ({ runInlineTest }) => {
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);
   expect(result.skipped).toBe(1);
-  expect(stripAscii(result.output).split('\n')[2]).toBe('××°F×°FF°');
+  expect(stripAscii(result.output).split('\n')[2]).toBe('×°×°F°');
   expect(result.output).toContain('BeforeAll is bugged!');
 });
 

--- a/tests/playwright-test/stdio.spec.ts
+++ b/tests/playwright-test/stdio.spec.ts
@@ -61,19 +61,6 @@ test('should get stdio from worker fixture teardown', async ({ runInlineTest }) 
   ]);
 });
 
-test('should get stdio from beforeAll and afterAll', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'a.spec.js': `
-      const { test } = pwt;
-      test.beforeAll(() => console.log('before'));
-      test('is a test', () => {});
-      test.afterAll(() => console.error('after'));
-    `
-  });
-  expect(result.report.suites[0].hooks[0].tests[0].results[0].stdout).toEqual([{ text: 'before\n' }]);
-  expect(result.report.suites[0].hooks[1].tests[0].results[0].stderr).toEqual([{ text: 'after\n' }]);
-});
-
 test('should ignore stdio when quiet', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `

--- a/utils/generate_types/overrides-testReporter.d.ts
+++ b/utils/generate_types/overrides-testReporter.d.ts
@@ -29,7 +29,6 @@ export interface Suite {
   location?: Location;
   suites: Suite[];
   tests: TestCase[];
-  hooks: TestCase[];
   titlePath(): string[];
   allTests(): TestCase[];
   project(): FullProject | undefined;


### PR DESCRIPTION
This api is not ready yet. References #10707.