### PR TITLE
chore(test runner): make timeout a separate error in TestInfo.errors

### DIFF
--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -21,7 +21,6 @@ import type { TestType, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWor
 import { rootTestType } from './testType';
 import { createGuid, removeFolders, debugMode } from 'playwright-core/lib/utils/utils';
 import { GridClient } from 'playwright-core/lib/grid/gridClient';
-import { prependToTestError } from './util';
 export { expect } from './expect';
 export const _baseTest: TestType<{}, {}> = rootTestType.test;
 import * as outOfProcess from 'playwright-core/lib/outofprocess';
@@ -429,7 +428,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
       const pendingCalls = anyContext ? formatPendingCalls((anyContext as any)._connection.pendingProtocolCalls()) : '';
       await Promise.all(leftoverContexts.filter(c => createdContexts.has(c)).map(c => c.close()));
       if (pendingCalls)
-        testInfo.error = prependToTestError(testInfo.error, pendingCalls);
+        testInfo.errors.push({ message: pendingCalls });
     }
   }, { auto: true }],
 
@@ -484,7 +483,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
     }));
 
     if (prependToError)
-      testInfo.error = prependToTestError(testInfo.error, prependToError);
+      testInfo.errors.push({ message: prependToError });
   },
 
   context: async ({ _contextFactory }, use) => {
@@ -511,7 +510,7 @@ function formatPendingCalls(calls: ParsedStackTrace[]) {
   return 'Pending operations:\n' + calls.map(call => {
     const frame = call.frames && call.frames[0] ? ' at ' + formatStackFrame(call.frames[0]) : '';
     return `  - ${call.apiName}${frame}\n`;
-  }).join('') + '\n';
+  }).join('');
 }
 
 function formatStackFrame(frame: StackFrame) {

--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -75,11 +75,15 @@ export type RunPayload = {
 };
 
 export type DonePayload = {
-  fatalError?: TestError;
+  fatalErrors: TestError[];
 };
 
 export type TestOutputPayload = {
   testId?: string;
   text?: string;
   buffer?: string;
+};
+
+export type TeardownErrorsPayload = {
+  fatalErrors: TestError[];
 };

--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -303,11 +303,7 @@ export function formatFailure(config: FullConfig, test: TestCase, options: {inde
 export function formatResultFailure(config: FullConfig, test: TestCase, result: TestResult, initialIndent: string, highlightCode: boolean): ErrorDetails[] {
   const errorDetails: ErrorDetails[] = [];
 
-  if (result.status === 'timedOut') {
-    errorDetails.push({
-      message: indent(colors.red(`Timeout of ${test.timeout}ms exceeded.`), initialIndent),
-    });
-  } else if (result.status === 'passed' && test.expectedStatus === 'failed') {
+  if (result.status === 'passed' && test.expectedStatus === 'failed') {
     errorDetails.push({
       message: indent(colors.red(`Expected to fail, but passed.`), initialIndent),
     });

--- a/packages/playwright-test/src/testInfo.ts
+++ b/packages/playwright-test/src/testInfo.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import colors from 'colors/safe';
 import fs from 'fs';
 import * as mime from 'mime';
 import path from 'path';
@@ -25,7 +26,7 @@ import { Loader } from './loader';
 import { ProjectImpl } from './project';
 import { TestCase } from './test';
 import { Annotations, TestStepInternal } from './types';
-import { addSuffixToFilePath, getContainedPath, monotonicTime, sanitizeForFilePath, serializeError, trimLongString } from './util';
+import { addSuffixToFilePath, formatLocation, getContainedPath, monotonicTime, sanitizeForFilePath, serializeError, trimLongString } from './util';
 
 export class TestInfoImpl implements TestInfo {
   private _projectImpl: ProjectImpl;
@@ -167,8 +168,16 @@ export class TestInfoImpl implements TestInfo {
       if (!(error instanceof TimeoutRunnerError))
         throw error;
       // Do not overwrite existing failure upon hook/teardown timeout.
-      if (this.status === 'passed')
+      if (this.status === 'passed') {
         this.status = 'timedOut';
+        if (this._test._type === 'test') {
+          this.errors.push({ message: colors.red(`Timeout of ${this.timeout}ms exceeded.`) });
+        } else {
+          // Include location for the hook to distinguish between multiple hooks.
+          const message = colors.red(`Timeout of ${this.timeout}ms exceeded in ${this._test._type} hook.`);
+          this.errors.push({ message: message, stack: message + `\n    at ${formatLocation(this._test.location)}.` });
+        }
+      }
     }
     this.duration = monotonicTime() - this._startTime;
   }

--- a/packages/playwright-test/src/util.ts
+++ b/packages/playwright-test/src/util.ts
@@ -205,24 +205,3 @@ export function getContainedPath(parentPath: string, subPath: string = ''): stri
 }
 
 export const debugTest = debug('pw:test');
-
-export function prependToTestError(testError: TestError | undefined, message: string, location?: Location): TestError {
-  if (!testError) {
-    if (!location)
-      return { value: message };
-    let stack = `    at ${location.file}:${location.line}:${location.column}`;
-    if (!message.endsWith('\n'))
-      stack = '\n' + stack;
-    return { message: message, stack: message + stack };
-  }
-  if (testError.message) {
-    const stack = testError.stack ? message + testError.stack : testError.stack;
-    message = message + testError.message;
-    return {
-      value: testError.value,
-      message,
-      stack,
-    };
-  }
-  return testError;
-}

--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -499,7 +499,7 @@ test('afterAll timeout should be reported', async ({ runInlineTest }, testInfo) 
     '%%afterAll',
   ]);
   expect(result.output).toContain('Timeout of 1000ms exceeded in afterAll hook.');
-  expect(result.output).toContain(`at ${testInfo.outputPath('a.test.js')}:6:12`);
+  expect(result.output).toContain(`at a.test.js:6:12`);
 });
 
 test('beforeAll and afterAll timeouts at the same time should be reported', async ({ runInlineTest }) => {


### PR DESCRIPTION
This way we control the timeout error message from the runner, so that later on we can differentiate between test timeout, fixture timeout and hook timeout.