### PR TITLE
fix: quote path to prevent space issue

### DIFF
--- a/packages/playwright-core/src/utils/registry.ts
+++ b/packages/playwright-core/src/utils/registry.ts
@@ -647,7 +647,7 @@ export class Registry {
       if (code !== 0)
         throw new Error(`Failed to install ${channel}`);
     } else {
-      const { command, args, elevatedPermissions } = await transformCommandsForRoot([`bash ${path.join(BIN_PATH, scriptName)} ${scriptArgs.join('')}`]);
+      const { command, args, elevatedPermissions } = await transformCommandsForRoot([`bash "${path.join(BIN_PATH, scriptName)}" ${scriptArgs.join('')}`]);
       if (elevatedPermissions)
         console.log('Switching to root user to install dependencies...'); // eslint-disable-line no-console
       const { code } = await spawnAsync(command, args, { cwd, stdio: 'inherit' });

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -74,7 +74,11 @@ function filePath(relative) {
  * @returns {string}
  */
 function quotePath(path) {
-  return "\"" + path + "\"";
+  if (process.env.PSModulePath) {
+    return "\\\"" + path + "\\\"";
+  } else {
+    return "\"" + path + "\"";
+  }
 }
 
 async function runWatch() {

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -74,11 +74,7 @@ function filePath(relative) {
  * @returns {string}
  */
 function quotePath(path) {
-  if (process.env.PSModulePath) {
-    return "\\\"" + path + "\\\"";
-  } else {
-    return "\"" + path + "\"";
-  }
+  return "\"" + path + "\"";
 }
 
 async function runWatch() {

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -62,11 +62,19 @@ const lintMode = process.argv.slice(2).includes('--lint');
 const ROOT = path.join(__dirname, '..', '..');
 
 /**
- * @param {string} relative 
+ * @param {string} relative
  * @returns {string}
  */
 function filePath(relative) {
   return path.join(ROOT, ...relative.split('/'));
+}
+
+/**
+ * @param {string} path
+ * @returns {string}
+ */
+function quotePath(path) {
+  return "\"" + path + "\"";
 }
 
 async function runWatch() {
@@ -108,7 +116,7 @@ async function runWatch() {
 
 async function runBuild() {
   /**
-   * @param {Step} step 
+   * @param {Step} step
    */
   function runStep(step) {
     const out = child_process.spawnSync(step.command, step.args, {
@@ -143,9 +151,9 @@ async function runBuild() {
 }
 
 /**
- * @param {string} file 
- * @param {string} from 
- * @param {string} to 
+ * @param {string} file
+ * @param {string} from
+ * @param {string} to
  */
 function copyFile(file, from, to) {
   const destination = path.resolve(filePath(to), path.relative(filePath(from), file));
@@ -172,7 +180,7 @@ const webPackFiles = [
 for (const file of webPackFiles) {
   steps.push({
     command: 'npx',
-    args: ['webpack', '--config', filePath(file), ...(watchMode ? ['--watch', '--stats', 'none'] : [])],
+    args: ['webpack', '--config', quotePath(filePath(file)), ...(watchMode ? ['--watch', '--stats', 'none'] : [])],
     shell: true,
     env: {
       NODE_ENV: watchMode ? 'development' : 'production'
@@ -190,9 +198,9 @@ for (const packageDir of packages) {
       'babel',
       ...(watchMode ? ['-w', '--source-maps'] : []),
       '--extensions', '.ts',
-      '--out-dir', path.join(packageDir, 'lib'),
+      '--out-dir', quotePath(path.join(packageDir, 'lib')),
       '--ignore', '"packages/playwright-core/src/server/injected/**/*"',
-      path.join(packageDir, 'src')],
+      quotePath(path.join(packageDir, 'src'))],
     shell: true,
   });
 }
@@ -263,7 +271,7 @@ if (lintMode) {
   // Run TypeScript for type chekcing.
   steps.push({
     command: 'npx',
-    args: ['tsc', ...(watchMode ? ['-w'] : []), '-p', filePath('.')],
+    args: ['tsc', ...(watchMode ? ['-w'] : []), '-p', quotePath(filePath('.'))],
     shell: true,
   });
 }


### PR DESCRIPTION
This PR fixes two issues:
1. When installing chrome on macOS / Linux, if current working directory contains space in path, the bash will fail since the space is not quoted.
2. `npm run build` won't work if path includes space. This happends in all shells including bash (macOS) and powershell (windows).