### PR TITLE
feat(locator): "has" option

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -876,5 +876,14 @@ Slows down Playwright operations by the specified amount of milliseconds. Useful
 Matches elements containing specified text somewhere inside, possibly in a child or a descendant element.
 For example, `"Playwright"` matches `<article><div>Playwright</div></article>`.
 
+## locator-option-has
+- `has` <[Locator]>
+
+Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
+For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
+
+Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+
 ## locator-options-list
 - %%-locator-option-has-text-%%
+- %%-locator-option-has-%%

--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -288,7 +288,7 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
     return await this._channel.highlight({ selector });
   }
 
-  locator(selector: string, options?: { hasText?: string | RegExp }): Locator {
+  locator(selector: string, options?: { hasText?: string | RegExp, has?: Locator }): Locator {
     return new Locator(this, selector, options);
   }
 

--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -29,7 +29,7 @@ export class Locator implements api.Locator {
   private _frame: Frame;
   private _selector: string;
 
-  constructor(frame: Frame, selector: string, options?: { hasText?: string | RegExp }) {
+  constructor(frame: Frame, selector: string, options?: { hasText?: string | RegExp, has?: Locator }) {
     this._frame = frame;
     this._selector = selector;
 
@@ -39,6 +39,12 @@ export class Locator implements api.Locator {
         this._selector += ` >> :scope:text-matches(${escapeWithQuotes(text.source, '"')}, "${text.flags}")`;
       else
         this._selector += ` >> :scope:has-text(${escapeWithQuotes(text, '"')})`;
+    }
+
+    if (options?.has) {
+      if (options.has._frame !== frame)
+        throw new Error(`Inner "has" locator must belong to the same frame.`);
+      this._selector += ` >> has=` + JSON.stringify(options.has._selector);
     }
   }
 
@@ -110,7 +116,7 @@ export class Locator implements api.Locator {
     return this._frame._highlight(this._selector);
   }
 
-  locator(selector: string, options?: { hasText?: string | RegExp }): Locator {
+  locator(selector: string, options?: { hasText?: string | RegExp, has?: Locator }): Locator {
     return new Locator(this._frame, this._selector + ' >> ' + selector, options);
   }
 

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -515,7 +515,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     return this._mainFrame.fill(selector, value, options);
   }
 
-  locator(selector: string, options?: { hasText?: string | RegExp }): Locator {
+  locator(selector: string, options?: { hasText?: string | RegExp, has?: Locator }): Locator {
     return this.mainFrame().locator(selector, options);
   }
 

--- a/packages/playwright-core/src/server/selectors.ts
+++ b/packages/playwright-core/src/server/selectors.ts
@@ -18,7 +18,7 @@ import * as dom from './dom';
 import * as frames from './frames';
 import * as js from './javascript';
 import * as types from './types';
-import { InvalidSelectorError, ParsedSelector, parseSelector, stringifySelector } from './common/selectorParser';
+import { allEngineNames, InvalidSelectorError, ParsedSelector, parseSelector, stringifySelector } from './common/selectorParser';
 import { createGuid } from '../utils/utils';
 
 export type SelectorInfo = {
@@ -44,7 +44,7 @@ export class Selectors {
       'data-testid', 'data-testid:light',
       'data-test-id', 'data-test-id:light',
       'data-test', 'data-test:light',
-      'nth', 'visible', 'control'
+      'nth', 'visible', 'control', 'has',
     ]);
     this._builtinEnginesInMainWorld = new Set([
       '_react', '_vue',
@@ -135,13 +135,13 @@ export class Selectors {
   parseSelector(selector: string | ParsedSelector, strict: boolean): SelectorInfo {
     const parsed = typeof selector === 'string' ? parseSelector(selector) : selector;
     let needsMainWorld = false;
-    for (const part of parsed.parts) {
-      const custom = this._engines.get(part.name);
-      if (!custom && !this._builtinEngines.has(part.name))
-        throw new InvalidSelectorError(`Unknown engine "${part.name}" while parsing selector ${stringifySelector(parsed)}`);
+    for (const name of allEngineNames(parsed)) {
+      const custom = this._engines.get(name);
+      if (!custom && !this._builtinEngines.has(name))
+        throw new InvalidSelectorError(`Unknown engine "${name}" while parsing selector ${stringifySelector(parsed)}`);
       if (custom && !custom.contentScript)
         needsMainWorld = true;
-      if (this._builtinEnginesInMainWorld.has(part.name))
+      if (this._builtinEnginesInMainWorld.has(name))
         needsMainWorld = true;
     }
     return {

--- a/packages/playwright-core/src/server/supplements/injected/consoleApi.ts
+++ b/packages/playwright-core/src/server/supplements/injected/consoleApi.ts
@@ -24,7 +24,7 @@ function createLocator(injectedScript: InjectedScript, initial: string, options?
     element: Element | undefined;
     elements: Element[];
 
-    constructor(selector: string, options?: { hasText?: string | RegExp }) {
+    constructor(selector: string, options?: { hasText?: string | RegExp, has?: Locator }) {
       this.selector = selector;
       if (options?.hasText) {
         const text = options.hasText;
@@ -33,12 +33,14 @@ function createLocator(injectedScript: InjectedScript, initial: string, options?
         else
           this.selector += ` >> :scope:has-text(${escapeWithQuotes(text)})`;
       }
+      if (options?.has)
+        this.selector += ` >> has=` + JSON.stringify(options.has.selector);
       const parsed = injectedScript.parseSelector(this.selector);
       this.element = injectedScript.querySelector(parsed, document, false);
       this.elements = injectedScript.querySelectorAll(parsed, document);
     }
 
-    locator(selector: string, options?: { hasText: string | RegExp }): Locator {
+    locator(selector: string, options?: { hasText: string | RegExp, has?: Locator }): Locator {
       return new Locator(this.selector ? this.selector + ' >> ' + selector : selector, options);
     }
   }
@@ -48,7 +50,7 @@ function createLocator(injectedScript: InjectedScript, initial: string, options?
 type ConsoleAPIInterface = {
   $: (selector: string) => void;
   $$: (selector: string) => void;
-  locator: (selector: string) => any;
+  locator: (selector: string, options?: { hasText: string | RegExp, has?: any }) => any;
   inspect: (selector: string) => void;
   selector: (element: Element) => void;
   resume: () => void;

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2571,6 +2571,14 @@ export interface Page {
    */
   locator(selector: string, options?: {
     /**
+     * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
+     * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    has?: Locator;
+
+    /**
      * Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. For example,
      * `"Playwright"` matches `<article><div>Playwright</div></article>`.
      */
@@ -5353,6 +5361,14 @@ export interface Frame {
    * @param options
    */
   locator(selector: string, options?: {
+    /**
+     * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
+     * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    has?: Locator;
+
     /**
      * Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. For example,
      * `"Playwright"` matches `<article><div>Playwright</div></article>`.
@@ -9266,6 +9282,14 @@ export interface Locator {
    * @param options
    */
   locator(selector: string, options?: {
+    /**
+     * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
+     * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    has?: Locator;
+
     /**
      * Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. For example,
      * `"Playwright"` matches `<article><div>Playwright</div></article>`.
@@ -13696,6 +13720,14 @@ export interface FrameLocator {
    * @param options
    */
   locator(selector: string, options?: {
+    /**
+     * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
+     * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    has?: Locator;
+
     /**
      * Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. For example,
      * `"Playwright"` matches `<article><div>Playwright</div></article>`.

--- a/tests/inspector/console-api.spec.ts
+++ b/tests/inspector/console-api.spec.ts
@@ -60,3 +60,9 @@ it('should support playwright.locator.values', async ({ page }) => {
   expect(await page.evaluate(`playwright.locator('div', { hasText: /ELL/i }).elements.length`)).toBe(1);
   expect(await page.evaluate(`playwright.locator('div', { hasText: /Hello/ }).elements.length`)).toBe(1);
 });
+
+it('should support playwright.locator({ has })', async ({ page }) => {
+  await page.setContent('<div>Hi</div><div><span>Hello</span></div>');
+  expect(await page.evaluate(`playwright.locator('div', { has: playwright.locator('span') }).element.innerHTML`)).toContain('Hello');
+  expect(await page.evaluate(`playwright.locator('div', { has: playwright.locator('text=Hello') }).element.innerHTML`)).toContain('span');
+});

--- a/tests/page/selectors-misc.spec.ts
+++ b/tests/page/selectors-misc.spec.ts
@@ -362,6 +362,7 @@ it('should work with has=', async ({ page, server }) => {
   expect(await page.$$eval(`div >> has="span"`, els => els.length)).toBe(2);
   expect(await page.$$eval(`div >> has="span >> text=wor"`, els => els.length)).toBe(1);
   expect(await page.$eval(`div >> has="span >> text=wor"`, e => e.outerHTML)).toBe(`<div><span>world</span></div>`);
+  expect(await page.$eval(`div >> has="span >> text=wor" >> span`, e => e.outerHTML)).toBe(`<span>world</span>`);
 
   const error1 = await page.$(`div >> has=abc`).catch(e => e);
   expect(error1.message).toContain('Malformed selector: has=abc');


### PR DESCRIPTION
This PR introduces `locator('div', { has: locator })` syntax that matches elements containing other elements. Can be used together with `hasText`.

Internally, `has` selector engine takes an inner selector escaped with double-quotes: `div >> has="li >> span >> text=Foo" >> span`.