### PR TITLE
fix: do not hang forever when showing HTML report

### DIFF
--- a/packages/playwright-core/src/utils/utils.ts
+++ b/packages/playwright-core/src/utils/utils.ts
@@ -575,3 +575,45 @@ export async function transformCommandsForRoot(commands: string[]): Promise<{ co
     return { command: 'sudo', args: ['--', 'sh', '-c', `${commands.join('&& ')}`], elevatedPermissions: true };
   return { command: 'su', args: ['root', '-c', `${commands.join('&& ')}`], elevatedPermissions: true };
 }
+
+export class SigIntWatcher {
+  private _hadSignal: boolean = false;
+  private _sigintPromise: Promise<void>;
+  private _sigintHandler: () => void;
+  constructor() {
+    let sigintCallback: () => void;
+    this._sigintPromise = new Promise<void>(f => sigintCallback = f);
+    this._sigintHandler = () => {
+      // We remove the handler so that second Ctrl+C immediately kills the runner
+      // via the default sigint handler. This is handy in the case where our shutdown
+      // takes a lot of time or is buggy.
+      //
+      // When running through NPM we might get multiple SIGINT signals
+      // for a single Ctrl+C - this is an NPM bug present since at least NPM v6.
+      // https://github.com/npm/cli/issues/1591
+      // https://github.com/npm/cli/issues/2124
+      //
+      // Therefore, removing the handler too soon will just kill the process
+      // with default handler without printing the results.
+      // We work around this by giving NPM 1000ms to send us duplicate signals.
+      // The side effect is that slow shutdown or bug in our runner will force
+      // the user to hit Ctrl+C again after at least a second.
+      setTimeout(() => process.off('SIGINT', this._sigintHandler), 1000);
+      this._hadSignal = true;
+      sigintCallback();
+    };
+    process.on('SIGINT', this._sigintHandler);
+  }
+
+  promise(): Promise<void> {
+    return this._sigintPromise;
+  }
+
+  hadSignal(): boolean {
+    return this._hadSignal;
+  }
+
+  disarm() {
+    process.off('SIGINT', this._sigintHandler);
+  }
+}

--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -21,6 +21,7 @@ import path from 'path';
 import { Transform, TransformCallback } from 'stream';
 import { FullConfig, Suite, Reporter } from '../../types/testReporter';
 import { HttpServer } from 'playwright-core/lib/utils/httpServer';
+import { SigIntWatcher } from 'playwright-core/lib/utils/utils';
 import { calculateSha1, removeFolders } from 'playwright-core/lib/utils/utils';
 import RawReporter, { JsonReport, JsonSuite, JsonTestCase, JsonTestResult, JsonTestStep } from './raw';
 import assert from 'assert';
@@ -190,11 +191,12 @@ export async function showHTMLReport(reportFolder: string | undefined, testId?: 
   const server = startHtmlReportServer(folder);
   let url = await server.start(9323);
   console.log('');
-  console.log(colors.cyan(`  Serving HTML report at ${url}. Press Ctrl+C to quit.`));
+  console.log(colors.cyan(`  Serving HTML report at ${url}. Press Ctrl+C to quit.\n`));
   if (testId)
     url += `#?testId=${testId}`;
   open(url);
-  await new Promise(() => {});
+  const sigintWatcher = new SigIntWatcher();
+  await sigintWatcher.promise();
 }
 
 export function startHtmlReportServer(folder: string): HttpServer {


### PR DESCRIPTION
Hanging forever causes runner to never perform its teardown.
This patch changes forever-promise to a sigint waiter.

Fixes #11647
