### PR TITLE
cherry-pick(#11662) fix(test runner): resolve tsconfig for each file

### DIFF
--- a/packages/playwright-test/src/experimentalLoader.ts
+++ b/packages/playwright-test/src/experimentalLoader.ts
@@ -15,11 +15,7 @@
  */
 
 import fs from 'fs';
-import path from 'path';
-import { tsConfigLoader, TsConfigLoaderResult } from './third_party/tsconfig-loader';
 import { transformHook } from './transform';
-
-const tsConfigCache = new Map<string, TsConfigLoaderResult>();
 
 async function resolve(specifier: string, context: { parentURL: string }, defaultResolve: any) {
   if (specifier.endsWith('.js') || specifier.endsWith('.ts') || specifier.endsWith('.mjs'))
@@ -36,17 +32,8 @@ async function resolve(specifier: string, context: { parentURL: string }, defaul
 async function load(url: string, context: any, defaultLoad: any) {
   if (url.endsWith('.ts') || url.endsWith('.tsx')) {
     const filename = url.substring('file://'.length);
-    const cwd = path.dirname(filename);
-    let tsconfig = tsConfigCache.get(cwd);
-    if (!tsconfig) {
-      tsconfig = tsConfigLoader({
-        getEnv: (name: string) => process.env[name],
-        cwd
-      });
-      tsConfigCache.set(cwd, tsconfig);
-    }
     const code = fs.readFileSync(filename, 'utf-8');
-    const source = transformHook(code, filename, tsconfig, true);
+    const source = transformHook(code, filename, true);
     return { format: 'module', source };
   }
   return defaultLoad(url, context, defaultLoad);

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -27,12 +27,10 @@ import { ProjectImpl } from './project';
 import { Reporter } from '../types/testReporter';
 import { BuiltInReporter, builtInReporters } from './runner';
 import { isRegExp } from 'playwright-core/lib/utils/utils';
-import { tsConfigLoader, TsConfigLoaderResult } from './third_party/tsconfig-loader';
 
 // To allow multiple loaders in the same process without clearing require cache,
 // we make these maps global.
 const cachedFileSuites = new Map<string, Suite>();
-const cachedTSConfigs = new Map<string, TsConfigLoaderResult>();
 
 export class Loader {
   private _defaultConfig: Config;
@@ -194,18 +192,7 @@ export class Loader {
 
 
   private async _requireOrImport(file: string) {
-    // Respect tsconfig paths.
-    const cwd = path.dirname(file);
-    let tsconfig = cachedTSConfigs.get(cwd);
-    if (!tsconfig) {
-      tsconfig = tsConfigLoader({
-        getEnv: (name: string) => process.env[name],
-        cwd
-      });
-      cachedTSConfigs.set(cwd, tsconfig);
-    }
-
-    const revertBabelRequire = installTransform(tsconfig);
+    const revertBabelRequire = installTransform();
 
     // Figure out if we are importing or requiring.
     let isModule: boolean;

--- a/tests/browsertype-connect.spec.ts
+++ b/tests/browsertype-connect.spec.ts
@@ -17,7 +17,7 @@
 
 import fs from 'fs';
 import * as path from 'path';
-import { getUserAgent } from 'playwright-core/lib/utils/utils';
+import { getUserAgent } from '../packages/playwright-core/lib/utils/utils';
 import WebSocket from 'ws';
 import { expect, playwrightTest as test } from './config/browserTest';
 import { parseTrace, suppressCertificateWarning } from './config/utils';

--- a/tests/chromium/chromium.spec.ts
+++ b/tests/chromium/chromium.spec.ts
@@ -19,7 +19,7 @@ import { contextTest as test, expect } from '../config/browserTest';
 import { playwrightTest } from '../config/browserTest';
 import http from 'http';
 import fs from 'fs';
-import { getUserAgent } from 'playwright-core/lib/utils/utils';
+import { getUserAgent } from '../../packages/playwright-core/lib/utils/utils';
 import { suppressCertificateWarning } from '../config/utils';
 
 test('should create a worker from a service worker', async ({ page, server }) => {

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -19,7 +19,7 @@ import * as os from 'os';
 import { PageTestFixtures, PageWorkerFixtures } from '../page/pageTestApi';
 import * as path from 'path';
 import type { BrowserContext, BrowserContextOptions, BrowserType, Page } from 'playwright-core';
-import { removeFolders } from 'playwright-core/lib/utils/utils';
+import { removeFolders } from '../../packages/playwright-core/lib/utils/utils';
 import { baseTest } from './baseTest';
 import { RemoteServer, RemoteServerOptions } from './remoteServer';
 

--- a/tests/global-fetch.spec.ts
+++ b/tests/global-fetch.spec.ts
@@ -17,7 +17,7 @@
 import http from 'http';
 import os from 'os';
 import * as util from 'util';
-import { getPlaywrightVersion } from 'playwright-core/lib/utils/utils';
+import { getPlaywrightVersion } from '../packages/playwright-core/lib/utils/utils';
 import { expect, playwrightTest as it } from './config/browserTest';
 
 it.skip(({ mode }) => mode !== 'default');

--- a/tests/har.spec.ts
+++ b/tests/har.spec.ts
@@ -21,7 +21,7 @@ import fs from 'fs';
 import http2 from 'http2';
 import type { BrowserContext, BrowserContextOptions } from 'playwright-core';
 import type { AddressInfo } from 'net';
-import type { Log } from 'playwright-core/lib/server/supplements/har/har';
+import type { Log } from '../packages/playwright-core/src/server/supplements/har/har';
 
 async function pageWithHar(contextFactory: (options?: BrowserContextOptions) => Promise<BrowserContext>, testInfo: any, outputPath: string = 'test.har') {
   const harPath = testInfo.outputPath(outputPath);

--- a/tests/inspector/inspectorTest.ts
+++ b/tests/inspector/inspectorTest.ts
@@ -17,7 +17,7 @@
 import { contextTest } from '../config/browserTest';
 import type { Page } from 'playwright-core';
 import * as path from 'path';
-import type { Source } from 'playwright-core/lib/server/supplements/recorder/recorderTypes';
+import type { Source } from '../../packages/playwright-core/src/server/supplements/recorder/recorderTypes';
 import { CommonFixtures, TestChildProcess } from '../config/commonFixtures';
 export { expect } from '@playwright/test';
 

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -18,7 +18,7 @@ import { test, expect, stripAscii } from './playwright-test-fixtures';
 import fs from 'fs';
 import path from 'path';
 import { spawnSync } from 'child_process';
-import { registry } from 'playwright-core/lib/utils/registry';
+import { registry } from '../../packages/playwright-core/lib/utils/registry';
 
 const ffmpeg = registry.findExecutable('ffmpeg')!.executablePath();
 

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { test as baseTest, expect } from './playwright-test-fixtures';
-import { HttpServer } from 'playwright-core/lib/utils/httpServer';
+import { HttpServer } from '../../packages/playwright-core/lib/utils/httpServer';
 import { startHtmlReportServer } from '../../packages/playwright-test/lib/reporters/html';
 
 const test = baseTest.extend<{ showReport: () => Promise<void> }>({

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -9,10 +9,6 @@
         "strictBindCallApply": true,
         "allowSyntheticDefaultImports": true,
         "useUnknownInCatchVariables": false,
-        "baseUrl": ".",
-        "paths": {
-          "playwright-core/lib/*": ["../packages/playwright-core/src/*"]
-        },
     },
     "include": ["**/*.spec.js", "**/*.ts", "index.d.ts"],
     "exclude": ["playwright-test/"]

--- a/tests/video.spec.ts
+++ b/tests/video.spec.ts
@@ -19,7 +19,7 @@ import fs from 'fs';
 import path from 'path';
 import { spawnSync } from 'child_process';
 import { PNG } from 'pngjs';
-import { registry } from 'playwright-core/lib/utils/registry';
+import { registry } from '../packages/playwright-core/lib/utils/registry';
 
 const ffmpeg = registry.findExecutable('ffmpeg')!.executablePath('javascript');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["esnext", "dom", "DOM.Iterable"],
     "baseUrl": ".",
     "paths": {
-      "*": ["./packages/*/"],
       "playwright-core/lib/*": ["./packages/playwright-core/src/*"]
     },
     "esModuleInterop": true,


### PR DESCRIPTION
This allows us to properly handle path mappings
that are not too ambiguous.

