### PR TITLE
fix(remote): make playwright server work with firefox-beta

### DIFF
--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -166,7 +166,7 @@ class Connection {
     const playwright = createPlaywright('javascript');
     const socksProxy = await this._enableSocksProxyIfNeeded(playwright);
     const browser = await playwright[executable.browserName].launch(internalCallMetadata(), {
-      channel: executable.type === 'channel' ? executable.name : undefined,
+      channel: executable.type === 'browser' ? undefined : executable.name,
     });
 
     // Close the browser on disconnect.


### PR DESCRIPTION
It is not considered "channel", but rather a "tool".