### PR TITLE
docs: fix frame locator docs for python sync

### DIFF
--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -418,7 +418,7 @@ await locator.click()
 ```
 
 ```python sync
-locator = page.frame_locator("text=Submit").locator("text=Submit")
+locator = page.frame_locator("iframe").locator("text=Submit")
 locator.click()
 ```
 


### PR DESCRIPTION
the python sync documentation is incorrect
![image](https://user-images.githubusercontent.com/9786571/151394959-aa550c65-ae4a-490a-9dd4-fb61c62b5a29.png)
![image](https://user-images.githubusercontent.com/9786571/151395031-2f19f9c6-31fa-456e-a91a-9a9392ef5aaf.png)
