### PR TITLE
fix: update to @dabh/colors for safe alternative

### DIFF
--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -46,7 +46,7 @@
     "@babel/plugin-transform-react-jsx": "^7.14.5",
     "@babel/preset-typescript": "^7.14.5",
     "babel-plugin-module-resolver": "^4.1.0",
-    "colors": "1.4.0",
+    "@dabh/colors": "^1.4.0",
     "commander": "^8.2.0",
     "debug": "^4.1.1",
     "expect": "=27.2.5",


### PR DESCRIPTION
This PR updates the color package to using [@dabh/colors](https://www.npmjs.com/package/@dabh/colors) as stated on this [colors issue #317](https://github.com/Marak/colors.js/issues/317#issue-1098535594) which is a safe alternative.

