### PR TITLE
fix(testrunner): fix stack.split error that we see on bots

### DIFF
--- a/packages/playwright-test/src/transform.ts
+++ b/packages/playwright-test/src/transform.ts
@@ -40,10 +40,14 @@ sourceMapSupport.install({
     const sourceMapPath = sourceMaps.get(source)!;
     if (!fs.existsSync(sourceMapPath))
       return null;
-    return {
-      map: JSON.parse(fs.readFileSync(sourceMapPath, 'utf-8')),
-      url: source
-    };
+    try {
+      return {
+        map: JSON.parse(fs.readFileSync(sourceMapPath, 'utf-8')),
+        url: source
+      };
+    } catch (e) {
+      return null;
+    }
   }
 });
 


### PR DESCRIPTION
I was able to reproduce this locally. This patch fixes it for me.

