### PR TITLE
cherry-pick(#11991): fix(mac): avoid printing empty line to stderr on mac

### DIFF
--- a/packages/playwright-core/src/utils/utils.ts
+++ b/packages/playwright-core/src/utils/utils.ts
@@ -457,7 +457,7 @@ function determineUserAgent(): string {
     osIdentifier = 'windows';
     osVersion = `${version[0]}.${version[1]}`;
   } else if (process.platform === 'darwin') {
-    const version = execSync('sw_vers -productVersion').toString().trim().split('.');
+    const version = execSync('sw_vers -productVersion', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim().split('.');
     osIdentifier = 'macOS';
     osVersion = `${version[0]}.${version[1]}`;
   } else if (process.platform === 'linux') {


### PR DESCRIPTION
SHA: 1f6b84f445597655b015df52cef0784d9963492c

It turns out, `sw_vers` prints an empty stderr line and we inherit it.

