### PR TITLE
browser(webkit): roll to 02/17/22

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1611
-Changed: dkolesa@igalia.com Mon Feb  7 18:16:16 CET 2022
+1612
+Changed: dpino@igalia.com Thu 17 Feb 2022 07:09:04 AM UTC

--- a/browser_patches/webkit/UPSTREAM_CONFIG.sh
+++ b/browser_patches/webkit/UPSTREAM_CONFIG.sh
@@ -1,3 +1,3 @@
 REMOTE_URL="https://github.com/WebKit/WebKit.git"
 BASE_BRANCH="main"
-BASE_REVISION="f522f6f875f2443ba32dc2cce3d8b0cfd97ffc77"
+BASE_REVISION="67bba24ec7e94838cdbea3df68108e014a64d2f4"

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -1,8 +1,8 @@
 diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
-index 788377f671399a13b0b51531e0c29c24743db821..3ecf6ef79bc3fdb97282f8a9f0bddd85f693b639 100644
+index c04ef548ccd98cf93f1b9dc87521b850ecfa807d..c7313837c1ea29f93cb5e0ec315948e50b84511a 100644
 --- a/Source/JavaScriptCore/CMakeLists.txt
 +++ b/Source/JavaScriptCore/CMakeLists.txt
-@@ -1343,22 +1343,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
+@@ -1339,22 +1339,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/CSS.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Canvas.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Console.json
@@ -502,7 +502,7 @@ index e81573fd0fffaaf6fd2af36635c78fcdf8608c69..4169e227b5fb5a3a7fb51396c4679100
      // FrontendChannel
      FrontendChannel::ConnectionType connectionType() const;
 diff --git a/Source/JavaScriptCore/inspector/protocol/DOM.json b/Source/JavaScriptCore/inspector/protocol/DOM.json
-index 31ef6b8ad406d5e11a566a986bb08e7562e3dc73..be2cf97da7bd3eff027faafbeda9e0ed1b10be56 100644
+index d792b799277c6c5f00cc4fc17c7488ab7c4c25ca..df833fa57c490c4147d9acc0d0c0b12cd29c68a1 100644
 --- a/Source/JavaScriptCore/inspector/protocol/DOM.json
 +++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
 @@ -80,6 +80,16 @@
