### PR TITLE
chore: refactor toMatchSnapshot once again

### DIFF
--- a/packages/playwright-test/src/matchers/matchers.ts
+++ b/packages/playwright-test/src/matchers/matchers.ts
@@ -18,10 +18,10 @@ import { Locator, Page, APIResponse } from 'playwright-core';
 import { FrameExpectOptions } from 'playwright-core/lib/client/types';
 import { constructURLBasedOnBaseURL } from 'playwright-core/lib/utils/utils';
 import type { Expect } from '../types';
-import { expectType } from '../util';
+import { expectType, callLogText } from '../util';
 import { toBeTruthy } from './toBeTruthy';
 import { toEqual } from './toEqual';
-import { callLogText, toExpectedTextValues, toMatchText } from './toMatchText';
+import { toExpectedTextValues, toMatchText } from './toMatchText';
 
 interface LocatorEx extends Locator {
   _expect(expression: string, options: Omit<FrameExpectOptions, 'expectedValue'> & { expectedValue?: any }): Promise<{ matches: boolean, received?: any, log?: string[] }>;

--- a/packages/playwright-test/src/matchers/toBeTruthy.ts
+++ b/packages/playwright-test/src/matchers/toBeTruthy.ts
@@ -15,8 +15,7 @@
  */
 
 import type { Expect } from '../types';
-import { expectType } from '../util';
-import { callLogText, currentExpectTimeout } from './toMatchText';
+import { expectType, callLogText, currentExpectTimeout } from '../util';
 
 export async function toBeTruthy(
   this: ReturnType<Expect['getState']>,

--- a/packages/playwright-test/src/matchers/toEqual.ts
+++ b/packages/playwright-test/src/matchers/toEqual.ts
@@ -16,7 +16,7 @@
 
 import type { Expect } from '../types';
 import { expectType } from '../util';
-import { callLogText, currentExpectTimeout } from './toMatchText';
+import { callLogText, currentExpectTimeout } from '../util';
 
 // Omit colon and one or more spaces, so can call getLabelPrinter.
 const EXPECTED_LABEL = 'Expected';

--- a/packages/playwright-test/src/matchers/toMatchText.ts
+++ b/packages/playwright-test/src/matchers/toMatchText.ts
@@ -15,12 +15,10 @@
  */
 
 
-import colors from 'colors/safe';
 import type { ExpectedTextValue } from 'playwright-core/lib/protocol/channels';
 import { isRegExp, isString } from 'playwright-core/lib/utils/utils';
-import { currentTestInfo } from '../globals';
 import type { Expect } from '../types';
-import { expectType } from '../util';
+import { expectType, callLogText, currentExpectTimeout } from '../util';
 import {
   printReceivedStringContainExpectedResult,
   printReceivedStringContainExpectedSubstring
@@ -110,23 +108,4 @@ export function toExpectedTextValues(items: (string | RegExp)[], options: { matc
     matchSubstring: options.matchSubstring,
     normalizeWhiteSpace: options.normalizeWhiteSpace,
   }));
-}
-
-export function callLogText(log: string[] | undefined): string {
-  if (!log)
-    return '';
-  return `
-Call log:
-  ${colors.dim('- ' + (log || []).join('\n  - '))}
-`;
-}
-
-export function currentExpectTimeout(options: { timeout?: number }) {
-  const testInfo = currentTestInfo();
-  if (options.timeout !== undefined)
-    return options.timeout;
-  let defaultExpectTimeout = testInfo?.project.expect?.timeout;
-  if (typeof defaultExpectTimeout === 'undefined')
-    defaultExpectTimeout = 5000;
-  return defaultExpectTimeout;
 }

--- a/packages/playwright-test/src/util.ts
+++ b/packages/playwright-test/src/util.ts
@@ -17,11 +17,13 @@
 import util from 'util';
 import path from 'path';
 import url from 'url';
+import colors from 'colors/safe';
 import type { TestError, Location } from './types';
 import { default as minimatch } from 'minimatch';
 import debug from 'debug';
 import { calculateSha1, isRegExp } from 'playwright-core/lib/utils/utils';
 import { isInternalFileName } from 'playwright-core/lib/utils/stackTrace';
+import { currentTestInfo } from './globals';
 
 const PLAYWRIGHT_CORE_PATH = path.dirname(require.resolve('playwright-core'));
 const EXPECT_PATH = path.dirname(require.resolve('expect'));
@@ -205,3 +207,23 @@ export function getContainedPath(parentPath: string, subPath: string = ''): stri
 }
 
 export const debugTest = debug('pw:test');
+
+export function callLogText(log: string[] | undefined): string {
+  if (!log)
+    return '';
+  return `
+Call log:
+  ${colors.dim('- ' + (log || []).join('\n  - '))}
+`;
+}
+
+export function currentExpectTimeout(options: { timeout?: number }) {
+  const testInfo = currentTestInfo();
+  if (options.timeout !== undefined)
+    return options.timeout;
+  let defaultExpectTimeout = testInfo?.project.expect?.timeout;
+  if (typeof defaultExpectTimeout === 'undefined')
+    defaultExpectTimeout = 5000;
+  return defaultExpectTimeout;
+}
+

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -18,6 +18,7 @@ import type { JSONReport, JSONReportSuite } from '@playwright/test/src/reporters
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { PNG } from 'pngjs';
 import rimraf from 'rimraf';
 import { promisify } from 'util';
 import { CommonFixtures, commonFixtures } from '../config/commonFixtures';
@@ -264,4 +265,29 @@ export function countTimes(s: string, sub: string): number {
     }
   }
   return result;
+}
+
+export function createImage(width: number, height: number, r: number = 0, g: number = 0, b: number = 0): Buffer {
+  const image = new PNG({ width, height });
+  // Make both images red.
+  for (let i = 0; i < width * height; ++i) {
+    image.data[i * 4 + 0] = r;
+    image.data[i * 4 + 1] = g;
+    image.data[i * 4 + 2] = b;
+    image.data[i * 4 + 3] = 255;
+  }
+  return PNG.sync.write(image);
+}
+
+export function createWhiteImage(width: number, height: number) {
+  return createImage(width, height, 255, 255, 255);
+}
+
+export function paintBlackPixels(image: Buffer, blackPixelsCount: number): Buffer {
+  image = PNG.sync.read(image);
+  for (let i = 0; i < blackPixelsCount; ++i) {
+    for (let j = 0; j < 3; ++j)
+      image.data[i * 4 + j] = 0;
+  }
+  return PNG.sync.write(image);
 }


### PR DESCRIPTION
Keep massaging code in preparation for `toHaveScreenshot`.

References #9938
