### PR TITLE
fix(test runner): use a separate cache when baseUrl is set

### DIFF
--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -27,6 +27,7 @@ import { showHTMLReport } from './reporters/html';
 import { GridServer } from 'playwright-core/lib/grid/gridServer';
 import dockerFactory from 'playwright-core/lib/grid/dockerGridFactory';
 import { createGuid } from 'playwright-core/lib/utils/utils';
+import { cleanupUniqueCacheDir } from './transform';
 
 const defaultTimeout = 30000;
 const defaultReporter: BuiltInReporter = process.env.CI ? 'dot' : 'list';
@@ -159,6 +160,7 @@ async function runTests(args: string[], opts: { [key: string]: any }) {
     filePatternFilter,
     projectFilter: opts.project || undefined,
   });
+  await cleanupUniqueCacheDir();
   await stopProfiling(undefined);
 
   if (result.status === 'interrupted')
@@ -172,6 +174,7 @@ async function listTests(opts: { [key: string]: any }) {
   const runner = new Runner({}, { defaultConfig: {} });
   const config = await runner.loadConfigFromFile(configFile);
   const report = await runner.listAllTestFiles(config, opts.project);
+  await cleanupUniqueCacheDir();
   process.stdout.write(JSON.stringify(report), () => {
     process.exit(0);
   });


### PR DESCRIPTION
Currently, with baseUrl, we end up writing the map file but not the source file. This leads to multiple workers concurrently writing and reading the same source map, instead of it being written just once by the runner process.
    
This change uses a unique cache directory when baseUrl is present, cleaned up after the run.