### PR TITLE
fix(electron): remove timeout from electronApp.close

### DIFF
--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -83,7 +83,7 @@ export class ElectronApplication extends SdkObject {
 
   async close() {
     const progressController = new ProgressController(internalCallMetadata(), this);
-    const closed = progressController.run(progress => helper.waitForEvent(progress, this, ElectronApplication.Events.Close).promise, this._timeoutSettings.timeout({}));
+    const closed = progressController.run(progress => helper.waitForEvent(progress, this, ElectronApplication.Events.Close).promise);
     await this._browserContext.close(internalCallMetadata());
     this._nodeConnection.close();
     await closed;


### PR DESCRIPTION
We do not have a timeout for any other close method, such as
`browserContext.close` or `browser.close`, and hitting default
30 seconds is very realistic with large Electron apps.

Fixes #11068.