### PR TITLE
feat(test-runner): introduce `pixelCount` and `pixelRatio` options

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -39,7 +39,7 @@ export default config;
   - `toMatchSnapshot` <[Object]>
     - `threshold` <[float]> an acceptable percieved color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between pixels in compared images, between zero (strict) and one (lax). Defaults to `0.2`.
     - `pixelCount` <[int]> an acceptable amount of pixels that could be different, unset by default.
-    - `pixelRatio` <[float]> a ratio from `0` to `1` of all pixels on the image that could be different, unset by default.
+    - `pixelRatio` <[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
 
 Configuration for the `expect` assertion library. Learn more about [various timeouts](./test-timeouts.md).
 

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -37,7 +37,9 @@ export default config;
 - type: <[Object]>
   - `timeout` <[int]> Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
   - `toMatchSnapshot` <[Object]>
-    - `threshold` <[float]> Image matching threshold between zero (strict) and one (lax).
+    - `threshold` <[float]> an acceptable percieved color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between pixels in compared images, between zero (strict) and one (lax). Defaults to `0.2`.
+    - `pixelCount` <[int]> an acceptable amount of pixels that could be different, unset by default.
+    - `pixelRatio` <[float]> a ratio from `0` to `1` of all pixels on the image that could be different, unset by default.
 
 Configuration for the `expect` assertion library. Learn more about [various timeouts](./test-timeouts.md).
 

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -108,7 +108,9 @@ export default config;
 - type: <[Object]>
   - `timeout` <[int]> Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
   - `toMatchSnapshot` <[Object]>
-    - `threshold` <[float]> Image matching threshold between zero (strict) and one (lax).
+    - `threshold` <[float]> an acceptable percieved color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between pixels in compared images, between zero (strict) and one (lax). Defaults to `0.2`.
+    - `pixelCount` <[int]> an acceptable amount of pixels that could be different, unset by default.
+    - `pixelRatio` <[float]> a ratio from `0` to `1` of all pixels on the image that could be different, unset by default.
 
 Configuration for the `expect` assertion library.
 

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -110,7 +110,7 @@ export default config;
   - `toMatchSnapshot` <[Object]>
     - `threshold` <[float]> an acceptable percieved color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between pixels in compared images, between zero (strict) and one (lax). Defaults to `0.2`.
     - `pixelCount` <[int]> an acceptable amount of pixels that could be different, unset by default.
-    - `pixelRatio` <[float]> a ratio from `0` to `1` of all pixels on the image that could be different, unset by default.
+    - `pixelRatio` <[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
 
 Configuration for the `expect` assertion library.
 

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -349,7 +349,7 @@ await expect(page).toHaveURL(/.*checkout/);
 - `options`
   - `threshold` <[float]> an acceptable percieved color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between pixels in compared images, between zero (strict) and one (lax), default is configurable with [`property: TestConfig.expect`]. Defaults to `0.2`.
   - `pixelCount` <[int]> an acceptable amount of pixels that could be different, unset by default.
-  - `pixelRatio` <[float]> a ratio from `0` to `1` of all pixels on the image that could be different, unset by default.
+  - `pixelRatio` <[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
 
 Ensures that passed value, either a [string] or a [Buffer], matches the expected snapshot stored in the test snapshots directory.
 

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -347,7 +347,9 @@ await expect(page).toHaveURL(/.*checkout/);
 ## expect(value).toMatchSnapshot(name[, options])
 - `name` <[string] | [Array]<[string]>> Snapshot name.
 - `options`
-  - `threshold` <[float]> Image matching threshold between zero (strict) and one (lax), default is configurable with [`property: TestConfig.expect`].
+  - `threshold` <[float]> an acceptable percieved color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between pixels in compared images, between zero (strict) and one (lax), default is configurable with [`property: TestConfig.expect`]. Defaults to `0.2`.
+  - `pixelCount` <[int]> an acceptable amount of pixels that could be different, unset by default.
+  - `pixelRatio` <[float]> a ratio from `0` to `1` of all pixels on the image that could be different, unset by default.
 
 Ensures that passed value, either a [string] or a [Buffer], matches the expected snapshot stored in the test snapshots directory.
 

--- a/docs/src/test-snapshots-js.md
+++ b/docs/src/test-snapshots-js.md
@@ -67,7 +67,7 @@ npx playwright test --update-snapshots
 > Note that `snapshotName` also accepts an array of path segments to the snapshot file such as `expect(value).toMatchSnapshot(['relative', 'path', 'to', 'snapshot.png'])`.
 > However, this path must stay within the snapshots directory for each test file (i.e. `a.spec.js-snapshots`), otherwise it will throw.
 
-Playwright Test uses the [pixelmatch](https://github.com/mapbox/pixelmatch) library. You can pass comparison `threshold` as an option.
+Playwright Test uses the [pixelmatch](https://github.com/mapbox/pixelmatch) library. You can [pass various options](./test-assertions#expectvaluetomatchsnapshotname-options) to modify its behavior:
 
 ```js js-flavor=js
 // example.spec.js
@@ -75,7 +75,7 @@ const { test, expect } = require('@playwright/test');
 
 test('example test', async ({ page }) => {
   await page.goto('https://playwright.dev');
-  expect(await page.screenshot()).toMatchSnapshot('home.png', { threshold: 0.2 });
+  expect(await page.screenshot()).toMatchSnapshot('home.png', { pixelCount: 100 });
 });
 ```
 
@@ -85,7 +85,7 @@ import { test, expect } from '@playwright/test';
 
 test('example test', async ({ page }) => {
   await page.goto('https://playwright.dev');
-  expect(await page.screenshot()).toMatchSnapshot('home.png', { threshold: 0.2 });
+  expect(await page.screenshot()).toMatchSnapshot('home.png', { pixelCount: 100 });
 });
 ```
 
@@ -94,7 +94,7 @@ If you'd like to share the default value among all the tests in the project, you
 ```js js-flavor=js
 module.exports = {
   expect: {
-    toMatchSnapshot: { threshold: 0.1 },
+    toMatchSnapshot: { pixelCount: 100 },
   },
 };
 ```
@@ -103,7 +103,7 @@ module.exports = {
 import { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   expect: {
-    toMatchSnapshot: { threshold: 0.1 },
+    toMatchSnapshot: { pixelCount: 100 },
   },
 };
 export default config;

--- a/packages/playwright-test/src/matchers/golden.ts
+++ b/packages/playwright-test/src/matchers/golden.ts
@@ -81,7 +81,7 @@ function compareImages(actualBuffer: Buffer | string, expectedBuffer: Buffer, mi
   const count = pixelmatch(expected.data, actual.data, diff.data, expected.width, expected.height, thresholdOptions);
 
   const pixelCount1 = options.pixelCount;
-  const pixelCount2 = options.pixelRatio ? expected.width * expected.height * options.pixelRatio : undefined;
+  const pixelCount2 = options.pixelRatio !== undefined ? expected.width * expected.height * options.pixelRatio : undefined;
   let pixelCount;
   if (pixelCount1 !== undefined && pixelCount2 !== undefined)
     pixelCount = Math.min(pixelCount1, pixelCount2);

--- a/packages/playwright-test/src/matchers/golden.ts
+++ b/packages/playwright-test/src/matchers/golden.ts
@@ -57,7 +57,7 @@ function compareBuffersOrStrings(actualBuffer: Buffer | string, expectedBuffer: 
   return null;
 }
 
-function compareImages(actualBuffer: Buffer | string, expectedBuffer: Buffer, mimeType: string, options = {}): { diff?: Buffer; errorMessage?: string; } | null {
+function compareImages(actualBuffer: Buffer | string, expectedBuffer: Buffer, mimeType: string, options: { threshold?: number, pixelCount?: number, pixelRatio?: number } = {}): { diff?: Buffer; errorMessage?: string; } | null {
   if (!actualBuffer || !(actualBuffer instanceof Buffer))
     return { errorMessage: 'Actual result should be a Buffer.' };
 
@@ -79,7 +79,15 @@ function compareImages(actualBuffer: Buffer | string, expectedBuffer: Buffer, mi
     return result.code !== BlinkDiff.RESULT_IDENTICAL ? { diff: PNG.sync.write(diff._imageOutput.getImage()) } : null;
   }
   const count = pixelmatch(expected.data, actual.data, diff.data, expected.width, expected.height, thresholdOptions);
-  return count > 0 ? { diff: PNG.sync.write(diff) } : null;
+
+  const pixelCount1 = options.pixelCount;
+  const pixelCount2 = options.pixelRatio ? expected.width * expected.height * options.pixelRatio : undefined;
+  let pixelCount;
+  if (pixelCount1 !== undefined && pixelCount2 !== undefined)
+    pixelCount = Math.min(pixelCount1, pixelCount2);
+  else
+    pixelCount = pixelCount1 ?? pixelCount2 ?? 0;
+  return count > pixelCount ? { diff: PNG.sync.write(diff) } : null;
 }
 
 function compareText(actual: Buffer | string, expectedBuffer: Buffer): { diff?: Buffer; errorMessage?: string; diffExtension?: string; } | null {
@@ -102,7 +110,7 @@ export function compare(
   testInfo: TestInfoImpl,
   updateSnapshots: UpdateSnapshots,
   withNegateComparison: boolean,
-  options?: { threshold?: number }
+  options?: { threshold?: number, pixelCount?: number, pixelRatio?: number }
 ): { pass: boolean; message?: string; expectedPath?: string, actualPath?: string, diffPath?: string, mimeType?: string } {
   const snapshotFile = testInfo.snapshotPath(...pathSegments);
   const outputFile = testInfo.outputPath(...pathSegments);

--- a/packages/playwright-test/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright-test/src/matchers/toMatchSnapshot.ts
@@ -45,20 +45,13 @@ export function toMatchSnapshot(this: ReturnType<Expect['getState']>, received: 
     options.name = sanitizeForFilePath(trimLongString(fullTitleWithoutSpec)) + determineFileExtension(received);
   }
 
-  const projectThreshold = testInfo.project.expect?.toMatchSnapshot?.threshold;
-  if (options.threshold === undefined && projectThreshold !== undefined)
-    options.threshold = projectThreshold;
-
-  const projectPixelDelta = testInfo.project.expect?.toMatchSnapshot?.pixelCount;
-  if (options.pixelCount === undefined && projectPixelDelta !== undefined)
-    options.pixelCount = projectPixelDelta;
+  options = {
+    ...(testInfo.project.expect?.toMatchSnapshot || {}),
+    ...options,
+  };
 
   if (options.pixelCount !== undefined && options.pixelCount < 0)
     throw new Error('`pixelCount` option value must be non-negative integer');
-
-  const projectPixelPercent = testInfo.project.expect?.toMatchSnapshot?.pixelRatio;
-  if (options.pixelRatio === undefined && projectPixelPercent !== undefined)
-    options.pixelRatio = projectPixelPercent;
 
   if (options.pixelRatio !== undefined && (options.pixelRatio < 0 || options.pixelRatio > 1))
     throw new Error('`pixelRatio` option value must be between 0 and 1');

--- a/packages/playwright-test/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright-test/src/matchers/toMatchSnapshot.ts
@@ -27,8 +27,8 @@ type SyncExpectationResult = {
 
 type NameOrSegments = string | string[];
 const SNAPSHOT_COUNTER = Symbol('noname-snapshot-counter');
-export function toMatchSnapshot(this: ReturnType<Expect['getState']>, received: Buffer | string, nameOrOptions: NameOrSegments | { name: NameOrSegments, threshold?: number }, optOptions: { threshold?: number } = {}): SyncExpectationResult {
-  let options: { name: NameOrSegments, threshold?: number };
+export function toMatchSnapshot(this: ReturnType<Expect['getState']>, received: Buffer | string, nameOrOptions: NameOrSegments | { name: NameOrSegments, threshold?: number }, optOptions: { threshold?: number, pixelCount?: number, pixelRatio?: number } = {}): SyncExpectationResult {
+  let options: { name: NameOrSegments, threshold?: number, pixelCount?: number, pixelRatio?: number };
   const testInfo = currentTestInfo();
   if (!testInfo)
     throw new Error(`toMatchSnapshot() must be called during the test`);
@@ -48,6 +48,20 @@ export function toMatchSnapshot(this: ReturnType<Expect['getState']>, received: 
   const projectThreshold = testInfo.project.expect?.toMatchSnapshot?.threshold;
   if (options.threshold === undefined && projectThreshold !== undefined)
     options.threshold = projectThreshold;
+
+  const projectPixelDelta = testInfo.project.expect?.toMatchSnapshot?.pixelCount;
+  if (options.pixelCount === undefined && projectPixelDelta !== undefined)
+    options.pixelCount = projectPixelDelta;
+
+  if (options.pixelCount !== undefined && options.pixelCount < 0)
+    throw new Error('`pixelCount` option value must be non-negative integer');
+
+  const projectPixelPercent = testInfo.project.expect?.toMatchSnapshot?.pixelRatio;
+  if (options.pixelRatio === undefined && projectPixelPercent !== undefined)
+    options.pixelRatio = projectPixelPercent;
+
+  if (options.pixelRatio !== undefined && (options.pixelRatio < 0 || options.pixelRatio > 1))
+    throw new Error('`pixelRatio` option value must be between 0 and 1');
 
   // sanitizes path if string
   const pathSegments = Array.isArray(options.name) ? options.name : [addSuffixToFilePath(options.name, '', undefined, true)];

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -52,7 +52,7 @@ type ExpectSettings = {
      */
     pixelCount?: number,
     /**
-     * A ratio from `0` to `1` of all pixels on the image that could be different, unset by default.
+     * An acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
      */
     pixelRatio?: number,
   }

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -39,11 +39,22 @@ export type UpdateSnapshots = 'all' | 'none' | 'missing';
 type UseOptions<TestArgs, WorkerArgs> = { [K in keyof WorkerArgs]?: WorkerArgs[K] } & { [K in keyof TestArgs]?: TestArgs[K] };
 
 type ExpectSettings = {
-  // Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
+  /**
+   * Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
+   */
   timeout?: number;
   toMatchSnapshot?: {
-    // Pixel match threshold.
-    threshold?: number
+    /** An acceptable percieved color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between pixels in compared images, between zero (strict) and one (lax). Defaults to `0.2`.
+     */
+    threshold?: number,
+    /**
+     * An acceptable amount of pixels that could be different, unset by default.
+     */
+    pixelCount?: number,
+    /**
+     * A ratio from `0` to `1` of all pixels on the image that could be different, unset by default.
+     */
+    pixelRatio?: number,
   }
 };
 

--- a/packages/playwright-test/types/testExpect.d.ts
+++ b/packages/playwright-test/types/testExpect.d.ts
@@ -79,7 +79,9 @@ declare global {
        */
       toMatchSnapshot(options?: {
         name?: string | string[],
-        threshold?: number
+        threshold?: number,
+        pixelCount?: number,
+        pixelRatio?: number,
       }): R;
       /**
        * Match snapshot

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -51,7 +51,7 @@ type ExpectSettings = {
      */
     pixelCount?: number,
     /**
-     * A ratio from `0` to `1` of all pixels on the image that could be different, unset by default.
+     * An acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
      */
     pixelRatio?: number,
   }

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -38,11 +38,22 @@ export type UpdateSnapshots = 'all' | 'none' | 'missing';
 type UseOptions<TestArgs, WorkerArgs> = { [K in keyof WorkerArgs]?: WorkerArgs[K] } & { [K in keyof TestArgs]?: TestArgs[K] };
 
 type ExpectSettings = {
-  // Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
+  /**
+   * Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
+   */
   timeout?: number;
   toMatchSnapshot?: {
-    // Pixel match threshold.
-    threshold?: number
+    /** An acceptable percieved color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between pixels in compared images, between zero (strict) and one (lax). Defaults to `0.2`.
+     */
+    threshold?: number,
+    /**
+     * An acceptable amount of pixels that could be different, unset by default.
+     */
+    pixelCount?: number,
+    /**
+     * A ratio from `0` to `1` of all pixels on the image that could be different, unset by default.
+     */
+    pixelRatio?: number,
   }
 };
 


### PR DESCRIPTION
This patch adds additional options to `toMatchSnapshot` method:
- `pixelCount` - acceptable number of pixels that differ to still
  consider images equal, unset by default.
- `pixelRatio` - acceptable percentage of pixels that differ to still
  consider images equal, unset by default.

Fixes #12167, #10219
