### PR TITLE
chore: cut v1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-internal",
-  "version": "1.18.0-next",
+  "version": "1.19.0-next",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-internal",
-      "version": "1.18.0-next",
+      "version": "1.19.0-next",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -9051,7 +9051,7 @@
     },
     "packages/html-reporter": {},
     "packages/playwright": {
-      "version": "1.18.0-next",
+      "version": "1.19.0-next",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9065,7 +9065,7 @@
       }
     },
     "packages/playwright-chromium": {
-      "version": "1.18.0-next",
+      "version": "1.19.0-next",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9079,7 +9079,7 @@
       }
     },
     "packages/playwright-core": {
-      "version": "1.18.0-next",
+      "version": "1.19.0-next",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^8.2.0",
@@ -9115,7 +9115,7 @@
       }
     },
     "packages/playwright-firefox": {
-      "version": "1.18.0-next",
+      "version": "1.19.0-next",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9130,7 +9130,7 @@
     },
     "packages/playwright-test": {
       "name": "@playwright/test",
-      "version": "1.18.0-next",
+      "version": "1.19.0-next",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
@@ -9165,7 +9165,7 @@
         "open": "^8.3.0",
         "pirates": "^4.0.1",
         "pixelmatch": "^5.2.1",
-        "playwright-core": "=1.18.0-next",
+        "playwright-core": "=1.19.0-next",
         "pngjs": "^5.0.0",
         "rimraf": "^3.0.2",
         "source-map-support": "^0.4.18",
@@ -9204,7 +9204,7 @@
       }
     },
     "packages/playwright-webkit": {
-      "version": "1.18.0-next",
+      "version": "1.19.0-next",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-internal",
   "private": true,
-  "version": "1.18.0-next",
+  "version": "1.19.0-next",
   "description": "A high-level API to automate web browsers",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",

--- a/packages/playwright-chromium/package.json
+++ b/packages/playwright-chromium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-chromium",
-  "version": "1.18.0-next",
+  "version": "1.19.0-next",
   "description": "A high-level API to automate Chromium",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
@@ -26,6 +26,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "=1.18.0-next"
+    "playwright-core": "=1.19.0-next"
   }
 }

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-core",
-  "version": "1.18.0-next",
+  "version": "1.19.0-next",
   "description": "A high-level API to automate web browsers",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",

--- a/packages/playwright-firefox/package.json
+++ b/packages/playwright-firefox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-firefox",
-  "version": "1.18.0-next",
+  "version": "1.19.0-next",
   "description": "A high-level API to automate Firefox",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
@@ -26,6 +26,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "=1.18.0-next"
+    "playwright-core": "=1.19.0-next"
   }
 }

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/test",
-  "version": "1.18.0-next",
+  "version": "1.19.0-next",
   "description": "A high-level API to automate web browsers",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
@@ -59,7 +59,7 @@
     "open": "^8.3.0",
     "pirates": "^4.0.1",
     "pixelmatch": "^5.2.1",
-    "playwright-core": "=1.18.0-next",
+    "playwright-core": "=1.19.0-next",
     "pngjs": "^5.0.0",
     "rimraf": "^3.0.2",
     "source-map-support": "^0.4.18",

--- a/packages/playwright-webkit/package.json
+++ b/packages/playwright-webkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-webkit",
-  "version": "1.18.0-next",
+  "version": "1.19.0-next",
   "description": "A high-level API to automate WebKit",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
@@ -25,6 +25,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "=1.18.0-next"
+    "playwright-core": "=1.19.0-next"
   }
 }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright",
-  "version": "1.18.0-next",
+  "version": "1.19.0-next",
   "description": "A high-level API to automate web browsers",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
@@ -26,6 +26,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "=1.18.0-next"
+    "playwright-core": "=1.19.0-next"
   }
 }

--- a/utils/bump_package_versions.js
+++ b/utils/bump_package_versions.js
@@ -20,10 +20,12 @@ const path = require('path');
 const fs = require('fs');
 const { execSync } = require('child_process');
 
-const { packages } = require('./list_packages.js');
+const { packages, packagesToPublish } = require('./list_packages.js');
 
 (async () => {
   const version = process.argv[2];
+  if (version.startsWith('v'))
+    throw new Error('Version must not start with "v"');
   if (!version)
     throw new Error('Please specify version! See --help for more information.');
   if (process.argv[2] === '--help')
@@ -46,9 +48,11 @@ const { packages } = require('./list_packages.js');
   {
     const packageLockPath = path.join(rootDir, 'package-lock.json');
     const packageLock = JSON.parse(fs.readFileSync(packageLockPath, 'utf8'));
+    const publicPackages = new Set(packagesToPublish.map(package => path.basename(package)));
     for (const package of packages.map(package => path.basename(package))) {
       const playwrightCorePackages = packageLock['packages']['packages/' + package];
-      playwrightCorePackages.version = version;
+      if (publicPackages.has(package))
+        playwrightCorePackages.version = version;
       if (playwrightCorePackages.dependencies && playwrightCorePackages.dependencies['playwright-core'])
         packageLock['packages']['packages/playwright-test']['dependencies']['playwright-core'] = '=' + version;
     }


### PR DESCRIPTION
Drive-by: fix `//utils/bump_package_version.js` to take care of `html-reporter` package. 