### PR TITLE
fix(test runner): skip beforeAll/afterAll when all tests are skipped

### DIFF
--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -165,6 +165,15 @@ export class WorkerRunner extends EventEmitter {
       return;
     annotations = annotations.concat(suite._annotations);
 
+    const allSkipped = suite.allTests().every(test => {
+      const runEntry = this._entries.get(test._id);
+      return !runEntry || test.expectedStatus === 'skipped';
+    });
+    if (allSkipped) {
+      // This avoids running beforeAll/afterAll hooks.
+      annotations.push({ type: 'skip' });
+    }
+
     for (const beforeAllModifier of suite._modifiers) {
       if (!this._fixtureRunner.dependsOnWorkerFixturesOnly(beforeAllModifier.fn, beforeAllModifier.location))
         continue;

--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -224,6 +224,35 @@ test('beforeAll hooks are skipped when no tests in the suite are run', async ({ 
   expect(result.output).not.toContain('%%beforeAll1');
 });
 
+test('beforeAll/afterAll hooks are skipped when no tests in the suite are run 2', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test.beforeAll(() => {
+        console.log('\\n%%beforeAll1');
+      });
+      test.afterAll(() => {
+        console.log('\\n%%afterAll1');
+      });
+      test.skip('skipped1', () => {});
+      test.describe('inner', () => {
+        test.beforeAll(() => {
+          console.log('\\n%%beforeAll2');
+        });
+        test.afterAll(() => {
+          console.log('\\n%%afterAll2');
+        });
+        test.skip('skipped2', () => {});
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(0);
+  expect(result.skipped).toBe(2);
+  expect(result.output).not.toContain('%%beforeAll');
+  expect(result.output).not.toContain('%%afterAll');
+});
+
 test('should run hooks after failure', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `


### PR DESCRIPTION
There is a corner case where tests were skipped like this:

```js
test.skip('title', () => {});
```
