### PR TITLE
chore(installation-tests): introduce `npm_i` to install local packages

### DIFF
--- a/installation-tests/README.md
+++ b/installation-tests/README.md
@@ -16,3 +16,5 @@ To run all tests:
 ```bash
 ./run_all_tests.sh
 ```
+
+To install local builds of `playwright` packages in tests, do `npm_i playwright`.

--- a/installation-tests/bin/npm_i
+++ b/installation-tests/bin/npm_i
@@ -1,27 +1,24 @@
 #!/bin/bash
 
-if [[ $1 == "i" || $1 == "install" ]]; then
-  shift;
-  args="install"
-  for i in "$@"; do
-    if [[ "$i" == "playwright" ]]; then
-      args="${args} ${PLAYWRIGHT_TGZ}"
-    elif [[ $i == "playwright-core" ]]; then
-      args="${args} ${PLAYWRIGHT_CORE_TGZ}"
-    elif [[ $i == "playwright-firefox" ]]; then
-      args="${args} ${PLAYWRIGHT_FIREFOX_TGZ}"
-    elif [[ $i == "playwright-chromium" ]]; then
-      args="${args} ${PLAYWRIGHT_CHROMIUM_TGZ}"
-    elif [[ $i == "playwright-webkit" ]]; then
-      args="${args} ${PLAYWRIGHT_WEBKIT_TGZ}"
-    elif [[ $i == "@playwright/test" ]]; then
-      args="${args} ${PLAYWRIGHT_TEST_TGZ}"
-    else
-      args="${args} $i"
-    fi
-  done
-  npm $args 2>&1
-else
-  npm $@ 2>&1
-fi
+args=""
+for i in "$@"; do
+  if [[ "$i" == "playwright" ]]; then
+    args="${args} ${PLAYWRIGHT_TGZ}"
+  elif [[ $i == "playwright-core" ]]; then
+    args="${args} ${PLAYWRIGHT_CORE_TGZ}"
+  elif [[ $i == "playwright-firefox" ]]; then
+    args="${args} ${PLAYWRIGHT_FIREFOX_TGZ}"
+  elif [[ $i == "playwright-chromium" ]]; then
+    args="${args} ${PLAYWRIGHT_CHROMIUM_TGZ}"
+  elif [[ $i == "playwright-webkit" ]]; then
+    args="${args} ${PLAYWRIGHT_WEBKIT_TGZ}"
+  elif [[ $i == "@playwright/test" ]]; then
+    args="${args} ${PLAYWRIGHT_TEST_TGZ}"
+  elif [[ $i == "-"* ]]; then
+    args="${args} $i"
+  else
+    echo "ERROR: cannot install package $i using npm_i. Use regular npm instead"
+  fi
+done
+npm install $args 2>&1
 

--- a/installation-tests/bin/npm_i
+++ b/installation-tests/bin/npm_i
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [[ $1 == "i" || $1 == "install" ]]; then
+  shift;
+  args="install"
+  for i in "$@"; do
+    if [[ "$i" == "playwright" ]]; then
+      args="${args} ${PLAYWRIGHT_TGZ}"
+    elif [[ $i == "playwright-core" ]]; then
+      args="${args} ${PLAYWRIGHT_CORE_TGZ}"
+    elif [[ $i == "playwright-firefox" ]]; then
+      args="${args} ${PLAYWRIGHT_FIREFOX_TGZ}"
+    elif [[ $i == "playwright-chromium" ]]; then
+      args="${args} ${PLAYWRIGHT_CHROMIUM_TGZ}"
+    elif [[ $i == "playwright-webkit" ]]; then
+      args="${args} ${PLAYWRIGHT_WEBKIT_TGZ}"
+    elif [[ $i == "@playwright/test" ]]; then
+      args="${args} ${PLAYWRIGHT_TEST_TGZ}"
+    else
+      args="${args} $i"
+    fi
+  done
+  npm $args 2>&1
+else
+  npm $@ 2>&1
+fi
+

