### PR TITLE
fix(fixtures): account for default options being undefined

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -47,8 +47,8 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
   _playwright!: Playwright;
 
   // Instrumentation.
-  _defaultContextOptions: BrowserContextOptions = {};
-  _defaultLaunchOptions: LaunchOptions = {};
+  _defaultContextOptions?: BrowserContextOptions;
+  _defaultLaunchOptions?: LaunchOptions;
   _onDidCreateContext?: (context: BrowserContext) => Promise<void>;
   _onWillCloseContext?: (context: BrowserContext) => Promise<void>;
 
@@ -67,7 +67,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
   }
 
   async launch(options: LaunchOptions = {}): Promise<Browser> {
-    const logger = options.logger || this._defaultLaunchOptions.logger;
+    const logger = options.logger || this._defaultLaunchOptions?.logger;
     assert(!(options as any).userDataDir, 'userDataDir option is not supported in `browserType.launch`. Use `browserType.launchPersistentContext` instead');
     assert(!(options as any).port, 'Cannot specify a port without launching as a server.');
     options = { ...this._defaultLaunchOptions, ...options };
@@ -92,7 +92,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
   }
 
   async launchPersistentContext(userDataDir: string, options: LaunchPersistentContextOptions = {}): Promise<BrowserContext> {
-    const logger = options.logger || this._defaultLaunchOptions.logger;
+    const logger = options.logger || this._defaultLaunchOptions?.logger;
     assert(!(options as any).port, 'Cannot specify a port without launching as a server.');
     options = { ...this._defaultLaunchOptions, ...this._defaultContextOptions, ...options };
     const contextParams = await prepareBrowserContextParams(options);

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -457,11 +457,12 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
 
 
 function formatPendingCalls(calls: ParsedStackTrace[]) {
+  calls = calls.filter(call => !!call.apiName);
   if (!calls.length)
     return '';
   return 'Pending operations:\n' + calls.map(call => {
-    const frame = call.frames && call.frames[0] ? formatStackFrame(call.frames[0]) : '<unknown>';
-    return `  - ${call.apiName} at ${frame}\n`;
+    const frame = call.frames && call.frames[0] ? ' at ' + formatStackFrame(call.frames[0]) : '';
+    return `  - ${call.apiName}${frame}\n`;
   }).join('') + '\n';
 }
 


### PR DESCRIPTION
This avoids `TypeError: Cannot read properties of undefined (reading 'logger')`.

Drive-by: get rid of `undefined` pending operations.