### PR TITLE
chore: fix typo in Python APIRequestContext example

### DIFF
--- a/docs/src/api/class-apirequestcontext.md
+++ b/docs/src/api/class-apirequestcontext.md
@@ -71,13 +71,13 @@ with sync_playwright() as p:
     # This will launch a new browser, create a context and page. When making HTTP
     # requests with the internal APIRequestContext (e.g. `context.request` or `page.request`)
     # it will automatically set the cookies to the browser page and vise versa.
-    browser = playwright.chromium.launch()
+    browser = p.chromium.launch()
     context = browser.new_context(base_url="https://api.github.com")
     api_request_context = context.request
     page = context.new_page()
 
     # Alternatively you can create a APIRequestContext manually without having a browser context attached:
-    # api_request_context = playwright.request.new_context(base_url="https://api.github.com")
+    # api_request_context = p.request.new_context(base_url="https://api.github.com")
 
 
     # Create a repository.


### PR DESCRIPTION
`playwright.chromium` should be `p.chromium`, etc.

