### PR TITLE
cherry-pick(#12003): docs: avoid .net version ambiguity

### DIFF
--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -19,7 +19,7 @@ cd PlaywrightDemo
 dotnet add package Microsoft.Playwright
 # Build the project
 dotnet build
-# Install required browsers
+# Install required browsers - replace netX with actual output folder name, f.ex. net6.0.
 pwsh bin\Debug\netX\playwright.ps1 install
 
 # If the pwsh command does not work (throws TypeNotFound), make sure to use an up-to-date version of PowerShell.


### PR DESCRIPTION
SHA 1df07aa2cfcef198cac860c7672a42c08920e171

<!--
Thank you for your Pull Request. Please link to the issue this PR addresses.
-->
Fixes #

<!-- PR Checklist
- The issue has been triaged and positive signals were received from maintainers
- Existing tests pass
- New tests are added
- Relevant documentation is changed or added
-->