@@ -539,7 +539,7 @@ index 31ef6b8ad406d5e11a566a986bb08e7562e3dc73..be2cf97da7bd3eff027faafbeda9e0ed
          }
      ],
      "commands": [
-@@ -541,7 +561,9 @@
+@@ -558,7 +578,9 @@
              "description": "Resolves JavaScript node object for given node id.",
              "targetTypes": ["page"],
              "parameters": [
@@ -550,7 +550,7 @@ index 31ef6b8ad406d5e11a566a986bb08e7562e3dc73..be2cf97da7bd3eff027faafbeda9e0ed
                  { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
              ],
              "returns": [
-@@ -608,6 +630,45 @@
+@@ -625,6 +647,45 @@
              "parameters": [
                  { "name": "allow", "type": "boolean" }
              ]
@@ -1861,7 +1861,7 @@ index 6f134e33eb8ebdd3888fdb068df7bfcd0c4225fd..1e3f2f08ee3bcb1d4a52009907a2dd9e
  
  } } // namespace JSC::Wasm
 diff --git a/Source/PlatformWPE.cmake b/Source/PlatformWPE.cmake
-index fabd776e617d07a6c30b9f2df30f884491259359..d9c39df7db565545108c765407ce1cda544856f7 100644
+index 277feac7ce8f20ac94b6a02351f1c29f221fcef7..d9c39df7db565545108c765407ce1cda544856f7 100644
 --- a/Source/PlatformWPE.cmake
 +++ b/Source/PlatformWPE.cmake
 @@ -8,32 +8,3 @@ list(APPEND DocumentationDependencies
@@ -1870,10 +1870,10 @@ index fabd776e617d07a6c30b9f2df30f884491259359..d9c39df7db565545108c765407ce1cda
  )
 -
 -if (ENABLE_GTKDOC)
--    install(DIRECTORY ${CMAKE_BINARY_DIR}/Documentation/wpe-${WPE_API_VERSION}/html/wpe-${WPE_API_VERSION}
+-    install(DIRECTORY ${CMAKE_BINARY_DIR}/Documentation/wpe-${WPE_API_DOC_VERSION}/html/wpe-${WPE_API_DOC_VERSION}
 -            DESTINATION "${CMAKE_INSTALL_DATADIR}/gtk-doc/html"
 -    )
--    install(DIRECTORY ${CMAKE_BINARY_DIR}/Documentation/wpe-webextensions-${WPE_API_VERSION}/html/wpe-webextensions-${WPE_API_VERSION}
+-    install(DIRECTORY ${CMAKE_BINARY_DIR}/Documentation/wpe-webextensions-${WPE_API_DOC_VERSION}/html/wpe-webextensions-${WPE_API_DOC_VERSION}
 -        DESTINATION "${CMAKE_INSTALL_DATADIR}/gtk-doc/html"
 -    )
 -endif ()
@@ -1925,10 +1925,10 @@ index be86666961906832f585adb43edeb381ad199222..23b1fd28ee684537fcbcc9c671e2bff8
      Source/third_party/opus/src/celt
      Source/third_party/opus/src/include
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
-index ca5473a62ad98bf6b4e0ceb602885645d90f7d23..d2808ac22cfa34f15662941d2dcba7abe4a80d7d 100644
+index 2a57dca5af38edf3e3a0e9a4efef64c8a63e9e6c..5ef0a4e3cb7dd2db50d55d0a7a42b717ed07f339 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
-@@ -332,3 +332,23 @@ __ZNK3rtc14RTCCertificate17GetSSLCertificateEv
+@@ -335,3 +335,23 @@ __ZNK3rtc14RTCCertificate17GetSSLCertificateEv
  __ZTVN6webrtc30WrappingAsyncDnsResolverResultE
  __ZN6webrtc20pixelBufferFromFrameERKNS_10VideoFrameE
  __ZN6webrtc14copyVideoFrameERKNS_10VideoFrameEPh
@@ -1953,10 +1953,10 @@ index ca5473a62ad98bf6b4e0ceb602885645d90f7d23..d2808ac22cfa34f15662941d2dcba7ab
 +_vpx_codec_version_str
 +_vpx_codec_vp8_cx
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
-index 2ee75dd5ff6bb1a30bd27c28600210f70beb17f8..1ad9a018d3431aa1e877983a55578296302b0ae7 100644
+index 18c86b76735a4d8458467e4b96ce0c452232bb3a..aebc45d2f61413fc7a4cd0cac0f82b5e53e93673 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
-@@ -46,7 +46,7 @@ DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_ = $(DYLIB_INSTALL_NAME_BASE);
+@@ -46,7 +46,7 @@ DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_ = $(NORMAL_WEBCORE_FRAMEWORKS
  DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_YES = @loader_path/../../../;
  
  GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
@@ -2048,7 +2048,7 @@ index 447a02d3cd2802e028ec16d549654a06adcaaae5..bf576a79f103fe43e375df9be49e0f6e
  				41323A1D2665288B00B38623 /* packet_sequencer.cc in Sources */,
  				4131BF2D234B88200028A615 /* rtc_stats_collector.cc in Sources */,
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferences.yaml b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
-index e79c7d92d128a8668f34c32418539146331f2ece..01b4985add6381a37d6bbfe7cb44f1f20f44b3e6 100644
+index 4aa67a3129804da9ff8e6a4494596c4661ff9e16..4fcf5dd448703b5d6a2d738f3cd5c88e4a0de6ac 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
 @@ -995,7 +995,7 @@ InspectorStartsAttached:
@@ -2060,7 +2060,7 @@ index e79c7d92d128a8668f34c32418539146331f2ece..01b4985add6381a37d6bbfe7cb44f1f2
  
  InspectorWindowFrame:
    type: String
-@@ -1735,6 +1735,17 @@ PluginsEnabled:
+@@ -1775,6 +1775,17 @@ PluginsEnabled:
      WebCore:
        default: false
  
@@ -2079,7 +2079,7 @@ index e79c7d92d128a8668f34c32418539146331f2ece..01b4985add6381a37d6bbfe7cb44f1f2
    type: bool
    humanReadableName: "Private Click Measurement"
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index 5b4d3b625717532554f3ad72a4db45a69eca85e6..30c6a502efdbf0fe619e7ddf2239f1535078958a 100644
+index e3ce812b93f75329a9dc9370ee7c3ca568a7c863..20487ddd08f4ef7cbfb7fd4c88e028476b3e1077 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 @@ -455,7 +455,7 @@ CrossOriginOpenerPolicyEnabled:
@@ -2103,7 +2103,7 @@ index 5b4d3b625717532554f3ad72a4db45a69eca85e6..30c6a502efdbf0fe619e7ddf2239f153
  
  # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
  MediaCapabilitiesExtensionsEnabled:
-@@ -1314,7 +1314,7 @@ SpeechRecognitionEnabled:
+@@ -1316,7 +1316,7 @@ SpeechRecognitionEnabled:
      WebKitLegacy:
        default: false
      WebKit:
@@ -2247,10 +2247,10 @@ index 07ddf3854633cb5e4ca9679359c048f13395e4ab..a0be72ba35e7afa09e8ea5976ebf600b
  WTF_EXPORT_PRIVATE LocalTimeOffset calculateLocalTimeOffset(double utcInMilliseconds, TimeType = UTCTime);
  
 diff --git a/Source/WTF/wtf/PlatformEnable.h b/Source/WTF/wtf/PlatformEnable.h
-index 664b0e29f6ba3ce4826e5109d73f86cc9bc6adfd..95e9875d933ff7b9219b2a1d89029b8aede0a73c 100644
+index f541ff99b9453c2dbef4ed3a28453e7c84986897..3f4841caee0df98920dcab3a19fd9561c7d62164 100644
 --- a/Source/WTF/wtf/PlatformEnable.h
 +++ b/Source/WTF/wtf/PlatformEnable.h
-@@ -412,7 +412,7 @@
+@@ -416,7 +416,7 @@
  #endif
  
  #if !defined(ENABLE_ORIENTATION_EVENTS)
@@ -2259,7 +2259,7 @@ index 664b0e29f6ba3ce4826e5109d73f86cc9bc6adfd..95e9875d933ff7b9219b2a1d89029b8a
  #endif
  
  #if OS(WINDOWS)
-@@ -473,7 +473,7 @@
+@@ -477,7 +477,7 @@
  #endif
  
  #if !defined(ENABLE_TOUCH_EVENTS)
@@ -2269,7 +2269,7 @@ index 664b0e29f6ba3ce4826e5109d73f86cc9bc6adfd..95e9875d933ff7b9219b2a1d89029b8a
  
  #if !defined(ENABLE_TOUCH_ACTION_REGIONS)
 diff --git a/Source/WTF/wtf/PlatformEnableCocoa.h b/Source/WTF/wtf/PlatformEnableCocoa.h
-index 760bc70fee671a73d8cb302cef9480072dbab937..f282ad28a5d857b064eca9c123ecf5fdd9da63c6 100644
+index 057e661a95cf144a01fafb058aa3f213df7c7b99..2268fc8e2a28356918a3189c5c990c1767afd758 100644
 --- a/Source/WTF/wtf/PlatformEnableCocoa.h
 +++ b/Source/WTF/wtf/PlatformEnableCocoa.h
 @@ -215,7 +215,7 @@
@@ -2294,10 +2294,10 @@ index 3901bfb0f5479064f4e7b67c90621ff26d74b580..5b3615a871d0d7123822394c94d5ce10
  
  if (Journald_FOUND)
 diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
-index 70ca32462835341f4966ada7fbe0875868788773..0266b7b3633c684ae2d6a17fcf9853b05b38b894 100644
+index 25826f61c90738f43470e41ec2e6f186e386b9ef..d7ca54fc0637144531f39cb00e915eaae66b3e7a 100644
 --- a/Source/WTF/wtf/PlatformHave.h
 +++ b/Source/WTF/wtf/PlatformHave.h
-@@ -397,7 +397,7 @@
+@@ -404,7 +404,7 @@
  #define HAVE_FOUNDATION_WITH_SAME_SITE_COOKIE_SUPPORT 1
  #endif
  
@@ -2319,10 +2319,10 @@ index f8bedf1af5d20d9c93a96af565e416bfb0df6faa..a072e5e130822d3658cbab453aef8d16
  
  if (Journald_FOUND)
 diff --git a/Source/WebCore/DerivedSources.make b/Source/WebCore/DerivedSources.make
-index 21a65b9313ae7c53bb158043f5473d29bdf0270e..28ea88e58665703e7b155ec8df65adbf3acf7bfd 100644
+index 87dba79878efbcec50015905cdc7ef630ed4d3ce..bf7a979aa5d66b1e8db266d36294e2c240c19109 100644
 --- a/Source/WebCore/DerivedSources.make
 +++ b/Source/WebCore/DerivedSources.make
-@@ -958,6 +958,10 @@ JS_BINDING_IDLS := \
+@@ -960,6 +960,10 @@ JS_BINDING_IDLS := \
      $(WebCore)/dom/Slotable.idl \
      $(WebCore)/dom/StaticRange.idl \
      $(WebCore)/dom/StringCallback.idl \
@@ -2333,7 +2333,7 @@ index 21a65b9313ae7c53bb158043f5473d29bdf0270e..28ea88e58665703e7b155ec8df65adbf
      $(WebCore)/dom/Text.idl \
      $(WebCore)/dom/TextDecoder.idl \
      $(WebCore)/dom/TextDecoderStream.idl \
-@@ -1500,9 +1504,6 @@ JS_BINDING_IDLS := \
+@@ -1502,9 +1506,6 @@ JS_BINDING_IDLS := \
  ADDITIONAL_BINDING_IDLS = \
      DocumentTouch.idl \
      GestureEvent.idl \
@@ -2408,10 +2408,10 @@ index bc5c6219b5dadc3b1cdc590d65c897b7250b1e21..37d07ef4f59ad450077d90d451cf5120
          _hasSentSpeechStart = true;
          _delegateCallback(SpeechRecognitionUpdate::create(_identifier, SpeechRecognitionUpdateType::SpeechStart));
 diff --git a/Source/WebCore/PlatformWPE.cmake b/Source/WebCore/PlatformWPE.cmake
-index bd3dead9cece47e9af0cc5b4ad188d74aabb8fcb..46a89056a878c8c4f015257df69629e76ba3f697 100644
+index 03e96a72e1e763255646a96303fad389577ec116..ca2be7461da997b6eb25b3ab64b54bd2cdf870d9 100644
 --- a/Source/WebCore/PlatformWPE.cmake
 +++ b/Source/WebCore/PlatformWPE.cmake
-@@ -48,6 +48,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+@@ -49,6 +49,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
  
      platform/graphics/wayland/PlatformDisplayWayland.h
      platform/graphics/wayland/WlUniquePtr.h
@@ -2420,13 +2420,13 @@ index bd3dead9cece47e9af0cc5b4ad188d74aabb8fcb..46a89056a878c8c4f015257df69629e7
  
  set(CSS_VALUE_PLATFORM_DEFINES "HAVE_OS_DARK_MODE_SUPPORT=1")
 diff --git a/Source/WebCore/SourcesCocoa.txt b/Source/WebCore/SourcesCocoa.txt
-index 33a896520f78d5b83cb84f181fa76be3e1054942..04bcc6b5170cba64c90c43a500fb3e969325bfae 100644
+index ccb086858c1c9cc311a87fb39588768881090ee7..0eb7ae3219fa283b2dd083b6b3a1d64219415c74 100644
 --- a/Source/WebCore/SourcesCocoa.txt
 +++ b/Source/WebCore/SourcesCocoa.txt
-@@ -617,3 +617,9 @@ platform/graphics/angle/ANGLEUtilities.cpp @no-unify
- platform/graphics/angle/ExtensionsGLANGLE.cpp @no-unify
- platform/graphics/angle/GraphicsContextGLANGLE.cpp @no-unify
- platform/graphics/angle/TemporaryANGLESetting.cpp @no-unify
+@@ -620,3 +620,9 @@ platform/graphics/angle/GraphicsContextGLANGLE.cpp @no-unify
+ platform/graphics/cocoa/ANGLEUtilitiesCocoa.cpp @no-unify
+ platform/graphics/cocoa/GraphicsContextGLCocoa.mm @no-unify
+ platform/graphics/cv/GraphicsContextGLCVCocoa.cpp @no-unify
 +
 +// Playwright begin
 +JSTouch.cpp
@@ -2434,12 +2434,12 @@ index 33a896520f78d5b83cb84f181fa76be3e1054942..04bcc6b5170cba64c90c43a500fb3e96
 +JSTouchList.cpp
 +// Playwright end
 diff --git a/Source/WebCore/SourcesGTK.txt b/Source/WebCore/SourcesGTK.txt
-index 733a99236ad1ceb964471b218f04d08ec6c8f168..16e7ec8087f3a8b3d1cf84e00720fa49042ac4ca 100644
+index c7044912d31213df8355bf1605abbcf54db8ca7c..4e30335cfad9ed79b0573731f52412cbb9d26b36 100644
 --- a/Source/WebCore/SourcesGTK.txt
 +++ b/Source/WebCore/SourcesGTK.txt
-@@ -101,7 +101,7 @@ platform/graphics/egl/GLContextEGLLibWPE.cpp @no-unify
- platform/graphics/egl/GLContextEGLWayland.cpp @no-unify
- platform/graphics/egl/GLContextEGLX11.cpp @no-unify
+@@ -103,7 +103,7 @@ platform/graphics/egl/GLContextEGLX11.cpp @no-unify
+ 
+ platform/graphics/gbm/GBMDevice.cpp
  
 -platform/graphics/glx/GLContextGLX.cpp
 +platform/graphics/glx/GLContextGLX.cpp @no-unify
@@ -2447,7 +2447,7 @@ index 733a99236ad1ceb964471b218f04d08ec6c8f168..16e7ec8087f3a8b3d1cf84e00720fa49
  platform/graphics/gtk/ColorGtk.cpp
  platform/graphics/gtk/DisplayRefreshMonitorGtk.cpp
 diff --git a/Source/WebCore/SourcesWPE.txt b/Source/WebCore/SourcesWPE.txt
-index b9410ccb53442e4a82ae49ea9c8a104ab48cb517..b527f673e23a817274af7718f541c14bde15fd5a 100644
+index 57fa7ca67c4dea4a9e5b9845e72ae25873d8cf55..80b49517655ef1dae7f6e21c3672431d90c7ecf0 100644
 --- a/Source/WebCore/SourcesWPE.txt
 +++ b/Source/WebCore/SourcesWPE.txt
 @@ -61,6 +61,8 @@ editing/libwpe/EditorLibWPE.cpp
@@ -2459,7 +2459,7 @@ index b9410ccb53442e4a82ae49ea9c8a104ab48cb517..b527f673e23a817274af7718f541c14b
  page/linux/ResourceUsageOverlayLinux.cpp
  page/linux/ResourceUsageThreadLinux.cpp
  
-@@ -102,8 +104,12 @@ platform/text/LocaleICU.cpp
+@@ -104,8 +106,12 @@ platform/text/LocaleICU.cpp
  
  platform/unix/LoggingUnix.cpp
  
@@ -2485,10 +2485,10 @@ index c4898d6db6bf06552f602c4b7f0a7267e64e44f4..7cf2e30729671a89c373870c5691d337
  __ZN7WebCore14DocumentLoaderD2Ev
  __ZN7WebCore14DocumentLoader17clearMainResourceEv
 diff --git a/Source/WebCore/WebCore.xcodeproj/project.pbxproj b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-index c5f44ef04a7058b19b24c85d11d63d9454e3db0c..319dc3d3e3c49e73c9b04f9c978a3a6667584258 100644
+index 97f8145694580de4bc0ab7a02286883282e6b155..c829fd58084ca68830f598b62bb1e7a6676513ec 100644
 --- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 +++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-@@ -5485,6 +5485,13 @@
+@@ -5500,6 +5500,13 @@
  		EDE3A5000C7A430600956A37 /* ColorMac.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE3A4FF0C7A430600956A37 /* ColorMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		EDEC98030AED7E170059137F /* WebCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEC98020AED7E170059137F /* WebCorePrefix.h */; };
  		EFCC6C8F20FE914400A2321B /* CanvasActivityRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2502,7 +2502,7 @@ index c5f44ef04a7058b19b24c85d11d63d9454e3db0c..319dc3d3e3c49e73c9b04f9c978a3a66
  		F12171F616A8CF0B000053CA /* WebVTTElement.h in Headers */ = {isa = PBXBuildFile; fileRef = F12171F416A8BC63000053CA /* WebVTTElement.h */; };
  		F32BDCD92363AACA0073B6AE /* UserGestureEmulationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F32BDCD72363AACA0073B6AE /* UserGestureEmulationScope.h */; };
  		F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
-@@ -17731,6 +17738,14 @@
+@@ -17771,6 +17778,14 @@
  		EDEC98020AED7E170059137F /* WebCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCorePrefix.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
  		EFB7287B2124C73D005C2558 /* CanvasActivityRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasActivityRecord.cpp; sourceTree = "<group>"; };
  		EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasActivityRecord.h; sourceTree = "<group>"; };
@@ -2517,7 +2517,7 @@ index c5f44ef04a7058b19b24c85d11d63d9454e3db0c..319dc3d3e3c49e73c9b04f9c978a3a66
  		F12171F316A8BC63000053CA /* WebVTTElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebVTTElement.cpp; sourceTree = "<group>"; };
  		F12171F416A8BC63000053CA /* WebVTTElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebVTTElement.h; sourceTree = "<group>"; };
  		F32BDCD52363AAC90073B6AE /* UserGestureEmulationScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserGestureEmulationScope.cpp; sourceTree = "<group>"; };
-@@ -24064,7 +24079,12 @@
+@@ -24129,7 +24144,12 @@
  				93D6B7A62551D3ED0058DD3A /* DummySpeechRecognitionProvider.h */,
  				1AF326770D78B9440068F0C4 /* EditorClient.h */,
  				93C09A800B064F00005ABD4D /* EventHandler.cpp */,
@@ -2530,7 +2530,7 @@ index c5f44ef04a7058b19b24c85d11d63d9454e3db0c..319dc3d3e3c49e73c9b04f9c978a3a66
  				E0FEF371B27C53EAC1C1FBEE /* EventSource.cpp */,
  				E0FEF371B17C53EAC1C1FBEE /* EventSource.h */,
  				E0FEF371B07C53EAC1C1FBEE /* EventSource.idl */,
-@@ -30025,6 +30045,8 @@
+@@ -30082,6 +30102,8 @@
  				29E4D8DF16B0940F00C84704 /* PlatformSpeechSynthesizer.h */,
  				1AD8F81A11CAB9E900E93E54 /* PlatformStrategies.cpp */,
  				1AD8F81911CAB9E900E93E54 /* PlatformStrategies.h */,
@@ -2539,7 +2539,7 @@ index c5f44ef04a7058b19b24c85d11d63d9454e3db0c..319dc3d3e3c49e73c9b04f9c978a3a66
  				0FD7C21D23CE41E30096D102 /* PlatformWheelEvent.cpp */,
  				935C476A09AC4D4F00A6AAB4 /* PlatformWheelEvent.h */,
  				BCBB8AB513F1AFB000734DF0 /* PODInterval.h */,
-@@ -32334,6 +32356,7 @@
+@@ -32401,6 +32423,7 @@
  				BCCFBAE70B5152ED0001F1D7 /* DocumentParser.h */,
  				AD6E71AA1668899D00320C13 /* DocumentSharedObjectPool.cpp */,
  				AD6E71AB1668899D00320C13 /* DocumentSharedObjectPool.h */,
@@ -2547,7 +2547,7 @@ index c5f44ef04a7058b19b24c85d11d63d9454e3db0c..319dc3d3e3c49e73c9b04f9c978a3a66
  				6BDB5DC1227BD3B800919770 /* DocumentStorageAccess.cpp */,
  				6BDB5DC0227BD3B800919770 /* DocumentStorageAccess.h */,
  				7CE7FA5B1EF882300060C9D6 /* DocumentTouch.cpp */,
-@@ -33345,6 +33368,7 @@
+@@ -33412,6 +33435,7 @@
  				93C4F6EB1108F9A50099D0DB /* AccessibilityScrollbar.h in Headers */,
  				29489FC712C00F0300D83F0F /* AccessibilityScrollView.h in Headers */,
  				0709FC4E1025DEE30059CDBA /* AccessibilitySlider.h in Headers */,
@@ -2555,7 +2555,7 @@ index c5f44ef04a7058b19b24c85d11d63d9454e3db0c..319dc3d3e3c49e73c9b04f9c978a3a66
  				29D7BCFA1444AF7D0070619C /* AccessibilitySpinButton.h in Headers */,
  				69A6CBAD1C6BE42C00B836E9 /* AccessibilitySVGElement.h in Headers */,
  				AAC08CF315F941FD00F1E188 /* AccessibilitySVGRoot.h in Headers */,
-@@ -35470,6 +35494,7 @@
+@@ -35541,6 +35565,7 @@
  				6E4ABCD5138EA0B70071D291 /* JSHTMLUnknownElement.h in Headers */,
  				E44614170CD6826900FADA75 /* JSHTMLVideoElement.h in Headers */,
  				81BE20D311F4BC3200915DFA /* JSIDBCursor.h in Headers */,
@@ -2563,7 +2563,7 @@ index c5f44ef04a7058b19b24c85d11d63d9454e3db0c..319dc3d3e3c49e73c9b04f9c978a3a66
  				7C3D8EF01E0B21430023B084 /* JSIDBCursorDirection.h in Headers */,
  				C585A68311D4FB08004C3E4B /* JSIDBDatabase.h in Headers */,
  				C585A69711D4FB13004C3E4B /* JSIDBFactory.h in Headers */,
-@@ -36581,6 +36606,7 @@
+@@ -36652,6 +36677,7 @@
  				0F7D07331884C56C00B4AF86 /* PlatformTextTrack.h in Headers */,
  				074E82BB18A69F0E007EF54C /* PlatformTimeRanges.h in Headers */,
  				CDD08ABD277E542600EA3755 /* PlatformTrackConfiguration.h in Headers */,
@@ -2571,23 +2571,23 @@ index c5f44ef04a7058b19b24c85d11d63d9454e3db0c..319dc3d3e3c49e73c9b04f9c978a3a66
  				CD1F9B022700323D00617EB6 /* PlatformVideoColorPrimaries.h in Headers */,
  				CD1F9B01270020B700617EB6 /* PlatformVideoColorSpace.h in Headers */,
  				CD1F9B032700323D00617EB6 /* PlatformVideoMatrixCoefficients.h in Headers */,
-@@ -38619,6 +38645,7 @@
+@@ -38720,6 +38746,7 @@
  				1ABA76CA11D20E50004C201C /* CSSPropertyNames.cpp in Sources */,
  				2D22830323A8470700364B7E /* CursorMac.mm in Sources */,
  				5CBD59592280E926002B22AA /* CustomHeaderFields.cpp in Sources */,
 +				F050E17423AD6A800011CE47 /* DocumentTouch.cpp in Sources */,
- 				6E72F54C229DCD0C00B3E151 /* ExtensionsGLANGLE.cpp in Sources */,
  				7CE6CBFD187F394900D46BF5 /* FormatConverter.cpp in Sources */,
  				5130F2F624AEA60A00E1D0A0 /* GameControllerSoftLink.mm in Sources */,
-@@ -38691,6 +38718,7 @@
- 				6E72F54F229DCD1300B3E151 /* TemporaryANGLESetting.cpp in Sources */,
+ 				51A4BB0A1954D61600FA5C2E /* Gamepad.cpp in Sources */,
+@@ -38793,6 +38820,7 @@
+ 				C1692DD223D23ABD006E88F7 /* SystemBattery.mm in Sources */,
  				CE88EE262414467B007F29C2 /* TextAlternativeWithRange.mm in Sources */,
  				51DF6D800B92A18E00C2DC85 /* ThreadCheck.mm in Sources */,
 +				F050E17123AD669F0011CE47 /* TouchEvent.cpp in Sources */,
  				538EC8031F96AF81004D22A8 /* UnifiedSource1-mm.mm in Sources */,
  				538EC8021F96AF81004D22A8 /* UnifiedSource1.cpp in Sources */,
  				538EC8051F96AF81004D22A8 /* UnifiedSource2-mm.mm in Sources */,
-@@ -38739,6 +38767,7 @@
+@@ -38841,6 +38869,7 @@
  				538EC8881F993F9C004D22A8 /* UnifiedSource23.cpp in Sources */,
  				DE5F85801FA1ABF4006DB63A /* UnifiedSource24-mm.mm in Sources */,
  				538EC8891F993F9D004D22A8 /* UnifiedSource24.cpp in Sources */,
@@ -2595,7 +2595,7 @@ index c5f44ef04a7058b19b24c85d11d63d9454e3db0c..319dc3d3e3c49e73c9b04f9c978a3a66
  				DE5F85811FA1ABF4006DB63A /* UnifiedSource25-mm.mm in Sources */,
  				538EC88A1F993F9D004D22A8 /* UnifiedSource25.cpp in Sources */,
  				DE5F85821FA1ABF4006DB63A /* UnifiedSource26-mm.mm in Sources */,
-@@ -39271,6 +39300,7 @@
+@@ -39373,6 +39402,7 @@
  				2D8B92F1203D13E1009C868F /* UnifiedSource516.cpp in Sources */,
  				2D8B92F2203D13E1009C868F /* UnifiedSource517.cpp in Sources */,
  				2D8B92F3203D13E1009C868F /* UnifiedSource518.cpp in Sources */,
@@ -2604,7 +2604,7 @@ index c5f44ef04a7058b19b24c85d11d63d9454e3db0c..319dc3d3e3c49e73c9b04f9c978a3a66
  				2D8B92F5203D13E1009C868F /* UnifiedSource520.cpp in Sources */,
  				2D8B92F6203D13E1009C868F /* UnifiedSource521.cpp in Sources */,
 diff --git a/Source/WebCore/accessibility/AccessibilityObject.cpp b/Source/WebCore/accessibility/AccessibilityObject.cpp
-index ed1c65b61c0eed1be35c8d2d6641887c74cafd80..ed5d78d7c073f8647311d3be6600b30c16357b2e 100644
+index 82770a7f2d66f781b8c7363ce970aab548e89a3b..f36ae22439c760208eba7a7ea06c0df5f5f325c9 100644
 --- a/Source/WebCore/accessibility/AccessibilityObject.cpp
 +++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
 @@ -61,6 +61,7 @@
@@ -2615,13 +2615,11 @@ index ed1c65b61c0eed1be35c8d2d6641887c74cafd80..ed5d78d7c073f8647311d3be6600b30c
  #include "LocalizedStrings.h"
  #include "MathMLNames.h"
  #include "NodeList.h"
-@@ -3617,10 +3618,15 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
-     
-     if (useParentData ? m_isIgnoredFromParentData.isPresentationalChildOfAriaRole : isPresentationalChildOfAriaRole())
-         return AccessibilityObjectInclusion::IgnoreObject;
--    
+@@ -3626,9 +3627,14 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
+     if (roleValue() == AccessibilityRole::ApplicationDialog)
+         return AccessibilityObjectInclusion::IncludeObject;
+ 
 -    return accessibilityPlatformIncludesObject();
-+
 +    AccessibilityObjectInclusion platformBehavior = accessibilityPlatformIncludesObject();
 +    if (platformBehavior != AccessibilityObjectInclusion::DefaultBehavior) {
 +        if (auto* page = this->page())
@@ -2635,18 +2633,18 @@ index ed1c65b61c0eed1be35c8d2d6641887c74cafd80..ed5d78d7c073f8647311d3be6600b30c
  {
      AXComputedObjectAttributeCache* attributeCache = nullptr;
 diff --git a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
-index 153766e6b03376d723128166a61b3f45fbb05962..0272ed7266a896fb53594968fa8dfde3c01d8aaf 100644
+index 632190ae73d71caed24cf043de0efe1e495e6e3f..f9e0feb6a03f7a24c49d2a6470f4290f5a41cae3 100644
 --- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
 +++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
-@@ -109,6 +109,8 @@ namespace WebCore {
-     macro(Database) \
+@@ -122,6 +122,8 @@ namespace WebCore {
      macro(DataTransferItem) \
      macro(DataTransferItemList) \
+     macro(DelayNode) \
 +    macro(DeviceMotionEvent) \
 +    macro(DeviceOrientationEvent) \
      macro(DocumentTimeline) \
+     macro(DynamicsCompressorNode) \
      macro(EnterPictureInPictureEvent) \
-     macro(ExtendableEvent) \
 diff --git a/Source/WebCore/css/MediaQueryEvaluator.cpp b/Source/WebCore/css/MediaQueryEvaluator.cpp
 index 345cc24534bc0451867035faa033bdf5cd0604f6..59f4a45331219709e98bbc35c479e78b4726714b 100644
 --- a/Source/WebCore/css/MediaQueryEvaluator.cpp
@@ -2672,27 +2670,6 @@ index 345cc24534bc0451867035faa033bdf5cd0604f6..59f4a45331219709e98bbc35c479e78b
  
      if (!value)
          return userPrefersReducedMotion;
-diff --git a/Source/WebCore/dom/AbortSignal.cpp b/Source/WebCore/dom/AbortSignal.cpp
-index 1270ee722c6bb40b414e2e636da14e00622f3672..a13bcc589cdd4d60fe860c43974ca41cb8b6a798 100644
---- a/Source/WebCore/dom/AbortSignal.cpp
-+++ b/Source/WebCore/dom/AbortSignal.cpp
-@@ -34,6 +34,7 @@
- #include "JSDOMException.h"
- #include "ScriptExecutionContext.h"
- #include <JavaScriptCore/Exception.h>
-+#include <JavaScriptCore/JSCast.h>
- #include <wtf/IsoMallocInlines.h>
- 
- namespace WebCore {
-@@ -62,7 +63,7 @@ Ref<AbortSignal> AbortSignal::timeout(ScriptExecutionContext& context, uint64_t
-     auto action = [signal](ScriptExecutionContext& context) mutable {
-         signal->setHasActiveTimeoutTimer(false);
- 
--        auto* globalObject = jsCast<JSDOMGlobalObject*>(context.globalObject());
-+        auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(context.globalObject());
-         if (!globalObject)
-             return;
- 
 diff --git a/Source/WebCore/dom/DataTransfer.cpp b/Source/WebCore/dom/DataTransfer.cpp
 index 86ab889bc0ea15a547357fb64dff9f10b862dc54..ec5f9a66c29431a1bbf24c4013e45042d584965c 100644
 --- a/Source/WebCore/dom/DataTransfer.cpp
@@ -2727,7 +2704,7 @@ index b084ee416512652220e43a6d4bcccaff7c666d5a..b250f3d0161817efef7e2634a16713b0
      static Ref<DataTransfer> createForDrop(const Document&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
      static Ref<DataTransfer> createForUpdatingDropTarget(const Document&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
 diff --git a/Source/WebCore/dom/DeviceMotionEvent.idl b/Source/WebCore/dom/DeviceMotionEvent.idl
-index fca03d4c02903b5992884c108c317a65160e924f..f42d3f0d7024677e296fba281076c521166ba36e 100644
+index e1a23ca36baf5a6b31653af491b7d9213836b298..1c8b700ad4de11686cfaa633500f8f375dc248a3 100644
 --- a/Source/WebCore/dom/DeviceMotionEvent.idl
 +++ b/Source/WebCore/dom/DeviceMotionEvent.idl
 @@ -25,6 +25,7 @@
@@ -2739,7 +2716,7 @@ index fca03d4c02903b5992884c108c317a65160e924f..f42d3f0d7024677e296fba281076c521
  ] interface DeviceMotionEvent : Event {
      readonly attribute Acceleration? acceleration;
 diff --git a/Source/WebCore/dom/DeviceOrientationEvent.idl b/Source/WebCore/dom/DeviceOrientationEvent.idl
-index 905bb471d59c7d86a86aa3da193f98506971d3f5..9fd2bba81e821cba25da66a1c1838f1d26fdd109 100644
+index 085eedc5a342543362b811f8018da6bffec982c8..d55ecf7465bd00c01355a6809cb8b2a502bb6af3 100644
 --- a/Source/WebCore/dom/DeviceOrientationEvent.idl
 +++ b/Source/WebCore/dom/DeviceOrientationEvent.idl
 @@ -25,6 +25,7 @@
@@ -2884,7 +2861,7 @@ index 9d60b85152f378566118574663701c25b001df3d..9811ce9aa6f066c57acf65f629d2ab81
  #endif
  
 diff --git a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
-index 8595ed1ddf389711422e453988dbbc3de5de8703..8e5f3aef9846a4b82a95ef0081d588b6878b3f78 100644
+index b978e2e8f8e882bbc7d0f91cad76c382508e9a3f..ba014f922a36f0fa6005b4b0bb0d3b4d2bece0c1 100644
 --- a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
 +++ b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
 @@ -33,6 +33,7 @@
@@ -2895,7 +2872,7 @@ index 8595ed1ddf389711422e453988dbbc3de5de8703..8e5f3aef9846a4b82a95ef0081d588b6
  #include "markup.h"
  
  namespace WebCore {
-@@ -99,6 +100,14 @@ void Editor::platformPasteFont()
+@@ -98,6 +99,14 @@ void Editor::platformPasteFont()
  {
  }
  
@@ -2935,10 +2912,10 @@ index a2377bc1f2b46aa4f48816fc37061e09a49c9762..2a93fc1b820e6ac2e0d071b4b7197fca
          return;
  
 diff --git a/Source/WebCore/inspector/InspectorController.cpp b/Source/WebCore/inspector/InspectorController.cpp
-index 0ea5d77fe5a35f8bcaa51b363a58db1ee0386376..75e29876dbf8812fc0b402ed9bc71f07af1b1ad9 100644
+index ea02ba6e973b974da0c4a2985ed057a6c62f2b37..559b14d71f32a086d2631eee7880880c9b341a00 100644
 --- a/Source/WebCore/inspector/InspectorController.cpp
 +++ b/Source/WebCore/inspector/InspectorController.cpp
-@@ -387,8 +387,8 @@ void InspectorController::inspect(Node* node)
+@@ -392,8 +392,8 @@ void InspectorController::inspect(Node* node)
      if (!enabled())
          return;
  
@@ -2949,7 +2926,7 @@ index 0ea5d77fe5a35f8bcaa51b363a58db1ee0386376..75e29876dbf8812fc0b402ed9bc71f07
  
      ensureDOMAgent().inspect(node);
  }
-@@ -529,4 +529,24 @@ void InspectorController::didComposite(Frame& frame)
+@@ -534,4 +534,24 @@ void InspectorController::didComposite(Frame& frame)
      InspectorInstrumentation::didComposite(frame);
  }
  
@@ -2975,7 +2952,7 @@ index 0ea5d77fe5a35f8bcaa51b363a58db1ee0386376..75e29876dbf8812fc0b402ed9bc71f07
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/InspectorController.h b/Source/WebCore/inspector/InspectorController.h
-index 7e8752d156bd0aec787eb1c056be11f37cb16b9e..af1464e343dab656d0c817a92beca1fa2305cde2 100644
+index 4d5a3859ec6a46d07d45c80a3b5870ee2ef13d36..75eb55a024a6ae3892a4fedc535bf6a647cc3bc7 100644
 --- a/Source/WebCore/inspector/InspectorController.h
 +++ b/Source/WebCore/inspector/InspectorController.h
 @@ -101,6 +101,10 @@ public:
@@ -2989,7 +2966,7 @@ index 7e8752d156bd0aec787eb1c056be11f37cb16b9e..af1464e343dab656d0c817a92beca1fa
      // Testing support.
      WEBCORE_EXPORT bool isUnderTest() const;
      void setIsUnderTest(bool isUnderTest) { m_isUnderTest = isUnderTest; }
-@@ -153,6 +157,7 @@ private:
+@@ -154,6 +158,7 @@ private:
      bool m_isAutomaticInspection { false };
      bool m_pauseAfterInitialization = { false };
      bool m_didCreateLazyAgents { false };
@@ -2998,7 +2975,7 @@ index 7e8752d156bd0aec787eb1c056be11f37cb16b9e..af1464e343dab656d0c817a92beca1fa
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/InspectorInstrumentation.cpp b/Source/WebCore/inspector/InspectorInstrumentation.cpp
-index fa92adcea9ef8572e2aa853a2072cc645fac10fd..dc994c365d50712a9bd208a33f26f21daebbc82a 100644
+index f96f40cf38395152ec33c48c7a0c4723dfa0c573..d89d2e4bd9e8b4ed3e17e6b73f25062ef2cc99b7 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
 +++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
 @@ -572,6 +572,13 @@ void InspectorInstrumentation::applyUserAgentOverrideImpl(InstrumentingAgents& i
@@ -3015,7 +2992,7 @@ index fa92adcea9ef8572e2aa853a2072cc645fac10fd..dc994c365d50712a9bd208a33f26f21d
  void InspectorInstrumentation::applyEmulatedMediaImpl(InstrumentingAgents& instrumentingAgents, String& media)
  {
      if (auto* pageAgent = instrumentingAgents.enabledPageAgent())
-@@ -639,6 +646,12 @@ void InspectorInstrumentation::didFailLoadingImpl(InstrumentingAgents& instrumen
+@@ -651,6 +658,12 @@ void InspectorInstrumentation::didFailLoadingImpl(InstrumentingAgents& instrumen
          consoleAgent->didFailLoading(identifier, error); // This should come AFTER resource notification, front-end relies on this.
  }
  
@@ -3028,7 +3005,7 @@ index fa92adcea9ef8572e2aa853a2072cc645fac10fd..dc994c365d50712a9bd208a33f26f21d
  void InspectorInstrumentation::willLoadXHRSynchronouslyImpl(InstrumentingAgents& instrumentingAgents)
  {
      if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
-@@ -671,20 +684,17 @@ void InspectorInstrumentation::didReceiveScriptResponseImpl(InstrumentingAgents&
+@@ -683,20 +696,17 @@ void InspectorInstrumentation::didReceiveScriptResponseImpl(InstrumentingAgents&
  
  void InspectorInstrumentation::domContentLoadedEventFiredImpl(InstrumentingAgents& instrumentingAgents, Frame& frame)
  {
@@ -3052,7 +3029,7 @@ index fa92adcea9ef8572e2aa853a2072cc645fac10fd..dc994c365d50712a9bd208a33f26f21d
  }
  
  void InspectorInstrumentation::frameDetachedFromParentImpl(InstrumentingAgents& instrumentingAgents, Frame& frame)
-@@ -765,12 +775,6 @@ void InspectorInstrumentation::frameDocumentUpdatedImpl(InstrumentingAgents& ins
+@@ -777,12 +787,6 @@ void InspectorInstrumentation::frameDocumentUpdatedImpl(InstrumentingAgents& ins
          pageDOMDebuggerAgent->frameDocumentUpdated(frame);
  }
  
@@ -3065,7 +3042,7 @@ index fa92adcea9ef8572e2aa853a2072cc645fac10fd..dc994c365d50712a9bd208a33f26f21d
  void InspectorInstrumentation::frameStartedLoadingImpl(InstrumentingAgents& instrumentingAgents, Frame& frame)
  {
      if (frame.isMainFrame()) {
-@@ -807,6 +811,12 @@ void InspectorInstrumentation::frameClearedScheduledNavigationImpl(Instrumenting
+@@ -819,6 +823,12 @@ void InspectorInstrumentation::frameClearedScheduledNavigationImpl(Instrumenting
          inspectorPageAgent->frameClearedScheduledNavigation(frame);
  }
  
@@ -3078,7 +3055,7 @@ index fa92adcea9ef8572e2aa853a2072cc645fac10fd..dc994c365d50712a9bd208a33f26f21d
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
  void InspectorInstrumentation::defaultAppearanceDidChangeImpl(InstrumentingAgents& instrumentingAgents, bool useDarkAppearance)
  {
-@@ -1289,6 +1299,36 @@ void InspectorInstrumentation::renderLayerDestroyedImpl(InstrumentingAgents& ins
+@@ -1301,6 +1311,36 @@ void InspectorInstrumentation::renderLayerDestroyedImpl(InstrumentingAgents& ins
          layerTreeAgent->renderLayerDestroyed(renderLayer);
  }
  
@@ -3115,7 +3092,7 @@ index fa92adcea9ef8572e2aa853a2072cc645fac10fd..dc994c365d50712a9bd208a33f26f21d
  InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(WorkerOrWorkletGlobalScope& globalScope)
  {
      return globalScope.inspectorController().m_instrumentingAgents;
-@@ -1300,6 +1340,13 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
+@@ -1312,6 +1352,13 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
      return page.inspectorController().m_instrumentingAgents.get();
  }
  
@@ -3130,7 +3107,7 @@ index fa92adcea9ef8572e2aa853a2072cc645fac10fd..dc994c365d50712a9bd208a33f26f21d
  {
      if (is<Document>(context))
 diff --git a/Source/WebCore/inspector/InspectorInstrumentation.h b/Source/WebCore/inspector/InspectorInstrumentation.h
-index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd726e8b12e0 100644
+index b61f6a0dcab296bbacbc125caac03586e9c197f0..f2e12e0ac0bdeab14414d3c77ec64dd041f9a5e3 100644
 --- a/Source/WebCore/inspector/InspectorInstrumentation.h
 +++ b/Source/WebCore/inspector/InspectorInstrumentation.h
 @@ -31,6 +31,7 @@
@@ -3164,8 +3141,8 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
 +    static void applyPlatformOverride(Frame&, String&);
      static void applyEmulatedMedia(Frame&, String&);
  
-     static void willSendRequest(Frame*, ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, const ResourceResponse& redirectResponse, const CachedResource*);
-@@ -198,6 +202,7 @@ public:
+     static void flexibleBoxRendererBeganLayout(const RenderObject&);
+@@ -201,6 +205,7 @@ public:
      static void didReceiveData(Frame*, ResourceLoaderIdentifier, const SharedBuffer&, int encodedDataLength);
      static void didFinishLoading(Frame*, DocumentLoader*, ResourceLoaderIdentifier, const NetworkLoadMetrics&, ResourceLoader*);
      static void didFailLoading(Frame*, DocumentLoader*, ResourceLoaderIdentifier, const ResourceError&);
@@ -3173,7 +3150,7 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
  
      static void willSendRequest(WorkerOrWorkletGlobalScope&, ResourceLoaderIdentifier, ResourceRequest&);
      static void didReceiveResourceResponse(WorkerOrWorkletGlobalScope&, ResourceLoaderIdentifier, const ResourceResponse&);
-@@ -224,11 +229,11 @@ public:
+@@ -227,11 +232,11 @@ public:
      static void frameDetachedFromParent(Frame&);
      static void didCommitLoad(Frame&, DocumentLoader*);
      static void frameDocumentUpdated(Frame&);
@@ -3186,7 +3163,7 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
      static void defaultAppearanceDidChange(Page&, bool useDarkAppearance);
  #endif
-@@ -315,6 +320,12 @@ public:
+@@ -318,6 +323,12 @@ public:
      static void layerTreeDidChange(Page*);
      static void renderLayerDestroyed(Page*, const RenderLayer&);
  
@@ -3199,7 +3176,7 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
      static void frontendCreated();
      static void frontendDeleted();
      static bool hasFrontends() { return InspectorInstrumentationPublic::hasFrontends(); }
-@@ -331,6 +342,8 @@ public:
+@@ -334,6 +345,8 @@ public:
      static void registerInstrumentingAgents(InstrumentingAgents&);
      static void unregisterInstrumentingAgents(InstrumentingAgents&);
  
@@ -3208,15 +3185,15 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
  private:
      static void didClearWindowObjectInWorldImpl(InstrumentingAgents&, Frame&, DOMWrapperWorld&);
      static bool isDebuggerPausedImpl(InstrumentingAgents&);
-@@ -408,6 +421,7 @@ private:
+@@ -411,6 +424,7 @@ private:
      static void didRecalculateStyleImpl(InstrumentingAgents&);
      static void didScheduleStyleRecalculationImpl(InstrumentingAgents&, Document&);
      static void applyUserAgentOverrideImpl(InstrumentingAgents&, String&);
 +    static void applyPlatformOverrideImpl(InstrumentingAgents&, String&);
      static void applyEmulatedMediaImpl(InstrumentingAgents&, String&);
  
-     static void willSendRequestImpl(InstrumentingAgents&, ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, const ResourceResponse& redirectResponse, const CachedResource*);
-@@ -419,6 +433,7 @@ private:
+     static void flexibleBoxRendererBeganLayoutImpl(InstrumentingAgents&, const RenderObject&);
+@@ -425,6 +439,7 @@ private:
      static void didReceiveDataImpl(InstrumentingAgents&, ResourceLoaderIdentifier, const SharedBuffer&, int encodedDataLength);
      static void didFinishLoadingImpl(InstrumentingAgents&, ResourceLoaderIdentifier, DocumentLoader*, const NetworkLoadMetrics&, ResourceLoader*);
      static void didFailLoadingImpl(InstrumentingAgents&, ResourceLoaderIdentifier, DocumentLoader*, const ResourceError&);
@@ -3224,7 +3201,7 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
      static void willLoadXHRSynchronouslyImpl(InstrumentingAgents&);
      static void didLoadXHRSynchronouslyImpl(InstrumentingAgents&);
      static void scriptImportedImpl(InstrumentingAgents&, ResourceLoaderIdentifier, const String& sourceString);
-@@ -429,11 +444,11 @@ private:
+@@ -435,11 +450,11 @@ private:
      static void frameDetachedFromParentImpl(InstrumentingAgents&, Frame&);
      static void didCommitLoadImpl(InstrumentingAgents&, Frame&, DocumentLoader*);
      static void frameDocumentUpdatedImpl(InstrumentingAgents&, Frame&);
@@ -3237,7 +3214,7 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
      static void defaultAppearanceDidChangeImpl(InstrumentingAgents&, bool useDarkAppearance);
  #endif
-@@ -515,6 +530,12 @@ private:
+@@ -521,6 +536,12 @@ private:
      static void layerTreeDidChangeImpl(InstrumentingAgents&);
      static void renderLayerDestroyedImpl(InstrumentingAgents&, const RenderLayer&);
  
@@ -3250,7 +3227,7 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
      static InstrumentingAgents& instrumentingAgents(Page&);
      static InstrumentingAgents& instrumentingAgents(WorkerOrWorkletGlobalScope&);
  
-@@ -1033,6 +1054,13 @@ inline void InspectorInstrumentation::applyUserAgentOverride(Frame& frame, Strin
+@@ -1039,6 +1060,13 @@ inline void InspectorInstrumentation::applyUserAgentOverride(Frame& frame, Strin
          applyUserAgentOverrideImpl(*agents, userAgent);
  }
  
@@ -3264,7 +3241,7 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
  inline void InspectorInstrumentation::applyEmulatedMedia(Frame& frame, String& media)
  {
      FAST_RETURN_IF_NO_FRONTENDS(void());
-@@ -1121,6 +1149,13 @@ inline void InspectorInstrumentation::didFailLoading(WorkerOrWorkletGlobalScope&
+@@ -1141,6 +1169,13 @@ inline void InspectorInstrumentation::didFailLoading(WorkerOrWorkletGlobalScope&
      didFailLoadingImpl(instrumentingAgents(globalScope), identifier, nullptr, error);
  }
  
@@ -3278,7 +3255,7 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
  inline void InspectorInstrumentation::continueAfterXFrameOptionsDenied(Frame& frame, ResourceLoaderIdentifier identifier, DocumentLoader& loader, const ResourceResponse& response)
  {
      // Treat the same as didReceiveResponse.
-@@ -1211,13 +1246,6 @@ inline void InspectorInstrumentation::frameDocumentUpdated(Frame& frame)
+@@ -1231,13 +1266,6 @@ inline void InspectorInstrumentation::frameDocumentUpdated(Frame& frame)
          frameDocumentUpdatedImpl(*agents, frame);
  }
  
@@ -3292,7 +3269,7 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
  inline void InspectorInstrumentation::frameStartedLoading(Frame& frame)
  {
      FAST_RETURN_IF_NO_FRONTENDS(void());
-@@ -1246,6 +1274,13 @@ inline void InspectorInstrumentation::frameClearedScheduledNavigation(Frame& fra
+@@ -1266,6 +1294,13 @@ inline void InspectorInstrumentation::frameClearedScheduledNavigation(Frame& fra
          frameClearedScheduledNavigationImpl(*agents, frame);
  }
  
@@ -3306,7 +3283,7 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
  inline void InspectorInstrumentation::defaultAppearanceDidChange(Page& page, bool useDarkAppearance)
  {
-@@ -1676,6 +1711,42 @@ inline void InspectorInstrumentation::renderLayerDestroyed(Page* page, const Ren
+@@ -1696,6 +1731,42 @@ inline void InspectorInstrumentation::renderLayerDestroyed(Page* page, const Ren
          renderLayerDestroyedImpl(*agents, renderLayer);
  }
  
@@ -3350,7 +3327,7 @@ index 777a7ed4c082bd24ef719956e2a653744e0755f3..ec2d0dafb058d56955c5f5309379cd72
  {
      return context ? instrumentingAgents(*context) : nullptr;
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
-index f2eeb4979b81480cfe751f94ec108bf51f576e4b..ff2a10d2456ba56079cba29adf48c1c27defc5ee 100644
+index 4735111adac014387125bc5f17c842e1d4d946f8..266fbf8659fb5b70b63ef1ca909bf6680dd521e1 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 @@ -62,12 +62,16 @@
@@ -3370,12 +3347,12 @@ index f2eeb4979b81480cfe751f94ec108bf51f576e4b..ff2a10d2456ba56079cba29adf48c1c2
  #include "HTMLMediaElement.h"
  #include "HTMLNames.h"
  #include "HTMLParserIdioms.h"
-@@ -95,11 +99,14 @@
+@@ -95,12 +99,14 @@
  #include "Pasteboard.h"
  #include "PseudoElement.h"
  #include "RenderGrid.h"
 +#include "RenderLayer.h"
-+#include "RenderObject.h"
+ #include "RenderObject.h"
  #include "RenderStyle.h"
  #include "RenderStyleConstants.h"
  #include "ScriptController.h"
@@ -3385,7 +3362,7 @@ index f2eeb4979b81480cfe751f94ec108bf51f576e4b..ff2a10d2456ba56079cba29adf48c1c2
  #include "StaticNodeList.h"
  #include "StyleProperties.h"
  #include "StyleResolver.h"
-@@ -133,7 +140,8 @@ using namespace HTMLNames;
+@@ -134,7 +140,8 @@ using namespace HTMLNames;
  static const size_t maxTextSize = 10000;
  static const UChar ellipsisUChar[] = { 0x2026, 0 };
  
@@ -3395,7 +3372,7 @@ index f2eeb4979b81480cfe751f94ec108bf51f576e4b..ff2a10d2456ba56079cba29adf48c1c2
  {
      if (!colorObject)
          return std::nullopt;
-@@ -152,7 +160,7 @@ static std::optional<Color> parseColor(RefPtr<JSON::Object>&& colorObject)
+@@ -153,7 +160,7 @@ static std::optional<Color> parseColor(RefPtr<JSON::Object>&& colorObject)
  
  static Color parseConfigColor(const String& fieldName, JSON::Object& configObject)
  {
@@ -3404,7 +3381,7 @@ index f2eeb4979b81480cfe751f94ec108bf51f576e4b..ff2a10d2456ba56079cba29adf48c1c2
  }
  
  static bool parseQuad(Ref<JSON::Array>&& quadArray, FloatQuad* quad)
-@@ -433,6 +441,20 @@ Node* InspectorDOMAgent::assertNode(Protocol::ErrorString& errorString, Protocol
+@@ -440,6 +447,20 @@ Node* InspectorDOMAgent::assertNode(Protocol::ErrorString& errorString, Protocol
      return node;
  }
  
@@ -3425,7 +3402,7 @@ index f2eeb4979b81480cfe751f94ec108bf51f576e4b..ff2a10d2456ba56079cba29adf48c1c2
  Document* InspectorDOMAgent::assertDocument(Protocol::ErrorString& errorString, Protocol::DOM::NodeId nodeId)
  {
      Node* node = assertNode(errorString, nodeId);
-@@ -1419,16 +1441,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(Ref<JSON::Obj
+@@ -1426,16 +1447,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(Ref<JSON::Obj
  Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNode(Ref<JSON::Object>&& highlightInspectorObject, std::optional<Protocol::DOM::NodeId>&& nodeId, const Protocol::Runtime::RemoteObjectId& objectId)
  {
      Protocol::ErrorString errorString;
@@ -3443,7 +3420,7 @@ index f2eeb4979b81480cfe751f94ec108bf51f576e4b..ff2a10d2456ba56079cba29adf48c1c2
      if (!node)
          return makeUnexpected(errorString);
  
-@@ -1630,15 +1643,136 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Protocol::DOM:
+@@ -1672,15 +1684,136 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Protocol::DOM:
      return { };
  }
  
@@ -3584,7 +3561,7 @@ index f2eeb4979b81480cfe751f94ec108bf51f576e4b..ff2a10d2456ba56079cba29adf48c1c2
      if (!object)
          return makeUnexpected("Missing injected script for given nodeId"_s);
  
-@@ -2876,7 +3010,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPath
+@@ -2935,7 +3068,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPath
      return makeUnexpected("Missing node for given path"_s);
  }
  
@@ -3593,7 +3570,7 @@ index f2eeb4979b81480cfe751f94ec108bf51f576e4b..ff2a10d2456ba56079cba29adf48c1c2
  {
      Document* document = &node->document();
      if (auto* templateHost = document->templateDocumentHost())
-@@ -2885,12 +3019,18 @@ RefPtr<Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* nod
+@@ -2944,12 +3077,18 @@ RefPtr<Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* nod
      if (!frame)
          return nullptr;
  
@@ -3615,7 +3592,7 @@ index f2eeb4979b81480cfe751f94ec108bf51f576e4b..ff2a10d2456ba56079cba29adf48c1c2
  }
  
  Node* InspectorDOMAgent::scriptValueAsNode(JSC::JSValue value)
-@@ -2913,4 +3053,42 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowT
+@@ -2972,4 +3111,42 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowT
      return { };
  }
  
@@ -3659,7 +3636,7 @@ index f2eeb4979b81480cfe751f94ec108bf51f576e4b..ff2a10d2456ba56079cba29adf48c1c2
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.h b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
-index eec24d3eea0c6930c5be29ed653bc549c021ab42..3b0859be4b8b4247f2ebea501651d4dff917cd99 100644
+index fd56c2afd7749f1b145cfe8cf0b5ad4fa653b8a9..ac55eb4498196c1c9b28eaa6483052ed0035b9c8 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
 @@ -57,6 +57,7 @@ namespace WebCore {
@@ -3670,7 +3647,7 @@ index eec24d3eea0c6930c5be29ed653bc549c021ab42..3b0859be4b8b4247f2ebea501651d4df
  class DOMEditor;
  class Document;
  class Element;
-@@ -88,6 +89,7 @@ public:
+@@ -89,6 +90,7 @@ public:
      static String toErrorString(Exception&&);
  
      static String documentURLString(Document*);
@@ -3678,7 +3655,7 @@ index eec24d3eea0c6930c5be29ed653bc549c021ab42..3b0859be4b8b4247f2ebea501651d4df
  
      // We represent embedded doms as a part of the same hierarchy. Hence we treat children of frame owners differently.
      // We also skip whitespace text nodes conditionally. Following methods encapsulate these specifics.
-@@ -131,7 +133,7 @@ public:
+@@ -132,7 +134,7 @@ public:
      Inspector::Protocol::ErrorStringOr<std::tuple<String /* searchId */, int /* resultCount */>> performSearch(const String& query, RefPtr<JSON::Array>&& nodeIds, std::optional<bool>&& caseSensitive);
      Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> getSearchResults(const String& searchId, int fromIndex, int toIndex);
      Inspector::Protocol::ErrorStringOr<void> discardSearchResults(const String& searchId);
@@ -3687,7 +3664,7 @@ index eec24d3eea0c6930c5be29ed653bc549c021ab42..3b0859be4b8b4247f2ebea501651d4df
      Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> getAttributes(Inspector::Protocol::DOM::NodeId);
  #if PLATFORM(IOS_FAMILY)
      Inspector::Protocol::ErrorStringOr<void> setInspectModeEnabled(bool, RefPtr<JSON::Object>&& highlightConfig);
-@@ -156,6 +158,10 @@ public:
+@@ -159,6 +161,10 @@ public:
      Inspector::Protocol::ErrorStringOr<void> focus(Inspector::Protocol::DOM::NodeId);
      Inspector::Protocol::ErrorStringOr<void> setInspectedNode(Inspector::Protocol::DOM::NodeId);
      Inspector::Protocol::ErrorStringOr<void> setAllowEditingUserAgentShadowTrees(bool);
@@ -3698,7 +3675,7 @@ index eec24d3eea0c6930c5be29ed653bc549c021ab42..3b0859be4b8b4247f2ebea501651d4df
  
      // InspectorInstrumentation
      Inspector::Protocol::DOM::NodeId identifierForNode(Node&);
-@@ -195,7 +201,7 @@ public:
+@@ -200,7 +206,7 @@ public:
      Node* nodeForId(Inspector::Protocol::DOM::NodeId);
      Inspector::Protocol::DOM::NodeId boundNodeId(const Node*);
  
@@ -3707,7 +3684,7 @@ index eec24d3eea0c6930c5be29ed653bc549c021ab42..3b0859be4b8b4247f2ebea501651d4df
      bool handleMousePress();
      void mouseDidMoveOverElement(const HitTestResult&, unsigned modifierFlags);
      void inspect(Node*);
-@@ -206,12 +212,15 @@ public:
+@@ -212,12 +218,15 @@ public:
      void reset();
  
      Node* assertNode(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);
@@ -3723,7 +3700,7 @@ index eec24d3eea0c6930c5be29ed653bc549c021ab42..3b0859be4b8b4247f2ebea501651d4df
  private:
  #if ENABLE(VIDEO)
      void mediaMetricsTimerFired();
-@@ -240,7 +249,6 @@ private:
+@@ -246,7 +255,6 @@ private:
      void processAccessibilityChildren(AXCoreObject&, JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>&);
      
      Node* nodeForPath(const String& path);
@@ -3744,7 +3721,7 @@ index 3386cb879f1178c1b9635775c9a0e864f5b94c52..d2350182f5f061855e8ca172779ad60e
  class Page;
  class SecurityOrigin;
 diff --git a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
-index c087f7508c18295714dc75fbbe7fafb6cbd97dbf..a8028d3e4a1d37cc41a61ad8c9091ac2a6a76852 100644
+index 6e5a5fc89ccef05b73ceda257d6c59cb0e82861c..8d32d6cbce1827a32f4aad33f4ac1535886bfb52 100644
 --- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
 @@ -45,6 +45,7 @@
@@ -5025,11 +5002,14 @@ index a4ffd1361cdde5ab7d973cd00d19a910ae9ed29f..80d24823328eb8377327ce5c828a3556
  
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorPageAgent.h b/Source/WebCore/inspector/agents/InspectorPageAgent.h
-index 3d5e566dbe0c5ec11d9e8df67fcf0a70988a2f8f..9db71cc22000a6dc6ddc157cbb0c9a90e0c9fa36 100644
+index 3d5e566dbe0c5ec11d9e8df67fcf0a70988a2f8f..35f38d348513e5c4624ad9efa788ade47b8105fa 100644
 --- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
-@@ -34,17 +34,23 @@
+@@ -32,19 +32,26 @@
+ #pragma once
+ 
  #include "CachedResource.h"
++#include "FrameIdentifier.h"
  #include "InspectorWebAgentBase.h"
  #include "LayoutRect.h"
 +#include "ProcessIdentifier.h"
@@ -5052,7 +5032,7 @@ index 3d5e566dbe0c5ec11d9e8df67fcf0a70988a2f8f..9db71cc22000a6dc6ddc157cbb0c9a90
  class InspectorClient;
  class InspectorOverlay;
  class Page;
-@@ -69,12 +75,14 @@ public:
+@@ -69,12 +76,14 @@ public:
          PingResource,
          BeaconResource,
          WebSocketResource,
@@ -5067,7 +5047,7 @@ index 3d5e566dbe0c5ec11d9e8df67fcf0a70988a2f8f..9db71cc22000a6dc6ddc157cbb0c9a90
      static bool sharedBufferContent(RefPtr<FragmentedSharedBuffer>&&, const String& textEncodingName, bool withBase64Encode, String* result);
      static Vector<CachedResource*> cachedResourcesForFrame(Frame*);
      static void resourceContent(Inspector::Protocol::ErrorString&, Frame*, const URL&, String* result, bool* base64Encoded);
-@@ -95,15 +103,18 @@ public:
+@@ -95,15 +104,18 @@ public:
      Inspector::Protocol::ErrorStringOr<void> enable();
      Inspector::Protocol::ErrorStringOr<void> disable();
      Inspector::Protocol::ErrorStringOr<void> reload(std::optional<bool>&& ignoreCache, std::optional<bool>&& revalidateAllResources);
@@ -5087,7 +5067,7 @@ index 3d5e566dbe0c5ec11d9e8df67fcf0a70988a2f8f..9db71cc22000a6dc6ddc157cbb0c9a90
      Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>>> searchInResource(const Inspector::Protocol::Network::FrameId&, const String& url, const String& query, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex, const Inspector::Protocol::Network::RequestId&);
      Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Page::SearchResult>>> searchInResources(const String&, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex);
  #if !PLATFORM(IOS_FAMILY)
-@@ -114,35 +125,55 @@ public:
+@@ -114,35 +126,55 @@ public:
  #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
      Inspector::Protocol::ErrorStringOr<void> setForcedAppearance(std::optional<Inspector::Protocol::Page::Appearance>&&);
  #endif
@@ -5149,7 +5129,7 @@ index 3d5e566dbe0c5ec11d9e8df67fcf0a70988a2f8f..9db71cc22000a6dc6ddc157cbb0c9a90
  
      Frame* frameForId(const Inspector::Protocol::Network::FrameId&);
      WEBCORE_EXPORT String frameId(Frame*);
-@@ -151,6 +182,7 @@ public:
+@@ -151,6 +183,7 @@ public:
  
  private:
      double timestamp();
@@ -5157,7 +5137,7 @@ index 3d5e566dbe0c5ec11d9e8df67fcf0a70988a2f8f..9db71cc22000a6dc6ddc157cbb0c9a90
  
      static bool mainResourceContent(Frame*, bool withBase64Encode, String* result);
      static bool dataContent(const uint8_t* data, unsigned size, const String& textEncodingName, bool withBase64Encode, String* result);
-@@ -162,18 +194,20 @@ private:
+@@ -162,18 +195,20 @@ private:
      RefPtr<Inspector::PageBackendDispatcher> m_backendDispatcher;
  
      Page& m_inspectedPage;
@@ -5372,19 +5352,6 @@ index 16edb3bc689b8e2dde17597b642b706c1343e1f5..f363b2ca2410f22cff8d6ad908a88527
      ~UserGestureEmulationScope();
  
  private:
-diff --git a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
-index c85b7b875b81c6da4b3ddcf60df0f330bff2acf1..2e5d880289422e432308f8f1740156b657a11016 100644
---- a/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
-+++ b/Source/WebCore/layout/integration/LayoutIntegrationLineLayout.cpp
-@@ -307,7 +307,7 @@ void LineLayout::updateFormattingRootGeometryAndInvalidate()
- 
-     auto updateGeometry = [&](auto& root) {
-         root.setContentBoxWidth(flow.contentLogicalWidth());
--        root.setPadding(Layout::Edges { { flow.paddingStart(), flow.paddingEnd() }, { flow.paddingBefore(), flow.paddingAfter() } });
-+	root.setPadding(Layout::Edges { { flow.paddingStart(), flow.paddingEnd() }, { flow.paddingBefore(), flow.paddingAfter() } });
-         root.setBorder(Layout::Edges { { flow.borderStart(), flow.borderEnd() }, { flow.borderBefore(), flow.borderAfter() } });
-         root.setHorizontalMargin({ });
-         root.setVerticalMargin({ });
 diff --git a/Source/WebCore/loader/CookieJar.h b/Source/WebCore/loader/CookieJar.h
 index 982691dd2dfe2f65201370a12302b5086703c126..4af72beb3b1405ffac78e89e7fbb2b14d6647903 100644
 --- a/Source/WebCore/loader/CookieJar.h
@@ -5421,7 +5388,7 @@ index 359b63851868423c37a10063501a4df06d9adbaa..3e5593c61d5a73eff267423080c29b2a
  }
  
 diff --git a/Source/WebCore/loader/DocumentLoader.h b/Source/WebCore/loader/DocumentLoader.h
-index 123d04213f75354949837089d2065966f929c9e6..976b4266690d08df1b4defc023f720283a10b091 100644
+index c2bea6f6a69b836472c0aff7a0d7070396ba6c2b..80af07d2f4327a400c85b65b640bcfa2ab2f430a 100644
 --- a/Source/WebCore/loader/DocumentLoader.h
 +++ b/Source/WebCore/loader/DocumentLoader.h
 @@ -179,9 +179,13 @@ public:
@@ -5439,7 +5406,7 @@ index 123d04213f75354949837089d2065966f929c9e6..976b4266690d08df1b4defc023f72028
      DocumentWriter& writer() const { return m_writer; }
  
 diff --git a/Source/WebCore/loader/FrameLoader.cpp b/Source/WebCore/loader/FrameLoader.cpp
-index 31fb8a5df6a091a343026a996d5751c7562fc16e..64b788bd245f54f22cea8a2c1d4c59bf92b465b4 100644
+index fa27a3004fe662d5a0084a822acfa19002854961..368f3378c19adfafc8031920bd9d111a43ec222a 100644
 --- a/Source/WebCore/loader/FrameLoader.cpp
 +++ b/Source/WebCore/loader/FrameLoader.cpp
 @@ -1154,6 +1154,7 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
@@ -5469,7 +5436,7 @@ index 31fb8a5df6a091a343026a996d5751c7562fc16e..64b788bd245f54f22cea8a2c1d4c59bf
          continueLoadAfterNavigationPolicy(request, formState.get(), navigationPolicyDecision, allowNavigationToInvalidURL);
          completionHandler();
      }, PolicyDecisionMode::Asynchronous);
-@@ -2784,12 +2789,17 @@ String FrameLoader::userAgent(const URL& url) const
+@@ -2788,12 +2793,17 @@ String FrameLoader::userAgent(const URL& url) const
  
  String FrameLoader::navigatorPlatform() const
  {
@@ -5489,7 +5456,7 @@ index 31fb8a5df6a091a343026a996d5751c7562fc16e..64b788bd245f54f22cea8a2c1d4c59bf
  }
  
  void FrameLoader::dispatchOnloadEvents()
-@@ -3195,6 +3205,8 @@ void FrameLoader::receivedMainResourceError(const ResourceError& error)
+@@ -3199,6 +3209,8 @@ void FrameLoader::receivedMainResourceError(const ResourceError& error)
      checkCompleted();
      if (m_frame.page())
          checkLoadComplete();
@@ -5498,7 +5465,7 @@ index 31fb8a5df6a091a343026a996d5751c7562fc16e..64b788bd245f54f22cea8a2c1d4c59bf
  }
  
  void FrameLoader::continueFragmentScrollAfterNavigationPolicy(const ResourceRequest& request, bool shouldContinue)
-@@ -3962,9 +3974,6 @@ String FrameLoader::referrer() const
+@@ -3966,9 +3978,6 @@ String FrameLoader::referrer() const
  
  void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
  {
@@ -5508,7 +5475,7 @@ index 31fb8a5df6a091a343026a996d5751c7562fc16e..64b788bd245f54f22cea8a2c1d4c59bf
      Vector<Ref<DOMWrapperWorld>> worlds;
      ScriptController::getAllWorlds(worlds);
      for (auto& world : worlds)
-@@ -3973,13 +3982,13 @@ void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
+@@ -3977,13 +3986,13 @@ void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
  
  void FrameLoader::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld& world)
  {
@@ -5541,7 +5508,7 @@ index 29d2e3f46140aaa51160e6a28562f370e371eb21..676ddc9369050c19454fbf5faffac2b2
      virtual bool shouldPerformSecurityChecks() const { return false; }
      virtual bool havePerformedSecurityChecks(const ResourceResponse&) const { return false; }
 diff --git a/Source/WebCore/loader/PolicyChecker.cpp b/Source/WebCore/loader/PolicyChecker.cpp
-index c3fbb569999a0667188eabe1a460e6f076684f0d..ab5d5925c91e92d2510246aaffa06b1f35af7ac9 100644
+index b24f1d47d4fb0515b3d30cf4f8628970f7e40fd1..64e4bb3281f5d8ae464448e1af410111ee5e6710 100644
 --- a/Source/WebCore/loader/PolicyChecker.cpp
 +++ b/Source/WebCore/loader/PolicyChecker.cpp
 @@ -46,6 +46,7 @@
@@ -5575,7 +5542,7 @@ index a2c6d72b5ba0f04a49ca6dc710ef6fa5e0125c33..759b0d34b7db839027063a1b6ce8fb0f
  
  void ProgressTracker::incrementProgress(ResourceLoaderIdentifier identifier, const ResourceResponse& response)
 diff --git a/Source/WebCore/page/ChromeClient.h b/Source/WebCore/page/ChromeClient.h
-index 284967df462545fe06cc2eb66a2716282053f2f3..54a62a348579e54013e23f9d65c55b54c4569127 100644
+index 4419ed5553051938b75800bdeebd4f6b4473078c..b4db731a48c091604b1b1e938232a387b677d7c6 100644
 --- a/Source/WebCore/page/ChromeClient.h
 +++ b/Source/WebCore/page/ChromeClient.h
 @@ -316,7 +316,7 @@ public:
@@ -5588,10 +5555,10 @@ index 284967df462545fe06cc2eb66a2716282053f2f3..54a62a348579e54013e23f9d65c55b54
  
  #if ENABLE(INPUT_TYPE_COLOR)
 diff --git a/Source/WebCore/page/EventHandler.cpp b/Source/WebCore/page/EventHandler.cpp
-index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395a536b164 100644
+index ccc33d0e2824af0e1d22711618a00bb9e74ebf6f..0324a3be1db85ae268ae318f3f18902c61b5360f 100644
 --- a/Source/WebCore/page/EventHandler.cpp
 +++ b/Source/WebCore/page/EventHandler.cpp
-@@ -140,6 +140,7 @@
+@@ -141,6 +141,7 @@
  
  #if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
  #include "PlatformTouchEvent.h"
@@ -5599,7 +5566,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
  #endif
  
  #if ENABLE(MAC_GESTURE_EVENTS)
-@@ -799,9 +800,7 @@ bool EventHandler::handleMousePressEvent(const MouseEventWithHitTestResults& eve
+@@ -801,9 +802,7 @@ bool EventHandler::handleMousePressEvent(const MouseEventWithHitTestResults& eve
      m_mousePressNode = event.targetNode();
      m_frame.document()->setFocusNavigationStartingNode(event.targetNode());
  
@@ -5609,7 +5576,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
  
      m_mousePressed = true;
      m_selectionInitiationState = HaveNotStartedSelection;
-@@ -841,8 +840,6 @@ VisiblePosition EventHandler::selectionExtentRespectingEditingBoundary(const Vis
+@@ -843,8 +842,6 @@ VisiblePosition EventHandler::selectionExtentRespectingEditingBoundary(const Vis
      return adjustedTarget->renderer()->positionForPoint(LayoutPoint(selectionEndPoint), nullptr);
  }
  
@@ -5618,7 +5585,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
  #if !PLATFORM(IOS_FAMILY)
  
  bool EventHandler::supportsSelectionUpdatesOnMouseDrag() const
-@@ -864,8 +861,10 @@ bool EventHandler::handleMouseDraggedEvent(const MouseEventWithHitTestResults& e
+@@ -866,8 +863,10 @@ bool EventHandler::handleMouseDraggedEvent(const MouseEventWithHitTestResults& e
  
      Ref<Frame> protectedFrame(m_frame);
  
@@ -5629,7 +5596,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
  
      RefPtr targetNode = event.targetNode();
      if (event.event().button() != LeftButton || !targetNode)
-@@ -886,7 +885,9 @@ bool EventHandler::handleMouseDraggedEvent(const MouseEventWithHitTestResults& e
+@@ -888,7 +887,9 @@ bool EventHandler::handleMouseDraggedEvent(const MouseEventWithHitTestResults& e
      ASSERT(mouseDownMayStartSelect() || m_mouseDownMayStartAutoscroll);
  #endif
  
@@ -5639,7 +5606,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
  
      if (m_mouseDownMayStartAutoscroll && !panScrollInProgress()) {
          m_autoscrollController->startAutoscrollForSelection(renderer);
-@@ -903,6 +904,8 @@ bool EventHandler::handleMouseDraggedEvent(const MouseEventWithHitTestResults& e
+@@ -905,6 +906,8 @@ bool EventHandler::handleMouseDraggedEvent(const MouseEventWithHitTestResults& e
      return true;
  }
      
@@ -5648,7 +5615,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
  bool EventHandler::eventMayStartDrag(const PlatformMouseEvent& event) const
  {
      // This is a pre-flight check of whether the event might lead to a drag being started.  Be careful
-@@ -934,6 +937,8 @@ bool EventHandler::eventMayStartDrag(const PlatformMouseEvent& event) const
+@@ -936,6 +939,8 @@ bool EventHandler::eventMayStartDrag(const PlatformMouseEvent& event) const
      return targetElement && page->dragController().draggableElement(&m_frame, targetElement.get(), result.roundedPointInInnerNodeFrame(), state);
  }
  
@@ -5657,7 +5624,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
  void EventHandler::updateSelectionForMouseDrag()
  {
      if (!supportsSelectionUpdatesOnMouseDrag())
-@@ -1028,7 +1033,6 @@ void EventHandler::updateSelectionForMouseDrag(const HitTestResult& hitTestResul
+@@ -1030,7 +1035,6 @@ void EventHandler::updateSelectionForMouseDrag(const HitTestResult& hitTestResul
      if (oldSelection != newSelection && ImageOverlay::isOverlayText(newSelection.start().containerNode()) && ImageOverlay::isOverlayText(newSelection.end().containerNode()))
          invalidateClick();
  }
@@ -5665,7 +5632,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
  
  void EventHandler::lostMouseCapture()
  {
-@@ -1076,9 +1080,7 @@ bool EventHandler::handleMouseReleaseEvent(const MouseEventWithHitTestResults& e
+@@ -1078,9 +1082,7 @@ bool EventHandler::handleMouseReleaseEvent(const MouseEventWithHitTestResults& e
      // on the selection, the selection goes away.  However, if we are
      // editing, place the caret.
      if (m_mouseDownWasSingleClickInSelection && m_selectionInitiationState != ExtendedSelection
@@ -5675,7 +5642,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
              && m_frame.selection().isRange()
              && event.event().button() != RightButton) {
          VisibleSelection newSelection;
-@@ -2045,10 +2047,8 @@ bool EventHandler::handleMouseMoveEvent(const PlatformMouseEvent& platformMouseE
+@@ -2050,10 +2052,8 @@ bool EventHandler::handleMouseMoveEvent(const PlatformMouseEvent& platformMouseE
      
      swallowEvent = !dispatchMouseEvent(eventNames().mousemoveEvent, mouseEvent.targetNode(), 0, platformMouseEvent, FireMouseOverOut::Yes);
  
@@ -5686,7 +5653,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
  
      return swallowEvent;
  }
-@@ -4117,7 +4117,14 @@ bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDr
+@@ -4141,7 +4141,14 @@ bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDr
      if (!m_frame.document())
          return false;
  
@@ -5702,7 +5669,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
      auto hasNonDefaultPasteboardData = HasNonDefaultPasteboardData::No;
      
      if (dragState().shouldDispatchEvents) {
-@@ -4506,7 +4513,8 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
+@@ -4530,7 +4537,8 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
              allTouchReleased = false;
      }
  
@@ -5712,7 +5679,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
          PlatformTouchPoint::State pointState = point.state();
          LayoutPoint pagePoint = documentPointForWindowPoint(m_frame, point.pos());
  
-@@ -4633,6 +4641,9 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
+@@ -4657,6 +4665,9 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
              changedTouches[pointState].m_touches->append(WTFMove(touch));
              changedTouches[pointState].m_targets.add(touchTarget);
          }
@@ -5723,7 +5690,7 @@ index 27517c22e7709eaae55123f99ee697ed6685a901..90d55bd1e045b12b1b0e7a2367978395
      m_touchPressed = touches->length() > 0;
      if (allTouchReleased)
 diff --git a/Source/WebCore/page/EventHandler.h b/Source/WebCore/page/EventHandler.h
-index 6b359e7556a2d6a1485e04e8c20fa5f470c5a04a..4eda11b09ed371ff7bafd6d6f37a96b58f5c2075 100644
+index de408bfdd161f86de51d9b528a9d27452a76b82a..d9b2374b0f7abf2789729fcc805c65050eba43b4 100644
 --- a/Source/WebCore/page/EventHandler.h
 +++ b/Source/WebCore/page/EventHandler.h
 @@ -135,9 +135,7 @@ public:
@@ -5736,7 +5703,7 @@ index 6b359e7556a2d6a1485e04e8c20fa5f470c5a04a..4eda11b09ed371ff7bafd6d6f37a96b5
  
  #if ENABLE(PAN_SCROLLING)
      void didPanScrollStart();
-@@ -384,10 +382,8 @@ private:
+@@ -385,10 +383,8 @@ private:
      bool startKeyboardScrolling(KeyboardEvent&);
      void stopKeyboardScrolling();
  
@@ -5747,7 +5714,7 @@ index 6b359e7556a2d6a1485e04e8c20fa5f470c5a04a..4eda11b09ed371ff7bafd6d6f37a96b5
  
      WEBCORE_EXPORT bool handleMouseReleaseEvent(const MouseEventWithHitTestResults&);
  
-@@ -487,10 +483,8 @@ private:
+@@ -488,10 +484,8 @@ private:
      void defaultTabEventHandler(KeyboardEvent&);
      void defaultArrowEventHandler(FocusDirection, KeyboardEvent&);
  
@@ -5758,7 +5725,7 @@ index 6b359e7556a2d6a1485e04e8c20fa5f470c5a04a..4eda11b09ed371ff7bafd6d6f37a96b5
  
      // The following are called at the beginning of handleMouseUp and handleDrag.  
      // If they return true it indicates that they have consumed the event.
-@@ -498,9 +492,10 @@ private:
+@@ -499,9 +493,10 @@ private:
  
  #if ENABLE(DRAG_SUPPORT)
      bool eventLoopHandleMouseDragged(const MouseEventWithHitTestResults&);
@@ -5770,7 +5737,7 @@ index 6b359e7556a2d6a1485e04e8c20fa5f470c5a04a..4eda11b09ed371ff7bafd6d6f37a96b5
      enum class SetOrClearLastScrollbar { Clear, Set };
      void updateLastScrollbarUnderMouse(Scrollbar*, SetOrClearLastScrollbar);
      
-@@ -592,8 +587,8 @@ private:
+@@ -593,8 +588,8 @@ private:
      Timer m_autoHideCursorTimer;
  #endif
  
@@ -5801,7 +5768,7 @@ index 8cc8df1ac26cd347924d76bdbfec92af910e1369..5df20918a9b9e0b89f8b4747f2e615c1
      request.setHTTPHeaderField(HTTPHeaderName::Accept, "text/event-stream");
      request.setHTTPHeaderField(HTTPHeaderName::CacheControl, "no-cache");
 diff --git a/Source/WebCore/page/Frame.cpp b/Source/WebCore/page/Frame.cpp
-index a47ea0d84400580cebe121c89ebc0f877247fc88..f97db5fd5276e52731663248a19032fe5cdc1783 100644
+index 4aa1e77a3ab2d0ec7961b661d5ce7fb8fc190cfc..6a2ffb8d3fbbe1d0bd957081de63b6d9ff29e260 100644
 --- a/Source/WebCore/page/Frame.cpp
 +++ b/Source/WebCore/page/Frame.cpp
 @@ -39,6 +39,7 @@
@@ -5810,9 +5777,9 @@ index a47ea0d84400580cebe121c89ebc0f877247fc88..f97db5fd5276e52731663248a19032fe
  #include "ChromeClient.h"
 +#include "ComposedTreeIterator.h"
  #include "DOMWindow.h"
- #include "DocumentTimeline.h"
  #include "DocumentTimelinesController.h"
-@@ -73,6 +74,7 @@
+ #include "DocumentType.h"
+@@ -72,6 +73,7 @@
  #include "NavigationScheduler.h"
  #include "Navigator.h"
  #include "NodeList.h"
@@ -5820,7 +5787,7 @@ index a47ea0d84400580cebe121c89ebc0f877247fc88..f97db5fd5276e52731663248a19032fe
  #include "NodeTraversal.h"
  #include "Page.h"
  #include "ProcessWarming.h"
-@@ -191,6 +193,7 @@ Frame::Frame(Page& page, HTMLFrameOwnerElement* ownerElement, UniqueRef<FrameLoa
+@@ -190,6 +192,7 @@ Frame::Frame(Page& page, HTMLFrameOwnerElement* ownerElement, UniqueRef<FrameLoa
  void Frame::init()
  {
      m_loader->init();
@@ -5828,7 +5795,7 @@ index a47ea0d84400580cebe121c89ebc0f877247fc88..f97db5fd5276e52731663248a19032fe
  }
  
  Ref<Frame> Frame::create(Page* page, HTMLFrameOwnerElement* ownerElement, UniqueRef<FrameLoaderClient>&& client)
-@@ -370,7 +373,7 @@ void Frame::orientationChanged()
+@@ -369,7 +372,7 @@ void Frame::orientationChanged()
  int Frame::orientation() const
  {
      if (m_page)
@@ -5837,7 +5804,7 @@ index a47ea0d84400580cebe121c89ebc0f877247fc88..f97db5fd5276e52731663248a19032fe
      return 0;
  }
  #endif // ENABLE(ORIENTATION_EVENTS)
-@@ -1150,6 +1153,362 @@ DataDetectionResultsStorage& Frame::dataDetectionResults()
+@@ -1147,6 +1150,362 @@ DataDetectionResultsStorage& Frame::dataDetectionResults()
  
  #endif
  
@@ -6311,7 +6278,7 @@ index 1b77026f51092001cda86e32480890395b145b2e..6026bc23508016454f331b06c9f071a8
  
  struct SnapshotOptions {
 diff --git a/Source/WebCore/page/History.cpp b/Source/WebCore/page/History.cpp
-index 28d1fc3242174a680711027877d4153923790220..058b5309eed081fcc1e4158f66e806421dcc9d56 100644
+index f1da2c85a008476ff08832f3a0b8e7c405bb9764..d27abce0760ec3dea146cbcaef3d493906e5e53b 100644
 --- a/Source/WebCore/page/History.cpp
 +++ b/Source/WebCore/page/History.cpp
 @@ -33,6 +33,7 @@
@@ -6331,7 +6298,7 @@ index 28d1fc3242174a680711027877d4153923790220..058b5309eed081fcc1e4158f66e80642
      if (stateObjectType == StateObjectType::Push) {
          frame->loader().history().pushState(WTFMove(data), title, fullURL.string());
 diff --git a/Source/WebCore/page/Page.cpp b/Source/WebCore/page/Page.cpp
-index 83a50e2421ee0d0c6fcb75007a804a6edd711975..858e02caa87de9739cf03aad914617f294ac55d8 100644
+index fb56ae191a6227dd6ea44e867d34625940e10b53..bbfa68485164990bb22467ba1f386b8e47131c66 100644
 --- a/Source/WebCore/page/Page.cpp
 +++ b/Source/WebCore/page/Page.cpp
 @@ -471,6 +471,37 @@ void Page::setOverrideViewportArguments(const std::optional<ViewportArguments>&
@@ -6383,7 +6350,7 @@ index 83a50e2421ee0d0c6fcb75007a804a6edd711975..858e02caa87de9739cf03aad914617f2
      resetSeenPlugins();
      resetSeenMediaEngines();
  
-@@ -3350,6 +3377,16 @@ void Page::setUseDarkAppearanceOverride(std::optional<bool> valueOverride)
+@@ -3355,6 +3382,16 @@ void Page::setUseDarkAppearanceOverride(std::optional<bool> valueOverride)
  #endif
  }
  
@@ -6401,7 +6368,7 @@ index 83a50e2421ee0d0c6fcb75007a804a6edd711975..858e02caa87de9739cf03aad914617f2
  {
      if (insets == m_fullscreenInsets)
 diff --git a/Source/WebCore/page/Page.h b/Source/WebCore/page/Page.h
-index 8fd51eb67d1eba2ff0a9cd5881a7ce767e22abb9..0b51d4b0bfc01e93b3cffa5f1d592b8f4ffb5a84 100644
+index 51c80d8c1e2cec66b6a2fb26e6eaa36071c67fd8..31137c300cd213ed1a1ed94c440d5beab5343ba6 100644
 --- a/Source/WebCore/page/Page.h
 +++ b/Source/WebCore/page/Page.h
 @@ -273,6 +273,9 @@ public:
@@ -6446,7 +6413,7 @@ index 8fd51eb67d1eba2ff0a9cd5881a7ce767e22abb9..0b51d4b0bfc01e93b3cffa5f1d592b8f
  #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
      DeviceOrientationUpdateProvider* deviceOrientationUpdateProvider() const { return m_deviceOrientationUpdateProvider.get(); }
  #endif
-@@ -996,6 +1010,9 @@ private:
+@@ -997,6 +1011,9 @@ private:
  
  #if ENABLE(DRAG_SUPPORT)
      const std::unique_ptr<DragController> m_dragController;
@@ -6456,7 +6423,7 @@ index 8fd51eb67d1eba2ff0a9cd5881a7ce767e22abb9..0b51d4b0bfc01e93b3cffa5f1d592b8f
  #endif
      const std::unique_ptr<FocusController> m_focusController;
  #if ENABLE(CONTEXT_MENUS)
-@@ -1075,6 +1092,7 @@ private:
+@@ -1076,6 +1093,7 @@ private:
      bool m_useElevatedUserInterfaceLevel { false };
      bool m_useDarkAppearance { false };
      std::optional<bool> m_useDarkAppearanceOverride;
@@ -6464,7 +6431,7 @@ index 8fd51eb67d1eba2ff0a9cd5881a7ce767e22abb9..0b51d4b0bfc01e93b3cffa5f1d592b8f
  
  #if ENABLE(TEXT_AUTOSIZING)
      float m_textAutosizingWidth { 0 };
-@@ -1253,6 +1271,11 @@ private:
+@@ -1254,6 +1272,11 @@ private:
  #endif
  
      std::optional<ViewportArguments> m_overrideViewportArguments;
@@ -6538,10 +6505,10 @@ index 04fff21a26adbc73d8b74dbf55acc8e9824f35da..cd7346fe3b4701724431bc1617e13d2e
  #endif
  
 diff --git a/Source/WebCore/page/RuntimeEnabledFeatures.h b/Source/WebCore/page/RuntimeEnabledFeatures.h
-index cf2f08941f63a7c103a6a73db88b643986d200a4..2842d5edcbecda27e6caec1d30315250ed8af934 100644
+index 3fe51fd1e4360b0fd17b6d86da410faa131359b6..8c464be4352a3aa901af54d5cad1e7ece4a5a2d4 100644
 --- a/Source/WebCore/page/RuntimeEnabledFeatures.h
 +++ b/Source/WebCore/page/RuntimeEnabledFeatures.h
-@@ -185,6 +185,7 @@ public:
+@@ -188,6 +188,7 @@ public:
      void setMouseEventsSimulationEnabled(bool isEnabled) { m_mouseEventsSimulationEnabled = isEnabled; }
      bool touchEventsEnabled() const;
      void setTouchEventsEnabled(bool isEnabled) { m_touchEventsEnabled = isEnabled; }
@@ -6907,7 +6874,7 @@ index be373f080140728d3e0bfc1e7db9f163ed3aedc8..12f49cdf02ec892acef95e524e72929c
  #endif
  
 diff --git a/Source/WebCore/platform/ScrollableArea.h b/Source/WebCore/platform/ScrollableArea.h
-index a36e198c695b1b8465ac050fe1c34a68e1e985ae..ebed9d692157d1e310568eb19dda68e4addc0d32 100644
+index 2bdc18a1988004fafc237572daf2927291ed8def..e915cabfee73cd0abdc6ce2cc518db2cb5ee4603 100644
 --- a/Source/WebCore/platform/ScrollableArea.h
 +++ b/Source/WebCore/platform/ScrollableArea.h
 @@ -103,7 +103,7 @@ public:
@@ -7006,10 +6973,10 @@ index 0000000000000000000000000000000000000000..f0c3a183e5bc44bdfa4201e0db2067b4
 +
 +#endif // ENABLE(SPEECH_SYNTHESIS)
 diff --git a/Source/WebCore/platform/graphics/FontCascade.h b/Source/WebCore/platform/graphics/FontCascade.h
-index 24cfb7137431a77ecb01fedaa4473c69784476c3..9c1413baafa7675fd62d8eb85a267575f47c99be 100644
+index 09f41d601d60cb10fb996540149a1bc652fce835..d69f7dc19d76d2b9174cedb11692b4c0cb1316d7 100644
 --- a/Source/WebCore/platform/graphics/FontCascade.h
 +++ b/Source/WebCore/platform/graphics/FontCascade.h
-@@ -304,7 +304,8 @@ private:
+@@ -303,7 +303,8 @@ private:
              return true;
          if (textRenderingMode == TextRenderingMode::OptimizeSpeed)
              return false;
@@ -7019,21 +6986,6 @@ index 24cfb7137431a77ecb01fedaa4473c69784476c3..9c1413baafa7675fd62d8eb85a267575
          return true;
  #else
          return false;
-diff --git a/Source/WebCore/platform/graphics/PlatformDisplay.cpp b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
-index 0db17070922ca03cd57433871670a11df671a3cb..89f15190dd0396088a4e6ed486c426c49c3616f4 100644
---- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
-+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
-@@ -84,6 +84,10 @@
- #include <wtf/glib/GUniquePtr.h>
- #endif
- 
-+#if USE(GLIB)
-+#include <wtf/glib/GRefPtr.h>
-+#endif
-+
- namespace WebCore {
- 
- std::unique_ptr<PlatformDisplay> PlatformDisplay::createPlatformDisplay()
 diff --git a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
 index 4db603a94f3af1b1bce94ab0f1ae36054c004fcc..c1820f48eb86348f8ca678fde636244e8c91267e 100644
 --- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
@@ -7159,7 +7111,7 @@ index b60f9a64bacc8282860da6de299b75aeb295b9b5..55bd017c03c6478ca334bd5ef164160f
  namespace WebCore {
  
 diff --git a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
-index 68b6cd3f524bf6a09eaf7fd6848fbac1da733ab3..991d7f20c21290db6732f02f8455974167e34bcf 100644
+index c35b2f0f15d9cd09b9b28be0bf44778874305738..5bc1b35e603afe5ae979ece6d3813bcb1e8492ad 100644
 --- a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
 +++ b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
 @@ -27,7 +27,7 @@
@@ -8142,10 +8094,10 @@ index a8f57a72d0eacca7755be84fcaa1c9bf10958c0b..a5d67b8016a86b9184ded0904e317048
  
  SocketStreamHandleImpl::~SocketStreamHandleImpl()
 diff --git a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
-index fcfa4e995212ae926f6339d37dbbb3d1051e0fc3..b2341ee77f6b1c2c0b4ebecc6e861f36522e2a7f 100644
+index fab574233fe00f4b0bf22e0baec09db116a4d3ce..79e4ba64115d88aec771175833e9d3ed71591692 100644
 --- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
 +++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
-@@ -408,6 +408,30 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
+@@ -410,6 +410,30 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
      soup_cookie_jar_add_cookie(cookieStorage(), cookie.toSoupCookie());
  }
  
@@ -8768,10 +8720,10 @@ index 2e90534ffd8da83b7dc54d46fa7def16319bbb43..2493c00d58957751c65c37eb409fa8d6
      int innerLineHeight() const override;
  #endif
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
-index a34f79bde3e081696d73a55fbf59058bf6d8f379..dd0004e8281c53877f4133a0caf4b94ef6b006b7 100644
+index 40a7e2aea4a1bcf9fdf7eb32b33266b0bd6a551f..c7ce89d3063e1115eefae48c5df41c2cdb695038 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
-@@ -77,6 +77,11 @@
+@@ -83,6 +83,11 @@
  #include <WebCore/SameSiteInfo.h>
  #include <WebCore/SecurityPolicy.h>
  
@@ -8783,7 +8735,7 @@ index a34f79bde3e081696d73a55fbf59058bf6d8f379..dd0004e8281c53877f4133a0caf4b94e
  #if ENABLE(APPLE_PAY_REMOTE_UI)
  #include "WebPaymentCoordinatorProxyMessages.h"
  #endif
-@@ -465,6 +470,10 @@ void NetworkConnectionToWebProcess::createSocketStream(URL&& url, String cachePa
+@@ -488,6 +493,10 @@ void NetworkConnectionToWebProcess::createSocketStream(URL&& url, String cachePa
      if (auto* session = networkSession())
          acceptInsecureCertificates = session->shouldAcceptInsecureCertificatesForWebSockets();
  #endif
@@ -8794,7 +8746,7 @@ index a34f79bde3e081696d73a55fbf59058bf6d8f379..dd0004e8281c53877f4133a0caf4b94e
      m_networkSocketStreams.add(identifier, NetworkSocketStream::create(m_networkProcess.get(), WTFMove(url), m_sessionID, cachePartition, identifier, m_connection, WTFMove(token), acceptInsecureCertificates));
  }
  
-@@ -1011,6 +1020,14 @@ void NetworkConnectionToWebProcess::clearPageSpecificData(PageIdentifier pageID)
+@@ -1036,6 +1045,14 @@ void NetworkConnectionToWebProcess::clearPageSpecificData(PageIdentifier pageID)
  #endif
  }
  
@@ -8810,10 +8762,10 @@ index a34f79bde3e081696d73a55fbf59058bf6d8f379..dd0004e8281c53877f4133a0caf4b94e
  void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier frameID, PageIdentifier pageID)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
-index ab96657d0df4a2331040ac51fc43c06847848047..c284d1a4eb98e10f43a10acf8a776c306f3fa7fb 100644
+index d0aa4ef74520a2ca0b551b469e86ea7668b678e7..c42b9217d166efc789d194fe5ec848398767bb7c 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
-@@ -294,6 +294,8 @@ private:
+@@ -305,6 +305,8 @@ private:
  
      void clearPageSpecificData(WebCore::PageIdentifier);
  
@@ -8823,7 +8775,7 @@ index ab96657d0df4a2331040ac51fc43c06847848047..c284d1a4eb98e10f43a10acf8a776c30
      void removeStorageAccessForFrame(WebCore::FrameIdentifier, WebCore::PageIdentifier);
  
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
-index 242835050b24970c5eac1e26bf86b5b025a80e53..7e5277d3613d45054d349ce4935202ff4d176e1f 100644
+index b97ca3479b4d9d5579a7e7e55a691a60dd8866bc..9cf3a813e7822b1c9be379fac7e5a4d868a7a936 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 @@ -66,6 +66,8 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
@@ -8836,7 +8788,7 @@ index 242835050b24970c5eac1e26bf86b5b025a80e53..7e5277d3613d45054d349ce4935202ff
      RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
      LogUserInteraction(WebCore::RegistrableDomain domain)
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.cpp b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
-index 7c79e2a20976a139c7f667f113c48946dedd5641..9b699a12467f20f029c0f933d0e3e343f168475c 100644
+index 12f8e8a5b59f00dd7b7efd3b2ad1357fa2516933..7208d6d1fbafa3bbdf9ead9d868e14e5c4ff60af 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 @@ -26,7 +26,6 @@
@@ -8847,7 +8799,7 @@ index 7c79e2a20976a139c7f667f113c48946dedd5641..9b699a12467f20f029c0f933d0e3e343
  #include "ArgumentCoders.h"
  #include "Attachment.h"
  #include "AuthenticationManager.h"
-@@ -535,6 +534,41 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID)
+@@ -532,6 +531,41 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID)
      m_sessionsControlledByAutomation.remove(sessionID);
  }
  
@@ -8890,18 +8842,18 @@ index 7c79e2a20976a139c7f667f113c48946dedd5641..9b699a12467f20f029c0f933d0e3e343
  void NetworkProcess::dumpResourceLoadStatistics(PAL::SessionID sessionID, CompletionHandler<void(String)>&& completionHandler)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.h b/Source/WebKit/NetworkProcess/NetworkProcess.h
-index 7877927a17c5596eb03bd4acf4d58e418ac8ba23..901fb80d71c8cac0eb0414153184ad928ff498ad 100644
+index 0f8533ed13dd26277a6dd52ab6dabe20c3e08805..460cad5f9a89c82eb3921dbd3e87000bb79da404 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
-@@ -35,6 +35,7 @@
- #include "NetworkResourceLoadIdentifier.h"
+@@ -36,6 +36,7 @@
+ #include "QuotaIncreaseRequestIdentifier.h"
  #include "RTCDataChannelRemoteManagerProxy.h"
  #include "SandboxExtension.h"
 +#include "StorageNamespaceIdentifier.h"
  #include "WebPageProxyIdentifier.h"
  #include "WebResourceLoadStatisticsStore.h"
  #include "WebsiteData.h"
-@@ -79,6 +80,7 @@ class SessionID;
+@@ -80,6 +81,7 @@ class SessionID;
  
  namespace WebCore {
  class CertificateInfo;
@@ -8909,7 +8861,7 @@ index 7877927a17c5596eb03bd4acf4d58e418ac8ba23..901fb80d71c8cac0eb0414153184ad92
  class CurlProxySettings;
  class ProtectionSpace;
  class NetworkStorageSession;
-@@ -201,6 +203,11 @@ public:
+@@ -202,6 +204,11 @@ public:
  
      void addWebsiteDataStore(WebsiteDataStoreParameters&&);
  
@@ -8922,7 +8874,7 @@ index 7877927a17c5596eb03bd4acf4d58e418ac8ba23..901fb80d71c8cac0eb0414153184ad92
      void clearPrevalentResource(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
      void clearUserInteraction(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
-index 637e159f186393bec5cc05ab5bd5780be8c6fce4..8032679d6f8a585441d4c5984f3cc7cdeb929e34 100644
+index 631e2b6073c019213068c2096b827b279dbc7de0..242797845981dab94c3425e910d84cedacd7466c 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 @@ -78,6 +78,11 @@ messages -> NetworkProcess LegacyReceiver {
@@ -8938,10 +8890,10 @@ index 637e159f186393bec5cc05ab5bd5780be8c6fce4..8032679d6f8a585441d4c5984f3cc7cd
      ClearPrevalentResource(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> () Async
      ClearUserInteraction(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> () Async
 diff --git a/Source/WebKit/NetworkProcess/NetworkSession.h b/Source/WebKit/NetworkProcess/NetworkSession.h
-index 19307cf40be3b2f26057d016c766edce498c9542..091438735aa757887d534d122bb01a1c6144ea7a 100644
+index 85c7cbd69034d9cba7f445da9de475a1d7b35118..f5a50c9773902bd9e376ebd07df5889699b7c63e 100644
 --- a/Source/WebKit/NetworkProcess/NetworkSession.h
 +++ b/Source/WebKit/NetworkProcess/NetworkSession.h
-@@ -192,6 +192,9 @@ public:
+@@ -193,6 +193,9 @@ public:
  
      void lowMemoryHandler(WTF::Critical);
  
@@ -8951,7 +8903,7 @@ index 19307cf40be3b2f26057d016c766edce498c9542..091438735aa757887d534d122bb01a1c
  #if ENABLE(SERVICE_WORKER)
      void addSoftUpdateLoader(std::unique_ptr<ServiceWorkerSoftUpdateLoader>&& loader) { m_softUpdateLoaders.add(WTFMove(loader)); }
      void removeSoftUpdateLoader(ServiceWorkerSoftUpdateLoader* loader) { m_softUpdateLoaders.remove(loader); }
-@@ -279,6 +282,7 @@ protected:
+@@ -277,6 +280,7 @@ protected:
      bool m_privateClickMeasurementDebugModeEnabled { false };
      std::optional<WebCore::PrivateClickMeasurement> m_ephemeralMeasurement;
      bool m_isRunningEphemeralMeasurementTest { false };
@@ -9041,10 +8993,10 @@ index f57a72b6bdc3382469d69adb1b1201c7a9f07a84..c501211b094312ca44f0bf92de5d6ebc
      void clear();
  
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-index 834e5261733119e70e1ef20d177a73819feffc91..565b653f77e70e63679e9c6128539fb37e334b8c 100644
+index 9eaa83feae195de9c06c5e418ddc1b83080f864e..25aadcc715b351a366700bb91d5d3bab142d6c55 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-@@ -736,7 +736,7 @@ void NetworkSessionCocoa::setClientAuditToken(const WebCore::AuthenticationChall
+@@ -718,7 +718,7 @@ void NetworkSessionCocoa::setClientAuditToken(const WebCore::AuthenticationChall
  
      if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
          sessionCocoa->setClientAuditToken(challenge);
@@ -9053,7 +9005,7 @@ index 834e5261733119e70e1ef20d177a73819feffc91..565b653f77e70e63679e9c6128539fb3
              return completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
  
          NSURLSessionTaskTransactionMetrics *metrics = task._incompleteTaskMetrics.transactionMetrics.lastObject;
-@@ -974,6 +974,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
+@@ -956,6 +956,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
  
          resourceResponse.setDeprecatedNetworkLoadMetrics(WebCore::copyTimingData(taskMetrics, networkDataTask->networkLoadMetrics()));
  
@@ -9243,7 +9195,7 @@ index e55864a95f7bcbc085c46628bff058573573286c..d82268c1877a29e3e9e848185e4df4e7
  
      WebCore::ShouldRelaxThirdPartyCookieBlocking m_shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
 diff --git a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
-index 81d990d2b653d8e8018afdec45c79f271d4c1c9c..79e7d85c2576eb355e5cf1b5077ab66d6fdaa18c 100644
+index 66e4895549a3aec8d1df994d25fdcda4ed2d7e66..b69f2b4fc68f483b4272704be56ef958fef2785e 100644
 --- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 +++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 @@ -494,6 +494,8 @@ void NetworkDataTaskSoup::didSendRequest(GRefPtr<GInputStream>&& inputStream)
@@ -9540,6 +9492,19 @@ index 24bd842672aa8101d1c1eb6db4335f1e5f0b840d..52e9e574d103d5e831d022affe24601b
      )
  endif ()
  
+diff --git a/Source/WebKit/Scripts/generate-unified-sources.sh b/Source/WebKit/Scripts/generate-unified-sources.sh
+index defd969315770cf57bcb6aee427af4cb6ccbbbf0..4e305bbdbb9196444461d468efb666e4a98d5546 100755
+--- a/Source/WebKit/Scripts/generate-unified-sources.sh
++++ b/Source/WebKit/Scripts/generate-unified-sources.sh
+@@ -14,7 +14,7 @@ if [ -z "${BUILD_SCRIPTS_DIR}" ]; then
+     fi
+ fi
+ 
+-UnifiedSourceCppFileCount=120
++UnifiedSourceCppFileCount=122
+ UnifiedSourceMmFileCount=80
+ 
+ if [ $# -eq 0 ]; then
 diff --git a/Source/WebKit/Shared/API/c/wpe/WebKit.h b/Source/WebKit/Shared/API/c/wpe/WebKit.h
 index caf67e1dece5b727e43eba780e70814f8fdb0f63..740150d2589d6e16a516daa3bf6ef899ac538c99 100644
 --- a/Source/WebKit/Shared/API/c/wpe/WebKit.h
@@ -9601,10 +9566,10 @@ index ee8cac1c980039c4a36de5501ab7f135e710d06b..deae2be9e720ff76186ecea89920dfc3
  
  #if USE(APPKIT)
 diff --git a/Source/WebKit/Shared/NativeWebMouseEvent.h b/Source/WebKit/Shared/NativeWebMouseEvent.h
-index 001558dd58f4d85f360d5711caa03db33889011e..1e0898f985f1d13036d31e3e284258a3c64fa0a4 100644
+index fef57e34be6ed7592187c3e1fd73c989bf79da1a..e35612e9b88877627802df18e9084e7f4022e629 100644
 --- a/Source/WebKit/Shared/NativeWebMouseEvent.h
 +++ b/Source/WebKit/Shared/NativeWebMouseEvent.h
-@@ -77,6 +77,11 @@ public:
+@@ -78,6 +78,11 @@ public:
      NativeWebMouseEvent(HWND, UINT message, WPARAM, LPARAM, bool);
  #endif
  
@@ -9631,7 +9596,7 @@ index f2f3979fcac9dfd97d0e0ead600fe35eb8defd40..ac91412e1a96bdf521b1890a66e465dc
      NSEvent* nativeEvent() const { return m_nativeEvent.get(); }
  #elif PLATFORM(GTK)
 diff --git a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
-index 28345004e5d182dbfd43584f59846e86aae8d7a6..8b707077d6628fcbefd7a120c3801317777d06ac 100644
+index 9987b1a84768f273863dc0b1a5539153c4981783..4587d56e8e194cde51ad2a8d31d573e424a0ae46 100644
 --- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 +++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 @@ -117,6 +117,10 @@
@@ -9839,10 +9804,10 @@ index 1817691d3e12ddec8169248c791826cc13b057e3..cdc90eda23ed5ba20ee78a02c0dd632b
  
      const String& text() const { return m_text; }
 diff --git a/Source/WebKit/Shared/WebMouseEvent.h b/Source/WebKit/Shared/WebMouseEvent.h
-index 3dbe10d49b4de34636900efe31fb57e7e60e341c..1457cbaad0bf5c3b17902fd8c2f243a2c0688716 100644
+index cf2adc382b3f59890c43a54b6c28bab2c4a965c6..998e96ec8c997bd1b51434c77e73e9420f5ebaa7 100644
 --- a/Source/WebKit/Shared/WebMouseEvent.h
 +++ b/Source/WebKit/Shared/WebMouseEvent.h
-@@ -59,6 +59,7 @@ public:
+@@ -62,6 +62,7 @@ public:
  
      Button button() const { return static_cast<Button>(m_button); }
      unsigned short buttons() const { return m_buttons; }
@@ -9851,10 +9816,10 @@ index 3dbe10d49b4de34636900efe31fb57e7e60e341c..1457cbaad0bf5c3b17902fd8c2f243a2
      const WebCore::IntPoint& globalPosition() const { return m_globalPosition; }
      float deltaX() const { return m_deltaX; }
 diff --git a/Source/WebKit/Shared/WebPageCreationParameters.cpp b/Source/WebKit/Shared/WebPageCreationParameters.cpp
-index 7fa64a927781735369d795f34328cd39a120846d..113a00d0430a6bfc8398813816a1d20841bb1fd0 100644
+index 3e62edd10a1f1f20bf9a77c5cb5afc14f87680a2..e41d25ac6f9eb7b67a49363bada74b9a27f64e1a 100644
 --- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
 +++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
-@@ -161,6 +161,8 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
+@@ -157,6 +157,8 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
      encoder << crossOriginAccessControlCheckEnabled;
      encoder << processDisplayName;
  
@@ -9863,7 +9828,7 @@ index 7fa64a927781735369d795f34328cd39a120846d..113a00d0430a6bfc8398813816a1d208
      encoder << shouldCaptureAudioInUIProcess;
      encoder << shouldCaptureAudioInGPUProcess;
      encoder << shouldCaptureVideoInUIProcess;
-@@ -556,7 +558,10 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
+@@ -540,7 +542,10 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
      if (!processDisplayName)
          return std::nullopt;
      parameters.processDisplayName = WTFMove(*processDisplayName);
@@ -9876,17 +9841,17 @@ index 7fa64a927781735369d795f34328cd39a120846d..113a00d0430a6bfc8398813816a1d208
          return std::nullopt;
  
 diff --git a/Source/WebKit/Shared/WebPageCreationParameters.h b/Source/WebKit/Shared/WebPageCreationParameters.h
-index 7b7065ab9d4cca89c602413f19d90a30577b2b90..df6e48de3f59e28a7c9415cfaeed66783d3a78e8 100644
+index e78a3141450f96a739a72d787b9a68fa179a65b2..395515b256593af0121fc36241a2b28005fdfd77 100644
 --- a/Source/WebKit/Shared/WebPageCreationParameters.h
 +++ b/Source/WebKit/Shared/WebPageCreationParameters.h
-@@ -257,6 +257,8 @@ struct WebPageCreationParameters {
- 
-     WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
+@@ -252,6 +252,8 @@ struct WebPageCreationParameters {
+     
+     bool httpsUpgradeEnabled { true };
  
 +    bool shouldPauseInInspectorWhenShown { false };
 +
- #if PLATFORM(GTK)
-     GtkSettingsState gtkSettings;
+ #if PLATFORM(IOS)
+     bool allowsDeprecatedSynchronousXMLHttpRequestDuringUnload { false };
  #endif
 diff --git a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
 index 5b817212dbd05d73172a72ca6cb5df979b7663c1..f6bd6c9e1f8ea5b5214ef05b422cd804d761ecb0 100644
@@ -9926,14 +9891,14 @@ index c204637774ee803eac42a34cde79aa556f143b82..345f5b08179e3dd239725bed06e48b46
  {
  }
 diff --git a/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp b/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
-index 7cc65739c320cb4312d9d705284220a383a0293a..da53885517d55d424423ee3d0dcead25825cc022 100644
+index ebf179e3f11c3e05e2354d36b1a68c4c3b965403..c00ea8a5ebe6f1d7fa987cac003dc3a281cfb386 100644
 --- a/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
 +++ b/Source/WebKit/Shared/gtk/NativeWebMouseEventGtk.cpp
 @@ -54,7 +54,7 @@ NativeWebMouseEvent::NativeWebMouseEvent(Type type, Button button, unsigned shor
  }
  
  NativeWebMouseEvent::NativeWebMouseEvent(const NativeWebMouseEvent& event)
--    : WebMouseEvent(event.type(), event.button(), event.buttons(), event.position(), event.globalPosition(), event.deltaX(), event.deltaY(), event.deltaZ(), event.clickCount(), event.modifiers(), event.timestamp(), 0, NoTap, event.pointerId(), event.pointerType())
+-    : WebMouseEvent(event.type(), event.button(), event.buttons(), event.position(), event.globalPosition(), event.deltaX(), event.deltaY(), event.deltaZ(), event.clickCount(), event.modifiers(), event.timestamp(), 0, NoTap, event.isTouchEvent(), event.pointerId(), event.pointerType())
 +    : WebMouseEvent(event)
      , m_nativeEvent(event.nativeEvent() ? gdk_event_copy(const_cast<GdkEvent*>(event.nativeEvent())) : nullptr)
  {
@@ -10216,10 +10181,10 @@ index 85d6f74114f4e7f82d9502d1b99d69098d6a49b6..6896c9756edb233dda46c7031e1af699
      return WebTouchEvent();
  }
 diff --git a/Source/WebKit/Sources.txt b/Source/WebKit/Sources.txt
-index 57ef3b14eaf2c1092098ee9432f508c611e58e35..782a0547ad06f0c72d8cad1f2457d1117ad3e021 100644
+index c7320b102e7d8f2b6fef8d2b46fcc8b9ed7d109a..05b1b72a2c24298357a68009687a05f8f49e87df 100644
 --- a/Source/WebKit/Sources.txt
 +++ b/Source/WebKit/Sources.txt
-@@ -393,11 +393,14 @@ Shared/XR/XRDeviceProxy.cpp
+@@ -404,11 +404,14 @@ Shared/XR/XRDeviceProxy.cpp
  
  UIProcess/AuxiliaryProcessProxy.cpp
  UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -10234,7 +10199,7 @@ index 57ef3b14eaf2c1092098ee9432f508c611e58e35..782a0547ad06f0c72d8cad1f2457d111
  UIProcess/LegacyGlobalSettings.cpp
  UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
  UIProcess/MediaKeySystemPermissionRequestProxy.cpp
-@@ -406,6 +409,7 @@ UIProcess/PageLoadState.cpp
+@@ -417,6 +420,7 @@ UIProcess/PageLoadState.cpp
  UIProcess/ProcessAssertion.cpp
  UIProcess/ProcessThrottler.cpp
  UIProcess/ProvisionalPageProxy.cpp
@@ -10242,7 +10207,7 @@ index 57ef3b14eaf2c1092098ee9432f508c611e58e35..782a0547ad06f0c72d8cad1f2457d111
  UIProcess/ResponsivenessTimer.cpp
  UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
  UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
-@@ -447,6 +451,8 @@ UIProcess/WebOpenPanelResultListenerProxy.cpp
+@@ -458,6 +462,8 @@ UIProcess/WebOpenPanelResultListenerProxy.cpp
  UIProcess/WebPageDiagnosticLoggingClient.cpp
  UIProcess/WebPageGroup.cpp
  UIProcess/WebPageInjectedBundleClient.cpp
@@ -10251,7 +10216,7 @@ index 57ef3b14eaf2c1092098ee9432f508c611e58e35..782a0547ad06f0c72d8cad1f2457d111
  UIProcess/WebPageProxy.cpp
  UIProcess/WebPasteboardProxy.cpp
  UIProcess/WebPreferences.cpp
-@@ -568,7 +574,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
+@@ -580,7 +586,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
  UIProcess/Inspector/WebPageDebuggable.cpp
  UIProcess/Inspector/WebPageInspectorController.cpp
  
@@ -10264,10 +10229,10 @@ index 57ef3b14eaf2c1092098ee9432f508c611e58e35..782a0547ad06f0c72d8cad1f2457d111
  UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
  UIProcess/Media/MediaUsageManager.cpp
 diff --git a/Source/WebKit/SourcesCocoa.txt b/Source/WebKit/SourcesCocoa.txt
-index 3a72596a4d7a5cab4566277136564ba015b196cd..aecfb624b16bb5dc37b76e3c5f2b84647d5aa377 100644
+index 39fea91ce561758160ad9218989453e583ed6461..e2d87dc8d11e00e983006ac60309231e64ceac01 100644
 --- a/Source/WebKit/SourcesCocoa.txt
 +++ b/Source/WebKit/SourcesCocoa.txt
-@@ -273,6 +273,7 @@ UIProcess/API/Cocoa/_WKApplicationManifest.mm
+@@ -276,6 +276,7 @@ UIProcess/API/Cocoa/_WKApplicationManifest.mm
  UIProcess/API/Cocoa/_WKAttachment.mm
  UIProcess/API/Cocoa/_WKAutomationSession.mm
  UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm
@@ -10275,7 +10240,7 @@ index 3a72596a4d7a5cab4566277136564ba015b196cd..aecfb624b16bb5dc37b76e3c5f2b8464
  UIProcess/API/Cocoa/_WKContentRuleListAction.mm
  UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
  UIProcess/API/Cocoa/_WKCustomHeaderFields.mm @no-unify
-@@ -447,6 +448,7 @@ UIProcess/Inspector/ios/WKInspectorHighlightView.mm
+@@ -452,6 +453,7 @@ UIProcess/Inspector/ios/WKInspectorHighlightView.mm
  UIProcess/Inspector/ios/WKInspectorNodeSearchGestureRecognizer.mm
  
  UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -10284,7 +10249,7 @@ index 3a72596a4d7a5cab4566277136564ba015b196cd..aecfb624b16bb5dc37b76e3c5f2b8464
  UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
  UIProcess/Inspector/mac/WKInspectorViewController.mm
 diff --git a/Source/WebKit/SourcesGTK.txt b/Source/WebKit/SourcesGTK.txt
-index 67f80410e8c9df9647d76b3775cfbcffc7d3b676..f9b23ba14cfe2bbe709390ddda0f6fac477a1718 100644
+index 7e7408e5afc02c82ee694ce5374cce6c9c8fc388..d23104efb3909171b569ceda32a8ad6460bc3bff 100644
 --- a/Source/WebKit/SourcesGTK.txt
 +++ b/Source/WebKit/SourcesGTK.txt
 @@ -127,6 +127,7 @@ UIProcess/API/glib/WebKitAuthenticationRequest.cpp @no-unify
@@ -10295,7 +10260,7 @@ index 67f80410e8c9df9647d76b3775cfbcffc7d3b676..f9b23ba14cfe2bbe709390ddda0f6fac
  UIProcess/API/glib/WebKitContextMenuClient.cpp @no-unify
  UIProcess/API/glib/WebKitCookieManager.cpp @no-unify
  UIProcess/API/glib/WebKitCredential.cpp @no-unify
-@@ -242,6 +243,7 @@ UIProcess/WebsiteData/unix/WebsiteDataStoreUnix.cpp
+@@ -243,6 +244,7 @@ UIProcess/WebsiteData/unix/WebsiteDataStoreUnix.cpp
  
  UIProcess/cairo/BackingStoreCairo.cpp @no-unify
  
@@ -10303,7 +10268,7 @@ index 67f80410e8c9df9647d76b3775cfbcffc7d3b676..f9b23ba14cfe2bbe709390ddda0f6fac
  UIProcess/glib/WebPageProxyGLib.cpp
  UIProcess/glib/WebProcessPoolGLib.cpp
  UIProcess/glib/WebProcessProxyGLib.cpp
-@@ -259,6 +261,7 @@ UIProcess/gtk/ClipboardGtk4.cpp @no-unify
+@@ -260,6 +262,7 @@ UIProcess/gtk/ClipboardGtk4.cpp @no-unify
  UIProcess/gtk/WebDateTimePickerGtk.cpp
  UIProcess/gtk/GtkSettingsManager.cpp
  UIProcess/gtk/HardwareAccelerationManager.cpp
@@ -10311,7 +10276,7 @@ index 67f80410e8c9df9647d76b3775cfbcffc7d3b676..f9b23ba14cfe2bbe709390ddda0f6fac
  UIProcess/gtk/KeyBindingTranslator.cpp
  UIProcess/gtk/PointerLockManager.cpp @no-unify
  UIProcess/gtk/PointerLockManagerWayland.cpp @no-unify
-@@ -271,6 +274,8 @@ UIProcess/gtk/WaylandCompositor.cpp @no-unify
+@@ -272,6 +275,8 @@ UIProcess/gtk/WaylandCompositor.cpp @no-unify
  UIProcess/gtk/WebColorPickerGtk.cpp
  UIProcess/gtk/WebContextMenuProxyGtk.cpp
  UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
@@ -10321,7 +10286,7 @@ index 67f80410e8c9df9647d76b3775cfbcffc7d3b676..f9b23ba14cfe2bbe709390ddda0f6fac
  UIProcess/gtk/WebPasteboardProxyGtk.cpp
  UIProcess/gtk/WebPopupMenuProxyGtk.cpp
 diff --git a/Source/WebKit/SourcesWPE.txt b/Source/WebKit/SourcesWPE.txt
-index 94419dd86f079c5c53e68ce8e79b915505a87ab0..076d3c33ccbdd2894239375a308df5bd61c59242 100644
+index 97fedd4409cebcb04fb9559edbf71ba76428a1cd..62411a320864521bb58009c62c6bc272b45f5bd2 100644
 --- a/Source/WebKit/SourcesWPE.txt
 +++ b/Source/WebKit/SourcesWPE.txt
 @@ -86,6 +86,7 @@ Shared/glib/ProcessExecutablePathGLib.cpp
@@ -10364,7 +10329,7 @@ index 94419dd86f079c5c53e68ce8e79b915505a87ab0..076d3c33ccbdd2894239375a308df5bd
  UIProcess/glib/WebPageProxyGLib.cpp
  UIProcess/glib/WebProcessPoolGLib.cpp
  UIProcess/glib/WebProcessProxyGLib.cpp
-@@ -224,6 +229,11 @@ UIProcess/linux/MemoryPressureMonitor.cpp
+@@ -225,6 +230,11 @@ UIProcess/linux/MemoryPressureMonitor.cpp
  UIProcess/soup/WebCookieManagerProxySoup.cpp
  UIProcess/soup/WebProcessPoolSoup.cpp
  
@@ -10376,7 +10341,7 @@ index 94419dd86f079c5c53e68ce8e79b915505a87ab0..076d3c33ccbdd2894239375a308df5bd
  UIProcess/wpe/WebPageProxyWPE.cpp
  
  WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp
-@@ -252,6 +262,8 @@ WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp
+@@ -253,6 +263,8 @@ WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp
  
  WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp
  
@@ -10438,10 +10403,10 @@ index cc642c51ba663e843df54d14cfccb6d4ef81726c..229ae1a7df1e418f9b09bf9c3c3bb1ed
      bool m_shouldTakeUIBackgroundAssertion { true };
      bool m_shouldCaptureDisplayInUIProcess { DEFAULT_CAPTURE_DISPLAY_IN_UI_PROCESS };
 diff --git a/Source/WebKit/UIProcess/API/APIUIClient.h b/Source/WebKit/UIProcess/API/APIUIClient.h
-index 9685054929cfdc35e98a15f054f7839e1df4ae08..6b79a387dacef4ef2a3e015fe078c19a80a664e4 100644
+index fbce945e4586f2df7e750fa9807664487de28445..de9410c85eb5786d3a5697451adf69178d02a94a 100644
 --- a/Source/WebKit/UIProcess/API/APIUIClient.h
 +++ b/Source/WebKit/UIProcess/API/APIUIClient.h
-@@ -104,6 +104,7 @@ public:
+@@ -105,6 +105,7 @@ public:
      virtual void runJavaScriptAlert(WebKit::WebPageProxy&, const WTF::String&, WebKit::WebFrameProxy*, WebKit::FrameInfoData&&, Function<void()>&& completionHandler) { completionHandler(); }
      virtual void runJavaScriptConfirm(WebKit::WebPageProxy&, const WTF::String&, WebKit::WebFrameProxy*, WebKit::FrameInfoData&&, Function<void(bool)>&& completionHandler) { completionHandler(false); }
      virtual void runJavaScriptPrompt(WebKit::WebPageProxy&, const WTF::String&, const WTF::String&, WebKit::WebFrameProxy*, WebKit::FrameInfoData&&, Function<void(const WTF::String&)>&& completionHandler) { completionHandler(WTF::String()); }
@@ -10493,24 +10458,10 @@ index 026121d114c5fcad84c1396be8d692625beaa3bd..edd6e5cae033124c589959a42522fde0
  }
  #endif
 diff --git a/Source/WebKit/UIProcess/API/C/WKPage.cpp b/Source/WebKit/UIProcess/API/C/WKPage.cpp
-index 20a1e302ddbd2a61e3c5a2cd5ef11d35c94bffba..f682c0b9d17c47a6b9dd410e1f42c2bf0d96f6ae 100644
+index 6047c5fa4e736867566222d63f66572af94cd810..2028199bd8a10b9fb27d89acb25992c852725b2f 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
 +++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
-@@ -1775,6 +1775,13 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
-             completionHandler(String());
-         }
- 
-+        void handleJavaScriptDialog(WebPageProxy& page, bool accept, const String& value) final {
-+            if (m_client.handleJavaScriptDialog) {
-+                m_client.handleJavaScriptDialog(toAPI(&page), accept, toAPI(value.impl()), m_client.base.clientInfo);
-+                return;
-+            }
-+        }
-+
-         void setStatusText(WebPageProxy* page, const String& text) final
-         {
-             if (!m_client.setStatusText)
-@@ -1804,6 +1811,8 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
+@@ -1805,6 +1805,8 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
          {
              if (!m_client.didNotHandleKeyEvent)
                  return;
@@ -10520,7 +10471,7 @@ index 20a1e302ddbd2a61e3c5a2cd5ef11d35c94bffba..f682c0b9d17c47a6b9dd410e1f42c2bf
          }
  
 diff --git a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
-index 66fa7f948bdc35669fa7db5a01535333befa55ec..c7c4910916dc72f6c0efa7aac6678e9f867686a5 100644
+index e33187477d3d6e7614b8918d467b30847f943864..5149d29bf4e2ef53e7d28505f7e47da202113f54 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
 +++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
 @@ -90,6 +90,7 @@ typedef void (*WKPageRunBeforeUnloadConfirmPanelCallback)(WKPageRef page, WKStri
@@ -10602,10 +10553,10 @@ index afa925f36c29db9c23921298dead9cce737500d6..42d396342acdb6d39830f611df0ee40e
  
  NS_ASSUME_NONNULL_END
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
-index f913483deda04127638afbadf1dd72eb84b38218..52ed5e019ca152a671a4fefb84bee2e187c97e98 100644
+index eaa2ad6214464293cc947ff2a152e5e96bf05f3b..7845d8b4f770164beea06e1fa5d01db628a47d95 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
-@@ -45,6 +45,7 @@
+@@ -46,6 +46,7 @@
  #import "_WKResourceLoadStatisticsThirdPartyInternal.h"
  #import "_WKWebsiteDataStoreConfigurationInternal.h"
  #import "_WKWebsiteDataStoreDelegate.h"
@@ -10613,7 +10564,7 @@ index f913483deda04127638afbadf1dd72eb84b38218..52ed5e019ca152a671a4fefb84bee2e1
  #import <WebCore/Credential.h>
  #import <WebCore/RegistrationDatabase.h>
  #import <WebCore/WebCoreObjCExtras.h>
-@@ -206,6 +207,11 @@ static WallTime toSystemClockTime(NSDate *date)
+@@ -207,6 +208,11 @@ static WallTime toSystemClockTime(NSDate *date)
      });
  }
  
@@ -10860,6 +10811,18 @@ index 1e827013c603ae8bd43d798170deb98fc3153852..2075bc78069bde530ec237c0b761773c
  #import <wtf/cocoa/VectorCocoa.h>
  
  @implementation _WKUserStyleSheet
+diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+index ca304242f78d1fa0a916aca873c7022f8881cddf..7d4d60d971f1f58a316b28adfc65c97049cdab17 100644
+--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
++++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+@@ -55,6 +55,7 @@
+ #import <WebCore/PublicKeyCredentialRequestOptions.h>
+ #import <WebCore/WebAuthenticationConstants.h>
+ #import <WebCore/WebAuthenticationUtils.h>
++#import <WebCore/WebCoreObjCExtras.h>
+ #import <objc/runtime.h>
+ #import <pal/crypto/CryptoDigest.h>
+ #import <wtf/BlockPtr.h>
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspector.cpp b/Source/WebKit/UIProcess/API/glib/WebKitBrowserInspector.cpp
 new file mode 100644
 index 0000000000000000000000000000000000000000..54529a23f53cebe6f8a96873ca6c2f31f0481ae0
@@ -11202,7 +11165,7 @@ index 78d1578f94793e9e59a3d4d2b33e79ea8530fa04..493cdadac3873508b3efa3048638e73a
  #endif
 +int webkitWebContextExistingCount();
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
-index c893e91c3971b7e771b0751e5df025d415f9ab87..41401a4f72e1eba38412075eba1ad29f59fef0ff 100644
+index 1ec86a3f16a097bf843dbdacf8d8ebd62d8175a4..457307ae7e9a5a9f4f56bbde07dc12482ff815a3 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 @@ -32,6 +32,7 @@
@@ -11417,10 +11380,10 @@ index 0000000000000000000000000000000000000000..9f1a0173a5641d6f158d815b8f7b9ea6
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
-index 27a770ecbfc69b96d693a8662df1dbaead44d7e2..81b150bac8ca394282c5f2146ef3ce41241a8101 100644
+index 75f27e783c69b2b7dba43c62ab020a59df7a27b6..5c0ede019748dcb463b6ce2d926631a6bce3fa17 100644
 --- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
 +++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
-@@ -2539,6 +2539,11 @@ void webkitWebViewBaseResetClickCounter(WebKitWebViewBase* webkitWebViewBase)
+@@ -2542,6 +2542,11 @@ void webkitWebViewBaseResetClickCounter(WebKitWebViewBase* webkitWebViewBase)
  #endif
  }
  
@@ -12077,7 +12040,7 @@ index 8a95a3f8036bb0c664954c23ba3ecf72058ae711..dd10e28e2499cd84be2d072dc7567050
  namespace WebKit {
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
-index 3d1e64c215a223fb7168ffd42be358488f5254b1..8d447e8fbaaa9bdf9ae867227f3b24b554fc7503 100644
+index c02db482965c5e8d3fc40d90869c9e8f80ad301e..ce046a3949e2b3fe6a106af133b3dbc25a81a276 100644
 --- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
 +++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
 @@ -95,6 +95,7 @@ private:
@@ -12088,7 +12051,7 @@ index 3d1e64c215a223fb7168ffd42be358488f5254b1..8d447e8fbaaa9bdf9ae867227f3b24b5
          void presentStorageAccessConfirmDialog(const WTF::String& requestingDomain, const WTF::String& currentDomain, CompletionHandler<void(bool)>&&);
          void requestStorageAccessConfirm(WebPageProxy&, WebFrameProxy*, const WebCore::RegistrableDomain& requestingDomain, const WebCore::RegistrableDomain& currentDomain, CompletionHandler<void(bool)>&&) final;
          void decidePolicyForGeolocationPermissionRequest(WebPageProxy&, WebFrameProxy&, const FrameInfoData&, Function<void(bool)>&) final;
-@@ -193,6 +194,7 @@ private:
+@@ -196,6 +197,7 @@ private:
          bool webViewRunJavaScriptAlertPanelWithMessageInitiatedByFrameCompletionHandler : 1;
          bool webViewRunJavaScriptConfirmPanelWithMessageInitiatedByFrameCompletionHandler : 1;
          bool webViewRunJavaScriptTextInputPanelWithPromptDefaultTextInitiatedByFrameCompletionHandler : 1;
@@ -12097,10 +12060,10 @@ index 3d1e64c215a223fb7168ffd42be358488f5254b1..8d447e8fbaaa9bdf9ae867227f3b24b5
          bool webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler : 1;
          bool webViewRequestGeolocationPermissionForFrameDecisionHandler : 1;
 diff --git a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
-index f9d63139c03f815a6e700e9b3cc9193a7d4ed64c..38d72f827d35078dcc10eacaa3fcce5416edd6fe 100644
+index 849d81134ff8d89a4c475e64f8b80eb6ae088529..c6055f2ecf1638e57cdd967a037586e651573179 100644
 --- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
-@@ -110,6 +110,7 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
+@@ -111,6 +111,7 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
      m_delegateMethods.webViewRunJavaScriptAlertPanelWithMessageInitiatedByFrameCompletionHandler = [delegate respondsToSelector:@selector(webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:)];
      m_delegateMethods.webViewRunJavaScriptConfirmPanelWithMessageInitiatedByFrameCompletionHandler = [delegate respondsToSelector:@selector(webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:)];
      m_delegateMethods.webViewRunJavaScriptTextInputPanelWithPromptDefaultTextInitiatedByFrameCompletionHandler = [delegate respondsToSelector:@selector(webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:)];
@@ -12108,7 +12071,7 @@ index f9d63139c03f815a6e700e9b3cc9193a7d4ed64c..38d72f827d35078dcc10eacaa3fcce54
      m_delegateMethods.webViewRequestStorageAccessPanelUnderFirstPartyCompletionHandler = [delegate respondsToSelector:@selector(_webView:requestStorageAccessPanelForDomain:underCurrentDomain:completionHandler:)];
      m_delegateMethods.webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler = [delegate respondsToSelector:@selector(_webView:runBeforeUnloadConfirmPanelWithMessage:initiatedByFrame:completionHandler:)];
      m_delegateMethods.webViewRequestGeolocationPermissionForOriginDecisionHandler = [delegate respondsToSelector:@selector(_webView:requestGeolocationPermissionForOrigin:initiatedByFrame:decisionHandler:)];
-@@ -384,6 +385,15 @@ void UIDelegate::UIClient::runJavaScriptPrompt(WebPageProxy& page, const WTF::St
+@@ -410,6 +411,15 @@ void UIDelegate::UIClient::runJavaScriptPrompt(WebPageProxy& page, const WTF::St
      }).get()];
  }
  
@@ -12125,7 +12088,7 @@ index f9d63139c03f815a6e700e9b3cc9193a7d4ed64c..38d72f827d35078dcc10eacaa3fcce54
  {
      if (!m_uiDelegate)
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
-index b0dd19a8fe284f48ce07e2da604612077619a0c3..451b5ab76b204246d0479627f44c357a9f57ca45 100644
+index 4dbf2815118c39b56ab900b668ae2f6ac818901e..2004b2c58598446c81800888e258d627df971508 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 @@ -37,6 +37,7 @@
@@ -12133,10 +12096,10 @@ index b0dd19a8fe284f48ce07e2da604612077619a0c3..451b5ab76b204246d0479627f44c357a
  #import "ModalContainerControlClassifier.h"
  #import "PageClient.h"
 +#import "PasteboardTypes.h"
+ #import "PlaybackSessionManagerProxy.h"
  #import "QuarantineSPI.h"
  #import "QuickLookThumbnailLoader.h"
- #import "SafeBrowsingSPI.h"
-@@ -236,9 +237,66 @@ bool WebPageProxy::scrollingUpdatesDisabledForTesting()
+@@ -238,9 +239,66 @@ bool WebPageProxy::scrollingUpdatesDisabledForTesting()
  
  void WebPageProxy::startDrag(const DragItem& dragItem, const ShareableBitmap::Handle& dragImageHandle)
  {
@@ -12204,10 +12167,10 @@ index b0dd19a8fe284f48ce07e2da604612077619a0c3..451b5ab76b204246d0479627f44c357a
  #if PLATFORM(IOS_FAMILY)
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-index cc5f6b0722c4061d53ff6405af79ef3d45b560f7..074c87276777c12b6e9a2611b02b7a02464f11b5 100644
+index 5696da38988527c7ae693b8fc71d6bb5f4ae8604..7446c2d0618a1e981898e60376a3393c38a29d44 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-@@ -396,7 +396,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
+@@ -398,7 +398,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
      auto screenProperties = WebCore::collectScreenProperties();
      parameters.screenProperties = WTFMove(screenProperties);
  #if PLATFORM(MAC)
@@ -12216,7 +12179,7 @@ index cc5f6b0722c4061d53ff6405af79ef3d45b560f7..074c87276777c12b6e9a2611b02b7a02
  #endif
      
  #if PLATFORM(IOS)
-@@ -697,8 +697,8 @@ void WebProcessPool::registerNotificationObservers()
+@@ -696,8 +696,8 @@ void WebProcessPool::registerNotificationObservers()
      }];
  
      m_scrollerStyleNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSPreferredScrollerStyleDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
@@ -12242,9 +12205,42 @@ index d64a7dba42d94db24efa8f60ae499a76423d85e9..4364cae8ec64acde543be9c8ec18175f
      void saveBackForwardSnapshotForCurrentItem();
      void saveBackForwardSnapshotForItem(WebBackForwardListItem&);
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
-index bec2ecbd2d849ab8535a1e8f96dca647e1b62631..42037cb1b4a10498430b8bd1faecf420c81fe11f 100644
+index bec2ecbd2d849ab8535a1e8f96dca647e1b62631..4d0e1e398d6b18bc24e92f7e3e83e4610083107a 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
+@@ -203,7 +203,7 @@ static RetainPtr<CocoaImageAnalyzerRequest> createImageAnalyzerRequest(CGImageRe
+     return request;
+ }
+ 
+-void WebViewImpl::requestTextRecognition(const URL& imageURL, const ShareableBitmap::Handle& imageData, const String& identifier, CompletionHandler<void(TextRecognitionResult&&)>&& completion)
++void WebViewImpl::requestTextRecognition(const URL& imageURL, const ShareableBitmap::Handle& imageData, const String& identifier, CompletionHandler<void(WebCore::TextRecognitionResult&&)>&& completion)
+ {
+     if (!isLiveTextAvailableAndEnabled()) {
+         completion({ });
+@@ -1770,7 +1770,7 @@ void WebViewImpl::showSafeBrowsingWarning(const SafeBrowsingWarning& warning, Co
+     WebCore::DiagnosticLoggingClient::ValueDictionary showedWarningDictionary;
+     showedWarningDictionary.set("source"_s, String("service"));
+ 
+-    m_page->logDiagnosticMessageWithValueDictionary("SafeBrowsing.ShowedWarning"_s, "Safari"_s, showedWarningDictionary, ShouldSample::No);
++    m_page->logDiagnosticMessageWithValueDictionary("SafeBrowsing.ShowedWarning"_s, "Safari"_s, showedWarningDictionary, WebCore::ShouldSample::No);
+ 
+     m_safeBrowsingWarning = adoptNS([[WKSafeBrowsingWarning alloc] initWithFrame:[m_view bounds] safeBrowsingWarning:warning completionHandler:[weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (auto&& result) mutable {
+         completionHandler(WTFMove(result));
+@@ -1796,12 +1796,12 @@ void WebViewImpl::showSafeBrowsingWarning(const SafeBrowsingWarning& warning, Co
+             else
+                 dictionary.set("action"_s, String("redirect to url"));
+ 
+-            weakThis->m_page->logDiagnosticMessageWithValueDictionary("SafeBrowsing.PerformedAction"_s, "Safari"_s, dictionary, ShouldSample::No);
++            weakThis->m_page->logDiagnosticMessageWithValueDictionary("SafeBrowsing.PerformedAction"_s, "Safari"_s, dictionary, WebCore::ShouldSample::No);
+             return;
+         }
+ 
+         dictionary.set("action"_s, String("go back"));
+-        weakThis->m_page->logDiagnosticMessageWithValueDictionary("SafeBrowsing.PerformedAction"_s, "Safari"_s, dictionary, ShouldSample::No);
++        weakThis->m_page->logDiagnosticMessageWithValueDictionary("SafeBrowsing.PerformedAction"_s, "Safari"_s, dictionary, WebCore::ShouldSample::No);
+ 
+         if (!navigatesFrame && weakThis->m_safeBrowsingWarning && !forMainFrameNavigation) {
+             weakThis->m_page->goBack();
 @@ -2644,6 +2644,11 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
          if (!m_colorSpace)
              m_colorSpace = [NSColorSpace sRGBColorSpace];
@@ -12252,7 +12248,7 @@ index bec2ecbd2d849ab8535a1e8f96dca647e1b62631..42037cb1b4a10498430b8bd1faecf420
 +    // Playwright begin
 +    // window.colorSpace is sometimes null on popup windows in headless mode
 +    if (!m_colorSpace)
-+        return DestinationColorSpace::SRGB();
++        return WebCore::DestinationColorSpace::SRGB();
 +    // Playwright end
  
      ASSERT(m_colorSpace);
@@ -12276,6 +12272,24 @@ index bec2ecbd2d849ab8535a1e8f96dca647e1b62631..42037cb1b4a10498430b8bd1faecf420
  RefPtr<ViewSnapshot> WebViewImpl::takeViewSnapshot()
  {
      NSWindow *window = [m_view window];
+@@ -5516,7 +5533,7 @@ void WebViewImpl::mouseMoved(NSEvent *event)
+     mouseMovedInternal(event);
+ }
+ 
+-static _WKRectEdge toWKRectEdge(RectEdges<bool> edges)
++static _WKRectEdge toWKRectEdge(WebCore::RectEdges<bool> edges)
+ {
+     _WKRectEdge result = _WKRectEdgeNone;
+ 
+@@ -5535,7 +5552,7 @@ static _WKRectEdge toWKRectEdge(RectEdges<bool> edges)
+     return result;
+ }
+ 
+-static RectEdges<bool> toRectEdges(_WKRectEdge edges)
++static WebCore::RectEdges<bool> toRectEdges(_WKRectEdge edges)
+ {
+     return {
+         edges & _WKRectEdgeTop,
 diff --git a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 index 8735b17ae6bd1e690d259021fc1933aa69eb54bb..2a9e51ef46b75dd4863f47c6d8fc1827fb76a7a8 100644
 --- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -15807,10 +15821,10 @@ index 7a14cfba15c103a2d4fe263fa49d25af3c396ec2..3ee0e154349661632799057c71f1d1f1
      BOOL result = ::CreateProcess(0, commandLine.data(), 0, 0, true, 0, 0, 0, &startupInfo, &processInformation);
  
 diff --git a/Source/WebKit/UIProcess/PageClient.h b/Source/WebKit/UIProcess/PageClient.h
-index 2e5f6073c7ed8eefe6cbf847318e8e4aed40382e..0c6327776cae234141a017f33d439977bb4a8969 100644
+index b2cbc5eb75a38e1019faf6cb2b4773de00540cf2..42448dd4e04cf497a6cf1aceaa82ae0e6d3b30cb 100644
 --- a/Source/WebKit/UIProcess/PageClient.h
 +++ b/Source/WebKit/UIProcess/PageClient.h
-@@ -324,6 +324,11 @@ public:
+@@ -325,6 +325,11 @@ public:
      virtual void selectionDidChange() = 0;
  #endif
  
@@ -16177,20 +16191,6 @@ index 630bf1170da176dcc65d659c1fdf7c05185910e5..ec12ef12dfc7e7c00ed69e2afb10367c
 +    virtual void hide() {}
  
      WebPageProxy* page() const { return m_page.get(); }
- 
-diff --git a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
-index 04f3227cd55c992a42cd96a3f25d697aed7965a2..f0d36935f47bab03ea2ec50b705092068ecd3efa 100644
---- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
-+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
-@@ -128,7 +128,8 @@ void WebGeolocationManagerProxy::startUpdating(IPC::Connection& connection, WebP
-     if (!wasUpdating) {
-         m_provider->setEnableHighAccuracy(*this, isHighAccuracyEnabled());
-         m_provider->startUpdating(*this);
--    } else if (m_lastPosition)
-+    }
-+    if (m_lastPosition)
-         connection.send(Messages::WebGeolocationManager::DidChangePosition(m_lastPosition.value()), 0);
- }
  
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp
 new file mode 100644
@@ -16854,7 +16854,7 @@ index 0000000000000000000000000000000000000000..48c9ccc420c1b4ae3259e1d5ba17fd8f
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6bd3afe67f 100644
+index 0ac37615e63177e426eb227461af475acbbf370f..d9ee751b09cd2cf2512f2883e8fa0eaa18e30a54 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
 @@ -248,6 +248,9 @@
@@ -16867,7 +16867,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  #include <WebCore/SelectionData.h>
  #endif
  
-@@ -619,6 +622,10 @@ WebPageProxy::~WebPageProxy()
+@@ -622,6 +625,10 @@ WebPageProxy::~WebPageProxy()
      if (m_preferences->mediaSessionCoordinatorEnabled())
          GroupActivitiesSessionNotifier::sharedNotifier().removeWebPage(*this);
  #endif
@@ -16878,7 +16878,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  }
  
  void WebPageProxy::addAllMessageReceivers()
-@@ -1020,6 +1027,7 @@ void WebPageProxy::finishAttachingToWebProcess(ProcessLaunchReason reason)
+@@ -1023,6 +1030,7 @@ void WebPageProxy::finishAttachingToWebProcess(ProcessLaunchReason reason)
      m_pageLoadState.didSwapWebProcesses();
      if (reason != ProcessLaunchReason::InitialProcess)
          m_drawingArea->waitForBackingStoreUpdateOnNextPaint();
@@ -16886,7 +16886,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  }
  
  void WebPageProxy::didAttachToRunningProcess()
-@@ -1373,6 +1381,21 @@ WebProcessProxy& WebPageProxy::ensureRunningProcess()
+@@ -1376,6 +1384,21 @@ WebProcessProxy& WebPageProxy::ensureRunningProcess()
      return m_process;
  }
  
@@ -16908,7 +16908,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  RefPtr<API::Navigation> WebPageProxy::loadRequest(ResourceRequest&& request, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, API::Object* userData)
  {
      if (m_isClosed)
-@@ -1921,6 +1944,31 @@ void WebPageProxy::setControlledByAutomation(bool controlled)
+@@ -1924,6 +1947,31 @@ void WebPageProxy::setControlledByAutomation(bool controlled)
      websiteDataStore().networkProcess().send(Messages::NetworkProcess::SetSessionIsControlledByAutomation(m_websiteDataStore->sessionID(), m_controlledByAutomation), 0);
  }
  
@@ -16940,7 +16940,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  void WebPageProxy::createInspectorTarget(const String& targetId, Inspector::InspectorTargetType type)
  {
      MESSAGE_CHECK(m_process, !targetId.isEmpty());
-@@ -2111,6 +2159,25 @@ void WebPageProxy::updateActivityState(OptionSet<ActivityState::Flag> flagsToUpd
+@@ -2114,6 +2162,25 @@ void WebPageProxy::updateActivityState(OptionSet<ActivityState::Flag> flagsToUpd
  {
      bool wasVisible = isViewVisible();
      m_activityState.remove(flagsToUpdate);
@@ -16966,7 +16966,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
      if (flagsToUpdate & ActivityState::IsFocused && pageClient().isViewFocused())
          m_activityState.add(ActivityState::IsFocused);
      if (flagsToUpdate & ActivityState::WindowIsActive && pageClient().isViewWindowActive())
-@@ -2694,6 +2761,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
+@@ -2697,6 +2764,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
  {
      if (!hasRunningProcess())
          return;
@@ -16975,7 +16975,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  #if PLATFORM(GTK)
      UNUSED_PARAM(dragStorageName);
      UNUSED_PARAM(sandboxExtensionHandle);
-@@ -2704,6 +2773,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
+@@ -2707,6 +2776,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
          m_process->assumeReadAccessToBaseURL(*this, url);
  
      ASSERT(dragData.platformData());
@@ -16984,7 +16984,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
      send(Messages::WebPage::PerformDragControllerAction(action, dragData.clientPosition(), dragData.globalPosition(), dragData.draggingSourceOperationMask(), *dragData.platformData(), dragData.flags()));
  #else
      send(Messages::WebPage::PerformDragControllerAction(action, dragData, sandboxExtensionHandle, sandboxExtensionsForUpload));
-@@ -2719,18 +2790,41 @@ void WebPageProxy::didPerformDragControllerAction(std::optional<WebCore::DragOpe
+@@ -2722,18 +2793,41 @@ void WebPageProxy::didPerformDragControllerAction(std::optional<WebCore::DragOpe
      m_currentDragCaretEditableElementRect = editableElementRect;
      setDragCaretRect(insertionRect);
      pageClient().didPerformDragControllerAction();
@@ -17029,7 +17029,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<WebCore::DragOperation> dragOperationMask)
  {
      if (!hasRunningProcess())
-@@ -2739,6 +2833,24 @@ void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& glo
+@@ -2742,6 +2836,24 @@ void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& glo
      setDragCaretRect({ });
  }
  
@@ -17054,7 +17054,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  void WebPageProxy::didPerformDragOperation(bool handled)
  {
      pageClient().didPerformDragOperation(handled);
-@@ -2751,8 +2863,18 @@ void WebPageProxy::didStartDrag()
+@@ -2754,8 +2866,18 @@ void WebPageProxy::didStartDrag()
  
      discardQueuedMouseEvents();
      send(Messages::WebPage::DidStartDrag());
@@ -17074,7 +17074,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  void WebPageProxy::dragCancelled()
  {
      if (hasRunningProcess())
-@@ -2857,16 +2979,38 @@ void WebPageProxy::processNextQueuedMouseEvent()
+@@ -2860,16 +2982,38 @@ void WebPageProxy::processNextQueuedMouseEvent()
          m_process->startResponsivenessTimer();
      }
  
@@ -17120,7 +17120,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  }
  
  void WebPageProxy::doAfterProcessingAllPendingMouseEvents(WTF::Function<void ()>&& action)
-@@ -3030,7 +3174,7 @@ static TrackingType mergeTrackingTypes(TrackingType a, TrackingType b)
+@@ -3033,7 +3177,7 @@ static TrackingType mergeTrackingTypes(TrackingType a, TrackingType b)
  
  void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent)
  {
@@ -17129,7 +17129,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
      const EventNames& names = eventNames();
      for (auto& touchPoint : touchStartEvent.touchPoints()) {
          IntPoint location = touchPoint.location();
-@@ -3063,7 +3207,7 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
+@@ -3066,7 +3210,7 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
      m_touchAndPointerEventTracking.touchStartTracking = TrackingType::Synchronous;
      m_touchAndPointerEventTracking.touchMoveTracking = TrackingType::Synchronous;
      m_touchAndPointerEventTracking.touchEndTracking = TrackingType::Synchronous;
@@ -17138,7 +17138,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  }
  
  TrackingType WebPageProxy::touchEventTrackingType(const WebTouchEvent& touchStartEvent) const
-@@ -3452,6 +3596,8 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
+@@ -3455,6 +3599,8 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
          policyAction = PolicyAction::Download;
  
      if (policyAction != PolicyAction::Use || !frame.isMainFrame() || !navigation) {
@@ -17147,7 +17147,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
          receivedPolicyDecision(policyAction, navigation, WTFMove(policies), WTFMove(navigationAction), WTFMove(sender));
          return;
      }
-@@ -3520,6 +3666,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
+@@ -3523,6 +3669,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
  
  void WebPageProxy::receivedPolicyDecision(PolicyAction action, API::Navigation* navigation, RefPtr<API::WebsitePolicies>&& websitePolicies, std::variant<Ref<API::NavigationResponse>, Ref<API::NavigationAction>>&& navigationActionOrResponse, Ref<PolicyDecisionSender>&& sender, std::optional<SandboxExtension::Handle> sandboxExtensionHandle, WillContinueLoadInNewProcess willContinueLoadInNewProcess)
  {
@@ -17155,7 +17155,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
      if (!hasRunningProcess()) {
          sender->send(PolicyDecision { sender->identifier(), isNavigatingToAppBoundDomain(), PolicyAction::Ignore, 0, std::nullopt, std::nullopt });
          return;
-@@ -4256,6 +4403,11 @@ void WebPageProxy::pageScaleFactorDidChange(double scaleFactor)
+@@ -4257,6 +4404,11 @@ void WebPageProxy::pageScaleFactorDidChange(double scaleFactor)
      m_pageScaleFactor = scaleFactor;
  }
  
@@ -17167,7 +17167,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  void WebPageProxy::pluginScaleFactorDidChange(double pluginScaleFactor)
  {
      m_pluginScaleFactor = pluginScaleFactor;
-@@ -4638,6 +4790,7 @@ void WebPageProxy::didDestroyNavigation(uint64_t navigationID)
+@@ -4639,6 +4791,7 @@ void WebPageProxy::didDestroyNavigation(uint64_t navigationID)
          return;
  
      m_navigationState->didDestroyNavigation(navigationID);
@@ -17175,7 +17175,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  }
  
  void WebPageProxy::didStartProvisionalLoadForFrame(FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, uint64_t navigationID, URL&& url, URL&& unreachableURL, const UserData& userData)
-@@ -4862,6 +5015,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
+@@ -4863,6 +5016,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
  
      m_failingProvisionalLoadURL = { };
  
@@ -17184,7 +17184,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
      // If the provisional page's load fails then we destroy the provisional page.
      if (m_provisionalPage && m_provisionalPage->mainFrame() == &frame && willContinueLoading == WillContinueLoading::No)
          m_provisionalPage = nullptr;
-@@ -5333,7 +5488,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
+@@ -5334,7 +5489,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
      NavigationActionData&& navigationActionData, FrameInfoData&& originatingFrameInfo, std::optional<WebPageProxyIdentifier> originatingPageID, const WebCore::ResourceRequest& originalRequest, WebCore::ResourceRequest&& request,
      IPC::FormDataReference&& requestBody, WebCore::ResourceResponse&& redirectResponse, const UserData& userData, uint64_t listenerID)
  {
@@ -17200,7 +17200,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  }
  
  void WebPageProxy::decidePolicyForNavigationActionAsyncShared(Ref<WebProcessProxy>&& process, PageIdentifier webPageID, FrameIdentifier frameID, FrameInfoData&& frameInfo,
-@@ -5899,6 +6061,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -5903,6 +6065,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
      if (originatingPage)
          openerAppInitiatedState = originatingPage->lastNavigationWasAppInitiated();
  
@@ -17208,7 +17208,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
      auto completionHandler = [this, protectedThis = Ref { *this }, mainFrameURL, request, reply = WTFMove(reply), privateClickMeasurement = navigationActionData.privateClickMeasurement, openerAppInitiatedState = WTFMove(openerAppInitiatedState)] (RefPtr<WebPageProxy> newPage) mutable {
          if (!newPage) {
              reply(std::nullopt, std::nullopt);
-@@ -5945,6 +6108,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -5949,6 +6112,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
  void WebPageProxy::showPage()
  {
      m_uiClient->showPage(this);
@@ -17216,7 +17216,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  }
  
  void WebPageProxy::exitFullscreenImmediately()
-@@ -5980,6 +6144,10 @@ void WebPageProxy::closePage()
+@@ -6006,6 +6170,10 @@ void WebPageProxy::closePage()
      if (isClosed())
          return;
  
@@ -17227,7 +17227,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
      WEBPAGEPROXY_RELEASE_LOG(Process, "closePage:");
      pageClient().clearAllEditCommands();
      m_uiClient->close(this);
-@@ -6016,6 +6184,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
+@@ -6042,6 +6210,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
      }
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
@@ -17236,7 +17236,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
          page.m_uiClient->runJavaScriptAlert(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)]() mutable {
              reply();
              completion();
-@@ -6037,6 +6207,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
+@@ -6063,6 +6233,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17245,7 +17245,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptConfirm(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](bool result) mutable {
-@@ -6060,6 +6232,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
+@@ -6086,6 +6258,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17254,7 +17254,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply), defaultValue](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptPrompt(page, message, defaultValue, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](auto& result) mutable {
-@@ -6187,6 +6361,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
+@@ -6213,6 +6387,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
              return;
          }
      }
@@ -17263,7 +17263,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
  
      // Since runBeforeUnloadConfirmPanel() can spin a nested run loop we need to turn off the responsiveness timer and the tryClose timer.
      m_process->stopResponsivenessTimer();
-@@ -7426,6 +7602,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7459,6 +7635,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->mouseEventsFlushedForPage(*this);
              didFinishProcessingAllPendingMouseEvents();
@@ -17272,7 +17272,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
          }
          break;
      }
-@@ -7440,10 +7618,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7473,10 +7651,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              pageClient().wheelEventWasNotHandledByWebCore(oldestProcessedEvent);
          }
  
@@ -17289,7 +17289,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
          break;
      }
  
-@@ -7452,7 +7633,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7485,7 +7666,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
      case WebEvent::RawKeyDown:
      case WebEvent::Char: {
          LOG(KeyHandling, "WebPageProxy::didReceiveEvent: %s (queue empty %d)", webKeyboardEventTypeString(type), m_keyEventQueue.isEmpty());
@@ -17297,7 +17297,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
          MESSAGE_CHECK(m_process, !m_keyEventQueue.isEmpty());
          auto event = m_keyEventQueue.takeFirst();
          MESSAGE_CHECK(m_process, type == event.type());
-@@ -7471,7 +7651,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7504,7 +7684,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          // The call to doneWithKeyEvent may close this WebPage.
          // Protect against this being destroyed.
          Ref<WebPageProxy> protect(*this);
@@ -17305,7 +17305,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
          pageClient().doneWithKeyEvent(event, handled);
          if (!handled)
              m_uiClient->didNotHandleKeyEvent(this, event);
-@@ -7480,6 +7659,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7513,6 +7692,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          if (!canProcessMoreKeyEvents) {
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->keyboardEventsFlushedForPage(*this);
@@ -17313,7 +17313,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
          }
          break;
      }
-@@ -7834,7 +8014,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
+@@ -7867,7 +8047,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
  {
      WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "dispatchProcessDidTerminate: reason=%{public}s", processTerminationReasonToString(reason));
  
@@ -17325,7 +17325,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
      if (m_loaderClient)
          handledByClient = reason != ProcessTerminationReason::RequestedByClient && m_loaderClient->processDidCrash(*this);
      else
-@@ -8226,6 +8409,7 @@ static Span<const ASCIILiteral> mediaRelatedIOKitClasses()
+@@ -8249,6 +8432,7 @@ static Span<const ASCIILiteral> mediaRelatedIOKitClasses()
  
  WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& process, DrawingAreaProxy& drawingArea, RefPtr<API::WebsitePolicies>&& websitePolicies)
  {
@@ -17333,16 +17333,16 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
      WebPageCreationParameters parameters;
  
      parameters.processDisplayName = configuration().processDisplayName();
-@@ -8424,6 +8608,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
-     parameters.shouldRelaxThirdPartyCookieBlocking = m_configuration->shouldRelaxThirdPartyCookieBlocking();
-     parameters.canUseCredentialStorage = m_canUseCredentialStorage;
+@@ -8449,6 +8633,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
+ 
+     parameters.httpsUpgradeEnabled = preferences().upgradeKnownHostsToHTTPSEnabled() ? m_configuration->httpsUpgradeEnabled() : false;
  
 +    parameters.shouldPauseInInspectorWhenShown = m_inspectorController->shouldPauseLoading();
 +
- #if PLATFORM(GTK)
-     parameters.gtkSettings = GtkSettingsManager::singleton().settingsState();
- #endif
-@@ -8505,6 +8691,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
+ #if PLATFORM(IOS)
+     // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
+     parameters.allowsDeprecatedSynchronousXMLHttpRequestDuringUnload = allowsDeprecatedSynchronousXMLHttpRequestDuringUnload();
+@@ -8517,6 +8703,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
  
  void WebPageProxy::didReceiveAuthenticationChallengeProxy(Ref<AuthenticationChallengeProxy>&& authenticationChallenge, NegotiatedLegacyTLS negotiatedLegacyTLS)
  {
@@ -17357,7 +17357,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
      if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes) {
          m_navigationClient->shouldAllowLegacyTLS(*this, authenticationChallenge.get(), [this, protectedThis = Ref { *this }, authenticationChallenge] (bool shouldAllowLegacyTLS) {
              if (shouldAllowLegacyTLS)
-@@ -8598,6 +8792,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
+@@ -8610,6 +8804,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
              request->deny();
      };
  
@@ -17374,7 +17374,7 @@ index e49935c325f69f343440caa0add7bffe1c005282..37aa17314a303faf69f2114fe7021f6b
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492982b8f2b 100644
+index afe8146993e4eda84a23013cf7c9ab558504204f..500dfbcf4db084f6c9572ef46da271a9c3517000 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -39,6 +39,7 @@
@@ -17397,7 +17397,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
  #endif
  
  #if ENABLE(TOUCH_EVENTS)
-@@ -170,6 +174,14 @@
+@@ -171,6 +175,14 @@
  #include "ArgumentCodersGtk.h"
  #endif
  
@@ -17412,7 +17412,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
  #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
  #include <WebCore/MediaPlaybackTargetPicker.h>
  #include <WebCore/WebMediaSessionManagerClient.h>
-@@ -247,6 +259,7 @@ class AuthenticationChallenge;
+@@ -248,6 +260,7 @@ class AuthenticationChallenge;
  class CertificateInfo;
  class Cursor;
  class DragData;
@@ -17420,7 +17420,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
  class FloatRect;
  class FontAttributeChanges;
  class FontChanges;
-@@ -254,7 +267,6 @@ class GraphicsLayer;
+@@ -255,7 +268,6 @@ class GraphicsLayer;
  class IntSize;
  class ProtectionSpace;
  class RunLoopObserver;
@@ -17428,7 +17428,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
  class SharedBuffer;
  class SpeechRecognitionRequest;
  class TextIndicator;
-@@ -542,6 +554,8 @@ public:
+@@ -545,6 +557,8 @@ public:
      void setControlledByAutomation(bool);
  
      WebPageInspectorController& inspectorController() { return *m_inspectorController; }
@@ -17437,7 +17437,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
  
  #if PLATFORM(IOS_FAMILY)
      void showInspectorIndication();
-@@ -646,6 +660,11 @@ public:
+@@ -650,6 +664,11 @@ public:
  
      void setPageLoadStateObserver(std::unique_ptr<PageLoadState::Observer>&&);
  
@@ -17449,7 +17449,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
      void initializeWebPage();
      void setDrawingArea(std::unique_ptr<DrawingAreaProxy>&&);
  
-@@ -673,6 +692,7 @@ public:
+@@ -677,6 +696,7 @@ public:
      void closePage();
  
      void addPlatformLoadParameters(WebProcessProxy&, LoadParameters&);
@@ -17457,7 +17457,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
      RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadData(const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
-@@ -1190,6 +1210,7 @@ public:
+@@ -1196,6 +1216,7 @@ public:
  #endif
  
      void pageScaleFactorDidChange(double);
@@ -17465,7 +17465,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
      void pluginScaleFactorDidChange(double);
      void pluginZoomFactorDidChange(double);
  
-@@ -1275,14 +1296,20 @@ public:
+@@ -1281,14 +1302,20 @@ public:
      void didStartDrag();
      void dragCancelled();
      void setDragCaretRect(const WebCore::IntRect&);
@@ -17487,7 +17487,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
  #endif
  
      void processDidBecomeUnresponsive();
-@@ -1529,6 +1556,8 @@ public:
+@@ -1535,6 +1562,8 @@ public:
  
  #if PLATFORM(COCOA) || PLATFORM(GTK)
      RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
@@ -17496,7 +17496,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
  #endif
  
  #if ENABLE(WEB_CRYPTO)
-@@ -2651,6 +2680,7 @@ private:
+@@ -2677,6 +2706,7 @@ private:
      String m_overrideContentSecurityPolicy;
  
      RefPtr<WebInspectorUIProxy> m_inspector;
@@ -17504,7 +17504,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
  
  #if PLATFORM(COCOA)
      WeakObjCPtr<WKWebView> m_cocoaView;
-@@ -2915,6 +2945,20 @@ private:
+@@ -2941,6 +2971,20 @@ private:
      unsigned m_currentDragNumberOfFilesToBeAccepted { 0 };
      WebCore::IntRect m_currentDragCaretRect;
      WebCore::IntRect m_currentDragCaretEditableElementRect;
@@ -17525,7 +17525,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
  #endif
  
      PageLoadState m_pageLoadState;
-@@ -3124,6 +3168,9 @@ private:
+@@ -3150,6 +3194,9 @@ private:
          RefPtr<API::Object> messageBody;
      };
      Vector<InjectedBundleMessage> m_pendingInjectedBundleMessages;
@@ -17536,7 +17536,7 @@ index 507eac8a9652ae0fe0a13b226deff882dec38f31..93e17bebb8f02a6cd14e45ab2934d492
  #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
      std::unique_ptr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.messages.in b/Source/WebKit/UIProcess/WebPageProxy.messages.in
-index 15cd0e3d5968bc6617ea5c4a28f017a114dab95b..c3d27602c67eb6740180dd5c679e42057947999e 100644
+index 3d68df99c7e4f43a9bfe1a15daf0c6fc62535f33..2223848b2848fab6d9c1a29372c4dca71c494eda 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
 +++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
 @@ -29,6 +29,7 @@ messages -> WebPageProxy {
@@ -17571,10 +17571,10 @@ index 15cd0e3d5968bc6617ea5c4a28f017a114dab95b..c3d27602c67eb6740180dd5c679e4205
      DidPerformDragOperation(bool handled)
  #endif
 diff --git a/Source/WebKit/UIProcess/WebProcessPool.cpp b/Source/WebKit/UIProcess/WebProcessPool.cpp
-index afc23ee53f12842193d2eaef20f25962eed73fa2..a31a99922b3f8076a3825eeeb3d8965adde790be 100644
+index fa1742cf32da99527323dfc7c8bf0a79063041fe..7154d2235be8b7aab6fae2a0e29f7945ba384ab4 100644
 --- a/Source/WebKit/UIProcess/WebProcessPool.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
-@@ -539,6 +539,14 @@ void WebProcessPool::establishServiceWorkerContextConnectionToNetworkProcess(Net
+@@ -536,6 +536,14 @@ void WebProcessPool::establishServiceWorkerContextConnectionToNetworkProcess(Reg
  
      // Arbitrarily choose the first process pool to host the service worker process.
      auto* processPool = processPools()[0];
@@ -17589,7 +17589,7 @@ index afc23ee53f12842193d2eaef20f25962eed73fa2..a31a99922b3f8076a3825eeeb3d8965a
      ASSERT(processPool);
  
      WebProcessProxy* serviceWorkerProcessProxy { nullptr };
-@@ -811,8 +819,12 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
+@@ -859,8 +867,12 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
  #endif
  
      parameters.cacheModel = LegacyGlobalSettings::singleton().cacheModel();
@@ -17605,10 +17605,10 @@ index afc23ee53f12842193d2eaef20f25962eed73fa2..a31a99922b3f8076a3825eeeb3d8965a
      parameters.urlSchemesRegisteredAsEmptyDocument = copyToVector(m_schemesToRegisterAsEmptyDocument);
      parameters.urlSchemesRegisteredAsSecure = copyToVector(LegacyGlobalSettings::singleton().schemesToRegisterAsSecure());
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.cpp b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-index 057d4992418a0043d84c59d7b6e52f9e02658a71..2329d11783b07a426b39f04e1544832e8db01c93 100644
+index b12860df510bc4e3dfbb7e3fc920b5d042b84321..6224fedca93ef7820165161fcdc25d4833f010af 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-@@ -143,6 +143,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
+@@ -146,6 +146,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
      return map;
  }
  
@@ -17621,10 +17621,10 @@ index 057d4992418a0043d84c59d7b6e52f9e02658a71..2329d11783b07a426b39f04e1544832e
  {
      return allProcesses().get(identifier);
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.h b/Source/WebKit/UIProcess/WebProcessProxy.h
-index f8b795b1d343535e8092e01dbab379af33461dbe..cb4bf4fdab5aeced74e054cb81636911dbd839a7 100644
+index 25ac75c5fbf877a0901d935f47deb77773857eee..8bb6e9b2e5d26a75ebb13b147d29bb6c765ffe97 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.h
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.h
-@@ -143,6 +143,7 @@ public:
+@@ -144,6 +144,7 @@ public:
      ~WebProcessProxy();
  
      static void forWebPagesWithOrigin(PAL::SessionID, const WebCore::SecurityOriginData&, const Function<void(WebPageProxy&)>&);
@@ -17633,10 +17633,10 @@ index f8b795b1d343535e8092e01dbab379af33461dbe..cb4bf4fdab5aeced74e054cb81636911
      WebConnection* webConnection() const { return m_webConnection.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-index 08cecfebfe0de44b1f5a4b5011405e1fd81509fe..6566b59b11756c7e1eee5f379e14e5880a30e3a4 100644
+index 9ef14a5e8f64d739f4cd331608178ea051126ef0..5fc3f02a4cfea395c9d1e0bfcccd36d8c4ee51e7 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-@@ -1981,6 +1981,17 @@ void WebsiteDataStore::renameOriginInWebsiteData(URL&& oldName, URL&& newName, O
+@@ -1983,6 +1983,17 @@ void WebsiteDataStore::renameOriginInWebsiteData(URL&& oldName, URL&& newName, O
      networkProcess().renameOriginInWebsiteData(m_sessionID, oldName, newName, dataTypes, WTFMove(completionHandler));
  }
  
@@ -17655,10 +17655,10 @@ index 08cecfebfe0de44b1f5a4b5011405e1fd81509fe..6566b59b11756c7e1eee5f379e14e588
  void WebsiteDataStore::hasAppBoundSession(CompletionHandler<void(bool)>&& completionHandler) const
  {
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
-index 6bc69369c33832869dea1f5daa50e79faa6e7bf9..3da31804209b64b42941c951e48986377f09cbc3 100644
+index 46af0ef59ebca120bcce8be9e2a4e3882c5bd504..50324d159a0309e7b1ece3460d9442198042b904 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
-@@ -88,6 +88,7 @@ class SecKeyProxyStore;
+@@ -89,6 +89,7 @@ class SecKeyProxyStore;
  class DeviceIdHashSaltStorage;
  class NetworkProcessProxy;
  class SOAuthorizationCoordinator;
@@ -17666,7 +17666,7 @@ index 6bc69369c33832869dea1f5daa50e79faa6e7bf9..3da31804209b64b42941c951e4898637
  class VirtualAuthenticatorManager;
  class WebPageProxy;
  class WebProcessPool;
-@@ -97,6 +98,7 @@ enum class CacheModel : uint8_t;
+@@ -98,6 +99,7 @@ enum class CacheModel : uint8_t;
  enum class WebsiteDataFetchOption : uint8_t;
  enum class WebsiteDataType : uint32_t;
  
@@ -17674,7 +17674,7 @@ index 6bc69369c33832869dea1f5daa50e79faa6e7bf9..3da31804209b64b42941c951e4898637
  struct NetworkProcessConnectionInfo;
  struct WebsiteDataRecord;
  struct WebsiteDataStoreParameters;
-@@ -107,6 +109,14 @@ enum class StorageAccessStatus : uint8_t;
+@@ -108,6 +110,14 @@ enum class StorageAccessStatus : uint8_t;
  enum class StorageAccessPromptStatus;
  #endif
  
@@ -17689,7 +17689,7 @@ index 6bc69369c33832869dea1f5daa50e79faa6e7bf9..3da31804209b64b42941c951e4898637
  class WebsiteDataStore : public API::ObjectImpl<API::Object::Type::WebsiteDataStore>, public Identified<WebsiteDataStore>, public CanMakeWeakPtr<WebsiteDataStore>  {
  public:
      static Ref<WebsiteDataStore> defaultDataStore();
-@@ -286,11 +296,13 @@ public:
+@@ -287,11 +297,13 @@ public:
      const WebCore::CurlProxySettings& networkProxySettings() const { return m_proxySettings; }
  #endif
  
@@ -17704,9 +17704,9 @@ index 6bc69369c33832869dea1f5daa50e79faa6e7bf9..3da31804209b64b42941c951e4898637
      void setNetworkProxySettings(WebCore::SoupNetworkProxySettings&&);
      const WebCore::SoupNetworkProxySettings& networkProxySettings() const { return m_networkProxySettings; }
      void setCookiePersistentStorage(const String&, SoupCookiePersistentStorageType);
-@@ -351,6 +363,14 @@ public:
-     static WTF::String defaultJavaScriptConfigurationDirectory();
+@@ -353,6 +365,14 @@ public:
      static bool http3Enabled();
+     static constexpr uint64_t defaultPerOriginQuota() { return 1000 * MB; }
  
 +    void setLanguagesForAutomation(Vector<String>&&);
 +    Vector<String>& languagesForAutomation() { return m_languagesForAutomation; };
@@ -17719,7 +17719,7 @@ index 6bc69369c33832869dea1f5daa50e79faa6e7bf9..3da31804209b64b42941c951e4898637
      void resetQuota(CompletionHandler<void()>&&);
      void clearStorage(CompletionHandler<void()>&&);
  
-@@ -434,9 +454,11 @@ private:
+@@ -441,9 +461,11 @@ private:
      WebCore::CurlProxySettings m_proxySettings;
  #endif
  
@@ -17732,7 +17732,7 @@ index 6bc69369c33832869dea1f5daa50e79faa6e7bf9..3da31804209b64b42941c951e4898637
      WebCore::SoupNetworkProxySettings m_networkProxySettings;
      String m_cookiePersistentStoragePath;
      SoupCookiePersistentStorageType m_cookiePersistentStorageType { SoupCookiePersistentStorageType::SQLite };
-@@ -464,6 +486,11 @@ private:
+@@ -471,6 +493,11 @@ private:
      RefPtr<API::HTTPCookieStore> m_cookieStore;
      RefPtr<NetworkProcessProxy> m_networkProcess;
  
@@ -18364,7 +18364,7 @@ index 0000000000000000000000000000000000000000..d0f9827544994e450e24e3f7a427c35e
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
-index 0ec2088fabdf470899fd0359af5cb97e68d5f4a2..8aa97e9356a933c47e639b918e7dc702f91b91f7 100644
+index 2b5f51c2d807cdf7e6ee5957d66f3a71fd82c2da..e242207d97bcb58b1d329bf29c6387e525f28193 100644
 --- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 +++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 @@ -437,6 +437,8 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
@@ -18719,11 +18719,23 @@ index 756184af6cd9946a5f947df90dd9e6bfb44e0e56..8f55df003e3bc7c19eafdbb966ae669d
      return m_impl->windowIsFrontWindowUnderMouse(event.nativeEvent());
  }
  
+diff --git a/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.h b/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.h
+index 8bd4f54abda3caf6e381828cd4af21b0d0728daf..11bb60cd80e8d52e8d9289e7b5162575c899869b 100644
+--- a/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.h
++++ b/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.h
+@@ -26,6 +26,7 @@
+ #if ENABLE(SERVICE_CONTROLS)
+ 
+ #import <wtf/RetainPtr.h>
++#import <wtf/text/WTFString.h>
+ 
+ namespace WebKit {
+ class WebContextMenuProxyMac;
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
-index 34e2d00746ebb079719becbe781f5bc6cea1d480..bf496a6327b962f8f40c207c9e2023d2152aded1 100644
+index 31bc0797a1b086b9342e5449e48cf5b3050464eb..450b6acf92b31cb40c404e3a8553e263da23bf84 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
-@@ -70,6 +70,7 @@ private:
+@@ -71,6 +71,7 @@ private:
      void show() override;
      void showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&&) override;
      void useContextMenuItems(Vector<Ref<WebContextMenuItem>>&&) override;
@@ -18732,10 +18744,10 @@ index 34e2d00746ebb079719becbe781f5bc6cea1d480..bf496a6327b962f8f40c207c9e2023d2
      void getContextMenuItem(const WebContextMenuItemData&, CompletionHandler<void(NSMenuItem *)>&&);
      void getContextMenuFromItems(const Vector<WebContextMenuItemData>&, CompletionHandler<void(NSMenu *)>&&);
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-index e1f02a70963c950a080d2ccc6dce136c2fd1c54c..e2a033a88ea44fe1d007d9b33feaf945c34ee6ba 100644
+index e12f9ce3f0f3a4b2a5d00515dca3914b6062d9ae..9727f2c8bc782ec2d143d726052a04d9644f145e 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-@@ -370,6 +370,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
+@@ -429,6 +429,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
  }
  #endif
  
@@ -19688,11 +19700,24 @@ index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705e
 +}
 + 
 +} // namespace WebKit
+diff --git a/Source/WebKit/UnifiedSources-output.xcfilelist b/Source/WebKit/UnifiedSources-output.xcfilelist
+index 62c22ee2bc73782bd451b507857075e36a6d8f10..cf013bbd6e753f87ff563e2302788c6fbfe745ad 100644
+--- a/Source/WebKit/UnifiedSources-output.xcfilelist
++++ b/Source/WebKit/UnifiedSources-output.xcfilelist
+@@ -28,6 +28,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource119.cpp
+ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource12-mm.mm
+ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource12.cpp
+ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource120.cpp
++$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource121.cpp
++$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource122.cpp
+ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource13-mm.mm
+ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource13.cpp
+ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource14-mm.mm
 diff --git a/Source/WebKit/WebKit.xcodeproj/project.pbxproj b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce23464b44b 100644
+index 179b43f11005c87d34ae4ecfa12f0320a55a8b53..9c4c65619e992aa2a09b5cb9f173bf75543f6c73 100644
 --- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 +++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-@@ -1242,6 +1242,7 @@
+@@ -1251,6 +1251,7 @@
  		5CABDC8722C40FED001EDE8E /* APIMessageListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CABDC8322C40FA7001EDE8E /* APIMessageListener.h */; };
  		5CADDE05215046BD0067D309 /* WKWebProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C74300E21500492004BFA17 /* WKWebProcess.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		5CAECB6627465AE400AB78D0 /* UnifiedSource115.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */; };
@@ -19700,7 +19725,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  		5CAF7AA726F93AB00003F19E /* adattributiond.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAF7AA526F93A950003F19E /* adattributiond.cpp */; };
  		5CAFDE452130846300B1F7E1 /* _WKInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE422130843500B1F7E1 /* _WKInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		5CAFDE472130846A00B1F7E1 /* _WKInspectorInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE442130843600B1F7E1 /* _WKInspectorInternal.h */; };
-@@ -1937,6 +1938,18 @@
+@@ -1953,6 +1954,18 @@
  		DF0C5F28252ECB8E00D921DB /* WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F24252ECB8D00D921DB /* WKDownload.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2A252ECB8E00D921DB /* WKDownloadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2B252ED44000D921DB /* WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */; };
@@ -19719,7 +19744,16 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  		DF462E0F23F22F5500EFF35F /* WKHTTPCookieStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */; };
-@@ -2007,6 +2020,9 @@
+@@ -2010,6 +2023,8 @@
+ 		E5BEF6822130C48000F31111 /* WebDataListSuggestionsDropdownIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E5BEF6802130C47F00F31111 /* WebDataListSuggestionsDropdownIOS.h */; };
+ 		E5CB07DC20E1678F0022C183 /* WKFormColorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */; };
+ 		E5CBA76427A318E100DF7858 /* UnifiedSource120.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */; };
++		E5CBA77427A318E100DF7858 /* UnifiedSource121.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76F27A3187800DF7858 /* UnifiedSource121.cpp */; };
++		E5CBA78427A318E100DF7858 /* UnifiedSource122.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA77F27A3187800DF7858 /* UnifiedSource122.cpp */; };
+ 		E5CBA76527A318E100DF7858 /* UnifiedSource118.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */; };
+ 		E5CBA76627A318E100DF7858 /* UnifiedSource116.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76327A3187B00DF7858 /* UnifiedSource116.cpp */; };
+ 		E5CBA76727A318E100DF7858 /* UnifiedSource119.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */; };
+@@ -2026,6 +2041,9 @@
  		EBA8D3B627A5E33F00CB7900 /* MockPushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B027A5E33F00CB7900 /* MockPushServiceConnection.mm */; };
  		EBA8D3B727A5E33F00CB7900 /* PushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B127A5E33F00CB7900 /* PushServiceConnection.mm */; };
  		ED82A7F2128C6FAF004477B3 /* WKBundlePageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22F0FF1289FCD90085E74F /* WKBundlePageOverlay.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -19729,7 +19763,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
  		F42D634122A0EFDF00D2FB3A /* WebAutocorrectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */; };
-@@ -4920,6 +4936,7 @@
+@@ -4970,6 +4988,7 @@
  		5CABDC8522C40FCC001EDE8E /* WKMessageListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKMessageListener.h; sourceTree = "<group>"; };
  		5CADDE0D2151AA010067D309 /* AuthenticationChallengeDisposition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthenticationChallengeDisposition.h; sourceTree = "<group>"; };
  		5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource115.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource115.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -19737,7 +19771,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  		5CAF7AA426F93A750003F19E /* adattributiond */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = adattributiond; sourceTree = BUILT_PRODUCTS_DIR; };
  		5CAF7AA526F93A950003F19E /* adattributiond.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = adattributiond.cpp; sourceTree = "<group>"; };
  		5CAF7AA626F93AA50003F19E /* adattributiond.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = adattributiond.xcconfig; sourceTree = "<group>"; };
-@@ -6332,6 +6349,19 @@
+@@ -6402,6 +6421,19 @@
  		DF0C5F24252ECB8D00D921DB /* WKDownload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownload.h; sourceTree = "<group>"; };
  		DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadInternal.h; sourceTree = "<group>"; };
  		DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadDelegate.h; sourceTree = "<group>"; };
@@ -19757,7 +19791,16 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  		DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHTTPCookieStorePrivate.h; sourceTree = "<group>"; };
  		DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKContentWorldPrivate.h; sourceTree = "<group>"; };
  		DF58C6311371AC5800F9A37C /* NativeWebWheelEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeWebWheelEvent.h; sourceTree = "<group>"; };
-@@ -6470,6 +6500,14 @@
+@@ -6523,6 +6555,8 @@
+ 		E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKFormColorControl.h; path = ios/forms/WKFormColorControl.h; sourceTree = "<group>"; };
+ 		E5CB07DB20E1678F0022C183 /* WKFormColorControl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKFormColorControl.mm; path = ios/forms/WKFormColorControl.mm; sourceTree = "<group>"; };
+ 		E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource120.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource120.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
++		E5CBA76F27A3187800DF7858 /* UnifiedSource121.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource121.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource121.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
++		E5CBA77F27A3187800DF7858 /* UnifiedSource122.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource122.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource122.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
+ 		E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource119.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource119.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
+ 		E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource118.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource118.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
+ 		E5CBA76227A3187900DF7858 /* UnifiedSource117.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource117.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource117.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
+@@ -6544,6 +6578,14 @@
  		ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtraPrivateSymbolsForTAPI.h; sourceTree = "<group>"; };
  		ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExtraPublicSymbolsForTAPI.h; sourceTree = "<group>"; };
  		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
@@ -19772,7 +19815,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  		F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDragDestinationAction.h; sourceTree = "<group>"; };
  		F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionContext.h; path = ios/WebAutocorrectionContext.h; sourceTree = "<group>"; };
  		F41056612130699A0092281D /* APIAttachmentCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = APIAttachmentCocoa.mm; sourceTree = "<group>"; };
-@@ -6614,6 +6652,7 @@
+@@ -6690,6 +6732,7 @@
  				3766F9EF189A1244003CF19B /* QuartzCore.framework in Frameworks */,
  				37694525184FC6B600CDE21F /* Security.framework in Frameworks */,
  				37BEC4DD1948FC6A008B4286 /* WebCore.framework in Frameworks */,
@@ -19780,7 +19823,16 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -8685,6 +8724,7 @@
+@@ -8415,6 +8458,8 @@
+ 				E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */,
+ 				E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */,
+ 				E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */,
++				E5CBA76F27A3187800DF7858 /* UnifiedSource121.cpp */,
++				E5CBA77F27A3187800DF7858 /* UnifiedSource122.cpp */,
+ 			);
+ 			name = "unified-sources";
+ 			path = "DerivedSources/WebKit/unified-sources";
+@@ -8778,6 +8823,7 @@
  		37C4C08318149C2A003688B9 /* Cocoa */ = {
  			isa = PBXGroup;
  			children = (
@@ -19788,7 +19840,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				1A43E826188F38E2009E4D30 /* Deprecated */,
  				37A5E01218BBF937000A081E /* _WKActivatedElementInfo.h */,
  				37A5E01118BBF937000A081E /* _WKActivatedElementInfo.mm */,
-@@ -9831,6 +9871,7 @@
+@@ -9957,6 +10003,7 @@
  			children = (
  				DDE992F4278D06D900F60D26 /* libWebKitAdditions.a */,
  				57A9FF15252C6AEF006A2040 /* libWTF.a */,
@@ -19796,7 +19848,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				5750F32A2032D4E500389347 /* LocalAuthentication.framework */,
  				570DAAB0230273D200E8FC04 /* NearField.framework */,
  				51F7BB7E274564A100C45A72 /* Security.framework */,
-@@ -10343,6 +10384,12 @@
+@@ -10471,6 +10518,12 @@
  			children = (
  				9197940423DBC4BB00257892 /* InspectorBrowserAgent.cpp */,
  				9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */,
@@ -19809,7 +19861,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  			);
  			path = Agents;
  			sourceTree = "<group>";
-@@ -10351,6 +10398,7 @@
+@@ -10479,6 +10532,7 @@
  			isa = PBXGroup;
  			children = (
  				A5D3504D1D78F0D2005124A9 /* RemoteWebInspectorUIProxyMac.mm */,
@@ -19817,7 +19869,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */,
  				99A7ACE326012919006D57FD /* WKInspectorResourceURLSchemeHandler.h */,
  				99A7ACE42601291A006D57FD /* WKInspectorResourceURLSchemeHandler.mm */,
-@@ -10899,6 +10947,12 @@
+@@ -11035,6 +11089,12 @@
  		BC032DC310F438260058C15A /* UIProcess */ = {
  			isa = PBXGroup;
  			children = (
@@ -19830,7 +19882,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				BC032DC410F4387C0058C15A /* API */,
  				512F588D12A8836F00629530 /* Authentication */,
  				9955A6E81C79809000EB6A93 /* Automation */,
-@@ -11204,6 +11258,7 @@
+@@ -11341,6 +11401,7 @@
  		BC0C376610F807660076D7CB /* C */ = {
  			isa = PBXGroup;
  			children = (
@@ -19838,7 +19890,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				5123CF18133D25E60056F800 /* cg */,
  				6EE849C41368D9040038D481 /* mac */,
  				BCB63477116BF10600603215 /* WebKit2_C.h */,
-@@ -11792,6 +11847,11 @@
+@@ -11931,6 +11992,11 @@
  		BCCF085C113F3B7500C650C5 /* mac */ = {
  			isa = PBXGroup;
  			children = (
@@ -19850,7 +19902,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				B878B613133428DC006888E9 /* CorrectionPanel.h */,
  				B878B614133428DC006888E9 /* CorrectionPanel.mm */,
  				07EF07592745A8160066EA04 /* DisplayCaptureSessionManager.h */,
-@@ -12708,6 +12768,7 @@
+@@ -12856,6 +12922,7 @@
  				99788ACB1F421DDA00C08000 /* _WKAutomationSessionConfiguration.h in Headers */,
  				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
  				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
@@ -19858,7 +19910,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
  				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
  				1A5704F81BE01FF400874AF1 /* _WKContextMenuElementInfo.h in Headers */,
-@@ -13018,6 +13079,7 @@
+@@ -13168,6 +13235,7 @@
  				1A14F8E21D74C834006CBEC6 /* FrameInfoData.h in Headers */,
  				1AE00D611831792100087DD7 /* FrameLoadState.h in Headers */,
  				5C121E842410208D00486F9B /* FrameTreeNodeData.h in Headers */,
@@ -19866,7 +19918,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				2D4AF0892044C3C4006C8817 /* FrontBoardServicesSPI.h in Headers */,
  				CD78E1151DB7D7ED0014A2DE /* FullscreenClient.h in Headers */,
  				CD19D2EA2046406F0017074A /* FullscreenTouchSecheuristic.h in Headers */,
-@@ -13033,6 +13095,7 @@
+@@ -13183,6 +13251,7 @@
  				410F0D4C2701EFF900F96DFC /* GPUProcessConnectionInitializationParameters.h in Headers */,
  				4614F13225DED875007006E7 /* GPUProcessConnectionParameters.h in Headers */,
  				2DA049B8180CCD0A00AAFA9E /* GraphicsLayerCARemote.h in Headers */,
@@ -19874,7 +19926,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				C0CE72AD1247E78D00BC0EC4 /* HandleMessage.h in Headers */,
  				1AC75A1B1B3368270056745B /* HangDetectionDisabler.h in Headers */,
  				57AC8F50217FEED90055438C /* HidConnection.h in Headers */,
-@@ -13180,6 +13243,7 @@
+@@ -13333,6 +13402,7 @@
  				413075AC1DE85F370039EC69 /* NetworkRTCMonitor.h in Headers */,
  				41DC45961E3D6E2200B11F51 /* NetworkRTCProvider.h in Headers */,
  				5C20CBA01BB1ECD800895BB1 /* NetworkSession.h in Headers */,
@@ -19882,7 +19934,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				532159551DBAE7290054AA3C /* NetworkSessionCocoa.h in Headers */,
  				417915B92257046F00D6F97E /* NetworkSocketChannel.h in Headers */,
  				93085DE026E5BCFD000EC6A7 /* NetworkStorageManager.h in Headers */,
-@@ -13245,6 +13309,7 @@
+@@ -13398,6 +13468,7 @@
  				BC1A7C581136E19C00FB7167 /* ProcessLauncher.h in Headers */,
  				463FD4821EB94EC000A2982C /* ProcessTerminationReason.h in Headers */,
  				86E67A251910B9D100004AB7 /* ProcessThrottler.h in Headers */,
@@ -19890,7 +19942,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				83048AE61ACA45DC0082C832 /* ProcessThrottlerClient.h in Headers */,
  				2D279E1926955768004B3EEB /* PrototypeToolsSPI.h in Headers */,
  				517B5F81275E97B6002DC22D /* PushAppBundle.h in Headers */,
-@@ -13271,6 +13336,7 @@
+@@ -13428,6 +13499,7 @@
  				CDAC20CA23FC2F750021DEE3 /* RemoteCDMInstanceSession.h in Headers */,
  				CDAC20C923FC2F750021DEE3 /* RemoteCDMInstanceSessionIdentifier.h in Headers */,
  				F451C0FE2703B263002BA03B /* RemoteDisplayListRecorderProxy.h in Headers */,
@@ -19898,7 +19950,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				2D47B56D1810714E003A3AEE /* RemoteLayerBackingStore.h in Headers */,
  				2DDF731518E95060004F5A66 /* RemoteLayerBackingStoreCollection.h in Headers */,
  				1AB16AEA164B3A8800290D62 /* RemoteLayerTreeContext.h in Headers */,
-@@ -13608,6 +13674,7 @@
+@@ -13768,6 +13840,7 @@
  				A543E30D215C8A9000279CD9 /* WebPageInspectorTargetController.h in Headers */,
  				A543E307215AD13700279CD9 /* WebPageInspectorTargetFrontendChannel.h in Headers */,
  				C0CE72A11247E71D00BC0EC4 /* WebPageMessages.h in Headers */,
@@ -19906,7 +19958,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				2D5C9D0619C81D8F00B3C5C1 /* WebPageOverlay.h in Headers */,
  				46C392292316EC4D008EED9B /* WebPageProxyIdentifier.h in Headers */,
  				BCBD3915125BB1A800D2C29F /* WebPageProxyMessages.h in Headers */,
-@@ -13746,6 +13813,7 @@
+@@ -13911,6 +13984,7 @@
  				BCD25F1711D6BDE100169B0E /* WKBundleFrame.h in Headers */,
  				BCF049E611FE20F600F86A58 /* WKBundleFramePrivate.h in Headers */,
  				BC49862F124D18C100D834E1 /* WKBundleHitTestResult.h in Headers */,
@@ -19914,7 +19966,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				BC204EF211C83EC8008F3375 /* WKBundleInitialize.h in Headers */,
  				65B86F1E12F11DE300B7DD8A /* WKBundleInspector.h in Headers */,
  				1A8B66B41BC45B010082DF77 /* WKBundleMac.h in Headers */,
-@@ -13799,6 +13867,7 @@
+@@ -13964,6 +14038,7 @@
  				5C795D71229F3757003FF1C4 /* WKContextMenuElementInfoPrivate.h in Headers */,
  				51A555F6128C6C47009ABCEC /* WKContextMenuItem.h in Headers */,
  				51A55601128C6D92009ABCEC /* WKContextMenuItemTypes.h in Headers */,
@@ -19922,7 +19974,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				A1EA02381DABFF7E0096021F /* WKContextMenuListener.h in Headers */,
  				BCC938E11180DE440085E5FE /* WKContextPrivate.h in Headers */,
  				9FB5F395169E6A80002C25BF /* WKContextPrivateMac.h in Headers */,
-@@ -13955,6 +14024,7 @@
+@@ -14120,6 +14195,7 @@
  				1AB8A1F818400BB800E9AE69 /* WKPageContextMenuClient.h in Headers */,
  				8372DB251A674C8F00C697C5 /* WKPageDiagnosticLoggingClient.h in Headers */,
  				1AB8A1F418400B8F00E9AE69 /* WKPageFindClient.h in Headers */,
@@ -19930,7 +19982,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				1AB8A1F618400B9D00E9AE69 /* WKPageFindMatchesClient.h in Headers */,
  				1AB8A1F018400B0000E9AE69 /* WKPageFormClient.h in Headers */,
  				BC7B633712A45ABA00D174A4 /* WKPageGroup.h in Headers */,
-@@ -15471,6 +15541,8 @@
+@@ -15638,6 +15714,8 @@
  				C1A152D724E5A29A00978C8B /* HandleXPCEndpointMessages.mm in Sources */,
  				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
  				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
@@ -19939,7 +19991,16 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
  				C1710CF724AA643200D7C112 /* LaunchServicesDatabaseObserver.mm in Sources */,
  				2984F588164BA095004BC0C6 /* LegacyCustomProtocolManagerMessageReceiver.cpp in Sources */,
-@@ -15799,6 +15871,8 @@
+@@ -15919,6 +15997,8 @@
+ 				E5CBA76527A318E100DF7858 /* UnifiedSource118.cpp in Sources */,
+ 				E5CBA76727A318E100DF7858 /* UnifiedSource119.cpp in Sources */,
+ 				E5CBA76427A318E100DF7858 /* UnifiedSource120.cpp in Sources */,
++				E5CBA77427A318E100DF7858 /* UnifiedSource121.cpp in Sources */,
++				E5CBA78427A318E100DF7858 /* UnifiedSource122.cpp in Sources */,
+ 				E38A1FC023A551BF00D2374F /* UserInterfaceIdiom.mm in Sources */,
+ 				CD491B0D1E732E4D00009066 /* UserMediaCaptureManagerMessageReceiver.cpp in Sources */,
+ 				CD491B171E73525500009066 /* UserMediaCaptureManagerProxyMessageReceiver.cpp in Sources */,
+@@ -15967,6 +16047,8 @@
  				51F060E11654318500F3282F /* WebMDNSRegisterMessageReceiver.cpp in Sources */,
  				31BA924D148831260062EDB5 /* WebNotificationManagerMessageReceiver.cpp in Sources */,
  				2DF6FE52212E110900469030 /* WebPage.cpp in Sources */,
@@ -19949,7 +20010,7 @@ index dc02f89412df46f85006a3460b7f4ccae85d01d1..4cc2af1d3e2257073f7810780daecce2
  				BCBD3914125BB1A800D2C29F /* WebPageProxyMessageReceiver.cpp in Sources */,
  				7CE9CE101FA0767A000177DE /* WebPageUpdatePreferences.cpp in Sources */,
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
-index d85f495a108af473849e0be7a16adcb6d7ba2157..ab6f199f645d5c0339f729d3a3f547443ada2c3d 100644
+index 89f5b04696460887f3cc4604bfb2e3979f1c7ad0..b8dfe915eb13304098fb06243788c1daec9e54d4 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 @@ -231,6 +231,11 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
@@ -19961,10 +20022,10 @@ index d85f495a108af473849e0be7a16adcb6d7ba2157..ab6f199f645d5c0339f729d3a3f54744
 +        return;
 +    }
 +
-     if (!tryLoadingUsingURLSchemeHandler(resourceLoader, trackingParameters)) {
-         WEBLOADERSTRATEGY_RELEASE_LOG("scheduleLoad: URL will be scheduled with the NetworkProcess");
+     if (tryLoadingUsingPDFJSHandler(resourceLoader, trackingParameters))
+         return;
  
-@@ -298,7 +303,8 @@ static void addParametersShared(const Frame* frame, NetworkResourceLoadParameter
+@@ -309,7 +314,8 @@ static void addParametersShared(const Frame* frame, NetworkResourceLoadParameter
      }
  }
  
@@ -19974,7 +20035,7 @@ index d85f495a108af473849e0be7a16adcb6d7ba2157..ab6f199f645d5c0339f729d3a3f54744
  {
      auto identifier = resourceLoader.identifier();
      ASSERT(identifier);
-@@ -314,7 +320,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -325,7 +331,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
              RunLoop::main().dispatch([resourceLoader = Ref { resourceLoader }] {
                  resourceLoader->didFail(resourceLoader->blockedError());
              });
@@ -19983,7 +20044,7 @@ index d85f495a108af473849e0be7a16adcb6d7ba2157..ab6f199f645d5c0339f729d3a3f54744
          }
      }
  
-@@ -324,7 +330,6 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -335,7 +341,6 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
  
      LOG(NetworkScheduling, "(WebProcess) WebLoaderStrategy::scheduleLoad, url '%s' will be scheduled with the NetworkProcess with priority %d, storedCredentialsPolicy %i", resourceLoader.url().string().latin1().data(), static_cast<int>(resourceLoader.request().priority()), (int)storedCredentialsPolicy);
  
@@ -19991,7 +20052,7 @@ index d85f495a108af473849e0be7a16adcb6d7ba2157..ab6f199f645d5c0339f729d3a3f54744
      loadParameters.identifier = identifier;
      loadParameters.webPageProxyID = trackingParameters.webPageProxyID;
      loadParameters.webPageID = trackingParameters.pageID;
-@@ -409,14 +414,11 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -420,14 +425,11 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
  
      if (loadParameters.options.mode != FetchOptions::Mode::Navigate) {
          ASSERT(loadParameters.sourceOrigin);
@@ -20009,7 +20070,7 @@ index d85f495a108af473849e0be7a16adcb6d7ba2157..ab6f199f645d5c0339f729d3a3f54744
  
      loadParameters.isMainFrameNavigation = resourceLoader.frame() && resourceLoader.frame()->isMainFrame() && resourceLoader.options().mode == FetchOptions::Mode::Navigate;
      if (loadParameters.isMainFrameNavigation && document)
-@@ -455,6 +457,17 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -466,6 +468,17 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
      }
  
      ASSERT((loadParameters.webPageID && loadParameters.webFrameID) || loadParameters.clientCredentialPolicy == ClientCredentialPolicy::CannotAskClientForCredentials);
@@ -20027,7 +20088,7 @@ index d85f495a108af473849e0be7a16adcb6d7ba2157..ab6f199f645d5c0339f729d3a3f54744
  
      std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
      if (loadParameters.isMainFrameNavigation)
-@@ -469,7 +482,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -480,7 +493,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
      }
  
      auto loader = WebResourceLoader::create(resourceLoader, trackingParameters);
@@ -20036,7 +20097,7 @@ index d85f495a108af473849e0be7a16adcb6d7ba2157..ab6f199f645d5c0339f729d3a3f54744
  }
  
  void WebLoaderStrategy::scheduleInternallyFailedLoad(WebCore::ResourceLoader& resourceLoader)
-@@ -876,7 +889,7 @@ void WebLoaderStrategy::didFinishPreconnection(WebCore::ResourceLoaderIdentifier
+@@ -887,7 +900,7 @@ void WebLoaderStrategy::didFinishPreconnection(WebCore::ResourceLoaderIdentifier
  
  bool WebLoaderStrategy::isOnLine() const
  {
@@ -20045,7 +20106,7 @@ index d85f495a108af473849e0be7a16adcb6d7ba2157..ab6f199f645d5c0339f729d3a3f54744
  }
  
  void WebLoaderStrategy::addOnlineStateChangeListener(Function<void(bool)>&& listener)
-@@ -896,6 +909,11 @@ void WebLoaderStrategy::isResourceLoadFinished(CachedResource& resource, Complet
+@@ -907,6 +920,11 @@ void WebLoaderStrategy::isResourceLoadFinished(CachedResource& resource, Complet
  
  void WebLoaderStrategy::setOnLineState(bool isOnLine)
  {
@@ -20057,7 +20118,7 @@ index d85f495a108af473849e0be7a16adcb6d7ba2157..ab6f199f645d5c0339f729d3a3f54744
      if (m_isOnLine == isOnLine)
          return;
  
-@@ -904,6 +922,12 @@ void WebLoaderStrategy::setOnLineState(bool isOnLine)
+@@ -915,6 +933,12 @@ void WebLoaderStrategy::setOnLineState(bool isOnLine)
          listener(isOnLine);
  }
  
@@ -20071,7 +20132,7 @@ index d85f495a108af473849e0be7a16adcb6d7ba2157..ab6f199f645d5c0339f729d3a3f54744
  {
      WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::SetCaptureExtraNetworkLoadMetricsEnabled(enabled), 0);
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
-index 2290d987c36f68245b08fb2b86319d4d5a68e4a3..f22b3a7c855918b11582dd1ea9be00b2def665c9 100644
+index e07a15c59ed7378b08069a4a9b930e1825357083..8b9e151e172657e772e3d977d0a0d9de79cc1b80 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
 @@ -41,6 +41,7 @@ struct FetchOptions;
@@ -20092,7 +20153,7 @@ index 2290d987c36f68245b08fb2b86319d4d5a68e4a3..f22b3a7c855918b11582dd1ea9be00b2
  
      void setExistingNetworkResourceLoadIdentifierToResume(std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume) { m_existingNetworkResourceLoadIdentifierToResume = existingNetworkResourceLoadIdentifierToResume; }
  
-@@ -137,6 +141,7 @@ private:
+@@ -138,6 +142,7 @@ private:
      Vector<Function<void(bool)>> m_onlineStateChangeListeners;
      std::optional<NetworkResourceLoadIdentifier> m_existingNetworkResourceLoadIdentifierToResume;
      bool m_isOnLine { true };
@@ -20101,7 +20162,7 @@ index 2290d987c36f68245b08fb2b86319d4d5a68e4a3..f22b3a7c855918b11582dd1ea9be00b2
  
  } // namespace WebKit
 diff --git a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
-index efe2755ee12a7667bf7812f50bc8b42e5bae11fe..609082c4425ddc2b44e37c7355882b379b432998 100644
+index 4a00f228cd50f85c03f997f047c69ce520e9f177..59f5fc400aa1658d2531a509050b2e2acd4f7d6e 100644
 --- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
 @@ -191,9 +191,6 @@ void WebResourceLoader::didReceiveResponse(const ResourceResponse& response, Pri
@@ -20137,7 +20198,7 @@ index e00c722c2be5d505243d45f46001839d4eb8a977..33c0832cde6c292230397a13e70d90fb
  
              auto permissionHandlers = m_requestsPerOrigin.take(securityOrigin);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
-index dca85e223c15a348858b29a60ee4e7f5f1a8bba9..4a418ce736adafc250ea3afe5ba6c4c0adcaf1b1 100644
+index c5f403a6d44d554b6be794d16903ddc87c622a77..3cbed199847600c9a8d1e0e35c3882bfdd157552 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 @@ -417,6 +417,8 @@ void WebChromeClient::setResizable(bool resizable)
@@ -20461,7 +20522,7 @@ index 4f727e418b082eebe86711294bb0f26f9c74d7d1..3e713db9bbd2a2bc78bdc464cfa02ca4
  #if USE(COORDINATED_GRAPHICS)
      void layerFlushTimerFired();
 diff --git a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
-index d1d2db8c0f1dcb033753b9f45ff86984a7890093..0e619b2541577790c3eb9ea3ec6c1100c03bb24b 100644
+index db2e5d686e6ffff8f5299903c4d42fb3a64607ac..8a4d23bdebe6a7b2f7dea87517de8f0cea62093d 100644
 --- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
 @@ -27,6 +27,7 @@
@@ -20472,8 +20533,8 @@ index d1d2db8c0f1dcb033753b9f45ff86984a7890093..0e619b2541577790c3eb9ea3ec6c1100
  #include "WebPage.h"
  #include "WebPageCreationParameters.h"
  #include "WebProcess.h"
-@@ -89,6 +90,13 @@ void DrawingArea::dispatchAfterEnsuringUpdatedScrollPosition(WTF::Function<void
-     function();
+@@ -94,6 +95,13 @@ void DrawingArea::tryMarkLayersVolatile(CompletionHandler<void(bool)>&& completi
+     completionFunction(true);
  }
  
 +#if PLATFORM(WIN)
@@ -20487,7 +20548,7 @@ index d1d2db8c0f1dcb033753b9f45ff86984a7890093..0e619b2541577790c3eb9ea3ec6c1100
  {
      if (m_hasRemovedMessageReceiver)
 diff --git a/Source/WebKit/WebProcess/WebPage/DrawingArea.h b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
-index 29d99aaf952b731e9b0235aa113acae8d9d5fea8..59cb0b3ccd3ed356e88a53f10e1878b12a57a3b9 100644
+index 21d4658c6c52fdd15444565b9181eec0e6ab0035..c8d1087910fbdddf985edb28114ac5e0889aca25 100644
 --- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
 +++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
 @@ -148,6 +148,9 @@ public:
@@ -20571,10 +20632,10 @@ index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4
      uint64_t m_navigationID;
  };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d22880090029ef886b5 100644
+index 9a1d30ff0ef2688a4032cdec236f7dcdabf425af..fa68604d61a8f56d0a6d522822ef93310bd3a404 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-@@ -916,6 +916,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
+@@ -907,6 +907,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
      }
  #endif
  
@@ -20584,7 +20645,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
      updateThrottleState();
  }
  
-@@ -1688,6 +1691,22 @@ void WebPage::platformDidReceiveLoadParameters(const LoadParameters& loadParamet
+@@ -1675,6 +1678,22 @@ void WebPage::platformDidReceiveLoadParameters(const LoadParameters& loadParamet
  }
  #endif
  
@@ -20607,7 +20668,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
  void WebPage::loadRequest(LoadParameters&& loadParameters)
  {
      WEBPAGE_RELEASE_LOG(Loading, "loadRequest: navigationID=%" PRIu64 ", shouldTreatAsContinuingLoad=%u, lastNavigationWasAppInitiated=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, loadParameters.navigationID, static_cast<unsigned>(loadParameters.shouldTreatAsContinuingLoad), loadParameters.request.isAppInitiated(), valueOrDefault(loadParameters.existingNetworkResourceLoadIdentifierToResume).toUInt64());
-@@ -1954,17 +1973,13 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
+@@ -1941,17 +1960,13 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
      view->resize(viewSize);
      m_drawingArea->setNeedsDisplay();
  
@@ -20626,7 +20687,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
  
      // Viewport properties have no impact on zero sized fixed viewports.
      if (m_viewSize.isEmpty())
-@@ -1981,20 +1996,18 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
+@@ -1968,20 +1983,18 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
  
      ViewportAttributes attr = computeViewportAttributes(viewportArguments, minimumLayoutFallbackWidth, deviceWidth, deviceHeight, 1, m_viewSize);
  
@@ -20654,7 +20715,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
  
  #if USE(COORDINATED_GRAPHICS)
      m_drawingArea->didChangeViewportAttributes(WTFMove(attr));
-@@ -2002,7 +2015,6 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
+@@ -1989,7 +2002,6 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
      send(Messages::WebPageProxy::DidChangeViewportProperties(attr));
  #endif
  }
@@ -20662,7 +20723,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
  
  void WebPage::scrollMainFrameIfNotAtMaxScrollPosition(const IntSize& scrollOffset)
  {
-@@ -2297,6 +2309,7 @@ void WebPage::scaleView(double scale)
+@@ -2284,6 +2296,7 @@ void WebPage::scaleView(double scale)
      }
  
      m_page->setViewScaleFactor(scale);
@@ -20670,7 +20731,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
      scalePage(pageScale, scrollPositionAtNewScale);
  }
  
-@@ -2401,17 +2414,13 @@ void WebPage::viewportPropertiesDidChange(const ViewportArguments& viewportArgum
+@@ -2388,17 +2401,13 @@ void WebPage::viewportPropertiesDidChange(const ViewportArguments& viewportArgum
          viewportConfigurationChanged();
  #endif
  
@@ -20689,7 +20750,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
  }
  
  void WebPage::listenForLayoutMilestones(OptionSet<WebCore::LayoutMilestone> milestones)
-@@ -3305,6 +3314,104 @@ void WebPage::touchEvent(const WebTouchEvent& touchEvent)
+@@ -3307,6 +3316,104 @@ void WebPage::touchEvent(const WebTouchEvent& touchEvent)
  
      send(Messages::WebPageProxy::DidReceiveEvent(static_cast<uint32_t>(touchEvent.type()), handled));
  }
@@ -20794,7 +20855,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
  #endif
  
  void WebPage::cancelPointer(WebCore::PointerID pointerId, const WebCore::IntPoint& documentPoint)
-@@ -3381,6 +3488,11 @@ void WebPage::sendMessageToTargetBackend(const String& targetId, const String& m
+@@ -3383,6 +3490,11 @@ void WebPage::sendMessageToTargetBackend(const String& targetId, const String& m
      m_inspectorTargetController->sendMessageToTargetBackend(targetId, message);
  }
  
@@ -20806,7 +20867,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
  void WebPage::insertNewlineInQuotedContent()
  {
      Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-@@ -3619,6 +3731,7 @@ void WebPage::didCompletePageTransition()
+@@ -3621,6 +3733,7 @@ void WebPage::didCompletePageTransition()
  void WebPage::show()
  {
      send(Messages::WebPageProxy::ShowPage());
@@ -20814,7 +20875,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
  }
  
  void WebPage::setIsTakingSnapshotsForApplicationSuspension(bool isTakingSnapshotsForApplicationSuspension)
-@@ -4439,7 +4552,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
+@@ -4447,7 +4560,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
  
  #if ENABLE(DRAG_SUPPORT)
  
@@ -20823,7 +20884,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
  void WebPage::performDragControllerAction(DragControllerAction action, const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation> draggingSourceOperationMask, SelectionData&& selectionData, OptionSet<DragApplicationFlags> flags)
  {
      if (!m_page) {
-@@ -6799,6 +6912,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
+@@ -6844,6 +6957,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
              WebsitePoliciesData::applyToDocumentLoader(WTFMove(*m_pendingWebsitePolicies), documentLoader);
              m_pendingWebsitePolicies = std::nullopt;
          }
@@ -20834,7 +20895,7 @@ index 6548507869ceaf50d187ed693e6d917d23fd00f9..3b99c1e193987df3d7809d2288009002
  
      return documentLoader;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.h b/Source/WebKit/WebProcess/WebPage/WebPage.h
-index 67d48fed2995bc1a1171a9e995a6a7b6e7950170..1e2d18dc74d9eedef0f88904eae7cfa71cea2fee 100644
+index 9d26c67d49ae346b5b8c4982e26a0fcc0b21f1e5..ddbdda7f13d936a0a81715a9e665f60d62c0639e 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
 @@ -122,6 +122,10 @@ typedef struct _AtkObject AtkObject;
@@ -20848,7 +20909,7 @@ index 67d48fed2995bc1a1171a9e995a6a7b6e7950170..1e2d18dc74d9eedef0f88904eae7cfa7
  #if PLATFORM(GTK) || PLATFORM(WPE)
  #include "InputMethodState.h"
  #endif
-@@ -988,11 +992,11 @@ public:
+@@ -997,11 +1001,11 @@ public:
      void clearSelection();
      void restoreSelectionInFocusedEditableElement();
  
@@ -20862,7 +20923,7 @@ index 67d48fed2995bc1a1171a9e995a6a7b6e7950170..1e2d18dc74d9eedef0f88904eae7cfa7
      void performDragControllerAction(DragControllerAction, const WebCore::DragData&, SandboxExtension::Handle&&, Vector<SandboxExtension::Handle>&&);
  #endif
  
-@@ -1006,6 +1010,9 @@ public:
+@@ -1015,6 +1019,9 @@ public:
      void didStartDrag();
      void dragCancelled();
      OptionSet<WebCore::DragSourceAction> allowedDragSourceActions() const { return m_allowedDragSourceActions; }
@@ -20872,7 +20933,7 @@ index 67d48fed2995bc1a1171a9e995a6a7b6e7950170..1e2d18dc74d9eedef0f88904eae7cfa7
  #endif
  
      void beginPrinting(WebCore::FrameIdentifier, const PrintInfo&);
-@@ -1242,6 +1249,7 @@ public:
+@@ -1251,6 +1258,7 @@ public:
      void connectInspector(const String& targetId, Inspector::FrontendChannel::ConnectionType);
      void disconnectInspector(const String& targetId);
      void sendMessageToTargetBackend(const String& targetId, const String& message);
@@ -20880,7 +20941,7 @@ index 67d48fed2995bc1a1171a9e995a6a7b6e7950170..1e2d18dc74d9eedef0f88904eae7cfa7
  
      void insertNewlineInQuotedContent();
  
-@@ -1602,6 +1610,7 @@ private:
+@@ -1615,6 +1623,7 @@ private:
      // Actions
      void tryClose(CompletionHandler<void(bool)>&&);
      void platformDidReceiveLoadParameters(const LoadParameters&);
@@ -20888,7 +20949,7 @@ index 67d48fed2995bc1a1171a9e995a6a7b6e7950170..1e2d18dc74d9eedef0f88904eae7cfa7
      void loadRequest(LoadParameters&&);
      NO_RETURN void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
      void loadData(LoadParameters&&);
-@@ -1639,6 +1648,7 @@ private:
+@@ -1652,6 +1661,7 @@ private:
      void updatePotentialTapSecurityOrigin(const WebTouchEvent&, bool wasHandled);
  #elif ENABLE(TOUCH_EVENTS)
      void touchEvent(const WebTouchEvent&);
@@ -20896,7 +20957,7 @@ index 67d48fed2995bc1a1171a9e995a6a7b6e7950170..1e2d18dc74d9eedef0f88904eae7cfa7
  #endif
  
      void cancelPointer(WebCore::PointerID, const WebCore::IntPoint&);
-@@ -1772,9 +1782,7 @@ private:
+@@ -1785,9 +1795,7 @@ private:
  
      void requestRectForFoundTextRange(const WebFoundTextRange&, CompletionHandler<void(WebCore::FloatRect)>&&);
  
@@ -20906,7 +20967,7 @@ index 67d48fed2995bc1a1171a9e995a6a7b6e7950170..1e2d18dc74d9eedef0f88904eae7cfa7
  
      void didChangeSelectedIndexForActivePopupMenu(int32_t newIndex);
      void setTextForActivePopupMenu(int32_t index);
-@@ -2309,6 +2317,7 @@ private:
+@@ -2323,6 +2331,7 @@ private:
      UserActivity m_userActivity;
  
      uint64_t m_pendingNavigationID { 0 };
@@ -20915,10 +20976,10 @@ index 67d48fed2995bc1a1171a9e995a6a7b6e7950170..1e2d18dc74d9eedef0f88904eae7cfa7
  
      bool m_mainFrameProgressCompleted { false };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-index 1191837c351ea2795df9b1a5bf2a4643658e0d4e..058eed0658640b5e278ba1a04c8c388e42d5c058 100644
+index ba9e82bd64a356f6d0ef033e45a8f3417581a848..edee039c286a5c87e4dbf529cd57e5b9b9d931bb 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-@@ -133,6 +133,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -139,6 +139,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      ConnectInspector(String targetId, Inspector::FrontendChannel::ConnectionType connectionType)
      DisconnectInspector(String targetId)
      SendMessageToTargetBackend(String targetId, String message)
@@ -20926,7 +20987,7 @@ index 1191837c351ea2795df9b1a5bf2a4643658e0d4e..058eed0658640b5e278ba1a04c8c388e
  
  #if ENABLE(REMOTE_INSPECTOR)
      SetIndicating(bool indicating);
-@@ -144,6 +145,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -150,6 +151,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
  #endif
  #if !ENABLE(IOS_TOUCH_EVENTS) && ENABLE(TOUCH_EVENTS)
      TouchEvent(WebKit::WebTouchEvent event)
@@ -20934,7 +20995,7 @@ index 1191837c351ea2795df9b1a5bf2a4643658e0d4e..058eed0658640b5e278ba1a04c8c388e
  #endif
  
      CancelPointer(WebCore::PointerID pointerId, WebCore::IntPoint documentPoint)
-@@ -173,6 +175,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -179,6 +181,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      LoadURLInFrame(URL url, String referrer, WebCore::FrameIdentifier frameID)
      LoadDataInFrame(IPC::DataReference data, String MIMEType, String encodingName, URL baseURL, WebCore::FrameIdentifier frameID)
      LoadRequest(struct WebKit::LoadParameters loadParameters)
@@ -20942,7 +21003,7 @@ index 1191837c351ea2795df9b1a5bf2a4643658e0d4e..058eed0658640b5e278ba1a04c8c388e
      LoadRequestWaitingForProcessLaunch(struct WebKit::LoadParameters loadParameters, URL resourceDirectoryURL, WebKit::WebPageProxyIdentifier pageID, bool checkAssumedReadAccessToResourceURL)
      LoadData(struct WebKit::LoadParameters loadParameters)
      LoadSimulatedRequestAndResponse(struct WebKit::LoadParameters loadParameters, WebCore::ResourceResponse simulatedResponse)
-@@ -324,10 +327,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -330,10 +333,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      AddMIMETypeWithCustomContentProvider(String mimeType)
  
      # Drag and drop.
@@ -20955,7 +21016,7 @@ index 1191837c351ea2795df9b1a5bf2a4643658e0d4e..058eed0658640b5e278ba1a04c8c388e
      PerformDragControllerAction(enum:uint8_t WebKit::DragControllerAction action, WebCore::DragData dragData, WebKit::SandboxExtension::Handle sandboxExtensionHandle, Vector<WebKit::SandboxExtension::Handle> sandboxExtensionsForUpload)
  #endif
  #if ENABLE(DRAG_SUPPORT)
-@@ -336,6 +339,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -342,6 +345,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      DragCancelled()
  #endif
  
@@ -20967,10 +21028,10 @@ index 1191837c351ea2795df9b1a5bf2a4643658e0d4e..058eed0658640b5e278ba1a04c8c388e
      RequestDragStart(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
      RequestAdditionalItemsForDragSession(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
 diff --git a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
-index 7300f7c647de4b019830c93e2e762f0577e6281c..878e1a04cf1761ad467dd993ecf70a7d3398681b 100644
+index 9dc00da2770c1939891a300f2337496a9c8e701d..f1be96a7cd7d5a9da83a606f55e47d888132bf93 100644
 --- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
 +++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
-@@ -801,21 +801,37 @@ String WebPage::platformUserAgent(const URL&) const
+@@ -783,21 +783,37 @@ String WebPage::platformUserAgent(const URL&) const
  
  bool WebPage::hoverSupportedByPrimaryPointingDevice() const
  {
@@ -21059,10 +21120,10 @@ index bb512aec34506aa588a736b6dcf6b6f3b669e342..fbcad974ad70113d527f7cac688e47d5
  }
  
 diff --git a/Source/WebKit/WebProcess/WebProcess.cpp b/Source/WebKit/WebProcess/WebProcess.cpp
-index dd8d581ac5b24d5d94062b9c65c242f0c51ec984..057cdb7f7de86946bfef599a172c69f2bcb7cfdf 100644
+index 799613d37742363bfbdcd952979962206f0228a8..ab47a2d1591beb4007e15b10fa6dee0567ec7185 100644
 --- a/Source/WebKit/WebProcess/WebProcess.cpp
 +++ b/Source/WebKit/WebProcess/WebProcess.cpp
-@@ -89,6 +89,7 @@
+@@ -91,6 +91,7 @@
  #include "WebsiteData.h"
  #include "WebsiteDataStoreParameters.h"
  #include "WebsiteDataType.h"
@@ -21070,7 +21131,7 @@ index dd8d581ac5b24d5d94062b9c65c242f0c51ec984..057cdb7f7de86946bfef599a172c69f2
  #include <JavaScriptCore/JSLock.h>
  #include <JavaScriptCore/MemoryStatistics.h>
  #include <JavaScriptCore/WasmFaultSignalHandler.h>
-@@ -350,6 +351,8 @@ void WebProcess::initializeProcess(const AuxiliaryProcessInitializationParameter
+@@ -353,6 +354,8 @@ void WebProcess::initializeProcess(const AuxiliaryProcessInitializationParameter
      
      platformInitializeProcess(parameters);
      updateCPULimit();
@@ -21095,10 +21156,10 @@ index 8987c3964a9308f2454759de7f8972215a3ae416..bcac0afeb94ed8123d1f9fb0b932c849
              SetProcessDPIAware();
          return true;
 diff --git a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-index 49899318dc9ac52e3c887b54e789aec60b973050..edf2f4b8ef72eb3812b6447a5a628ba3bb87867a 100644
+index aa96fc7a1d5bf7ce3256d462872793cd38680899..1d786a4a6a5ecba393c2cd2ca1aec0028ce2cb64 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-@@ -4169,7 +4169,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
+@@ -4170,7 +4170,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
      _private->handlingMouseDownEvent = NO;
  }
  
@@ -21161,12 +21222,12 @@ index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d
 +    LIBVPX_LIBRARIES
 +)
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index 2260d519347ff8ef62b32da566b496b61d572b10..67cec307b28545ffa5e5b27d899c620d9fc54ee3 100644
+index 4308075122f753e72b5ac66e06db1c14f206d3d4..12bb610dcebc08773ea0a4ce2723400015a7dfda 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
 @@ -5,6 +5,7 @@ WEBKIT_OPTION_BEGIN()
  
- SET_PROJECT_VERSION(2 35 2)
+ SET_PROJECT_VERSION(2 35 3)
  
 +set(ENABLE_WEBKIT_LEGACY OFF)
  
@@ -21246,7 +21307,7 @@ index 2260d519347ff8ef62b32da566b496b61d572b10..67cec307b28545ffa5e5b27d899c620d
  
  # Finalize the value for all options. Do not attempt to use an option before
 diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
-index 79b46b20c0ca45536777dce7018c8619c7906452..637352517eb126530fbbafcb5ef03e0331ee9db6 100644
+index 9038170f06852079d4c26dac6210f87edfe55d2f..1446ccb83744336e7f763ff91de3ea102ac80274 100644
 --- a/Source/cmake/OptionsWPE.cmake
 +++ b/Source/cmake/OptionsWPE.cmake
 @@ -3,6 +3,7 @@ include(VersioningUtils)
@@ -21989,10 +22050,10 @@ index 44ebbc30033692f13543fdb50a86c921decd6a94..93edbf8c4084ff8400be2a13bbeb539a
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
 diff --git a/Tools/WebKitTestRunner/PlatformWPE.cmake b/Tools/WebKitTestRunner/PlatformWPE.cmake
-index 2014ba2e11644b5d19f5f979d02485d488765ecc..3ab1dd0e1ae697d5c95895b8193f4ff3ac2f9062 100644
+index f6b59db3c0eeb0612f25e85b29495cd990add74d..69df426e74d2f1336a24e744ae25915b14982d51 100644
 --- a/Tools/WebKitTestRunner/PlatformWPE.cmake
 +++ b/Tools/WebKitTestRunner/PlatformWPE.cmake
-@@ -30,6 +30,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
+@@ -31,6 +31,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
      ${WPEBACKEND_FDO_LIBRARIES}
      Cairo::Cairo
      WebKit::WPEToolingBackends
@@ -22000,18 +22061,6 @@ index 2014ba2e11644b5d19f5f979d02485d488765ecc..3ab1dd0e1ae697d5c95895b8193f4ff3
  )
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
-diff --git a/Tools/WebKitTestRunner/TestController.cpp b/Tools/WebKitTestRunner/TestController.cpp
-index 270509ce94c95a0c2c257c5437a1fb4a9c26692f..7ff81bc742cc572649afbe1b27fd2311e015b7e2 100644
---- a/Tools/WebKitTestRunner/TestController.cpp
-+++ b/Tools/WebKitTestRunner/TestController.cpp
-@@ -808,6 +808,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
-         0, // requestStorageAccessConfirm
-         shouldAllowDeviceOrientationAndMotionAccess,
-         runWebAuthenticationPanel,
-+        0, // handleJavaScriptDialog
-         decidePolicyForSpeechRecognitionPermissionRequest,
-         decidePolicyForMediaKeySystemPermissionRequest
-     };
 diff --git a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
 index 7e7585e699663e5bdc8284e4e3540818742102ab..54d1853f259e824e5731bd39825c37629ab7ae5e 100644
 --- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm


### PR DESCRIPTION
Rebase `webkit/patches/bootstrap.diff` to [r289982](https://trac.webkit.org/changeset/289982/webkit)

* [3-way diff](https://github.com/dpino/WebKit/commit/7f83c2debab031b4df6da743c821cd5fa209844b)
* [Resolve conflicts](https://github.com/dpino/WebKit/commit/035258d9d9dd4b33cae7e6be6e43c3263ac59994)
* [Build fix: add missing header](https://github.com/dpino/WebKit/commit/8571f759b32e5bd1f7fde319d02a0410b57f3638)
* [Build fix: handleJavaScriptDialog](https://github.com/dpino/WebKit/commit/7d78cea3bd68217d9d2719c3a289bee8acb18248)
  - I'm not sure about this change.
* [Add UnifiedSource121.cpp and UnifiedSource122.cpp](https://github.com/dpino/WebKit/commit/d452447697604b586d03e8b439b3193268bb6600)
  - The Mac build required to add two new UnifiedSource files.
* [Non-unified build fixes for Mac](https://github.com/dpino/WebKit/commit/e00d33c48d9386ee13eb7864d95fd7449363d23e)
  - Sometimes when unified source files contain different sets of files, indirectly unveils build errors that were hidden by the unified source build (usually related to missing headers, or missing namespace scopes). (Upstream bug: https://bugs.webkit.org/show_bug.cgi?id=236752)
