### PR TITLE
Add jq to base docker images

### DIFF
--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -15,6 +15,9 @@ RUN apt-get update && \
     # Feature-parity with node.js base images.
     apt-get install -y --no-install-recommends git openssh-client && \
     npm install -g yarn && \
+    
+    # Install minimal dependencies
+    apt-get install -y jq \
 
     # Install Python 3.8
     apt-get install -y python3.8 python3-pip && \


### PR DESCRIPTION
Fixes #11412 

This adds a minimal dependency which matches some base images of popular CI providers like CircleCI, Github Actions, etc.