### PR TITLE
docs(class-page.md): fix response status assertion on python example

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3651,7 +3651,7 @@ response = response_info.value
 return response.ok
 
 # or with a lambda
-with page.expect_response(lambda response: response.url == "https://example.com" and response.status === 200) as response_info:
+with page.expect_response(lambda response: response.url == "https://example.com" and response.status == 200) as response_info:
     page.click("input")
 response = response_info.value
 return response.ok


### PR DESCRIPTION
This commit removes an `=` sign from the python `page.expect_response` example as it was using JavaScript's strict equality syntax

<!--
Thank you for your Pull Request. Please link to the issue this PR addresses.
-->
Fixes #

<!-- PR Checklist
- The issue has been triaged and positive signals were received from maintainers
- Existing tests pass
- New tests are added
- Relevant documentation is changed or added
-->
