### PR TITLE
cherry-pick(release-1.19): docs(python): enable Route.fulfill.response

### DIFF
--- a/docs/src/api/class-route.md
+++ b/docs/src/api/class-route.md
@@ -221,7 +221,7 @@ File path to respond with. The content type will be inferred from file extension
 is resolved relative to the current working directory.
 
 ### option: Route.fulfill.response
-* langs: js, java
+* langs: js, java, python
 - `response` <[APIResponse]>
 
 [APIResponse] to fulfill route's request with. Individual fields of the response (such as headers) can be overridden using fulfill options.


### PR DESCRIPTION
281518016262e368f7d47fd1cf0201380d11c0a5