### PR TITLE
chore: work-around npm install on windows

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
     - run: npm run build
     - run: npx playwright install-deps

--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         node-version: 12
         registry-url: 'https://registry.npmjs.org'
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
     - run: npm run build
     - run: npx playwright install-deps

--- a/.github/workflows/publish_release_docker.yml
+++ b/.github/workflows/publish_release_docker.yml
@@ -30,7 +30,7 @@ jobs:
       uses: docker/setup-qemu-action@v1
       with:
         platforms: arm64
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
     - run: npm run build
     - run: npx playwright install-deps

--- a/.github/workflows/publish_release_driver.yml
+++ b/.github/workflows/publish_release_driver.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         node-version: 12
         registry-url: 'https://registry.npmjs.org'
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
     - run: npm run build
     - run: npx playwright install-deps

--- a/.github/workflows/publish_release_npm.yml
+++ b/.github/workflows/publish_release_npm.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         node-version: 12
         registry-url: 'https://registry.npmjs.org'
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
     - run: npm run build
     - run: npx playwright install-deps

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 16
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
     - run: npm run build
     - name: Install dependencies

--- a/.github/workflows/tests_fyi.yml
+++ b/.github/workflows/tests_fyi.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 14
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install
@@ -65,7 +65,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: ${{matrix.node-version}}
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install
@@ -84,7 +84,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -90,7 +90,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 14
+        node-version: 12
     - run: npm i -g npm@8.3
     - run: npm ci
       env:

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install
@@ -90,8 +90,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 12
-    - run: npm i -g npm@8
+        node-version: 14
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install
@@ -146,7 +146,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install
@@ -177,7 +177,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install
@@ -207,7 +207,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install
@@ -228,7 +228,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -253,7 +253,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -280,7 +280,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -305,7 +305,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -330,7 +330,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -357,7 +357,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -382,7 +382,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -408,7 +408,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -432,7 +432,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -457,7 +457,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -482,7 +482,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -506,7 +506,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -531,7 +531,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -556,7 +556,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -580,7 +580,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -605,7 +605,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -630,7 +630,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -657,7 +657,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -682,7 +682,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -706,7 +706,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-    - run: npm i -g npm@8
+    - run: npm i -g npm@8.3
     - run: npm ci
     - run: npm run build
     - run: npx playwright install-deps


### PR DESCRIPTION
Since yesterday all our windows bots are dying while trying to
install npm@8.

Turns out this is due to recent release of npm@8.4. This patch
moves our CI to use npm@8.3

https://github.com/npm/cli/issues/4341
