### PR TITLE
feat(remote): make PlaywrightServer work with browserType.connect

### DIFF
--- a/packages/playwright-core/src/cli/driver.ts
+++ b/packages/playwright-core/src/cli/driver.ts
@@ -53,7 +53,7 @@ export function runDriver() {
 }
 
 export async function runServer(port: number | undefined) {
-  const server = await PlaywrightServer.startDefault();
+  const server = await PlaywrightServer.startDefault({ path: '/', maxClients: Infinity });
   const wsEndpoint = await server.listen(port);
   process.on('exit', () => server.close().catch(console.error));
   console.log('Listening on ' + wsEndpoint);  // eslint-disable-line no-console

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -168,6 +168,8 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
           throw new Error('Malformed endpoint. Did you use launchServer method?');
         }
         playwright._setSelectors(this._playwright.selectors);
+        if ((params as any).__testHookPortForwarding)
+          playwright._enablePortForwarding((params as any).__testHookPortForwarding.redirectPortForTest);
         browser = Browser.from(playwright._initializer.preLaunchedBrowser!);
         browser._logger = logger;
         browser._shouldCloseConnectionOnClose = true;

--- a/packages/playwright-core/src/dispatchers/browserDispatcher.ts
+++ b/packages/playwright-core/src/dispatchers/browserDispatcher.ts
@@ -21,7 +21,9 @@ import { CDPSessionDispatcher } from './cdpSessionDispatcher';
 import { Dispatcher, DispatcherScope } from './dispatcher';
 import { CRBrowser } from '../server/chromium/crBrowser';
 import { PageDispatcher } from './pageDispatcher';
-import { CallMetadata } from '../server/instrumentation';
+import { CallMetadata, internalCallMetadata } from '../server/instrumentation';
+import { BrowserContext } from '../server/browserContext';
+import { Selectors } from '../server/selectors';
 
 export class BrowserDispatcher extends Dispatcher<Browser, channels.BrowserChannel> implements channels.BrowserChannel {
   _type_Browser = true;
@@ -70,5 +72,65 @@ export class BrowserDispatcher extends Dispatcher<Browser, channels.BrowserChann
     const crBrowser = this._object as CRBrowser;
     const buffer = await crBrowser.stopTracing();
     return { binary: buffer.toString('base64') };
+  }
+}
+
+// This class implements multiplexing browser dispatchers over a single Browser instance.
+export class ConnectedBrowserDispatcher extends Dispatcher<Browser, channels.BrowserChannel> implements channels.BrowserChannel {
+  _type_Browser = true;
+  private _contexts = new Set<BrowserContext>();
+  readonly selectors: Selectors;
+
+  constructor(scope: DispatcherScope, browser: Browser) {
+    super(scope, browser, 'Browser', { version: browser.version(), name: browser.options.name }, true);
+    // When we have a remotely-connected browser, each client gets a fresh Selector instance,
+    // so that two clients do not interfere between each other.
+    this.selectors = new Selectors();
+  }
+
+  async newContext(params: channels.BrowserNewContextParams, metadata: CallMetadata): Promise<channels.BrowserNewContextResult> {
+    if (params.recordVideo)
+      params.recordVideo.dir = this._object.options.artifactsDir;
+    const context = await this._object.newContext(params);
+    this._contexts.add(context);
+    context._setSelectors(this.selectors);
+    context.on(BrowserContext.Events.Close, () => this._contexts.delete(context));
+    if (params.storageState)
+      await context.setStorageState(metadata, params.storageState);
+    return { context: new BrowserContextDispatcher(this._scope, context) };
+  }
+
+  async close(): Promise<void> {
+    // Client should not send us Browser.close.
+  }
+
+  async killForTests(): Promise<void> {
+    // Client should not send us Browser.killForTests.
+  }
+
+  async newBrowserCDPSession(): Promise<channels.BrowserNewBrowserCDPSessionResult> {
+    if (!this._object.options.isChromium)
+      throw new Error(`CDP session is only available in Chromium`);
+    const crBrowser = this._object as CRBrowser;
+    return { session: new CDPSessionDispatcher(this._scope, await crBrowser.newBrowserCDPSession()) };
+  }
+
+  async startTracing(params: channels.BrowserStartTracingParams): Promise<void> {
+    if (!this._object.options.isChromium)
+      throw new Error(`Tracing is only available in Chromium`);
+    const crBrowser = this._object as CRBrowser;
+    await crBrowser.startTracing(params.page ? (params.page as PageDispatcher)._object : undefined, params);
+  }
+
+  async stopTracing(): Promise<channels.BrowserStopTracingResult> {
+    if (!this._object.options.isChromium)
+      throw new Error(`Tracing is only available in Chromium`);
+    const crBrowser = this._object as CRBrowser;
+    const buffer = await crBrowser.stopTracing();
+    return { binary: buffer.toString('base64') };
+  }
+
+  async cleanupContexts() {
+    await Promise.all(Array.from(this._contexts).map(context => context.close(internalCallMetadata())));
   }
 }

