### PR TITLE
feat(test-runner): attach snapshots when run with `--update-snapshots`

### DIFF
--- a/packages/playwright-test/src/matchers/golden.ts
+++ b/packages/playwright-test/src/matchers/golden.ts
@@ -115,7 +115,7 @@ export function compare(
     const commonMissingSnapshotMessage = `${snapshotFile} is missing in snapshots`;
     if (withNegateComparison) {
       const message = `${commonMissingSnapshotMessage}${isWriteMissingMode ? ', matchers using ".not" won\'t write them automatically.' : '.'}`;
-      return { pass: true , message };
+      return { pass: true , message, snapshotFile };
     }
     if (isWriteMissingMode) {
       fs.mkdirSync(path.dirname(snapshotFile), { recursive: true });
@@ -126,13 +126,13 @@ export function compare(
     const message = `${commonMissingSnapshotMessage}${isWriteMissingMode ? ', writing actual.' : '.'}`;
     if (updateSnapshots === 'all') {
       console.log(message);
-      return { pass: true, message };
+      return { pass: true, message, snapshotFile };
     }
     if (updateSnapshots === 'missing') {
       testInfo._failWithError(serializeError(new Error(message)), false /* isHardError */);
-      return { pass: true };
+      return { pass: true, snapshotFile };
     }
-    return { pass: false, message };
+    return { pass: false, message, snapshotFile };
   }
 
   const expected = fs.readFileSync(snapshotFile);
@@ -157,15 +157,17 @@ export function compare(
       return {
         pass: true,
         message,
+        snapshotFile,
       };
     }
 
-    return { pass: true };
+    return { pass: true, snapshotFile };
   }
 
   if (withNegateComparison) {
     return {
       pass: false,
+      snapshotFile,
     };
   }
 
@@ -175,6 +177,7 @@ export function compare(
     console.log(snapshotFile + ' does not match, writing actual.');
     return {
       pass: true,
+      snapshotFile,
       message: snapshotFile + ' running with --update-snapshots, writing actual.'
     };
   }
@@ -204,6 +207,7 @@ export function compare(
     message: output.join('\n'),
     expectedPath,
     actualPath,
+    snapshotFile,
     diffPath: result.diff ? diffPath : undefined,
     mimeType
   };

--- a/packages/playwright-test/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright-test/src/matchers/toMatchSnapshot.ts
@@ -48,7 +48,7 @@ export function toMatchSnapshot(this: ReturnType<Expect['getState']>, received: 
   let updateSnapshots = testInfo.config.updateSnapshots;
   if (updateSnapshots === 'missing' && testInfo.retry < testInfo.project.retries)
     updateSnapshots = 'none';
-  const { pass, message, expectedPath, actualPath, diffPath, mimeType } = compare(
+  const { pass, message, expectedPath, actualPath, diffPath, snapshotFile, mimeType } = compare(
       received,
       pathSegments,
       testInfo,
@@ -57,6 +57,8 @@ export function toMatchSnapshot(this: ReturnType<Expect['getState']>, received: 
       options
   );
   const contentType = mimeType || 'application/octet-stream';
+  if (updateSnapshots === 'all')
+    testInfo.attachments.push({ name: 'snapshot - ' + options.name, contentType, path: snapshotFile });
   if (expectedPath)
     testInfo.attachments.push({ name: 'expected', contentType, path: expectedPath });
   if (actualPath)


### PR DESCRIPTION
This way we can use HTML report to look at the updated snapshots.
