### PR TITLE
docs: fix duplicate sections

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -255,6 +255,8 @@ declaration.
 
 Learn more about the execution modes [here](./test-parallel-js.md).
 
+Running tests in parallel:
+
 ```js js-flavor=js
 // Run all the tests in the file concurrently using parallel workers.
 test.describe.configure({ mode: 'parallel' });
@@ -268,6 +270,8 @@ test.describe.configure({ mode: 'parallel' });
 test('runs in parallel 1', async ({ page }) => {});
 test('runs in parallel 2', async ({ page }) => {});
 ```
+
+Running tests sequentially:
 
 ```js js-flavor=js
 // Annotate tests as inter-dependent.

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -1719,12 +1719,16 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    *
    * Learn more about the execution modes [here](https://playwright.dev/docs/test-parallel-js).
    *
+   * Running tests in parallel:
+   *
    * ```ts
    * // Run all the tests in the file concurrently using parallel workers.
    * test.describe.configure({ mode: 'parallel' });
    * test('runs in parallel 1', async ({ page }) => {});
    * test('runs in parallel 2', async ({ page }) => {});
    * ```
+   *
+   * Running tests sequentially:
    *
    * ```ts
    * // Annotate tests as inter-dependent.


### PR DESCRIPTION
It fixes this problem with the docs roll:

```sh
/home/yurys/playwright.dev/src/format_utils.js:58
          throw new Error('Dupe tabs: ' + md.render(spec));                                                                              
          ^                                                                                                                              
                                                                    
Error: Dupe tabs: Set execution mode of execution for the enclosing scope. Can be executed either on the top level or inside a describe. Configuration applies to the entire scope, regardless of whether it run before or after the test declaration.
                                                                                                                                         
Learn more about the execution modes [here](./test-parallel-js.md).                                                                      
```