### PR TITLE
fix: falsey behavior in route.continue, page.post, testInfo.attach

### DIFF
--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -78,7 +78,7 @@ export class Request extends ChannelOwner<channels.RequestChannel> implements ap
     if (this._redirectedFrom)
       this._redirectedFrom._redirectedTo = this;
     this._provisionalHeaders = new RawHeaders(initializer.headers);
-    this._postData = initializer.postData ? Buffer.from(initializer.postData, 'base64') : null;
+    this._postData = isString(initializer.postData) ? Buffer.from(initializer.postData, 'base64') : null;
     this._timing = {
       startTime: 0,
       domainLookupStart: -1,

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -78,7 +78,7 @@ export class Request extends ChannelOwner<channels.RequestChannel> implements ap
     if (this._redirectedFrom)
       this._redirectedFrom._redirectedTo = this;
     this._provisionalHeaders = new RawHeaders(initializer.headers);
-    this._postData = isString(initializer.postData) ? Buffer.from(initializer.postData, 'base64') : null;
+    this._postData = initializer.postData !== undefined ? Buffer.from(initializer.postData, 'base64') : null;
     this._timing = {
       startTime: 0,
       domainLookupStart: -1,

--- a/packages/playwright-core/src/dispatchers/networkDispatchers.ts
+++ b/packages/playwright-core/src/dispatchers/networkDispatchers.ts
@@ -18,6 +18,7 @@ import * as channels from '../protocol/channels';
 import { APIRequestContext } from '../server/fetch';
 import { CallMetadata } from '../server/instrumentation';
 import { Request, Response, Route, WebSocket } from '../server/network';
+import { isString } from '../utils/utils';
 import { Dispatcher, DispatcherScope, existingDispatcher, lookupNullableDispatcher } from './dispatcher';
 import { FrameDispatcher } from './frameDispatcher';
 
@@ -122,7 +123,7 @@ export class RouteDispatcher extends Dispatcher<Route, channels.RouteChannel> im
       url: params.url,
       method: params.method,
       headers: params.headers,
-      postData: params.postData ? Buffer.from(params.postData, 'base64') : undefined,
+      postData: isString(params.postData) ? Buffer.from(params.postData, 'base64') : undefined,
     });
   }
 

--- a/packages/playwright-core/src/dispatchers/networkDispatchers.ts
+++ b/packages/playwright-core/src/dispatchers/networkDispatchers.ts
@@ -18,7 +18,6 @@ import * as channels from '../protocol/channels';
 import { APIRequestContext } from '../server/fetch';
 import { CallMetadata } from '../server/instrumentation';
 import { Request, Response, Route, WebSocket } from '../server/network';
-import { isString } from '../utils/utils';
 import { Dispatcher, DispatcherScope, existingDispatcher, lookupNullableDispatcher } from './dispatcher';
 import { FrameDispatcher } from './frameDispatcher';
 
@@ -123,7 +122,7 @@ export class RouteDispatcher extends Dispatcher<Route, channels.RouteChannel> im
       url: params.url,
       method: params.method,
       headers: params.headers,
-      postData: isString(params.postData) ? Buffer.from(params.postData, 'base64') : undefined,
+      postData: params.postData !== undefined ? Buffer.from(params.postData, 'base64') : undefined,
     });
   }
 

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -25,7 +25,7 @@ import zlib from 'zlib';
 import { HTTPCredentials } from '../../types/types';
 import * as channels from '../protocol/channels';
 import { TimeoutSettings } from '../utils/timeoutSettings';
-import { assert, createGuid, getUserAgent, isString, monotonicTime } from '../utils/utils';
+import { assert, createGuid, getUserAgent, monotonicTime } from '../utils/utils';
 import { BrowserContext } from './browserContext';
 import { CookieStore, domainMatches } from './cookieStore';
 import { MultipartFormData } from './formData';
@@ -583,7 +583,7 @@ function serializePostData(params: channels.APIRequestContextFetchParams, header
     }
     headers['content-type'] ??= formData.contentTypeHeader();
     return formData.finish();
