### PR TITLE
fix(assertions): hide selector logs on page assertions

### DIFF
--- a/tests/playwright-test/playwright.expect.misc.spec.ts
+++ b/tests/playwright-test/playwright.expect.misc.spec.ts
@@ -249,6 +249,8 @@ test('should support toHaveTitle', async ({ runInlineTest }) => {
   const output = stripAnsi(result.output);
   expect(output).toContain('expect(page).toHaveTitle');
   expect(output).toContain('Expected string: \"Hello\"');
+  expect(output).not.toContain('waiting for selector ":root"');
+  expect(output).not.toContain('selector resolved to ');
   expect(result.passed).toBe(1);
   expect(result.failed).toBe(1);
   expect(result.exitCode).toBe(1);
@@ -273,6 +275,8 @@ test('should support toHaveURL', async ({ runInlineTest }) => {
   const output = stripAnsi(result.output);
   expect(output).toContain('expect(page).toHaveURL');
   expect(output).toContain('Expected string: \"wrong\"');
+  expect(output).not.toContain('waiting for selector ":root"');
+  expect(output).not.toContain('selector resolved to ');
   expect(result.passed).toBe(1);
   expect(result.failed).toBe(1);
   expect(result.exitCode).toBe(1);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please link to the issue this PR addresses.
-->
Fixes https://github.com/microsoft/playwright/issues/11867

<!-- PR Checklist
- The issue has been triaged and positive signals were received from maintainers
- Existing tests pass
- New tests are added
- Relevant documentation is changed or added
-->