--- a/installation-tests/test_android_types.sh
+++ b/installation-tests/test_android_types.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_TGZ}
-npm install -D typescript@3.8
-npm install -D @types/node@14
+npm_i playwright-core
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright
+npm_i -D typescript@3.8
+npm_i -D @types/node@14
 echo "import { AndroidDevice, _android, AndroidWebView, Page } from 'playwright';" > "test.ts"
 
 echo "Running tsc"

--- a/installation-tests/test_android_types.sh
+++ b/installation-tests/test_android_types.sh
@@ -3,8 +3,8 @@ source ./initialize_test.sh && initialize_test "$@"
 
 npm_i playwright-core
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright
-npm_i -D typescript@3.8
-npm_i -D @types/node@14
+npm i -D typescript@3.8
+npm i -D @types/node@14
 echo "import { AndroidDevice, _android, AndroidWebView, Page } from 'playwright';" > "test.ts"
 
 echo "Running tsc"

--- a/installation-tests/test_connect_to_selenium.sh
+++ b/installation-tests/test_connect_to_selenium.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm i playwright-core
+npm_i playwright-core
 node "./download-chromedriver.js" "${PWD}"
 export PWTEST_CHROMEDRIVER="${PWD}/chromedriver"
 cd "${PLAYWRIGHT_CHECKOUT}"

--- a/installation-tests/test_connect_to_selenium.sh
+++ b/installation-tests/test_connect_to_selenium.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
+npm i playwright-core
 node "./download-chromedriver.js" "${PWD}"
 export PWTEST_CHROMEDRIVER="${PWD}/chromedriver"
 cd "${PLAYWRIGHT_CHECKOUT}"

--- a/installation-tests/test_electron_types.sh
+++ b/installation-tests/test_electron_types.sh
@@ -3,9 +3,9 @@ source ./initialize_test.sh && initialize_test "$@"
 
 npm_i playwright-core
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright
-npm_i electron@12
-npm_i -D typescript@3.8
-npm_i -D @types/node@14
+npm i electron@12
+npm i -D typescript@3.8
+npm i -D @types/node@14
 echo "import { Page, _electron, ElectronApplication, Electron } from 'playwright';" > "test.ts"
 
 echo "Running tsc"

--- a/installation-tests/test_electron_types.sh
+++ b/installation-tests/test_electron_types.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_TGZ}
-npm install electron@12
-npm install -D typescript@3.8
-npm install -D @types/node@14
+npm_i playwright-core
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright
+npm_i electron@12
+npm_i -D typescript@3.8
+npm_i -D @types/node@14
 echo "import { Page, _electron, ElectronApplication, Electron } from 'playwright';" > "test.ts"
 
 echo "Running tsc"

--- a/installation-tests/test_npm_i_installs_local_package.sh
+++ b/installation-tests/test_npm_i_installs_local_package.sh
@@ -4,7 +4,7 @@ source ./initialize_test.sh && initialize_test "$@"
 
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright{,-core,-webkit,-firefox,-chromium}
 # test subshell installation
-OUTPUT=$(npm i --foreground-script @playwright/test)
+OUTPUT=$(npm_i --foreground-script @playwright/test)
 
 SCRIPT=$(cat <<EOF
   const packageJSON = require('./package.json');

--- a/installation-tests/test_npm_i_installs_local_package.sh
+++ b/installation-tests/test_npm_i_installs_local_package.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+source ./initialize_test.sh && initialize_test "$@"
+
+
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright{,-core,-webkit,-firefox,-chromium}
+# test subshell installation
+OUTPUT=$(npm i --foreground-script @playwright/test)
+
+SCRIPT=$(cat <<EOF
+  const packageJSON = require('./package.json');
+  for (const [entry, value] of Object.entries(packageJSON.dependencies)) {
+    if (!value.startsWith('file:')) {
+      console.log('ERROR: entry ' + entry + ' installed from NPM registry!');
+      process.exit(1);
+    }
+  }
+EOF
+)
+# make sure all dependencies are locally installed.
+node -e "${SCRIPT}"
+

--- a/installation-tests/test_playwright_chromium_should_work.sh
+++ b/installation-tests/test_playwright_chromium_should_work.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-OUTPUT=$(npm install --foreground-script ${PLAYWRIGHT_CHROMIUM_TGZ})
+npm_i playwright-core
+OUTPUT=$(npm_i --foreground-script playwright-chromium)
 if [[ "${OUTPUT}" != *"chromium"* ]]; then
   echo "ERROR: should download chromium"
   exit 1

--- a/installation-tests/test_playwright_cli_codegen_should_work.sh
+++ b/installation-tests/test_playwright_cli_codegen_should_work.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-npm install ${PLAYWRIGHT_TGZ}
+npm_i playwright-core
+npm_i playwright
 
 echo "Running playwright codegen"
 OUTPUT=$(PWTEST_CLI_EXIT=1 npx playwright codegen)

--- a/installation-tests/test_playwright_cli_install_should_work.sh
+++ b/installation-tests/test_playwright_cli_install_should_work.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_TGZ}
+npm_i playwright-core
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright
 
 BROWSERS="$(pwd -P)/browsers"
 

