### PR TITLE
fix(android): use isRegExp for a more robust check in different execution contexts

### DIFF
--- a/packages/playwright-core/src/client/android.ts
+++ b/packages/playwright-core/src/client/android.ts
@@ -15,7 +15,7 @@
  */
 
 import fs from 'fs';
-import { isString } from '../utils/utils';
+import { isString, isRegExp } from '../utils/utils';
 import * as channels from '../protocol/channels';
 import { Events } from './events';
 import { BrowserContext, prepareBrowserContextParams } from './browserContext';
@@ -289,7 +289,7 @@ function toSelectorChannel(selector: api.AndroidSelector): channels.AndroidSelec
   const toRegex = (value: RegExp | string | undefined): string | undefined => {
     if (value === undefined)
       return undefined;
-    if (value instanceof RegExp)
+    if (isRegExp(value))
       return value.source;
     return '^' + value.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d') + '$';
   };


### PR DESCRIPTION
See upcoming issue.

<!--
Thank you for your Pull Request. Please link to the issue this PR addresses.
-->
Fixes #11360

<!-- PR Checklist
- The issue has been triaged and positive signals were received from maintainers
- Existing tests pass
- New tests are added
- Relevant documentation is changed or added
-->
