### PR TITLE
docs: missing $ in PowerShell shell command

### DIFF
--- a/docs/src/debug.md
+++ b/docs/src/debug.md
@@ -121,7 +121,7 @@ npm run test
 ```
 
 ```bash bash-flavor=powershell lang=js
-env:PWDEBUG="console"
+$env:PWDEBUG="console"
 npm run test
 ```
 


### PR DESCRIPTION
I hate one char PRs.