### PR TITLE
feat(junit reporter): link testcases to Xray test issues and provide additional metadata for Xray Test Management

### DIFF
--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -393,7 +393,12 @@ The JUnit reporter provides support for embedding additional information on the 
 
 In configuration file, a set of options can be used to configure this behavior. A full example, in this case for Xray, follows ahead.
 
-```js js-flavor=ts
+```js js-flavor=js
+// playwright.config.js
+// @ts-check
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+
 // JUnit reporter config for Xray
 const xrayOptions = {
   // Whether to add <properties> with all annotations; default is false
@@ -411,15 +416,60 @@ const xrayOptions = {
   outputFile: './xray-report.xml'
 };
 
-module.exports = {
-  reporter: [['junit', xrayOptions]]
+const config = {
+  reporter: [ ['junit', xrayOptions] ]
 };
+
+module.exports = config;
+```
+
+```js js-flavor=ts
+// playwright.config.ts
+import { PlaywrightTestConfig } from '@playwright/test';
+
+// JUnit reporter config for Xray
+const xrayOptions = {
+  // Whether to add <properties> with all annotations; default is false
+  embedAnnotationsAsProperties: true,
+
+  // By default, annotation is reported as <property name='' value=''>.
+  // These annotations are reported as <property name=''>value</property>.
+  textContentAnnotations: ['test_description'],
+
+  // This will create a "testrun_evidence" property that contains all attachments. Each attachment is added as an inner <item> element.
+  // Disables [[ATTACHMENT|path]] in the <system-out>.
+  embedAttachmentsAsProperty: 'testrun_evidence',
+
+  // Where to put the report.
+  outputFile: './xray-report.xml'
+};
+
+const config: PlaywrightTestConfig = {
+  reporter: [ ['junit', xrayOptions] ]
+};
+
+export default config;
 ```
 
 In the previous configuration sample, all annotations will be added as `<property>` elements on the JUnit XML report. The annotation type is mapped to the `name` attribute of the `<property>`, and the annotation description will be added as a `value` attribute. In this case, the exception will be the annotation type `testrun_evidence` whose description will be added as inner content on the respective `<property>`.
 Annotations can be used to, for example, link a Playwright test with an existing Test in Xray or to link a test with an existing story/requirement in Jira (i.e., "cover" it).
 
 ```js js-flavor=js
+// @ts-check
+const { test } = require('@playwright/test');
+
+test('using specific annotations for passing test metadata to Xray', async ({}, testInfo) => {
+  testInfo.annotations.push({ type: 'test_id', description: '1234' });
+  testInfo.annotations.push({ type: 'test_key', description: 'CALC-2' });
+  testInfo.annotations.push({ type: 'test_summary', description: 'sample summary' });
+  testInfo.annotations.push({ type: 'requirements', description: 'CALC-5,CALC-6' });
+  testInfo.annotations.push({ type: 'test_description', description: 'sample description' });
+});
+```
+
+```js js-flavor=ts
+import { test } from '@playwright/test';
+
 test('using specific annotations for passing test metadata to Xray', async ({}, testInfo) => {
   testInfo.annotations.push({ type: 'test_id', description: '1234' });
   testInfo.annotations.push({ type: 'test_key', description: 'CALC-2' });
@@ -434,6 +484,8 @@ Please note that the semantics of these properties will depend on the tool that 
 If the configuration option `embedAttachmentsAsProperty` is defined, then a `property` with its name is created. Attachments, including their contents, will be embeded on the JUnit XML report inside `<item>` elements under this `property`. Attachments are obtained from the `TestInfo` object, using either a path or a body, and are added as base64 encoded content.
 Embedding attachments can be used to attach screenshots or any other relevant evidence; nevertheless, use it wisely as it affects the report size.
 
+The following configuration sample enables embedding attachments by using the `testrun_evidence` element on the JUnit XML report:
+
 ```js js-flavor=js
 // playwright.config.js
 // @ts-check
@@ -442,14 +494,43 @@ Embedding attachments can be used to attach screenshots or any other relevant ev
 const config = {
   reporter: [ ['junit', { embedAttachmentsAsProperty: 'testrun_evidence', outputFile: 'results.xml' }] ],
 };
+
+module.exports = config;
 ```
 
+```js js-flavor=ts
+// playwright.config.js
+
+import { PlaywrightTestConfig } from '@playwright/test';
+const config: PlaywrightTestConfig = {
+  reporter: [ ['junit', { embedAttachmentsAsProperty: 'testrun_evidence', outputFile: 'results.xml' }] ],
+};
+
+export default config;
+```
+
+The following test adds attachments:
+
 ```js js-flavor=js
+// @ts-check
+const { test } = require('@playwright/test');
+
 test('embed attachments, including its content, on the JUnit report', async ({}, testInfo) => {
   const file = testInfo.outputPath('evidence1.txt');
   require('fs').writeFileSync(file, 'hello', 'utf8');
-  testInfo.attachments.push({ name: 'evidence1.txt', path: file, contentType: 'text/plain' });
-  testInfo.attachments.push({ name: 'evidence2.txt', body: Buffer.from('world'), contentType: 'text/plain' });
+  await testInfo.attach('evidence1.txt', { path: file, contentType: 'text/plain' });
+  await testInfo.attach('evidence2.txt', { body: Buffer.from('world'), contentType: 'text/plain' });
+});
+```
+
+```js js-flavor=ts
+import { test } from '@playwright/test';
+
+test('embed attachments, including its content, on the JUnit report', async ({}, testInfo) => {
+  const file = testInfo.outputPath('evidence1.txt');
+  require('fs').writeFileSync(file, 'hello', 'utf8');
+  await testInfo.attach('evidence1.txt', { path: file, contentType: 'text/plain' });
+  await testInfo.attach('evidence2.txt', { body: Buffer.from('world'), contentType: 'text/plain' });
 });
 ```
 

--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -442,6 +442,7 @@ Embedding attachments can be used to attach screenshots or any other relevant ev
 const config = {
   reporter: [ ['junit', { embedAttachmentsAsProperty: 'testrun_evidence', outputFile: 'results.xml' }] ],
 };
+```
 
 ```js js-flavor=js
 test('embed attachments, including its content, on the JUnit report', async ({}, testInfo) => {

--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -389,6 +389,31 @@ const config: PlaywrightTestConfig = {
 export default config;
 ```
 
+The JUnit reporter also provides support for Xray Test Management, which uses an evolved JUnit XML format to provide additional information on the `testcase` elements using inner `properties`. Specific annotations can be used to, for example, link a Playwright test with an existing Test in Xray or to link a test with an existing story/requirement in Jira (i.e., "cover" it). For more information about the available properties and their semantics, please check [Xray Test Management documentation](https://docs.getxray.app/display/XRAYCLOUD/Taking+advantage+of+JUnit+XML+reports).
+
+```js js-flavor=js
+test('using specific annotations for passing test metadata to Xray', async ({}, testInfo) => {
+  testInfo.annotations.push({ type: 'test_id', description: '1234' });
+  testInfo.annotations.push({ type: 'test_key', description: 'CALC-2' });
+  testInfo.annotations.push({ type: 'test_summary', description: 'sample summary' });
+  testInfo.annotations.push({ type: 'requirements', description: 'CALC-5,CALC-6' });
+  testInfo.annotations.push({ type: 'test_description', description: 'sample description' });
+});
+```
+
+A more advanced scenario is supported by Xray: the ability to embed attachments, including their contents, on the JUnit XML report. For that, the `embed_attachments_in_report` annotation must be specified, having the `true` value as its description. Attachments are obtained from the `TestInfo` object, using either a path or a body, and are embed as base64 encoded content on a custom `property` on the JUnit report.
+Embedding attachments can be used to attach screenshots or any other relevant evidence; nevertheless, use it wisely as it affects the report size.
+
+```js js-flavor=js
+test('embed attachments on the JUnit report processable by Xray', async ({}, testInfo) => {
+  testInfo.annotations.push({ type: 'embed_attachments_in_report', description: 'true' });
+  const file = testInfo.outputPath('evidence1.txt');
+  require('fs').writeFileSync(file, 'hello', 'utf8');
+  testInfo.attachments.push({ name: 'evidence1.txt', path: file, contentType: 'text/plain' });
+  testInfo.attachments.push({ name: 'evidence2.txt', body: Buffer.from('world'), contentType: 'text/plain' });
+});
+```
+
 ### GitHub Actions annotations
 
 You can use the built in `github` reporter to get automatic failure annotations when running in GitHub actions.

--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -389,7 +389,35 @@ const config: PlaywrightTestConfig = {
 export default config;
 ```
 
-The JUnit reporter also provides support for Xray Test Management, which uses an evolved JUnit XML format to provide additional information on the `testcase` elements using inner `properties`. Specific annotations can be used to, for example, link a Playwright test with an existing Test in Xray or to link a test with an existing story/requirement in Jira (i.e., "cover" it). For more information about the available properties and their semantics, please check [Xray Test Management documentation](https://docs.getxray.app/display/XRAYCLOUD/Taking+advantage+of+JUnit+XML+reports).
+The JUnit reporter provides support for embedding additional information on the `testcase` elements using inner `properties`. This is based on an [evolved JUnit XML format](https://docs.getxray.app/display/XRAYCLOUD/Taking+advantage+of+JUnit+XML+reports) from Xray Test Management, but can also be used by other tools if they support this way of embedding additonal information for test results; please check it first.
+
+In configuration file, a set of options can be used to configure this behavior. A full example, in this case for Xray, follows ahead.
+
+```js js-flavor=ts
+// JUnit reporter config for Xray
+const xrayOptions = {
+  // Whether to add <properties> with all annotations; default is false
+  embedAnnotationsAsProperties: true,
+
+  // By default, annotation is reported as <property name='' value=''>.
+  // These annotations are reported as <property name=''>value</property>.
+  textContentAnnotations: ['test_description'],
+
+  // This will create a "testrun_evidence" property that contains all attachments. Each attachment is added as an inner <item> element.
+  // Disables [[ATTACHMENT|path]] in the <system-out>.
+  embedAttachmentsAsProperty: 'testrun_evidence',
+
+  // Where to put the report.
+  outputFile: './xray-report.xml'
+};
+
+module.exports = {
+  reporter: [['junit', xrayOptions]]
+};
+```
+
+In the previous configuration sample, all annotations will be added as `<property>` elements on the JUnit XML report. The annotation type is mapped to the `name` attribute of the `<property>`, and the annotation description will be added as a `value` attribute. In this case, the exception will be the annotation type `testrun_evidence` whose description will be added as inner content on the respective `<property>`.
+Annotations can be used to, for example, link a Playwright test with an existing Test in Xray or to link a test with an existing story/requirement in Jira (i.e., "cover" it).
 
 ```js js-flavor=js
 test('using specific annotations for passing test metadata to Xray', async ({}, testInfo) => {
@@ -401,12 +429,22 @@ test('using specific annotations for passing test metadata to Xray', async ({}, 
 });
 ```
 
-A more advanced scenario is supported by Xray: the ability to embed attachments, including their contents, on the JUnit XML report. For that, the `embed_attachments_in_report` annotation must be specified, having the `true` value as its description. Attachments are obtained from the `TestInfo` object, using either a path or a body, and are embed as base64 encoded content on a custom `property` on the JUnit report.
+Please note that the semantics of these properties will depend on the tool that will process this evoled report format; there are no standard property names/annotations.
+
+If the configuration option `embedAttachmentsAsProperty` is defined, then a `property` with its name is created. Attachments, including their contents, will be embeded on the JUnit XML report inside `<item>` elements under this `property`. Attachments are obtained from the `TestInfo` object, using either a path or a body, and are added as base64 encoded content.
 Embedding attachments can be used to attach screenshots or any other relevant evidence; nevertheless, use it wisely as it affects the report size.
 
 ```js js-flavor=js
-test('embed attachments on the JUnit report processable by Xray', async ({}, testInfo) => {
-  testInfo.annotations.push({ type: 'embed_attachments_in_report', description: 'true' });
+// playwright.config.js
+// @ts-check
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  reporter: [ ['junit', { embedAttachmentsAsProperty: 'testrun_evidence', outputFile: 'results.xml' }] ],
+};
+
+```js js-flavor=js
+test('embed attachments, including its content, on the JUnit report', async ({}, testInfo) => {
   const file = testInfo.outputPath('evidence1.txt');
   require('fs').writeFileSync(file, 'hello', 'utf8');
   testInfo.attachments.push({ name: 'evidence1.txt', path: file, contentType: 'text/plain' });

--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -218,7 +218,6 @@ class JUnitReporter implements Reporter {
       properties.children?.push(evidence);
     }
 
-    // TODO: check this
     if (properties.children?.length)
       entry.children.push(properties);
 

--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -172,6 +172,7 @@ class JUnitReporter implements Reporter {
       }
     }
 
+    const systemErr: string[] = [];
     // attachments are optionally embed as base64 encoded content on inner <item> elements
     if (this.embedAttachmentsAsProperty) {
       const evidence: XMLEntry = {
@@ -193,6 +194,8 @@ class JUnitReporter implements Reporter {
               const attachmentPath = path.relative(this.config.rootDir, attachment.path);
               if (fs.existsSync(attachmentPath))
                 contents = fs.readFileSync(attachmentPath, { encoding: 'base64' });
+              else
+                systemErr.push(`\nWarning: attachment ${attachmentPath} is missing`);
             } catch (e) {
             }
           }
@@ -233,7 +236,6 @@ class JUnitReporter implements Reporter {
     }
 
     const systemOut: string[] = [];
-    const systemErr: string[] = [];
     for (const result of test.results) {
       systemOut.push(...result.stdout.map(item => item.toString()));
       systemErr.push(...result.stderr.map(item => item.toString()));

--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -133,6 +133,43 @@ class JUnitReporter implements Reporter {
     };
     entries.push(entry);
 
+    const properties: XMLEntry = {
+      name: 'properties',
+      children: [] as XMLEntry[]
+    };
+
+    const testKey = test.annotations.find(annotation => {
+      return annotation.type === 'test_key';
+    });
+    if (testKey !== undefined) {
+      const property = {
+        name: 'property',
+        attributes: {
+          name: 'test_key',
+          value: testKey.description
+        }
+      };
+      properties.children.push(property);
+    }
+
+    const requirements = test.annotations.find(annotation => {
+      return annotation.type === 'requirements';
+    });
+    if (requirements !== undefined) {
+      const property = {
+        name: 'property',
+        attributes: {
+          name: 'requirements',
+          value: requirements.description
+        }
+      };
+      properties.children.push(property);
+    }
+
+    entry.children.push(properties);
+    //test.annotations
+
+
     if (test.outcome() === 'skipped') {
       entry.children.push({ name: 'skipped' });
       return;

--- a/tests/playwright-test/reporter-junit.spec.ts
+++ b/tests/playwright-test/reporter-junit.spec.ts
@@ -256,7 +256,7 @@ function parseXML(xml: string): any {
   return result;
 }
 
-test.only('should not render Xray text based annotations to custom testcase properties', async ({ runInlineTest }) => {
+test('should not render Xray text based annotations to custom testcase properties', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
       const { test } = pwt;
@@ -271,7 +271,7 @@ test.only('should not render Xray text based annotations to custom testcase prop
   expect(result.exitCode).toBe(0);
 });
 
-test.only('should render Xray text based annotations to custom testcase properties', async ({ runInlineTest }) => {
+test('should render Xray text based annotations to custom testcase properties', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
       const { test } = pwt;
@@ -303,7 +303,7 @@ test.only('should render Xray text based annotations to custom testcase properti
 });
 
 
-test.only('should embed attachments to a custom testcase property, if explictly requested', async ({ runInlineTest }) => {
+test('should embed attachments to a custom testcase property, if explictly requested', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
       const { test } = pwt;
@@ -328,7 +328,7 @@ test.only('should embed attachments to a custom testcase property, if explictly 
   expect(result.exitCode).toBe(0);
 });
 
-test.only('should not embed attachments to a custom testcase property, if not explictly requested', async ({ runInlineTest }) => {
+test('should not embed attachments to a custom testcase property, if not explictly requested', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
       const { test } = pwt;

--- a/tests/playwright-test/reporter-junit.spec.ts
+++ b/tests/playwright-test/reporter-junit.spec.ts
@@ -305,8 +305,7 @@ test('should render all annotations to testcase value based properties, if reque
   const result = await runInlineTest({
     'playwright.config.ts': `
       const xrayOptions = {
-        embedAnnotationsAsProperties: true,
-        textContentAnnotations: ['test_description']
+        embedAnnotationsAsProperties: true
       }
       module.exports = {
         reporter: [ ['junit', xrayOptions] ],
@@ -350,11 +349,12 @@ test('should embed attachments to a custom testcase property, if explictly reque
     'a.test.js': `
       const { test } = pwt;
       test('one', async ({}, testInfo) => {
-        testInfo.annotations.push({ type: 'embed_attachments_in_report', description: 'true' });
         const file = testInfo.outputPath('evidence1.txt');
         require('fs').writeFileSync(file, 'hello', 'utf8');
         testInfo.attachments.push({ name: 'evidence1.txt', path: file, contentType: 'text/plain' });
         testInfo.attachments.push({ name: 'evidence2.txt', body: Buffer.from('world'), contentType: 'text/plain' });
+        // await testInfo.attach('evidence1.txt', { path: file, contentType: 'text/plain' });
+        // await testInfo.attach('evidence2.txt', { body: Buffer.from('world'), contentType: 'text/plain' });
         console.log('log here');
       });
     `
@@ -384,6 +384,8 @@ test('should not embed attachments to a custom testcase property, if not explict
         require('fs').writeFileSync(file, 'hello', 'utf8');
         testInfo.attachments.push({ name: 'evidence1.txt', path: file, contentType: 'text/plain' });
         testInfo.attachments.push({ name: 'evidence2.txt', body: Buffer.from('world'), contentType: 'text/plain' });
+        // await testInfo.attach('evidence1.txt', { path: file, contentType: 'text/plain' });
+        // await testInfo.attach('evidence2.txt', { body: Buffer.from('world'), contentType: 'text/plain' });
       });
     `
   }, { reporter: 'junit' });

--- a/tests/playwright-test/reporter-junit.spec.ts
+++ b/tests/playwright-test/reporter-junit.spec.ts
@@ -282,7 +282,7 @@ test.only('should render Xray text based annotations to custom testcase properti
         testInfo.annotations.push({ type: 'requirements', description: 'CALC-5,CALC-6' });
         testInfo.annotations.push({ type: 'test_description', description: 'sample description' });
         testInfo.annotations.push({ type: 'unknown_annotation', description: 'unknown' });
-      });2
+      });
     `
   }, { reporter: 'junit' });
   const xml = parseXML(result.output);
@@ -313,7 +313,7 @@ test.only('should embed attachments to a custom testcase property, if explictly 
         require('fs').writeFileSync(file, 'hello', 'utf8');
         testInfo.attachments.push({ name: 'evidence1.txt', path: file, contentType: 'text/plain' });
         testInfo.attachments.push({ name: 'evidence2.txt', body: Buffer.from('world'), contentType: 'text/plain' });
-      });2
+      });
     `
   }, { reporter: 'junit' });
   const xml = parseXML(result.output);
@@ -337,7 +337,7 @@ test.only('should not embed attachments to a custom testcase property, if not ex
         require('fs').writeFileSync(file, 'hello', 'utf8');
         testInfo.attachments.push({ name: 'evidence1.txt', path: file, contentType: 'text/plain' });
         testInfo.attachments.push({ name: 'evidence2.txt', body: Buffer.from('world'), contentType: 'text/plain' });
-      });2
+      });
     `
   }, { reporter: 'junit' });
   const xml = parseXML(result.output);


### PR DESCRIPTION
Provides support for specific enhancements on the junit report, allowing deeper integration with Xray Test Management to show additional information on Jira side, or do some related operations upon the time of importing tesults.
The test metainformation may be specified using annotations on the `TestInfo` object.

This PR gives users the ability to:
- link a Playwright test to an existing Test in Xray, by referring its issue key using an annotation with type `test_key`
- link a Playwright test to an existing Test in Xray, by referring its issue id using an annotation with type `test_id`
- link a Playwright test to an existing story/requirement kinda of issue in Jira, by referring its key using an annotation with type `requirements`; multiple requirements may be specified, using comma as a delimiter on the annotation's description
- specify the Test issue' summary, to be used during provisioning of the Test in Xray if it doesn't exist yet, using an annotation with type 'test_summary'
- specify the Test issue's description, to be used during provisioning of the Test in Xray if it doesn't exist yet, using an annotation with type 'test_description'
- embed attachments, including its contents, on the report, by flagging it using a `embed_attachments_in_report` annotation with 'true' as its description
 
Resolves #9348 
