### PR TITLE
cherry-pick(#11973): fix: proper chrome-beta channel installation on …

### DIFF
--- a/packages/playwright-core/bin/reinstall_chrome_beta_mac.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_mac.sh
@@ -4,7 +4,7 @@ set -x
 
 rm -rf "/Applications/Google Chrome Beta.app"
 cd /tmp
-curl -o ./googlechromebeta.dmg -k https://dl.google.com/chrome/mac/beta/googlechromebeta.dmg
+curl -o ./googlechromebeta.dmg -k https://dl.google.com/chrome/mac/universal/beta/googlechromebeta.dmg
 hdiutil attach -nobrowse -quiet -noautofsck -noautoopen -mountpoint /Volumes/googlechromebeta.dmg ./googlechromebeta.dmg
 cp -rf "/Volumes/googlechromebeta.dmg/Google Chrome Beta.app" /Applications
 hdiutil detach /Volumes/googlechromebeta.dmg

--- a/packages/playwright-core/bin/reinstall_chrome_stable_mac.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_mac.sh
@@ -4,7 +4,7 @@ set -x
 
 rm -rf "/Applications/Google Chrome.app"
 cd /tmp
-curl -o ./googlechrome.dmg -k https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg
+curl -o ./googlechrome.dmg -k https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg
 hdiutil attach -nobrowse -quiet -noautofsck -noautoopen -mountpoint /Volumes/googlechrome.dmg ./googlechrome.dmg
 cp -rf "/Volumes/googlechrome.dmg/Google Chrome.app" /Applications
 hdiutil detach /Volumes/googlechrome.dmg


### PR DESCRIPTION
…MacOS

SHA: 1e1a6acaf7f1f16cb4a83302802f040238611120

chrome-beta installation on MacOS should download universal binaries.

The old download URL for chrome-beta was downloading Chrome Beta M96