-  } else if (isString(params.postData)) {
+  } else if (params.postData !== undefined) {
     headers['content-type'] ??= 'application/octet-stream';
     return Buffer.from(params.postData, 'base64');
   }

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -563,7 +563,7 @@ function isJsonParsable(value: any) {
 
 function serializePostData(params: channels.APIRequestContextFetchParams, headers: { [name: string]: string }): Buffer | undefined {
   assert((params.postData ? 1 : 0) + (params.jsonData ? 1 : 0) + (params.formData ? 1 : 0) + (params.multipartData ? 1 : 0) <= 1, `Only one of 'data', 'form' or 'multipart' can be specified`);
-  if (isString(params.jsonData)) {
+  if (params.jsonData !== undefined) {
     const json = isJsonParsable(params.jsonData) ? params.jsonData : JSON.stringify(params.jsonData);
     headers['content-type'] ??= 'application/json';
     return Buffer.from(json, 'utf8');

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -25,7 +25,7 @@ import zlib from 'zlib';
 import { HTTPCredentials } from '../../types/types';
 import * as channels from '../protocol/channels';
 import { TimeoutSettings } from '../utils/timeoutSettings';
-import { assert, createGuid, getUserAgent, monotonicTime } from '../utils/utils';
+import { assert, createGuid, getUserAgent, isString, monotonicTime } from '../utils/utils';
 import { BrowserContext } from './browserContext';
 import { CookieStore, domainMatches } from './cookieStore';
 import { MultipartFormData } from './formData';
@@ -563,7 +563,7 @@ function isJsonParsable(value: any) {
 
 function serializePostData(params: channels.APIRequestContextFetchParams, headers: { [name: string]: string }): Buffer | undefined {
   assert((params.postData ? 1 : 0) + (params.jsonData ? 1 : 0) + (params.formData ? 1 : 0) + (params.multipartData ? 1 : 0) <= 1, `Only one of 'data', 'form' or 'multipart' can be specified`);
-  if (params.jsonData) {
+  if (isString(params.jsonData)) {
     const json = isJsonParsable(params.jsonData) ? params.jsonData : JSON.stringify(params.jsonData);
     headers['content-type'] ??= 'application/json';
     return Buffer.from(json, 'utf8');
@@ -583,7 +583,7 @@ function serializePostData(params: channels.APIRequestContextFetchParams, header
     }
     headers['content-type'] ??= formData.contentTypeHeader();
     return formData.finish();
-  } else if (params.postData) {
+  } else if (isString(params.postData)) {
     headers['content-type'] ??= 'application/octet-stream';
     return Buffer.from(params.postData, 'base64');
   }

--- a/packages/playwright-test/src/dispatcher.ts
+++ b/packages/playwright-test/src/dispatcher.ts
@@ -22,7 +22,6 @@ import type { TestResult, Reporter, TestStep } from '../types/testReporter';
 import { Suite, TestCase } from './test';
 import { Loader } from './loader';
 import { ManualPromise } from 'playwright-core/lib/utils/async';
-import { isString } from 'playwright-core/lib/utils/utils';
 
 export type TestGroup = {
   workerHash: string;
@@ -205,7 +204,7 @@ export class Dispatcher {
         name: a.name,
         path: a.path,
         contentType: a.contentType,
-        body: isString(a.body) ? Buffer.from(a.body, 'base64') : undefined
+        body: a.body !== undefined ? Buffer.from(a.body, 'base64') : undefined
       }));
       result.status = params.status;
       test.expectedStatus = params.expectedStatus;

--- a/packages/playwright-test/src/dispatcher.ts
+++ b/packages/playwright-test/src/dispatcher.ts
@@ -22,6 +22,7 @@ import type { TestResult, Reporter, TestStep } from '../types/testReporter';
 import { Suite, TestCase } from './test';
 import { Loader } from './loader';
 import { ManualPromise } from 'playwright-core/lib/utils/async';
+import { isString } from 'playwright-core/lib/utils/utils';
 
 export type TestGroup = {
   workerHash: string;
@@ -204,7 +205,7 @@ export class Dispatcher {
         name: a.name,
         path: a.path,
         contentType: a.contentType,
-        body: typeof a.body !== 'undefined' ? Buffer.from(a.body, 'base64') : undefined
+        body: isString(a.body) ? Buffer.from(a.body, 'base64') : undefined
       }));
       result.status = params.status;
       test.expectedStatus = params.expectedStatus;

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -30,7 +30,7 @@ import { Annotations, TestCaseType, TestError, TestInfo, TestInfoImpl, TestStepI
 import { ProjectImpl } from './project';
 import { FixtureRunner } from './fixtures';
 import { DeadlineRunner, raceAgainstDeadline } from 'playwright-core/lib/utils/async';
-import { calculateSha1, isString } from 'playwright-core/lib/utils/utils';
+import { calculateSha1 } from 'playwright-core/lib/utils/utils';
 
 const removeFolderAsync = util.promisify(rimraf);
 
@@ -267,7 +267,7 @@ export class WorkerRunner extends EventEmitter {
       attach: async (name: string, options: { path?: string, body?: string | Buffer, contentType?: string } = {}) => {
         if ((options.path !== undefined ? 1 : 0) + (options.body !== undefined ? 1 : 0) !== 1)
           throw new Error(`Exactly one of "path" and "body" must be specified`);
-        if (isString(options.path)) {
+        if (options.path !== undefined) {
           const hash = calculateSha1(options.path);
           const dest = testInfo.outputPath('attachments', hash + path.extname(options.path));
           await fs.promises.mkdir(path.dirname(dest), { recursive: true });

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -30,7 +30,7 @@ import { Annotations, TestCaseType, TestError, TestInfo, TestInfoImpl, TestStepI
 import { ProjectImpl } from './project';
 import { FixtureRunner } from './fixtures';
 import { DeadlineRunner, raceAgainstDeadline } from 'playwright-core/lib/utils/async';
-import { calculateSha1 } from 'playwright-core/lib/utils/utils';
+import { calculateSha1, isString } from 'playwright-core/lib/utils/utils';
 
 const removeFolderAsync = util.promisify(rimraf);
 
@@ -267,7 +267,7 @@ export class WorkerRunner extends EventEmitter {
       attach: async (name: string, options: { path?: string, body?: string | Buffer, contentType?: string } = {}) => {
         if ((options.path !== undefined ? 1 : 0) + (options.body !== undefined ? 1 : 0) !== 1)
           throw new Error(`Exactly one of "path" and "body" must be specified`);
-        if (options.path) {
+        if (isString(options.path)) {
           const hash = calculateSha1(options.path);
           const dest = testInfo.outputPath('attachments', hash + path.extname(options.path));
           await fs.promises.mkdir(path.dirname(dest), { recursive: true });

--- a/tests/browsercontext-route.spec.ts
+++ b/tests/browsercontext-route.spec.ts
@@ -245,7 +245,6 @@ it(`should overwrite post body`, async ({ context, server, page }) => {
 });
 
 it(`should overwrite post body with empty string`, async ({ context, server, page, browserName }) => {
-  it.fail(browserName === 'firefox', `There's likely a FF-specific bug in Juggler or how we ser/de to Juggler.`);
   server.setRoute('/load', (req, res) => {
     res.write(`
       <script>

--- a/tests/browsercontext-route.spec.ts
+++ b/tests/browsercontext-route.spec.ts
@@ -226,7 +226,7 @@ it('should overwrite post body with empty string', async ({ context, server, pag
     page.setContent(`
       <script>
         (async () => {
-            await fetch('/empty.html', {
+            await fetch('${server.EMPTY_PAGE}', {
               method: 'POST',
               body: 'original',
             });

--- a/tests/browsercontext-route.spec.ts
+++ b/tests/browsercontext-route.spec.ts
@@ -218,12 +218,10 @@ it(`should overwrite post body`, async ({ context, server, page }) => {
     res.write(`
       <script>
         (async () => {
-          await Promise.all([
-            fetch('/empty.html', {
-              method: 'POST',
-              body: 'original',
-            }),
-          ]);
+          await fetch('/empty.html', {
+            method: 'POST',
+            body: 'original',
+          });
         })()
       </script>
     `);
@@ -246,18 +244,16 @@ it(`should overwrite post body`, async ({ context, server, page }) => {
   expect(body).toBe('replaced');
 });
 
-it(`should overwrite post body with empty string`, async ({ context, server, page }) => {
-  it.fail(true, 'Search for "postData ?" for likely fix locations');
+it(`should overwrite post body with empty string`, async ({ context, server, page, browserName }) => {
+  it.fail(browserName === 'firefox', `There's likely a FF-specific bug in Juggler or how we ser/de to Juggler.`);
   server.setRoute('/load', (req, res) => {
     res.write(`
       <script>
         (async () => {
-          await Promise.all([
-            fetch('/empty.html', {
+            await fetch('/empty.html', {
               method: 'POST',
               body: 'original',
-            }),
-          ]);
+            });
         })()
       </script>
     `);

--- a/tests/browsercontext-route.spec.ts
+++ b/tests/browsercontext-route.spec.ts
@@ -214,7 +214,6 @@ it('should support the times parameter with route matching', async ({ context, p
 });
 
 it('should overwrite post body with empty string', async ({ context, server, page, browserName }) => {
-  it.fail(browserName === 'firefox', 'This should work after rev of FF built from #11421 with some Juggler fixes.');
   await context.route('**/empty.html', route => {
     route.continue({
       postData: '',

--- a/tests/browsercontext-route.spec.ts
+++ b/tests/browsercontext-route.spec.ts
@@ -236,6 +236,5 @@ it('should overwrite post body with empty string', async ({ context, server, pag
   ]);
 
   const body = (await req.postBody).toString();
-  expect(body).not.toBe('original');
   expect(body).toBe('');
 });

--- a/tests/browsercontext-route.spec.ts
+++ b/tests/browsercontext-route.spec.ts
@@ -245,6 +245,7 @@ it(`should overwrite post body`, async ({ context, server, page }) => {
 });
 
 it(`should overwrite post body with empty string`, async ({ context, server, page, browserName }) => {
+  it.fail(browserName === 'firefox', `There's likely a FF-specific bug in Juggler or how we ser/de to Juggler.`);
   server.setRoute('/load', (req, res) => {
     res.write(`
       <script>

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -276,13 +276,11 @@ const serialization: [string, any][] = [
   ['number', 2021],
   ['number (falsey)', 0],
   ['null', null],
-  ['literal string null', 'null'],
   ['literal string undefined', 'undefined'],
 ];
 for (const [type, value] of serialization) {
   const stringifiedValue = JSON.stringify(value);
   it(`should json stringify ${type} body when content-type is application/json`, async ({ playwright, server }) => {
-    it.fail(type === 'literal string null', `Some where isn't escaping this. Perhaps either at the following link or before: https://github.com/microsoft/playwright/blob/bfe7b7cc20ab9fdbf63dc84986369bf0f3f5a2dd/packages/playwright-core/src/protocol/serializers.ts#L53`);
     const request = await playwright.request.newContext();
     const [req] = await Promise.all([
       server.waitForRequest('/empty.html'),

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -276,11 +276,13 @@ const serialization: [string, any][] = [
   ['number', 2021],
   ['number (falsey)', 0],
   ['null', null],
+  ['literal string null', 'null'],
+  ['literal string undefined', 'undefined'],
 ];
 for (const [type, value] of serialization) {
   const stringifiedValue = JSON.stringify(value);
   it(`should json stringify ${type} body when content-type is application/json`, async ({ playwright, server }) => {
-    it.fail(/false|null/.test(type), 'Search for /if.*jsonData/ for likely fix locations');
+    it.fail(type === 'literal string null', `Some where isn't escaping this. Perhaps either at the following link or before: https://github.com/microsoft/playwright/blob/bfe7b7cc20ab9fdbf63dc84986369bf0f3f5a2dd/packages/playwright-core/src/protocol/serializers.ts#L53`);
     const request = await playwright.request.newContext();
     const [req] = await Promise.all([
       server.waitForRequest('/empty.html'),

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -266,16 +266,21 @@ it('should remove content-length from reidrected post requests', async ({ playwr
 });
 
 
-const serialization = [
+const serialization: [string, any][] = [
   ['object', { 'foo': 'bar' }],
   ['array', ['foo', 'bar', 2021]],
   ['string', 'foo'],
+  ['string (falsey)', ''],
   ['bool', true],
+  ['bool (false)', false],
   ['number', 2021],
+  ['number (falsey)', 0],
+  ['null', null],
 ];
 for (const [type, value] of serialization) {
   const stringifiedValue = JSON.stringify(value);
   it(`should json stringify ${type} body when content-type is application/json`, async ({ playwright, server }) => {
+    it.fail(/false|null/.test(type), 'Search for /if.*jsonData/ for likely fix locations');
     const request = await playwright.request.newContext();
     const [req] = await Promise.all([
       server.waitForRequest('/empty.html'),

--- a/tests/playwright-test/reporter-attachment.spec.ts
+++ b/tests/playwright-test/reporter-attachment.spec.ts
@@ -104,7 +104,6 @@ test(`testInfo.attach errors`, async ({ runInlineTest }) => {
 });
 
 test(`testInfo.attach errors with empty path`, async ({ runInlineTest }) => {
-  test.fail(true, `We're ending up in the inline body branch due to falseyness of empty string as path making the exit clean, but since '' is not an valid file path, we should probably error. (Here's the branch that's actually getting executed right now: https://github.com/microsoft/playwright/blob/1b0c350d0a1c22faa4329c3897f92cd8569b82e2/packages/playwright-test/src/workerRunner.ts#L278)`);
   const result = await runInlineTest({
     'a.test.js': `
       const { test } = pwt;
@@ -113,6 +112,7 @@ test(`testInfo.attach errors with empty path`, async ({ runInlineTest }) => {
       });
     `,
   }, { reporter: 'line', workers: 1 });
+  expect(stripAscii(result.output)).toMatch(/Error: ENOENT: no such file or directory, copyfile ''/);
   expect(result.exitCode).toBe(1);
 });
 

--- a/tests/playwright-test/reporter-attachment.spec.ts
+++ b/tests/playwright-test/reporter-attachment.spec.ts
@@ -103,6 +103,19 @@ test(`testInfo.attach errors`, async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
 });
 
+test(`testInfo.attach errors with empty path`, async ({ runInlineTest }) => {
+  test.fail(true, `We're ending up in the inline body branch due to falseyness of empty string as path making the exit clean, but since '' is not an valid file path, we should probably error. (Here's the branch that's actually getting executed right now: https://github.com/microsoft/playwright/blob/1b0c350d0a1c22faa4329c3897f92cd8569b82e2/packages/playwright-test/src/workerRunner.ts#L278)`);
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test('fail', async ({}, testInfo) => {
+        await testInfo.attach('name', { path: '' });
+      });
+    `,
+  }, { reporter: 'line', workers: 1 });
+  expect(result.exitCode).toBe(1);
+});
+
 test(`testInfo.attach error in fixture`, async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `


### PR DESCRIPTION
In several of the Playwright APIs, falsey values were not handled correctly. This changeset adds tests (and some fixes):

1. `route.continue`: If `options.postData` was the empty string, the `continue` failed to override the post data.
2. `page.post` (`application/json` with `options.data: false|''|0|null`): Raw falsey values were getting dropped (i.e. you can't do the equivalent of `curl --header application/json … -d 'false'`). This has been fixed with most values across all browsers, but an additional fix is needed for `'null'` which the channel serializer treats extra specially.
3. `testInfo.attach`: This didn't get reported as an error when `options.path` was the empty string, but should have been.

#11413 (and its fix #11414) inspired this search as they are the same
class of bug.

Unlike #11413, this set was programmatically found with static analysis (ESLint's
`strict-boolean-expressions`) + grep filtering + manual review.
(Given JS conventions, that rule itself is too noisy to be useful on its
own as most of it would be FPs from a functional point.)