### PR TITLE
feat(test-runner): filter out syntax error stack traces

### DIFF
--- a/packages/playwright-test/src/util.ts
+++ b/packages/playwright-test/src/util.ts
@@ -25,6 +25,7 @@ import { isInternalFileName } from 'playwright-core/lib/utils/stackTrace';
 
 const PLAYWRIGHT_CORE_PATH = path.dirname(require.resolve('playwright-core'));
 const EXPECT_PATH = path.dirname(require.resolve('expect'));
+const BABEL_PARSER_PATH = path.dirname(require.resolve('@babel/parser'));
 const PLAYWRIGHT_TEST_PATH = path.join(__dirname, '..');
 
 function filterStackTrace(e: Error) {
@@ -47,7 +48,11 @@ function filterStackTrace(e: Error) {
       const functionName = callSite.getFunctionName() || undefined;
       if (!fileName)
         return true;
-      return !fileName.startsWith(PLAYWRIGHT_TEST_PATH) && !fileName.startsWith(PLAYWRIGHT_CORE_PATH) && !fileName.startsWith(EXPECT_PATH) && !isInternalFileName(fileName, functionName);
+      return !fileName.startsWith(PLAYWRIGHT_TEST_PATH) &&
+             !fileName.startsWith(PLAYWRIGHT_CORE_PATH) &&
+             !fileName.startsWith(EXPECT_PATH) &&
+             !fileName.startsWith(BABEL_PARSER_PATH) &&
+             !isInternalFileName(fileName, functionName);
     }));
   };
   // eslint-disable-next-line

--- a/packages/playwright-test/src/util.ts
+++ b/packages/playwright-test/src/util.ts
@@ -25,7 +25,6 @@ import { isInternalFileName } from 'playwright-core/lib/utils/stackTrace';
 
 const PLAYWRIGHT_CORE_PATH = path.dirname(require.resolve('playwright-core'));
 const EXPECT_PATH = path.dirname(require.resolve('expect'));
-const BABEL_PARSER_PATH = path.dirname(require.resolve('@babel/parser'));
 const PLAYWRIGHT_TEST_PATH = path.join(__dirname, '..');
 
 function filterStackTrace(e: Error) {
@@ -51,7 +50,6 @@ function filterStackTrace(e: Error) {
       return !fileName.startsWith(PLAYWRIGHT_TEST_PATH) &&
              !fileName.startsWith(PLAYWRIGHT_CORE_PATH) &&
              !fileName.startsWith(EXPECT_PATH) &&
-             !fileName.startsWith(BABEL_PARSER_PATH) &&
              !isInternalFileName(fileName, functionName);
     }));
   };

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -314,6 +314,21 @@ test('should filter out event emitter from stack traces', async ({ runInlineTest
   expect(outputWithoutGoodStackFrames).not.toContain('EventEmitter.emit');
 });
 
+test('should filter out syntax error stack traces', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'expect-test.spec.ts': `
+      const { test } = pwt;
+      test('should work', ({}) => {
+        // syntax error: cannot have await in non-async function
+        await Proimse.resolve();
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(stripAnsi(result.output)).not.toContain('babel');
+  expect(stripAnsi(result.output)).not.toContain('    at ');
+});
+
 test('should filter stack trace for raw errors', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'expect-test.spec.ts': `


### PR DESCRIPTION
Filter out long stack traces from babel when it fails compilation
due to syntax error in test.
