### PR TITLE
test: update wk win expectations for "should report raw headers"

### DIFF
--- a/tests/page/page-network-request.spec.ts
+++ b/tests/page/page-network-request.spec.ts
@@ -273,7 +273,7 @@ it('should report raw headers', async ({ page, server, browserName, platform }) 
     for (let i = 0; i < req.rawHeaders.length; i += 2)
       expectedHeaders.push({ name: req.rawHeaders[i], value: req.rawHeaders[i + 1] });
     if (browserName === 'webkit' && platform === 'win32')
-      expectedHeaders = expectedHeaders.filter(({ name }) => name.toLowerCase() !== 'accept-encoding' && name.toLowerCase() !== 'accept-language');
+      expectedHeaders = expectedHeaders.filter(({ name }) => name.toLowerCase() !== 'accept-encoding');
     res.end();
   });
   await page.goto(server.EMPTY_PAGE);

--- a/tests/page/page-network-request.spec.ts
+++ b/tests/page/page-network-request.spec.ts
@@ -272,8 +272,21 @@ it('should report raw headers', async ({ page, server, browserName, platform }) 
     expectedHeaders = [];
     for (let i = 0; i < req.rawHeaders.length; i += 2)
       expectedHeaders.push({ name: req.rawHeaders[i], value: req.rawHeaders[i + 1] });
-    if (browserName === 'webkit' && platform === 'win32')
+    if (browserName === 'webkit' && platform === 'win32') {
       expectedHeaders = expectedHeaders.filter(({ name }) => name.toLowerCase() !== 'accept-encoding');
+      // Convert "value": "en-US, en-US" => "en-US"
+      expectedHeaders = expectedHeaders.map(e => {
+        const { name, value } = e;
+        if (name.toLowerCase() !== 'accept-language')
+          return e;
+        const values = value.split(',').map(v => v.trim());
+        if (values.length === 1)
+          return e;
+        if (values[0] !== values[1])
+          return e;
+        return { name, value: values[0] };
+      });
+    }
     res.end();
   });
   await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
The test has been failing recently as 'Accept-Language' is not present in the headers.