### PR TITLE
cherry-pick(#12025): chore(dotnet): do not use global CLI and use ps1 instead

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -138,30 +138,30 @@ you can still opt into stable channels on the bots that are typically free of su
 ### Prerequisites for .NET
 * langs: csharp
 
-All examples require the `Microsoft.Playwright.CLI` to be installed. You only have to do this once:
+To invoke Playwright CLI commands, you need to invoke a PowerShell script:
 
 ```bash
-dotnet tool install -g Microsoft.Playwright.CLI
+pwsh bin\Debug\netX\playwright.ps1 --help
 ```
 
 Playwright can install supported browsers by means of the CLI tool.
 
 ```bash csharp
 # Running without arguments will install all browsers
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 You can also install specific browsers by providing an argument:
 
 ```bash csharp
 # Install WebKit
-playwright install webkit
+pwsh bin\Debug\netX\playwright.ps1 install webkit
 ```
 
 See all supported browsers:
 
 ```bash csharp
-playwright install --help
+pwsh bin\Debug\netX\playwright.ps1 install --help
 ```
 
 ## Managing browser binaries
@@ -230,17 +230,17 @@ mvn test
 
 ```bash bash-flavor=bash lang=csharp
 PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers 
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ```bash bash-flavor=batch lang=csharp
 set PLAYWRIGHT_BROWSERS_PATH=%USERPROFILE%\pw-browsers
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ```bash bash-flavor=powershell lang=csharp
 $env:PLAYWRIGHT_BROWSERS_PATH="$env:USERPROFILE\pw-browsers"
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 When running Playwright scripts, ask it to search for browsers in a shared location.
@@ -398,17 +398,17 @@ mvn test
 ```
 
 ```bash bash-flavor=bash lang=csharp
-HTTPS_PROXY=https://192.0.2.1 playwright install
+HTTPS_PROXY=https://192.0.2.1 pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ```bash bash-flavor=batch lang=csharp
 set HTTPS_PROXY=https://192.0.2.1
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ```bash bash-flavor=powershell lang=csharp
 $env:HTTPS_PROXY="https://192.0.2.1"
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ## Download from artifact repository
@@ -479,17 +479,17 @@ mvn test
 ```
 
 ```bash bash-flavor=bash lang=csharp
-PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 playwright install
+PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ```bash bash-flavor=batch lang=csharp
 set PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ```bash bash-flavor=powershell lang=csharp
 $env:PLAYWRIGHT_DOWNLOAD_HOST="192.0.2.1"
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 It is also possible to use a per-browser download hosts using `PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST`, `PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST` and `PLAYWRIGHT_WEBKIT_DOWNLOAD_HOST` env variables that
@@ -563,19 +563,19 @@ mvn test
 ```
 
 ```bash bash-flavor=bash lang=csharp
-PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=203.0.113.3 PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 playwright install
+PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=203.0.113.3 PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ```bash bash-flavor=batch lang=csharp
 set PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=203.0.113.3
 set PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ```bash bash-flavor=powershell lang=csharp
 $env:PLAYWRIGHT_DOWNLOAD_HOST="192.0.2.1"
 $env:PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST="203.0.113.3"
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ## Skip browser downloads
@@ -617,17 +617,17 @@ mvn test
 ```
 
 ```bash bash-flavor=bash lang=csharp
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 playwright install
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ```bash bash-flavor=batch lang=csharp
 set PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ```bash bash-flavor=powershell lang=csharp
 $env:PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 ## Download single browser binary

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -22,10 +22,8 @@ playwright
 ```
 
 ```bash csharp
-# Install the CLI once.
-dotnet tool install --global Microsoft.Playwright.CLI
 # Use the tools.
-playwright
+pwsh bin\Debug\netX\playwright.ps1 --help
 ```
 
 ```json js
@@ -58,7 +56,7 @@ playwright install
 
 ```bash csharp
 # Running without arguments will install default browsers
-playwright install
+pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
 You can also install specific browsers by providing an argument:
@@ -80,7 +78,7 @@ playwright install webkit
 
 ```bash csharp
 # Install WebKit
-playwright install webkit
+pwsh bin\Debug\netX\playwright.ps1 install webkit
 ```
 
 See all supported browsers:
@@ -174,7 +172,7 @@ playwright codegen --load-storage=auth.json my.web.app
 
 ```bash csharp
 pwsh bin\Debug\netX\playwright.ps1 open --load-storage=auth.json my.web.app
-playwright codegen --load-storage=auth.json my.web.app
+pwsh bin\Debug\netX\playwright.ps1 codegen --load-storage=auth.json my.web.app
 # Perform actions in authenticated state.
 ```
 
@@ -300,7 +298,7 @@ playwright open example.com
 
 ```bash csharp
 # Open page in Chromium
-playwright open example.com
+pwsh bin\Debug\netX\playwright.ps1 open example.com
 ```
 
 ```bash js
@@ -320,7 +318,7 @@ playwright wk example.com
 
 ```bash csharp
 # Open page in WebKit
-playwright wk example.com
+pwsh bin\Debug\netX\playwright.ps1 wk example.com
 ```
 
 ### Emulate devices
@@ -343,7 +341,7 @@ playwright open --device="iPhone 11" wikipedia.org
 
 ```bash csharp
 # Emulate iPhone 11.
-playwright open --device="iPhone 11" wikipedia.org
+pwsh bin\Debug\netX\playwright.ps1 open --device="iPhone 11" wikipedia.org
 ```
 
 ### Emulate color scheme and viewport size
@@ -365,7 +363,7 @@ playwright open --viewport-size=800,600 --color-scheme=dark twitter.com
 
 ```bash csharp
 # Emulate screen size and color scheme.
-playwright open --viewport-size=800,600 --color-scheme=dark twitter.com
+pwsh bin\Debug\netX\playwright.ps1 open --viewport-size=800,600 --color-scheme=dark twitter.com
 ```
 
 ### Emulate geolocation, language and timezone
@@ -391,7 +389,7 @@ playwright open --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --l
 ```bash csharp
 # Emulate timezone, language & location
 # Once page opens, click the "my location" button to see geolocation in action
-playwright open --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" maps.google.com
+pwsh bin\Debug\netX\playwright.ps1 open --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" maps.google.com
 ```
 
 ## Inspect selectors
@@ -491,7 +489,7 @@ playwright screenshot \
 
 ```bash csharp
 # Wait 3 seconds before capturing a screenshot after page loads ('load' event fires)
-playwright screenshot \
+pwsh bin\Debug\netX\playwright.ps1 screenshot \
     --device="iPhone 11" \
     --color-scheme=dark \
     --wait-for-timeout=3000 \
@@ -515,7 +513,7 @@ playwright screenshot --full-page en.wikipedia.org wiki-full.png
 
 ```bash csharp
 # Capture a full page screenshot
-playwright screenshot --full-page en.wikipedia.org wiki-full.png
+pwsh bin\Debug\netX\playwright.ps1 screenshot --full-page en.wikipedia.org wiki-full.png
 ```
 
 ## Generate PDF
@@ -539,7 +537,7 @@ playwright pdf https://en.wikipedia.org/wiki/PDF wiki.pdf
 
 ```bash csharp
 # See command help
-playwright pdf https://en.wikipedia.org/wiki/PDF wiki.pdf
+pwsh bin\Debug\netX\playwright.ps1 pdf https://en.wikipedia.org/wiki/PDF wiki.pdf
 ```
 
 ## Install system dependencies
@@ -563,7 +561,7 @@ playwright install-deps
 
 ```bash csharp
 # See command help
-playwright install-deps
+pwsh bin\Debug\netX\playwright.ps1 install-deps
 ```
 
 You can also install the dependencies for a single browser only by passing it as an argument:

--- a/docs/src/codegen.md
+++ b/docs/src/codegen.md
@@ -22,7 +22,7 @@ playwright codegen wikipedia.org
 ```
 
 ```bash csharp
-playwright codegen wikipedia.org
+pwsh bin\Debug\netX\playwright.ps1 codegen wikipedia.org
 ```
 
 Run `codegen` and perform actions in the browser. Playwright will generate the code for the user interactions. `codegen` will attempt to generate resilient text-based selectors.
@@ -52,7 +52,7 @@ playwright codegen --save-storage=auth.json
 ```
 
 ```bash csharp
-playwright codegen --save-storage=auth.json
+pwsh bin\Debug\netX\playwright.ps1 codegen --save-storage=auth.json
 # Perform authentication and exit.
 # auth.json will contain the storage state.
 ```
@@ -79,8 +79,8 @@ playwright codegen --load-storage=auth.json my.web.app
 ```
 
 ```bash csharp
-playwright open --load-storage=auth.json my.web.app
-playwright codegen --load-storage=auth.json my.web.app
+pwsh bin\Debug\netX\playwright.ps1 open --load-storage=auth.json my.web.app
+pwsh bin\Debug\netX\playwright.ps1 codegen --load-storage=auth.json my.web.app
 # Perform actions in authenticated state.
 ```
 
@@ -206,7 +206,7 @@ playwright codegen --device="iPhone 11" wikipedia.org
 
 ```bash csharp
 # Emulate iPhone 11.
-playwright codegen --device="iPhone 11" wikipedia.org
+pwsh bin\Debug\netX\playwright.ps1 codegen --device="iPhone 11" wikipedia.org
 ```
 
 ## Emulate color scheme and viewport size
@@ -230,7 +230,7 @@ playwright codegen --viewport-size=800,600 --color-scheme=dark twitter.com
 
 ```bash csharp
 # Emulate screen size and color scheme.
-playwright codegen --viewport-size=800,600 --color-scheme=dark twitter.com
+pwsh bin\Debug\netX\playwright.ps1 codegen --viewport-size=800,600 --color-scheme=dark twitter.com
 ```
 
 ## Emulate geolocation, language and timezone
@@ -256,5 +256,5 @@ playwright codegen --timezone="Europe/Rome" --geolocation="41.890221,12.492348" 
 ```bash csharp
 # Emulate timezone, language & location
 # Once page opens, click the "my location" button to see geolocation in action
-playwright codegen --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" maps.google.com
+pwsh bin\Debug\netX\playwright.ps1 codegen --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" maps.google.com
 ```

--- a/docs/src/inspector.md
+++ b/docs/src/inspector.md
@@ -60,6 +60,20 @@ configures Playwright for debugging and opens the inspector.
   pytest -s
   ```
 
+  ```bash bash-flavor=bash lang=csharp
+  PWDEBUG=1 dotnet test
+  ```
+
+  ```bash bash-flavor=batch lang=csharp
+  set PWDEBUG=1
+  dotnet test
+  ```
+
+  ```bash bash-flavor=powershell lang=csharp
+  $env:PWDEBUG=1
+  dotnet test
+  ```
+
   Additional useful defaults are configured when `PWDEBUG=1` is set:
   - Browsers launch in the headed mode
   - Default timeout is set to 0 (= no timeout)
@@ -103,6 +117,10 @@ configures Playwright for debugging and opens the inspector.
 
   ```bash python
   playwright codegen wikipedia.org
+  ```
+
+  ```bash csharp
+  pwsh bin\Debug\netX\playwright.ps1 codegen wikipedia.org
   ```
 
 ## Stepping through the Playwright script

--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -106,7 +106,7 @@ Playwright Trace Viewer is now **available online** at https://trace.playwright.
 - Playwright now supports **Ubuntu 20.04 ARM64**. You can now run Playwright tests inside Docker on Apple M1 and on Raspberry Pi.
 - You can now use Playwright to install stable version of Edge on Linux:
     ```bash
-    npx playwright install msedge
+    pwsh bin\Debug\netX\playwright.ps1 install msedge
     ```
 
 
@@ -133,7 +133,7 @@ Read more about [`method: Locator.waitFor`].
 
 ### 🎭 Playwright Trace Viewer
 
-- run trace viewer with `npx playwright show-trace` and drop trace files to the trace viewer PWA
+- run trace viewer with `pwsh bin\Debug\netX\playwright.ps1 show-trace` and drop trace files to the trace viewer PWA
 - better visual attribution of action targets
 
 Read more about [Trace Viewer](./trace-viewer).

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -158,7 +158,7 @@ Playwright Trace Viewer is now **available online** at https://trace.playwright.
 - Playwright now supports **Ubuntu 20.04 ARM64**. You can now run Playwright tests inside Docker on Apple M1 and on Raspberry Pi.
 - You can now use Playwright to install stable version of Edge on Linux:
     ```bash
-    npx playwright install msedge
+    mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install msedge"
     ```
 
 
@@ -185,7 +185,7 @@ Read more about [`method: Locator.waitFor`].
 
 ### 🎭 Playwright Trace Viewer
 
-- run trace viewer with `npx playwright show-trace` and drop trace files to the trace viewer PWA
+- run trace viewer with `mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="show-trace"` and drop trace files to the trace viewer PWA
 - better visual attribution of action targets
 
 Read more about [Trace Viewer](./trace-viewer).
@@ -474,10 +474,7 @@ This version of Playwright was also tested against the following stable channels
 - [Selecting elements based on layout](./selectors.md#selecting-elements-based-on-layout) with `:left-of()`, `:right-of()`, `:above()` and `:below()`.
 - Playwright now includes [command line interface](./cli.md), former playwright-cli.
   ```bash js
-  npx playwright --help
-  ```
-  ```bash python
-  playwright --help
+  mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="--help"
   ```
 - [`method: Page.selectOption`] now waits for the options to be present.
 - New methods to [assert element state](./actionability#assertions) like [`method: Page.isEditable`].

--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -151,7 +151,7 @@ playwright show-trace trace.zip
 ```
 
 ```bash csharp
-playwright show-trace trace.zip
+pwsh bin\Debug\netX\playwright.ps1 show-trace trace.zip
 ```
 
 ## Actions
@@ -218,5 +218,5 @@ playwright show-trace https://example.com/trace.zip
 ```
 
 ```bash csharp
-playwright show-trace https://example.com/trace.zip
+pwsh bin\Debug\netX\playwright.ps1 show-trace https://example.com/trace.zip
 ```

--- a/packages/playwright-core/src/cli/innerCli.ts
+++ b/packages/playwright-core/src/cli/innerCli.ts
@@ -611,7 +611,7 @@ function buildBasePlaywrightCLICommand(cliTargetLang: string | undefined): strin
     case 'java':
       return `mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="...options.."`;
     case 'csharp':
-      return `playwright`;
+      return `pwsh bin\\Debug\\netX\\playwright.ps1`;
     default:
       return `npx playwright`;
   }

--- a/packages/playwright-core/src/utils/registry.ts
+++ b/packages/playwright-core/src/utils/registry.ts
@@ -716,7 +716,7 @@ export function buildPlaywrightCLICommand(sdkLanguage: string, parameters: strin
     case 'java':
       return `mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="${parameters}"`;
     case 'csharp':
-      return `playwright ${parameters}`;
+      return `pwsh bin\\Debug\\netX\\playwright.ps1 ${parameters}`;
     default:
       return `npx playwright ${parameters}`;
   }


### PR DESCRIPTION
SHA: 7e7996a7b717830356531856496c78ffdb4d5d46
Fixes https://github.com/microsoft/playwright-dotnet/issues/2005

