### PR TITLE
feat: introduce `disableAnimations` option for screenshots

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -642,6 +642,14 @@ The quality of the image, between 0-100. Not applicable to `png` images.
 Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
 Defaults to `false`.
 
+### option: ElementHandle.screenshot.disableAnimations
+- `disableAnimations` <[boolean]>
+
+When true, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment depending on their duration:
+- finite animations are fast-forwarded to completion, so they'll fire `transitionend` event.
+- infinite animations are canceled to initial state, and then played over after the screenshot.
+
+
 ### option: ElementHandle.screenshot.timeout = %%-input-timeout-%%
 
 ## async method: ElementHandle.scrollIntoViewIfNeeded

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -620,6 +620,13 @@ The quality of the image, between 0-100. Not applicable to `png` images.
 Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
 Defaults to `false`.
 
+### option: Locator.screenshot.disableAnimations
+- `disableAnimations` <[boolean]>
+
+When true, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment depending on their duration:
+- finite animations are fast-forwarded to completion, so they'll fire `transitionend` event.
+- infinite animations are canceled to initial state, and then played over after the screenshot.
+
 ### option: Locator.screenshot.timeout = %%-input-timeout-%%
 
 ## async method: Locator.scrollIntoViewIfNeeded

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2668,6 +2668,13 @@ The quality of the image, between 0-100. Not applicable to `png` images.
 When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to
 `false`.
 