--- a/installation-tests/test_playwright_cli_screenshot_should_work.sh
+++ b/installation-tests/test_playwright_cli_screenshot_should_work.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-npm install ${PLAYWRIGHT_TGZ}
+npm_i playwright-core
+npm_i playwright
 
 echo "Running playwright screenshot"
 

--- a/installation-tests/test_playwright_driver_should_work.sh
+++ b/installation-tests/test_playwright_driver_should_work.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_TGZ}
+npm_i playwright-core
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright
 
 echo "Running playwright install"
 PLAYWRIGHT_BROWSERS_PATH="0" npx playwright install

--- a/installation-tests/test_playwright_electron_should_work.sh
+++ b/installation-tests/test_playwright_electron_should_work.sh
@@ -3,7 +3,7 @@ source ./initialize_test.sh && initialize_test "$@"
 
 npm_i playwright-core
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright
-npm_i electron@9.0
+npm i electron@9.0
 
 echo "Running sanity-electron.js"
 node sanity-electron.js

--- a/installation-tests/test_playwright_electron_should_work.sh
+++ b/installation-tests/test_playwright_electron_should_work.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_TGZ}
-npm install electron@9.0
+npm_i playwright-core
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright
+npm_i electron@9.0
 
 echo "Running sanity-electron.js"
 node sanity-electron.js

--- a/installation-tests/test_playwright_firefox_should_work.sh
+++ b/installation-tests/test_playwright_firefox_should_work.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-OUTPUT=$(npm install --foreground-script ${PLAYWRIGHT_FIREFOX_TGZ})
+npm_i playwright-core
+OUTPUT=$(npm_i --foreground-script playwright-firefox)
 if [[ "${OUTPUT}" == *"chromium"* ]]; then
   echo "ERROR: should not download chromium"
   exit 1

--- a/installation-tests/test_playwright_global_installation.sh
+++ b/installation-tests/test_playwright_global_installation.sh
@@ -2,8 +2,8 @@
 source ./initialize_test.sh && initialize_test "$@"
 
 BROWSERS="$(pwd -P)/browsers"
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm install ${PLAYWRIGHT_TGZ}
+npm_i playwright-core
+PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm_i playwright
 if [[ ! -d "${BROWSERS}" ]]; then
   echo "Directory for shared browsers was not created!"
   exit 1

--- a/installation-tests/test_playwright_global_installation_cross_package.sh
+++ b/installation-tests/test_playwright_global_installation_cross_package.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_FIREFOX_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_WEBKIT_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_CHROMIUM_TGZ}
+npm_i playwright-core
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright-firefox
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright-webkit
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright-chromium
 
 BROWSERS="$(pwd -P)/browsers"
-PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm install ${PLAYWRIGHT_TGZ}
+PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm_i playwright
 if [[ ! -d "${BROWSERS}" ]]; then
   echo "Directory for shared browsers was not created!"
   exit 1

