### PR TITLE
feat: compute md5 hash for CDN uploads.

### DIFF
--- a/browser_patches/upload.sh
+++ b/browser_patches/upload.sh
@@ -43,6 +43,16 @@ if [[ ("$2" == '--check') ]]; then
   fi
 fi
 
+GENERATE_MD5_HASH=$(cat <<EOF
+  const crypto = require('crypto');
+  const buffer = fs.readFileSync(process.argv[1]);
+  console.log(crypto.createHash('md5').update(buffer).digest("base64"));
+EOF
+)
+
+MD5_HASH=$(node -e "${GENERATE_MD5_HASH}" "${ZIP_PATH}")
+echo "MD5 hash: ${MD5_HASH}"
+
 if ! [[ -f $ZIP_PATH ]]; then
   echo "ERROR: ${ZIP_PATH} does not exist"
   exit 1
@@ -55,9 +65,9 @@ if [[ $(uname) == MINGW* ]]; then
   # Convert POSIX path to MSYS
   WIN_PATH=$({ cd $(dirname "$ZIP_PATH") && pwd -W; } | sed 's|/|\\|g')
   WIN_PATH="${WIN_PATH}\\$(basename "$ZIP_PATH")"
-  az storage blob upload -c builds --account-key "$AZ_ACCOUNT_KEY" --account-name "$AZ_ACCOUNT_NAME" -f "$WIN_PATH" -n "$BLOB_PATH"
+  az storage blob upload -c builds --account-key "$AZ_ACCOUNT_KEY" --account-name "$AZ_ACCOUNT_NAME" -f "$WIN_PATH" -n "$BLOB_PATH" --content-md5 "${MD5_HASH}"
 else
-  az storage blob upload -c builds --account-key "$AZ_ACCOUNT_KEY" --account-name "$AZ_ACCOUNT_NAME" -f "$ZIP_PATH" -n "$BLOB_PATH"
+  az storage blob upload -c builds --account-key "$AZ_ACCOUNT_KEY" --account-name "$AZ_ACCOUNT_NAME" -f "$ZIP_PATH" -n "$BLOB_PATH" --content-md5 "${MD5_HASH}"
 fi
 
 echo "UPLOAD SUCCESSFUL!"

--- a/browser_patches/upload.sh
+++ b/browser_patches/upload.sh
@@ -45,8 +45,9 @@ fi
 
 GENERATE_MD5_HASH=$(cat <<EOF
   const crypto = require('crypto');
+  const fs = require('fs');
   const buffer = fs.readFileSync(process.argv[1]);
-  console.log(crypto.createHash('md5').update(buffer).digest("base64"));
+  console.log(crypto.createHash('md5').update(buffer).digest('base64'));
 EOF
 )
 


### PR DESCRIPTION
By default, azure auto-computes MD5 for all blobs < 64MBs.
However, many of our binaries exceed 64MB so md5 has to be computed
manually.

With this patch, MD5 hash will be set to all our CDN uploads and could
be retrieved as `content-md5` header, e.g.:

```bash
$ curl -I https://playwright.azureedge.net/builds/ffmpeg/1001/ffmpeg-win32.zip
```

Fixes #10173