+### option: Page.screenshot.disableAnimations
+- `disableAnimations` <[boolean]>
+
+When true, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment depending on their duration:
+- finite animations are fast-forwarded to completion, so they'll fire `transitionend` event.
+- infinite animations are canceled to initial state, and then played over after the screenshot.
+
 ### option: Page.screenshot.clip
 - `clip` <[Object]>
   - `x` <[float]> x-coordinate of top-left corner of clip area

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -1475,6 +1475,7 @@ export type PageScreenshotParams = {
   quality?: number,
   omitBackground?: boolean,
   fullPage?: boolean,
+  disableAnimations?: boolean,
   clip?: Rect,
 };
 export type PageScreenshotOptions = {
@@ -1483,6 +1484,7 @@ export type PageScreenshotOptions = {
   quality?: number,
   omitBackground?: boolean,
   fullPage?: boolean,
+  disableAnimations?: boolean,
   clip?: Rect,
 };
 export type PageScreenshotResult = {
@@ -2778,12 +2780,14 @@ export type ElementHandleScreenshotParams = {
   type?: 'png' | 'jpeg',
   quality?: number,
   omitBackground?: boolean,
+  disableAnimations?: boolean,
 };
 export type ElementHandleScreenshotOptions = {
   timeout?: number,
   type?: 'png' | 'jpeg',
   quality?: number,
   omitBackground?: boolean,
+  disableAnimations?: boolean,
 };
 export type ElementHandleScreenshotResult = {
   binary: Binary,

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -996,6 +996,7 @@ Page:
         quality: number?
         omitBackground: boolean?
         fullPage: boolean?
+        disableAnimations: boolean?
         clip: Rect?
       returns:
         binary: binary
@@ -2148,6 +2149,7 @@ ElementHandle:
           - jpeg
         quality: number?
         omitBackground: boolean?
+        disableAnimations: boolean?
       returns:
         binary: binary
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -545,6 +545,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     quality: tOptional(tNumber),
     omitBackground: tOptional(tBoolean),
     fullPage: tOptional(tBoolean),
+    disableAnimations: tOptional(tBoolean),
     clip: tOptional(tType('Rect')),
   });
   scheme.PageSetExtraHTTPHeadersParams = tObject({
@@ -1035,6 +1036,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     type: tOptional(tEnum(['png', 'jpeg'])),
     quality: tOptional(tNumber),
     omitBackground: tOptional(tBoolean),
+    disableAnimations: tOptional(tBoolean),
   });
   scheme.ElementHandleScrollIntoViewIfNeededParams = tObject({
     timeout: tOptional(tNumber),

--- a/packages/playwright-core/src/server/screenshotter.ts
+++ b/packages/playwright-core/src/server/screenshotter.ts
@@ -164,12 +164,12 @@ export class Screenshotter {
               } else {
                 try {
                   animation.cancel();
+                  infiniteAnimationsToResume.add(animation);
                 } catch (e) {
                   // animation.cancel() should not throw for
                   // infinite animations, but we'd like to be on the
                   // safe side.
                 }
-                infiniteAnimationsToResume.add(animation);
               }
             }
           };

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -51,6 +51,7 @@ export type ElementScreenshotOptions = TimeoutOptions & {
   type?: 'png' | 'jpeg',
   quality?: number,
   omitBackground?: boolean,
+  disableAnimations?: boolean,
 };
 
 export type ScreenshotOptions = ElementScreenshotOptions & {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8065,6 +8065,12 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
    */
   screenshot(options?: {
     /**
+     * When true, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment depending on
+     * their duration:
+     */
+    disableAnimations?: boolean;
+
+    /**
      * Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
      * Defaults to `false`.
      */
@@ -9361,6 +9367,12 @@ export interface Locator {
    * @param options
    */
   screenshot(options?: {
+    /**
+     * When true, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment depending on
+     * their duration:
+     */
+    disableAnimations?: boolean;
+
     /**
      * Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
      * Defaults to `false`.
@@ -15697,6 +15709,12 @@ export interface PageScreenshotOptions {
      */
     height: number;
   };
+
+  /**
+   * When true, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment depending on
+   * their duration:
+   */
+  disableAnimations?: boolean;
 
   /**
    * When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to

--- a/tests/assets/css-transition.html
+++ b/tests/assets/css-transition.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<style>
+  div {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 200px;
+    height: 100px;
+    background-color: red;
+    transition: all 10s;
+  }
+  .transition {
+    transform: rotate(360deg);
+  }
+</style>
+<div></div>
+<script>
+  window.addEventListener('load', () => {
+    document.querySelector('div').classList.add('transition');
+  }, false);
+</script>

--- a/tests/assets/rotate-pseudo.html
+++ b/tests/assets/rotate-pseudo.html
@@ -1,8 +1,9 @@
 <html>
   <head>
     <style type="text/css">
-      .square {
+      div::after {
         position: absolute;
+        content: " ";
         top: 0;
         left: 0;
         width: 200px;
@@ -12,6 +13,11 @@
         animation-duration: 5s;
         animation-iteration-count: infinite;
         animation-timing-function: linear;
+      }
+      div {
+        position: absolute;
+        width: 10px;
+        height: 10px;
       }
 
       @keyframes z-spin {

--- a/tests/assets/rotate-z-shadow-dom.html
+++ b/tests/assets/rotate-z-shadow-dom.html
@@ -1,0 +1,31 @@
+<html>
+  <head></head>
+  <body></body>
+  <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      const shadow = document.body.attachShadow({mode: 'open'});
+      shadow.append(document.createElement('div'));
+      const style = document.createElement('style');
+      style.textContent = `
+        div {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 200px;
+          height: 100px;
+          background-color: red;
+          animation-name: z-spin;
+          animation-duration: 5s;
+          animation-iteration-count: infinite;
+          animation-timing-function: linear;
+        }
+
+        @keyframes z-spin {
+          0%    { transform: rotateZ(0deg); }
+          100%  { transform: rotateZ(360deg); }
+        }
+      `;
+      shadow.append(style);
+    }, false);
+  </script>
+</html>

--- a/tests/assets/web-animation.html
+++ b/tests/assets/web-animation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<style>
+  div {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 200px;
+    height: 100px;
+    background-color: red;
+  }
+</style>
+<div></div>
+<script>
+  document.querySelector('div').animate(
+    [
+      { transform: 'rotate(0deg)' },
+      { transform: 'rotate(360deg)' }
+    ], {
+      duration: 3000,
+      iterations: Infinity
+    }
+  );
+</script>

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -593,7 +593,7 @@ it.describe('page screenshot animations', () => {
     await div.evaluate(async el => {
       window._EVENTS = [];
       // Make CSS animation to be finite.
-      el.style.setProperty('animation-iteration-count', 1000);
+      el.style.setProperty('animation-iteration-count', '1000');
       el.addEventListener('animationend', () => {
         window._EVENTS.push('animationend');
         console.log('animationend');


### PR DESCRIPTION
This option stops all kinds of CSS animations while doing screenshot:
- CSS animations
- CSS transitions
- Web Animations

Animations get different treatment depending on animation duration:
- finite animations are fast-forwarded to its end, issuing the
  `transitionend` event.
- Infinite animations are resetted to its beginning, and then
  resumed after the screenshot.

References #9938, fixes #11912

