### PR TITLE
chore: rename env variables

### DIFF
--- a/packages/playwright-core/src/cli/innerCli.ts
+++ b/packages/playwright-core/src/cli/innerCli.ts
@@ -38,7 +38,7 @@ const packageJSON = require('../../package.json');
 
 program
     .version('Version ' + (process.env.PW_CLI_DISPLAY_VERSION || packageJSON.version))
-    .name(buildBasePlaywrightCLICommand(process.env.PW_CLI_TARGET_LANG));
+    .name(buildBasePlaywrightCLICommand(process.env.PW_LANG_NAME));
 
 commandWithOpenOptions('open [url]', 'open page in browser specified via -b, --browser', [])
     .action(function(url, options) {
@@ -235,7 +235,7 @@ Examples:
 
   $ show-trace https://example.com/trace.zip`);
 
-if (!process.env.PW_CLI_TARGET_LANG) {
+if (!process.env.PW_LANG_NAME) {
   let playwrightTestPackagePath = null;
   try {
     playwrightTestPackagePath = require.resolve('@playwright/test/lib/cli', {
@@ -559,7 +559,7 @@ function logErrorAndExit(e: Error) {
 }
 
 function language(): string {
-  return process.env.PW_CLI_TARGET_LANG || 'test';
+  return process.env.PW_LANG_NAME || 'test';
 }
 
 function commandWithOpenOptions(command: string, description: string, options: any[][]): Command {

--- a/packages/playwright-core/src/utils/utils.ts
+++ b/packages/playwright-core/src/utils/utils.ts
@@ -475,12 +475,12 @@ function determineUserAgent(): string {
 
   let langName = 'unknown';
   let langVersion = 'unknown';
-  if (!process.env.PW_CLI_TARGET_LANG) {
+  if (!process.env.PW_LANG_NAME) {
     langName = 'node';
     langVersion = process.version.substring(1).split('.').slice(0, 2).join('.');
-  } else if (['node', 'python', 'java', 'csharp'].includes(process.env.PW_CLI_TARGET_LANG)) {
-    langName = process.env.PW_CLI_TARGET_LANG;
-    langVersion = process.env.PW_CLI_TARGET_LANG_VERSION ?? 'unknown';
+  } else if (['node', 'python', 'java', 'csharp'].includes(process.env.PW_LANG_NAME)) {
+    langName = process.env.PW_LANG_NAME;
+    langVersion = process.env.PW_LANG_NAME_VERSION ?? 'unknown';
   }
 
   return `Playwright/${getPlaywrightVersion()} (${os.arch()}; ${osIdentifier} ${osVersion}) ${langName}/${langVersion}`;


### PR DESCRIPTION
These variables aren't CLI-only anymore, so pick some more general
names for them.

Note: all language ports would need to follow-up with the rename
after the next roll.

Fixes #11450
