### PR TITLE
fix(fixtures): make sure connected browser respects context options

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -171,7 +171,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
         browser = Browser.from(playwright._initializer.preLaunchedBrowser!);
         browser._logger = logger;
         browser._shouldCloseConnectionOnClose = true;
-        browser._setBrowserType((playwright as any)[browser._name]);
+        browser._setBrowserType(this);
         browser._localUtils = this._playwright._utils;
         browser.on(Events.Browser.Disconnected, closePipe);
         return browser;

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -568,9 +568,11 @@ test('should work with connectOptions', async ({ runInlineTest }) => {
     `,
     'a.test.ts': `
       const { test } = pwt;
+      test.use({ locale: 'fr-CH' });
       test('pass', async ({ page }) => {
         await page.setContent('<div>PASS</div>');
         await expect(page.locator('div')).toHaveText('PASS');
+        expect(await page.evaluate(() => navigator.language)).toBe('fr-CH');
       });
     `,
   });


### PR DESCRIPTION
Connected browser was wired up to the wrong browserType object.
