### PR TITLE
fix(test runner): dispatcher transformation of empty attachments

### DIFF
--- a/packages/playwright-test/src/dispatcher.ts
+++ b/packages/playwright-test/src/dispatcher.ts
@@ -204,7 +204,7 @@ export class Dispatcher {
         name: a.name,
         path: a.path,
         contentType: a.contentType,
-        body: a.body ? Buffer.from(a.body, 'base64') : undefined
+        body: typeof a.body !== 'undefined' ? Buffer.from(a.body, 'base64') : undefined
       }));
       result.status = params.status;
       test.expectedStatus = params.expectedStatus;

--- a/tests/playwright-test/reporter-attachment.spec.ts
+++ b/tests/playwright-test/reporter-attachment.spec.ts
@@ -143,3 +143,35 @@ test(`testInfo.attach success in fixture`, async ({ runInlineTest }) => {
   expect(result.failed).toBe(1);
   expect(stripAscii(result.output)).toContain('attachment #1: name (text/plain)');
 });
+
+test(`testInfo.attach allow empty string body`, async ({ runInlineTest }) => {
+  test.fail(true, `Currently throws TypeError: Cannot read property 'toString' of undefined: https://github.com/microsoft/playwright/issues/11413`);
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test('success', async ({}, testInfo) => {
+        await testInfo.attach('name', { body: '', contentType: 'text/plain' });
+        expect(0).toBe(1);
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(stripAscii(result.output)).toContain('attachment #1: name (text/plain)');
+});
+
+test(`testInfo.attach allow empty buffer body`, async ({ runInlineTest }) => {
+  test.fail(true, `Currently throws TypeError: Cannot read property 'toString' of undefined: https://github.com/microsoft/playwright/issues/11413`);
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test('success', async ({}, testInfo) => {
+        await testInfo.attach('name', { body: Buffer.from(''), contentType: 'text/plain' });
+        expect(0).toBe(1);
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(stripAscii(result.output)).toContain('attachment #1: name (text/plain)');
+});

--- a/tests/playwright-test/reporter-attachment.spec.ts
+++ b/tests/playwright-test/reporter-attachment.spec.ts
@@ -145,7 +145,6 @@ test(`testInfo.attach success in fixture`, async ({ runInlineTest }) => {
 });
 
 test(`testInfo.attach allow empty string body`, async ({ runInlineTest }) => {
-  test.fail(true, `Currently throws TypeError: Cannot read property 'toString' of undefined: https://github.com/microsoft/playwright/issues/11413`);
   const result = await runInlineTest({
     'a.test.js': `
       const { test } = pwt;
@@ -157,11 +156,10 @@ test(`testInfo.attach allow empty string body`, async ({ runInlineTest }) => {
   });
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(stripAscii(result.output)).toContain('attachment #1: name (text/plain)');
+  expect(stripAscii(result.output)).toMatch(/^.*attachment #1: name \(text\/plain\).*\n.*\n.*------/gm);
 });
 
 test(`testInfo.attach allow empty buffer body`, async ({ runInlineTest }) => {
-  test.fail(true, `Currently throws TypeError: Cannot read property 'toString' of undefined: https://github.com/microsoft/playwright/issues/11413`);
   const result = await runInlineTest({
     'a.test.js': `
       const { test } = pwt;
@@ -173,5 +171,5 @@ test(`testInfo.attach allow empty buffer body`, async ({ runInlineTest }) => {
   });
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(stripAscii(result.output)).toContain('attachment #1: name (text/plain)');
+  expect(stripAscii(result.output)).toMatch(/^.*attachment #1: name \(text\/plain\).*\n.*\n.*------/gm);
 });


### PR DESCRIPTION
Fixes #11413
