### PR TITLE
devops: expect mac 12.2

### DIFF
--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -284,12 +284,12 @@ elif [[ "$BUILD_FLAVOR" == "webkit-mac-10.15" ]]; then
 elif [[ "$BUILD_FLAVOR" == "webkit-mac-12" ]]; then
   BROWSER_NAME="webkit"
   EXPECTED_HOST_OS="Darwin"
-  EXPECTED_HOST_OS_VERSION="12.1"
+  EXPECTED_HOST_OS_VERSION="12.2"
   BUILD_BLOB_NAME="webkit-mac-12.zip"
 elif [[ "$BUILD_FLAVOR" == "webkit-mac-12-arm64" ]]; then
   BROWSER_NAME="webkit"
   EXPECTED_HOST_OS="Darwin"
-  EXPECTED_HOST_OS_VERSION="12.1"
+  EXPECTED_HOST_OS_VERSION="12.2"
   EXPECTED_ARCH="arm64"
   BUILD_BLOB_NAME="webkit-mac-12-arm64.zip"
 elif [[ "$BUILD_FLAVOR" == "webkit-mac-11-arm64" ]]; then


### PR DESCRIPTION
```sh
Run arch -arm64e ./browser_patches/checkout_build_archive_upload.sh webkit-mac-[12](https://github.com/microsoft/playwright-internal/runs/5188008771?check_suite_focus=true#step:4:12)-arm64
ERROR: cannot build webkit-mac-12-arm64
  -- expected OS Version: 12.1
  --  current OS Version: 12.2
Error: Process completed with exit code 1.
```