### PR TITLE
fix(trace-viewer): don't crash when argument is null

### DIFF
--- a/packages/playwright-core/src/web/traceViewer/ui/callTab.tsx
+++ b/packages/playwright-core/src/web/traceViewer/ui/callTab.tsx
@@ -82,7 +82,7 @@ function toString(metadata: CallMetadata, name: string, value: any): { title: st
       value = parseSerializedValue(value, new Array(10).fill({ handle: '<handle>' }));
   }
   const type = typeof value;
-  if (type !== 'object')
+  if (type !== 'object' || value === null)
     return { title: String(value), type };
   if (value.guid)
     return { title: '<handle>', type: 'handle' };

--- a/tests/trace-viewer/trace-viewer.spec.ts
+++ b/tests/trace-viewer/trace-viewer.spec.ts
@@ -145,6 +145,8 @@ test.beforeAll(async function recordTrace({ browser, browserName, browserType, s
     });
   }, { a: 'paramA', b: 4 });
 
+  await page.evaluate(() => 1 + 1, null);
+
   async function doClick() {
     await page.click('"Click"');
   }
@@ -191,6 +193,7 @@ test('should open simple trace viewer', async ({ showTraceViewer }) => {
     /page.gotodata:text\/html,<html>Hello world<\/html>/,
     /page.setContent/,
     /expect.toHaveTextbutton/,
+    /page.evaluate/,
     /page.evaluate/,
     /page.click"Click"/,
     /page.waitForEvent/,
@@ -251,6 +254,20 @@ test('should show params and return value', async ({ showTraceViewer, browserNam
     'isFunction: true',
     'arg: {"a":"paramA","b":4}',
     'value: "return paramA"'
+  ]);
+});
+
+test('should show null as a param', async ({ showTraceViewer, browserName }) => {
+  const traceViewer = await showTraceViewer([traceFile]);
+  await traceViewer.selectAction('page.evaluate', 1);
+  await expect(traceViewer.callLines).toHaveText([
+    /page.evaluate/,
+    /wall time: [0-9/:,APM ]+/,
+    /duration: [\d]+ms/,
+    'expression: "() => 1 + 1"',
+    'isFunction: true',
+    'arg: null',
+    'value: 2'
   ]);
 });
 


### PR DESCRIPTION
Previously the following was crashing the trace viewer with `cannot read 'guid' of null`.

Repro:
```ts
const { chromium } = require('playwright');

(async () => {
  const browser = await chromium.launch();
  const page = await browser.newPage();
  await context.tracing.start();
  await page.evaluate("1+1", null)
  await context.tracing.stop({path: "foo.zip"})
  await browser.close();
})();
```

This was because `null` is typeof `object`.