### PR TITLE
test: mark cltr+click test as timing out on windows

### DIFF
--- a/tests/browsercontext-page-event.spec.ts
+++ b/tests/browsercontext-page-event.spec.ts
@@ -185,9 +185,10 @@ it('should work with Ctrl-clicking', async ({ browser, server, isMac, browserNam
   await context.close();
 });
 
-it('should not hang on ctrl-click during provisional load', async ({ context, page, server, isMac, browserName }) => {
+it('should not hang on ctrl-click during provisional load', async ({ context, page, server, isMac, isWindows, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/11595' });
   it.skip(browserName === 'chromium', 'Chromium does not dispatch renderer messages while navigation is provisional.');
+  it.fixme(browserName === 'webkit' && isWindows, 'Timesout while trying to click');
   await page.goto(server.EMPTY_PAGE);
   await page.setContent('<a href="/one-style.html">yo</a>');
   server.setRoute('/slow.html', () => {});


### PR DESCRIPTION
It's been [failing](https://devops.aslushnikov.com/flakiness2.html#filter_spec=browsercontext-page-event.spec.ts&timestamp=1643905281358) with:

```
Timeout of 30000ms exceeded.

    Pending operations:
      - page.click at tests\browsercontext-page-event.spec.ts:196:57

    page.click: Target closed
    =========================== logs ===========================
    waiting for selector "a"
      selector resolved to visible <a href="/one-style.html">yo</a>
    attempting click action
      waiting for element to be visible, enabled and stable
    ============================================================

      194 |   const [popup] = await Promise.all([
      195 |     context.waitForEvent('page'),
    > 196 |     server.waitForRequest('/slow.html').then(() => page.click('a', { modifiers: [ isMac ? 'Meta' : 'Control'] })),
          |                                                         ^
      1[97](https://github.com/microsoft/playwright/runs/5047953786?check_suite_focus=true#step:8:97) |     page.evaluate(url => setTimeout(() => location.href = url, 0), server.CROSS_PROCESS_PREFIX + '/slow.html'),
      1[98](https://github.com/microsoft/playwright/runs/5047953786?check_suite_focus=true#step:8:98) |   ]);
      1[99](https://github.com/microsoft/playwright/runs/5047953786?check_suite_focus=true#step:8:99) |   expect(popup).toBeTruthy();

        at D:\a\playwright\playwright\tests\browsercontext-page-event.spec.ts:196:57
        at D:\a\playwright\playwright\tests\browsercontext-page-event.spec.ts:194:19
    <inner error>
    Error: Target closed
    =========================== logs ===========================
    waiting for selector "a"
      selector resolved to visible <a href="/one-style.html">yo</a>
    attempting click action
      waiting for element to be visible, enabled and stable
    ============================================================
        at D:\a\playwright\playwright\packages\playwright-core\lib\server\webkit\wkConnection.js:163:16
        at new Promise (<anonymous>)
        at WKSession.send (D:\a\playwright\playwright\packages\playwright-core\lib\server\webkit\wkConnection.js:159:12)
        at WKExecutionContext.evaluateWithArguments (D:\a\playwright\playwright\packages\playwright-core\lib\server\webkit\wkExecutionContext.js:86:44)
        at FrameExecutionContext.evaluateWithArguments (D:\a\playwright\playwright\packages\playwright-core\lib\server\javascript.js:73:61)
        at evaluateExpression (D:\a\playwright\playwright\packages\playwright-core\lib\server\javascript.js:263:26)
        at InjectedScriptPollHandler.finish (D:\a\playwright\playwright\packages\playwright-core\lib\server\dom.js:[101](https://github.com/microsoft/playwright/runs/5047953786?check_suite_focus=true#step:8:101)8:22)
        at ElementHandle.evaluatePoll (D:\a\playwright\playwright\packages\playwright-core\lib\server\dom.js:188:14)
        at ElementHandle._waitForDisplayedAtStablePosition (D:\a\playwright\playwright\packages\playwright-core\lib\server\dom.js:945:20)
        at ElementHandle._performPointerAction (D:\a\playwright\playwright\packages\playwright-core\lib\server\dom.js:434:20)
        at ElementHandle._retryPointerAction (D:\a\playwright\playwright\packages\playwright-core\lib\server\dom.js:402:22)
        at D:\a\playwright\playwright\packages\playwright-core\lib\server\frames.js:1074:24
        at Frame.retryWithProgress (D:\a\playwright\playwright\packages\playwright-core\lib\server\frames.js:[103](https://github.com/microsoft/playwright/runs/5047953786?check_suite_focus=true#step:8:103)4:24)
        at D:\a\playwright\playwright\packages\playwright-core\lib\server\frames.js:[109](https://github.com/microsoft/playwright/runs/5047953786?check_suite_focus=true#step:8:109)1:29
        at ProgressController.run (D:\a\playwright\playwright\packages\playwright-core\lib\server\progress.js:101:22)
```