--- a/installation-tests/test_playwright_global_installation_subsequent_installs.sh
+++ b/installation-tests/test_playwright_global_installation_subsequent_installs.sh
@@ -6,8 +6,8 @@ source ./initialize_test.sh && initialize_test "$@"
 BROWSERS="$(pwd -P)/browsers"
 
 mkdir install-1 && pushd install-1 && npm init -y
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm install ${PLAYWRIGHT_TGZ}
+npm_i playwright-core
+PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm_i playwright
 # Note: the `npm install` would not actually crash, the error
 # is merely logged to the console. To reproduce the error, we should make
 # sure that script's install.js can be run subsequently without unhandled promise rejections.

--- a/installation-tests/test_playwright_should_work.sh
+++ b/installation-tests/test_playwright_should_work.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-OUTPUT=$(npm install --foreground-script ${PLAYWRIGHT_TGZ})
+npm i playwright-core
+OUTPUT=$(npm i --foreground-script playwright)
 if [[ "${OUTPUT}" != *"chromium"* ]]; then
   echo "ERROR: should download chromium"
   exit 1

--- a/installation-tests/test_playwright_should_work.sh
+++ b/installation-tests/test_playwright_should_work.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm i playwright-core
-OUTPUT=$(npm i --foreground-script playwright)
+npm_i playwright-core
+OUTPUT=$(npm_i --foreground-script playwright)
 if [[ "${OUTPUT}" != *"chromium"* ]]; then
   echo "ERROR: should download chromium"
   exit 1

--- a/installation-tests/test_playwright_should_work_with_relative_browsers_path.sh
+++ b/installation-tests/test_playwright_should_work_with_relative_browsers_path.sh
@@ -4,8 +4,8 @@ source ./initialize_test.sh && initialize_test "$@"
 # Make sure that browsers path is resolved relative to the `npm install` call location.
 mkdir foo
 cd foo
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_BROWSERS_PATH="../relative" npm install ${PLAYWRIGHT_TGZ}
+npm_i playwright-core
+PLAYWRIGHT_BROWSERS_PATH="../relative" npm_i playwright
 cd ..
 
 echo "Running sanity.js"

--- a/installation-tests/test_playwright_should_work_with_relative_home_path.sh
+++ b/installation-tests/test_playwright_should_work_with_relative_home_path.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_BROWSERS_PATH="" HOME=. npm install ${PLAYWRIGHT_TGZ}
+npm_i playwright-core
+PLAYWRIGHT_BROWSERS_PATH="" HOME=. npm_i playwright
 echo "Running sanity.js"
 # Firefox does not work with relative HOME.
 PLAYWRIGHT_BROWSERS_PATH="" HOME=. node sanity.js playwright chromium webkit

--- a/installation-tests/test_playwright_test_should_work.sh
+++ b/installation-tests/test_playwright_test_should_work.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-npm install ${PLAYWRIGHT_TEST_TGZ}
+npm_i playwright-core
+npm_i @playwright/test
 
 echo "Running playwright test without install"
 if npx playwright test -c .; then

--- a/installation-tests/test_playwright_test_stacks_should_work.sh
+++ b/installation-tests/test_playwright_test_stacks_should_work.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-npm install ${PLAYWRIGHT_TEST_TGZ}
+npm_i playwright-core
+npm_i @playwright/test
 PLAYWRIGHT_BROWSERS_PATH="0" npx playwright install chromium
 
 echo "Running playwright test"

--- a/installation-tests/test_playwright_validate_dependencies.sh
+++ b/installation-tests/test_playwright_validate_dependencies.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-npm install ${PLAYWRIGHT_TGZ}
+npm_i playwright-core
+npm_i playwright
 
 OUTPUT="$(node validate-dependencies.js)"
 if [[ "${OUTPUT}" != *"PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS"* ]]; then

--- a/installation-tests/test_playwright_validate_dependencies_skip_executable_path.sh
+++ b/installation-tests/test_playwright_validate_dependencies_skip_executable_path.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-npm install ${PLAYWRIGHT_TGZ}
+npm_i playwright-core
+npm_i playwright
 
 OUTPUT="$(node validate-dependencies-skip-executable-path.js)"
 if [[ "${OUTPUT}" == *"PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS"* ]]; then

