### PR TITLE
chore: Add pixel-buffer-diff behind env variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5775,6 +5775,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/pixel-buffer-diff": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pixel-buffer-diff/-/pixel-buffer-diff-1.3.2.tgz",
+      "integrity": "sha512-qE/EcXw2Gbm0kX9k4OEaGCvz7wrzDFJH60hAV4WQjCERoxv9Uhkk7M2pyy6QqZZLDs0gHw1c0igIpWtcADkwKg=="
+    },
     "node_modules/pixelmatch": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
@@ -7625,6 +7630,7 @@
         "ms": "2.1.3",
         "open": "8.4.0",
         "pirates": "4.0.4",
+        "pixel-buffer-diff": "1.3.2",
         "pixelmatch": "5.2.1",
         "playwright-core": "1.19.0-next",
         "pngjs": "6.0.0",
@@ -8434,6 +8440,7 @@
         "ms": "2.1.3",
         "open": "8.4.0",
         "pirates": "4.0.4",
+        "pixel-buffer-diff": "1.3.2",
         "pixelmatch": "5.2.1",
         "playwright-core": "1.19.0-next",
         "pngjs": "6.0.0",
@@ -12024,6 +12031,11 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
+    },
+    "pixel-buffer-diff": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pixel-buffer-diff/-/pixel-buffer-diff-1.3.2.tgz",
+      "integrity": "sha512-qE/EcXw2Gbm0kX9k4OEaGCvz7wrzDFJH60hAV4WQjCERoxv9Uhkk7M2pyy6QqZZLDs0gHw1c0igIpWtcADkwKg=="
     },
     "pixelmatch": {
       "version": "5.2.1",

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -58,6 +58,7 @@
     "ms": "2.1.3",
     "open": "8.4.0",
     "pirates": "4.0.4",
+    "pixel-buffer-diff": "1.3.2",
     "pixelmatch": "5.2.1",
     "playwright-core": "1.19.0-next",
     "pngjs": "6.0.0",

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -425,7 +425,7 @@ test('should compare different PNG images', async ({ runInlineTest }, testInfo) 
 });
 
 test('should respect threshold', async ({ runInlineTest }) => {
-  test.skip(!!process.env.PW_USE_BLINK_DIFF);
+  test.skip(!!process.env.PW_USE_BLINK_DIFF && !!process.env.PW_USE_PIXEL_BUFFER_DIFF);
   const expected = fs.readFileSync(path.join(__dirname, 'assets/screenshot-canvas-expected.png'));
   const actual = fs.readFileSync(path.join(__dirname, 'assets/screenshot-canvas-actual.png'));
   const result = await runInlineTest({
@@ -446,7 +446,7 @@ test('should respect threshold', async ({ runInlineTest }) => {
 });
 
 test('should respect project threshold', async ({ runInlineTest }) => {
-  test.skip(!!process.env.PW_USE_BLINK_DIFF);
+  test.skip(!!process.env.PW_USE_BLINK_DIFF && !!process.env.PW_USE_PIXEL_BUFFER_DIFF);
   const expected = fs.readFileSync(path.join(__dirname, 'assets/screenshot-canvas-expected.png'));
   const actual = fs.readFileSync(path.join(__dirname, 'assets/screenshot-canvas-actual.png'));
   const result = await runInlineTest({


### PR DESCRIPTION
Prove alternative image comparison using [pixel_buffer_diff](https://www.npmjs.com/package/pixel-buffer-diff) behind an env variable, just like for blinkDiff. This image comparison weighs ~1.2kb, is 4x faster than pixelMatch and yields better results as it takes both individual pixel differences and their sum into account to avoid false positives due to anti-aliasing differences.

Test authors, can opt-in by setting the `PW_USE_PIXEL_BUFFER_DIFF` env variable.