### PR TITLE
chore: simplify screenshot option handling

### DIFF
--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -18,7 +18,7 @@ import * as mime from 'mime';
 import * as injectedScriptSource from '../generated/injectedScriptSource';
 import * as channels from '../protocol/channels';
 import { isSessionClosedError } from './protocolError';
-import { ScreenshotMaskOption } from './screenshotter';
+import { ScreenshotOptions } from './screenshotter';
 import * as frames from './frames';
 import type { InjectedScript, InjectedScriptPoll, LogEntry, HitTargetInterceptionResult } from './injected/injectedScript';
 import { CallMetadata } from './instrumentation';
@@ -27,6 +27,7 @@ import { Page } from './page';
 import { Progress, ProgressController } from './progress';
 import { SelectorInfo } from './selectors';
 import * as types from './types';
+import { TimeoutOptions } from '../common/types';
 
 type SetInputFilesFiles = channels.ElementHandleSetInputFilesParams['files'];
 type ActionName = 'click' | 'hover' | 'dblclick' | 'tap' | 'move and up' | 'move and down';
@@ -773,7 +774,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._page._delegate.getBoundingBox(this);
   }
 
-  async screenshot(metadata: CallMetadata, options: types.ElementScreenshotOptions & ScreenshotMaskOption = {}): Promise<Buffer> {
+  async screenshot(metadata: CallMetadata, options: ScreenshotOptions & TimeoutOptions = {}): Promise<Buffer> {
     const controller = new ProgressController(metadata, this);
     return controller.run(
         progress => this._page._screenshotter.screenshotElement(progress, this, options),

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -20,7 +20,7 @@ import * as frames from './frames';
 import * as input from './input';
 import * as js from './javascript';
 import * as network from './network';
-import { Screenshotter, ScreenshotMaskOption } from './screenshotter';
+import { Screenshotter, ScreenshotOptions } from './screenshotter';
 import { TimeoutSettings } from '../utils/timeoutSettings';
 import * as types from './types';
 import { BrowserContext } from './browserContext';
@@ -35,6 +35,7 @@ import { SelectorInfo, Selectors } from './selectors';
 import { CallMetadata, SdkObject } from './instrumentation';
 import { Artifact } from './artifact';
 import { ParsedSelector } from './common/selectorParser';
+import { TimeoutOptions } from '../common/types';
 
 export interface PageDelegate {
   readonly rawMouse: input.RawMouse;
@@ -424,7 +425,7 @@ export class Page extends SdkObject {
     route.continue();
   }
 
-  async screenshot(metadata: CallMetadata, options: types.ScreenshotOptions & ScreenshotMaskOption = {}): Promise<Buffer> {
+  async screenshot(metadata: CallMetadata, options: ScreenshotOptions & TimeoutOptions): Promise<Buffer> {
     const controller = new ProgressController(metadata, this);
     return controller.run(
         progress => this._screenshotter.screenshotPage(progress, options),

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Size, Point, Rect, TimeoutOptions } from '../common/types';
+import { Size, Point, TimeoutOptions } from '../common/types';
 export { Size, Point, Rect, Quad, URLMatch, TimeoutOptions } from '../common/types';
 
 export type StrictOptions = {

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -47,18 +47,6 @@ export type PointerActionWaitOptions = TimeoutOptions & ForceOptions & StrictOpt
   trial?: boolean;
 };
 
-export type ElementScreenshotOptions = TimeoutOptions & {
-  type?: 'png' | 'jpeg',
-  quality?: number,
-  omitBackground?: boolean,
-  disableAnimations?: boolean,
-};
-
-export type ScreenshotOptions = ElementScreenshotOptions & {
-  fullPage?: boolean,
-  clip?: Rect,
-};
-
 export type PageScreencastOptions = {
   width: number,
   height: number,


### PR DESCRIPTION
Use a single `ScreenshotOptions` type instead of a variety.