--- a/installation-tests/test_playwright_webkit_should_work.sh
+++ b/installation-tests/test_playwright_webkit_should_work.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-OUTPUT=$(npm install --foreground-script ${PLAYWRIGHT_WEBKIT_TGZ})
+npm_i playwright-core
+OUTPUT=$(npm_i --foreground-script playwright-webkit)
 if [[ "${OUTPUT}" == *"chromium"* ]]; then
   echo "ERROR: should not download chromium"
   exit 1

--- a/installation-tests/test_screencast.sh
+++ b/installation-tests/test_screencast.sh
@@ -2,11 +2,11 @@
 source ./initialize_test.sh && initialize_test "$@"
 
 BROWSERS="$(pwd -P)/browsers"
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm install ${PLAYWRIGHT_TGZ}
-PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm install ${PLAYWRIGHT_FIREFOX_TGZ}
-PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm install ${PLAYWRIGHT_WEBKIT_TGZ}
-PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm install ${PLAYWRIGHT_CHROMIUM_TGZ}
+npm_i playwright-core
+PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm_i playwright
+PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm_i playwright-firefox
+PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm_i playwright-webkit
+PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" npm_i playwright-chromium
 
 echo "Running screencast.js"
 PLAYWRIGHT_BROWSERS_PATH="${BROWSERS}" node screencast.js playwright

--- a/installation-tests/test_skip_browser_download.sh
+++ b/installation-tests/test_skip_browser_download.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-OUTPUT=$(PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install --foreground-script ${PLAYWRIGHT_TGZ})
+npm_i playwright-core
+OUTPUT=$(PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i --foreground-script playwright)
 if [[ "${OUTPUT}" != *"Skipping browsers download because"* ]]; then
   echo "missing log message that browsers download is skipped"
   exit 1

--- a/installation-tests/test_skip_browser_download_inspect_with_custom_executable.sh
+++ b/installation-tests/test_skip_browser_download_inspect_with_custom_executable.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source ./initialize_test.sh && initialize_test "$@"
 
-npm install ${PLAYWRIGHT_CORE_TGZ}
-OUTPUT=$(PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install --foreground-script ${PLAYWRIGHT_TGZ})
+npm_i playwright-core
+OUTPUT=$(PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i --foreground-script playwright)
 if [[ "${OUTPUT}" != *"Skipping browsers download because"* ]]; then
   echo "missing log message that browsers download is skipped"
   exit 1

--- a/installation-tests/test_typescript_types.sh
+++ b/installation-tests/test_typescript_types.sh
@@ -4,7 +4,7 @@ source ./initialize_test.sh && initialize_test "$@"
 # @types/node@14.18.9 is the last version which is compatibel with typescript@3.7.5.
 # After @types/node@14.18.9 URLSearchParams from @types/node conflicts with typescript's
 # shipped types and it results in a type error / build failure.
-npm_i -D @types/node@14.18.9
+npm i -D @types/node@14.18.9
 
 # install all packages.
 npm_i playwright-core

--- a/installation-tests/test_typescript_types.sh
+++ b/installation-tests/test_typescript_types.sh
@@ -4,15 +4,15 @@ source ./initialize_test.sh && initialize_test "$@"
 # @types/node@14.18.9 is the last version which is compatibel with typescript@3.7.5.
 # After @types/node@14.18.9 URLSearchParams from @types/node conflicts with typescript's
 # shipped types and it results in a type error / build failure.
-npm install -D @types/node@14.18.9
+npm_i -D @types/node@14.18.9
 
 # install all packages.
-npm install ${PLAYWRIGHT_CORE_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_FIREFOX_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_WEBKIT_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_CHROMIUM_TGZ}
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install ${PLAYWRIGHT_TEST_TGZ}
+npm_i playwright-core
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright-firefox
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright-webkit
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i playwright-chromium
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_i @playwright/test
 
 # typecheck all packages.
 for PKG_NAME in "playwright" \


### PR DESCRIPTION
This patch introduces `npm_i` command to install locally-built versions of
Playwright packages instead of fetching them from the registry.

With this patch:

```bash
npm i ${PLAYWRIGHT_CORE_TGZ}` # never needed anymore
npm_i playwright-core # the right way to install local package
```

Note that you can install any packages with `npm_i` and pass it all NPM arguments.
