### PR TITLE
fix: default list reporter should dump stderr to stderr

### DIFF
--- a/installation-tests/installation-tests.sh
+++ b/installation-tests/installation-tests.sh
@@ -633,7 +633,7 @@ function test_playwright_test_stacks_should_work {
   copy_test_scripts
 
   echo "Running playwright test"
-  OUTPUT=$(DEBUG=pw:api npx playwright test -c . failing.spec.js || true)
+  OUTPUT=$(DEBUG=pw:api npx playwright test -c . failing.spec.js 2>&1 || true)
   if [[ "${OUTPUT}" != *"expect.toHaveText started"* ]]; then
     echo "ERROR: missing 'expect.toHaveText started' in the output"
     exit 1

--- a/packages/playwright-test/src/reporters/list.ts
+++ b/packages/playwright-test/src/reporters/list.ts
@@ -67,7 +67,7 @@ class ListReporter extends BaseReporter {
 
   override onStdErr(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
     super.onStdErr(chunk, test, result);
-    this._dumpToStdio(test, chunk, process.stdout);
+    this._dumpToStdio(test, chunk, process.stderr);
   }
 
   onStepBegin(test: TestCase, result: TestResult, step: TestStep) {


### PR DESCRIPTION
This is consistent with all other reporters we have in place.

