### PR TITLE
test: unflake browsertype-connect.spec

### DIFF
--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -97,8 +97,12 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
       await remoteServer._start(childProcess, browserType, options);
       return remoteServer;
     });
-    if (remoteServer)
+    if (remoteServer) {
       await remoteServer.close();
+      // Give any connected browsers a chance to disconnect to avoid
+      // poisoning next test with quasy-alive browsers.
+      await new Promise(f => setTimeout(f, 1000));
+    }
   },
 });
 


### PR DESCRIPTION
Consider the scenario:
- First test starts a remote server, connects to it and does not close.
- Remote server fixture stops the server in teardown. Meanwhile, the connected browser did not get notified about disconnect just yet.
- Second test starts and sets up tracing in the old connected browser.
- Tracing fails because the browser now realises it has disconnected.
