### PR TITLE
dotnet: generate byte[] for binary properties

### DIFF
--- a/utils/generate_dotnet_channels.js
+++ b/utils/generate_dotnet_channels.js
@@ -62,7 +62,7 @@ function inlineType(type, indent = '', wrapEnums = false) {
     if (optional)
       type = type.substring(0, type.length - 1);
     if (type === 'binary')
-      return { ts: 'string', scheme: 'tString', optional };
+      return { ts: 'byte[]', scheme: 'tArray(tByte)', optional };
     if (type === 'json')
       return { ts: 'any', scheme: 'tAny', optional };
     if (['string', 'boolean', 'number', 'undefined'].includes(type)) {


### PR DESCRIPTION
System.Text.Json does support (de)serializing base64 strings to and from byte[] so `binary` properties could be changed to be actual byte[] to avoid manually converting them: https://github.com/microsoft/playwright-dotnet/blob/c6752fbcd53b7e5eaa685f880dd539ac008c2256/src/Playwright/Core/Request.cs#L51

Currently this would only affect `RequestInitializer`:

```diff
diff --git a/src/Playwright/Transport/Protocol/Generated/RequestInitializer.cs b/src/Playwright/Transport/Protocol/Generated/RequestInitializer.cs
index b9cc91c7..cf18d59d 100644
--- a/src/Playwright/Transport/Protocol/Generated/RequestInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/RequestInitializer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Playwright.Transport.Protocol

         public string Method { get; set; }

-        public string PostData { get; set; }
+        public byte[] PostData { get; set; }

         public List<HeaderEntry> Headers { get; set; }

```

Reference: https://github.com/microsoft/playwright-dotnet/pull/1948