--- a/packages/playwright-core/src/remote/playwrightClient.ts
+++ b/packages/playwright-core/src/remote/playwrightClient.ts
@@ -19,6 +19,8 @@ import { Connection } from '../client/connection';
 import { Playwright } from '../client/playwright';
 import { makeWaitForNextTask } from '../utils/utils';
 
+// TODO: this file should be removed because it uses the old protocol.
+
 export type PlaywrightClientConnectOptions = {
   wsEndpoint: string;
   timeout?: number;

--- a/tests/config/default.playwright.config.ts
+++ b/tests/config/default.playwright.config.ts
@@ -32,7 +32,7 @@ const getExecutablePath = (browserName: BrowserName) => {
 
 const mode = process.env.PW_OUT_OF_PROCESS_DRIVER ?
   'driver' :
-  (process.env.PWTEST_MODE || 'default') as ('default' | 'driver' | 'service');
+  (process.env.PWTEST_MODE || 'default') as ('default' | 'driver' | 'service' | 'service2');
 const headed = !!process.env.HEADFUL;
 const channel = process.env.PWTEST_CHANNEL as any;
 const video = !!process.env.PWTEST_VIDEO;
@@ -59,12 +59,23 @@ const config: Config<CoverageWorkerOptions & PlaywrightWorkerOptions & Playwrigh
     ['html', { open: 'on-failure' }]
   ],
   projects: [],
-  webServer: mode === 'service' ? {
+};
+
+if (mode === 'service') {
+  config.webServer = {
     command: 'npx playwright experimental-grid-server',
     port: 3333,
     reuseExistingServer: true,
-  } : undefined,
-};
+  };
+}
+
+if (mode === 'service2') {
+  config.webServer = {
+    command: 'npx playwright run-server 3333',
+    port: 3333,
+    reuseExistingServer: true,
+  };
+}
 
 const browserNames = ['chromium', 'webkit', 'firefox'] as BrowserName[];
 for (const browserName of browserNames) {
@@ -90,6 +101,9 @@ for (const browserName of browserNames) {
       },
       trace: trace ? 'on' : undefined,
       coverageName: browserName,
+      connectOptions: mode === 'service2' ? {
+        wsEndpoint: 'ws://localhost:3333/?browser=' + (channel || browserName),
+      } : undefined,
     },
     metadata: {
       platform: process.platform,

--- a/tests/config/testMode.ts
+++ b/tests/config/testMode.ts
@@ -18,7 +18,7 @@ import { GridClient } from '../../packages/playwright-core/lib/grid/gridClient';
 import { start } from '../../packages/playwright-core/lib/outofprocess';
 import { Playwright } from '../../packages/playwright-core/lib/client/playwright';
 
-export type TestModeName = 'default' | 'driver' | 'service';
+export type TestModeName = 'default' | 'driver' | 'service' | 'service2';
 
 interface TestMode {
   setup(): Promise<Playwright>;

--- a/tests/config/testModeFixtures.ts
+++ b/tests/config/testModeFixtures.ts
@@ -33,6 +33,7 @@ export const testModeTest = test.extend<{}, TestModeWorkerOptions & TestModeWork
       default: new DefaultTestMode(),
       service: new ServiceTestMode(),
       driver: new DriverTestMode(),
+      service2: new DefaultTestMode(),
     }[mode];
     require('playwright-core/lib/utils/utils').setUnderTest();
     const playwright = await testMode.setup();

--- a/utils/testserver/index.js
+++ b/utils/testserver/index.js
@@ -87,7 +87,7 @@ class TestServer {
     });
     this._server.listen(port);
     this._dirPath = dirPath;
-    this.debugServer = require('debug')('pw:server');
+    this.debugServer = require('debug')('pw:testserver');
 
     this._startTime = new Date();
     this._cachedPathPrefix = null;


### PR DESCRIPTION
This changes PlaywrigtServer to serve connections like `ws://localhost:3333/?browser=chromium`:
- launches the browser;
- talks `browserType.connect`-style protocol over websocket;
- compatible with `connectOptions` fixture.

```js
await playwright.chromium.connect({ wsEndpoint: 'ws://localhost:3333/?browser=chrome' });
```
